### PR TITLE
fix(linux): write pack layer tar to storage disk instead of /tmp

### DIFF
--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -1111,8 +1111,11 @@ pub fn export_layer(image_digest: &str, layer_index: usize) -> Result<PathBuf> {
         )));
     }
 
-    // Create tar archive in /tmp
-    let tar_path = PathBuf::from(format!("/tmp/layer-{}.tar", &layer_id[..12]));
+    // Create tar archive on the storage disk (/tmp is on virtiofs which is
+    // read-only on Linux — ENOTSUP)
+    let tmp_dir = root.join("tmp");
+    std::fs::create_dir_all(&tmp_dir)?;
+    let tar_path = tmp_dir.join(format!("layer-{}.tar", &layer_id[..12]));
 
     info!(
         layer_id = %layer_id,


### PR DESCRIPTION
## Summary

- On Linux, the agent's rootfs is served via virtiofs which does not support writes (returns ENOTSUP). The `export_layer()` function was writing its tar archive to `/tmp` on this rootfs, causing pack to fail with "failed to create tar archive for layer".
- Fix: write the tar to `/storage/tmp/` instead, which is on the ext4 storage disk and always writable. This is consistent with how the rest of storage.rs uses `STORAGE_ROOT` for all writable data.