### PR TITLE
Fix image-backed machine exec --stream routing

### DIFF
--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 use std::time::Duration;
 
 /// Events from a streaming exec session.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ExecEvent {
     /// Standard output data.
     Stdout(Vec<u8>),
@@ -1086,6 +1086,38 @@ impl AgentClient {
         Ok(pid)
     }
 
+    /// Run a command in an image's rootfs and handle streamed events as they arrive.
+    ///
+    /// Unlike `run_interactive`, this does not forward stdin. It is the
+    /// image-backed counterpart to `vm_exec_streaming_with`.
+    pub fn run_streaming_with<F>(&mut self, config: RunConfig, on_event: F) -> Result<()>
+    where
+        F: FnMut(ExecEvent),
+    {
+        let timeout_ms = config.timeout.map(|t| t.as_millis() as u64);
+
+        self.stream
+            .set_read_timeout(None)
+            .map_err(|e| Error::agent("set read timeout", e.to_string()))?;
+
+        self.send(&AgentRequest::Run {
+            image: config.image,
+            command: config.command,
+            env: config.env,
+            workdir: config.workdir,
+            user: config.user,
+            mounts: config.mounts,
+            timeout_ms,
+            interactive: true,
+            tty: false,
+            detached: false,
+            persistent_overlay_id: config.persistent_overlay_id,
+            background: false,
+        })?;
+
+        collect_exec_events(self, "run streaming", on_event)
+    }
+
     /// Run a command interactively with streaming I/O.
     ///
     /// This method streams output directly to stdout/stderr and forwards stdin.
@@ -1455,10 +1487,13 @@ impl AgentClient {
 
     /// Execute a command with streaming output.
     ///
+    /// This compatibility wrapper buffers all events before returning. New
+    /// callers that need live output should use `vm_exec_streaming_with`.
+    ///
     /// Sends a VmExec request with interactive=true, tty=false. Reads
-    /// Stdout/Stderr/Exited responses and sends them as `ExecEvent` on
-    /// the returned receiver. Blocks the current thread until the command
-    /// finishes — call from a blocking context (e.g., `spawn_blocking`).
+    /// Stdout/Stderr/Exited responses into a vector and blocks until the
+    /// command finishes — call from a blocking context (e.g.,
+    /// `spawn_blocking`).
     pub fn vm_exec_streaming(
         &mut self,
         command: Vec<String>,
@@ -1466,6 +1501,27 @@ impl AgentClient {
         workdir: Option<String>,
         timeout: Option<Duration>,
     ) -> Result<Vec<ExecEvent>> {
+        let mut events = Vec::new();
+        self.vm_exec_streaming_with(command, env, workdir, timeout, |event| {
+            events.push(event);
+        })?;
+        Ok(events)
+    }
+
+    /// Execute a command with streaming output and handle events as they arrive.
+    ///
+    /// This is the live-output variant of `vm_exec_streaming`.
+    pub fn vm_exec_streaming_with<F>(
+        &mut self,
+        command: Vec<String>,
+        env: Vec<(String, String)>,
+        workdir: Option<String>,
+        timeout: Option<Duration>,
+        on_event: F,
+    ) -> Result<()>
+    where
+        F: FnMut(ExecEvent),
+    {
         let timeout_ms = timeout.map(|t| t.as_millis() as u64);
 
         self.stream
@@ -1482,42 +1538,7 @@ impl AgentClient {
             background: false,
         })?;
 
-        // Wait for Started
-        match self.receive()? {
-            AgentResponse::Started => {}
-            AgentResponse::Error { message, .. } => {
-                return Err(Error::agent("streaming exec", message));
-            }
-            _ => return Err(Error::agent("streaming exec", "expected Started")),
-        }
-
-        let mut events = Vec::new();
-
-        loop {
-            match self.receive() {
-                Ok(AgentResponse::Stdout { data }) => {
-                    events.push(ExecEvent::Stdout(data));
-                }
-                Ok(AgentResponse::Stderr { data }) => {
-                    events.push(ExecEvent::Stderr(data));
-                }
-                Ok(AgentResponse::Exited { exit_code }) => {
-                    events.push(ExecEvent::Exit(exit_code));
-                    break;
-                }
-                Ok(AgentResponse::Error { message, .. }) => {
-                    events.push(ExecEvent::Error(message));
-                    break;
-                }
-                Ok(_) => {}
-                Err(e) => {
-                    events.push(ExecEvent::Error(e.to_string()));
-                    break;
-                }
-            }
-        }
-
-        Ok(events)
+        collect_exec_events(self, "streaming exec", on_event)
     }
 
     /// Low-level send without waiting for response (public).
@@ -1653,6 +1674,44 @@ impl AgentClient {
             .map_err(|e| Error::agent("deserialize response", e.to_string()))?;
         Ok(resp)
     }
+}
+
+fn collect_exec_events<F>(client: &mut AgentClient, op: &str, mut on_event: F) -> Result<()>
+where
+    F: FnMut(ExecEvent),
+{
+    match client.receive()? {
+        AgentResponse::Started => {}
+        AgentResponse::Error { message, .. } => {
+            return Err(Error::agent(op, message));
+        }
+        _ => return Err(Error::agent(op, "expected Started")),
+    }
+
+    loop {
+        match client.receive() {
+            Ok(AgentResponse::Stdout { data }) => {
+                on_event(ExecEvent::Stdout(data));
+            }
+            Ok(AgentResponse::Stderr { data }) => {
+                on_event(ExecEvent::Stderr(data));
+            }
+            Ok(AgentResponse::Exited { exit_code }) => {
+                on_event(ExecEvent::Exit(exit_code));
+                break;
+            }
+            Ok(AgentResponse::Error { message, .. }) => {
+                on_event(ExecEvent::Error(message));
+                break;
+            }
+            Ok(_) => {}
+            Err(err) => {
+                on_event(ExecEvent::Error(err.to_string()));
+                break;
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Consume streamed `DataChunk` responses, enforcing the per-transfer
@@ -1958,5 +2017,102 @@ mod run_background_tests {
             err
         );
         server.join().unwrap();
+    }
+}
+
+#[cfg(test)]
+mod run_streaming_tests {
+    //! Regression coverage for image-backed streaming exec.
+    //!
+    //! `machine exec --stream` must preserve the same execution target as
+    //! buffered `machine exec`. For image-backed machines that means sending a
+    //! `Run { interactive: true }` request to the agent, not `VmExec` against
+    //! the bare agent rootfs.
+    use super::*;
+    use smolvm_protocol::{encode_message, AgentRequest, AgentResponse, Envelope};
+    use std::io::{Read, Write};
+    use std::thread;
+
+    #[test]
+    fn run_streaming_sends_interactive_run_and_collects_events() {
+        let (client_stream, mut server_stream) = UnixStream::pair().unwrap();
+
+        let server = thread::spawn(move || {
+            let mut len_buf = [0u8; 4];
+            server_stream.read_exact(&mut len_buf).unwrap();
+            let len = u32::from_be_bytes(len_buf) as usize;
+            let mut payload = vec![0u8; len];
+            server_stream.read_exact(&mut payload).unwrap();
+
+            let envelope: Envelope<AgentRequest> =
+                serde_json::from_slice(&payload).expect("valid Envelope<AgentRequest>");
+            match envelope.body {
+                AgentRequest::Run {
+                    image,
+                    command,
+                    mounts,
+                    interactive,
+                    tty,
+                    detached,
+                    background,
+                    persistent_overlay_id,
+                    ..
+                } => {
+                    assert_eq!(image, "ubuntu:24.04");
+                    assert_eq!(command, vec!["/bin/bash", "-lc", "echo hi"]);
+                    assert_eq!(
+                        mounts,
+                        vec![("work".to_string(), "/work".to_string(), false)]
+                    );
+                    assert!(interactive, "streaming image exec must use interactive Run");
+                    assert!(!tty, "plain --stream must not allocate a TTY");
+                    assert!(!detached, "streaming exec must not detach");
+                    assert!(!background, "streaming exec must not run in background");
+                    assert_eq!(persistent_overlay_id, Some("dev".to_string()));
+                }
+                other => panic!("expected AgentRequest::Run, got {:?}", other),
+            }
+
+            for response in [
+                AgentResponse::Started,
+                AgentResponse::Stdout {
+                    data: b"hi\n".to_vec(),
+                },
+                AgentResponse::Stderr {
+                    data: b"warn\n".to_vec(),
+                },
+                AgentResponse::Exited { exit_code: 7 },
+            ] {
+                let encoded = encode_message(&response).expect("encode response");
+                server_stream.write_all(&encoded).expect("write response");
+            }
+        });
+
+        let mut client = AgentClient::from_stream(client_stream);
+        let config = RunConfig::new(
+            "ubuntu:24.04",
+            vec![
+                "/bin/bash".to_string(),
+                "-lc".to_string(),
+                "echo hi".to_string(),
+            ],
+        )
+        .with_mounts(vec![("work".to_string(), "/work".to_string(), false)])
+        .with_persistent_overlay(Some("dev".to_string()));
+
+        let mut events = Vec::new();
+        client
+            .run_streaming_with(config, |event| events.push(event))
+            .expect("run_streaming_with should handle streamed events");
+
+        assert_eq!(
+            events,
+            vec![
+                ExecEvent::Stdout(b"hi\n".to_vec()),
+                ExecEvent::Stderr(b"warn\n".to_vec()),
+                ExecEvent::Exit(7),
+            ]
+        );
+        server.join().expect("server thread joined cleanly");
     }
 }

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -1102,37 +1102,6 @@ impl ExecCmd {
             .or_else(|| record.as_ref().and_then(|r| r.workdir.clone()));
         let record_image = record.as_ref().and_then(|r| r.image.clone());
 
-        // Streaming mode — print output as it arrives, no buffering
-        if self.stream {
-            let events = client.vm_exec_streaming(
-                self.command.clone(),
-                env.clone(),
-                workdir.clone(),
-                self.timeout,
-            )?;
-            let mut exit_code = 0;
-            for event in events {
-                match event {
-                    smolvm::agent::ExecEvent::Stdout(data) => {
-                        let _ = std::io::stdout().write_all(&data);
-                        let _ = std::io::stdout().flush();
-                    }
-                    smolvm::agent::ExecEvent::Stderr(data) => {
-                        let _ = std::io::stderr().write_all(&data);
-                        let _ = std::io::stderr().flush();
-                    }
-                    smolvm::agent::ExecEvent::Exit(code) => {
-                        exit_code = code;
-                    }
-                    smolvm::agent::ExecEvent::Error(msg) => {
-                        eprintln!("error: {}", msg);
-                        exit_code = 1;
-                    }
-                }
-            }
-            std::process::exit(exit_code);
-        }
-
         // Check if this machine has an image — if so, exec inside the image's
         // rootfs via client.run_interactive()/run_non_interactive() instead of bare vm_exec().
         let mount_bindings = record
@@ -1178,6 +1147,19 @@ impl ExecCmd {
                 std::process::exit(exit_code);
             }
 
+            if self.stream {
+                let config = smolvm::agent::RunConfig::new(image, self.command.clone())
+                    .with_env(defaults.env.clone())
+                    .with_workdir(defaults.workdir.clone())
+                    .with_user(defaults.user.clone())
+                    .with_mounts(mount_bindings)
+                    .with_timeout(self.timeout)
+                    .with_persistent_overlay(Some(machine_name.clone()));
+                let mut printer = ExecEventPrinter::default();
+                client.run_streaming_with(config, |event| printer.handle(event))?;
+                std::process::exit(printer.exit_code);
+            }
+
             let config = smolvm::agent::RunConfig::new(image, self.command.clone())
                 .with_env(defaults.env)
                 .with_workdir(defaults.workdir)
@@ -1205,9 +1187,48 @@ impl ExecCmd {
                 std::process::exit(exit_code);
             }
 
+            if self.stream {
+                let mut printer = ExecEventPrinter::default();
+                client.vm_exec_streaming_with(
+                    self.command.clone(),
+                    env.clone(),
+                    workdir.clone(),
+                    self.timeout,
+                    |event| printer.handle(event),
+                )?;
+                std::process::exit(printer.exit_code);
+            }
+
             let (exit_code, stdout, stderr) =
                 client.vm_exec(self.command.clone(), env, workdir.clone(), self.timeout)?;
             vm_common::print_output_and_exit(&manager, exit_code, &stdout, &stderr);
+        }
+    }
+}
+
+#[derive(Default)]
+struct ExecEventPrinter {
+    exit_code: i32,
+}
+
+impl ExecEventPrinter {
+    fn handle(&mut self, event: smolvm::agent::ExecEvent) {
+        match event {
+            smolvm::agent::ExecEvent::Stdout(data) => {
+                let _ = std::io::stdout().write_all(&data);
+                let _ = std::io::stdout().flush();
+            }
+            smolvm::agent::ExecEvent::Stderr(data) => {
+                let _ = std::io::stderr().write_all(&data);
+                let _ = std::io::stderr().flush();
+            }
+            smolvm::agent::ExecEvent::Exit(code) => {
+                self.exit_code = code;
+            }
+            smolvm::agent::ExecEvent::Error(msg) => {
+                eprintln!("error: {}", msg);
+                self.exit_code = 1;
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem

`smolvm machine exec --stream` currently changes the execution target for image-backed machines.

Normal `machine exec` first checks whether the machine has an image. If it does, it executes the command inside that image rootfs via `AgentRequest::Run`. That is why this works for an Ubuntu-backed machine:

```sh
smolvm machine exec --name dev /bin/bash -lc 'echo ok'
```

The `--stream` path bypassed that image-backed dispatch and immediately called `vm_exec_streaming`, which sends `AgentRequest::VmExec`. `VmExec` runs in the bare agent rootfs, not inside the configured image. So the same command with `--stream` could fail with `No such file or directory` for `/bin/bash`, or worse, appear to work with `/bin/sh` while actually running in the wrong rootfs.

## Fix

This keeps `--stream` as an output-mode choice, not an execution-target choice.

- image-backed machines now stream through `AgentRequest::Run`
- bare VM machines still stream through `AgentRequest::VmExec`
- the CLI prints streamed events as they arrive
- the existing `vm_exec_streaming(...) -> Vec<ExecEvent>` API remains as a documented compatibility wrapper
- new `*_streaming_with(...)` helpers support live event handling without buffering

## Why this is better

This makes `machine exec --stream` consistent with buffered `machine exec`: adding `--stream` changes how output is delivered, not where the command runs.

It also avoids using `run_interactive` for this path. `--stream` should stream stdout/stderr without forwarding stdin or allocating a TTY, so the new callback streaming helpers model that behavior directly.

## Regression test

The new test asserts that image-backed streaming exec sends:

```rust
AgentRequest::Run {
    interactive: true,
    tty: false,
    detached: false,
    background: false,
    ...
}
```

rather than `AgentRequest::VmExec`.

## Testing

- `cargo fmt`
- `git diff --check`
- `cargo check -p smolvm --bin smolvm`
- `LIBKRUN_BUNDLE=lib cargo test -p smolvm run_streaming_tests -- --nocapture`
- live smoke with an Ubuntu-backed machine:
  `smolvm machine exec --name libbun-ubuntu-arm64 --stream --timeout 30s /bin/bash -lc 'echo stream-callback-ok; pwd; command -v cargo'`
