### PR TITLE
Fix Linux libkrun bundle path in cargo make dev

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -20,11 +20,18 @@ skip_core_tasks = true
 [tasks.dev]
 description = "Build and codesign dev binary (macOS auto-signs)"
 category = "Development"
-env = { LIBKRUN_BUNDLE = "${CARGO_MAKE_WORKING_DIRECTORY}/lib" }
 
 script_runner = "bash"
 script = [
 '''
+if [ -z "${LIBKRUN_BUNDLE:-}" ]; then
+  if [ "$(uname -s)" = "Linux" ]; then
+    export LIBKRUN_BUNDLE="${CARGO_MAKE_WORKING_DIRECTORY}/lib/linux-$(uname -m)"
+  else
+    export LIBKRUN_BUNDLE="${CARGO_MAKE_WORKING_DIRECTORY}/lib"
+  fi
+fi
+
 cargo build --release
 if [ "$(uname -s)" = "Darwin" ]; then
   codesign --force --sign - --entitlements smolvm.entitlements ./target/release/smolvm


### PR DESCRIPTION
Use the architecture-specific bundled library directory on Linux so the dev build can find libkrun instead of failing to link against the macOS-style ./lib path.