### PR TITLE
fix: machine start re-dispatches workload for run -d-created VMs

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -1483,17 +1483,31 @@ fn handle_request(
             interactive: false,
             tty: false,
             persistent_overlay_id,
-        } => handle_run(
-            &image,
-            &command,
-            &env,
-            workdir.as_deref(),
-            user.as_deref(),
-            &mounts,
-            timeout_ms,
-            persistent_overlay_id.as_deref(),
-            client_fd,
-        ),
+            background,
+        } => {
+            if background {
+                handle_run_background(
+                    &image,
+                    &command,
+                    &env,
+                    workdir.as_deref(),
+                    &mounts,
+                    persistent_overlay_id.as_deref(),
+                )
+            } else {
+                handle_run(
+                    &image,
+                    &command,
+                    &env,
+                    workdir.as_deref(),
+                    user.as_deref(),
+                    &mounts,
+                    timeout_ms,
+                    persistent_overlay_id.as_deref(),
+                    client_fd,
+                )
+            }
+        }
 
         AgentRequest::Run { .. } => {
             // Interactive mode should be handled by handle_interactive_run
@@ -3157,6 +3171,39 @@ fn test_tcp_syscall(target: &str) -> serde_json::Value {
 }
 
 /// Handle command execution request (non-interactive).
+/// Handle a background `Run` request — spawn the container and return its PID.
+///
+/// Background mode requires a persistent overlay ID; an ephemeral overlay
+/// would leak because nothing waits for the container to exit to clean it
+/// up. The returned PID is the crun process, which stays alive as long as
+/// the container's init process runs.
+fn handle_run_background(
+    image: &str,
+    command: &[String],
+    env: &[(String, String)],
+    workdir: Option<&str>,
+    mounts: &[(String, String, bool)],
+    persistent_overlay_id: Option<&str>,
+) -> AgentResponse {
+    info!(image = %image, command = ?command, mounts = ?mounts, "running command in background");
+
+    let Some(overlay_id) = persistent_overlay_id else {
+        return AgentResponse::error(
+            "background run requires persistent_overlay_id",
+            error_codes::INVALID_REQUEST,
+        );
+    };
+
+    match storage::spawn_in_overlay(image, command, env, workdir, mounts, overlay_id) {
+        Ok(pid) => AgentResponse::Completed {
+            exit_code: 0,
+            stdout: format!("{}", pid).into_bytes(),
+            stderr: Vec::new(),
+        },
+        Err(e) => AgentResponse::from_err(e, error_codes::RUN_FAILED),
+    }
+}
+
 fn handle_run(
     image: &str,
     command: &[String],

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -2096,6 +2096,85 @@ pub fn run_command(
     result
 }
 
+/// Spawn a command in an image's overlay rootfs and return the crun PID.
+///
+/// Unlike `run_command`, this does not wait for the container to exit. The
+/// container runs detached under crun with stdout/stderr redirected to
+/// /dev/null; the returned PID is the crun process, which stays alive as
+/// long as the container init runs.
+///
+/// Requires a persistent overlay ID — ephemeral overlays would leak their
+/// upper/work/merged directories because nothing is waiting to clean them
+/// up after the container exits.
+pub fn spawn_in_overlay(
+    image: &str,
+    command: &[String],
+    env: &[(String, String)],
+    workdir: Option<&str>,
+    mounts: &[(String, String, bool)],
+    persistent_overlay_id: &str,
+) -> Result<u32> {
+    crate::oci::validate_image_reference(image).map_err(StorageError::new)?;
+    crate::oci::validate_env_vars(env).map_err(StorageError::new)?;
+
+    let prepared = prepare_for_run_persistent(image, persistent_overlay_id)?;
+    debug!(rootfs = %prepared.rootfs_path, "using persistent overlay for background command");
+
+    let mounted_paths = setup_volume_mounts(&prepared.rootfs_path, mounts)?;
+
+    let overlay_root = Path::new(STORAGE_ROOT)
+        .join(OVERLAYS_DIR)
+        .join(&prepared.workload_id);
+    let bundle_path = overlay_root.join("bundle");
+
+    let workdir_str = workdir.unwrap_or("/");
+    let identity = crate::oci::ProcessIdentity::root();
+    let mut spec = OciSpec::new(command, env, workdir_str, false, &identity);
+
+    for (tag, container_path, read_only) in mounts {
+        let virtiofs_mount = Path::new(paths::VIRTIOFS_MOUNT_ROOT).join(tag);
+        spec.add_bind_mount(
+            &virtiofs_mount.to_string_lossy(),
+            container_path,
+            *read_only,
+        );
+    }
+
+    let workspace_src = Path::new(STORAGE_ROOT).join(WORKSPACE_DIR);
+    if workspace_src.exists() {
+        spec.add_bind_mount(&workspace_src.to_string_lossy(), "/workspace", false);
+    }
+
+    crate::ssh_agent::inject_into_container(&mut spec);
+
+    spec.write_to(&bundle_path)
+        .map_err(|e| StorageError::new(format!("failed to write OCI spec: {}", e)))?;
+
+    let container_id = generate_container_id();
+
+    let child = CrunCommand::run(&bundle_path, &container_id)
+        .stdin_null()
+        .discard_output()
+        .spawn()
+        .map_err(|e| {
+            StorageError::new(format!(
+                "failed to spawn crun: {}. Is crun installed at {}?",
+                e,
+                paths::CRUN_PATH
+            ))
+        })?;
+
+    let pid = child.id();
+    // Don't wait on the child; it reaps itself when the container exits.
+    // reap_background_children() in the agent's accept loop collects the
+    // eventual zombie.
+    std::mem::forget(child);
+
+    let _ = mounted_paths; // suppress unused warning; mounts persist with the overlay
+    info!(container_id = %container_id, pid = pid, "background container started");
+    Ok(pid)
+}
+
 /// Prepare for running a command - returns the rootfs path.
 /// This is used by interactive mode which spawns the command separately.
 pub fn prepare_for_run(image: &str) -> Result<PreparedOverlayRootfs> {

--- a/crates/smolvm-protocol/src/lib.rs
+++ b/crates/smolvm-protocol/src/lib.rs
@@ -260,6 +260,11 @@ pub enum AgentRequest {
         /// created and destroyed after the run.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         persistent_overlay_id: Option<String>,
+        /// Spawn the container and return immediately with the crun PID.
+        /// The container runs detached; stdout/stderr go to /dev/null.
+        /// Incompatible with `interactive` and `tty`.
+        #[serde(default)]
+        background: bool,
     },
 
     /// Send stdin data to a running interactive command.

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -322,6 +322,21 @@ fn expect_completed(resp: AgentResponse, op: &str) -> Result<(i32, Vec<u8>, Vec<
     }
 }
 
+#[cfg(test)]
+impl AgentClient {
+    /// Build an `AgentClient` from a pre-connected `UnixStream`.
+    ///
+    /// Test-only: production code must go through [`AgentClient::connect`]
+    /// so socket timeouts are configured correctly. Used by the regression
+    /// tests that drive the client against a `UnixStream::pair()`.
+    pub(crate) fn from_stream(stream: UnixStream) -> Self {
+        Self {
+            stream,
+            trace_id: None,
+        }
+    }
+}
+
 impl AgentClient {
     /// Set socket read timeout, returning an error if it fails.
     ///
@@ -1027,9 +1042,41 @@ impl AgentClient {
             interactive: false,
             tty: false,
             persistent_overlay_id: config.persistent_overlay_id,
+            background: false,
         })?;
 
         expect_completed(resp, "run command")
+    }
+
+    /// Run a command in an image's rootfs in the background.
+    ///
+    /// Spawns the container and returns immediately with the crun PID.
+    /// stdout/stderr go to /dev/null inside the guest. Use a persistent
+    /// overlay ID so subsequent `exec` sessions see the same filesystem.
+    pub fn run_background(&mut self, config: RunConfig) -> Result<u32> {
+        let resp = self.request(&AgentRequest::Run {
+            image: config.image,
+            command: config.command,
+            env: config.env,
+            workdir: config.workdir,
+            user: config.user,
+            mounts: config.mounts,
+            timeout_ms: None,
+            interactive: false,
+            tty: false,
+            persistent_overlay_id: config.persistent_overlay_id,
+            background: true,
+        })?;
+
+        let (exit_code, stdout, _stderr) = expect_completed(resp, "run background")?;
+        if exit_code != 0 {
+            return Err(Error::agent("run background", "spawn failed"));
+        }
+        let pid: u32 = String::from_utf8_lossy(&stdout)
+            .trim()
+            .parse()
+            .map_err(|_| Error::agent("run background", "invalid PID in response"))?;
+        Ok(pid)
     }
 
     /// Run a command interactively with streaming I/O.
@@ -1059,6 +1106,7 @@ impl AgentClient {
                 interactive: true,
                 tty,
                 persistent_overlay_id: config.persistent_overlay_id,
+                background: false,
             },
             tty,
             "run interactive",
@@ -1730,5 +1778,133 @@ mod read_cap_tests {
     fn read_cap_rejects_unexpected_response_type() {
         let err = drive(vec![AgentResponse::Pong { version: 1 }]).unwrap_err();
         assert!(format!("{}", err).contains("unexpected response"));
+    }
+}
+
+#[cfg(test)]
+mod run_background_tests {
+    //! Regression test for image-backed `machine run -d`.
+    //!
+    //! The original bug: the CLI's image + `--detach` path pulled the image
+    //! and persisted the VM record but silently dropped the command. The
+    //! fix wires in `AgentClient::run_background`, which must send a
+    //! `Run { background: true }` over the wire and parse the returned PID.
+    //!
+    //! If this test fails, the detach path either lost its `background`
+    //! plumbing or stopped parsing the PID response — either way, the
+    //! original "command never runs" regression is back.
+    use super::*;
+    use smolvm_protocol::{encode_message, AgentRequest, AgentResponse, Envelope};
+    use std::io::{Read, Write};
+    use std::thread;
+
+    #[test]
+    fn run_background_sends_background_true_and_returns_pid() {
+        let (client_stream, mut server_stream) = UnixStream::pair().unwrap();
+
+        // Fake agent: read one request, assert it's a background Run, respond
+        // with a Completed PID. Mirrors what the real agent does in
+        // `handle_run_background`.
+        let server = thread::spawn(move || {
+            let mut len_buf = [0u8; 4];
+            server_stream.read_exact(&mut len_buf).unwrap();
+            let len = u32::from_be_bytes(len_buf) as usize;
+
+            let mut payload = vec![0u8; len];
+            server_stream.read_exact(&mut payload).unwrap();
+
+            let envelope: Envelope<AgentRequest> =
+                serde_json::from_slice(&payload).expect("valid Envelope<AgentRequest>");
+
+            match envelope.body {
+                AgentRequest::Run {
+                    image,
+                    command,
+                    persistent_overlay_id,
+                    background,
+                    interactive,
+                    tty,
+                    ..
+                } => {
+                    assert!(
+                        background,
+                        "run_background must send background: true — the image+detach CLI path \
+                         depends on this field to dispatch the command inside the container"
+                    );
+                    assert!(!interactive, "background runs are never interactive");
+                    assert!(!tty, "background runs never allocate a TTY");
+                    assert_eq!(image, "alpine:3.19");
+                    assert_eq!(command, vec!["sh", "-c", "echo hi"]);
+                    assert_eq!(
+                        persistent_overlay_id,
+                        Some("default".to_string()),
+                        "background runs must use a persistent overlay so subsequent execs \
+                         see the same filesystem"
+                    );
+                }
+                other => panic!("expected AgentRequest::Run, got {:?}", other),
+            }
+
+            let resp = AgentResponse::Completed {
+                exit_code: 0,
+                stdout: b"12345".to_vec(),
+                stderr: Vec::new(),
+            };
+            let encoded = encode_message(&resp).expect("encode response");
+            server_stream.write_all(&encoded).expect("write response");
+        });
+
+        let mut client = AgentClient::from_stream(client_stream);
+        let config = RunConfig::new(
+            "alpine:3.19",
+            vec!["sh".to_string(), "-c".to_string(), "echo hi".to_string()],
+        )
+        .with_persistent_overlay(Some("default".to_string()));
+
+        let pid = client
+            .run_background(config)
+            .expect("run_background should succeed on a Completed response");
+
+        assert_eq!(pid, 12345, "client must parse the PID from stdout");
+        server.join().expect("server thread joined cleanly");
+    }
+
+    #[test]
+    fn run_background_rejects_nonzero_exit_code() {
+        // If the agent fails to spawn the container, it returns a non-zero
+        // exit_code. The client must turn that into an error rather than
+        // silently returning a bogus PID.
+        let (client_stream, mut server_stream) = UnixStream::pair().unwrap();
+
+        let server = thread::spawn(move || {
+            let mut len_buf = [0u8; 4];
+            server_stream.read_exact(&mut len_buf).unwrap();
+            let len = u32::from_be_bytes(len_buf) as usize;
+            let mut payload = vec![0u8; len];
+            server_stream.read_exact(&mut payload).unwrap();
+
+            let resp = AgentResponse::Completed {
+                exit_code: 1,
+                stdout: Vec::new(),
+                stderr: b"spawn failed".to_vec(),
+            };
+            let encoded = encode_message(&resp).unwrap();
+            server_stream.write_all(&encoded).unwrap();
+        });
+
+        let mut client = AgentClient::from_stream(client_stream);
+        let config = RunConfig::new("alpine:3.19", vec!["true".to_string()])
+            .with_persistent_overlay(Some("default".to_string()));
+
+        let err = client
+            .run_background(config)
+            .expect_err("non-zero exit must surface as an error");
+        assert!(
+            format!("{}", err).contains("spawn failed")
+                || format!("{}", err).contains("run background"),
+            "unexpected error: {}",
+            err
+        );
+        server.join().unwrap();
     }
 }

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -172,7 +172,9 @@ pub struct RunCmd {
     #[arg(trailing_var_arg = true, value_name = "COMMAND")]
     pub command: Vec<String>,
 
-    /// Run in background and keep machine alive after command exits
+    /// Start the command in the background and detach, leaving the VM
+    /// running. Use `machine exec` to run further commands against the VM
+    /// and `machine stop` to tear it down.
     #[arg(short = 'd', long, help_heading = "Execution")]
     pub detach: bool,
 
@@ -537,11 +539,30 @@ impl RunCmd {
                 params.workdir.as_deref(),
             );
             if self.detach {
-                // Detach mode: persist the record with image info.
-                // The VM is already running. The image will be pulled and
-                // command started on subsequent `machine start` if stopped/restarted.
-                // For now, pull the image so it's cached for exec.
+                // Detach mode: pull the image, kick the command off in the
+                // background inside the image's overlay rootfs, and persist
+                // the record so subsequent `machine exec` sessions see the
+                // same filesystem (same overlay ID as the exec path below).
                 crate::cli::pull_with_progress(&mut client, img, self.oci_platform.as_deref())?;
+
+                // Run the resolved command in the background inside the image.
+                // Skip when the command is just the idle default — there's
+                // nothing useful to dispatch.
+                let is_idle = command.is_empty()
+                    || command
+                        == DEFAULT_IDLE_CMD
+                            .iter()
+                            .map(|s| s.to_string())
+                            .collect::<Vec<_>>();
+                if !is_idle {
+                    let bg_config = smolvm::agent::RunConfig::new(img, command.clone())
+                        .with_env(env.clone())
+                        .with_workdir(params.workdir.clone())
+                        .with_mounts(mount_bindings.clone())
+                        .with_persistent_overlay(Some("default".to_string()));
+                    let pid = client.run_background(bg_config)?;
+                    tracing::info!(pid = pid, "background workload started");
+                }
 
                 {
                     use smolvm::config::SmolvmConfig;

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -14,6 +14,7 @@ use smolvm::data::validate_vm_name;
 use smolvm::db::SmolvmDb;
 use smolvm::network::NetworkBackend;
 use smolvm::storage::{DEFAULT_OVERLAY_SIZE_GIB, DEFAULT_STORAGE_SIZE_GIB};
+use smolvm::DEFAULT_IDLE_CMD;
 use smolvm_protocol::ImageInfo;
 use std::io::Write;
 
@@ -690,9 +691,26 @@ pub fn start_vm_named(name: &str) -> smolvm::Result<()> {
         return Err(e);
     }
 
-    if record.image.is_some() {
-        // Image-based machine: VM is running, image pulled and cached,
-        // init done. Sits idle until `machine exec` is called.
+    if let Some(ref image) = record.image {
+        let mut bg_cmd = record.entrypoint.clone();
+        bg_cmd.extend(record.cmd.clone());
+        if bg_cmd.is_empty() {
+            if let Some(image_info) = image_info.as_ref() {
+                bg_cmd = image_info.entrypoint.clone();
+                bg_cmd.extend(image_info.cmd.clone());
+            }
+        }
+        if should_dispatch_background_workload(&bg_cmd) {
+            let bg_config = smolvm::agent::RunConfig::new(image, bg_cmd)
+                .with_env(record.env.clone())
+                .with_workdir(record.workdir.clone())
+                .with_mounts(crate::cli::parsers::record_mounts_to_runconfig_bindings(
+                    &record.mounts,
+                ))
+                .with_persistent_overlay(Some(name.to_string()));
+            let bg_pid = client.run_background(bg_config)?;
+            tracing::info!(pid = bg_pid, "background workload restarted");
+        }
         println!("Machine '{}' running (PID: {})", name, pid.unwrap_or(0));
     } else {
         // No image — bare VM mode. Run entrypoint+cmd if configured.
@@ -728,6 +746,18 @@ pub fn start_vm_named(name: &str) -> smolvm::Result<()> {
     // Keep VM running (persistent)
     manager.detach();
     Ok(())
+}
+
+fn should_dispatch_background_workload(command: &[String]) -> bool {
+    !command.is_empty() && !is_default_idle_command(command)
+}
+
+fn is_default_idle_command(command: &[String]) -> bool {
+    command.len() == DEFAULT_IDLE_CMD.len()
+        && command
+            .iter()
+            .map(String::as_str)
+            .eq(DEFAULT_IDLE_CMD.iter().copied())
 }
 
 /// Persist the "default" VM as running in the database.
@@ -1510,6 +1540,25 @@ mod init_runner_tests {
                 "pacman -Sy && pacman -S git".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn background_workload_dispatch_skips_empty_and_idle_commands() {
+        let cases = [
+            (Vec::<String>::new(), false),
+            (
+                DEFAULT_IDLE_CMD
+                    .iter()
+                    .map(|part| part.to_string())
+                    .collect(),
+                false,
+            ),
+            (vec!["echo".to_string(), "hello".to_string()], true),
+        ];
+
+        for (command, expected) in cases {
+            assert_eq!(should_dispatch_background_workload(&command), expected);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Re-dispatch the persisted workload on `machine start` for image-backed VMs created via `machine run -d`. After `stop` + `start`, the VM was running but had no PID 1, every subsequent `exec` hit the bare-Alpine fallback and reported the workload missing.

## Why this matters

Issue [#201](https://github.com/smol-machines/smolvm/issues/201) traces the bug to `start_vm_named` in `src/cli/vm_common.rs:512`:

> Looking at the existing `start_vm_named` path: for image-backed machines, it pulls the image, runs init commands, and reports "Machine 'X' running (PID: N)", but never spawns the primary container. The documented `machine create` + `machine start` flow is intentionally no-container ("persistent dev env" pattern). The same code path runs for `run -d`-created records, even though the semantic contract is different.

- @geekgonecrazy in [#201](https://github.com/smol-machines/smolvm/issues/201)

This breaks the contract the issue calls out:

> A VM created with `machine run -d -s Smolfile` comes up with the Smolfile's `cmd` running as the primary workload. After `machine stop` + `machine start`, the VM reports state `running` again, but the workload is silently gone.

## Approach

`start_vm_named` already calls `pull_with_progress` for image-backed machines and gets back `image_info`. After init runs, resolve the workload command in the same order `RunCmd::run` resolves it at first launch:

1. Persisted record `entrypoint + cmd` (Smolfile cmd, CLI trailing args)
2. Fall back to OCI image metadata (`image_info.entrypoint + image_info.cmd`) so plain `machine run -d --image nginx` lineage works after restart
3. Empty after both → skip dispatch (preserves `machine create` no-container lineage)
4. Resolves to `DEFAULT_IDLE_CMD` → skip dispatch

When dispatch fires, build a `RunConfig` with the persisted env, workdir, mounts (via `record_mounts_to_runconfig_bindings`), and `with_persistent_overlay(Some(name))`, then call `client.run_background(config)`, the helper introduced in #215.

## Stack note

This builds on #215. The `AgentClient::run_background` call site here is the same shape #215 uses for first-launch dispatch in `RunCmd::run`. Do not merge until #215 lands, this PR's diff includes #215's commit. After #215 merges to main, this PR will rebase down to the ~52-line restart-side change in `src/cli/vm_common.rs`.

## Changes

- `src/cli/vm_common.rs::start_vm_named`, image branch resolves the workload, falls back to OCI metadata, dispatches via `client.run_background` when non-empty and non-idle.
- New helpers `should_dispatch_background_workload` and `is_default_idle_command` (private, in the same module).
- Unit test covering the gate decision against empty / `DEFAULT_IDLE_CMD` / real-command inputs.
- `machine create` lineage (empty record + idle image entrypoint) is unchanged, no spurious workload spawned.

## Testing

```
cargo fmt --all -- --check          # clean
cargo clippy --all-targets -- -D warnings  # clean
cargo build --release               # ok
cargo test --bin smolvm             # 31 passed (includes new background_workload_dispatch test)
```

Manual stop/start/exec round-trip verification needs a real Hypervisor.framework host and libkrun runtime; the gate logic is the part the unit test exercises directly. The dispatch path itself is the same one #215 already exercised in its tests at first launch.

Fixes #201.
