### PR TITLE
Add info about installation directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ curl -sSL https://smolmachines.com/install.sh | bash
 curl -sSL https://smolmachines.com/install.sh | bash && smolvm --help
 ```
 
-Or download from [GitHub Releases](https://github.com/smol-machines/smolvm/releases).
+Or download from [GitHub Releases](https://github.com/smol-machines/smolvm/releases), and place it into `~/.local/share/`.
 
 Quick Start
 -----------


### PR DESCRIPTION
`agent-rootfs` is expected to be in `~/.local/share/` - so just downloading the tarball and extracting it isn't going to work. 

This here fixes the problem.