### PR TITLE
feat: smolmachine format change with pack test changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,25 +16,34 @@ A local tool to build and run portable, lightweight, self-contained virtual mach
 Each workload runs in its own Linux microVM with a separate kernel. The host
 filesystem, network, and credentials are isolated unless explicitly shared.
 
+Install
+-------
+
+```bash
+curl -sSL https://smolmachines.com/install.sh | bash
+```
+
+Or download from [GitHub Releases](https://github.com/smol-machines/smolvm/releases).
+
 Quick Start
 -----------
 
-* Install: [GitHub Releases](https://github.com/smol-machines/smolvm/releases) or `curl -sSL https://smolmachines.com/install.sh | bash`
-* Documentation: https://smolmachines.com/sdk/
-* Report a bug: https://github.com/smol-machines/smolvm/issues
-* Join the community: https://discord.gg/qhQ7FHZ2zd
-
 ```bash
-# Create and run an isolated machine
+# Run a command in an ephemeral VM (cleaned up after exit)
+smolvm machine run --image alpine -- echo "hello from a microVM"
+
+# Interactive shell
+smolvm machine run -it --image alpine
+
+# Persistent machine (survives stop/start)
 smolvm machine create --net myvm
-smolvm machine start myvm
+smolvm machine start --name myvm
 smolvm machine exec --name myvm -- apk add sl
-smolvm machine exec --name myvm -it -- sl
-smolvm machine exec --name myvm -it -- /bin/sh   # interactive shell
-smolvm machine stop myvm
+smolvm machine exec --name myvm -it -- /bin/sh
+smolvm machine stop --name myvm
 
 # Pack into a portable executable
-smolvm pack create python:3.12-alpine -o ./my-pythonvm
+smolvm pack create --image python:3.12-alpine -o ./my-pythonvm
 ./my-pythonvm python3 -c "print('hello from a packed VM')"
 ```
 

--- a/crates/smolvm-pack/src/assets.rs
+++ b/crates/smolvm-pack/src/assets.rs
@@ -48,7 +48,6 @@ impl AssetCollector {
     /// Create a new asset collector with a staging directory.
     pub fn new(staging_dir: PathBuf) -> Result<Self> {
         fs::create_dir_all(&staging_dir)?;
-        fs::create_dir_all(staging_dir.join("lib"))?;
         fs::create_dir_all(staging_dir.join("layers"))?;
 
         Ok(Self {
@@ -77,6 +76,8 @@ impl AssetCollector {
     /// - libkrun.dylib (macOS) or libkrun.so (Linux)
     /// - libkrunfw.5.dylib (macOS) or libkrunfw.so.5 (Linux)
     pub fn collect_libraries(&mut self, lib_dir: &Path) -> Result<()> {
+        fs::create_dir_all(self.staging_dir.join("lib"))?;
+
         let lib_names = if cfg!(target_os = "macos") {
             vec!["libkrun.dylib", "libkrunfw.5.dylib"]
         } else {
@@ -323,17 +324,39 @@ impl AssetCollector {
         self.inventory
     }
 
-    /// Compress all staged assets into a single zstd-compressed tarball.
-    pub fn compress(&self, output: &Path) -> Result<u64> {
+    /// Compress staged assets into a single zstd-compressed tarball.
+    ///
+    /// When `exclude_libs` is true, the `lib/` directory is excluded
+    /// (two-file mode: libs are embedded in the stub binary instead).
+    /// When false, everything is included (single-file mode).
+    pub fn compress(&self, output: &Path, exclude_libs: bool) -> Result<u64> {
         let output_file = File::create(output)?;
         let encoder = zstd::stream::Encoder::new(output_file, ZSTD_LEVEL)
             .map_err(|e| PackError::Compression(e.to_string()))?;
         let mut tar_builder = tar::Builder::new(encoder);
 
-        // Add all files from staging directory
-        tar_builder
-            .append_dir_all(".", &self.staging_dir)
-            .map_err(|e| PackError::Tar(e.to_string()))?;
+        // Sort entries for deterministic tar ordering (consistent checksums)
+        let mut entries: Vec<_> = fs::read_dir(&self.staging_dir)?
+            .filter_map(|e| e.ok())
+            .collect();
+        entries.sort_by_key(|e| e.file_name());
+
+        for entry in entries {
+            let name = entry.file_name();
+            if exclude_libs && name == "lib" {
+                continue; // libs go in the stub, not the sidecar
+            }
+            let path = entry.path();
+            if path.is_dir() {
+                tar_builder
+                    .append_dir_all(name.to_string_lossy().as_ref(), &path)
+                    .map_err(|e| PackError::Tar(e.to_string()))?;
+            } else {
+                tar_builder
+                    .append_path_with_name(&path, name.to_string_lossy().as_ref())
+                    .map_err(|e| PackError::Tar(e.to_string()))?;
+            }
+        }
 
         let encoder = tar_builder
             .into_inner()
@@ -449,7 +472,8 @@ mod tests {
 
         let _collector = AssetCollector::new(staging.clone()).unwrap();
 
-        assert!(staging.join("lib").exists());
+        // lib/ is only created when collect_libraries() is called
+        assert!(!staging.join("lib").exists());
         assert!(staging.join("layers").exists());
     }
 
@@ -467,7 +491,7 @@ mod tests {
         // Create collector and compress
         let collector = AssetCollector::new(staging).unwrap();
         let compressed = temp_dir.path().join("assets.tar.zst");
-        collector.compress(&compressed).unwrap();
+        collector.compress(&compressed, false).unwrap();
 
         // Decompress and verify
         decompress_assets_from_file(&compressed, &output).unwrap();

--- a/crates/smolvm-pack/src/extract.rs
+++ b/crates/smolvm-pack/src/extract.rs
@@ -397,6 +397,131 @@ fn post_process_extraction(cache_dir: &Path, debug: bool) -> std::io::Result<()>
     Ok(())
 }
 
+/// Marker file indicating libs extraction is complete.
+const LIBS_EXTRACTION_MARKER: &str = ".smolvm-libs-extracted";
+
+/// Extract runtime libraries from a packed stub binary.
+///
+/// Reads the last 32 bytes of the executable looking for a SMOLLIBS footer.
+/// If found, extracts the compressed libs bundle to a cache directory and
+/// returns the path to the `lib/` directory containing libkrun/libkrunfw.
+///
+/// Returns `None` if the binary has no embedded libs (e.g., a V2 stub or
+/// the base smolvm binary).
+pub fn extract_libs_from_binary(exe_path: &Path, debug: bool) -> std::io::Result<Option<PathBuf>> {
+    use crate::format::{LibsFooter, LIBS_FOOTER_SIZE};
+
+    let mut file = File::open(exe_path)?;
+    let file_size = file.metadata()?.len();
+    if file_size < LIBS_FOOTER_SIZE as u64 {
+        return Ok(None);
+    }
+
+    // Read the last 32 bytes
+    file.seek(SeekFrom::End(-(LIBS_FOOTER_SIZE as i64)))?;
+    let mut footer_buf = [0u8; LIBS_FOOTER_SIZE];
+    file.read_exact(&mut footer_buf)?;
+
+    let footer = match LibsFooter::from_bytes(&footer_buf) {
+        Ok(f) => f,
+        Err(_) => return Ok(None), // No SMOLLIBS footer — not a V3 stub
+    };
+
+    if debug {
+        eprintln!(
+            "debug: found SMOLLIBS footer: offset={}, size={}",
+            footer.libs_offset, footer.libs_size
+        );
+    }
+
+    // Cache key based on libs content hash
+    file.seek(SeekFrom::Start(footer.libs_offset))?;
+    let mut hasher = crc32fast::Hasher::new();
+    let mut remaining = footer.libs_size;
+    let mut buf = [0u8; 64 * 1024];
+    while remaining > 0 {
+        let to_read = remaining.min(buf.len() as u64) as usize;
+        let n = file.read(&mut buf[..to_read])?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+        remaining -= n as u64;
+    }
+    let libs_checksum = hasher.finalize();
+
+    let cache_base = dirs::cache_dir()
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "no cache directory"))?;
+    let libs_cache_dir = cache_base
+        .join("smolvm-libs")
+        .join(format!("{:08x}", libs_checksum));
+    let lib_dir = libs_cache_dir.join("lib");
+
+    // Acquire exclusive lock to prevent concurrent extraction races.
+    if let Some(parent) = libs_cache_dir.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let lock_path = libs_cache_dir.with_extension("lock");
+    let lock_file = fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)?;
+
+    #[cfg(unix)]
+    {
+        let ret = unsafe { libc::flock(lock_file.as_raw_fd(), libc::LOCK_EX) };
+        if ret != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+    }
+
+    // Re-check after acquiring lock (another process may have finished)
+    if libs_cache_dir.join(LIBS_EXTRACTION_MARKER).exists() {
+        if debug {
+            eprintln!("debug: libs already extracted at {}", lib_dir.display());
+        }
+        // Lock released on drop of lock_file
+        let _ = lock_file;
+        return Ok(Some(lib_dir));
+    }
+
+    // Extract
+    fs::create_dir_all(&libs_cache_dir)?;
+    file.seek(SeekFrom::Start(footer.libs_offset))?;
+    let limited_reader = (&mut file).take(footer.libs_size);
+    let decoder = zstd::stream::Decoder::new(limited_reader)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    let mut archive = tar::Archive::new(decoder);
+    safe_unpack(&mut archive, &libs_cache_dir)?;
+
+    // Make libs executable
+    if lib_dir.exists() {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            for entry in fs::read_dir(&lib_dir)? {
+                let entry = entry?;
+                if entry.path().is_file() {
+                    let mut perms = fs::metadata(entry.path())?.permissions();
+                    perms.set_mode(0o755);
+                    fs::set_permissions(entry.path(), perms)?;
+                }
+            }
+        }
+    }
+
+    fs::write(libs_cache_dir.join(LIBS_EXTRACTION_MARKER), "")?;
+    // Lock released on drop of lock_file
+    let _ = lock_file;
+
+    if debug {
+        eprintln!("debug: extracted libs to {}", lib_dir.display());
+    }
+
+    Ok(Some(lib_dir))
+}
+
 /// Clean up old cached extractions (keep only the most recent N).
 #[allow(dead_code)]
 pub fn cleanup_old_caches(keep: usize) -> std::io::Result<()> {

--- a/crates/smolvm-pack/src/format.rs
+++ b/crates/smolvm-pack/src/format.rs
@@ -13,10 +13,14 @@ pub const MAGIC: &[u8; 8] = b"SMOLPACK";
 /// Magic bytes for embedded section header.
 pub const SECTION_MAGIC: &[u8; 8] = b"SMOLSECT";
 
+/// Magic bytes for libs footer appended to the stub binary.
+pub const LIBS_MAGIC: &[u8; 8] = b"SMOLLIBS";
+
 /// Current format version.
 /// Version 1: Assets appended to binary
 /// Version 2: Assets in sidecar file (.smolmachine)
-pub const FORMAT_VERSION: u32 = 2;
+/// Version 3: Libs in stub binary, sidecar is cross-platform
+pub const FORMAT_VERSION: u32 = 3;
 
 /// Extension for sidecar assets file.
 pub const SIDECAR_EXTENSION: &str = ".smolmachine";
@@ -26,6 +30,9 @@ pub const FOOTER_SIZE: usize = 64;
 
 /// Embedded section header size (fixed).
 pub const SECTION_HEADER_SIZE: usize = 32;
+
+/// Libs footer size in bytes (fixed).
+pub const LIBS_FOOTER_SIZE: usize = 32;
 
 /// Header for data embedded in the __SMOLVM,__smolvm Mach-O section.
 ///
@@ -104,6 +111,61 @@ impl SectionHeader {
                 buf[16], buf[17], buf[18], buf[19], buf[20], buf[21], buf[22], buf[23],
             ]),
             checksum: u32::from_le_bytes([buf[24], buf[25], buf[26], buf[27]]),
+        })
+    }
+}
+
+/// Footer appended to the stub binary to locate embedded runtime libraries.
+///
+/// The stub reads its own last 32 bytes to find the compressed libs bundle,
+/// extracts them to a cache directory, and dlopen's libkrun from there.
+/// This keeps the .smolmachine sidecar cross-platform (no platform-specific libs).
+///
+/// Layout (32 bytes total):
+/// ```text
+/// Offset  Size  Field
+/// 0       8     magic ("SMOLLIBS")
+/// 8       4     version (u32 LE)
+/// 12      8     libs_offset (u64 LE) - offset to compressed libs blob
+/// 20      8     libs_size (u64 LE) - size of compressed libs blob
+/// 28      4     reserved (zeroes)
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct LibsFooter {
+    /// Offset from start of file to the compressed libs blob.
+    pub libs_offset: u64,
+    /// Size of the compressed libs blob.
+    pub libs_size: u64,
+}
+
+impl LibsFooter {
+    /// Serialize footer to bytes.
+    pub fn to_bytes(&self) -> [u8; LIBS_FOOTER_SIZE] {
+        let mut buf = [0u8; LIBS_FOOTER_SIZE];
+        buf[0..8].copy_from_slice(LIBS_MAGIC);
+        buf[8..12].copy_from_slice(&1u32.to_le_bytes()); // version 1
+        buf[12..20].copy_from_slice(&self.libs_offset.to_le_bytes());
+        buf[20..28].copy_from_slice(&self.libs_size.to_le_bytes());
+        // 28..32 reserved (zeroed)
+        buf
+    }
+
+    /// Deserialize footer from bytes.
+    pub fn from_bytes(buf: &[u8; LIBS_FOOTER_SIZE]) -> Result<Self> {
+        if &buf[0..8] != LIBS_MAGIC {
+            return Err(PackError::InvalidMagic);
+        }
+        let version = u32::from_le_bytes([buf[8], buf[9], buf[10], buf[11]]);
+        if version != 1 {
+            return Err(PackError::UnsupportedVersion(version));
+        }
+        Ok(Self {
+            libs_offset: u64::from_le_bytes([
+                buf[12], buf[13], buf[14], buf[15], buf[16], buf[17], buf[18], buf[19],
+            ]),
+            libs_size: u64::from_le_bytes([
+                buf[20], buf[21], buf[22], buf[23], buf[24], buf[25], buf[26], buf[27],
+            ]),
         })
     }
 }

--- a/crates/smolvm-pack/src/packer.rs
+++ b/crates/smolvm-pack/src/packer.rs
@@ -90,7 +90,7 @@ impl Packer {
             .as_ref()
             .ok_or_else(|| crate::PackError::AssetNotFound("stub executable".to_string()))?;
 
-        // 1. Copy stub executable to output (pure Mach-O, no modifications)
+        // 1. Copy stub executable to output (libs are appended later, after signing)
         let stub_data = fs::read(stub_path)?;
         let stub_size = stub_data.len() as u64;
         fs::write(output, &stub_data)?;
@@ -104,14 +104,14 @@ impl Packer {
             fs::set_permissions(output, perms)?;
         }
 
-        // 2. Build sidecar file with: assets + manifest + footer
+        // 3. Build sidecar file with: assets (no libs) + manifest + footer
         let sidecar_path = sidecar_path_for(output);
         let mut sidecar_file = File::create(&sidecar_path)?;
 
-        // 2a. Write compressed assets
+        // 3a. Write compressed assets (excludes lib/ — those are embedded in the stub)
         let assets_temp = temp_dir.path().join("assets.tar.zst");
         let assets_size = if let Some(collector) = &self.asset_collector {
-            collector.compress(&assets_temp)?
+            collector.compress(&assets_temp, true)?
         } else {
             let empty_file = File::create(&assets_temp)?;
             let encoder = zstd::stream::Encoder::new(empty_file, 1)?;
@@ -124,19 +124,19 @@ impl Packer {
         let mut assets_file = File::open(&assets_temp)?;
         std::io::copy(&mut assets_file, &mut sidecar_file)?;
 
-        // 2b. Write manifest JSON
+        // 3b. Write manifest JSON
         let manifest_offset = assets_size;
         let manifest_json = self.manifest.to_json()?;
         let manifest_size = manifest_json.len() as u64;
         sidecar_file.write_all(&manifest_json)?;
 
-        // 2c. Calculate checksum of assets + manifest
+        // 3c. Calculate checksum of assets + manifest
         sidecar_file.flush()?;
         drop(sidecar_file);
         let checksum_size = assets_size + manifest_size;
         let checksum = crc32_file_range(&sidecar_path, 0, checksum_size)?;
 
-        // 2d. Write footer to sidecar
+        // 3d. Write footer to sidecar
         let footer = PackFooter {
             stub_size: 0,     // Not used in sidecar mode
             assets_offset: 0, // Assets start at beginning of sidecar
@@ -252,7 +252,7 @@ impl Packer {
         // Compress assets
         let assets_temp = temp_dir.path().join("assets.tar.zst");
         let assets_size = if let Some(collector) = &self.asset_collector {
-            collector.compress(&assets_temp)?
+            collector.compress(&assets_temp, false)? // include libs in single-file mode
         } else {
             let empty_file = File::create(&assets_temp)?;
             let encoder = zstd::stream::Encoder::new(empty_file, 1)?;
@@ -343,7 +343,7 @@ impl Packer {
         // 2. Compress and append assets
         let assets_temp = temp_dir.path().join("assets.tar.zst");
         let assets_size = if let Some(collector) = &self.asset_collector {
-            collector.compress(&assets_temp)?
+            collector.compress(&assets_temp, false)? // include libs in append mode
         } else {
             let empty_file = File::create(&assets_temp)?;
             let encoder = zstd::stream::Encoder::new(empty_file, 1)?;
@@ -402,6 +402,61 @@ impl Packer {
             sidecar_path: None, // No sidecar in embedded mode
         })
     }
+}
+
+/// Append compressed runtime libraries to a packed binary.
+///
+/// Call this AFTER code signing — the SMOLLIBS footer must be the last
+/// bytes of the file so `extract_libs_from_binary()` can find it.
+pub fn embed_libs_in_binary(binary_path: &Path, staging_dir: &Path) -> Result<()> {
+    use crate::format::LibsFooter;
+
+    let lib_dir = staging_dir.join("lib");
+    if !lib_dir.exists() {
+        return Ok(()); // No libs to embed
+    }
+
+    // Check if there are actual library files
+    let has_libs = fs::read_dir(&lib_dir)?
+        .filter_map(|e| e.ok())
+        .any(|e| e.path().is_file());
+    if !has_libs {
+        return Ok(());
+    }
+
+    let temp_dir = tempfile::tempdir()?;
+    let libs_temp = temp_dir.path().join("libs.tar.zst");
+
+    // Compress libs
+    let output_file = File::create(&libs_temp)?;
+    let encoder = zstd::stream::Encoder::new(output_file, crate::assets::ZSTD_LEVEL)
+        .map_err(|e| crate::PackError::Compression(e.to_string()))?;
+    let mut tar_builder = tar::Builder::new(encoder);
+    tar_builder
+        .append_dir_all("lib", &lib_dir)
+        .map_err(|e| crate::PackError::Tar(e.to_string()))?;
+    let encoder = tar_builder
+        .into_inner()
+        .map_err(|e| crate::PackError::Tar(e.to_string()))?;
+    encoder
+        .finish()
+        .map_err(|e| crate::PackError::Compression(e.to_string()))?;
+
+    let libs_size = fs::metadata(&libs_temp)?.len();
+    let binary_size = fs::metadata(binary_path)?.len();
+
+    // Append libs blob + footer
+    let mut output_file = fs::OpenOptions::new().append(true).open(binary_path)?;
+    let mut libs_file = File::open(&libs_temp)?;
+    std::io::copy(&mut libs_file, &mut output_file)?;
+
+    let libs_footer = LibsFooter {
+        libs_offset: binary_size,
+        libs_size,
+    };
+    output_file.write_all(&libs_footer.to_bytes())?;
+
+    Ok(())
 }
 
 /// Get the sidecar path for a packed binary.

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -70,7 +70,7 @@ const KRUN_TSI_HIJACK_INET: u32 = 1 << 0;
 /// - `<exe_dir>/lib/` (distribution layout)
 /// - `<exe_dir>/../lib/` (alternative layout)
 /// - `<exe_dir>/../../lib/linux-<arch>/` (source tree dev builds)
-fn find_lib_dir() -> Option<PathBuf> {
+pub fn find_lib_dir() -> Option<PathBuf> {
     let lib_name = libkrunfw_filename();
     if let Ok(explicit_dir) = std::env::var(ENV_SMOLVM_LIB_DIR) {
         let path = PathBuf::from(explicit_dir);

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -14,7 +14,7 @@ pub use crate::data::network::PortMapping;
 pub use crate::data::resources::VmResources;
 pub use crate::data::storage::HostMount;
 pub use client::{AgentClient, PullOptions, RunConfig};
-pub use launcher::{launch_agent_vm, VmDisks};
+pub use launcher::{find_lib_dir, launch_agent_vm, VmDisks};
 pub use manager::{docker_config_dir, docker_config_mount, vm_data_dir, AgentManager, AgentState};
 
 /// Agent VM name.

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -556,11 +556,6 @@ pub struct StartCmd {
 
 impl StartCmd {
     pub fn run(self) -> smolvm::Result<()> {
-        // If a name is given, use the named path directly.
-        // If no name, try starting "default" as a named VM (which already exists
-        // if it was previously created). Only fall back to start_vm_default()
-        // if the named record doesn't exist. This avoids a redundant DB read
-        // that resolve_vm_name would do.
         let name = self.name.unwrap_or_else(|| "default".to_string());
         match vm_common::start_vm_named(KIND, &name) {
             Ok(()) => Ok(()),

--- a/src/cli/pack.rs
+++ b/src/cli/pack.rs
@@ -470,7 +470,7 @@ impl PackCreateCmd {
 
         manifest.assets = collector.into_inventory();
 
-        let collector = AssetCollector::new(staging_dir)
+        let collector = AssetCollector::new(staging_dir.clone())
             .map_err(|e| Error::agent("collect assets", e.to_string()))?;
 
         let packer = Packer::new(manifest)
@@ -515,6 +515,12 @@ impl PackCreateCmd {
             } else {
                 println!("Signed successfully");
             }
+        }
+
+        // Embed libs in stub AFTER signing — SMOLLIBS footer must be at end of file
+        if !self.single_file {
+            smolvm_pack::packer::embed_libs_in_binary(&self.output, &staging_dir)
+                .map_err(|e| Error::agent("embed libraries", e.to_string()))?;
         }
 
         println!("\nRun with: {}", self.output.display());
@@ -576,6 +582,13 @@ impl PackCreateCmd {
     }
 
     /// Find the agent rootfs directory.
+    ///
+    /// Search order:
+    /// 1. Explicit `--rootfs-dir` flag
+    /// 2. `SMOLVM_AGENT_ROOTFS` env var (same as VM boot path)
+    /// 3. Build output (`target/agent-rootfs`)
+    /// 4. Next to the executable (`exe-dir/agent-rootfs`)
+    /// 5. User data dir (`~/Library/Application Support/smolvm/agent-rootfs`)
     fn find_rootfs_dir(&self) -> smolvm::Result<PathBuf> {
         if let Some(ref dir) = self.rootfs_dir {
             return Ok(dir.clone());
@@ -583,8 +596,10 @@ impl PackCreateCmd {
 
         // Check common locations
         let candidates = [
+            // SMOLVM_AGENT_ROOTFS env var (consistent with VM boot path)
+            std::env::var("SMOLVM_AGENT_ROOTFS").ok().map(PathBuf::from),
             // Build output
-            Some(PathBuf::from("target/agent-rootfs/rootfs")),
+            Some(PathBuf::from("target/agent-rootfs")),
             // Distribution
             std::env::current_exe()
                 .ok()

--- a/src/cli/pack_run.rs
+++ b/src/cli/pack_run.rs
@@ -30,6 +30,48 @@ use std::time::Duration;
 /// Timeout waiting for the agent to become ready.
 const AGENT_READY_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Resolve the lib directory containing libkrun/libkrunfw.
+///
+/// Two-file mode: libs embedded in stub binary (SMOLLIBS footer).
+/// Single-file mode: libs extracted from Mach-O section to cache_dir/lib/.
+/// `smolvm pack run`: uses the host-installed libs.
+fn resolve_lib_dir(cache_dir: &Path, debug: bool) -> smolvm::Result<PathBuf> {
+    // Two-file mode: libs embedded in stub binary (SMOLLIBS footer)
+    if let Ok(exe_path) = std::env::current_exe() {
+        if let Ok(Some(lib_dir)) = extract::extract_libs_from_binary(&exe_path, debug) {
+            if debug {
+                eprintln!("debug: using libs from stub binary: {}", lib_dir.display());
+            }
+            return Ok(lib_dir);
+        }
+    }
+
+    // Single-file mode: libs extracted from Mach-O section alongside other assets
+    let cache_lib = cache_dir.join("lib");
+    if cache_lib.exists() {
+        if debug {
+            eprintln!("debug: using libs from cache: {}", cache_lib.display());
+        }
+        return Ok(cache_lib);
+    }
+
+    // Host-installed libs (for `smolvm pack run .smolmachine`)
+    if let Some(host_lib) = smolvm::agent::find_lib_dir() {
+        if debug {
+            eprintln!(
+                "debug: using libs from host install: {}",
+                host_lib.display()
+            );
+        }
+        return Ok(host_lib);
+    }
+
+    Err(Error::agent(
+        "find libraries",
+        "libkrun/libkrunfw not found. The binary may be corrupted or the libraries are missing.",
+    ))
+}
+
 /// Convert parsed mounts to PackedMount format for the VM launcher.
 fn mounts_to_packed(mounts: &[smolvm::data::storage::HostMount]) -> Vec<PackedMount> {
     mounts
@@ -240,7 +282,7 @@ impl PackRunCmd {
         //    storage.ext4 / agent.sock.  tempdir_in gives us a truly unique
         //    directory that survives PID reuse and abrupt termination.
         let rootfs_path = cache_dir.join("agent-rootfs");
-        let lib_dir = cache_dir.join("lib");
+        let lib_dir = resolve_lib_dir(&cache_dir, self.debug)?;
         let layers_dir = cache_dir.join("layers");
         let runtime_parent = cache_dir.join("runtime");
         std::fs::create_dir_all(&runtime_parent)
@@ -927,7 +969,7 @@ fn run_from_cache(
     cli: PackedCli,
 ) -> smolvm::Result<()> {
     let rootfs_path = cache_dir.join("agent-rootfs");
-    let lib_dir = cache_dir.join("lib");
+    let lib_dir = resolve_lib_dir(cache_dir, cli.debug)?;
     let layers_dir = cache_dir.join("layers");
     let runtime_parent = cache_dir.join("runtime");
     std::fs::create_dir_all(&runtime_parent)
@@ -1294,7 +1336,7 @@ fn daemon_start(mode: &PackedMode, cli: &PackedCli) -> smolvm::Result<()> {
     let packed_mounts = mounts_to_packed(&mounts);
 
     let rootfs_path = cache_dir.join("agent-rootfs");
-    let lib_dir = cache_dir.join("lib");
+    let lib_dir = resolve_lib_dir(&cache_dir, cli.debug)?;
     let layers_dir = cache_dir.join("layers");
     let debug = cli.debug;
 

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -112,20 +112,56 @@ log_info() {
 # Track failed test names for summary
 FAILED_TESTS=()
 
-# Run a test function
+# Fail-fast mode: stop on first failure.
+# Set FAIL_FAST=1 or pass --fail-fast to run_all.sh.
+FAIL_FAST="${FAIL_FAST:-0}"
+
+# Single test filter: only run tests whose name contains this string.
+# Usage: TEST_FILTER="from .smolmachine" bash tests/test_machine.sh
+TEST_FILTER="${TEST_FILTER:-}"
+
+# Run a test function, capturing output and showing it on failure.
 run_test() {
     local test_name="$1"
     local test_func="$2"
 
+    # Skip if filter is set and test name doesn't match
+    if [[ -n "$TEST_FILTER" ]] && [[ "$test_name" != *"$TEST_FILTER"* ]]; then
+        return 0
+    fi
+
+    # Skip remaining tests if fail-fast triggered
+    if [[ "$FAIL_FAST" == "1" ]] && [[ $TESTS_FAILED -gt 0 ]]; then
+        return 0
+    fi
+
     ((TESTS_RUN++))
     log_test "$test_name"
 
-    if $test_func; then
+    local output_file
+    output_file=$(mktemp)
+
+    if $test_func 2>&1 | tee "$output_file"; then
         log_pass "$test_name"
+        rm -f "$output_file"
         return 0
     else
         log_fail "$test_name"
         FAILED_TESTS+=("$test_name")
+
+        # Show last 10 lines on failure (may already be visible, but
+        # repeating under the FAIL marker makes it easy to find)
+        local output
+        output=$(tail -10 "$output_file" 2>/dev/null || true)
+        if [[ -n "$output" ]]; then
+            echo -e "  ${RED}Error output:${NC}"
+            echo "$output" | sed 's/^/    /'
+        fi
+        rm -f "$output_file"
+
+        if [[ "$FAIL_FAST" == "1" ]]; then
+            echo -e "\n${RED}Stopping: --fail-fast is set${NC}"
+        fi
         return 1
     fi
 }

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -14,8 +14,12 @@
 #   ./tests/run_all.sh bench-vm     # Run VM startup benchmark only
 #   ./tests/run_all.sh bench-container # Run container benchmark only
 #
+# Flags:
+#   --fail-fast          Stop on first test failure (useful for debugging)
+#
 # Environment:
 #   SMOLVM=/path/to/smolvm   # Use specific binary
+#   FAIL_FAST=1              # Same as --fail-fast
 
 set -euo pipefail
 
@@ -52,12 +56,18 @@ run_suite() {
     fi
 }
 
-# Determine which tests to run
-if [[ $# -eq 0 ]]; then
-    TESTS_TO_RUN="all"
-else
-    TESTS_TO_RUN="$1"
-fi
+# Parse arguments
+TESTS_TO_RUN="all"
+for arg in "$@"; do
+    case "$arg" in
+        --fail-fast)
+            export FAIL_FAST=1
+            ;;
+        *)
+            TESTS_TO_RUN="$arg"
+            ;;
+    esac
+done
 
 echo ""
 echo "=========================================="

--- a/tests/test_api.sh
+++ b/tests/test_api.sh
@@ -24,16 +24,8 @@ kill_orphan_smolvm_processes
 API_PORT=18080
 API_URL="http://127.0.0.1:$API_PORT"
 SERVER_PID=""
-<<<<<<< Updated upstream
-SANDBOX_NAME="api-test-machine"
-=======
-<<<<<<< Updated upstream
-SANDBOX_NAME="api-test-sandbox"
-=======
-SANDBOX_NAME="api-test-machine"
+MACHINE_NAME="api-test-machine"
 REGISTRY_TEST_NAME="registry-coherence-test"
->>>>>>> Stashed changes
->>>>>>> Stashed changes
 
 # =============================================================================
 # Setup / Teardown
@@ -68,22 +60,10 @@ stop_server() {
 }
 
 cleanup() {
-<<<<<<< Updated upstream
-    # Delete machine via API (this stops the VM properly)
-    if curl -s "$API_URL/health" >/dev/null 2>&1; then
-        curl -s -X DELETE "$API_URL/api/v1/machines/$SANDBOX_NAME" >/dev/null 2>&1 || true
-=======
-<<<<<<< Updated upstream
-    # Delete sandbox via API (this stops the VM properly)
-    if curl -s "$API_URL/health" >/dev/null 2>&1; then
-        curl -s -X DELETE "$API_URL/api/v1/sandboxes/$SANDBOX_NAME" >/dev/null 2>&1 || true
-=======
     # Delete machines via API (this stops the VMs properly)
     if curl -s "$API_URL/health" >/dev/null 2>&1; then
-        curl -s -X DELETE "$API_URL/api/v1/machines/$SANDBOX_NAME" >/dev/null 2>&1 || true
+        curl -s -X DELETE "$API_URL/api/v1/machines/$MACHINE_NAME" >/dev/null 2>&1 || true
         curl -s -X DELETE "$API_URL/api/v1/machines/$REGISTRY_TEST_NAME" >/dev/null 2>&1 || true
->>>>>>> Stashed changes
->>>>>>> Stashed changes
     fi
     stop_server
 
@@ -109,18 +89,18 @@ test_create_and_start_machine() {
     local status
     status=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$API_URL/api/v1/machines" \
         -H "Content-Type: application/json" \
-        -d "{\"name\": \"$SANDBOX_NAME\", \"network\": true, \"cpus\": 1, \"mem\": 512}")
+        -d "{\"name\": \"$MACHINE_NAME\", \"network\": true, \"cpus\": 1, \"mem\": 512}")
     [[ "$status" != "200" ]] && return 1
 
     # Start machine (boots VM)
     local response
-    response=$(curl -s -X POST "$API_URL/api/v1/machines/$SANDBOX_NAME/start")
+    response=$(curl -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/start")
     [[ "$response" == *'"state":"running"'* ]]
 }
 
 test_exec_echo() {
     local response
-    response=$(curl -s -X POST "$API_URL/api/v1/machines/$SANDBOX_NAME/exec" \
+    response=$(curl -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/exec" \
         -H "Content-Type: application/json" \
         -d '{"command": ["echo", "api-test-marker"]}')
     [[ "$response" == *"api-test-marker"* ]]
@@ -128,7 +108,7 @@ test_exec_echo() {
 
 test_exec_reads_vm_filesystem() {
     local response
-    response=$(curl -s -X POST "$API_URL/api/v1/machines/$SANDBOX_NAME/exec" \
+    response=$(curl -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/exec" \
         -H "Content-Type: application/json" \
         -d '{"command": ["cat", "/etc/os-release"]}')
     [[ "$response" == *"Alpine"* ]] || [[ "$response" == *"alpine"* ]]
@@ -137,14 +117,14 @@ test_exec_reads_vm_filesystem() {
 test_exec_exit_codes() {
     # Test exit code 0
     local response exit_code
-    response=$(curl -s -X POST "$API_URL/api/v1/machines/$SANDBOX_NAME/exec" \
+    response=$(curl -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/exec" \
         -H "Content-Type: application/json" \
         -d '{"command": ["sh", "-c", "exit 0"]}')
     exit_code=$(echo "$response" | grep -o '"exitCode":[0-9]*' | cut -d: -f2)
     [[ "$exit_code" != "0" ]] && return 1
 
     # Test exit code 42
-    response=$(curl -s -X POST "$API_URL/api/v1/machines/$SANDBOX_NAME/exec" \
+    response=$(curl -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/exec" \
         -H "Content-Type: application/json" \
         -d '{"command": ["sh", "-c", "exit 42"]}')
     exit_code=$(echo "$response" | grep -o '"exitCode":[0-9]*' | cut -d: -f2)
@@ -153,7 +133,7 @@ test_exec_exit_codes() {
 
 test_exec_with_env() {
     local response
-    response=$(curl -s -X POST "$API_URL/api/v1/machines/$SANDBOX_NAME/exec" \
+    response=$(curl -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/exec" \
         -H "Content-Type: application/json" \
         -d '{"command": ["sh", "-c", "echo $MY_VAR"], "env": [{"name": "MY_VAR", "value": "hello_from_api"}]}')
     [[ "$response" == *"hello_from_api"* ]]
@@ -161,7 +141,7 @@ test_exec_with_env() {
 
 test_exec_with_workdir() {
     local response
-    response=$(curl -s -X POST "$API_URL/api/v1/machines/$SANDBOX_NAME/exec" \
+    response=$(curl -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/exec" \
         -H "Content-Type: application/json" \
         -d '{"command": ["pwd"], "workdir": "/tmp"}')
     [[ "$response" == *"/tmp"* ]]
@@ -169,7 +149,7 @@ test_exec_with_workdir() {
 
 test_exec_shell_pipeline() {
     local response
-    response=$(curl -s -X POST "$API_URL/api/v1/machines/$SANDBOX_NAME/exec" \
+    response=$(curl -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/exec" \
         -H "Content-Type: application/json" \
         -d '{"command": ["sh", "-c", "echo hello world | wc -w"]}')
     [[ "$response" == *"2"* ]]
@@ -177,13 +157,13 @@ test_exec_shell_pipeline() {
 
 test_pull_and_run_image() {
     # Pull image
-    curl -s -X POST "$API_URL/api/v1/machines/$SANDBOX_NAME/images/pull" \
+    curl -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/images/pull" \
         -H "Content-Type: application/json" \
         -d '{"image": "alpine:latest"}' >/dev/null
 
     # Run in image
     local response
-    response=$(curl -s -X POST "$API_URL/api/v1/machines/$SANDBOX_NAME/run" \
+    response=$(curl -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/run" \
         -H "Content-Type: application/json" \
         -d '{"image": "alpine:latest", "command": ["echo", "container-test"]}')
     [[ "$response" == *"container-test"* ]]
@@ -191,13 +171,13 @@ test_pull_and_run_image() {
 
 test_stop_machine() {
     local response
-    response=$(curl -s -X POST "$API_URL/api/v1/machines/$SANDBOX_NAME/stop")
+    response=$(curl -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/stop")
     [[ "$response" == *'"state":"stopped"'* ]] || [[ "$response" == *'"name":'* ]]
 }
 
 test_delete_machine() {
     local status
-    status=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE "$API_URL/api/v1/machines/$SANDBOX_NAME")
+    status=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE "$API_URL/api/v1/machines/$MACHINE_NAME")
     [[ "$status" == "200" ]]
 }
 

--- a/tests/test_pack.sh
+++ b/tests/test_pack.sh
@@ -174,6 +174,52 @@ test_binary_is_clean_macho() {
     [[ "$file_result" == *"Mach-O"* ]]
 }
 
+test_sidecar_has_no_libs() {
+    local output="$TEST_DIR/test-alpine"
+
+    if [[ ! -f "$output.smolmachine" ]]; then
+        echo "SKIP: No sidecar"
+        return 0
+    fi
+
+    # Extract sidecar and verify no lib/ directory (V3: libs are in stub)
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    # Sidecar is: [assets.tar.zst][manifest json][64-byte footer]
+    # Read footer to get assets_size, then extract just the tar.zst
+    # Simpler: just list the tar contents and check for lib/
+    local footer_size=64
+    local file_size
+    file_size=$(stat -f%z "$output.smolmachine" 2>/dev/null || stat -c%s "$output.smolmachine" 2>/dev/null)
+
+    # The assets tar.zst starts at offset 0 in the sidecar
+    # Check that decompressed tar has no lib/ entries
+    if command -v zstd >/dev/null 2>&1; then
+        # Use head to get just the compressed portion (before manifest+footer)
+        # This is approximate but sufficient — if lib/ is in the tar, tar -t will find it
+        zstd -d < "$output.smolmachine" 2>/dev/null | tar -t 2>/dev/null | grep -q "^lib/" && return 1
+    else
+        echo "SKIP: zstd not installed"
+    fi
+
+    rm -rf "$tmpdir"
+    return 0
+}
+
+test_stub_has_libs_footer() {
+    local output="$TEST_DIR/test-alpine"
+
+    if [[ ! -f "$output" ]]; then
+        echo "SKIP: No packed binary"
+        return 0
+    fi
+
+    # Check last 32 bytes for SMOLLIBS magic
+    local magic
+    magic=$(tail -c 32 "$output" | head -c 8 2>/dev/null) || true
+    [[ "$magic" == "SMOLLIBS" ]]
+}
+
 # =============================================================================
 # Packed Binary - Ephemeral Execution (Requires VM)
 # =============================================================================
@@ -625,6 +671,8 @@ run_test "Packed --info" test_packed_info || true
 run_test "Packed --version" test_packed_version || true
 run_test "Packed --help" test_packed_help || true
 run_test "Sidecar has SMOLPACK magic" test_sidecar_has_magic || true
+run_test "Sidecar has no libs (V3)" test_sidecar_has_no_libs || true
+run_test "Stub has SMOLLIBS footer" test_stub_has_libs_footer || true
 run_test "Binary is clean Mach-O" test_binary_is_clean_macho || true
 
 echo ""


### PR DESCRIPTION
Changing the format of .smolmachine, it used to contain kernel libs but that is mostly redundant if there's many .smolmachines. This is a bit of an optimization as I'm working on the machine registry.

So let's move that code to the launcher and keep .smolmachines the data of the vm while the vm environment is the launcher i.e. smolvm.