### PR TITLE
feat: add Nix flake packaging and dev shell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,11 @@ Cargo.lock
 /dist/smolvm-*/
 /dist/*.tar.gz
 
+# Nix/devshell artifacts
+/.direnv/
+/result
+/result-*
+
 # Bundled libraries are in the /lib (large binaries - download or build locally)
 # These are bundled into release tarballs by build-dist.sh
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,63 @@
+{
+  "nodes": {
+    "libkrun-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1779235645,
+        "narHash": "sha256-rmRMZ5j3HlueCAXQLydjmMq45+hwhxSLWM02VvHokcY=",
+        "owner": "smol-machines",
+        "repo": "libkrun",
+        "rev": "98163265197caa24a789699f16a68b98e917b65b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "smol-machines",
+        "repo": "libkrun",
+        "rev": "98163265197caa24a789699f16a68b98e917b65b",
+        "type": "github"
+      }
+    },
+    "libkrunfw-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1778821066,
+        "narHash": "sha256-g2DxDnnh52JCPg4ktPWFBi0J9203FCncGOzB3eiCRxQ=",
+        "owner": "smol-machines",
+        "repo": "libkrunfw",
+        "rev": "516ceece6aed60ccc84ac8faa459885062e39400",
+        "type": "github"
+      },
+      "original": {
+        "owner": "smol-machines",
+        "repo": "libkrunfw",
+        "rev": "516ceece6aed60ccc84ac8faa459885062e39400",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779357205,
+        "narHash": "sha256-cCO8aTqss5x9Ky8GWkpY0Hy5fyTZEbtifSUV8QjSzic=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "libkrun-src": "libkrun-src",
+        "libkrunfw-src": "libkrunfw-src",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,92 @@
+{
+  description = "Ship and run software with isolation by default.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    libkrun-src = {
+      url = "github:smol-machines/libkrun/98163265197caa24a789699f16a68b98e917b65b";
+      flake = false;
+    };
+
+    libkrunfw-src = {
+      url = "github:smol-machines/libkrunfw/516ceece6aed60ccc84ac8faa459885062e39400";
+      flake = false;
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      libkrun-src,
+      libkrunfw-src,
+      ...
+    }:
+    let
+      forAllSystems =
+        function:
+        nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed (
+          system: function (nixpkgs.legacyPackages.${system}.extend overlay)
+        );
+
+      overlay = final: prev: {
+        smolvm-libkrunfw = final.callPackage ./nix/libkrunfw.nix {
+          src = libkrunfw-src;
+        };
+
+        smolvm-libkrun = final.callPackage ./nix/libkrun.nix {
+          src = libkrun-src;
+          libkrunfw = final.smolvm-libkrunfw;
+          withBlk = true;
+          withNet = true;
+          withGpu = final.stdenv.hostPlatform.isLinux;
+        };
+
+        smolvm = final.callPackage ./nix/smolvm.nix { };
+      };
+    in
+    {
+      overlays.default = overlay;
+
+      formatter = forAllSystems (pkgs: pkgs.alejandra);
+
+      packages = forAllSystems (pkgs: {
+        libkrunfw = pkgs.smolvm-libkrunfw;
+        libkrun = pkgs.smolvm-libkrun;
+        smolvm = pkgs.smolvm;
+        default = pkgs.smolvm;
+      });
+
+      apps = forAllSystems (pkgs: {
+        default = {
+          type = "app";
+          program = "${self.packages.${pkgs.stdenv.hostPlatform.system}.default}/bin/smolvm";
+        };
+      });
+
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          inputsFrom = [
+            self.packages.${pkgs.stdenv.hostPlatform.system}.libkrun
+          ];
+
+          packages = with pkgs; [
+            cargo
+            rustc
+            rustfmt
+            clippy
+            rust-analyzer
+            cargo-make
+            pkg-config
+          ];
+
+          LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+          LIBKRUN_DIR = "${pkgs.lib.getLib self.packages.${pkgs.stdenv.hostPlatform.system}.libkrun}/${
+            if pkgs.stdenv.hostPlatform.isDarwin then "lib" else "lib64"
+          }";
+          RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
+        };
+      });
+    };
+}

--- a/nix/libkrun.nix
+++ b/nix/libkrun.nix
@@ -1,0 +1,155 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  src,
+  cargo,
+  curl,
+  cacert,
+  pkg-config,
+  glibc,
+  openssl,
+  libcap_ng,
+  libepoxy,
+  libdrm,
+  pipewire,
+  virglrenderer,
+  libkrunfw,
+  rustc,
+  pkgsCross,
+  darwin,
+  apple-sdk_15 ? null,
+  libiconv,
+  libarchive ? null,
+  libnsm ? null,
+  withBlk ? false,
+  withNet ? false,
+  withGpu ? false,
+  withSound ? false,
+  withInput ? false,
+  withTimesync ? false,
+  withAwsNitro ? false,
+  variant ? null,
+}:
+
+assert lib.elem variant [
+  null
+  "sev"
+  "tdx"
+];
+assert withAwsNitro -> variant == null;
+assert withAwsNitro -> stdenv.hostPlatform.isLinux;
+assert withAwsNitro -> libarchive != null && libnsm != null;
+
+let
+  linuxCrossPkgs = if stdenv.hostPlatform.isAarch64
+    then pkgsCross.aarch64-multiplatform
+    else pkgsCross.gnu64;
+  libkrunfw' = (libkrunfw.override { inherit variant; });
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libkrun"
+    + lib.optionalString (variant != null) "-${variant}"
+    + lib.optionalString withAwsNitro "-awsnitro";
+  version = "1.17.3";
+
+  inherit src;
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) src;
+    hash = "sha256-b6Rk6ljpHNKwVD7r/NhppGE1TLKRXo8MxZNAszcOH5I=";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace 'cargo build --release $(FEATURE_FLAGS)' 'cargo build -p libkrun --release $(FEATURE_FLAGS)' \
+      --replace 'cargo build $(FEATURE_FLAGS)' 'cargo build -p libkrun $(FEATURE_FLAGS)'
+  '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace Makefile \
+      --replace 'CC_LINUX=$(CLANG) -target $(GCC_TRIPLET) -fuse-ld=lld -Wl,-strip-debug --sysroot $(abspath $(SYSROOT_LINUX)) -B$(GCC_LIB_DIR) -L$(GCC_LIB_DIR) -Wno-c23-extensions' 'CC_LINUX=${linuxCrossPkgs.stdenv.cc}/bin/${linuxCrossPkgs.stdenv.cc.targetPrefix}gcc -L${linuxCrossPkgs.glibc.static}/lib' \
+      --replace 'mv target/release/libkrun.dylib target/release/$(KRUN_BASE_$(OS))' 'true'
+  '';
+
+  nativeBuildInputs = [
+    rustPlatform.cargoSetupHook
+    rustPlatform.bindgenHook
+    cargo
+    pkg-config
+    rustc
+    curl
+    cacert
+  ] ++ lib.optional stdenv.hostPlatform.isDarwin linuxCrossPkgs.stdenv.cc;
+
+  buildInputs = [
+    libkrunfw'
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    libcap_ng
+    glibc
+    glibc.static
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    apple-sdk_15
+    libiconv
+  ]
+  ++ lib.optionals withGpu [
+    libepoxy
+    libdrm
+    virglrenderer
+  ]
+  ++ lib.optional withSound pipewire
+  ++ lib.optional (variant == "sev" || variant == "tdx") openssl
+  ++ lib.optionals withAwsNitro [
+    libarchive
+    libnsm
+  ];
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ]
+  ++ lib.optional withBlk "BLK=1"
+  ++ lib.optional withNet "NET=1"
+  ++ lib.optional withGpu "GPU=1"
+  ++ lib.optional withSound "SND=1"
+  ++ lib.optional withInput "INPUT=1"
+  ++ lib.optional withTimesync "TIMESYNC=1"
+  ++ lib.optional withAwsNitro "AWS_NITRO=1"
+  ++ lib.optional (variant == "sev") "SEV=1"
+  ++ lib.optional (variant == "tdx") "TDX=1";
+
+  postInstall = ''
+    mkdir -p $dev/lib/pkgconfig
+    mv $out/${if stdenv.hostPlatform.isDarwin then "lib" else "lib64"}/pkgconfig $dev/lib/
+    mv $out/include $dev/
+  '';
+
+  env = {
+    OPENSSL_NO_VENDOR = true;
+  }
+  // lib.optionalAttrs stdenv.hostPlatform.isLinux {
+    # Make sure libkrunfw can be found by dlopen().
+    RUSTFLAGS = toString (
+      map (flag: "-C link-arg=" + flag) [
+        "-Wl,--push-state,--no-as-needed"
+        ("-lkrunfw" + lib.optionalString (variant != null) "-${variant}")
+        "-Wl,--pop-state"
+      ]
+    );
+  }
+  // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    CC_LINUX = "${linuxCrossPkgs.stdenv.cc}/bin/${linuxCrossPkgs.stdenv.cc.targetPrefix}gcc -L${linuxCrossPkgs.glibc.static}/lib";
+    SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+  };
+
+  meta = {
+    description = "Dynamic library providing Virtualization-based process isolation capabilities";
+    homepage = "https://github.com/smol-machines/libkrun";
+    license = lib.licenses.asl20;
+    platforms = libkrunfw'.meta.platforms;
+  };
+})

--- a/nix/libkrunfw.nix
+++ b/nix/libkrunfw.nix
@@ -1,0 +1,119 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  src,
+  pkgsCross,
+  flex,
+  bison,
+  bc,
+  cpio,
+  perl,
+  elfutils,
+  libelf,
+  python3,
+  variant ? null,
+}:
+
+assert lib.elem variant [
+  null
+  "sev"
+  "tdx"
+];
+
+let
+  linuxCrossCc = if stdenv.hostPlatform.isAarch64
+    then pkgsCross.aarch64-multiplatform.stdenv.cc
+    else pkgsCross.gnu64.stdenv.cc;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libkrunfw" + lib.optionalString (variant != null) "-${variant}";
+  version = "5.4.0";
+
+  inherit src;
+
+  kernelSrc = fetchurl {
+    url = "mirror://kernel/linux/kernel/v6.x/linux-6.12.87.tar.xz";
+    hash = "sha256-zBKnZEtM754GYnsp3odT4is9B2cDqbUr6EJj4FyLmDA=";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace 'curl $(KERNEL_REMOTE) -o $(KERNEL_TARBALL)' 'ln -s $(kernelSrc) $(KERNEL_TARBALL)'
+  '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace Makefile \
+      --replace 'for patch in $(KERNEL_PATCHES); do patch -p1 -d $(KERNEL_SOURCES) < "$$patch"; done' 'for patch in $(KERNEL_PATCHES); do patch -p1 -d $(KERNEL_SOURCES) < "$$patch"; done; perl -0pi -e "s/typedef struct \\{\\n\\t__u8 b\\[16\\];\\n\\} uuid_t;/#ifndef __APPLE__\\ntypedef struct {\\n\\t__u8 b[16];\\n} uuid_t;\\n#endif/; s/uuid->b\\[/(*uuid)[/g" $(KERNEL_SOURCES)/scripts/mod/file2alias.c' \
+      --replace '$(MAKE) olddefconfig' '$(MAKE) HOSTCC=cc HOSTCFLAGS=-I../host-include olddefconfig' \
+      --replace '$(MAKE) $(MAKEFLAGS) $(KERNEL_FLAGS)' '$(MAKE) HOSTCC=cc HOSTCFLAGS=-I../host-include $(MAKEFLAGS) $(KERNEL_FLAGS)'
+  '';
+
+  preBuild = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -p host-include
+    cp ${linuxCrossCc.libc.dev}/include/elf.h host-include/
+    cat > host-include/byteswap.h <<'EOF'
+    #pragma once
+    #define bswap_16(x) __builtin_bswap16(x)
+    #define bswap_32(x) __builtin_bswap32(x)
+    #define bswap_64(x) __builtin_bswap64(x)
+    EOF
+    export HOSTCC=cc
+  '';
+
+  nativeBuildInputs = [
+    stdenv.cc
+    flex
+    bison
+    bc
+    cpio
+    perl
+    python3
+    python3.pkgs.pyelftools
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    linuxCrossCc
+    libelf
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    elfutils
+  ];
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    "OS=Linux"
+    "ARCH=${stdenv.hostPlatform.linuxArch}"
+    "CROSS_COMPILE=${linuxCrossCc.targetPrefix}"
+  ]
+  ++ lib.optionals (variant == "sev") [
+    "SEV=1"
+  ]
+  ++ lib.optionals (variant == "tdx") [
+    "TDX=1"
+  ];
+
+  # Fixes https://github.com/containers/libkrunfw/issues/55
+  env = lib.optionalAttrs stdenv.targetPlatform.isAarch64 {
+    NIX_CFLAGS_COMPILE = "-march=armv8-a+crypto";
+  };
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "Dynamic library bundling the guest payload consumed by libkrun";
+    homepage = "https://github.com/smol-machines/libkrunfw";
+    license = with lib.licenses; [
+      lgpl2Only
+      lgpl21Only
+    ];
+    platforms = [
+      "x86_64-linux"
+    ]
+    ++ lib.optionals (variant == null) [
+      "aarch64-linux"
+      "riscv64-linux"
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ];
+  };
+})

--- a/nix/smolvm.nix
+++ b/nix/smolvm.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  patchelf,
+  gcc-unwrapped,
+  bzip2,
+}: let
+  version = "0.8.2";
+
+  releases = {
+    x86_64-linux = {
+      asset = "smolvm-${version}-linux-x86_64.tar.gz";
+      root = "smolvm-${version}-linux-x86_64";
+      hash = "sha256-FEzCyn9yauzy/ydXZxeD2DK1cXVg2XYlOil6UeUKJeA=";
+    };
+    aarch64-linux = {
+      asset = "smolvm-${version}-linux-arm64.tar.gz";
+      root = "smolvm-${version}-linux-arm64";
+      hash = "sha256-214tjfCntQbk40FiX3TleC9c2xQA0GuTAzJ1QDisn18=";
+    };
+    aarch64-darwin = {
+      asset = "smolvm-${version}-darwin-arm64.tar.gz";
+      root = "smolvm-${version}-darwin-arm64";
+      hash = "sha256-jDHrgsq/Ca0UKahufRHMuA2B/i4Y2JKKUpDqWmVWKgI=";
+    };
+  };
+
+  release = releases.${stdenv.hostPlatform.system} or (throw "smolvm release tarball is not available for ${stdenv.hostPlatform.system}");
+
+  linuxRpath = lib.makeLibraryPath [
+    gcc-unwrapped.lib
+    bzip2
+  ];
+in
+  stdenv.mkDerivation {
+    pname = "smolvm";
+    inherit version;
+
+    src = fetchurl {
+      url = "https://github.com/smol-machines/smolvm/releases/download/v${version}/${release.asset}";
+      inherit (release) hash;
+    };
+
+    sourceRoot = release.root;
+
+    nativeBuildInputs =
+      [
+        makeWrapper
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isLinux [
+        patchelf
+      ];
+
+    dontPatchELF = true;
+    dontPatchShebangs = true;
+    dontStrip = true;
+
+    installPhase =
+      ''
+        runHook preInstall
+
+        mkdir -p $out/libexec/smolvm $out/bin
+        cp -R . $out/libexec/smolvm/
+        chmod +x $out/libexec/smolvm/smolvm $out/libexec/smolvm/smolvm-bin
+        patchShebangs $out/libexec/smolvm/smolvm
+      ''
+      + lib.optionalString stdenv.hostPlatform.isLinux ''
+        patchelf --set-interpreter ${stdenv.cc.bintools.dynamicLinker} \
+          --set-rpath '$ORIGIN/lib:${linuxRpath}' \
+          $out/libexec/smolvm/smolvm-bin
+
+        for library in $out/libexec/smolvm/lib/*.so*; do
+          if patchelf --print-needed "$library" >/dev/null 2>&1; then
+            patchelf --set-rpath '$ORIGIN:${linuxRpath}' "$library"
+          fi
+        done
+      ''
+      + ''
+        makeWrapper $out/libexec/smolvm/smolvm $out/bin/smolvm \
+          --set-default SMOLVM_AGENT_ROOTFS $out/libexec/smolvm/agent-rootfs
+
+        runHook postInstall
+      '';
+
+    meta = {
+      description = "Ship and run software with isolation by default";
+      homepage = "https://github.com/smol-machines/smolvm";
+      license = lib.licenses.asl20;
+      platforms = builtins.attrNames releases;
+      mainProgram = "smolvm";
+      sourceProvenance = with lib.sourceTypes; [binaryNativeCode];
+    };
+  }


### PR DESCRIPTION
## Summary

- add a root Nix flake with package, app, dev shell, and overlay outputs
- package smolvm using tarballs plus forked smol-machines libkrun/libkrunfw derivations

## Notes

- This has been build-tested on `x86_64-linux` and `aarch64-darwin`so far. `aarch64-linux` is packaged, but cannot be tested due to the lack of a local linux machine with that chip.

## Validation

- `nix flake check --no-build`
- `nix build .#libkrunfw`
- `nix build .#libkrun`
- `nix build .#smolvm`
