### PR TITLE
chores: rename network backend for virtio-net to virtio-net instead o…

### DIFF
--- a/crates/smolvm-agent/Cargo.toml
+++ b/crates/smolvm-agent/Cargo.toml
@@ -10,6 +10,7 @@ name = "smolvm-agent"
 path = "src/main.rs"
 
 [dependencies]
+smolvm-network = { path = "../smolvm-network" }
 smolvm-protocol = { path = "../smolvm-protocol" }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/smolvm-agent/src/dns_proxy.rs
+++ b/crates/smolvm-agent/src/dns_proxy.rs
@@ -13,8 +13,8 @@
 //!
 //! The host responds with the same framing.
 
-use smolvm_protocol::ports;
 use smolvm_network::guest_env;
+use smolvm_protocol::ports;
 use std::io::{self, Read, Write};
 use std::net::UdpSocket;
 use std::thread;

--- a/crates/smolvm-agent/src/dns_proxy.rs
+++ b/crates/smolvm-agent/src/dns_proxy.rs
@@ -14,6 +14,7 @@
 //! The host responds with the same framing.
 
 use smolvm_protocol::ports;
+use smolvm_network::guest_env;
 use std::io::{self, Read, Write};
 use std::net::UdpSocket;
 use std::thread;
@@ -45,7 +46,7 @@ pub fn start() {
 /// Check if DNS filtering is enabled via environment variable.
 /// The host sets this when `--allow-host` is used.
 pub fn is_enabled() -> bool {
-    std::env::var("SMOLVM_DNS_FILTER").as_deref() == Ok("1")
+    std::env::var(guest_env::DNS_FILTER).as_deref() == Ok("1")
 }
 
 fn run_proxy() -> io::Result<()> {

--- a/crates/smolvm-agent/src/network/mod.rs
+++ b/crates/smolvm-agent/src/network/mod.rs
@@ -98,7 +98,7 @@ pub fn configure_from_env() -> Result<bool, String> {
         _ => return Ok(false),
     };
 
-    if backend != guest_env::BACKEND_VIRTIO_NET && backend != guest_env::BACKEND_VIRTIO_LEGACY {
+    if backend != guest_env::BACKEND_VIRTIO_NET {
         return Err(format!(
             "unsupported {} value: {}",
             guest_env::BACKEND,

--- a/crates/smolvm-agent/src/network/mod.rs
+++ b/crates/smolvm-agent/src/network/mod.rs
@@ -17,7 +17,7 @@
 //!
 //! ```text
 //! host launcher
-//!   -> decides backend = virtio
+//!   -> decides backend = virtio-net
 //!   -> chooses guest IP / gateway / DNS / MAC
 //!   -> exports SMOLVM_NETWORK_* env
 //!   -> starts guest agent
@@ -47,6 +47,7 @@
 //! The Linux-specific implementation lives in `linux.rs`. Non-Linux guests
 //! currently return an explicit error instead of attempting a partial setup.
 
+use smolvm_network::guest_env;
 use std::net::Ipv4Addr;
 
 /// Configure the guest network interface from host-provided environment.
@@ -57,7 +58,7 @@ use std::net::Ipv4Addr;
 /// --------------------
 ///
 /// The host launcher currently provides:
-/// - `SMOLVM_NETWORK_BACKEND=virtio`
+/// - `SMOLVM_NETWORK_BACKEND=virtio-net`
 /// - `SMOLVM_NETWORK_GUEST_IP`
 /// - `SMOLVM_NETWORK_GATEWAY`
 /// - `SMOLVM_NETWORK_PREFIX_LEN`
@@ -67,7 +68,7 @@ use std::net::Ipv4Addr;
 /// Example:
 ///
 /// ```text
-/// SMOLVM_NETWORK_BACKEND=virtio
+/// SMOLVM_NETWORK_BACKEND=virtio-net
 /// SMOLVM_NETWORK_GUEST_IP=10.0.2.15
 /// SMOLVM_NETWORK_GATEWAY=10.0.2.2
 /// SMOLVM_NETWORK_PREFIX_LEN=24
@@ -92,23 +93,24 @@ use std::net::Ipv4Addr;
 ///   or malformed, so boot should fail instead of continuing with a
 ///   half-configured NIC.
 pub fn configure_from_env() -> Result<bool, String> {
-    let backend = match std::env::var("SMOLVM_NETWORK_BACKEND") {
+    let backend = match std::env::var(guest_env::BACKEND) {
         Ok(value) if !value.is_empty() => value,
         _ => return Ok(false),
     };
 
-    if backend != "virtio" {
+    if backend != guest_env::BACKEND_VIRTIO_NET && backend != guest_env::BACKEND_VIRTIO_LEGACY {
         return Err(format!(
-            "unsupported SMOLVM_NETWORK_BACKEND value: {}",
+            "unsupported {} value: {}",
+            guest_env::BACKEND,
             backend
         ));
     }
 
-    let guest_ip = env_ipv4("SMOLVM_NETWORK_GUEST_IP")?;
-    let gateway = env_ipv4("SMOLVM_NETWORK_GATEWAY")?;
-    let prefix_len = env_u8("SMOLVM_NETWORK_PREFIX_LEN")?;
-    let guest_mac = env_mac("SMOLVM_NETWORK_GUEST_MAC")?;
-    let dns_server = env_ipv4("SMOLVM_NETWORK_DNS")?;
+    let guest_ip = env_ipv4(guest_env::GUEST_IP)?;
+    let gateway = env_ipv4(guest_env::GATEWAY)?;
+    let prefix_len = env_u8(guest_env::PREFIX_LEN)?;
+    let guest_mac = env_mac(guest_env::GUEST_MAC)?;
+    let dns_server = env_ipv4(guest_env::DNS)?;
 
     linux::configure_interface(
         "eth0", guest_mac, 1500, guest_ip, prefix_len, gateway, dns_server,

--- a/crates/smolvm-network/src/guest_env.rs
+++ b/crates/smolvm-network/src/guest_env.rs
@@ -11,8 +11,6 @@
 pub const BACKEND: &str = "SMOLVM_NETWORK_BACKEND";
 /// Canonical backend value meaning "configure guest virtio-net".
 pub const BACKEND_VIRTIO_NET: &str = "virtio-net";
-/// Legacy backend value retained for backwards compatibility.
-pub const BACKEND_VIRTIO_LEGACY: &str = "virtio";
 /// Guest IPv4 address.
 pub const GUEST_IP: &str = "SMOLVM_NETWORK_GUEST_IP";
 /// Guest-visible default gateway IPv4 address.

--- a/crates/smolvm-network/src/guest_env.rs
+++ b/crates/smolvm-network/src/guest_env.rs
@@ -1,0 +1,27 @@
+//! Shared environment-variable contract for guest virtio networking.
+//!
+//! These names form the protocol boundary between:
+//! - the host-side launcher, which decides the guest/gateway plan
+//! - the guest agent, which configures the in-guest NIC from that plan
+//!
+//! They should be treated as stable protocol constants rather than ad hoc
+//! launcher strings.
+
+/// Selects whether the guest should configure a real virtio NIC.
+pub const BACKEND: &str = "SMOLVM_NETWORK_BACKEND";
+/// Canonical backend value meaning "configure guest virtio-net".
+pub const BACKEND_VIRTIO_NET: &str = "virtio-net";
+/// Legacy backend value retained for backwards compatibility.
+pub const BACKEND_VIRTIO_LEGACY: &str = "virtio";
+/// Guest IPv4 address.
+pub const GUEST_IP: &str = "SMOLVM_NETWORK_GUEST_IP";
+/// Guest-visible default gateway IPv4 address.
+pub const GATEWAY: &str = "SMOLVM_NETWORK_GATEWAY";
+/// Guest subnet prefix length.
+pub const PREFIX_LEN: &str = "SMOLVM_NETWORK_PREFIX_LEN";
+/// Guest MAC address in colon-separated string form.
+pub const GUEST_MAC: &str = "SMOLVM_NETWORK_GUEST_MAC";
+/// Guest-visible DNS server IPv4 address.
+pub const DNS: &str = "SMOLVM_NETWORK_DNS";
+/// Enables the guest-side DNS filtering proxy.
+pub const DNS_FILTER: &str = "SMOLVM_DNS_FILTER";

--- a/crates/smolvm-network/src/lib.rs
+++ b/crates/smolvm-network/src/lib.rs
@@ -53,6 +53,7 @@
 
 pub mod device;
 pub mod frame_stream;
+pub mod guest_env;
 pub mod queues;
 pub mod stack;
 pub mod tcp_relay;

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -10,6 +10,7 @@ use crate::error::{Error, Result};
 use crate::storage::{OverlayDisk, StorageDisk};
 use crate::util::libkrunfw_filename;
 
+use smolvm_network::guest_env;
 use smolvm_protocol::ports;
 use std::ffi::{CStr, CString};
 use std::path::{Path, PathBuf};
@@ -591,7 +592,7 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
 
         // Tell the agent to start DNS filtering proxy
         if dns_filter_socket.is_some() {
-            env_strings.push(cstr("SMOLVM_DNS_FILTER=1"));
+            env_strings.push(cstr(&format!("{}=1", guest_env::DNS_FILTER)));
         }
 
         // Tell the agent about pre-extracted packed layers

--- a/src/network/backend.rs
+++ b/src/network/backend.rs
@@ -1,24 +1,7 @@
 use clap::ValueEnum;
 
-/// virtio-net checksum offload feature bit.
-pub const NET_FEATURE_CSUM: u32 = 1 << 0;
-/// virtio-net guest checksum offload feature bit.
-pub const NET_FEATURE_GUEST_CSUM: u32 = 1 << 1;
-/// virtio-net guest TCP segmentation offload for IPv4.
-pub const NET_FEATURE_GUEST_TSO4: u32 = 1 << 7;
-/// virtio-net guest UDP fragmentation offload.
-pub const NET_FEATURE_GUEST_UFO: u32 = 1 << 10;
-/// virtio-net host TCP segmentation offload for IPv4.
-pub const NET_FEATURE_HOST_TSO4: u32 = 1 << 11;
-/// virtio-net host UDP fragmentation offload.
-pub const NET_FEATURE_HOST_UFO: u32 = 1 << 14;
 /// libkrun's compatibility feature set for unixstream-backed virtio-net.
-pub const COMPAT_NET_FEATURES: u32 = NET_FEATURE_CSUM
-    | NET_FEATURE_GUEST_CSUM
-    | NET_FEATURE_GUEST_TSO4
-    | NET_FEATURE_GUEST_UFO
-    | NET_FEATURE_HOST_TSO4
-    | NET_FEATURE_HOST_UFO;
+pub const COMPAT_NET_FEATURES: u32 = 0;
 
 /// Network backend override for machine launch.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, ValueEnum)]

--- a/src/network/backend.rs
+++ b/src/network/backend.rs
@@ -28,8 +28,8 @@ pub enum NetworkBackend {
     #[value(name = "tsi")]
     Tsi,
     /// Use virtio-net with the host-side smolvm network stack.
-    #[serde(rename = "virtio")]
-    #[value(name = "virtio")]
+    #[serde(alias = "virtio")]
+    #[value(name = "virtio-net", alias = "virtio")]
     VirtioNet,
 }
 
@@ -38,7 +38,7 @@ impl NetworkBackend {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Tsi => "tsi",
-            Self::VirtioNet => "virtio",
+            Self::VirtioNet => "virtio-net",
         }
     }
 
@@ -54,5 +54,22 @@ impl NetworkBackend {
 impl std::fmt::Display for NetworkBackend {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NetworkBackend;
+
+    #[test]
+    fn virtio_net_serializes_to_canonical_name() {
+        let value = serde_json::to_string(&NetworkBackend::VirtioNet).unwrap();
+        assert_eq!(value, "\"virtio-net\"");
+    }
+
+    #[test]
+    fn virtio_net_deserializes_legacy_alias() {
+        let value: NetworkBackend = serde_json::from_str("\"virtio\"").unwrap();
+        assert_eq!(value, NetworkBackend::VirtioNet);
     }
 }

--- a/src/network/launch.rs
+++ b/src/network/launch.rs
@@ -38,10 +38,10 @@ impl NetworkFallbackReason {
                 "virtio-net has not been implemented in this branch yet"
             }
             Self::PortsRequireTsi => {
-                "port publishing still uses the TSI backend; falling back from virtio"
+                "port publishing still uses the TSI backend; falling back from virtio-net"
             }
             Self::PolicyRequiresTsi => {
-                "allow-cidr/allow-host policies still use the TSI backend; falling back from virtio"
+                "allow-cidr/allow-host policies still use the TSI backend; falling back from virtio-net"
             }
         }
     }
@@ -148,7 +148,7 @@ pub fn validate_requested_network_backend(
     if !wants_network {
         return Err(crate::Error::config(
             "--net-backend",
-            "--net-backend virtio requires --net",
+            "--net-backend virtio-net requires --net",
         ));
     }
 

--- a/tests/test_virtio_net.sh
+++ b/tests/test_virtio_net.sh
@@ -19,13 +19,13 @@ echo "  smolvm Virtio-Net Tests"
 echo "=========================================="
 echo ""
 
-test_machine_create_virtio_works() {
+test_machine_create_virtio_net_works() {
     cleanup_machine
     local vm_name="virtio-create-test-$$"
     local output
 
-    output=$($SMOLVM machine create "$vm_name" --net --net-backend virtio 2>&1) || {
-        echo "expected virtio machine create to succeed"
+    output=$($SMOLVM machine create "$vm_name" --net --net-backend virtio-net 2>&1) || {
+        echo "expected virtio-net machine create to succeed"
         echo "$output"
         $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
         return 1
@@ -34,7 +34,7 @@ test_machine_create_virtio_works() {
     local list_output
     list_output=$($SMOLVM machine ls --json 2>&1)
     [[ "$list_output" == *"$vm_name"* ]] || {
-        echo "virtio create should persist machine state"
+        echo "virtio-net create should persist machine state"
         $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
         return 1
     }
@@ -42,14 +42,14 @@ test_machine_create_virtio_works() {
     $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
 }
 
-test_machine_run_virtio_rejected_until_implemented() {
+test_machine_run_virtio_net_rejected_until_implemented() {
     cleanup_machine
     local exit_code=0
     local output
 
-    output=$($SMOLVM machine run --net --net-backend virtio -- true 2>&1) || exit_code=$?
+    output=$($SMOLVM machine run --net --net-backend virtio-net -- true 2>&1) || exit_code=$?
     [[ $exit_code -ne 0 ]] || {
-        echo "expected run failure for unsupported virtio backend"
+        echo "expected run failure for unsupported virtio-net backend"
         return 1
     }
     [[ "$output" == *"not ready yet on this branch"* ]] || {
@@ -58,15 +58,15 @@ test_machine_run_virtio_rejected_until_implemented() {
     }
 }
 
-test_machine_create_virtio_ports_rejected() {
+test_machine_create_virtio_net_ports_rejected() {
     cleanup_machine
     local vm_name="virtio-ports-test-$$"
     local exit_code=0
     local output
 
-    output=$($SMOLVM machine create "$vm_name" --net --net-backend virtio -p 18080:80 2>&1) || exit_code=$?
+    output=$($SMOLVM machine create "$vm_name" --net --net-backend virtio-net -p 18080:80 2>&1) || exit_code=$?
     [[ $exit_code -ne 0 ]] || {
-        echo "expected create failure for virtio published port request"
+        echo "expected create failure for virtio-net published port request"
         $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
         return 1
     }
@@ -76,15 +76,15 @@ test_machine_create_virtio_ports_rejected() {
     }
 }
 
-test_machine_create_virtio_policy_rejected() {
+test_machine_create_virtio_net_policy_rejected() {
     cleanup_machine
     local vm_name="virtio-policy-test-$$"
     local exit_code=0
     local output
 
-    output=$($SMOLVM machine create "$vm_name" --net --net-backend virtio --allow-cidr 1.1.1.1/32 2>&1) || exit_code=$?
+    output=$($SMOLVM machine create "$vm_name" --net --net-backend virtio-net --allow-cidr 1.1.1.1/32 2>&1) || exit_code=$?
     [[ $exit_code -ne 0 ]] || {
-        echo "expected create failure for virtio policy request"
+        echo "expected create failure for virtio-net policy request"
         $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
         return 1
     }
@@ -94,7 +94,7 @@ test_machine_create_virtio_policy_rejected() {
     }
 }
 
-test_pack_run_virtio_rejected_until_implemented() {
+test_pack_run_virtio_net_rejected_until_implemented() {
     local output_path="$TEST_DIR/virtio-pack"
     local exit_code=0
     local output
@@ -103,9 +103,9 @@ test_pack_run_virtio_rejected_until_implemented() {
         $SMOLVM pack create --image alpine:latest -o "$output_path" >/dev/null 2>&1 || return 1
     fi
 
-    output=$($SMOLVM pack run --sidecar "$output_path.smolmachine" --net --net-backend virtio -- true 2>&1) || exit_code=$?
+    output=$($SMOLVM pack run --sidecar "$output_path.smolmachine" --net --net-backend virtio-net -- true 2>&1) || exit_code=$?
     [[ $exit_code -ne 0 ]] || {
-        echo "expected pack run failure for unsupported virtio backend"
+        echo "expected pack run failure for unsupported virtio-net backend"
         return 1
     }
     [[ "$output" == *"not ready yet on this branch"* ]] || {
@@ -114,10 +114,10 @@ test_pack_run_virtio_rejected_until_implemented() {
     }
 }
 
-run_test "Machine create: virtio works" test_machine_create_virtio_works || true
-run_test "Machine run: virtio rejected until implemented" test_machine_run_virtio_rejected_until_implemented || true
-run_test "Machine create: virtio + published ports rejected" test_machine_create_virtio_ports_rejected || true
-run_test "Machine create: virtio + policy rejected" test_machine_create_virtio_policy_rejected || true
-run_test "Pack run: virtio rejected until implemented" test_pack_run_virtio_rejected_until_implemented || true
+run_test "Machine create: virtio-net works" test_machine_create_virtio_net_works || true
+run_test "Machine run: virtio-net rejected until implemented" test_machine_run_virtio_net_rejected_until_implemented || true
+run_test "Machine create: virtio-net + published ports rejected" test_machine_create_virtio_net_ports_rejected || true
+run_test "Machine create: virtio-net + policy rejected" test_machine_create_virtio_net_policy_rejected || true
+run_test "Pack run: virtio-net rejected until implemented" test_pack_run_virtio_net_rejected_until_implemented || true
 
 print_summary "Virtio-Net Tests"


### PR DESCRIPTION
Chores:

1. Extract the `SMOLVM_NETWORK_XXX` env as consts
2. rename the name for virtio-net network-backend option from `virtio` to `virtio-net`, mainly b/c TSI is actually `virtio-vsock + tsi`
3. Removed several TCP network features that are not used at all


No actual logic change

### Testing

```

All tests passed!
Machine 'default' is not running (state: stopped)
Cleaning up data directory for vm: default
Deleted machine: default

==========================================
  Overall Summary
==========================================

Test suites run:    6
Test suites passed: 4
Test suites failed: 2
```

One failure is the virtio_net_test.sh, which is expected to fail until virtio-net is supported
Another is a smolmachine test failures, not related to this change, and I am fixing it in a separate PR