### PR TITLE
feat: embedded node SDK part 4 - add embedded node workspace skeleton

### DIFF
--- a/sdks/node/README.md
+++ b/sdks/node/README.md
@@ -1,0 +1,10 @@
+# Embedded Node SDK Workspace
+
+This workspace contains:
+
+- `smolvm-embedded`: the public package users install
+- `smolvm-embedded-*`: internal platform packages that carry the `.node`
+  binary plus bundled `libkrun` and `libkrunfw`
+
+Users should only install `smolvm-embedded`. The platform packages are an
+implementation detail used by npm's optional dependency resolution.

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "smolvm-embedded-node-workspace",
+  "private": true,
+  "workspaces": [
+    "smolvm-embedded",
+    "smolvm-embedded-darwin-arm64",
+    "smolvm-embedded-darwin-x64",
+    "smolvm-embedded-linux-arm64-gnu",
+    "smolvm-embedded-linux-x64-gnu"
+  ],
+  "devDependencies": {
+    "@napi-rs/cli": "^2.18.0",
+    "@types/node": "^20.0.0",
+    "tsup": "^8.0.0",
+    "tsx": "^4.19.3",
+    "typescript": "^5.3.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/sdks/node/smolvm-embedded-darwin-arm64/package.json
+++ b/sdks/node/smolvm-embedded-darwin-arm64/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "smolvm-embedded-darwin-arm64",
+  "version": "0.1.0",
+  "description": "Internal platform package for smolvm-embedded on macOS arm64",
+  "main": "native/index.js",
+  "types": "native/index.d.ts",
+  "files": [
+    "native",
+    "lib"
+  ],
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "license": "Apache-2.0"
+}

--- a/sdks/node/smolvm-embedded-darwin-x64/package.json
+++ b/sdks/node/smolvm-embedded-darwin-x64/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "smolvm-embedded-darwin-x64",
+  "version": "0.1.0",
+  "description": "Internal platform package for smolvm-embedded on macOS x64",
+  "main": "native/index.js",
+  "types": "native/index.d.ts",
+  "files": [
+    "native",
+    "lib"
+  ],
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "license": "Apache-2.0"
+}

--- a/sdks/node/smolvm-embedded-linux-arm64-gnu/package.json
+++ b/sdks/node/smolvm-embedded-linux-arm64-gnu/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "smolvm-embedded-linux-arm64-gnu",
+  "version": "0.1.0",
+  "description": "Internal platform package for smolvm-embedded on Linux arm64 GNU",
+  "main": "native/index.js",
+  "types": "native/index.d.ts",
+  "files": [
+    "native",
+    "lib"
+  ],
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "license": "Apache-2.0"
+}

--- a/sdks/node/smolvm-embedded-linux-x64-gnu/package.json
+++ b/sdks/node/smolvm-embedded-linux-x64-gnu/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "smolvm-embedded-linux-x64-gnu",
+  "version": "0.1.0",
+  "description": "Internal platform package for smolvm-embedded on Linux x64 GNU",
+  "main": "native/index.js",
+  "types": "native/index.d.ts",
+  "files": [
+    "native",
+    "lib"
+  ],
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "license": "Apache-2.0"
+}

--- a/sdks/node/smolvm-embedded/README.md
+++ b/sdks/node/smolvm-embedded/README.md
@@ -1,0 +1,6 @@
+# smolvm-embedded
+
+Public embedded Node.js SDK package.
+
+This package will expose the TypeScript API surface and resolve the correct
+internal platform package at install/runtime.

--- a/sdks/node/smolvm-embedded/package.json
+++ b/sdks/node/smolvm-embedded/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "smolvm-embedded",
+  "version": "0.1.0",
+  "description": "Embedded Node.js SDK for smolvm",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "license": "Apache-2.0"
+}


### PR DESCRIPTION
This change is to add the node sdk workspace skeleton. We plan to have platform specific workspaces with a top-level resolver that resolves the sdk installation to the one for its specific platform.

Ultimately we expect the user to call only `npm install smolvm-embedded`, and internally it  will install `smolvm-embedded-linux-*`, `smolvm-embedded-darwin-arm-*` etc.