### PR TITLE
fix: issue-169 - resolve env and workdirs correctly

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -1477,6 +1477,7 @@ fn handle_request(
             command,
             env,
             workdir,
+            user,
             mounts,
             timeout_ms,
             interactive: false,
@@ -1487,6 +1488,7 @@ fn handle_request(
             &command,
             &env,
             workdir.as_deref(),
+            user.as_deref(),
             &mounts,
             timeout_ms,
             persistent_overlay_id.as_deref(),
@@ -2159,13 +2161,14 @@ fn handle_interactive_run(
     request: AgentRequest,
 ) -> Result<(), Box<dyn std::error::Error>> {
     ensure_storage_mounted();
-    let (image, command, env, workdir, mounts, timeout_ms, tty, persistent_overlay_id) =
+    let (image, command, env, workdir, user, mounts, timeout_ms, tty, persistent_overlay_id) =
         match request {
             AgentRequest::Run {
                 image,
                 command,
                 env,
                 workdir,
+                user,
                 mounts,
                 timeout_ms,
                 tty,
@@ -2176,6 +2179,7 @@ fn handle_interactive_run(
                 command,
                 env,
                 workdir,
+                user,
                 mounts,
                 timeout_ms,
                 tty,
@@ -2229,6 +2233,7 @@ fn handle_interactive_run(
         &command,
         &env,
         workdir.as_deref(),
+        user.as_deref(),
         &mounts,
         tty,
     ) {
@@ -2284,10 +2289,11 @@ fn spawn_interactive_command(
     command: &[String],
     env: &[(String, String)],
     workdir: Option<&str>,
+    user: Option<&str>,
     mounts: &[(String, String, bool)],
     tty: bool,
 ) -> Result<(Child, Option<pty::PtyMaster>), Box<dyn std::error::Error>> {
-    use std::os::unix::io::{AsRawFd as _, FromRawFd as _};
+    use std::os::unix::io::AsRawFd as _;
     use std::path::Path;
 
     if command.is_empty() {
@@ -2306,7 +2312,8 @@ fn spawn_interactive_command(
 
     let workdir_str = workdir.unwrap_or("/");
     // terminal: true tells crun to set up a controlling terminal (setsid + TIOCSCTTY)
-    let mut spec = oci::OciSpec::new(command, env, workdir_str, tty);
+    let identity = oci::resolve_process_identity(rootfs_path, user)?;
+    let mut spec = oci::OciSpec::new(command, env, workdir_str, tty, &identity);
 
     for (tag, container_path, read_only) in mounts {
         let virtiofs_mount = Path::new(paths::VIRTIOFS_MOUNT_ROOT).join(tag);
@@ -2376,6 +2383,7 @@ fn spawn_interactive_command(
     command: &[String],
     env: &[(String, String)],
     workdir: Option<&str>,
+    user: Option<&str>,
     mounts: &[(String, String, bool)],
     _tty: bool,
 ) -> Result<(Child, Option<()>), Box<dyn std::error::Error>> {
@@ -2396,7 +2404,8 @@ fn spawn_interactive_command(
     }
 
     let workdir_str = workdir.unwrap_or("/");
-    let mut spec = oci::OciSpec::new(command, env, workdir_str, false);
+    let identity = oci::resolve_process_identity(rootfs_path, user)?;
+    let mut spec = oci::OciSpec::new(command, env, workdir_str, false, &identity);
 
     for (tag, container_path, read_only) in mounts {
         let virtiofs_mount = Path::new(paths::VIRTIOFS_MOUNT_ROOT).join(tag);
@@ -3153,6 +3162,7 @@ fn handle_run(
     command: &[String],
     env: &[(String, String)],
     workdir: Option<&str>,
+    user: Option<&str>,
     mounts: &[(String, String, bool)],
     timeout_ms: Option<u64>,
     persistent_overlay_id: Option<&str>,
@@ -3165,6 +3175,7 @@ fn handle_run(
         command,
         env,
         workdir,
+        user,
         mounts,
         timeout_ms,
         persistent_overlay_id,

--- a/crates/smolvm-agent/src/oci.rs
+++ b/crates/smolvm-agent/src/oci.rs
@@ -126,18 +126,7 @@ pub fn resolve_process_identity(
     }
 
     let spec = normalized.expect("checked above");
-    let (user_token, group_token) = match spec.split_once(':') {
-        Some((user, group)) => {
-            if user.is_empty() {
-                return Err("invalid empty user in OCI image config".to_string());
-            }
-            if group.is_empty() {
-                return Err("invalid empty group in OCI image config".to_string());
-            }
-            (user, Some(group))
-        }
-        None => (spec, None),
-    };
+    let (user_token, group_token) = parse_user_spec(spec)?;
 
     let resolved_user = resolve_user_token(user_token, &passwd_entries)?;
     let primary_gid = match group_token {
@@ -166,6 +155,21 @@ pub fn resolve_process_identity(
         },
         home,
     })
+}
+
+fn parse_user_spec(spec: &str) -> Result<(&str, Option<&str>), String> {
+    match spec.split_once(':') {
+        Some((user, group)) => {
+            if user.is_empty() {
+                return Err("invalid empty user in OCI image config".to_string());
+            }
+            if group.is_empty() {
+                return Err("invalid empty group in OCI image config".to_string());
+            }
+            Ok((user, Some(group)))
+        }
+        None => Ok((spec, None)),
+    }
 }
 
 fn resolve_default_root_identity(
@@ -1091,6 +1095,20 @@ mod tests {
         assert_eq!(identity.user.gid, 2345);
         assert!(identity.user.additional_gids.is_empty());
         assert!(identity.home.is_none());
+    }
+
+    #[test]
+    fn test_parse_user_spec_rejects_empty_user_or_group() {
+        assert_eq!(
+            parse_user_spec(":1000"),
+            Err("invalid empty user in OCI image config".to_string())
+        );
+        assert_eq!(
+            parse_user_spec("steam:"),
+            Err("invalid empty group in OCI image config".to_string())
+        );
+        assert_eq!(parse_user_spec("steam"), Ok(("steam", None)));
+        assert_eq!(parse_user_spec("steam:audio"), Ok(("steam", Some("audio"))));
     }
 
     #[test]

--- a/crates/smolvm-agent/src/oci.rs
+++ b/crates/smolvm-agent/src/oci.rs
@@ -4,6 +4,8 @@
 //! config.json files used by crun to execute containers.
 
 use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::ErrorKind;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -57,12 +59,280 @@ pub struct OciProcess {
 }
 
 /// User configuration.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OciUser {
     pub uid: u32,
     pub gid: u32,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub additional_gids: Vec<u32>,
+}
+
+/// Resolved process identity for container execution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessIdentity {
+    pub user: OciUser,
+    pub home: Option<String>,
+}
+
+impl ProcessIdentity {
+    pub fn root() -> Self {
+        Self {
+            user: OciUser {
+                uid: 0,
+                gid: 0,
+                additional_gids: vec![],
+            },
+            home: Some("/root".to_string()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PasswdEntry {
+    username: String,
+    uid: u32,
+    gid: u32,
+    home: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GroupEntry {
+    name: String,
+    gid: u32,
+    members: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResolvedUser {
+    uid: u32,
+    username: Option<String>,
+    primary_gid: Option<u32>,
+    home: Option<String>,
+}
+
+pub fn resolve_process_identity(
+    rootfs: &Path,
+    user_spec: Option<&str>,
+) -> Result<ProcessIdentity, String> {
+    let normalized = user_spec.map(str::trim).filter(|s| !s.is_empty());
+    let passwd_entries = load_passwd_entries(rootfs)?;
+    let group_entries = load_group_entries(rootfs)?;
+
+    if normalized.is_none() {
+        return Ok(resolve_default_root_identity(
+            &passwd_entries,
+            &group_entries,
+        ));
+    }
+
+    let spec = normalized.expect("checked above");
+    let (user_token, group_token) = match spec.split_once(':') {
+        Some((user, group)) => {
+            if user.is_empty() {
+                return Err("invalid empty user in OCI image config".to_string());
+            }
+            if group.is_empty() {
+                return Err("invalid empty group in OCI image config".to_string());
+            }
+            (user, Some(group))
+        }
+        None => (spec, None),
+    };
+
+    let resolved_user = resolve_user_token(user_token, &passwd_entries)?;
+    let primary_gid = match group_token {
+        Some(group) => resolve_group_token(group, &group_entries)?,
+        None => resolved_user.primary_gid.unwrap_or(0),
+    };
+
+    let additional_gids = supplemental_group_ids(
+        &group_entries,
+        resolved_user.username.as_deref(),
+        primary_gid,
+    );
+    let home = resolved_user.home.or_else(|| {
+        if resolved_user.uid == 0 {
+            Some("/root".to_string())
+        } else {
+            None
+        }
+    });
+
+    Ok(ProcessIdentity {
+        user: OciUser {
+            uid: resolved_user.uid,
+            gid: primary_gid,
+            additional_gids,
+        },
+        home,
+    })
+}
+
+fn resolve_default_root_identity(
+    passwd_entries: &[PasswdEntry],
+    group_entries: &[GroupEntry],
+) -> ProcessIdentity {
+    if let Some(root) = passwd_entries.iter().find(|entry| entry.username == "root") {
+        return ProcessIdentity {
+            user: OciUser {
+                uid: root.uid,
+                gid: root.gid,
+                additional_gids: supplemental_group_ids(
+                    group_entries,
+                    Some(root.username.as_str()),
+                    root.gid,
+                ),
+            },
+            home: Some(root.home.clone()),
+        };
+    }
+
+    ProcessIdentity::root()
+}
+
+fn resolve_user_token(user: &str, passwd_entries: &[PasswdEntry]) -> Result<ResolvedUser, String> {
+    if let Ok(uid) = user.parse::<u32>() {
+        if let Some(entry) = passwd_entries.iter().find(|entry| entry.uid == uid) {
+            return Ok(ResolvedUser {
+                uid,
+                username: Some(entry.username.clone()),
+                primary_gid: Some(entry.gid),
+                home: Some(entry.home.clone()),
+            });
+        }
+
+        return Ok(ResolvedUser {
+            uid,
+            username: None,
+            primary_gid: None,
+            home: None,
+        });
+    }
+
+    let entry = passwd_entries
+        .iter()
+        .find(|entry| entry.username == user)
+        .ok_or_else(|| format!("user '{}' not found in container rootfs", user))?;
+
+    Ok(ResolvedUser {
+        uid: entry.uid,
+        username: Some(entry.username.clone()),
+        primary_gid: Some(entry.gid),
+        home: Some(entry.home.clone()),
+    })
+}
+
+fn resolve_group_token(group: &str, group_entries: &[GroupEntry]) -> Result<u32, String> {
+    if let Ok(gid) = group.parse::<u32>() {
+        return Ok(gid);
+    }
+
+    group_entries
+        .iter()
+        .find(|entry| entry.name == group)
+        .map(|entry| entry.gid)
+        .ok_or_else(|| format!("group '{}' not found in container rootfs", group))
+}
+
+fn supplemental_group_ids(
+    group_entries: &[GroupEntry],
+    username: Option<&str>,
+    primary_gid: u32,
+) -> Vec<u32> {
+    let Some(username) = username else {
+        return Vec::new();
+    };
+
+    let mut gids = Vec::new();
+    for entry in group_entries {
+        if entry.gid != primary_gid
+            && entry.members.iter().any(|member| member == username)
+            && !gids.contains(&entry.gid)
+        {
+            gids.push(entry.gid);
+        }
+    }
+    gids
+}
+
+fn load_passwd_entries(rootfs: &Path) -> Result<Vec<PasswdEntry>, String> {
+    load_entries(rootfs.join("etc/passwd"), parse_passwd_entries)
+}
+
+fn load_group_entries(rootfs: &Path) -> Result<Vec<GroupEntry>, String> {
+    load_entries(rootfs.join("etc/group"), parse_group_entries)
+}
+
+fn load_entries<T>(
+    path: std::path::PathBuf,
+    parse: impl FnOnce(&str) -> Vec<T>,
+) -> Result<Vec<T>, String> {
+    match fs::read_to_string(&path) {
+        Ok(contents) => Ok(parse(&contents)),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(Vec::new()),
+        Err(error) => Err(format!("failed to read {}: {}", path.display(), error)),
+    }
+}
+
+fn parse_passwd_entries(contents: &str) -> Vec<PasswdEntry> {
+    contents
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                return None;
+            }
+
+            let mut parts = line.splitn(7, ':');
+            let username = parts.next()?;
+            let _password = parts.next()?;
+            let uid = parts.next()?.parse().ok()?;
+            let gid = parts.next()?.parse().ok()?;
+            let _gecos = parts.next()?;
+            let home = parts.next()?;
+            let _shell = parts.next()?;
+
+            Some(PasswdEntry {
+                username: username.to_string(),
+                uid,
+                gid,
+                home: home.to_string(),
+            })
+        })
+        .collect()
+}
+
+fn parse_group_entries(contents: &str) -> Vec<GroupEntry> {
+    contents
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                return None;
+            }
+
+            let mut parts = line.splitn(4, ':');
+            let name = parts.next()?;
+            let _password = parts.next()?;
+            let gid = parts.next()?.parse().ok()?;
+            let members = parts
+                .next()
+                .map(|field| {
+                    field
+                        .split(',')
+                        .filter(|member| !member.is_empty())
+                        .map(str::to_string)
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            Some(GroupEntry {
+                name: name.to_string(),
+                gid,
+                members,
+            })
+        })
+        .collect()
 }
 
 /// Linux capabilities configuration.
@@ -166,16 +436,25 @@ impl OciSpec {
     /// * `env` - Environment variables as (key, value) pairs
     /// * `workdir` - Working directory inside the container
     /// * `tty` - Whether to allocate a pseudo-terminal
-    pub fn new(command: &[String], env: &[(String, String)], workdir: &str, tty: bool) -> Self {
+    /// * `identity` - Resolved process uid/gid/home for the container
+    pub fn new(
+        command: &[String],
+        env: &[(String, String)],
+        workdir: &str,
+        tty: bool,
+        identity: &ProcessIdentity,
+    ) -> Self {
         // Build environment variables
-        let env_strings: Vec<String> = [
+        let mut env_strings = vec![
             "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".to_string(),
-            "HOME=/root".to_string(),
             "TERM=xterm-256color".to_string(),
-        ]
-        .into_iter()
-        .chain(env.iter().map(|(k, v)| format!("{}={}", k, v)))
-        .collect();
+        ];
+        if !env.iter().any(|(key, _)| key == "HOME") {
+            if let Some(home) = &identity.home {
+                env_strings.push(format!("HOME={home}"));
+            }
+        }
+        env_strings.extend(env.iter().map(|(k, v)| format!("{}={}", k, v)));
 
         // Default capabilities for root containers
         let capabilities = OciCapabilities {
@@ -194,11 +473,7 @@ impl OciSpec {
             },
             process: OciProcess {
                 terminal: tty,
-                user: OciUser {
-                    uid: 0,
-                    gid: 0,
-                    additional_gids: vec![],
-                },
+                user: identity.user.clone(),
                 args: command.to_vec(),
                 env: env_strings,
                 cwd: workdir.to_string(),
@@ -656,6 +931,7 @@ fn default_mounts() -> Vec<OciMount> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
 
     #[test]
     fn test_validate_image_reference_valid() {
@@ -725,17 +1001,25 @@ mod tests {
             &[("FOO".to_string(), "bar".to_string())],
             "/",
             false,
+            &ProcessIdentity::root(),
         );
 
         assert_eq!(spec.oci_version, "1.0.2");
         assert_eq!(spec.process.args, vec!["echo", "hello"]);
         assert!(spec.process.env.contains(&"FOO=bar".to_string()));
+        assert!(spec.process.env.contains(&"HOME=/root".to_string()));
         assert!(!spec.process.terminal);
     }
 
     #[test]
     fn test_add_bind_mount() {
-        let mut spec = OciSpec::new(&["sh".to_string()], &[], "/", false);
+        let mut spec = OciSpec::new(
+            &["sh".to_string()],
+            &[],
+            "/",
+            false,
+            &ProcessIdentity::root(),
+        );
         spec.add_bind_mount("/host/path", "/container/path", true);
 
         let mount = spec.mounts.last().unwrap();
@@ -770,6 +1054,66 @@ mod tests {
         assert!(validate_env_vars(&[("FOO.BAR".to_string(), "value".to_string())]).is_err());
         assert!(validate_env_vars(&[("FOO BAR".to_string(), "value".to_string())]).is_err());
         assert!(validate_env_vars(&[("FOO=BAR".to_string(), "value".to_string())]).is_err());
+    }
+
+    #[test]
+    fn test_resolve_process_identity_named_user_uses_passwd_and_groups() {
+        let rootfs = tempdir().unwrap();
+        let etc = rootfs.path().join("etc");
+        std::fs::create_dir_all(&etc).unwrap();
+        std::fs::write(
+            etc.join("passwd"),
+            "root:x:0:0:root:/root:/bin/sh\nsteam:x:1000:1000::/home/steam:/bin/sh\n",
+        )
+        .unwrap();
+        std::fs::write(
+            etc.join("group"),
+            "root:x:0:\nsteam:x:1000:\naudio:x:29:steam\nvideo:x:44:steam\n",
+        )
+        .unwrap();
+
+        let identity = resolve_process_identity(rootfs.path(), Some("steam")).unwrap();
+
+        assert_eq!(identity.user.uid, 1000);
+        assert_eq!(identity.user.gid, 1000);
+        assert_eq!(identity.user.additional_gids, vec![29, 44]);
+        assert_eq!(identity.home.as_deref(), Some("/home/steam"));
+    }
+
+    #[test]
+    fn test_resolve_process_identity_numeric_uid_gid_without_passwd() {
+        let rootfs = tempdir().unwrap();
+        std::fs::create_dir_all(rootfs.path().join("etc")).unwrap();
+
+        let identity = resolve_process_identity(rootfs.path(), Some("1234:2345")).unwrap();
+
+        assert_eq!(identity.user.uid, 1234);
+        assert_eq!(identity.user.gid, 2345);
+        assert!(identity.user.additional_gids.is_empty());
+        assert!(identity.home.is_none());
+    }
+
+    #[test]
+    fn test_oci_spec_uses_identity_home_when_env_does_not_override_it() {
+        let spec = OciSpec::new(
+            &["id".to_string()],
+            &[("FOO".to_string(), "bar".to_string())],
+            "/home/steam",
+            false,
+            &ProcessIdentity {
+                user: OciUser {
+                    uid: 1000,
+                    gid: 1000,
+                    additional_gids: vec![29],
+                },
+                home: Some("/home/steam".to_string()),
+            },
+        );
+
+        assert!(spec.process.env.contains(&"HOME=/home/steam".to_string()));
+        assert_eq!(spec.process.user.uid, 1000);
+        assert_eq!(spec.process.user.gid, 1000);
+        assert_eq!(spec.process.user.additional_gids, vec![29]);
     }
 
     #[test]

--- a/crates/smolvm-agent/src/ssh_agent.rs
+++ b/crates/smolvm-agent/src/ssh_agent.rs
@@ -64,11 +64,17 @@ fn inject_into_container_if(spec: &mut crate::oci::OciSpec, enabled: bool) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::oci::OciSpec;
+    use crate::oci::{OciSpec, ProcessIdentity};
 
     #[test]
     fn inject_is_noop_when_disabled() {
-        let mut spec = OciSpec::new(&["true".to_string()], &[], "/", false);
+        let mut spec = OciSpec::new(
+            &["true".to_string()],
+            &[],
+            "/",
+            false,
+            &ProcessIdentity::root(),
+        );
         let mounts_before = spec.mounts.len();
         let envs_before = spec.process.env.len();
 
@@ -85,7 +91,13 @@ mod tests {
 
     #[test]
     fn inject_adds_env_and_mount_when_enabled() {
-        let mut spec = OciSpec::new(&["true".to_string()], &[], "/", false);
+        let mut spec = OciSpec::new(
+            &["true".to_string()],
+            &[],
+            "/",
+            false,
+            &ProcessIdentity::root(),
+        );
 
         inject_into_container_if(&mut spec, true);
 
@@ -114,7 +126,13 @@ mod tests {
         // Simulates an image whose config already exports a stale
         // SSH_AUTH_SOCK: we must replace it, not duplicate it — two entries
         // for the same key leaves the effective value shell-dependent.
-        let mut spec = OciSpec::new(&["true".to_string()], &[], "/", false);
+        let mut spec = OciSpec::new(
+            &["true".to_string()],
+            &[],
+            "/",
+            false,
+            &ProcessIdentity::root(),
+        );
         spec.process
             .env
             .push("SSH_AUTH_SOCK=/stale/path".to_string());
@@ -269,7 +287,6 @@ struct VsockStream {
 #[cfg(target_os = "linux")]
 impl std::os::unix::io::AsRawFd for VsockStream {
     fn as_raw_fd(&self) -> std::os::unix::io::RawFd {
-        use std::os::fd::AsRawFd;
         self.fd.as_raw_fd()
     }
 }

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -1100,7 +1100,7 @@ where
             .ok_or_else(|| StorageError::new("failed to capture crane stdout".to_string()))?;
 
         let mut tar_cmd = Command::new("tar");
-        tar_cmd.args(["--no-same-owner", "-xzf", "-", "-C"]);
+        tar_cmd.args(["-xzf", "-", "-C"]);
         tar_cmd.arg(&layer_dir);
         tar_cmd.stdin(crane_stdout);
         tar_cmd.stdout(Stdio::null());

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -404,6 +404,7 @@ fn create_packed_image_info(image: &str, packed_dir: &Path) -> Result<ImageInfo>
         cmd: Vec::new(),
         env: Vec::new(),
         workdir: None,
+        user: None,
     })
 }
 
@@ -1168,12 +1169,16 @@ where
     let os = config_json["os"].as_str().unwrap_or("linux").to_string();
     let created = config_json["created"].as_str().map(String::from);
 
-    // Extract OCI config fields (Entrypoint, Cmd, Env, WorkingDir)
+    // Extract OCI config fields (Entrypoint, Cmd, Env, WorkingDir, User)
     let oci_config = &config_json["config"];
     let entrypoint = json_string_array(oci_config, "Entrypoint");
     let cmd = json_string_array(oci_config, "Cmd");
     let env = json_string_array(oci_config, "Env");
     let workdir = oci_config["WorkingDir"]
+        .as_str()
+        .filter(|s| !s.is_empty())
+        .map(String::from);
+    let user = oci_config["User"]
         .as_str()
         .filter(|s| !s.is_empty())
         .map(String::from);
@@ -1191,6 +1196,7 @@ where
         cmd,
         env,
         workdir,
+        user,
     })
 }
 
@@ -1270,6 +1276,10 @@ pub fn query_image(image: &str) -> Result<Option<ImageInfo>> {
         .as_str()
         .filter(|s| !s.is_empty())
         .map(String::from);
+    let user = oci_config["User"]
+        .as_str()
+        .filter(|s| !s.is_empty())
+        .map(String::from);
 
     Ok(Some(ImageInfo {
         reference: image.to_string(),
@@ -1284,6 +1294,7 @@ pub fn query_image(image: &str) -> Result<Option<ImageInfo>> {
         cmd,
         env,
         workdir,
+        user,
     }))
 }
 
@@ -2009,6 +2020,7 @@ pub fn run_command(
     command: &[String],
     env: &[(String, String)],
     workdir: Option<&str>,
+    user: Option<&str>,
     mounts: &[(String, String, bool)],
     timeout_ms: Option<u64>,
     persistent_overlay_id: Option<&str>,
@@ -2037,7 +2049,9 @@ pub fn run_command(
 
         // Create OCI spec
         let workdir_str = workdir.unwrap_or("/");
-        let mut spec = OciSpec::new(command, env, workdir_str, false);
+        let identity = crate::oci::resolve_process_identity(Path::new(&prepared.rootfs_path), user)
+            .map_err(StorageError::new)?;
+        let mut spec = OciSpec::new(command, env, workdir_str, false, &identity);
 
         // Add virtiofs bind mounts to OCI spec
         for (tag, container_path, read_only) in mounts {

--- a/crates/smolvm-protocol/src/lib.rs
+++ b/crates/smolvm-protocol/src/lib.rs
@@ -234,6 +234,9 @@ pub enum AgentRequest {
         env: Vec<(String, String)>,
         /// Working directory inside the rootfs.
         workdir: Option<String>,
+        /// User inside the rootfs. If omitted, the OCI image default applies.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        user: Option<String>,
         /// Volume mounts to bind into the container.
         /// Each tuple is (virtiofs_tag, container_path, read_only).
         #[serde(default)]
@@ -599,6 +602,9 @@ pub struct ImageInfo {
     /// Image working directory (from OCI config).
     #[serde(default)]
     pub workdir: Option<String>,
+    /// Image default user (from OCI config).
+    #[serde(default)]
+    pub user: Option<String>,
 }
 
 /// Overlay preparation result.

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -113,6 +113,8 @@ pub struct RunConfig {
     pub env: Vec<(String, String)>,
     /// Working directory inside the container.
     pub workdir: Option<String>,
+    /// User to execute as inside the container.
+    pub user: Option<String>,
     /// Volume mounts as (tag, guest_path, read_only) tuples.
     pub mounts: Vec<(String, String, bool)>,
     /// Timeout for command execution.
@@ -132,6 +134,7 @@ impl RunConfig {
             command,
             env: Vec::new(),
             workdir: None,
+            user: None,
             mounts: Vec::new(),
             timeout: None,
             tty: false,
@@ -148,6 +151,12 @@ impl RunConfig {
     /// Set working directory.
     pub fn with_workdir(mut self, workdir: Option<String>) -> Self {
         self.workdir = workdir;
+        self
+    }
+
+    /// Set container user.
+    pub fn with_user(mut self, user: Option<String>) -> Self {
+        self.user = user;
         self
     }
 
@@ -1012,6 +1021,7 @@ impl AgentClient {
             command: config.command,
             env: config.env,
             workdir: config.workdir,
+            user: config.user,
             mounts: config.mounts,
             timeout_ms,
             interactive: false,
@@ -1043,6 +1053,7 @@ impl AgentClient {
                 command: config.command,
                 env: config.env,
                 workdir: config.workdir,
+                user: config.user,
                 mounts: config.mounts,
                 timeout_ms,
                 interactive: true,

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -526,14 +526,14 @@ impl RunCmd {
             vec![DEFAULT_SHELL_CMD.to_string()]
         };
 
-        let provided_env = parse_env_list(&params.env);
+        let env = parse_env_list(&params.env);
         let mount_bindings = mounts_to_virtiofs_bindings(&mounts);
 
         // Two modes: with image or bare VM (no image)
         if let Some(ref img) = image {
             let defaults = vm_common::resolve_image_runtime_defaults(
                 image_info.as_ref(),
-                &provided_env,
+                &env,
                 params.workdir.as_deref(),
             );
             if self.detach {
@@ -573,7 +573,7 @@ impl RunCmd {
                                 overlay_gb: params.overlay_gb,
                                 allowed_cidrs: params.allowed_cidrs.clone(),
                                 init: params.init.clone(),
-                                env: provided_env.clone(),
+                                env: env.clone(),
                                 workdir: params.workdir.clone(),
                                 image: Some(img.clone()),
                                 entrypoint: params.entrypoint.clone(),
@@ -649,8 +649,7 @@ impl RunCmd {
                             .map(|s| s.to_string())
                             .collect::<Vec<_>>();
                 if !is_idle {
-                    let pid =
-                        client.vm_exec_background(command, provided_env, params.workdir.clone())?;
+                    let pid = client.vm_exec_background(command, env, params.workdir.clone())?;
                     tracing::info!(pid = pid, "background workload started");
                 }
 
@@ -712,18 +711,14 @@ impl RunCmd {
                 let exit_code = if interactive || tty {
                     client.vm_exec_interactive(
                         command,
-                        provided_env,
+                        env,
                         params.workdir.clone(),
                         self.timeout,
                         tty,
                     )?
                 } else {
-                    let (exit_code, stdout, stderr) = client.vm_exec(
-                        command,
-                        provided_env,
-                        params.workdir.clone(),
-                        self.timeout,
-                    )?;
+                    let (exit_code, stdout, stderr) =
+                        client.vm_exec(command, env, params.workdir.clone(), self.timeout)?;
                     if !stdout.is_empty() {
                         let _ = std::io::stdout().write_all(&stdout);
                     }
@@ -799,7 +794,7 @@ impl ExecCmd {
         // AgentManager::Drop which calls stop() and kills the VM.
         manager.detach();
 
-        let provided_env = parse_env_list(&self.env);
+        let env = parse_env_list(&self.env);
 
         // Load machine record for workdir and image info
         let name = self.name.clone().unwrap_or_else(|| "default".to_string());
@@ -818,7 +813,7 @@ impl ExecCmd {
         if self.stream {
             let events = client.vm_exec_streaming(
                 self.command.clone(),
-                provided_env.clone(),
+                env.clone(),
                 workdir.clone(),
                 self.timeout,
             )?;
@@ -866,7 +861,7 @@ impl ExecCmd {
             };
             let configured_env = vm_common::merge_env_overrides(
                 record.as_ref().map(|r| r.env.as_slice()).unwrap_or(&[]),
-                &provided_env,
+                &env,
             );
             let defaults = vm_common::resolve_image_runtime_defaults(
                 image_info.as_ref(),
@@ -904,7 +899,7 @@ impl ExecCmd {
             if self.interactive || self.tty {
                 let exit_code = client.vm_exec_interactive(
                     self.command.clone(),
-                    provided_env.clone(),
+                    env.clone(),
                     workdir.clone(),
                     self.timeout,
                     self.tty,
@@ -912,12 +907,8 @@ impl ExecCmd {
                 std::process::exit(exit_code);
             }
 
-            let (exit_code, stdout, stderr) = client.vm_exec(
-                self.command.clone(),
-                provided_env,
-                workdir.clone(),
-                self.timeout,
-            )?;
+            let (exit_code, stdout, stderr) =
+                client.vm_exec(self.command.clone(), env, workdir.clone(), self.timeout)?;
             vm_common::print_output_and_exit(&manager, exit_code, &stdout, &stderr);
         }
     }

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -531,7 +531,7 @@ impl RunCmd {
 
         // Two modes: with image or bare VM (no image)
         if let Some(ref img) = image {
-            let (resolved_env, resolved_workdir) = vm_common::resolve_image_runtime_defaults(
+            let defaults = vm_common::resolve_image_runtime_defaults(
                 image_info.as_ref(),
                 &explicit_env,
                 params.workdir.as_deref(),
@@ -604,16 +604,18 @@ impl RunCmd {
 
                 let exit_code = if interactive || tty {
                     let config = RunConfig::new(img, command)
-                        .with_env(resolved_env.clone())
-                        .with_workdir(resolved_workdir.clone())
+                        .with_env(defaults.env.clone())
+                        .with_workdir(defaults.workdir.clone())
+                        .with_user(defaults.user.clone())
                         .with_mounts(mount_bindings)
                         .with_timeout(self.timeout)
                         .with_tty(tty);
                     client.run_interactive(config)?
                 } else {
                     let config = RunConfig::new(img, command)
-                        .with_env(resolved_env)
-                        .with_workdir(resolved_workdir)
+                        .with_env(defaults.env)
+                        .with_workdir(defaults.workdir)
+                        .with_user(defaults.user)
                         .with_mounts(mount_bindings)
                         .with_timeout(self.timeout);
                     let (exit_code, stdout, stderr) = client.run_non_interactive(config)?;
@@ -866,7 +868,7 @@ impl ExecCmd {
                 record.as_ref().map(|r| r.env.as_slice()).unwrap_or(&[]),
                 &explicit_env,
             );
-            let (resolved_env, resolved_workdir) = vm_common::resolve_image_runtime_defaults(
+            let defaults = vm_common::resolve_image_runtime_defaults(
                 image_info.as_ref(),
                 &configured_env,
                 workdir.as_deref(),
@@ -877,8 +879,9 @@ impl ExecCmd {
             let machine_name = name.clone();
             if self.interactive || self.tty {
                 let config = smolvm::agent::RunConfig::new(image, self.command.clone())
-                    .with_env(resolved_env.clone())
-                    .with_workdir(resolved_workdir.clone())
+                    .with_env(defaults.env.clone())
+                    .with_workdir(defaults.workdir.clone())
+                    .with_user(defaults.user.clone())
                     .with_mounts(mount_bindings)
                     .with_timeout(self.timeout)
                     .with_tty(self.tty)
@@ -888,8 +891,9 @@ impl ExecCmd {
             }
 
             let config = smolvm::agent::RunConfig::new(image, self.command.clone())
-                .with_env(resolved_env)
-                .with_workdir(resolved_workdir)
+                .with_env(defaults.env)
+                .with_workdir(defaults.workdir)
+                .with_user(defaults.user)
                 .with_mounts(mount_bindings)
                 .with_timeout(self.timeout)
                 .with_persistent_overlay(Some(machine_name));

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -645,11 +645,8 @@ impl RunCmd {
                             .map(|s| s.to_string())
                             .collect::<Vec<_>>();
                 if !is_idle {
-                    let pid = client.vm_exec_background(
-                        command,
-                        explicit_env,
-                        params.workdir.clone(),
-                    )?;
+                    let pid =
+                        client.vm_exec_background(command, explicit_env, params.workdir.clone())?;
                     tracing::info!(pid = pid, "background workload started");
                 }
 
@@ -717,8 +714,12 @@ impl RunCmd {
                         tty,
                     )?
                 } else {
-                    let (exit_code, stdout, stderr) =
-                        client.vm_exec(command, explicit_env, params.workdir.clone(), self.timeout)?;
+                    let (exit_code, stdout, stderr) = client.vm_exec(
+                        command,
+                        explicit_env,
+                        params.workdir.clone(),
+                        self.timeout,
+                    )?;
                     if !stdout.is_empty() {
                         let _ = std::io::stdout().write_all(&stdout);
                     }
@@ -860,10 +861,7 @@ impl ExecCmd {
                 }
             };
             let configured_env = vm_common::merge_env_overrides(
-                record
-                    .as_ref()
-                    .map(|r| r.env.as_slice())
-                    .unwrap_or(&[]),
+                record.as_ref().map(|r| r.env.as_slice()).unwrap_or(&[]),
                 &explicit_env,
             );
             let (resolved_env, resolved_workdir) = vm_common::resolve_image_runtime_defaults(
@@ -908,13 +906,12 @@ impl ExecCmd {
                 std::process::exit(exit_code);
             }
 
-            let (exit_code, stdout, stderr) =
-                client.vm_exec(
-                    self.command.clone(),
-                    explicit_env,
-                    workdir.clone(),
-                    self.timeout,
-                )?;
+            let (exit_code, stdout, stderr) = client.vm_exec(
+                self.command.clone(),
+                explicit_env,
+                workdir.clone(),
+                self.timeout,
+            )?;
             vm_common::print_output_and_exit(&manager, exit_code, &stdout, &stderr);
         }
     }

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -526,14 +526,14 @@ impl RunCmd {
             vec![DEFAULT_SHELL_CMD.to_string()]
         };
 
-        let explicit_env = parse_env_list(&params.env);
+        let provided_env = parse_env_list(&params.env);
         let mount_bindings = mounts_to_virtiofs_bindings(&mounts);
 
         // Two modes: with image or bare VM (no image)
         if let Some(ref img) = image {
             let defaults = vm_common::resolve_image_runtime_defaults(
                 image_info.as_ref(),
-                &explicit_env,
+                &provided_env,
                 params.workdir.as_deref(),
             );
             if self.detach {
@@ -573,7 +573,7 @@ impl RunCmd {
                                 overlay_gb: params.overlay_gb,
                                 allowed_cidrs: params.allowed_cidrs.clone(),
                                 init: params.init.clone(),
-                                env: explicit_env.clone(),
+                                env: provided_env.clone(),
                                 workdir: params.workdir.clone(),
                                 image: Some(img.clone()),
                                 entrypoint: params.entrypoint.clone(),
@@ -650,7 +650,7 @@ impl RunCmd {
                             .collect::<Vec<_>>();
                 if !is_idle {
                     let pid =
-                        client.vm_exec_background(command, explicit_env, params.workdir.clone())?;
+                        client.vm_exec_background(command, provided_env, params.workdir.clone())?;
                     tracing::info!(pid = pid, "background workload started");
                 }
 
@@ -712,7 +712,7 @@ impl RunCmd {
                 let exit_code = if interactive || tty {
                     client.vm_exec_interactive(
                         command,
-                        explicit_env,
+                        provided_env,
                         params.workdir.clone(),
                         self.timeout,
                         tty,
@@ -720,7 +720,7 @@ impl RunCmd {
                 } else {
                     let (exit_code, stdout, stderr) = client.vm_exec(
                         command,
-                        explicit_env,
+                        provided_env,
                         params.workdir.clone(),
                         self.timeout,
                     )?;
@@ -799,7 +799,7 @@ impl ExecCmd {
         // AgentManager::Drop which calls stop() and kills the VM.
         manager.detach();
 
-        let explicit_env = parse_env_list(&self.env);
+        let provided_env = parse_env_list(&self.env);
 
         // Load machine record for workdir and image info
         let name = self.name.clone().unwrap_or_else(|| "default".to_string());
@@ -818,7 +818,7 @@ impl ExecCmd {
         if self.stream {
             let events = client.vm_exec_streaming(
                 self.command.clone(),
-                explicit_env.clone(),
+                provided_env.clone(),
                 workdir.clone(),
                 self.timeout,
             )?;
@@ -866,7 +866,7 @@ impl ExecCmd {
             };
             let configured_env = vm_common::merge_env_overrides(
                 record.as_ref().map(|r| r.env.as_slice()).unwrap_or(&[]),
-                &explicit_env,
+                &provided_env,
             );
             let defaults = vm_common::resolve_image_runtime_defaults(
                 image_info.as_ref(),
@@ -904,7 +904,7 @@ impl ExecCmd {
             if self.interactive || self.tty {
                 let exit_code = client.vm_exec_interactive(
                     self.command.clone(),
-                    explicit_env.clone(),
+                    provided_env.clone(),
                     workdir.clone(),
                     self.timeout,
                     self.tty,
@@ -914,7 +914,7 @@ impl ExecCmd {
 
             let (exit_code, stdout, stderr) = client.vm_exec(
                 self.command.clone(),
-                explicit_env,
+                provided_env,
                 workdir.clone(),
                 self.timeout,
             )?;

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -482,6 +482,7 @@ impl RunCmd {
                 &mut client,
                 &params.init,
                 image.as_deref(),
+                image_info.as_ref(),
                 &init_env,
                 params.workdir.as_deref(),
                 &record_mounts,
@@ -523,11 +524,16 @@ impl RunCmd {
             vec![DEFAULT_SHELL_CMD.to_string()]
         };
 
-        let env = parse_env_list(&params.env);
+        let explicit_env = parse_env_list(&params.env);
         let mount_bindings = mounts_to_virtiofs_bindings(&mounts);
 
         // Two modes: with image or bare VM (no image)
         if let Some(ref img) = image {
+            let (resolved_env, resolved_workdir) = vm_common::resolve_image_runtime_defaults(
+                image_info.as_ref(),
+                &explicit_env,
+                params.workdir.as_deref(),
+            );
             if self.detach {
                 // Detach mode: persist the record with image info.
                 // The VM is already running. The image will be pulled and
@@ -565,7 +571,7 @@ impl RunCmd {
                                 overlay_gb: params.overlay_gb,
                                 allowed_cidrs: params.allowed_cidrs.clone(),
                                 init: params.init.clone(),
-                                env: parse_env_list(&params.env),
+                                env: explicit_env.clone(),
                                 workdir: params.workdir.clone(),
                                 image: Some(img.clone()),
                                 entrypoint: params.entrypoint.clone(),
@@ -596,16 +602,16 @@ impl RunCmd {
 
                 let exit_code = if interactive || tty {
                     let config = RunConfig::new(img, command)
-                        .with_env(env)
-                        .with_workdir(params.workdir.clone())
+                        .with_env(resolved_env.clone())
+                        .with_workdir(resolved_workdir.clone())
                         .with_mounts(mount_bindings)
                         .with_timeout(self.timeout)
                         .with_tty(tty);
                     client.run_interactive(config)?
                 } else {
                     let config = RunConfig::new(img, command)
-                        .with_env(env)
-                        .with_workdir(params.workdir.clone())
+                        .with_env(resolved_env)
+                        .with_workdir(resolved_workdir)
                         .with_mounts(mount_bindings)
                         .with_timeout(self.timeout);
                     let (exit_code, stdout, stderr) = client.run_non_interactive(config)?;
@@ -639,7 +645,11 @@ impl RunCmd {
                             .map(|s| s.to_string())
                             .collect::<Vec<_>>();
                 if !is_idle {
-                    let pid = client.vm_exec_background(command, env, params.workdir.clone())?;
+                    let pid = client.vm_exec_background(
+                        command,
+                        explicit_env,
+                        params.workdir.clone(),
+                    )?;
                     tracing::info!(pid = pid, "background workload started");
                 }
 
@@ -701,14 +711,14 @@ impl RunCmd {
                 let exit_code = if interactive || tty {
                     client.vm_exec_interactive(
                         command,
-                        env,
+                        explicit_env,
                         params.workdir.clone(),
                         self.timeout,
                         tty,
                     )?
                 } else {
                     let (exit_code, stdout, stderr) =
-                        client.vm_exec(command, env, params.workdir.clone(), self.timeout)?;
+                        client.vm_exec(command, explicit_env, params.workdir.clone(), self.timeout)?;
                     if !stdout.is_empty() {
                         let _ = std::io::stdout().write_all(&stdout);
                     }
@@ -784,7 +794,7 @@ impl ExecCmd {
         // AgentManager::Drop which calls stop() and kills the VM.
         manager.detach();
 
-        let env = parse_env_list(&self.env);
+        let explicit_env = parse_env_list(&self.env);
 
         // Load machine record for workdir and image info
         let name = self.name.clone().unwrap_or_else(|| "default".to_string());
@@ -803,7 +813,7 @@ impl ExecCmd {
         if self.stream {
             let events = client.vm_exec_streaming(
                 self.command.clone(),
-                env,
+                explicit_env.clone(),
                 workdir.clone(),
                 self.timeout,
             )?;
@@ -838,14 +848,37 @@ impl ExecCmd {
             .unwrap_or_default();
 
         if let Some(ref image) = record_image {
+            let image_info = match client.query(image) {
+                Ok(info) => info,
+                Err(e) => {
+                    tracing::debug!(
+                        error = %e,
+                        image = %image,
+                        "failed to query local image metadata"
+                    );
+                    None
+                }
+            };
+            let configured_env = vm_common::merge_env_overrides(
+                record
+                    .as_ref()
+                    .map(|r| r.env.as_slice())
+                    .unwrap_or(&[]),
+                &explicit_env,
+            );
+            let (resolved_env, resolved_workdir) = vm_common::resolve_image_runtime_defaults(
+                image_info.as_ref(),
+                &configured_env,
+                workdir.as_deref(),
+            );
             // Image-based machine: exec inside the image's rootfs via crun.
             // Use machine name as persistent overlay ID so filesystem changes
             // (e.g. package installs) survive across exec sessions.
             let machine_name = name.clone();
             if self.interactive || self.tty {
                 let config = smolvm::agent::RunConfig::new(image, self.command.clone())
-                    .with_env(env)
-                    .with_workdir(workdir.clone())
+                    .with_env(resolved_env.clone())
+                    .with_workdir(resolved_workdir.clone())
                     .with_mounts(mount_bindings)
                     .with_timeout(self.timeout)
                     .with_tty(self.tty)
@@ -855,8 +888,8 @@ impl ExecCmd {
             }
 
             let config = smolvm::agent::RunConfig::new(image, self.command.clone())
-                .with_env(env)
-                .with_workdir(workdir.clone())
+                .with_env(resolved_env)
+                .with_workdir(resolved_workdir)
                 .with_mounts(mount_bindings)
                 .with_timeout(self.timeout)
                 .with_persistent_overlay(Some(machine_name));
@@ -867,7 +900,7 @@ impl ExecCmd {
             if self.interactive || self.tty {
                 let exit_code = client.vm_exec_interactive(
                     self.command.clone(),
-                    env,
+                    explicit_env.clone(),
                     workdir.clone(),
                     self.timeout,
                     self.tty,
@@ -876,7 +909,12 @@ impl ExecCmd {
             }
 
             let (exit_code, stdout, stderr) =
-                client.vm_exec(self.command.clone(), env, workdir.clone(), self.timeout)?;
+                client.vm_exec(
+                    self.command.clone(),
+                    explicit_env,
+                    workdir.clone(),
+                    self.timeout,
+                )?;
             vm_common::print_output_and_exit(&manager, exit_code, &stdout, &stderr);
         }
     }

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -481,12 +481,14 @@ impl RunCmd {
             if let Err(e) = vm_common::run_init_commands(
                 &mut client,
                 &params.init,
-                image.as_deref(),
-                image_info.as_ref(),
-                &init_env,
-                params.workdir.as_deref(),
-                &record_mounts,
-                "default",
+                vm_common::InitRunContext {
+                    image: image.as_deref(),
+                    image_info: image_info.as_ref(),
+                    env: &init_env,
+                    workdir: params.workdir.as_deref(),
+                    record_mounts: &record_mounts,
+                    overlay_id: "default",
+                },
             ) {
                 // Ephemeral VMs have no state to preserve — `kill()`
                 // matches the success path's lifetime semantics

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -282,20 +282,20 @@ pub(crate) struct ImageRuntimeDefaults {
 
 pub(crate) fn resolve_image_runtime_defaults(
     image_info: Option<&ImageInfo>,
-    provided_env: &[(String, String)],
+    env: &[(String, String)],
     explicit_workdir: Option<&str>,
 ) -> ImageRuntimeDefaults {
-    let mut env = Vec::new();
+    let mut resolved_env = Vec::new();
 
     if let Some(image_info) = image_info {
         for spec in &image_info.env {
             if let Some((key, value)) = smolvm::util::parse_env_spec(spec) {
-                apply_env_override(&mut env, key, value);
+                apply_env_override(&mut resolved_env, key, value);
             }
         }
     }
 
-    env = merge_env_overrides(&env, provided_env);
+    resolved_env = merge_env_overrides(&resolved_env, env);
 
     let workdir = explicit_workdir
         .map(str::to_string)
@@ -303,7 +303,11 @@ pub(crate) fn resolve_image_runtime_defaults(
 
     let user = image_info.and_then(|info| info.user.clone());
 
-    ImageRuntimeDefaults { env, workdir, user }
+    ImageRuntimeDefaults {
+        env: resolved_env,
+        workdir,
+        user,
+    }
 }
 
 pub(crate) fn merge_env_overrides(
@@ -1631,16 +1635,13 @@ mod init_runner_tests {
             Some("/image-workdir"),
             Some("steam"),
         );
-        let provided_env = vec![
+        let env = vec![
             ("BAR".to_string(), "from-cli".to_string()),
             ("BAZ".to_string(), "from-cli".to_string()),
         ];
 
-        let defaults = resolve_image_runtime_defaults(
-            Some(&image_info),
-            &provided_env,
-            Some("/explicit-workdir"),
-        );
+        let defaults =
+            resolve_image_runtime_defaults(Some(&image_info), &env, Some("/explicit-workdir"));
 
         assert_eq!(
             defaults.env,
@@ -1661,12 +1662,12 @@ mod init_runner_tests {
             Some("/image-workdir"),
             Some("1000:1000"),
         );
-        let provided_env = vec![
+        let env = vec![
             ("BAR".to_string(), "from-cli".to_string()),
             ("BAR".to_string(), "last-cli".to_string()),
         ];
 
-        let defaults = resolve_image_runtime_defaults(Some(&image_info), &provided_env, None);
+        let defaults = resolve_image_runtime_defaults(Some(&image_info), &env, None);
 
         assert_eq!(
             defaults.env,
@@ -1681,12 +1682,11 @@ mod init_runner_tests {
 
     #[test]
     fn resolve_image_runtime_defaults_falls_back_to_explicit_values_without_image_info() {
-        let provided_env = vec![("FOO".to_string(), "from-explicit".to_string())];
+        let env = vec![("FOO".to_string(), "from-explicit".to_string())];
 
-        let defaults =
-            resolve_image_runtime_defaults(None, &provided_env, Some("/explicit-workdir"));
+        let defaults = resolve_image_runtime_defaults(None, &env, Some("/explicit-workdir"));
 
-        assert_eq!(defaults.env, provided_env);
+        assert_eq!(defaults.env, env);
         assert_eq!(defaults.workdir.as_deref(), Some("/explicit-workdir"));
         assert!(defaults.user.is_none());
     }

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -224,13 +224,12 @@ pub(crate) fn run_init_commands(
     println!("Running {} init command(s)...", init.len());
     for (i, cmd) in init.iter().enumerate() {
         let (exit_code, stdout, stderr) = if let Some(image) = context.image {
-            let (effective_env, effective_workdir) =
+            let defaults =
                 resolve_image_runtime_defaults(context.image_info, context.env, context.workdir);
             let config = build_init_run_config(
                 image,
                 cmd,
-                &effective_env,
-                effective_workdir.as_deref(),
+                &defaults,
                 context.record_mounts,
                 context.overlay_id,
             );
@@ -273,13 +272,19 @@ fn init_argv(cmd: &str) -> Vec<String> {
 /// Image metadata provides the baseline defaults. Explicit values from the
 /// CLI/Smolfile/persisted machine config override those defaults by key, while
 /// workdir uses the explicit value when present and otherwise falls back to the
-/// image's `WorkingDir`.
-/// TODO: need to ensure using the USER in image as well if image is provided.
+/// image's `WorkingDir`. Image `User` flows through unchanged because there is
+/// no CLI or persisted override for it today.
+pub(crate) struct ImageRuntimeDefaults {
+    pub(crate) env: Vec<(String, String)>,
+    pub(crate) workdir: Option<String>,
+    pub(crate) user: Option<String>,
+}
+
 pub(crate) fn resolve_image_runtime_defaults(
     image_info: Option<&ImageInfo>,
     explicit_env: &[(String, String)],
     explicit_workdir: Option<&str>,
-) -> (Vec<(String, String)>, Option<String>) {
+) -> ImageRuntimeDefaults {
     let mut env = Vec::new();
 
     if let Some(image_info) = image_info {
@@ -296,7 +301,9 @@ pub(crate) fn resolve_image_runtime_defaults(
         .map(str::to_string)
         .or_else(|| image_info.and_then(|info| info.workdir.clone()));
 
-    (env, workdir)
+    let user = image_info.and_then(|info| info.user.clone());
+
+    ImageRuntimeDefaults { env, workdir, user }
 }
 
 pub(crate) fn merge_env_overrides(
@@ -326,15 +333,15 @@ fn apply_env_override(env: &mut Vec<(String, String)>, key: String, value: Strin
 fn build_init_run_config(
     image: &str,
     cmd: &str,
-    env: &[(String, String)],
-    workdir: Option<&str>,
+    defaults: &ImageRuntimeDefaults,
     record_mounts: &[(String, String, bool)],
     overlay_id: &str,
 ) -> smolvm::agent::RunConfig {
     let mounts = crate::cli::parsers::record_mounts_to_runconfig_bindings(record_mounts);
     smolvm::agent::RunConfig::new(image, init_argv(cmd))
-        .with_env(env.to_vec())
-        .with_workdir(workdir.map(|s| s.to_string()))
+        .with_env(defaults.env.clone())
+        .with_workdir(defaults.workdir.clone())
+        .with_user(defaults.user.clone())
         .with_mounts(mounts)
         .with_persistent_overlay(Some(overlay_id.to_string()))
 }
@@ -1390,7 +1397,7 @@ pub fn cleanup_orphaned_ephemeral_vms() {
 mod init_runner_tests {
     use super::*;
 
-    fn sample_image_info(env: Vec<&str>, workdir: Option<&str>) -> ImageInfo {
+    fn sample_image_info(env: Vec<&str>, workdir: Option<&str>, user: Option<&str>) -> ImageInfo {
         ImageInfo {
             reference: "alpine:latest".to_string(),
             digest: "sha256:test".to_string(),
@@ -1404,6 +1411,7 @@ mod init_runner_tests {
             cmd: Vec::new(),
             env: env.into_iter().map(str::to_string).collect(),
             workdir: workdir.map(str::to_string),
+            user: user.map(str::to_string),
         }
     }
 
@@ -1480,7 +1488,17 @@ mod init_runner_tests {
         // succeed but `git --version` post-start would fail with "not
         // found" — exactly the user-confusing regression we're guarding
         // against.
-        let config = build_init_run_config("alpine", "true", &[], None, &[], "my-vm");
+        let config = build_init_run_config(
+            "alpine",
+            "true",
+            &ImageRuntimeDefaults {
+                env: vec![],
+                workdir: None,
+                user: None,
+            },
+            &[],
+            "my-vm",
+        );
         assert_eq!(config.persistent_overlay_id.as_deref(), Some("my-vm"));
     }
 
@@ -1491,11 +1509,21 @@ mod init_runner_tests {
         // refactor, the user's `[dev].env` or `[dev].workdir` would
         // silently stop applying to init.
         let env = vec![("HTTP_PROXY".to_string(), "http://proxy:3128".to_string())];
-        let config =
-            build_init_run_config("debian:slim", "apt update", &env, Some("/work"), &[], "vm");
+        let config = build_init_run_config(
+            "debian:slim",
+            "apt update",
+            &ImageRuntimeDefaults {
+                env: env.clone(),
+                workdir: Some("/work".to_string()),
+                user: Some("steam".to_string()),
+            },
+            &[],
+            "vm",
+        );
         assert_eq!(config.image, "debian:slim");
         assert_eq!(config.env, env);
         assert_eq!(config.workdir.as_deref(), Some("/work"));
+        assert_eq!(config.user.as_deref(), Some("steam"));
         // Command is sh-wrapped; assert the wrapped form arrives.
         assert_eq!(
             config.command,
@@ -1513,7 +1541,17 @@ mod init_runner_tests {
             ("/host/src".to_string(), "/app".to_string(), false),
             ("/host/data".to_string(), "/data".to_string(), true),
         ];
-        let config = build_init_run_config("alpine", "true", &[], None, &mounts, "vm");
+        let config = build_init_run_config(
+            "alpine",
+            "true",
+            &ImageRuntimeDefaults {
+                env: vec![],
+                workdir: None,
+                user: None,
+            },
+            &mounts,
+            "vm",
+        );
         assert_eq!(
             config.mounts,
             vec![
@@ -1529,40 +1567,57 @@ mod init_runner_tests {
         // a valid init invocation. No mounts, no workdir, no env — must
         // still produce a usable RunConfig (vs. e.g. panicking on
         // `unwrap` somewhere in the builder).
-        let config = build_init_run_config("alpine", "echo hi", &[], None, &[], "vm");
+        let config = build_init_run_config(
+            "alpine",
+            "echo hi",
+            &ImageRuntimeDefaults {
+                env: vec![],
+                workdir: None,
+                user: None,
+            },
+            &[],
+            "vm",
+        );
         assert!(config.mounts.is_empty());
         assert!(config.workdir.is_none());
         assert!(config.env.is_empty());
+        assert!(config.user.is_none());
         assert_eq!(config.persistent_overlay_id.as_deref(), Some("vm"));
     }
 
     #[test]
-    fn resolve_image_runtime_defaults_uses_image_env_and_workdir() {
+    fn resolve_image_runtime_defaults_uses_image_env_workdir_and_user() {
         let image_info = sample_image_info(
             vec!["FOO=from-image", "BAR=from-image"],
             Some("/image-workdir"),
+            Some("steam"),
         );
 
-        let (env, workdir) = resolve_image_runtime_defaults(Some(&image_info), &[], None);
+        let defaults = resolve_image_runtime_defaults(Some(&image_info), &[], None);
 
         assert_eq!(
-            env,
+            defaults.env,
             vec![
                 ("FOO".to_string(), "from-image".to_string()),
                 ("BAR".to_string(), "from-image".to_string()),
             ]
         );
-        assert_eq!(workdir.as_deref(), Some("/image-workdir"));
+        assert_eq!(defaults.workdir.as_deref(), Some("/image-workdir"));
+        assert_eq!(defaults.user.as_deref(), Some("steam"));
     }
 
     #[test]
     fn image_workdir_flows_into_init_run_config_when_no_explicit_workdir_is_set() {
-        let image_info = sample_image_info(vec!["FOO=from-image"], Some("/image-workdir"));
-        let (env, workdir) = resolve_image_runtime_defaults(Some(&image_info), &[], None);
-        let config =
-            build_init_run_config("alpine:latest", "pwd", &env, workdir.as_deref(), &[], "vm");
+        let image_info = sample_image_info(
+            vec!["FOO=from-image"],
+            Some("/image-workdir"),
+            Some("steam"),
+        );
+        let defaults = resolve_image_runtime_defaults(Some(&image_info), &[], None);
+        let config = build_init_run_config("alpine:latest", "pwd", &defaults, &[], "vm");
 
         assert_eq!(config.workdir.as_deref(), Some("/image-workdir"));
+        assert_eq!(config.user.as_deref(), Some("steam"));
         assert_eq!(
             config.env,
             vec![("FOO".to_string(), "from-image".to_string())]
@@ -1574,27 +1629,29 @@ mod init_runner_tests {
         let image_info = sample_image_info(
             vec!["FOO=from-image", "BAR=from-image"],
             Some("/image-workdir"),
+            Some("steam"),
         );
         let explicit_env = vec![
             ("BAR".to_string(), "from-cli".to_string()),
             ("BAZ".to_string(), "from-cli".to_string()),
         ];
 
-        let (env, workdir) = resolve_image_runtime_defaults(
+        let defaults = resolve_image_runtime_defaults(
             Some(&image_info),
             &explicit_env,
             Some("/explicit-workdir"),
         );
 
         assert_eq!(
-            env,
+            defaults.env,
             vec![
                 ("FOO".to_string(), "from-image".to_string()),
                 ("BAR".to_string(), "from-cli".to_string()),
                 ("BAZ".to_string(), "from-cli".to_string()),
             ]
         );
-        assert_eq!(workdir.as_deref(), Some("/explicit-workdir"));
+        assert_eq!(defaults.workdir.as_deref(), Some("/explicit-workdir"));
+        assert_eq!(defaults.user.as_deref(), Some("steam"));
     }
 
     #[test]
@@ -1602,33 +1659,36 @@ mod init_runner_tests {
         let image_info = sample_image_info(
             vec!["BROKEN", "=empty-key", "FOO=from-image", "FOO=last-image"],
             Some("/image-workdir"),
+            Some("1000:1000"),
         );
         let explicit_env = vec![
             ("BAR".to_string(), "from-cli".to_string()),
             ("BAR".to_string(), "last-cli".to_string()),
         ];
 
-        let (env, workdir) = resolve_image_runtime_defaults(Some(&image_info), &explicit_env, None);
+        let defaults = resolve_image_runtime_defaults(Some(&image_info), &explicit_env, None);
 
         assert_eq!(
-            env,
+            defaults.env,
             vec![
                 ("FOO".to_string(), "last-image".to_string()),
                 ("BAR".to_string(), "last-cli".to_string()),
             ]
         );
-        assert_eq!(workdir.as_deref(), Some("/image-workdir"));
+        assert_eq!(defaults.workdir.as_deref(), Some("/image-workdir"));
+        assert_eq!(defaults.user.as_deref(), Some("1000:1000"));
     }
 
     #[test]
     fn resolve_image_runtime_defaults_falls_back_to_explicit_values_without_image_info() {
         let explicit_env = vec![("FOO".to_string(), "from-explicit".to_string())];
 
-        let (env, workdir) =
+        let defaults =
             resolve_image_runtime_defaults(None, &explicit_env, Some("/explicit-workdir"));
 
-        assert_eq!(env, explicit_env);
-        assert_eq!(workdir.as_deref(), Some("/explicit-workdir"));
+        assert_eq!(defaults.env, explicit_env);
+        assert_eq!(defaults.workdir.as_deref(), Some("/explicit-workdir"));
+        assert!(defaults.user.is_none());
     }
 
     #[test]

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -14,6 +14,7 @@ use smolvm::data::validate_vm_name;
 use smolvm::db::SmolvmDb;
 use smolvm::network::NetworkBackend;
 use smolvm::storage::{DEFAULT_OVERLAY_SIZE_GIB, DEFAULT_STORAGE_SIZE_GIB};
+use smolvm_protocol::ImageInfo;
 use std::io::Write;
 
 // ============================================================================
@@ -207,6 +208,7 @@ pub(crate) fn run_init_commands(
     client: &mut smolvm::agent::AgentClient,
     init: &[String],
     image: Option<&str>,
+    image_info: Option<&ImageInfo>,
     env: &[(String, String)],
     workdir: Option<&str>,
     record_mounts: &[(String, String, bool)],
@@ -218,7 +220,16 @@ pub(crate) fn run_init_commands(
     println!("Running {} init command(s)...", init.len());
     for (i, cmd) in init.iter().enumerate() {
         let (exit_code, stdout, stderr) = if let Some(image) = image {
-            let config = build_init_run_config(image, cmd, env, workdir, record_mounts, overlay_id);
+            let (effective_env, effective_workdir) =
+                resolve_image_runtime_defaults(image_info, env, workdir);
+            let config = build_init_run_config(
+                image,
+                cmd,
+                &effective_env,
+                effective_workdir.as_deref(),
+                record_mounts,
+                overlay_id,
+            );
             client.run_non_interactive(config)?
         } else {
             client.vm_exec(
@@ -251,6 +262,52 @@ pub(crate) fn run_init_commands(
 /// features (`&&`, `|`, env expansion) without quoting gymnastics.
 fn init_argv(cmd: &str) -> Vec<String> {
     vec!["sh".into(), "-c".into(), cmd.to_string()]
+}
+
+/// Resolve effective env/workdir for image-backed execution.
+///
+/// Image metadata provides the baseline defaults. Explicit values from the
+/// CLI/Smolfile/persisted machine config override those defaults by key, while
+/// workdir uses the explicit value when present and otherwise falls back to the
+/// image's `WorkingDir`.
+pub(crate) fn resolve_image_runtime_defaults(
+    image_info: Option<&ImageInfo>,
+    explicit_env: &[(String, String)],
+    explicit_workdir: Option<&str>,
+) -> (Vec<(String, String)>, Option<String>) {
+    let mut env = Vec::new();
+
+    if let Some(image_info) = image_info {
+        for spec in &image_info.env {
+            if let Some((key, value)) = smolvm::util::parse_env_spec(spec) {
+                apply_env_override(&mut env, key, value);
+            }
+        }
+    }
+
+    env = merge_env_overrides(&env, explicit_env);
+
+    let workdir = explicit_workdir
+        .map(str::to_string)
+        .or_else(|| image_info.and_then(|info| info.workdir.clone()));
+
+    (env, workdir)
+}
+
+pub(crate) fn merge_env_overrides(
+    base_env: &[(String, String)],
+    overrides: &[(String, String)],
+) -> Vec<(String, String)> {
+    let mut env = base_env.to_vec();
+    for (key, value) in overrides {
+        apply_env_override(&mut env, key.clone(), value.clone());
+    }
+    env
+}
+
+fn apply_env_override(env: &mut Vec<(String, String)>, key: String, value: String) {
+    env.retain(|(existing, _)| existing != &key);
+    env.push((key, value));
 }
 
 /// Build the `RunConfig` an image-based init command runs under.
@@ -558,12 +615,15 @@ pub fn start_vm_named(name: &str) -> smolvm::Result<()> {
     // would hit the bare Alpine agent and fail with "not found".
     let mut client = smolvm::agent::AgentClient::connect_with_retry(manager.vsock_socket())?;
 
-    if record.source_smolmachine.is_some() {
+    let image_info = if record.source_smolmachine.is_some() {
         // Layers already mounted via virtiofs — no pull needed.
+        None
     } else if let Some(ref image) = record.image {
         println!("Pulling {}...", image);
-        let _image_info = crate::cli::pull_with_progress(&mut client, image, None)?;
-    }
+        Some(crate::cli::pull_with_progress(&mut client, image, None)?)
+    } else {
+        None
+    };
 
     // Run init commands if configured (before reporting success).
     // `run_init_commands` branches on image: container path for
@@ -572,6 +632,7 @@ pub fn start_vm_named(name: &str) -> smolvm::Result<()> {
         &mut client,
         &record.init,
         record.image.as_deref(),
+        image_info.as_ref(),
         &record.env,
         record.workdir.as_deref(),
         &record.mounts,
@@ -774,15 +835,18 @@ pub fn start_vm_default() -> smolvm::Result<()> {
             let mut client =
                 smolvm::agent::AgentClient::connect_with_retry(manager.vsock_socket())?;
 
-            if let Some(ref image) = record.image {
+            let image_info = if let Some(ref image) = record.image {
                 println!("Pulling {}...", image);
-                let _ = crate::cli::pull_with_progress(&mut client, image, None)?;
-            }
+                Some(crate::cli::pull_with_progress(&mut client, image, None)?)
+            } else {
+                None
+            };
 
             if let Err(e) = run_init_commands(
                 &mut client,
                 &record.init,
                 record.image.as_deref(),
+                image_info.as_ref(),
                 &record.env,
                 record.workdir.as_deref(),
                 &record.mounts,
@@ -1317,6 +1381,23 @@ pub fn cleanup_orphaned_ephemeral_vms() {
 mod init_runner_tests {
     use super::*;
 
+    fn sample_image_info(env: Vec<&str>, workdir: Option<&str>) -> ImageInfo {
+        ImageInfo {
+            reference: "alpine:latest".to_string(),
+            digest: "sha256:test".to_string(),
+            size: 0,
+            created: None,
+            architecture: "x86_64".to_string(),
+            os: "linux".to_string(),
+            layer_count: 0,
+            layers: Vec::new(),
+            entrypoint: Vec::new(),
+            cmd: Vec::new(),
+            env: env.into_iter().map(str::to_string).collect(),
+            workdir: workdir.map(str::to_string),
+        }
+    }
+
     #[test]
     fn format_init_failure_includes_stderr_only() {
         // Single stream → no "stdout:" / "stderr:" labels needed; the
@@ -1444,5 +1525,109 @@ mod init_runner_tests {
         assert!(config.workdir.is_none());
         assert!(config.env.is_empty());
         assert_eq!(config.persistent_overlay_id.as_deref(), Some("vm"));
+    }
+
+    #[test]
+    fn resolve_image_runtime_defaults_uses_image_env_and_workdir() {
+        let image_info = sample_image_info(
+            vec!["FOO=from-image", "BAR=from-image"],
+            Some("/image-workdir"),
+        );
+
+        let (env, workdir) = resolve_image_runtime_defaults(Some(&image_info), &[], None);
+
+        assert_eq!(
+            env,
+            vec![
+                ("FOO".to_string(), "from-image".to_string()),
+                ("BAR".to_string(), "from-image".to_string()),
+            ]
+        );
+        assert_eq!(workdir.as_deref(), Some("/image-workdir"));
+    }
+
+    #[test]
+    fn resolve_image_runtime_defaults_explicit_values_override_image_defaults() {
+        let image_info = sample_image_info(
+            vec!["FOO=from-image", "BAR=from-image"],
+            Some("/image-workdir"),
+        );
+        let explicit_env = vec![
+            ("BAR".to_string(), "from-cli".to_string()),
+            ("BAZ".to_string(), "from-cli".to_string()),
+        ];
+
+        let (env, workdir) = resolve_image_runtime_defaults(
+            Some(&image_info),
+            &explicit_env,
+            Some("/explicit-workdir"),
+        );
+
+        assert_eq!(
+            env,
+            vec![
+                ("FOO".to_string(), "from-image".to_string()),
+                ("BAR".to_string(), "from-cli".to_string()),
+                ("BAZ".to_string(), "from-cli".to_string()),
+            ]
+        );
+        assert_eq!(workdir.as_deref(), Some("/explicit-workdir"));
+    }
+
+    #[test]
+    fn resolve_image_runtime_defaults_ignores_invalid_image_env_and_last_value_wins() {
+        let image_info = sample_image_info(
+            vec!["BROKEN", "=empty-key", "FOO=from-image", "FOO=last-image"],
+            Some("/image-workdir"),
+        );
+        let explicit_env = vec![
+            ("BAR".to_string(), "from-cli".to_string()),
+            ("BAR".to_string(), "last-cli".to_string()),
+        ];
+
+        let (env, workdir) = resolve_image_runtime_defaults(Some(&image_info), &explicit_env, None);
+
+        assert_eq!(
+            env,
+            vec![
+                ("FOO".to_string(), "last-image".to_string()),
+                ("BAR".to_string(), "last-cli".to_string()),
+            ]
+        );
+        assert_eq!(workdir.as_deref(), Some("/image-workdir"));
+    }
+
+    #[test]
+    fn resolve_image_runtime_defaults_falls_back_to_explicit_values_without_image_info() {
+        let explicit_env = vec![("FOO".to_string(), "from-explicit".to_string())];
+
+        let (env, workdir) =
+            resolve_image_runtime_defaults(None, &explicit_env, Some("/explicit-workdir"));
+
+        assert_eq!(env, explicit_env);
+        assert_eq!(workdir.as_deref(), Some("/explicit-workdir"));
+    }
+
+    #[test]
+    fn merge_env_overrides_last_value_wins_by_key() {
+        let base_env = vec![
+            ("FOO".to_string(), "from-record".to_string()),
+            ("BAR".to_string(), "from-record".to_string()),
+        ];
+        let overrides = vec![
+            ("BAR".to_string(), "from-cli".to_string()),
+            ("BAZ".to_string(), "from-cli".to_string()),
+        ];
+
+        let merged = merge_env_overrides(&base_env, &overrides);
+
+        assert_eq!(
+            merged,
+            vec![
+                ("FOO".to_string(), "from-record".to_string()),
+                ("BAR".to_string(), "from-cli".to_string()),
+                ("BAZ".to_string(), "from-cli".to_string()),
+            ]
+        );
     }
 }

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -270,6 +270,7 @@ fn init_argv(cmd: &str) -> Vec<String> {
 /// CLI/Smolfile/persisted machine config override those defaults by key, while
 /// workdir uses the explicit value when present and otherwise falls back to the
 /// image's `WorkingDir`.
+/// TODO: need to ensure using the USER in image as well if image is provided.
 pub(crate) fn resolve_image_runtime_defaults(
     image_info: Option<&ImageInfo>,
     explicit_env: &[(String, String)],
@@ -1544,6 +1545,20 @@ mod init_runner_tests {
             ]
         );
         assert_eq!(workdir.as_deref(), Some("/image-workdir"));
+    }
+
+    #[test]
+    fn image_workdir_flows_into_init_run_config_when_no_explicit_workdir_is_set() {
+        let image_info = sample_image_info(vec!["FOO=from-image"], Some("/image-workdir"));
+        let (env, workdir) = resolve_image_runtime_defaults(Some(&image_info), &[], None);
+        let config =
+            build_init_run_config("alpine:latest", "pwd", &env, workdir.as_deref(), &[], "vm");
+
+        assert_eq!(config.workdir.as_deref(), Some("/image-workdir"));
+        assert_eq!(
+            config.env,
+            vec![("FOO".to_string(), "from-image".to_string())]
+        );
     }
 
     #[test]

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -197,6 +197,15 @@ pub fn print_output_and_exit(
 ///   `client.vm_exec`. There's no container, so `record_mounts` and
 ///   `overlay_id` are unused on this branch.
 ///
+pub(crate) struct InitRunContext<'a> {
+    pub(crate) image: Option<&'a str>,
+    pub(crate) image_info: Option<&'a ImageInfo>,
+    pub(crate) env: &'a [(String, String)],
+    pub(crate) workdir: Option<&'a str>,
+    pub(crate) record_mounts: &'a [(String, String, bool)],
+    pub(crate) overlay_id: &'a str,
+}
+
 /// On the first non-zero exit, returns an error containing the command
 /// index, exit code, and any stdout/stderr the command produced.
 /// **Both** streams are surfaced because package managers often write
@@ -207,35 +216,30 @@ pub fn print_output_and_exit(
 pub(crate) fn run_init_commands(
     client: &mut smolvm::agent::AgentClient,
     init: &[String],
-    image: Option<&str>,
-    image_info: Option<&ImageInfo>,
-    env: &[(String, String)],
-    workdir: Option<&str>,
-    record_mounts: &[(String, String, bool)],
-    overlay_id: &str,
+    context: InitRunContext<'_>,
 ) -> smolvm::Result<()> {
     if init.is_empty() {
         return Ok(());
     }
     println!("Running {} init command(s)...", init.len());
     for (i, cmd) in init.iter().enumerate() {
-        let (exit_code, stdout, stderr) = if let Some(image) = image {
+        let (exit_code, stdout, stderr) = if let Some(image) = context.image {
             let (effective_env, effective_workdir) =
-                resolve_image_runtime_defaults(image_info, env, workdir);
+                resolve_image_runtime_defaults(context.image_info, context.env, context.workdir);
             let config = build_init_run_config(
                 image,
                 cmd,
                 &effective_env,
                 effective_workdir.as_deref(),
-                record_mounts,
-                overlay_id,
+                context.record_mounts,
+                context.overlay_id,
             );
             client.run_non_interactive(config)?
         } else {
             client.vm_exec(
                 init_argv(cmd),
-                env.to_vec(),
-                workdir.map(|s| s.to_string()),
+                context.env.to_vec(),
+                context.workdir.map(|s| s.to_string()),
                 None,
             )?
         };
@@ -632,12 +636,14 @@ pub fn start_vm_named(name: &str) -> smolvm::Result<()> {
     if let Err(e) = run_init_commands(
         &mut client,
         &record.init,
-        record.image.as_deref(),
-        image_info.as_ref(),
-        &record.env,
-        record.workdir.as_deref(),
-        &record.mounts,
-        name,
+        InitRunContext {
+            image: record.image.as_deref(),
+            image_info: image_info.as_ref(),
+            env: &record.env,
+            workdir: record.workdir.as_deref(),
+            record_mounts: &record.mounts,
+            overlay_id: name,
+        },
     ) {
         if let Err(stop_err) = manager.stop() {
             tracing::warn!(error = %stop_err, "failed to stop machine after init failure");
@@ -846,12 +852,14 @@ pub fn start_vm_default() -> smolvm::Result<()> {
             if let Err(e) = run_init_commands(
                 &mut client,
                 &record.init,
-                record.image.as_deref(),
-                image_info.as_ref(),
-                &record.env,
-                record.workdir.as_deref(),
-                &record.mounts,
-                "default",
+                InitRunContext {
+                    image: record.image.as_deref(),
+                    image_info: image_info.as_ref(),
+                    env: &record.env,
+                    workdir: record.workdir.as_deref(),
+                    record_mounts: &record.mounts,
+                    overlay_id: "default",
+                },
             ) {
                 if let Err(stop_err) = manager.stop() {
                     tracing::warn!(error = %stop_err, "failed to stop machine after init failure");

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -282,7 +282,7 @@ pub(crate) struct ImageRuntimeDefaults {
 
 pub(crate) fn resolve_image_runtime_defaults(
     image_info: Option<&ImageInfo>,
-    explicit_env: &[(String, String)],
+    provided_env: &[(String, String)],
     explicit_workdir: Option<&str>,
 ) -> ImageRuntimeDefaults {
     let mut env = Vec::new();
@@ -295,7 +295,7 @@ pub(crate) fn resolve_image_runtime_defaults(
         }
     }
 
-    env = merge_env_overrides(&env, explicit_env);
+    env = merge_env_overrides(&env, provided_env);
 
     let workdir = explicit_workdir
         .map(str::to_string)
@@ -1631,14 +1631,14 @@ mod init_runner_tests {
             Some("/image-workdir"),
             Some("steam"),
         );
-        let explicit_env = vec![
+        let provided_env = vec![
             ("BAR".to_string(), "from-cli".to_string()),
             ("BAZ".to_string(), "from-cli".to_string()),
         ];
 
         let defaults = resolve_image_runtime_defaults(
             Some(&image_info),
-            &explicit_env,
+            &provided_env,
             Some("/explicit-workdir"),
         );
 
@@ -1661,12 +1661,12 @@ mod init_runner_tests {
             Some("/image-workdir"),
             Some("1000:1000"),
         );
-        let explicit_env = vec![
+        let provided_env = vec![
             ("BAR".to_string(), "from-cli".to_string()),
             ("BAR".to_string(), "last-cli".to_string()),
         ];
 
-        let defaults = resolve_image_runtime_defaults(Some(&image_info), &explicit_env, None);
+        let defaults = resolve_image_runtime_defaults(Some(&image_info), &provided_env, None);
 
         assert_eq!(
             defaults.env,
@@ -1681,12 +1681,12 @@ mod init_runner_tests {
 
     #[test]
     fn resolve_image_runtime_defaults_falls_back_to_explicit_values_without_image_info() {
-        let explicit_env = vec![("FOO".to_string(), "from-explicit".to_string())];
+        let provided_env = vec![("FOO".to_string(), "from-explicit".to_string())];
 
         let defaults =
-            resolve_image_runtime_defaults(None, &explicit_env, Some("/explicit-workdir"));
+            resolve_image_runtime_defaults(None, &provided_env, Some("/explicit-workdir"));
 
-        assert_eq!(defaults.env, explicit_env);
+        assert_eq!(defaults.env, provided_env);
         assert_eq!(defaults.workdir.as_deref(), Some("/explicit-workdir"));
         assert!(defaults.user.is_none());
     }

--- a/tests/test_machine.sh
+++ b/tests/test_machine.sh
@@ -1172,6 +1172,38 @@ test_machine_run_workdir() {
     [[ "$output" == *"/tmp"* ]]
 }
 
+# Regression for issue #169: image WorkingDir should flow into the actual
+# image-backed runtime when no explicit -w/--workdir is provided. The original
+# issue used an x86-only image, so this uses the multi-arch Redis image, which
+# sets WORKDIR /data.
+test_machine_run_image_default_workdir_issue_169() {
+    local output exit_code=0
+    output=$(run_with_timeout 180 \
+        "$SMOLVM" machine run -I docker.io/library/redis:7.4 --net -- \
+        sh -lc "pwd") || exit_code=$?
+
+    if [[ $exit_code -ne 0 ]]; then
+        case "$output" in
+            *"no matching manifest"*|*"exec format error"*|*"platform"* )
+                log_skip "Skipping issue #169 workdir regression: image unsupported on this host"
+                return 0
+                ;;
+        esac
+
+        echo "machine run failed:"
+        echo "$output"
+        return 1
+    fi
+
+    local pwd_result
+    pwd_result=$(printf '%s\n' "$output" | tail -n 1 | tr -d '\r')
+    [[ "$pwd_result" == "/data" ]] || {
+        echo "expected image workdir /data, got: $pwd_result"
+        echo "$output"
+        return 1
+    }
+}
+
 test_machine_run_detached() {
     $SMOLVM machine stop 2>/dev/null || true
     $SMOLVM machine delete default -f 2>/dev/null || true
@@ -1379,6 +1411,7 @@ run_test "Machine run: env variable" test_machine_run_env || true
 run_test "Machine run: volume mount" test_machine_run_volume || true
 run_test "Machine run: volume readonly" test_machine_run_volume_readonly || true
 run_test "Machine run: workdir" test_machine_run_workdir || true
+run_test "Machine run: image default workdir issue #169" test_machine_run_image_default_workdir_issue_169 || true
 run_test "Machine run: detached" test_machine_run_detached || true
 run_test "Machine run: timeout" test_machine_run_timeout || true
 run_test "Bare VM: /workspace exists" test_bare_vm_workspace || true

--- a/tests/test_machine.sh
+++ b/tests/test_machine.sh
@@ -1172,11 +1172,10 @@ test_machine_run_workdir() {
     [[ "$output" == *"/tmp"* ]]
 }
 
-# Regression for issue #169: image WorkingDir should flow into the actual
-# image-backed runtime when no explicit -w/--workdir is provided. The original
-# issue used an x86-only image, so this uses the multi-arch Redis image, which
-# sets WORKDIR /data.
-test_machine_run_image_default_workdir_issue_169() {
+# Regression: image WorkingDir should flow into the actual image-backed
+# runtime when no explicit -w/--workdir is provided. Use the multi-arch Redis
+# image because it sets WORKDIR /data.
+test_machine_run_image_default_workdir() {
     local output exit_code=0
     output=$(run_with_timeout 180 \
         "$SMOLVM" machine run -I docker.io/library/redis:7.4 --net -- \
@@ -1185,7 +1184,7 @@ test_machine_run_image_default_workdir_issue_169() {
     if [[ $exit_code -ne 0 ]]; then
         case "$output" in
             *"no matching manifest"*|*"exec format error"*|*"platform"* )
-                log_skip "Skipping issue #169 workdir regression: image unsupported on this host"
+                log_skip "Skipping image default workdir regression: image unsupported on this host"
                 return 0
                 ;;
         esac
@@ -1199,6 +1198,37 @@ test_machine_run_image_default_workdir_issue_169() {
     pwd_result=$(printf '%s\n' "$output" | tail -n 1 | tr -d '\r')
     [[ "$pwd_result" == "/data" ]] || {
         echo "expected image workdir /data, got: $pwd_result"
+        echo "$output"
+        return 1
+    }
+}
+
+# Regression: image User should flow into the actual image-backed runtime
+# when no explicit override is provided. Use a multi-arch unprivileged NGINX
+# image because it sets USER 101.
+test_machine_run_image_default_user() {
+    local output exit_code=0
+    output=$(run_with_timeout 180 \
+        "$SMOLVM" machine run -I docker.io/nginxinc/nginx-unprivileged:stable-alpine --net -- \
+        sh -lc "id -u") || exit_code=$?
+
+    if [[ $exit_code -ne 0 ]]; then
+        case "$output" in
+            *"no matching manifest"*|*"exec format error"*|*"platform"*|*"not found"* )
+                log_skip "Skipping image default user regression: image unsupported on this host"
+                return 0
+                ;;
+        esac
+
+        echo "machine run failed:"
+        echo "$output"
+        return 1
+    fi
+
+    local user_result
+    user_result=$(printf '%s\n' "$output" | tail -n 1 | tr -d '\r')
+    [[ "$user_result" == "101" ]] || {
+        echo "expected image user id 101, got: $user_result"
         echo "$output"
         return 1
     }
@@ -1411,7 +1441,8 @@ run_test "Machine run: env variable" test_machine_run_env || true
 run_test "Machine run: volume mount" test_machine_run_volume || true
 run_test "Machine run: volume readonly" test_machine_run_volume_readonly || true
 run_test "Machine run: workdir" test_machine_run_workdir || true
-run_test "Machine run: image default workdir issue #169" test_machine_run_image_default_workdir_issue_169 || true
+run_test "Machine run: image default workdir" test_machine_run_image_default_workdir || true
+run_test "Machine run: image default user" test_machine_run_image_default_user || true
 run_test "Machine run: detached" test_machine_run_detached || true
 run_test "Machine run: timeout" test_machine_run_timeout || true
 run_test "Bare VM: /workspace exists" test_bare_vm_workspace || true

--- a/tests/test_pack.sh
+++ b/tests/test_pack.sh
@@ -262,6 +262,12 @@ test_pack_bundled_libkrun_has_required_symbols() {
     # Verify all required symbols exist in the bundled library.
     # This catches the bug where an older system libkrun gets bundled
     # instead of the one smolvm was built against.
+    #
+    # Symbol inspection is platform-specific here:
+    # - macOS uses Mach-O, where `nm -gU` lists external symbols and C exports
+    #   appear with a leading underscore (for example `_krun_create_ctx`)
+    # - Linux uses ELF, where `nm -D --defined-only` lists dynamic exports and
+    #   the same symbol appears without the underscore (`krun_create_ctx`)
     local symbols nm_prefix
     if [[ "$(uname)" == "Darwin" ]]; then
         symbols=$(nm -gU "$libkrun" 2>/dev/null) || {

--- a/tests/test_pack.sh
+++ b/tests/test_pack.sh
@@ -262,12 +262,24 @@ test_pack_bundled_libkrun_has_required_symbols() {
     # Verify all required symbols exist in the bundled library.
     # This catches the bug where an older system libkrun gets bundled
     # instead of the one smolvm was built against.
-    local symbols
-    symbols=$(nm -gU "$libkrun" 2>/dev/null) || { echo "FAIL: nm failed on $libkrun"; return 1; }
+    local symbols nm_prefix
+    if [[ "$(uname)" == "Darwin" ]]; then
+        symbols=$(nm -gU "$libkrun" 2>/dev/null) || {
+            echo "FAIL: nm failed on $libkrun"
+            return 1
+        }
+        nm_prefix="_"
+    else
+        symbols=$(nm -D --defined-only "$libkrun" 2>/dev/null) || {
+            echo "FAIL: nm failed on $libkrun"
+            return 1
+        }
+        nm_prefix=""
+    fi
 
     local missing=0
     for sym in krun_create_ctx krun_add_disk2 krun_add_vsock_port2 krun_start_enter; do
-        if ! echo "$symbols" | grep -q "_${sym}$"; then
+        if ! echo "$symbols" | grep -q "${nm_prefix}${sym}$"; then
             echo "FAIL: bundled libkrun missing required symbol: $sym"
             missing=1
         fi


### PR DESCRIPTION
Original issue:

https://github.com/smol-machines/smolvm/issues/169

This PR only fixs the resolving of env and workdir, and takes into consideration of the env and workdir that comes with the image.

### Manual Tests

```
qiaofu@ubuntu-node:~/repos/smolvm$ smolvm machine run -I docker.io/warbll/steamcmd-proton -it --net -- bash
Starting ephemeral machine...
Pulling image docker.io/warbll/steamcmd-proton... done.                              ng...
root@container:/home/steam# pwd
/home/steam
```

Will fix the `USER` resolution in the next PR


### Other Tests


```
Machine 'default' is not running (state: stopped)
Cleaning up data directory for vm: default
Deleted machine: default

==========================================
  Overall Summary
==========================================

Test suites run:    6
Test suites passed: 4
Test suites failed: 2

```

1 failure was the virtio-net testing failure, whcih is expected
another failure was the smolmachine file test failure, not related to this fix