### PR TITLE
feat: add NAPI-RS bindings for native Node.js embedding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "crates/smolvm-agent", "crates/smolvm-protocol", "crates/smolvm-pack"]
+members = [".", "crates/smolvm-agent", "crates/smolvm-protocol", "crates/smolvm-pack", "crates/smolvm-napi"]
 resolver = "2"
 
 [package]

--- a/crates/smolvm-napi/Cargo.toml
+++ b/crates/smolvm-napi/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "smolvm-napi"
+version = "0.1.0"
+edition = "2021"
+description = "NAPI-RS bindings for smolvm — embed microVMs directly in Node.js"
+license = "Apache-2.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+smolvm = { path = "../.." }
+smolvm-protocol = { path = "../smolvm-protocol" }
+napi = { version = "2", features = ["async", "napi6", "tokio_rt"] }
+napi-derive = "2"
+tokio = { version = "1", features = ["rt", "sync"] }
+
+[build-dependencies]
+napi-build = "2"
+pkg-config = "0.3"

--- a/crates/smolvm-napi/build.rs
+++ b/crates/smolvm-napi/build.rs
@@ -1,0 +1,180 @@
+//! Build script for smolvm-napi.
+//!
+//! Calls napi_build::setup() for NAPI-RS and replicates the libkrun
+//! discovery logic from smolvm's build.rs so the .node binary can
+//! dynamically link libkrun at load time.
+
+#[cfg(target_os = "linux")]
+use std::path::Path;
+use std::process::Command;
+
+#[cfg(target_os = "linux")]
+fn is_lfs_pointer(path: &Path) -> bool {
+    if let Ok(metadata) = std::fs::metadata(path) {
+        if metadata.len() > 500 {
+            return false;
+        }
+    }
+    if let Ok(content) = std::fs::read_to_string(path) {
+        return content.starts_with("version https://git-lfs.github.com/spec/v1");
+    }
+    false
+}
+
+fn link_krun() {
+    #[cfg(target_os = "macos")]
+    println!("cargo:rustc-link-arg=-Wl,-weak-lkrun");
+    #[cfg(not(target_os = "macos"))]
+    println!("cargo:rustc-link-lib=krun");
+}
+
+fn main() {
+    napi_build::setup();
+
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    link_libkrun();
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn link_libkrun() {
+    println!("cargo:rerun-if-env-changed=LIBKRUN_STATIC");
+    println!("cargo:rerun-if-env-changed=LIBKRUN_BUNDLE");
+    println!("cargo:rerun-if-env-changed=LIBKRUN_DIR");
+
+    // Option 1: Bundle libraries with the binary
+    if let Ok(bundle_path) = std::env::var("LIBKRUN_BUNDLE") {
+        println!("cargo:rustc-link-search=native={}", bundle_path);
+        link_krun();
+
+        #[cfg(target_os = "macos")]
+        {
+            println!("cargo:rustc-link-arg=-Wl,-rpath,@loader_path");
+            println!("cargo:rustc-link-arg=-Wl,-rpath,@loader_path/lib");
+            println!("cargo:rustc-link-arg=-Wl,-rpath,@loader_path/../lib");
+
+            let lib_path = std::path::Path::new(&bundle_path).join("libkrun.dylib");
+            if lib_path.exists() {
+                let _ = Command::new("install_name_tool")
+                    .args(["-id", "@rpath/libkrun.dylib", lib_path.to_str().unwrap()])
+                    .status();
+                let _ = Command::new("codesign")
+                    .args(["--force", "--sign", "-", lib_path.to_str().unwrap()])
+                    .status();
+            }
+        }
+        #[cfg(target_os = "linux")]
+        {
+            println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN");
+            println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN/lib");
+            println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN/../lib");
+        }
+        return;
+    }
+
+    // Option 2: Static linking
+    if let Ok(static_path) = std::env::var("LIBKRUN_STATIC") {
+        let path = std::path::Path::new(&static_path);
+        if path.is_dir() {
+            println!("cargo:rustc-link-search=native={}", static_path);
+        } else if path.is_file() {
+            if let Some(dir) = path.parent() {
+                println!("cargo:rustc-link-search=native={}", dir.display());
+            }
+        } else {
+            panic!("LIBKRUN_STATIC path does not exist: {}", static_path);
+        }
+        println!("cargo:rustc-link-lib=static=krun");
+
+        #[cfg(target_os = "macos")]
+        {
+            println!("cargo:rustc-link-lib=framework=Hypervisor");
+            println!("cargo:rustc-link-lib=framework=vmnet");
+        }
+        return;
+    }
+
+    // Option 3: Custom directory
+    if let Ok(dir) = std::env::var("LIBKRUN_DIR") {
+        println!("cargo:rustc-link-search=native={}", dir);
+        link_krun();
+        return;
+    }
+
+    // Option 4: Bundled libraries in lib/linux-{arch}/ (Linux only)
+    #[cfg(target_os = "linux")]
+    {
+        let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
+        // Look in the smolvm root (two levels up from crates/smolvm-napi/)
+        let smolvm_root = std::path::Path::new(&manifest_dir)
+            .parent()
+            .and_then(|p| p.parent())
+            .unwrap_or(std::path::Path::new("."));
+        let lib_dir = smolvm_root.join(format!("lib/linux-{}", arch));
+        let libkrun_path = lib_dir.join("libkrun.so");
+
+        if libkrun_path.exists() && !is_lfs_pointer(&libkrun_path) {
+            println!(
+                "cargo:warning=Using bundled Linux libraries from {}",
+                lib_dir.display()
+            );
+            println!("cargo:rustc-link-search=native={}", lib_dir.display());
+            link_krun();
+            println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN");
+            println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN/lib");
+            return;
+        }
+    }
+
+    // Option 5: System installation via pkg-config
+    if pkg_config::Config::new()
+        .atleast_version("1.0")
+        .probe("libkrun")
+        .is_ok()
+    {
+        return;
+    }
+
+    // Option 6: Common installation paths
+    #[cfg(target_os = "macos")]
+    {
+        let paths = [
+            "/opt/homebrew/lib",
+            "/usr/local/lib",
+            "/opt/homebrew/opt/libkrun/lib",
+            "/usr/local/opt/libkrun/lib",
+        ];
+
+        for path in paths {
+            if std::path::Path::new(path).join("libkrun.dylib").exists() {
+                println!("cargo:rustc-link-search=native={}", path);
+                link_krun();
+                println!("cargo:rustc-link-arg=-Wl,-rpath,{}", path);
+                return;
+            }
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let paths = [
+            "/usr/lib",
+            "/usr/local/lib",
+            "/usr/lib64",
+            "/usr/local/lib64",
+            "/usr/lib/x86_64-linux-gnu",
+            "/usr/lib/aarch64-linux-gnu",
+        ];
+
+        for path in paths {
+            if std::path::Path::new(path).join("libkrun.so").exists() {
+                println!("cargo:rustc-link-search=native={}", path);
+                link_krun();
+                return;
+            }
+        }
+    }
+
+    // Fallback: let the linker figure it out
+    link_krun();
+}

--- a/crates/smolvm-napi/src/error.rs
+++ b/crates/smolvm-napi/src/error.rs
@@ -1,0 +1,102 @@
+//! Error conversion from smolvm::Error to napi::Error.
+
+use napi::Status;
+use smolvm::error::{AgentErrorKind, Error as SmolvmError};
+
+/// Error codes exposed to JavaScript as `error.code`.
+pub const NOT_FOUND: &str = "NOT_FOUND";
+pub const INVALID_STATE: &str = "INVALID_STATE";
+pub const HYPERVISOR_UNAVAILABLE: &str = "HYPERVISOR_UNAVAILABLE";
+pub const CONFLICT: &str = "CONFLICT";
+pub const STORAGE_ERROR: &str = "STORAGE_ERROR";
+pub const MOUNT_ERROR: &str = "MOUNT_ERROR";
+pub const CONFIG_ERROR: &str = "CONFIG_ERROR";
+pub const COMMAND_FAILED: &str = "COMMAND_FAILED";
+pub const KVM_UNAVAILABLE: &str = "KVM_UNAVAILABLE";
+pub const SMOLVM_ERROR: &str = "SMOLVM_ERROR";
+
+/// Convert a smolvm::Error into a napi::Error with an appropriate error code.
+pub fn to_napi_error(err: SmolvmError) -> napi::Error {
+    let (code, msg) = match &err {
+        SmolvmError::VmNotFound { name } => (NOT_FOUND, format!("VM not found: {}", name)),
+
+        SmolvmError::InvalidState { expected, actual } => (
+            INVALID_STATE,
+            format!("Invalid state: expected {}, got {}", expected, actual),
+        ),
+
+        SmolvmError::HypervisorUnavailable(reason) => (
+            HYPERVISOR_UNAVAILABLE,
+            format!("Hypervisor unavailable: {}", reason),
+        ),
+
+        SmolvmError::Agent {
+            operation,
+            reason,
+            kind,
+        } => {
+            let code = match kind {
+                AgentErrorKind::NotFound => NOT_FOUND,
+                AgentErrorKind::Conflict => CONFLICT,
+                AgentErrorKind::Other => SMOLVM_ERROR,
+            };
+            (code, format!("Agent error ({}): {}", operation, reason))
+        }
+
+        SmolvmError::RootfsNotFound { path } => {
+            (NOT_FOUND, format!("Rootfs not found: {}", path.display()))
+        }
+
+        SmolvmError::DiskNotFound { path } => {
+            (NOT_FOUND, format!("Disk not found: {}", path.display()))
+        }
+
+        SmolvmError::MountSourceNotFound { path } => (
+            NOT_FOUND,
+            format!("Mount source not found: {}", path.display()),
+        ),
+
+        SmolvmError::Storage { operation, reason } => {
+            (STORAGE_ERROR, format!("Storage ({}): {}", operation, reason))
+        }
+
+        SmolvmError::Mount { operation, reason } => {
+            (MOUNT_ERROR, format!("Mount ({}): {}", operation, reason))
+        }
+
+        SmolvmError::InvalidMountPath { reason } => {
+            (MOUNT_ERROR, format!("Invalid mount path: {}", reason))
+        }
+
+        SmolvmError::Config { operation, reason } => {
+            (CONFIG_ERROR, format!("Config ({}): {}", operation, reason))
+        }
+
+        SmolvmError::CommandFailed { command, reason } => {
+            (COMMAND_FAILED, format!("Command '{}' failed: {}", command, reason))
+        }
+
+        SmolvmError::KvmUnavailable(reason) => {
+            (KVM_UNAVAILABLE, format!("KVM unavailable: {}", reason))
+        }
+
+        SmolvmError::KvmPermission(reason) => {
+            (KVM_UNAVAILABLE, format!("KVM permission denied: {}", reason))
+        }
+
+        _ => (SMOLVM_ERROR, err.to_string()),
+    };
+
+    napi::Error::new(Status::GenericFailure, format!("[{}] {}", code, msg))
+}
+
+/// Extension trait for converting smolvm::Result<T> to napi::Result<T>.
+pub trait IntoNapiResult<T> {
+    fn into_napi(self) -> napi::Result<T>;
+}
+
+impl<T> IntoNapiResult<T> for smolvm::error::Result<T> {
+    fn into_napi(self) -> napi::Result<T> {
+        self.map_err(to_napi_error)
+    }
+}

--- a/crates/smolvm-napi/src/lib.rs
+++ b/crates/smolvm-napi/src/lib.rs
@@ -1,0 +1,18 @@
+//! smolvm-napi — NAPI-RS bindings for the smolvm microVM runtime.
+//!
+//! This crate provides native Node.js bindings via NAPI-RS, allowing users
+//! to create, manage, and interact with microVMs directly from Node.js
+//! without requiring the `smolvm serve` daemon.
+//!
+//! # Architecture
+//!
+//! ```text
+//! TypeScript API layer (ergonomic, API-compatible with smolvm-node)
+//!   └── @smolvm/native .node binary (this crate)
+//!         └── smolvm library (Rust)
+//!               └── libkrun (dynamic linking) → Hypervisor.framework / KVM
+//! ```
+
+pub mod error;
+pub mod sandbox;
+pub mod types;

--- a/crates/smolvm-napi/src/sandbox.rs
+++ b/crates/smolvm-napi/src/sandbox.rs
@@ -1,0 +1,278 @@
+//! NapiSandbox — the main NAPI class wrapping AgentManager + AgentClient.
+//!
+//! All blocking operations (start, exec, pull, stop) run on tokio's blocking
+//! thread pool to avoid blocking Node's event loop. The AgentManager and
+//! AgentClient are wrapped in Arc<Mutex<>> for safe cross-thread access.
+
+use std::sync::{Arc, Mutex};
+
+use napi_derive::napi;
+
+use smolvm::agent::{AgentClient, AgentManager, HostMount, PortMapping, VmResources};
+
+use crate::error::IntoNapiResult;
+use crate::types::*;
+
+/// Wrapper to make AgentManager sendable across threads.
+/// AgentManager contains Arc<Mutex<AgentInner>> + PathBuf fields, all Send.
+struct ManagerWrapper(AgentManager);
+
+// SAFETY: AgentManager's fields are all Send (Arc<Mutex<_>>, PathBuf, String, Option<PathBuf>).
+// The internal Mutex synchronizes all mutable state.
+unsafe impl Send for ManagerWrapper {}
+unsafe impl Sync for ManagerWrapper {}
+
+#[napi]
+pub struct NapiSandbox {
+    name: String,
+    manager: Arc<ManagerWrapper>,
+    client: Arc<Mutex<Option<AgentClient>>>,
+    mounts: Vec<HostMount>,
+    ports: Vec<PortMapping>,
+    resources: VmResources,
+}
+
+#[napi]
+impl NapiSandbox {
+    /// Create a new sandbox. Does not start the VM yet — call `start()`.
+    #[napi(constructor)]
+    pub fn new(config: SandboxConfig) -> napi::Result<Self> {
+        let mounts: Vec<HostMount> = config
+            .mounts
+            .as_ref()
+            .map(|ms| ms.iter().map(HostMount::from).collect())
+            .unwrap_or_default();
+
+        let ports: Vec<PortMapping> = config
+            .ports
+            .as_ref()
+            .map(|ps| ps.iter().map(PortMapping::from).collect())
+            .unwrap_or_default();
+
+        let resources = config
+            .resources
+            .as_ref()
+            .map(|r| r.to_vm_resources())
+            .unwrap_or_default();
+
+        let manager =
+            AgentManager::for_vm_with_sizes(&config.name, resources.storage_gb, resources.overlay_gb)
+                .into_napi()?;
+
+        Ok(Self {
+            name: config.name,
+            manager: Arc::new(ManagerWrapper(manager)),
+            client: Arc::new(Mutex::new(None)),
+            mounts,
+            ports,
+            resources,
+        })
+    }
+
+    /// Get the sandbox name.
+    #[napi(getter)]
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    /// Get the current sandbox state: "stopped", "starting", "running", or "stopping".
+    #[napi]
+    pub fn state(&self) -> String {
+        self.manager.0.state().to_string()
+    }
+
+    /// Start the sandbox VM. Boots via fork + libkrun, waits for agent ready,
+    /// then connects the vsock client.
+    #[napi]
+    pub async fn start(&self) -> napi::Result<()> {
+        let manager = self.manager.clone();
+        let mounts = self.mounts.clone();
+        let ports = self.ports.clone();
+        let resources = self.resources;
+
+        tokio::task::spawn_blocking(move || {
+            manager.0.ensure_running_with_full_config(mounts, ports, resources)
+        })
+        .await
+        .map_err(|e| napi::Error::from_reason(format!("Task join error: {}", e)))?
+        .into_napi()?;
+
+        // Ensure we have a client connection
+        let needs_connect = {
+            let guard = self.client.lock().map_err(|e| {
+                napi::Error::from_reason(format!("Client lock poisoned: {}", e))
+            })?;
+            guard.is_none()
+        };
+
+        if needs_connect {
+            let manager = self.manager.clone();
+            let new_client = tokio::task::spawn_blocking(move || manager.0.connect())
+                .await
+                .map_err(|e| napi::Error::from_reason(format!("Task join error: {}", e)))?
+                .into_napi()?;
+
+            let mut guard = self.client.lock().map_err(|e| {
+                napi::Error::from_reason(format!("Client lock poisoned: {}", e))
+            })?;
+            *guard = Some(new_client);
+        }
+
+        Ok(())
+    }
+
+    /// Execute a command directly in the VM (not in a container).
+    #[napi]
+    pub async fn exec(
+        &self,
+        command: Vec<String>,
+        options: Option<ExecOptions>,
+    ) -> napi::Result<ExecResult> {
+        let (env, workdir, timeout) = parse_exec_options(&options);
+        let client = self.client.clone();
+
+        let result = tokio::task::spawn_blocking(move || {
+            let mut guard = client
+                .lock()
+                .map_err(|e| napi::Error::from_reason(format!("Client lock poisoned: {}", e)))?;
+            let c = guard.as_mut().ok_or_else(|| {
+                napi::Error::from_reason("Sandbox not started. Call start() first.")
+            })?;
+            c.vm_exec(command, env, workdir, timeout).into_napi()
+        })
+        .await
+        .map_err(|e| napi::Error::from_reason(format!("Task join error: {}", e)))??;
+
+        Ok(ExecResult {
+            exit_code: result.0,
+            stdout: result.1,
+            stderr: result.2,
+        })
+    }
+
+    /// Pull an OCI image and run a command inside it.
+    ///
+    /// This pulls the image (if not already cached), creates an overlay rootfs,
+    /// runs the command inside it, and cleans up. Equivalent to `smolvm run`.
+    #[napi]
+    pub async fn run(
+        &self,
+        image: String,
+        command: Vec<String>,
+        options: Option<ExecOptions>,
+    ) -> napi::Result<ExecResult> {
+        let (env, workdir, timeout) = parse_exec_options(&options);
+
+        // Pull the image first
+        let client = self.client.clone();
+        let image_for_pull = image.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut guard = client
+                .lock()
+                .map_err(|e| napi::Error::from_reason(format!("Client lock poisoned: {}", e)))?;
+            let c = guard.as_mut().ok_or_else(|| {
+                napi::Error::from_reason("Sandbox not started. Call start() first.")
+            })?;
+            c.pull_with_registry_config(&image_for_pull).into_napi()
+        })
+        .await
+        .map_err(|e| napi::Error::from_reason(format!("Task join error: {}", e)))??;
+
+        // Run the command in the image's rootfs via the agent protocol
+        let client = self.client.clone();
+        let result = tokio::task::spawn_blocking(move || {
+            let mut guard = client
+                .lock()
+                .map_err(|e| napi::Error::from_reason(format!("Client lock poisoned: {}", e)))?;
+            let c = guard.as_mut().ok_or_else(|| {
+                napi::Error::from_reason("Sandbox not started. Call start() first.")
+            })?;
+            c.run_with_mounts_and_timeout(&image, command, env, workdir, Vec::new(), timeout)
+                .into_napi()
+        })
+        .await
+        .map_err(|e| napi::Error::from_reason(format!("Task join error: {}", e)))??;
+
+        Ok(ExecResult {
+            exit_code: result.0,
+            stdout: result.1,
+            stderr: result.2,
+        })
+    }
+
+    /// Pull an OCI image into the sandbox's storage.
+    #[napi]
+    pub async fn pull_image(&self, image: String) -> napi::Result<ImageInfo> {
+        let client = self.client.clone();
+
+        let info = tokio::task::spawn_blocking(move || {
+            let mut guard = client
+                .lock()
+                .map_err(|e| napi::Error::from_reason(format!("Client lock poisoned: {}", e)))?;
+            let c = guard.as_mut().ok_or_else(|| {
+                napi::Error::from_reason("Sandbox not started. Call start() first.")
+            })?;
+            c.pull_with_registry_config(&image).into_napi()
+        })
+        .await
+        .map_err(|e| napi::Error::from_reason(format!("Task join error: {}", e)))??;
+
+        Ok(ImageInfo::from(info))
+    }
+
+    /// List all cached OCI images in the sandbox's storage.
+    #[napi]
+    pub async fn list_images(&self) -> napi::Result<Vec<ImageInfo>> {
+        let client = self.client.clone();
+
+        let images = tokio::task::spawn_blocking(move || {
+            let mut guard = client
+                .lock()
+                .map_err(|e| napi::Error::from_reason(format!("Client lock poisoned: {}", e)))?;
+            let c = guard.as_mut().ok_or_else(|| {
+                napi::Error::from_reason("Sandbox not started. Call start() first.")
+            })?;
+            c.list_images().into_napi()
+        })
+        .await
+        .map_err(|e| napi::Error::from_reason(format!("Task join error: {}", e)))??;
+
+        Ok(images.into_iter().map(ImageInfo::from).collect())
+    }
+
+    /// Stop the sandbox VM gracefully.
+    #[napi]
+    pub async fn stop(&self) -> napi::Result<()> {
+        // Drop the client first
+        {
+            let mut guard = self.client.lock().map_err(|e| {
+                napi::Error::from_reason(format!("Client lock poisoned: {}", e))
+            })?;
+            *guard = None;
+        }
+
+        let manager = self.manager.clone();
+        tokio::task::spawn_blocking(move || manager.0.stop().into_napi())
+            .await
+            .map_err(|e| napi::Error::from_reason(format!("Task join error: {}", e)))?
+    }
+
+    /// Stop the sandbox and clean up all storage (disks, config).
+    #[napi]
+    pub async fn delete(&self) -> napi::Result<()> {
+        self.stop().await?;
+
+        let data_dir = smolvm::agent::vm_data_dir(&self.name);
+        if data_dir.exists() {
+            std::fs::remove_dir_all(&data_dir).map_err(|e| {
+                napi::Error::from_reason(format!(
+                    "Failed to delete VM data at {}: {}",
+                    data_dir.display(),
+                    e
+                ))
+            })?;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/smolvm-napi/src/types.rs
+++ b/crates/smolvm-napi/src/types.rs
@@ -1,0 +1,182 @@
+//! NAPI-visible types mirroring smolvm Rust types.
+//!
+//! These structs are exposed to JavaScript via `#[napi(object)]` and include
+//! conversion impls to/from the corresponding smolvm types.
+
+use napi_derive::napi;
+use smolvm::agent::{HostMount, PortMapping, VmResources};
+
+// ============================================================================
+// Input types (JS → Rust)
+// ============================================================================
+
+/// Configuration for creating a sandbox.
+#[napi(object)]
+#[derive(Debug, Clone)]
+pub struct SandboxConfig {
+    /// Unique sandbox name. Used as the VM identifier.
+    pub name: String,
+    /// Host directories to mount into the VM.
+    pub mounts: Option<Vec<HostMountConfig>>,
+    /// Port mappings from host to guest.
+    pub ports: Option<Vec<PortMappingConfig>>,
+    /// VM resource allocation.
+    pub resources: Option<VmResourcesConfig>,
+}
+
+/// A host directory mount specification.
+#[napi(object)]
+#[derive(Debug, Clone)]
+pub struct HostMountConfig {
+    /// Absolute path on the host.
+    pub source: String,
+    /// Absolute path inside the guest.
+    pub target: String,
+    /// Mount as read-only (default: true).
+    pub read_only: Option<bool>,
+}
+
+/// A port mapping from host to guest.
+#[napi(object)]
+#[derive(Debug, Clone)]
+pub struct PortMappingConfig {
+    /// Port on the host.
+    pub host: u16,
+    /// Port inside the guest.
+    pub guest: u16,
+}
+
+/// VM resource allocation.
+#[napi(object)]
+#[derive(Debug, Clone)]
+pub struct VmResourcesConfig {
+    /// Number of vCPUs (default: 1).
+    pub cpus: Option<u8>,
+    /// Memory in MiB (default: 512).
+    pub memory_mb: Option<u32>,
+    /// Enable outbound network access (default: false).
+    pub network: Option<bool>,
+    /// Storage disk size in GiB (default: 20).
+    pub storage_gb: Option<f64>,
+    /// Overlay disk size in GiB (default: 2).
+    pub overlay_gb: Option<f64>,
+}
+
+/// Options for executing a command.
+#[napi(object)]
+#[derive(Debug, Clone)]
+pub struct ExecOptions {
+    /// Environment variables as key-value pairs.
+    pub env: Option<Vec<EnvVar>>,
+    /// Working directory inside the VM/container.
+    pub workdir: Option<String>,
+    /// Timeout in seconds.
+    pub timeout_secs: Option<u32>,
+}
+
+/// An environment variable key-value pair.
+#[napi(object)]
+#[derive(Debug, Clone)]
+pub struct EnvVar {
+    pub key: String,
+    pub value: String,
+}
+
+// ============================================================================
+// Output types (Rust → JS)
+// ============================================================================
+
+/// Result of executing a command.
+#[napi(object)]
+#[derive(Debug, Clone)]
+pub struct ExecResult {
+    /// Process exit code.
+    pub exit_code: i32,
+    /// Standard output.
+    pub stdout: String,
+    /// Standard error.
+    pub stderr: String,
+}
+
+/// Information about a pulled/cached OCI image.
+#[napi(object)]
+#[derive(Debug, Clone)]
+pub struct ImageInfo {
+    /// Image reference (e.g., "alpine:latest").
+    pub reference: String,
+    /// Image digest (sha256:...).
+    pub digest: String,
+    /// Image size in bytes.
+    pub size: f64,
+    /// Platform architecture (e.g., "arm64").
+    pub architecture: String,
+    /// Platform OS (e.g., "linux").
+    pub os: String,
+}
+
+// ============================================================================
+// Conversion impls
+// ============================================================================
+
+impl From<&HostMountConfig> for HostMount {
+    fn from(m: &HostMountConfig) -> Self {
+        let mount = HostMount::new(&m.source, &m.target);
+        if m.read_only.unwrap_or(true) {
+            mount
+        } else {
+            mount.writable()
+        }
+    }
+}
+
+impl From<&PortMappingConfig> for PortMapping {
+    fn from(p: &PortMappingConfig) -> Self {
+        PortMapping::new(p.host, p.guest)
+    }
+}
+
+impl VmResourcesConfig {
+    pub fn to_vm_resources(&self) -> VmResources {
+        VmResources {
+            cpus: self.cpus.unwrap_or(1),
+            mem: self.memory_mb.unwrap_or(512),
+            network: self.network.unwrap_or(false),
+            storage_gb: self.storage_gb.map(|g| g as u64),
+            overlay_gb: self.overlay_gb.map(|g| g as u64),
+        }
+    }
+}
+
+impl From<smolvm_protocol::ImageInfo> for ImageInfo {
+    fn from(info: smolvm_protocol::ImageInfo) -> Self {
+        ImageInfo {
+            reference: info.reference,
+            digest: info.digest,
+            size: info.size as f64,
+            architecture: info.architecture,
+            os: info.os,
+        }
+    }
+}
+
+/// Parse ExecOptions into the components needed by AgentClient::vm_exec().
+pub fn parse_exec_options(
+    options: &Option<ExecOptions>,
+) -> (Vec<(String, String)>, Option<String>, Option<std::time::Duration>) {
+    match options {
+        Some(opts) => {
+            let env = opts
+                .env
+                .as_ref()
+                .map(|vars| vars.iter().map(|v| (v.key.clone(), v.value.clone())).collect())
+                .unwrap_or_default();
+
+            let workdir = opts.workdir.clone();
+
+            let timeout = opts.timeout_secs.map(|s| std::time::Duration::from_secs(s as u64));
+
+            (env, workdir, timeout)
+        }
+        None => (Vec::new(), None, None),
+    }
+}


### PR DESCRIPTION
## Summary

- Add `smolvm-napi` crate (`crates/smolvm-napi/`) that wraps smolvm's `AgentManager` + `AgentClient` as a NAPI-RS native Node.js addon
- Enables **daemonless** microVM management directly from Node.js — no `smolvm serve` required
- Add crate to workspace members in root `Cargo.toml`

## Architecture

```
TypeScript API layer (@smolvm/node-native — see smolvm-sdk PR)
  └── smolvm-napi .node binary (this crate)
        └── smolvm library (Rust)
              └── libkrun (dynamic linking) → Hypervisor.framework / KVM
```

## Key Components

- **`NapiSandbox` class** — async methods: `start()`, `exec()`, `run()`, `pullImage()`, `listImages()`, `stop()`, `delete()`
- **Error conversion** — maps all `smolvm::Error` variants → NAPI errors with structured codes (`NOT_FOUND`, `INVALID_STATE`, `HYPERVISOR_UNAVAILABLE`, `CONFLICT`, etc.)
- **Type bindings** — NAPI-visible structs for `SandboxConfig`, `ExecOptions`, `ExecResult`, `ImageInfo` with `From` conversion impls
- **build.rs** — replicates libkrun discovery logic with `@loader_path` rpath for `.node` binary compatibility

## Technical Notes

- All blocking operations (VM boot, exec, pull) run on tokio's blocking thread pool via `spawn_blocking`
- `AgentManager` wrapped in `Arc<ManagerWrapper>` with manual `Send`/`Sync` impls (all fields are Send)
- `AgentClient` wrapped in `Arc<Mutex<Option<AgentClient>>>` for exclusive access
- `fork()` safety: child immediately calls `krun_start_enter()` which replaces the process, never touching V8/libuv

## Test plan

- [x] `cargo check -p smolvm-napi` passes
- [x] `cargo clippy -p smolvm-napi` passes (no warnings)
- [x] `cargo build -p smolvm-napi --release` produces `libsmolvm_napi.dylib` (~1.3MB)
- [ ] Integration tests via the TypeScript wrapper (see companion PR in smolvm-sdk)
