### PR TITLE
fix: build-dist.sh failure due to missing /dist/smolvm

### DIFF
--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -79,7 +79,7 @@ mkdir -p "$DIST_DIR/lib"
 cp ./target/release/smolvm "$DIST_DIR/smolvm-bin"
 
 # Copy wrapper script
-cp ./dist/smolvm "$DIST_DIR/smolvm"
+cp ./scripts/smolvm-wrapper.sh "$DIST_DIR/smolvm"
 chmod +x "$DIST_DIR/smolvm"
 
 # Copy libraries

--- a/scripts/smolvm-wrapper.sh
+++ b/scripts/smolvm-wrapper.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# smolvm - OCI-native microVM runtime
+# This wrapper sets up the library path and runs the smolvm binary.
+
+set -e
+
+# Resolve symlinks to get the actual script location
+resolve_symlink() {
+    local target="$1"
+    while [[ -L "$target" ]]; do
+        local link_dir
+        link_dir="$(cd "$(dirname "$target")" && pwd)"
+        target="$(readlink "$target")"
+        # Handle relative symlinks
+        if [[ "$target" != /* ]]; then
+            target="$link_dir/$target"
+        fi
+    done
+    echo "$target"
+}
+
+# Get the directory where the actual script lives (resolving symlinks)
+SCRIPT_PATH="$(resolve_symlink "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+
+# The actual binary and libraries are in the same directory
+SMOLVM_BIN="$SCRIPT_DIR/smolvm-bin"
+SMOLVM_LIB="$SCRIPT_DIR/lib"
+
+# Check if binary exists
+if [[ ! -x "$SMOLVM_BIN" ]]; then
+    echo "Error: smolvm binary not found at $SMOLVM_BIN" >&2
+    echo "Make sure you extracted the full distribution." >&2
+    exit 1
+fi
+
+# Check if libraries exist
+if [[ ! -d "$SMOLVM_LIB" ]]; then
+    echo "Error: library directory not found at $SMOLVM_LIB" >&2
+    echo "Make sure you extracted the full distribution." >&2
+    exit 1
+fi
+
+# Set library path based on OS and run
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    export DYLD_LIBRARY_PATH="$SMOLVM_LIB${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+else
+    export LD_LIBRARY_PATH="$SMOLVM_LIB${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+exec "$SMOLVM_BIN" "$@"


### PR DESCRIPTION
**Issue**

`./scripts/build-dist.sh` seems to assume the existing the `smolvm` file under `/dist`. This file is not tracked and in the downloaded package: https://github.com/smol-machines/smolvm/releases/download/v0.1.16/smolvm-0.1.16-darwin-arm64.tar.gz, I saw this `smolvm` is actually a wrapper script to help find the dynamic lib. 

Looking at `build.rs` [here](https://github.com/smol-machines/smolvm/blob/main/build.rs#L112-L126), I feel we may not always need this wrapper, especially after inspecting the built `smolvm-bin` binary on my linux machine. 


```
 readelf -d /home/qiaofu/workspace/smolvm-project/src/smolvm/dist/smolvm-0.1.15-linux-x86_64/smolvm-bin

Dynamic section at offset 0x1256b38 contains 31 entries:
  Tag        Type                         Name/Value
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN/lib:$ORIGIN/../lib]
 0x0000000000000001 (NEEDED)             Shared library: [libkrun.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
...
```

However, since this wrapper script hardens the robustness of the installation flow, i move it to a separate `smolvm-wrapper.sh` file and copy that into the distributed tar ball.


**Test**

* ` ./scripts/build-dist.sh `

```
Building smolvm distribution: smolvm-0.1.15-linux-x86_64
Building release binaries...
    Finished `release` profile [optimized] target(s) in 0.11s
Building smolvm-agent for Linux (optimized for size)...
OK: 198.1 MiB in 30 packages
info: syncing channel updates for 'stable-x86_64-unknown-linux-musl'
info: latest update on 2026-02-12, rust version 1.93.1 (01f6ddf75 2026-02-11)
info: downloading component 'cargo'
info: downloading component 'clippy'
info: downloading component 'rust-std'
info: downloading component 'rustc'
info: downloading component 'rustfmt'
info: installing component 'cargo'
info: installing component 'clippy'
info: installing component 'rust-std'
info: installing component 'rustc'
info: installing component 'rustfmt'
    Updating crates.io index
 Downloading crates ...
  Downloaded nu-ansi-term v0.50.3
  Downloaded fastrand v2.3.0
  Downloaded memoffset v0.9.1
  Downloaded lazy_static v1.5.0
  Downloaded errno v0.3.14
  Downloaded itoa v1.0.17
  Downloaded scopeguard v1.2.0
  Downloaded cfg-if v1.0.4
  Downloaded matchers v0.2.0
  Downloaded autocfg v1.5.0
  Downloaded quote v1.0.44
  Downloaded zmij v1.0.21
  Downloaded pin-project-lite v0.2.16
  Downloaded tracing-log v0.2.0
  Downloaded getrandom v0.4.1
  Downloaded sharded-slab v0.1.7
  Downloaded unicode-ident v1.0.24
  Downloaded tracing-core v0.1.36
  Downloaded base64 v0.22.1
  Downloaded memchr v2.8.0
  Downloaded serde v1.0.228
  Downloaded proc-macro2 v1.0.106
  Downloaded serde_derive v1.0.228
  Downloaded aho-corasick v1.1.4
  Downloaded serde_core v1.0.228
  Downloaded log v0.4.29
  Downloaded parking_lot v0.12.5
  Downloaded tracing-attributes v0.1.31
  Downloaded thread_local v1.1.9
  Downloaded tempfile v3.25.0
  Downloaded smallvec v1.15.1
  Downloaded parking_lot_core v0.9.12
  Downloaded once_cell v1.21.3
  Downloaded bitflags v2.11.0
  Downloaded serde_json v1.0.149
  Downloaded lock_api v0.4.14
  Downloaded tracing-subscriber v0.3.22
  Downloaded nix v0.27.1
  Downloaded syn v2.0.117
  Downloaded regex-syntax v0.8.9
  Downloaded rustix v1.1.3
  Downloaded tracing v0.1.44
  Downloaded regex-automata v0.4.14
  Downloaded libc v0.2.182
  Downloaded linux-raw-sys v0.11.0
    Finished `release-small` profile [optimized] target(s) in 1.77s
Creating distribution package...
Warning: init.krun not found - users may need to build libkrun init
Building agent-rootfs...
Agent rootfs size: 28M
Creating storage template...
Storage template created: 17M (sparse)
Overlay template created: 17M (sparse)
Generating checksums...
Creating tarball...

Distribution package created:
  dist/smolvm-0.1.15-linux-x86_64.tar.gz

Contents:
total 52368
drwxr-xr-x  4 qiaofu qiaofu      4096 Feb 24 22:42 .
drwxr-xr-x  3 qiaofu qiaofu      4096 Feb 24 22:42 ..
drwxr-xr-x 20 qiaofu qiaofu      4096 Feb 24 22:42 agent-rootfs
-rw-r--r--  1 qiaofu qiaofu       571 Feb 24 22:42 checksums.txt
drwxr-xr-x  2 qiaofu qiaofu      4096 Feb 24 22:42 lib
-rw-r--r--  1 qiaofu qiaofu 536870912 Feb 24 22:42 overlay-template.ext4
-rw-r--r--  1 qiaofu qiaofu      1445 Feb 24 22:42 README.txt
-rwxr-xr-x  1 qiaofu qiaofu      1506 Feb 24 22:42 smolvm
-rwxr-xr-x  1 qiaofu qiaofu  19243192 Feb 24 22:42 smolvm-bin
-rw-r--r--  1 qiaofu qiaofu 536870912 Feb 24 22:42 storage-template.ext4

To test locally:
  cd dist/smolvm-0.1.15-linux-x86_64 && ./smolvm --help

To install locally:
  ./scripts/install-local.sh

```

* `./scripts/install-local.sh `

```
qiaofu@ubuntu-node:~/workspace/smolvm-project/src/smolvm$ 

smolvm local installer

info: Found tarball: dist/smolvm-0.1.15-linux-x86_64.tar.gz
info: Extracting dist/smolvm-0.1.15-linux-x86_64.tar.gz...
info: Installing smolvm 0.1.15 to /home/qiaofu/.smolvm
info: Installing agent-rootfs to /home/qiaofu/.local/share/smolvm...
success: Agent rootfs installed
success: Installed smolvm to /home/qiaofu/.smolvm
success: Symlink created at /home/qiaofu/.local/bin/smolvm

Test your installation:
    smolvm --help

```

* `smolvm --help`

```
qiaofu@ubuntu-node:~/workspace/smolvm-project/src/smolvm$ 
smolvm is an OCI-native microVM runtime for macOS and Linux.

It runs container images inside lightweight VMs using libkrun, providing VM-level isolation with container-like UX.

Quick start:
  smolvm sandbox run alpine -- echo hello
  smolvm sandbox run -d nginx -p 8080:80

For programmatic access:
  smolvm serve

Usage: smolvm-bin <COMMAND>

Commands:
  sandbox    Run containers quickly (ephemeral or detached) [aliases: sb]
  microvm    Manage persistent microVMs [aliases: vm]
  container  Manage containers inside a microVM [aliases: ct]
  serve      Start the HTTP API server for programmatic control
  pack       Package an OCI image into a self-contained executable
  config     Manage smolvm configuration (registries, defaults)
  openapi    Export OpenAPI specification for SDK generation
  runpack    Run a VM from a packed .smolmachine sidecar file
  help       Print this message or the help of the given subcommand(s)

Options:
  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version
```