### PR TITLE
feat: virtio-net - part 6: honor egress policies

### DIFF
--- a/crates/smolvm-network/Cargo.toml
+++ b/crates/smolvm-network/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 [dependencies]
 crossbeam-queue = "0.3"
 humantime = "2"
+ipnet = "2.12.0"
 libc = "0.2"
 smoltcp = { version = "0.13", default-features = false, features = [
     "std",

--- a/crates/smolvm-network/src/lib.rs
+++ b/crates/smolvm-network/src/lib.rs
@@ -60,6 +60,7 @@
 pub mod device;
 pub mod frame_stream;
 pub mod guest_env;
+pub mod policy;
 pub mod queues;
 pub mod stack;
 pub mod tcp_listeners;
@@ -73,6 +74,7 @@ use std::thread::JoinHandle;
 use std::time::SystemTime;
 
 use frame_stream::{start_frame_stream_bridge, FrameStreamBridge};
+pub use policy::EgressPolicy;
 use queues::{NetworkFrameQueues, DEFAULT_FRAME_QUEUE_CAPACITY};
 use stack::{start_network_stack, VirtioPollConfig};
 use tcp_listeners::{create_tcp_channel, TcpPortListeners};
@@ -223,6 +225,7 @@ pub fn start_virtio_network(
     host_fd: RawFd,
     guest_network: GuestNetworkConfig,
     published_ports: &[PortMapping],
+    egress_policy: EgressPolicy,
 ) -> io::Result<VirtioNetworkRuntime> {
     virtio_net_log!(
         "virtio-net: starting runtime host_fd={} guest_ip={} gateway_ip={} dns_server={}",
@@ -255,6 +258,7 @@ pub fn start_virtio_network(
             mtu: 1500,
         },
         tcp_listeners.as_ref().map(|_| tcp_receiver),
+        egress_policy,
     )?;
 
     Ok(VirtioNetworkRuntime {

--- a/crates/smolvm-network/src/policy.rs
+++ b/crates/smolvm-network/src/policy.rs
@@ -1,0 +1,509 @@
+//! Egress policy support for the host-side virtio-net runtime.
+
+use ipnet::IpNet;
+use std::net::{IpAddr, ToSocketAddrs};
+use std::sync::mpsc::{self, RecvTimeoutError, Sender};
+use std::sync::{Arc, RwLock};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+const EGRESS_REFRESH_ENV: &str = "SMOLVM_EGRESS_REFRESH_SECS";
+const DEFAULT_EGRESS_REFRESH_SECS: u64 = 5 * 60;
+
+const DNS_HEADER_LEN: usize = 12;
+const DNS_FLAGS_HIGH_OFFSET: usize = 2;
+const DNS_FLAGS_LOW_OFFSET: usize = 3;
+const DNS_QUESTION_COUNT_OFFSET: usize = 4;
+const DNS_QUESTION_START: usize = DNS_HEADER_LEN;
+const DNS_RESPONSE_COUNT_START: usize = 6;
+const DNS_RESPONSE_COUNT_END: usize = DNS_HEADER_LEN;
+const DNS_ROOT_LABEL: u8 = 0;
+const DNS_LABEL_POINTER_MASK: u8 = 0xC0;
+const DNS_RESPONSE_FLAG: u8 = 0x80;
+const DNS_OPCODE_BITS: u8 = 0x78;
+const DNS_LOW_FLAG_BITS: u8 = 0xF0;
+const DNS_RECURSION_AVAILABLE_FLAG: u8 = 0x80;
+
+#[derive(Debug, Clone, Copy)]
+enum DnsResponseCode {
+    ServFail = 0x02,
+    NxDomain = 0x03,
+}
+
+impl DnsResponseCode {
+    fn bits(self) -> u8 {
+        self as u8
+    }
+}
+
+/// Launch-time egress policy inputs for the virtio-net runtime.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct EgressPolicy {
+    /// Allowed guest egress destination ranges. `None` means unrestricted;
+    /// `Some([])` means no TCP destinations are allowed.
+    pub allowed_cidrs: Option<Vec<String>>,
+    /// Allowed DNS hostnames. When set, guest DNS queries for other names get
+    /// NXDOMAIN responses from the gateway.
+    pub dns_filter_hosts: Option<Vec<String>>,
+}
+
+/// Runtime-ready egress policy.
+#[derive(Debug)]
+pub(crate) struct ResolvedEgressPolicy {
+    allowed_cidrs: Option<AllowedCidrs>,
+    dns_filter: Option<DnsFilter>,
+}
+
+impl ResolvedEgressPolicy {
+    /// Compile launch-time strings into efficient runtime checks.
+    pub(crate) fn compile(policy: EgressPolicy) -> Result<Self, String> {
+        let dns_filter_hosts = policy.dns_filter_hosts.unwrap_or_default();
+        let has_cidr_policy = policy.allowed_cidrs.is_some() || !dns_filter_hosts.is_empty();
+
+        let allowed_cidrs = if has_cidr_policy {
+            Some(AllowedCidrs::new(
+                policy.allowed_cidrs.unwrap_or_default(),
+                dns_filter_hosts.clone(),
+            )?)
+        } else {
+            None
+        };
+
+        let dns_filter = if dns_filter_hosts.is_empty() {
+            None
+        } else {
+            Some(DnsFilter::new(dns_filter_hosts))
+        };
+
+        Ok(Self {
+            allowed_cidrs,
+            dns_filter,
+        })
+    }
+
+    /// Whether a guest TCP destination IP is allowed.
+    pub(crate) fn allows_ip(&self, ip: IpAddr) -> bool {
+        match &self.allowed_cidrs {
+            None => true,
+            Some(cidrs) => cidrs.allows_ip(ip),
+        }
+    }
+
+    /// Filter a raw DNS query when hostname policy is configured.
+    ///
+    /// Returns `None` when DNS filtering is not active.
+    pub(crate) fn filter_dns_query(&self, query: &[u8]) -> Option<DnsQueryAction> {
+        self.dns_filter
+            .as_ref()
+            .map(|filter| filter.classify_query(query))
+    }
+}
+
+/// Policy result for one raw DNS query.
+pub(crate) enum DnsQueryAction {
+    /// The query is allowed and should be forwarded upstream.
+    Forward,
+    /// Return this DNS response to the guest without forwarding.
+    Respond(Vec<u8>),
+}
+
+#[derive(Debug)]
+struct AllowedCidrs {
+    static_cidrs: Vec<IpNet>,
+    _refresh_thread: Option<RefreshThread>,
+    refreshed_host_cidrs: Option<Arc<RwLock<Vec<IpNet>>>>,
+}
+
+impl AllowedCidrs {
+    fn new(static_cidrs: Vec<String>, refresh_hosts: Vec<String>) -> Result<Self, String> {
+        let static_cidrs = static_cidrs
+            .into_iter()
+            .map(|cidr| parse_cidr_or_ip(&cidr))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let (refreshed_host_cidrs, refresh_thread) = if refresh_hosts.is_empty() {
+            (None, None)
+        } else {
+            let initial = resolve_hosts_to_ipnets(&refresh_hosts);
+            let refreshed = Arc::new(RwLock::new(initial));
+            let refresh_thread = spawn_egress_refresh_thread(refresh_hosts, refreshed.clone());
+            (Some(refreshed), refresh_thread)
+        };
+
+        Ok(Self {
+            static_cidrs,
+            _refresh_thread: refresh_thread,
+            refreshed_host_cidrs,
+        })
+    }
+
+    fn allows_ip(&self, ip: IpAddr) -> bool {
+        self.static_cidrs.iter().any(|cidr| cidr.contains(&ip))
+            || self.refreshed_host_cidrs.as_ref().is_some_and(|cidrs| {
+                cidrs
+                    .read()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .iter()
+                    .any(|cidr| cidr.contains(&ip))
+            })
+    }
+}
+
+struct RefreshThread {
+    shutdown_tx: Sender<()>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl std::fmt::Debug for RefreshThread {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RefreshThread").finish_non_exhaustive()
+    }
+}
+
+impl Drop for RefreshThread {
+    fn drop(&mut self) {
+        let _ = self.shutdown_tx.send(());
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct DnsFilter {
+    allowed: Vec<String>,
+}
+
+impl DnsFilter {
+    fn new(allowed: Vec<String>) -> Self {
+        Self { allowed }
+    }
+
+    fn is_allowed(&self, domain: &str) -> bool {
+        let domain = domain.trim_end_matches('.');
+        self.allowed.iter().any(|pattern| {
+            let pattern = pattern.trim_end_matches('.');
+            domain.eq_ignore_ascii_case(pattern)
+                || domain
+                    .to_ascii_lowercase()
+                    .ends_with(&format!(".{}", pattern.to_ascii_lowercase()))
+        })
+    }
+
+    fn classify_query(&self, query: &[u8]) -> DnsQueryAction {
+        let Some(domain) = extract_domain_from_query(query) else {
+            return DnsQueryAction::Respond(build_error_response(query, DnsResponseCode::ServFail));
+        };
+
+        if !self.is_allowed(&domain) {
+            return DnsQueryAction::Respond(build_error_response(query, DnsResponseCode::NxDomain));
+        }
+
+        DnsQueryAction::Forward
+    }
+}
+
+fn parse_cidr_or_ip(value: &str) -> Result<IpNet, String> {
+    value
+        .parse::<IpNet>()
+        .or_else(|_| value.parse::<IpAddr>().map(IpNet::from))
+        .map_err(|_| format!("invalid CIDR or IP address in egress policy: {value}"))
+}
+
+fn resolve_host_to_ipnets(host: &str) -> Result<Vec<IpNet>, String> {
+    if host.contains(':') {
+        return Err(format!(
+            "invalid hostname '{host}': port suffixes are not supported"
+        ));
+    }
+
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        return Ok(vec![IpNet::from(ip)]);
+    }
+
+    let mut ipnets = Vec::new();
+    for addr in format!("{host}:0")
+        .to_socket_addrs()
+        .map_err(|e| format!("failed to resolve '{host}': {e}"))?
+    {
+        push_unique_ipnet(&mut ipnets, IpNet::from(addr.ip()));
+    }
+
+    if ipnets.is_empty() {
+        return Err(format!("'{host}' resolved to no IP addresses"));
+    }
+
+    Ok(ipnets)
+}
+
+fn resolve_hosts_to_ipnets(hosts: &[String]) -> Vec<IpNet> {
+    let mut fresh = Vec::new();
+    for host in hosts {
+        match resolve_host_to_ipnets(host) {
+            Ok(ipnets) => {
+                for ipnet in ipnets {
+                    push_unique_ipnet(&mut fresh, ipnet);
+                }
+            }
+            Err(err) => {
+                tracing::warn!(
+                    host = %host,
+                    error = %err,
+                    "virtio-net egress refresh: resolve failed"
+                );
+            }
+        }
+    }
+    fresh
+}
+
+fn push_unique_ipnet(ipnets: &mut Vec<IpNet>, ipnet: IpNet) {
+    if !ipnets.contains(&ipnet) {
+        ipnets.push(ipnet);
+    }
+}
+
+fn spawn_egress_refresh_thread(
+    hosts: Vec<String>,
+    cidrs: Arc<RwLock<Vec<IpNet>>>,
+) -> Option<RefreshThread> {
+    let (shutdown_tx, shutdown_rx) = mpsc::channel();
+    let spawn_result = thread::Builder::new()
+        .name("virtio-net-egress-refresh".into())
+        .spawn(move || {
+            let refresh_interval = Duration::from_secs(
+                std::env::var(EGRESS_REFRESH_ENV)
+                    .ok()
+                    .and_then(|s| s.parse().ok())
+                    .filter(|secs| *secs > 0)
+                    .unwrap_or(DEFAULT_EGRESS_REFRESH_SECS),
+            );
+
+            loop {
+                match shutdown_rx.recv_timeout(refresh_interval) {
+                    Ok(()) | Err(RecvTimeoutError::Disconnected) => return,
+                    Err(RecvTimeoutError::Timeout) => {}
+                }
+
+                let fresh = resolve_hosts_to_ipnets(&hosts);
+                if fresh.is_empty() {
+                    tracing::warn!(
+                        "virtio-net egress refresh resolved no hosts; keeping previous CIDR list"
+                    );
+                    continue;
+                }
+
+                let mut guard = cidrs.write().unwrap_or_else(|e| e.into_inner());
+                *guard = fresh;
+            }
+        });
+
+    match spawn_result {
+        Ok(handle) => Some(RefreshThread {
+            shutdown_tx,
+            handle: Some(handle),
+        }),
+        Err(err) => {
+            tracing::warn!(error = %err, "virtio-net egress refresh spawn failed");
+            None
+        }
+    }
+}
+
+fn extract_domain_from_query(packet: &[u8]) -> Option<String> {
+    if packet.len() < DNS_HEADER_LEN {
+        return None;
+    }
+
+    if dns_question_count(packet) == 0 {
+        return None;
+    }
+
+    let mut pos = DNS_QUESTION_START;
+    let mut labels = Vec::new();
+
+    loop {
+        if pos >= packet.len() {
+            return None;
+        }
+
+        let label_len = packet[pos];
+        if label_len == DNS_ROOT_LABEL {
+            break;
+        }
+        if is_dns_compression_pointer(label_len) {
+            return None;
+        }
+
+        pos += 1;
+        let label_len = usize::from(label_len);
+        if pos + label_len > packet.len() {
+            return None;
+        }
+
+        let label = std::str::from_utf8(&packet[pos..pos + label_len]).ok()?;
+        labels.push(label.to_string());
+        pos += label_len;
+    }
+
+    if labels.is_empty() {
+        None
+    } else {
+        Some(labels.join("."))
+    }
+}
+
+fn dns_question_count(packet: &[u8]) -> u16 {
+    u16::from_be_bytes([
+        packet[DNS_QUESTION_COUNT_OFFSET],
+        packet[DNS_QUESTION_COUNT_OFFSET + 1],
+    ])
+}
+
+fn is_dns_compression_pointer(label_len: u8) -> bool {
+    label_len & DNS_LABEL_POINTER_MASK == DNS_LABEL_POINTER_MASK
+}
+
+fn build_error_response(query: &[u8], rcode: DnsResponseCode) -> Vec<u8> {
+    if query.len() < DNS_HEADER_LEN {
+        return vec![];
+    }
+
+    let mut response = query.to_vec();
+
+    // Turn the copied query into a DNS response while preserving the query opcode.
+    response[DNS_FLAGS_HIGH_OFFSET] =
+        DNS_RESPONSE_FLAG | (response[DNS_FLAGS_HIGH_OFFSET] & DNS_OPCODE_BITS);
+
+    // Preserve the high flag bits in the low flag byte and set the DNS response code.
+    response[DNS_FLAGS_LOW_OFFSET] =
+        (response[DNS_FLAGS_LOW_OFFSET] & DNS_LOW_FLAG_BITS) | rcode.bits();
+
+    // Tell the guest resolver recursion is available, matching normal recursive DNS replies.
+    response[DNS_FLAGS_LOW_OFFSET] |= DNS_RECURSION_AVAILABLE_FLAG;
+
+    // Error responses answer the original question but carry no DNS records.
+    response[DNS_RESPONSE_COUNT_START..DNS_RESPONSE_COUNT_END].fill(0);
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_query(domain: &str) -> Vec<u8> {
+        let mut packet = vec![
+            0x12, 0x34, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+        for label in domain.split('.') {
+            packet.push(label.len() as u8);
+            packet.extend_from_slice(label.as_bytes());
+        }
+        packet.push(0x00);
+        packet.extend_from_slice(&[0x00, 0x01, 0x00, 0x01]);
+        packet
+    }
+
+    #[test]
+    fn cidr_policy_allows_matching_ips() {
+        let policy = ResolvedEgressPolicy::compile(EgressPolicy {
+            allowed_cidrs: Some(vec!["10.0.0.0/8".into(), "1.1.1.1".into()]),
+            dns_filter_hosts: None,
+        })
+        .unwrap();
+
+        assert!(policy.allows_ip("10.2.3.4".parse().unwrap()));
+        assert!(policy.allows_ip("1.1.1.1".parse().unwrap()));
+        assert!(!policy.allows_ip("8.8.8.8".parse().unwrap()));
+    }
+
+    #[test]
+    fn empty_cidr_policy_denies_tcp_destinations() {
+        let policy = ResolvedEgressPolicy::compile(EgressPolicy {
+            allowed_cidrs: Some(vec![]),
+            dns_filter_hosts: None,
+        })
+        .unwrap();
+
+        assert!(!policy.allows_ip("1.1.1.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn invalid_cidr_is_rejected() {
+        let err = ResolvedEgressPolicy::compile(EgressPolicy {
+            allowed_cidrs: Some(vec!["not-a-cidr".into()]),
+            dns_filter_hosts: None,
+        })
+        .unwrap_err();
+
+        assert!(err.contains("invalid CIDR or IP address"));
+    }
+
+    #[test]
+    fn hostname_policy_restricts_tcp_destinations_without_static_cidrs() {
+        let policy = ResolvedEgressPolicy::compile(EgressPolicy {
+            allowed_cidrs: None,
+            dns_filter_hosts: Some(vec!["1.1.1.1".into()]),
+        })
+        .unwrap();
+
+        assert!(policy.allows_ip("1.1.1.1".parse().unwrap()));
+        assert!(!policy.allows_ip("8.8.8.8".parse().unwrap()));
+    }
+
+    #[test]
+    fn hostname_policy_extends_static_cidrs() {
+        let policy = ResolvedEgressPolicy::compile(EgressPolicy {
+            allowed_cidrs: Some(vec!["10.0.0.0/8".into()]),
+            dns_filter_hosts: Some(vec!["1.1.1.1".into()]),
+        })
+        .unwrap();
+
+        assert!(policy.allows_ip("10.2.3.4".parse().unwrap()));
+        assert!(policy.allows_ip("1.1.1.1".parse().unwrap()));
+        assert!(!policy.allows_ip("8.8.8.8".parse().unwrap()));
+    }
+
+    #[test]
+    fn dns_filter_matches_exact_and_subdomain_names() {
+        let filter = DnsFilter::new(vec!["api.example.com".into()]);
+
+        assert!(filter.is_allowed("api.example.com"));
+        assert!(filter.is_allowed("v1.api.example.com"));
+        assert!(!filter.is_allowed("example.com"));
+    }
+
+    #[test]
+    fn dns_filter_blocks_disallowed_queries() {
+        let policy = ResolvedEgressPolicy::compile(EgressPolicy {
+            allowed_cidrs: None,
+            dns_filter_hosts: Some(vec!["allowed.example.com".into()]),
+        })
+        .unwrap();
+
+        let action = policy
+            .filter_dns_query(&build_query("blocked.example.com"))
+            .unwrap();
+
+        let DnsQueryAction::Respond(response) = action else {
+            panic!("blocked query should return a synthetic DNS response");
+        };
+        assert_eq!(response[3] & 0x0F, 0x03);
+    }
+
+    #[test]
+    fn dns_filter_forwards_allowed_queries() {
+        let policy = ResolvedEgressPolicy::compile(EgressPolicy {
+            allowed_cidrs: None,
+            dns_filter_hosts: Some(vec!["allowed.example.com".into()]),
+        })
+        .unwrap();
+
+        assert!(matches!(
+            policy
+                .filter_dns_query(&build_query("allowed.example.com"))
+                .unwrap(),
+            DnsQueryAction::Forward
+        ));
+    }
+}

--- a/crates/smolvm-network/src/stack.rs
+++ b/crates/smolvm-network/src/stack.rs
@@ -51,6 +51,7 @@
 //! ```
 
 use crate::device::VirtioNetworkDevice;
+use crate::policy::{DnsQueryAction, EgressPolicy, ResolvedEgressPolicy};
 use crate::queues::NetworkFrameQueues;
 use crate::tcp_listeners::AcceptedTcpConnection;
 use crate::tcp_relay::{spawn_tcp_relay, TcpRelayTable};
@@ -74,6 +75,7 @@ use std::time::{Duration, Instant as StdInstant};
 const DNS_SOCKET_PORT: u16 = 53;
 const DNS_PACKET_SLOTS: usize = 8;
 const DNS_BUFFER_BYTES: usize = 2048;
+const DNS_TRANSACTION_ID_LEN: usize = 2;
 const DEFAULT_IDLE_TIMEOUT_MS: i32 = 100;
 
 /// Resolved network parameters for one guest NIC.
@@ -119,6 +121,7 @@ pub fn start_network_stack(
     queues: Arc<NetworkFrameQueues>,
     config: VirtioPollConfig,
     tcp_receiver: Option<Receiver<AcceptedTcpConnection>>,
+    policy: EgressPolicy,
 ) -> std::io::Result<JoinHandle<()>> {
     virtio_net_log!(
         "virtio-net: spawning poll thread guest_ip={} gateway_ip={} mtu={}",
@@ -126,15 +129,28 @@ pub fn start_network_stack(
         config.gateway_ipv4,
         config.mtu
     );
+    let upstream_dns = match DEFAULT_DNS_ADDR {
+        std::net::IpAddr::V4(ip) => ip,
+        std::net::IpAddr::V6(_) => {
+            return Err(std::io::Error::other(
+                "virtio DNS policy currently requires an IPv4 upstream resolver",
+            ));
+        }
+    };
+    let policy = ResolvedEgressPolicy::compile(policy).map_err(std::io::Error::other)?;
+    let dns_forwarder = HostDnsForwarder::new(upstream_dns)?;
+
     thread::Builder::new()
         .name("smolvm-net-poll".into())
-        .spawn(move || run_network_stack(queues, config, tcp_receiver))
+        .spawn(move || run_network_stack(queues, config, tcp_receiver, policy, dns_forwarder))
 }
 
 fn run_network_stack(
     queues: Arc<NetworkFrameQueues>,
     config: VirtioPollConfig,
     mut tcp_receiver: Option<Receiver<AcceptedTcpConnection>>,
+    policy: ResolvedEgressPolicy,
+    mut dns_forwarder: HostDnsForwarder,
 ) {
     // Poll loop overview:
     //
@@ -200,6 +216,15 @@ fn run_network_stack(
                         source,
                         destination
                     );
+                    if !policy.allows_ip(destination.ip()) {
+                        tracing::warn!(
+                            source = %source,
+                            destination = %destination,
+                            "dropping guest TCP SYN because destination is blocked by policy"
+                        );
+                        device.drop_staged_frame();
+                        continue;
+                    }
                     if !relays.has_socket_for(&source, &destination) {
                         relays.create_tcp_socket(source, destination, &mut sockets);
                     }
@@ -245,7 +270,7 @@ fn run_network_stack(
         // Move payloads between established smoltcp TCP sockets and host relay
         // threads, and service the DNS gateway socket.
         relays.relay_data(&mut sockets);
-        process_dns_queries(dns_socket_handle, &mut sockets);
+        process_dns_queries(dns_socket_handle, &policy, &mut dns_forwarder, &mut sockets);
 
         // Once the guest-side TCP handshake is established inside smoltcp, we
         // can spawn the corresponding host relay thread.
@@ -403,14 +428,16 @@ fn relay_accepted_tcp_connection(
     }
 }
 
-fn process_dns_queries(dns_socket_handle: SocketHandle, sockets: &mut SocketSet<'_>) {
+fn process_dns_queries(
+    dns_socket_handle: SocketHandle,
+    policy: &ResolvedEgressPolicy,
+    dns_forwarder: &mut HostDnsForwarder,
+    sockets: &mut SocketSet<'_>,
+) {
     // Phase 1 DNS model:
     // guest UDP/53 -> smoltcp gateway socket -> host UDP socket -> upstream DNS
     //               <-               response bytes               <-
-    let upstream_dns = match DEFAULT_DNS_ADDR {
-        std::net::IpAddr::V4(ip) => ip,
-        std::net::IpAddr::V6(_) => return,
-    };
+    let upstream_dns = dns_forwarder.upstream_dns();
 
     let socket = sockets.get_mut::<UdpSocket>(dns_socket_handle);
     while socket.can_recv() {
@@ -425,12 +452,15 @@ fn process_dns_queries(dns_socket_handle: SocketHandle, sockets: &mut SocketSet<
             query.len(),
             upstream_dns
         );
-        let response = match forward_dns_query(upstream_dns, query) {
-            Ok(response) => response,
-            Err(err) => {
-                virtio_net_log!("virtio-net: host DNS forwarding failed error={}", err);
-                continue;
-            }
+        let response = match policy.filter_dns_query(query) {
+            Some(DnsQueryAction::Respond(response)) => response,
+            Some(DnsQueryAction::Forward) | None => match dns_forwarder.forward(query) {
+                Ok(response) => response,
+                Err(err) => {
+                    virtio_net_log!("virtio-net: host DNS forwarding failed error={}", err);
+                    continue;
+                }
+            },
         };
         virtio_net_log!(
             "virtio-net: forwarded DNS response back to guest guest={} response_len={}",
@@ -447,34 +477,71 @@ fn process_dns_queries(dns_socket_handle: SocketHandle, sockets: &mut SocketSet<
     }
 }
 
-fn forward_dns_query(upstream_dns: Ipv4Addr, query: &[u8]) -> std::io::Result<Vec<u8>> {
-    // This is intentionally a plain host UDP exchange rather than a smoltcp
-    // socket-to-socket relay. Once the guest packet reaches the gateway, the
-    // simplest MVP path is to proxy it with the host kernel's UDP stack.
-    //
-    // Rough shell equivalent:
-    //   send raw DNS message to `<upstream_dns>:53`
-    //   wait up to 2 seconds for one reply
-    let socket = HostUdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0))?;
-    socket.set_read_timeout(Some(Duration::from_secs(2)))?;
-    let local_addr = socket.local_addr()?;
-    virtio_net_log!(
-        "virtio-net: sending DNS query to upstream resolver local_addr={} upstream_dns={} query_len={}",
-        local_addr,
-        upstream_dns,
-        query.len()
-    );
-    socket.send_to(query, (upstream_dns, DNS_SOCKET_PORT))?;
+struct HostDnsForwarder {
+    upstream_dns: Ipv4Addr,
+    socket: HostUdpSocket,
+}
 
-    let mut buffer = vec![0u8; DNS_BUFFER_BYTES];
-    let (bytes_read, _) = socket.recv_from(&mut buffer)?;
-    buffer.truncate(bytes_read);
-    virtio_net_log!(
-        "virtio-net: received DNS response from upstream resolver upstream_dns={} response_len={}",
-        upstream_dns,
-        buffer.len()
-    );
-    Ok(buffer)
+impl HostDnsForwarder {
+    fn new(upstream_dns: Ipv4Addr) -> std::io::Result<Self> {
+        let socket = HostUdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0))?;
+        socket.connect((upstream_dns, DNS_SOCKET_PORT))?;
+        socket.set_read_timeout(Some(Duration::from_secs(2)))?;
+        Ok(Self {
+            upstream_dns,
+            socket,
+        })
+    }
+
+    fn upstream_dns(&self) -> Ipv4Addr {
+        self.upstream_dns
+    }
+
+    fn forward(&mut self, query: &[u8]) -> std::io::Result<Vec<u8>> {
+        // This is intentionally a plain host UDP exchange rather than a
+        // smoltcp socket-to-socket relay. The socket is reusable for the
+        // runtime, so DNS inspection does not bind a fresh host socket per
+        // query.
+        let local_addr = self.socket.local_addr()?;
+        virtio_net_log!(
+            "virtio-net: sending DNS query to upstream resolver local_addr={} upstream_dns={} query_len={}",
+            local_addr,
+            self.upstream_dns,
+            query.len()
+        );
+        self.socket.send(query)?;
+
+        let mut buffer = vec![0u8; DNS_BUFFER_BYTES];
+        loop {
+            let bytes_read = self.socket.recv(&mut buffer)?;
+            let response = &buffer[..bytes_read];
+            if dns_response_matches_query(query, response) {
+                virtio_net_log!(
+                    "virtio-net: received DNS response from upstream resolver upstream_dns={} response_len={}",
+                    self.upstream_dns,
+                    response.len()
+                );
+                return Ok(response.to_vec());
+            }
+
+            virtio_net_log!(
+                "virtio-net: ignored stale DNS response upstream_dns={} response_len={}",
+                self.upstream_dns,
+                bytes_read
+            );
+        }
+    }
+}
+
+fn dns_response_matches_query(query: &[u8], response: &[u8]) -> bool {
+    // The upstream socket is reused, so a delayed UDP response for an older
+    // query can arrive while we are waiting for the current query. DNS
+    // transaction IDs are the first two bytes and let us discard stale replies.
+    if query.len() < DNS_TRANSACTION_ID_LEN || response.len() < DNS_TRANSACTION_ID_LEN {
+        return false;
+    }
+
+    query[..DNS_TRANSACTION_ID_LEN] == response[..DNS_TRANSACTION_ID_LEN]
 }
 
 fn flush_interface_egress(

--- a/crates/smolvm-network/src/tcp_relay.rs
+++ b/crates/smolvm-network/src/tcp_relay.rs
@@ -35,7 +35,7 @@ use std::collections::{HashMap, HashSet};
 use std::io::{self, Read, Write};
 use std::net::{Ipv4Addr, Shutdown, SocketAddr, TcpStream};
 use std::sync::atomic::{AtomicU8, Ordering};
-use std::sync::mpsc::{self, Receiver, SyncSender, TryRecvError};
+use std::sync::mpsc::{self, Receiver, SyncSender, TryRecvError, TrySendError};
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
@@ -45,7 +45,6 @@ const TCP_TX_BUFFER_BYTES: usize = 64 * 1024;
 const MAX_CONNECTIONS: usize = 256;
 const CHANNEL_CAPACITY: usize = 32;
 const RELAY_BUFFER_BYTES: usize = 16 * 1024;
-const CLOSE_RETRY_LIMIT: u16 = 64;
 const PROXY_IDLE_SLEEP: Duration = Duration::from_millis(10);
 const PUBLISHED_PORT_START: u16 = 49_152;
 const PUBLISHED_PORT_END: u16 = 65_535;
@@ -93,10 +92,11 @@ struct TrackedConnection {
     pending_proxy_endpoints: Option<PendingProxyEndpoints>,
     // once true, a dedicated host relay thread exists
     relay_spawned: bool,
+    // guest->host payload already removed from smoltcp but waiting for relay
+    // channel capacity. This preserves TCP stream bytes under backpressure.
+    buffered_guest_data: Option<Vec<u8>>,
     // partial host->guest payload not yet fully accepted by smoltcp
     buffered_proxy_data: Option<(Vec<u8>, usize)>,
-    // bounded retry count for closing with unsent buffered data
-    close_attempts: u16,
     // relay thread termination mode observed by the poll loop
     exit_state: RelayExitState,
     // reserved local source port for published inbound connections
@@ -242,8 +242,8 @@ impl TcpRelayTable {
                     relay_target: RelayTarget::Connect(destination),
                 }),
                 relay_spawned: false,
+                buffered_guest_data: None,
                 buffered_proxy_data: None,
-                close_attempts: 0,
                 exit_state,
                 reserved_published_port: None,
             },
@@ -332,8 +332,8 @@ impl TcpRelayTable {
                     relay_target: RelayTarget::Attached(host_stream),
                 }),
                 relay_spawned: false,
+                buffered_guest_data: None,
                 buffered_proxy_data: None,
-                close_attempts: 0,
                 exit_state,
                 reserved_published_port: Some(local_port),
             },
@@ -369,29 +369,38 @@ impl TcpRelayTable {
                     flush_proxy_data(socket, connection);
                     if connection.buffered_proxy_data.is_none() {
                         socket.close();
-                    } else {
-                        connection.close_attempts += 1;
-                        if connection.close_attempts >= CLOSE_RETRY_LIMIT {
-                            socket.abort();
-                        }
                     }
                     continue;
                 }
                 RelayExitMode::Running => {}
             }
 
-            while socket.can_recv() {
-                match socket.recv_slice(&mut read_buffer) {
-                    Ok(bytes_read) if bytes_read > 0 => {
-                        let payload = read_buffer[..bytes_read].to_vec();
-                        if connection.to_proxy.try_send(payload).is_err() {
-                            break;
+            // 1. Move the buffered_guest_data to proxy and see if there are still room to read mroe
+            let can_read_more_from_smoltcp = matches!(
+                flush_guest_data_to_proxy(connection),
+                GuestDataFlush::Flushed
+            );
+
+            // 2. If there are still rooms to read more, then receive more from the smoltcp TCP socket
+            if can_read_more_from_smoltcp {
+                while socket.can_recv() {
+                    match socket.recv_slice(&mut read_buffer) {
+                        Ok(bytes_read) if bytes_read > 0 => {
+                            let payload = read_buffer[..bytes_read].to_vec();
+                            match send_guest_data_to_proxy(connection, payload) {
+                                GuestDataFlush::Flushed => {}
+                                // If there is no room to read more, stop reading from the smoltcp TCP socket
+                                GuestDataFlush::Backpressured | GuestDataFlush::Disconnected => {
+                                    break;
+                                }
+                            };
                         }
+                        _ => break,
                     }
-                    _ => break,
                 }
             }
 
+            // 3. Relay the data in the opposite direction.
             flush_proxy_data(socket, connection);
         }
     }
@@ -519,6 +528,8 @@ fn run_tcp_relay(
         "virtio-net: host TCP relay thread started destination={}",
         destination
     );
+    let relay_wake_on_exit = relay_wake.clone();
+
     match tcp_relay_loop(
         destination,
         relay_target,
@@ -532,7 +543,8 @@ fn run_tcp_relay(
                 destination,
                 mode
             );
-            exit_state.store(mode)
+            exit_state.store(mode);
+            relay_wake_on_exit.wake();
         }
         Err(err) => {
             virtio_net_log!(
@@ -541,6 +553,7 @@ fn run_tcp_relay(
                 err
             );
             exit_state.store(RelayExitMode::Abort);
+            relay_wake_on_exit.wake();
         }
     }
 }
@@ -584,48 +597,190 @@ fn tcp_relay_loop(
     stream.set_nonblocking(true)?;
 
     let mut guest_write_closed = false;
+    let mut guest_input_closed = false;
+    let mut pending_guest_write: Option<(Vec<u8>, usize)> = None;
     let mut read_buffer = [0u8; RELAY_BUFFER_BYTES];
 
     loop {
         let mut did_work = false;
 
-        loop {
-            match from_smoltcp.try_recv() {
-                Ok(payload) => {
-                    stream.write_all(&payload)?;
-                    did_work = true;
-                }
-                Err(TryRecvError::Empty) => break,
-                Err(TryRecvError::Disconnected) => {
-                    // The guest side closed its write half. Mirror that toward
-                    // the remote peer once, then keep reading until the remote
-                    // side closes too.
-                    if !guest_write_closed {
-                        let _ = stream.shutdown(Shutdown::Write);
-                        guest_write_closed = true;
-                    }
-                    break;
-                }
-            }
-        }
+        // 1. Finish any smoltcp->host payload that previously hit host socket.
+        did_work |= flush_pending_data_from_smoltcp(&mut stream, &mut pending_guest_write)?;
+        // 2. Drain new smoltcp->host payloads into the host TcpStream, and
+        //    remember when the smoltcp side will send no more bytes.
+        did_work |= drain_smoltcp_payloads_to_host(
+            &mut stream,
+            &from_smoltcp,
+            &mut pending_guest_write,
+            &mut guest_input_closed,
+        )?;
+        // 3. Once smoltcp is closed and all pending bytes are written,
+        //    close the host TcpStream write side.
+        did_work |= mirror_smoltcp_close_to_host(
+            &stream,
+            guest_input_closed,
+            &pending_guest_write,
+            &mut guest_write_closed,
+        );
 
-        match stream.read(&mut read_buffer) {
-            Ok(0) => return Ok(RelayExitMode::Graceful),
-            Ok(bytes_read) => {
-                if to_smoltcp.send(read_buffer[..bytes_read].to_vec()).is_err() {
-                    return Ok(RelayExitMode::Graceful);
-                }
-                relay_wake.wake();
-                did_work = true;
-            }
-            Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
-            Err(err) => return Err(err),
+        // 4. Read host->smoltcp payloads from the host TcpStream and wake the poll loop.
+        match read_host_payloads_to_smoltcp(
+            &mut stream,
+            &mut read_buffer,
+            &to_smoltcp,
+            relay_wake.as_ref(),
+        )? {
+            HostReadResult::DidWork => did_work = true,
+            HostReadResult::Idle => {}
+            HostReadResult::GracefulClose => return Ok(RelayExitMode::Graceful),
         }
 
         if !did_work {
             thread::sleep(PROXY_IDLE_SLEEP);
         }
     }
+}
+
+fn flush_pending_data_from_smoltcp<W: Write>(
+    stream: &mut W,
+    pending_guest_write: &mut Option<(Vec<u8>, usize)>,
+) -> io::Result<bool> {
+    if pending_guest_write.is_none() {
+        return Ok(false);
+    }
+
+    flush_pending_stream_write(stream, pending_guest_write)
+}
+
+fn drain_smoltcp_payloads_to_host<W: Write>(
+    stream: &mut W,
+    from_smoltcp: &Receiver<Vec<u8>>,
+    pending_guest_write: &mut Option<(Vec<u8>, usize)>,
+    guest_input_closed: &mut bool,
+) -> io::Result<bool> {
+    if pending_guest_write.is_some() {
+        return Ok(false);
+    }
+
+    let mut did_work = false;
+    loop {
+        match from_smoltcp.try_recv() {
+            Ok(payload) => {
+                *pending_guest_write = Some((payload, 0));
+                did_work = true;
+                if !flush_pending_stream_write(stream, pending_guest_write)? {
+                    break;
+                }
+            }
+            Err(TryRecvError::Empty) => break,
+            Err(TryRecvError::Disconnected) => {
+                *guest_input_closed = true;
+                break;
+            }
+        }
+    }
+
+    Ok(did_work)
+}
+
+fn mirror_smoltcp_close_to_host(
+    stream: &TcpStream,
+    guest_input_closed: bool,
+    pending_guest_write: &Option<(Vec<u8>, usize)>,
+    guest_write_closed: &mut bool,
+) -> bool {
+    if guest_input_closed && pending_guest_write.is_none() && !*guest_write_closed {
+        let _ = stream.shutdown(Shutdown::Write);
+        *guest_write_closed = true;
+        return true;
+    }
+
+    false
+}
+
+enum HostReadResult {
+    DidWork,
+    Idle,
+    GracefulClose,
+}
+
+fn read_host_payloads_to_smoltcp<R: Read>(
+    stream: &mut R,
+    read_buffer: &mut [u8],
+    to_smoltcp: &SyncSender<Vec<u8>>,
+    relay_wake: &WakePipe,
+) -> io::Result<HostReadResult> {
+    match stream.read(read_buffer) {
+        Ok(0) => Ok(HostReadResult::GracefulClose),
+        Ok(bytes_read) => {
+            if to_smoltcp.send(read_buffer[..bytes_read].to_vec()).is_err() {
+                return Ok(HostReadResult::GracefulClose);
+            }
+            relay_wake.wake();
+            Ok(HostReadResult::DidWork)
+        }
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => Ok(HostReadResult::Idle),
+        Err(err) => Err(err),
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum GuestDataFlush {
+    Flushed,
+    Backpressured,
+    Disconnected,
+}
+
+fn flush_guest_data_to_proxy(connection: &mut TrackedConnection) -> GuestDataFlush {
+    let Some(payload) = connection.buffered_guest_data.take() else {
+        return GuestDataFlush::Flushed;
+    };
+
+    send_guest_data_to_proxy(connection, payload)
+}
+
+fn send_guest_data_to_proxy(
+    connection: &mut TrackedConnection,
+    payload: Vec<u8>,
+) -> GuestDataFlush {
+    match connection.to_proxy.try_send(payload) {
+        Ok(()) => GuestDataFlush::Flushed,
+        Err(TrySendError::Full(payload)) => {
+            connection.buffered_guest_data = Some(payload);
+            GuestDataFlush::Backpressured
+        }
+        Err(TrySendError::Disconnected(_)) => GuestDataFlush::Disconnected,
+    }
+}
+
+fn flush_pending_stream_write<W: Write>(
+    stream: &mut W,
+    pending: &mut Option<(Vec<u8>, usize)>,
+) -> io::Result<bool> {
+    let Some((payload, offset)) = pending.as_mut() else {
+        return Ok(false);
+    };
+
+    let mut wrote = false;
+    while *offset < payload.len() {
+        match stream.write(&payload[*offset..]) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "short write while relaying guest TCP payload",
+                ));
+            }
+            Ok(bytes_written) => {
+                *offset += bytes_written;
+                wrote = true;
+            }
+            Err(err) if err.kind() == io::ErrorKind::WouldBlock => return Ok(wrote),
+            Err(err) => return Err(err),
+        }
+    }
+
+    *pending = None;
+    Ok(wrote)
 }
 
 fn flush_proxy_data(socket: &mut tcp::Socket<'_>, connection: &mut TrackedConnection) {
@@ -667,5 +822,94 @@ fn flush_proxy_data(socket: &mut tcp::Socket<'_>, connection: &mut TrackedConnec
             }
             Err(TryRecvError::Empty | TryRecvError::Disconnected) => break,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr};
+
+    fn test_connection(to_proxy: SyncSender<Vec<u8>>) -> TrackedConnection {
+        let (_from_proxy_tx, from_proxy_rx) = mpsc::sync_channel(CHANNEL_CAPACITY);
+
+        TrackedConnection {
+            source: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(100, 96, 0, 2)), 40_000),
+            destination: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10)), 22),
+            to_proxy,
+            from_proxy: from_proxy_rx,
+            pending_proxy_endpoints: None,
+            relay_spawned: true,
+            buffered_guest_data: None,
+            buffered_proxy_data: None,
+            exit_state: RelayExitState::new(),
+            reserved_published_port: None,
+        }
+    }
+
+    #[test]
+    fn buffers_guest_payload_when_proxy_channel_is_full() {
+        let (to_proxy_tx, to_proxy_rx) = mpsc::sync_channel(1);
+        let mut connection = test_connection(to_proxy_tx);
+
+        connection.to_proxy.send(vec![1]).unwrap();
+
+        assert_eq!(
+            send_guest_data_to_proxy(&mut connection, vec![2, 3]),
+            GuestDataFlush::Backpressured
+        );
+        assert_eq!(connection.buffered_guest_data.as_deref(), Some(&[2, 3][..]));
+
+        assert_eq!(to_proxy_rx.recv().unwrap(), vec![1]);
+        assert_eq!(
+            flush_guest_data_to_proxy(&mut connection),
+            GuestDataFlush::Flushed
+        );
+        assert!(connection.buffered_guest_data.is_none());
+        assert_eq!(to_proxy_rx.recv().unwrap(), vec![2, 3]);
+    }
+
+    struct PartialWouldBlockWriter {
+        writes_before_block: usize,
+        max_per_write: usize,
+        written: Vec<u8>,
+    }
+
+    impl Write for PartialWouldBlockWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            if self.writes_before_block == 0 {
+                return Err(io::Error::from(io::ErrorKind::WouldBlock));
+            }
+
+            self.writes_before_block -= 1;
+            let bytes_to_write = buf.len().min(self.max_per_write);
+            self.written.extend_from_slice(&buf[..bytes_to_write]);
+            Ok(bytes_to_write)
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn preserves_partial_nonblocking_socket_writes() {
+        let mut writer = PartialWouldBlockWriter {
+            writes_before_block: 1,
+            max_per_write: 2,
+            written: Vec::new(),
+        };
+        let mut pending = Some((b"abcdef".to_vec(), 0));
+
+        assert!(flush_pending_stream_write(&mut writer, &mut pending).unwrap());
+        assert_eq!(pending.as_ref().map(|(_, offset)| *offset), Some(2));
+        assert_eq!(writer.written, b"ab");
+
+        writer.writes_before_block = 1;
+        writer.max_per_write = 16;
+
+        assert!(flush_pending_stream_write(&mut writer, &mut pending).unwrap());
+        assert!(pending.is_none());
+        assert_eq!(writer.written, b"abcdef");
     }
 }

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -15,8 +15,8 @@ use crate::storage::{OverlayDisk, StorageDisk};
 use crate::util::{libkrun_filename, libkrunfw_filename};
 
 use smolvm_network::{
-    guest_env, start_virtio_network, GuestNetworkConfig, PortMapping as VirtioPortMapping,
-    VirtioNetworkRuntime,
+    guest_env, start_virtio_network, EgressPolicy, GuestNetworkConfig,
+    PortMapping as VirtioPortMapping, VirtioNetworkRuntime,
 };
 use smolvm_protocol::ports;
 use std::ffi::CString;
@@ -138,11 +138,9 @@ pub struct LaunchConfig<'a> {
     /// Whether DNS filtering was configured for this launch, even if the
     /// host-side proxy socket could not be created.
     pub dns_filter_enabled: bool,
-    /// Hostnames to periodically re-resolve for the live egress policy.
-    /// When set, a background thread re-resolves these every 5 minutes and
-    /// atomically replaces the CIDR list via the Arc handle obtained from
-    /// libkrun. This keeps the egress allow-list accurate for long-running VMs
-    /// hitting CDN-backed hosts whose IPs rotate.
+    /// Hostnames configured by allow-host policy.
+    /// TSI uses these for DNS filtering and live CIDR refresh; virtio-net uses
+    /// them for in-process DNS filtering in the host gateway.
     pub egress_refresh_hosts: Option<Vec<String>>,
 }
 
@@ -166,7 +164,11 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
         egress_refresh_hosts,
     } = config;
 
-    crate::network::validate_requested_network_backend(resources, None, port_mappings.len())?;
+    crate::network::validate_requested_network_backend(
+        resources,
+        egress_refresh_hosts.as_deref(),
+        port_mappings.len(),
+    )?;
 
     // Raise file descriptor limits
     raise_fd_limits();
@@ -279,10 +281,17 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
             return Err(Error::agent("set rootfs", "krun_set_root failed"));
         }
 
-        let network_plan = select_network_plan(resources, *dns_filter_enabled, port_mappings.len());
-        if let Some(reason) = network_plan.fallback_reason {
-            tracing::warn!(reason = %reason.user_message(), "network backend fell back to TSI");
-        }
+        let network_plan = select_network_plan(
+            resources,
+            egress_refresh_hosts.as_deref(),
+            *dns_filter_enabled,
+            port_mappings.len(),
+        );
+        let dns_filter_socket = if network_plan.backend == EffectiveNetworkBackend::Tsi {
+            *dns_filter_socket
+        } else {
+            None
+        };
 
         let mut virtio_network_runtime: Option<VirtioNetworkRuntime> = None;
         let guest_network = match network_plan.backend {
@@ -384,18 +393,26 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
                     .iter()
                     .map(|mapping| VirtioPortMapping::new(mapping.host, mapping.guest))
                     .collect();
-                let runtime =
-                    match start_virtio_network(host_fd, guest_network, &virtio_port_mappings) {
-                        Ok(runtime) => runtime,
-                        Err(err) => {
-                            libc::close(guest_fd);
-                            krun_free_ctx(ctx);
-                            return Err(Error::agent(
-                                "configure virtio-net",
-                                format!("failed to start virtio network runtime: {err}"),
-                            ));
-                        }
-                    };
+                let virtio_policy = EgressPolicy {
+                    allowed_cidrs: resources.allowed_cidrs.clone(),
+                    dns_filter_hosts: (*egress_refresh_hosts).clone(),
+                };
+                let runtime = match start_virtio_network(
+                    host_fd,
+                    guest_network,
+                    &virtio_port_mappings,
+                    virtio_policy,
+                ) {
+                    Ok(runtime) => runtime,
+                    Err(err) => {
+                        libc::close(guest_fd);
+                        krun_free_ctx(ctx);
+                        return Err(Error::agent(
+                            "configure virtio-net",
+                            format!("failed to start virtio network runtime: {err}"),
+                        ));
+                    }
+                };
 
                 if add_net_unixstream(
                     ctx,
@@ -706,67 +723,70 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
         //
         // Each cycle: resolve all hosts → build fresh list → single write-lock
         // swap. If all hosts fail to resolve, the previous list is kept intact.
-        if let Some(hosts) = egress_refresh_hosts.as_ref().filter(|h| !h.is_empty()) {
-            if let Some(krun_get_egress_handle) = krun.get_egress_handle {
-                let raw_handle = krun_get_egress_handle(ctx);
+        if network_plan.backend == EffectiveNetworkBackend::Tsi {
+            if let Some(hosts) = egress_refresh_hosts.as_ref().filter(|h| !h.is_empty()) {
+                if let Some(krun_get_egress_handle) = krun.get_egress_handle {
+                    let raw_handle = krun_get_egress_handle(ctx);
 
-                if !raw_handle.is_null() {
-                    let arc: EgressArc = *Box::from_raw(raw_handle as *mut EgressArc);
-                    let hosts_copy = hosts.clone();
-                    if let Err(e) = std::thread::Builder::new()
-                        .name("egress-refresh".into())
-                        .spawn(move || {
-                            let refresh_secs: u64 = std::env::var("SMOLVM_EGRESS_REFRESH_SECS")
-                                .ok()
-                                .and_then(|s| s.parse().ok())
-                                .unwrap_or(5 * 60);
-                            let refresh_interval = std::time::Duration::from_secs(refresh_secs);
-                            loop {
-                                std::thread::sleep(refresh_interval);
-                                // Resolve all hosts into a fresh list, then swap
-                                // the shared Vec in a single write-lock acquisition.
-                                // This ensures old rotated-away IPs are removed.
-                                let mut fresh: Vec<(std::net::IpAddr, u8)> = Vec::new();
-                                'hosts: for host in &hosts_copy {
-                                    match resolve_host_subprocess(host) {
-                                        Ok(new_cidrs) => {
-                                            for cidr_str in new_cidrs {
-                                                if fresh.len() >= EGRESS_CIDR_CAP {
-                                                    break 'hosts;
-                                                }
-                                                if let Some((ip_str, prefix_str)) =
-                                                    cidr_str.split_once('/')
-                                                {
-                                                    if let (Ok(ip), Ok(prefix)) = (
-                                                        ip_str.parse::<std::net::IpAddr>(),
-                                                        prefix_str.parse::<u8>(),
-                                                    ) {
-                                                        if !fresh.contains(&(ip, prefix)) {
-                                                            fresh.push((ip, prefix));
+                    if !raw_handle.is_null() {
+                        let arc: EgressArc = *Box::from_raw(raw_handle as *mut EgressArc);
+                        let hosts_copy = hosts.clone();
+                        if let Err(e) = std::thread::Builder::new()
+                            .name("egress-refresh".into())
+                            .spawn(move || {
+                                let refresh_secs: u64 = std::env::var("SMOLVM_EGRESS_REFRESH_SECS")
+                                    .ok()
+                                    .and_then(|s| s.parse().ok())
+                                    .unwrap_or(5 * 60);
+                                let refresh_interval = std::time::Duration::from_secs(refresh_secs);
+                                loop {
+                                    std::thread::sleep(refresh_interval);
+                                    // Resolve all hosts into a fresh list, then swap
+                                    // the shared Vec in a single write-lock acquisition.
+                                    // This ensures old rotated-away IPs are removed.
+                                    let mut fresh: Vec<(std::net::IpAddr, u8)> = Vec::new();
+                                    'hosts: for host in &hosts_copy {
+                                        match resolve_host_subprocess(host) {
+                                            Ok(new_cidrs) => {
+                                                for cidr_str in new_cidrs {
+                                                    if fresh.len() >= EGRESS_CIDR_CAP {
+                                                        break 'hosts;
+                                                    }
+                                                    if let Some((ip_str, prefix_str)) =
+                                                        cidr_str.split_once('/')
+                                                    {
+                                                        if let (Ok(ip), Ok(prefix)) = (
+                                                            ip_str.parse::<std::net::IpAddr>(),
+                                                            prefix_str.parse::<u8>(),
+                                                        ) {
+                                                            if !fresh.contains(&(ip, prefix)) {
+                                                                fresh.push((ip, prefix));
+                                                            }
                                                         }
                                                     }
                                                 }
                                             }
-                                        }
-                                        Err(e) => {
-                                            tracing::warn!(
-                                                host = %host,
-                                                error = %e,
-                                                "egress-refresh: resolve failed"
-                                            );
+                                            Err(e) => {
+                                                tracing::warn!(
+                                                    host = %host,
+                                                    error = %e,
+                                                    "egress-refresh: resolve failed"
+                                                );
+                                            }
                                         }
                                     }
+                                    // Only replace if at least one host resolved
+                                    // successfully; keeps the old list on total failure.
+                                    if !fresh.is_empty() {
+                                        let mut guard =
+                                            arc.write().unwrap_or_else(|e| e.into_inner());
+                                        *guard = fresh;
+                                    }
                                 }
-                                // Only replace if at least one host resolved
-                                // successfully; keeps the old list on total failure.
-                                if !fresh.is_empty() {
-                                    let mut guard = arc.write().unwrap_or_else(|e| e.into_inner());
-                                    *guard = fresh;
-                                }
-                            }
-                        })
-                    {
-                        tracing::warn!(error = %e, "egress-refresh spawn failed");
+                            })
+                        {
+                            tracing::warn!(error = %e, "egress-refresh spawn failed");
+                        }
                     }
                 }
             }
@@ -808,11 +828,13 @@ fn create_unix_stream_pair() -> std::io::Result<(RawFd, RawFd)> {
 
 fn select_network_plan(
     resources: &VmResources,
+    dns_filter_hosts: Option<&[String]>,
     dns_filter_enabled: bool,
     port_count: usize,
 ) -> crate::network::LaunchNetworkPlan {
     let dns_filter_placeholder = [String::from("configured")];
-    let dns_filter_hosts = dns_filter_enabled.then_some(dns_filter_placeholder.as_slice());
+    let dns_filter_hosts = dns_filter_hosts
+        .or_else(|| dns_filter_enabled.then_some(dns_filter_placeholder.as_slice()));
     plan_launch_network(resources, dns_filter_hosts, port_count)
 }
 

--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -9,8 +9,8 @@
 use crate::network::backend::{COMPAT_NET_FEATURES, TSI_FEATURE_HIJACK_INET};
 use crate::network::{plan_launch_network, EffectiveNetworkBackend};
 use smolvm_network::{
-    guest_env, start_virtio_network, GuestNetworkConfig, PortMapping as VirtioPortMapping,
-    VirtioNetworkRuntime,
+    guest_env, start_virtio_network, EgressPolicy, GuestNetworkConfig,
+    PortMapping as VirtioPortMapping, VirtioNetworkRuntime,
 };
 use smolvm_protocol::ports;
 use std::ffi::CString;
@@ -179,9 +179,6 @@ pub fn launch_agent_vm_dynamic(
     }
 
     let network_plan = plan_launch_network(&config.resources, None, config.port_mappings.len());
-    if let Some(reason) = network_plan.fallback_reason {
-        tracing::warn!(reason = %reason.user_message(), "network backend fell back to TSI");
-    }
 
     let mut virtio_network_runtime: Option<VirtioNetworkRuntime> = None;
     let guest_network = match network_plan.backend {
@@ -262,7 +259,15 @@ pub fn launch_agent_vm_dynamic(
                 .map(|(host, guest)| VirtioPortMapping::new(*host, *guest))
                 .collect();
 
-            let runtime = match start_virtio_network(host_fd, guest_network, &port_mappings) {
+            let runtime = match start_virtio_network(
+                host_fd,
+                guest_network,
+                &port_mappings,
+                EgressPolicy {
+                    allowed_cidrs: config.resources.allowed_cidrs.clone(),
+                    dns_filter_hosts: None, // launching packed stub does not support allow-host setting at this moment.
+                },
+            ) {
                 Ok(runtime) => runtime,
                 Err(err) => {
                     // SAFETY: guest_fd was created by socketpair above and not moved elsewhere.

--- a/src/cli/internal_boot.rs
+++ b/src/cli/internal_boot.rs
@@ -8,6 +8,7 @@
 
 use smolvm::agent::boot_config::BootConfig;
 use smolvm::agent::{launch_agent_vm, LaunchConfig, VmDisks};
+use smolvm::network::NetworkBackend;
 use std::path::PathBuf;
 
 /// Run the boot subprocess.
@@ -111,9 +112,11 @@ pub fn run(config_path: PathBuf) -> smolvm::Result<()> {
         overlay: Some(&overlay_disk),
     };
 
-    // Start DNS filter listener if configured
+    // Start the guest-side DNS filter listener only for TSI launches.
+    // Virtio-net enforces hostname policy inside the host gateway.
+    let use_guest_dns_filter = config.resources.network_backend != Some(NetworkBackend::VirtioNet);
     let dns_filter_socket_path = if let Some(ref hosts) = config.dns_filter_hosts {
-        if !hosts.is_empty() {
+        if use_guest_dns_filter && !hosts.is_empty() {
             let socket_path = config
                 .vsock_socket
                 .parent()

--- a/src/network/launch.rs
+++ b/src/network/launch.rs
@@ -12,40 +12,11 @@ pub enum EffectiveNetworkBackend {
     VirtioNet,
 }
 
-/// Reason a requested backend was downgraded.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum NetworkFallbackReason {
-    /// Current egress policies and DNS filtering are only implemented on TSI.
-    PolicyRequiresTsi,
-}
-
-impl NetworkFallbackReason {
-    /// User-facing explanation for the fallback.
-    pub const fn user_message(self) -> &'static str {
-        match self {
-            Self::PolicyRequiresTsi => {
-                "allow-cidr/allow-host policies still use the TSI backend; falling back from virtio-net"
-            }
-        }
-    }
-
-    /// User-facing explanation when an explicit virtio-net request must be rejected.
-    pub const fn unsupported_message(self) -> &'static str {
-        match self {
-            Self::PolicyRequiresTsi => {
-                "allow-cidr/allow-host policies are not supported by the current virtio-net implementation"
-            }
-        }
-    }
-}
-
 /// Network launch decision for a VM.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LaunchNetworkPlan {
     /// Selected backend.
     pub backend: EffectiveNetworkBackend,
-    /// Downgrade reason when a requested backend cannot be honored.
-    pub fallback_reason: Option<NetworkFallbackReason>,
 }
 
 impl LaunchNetworkPlan {
@@ -62,10 +33,7 @@ pub fn plan_launch_network(
     port_count: usize,
 ) -> LaunchNetworkPlan {
     let has_ports = port_count > 0;
-    let has_cidr_policy = resources
-        .allowed_cidrs
-        .as_ref()
-        .is_some_and(|cidrs| !cidrs.is_empty());
+    let has_cidr_policy = resources.allowed_cidrs.is_some();
     let has_dns_filter = dns_filter_hosts.is_some_and(|hosts| !hosts.is_empty());
     let has_policy = has_cidr_policy || has_dns_filter;
     let wants_network = resources.network || has_ports || has_policy;
@@ -73,27 +41,20 @@ pub fn plan_launch_network(
     if !wants_network {
         return LaunchNetworkPlan {
             backend: EffectiveNetworkBackend::None,
-            fallback_reason: None,
         };
     }
 
     match resources.network_backend.unwrap_or(NetworkBackend::Tsi) {
         NetworkBackend::Tsi => LaunchNetworkPlan {
             backend: EffectiveNetworkBackend::Tsi,
-            fallback_reason: None,
-        },
-        NetworkBackend::VirtioNet if has_policy => LaunchNetworkPlan {
-            backend: EffectiveNetworkBackend::Tsi,
-            fallback_reason: Some(NetworkFallbackReason::PolicyRequiresTsi),
         },
         NetworkBackend::VirtioNet => LaunchNetworkPlan {
             backend: EffectiveNetworkBackend::VirtioNet,
-            fallback_reason: None,
         },
     }
 }
 
-/// Reject explicit virtio-net requests that the current branch cannot honor.
+/// Validate explicit virtio-net backend requests.
 pub fn validate_requested_network_backend(
     resources: &VmResources,
     dns_filter_hosts: Option<&[String]>,
@@ -103,10 +64,7 @@ pub fn validate_requested_network_backend(
         return Ok(());
     }
 
-    let has_cidr_policy = resources
-        .allowed_cidrs
-        .as_ref()
-        .is_some_and(|cidrs| !cidrs.is_empty());
+    let has_cidr_policy = resources.allowed_cidrs.is_some();
     let has_dns_filter = dns_filter_hosts.is_some_and(|hosts| !hosts.is_empty());
     let wants_network = resources.network || port_count > 0 || has_cidr_policy || has_dns_filter;
 
@@ -114,17 +72,6 @@ pub fn validate_requested_network_backend(
         return Err(crate::Error::config(
             "--net-backend",
             "--net-backend virtio-net requires --net",
-        ));
-    }
-
-    let plan = plan_launch_network(resources, dns_filter_hosts, port_count);
-    if plan.backend != EffectiveNetworkBackend::VirtioNet {
-        let reason = plan
-            .fallback_reason
-            .unwrap_or(NetworkFallbackReason::PolicyRequiresTsi);
-        return Err(crate::Error::config(
-            "--net-backend",
-            reason.unsupported_message(),
         ));
     }
 
@@ -160,7 +107,6 @@ mod tests {
         resources.network_backend = Some(NetworkBackend::VirtioNet);
         let plan = plan_launch_network(&resources, None, 0);
         assert_eq!(plan.backend, EffectiveNetworkBackend::VirtioNet);
-        assert_eq!(plan.fallback_reason, None);
     }
 
     #[test]
@@ -170,21 +116,16 @@ mod tests {
         resources.network_backend = Some(NetworkBackend::VirtioNet);
         let plan = plan_launch_network(&resources, None, 1);
         assert_eq!(plan.backend, EffectiveNetworkBackend::VirtioNet);
-        assert_eq!(plan.fallback_reason, None);
     }
 
     #[test]
-    fn test_policy_forces_tsi() {
+    fn test_policy_works_with_virtio() {
         let mut resources = resources();
         resources.network = true;
         resources.network_backend = Some(NetworkBackend::VirtioNet);
         resources.allowed_cidrs = Some(vec!["1.1.1.1/32".into()]);
         let plan = plan_launch_network(&resources, None, 0);
-        assert_eq!(plan.backend, EffectiveNetworkBackend::Tsi);
-        assert_eq!(
-            plan.fallback_reason,
-            Some(NetworkFallbackReason::PolicyRequiresTsi)
-        );
+        assert_eq!(plan.backend, EffectiveNetworkBackend::VirtioNet);
     }
 
     #[test]
@@ -204,14 +145,19 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_policy_rejected_for_virtio() {
+    fn test_validate_policy_allowed_for_virtio() {
         let mut resources = resources();
         resources.network = true;
         resources.network_backend = Some(NetworkBackend::VirtioNet);
         resources.allowed_cidrs = Some(vec!["1.1.1.1/32".into()]);
-        let err = validate_requested_network_backend(&resources, None, 0).unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("allow-cidr/allow-host policies are not supported"));
+        validate_requested_network_backend(&resources, None, 0).unwrap();
+    }
+
+    #[test]
+    fn test_empty_policy_counts_as_network() {
+        let mut resources = resources();
+        resources.network_backend = Some(NetworkBackend::VirtioNet);
+        resources.allowed_cidrs = Some(vec![]);
+        validate_requested_network_backend(&resources, None, 0).unwrap();
     }
 }

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -9,6 +9,6 @@ pub mod policy;
 pub use backend::NetworkBackend;
 pub use launch::{
     plan_launch_network, validate_requested_network_backend, EffectiveNetworkBackend,
-    LaunchNetworkPlan, NetworkFallbackReason,
+    LaunchNetworkPlan,
 };
 pub use policy::get_dns_server;

--- a/tests/test_virtio_net.sh
+++ b/tests/test_virtio_net.sh
@@ -9,7 +9,7 @@
 # - part 4: the `create -> start -> exec`, `machine run`, and `pack run` flows
 #   all drive real virtio-backed guest networking
 # - part 5: published TCP ports work end-to-end on the virtio gateway
-# - unsupported policy features still fail clearly
+# - part 6: CIDR egress policy is enforced in the virtio gateway
 
 source "$(dirname "$0")/common.sh"
 init_smolvm
@@ -28,6 +28,23 @@ echo ""
 
 VIRTIO_TEST_IMAGE="${VIRTIO_TEST_IMAGE:-alpine:latest}"
 VIRTIO_PUBLISH_TEST_IMAGE="${VIRTIO_PUBLISH_TEST_IMAGE:-python:3.12-alpine}"
+
+detect_host_ipv4() {
+    if command -v route >/dev/null 2>&1 && command -v ipconfig >/dev/null 2>&1; then
+        local iface
+        iface=$(route -n get default 2>/dev/null | awk '/interface:/{print $2; exit}')
+        if [[ -n "$iface" ]]; then
+            ipconfig getifaddr "$iface" 2>/dev/null && return 0
+        fi
+    fi
+
+    if command -v ip >/dev/null 2>&1; then
+        ip -4 route get 1.1.1.1 2>/dev/null | awk '{for (i = 1; i <= NF; i++) if ($i == "src") { print $(i + 1); exit }}'
+        return 0
+    fi
+
+    return 1
+}
 
 virtio_guest_probe_script() {
     cat <<'EOF'
@@ -200,22 +217,108 @@ test_machine_run_virtio_net_port_publishing_works() {
     cleanup_machine
 }
 
-test_machine_create_virtio_net_policy_rejected() {
+test_machine_create_virtio_net_policy_allowed() {
     cleanup_machine
     local vm_name="virtio-policy-test-$$"
     local exit_code=0
     local output
 
     output=$($SMOLVM machine create "$vm_name" --net --net-backend virtio-net --allow-cidr 1.1.1.1/32 2>&1) || exit_code=$?
-    [[ $exit_code -ne 0 ]] || {
-        echo "expected create failure for virtio-net policy request"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    [[ ${exit_code:-0} -eq 0 ]] || {
+        echo "expected create success for virtio-net policy request"
+        echo "$output"
         return 1
     }
-    [[ "$output" == *"allow-cidr/allow-host policies are not supported"* ]] || {
+
+    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+}
+
+test_machine_run_virtio_net_allow_cidr_allows_tcp() {
+    cleanup_machine
+    local host_ip
+    host_ip=$(detect_host_ipv4 || true)
+    if [[ -z "$host_ip" ]]; then
+        log_skip "could not detect host IPv4 for virtio-net CIDR test"
+        return 0
+    fi
+
+    local host_port=$((43000 + ($$ % 10000)))
+    local serve_dir="$TEST_DIR/virtio-policy-allow"
+    local server_log="$TEST_DIR/virtio-policy-allow.log"
+    local server_pid=0
+    local output
+
+    mkdir -p "$serve_dir"
+    printf 'virtio-policy-ok\n' >"$serve_dir/index.html"
+
+    trap 'if [[ ${server_pid:-0} -ne 0 ]]; then kill "$server_pid" 2>/dev/null || true; wait "$server_pid" 2>/dev/null || true; fi; cleanup_machine' RETURN
+    python3 -m http.server "$host_port" --bind "$host_ip" --directory "$serve_dir" >"$server_log" 2>&1 &
+    server_pid=$!
+    sleep 1
+
+    output=$($SMOLVM machine run \
+        --image "$VIRTIO_PUBLISH_TEST_IMAGE" \
+        --net \
+        --net-backend virtio-net \
+        --allow-cidr "${host_ip}/32" \
+        -- python -c "import urllib.request; print(urllib.request.urlopen('http://${host_ip}:${host_port}', timeout=5).read().decode().strip())" 2>&1) || {
+        echo "$output"
+        tail -20 "$server_log" 2>/dev/null || true
+        return 1
+    }
+
+    [[ "$output" == *"virtio-policy-ok"* ]] || {
         echo "unexpected output: $output"
         return 1
     }
+
+    trap - RETURN
+    kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+    cleanup_machine
+}
+
+test_machine_run_virtio_net_allow_cidr_blocks_tcp() {
+    cleanup_machine
+    local host_ip
+    host_ip=$(detect_host_ipv4 || true)
+    if [[ -z "$host_ip" ]]; then
+        log_skip "could not detect host IPv4 for virtio-net CIDR test"
+        return 0
+    fi
+
+    local host_port=$((44000 + ($$ % 10000)))
+    local serve_dir="$TEST_DIR/virtio-policy-block"
+    local server_log="$TEST_DIR/virtio-policy-block.log"
+    local server_pid=0
+    local output
+    local exit_code=0
+
+    mkdir -p "$serve_dir"
+    printf 'virtio-policy-block\n' >"$serve_dir/index.html"
+
+    trap 'if [[ ${server_pid:-0} -ne 0 ]]; then kill "$server_pid" 2>/dev/null || true; wait "$server_pid" 2>/dev/null || true; fi; cleanup_machine' RETURN
+    python3 -m http.server "$host_port" --bind "$host_ip" --directory "$serve_dir" >"$server_log" 2>&1 &
+    server_pid=$!
+    sleep 1
+
+    output=$($SMOLVM machine run \
+        --image "$VIRTIO_PUBLISH_TEST_IMAGE" \
+        --net \
+        --net-backend virtio-net \
+        --allow-cidr 203.0.113.1/32 \
+        -- python -c "import urllib.request; urllib.request.urlopen('http://${host_ip}:${host_port}', timeout=3)" 2>&1) || exit_code=$?
+
+    [[ $exit_code -ne 0 ]] || {
+        echo "expected blocked virtio-net TCP request to fail"
+        echo "$output"
+        return 1
+    }
+
+    trap - RETURN
+    kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+    cleanup_machine
 }
 
 test_pack_run_virtio_net_works() {
@@ -248,7 +351,9 @@ run_test "Machine create: virtio-net works" test_machine_create_virtio_net_works
 run_test "Machine create/start/exec: virtio-net guest networking works" test_machine_create_start_exec_virtio_net_works || true
 run_test "Machine run: virtio-net guest networking works" test_machine_run_virtio_net_works || true
 run_test "Machine run: virtio-net published TCP ports work" test_machine_run_virtio_net_port_publishing_works || true
-run_test "Machine create: virtio-net + policy rejected" test_machine_create_virtio_net_policy_rejected || true
+run_test "Machine create: virtio-net + policy allowed" test_machine_create_virtio_net_policy_allowed || true
+run_test "Machine run: virtio-net allow-cidr allows TCP" test_machine_run_virtio_net_allow_cidr_allows_tcp || true
+run_test "Machine run: virtio-net allow-cidr blocks TCP" test_machine_run_virtio_net_allow_cidr_blocks_tcp || true
 run_test "Pack run: virtio-net guest networking works" test_pack_run_virtio_net_works || true
 
 print_summary "Virtio-Net Tests"


### PR DESCRIPTION
This is the honor the egress policies in virtio-net network backend

Main pieces are:

1. `ResolvedEgressPolicies`: hold all configured allowed CIDRs and hosts
2. `AllowCidr`: it has a thread to periodically check if the allowed host resolves to new CIDRs, and update the filter in `ResolvedEgressPolicies`
3. `HostDnsForwarder`: if a DNS query is deemed `Forward` (allowed), host dns forwarder call the upstream dns server and inspect the response. Also ensured the HostDnsForwarder is binding port 53 only once

### E2E Testing

```
==========================================
  Smolfile Tests Summary
==========================================

Tests run:    49
Tests passed: 49
Tests failed: 0

All tests passed!
Machine 'default' is not running (state: stopped)
Cleaning up data directory for vm: default
Deleted machine: default

==========================================
  Overall Summary
==========================================

Test suites run:    6
Test suites passed: 6
Test suites failed: 0

All test suites passed!
```