### PR TITLE
chores: clean up lingering tarball for correct installation

### DIFF
--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -442,6 +442,11 @@ EOF
 echo "Generating checksums..."
 (cd "$DIST_DIR" && shasum -a 256 smolvm smolvm-bin lib/* > checksums.txt)
 
+# Delete existing tarball. This is because when a new release is created, there could be 
+# tarball of the old release left in dist/, and ./install-local.sh may pick up the wrong tarball
+echo "Cleaning up existing tarball..."
+rm -f "smolvm-*.tar.gz"
+
 # Create tarball
 echo "Creating tarball..."
 cd dist

--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -6,6 +6,7 @@
 //!
 //! The static FFI path in `launcher.rs` remains untouched for normal operations.
 
+use crate::util::{libkrun_filename, libkrunfw_filename};
 use smolvm_protocol::ports;
 use std::ffi::{CStr, CString};
 use std::path::{Path, PathBuf};
@@ -56,10 +57,8 @@ impl KrunFunctions {
     /// Caller must ensure `lib_dir` contains valid libkrun and libkrunfw libraries.
     pub unsafe fn load(lib_dir: &Path) -> Result<Self, String> {
         // Platform-specific library names
-        #[cfg(target_os = "macos")]
-        let (fw_lib_name, lib_name) = ("libkrunfw.5.dylib", "libkrun.dylib");
-        #[cfg(target_os = "linux")]
-        let (fw_lib_name, lib_name) = ("libkrunfw.so.5", "libkrun.so");
+        let fw_lib_name = libkrunfw_filename();
+        let lib_name = libkrun_filename();
 
         // Preload libkrunfw with RTLD_GLOBAL so libkrun can find it
         let fw_lib_path = lib_dir.join(fw_lib_name);


### PR DESCRIPTION
This PR is for 2 purposes:

1. Removing the lingering `smolvm-*.tar.gz` from previous run of `./scripts/build-dist.sh`. 
2. Code clean up to use the util function to get libkrun and libkrunfw lib names


## Testing (All tests passed)

```
...
Run with: /var/folders/dh/z10h5jps0wg4wp06q7shl3080000gn/T/tmp.7kHZklBqx6/test-python
Note: Keep the .smolmachine file alongside the binary
Options: --help for usage
[PASS] Pack Python image
[TEST] Packed Python run
[PASS] Packed Python run
[TEST] pack run Python
[PASS] pack run Python

==========================================
  Pack Tests Summary
==========================================

Tests run:    34
Tests passed: 34
Tests failed: 0

All tests passed!

==========================================
  Overall Summary
==========================================

Test suites run:    6
Test suites passed: 6
Test suites failed: 0

All test suites passed!
```