### PR TITLE
fix(cli): keep default VM running after machine images / prune when it was already up

### DIFF
--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -1117,7 +1117,8 @@ impl ImagesCmd {
     pub fn run(self) -> smolvm::Result<()> {
         let manager = AgentManager::new_default()?;
 
-        let mut client = if manager.try_connect_existing().is_some() {
+        let attached_to_existing = manager.try_connect_existing().is_some();
+        let mut client = if attached_to_existing {
             AgentClient::connect_with_retry(manager.vsock_socket())?
         } else {
             println!("Starting machine to query storage...");
@@ -1174,6 +1175,9 @@ impl ImagesCmd {
             }
         }
 
+        if attached_to_existing {
+            manager.detach();
+        }
         Ok(())
     }
 }
@@ -1206,7 +1210,8 @@ impl PruneCmd {
     pub fn run(self) -> smolvm::Result<()> {
         let manager = AgentManager::new_default()?;
 
-        let mut client = if manager.try_connect_existing().is_some() {
+        let attached_to_existing = manager.try_connect_existing().is_some();
+        let mut client = if attached_to_existing {
             AgentClient::connect_with_retry(manager.vsock_socket())?
         } else {
             println!("Starting machine...");
@@ -1219,6 +1224,9 @@ impl PruneCmd {
 
             if images.is_empty() {
                 println!("No cached images to remove.");
+                if attached_to_existing {
+                    manager.detach();
+                }
                 return Ok(());
             }
 
@@ -1266,6 +1274,9 @@ impl PruneCmd {
             }
         }
 
+        if attached_to_existing {
+            manager.detach();
+        }
         Ok(())
     }
 }

--- a/tests/test_machine.sh
+++ b/tests/test_machine.sh
@@ -926,14 +926,18 @@ test_machine_images() {
     $SMOLVM machine create --net default 2>/dev/null || true
     $SMOLVM machine start --name default 2>/dev/null || true
 
-    local output
+    local output list_after
     output=$($SMOLVM machine images 2>&1)
+
+    # Observational command must not stop a VM we attached to (#81)
+    list_after=$($SMOLVM machine ls --json 2>&1)
 
     $SMOLVM machine stop 2>/dev/null || true
     $SMOLVM machine delete default -f 2>/dev/null || true
 
     # Should show storage info
     [[ "$output" == *"Storage"* ]] || [[ "$output" == *"storage"* ]]
+    [[ "$list_after" == *'"state": "running"'* ]]
 }
 
 test_machine_prune_dry_run() {
@@ -942,14 +946,17 @@ test_machine_prune_dry_run() {
     $SMOLVM machine create --net default 2>/dev/null || true
     $SMOLVM machine start --name default 2>/dev/null || true
 
-    local output
+    local output list_after
     output=$($SMOLVM machine prune --dry-run 2>&1)
+
+    list_after=$($SMOLVM machine ls --json 2>&1)
 
     $SMOLVM machine stop 2>/dev/null || true
     $SMOLVM machine delete default -f 2>/dev/null || true
 
     # Should complete without error
     [[ $? -eq 0 ]] || [[ "$output" == *"unreferenced"* ]] || [[ "$output" == *"No unreferenced"* ]]
+    [[ "$list_after" == *'"state": "running"'* ]]
 }
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Call `AgentManager::detach()` after `machine images` and `machine prune` when we attached to an already-running VM (`try_connect_existing()`), so `Drop` does not stop it.
- When this CLI started the VM via `start()`, we do not detach so existing cleanup-on-exit behavior is unchanged.
- Extend shell tests to assert the default machine stays `"running"` after these commands.

Fixes #81