### PR TITLE
fix: persistence bug when container images are used as overlay -

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,13 +10,21 @@ smolvm machine run --net --image alpine -- echo hello
 smolvm machine run --net -it --image alpine -- /bin/sh   # interactive shell
 smolvm machine run --net --image python:3.12-alpine -- python3 script.py
 
-# Persistent (survives stop/start)
+# Persistent (survives across exec sessions and stop/start)
 smolvm machine create --net myvm
 smolvm machine start --name myvm
-smolvm machine exec --name myvm -- apk add python3
+smolvm machine exec --name myvm -- apk add python3   # installs persist
+smolvm machine exec --name myvm -- which python3      # still there
 smolvm machine exec --name myvm -it -- /bin/sh
 smolvm machine stop --name myvm
 smolvm machine delete myvm
+
+# Image-based persistent (filesystem changes persist across exec sessions)
+smolvm machine create --net --image ubuntu myvm
+smolvm machine start --name myvm
+smolvm machine exec --name myvm -- apt-get update
+smolvm machine exec --name myvm -- apt-get install -y python3
+smolvm machine exec --name myvm -- which python3      # still there after exit+re-exec
 
 # SSH agent forwarding (git/ssh without exposing keys)
 smolvm machine run --ssh-agent --net --image alpine -- ssh-add -l
@@ -38,6 +46,12 @@ smolvm pack create --image python:3.12-alpine -o ./my-python
 | Use git/ssh with private keys safely | Add `--ssh-agent` to run or create |
 | Minimal VM without image | `smolvm machine run -s Smolfile` (bare VM) |
 | Declarative VM config | Create a Smolfile, use `--smolfile`/`-s` flag |
+
+### Persistence Model
+
+- **`machine run`** — ephemeral. All changes are discarded when the command exits.
+- **`machine exec`** — persistent. Filesystem changes (package installs, config edits) persist across exec sessions for the same machine, whether bare or image-based. Changes are stored in an overlay on the machine's storage disk.
+- **`machine stop` + `start`** — bare VMs persist changes across restarts. Image-based VMs remount the persistent overlay, preserving previous changes.
 
 ## CLI Structure
 

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -1078,6 +1078,7 @@ fn handle_request(request: AgentRequest) -> AgentResponse {
             timeout_ms,
             interactive: false,
             tty: false,
+            persistent_overlay_id,
         } => handle_run(
             &image,
             &command,
@@ -1085,6 +1086,7 @@ fn handle_request(request: AgentRequest) -> AgentResponse {
             workdir.as_deref(),
             &mounts,
             timeout_ms,
+            persistent_overlay_id.as_deref(),
         ),
 
         AgentRequest::Run { .. } => {
@@ -1187,30 +1189,46 @@ fn handle_interactive_run(
     stream: &mut impl ReadWrite,
     request: AgentRequest,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let (image, command, env, workdir, mounts, timeout_ms, tty) = match request {
-        AgentRequest::Run {
-            image,
-            command,
-            env,
-            workdir,
-            mounts,
-            timeout_ms,
-            tty,
-            ..
-        } => (image, command, env, workdir, mounts, timeout_ms, tty),
-        _ => {
-            send_response(
-                stream,
-                &AgentResponse::error("expected Run request", error_codes::INVALID_REQUEST),
-            )?;
-            return Ok(());
-        }
-    };
+    let (image, command, env, workdir, mounts, timeout_ms, tty, persistent_overlay_id) =
+        match request {
+            AgentRequest::Run {
+                image,
+                command,
+                env,
+                workdir,
+                mounts,
+                timeout_ms,
+                tty,
+                persistent_overlay_id,
+                ..
+            } => (
+                image,
+                command,
+                env,
+                workdir,
+                mounts,
+                timeout_ms,
+                tty,
+                persistent_overlay_id,
+            ),
+            _ => {
+                send_response(
+                    stream,
+                    &AgentResponse::error("expected Run request", error_codes::INVALID_REQUEST),
+                )?;
+                return Ok(());
+            }
+        };
 
-    info!(image = %image, command = ?command, tty = tty, "starting interactive run");
+    let is_persistent = persistent_overlay_id.is_some();
+    info!(image = %image, command = ?command, tty = tty, persistent = is_persistent, "starting interactive run");
 
     // Prepare the overlay and get the rootfs path
-    let prepared = match storage::prepare_for_run(&image) {
+    let prepared = match &persistent_overlay_id {
+        Some(id) => storage::prepare_for_run_persistent(&image, id),
+        None => storage::prepare_for_run(&image),
+    };
+    let prepared = match prepared {
         Ok(prepared) => prepared,
         Err(e) => {
             send_response(stream, &AgentResponse::from_err(e, error_codes::RUN_FAILED))?;
@@ -1219,8 +1237,15 @@ fn handle_interactive_run(
     };
 
     // Setup virtiofs mounts at staging area (crun will bind-mount them via OCI spec)
+    // Helper: only clean up ephemeral overlays, not persistent ones
+    let maybe_cleanup = |wid: &str| {
+        if !is_persistent {
+            let _ = storage::cleanup_overlay(wid);
+        }
+    };
+
     if let Err(e) = storage::setup_mounts(&prepared.rootfs_path, &mounts) {
-        let _ = storage::cleanup_overlay(&prepared.workload_id);
+        maybe_cleanup(&prepared.workload_id);
         send_response(
             stream,
             &AgentResponse::from_err(e, error_codes::MOUNT_FAILED),
@@ -1239,7 +1264,7 @@ fn handle_interactive_run(
     ) {
         Ok(result) => result,
         Err(e) => {
-            let _ = storage::cleanup_overlay(&prepared.workload_id);
+            maybe_cleanup(&prepared.workload_id);
             send_response(
                 stream,
                 &AgentResponse::from_err(e, error_codes::SPAWN_FAILED),
@@ -1257,14 +1282,14 @@ fn handle_interactive_run(
         Some(pty) => match run_interactive_loop_pty(stream, &mut child, pty, timeout_ms) {
             Ok(exit_code) => exit_code,
             Err(e) => {
-                let _ = storage::cleanup_overlay(&prepared.workload_id);
+                maybe_cleanup(&prepared.workload_id);
                 return Err(e);
             }
         },
         _ => match run_interactive_loop(stream, &mut child, timeout_ms) {
             Ok(exit_code) => exit_code,
             Err(e) => {
-                let _ = storage::cleanup_overlay(&prepared.workload_id);
+                maybe_cleanup(&prepared.workload_id);
                 return Err(e);
             }
         },
@@ -1272,7 +1297,7 @@ fn handle_interactive_run(
 
     // Send Exited response
     send_response(stream, &AgentResponse::Exited { exit_code })?;
-    let _ = storage::cleanup_overlay(&prepared.workload_id);
+    maybe_cleanup(&prepared.workload_id);
 
     Ok(())
 }
@@ -2098,10 +2123,19 @@ fn handle_run(
     workdir: Option<&str>,
     mounts: &[(String, String, bool)],
     timeout_ms: Option<u64>,
+    persistent_overlay_id: Option<&str>,
 ) -> AgentResponse {
-    info!(image = %image, command = ?command, mounts = ?mounts, timeout_ms = ?timeout_ms, "running command");
+    info!(image = %image, command = ?command, mounts = ?mounts, timeout_ms = ?timeout_ms, persistent = persistent_overlay_id.is_some(), "running command");
 
-    match storage::run_command(image, command, env, workdir, mounts, timeout_ms) {
+    match storage::run_command(
+        image,
+        command,
+        env,
+        workdir,
+        mounts,
+        timeout_ms,
+        persistent_overlay_id,
+    ) {
         Ok(result) => AgentResponse::Completed {
             exit_code: result.exit_code,
             stdout: result.stdout,

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -1487,6 +1487,46 @@ impl OverlaySetup {
         self.create_bundle()?;
         Ok(self.into_overlay_info())
     }
+
+    /// Reuse an existing persistent overlay or create a new one.
+    ///
+    /// If the overlay is already mounted, returns it immediately.
+    /// If the overlay directory exists but is not mounted (e.g. after VM restart),
+    /// remounts it preserving the upper layer (which contains previous changes).
+    /// If the overlay does not exist at all, creates it fresh.
+    fn execute_or_remount(self, lowerdirs: Vec<String>) -> Result<OverlayInfo> {
+        // Already mounted — just reuse it
+        if self.merged_path.exists() && is_mountpoint(&self.merged_path) {
+            info!(workload_id = %self.workload_id, "reusing existing persistent overlay");
+            self.create_bundle()?;
+            return Ok(self.into_overlay_info());
+        }
+
+        // Upper layer exists from a previous session — remount preserving it
+        if self.upper_path.exists() {
+            info!(workload_id = %self.workload_id, "remounting persistent overlay with existing upper layer");
+
+            // overlayfs requires an empty work directory at mount time
+            if self.work_path.exists() {
+                let _ = std::fs::remove_dir_all(&self.work_path);
+            }
+            std::fs::create_dir_all(&self.work_path)?;
+            std::fs::create_dir_all(&self.merged_path)?;
+
+            self.verify_layers(&lowerdirs)?;
+            self.mount(&lowerdirs)?;
+
+            let entry_count = self.verify_mount();
+            info!(workload_id = %self.workload_id, entry_count = entry_count, "persistent overlay remounted");
+
+            self.create_bundle()?;
+            return Ok(self.into_overlay_info());
+        }
+
+        // First time — full setup
+        info!(workload_id = %self.workload_id, "creating new persistent overlay");
+        self.execute(lowerdirs)
+    }
 }
 
 /// Prepare an overlay filesystem for a workload.
@@ -1572,6 +1612,56 @@ fn prepare_overlay_from_packed(
 
     // Use shared overlay setup logic
     OverlaySetup::new(workload_id).execute(lowerdirs)
+}
+
+/// Build lowerdir list from a pulled OCI image's layers.
+fn get_image_lowerdirs(image: &str) -> Result<Vec<String>> {
+    let info = query_image(image)?
+        .ok_or_else(|| StorageError::new(format!("image not found: {}", image)))?;
+
+    let root = Path::new(STORAGE_ROOT);
+    Ok(info
+        .layers
+        .iter()
+        .rev()
+        .map(|digest| {
+            let id = digest.strip_prefix("sha256:").unwrap_or(digest);
+            root.join(LAYERS_DIR).join(id).display().to_string()
+        })
+        .collect())
+}
+
+/// Build lowerdir list from pre-packed layer directories.
+fn get_packed_lowerdirs(packed_dir: &Path) -> Result<Vec<String>> {
+    let mut layer_dirs: Vec<PathBuf> = Vec::new();
+
+    let entries = std::fs::read_dir(packed_dir)
+        .map_err(|e| StorageError::read_error(packed_dir.display().to_string(), e))?;
+
+    for entry in entries {
+        let entry: std::fs::DirEntry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if !name.ends_with(".tar") {
+                layer_dirs.push(path);
+            }
+        }
+    }
+
+    if layer_dirs.is_empty() {
+        return Err(StorageError::new(format!(
+            "no layer directories found in {}",
+            packed_dir.display()
+        )));
+    }
+
+    layer_dirs.sort();
+    Ok(layer_dirs
+        .iter()
+        .rev()
+        .map(|path| path.display().to_string())
+        .collect())
 }
 
 /// Clean up an overlay filesystem.
@@ -1678,7 +1768,10 @@ fn prepare_rootfs_for_ephemeral_run(image: &str) -> Result<PreparedOverlayRootfs
 }
 
 /// Run a command in an image's overlay rootfs using crun OCI runtime.
-/// Uses a persistent overlay per image for fast repeated execution.
+///
+/// When `persistent_overlay_id` is `Some`, the overlay persists across runs
+/// (filesystem changes accumulate). When `None`, an ephemeral overlay is
+/// created and destroyed after the run.
 pub fn run_command(
     image: &str,
     command: &[String],
@@ -1686,13 +1779,17 @@ pub fn run_command(
     workdir: Option<&str>,
     mounts: &[(String, String, bool)],
     timeout_ms: Option<u64>,
+    persistent_overlay_id: Option<&str>,
 ) -> Result<RunResult> {
     // Validate inputs
     crate::oci::validate_image_reference(image).map_err(StorageError::new)?;
     crate::oci::validate_env_vars(env).map_err(StorageError::new)?;
 
-    let prepared = prepare_rootfs_for_ephemeral_run(image)?;
-    debug!(rootfs = %prepared.rootfs_path, "using overlay for command execution");
+    let prepared = match persistent_overlay_id {
+        Some(id) => prepare_for_run_persistent(image, id)?,
+        None => prepare_rootfs_for_ephemeral_run(image)?,
+    };
+    debug!(rootfs = %prepared.rootfs_path, persistent = persistent_overlay_id.is_some(), "using overlay for command execution");
 
     // Gather all steps to run a command in a single anon function
     let result = (|| {
@@ -1736,7 +1833,10 @@ pub fn run_command(
         result
     })();
 
-    let _ = cleanup_overlay(&prepared.workload_id);
+    // Only clean up ephemeral overlays; persistent ones survive across runs
+    if persistent_overlay_id.is_none() {
+        let _ = cleanup_overlay(&prepared.workload_id);
+    }
     result
 }
 
@@ -1744,6 +1844,36 @@ pub fn run_command(
 /// This is used by interactive mode which spawns the command separately.
 pub fn prepare_for_run(image: &str) -> Result<PreparedOverlayRootfs> {
     prepare_rootfs_for_ephemeral_run(image)
+}
+
+/// Prepare a persistent overlay that survives across exec sessions.
+///
+/// Uses a deterministic workload ID derived from `overlay_id` (typically the
+/// machine name). If the overlay already exists and is mounted, reuses it.
+/// If it exists but is unmounted (e.g. after VM restart), remounts preserving
+/// the upper layer that contains previous changes.
+pub fn prepare_for_run_persistent(image: &str, overlay_id: &str) -> Result<PreparedOverlayRootfs> {
+    let workload_id = format!("persistent-{}", overlay_id);
+
+    // Resolve image layers (same logic as prepare_overlay)
+    let lowerdirs = if let Some(packed_dir) = get_packed_layers_dir() {
+        get_packed_lowerdirs(&packed_dir)?
+    } else {
+        get_image_lowerdirs(image)?
+    };
+
+    let setup = OverlaySetup::new(&workload_id);
+    let overlay = setup.execute_or_remount(lowerdirs)?;
+
+    debug!(
+        workload_id = %workload_id,
+        rootfs = %overlay.rootfs_path,
+        "prepared persistent overlay for command execution"
+    );
+    Ok(PreparedOverlayRootfs {
+        workload_id,
+        rootfs_path: overlay.rootfs_path,
+    })
 }
 
 /// Setup volume mounts for a rootfs (public wrapper).

--- a/crates/smolvm-protocol/src/lib.rs
+++ b/crates/smolvm-protocol/src/lib.rs
@@ -209,6 +209,12 @@ pub enum AgentRequest {
         /// Enables terminal features like colors, line editing, and signal handling.
         #[serde(default)]
         tty: bool,
+        /// If set, use a persistent overlay that survives across exec sessions.
+        /// The overlay is identified by this ID (typically the machine name)
+        /// and reused on subsequent runs. If not set, an ephemeral overlay is
+        /// created and destroyed after the run.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        persistent_overlay_id: Option<String>,
     },
 
     /// Send stdin data to a running interactive command.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 - Rust toolchain
 - [git-lfs](https://git-lfs.com) (required for library binaries)
-- Docker (for cross-compiling the agent)
+- smolvm itself (for cross-compiling the agent — builds inside a `rust:alpine` VM)
 - e2fsprogs (for storage template creation; `mkfs.ext4`)
 - LLVM (macOS only, for building libkrun: `brew install llvm`)
 - [cargo-make](https://github.com/sagiegurari/cargo-make): `cargo install cargo-make`

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -120,6 +120,9 @@ pub struct RunConfig {
     pub timeout: Option<Duration>,
     /// Whether to allocate a TTY.
     pub tty: bool,
+    /// Persistent overlay ID. If set, the overlay persists across exec sessions
+    /// so filesystem changes (e.g. package installs) survive.
+    pub persistent_overlay_id: Option<String>,
 }
 
 impl RunConfig {
@@ -133,6 +136,7 @@ impl RunConfig {
             mounts: Vec::new(),
             timeout: None,
             tty: false,
+            persistent_overlay_id: None,
         }
     }
 
@@ -163,6 +167,12 @@ impl RunConfig {
     /// Enable TTY mode.
     pub fn with_tty(mut self, tty: bool) -> Self {
         self.tty = tty;
+        self
+    }
+
+    /// Set persistent overlay ID for cross-session filesystem persistence.
+    pub fn with_persistent_overlay(mut self, id: Option<String>) -> Self {
+        self.persistent_overlay_id = id;
         self
     }
 }
@@ -971,87 +981,28 @@ impl AgentClient {
         )
     }
 
-    /// Run a command in an image's rootfs.
+    /// Run a command in an image's rootfs (non-interactive).
     ///
-    /// # Arguments
-    ///
-    /// * `image` - Image reference (must be pulled first)
-    /// * `command` - Command and arguments
-    /// * `env` - Environment variables
-    /// * `workdir` - Working directory inside the rootfs
+    /// This is the non-interactive counterpart to `run_interactive()`.
+    /// Both accept a `RunConfig` for consistency.
     ///
     /// # Returns
     ///
     /// A tuple of (exit_code, stdout, stderr)
-    pub fn run(
-        &mut self,
-        image: &str,
-        command: Vec<String>,
-        env: Vec<(String, String)>,
-        workdir: Option<String>,
-    ) -> Result<(i32, String, String)> {
-        self.run_with_mounts(image, command, env, workdir, Vec::new())
-    }
-
-    /// Run a command in an image's rootfs with volume mounts.
-    ///
-    /// # Arguments
-    ///
-    /// * `image` - Image reference (must be pulled first)
-    /// * `command` - Command and arguments
-    /// * `env` - Environment variables
-    /// * `workdir` - Working directory inside the rootfs
-    /// * `mounts` - Volume mounts as (virtiofs_tag, container_path, read_only)
-    ///
-    /// # Returns
-    ///
-    /// A tuple of (exit_code, stdout, stderr)
-    pub fn run_with_mounts(
-        &mut self,
-        image: &str,
-        command: Vec<String>,
-        env: Vec<(String, String)>,
-        workdir: Option<String>,
-        mounts: Vec<(String, String, bool)>,
-    ) -> Result<(i32, String, String)> {
-        self.run_with_mounts_and_timeout(image, command, env, workdir, mounts, None)
-    }
-
-    /// Run a command in an image's rootfs with volume mounts and optional timeout.
-    ///
-    /// # Arguments
-    ///
-    /// * `image` - Image reference (must be pulled first)
-    /// * `command` - Command and arguments
-    /// * `env` - Environment variables
-    /// * `workdir` - Working directory inside the rootfs
-    /// * `mounts` - Volume mounts as (virtiofs_tag, container_path, read_only)
-    /// * `timeout` - Optional timeout duration. If exceeded, command is killed with exit code 124.
-    ///
-    /// # Returns
-    ///
-    /// A tuple of (exit_code, stdout, stderr)
-    pub fn run_with_mounts_and_timeout(
-        &mut self,
-        image: &str,
-        command: Vec<String>,
-        env: Vec<(String, String)>,
-        workdir: Option<String>,
-        mounts: Vec<(String, String, bool)>,
-        timeout: Option<Duration>,
-    ) -> Result<(i32, String, String)> {
-        let _timeout_guard = self.set_exec_timeout(timeout)?;
-        let timeout_ms = timeout.map(|t| t.as_millis() as u64);
+    pub fn run_non_interactive(&mut self, config: RunConfig) -> Result<(i32, String, String)> {
+        let _timeout_guard = self.set_exec_timeout(config.timeout)?;
+        let timeout_ms = config.timeout.map(|t| t.as_millis() as u64);
 
         let resp = self.request(&AgentRequest::Run {
-            image: image.to_string(),
-            command,
-            env,
-            workdir,
-            mounts,
+            image: config.image,
+            command: config.command,
+            env: config.env,
+            workdir: config.workdir,
+            mounts: config.mounts,
             timeout_ms,
             interactive: false,
             tty: false,
+            persistent_overlay_id: config.persistent_overlay_id,
         })?;
 
         expect_completed(resp, "run command")
@@ -1082,6 +1033,7 @@ impl AgentClient {
                 timeout_ms,
                 interactive: true,
                 tty,
+                persistent_overlay_id: config.persistent_overlay_id,
             },
             tty,
             "run interactive",

--- a/src/api/handlers/exec.rs
+++ b/src/api/handlers/exec.rs
@@ -184,7 +184,12 @@ pub async fn run_command(
     };
 
     let (exit_code, stdout, stderr) = with_machine_client(&entry, move |c| {
-        c.run_with_mounts_and_timeout(&image, command, env, workdir, mounts_config, timeout)
+        let config = crate::agent::RunConfig::new(image, command)
+            .with_env(env)
+            .with_workdir(workdir)
+            .with_mounts(mounts_config)
+            .with_timeout(timeout);
+        c.run_non_interactive(config)
     })
     .await?;
 

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -495,14 +495,12 @@ impl RunCmd {
                         .with_tty(tty);
                     client.run_interactive(config)?
                 } else {
-                    let (exit_code, stdout, stderr) = client.run_with_mounts_and_timeout(
-                        img,
-                        command,
-                        env,
-                        params.workdir.clone(),
-                        mount_bindings,
-                        self.timeout,
-                    )?;
+                    let config = RunConfig::new(img, command)
+                        .with_env(env)
+                        .with_workdir(params.workdir.clone())
+                        .with_mounts(mount_bindings)
+                        .with_timeout(self.timeout);
+                    let (exit_code, stdout, stderr) = client.run_non_interactive(config)?;
                     if !stdout.is_empty() {
                         print!("{}", stdout);
                     }
@@ -703,7 +701,7 @@ impl ExecCmd {
         }
 
         // Check if this machine has an image — if so, exec inside the image's
-        // rootfs via client.run() instead of bare vm_exec().
+        // rootfs via client.run_interactive()/run_non_interactive() instead of bare vm_exec().
         let record_image = {
             let name = self.name.clone().unwrap_or_else(|| "default".to_string());
             smolvm::db::SmolvmDb::open()
@@ -714,6 +712,9 @@ impl ExecCmd {
 
         if let Some(ref image) = record_image {
             // Image-based machine: exec inside the image's rootfs via crun.
+            // Use machine name as persistent overlay ID so filesystem changes
+            // (e.g. package installs) survive across exec sessions.
+            let machine_name = self.name.clone().unwrap_or_else(|| "default".to_string());
             let mount_bindings = vec![]; // mounts were set at create time
             if self.interactive || self.tty {
                 let config = smolvm::agent::RunConfig::new(image, self.command.clone())
@@ -721,20 +722,20 @@ impl ExecCmd {
                     .with_workdir(self.workdir.clone())
                     .with_mounts(mount_bindings)
                     .with_timeout(self.timeout)
-                    .with_tty(self.tty);
+                    .with_tty(self.tty)
+                    .with_persistent_overlay(Some(machine_name.clone()));
                 let exit_code = client.run_interactive(config)?;
                 manager.detach();
                 std::process::exit(exit_code);
             }
 
-            let (exit_code, stdout, stderr) = client.run_with_mounts_and_timeout(
-                image,
-                self.command.clone(),
-                env,
-                self.workdir.clone(),
-                mount_bindings,
-                self.timeout,
-            )?;
+            let config = smolvm::agent::RunConfig::new(image, self.command.clone())
+                .with_env(env)
+                .with_workdir(self.workdir.clone())
+                .with_mounts(mount_bindings)
+                .with_timeout(self.timeout)
+                .with_persistent_overlay(Some(machine_name));
+            let (exit_code, stdout, stderr) = client.run_non_interactive(config)?;
             vm_common::print_output_and_exit(&manager, exit_code, &stdout, &stderr);
         } else {
             // Bare VM: exec directly in the VM rootfs.

--- a/src/cli/pack_run.rs
+++ b/src/cli/pack_run.rs
@@ -649,7 +649,7 @@ fn build_env(manifest: &smolvm_pack::PackManifest, cli_env: &[String]) -> Vec<(S
 
 /// Execute the command in the VM using the existing AgentClient.
 ///
-/// In Container mode, runs via `client.run()` / `client.run_interactive()` (crun container).
+/// In Container mode, runs via `client.run_non_interactive()` / `client.run_interactive()` (crun container).
 /// In VM mode, runs via `client.vm_exec()` / `client.vm_exec_interactive()` (direct in rootfs).
 fn execute_command(
     client: &mut AgentClient,
@@ -729,14 +729,12 @@ fn execute_packed_command(
                     .with_tty(tty);
                 client.run_interactive(config)
             } else {
-                let (exit_code, stdout, stderr) = client.run_with_mounts_and_timeout(
-                    &manifest.image,
-                    command,
-                    env,
-                    workdir,
-                    mount_bindings,
-                    timeout,
-                )?;
+                let config = RunConfig::new(&manifest.image, command)
+                    .with_env(env)
+                    .with_workdir(workdir)
+                    .with_mounts(mount_bindings)
+                    .with_timeout(timeout);
+                let (exit_code, stdout, stderr) = client.run_non_interactive(config)?;
 
                 if !stdout.is_empty() {
                     print!("{}", stdout);


### PR DESCRIPTION
 the underlying smolvm is persisted but uses a new unique id when exec'd. This causes each exec when the image command was used to create the virtual machine to always land on a new overlay