### PR TITLE
feat: expose restart policy and healthcheck config in machine ls output

### DIFF
--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -1199,6 +1199,19 @@ pub fn list_vms(verbose: bool, json: bool) -> smolvm::Result<()> {
                 // truth (Unreachable vs Running) instead of trusting
                 // the PID-only check that fooled bug 2 victims.
                 let actual_state = smolvm::agent::state_probe::resolve_state(name, record);
+                // Expose the persisted health command as a single shell-friendly
+                // string when it was originally stored as `["sh", "-c", "<cmd>"]`
+                // (the shape produced by `machine monitor --health-cmd ...`).
+                // Otherwise, fall back to a space-joined argv so the field is
+                // still a string suitable for direct display in a UI.
+                let health_cmd_str = record.health_cmd.as_ref().map(|argv| {
+                    if argv.len() == 3 && argv[0] == "sh" && argv[1] == "-c" {
+                        argv[2].clone()
+                    } else {
+                        argv.join(" ")
+                    }
+                });
+
                 let mut obj = serde_json::json!({
                     "name": name,
                     "state": actual_state.to_string(),
@@ -1216,6 +1229,14 @@ pub fn list_vms(verbose: bool, json: bool) -> smolvm::Result<()> {
                     "ephemeral": record.ephemeral,
                     "gpu": record.gpu.unwrap_or(false),
                     "gpu_vram_mib": record.gpu_vram_mib,
+                    "restart_policy": record.restart.policy.to_string(),
+                    "restart_max_retries": record.restart.max_retries,
+                    "restart_count": record.restart.restart_count,
+                    "health_cmd": health_cmd_str,
+                    "health_interval_secs": record.health_interval_secs,
+                    "health_timeout_secs": record.health_timeout_secs,
+                    "health_retries": record.health_retries,
+                    "health_startup_grace_secs": record.health_startup_grace_secs,
                 });
                 obj.as_object_mut()
                     .unwrap()


### PR DESCRIPTION
## Summary

Extends `machine ls --json` per-machine output to include the restart policy and healthcheck configuration that `[restart]` / `[health]` Smolfile sections persist into `VmRecord`. Non-JSON (human) output is unchanged.

New fields per machine:

| Field                       | Type            | Source                                |
|-----------------------------|-----------------|---------------------------------------|
| `restart_policy`            | string          | `record.restart.policy`               |
| `restart_max_retries`       | u32             | `record.restart.max_retries`          |
| `restart_count`             | u32             | `record.restart.restart_count`        |
| `health_cmd`                | string \| null  | `record.health_cmd` (see note below)  |
| `health_interval_secs`      | u64 \| null     | `record.health_interval_secs`         |
| `health_timeout_secs`       | u64 \| null     | `record.health_timeout_secs`          |
| `health_retries`            | u32 \| null     | `record.health_retries`               |
| `health_startup_grace_secs` | u64 \| null     | `record.health_startup_grace_secs`    |

`health_cmd` is rendered as a single string for UI friendliness: when the stored argv has the shape `["sh", "-c", "<cmd>"]` (the form `machine monitor --health-cmd` writes), the inner command string is unwrapped. Otherwise the argv is space-joined.

## Motivation

These fields are persisted at create time via `machine create --smolfile <file>` (PR #54) but currently aren't surfaced anywhere a UI client can read them back. Without read-back, a GUI can write policy via Smolfile but can't display the current policy on an existing machine, or reconcile its UI state with `VmRecord`.

## Notes

- No DB schema change, no new query — the data was already serialized into the `vms` table by `SmolvmDb`.
- Mirrors the prior `gpu` / `gpu_vram_mib` surface-up in `3034954`.
- Live health state (e.g. `healthy` / `unhealthy` / `checking`) is deliberately NOT included — there's no persisted store for it; it lives only in-memory inside the foreground `machine monitor` loop. Surfacing a `null`/stub field would be misleading. A follow-up could add a status file written by `machine monitor`, but that's out of scope here.
- `restart_policy` is always present (never `null`) because `RestartConfig` defaults to `policy = Never`. Clients should treat `"never"` as the unset/default case.

## Test plan

- [ ] `cargo check` clean
- [ ] `smolvm machine ls --json` against an existing VM created with no `--smolfile` shows `restart_policy: "never"` and all `health_*` fields as `null`.
- [ ] `smolvm machine create test --image alpine --smolfile <path>` with `[restart] policy = "on-failure" max_retries = 3` and a `[health] exec = ["sh", "-c", "echo ok"]` block — confirm the fields round-trip into the ls JSON.
- [ ] Non-JSON `smolvm machine ls -v` output unchanged.