### PR TITLE
fix: pruning -all should just remove images

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -418,6 +418,6 @@ OpenAPI spec: `smolvm serve openapi`
 ## Important Behaviors
 
 - **Observational commands don't stop running VMs.** `machine images`, `machine status`, `machine ls` and similar read-only commands leave a running VM in its current state. If the VM was already running before the command, it stays running after.
-- **`machine prune` requires the VM to be stopped.** Pruning layers while a VM has active containers could break things. Stop the VM first with `machine stop`, then prune.
+- **`machine prune` works on a running VM.** Regular prune only removes unreferenced layers and is safe while containers are active. `prune --all` requires the VM to be stopped first since it deletes manifests for layers that may be in use.
 - **`machine exec` persists filesystem changes.** Package installs, config edits, and file writes inside `exec` survive across sessions. This works for both bare VMs and image-based VMs (created with `--image`).
 - **`machine run` is always ephemeral.** The VM is created, the command runs, and everything is cleaned up. No state carries over.

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -1602,7 +1602,7 @@ fn handle_request(
 
         AgentRequest::ListImages => handle_list_images(),
 
-        AgentRequest::GarbageCollect { dry_run } => handle_gc(dry_run),
+        AgentRequest::GarbageCollect { dry_run, purge_all } => handle_gc(dry_run, purge_all),
 
         AgentRequest::PrepareOverlay { image, workload_id } => {
             handle_prepare_overlay(&image, &workload_id)
@@ -3538,7 +3538,12 @@ fn handle_list_images() -> AgentResponse {
 }
 
 /// Handle garbage collection request.
-fn handle_gc(dry_run: bool) -> AgentResponse {
+fn handle_gc(dry_run: bool, purge_all: bool) -> AgentResponse {
+    if purge_all && !dry_run {
+        if let Err(e) = storage::purge_all_images() {
+            return AgentResponse::from_err(e, error_codes::GC_FAILED);
+        }
+    }
     match storage::garbage_collect(dry_run) {
         Ok(freed) => AgentResponse::ok_with_data(serde_json::json!({
             "freed_bytes": freed,

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -1479,6 +1479,24 @@ pub fn get_layer_digest(image_digest: &str, layer_index: usize) -> Result<String
     )))
 }
 
+/// Remove all image manifests and configs, making all layers unreferenced.
+///
+/// Call this before `garbage_collect()` to implement `prune --all`.
+pub fn purge_all_images() -> Result<()> {
+    let root = Path::new(STORAGE_ROOT);
+    let manifests_dir = root.join(MANIFESTS_DIR);
+    let configs_dir = root.join(CONFIGS_DIR);
+
+    if manifests_dir.exists() {
+        std::fs::remove_dir_all(&manifests_dir)?;
+    }
+    if configs_dir.exists() {
+        std::fs::remove_dir_all(&configs_dir)?;
+    }
+
+    Ok(())
+}
+
 /// Run garbage collection.
 pub fn garbage_collect(dry_run: bool) -> Result<u64> {
     let root = Path::new(STORAGE_ROOT);

--- a/crates/smolvm-protocol/src/lib.rs
+++ b/crates/smolvm-protocol/src/lib.rs
@@ -151,6 +151,10 @@ pub enum AgentRequest {
     GarbageCollect {
         /// If true, only report what would be deleted.
         dry_run: bool,
+        /// If true, delete all image manifests and configs first,
+        /// making all layers unreferenced so they get collected.
+        #[serde(default)]
+        purge_all: bool,
     },
 
     /// Prepare overlay rootfs for a workload.

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -685,8 +685,9 @@ impl AgentClient {
     /// # Arguments
     ///
     /// * `dry_run` - If true, only report what would be deleted
-    pub fn garbage_collect(&mut self, dry_run: bool) -> Result<u64> {
-        let resp = self.request(&AgentRequest::GarbageCollect { dry_run })?;
+    /// * `purge_all` - If true, delete all manifests/configs first so all layers are collected
+    pub fn garbage_collect(&mut self, dry_run: bool, purge_all: bool) -> Result<u64> {
+        let resp = self.request(&AgentRequest::GarbageCollect { dry_run, purge_all })?;
 
         match resp {
             AgentResponse::Ok { data: Some(data) } => {

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -1668,15 +1668,25 @@ impl PruneCmd {
     pub fn run(self) -> smolvm::Result<()> {
         let manager = AgentManager::new_default()?;
 
-        if manager.try_connect_existing().is_some() {
+        // Regular prune (unreferenced layers only) is safe on a running VM —
+        // referenced layers can't be collected. --all deletes manifests for
+        // layers that may be in active use, so it requires a stop first.
+        let already_running = manager.try_connect_existing().is_some();
+        let started_for_prune;
+
+        if already_running && self.all {
             return Err(smolvm::Error::agent(
                 "prune",
-                "cannot prune while the machine is running. Stop it first with 'smolvm machine stop'",
+                "cannot prune --all while the machine is running. Stop it first with 'smolvm machine stop'",
             ));
+        } else if already_running {
+            started_for_prune = false;
+        } else {
+            println!("Starting machine...");
+            manager.start()?;
+            started_for_prune = true;
         }
 
-        println!("Starting machine...");
-        manager.start()?;
         let mut client = AgentClient::connect_with_retry(manager.vsock_socket())?;
 
         if self.all {
@@ -1705,12 +1715,16 @@ impl PruneCmd {
                 }
             } else {
                 println!("Removing all cached images...");
-                let freed = client.garbage_collect(false)?;
-                println!("Freed {} of unreferenced layers", format_bytes(freed));
+                let freed = client.garbage_collect(false, true)?;
+                println!(
+                    "Removed {} images, freed {}",
+                    images.len(),
+                    format_bytes(freed)
+                );
             }
         } else if self.dry_run {
             println!("Scanning for unreferenced layers...");
-            let would_free = client.garbage_collect(true)?;
+            let would_free = client.garbage_collect(true, false)?;
 
             if would_free > 0 {
                 println!(
@@ -1722,13 +1736,19 @@ impl PruneCmd {
             }
         } else {
             println!("Removing unreferenced layers...");
-            let freed = client.garbage_collect(false)?;
+            let freed = client.garbage_collect(false, false)?;
 
             if freed > 0 {
                 println!("Freed {}", format_bytes(freed));
             } else {
                 println!("No unreferenced layers to remove.");
             }
+        }
+
+        // Only stop the VM if we started it for this prune operation.
+        // If the user's machine was already running, leave it running.
+        if started_for_prune {
+            let _ = manager.stop();
         }
 
         Ok(())

--- a/tests/test_machine.sh
+++ b/tests/test_machine.sh
@@ -2350,31 +2350,115 @@ test_images_does_not_stop_running_vm() {
     assert_vm_stays_running "machine images" $SMOLVM machine images
 }
 
-test_prune_refuses_on_running_vm() {
+test_prune_on_running_vm() {
     ensure_machine_running
 
     local status
     status=$($SMOLVM machine status 2>&1)
     [[ "$status" == *"running"* ]] || { echo "VM not running before test"; return 1; }
 
-    # Prune should refuse while VM is running
+    # Regular prune should work without stopping the VM
+    local output
+    output=$($SMOLVM machine prune 2>&1) || true
+    [[ "$output" == *"unreferenced"* ]] || [[ "$output" == *"No unreferenced"* ]] || {
+        echo "unexpected prune output: $output"
+        return 1
+    }
+
+    # VM should still be running after prune
+    status=$($SMOLVM machine status 2>&1)
+    [[ "$status" == *"running"* ]] || { echo "VM stopped after prune"; return 1; }
+}
+
+test_prune_dry_run_on_running_vm() {
+    ensure_machine_running
+
+    local output
+    output=$($SMOLVM machine prune --dry-run 2>&1) || true
+    [[ "$output" == *"unreferenced"* ]] || [[ "$output" == *"No unreferenced"* ]] || {
+        echo "unexpected prune --dry-run output: $output"
+        return 1
+    }
+
+    # VM should still be running
+    local status
+    status=$($SMOLVM machine status 2>&1)
+    [[ "$status" == *"running"* ]] || { echo "VM stopped after prune --dry-run"; return 1; }
+}
+
+test_prune_all_refuses_on_running_vm() {
+    ensure_machine_running "true"
+
+    local status
+    status=$($SMOLVM machine status 2>&1)
+    [[ "$status" == *"running"* ]] || { echo "VM not running before test"; return 1; }
+
+    # --all should refuse while the VM is running
     local output exit_code=0
-    output=$($SMOLVM machine prune 2>&1) || exit_code=$?
-    [[ $exit_code -ne 0 ]] || { echo "prune should have failed on running VM"; return 1; }
-    [[ "$output" == *"cannot prune while the machine is running"* ]] || { echo "unexpected error: $output"; return 1; }
+    output=$($SMOLVM machine prune --all 2>&1) || exit_code=$?
+    [[ $exit_code -ne 0 ]] || { echo "prune --all should have failed on running VM"; return 1; }
+    [[ "$output" == *"cannot prune --all while the machine is running"* ]] || {
+        echo "unexpected error: $output"
+        return 1
+    }
 
     # VM should still be running
     status=$($SMOLVM machine status 2>&1)
-    [[ "$status" == *"running"* ]] || { echo "VM stopped after rejected prune"; return 1; }
+    [[ "$status" == *"running"* ]] || { echo "VM stopped after rejected prune --all"; return 1; }
 }
 
-test_prune_dry_run_refuses_on_running_vm() {
-    ensure_machine_running
+# Regression: prune --all said "Removing all cached images" but never
+# actually deleted the manifests, so images survived. This test verifies
+# images are gone after prune --all.
+test_prune_all_removes_images() {
+    # Start with a clean machine that has an image cached
+    $SMOLVM machine stop 2>/dev/null || true
+    $SMOLVM machine delete default -f 2>/dev/null || true
+    $SMOLVM machine create --image alpine --net default 2>&1 || return 1
+    $SMOLVM machine start 2>&1 || return 1
 
-    local output exit_code=0
-    output=$($SMOLVM machine prune --dry-run 2>&1) || exit_code=$?
-    [[ $exit_code -ne 0 ]] || { echo "prune --dry-run should have failed on running VM"; return 1; }
-    [[ "$output" == *"cannot prune while the machine is running"* ]]
+    # Verify the image is cached
+    $SMOLVM machine exec -- true 2>&1 || { echo "VM not reachable"; return 1; }
+
+    # Check images before prune
+    local images_before
+    images_before=$($SMOLVM machine images 2>&1)
+
+    # Stop the VM (prune requires it)
+    $SMOLVM machine stop 2>&1
+
+    # Run prune --all
+    local output
+    output=$($SMOLVM machine prune --all 2>&1) || {
+        echo "prune --all failed: $output"
+        $SMOLVM machine delete default -f 2>/dev/null
+        return 1
+    }
+    [[ "$output" == *"Removed"* ]] || [[ "$output" == *"No cached images"* ]] || {
+        echo "unexpected prune output: $output"
+        $SMOLVM machine delete default -f 2>/dev/null
+        return 1
+    }
+
+    # Restart and verify images are gone
+    $SMOLVM machine start 2>&1 || {
+        $SMOLVM machine delete default -f 2>/dev/null
+        return 1
+    }
+
+    local images_after
+    images_after=$($SMOLVM machine images 2>&1)
+
+    $SMOLVM machine stop 2>/dev/null || true
+    $SMOLVM machine delete default -f 2>/dev/null || true
+
+    # After prune --all, no images should remain
+    if echo "$images_after" | grep -qE "^[a-z].*[0-9]+ MB"; then
+        echo "FAIL: images still present after prune --all"
+        echo "Before: $images_before"
+        echo "After: $images_after"
+        return 1
+    fi
 }
 
 test_machine_ls_does_not_kill_vm() {
@@ -2513,8 +2597,10 @@ run_test "Concurrent exec does not flip VM to unreachable" test_concurrent_exec_
 run_test "Listing: machine ls does not kill VM" test_machine_ls_does_not_kill_vm || true
 run_test "Listing: named VM survives repeated ls" test_named_vm_survives_ls || true
 run_test "Images: does not stop running VM" test_images_does_not_stop_running_vm || true
-run_test "Prune: refuses on running VM" test_prune_refuses_on_running_vm || true
-run_test "Prune --dry-run: refuses on running VM" test_prune_dry_run_refuses_on_running_vm || true
+run_test "Prune: works on running VM without stopping it" test_prune_on_running_vm || true
+run_test "Prune --dry-run: works on running VM" test_prune_dry_run_on_running_vm || true
+run_test "Prune --all: refuses on running VM" test_prune_all_refuses_on_running_vm || true
+run_test "Prune --all: removes cached images" test_prune_all_removes_images || true
 
 # =============================================================================
 # grpcio / TSI SOL_SOCKET round-trip test


### PR DESCRIPTION
keeping prune with--all to match similar in concept to container image pruning.

but --all for a vm should have different behavior

---
Looking to address:

https://github.com/smol-machines/smolvm/issues/241

https://github.com/smol-machines/smolvm/issues/175