### PR TITLE
fix: libkrun has a bug for TSI silent dropping with idle guest

### DIFF
--- a/lib/libkrun.dylib
+++ b/lib/libkrun.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8c090eadda42cf671dcad62aaa997036bf207c276e7d67189440794118111ce3
-size 4327408
+oid sha256:9bead1218cabb58600c7fb9efceb7805e96e85b11a518ddd10f4a694044fdcf5
+size 4966480


### PR DESCRIPTION
libkrun update to fix this issue: https://github.com/smol-machines/smolvm/issues/177