### PR TITLE
feat: virtio-net - add network backend selection plumbing

### DIFF
--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -746,6 +746,7 @@ pub fn resource_spec_to_vm_resources(spec: &ResourceSpec, network: bool) -> VmRe
         cpus: spec.cpus.unwrap_or(DEFAULT_MICROVM_CPU_COUNT),
         memory_mib: spec.memory_mb.unwrap_or(DEFAULT_MICROVM_MEMORY_MIB),
         network,
+        network_backend: None,
         storage_gib: spec.storage_gb,
         overlay_gib: spec.overlay_gb,
         allowed_cidrs: spec.allowed_cidrs.clone(),

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -20,9 +20,41 @@ use smolvm::agent::{docker_config_mount, AgentClient, AgentManager, RunConfig, V
 use smolvm::data::network::PortMapping;
 use smolvm::data::resources::{DEFAULT_MICROVM_CPU_COUNT, DEFAULT_MICROVM_MEMORY_MIB};
 use smolvm::data::storage::HostMount;
+use smolvm::network::{plan_launch_network, NetworkBackend};
 use smolvm::{DEFAULT_IDLE_CMD, DEFAULT_SHELL_CMD};
 use std::path::PathBuf;
 use std::time::Duration;
+
+fn warn_backend_fallback(
+    requested_backend: Option<NetworkBackend>,
+    resources: &VmResources,
+    dns_filter_hosts: Option<&[String]>,
+    port_count: usize,
+) {
+    if requested_backend != Some(NetworkBackend::VirtioNet) {
+        return;
+    }
+
+    let plan = plan_launch_network(resources, dns_filter_hosts, port_count);
+    if let Some(reason) = plan.fallback_reason {
+        eprintln!("warning: {}", reason.user_message());
+    }
+}
+
+fn validate_network_backend_request(
+    requested_backend: Option<NetworkBackend>,
+    net_enabled: bool,
+    port_count: usize,
+) -> smolvm::Result<()> {
+    if requested_backend == Some(NetworkBackend::VirtioNet) && !net_enabled && port_count == 0 {
+        return Err(smolvm::Error::config(
+            "--net-backend",
+            "--net-backend virtio requires --net",
+        ));
+    }
+
+    Ok(())
+}
 
 /// Resolve `--allow-cidr`, `--allow-host`, and `--outbound-localhost-only` into a CIDR list,
 /// net flag, and the original hostname list (for DNS filtering).
@@ -215,6 +247,15 @@ pub struct RunCmd {
     #[arg(long, help_heading = "Network")]
     pub net: bool,
 
+    /// Select the networking backend.
+    #[arg(
+        long = "net-backend",
+        value_enum,
+        hide = true,
+        help_heading = "Network"
+    )]
+    pub net_backend: Option<NetworkBackend>,
+
     /// Allow egress to specific CIDR range (can be used multiple times, implies --net)
     #[arg(long = "allow-cidr", value_parser = parse_cidr, value_name = "CIDR", help_heading = "Network")]
     pub allow_cidr: Vec<String>,
@@ -265,7 +306,7 @@ impl RunCmd {
     pub fn run(self) -> smolvm::Result<()> {
         use smolvm::Error;
 
-        let (cli_allow_cidrs, net, dns_filter_hosts) = resolve_egress_flags(
+        let (cli_allow_cidrs, net, cli_dns_filter_hosts) = resolve_egress_flags(
             self.allow_cidr,
             self.allow_host,
             self.outbound_localhost_only,
@@ -282,6 +323,7 @@ impl RunCmd {
             self.volume,
             self.port,
             net,
+            self.net_backend,
             vec![],
             self.env,
             self.workdir,
@@ -290,6 +332,17 @@ impl RunCmd {
             self.overlay,
             cli_allow_cidrs,
         )?;
+
+        let mut params = params;
+        params.dns_filter_hosts = match (params.dns_filter_hosts.take(), cli_dns_filter_hosts) {
+            (Some(mut from_smolfile), Some(mut from_cli)) => {
+                from_smolfile.append(&mut from_cli);
+                Some(from_smolfile)
+            }
+            (Some(from_smolfile), None) => Some(from_smolfile),
+            (None, some) => some,
+        };
+        validate_network_backend_request(params.network_backend, params.net, params.port.len())?;
 
         let mut mounts = HostMount::parse(&params.volume)?;
         let ports = params.port.clone();
@@ -325,10 +378,17 @@ impl RunCmd {
             cpus: params.cpus,
             memory_mib: params.mem,
             network: params.net,
+            network_backend: params.network_backend,
             storage_gib: params.storage_gb,
             overlay_gib: params.overlay_gb,
             allowed_cidrs: params.allowed_cidrs.clone(),
         };
+        warn_backend_fallback(
+            params.network_backend,
+            &resources,
+            params.dns_filter_hosts.as_deref(),
+            params.port.len(),
+        );
 
         let manager = AgentManager::new_default_with_sizes(params.storage_gb, params.overlay_gb)
             .map_err(|e| Error::agent("create agent manager", e.to_string()))?;
@@ -356,7 +416,7 @@ impl RunCmd {
 
         let features = smolvm::agent::LaunchFeatures {
             ssh_agent_socket,
-            dns_filter_hosts,
+            dns_filter_hosts: params.dns_filter_hosts.clone(),
         };
 
         let freshly_started = manager
@@ -475,8 +535,10 @@ impl RunCmd {
                                 mounts: mount_tuples,
                                 ports: port_tuples,
                                 network: params.net,
+                                network_backend: params.network_backend,
                                 storage_gb: params.storage_gb,
                                 overlay_gb: params.overlay_gb,
+                                allowed_cidrs: params.allowed_cidrs.clone(),
                                 init: params.init.clone(),
                                 env: parse_env_list(&params.env),
                                 workdir: params.workdir.clone(),
@@ -484,6 +546,7 @@ impl RunCmd {
                                 entrypoint: params.entrypoint.clone(),
                                 cmd: params.cmd.clone(),
                                 ssh_agent: self.ssh_agent || params.ssh_agent,
+                                dns_filter_hosts: params.dns_filter_hosts.clone(),
                             }),
                         );
                     }
@@ -581,8 +644,10 @@ impl RunCmd {
                                 mounts: mount_tuples,
                                 ports: port_tuples,
                                 network: params.net,
+                                network_backend: params.network_backend,
                                 storage_gb: params.storage_gb,
                                 overlay_gb: params.overlay_gb,
+                                allowed_cidrs: params.allowed_cidrs.clone(),
                                 init: params.init.clone(),
                                 env: parse_env_list(&params.env),
                                 workdir: params.workdir.clone(),
@@ -590,6 +655,7 @@ impl RunCmd {
                                 entrypoint: params.entrypoint.clone(),
                                 cmd: params.cmd.clone(),
                                 ssh_agent: self.ssh_agent || params.ssh_agent,
+                                dns_filter_hosts: params.dns_filter_hosts.clone(),
                             }),
                         );
                     }
@@ -837,6 +903,10 @@ pub struct CreateCmd {
     #[arg(long)]
     pub net: bool,
 
+    /// Select the networking backend.
+    #[arg(long = "net-backend", value_enum, hide = true)]
+    pub net_backend: Option<NetworkBackend>,
+
     /// Allow egress to specific CIDR range (can be used multiple times, implies --net)
     #[arg(long = "allow-cidr", value_parser = parse_cidr, value_name = "CIDR")]
     pub allow_cidr: Vec<String>,
@@ -872,7 +942,7 @@ pub struct CreateCmd {
 
 impl CreateCmd {
     pub fn run(self) -> smolvm::Result<()> {
-        let (cli_allow_cidrs, net, _dns_filter_hosts) = resolve_egress_flags(
+        let (cli_allow_cidrs, net, cli_dns_filter_hosts) = resolve_egress_flags(
             self.allow_cidr,
             self.allow_host,
             self.outbound_localhost_only,
@@ -893,6 +963,7 @@ impl CreateCmd {
             self.volume,
             self.port,
             net,
+            self.net_backend,
             self.init,
             self.env,
             self.workdir,
@@ -902,6 +973,30 @@ impl CreateCmd {
             cli_allow_cidrs,
         )?;
         let mut params = params;
+        params.dns_filter_hosts = match (params.dns_filter_hosts.take(), cli_dns_filter_hosts) {
+            (Some(mut from_smolfile), Some(mut from_cli)) => {
+                from_smolfile.append(&mut from_cli);
+                Some(from_smolfile)
+            }
+            (Some(from_smolfile), None) => Some(from_smolfile),
+            (None, some) => some,
+        };
+        validate_network_backend_request(params.network_backend, params.net, params.port.len())?;
+        let resources = VmResources {
+            cpus: params.cpus,
+            memory_mib: params.mem,
+            network: params.net,
+            network_backend: params.network_backend,
+            storage_gib: params.storage_gb,
+            overlay_gib: params.overlay_gb,
+            allowed_cidrs: params.allowed_cidrs.clone(),
+        };
+        warn_backend_fallback(
+            params.network_backend,
+            &resources,
+            params.dns_filter_hosts.as_deref(),
+            params.port.len(),
+        );
         if self.ssh_agent {
             params.ssh_agent = true;
         }

--- a/src/cli/pack.rs
+++ b/src/cli/pack.rs
@@ -245,6 +245,7 @@ impl PackCreateCmd {
                 cpus: 2,
                 memory_mib: 512,
                 network: true,
+                network_backend: None,
                 storage_gib: None,
                 overlay_gib: None,
                 allowed_cidrs: None,

--- a/src/cli/pack_run.rs
+++ b/src/cli/pack_run.rs
@@ -16,6 +16,7 @@ use smolvm::agent::launcher_dynamic::{
 use smolvm::agent::{AgentClient, RunConfig, VmResources};
 use smolvm::data::network::PortMapping;
 use smolvm::data::storage::HostMount;
+use smolvm::network::{plan_launch_network, NetworkBackend};
 use smolvm::Error;
 use smolvm::DEFAULT_SHELL_CMD;
 use smolvm_pack::detect::PackedMode;
@@ -29,6 +30,36 @@ use std::time::Duration;
 
 /// Timeout waiting for the agent to become ready.
 const AGENT_READY_TIMEOUT: Duration = Duration::from_secs(30);
+
+fn warn_backend_fallback(
+    requested_backend: Option<NetworkBackend>,
+    resources: &VmResources,
+    port_count: usize,
+) {
+    if requested_backend != Some(NetworkBackend::VirtioNet) {
+        return;
+    }
+
+    let plan = plan_launch_network(resources, None, port_count);
+    if let Some(reason) = plan.fallback_reason {
+        eprintln!("warning: {}", reason.user_message());
+    }
+}
+
+fn validate_network_backend_request(
+    requested_backend: Option<NetworkBackend>,
+    net_enabled: bool,
+    port_count: usize,
+) -> smolvm::Result<()> {
+    if requested_backend == Some(NetworkBackend::VirtioNet) && !net_enabled && port_count == 0 {
+        return Err(Error::config(
+            "--net-backend",
+            "--net-backend virtio requires --net",
+        ));
+    }
+
+    Ok(())
+}
 
 /// Resolve the lib directory containing libkrun/libkrunfw.
 ///
@@ -161,6 +192,15 @@ pub struct PackRunCmd {
     /// Enable outbound network access
     #[arg(long, help_heading = "Network")]
     pub net: bool,
+
+    /// Select the networking backend.
+    #[arg(
+        long = "net-backend",
+        value_enum,
+        hide = true,
+        help_heading = "Network"
+    )]
+    pub net_backend: Option<NetworkBackend>,
 
     /// Number of virtual CPUs (overrides manifest default)
     #[arg(long, value_name = "N", help_heading = "Resources")]
@@ -312,15 +352,18 @@ impl PackRunCmd {
         // 7. Parse CLI args
         let mounts = HostMount::parse(&self.volume)?;
         let port_mappings = PortMapping::to_tuples(&self.port);
+        validate_network_backend_request(self.net_backend, self.net, self.port.len())?;
 
         let resources = VmResources {
             cpus: self.cpus.unwrap_or(manifest.cpus),
             memory_mib: self.mem.unwrap_or(manifest.mem),
             network: self.net || !self.port.is_empty(),
+            network_backend: self.net_backend,
             storage_gib: self.storage,
             overlay_gib: self.overlay,
             allowed_cidrs: None,
         };
+        warn_backend_fallback(self.net_backend, &resources, self.port.len());
 
         // Build packed mounts for the launcher
         let packed_mounts = mounts_to_packed(&mounts);
@@ -831,6 +874,10 @@ struct PackedRunArgs {
     #[arg(long)]
     net: bool,
 
+    /// Select the networking backend.
+    #[arg(long = "net-backend", value_enum, hide = true)]
+    net_backend: Option<NetworkBackend>,
+
     /// Number of vCPUs (overrides default)
     #[arg(long, value_name = "N")]
     cpus: Option<u8>,
@@ -878,6 +925,10 @@ struct PackedStartArgs {
     /// Enable outbound network access
     #[arg(long)]
     net: bool,
+
+    /// Select the networking backend.
+    #[arg(long = "net-backend", value_enum, hide = true)]
+    net_backend: Option<NetworkBackend>,
 }
 
 /// Arguments for the `exec` subcommand (run in existing VM).
@@ -1004,6 +1055,7 @@ fn run_ephemeral(
                 volume: args.volume,
                 port: args.port,
                 net: args.net,
+                net_backend: args.net_backend,
                 cpus: args.cpus,
                 mem: args.mem,
                 storage: args.storage,
@@ -1124,15 +1176,18 @@ fn run_from_cache(
 
     let mounts = HostMount::parse(&args.volume)?;
     let port_mappings = PortMapping::to_tuples(&args.port);
+    validate_network_backend_request(args.net_backend, args.net, args.port.len())?;
 
     let resources = VmResources {
         cpus: args.cpus.unwrap_or(manifest.cpus),
         memory_mib: args.mem.unwrap_or(manifest.mem),
         network: args.net || !args.port.is_empty(),
+        network_backend: args.net_backend,
         storage_gib: args.storage,
         overlay_gib: args.overlay,
         allowed_cidrs: None,
     };
+    warn_backend_fallback(args.net_backend, &resources, args.port.len());
 
     let packed_mounts = mounts_to_packed(&mounts);
 
@@ -1441,15 +1496,18 @@ fn daemon_start(
     // Parse CLI args
     let mounts = HostMount::parse(&args.volume)?;
     let port_mappings = PortMapping::to_tuples(&args.port);
+    validate_network_backend_request(args.net_backend, args.net, args.port.len())?;
 
     let resources = VmResources {
         cpus: args.cpus.unwrap_or(manifest.cpus),
         memory_mib: args.mem.unwrap_or(manifest.mem),
         network: args.net || !args.port.is_empty(),
+        network_backend: args.net_backend,
         storage_gib: args.storage,
         overlay_gib: args.overlay,
         allowed_cidrs: None,
     };
+    warn_backend_fallback(args.net_backend, &resources, args.port.len());
 
     let packed_mounts = mounts_to_packed(&mounts);
 

--- a/src/cli/smolfile.rs
+++ b/src/cli/smolfile.rs
@@ -8,6 +8,7 @@ use crate::cli::parsers::parse_cidr;
 use crate::cli::vm_common::CreateVmParams;
 use smolvm::data::network::PortMapping;
 use smolvm::data::resources::{DEFAULT_MICROVM_CPU_COUNT, DEFAULT_MICROVM_MEMORY_MIB};
+use smolvm::network::NetworkBackend;
 use std::path::PathBuf;
 
 // Re-export from the library
@@ -40,6 +41,7 @@ pub fn build_create_params(
     cli_volume: Vec<String>,
     cli_port: Vec<PortMapping>,
     cli_net: bool,
+    cli_network_backend: Option<NetworkBackend>,
     cli_init: Vec<String>,
     cli_env: Vec<String>,
     cli_workdir: Option<String>,
@@ -64,6 +66,7 @@ pub fn build_create_params(
                 volume: cli_volume,
                 port: cli_port,
                 net,
+                network_backend: cli_network_backend,
                 init: cli_init,
                 env: cli_env,
                 workdir: cli_workdir,
@@ -251,6 +254,7 @@ pub fn build_create_params(
         volume: volumes,
         port: ports,
         net,
+        network_backend: cli_network_backend,
         init,
         env,
         workdir,

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -12,6 +12,7 @@ use smolvm::data::resources::{DEFAULT_MICROVM_CPU_COUNT, DEFAULT_MICROVM_MEMORY_
 use smolvm::data::storage::HostMount;
 use smolvm::data::validate_vm_name;
 use smolvm::db::SmolvmDb;
+use smolvm::network::NetworkBackend;
 use smolvm::storage::{DEFAULT_OVERLAY_SIZE_GIB, DEFAULT_STORAGE_SIZE_GIB};
 
 // ============================================================================
@@ -114,6 +115,7 @@ pub struct CreateVmParams {
     pub volume: Vec<String>,
     pub port: Vec<PortMapping>,
     pub net: bool,
+    pub network_backend: Option<NetworkBackend>,
     pub init: Vec<String>,
     pub env: Vec<String>,
     pub workdir: Option<String>,
@@ -185,6 +187,7 @@ pub fn create_vm(params: CreateVmParams) -> smolvm::Result<()> {
     record.storage_gb = params.storage_gb;
     record.overlay_gb = params.overlay_gb;
     record.allowed_cidrs = params.allowed_cidrs.clone();
+    record.network_backend = params.network_backend;
     record.image = params.image.clone();
     record.entrypoint = params.entrypoint.clone();
     record.cmd = params.cmd.clone();
@@ -402,8 +405,10 @@ pub fn persist_default_running(
                 r.mounts = o.mounts.clone();
                 r.ports = o.ports.clone();
                 r.network = o.network;
+                r.network_backend = o.network_backend;
                 r.storage_gb = o.storage_gb;
                 r.overlay_gb = o.overlay_gb;
+                r.allowed_cidrs = o.allowed_cidrs.clone();
                 r.init = o.init.clone();
                 r.env = o.env.clone();
                 r.workdir = o.workdir.clone();
@@ -411,6 +416,7 @@ pub fn persist_default_running(
                 r.entrypoint = o.entrypoint.clone();
                 r.cmd = o.cmd.clone();
                 r.ssh_agent = o.ssh_agent;
+                r.dns_filter_hosts = o.dns_filter_hosts.clone();
             }
         })
         .is_none()
@@ -426,8 +432,10 @@ pub struct DefaultVmOverrides {
     pub mounts: Vec<(String, String, bool)>,
     pub ports: Vec<(u16, u16)>,
     pub network: bool,
+    pub network_backend: Option<NetworkBackend>,
     pub storage_gb: Option<u64>,
     pub overlay_gb: Option<u64>,
+    pub allowed_cidrs: Option<Vec<String>>,
     pub init: Vec<String>,
     pub env: Vec<(String, String)>,
     pub workdir: Option<String>,
@@ -435,6 +443,7 @@ pub struct DefaultVmOverrides {
     pub entrypoint: Vec<String>,
     pub cmd: Vec<String>,
     pub ssh_agent: bool,
+    pub dns_filter_hosts: Option<Vec<String>>,
 }
 
 /// Start the default machine.

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@ use crate::data::network::DEFAULT_DNS;
 use crate::data::resources::{DEFAULT_MICROVM_CPU_COUNT, DEFAULT_MICROVM_MEMORY_MIB};
 use crate::db::SmolvmDb;
 use crate::error::Result;
+use crate::network::NetworkBackend;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -386,6 +387,10 @@ pub struct VmRecord {
     #[serde(default)]
     pub allowed_cidrs: Option<Vec<String>>,
 
+    /// Preferred network backend override for machine launch.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network_backend: Option<NetworkBackend>,
+
     /// OCI image for auto-container creation on start.
     #[serde(default)]
     pub image: Option<String>,
@@ -469,6 +474,7 @@ impl VmRecord {
             storage_gb: None,
             overlay_gb: None,
             allowed_cidrs: None,
+            network_backend: None,
             image: None,
             entrypoint: Vec::new(),
             cmd: Vec::new(),
@@ -512,6 +518,7 @@ impl VmRecord {
             storage_gb: None,
             overlay_gb: None,
             allowed_cidrs: None,
+            network_backend: None,
             image: None,
             entrypoint: Vec::new(),
             cmd: Vec::new(),
@@ -577,6 +584,7 @@ impl VmRecord {
             cpus: self.cpus,
             memory_mib: self.mem,
             network: self.network,
+            network_backend: self.network_backend,
             storage_gib: self.storage_gb,
             overlay_gib: self.overlay_gb,
             allowed_cidrs: self.allowed_cidrs.clone(),

--- a/src/data/resources.rs
+++ b/src/data/resources.rs
@@ -7,6 +7,8 @@ pub const DEFAULT_MICROVM_CPU_COUNT: u8 = 4;
 /// reservation — the host only consumes what the guest actually uses.
 pub const DEFAULT_MICROVM_MEMORY_MIB: u32 = 8192;
 
+use crate::network::NetworkBackend;
+
 /// Resources available to a micro vm.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct VmResources {
@@ -16,6 +18,9 @@ pub struct VmResources {
     pub memory_mib: u32,
     /// Enable outbound network access (TSI).
     pub network: bool,
+    /// Preferred network backend override.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network_backend: Option<NetworkBackend>,
     /// Storage disk size in GiB (None = default 20 GiB).
     pub storage_gib: Option<u64>,
     /// Overlay disk size in GiB (None = default 10 GiB).
@@ -31,6 +36,7 @@ impl Default for VmResources {
             cpus: DEFAULT_MICROVM_CPU_COUNT,
             memory_mib: DEFAULT_MICROVM_MEMORY_MIB,
             network: false,
+            network_backend: None,
             storage_gib: None,
             overlay_gib: None,
             allowed_cidrs: None,

--- a/src/network/backend.rs
+++ b/src/network/backend.rs
@@ -1,0 +1,58 @@
+use clap::ValueEnum;
+
+/// virtio-net checksum offload feature bit.
+pub const NET_FEATURE_CSUM: u32 = 1 << 0;
+/// virtio-net guest checksum offload feature bit.
+pub const NET_FEATURE_GUEST_CSUM: u32 = 1 << 1;
+/// virtio-net guest TCP segmentation offload for IPv4.
+pub const NET_FEATURE_GUEST_TSO4: u32 = 1 << 7;
+/// virtio-net guest UDP fragmentation offload.
+pub const NET_FEATURE_GUEST_UFO: u32 = 1 << 10;
+/// virtio-net host TCP segmentation offload for IPv4.
+pub const NET_FEATURE_HOST_TSO4: u32 = 1 << 11;
+/// virtio-net host UDP fragmentation offload.
+pub const NET_FEATURE_HOST_UFO: u32 = 1 << 14;
+/// libkrun's compatibility feature set for unixstream-backed virtio-net.
+pub const COMPAT_NET_FEATURES: u32 = NET_FEATURE_CSUM
+    | NET_FEATURE_GUEST_CSUM
+    | NET_FEATURE_GUEST_TSO4
+    | NET_FEATURE_GUEST_UFO
+    | NET_FEATURE_HOST_TSO4
+    | NET_FEATURE_HOST_UFO;
+
+/// Network backend override for machine launch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+pub enum NetworkBackend {
+    /// Use libkrun TSI networking.
+    #[value(name = "tsi")]
+    Tsi,
+    /// Use virtio-net with the host-side smolvm network stack.
+    #[serde(rename = "virtio")]
+    #[value(name = "virtio")]
+    VirtioNet,
+}
+
+impl NetworkBackend {
+    /// Stable CLI/storage label for the backend.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Tsi => "tsi",
+            Self::VirtioNet => "virtio",
+        }
+    }
+
+    /// Human-readable backend label for logs.
+    pub const fn log_label(self) -> &'static str {
+        match self {
+            Self::Tsi => "tsi",
+            Self::VirtioNet => "virtio-net",
+        }
+    }
+}
+
+impl std::fmt::Display for NetworkBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}

--- a/src/network/launch.rs
+++ b/src/network/launch.rs
@@ -1,0 +1,153 @@
+use crate::data::resources::VmResources;
+use crate::network::backend::NetworkBackend;
+
+/// Effective backend selected for a launch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EffectiveNetworkBackend {
+    /// No network device.
+    None,
+    /// TSI networking.
+    Tsi,
+    /// Virtio-net networking.
+    VirtioNet,
+}
+
+/// Reason a requested backend was downgraded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NetworkFallbackReason {
+    /// Port publishing is only implemented on TSI.
+    PortsRequireTsi,
+    /// Current egress policies and DNS filtering are only implemented on TSI.
+    PolicyRequiresTsi,
+}
+
+impl NetworkFallbackReason {
+    /// User-facing explanation for the fallback.
+    pub const fn user_message(self) -> &'static str {
+        match self {
+            Self::PortsRequireTsi => {
+                "port publishing still uses the TSI backend; falling back from virtio"
+            }
+            Self::PolicyRequiresTsi => {
+                "allow-cidr/allow-host policies still use the TSI backend; falling back from virtio"
+            }
+        }
+    }
+}
+
+/// Network launch decision for a VM.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LaunchNetworkPlan {
+    /// Selected backend.
+    pub backend: EffectiveNetworkBackend,
+    /// Downgrade reason when a requested backend cannot be honored.
+    pub fallback_reason: Option<NetworkFallbackReason>,
+}
+
+impl LaunchNetworkPlan {
+    /// Whether the launch should attach any network backend at all.
+    pub const fn has_network(self) -> bool {
+        !matches!(self.backend, EffectiveNetworkBackend::None)
+    }
+}
+
+/// Compute the effective launch backend from user intent and current feature support.
+pub fn plan_launch_network(
+    resources: &VmResources,
+    dns_filter_hosts: Option<&[String]>,
+    port_count: usize,
+) -> LaunchNetworkPlan {
+    let has_ports = port_count > 0;
+    let has_cidr_policy = resources
+        .allowed_cidrs
+        .as_ref()
+        .is_some_and(|cidrs| !cidrs.is_empty());
+    let has_dns_filter = dns_filter_hosts.is_some_and(|hosts| !hosts.is_empty());
+    let has_policy = has_cidr_policy || has_dns_filter;
+    let wants_network = resources.network || has_ports || has_policy;
+
+    if !wants_network {
+        return LaunchNetworkPlan {
+            backend: EffectiveNetworkBackend::None,
+            fallback_reason: None,
+        };
+    }
+
+    match resources.network_backend.unwrap_or(NetworkBackend::Tsi) {
+        NetworkBackend::Tsi => LaunchNetworkPlan {
+            backend: EffectiveNetworkBackend::Tsi,
+            fallback_reason: None,
+        },
+        NetworkBackend::VirtioNet if has_ports => LaunchNetworkPlan {
+            backend: EffectiveNetworkBackend::Tsi,
+            fallback_reason: Some(NetworkFallbackReason::PortsRequireTsi),
+        },
+        NetworkBackend::VirtioNet if has_policy => LaunchNetworkPlan {
+            backend: EffectiveNetworkBackend::Tsi,
+            fallback_reason: Some(NetworkFallbackReason::PolicyRequiresTsi),
+        },
+        NetworkBackend::VirtioNet => LaunchNetworkPlan {
+            backend: EffectiveNetworkBackend::VirtioNet,
+            fallback_reason: None,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn resources() -> VmResources {
+        VmResources::default()
+    }
+
+    #[test]
+    fn test_no_network_plan() {
+        let plan = plan_launch_network(&resources(), None, 0);
+        assert_eq!(plan.backend, EffectiveNetworkBackend::None);
+    }
+
+    #[test]
+    fn test_default_network_uses_tsi() {
+        let mut resources = resources();
+        resources.network = true;
+        let plan = plan_launch_network(&resources, None, 0);
+        assert_eq!(plan.backend, EffectiveNetworkBackend::Tsi);
+    }
+
+    #[test]
+    fn test_virtio_selected_for_plain_egress() {
+        let mut resources = resources();
+        resources.network = true;
+        resources.network_backend = Some(NetworkBackend::VirtioNet);
+        let plan = plan_launch_network(&resources, None, 0);
+        assert_eq!(plan.backend, EffectiveNetworkBackend::VirtioNet);
+    }
+
+    #[test]
+    fn test_ports_force_tsi() {
+        let mut resources = resources();
+        resources.network = true;
+        resources.network_backend = Some(NetworkBackend::VirtioNet);
+        let plan = plan_launch_network(&resources, None, 1);
+        assert_eq!(plan.backend, EffectiveNetworkBackend::Tsi);
+        assert_eq!(
+            plan.fallback_reason,
+            Some(NetworkFallbackReason::PortsRequireTsi)
+        );
+    }
+
+    #[test]
+    fn test_policy_forces_tsi() {
+        let mut resources = resources();
+        resources.network = true;
+        resources.network_backend = Some(NetworkBackend::VirtioNet);
+        resources.allowed_cidrs = Some(vec!["1.1.1.1/32".into()]);
+        let plan = plan_launch_network(&resources, None, 0);
+        assert_eq!(plan.backend, EffectiveNetworkBackend::Tsi);
+        assert_eq!(
+            plan.fallback_reason,
+            Some(NetworkFallbackReason::PolicyRequiresTsi)
+        );
+    }
+}

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -1,0 +1,13 @@
+//! Network configuration and backend selection.
+
+/// Backend selection and serialization helpers.
+pub mod backend;
+/// Launch-time backend planning and fallback rules.
+pub mod launch;
+pub mod policy;
+
+pub use backend::NetworkBackend;
+pub use launch::{
+    plan_launch_network, EffectiveNetworkBackend, LaunchNetworkPlan, NetworkFallbackReason,
+};
+pub use policy::get_dns_server;

--- a/src/network/policy.rs
+++ b/src/network/policy.rs
@@ -1,6 +1,4 @@
-//! Network configuration.
-//!
-//! This module provides network policy configuration for VMs.
+//! Network policy helpers.
 
 use crate::data::network::DEFAULT_DNS_ADDR;
 use crate::vm::config::NetworkPolicy;
@@ -20,10 +18,8 @@ mod tests {
 
     #[test]
     fn test_get_dns_server() {
-        // None policy returns no DNS
         assert!(get_dns_server(&NetworkPolicy::None).is_none());
 
-        // Egress with default DNS
         let dns = get_dns_server(&NetworkPolicy::Egress {
             dns: None,
             allowed_cidrs: None,
@@ -31,7 +27,6 @@ mod tests {
         .unwrap();
         assert_eq!(dns.to_string(), crate::data::network::DEFAULT_DNS);
 
-        // Egress with custom DNS
         let custom: IpAddr = "8.8.8.8".parse().unwrap();
         let dns = get_dns_server(&NetworkPolicy::Egress {
             dns: Some(custom),


### PR DESCRIPTION
### Why
The virtio-net MVP needs an explicit backend choice without changing the default TSI behavior. That choice has to flow through machine state and CLI entrypoints before the launcher can act on it.

### What
- move the old network helper into src/network/policy.rs and add a dedicated src/network module.
- add NetworkBackend plus launch-time fallback planning for ports and policy-driven TSI cases\n- persist network_backend on VmResources and VmRecord
- plumb hidden --net-backend through machine and pack CLI flows and warn when virtio requests fall back to TSI

### Next
- teach the guest agent how to configure eth0 for the virtio-net path once the host passes network settings in.