### PR TITLE
feat: use unix sock for listen by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ smolvm pack create --image IMAGE -o PATH          # package
 smolvm pack create --from-vm NAME -o PATH         # pack from VM snapshot
 smolvm pack run [--sidecar PATH] [-- CMD]         # run .smolmachine
 
-smolvm serve start [--listen ADDR:PORT]           # HTTP API
+smolvm serve start [--listen ADDR:PORT|PATH]      # HTTP API
 smolvm config registries edit                     # registry auth
 ```
 
@@ -328,7 +328,7 @@ The `.smolmachine` manifest includes registry-oriented metadata:
 
 ## HTTP API
 
-Start with `smolvm serve start --listen 127.0.0.1:8080`. Key endpoints:
+Start with `smolvm serve start --listen 127.0.0.1:8080` or `smolvm serve start --listen /tmp/smol.sock`. Key endpoints:
 
 ```
 POST   /api/v1/machines                    Create machine

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -328,7 +328,7 @@ The `.smolmachine` manifest includes registry-oriented metadata:
 
 ## HTTP API
 
-Start with `smolvm serve start --listen 127.0.0.1:8080` or `smolvm serve start --listen /tmp/smol.sock`. Key endpoints:
+Start with `smolvm serve start --listen 127.0.0.1:8080` or `smolvm serve start --listen $XDG_RUNTIME_DIR/smolvm.sock`. Key endpoints:
 
 ```
 POST   /api/v1/machines                    Create machine

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ futures-util = "0.3"
 # OpenAPI documentation
 utoipa = { version = "5", features = ["axum_extras"] }
 utoipa-axum = "0.2"
-utoipa-swagger-ui = { version = "9", features = ["axum"] }
+utoipa-swagger-ui = { version = "9", features = ["axum", "vendored"] }
 ipnet = "2.12.0"
 metrics = "0.24"
 metrics-exporter-prometheus = { version = "0.16", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ tempfile = "3"
 
 # HTTP API server
 tokio = { version = "1", features = ["full"] }
-axum = { version = "0.7", features = ["macros"] }
-tower-http = { version = "0.5", features = ["cors", "trace", "timeout"] }
+axum = { version = "0.8", features = ["macros"] }
+tower-http = { version = "0.6", features = ["cors", "trace", "timeout"] }
 tokio-stream = "0.1"
 parking_lot = "0.12"
 async-stream = "0.3"
@@ -57,7 +57,7 @@ futures-util = "0.3"
 # OpenAPI documentation
 utoipa = { version = "5", features = ["axum_extras"] }
 utoipa-axum = "0.2"
-utoipa-swagger-ui = { version = "8", features = ["axum"] }
+utoipa-swagger-ui = { version = "9", features = ["axum"] }
 ipnet = "2.12.0"
 metrics = "0.24"
 metrics-exporter-prometheus = { version = "0.16", default-features = false }

--- a/src/api/handlers/health.rs
+++ b/src/api/handlers/health.rs
@@ -23,20 +23,13 @@ pub fn mark_server_start() {
         (status = 200, description = "Server is healthy", body = HealthResponse)
     )
 )]
-pub async fn health(state: Option<State<Arc<ApiState>>>) -> Json<HealthResponse> {
-    let (machines, uptime) = match state {
-        Some(State(s)) => {
-            let counts = s.machine_counts();
-            (
-                Some(MachineCountsResponse {
-                    total: counts.0,
-                    running: counts.1,
-                }),
-                SERVER_START.get().map(|t| t.elapsed().as_secs()),
-            )
-        }
-        None => (None, None),
-    };
+pub async fn health(State(state): State<Arc<ApiState>>) -> Json<HealthResponse> {
+    let counts = state.machine_counts();
+    let machines = Some(MachineCountsResponse {
+        total: counts.0,
+        running: counts.1,
+    });
+    let uptime = SERVER_START.get().map(|t| t.elapsed().as_secs());
 
     Json(HealthResponse {
         status: "ok",

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -24,7 +24,7 @@ pub mod types;
 
 use axum::{
     extract::Request,
-    http::HeaderValue,
+    http::{HeaderValue, StatusCode},
     middleware::{self, Next},
     response::Response,
     routing::{delete, get, post, put},
@@ -160,9 +160,10 @@ pub fn create_router(state: Arc<ApiState>, cors_origins: Vec<String>) -> Router 
         .route("/:id/images", get(handlers::images::list_images))
         .route("/:id/images/pull", post(handlers::images::pull_image))
         // Apply timeout only to these routes
-        .layer(TimeoutLayer::new(Duration::from_secs(
-            API_REQUEST_TIMEOUT_SECS,
-        )));
+        .layer(TimeoutLayer::with_status_code(
+            StatusCode::REQUEST_TIMEOUT,
+            Duration::from_secs(API_REQUEST_TIMEOUT_SECS),
+        ));
 
     // Machine routes
     let machine_routes = Router::new()

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -142,26 +142,26 @@ pub fn create_router(state: Arc<ApiState>, cors_origins: Vec<String>) -> Router 
     let health_route = Router::new().route("/health", get(handlers::health::health));
 
     // SSE logs route (no timeout - streams indefinitely)
-    let logs_route = Router::new().route("/:id/logs", get(handlers::exec::stream_logs));
+    let logs_route = Router::new().route("/{id}/logs", get(handlers::exec::stream_logs));
 
     // Machine routes with timeout
     let machine_routes_with_timeout = Router::new()
         .route("/", post(handlers::machines::create_machine))
         .route("/", get(handlers::machines::list_machines))
-        .route("/:id", get(handlers::machines::get_machine))
-        .route("/:id/start", post(handlers::machines::start_machine))
-        .route("/:id/stop", post(handlers::machines::stop_machine))
-        .route("/:id", delete(handlers::machines::delete_machine))
+        .route("/{id}", get(handlers::machines::get_machine))
+        .route("/{id}/start", post(handlers::machines::start_machine))
+        .route("/{id}/stop", post(handlers::machines::stop_machine))
+        .route("/{id}", delete(handlers::machines::delete_machine))
         // Exec routes
-        .route("/:id/exec", post(handlers::exec::exec_command))
-        .route("/:id/exec/stream", post(handlers::exec::exec_stream))
-        .route("/:id/run", post(handlers::exec::run_command))
+        .route("/{id}/exec", post(handlers::exec::exec_command))
+        .route("/{id}/exec/stream", post(handlers::exec::exec_stream))
+        .route("/{id}/run", post(handlers::exec::run_command))
         // File I/O routes
-        .route("/:id/files/*path", put(handlers::files::upload_file))
-        .route("/:id/files/*path", get(handlers::files::download_file))
+        .route("/{id}/files/{*path}", put(handlers::files::upload_file))
+        .route("/{id}/files/{*path}", get(handlers::files::download_file))
         // Image routes
-        .route("/:id/images", get(handlers::images::list_images))
-        .route("/:id/images/pull", post(handlers::images::pull_image))
+        .route("/{id}/images", get(handlers::images::list_images))
+        .route("/{id}/images/pull", post(handlers::images::pull_image))
         // Apply timeout only to these routes
         .layer(TimeoutLayer::with_status_code(
             StatusCode::REQUEST_TIMEOUT,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -6,8 +6,11 @@
 //! # Example
 //!
 //! ```bash
-//! # Start the server
-//! smolvm serve --listen 127.0.0.1:8080
+//! # Start the server on the default Unix socket
+//! smolvm serve start
+//!
+//! # Or start the server on TCP explicitly
+//! smolvm serve start --listen 127.0.0.1:8080
 //!
 //! # Create a machine
 //! curl -X POST http://localhost:8080/api/v1/machines \

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -143,9 +143,14 @@ impl ServeStartCmd {
         });
 
         // Create router
-        let app = smolvm::api::create_router(state, self.cors_origins);
+        let app = smolvm::api::create_router(state, self.cors_origins.clone());
 
-        Self::bind(listen_target, app).await?;
+        // Listen server on TCP or Unix socket
+        match listen_target {
+            ListenTarget::Tcp(addr) => self.serve_tcp(addr, app).await?,
+            #[cfg(unix)]
+            ListenTarget::Unix(path) => self.serve_unix(path, app).await?,
+        }
 
         // Signal supervisor to stop
         let _ = shutdown_tx.send(true);
@@ -159,15 +164,7 @@ impl ServeStartCmd {
         Ok(())
     }
 
-    async fn bind(listen_target: ListenTarget, app: Router) -> Result<()> {
-        match listen_target {
-            ListenTarget::Tcp(addr) => Self::bind_tcp(addr, app).await,
-            #[cfg(unix)]
-            ListenTarget::Unix(path) => Self::bind_unix(path, app).await,
-        }
-    }
-
-    async fn bind_tcp(addr: SocketAddr, app: Router) -> Result<()> {
+    async fn serve_tcp(&self, addr: SocketAddr, app: Router) -> Result<()> {
         let listener = tokio::net::TcpListener::bind(addr)
             .await
             .map_err(smolvm::error::Error::Io)?;
@@ -182,7 +179,7 @@ impl ServeStartCmd {
     }
 
     #[cfg(unix)]
-    async fn bind_unix(path: PathBuf, app: Router) -> Result<()> {
+    async fn serve_unix(&self, path: PathBuf, app: Router) -> Result<()> {
         let socket_guard = UnixSocketGuard::bind(&path)?;
         let listener =
             tokio::net::UnixListener::bind(&socket_guard.path).map_err(smolvm::error::Error::Io)?;

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -1,7 +1,9 @@
 //! HTTP API server command.
 
+use axum::Router;
 use clap::Parser;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use smolvm::api::state::ApiState;
@@ -30,6 +32,7 @@ API ENDPOINTS:
 EXAMPLES:
   smolvm serve start                         Listen on 127.0.0.1:8080 (default)
   smolvm serve start -l 0.0.0.0:9000         Listen on all interfaces, port 9000
+  smolvm serve start -l /tmp/smol.sock       Listen on a Unix domain socket
   smolvm serve start -v                      Enable verbose logging")]
     Start(ServeStartCmd),
 
@@ -48,12 +51,12 @@ impl ServeCmd {
 
 #[derive(Parser, Debug)]
 pub struct ServeStartCmd {
-    /// Address and port to listen on
+    /// Address and port or Unix socket path to listen on
     #[arg(
         short,
         long,
         default_value = "127.0.0.1:8080",
-        value_name = "ADDR:PORT"
+        value_name = "ADDR:PORT|PATH"
     )]
     listen: String,
 
@@ -78,13 +81,7 @@ impl ServeStartCmd {
             std::env::set_var("SMOLVM_LOG_FORMAT", "json");
         }
 
-        // Parse listen address
-        let addr: SocketAddr = self.listen.parse().map_err(|e| {
-            smolvm::error::Error::config(
-                "parse listen address",
-                format!("invalid address '{}': {}", self.listen, e),
-            )
-        })?;
+        let listen_target = ListenTarget::parse(&self.listen)?;
 
         // Set up verbose logging if requested
         if self.verbose {
@@ -100,18 +97,19 @@ impl ServeStartCmd {
             .build()
             .map_err(smolvm::error::Error::Io)?;
 
-        runtime.block_on(async move { self.run_server(addr).await })
+        runtime.block_on(async move { self.run_server(listen_target).await })
     }
 
-    async fn run_server(self, addr: SocketAddr) -> Result<()> {
-        // Security warning if binding to all interfaces
-        if addr.ip().is_unspecified() {
-            eprintln!(
-                "WARNING: Server is listening on all interfaces ({}).",
-                addr.ip()
-            );
-            eprintln!("         The API has no authentication - any network client can control this host.");
-            eprintln!("         Consider using --listen 127.0.0.1:8080 for local-only access.");
+    async fn run_server(self, listen_target: ListenTarget) -> Result<()> {
+        if let ListenTarget::Tcp(addr) = &listen_target {
+            if addr.ip().is_unspecified() {
+                eprintln!(
+                    "WARNING: Server is listening on all interfaces ({}).",
+                    addr.ip()
+                );
+                eprintln!("         The API has no authentication - any network client can control this host.");
+                eprintln!("         Consider using --listen 127.0.0.1:8080 for local-only access.");
+            }
         }
 
         // Install Prometheus metrics recorder and mark start time
@@ -147,19 +145,7 @@ impl ServeStartCmd {
         // Create router
         let app = smolvm::api::create_router(state, self.cors_origins);
 
-        // Create listener
-        let listener = tokio::net::TcpListener::bind(addr)
-            .await
-            .map_err(smolvm::error::Error::Io)?;
-
-        tracing::info!(address = %addr, "starting HTTP API server");
-        println!("smolvm API server listening on http://{}", addr);
-
-        // Run the server with graceful shutdown (VMs keep running independently)
-        axum::serve(listener, app)
-            .with_graceful_shutdown(shutdown_signal())
-            .await
-            .map_err(smolvm::error::Error::Io)?;
+        Self::bind(listen_target, app).await?;
 
         // Signal supervisor to stop
         let _ = shutdown_tx.send(true);
@@ -171,6 +157,110 @@ impl ServeStartCmd {
         }
 
         Ok(())
+    }
+
+    async fn bind(listen_target: ListenTarget, app: Router) -> Result<()> {
+        match listen_target {
+            ListenTarget::Tcp(addr) => Self::bind_tcp(addr, app).await,
+            #[cfg(unix)]
+            ListenTarget::Unix(path) => Self::bind_unix(path, app).await,
+        }
+    }
+
+    async fn bind_tcp(addr: SocketAddr, app: Router) -> Result<()> {
+        let listener = tokio::net::TcpListener::bind(addr)
+            .await
+            .map_err(smolvm::error::Error::Io)?;
+
+        tracing::info!(address = %addr, "starting HTTP API server");
+        println!("smolvm API server listening on http://{}", addr);
+
+        axum::serve(listener, app)
+            .with_graceful_shutdown(shutdown_signal())
+            .await
+            .map_err(smolvm::error::Error::Io)
+    }
+
+    #[cfg(unix)]
+    async fn bind_unix(path: PathBuf, app: Router) -> Result<()> {
+        let socket_guard = UnixSocketGuard::bind(&path)?;
+        let listener =
+            tokio::net::UnixListener::bind(&socket_guard.path).map_err(smolvm::error::Error::Io)?;
+
+        tracing::info!(path = %socket_guard.path.display(), "starting HTTP API server");
+        println!(
+            "smolvm API server listening on unix://{}",
+            socket_guard.path.display()
+        );
+
+        axum::serve(listener, app)
+            .with_graceful_shutdown(shutdown_signal())
+            .await
+            .map_err(smolvm::error::Error::Io)
+    }
+}
+
+#[derive(Debug, Clone)]
+enum ListenTarget {
+    Tcp(SocketAddr),
+    #[cfg(unix)]
+    Unix(PathBuf),
+}
+
+impl ListenTarget {
+    fn parse(value: &str) -> Result<Self> {
+        if let Ok(addr) = value.parse::<SocketAddr>() {
+            return Ok(Self::Tcp(addr));
+        }
+
+        #[cfg(unix)]
+        {
+            return Ok(Self::Unix(PathBuf::from(value)));
+        }
+
+        #[cfg(not(unix))]
+        {
+            Err(smolvm::error::Error::config(
+                "parse listen address",
+                format!("invalid address '{}': expected ADDR:PORT", value),
+            ))
+        }
+    }
+}
+
+#[cfg(unix)]
+#[derive(Debug)]
+struct UnixSocketGuard {
+    path: PathBuf,
+}
+
+#[cfg(unix)]
+impl UnixSocketGuard {
+    fn bind(path: &std::path::Path) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(smolvm::error::Error::Io)?;
+        }
+
+        match std::fs::remove_file(path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(smolvm::error::Error::Io(e)),
+        }
+
+        Ok(Self {
+            path: path.to_path_buf(),
+        })
+    }
+}
+
+#[cfg(unix)]
+impl Drop for UnixSocketGuard {
+    fn drop(&mut self) {
+        if let Err(e) = std::fs::remove_file(&self.path) {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                tracing::warn!(path = %self.path.display(), error = %e, "failed to remove unix socket");
+            }
+        }
     }
 }
 
@@ -208,4 +298,31 @@ async fn shutdown_signal() {
 
     tracing::info!("shutdown signal received");
     eprintln!("\nShutting down server (VMs continue running)...");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ListenTarget;
+
+    #[test]
+    fn parse_tcp_listen_target() {
+        let target = ListenTarget::parse("127.0.0.1:8080").expect("tcp target should parse");
+        match target {
+            ListenTarget::Tcp(addr) => assert_eq!(addr.to_string(), "127.0.0.1:8080"),
+            #[cfg(unix)]
+            ListenTarget::Unix(path) => panic!("expected tcp, got unix path {}", path.display()),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn parse_unix_listen_target() {
+        let target = ListenTarget::parse("/tmp/smol.sock").expect("unix target should parse");
+        match target {
+            ListenTarget::Unix(path) => {
+                assert_eq!(path, std::path::PathBuf::from("/tmp/smol.sock"))
+            }
+            ListenTarget::Tcp(addr) => panic!("expected unix, got tcp address {addr}"),
+        }
+    }
 }

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -212,7 +212,7 @@ impl ListenTarget {
 
         #[cfg(unix)]
         {
-            return Ok(Self::Unix(PathBuf::from(value)));
+            Ok(Self::Unix(PathBuf::from(value)))
         }
 
         #[cfg(not(unix))]

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -315,7 +315,7 @@ async fn shutdown_signal() {
 
 #[cfg(test)]
 mod tests {
-    use super::{default_listen_value, ListenTarget};
+    use super::ListenTarget;
 
     #[test]
     fn parse_tcp_listen_target() {

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -20,7 +20,7 @@ pub enum ServeCmd {
 Machines persist independently of the server - they continue running even if the server stops.
 
 API ENDPOINTS:
-  GET    /health                       Health check
+  GET    /health                      Health check
   POST   /api/v1/machines             Create machine
   GET    /api/v1/machines             List machines
   GET    /api/v1/machines/:id         Get machine status
@@ -30,10 +30,10 @@ API ENDPOINTS:
   DELETE /api/v1/machines/:id         Delete machine
 
 EXAMPLES:
-  smolvm serve start                         Listen on the default Unix socket
-  smolvm serve start -l 0.0.0.0:9000         Listen on all interfaces, port 9000
-  smolvm serve start -l /tmp/smol.sock       Listen on a Unix domain socket
-  smolvm serve start -v                      Enable verbose logging")]
+  smolvm serve start                                Listen on the default Unix socket (unix:///$XDG_RUNTIME_DIR/smolvm.sock)
+  smolvm serve start -l 0.0.0.0:9000                Listen on all interfaces, port 9000
+  smolvm serve start -l unix:///tmp/smol.sock       Listen on a Unix domain socket
+  smolvm serve start -v                             Enable verbose logging")]
     Start(ServeStartCmd),
 
     /// Export OpenAPI specification for SDK generation
@@ -212,7 +212,10 @@ impl ListenTarget {
 
         #[cfg(unix)]
         {
-            Ok(Self::Unix(PathBuf::from(value)))
+            let path = value
+                .strip_prefix("unix://")
+                .unwrap_or(value);
+            Ok(Self::Unix(PathBuf::from(path)))
         }
 
         #[cfg(not(unix))]
@@ -228,11 +231,12 @@ impl ListenTarget {
 fn default_listen_value() -> String {
     #[cfg(unix)]
     {
-        dirs::runtime_dir()
+        let path = dirs::runtime_dir()
             .unwrap_or_else(|| PathBuf::from("/tmp"))
             .join("smolvm.sock")
             .display()
-            .to_string()
+            .to_string();
+        format!("unix://{path}")
     }
 
     #[cfg(not(unix))]
@@ -331,6 +335,19 @@ mod tests {
     #[test]
     fn parse_unix_listen_target() {
         let target = ListenTarget::parse("/tmp/smol.sock").expect("unix target should parse");
+        match target {
+            ListenTarget::Unix(path) => {
+                assert_eq!(path, std::path::PathBuf::from("/tmp/smol.sock"))
+            }
+            ListenTarget::Tcp(addr) => panic!("expected unix, got tcp address {addr}"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn parse_unix_listen_target_with_prefix() {
+        let target =
+            ListenTarget::parse("unix:///tmp/smol.sock").expect("unix target should parse");
         match target {
             ListenTarget::Unix(path) => {
                 assert_eq!(path, std::path::PathBuf::from("/tmp/smol.sock"))

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -228,7 +228,11 @@ impl ListenTarget {
 fn default_listen_value() -> String {
     #[cfg(unix)]
     {
-        String::from("/var/run/smolvm.sock")
+        dirs::runtime_dir()
+            .unwrap_or_else(|| PathBuf::from("/tmp"))
+            .join("smolvm.sock")
+            .display()
+            .to_string()
     }
 
     #[cfg(not(unix))]
@@ -311,7 +315,7 @@ async fn shutdown_signal() {
 
 #[cfg(test)]
 mod tests {
-    use super::ListenTarget;
+    use super::{default_listen_value, ListenTarget};
 
     #[test]
     fn parse_tcp_listen_target() {

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -30,7 +30,7 @@ API ENDPOINTS:
   DELETE /api/v1/machines/:id         Delete machine
 
 EXAMPLES:
-  smolvm serve start                         Listen on 127.0.0.1:8080 (default)
+  smolvm serve start                         Listen on the default Unix socket
   smolvm serve start -l 0.0.0.0:9000         Listen on all interfaces, port 9000
   smolvm serve start -l /tmp/smol.sock       Listen on a Unix domain socket
   smolvm serve start -v                      Enable verbose logging")]
@@ -55,7 +55,7 @@ pub struct ServeStartCmd {
     #[arg(
         short,
         long,
-        default_value = "127.0.0.1:8080",
+        default_value_t = default_listen_value(),
         value_name = "ADDR:PORT|PATH"
     )]
     listen: String,
@@ -108,7 +108,7 @@ impl ServeStartCmd {
                     addr.ip()
                 );
                 eprintln!("         The API has no authentication - any network client can control this host.");
-                eprintln!("         Consider using --listen 127.0.0.1:8080 for local-only access.");
+                eprintln!("         Consider using the default Unix socket or --listen 127.0.0.1:8080 for local-only access.");
             }
         }
 
@@ -222,6 +222,18 @@ impl ListenTarget {
                 format!("invalid address '{}': expected ADDR:PORT", value),
             ))
         }
+    }
+}
+
+fn default_listen_value() -> String {
+    #[cfg(unix)]
+    {
+        String::from("/var/run/smolvm.sock")
+    }
+
+    #[cfg(not(unix))]
+    {
+        String::from("127.0.0.1:8080")
     }
 }
 

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -212,9 +212,7 @@ impl ListenTarget {
 
         #[cfg(unix)]
         {
-            let path = value
-                .strip_prefix("unix://")
-                .unwrap_or(value);
+            let path = value.strip_prefix("unix://").unwrap_or(value);
             Ok(Self::Unix(PathBuf::from(path)))
         }
 

--- a/tests/test_api.sh
+++ b/tests/test_api.sh
@@ -21,24 +21,28 @@ log_info "Pre-flight cleanup: killing orphan processes..."
 kill_orphan_smolvm_processes
 
 # API server configuration
-API_PORT=18080
-API_URL="http://127.0.0.1:$API_PORT"
+API_SOCKET="${XDG_RUNTIME_DIR:-/tmp}/smolvm.sock"
+API_URL="http://localhost"
 SERVER_PID=""
 MACHINE_NAME="api-test-machine"
 REGISTRY_TEST_NAME="registry-coherence-test"
+
+# API client shortcut
+CURL=(curl --unix-socket "$API_SOCKET")
 
 # =============================================================================
 # Setup / Teardown
 # =============================================================================
 
 start_server() {
-    log_info "Starting API server on port $API_PORT..."
-    $SMOLVM serve start --listen "127.0.0.1:$API_PORT" &
+    log_info "Starting API server on unix://$API_SOCKET..."
+    rm -f "$API_SOCKET"
+    $SMOLVM serve start &
     SERVER_PID=$!
 
     local retries=30
     while [[ $retries -gt 0 ]]; do
-        if curl -s "$API_URL/health" >/dev/null 2>&1; then
+        if "${CURL[@]}" -s "$API_URL/health" >/dev/null 2>&1; then
             log_info "Server started (PID: $SERVER_PID)"
             return 0
         fi
@@ -61,9 +65,9 @@ stop_server() {
 
 cleanup() {
     # Delete machines via API (this stops the VMs properly)
-    if curl -s "$API_URL/health" >/dev/null 2>&1; then
-        curl -s -X DELETE "$API_URL/api/v1/machines/$MACHINE_NAME" >/dev/null 2>&1 || true
-        curl -s -X DELETE "$API_URL/api/v1/machines/$REGISTRY_TEST_NAME" >/dev/null 2>&1 || true
+    if "${CURL[@]}" -s "$API_URL/health" >/dev/null 2>&1; then
+        "${CURL[@]}" -s -X DELETE "$API_URL/api/v1/machines/$MACHINE_NAME" >/dev/null 2>&1 || true
+        "${CURL[@]}" -s -X DELETE "$API_URL/api/v1/machines/$REGISTRY_TEST_NAME" >/dev/null 2>&1 || true
     fi
     stop_server
 
@@ -80,27 +84,27 @@ trap cleanup EXIT
 
 test_health() {
     local response
-    response=$(curl -s "$API_URL/health")
+    response=$("${CURL[@]}" -s "$API_URL/health")
     [[ "$response" == *'"status":"ok"'* ]]
 }
 
 test_create_and_start_machine() {
     # Create machine
     local status
-    status=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$API_URL/api/v1/machines" \
+    status=$("${CURL[@]}" -s -o /dev/null -w "%{http_code}" -X POST "$API_URL/api/v1/machines" \
         -H "Content-Type: application/json" \
         -d "{\"name\": \"$MACHINE_NAME\", \"network\": true, \"cpus\": 1, \"mem\": 512}")
     [[ "$status" != "200" ]] && return 1
 
     # Start machine (boots VM)
     local response
-    response=$(curl -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/start")
+    response=$("${CURL[@]}" -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/start")
     [[ "$response" == *'"state":"running"'* ]]
 }
 
 test_exec_echo() {
     local response
-    response=$(curl -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/exec" \
+    response=$("${CURL[@]}" -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/exec" \
         -H "Content-Type: application/json" \
         -d '{"command": ["echo", "api-test-marker"]}')
     [[ "$response" == *"api-test-marker"* ]]
@@ -108,7 +112,7 @@ test_exec_echo() {
 
 test_exec_reads_vm_filesystem() {
     local response
-    response=$(curl -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/exec" \
+    response=$("${CURL[@]}" -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/exec" \
         -H "Content-Type: application/json" \
         -d '{"command": ["cat", "/etc/os-release"]}')
     [[ "$response" == *"Alpine"* ]] || [[ "$response" == *"alpine"* ]]
@@ -117,14 +121,14 @@ test_exec_reads_vm_filesystem() {
 test_exec_exit_codes() {
     # Test exit code 0
     local response exit_code
-    response=$(curl -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/exec" \
+    response=$("${CURL[@]}" -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/exec" \
         -H "Content-Type: application/json" \
         -d '{"command": ["sh", "-c", "exit 0"]}')
     exit_code=$(echo "$response" | grep -o '"exitCode":[0-9]*' | cut -d: -f2)
     [[ "$exit_code" != "0" ]] && return 1
 
     # Test exit code 42
-    response=$(curl -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/exec" \
+    response=$("${CURL[@]}" -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/exec" \
         -H "Content-Type: application/json" \
         -d '{"command": ["sh", "-c", "exit 42"]}')
     exit_code=$(echo "$response" | grep -o '"exitCode":[0-9]*' | cut -d: -f2)
@@ -133,7 +137,7 @@ test_exec_exit_codes() {
 
 test_exec_with_env() {
     local response
-    response=$(curl -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/exec" \
+    response=$("${CURL[@]}" -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/exec" \
         -H "Content-Type: application/json" \
         -d '{"command": ["sh", "-c", "echo $MY_VAR"], "env": [{"name": "MY_VAR", "value": "hello_from_api"}]}')
     [[ "$response" == *"hello_from_api"* ]]
@@ -141,7 +145,7 @@ test_exec_with_env() {
 
 test_exec_with_workdir() {
     local response
-    response=$(curl -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/exec" \
+    response=$("${CURL[@]}" -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/exec" \
         -H "Content-Type: application/json" \
         -d '{"command": ["pwd"], "workdir": "/tmp"}')
     [[ "$response" == *"/tmp"* ]]
@@ -149,7 +153,7 @@ test_exec_with_workdir() {
 
 test_exec_shell_pipeline() {
     local response
-    response=$(curl -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/exec" \
+    response=$("${CURL[@]}" -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/exec" \
         -H "Content-Type: application/json" \
         -d '{"command": ["sh", "-c", "echo hello world | wc -w"]}')
     [[ "$response" == *"2"* ]]
@@ -157,13 +161,13 @@ test_exec_shell_pipeline() {
 
 test_pull_and_run_image() {
     # Pull image
-    curl -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/images/pull" \
+    "${CURL[@]}" -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/images/pull" \
         -H "Content-Type: application/json" \
         -d '{"image": "alpine:latest"}' >/dev/null
 
     # Run in image
     local response
-    response=$(curl -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/run" \
+    response=$("${CURL[@]}" -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/run" \
         -H "Content-Type: application/json" \
         -d '{"image": "alpine:latest", "command": ["echo", "container-test"]}')
     [[ "$response" == *"container-test"* ]]
@@ -171,25 +175,25 @@ test_pull_and_run_image() {
 
 test_stop_machine() {
     local response
-    response=$(curl -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/stop")
+    response=$("${CURL[@]}" -s -X POST "$API_URL/api/v1/machines/$MACHINE_NAME/stop")
     [[ "$response" == *'"state":"stopped"'* ]] || [[ "$response" == *'"name":'* ]]
 }
 
 test_delete_machine() {
     local status
-    status=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE "$API_URL/api/v1/machines/$MACHINE_NAME")
+    status=$("${CURL[@]}" -s -o /dev/null -w "%{http_code}" -X DELETE "$API_URL/api/v1/machines/$MACHINE_NAME")
     [[ "$status" == "200" ]]
 }
 
 test_error_not_found() {
     local status
-    status=$(curl -s -o /dev/null -w "%{http_code}" "$API_URL/api/v1/machines/nonexistent-12345")
+    status=$("${CURL[@]}" -s -o /dev/null -w "%{http_code}" "$API_URL/api/v1/machines/nonexistent-12345")
     [[ "$status" == "404" ]]
 }
 
 test_error_bad_request() {
     local status
-    status=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$API_URL/api/v1/machines" \
+    status=$("${CURL[@]}" -s -o /dev/null -w "%{http_code}" -X POST "$API_URL/api/v1/machines" \
         -H "Content-Type: application/json" \
         -d '{"name": ""}')
     [[ "$status" == "400" ]]
@@ -204,18 +208,18 @@ test_error_bad_request() {
 test_registry_create_start_exec() {
     # Create a fresh machine
     local status
-    status=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$API_URL/api/v1/machines" \
+    status=$("${CURL[@]}" -s -o /dev/null -w "%{http_code}" -X POST "$API_URL/api/v1/machines" \
         -H "Content-Type: application/json" \
         -d "{\"name\": \"$REGISTRY_TEST_NAME\", \"network\": true, \"cpus\": 1, \"mem\": 512}")
     [[ "$status" != "200" ]] && { echo "create failed: $status"; return 1; }
 
     # Start it
     local response
-    response=$(curl -s -X POST "$API_URL/api/v1/machines/$REGISTRY_TEST_NAME/start")
+    response=$("${CURL[@]}" -s -X POST "$API_URL/api/v1/machines/$REGISTRY_TEST_NAME/start")
     [[ "$response" != *'"state":"running"'* ]] && { echo "start failed: $response"; return 1; }
 
     # Exec immediately — this is the key test. Before the registry fix, this returned 404.
-    response=$(curl -s -X POST "$API_URL/api/v1/machines/$REGISTRY_TEST_NAME/exec" \
+    response=$("${CURL[@]}" -s -X POST "$API_URL/api/v1/machines/$REGISTRY_TEST_NAME/exec" \
         -H "Content-Type: application/json" \
         -d '{"command": ["echo", "registry-ok"]}')
     [[ "$response" == *"registry-ok"* ]]
@@ -223,16 +227,16 @@ test_registry_create_start_exec() {
 
 test_registry_get_machine() {
     local response
-    response=$(curl -s "$API_URL/api/v1/machines/$REGISTRY_TEST_NAME")
+    response=$("${CURL[@]}" -s "$API_URL/api/v1/machines/$REGISTRY_TEST_NAME")
     [[ "$response" == *"\"name\":\"$REGISTRY_TEST_NAME\""* ]] && \
     [[ "$response" == *'"state":"running"'* ]]
 }
 
 test_registry_cleanup() {
     # Stop + delete the registry test machine
-    curl -s -X POST "$API_URL/api/v1/machines/$REGISTRY_TEST_NAME/stop" >/dev/null 2>&1 || true
+    "${CURL[@]}" -s -X POST "$API_URL/api/v1/machines/$REGISTRY_TEST_NAME/stop" >/dev/null 2>&1 || true
     local status
-    status=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE "$API_URL/api/v1/machines/$REGISTRY_TEST_NAME")
+    status=$("${CURL[@]}" -s -o /dev/null -w "%{http_code}" -X DELETE "$API_URL/api/v1/machines/$REGISTRY_TEST_NAME")
     [[ "$status" == "200" ]]
 }
 
@@ -268,7 +272,7 @@ run_test "Registry: cleanup test machine" test_registry_cleanup || true
 test_api_auto_generated_names() {
     # Without name → auto-generated vm-* name
     local response
-    response=$(curl -sf -X POST "$API_URL/api/v1/machines" \
+    response=$("${CURL[@]}" -sf -X POST "$API_URL/api/v1/machines" \
         -H "Content-Type: application/json" \
         -d '{"cpus": 1, "memoryMb": 512}' 2>&1) || { echo "Create failed: $response"; return 1; }
 
@@ -278,7 +282,7 @@ test_api_auto_generated_names() {
 
     # With explicit name → uses it
     local explicit="api-name-test-$$"
-    response=$(curl -sf -X POST "$API_URL/api/v1/machines" \
+    response=$("${CURL[@]}" -sf -X POST "$API_URL/api/v1/machines" \
         -H "Content-Type: application/json" \
         -d "{\"name\": \"$explicit\", \"cpus\": 1, \"memoryMb\": 512}" 2>&1) || return 1
     local name
@@ -286,8 +290,8 @@ test_api_auto_generated_names() {
     [[ "$name" == "$explicit" ]] || { echo "Expected $explicit, got: $name"; return 1; }
 
     # Cleanup
-    curl -sf -X DELETE "$API_URL/api/v1/machines/$auto_name" 2>/dev/null
-    curl -sf -X DELETE "$API_URL/api/v1/machines/$explicit" 2>/dev/null
+    "${CURL[@]}" -sf -X DELETE "$API_URL/api/v1/machines/$auto_name" 2>/dev/null
+    "${CURL[@]}" -sf -X DELETE "$API_URL/api/v1/machines/$explicit" 2>/dev/null
 }
 
 echo ""
@@ -305,7 +309,7 @@ run_test "API: auto-generated names" test_api_auto_generated_names || true
 test_trace_id_in_response_header() {
     # Every API response should have an X-Trace-Id header
     local headers
-    headers=$(curl -sI "$API_URL/health" 2>&1)
+    headers=$("${CURL[@]}" -sI "$API_URL/health" 2>&1)
     echo "$headers" | grep -qi "x-trace-id" || { echo "Missing X-Trace-Id header"; return 1; }
 
     # Trace ID should be a hex string
@@ -317,8 +321,8 @@ test_trace_id_in_response_header() {
 test_trace_id_unique_per_request() {
     # Two requests should get different trace IDs
     local tid1 tid2
-    tid1=$(curl -sI "$API_URL/health" 2>&1 | grep -i "x-trace-id" | tr -d '\r' | awk '{print $2}')
-    tid2=$(curl -sI "$API_URL/health" 2>&1 | grep -i "x-trace-id" | tr -d '\r' | awk '{print $2}')
+    tid1=$("${CURL[@]}" -sI "$API_URL/health" 2>&1 | grep -i "x-trace-id" | tr -d '\r' | awk '{print $2}')
+    tid2=$("${CURL[@]}" -sI "$API_URL/health" 2>&1 | grep -i "x-trace-id" | tr -d '\r' | awk '{print $2}')
 
     [[ -n "$tid1" ]] && [[ -n "$tid2" ]] && [[ "$tid1" != "$tid2" ]] || {
         echo "Trace IDs not unique: '$tid1' vs '$tid2'"
@@ -336,23 +340,23 @@ run_test "Trace ID: unique per request" test_trace_id_unique_per_request || true
 test_trace_id_end_to_end() {
     # Create and start a machine via API
     local vm_name="trace-e2e-test-$$"
-    curl -sf -X POST "$API_URL/api/v1/machines" \
+    "${CURL[@]}" -sf -X POST "$API_URL/api/v1/machines" \
         -H "Content-Type: application/json" \
         -d "{\"name\": \"$vm_name\", \"cpus\": 1, \"memoryMb\": 512}" >/dev/null 2>&1 || return 1
-    curl -sf -X POST "$API_URL/api/v1/machines/$vm_name/start" >/dev/null 2>&1 || {
-        curl -sf -X DELETE "$API_URL/api/v1/machines/$vm_name" >/dev/null 2>&1
+    "${CURL[@]}" -sf -X POST "$API_URL/api/v1/machines/$vm_name/start" >/dev/null 2>&1 || {
+        "${CURL[@]}" -sf -X DELETE "$API_URL/api/v1/machines/$vm_name" >/dev/null 2>&1
         return 1
     }
 
     # Exec a command and capture the trace ID from the response header
     local trace_id
-    trace_id=$(curl -sD - -X POST "$API_URL/api/v1/machines/$vm_name/exec" \
+    trace_id=$("${CURL[@]}" -sD - -X POST "$API_URL/api/v1/machines/$vm_name/exec" \
         -H "Content-Type: application/json" \
         -d '{"command": ["echo", "trace-e2e"]}' 2>&1 | grep -i "x-trace-id" | tr -d '\r' | awk '{print $2}')
 
     # Cleanup
-    curl -sf -X POST "$API_URL/api/v1/machines/$vm_name/stop" >/dev/null 2>&1
-    curl -sf -X DELETE "$API_URL/api/v1/machines/$vm_name" >/dev/null 2>&1
+    "${CURL[@]}" -sf -X POST "$API_URL/api/v1/machines/$vm_name/stop" >/dev/null 2>&1
+    "${CURL[@]}" -sf -X DELETE "$API_URL/api/v1/machines/$vm_name" >/dev/null 2>&1
 
     # Verify we got a trace ID back
     [[ -n "$trace_id" ]] || { echo "No trace ID returned from exec"; return 1; }
@@ -365,7 +369,7 @@ run_test "Trace ID: end-to-end with running VM" test_trace_id_end_to_end || true
 
 test_metrics_endpoint() {
     local response
-    response=$(curl -s "$API_URL/metrics" 2>&1)
+    response=$("${CURL[@]}" -s "$API_URL/metrics" 2>&1)
 
     # Should return Prometheus text format
     [[ -n "$response" ]] || { echo "Empty metrics response"; return 1; }
@@ -376,7 +380,7 @@ test_metrics_endpoint() {
 
 test_health_enriched() {
     local response
-    response=$(curl -s "$API_URL/health" 2>&1)
+    response=$("${CURL[@]}" -s "$API_URL/health" 2>&1)
 
     # Should have version
     echo "$response" | grep -q '"version"' || { echo "Missing version"; return 1; }


### PR DESCRIPTION
fixes #88 

this pr made the following changes:

- upgrades axum to 0.8 which has a better support to listen on UNIX socks
- add a ListenTarget struct which encapuslates parsing listening addrs
- set default listen value to be $XDG_RUNTIME_DIR/smolvm.sock