### PR TITLE
pack create: fix temp agent-VM name prefix violating validate_vm_name

### DIFF
--- a/src/cli/pack.rs
+++ b/src/cli/pack.rs
@@ -175,10 +175,15 @@ impl PackCreateCmd {
         let staging_dir = temp_dir.path().join("staging");
 
         // Start a temporary agent VM with a unique identity so concurrent
-        // pack runs and the user's "default" VM don't collide.
+        // pack runs and the user's "default" VM don't collide. The prefix
+        // must start with an ascii-alphanumeric character to satisfy
+        // `validate_vm_name` when `AgentManager::for_vm` receives the name
+        // (see src/data/mod.rs). A leading underscore — the previous
+        // `__pack_` convention — was rejected outright and made every
+        // `smolvm pack create` invocation fail.
         // Use PID + epoch nanos to avoid PID-reuse collisions with orphaned VMs.
         let pack_vm_name = format!(
-            "__pack_{}_{}",
+            "pack-{}-{}",
             std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
@@ -485,8 +490,10 @@ impl PackCreateCmd {
             // Start temp VM with source VM's storage disk attached as an extra
             // virtio-blk device. virtiofs can only share directories, not files,
             // so we pass the ext4 disk image as a third block device (/dev/vdc).
+            // Same alphanumeric-first-char constraint as the image-pack
+            // path above; see the comment there for rationale.
             let pack_vm_name = format!(
-                "__pack_fromvm_{}_{}",
+                "pack-fromvm-{}-{}",
                 std::process::id(),
                 std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -66,11 +66,13 @@ pub fn validate_vm_name(name: &str, label: &str) -> Result<(), String> {
     }
 
     if !first_char.is_ascii_alphanumeric() {
-        return Err(format!("{label} must start with a letter or digit"));
+        return Err(format!(
+            "{label} must start with a letter or digit (got: {name:?})"
+        ));
     }
 
     if name.ends_with('-') {
-        return Err(format!("{label} cannot end with a hyphen"));
+        return Err(format!("{label} cannot end with a hyphen (got: {name:?})"));
     }
 
     let mut prev_was_hyphen = false;


### PR DESCRIPTION
## Summary

Every invocation of `smolvm pack create` fails with:

```
Error: config operation failed: validate machine name: machine name must start with a letter or digit
```

The temp agent-VM name generated by `pack create` starts with `__pack_`, and `validate_vm_name` rejects anything whose first char isn't ASCII-alphanumeric.

## Reproduction

Any image, any flag combination, on a fresh smolvm install:

```bash
smolvm pack create --image alpine:latest -o /tmp/t.smolmachine
# → Starting agent VM...
# → Error: config operation failed: validate machine name:
#          machine name must start with a letter or digit
```

## Root cause

Two source files have disagreeing alphabets:

- [`src/cli/pack.rs`](https://github.com/smol-machines/smolvm/blob/main/src/cli/pack.rs) generates `"__pack_{pid}_{nanos}"` / `"__pack_fromvm_{pid}_{nanos}"` as the temp agent VM name (leading `__` for namespacing).
- [`src/data/mod.rs::validate_vm_name`](https://github.com/smol-machines/smolvm/blob/main/src/data/mod.rs) requires `first_char.is_ascii_alphanumeric()`.
- [`src/agent/manager.rs`](https://github.com/smol-machines/smolvm/blob/main/src/agent/manager.rs) calls `validate_vm_name` unconditionally when `AgentManager::for_vm` receives any named VM — including the pack's temp VM.

The `__pack_` convention appears to predate `validate_vm_name`'s consolidation (commit `eb2494c`, 2026-04-11), which now flows through `AgentManager::for_vm` without a bypass for internal names.

## Fix

Swap both pack VM naming sites from `__pack_*` to `pack-*` (and the from-vm variant to `pack-fromvm-*`). Leading `p` is ASCII-alphanumeric; hyphens are already allowed by the validator's interior alphabet; namespacing intent is preserved since `pack-<pid>-<nanos>` is unambiguous.

## Bonus: include the offending name in validator errors

Two error messages (`must start with a letter or digit`, `cannot end with a hyphen`) now include the actual name value in the output. Made diagnosing this bug much harder than it needed to be — future similar defects will surface the generated name automatically.

## Verification

After the patch: `smolvm pack create --image alpine:latest -o /tmp/t.smolmachine` reaches the layer-export phase and produces the artifact. Verified locally on macOS 26.3.1 / arm64 with smolvm v0.5.18.

Existing test suite unchanged and still passes. Validator tests don't assert on error-message text for the two modified strings, so they remain green.