### PR TITLE
fix: show image download progress for pack

### DIFF
--- a/src/cli/pack.rs
+++ b/src/cli/pack.rs
@@ -8,7 +8,7 @@
 //! - Configuration manifest
 
 use clap::{Args, Subcommand};
-use smolvm::agent::{AgentClient, AgentManager, PullOptions, VmResources};
+use smolvm::agent::{AgentClient, AgentManager, VmResources};
 use smolvm::data::resources::DEFAULT_MICROVM_CPU_COUNT;
 
 /// Default memory for packed VMs. Same as machine create — memory is elastic
@@ -258,12 +258,11 @@ impl PackCreateCmd {
         let mut client = guard.manager.connect()?;
 
         // Pull image
-        println!("Pulling {}...", image);
-        let mut pull_opts = PullOptions::new().use_registry_config(true);
-        if let Some(ref oci_platform) = pack_config.oci_platform {
-            pull_opts = pull_opts.oci_platform(oci_platform);
-        }
-        let image_info = client.pull(&image, pull_opts)?;
+        let image_info = crate::cli::pull_with_progress(
+            &mut client,
+            &image,
+            pack_config.oci_platform.as_deref(),
+        )?;
         debug!(image_info = ?image_info, "image pulled");
 
         println!(


### PR DESCRIPTION
### Testing

```
qiaofu@Fus-MacBook-Pro-Dev smolvm-issue-103 % smolvm pack create --image python:3.12-alpine -o ./python312
Starting agent VM...
Pulling image python:3.12-alpine... done.                              ng...
Image: python:3.12-alpine (4 layers, 356586447 bytes)
Collecting runtime libraries...
Collecting agent rootfs...
Creating storage template...
Exporting 4 layers...
  Layer 1/4: sha256:d8ad8cd72600... 8 MB done
  Layer 2/4: sha256:0eea6371d752... 1 MB done
  Layer 3/4: sha256:af6249c05239... 42 MB done
  Layer 4/4: sha256:7970bd897195... 5 KB done
Assembling packed binary done
Packed: ./python312 (stub: 19834KB, total: 42791KB)
Assets: ./python312.smolmachine (22954KB compressed)
Signing binary with hypervisor entitlements...
Signed successfully

Run with: ./python312
Note: Keep the .smolmachine file alongside the binary
Options: --help for usage
```