### PR TITLE
chore: enforce linux-only build target for smolvm-agent at Cargo level

### DIFF
--- a/crates/smolvm-agent/Cargo.toml
+++ b/crates/smolvm-agent/Cargo.toml
@@ -23,3 +23,13 @@ tempfile = "3"
 # Linux-specific dependencies for vsock
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = { version = "0.27", features = ["socket", "fs"] }
+
+[package.metadata]
+# smolvm-agent only compiles and runs on Linux (inside the VM).
+# Build using: ./scripts/rebuild-agent.sh
+
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+# This crate does not support non-Linux targets.
+# Attempting to compile it directly on other OS will produce errors.
+# Use ./scripts/rebuild-agent.sh instead.
+"smolvm-agent-is-linux-only-run-scripts-rebuild-agent-sh" = { version = "0.0.0" }


### PR DESCRIPTION
**Summary:**
This PR cleanly enforces that `smolvm-agent` can only be built for Linux targets by utilizing a Cargo.toml `[target]` guard. 

Since the agent is intentionally designed to compile and run exclusively inside a Linux VM (via [scripts/rebuild-agent.sh]), attempting to compile it natively on macOS results in confusing missing symbol/syscall errors. Instead of cluttering the codebase with `#[cfg]` attribute noise, this adds an unsupported mock dependency for non-Linux OS targets.

If a developer accidentally compiles the crate directly on macOS, the build now fails immediately and gracefully with a descriptive error message:
```text
error: no matching package named `smolvm-agent-is-linux-only-run-scripts-rebuild-agent-sh` found
```

Closes: #112