### PR TITLE
fix: add GLIBC version detection to prevent cryptic errors on older Linux

### DIFF
--- a/scripts/smolvm-wrapper.sh
+++ b/scripts/smolvm-wrapper.sh
@@ -39,6 +39,29 @@ if [[ ! -x "$SMOLVM_BIN" ]]; then
     exit 1
 fi
 
+# Check GLIBC compatibility on Linux
+if [[ "$(uname -s)" == "Linux" ]]; then
+    # Extract the maximum required GLIBC version from the binary
+    REQUIRED_GLIBC=$(objdump -T "$SMOLVM_BIN" 2>/dev/null | grep -oP 'GLIBC_\d+\.\d+' | sort -V | tail -1 | sed 's/GLIBC_//')
+    if [[ -n "$REQUIRED_GLIBC" ]]; then
+        # Get the system GLIBC version
+        SYSTEM_GLIBC=$(ldd --version 2>&1 | head -1 | grep -oP '\d+\.\d+' | head -1)
+        if [[ -n "$SYSTEM_GLIBC" ]]; then
+            # Compare versions
+            if [[ "$(printf '%s\n' "$REQUIRED_GLIBC" "$SYSTEM_GLIBC" | sort -V | tail -1)" != "$SYSTEM_GLIBC" ]]; then
+                echo "Error: smolvm requires GLIBC >= $REQUIRED_GLIBC but your system has GLIBC $SYSTEM_GLIBC" >&2
+                echo "" >&2
+                echo "This typically happens on older Linux distributions (e.g., Ubuntu 22.04)." >&2
+                echo "To resolve:" >&2
+                echo "  1. Upgrade to Ubuntu 24.04 or newer, or" >&2
+                echo "  2. Build smolvm from source: https://github.com/smol-machines/smolvm#building-from-source" >&2
+                echo "  3. Use the smolvm Docker image: docker run --rm -it --privileged smolmachines/smolvm" >&2
+                exit 1
+            fi
+        fi
+    fi
+fi
+
 # Check if libraries exist
 if [[ ! -d "$SMOLVM_LIB" ]]; then
     echo "Error: library directory not found at $SMOLVM_LIB" >&2


### PR DESCRIPTION
## Summary

Fixes #228: smolvm fails with cryptic `GLIBC_2.39 not found` error on Ubuntu 22.04 / WSL.

## Problem

The pre-built `smolvm-bin` binary is compiled on a build machine with GLIBC 2.39+, but users on Ubuntu 22.04 (which ships GLIBC 2.35) receive a cryptic `version 'GLIBC_2.39' not found` error from the dynamic linker. This is especially common for WSL users who default to Ubuntu 22.04.

## Solution

Added explicit GLIBC version compatibility checking to the wrapper script (`scripts/smolvm-wrapper.sh`):

1. Uses `objdump -T` to extract the maximum required GLIBC version from the binary
2. Reads the system's installed GLIBC version via `ldd --version`
3. Compares versions and exits with a clear, actionable error message if incompatible
4. Provides specific resolution steps (upgrade, build from source, or use Docker)

### Before:
```
$ smolvm --help
/home/user/.smolvm/smolvm-bin: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
```

### After:
```
$ smolvm --help
Error: smolvm requires GLIBC >= 2.39 but your system has GLIBC 2.35

This typically happens on older Linux distributions (e.g., Ubuntu 22.04).
To resolve:
  1. Upgrade to Ubuntu 24.04 or newer, or
  2. Build smolvm from source: https://github.com/smol-machines/smolvm#building-from-source
  3. Use the smolvm Docker image: docker run --rm -it --privileged smolmachines/smolvm
```

This gracefully handles systems without `objdump` by falling through to the existing behavior.

## Type of Change

- [x] Bug fix (improved error handling)