### PR TITLE
Clarify that smolvm uses the OCI / Docker image format

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ How It Works
 
 Each workload gets real hardware isolation — its own kernel on [Hypervisor.framework](https://developer.apple.com/documentation/hypervisor) (macOS) or KVM (Linux). [libkrun](https://github.com/containers/libkrun) VMM with custom kernel: [libkrunfw](https://github.com/smol-machines/libkrunfw). Pack it into a `.smolmachine` and it runs anywhere the host architecture matches, with zero dependencies.
 
+Images use the [OCI](https://opencontainers.org/) format — the same open standard Docker uses. Any image on Docker Hub, ghcr.io, or other OCI registries can be pulled and booted as a microVM. No Docker daemon required.
+
 Defaults: 4 vCPUs, 8 GiB RAM. Memory is elastic via virtio balloon — the host only commits what the guest actually uses and reclaims the rest automatically. vCPU threads sleep in the hypervisor when idle, so over-provisioning has near-zero cost. Override with `--cpus` and `--mem`.
 
 Comparison


### PR DESCRIPTION
## Problem

Reading through the HN launch comments, a lot of people seemed confused about *where* the images come from when they see `--image alpine` or `--image python:3.12-alpine` in the README. They weren't sure if smolvm had its own image format, needed Docker running, or pulled from somewhere specific.

## Solution

Adds one short paragraph to the "How It Works" section that spells it out: smolvm uses OCI, which is an open standard — the same one Docker uses — so any image on Docker Hub, ghcr.io, or any other OCI registry just works. No Docker daemon required.

Only touches `README.md`. No code changes.
