### PR TITLE
chores: remove duplicate code in storagedisk and overlaydisk

### DIFF
--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -26,18 +26,29 @@ use axum::{
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::agent::{AgentManager, HostMount};
+use crate::agent::{AgentClient, AgentManager, HostMount};
 use crate::api::error::ApiError;
-use crate::api::state::{ApiState, MachineEntry};
+use crate::api::state::{
+    vm_resources_to_spec, ApiState, MachineEntry, MachineRegistration, ReservationGuard,
+};
 use crate::api::types::{
     ApiErrorResponse, CreateMachineRequest, DeleteResponse, EnvVar, ExecResponse,
-    ListMachinesResponse, MachineExecRequest, MachineInfo, MountSpec, PortSpec,
+    ListMachinesResponse, MachineExecRequest, MachineInfo, MountInfo, MountSpec, PortSpec,
     ResizeMachineRequest, ResourceSpec,
 };
 use crate::api::validate_command;
 use crate::api::TraceId;
 use crate::config::{RecordState, RestartConfig, VmRecord};
 use crate::data::validate_vm_name;
+use crate::process::{
+    is_alive, is_our_process_strict, process_start_time, stop_vm_process, VM_SIGKILL_TIMEOUT,
+    VM_SIGTERM_TIMEOUT,
+};
+use crate::storage::{
+    expand_disk, Overlay, Storage, DEFAULT_OVERLAY_SIZE_GIB, DEFAULT_STORAGE_SIZE_GIB,
+};
+use crate::util::generate_machine_name;
+use crate::Error as SmolvmError;
 
 /// Re-export of the shared resolver. The CLI and API list endpoints
 /// must compute state the same way, otherwise `machine list` (CLI)
@@ -66,19 +77,17 @@ fn record_to_info(name: &str, record: &VmRecord) -> MachineInfo {
             .mounts
             .iter()
             .enumerate()
-            .map(
-                |(i, (source, target, readonly))| crate::api::types::MountInfo {
-                    tag: crate::data::storage::HostMount::mount_tag(i),
-                    source: source.clone(),
-                    target: target.clone(),
-                    readonly: *readonly,
-                },
-            )
+            .map(|(i, (source, target, readonly))| MountInfo {
+                tag: HostMount::mount_tag(i),
+                source: source.clone(),
+                target: target.clone(),
+                readonly: *readonly,
+            })
             .collect(),
         ports: record
             .ports
             .iter()
-            .map(|(host, guest)| crate::api::types::PortSpec {
+            .map(|(host, guest)| PortSpec {
                 host: *host,
                 guest: *guest,
             })
@@ -117,7 +126,7 @@ fn machine_entry_from_record(record: &VmRecord, manager: AgentManager) -> Machin
         manager,
         mounts,
         ports,
-        resources: crate::api::state::vm_resources_to_spec(record.vm_resources()),
+        resources: vm_resources_to_spec(record.vm_resources()),
         restart: record.restart.clone(),
         network: record.network,
     }
@@ -134,7 +143,7 @@ fn shutdown_machine_process(name: &str, pid: Option<i32>, pid_start_time: Option
     let manager = AgentManager::for_vm(name).ok();
     let mut vsock_confirmed = false;
     if let Some(ref manager) = manager {
-        if let Ok(mut client) = crate::agent::AgentClient::connect(manager.vsock_socket()) {
+        if let Ok(mut client) = AgentClient::connect(manager.vsock_socket()) {
             vsock_confirmed = true;
             let _ = client.shutdown();
         }
@@ -146,28 +155,23 @@ fn shutdown_machine_process(name: &str, pid: Option<i32>, pid_start_time: Option
         // We intentionally do NOT use the lenient is_our_process() here because
         // it treats any alive PID as "ours" when start_time is None — which risks
         // killing an unrelated process if the OS reused the PID.
-        let identity_ok =
-            vsock_confirmed || crate::process::is_our_process_strict(pid, pid_start_time);
+        let identity_ok = vsock_confirmed || is_our_process_strict(pid, pid_start_time);
 
         if identity_ok {
-            let _ = crate::process::stop_vm_process(
-                pid,
-                crate::process::VM_SIGTERM_TIMEOUT,
-                crate::process::VM_SIGKILL_TIMEOUT,
-            );
+            let _ = stop_vm_process(pid, VM_SIGTERM_TIMEOUT, VM_SIGKILL_TIMEOUT);
         } else {
             tracing::debug!(pid, name, "PID already dead");
         }
 
         // Post-check: verify the process is actually gone.
-        if crate::process::is_alive(pid) {
+        if is_alive(pid) {
             tracing::warn!(pid, name, "process still alive after shutdown attempts");
             return false;
         }
     } else {
         // No PID available — check if VM is still reachable via vsock.
         if let Some(ref manager) = manager {
-            if let Ok(mut client) = crate::agent::AgentClient::connect(manager.vsock_socket()) {
+            if let Ok(mut client) = AgentClient::connect(manager.vsock_socket()) {
                 if client.ping().is_ok() {
                     tracing::warn!(name, "VM still reachable via vsock but no PID to signal");
                     return false;
@@ -195,13 +199,8 @@ pub async fn create_machine(
     State(state): State<Arc<ApiState>>,
     Json(req): Json<CreateMachineRequest>,
 ) -> Result<Json<MachineInfo>, ApiError> {
-    use crate::api::state::{MachineRegistration, ReservationGuard};
-
     // Generate name if not provided, then validate.
-    let name = req
-        .name
-        .clone()
-        .unwrap_or_else(crate::util::generate_machine_name);
+    let name = req.name.clone().unwrap_or_else(generate_machine_name);
     validate_vm_name(&name, "machine name").map_err(ApiError::BadRequest)?;
 
     // Validate mount paths
@@ -409,7 +408,7 @@ pub async fn start_machine(
     state.insert_machine(&name, machine_entry_from_record(&record, manager));
 
     // Capture start time for PID verification
-    let pid_start_time = pid.and_then(crate::process::process_start_time);
+    let pid_start_time = pid.and_then(process_start_time);
 
     // Persist state to database
     let record = db
@@ -610,10 +609,10 @@ pub async fn exec_machine(
     let result = tokio::task::spawn_blocking(move || {
         // Get manager and check if running
         let manager = AgentManager::for_vm(&name_clone)
-            .map_err(|e| crate::Error::agent("create agent manager", e.to_string()))?;
+            .map_err(|e| SmolvmError::agent("create agent manager", e.to_string()))?;
 
         if manager.try_connect_existing().is_none() {
-            return Err(crate::Error::InvalidState {
+            return Err(SmolvmError::InvalidState {
                 expected: "running".into(),
                 actual: "stopped".into(),
             });
@@ -622,13 +621,13 @@ pub async fn exec_machine(
         // Execute command
         let mut client = manager
             .connect()
-            .map_err(|e| crate::Error::agent("connect", e.to_string()))?;
+            .map_err(|e| SmolvmError::agent("connect", e.to_string()))?;
         if let Some(tid) = tid {
             client.set_trace_id(tid);
         }
         let (exit_code, stdout, stderr) = client
             .vm_exec(command, env, workdir, timeout)
-            .map_err(|e| crate::Error::agent("exec", e.to_string()))?;
+            .map_err(|e| SmolvmError::agent("exec", e.to_string()))?;
 
         // Keep VM running (persistent)
         manager.detach();
@@ -686,12 +685,8 @@ pub async fn resize_machine(
         }
     }
 
-    let current_storage_gb = record
-        .storage_gb
-        .unwrap_or(crate::storage::DEFAULT_STORAGE_SIZE_GIB);
-    let current_overlay_gb = record
-        .overlay_gb
-        .unwrap_or(crate::storage::DEFAULT_OVERLAY_SIZE_GIB);
+    let current_storage_gb = record.storage_gb.unwrap_or(DEFAULT_STORAGE_SIZE_GIB);
+    let current_overlay_gb = record.overlay_gb.unwrap_or(DEFAULT_OVERLAY_SIZE_GIB);
 
     if req.storage_gb.unwrap_or(current_storage_gb) < current_storage_gb {
         return Err(ApiError::BadRequest(format!(
@@ -712,13 +707,13 @@ pub async fn resize_machine(
         ));
     }
 
-    let manager = crate::agent::AgentManager::for_vm(&name)
+    let manager = AgentManager::for_vm(&name)
         .map_err(|e| ApiError::internal(format!("failed to get agent manager: {}", e)))?;
 
     if let Some(storage_gb) = req.storage_gb {
         if storage_gb > current_storage_gb {
             let storage_path = manager.storage_path();
-            crate::storage::expand_disk::<crate::storage::Storage>(storage_path, storage_gb)
+            expand_disk::<Storage>(storage_path, storage_gb)
                 .map_err(|e| ApiError::internal(format!("failed to expand storage: {}", e)))?;
         }
     }
@@ -726,7 +721,7 @@ pub async fn resize_machine(
     if let Some(overlay_gb) = req.overlay_gb {
         if overlay_gb > current_overlay_gb {
             let overlay_path = manager.overlay_path();
-            crate::storage::expand_disk::<crate::storage::Overlay>(overlay_path, overlay_gb)
+            expand_disk::<Overlay>(overlay_path, overlay_gb)
                 .map_err(|e| ApiError::internal(format!("failed to expand overlay: {}", e)))?;
         }
     }

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -39,14 +39,13 @@ use crate::api::types::{
 use crate::api::validate_command;
 use crate::api::TraceId;
 use crate::config::{RecordState, RestartConfig, VmRecord};
+use crate::data::disk::{Overlay, Storage};
 use crate::data::validate_vm_name;
 use crate::process::{
     is_alive, is_our_process_strict, process_start_time, stop_vm_process, VM_SIGKILL_TIMEOUT,
     VM_SIGTERM_TIMEOUT,
 };
-use crate::storage::{
-    expand_disk, Overlay, Storage, DEFAULT_OVERLAY_SIZE_GIB, DEFAULT_STORAGE_SIZE_GIB,
-};
+use crate::storage::{expand_disk, DEFAULT_OVERLAY_SIZE_GIB, DEFAULT_STORAGE_SIZE_GIB};
 use crate::util::generate_machine_name;
 use crate::Error as SmolvmError;
 

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -718,7 +718,7 @@ pub async fn resize_machine(
     if let Some(storage_gb) = req.storage_gb {
         if storage_gb > current_storage_gb {
             let storage_path = manager.storage_path();
-            crate::storage::expand_disk(storage_path, storage_gb, "storage")
+            crate::storage::expand_disk::<crate::storage::Storage>(storage_path, storage_gb)
                 .map_err(|e| ApiError::internal(format!("failed to expand storage: {}", e)))?;
         }
     }
@@ -726,7 +726,7 @@ pub async fn resize_machine(
     if let Some(overlay_gb) = req.overlay_gb {
         if overlay_gb > current_overlay_gb {
             let overlay_path = manager.overlay_path();
-            crate::storage::expand_disk(overlay_path, overlay_gb, "overlay")
+            crate::storage::expand_disk::<crate::storage::Overlay>(overlay_path, overlay_gb)
                 .map_err(|e| ApiError::internal(format!("failed to expand overlay: {}", e)))?;
         }
     }

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -1017,10 +1017,9 @@ pub fn resize_vm(
     new_overlay_gb: Option<u64>,
 ) -> smolvm::Result<()> {
     use smolvm::config::RecordState;
+    use smolvm::data::disk::{Overlay, Storage};
     use smolvm::db::SmolvmDb;
-    use smolvm::storage::{
-        expand_disk, Overlay, Storage, DEFAULT_OVERLAY_SIZE_GIB, DEFAULT_STORAGE_SIZE_GIB,
-    };
+    use smolvm::storage::{expand_disk, DEFAULT_OVERLAY_SIZE_GIB, DEFAULT_STORAGE_SIZE_GIB};
 
     // Get VM record from database
     let db = SmolvmDb::open()?;

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -1018,7 +1018,9 @@ pub fn resize_vm(
 ) -> smolvm::Result<()> {
     use smolvm::config::RecordState;
     use smolvm::db::SmolvmDb;
-    use smolvm::storage::{expand_disk, DEFAULT_OVERLAY_SIZE_GIB, DEFAULT_STORAGE_SIZE_GIB};
+    use smolvm::storage::{
+        expand_disk, Overlay, Storage, DEFAULT_OVERLAY_SIZE_GIB, DEFAULT_STORAGE_SIZE_GIB,
+    };
 
     // Get VM record from database
     let db = SmolvmDb::open()?;
@@ -1084,7 +1086,7 @@ pub fn resize_vm(
             std::io::Write::flush(&mut std::io::stdout()).ok();
 
             let storage_path = manager.storage_path();
-            expand_disk(storage_path, storage_gb, "storage")
+            expand_disk::<Storage>(storage_path, storage_gb)
                 .map_err(|e| smolvm::Error::storage("expand storage disk", e.to_string()))?;
             println!(" done");
         }
@@ -1100,7 +1102,7 @@ pub fn resize_vm(
             std::io::Write::flush(&mut std::io::stdout()).ok();
 
             let overlay_path = manager.overlay_path();
-            expand_disk(overlay_path, overlay_gb, "overlay")
+            expand_disk::<Overlay>(overlay_path, overlay_gb)
                 .map_err(|e| smolvm::Error::storage("expand overlay disk", e.to_string()))?;
             println!(" done");
         }

--- a/src/data/disk.rs
+++ b/src/data/disk.rs
@@ -1,0 +1,44 @@
+//! Canonical shared disk type metadata.
+
+use crate::data::storage::{
+    DEFAULT_OVERLAY_SIZE_GIB, DEFAULT_STORAGE_SIZE_GIB, OVERLAY_DISK_FILENAME,
+    STORAGE_DISK_FILENAME,
+};
+
+/// Marker type for the persistent rootfs overlay disk.
+#[derive(Debug, Clone, Copy)]
+pub enum Overlay {}
+
+/// Marker type for the shared storage disk.
+#[derive(Debug, Clone, Copy)]
+pub enum Storage {}
+
+/// Compile-time metadata for a typed VM disk.
+pub trait DiskType {
+    /// Human-readable disk type name used in logs and errors.
+    const NAME: &'static str;
+    /// Default filename for this disk type.
+    const DEFAULT_FILENAME: &'static str;
+    /// Default size for this disk type, in GiB.
+    const DEFAULT_SIZE_GIB: u64;
+    /// Preformatted template filename for this disk type.
+    const TEMPLATE_FILENAME: &'static str;
+    /// ext4 volume label used when formatting this disk type.
+    const VOLUME_LABEL: &'static str;
+}
+
+impl DiskType for Overlay {
+    const NAME: &'static str = "overlay";
+    const DEFAULT_FILENAME: &'static str = OVERLAY_DISK_FILENAME;
+    const DEFAULT_SIZE_GIB: u64 = DEFAULT_OVERLAY_SIZE_GIB;
+    const TEMPLATE_FILENAME: &'static str = "overlay-template.ext4";
+    const VOLUME_LABEL: &'static str = "smolvm-overlay";
+}
+
+impl DiskType for Storage {
+    const NAME: &'static str = "storage";
+    const DEFAULT_FILENAME: &'static str = STORAGE_DISK_FILENAME;
+    const DEFAULT_SIZE_GIB: u64 = DEFAULT_STORAGE_SIZE_GIB;
+    const TEMPLATE_FILENAME: &'static str = "storage-template.ext4";
+    const VOLUME_LABEL: &'static str = "smolvm";
+}

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -2,6 +2,8 @@
 
 /// Shared constants used across the runtime and adapters.
 pub mod consts;
+/// Canonical disk type metadata shared by storage helpers.
+pub mod disk;
 /// Canonical error types used by the shared data layer.
 #[path = "errors.rs"]
 pub mod error;

--- a/src/disk_utils.rs
+++ b/src/disk_utils.rs
@@ -27,6 +27,9 @@ pub(crate) fn find_e2fsprogs_tool(name: &str) -> Option<String> {
     }
 
     if std::process::Command::new(name)
+        // Every e2fsprogs tool we care about supports `--version`; this is
+        // the cheapest non-destructive probe that confirms the binary is
+        // present on PATH and executable before we try to use it for real.
         .arg("--version")
         .output()
         .is_ok()
@@ -192,14 +195,30 @@ pub(crate) fn format_disk_with_mkfs<D: DiskType>(disk_path: &Path) -> Result<()>
 
     let output = std::process::Command::new(mkfs_path)
         .args([
+            // Force creation on a regular file rather than requiring a block
+            // device. Our "disk" here is a raw sparse image file on the host.
             "-F",
+            // Quiet mode keeps stderr/stdout small on success. We only need the
+            // detailed mkfs output when the command fails.
             "-q",
+            // Set the reserved-blocks percentage flag.
             "-m",
+            // Reserve 0% of blocks for root. This is a VM-owned data disk, not
+            // a host root filesystem, so holding capacity back for root is just
+            // wasted space.
             "0",
+            // Specify ext4 feature flags explicitly.
             "-O",
+            // Disable the journal. These disks are scratch/data images managed
+            // by a VM, and dropping the journal reduces write amplification and
+            // space overhead for our use case.
             "^has_journal",
+            // Set the filesystem label.
             "-L",
+            // The label lets the guest-side tooling distinguish storage and
+            // overlay disks in logs and inspection output.
             D::VOLUME_LABEL,
+            // The target sparse image file to format.
             path_str,
         ])
         .output()

--- a/src/disk_utils.rs
+++ b/src/disk_utils.rs
@@ -1,7 +1,7 @@
 use crate::data::consts::BYTES_PER_GIB;
+use crate::data::disk::DiskType;
 use crate::error::{Error, Result};
 use crate::platform::Os;
-use crate::storage::DiskType;
 use std::io::{Seek, SeekFrom, Write};
 use std::path::Path;
 

--- a/src/disk_utils.rs
+++ b/src/disk_utils.rs
@@ -1,0 +1,270 @@
+use crate::data::consts::BYTES_PER_GIB;
+use crate::error::{Error, Result};
+use crate::platform::Os;
+use crate::storage::DiskType;
+use std::io::{Seek, SeekFrom, Write};
+use std::path::Path;
+
+/// Common search paths for e2fsprogs tools (mkfs.ext4, e2fsck, resize2fs).
+const E2FSPROGS_PATH_PREFIXES: &[&str] = &[
+    "/opt/homebrew/opt/e2fsprogs/sbin", // macOS ARM (Homebrew)
+    "/usr/local/opt/e2fsprogs/sbin",    // macOS Intel (Homebrew)
+    "/opt/homebrew/sbin",               // macOS ARM (Homebrew alt)
+    "/usr/local/sbin",                  // macOS Intel (Homebrew alt)
+    "/sbin",                            // Linux
+    "/usr/sbin",                        // Linux alt
+];
+
+/// Find an e2fsprogs tool by name (e.g., "mkfs.ext4", "e2fsck", "resize2fs").
+///
+/// Searches common installation paths, then falls back to PATH lookup.
+pub(crate) fn find_e2fsprogs_tool(name: &str) -> Option<String> {
+    for prefix in E2FSPROGS_PATH_PREFIXES {
+        let path = format!("{}/{}", prefix, name);
+        if Path::new(&path).exists() {
+            return Some(path);
+        }
+    }
+
+    if std::process::Command::new(name)
+        .arg("--version")
+        .output()
+        .is_ok()
+    {
+        return Some(name.to_string());
+    }
+
+    None
+}
+
+/// Create a sparse disk image file.
+pub(crate) fn create_sparse_disk<D: DiskType>(path: &Path, size_bytes: u64) -> Result<()> {
+    use std::fs::OpenOptions;
+
+    tracing::info!(
+        path = %path.display(),
+        disk_type = D::NAME,
+        size_gb = size_bytes / BYTES_PER_GIB,
+        "creating sparse {} disk",
+        D::NAME,
+    );
+
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|e| Error::storage("create sparse disk", e.to_string()))?;
+    write_last_byte(
+        &mut file,
+        size_bytes,
+        "seek to create disk",
+        "write disk tail",
+    )
+}
+
+/// Copy a disk from a pre-formatted template, resizing to target size.
+///
+/// On macOS, uses `clonefile()` for instant APFS copy-on-write cloning.
+/// On Linux, falls back to `fs::copy` (which uses `copy_file_range` for
+/// sparse-aware copying on supported filesystems).
+pub(crate) fn copy_disk_from_template<D: DiskType>(
+    disk_path: &Path,
+    size_bytes: u64,
+    template_path: &Path,
+) -> Result<()> {
+    use std::fs::OpenOptions;
+
+    tracing::info!(
+        template = %template_path.display(),
+        target = %disk_path.display(),
+        disk_type = D::NAME,
+        "copying {} from template",
+        D::NAME,
+    );
+
+    if let Some(parent) = disk_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| Error::storage("create directory", e.to_string()))?;
+    }
+
+    clone_or_copy_file(template_path, disk_path)?;
+
+    let current_size = std::fs::metadata(disk_path)
+        .map_err(|e| Error::storage("read copied disk metadata", e.to_string()))?
+        .len();
+    if current_size < size_bytes {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .open(disk_path)
+            .map_err(|e| Error::storage("open for resize", e.to_string()))?;
+        write_last_byte(&mut file, size_bytes, "seek for resize", "extend disk")?;
+    }
+
+    tracing::info!(
+        path = %disk_path.display(),
+        disk_type = D::NAME,
+        "{} copied from template",
+        D::NAME
+    );
+    Ok(())
+}
+
+/// Expand a sparse disk image file to a new size.
+pub(crate) fn expand_sparse_disk<D: DiskType>(path: &Path, new_size_gb: u64) -> Result<()> {
+    use std::fs::OpenOptions;
+
+    let new_size_bytes = new_size_gb * BYTES_PER_GIB;
+    let current_size = std::fs::metadata(path)
+        .map_err(|e| Error::storage("get disk metadata", e.to_string()))?
+        .len();
+
+    if new_size_bytes <= current_size {
+        return Err(Error::storage(
+            "expand disk",
+            format!(
+                "new size ({} GiB) must be larger than current size ({} GiB)",
+                new_size_gb,
+                current_size / BYTES_PER_GIB
+            ),
+        ));
+    }
+
+    tracing::info!(
+        path = %path.display(),
+        disk_type = D::NAME,
+        current_gb = current_size / BYTES_PER_GIB,
+        new_gb = new_size_gb,
+        "expanding {} disk",
+        D::NAME
+    );
+
+    let mut file = OpenOptions::new()
+        .write(true)
+        .open(path)
+        .map_err(|e| Error::storage("open disk for expansion", e.to_string()))?;
+    write_last_byte(
+        &mut file,
+        new_size_bytes,
+        "seek to expand",
+        "write to expand",
+    )?;
+    file.sync_all()
+        .map_err(|e| Error::storage("sync after expand", e.to_string()))?;
+
+    tracing::info!(
+        path = %path.display(),
+        disk_type = D::NAME,
+        new_gb = new_size_gb,
+        "{} disk expanded successfully",
+        D::NAME
+    );
+    Ok(())
+}
+
+/// Format a disk with mkfs.ext4 (requires e2fsprogs).
+pub(crate) fn format_disk_with_mkfs<D: DiskType>(disk_path: &Path) -> Result<()> {
+    tracing::info!(
+        path = %disk_path.display(),
+        disk_type = D::NAME,
+        "formatting {} disk with mkfs.ext4",
+        D::NAME
+    );
+
+    let mkfs_path = find_e2fsprogs_tool("mkfs.ext4").ok_or_else(|| {
+        let hint = if Os::current().is_macos() {
+            "On macOS, install with: brew install e2fsprogs"
+        } else {
+            "On Linux, install with: apt install e2fsprogs (or equivalent)"
+        };
+        Error::storage(
+            "find mkfs.ext4",
+            format!(
+                "mkfs.ext4 not found - required for {} disk formatting.\n  {}",
+                D::NAME,
+                hint
+            ),
+        )
+    })?;
+
+    let path_str = disk_path
+        .to_str()
+        .ok_or_else(|| Error::storage("validate path", "disk path contains invalid characters"))?;
+
+    let output = std::process::Command::new(mkfs_path)
+        .args([
+            "-F",
+            "-q",
+            "-m",
+            "0",
+            "-O",
+            "^has_journal",
+            "-L",
+            D::VOLUME_LABEL,
+            path_str,
+        ])
+        .output()
+        .map_err(|e| Error::storage("run mkfs.ext4", e.to_string()))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(Error::storage("format with mkfs.ext4", stderr.to_string()));
+    }
+
+    tracing::info!(
+        path = %disk_path.display(),
+        disk_type = D::NAME,
+        "{} disk formatted successfully",
+        D::NAME
+    );
+    Ok(())
+}
+
+pub(crate) fn write_last_byte(
+    file: &mut std::fs::File,
+    size_bytes: u64,
+    seek_context: &str,
+    write_context: &str,
+) -> Result<()> {
+    assert!(size_bytes > 0, "disk size must be greater than 0");
+
+    file.seek(SeekFrom::Start(size_bytes - 1))
+        .map_err(|e| Error::storage(seek_context, e.to_string()))?;
+    file.write_all(&[0])
+        .map_err(|e| Error::storage(write_context, e.to_string()))?;
+    Ok(())
+}
+
+/// Clone a file using the platform-optimal copy method.
+///
+/// - macOS: `clonefile()` for instant APFS copy-on-write (falls back to `fs::copy`)
+/// - Linux: `fs::copy` (uses `copy_file_range` for sparse-aware copy)
+pub(crate) fn clone_or_copy_file(src: &Path, dst: &Path) -> Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        use std::ffi::CString;
+
+        if dst.exists() {
+            let _ = std::fs::remove_file(dst);
+        }
+
+        let src_c = CString::new(src.to_string_lossy().as_bytes())
+            .map_err(|e| Error::storage("clonefile src path", e.to_string()))?;
+        let dst_c = CString::new(dst.to_string_lossy().as_bytes())
+            .map_err(|e| Error::storage("clonefile dst path", e.to_string()))?;
+
+        let ret = unsafe { libc::clonefile(src_c.as_ptr(), dst_c.as_ptr(), 0) };
+        if ret == 0 {
+            tracing::debug!(src = %src.display(), dst = %dst.display(), "clonefile succeeded");
+            return Ok(());
+        }
+
+        tracing::debug!(
+            src = %src.display(),
+            errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0),
+            "clonefile failed, falling back to fs::copy"
+        );
+    }
+
+    std::fs::copy(src, dst).map_err(|e| Error::storage("copy file", e.to_string()))?;
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ pub mod config;
 /// Canonical shared data models and constants used across adapters.
 pub mod data;
 pub mod db;
+mod disk_utils;
 pub mod dns_filter;
 pub mod dns_filter_listener;
 /// Language-neutral embedded runtime support shared by SDK adapters.

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -16,6 +16,7 @@
 //! and overlay filesystem management.
 
 use crate::data::consts::BYTES_PER_GIB;
+pub use crate::data::disk::{DiskType, Overlay, Storage};
 pub use crate::data::storage::{
     DEFAULT_OVERLAY_SIZE_GIB, DEFAULT_STORAGE_SIZE_GIB, OVERLAY_DISK_FILENAME,
     STORAGE_DISK_FILENAME,
@@ -60,44 +61,6 @@ impl DiskVersion {
     pub fn is_compatible(&self) -> bool {
         self.format_version <= Self::CURRENT_VERSION
     }
-}
-
-/// Marker type for the persistent rootfs overlay disk.
-#[derive(Debug, Clone, Copy)]
-pub enum Overlay {}
-
-/// Marker type for the shared storage disk.
-#[derive(Debug, Clone, Copy)]
-pub enum Storage {}
-
-/// Compile-time metadata for a typed VM disk.
-pub trait DiskType {
-    /// Human-readable disk type name used in logs and errors.
-    const NAME: &'static str;
-    /// Default filename for this disk type.
-    const DEFAULT_FILENAME: &'static str;
-    /// Default size for this disk type, in GiB.
-    const DEFAULT_SIZE_GIB: u64;
-    /// Preformatted template filename for this disk type.
-    const TEMPLATE_FILENAME: &'static str;
-    /// ext4 volume label used when formatting this disk type.
-    const VOLUME_LABEL: &'static str;
-}
-
-impl DiskType for Overlay {
-    const NAME: &'static str = "overlay";
-    const DEFAULT_FILENAME: &'static str = OVERLAY_DISK_FILENAME;
-    const DEFAULT_SIZE_GIB: u64 = DEFAULT_OVERLAY_SIZE_GIB;
-    const TEMPLATE_FILENAME: &'static str = "overlay-template.ext4";
-    const VOLUME_LABEL: &'static str = "smolvm-overlay";
-}
-
-impl DiskType for Storage {
-    const NAME: &'static str = "storage";
-    const DEFAULT_FILENAME: &'static str = STORAGE_DISK_FILENAME;
-    const DEFAULT_SIZE_GIB: u64 = DEFAULT_STORAGE_SIZE_GIB;
-    const TEMPLATE_FILENAME: &'static str = "storage-template.ext4";
-    const VOLUME_LABEL: &'static str = "smolvm";
 }
 
 /// Shared disk implementation for storage and overlay disks.
@@ -198,7 +161,7 @@ impl<K: DiskType> VmDisk<K> {
     }
 
     /// Get the disk size in GiB.
-    pub fn size_gb(&self) -> u64 {
+    pub fn size_gib(&self) -> u64 {
         self.size_bytes / BYTES_PER_GIB
     }
 
@@ -381,7 +344,7 @@ mod tests {
         let disk = StorageDisk::open_or_create_at(&disk_path, 1).unwrap();
 
         assert!(disk_path.exists());
-        assert_eq!(disk.size_gb(), 1);
+        assert_eq!(disk.size_gib(), 1);
         assert!(disk.needs_format());
 
         write_ext4_magic(&disk_path);
@@ -509,7 +472,7 @@ mod tests {
         expand_disk::<Storage>(&disk_path, 2).unwrap();
 
         let disk = StorageDisk::open_or_create_at(&disk_path, 2).unwrap();
-        assert_eq!(disk.size_gb(), 2);
+        assert_eq!(disk.size_gib(), 2);
         let metadata = std::fs::metadata(&disk_path).unwrap();
         assert_eq!(metadata.len(), 2 * BYTES_PER_GIB);
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -20,363 +20,11 @@ pub use crate::data::storage::{
     DEFAULT_OVERLAY_SIZE_GIB, DEFAULT_STORAGE_SIZE_GIB, OVERLAY_DISK_FILENAME,
     STORAGE_DISK_FILENAME,
 };
+use crate::disk_utils;
 use crate::error::{Error, Result};
-use crate::platform::Os;
 use serde::{Deserialize, Serialize};
+use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
-
-/// Common search paths for e2fsprogs tools (mkfs.ext4, e2fsck, resize2fs).
-const E2FSPROGS_PATH_PREFIXES: &[&str] = &[
-    "/opt/homebrew/opt/e2fsprogs/sbin", // macOS ARM (Homebrew)
-    "/usr/local/opt/e2fsprogs/sbin",    // macOS Intel (Homebrew)
-    "/opt/homebrew/sbin",               // macOS ARM (Homebrew alt)
-    "/usr/local/sbin",                  // macOS Intel (Homebrew alt)
-    "/sbin",                            // Linux
-    "/usr/sbin",                        // Linux alt
-];
-
-/// Find an e2fsprogs tool by name (e.g., "mkfs.ext4", "e2fsck", "resize2fs").
-///
-/// Searches common installation paths, then falls back to PATH lookup.
-fn find_e2fsprogs_tool(name: &str) -> Option<String> {
-    // Check known paths first
-    for prefix in E2FSPROGS_PATH_PREFIXES {
-        let path = format!("{}/{}", prefix, name);
-        if std::path::Path::new(&path).exists() {
-            return Some(path);
-        }
-    }
-
-    // Fall back to PATH lookup
-    if std::process::Command::new(name)
-        .arg("--version")
-        .output()
-        .is_ok()
-    {
-        return Some(name.to_string());
-    }
-
-    None
-}
-
-// ============================================================================
-// Shared ext4 disk operations
-// ============================================================================
-
-/// Create a sparse disk image file.
-fn create_sparse_disk(path: &Path, size_bytes: u64, label: &str) -> Result<()> {
-    use std::fs::OpenOptions;
-    use std::io::{Seek, SeekFrom, Write};
-
-    assert!(size_bytes > 0, "disk size must be greater than 0");
-
-    tracing::info!(
-        path = %path.display(),
-        size_gb = size_bytes / BYTES_PER_GIB,
-        "creating sparse {} disk",
-        label
-    );
-
-    let mut file = OpenOptions::new().write(true).create_new(true).open(path)?;
-    file.seek(SeekFrom::Start(size_bytes - 1))?;
-    file.write_all(&[0])?;
-
-    Ok(())
-}
-
-/// Find a pre-formatted disk template by filename.
-///
-/// Searches in order:
-/// 1. `~/.smolvm/{filename}` (installed location)
-/// 2. Next to the current executable (development)
-fn find_disk_template(template_filename: &str) -> Option<PathBuf> {
-    if let Some(home) = dirs::home_dir() {
-        let installed_path = home.join(".smolvm").join(template_filename);
-        if installed_path.exists() {
-            tracing::debug!(path = %installed_path.display(), "found disk template");
-            return Some(installed_path);
-        }
-    }
-
-    if let Ok(exe_path) = std::env::current_exe() {
-        if let Some(exe_dir) = exe_path.parent() {
-            let dev_path = exe_dir.join(template_filename);
-            if dev_path.exists() {
-                tracing::debug!(path = %dev_path.display(), "found disk template (dev)");
-                return Some(dev_path);
-            }
-        }
-    }
-
-    None
-}
-
-/// Copy a disk from a pre-formatted template, resizing to target size.
-///
-/// On macOS, uses `clonefile()` for instant APFS copy-on-write cloning.
-/// On Linux, falls back to `fs::copy` (which uses `copy_file_range` for
-/// sparse-aware copying on supported filesystems).
-fn copy_disk_from_template(
-    disk_path: &Path,
-    size_bytes: u64,
-    template_path: &Path,
-    label: &str,
-) -> Result<()> {
-    tracing::info!(
-        template = %template_path.display(),
-        target = %disk_path.display(),
-        "copying {} from template", label
-    );
-
-    if let Some(parent) = disk_path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|e| Error::storage("create directory", e.to_string()))?;
-    }
-
-    clone_or_copy_file(template_path, disk_path)?;
-
-    // Resize to the desired size (template may be smaller than target)
-    use std::io::{Seek, SeekFrom, Write};
-    let mut file = std::fs::OpenOptions::new()
-        .write(true)
-        .open(disk_path)
-        .map_err(|e| Error::storage("open for resize", e.to_string()))?;
-
-    file.seek(SeekFrom::Start(size_bytes - 1))
-        .map_err(|e| Error::storage("seek for resize", e.to_string()))?;
-    file.write_all(&[0])
-        .map_err(|e| Error::storage("extend disk", e.to_string()))?;
-
-    // Filesystem resize happens inside the VM (guest runs resize2fs on boot).
-
-    mark_disk_formatted(disk_path)?;
-
-    tracing::info!(path = %disk_path.display(), "{} copied from template", label);
-    Ok(())
-}
-
-/// Clone a file using platform-optimal method.
-///
-/// - macOS: `clonefile()` for instant APFS copy-on-write (falls back to `fs::copy`)
-/// - Linux: `fs::copy` (uses `copy_file_range` for sparse-aware copy)
-fn clone_or_copy_file(src: &Path, dst: &Path) -> Result<()> {
-    #[cfg(target_os = "macos")]
-    {
-        use std::ffi::CString;
-
-        // clonefile(2) requires the destination to not exist
-        if dst.exists() {
-            let _ = std::fs::remove_file(dst);
-        }
-
-        let src_c = CString::new(src.to_string_lossy().as_bytes())
-            .map_err(|e| Error::storage("clonefile src path", e.to_string()))?;
-        let dst_c = CString::new(dst.to_string_lossy().as_bytes())
-            .map_err(|e| Error::storage("clonefile dst path", e.to_string()))?;
-
-        // clonefile(2): instant APFS copy-on-write clone
-        let ret = unsafe { libc::clonefile(src_c.as_ptr(), dst_c.as_ptr(), 0) };
-        if ret == 0 {
-            tracing::debug!(src = %src.display(), dst = %dst.display(), "clonefile succeeded");
-            return Ok(());
-        }
-
-        // Fall back to regular copy if clonefile fails (e.g., non-APFS filesystem)
-        tracing::debug!(
-            src = %src.display(),
-            errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0),
-            "clonefile failed, falling back to fs::copy"
-        );
-    }
-
-    std::fs::copy(src, dst).map_err(|e| Error::storage("copy template", e.to_string()))?;
-    Ok(())
-}
-
-/// Format a disk with mkfs.ext4 (requires e2fsprogs).
-fn format_disk_with_mkfs(disk_path: &Path, volume_label: &str, label: &str) -> Result<()> {
-    tracing::info!(path = %disk_path.display(), "formatting {} disk with mkfs.ext4", label);
-
-    let mkfs_path = find_e2fsprogs_tool("mkfs.ext4").ok_or_else(|| {
-        let hint = if Os::current().is_macos() {
-            "On macOS, install with: brew install e2fsprogs"
-        } else {
-            "On Linux, install with: apt install e2fsprogs (or equivalent)"
-        };
-        Error::storage(
-            "find mkfs.ext4",
-            format!(
-                "mkfs.ext4 not found - required for {} disk formatting.\n  {}",
-                label, hint
-            ),
-        )
-    })?;
-
-    let path_str = disk_path
-        .to_str()
-        .ok_or_else(|| Error::storage("validate path", "disk path contains invalid characters"))?;
-
-    let output = std::process::Command::new(mkfs_path)
-        .args([
-            "-F",
-            "-q",
-            "-m",
-            "0",
-            "-O",
-            "^has_journal",
-            "-L",
-            volume_label,
-            path_str,
-        ])
-        .output()
-        .map_err(|e| Error::storage("run mkfs.ext4", e.to_string()))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(Error::storage("format with mkfs.ext4", stderr.to_string()));
-    }
-
-    mark_disk_formatted(disk_path)?;
-
-    tracing::info!(path = %disk_path.display(), "{} disk formatted successfully", label);
-    Ok(())
-}
-
-/// Check if a disk file appears to be a valid ext4 filesystem.
-/// Used in tests; removed from hot path to avoid spawning `file` command on every start.
-#[cfg(test)]
-fn disk_appears_valid_ext4(disk_path: &Path) -> bool {
-    let output = std::process::Command::new("file")
-        .arg("-b")
-        .arg(disk_path)
-        .output();
-
-    match output {
-        Ok(output) if output.status.success() => {
-            let desc = String::from_utf8_lossy(&output.stdout);
-            let is_ext4 = desc.contains("ext4") || desc.contains("ext2") || desc.contains("ext3");
-            if !is_ext4 {
-                tracing::debug!(
-                    path = %disk_path.display(),
-                    file_type = %desc.trim(),
-                    "disk is not ext4"
-                );
-            }
-            is_ext4
-        }
-        _ => {
-            tracing::debug!(path = %disk_path.display(), "could not verify disk type, assuming valid");
-            true
-        }
-    }
-}
-
-/// Check if a disk needs to be formatted.
-///
-/// Fast path: if the format marker AND the disk file both exist, the disk
-/// was formatted successfully — skip the expensive `file` command validation.
-/// The marker is only created after successful mkfs.ext4 completion.
-fn disk_needs_format(disk_path: &Path, _label: &str) -> bool {
-    let marker_path = disk_marker_path(disk_path);
-
-    if !marker_path.exists() {
-        return true;
-    }
-
-    if !disk_path.exists() {
-        // Marker exists but disk is gone — stale marker
-        let _ = std::fs::remove_file(&marker_path);
-        return true;
-    }
-
-    // Both marker and disk exist — disk was formatted successfully.
-    // Skip spawning `file` command (~10ms) on every restart.
-    false
-}
-
-/// Get the path to the format marker file for a disk.
-fn disk_marker_path(disk_path: &Path) -> PathBuf {
-    disk_path.with_extension("formatted")
-}
-
-/// Mark a disk as formatted by creating its marker file.
-fn mark_disk_formatted(disk_path: &Path) -> Result<()> {
-    std::fs::write(disk_marker_path(disk_path), "1")?;
-    Ok(())
-}
-
-/// Delete a disk image and its marker file.
-fn delete_disk_and_marker(disk_path: &Path) -> Result<()> {
-    if disk_path.exists() {
-        std::fs::remove_file(disk_path)?;
-    }
-    let marker = disk_marker_path(disk_path);
-    if marker.exists() {
-        std::fs::remove_file(&marker)?;
-    }
-    Ok(())
-}
-
-/// Expand a sparse disk image file to a new size by seeking to the new end
-/// position and writing a single byte, which creates a sparse file.
-pub fn expand_disk(path: &Path, new_size_gb: u64, label: &str) -> Result<()> {
-    use std::fs::OpenOptions;
-    use std::io::{Seek, SeekFrom, Write};
-
-    let new_size_bytes = new_size_gb * BYTES_PER_GIB;
-
-    // Get current size
-    let metadata =
-        std::fs::metadata(path).map_err(|e| Error::storage("get disk metadata", e.to_string()))?;
-    let current_size = metadata.len();
-
-    if new_size_bytes <= current_size {
-        return Err(Error::storage(
-            "expand disk",
-            format!(
-                "new size ({} GiB) must be larger than current size ({} GiB)",
-                new_size_gb,
-                current_size / BYTES_PER_GIB
-            ),
-        ));
-    }
-
-    tracing::info!(
-        path = %path.display(),
-        label,
-        current_gb = current_size / BYTES_PER_GIB,
-        new_gb = new_size_gb,
-        "expanding {} disk",
-        label
-    );
-
-    let mut file = OpenOptions::new()
-        .write(true)
-        .open(path)
-        .map_err(|e| Error::storage("open disk for expansion", e.to_string()))?;
-
-    // Seek to new end position (minus 1 byte)
-    file.seek(SeekFrom::Start(new_size_bytes - 1))
-        .map_err(|e| Error::storage("seek to expand", e.to_string()))?;
-
-    // Write single byte to extend (creates sparse file)
-    file.write_all(&[0])
-        .map_err(|e| Error::storage("write to expand", e.to_string()))?;
-
-    // Sync to ensure the file is extended on disk
-    file.sync_all()
-        .map_err(|e| Error::storage("sync after expand", e.to_string()))?;
-
-    tracing::info!(
-        path = %path.display(),
-        label,
-        new_gb = new_size_gb,
-        "{} disk expanded successfully",
-        label
-    );
-
-    Ok(())
-}
 
 /// Disk format version info (stored at `/.smolvm/version.json` in ext4 disk).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -414,6 +62,243 @@ impl DiskVersion {
     }
 }
 
+/// Marker type for the persistent rootfs overlay disk.
+#[derive(Debug, Clone, Copy)]
+pub enum Overlay {}
+
+/// Marker type for the shared storage disk.
+#[derive(Debug, Clone, Copy)]
+pub enum Storage {}
+
+/// Compile-time metadata for a typed VM disk.
+pub trait DiskType {
+    /// Human-readable disk type name used in logs and errors.
+    const NAME: &'static str;
+    /// Default filename for this disk type.
+    const DEFAULT_FILENAME: &'static str;
+    /// Default size for this disk type, in GiB.
+    const DEFAULT_SIZE_GIB: u64;
+    /// Preformatted template filename for this disk type.
+    const TEMPLATE_FILENAME: &'static str;
+    /// ext4 volume label used when formatting this disk type.
+    const VOLUME_LABEL: &'static str;
+}
+
+impl DiskType for Overlay {
+    const NAME: &'static str = "overlay";
+    const DEFAULT_FILENAME: &'static str = OVERLAY_DISK_FILENAME;
+    const DEFAULT_SIZE_GIB: u64 = DEFAULT_OVERLAY_SIZE_GIB;
+    const TEMPLATE_FILENAME: &'static str = "overlay-template.ext4";
+    const VOLUME_LABEL: &'static str = "smolvm-overlay";
+}
+
+impl DiskType for Storage {
+    const NAME: &'static str = "storage";
+    const DEFAULT_FILENAME: &'static str = STORAGE_DISK_FILENAME;
+    const DEFAULT_SIZE_GIB: u64 = DEFAULT_STORAGE_SIZE_GIB;
+    const TEMPLATE_FILENAME: &'static str = "storage-template.ext4";
+    const VOLUME_LABEL: &'static str = "smolvm";
+}
+
+/// Shared disk implementation for storage and overlay disks.
+#[derive(Debug, Clone)]
+pub struct VmDisk<K> {
+    path: PathBuf,
+    size_bytes: u64,
+    _kind: PhantomData<K>,
+}
+
+impl<K: DiskType> VmDisk<K> {
+    /// Get the default path for the disk.
+    pub fn default_path() -> Result<PathBuf> {
+        let data_dir = dirs::data_local_dir()
+            .or_else(dirs::data_dir)
+            .ok_or_else(|| {
+                Error::storage(
+                    format!("resolve {} path", K::NAME),
+                    "could not determine data directory",
+                )
+            })?;
+
+        Ok(data_dir.join("smolvm").join(K::DEFAULT_FILENAME))
+    }
+
+    /// Open or create the disk of the default size at the default location.
+    pub fn open_or_create() -> Result<Self> {
+        let path = Self::default_path()?;
+        Self::open_or_create_at(&path, K::DEFAULT_SIZE_GIB)
+    }
+
+    /// Open or create the disk of the custom size at a custom path.
+    pub fn open_or_create_at(path: &Path, size_gb: u64) -> Result<Self> {
+        if size_gb == 0 {
+            return Err(Error::config(
+                format!("validate {} size", K::NAME),
+                "disk size must be greater than 0 GiB",
+            ));
+        }
+
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let size_bytes = size_gb * BYTES_PER_GIB;
+
+        if path.exists() {
+            let metadata = std::fs::metadata(path)?;
+            Ok(Self {
+                path: path.to_path_buf(),
+                size_bytes: metadata.len(),
+                _kind: PhantomData,
+            })
+        } else {
+            disk_utils::create_sparse_disk::<K>(path, size_bytes)?;
+            Ok(Self {
+                path: path.to_path_buf(),
+                size_bytes,
+                _kind: PhantomData,
+            })
+        }
+    }
+
+    /// Pre-format the disk with ext4 on the host.
+    ///
+    /// This tries multiple approaches in order:
+    /// 1. Copy from pre-formatted template (no dependencies, fastest)
+    /// 2. Format with mkfs.ext4 (requires e2fsprogs)
+    ///
+    /// The template approach eliminates the e2fsprogs dependency for end users.
+    pub fn ensure_formatted(&self) -> Result<()> {
+        if !self.needs_format() {
+            tracing::debug!(
+                path = %self.path.display(),
+                disk_type = K::NAME,
+                "disk already formatted"
+            );
+            return Ok(());
+        }
+
+        if let Some(template_path) = Self::template_path() {
+            disk_utils::copy_disk_from_template::<K>(&self.path, self.size_bytes, &template_path)?;
+        } else {
+            disk_utils::format_disk_with_mkfs::<K>(&self.path)?;
+        }
+
+        self.mark_formatted()
+    }
+
+    /// Get the path to the disk image.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Get the disk size in bytes.
+    pub fn size_bytes(&self) -> u64 {
+        self.size_bytes
+    }
+
+    /// Get the disk size in GiB.
+    pub fn size_gb(&self) -> u64 {
+        self.size_bytes / BYTES_PER_GIB
+    }
+
+    /// Check if the disk needs to be formatted.
+    ///
+    /// Fast path: if the format marker and the disk file both exist, the disk
+    /// was formatted successfully, so skip the expensive `file` command check.
+    pub fn needs_format(&self) -> bool {
+        if !self.disk_marker_path().exists() {
+            return true;
+        }
+
+        if !self.path.exists() {
+            let marker_path = self.disk_marker_path();
+            if let Err(error) = std::fs::remove_file(&marker_path) {
+                tracing::warn!(
+                    path = %marker_path.display(),
+                    disk_type = K::NAME,
+                    %error,
+                    "failed to remove stale disk marker"
+                );
+            }
+            return true;
+        }
+
+        false
+    }
+
+    /// Mark a disk as formatted by creating its marker file.
+    pub fn mark_formatted(&self) -> Result<()> {
+        std::fs::write(self.disk_marker_path(), "1")?;
+        Ok(())
+    }
+
+    /// Delete a disk image and its marker file.
+    pub fn delete(&self) -> Result<()> {
+        if self.path.exists() {
+            std::fs::remove_file(&self.path)?;
+        }
+
+        let marker_path = self.disk_marker_path();
+        if marker_path.exists() {
+            std::fs::remove_file(marker_path)?;
+        }
+        Ok(())
+    }
+
+    /// Find a pre-formatted disk template.
+    ///
+    /// Searches in order:
+    /// 1. `~/.smolvm/{filename}` (installed location)
+    /// 2. Next to the current executable (development)
+    fn template_path() -> Option<PathBuf> {
+        if let Some(home) = dirs::home_dir() {
+            let installed_path = home.join(".smolvm").join(K::TEMPLATE_FILENAME);
+            if installed_path.exists() {
+                tracing::debug!(
+                    path = %installed_path.display(),
+                    disk_type = K::NAME,
+                    "found disk template"
+                );
+                return Some(installed_path);
+            }
+        }
+
+        if let Ok(exe_path) = std::env::current_exe() {
+            if let Some(exe_dir) = exe_path.parent() {
+                let dev_path = exe_dir.join(K::TEMPLATE_FILENAME);
+                if dev_path.exists() {
+                    tracing::debug!(
+                        path = %dev_path.display(),
+                        disk_type = K::NAME,
+                        "found disk template (dev)"
+                    );
+                    return Some(dev_path);
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Get the path to the format marker file for a disk.
+    fn disk_marker_path(&self) -> PathBuf {
+        self.path.with_extension("formatted")
+    }
+}
+
+impl VmDisk<Storage> {
+    /// Open or create the storage disk at the default location with a custom size.
+    pub fn open_or_create_with_size(size_gb: u64) -> Result<Self> {
+        let path = Self::default_path()?;
+        Self::open_or_create_at(&path, size_gb)
+    }
+}
+
+// ============================================================================
+// Storage Disk
+// ============================================================================
+
 /// Shared storage disk for OCI layers.
 ///
 /// This is a sparse raw disk image that the helper VM mounts to store
@@ -436,126 +321,7 @@ impl DiskVersion {
 /// └── manifests/           # Cached image manifests
 ///     └── {image_ref}.json
 /// ```
-#[derive(Debug, Clone)]
-pub struct StorageDisk {
-    /// Path to the disk image file.
-    path: PathBuf,
-    /// Size in bytes.
-    size_bytes: u64,
-}
-
-impl StorageDisk {
-    /// Get the default path for the storage disk.
-    ///
-    /// On macOS: `~/Library/Application Support/smolvm/storage.raw`
-    /// On Linux: `~/.local/share/smolvm/storage.raw`
-    pub fn default_path() -> Result<PathBuf> {
-        let data_dir = dirs::data_local_dir()
-            .or_else(dirs::data_dir)
-            .ok_or_else(|| Error::storage("resolve path", "could not determine data directory"))?;
-
-        let smolvm_dir = data_dir.join("smolvm");
-        Ok(smolvm_dir.join(STORAGE_DISK_FILENAME))
-    }
-
-    /// Open or create the storage disk at the default location.
-    pub fn open_or_create() -> Result<Self> {
-        let path = Self::default_path()?;
-        Self::open_or_create_at(&path, DEFAULT_STORAGE_SIZE_GIB)
-    }
-
-    /// Open or create the storage disk at the default location with a custom size.
-    pub fn open_or_create_with_size(size_gb: u64) -> Result<Self> {
-        let path = Self::default_path()?;
-        Self::open_or_create_at(&path, size_gb)
-    }
-
-    /// Open or create the storage disk at a custom path.
-    pub fn open_or_create_at(path: &Path, size_gb: u64) -> Result<Self> {
-        // Validate size
-        if size_gb == 0 {
-            return Err(Error::config(
-                "validate storage size",
-                "disk size must be greater than 0 GB",
-            ));
-        }
-
-        // Ensure parent directory exists
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-
-        let size_bytes = size_gb * BYTES_PER_GIB;
-
-        if path.exists() {
-            // Open existing disk
-            let metadata = std::fs::metadata(path)?;
-            Ok(Self {
-                path: path.to_path_buf(),
-                size_bytes: metadata.len(),
-            })
-        } else {
-            // Create sparse disk image
-            Self::create_sparse(path, size_bytes)?;
-            Ok(Self {
-                path: path.to_path_buf(),
-                size_bytes,
-            })
-        }
-    }
-
-    fn create_sparse(path: &Path, size_bytes: u64) -> Result<()> {
-        create_sparse_disk(path, size_bytes, "storage")
-    }
-
-    /// Pre-format the disk with ext4 on the host.
-    ///
-    /// This tries multiple approaches in order:
-    /// 1. Copy from pre-formatted template (no dependencies, fastest)
-    /// 2. Format with mkfs.ext4 (requires e2fsprogs)
-    ///
-    /// The template approach eliminates the e2fsprogs dependency for end users.
-    pub fn ensure_formatted(&self) -> Result<()> {
-        if !self.needs_format() {
-            tracing::debug!(path = %self.path.display(), "disk already formatted");
-            return Ok(());
-        }
-        if let Some(template_path) = find_disk_template("storage-template.ext4") {
-            return copy_disk_from_template(&self.path, self.size_bytes, &template_path, "storage");
-        }
-        format_disk_with_mkfs(&self.path, "smolvm", "storage")
-    }
-
-    /// Get the path to the disk image.
-    pub fn path(&self) -> &Path {
-        &self.path
-    }
-
-    /// Get the disk size in bytes.
-    pub fn size_bytes(&self) -> u64 {
-        self.size_bytes
-    }
-
-    /// Get the disk size in GiB.
-    pub fn size_gb(&self) -> u64 {
-        self.size_bytes / BYTES_PER_GIB
-    }
-
-    /// Check if the disk needs to be formatted.
-    pub fn needs_format(&self) -> bool {
-        disk_needs_format(&self.path, "storage")
-    }
-
-    /// Mark the disk as formatted.
-    pub fn mark_formatted(&self) -> Result<()> {
-        mark_disk_formatted(&self.path)
-    }
-
-    /// Delete the storage disk and its marker.
-    pub fn delete(&self) -> Result<()> {
-        delete_disk_and_marker(&self.path)
-    }
-}
+pub type StorageDisk = VmDisk<Storage>;
 
 // ============================================================================
 // Overlay Disk
@@ -569,89 +335,19 @@ impl StorageDisk {
 ///
 /// The overlay is set up by the agent's `setup_persistent_rootfs()`
 /// function early in boot, before the vsock listener starts.
-#[derive(Debug, Clone)]
-pub struct OverlayDisk {
-    /// Path to the disk image file.
-    path: PathBuf,
-    /// Size in bytes.
-    size_bytes: u64,
-}
+pub type OverlayDisk = VmDisk<Overlay>;
 
-impl OverlayDisk {
-    /// Open or create the overlay disk at a custom path.
-    pub fn open_or_create_at(path: &Path, size_gb: u64) -> Result<Self> {
-        if size_gb == 0 {
-            return Err(Error::config(
-                "validate overlay size",
-                "disk size must be greater than 0 GB",
-            ));
-        }
-
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-
-        let size_bytes = size_gb * BYTES_PER_GIB;
-
-        if path.exists() {
-            let metadata = std::fs::metadata(path)?;
-            Ok(Self {
-                path: path.to_path_buf(),
-                size_bytes: metadata.len(),
-            })
-        } else {
-            // Create sparse disk image
-            Self::create_sparse(path, size_bytes)?;
-            Ok(Self {
-                path: path.to_path_buf(),
-                size_bytes,
-            })
-        }
-    }
-
-    fn create_sparse(path: &Path, size_bytes: u64) -> Result<()> {
-        create_sparse_disk(path, size_bytes, "overlay")
-    }
-
-    /// Pre-format the overlay disk with ext4 on the host.
-    ///
-    /// Tries template copy first (fast, no dependencies), then falls back
-    /// to mkfs.ext4 (requires e2fsprogs).
-    pub fn ensure_formatted(&self) -> Result<()> {
-        if !self.needs_format() {
-            tracing::debug!(path = %self.path.display(), "overlay disk already formatted");
-            return Ok(());
-        }
-        if let Some(template_path) = find_disk_template("overlay-template.ext4") {
-            return copy_disk_from_template(&self.path, self.size_bytes, &template_path, "overlay");
-        }
-        format_disk_with_mkfs(&self.path, "smolvm-overlay", "overlay")
-    }
-
-    /// Get the path to the disk image.
-    pub fn path(&self) -> &Path {
-        &self.path
-    }
-
-    /// Check if the disk needs to be formatted.
-    fn needs_format(&self) -> bool {
-        disk_needs_format(&self.path, "overlay")
-    }
-
-    /// Delete the overlay disk and its marker.
-    pub fn delete(&self) -> Result<()> {
-        delete_disk_and_marker(&self.path)
-    }
+/// Expand a disk image at an arbitrary path for a specific disk type.
+pub fn expand_disk<D: DiskType>(path: &Path, new_size_gb: u64) -> Result<()> {
+    disk_utils::expand_sparse_disk::<D>(path, new_size_gb)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::data::consts::BYTES_PER_MIB;
 
     #[test]
     fn test_disk_version_compatibility() {
-        // Important for migration safety
         let version = DiskVersion::new("sha256:abc123");
         assert!(version.is_compatible());
 
@@ -679,31 +375,36 @@ mod tests {
         std::fs::create_dir_all(&temp_dir).unwrap();
         let disk_path = temp_dir.join("test_storage.raw");
 
-        // Clean up any existing file
         let _ = std::fs::remove_file(&disk_path);
         let _ = std::fs::remove_file(disk_path.with_extension("formatted"));
 
-        // Create a small disk for testing (1 GB)
         let disk = StorageDisk::open_or_create_at(&disk_path, 1).unwrap();
 
         assert!(disk_path.exists());
         assert_eq!(disk.size_gb(), 1);
         assert!(disk.needs_format());
 
-        // Write ext4 magic bytes so the disk appears valid
-        // ext4 superblock is at offset 1024, magic (0xEF53) is at offset 56 within superblock
         write_ext4_magic(&disk_path);
 
-        // Mark as formatted
         disk.mark_formatted().unwrap();
-        assert!(!disk.needs_format()); // Should pass now that disk has ext4 magic
+        assert!(!disk.needs_format());
 
-        // Delete disk
         disk.delete().unwrap();
         assert!(!disk_path.exists());
 
-        // Clean up temp dir
         let _ = std::fs::remove_dir(&temp_dir);
+    }
+
+    #[test]
+    fn test_default_paths_use_expected_filenames() {
+        assert_eq!(
+            StorageDisk::default_path().unwrap().file_name().unwrap(),
+            STORAGE_DISK_FILENAME
+        );
+        assert_eq!(
+            OverlayDisk::default_path().unwrap().file_name().unwrap(),
+            OVERLAY_DISK_FILENAME
+        );
     }
 
     #[test]
@@ -713,62 +414,28 @@ mod tests {
         let disk_path = temp_dir.join("corrupt_storage.raw");
         let marker_path = disk_path.with_extension("formatted");
 
-        // Clean up any existing files
         let _ = std::fs::remove_file(&disk_path);
         let _ = std::fs::remove_file(&marker_path);
 
-        // Create disk and mark as formatted (simulating previous successful run)
         let disk = StorageDisk::open_or_create_at(&disk_path, 1).unwrap();
         write_ext4_magic(&disk_path);
         disk.mark_formatted().unwrap();
 
-        // Verify it's recognized as valid
         assert!(!disk.needs_format());
         assert!(disk_appears_valid_ext4(&disk_path));
 
-        // Now corrupt the disk by zeroing the magic bytes
         corrupt_ext4_magic(&disk_path);
 
-        // disk_appears_valid_ext4 catches corruption via `file` command
         assert!(!disk_appears_valid_ext4(&disk_path));
 
-        // But needs_format trusts the marker file for performance (avoids
-        // spawning `file` on every start). Marker + disk present = no reformat.
         let disk2 = StorageDisk::open_or_create_at(&disk_path, 1).unwrap();
         assert!(!disk2.needs_format());
 
-        // Stale marker (disk deleted) should be detected
         let _ = std::fs::remove_file(&disk_path);
         assert!(disk2.needs_format());
-        // Stale marker should be cleaned up
         assert!(!marker_path.exists());
 
-        // Clean up temp dir
         let _ = std::fs::remove_dir(&temp_dir);
-    }
-
-    /// Write ext4 magic bytes to make `file` command recognize it as ext4.
-    /// ext4 superblock is at offset 1024, magic number 0xEF53 is at offset 56.
-    fn write_ext4_magic(path: &std::path::Path) {
-        use std::io::{Seek, SeekFrom, Write};
-        let mut file = std::fs::OpenOptions::new().write(true).open(path).unwrap();
-
-        // Seek to superblock magic offset (1024 + 56 = 1080)
-        file.seek(SeekFrom::Start(1080)).unwrap();
-        // Write ext4 magic: 0xEF53 (little-endian: 0x53, 0xEF)
-        file.write_all(&[0x53, 0xEF]).unwrap();
-        file.sync_all().unwrap();
-    }
-
-    /// Corrupt the ext4 magic bytes by zeroing them.
-    fn corrupt_ext4_magic(path: &std::path::Path) {
-        use std::io::{Seek, SeekFrom, Write};
-        let mut file = std::fs::OpenOptions::new().write(true).open(path).unwrap();
-
-        // Seek to superblock magic offset and zero it
-        file.seek(SeekFrom::Start(1080)).unwrap();
-        file.write_all(&[0x00, 0x00]).unwrap();
-        file.sync_all().unwrap();
     }
 
     #[test]
@@ -777,28 +444,22 @@ mod tests {
         std::fs::create_dir_all(&temp_dir).unwrap();
         let disk_path = temp_dir.join("test_overlay.raw");
 
-        // Clean up any existing file
         let _ = std::fs::remove_file(&disk_path);
         let _ = std::fs::remove_file(disk_path.with_extension("formatted"));
 
-        // Create overlay disk (1 GB for testing)
         let disk = OverlayDisk::open_or_create_at(&disk_path, 1).unwrap();
 
         assert!(disk_path.exists());
         assert!(disk.needs_format());
 
-        // Write ext4 magic so disk_appears_valid_ext4() passes
         write_ext4_magic(&disk_path);
 
-        // Mark as formatted
-        mark_disk_formatted(&disk_path).unwrap();
+        disk.mark_formatted().unwrap();
         assert!(!disk.needs_format());
 
-        // Delete disk
         disk.delete().unwrap();
         assert!(!disk_path.exists());
 
-        // Clean up temp dir
         let _ = std::fs::remove_dir(&temp_dir);
     }
 
@@ -811,8 +472,7 @@ mod tests {
 
     #[test]
     fn test_overlay_disk_ensure_formatted() {
-        // Skip if mkfs.ext4 is not available (CI without e2fsprogs)
-        if find_e2fsprogs_tool("mkfs.ext4").is_none() {
+        if disk_utils::find_e2fsprogs_tool("mkfs.ext4").is_none() {
             eprintln!("skipping test_overlay_disk_ensure_formatted: mkfs.ext4 not found");
             return;
         }
@@ -821,24 +481,39 @@ mod tests {
         std::fs::create_dir_all(&temp_dir).unwrap();
         let disk_path = temp_dir.join("fmt_overlay.raw");
 
-        // Clean up any existing files
         let _ = std::fs::remove_file(&disk_path);
         let _ = std::fs::remove_file(disk_path.with_extension("formatted"));
 
-        // Create overlay disk (1 GB sparse)
         let disk = OverlayDisk::open_or_create_at(&disk_path, 1).unwrap();
         assert!(disk.needs_format());
 
-        // Format it — this calls mkfs.ext4 for real
         disk.ensure_formatted().unwrap();
         assert!(!disk.needs_format());
 
-        // Calling ensure_formatted again should be a no-op
         disk.ensure_formatted().unwrap();
 
-        // Clean up
         disk.delete().unwrap();
         assert!(!disk_path.exists());
+        let _ = std::fs::remove_dir(&temp_dir);
+    }
+
+    #[test]
+    fn test_typed_expand_updates_cached_size() {
+        let temp_dir = std::env::temp_dir().join("smolvm_test_typed_expand");
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let disk_path = temp_dir.join("typed_expand_test.raw");
+
+        let _ = std::fs::remove_file(&disk_path);
+
+        let _disk = StorageDisk::open_or_create_at(&disk_path, 1).unwrap();
+        expand_disk::<Storage>(&disk_path, 2).unwrap();
+
+        let disk = StorageDisk::open_or_create_at(&disk_path, 2).unwrap();
+        assert_eq!(disk.size_gb(), 2);
+        let metadata = std::fs::metadata(&disk_path).unwrap();
+        assert_eq!(metadata.len(), 2 * BYTES_PER_GIB);
+
+        let _ = std::fs::remove_file(&disk_path);
         let _ = std::fs::remove_dir(&temp_dir);
     }
 
@@ -848,25 +523,19 @@ mod tests {
         std::fs::create_dir_all(&temp_dir).unwrap();
         let disk_path = temp_dir.join("expand_test.raw");
 
-        // Clean up any existing file
         let _ = std::fs::remove_file(&disk_path);
 
-        // Create a small initial disk (100 MB)
-        let initial_size = 100 * BYTES_PER_MIB;
-        create_sparse_disk(&disk_path, initial_size, "test").unwrap();
+        let initial_size = BYTES_PER_GIB;
+        disk_utils::create_sparse_disk::<Storage>(&disk_path, initial_size).unwrap();
 
-        // Verify initial size
         let metadata = std::fs::metadata(&disk_path).unwrap();
         assert_eq!(metadata.len(), initial_size);
 
-        // Expand to 200 MB
-        expand_disk(&disk_path, 200, "test").unwrap();
+        expand_disk::<Storage>(&disk_path, 2).unwrap();
 
-        // Verify new size
         let metadata = std::fs::metadata(&disk_path).unwrap();
-        assert_eq!(metadata.len(), 200 * BYTES_PER_GIB);
+        assert_eq!(metadata.len(), 2 * BYTES_PER_GIB);
 
-        // Clean up
         let _ = std::fs::remove_file(&disk_path);
         let _ = std::fs::remove_dir(&temp_dir);
     }
@@ -877,24 +546,19 @@ mod tests {
         std::fs::create_dir_all(&temp_dir).unwrap();
         let disk_path = temp_dir.join("shrink_test.raw");
 
-        // Clean up any existing file
         let _ = std::fs::remove_file(&disk_path);
 
-        // Create a 10 GB disk
         let initial_size = 10 * BYTES_PER_GIB;
-        create_sparse_disk(&disk_path, initial_size, "test").unwrap();
+        disk_utils::create_sparse_disk::<Storage>(&disk_path, initial_size).unwrap();
 
-        // Try to shrink to 5 GB - should fail
-        let result = expand_disk(&disk_path, 5, "test");
+        let result = expand_disk::<Storage>(&disk_path, 5);
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.to_string().contains("must be larger"));
 
-        // Verify size unchanged
         let metadata = std::fs::metadata(&disk_path).unwrap();
         assert_eq!(metadata.len(), initial_size);
 
-        // Clean up
         let _ = std::fs::remove_file(&disk_path);
         let _ = std::fs::remove_dir(&temp_dir);
     }
@@ -905,19 +569,64 @@ mod tests {
         std::fs::create_dir_all(&temp_dir).unwrap();
         let disk_path = temp_dir.join("same_test.raw");
 
-        // Clean up any existing file
         let _ = std::fs::remove_file(&disk_path);
 
-        // Create a 10 GB disk
         let initial_size = 10 * BYTES_PER_GIB;
-        create_sparse_disk(&disk_path, initial_size, "test").unwrap();
+        disk_utils::create_sparse_disk::<Storage>(&disk_path, initial_size).unwrap();
 
-        // Try to expand to same size - should fail (must be strictly larger)
-        let result = expand_disk(&disk_path, 10, "test");
+        let result = expand_disk::<Storage>(&disk_path, 10);
         assert!(result.is_err());
 
-        // Clean up
         let _ = std::fs::remove_file(&disk_path);
         let _ = std::fs::remove_dir(&temp_dir);
+    }
+
+    /// Write ext4 magic bytes to make `file` command recognize it as ext4.
+    /// ext4 superblock is at offset 1024, magic number 0xEF53 is at offset 56.
+    fn write_ext4_magic(path: &std::path::Path) {
+        use std::io::{Seek, SeekFrom, Write};
+        let mut file = std::fs::OpenOptions::new().write(true).open(path).unwrap();
+
+        file.seek(SeekFrom::Start(1080)).unwrap();
+        file.write_all(&[0x53, 0xEF]).unwrap();
+        file.sync_all().unwrap();
+    }
+
+    /// Corrupt the ext4 magic bytes by zeroing them.
+    fn corrupt_ext4_magic(path: &std::path::Path) {
+        use std::io::{Seek, SeekFrom, Write};
+        let mut file = std::fs::OpenOptions::new().write(true).open(path).unwrap();
+
+        file.seek(SeekFrom::Start(1080)).unwrap();
+        file.write_all(&[0x00, 0x00]).unwrap();
+        file.sync_all().unwrap();
+    }
+
+    /// Check if a disk file appears to be a valid ext4 filesystem.
+    fn disk_appears_valid_ext4(disk_path: &Path) -> bool {
+        let output = std::process::Command::new("file")
+            .arg("-b")
+            .arg(disk_path)
+            .output();
+
+        match output {
+            Ok(output) if output.status.success() => {
+                let desc = String::from_utf8_lossy(&output.stdout);
+                let is_ext4 =
+                    desc.contains("ext4") || desc.contains("ext2") || desc.contains("ext3");
+                if !is_ext4 {
+                    tracing::debug!(
+                        path = %disk_path.display(),
+                        file_type = %desc.trim(),
+                        "disk is not ext4"
+                    );
+                }
+                is_ext4
+            }
+            _ => {
+                tracing::debug!(path = %disk_path.display(), "could not verify disk type, assuming valid");
+                true
+            }
+        }
     }
 }


### PR DESCRIPTION
Essentially the same as this discarded PR: https://github.com/smol-machines/smolvm/pull/46

- Remove the duplicate creation logic shared by OverlayDisk and StorageDisk
- Created marker types: `Overlay` and `Storage`, and the `DiskType` trait. This binds disk-related functions tighter to type of disks, e.g. the sematics of `func_name<Overlay>(...)` and `func_name<Storage>(...)` instead of `func_name(..., "storage")` or `func_name(..., "overlay")`
- Defined a template VmDisk, and remade `StorageDisk` / `OverlayDisk` as `VmDisk<Storage>` and `VmDisk<Overlay>`
- also create a separate `disk_utils` module for all file and disk operations

