### PR TITLE
pack: install SigintGuard on all pack-flow fork sites

### DIFF
--- a/src/cli/pack.rs
+++ b/src/cli/pack.rs
@@ -256,6 +256,15 @@ impl PackCreateCmd {
             data_dir: vm_data_dir,
             finalized: false,
         };
+        // Ensure Ctrl+C during a long pack create tears down the agent
+        // VM rather than orphaning it. Default SIGINT exits immediately
+        // and skips PackVmGuard::Drop, leaving the setsid()-detached
+        // VM plus a ~500 MB overlay disk on the host. Same gap fixed
+        // in pack_run's ephemeral/run paths.
+        let _sigint_guard = guard
+            .manager
+            .child_pid()
+            .map(smolvm::process::SigintGuard::new);
         let mut client = guard.manager.connect()?;
 
         // Pull image

--- a/src/cli/pack_run.rs
+++ b/src/cli/pack_run.rs
@@ -420,12 +420,21 @@ impl PackRunCmd {
             runtime_dir,
         };
 
+        // Ensure Ctrl+C tears down the forked VM child rather than
+        // orphaning it. Without this guard the default SIGINT handler
+        // exits the parent immediately and skips ChildGuard::Drop — the
+        // setsid()-detached VM keeps running and holds its sockets. Same
+        // fix applied in run_ephemeral below; both fork sites had the
+        // gap.
+        let sigint_guard = smolvm::process::SigintGuard::new(child_pid);
+
         // 9. Parent: wait for agent, connect, execute command
         let mut client = wait_for_agent(&vsock_path, self.debug)?;
 
         let exit_code = execute_command(&mut client, &manifest, &self, &mounts)?;
 
         // std::process::exit skips destructors, so drop explicitly first.
+        drop(sigint_guard);
         drop(child_guard);
         drop(layers_lease); // releases layers volume lease (detaches if last)
         std::process::exit(exit_code);
@@ -1239,6 +1248,16 @@ fn run_from_cache(
         start_time: child_start_time,
         runtime_dir,
     };
+
+    // Ensure Ctrl+C tears down the forked VM child rather than orphaning
+    // it. Without this guard, the default SIGINT handler exits the parent
+    // immediately and skips ChildGuard::Drop, so the setsid()-detached VM
+    // process keeps running and keeps the port bound. Mirrors the pattern
+    // machine.rs already uses for persistent VMs. Declared AFTER
+    // child_guard so Drop order (reverse of declaration) fires
+    // SigintGuard first on normal exit — harmless since it only restores
+    // the default handler.
+    let _sigint_guard = smolvm::process::SigintGuard::new(child_pid);
 
     let mut client = wait_for_agent(&vsock_path, debug)?;
 


### PR DESCRIPTION
## Summary

Ctrl+C during any of three pack-flow fork sites exited the parent via the default SIGINT handler, which skips every Rust destructor — leaving the \`setsid()\`-detached VM child orphaned, holding sockets, and occupying host ports. The existing \`SigintGuard\` type in \`src/process.rs\` (already used by \`machine.rs\` for persistent VMs) does exactly the right teardown; it just wasn't wired into the pack paths.

## Reproduction (before this patch)

1. Start a long-lived ephemeral VM:
   \`\`\`bash
   smolvm pack run --net <some-app-image>
   \`\`\`
   (or bare-mode invocation of a packed \`.smolmachine\`)
2. Open a connection to a port the guest binds (e.g. \`curl localhost:9000\`).
3. Hit Ctrl+C in the terminal where smolvm was launched.

Observed: parent process exits, but \`pgrep\` shows the VM child is still alive and \`lsof -iTCP:<port>\` shows it still holding the socket.

## Root cause

Three fork sites in the pack flow create a session-leader child but don't install a SIGINT handler:

- \`src/cli/pack_run.rs::run_ephemeral\` — the path bare \`./binary\` and \`./binary run\` take for a packed \`.smolmachine\`.
- \`src/cli/pack_run.rs::PackRunCmd::run\` — the non-packaged \`smolvm pack run\` CLI entry. Also has an explicit \`std::process::exit\` on the success path that bypasses destructors.
- \`src/cli/pack.rs::PackCreateCmd::run\` — \`smolvm pack create\`, where orphaning leaks a ~500 MB overlay disk per aborted pack.

## Fix

All three sites now install \`SigintGuard\` on the tracked child PID immediately after the \`ChildGuard\` / \`PackVmGuard\`. For the \`std::process::exit\` path in \`PackRunCmd::run\`, the guard is explicitly dropped before the exit call so its \`Drop\` runs (mirrors the existing \`drop(child_guard)\` pattern).

The handler in \`SigintGuard\` was already async-signal-safe (only \`kill()\` and \`_exit()\`) and had documented semantics matching exactly what these sites needed — the diff is purely wire-up.

## Verification

With this patch, Ctrl+C on a running pack-mode VM terminates the child within ~1 second (SIGTERM grace period + SIGKILL escalation built into \`sigint_kill_handler\`). \`pgrep\` and \`lsof\` show the process is gone and the port is free immediately after return-to-prompt. Verified on macOS 26.3.1 / arm64 with a Play framework JVM workload that was previously keeping the VM alive via established TCP connections.

## Related

Discovered alongside #160 (the pack_vm_name prefix fix). These two bugs together meant \`pack create\` couldn't even start, and \`pack run\` couldn't be cleanly stopped. Landing both makes the pack flow usable end-to-end.