### PR TITLE
fix: crun and resize2fs are not executable

### DIFF
--- a/scripts/build-agent-rootfs.sh
+++ b/scripts/build-agent-rootfs.sh
@@ -146,24 +146,31 @@ install_packages_apk_static() {
     echo "Packages installed successfully"
 }
 
-repair_required_tool_modes() {
+repair_executable_modes() {
     local rootfs_dir="$1"
-    local tools=(
-        "$rootfs_dir/usr/bin/crun"
-        "$rootfs_dir/usr/sbin/resize2fs"
+    local dirs=(
+        "$rootfs_dir/bin"
+        "$rootfs_dir/sbin"
+        "$rootfs_dir/usr/bin"
+        "$rootfs_dir/usr/sbin"
+        "$rootfs_dir/usr/local/bin"
+        "$rootfs_dir/usr/local/sbin"
     )
 
-    echo "Repairing required tool permissions..."
-    for tool in "${tools[@]}"; do
-        if [[ ! -f "$tool" ]]; then
+    echo "Normalizing executable permissions..."
+    for dir in "${dirs[@]}"; do
+        if [[ ! -d "$dir" ]]; then
             continue
         fi
 
         # On the macOS build path, apk install into the host-mounted rootfs can
-        # leave these guest tools without execute bits (observed as mode 0600).
-        # They are required for packed/container execution, so restore the
-        # standard executable mode before install or packing preserves the bug.
-        chmod 755 "$tool"
+        # strip execute bits from package-installed guest tools. We observed
+        # this on crun, resize2fs, and e2fsck, and the failures only surfaced
+        # later during packed/container execution. These directories are the
+        # standard executable locations in the guest rootfs, so normalize their
+        # contents before install/pack preserves the bad modes.
+        find "$dir" -type d -exec chmod 755 {} +
+        find "$dir" -type f -exec chmod 755 {} +
     done
 }
 
@@ -186,7 +193,7 @@ else
     exit 1
 fi
 
-repair_required_tool_modes "$OUTPUT_DIR"
+repair_executable_modes "$OUTPUT_DIR"
 
 # Create necessary directories
 mkdir -p "$OUTPUT_DIR/storage"

--- a/scripts/build-agent-rootfs.sh
+++ b/scripts/build-agent-rootfs.sh
@@ -146,6 +146,27 @@ install_packages_apk_static() {
     echo "Packages installed successfully"
 }
 
+repair_required_tool_modes() {
+    local rootfs_dir="$1"
+    local tools=(
+        "$rootfs_dir/usr/bin/crun"
+        "$rootfs_dir/usr/sbin/resize2fs"
+    )
+
+    echo "Repairing required tool permissions..."
+    for tool in "${tools[@]}"; do
+        if [[ ! -f "$tool" ]]; then
+            continue
+        fi
+
+        # On the macOS build path, apk install into the host-mounted rootfs can
+        # leave these guest tools without execute bits (observed as mode 0600).
+        # They are required for packed/container execution, so restore the
+        # standard executable mode before install or packing preserves the bug.
+        chmod 755 "$tool"
+    done
+}
+
 if [[ "$(uname -s)" == "Linux" ]]; then
     # On Linux, apk.static is preferred — it handles cross-arch correctly
     install_packages_apk_static
@@ -164,6 +185,8 @@ else
     echo "Install smolvm first: https://github.com/smolvm/smolvm"
     exit 1
 fi
+
+repair_required_tool_modes "$OUTPUT_DIR"
 
 # Create necessary directories
 mkdir -p "$OUTPUT_DIR/storage"

--- a/tests/test_pack.sh
+++ b/tests/test_pack.sh
@@ -761,7 +761,7 @@ test_packed_rbase_run() {
     local exit_code=$?
 
     [[ $exit_code -eq 124 ]] && { echo "TIMEOUT"; return 1; }
-    [[ "$result" == *"R version"* ]]
+    [[ "$result" == *"GNU R Version"* ]] || [[ "$result" == *"r ('littler') version"* ]]
 }
 
 test_packed_rbase_auto_storage() {


### PR DESCRIPTION
run command for packed is failing due to error: permission denied.


After the fix. Both binaries become executable

```
qiaofu@Fus-MacBook-Pro-Dev smolvm-rootfs-mode-fix % ls -l dist/smolvm-0.5.10-darwin-arm64/agent-rootfs/usr/bin/crun 
-rwxr-xr-x@ 1 qiaofu  staff  469752 Nov 25  2023 dist/smolvm-0.5.10-darwin-arm64/agent-rootfs/usr/bin/crun
qiaofu@Fus-MacBook-Pro-Dev smolvm-rootfs-mode-fix % 
qiaofu@Fus-MacBook-Pro-Dev smolvm-rootfs-mode-fix % 
qiaofu@Fus-MacBook-Pro-Dev smolvm-rootfs-mode-fix % ls -l dist/smolvm-0.5.10-darwin-arm64/agent-rootfs/usr/sbin/resize2fs 
-rwxr-xr-x@ 1 qiaofu  staff  67264 Oct 17  2023 dist/smolvm-0.5.10-darwin-arm64/agent-rootfs/usr/sbin/resize2fs
```

### Test

`test_pack` all passed

```
[PASS] Pack r-base (large image, streaming export)
[TEST] Packed r-base run
[PASS] Packed r-base run
[TEST] Packed r-base auto-sized storage (force-extract)
[PASS] Packed r-base auto-sized storage (force-extract)

==========================================
  Pack Tests Summary
==========================================

Tests run:    47
Tests passed: 47
Tests failed: 0

All tests passed!
```