### PR TITLE
fix(agent): run each connection on its own thread; scope child reaper

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -1276,6 +1276,49 @@ fn mount_storage_disk() -> bool {
     false
 }
 
+/// Maximum number of vsock connections serviced concurrently.
+/// Bounds thread count and prevents vsock channel saturation.
+/// 8 (2^3) gives headroom for several parallel execs plus the state probe.
+const MAX_CONCURRENT_CONNECTIONS: usize = 8;
+
+/// A counting semaphore for bounding concurrent connection handlers.
+struct ConnectionSemaphore {
+    inner: std::sync::Arc<(std::sync::Mutex<usize>, std::sync::Condvar)>,
+}
+
+impl ConnectionSemaphore {
+    fn new(n: usize) -> Self {
+        Self {
+            inner: std::sync::Arc::new((std::sync::Mutex::new(n), std::sync::Condvar::new())),
+        }
+    }
+
+    fn acquire(&self) -> ConnectionPermit {
+        let (lock, cvar) = &*self.inner;
+        let mut count = lock.lock().unwrap();
+        while *count == 0 {
+            count = cvar.wait(count).unwrap();
+        }
+        *count -= 1;
+        ConnectionPermit {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+/// RAII guard that releases a semaphore slot when dropped.
+struct ConnectionPermit {
+    inner: std::sync::Arc<(std::sync::Mutex<usize>, std::sync::Condvar)>,
+}
+
+impl Drop for ConnectionPermit {
+    fn drop(&mut self) {
+        let (lock, cvar) = &*self.inner;
+        *lock.lock().unwrap() += 1;
+        cvar.notify_one();
+    }
+}
+
 /// Run the vsock server with a pre-created listener.
 /// The listener is created early (before initialization) to ensure the kernel
 /// has a listener ready when the host connects.
@@ -1284,11 +1327,12 @@ fn run_server_with_listener(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut first_connection = true;
     let listen_start = uptime_ms();
+    let semaphore = std::sync::Arc::new(ConnectionSemaphore::new(MAX_CONCURRENT_CONNECTIONS));
 
     info!(uptime_ms = uptime_ms(), "entering vsock accept loop");
 
     loop {
-        // Reap any exited background children to prevent zombie accumulation
+        // Reap any exited background children to prevent zombie accumulation.
         reap_background_children();
 
         match listener.accept() {
@@ -1303,9 +1347,22 @@ fn run_server_with_listener(
                 }
                 info!("accepted connection");
 
-                if let Err(e) = handle_connection(&mut stream) {
-                    warn!(error = %e, "connection error");
-                }
+                // Acquire a slot before spawning; blocks if MAX_CONCURRENT_CONNECTIONS
+                // threads are already running. This bounds thread count and prevents
+                // vsock channel saturation under heavy concurrency.
+                let permit = semaphore.acquire();
+
+                // Service the connection in its own thread so a long-running
+                // exec doesn't block subsequent requests on the same listener.
+                // Before this landed, a single held-open `machine exec` would
+                // stall the 250ms state probe, flip the VM to Unreachable,
+                // and make every following exec fail with "not running".
+                std::thread::spawn(move || {
+                    let _permit = permit;
+                    if let Err(e) = handle_connection(&mut stream) {
+                        warn!(error = %e, "connection error");
+                    }
+                });
             }
             Err(e) => {
                 warn!(error = %e, "accept error");
@@ -3593,22 +3650,55 @@ fn handle_storage_status() -> AgentResponse {
 // VM-Level Exec Handlers (Direct Execution in VM)
 // ============================================================================
 
-/// Handle VM-level exec (non-interactive).
-/// Executes command directly in the VM's rootfs without any container isolation.
+/// PIDs of background children the agent owns and must reap.
+///
+/// Populated by [`register_background_child`] when a background-mode
+/// handler (`handle_vm_exec_background`, `handle_run_background`)
+/// spawns + forgets a process. Cleared by [`reap_background_children`].
+///
+/// Scoping to known PIDs is required once the accept loop is
+/// multi-threaded: an unscoped `waitpid(-1, WNOHANG)` would steal the
+/// exit status from *any* exited child — including the foreground
+/// crun processes that per-request handlers are actively waiting on —
+/// and produce ECHILD races under concurrent load.
+static BG_CHILDREN: OnceLock<std::sync::Mutex<Vec<u32>>> = OnceLock::new();
+
+fn bg_children() -> &'static std::sync::Mutex<Vec<u32>> {
+    BG_CHILDREN.get_or_init(|| std::sync::Mutex::new(Vec::new()))
+}
+
+/// Track a PID so a later [`reap_background_children`] waits on it.
+///
+/// Callers should pair this with `std::mem::forget(child)` so the
+/// Rust `Child` doesn't also race to reap the process on drop.
+fn register_background_child(pid: u32) {
+    bg_children().lock().unwrap().push(pid);
+}
+
 /// Reap any exited background children to prevent zombie accumulation.
 ///
-/// Called periodically in the accept loop. Uses `waitpid(-1, WNOHANG)`
-/// to collect all exited children without blocking. Safe to call even
-/// when no background children exist.
+/// Called periodically in the accept loop. Walks the registered PID
+/// list and issues a per-PID `waitpid(..., WNOHANG)` — non-blocking
+/// and scoped, so it never steals exit statuses from foreground
+/// handlers running in sibling threads.
 #[cfg(target_os = "linux")]
 fn reap_background_children() {
-    loop {
-        let ret = unsafe { libc::waitpid(-1, std::ptr::null_mut(), libc::WNOHANG) };
-        if ret <= 0 {
-            break;
+    let mut guard = bg_children().lock().unwrap();
+    guard.retain(|&pid| {
+        let ret = unsafe { libc::waitpid(pid as i32, std::ptr::null_mut(), libc::WNOHANG) };
+        match ret {
+            // >0 = child was reaped; drop from tracking.
+            r if r > 0 => {
+                debug!(pid, "reaped background child");
+                false
+            }
+            // 0 = still running; keep tracking for the next sweep.
+            0 => true,
+            // <0 = error (typically ECHILD — already reaped elsewhere or the
+            // PID was detached in a way we don't own). Drop either way.
+            _ => false,
         }
-        debug!(pid = ret, "reaped background child");
-    }
+    });
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -3648,9 +3738,12 @@ fn handle_vm_exec_background(
     match cmd.spawn() {
         Ok(child) => {
             let pid = child.id();
-            // Don't wait — let the child run independently.
-            // reap_background_children() in the accept loop collects the exit status.
+            // Don't wait — let the child run independently. The Rust
+            // `Child` is forgotten so drop doesn't race our reaper, and
+            // the PID is registered so reap_background_children()
+            // collects the eventual exit status.
             std::mem::forget(child);
+            register_background_child(pid);
             info!(pid = pid, "background process started");
             AgentResponse::Completed {
                 exit_code: 0,
@@ -3990,6 +4083,98 @@ fn send_response(
 /// Trait for read+write streams with raw fd access.
 trait ReadWrite: Read + Write + AsRawFd {}
 impl<T: Read + Write + AsRawFd> ReadWrite for T {}
+
+/// Regression tests for the scoped background-child reaper.
+///
+/// These are the companion to the accept-loop threading change. The bug
+/// they guard against: once the accept loop spawns a thread per
+/// connection, an unscoped `waitpid(-1, WNOHANG)` in the reaper steals
+/// exit statuses from any foreground crun process that a sibling thread
+/// is waiting on, producing ECHILD races and "command died mid-run"
+/// failures. Scoped reaping must only touch PIDs registered as
+/// background.
+///
+/// Linux-only because `waitpid` behavior + the agent crate as a whole
+/// is Linux-specific. `cargo test -p smolvm-agent --target
+/// aarch64-unknown-linux-musl` on a Linux runner.
+#[cfg(test)]
+#[cfg(target_os = "linux")]
+mod bg_reap_tests {
+    use super::*;
+    use std::process::Command;
+    use std::time::Duration;
+
+    #[test]
+    fn reaper_leaves_unregistered_children_waitable() {
+        // Foreground child: the test owns it and will wait on it. The
+        // reaper must NOT steal it.
+        let mut foreground = Command::new("/bin/true")
+            .spawn()
+            .expect("spawn foreground /bin/true");
+        let fg_pid = foreground.id();
+
+        // Background child: registered, and the Rust Child handle is
+        // forgotten so drop doesn't race the reaper.
+        let background = Command::new("/bin/true")
+            .spawn()
+            .expect("spawn background /bin/true");
+        let bg_pid = background.id();
+        register_background_child(bg_pid);
+        std::mem::forget(background);
+
+        // Let both exit before we reap.
+        std::thread::sleep(Duration::from_millis(150));
+
+        reap_background_children();
+
+        // Foreground must still be reapable via the Rust Child. If the
+        // unscoped reaper stole it, wait() returns ECHILD and this
+        // expect() fires — that's exactly the concurrent-exec bug.
+        let status = foreground.wait().expect(
+            "foreground child must still be waitable — reaper must not touch unregistered PIDs",
+        );
+        assert!(status.success(), "foreground /bin/true should succeed");
+
+        // Background PID should be gone from tracking (reaped). Check
+        // only this test's PID so parallel tests don't interfere.
+        let tracked = bg_children().lock().unwrap().clone();
+        assert!(
+            !tracked.contains(&bg_pid),
+            "reaped bg PID {} must be removed from tracking",
+            bg_pid
+        );
+        assert!(
+            !tracked.contains(&fg_pid),
+            "unregistered fg PID {} must never enter tracking",
+            fg_pid
+        );
+    }
+
+    #[test]
+    fn reaper_retains_still_running_background_children() {
+        // A registered but still-alive child must stay in tracking so a
+        // subsequent sweep collects it after it exits.
+        let mut child = Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn sleep 30");
+        let pid = child.id();
+        register_background_child(pid);
+
+        reap_background_children();
+
+        let tracked = bg_children().lock().unwrap().clone();
+        assert!(
+            tracked.contains(&pid),
+            "still-running bg PID {} must remain in tracking",
+            pid
+        );
+
+        // Clean up so the test doesn't leak a 30-second sleep.
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/tests/test_machine.sh
+++ b/tests/test_machine.sh
@@ -2468,6 +2468,48 @@ test_state_probe_tolerates_busy_agent() {
 }
 
 run_test "State probe tolerates busy agent (no false unreachable)" test_state_probe_tolerates_busy_agent || true
+
+# Regression test for https://github.com/smol-machines/smolvm/issues/199
+# The agent's vsock accept loop was single-threaded: a long-running exec held
+# the handler, the 250ms state probe timed out, the record flipped to
+# "unreachable", and every subsequent exec failed with "machine is not running".
+# Fix: each accepted connection is handed to its own thread.
+test_concurrent_exec_does_not_flip_unreachable() {
+    ensure_machine_running
+
+    # Hold a long-running exec open in the background.
+    $SMOLVM machine exec -- sh -c 'sleep 5' &
+    local hold_pid=$!
+
+    # Give it time to be accepted by the agent and block the old single thread.
+    sleep 1
+
+    # A second exec must succeed while the first is still running.
+    local second_output
+    second_output=$($SMOLVM machine exec -- echo concurrent_ok 2>&1)
+    local second_exit=$?
+
+    # Also verify state did not flip to unreachable.
+    local state
+    state=$($SMOLVM machine ls 2>&1 | grep "^default " | awk '{print $2}')
+
+    wait "$hold_pid" 2>/dev/null
+
+    if [[ $second_exit -ne 0 ]]; then
+        echo "FAIL: second concurrent exec failed (exit $second_exit): $second_output"
+        return 1
+    fi
+    if [[ "$second_output" != *"concurrent_ok"* ]]; then
+        echo "FAIL: second exec output unexpected: $second_output"
+        return 1
+    fi
+    if [[ "$state" != "running" ]]; then
+        echo "FAIL: VM flipped to '$state' during concurrent exec (expected 'running')"
+        return 1
+    fi
+}
+
+run_test "Concurrent exec does not flip VM to unreachable" test_concurrent_exec_does_not_flip_unreachable || true
 run_test "Listing: machine ls does not kill VM" test_machine_ls_does_not_kill_vm || true
 run_test "Listing: named VM survives repeated ls" test_named_vm_survives_ls || true
 run_test "Images: does not stop running VM" test_images_does_not_stop_running_vm || true


### PR DESCRIPTION
Fixes #199.

## Problem

The vsock accept loop serviced one connection at a time. A long-running
`machine exec` held the single handler thread, so the host's 250 ms state
probe couldn't get an ack, flipped the record to `Unreachable`, and every
subsequent exec failed with "machine '…' is not running". The VM itself
was fine; only the host's view of it died.

## Fix

Each accepted stream is handed to its own `std::thread::spawn`. Execs,
pulls, and probes run in parallel; concurrent execs against the same VM
no longer starve the probe.

**Concurrency hazard introduced, and how it's handled:** the old reaper
called `waitpid(-1, WNOHANG)` — unscoped, so with sibling threads waiting
on specific children (crun processes for foreground runs) it would steal
their exit statuses and produce ECHILD races. Fix: track a `Vec<u32>` of
PIDs the agent spawned into background mode, and only reap those specific
PIDs. Foreground handlers keep owning their own `std::process::Child` and
calling `wait()` directly.

Also includes a prerequisite chore: four tests in `process.rs` called
`Vec<u8>::contains("string")` which can't compile — converts them to
`String::from_utf8_lossy(...).contains(...)`.

## Test plan

- [x] Manually reproduced the bug on `upstream/main`: held a `machine exec -- sh -c 'sleep 60'` open, `machine ls` showed `default unreachable`, second exec failed with "machine 'default' is not running"
- [x] With this fix applied: `machine ls` shows `default running` while exec is held open, second concurrent exec returns `probe` (exit 0)
- [x] Regression tests for the scoped reaper (Linux-only, agent crate): reaper leaves unregistered children waitable, retains still-running registered children across sweeps