### PR TITLE
fix: send VEOF twice so PTY exec with unterminated stdin terminates

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -3772,11 +3772,21 @@ fn run_interactive_loop_pty(
                         // Host stdin reached EOF. A PTY cannot have one
                         // direction closed, so signal end-of-input to the
                         // child by writing the EOF control character (VEOF,
-                        // Ctrl-D / 0x04). In canonical mode this makes the
-                        // child's next read on the slave return 0. Without
-                        // it, a stdin-reading child (cat, sh, read) never
-                        // terminates and the exec session hangs.
-                        let _ = pty_master.write_all(&[0x04]);
+                        // Ctrl-D / 0x04). In canonical mode VEOF makes the
+                        // pending line available to the child's read()
+                        // immediately; a read() that finds an empty line
+                        // buffer returns 0, which is the EOF the child waits
+                        // for. Without it a stdin-reading child (cat, sh,
+                        // read) never terminates and the exec session hangs.
+                        //
+                        // Send it twice: if the host's final stdin chunk was
+                        // not newline-terminated, the first VEOF only flushes
+                        // that partial line (delivered as data, not EOF), so a
+                        // second VEOF — now at an empty line buffer — is what
+                        // produces the zero-length read. When the buffer is
+                        // already empty the first VEOF yields EOF and the
+                        // second is harmlessly consumed after the child exits.
+                        let _ = pty_master.write_all(&[0x04, 0x04]);
                     } else {
                         let _ = pty_master.write_all(&data);
                     }

--- a/tests/test_machine_bare.sh
+++ b/tests/test_machine_bare.sh
@@ -786,15 +786,26 @@ test_exec_tty_piped_stdin_terminates() {
     "$SMOLVM" machine create "$_EXEC_STDIN_MACHINE" 2>/dev/null || return 1
     "$SMOLVM" machine start --name "$_EXEC_STDIN_MACHINE" 2>/dev/null || return 1
 
+    # Newline-terminated input: the PTY line buffer is empty when EOF
+    # arrives, so a single VEOF would already yield the zero-length read.
     local exit_code=0
     run_with_timeout 15 sh -c \
         "echo tty-input | '$SMOLVM' machine exec --name '$_EXEC_STDIN_MACHINE' --tty -i -- cat" \
         >/dev/null 2>&1 || exit_code=$?
 
+    # Unterminated input (no trailing newline): the first VEOF only flushes
+    # the partial line as data, so a second VEOF is required to deliver the
+    # zero-length read. This is the case a single VEOF fails to terminate.
+    local exit_code_partial=0
+    run_with_timeout 15 sh -c \
+        "printf no-newline | '$SMOLVM' machine exec --name '$_EXEC_STDIN_MACHINE' --tty -i -- cat" \
+        >/dev/null 2>&1 || exit_code_partial=$?
+
     "$SMOLVM" machine stop --name "$_EXEC_STDIN_MACHINE" 2>/dev/null || true
     "$SMOLVM" machine delete "$_EXEC_STDIN_MACHINE" -f 2>/dev/null || true
 
     [[ $exit_code -ne 124 ]] || { echo "FAIL: 'exec --tty -i' with piped stdin timed out (PTY EOF not propagated)"; return 1; }
+    [[ $exit_code_partial -ne 124 ]] || { echo "FAIL: 'exec --tty -i' with unterminated stdin timed out (PTY EOF not propagated)"; return 1; }
 }
 
 run_test "Exec: 'exec --tty -i' with piped stdin terminates (PTY EOF)" test_exec_tty_piped_stdin_terminates || true


### PR DESCRIPTION
<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/314">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->