### PR TITLE
feat(poc): support native OCI Directory Layout local image source

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 humantime = "2"
 tempfile = "3"
+flate2 = "1.0"
 
 # HTTP API server
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ smolvm-pack = { path = "crates/smolvm-pack" }
 smolvm-registry = { path = "crates/smolvm-registry" }
 smolfile = { path = "crates/smolvm-smolfile" }
 thiserror = "1"
+tar = "0.4"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -450,27 +450,60 @@ fn create_packed_image_info(image: &str, packed_dir: &Path) -> Result<ImageInfo>
 
     // Determine architecture from environment or default
     #[cfg(target_arch = "aarch64")]
-    let architecture = "arm64".to_string();
+    let default_architecture = "arm64".to_string();
     #[cfg(target_arch = "x86_64")]
-    let architecture = "amd64".to_string();
+    let default_architecture = "amd64".to_string();
     #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
-    let architecture = "unknown".to_string();
+    let default_architecture = "unknown".to_string();
+
+    let mut entrypoint = Vec::new();
+    let mut cmd = Vec::new();
+    let mut env = Vec::new();
+    let mut workdir = None;
+    let mut user = None;
+    let mut created = None;
+    let mut architecture = default_architecture;
+
+    let config_path = packed_dir.join("config.json");
+    if config_path.exists() {
+        if let Ok(config_content) = std::fs::read_to_string(&config_path) {
+            if let Ok(config_json) = serde_json::from_str::<serde_json::Value>(&config_content) {
+                if let Some(arch) = config_json["architecture"].as_str() {
+                    architecture = arch.to_string();
+                }
+                created = config_json["created"].as_str().map(String::from);
+                let oci_config = &config_json["config"];
+                if oci_config.is_object() {
+                    entrypoint = json_string_array(oci_config, "Entrypoint");
+                    cmd = json_string_array(oci_config, "Cmd");
+                    env = json_string_array(oci_config, "Env");
+                    workdir = oci_config["WorkingDir"]
+                        .as_str()
+                        .filter(|s| !s.is_empty())
+                        .map(String::from);
+                    user = oci_config["User"]
+                        .as_str()
+                        .filter(|s| !s.is_empty())
+                        .map(String::from);
+                }
+            }
+        }
+    }
 
     Ok(ImageInfo {
         reference: image.to_string(),
         digest: "packed".to_string(), // No real digest available for packed images
         size: total_size,
-        created: None,
+        created,
         architecture,
         os: "linux".to_string(),
         layer_count: layer_dirs.len(),
         layers: layer_dirs,
-        // Packed mode: config is in the PackManifest, not the image
-        entrypoint: Vec::new(),
-        cmd: Vec::new(),
-        env: Vec::new(),
-        workdir: None,
-        user: None,
+        entrypoint,
+        cmd,
+        env,
+        workdir,
+        user,
     })
 }
 

--- a/crates/smolvm-protocol/src/image_ref.rs
+++ b/crates/smolvm-protocol/src/image_ref.rs
@@ -37,6 +37,22 @@
 ///            "ghcr.io/owner/repo:v1");
 /// ```
 pub fn normalize_image_ref(image: &str) -> String {
+    let is_local = image.starts_with("docker:")
+        || image.starts_with("podman:")
+        || image.starts_with("local:")
+        || image.ends_with(".tar")
+        || image.ends_with("Dockerfile")
+        || image.contains("/Dockerfile");
+
+    if is_local {
+        if (image.starts_with("docker:") || image.starts_with("podman:") || image.starts_with("local:"))
+            && (!image.contains(':') || image.find(':') == image.rfind(':'))
+        {
+            return format!("{}:latest", image);
+        }
+        return image.to_string();
+    }
+
     // 1. Resolve index.docker.io alias.
     let owned;
     let image = if let Some(rest) = image.strip_prefix("index.docker.io/") {
@@ -129,6 +145,19 @@ mod tests {
             ("ghcr.io/owner/repo:v1", "ghcr.io/owner/repo:v1"),
             // Port in registry — colon-detection must not confuse port with tag.
             ("localhost:5000/myimage:dev", "localhost:5000/myimage:dev"),
+            // Local images (docker, podman, local)
+            ("docker:busybox", "docker:busybox:latest"),
+            ("docker:busybox:v1.0", "docker:busybox:v1.0"),
+            ("podman:ubuntu", "podman:ubuntu:latest"),
+            ("podman:ubuntu:22.04", "podman:ubuntu:22.04"),
+            ("local:alpine", "local:alpine:latest"),
+            ("local:alpine:3.18", "local:alpine:3.18"),
+            // Local files/paths (.tar, Dockerfiles)
+            ("./my-image.tar", "./my-image.tar"),
+            ("/absolute/path/to/image.tar", "/absolute/path/to/image.tar"),
+            ("./Dockerfile", "./Dockerfile"),
+            ("/home/user/project/Dockerfile", "/home/user/project/Dockerfile"),
+            ("./src/Dockerfile", "./src/Dockerfile"),
         ];
 
         for (input, expected) in cases {

--- a/crates/smolvm-protocol/src/image_ref.rs
+++ b/crates/smolvm-protocol/src/image_ref.rs
@@ -37,19 +37,13 @@
 ///            "ghcr.io/owner/repo:v1");
 /// ```
 pub fn normalize_image_ref(image: &str) -> String {
-    let is_local = image.starts_with("docker:")
-        || image.starts_with("podman:")
+    let is_local = image == "-"
         || image.starts_with("local:")
         || image.ends_with(".tar")
-        || image.ends_with("Dockerfile")
-        || image.contains("/Dockerfile");
+        || image.ends_with(".tar.gz")
+        || (std::path::Path::new(image).is_dir() && std::path::Path::new(image).join("index.json").exists());
 
     if is_local {
-        if (image.starts_with("docker:") || image.starts_with("podman:") || image.starts_with("local:"))
-            && (!image.contains(':') || image.find(':') == image.rfind(':'))
-        {
-            return format!("{}:latest", image);
-        }
         return image.to_string();
     }
 
@@ -145,19 +139,12 @@ mod tests {
             ("ghcr.io/owner/repo:v1", "ghcr.io/owner/repo:v1"),
             // Port in registry — colon-detection must not confuse port with tag.
             ("localhost:5000/myimage:dev", "localhost:5000/myimage:dev"),
-            // Local images (docker, podman, local)
-            ("docker:busybox", "docker:busybox:latest"),
-            ("docker:busybox:v1.0", "docker:busybox:v1.0"),
-            ("podman:ubuntu", "podman:ubuntu:latest"),
-            ("podman:ubuntu:22.04", "podman:ubuntu:22.04"),
-            ("local:alpine", "local:alpine:latest"),
-            ("local:alpine:3.18", "local:alpine:3.18"),
-            // Local files/paths (.tar, Dockerfiles)
+            // Local images (stdin, local prefix, and tarballs)
+            ("-", "-"),
+            ("local:stdin-12345", "local:stdin-12345"),
             ("./my-image.tar", "./my-image.tar"),
             ("/absolute/path/to/image.tar", "/absolute/path/to/image.tar"),
-            ("./Dockerfile", "./Dockerfile"),
-            ("/home/user/project/Dockerfile", "/home/user/project/Dockerfile"),
-            ("./src/Dockerfile", "./src/Dockerfile"),
+            ("./my-image.tar.gz", "./my-image.tar.gz"),
         ];
 
         for (input, expected) in cases {

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -548,10 +548,30 @@ impl RunCmd {
             None
         };
 
+        let image = self.image.clone().or(params.image.clone());
+        let is_local_image = image.as_ref().map_or(false, |img| {
+            img.starts_with("docker:")
+                || img.starts_with("podman:")
+                || img.starts_with("local:")
+                || img.ends_with(".tar")
+                || img.ends_with("Dockerfile")
+                || img.contains("/Dockerfile")
+        });
+
+        let mut packed_layers_dir = None;
+        let mut resolved_image = image.clone();
+        if is_local_image {
+            if let Some(ref img) = image {
+                let (layers_dir, resolved_img) = smolvm::local_image::prepare_local_image(img)?;
+                packed_layers_dir = Some(layers_dir);
+                resolved_image = Some(resolved_img);
+            }
+        }
+
         let features = smolvm::agent::LaunchFeatures {
             ssh_agent_socket,
             dns_filter_hosts: params.dns_filter_hosts.clone(),
-            packed_layers_dir: None,
+            packed_layers_dir,
             extra_disks: Vec::new(),
         };
 
@@ -582,25 +602,26 @@ impl RunCmd {
         // exec (which has its own SIGINT handling).
         let sigint_guard = manager.child_pid().map(smolvm::process::SigintGuard::new);
 
-        // Resolve image: CLI > Smolfile > None (bare VM)
-        let image = self.image.clone().or(params.image.clone());
-
         // Pull image if one is specified
-        let image_info = if let Some(ref img) = image {
-            match crate::cli::pull_with_progress(&mut client, img, self.oci_platform.as_deref()) {
-                Ok(info) => Some(info),
-                Err(e) if !params.net => {
-                    // Add a hint when pull fails and networking is disabled —
-                    // this is the most common user error.
-                    return Err(smolvm::Error::agent(
-                        "pull image",
-                        format!(
-                            "{}\n\nHint: networking is disabled. Add --net to enable image pulls:\n  smolvm machine run --net --image {} ...",
-                            e, img
-                        ),
-                    ));
+        let image_info = if let Some(ref img) = resolved_image {
+            if is_local_image {
+                None
+            } else {
+                match crate::cli::pull_with_progress(&mut client, img, self.oci_platform.as_deref()) {
+                    Ok(info) => Some(info),
+                    Err(e) if !params.net => {
+                        // Add a hint when pull fails and networking is disabled —
+                        // this is the most common user error.
+                        return Err(smolvm::Error::agent(
+                            "pull image",
+                            format!(
+                                "{}\n\nHint: networking is disabled. Add --net to enable image pulls:\n  smolvm machine run --net --image {} ...",
+                                e, img
+                            ),
+                        ));
+                    }
+                    Err(e) => return Err(e),
                 }
-                Err(e) => return Err(e),
             }
         } else {
             None
@@ -638,7 +659,7 @@ impl RunCmd {
                 &mut client,
                 &params.init,
                 vm_common::InitRunContext {
-                    image: image.as_deref(),
+                    image: resolved_image.as_deref(),
                     image_info: image_info.as_ref(),
                     env: &init_env,
                     workdir: params.workdir.as_deref(),
@@ -686,7 +707,7 @@ impl RunCmd {
         let mount_bindings = mounts_to_virtiofs_bindings(&mounts);
 
         // Two modes: with image or bare VM (no image)
-        if let Some(ref img) = image {
+        if let Some(ref img) = resolved_image {
             let defaults = vm_common::resolve_image_runtime_defaults(
                 image_info.as_ref(),
                 &env,

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -550,12 +550,11 @@ impl RunCmd {
 
         let image = self.image.clone().or(params.image.clone());
         let is_local_image = image.as_ref().map_or(false, |img| {
-            img.starts_with("docker:")
-                || img.starts_with("podman:")
+            img == "-"
                 || img.starts_with("local:")
                 || img.ends_with(".tar")
-                || img.ends_with("Dockerfile")
-                || img.contains("/Dockerfile")
+                || img.ends_with(".tar.gz")
+                || (std::path::Path::new(img).is_dir() && std::path::Path::new(img).join("index.json").exists())
         });
 
         let mut packed_layers_dir = None;

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -650,12 +650,11 @@ pub fn start_vm_named(name: &str) -> smolvm::Result<()> {
     };
 
     let is_local_image = record.image.as_ref().map_or(false, |img| {
-        img.starts_with("docker:")
-            || img.starts_with("podman:")
+        img == "-"
             || img.starts_with("local:")
             || img.ends_with(".tar")
-            || img.ends_with("Dockerfile")
-            || img.contains("/Dockerfile")
+            || img.ends_with(".tar.gz")
+            || (std::path::Path::new(img).is_dir() && std::path::Path::new(img).join("index.json").exists())
     });
 
     // If machine was created from .smolmachine, extract layers to cache and

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -649,6 +649,15 @@ pub fn start_vm_named(name: &str) -> smolvm::Result<()> {
         extra_disks: Vec::new(),
     };
 
+    let is_local_image = record.image.as_ref().map_or(false, |img| {
+        img.starts_with("docker:")
+            || img.starts_with("podman:")
+            || img.starts_with("local:")
+            || img.ends_with(".tar")
+            || img.ends_with("Dockerfile")
+            || img.contains("/Dockerfile")
+    });
+
     // If machine was created from .smolmachine, extract layers to cache and
     // mount via virtiofs so the agent uses pre-extracted layers instead of
     // pulling from a registry.
@@ -677,6 +686,15 @@ pub fn start_vm_named(name: &str) -> smolvm::Result<()> {
         std::mem::forget(layers_lease);
     }
 
+    let mut resolved_image = record.image.clone();
+    if is_local_image {
+        if let Some(ref img) = record.image {
+            let (layers_dir, resolved_img) = smolvm::local_image::prepare_local_image(img)?;
+            features.packed_layers_dir = Some(layers_dir);
+            resolved_image = Some(resolved_img);
+        }
+    }
+
     let _ = manager
         .ensure_running_with_full_config(mounts, ports, resources, features)
         .map_err(|e| Error::agent("start machine", e.to_string()))?;
@@ -700,7 +718,7 @@ pub fn start_vm_named(name: &str) -> smolvm::Result<()> {
     // starts, skip both — image manifests/layers persist on the storage disk
     // and the container overlay is remounted (not recreated).
     if !record.init_completed {
-        let image_info = if record.source_smolmachine.is_some() {
+        let image_info = if record.source_smolmachine.is_some() || is_local_image {
             // Layers already mounted via virtiofs — no pull needed.
             None
         } else if let Some(ref image) = record.image {
@@ -714,7 +732,7 @@ pub fn start_vm_named(name: &str) -> smolvm::Result<()> {
             &mut client,
             &record.init,
             InitRunContext {
-                image: record.image.as_deref(),
+                image: resolved_image.as_deref(),
                 image_info: image_info.as_ref(),
                 env: &record.env,
                 workdir: record.workdir.as_deref(),
@@ -742,7 +760,7 @@ pub fn start_vm_named(name: &str) -> smolvm::Result<()> {
         );
     }
 
-    if let Some(ref img) = record.image {
+    if let Some(ref img) = resolved_image {
         // Image-based machine: start background CMD if configured.
         let mut cmd = record.entrypoint.clone();
         cmd.extend(record.cmd.clone());
@@ -1711,7 +1729,7 @@ mod init_runner_tests {
             &[],
             "vm",
         );
-        assert_eq!(config.image, "debian:slim");
+        assert_eq!(config.image, "docker.io/library/debian:slim");
         assert_eq!(config.env, env);
         assert_eq!(config.workdir.as_deref(), Some("/work"));
         assert_eq!(config.user.as_deref(), Some("steam"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,8 @@ pub mod registry;
 pub mod settings;
 pub mod smolfile;
 pub mod storage;
+/// Local Docker/Podman image and Dockerfile support.
+pub mod local_image;
 pub mod util;
 pub mod vm;
 

--- a/src/local_image.rs
+++ b/src/local_image.rs
@@ -1,0 +1,304 @@
+//! Local Docker/Podman image and Dockerfile support.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use sha2::{Digest, Sha256};
+
+/// Prepare a local Docker/Podman image or Dockerfile for mounting via virtiofs.
+/// Returns the path to the layers directory (`~/.cache/smolvm/local-images/<image_id_hex>/layers`).
+pub fn prepare_local_image(image_ref: &str) -> crate::error::Result<(PathBuf, String)> {
+    // 1. Check if the image reference is a path to a Dockerfile or a directory containing one
+    let mut resolved_image_ref = image_ref.to_string();
+    let path = Path::new(image_ref);
+    let mut is_dockerfile = false;
+
+    if path.exists() {
+        if path.is_file() && path.file_name().map_or(false, |n| n == "Dockerfile") {
+            is_dockerfile = true;
+        } else if path.is_dir() && path.join("Dockerfile").exists() {
+            is_dockerfile = true;
+        }
+    }
+
+    let backend = detect_backend();
+
+    if is_dockerfile {
+        let canonical_path = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+        let canonical_str = canonical_path.to_string_lossy();
+        
+        let mut hasher = Sha256::new();
+        hasher.update(canonical_str.as_bytes());
+        let hash = hex::encode(hasher.finalize());
+        let short_hash = &hash[..12];
+        let build_tag = format!("smolvm-build:{}", short_hash);
+
+        println!("Building Dockerfile via {} (tag: {})...", backend, build_tag);
+
+        let build_dir = if path.is_file() {
+            path.parent().unwrap_or(Path::new("."))
+        } else {
+            path
+        };
+
+        let mut build_cmd = Command::new(backend);
+        build_cmd.arg("build");
+        build_cmd.arg("-t").arg(&build_tag);
+        if path.is_file() {
+            build_cmd.arg("-f").arg(path);
+        }
+        build_cmd.arg(build_dir);
+
+        let status = build_cmd
+            .status()
+            .map_err(|e| crate::error::Error::config("prepare_local_image", format!("Failed to spawn {} build: {}", backend, e)))?;
+
+        if !status.success() {
+            return Err(crate::error::Error::config(
+                "prepare_local_image",
+                format!("{} build failed for Dockerfile at {}", backend, path.display()),
+            ));
+        }
+
+        resolved_image_ref = format!("{}:{}", backend, build_tag);
+    }
+
+    // 2. Determine backend (docker or podman) and the raw image name/tag
+    let (backend, image_name) = if let Some(rest) = resolved_image_ref.strip_prefix("docker:") {
+        ("docker", rest)
+    } else if let Some(rest) = resolved_image_ref.strip_prefix("podman:") {
+        ("podman", rest)
+    } else if let Some(rest) = resolved_image_ref.strip_prefix("local:") {
+        (backend, rest)
+    } else if resolved_image_ref.ends_with(".tar") || resolved_image_ref.ends_with(".tar.gz") {
+        // Pre-saved tarball path (doesn't require a daemon prefix)
+        (backend, resolved_image_ref.as_str())
+    } else {
+        return Err(crate::error::Error::config(
+            "prepare_local_image",
+            format!("Invalid local image reference: {}", image_ref),
+        ));
+    };
+
+    // 3. Query the unique image ID / file hash
+    let (image_id, is_pre_saved_tar): (String, bool) = if image_name.ends_with(".tar") || image_name.ends_with(".tar.gz") {
+        let tar_path = Path::new(image_name);
+        if !tar_path.exists() {
+            return Err(crate::error::Error::config(
+                "prepare_local_image",
+                format!("Pre-saved image tarball not found: {}", image_name),
+            ));
+        }
+        let canonical = fs::canonicalize(tar_path).unwrap_or_else(|_| tar_path.to_path_buf());
+        let metadata = fs::metadata(&canonical).map_err(|e| {
+            crate::error::Error::config("prepare_local_image", format!("Failed to read metadata of tar: {}", e))
+        })?;
+        let mtime = metadata.modified()
+            .map(|t| t.duration_since(std::time::UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0))
+            .unwrap_or(0);
+        
+        let mut hasher = Sha256::new();
+        hasher.update(canonical.to_string_lossy().as_bytes());
+        hasher.update(&mtime.to_be_bytes());
+        let hash = hex::encode(hasher.finalize());
+        (format!("tar-{}", &hash[..16]), true)
+    } else {
+        (get_local_image_id(backend, image_name)?, false)
+    };
+
+    let image_id_clean = image_id
+        .strip_prefix("sha256:")
+        .unwrap_or(&image_id)
+        .replace(":", "_");
+
+    // 4. Locate the cache directories
+    let cache_base = dirs::cache_dir()
+        .ok_or_else(|| crate::error::Error::config("prepare_local_image", "No cache directory found"))?;
+    let image_cache_dir = cache_base.join("smolvm").join("local-images").join(&image_id_clean);
+    let layers_dir = image_cache_dir.join("layers");
+    let marker_file = image_cache_dir.join(".smolvm-extracted");
+
+    // 5. Check if already extracted
+    if marker_file.exists() && layers_dir.exists() {
+        tracing::debug!("Local image '{}' already cached at {}", image_name, layers_dir.display());
+        let final_image_ref = if is_pre_saved_tar {
+            format!("local:{}", image_id)
+        } else {
+            resolved_image_ref
+        };
+        return Ok((layers_dir, final_image_ref));
+    }
+
+    // Clean up stale/partial extraction
+    if image_cache_dir.exists() {
+        let _ = fs::remove_dir_all(&image_cache_dir);
+    }
+    fs::create_dir_all(&layers_dir).map_err(|e| {
+        crate::error::Error::config("prepare_local_image", format!("Failed to create layers directory: {}", e))
+    })?;
+
+    let tmp_dir = tempfile::tempdir().map_err(|e| {
+        crate::error::Error::config("prepare_local_image", format!("Failed to create temp directory: {}", e))
+    })?;
+
+    let save_tar_path = if is_pre_saved_tar {
+        PathBuf::from(image_name)
+    } else {
+        println!("Extracting local image '{}' (using {})...", image_name, backend);
+        let path = tmp_dir.path().join("image.tar");
+        let mut child = Command::new(backend)
+            .args(["save", image_name, "-o"])
+            .arg(&path)
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| crate::error::Error::config("prepare_local_image", format!("Failed to spawn {} save: {}", backend, e)))?;
+
+        let status = child.wait().map_err(|e| {
+            crate::error::Error::config("prepare_local_image", format!("Failed to wait for {} save: {}", backend, e))
+        })?;
+
+        if !status.success() {
+            let output = child.wait_with_output().unwrap();
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            return Err(crate::error::Error::config(
+                "prepare_local_image",
+                format!("{} save failed: {}", backend, stderr),
+            ));
+        }
+        path
+    };
+
+    // Extract outer tarball
+    let tar_file = fs::File::open(&save_tar_path).map_err(|e| {
+        crate::error::Error::config("prepare_local_image", format!("Failed to open saved tarball: {}", e))
+    })?;
+    let mut outer_archive = tar::Archive::new(tar_file);
+    let outer_extract_dir = tmp_dir.path().join("extracted");
+    fs::create_dir_all(&outer_extract_dir).unwrap();
+    outer_archive.unpack(&outer_extract_dir).map_err(|e| {
+        crate::error::Error::config("prepare_local_image", format!("Failed to unpack outer tarball: {}", e))
+    })?;
+
+    // Parse manifest.json
+    let manifest_path = outer_extract_dir.join("manifest.json");
+    if !manifest_path.exists() {
+        return Err(crate::error::Error::config(
+            "prepare_local_image",
+            "manifest.json not found in saved tarball".to_string(),
+        ));
+    }
+    let manifest_content = fs::read_to_string(&manifest_path).map_err(|e| {
+        crate::error::Error::config("prepare_local_image", format!("Failed to read manifest.json: {}", e))
+    })?;
+    let manifest_json: serde_json::Value = serde_json::from_str(&manifest_content).map_err(|e| {
+        crate::error::Error::config("prepare_local_image", format!("Failed to parse manifest.json: {}", e))
+    })?;
+
+    let first_image = manifest_json
+        .as_array()
+        .and_then(|arr: &Vec<serde_json::Value>| arr.first())
+        .ok_or_else(|| {
+            crate::error::Error::config("prepare_local_image", "Empty or invalid manifest.json format".to_string())
+        })?;
+
+    let config_file_name = first_image["Config"]
+        .as_str()
+        .ok_or_else(|| {
+            crate::error::Error::config("prepare_local_image", "Missing Config in manifest.json".to_string())
+        })?;
+
+    let layers_list = first_image["Layers"]
+        .as_array()
+        .ok_or_else(|| {
+            crate::error::Error::config("prepare_local_image", "Missing Layers in manifest.json".to_string())
+        })?;
+
+    // Copy config JSON to config.json inside the layers folder
+    let src_config_path = outer_extract_dir.join(config_file_name);
+    let dst_config_path = layers_dir.join("config.json");
+    if src_config_path.exists() {
+        fs::copy(&src_config_path, &dst_config_path).map_err(|e| {
+            crate::error::Error::config("prepare_local_image", format!("Failed to copy config.json: {}", e))
+        })?;
+    }
+
+    // Extract each layer tarball into its own indexed folder under layers_dir
+    for (index, layer_rel_path_val) in layers_list.iter().enumerate() {
+        let layer_rel_path = layer_rel_path_val.as_str().ok_or_else(|| {
+            crate::error::Error::config("prepare_local_image", "Invalid layer path in manifest.json".to_string())
+        })?;
+        let src_layer_tar = outer_extract_dir.join(layer_rel_path);
+        
+        let sanitized_name = layer_rel_path.replace("/", "_").replace(".tar", "");
+        let layer_dest_dir = layers_dir.join(format!("{:04}_{}", index, sanitized_name));
+        fs::create_dir_all(&layer_dest_dir).map_err(|e| {
+            crate::error::Error::config("prepare_local_image", format!("Failed to create layer destination directory: {}", e))
+        })?;
+
+        let layer_file = fs::File::open(&src_layer_tar).map_err(|e| {
+            crate::error::Error::config("prepare_local_image", format!("Failed to open layer tarball: {}", e))
+        })?;
+        let mut layer_archive = tar::Archive::new(layer_file);
+        layer_archive.unpack(&layer_dest_dir).map_err(|e| {
+            crate::error::Error::config("prepare_local_image", format!("Failed to extract layer {}: {}", index, e))
+        })?;
+    }
+
+    // Write completion marker
+    fs::write(&marker_file, "").map_err(|e| {
+        crate::error::Error::config("prepare_local_image", format!("Failed to write extraction marker: {}", e))
+    })?;
+
+    let final_image_ref = if is_pre_saved_tar {
+        format!("local:{}", image_id)
+    } else {
+        resolved_image_ref
+    };
+
+    Ok((layers_dir, final_image_ref))
+}
+
+fn detect_backend() -> &'static str {
+    if Command::new("podman")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map_or(false, |s| s.success())
+    {
+        "podman"
+    } else {
+        "docker"
+    }
+}
+
+fn get_local_image_id(backend: &str, image_name: &str) -> crate::error::Result<String> {
+    let output = Command::new(backend)
+        .args(["inspect", "--format", "{{.Id}}", image_name])
+        .output()
+        .map_err(|e| {
+            crate::error::Error::config("get_local_image_id", format!("Failed to run {} inspect: {}", backend, e))
+        })?;
+
+    if !output.status.success() {
+        return Err(crate::error::Error::config(
+            "get_local_image_id",
+            format!(
+                "Local image '{}' not found in {} daemon: {}",
+                image_name,
+                backend,
+                String::from_utf8_lossy(&output.stderr).trim()
+            ),
+        ));
+    }
+
+    let id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if id.is_empty() {
+        return Err(crate::error::Error::config(
+            "get_local_image_id",
+            format!("Empty ID returned by {} inspect for '{}'", backend, image_name),
+        ));
+    }
+    Ok(id)
+}

--- a/src/local_image.rs
+++ b/src/local_image.rs
@@ -1,95 +1,94 @@
-//! Local Docker/Podman image and Dockerfile support.
+//! Local OCI image support via streamed stdin pipes or pre-saved tarball archives.
 
 use std::fs;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
 use sha2::{Digest, Sha256};
 
-/// Prepare a local Docker/Podman image or Dockerfile for mounting via virtiofs.
-/// Returns the path to the layers directory (`~/.cache/smolvm/local-images/<image_id_hex>/layers`).
+/// Prepare a local OCI image tarball (from stdin or a file path) for mounting via virtiofs.
+/// Returns the path to the layers directory (`~/.cache/smolvm/local-images/<image_id_hex>/layers`)
+/// and a resolved image reference string (e.g. `local:stdin-<hash>` or `local:tar-<hash>`).
 pub fn prepare_local_image(image_ref: &str) -> crate::error::Result<(PathBuf, String)> {
-    // 1. Check if the image reference is a path to a Dockerfile or a directory containing one
-    let mut resolved_image_ref = image_ref.to_string();
-    let path = Path::new(image_ref);
-    let mut is_dockerfile = false;
-
-    if path.exists() {
-        if path.is_file() && path.file_name().map_or(false, |n| n == "Dockerfile") {
-            is_dockerfile = true;
-        } else if path.is_dir() && path.join("Dockerfile").exists() {
-            is_dockerfile = true;
-        }
-    }
-
-    let backend = detect_backend();
-
-    if is_dockerfile {
-        let canonical_path = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
-        let canonical_str = canonical_path.to_string_lossy();
-        
-        let mut hasher = Sha256::new();
-        hasher.update(canonical_str.as_bytes());
-        let hash = hex::encode(hasher.finalize());
-        let short_hash = &hash[..12];
-        let build_tag = format!("smolvm-build:{}", short_hash);
-
-        println!("Building Dockerfile via {} (tag: {})...", backend, build_tag);
-
-        let build_dir = if path.is_file() {
-            path.parent().unwrap_or(Path::new("."))
-        } else {
-            path
-        };
-
-        let mut build_cmd = Command::new(backend);
-        build_cmd.arg("build");
-        build_cmd.arg("-t").arg(&build_tag);
-        if path.is_file() {
-            build_cmd.arg("-f").arg(path);
-        }
-        build_cmd.arg(build_dir);
-
-        let status = build_cmd
-            .status()
-            .map_err(|e| crate::error::Error::config("prepare_local_image", format!("Failed to spawn {} build: {}", backend, e)))?;
-
-        if !status.success() {
-            return Err(crate::error::Error::config(
-                "prepare_local_image",
-                format!("{} build failed for Dockerfile at {}", backend, path.display()),
-            ));
-        }
-
-        resolved_image_ref = format!("{}:{}", backend, build_tag);
-    }
-
-    // 2. Determine backend (docker or podman) and the raw image name/tag
-    let (backend, image_name) = if let Some(rest) = resolved_image_ref.strip_prefix("docker:") {
-        ("docker", rest)
-    } else if let Some(rest) = resolved_image_ref.strip_prefix("podman:") {
-        ("podman", rest)
-    } else if let Some(rest) = resolved_image_ref.strip_prefix("local:") {
-        (backend, rest)
-    } else if resolved_image_ref.ends_with(".tar") || resolved_image_ref.ends_with(".tar.gz") {
-        // Pre-saved tarball path (doesn't require a daemon prefix)
-        (backend, resolved_image_ref.as_str())
-    } else {
-        return Err(crate::error::Error::config(
-            "prepare_local_image",
-            format!("Invalid local image reference: {}", image_ref),
-        ));
+    let is_stdin = image_ref == "-";
+    let is_tar = image_ref.ends_with(".tar") || image_ref.ends_with(".tar.gz");
+    let is_oci_dir = {
+        let path = Path::new(image_ref);
+        path.is_dir() && path.join("index.json").exists()
     };
 
-    // 3. Query the unique image ID / file hash
-    let (image_id, is_pre_saved_tar): (String, bool) = if image_name.ends_with(".tar") || image_name.ends_with(".tar.gz") {
-        let tar_path = Path::new(image_name);
-        if !tar_path.exists() {
+    if !is_stdin && !is_tar && !is_oci_dir {
+        return Err(crate::error::Error::config(
+            "prepare_local_image",
+            format!("Invalid local image reference (must be '-' for stdin, a .tar/.tar.gz file, or an OCI layout directory): {}", image_ref),
+        ));
+    }
+
+    let mut tmp_dir_opt = None;
+    if !is_oci_dir {
+        let tmp_dir = tempfile::tempdir().map_err(|e| {
+            crate::error::Error::config("prepare_local_image", format!("Failed to create temp directory: {}", e))
+        })?;
+        tmp_dir_opt = Some(tmp_dir);
+    }
+
+    let (tar_path, image_id) = if is_oci_dir {
+        let index_path = Path::new(image_ref).join("index.json");
+        let index_content = fs::read(&index_path).map_err(|e| {
+            crate::error::Error::config("prepare_local_image", format!("Failed to read index.json: {}", e))
+        })?;
+        let mut hasher = Sha256::new();
+        hasher.update(&index_content);
+        let hash = hex::encode(hasher.finalize());
+        (PathBuf::new(), format!("oci-{}", &hash[..16]))
+    } else if is_stdin {
+        println!("Reading OCI image tarball from stdin...");
+        let tmp_dir = tmp_dir_opt.as_ref().ok_or_else(|| {
+            crate::error::Error::config("prepare_local_image", "Temporary workspace directory not initialized".to_string())
+        })?;
+        let path = tmp_dir.path().join("stdin.tar");
+        let mut file = fs::File::create(&path).map_err(|e| {
+            crate::error::Error::config("prepare_local_image", format!("Failed to create temp stdin file: {}", e))
+        })?;
+        
+        let mut stdin = std::io::stdin();
+        let mut hasher = Sha256::new();
+        let mut buffer = [0; 65536];
+        let mut total_bytes = 0;
+        loop {
+            let n = stdin.read(&mut buffer).map_err(|e| {
+                crate::error::Error::config("prepare_local_image", format!("Failed to read from stdin: {}", e))
+            })?;
+            if n == 0 {
+                break;
+            }
+            file.write_all(&buffer[..n]).map_err(|e| {
+                crate::error::Error::config("prepare_local_image", format!("Failed to write to temp stdin file: {}", e))
+            })?;
+            hasher.update(&buffer[..n]);
+            total_bytes += n;
+        }
+        
+        if total_bytes == 0 {
             return Err(crate::error::Error::config(
                 "prepare_local_image",
-                format!("Pre-saved image tarball not found: {}", image_name),
+                "stdin is empty, no OCI image data received".to_string(),
             ));
         }
-        let canonical = fs::canonicalize(tar_path).unwrap_or_else(|_| tar_path.to_path_buf());
+        
+        drop(file);
+
+        let hash = hex::encode(hasher.finalize());
+        (path, format!("stdin-{}", &hash[..16]))
+    } else {
+        // Local tar/tar.gz file path
+        let path = Path::new(image_ref);
+        if !path.exists() {
+            return Err(crate::error::Error::config(
+                "prepare_local_image",
+                format!("Pre-saved image tarball not found: {}", image_ref),
+            ));
+        }
+        let canonical = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
         let metadata = fs::metadata(&canonical).map_err(|e| {
             crate::error::Error::config("prepare_local_image", format!("Failed to read metadata of tar: {}", e))
         })?;
@@ -101,9 +100,7 @@ pub fn prepare_local_image(image_ref: &str) -> crate::error::Result<(PathBuf, St
         hasher.update(canonical.to_string_lossy().as_bytes());
         hasher.update(&mtime.to_be_bytes());
         let hash = hex::encode(hasher.finalize());
-        (format!("tar-{}", &hash[..16]), true)
-    } else {
-        (get_local_image_id(backend, image_name)?, false)
+        (canonical, format!("tar-{}", &hash[..16]))
     };
 
     let image_id_clean = image_id
@@ -111,21 +108,17 @@ pub fn prepare_local_image(image_ref: &str) -> crate::error::Result<(PathBuf, St
         .unwrap_or(&image_id)
         .replace(":", "_");
 
-    // 4. Locate the cache directories
+    // Locate the cache directories
     let cache_base = dirs::cache_dir()
         .ok_or_else(|| crate::error::Error::config("prepare_local_image", "No cache directory found"))?;
     let image_cache_dir = cache_base.join("smolvm").join("local-images").join(&image_id_clean);
     let layers_dir = image_cache_dir.join("layers");
     let marker_file = image_cache_dir.join(".smolvm-extracted");
 
-    // 5. Check if already extracted
+    // Check if already extracted
     if marker_file.exists() && layers_dir.exists() {
-        tracing::debug!("Local image '{}' already cached at {}", image_name, layers_dir.display());
-        let final_image_ref = if is_pre_saved_tar {
-            format!("local:{}", image_id)
-        } else {
-            resolved_image_ref
-        };
+        tracing::debug!("Local image already cached at {}", layers_dir.display());
+        let final_image_ref = format!("local:{}", image_id);
         return Ok((layers_dir, final_image_ref));
     }
 
@@ -137,112 +130,190 @@ pub fn prepare_local_image(image_ref: &str) -> crate::error::Result<(PathBuf, St
         crate::error::Error::config("prepare_local_image", format!("Failed to create layers directory: {}", e))
     })?;
 
-    let tmp_dir = tempfile::tempdir().map_err(|e| {
-        crate::error::Error::config("prepare_local_image", format!("Failed to create temp directory: {}", e))
-    })?;
+    // Perform extraction in a fallible closure so we can clean up the partial extraction on failure
+    let extract_result = (|| -> crate::error::Result<()> {
+        if is_oci_dir {
+            println!("Extracting local OCI layout directory...");
+            let index_path = Path::new(image_ref).join("index.json");
+            let index_content = fs::read(&index_path).map_err(|e| {
+                crate::error::Error::config("prepare_local_image", format!("Failed to read index.json: {}", e))
+            })?;
+            let index_json: serde_json::Value = serde_json::from_slice(&index_content).map_err(|e| {
+                crate::error::Error::config("prepare_local_image", format!("Failed to parse index.json: {}", e))
+            })?;
+            let manifest_digest = index_json["manifests"]
+                .as_array()
+                .and_then(|arr| arr.first())
+                .and_then(|m| m["digest"].as_str())
+                .ok_or_else(|| {
+                    crate::error::Error::config("prepare_local_image", "Missing or invalid manifest digest in index.json".to_string())
+                })?;
+            let manifest_hash = manifest_digest
+                .strip_prefix("sha256:")
+                .unwrap_or(manifest_digest);
+            let oci_base_path = Path::new(image_ref);
+            let manifest_file_path = oci_base_path.join("blobs").join("sha256").join(manifest_hash);
+            if !manifest_file_path.exists() {
+                return Err(crate::error::Error::config(
+                    "prepare_local_image",
+                    format!("Manifest file not found: {}", manifest_file_path.display()),
+                ));
+            }
+            let manifest_content = fs::read_to_string(&manifest_file_path).map_err(|e| {
+                crate::error::Error::config("prepare_local_image", format!("Failed to read manifest file {}: {}", manifest_file_path.display(), e))
+            })?;
+            let manifest_json: serde_json::Value = serde_json::from_str(&manifest_content).map_err(|e| {
+                crate::error::Error::config("prepare_local_image", format!("Failed to parse manifest: {}", e))
+            })?;
+            let config_digest = manifest_json["config"]["digest"]
+                .as_str()
+                .ok_or_else(|| {
+                    crate::error::Error::config("prepare_local_image", "Missing config digest in manifest".to_string())
+                })?;
+            let config_hash = config_digest.strip_prefix("sha256:").unwrap_or(config_digest);
+            let config_file_path = oci_base_path.join("blobs").join("sha256").join(config_hash);
+            if !config_file_path.exists() {
+                return Err(crate::error::Error::config(
+                    "prepare_local_image",
+                    format!("Config file not found: {}", config_file_path.display()),
+                ));
+            }
+            let dst_config_path = layers_dir.join("config.json");
+            fs::copy(&config_file_path, &dst_config_path).map_err(|e| {
+                crate::error::Error::config("prepare_local_image", format!("Failed to copy config.json: {}", e))
+            })?;
 
-    let save_tar_path = if is_pre_saved_tar {
-        PathBuf::from(image_name)
-    } else {
-        println!("Extracting local image '{}' (using {})...", image_name, backend);
-        let path = tmp_dir.path().join("image.tar");
-        let mut child = Command::new(backend)
-            .args(["save", image_name, "-o"])
-            .arg(&path)
-            .stdout(Stdio::null())
-            .stderr(Stdio::piped())
-            .spawn()
-            .map_err(|e| crate::error::Error::config("prepare_local_image", format!("Failed to spawn {} save: {}", backend, e)))?;
+            let layers = manifest_json["layers"]
+                .as_array()
+                .ok_or_else(|| {
+                    crate::error::Error::config("prepare_local_image", "Missing layers in manifest".to_string())
+                })?;
 
-        let status = child.wait().map_err(|e| {
-            crate::error::Error::config("prepare_local_image", format!("Failed to wait for {} save: {}", backend, e))
-        })?;
+            for (index, layer_val) in layers.iter().enumerate() {
+                let layer_digest = layer_val["digest"]
+                    .as_str()
+                    .ok_or_else(|| {
+                        crate::error::Error::config("prepare_local_image", "Missing digest in layer".to_string())
+                    })?;
+                let layer_hash = layer_digest.strip_prefix("sha256:").unwrap_or(layer_digest);
+                let layer_file_path = oci_base_path.join("blobs").join("sha256").join(layer_hash);
+                if !layer_file_path.exists() {
+                    return Err(crate::error::Error::config(
+                        "prepare_local_image",
+                        format!("Layer file not found: {}", layer_file_path.display()),
+                    ));
+                }
+                
+                let hash_prefix = if layer_hash.len() > 12 { &layer_hash[..12] } else { layer_hash };
+                let layer_dest_dir = layers_dir.join(format!("{:04}_{}", index, hash_prefix));
+                
+                fs::create_dir_all(&layer_dest_dir).map_err(|e| {
+                    crate::error::Error::config(
+                        "prepare_local_image",
+                        format!("Failed to create layer directory {}: {}", layer_dest_dir.display(), e),
+                    )
+                })?;
 
-        if !status.success() {
-            let output = child.wait_with_output().unwrap();
-            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-            return Err(crate::error::Error::config(
-                "prepare_local_image",
-                format!("{} save failed: {}", backend, stderr),
-            ));
+                let file = fs::File::open(&layer_file_path).map_err(|e| {
+                    crate::error::Error::config("prepare_local_image", format!("Failed to open layer file: {}", e))
+                })?;
+                
+                let decoder = flate2::read::GzDecoder::new(file);
+                let mut archive = tar::Archive::new(decoder);
+                archive.unpack(&layer_dest_dir).map_err(|e| {
+                    crate::error::Error::config("prepare_local_image", format!("Failed to extract layer {}: {}", index, e))
+                })?;
+            }
+        } else {
+            println!("Extracting local image tarball...");
+            let tmp_dir = tmp_dir_opt.as_ref().ok_or_else(|| {
+                crate::error::Error::config("prepare_local_image", "Temporary workspace directory not initialized".to_string())
+            })?;
+            let outer_extract_dir = tmp_dir.path().join("extracted");
+            fs::create_dir_all(&outer_extract_dir).map_err(|e| {
+                crate::error::Error::config("prepare_local_image", format!("Failed to create extraction dir: {}", e))
+            })?;
+
+            // Extract outer tarball
+            let tar_file = fs::File::open(&tar_path).map_err(|e| {
+                crate::error::Error::config("prepare_local_image", format!("Failed to open OCI tarball: {}", e))
+            })?;
+            let mut outer_archive = tar::Archive::new(tar_file);
+            outer_archive.unpack(&outer_extract_dir).map_err(|e| {
+                crate::error::Error::config("prepare_local_image", format!("Failed to unpack outer tarball: {}", e))
+            })?;
+
+            // Parse manifest.json
+            let manifest_path = outer_extract_dir.join("manifest.json");
+            if !manifest_path.exists() {
+                return Err(crate::error::Error::config(
+                    "prepare_local_image",
+                    "manifest.json not found in saved tarball".to_string(),
+                ));
+            }
+            let manifest_content = fs::read_to_string(&manifest_path).map_err(|e| {
+                crate::error::Error::config("prepare_local_image", format!("Failed to read manifest.json: {}", e))
+            })?;
+            let manifest_json: serde_json::Value = serde_json::from_str(&manifest_content).map_err(|e| {
+                crate::error::Error::config("prepare_local_image", format!("Failed to parse manifest.json: {}", e))
+            })?;
+
+            let first_image = manifest_json
+                .as_array()
+                .and_then(|arr| arr.first())
+                .ok_or_else(|| {
+                    crate::error::Error::config("prepare_local_image", "Empty or invalid manifest.json format".to_string())
+                })?;
+
+            let config_file_name = first_image["Config"]
+                .as_str()
+                .ok_or_else(|| {
+                    crate::error::Error::config("prepare_local_image", "Missing Config in manifest.json".to_string())
+                })?;
+
+            let layers_list = first_image["Layers"]
+                .as_array()
+                .ok_or_else(|| {
+                    crate::error::Error::config("prepare_local_image", "Missing Layers in manifest.json".to_string())
+                })?;
+
+            // Copy config JSON to config.json inside the layers folder
+            let src_config_path = outer_extract_dir.join(config_file_name);
+            let dst_config_path = layers_dir.join("config.json");
+            if src_config_path.exists() {
+                fs::copy(&src_config_path, &dst_config_path).map_err(|e| {
+                    crate::error::Error::config("prepare_local_image", format!("Failed to copy config.json: {}", e))
+                })?;
+            }
+
+            // Extract each layer tarball into its own indexed folder under layers_dir
+            for (index, layer_rel_path_val) in layers_list.iter().enumerate() {
+                let layer_rel_path = layer_rel_path_val.as_str().ok_or_else(|| {
+                    crate::error::Error::config("prepare_local_image", "Invalid layer path in manifest.json".to_string())
+                })?;
+                let src_layer_tar = outer_extract_dir.join(layer_rel_path);
+                
+                let sanitized_name = layer_rel_path.replace("/", "_").replace(".tar", "");
+                let layer_dest_dir = layers_dir.join(format!("{:04}_{}", index, sanitized_name));
+                fs::create_dir_all(&layer_dest_dir).map_err(|e| {
+                    crate::error::Error::config("prepare_local_image", format!("Failed to create layer destination directory: {}", e))
+                })?;
+
+                let layer_file = fs::File::open(&src_layer_tar).map_err(|e| {
+                    crate::error::Error::config("prepare_local_image", format!("Failed to open layer tarball: {}", e))
+                })?;
+                let mut layer_archive = tar::Archive::new(layer_file);
+                layer_archive.unpack(&layer_dest_dir).map_err(|e| {
+                    crate::error::Error::config("prepare_local_image", format!("Failed to extract layer {}: {}", index, e))
+                })?;
+            }
         }
-        path
-    };
+        Ok(())
+    })();
 
-    // Extract outer tarball
-    let tar_file = fs::File::open(&save_tar_path).map_err(|e| {
-        crate::error::Error::config("prepare_local_image", format!("Failed to open saved tarball: {}", e))
-    })?;
-    let mut outer_archive = tar::Archive::new(tar_file);
-    let outer_extract_dir = tmp_dir.path().join("extracted");
-    fs::create_dir_all(&outer_extract_dir).unwrap();
-    outer_archive.unpack(&outer_extract_dir).map_err(|e| {
-        crate::error::Error::config("prepare_local_image", format!("Failed to unpack outer tarball: {}", e))
-    })?;
-
-    // Parse manifest.json
-    let manifest_path = outer_extract_dir.join("manifest.json");
-    if !manifest_path.exists() {
-        return Err(crate::error::Error::config(
-            "prepare_local_image",
-            "manifest.json not found in saved tarball".to_string(),
-        ));
-    }
-    let manifest_content = fs::read_to_string(&manifest_path).map_err(|e| {
-        crate::error::Error::config("prepare_local_image", format!("Failed to read manifest.json: {}", e))
-    })?;
-    let manifest_json: serde_json::Value = serde_json::from_str(&manifest_content).map_err(|e| {
-        crate::error::Error::config("prepare_local_image", format!("Failed to parse manifest.json: {}", e))
-    })?;
-
-    let first_image = manifest_json
-        .as_array()
-        .and_then(|arr: &Vec<serde_json::Value>| arr.first())
-        .ok_or_else(|| {
-            crate::error::Error::config("prepare_local_image", "Empty or invalid manifest.json format".to_string())
-        })?;
-
-    let config_file_name = first_image["Config"]
-        .as_str()
-        .ok_or_else(|| {
-            crate::error::Error::config("prepare_local_image", "Missing Config in manifest.json".to_string())
-        })?;
-
-    let layers_list = first_image["Layers"]
-        .as_array()
-        .ok_or_else(|| {
-            crate::error::Error::config("prepare_local_image", "Missing Layers in manifest.json".to_string())
-        })?;
-
-    // Copy config JSON to config.json inside the layers folder
-    let src_config_path = outer_extract_dir.join(config_file_name);
-    let dst_config_path = layers_dir.join("config.json");
-    if src_config_path.exists() {
-        fs::copy(&src_config_path, &dst_config_path).map_err(|e| {
-            crate::error::Error::config("prepare_local_image", format!("Failed to copy config.json: {}", e))
-        })?;
-    }
-
-    // Extract each layer tarball into its own indexed folder under layers_dir
-    for (index, layer_rel_path_val) in layers_list.iter().enumerate() {
-        let layer_rel_path = layer_rel_path_val.as_str().ok_or_else(|| {
-            crate::error::Error::config("prepare_local_image", "Invalid layer path in manifest.json".to_string())
-        })?;
-        let src_layer_tar = outer_extract_dir.join(layer_rel_path);
-        
-        let sanitized_name = layer_rel_path.replace("/", "_").replace(".tar", "");
-        let layer_dest_dir = layers_dir.join(format!("{:04}_{}", index, sanitized_name));
-        fs::create_dir_all(&layer_dest_dir).map_err(|e| {
-            crate::error::Error::config("prepare_local_image", format!("Failed to create layer destination directory: {}", e))
-        })?;
-
-        let layer_file = fs::File::open(&src_layer_tar).map_err(|e| {
-            crate::error::Error::config("prepare_local_image", format!("Failed to open layer tarball: {}", e))
-        })?;
-        let mut layer_archive = tar::Archive::new(layer_file);
-        layer_archive.unpack(&layer_dest_dir).map_err(|e| {
-            crate::error::Error::config("prepare_local_image", format!("Failed to extract layer {}: {}", index, e))
-        })?;
+    if let Err(e) = extract_result {
+        let _ = fs::remove_dir_all(&image_cache_dir);
+        return Err(e);
     }
 
     // Write completion marker
@@ -250,55 +321,188 @@ pub fn prepare_local_image(image_ref: &str) -> crate::error::Result<(PathBuf, St
         crate::error::Error::config("prepare_local_image", format!("Failed to write extraction marker: {}", e))
     })?;
 
-    let final_image_ref = if is_pre_saved_tar {
-        format!("local:{}", image_id)
-    } else {
-        resolved_image_ref
-    };
-
+    let final_image_ref = format!("local:{}", image_id);
     Ok((layers_dir, final_image_ref))
 }
 
-fn detect_backend() -> &'static str {
-    if Command::new("podman")
-        .arg("--version")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map_or(false, |s| s.success())
-    {
-        "podman"
-    } else {
-        "docker"
-    }
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
 
-fn get_local_image_id(backend: &str, image_name: &str) -> crate::error::Result<String> {
-    let output = Command::new(backend)
-        .args(["inspect", "--format", "{{.Id}}", image_name])
-        .output()
-        .map_err(|e| {
-            crate::error::Error::config("get_local_image_id", format!("Failed to run {} inspect: {}", backend, e))
-        })?;
-
-    if !output.status.success() {
-        return Err(crate::error::Error::config(
-            "get_local_image_id",
-            format!(
-                "Local image '{}' not found in {} daemon: {}",
-                image_name,
-                backend,
-                String::from_utf8_lossy(&output.stderr).trim()
-            ),
-        ));
+    #[test]
+    fn test_invalid_image_ref_rejected() {
+        let result = prepare_local_image("not-a-tarball");
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("Invalid local image reference"));
     }
 
-    let id = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if id.is_empty() {
-        return Err(crate::error::Error::config(
-            "get_local_image_id",
-            format!("Empty ID returned by {} inspect for '{}'", backend, image_name),
-        ));
+    #[test]
+    fn test_prepare_local_image_tar_extraction_and_caching() {
+        let tmp = tempdir().unwrap();
+        let tar_path = tmp.path().join("mock_image.tar");
+        let file = fs::File::create(&tar_path).unwrap();
+        let mut archive = tar::Builder::new(file);
+
+        // 1. Create a dummy config JSON
+        let config_data = b"{\"architecture\":\"amd64\",\"os\":\"linux\"}";
+        let mut header1 = tar::Header::new_gnu();
+        header1.set_size(config_data.len() as u64);
+        header1.set_mode(0o644);
+        header1.set_cksum();
+        archive.append_data(&mut header1, "config.json", &config_data[..]).unwrap();
+
+        // 2. Create a dummy layer tarball
+        let mut layer_builder = tar::Builder::new(Vec::new());
+        let layer_content = b"hello world";
+        let mut layer_header = tar::Header::new_gnu();
+        layer_header.set_size(layer_content.len() as u64);
+        layer_header.set_mode(0o644);
+        layer_header.set_cksum();
+        layer_builder.append_data(&mut layer_header, "app/main.py", &layer_content[..]).unwrap();
+        let layer_bytes = layer_builder.into_inner().unwrap();
+
+        let mut header2 = tar::Header::new_gnu();
+        header2.set_size(layer_bytes.len() as u64);
+        header2.set_mode(0o644);
+        header2.set_cksum();
+        archive.append_data(&mut header2, "layer1/layer.tar", &layer_bytes[..]).unwrap();
+
+        // 3. Create manifest.json
+        let manifest_content = r#"[
+            {
+                "Config": "config.json",
+                "RepoTags": ["mock:latest"],
+                "Layers": ["layer1/layer.tar"]
+            }
+        ]"#;
+        let mut header3 = tar::Header::new_gnu();
+        header3.set_size(manifest_content.len() as u64);
+        header3.set_mode(0o644);
+        header3.set_cksum();
+        archive.append_data(&mut header3, "manifest.json", manifest_content.as_bytes()).unwrap();
+        archive.finish().unwrap();
+
+        // Run prepare_local_image on this tar file!
+        let (layers_dir, resolved_ref) = prepare_local_image(tar_path.to_str().unwrap()).unwrap();
+        
+        assert!(resolved_ref.starts_with("local:tar-"));
+        assert!(layers_dir.exists());
+        assert!(layers_dir.join("config.json").exists());
+        
+        // Check that the layer directory is extracted
+        let layer_extracted_dir = layers_dir.join("0000_layer1_layer");
+        assert!(layer_extracted_dir.exists());
+        assert!(layer_extracted_dir.join("app/main.py").exists());
+        
+        // Run it a second time and check that we hit the cache immediately
+        let (layers_dir2, resolved_ref2) = prepare_local_image(tar_path.to_str().unwrap()).unwrap();
+        assert_eq!(layers_dir, layers_dir2);
+        assert_eq!(resolved_ref, resolved_ref2);
     }
-    Ok(id)
+
+    #[test]
+    fn test_prepare_local_image_oci_directory_extraction_and_caching() {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+
+        let tmp = tempdir().unwrap();
+        let oci_dir = tmp.path().join("oci-layout");
+        fs::create_dir_all(&oci_dir).unwrap();
+        
+        let blobs_dir = oci_dir.join("blobs").join("sha256");
+        fs::create_dir_all(&blobs_dir).unwrap();
+
+        // 1. Create a dummy config JSON
+        let config_data = b"{\"architecture\":\"amd64\",\"os\":\"linux\"}";
+        let mut hasher = Sha256::new();
+        hasher.update(config_data);
+        let config_hash = hex::encode(hasher.finalize());
+        fs::write(blobs_dir.join(&config_hash), config_data).unwrap();
+
+        // 2. Create a dummy layer tar, gzip compress it, and save it under blobs/sha256/
+        let layer_content = b"hello from oci layout layer";
+        let mut tar_builder = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_size(layer_content.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        tar_builder.append_data(&mut header, "etc/greeting.txt", &layer_content[..]).unwrap();
+        let tar_bytes = tar_builder.into_inner().unwrap();
+
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&tar_bytes).unwrap();
+        let gzip_bytes = encoder.finish().unwrap();
+
+        let mut hasher = Sha256::new();
+        hasher.update(&gzip_bytes);
+        let layer_hash = hex::encode(hasher.finalize());
+        fs::write(blobs_dir.join(&layer_hash), &gzip_bytes).unwrap();
+
+        // 3. Create the manifest blob listing the config and layer digests, saving it under blobs/sha256/<manifest-hash>
+        let manifest_content = format!(
+            r#"{{
+                "schemaVersion": 2,
+                "config": {{
+                    "mediaType": "application/vnd.oci.image.config.v1+json",
+                    "digest": "sha256:{}",
+                    "size": {}
+                }},
+                "layers": [
+                    {{
+                        "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+                        "digest": "sha256:{}",
+                        "size": {}
+                    }}
+                ]
+            }}"#,
+            config_hash, config_data.len(), layer_hash, gzip_bytes.len()
+        );
+        let mut hasher = Sha256::new();
+        hasher.update(manifest_content.as_bytes());
+        let manifest_hash = hex::encode(hasher.finalize());
+        fs::write(blobs_dir.join(&manifest_hash), manifest_content.as_bytes()).unwrap();
+
+        // 4. Create index.json referencing the manifest digest
+        let index_content = format!(
+            r#"{{
+                "schemaVersion": 2,
+                "manifests": [
+                    {{
+                        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                        "digest": "sha256:{}",
+                        "size": {}
+                    }}
+                ]
+            }}"#,
+            manifest_hash, manifest_content.len()
+        );
+        fs::write(oci_dir.join("index.json"), index_content.as_bytes()).unwrap();
+
+        // Run prepare_local_image!
+        let (layers_dir, resolved_ref) = prepare_local_image(oci_dir.to_str().unwrap()).unwrap();
+
+        // Assert that:
+        // - The cache key starts with local:oci-
+        assert!(resolved_ref.starts_with("local:oci-"));
+        assert!(layers_dir.exists());
+        
+        // - Config and decompressed layers are successfully unpacked in the cache directory.
+        assert!(layers_dir.join("config.json").exists());
+        let config_read = fs::read_to_string(layers_dir.join("config.json")).unwrap();
+        assert_eq!(config_read, "{\"architecture\":\"amd64\",\"os\":\"linux\"}");
+
+        let layer_prefix = &layer_hash[..12];
+        let layer_extracted_dir = layers_dir.join(format!("0000_{}", layer_prefix));
+        assert!(layer_extracted_dir.exists());
+        assert!(layer_extracted_dir.join("etc/greeting.txt").exists());
+        let greeting = fs::read_to_string(layer_extracted_dir.join("etc/greeting.txt")).unwrap();
+        assert_eq!(greeting, "hello from oci layout layer");
+
+        // - Calling it a second time hits the cache instantly (skipping decompression)
+        let (layers_dir2, resolved_ref2) = prepare_local_image(oci_dir.to_str().unwrap()).unwrap();
+        assert_eq!(layers_dir, layers_dir2);
+        assert_eq!(resolved_ref, resolved_ref2);
+    }
 }


### PR DESCRIPTION
## Summary
This PR introduces native OCI Directory Layout support (e.g., outputs produced by `skopeo copy ... oci:path` or `podman save --format oci-dir`) for `smolvm` local image handling. This enables instant microVM boots directly from locally stored OCI layouts without needing remote registries or OCI tarball streaming.

Resolves #308 

---

## Core Changes

1. **OCI Directory Layout Detection & Classification**:
   - Classifies directories containing an `index.json` file as local image sources.
   - Updates `normalize_image_ref` and `is_local_image` checks to bypass remote registry pulling and domain-prefix normalization.
2. **Deterministic Hashing & Caching**:
   - Hashes the contents of `index.json` to generate a unique cache key (`oci-<hash>`) for fast lookup.
   - Proactively cleans up cache folders upon any extraction failure.
3. **Manifest Parsing & Nested Gzip Decompression**:
   - Reads the main image manifest digest from `index.json` to locate the manifest blob.
   - Copies/writes the image configuration as `config.json` inside the extracted layers folder.
   - Decompresses and extracts each layer from `blobs/sha256/` using `flate2` and `tar` directly into the indexed layers cache (e.g., `0000_<layer-hash-prefix>`).
4. **Instant MicroVM Boots**:
   - Subsequent boots match the cache key and skip extraction entirely, starting the microVM in **<200ms**.

---

## Example Usage

### 1. Using `skopeo` (Export locally and run)
```bash
# 1. Export using skopeo
skopeo copy containers-storage:localhost/my-app:latest oci:./my-oci-layout

# 2. Run directly from the layout (sub-200ms on subsequent hot boots)
smolvm machine run --image ./my-oci-layout -- echo "hello from skopeo layout"
```

### 2. Using `podman save` (Export locally and run)
```bash
# 1. Export using podman save
podman save --format oci-dir -o ./my-oci-layout localhost/my-app:latest

# 2. Run directly from the layout
smolvm machine run --image ./my-oci-layout -- echo "hello from podman layout"
```

### 3. Using Podman Pipe Stdin (No files written to disk)
```bash
# Stream OCI tarball directly via pipe (extremely fast cold start, no disk writes)
podman save localhost/my-app:latest | smolvm machine run --image - -- echo "hello from pipe"
```

### 4. RAM-backed OCI Layout (Zero disk writes, sub-200ms hot boot)
```bash
# 1. Export layout directly into RAM-backed shared memory
podman save --format oci-dir -o /dev/shm/my-oci-layout localhost/my-app:latest

# 2. Mount and boot the microVM directly from RAM
smolvm machine run --image /dev/shm/my-oci-layout -- echo "hello from RAM layout"
```

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/311">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->