### PR TITLE
fix(installer): verify archives with published checksums

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ Known Limitations
 * macOS: binary must be signed with Hypervisor.framework entitlements.
 * `--ssh-agent` requires an SSH agent running on the host (`SSH_AUTH_SOCK` must be set).
 * GPU acceleration requires libkrun built with `GPU=1` and virglrenderer + a Vulkan driver on the host (see [GPU Acceleration](#gpu-acceleration) below).
+* The VM provides guest workload isolation, but the host-side control plane and VMM run as the invoking user. Use OS-level sandboxing or confinement if you need to restrict the VMM process itself.
+* Release archives are verified against the published SHA-256 checksum file when available. Releases are not currently signed or accompanied by cryptographic attestations.
 
 GPU Acceleration
 ----------------

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -204,10 +204,15 @@ get_download_url() {
     echo "https://github.com/${GITHUB_REPO}/releases/download/v${version}/smolvm-${version}-${download_platform}.tar.gz"
 }
 
-# Get checksum URL for a version and platform
-get_checksum_url() {
+# Get checksum URLs for a version.
+#
+# Current releases publish checksums.sha256. Keep checksums.txt as a legacy
+# fallback so older releases can still be installed if they used that name.
+get_checksum_urls() {
     local version="$1"
-    echo "https://github.com/${GITHUB_REPO}/releases/download/v${version}/checksums.txt"
+    local base="https://github.com/${GITHUB_REPO}/releases/download/v${version}"
+    echo "${base}/checksums.sha256"
+    echo "${base}/checksums.txt"
 }
 
 # Verify file checksum
@@ -219,11 +224,13 @@ verify_checksum() {
 
     # Extract expected checksum for this file
     local expected
-    expected=$(grep "$filename" "$checksums_file" 2>/dev/null | awk '{print $1}')
+    expected=$(
+        awk -v filename="$filename" '$2 == filename { print $1; exit }' "$checksums_file" 2>/dev/null
+    )
 
     if [[ -z "$expected" ]]; then
-        warn "Checksum not found for $filename, skipping verification"
-        return 0
+        error "Checksum not found for $filename in $checksums_file"
+        return 1
     fi
 
     # Calculate actual checksum
@@ -256,14 +263,12 @@ install_smolvm() {
 
     local url
     url=$(get_download_url "$version" "$platform")
-    local checksums_url
-    checksums_url=$(get_checksum_url "$version")
     local tmp_dir
     tmp_dir=$(mktemp -d)
     local archive_name
     archive_name=$(basename "$url")
     local archive="${tmp_dir}/${archive_name}"
-    local checksums="${tmp_dir}/checksums.txt"
+    local checksums="${tmp_dir}/checksums.sha256"
 
     # Download archive
     download "$url" "$archive" || {
@@ -273,14 +278,23 @@ install_smolvm() {
         exit 1
     }
 
-    # Download and verify checksums (optional - don't fail if checksums unavailable)
-    if download "$checksums_url" "$checksums" 2>/dev/null; then
-        verify_checksum "$archive" "$checksums" || {
-            error "Archive failed checksum verification - aborting for security"
-            rm -rf "$tmp_dir"
-            exit 1
-        }
-    else
+    # Download and verify checksums (optional - don't fail if no checksum asset
+    # exists, but do abort if a checksum file exists and does not match).
+    local checksum_downloaded=false
+    local checksums_url
+    while IFS= read -r checksums_url; do
+        if download "$checksums_url" "$checksums" 2>/dev/null; then
+            checksum_downloaded=true
+            verify_checksum "$archive" "$checksums" || {
+                error "Archive failed checksum verification - aborting for security"
+                rm -rf "$tmp_dir"
+                exit 1
+            }
+            break
+        fi
+    done < <(get_checksum_urls "$version")
+
+    if [[ "$checksum_downloaded" != true ]]; then
         warn "Checksums not available for this release, skipping verification"
     fi
 


### PR DESCRIPTION
## Summary

Addresses the concrete installer verification gap raised in #227.

- Prefer the current release checksum asset name, `checksums.sha256`, while keeping `checksums.txt` as a legacy fallback.
- Abort if a downloaded checksum file does not contain the archive being installed, instead of silently skipping verification.
- Match checksum entries by exact filename rather than regex substring.
- Document the current host-side/VMM isolation boundary and checksum/signing limitations in the README.

## Validation

- `gh release view -R smol-machines/smolvm v0.7.1 --json tagName,assets --jq '.tagName, [.assets[].name]'` confirmed current releases publish `checksums.sha256`.
- `bash -n scripts/install.sh`
- `bash scripts/install.sh --help`
- Sourced a temp copy of `install.sh` without running `main`, then verified:
  - `get_checksum_urls 0.7.1` emits `checksums.sha256` first and `checksums.txt` second.
  - `verify_checksum` succeeds for a matching checksum.
  - `verify_checksum` fails for a missing filename entry.
  - `verify_checksum` fails for a mismatched checksum.
- `cargo fmt --all -- --check`
- `git diff --check`

## Notes

I kept checksum assets optional for backwards compatibility with releases that may not publish either checksum file, but once a checksum file is present the installer now fails closed on missing or mismatched entries.
