### PR TITLE
fix(agent): forward terminal resize into container exec PTY

### DIFF
--- a/crates/smolvm-agent/src/console_socket.rs
+++ b/crates/smolvm-agent/src/console_socket.rs
@@ -9,7 +9,7 @@
 //! See the OCI runtime spec and crun(1) for protocol details.
 
 use std::io;
-use std::os::unix::io::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::os::unix::io::{AsRawFd, FromRawFd, OwnedFd};
 use std::os::unix::net::UnixListener;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -138,6 +138,7 @@ impl Drop for ConsoleSocket {
 mod tests {
     use super::*;
     use crate::pty::open_pty;
+    use std::os::unix::io::RawFd;
     use std::os::unix::net::UnixStream;
 
     /// Send `fd` to `stream` via SCM_RIGHTS. Mirrors what crun does with

--- a/crates/smolvm-agent/src/console_socket.rs
+++ b/crates/smolvm-agent/src/console_socket.rs
@@ -1,0 +1,218 @@
+//! AF_UNIX listener for crun's `--console-socket` handshake.
+//!
+//! When the agent spawns `crun run --console-socket <path>` for a
+//! container with `process.terminal = true`, crun allocates the
+//! container's PTY inside the container's user namespace and sends the
+//! master fd back to the caller over `path` using `SCM_RIGHTS`. This
+//! module implements the caller side of that handshake.
+//!
+//! See the OCI runtime spec and crun(1) for protocol details.
+
+use std::io;
+use std::os::unix::io::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::os::unix::net::UnixListener;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use crate::pty::PtyMaster;
+
+/// AF_UNIX listener used with `crun run --console-socket <path>`.
+///
+/// Binds a unix socket at the given path, accepts a single connection
+/// from crun, and receives the container's PTY master fd via
+/// `SCM_RIGHTS`. The socket file is removed on drop.
+pub struct ConsoleSocket {
+    listener: UnixListener,
+    path: PathBuf,
+}
+
+impl ConsoleSocket {
+    /// Bind and listen on `path`. Any stale file at the path is removed first.
+    pub fn new(path: &Path) -> io::Result<Self> {
+        let _ = std::fs::remove_file(path);
+        let listener = UnixListener::bind(path)?;
+        Ok(Self {
+            listener,
+            path: path.to_path_buf(),
+        })
+    }
+
+    /// Accept a connection and receive a PTY master fd via `SCM_RIGHTS`.
+    ///
+    /// Blocks up to `timeout` waiting for crun to connect. Returns the
+    /// received fd wrapped as a [`PtyMaster`]. Subsequent reads, writes
+    /// and `set_window_size` on that master control the container's PTY.
+    pub fn recv_pty_master(&self, timeout: Duration) -> io::Result<PtyMaster> {
+        // Wait for a connection with a bounded timeout so a misbehaving crun
+        // does not hang the agent indefinitely.
+        let lfd = self.listener.as_raw_fd();
+        let mut pfd = libc::pollfd {
+            fd: lfd,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let ms = timeout.as_millis().min(i32::MAX as u128) as i32;
+        let rc = unsafe { libc::poll(&mut pfd, 1, ms) };
+        if rc < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        if rc == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "console socket: timed out waiting for crun to connect",
+            ));
+        }
+
+        let (stream, _addr) = self.listener.accept()?;
+
+        // Receive one byte of payload plus a single SCM_RIGHTS control
+        // message containing the PTY master fd. crun (and runc) always send
+        // exactly one fd.
+        let mut byte = [0u8; 1];
+        let mut iov = libc::iovec {
+            iov_base: byte.as_mut_ptr() as *mut _,
+            iov_len: byte.len(),
+        };
+        let cmsg_space = unsafe { libc::CMSG_SPACE(std::mem::size_of::<libc::c_int>() as u32) };
+        let mut cmsg_buf = vec![0u8; cmsg_space as usize];
+        let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+        msg.msg_iov = &mut iov;
+        msg.msg_iovlen = 1;
+        msg.msg_control = cmsg_buf.as_mut_ptr() as *mut _;
+        msg.msg_controllen = cmsg_buf.len() as _;
+
+        // SAFETY: msg is fully initialized; iov and cmsg_buf outlive the call.
+        let n = unsafe { libc::recvmsg(stream.as_raw_fd(), &mut msg, 0) };
+        if n < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        if msg.msg_flags & libc::MSG_CTRUNC != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "console socket: control message truncated",
+            ));
+        }
+
+        // Walk cmsgs looking for SCM_RIGHTS. Close any stray fds we do not expect.
+        let mut pty_fd: libc::c_int = -1;
+        let mut cmsg_ptr = unsafe { libc::CMSG_FIRSTHDR(&msg) };
+        while !cmsg_ptr.is_null() {
+            // SAFETY: cmsg_ptr is a valid pointer returned by CMSG_FIRSTHDR/NXTHDR.
+            let level = unsafe { (*cmsg_ptr).cmsg_level };
+            let ty = unsafe { (*cmsg_ptr).cmsg_type };
+            if level == libc::SOL_SOCKET && ty == libc::SCM_RIGHTS {
+                let data_ptr = unsafe { libc::CMSG_DATA(cmsg_ptr) } as *const libc::c_int;
+                let fd = unsafe { std::ptr::read_unaligned(data_ptr) };
+                if pty_fd < 0 {
+                    pty_fd = fd;
+                } else {
+                    // Already have a master; close any extras defensively.
+                    // SAFETY: fd was just handed to us by the kernel via SCM_RIGHTS.
+                    unsafe { libc::close(fd) };
+                }
+            }
+            cmsg_ptr = unsafe { libc::CMSG_NXTHDR(&msg, cmsg_ptr) };
+        }
+
+        if pty_fd < 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "console socket: no SCM_RIGHTS fd received from crun",
+            ));
+        }
+
+        // SAFETY: pty_fd was just handed to us by the kernel via SCM_RIGHTS.
+        let owned = unsafe { OwnedFd::from_raw_fd(pty_fd) };
+        Ok(PtyMaster::from_fd(owned))
+    }
+}
+
+impl Drop for ConsoleSocket {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pty::open_pty;
+    use std::os::unix::net::UnixStream;
+
+    /// Send `fd` to `stream` via SCM_RIGHTS. Mirrors what crun does with
+    /// its console socket.
+    fn send_fd(stream: &UnixStream, fd: RawFd) -> io::Result<()> {
+        let payload = [0u8; 1];
+        let mut iov = libc::iovec {
+            iov_base: payload.as_ptr() as *mut _,
+            iov_len: payload.len(),
+        };
+        let cmsg_space = unsafe { libc::CMSG_SPACE(std::mem::size_of::<libc::c_int>() as u32) };
+        let mut cmsg_buf = vec![0u8; cmsg_space as usize];
+        let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+        msg.msg_iov = &mut iov;
+        msg.msg_iovlen = 1;
+        msg.msg_control = cmsg_buf.as_mut_ptr() as *mut _;
+        msg.msg_controllen = cmsg_buf.len() as _;
+        unsafe {
+            let cmsg = libc::CMSG_FIRSTHDR(&msg);
+            assert!(!cmsg.is_null());
+            (*cmsg).cmsg_level = libc::SOL_SOCKET;
+            (*cmsg).cmsg_type = libc::SCM_RIGHTS;
+            (*cmsg).cmsg_len = libc::CMSG_LEN(std::mem::size_of::<libc::c_int>() as u32) as _;
+            let data = libc::CMSG_DATA(cmsg) as *mut libc::c_int;
+            std::ptr::write_unaligned(data, fd);
+        }
+        let n = unsafe { libc::sendmsg(stream.as_raw_fd(), &msg, 0) };
+        if n < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn console_socket_recv_round_trips_pty_master() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("console.sock");
+
+        let server = ConsoleSocket::new(&sock_path).expect("bind console socket");
+
+        // Client thread: connect, send a real PTY master fd, drop the local copy.
+        let sock_path_cloned = sock_path.clone();
+        let client_thread = std::thread::spawn(move || {
+            let stream = UnixStream::connect(&sock_path_cloned).expect("connect");
+            let (master, _slave) = open_pty(40, 10).expect("open_pty");
+            send_fd(&stream, master.as_raw_fd()).expect("send_fd");
+            // Keep `master` alive until after sendmsg completes so the kernel
+            // does not close the fd before the receiver gets its own reference.
+            drop(master);
+        });
+
+        let received = server
+            .recv_pty_master(Duration::from_secs(5))
+            .expect("recv_pty_master");
+        client_thread.join().unwrap();
+
+        // The received fd should be a usable PTY master: we can resize it and
+        // read the new size back via TIOCGWINSZ.
+        received.set_window_size(100, 50).expect("set_window_size");
+        let mut ws: libc::winsize = unsafe { std::mem::zeroed() };
+        let rc = unsafe { libc::ioctl(received.as_raw_fd(), libc::TIOCGWINSZ, &mut ws) };
+        assert_eq!(rc, 0, "TIOCGWINSZ must succeed on received master");
+        assert_eq!(ws.ws_col, 100);
+        assert_eq!(ws.ws_row, 50);
+    }
+
+    #[test]
+    fn console_socket_recv_times_out_when_no_client_connects() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("console.sock");
+        let server = ConsoleSocket::new(&sock_path).expect("bind");
+        match server.recv_pty_master(Duration::from_millis(50)) {
+            Err(e) => assert_eq!(e.kind(), io::ErrorKind::TimedOut),
+            Ok(_) => panic!("recv_pty_master must time out when no client connects"),
+        }
+    }
+}

--- a/crates/smolvm-agent/src/crun.rs
+++ b/crates/smolvm-agent/src/crun.rs
@@ -84,7 +84,8 @@ impl CrunCommand {
     /// `console_socket`) can still insert options before the positional.
     pub fn run(bundle_dir: &Path, container_id: &str) -> Self {
         let mut c = Self::new();
-        c.cmd.args(["run", "--bundle", &bundle_dir.to_string_lossy()]);
+        c.cmd
+            .args(["run", "--bundle", &bundle_dir.to_string_lossy()]);
         c.pending_run_id = Some(container_id.to_string());
         c
     }

--- a/crates/smolvm-agent/src/crun.rs
+++ b/crates/smolvm-agent/src/crun.rs
@@ -36,6 +36,10 @@ fn ensure_path_in_env(env: &[(String, String)]) -> Vec<(String, String)> {
 /// and other common options.
 pub struct CrunCommand {
     cmd: Command,
+    /// Positional container id for `crun run`. Appended at the very end in
+    /// `spawn`/`output`/`status` so options added later (e.g. `--console-socket`
+    /// via `console_socket()`) still land before the positional.
+    pending_run_id: Option<String>,
 }
 
 impl CrunCommand {
@@ -48,7 +52,10 @@ impl CrunCommand {
         let mut cmd = Command::new(paths::CRUN_PATH);
         cmd.args(["--root", paths::CRUN_ROOT_DIR]);
         cmd.args(["--cgroup-manager", paths::CRUN_CGROUP_MANAGER]);
-        Self { cmd }
+        Self {
+            cmd,
+            pending_run_id: None,
+        }
     }
 
     /// Create a container: `crun create --bundle <path> <id>`
@@ -70,17 +77,15 @@ impl CrunCommand {
         c
     }
 
-    /// Run a container: `crun run --bundle <path> <id>`
+    /// Run a container: `crun run [options] --bundle <path> <id>`
     ///
-    /// This creates, starts, waits, and deletes the container in one operation.
+    /// Creates, starts, waits, and deletes the container in one operation.
+    /// The container id is deferred so later builder calls (e.g.
+    /// `console_socket`) can still insert options before the positional.
     pub fn run(bundle_dir: &Path, container_id: &str) -> Self {
         let mut c = Self::new();
-        c.cmd.args([
-            "run",
-            "--bundle",
-            &bundle_dir.to_string_lossy(),
-            container_id,
-        ]);
+        c.cmd.args(["run", "--bundle", &bundle_dir.to_string_lossy()]);
+        c.pending_run_id = Some(container_id.to_string());
         c
     }
 
@@ -155,6 +160,17 @@ impl CrunCommand {
         c
     }
 
+    /// Pass `--console-socket <path>` to the crun subcommand.
+    ///
+    /// With `process.terminal = true` in the OCI spec, crun will connect to
+    /// this AF_UNIX socket and send the container's PTY master fd via
+    /// `SCM_RIGHTS`. The caller must be listening on `path` before the crun
+    /// process starts.
+    pub fn console_socket(mut self, path: &Path) -> Self {
+        self.cmd.args(["--console-socket", &path.to_string_lossy()]);
+        self
+    }
+
     /// Set stdin to null.
     pub fn stdin_null(mut self) -> Self {
         self.cmd.stdin(Stdio::null());
@@ -224,18 +240,30 @@ impl CrunCommand {
         self
     }
 
+    /// Append the deferred `crun run` container id (if any) right before the
+    /// command is launched, so any options added by the caller land before
+    /// the positional argument.
+    fn apply_pending(&mut self) {
+        if let Some(id) = self.pending_run_id.take() {
+            self.cmd.arg(id);
+        }
+    }
+
     /// Spawn the command.
     pub fn spawn(mut self) -> std::io::Result<std::process::Child> {
+        self.apply_pending();
         self.cmd.spawn()
     }
 
     /// Run and wait for output.
     pub fn output(mut self) -> std::io::Result<std::process::Output> {
+        self.apply_pending();
         self.cmd.output()
     }
 
     /// Run and wait for status.
     pub fn status(mut self) -> std::io::Result<std::process::ExitStatus> {
+        self.apply_pending();
         self.cmd.status()
     }
 }

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -18,6 +18,7 @@ use std::process::{Child, Command, Stdio};
 use std::sync::OnceLock;
 use tracing::{debug, error, info, warn};
 
+mod console_socket;
 mod crun;
 
 /// Ensures storage disk is mounted exactly once. The mount happens either during

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -2273,12 +2273,22 @@ fn handle_interactive_run(
     Ok(())
 }
 
+/// How long the agent waits for crun to connect to the console socket
+/// and hand over the container PTY master fd before giving up.
+#[cfg(target_os = "linux")]
+const CONSOLE_SOCKET_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
 /// Spawn a command for interactive execution using crun OCI runtime.
 ///
-/// When `tty` is true, allocates a PTY pair and attaches the slave to crun's
-/// stdio. The OCI spec sets `terminal: true` so that crun handles the
-/// controlling terminal setup (setsid + TIOCSCTTY) inside the container.
-/// In foreground `crun run` mode, this doesn't require `--console-socket`.
+/// When `tty` is true, the OCI spec sets `terminal: true` and the agent
+/// asks crun to allocate the container's PTY via `--console-socket`.
+/// crun sends the PTY master fd back to the agent over an AF_UNIX socket
+/// using `SCM_RIGHTS`; the agent then reads, writes, and resizes that
+/// master directly. This is the only way to make `TIOCSWINSZ` reach the
+/// process inside the container. Without `--console-socket` crun
+/// allocates its own PTY that the agent has no handle on, and every
+/// resize message is silently applied to the wrong terminal. See GH
+/// #156.
 #[cfg(target_os = "linux")]
 fn spawn_interactive_command(
     rootfs: &str,
@@ -2288,7 +2298,6 @@ fn spawn_interactive_command(
     mounts: &[(String, String, bool)],
     tty: bool,
 ) -> Result<(Child, Option<pty::PtyMaster>), Box<dyn std::error::Error>> {
-    use std::os::unix::io::{AsRawFd as _, FromRawFd as _};
     use std::path::Path;
 
     if command.is_empty() {
@@ -2306,8 +2315,16 @@ fn spawn_interactive_command(
     }
 
     let workdir_str = workdir.unwrap_or("/");
-    // terminal: true tells crun to set up a controlling terminal (setsid + TIOCSCTTY)
     let mut spec = oci::OciSpec::new(command, env, workdir_str, tty);
+    if tty {
+        // Give the PTY a non-zero starting size. The host follows up with a
+        // Resize message carrying the real terminal dimensions as soon as
+        // the interactive session starts.
+        spec.process.console_size = Some(oci::OciConsoleSize {
+            height: 24,
+            width: 80,
+        });
+    }
 
     for (tag, container_path, read_only) in mounts {
         let virtiofs_mount = Path::new(paths::VIRTIOFS_MOUNT_ROOT).join(tag);
@@ -2342,24 +2359,41 @@ fn spawn_interactive_command(
     );
 
     if tty {
-        // Allocate a PTY pair — slave goes to crun's stdio, master returned to caller.
-        // With terminal:true in the OCI spec, crun sets up the controlling terminal
-        // for the container process.
-        let (pty_master, slave_fd) = pty::open_pty(80, 24)?;
-        let slave_raw = slave_fd.as_raw_fd();
+        // Bind a unix socket for crun's --console-socket handshake before
+        // spawning crun; otherwise crun will fail to connect.
+        let console_dir = tempfile::Builder::new()
+            .prefix("smolvm-console-")
+            .tempdir()
+            .map_err(|e| format!("failed to create console socket dir: {}", e))?;
+        let socket_path = console_dir.path().join("console.sock");
+        let console = console_socket::ConsoleSocket::new(&socket_path)
+            .map_err(|e| format!("failed to bind console socket: {}", e))?;
 
-        // SAFETY: slave_fd is a valid open fd from openpty.
-        let child = unsafe {
-            crun::CrunCommand::run(&bundle_path, &container_id)
-                .stdin_from_fd(libc::dup(slave_raw))
-                .stdout_from_fd(libc::dup(slave_raw))
-                .stderr_from_fd(libc::dup(slave_raw))
-                .spawn()?
+        let mut child = crun::CrunCommand::run(&bundle_path, &container_id)
+            .console_socket(&socket_path)
+            .stdin_null()
+            .spawn()?;
+
+        let pty_master = match console.recv_pty_master(CONSOLE_SOCKET_TIMEOUT) {
+            Ok(m) => m,
+            Err(e) => {
+                // crun died before handing us a PTY master. Report what it
+                // was doing so we do not just see a bare timeout.
+                let status = child.try_wait().ok().flatten();
+                error!(
+                    error = %e,
+                    crun_status = ?status,
+                    "failed to receive PTY master from crun"
+                );
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(format!("failed to receive PTY master from crun: {}", e).into());
+            }
         };
 
-        // Close slave in parent — crun has its own copies.
-        drop(slave_fd);
-
+        // `console` and `console_dir` drop at end of scope (after the
+        // tail return moves `child` and `pty_master` out), removing the
+        // socket file and temp dir once the handshake is done.
         Ok((child, Some(pty_master)))
     } else {
         let child = crun::CrunCommand::run(&bundle_path, &container_id)

--- a/crates/smolvm-agent/src/oci.rs
+++ b/crates/smolvm-agent/src/oci.rs
@@ -36,6 +36,9 @@ pub struct OciProcess {
     /// Whether to allocate a pseudo-terminal.
     #[serde(default)]
     pub terminal: bool,
+    /// Initial size of the container's pseudo-terminal (when `terminal: true`).
+    #[serde(rename = "consoleSize", skip_serializing_if = "Option::is_none")]
+    pub console_size: Option<OciConsoleSize>,
     /// User and group IDs.
     pub user: OciUser,
     /// Command and arguments to execute.
@@ -54,6 +57,18 @@ pub struct OciProcess {
     /// Do not create a new session for the process.
     #[serde(rename = "noNewPrivileges", default)]
     pub no_new_privileges: bool,
+}
+
+/// Initial size of a container's pseudo-terminal.
+///
+/// Serialises as OCI `consoleSize: { height, width }`. The host sends a
+/// `Resize` message with the real host terminal dimensions right after the
+/// container starts, so this is just the size seen by the very first
+/// frame the container draws.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct OciConsoleSize {
+    pub height: u32,
+    pub width: u32,
 }
 
 /// User configuration.
@@ -194,6 +209,7 @@ impl OciSpec {
             },
             process: OciProcess {
                 terminal: tty,
+                console_size: None,
                 user: OciUser {
                     uid: 0,
                     gid: 0,
@@ -731,6 +747,35 @@ mod tests {
         assert_eq!(spec.process.args, vec!["echo", "hello"]);
         assert!(spec.process.env.contains(&"FOO=bar".to_string()));
         assert!(!spec.process.terminal);
+        assert!(spec.process.console_size.is_none());
+    }
+
+    #[test]
+    fn test_oci_console_size_serialises_as_camel_case() {
+        let mut spec = OciSpec::new(&["sh".to_string()], &[], "/", true);
+        spec.process.console_size = Some(OciConsoleSize {
+            height: 24,
+            width: 80,
+        });
+        let json = serde_json::to_value(&spec).unwrap();
+        let cs = json
+            .get("process")
+            .and_then(|p| p.get("consoleSize"))
+            .expect("consoleSize should serialise as camelCase under process");
+        assert_eq!(cs.get("height").and_then(|v| v.as_u64()), Some(24));
+        assert_eq!(cs.get("width").and_then(|v| v.as_u64()), Some(80));
+    }
+
+    #[test]
+    fn test_oci_console_size_omitted_when_none() {
+        let spec = OciSpec::new(&["sh".to_string()], &[], "/", true);
+        let json = serde_json::to_value(&spec).unwrap();
+        assert!(
+            json.get("process")
+                .and_then(|p| p.get("consoleSize"))
+                .is_none(),
+            "consoleSize must be omitted when unset"
+        );
     }
 
     #[test]

--- a/crates/smolvm-agent/src/process.rs
+++ b/crates/smolvm-agent/src/process.rs
@@ -295,10 +295,7 @@ mod tests {
         let output = capture_child_output(&mut child);
 
         assert!(output.stdout.is_empty());
-        assert_eq!(
-            std::str::from_utf8(&output.stderr).unwrap().trim(),
-            "error"
-        );
+        assert_eq!(std::str::from_utf8(&output.stderr).unwrap().trim(), "error");
     }
 
     #[test]

--- a/crates/smolvm-agent/src/process.rs
+++ b/crates/smolvm-agent/src/process.rs
@@ -275,7 +275,10 @@ mod tests {
         child.wait().unwrap();
         let output = capture_child_output(&mut child);
 
-        assert!(output.stdout.contains("hello world"));
+        assert_eq!(
+            std::str::from_utf8(&output.stdout).unwrap().trim(),
+            "hello world"
+        );
         assert!(output.stderr.is_empty());
     }
 
@@ -292,7 +295,10 @@ mod tests {
         let output = capture_child_output(&mut child);
 
         assert!(output.stdout.is_empty());
-        assert!(output.stderr.contains("error"));
+        assert_eq!(
+            std::str::from_utf8(&output.stderr).unwrap().trim(),
+            "error"
+        );
     }
 
     #[test]
@@ -309,7 +315,7 @@ mod tests {
         match result {
             WaitResult::Completed { exit_code, output } => {
                 assert_eq!(exit_code, 0);
-                assert!(output.stdout.contains("hello"));
+                assert_eq!(std::str::from_utf8(&output.stdout).unwrap().trim(), "hello");
             }
             WaitResult::TimedOut { .. } => panic!("unexpected timeout"),
             WaitResult::ClientDisconnected { .. } => panic!("unexpected client disconnect"),
@@ -351,7 +357,7 @@ mod tests {
         match result {
             WaitResult::Completed { exit_code, output } => {
                 assert_eq!(exit_code, 0);
-                assert!(output.stdout.contains("quick"));
+                assert_eq!(std::str::from_utf8(&output.stdout).unwrap().trim(), "quick");
             }
             WaitResult::TimedOut { .. } => panic!("unexpected timeout"),
             WaitResult::ClientDisconnected { .. } => panic!("unexpected client disconnect"),

--- a/crates/smolvm-agent/src/pty.rs
+++ b/crates/smolvm-agent/src/pty.rs
@@ -15,6 +15,15 @@ pub struct PtyMaster {
 }
 
 impl PtyMaster {
+    /// Wrap an already-open PTY master fd.
+    ///
+    /// Used by modules that obtain a master from outside the agent (e.g.
+    /// the crun console-socket handshake) so they can return a `PtyMaster`
+    /// without reaching into the private `fd` field.
+    pub(crate) fn from_fd(fd: OwnedFd) -> Self {
+        Self { fd }
+    }
+
     /// Read bytes from the PTY master.
     pub fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
         let n = unsafe { libc::read(self.fd.as_raw_fd(), buf.as_mut_ptr() as *mut _, buf.len()) };


### PR DESCRIPTION
_DISCLAIMER: This is AI generated code (Claude Opus 4.7)_

I did manually test with a local build and confirmed it works, I also used [this skill](https://github.com/fgrehm/dotfiles/tree/6df38461925871e9b9ea56430d6459cb32250889/recipes/ai-tooling/chezmoi/private_dot_ai/agent-skills/rust-best-practices) as an attempt to make it better given I'm not a Rust developer as I mentioned in another ticket (wrote very few lines of Rust by hand).

In any case, I have a feeling that code feels a bit hacky, can't explain why but that `pending_run_id` seems smelly. Happy to adjust if you folks have ideas on how to clean this up or feel free to just close this and do it the Right Way :tm:, I won't get angry :)

-----

## Summary

`smolvm machine exec -it` on an image-based machine was sending terminal resize events to the wrong PTY. The OCI spec had `process.terminal = true` but crun was invoked without `--console-socket`, so crun allocated its own PTY inside the container and the agent never held that PTY's master fd. Inside a Debian container, `stty size` reported `0 0` forever and TUIs like nvim rendered with the wrong dimensions. Bare-VM exec (no `--image`) was unaffected.

The agent now binds a unix socket, passes `--console-socket` to crun, and receives the real container PTY master fd from crun over that socket. Resizes reach the container process.

Fixes #156.

## Commits

1. `test(agent): update ChildOutput assertions for Vec<u8>` (unblocks `cargo test -p smolvm-agent --bins`, broken on main since 267487d; commit message explains why CI missed it).
2. `feat(agent): add OciConsoleSize to OCI process spec`
3. `feat(agent): add ConsoleSocket and crun --console-socket builder`
4. `fix(agent): route container exec PTY via --console-socket`

## Reproduce

On main (bug present):

```bash
smolvm machine create --net --image debian:trixie gh156-repro
smolvm machine start --name gh156-repro
smolvm machine exec --name gh156-repro -it -- stty size
# prints "0 0"; resizing the host terminal doesn't help
```

On this branch (fixed): `stty size` prints real rows and cols, and updates when you resize the host terminal. Inside the same container, `nvim` renders full-size and redraws on resize.

Cleanup: `smolvm machine stop --name gh156-repro && smolvm machine delete --name gh156-repro`.

## Test plan

- [x] `cargo test -p smolvm-agent --bins`: 67 pass, 1 pre-existing failure (`storage::tests::test_validate_storage_id_rejects_traversal`) unrelated to this PR.
- [x] `cargo build --profile release-small -p smolvm-agent --target x86_64-unknown-linux-musl` clean.
- [x] End-to-end Linux x86_64 with a `debian:trixie` machine (see Reproduce).
- [ ] macOS reviewer sanity-check (agent code is `#[cfg(target_os = "linux")]`-gated, so macOS behaviour is unchanged).

## Scope

- Bare-VM exec unchanged.
- No wire protocol changes. Sub-millisecond window where the container may draw at the 80x24 default before the host's initial `Resize` lands; TUIs recover on the next SIGWINCH.
- No CI changes. The CI gap that hid the pre-existing `Vec<u8>` test breakage fixed in the first commit is tracked in #189.
