### PR TITLE
feat: Homebrew formula for smolvm

### DIFF
--- a/Casks/smolvm.rb
+++ b/Casks/smolvm.rb
@@ -1,0 +1,27 @@
+cask "smolvm" do
+  version "0.5.20"
+  sha256 "92d687486852f78ea5ddf12be88c879ae9b8d8fc2bd7159de6586df0cb71d3e1"
+
+  url "https://github.com/smol-machines/smolvm/releases/download/v#{version}/smolvm-#{version}-darwin-arm64.tar.gz"
+  name "smolvm"
+  desc "OCI-native microVM runtime with sub-200ms boot"
+  homepage "https://github.com/smol-machines/smolvm"
+
+  depends_on arch: :arm64
+  depends_on macos: ">= :big_sur"
+
+  binary "smolvm"
+
+  caveats <<~EOS
+    smolvm needs the agent rootfs at:
+      ~/Library/Application Support/smolvm/agent-rootfs
+
+    The runtime does not follow symlinks for that directory, so copy it on
+    first install (the staged files live in the Caskroom):
+
+      mkdir -p "$HOME/Library/Application Support/smolvm"
+      cp -a "#{staged_path}/agent-rootfs" "$HOME/Library/Application Support/smolvm/"
+
+    smolvm requires macOS 11 or later and Hypervisor.framework access.
+  EOS
+end

--- a/Formula/smolvm.rb
+++ b/Formula/smolvm.rb
@@ -1,0 +1,61 @@
+class Smolvm < Formula
+  desc "OCI-native microVM runtime with sub-200ms boot"
+  homepage "https://github.com/smol-machines/smolvm"
+  version "0.5.20"
+  license "Apache-2.0"
+
+  if OS.mac?
+    odie "smolvm currently ships an Apple Silicon build only" if Hardware::CPU.intel?
+    url "https://github.com/smol-machines/smolvm/releases/download/v#{version}/smolvm-#{version}-darwin-arm64.tar.gz"
+    sha256 "92d687486852f78ea5ddf12be88c879ae9b8d8fc2bd7159de6586df0cb71d3e1"
+  else
+    odie "smolvm currently ships a Linux x86_64 build only" if Hardware::CPU.arm?
+    url "https://github.com/smol-machines/smolvm/releases/download/v#{version}/smolvm-#{version}-linux-x86_64.tar.gz"
+    sha256 "68431f36711c27dbb989e9ca55f42188a5788faab95a965a3f126481248efc1a"
+  end
+
+  depends_on "e2fsprogs"
+
+  def install
+    libexec.install Dir["*"]
+
+    # The wrapper script in libexec/ resolves symlinks so a bin/ symlink works.
+    bin.install_symlink libexec/"smolvm"
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        smolvm needs the agent rootfs at:
+          ~/Library/Application Support/smolvm/agent-rootfs
+
+        The runtime does not follow symlinks for that directory, so copy it on
+        first install:
+
+          mkdir -p "$HOME/Library/Application Support/smolvm"
+          cp -a "#{libexec}/agent-rootfs" "$HOME/Library/Application Support/smolvm/"
+
+        smolvm requires macOS 11 or later and Hypervisor.framework access.
+      EOS
+    end
+    on_linux do
+      <<~EOS
+        smolvm needs the agent rootfs at:
+          ${XDG_DATA_HOME:-$HOME/.local/share}/smolvm/agent-rootfs
+
+        Copy it on first install:
+
+          DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/smolvm"
+          mkdir -p "$DATA_DIR"
+          cp -a "#{libexec}/agent-rootfs" "$DATA_DIR/"
+
+        smolvm needs /dev/kvm. Make sure your user is in the kvm group:
+          sudo usermod -aG kvm $USER  # then log out / log back in
+      EOS
+    end
+  end
+
+  test do
+    assert_match "smolvm", shell_output("#{bin}/smolvm --version")
+  end
+end

--- a/Formula/smolvm.rb
+++ b/Formula/smolvm.rb
@@ -16,6 +16,13 @@ class Smolvm < Formula
 
   depends_on "e2fsprogs"
 
+  on_linux do
+    # The Linux x86_64 release links against Linuxbrew's libbz2.so.1.0. Without
+    # this dep, smolvm-bin fails at startup with "libbz2.so.1.0 => not found"
+    # (reported on Fedora, PR #223).
+    depends_on "bzip2"
+  end
+
   def install
     libexec.install Dir["*"]
 

--- a/Formula/smolvm.rb
+++ b/Formula/smolvm.rb
@@ -19,7 +19,9 @@ class Smolvm < Formula
   on_linux do
     # The Linux x86_64 release links against Linuxbrew's libbz2.so.1.0. Without
     # this dep, smolvm-bin fails at startup with "libbz2.so.1.0 => not found"
-    # (reported on Fedora, PR #223).
+    # (reported on Fedora, PR #223). libkrun.so.1 has no RUNPATH set, so
+    # patchelf at install time so it can locate libbz2 from Linuxbrew's lib/.
+    depends_on "patchelf" => :build
     depends_on "bzip2"
   end
 
@@ -28,6 +30,11 @@ class Smolvm < Formula
 
     # The wrapper script in libexec/ resolves symlinks so a bin/ symlink works.
     bin.install_symlink libexec/"smolvm"
+    if OS.linux?
+      system "patchelf",
+             "--set-rpath", "#{libexec}/lib:#{HOMEBREW_PREFIX}/lib",
+             libexec/"lib/libkrun.so.1"
+    end
   end
 
   def caveats


### PR DESCRIPTION
## Summary

A Homebrew formula for smolvm. Pulls the prebuilt darwin-arm64 / linux-x86_64 release tarball from GitHub releases, installs the wrapper + binary + libs + agent-rootfs to `libexec`, and links the `smolvm` wrapper into `bin`.

## Why this matters

Issue [#15](https://github.com/smol-machines/smolvm/issues/15) was filed by @BinSquare:

> Instead of curl installation, brew would improve the user x

@luciodaou added the Homebrew Formula Cookbook + Adding-Software-to-Homebrew docs links. This PR is the formula that closes the gap. Once a `smol-machines/homebrew-tap` repo exists and mirrors this file, users will be able to:

```
brew install smol-machines/tap/smolvm
```

## Approach

Binary-tarball formula (no compilation). The release tarballs are already self-contained (smolvm wrapper, smolvm-bin, libkrun*.dylib, agent-rootfs, ext4 templates, README), so the formula just unpacks them.

The wrapper script in the tarball resolves symlinks before computing `SCRIPT_DIR`, so `bin/smolvm -> libexec/smolvm` works without modification.

## Layout

After install:
```
$(brew --prefix)/bin/smolvm                      # symlink
$(brew --prefix)/Cellar/smolvm/0.5.20/libexec/
    smolvm                                        # wrapper script
    smolvm-bin                                    # Mach-O / ELF binary
    lib/                                          # libkrun*.dylib (macOS) / .so (Linux)
    agent-rootfs/                                 # guest rootfs
    storage-template.ext4
    overlay-template.ext4
    checksums.txt
    README.txt
```

## Caveats handle the agent-rootfs

The runtime does not follow symlinks for the agent-rootfs directory (per the bundled README), so the formula's `caveats` tells the user to copy `libexec/agent-rootfs` to:

- macOS: `~/Library/Application Support/smolvm/agent-rootfs`
- Linux: `${XDG_DATA_HOME:-~/.local/share}/smolvm/agent-rootfs`

Doing this in `caveats` rather than `post_install` matches Homebrew's "no per-user side effects in formula install" convention. If a future smolvm release follows symlinks, the caveat can drop.

## Dependencies

- `e2fsprogs` (per the bundled README troubleshooting: needed for storage disk formatting)

Linux requires `/dev/kvm` and the user in the `kvm` group; that's already in the caveats.

## Tap setup (out of scope, for the maintainer)

Before users can `brew install smol-machines/tap/smolvm`, you need a tap repo. The standard pattern:

1. Create `smol-machines/homebrew-tap` (Homebrew auto-resolves `tap` to `homebrew-tap`).
2. Mirror `Formula/smolvm.rb` there. (Or have a workflow in this repo bump the tap on every release.)
3. The formula here in-tree stays as the source of truth.

`homebrew-core` is not the right home for smolvm because it depends on the bundled libkrun dylibs (vendored in the release tarball) rather than a homebrew-core libkrun, which homebrew-core would reject.

## Verification (local tap)

```
brew tap-new mvanhorn/smolvm-test
cp Formula/smolvm.rb $(brew --repo mvanhorn/smolvm-test)/Formula/

brew audit --strict --new mvanhorn/smolvm-test/smolvm    # clean (exit 0, no output)
brew install mvanhorn/smolvm-test/smolvm                  # ok
which smolvm                                              # /opt/homebrew/bin/smolvm
smolvm --version                                          # smolvm 0.5.20
brew test mvanhorn/smolvm-test/smolvm                     # passes (smolvm --version)
```

## Update flow

When a new smolvm release ships:
1. Update `version` in `Formula/smolvm.rb`.
2. Update both `sha256` lines from the new `checksums.sha256` asset.

Could be automated in `.github/workflows/release.yml` later.

Closes #15.
