### PR TITLE
feat: embedded node SDK part 3 - add shared embedded sdk scaffolding

### DIFF
--- a/sdks/README.md
+++ b/sdks/README.md
@@ -1,0 +1,20 @@
+# Embedded SDKs
+
+This directory holds language bindings that embed `smolvm` directly into the
+host process instead of talking to the API server.
+
+Layout convention:
+
+- `sdks/scripts/` contains shared helpers used by all embedded SDKs.
+- `sdks/node/` contains the Node.js embedded SDK and its internal platform
+  packages.
+- future embedded SDKs should live in sibling directories such as
+  `sdks/python/`, `sdks/go/`, and `sdks/c/`.
+
+Bundled native library rule:
+
+- Embedded SDKs ship package-local copies of `libkrun` and `libkrunfw`.
+- Those libraries are always staged from the `smolvm` repo's bundled `./lib`
+  directory, not from Homebrew or other system locations.
+- Shared helpers in `sdks/scripts/` should be used to copy the current host's
+  libraries into each SDK package's `lib/` directory.

--- a/sdks/scripts/stage-embedded-libs.sh
+++ b/sdks/scripts/stage-embedded-libs.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+copy_matching_libraries() {
+    local src_dir="$1"
+    local pattern="$2"
+    local dst_dir="$3"
+
+    if compgen -G "$src_dir/$pattern" > /dev/null; then
+        cp -a "$src_dir"/$pattern "$dst_dir"/
+    fi
+}
+
+detect_lib_bundle() {
+    if [[ -n "${SMOLVM_EMBEDDED_LIB_BUNDLE:-}" ]]; then
+        echo "$SMOLVM_EMBEDDED_LIB_BUNDLE"
+        return 0
+    fi
+
+    if [[ "$(uname -s)" == "Linux" ]]; then
+        echo "$REPO_ROOT/lib/linux-$(uname -m)"
+    else
+        echo "$REPO_ROOT/lib"
+    fi
+}
+
+usage() {
+    cat <<'EOF'
+Usage:
+  ./sdks/scripts/stage-embedded-libs.sh <target-lib-dir>
+
+Environment:
+  SMOLVM_EMBEDDED_LIB_BUNDLE  Override the bundled library source directory.
+EOF
+}
+
+if [[ $# -ne 1 ]]; then
+    usage >&2
+    exit 1
+fi
+
+TARGET_LIB_DIR="$1"
+SOURCE_LIB_DIR="$(detect_lib_bundle)"
+
+if [[ ! -d "$SOURCE_LIB_DIR" ]]; then
+    echo "Error: bundled library directory not found: $SOURCE_LIB_DIR" >&2
+    exit 1
+fi
+
+rm -rf "$TARGET_LIB_DIR"
+mkdir -p "$TARGET_LIB_DIR"
+
+if [[ "$(uname -s)" == "Linux" ]]; then
+    copy_matching_libraries "$SOURCE_LIB_DIR" "libkrun.so*" "$TARGET_LIB_DIR"
+    copy_matching_libraries "$SOURCE_LIB_DIR" "libkrunfw.so*" "$TARGET_LIB_DIR"
+else
+    copy_matching_libraries "$SOURCE_LIB_DIR" "libkrun*.dylib" "$TARGET_LIB_DIR"
+    copy_matching_libraries "$SOURCE_LIB_DIR" "libkrunfw*.dylib" "$TARGET_LIB_DIR"
+fi
+
+echo "Staged embedded SDK libraries from $SOURCE_LIB_DIR into $TARGET_LIB_DIR"


### PR DESCRIPTION
Scaffolding the embedded sdk building.

This `stage-embedded-libs.sh` is the shared “copy the native runtime into the SDK package” step. Later platform-specific embedded SDK builds will call it to stage libkrun and libkrunfw into their package-local lib/ directories, ensuring they ship the exact bundled libraries from this repo rather than relying on system installs.