### PR TITLE
Replace redb with SQLite for state persistence

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 toml = "0.8"
-redb = "2"
+rusqlite = { version = "0.32", features = ["bundled"] }
 libc = "0.2"
 dirs = "5"
 sha2 = "0.10"

--- a/src/agent/state_probe.rs
+++ b/src/agent/state_probe.rs
@@ -218,7 +218,7 @@ mod tests {
     #[test]
     fn unreachable_variant_round_trips_through_serde() {
         // The Unreachable variant must serialize cleanly so a record
-        // marked Unreachable in memory persists to redb correctly.
+        // marked Unreachable in memory persists to the database correctly.
         let r = record(RecordState::Unreachable, Some(12345));
         let json = serde_json::to_string(&r).unwrap();
         assert!(json.contains("\"state\":\"unreachable\""));

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -921,7 +921,7 @@ mod tests {
     #[allow(dead_code)]
     fn setup_test_state() -> (TempDir, Arc<ApiState>) {
         let dir = TempDir::new().expect("failed to create temp dir");
-        let db_path = dir.path().join("test.redb");
+        let db_path = dir.path().join("test.db");
         let db = SmolvmDb::open_at(&db_path).expect("failed to open test db");
         let state = Arc::new(ApiState::with_db(db));
         (dir, state)

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -843,7 +843,7 @@ mod tests {
     /// Create an ApiState with a temporary database for testing.
     fn temp_api_state() -> (TempDir, ApiState) {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("test.redb");
+        let path = dir.path().join("test.db");
         let db = SmolvmDb::open_at(&path).unwrap();
         (dir, ApiState::with_db(db))
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@
 //! This module handles persistent configuration storage for smolvm,
 //! including default settings and VM registry.
 //!
-//! State is persisted to a redb database at `~/.local/share/smolvm/server/smolvm.redb`.
+//! State is persisted to a SQLite database at `~/.local/share/smolvm/server/smolvm.db`.
 //! For backward compatibility, `SmolvmConfig` maintains an in-memory cache of VMs
 //! and provides the same API as the old confy-based implementation.
 
@@ -149,7 +149,7 @@ impl RestartConfig {
 /// Global smolvm configuration with database-backed persistence.
 ///
 /// This struct provides backward-compatible access to VM records while
-/// using redb for ACID-compliant storage. The `vms` field is an in-memory
+/// using SQLite for ACID-compliant storage. The `vms` field is an in-memory
 /// cache that is kept in sync with the database.
 #[derive(Debug, Clone)]
 pub struct SmolvmConfig {

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,50 +1,27 @@
 //! Database module for persistent state storage.
 //!
-//! This module provides ACID-compliant storage using redb for
-//! VM state persistence with atomic transactions and concurrent access safety.
+//! Provides ACID-compliant storage using SQLite for VM state persistence
+//! with atomic transactions and concurrent access safety.
 //!
-//! The database handle is cached for the lifetime of the `SmolvmDb` instance,
-//! amortising the ~3ms open + ~2-5ms close cost across all operations.
+//! The connection handle is cached for the lifetime of the `SmolvmDb`
+//! instance, amortising connection open cost across all operations.
+//!
+//! SQLite is configured in WAL mode with a 5s busy_timeout, so concurrent
+//! CLI invocations share the database file without manual retry logic.
 
 use crate::config::VmRecord;
 use crate::error::{Error, Result};
 use parking_lot::Mutex;
-use redb::{Database, ReadableTable, TableDefinition, TableError};
+use rusqlite::{params, Connection, OptionalExtension};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
-/// Maximum number of attempts to open the database when another process holds
-/// the lock. Each concurrent `smolvm` CLI invocation (e.g., parallel
-/// `machine start` calls) opens the database exclusively via redb's file lock.
-/// Without retry, the second process fails immediately with
-/// "Database already open. Cannot acquire lock."
-///
-/// With 10 retries and exponential backoff (50ms initial, 1s cap), the total
-/// wait before giving up is ~5 seconds — enough for any normal CLI operation
-/// to release the lock.
-const DB_OPEN_MAX_RETRIES: u32 = 10;
-
-/// Initial backoff delay between database open retries.
-/// Starts short (10ms) since typical DB operations complete in ~1-2ms.
-/// Doubles on each attempt: 10ms → 20ms → 40ms → 80ms → 160ms → 320ms → 640ms → 1000ms (capped).
-const DB_OPEN_INITIAL_BACKOFF: Duration = Duration::from_millis(10);
-
-/// Maximum backoff delay between retries. Prevents excessive wait on any
-/// single retry when the backoff would otherwise grow beyond this.
-const DB_OPEN_MAX_BACKOFF: Duration = Duration::from_secs(1);
-
-/// Check if a redb error indicates another process holds the database lock.
-fn is_lock_contention(e: &redb::DatabaseError) -> bool {
-    matches!(e, redb::DatabaseError::DatabaseAlreadyOpen)
-}
-
-/// Table for storing VM records (name -> JSON-serialized VmRecord).
-const VMS_TABLE: TableDefinition<&str, &[u8]> = TableDefinition::new("vms");
-
-/// Table for storing global configuration settings.
-const CONFIG_TABLE: TableDefinition<&str, &str> = TableDefinition::new("config");
+/// SQLite busy_timeout: how long a blocked writer waits for the write lock
+/// before returning SQLITE_BUSY. Replaces the per-process retry/backoff used
+/// with redb's exclusive file lock.
+const BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Extension trait to convert errors into `Error::database`.
 trait DbResultExt<T> {
@@ -59,16 +36,14 @@ impl<T, E: std::fmt::Display> DbResultExt<T> for std::result::Result<T, E> {
 
 /// Thread-safe database handle for smolvm state persistence.
 ///
-/// The redb `Database` handle is opened lazily on first use and cached for
-/// the lifetime of the `SmolvmDb` instance. This avoids the ~3ms open +
-/// ~2-5ms close overhead on every operation (benchmarked: read cycles drop
-/// from ~2ms to ~10us, write cycles from ~6.5ms to ~1.5ms).
+/// The SQLite `Connection` is opened lazily on first use and cached for the
+/// lifetime of the `SmolvmDb` instance. The Mutex serialises access within
+/// the process; cross-process concurrency is handled by SQLite's WAL mode
+/// and busy_timeout.
 #[derive(Clone)]
 pub struct SmolvmDb {
     path: PathBuf,
-    /// Cached database handle, opened lazily on first `with_db()` call.
-    /// The Mutex serializes all database access within the process.
-    handle: Arc<Mutex<Option<Database>>>,
+    handle: Arc<Mutex<Option<Connection>>>,
 }
 
 impl std::fmt::Debug for SmolvmDb {
@@ -81,58 +56,48 @@ impl std::fmt::Debug for SmolvmDb {
 }
 
 impl SmolvmDb {
-    /// Run a closure with the cached database handle, opening it on first use.
-    ///
-    /// If another process holds the database lock, retries with exponential
-    /// backoff rather than failing immediately. This allows concurrent CLI
-    /// commands (e.g., parallel `machine start` calls) to succeed.
-    fn with_db<T, F>(&self, f: F) -> Result<T>
+    /// Run a closure with the cached connection, opening it on first use.
+    fn with_conn<T, F>(&self, f: F) -> Result<T>
     where
-        F: FnOnce(&Database) -> Result<T>,
+        F: FnOnce(&mut Connection) -> Result<T>,
     {
         let mut guard = self.handle.lock();
         if guard.is_none() {
-            *guard = Some(Self::open_with_retry(&self.path)?);
+            *guard = Some(Self::open_connection(&self.path)?);
         }
-        f(guard.as_ref().unwrap())
+        f(guard.as_mut().unwrap())
     }
 
-    /// Open the database file, retrying with exponential backoff on lock contention.
-    ///
-    /// redb uses an exclusive file lock — only one process can have the database
-    /// open at a time. When multiple CLI commands run concurrently (e.g., parallel
-    /// `machine start` calls), the second process retries until the first releases
-    /// the lock. The API server avoids this entirely by holding a single long-lived
-    /// database connection.
-    fn open_with_retry(path: &Path) -> Result<Database> {
-        let mut backoff = DB_OPEN_INITIAL_BACKOFF;
-        for attempt in 0..=DB_OPEN_MAX_RETRIES {
-            match Database::create(path) {
-                Ok(db) => return Ok(db),
-                Err(e) if attempt < DB_OPEN_MAX_RETRIES && is_lock_contention(&e) => {
-                    tracing::debug!(
-                        attempt = attempt + 1,
-                        max = DB_OPEN_MAX_RETRIES,
-                        backoff_ms = backoff.as_millis(),
-                        "database locked by another process, retrying"
-                    );
-                    std::thread::sleep(backoff);
-                    backoff = std::cmp::min(backoff * 2, DB_OPEN_MAX_BACKOFF);
-                }
-                Err(e) => {
-                    return Err(Error::database_unavailable(format!("open database: {}", e)));
-                }
-            }
-        }
-        // All retries exhausted — the loop always returns on the last iteration
-        // (attempt == DB_OPEN_MAX_RETRIES falls through to the Err arm).
-        unreachable!()
+    /// Open the SQLite connection, configure pragmas, and ensure tables exist.
+    fn open_connection(path: &Path) -> Result<Connection> {
+        let conn = Connection::open(path)
+            .map_err(|e| Error::database_unavailable(format!("open database: {}", e)))?;
+
+        // WAL lets readers and writers overlap across processes; synchronous=NORMAL
+        // is safe under WAL and significantly faster than the default FULL.
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;")
+            .db_err("configure pragmas")?;
+        conn.busy_timeout(BUSY_TIMEOUT).db_err("set busy_timeout")?;
+
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS vms (
+                 name TEXT PRIMARY KEY NOT NULL,
+                 data BLOB NOT NULL
+             );
+             CREATE TABLE IF NOT EXISTS config (
+                 key TEXT PRIMARY KEY NOT NULL,
+                 value TEXT NOT NULL
+             );",
+        )
+        .db_err("create tables")?;
+
+        Ok(conn)
     }
 
     /// Open the database at the default location.
     ///
-    /// Default path: `~/Library/Application Support/smolvm/server/smolvm.redb` (macOS)
-    /// or `~/.local/share/smolvm/server/smolvm.redb` (Linux)
+    /// Default path: `~/Library/Application Support/smolvm/server/smolvm.db` (macOS)
+    /// or `~/.local/share/smolvm/server/smolvm.db` (Linux)
     ///
     /// If the database doesn't exist, it will be created.
     pub fn open() -> Result<Self> {
@@ -140,11 +105,8 @@ impl SmolvmDb {
         Self::open_at(&path)
     }
 
-    /// Open the database at a specific path.
-    ///
-    /// Creates parent directories but does NOT open the database file.
-    /// Tables are created lazily: write operations auto-create tables,
-    /// and read operations handle missing tables gracefully.
+    /// Open the database at a specific path. Parent directories are created
+    /// if missing; the connection itself is opened lazily on first use.
     pub fn open_at(path: &Path) -> Result<Self> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).db_err("create directory")?;
@@ -161,23 +123,15 @@ impl SmolvmDb {
         let data_dir = dirs::data_local_dir().ok_or_else(|| {
             Error::database_unavailable("could not determine local data directory")
         })?;
-        Ok(data_dir.join("smolvm").join("server").join("smolvm.redb"))
+        Ok(data_dir.join("smolvm").join("server").join("smolvm.db"))
     }
 
-    /// Initialize database tables (creates them if they don't exist).
+    /// Initialize database tables.
     ///
-    /// Call this at server startup for the API path. CLI paths handle
-    /// table creation lazily via write transactions and graceful reads.
+    /// Tables are created automatically when the connection opens, so this
+    /// just forces the connection open. Retained for API compatibility.
     pub fn init_tables(&self) -> Result<()> {
-        self.with_db(|db| {
-            let write_txn = db.begin_write().db_err("begin write transaction")?;
-            write_txn.open_table(VMS_TABLE).db_err("create vms table")?;
-            write_txn
-                .open_table(CONFIG_TABLE)
-                .db_err("create config table")?;
-            write_txn.commit().db_err("commit table creation")?;
-            Ok(())
-        })
+        self.with_conn(|_| Ok(()))
     }
 
     // ========================================================================
@@ -187,177 +141,151 @@ impl SmolvmDb {
     /// Insert or update a VM record.
     pub fn insert_vm(&self, name: &str, record: &VmRecord) -> Result<()> {
         let json = serde_json::to_vec(record).db_err("serialize vm record")?;
-
-        self.with_db(|db| {
-            let write_txn = db.begin_write().db_err("begin write transaction")?;
-            {
-                let mut table = write_txn.open_table(VMS_TABLE).db_err("open vms table")?;
-                table
-                    .insert(name, json.as_slice())
-                    .db_err(format!("insert vm '{}'", name))?;
-            }
-            write_txn.commit().db_err("commit vm insert")?;
+        self.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO vms (name, data) VALUES (?1, ?2)
+                 ON CONFLICT(name) DO UPDATE SET data = excluded.data",
+                params![name, json],
+            )
+            .db_err(format!("insert vm '{}'", name))?;
             Ok(())
         })
     }
 
     /// Insert a VM record only if it doesn't already exist.
     ///
-    /// Returns `Ok(true)` if inserted, `Ok(false)` if already exists.
-    /// This provides atomic conflict detection at the database level.
+    /// Returns `Ok(true)` if inserted, `Ok(false)` if the name already exists.
+    /// Atomicity is provided by SQLite's `INSERT OR IGNORE`.
     pub fn insert_vm_if_not_exists(&self, name: &str, record: &VmRecord) -> Result<bool> {
         let json = serde_json::to_vec(record).db_err("serialize vm record")?;
-
-        self.with_db(|db| {
-            let write_txn = db.begin_write().db_err("begin write transaction")?;
-
-            let inserted = {
-                let mut table = write_txn.open_table(VMS_TABLE).db_err("open vms table")?;
-                let exists = table
-                    .get(name)
-                    .db_err(format!("check vm '{}'", name))?
-                    .is_some();
-
-                if exists {
-                    false
-                } else {
-                    table
-                        .insert(name, json.as_slice())
-                        .db_err(format!("insert vm '{}'", name))?;
-                    true
-                }
-            };
-
-            write_txn.commit().db_err("commit vm insert")?;
-            Ok(inserted)
+        self.with_conn(|conn| {
+            let changed = conn
+                .execute(
+                    "INSERT OR IGNORE INTO vms (name, data) VALUES (?1, ?2)",
+                    params![name, json],
+                )
+                .db_err(format!("insert vm '{}'", name))?;
+            Ok(changed == 1)
         })
     }
 
     /// Get a VM record by name.
     pub fn get_vm(&self, name: &str) -> Result<Option<VmRecord>> {
-        self.with_db(|db| {
-            let read_txn = db.begin_read().db_err("begin read transaction")?;
-            let table = match read_txn.open_table(VMS_TABLE) {
-                Ok(t) => t,
-                Err(TableError::TableDoesNotExist(_)) => return Ok(None),
-                Err(e) => return Err(Error::database("open vms table", e.to_string())),
-            };
+        self.with_conn(|conn| {
+            let data: Option<Vec<u8>> = conn
+                .query_row(
+                    "SELECT data FROM vms WHERE name = ?1",
+                    params![name],
+                    |row| row.get(0),
+                )
+                .optional()
+                .db_err(format!("get vm '{}'", name))?;
 
-            match table.get(name) {
-                Ok(Some(guard)) => {
-                    let record: VmRecord = serde_json::from_slice(guard.value())
+            match data {
+                Some(bytes) => {
+                    let record: VmRecord = serde_json::from_slice(&bytes)
                         .db_err(format!("deserialize vm record '{}'", name))?;
                     Ok(Some(record))
                 }
-                Ok(None) => Ok(None),
-                Err(e) => Err(Error::database(format!("get vm '{}'", name), e.to_string())),
+                None => Ok(None),
             }
         })
     }
 
     /// Remove a VM record by name, returning the removed record if it existed.
     ///
-    /// Uses a single write transaction to atomically read and delete the record,
-    /// preventing TOCTOU races with concurrent writers.
+    /// Read + delete happen in a single transaction to prevent TOCTOU races.
     pub fn remove_vm(&self, name: &str) -> Result<Option<VmRecord>> {
-        self.with_db(|db| {
-            let write_txn = db.begin_write().db_err("begin write transaction")?;
+        self.with_conn(|conn| {
+            let tx = conn.transaction().db_err("begin transaction")?;
 
-            let existing = {
-                let mut table = write_txn.open_table(VMS_TABLE).db_err("open vms table")?;
+            let data: Option<Vec<u8>> = tx
+                .query_row(
+                    "SELECT data FROM vms WHERE name = ?1",
+                    params![name],
+                    |row| row.get(0),
+                )
+                .optional()
+                .db_err(format!("get vm '{}'", name))?;
 
-                // Read and deserialize first, releasing the AccessGuard before mutation
-                let record = {
-                    let get_result = table.get(name).db_err(format!("get vm '{}'", name))?;
-                    match get_result {
-                        Some(guard) => {
-                            let r: VmRecord = serde_json::from_slice(guard.value())
-                                .db_err(format!("deserialize vm record '{}'", name))?;
-                            Some(r)
-                        }
-                        None => None,
-                    }
-                };
-
-                // Now safe to mutate — AccessGuard is dropped
-                if record.is_some() {
-                    table.remove(name).db_err(format!("remove vm '{}'", name))?;
+            let record = match data {
+                Some(bytes) => {
+                    let r: VmRecord = serde_json::from_slice(&bytes)
+                        .db_err(format!("deserialize vm record '{}'", name))?;
+                    tx.execute("DELETE FROM vms WHERE name = ?1", params![name])
+                        .db_err(format!("remove vm '{}'", name))?;
+                    Some(r)
                 }
-                record
+                None => None,
             };
 
-            write_txn.commit().db_err("commit vm removal")?;
-            Ok(existing)
+            tx.commit().db_err("commit vm removal")?;
+            Ok(record)
         })
     }
 
     /// List all VM records.
     pub fn list_vms(&self) -> Result<Vec<(String, VmRecord)>> {
-        self.with_db(|db| {
-            let read_txn = db.begin_read().db_err("begin read transaction")?;
-            let table = match read_txn.open_table(VMS_TABLE) {
-                Ok(t) => t,
-                Err(TableError::TableDoesNotExist(_)) => return Ok(Vec::new()),
-                Err(e) => return Err(Error::database("open vms table", e.to_string())),
-            };
+        self.with_conn(|conn| {
+            let mut stmt = conn
+                .prepare_cached("SELECT name, data FROM vms")
+                .db_err("prepare list_vms")?;
+            let rows = stmt
+                .query_map([], |row| {
+                    let name: String = row.get(0)?;
+                    let data: Vec<u8> = row.get(1)?;
+                    Ok((name, data))
+                })
+                .db_err("query vms")?;
 
             let mut vms = Vec::new();
-            for entry in table.iter().db_err("iterate vms table")? {
-                let (key, value) = entry.db_err("read vms entry")?;
-                let name = key.value().to_string();
-                let record: VmRecord = serde_json::from_slice(value.value())
+            for row in rows {
+                let (name, data) = row.db_err("read vms row")?;
+                let record: VmRecord = serde_json::from_slice(&data)
                     .db_err(format!("deserialize vm record '{}'", name))?;
                 vms.push((name, record));
             }
-
             Ok(vms)
         })
     }
 
     /// Update a VM record in place using a closure.
     ///
-    /// Returns the updated record if found, `None` if not found.
-    ///
-    /// Uses a single write transaction to atomically read, mutate, and write back,
-    /// preventing lost updates from concurrent writers.
+    /// Returns the updated record if found, `None` if not found. Read +
+    /// write happen in a single transaction to prevent lost updates.
     pub fn update_vm<F>(&self, name: &str, f: F) -> Result<Option<VmRecord>>
     where
         F: FnOnce(&mut VmRecord),
     {
-        self.with_db(|db| {
-            let write_txn = db.begin_write().db_err("begin write transaction")?;
+        self.with_conn(|conn| {
+            let tx = conn.transaction().db_err("begin transaction")?;
 
-            let updated = {
-                let mut table = write_txn.open_table(VMS_TABLE).db_err("open vms table")?;
+            let data: Option<Vec<u8>> = tx
+                .query_row(
+                    "SELECT data FROM vms WHERE name = ?1",
+                    params![name],
+                    |row| row.get(0),
+                )
+                .optional()
+                .db_err(format!("get vm '{}'", name))?;
 
-                // Read and deserialize first, releasing the AccessGuard before mutation
-                let record = {
-                    let get_result = table.get(name).db_err(format!("get vm '{}'", name))?;
-                    match get_result {
-                        Some(guard) => {
-                            let r: VmRecord = serde_json::from_slice(guard.value())
-                                .db_err(format!("deserialize vm record '{}'", name))?;
-                            Some(r)
-                        }
-                        None => None,
-                    }
-                };
-
-                // Now safe to mutate — AccessGuard is dropped
-                match record {
-                    Some(mut record) => {
-                        f(&mut record);
-                        let json = serde_json::to_vec(&record).db_err("serialize vm record")?;
-                        table
-                            .insert(name, json.as_slice())
-                            .db_err(format!("update vm '{}'", name))?;
-                        Some(record)
-                    }
-                    None => None,
+            let updated = match data {
+                Some(bytes) => {
+                    let mut record: VmRecord = serde_json::from_slice(&bytes)
+                        .db_err(format!("deserialize vm record '{}'", name))?;
+                    f(&mut record);
+                    let new_data = serde_json::to_vec(&record).db_err("serialize vm record")?;
+                    tx.execute(
+                        "UPDATE vms SET data = ?2 WHERE name = ?1",
+                        params![name, new_data],
+                    )
+                    .db_err(format!("update vm '{}'", name))?;
+                    Some(record)
                 }
+                None => None,
             };
 
-            write_txn.commit().db_err("commit vm update")?;
+            tx.commit().db_err("commit vm update")?;
             Ok(updated)
         })
     }
@@ -368,67 +296,71 @@ impl SmolvmDb {
         Ok(vms.into_iter().collect())
     }
 
-    /// Load all config settings and VM records in a single database open.
-    ///
-    /// Reads all config keys and all VM records in one `with_db()` call,
-    /// replacing separate `get_config()` × N + `load_all_vms()` calls
-    /// that would each open/close the database independently.
-    /// Handles missing tables gracefully (returns empty maps for fresh DBs).
+    /// Load all config settings and VM records in a single transaction.
     pub fn load_all(&self) -> Result<(HashMap<String, String>, HashMap<String, VmRecord>)> {
-        self.with_db(|db| {
-            let read_txn = db.begin_read().db_err("begin read transaction")?;
+        self.with_conn(|conn| {
+            let tx = conn.transaction().db_err("begin read transaction")?;
 
-            // Read all config keys (empty if table doesn't exist yet)
             let mut config = HashMap::new();
-            match read_txn.open_table(CONFIG_TABLE) {
-                Ok(config_table) => {
-                    for entry in config_table.iter().db_err("iterate config table")? {
-                        let (key, value) = entry.db_err("read config entry")?;
-                        config.insert(key.value().to_string(), value.value().to_string());
-                    }
+            {
+                let mut stmt = tx
+                    .prepare_cached("SELECT key, value FROM config")
+                    .db_err("prepare list config")?;
+                let rows = stmt
+                    .query_map([], |row| {
+                        let k: String = row.get(0)?;
+                        let v: String = row.get(1)?;
+                        Ok((k, v))
+                    })
+                    .db_err("query config")?;
+                for row in rows {
+                    let (k, v) = row.db_err("read config row")?;
+                    config.insert(k, v);
                 }
-                Err(TableError::TableDoesNotExist(_)) => {}
-                Err(e) => return Err(Error::database("open config table", e.to_string())),
             }
 
-            // Read all VMs (empty if table doesn't exist yet)
             let mut vms = HashMap::new();
-            match read_txn.open_table(VMS_TABLE) {
-                Ok(vms_table) => {
-                    for entry in vms_table.iter().db_err("iterate vms table")? {
-                        let (key, value) = entry.db_err("read vms entry")?;
-                        let name = key.value().to_string();
-                        let record: VmRecord = serde_json::from_slice(value.value())
-                            .db_err(format!("deserialize vm record '{}'", name))?;
-                        vms.insert(name, record);
-                    }
+            {
+                let mut stmt = tx
+                    .prepare_cached("SELECT name, data FROM vms")
+                    .db_err("prepare list vms")?;
+                let rows = stmt
+                    .query_map([], |row| {
+                        let name: String = row.get(0)?;
+                        let data: Vec<u8> = row.get(1)?;
+                        Ok((name, data))
+                    })
+                    .db_err("query vms")?;
+                for row in rows {
+                    let (name, data) = row.db_err("read vms row")?;
+                    let record: VmRecord = serde_json::from_slice(&data)
+                        .db_err(format!("deserialize vm record '{}'", name))?;
+                    vms.insert(name, record);
                 }
-                Err(TableError::TableDoesNotExist(_)) => {}
-                Err(e) => return Err(Error::database("open vms table", e.to_string())),
             }
 
+            tx.commit().db_err("commit read transaction")?;
             Ok((config, vms))
         })
     }
 
     /// Save multiple config key-value pairs in a single transaction.
-    ///
-    /// Replaces calling `set_config()` × N separately, reducing N open/close
-    /// cycles to 1.
     pub fn save_config(&self, settings: &[(&str, &str)]) -> Result<()> {
-        self.with_db(|db| {
-            let write_txn = db.begin_write().db_err("begin write transaction")?;
+        self.with_conn(|conn| {
+            let tx = conn.transaction().db_err("begin transaction")?;
             {
-                let mut table = write_txn
-                    .open_table(CONFIG_TABLE)
-                    .db_err("open config table")?;
-                for (key, value) in settings {
-                    table
-                        .insert(*key, *value)
-                        .db_err(format!("set config '{}'", key))?;
+                let mut stmt = tx
+                    .prepare_cached(
+                        "INSERT INTO config (key, value) VALUES (?1, ?2)
+                         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                    )
+                    .db_err("prepare set config")?;
+                for (k, v) in settings {
+                    stmt.execute(params![k, v])
+                        .db_err(format!("set config '{}'", k))?;
                 }
             }
-            write_txn.commit().db_err("commit config save")?;
+            tx.commit().db_err("commit config save")?;
             Ok(())
         })
     }
@@ -439,38 +371,26 @@ impl SmolvmDb {
 
     /// Get a global configuration value.
     pub fn get_config(&self, key: &str) -> Result<Option<String>> {
-        self.with_db(|db| {
-            let read_txn = db.begin_read().db_err("begin read transaction")?;
-            let table = match read_txn.open_table(CONFIG_TABLE) {
-                Ok(t) => t,
-                Err(TableError::TableDoesNotExist(_)) => return Ok(None),
-                Err(e) => return Err(Error::database("open config table", e.to_string())),
-            };
-
-            match table.get(key) {
-                Ok(Some(guard)) => Ok(Some(guard.value().to_string())),
-                Ok(None) => Ok(None),
-                Err(e) => Err(Error::database(
-                    format!("get config '{}'", key),
-                    e.to_string(),
-                )),
-            }
+        self.with_conn(|conn| {
+            conn.query_row(
+                "SELECT value FROM config WHERE key = ?1",
+                params![key],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .db_err(format!("get config '{}'", key))
         })
     }
 
     /// Set a global configuration value.
     pub fn set_config(&self, key: &str, value: &str) -> Result<()> {
-        self.with_db(|db| {
-            let write_txn = db.begin_write().db_err("begin write transaction")?;
-            {
-                let mut table = write_txn
-                    .open_table(CONFIG_TABLE)
-                    .db_err("open config table")?;
-                table
-                    .insert(key, value)
-                    .db_err(format!("set config '{}'", key))?;
-            }
-            write_txn.commit().db_err("commit config set")?;
+        self.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO config (key, value) VALUES (?1, ?2)
+                 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                params![key, value],
+            )
+            .db_err(format!("set config '{}'", key))?;
             Ok(())
         })
     }
@@ -484,7 +404,7 @@ mod tests {
 
     fn temp_db() -> (TempDir, SmolvmDb) {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("test.redb");
+        let path = dir.path().join("test.db");
         let db = SmolvmDb::open_at(&path).unwrap();
         (dir, db)
     }
@@ -493,7 +413,6 @@ mod tests {
     fn test_db_crud_operations() {
         let (_dir, db) = temp_db();
 
-        // Create a VM record
         let record = VmRecord::new(
             "test-vm".to_string(),
             2,
@@ -503,16 +422,13 @@ mod tests {
             false,
         );
 
-        // Insert
         db.insert_vm("test-vm", &record).unwrap();
 
-        // Get
         let retrieved = db.get_vm("test-vm").unwrap().unwrap();
         assert_eq!(retrieved.name, "test-vm");
         assert_eq!(retrieved.cpus, 2);
         assert_eq!(retrieved.mem, 1024);
 
-        // Update — returns the mutated record
         let updated = db
             .update_vm("test-vm", |r| {
                 r.state = RecordState::Running;
@@ -523,16 +439,13 @@ mod tests {
         assert_eq!(updated.state, RecordState::Running);
         assert_eq!(updated.pid, Some(12345));
 
-        // List
         let vms = db.list_vms().unwrap();
         assert_eq!(vms.len(), 1);
         assert_eq!(vms[0].0, "test-vm");
 
-        // Remove
         let removed = db.remove_vm("test-vm").unwrap().unwrap();
         assert_eq!(removed.name, "test-vm");
 
-        // Verify removed
         assert!(db.get_vm("test-vm").unwrap().is_none());
     }
 
@@ -540,7 +453,6 @@ mod tests {
     fn test_db_concurrent_access() {
         let (_dir, db) = temp_db();
 
-        // Create multiple VMs from different threads
         let handles: Vec<_> = (0..10)
             .map(|i| {
                 let db = db.clone();
@@ -556,7 +468,6 @@ mod tests {
             handle.join().unwrap();
         }
 
-        // Verify all VMs were created
         let vms = db.list_vms().unwrap();
         assert_eq!(vms.len(), 10);
     }
@@ -565,14 +476,11 @@ mod tests {
     fn test_config_settings() {
         let (_dir, db) = temp_db();
 
-        // Set config
         db.set_config("test_key", "test_value").unwrap();
 
-        // Get config
         let value = db.get_config("test_key").unwrap().unwrap();
         assert_eq!(value, "test_value");
 
-        // Get non-existent config
         assert!(db.get_config("nonexistent").unwrap().is_none());
     }
 
@@ -580,7 +488,6 @@ mod tests {
     fn test_update_nonexistent_vm() {
         let (_dir, db) = temp_db();
 
-        // Update should return None for non-existent VM
         let result = db.update_vm("nonexistent", |_| {}).unwrap();
         assert!(result.is_none());
     }
@@ -589,7 +496,6 @@ mod tests {
     fn test_remove_nonexistent_vm() {
         let (_dir, db) = temp_db();
 
-        // Remove should return None for non-existent VM
         let result = db.remove_vm("nonexistent").unwrap();
         assert!(result.is_none());
     }
@@ -600,19 +506,15 @@ mod tests {
 
         let record = VmRecord::new("test-vm".to_string(), 1, 512, vec![], vec![], false);
 
-        // First insert should succeed
         let inserted = db.insert_vm_if_not_exists("test-vm", &record).unwrap();
         assert!(inserted, "first insert should succeed");
 
-        // Second insert with same name should return false
         let inserted = db.insert_vm_if_not_exists("test-vm", &record).unwrap();
         assert!(!inserted, "second insert should fail (already exists)");
 
-        // Verify only one VM exists
         let vms = db.list_vms().unwrap();
         assert_eq!(vms.len(), 1);
 
-        // Different name should succeed
         let record2 = VmRecord::new("test-vm2".to_string(), 2, 1024, vec![], vec![], false);
         let inserted = db.insert_vm_if_not_exists("test-vm2", &record2).unwrap();
         assert!(inserted, "different name should succeed");
@@ -625,7 +527,6 @@ mod tests {
     fn test_insert_vm_if_not_exists_concurrent() {
         let (_dir, db) = temp_db();
 
-        // Try to insert the same name from multiple threads
         let handles: Vec<_> = (0..10)
             .map(|_| {
                 let db = db.clone();
@@ -640,11 +541,9 @@ mod tests {
 
         let results: Vec<bool> = handles.into_iter().map(|h| h.join().unwrap()).collect();
 
-        // Exactly one should have succeeded
         let success_count = results.iter().filter(|&&r| r).count();
         assert_eq!(success_count, 1, "exactly one insert should succeed");
 
-        // Verify only one VM exists
         let vms = db.list_vms().unwrap();
         assert_eq!(vms.len(), 1);
     }

--- a/src/embedded/control.rs
+++ b/src/embedded/control.rs
@@ -170,7 +170,7 @@ mod tests {
             .unwrap()
             .as_nanos();
         let path = std::env::temp_dir().join(format!(
-            "smolvm-embedded-control-{}-{}.redb",
+            "smolvm-embedded-control-{}-{}.db",
             std::process::id(),
             unique
         ));

--- a/src/embedded/runtime.rs
+++ b/src/embedded/runtime.rs
@@ -338,7 +338,7 @@ mod tests {
             .unwrap()
             .as_nanos();
         let path = std::env::temp_dir().join(format!(
-            "smolvm-embedded-runtime-{}-{}.redb",
+            "smolvm-embedded-runtime-{}-{}.db",
             std::process::id(),
             unique
         ));


### PR DESCRIPTION
### Summary

  Replace redb with SQLite (rusqlite, bundled) as the SmolvmDb backend. WAL mode +
  busy_timeout=5s lets multiple processes share the DB concurrently, which fixes the
  single-writer contention bugs plaguing parallel CLI calls and the API-server-vs-CLI
  lockout.

  Closes #178 · Closes #14

 ### Why

  redb takes an exclusive file lock. Consequences:

  - #178 - concurrent machine {create,start,stop,delete} calls fail immediately with
  Database already open. Callers are forced to serialize externally.
  - #14 - running smolvm serve blocks every CLI command until the server exits.

  The redb code has a retry-on-open loop, but it can't help when a long-lived process
  holds the file.

### How

  - PRAGMA journal_mode=WAL — concurrent readers + serialized cross-process writers
  - busy_timeout=5000 — in-engine contention handling; the hand-rolled retry loop is gone
  - Public SmolvmDb API (all 14 methods) unchanged; callers unmodified. VmRecord still
  stored as JSON in a BLOB column.

###  Behavior changes

  - Cross-process concurrency works. CLI + server, or parallel CLIs, no longer fight.
  - Default DB file is smolvm.db, not smolvm.redb. No auto-migration — fresh installs
  start empty. Happy to add a one-shot importer if needed.
  - WAL creates smolvm.db-wal / -shm sidecars next to the main file during runtime.

### Tests

  All 218 library tests pass. The existing concurrent-access tests
  (test_db_concurrent_access, test_insert_vm_if_not_exists_concurrent) previously
  serialized through redb's mutex and now actually run in parallel.

### Open Questions

One thing that could still be done here is easily handle the migration between redb and sqlite.  

---
AI disclamer.  I did have Claude help with this change.  But tested it extensively along with some other changes i'll open in other PRs