### PR TITLE
feat: embedded node SDK part 2 - support embedded runtime library discovery

### DIFF
--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -4,9 +4,12 @@
 //! All setup is done in the child process after fork, where
 //! DYLD_LIBRARY_PATH is still available for dlopen.
 
+use crate::consts::ENV_SMOLVM_LIB_DIR;
 use crate::error::{Error, Result};
 use crate::storage::{OverlayDisk, StorageDisk};
+use crate::util::libkrunfw_filename;
 use crate::vm::config::HostMount;
+
 use smolvm_protocol::ports;
 use std::ffi::{CStr, CString};
 use std::path::{Path, PathBuf};
@@ -59,20 +62,31 @@ extern "C" {
 // TSI (Transparent Socket Impersonation) feature flags
 const KRUN_TSI_HIJACK_INET: u32 = 1 << 0;
 
-/// Find the directory containing libkrunfw by checking paths relative to the current executable.
+/// Find the directory containing libkrunfw by checking explicit overrides and
+/// paths relative to the current executable.
 ///
 /// Checks:
+/// - `$SMOLVM_LIB_DIR` (explicit override for embedded runtimes)
 /// - `<exe_dir>/lib/` (distribution layout)
 /// - `<exe_dir>/../lib/` (alternative layout)
 /// - `<exe_dir>/../../lib/linux-<arch>/` (source tree dev builds)
 fn find_lib_dir() -> Option<PathBuf> {
+    let lib_name = libkrunfw_filename();
+    if let Ok(explicit_dir) = std::env::var(ENV_SMOLVM_LIB_DIR) {
+        let path = PathBuf::from(explicit_dir);
+        if path.join(lib_name).exists() {
+            return path.canonicalize().ok().or(Some(path));
+        }
+
+        tracing::warn!(
+            path = %path.display(),
+            lib = lib_name,
+            "{} does not contain the expected libkrunfw library", ENV_SMOLVM_LIB_DIR
+        );
+    }
+
     let exe = std::env::current_exe().ok()?;
     let exe_dir = exe.parent()?;
-
-    #[cfg(target_os = "macos")]
-    let lib_name = "libkrunfw.5.dylib";
-    #[cfg(target_os = "linux")]
-    let lib_name = "libkrunfw.so.5";
 
     let candidates = [
         exe_dir.join("lib"),
@@ -104,12 +118,7 @@ fn preload_libkrunfw() {
         return;
     };
 
-    #[cfg(target_os = "macos")]
-    let lib_name = "libkrunfw.5.dylib";
-    #[cfg(target_os = "linux")]
-    let lib_name = "libkrunfw.so.5";
-
-    let lib_path = lib_dir.join(lib_name);
+    let lib_path = lib_dir.join(libkrunfw_filename());
     let Ok(lib_path_c) = CString::new(lib_path.to_string_lossy().as_bytes()) else {
         return;
     };

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,0 +1,14 @@
+//! Shared constants used across smolvm.
+//!
+//! # Environment Variables
+//!
+//! This section defines the names of environment variables recognized by
+//! smolvm. Keep all environment variable constants here so runtime behavior
+//! and documentation stay in sync.
+
+/// Name of the environment variable that overrides the directory used to
+/// locate bundled native libraries for smolvm.
+///
+/// If set, smolvm checks this directory before falling back to paths
+/// relative to the current executable. This is primarily used by embedded runtimes.
+pub const ENV_SMOLVM_LIB_DIR: &str = "SMOLVM_LIB_DIR";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@
 pub mod agent;
 pub mod api;
 pub mod config;
+pub mod consts;
 pub mod db;
 pub mod error;
 pub mod log_rotation;

--- a/src/util.rs
+++ b/src/util.rs
@@ -18,3 +18,21 @@ pub fn current_timestamp() -> String {
 
     format!("{}", duration.as_secs())
 }
+
+/// Get the filename of libkrunfw dynamic lib
+pub fn libkrunfw_filename() -> &'static str {
+    #[cfg(target_os = "macos")]
+    let lib_name = "libkrunfw.5.dylib";
+    #[cfg(target_os = "linux")]
+    let lib_name = "libkrunfw.so.5";
+    lib_name
+}
+
+/// Get the filename of the libkrun dynamic lib
+pub fn libkrun_filename() -> &'static str {
+    #[cfg(target_os = "macos")]
+    let lib_name = "libkrun.dylib";
+    #[cfg(target_os = "linux")]
+    let lib_name = "libkrun.so";
+    lib_name
+}

--- a/tests/test_api.sh
+++ b/tests/test_api.sh
@@ -83,17 +83,21 @@ test_health() {
 }
 
 test_create_and_start_sandbox() {
-    # Create sandbox
-    local status
-    status=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$API_URL/api/v1/sandboxes" \
+    # Create sandbox with network enabled so image pulls work later in the suite
+    local status response tmpfile
+    tmpfile=$(mktemp)
+    status=$(curl -s -o "$tmpfile" -w "%{http_code}" -X POST "$API_URL/api/v1/sandboxes" \
         -H "Content-Type: application/json" \
-        -d "{\"name\": \"$SANDBOX_NAME\"}")
+        -d "{\"name\": \"$SANDBOX_NAME\", \"resources\": {\"network\": true}}")
+    response=$(cat "$tmpfile")
+    rm -f "$tmpfile"
     [[ "$status" != "200" ]] && return 1
+    [[ "$response" == *'"network":true'* ]] || [[ "$response" == *'"network": true'* ]] || return 1
 
     # Start sandbox (boots VM)
-    local response
-    response=$(curl -s -X POST "$API_URL/api/v1/sandboxes/$SANDBOX_NAME/start")
-    [[ "$response" == *'"state":"running"'* ]]
+    local start_response
+    start_response=$(curl -s -X POST "$API_URL/api/v1/sandboxes/$SANDBOX_NAME/start")
+    [[ "$start_response" == *'"state":"running"'* ]]
 }
 
 test_exec_echo() {
@@ -154,17 +158,35 @@ test_exec_shell_pipeline() {
 }
 
 test_pull_and_run_image() {
+    local pull_status pull_response run_status run_response tmpfile
+
     # Pull image
-    curl -s -X POST "$API_URL/api/v1/sandboxes/$SANDBOX_NAME/images/pull" \
+    tmpfile=$(mktemp)
+    pull_status=$(curl -s -o "$tmpfile" -w "%{http_code}" -X POST \
+        "$API_URL/api/v1/sandboxes/$SANDBOX_NAME/images/pull" \
         -H "Content-Type: application/json" \
-        -d '{"image": "alpine:latest"}' >/dev/null
+        -d '{"image": "alpine:latest"}')
+    pull_response=$(cat "$tmpfile")
+    rm -f "$tmpfile"
+    if [[ "$pull_status" != "200" ]]; then
+        echo "image pull failed (status $pull_status): $pull_response" >&2
+        return 1
+    fi
+    [[ "$pull_response" == *'"reference":"alpine:latest"'* ]] || [[ "$pull_response" == *'"reference": "alpine:latest"'* ]] || return 1
 
     # Run in image
-    local response
-    response=$(curl -s -X POST "$API_URL/api/v1/sandboxes/$SANDBOX_NAME/run" \
+    tmpfile=$(mktemp)
+    run_status=$(curl -s -o "$tmpfile" -w "%{http_code}" -X POST \
+        "$API_URL/api/v1/sandboxes/$SANDBOX_NAME/run" \
         -H "Content-Type: application/json" \
         -d '{"image": "alpine:latest", "command": ["echo", "container-test"]}')
-    [[ "$response" == *"container-test"* ]]
+    run_response=$(cat "$tmpfile")
+    rm -f "$tmpfile"
+    if [[ "$run_status" != "200" ]]; then
+        echo "image run failed (status $run_status): $run_response" >&2
+        return 1
+    fi
+    [[ "$run_response" == *"container-test"* ]]
 }
 
 test_stop_sandbox() {


### PR DESCRIPTION
## Summary

This PR contains the following changes:

1. Introduced new env var: `SMOLVM_LIB_DIR`, for overriding the lib discovery directory. This is mainly for the embedded sdk because we will need to ship the libkrunfw and libkrun dynamic libs together with the node sdk
2. Refactored the libkrun and libkrunfw filenames spreading different places, and replaced them with util functions: `libkrunfw_filename`, and `libkrun_filename`
3. Fixed the failed `Pull and run image` tests

## Testing (All tests passed)

```
...
..
Run with: /var/folders/dh/z10h5jps0wg4wp06q7shl3080000gn/T/tmp.A8GRUUZpdh/test-python
Note: Keep the .smolmachine file alongside the binary
Options: --help for usage
[PASS] Pack Python image
[TEST] Packed Python run
[PASS] Packed Python run
[TEST] pack run Python
[PASS] pack run Python

==========================================
  Pack Tests Summary
==========================================

Tests run:    34
Tests passed: 34
Tests failed: 0

All tests passed!

==========================================
  Overall Summary
==========================================

Test suites run:    6
Test suites passed: 6
Test suites failed: 0

All test suites passed!
```

