### PR TITLE
pathbuf-canonicalize bug fixed across codebase

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -1515,55 +1515,194 @@ fn apply_mode_best_effort(path: &std::path::Path, mode: u32) {
 #[cfg(not(unix))]
 fn apply_mode_best_effort(_path: &std::path::Path, _mode: u32) {}
 
-/// Resolve a guest path through the active persistent container overlay.
-///
-/// When an image-based VM has a mounted persistent overlay, file I/O
-/// paths (from `machine cp`) target the overlay's merged directory so
-/// files are visible inside the container. The host ensures the overlay
-/// is mounted before sending file I/O requests (via `PrepareOverlay`).
-///
-/// Returns the path unchanged for bare VMs (no overlay) or paths that
-/// target the VM's internal directories (`/storage/...`).
-fn resolve_container_path(path: &str) -> std::path::PathBuf {
-    // Don't redirect VM-internal paths.
-    if path.starts_with("/storage/") || path.starts_with("/proc/") || path.starts_with("/sys/") {
-        return std::path::PathBuf::from(path);
+#[derive(Clone, Copy, Debug)]
+enum FilePathAccess {
+    Read,
+    Write,
+}
+
+fn invalid_guest_path_error(path: &str, reason: &str) -> AgentResponse {
+    AgentResponse::error(
+        format!("invalid guest path {}: {}", path, reason),
+        error_codes::INVALID_REQUEST,
+    )
+}
+
+fn normalize_guest_path(path: &str) -> std::result::Result<String, AgentResponse> {
+    if path.is_empty() {
+        return Err(invalid_guest_path_error(path, "path is empty"));
     }
 
-    // /workspace is bind-mounted from /storage/workspace into the container.
-    // Rewrite so the agent writes to the bind-mount source.
-    if let Some(relative) =
-        path.strip_prefix("/workspace/").or_else(
-            || {
-                if path == "/workspace" {
-                    Some("")
-                } else {
-                    None
-                }
-            },
-        )
-    {
-        return std::path::PathBuf::from("/storage/workspace").join(relative);
-    }
+    let normalized = if path.starts_with('/') {
+        path.to_string()
+    } else {
+        format!("/{}", path)
+    };
 
-    let overlays_dir = std::path::Path::new("/storage/overlays");
-    if let Ok(entries) = std::fs::read_dir(overlays_dir) {
-        for entry in entries.flatten() {
-            if !entry
-                .file_name()
-                .to_string_lossy()
-                .starts_with("persistent-")
-            {
-                continue;
+    let p = std::path::Path::new(&normalized);
+    for component in p.components() {
+        match component {
+            std::path::Component::ParentDir => {
+                return Err(invalid_guest_path_error(path, "parent traversal is not allowed"));
             }
-            let merged = entry.path().join("merged");
-            if merged.join("bin").exists() || merged.join("usr").exists() {
-                let relative = path.strip_prefix('/').unwrap_or(path);
-                return merged.join(relative);
+            std::path::Component::CurDir => {
+                return Err(invalid_guest_path_error(path, "current-dir segments are not allowed"));
+            }
+            std::path::Component::Prefix(_) => {
+                return Err(invalid_guest_path_error(path, "path prefixes are not allowed"));
+            }
+            std::path::Component::RootDir | std::path::Component::Normal(_) => {}
+        }
+    }
+
+    Ok(normalized)
+}
+
+fn active_persistent_overlay_merged_root() -> Option<std::path::PathBuf> {
+    let overlays_dir = std::path::Path::new("/storage/overlays");
+    let entries = std::fs::read_dir(overlays_dir).ok()?;
+    for entry in entries.flatten() {
+        if !entry.file_name().to_string_lossy().starts_with("persistent-") {
+            continue;
+        }
+        let merged = entry.path().join("merged");
+        if merged.join("bin").exists() || merged.join("usr").exists() {
+            return Some(merged);
+        }
+    }
+    None
+}
+
+fn ensure_descendant_after_canonicalize(
+    path: &std::path::Path,
+    root: &std::path::Path,
+    original_path: &str,
+    access: FilePathAccess,
+) -> std::result::Result<(), AgentResponse> {
+    if matches!(access, FilePathAccess::Write) && !root.exists() {
+        std::fs::create_dir_all(root).map_err(|e| {
+            AgentResponse::error(
+                format!("failed to create root {}: {}", root.display(), e),
+                error_codes::FILE_IO_FAILED,
+            )
+        })?;
+    }
+
+    let root_canon = root.canonicalize().map_err(|e| {
+        AgentResponse::error(
+            format!("failed to canonicalize root {}: {}", root.display(), e),
+            error_codes::FILE_IO_FAILED,
+        )
+    })?;
+
+    match access {
+        FilePathAccess::Read => {
+            let path_canon = path.canonicalize().map_err(|e| {
+                AgentResponse::error(
+                    format!("failed to canonicalize target {}: {}", original_path, e),
+                    error_codes::FILE_IO_FAILED,
+                )
+            })?;
+            if !path_canon.starts_with(&root_canon) {
+                return Err(invalid_guest_path_error(
+                    original_path,
+                    "resolved path escapes allowed root",
+                ));
+            }
+        }
+        FilePathAccess::Write => {
+            let parent = path.parent().ok_or_else(|| {
+                invalid_guest_path_error(original_path, "target has no parent directory")
+            })?;
+
+            std::fs::create_dir_all(parent).map_err(|e| {
+                AgentResponse::error(
+                    format!("failed to create directory {}: {}", parent.display(), e),
+                    error_codes::FILE_IO_FAILED,
+                )
+            })?;
+
+            let parent_canon = parent.canonicalize().map_err(|e| {
+                AgentResponse::error(
+                    format!("failed to canonicalize parent {}: {}", parent.display(), e),
+                    error_codes::FILE_IO_FAILED,
+                )
+            })?;
+            if !parent_canon.starts_with(&root_canon) {
+                return Err(invalid_guest_path_error(
+                    original_path,
+                    "resolved parent escapes allowed root",
+                ));
+            }
+
+            if path.exists() {
+                let path_canon = path.canonicalize().map_err(|e| {
+                    AgentResponse::error(
+                        format!("failed to canonicalize target {}: {}", original_path, e),
+                        error_codes::FILE_IO_FAILED,
+                    )
+                })?;
+                if !path_canon.starts_with(&root_canon) {
+                    return Err(invalid_guest_path_error(
+                        original_path,
+                        "resolved path escapes allowed root",
+                    ));
+                }
             }
         }
     }
-    std::path::PathBuf::from(path)
+
+    Ok(())
+}
+
+fn resolve_guest_io_path_with_roots(
+    path: &str,
+    access: FilePathAccess,
+    overlay_merged_root: Option<&std::path::Path>,
+    workspace_root: &std::path::Path,
+) -> std::result::Result<std::path::PathBuf, AgentResponse> {
+    let normalized = normalize_guest_path(path)?;
+
+    let Some(overlay_root) = overlay_merged_root else {
+        return Ok(std::path::PathBuf::from(normalized));
+    };
+
+    let (target, allowed_root): (std::path::PathBuf, &std::path::Path) =
+        if let Some(relative) = normalized.strip_prefix("/workspace/").or_else(|| {
+            if normalized == "/workspace" {
+                Some("")
+            } else {
+                None
+            }
+        }) {
+            (workspace_root.join(relative), workspace_root)
+        } else {
+            let relative = normalized.strip_prefix('/').unwrap_or(&normalized);
+            (overlay_root.join(relative), overlay_root)
+        };
+
+    ensure_descendant_after_canonicalize(&target, allowed_root, &normalized, access)?;
+    Ok(target)
+}
+
+/// Resolve guest file I/O path with strict boundary checks.
+///
+/// For image-based persistent VMs, paths are mapped into the active
+/// `persistent-*` overlay's `merged` root (except `/workspace`, which
+/// maps to `/storage/workspace`, the bind-mount source). Both read and
+/// write flows enforce canonicalized descendant checks against the
+/// selected root to prevent traversal and symlink escapes.
+fn resolve_guest_io_path(
+    path: &str,
+    access: FilePathAccess,
+) -> std::result::Result<std::path::PathBuf, AgentResponse> {
+    let overlay = active_persistent_overlay_merged_root();
+    resolve_guest_io_path_with_roots(
+        path,
+        access,
+        overlay.as_deref(),
+        std::path::Path::new("/storage/workspace"),
+    )
 }
 
 /// Shared between single-shot [`handle_file_write`] and the streaming
@@ -1571,7 +1710,10 @@ fn resolve_container_path(path: &str) -> std::path::PathBuf {
 /// need to guarantee: partial contents never appear at `path` under
 /// any error or kill scenario.
 fn install_file_atomic(path: &str, data: &[u8], mode: Option<u32>) -> AgentResponse {
-    let resolved = resolve_container_path(path);
+    let resolved = match resolve_guest_io_path(path, FilePathAccess::Write) {
+        Ok(p) => p,
+        Err(resp) => return resp,
+    };
     let target = resolved.as_path();
     if let Err(resp) = ensure_parent_dir(target) {
         return resp;
@@ -1787,7 +1929,10 @@ fn handle_file_write_begin(
             ),
         );
     }
-    let resolved = resolve_container_path(&path);
+    let resolved = match resolve_guest_io_path(&path, FilePathAccess::Write) {
+        Ok(p) => p,
+        Err(resp) => return (None, resp),
+    };
     match WriteSession::open(resolved, mode, total_size) {
         Ok(session) => (Some(session), AgentResponse::Ok { data: None }),
         Err(e) => (
@@ -1906,7 +2051,13 @@ fn handle_streaming_file_read(
     stream: &mut impl ReadWrite,
     path: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let resolved = resolve_container_path(path);
+    let resolved = match resolve_guest_io_path(path, FilePathAccess::Read) {
+        Ok(p) => p,
+        Err(resp) => {
+            send_response(stream, &resp)?;
+            return Ok(());
+        }
+    };
     let mut file = match std::fs::File::open(&resolved) {
         Ok(f) => f,
         Err(e) => {
@@ -3770,6 +3921,112 @@ mod tests {
         );
         assert_eq!(std::fs::read(&target).unwrap(), payload);
         assert!(staging_files_in(tmp.path()).is_empty());
+    }
+
+    #[test]
+    fn resolve_guest_path_rejects_parent_traversal() {
+        let tmp = tempfile::tempdir().unwrap();
+        let merged = tmp.path().join("merged");
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&merged).unwrap();
+        std::fs::create_dir_all(&workspace).unwrap();
+
+        let res = resolve_guest_io_path_with_roots(
+            "/../../storage/secret.txt",
+            FilePathAccess::Write,
+            Some(&merged),
+            &workspace,
+        );
+        assert!(matches!(res, Err(AgentResponse::Error { .. })));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_guest_read_rejects_symlink_escape_from_overlay() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let merged = tmp.path().join("merged");
+        let workspace = tmp.path().join("workspace");
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir_all(&merged).unwrap();
+        std::fs::create_dir_all(&workspace).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+
+        let outside_file = outside.join("secret.txt");
+        std::fs::write(&outside_file, b"secret").unwrap();
+        symlink(&outside_file, merged.join("link-outside")).unwrap();
+
+        let res = resolve_guest_io_path_with_roots(
+            "/link-outside",
+            FilePathAccess::Read,
+            Some(&merged),
+            &workspace,
+        );
+        assert!(matches!(res, Err(AgentResponse::Error { .. })));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_guest_write_rejects_symlink_escape_from_overlay() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let merged = tmp.path().join("merged");
+        let workspace = tmp.path().join("workspace");
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir_all(&merged).unwrap();
+        std::fs::create_dir_all(&workspace).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+
+        symlink(&outside, merged.join("escape-dir")).unwrap();
+
+        let res = resolve_guest_io_path_with_roots(
+            "/escape-dir/pwned.txt",
+            FilePathAccess::Write,
+            Some(&merged),
+            &workspace,
+        );
+        assert!(matches!(res, Err(AgentResponse::Error { .. })));
+    }
+
+    #[test]
+    fn resolve_guest_workspace_path_maps_to_workspace_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let merged = tmp.path().join("merged");
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&merged).unwrap();
+        std::fs::create_dir_all(&workspace).unwrap();
+
+        let resolved = resolve_guest_io_path_with_roots(
+            "/workspace/subdir/file.txt",
+            FilePathAccess::Write,
+            Some(&merged),
+            &workspace,
+        )
+        .unwrap();
+
+        assert!(resolved.starts_with(&workspace));
+        assert_eq!(resolved, workspace.join("subdir").join("file.txt"));
+    }
+
+    #[test]
+    fn resolve_guest_relative_path_is_normalized_under_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let merged = tmp.path().join("merged");
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&merged).unwrap();
+        std::fs::create_dir_all(&workspace).unwrap();
+
+        let resolved = resolve_guest_io_path_with_roots(
+            "etc/hosts",
+            FilePathAccess::Write,
+            Some(&merged),
+            &workspace,
+        )
+        .unwrap();
+
+        assert_eq!(resolved, merged.join("etc").join("hosts"));
     }
 
     #[test]

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -1596,13 +1596,22 @@ fn normalize_guest_path(path: &str) -> std::result::Result<String, AgentResponse
     for component in p.components() {
         match component {
             std::path::Component::ParentDir => {
-                return Err(invalid_guest_path_error(path, "parent traversal is not allowed"));
+                return Err(invalid_guest_path_error(
+                    path,
+                    "parent traversal is not allowed",
+                ));
             }
             std::path::Component::CurDir => {
-                return Err(invalid_guest_path_error(path, "current-dir segments are not allowed"));
+                return Err(invalid_guest_path_error(
+                    path,
+                    "current-dir segments are not allowed",
+                ));
             }
             std::path::Component::Prefix(_) => {
-                return Err(invalid_guest_path_error(path, "path prefixes are not allowed"));
+                return Err(invalid_guest_path_error(
+                    path,
+                    "path prefixes are not allowed",
+                ));
             }
             std::path::Component::RootDir | std::path::Component::Normal(_) => {}
         }
@@ -1615,7 +1624,11 @@ fn active_persistent_overlay_merged_root() -> Option<std::path::PathBuf> {
     let overlays_dir = std::path::Path::new("/storage/overlays");
     let entries = std::fs::read_dir(overlays_dir).ok()?;
     for entry in entries.flatten() {
-        if !entry.file_name().to_string_lossy().starts_with("persistent-") {
+        if !entry
+            .file_name()
+            .to_string_lossy()
+            .starts_with("persistent-")
+        {
             continue;
         }
         let merged = entry.path().join("merged");
@@ -1720,19 +1733,19 @@ fn resolve_guest_io_path_with_roots(
         return Ok(std::path::PathBuf::from(normalized));
     };
 
-    let (target, allowed_root): (std::path::PathBuf, &std::path::Path) =
-        if let Some(relative) = normalized.strip_prefix("/workspace/").or_else(|| {
+    let (target, allowed_root): (std::path::PathBuf, &std::path::Path) = if let Some(relative) =
+        normalized.strip_prefix("/workspace/").or_else(|| {
             if normalized == "/workspace" {
                 Some("")
             } else {
                 None
             }
         }) {
-            (workspace_root.join(relative), workspace_root)
-        } else {
-            let relative = normalized.strip_prefix('/').unwrap_or(&normalized);
-            (overlay_root.join(relative), overlay_root)
-        };
+        (workspace_root.join(relative), workspace_root)
+    } else {
+        let relative = normalized.strip_prefix('/').unwrap_or(&normalized);
+        (overlay_root.join(relative), overlay_root)
+    };
 
     ensure_descendant_after_canonicalize(&target, allowed_root, &normalized, access)?;
     Ok(target)

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -173,7 +173,10 @@ fn ensure_mount_target_under_root(rootfs: &Path, container_path: &str) -> Result
                 if !meta.is_dir() {
                     return Err(StorageError::ValidationFailed {
                         context: "mount destination".to_string(),
-                        reason: format!("destination component is not a directory: {}", current.display()),
+                        reason: format!(
+                            "destination component is not a directory: {}",
+                            current.display()
+                        ),
                     });
                 }
             }
@@ -2160,11 +2163,12 @@ fn setup_volume_mounts(rootfs: &str, mounts: &[(String, String, bool)]) -> Resul
                 .map_err(|e| StorageError::Internal {
                     message: format!("invalid source: {}", e),
                 })?;
-            let bind_dst = std::ffi::CString::new(target_path.to_string_lossy().as_ref()).map_err(|e| {
-                StorageError::Internal {
-                    message: format!("invalid target: {}", e),
-                }
-            })?;
+            let bind_dst =
+                std::ffi::CString::new(target_path.to_string_lossy().as_ref()).map_err(|e| {
+                    StorageError::Internal {
+                        message: format!("invalid target: {}", e),
+                    }
+                })?;
             // SAFETY: bind mount with MS_BIND flag
             let rc = unsafe {
                 libc::mount(

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -28,6 +28,184 @@ const MANIFESTS_DIR: &str = "manifests";
 const OVERLAYS_DIR: &str = "overlays";
 const WORKSPACE_DIR: &str = "workspace";
 
+fn validate_storage_id(value: &str, context: &str) -> Result<()> {
+    if value.is_empty() {
+        return Err(StorageError::ValidationFailed {
+            context: context.to_string(),
+            reason: "cannot be empty".to_string(),
+        });
+    }
+
+    if value.len() > 128 {
+        return Err(StorageError::ValidationFailed {
+            context: context.to_string(),
+            reason: "too long (max 128 chars)".to_string(),
+        });
+    }
+
+    let path = Path::new(value);
+    for component in path.components() {
+        match component {
+            std::path::Component::ParentDir => {
+                return Err(StorageError::ValidationFailed {
+                    context: context.to_string(),
+                    reason: "parent traversal is not allowed".to_string(),
+                });
+            }
+            std::path::Component::CurDir => {
+                return Err(StorageError::ValidationFailed {
+                    context: context.to_string(),
+                    reason: "dot segments are not allowed".to_string(),
+                });
+            }
+            std::path::Component::RootDir | std::path::Component::Prefix(_) => {
+                return Err(StorageError::ValidationFailed {
+                    context: context.to_string(),
+                    reason: "path separators are not allowed".to_string(),
+                });
+            }
+            std::path::Component::Normal(seg) => {
+                let seg = seg.to_string_lossy();
+                if !seg
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+                {
+                    return Err(StorageError::ValidationFailed {
+                        context: context.to_string(),
+                        reason: format!("contains invalid character(s): {}", value),
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn overlay_root_for_workload(workload_id: &str) -> Result<PathBuf> {
+    validate_storage_id(workload_id, "workload_id")?;
+    Ok(Path::new(STORAGE_ROOT).join(OVERLAYS_DIR).join(workload_id))
+}
+
+fn validate_container_destination_path(container_path: &str) -> Result<PathBuf> {
+    if !container_path.starts_with('/') {
+        return Err(StorageError::ValidationFailed {
+            context: "mount destination".to_string(),
+            reason: "must be an absolute path".to_string(),
+        });
+    }
+    if container_path == "/" {
+        return Err(StorageError::ValidationFailed {
+            context: "mount destination".to_string(),
+            reason: "mounting to '/' is not allowed".to_string(),
+        });
+    }
+
+    let mut relative = PathBuf::new();
+    for component in Path::new(container_path).components() {
+        match component {
+            std::path::Component::RootDir => {}
+            std::path::Component::Normal(seg) => relative.push(seg),
+            std::path::Component::ParentDir => {
+                return Err(StorageError::ValidationFailed {
+                    context: "mount destination".to_string(),
+                    reason: "parent traversal is not allowed".to_string(),
+                });
+            }
+            std::path::Component::CurDir => {
+                return Err(StorageError::ValidationFailed {
+                    context: "mount destination".to_string(),
+                    reason: "dot segments are not allowed".to_string(),
+                });
+            }
+            std::path::Component::Prefix(_) => {
+                return Err(StorageError::ValidationFailed {
+                    context: "mount destination".to_string(),
+                    reason: "path prefixes are not allowed".to_string(),
+                });
+            }
+        }
+    }
+
+    if relative.as_os_str().is_empty() {
+        return Err(StorageError::ValidationFailed {
+            context: "mount destination".to_string(),
+            reason: "cannot resolve mount destination".to_string(),
+        });
+    }
+
+    Ok(relative)
+}
+
+fn ensure_mount_target_under_root(rootfs: &Path, container_path: &str) -> Result<PathBuf> {
+    let root_canon = rootfs.canonicalize().map_err(|e| StorageError::ReadFile {
+        path: rootfs.display().to_string(),
+        cause: format!("failed to canonicalize rootfs: {}", e),
+    })?;
+
+    let relative = validate_container_destination_path(container_path)?;
+    let mut current = root_canon.clone();
+
+    for component in relative.components() {
+        let std::path::Component::Normal(seg) = component else {
+            return Err(StorageError::ValidationFailed {
+                context: "mount destination".to_string(),
+                reason: "invalid destination component".to_string(),
+            });
+        };
+
+        current.push(seg);
+        match std::fs::symlink_metadata(&current) {
+            Ok(meta) => {
+                if meta.file_type().is_symlink() {
+                    let canon = current.canonicalize().map_err(|e| StorageError::ReadFile {
+                        path: current.display().to_string(),
+                        cause: format!("failed to canonicalize symlink target: {}", e),
+                    })?;
+                    if !canon.starts_with(&root_canon) {
+                        return Err(StorageError::ValidationFailed {
+                            context: "mount destination".to_string(),
+                            reason: "resolved path escapes rootfs".to_string(),
+                        });
+                    }
+                }
+
+                if !meta.is_dir() {
+                    return Err(StorageError::ValidationFailed {
+                        context: "mount destination".to_string(),
+                        reason: format!("destination component is not a directory: {}", current.display()),
+                    });
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                std::fs::create_dir(&current).map_err(|err| StorageError::CreateDir {
+                    path: current.display().to_string(),
+                    cause: err.to_string(),
+                })?;
+            }
+            Err(e) => {
+                return Err(StorageError::ReadFile {
+                    path: current.display().to_string(),
+                    cause: e.to_string(),
+                });
+            }
+        }
+    }
+
+    let final_canon = current.canonicalize().map_err(|e| StorageError::ReadFile {
+        path: current.display().to_string(),
+        cause: format!("failed to canonicalize mount destination: {}", e),
+    })?;
+    if !final_canon.starts_with(&root_canon) {
+        return Err(StorageError::ValidationFailed {
+            context: "mount destination".to_string(),
+            reason: "resolved path escapes rootfs".to_string(),
+        });
+    }
+
+    Ok(final_canon)
+}
+
 /// Global state for packed layers support.
 /// Set at startup if SMOLVM_PACKED_LAYERS env var is present.
 static PACKED_LAYERS_DIR: OnceLock<Option<PathBuf>> = OnceLock::new();
@@ -1345,16 +1523,15 @@ struct OverlaySetup {
 
 impl OverlaySetup {
     /// Create a new overlay setup for the given workload.
-    fn new(workload_id: &str) -> Self {
-        let root = Path::new(STORAGE_ROOT);
-        let overlay_root = root.join(OVERLAYS_DIR).join(workload_id);
-        Self {
+    fn new(workload_id: &str) -> Result<Self> {
+        let overlay_root = overlay_root_for_workload(workload_id)?;
+        Ok(Self {
             upper_path: overlay_root.join("upper"),
             work_path: overlay_root.join("work"),
             merged_path: overlay_root.join("merged"),
             overlay_root,
             workload_id: workload_id.to_string(),
-        }
+        })
     }
 
     /// Prepare overlay directories, cleaning up any previous state.
@@ -1584,7 +1761,7 @@ pub fn prepare_overlay(image: &str, workload_id: &str) -> Result<OverlayInfo> {
         })
         .collect();
 
-    OverlaySetup::new(workload_id).execute_or_remount(lowerdirs)
+    OverlaySetup::new(workload_id)?.execute_or_remount(lowerdirs)
 }
 
 /// Prepare an overlay filesystem using pre-packed layers.
@@ -1641,7 +1818,7 @@ fn prepare_overlay_from_packed(
         .collect();
 
     // Use shared overlay setup logic
-    OverlaySetup::new(workload_id).execute(lowerdirs)
+    OverlaySetup::new(workload_id)?.execute(lowerdirs)
 }
 
 /// Build lowerdir list from a pulled OCI image's layers.
@@ -1697,8 +1874,7 @@ fn get_packed_lowerdirs(packed_dir: &Path) -> Result<Vec<String>> {
 /// Clean up an overlay filesystem.
 /// Log the error inside this function to skip the repetitive Err matching when unnecessary.
 pub fn cleanup_overlay(workload_id: &str) -> Result<()> {
-    let root = Path::new(STORAGE_ROOT);
-    let overlay_root = root.join(OVERLAYS_DIR).join(workload_id);
+    let overlay_root = overlay_root_for_workload(workload_id)?;
     let merged_path = overlay_root.join("merged");
 
     // Unmount nested bind mounts inside the overlay rootfs first. Volume mounts
@@ -1889,6 +2065,7 @@ pub fn prepare_for_run(image: &str) -> Result<PreparedOverlayRootfs> {
 /// If it exists but is unmounted (e.g. after VM restart), remounts preserving
 /// the upper layer that contains previous changes.
 pub fn prepare_for_run_persistent(image: &str, overlay_id: &str) -> Result<PreparedOverlayRootfs> {
+    validate_storage_id(overlay_id, "persistent overlay id")?;
     let workload_id = format!("persistent-{}", overlay_id);
 
     // Resolve image layers (same logic as prepare_overlay)
@@ -1898,7 +2075,7 @@ pub fn prepare_for_run_persistent(image: &str, overlay_id: &str) -> Result<Prepa
         get_image_lowerdirs(image)?
     };
 
-    let setup = OverlaySetup::new(&workload_id);
+    let setup = OverlaySetup::new(&workload_id)?;
     let overlay = setup.execute_or_remount(lowerdirs)?;
 
     debug!(
@@ -1921,8 +2098,10 @@ pub fn setup_mounts(rootfs: &str, mounts: &[(String, String, bool)]) -> Result<(
 /// Setup volume mounts by mounting virtiofs and bind-mounting into the rootfs.
 fn setup_volume_mounts(rootfs: &str, mounts: &[(String, String, bool)]) -> Result<Vec<PathBuf>> {
     let mut mounted_paths = Vec::new();
+    let rootfs_path = Path::new(rootfs);
 
     for (tag, container_path, read_only) in mounts {
+        validate_storage_id(tag, "mount tag")?;
         debug!(tag = %tag, container_path = %container_path, read_only = %read_only, "setting up volume mount");
 
         // First, mount the virtiofs device at a staging location
@@ -1964,14 +2143,13 @@ fn setup_volume_mounts(rootfs: &str, mounts: &[(String, String, bool)]) -> Resul
         }
 
         // Now bind-mount into the container rootfs
-        let target_path = format!("{}{}", rootfs, container_path);
-        std::fs::create_dir_all(&target_path)?;
+        let target_path = ensure_mount_target_under_root(rootfs_path, container_path)?;
 
         // Check if already bind-mounted
-        if !is_mountpoint(Path::new(&target_path)) {
+        if !is_mountpoint(&target_path) {
             info!(
                 source = %virtiofs_mount.display(),
-                target = %target_path,
+                target = %target_path.display(),
                 read_only = %read_only,
                 "bind-mounting into container"
             );
@@ -1981,7 +2159,7 @@ fn setup_volume_mounts(rootfs: &str, mounts: &[(String, String, bool)]) -> Resul
                 .map_err(|e| StorageError::Internal {
                     message: format!("invalid source: {}", e),
                 })?;
-            let bind_dst = std::ffi::CString::new(target_path.as_str()).map_err(|e| {
+            let bind_dst = std::ffi::CString::new(target_path.to_string_lossy().as_ref()).map_err(|e| {
                 StorageError::Internal {
                     message: format!("invalid target: {}", e),
                 }
@@ -1998,7 +2176,7 @@ fn setup_volume_mounts(rootfs: &str, mounts: &[(String, String, bool)]) -> Resul
             };
             if rc != 0 {
                 let err = std::io::Error::last_os_error();
-                warn!(error = %err, target = %target_path, "failed to bind-mount");
+                warn!(error = %err, target = %target_path.display(), "failed to bind-mount");
                 continue;
             }
 
@@ -2017,7 +2195,7 @@ fn setup_volume_mounts(rootfs: &str, mounts: &[(String, String, bool)]) -> Resul
             }
         }
 
-        mounted_paths.push(PathBuf::from(target_path));
+        mounted_paths.push(target_path);
     }
 
     Ok(mounted_paths)
@@ -2585,5 +2763,41 @@ mod tests {
             sanitize_image_name("ghcr.io/owner/repo@sha256:abc123"),
             "ghcr.io_owner_repo_sha256_abc123"
         );
+    }
+
+    #[test]
+    fn test_validate_storage_id_rejects_traversal() {
+        assert!(validate_storage_id("../escape", "workload_id").is_err());
+        assert!(validate_storage_id("foo/bar", "workload_id").is_err());
+    }
+
+    #[test]
+    fn test_validate_container_destination_path_requires_absolute() {
+        assert!(validate_container_destination_path("var/data").is_err());
+        assert!(validate_container_destination_path("/").is_err());
+        assert!(validate_container_destination_path("/var/data").is_ok());
+    }
+
+    #[test]
+    fn test_ensure_mount_target_under_root_rejects_parent_traversal() {
+        let root = tempfile::tempdir().unwrap();
+        let rootfs = root.path().join("rootfs");
+        std::fs::create_dir_all(&rootfs).unwrap();
+
+        assert!(ensure_mount_target_under_root(&rootfs, "/../../escape").is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_ensure_mount_target_under_root_rejects_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let rootfs = root.path().join("rootfs");
+        std::fs::create_dir_all(&rootfs).unwrap();
+
+        symlink(outside.path(), rootfs.join("link-out")).unwrap();
+        assert!(ensure_mount_target_under_root(&rootfs, "/link-out/dir").is_err());
     }
 }

--- a/crates/smolvm-pack/src/extract.rs
+++ b/crates/smolvm-pack/src/extract.rs
@@ -132,6 +132,62 @@ fn normalize_path(path: &Path) -> PathBuf {
     components.iter().collect()
 }
 
+fn resolve_cache_asset_path(
+    cache_dir: &Path,
+    asset_rel_path: &str,
+    context: &str,
+) -> std::io::Result<PathBuf> {
+    if asset_rel_path.is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("{} path is empty", context),
+        ));
+    }
+
+    let rel = Path::new(asset_rel_path);
+    if rel.is_absolute() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("{} path must be relative", context),
+        ));
+    }
+
+    for component in rel.components() {
+        match component {
+            std::path::Component::Normal(_) => {}
+            std::path::Component::ParentDir
+            | std::path::Component::CurDir
+            | std::path::Component::RootDir
+            | std::path::Component::Prefix(_) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("{} path contains disallowed components", context),
+                ));
+            }
+        }
+    }
+
+    let cache_root = cache_dir
+        .canonicalize()
+        .unwrap_or_else(|_| normalize_path(cache_dir));
+    let candidate = cache_dir.join(rel);
+
+    let resolved = if candidate.exists() {
+        candidate.canonicalize()?
+    } else {
+        normalize_path(&candidate)
+    };
+
+    if !resolved.starts_with(&cache_root) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("{} path escapes cache directory", context),
+        ));
+    }
+
+    Ok(resolved)
+}
+
 /// Marker file indicating extraction is complete.
 const EXTRACTION_MARKER: &str = ".smolvm-extracted";
 
@@ -563,7 +619,7 @@ pub fn copy_overlay_template(
         )
     })?;
 
-    let src = cache_dir.join(template);
+    let src = resolve_cache_asset_path(cache_dir, template, "overlay template")?;
     if !src.exists() {
         return Err(std::io::Error::new(
             std::io::ErrorKind::NotFound,
@@ -600,7 +656,7 @@ pub fn create_or_copy_storage_disk(
     size_gb_override: Option<u64>,
 ) -> std::io::Result<()> {
     if let Some(template) = template_path {
-        let template_path = cache_dir.join(template);
+        let template_path = resolve_cache_asset_path(cache_dir, template, "storage template")?;
         if template_path.exists() {
             fs::copy(&template_path, storage_path)?;
             // If a custom size was requested and it's larger than the template,
@@ -735,6 +791,41 @@ mod tests {
         // We can't test GiB-sized files, but we can verify the copy works
         copy_overlay_template(temp_dir.path(), Some("overlay.raw"), &dest2, None).unwrap();
         assert!(dest2.exists());
+    }
+
+    #[test]
+    fn test_copy_overlay_template_rejects_traversal_path() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let outside = temp_dir.path().join("outside.raw");
+        let dest = temp_dir.path().join("overlay.raw");
+        fs::write(&outside, b"x").unwrap();
+
+        let result = copy_overlay_template(temp_dir.path(), Some("../outside.raw"), &dest, None);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_create_or_copy_storage_disk_rejects_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let outside_dir = tempfile::tempdir().unwrap();
+        let outside_file = outside_dir.path().join("storage-template.ext4");
+        fs::write(&outside_file, b"template").unwrap();
+
+        symlink(outside_dir.path(), temp_dir.path().join("symlink-out")).unwrap();
+
+        let storage_path = temp_dir.path().join("storage.ext4");
+        let result = create_or_copy_storage_disk(
+            temp_dir.path(),
+            Some("symlink-out/storage-template.ext4"),
+            &storage_path,
+            None,
+        );
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::InvalidInput);
     }
 
     #[test]

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -3,6 +3,7 @@
 //! The AgentManager is responsible for starting and stopping the agent VM,
 //! which runs the smolvm-agent for OCI image management and command execution.
 
+use crate::data::validate_vm_name;
 use crate::error::{Error, Result};
 use crate::process::{self, ChildProcess};
 use crate::storage::{OverlayDisk, StorageDisk};
@@ -242,6 +243,11 @@ impl AgentManager {
         storage_disk: StorageDisk,
         overlay_disk: OverlayDisk,
     ) -> Result<Self> {
+        if let Some(ref vm_name) = name {
+            validate_vm_name(vm_name, "machine name")
+                .map_err(|e| Error::config("validate machine name", e))?;
+        }
+
         // Create runtime directory for sockets
         let runtime_dir = dirs::runtime_dir()
             .or_else(dirs::cache_dir)

--- a/src/api/supervisor.rs
+++ b/src/api/supervisor.rs
@@ -192,6 +192,11 @@ impl Supervisor {
 
     /// Get the console log path for a machine.
     fn get_machine_log_path(&self, name: &str) -> Option<std::path::PathBuf> {
+        if crate::data::validate_vm_name(name, "machine name").is_err() {
+            tracing::warn!(machine = %name, "skipping invalid machine name when resolving log path");
+            return None;
+        }
+
         let runtime_dir = dirs::runtime_dir()
             .or_else(dirs::cache_dir)
             .unwrap_or_else(|| std::path::PathBuf::from("/tmp"));


### PR DESCRIPTION
## Summary
Hardens path handling across file I/O and asset extraction to prevent path traversal and symlink-based escapes from intended roots.

Closes #115 

## Why
User-influenced paths were being joined with PathBuf in multiple places without strict root-boundary enforcement.
This allowed .. traversal and symlink escape patterns in some flows (cp/API file ops, mount target construction, packed template path resolution).

## What changed

Added strict guest file path resolution in main.rs: 
- lexical validation (.., . and invalid prefix rejection)
- canonicalization + descendant checks
- read/write root enforcement for overlay/workspace mapping

Hardened overlay/mount path handling in storage.rs:
- validated workload IDs / mount tags / persistent overlay IDs
- replaced rootfs string concatenation with validated path resolution
- blocked symlink escapes for mount destinations

Hardened packed template path resolution in extract.rs:
- enforced relative-only asset paths
- canonicalized and enforced cache-root descendants
- blocked traversal/symlink escapes for storage/overlay template paths
Added defensive machine-name validation before host log path derivation:
- manager.rs
- supervisor.rs


## Security impact
Prevents traversal and symlink escape from intended filesystem roots in patched flows.
This is a hardening improvement; smolvm’s primary security boundary remains VM isolation.

## Tests / validation
- cargo check -p smolvm-pack
- cargo check -p smolvm 
- cargo check -p smolvm-agent --tests --target x86_64-unknown-linux-musl

- Added regression tests for: traversal rejection, symlink escape rejection, mount destination/rootfs boundary enforcement, template cache path boundary enforcement

### Notes
This is a minimal, DRY hardening pass with low refactor blast radius and good backportability.