### PR TITLE
feat: virtio-net - part 1: add network backend selection

### DIFF
--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -204,6 +204,9 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
         dns_filter_socket,
         packed_layers_dir,
     } = config;
+
+    crate::network::validate_requested_network_backend(resources, None, port_mappings.len())?;
+
     // Raise file descriptor limits
     raise_fd_limits();
 

--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -206,6 +206,13 @@ pub fn launch_agent_vm_dynamic(
     krun: &KrunFunctions,
     config: &PackedLaunchConfig,
 ) -> Result<(), String> {
+    crate::network::validate_requested_network_backend(
+        &config.resources,
+        None,
+        config.port_mappings.len(),
+    )
+    .map_err(|e| e.to_string())?;
+
     // Raise file descriptor limits
     raise_fd_limits();
 

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -746,6 +746,7 @@ pub fn resource_spec_to_vm_resources(spec: &ResourceSpec, network: bool) -> VmRe
         cpus: spec.cpus.unwrap_or(DEFAULT_MICROVM_CPU_COUNT),
         memory_mib: spec.memory_mb.unwrap_or(DEFAULT_MICROVM_MEMORY_MIB),
         network,
+        network_backend: None,
         storage_gib: spec.storage_gb,
         overlay_gib: spec.overlay_gb,
         allowed_cidrs: spec.allowed_cidrs.clone(),

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -1092,6 +1092,7 @@ impl CreateCmd {
             volume: self.volume.clone(),
             port: self.port.clone(),
             net: self.net || manifest.network,
+            network_backend: self.net_backend,
             init: self.init.clone(),
             env: {
                 let mut env = manifest.env;

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -20,6 +20,7 @@ use smolvm::agent::{docker_config_mount, AgentClient, AgentManager, RunConfig, V
 use smolvm::data::network::PortMapping;
 use smolvm::data::resources::{DEFAULT_MICROVM_CPU_COUNT, DEFAULT_MICROVM_MEMORY_MIB};
 use smolvm::data::storage::HostMount;
+use smolvm::network::{validate_requested_network_backend, NetworkBackend};
 use smolvm::{DEFAULT_IDLE_CMD, DEFAULT_SHELL_CMD};
 use std::path::PathBuf;
 use std::time::Duration;
@@ -215,6 +216,15 @@ pub struct RunCmd {
     #[arg(long, help_heading = "Network")]
     pub net: bool,
 
+    /// Select the networking backend.
+    #[arg(
+        long = "net-backend",
+        value_enum,
+        hide = true,
+        help_heading = "Network"
+    )]
+    pub net_backend: Option<NetworkBackend>,
+
     /// Allow egress to specific CIDR range (can be used multiple times, implies --net)
     #[arg(long = "allow-cidr", value_parser = parse_cidr, value_name = "CIDR", help_heading = "Network")]
     pub allow_cidr: Vec<String>,
@@ -265,7 +275,7 @@ impl RunCmd {
     pub fn run(self) -> smolvm::Result<()> {
         use smolvm::Error;
 
-        let (cli_allow_cidrs, net, dns_filter_hosts) = resolve_egress_flags(
+        let (cli_allow_cidrs, net, cli_dns_filter_hosts) = resolve_egress_flags(
             self.allow_cidr,
             self.allow_host,
             self.outbound_localhost_only,
@@ -282,6 +292,7 @@ impl RunCmd {
             self.volume,
             self.port,
             net,
+            self.net_backend,
             vec![],
             self.env,
             self.workdir,
@@ -291,6 +302,15 @@ impl RunCmd {
             cli_allow_cidrs,
         )?;
 
+        let mut params = params;
+        params.dns_filter_hosts = match (params.dns_filter_hosts.take(), cli_dns_filter_hosts) {
+            (Some(mut from_smolfile), Some(mut from_cli)) => {
+                from_smolfile.append(&mut from_cli);
+                Some(from_smolfile)
+            }
+            (Some(from_smolfile), None) => Some(from_smolfile),
+            (None, some) => some,
+        };
         let mut mounts = HostMount::parse(&params.volume)?;
         let ports = params.port.clone();
         PortMapping::check_duplicates(&ports)
@@ -331,10 +351,16 @@ impl RunCmd {
             cpus: params.cpus,
             memory_mib: params.mem,
             network: params.net,
+            network_backend: params.network_backend,
             storage_gib: params.storage_gb,
             overlay_gib: params.overlay_gb,
             allowed_cidrs: params.allowed_cidrs.clone(),
         };
+        validate_requested_network_backend(
+            &resources,
+            params.dns_filter_hosts.as_deref(),
+            params.port.len(),
+        )?;
 
         let manager = AgentManager::new_default_with_sizes(params.storage_gb, params.overlay_gb)
             .map_err(|e| Error::agent("create agent manager", e.to_string()))?;
@@ -362,7 +388,7 @@ impl RunCmd {
 
         let features = smolvm::agent::LaunchFeatures {
             ssh_agent_socket,
-            dns_filter_hosts,
+            dns_filter_hosts: params.dns_filter_hosts.clone(),
             packed_layers_dir: None,
         };
 
@@ -523,8 +549,10 @@ impl RunCmd {
                                 mounts: mount_tuples,
                                 ports: port_tuples,
                                 network: params.net,
+                                network_backend: params.network_backend,
                                 storage_gb: params.storage_gb,
                                 overlay_gb: params.overlay_gb,
+                                allowed_cidrs: params.allowed_cidrs.clone(),
                                 init: params.init.clone(),
                                 env: parse_env_list(&params.env),
                                 workdir: params.workdir.clone(),
@@ -532,6 +560,7 @@ impl RunCmd {
                                 entrypoint: params.entrypoint.clone(),
                                 cmd: params.cmd.clone(),
                                 ssh_agent: self.ssh_agent || params.ssh_agent,
+                                dns_filter_hosts: params.dns_filter_hosts.clone(),
                             }),
                         );
                     }
@@ -629,8 +658,10 @@ impl RunCmd {
                                 mounts: mount_tuples,
                                 ports: port_tuples,
                                 network: params.net,
+                                network_backend: params.network_backend,
                                 storage_gb: params.storage_gb,
                                 overlay_gb: params.overlay_gb,
+                                allowed_cidrs: params.allowed_cidrs.clone(),
                                 init: params.init.clone(),
                                 env: parse_env_list(&params.env),
                                 workdir: params.workdir.clone(),
@@ -638,6 +669,7 @@ impl RunCmd {
                                 entrypoint: params.entrypoint.clone(),
                                 cmd: params.cmd.clone(),
                                 ssh_agent: self.ssh_agent || params.ssh_agent,
+                                dns_filter_hosts: params.dns_filter_hosts.clone(),
                             }),
                         );
                     }
@@ -892,6 +924,10 @@ pub struct CreateCmd {
     #[arg(long)]
     pub net: bool,
 
+    /// Select the networking backend.
+    #[arg(long = "net-backend", value_enum, hide = true)]
+    pub net_backend: Option<NetworkBackend>,
+
     /// Allow egress to specific CIDR range (can be used multiple times, implies --net)
     #[arg(long = "allow-cidr", value_parser = parse_cidr, value_name = "CIDR")]
     pub allow_cidr: Vec<String>,
@@ -937,7 +973,7 @@ impl CreateCmd {
             return self.run_from_smolmachine(sidecar_path);
         }
 
-        let (cli_allow_cidrs, net, _dns_filter_hosts) = resolve_egress_flags(
+        let (cli_allow_cidrs, net, cli_dns_filter_hosts) = resolve_egress_flags(
             self.allow_cidr,
             self.allow_host,
             self.outbound_localhost_only,
@@ -958,6 +994,7 @@ impl CreateCmd {
             self.volume,
             self.port,
             net,
+            self.net_backend,
             self.init,
             self.env,
             self.workdir,
@@ -967,6 +1004,28 @@ impl CreateCmd {
             cli_allow_cidrs,
         )?;
         let mut params = params;
+        params.dns_filter_hosts = match (params.dns_filter_hosts.take(), cli_dns_filter_hosts) {
+            (Some(mut from_smolfile), Some(mut from_cli)) => {
+                from_smolfile.append(&mut from_cli);
+                Some(from_smolfile)
+            }
+            (Some(from_smolfile), None) => Some(from_smolfile),
+            (None, some) => some,
+        };
+        let resources = VmResources {
+            cpus: params.cpus,
+            memory_mib: params.mem,
+            network: params.net,
+            network_backend: params.network_backend,
+            storage_gib: params.storage_gb,
+            overlay_gib: params.overlay_gb,
+            allowed_cidrs: params.allowed_cidrs.clone(),
+        };
+        validate_requested_network_backend(
+            &resources,
+            params.dns_filter_hosts.as_deref(),
+            params.port.len(),
+        )?;
         if self.ssh_agent {
             params.ssh_agent = true;
         }

--- a/src/cli/pack.rs
+++ b/src/cli/pack.rs
@@ -245,6 +245,7 @@ impl PackCreateCmd {
                 cpus: 4,
                 memory_mib: 8192,
                 network: true,
+                network_backend: None,
                 storage_gib: None,
                 overlay_gib: None,
                 allowed_cidrs: None,

--- a/src/cli/pack_run.rs
+++ b/src/cli/pack_run.rs
@@ -16,6 +16,7 @@ use smolvm::agent::launcher_dynamic::{
 use smolvm::agent::{AgentClient, RunConfig, VmResources};
 use smolvm::data::network::PortMapping;
 use smolvm::data::storage::HostMount;
+use smolvm::network::{validate_requested_network_backend, NetworkBackend};
 use smolvm::Error;
 use smolvm::DEFAULT_SHELL_CMD;
 use smolvm_pack::detect::PackedMode;
@@ -162,6 +163,15 @@ pub struct PackRunCmd {
     #[arg(long, help_heading = "Network")]
     pub net: bool,
 
+    /// Select the networking backend.
+    #[arg(
+        long = "net-backend",
+        value_enum,
+        hide = true,
+        help_heading = "Network"
+    )]
+    pub net_backend: Option<NetworkBackend>,
+
     /// Number of virtual CPUs (overrides manifest default)
     #[arg(long, value_name = "N", help_heading = "Resources")]
     pub cpus: Option<u8>,
@@ -298,10 +308,12 @@ impl PackRunCmd {
             cpus: self.cpus.unwrap_or(manifest.cpus),
             memory_mib: self.mem.unwrap_or(manifest.mem),
             network: self.net || manifest.network || !self.port.is_empty(),
+            network_backend: self.net_backend,
             storage_gib,
             overlay_gib: self.overlay,
             allowed_cidrs: None,
         };
+        validate_requested_network_backend(&resources, None, self.port.len())?;
 
         // Build packed mounts for the launcher
         let packed_mounts = mounts_to_packed(&mounts);
@@ -841,6 +853,10 @@ struct PackedRunArgs {
     #[arg(long)]
     net: bool,
 
+    /// Select the networking backend.
+    #[arg(long = "net-backend", value_enum, hide = true)]
+    net_backend: Option<NetworkBackend>,
+
     /// Number of vCPUs (overrides default)
     #[arg(long, value_name = "N")]
     cpus: Option<u8>,
@@ -888,6 +904,10 @@ struct PackedStartArgs {
     /// Enable outbound network access
     #[arg(long)]
     net: bool,
+
+    /// Select the networking backend.
+    #[arg(long = "net-backend", value_enum, hide = true)]
+    net_backend: Option<NetworkBackend>,
 }
 
 /// Arguments for the `exec` subcommand (run in existing VM).
@@ -1014,6 +1034,7 @@ fn run_ephemeral(
                 volume: args.volume,
                 port: args.port,
                 net: args.net,
+                net_backend: args.net_backend,
                 cpus: args.cpus,
                 mem: args.mem,
                 storage: args.storage,
@@ -1138,15 +1159,16 @@ fn run_from_cache(
 
     let mounts = HostMount::parse(&args.volume)?;
     let port_mappings = PortMapping::to_tuples(&args.port);
-
     let resources = VmResources {
         cpus: args.cpus.unwrap_or(manifest.cpus),
         memory_mib: args.mem.unwrap_or(manifest.mem),
         network: args.net || manifest.network || !args.port.is_empty(),
+        network_backend: args.net_backend,
         storage_gib,
         overlay_gib: args.overlay,
         allowed_cidrs: None,
     };
+    validate_requested_network_backend(&resources, None, args.port.len())?;
 
     let packed_mounts = mounts_to_packed(&mounts);
 
@@ -1460,15 +1482,16 @@ fn daemon_start(
     // Parse CLI args
     let mounts = HostMount::parse(&args.volume)?;
     let port_mappings = PortMapping::to_tuples(&args.port);
-
     let resources = VmResources {
         cpus: args.cpus.unwrap_or(manifest.cpus),
         memory_mib: args.mem.unwrap_or(manifest.mem),
         network: args.net || manifest.network || !args.port.is_empty(),
+        network_backend: args.net_backend,
         storage_gib,
         overlay_gib: args.overlay,
         allowed_cidrs: None,
     };
+    validate_requested_network_backend(&resources, None, args.port.len())?;
 
     let packed_mounts = mounts_to_packed(&mounts);
 

--- a/src/cli/smolfile.rs
+++ b/src/cli/smolfile.rs
@@ -8,6 +8,7 @@ use crate::cli::parsers::parse_cidr;
 use crate::cli::vm_common::CreateVmParams;
 use smolvm::data::network::PortMapping;
 use smolvm::data::resources::{DEFAULT_MICROVM_CPU_COUNT, DEFAULT_MICROVM_MEMORY_MIB};
+use smolvm::network::NetworkBackend;
 use std::path::PathBuf;
 
 // Re-export from the library
@@ -40,6 +41,7 @@ pub fn build_create_params(
     cli_volume: Vec<String>,
     cli_port: Vec<PortMapping>,
     cli_net: bool,
+    cli_network_backend: Option<NetworkBackend>,
     cli_init: Vec<String>,
     cli_env: Vec<String>,
     cli_workdir: Option<String>,
@@ -64,6 +66,7 @@ pub fn build_create_params(
                 volume: cli_volume,
                 port: cli_port,
                 net,
+                network_backend: cli_network_backend,
                 init: cli_init,
                 env: cli_env,
                 workdir: cli_workdir,
@@ -252,6 +255,7 @@ pub fn build_create_params(
         volume: volumes,
         port: ports,
         net,
+        network_backend: cli_network_backend,
         init,
         env,
         workdir,

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -12,6 +12,7 @@ use smolvm::data::resources::{DEFAULT_MICROVM_CPU_COUNT, DEFAULT_MICROVM_MEMORY_
 use smolvm::data::storage::HostMount;
 use smolvm::data::validate_vm_name;
 use smolvm::db::SmolvmDb;
+use smolvm::network::NetworkBackend;
 use smolvm::storage::{DEFAULT_OVERLAY_SIZE_GIB, DEFAULT_STORAGE_SIZE_GIB};
 
 // ============================================================================
@@ -300,6 +301,7 @@ pub struct CreateVmParams {
     pub volume: Vec<String>,
     pub port: Vec<PortMapping>,
     pub net: bool,
+    pub network_backend: Option<NetworkBackend>,
     pub init: Vec<String>,
     pub env: Vec<String>,
     pub workdir: Option<String>,
@@ -373,6 +375,7 @@ pub fn create_vm(params: CreateVmParams) -> smolvm::Result<()> {
     record.storage_gb = params.storage_gb;
     record.overlay_gb = params.overlay_gb;
     record.allowed_cidrs = params.allowed_cidrs.clone();
+    record.network_backend = params.network_backend;
     record.image = params.image.clone();
     record.entrypoint = params.entrypoint.clone();
     record.cmd = params.cmd.clone();
@@ -641,8 +644,10 @@ pub fn persist_default_running(
                 r.mounts = o.mounts.clone();
                 r.ports = o.ports.clone();
                 r.network = o.network;
+                r.network_backend = o.network_backend;
                 r.storage_gb = o.storage_gb;
                 r.overlay_gb = o.overlay_gb;
+                r.allowed_cidrs = o.allowed_cidrs.clone();
                 r.init = o.init.clone();
                 r.env = o.env.clone();
                 r.workdir = o.workdir.clone();
@@ -650,6 +655,7 @@ pub fn persist_default_running(
                 r.entrypoint = o.entrypoint.clone();
                 r.cmd = o.cmd.clone();
                 r.ssh_agent = o.ssh_agent;
+                r.dns_filter_hosts = o.dns_filter_hosts.clone();
             }
         })
         .is_none()
@@ -665,8 +671,10 @@ pub struct DefaultVmOverrides {
     pub mounts: Vec<(String, String, bool)>,
     pub ports: Vec<(u16, u16)>,
     pub network: bool,
+    pub network_backend: Option<NetworkBackend>,
     pub storage_gb: Option<u64>,
     pub overlay_gb: Option<u64>,
+    pub allowed_cidrs: Option<Vec<String>>,
     pub init: Vec<String>,
     pub env: Vec<(String, String)>,
     pub workdir: Option<String>,
@@ -674,6 +682,7 @@ pub struct DefaultVmOverrides {
     pub entrypoint: Vec<String>,
     pub cmd: Vec<String>,
     pub ssh_agent: bool,
+    pub dns_filter_hosts: Option<Vec<String>>,
 }
 
 /// Check if any running VM already binds to the same host ports.

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@ use crate::data::network::DEFAULT_DNS;
 use crate::data::resources::{DEFAULT_MICROVM_CPU_COUNT, DEFAULT_MICROVM_MEMORY_MIB};
 use crate::db::SmolvmDb;
 use crate::error::Result;
+use crate::network::NetworkBackend;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -395,6 +396,10 @@ pub struct VmRecord {
     #[serde(default)]
     pub allowed_cidrs: Option<Vec<String>>,
 
+    /// Preferred network backend override for machine launch.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network_backend: Option<NetworkBackend>,
+
     /// OCI image for auto-container creation on start.
     #[serde(default)]
     pub image: Option<String>,
@@ -484,6 +489,7 @@ impl VmRecord {
             storage_gb: None,
             overlay_gb: None,
             allowed_cidrs: None,
+            network_backend: None,
             image: None,
             entrypoint: Vec::new(),
             cmd: Vec::new(),
@@ -528,6 +534,7 @@ impl VmRecord {
             storage_gb: None,
             overlay_gb: None,
             allowed_cidrs: None,
+            network_backend: None,
             image: None,
             entrypoint: Vec::new(),
             cmd: Vec::new(),
@@ -594,6 +601,7 @@ impl VmRecord {
             cpus: self.cpus,
             memory_mib: self.mem,
             network: self.network,
+            network_backend: self.network_backend,
             storage_gib: self.storage_gb,
             overlay_gib: self.overlay_gb,
             allowed_cidrs: self.allowed_cidrs.clone(),

--- a/src/data/resources.rs
+++ b/src/data/resources.rs
@@ -7,6 +7,8 @@ pub const DEFAULT_MICROVM_CPU_COUNT: u8 = 4;
 /// reservation — the host only consumes what the guest actually uses.
 pub const DEFAULT_MICROVM_MEMORY_MIB: u32 = 8192;
 
+use crate::network::NetworkBackend;
+
 /// Resources available to a micro vm.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct VmResources {
@@ -16,6 +18,9 @@ pub struct VmResources {
     pub memory_mib: u32,
     /// Enable outbound network access (TSI).
     pub network: bool,
+    /// Preferred network backend override.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network_backend: Option<NetworkBackend>,
     /// Storage disk size in GiB (None = default 20 GiB).
     pub storage_gib: Option<u64>,
     /// Overlay disk size in GiB (None = default 10 GiB).
@@ -68,6 +73,7 @@ impl Default for VmResources {
             cpus: DEFAULT_MICROVM_CPU_COUNT,
             memory_mib: DEFAULT_MICROVM_MEMORY_MIB,
             network: false,
+            network_backend: None,
             storage_gib: None,
             overlay_gib: None,
             allowed_cidrs: None,

--- a/src/network/backend.rs
+++ b/src/network/backend.rs
@@ -1,0 +1,58 @@
+use clap::ValueEnum;
+
+/// virtio-net checksum offload feature bit.
+pub const NET_FEATURE_CSUM: u32 = 1 << 0;
+/// virtio-net guest checksum offload feature bit.
+pub const NET_FEATURE_GUEST_CSUM: u32 = 1 << 1;
+/// virtio-net guest TCP segmentation offload for IPv4.
+pub const NET_FEATURE_GUEST_TSO4: u32 = 1 << 7;
+/// virtio-net guest UDP fragmentation offload.
+pub const NET_FEATURE_GUEST_UFO: u32 = 1 << 10;
+/// virtio-net host TCP segmentation offload for IPv4.
+pub const NET_FEATURE_HOST_TSO4: u32 = 1 << 11;
+/// virtio-net host UDP fragmentation offload.
+pub const NET_FEATURE_HOST_UFO: u32 = 1 << 14;
+/// libkrun's compatibility feature set for unixstream-backed virtio-net.
+pub const COMPAT_NET_FEATURES: u32 = NET_FEATURE_CSUM
+    | NET_FEATURE_GUEST_CSUM
+    | NET_FEATURE_GUEST_TSO4
+    | NET_FEATURE_GUEST_UFO
+    | NET_FEATURE_HOST_TSO4
+    | NET_FEATURE_HOST_UFO;
+
+/// Network backend override for machine launch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+pub enum NetworkBackend {
+    /// Use libkrun TSI networking.
+    #[value(name = "tsi")]
+    Tsi,
+    /// Use virtio-net with the host-side smolvm network stack.
+    #[serde(rename = "virtio")]
+    #[value(name = "virtio")]
+    VirtioNet,
+}
+
+impl NetworkBackend {
+    /// Stable CLI/storage label for the backend.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Tsi => "tsi",
+            Self::VirtioNet => "virtio",
+        }
+    }
+
+    /// Human-readable backend label for logs.
+    pub const fn log_label(self) -> &'static str {
+        match self {
+            Self::Tsi => "tsi",
+            Self::VirtioNet => "virtio-net",
+        }
+    }
+}
+
+impl std::fmt::Display for NetworkBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}

--- a/src/network/launch.rs
+++ b/src/network/launch.rs
@@ -234,10 +234,9 @@ mod tests {
         resources.network = true;
         resources.network_backend = Some(NetworkBackend::VirtioNet);
         let err = validate_requested_network_backend(&resources, None, 0).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("current virtio-net implementation is not ready yet")
-        );
+        assert!(err
+            .to_string()
+            .contains("current virtio-net implementation is not ready yet"));
     }
 
     #[test]
@@ -246,10 +245,9 @@ mod tests {
         resources.network = true;
         resources.network_backend = Some(NetworkBackend::VirtioNet);
         let err = validate_requested_network_backend(&resources, None, 1).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("published ports are not supported")
-        );
+        assert!(err
+            .to_string()
+            .contains("published ports are not supported"));
     }
 
     #[test]
@@ -259,9 +257,8 @@ mod tests {
         resources.network_backend = Some(NetworkBackend::VirtioNet);
         resources.allowed_cidrs = Some(vec!["1.1.1.1/32".into()]);
         let err = validate_requested_network_backend(&resources, None, 0).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("allow-cidr/allow-host policies are not supported")
-        );
+        assert!(err
+            .to_string()
+            .contains("allow-cidr/allow-host policies are not supported"));
     }
 }

--- a/src/network/launch.rs
+++ b/src/network/launch.rs
@@ -1,0 +1,267 @@
+use crate::data::resources::VmResources;
+use crate::network::backend::NetworkBackend;
+
+/// Current staged-transplant support for plain virtio-net egress.
+const VIRTIO_NET_SUPPORTS_PLAIN_EGRESS: bool = false;
+/// Current staged-transplant support for published ports on virtio-net.
+const VIRTIO_NET_SUPPORTS_PUBLISHED_PORTS: bool = false;
+/// Current staged-transplant support for in-process policy on virtio-net.
+const VIRTIO_NET_SUPPORTS_POLICY: bool = false;
+
+/// Effective backend selected for a launch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EffectiveNetworkBackend {
+    /// No network device.
+    None,
+    /// TSI networking.
+    Tsi,
+    /// Virtio-net networking.
+    VirtioNet,
+}
+
+/// Reason a requested backend was downgraded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NetworkFallbackReason {
+    /// virtio-net has been requested but is not implemented on this branch yet.
+    VirtioNetNotYetImplemented,
+    /// Port publishing is only implemented on TSI.
+    PortsRequireTsi,
+    /// Current egress policies and DNS filtering are only implemented on TSI.
+    PolicyRequiresTsi,
+}
+
+impl NetworkFallbackReason {
+    /// User-facing explanation for the fallback.
+    pub const fn user_message(self) -> &'static str {
+        match self {
+            Self::VirtioNetNotYetImplemented => {
+                "virtio-net has not been implemented in this branch yet"
+            }
+            Self::PortsRequireTsi => {
+                "port publishing still uses the TSI backend; falling back from virtio"
+            }
+            Self::PolicyRequiresTsi => {
+                "allow-cidr/allow-host policies still use the TSI backend; falling back from virtio"
+            }
+        }
+    }
+
+    /// User-facing explanation when an explicit virtio-net request must be rejected.
+    pub const fn unsupported_message(self) -> &'static str {
+        match self {
+            Self::VirtioNetNotYetImplemented => {
+                "the current virtio-net implementation is not ready yet on this branch"
+            }
+            Self::PortsRequireTsi => {
+                "published ports are not supported by the current virtio-net implementation"
+            }
+            Self::PolicyRequiresTsi => {
+                "allow-cidr/allow-host policies are not supported by the current virtio-net implementation"
+            }
+        }
+    }
+}
+
+/// Network launch decision for a VM.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LaunchNetworkPlan {
+    /// Selected backend.
+    pub backend: EffectiveNetworkBackend,
+    /// Downgrade reason when a requested backend cannot be honored.
+    pub fallback_reason: Option<NetworkFallbackReason>,
+}
+
+impl LaunchNetworkPlan {
+    /// Whether the launch should attach any network backend at all.
+    pub const fn has_network(self) -> bool {
+        !matches!(self.backend, EffectiveNetworkBackend::None)
+    }
+}
+
+/// Compute the effective launch backend from user intent and current feature support.
+pub fn plan_launch_network(
+    resources: &VmResources,
+    dns_filter_hosts: Option<&[String]>,
+    port_count: usize,
+) -> LaunchNetworkPlan {
+    let has_ports = port_count > 0;
+    let has_cidr_policy = resources
+        .allowed_cidrs
+        .as_ref()
+        .is_some_and(|cidrs| !cidrs.is_empty());
+    let has_dns_filter = dns_filter_hosts.is_some_and(|hosts| !hosts.is_empty());
+    let has_policy = has_cidr_policy || has_dns_filter;
+    let wants_network = resources.network || has_ports || has_policy;
+
+    if !wants_network {
+        return LaunchNetworkPlan {
+            backend: EffectiveNetworkBackend::None,
+            fallback_reason: None,
+        };
+    }
+
+    match resources.network_backend.unwrap_or(NetworkBackend::Tsi) {
+        NetworkBackend::Tsi => LaunchNetworkPlan {
+            backend: EffectiveNetworkBackend::Tsi,
+            fallback_reason: None,
+        },
+        NetworkBackend::VirtioNet if has_ports && !VIRTIO_NET_SUPPORTS_PUBLISHED_PORTS => {
+            LaunchNetworkPlan {
+                backend: EffectiveNetworkBackend::Tsi,
+                fallback_reason: Some(NetworkFallbackReason::PortsRequireTsi),
+            }
+        }
+        NetworkBackend::VirtioNet if has_policy && !VIRTIO_NET_SUPPORTS_POLICY => {
+            LaunchNetworkPlan {
+                backend: EffectiveNetworkBackend::Tsi,
+                fallback_reason: Some(NetworkFallbackReason::PolicyRequiresTsi),
+            }
+        }
+        NetworkBackend::VirtioNet if !VIRTIO_NET_SUPPORTS_PLAIN_EGRESS => LaunchNetworkPlan {
+            backend: EffectiveNetworkBackend::Tsi,
+            fallback_reason: Some(NetworkFallbackReason::VirtioNetNotYetImplemented),
+        },
+        NetworkBackend::VirtioNet => LaunchNetworkPlan {
+            backend: EffectiveNetworkBackend::VirtioNet,
+            fallback_reason: None,
+        },
+    }
+}
+
+/// Reject explicit virtio-net requests that the current branch cannot honor.
+pub fn validate_requested_network_backend(
+    resources: &VmResources,
+    dns_filter_hosts: Option<&[String]>,
+    port_count: usize,
+) -> crate::Result<()> {
+    if resources.network_backend != Some(NetworkBackend::VirtioNet) {
+        return Ok(());
+    }
+
+    let has_cidr_policy = resources
+        .allowed_cidrs
+        .as_ref()
+        .is_some_and(|cidrs| !cidrs.is_empty());
+    let has_dns_filter = dns_filter_hosts.is_some_and(|hosts| !hosts.is_empty());
+    let wants_network = resources.network || port_count > 0 || has_cidr_policy || has_dns_filter;
+
+    if !wants_network {
+        return Err(crate::Error::config(
+            "--net-backend",
+            "--net-backend virtio requires --net",
+        ));
+    }
+
+    let plan = plan_launch_network(resources, dns_filter_hosts, port_count);
+    if plan.backend != EffectiveNetworkBackend::VirtioNet {
+        let reason = plan
+            .fallback_reason
+            .unwrap_or(NetworkFallbackReason::VirtioNetNotYetImplemented);
+        return Err(crate::Error::config(
+            "--net-backend",
+            reason.unsupported_message(),
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn resources() -> VmResources {
+        VmResources::default()
+    }
+
+    #[test]
+    fn test_no_network_plan() {
+        let plan = plan_launch_network(&resources(), None, 0);
+        assert_eq!(plan.backend, EffectiveNetworkBackend::None);
+    }
+
+    #[test]
+    fn test_default_network_uses_tsi() {
+        let mut resources = resources();
+        resources.network = true;
+        let plan = plan_launch_network(&resources, None, 0);
+        assert_eq!(plan.backend, EffectiveNetworkBackend::Tsi);
+    }
+
+    #[test]
+    fn test_plain_virtio_currently_falls_back_until_implemented() {
+        let mut resources = resources();
+        resources.network = true;
+        resources.network_backend = Some(NetworkBackend::VirtioNet);
+        let plan = plan_launch_network(&resources, None, 0);
+        assert_eq!(plan.backend, EffectiveNetworkBackend::Tsi);
+        assert_eq!(
+            plan.fallback_reason,
+            Some(NetworkFallbackReason::VirtioNetNotYetImplemented)
+        );
+    }
+
+    #[test]
+    fn test_ports_force_tsi() {
+        let mut resources = resources();
+        resources.network = true;
+        resources.network_backend = Some(NetworkBackend::VirtioNet);
+        let plan = plan_launch_network(&resources, None, 1);
+        assert_eq!(plan.backend, EffectiveNetworkBackend::Tsi);
+        assert_eq!(
+            plan.fallback_reason,
+            Some(NetworkFallbackReason::PortsRequireTsi)
+        );
+    }
+
+    #[test]
+    fn test_policy_forces_tsi() {
+        let mut resources = resources();
+        resources.network = true;
+        resources.network_backend = Some(NetworkBackend::VirtioNet);
+        resources.allowed_cidrs = Some(vec!["1.1.1.1/32".into()]);
+        let plan = plan_launch_network(&resources, None, 0);
+        assert_eq!(plan.backend, EffectiveNetworkBackend::Tsi);
+        assert_eq!(
+            plan.fallback_reason,
+            Some(NetworkFallbackReason::PolicyRequiresTsi)
+        );
+    }
+
+    #[test]
+    fn test_validate_plain_virtio_rejected_until_implemented() {
+        let mut resources = resources();
+        resources.network = true;
+        resources.network_backend = Some(NetworkBackend::VirtioNet);
+        let err = validate_requested_network_backend(&resources, None, 0).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("current virtio-net implementation is not ready yet")
+        );
+    }
+
+    #[test]
+    fn test_validate_ports_rejected_for_virtio() {
+        let mut resources = resources();
+        resources.network = true;
+        resources.network_backend = Some(NetworkBackend::VirtioNet);
+        let err = validate_requested_network_backend(&resources, None, 1).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("published ports are not supported")
+        );
+    }
+
+    #[test]
+    fn test_validate_policy_rejected_for_virtio() {
+        let mut resources = resources();
+        resources.network = true;
+        resources.network_backend = Some(NetworkBackend::VirtioNet);
+        resources.allowed_cidrs = Some(vec!["1.1.1.1/32".into()]);
+        let err = validate_requested_network_backend(&resources, None, 0).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("allow-cidr/allow-host policies are not supported")
+        );
+    }
+}

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -1,0 +1,14 @@
+//! Network configuration and backend selection.
+
+/// Backend selection and serialization helpers.
+pub mod backend;
+/// Launch-time backend planning and request validation rules.
+pub mod launch;
+pub mod policy;
+
+pub use backend::NetworkBackend;
+pub use launch::{
+    plan_launch_network, validate_requested_network_backend, EffectiveNetworkBackend,
+    LaunchNetworkPlan, NetworkFallbackReason,
+};
+pub use policy::get_dns_server;

--- a/src/network/policy.rs
+++ b/src/network/policy.rs
@@ -1,6 +1,4 @@
-//! Network configuration.
-//!
-//! This module provides network policy configuration for VMs.
+//! Network policy helpers.
 
 use crate::data::network::DEFAULT_DNS_ADDR;
 use crate::vm::config::NetworkPolicy;
@@ -20,10 +18,8 @@ mod tests {
 
     #[test]
     fn test_get_dns_server() {
-        // None policy returns no DNS
         assert!(get_dns_server(&NetworkPolicy::None).is_none());
 
-        // Egress with default DNS
         let dns = get_dns_server(&NetworkPolicy::Egress {
             dns: None,
             allowed_cidrs: None,
@@ -31,7 +27,6 @@ mod tests {
         .unwrap();
         assert_eq!(dns.to_string(), crate::data::network::DEFAULT_DNS);
 
-        // Egress with custom DNS
         let custom: IpAddr = "8.8.8.8".parse().unwrap();
         let dns = get_dns_server(&NetworkPolicy::Egress {
             dns: Some(custom),

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -6,6 +6,7 @@
 #   ./tests/run_all.sh              # Run all tests
 #   ./tests/run_all.sh cli          # Run only CLI tests
 #   ./tests/run_all.sh machine      # Run only machine tests
+#   ./tests/run_all.sh virtio-net   # Run only virtio-net tests
 #   ./tests/run_all.sh container    # Run only container tests
 #   ./tests/run_all.sh api          # Run only HTTP API tests
 #   ./tests/run_all.sh pack         # Run only pack tests
@@ -95,6 +96,9 @@ case "$TESTS_TO_RUN" in
     machine)
         run_suite "Machine Tests" "$SCRIPT_DIR/test_machine.sh"
         ;;
+    virtio-net)
+        run_suite "Virtio-Net Tests" "$SCRIPT_DIR/test_virtio_net.sh"
+        ;;
     api)
         run_suite "HTTP API Tests" "$SCRIPT_DIR/test_api.sh"
         ;;
@@ -121,13 +125,14 @@ case "$TESTS_TO_RUN" in
     all)
         run_suite "CLI Tests" "$SCRIPT_DIR/test_cli.sh"
         run_suite "Machine Tests" "$SCRIPT_DIR/test_machine.sh"
+        run_suite "Virtio-Net Tests" "$SCRIPT_DIR/test_virtio_net.sh"
         run_suite "HTTP API Tests" "$SCRIPT_DIR/test_api.sh"
         run_suite "Pack Tests" "$SCRIPT_DIR/test_pack.sh"
         run_suite "Smolfile & SSH Agent Tests" "$SCRIPT_DIR/test_smolfile.sh"
         ;;
     *)
         echo "Unknown test suite: $TESTS_TO_RUN"
-        echo "Available: cli, machine, smolfile, api, pack, pack-quick, bench, bench-vm, all"
+        echo "Available: cli, machine, virtio-net, smolfile, api, pack, pack-quick, bench, bench-vm, all"
         exit 1
         ;;
 esac

--- a/tests/test_virtio_net.sh
+++ b/tests/test_virtio_net.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+#
+# virtio-net backend selection tests for smolvm.
+#
+# Covers the part-1 backend-selection plumbing from the user-visible CLI paths.
+
+source "$(dirname "$0")/common.sh"
+init_smolvm
+
+log_info "Pre-flight cleanup: killing orphan processes..."
+kill_orphan_smolvm_processes
+
+TEST_DIR=$(mktemp -d)
+trap "rm -rf '$TEST_DIR'; cleanup_machine" EXIT
+
+echo ""
+echo "=========================================="
+echo "  smolvm Virtio-Net Tests"
+echo "=========================================="
+echo ""
+
+test_machine_create_virtio_rejected_until_implemented() {
+    cleanup_machine
+    local vm_name="virtio-create-test-$$"
+    local exit_code=0
+    local output
+
+    output=$($SMOLVM machine create "$vm_name" --net --net-backend virtio 2>&1) || exit_code=$?
+    [[ $exit_code -ne 0 ]] || {
+        echo "expected create failure for unsupported virtio backend"
+        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        return 1
+    }
+    [[ "$output" == *"not ready yet on this branch"* ]] || {
+        echo "unexpected output: $output"
+        return 1
+    }
+
+    local list_output
+    list_output=$($SMOLVM machine ls --json 2>&1)
+    [[ "$list_output" != *"$vm_name"* ]] || {
+        echo "create failure should not persist machine state"
+        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        return 1
+    }
+}
+
+test_machine_run_virtio_rejected_until_implemented() {
+    cleanup_machine
+    local exit_code=0
+    local output
+
+    output=$($SMOLVM machine run --net --net-backend virtio -- true 2>&1) || exit_code=$?
+    [[ $exit_code -ne 0 ]] || {
+        echo "expected run failure for unsupported virtio backend"
+        return 1
+    }
+    [[ "$output" == *"not ready yet on this branch"* ]] || {
+        echo "unexpected output: $output"
+        return 1
+    }
+}
+
+test_machine_create_virtio_ports_rejected() {
+    cleanup_machine
+    local vm_name="virtio-ports-test-$$"
+    local exit_code=0
+    local output
+
+    output=$($SMOLVM machine create "$vm_name" --net --net-backend virtio -p 18080:80 2>&1) || exit_code=$?
+    [[ $exit_code -ne 0 ]] || {
+        echo "expected create failure for virtio published port request"
+        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        return 1
+    }
+    [[ "$output" == *"published ports are not supported"* ]] || {
+        echo "unexpected output: $output"
+        return 1
+    }
+}
+
+test_machine_create_virtio_policy_rejected() {
+    cleanup_machine
+    local vm_name="virtio-policy-test-$$"
+    local exit_code=0
+    local output
+
+    output=$($SMOLVM machine create "$vm_name" --net --net-backend virtio --allow-cidr 1.1.1.1/32 2>&1) || exit_code=$?
+    [[ $exit_code -ne 0 ]] || {
+        echo "expected create failure for virtio policy request"
+        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        return 1
+    }
+    [[ "$output" == *"allow-cidr/allow-host policies are not supported"* ]] || {
+        echo "unexpected output: $output"
+        return 1
+    }
+}
+
+test_pack_run_virtio_rejected_until_implemented() {
+    local output_path="$TEST_DIR/virtio-pack"
+    local exit_code=0
+    local output
+
+    if [[ ! -f "$output_path.smolmachine" ]]; then
+        $SMOLVM pack create --image alpine:latest -o "$output_path" >/dev/null 2>&1 || return 1
+    fi
+
+    output=$($SMOLVM pack run --sidecar "$output_path.smolmachine" --net --net-backend virtio -- true 2>&1) || exit_code=$?
+    [[ $exit_code -ne 0 ]] || {
+        echo "expected pack run failure for unsupported virtio backend"
+        return 1
+    }
+    [[ "$output" == *"not ready yet on this branch"* ]] || {
+        echo "unexpected output: $output"
+        return 1
+    }
+}
+
+run_test "Machine create: virtio rejected until implemented" test_machine_create_virtio_rejected_until_implemented || true
+run_test "Machine run: virtio rejected until implemented" test_machine_run_virtio_rejected_until_implemented || true
+run_test "Machine create: virtio + published ports rejected" test_machine_create_virtio_ports_rejected || true
+run_test "Machine create: virtio + policy rejected" test_machine_create_virtio_policy_rejected || true
+run_test "Pack run: virtio rejected until implemented" test_pack_run_virtio_rejected_until_implemented || true
+
+print_summary "Virtio-Net Tests"


### PR DESCRIPTION
add an new cli arg `--net-backend` to allow choosing between virtio-net and tsi. default is tsi

## Testing

```
[PASS] Exec CLI --workdir overrides Smolfile

==========================================
  Smolfile Tests Summary
==========================================

Tests run:    48
Tests passed: 48
Tests failed: 0

All tests passed!
Machine 'default' is not running (state: stopped)
Cleaning up data directory for vm: default
Deleted machine: default

==========================================
  Overall Summary
==========================================

Test suites run:    5
Test suites passed: 5
Test suites failed: 0

All test suites passed!
```