### PR TITLE
chore: update git-lfs build checks and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,13 @@ smolvm microvm exec --name codex-sandbox -it -- codex
 
 ## development
 
+**Prerequisites (for building from source):**
+- Rust toolchain
+- [git-lfs](https://git-lfs.com) (required for library binaries)
+- Docker (for cross-compiling the agent)
+- e2fsprogs (for storage template creation; `mkfs.ext4`)
+- LLVM (macOS only, for building libkrun: `brew install llvm`)
+
 ```bash
 # build
 ./scripts/build-dist.sh

--- a/build.rs
+++ b/build.rs
@@ -127,6 +127,17 @@ fn link_libkrun() {
 
     // Option 1: Bundle libraries with the binary
     if let Ok(bundle_path) = std::env::var("LIBKRUN_BUNDLE") {
+        // On Linux, check that the library is not an LFS pointer before linking
+        #[cfg(target_os = "linux")]
+        {
+            let lib_path = std::path::Path::new(&bundle_path).join("libkrun.so");
+            if lib_path.exists() && is_lfs_pointer(&lib_path) {
+                println!("cargo:error=libkrun.so is a Git LFS pointer, not the actual library.");
+                println!("cargo:error=Run 'git lfs pull' to fetch the actual library binary.");
+                panic!("Git LFS pointer detected");
+            }
+        }
+
         println!("cargo:rustc-link-search=native={}", bundle_path);
         link_krun();
 

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -76,6 +76,12 @@ fi
 
 echo "Building smolvm distribution: ${DIST_NAME}"
 
+# Check for git-lfs (required for library binaries)
+if ! command -v git-lfs &> /dev/null && ! git lfs version &> /dev/null 2>&1; then
+    echo "Error: git-lfs is required to build smolvm distributions"
+    exit 1
+fi
+
 # Resolve bundled library directory
 if [[ "$(uname -s)" == "Linux" ]]; then
     ARCH="$(uname -m)"


### PR DESCRIPTION
Ran into some issues on an older linux box that didn't yet have git-lfs - so these extra checks should help

Update build.rs and scripts/build-dist.sh to check for git-lfs installation and git LFS pointers. Include git-lfs as a build requirement in a new README section.

**Testing**

1. git-lfs not found:

```
$ ./scripts/build-dist.sh 
Building smolvm distribution: smolvm-0.1.18-linux-x86_64
Error: git-lfs is required to build smolvm distributions

```

2. git-lfs found, but objects files still lfs pointers

```
$ ./scripts/build-dist.sh 
...
error: failed to run custom build command for `smolvm v0.1.18 (/home/ginglis/smolvm)`

Caused by:
  process didn't exit successfully: `/home/ginglis/smolvm/target/release/build/smolvm-29ea0c7c25419c65/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=LIBKRUN_STATIC
  cargo:rerun-if-env-changed=LIBKRUN_BUNDLE
  cargo:rerun-if-env-changed=LIBKRUN_DIR
  cargo:rerun-if-env-changed=LIBKRUN_BUILD
  cargo:error=libkrun.so is a Git LFS pointer, not the actual library.
  cargo:error=Run 'git lfs pull' to fetch the actual library binary.

  --- stderr

  thread 'main' (164788) panicked at build.rs:137:17:
  Git LFS pointer detected
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
...
```

4. Linux CI - no changes necessary since it is using stubbed libraries, not the bundled LFS files, nor is it running the `build-dist.sh` script.