### PR TITLE
fix: dynamically rotate stale cidr

### DIFF
--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -23,6 +23,14 @@ use std::path::{Path, PathBuf};
 
 use super::{PortMapping, VmResources};
 
+/// Maximum number of CIDR entries held in the live egress allow-list.
+/// Protects the muxer's per-packet O(n) scan from unbounded growth when
+/// a host resolves to many IPs across many refresh cycles.
+const EGRESS_CIDR_CAP: usize = 512;
+
+/// The Arc type shared between the egress-refresh thread and libkrun's vsock muxer.
+type EgressArc = std::sync::Arc<std::sync::RwLock<Vec<(std::net::IpAddr, u8)>>>;
+
 /// Disks to attach to the agent VM.
 pub struct VmDisks<'a> {
     /// Storage disk for OCI layers (/dev/vda in guest).
@@ -198,6 +206,12 @@ pub struct LaunchConfig<'a> {
     /// Whether DNS filtering was configured for this launch, even if the
     /// host-side proxy socket could not be created.
     pub dns_filter_enabled: bool,
+    /// Hostnames to periodically re-resolve for the live egress policy.
+    /// When set, a background thread re-resolves these every 5 minutes and
+    /// atomically replaces the CIDR list via the Arc handle obtained from
+    /// libkrun. This keeps the egress allow-list accurate for long-running VMs
+    /// hitting CDN-backed hosts whose IPs rotate.
+    pub egress_refresh_hosts: Option<Vec<String>>,
 }
 
 /// Launch the agent VM using libkrun.
@@ -217,6 +231,7 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
         packed_layers_dir,
         extra_disks,
         dns_filter_enabled,
+        egress_refresh_hosts,
     } = config;
 
     crate::network::validate_requested_network_backend(resources, None, port_mappings.len())?;
@@ -687,6 +702,87 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
             return Err(Error::agent("set exec command", "krun_set_exec failed"));
         }
 
+        // Egress CIDR live-refresh thread.
+        //
+        // Re-resolves DNS filter hostnames every SMOLVM_EGRESS_REFRESH_SECS
+        // (default 5 min) and atomically replaces the Arc<RwLock<Vec<...>>>
+        // that the vsock muxer reads on every packet. The Arc is borrowed from
+        // libkrun via `krun_get_egress_handle` — see libkrun/src/libkrun/src/lib.rs.
+        //
+        // Each cycle: resolve all hosts → build fresh list → single write-lock
+        // swap. If all hosts fail to resolve, the previous list is kept intact.
+        if let Some(hosts) = egress_refresh_hosts.as_ref().filter(|h| !h.is_empty()) {
+            type GetHandleFn = unsafe extern "C" fn(u32) -> *mut libc::c_void;
+            let get_sym = CString::new("krun_get_egress_handle").expect("symbol name is static");
+            let get_ptr = libc::dlsym(libc::RTLD_DEFAULT, get_sym.as_ptr());
+
+            if !get_ptr.is_null() {
+                #[allow(clippy::missing_transmute_annotations)]
+                let krun_get_egress_handle: GetHandleFn = std::mem::transmute(get_ptr);
+                let raw_handle = krun_get_egress_handle(ctx);
+
+                if !raw_handle.is_null() {
+                    let arc: EgressArc = *Box::from_raw(raw_handle as *mut EgressArc);
+                    let hosts_copy = hosts.clone();
+                    if let Err(e) = std::thread::Builder::new()
+                        .name("egress-refresh".into())
+                        .spawn(move || {
+                            let refresh_secs: u64 = std::env::var("SMOLVM_EGRESS_REFRESH_SECS")
+                                .ok()
+                                .and_then(|s| s.parse().ok())
+                                .unwrap_or(5 * 60);
+                            let refresh_interval = std::time::Duration::from_secs(refresh_secs);
+                            loop {
+                                std::thread::sleep(refresh_interval);
+                                // Resolve all hosts into a fresh list, then swap
+                                // the shared Vec in a single write-lock acquisition.
+                                // This ensures old rotated-away IPs are removed.
+                                let mut fresh: Vec<(std::net::IpAddr, u8)> = Vec::new();
+                                'hosts: for host in &hosts_copy {
+                                    match resolve_host_subprocess(host) {
+                                        Ok(new_cidrs) => {
+                                            for cidr_str in new_cidrs {
+                                                if fresh.len() >= EGRESS_CIDR_CAP {
+                                                    break 'hosts;
+                                                }
+                                                if let Some((ip_str, prefix_str)) =
+                                                    cidr_str.split_once('/')
+                                                {
+                                                    if let (Ok(ip), Ok(prefix)) = (
+                                                        ip_str.parse::<std::net::IpAddr>(),
+                                                        prefix_str.parse::<u8>(),
+                                                    ) {
+                                                        if !fresh.contains(&(ip, prefix)) {
+                                                            fresh.push((ip, prefix));
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        Err(e) => {
+                                            tracing::warn!(
+                                                host = %host,
+                                                error = %e,
+                                                "egress-refresh: resolve failed"
+                                            );
+                                        }
+                                    }
+                                }
+                                // Only replace if at least one host resolved
+                                // successfully; keeps the old list on total failure.
+                                if !fresh.is_empty() {
+                                    let mut guard = arc.write().unwrap_or_else(|e| e.into_inner());
+                                    *guard = fresh;
+                                }
+                            }
+                        })
+                    {
+                        tracing::warn!(error = %e, "egress-refresh spawn failed");
+                    }
+                }
+            }
+        }
+
         // Start VM (this replaces the process on success)
         let ret = krun_start_enter(ctx);
 
@@ -751,6 +847,62 @@ fn format_mac(mac: [u8; 6]) -> String {
         "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
         mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
     )
+}
+
+/// Resolve a hostname to /32 CIDR strings for the egress-refresh thread.
+///
+/// ## Why not `getaddrinfo`?
+///
+/// The `egress-refresh` thread runs inside the `_boot-vm` subprocess. Before
+/// `krun_start_enter` is called, `internal_boot.rs` closes every inherited FD
+/// from 3 up to `max_fd`. Apple's Network framework maps shared memory at
+/// process launch and accesses it via FD-derived handles. After the mass close,
+/// those handles are invalid, so any call to `getaddrinfo` (which routes
+/// through the Network framework on macOS) crashes with SIGBUS at
+/// `_os_log_preferences_refresh` inside `nw_path_libinfo_path_check`.
+///
+/// Spawning an external `dig` process sidesteps this: `exec()` gives the child
+/// a completely fresh address space, so it never touches the broken inherited
+/// shared memory. On non-macOS platforms `getaddrinfo` via glibc is safe and
+/// is used directly.
+#[cfg(target_os = "macos")]
+#[inline(never)]
+fn resolve_host_subprocess(host: &str) -> std::result::Result<Vec<String>, String> {
+    // `/usr/bin/dig` is always present on macOS (part of BIND-tools in the
+    // base system). `+short` prints one result per line (IPs and CNAMEs);
+    // `+timeout=5 +tries=2` keeps the refresh loop from stalling the VM on
+    // a flaky network.
+    let output = std::process::Command::new("/usr/bin/dig")
+        .args(["+short", "+timeout=5", "+tries=2", host])
+        .output()
+        .map_err(|e| format!("dig subprocess failed for '{}': {}", host, e))?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // `+short` emits CNAMEs (ending in '.') interleaved with IPs; parse::<IpAddr>
+    // silently skips the CNAME lines, leaving only valid addresses.
+    let cidrs: Vec<String> = stdout
+        .lines()
+        .filter_map(|line| {
+            line.trim()
+                .parse::<std::net::IpAddr>()
+                .ok()
+                .map(|ip| format!("{}/32", ip))
+        })
+        .collect();
+
+    if cidrs.is_empty() {
+        return Err(format!("dig resolved '{}' to no IP addresses", host));
+    }
+    Ok(cidrs)
+}
+
+/// On non-macOS (Linux), `getaddrinfo` is safe to call from background threads
+/// in child processes — glibc does not use shared-memory handles that become
+/// invalid after a mass FD close. Delegate directly to the standard resolver.
+#[cfg(not(target_os = "macos"))]
+#[inline(never)]
+fn resolve_host_subprocess(host: &str) -> std::result::Result<Vec<String>, String> {
+    crate::smolfile::resolve_host_to_cidrs(host)
 }
 
 /// Raise file descriptor limits (required by libkrun).

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -1162,6 +1162,7 @@ impl AgentManager {
                     .dns_filter_hosts
                     .as_ref()
                     .is_some_and(|hosts| !hosts.is_empty()),
+                egress_refresh_hosts: features.dns_filter_hosts.clone(),
             });
 
             // If we get here, something went wrong (stderr is /dev/null,

--- a/src/cli/internal_boot.rs
+++ b/src/cli/internal_boot.rs
@@ -121,6 +121,7 @@ pub fn run(config_path: PathBuf) -> smolvm::Result<()> {
             .dns_filter_hosts
             .as_ref()
             .is_some_and(|hosts| !hosts.is_empty()),
+        egress_refresh_hosts: config.dns_filter_hosts.clone(),
     });
 
     // If we get here, launch_agent_vm returned (should only happen on error)

--- a/src/cli/smolfile.rs
+++ b/src/cli/smolfile.rs
@@ -12,7 +12,7 @@ use smolvm::network::NetworkBackend;
 use std::path::PathBuf;
 
 // Re-export from the library
-pub use smolvm::smolfile::{parse_duration_secs, resolve_host_to_cidrs, Smolfile};
+pub use smolvm::smolfile::{parse_duration_secs, Smolfile};
 
 /// Load and parse a Smolfile from the given path.
 pub fn load(path: &std::path::Path) -> smolvm::Result<Smolfile> {
@@ -174,18 +174,14 @@ pub fn build_create_params(
     // Merge network policy: [network] section, then CLI extends
     let network = sf.network.unwrap_or_default();
 
-    // Preserve original hostnames for DNS filtering
+    // Preserve original hostnames for DNS filtering.
+    // Do NOT resolve these to CIDRs here — CDN-backed hosts rotate IPs and the
+    // resolved addresses would be stale by the time the machine is started.
+    // Re-resolution happens at `machine start` time (see start_vm_named).
     let sf_allow_hosts = network.allow_hosts;
 
-    // Resolve hostnames to CIDRs for egress policy
+    // Parse [network].allow_cidrs — these are explicit stable CIDRs, stored as-is.
     let mut allowed_cidrs_vec: Vec<String> = Vec::new();
-    for host in &sf_allow_hosts {
-        let cidrs = resolve_host_to_cidrs(host)
-            .map_err(|e| smolvm::Error::config("smolfile [network] allow_hosts", e))?;
-        allowed_cidrs_vec.extend(cidrs);
-    }
-
-    // Parse [network].allow_cidrs
     let sf_cidrs: Vec<String> = network
         .allow_cidrs
         .iter()
@@ -198,7 +194,7 @@ pub fn build_create_params(
     allowed_cidrs_vec.extend(cli_allow_cidr);
 
     // --allow-cidr / --allow-host / [network] implies --net
-    let net = if !allowed_cidrs_vec.is_empty() {
+    let net = if !allowed_cidrs_vec.is_empty() || !sf_allow_hosts.is_empty() {
         true
     } else {
         net

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -539,7 +539,35 @@ pub fn start_vm_named(name: &str) -> smolvm::Result<()> {
 
     let mounts = record.host_mounts();
     let ports = record.port_mappings();
-    let resources = record.vm_resources();
+    let mut resources = record.vm_resources();
+
+    // Re-resolve allow_hosts to fresh CIDRs at start time.
+    // Hostnames for CDN-backed services (e.g. dl-cdn.alpinelinux.org) rotate
+    // IPs — storing resolved CIDRs at `machine create` time means the egress
+    // policy goes stale. We re-resolve here so the policy always reflects
+    // current DNS, then merge with any explicit allow_cidrs stored in the DB.
+    //
+    // IMPORTANT: always initialize allowed_cidrs (even to an empty Vec) when
+    // dns_filter_hosts is set. This ensures launcher.rs always calls
+    // krun_set_egress_policy, even when every hostname fails to resolve.
+    // Without this, a DNS outage at start time causes the VM to boot with no
+    // egress restriction at all (fail-open). With it, the policy starts as
+    // deny-all and launcher.rs's ensure_dns_in_cidrs adds 1.1.1.1/32 as the
+    // minimum (fail-closed: only DNS reachable until resolution succeeds).
+    if let Some(ref hosts) = record.dns_filter_hosts {
+        if !hosts.is_empty() {
+            let existing = resources.allowed_cidrs.get_or_insert_with(Vec::new);
+            for host in hosts {
+                match crate::cli::parsers::resolve_host_to_cidrs(host) {
+                    Ok(cidrs) => existing.extend(cidrs),
+                    Err(e) => eprintln!(
+                        "Warning: could not resolve '{}' for egress policy: {}",
+                        host, e
+                    ),
+                }
+            }
+        }
+    }
 
     // Check for host port conflicts with other running VMs.
     if !ports.is_empty() {

--- a/tests/test_machine.sh
+++ b/tests/test_machine.sh
@@ -724,6 +724,198 @@ test_machine_allow_host_persists_across_restart() {
     [[ $exit_code_after -ne 0 ]]
 }
 
+# Regression test for GitHub issue #124:
+# Smolfile [network].allow_hosts should work on persistent machines even after
+# IP rotation (CDN-backed hosts). Tests that egress policy is re-resolved at
+# `machine start` time using fresh DNS, not stale CIDRs from create time.
+#
+# Strategy: create via Smolfile, then use sqlite3 to overwrite allowed_cidrs
+# with a bogus RFC-5737 TEST-NET address (192.0.2.0/24) — simulating stale
+# CDN IPs. With the fix, start must re-resolve allow_hosts and override the
+# stale stored value; without it, egress would be blocked.
+test_smolfile_allow_hosts_stale_cidr_regression() {
+    local vm_name="allow-hosts-stale-test-$$"
+
+    # sqlite3 is required to inject stale CIDRs into the DB
+    if ! command -v sqlite3 >/dev/null 2>&1; then
+        echo "SKIP: sqlite3 not available"
+        return 0
+    fi
+
+    $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
+    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+
+    local tmpdir
+    tmpdir=$(mktemp -d)
+
+    # Smolfile with allow_hosts — no explicit allow_cidrs.
+    # one.one.one.one resolves to 1.1.1.1 / 1.0.0.1 (Cloudflare DNS).
+    cat > "$tmpdir/Smolfile.toml" <<'EOF'
+[network]
+allow_hosts = ["one.one.one.one"]
+EOF
+
+    (
+        cd "$tmpdir"
+        $SMOLVM machine create "$vm_name" -s Smolfile.toml 2>&1
+    ) || { rm -rf "$tmpdir"; return 1; }
+
+    # Determine DB path (matches SmolvmDb::default_path logic)
+    local db_path
+    if [[ "$(uname)" == "Darwin" ]]; then
+        db_path="$HOME/Library/Application Support/smolvm/server/smolvm.db"
+    else
+        db_path="$HOME/.local/share/smolvm/server/smolvm.db"
+    fi
+
+    # Inject stale CIDRs — 192.0.2.0/24 is RFC 5737 TEST-NET, never routed.
+    # This simulates the old bug: CIDRs resolved at create time that are now
+    # stale due to CDN IP rotation.
+    # The data column is stored as BLOB. json_set returns TEXT, so we must
+    # CAST both ways: TEXT for JSON manipulation, then back to BLOB for storage.
+    sqlite3 "$db_path" \
+        "UPDATE vms SET data = CAST(json_set(CAST(data AS TEXT), '$.allowed_cidrs', json('[\"192.0.2.0/24\"]')) AS BLOB) WHERE name = '$vm_name'" \
+        2>&1 || { echo "sqlite3 update failed"; rm -rf "$tmpdir"; $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+
+    # Start — fix must re-resolve allow_hosts and override the stale CIDRs
+    $SMOLVM machine start --name "$vm_name" 2>&1 \
+        || { rm -rf "$tmpdir"; $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+
+    # Probe egress using 1.0.0.1 as the resolver — also a valid IP for
+    # one.one.one.one, but NOT auto-added by ensure_dns_in_cidrs (which only
+    # injects 1.1.1.1). With stale CIDRs and no re-resolution, 1.0.0.1 is
+    # blocked; with the fix, fresh resolution adds it and the query succeeds.
+    local exit_code=0
+    $SMOLVM machine exec --name "$vm_name" -- nslookup one.one.one.one 1.0.0.1 2>&1 || exit_code=$?
+
+    $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
+    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    # Fallback: if machine delete failed due to a corrupt DB row (e.g. from a
+    # botched sqlite3 update), remove the row directly so it doesn't poison
+    # subsequent test runs that scan all rows.
+    sqlite3 "$db_path" "DELETE FROM vms WHERE name = '$vm_name'" 2>/dev/null || true
+    rm -rf "$tmpdir"
+    ensure_data_dir_deleted "$vm_name"
+
+    [[ $exit_code -eq 0 ]]
+}
+
+# Basic e2e: Smolfile [network].allow_hosts permits egress to the named host
+# and blocks egress to hosts not in the list. This verifies the Smolfile path
+# (distinct from --allow-host CLI flag) works end-to-end at start time.
+test_smolfile_allow_hosts_egress_basic() {
+    local vm_name="allow-hosts-sf-basic-$$"
+
+    $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
+    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+
+    local tmpdir
+    tmpdir=$(mktemp -d)
+
+    cat > "$tmpdir/Smolfile.toml" <<'EOF'
+[network]
+allow_hosts = ["one.one.one.one"]
+EOF
+
+    (
+        cd "$tmpdir"
+        $SMOLVM machine create "$vm_name" -s Smolfile.toml 2>&1
+    ) || { rm -rf "$tmpdir"; return 1; }
+
+    $SMOLVM machine start --name "$vm_name" 2>&1 \
+        || { rm -rf "$tmpdir"; $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+
+    # Probe 1: 1.1.1.1 — always in the egress policy via ensure_dns_in_cidrs.
+    # Verifies the policy doesn't block what it should allow, but does NOT
+    # prove that hostname resolution ran (1.1.1.1 is auto-added regardless).
+    local exit_code_allowed=0
+    $SMOLVM machine exec --name "$vm_name" -- nslookup one.one.one.one 1.1.1.1 2>&1 || exit_code_allowed=$?
+
+    # Probe 2: 1.0.0.1 — a real IP of one.one.one.one, but NOT auto-added by
+    # ensure_dns_in_cidrs. This probe passes only if allow_hosts DNS resolution
+    # actually ran and added 1.0.0.1 to the CIDR list. It is the definitive
+    # proof that the hostname-to-CIDR path works end-to-end.
+    local exit_code_resolution=0
+    $SMOLVM machine exec --name "$vm_name" -- nslookup one.one.one.one 1.0.0.1 2>&1 || exit_code_resolution=$?
+
+    # Egress to a non-allowed resolver (8.8.8.8) must be blocked
+    local exit_code_blocked=0
+    $SMOLVM machine exec --name "$vm_name" -- nslookup cloudflare.com 8.8.8.8 2>&1 || exit_code_blocked=$?
+
+    $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
+    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    rm -rf "$tmpdir"
+    ensure_data_dir_deleted "$vm_name"
+
+    [[ $exit_code_allowed -eq 0 ]] && [[ $exit_code_resolution -eq 0 ]] && [[ $exit_code_blocked -ne 0 ]]
+}
+
+# Stability smoke test for the egress refresh thread.
+#
+# Why we can't do a full e2e regression test for the refresh thread:
+#   `dns_filter_hosts` in VmRecord drives BOTH start-time re-resolution (in
+#   start_vm_named) AND the refresh thread. If dns_filter_hosts is set, start
+#   time already resolves both 1.1.1.1 and 1.0.0.1 into the policy — leaving
+#   nothing for the refresh thread to newly add. If dns_filter_hosts is null,
+#   the refresh thread also has no hosts to resolve. There is no external
+#   interface to inject stale state into the running muxer's Arc.
+#
+# What this test verifies instead:
+#   The machine starts with allow_hosts and SMOLVM_EGRESS_REFRESH_SECS=10.
+#   After waiting for 2 refresh cycles, egress to the allowed host still works.
+#   This confirms: (1) the refresh thread does not crash, (2) it does not corrupt
+#   the egress policy, and (3) existing CIDRs are preserved across refreshes.
+#
+# The true "adds new CIDR" behavior requires a unit test with controlled DNS.
+#
+# Note: this test takes ~25 seconds due to the sleep.
+test_egress_refresh_thread_stability() {
+    local vm_name="egress-refresh-smoke-$$"
+
+    $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
+    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+
+    local tmpdir
+    tmpdir=$(mktemp -d)
+
+    cat > "$tmpdir/Smolfile.toml" <<'EOF'
+[network]
+allow_hosts = ["one.one.one.one"]
+EOF
+
+    (
+        cd "$tmpdir"
+        $SMOLVM machine create "$vm_name" -s Smolfile.toml 2>&1
+    ) || { rm -rf "$tmpdir"; return 1; }
+
+    # Start with a 10-second refresh interval so the thread fires twice during
+    # the test window without making the test slow.
+    SMOLVM_EGRESS_REFRESH_SECS=10 $SMOLVM machine start --name "$vm_name" 2>&1 \
+        || { rm -rf "$tmpdir"; $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+
+    # Verify egress works immediately after start.
+    local exit_code_before=0
+    $SMOLVM machine exec --name "$vm_name" -- nslookup one.one.one.one 1.1.1.1 2>&1 \
+        || exit_code_before=$?
+
+    # Wait for two refresh cycles to fire (2 × 10 s + 5 s buffer).
+    echo "  Waiting 25s for two egress refresh cycles..."
+    sleep 25
+
+    # Egress must still work after refreshes — the thread must not have
+    # wiped or corrupted the existing CIDR list.
+    local exit_code_after=0
+    $SMOLVM machine exec --name "$vm_name" -- nslookup one.one.one.one 1.1.1.1 2>&1 \
+        || exit_code_after=$?
+
+    $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
+    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    rm -rf "$tmpdir"
+    ensure_data_dir_deleted "$vm_name"
+
+    [[ $exit_code_before -eq 0 ]] && [[ $exit_code_after -eq 0 ]]
+}
+
 # =============================================================================
 # Persistent Rootfs (Overlay)
 # Tests verify that the overlayfs root is active and persists across reboots.
@@ -1356,6 +1548,9 @@ run_test "Egress: invalid hostname rejected at create" test_machine_egress_allow
 run_test "Egress: host:port syntax rejected" test_machine_egress_allow_host_port_rejected || true
 run_test "DNS filter: blocks resolution of non-allowed domains" test_machine_dns_filter_blocks_resolution || true
 run_test "DNS filter: allow-host persists across restart" test_machine_allow_host_persists_across_restart || true
+run_test "Smolfile: allow_hosts basic egress permitted/blocked" test_smolfile_allow_hosts_egress_basic || true
+run_test "Smolfile: allow_hosts re-resolves stale CIDRs on start (issue #124)" test_smolfile_allow_hosts_stale_cidr_regression || true
+run_test "Egress refresh thread: stability across refresh cycles" test_egress_refresh_thread_stability || true
 run_test "Overlay: root is overlayfs" test_machine_overlay_root_active || true
 run_test "Overlay: rootfs persists across reboot" test_machine_rootfs_persists_across_reboot || true
 run_test "Volume: mount visible to exec" test_machine_volume_mount_visible_to_exec || true


### PR DESCRIPTION
A lot of comments to explain the decisions.

Basically underlying cidr rotates despite the domain names staying the same. Over a long period of time - the vm will stop having access to networking due to those rotations.