### PR TITLE
fix(linux): pass --root and --cgroup-manager to all crun invocations, create crun state directory

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -549,6 +549,7 @@ fn mount_storage_disk() {
             "containers/run",
             "containers/logs",
             "containers/exit",
+            "containers/crun",
         ];
         for dir in dirs {
             let _ = std::fs::create_dir_all(std::path::Path::new(STORAGE_MOUNT).join(dir));

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -523,6 +523,7 @@ pub fn init() -> Result<()> {
         (paths::CONTAINERS_RUN_DIR, "container runtime state"),
         (paths::CONTAINERS_LOGS_DIR, "container logs"),
         (paths::CONTAINERS_EXIT_DIR, "container exit codes"),
+        (paths::CRUN_ROOT_DIR, "crun state root"),
     ];
 
     for (dir, description) in &container_dirs {
@@ -576,6 +577,7 @@ pub fn format() -> Result<()> {
         (PathBuf::from(paths::CONTAINERS_RUN_DIR), "container run"),
         (PathBuf::from(paths::CONTAINERS_LOGS_DIR), "container logs"),
         (PathBuf::from(paths::CONTAINERS_EXIT_DIR), "container exit"),
+        (PathBuf::from(paths::CRUN_ROOT_DIR), "crun state root"),
     ];
 
     for (path, name) in &all_dirs {


### PR DESCRIPTION
## Summary

Fixes container create, detached sandbox (`-d`), exec, and pack on Linux.

**Root cause 1 — missing `--root`:** Direct `Command::new(CRUN_PATH)` call sites in `container.rs` were missing `--root /storage/containers/crun`. Without `--root`, crun defaults to writing state at `/run/crun`. On Linux, `/run` is read-only under the overlayfs rootfs, so crun fails. This was never caught on macOS because `/run` is writable inside the macOS VM.

**Root cause 2 — missing `--cgroup-manager disabled`:** Inside the libkrun VM, cgroup2 is mounted **read-only** (`cgroup /sys/fs/cgroup cgroup2 ro`). Without `--cgroup-manager disabled`, crun always tries to write to `/sys/fs/cgroup/cgroup.subtree_control` to enable controllers — even when no resource limits are in the OCI spec — causing the operation to fail with `Read-only file system`.

**Secondary fix:** The crun state directory (`/storage/containers/crun`) was defined in `paths.rs` but never actually created during storage initialization.

## Changes

- Refactor all raw `Command::new(CRUN_PATH)` invocations in `container.rs` to use `CrunCommand`, which centralizes `--root` and `--cgroup-manager`
- Add `CrunCommand::create()` with null stdio baked in (pipes block when child processes inherit fds)
- Extend `CrunCommand::exec()` with `workdir` and `tty` support so no call site needs to bypass the builder
- Make `ensure_path_in_env` private (only used internally by `CrunCommand`)
- Add `containers/crun` to directory creation in `mount_storage_disk()`, `init()`, and `format()`