### PR TITLE
fix: napi compilation failures

### DIFF
--- a/crates/smolvm-napi/src/machine.rs
+++ b/crates/smolvm-napi/src/machine.rs
@@ -135,8 +135,8 @@ impl NapiMachine {
 
         Ok(ExecResult {
             exit_code: result.0,
-            stdout: result.1,
-            stderr: result.2,
+            stdout: String::from_utf8_lossy(&result.1).into_owned(),
+            stderr: String::from_utf8_lossy(&result.2).into_owned(),
         })
     }
 
@@ -164,8 +164,8 @@ impl NapiMachine {
 
         Ok(ExecResult {
             exit_code: result.0,
-            stdout: result.1,
-            stderr: result.2,
+            stdout: String::from_utf8_lossy(&result.1).into_owned(),
+            stderr: String::from_utf8_lossy(&result.2).into_owned(),
         })
     }
 

--- a/crates/smolvm-napi/src/types.rs
+++ b/crates/smolvm-napi/src/types.rs
@@ -164,6 +164,7 @@ impl VmResourcesConfig {
             cpus: self.cpus.unwrap_or(DEFAULT_MICROVM_CPU_COUNT),
             memory_mib: self.memory_mib.unwrap_or(DEFAULT_MICROVM_MEMORY_MIB),
             network: self.network.unwrap_or(false),
+            network_backend: None,
             storage_gib: self.storage_gib.map(|g| g as u64),
             overlay_gib: self.overlay_gib.map(|g| g as u64),
             allowed_cidrs: None,


### PR DESCRIPTION
### Testing

```
 npm run build:platform && npm run --workspace smolvm-embedded test


> build:platform
> ./scripts/build-platform-package.sh

Building embedded Node platform package: smolvm-embedded-darwin-arm64
    Finished `release` profile [optimized] target(s) in 0.08s
Staged embedded SDK libraries from /Users/qiaofu/workspace/smol-machines-dev/smolvm-napi-fixes/lib into /Users/qiaofu/workspace/smol-machines-dev/smolvm-napi-fixes/sdks/node/smolvm-embedded-darwin-arm64/lib

Built platform package: smolvm-embedded-darwin-arm64
Package directory: /Users/qiaofu/workspace/smol-machines-dev/smolvm-napi-fixes/sdks/node/smolvm-embedded-darwin-arm64

Next useful commands:
  - cd /Users/qiaofu/workspace/smol-machines-dev/smolvm-napi-fixes/sdks/node && npm run build
  - cd /Users/qiaofu/workspace/smol-machines-dev/smolvm-napi-fixes/sdks/node && npm test
  - cd /Users/qiaofu/workspace/smol-machines-dev/smolvm-napi-fixes/sdks/node && npm run smoke

> smolvm-embedded@0.2.0 test
> ../node_modules/.bin/vitest run

The CJS build of Vite's Node API is deprecated. See https://vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.

 RUN  v1.6.1 /Users/qiaofu/workspace/smol-machines-dev/smolvm-napi-fixes/sdks/node/smolvm-embedded

 ✓ __tests__/machine.test.ts (13) 9936ms
 ✓ integration-tests/network-and-mounts.test.ts (4) 1917ms
 ✓ integration-tests/exec-and-files.test.ts (3) 621ms
 ✓ integration-tests/images.test.ts (3) 7853ms
 ✓ integration-tests/lifecycle.test.ts (2) 578ms
 ✓ integration-tests/resources.test.ts (1)

 Test Files  6 passed (6)
      Tests  26 passed (26)
   Start at  22:47:18
   Duration  22.40s (transform 46ms, setup 0ms, collect 531ms, tests 21.14s, environment 0ms, prepare 143ms)

qiaofu@Fus-MacBook-Pro-Dev node % npm run --workspace smolvm-embedded test:integration

> smolvm-embedded@0.2.0 test:integration
> ../node_modules/.bin/vitest run integration-tests

The CJS build of Vite's Node API is deprecated. See https://vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.

 RUN  v1.6.1 /Users/qiaofu/workspace/smol-machines-dev/smolvm-napi-fixes/sdks/node/smolvm-embedded

 ✓ integration-tests/network-and-mounts.test.ts (4) 1933ms
 ✓ integration-tests/exec-and-files.test.ts (3) 630ms
 ✓ integration-tests/images.test.ts (3) 7697ms
 ✓ integration-tests/lifecycle.test.ts (2) 594ms
 ✓ integration-tests/resources.test.ts (1)

 Test Files  5 passed (5)
      Tests  13 passed (13)
   Start at  22:47:52
   Duration  11.73s (transform 33ms, setup 0ms, collect 72ms, tests 11.06s, environment 0ms, prepare 110ms)
   ```