### PR TITLE
feat: workspace shared directory convention functionality

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,6 +225,29 @@ smolvm machine cp ./script.py myvm:/workspace/script.py
 smolvm machine cp myvm:/workspace/output.json ./output.json
 ```
 
+**Image-based VMs (--image):** Files copied with `cp` are visible to
+`exec` at the same path, and vice versa. This works for any path —
+`/tmp`, `/home`, `/workspace`, etc. Under the hood, `cp` routes
+through the container's overlay filesystem so both commands see the
+same files.
+
+**`/workspace` shared directory:** Every machine has a `/workspace`
+directory that is shared between the VM and the container. It persists
+across `exec` sessions and is a good default location for scripts,
+data, and results:
+
+```bash
+# Typical agent workflow: copy code in, execute, extract results
+smolvm machine create r-sandbox --image r-base:latest --net
+smolvm machine start --name r-sandbox
+
+smolvm machine cp analysis.R r-sandbox:/workspace/analysis.R
+smolvm machine exec --name r-sandbox -- Rscript /workspace/analysis.R
+smolvm machine cp r-sandbox:/workspace/results.csv ./results.csv
+
+smolvm machine stop --name r-sandbox
+```
+
 **Behavior and limits:**
 
 - Files up to 1 MiB transfer as a single message — no perceptible
@@ -245,7 +268,7 @@ smolvm machine cp myvm:/workspace/output.json ./output.json
   mid-stream, the staging file is cleaned up and the original
   destination (if any) is unaffected.
 
-Typical throughput on local KVM, Linux host: ~11 MB/s upload,
+Typical throughput on macOS (Apple Silicon): ~35-42 MB/s upload,
 ~170 MB/s download.
 
 ## Streaming Exec

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -924,6 +924,7 @@ fn create_storage_dirs(mount_point: &str) {
         "configs",
         "manifests",
         "overlays",
+        "workspace",
         "containers/run",
         "containers/logs",
         "containers/exit",
@@ -1514,14 +1515,64 @@ fn apply_mode_best_effort(path: &std::path::Path, mode: u32) {
 #[cfg(not(unix))]
 fn apply_mode_best_effort(_path: &std::path::Path, _mode: u32) {}
 
-/// Atomically install `data` at `path` via a staging file + rename.
+/// Resolve a guest path through the active persistent container overlay.
 ///
+/// When an image-based VM has a mounted persistent overlay, file I/O
+/// paths (from `machine cp`) target the overlay's merged directory so
+/// files are visible inside the container. The host ensures the overlay
+/// is mounted before sending file I/O requests (via `PrepareOverlay`).
+///
+/// Returns the path unchanged for bare VMs (no overlay) or paths that
+/// target the VM's internal directories (`/storage/...`).
+fn resolve_container_path(path: &str) -> std::path::PathBuf {
+    // Don't redirect VM-internal paths.
+    if path.starts_with("/storage/") || path.starts_with("/proc/") || path.starts_with("/sys/") {
+        return std::path::PathBuf::from(path);
+    }
+
+    // /workspace is bind-mounted from /storage/workspace into the container.
+    // Rewrite so the agent writes to the bind-mount source.
+    if let Some(relative) =
+        path.strip_prefix("/workspace/").or_else(
+            || {
+                if path == "/workspace" {
+                    Some("")
+                } else {
+                    None
+                }
+            },
+        )
+    {
+        return std::path::PathBuf::from("/storage/workspace").join(relative);
+    }
+
+    let overlays_dir = std::path::Path::new("/storage/overlays");
+    if let Ok(entries) = std::fs::read_dir(overlays_dir) {
+        for entry in entries.flatten() {
+            if !entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with("persistent-")
+            {
+                continue;
+            }
+            let merged = entry.path().join("merged");
+            if merged.join("bin").exists() || merged.join("usr").exists() {
+                let relative = path.strip_prefix('/').unwrap_or(path);
+                return merged.join(relative);
+            }
+        }
+    }
+    std::path::PathBuf::from(path)
+}
+
 /// Shared between single-shot [`handle_file_write`] and the streaming
 /// finalize step. The atomic-rename pattern is the thing both paths
 /// need to guarantee: partial contents never appear at `path` under
 /// any error or kill scenario.
 fn install_file_atomic(path: &str, data: &[u8], mode: Option<u32>) -> AgentResponse {
-    let target = std::path::Path::new(path);
+    let resolved = resolve_container_path(path);
+    let target = resolved.as_path();
     if let Err(resp) = ensure_parent_dir(target) {
         return resp;
     }
@@ -1736,7 +1787,8 @@ fn handle_file_write_begin(
             ),
         );
     }
-    match WriteSession::open(path.into(), mode, total_size) {
+    let resolved = resolve_container_path(&path);
+    match WriteSession::open(resolved, mode, total_size) {
         Ok(session) => (Some(session), AgentResponse::Ok { data: None }),
         Err(e) => (
             None,
@@ -1854,7 +1906,8 @@ fn handle_streaming_file_read(
     stream: &mut impl ReadWrite,
     path: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let mut file = match std::fs::File::open(path) {
+    let resolved = resolve_container_path(path);
+    let mut file = match std::fs::File::open(&resolved) {
         Ok(f) => f,
         Err(e) => {
             send_response(
@@ -2042,6 +2095,12 @@ fn spawn_interactive_command(
         );
     }
 
+    // Shared workspace: /storage/workspace → /workspace inside container
+    let workspace_src = std::path::Path::new("/storage/workspace");
+    if workspace_src.exists() {
+        spec.add_bind_mount(&workspace_src.to_string_lossy(), "/workspace", false);
+    }
+
     spec.write_to(&bundle_path)
         .map_err(|e| format!("failed to write OCI spec: {}", e))?;
 
@@ -2121,6 +2180,12 @@ fn spawn_interactive_command(
             container_path,
             *read_only,
         );
+    }
+
+    // Shared workspace: /storage/workspace → /workspace inside container
+    let workspace_src = std::path::Path::new("/storage/workspace");
+    if workspace_src.exists() {
+        spec.add_bind_mount(&workspace_src.to_string_lossy(), "/workspace", false);
     }
 
     spec.write_to(&bundle_path)

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -26,6 +26,7 @@ const LAYERS_DIR: &str = "layers";
 const CONFIGS_DIR: &str = "configs";
 const MANIFESTS_DIR: &str = "manifests";
 const OVERLAYS_DIR: &str = "overlays";
+const WORKSPACE_DIR: &str = "workspace";
 
 /// Global state for packed layers support.
 /// Set at startup if SMOLVM_PACKED_LAYERS env var is present.
@@ -595,6 +596,10 @@ pub fn init() -> Result<()> {
         (CONFIGS_DIR, "image configurations"),
         (MANIFESTS_DIR, "image manifests"),
         (OVERLAYS_DIR, "overlay filesystems"),
+        (
+            WORKSPACE_DIR,
+            "shared workspace (visible inside containers)",
+        ),
     ];
 
     for (dir, description) in &required_dirs {
@@ -1551,6 +1556,11 @@ impl OverlaySetup {
 }
 
 /// Prepare an overlay filesystem for a workload.
+///
+/// Reuses an existing overlay if already mounted, remounts if the upper
+/// directory exists (preserving state from previous sessions), or creates
+/// a fresh overlay. This idempotent behavior is critical for `machine cp`
+/// which may call this before or after `machine exec`.
 pub fn prepare_overlay(image: &str, workload_id: &str) -> Result<OverlayInfo> {
     // Check if we have packed layers available
     if let Some(packed_dir) = get_packed_layers_dir() {
@@ -1574,8 +1584,7 @@ pub fn prepare_overlay(image: &str, workload_id: &str) -> Result<OverlayInfo> {
         })
         .collect();
 
-    // Use shared overlay setup logic
-    OverlaySetup::new(workload_id).execute(lowerdirs)
+    OverlaySetup::new(workload_id).execute_or_remount(lowerdirs)
 }
 
 /// Prepare an overlay filesystem using pre-packed layers.
@@ -1835,6 +1844,12 @@ pub fn run_command(
                 container_path,
                 *read_only,
             );
+        }
+
+        // Shared workspace: /storage/workspace → /workspace inside container
+        let workspace_src = Path::new(STORAGE_ROOT).join(WORKSPACE_DIR);
+        if workspace_src.exists() {
+            spec.add_bind_mount(&workspace_src.to_string_lossy(), "/workspace", false);
         }
 
         // Write config.json to bundle

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -1343,9 +1343,23 @@ impl CpCmd {
                 ));
             };
 
-        let (manager, mut client) = vm_common::ensure_running_and_connect(&Some(machine_name))?;
+        let (manager, mut client) =
+            vm_common::ensure_running_and_connect(&Some(machine_name.clone()))?;
         // Detach so the VM keeps running after cp exits.
         manager.detach();
+
+        // For image-based VMs, ensure the persistent container overlay is
+        // mounted so cp targets the container filesystem (not the VM rootfs).
+        // prepare_overlay is idempotent: reuses if mounted, remounts if upper
+        // exists, creates fresh otherwise.
+        if let Some(image) = smolvm::db::SmolvmDb::open()
+            .ok()
+            .and_then(|db| db.get_vm(&machine_name).ok().flatten())
+            .and_then(|r| r.image.clone())
+        {
+            let overlay_id = format!("persistent-{}", machine_name);
+            let _ = client.prepare_overlay(&image, &overlay_id);
+        }
 
         if is_upload {
             // Stream from file — only one chunk (~1 MiB) in memory at a time.


### PR DESCRIPTION
mroe of a draft - there's a lot of cases where we want files access within the guest vm <-> and guest vm's container.

workspace seems like a natural place for that. Let's implement it as an experiment