### PR TITLE
 fix: machine run -d / exec / stop round-trip matches docker run -d semantics

### DIFF
--- a/crates/smolvm-agent/src/crun.rs
+++ b/crates/smolvm-agent/src/crun.rs
@@ -224,6 +224,23 @@ impl CrunCommand {
         self
     }
 
+    /// Register a closure to run in the child after `fork` but before
+    /// `exec`. Only async-signal-safe calls are permitted inside.
+    ///
+    /// # Safety
+    /// The closure must only call async-signal-safe functions — see
+    /// `signal-safety(7)`. Violating that can deadlock or corrupt the
+    /// child process.
+    #[cfg(unix)]
+    pub unsafe fn pre_exec<F>(mut self, f: F) -> Self
+    where
+        F: FnMut() -> std::io::Result<()> + Send + Sync + 'static,
+    {
+        use std::os::unix::process::CommandExt;
+        self.cmd.pre_exec(f);
+        self
+    }
+
     /// Spawn the command.
     pub fn spawn(mut self) -> std::io::Result<std::process::Child> {
         self.cmd.spawn()

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -1238,6 +1238,16 @@ fn handle_connection(stream: &mut impl ReadWrite) -> Result<(), Box<dyn std::err
             continue;
         }
 
+        // Interactive exec-into-container (`crun exec --tty` style).
+        if let AgentRequest::ExecContainer {
+            interactive: true, ..
+        }
+        | AgentRequest::ExecContainer { tty: true, .. } = &request
+        {
+            handle_interactive_exec_container(stream, request)?;
+            continue;
+        }
+
         // Handle Pull with progress streaming
         if let AgentRequest::Pull {
             ref image,
@@ -3795,6 +3805,135 @@ fn handle_vm_exec(
         stdout,
         stderr,
     }
+}
+
+/// Handle interactive `exec` inside an already-running container.
+///
+/// Mirrors `handle_interactive_vm_exec` but spawns `crun exec` so the
+/// command joins the container's namespaces. Allocates a PTY on the
+/// agent side when `tty` is set and attaches the slave to crun's stdio
+/// so terminal features (controlling tty, signal-forwarding, SIGWINCH)
+/// work as expected for `machine exec -it -- /bin/sh`.
+fn handle_interactive_exec_container(
+    stream: &mut impl ReadWrite,
+    request: AgentRequest,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (container_id, command, env, workdir, timeout_ms, tty) = match request {
+        AgentRequest::ExecContainer {
+            container_id,
+            command,
+            env,
+            workdir,
+            timeout_ms,
+            tty,
+            ..
+        } => (container_id, command, env, workdir, timeout_ms, tty),
+        _ => {
+            send_response(
+                stream,
+                &AgentResponse::error(
+                    "expected ExecContainer request",
+                    error_codes::INVALID_REQUEST,
+                ),
+            )?;
+            return Ok(());
+        }
+    };
+
+    info!(container_id = %container_id, command = ?command, tty = tty, "starting interactive exec in container");
+
+    if command.is_empty() {
+        send_response(
+            stream,
+            &AgentResponse::error("command cannot be empty", error_codes::INVALID_REQUEST),
+        )?;
+        return Ok(());
+    }
+
+    let (mut child, pty_master) = match spawn_crun_exec_interactive(
+        &container_id,
+        &command,
+        &env,
+        workdir.as_deref(),
+        tty,
+    ) {
+        Ok(result) => result,
+        Err(e) => {
+            send_response(
+                stream,
+                &AgentResponse::from_err(e, error_codes::SPAWN_FAILED),
+            )?;
+            return Ok(());
+        }
+    };
+
+    send_response(stream, &AgentResponse::Started)?;
+
+    let exit_code = match pty_master {
+        #[cfg(target_os = "linux")]
+        Some(pty) => run_interactive_loop_pty(stream, &mut child, pty, timeout_ms)?,
+        _ => run_interactive_loop(stream, &mut child, timeout_ms)?,
+    };
+
+    send_response(stream, &AgentResponse::Exited { exit_code })?;
+    Ok(())
+}
+
+/// Spawn `crun exec` with an optional PTY attached to the child's stdio.
+///
+/// Mirrors `spawn_direct_interactive_command` but routes through
+/// `CrunCommand::exec` so the command joins an existing container.
+#[cfg(target_os = "linux")]
+fn spawn_crun_exec_interactive(
+    container_id: &str,
+    command: &[String],
+    env: &[(String, String)],
+    workdir: Option<&str>,
+    tty: bool,
+) -> Result<(Child, Option<pty::PtyMaster>), Box<dyn std::error::Error>> {
+    use std::os::unix::io::AsRawFd as _;
+
+    let builder = crate::crun::CrunCommand::exec(container_id, env, command, workdir, tty);
+
+    if tty {
+        let (pty_master, slave_fd) = pty::open_pty(80, 24)?;
+        let slave_raw = slave_fd.as_raw_fd();
+
+        // SAFETY: slave_raw comes from `open_pty` so it's a valid open fd.
+        // dup() three times so each stdio handle owns its own copy; the
+        // original slave_fd is dropped after spawn so only the child holds
+        // references.
+        let child = unsafe {
+            builder
+                .stdin_from_fd(libc::dup(slave_raw))
+                .stdout_from_fd(libc::dup(slave_raw))
+                .stderr_from_fd(libc::dup(slave_raw))
+                .pre_exec(pty::slave_pre_exec(slave_raw))
+                .spawn()
+        }?;
+
+        drop(slave_fd);
+        Ok((child, Some(pty_master)))
+    } else {
+        let child = builder.stdin_piped().capture_output().spawn()?;
+        Ok((child, None))
+    }
+}
+
+/// Stub for non-Linux platforms. PTY work only happens on Linux since
+/// the agent is Linux-only in production; this keeps the code compilable
+/// when `cargo check`ing from a macOS host.
+#[cfg(not(target_os = "linux"))]
+fn spawn_crun_exec_interactive(
+    container_id: &str,
+    command: &[String],
+    env: &[(String, String)],
+    workdir: Option<&str>,
+    _tty: bool,
+) -> Result<(Child, Option<()>), Box<dyn std::error::Error>> {
+    let builder = crate::crun::CrunCommand::exec(container_id, env, command, workdir, false);
+    let child = builder.stdin_piped().capture_output().spawn()?;
+    Ok((child, None))
 }
 
 /// Handle interactive VM-level exec with streaming I/O.

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -1482,16 +1482,30 @@ fn handle_request(
             interactive: false,
             tty: false,
             persistent_overlay_id,
-        } => handle_run(
-            &image,
-            &command,
-            &env,
-            workdir.as_deref(),
-            &mounts,
-            timeout_ms,
-            persistent_overlay_id.as_deref(),
-            client_fd,
-        ),
+            background,
+        } => {
+            if background {
+                handle_run_background(
+                    &image,
+                    &command,
+                    &env,
+                    workdir.as_deref(),
+                    &mounts,
+                    persistent_overlay_id.as_deref(),
+                )
+            } else {
+                handle_run(
+                    &image,
+                    &command,
+                    &env,
+                    workdir.as_deref(),
+                    &mounts,
+                    timeout_ms,
+                    persistent_overlay_id.as_deref(),
+                    client_fd,
+                )
+            }
+        }
 
         AgentRequest::Run { .. } => {
             // Interactive mode should be handled by handle_interactive_run
@@ -3148,6 +3162,39 @@ fn test_tcp_syscall(target: &str) -> serde_json::Value {
 }
 
 /// Handle command execution request (non-interactive).
+/// Handle a background `Run` request — spawn the container and return its PID.
+///
+/// Background mode requires a persistent overlay ID; an ephemeral overlay
+/// would leak because nothing waits for the container to exit to clean it
+/// up. The returned PID is the crun process, which stays alive as long as
+/// the container's init process runs.
+fn handle_run_background(
+    image: &str,
+    command: &[String],
+    env: &[(String, String)],
+    workdir: Option<&str>,
+    mounts: &[(String, String, bool)],
+    persistent_overlay_id: Option<&str>,
+) -> AgentResponse {
+    info!(image = %image, command = ?command, mounts = ?mounts, "running command in background");
+
+    let Some(overlay_id) = persistent_overlay_id else {
+        return AgentResponse::error(
+            "background run requires persistent_overlay_id",
+            error_codes::INVALID_REQUEST,
+        );
+    };
+
+    match storage::spawn_in_overlay(image, command, env, workdir, mounts, overlay_id) {
+        Ok(pid) => AgentResponse::Completed {
+            exit_code: 0,
+            stdout: format!("{}", pid).into_bytes(),
+            stderr: Vec::new(),
+        },
+        Err(e) => AgentResponse::from_err(e, error_codes::RUN_FAILED),
+    }
+}
+
 fn handle_run(
     image: &str,
     command: &[String],

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -1489,6 +1489,7 @@ fn handle_request(
             interactive: false,
             tty: false,
             persistent_overlay_id,
+            container_id,
             background,
         } => {
             if background {
@@ -1499,6 +1500,7 @@ fn handle_request(
                     workdir.as_deref(),
                     &mounts,
                     persistent_overlay_id.as_deref(),
+                    container_id.as_deref(),
                 )
             } else {
                 handle_run(
@@ -1509,9 +1511,35 @@ fn handle_request(
                     &mounts,
                     timeout_ms,
                     persistent_overlay_id.as_deref(),
+                    container_id.as_deref(),
                     client_fd,
                 )
             }
+        }
+
+        AgentRequest::ExecContainer {
+            container_id,
+            command,
+            env,
+            workdir,
+            timeout_ms,
+            interactive: false,
+            tty: false,
+        } => handle_exec_container(
+            &container_id,
+            &command,
+            &env,
+            workdir.as_deref(),
+            timeout_ms,
+            client_fd,
+        ),
+
+        AgentRequest::ExecContainer { .. } => {
+            // Interactive mode is handled separately by handle_interactive_exec_container
+            AgentResponse::error(
+                "interactive exec must be handled by handle_interactive_exec_container",
+                error_codes::INTERNAL_ERROR,
+            )
         }
 
         AgentRequest::Run { .. } => {
@@ -3182,8 +3210,9 @@ fn handle_run_background(
     workdir: Option<&str>,
     mounts: &[(String, String, bool)],
     persistent_overlay_id: Option<&str>,
+    container_id: Option<&str>,
 ) -> AgentResponse {
-    info!(image = %image, command = ?command, mounts = ?mounts, "running command in background");
+    info!(image = %image, command = ?command, mounts = ?mounts, container_id = ?container_id, "running command in background");
 
     let Some(overlay_id) = persistent_overlay_id else {
         return AgentResponse::error(
@@ -3192,7 +3221,8 @@ fn handle_run_background(
         );
     };
 
-    match storage::spawn_in_overlay(image, command, env, workdir, mounts, overlay_id) {
+    match storage::spawn_in_overlay(image, command, env, workdir, mounts, overlay_id, container_id)
+    {
         Ok(pid) => {
             // The crun process is now an orphaned child of the agent.
             // Register it so reap_background_children() collects its
@@ -3208,6 +3238,96 @@ fn handle_run_background(
     }
 }
 
+/// Handle `ExecContainer` — `crun exec <container_id> <command>`.
+///
+/// The command joins the main container's PID / mount / cgroup namespaces,
+/// so `ps -ef` sees the container's init process and sibling execs, and
+/// signals cross process boundaries. This is the "one container per VM"
+/// model that matches the project README — `machine exec` joins the
+/// workload started by `machine run -d`, it doesn't spawn a sibling.
+fn handle_exec_container(
+    container_id: &str,
+    command: &[String],
+    env: &[(String, String)],
+    workdir: Option<&str>,
+    timeout_ms: Option<u64>,
+    client_fd: Option<std::os::unix::io::RawFd>,
+) -> AgentResponse {
+    info!(container_id = %container_id, command = ?command, timeout_ms = ?timeout_ms, "exec in container");
+
+    if command.is_empty() {
+        return AgentResponse::error("command cannot be empty", error_codes::INVALID_REQUEST);
+    }
+
+    let mut child = match crate::crun::CrunCommand::exec(container_id, env, command, workdir, false)
+        .stdin_null()
+        .capture_output()
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            return AgentResponse::error(
+                format!("failed to spawn crun exec: {}", e),
+                error_codes::SPAWN_FAILED,
+            );
+        }
+    };
+
+    // Wait with timeout + client liveness. No container-level teardown on
+    // timeout — that would kill the whole main container; we only kill
+    // the exec invocation. `child.kill()` is captured via raw libc since
+    // we can't re-borrow `child` inside the closure.
+    let child_pid = child.id() as libc::pid_t;
+    let result = match crate::process::wait_with_timeout_cleanup_and_liveness(
+        &mut child,
+        timeout_ms,
+        client_fd,
+        || {
+            // SAFETY: kill() with SIGKILL on a PID we just spawned is
+            // safe; the PID is valid until we waitpid() it below.
+            unsafe {
+                libc::kill(child_pid, libc::SIGKILL);
+            }
+        },
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            return AgentResponse::error(
+                format!("wait for crun exec failed: {}", e),
+                error_codes::RUN_FAILED,
+            );
+        }
+    };
+
+    match result {
+        crate::process::WaitResult::Completed { exit_code, output } => AgentResponse::Completed {
+            exit_code,
+            stdout: output.stdout,
+            stderr: output.stderr,
+        },
+        crate::process::WaitResult::TimedOut { output, timeout_ms } => {
+            let mut stderr = output.stderr;
+            stderr.extend_from_slice(
+                format!("\nexec timed out after {}ms", timeout_ms).as_bytes(),
+            );
+            AgentResponse::Completed {
+                exit_code: 124,
+                stdout: output.stdout,
+                stderr,
+            }
+        }
+        crate::process::WaitResult::ClientDisconnected { output } => {
+            let mut stderr = output.stderr;
+            stderr.extend_from_slice(b"\nexec killed: client disconnected");
+            AgentResponse::Completed {
+                exit_code: 129,
+                stdout: output.stdout,
+                stderr,
+            }
+        }
+    }
+}
+
 fn handle_run(
     image: &str,
     command: &[String],
@@ -3216,9 +3336,10 @@ fn handle_run(
     mounts: &[(String, String, bool)],
     timeout_ms: Option<u64>,
     persistent_overlay_id: Option<&str>,
+    container_id: Option<&str>,
     client_fd: Option<std::os::unix::io::RawFd>,
 ) -> AgentResponse {
-    info!(image = %image, command = ?command, mounts = ?mounts, timeout_ms = ?timeout_ms, persistent = persistent_overlay_id.is_some(), "running command");
+    info!(image = %image, command = ?command, mounts = ?mounts, timeout_ms = ?timeout_ms, persistent = persistent_overlay_id.is_some(), container_id = ?container_id, "running command");
 
     match storage::run_command(
         image,
@@ -3228,6 +3349,7 @@ fn handle_run(
         mounts,
         timeout_ms,
         persistent_overlay_id,
+        container_id,
         client_fd,
     ) {
         Ok(result) => AgentResponse::Completed {

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -1105,7 +1105,7 @@ fn run_server_with_listener(
     info!(uptime_ms = uptime_ms(), "entering vsock accept loop");
 
     loop {
-        // Reap any exited background children to prevent zombie accumulation
+        // Reap any exited background children to prevent zombie accumulation.
         reap_background_children();
 
         match listener.accept() {
@@ -1120,9 +1120,16 @@ fn run_server_with_listener(
                 }
                 info!("accepted connection");
 
-                if let Err(e) = handle_connection(&mut stream) {
-                    warn!(error = %e, "connection error");
-                }
+                // Service the connection in its own thread so a long-running
+                // exec doesn't block subsequent requests on the same listener.
+                // Before this landed, a single held-open `machine exec` would
+                // stall the 250ms state probe, flip the VM to Unreachable,
+                // and make every following exec fail with "not running".
+                std::thread::spawn(move || {
+                    if let Err(e) = handle_connection(&mut stream) {
+                        warn!(error = %e, "connection error");
+                    }
+                });
             }
             Err(e) => {
                 warn!(error = %e, "accept error");
@@ -3186,11 +3193,17 @@ fn handle_run_background(
     };
 
     match storage::spawn_in_overlay(image, command, env, workdir, mounts, overlay_id) {
-        Ok(pid) => AgentResponse::Completed {
-            exit_code: 0,
-            stdout: format!("{}", pid).into_bytes(),
-            stderr: Vec::new(),
-        },
+        Ok(pid) => {
+            // The crun process is now an orphaned child of the agent.
+            // Register it so reap_background_children() collects its
+            // exit status once the container's init terminates.
+            register_background_child(pid);
+            AgentResponse::Completed {
+                exit_code: 0,
+                stdout: format!("{}", pid).into_bytes(),
+                stderr: Vec::new(),
+            }
+        }
         Err(e) => AgentResponse::from_err(e, error_codes::RUN_FAILED),
     }
 }
@@ -3395,22 +3408,55 @@ fn handle_storage_status() -> AgentResponse {
 // VM-Level Exec Handlers (Direct Execution in VM)
 // ============================================================================
 
-/// Handle VM-level exec (non-interactive).
-/// Executes command directly in the VM's rootfs without any container isolation.
+/// PIDs of background children the agent owns and must reap.
+///
+/// Populated by [`register_background_child`] when a background-mode
+/// handler (`handle_vm_exec_background`, `handle_run_background`)
+/// spawns + forgets a process. Cleared by [`reap_background_children`].
+///
+/// Scoping to known PIDs is required once the accept loop is
+/// multi-threaded: an unscoped `waitpid(-1, WNOHANG)` would steal the
+/// exit status from *any* exited child — including the foreground
+/// crun processes that per-request handlers are actively waiting on —
+/// and produce ECHILD races under concurrent load.
+static BG_CHILDREN: OnceLock<std::sync::Mutex<Vec<u32>>> = OnceLock::new();
+
+fn bg_children() -> &'static std::sync::Mutex<Vec<u32>> {
+    BG_CHILDREN.get_or_init(|| std::sync::Mutex::new(Vec::new()))
+}
+
+/// Track a PID so a later [`reap_background_children`] waits on it.
+///
+/// Callers should pair this with `std::mem::forget(child)` so the
+/// Rust `Child` doesn't also race to reap the process on drop.
+fn register_background_child(pid: u32) {
+    bg_children().lock().unwrap().push(pid);
+}
+
 /// Reap any exited background children to prevent zombie accumulation.
 ///
-/// Called periodically in the accept loop. Uses `waitpid(-1, WNOHANG)`
-/// to collect all exited children without blocking. Safe to call even
-/// when no background children exist.
+/// Called periodically in the accept loop. Walks the registered PID
+/// list and issues a per-PID `waitpid(..., WNOHANG)` — non-blocking
+/// and scoped, so it never steals exit statuses from foreground
+/// handlers running in sibling threads.
 #[cfg(target_os = "linux")]
 fn reap_background_children() {
-    loop {
-        let ret = unsafe { libc::waitpid(-1, std::ptr::null_mut(), libc::WNOHANG) };
-        if ret <= 0 {
-            break;
+    let mut guard = bg_children().lock().unwrap();
+    guard.retain(|&pid| {
+        let ret = unsafe { libc::waitpid(pid as i32, std::ptr::null_mut(), libc::WNOHANG) };
+        match ret {
+            // >0 = child was reaped; drop from tracking.
+            r if r > 0 => {
+                debug!(pid, "reaped background child");
+                false
+            }
+            // 0 = still running; keep tracking for the next sweep.
+            0 => true,
+            // <0 = error (typically ECHILD — already reaped elsewhere or the
+            // PID was detached in a way we don't own). Drop either way.
+            _ => false,
         }
-        debug!(pid = ret, "reaped background child");
-    }
+    });
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -3450,9 +3496,12 @@ fn handle_vm_exec_background(
     match cmd.spawn() {
         Ok(child) => {
             let pid = child.id();
-            // Don't wait — let the child run independently.
-            // reap_background_children() in the accept loop collects the exit status.
+            // Don't wait — let the child run independently. The Rust
+            // `Child` is forgotten so drop doesn't race our reaper, and
+            // the PID is registered so reap_background_children()
+            // collects the eventual exit status.
             std::mem::forget(child);
+            register_background_child(pid);
             info!(pid = pid, "background process started");
             AgentResponse::Completed {
                 exit_code: 0,
@@ -3792,6 +3841,98 @@ fn send_response(
 /// Trait for read+write streams with raw fd access.
 trait ReadWrite: Read + Write + AsRawFd {}
 impl<T: Read + Write + AsRawFd> ReadWrite for T {}
+
+/// Regression tests for the scoped background-child reaper.
+///
+/// These are the companion to the accept-loop threading change. The bug
+/// they guard against: once the accept loop spawns a thread per
+/// connection, an unscoped `waitpid(-1, WNOHANG)` in the reaper steals
+/// exit statuses from any foreground crun process that a sibling thread
+/// is waiting on, producing ECHILD races and "command died mid-run"
+/// failures. Scoped reaping must only touch PIDs registered as
+/// background.
+///
+/// Linux-only because `waitpid` behavior + the agent crate as a whole
+/// is Linux-specific. `cargo test -p smolvm-agent --target
+/// aarch64-unknown-linux-musl` on a Linux runner.
+#[cfg(test)]
+#[cfg(target_os = "linux")]
+mod bg_reap_tests {
+    use super::*;
+    use std::process::Command;
+    use std::time::Duration;
+
+    #[test]
+    fn reaper_leaves_unregistered_children_waitable() {
+        // Foreground child: the test owns it and will wait on it. The
+        // reaper must NOT steal it.
+        let mut foreground = Command::new("/bin/true")
+            .spawn()
+            .expect("spawn foreground /bin/true");
+        let fg_pid = foreground.id();
+
+        // Background child: registered, and the Rust Child handle is
+        // forgotten so drop doesn't race the reaper.
+        let background = Command::new("/bin/true")
+            .spawn()
+            .expect("spawn background /bin/true");
+        let bg_pid = background.id();
+        register_background_child(bg_pid);
+        std::mem::forget(background);
+
+        // Let both exit before we reap.
+        std::thread::sleep(Duration::from_millis(150));
+
+        reap_background_children();
+
+        // Foreground must still be reapable via the Rust Child. If the
+        // unscoped reaper stole it, wait() returns ECHILD and this
+        // expect() fires — that's exactly the concurrent-exec bug.
+        let status = foreground
+            .wait()
+            .expect("foreground child must still be waitable — reaper must not touch unregistered PIDs");
+        assert!(status.success(), "foreground /bin/true should succeed");
+
+        // Background PID should be gone from tracking (reaped). Check
+        // only this test's PID so parallel tests don't interfere.
+        let tracked = bg_children().lock().unwrap().clone();
+        assert!(
+            !tracked.contains(&bg_pid),
+            "reaped bg PID {} must be removed from tracking",
+            bg_pid
+        );
+        assert!(
+            !tracked.contains(&fg_pid),
+            "unregistered fg PID {} must never enter tracking",
+            fg_pid
+        );
+    }
+
+    #[test]
+    fn reaper_retains_still_running_background_children() {
+        // A registered but still-alive child must stay in tracking so a
+        // subsequent sweep collects it after it exits.
+        let mut child = Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn sleep 30");
+        let pid = child.id();
+        register_background_child(pid);
+
+        reap_background_children();
+
+        let tracked = bg_children().lock().unwrap().clone();
+        assert!(
+            tracked.contains(&pid),
+            "still-running bg PID {} must remain in tracking",
+            pid
+        );
+
+        // Clean up so the test doesn't leak a 30-second sleep.
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/smolvm-agent/src/process.rs
+++ b/crates/smolvm-agent/src/process.rs
@@ -275,7 +275,7 @@ mod tests {
         child.wait().unwrap();
         let output = capture_child_output(&mut child);
 
-        assert!(output.stdout.contains("hello world"));
+        assert!(String::from_utf8_lossy(&output.stdout).contains("hello world"));
         assert!(output.stderr.is_empty());
     }
 
@@ -292,7 +292,7 @@ mod tests {
         let output = capture_child_output(&mut child);
 
         assert!(output.stdout.is_empty());
-        assert!(output.stderr.contains("error"));
+        assert!(String::from_utf8_lossy(&output.stderr).contains("error"));
     }
 
     #[test]
@@ -309,7 +309,7 @@ mod tests {
         match result {
             WaitResult::Completed { exit_code, output } => {
                 assert_eq!(exit_code, 0);
-                assert!(output.stdout.contains("hello"));
+                assert!(String::from_utf8_lossy(&output.stdout).contains("hello"));
             }
             WaitResult::TimedOut { .. } => panic!("unexpected timeout"),
             WaitResult::ClientDisconnected { .. } => panic!("unexpected client disconnect"),
@@ -351,7 +351,7 @@ mod tests {
         match result {
             WaitResult::Completed { exit_code, output } => {
                 assert_eq!(exit_code, 0);
-                assert!(output.stdout.contains("quick"));
+                assert!(String::from_utf8_lossy(&output.stdout).contains("quick"));
             }
             WaitResult::TimedOut { .. } => panic!("unexpected timeout"),
             WaitResult::ClientDisconnected { .. } => panic!("unexpected client disconnect"),

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -2082,6 +2082,84 @@ pub fn run_command(
     result
 }
 
+/// Spawn a command in an image's overlay rootfs and return the crun PID.
+///
+/// Unlike `run_command`, this does not wait for the container to exit. The
+/// container runs detached under crun with stdout/stderr redirected to
+/// /dev/null; the returned PID is the crun process, which stays alive as
+/// long as the container init runs.
+///
+/// Requires a persistent overlay ID — ephemeral overlays would leak their
+/// upper/work/merged directories because nothing is waiting to clean them
+/// up after the container exits.
+pub fn spawn_in_overlay(
+    image: &str,
+    command: &[String],
+    env: &[(String, String)],
+    workdir: Option<&str>,
+    mounts: &[(String, String, bool)],
+    persistent_overlay_id: &str,
+) -> Result<u32> {
+    crate::oci::validate_image_reference(image).map_err(StorageError::new)?;
+    crate::oci::validate_env_vars(env).map_err(StorageError::new)?;
+
+    let prepared = prepare_for_run_persistent(image, persistent_overlay_id)?;
+    debug!(rootfs = %prepared.rootfs_path, "using persistent overlay for background command");
+
+    let mounted_paths = setup_volume_mounts(&prepared.rootfs_path, mounts)?;
+
+    let overlay_root = Path::new(STORAGE_ROOT)
+        .join(OVERLAYS_DIR)
+        .join(&prepared.workload_id);
+    let bundle_path = overlay_root.join("bundle");
+
+    let workdir_str = workdir.unwrap_or("/");
+    let mut spec = OciSpec::new(command, env, workdir_str, false);
+
+    for (tag, container_path, read_only) in mounts {
+        let virtiofs_mount = Path::new(paths::VIRTIOFS_MOUNT_ROOT).join(tag);
+        spec.add_bind_mount(
+            &virtiofs_mount.to_string_lossy(),
+            container_path,
+            *read_only,
+        );
+    }
+
+    let workspace_src = Path::new(STORAGE_ROOT).join(WORKSPACE_DIR);
+    if workspace_src.exists() {
+        spec.add_bind_mount(&workspace_src.to_string_lossy(), "/workspace", false);
+    }
+
+    crate::ssh_agent::inject_into_container(&mut spec);
+
+    spec.write_to(&bundle_path)
+        .map_err(|e| StorageError::new(format!("failed to write OCI spec: {}", e)))?;
+
+    let container_id = generate_container_id();
+
+    let child = CrunCommand::run(&bundle_path, &container_id)
+        .stdin_null()
+        .discard_output()
+        .spawn()
+        .map_err(|e| {
+            StorageError::new(format!(
+                "failed to spawn crun: {}. Is crun installed at {}?",
+                e,
+                paths::CRUN_PATH
+            ))
+        })?;
+
+    let pid = child.id();
+    // Don't wait on the child; it reaps itself when the container exits.
+    // reap_background_children() in the agent's accept loop collects the
+    // eventual zombie.
+    std::mem::forget(child);
+
+    let _ = mounted_paths; // suppress unused warning; mounts persist with the overlay
+    info!(container_id = %container_id, pid = pid, "background container started");
+    Ok(pid)
+}
+
 /// Prepare for running a command - returns the rootfs path.
 /// This is used by interactive mode which spawns the command separately.
 pub fn prepare_for_run(image: &str) -> Result<PreparedOverlayRootfs> {

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -2146,7 +2146,25 @@ pub fn spawn_in_overlay(
         .map(|s| s.to_string())
         .unwrap_or_else(generate_container_id);
 
-    let child = CrunCommand::run(&bundle_path, &container_id)
+    // Clear any stale crun state for this ID before spawning a new
+    // container with the same name. After `machine stop` + `machine
+    // start` on a `run -d`-created VM, the persistent storage disk
+    // still holds `/var/lib/crun/<id>` from the previous run — `crun
+    // run <id>` would fail immediately with "container already
+    // exists" and the new spawn would silently die. `-f` is safe
+    // because the state is from a prior VM lifetime; the VM is fresh
+    // and no live process holds the container.
+    let delete_status = CrunCommand::delete(&container_id, true)
+        .stdin_null()
+        .discard_output()
+        .status();
+    if let Ok(s) = delete_status {
+        if s.success() {
+            debug!(container_id = %container_id, "cleared stale crun state from prior run");
+        }
+    }
+
+    let mut child = CrunCommand::run(&bundle_path, &container_id)
         .stdin_null()
         .discard_output()
         .spawn()
@@ -2157,6 +2175,27 @@ pub fn spawn_in_overlay(
                 paths::CRUN_PATH
             ))
         })?;
+
+    // Check if crun died immediately. When `crun run` fails — stale
+    // state, malformed bundle, missing binaries in the rootfs — it
+    // exits within a few milliseconds. Catching that here turns the
+    // previous silent failure ("command dies under the agent log,
+    // `machine start` still prints success, first exec fails with a
+    // confusing error") into a reported error the caller can act on.
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    match child.try_wait() {
+        Ok(Some(status)) => {
+            return Err(StorageError::new(format!(
+                "crun exited immediately with {:?} — container did not start. \
+                 Check the agent log for crun output.",
+                status.code()
+            )));
+        }
+        Ok(None) => {} // still running, good
+        Err(e) => {
+            debug!(error = %e, "try_wait on crun child failed; assuming alive");
+        }
+    }
 
     let pid = child.id();
     // Don't wait on the child; it reaps itself when the container exits.

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -2012,6 +2012,7 @@ pub fn run_command(
     mounts: &[(String, String, bool)],
     timeout_ms: Option<u64>,
     persistent_overlay_id: Option<&str>,
+    container_id: Option<&str>,
     client_fd: Option<std::os::unix::io::RawFd>,
 ) -> Result<RunResult> {
     // Validate inputs
@@ -2062,8 +2063,11 @@ pub fn run_command(
         spec.write_to(&bundle_path)
             .map_err(|e| StorageError::new(format!("failed to write OCI spec: {}", e)))?;
 
-        // Generate unique container ID for this execution
-        let container_id = generate_container_id();
+        // Deterministic container ID (so later `crun exec` can target it)
+        // or a freshly-generated one when the caller didn't supply one.
+        let container_id = container_id
+            .map(|s| s.to_string())
+            .unwrap_or_else(generate_container_id);
 
         // Run with crun
         let result = run_with_crun(&bundle_path, &container_id, timeout_ms, client_fd);
@@ -2099,6 +2103,7 @@ pub fn spawn_in_overlay(
     workdir: Option<&str>,
     mounts: &[(String, String, bool)],
     persistent_overlay_id: &str,
+    container_id: Option<&str>,
 ) -> Result<u32> {
     crate::oci::validate_image_reference(image).map_err(StorageError::new)?;
     crate::oci::validate_env_vars(env).map_err(StorageError::new)?;
@@ -2135,7 +2140,11 @@ pub fn spawn_in_overlay(
     spec.write_to(&bundle_path)
         .map_err(|e| StorageError::new(format!("failed to write OCI spec: {}", e)))?;
 
-    let container_id = generate_container_id();
+    // Deterministic ID (so `machine exec` can `crun exec` this container)
+    // or a fresh random one for callers that don't need addressability.
+    let container_id = container_id
+        .map(|s| s.to_string())
+        .unwrap_or_else(generate_container_id);
 
     let child = CrunCommand::run(&bundle_path, &container_id)
         .stdin_null()

--- a/crates/smolvm-protocol/src/lib.rs
+++ b/crates/smolvm-protocol/src/lib.rs
@@ -257,6 +257,11 @@ pub enum AgentRequest {
         /// created and destroyed after the run.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         persistent_overlay_id: Option<String>,
+        /// Spawn the container and return immediately with the crun PID.
+        /// The container runs detached; stdout/stderr go to /dev/null.
+        /// Incompatible with `interactive` and `tty`.
+        #[serde(default)]
+        background: bool,
     },
 
     /// Send stdin data to a running interactive command.

--- a/crates/smolvm-protocol/src/lib.rs
+++ b/crates/smolvm-protocol/src/lib.rs
@@ -257,11 +257,45 @@ pub enum AgentRequest {
         /// created and destroyed after the run.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         persistent_overlay_id: Option<String>,
+        /// Explicit crun container ID. When `None` the agent generates a
+        /// random one (old behavior). When `Some`, the container is named
+        /// deterministically so a later `ExecContainer` can join it — the
+        /// "one container per VM" semantics promised by the README.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        container_id: Option<String>,
         /// Spawn the container and return immediately with the crun PID.
         /// The container runs detached; stdout/stderr go to /dev/null.
         /// Incompatible with `interactive` and `tty`.
         #[serde(default)]
         background: bool,
+    },
+
+    /// Execute a command inside an already-running container.
+    ///
+    /// Uses `crun exec <container_id>` so the command joins the
+    /// container's PID / mount / cgroup namespaces. This is the agent-
+    /// side behavior that `docker exec` models: `ps -ef` shows the
+    /// main workload, signals reach it, env variables survive, and
+    /// sibling execs see each other's processes.
+    ExecContainer {
+        /// The container to join.
+        container_id: String,
+        /// Command and arguments.
+        command: Vec<String>,
+        /// Environment variables.
+        #[serde(default)]
+        env: Vec<(String, String)>,
+        /// Working directory inside the container.
+        workdir: Option<String>,
+        /// Timeout in milliseconds.
+        #[serde(default)]
+        timeout_ms: Option<u64>,
+        /// Interactive mode — stream I/O instead of buffering.
+        #[serde(default)]
+        interactive: bool,
+        /// Allocate a pseudo-TTY.
+        #[serde(default)]
+        tty: bool,
     },
 
     /// Send stdin data to a running interactive command.

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -313,6 +313,21 @@ fn expect_completed(resp: AgentResponse, op: &str) -> Result<(i32, Vec<u8>, Vec<
     }
 }
 
+#[cfg(test)]
+impl AgentClient {
+    /// Build an `AgentClient` from a pre-connected `UnixStream`.
+    ///
+    /// Test-only: production code must go through [`AgentClient::connect`]
+    /// so socket timeouts are configured correctly. Used by the regression
+    /// tests that drive the client against a `UnixStream::pair()`.
+    pub(crate) fn from_stream(stream: UnixStream) -> Self {
+        Self {
+            stream,
+            trace_id: None,
+        }
+    }
+}
+
 impl AgentClient {
     /// Set socket read timeout, returning an error if it fails.
     ///
@@ -1017,9 +1032,40 @@ impl AgentClient {
             interactive: false,
             tty: false,
             persistent_overlay_id: config.persistent_overlay_id,
+            background: false,
         })?;
 
         expect_completed(resp, "run command")
+    }
+
+    /// Run a command in an image's rootfs in the background.
+    ///
+    /// Spawns the container and returns immediately with the crun PID.
+    /// stdout/stderr go to /dev/null inside the guest. Use a persistent
+    /// overlay ID so subsequent `exec` sessions see the same filesystem.
+    pub fn run_background(&mut self, config: RunConfig) -> Result<u32> {
+        let resp = self.request(&AgentRequest::Run {
+            image: config.image,
+            command: config.command,
+            env: config.env,
+            workdir: config.workdir,
+            mounts: config.mounts,
+            timeout_ms: None,
+            interactive: false,
+            tty: false,
+            persistent_overlay_id: config.persistent_overlay_id,
+            background: true,
+        })?;
+
+        let (exit_code, stdout, _stderr) = expect_completed(resp, "run background")?;
+        if exit_code != 0 {
+            return Err(Error::agent("run background", "spawn failed"));
+        }
+        let pid: u32 = String::from_utf8_lossy(&stdout)
+            .trim()
+            .parse()
+            .map_err(|_| Error::agent("run background", "invalid PID in response"))?;
+        Ok(pid)
     }
 
     /// Run a command interactively with streaming I/O.
@@ -1048,6 +1094,7 @@ impl AgentClient {
                 interactive: true,
                 tty,
                 persistent_overlay_id: config.persistent_overlay_id,
+                background: false,
             },
             tty,
             "run interactive",
@@ -1719,5 +1766,133 @@ mod read_cap_tests {
     fn read_cap_rejects_unexpected_response_type() {
         let err = drive(vec![AgentResponse::Pong { version: 1 }]).unwrap_err();
         assert!(format!("{}", err).contains("unexpected response"));
+    }
+}
+
+#[cfg(test)]
+mod run_background_tests {
+    //! Regression test for image-backed `machine run -d`.
+    //!
+    //! The original bug: the CLI's image + `--detach` path pulled the image
+    //! and persisted the VM record but silently dropped the command. The
+    //! fix wires in `AgentClient::run_background`, which must send a
+    //! `Run { background: true }` over the wire and parse the returned PID.
+    //!
+    //! If this test fails, the detach path either lost its `background`
+    //! plumbing or stopped parsing the PID response — either way, the
+    //! original "command never runs" regression is back.
+    use super::*;
+    use smolvm_protocol::{encode_message, AgentRequest, AgentResponse, Envelope};
+    use std::io::{Read, Write};
+    use std::thread;
+
+    #[test]
+    fn run_background_sends_background_true_and_returns_pid() {
+        let (client_stream, mut server_stream) = UnixStream::pair().unwrap();
+
+        // Fake agent: read one request, assert it's a background Run, respond
+        // with a Completed PID. Mirrors what the real agent does in
+        // `handle_run_background`.
+        let server = thread::spawn(move || {
+            let mut len_buf = [0u8; 4];
+            server_stream.read_exact(&mut len_buf).unwrap();
+            let len = u32::from_be_bytes(len_buf) as usize;
+
+            let mut payload = vec![0u8; len];
+            server_stream.read_exact(&mut payload).unwrap();
+
+            let envelope: Envelope<AgentRequest> =
+                serde_json::from_slice(&payload).expect("valid Envelope<AgentRequest>");
+
+            match envelope.body {
+                AgentRequest::Run {
+                    image,
+                    command,
+                    persistent_overlay_id,
+                    background,
+                    interactive,
+                    tty,
+                    ..
+                } => {
+                    assert!(
+                        background,
+                        "run_background must send background: true — the image+detach CLI path \
+                         depends on this field to dispatch the command inside the container"
+                    );
+                    assert!(!interactive, "background runs are never interactive");
+                    assert!(!tty, "background runs never allocate a TTY");
+                    assert_eq!(image, "alpine:3.19");
+                    assert_eq!(command, vec!["sh", "-c", "echo hi"]);
+                    assert_eq!(
+                        persistent_overlay_id,
+                        Some("default".to_string()),
+                        "background runs must use a persistent overlay so subsequent execs \
+                         see the same filesystem"
+                    );
+                }
+                other => panic!("expected AgentRequest::Run, got {:?}", other),
+            }
+
+            let resp = AgentResponse::Completed {
+                exit_code: 0,
+                stdout: b"12345".to_vec(),
+                stderr: Vec::new(),
+            };
+            let encoded = encode_message(&resp).expect("encode response");
+            server_stream.write_all(&encoded).expect("write response");
+        });
+
+        let mut client = AgentClient::from_stream(client_stream);
+        let config = RunConfig::new(
+            "alpine:3.19",
+            vec!["sh".to_string(), "-c".to_string(), "echo hi".to_string()],
+        )
+        .with_persistent_overlay(Some("default".to_string()));
+
+        let pid = client
+            .run_background(config)
+            .expect("run_background should succeed on a Completed response");
+
+        assert_eq!(pid, 12345, "client must parse the PID from stdout");
+        server.join().expect("server thread joined cleanly");
+    }
+
+    #[test]
+    fn run_background_rejects_nonzero_exit_code() {
+        // If the agent fails to spawn the container, it returns a non-zero
+        // exit_code. The client must turn that into an error rather than
+        // silently returning a bogus PID.
+        let (client_stream, mut server_stream) = UnixStream::pair().unwrap();
+
+        let server = thread::spawn(move || {
+            let mut len_buf = [0u8; 4];
+            server_stream.read_exact(&mut len_buf).unwrap();
+            let len = u32::from_be_bytes(len_buf) as usize;
+            let mut payload = vec![0u8; len];
+            server_stream.read_exact(&mut payload).unwrap();
+
+            let resp = AgentResponse::Completed {
+                exit_code: 1,
+                stdout: Vec::new(),
+                stderr: b"spawn failed".to_vec(),
+            };
+            let encoded = encode_message(&resp).unwrap();
+            server_stream.write_all(&encoded).unwrap();
+        });
+
+        let mut client = AgentClient::from_stream(client_stream);
+        let config = RunConfig::new("alpine:3.19", vec!["true".to_string()])
+            .with_persistent_overlay(Some("default".to_string()));
+
+        let err = client
+            .run_background(config)
+            .expect_err("non-zero exit must surface as an error");
+        assert!(
+            format!("{}", err).contains("spawn failed")
+                || format!("{}", err).contains("run background"),
+            "unexpected error: {}",
+            err
+        );
+        server.join().unwrap();
     }
 }

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -122,6 +122,12 @@ pub struct RunConfig {
     /// Persistent overlay ID. If set, the overlay persists across exec sessions
     /// so filesystem changes (e.g. package installs) survive.
     pub persistent_overlay_id: Option<String>,
+    /// Explicit crun container ID. When set, the container is named
+    /// deterministically so a later `exec_container` can join it —
+    /// the "one container per VM" semantics the README promises.
+    /// Leave `None` for session-scoped runs that don't need to be
+    /// addressable by later execs.
+    pub container_id: Option<String>,
 }
 
 impl RunConfig {
@@ -136,6 +142,7 @@ impl RunConfig {
             timeout: None,
             tty: false,
             persistent_overlay_id: None,
+            container_id: None,
         }
     }
 
@@ -172,6 +179,13 @@ impl RunConfig {
     /// Set persistent overlay ID for cross-session filesystem persistence.
     pub fn with_persistent_overlay(mut self, id: Option<String>) -> Self {
         self.persistent_overlay_id = id;
+        self
+    }
+
+    /// Set an explicit crun container ID so the spawned container is
+    /// addressable by a later `exec_container` call.
+    pub fn with_container_id(mut self, id: Option<String>) -> Self {
+        self.container_id = id;
         self
     }
 }
@@ -1032,6 +1046,7 @@ impl AgentClient {
             interactive: false,
             tty: false,
             persistent_overlay_id: config.persistent_overlay_id,
+            container_id: config.container_id,
             background: false,
         })?;
 
@@ -1054,6 +1069,7 @@ impl AgentClient {
             interactive: false,
             tty: false,
             persistent_overlay_id: config.persistent_overlay_id,
+            container_id: config.container_id,
             background: true,
         })?;
 
@@ -1066,6 +1082,61 @@ impl AgentClient {
             .parse()
             .map_err(|_| Error::agent("run background", "invalid PID in response"))?;
         Ok(pid)
+    }
+
+    /// Execute a command inside an already-running container.
+    ///
+    /// Sends an `ExecContainer` request so the agent calls
+    /// `crun exec <container_id>`. The command joins the container's
+    /// PID / mount / cgroup namespaces — so `ps`, signals, and env
+    /// work the way Docker users expect.
+    pub fn exec_container(
+        &mut self,
+        container_id: &str,
+        command: Vec<String>,
+        env: Vec<(String, String)>,
+        workdir: Option<String>,
+        timeout: Option<Duration>,
+    ) -> Result<(i32, Vec<u8>, Vec<u8>)> {
+        let _timeout_guard = self.set_exec_timeout(timeout)?;
+        let timeout_ms = timeout.map(|t| t.as_millis() as u64);
+        let resp = self.request(&AgentRequest::ExecContainer {
+            container_id: container_id.to_string(),
+            command,
+            env,
+            workdir,
+            timeout_ms,
+            interactive: false,
+            tty: false,
+        })?;
+        expect_completed(resp, "exec container")
+    }
+
+    /// Interactive variant of `exec_container` — streams stdin/stdout
+    /// to the terminal and returns the exit code.
+    pub fn exec_container_interactive(
+        &mut self,
+        container_id: &str,
+        command: Vec<String>,
+        env: Vec<(String, String)>,
+        workdir: Option<String>,
+        timeout: Option<Duration>,
+        tty: bool,
+    ) -> Result<i32> {
+        let timeout_ms = timeout.map(|t| t.as_millis() as u64);
+        self.interactive_session(
+            AgentRequest::ExecContainer {
+                container_id: container_id.to_string(),
+                command,
+                env,
+                workdir,
+                timeout_ms,
+                interactive: true,
+                tty,
+            },
+            tty,
+            "exec container interactive",
+        )
     }
 
     /// Run a command interactively with streaming I/O.
@@ -1094,6 +1165,7 @@ impl AgentClient {
                 interactive: true,
                 tty,
                 persistent_overlay_id: config.persistent_overlay_id,
+                container_id: config.container_id,
                 background: false,
             },
             tty,
@@ -1893,6 +1965,140 @@ mod run_background_tests {
             "unexpected error: {}",
             err
         );
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn run_background_passes_through_container_id() {
+        // The "one container per VM" model depends on the CLI naming the
+        // container deterministically via `with_container_id(...)`. If the
+        // field stops flowing to the wire, `machine exec` can't find the
+        // container to join — and we silently regress to the sibling-
+        // container model the README explicitly contrasts smolvm against.
+        let (client_stream, mut server_stream) = UnixStream::pair().unwrap();
+
+        let server = thread::spawn(move || {
+            let mut len_buf = [0u8; 4];
+            server_stream.read_exact(&mut len_buf).unwrap();
+            let len = u32::from_be_bytes(len_buf) as usize;
+            let mut payload = vec![0u8; len];
+            server_stream.read_exact(&mut payload).unwrap();
+
+            let envelope: Envelope<AgentRequest> =
+                serde_json::from_slice(&payload).expect("valid Envelope<AgentRequest>");
+
+            match envelope.body {
+                AgentRequest::Run {
+                    container_id,
+                    background,
+                    ..
+                } => {
+                    assert!(background);
+                    assert_eq!(
+                        container_id,
+                        Some("smolvm-default".to_string()),
+                        "container_id must flow through RunConfig → AgentRequest::Run"
+                    );
+                }
+                other => panic!("expected AgentRequest::Run, got {:?}", other),
+            }
+
+            let resp = AgentResponse::Completed {
+                exit_code: 0,
+                stdout: b"999".to_vec(),
+                stderr: Vec::new(),
+            };
+            server_stream
+                .write_all(&encode_message(&resp).unwrap())
+                .unwrap();
+        });
+
+        let mut client = AgentClient::from_stream(client_stream);
+        let config = RunConfig::new("alpine:3.19", vec!["true".to_string()])
+            .with_persistent_overlay(Some("default".to_string()))
+            .with_container_id(Some("smolvm-default".to_string()));
+        let pid = client.run_background(config).expect("run_background ok");
+        assert_eq!(pid, 999);
+        server.join().unwrap();
+    }
+}
+
+#[cfg(test)]
+mod exec_container_tests {
+    //! Regression test for Fix #4 — `machine exec` joins the running
+    //! container instead of spawning a sibling.
+    //!
+    //! If this test fails, the client stopped issuing `ExecContainer`
+    //! requests (or stopped targeting the right container_id). The
+    //! observable symptom is that `machine exec ... ps -ef` no longer
+    //! sees the main workload — the "one container per VM" model the
+    //! README promises is broken.
+    use super::*;
+    use smolvm_protocol::{encode_message, AgentRequest, AgentResponse, Envelope};
+    use std::io::{Read, Write};
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn exec_container_sends_exec_container_request_to_named_container() {
+        let (client_stream, mut server_stream) = UnixStream::pair().unwrap();
+
+        let server = thread::spawn(move || {
+            let mut len_buf = [0u8; 4];
+            server_stream.read_exact(&mut len_buf).unwrap();
+            let len = u32::from_be_bytes(len_buf) as usize;
+            let mut payload = vec![0u8; len];
+            server_stream.read_exact(&mut payload).unwrap();
+
+            let envelope: Envelope<AgentRequest> =
+                serde_json::from_slice(&payload).expect("valid Envelope<AgentRequest>");
+
+            match envelope.body {
+                AgentRequest::ExecContainer {
+                    container_id,
+                    command,
+                    workdir,
+                    timeout_ms,
+                    interactive,
+                    tty,
+                    ..
+                } => {
+                    assert_eq!(
+                        container_id, "smolvm-default",
+                        "exec_container must target the deterministic container name"
+                    );
+                    assert_eq!(command, vec!["ps", "-ef"]);
+                    assert_eq!(workdir, Some("/app".to_string()));
+                    assert_eq!(timeout_ms, Some(5000));
+                    assert!(!interactive);
+                    assert!(!tty);
+                }
+                other => panic!("expected AgentRequest::ExecContainer, got {:?}", other),
+            }
+
+            let resp = AgentResponse::Completed {
+                exit_code: 0,
+                stdout: b"  PID  USER     COMMAND\n    1 root     sleep infinity\n".to_vec(),
+                stderr: Vec::new(),
+            };
+            server_stream
+                .write_all(&encode_message(&resp).unwrap())
+                .unwrap();
+        });
+
+        let mut client = AgentClient::from_stream(client_stream);
+        let (exit_code, stdout, _stderr) = client
+            .exec_container(
+                "smolvm-default",
+                vec!["ps".to_string(), "-ef".to_string()],
+                Vec::new(),
+                Some("/app".to_string()),
+                Some(Duration::from_secs(5)),
+            )
+            .expect("exec_container should succeed");
+
+        assert_eq!(exit_code, 0);
+        assert!(String::from_utf8_lossy(&stdout).contains("sleep infinity"));
         server.join().unwrap();
     }
 }

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -537,24 +537,20 @@ impl RunCmd {
                 // same filesystem (same overlay ID as the exec path below).
                 crate::cli::pull_with_progress(&mut client, img, self.oci_platform.as_deref())?;
 
-                // Run the resolved command in the background inside the image.
-                // Skip when the command is just the idle default — there's
-                // nothing useful to dispatch.
-                let is_idle = command.is_empty()
-                    || command
-                        == DEFAULT_IDLE_CMD
-                            .iter()
-                            .map(|s| s.to_string())
-                            .collect::<Vec<_>>();
-                if !is_idle {
-                    let bg_config = smolvm::agent::RunConfig::new(img, command.clone())
-                        .with_env(env.clone())
-                        .with_workdir(params.workdir.clone())
-                        .with_mounts(mount_bindings.clone())
-                        .with_persistent_overlay(Some("default".to_string()));
-                    let pid = client.run_background(bg_config)?;
-                    tracing::info!(pid = pid, "background workload started");
-                }
+                // Always spawn the main container — `machine exec` joins it
+                // via `crun exec`, so the container must exist even when
+                // the user didn't supply a command. DEFAULT_IDLE_CMD
+                // ("sleep infinity") keeps the container alive so later
+                // execs have something to attach to. This is the
+                // one-container-per-VM model the README describes.
+                let bg_config = smolvm::agent::RunConfig::new(img, command.clone())
+                    .with_env(env.clone())
+                    .with_workdir(params.workdir.clone())
+                    .with_mounts(mount_bindings.clone())
+                    .with_persistent_overlay(Some("default".to_string()))
+                    .with_container_id(Some("smolvm-default".to_string()));
+                let pid = client.run_background(bg_config)?;
+                tracing::info!(pid = pid, "main container started");
 
                 {
                     use smolvm::config::SmolvmConfig;
@@ -851,37 +847,42 @@ impl ExecCmd {
             std::process::exit(exit_code);
         }
 
-        // Check if this machine has an image — if so, exec inside the image's
-        // rootfs via client.run_interactive()/run_non_interactive() instead of bare vm_exec().
-        let mount_bindings = record
+        // Image-backed machines have a single long-lived container named
+        // `smolvm-{name}` that was started by `machine run -d` (or
+        // `machine start`). Exec joins that container via `crun exec` so
+        // all execs share the same PID / mount / cgroup namespaces as the
+        // main workload — `ps -ef` sees the whole picture, signals cross
+        // exec boundaries, env set in the container is visible, etc.
+        //
+        // Bare-VM machines (no image) still use the direct `vm_exec`
+        // path, which runs commands in the agent's own rootfs without any
+        // container isolation.
+        let _mount_bindings = record
             .as_ref()
             .map(|r| mounts_to_virtiofs_bindings(&r.host_mounts()))
             .unwrap_or_default();
 
-        if let Some(ref image) = record_image {
-            // Image-based machine: exec inside the image's rootfs via crun.
-            // Use machine name as persistent overlay ID so filesystem changes
-            // (e.g. package installs) survive across exec sessions.
-            let machine_name = name.clone();
+        if record_image.is_some() {
+            let container_id = format!("smolvm-{}", name);
             if self.interactive || self.tty {
-                let config = smolvm::agent::RunConfig::new(image, self.command.clone())
-                    .with_env(env)
-                    .with_workdir(workdir.clone())
-                    .with_mounts(mount_bindings)
-                    .with_timeout(self.timeout)
-                    .with_tty(self.tty)
-                    .with_persistent_overlay(Some(machine_name.clone()));
-                let exit_code = client.run_interactive(config)?;
+                let exit_code = client.exec_container_interactive(
+                    &container_id,
+                    self.command.clone(),
+                    env,
+                    workdir.clone(),
+                    self.timeout,
+                    self.tty,
+                )?;
                 std::process::exit(exit_code);
             }
 
-            let config = smolvm::agent::RunConfig::new(image, self.command.clone())
-                .with_env(env)
-                .with_workdir(workdir.clone())
-                .with_mounts(mount_bindings)
-                .with_timeout(self.timeout)
-                .with_persistent_overlay(Some(machine_name));
-            let (exit_code, stdout, stderr) = client.run_non_interactive(config)?;
+            let (exit_code, stdout, stderr) = client.exec_container(
+                &container_id,
+                self.command.clone(),
+                env,
+                workdir.clone(),
+                self.timeout,
+            )?;
             vm_common::print_output_and_exit(&manager, exit_code, &stdout, &stderr);
         } else {
             // Bare VM: exec directly in the VM rootfs.

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -172,7 +172,9 @@ pub struct RunCmd {
     #[arg(trailing_var_arg = true, value_name = "COMMAND")]
     pub command: Vec<String>,
 
-    /// Run in background and keep machine alive after command exits
+    /// Start the command in the background and detach, leaving the VM
+    /// running. Use `machine exec` to run further commands against the VM
+    /// and `machine stop` to tear it down.
     #[arg(short = 'd', long, help_heading = "Execution")]
     pub detach: bool,
 
@@ -529,11 +531,30 @@ impl RunCmd {
         // Two modes: with image or bare VM (no image)
         if let Some(ref img) = image {
             if self.detach {
-                // Detach mode: persist the record with image info.
-                // The VM is already running. The image will be pulled and
-                // command started on subsequent `machine start` if stopped/restarted.
-                // For now, pull the image so it's cached for exec.
+                // Detach mode: pull the image, kick the command off in the
+                // background inside the image's overlay rootfs, and persist
+                // the record so subsequent `machine exec` sessions see the
+                // same filesystem (same overlay ID as the exec path below).
                 crate::cli::pull_with_progress(&mut client, img, self.oci_platform.as_deref())?;
+
+                // Run the resolved command in the background inside the image.
+                // Skip when the command is just the idle default — there's
+                // nothing useful to dispatch.
+                let is_idle = command.is_empty()
+                    || command
+                        == DEFAULT_IDLE_CMD
+                            .iter()
+                            .map(|s| s.to_string())
+                            .collect::<Vec<_>>();
+                if !is_idle {
+                    let bg_config = smolvm::agent::RunConfig::new(img, command.clone())
+                        .with_env(env.clone())
+                        .with_workdir(params.workdir.clone())
+                        .with_mounts(mount_bindings.clone())
+                        .with_persistent_overlay(Some("default".to_string()));
+                    let pid = client.run_background(bg_config)?;
+                    tracing::info!(pid = pid, "background workload started");
+                }
 
                 {
                     use smolvm::config::SmolvmConfig;

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -178,6 +178,13 @@ pub struct RunCmd {
     #[arg(short = 'd', long, help_heading = "Execution")]
     pub detach: bool,
 
+    /// Name the persistent machine. Defaults to "default" when used with
+    /// `-d`. Equivalent to `docker run --name <NAME>` — later
+    /// `smolvm machine exec --name <NAME>` targets the same container.
+    /// Ignored in foreground mode (use `machine create <NAME>` for that).
+    #[arg(long, value_name = "NAME", help_heading = "Execution")]
+    pub name: Option<String>,
+
     /// Keep stdin open for interactive input
     #[arg(short = 'i', long, help_heading = "Execution")]
     pub interactive: bool,
@@ -374,8 +381,25 @@ impl RunCmd {
             params.port.len(),
         )?;
 
-        let manager = AgentManager::new_default_with_sizes(params.storage_gb, params.overlay_gb)
-            .map_err(|e| Error::agent("create agent manager", e.to_string()))?;
+        // --name is docker-style: names the persistent machine so a
+        // later `machine exec --name <NAME>` can target it. Without
+        // --name, the old hardcoded "default" machine is used. --name
+        // is only meaningful with -d; foreground runs are ephemeral
+        // and use an auto-generated name regardless.
+        let persistent_name = self.name.clone();
+        let manager = match persistent_name.as_deref() {
+            Some(n) if self.detach => {
+                AgentManager::for_vm_with_sizes(n, params.storage_gb, params.overlay_gb)
+                    .map_err(|e| Error::agent("create agent manager", e.to_string()))?
+            }
+            _ => AgentManager::new_default_with_sizes(params.storage_gb, params.overlay_gb)
+                .map_err(|e| Error::agent("create agent manager", e.to_string()))?,
+        };
+        if persistent_name.is_some() && !self.detach {
+            eprintln!(
+                "warning: --name is ignored in foreground mode; use `machine create <NAME>` to define a persistent machine"
+            );
+        }
 
         let mode = if self.detach {
             "persistent"
@@ -473,13 +497,12 @@ impl RunCmd {
                 })
                 .collect();
             let init_env = parse_env_list(&params.env);
-            // Use "default" as the overlay ID so any rootfs changes
-            // init makes (e.g. `pacman -S git`) are visible to a
-            // subsequent `machine exec`. The exec path resolves the
-            // overlay from the machine name, falling back to "default"
-            // when no `--name` is given (`src/cli/machine.rs:741`), so
-            // matching that constant here is what makes init's effects
-            // observable to the user.
+            // Init must land on the same overlay that `machine exec`
+            // will later resolve — the machine name if `-d --name`
+            // was used, "default" otherwise. Drift here would leave
+            // init's effects (e.g. `pacman -S git`) invisible to
+            // subsequent execs.
+            let init_overlay_id = persistent_name.as_deref().unwrap_or("default");
             if let Err(e) = vm_common::run_init_commands(
                 &mut client,
                 &params.init,
@@ -487,7 +510,7 @@ impl RunCmd {
                 &init_env,
                 params.workdir.as_deref(),
                 &record_mounts,
-                "default",
+                init_overlay_id,
             ) {
                 // Ephemeral VMs have no state to preserve — `kill()`
                 // matches the success path's lifetime semantics
@@ -543,14 +566,19 @@ impl RunCmd {
                 // ("sleep infinity") keeps the container alive so later
                 // execs have something to attach to. This is the
                 // one-container-per-VM model the README describes.
+                //
+                // Container ID is derived from the chosen machine name so
+                // `machine exec --name <n>` can target it directly
+                // (see `ExecCmd::run`).
+                let detach_name = persistent_name.as_deref().unwrap_or("default");
                 let bg_config = smolvm::agent::RunConfig::new(img, command.clone())
                     .with_env(env.clone())
                     .with_workdir(params.workdir.clone())
                     .with_mounts(mount_bindings.clone())
-                    .with_persistent_overlay(Some("default".to_string()))
-                    .with_container_id(Some("smolvm-default".to_string()));
+                    .with_persistent_overlay(Some(detach_name.to_string()))
+                    .with_container_id(Some(format!("smolvm-{}", detach_name)));
                 let pid = client.run_background(bg_config)?;
-                tracing::info!(pid = pid, "main container started");
+                tracing::info!(pid = pid, container_name = %detach_name, "main container started");
 
                 {
                     use smolvm::config::SmolvmConfig;
@@ -568,8 +596,9 @@ impl RunCmd {
                     let port_tuples: Vec<(u16, u16)> =
                         params.port.iter().map(|p| (p.host, p.guest)).collect();
                     if let Ok(mut config) = SmolvmConfig::load() {
-                        vm_common::persist_default_running(
+                        vm_common::persist_vm_running(
                             &mut config,
+                            detach_name,
                             manager.child_pid(),
                             Some(DefaultVmOverrides {
                                 cpus: params.cpus,
@@ -597,11 +626,16 @@ impl RunCmd {
                 // Disarm SIGINT guard — detaching, VM stays running.
                 drop(sigint_guard);
 
-                println!("Machine running in background");
+                println!("Machine '{}' running in background", detach_name);
+                let name_flag = if detach_name == "default" {
+                    String::new()
+                } else {
+                    format!(" --name {}", detach_name)
+                };
                 println!("\nTo interact:");
-                println!("  smolvm machine exec -- <command>");
+                println!("  smolvm machine exec{} -- <command>", name_flag);
                 println!("\nTo stop:");
-                println!("  smolvm machine stop");
+                println!("  smolvm machine stop{}", name_flag);
 
                 manager.detach();
                 Ok(())
@@ -660,7 +694,9 @@ impl RunCmd {
                     tracing::info!(pid = pid, "background workload started");
                 }
 
-                // Persist the default VM state so it survives stop/start.
+                let detach_name = persistent_name.as_deref().unwrap_or("default");
+
+                // Persist the named (or default) VM state so it survives stop/start.
                 {
                     use smolvm::config::SmolvmConfig;
                     use vm_common::DefaultVmOverrides;
@@ -677,8 +713,9 @@ impl RunCmd {
                     let port_tuples: Vec<(u16, u16)> =
                         params.port.iter().map(|p| (p.host, p.guest)).collect();
                     if let Ok(mut config) = SmolvmConfig::load() {
-                        vm_common::persist_default_running(
+                        vm_common::persist_vm_running(
                             &mut config,
+                            detach_name,
                             manager.child_pid(),
                             Some(DefaultVmOverrides {
                                 cpus: params.cpus,
@@ -704,13 +741,19 @@ impl RunCmd {
                 }
 
                 println!(
-                    "Machine running (PID: {})",
+                    "Machine '{}' running (PID: {})",
+                    detach_name,
                     manager.child_pid().unwrap_or(0)
                 );
+                let name_flag = if detach_name == "default" {
+                    String::new()
+                } else {
+                    format!(" --name {}", detach_name)
+                };
                 println!("\nTo interact:");
-                println!("  smolvm machine exec -- <command>");
+                println!("  smolvm machine exec{} -- <command>", name_flag);
                 println!("\nTo stop:");
-                println!("  smolvm machine stop");
+                println!("  smolvm machine stop{}", name_flag);
 
                 manager.detach();
                 Ok(())

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -614,7 +614,24 @@ pub fn start_vm_named(name: &str) -> smolvm::Result<()> {
                 tracing::info!(pid = container_pid, container = %name, "main container started");
             }
             Err(e) => {
-                tracing::warn!(error = %e, "failed to start main container — `machine exec` will fail until the VM is restarted");
+                // Silent failure here was the `stop + start` bug — the
+                // VM came up fine, state flipped to `running`, but the
+                // workload was gone and the user only noticed when
+                // `machine exec` failed. Tear the VM back down and
+                // surface a real error so the state doesn't lie.
+                if let Err(stop_err) = manager.stop() {
+                    tracing::warn!(
+                        error = %stop_err,
+                        "failed to stop VM after main container startup failure"
+                    );
+                }
+                return Err(Error::agent(
+                    "start main container",
+                    format!(
+                        "failed to start main container '{}' after VM boot: {}",
+                        name, e
+                    ),
+                ));
             }
         }
         println!("Machine '{}' running (PID: {})", name, pid.unwrap_or(0));

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -654,32 +654,35 @@ pub fn start_vm_named(name: &str) -> smolvm::Result<()> {
     Ok(())
 }
 
-/// Persist the "default" VM as running in the database.
+/// Persist the named VM as running in the database.
 ///
 /// Creates the record if it doesn't exist, then updates state to Running
 /// with the current PID and optional config overrides (cpus, mem, etc.).
-pub fn persist_default_running(
+/// `name` is typically "default" for the unnamed `run -d` case; any
+/// other value means `run -d --name <NAME>` was used.
+pub fn persist_vm_running(
     config: &mut SmolvmConfig,
+    name: &str,
     pid: Option<i32>,
     overrides: Option<DefaultVmOverrides>,
 ) {
-    if config.get_vm("default").is_none() {
+    if config.get_vm(name).is_none() {
         let record = VmRecord::new(
-            "default".to_string(),
+            name.to_string(),
             DEFAULT_MICROVM_CPU_COUNT,
             DEFAULT_MICROVM_MEMORY_MIB,
             vec![],
             vec![],
             false,
         );
-        if let Err(e) = config.insert_vm("default".to_string(), record) {
-            tracing::warn!(error = %e, "failed to insert default VM record");
+        if let Err(e) = config.insert_vm(name.to_string(), record) {
+            tracing::warn!(error = %e, vm = %name, "failed to insert VM record");
             return;
         }
     }
     let pid_start_time = pid.and_then(smolvm::process::process_start_time);
     if config
-        .update_vm("default", |r| {
+        .update_vm(name, |r| {
             r.state = RecordState::Running;
             r.pid = pid;
             r.pid_start_time = pid_start_time;
@@ -705,7 +708,7 @@ pub fn persist_default_running(
         })
         .is_none()
     {
-        tracing::warn!("failed to update default VM record (record missing after insert)");
+        tracing::warn!(vm = %name, "failed to update VM record (record missing after insert)");
     }
 }
 
@@ -789,7 +792,7 @@ pub fn start_vm_default() -> smolvm::Result<()> {
     manager.ensure_running()?;
 
     let mut config = SmolvmConfig::load()?;
-    persist_default_running(&mut config, manager.child_pid(), None);
+    persist_vm_running(&mut config, "default", manager.child_pid(), None);
 
     // Pull image (if persisted via `machine run -d -s`) before running
     // init, then run init through the shared runner — same fix as

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -583,9 +583,40 @@ pub fn start_vm_named(name: &str) -> smolvm::Result<()> {
         return Err(e);
     }
 
-    if record.image.is_some() {
-        // Image-based machine: VM is running, image pulled and cached,
-        // init done. Sits idle until `machine exec` is called.
+    if let Some(ref image) = record.image {
+        // Image-based machine: spawn the single long-lived container the
+        // README describes ("one container per VM"). `machine exec` joins
+        // it via `crun exec`, so the container must exist before the
+        // first exec. Use the stored entrypoint+cmd if present; otherwise
+        // fall back to `sleep infinity` so exec has something to attach to.
+        let container_cmd = {
+            let mut c = record.entrypoint.clone();
+            c.extend(record.cmd.clone());
+            if c.is_empty() {
+                smolvm::DEFAULT_IDLE_CMD
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect()
+            } else {
+                c
+            }
+        };
+        let mount_bindings =
+            crate::cli::parsers::record_mounts_to_runconfig_bindings(&record.mounts);
+        let bg_config = smolvm::agent::RunConfig::new(image, container_cmd)
+            .with_env(record.env.clone())
+            .with_workdir(record.workdir.clone())
+            .with_mounts(mount_bindings)
+            .with_persistent_overlay(Some(name.to_string()))
+            .with_container_id(Some(format!("smolvm-{}", name)));
+        match client.run_background(bg_config) {
+            Ok(container_pid) => {
+                tracing::info!(pid = container_pid, container = %name, "main container started");
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to start main container — `machine exec` will fail until the VM is restarted");
+            }
+        }
         println!("Machine '{}' running (PID: {})", name, pid.unwrap_or(0));
     } else {
         // No image — bare VM mode. Run entrypoint+cmd if configured.


### PR DESCRIPTION
## Summary

End-to-end fixes for the `machine run -d` → `machine exec` → `machine stop`/`start` lifecycle. Aligns actual behavior with the README's "VM per workload" positioning. Seven commits, covering four distinct bugs.

Closes #198, closes #199, closes #200, closes #201, closes #202

**Unblocks #189** (fixes pre-existing agent-crate test compile errors so CI can actually run agent tests).

## Fixes

- **`machine run -d --image X -- cmd` silently dropped the command** (#198) — image+detach only pulled the image and persisted the record; the resolved command was never dispatched. Now spawns the container under a deterministic ID. ([`a62745a`](../commit/a62745a))
- **Concurrent `machine exec` killed the VM's reachability** (#199) — the vsock accept loop was single-threaded, so a held-open exec starved the 250ms state probe and the CLI flipped to `unreachable`. Now thread-per-connection, with a scoped child-reaper to prevent `waitpid(-1)` from stealing exit statuses across threads. ([`b9fef31`](../commit/b9fef31))
- **`machine exec` spawned sibling containers instead of joining** (#200) — see design note below. ([`05f95e7`](../commit/05f95e7), [`b020df0`](../commit/b020df0))
- **`machine run -d --name <n>` didn't exist** (#202) — parity with `docker run --name`; short-circuits the `create + start + exec` three-step dance. ([`eadcb04`](../commit/eadcb04))
- **`machine stop` + `machine start` silently lost the primary container** (#201) — stale crun state on the persistent storage disk survived across VM lifetimes; `crun run` failed instantly but we only checked the spawn call, not the exit code. Now force-cleans stale state and `try_wait`s after spawn to catch instant failures. ([`b2a6b85`](../commit/b2a6b85))

## Design note: multi-container vs single-container

The first fix ([`a62745a`](../commit/a62745a)) shipped a **multi-container** model: `run -d` spawned one container for the main workload, then each `machine exec` spawned a *sibling* container sharing a persistent overlay filesystem. It worked — `/shared/marker` propagated, `apk add` survived across execs — but `exec ... ps -ef` couldn't see the main workload, signals didn't cross, and env vars set in the main container weren't visible from execs. Basically: Docker users hit a visibility cliff the moment they ran exec.

[`05f95e7`](../commit/05f95e7) switched to the **single-container** model the README advertises (`Isolation: VM per workload`):

- `run -d` / `machine start` spawn one container per VM under a deterministic name (`smolvm-{machine-name}`)
- `machine exec` issues `AgentRequest::ExecContainer` → `crun exec <container_id>` → joins the container's PID/mount/cgroup namespaces
- Bare-VM exec (no image) still uses the old `vm_exec` path — container-less by design

This matches `docker run -d` + `docker exec` semantics exactly: `ps` sees the main workload, signals reach it, the cgroup resource envelope is shared, `machine exec -it -- /bin/sh` drops you into the same container the workload lives in.

## Test plan

- [ ] `cargo test --lib` — 222 tests pass (including new client-side regression tests for `run_background` with container_id and `exec_container` wire format)
- [ ] Repro issue #1: `machine run -d --image alpine -v /tmp/s:/shared -- sh -c 'echo RAN > /shared/marker; sleep 60'` → marker appears
- [ ] Repro issue #2: concurrent `machine exec` while a long one holds a connection → VM stays `running`, all execs succeed
- [ ] Repro issue #4: `machine run -d --image alpine -- sleep 300` → `machine exec -- ps -ef` shows `PID 1: sleep 300`
- [ ] `machine run -d --name foo --image alpine -- cmd` → `machine exec --name foo -it -- /bin/sh` drops you in
- [ ] `machine run -d --name r -s Smolfile` → `machine stop --name r` → `machine start --name r` → `machine exec --name r -- ps -ef` still shows the workload

---

AI disclamer. I did have Claude help with this change. But tested it extensively along with the changes in #195 can see full combined here: https://github.com/atomicdotdev/smolvm/tree/combined/sqlite-and-fixes
