### PR TITLE
fix: unpack shouldn't choke on char entries

### DIFF
--- a/crates/smolvm-pack/src/extract.rs
+++ b/crates/smolvm-pack/src/extract.rs
@@ -73,6 +73,13 @@ fn safe_unpack<R: Read>(archive: &mut tar::Archive<R>, dest: &Path) -> std::io::
                     }
                 }
             }
+            tar::EntryType::Char | tar::EntryType::Block => {
+                // Device nodes appear in overlayfs upper-layer exports from
+                // Debian-based images (e.g., update-alternatives creates char
+                // entries in /etc/alternatives/). These cannot be created
+                // without root and aren't needed on the host — skip them.
+                continue;
+            }
             other => {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
@@ -283,7 +290,17 @@ pub fn extract_sidecar(
         let _ = fs::remove_dir_all(cache_dir);
     }
 
-    extract_sidecar_inner(sidecar_path, cache_dir, footer, debug)
+    let result = extract_sidecar_inner(sidecar_path, cache_dir, footer, debug);
+
+    // If extraction failed mid-stream, partially extracted files remain on
+    // disk without a completion marker. Subsequent retries hit the same
+    // error at the same tar entry, never completing. Clean up the partial
+    // directory so the next attempt starts fresh.
+    if result.is_err() && cache_dir.exists() && !is_extracted(cache_dir) {
+        let _ = fs::remove_dir_all(cache_dir);
+    }
+
+    result
     // Lock released on drop of lock_file
 }
 
@@ -1532,5 +1549,82 @@ mod tests {
             result.unwrap_err().to_string().contains("disallowed type"),
             "error should mention disallowed type"
         );
+    }
+
+    #[test]
+    fn test_safe_unpack_skips_char_and_block_devices() {
+        // Char/Block entries appear in overlayfs exports from Debian images
+        // (e.g., update-alternatives). They should be skipped, not rejected.
+        let temp_dir = tempfile::tempdir().unwrap();
+        let dest_raw = temp_dir.path().join("out");
+        fs::create_dir_all(&dest_raw).unwrap();
+        let dest = dest_raw.canonicalize().unwrap();
+
+        let mut builder = tar::Builder::new(Vec::new());
+
+        // Regular file before device entries
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Regular);
+        header.set_size(5);
+        header.set_mode(0o644);
+        header.set_path("before.txt").unwrap();
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "before.txt", &b"hello"[..])
+            .unwrap();
+
+        // Char device entry (should be skipped)
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Char);
+        header.set_size(0);
+        header.set_mode(0o644);
+        header.set_path("etc/alternatives/pager.1.gz").unwrap();
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "etc/alternatives/pager.1.gz", &b""[..])
+            .unwrap();
+
+        // Block device entry (should be skipped)
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Block);
+        header.set_size(0);
+        header.set_mode(0o644);
+        header.set_path("dev/sda").unwrap();
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "dev/sda", &b""[..])
+            .unwrap();
+
+        // Regular file after device entries (must survive)
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Regular);
+        header.set_size(5);
+        header.set_mode(0o644);
+        header.set_path("after.txt").unwrap();
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "after.txt", &b"world"[..])
+            .unwrap();
+
+        let tar_data = builder.into_inner().unwrap();
+
+        let mut archive = tar::Archive::new(tar_data.as_slice());
+        let result = safe_unpack(&mut archive, &dest);
+        assert!(
+            result.is_ok(),
+            "Char/Block entries should be skipped: {:?}",
+            result.err()
+        );
+
+        // Files before AND after device entries are extracted
+        assert_eq!(
+            fs::read_to_string(dest.join("before.txt")).unwrap(),
+            "hello"
+        );
+        assert_eq!(fs::read_to_string(dest.join("after.txt")).unwrap(), "world");
+
+        // Device entries are not created
+        assert!(!dest.join("etc/alternatives/pager.1.gz").exists());
+        assert!(!dest.join("dev/sda").exists());
     }
 }

--- a/tests/test_pack.sh
+++ b/tests/test_pack.sh
@@ -828,6 +828,107 @@ test_from_vm_image_overlay() {
 }
 
 # =============================================================================
+# Debian Pack Roundtrip (issue #235 regression)
+#
+# Debian's update-alternatives creates Char device entries in /etc/alternatives/
+# in the overlayfs upper layer. These entries caused safe_unpack() to abort
+# mid-stream, silently dropping files that appeared after the Char entry in the
+# tar. This test verifies the full round-trip:
+#   1. Create image-based VM with Debian image
+#   2. Install a package that triggers update-alternatives (creates Char entries)
+#   3. Write a test file
+#   4. Pack the VM
+#   5. Create a new machine from the pack
+#   6. Verify the test file survived (it appears after Char entries in the tar)
+# =============================================================================
+
+test_from_vm_debian_roundtrip() {
+    local vm_name="debian-pack-$$"
+    local from_name="debian-from-$$"
+    local pack_output="$TEST_DIR/test-debian-roundtrip"
+
+    # Cleanup any leftovers
+    $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
+    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine stop --name "$from_name" 2>/dev/null || true
+    $SMOLVM machine delete "$from_name" -f 2>/dev/null || true
+
+    # 1. Create a Debian-based VM
+    echo "  Step 1: Creating Debian VM..."
+    $SMOLVM machine create "$vm_name" --image python:3.12-slim --net 2>&1 || return 1
+    $SMOLVM machine start --name "$vm_name" 2>&1 || {
+        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+    }
+
+    # 2. Install a package that creates Char entries via update-alternatives
+    echo "  Step 2: Installing man-db (creates Char entries in /etc/alternatives/)..."
+    $SMOLVM machine exec --name "$vm_name" -- \
+        bash -c "apt-get update -qq && apt-get install -y -qq man-db >/dev/null 2>&1" || {
+        echo "FAIL: apt-get install failed"
+        $SMOLVM machine stop --name "$vm_name" 2>/dev/null
+        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+    }
+
+    # 3. Write a test file (appears late in tar stream — after Char entries)
+    echo "  Step 3: Writing test marker..."
+    $SMOLVM machine exec --name "$vm_name" -- \
+        bash -c "echo 'debian-roundtrip-ok' > /test-marker.txt"
+
+    local content
+    content=$($SMOLVM machine exec --name "$vm_name" -- cat /test-marker.txt 2>&1)
+    [[ "$content" == *"debian-roundtrip-ok"* ]] || {
+        echo "FAIL: test marker not written (got: '$content')"
+        $SMOLVM machine stop --name "$vm_name" 2>/dev/null
+        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+    }
+
+    # 4. Stop and pack
+    echo "  Step 4: Packing VM..."
+    $SMOLVM machine stop --name "$vm_name" 2>&1
+    $SMOLVM pack create --from-vm "$vm_name" -o "$pack_output" 2>&1 || {
+        echo "FAIL: pack create --from-vm failed"
+        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+    }
+
+    # 5. Create a new machine from the pack
+    echo "  Step 5: Creating machine from pack..."
+    $SMOLVM machine create "$from_name" --from "$pack_output.smolmachine" 2>&1 || {
+        echo "FAIL: machine create --from failed (this was the #235 bug)"
+        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+    }
+    $SMOLVM machine start --name "$from_name" 2>&1 || {
+        echo "FAIL: machine start failed"
+        $SMOLVM machine delete "$from_name" -f 2>/dev/null
+        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+    }
+
+    # 6. Verify test file survived the roundtrip
+    echo "  Step 6: Verifying test marker survived..."
+    local result
+    result=$($SMOLVM machine exec --name "$from_name" -- cat /test-marker.txt 2>&1) || {
+        echo "FAIL: test marker missing after roundtrip (this was the #235 data loss)"
+        $SMOLVM machine stop --name "$from_name" 2>/dev/null
+        $SMOLVM machine delete "$from_name" -f 2>/dev/null
+        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+    }
+
+    [[ "$result" == *"debian-roundtrip-ok"* ]] || {
+        echo "FAIL: test marker content mismatch (got: '$result')"
+        $SMOLVM machine stop --name "$from_name" 2>/dev/null
+        $SMOLVM machine delete "$from_name" -f 2>/dev/null
+        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+    }
+
+    echo "  Test marker survived Debian pack/unpack roundtrip"
+
+    # Cleanup
+    $SMOLVM machine stop --name "$from_name" 2>/dev/null || true
+    $SMOLVM machine delete "$from_name" -f 2>/dev/null || true
+    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    rm -f "$pack_output" "$pack_output.smolmachine"
+}
+
+# =============================================================================
 # Case-Insensitive Collision Test (macOS regression)
 #
 # Regression test for macOS case-insensitive APFS. Linux OCI layers may
@@ -1230,6 +1331,12 @@ if [[ "$QUICK_MODE" != "true" ]]; then
     echo ""
 
     run_test "from-vm-image: container overlay captured" test_from_vm_image_overlay || true
+
+    echo ""
+    echo "Running Debian Pack Roundtrip Tests (issue #235)..."
+    echo ""
+
+    run_test "from-vm-debian: Char device entries don't break extraction" test_from_vm_debian_roundtrip || true
 fi
 
 # =============================================================================


### PR DESCRIPTION
After testing -  Char and Block types during the untar does not appear to be required for functionality.

The char entries require root on the host to extract - so as a result the old code just crashes here. But since after the guest boots, the system is reinitialized - it just gets recreated.