### PR TITLE
feat: add flag to build with local libkrun changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,16 @@ smolvm microvm exec --name codex-sandbox -it -- codex
 # build
 ./scripts/build-dist.sh
 
+# build using local libkrun changes from ../libkrun
+./scripts/build-dist.sh --with-local-libkrun
+
+# local lib bundle staging path used by --with-local-libkrun
+# (libkrun artifacts are copied here and used for linking/packaging)
+# target/local-lib-bundle/libkrun.dylib
+# target/local-lib-bundle/libkrun.1.dylib
+# target/local-lib-bundle/libkrunfw.5.dylib
+# Note: tracked files under ./lib/ are not modified by this mode.
+
 # run tests
 ./tests/run_all.sh
 ```

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -1,11 +1,63 @@
 #!/bin/bash
 # Build a distributable smolvm package
 #
-# Usage: ./scripts/build-dist.sh
+# Usage:
+#   ./scripts/build-dist.sh
+#   ./scripts/build-dist.sh --with-local-libkrun
 #
 # Output: dist/smolvm-<version>-<platform>.tar.gz
 
 set -e
+
+# Options
+WITH_LOCAL_LIBKRUN=0
+LOCAL_LIBKRUN_DIR=""
+LIBKRUN_MAKE_FLAGS="${LIBKRUN_MAKE_FLAGS:-BLK=1}"
+
+print_help() {
+    cat <<'EOF'
+Build a distributable smolvm package.
+
+Usage:
+  ./scripts/build-dist.sh [options]
+
+Options:
+  --with-local-libkrun       Build libkrun from local checkout and refresh bundled lib/
+  --local-libkrun-dir PATH   Local libkrun checkout (default: ../libkrun)
+  -h, --help                 Show this help text
+
+Environment:
+  LIBKRUN_MAKE_FLAGS   make flags for local libkrun build (default: BLK=1)
+  LIBCLANG_PATH        path to libclang.dylib (auto-detected from brew llvm on macOS)
+  LIB_DIR              Override bundled library directory used by smolvm build
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --with-local-libkrun)
+            WITH_LOCAL_LIBKRUN=1
+            shift
+            ;;
+        --local-libkrun-dir)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --local-libkrun-dir requires a path"
+                exit 1
+            fi
+            LOCAL_LIBKRUN_DIR="$2"
+            shift 2
+            ;;
+        -h|--help)
+            print_help
+            exit 0
+            ;;
+        *)
+            echo "Error: unknown option: $1"
+            print_help
+            exit 1
+            ;;
+    esac
+done
 
 # Configuration
 VERSION="${VERSION:-$(grep '^version' Cargo.toml | head -1 | cut -d'"' -f2)}"
@@ -14,21 +66,149 @@ DIST_NAME="smolvm-${VERSION}-${PLATFORM}"
 DIST_DIR="dist/${DIST_NAME}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+WORKSPACE_SRC_ROOT="$(cd "$PROJECT_ROOT/.." && pwd)"
+LOCAL_STAGE_DIR="$PROJECT_ROOT/target/local-lib-stage"
+LOCAL_INIT_KRUN=""
+
+if [[ -z "$LOCAL_LIBKRUN_DIR" ]]; then
+    LOCAL_LIBKRUN_DIR="$WORKSPACE_SRC_ROOT/libkrun"
+fi
 
 echo "Building smolvm distribution: ${DIST_NAME}"
 
-# Check for required libraries
-# On Linux, look in lib/linux-{arch}/ first
+# Resolve bundled library directory
 if [[ "$(uname -s)" == "Linux" ]]; then
     ARCH="$(uname -m)"
-    LIB_DIR="${LIB_DIR:-./lib/linux-${ARCH}}"
+    DEFAULT_LIB_DIR="./lib/linux-${ARCH}"
+    STAGED_LIB_DIR="$LOCAL_STAGE_DIR/usr/local/lib64"
 else
-    LIB_DIR="${LIB_DIR:-./lib}"
+    DEFAULT_LIB_DIR="./lib"
+    STAGED_LIB_DIR="$LOCAL_STAGE_DIR/usr/local/lib"
 fi
 
-if [[ ! -f "$LIB_DIR/libkrun.dylib" ]] && [[ ! -f "$LIB_DIR/libkrun.so" ]]; then
-    echo "Error: libkrun not found in $LIB_DIR"
+BASE_LIB_DIR="${LIB_DIR:-$DEFAULT_LIB_DIR}"
+WORK_LIB_DIR="$BASE_LIB_DIR"
+LOCAL_BUNDLE_DIR="$PROJECT_ROOT/target/local-lib-bundle"
+
+run_make() {
+    local repo="$1"
+    local flags="$2"
+    shift 2
+    local -a args=()
+    if [[ -n "$flags" ]]; then
+        read -r -a args <<< "$flags"
+    fi
+    make -C "$repo" "${args[@]}" "$@"
+}
+
+copy_matching_libraries() {
+    local src_dir="$1"
+    local pattern="$2"
+    local dst_dir="$3"
+
+    if compgen -G "$src_dir/$pattern" > /dev/null; then
+        cp -a "$src_dir"/$pattern "$dst_dir"/
+    fi
+}
+
+setup_macos_libkrun_env() {
+    if [[ "$(uname -s)" != "Darwin" ]]; then
+        return
+    fi
+    if [[ ! -f "$LOCAL_LIBKRUN_DIR/Makefile" ]]; then
+        return
+    fi
+
+    # libkrun build scripts use bindgen and require libclang.dylib at runtime.
+    if [[ -z "${LIBCLANG_PATH:-}" ]] && command -v brew &> /dev/null; then
+        local llvm_prefix
+        llvm_prefix="$(brew --prefix llvm 2>/dev/null || true)"
+        if [[ -n "$llvm_prefix" ]] && [[ -f "$llvm_prefix/lib/libclang.dylib" ]]; then
+            export LIBCLANG_PATH="$llvm_prefix/lib"
+            echo "Using libclang from $LIBCLANG_PATH"
+        fi
+    fi
+
+    if [[ -n "${LIBCLANG_PATH:-}" ]]; then
+        export DYLD_FALLBACK_LIBRARY_PATH="$LIBCLANG_PATH:${DYLD_FALLBACK_LIBRARY_PATH:-}"
+    else
+        echo "Warning: LIBCLANG_PATH is not set."
+        echo "         If libkrun build fails with 'Library not loaded: @rpath/libclang.dylib',"
+        echo "         install llvm via brew and set LIBCLANG_PATH to its lib directory."
+    fi
+
+    if [[ "$LIBKRUN_MAKE_FLAGS" == *"BUILD_INIT=0"* ]] && [[ ! -f "$LOCAL_LIBKRUN_DIR/init/init" ]]; then
+        echo "Error: LIBKRUN_MAKE_FLAGS includes BUILD_INIT=0 but init binary is missing:"
+        echo "       $LOCAL_LIBKRUN_DIR/init/init"
+        echo "Build init first (for example: make -C \"$LOCAL_LIBKRUN_DIR\" BLK=1),"
+        echo "or remove BUILD_INIT=0 from LIBKRUN_MAKE_FLAGS."
+        exit 1
+    fi
+}
+
+refresh_bundled_libs_from_local() {
+    local repo="$1"
+    local flags="$2"
+    local prefix="$3"
+
+    if [[ ! -f "$repo/Makefile" ]]; then
+        echo "Error: local repo not found: $repo"
+        exit 1
+    fi
+
+    mkdir -p "$WORK_LIB_DIR"
+    rm -rf "$LOCAL_STAGE_DIR"
+    mkdir -p "$LOCAL_STAGE_DIR"
+
+    run_make "$repo" "$flags"
+    run_make "$repo" "$flags" install "DESTDIR=$LOCAL_STAGE_DIR" "PREFIX=/usr/local"
+
+    if [[ ! -d "$STAGED_LIB_DIR" ]]; then
+        echo "Error: no staged libraries found in $STAGED_LIB_DIR"
+        exit 1
+    fi
+
+    if ! compgen -G "$STAGED_LIB_DIR/${prefix}*" > /dev/null; then
+        echo "Error: no staged ${prefix} artifacts found in $STAGED_LIB_DIR"
+        exit 1
+    fi
+
+    cp -a "$STAGED_LIB_DIR"/${prefix}* "$WORK_LIB_DIR"/
+}
+
+if [[ "$WITH_LOCAL_LIBKRUN" == "1" ]]; then
+    if [[ ! -d "$BASE_LIB_DIR" ]]; then
+        echo "Error: base library directory does not exist: $BASE_LIB_DIR"
+        echo "Set LIB_DIR to a directory containing libkrun/libkrunfw artifacts."
+        exit 1
+    fi
+
+    rm -rf "$LOCAL_BUNDLE_DIR"
+    mkdir -p "$LOCAL_BUNDLE_DIR"
+    copy_matching_libraries "$BASE_LIB_DIR" "libkrun*" "$LOCAL_BUNDLE_DIR"
+    copy_matching_libraries "$BASE_LIB_DIR" "libkrunfw*" "$LOCAL_BUNDLE_DIR"
+    WORK_LIB_DIR="$LOCAL_BUNDLE_DIR"
+    echo "Staging local build bundle in $WORK_LIB_DIR"
+fi
+
+if [[ "$WITH_LOCAL_LIBKRUN" == "1" ]]; then
+    echo "Building local libkrun from $LOCAL_LIBKRUN_DIR..."
+    setup_macos_libkrun_env
+    refresh_bundled_libs_from_local "$LOCAL_LIBKRUN_DIR" "$LIBKRUN_MAKE_FLAGS" "libkrun"
+    if [[ -f "$LOCAL_LIBKRUN_DIR/init/init" ]]; then
+        LOCAL_INIT_KRUN="$LOCAL_LIBKRUN_DIR/init/init"
+    fi
+fi
+
+# Check for required libraries
+if [[ ! -f "$WORK_LIB_DIR/libkrun.dylib" ]] && [[ ! -f "$WORK_LIB_DIR/libkrun.so" ]]; then
+    echo "Error: libkrun not found in $WORK_LIB_DIR"
     echo "Set LIB_DIR to point to your libkrun library directory."
+    exit 1
+fi
+if [[ ! -f "$WORK_LIB_DIR/libkrunfw.5.dylib" ]] && [[ ! -f "$WORK_LIB_DIR/libkrunfw.so" ]]; then
+    echo "Error: libkrunfw not found in $WORK_LIB_DIR"
+    echo "Set LIB_DIR to point to your libkrunfw library directory."
     exit 1
 fi
 
@@ -40,7 +220,7 @@ fi
 
 # Build release binaries
 echo "Building release binaries..."
-LIBKRUN_BUNDLE="$LIB_DIR" cargo build --release --bin smolvm
+LIBKRUN_BUNDLE="$WORK_LIB_DIR" cargo build --release --bin smolvm
 
 # Build smolvm-agent for Linux (size-optimized)
 echo "Building smolvm-agent for Linux (optimized for size)..."
@@ -84,25 +264,25 @@ chmod +x "$DIST_DIR/smolvm"
 
 # Copy libraries
 if [[ "$(uname -s)" == "Darwin" ]]; then
-    cp "$LIB_DIR/libkrun.dylib" "$DIST_DIR/lib/"
-    cp "$LIB_DIR/libkrunfw.5.dylib" "$DIST_DIR/lib/"
+    cp "$WORK_LIB_DIR/libkrun.dylib" "$DIST_DIR/lib/"
+    cp "$WORK_LIB_DIR/libkrunfw.5.dylib" "$DIST_DIR/lib/"
     # Create symlink for compatibility
     ln -sf libkrunfw.5.dylib "$DIST_DIR/lib/libkrunfw.dylib"
 else
     # Copy libraries preserving symlinks with -a, or copy files individually
-    if [[ -L "$LIB_DIR/libkrun.so" ]]; then
-        cp -a "$LIB_DIR"/libkrun.so* "$DIST_DIR/lib/" 2>/dev/null || \
-            cp "$LIB_DIR"/libkrun.so* "$DIST_DIR/lib/"
+    if [[ -L "$WORK_LIB_DIR/libkrun.so" ]]; then
+        cp -a "$WORK_LIB_DIR"/libkrun.so* "$DIST_DIR/lib/" 2>/dev/null || \
+            cp "$WORK_LIB_DIR"/libkrun.so* "$DIST_DIR/lib/"
     else
-        cp "$LIB_DIR/libkrun.so" "$DIST_DIR/lib/"
+        cp "$WORK_LIB_DIR/libkrun.so" "$DIST_DIR/lib/"
         # Create versioned symlink
         ln -sf libkrun.so "$DIST_DIR/lib/libkrun.so.1"
     fi
-    if [[ -L "$LIB_DIR/libkrunfw.so" ]]; then
-        cp -a "$LIB_DIR"/libkrunfw.so* "$DIST_DIR/lib/" 2>/dev/null || \
-            cp "$LIB_DIR"/libkrunfw.so* "$DIST_DIR/lib/"
+    if [[ -L "$WORK_LIB_DIR/libkrunfw.so" ]]; then
+        cp -a "$WORK_LIB_DIR"/libkrunfw.so* "$DIST_DIR/lib/" 2>/dev/null || \
+            cp "$WORK_LIB_DIR"/libkrunfw.so* "$DIST_DIR/lib/"
     else
-        cp "$LIB_DIR/libkrunfw.so"* "$DIST_DIR/lib/"
+        cp "$WORK_LIB_DIR/libkrunfw.so"* "$DIST_DIR/lib/"
     fi
 fi
 
@@ -110,7 +290,9 @@ fi
 if [[ "$(uname -s)" == "Linux" ]]; then
     # Look for init.krun in libkrun submodule or system locations
     INIT_KRUN=""
-    if [[ -f "$PROJECT_ROOT/libkrun/init/init" ]]; then
+    if [[ -n "$LOCAL_INIT_KRUN" ]] && [[ -f "$LOCAL_INIT_KRUN" ]]; then
+        INIT_KRUN="$LOCAL_INIT_KRUN"
+    elif [[ -f "$PROJECT_ROOT/libkrun/init/init" ]]; then
         INIT_KRUN="$PROJECT_ROOT/libkrun/init/init"
     elif [[ -f "/usr/local/share/smolvm/init.krun" ]]; then
         INIT_KRUN="/usr/local/share/smolvm/init.krun"


### PR DESCRIPTION
**Tests:**

`./scripts/build-dist.sh --with-local-libkrun`

```                 
Building smolvm distribution: smolvm-0.1.17-darwin-arm64
Staging local build bundle in /Users/qiaofu/workspace/smolvm-project/src/smolvm/target/local-lib-bundle
Building local libkrun from /Users/qiaofu/workspace/smolvm-project/src/libkrun...
Using libclang from /opt/homebrew/opt/llvm/lib
cargo build --release --features blk
    Finished `release` profile [optimized] target(s) in 0.09s
mv target/release/libkrun.dylib target/release/libkrun.dylib
cp target/release/libkrun.dylib target/release/libkrun.1.17.3.dylib
rm -f libkrun.pc libkrun.pc-t
sed -e 's|@prefix@|/usr/local|' \
	    -e 's|@libdir@|/usr/local/lib|' \
	    -e 's|@includedir@|/usr/local/include|' \
	    -e 's|@PACKAGE_NAME@|libkrun|' \
	    -e 's|@PACKAGE_VERSION@|1.17.3|' \
	    libkrun.pc.in > libkrun.pc-t
mv libkrun.pc-t libkrun.pc
rm -f libkrun.pc libkrun.pc-t
sed -e 's|@prefix@|/usr/local|' \
	    -e 's|@libdir@|/usr/local/lib|' \
	    -e 's|@includedir@|/usr/local/include|' \
	    -e 's|@PACKAGE_NAME@|libkrun|' \
	    -e 's|@PACKAGE_VERSION@|1.17.3|' \
	    libkrun.pc.in > libkrun.pc-t
mv libkrun.pc-t libkrun.pc
install -d /Users/qiaofu/workspace/smolvm-project/src/smolvm/target/local-lib-stage/usr/local/lib/
install -d /Users/qiaofu/workspace/smolvm-project/src/smolvm/target/local-lib-stage/usr/local/lib/pkgconfig
install -d /Users/qiaofu/workspace/smolvm-project/src/smolvm/target/local-lib-stage/usr/local/include
install -m 644 include/libkrun.h /Users/qiaofu/workspace/smolvm-project/src/smolvm/target/local-lib-stage/usr/local/include
install -m 644 include/libkrun_display.h /Users/qiaofu/workspace/smolvm-project/src/smolvm/target/local-lib-stage/usr/local/include
install -m 644 include/libkrun_input.h /Users/qiaofu/workspace/smolvm-project/src/smolvm/target/local-lib-stage/usr/local/include
install -m 644 libkrun.pc /Users/qiaofu/workspace/smolvm-project/src/smolvm/target/local-lib-stage/usr/local/lib/pkgconfig
install -m 755 target/release/libkrun.1.17.3.dylib /Users/qiaofu/workspace/smolvm-project/src/smolvm/target/local-lib-stage/usr/local/lib/
cd /Users/qiaofu/workspace/smolvm-project/src/smolvm/target/local-lib-stage/usr/local/lib/ ; ln -sf libkrun.1.17.3.dylib libkrun.1.dylib ; ln -sf libkrun.1.dylib libkrun.dylib
Building release binaries...
    Finished `release` profile [optimized] target(s) in 0.15s
Building smolvm-agent for Linux (optimized for size)...
OK: 174.4 MiB in 30 packages
info: syncing channel updates for 'stable-aarch64-unknown-linux-musl'
info: latest update on 2026-02-12, rust version 1.93.1 (01f6ddf75 2026-02-11)
info: downloading component 'cargo'
info: downloading component 'clippy'
info: downloading component 'rust-std'
info: downloading component 'rustc'
info: downloading component 'rustfmt'
info: installing component 'cargo'
info: installing component 'clippy'
info: installing component 'rust-std'
info: installing component 'rustc'
info: installing component 'rustfmt'
    Updating crates.io index
 Downloading crates ...
  Downloaded cfg-if v1.0.4
  Downloaded lazy_static v1.5.0
  Downloaded itoa v1.0.17
  Downloaded errno v0.3.14
  Downloaded memoffset v0.9.1
  Downloaded fastrand v2.3.0
  Downloaded matchers v0.2.0
  Downloaded autocfg v1.5.0
  Downloaded scopeguard v1.2.0
  Downloaded quote v1.0.44
  Downloaded nu-ansi-term v0.50.3
  Downloaded zmij v1.0.21
  Downloaded tracing-log v0.2.0
  Downloaded thread_local v1.1.9
  Downloaded smallvec v1.15.1
  Downloaded once_cell v1.21.3
  Downloaded bitflags v2.11.0
  Downloaded parking_lot_core v0.9.12
  Downloaded pin-project-lite v0.2.16
  Downloaded tracing-attributes v0.1.31
  Downloaded unicode-ident v1.0.24
  Downloaded tracing-core v0.1.36
  Downloaded serde_derive v1.0.228
  Downloaded memchr v2.8.0
  Downloaded base64 v0.22.1
  Downloaded aho-corasick v1.1.4
  Downloaded serde_core v1.0.228
  Downloaded serde v1.0.228
  Downloaded proc-macro2 v1.0.106
  Downloaded sharded-slab v0.1.7
  Downloaded log v0.4.29
  Downloaded serde_json v1.0.149
  Downloaded getrandom v0.4.1
  Downloaded tempfile v3.26.0
  Downloaded parking_lot v0.12.5
  Downloaded lock_api v0.4.14
  Downloaded tracing-subscriber v0.3.22
  Downloaded nix v0.27.1
  Downloaded syn v2.0.117
  Downloaded regex-syntax v0.8.10
  Downloaded rustix v1.1.4
  Downloaded tracing v0.1.44
  Downloaded regex-automata v0.4.14
  Downloaded libc v0.2.182
  Downloaded linux-raw-sys v0.12.1
    Finished `release-small` profile [optimized] target(s) in 1.19s
Signing binary...
./target/release/smolvm: replacing existing signature
Creating distribution package...
Building agent-rootfs...
Agent rootfs size:  34M
Creating storage template...
Storage template created:  25M (sparse)
Overlay template created:  25M (sparse)
Generating checksums...
Creating tarball...

Distribution package created:
  dist/smolvm-0.1.17-darwin-arm64.tar.gz

Contents:
total 135352
drwxr-xr-x@ 10 qiaofu  staff        320 Mar  2 23:25 .
drwxr-xr-x   6 qiaofu  staff        192 Mar  2 23:25 ..
drwxr-xr-x@ 20 qiaofu  staff        640 Mar  2 23:25 agent-rootfs
-rw-r--r--@  1 qiaofu  staff        408 Mar  2 23:25 checksums.txt
drwxr-xr-x@  5 qiaofu  staff        160 Mar  2 23:25 lib
-rw-r--r--@  1 qiaofu  staff  536870912 Mar  2 23:25 overlay-template.ext4
-rw-r--r--@  1 qiaofu  staff       1445 Mar  2 23:25 README.txt
-rwxr-xr-x@  1 qiaofu  staff       1506 Mar  2 23:25 smolvm
-rwxr-xr-x@  1 qiaofu  staff   17840688 Mar  2 23:25 smolvm-bin
-rw-r--r--@  1 qiaofu  staff  536870912 Mar  2 23:25 storage-template.ext4

To test locally:
  cd dist/smolvm-0.1.17-darwin-arm64 && ./smolvm --help

To install locally:
  ./scripts/install-local.sh
```