### PR TITLE
feat: virtio-net part 5 - tcp port mapping

### DIFF
--- a/crates/smolvm-network/src/lib.rs
+++ b/crates/smolvm-network/src/lib.rs
@@ -24,6 +24,8 @@
 //! ├─ FrameStreamBridge
 //! │  ├─ reader thread
 //! │  └─ writer thread
+//! ├─ TcpPortListeners
+//! │  └─ one non-blocking accept loop per `-p HOST:GUEST`
 //! ├─ Arc<NetworkFrameQueues>
 //! │  ├─ guest_to_host
 //! │  ├─ host_to_guest
@@ -40,6 +42,8 @@
 //! Component roles:
 //! - `FrameStreamBridge`: translates libkrun's Unix-stream frame protocol into
 //!   queue operations
+//! - `TcpPortListeners`: accepts host TCP connections for published ports
+//!   and hands them to the poll loop
 //! - `NetworkFrameQueues`: handoff boundary between threads
 //! - `VirtioNetworkDevice`: adapts those queues to smoltcp's `phy::Device`
 //! - poll thread: acts as the guest-visible gateway and protocol dispatcher
@@ -50,12 +54,15 @@
 //! - presenting a gateway endpoint to the guest
 //! - handling DNS through a gateway UDP socket and host UDP forwarding
 //! - relaying guest TCP connections to host `TcpStream`s
+//! - accepting published host TCP ports and forwarding them into guest TCP
+//!   connections
 
 pub mod device;
 pub mod frame_stream;
 pub mod guest_env;
 pub mod queues;
 pub mod stack;
+pub mod tcp_listeners;
 pub mod tcp_relay;
 
 use std::fmt;
@@ -68,9 +75,30 @@ use std::time::SystemTime;
 use frame_stream::{start_frame_stream_bridge, FrameStreamBridge};
 use queues::{NetworkFrameQueues, DEFAULT_FRAME_QUEUE_CAPACITY};
 use stack::{start_network_stack, VirtioPollConfig};
+use tcp_listeners::{create_tcp_channel, TcpPortListeners};
 
 /// Default upstream DNS resolver used by the gateway runtime.
 pub const DEFAULT_DNS_ADDR: IpAddr = IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1));
+
+/// Host->guest published TCP port mapping serviced by the virtio gateway.
+///
+/// This stays crate-local so the launchers can translate CLI/data-layer port
+/// mappings into the gateway runtime without pulling the gateway logic back
+/// into the main `smolvm` crate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PortMapping {
+    /// Port bound on the host loopback interface.
+    pub host: u16,
+    /// Port exposed inside the guest.
+    pub guest: u16,
+}
+
+impl PortMapping {
+    /// Create a new published port mapping.
+    pub const fn new(host: u16, guest: u16) -> Self {
+        Self { host, guest }
+    }
+}
 
 /// Static guest network configuration for the virtio-net MVP.
 ///
@@ -136,6 +164,7 @@ pub(crate) use virtio_net_log;
 /// - one runtime instance corresponds to one guest virtio NIC
 /// - it owns the queue set shared by the worker threads
 /// - it owns the libkrun Unix-stream bridge threads
+/// - it owns the published-port listener threads
 /// - it owns the smoltcp poll thread
 ///
 /// Dropping the runtime is the shutdown signal. `Drop` marks the shared queues
@@ -143,6 +172,7 @@ pub(crate) use virtio_net_log;
 pub struct VirtioNetworkRuntime {
     queues: std::sync::Arc<NetworkFrameQueues>,
     _frame_bridge: FrameStreamBridge,
+    published_ports: Option<TcpPortListeners>,
     poll_handle: Option<JoinHandle<()>>,
 }
 
@@ -154,18 +184,45 @@ pub struct VirtioNetworkRuntime {
 ///   `krun_add_net_unixstream()` setup path.
 /// - `guest_network`: the static guest/gateway addressing and MAC plan for this
 ///   NIC.
+/// - `published_ports`: host->guest TCP port mappings that should be serviced
+///   directly by the virtio runtime instead of TSI.
+///
+/// High-level flow:
+///
+/// ```text
+/// start_virtio_network()
+///   -> create shared frame queues + wake pipes
+///   -> start frame reader/writer threads on the Unix stream
+///   -> start host TcpListeners for published ports
+///   -> start the smoltcp poll thread
+///   -> return a handle that owns the whole runtime
+/// ```
+///
+/// Expanded startup picture:
+///
+/// ```text
+/// host_fd from libkrun
+///   -> FrameStreamBridge(host_fd)
+///      -> reader thread
+///      -> writer thread
+///   -> TcpPortListeners
+///      -> accept host TcpStreams
+///      -> send them to the poll loop over a bounded channel
+///   -> NetworkFrameQueues
+///   -> start_network_stack(...)
+///      -> poll thread owns smoltcp Interface + sockets
+///   -> VirtioNetworkRuntime returned to launcher
+/// ```
 ///
 /// Outcome:
-/// - reader thread: reads raw Ethernet frames from the Unix socket and pushes
-///   them into `guest_to_host`
-/// - writer thread: pops raw Ethernet frames from `host_to_guest` and writes
-///   them back to the Unix socket
-/// - poll thread: runs the host-side smoltcp gateway/runtime, consumes guest
-///   frames, emits response frames, and handles protocol-specific logic such as
-///   DNS forwarding and TCP relay setup
+/// - guest->host Ethernet frames start flowing into the queues
+/// - host->guest Ethernet frames emitted by smoltcp are written back to libkrun
+/// - published host TCP connections can be forwarded toward guest listeners
+/// - the poll loop starts acting as the guest-visible gateway
 pub fn start_virtio_network(
     host_fd: RawFd,
     guest_network: GuestNetworkConfig,
+    published_ports: &[PortMapping],
 ) -> io::Result<VirtioNetworkRuntime> {
     virtio_net_log!(
         "virtio-net: starting runtime host_fd={} guest_ip={} gateway_ip={} dns_server={}",
@@ -176,6 +233,18 @@ pub fn start_virtio_network(
     );
     let queues = NetworkFrameQueues::shared(DEFAULT_FRAME_QUEUE_CAPACITY);
     let frame_bridge = start_frame_stream_bridge(host_fd, queues.clone())?;
+    // tcp_sender sends the accepted TCP connections to the channel
+    // tcp_receiver receives the accepted TCP connections via the channel, and let it be consumed in poll thread.
+    let (tcp_sender, tcp_receiver) = create_tcp_channel();
+    let tcp_listeners = if published_ports.is_empty() {
+        None
+    } else {
+        Some(TcpPortListeners::start(
+            published_ports,
+            tcp_sender,
+            queues.relay_wake.clone(),
+        )?)
+    };
     let poll_handle = start_network_stack(
         queues.clone(),
         VirtioPollConfig {
@@ -185,11 +254,13 @@ pub fn start_virtio_network(
             guest_ipv4: guest_network.guest_ip,
             mtu: 1500,
         },
+        tcp_listeners.as_ref().map(|_| tcp_receiver),
     )?;
 
     Ok(VirtioNetworkRuntime {
         queues,
         _frame_bridge: frame_bridge,
+        published_ports: tcp_listeners,
         poll_handle: Some(poll_handle),
     })
 }
@@ -202,6 +273,7 @@ impl Drop for VirtioNetworkRuntime {
     /// here because the frame bridge joins its own threads in its own `Drop`.
     fn drop(&mut self) {
         self.queues.begin_shutdown();
+        self.published_ports = None;
         if let Some(handle) = self.poll_handle.take() {
             let _ = handle.join();
         }

--- a/crates/smolvm-network/src/stack.rs
+++ b/crates/smolvm-network/src/stack.rs
@@ -46,11 +46,13 @@
 //! ```text
 //! new guest frame         -> guest_wake  -> poll loop
 //! host relay has data     -> relay_wake  -> poll loop
+//! published host connect  -> relay_wake  -> poll loop
 //! smoltcp emitted frames  -> host_wake   -> frame writer
 //! ```
 
 use crate::device::VirtioNetworkDevice;
 use crate::queues::NetworkFrameQueues;
+use crate::tcp_listeners::AcceptedTcpConnection;
 use crate::tcp_relay::{spawn_tcp_relay, TcpRelayTable};
 use crate::{virtio_net_log, DEFAULT_DNS_ADDR};
 use smoltcp::iface::{
@@ -64,6 +66,7 @@ use smoltcp::wire::{
 };
 use std::net::{Ipv4Addr, SocketAddr, UdpSocket as HostUdpSocket};
 use std::sync::atomic::Ordering;
+use std::sync::mpsc::{Receiver, TryRecvError};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant as StdInstant};
@@ -115,6 +118,7 @@ enum FrameAction {
 pub fn start_network_stack(
     queues: Arc<NetworkFrameQueues>,
     config: VirtioPollConfig,
+    tcp_receiver: Option<Receiver<AcceptedTcpConnection>>,
 ) -> std::io::Result<JoinHandle<()>> {
     virtio_net_log!(
         "virtio-net: spawning poll thread guest_ip={} gateway_ip={} mtu={}",
@@ -124,10 +128,14 @@ pub fn start_network_stack(
     );
     thread::Builder::new()
         .name("smolvm-net-poll".into())
-        .spawn(move || run_network_stack(queues, config))
+        .spawn(move || run_network_stack(queues, config, tcp_receiver))
 }
 
-fn run_network_stack(queues: Arc<NetworkFrameQueues>, config: VirtioPollConfig) {
+fn run_network_stack(
+    queues: Arc<NetworkFrameQueues>,
+    config: VirtioPollConfig,
+    mut tcp_receiver: Option<Receiver<AcceptedTcpConnection>>,
+) {
     // Poll loop overview:
     //
     // 1. Drain staged guest Ethernet frames from the guest_to_host queue.
@@ -219,6 +227,15 @@ fn run_network_stack(queues: Arc<NetworkFrameQueues>, config: VirtioPollConfig) 
             }
         }
 
+        relay_accepted_tcp_connection(
+            &mut tcp_receiver,
+            &mut relays,
+            &mut interface,
+            &mut sockets,
+            config.gateway_ipv4,
+            config.guest_ipv4,
+        );
+
         // First egress pass: let smoltcp emit any packets caused by the most
         // recent ingress work before we service higher-level relays.
         flush_interface_egress(&mut interface, &mut device, &mut sockets, now);
@@ -235,6 +252,7 @@ fn run_network_stack(queues: Arc<NetworkFrameQueues>, config: VirtioPollConfig) 
         for connection in relays.take_new_connections(&mut sockets) {
             spawn_tcp_relay(
                 connection.destination,
+                connection.relay_target,
                 connection.from_smoltcp,
                 connection.to_smoltcp,
                 relay_wake.clone(),
@@ -321,6 +339,68 @@ fn add_dns_socket(sockets: &mut SocketSet<'_>, gateway_ipv4: Ipv4Addr) -> Socket
         })
         .expect("failed to bind gateway DNS socket");
     sockets.add(socket)
+}
+
+/// Receive the accepted TCP connection from the tcp_channel, and then relay it to
+/// the TcpRelayTable where the TCP network packets will be relayed to the guest.
+fn relay_accepted_tcp_connection(
+    tcp_receiver: &mut Option<Receiver<AcceptedTcpConnection>>,
+    relays: &mut TcpRelayTable,
+    interface: &mut Interface,
+    sockets: &mut SocketSet<'_>,
+    gateway_ipv4: Ipv4Addr,
+    guest_ipv4: Ipv4Addr,
+) {
+    // Published-port model:
+    //
+    // host client -> accepted host TcpStream
+    //             -> create guest-facing smoltcp socket from gateway_ip:ephemeral
+    //             -> guest sees a normal inbound TCP connection to guest_port
+    //             -> once Established, the relay thread bridges payloads
+    //
+    // The guest does not see the original host peer address here. This path is
+    // effectively a small userspace TCP proxy/NAT at the gateway boundary.
+    let mut disconnected = false;
+
+    if let Some(receiver) = tcp_receiver.as_mut() {
+        loop {
+            match receiver.try_recv() {
+                Ok(connection) => {
+                    let guest_destination =
+                        SocketAddr::new(std::net::IpAddr::V4(guest_ipv4), connection.guest_port);
+                    virtio_net_log!(
+                        "virtio-net: accepted published TCP connection peer={} host_port={} guest_destination={}",
+                        connection.peer_addr,
+                        connection.host_port,
+                        guest_destination
+                    );
+                    if !relays.create_published_socket(
+                        interface,
+                        gateway_ipv4,
+                        guest_destination,
+                        connection.stream,
+                        sockets,
+                    ) {
+                        tracing::warn!(
+                            host_port = connection.host_port,
+                            guest_port = connection.guest_port,
+                            peer_addr = %connection.peer_addr,
+                            "dropping published TCP connection because the guest relay path could not be created"
+                        );
+                    }
+                }
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => {
+                    disconnected = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    if disconnected {
+        *tcp_receiver = None;
+    }
 }
 
 fn process_dns_queries(dns_socket_handle: SocketHandle, sockets: &mut SocketSet<'_>) {
@@ -423,74 +503,57 @@ fn wake_guest_if_needed(queues: &NetworkFrameQueues, device: &VirtioNetworkDevic
     }
 }
 
-fn smoltcp_now(start: StdInstant) -> Instant {
-    Instant::from_micros(start.elapsed().as_micros() as i64)
+fn smoltcp_now(clock: StdInstant) -> Instant {
+    let elapsed = clock.elapsed();
+    Instant::from_millis(elapsed.as_millis() as i64)
 }
 
 fn classify_guest_frame(frame: &[u8]) -> FrameAction {
-    // This pre-parser is intentionally shallow. It only looks far enough to
-    // decide whether the poll loop needs special handling before smoltcp sees
-    // the frame.
-    //
-    // Current policy:
-    // - TCP SYN  -> create relay/socket state before ingress
-    // - UDP/53   -> allow as DNS
-    // - other UDP-> drop in Phase 1
-    // - anything else -> normal smoltcp ingress path
-    let Ok(ethernet) = EthernetFrame::new_checked(frame) else {
-        return FrameAction::Passthrough;
+    let ethernet = match EthernetFrame::new_checked(frame) {
+        Ok(frame) => frame,
+        Err(_) => return FrameAction::Passthrough,
     };
 
     if ethernet.ethertype() != EthernetProtocol::Ipv4 {
         return FrameAction::Passthrough;
     }
 
-    let Ok(ipv4) = Ipv4Packet::new_checked(ethernet.payload()) else {
-        return FrameAction::Passthrough;
+    let ipv4 = match Ipv4Packet::new_checked(ethernet.payload()) {
+        Ok(packet) => packet,
+        Err(_) => return FrameAction::Passthrough,
     };
 
     match ipv4.next_header() {
         smoltcp::wire::IpProtocol::Tcp => {
-            classify_tcp(ipv4.payload(), ipv4.src_addr(), ipv4.dst_addr())
+            let tcp = match TcpPacket::new_checked(ipv4.payload()) {
+                Ok(packet) => packet,
+                Err(_) => return FrameAction::Passthrough,
+            };
+
+            if tcp.syn() && !tcp.ack() {
+                FrameAction::TcpSyn {
+                    source: SocketAddr::new(std::net::IpAddr::V4(ipv4.src_addr()), tcp.src_port()),
+                    destination: SocketAddr::new(
+                        std::net::IpAddr::V4(ipv4.dst_addr()),
+                        tcp.dst_port(),
+                    ),
+                }
+            } else {
+                FrameAction::Passthrough
+            }
         }
-        smoltcp::wire::IpProtocol::Udp => classify_udp(ipv4.payload()),
+        smoltcp::wire::IpProtocol::Udp => {
+            let udp = match UdpPacket::new_checked(ipv4.payload()) {
+                Ok(packet) => packet,
+                Err(_) => return FrameAction::Passthrough,
+            };
+
+            if udp.dst_port() == DNS_SOCKET_PORT {
+                FrameAction::DnsQuery
+            } else {
+                FrameAction::UnsupportedUdp
+            }
+        }
         _ => FrameAction::Passthrough,
-    }
-}
-
-fn classify_tcp(payload: &[u8], source: Ipv4Addr, destination: Ipv4Addr) -> FrameAction {
-    // New outgoing guest TCP connections are identified by the initial
-    // SYN-without-ACK packet. That is the moment where we need a matching
-    // smoltcp socket and later a host relay thread.
-    let Ok(tcp) = TcpPacket::new_checked(payload) else {
-        return FrameAction::Passthrough;
-    };
-
-    if tcp.syn() && !tcp.ack() && !tcp.rst() {
-        FrameAction::TcpSyn {
-            source: SocketAddr::new(source.into(), tcp.src_port()),
-            destination: SocketAddr::new(destination.into(), tcp.dst_port()),
-        }
-    } else {
-        FrameAction::Passthrough
-    }
-}
-
-fn classify_udp(payload: &[u8]) -> FrameAction {
-    // Phase 1 treats DNS as the only supported guest UDP protocol.
-    let Ok(udp) = UdpPacket::new_checked(payload) else {
-        return FrameAction::Passthrough;
-    };
-
-    if udp.dst_port() == DNS_SOCKET_PORT {
-        virtio_net_log!(
-            "virtio-net: guest DNS UDP datagram received src_port={} dst_port={} payload_len={}",
-            udp.src_port(),
-            udp.dst_port(),
-            udp.payload().len()
-        );
-        FrameAction::DnsQuery
-    } else {
-        FrameAction::UnsupportedUdp
     }
 }

--- a/crates/smolvm-network/src/tcp_listeners.rs
+++ b/crates/smolvm-network/src/tcp_listeners.rs
@@ -1,0 +1,194 @@
+//! Host-side TCP listeners for published virtio-net ports.
+//!
+//! Context
+//! =======
+//!
+//! This module is the host-facing half of `-p HOST:GUEST` for the virtio-net
+//! backend.
+//!
+//! The outbound virtio path already handles guest-initiated TCP:
+//!
+//! ```text
+//! guest TCP connect -> smoltcp socket -> host TcpStream -> remote server
+//! ```
+//!
+//! Published ports invert the initiator:
+//!
+//! ```text
+//! host client -> host TcpListener -> accepted TcpStream
+//!           -> smoltcp creates gateway-side TCP connection to guest_ip:GUEST
+//!           -> relay thread bridges the accepted host socket to the guest flow
+//! ```
+//!
+//! High-level flow:
+//!
+//! ```text
+//! host client connects to 127.0.0.1:HOST
+//!   -> TcpPortListeners accepts TcpStream
+//!   -> AcceptedTcpConnection sent over a bounded channel
+//!   -> relay_wake wakes the smoltcp poll loop
+//!   -> poll loop creates a guest-facing TCP socket to guest_ip:GUEST
+//!   -> once Established, tcp_relay uses the accepted host TcpStream directly
+//! ```
+
+use crate::queues::WakePipe;
+use crate::PortMapping;
+use std::io;
+use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{self, SyncSender, TrySendError};
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+const ACCEPT_POLL_INTERVAL: Duration = Duration::from_millis(25);
+/// Maximum number of accepted published sockets queued for the poll loop.
+pub const DEFAULT_PUBLISH_QUEUE_CAPACITY: usize = 64;
+
+/// Accepted host TCP connection waiting for the smoltcp poll loop.
+pub struct AcceptedTcpConnection {
+    /// Connected host-side socket returned by `accept(2)`.
+    pub stream: TcpStream,
+    /// Host port that accepted the connection.
+    pub host_port: u16,
+    /// Guest port the connection should be forwarded to.
+    pub guest_port: u16,
+    /// Remote peer that connected to the published port.
+    pub peer_addr: SocketAddr,
+}
+
+/// Running published-port listener set for one guest NIC.
+pub struct TcpPortListeners {
+    shutdown: Arc<AtomicBool>,
+    handles: Vec<JoinHandle<()>>,
+}
+
+impl TcpPortListeners {
+    /// Start one non-blocking listener thread per published port.
+    pub fn start(
+        port_mappings: &[PortMapping],
+        tcp_sender: SyncSender<AcceptedTcpConnection>,
+        publish_wake: WakePipe,
+    ) -> io::Result<Self> {
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let mut handles = Vec::with_capacity(port_mappings.len());
+
+        for mapping in port_mappings {
+            let listener = match TcpListener::bind((Ipv4Addr::LOCALHOST, mapping.host)) {
+                Ok(listener) => listener,
+                Err(err) => {
+                    shutdown_all(&shutdown, &mut handles);
+                    return Err(err);
+                }
+            };
+            if let Err(err) = listener.set_nonblocking(true) {
+                shutdown_all(&shutdown, &mut handles);
+                return Err(err);
+            }
+
+            let tcp_sender = tcp_sender.clone();
+            let publish_wake = publish_wake.clone();
+            let shutdown_flag = shutdown.clone();
+            let host_port = mapping.host;
+            let guest_port = mapping.guest;
+
+            let handle = thread::Builder::new()
+                .name(format!("smolvm-tcp-{host_port}"))
+                .spawn(move || {
+                    run_tcp_port_listener(
+                        listener,
+                        host_port,
+                        guest_port,
+                        tcp_sender,
+                        publish_wake,
+                        shutdown_flag,
+                    )
+                })
+                .map_err(|err| {
+                    shutdown_all(&shutdown, &mut handles);
+                    io::Error::other(format!(
+                        "failed to spawn published-port listener thread for {host_port}: {err}"
+                    ))
+                })?;
+            handles.push(handle);
+        }
+
+        Ok(Self { shutdown, handles })
+    }
+}
+
+impl Drop for TcpPortListeners {
+    fn drop(&mut self) {
+        shutdown_all(&self.shutdown, &mut self.handles);
+    }
+}
+
+fn shutdown_all(shutdown: &Arc<AtomicBool>, handles: &mut Vec<JoinHandle<()>>) {
+    shutdown.store(true, Ordering::SeqCst);
+    for handle in handles.drain(..) {
+        let _ = handle.join();
+    }
+}
+
+fn run_tcp_port_listener(
+    listener: TcpListener,
+    host_port: u16,
+    guest_port: u16,
+    tcp_sender: SyncSender<AcceptedTcpConnection>,
+    publish_wake: WakePipe,
+    shutdown: Arc<AtomicBool>,
+) {
+    loop {
+        if shutdown.load(Ordering::SeqCst) {
+            return;
+        }
+
+        match listener.accept() {
+            Ok((stream, peer_addr)) => {
+                let accepted = AcceptedTcpConnection {
+                    stream,
+                    host_port,
+                    guest_port,
+                    peer_addr,
+                };
+
+                match tcp_sender.try_send(accepted) {
+                    Ok(()) => publish_wake.wake(),
+                    Err(TrySendError::Full(accepted)) => {
+                        tracing::warn!(
+                            host_port = accepted.host_port,
+                            guest_port = accepted.guest_port,
+                            peer_addr = %accepted.peer_addr,
+                            "dropping published TCP connection because the accept queue is full"
+                        );
+                    }
+                    Err(TrySendError::Disconnected(_)) => return,
+                }
+            }
+            Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
+                thread::sleep(ACCEPT_POLL_INTERVAL);
+            }
+            Err(err) => {
+                tracing::warn!(
+                    host_port,
+                    guest_port,
+                    error = %err,
+                    "published port listener accept failed"
+                );
+                thread::sleep(ACCEPT_POLL_INTERVAL);
+            }
+        }
+    }
+}
+
+/// Create the bounded channel used to hand accepted host sockets to the poll loop.
+/// Each host port in the provided PortMapping has a listener. When the listener
+/// accepts a TCP connection, it "sends" the TcpStream to the poll thread by putting
+/// the AcceptedTcpConnection into this channel. The receiver consumes it in the
+/// poll thread.
+pub fn create_tcp_channel() -> (
+    SyncSender<AcceptedTcpConnection>,
+    mpsc::Receiver<AcceptedTcpConnection>,
+) {
+    mpsc::sync_channel(DEFAULT_PUBLISH_QUEUE_CAPACITY)
+}

--- a/crates/smolvm-network/src/tcp_relay.rs
+++ b/crates/smolvm-network/src/tcp_relay.rs
@@ -28,12 +28,12 @@
 
 use crate::queues::WakePipe;
 use crate::virtio_net_log;
-use smoltcp::iface::{SocketHandle, SocketSet};
+use smoltcp::iface::{Interface, SocketHandle, SocketSet};
 use smoltcp::socket::tcp;
 use smoltcp::wire::IpListenEndpoint;
 use std::collections::{HashMap, HashSet};
 use std::io::{self, Read, Write};
-use std::net::{Shutdown, SocketAddr, TcpStream};
+use std::net::{Ipv4Addr, Shutdown, SocketAddr, TcpStream};
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::mpsc::{self, Receiver, SyncSender, TryRecvError};
 use std::sync::Arc;
@@ -47,6 +47,8 @@ const CHANNEL_CAPACITY: usize = 32;
 const RELAY_BUFFER_BYTES: usize = 16 * 1024;
 const CLOSE_RETRY_LIMIT: u16 = 64;
 const PROXY_IDLE_SLEEP: Duration = Duration::from_millis(10);
+const PUBLISHED_PORT_START: u16 = 49_152;
+const PUBLISHED_PORT_END: u16 = 65_535;
 
 /// Track all active guest TCP connections bridged through host sockets.
 ///
@@ -55,6 +57,8 @@ const PROXY_IDLE_SLEEP: Duration = Duration::from_millis(10);
 pub struct TcpRelayTable {
     connections: HashMap<SocketHandle, TrackedConnection>,
     connection_keys: HashSet<(SocketAddr, SocketAddr)>,
+    used_published_ports: HashSet<u16>,
+    next_published_port: u16,
     max_connections: usize,
 }
 
@@ -66,6 +70,8 @@ pub struct TcpRelayTable {
 pub struct NewTcpConnection {
     /// Destination originally requested by the guest.
     pub destination: SocketAddr,
+    /// How the host-side relay should be started.
+    pub relay_target: RelayTarget,
     /// Guest-to-host payloads read from the smoltcp socket.
     pub from_smoltcp: Receiver<Vec<u8>>,
     /// Host-to-guest payloads written back into the smoltcp socket.
@@ -93,12 +99,24 @@ struct TrackedConnection {
     close_attempts: u16,
     // relay thread termination mode observed by the poll loop
     exit_state: RelayExitState,
+    // reserved local source port for published inbound connections
+    reserved_published_port: Option<u16>,
 }
 
 #[derive(Debug)]
 struct PendingProxyEndpoints {
     from_smoltcp: Receiver<Vec<u8>>,
     to_smoltcp: SyncSender<Vec<u8>>,
+    relay_target: RelayTarget,
+}
+
+/// How a host-side TCP relay should obtain its remote socket.
+#[derive(Debug)]
+pub enum RelayTarget {
+    /// Open a new outbound host `TcpStream` to the destination.
+    Connect(SocketAddr),
+    /// Use an already-accepted host `TcpStream` from a published port listener.
+    Attached(TcpStream),
 }
 
 /// Host relay termination state shared between the poll loop and the relay thread.
@@ -151,6 +169,8 @@ impl TcpRelayTable {
         Self {
             connections: HashMap::new(),
             connection_keys: HashSet::new(),
+            used_published_ports: HashSet::new(),
+            next_published_port: PUBLISHED_PORT_START,
             max_connections: max_connections.unwrap_or(MAX_CONNECTIONS),
         }
     }
@@ -219,11 +239,103 @@ impl TcpRelayTable {
                 pending_proxy_endpoints: Some(PendingProxyEndpoints {
                     from_smoltcp: to_proxy_rx,
                     to_smoltcp: from_proxy_tx,
+                    relay_target: RelayTarget::Connect(destination),
                 }),
                 relay_spawned: false,
                 buffered_proxy_data: None,
                 close_attempts: 0,
                 exit_state,
+                reserved_published_port: None,
+            },
+        );
+
+        true
+    }
+
+    /// Create a guest-facing TCP connection for a published host socket.
+    ///
+    /// This is the host->guest mirror of `create_tcp_socket`:
+    ///
+    /// ```text
+    /// host client connects to published port
+    ///   -> host listener accepts TcpStream
+    ///   -> poll loop creates smoltcp TCP socket from gateway_ip:ephemeral
+    ///      to guest_ip:guest_port
+    ///   -> guest kernel sees a normal inbound TCP connection on guest_port
+    /// ```
+    ///
+    /// The guest-visible source address is the gateway IP, not the original
+    /// host peer address. That keeps the first version simple and matches the
+    /// fact that this runtime is acting as a userspace gateway/proxy.
+    pub fn create_published_socket(
+        &mut self,
+        interface: &mut Interface,
+        gateway_ip: Ipv4Addr,
+        destination: SocketAddr,
+        host_stream: TcpStream,
+        sockets: &mut SocketSet<'_>,
+    ) -> bool {
+        if self.connections.len() >= self.max_connections {
+            tracing::warn!("dropping published TCP connection because the relay table is full");
+            return false;
+        }
+
+        let Some(local_port) = self.allocate_published_port() else {
+            tracing::warn!(
+                "dropping published TCP connection because no gateway source port is available"
+            );
+            return false;
+        };
+
+        let std::net::IpAddr::V4(destination_ip) = destination.ip() else {
+            self.used_published_ports.remove(&local_port);
+            return false;
+        };
+
+        let rx_buffer = tcp::SocketBuffer::new(vec![0u8; TCP_RX_BUFFER_BYTES]);
+        let tx_buffer = tcp::SocketBuffer::new(vec![0u8; TCP_TX_BUFFER_BYTES]);
+        let mut socket = tcp::Socket::new(rx_buffer, tx_buffer);
+        let local_endpoint = IpListenEndpoint {
+            addr: Some(gateway_ip.into()),
+            port: local_port,
+        };
+        if socket
+            .connect(
+                interface.context(),
+                (destination_ip, destination.port()),
+                local_endpoint,
+            )
+            .is_err()
+        {
+            self.used_published_ports.remove(&local_port);
+            return false;
+        }
+
+        let handle = sockets.add(socket);
+        let source = SocketAddr::new(std::net::IpAddr::V4(gateway_ip), local_port);
+
+        let (to_proxy_tx, to_proxy_rx) = mpsc::sync_channel(CHANNEL_CAPACITY);
+        let (from_proxy_tx, from_proxy_rx) = mpsc::sync_channel(CHANNEL_CAPACITY);
+        let exit_state = RelayExitState::new();
+
+        self.connection_keys.insert((source, destination));
+        self.connections.insert(
+            handle,
+            TrackedConnection {
+                source,
+                destination,
+                to_proxy: to_proxy_tx,
+                from_proxy: from_proxy_rx,
+                pending_proxy_endpoints: Some(PendingProxyEndpoints {
+                    from_smoltcp: to_proxy_rx,
+                    to_smoltcp: from_proxy_tx,
+                    relay_target: RelayTarget::Attached(host_stream),
+                }),
+                relay_spawned: false,
+                buffered_proxy_data: None,
+                close_attempts: 0,
+                exit_state,
+                reserved_published_port: Some(local_port),
             },
         );
 
@@ -304,6 +416,7 @@ impl TcpRelayTable {
                 if let Some(endpoints) = connection.pending_proxy_endpoints.take() {
                     new_connections.push(NewTcpConnection {
                         destination: connection.destination,
+                        relay_target: endpoints.relay_target,
                         from_smoltcp: endpoints.from_smoltcp,
                         to_smoltcp: endpoints.to_smoltcp,
                         exit_state: connection.exit_state.clone(),
@@ -320,16 +433,41 @@ impl TcpRelayTable {
     /// This is the final ownership cleanup step for a guest TCP flow.
     pub fn cleanup_closed(&mut self, sockets: &mut SocketSet<'_>) {
         let keys = &mut self.connection_keys;
+        let published_ports = &mut self.used_published_ports;
         self.connections.retain(|&handle, connection| {
             let socket = sockets.get::<tcp::Socket>(handle);
             if socket.state() == tcp::State::Closed {
                 keys.remove(&(connection.source, connection.destination));
+                if let Some(port) = connection.reserved_published_port {
+                    published_ports.remove(&port);
+                }
                 sockets.remove(handle);
                 false
             } else {
                 true
             }
         });
+    }
+
+    fn allocate_published_port(&mut self) -> Option<u16> {
+        let start = self.next_published_port;
+
+        loop {
+            let candidate = self.next_published_port;
+            self.next_published_port = if candidate == PUBLISHED_PORT_END {
+                PUBLISHED_PORT_START
+            } else {
+                candidate + 1
+            };
+
+            if self.used_published_ports.insert(candidate) {
+                return Some(candidate);
+            }
+
+            if self.next_published_port == start {
+                return None;
+            }
+        }
     }
 }
 
@@ -343,6 +481,7 @@ impl TcpRelayTable {
 /// - report termination mode through `exit_state`
 pub fn spawn_tcp_relay(
     destination: SocketAddr,
+    relay_target: RelayTarget,
     from_smoltcp: Receiver<Vec<u8>>,
     to_smoltcp: SyncSender<Vec<u8>>,
     relay_wake: Arc<WakePipe>,
@@ -357,6 +496,7 @@ pub fn spawn_tcp_relay(
     let _ = thread::Builder::new().name(thread_name).spawn(move || {
         run_tcp_relay(
             destination,
+            relay_target,
             from_smoltcp,
             to_smoltcp,
             relay_wake,
@@ -367,6 +507,7 @@ pub fn spawn_tcp_relay(
 
 fn run_tcp_relay(
     destination: SocketAddr,
+    relay_target: RelayTarget,
     from_smoltcp: Receiver<Vec<u8>>,
     to_smoltcp: SyncSender<Vec<u8>>,
     relay_wake: Arc<WakePipe>,
@@ -378,7 +519,13 @@ fn run_tcp_relay(
         "virtio-net: host TCP relay thread started destination={}",
         destination
     );
-    match tcp_relay_loop(destination, from_smoltcp, to_smoltcp, relay_wake) {
+    match tcp_relay_loop(
+        destination,
+        relay_target,
+        from_smoltcp,
+        to_smoltcp,
+        relay_wake,
+    ) {
         Ok(mode) => {
             virtio_net_log!(
                 "virtio-net: host TCP relay thread exited destination={} mode={:?}",
@@ -400,6 +547,7 @@ fn run_tcp_relay(
 
 fn tcp_relay_loop(
     destination: SocketAddr,
+    relay_target: RelayTarget,
     from_smoltcp: Receiver<Vec<u8>>,
     to_smoltcp: SyncSender<Vec<u8>>,
     relay_wake: Arc<WakePipe>,
@@ -410,16 +558,30 @@ fn tcp_relay_loop(
     // 2. Non-blockingly drain guest payloads from the channel into the socket.
     // 3. Non-blockingly read remote payloads from the socket into the channel.
     // 4. If neither side made progress, sleep briefly to avoid a hot spin loop.
-    virtio_net_log!(
-        "virtio-net: connecting host TCP relay socket destination={}",
-        destination
-    );
-    let mut stream = TcpStream::connect(destination)?;
+    let mut stream = match relay_target {
+        RelayTarget::Connect(destination) => {
+            virtio_net_log!(
+                "virtio-net: connecting host TCP relay socket destination={}",
+                destination
+            );
+            let stream = TcpStream::connect(destination)?;
+            virtio_net_log!(
+                "virtio-net: host TCP relay socket connected destination={}",
+                destination
+            );
+            stream
+        }
+        RelayTarget::Attached(stream) => {
+            virtio_net_log!(
+                "virtio-net: using accepted host TCP socket for published port guest_destination={} peer_addr={:?} local_addr={:?}",
+                destination,
+                stream.peer_addr().ok(),
+                stream.local_addr().ok()
+            );
+            stream
+        }
+    };
     stream.set_nonblocking(true)?;
-    virtio_net_log!(
-        "virtio-net: host TCP relay socket connected destination={}",
-        destination
-    );
 
     let mut guest_write_closed = false;
     let mut read_buffer = [0u8; RELAY_BUFFER_BYTES];

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -12,7 +12,10 @@ use crate::network::{plan_launch_network, EffectiveNetworkBackend};
 use crate::storage::{OverlayDisk, StorageDisk};
 use crate::util::libkrunfw_filename;
 
-use smolvm_network::{guest_env, start_virtio_network, GuestNetworkConfig, VirtioNetworkRuntime};
+use smolvm_network::{
+    guest_env, start_virtio_network, GuestNetworkConfig, PortMapping as VirtioPortMapping,
+    VirtioNetworkRuntime,
+};
 use smolvm_protocol::ports;
 use std::ffi::{CStr, CString};
 use std::os::fd::RawFd;
@@ -380,17 +383,22 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
                     Error::agent("configure virtio-net", format!("socketpair failed: {e}"))
                 })?;
 
-                let runtime = match start_virtio_network(host_fd, guest_network) {
-                    Ok(runtime) => runtime,
-                    Err(err) => {
-                        libc::close(guest_fd);
-                        krun_free_ctx(ctx);
-                        return Err(Error::agent(
-                            "configure virtio-net",
-                            format!("failed to start virtio network runtime: {err}"),
-                        ));
-                    }
-                };
+                let virtio_port_mappings: Vec<VirtioPortMapping> = port_mappings
+                    .iter()
+                    .map(|mapping| VirtioPortMapping::new(mapping.host, mapping.guest))
+                    .collect();
+                let runtime =
+                    match start_virtio_network(host_fd, guest_network, &virtio_port_mappings) {
+                        Ok(runtime) => runtime,
+                        Err(err) => {
+                            libc::close(guest_fd);
+                            krun_free_ctx(ctx);
+                            return Err(Error::agent(
+                                "configure virtio-net",
+                                format!("failed to start virtio network runtime: {err}"),
+                            ));
+                        }
+                    };
 
                 if add_net_unixstream(
                     ctx,

--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -9,7 +9,10 @@
 use crate::network::backend::{COMPAT_NET_FEATURES, TSI_FEATURE_HIJACK_INET};
 use crate::network::{plan_launch_network, EffectiveNetworkBackend};
 use crate::util::{libkrun_filename, libkrunfw_filename};
-use smolvm_network::{guest_env, start_virtio_network, GuestNetworkConfig, VirtioNetworkRuntime};
+use smolvm_network::{
+    guest_env, start_virtio_network, GuestNetworkConfig, PortMapping as VirtioPortMapping,
+    VirtioNetworkRuntime,
+};
 use smolvm_protocol::ports;
 use std::ffi::{CStr, CString};
 use std::os::fd::RawFd;
@@ -379,8 +382,13 @@ pub fn launch_agent_vm_dynamic(
             let mut guest_mac = guest_network.guest_mac;
             let (host_fd, guest_fd) =
                 create_unix_stream_pair().map_err(|e| format!("socketpair failed: {e}"))?;
+            let port_mappings: Vec<VirtioPortMapping> = config
+                .port_mappings
+                .iter()
+                .map(|(host, guest)| VirtioPortMapping::new(*host, *guest))
+                .collect();
 
-            let runtime = match start_virtio_network(host_fd, guest_network) {
+            let runtime = match start_virtio_network(host_fd, guest_network, &port_mappings) {
                 Ok(runtime) => runtime,
                 Err(err) => {
                     // SAFETY: guest_fd was created by socketpair above and not moved elsewhere.

--- a/src/network/launch.rs
+++ b/src/network/launch.rs
@@ -1,13 +1,6 @@
 use crate::data::resources::VmResources;
 use crate::network::backend::NetworkBackend;
 
-/// Current staged-transplant support for plain virtio-net egress.
-const VIRTIO_NET_SUPPORTS_PLAIN_EGRESS: bool = true;
-/// Current staged-transplant support for published ports on virtio-net.
-const VIRTIO_NET_SUPPORTS_PUBLISHED_PORTS: bool = false;
-/// Current staged-transplant support for in-process policy on virtio-net.
-const VIRTIO_NET_SUPPORTS_POLICY: bool = false;
-
 /// Effective backend selected for a launch.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EffectiveNetworkBackend {
@@ -22,10 +15,6 @@ pub enum EffectiveNetworkBackend {
 /// Reason a requested backend was downgraded.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NetworkFallbackReason {
-    /// virtio-net has been requested but is not implemented on this branch yet.
-    VirtioNetNotYetImplemented,
-    /// Port publishing is only implemented on TSI.
-    PortsRequireTsi,
     /// Current egress policies and DNS filtering are only implemented on TSI.
     PolicyRequiresTsi,
 }
@@ -34,12 +23,6 @@ impl NetworkFallbackReason {
     /// User-facing explanation for the fallback.
     pub const fn user_message(self) -> &'static str {
         match self {
-            Self::VirtioNetNotYetImplemented => {
-                "virtio-net has not been implemented in this branch yet"
-            }
-            Self::PortsRequireTsi => {
-                "port publishing still uses the TSI backend; falling back from virtio-net"
-            }
             Self::PolicyRequiresTsi => {
                 "allow-cidr/allow-host policies still use the TSI backend; falling back from virtio-net"
             }
@@ -49,12 +32,6 @@ impl NetworkFallbackReason {
     /// User-facing explanation when an explicit virtio-net request must be rejected.
     pub const fn unsupported_message(self) -> &'static str {
         match self {
-            Self::VirtioNetNotYetImplemented => {
-                "the current virtio-net implementation is not ready yet on this branch"
-            }
-            Self::PortsRequireTsi => {
-                "published ports are not supported by the current virtio-net implementation"
-            }
             Self::PolicyRequiresTsi => {
                 "allow-cidr/allow-host policies are not supported by the current virtio-net implementation"
             }
@@ -105,21 +82,9 @@ pub fn plan_launch_network(
             backend: EffectiveNetworkBackend::Tsi,
             fallback_reason: None,
         },
-        NetworkBackend::VirtioNet if has_ports && !VIRTIO_NET_SUPPORTS_PUBLISHED_PORTS => {
-            LaunchNetworkPlan {
-                backend: EffectiveNetworkBackend::Tsi,
-                fallback_reason: Some(NetworkFallbackReason::PortsRequireTsi),
-            }
-        }
-        NetworkBackend::VirtioNet if has_policy && !VIRTIO_NET_SUPPORTS_POLICY => {
-            LaunchNetworkPlan {
-                backend: EffectiveNetworkBackend::Tsi,
-                fallback_reason: Some(NetworkFallbackReason::PolicyRequiresTsi),
-            }
-        }
-        NetworkBackend::VirtioNet if !VIRTIO_NET_SUPPORTS_PLAIN_EGRESS => LaunchNetworkPlan {
+        NetworkBackend::VirtioNet if has_policy => LaunchNetworkPlan {
             backend: EffectiveNetworkBackend::Tsi,
-            fallback_reason: Some(NetworkFallbackReason::VirtioNetNotYetImplemented),
+            fallback_reason: Some(NetworkFallbackReason::PolicyRequiresTsi),
         },
         NetworkBackend::VirtioNet => LaunchNetworkPlan {
             backend: EffectiveNetworkBackend::VirtioNet,
@@ -156,7 +121,7 @@ pub fn validate_requested_network_backend(
     if plan.backend != EffectiveNetworkBackend::VirtioNet {
         let reason = plan
             .fallback_reason
-            .unwrap_or(NetworkFallbackReason::VirtioNetNotYetImplemented);
+            .unwrap_or(NetworkFallbackReason::PolicyRequiresTsi);
         return Err(crate::Error::config(
             "--net-backend",
             reason.unsupported_message(),
@@ -199,16 +164,13 @@ mod tests {
     }
 
     #[test]
-    fn test_ports_force_tsi() {
+    fn test_ports_work_with_virtio() {
         let mut resources = resources();
         resources.network = true;
         resources.network_backend = Some(NetworkBackend::VirtioNet);
         let plan = plan_launch_network(&resources, None, 1);
-        assert_eq!(plan.backend, EffectiveNetworkBackend::Tsi);
-        assert_eq!(
-            plan.fallback_reason,
-            Some(NetworkFallbackReason::PortsRequireTsi)
-        );
+        assert_eq!(plan.backend, EffectiveNetworkBackend::VirtioNet);
+        assert_eq!(plan.fallback_reason, None);
     }
 
     #[test]
@@ -234,14 +196,11 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_ports_rejected_for_virtio() {
+    fn test_validate_ports_allowed_for_virtio() {
         let mut resources = resources();
         resources.network = true;
         resources.network_backend = Some(NetworkBackend::VirtioNet);
-        let err = validate_requested_network_backend(&resources, None, 1).unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("published ports are not supported"));
+        validate_requested_network_backend(&resources, None, 1).unwrap();
     }
 
     #[test]

--- a/tests/test_virtio_net.sh
+++ b/tests/test_virtio_net.sh
@@ -8,7 +8,8 @@
 #   gateway for DNS and outbound TCP
 # - part 4: the `create -> start -> exec`, `machine run`, and `pack run` flows
 #   all drive real virtio-backed guest networking
-# - unsupported features like published ports and policy still fail clearly
+# - part 5: published TCP ports work end-to-end on the virtio gateway
+# - unsupported policy features still fail clearly
 
 source "$(dirname "$0")/common.sh"
 init_smolvm
@@ -26,6 +27,7 @@ echo "=========================================="
 echo ""
 
 VIRTIO_TEST_IMAGE="${VIRTIO_TEST_IMAGE:-alpine:latest}"
+VIRTIO_PUBLISH_TEST_IMAGE="${VIRTIO_PUBLISH_TEST_IMAGE:-python:3.12-alpine}"
 
 virtio_guest_probe_script() {
     cat <<'EOF'
@@ -141,22 +143,61 @@ test_machine_run_virtio_net_works() {
     }
 }
 
-test_machine_create_virtio_net_ports_rejected() {
+test_machine_run_virtio_net_port_publishing_works() {
     cleanup_machine
-    local vm_name="virtio-ports-test-$$"
-    local exit_code=0
-    local output
+    local host_port=$((41000 + ($$ % 10000)))
+    local serve_dir="$TEST_DIR/virtio-port-publish"
+    local run_log="$TEST_DIR/virtio-port-publish.log"
+    local run_pid=0
+    local curl_output=""
+    local ready=0
 
-    output=$($SMOLVM machine create "$vm_name" --net --net-backend virtio-net -p 18080:80 2>&1) || exit_code=$?
-    [[ $exit_code -ne 0 ]] || {
-        echo "expected create failure for virtio-net published port request"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    mkdir -p "$serve_dir"
+    printf 'virtio-port-ok\n' >"$serve_dir/index.html"
+
+    trap 'if [[ ${run_pid:-0} -ne 0 ]]; then kill "$run_pid" 2>/dev/null || true; wait "$run_pid" 2>/dev/null || true; fi; cleanup_machine' RETURN
+
+    $SMOLVM machine run \
+        --image "$VIRTIO_PUBLISH_TEST_IMAGE" \
+        --net \
+        --net-backend virtio-net \
+        -v "$serve_dir:/srv:ro" \
+        -p "${host_port}:8080" \
+        -- python -m http.server 8080 --directory /srv >"$run_log" 2>&1 &
+    run_pid=$!
+
+    for _ in $(seq 1 30); do
+        if curl_output=$(curl -fsS --connect-timeout 2 "http://127.0.0.1:${host_port}/" 2>&1); then
+            ready=1
+            break
+        fi
+        if ! kill -0 "$run_pid" 2>/dev/null; then
+            echo "virtio-net machine run exited before published port became reachable"
+            tail -20 "$run_log" 2>/dev/null || true
+            return 1
+        fi
+        sleep 1
+    done
+
+    [[ $ready -eq 1 ]] || {
+        echo "virtio-net published TCP port did not become reachable"
+        if [[ -n "$curl_output" ]]; then
+            echo "$curl_output"
+        fi
+        tail -20 "$run_log" 2>/dev/null || true
         return 1
     }
-    [[ "$output" == *"published ports are not supported"* ]] || {
-        echo "$output"
+
+    [[ "$curl_output" == *"virtio-port-ok"* ]] || {
+        echo "unexpected HTTP response from virtio-net published port"
+        echo "$curl_output"
         return 1
     }
+
+    trap - RETURN
+    kill "$run_pid" 2>/dev/null || true
+    wait "$run_pid" 2>/dev/null || true
+    cleanup_machine
 }
 
 test_machine_create_virtio_net_policy_rejected() {
@@ -206,7 +247,7 @@ test_pack_run_virtio_net_works() {
 run_test "Machine create: virtio-net works" test_machine_create_virtio_net_works || true
 run_test "Machine create/start/exec: virtio-net guest networking works" test_machine_create_start_exec_virtio_net_works || true
 run_test "Machine run: virtio-net guest networking works" test_machine_run_virtio_net_works || true
-run_test "Machine create: virtio-net + published ports rejected" test_machine_create_virtio_net_ports_rejected || true
+run_test "Machine run: virtio-net published TCP ports work" test_machine_run_virtio_net_port_publishing_works || true
 run_test "Machine create: virtio-net + policy rejected" test_machine_create_virtio_net_policy_rejected || true
 run_test "Pack run: virtio-net guest networking works" test_pack_run_virtio_net_works || true
 


### PR DESCRIPTION
### Inbound TCP Testing (Linux)

- Inside the VM (a python tcp server)

```
smolvm machine run --net --net-backend virtio-net -p 48082:8080 --image python:3.12-alpine -- python -m http.server 8080
Starting ephemeral machine...
Pulling image python:3.12-alpine...2026-04-21T22:51:45.564889Z  WARN using plaintext password from config — use password_env instead registry=docker.io
Pulling image python:3.12-alpine... done.   
```

- on the host:

```
qiaofu@ubuntu-node:~$ curl -fsS http://127.0.0.1:48082 
<!DOCTYPE HTML>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Directory listing for /</title>
</head>
<body>
<h1>Directory listing for /</h1>
<hr>
<ul>
<li><a href="bin/">bin/</a></li>
<li><a href="dev/">dev/</a></li>
<li><a href="etc/">etc/</a></li>
<li><a href="home/">home/</a></li>
<li><a href="lib/">lib/</a></li>
<li><a href="media/">media/</a></li>
<li><a href="mnt/">mnt/</a></li>
<li><a href="opt/">opt/</a></li>
<li><a href="proc/">proc/</a></li>
<li><a href="root/">root/</a></li>
<li><a href="run/">run/</a></li>
<li><a href="sbin/">sbin/</a></li>
<li><a href="srv/">srv/</a></li>
<li><a href="sys/">sys/</a></li>
<li><a href="tmp/">tmp/</a></li>
<li><a href="usr/">usr/</a></li>
<li><a href="var/">var/</a></li>
<li><a href="workspace/">workspace/</a></li>
</ul>
<hr>
</body>
</html>
```