### PR TITLE
fix: crun fails with 'create directory /run/crun' on overlayfs rootfs

### DIFF
--- a/crates/smolvm-agent/src/crun.rs
+++ b/crates/smolvm-agent/src/crun.rs
@@ -40,8 +40,13 @@ pub struct CrunCommand {
 
 impl CrunCommand {
     /// Create a new crun command with standard configuration.
+    ///
+    /// Uses `--root` to store container state on the persistent storage disk
+    /// instead of the default `/run/crun`, which may not be writable when the
+    /// rootfs is an overlayfs with an initramfs lower layer.
     fn new() -> Self {
         let mut cmd = Command::new(paths::CRUN_PATH);
+        cmd.args(["--root", paths::CRUN_ROOT_DIR]);
         cmd.args(["--cgroup-manager", paths::CRUN_CGROUP_MANAGER]);
         Self { cmd }
     }

--- a/crates/smolvm-agent/src/paths.rs
+++ b/crates/smolvm-agent/src/paths.rs
@@ -12,6 +12,11 @@ use std::path::PathBuf;
 /// Path to crun OCI runtime binary.
 pub const CRUN_PATH: &str = "/usr/bin/crun";
 
+/// crun state root directory.
+/// Stored on the persistent storage disk instead of `/run/crun` because
+/// `/run` may not be writable under the overlayfs rootfs.
+pub const CRUN_ROOT_DIR: &str = "/storage/containers/crun";
+
 /// crun cgroup manager setting.
 /// Set to "disabled" because libkrun mounts cgroup2 as read-only.
 /// Without this, crun create/start hang trying to create container cgroups.


### PR DESCRIPTION
## Summary

Fixes `create directory '/run/crun': No such file or directory` when running containers on Linux with the overlayfs rootfs.

**Reproduction:**
```
SMOLVM_AGENT_ROOTFS=./target/agent-rootfs/ ./target/release/smolvm sandbox run --net alpine:latest -- echo "hello"
```

**Error:**
```
Starting ephemeral sandbox...
Pulling image alpine:latest... done.
create directory `/run/crun`: No such file or directory
```

## Root Cause

crun defaults to `/run/crun` for storing container state (PID files, status JSON). After the agent's `pivot_root` to the overlayfs rootfs, `/run` comes from the initramfs lower layer and is not writable:

```
Overlayfs after pivot_root:
┌─────────────┐
│ upper layer  │  /dev/vdb (ext4) — writes go here
├─────────────┤
│ lower layer  │  initramfs (RAM, read-only)
└─────────────┘

/run/ ← visible from lower layer, but mkdir("/run/crun") fails with ENOENT
```

The essential mounts (`/proc`, `/sys`, `/dev`) are explicitly moved into the new root during `pivot_root`, but `/run` is not a mount — it's a plain directory from the initramfs, so it can't be moved. It ends up as a read-only lower-layer directory where crun can't create subdirectories.

## Fix

Redirect crun's state directory to `/storage/containers/crun` via `--root`, which lives on `/dev/vda` (persistent ext4 storage disk, guaranteed writable):

- **`crates/smolvm-agent/src/paths.rs`**: Add `CRUN_ROOT_DIR` constant pointing to `/storage/containers/crun`
- **`crates/smolvm-agent/src/crun.rs`**: Add `--root` flag to `CrunCommand::new()` so all crun invocations use the writable path

```
Before: crun --cgroup-manager disabled run --bundle ...
             └─→ mkdir("/run/crun") → ENOENT ✗

After:  crun --root /storage/containers/crun --cgroup-manager disabled run --bundle ...
             └─→ mkdir("/storage/containers/crun") → OK ✓
```

## Test plan

- [ ] `smolvm sandbox run --net alpine:latest -- echo "hello"` succeeds
- [ ] `smolvm sandbox run --net alpine:latest -- ls /` shows expected output
- [ ] Container state files appear in `/storage/containers/crun/` inside the VM
- [ ] Verify no regressions with `smolvm microvm exec` and container lifecycle commands


🤖 Generated with [Claude Code](https://claude.com/claude-code)