### PR TITLE
feat: expose gpu and gpu_vram_mib in machine ls output

### DIFF
--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -1214,6 +1214,8 @@ pub fn list_vms(verbose: bool, json: bool) -> smolvm::Result<()> {
                     "entrypoint": record.entrypoint,
                     "cmd": record.cmd,
                     "ephemeral": record.ephemeral,
+                    "gpu": record.gpu.unwrap_or(false),
+                    "gpu_vram_mib": record.gpu_vram_mib,
                 });
                 obj.as_object_mut()
                     .unwrap()
@@ -1265,6 +1267,12 @@ pub fn list_vms(verbose: bool, json: bool) -> smolvm::Result<()> {
                 }
                 if record.network {
                     println!("  Network: enabled");
+                }
+                if record.gpu.unwrap_or(false) {
+                    match record.gpu_vram_mib {
+                        Some(vram) => println!("  GPU: enabled ({} MiB VRAM)", vram),
+                        None => println!("  GPU: enabled"),
+                    }
                 }
                 for cmd in &record.init {
                     println!("  Init: {}", cmd);


### PR DESCRIPTION
## Summary

Surface the `gpu` and `gpu_vram_mib` fields already stored in `VmRecord` through the `machine ls --json` output and the verbose text listing. Without this, downstream tools (e.g. a desktop UI) have no way to tell whether a machine was created with `--gpu`, even though the config is persisted on disk under `agent.config.json -> resources.gpu`.

## Change

Eight additive lines in `src/cli/vm_common.rs::list_vms`. No fields renamed or removed.

### JSON output

Before:
```json
{
  "name": "my-gpu-vm",
  "cpus": 4,
  "memory_mib": 8192,
  "network": true
}
```

After:
```json
{
  "name": "my-gpu-vm",
  "cpus": 4,
  "memory_mib": 8192,
  "network": true,
  "gpu": true,
  "gpu_vram_mib": 2048
}
```

`gpu` is always present (`false` when not enabled); `gpu_vram_mib` is `null` when unset.

### Verbose text output

Gains a `GPU: enabled` line (or `GPU: enabled (<N> MiB VRAM)` when VRAM was set), shown only when the machine has GPU enabled, matching the existing `Network: enabled` convention.

```
my-gpu-vm            created          4   8192 MiB       0       0   20 GiB   10 GiB
  Network: enabled
  GPU: enabled (2048 MiB VRAM)
```

## Tested

- `cargo check --all-targets` clean.
- Created two machines locally with `--gpu --gpu-vram 2048` and without; confirmed JSON output, verbose text output, and that the no-GPU case omits the new line as expected.

## Test plan

- [x] `machine ls --json` shows `gpu` / `gpu_vram_mib` for a GPU machine.
- [x] `machine ls --json` shows `gpu: false`, `gpu_vram_mib: null` for a non-GPU machine.
- [x] `machine ls -v` shows the `GPU:` line only for GPU machines.
- [x] No regression in existing JSON consumers (fields are additive).