### PR TITLE
fix: ephemeral runs point to default name resulting in shared state

### DIFF
--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -1266,6 +1266,24 @@ impl AgentManager {
         self.cleanup_marker_files();
     }
 
+    /// Remove the VM's entire data directory (storage, overlay, socket, logs).
+    ///
+    /// Only safe for ephemeral VMs after the process is confirmed dead.
+    pub fn cleanup_data_dir(&self) {
+        if let Some(ref name) = self.name {
+            let dir = vm_data_dir(name);
+            if dir.exists() {
+                if let Err(e) = std::fs::remove_dir_all(&dir) {
+                    tracing::debug!(
+                        error = %e,
+                        path = %dir.display(),
+                        "failed to remove ephemeral VM data directory"
+                    );
+                }
+            }
+        }
+    }
+
     /// Stop the agent VM.
     pub fn stop(&self) -> Result<()> {
         let state = {

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -308,13 +308,10 @@ impl RunCmd {
         use smolvm::Error;
 
         let requested_name = self.name.clone();
-        if !self.detach && requested_name.is_some() {
-            eprintln!("warning: --name is ignored without -d");
-        }
         let vm_name = if self.detach {
             requested_name.unwrap_or_else(|| "default".to_string())
         } else {
-            "default".to_string()
+            smolvm::util::generate_machine_name()
         };
 
         if self.name.is_some() && vm_name != "default" && self.detach {
@@ -423,12 +420,11 @@ impl RunCmd {
             AgentManager::for_vm_with_sizes(&vm_name, params.storage_gb, params.overlay_gb)
                 .map_err(|e| Error::agent("create agent manager", e.to_string()))?;
 
-        let mode = if self.detach {
-            "persistent"
+        if self.detach {
+            println!("Starting persistent machine...");
         } else {
-            "ephemeral"
-        };
-        println!("Starting {} machine...", mode);
+            println!("Starting ephemeral machine ({})...", vm_name);
+        }
 
         let ssh_agent_socket = if self.ssh_agent || params.ssh_agent {
             match std::env::var("SSH_AUTH_SOCK") {
@@ -701,9 +697,10 @@ impl RunCmd {
                     exit_code
                 };
 
-                // Ephemeral run — command finished, kill VM immediately.
+                // Ephemeral run — tear down VM and its data directory.
                 vm_common::deregister_ephemeral_vm(&ephemeral_name);
                 manager.kill();
+                manager.cleanup_data_dir();
                 std::process::exit(exit_code);
             }
         } else {
@@ -812,9 +809,10 @@ impl RunCmd {
                     flush_output();
                     exit_code
                 };
-                // Ephemeral run — command finished, kill VM immediately.
+                // Ephemeral run — tear down VM and its data directory.
                 vm_common::deregister_ephemeral_vm(&ephemeral_name);
                 manager.kill();
+                manager.cleanup_data_dir();
                 std::process::exit(exit_code);
             }
         }

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -1433,6 +1433,10 @@ pub fn cleanup_orphaned_ephemeral_vms() {
         if is_orphan {
             tracing::debug!(name = %name, pid = ?record.pid, "cleaning up orphaned ephemeral VM");
             let _ = db.remove_vm(name);
+            let dir = smolvm::agent::vm_data_dir(name);
+            if dir.exists() {
+                let _ = std::fs::remove_dir_all(&dir);
+            }
         }
     }
 }

--- a/tests/test_machine.sh
+++ b/tests/test_machine.sh
@@ -3003,4 +3003,46 @@ test_storage_mounted_as_ext4() {
 run_test "Storage: resize + large image pull (fresh disk)" test_storage_resize_and_large_pull || true
 run_test "Storage: /dev/vda mounted as ext4 with correct size" test_storage_mounted_as_ext4 || true
 
+# =============================================================================
+# Ephemeral VM Isolation
+# =============================================================================
+
+test_ephemeral_runs_do_not_share_state() {
+    # Run 1: create a marker file
+    $SMOLVM machine run --net --image alpine:latest -- \
+        sh -c 'echo ephemeral-leak-test > /tmp/ephemeral-marker.txt' 2>&1
+
+    # Run 2: marker must not exist
+    local output exit_code=0
+    output=$($SMOLVM machine run --net --image alpine:latest -- \
+        sh -c 'cat /tmp/ephemeral-marker.txt 2>&1 || echo MARKER_NOT_FOUND' 2>&1) || exit_code=$?
+
+    [[ "$output" == *"MARKER_NOT_FOUND"* ]] || {
+        echo "FAIL: ephemeral run found file from previous run"
+        echo "$output"
+        return 1
+    }
+}
+
+test_ephemeral_volume_mount_reflects_host() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    echo "file-a" > "$tmpdir/a.txt"
+    echo "file-b" > "$tmpdir/b.txt"
+    echo "file-c" > "$tmpdir/c.txt"
+
+    local output
+    output=$($SMOLVM machine run --net -v "$tmpdir:/hostmnt" --image alpine:latest -- \
+        ls /hostmnt 2>&1)
+
+    rm -rf "$tmpdir"
+
+    [[ "$output" == *"a.txt"* ]] || { echo "missing a.txt: $output"; return 1; }
+    [[ "$output" == *"b.txt"* ]] || { echo "missing b.txt: $output"; return 1; }
+    [[ "$output" == *"c.txt"* ]] || { echo "missing c.txt: $output"; return 1; }
+}
+
+run_test "Ephemeral run: no state leaks between runs" test_ephemeral_runs_do_not_share_state || true
+run_test "Ephemeral run: volume mount shows correct host contents" test_ephemeral_volume_mount_reflects_host || true
+
 print_summary "Machine Tests"


### PR DESCRIPTION
default is basically the name used for any vm's without a --name to provide a seamless fallback.

ephemeral runs that don't specify a name as a result lands on the default name & concurrent runs on the same named machine results in sharing the state of the filesystems

so let's just have the ephemeral run use a name generator + guard to clean up finished ephemeral runs