### PR TITLE
feat: boot from local docker/OCI image archives (stdin pipe or .tar)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,6 @@ smolvm-pack = { path = "crates/smolvm-pack" }
 smolvm-registry = { path = "crates/smolvm-registry" }
 smolfile = { path = "crates/smolvm-smolfile" }
 thiserror = "1"
-tar = "0.4"
-flate2 = "1"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ smolvm-pack = { path = "crates/smolvm-pack" }
 smolvm-registry = { path = "crates/smolvm-registry" }
 smolfile = { path = "crates/smolvm-smolfile" }
 thiserror = "1"
+tar = "0.4"
+flate2 = "1"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/smolvm-agent/src/image_archive.rs
+++ b/crates/smolvm-agent/src/image_archive.rs
@@ -1,0 +1,423 @@
+//! Guest-side image archive ingestion.
+//!
+//! Handles extracting, decompressing, and flattening Docker/OCI image archives
+//! staged via virtiofs. Spawns `crane` and `tar` inside the guest to assemble
+//! a local rootfs inside the microvm's persistent /storage disk.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use tracing::debug;
+
+use crate::storage::StorageError;
+
+type Result<T> = std::result::Result<T, StorageError>;
+
+pub const IMAGE_ARCHIVE_FILE: &str = "archive.tar";
+pub const IMAGE_ARCHIVE_DIR: &str = "image-archive";
+pub const IMAGE_ARCHIVE_MARKER: &str = ".extracted";
+const GZIP_MAGIC: [u8; 2] = [0x1f, 0x8b];
+const STORAGE_ROOT: &str = "/storage";
+
+/// Flatten a host-staged image archive into a single rootfs layer using
+/// `crane`, returning a packed-layers directory the rest of the pipeline can
+/// consume unchanged.
+///
+/// Extraction, layer ordering, and whiteout handling are delegated entirely to
+/// `crane export` (already bundled for registry pulls); the agent only stages
+/// I/O and reads the image config blob to recover Entrypoint/Cmd/Env. The
+/// result lives on the storage disk and is guarded by a completion marker, so
+/// for named machines `crane` runs only on first boot.
+///
+/// Only the Docker `save` archive format (top-level `manifest.json`) is
+/// supported, which is what `docker save` and `podman save` (default) produce.
+/// OCI-layout archives (`index.json`) are rejected with a clear error, since
+/// `crane export` cannot read them from a tar stream.
+#[cfg(target_os = "linux")]
+pub fn materialize_image_archive(archive_mount: &Path) -> Result<PathBuf> {
+    let target = Path::new(STORAGE_ROOT).join(IMAGE_ARCHIVE_DIR);
+    let layer_dir = target.join("0000_rootfs");
+    let marker = target.join(IMAGE_ARCHIVE_MARKER);
+
+    // Cache hit: a previous boot already flattened this archive onto the
+    // (persistent) storage disk.
+    if marker.exists() && layer_dir.exists() {
+        debug!(target = %target.display(), "reusing previously flattened image archive");
+        return Ok(target);
+    }
+
+    // Clear any partial/stale extraction before re-flattening.
+    if target.exists() {
+        let _ = std::fs::remove_dir_all(&target);
+    }
+    std::fs::create_dir_all(&layer_dir)?;
+
+    let archive_path = archive_mount.join(IMAGE_ARCHIVE_FILE);
+
+    // `crane export` and `tar -xO` both need an uncompressed tar. `docker save
+    // | gzip` and `.tar.gz` inputs are gzip-wrapped, so decompress once with
+    // the bundled busybox `gunzip` rather than re-implementing gzip.
+    let plain_tar = target.join(".plain.tar");
+    let used_plain = if is_gzip(&archive_path)? {
+        decompress_gzip(&archive_path, &plain_tar)?;
+        true
+    } else {
+        false
+    };
+    let source_tar = if used_plain {
+        plain_tar.as_path()
+    } else {
+        archive_path.as_path()
+    };
+
+    flatten_with_crane(source_tar, &layer_dir)?;
+    write_archive_config(source_tar, &target)?;
+
+    if used_plain {
+        let _ = std::fs::remove_file(&plain_tar);
+    }
+
+    std::fs::write(&marker, b"")?;
+    // SAFETY: sync() is always safe to call; ensures the flattened rootfs is
+    // durable before the overlay is assembled on top of it.
+    unsafe {
+        libc::sync();
+    }
+
+    Ok(target)
+}
+
+/// True when `path` begins with the gzip magic bytes.
+#[cfg(target_os = "linux")]
+fn is_gzip(path: &Path) -> Result<bool> {
+    use std::io::Read;
+    let mut file = std::fs::File::open(path)
+        .map_err(|e| StorageError::read_error(path.display().to_string(), e))?;
+    let mut magic = [0u8; 2];
+    let n = file.read(&mut magic).unwrap_or(0);
+    Ok(n == 2 && magic == GZIP_MAGIC)
+}
+
+/// Decompress a gzip file to `dest` using the bundled `gunzip`.
+#[cfg(target_os = "linux")]
+fn decompress_gzip(src: &Path, dest: &Path) -> Result<()> {
+    let input = std::fs::File::open(src)
+        .map_err(|e| StorageError::read_error(src.display().to_string(), e))?;
+    let output = std::fs::File::create(dest)
+        .map_err(|e| StorageError::write_error(dest.display().to_string(), e))?;
+    let status = Command::new("gunzip")
+        .arg("-c")
+        .stdin(Stdio::from(input))
+        .stdout(Stdio::from(output))
+        .stderr(Stdio::null())
+        .status()
+        .map_err(|e| StorageError::new(format!("failed to spawn gunzip: {}", e)))?;
+    if !status.success() {
+        return Err(StorageError::new(
+            "gunzip failed to decompress image archive".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Flatten a Docker `save` tarball into `layer_dir` by piping
+/// `crane export - -` into `tar -x`.
+#[cfg(target_os = "linux")]
+fn flatten_with_crane(source_tar: &Path, layer_dir: &Path) -> Result<()> {
+    let archive = std::fs::File::open(source_tar)
+        .map_err(|e| StorageError::read_error(source_tar.display().to_string(), e))?;
+
+    // Read the image tarball from stdin, write the flattened rootfs to stdout.
+    // Stderr is directed to Stdio::null() to prevent a potential OS pipe-buffer
+    // deadlock when crane writes logs concurrently while tar blocks on stdin.
+    let mut crane = Command::new("crane")
+        .args(["export", "-", "-"])
+        .stdin(Stdio::from(archive))
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| StorageError::new(format!("failed to spawn crane: {}", e)))?;
+
+    let crane_stdout = crane
+        .stdout
+        .take()
+        .ok_or_else(|| StorageError::new("failed to capture crane stdout".to_string()))?;
+
+    let tar_output = Command::new("tar")
+        .arg("-x")
+        .arg("-f")
+        .arg("-")
+        .arg("-C")
+        .arg(layer_dir)
+        .stdin(Stdio::from(crane_stdout))
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| StorageError::new(format!("failed to run tar: {}", e)))?;
+
+    let crane_status = crane
+        .wait()
+        .map_err(|e| StorageError::new(format!("failed to wait for crane: {}", e)))?;
+
+    if !crane_status.success() {
+        // Since crane's stderr is Stdio::null() to prevent deadlock, we provide
+        // a clean format error suggestion. OCI-layout archives (index.json)
+        // are not supported by crane export.
+        return Err(StorageError::new(
+            "crane could not read the image archive. \
+             Only the Docker 'save' format is supported \
+             (docker save / podman save); re-export with that format."
+                .to_string(),
+        ));
+    }
+
+    if !tar_output.status.success() {
+        let stderr = String::from_utf8_lossy(&tar_output.stderr);
+        return Err(StorageError::new(format!(
+            "failed to extract flattened rootfs: {}",
+            stderr.trim()
+        )));
+    }
+
+    Ok(())
+}
+
+/// Read the image config blob from a Docker `save` tarball (located via its
+/// top-level `manifest.json`) and write it to `<target>/config.json`, the file
+/// `create_packed_image_info` reads to recover image metadata.
+#[cfg(target_os = "linux")]
+fn write_archive_config(source_tar: &Path, target: &Path) -> Result<()> {
+    let manifest_bytes = read_tar_member(source_tar, "manifest.json")?;
+    let manifest: serde_json::Value = serde_json::from_slice(&manifest_bytes)
+        .map_err(|e| StorageError::parse_error("manifest.json", e))?;
+
+    let config_member = manifest
+        .as_array()
+        .and_then(|entries| entries.first())
+        .and_then(|entry| entry["Config"].as_str())
+        .ok_or_else(|| StorageError::new("manifest.json missing Config entry".to_string()))?;
+
+    let config_bytes = read_tar_member(source_tar, config_member)?;
+    std::fs::write(target.join("config.json"), &config_bytes).map_err(|e| {
+        StorageError::write_error(target.join("config.json").display().to_string(), e)
+    })?;
+    Ok(())
+}
+
+/// Extract a single named member from a tar archive to memory via `tar -xO`.
+#[cfg(target_os = "linux")]
+fn read_tar_member(source_tar: &Path, member: &str) -> Result<Vec<u8>> {
+    let output = Command::new("tar")
+        .arg("-xOf")
+        .arg(source_tar)
+        .arg(member)
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| StorageError::new(format!("failed to run tar: {}", e)))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(StorageError::new(format!(
+            "failed to read '{}' from image archive: {}",
+            member,
+            stderr.trim()
+        )));
+    }
+    Ok(output.stdout)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_os = "linux")]
+    fn crane_available() -> bool {
+        Command::new("crane")
+            .arg("version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
+    /// Build a minimal Docker `save` tarball (flat `manifest.json` naming) at
+    /// `dest` containing a single layer with `hello.txt`. crane does not
+    /// validate `diff_ids`, so a placeholder digest is fine for tests.
+    #[cfg(target_os = "linux")]
+    fn make_docker_save_tar(work: &Path, dest: &Path) {
+        let layer_root = work.join("layerroot");
+        std::fs::create_dir_all(&layer_root).unwrap();
+        std::fs::write(layer_root.join("hello.txt"), b"hi from layer").unwrap();
+
+        let build = work.join("build");
+        std::fs::create_dir_all(&build).unwrap();
+        // Layer tar (contents become the flattened rootfs).
+        assert!(Command::new("tar")
+            .arg("-cf")
+            .arg(build.join("layer.tar"))
+            .arg("-C")
+            .arg(&layer_root)
+            .arg(".")
+            .status()
+            .unwrap()
+            .success());
+
+        std::fs::write(
+            build.join("config.json"),
+            br#"{"architecture":"amd64","os":"linux","config":{"Entrypoint":["/entry"],"Cmd":["run"],"Env":["K=V"]},"rootfs":{"type":"layers","diff_ids":["sha256:0000000000000000000000000000000000000000000000000000000000000000"]}}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            build.join("manifest.json"),
+            br#"[{"Config":"config.json","RepoTags":["test:latest"],"Layers":["layer.tar"]}]"#,
+        )
+        .unwrap();
+
+        // Flat member names (manifest.json, not ./manifest.json) — crane's
+        // tarball reader requires this, matching real docker/podman output.
+        assert!(Command::new("tar")
+            .arg("-cf")
+            .arg(dest)
+            .arg("-C")
+            .arg(&build)
+            .arg("manifest.json")
+            .arg("config.json")
+            .arg("layer.tar")
+            .status()
+            .unwrap()
+            .success());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_flatten_docker_save_and_recover_config() {
+        if !crane_available() {
+            eprintln!("skipping: crane not on PATH");
+            return;
+        }
+        let work = tempfile::tempdir().unwrap();
+        let archive = work.path().join("archive.tar");
+        make_docker_save_tar(work.path(), &archive);
+
+        // Flatten the rootfs via crane.
+        let layer_dir = work.path().join("rootfs");
+        std::fs::create_dir_all(&layer_dir).unwrap();
+        flatten_with_crane(&archive, &layer_dir).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(layer_dir.join("hello.txt")).unwrap(),
+            "hi from layer"
+        );
+
+        // Recover the image config beside the layer.
+        let target = work.path().join("target");
+        std::fs::create_dir_all(&target).unwrap();
+        write_archive_config(&archive, &target).unwrap();
+
+        let config: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(target.join("config.json")).unwrap()).unwrap();
+        let config_val = &config["config"];
+        let entrypoint: Vec<String> = config_val["Entrypoint"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+        let cmd: Vec<String> = config_val["Cmd"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+        let env: Vec<String> = config_val["Env"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+
+        assert_eq!(entrypoint, vec!["/entry"]);
+        assert_eq!(cmd, vec!["run"]);
+        assert_eq!(env, vec!["K=V"]);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_flatten_handles_gzipped_archive() {
+        if !crane_available() {
+            eprintln!("skipping: crane not on PATH");
+            return;
+        }
+        let work = tempfile::tempdir().unwrap();
+        let archive = work.path().join("archive.tar");
+        make_docker_save_tar(work.path(), &archive);
+
+        // gzip the outer archive (docker save | gzip / .tar.gz).
+        let gz = work.path().join("archive.tar.gz");
+        let input = std::fs::File::open(&archive).unwrap();
+        let output = std::fs::File::create(&gz).unwrap();
+        assert!(Command::new("gzip")
+            .arg("-c")
+            .stdin(Stdio::from(input))
+            .stdout(Stdio::from(output))
+            .status()
+            .unwrap()
+            .success());
+
+        assert!(is_gzip(&gz).unwrap());
+        assert!(!is_gzip(&archive).unwrap());
+
+        let plain = work.path().join("plain.tar");
+        decompress_gzip(&gz, &plain).unwrap();
+
+        let layer_dir = work.path().join("rootfs");
+        std::fs::create_dir_all(&layer_dir).unwrap();
+        flatten_with_crane(&plain, &layer_dir).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(layer_dir.join("hello.txt")).unwrap(),
+            "hi from layer"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_oci_layout_archive_rejected_with_clear_error() {
+        if !crane_available() {
+            eprintln!("skipping: crane not on PATH");
+            return;
+        }
+        // An OCI-layout archive has index.json but no top-level manifest.json,
+        // which crane's tar reader cannot consume from a stream.
+        let work = tempfile::tempdir().unwrap();
+        let build = work.path().join("oci");
+        std::fs::create_dir_all(&build).unwrap();
+        std::fs::write(
+            build.join("index.json"),
+            br#"{"schemaVersion":2,"manifests":[]}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            build.join("oci-layout"),
+            br#"{"imageLayoutVersion":"1.0.0"}"#,
+        )
+        .unwrap();
+        let archive = work.path().join("oci.tar");
+        assert!(Command::new("tar")
+            .arg("-cf")
+            .arg(&archive)
+            .arg("-C")
+            .arg(&build)
+            .arg("index.json")
+            .arg("oci-layout")
+            .status()
+            .unwrap()
+            .success());
+
+        let layer_dir = work.path().join("rootfs");
+        std::fs::create_dir_all(&layer_dir).unwrap();
+        let err = flatten_with_crane(&archive, &layer_dir).unwrap_err();
+        assert!(
+            err.to_string().contains("Docker 'save' format"),
+            "expected a clear docker-save guidance error, got: {}",
+            err
+        );
+    }
+}

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -80,6 +80,7 @@ fn boot_log(level: &str, msg: &str) {
     }
 }
 mod dns_proxy;
+mod image_archive;
 mod network;
 mod oci;
 mod paths;

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -450,27 +450,64 @@ fn create_packed_image_info(image: &str, packed_dir: &Path) -> Result<ImageInfo>
 
     // Determine architecture from environment or default
     #[cfg(target_arch = "aarch64")]
-    let architecture = "arm64".to_string();
+    let default_architecture = "arm64".to_string();
     #[cfg(target_arch = "x86_64")]
-    let architecture = "amd64".to_string();
+    let default_architecture = "amd64".to_string();
     #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
-    let architecture = "unknown".to_string();
+    let default_architecture = "unknown".to_string();
+
+    // Recover the OCI image config when present. `.smolmachine` packs carry it
+    // in the PackManifest, but local image archives (docker/podman save) drop a
+    // `config.json` beside the layers. Parse the same fields the registry-pull
+    // path reads so Entrypoint/Cmd/Env/WorkingDir/User actually take effect.
+    let mut entrypoint = Vec::new();
+    let mut cmd = Vec::new();
+    let mut env = Vec::new();
+    let mut workdir = None;
+    let mut user = None;
+    let mut created = None;
+    let mut architecture = default_architecture;
+
+    let config_path = packed_dir.join("config.json");
+    if config_path.exists() {
+        if let Ok(config_content) = std::fs::read_to_string(&config_path) {
+            if let Ok(config_json) = serde_json::from_str::<serde_json::Value>(&config_content) {
+                if let Some(arch) = config_json["architecture"].as_str() {
+                    architecture = arch.to_string();
+                }
+                created = config_json["created"].as_str().map(String::from);
+                let oci_config = &config_json["config"];
+                if oci_config.is_object() {
+                    entrypoint = json_string_array(oci_config, "Entrypoint");
+                    cmd = json_string_array(oci_config, "Cmd");
+                    env = json_string_array(oci_config, "Env");
+                    workdir = oci_config["WorkingDir"]
+                        .as_str()
+                        .filter(|s| !s.is_empty())
+                        .map(String::from);
+                    user = oci_config["User"]
+                        .as_str()
+                        .filter(|s| !s.is_empty())
+                        .map(String::from);
+                }
+            }
+        }
+    }
 
     Ok(ImageInfo {
         reference: image.to_string(),
         digest: "packed".to_string(), // No real digest available for packed images
         size: total_size,
-        created: None,
+        created,
         architecture,
         os: "linux".to_string(),
         layer_count: layer_dirs.len(),
         layers: layer_dirs,
-        // Packed mode: config is in the PackManifest, not the image
-        entrypoint: Vec::new(),
-        cmd: Vec::new(),
-        env: Vec::new(),
-        workdir: None,
-        user: None,
+        entrypoint,
+        cmd,
+        env,
+        workdir,
+        user,
     })
 }
 

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -17,7 +17,7 @@ use smolvm_protocol::{normalize_image_ref, ImageInfo, OverlayInfo, RegistryAuth,
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::OnceLock;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 /// Storage root path (where the ext4 disk is mounted).
 const STORAGE_ROOT: &str = "/storage";
@@ -28,6 +28,7 @@ const CONFIGS_DIR: &str = "configs";
 const MANIFESTS_DIR: &str = "manifests";
 const OVERLAYS_DIR: &str = "overlays";
 const WORKSPACE_DIR: &str = "workspace";
+
 const DOCKER_HUB_AUTH_CONFIG_KEY: &str = "https://index.docker.io/v1/";
 const DOCKER_HUB_REGISTRY_ALIASES: &[&str] = &["docker.io", "index.docker.io"];
 
@@ -302,6 +303,25 @@ pub fn init_packed_layers() -> Option<PathBuf> {
         }
         info!(mount_point = %mount_point.display(), "packed layers mounted successfully");
 
+        // Archive-ingest mode: the host staged a raw image archive instead of
+        // pre-extracted layers. Delegate extraction to `crane` and use the
+        // flattened rootfs as the packed-layers directory.
+        if mount_point
+            .join(crate::image_archive::IMAGE_ARCHIVE_FILE)
+            .exists()
+        {
+            return match crate::image_archive::materialize_image_archive(&mount_point) {
+                Ok(dir) => {
+                    info!(layers_dir = %dir.display(), "image archive flattened via crane");
+                    Some(dir)
+                }
+                Err(e) => {
+                    error!(error = %e, "failed to flatten image archive with crane");
+                    None
+                }
+            };
+        }
+
         // List contents for debugging (only at debug level to avoid boot overhead)
         if let Ok(entries) = std::fs::read_dir(&mount_point) {
             let layer_dirs: Vec<_> = entries
@@ -324,6 +344,44 @@ pub fn init_packed_layers() -> Option<PathBuf> {
 /// Get the packed layers directory if available.
 pub fn get_packed_layers_dir() -> Option<&'static PathBuf> {
     PACKED_LAYERS_DIR.get_or_init(init_packed_layers).as_ref()
+}
+
+/// OCI image-config fields needed to populate an [`ImageInfo`]. Shared by the
+/// registry-pull, cached-image, and packed/archive paths so config parsing
+/// lives in exactly one place.
+struct ImageConfigFields {
+    architecture: String,
+    os: String,
+    created: Option<String>,
+    entrypoint: Vec<String>,
+    cmd: Vec<String>,
+    env: Vec<String>,
+    workdir: Option<String>,
+    user: Option<String>,
+}
+
+/// Parse the OCI image-config JSON into the fields used by [`ImageInfo`].
+fn parse_image_config_fields(config_json: &serde_json::Value) -> ImageConfigFields {
+    let oci_config = &config_json["config"];
+    ImageConfigFields {
+        architecture: config_json["architecture"]
+            .as_str()
+            .unwrap_or("unknown")
+            .to_string(),
+        os: config_json["os"].as_str().unwrap_or("linux").to_string(),
+        created: config_json["created"].as_str().map(String::from),
+        entrypoint: json_string_array(oci_config, "Entrypoint"),
+        cmd: json_string_array(oci_config, "Cmd"),
+        env: json_string_array(oci_config, "Env"),
+        workdir: oci_config["WorkingDir"]
+            .as_str()
+            .filter(|s| !s.is_empty())
+            .map(String::from),
+        user: oci_config["User"]
+            .as_str()
+            .filter(|s| !s.is_empty())
+            .map(String::from),
+    }
 }
 
 /// Initialize volume mounts at boot by reading SMOLVM_MOUNT_* env vars.
@@ -448,67 +506,55 @@ fn create_packed_image_info(image: &str, packed_dir: &Path) -> Result<ImageInfo>
         }
     }
 
-    // Determine architecture from environment or default
+    // Architecture defaults to the build target when no config is present
+    // (e.g. bare `.smolmachine` layers without an image config).
     #[cfg(target_arch = "aarch64")]
-    let default_architecture = "arm64".to_string();
+    let default_architecture = "arm64";
     #[cfg(target_arch = "x86_64")]
-    let default_architecture = "amd64".to_string();
+    let default_architecture = "amd64";
     #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
-    let default_architecture = "unknown".to_string();
+    let default_architecture = "unknown";
 
     // Recover the OCI image config when present. `.smolmachine` packs carry it
-    // in the PackManifest, but local image archives (docker/podman save) drop a
-    // `config.json` beside the layers. Parse the same fields the registry-pull
-    // path reads so Entrypoint/Cmd/Env/WorkingDir/User actually take effect.
-    let mut entrypoint = Vec::new();
-    let mut cmd = Vec::new();
-    let mut env = Vec::new();
-    let mut workdir = None;
-    let mut user = None;
-    let mut created = None;
-    let mut architecture = default_architecture;
-
-    let config_path = packed_dir.join("config.json");
-    if config_path.exists() {
-        if let Ok(config_content) = std::fs::read_to_string(&config_path) {
-            if let Ok(config_json) = serde_json::from_str::<serde_json::Value>(&config_content) {
-                if let Some(arch) = config_json["architecture"].as_str() {
-                    architecture = arch.to_string();
-                }
-                created = config_json["created"].as_str().map(String::from);
-                let oci_config = &config_json["config"];
-                if oci_config.is_object() {
-                    entrypoint = json_string_array(oci_config, "Entrypoint");
-                    cmd = json_string_array(oci_config, "Cmd");
-                    env = json_string_array(oci_config, "Env");
-                    workdir = oci_config["WorkingDir"]
-                        .as_str()
-                        .filter(|s| !s.is_empty())
-                        .map(String::from);
-                    user = oci_config["User"]
-                        .as_str()
-                        .filter(|s| !s.is_empty())
-                        .map(String::from);
-                }
-            }
-        }
-    }
+    // in the PackManifest, but local image archives drop a `config.json` beside
+    // the flattened layer (written by `write_archive_config`). Parse it with the
+    // same helper the registry-pull path uses so Entrypoint/Cmd/Env/WorkingDir/
+    // User take effect identically.
+    let config = packed_image_config(packed_dir);
+    let architecture = config
+        .as_ref()
+        .map(|c| c.architecture.clone())
+        .unwrap_or_else(|| default_architecture.to_string());
 
     Ok(ImageInfo {
         reference: image.to_string(),
         digest: "packed".to_string(), // No real digest available for packed images
         size: total_size,
-        created,
+        created: config.as_ref().and_then(|c| c.created.clone()),
         architecture,
-        os: "linux".to_string(),
+        os: config
+            .as_ref()
+            .map(|c| c.os.clone())
+            .unwrap_or_else(|| "linux".to_string()),
         layer_count: layer_dirs.len(),
         layers: layer_dirs,
-        entrypoint,
-        cmd,
-        env,
-        workdir,
-        user,
+        entrypoint: config
+            .as_ref()
+            .map(|c| c.entrypoint.clone())
+            .unwrap_or_default(),
+        cmd: config.as_ref().map(|c| c.cmd.clone()).unwrap_or_default(),
+        env: config.as_ref().map(|c| c.env.clone()).unwrap_or_default(),
+        workdir: config.as_ref().and_then(|c| c.workdir.clone()),
+        user: config.and_then(|c| c.user),
     })
+}
+
+/// Read and parse `<packed_dir>/config.json` if present (best-effort).
+fn packed_image_config(packed_dir: &Path) -> Option<ImageConfigFields> {
+    let config_path = packed_dir.join("config.json");
+    let content = std::fs::read_to_string(&config_path).ok()?;
+    let config_json = serde_json::from_str::<serde_json::Value>(&content).ok()?;
+    Some(parse_image_config_fields(&config_json))
 }
 
 /// Error type for storage operations.
@@ -1269,41 +1315,22 @@ where
     }
 
     // Build ImageInfo
-    let architecture = config_json["architecture"]
-        .as_str()
-        .unwrap_or("unknown")
-        .to_string();
-    let os = config_json["os"].as_str().unwrap_or("linux").to_string();
-    let created = config_json["created"].as_str().map(String::from);
-
-    // Extract OCI config fields (Entrypoint, Cmd, Env, WorkingDir, User)
-    let oci_config = &config_json["config"];
-    let entrypoint = json_string_array(oci_config, "Entrypoint");
-    let cmd = json_string_array(oci_config, "Cmd");
-    let env = json_string_array(oci_config, "Env");
-    let workdir = oci_config["WorkingDir"]
-        .as_str()
-        .filter(|s| !s.is_empty())
-        .map(String::from);
-    let user = oci_config["User"]
-        .as_str()
-        .filter(|s| !s.is_empty())
-        .map(String::from);
+    let fields = parse_image_config_fields(&config_json);
 
     Ok(ImageInfo {
         reference: image.to_string(),
         digest: config_digest.to_string(),
         size: total_size,
-        created,
-        architecture,
-        os,
+        created: fields.created,
+        architecture: fields.architecture,
+        os: fields.os,
         layer_count: layers.len(),
         layers,
-        entrypoint,
-        cmd,
-        env,
-        workdir,
-        user,
+        entrypoint: fields.entrypoint,
+        cmd: fields.cmd,
+        env: fields.env,
+        workdir: fields.workdir,
+        user: fields.user,
     })
 }
 
@@ -1352,12 +1379,7 @@ pub fn query_image(image: &str) -> Result<Option<ImageInfo>> {
     let config_json: serde_json::Value =
         serde_json::from_str(&config).map_err(|e| StorageError::parse_error("config", e))?;
 
-    let architecture = config_json["architecture"]
-        .as_str()
-        .unwrap_or("unknown")
-        .to_string();
-    let os = config_json["os"].as_str().unwrap_or("linux").to_string();
-    let created = config_json["created"].as_str().map(String::from);
+    let fields = parse_image_config_fields(&config_json);
 
     // Verify all layers exist and calculate total size
     let mut total_size = 0u64;
@@ -1376,34 +1398,20 @@ pub fn query_image(image: &str) -> Result<Option<ImageInfo>> {
         }
     }
 
-    // Extract OCI config fields
-    let oci_config = &config_json["config"];
-    let entrypoint = json_string_array(oci_config, "Entrypoint");
-    let cmd = json_string_array(oci_config, "Cmd");
-    let env = json_string_array(oci_config, "Env");
-    let workdir = oci_config["WorkingDir"]
-        .as_str()
-        .filter(|s| !s.is_empty())
-        .map(String::from);
-    let user = oci_config["User"]
-        .as_str()
-        .filter(|s| !s.is_empty())
-        .map(String::from);
-
     Ok(Some(ImageInfo {
         reference: image.to_string(),
         digest: config_digest.to_string(),
         size: total_size,
-        created,
-        architecture,
-        os,
+        created: fields.created,
+        architecture: fields.architecture,
+        os: fields.os,
         layer_count: layers.len(),
         layers,
-        entrypoint,
-        cmd,
-        env,
-        workdir,
-        user,
+        entrypoint: fields.entrypoint,
+        cmd: fields.cmd,
+        env: fields.env,
+        workdir: fields.workdir,
+        user: fields.user,
     }))
 }
 
@@ -3314,5 +3322,46 @@ mod tests {
             workspace_link.is_dir(),
             "/workspace should now be a directory"
         );
+    }
+
+    #[test]
+    fn test_parse_image_config_fields_extracts_oci_config() {
+        let config = serde_json::json!({
+            "architecture": "arm64",
+            "os": "linux",
+            "created": "2024-01-01T00:00:00Z",
+            "config": {
+                "Entrypoint": ["/app/run"],
+                "Cmd": ["serve", "--port", "8080"],
+                "Env": ["PATH=/usr/bin", "APP=1"],
+                "WorkingDir": "/app",
+                "User": "app",
+            }
+        });
+
+        let fields = parse_image_config_fields(&config);
+        assert_eq!(fields.architecture, "arm64");
+        assert_eq!(fields.os, "linux");
+        assert_eq!(fields.created.as_deref(), Some("2024-01-01T00:00:00Z"));
+        assert_eq!(fields.entrypoint, vec!["/app/run"]);
+        assert_eq!(fields.cmd, vec!["serve", "--port", "8080"]);
+        assert_eq!(fields.env, vec!["PATH=/usr/bin", "APP=1"]);
+        assert_eq!(fields.workdir.as_deref(), Some("/app"));
+        assert_eq!(fields.user.as_deref(), Some("app"));
+    }
+
+    #[test]
+    fn test_parse_image_config_fields_applies_defaults() {
+        // Missing config/architecture/os fall back to sane defaults; empty
+        // WorkingDir/User are treated as absent.
+        let config = serde_json::json!({ "config": { "WorkingDir": "", "User": "" } });
+        let fields = parse_image_config_fields(&config);
+        assert_eq!(fields.architecture, "unknown");
+        assert_eq!(fields.os, "linux");
+        assert!(fields.created.is_none());
+        assert!(fields.entrypoint.is_empty());
+        assert!(fields.cmd.is_empty());
+        assert!(fields.workdir.is_none());
+        assert!(fields.user.is_none());
     }
 }

--- a/crates/smolvm-protocol/src/image_ref.rs
+++ b/crates/smolvm-protocol/src/image_ref.rs
@@ -37,6 +37,16 @@
 ///            "ghcr.io/owner/repo:v1");
 /// ```
 pub fn normalize_image_ref(image: &str) -> String {
+    // `local:<hash>` references denote a local image archive that the CLI has
+    // already extracted into its content-addressed cache. These are not
+    // registry references, so pass them through untouched. The host transport
+    // spellings (stdin `-`, `.tar`/`.tar.gz` files) are classified and resolved
+    // to `local:<hash>` CLI-side before they ever reach this function, so only
+    // the resolved scheme needs handling here.
+    if image.starts_with("local:") {
+        return image.to_string();
+    }
+
     // 1. Resolve index.docker.io alias.
     let owned;
     let image = if let Some(rest) = image.strip_prefix("index.docker.io/") {
@@ -129,6 +139,9 @@ mod tests {
             ("ghcr.io/owner/repo:v1", "ghcr.io/owner/repo:v1"),
             // Port in registry — colon-detection must not confuse port with tag.
             ("localhost:5000/myimage:dev", "localhost:5000/myimage:dev"),
+            // Resolved local image archive — passed through verbatim, no
+            // normalization (the CLI owns transport-form classification).
+            ("local:0123456789abcdef", "local:0123456789abcdef"),
         ];
 
         for (input, expected) in cases {

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -548,10 +548,32 @@ impl RunCmd {
             None
         };
 
+        // Resolve image: CLI > Smolfile > None (bare VM)
+        let image = self.image.clone().or(params.image.clone());
+
+        // Reading the image from stdin consumes the same stream an interactive
+        // session needs, so the two are mutually exclusive.
+        if image.as_deref() == Some("-") && (interactive || tty) {
+            return Err(Error::config(
+                "machine run",
+                "cannot read an image from stdin (--image -) together with -i/-t; \
+                 stdin is consumed by the image archive",
+            ));
+        }
+
+        // Image archives (stdin pipe / `.tar` files) are extracted on the host
+        // and mounted via virtiofs instead of being pulled from a registry.
+        let archive = smolvm::image_archive::resolve_if_archive(image.as_deref())?;
+        let is_image_archive = archive.is_some();
+        let (packed_layers_dir, resolved_image) = match archive {
+            Some((layers_dir, resolved)) => (Some(layers_dir), Some(resolved)),
+            None => (None, image.clone()),
+        };
+
         let features = smolvm::agent::LaunchFeatures {
             ssh_agent_socket,
             dns_filter_hosts: params.dns_filter_hosts.clone(),
-            packed_layers_dir: None,
+            packed_layers_dir,
             extra_disks: Vec::new(),
         };
 
@@ -582,11 +604,11 @@ impl RunCmd {
         // exec (which has its own SIGINT handling).
         let sigint_guard = manager.child_pid().map(smolvm::process::SigintGuard::new);
 
-        // Resolve image: CLI > Smolfile > None (bare VM)
-        let image = self.image.clone().or(params.image.clone());
-
-        // Pull image if one is specified
-        let image_info = if let Some(ref img) = image {
+        // Pull image if one is specified. Image archives are already mounted via
+        // virtiofs (packed layers), so no registry pull is performed.
+        let image_info = if is_image_archive {
+            None
+        } else if let Some(ref img) = resolved_image {
             match crate::cli::pull_with_progress(&mut client, img, self.oci_platform.as_deref()) {
                 Ok(info) => Some(info),
                 Err(e) if !params.net => {
@@ -638,7 +660,7 @@ impl RunCmd {
                 &mut client,
                 &params.init,
                 vm_common::InitRunContext {
-                    image: image.as_deref(),
+                    image: resolved_image.as_deref(),
                     image_info: image_info.as_ref(),
                     env: &init_env,
                     workdir: params.workdir.as_deref(),
@@ -686,7 +708,7 @@ impl RunCmd {
         let mount_bindings = mounts_to_virtiofs_bindings(&mounts);
 
         // Two modes: with image or bare VM (no image)
-        if let Some(ref img) = image {
+        if let Some(ref img) = resolved_image {
             let defaults = vm_common::resolve_image_runtime_defaults(
                 image_info.as_ref(),
                 &env,
@@ -1460,6 +1482,17 @@ impl CreateCmd {
         }
         PortMapping::check_duplicates(&params.port)
             .map_err(|e| smolvm::Error::config("validate ports", e))?;
+
+        // Image archives must be consumed now: a stdin pipe is only available at
+        // create time, not on later `machine start`. Extract into the
+        // content-addressed cache and persist the resolved `local:<hash>`
+        // reference so subsequent starts resolve straight from the cache.
+        if let Some((_layers_dir, resolved)) =
+            smolvm::image_archive::resolve_if_archive(params.image.as_deref())?
+        {
+            params.image = Some(resolved);
+        }
+
         vm_common::create_vm(params)
     }
 

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -604,10 +604,14 @@ impl RunCmd {
         // exec (which has its own SIGINT handling).
         let sigint_guard = manager.child_pid().map(smolvm::process::SigintGuard::new);
 
-        // Pull image if one is specified. Image archives are already mounted via
-        // virtiofs (packed layers), so no registry pull is performed.
+        // Pull image if one is specified. Image archives are flattened in-VM by
+        // crane (packed layers) rather than pulled from a registry, but still
+        // return ImageInfo so the archive's Entrypoint/Cmd/Env take effect.
         let image_info = if is_image_archive {
-            None
+            match resolved_image {
+                Some(ref img) => Some(crate::cli::resolve_archive_image_info(&mut client, img)?),
+                None => None,
+            }
         } else if let Some(ref img) = resolved_image {
             match crate::cli::pull_with_progress(&mut client, img, self.oci_platform.as_deref()) {
                 Ok(info) => Some(info),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -213,3 +213,17 @@ pub fn pull_with_progress(
     );
     result
 }
+
+/// Resolve image metadata for a locally-staged image archive (`local:<hash>`).
+///
+/// The agent short-circuits to the crane-flattened packed layers instead of
+/// contacting a registry, so this recovers the archive's Entrypoint/Cmd/Env
+/// without any network access — and without the registry-pull progress output,
+/// which would otherwise print a misleading "Pulling image local:<hash>".
+pub fn resolve_archive_image_info(
+    client: &mut smolvm::agent::AgentClient,
+    image: &str,
+) -> smolvm::Result<smolvm_protocol::ImageInfo> {
+    eprintln!("Preparing image archive...");
+    client.pull_with_registry_config_and_progress(image, None, |_, _, _| {})
+}

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -677,6 +677,15 @@ pub fn start_vm_named(name: &str) -> smolvm::Result<()> {
         std::mem::forget(layers_lease);
     }
 
+    // Image archive: the record stores a `local:<hash>` reference whose layers
+    // were extracted into the content-addressed cache at create time. Resolve
+    // it from the cache and mount via virtiofs instead of pulling.
+    let archive = smolvm::image_archive::resolve_if_archive(record.image.as_deref())?;
+    let is_image_archive = archive.is_some();
+    if let Some((layers_dir, _resolved)) = archive {
+        features.packed_layers_dir = Some(layers_dir);
+    }
+
     let _ = manager
         .ensure_running_with_full_config(mounts, ports, resources, features)
         .map_err(|e| Error::agent("start machine", e.to_string()))?;
@@ -700,7 +709,7 @@ pub fn start_vm_named(name: &str) -> smolvm::Result<()> {
     // starts, skip both — image manifests/layers persist on the storage disk
     // and the container overlay is remounted (not recreated).
     if !record.init_completed {
-        let image_info = if record.source_smolmachine.is_some() {
+        let image_info = if record.source_smolmachine.is_some() || is_image_archive {
             // Layers already mounted via virtiofs — no pull needed.
             None
         } else if let Some(ref image) = record.image {

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -709,9 +709,18 @@ pub fn start_vm_named(name: &str) -> smolvm::Result<()> {
     // starts, skip both — image manifests/layers persist on the storage disk
     // and the container overlay is remounted (not recreated).
     if !record.init_completed {
-        let image_info = if record.source_smolmachine.is_some() || is_image_archive {
-            // Layers already mounted via virtiofs — no pull needed.
+        let image_info = if record.source_smolmachine.is_some() {
+            // .smolmachine layers already mounted via virtiofs; config travels
+            // in the PackManifest, so no pull is needed.
             None
+        } else if is_image_archive {
+            // Archive flattened in-VM by crane; recover its config (no network).
+            match record.image {
+                Some(ref image) => {
+                    Some(crate::cli::resolve_archive_image_info(&mut client, image)?)
+                }
+                None => None,
+            }
         } else if let Some(ref image) = record.image {
             eprintln!("Pulling {}...", image);
             Some(crate::cli::pull_with_progress(&mut client, image, None)?)
@@ -1720,7 +1729,7 @@ mod init_runner_tests {
             &[],
             "vm",
         );
-        assert_eq!(config.image, "debian:slim");
+        assert_eq!(config.image, "docker.io/library/debian:slim");
         assert_eq!(config.env, env);
         assert_eq!(config.workdir.as_deref(), Some("/work"));
         assert_eq!(config.user.as_deref(), Some("steam"));

--- a/src/image_archive.rs
+++ b/src/image_archive.rs
@@ -1,0 +1,594 @@
+//! Image archive support.
+//!
+//! Consumes a Docker- or OCI-format image archive produced by `docker save` /
+//! `podman save` — piped on stdin (`-`) or stored as a `.tar`/`.tar.gz` file —
+//! and extracts its layers into a content-addressed cache laid out exactly like
+//! the packed-layers directory that `.smolmachine` artifacts already use. The
+//! extracted directory is then mounted into the VM via virtiofs
+//! (`packed_layers_dir`). The outer archive and the individual layer blobs may
+//! be gzip-compressed; gzip is detected from magic bytes and decompressed
+//! transparently.
+//!
+//! smolvm stays strictly on the image-source / transport side: it only reads a
+//! tar stream and unpacks layers. It never contacts a registry, builds an
+//! image, or invokes a container daemon — the in-VM runtime executes the
+//! mounted layers exactly as it does for a registry pull.
+
+use std::fs;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+use crate::error::{Error, Result};
+
+const EXTRACT_MARKER: &str = ".smolvm-extracted";
+
+/// True when `image_ref` denotes an image archive (stdin pipe, `.tar`/`.tar.gz`
+/// file, or a resolved `local:<hash>` cache reference) rather than a remote
+/// registry reference.
+pub fn is_image_archive(image_ref: &str) -> bool {
+    image_ref == "-"
+        || image_ref.starts_with("local:")
+        || image_ref.ends_with(".tar")
+        || image_ref.ends_with(".tar.gz")
+}
+
+/// Prepare an image archive for mounting via virtiofs.
+///
+/// Accepts a stdin pipe (`-`), a `.tar`/`.tar.gz` file path, or an
+/// already-resolved `local:<sha256>` cache reference. Returns the path to the
+/// extracted layers directory and the canonical `local:<sha256>` reference that
+/// callers should persist so subsequent boots resolve straight from the cache.
+pub fn prepare_image_archive(image_ref: &str) -> Result<(PathBuf, String)> {
+    // Already-resolved cache reference (e.g. on `machine start`): the source
+    // archive is gone, so this must resolve from the cache or fail clearly.
+    if let Some(hash) = image_ref.strip_prefix("local:") {
+        let layers_dir = cache_layers_dir(hash)?;
+        let marker = cache_dir_of(&layers_dir).join(EXTRACT_MARKER);
+        if marker.exists() && layers_dir.exists() {
+            return Ok((layers_dir, image_ref.to_string()));
+        }
+        return Err(Error::config(
+            "prepare_image_archive",
+            format!(
+                "cached image archive '{image_ref}' not found. Re-pipe the source archive (e.g. `docker save IMAGE | smolvm ...`)."
+            ),
+        ));
+    }
+
+    // Obtain a seekable handle to the archive plus the SHA-256 of its bytes
+    // (the cache key). A stdin stream is single-pass, so it is buffered to a
+    // tempfile while hashing; on-disk archives are hashed in place and reopened
+    // for extraction — no second full-size copy.
+    let mut tmp_guard = None;
+    let (hash, archive_file) = if image_ref == "-" {
+        let mut tmp = tempfile::NamedTempFile::new().map_err(|e| {
+            Error::config(
+                "prepare_image_archive",
+                format!("failed to create temp file: {e}"),
+            )
+        })?;
+        let mut stdin = std::io::stdin().lock();
+        let hash = buffer_and_hash(&mut stdin, tmp.as_file_mut())?;
+        let file = tmp.reopen().map_err(|e| {
+            Error::config(
+                "prepare_image_archive",
+                format!("failed to reopen temp archive: {e}"),
+            )
+        })?;
+        tmp_guard = Some(tmp);
+        (hash, file)
+    } else {
+        let path = Path::new(image_ref);
+        if !path.exists() {
+            return Err(Error::config(
+                "prepare_image_archive",
+                format!("image archive not found: {image_ref}"),
+            ));
+        }
+        let hash = hash_file(path)?;
+        let file = fs::File::open(path).map_err(|e| {
+            Error::config(
+                "prepare_image_archive",
+                format!("failed to open archive '{image_ref}': {e}"),
+            )
+        })?;
+        (hash, file)
+    };
+    // Keep the stdin tempfile (if any) alive until extraction completes.
+    let _tmp_guard = tmp_guard;
+
+    let layers_dir = cache_layers_dir(&hash)?;
+    let cache_dir = cache_dir_of(&layers_dir);
+    let marker = cache_dir.join(EXTRACT_MARKER);
+    let resolved_ref = format!("local:{hash}");
+
+    // Cache hit — extraction already complete.
+    if marker.exists() && layers_dir.exists() {
+        return Ok((layers_dir, resolved_ref));
+    }
+
+    // Clean any stale/partial extraction before re-extracting.
+    if cache_dir.exists() {
+        let _ = fs::remove_dir_all(&cache_dir);
+    }
+    fs::create_dir_all(&layers_dir).map_err(|e| {
+        Error::config(
+            "prepare_image_archive",
+            format!("failed to create layers dir: {e}"),
+        )
+    })?;
+
+    let result =
+        decompress_file(archive_file).and_then(|reader| extract_archive(reader, &layers_dir));
+    if let Err(e) = result {
+        let _ = fs::remove_dir_all(&cache_dir);
+        return Err(e);
+    }
+
+    fs::write(&marker, "").map_err(|e| {
+        Error::config(
+            "prepare_image_archive",
+            format!("failed to write extraction marker: {e}"),
+        )
+    })?;
+
+    Ok((layers_dir, resolved_ref))
+}
+
+/// Resolve an optional image reference, extracting it when it is a local image
+/// archive (stdin pipe, `.tar`/`.tar.gz` file, or resolved `local:<hash>`).
+///
+/// Returns `Some((packed_layers_dir, resolved_ref))` for archives — the layers
+/// directory to mount via virtiofs and the canonical `local:<hash>` reference
+/// to persist — or `None` when `image` is absent or a normal registry ref.
+pub fn resolve_if_archive(image: Option<&str>) -> Result<Option<(PathBuf, String)>> {
+    match image {
+        Some(img) if is_image_archive(img) => prepare_image_archive(img).map(Some),
+        _ => Ok(None),
+    }
+}
+
+/// `~/.cache/smolvm/image-archives/<hash>/layers`.
+fn cache_layers_dir(hash: &str) -> Result<PathBuf> {
+    let base = dirs::cache_dir()
+        .ok_or_else(|| Error::config("prepare_image_archive", "no cache directory available"))?;
+    Ok(base
+        .join("smolvm")
+        .join("image-archives")
+        .join(hash)
+        .join("layers"))
+}
+
+/// The parent (`<hash>`) directory of a `.../layers` path.
+fn cache_dir_of(layers_dir: &Path) -> PathBuf {
+    layers_dir
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| layers_dir.to_path_buf())
+}
+
+/// Stream `reader` into `out` while computing the SHA-256 of the bytes.
+fn buffer_and_hash<R: Read>(reader: &mut R, out: &mut fs::File) -> Result<String> {
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = reader.read(&mut buf).map_err(|e| {
+            Error::config(
+                "prepare_image_archive",
+                format!("failed to read archive: {e}"),
+            )
+        })?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+        out.write_all(&buf[..n]).map_err(|e| {
+            Error::config(
+                "prepare_image_archive",
+                format!("failed to buffer archive: {e}"),
+            )
+        })?;
+    }
+    out.flush().map_err(|e| {
+        Error::config(
+            "prepare_image_archive",
+            format!("failed to flush archive: {e}"),
+        )
+    })?;
+    Ok(hex::encode(hasher.finalize()))
+}
+
+/// Unpack an image archive (Docker or OCI layout) into `layers_dir`.
+fn extract_archive<R: Read>(reader: R, layers_dir: &Path) -> Result<()> {
+    let staging = tempfile::tempdir().map_err(|e| {
+        Error::config(
+            "extract_archive",
+            format!("failed to create staging dir: {e}"),
+        )
+    })?;
+    let mut archive = tar::Archive::new(reader);
+    archive.unpack(staging.path()).map_err(|e| {
+        Error::config(
+            "extract_archive",
+            format!("failed to unpack image archive: {e}"),
+        )
+    })?;
+
+    let root = staging.path();
+    if root.join("manifest.json").exists() {
+        extract_docker_archive(root, layers_dir)
+    } else if root.join("index.json").exists() {
+        extract_oci_archive(root, layers_dir)
+    } else {
+        Err(Error::config(
+            "extract_archive",
+            "unrecognized image archive: no manifest.json (docker) or index.json (OCI) found",
+        ))
+    }
+}
+
+/// Extract a `docker save` archive (`manifest.json` + uncompressed layer tars).
+fn extract_docker_archive(root: &Path, layers_dir: &Path) -> Result<()> {
+    let manifest = read_json(&root.join("manifest.json"))?;
+    let first = manifest
+        .as_array()
+        .and_then(|a| a.first())
+        .ok_or_else(|| Error::config("extract_docker_archive", "empty manifest.json"))?;
+
+    let config_file = first["Config"]
+        .as_str()
+        .ok_or_else(|| Error::config("extract_docker_archive", "manifest.json missing Config"))?;
+    copy_config(&root.join(config_file), layers_dir)?;
+
+    let layers = first["Layers"]
+        .as_array()
+        .ok_or_else(|| Error::config("extract_docker_archive", "manifest.json missing Layers"))?;
+    for (index, layer) in layers.iter().enumerate() {
+        let rel = layer.as_str().ok_or_else(|| {
+            Error::config(
+                "extract_docker_archive",
+                "invalid layer path in manifest.json",
+            )
+        })?;
+        let name = rel.replace('/', "_").replace(".tar", "");
+        extract_layer(&root.join(rel), &layer_dest(layers_dir, index, &name))?;
+    }
+    Ok(())
+}
+
+/// Extract an OCI layout archive (`index.json` + gzip layer blobs).
+fn extract_oci_archive(root: &Path, layers_dir: &Path) -> Result<()> {
+    let index = read_json(&root.join("index.json"))?;
+    let manifest_digest = index["manifests"]
+        .as_array()
+        .and_then(|manifests| pick_manifest(manifests))
+        .and_then(|m| m["digest"].as_str())
+        .ok_or_else(|| Error::config("extract_oci_archive", "index.json has no manifest entry"))?;
+
+    let manifest = resolve_manifest(root, manifest_digest)?;
+
+    let config_digest = manifest["config"]["digest"]
+        .as_str()
+        .ok_or_else(|| Error::config("extract_oci_archive", "manifest missing config digest"))?;
+    copy_config(&blob_path(root, config_digest)?, layers_dir)?;
+
+    let layers = manifest["layers"]
+        .as_array()
+        .ok_or_else(|| Error::config("extract_oci_archive", "manifest missing layers"))?;
+    for (index, layer) in layers.iter().enumerate() {
+        let digest = layer["digest"].as_str().ok_or_else(|| {
+            Error::config("extract_oci_archive", "invalid layer digest in manifest")
+        })?;
+        let short = digest.strip_prefix("sha256:").unwrap_or(digest);
+        let short = &short[..short.len().min(12)];
+        extract_layer(
+            &blob_path(root, digest)?,
+            &layer_dest(layers_dir, index, short),
+        )?;
+    }
+    Ok(())
+}
+
+/// Follow `index.json` entries (descending through nested indexes) until an
+/// image manifest with a `layers` array is found.
+fn resolve_manifest(root: &Path, digest: &str) -> Result<serde_json::Value> {
+    let mut current = digest.to_string();
+    for _ in 0..4 {
+        let blob = read_json(&blob_path(root, &current)?)?;
+        if blob.get("layers").is_some() {
+            return Ok(blob);
+        }
+        let next = blob["manifests"]
+            .as_array()
+            .and_then(|manifests| pick_manifest(manifests))
+            .and_then(|m| m["digest"].as_str().map(String::from));
+        match next {
+            Some(d) => current = d,
+            None => break,
+        }
+    }
+    Err(Error::config(
+        "extract_oci_archive",
+        "could not resolve image manifest from index.json",
+    ))
+}
+
+/// Prefer the manifest entry matching the host architecture, else the first.
+fn pick_manifest(manifests: &[serde_json::Value]) -> Option<&serde_json::Value> {
+    let arch = host_oci_arch();
+    manifests
+        .iter()
+        .find(|m| {
+            m["platform"]["architecture"].as_str() == Some(arch)
+                && m["platform"]["os"].as_str().is_none_or(|os| os == "linux")
+        })
+        .or_else(|| manifests.first())
+}
+
+/// Host architecture using OCI naming (`amd64`/`arm64`).
+fn host_oci_arch() -> &'static str {
+    match std::env::consts::ARCH {
+        "x86_64" => "amd64",
+        "aarch64" => "arm64",
+        other => other,
+    }
+}
+
+/// Map an OCI `algo:hex` digest to its `blobs/<algo>/<hex>` path.
+fn blob_path(root: &Path, digest: &str) -> Result<PathBuf> {
+    let (algo, hex) = digest
+        .split_once(':')
+        .ok_or_else(|| Error::config("extract_oci_archive", format!("invalid digest: {digest}")))?;
+    Ok(root.join("blobs").join(algo).join(hex))
+}
+
+/// Copy the image config blob to `<layers_dir>/config.json` (read by the agent
+/// to recover Entrypoint/Cmd/Env), if present.
+fn copy_config(src: &Path, layers_dir: &Path) -> Result<()> {
+    if src.exists() {
+        fs::copy(src, layers_dir.join("config.json")).map_err(|e| {
+            Error::config(
+                "extract_archive",
+                format!("failed to copy image config: {e}"),
+            )
+        })?;
+    }
+    Ok(())
+}
+
+/// Extract a single layer tar (gzip-compressed or plain) into `dest`.
+fn extract_layer(src: &Path, dest: &Path) -> Result<()> {
+    fs::create_dir_all(dest)
+        .map_err(|e| Error::config("extract_layer", format!("failed to create layer dir: {e}")))?;
+    let file = fs::File::open(src).map_err(|e| {
+        Error::config(
+            "extract_layer",
+            format!("failed to open layer '{}': {e}", src.display()),
+        )
+    })?;
+    unpack_tar(decompress_file(file)?, dest)
+}
+
+/// gzip stream identifier (leading magic bytes).
+const GZIP_MAGIC: [u8; 2] = [0x1f, 0x8b];
+
+/// Wrap `file` in a reader that transparently decompresses gzip input, detected
+/// from leading magic bytes; uncompressed input is read as-is.
+///
+/// Used for both the outer image archive (so `.tar.gz` works) and individual
+/// layer blobs (Docker layers are plain; OCI layers are gzip).
+fn decompress_file(mut file: fs::File) -> Result<Box<dyn Read>> {
+    let mut magic = [0u8; 2];
+    let n = read_up_to(&mut file, &mut magic)?;
+    file.seek(SeekFrom::Start(0)).map_err(|e| {
+        Error::config("extract_archive", format!("failed to rewind archive: {e}"))
+    })?;
+    if magic[..n].starts_with(&GZIP_MAGIC) {
+        Ok(Box::new(flate2::read::GzDecoder::new(file)))
+    } else {
+        Ok(Box::new(file))
+    }
+}
+
+/// Read up to `buf.len()` bytes, tolerating short reads and `Interrupted`.
+fn read_up_to<R: Read>(reader: &mut R, buf: &mut [u8]) -> Result<usize> {
+    let mut filled = 0;
+    while filled < buf.len() {
+        match reader.read(&mut buf[filled..]) {
+            Ok(0) => break,
+            Ok(n) => filled += n,
+            Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(e) => {
+                return Err(Error::config(
+                    "extract_archive",
+                    format!("failed to read archive header: {e}"),
+                ))
+            }
+        }
+    }
+    Ok(filled)
+}
+
+/// Stream a file through SHA-256 without copying it, returning the hex digest.
+fn hash_file(path: &Path) -> Result<String> {
+    let mut file = fs::File::open(path).map_err(|e| {
+        Error::config(
+            "prepare_image_archive",
+            format!("failed to open archive '{}': {e}", path.display()),
+        )
+    })?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = file.read(&mut buf).map_err(|e| {
+            Error::config(
+                "prepare_image_archive",
+                format!("failed to read archive: {e}"),
+            )
+        })?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(hex::encode(hasher.finalize()))
+}
+
+/// Unpack a tar stream into `dest`.
+fn unpack_tar<R: Read>(reader: R, dest: &Path) -> Result<()> {
+    let mut archive = tar::Archive::new(reader);
+    archive.unpack(dest).map_err(|e| {
+        Error::config(
+            "extract_layer",
+            format!("failed to extract layer into '{}': {e}", dest.display()),
+        )
+    })
+}
+
+/// `<layers_dir>/<NNNN>_<name>` — the indexed per-layer directory the agent
+/// scans in `create_packed_image_info`.
+fn layer_dest(layers_dir: &Path, index: usize, name: &str) -> PathBuf {
+    layers_dir.join(format!("{index:04}_{name}"))
+}
+
+/// Read and parse a JSON file into a [`serde_json::Value`].
+fn read_json(path: &Path) -> Result<serde_json::Value> {
+    let content = fs::read_to_string(path).map_err(|e| {
+        Error::config(
+            "extract_archive",
+            format!("failed to read '{}': {e}", path.display()),
+        )
+    })?;
+    serde_json::from_str(&content).map_err(|e| {
+        Error::config(
+            "extract_archive",
+            format!("failed to parse '{}': {e}", path.display()),
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use flate2::write::GzEncoder;
+    use flate2::Compression;
+
+    /// Build an in-memory tar archive from `(path, bytes)` entries.
+    fn make_tar(entries: &[(&str, Vec<u8>)]) -> Vec<u8> {
+        let mut builder = tar::Builder::new(Vec::new());
+        for (name, data) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(data.len() as u64);
+            header.set_mode(0o644);
+            builder
+                .append_data(&mut header, name, data.as_slice())
+                .unwrap();
+        }
+        builder.into_inner().unwrap()
+    }
+
+    fn gzip(data: &[u8]) -> Vec<u8> {
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(data).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    /// Write `bytes` to a temp file and return an open, rewound handle to it.
+    fn temp_file_with(bytes: &[u8]) -> fs::File {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(bytes).unwrap();
+        tmp.flush().unwrap();
+        tmp.reopen().unwrap()
+    }
+
+    #[test]
+    fn test_extract_docker_archive_layout() {
+        let layer_tar = make_tar(&[("hello.txt", b"hi".to_vec())]);
+        let config = br#"{"architecture":"amd64","config":{"Cmd":["/bin/sh"]}}"#.to_vec();
+        let manifest = br#"[{"Config":"config.json","Layers":["layer0.tar"]}]"#.to_vec();
+        let archive = make_tar(&[
+            ("manifest.json", manifest),
+            ("config.json", config),
+            ("layer0.tar", layer_tar),
+        ]);
+
+        let layers_dir = tempfile::tempdir().unwrap();
+        extract_archive(archive.as_slice(), layers_dir.path()).unwrap();
+
+        assert!(layers_dir.path().join("config.json").exists());
+        let layer_file = layers_dir.path().join("0000_layer0").join("hello.txt");
+        assert_eq!(std::fs::read_to_string(layer_file).unwrap(), "hi");
+    }
+
+    #[test]
+    fn test_extract_oci_archive_layout() {
+        let layer_tar = make_tar(&[("data.txt", b"oci".to_vec())]);
+        let layer_gz = gzip(&layer_tar);
+        let config = br#"{"architecture":"arm64","config":{"Entrypoint":["/run"]}}"#.to_vec();
+        let manifest =
+            br#"{"config":{"digest":"sha256:cfg"},"layers":[{"digest":"sha256:lyr"}]}"#.to_vec();
+        let index = br#"{"manifests":[{"digest":"sha256:man"}]}"#.to_vec();
+        let archive = make_tar(&[
+            ("oci-layout", br#"{"imageLayoutVersion":"1.0.0"}"#.to_vec()),
+            ("index.json", index),
+            ("blobs/sha256/man", manifest),
+            ("blobs/sha256/cfg", config),
+            ("blobs/sha256/lyr", layer_gz),
+        ]);
+
+        let layers_dir = tempfile::tempdir().unwrap();
+        extract_archive(archive.as_slice(), layers_dir.path()).unwrap();
+
+        assert!(layers_dir.path().join("config.json").exists());
+        let layer_file = layers_dir.path().join("0000_lyr").join("data.txt");
+        assert_eq!(std::fs::read_to_string(layer_file).unwrap(), "oci");
+    }
+
+    #[test]
+    fn test_gzipped_outer_archive() {
+        // `docker save | gzip` / a `.tar.gz` file: the whole archive is gzip
+        // wrapped and must be decompressed before the tar is read.
+        let layer_tar = make_tar(&[("hello.txt", b"hi".to_vec())]);
+        let config = br#"{"architecture":"amd64"}"#.to_vec();
+        let manifest = br#"[{"Config":"config.json","Layers":["layer0.tar"]}]"#.to_vec();
+        let archive = make_tar(&[
+            ("manifest.json", manifest),
+            ("config.json", config),
+            ("layer0.tar", layer_tar),
+        ]);
+
+        let layers_dir = tempfile::tempdir().unwrap();
+        let reader = decompress_file(temp_file_with(&gzip(&archive))).unwrap();
+        extract_archive(reader, layers_dir.path()).unwrap();
+
+        let layer_file = layers_dir.path().join("0000_layer0").join("hello.txt");
+        assert_eq!(std::fs::read_to_string(layer_file).unwrap(), "hi");
+    }
+
+    #[test]
+    fn test_missing_manifest_rejected() {
+        let archive = make_tar(&[("random.txt", b"nope".to_vec())]);
+        let layers_dir = tempfile::tempdir().unwrap();
+        assert!(extract_archive(archive.as_slice(), layers_dir.path()).is_err());
+    }
+
+    #[test]
+    fn test_archive_ref_cache_miss_errors() {
+        let result = prepare_image_archive(
+            "local:0000000000000000000000000000000000000000000000000000000000000000",
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_is_image_archive() {
+        assert!(is_image_archive("-"));
+        assert!(is_image_archive("local:abc"));
+        assert!(is_image_archive("./img.tar"));
+        assert!(is_image_archive("img.tar.gz"));
+        assert!(!is_image_archive("alpine"));
+        assert!(!is_image_archive("ghcr.io/owner/repo:v1"));
+    }
+}

--- a/src/image_archive.rs
+++ b/src/image_archive.rs
@@ -1,28 +1,32 @@
 //! Image archive support.
 //!
-//! Consumes a Docker- or OCI-format image archive produced by `docker save` /
+//! Stages a Docker-format image archive produced by `docker save` /
 //! `podman save` — piped on stdin (`-`) or stored as a `.tar`/`.tar.gz` file —
-//! and extracts its layers into a content-addressed cache laid out exactly like
-//! the packed-layers directory that `.smolmachine` artifacts already use. The
-//! extracted directory is then mounted into the VM via virtiofs
-//! (`packed_layers_dir`). The outer archive and the individual layer blobs may
-//! be gzip-compressed; gzip is detected from magic bytes and decompressed
-//! transparently.
+//! into a content-addressed cache directory, then hands that directory to the
+//! VM through the established `packed_layers_dir` virtiofs mount.
 //!
-//! smolvm stays strictly on the image-source / transport side: it only reads a
-//! tar stream and unpacks layers. It never contacts a registry, builds an
-//! image, or invokes a container daemon — the in-VM runtime executes the
-//! mounted layers exactly as it does for a registry pull.
+//! smolvm stays strictly on the image-source / transport side: it hashes the
+//! archive bytes for caching and stages the raw tar. It never parses layers,
+//! decompresses, or assembles a rootfs on the host — the in-VM `crane` does
+//! that (see the agent's `materialize_image_archive`), exactly as it does for a
+//! registry pull. This keeps archive/extraction responsibilities delegated to
+//! existing OCI tooling rather than baked into smolvm.
 
 use std::fs;
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
 use sha2::{Digest, Sha256};
 
 use crate::error::{Error, Result};
 
-const EXTRACT_MARKER: &str = ".smolvm-extracted";
+/// Marker written once an archive has been fully staged into its cache dir.
+const STAGE_MARKER: &str = ".smolvm-archive";
+
+/// Filename the archive is staged as inside its cache dir. Must match the
+/// agent's `IMAGE_ARCHIVE_FILE`, which the agent looks for to switch into
+/// crane-based archive-ingest mode.
+const ARCHIVE_FILE: &str = "archive.tar";
 
 /// True when `image_ref` denotes an image archive (stdin pipe, `.tar`/`.tar.gz`
 /// file, or a resolved `local:<hash>` cache reference) rather than a remote
@@ -34,20 +38,20 @@ pub fn is_image_archive(image_ref: &str) -> bool {
         || image_ref.ends_with(".tar.gz")
 }
 
-/// Prepare an image archive for mounting via virtiofs.
+/// Stage an image archive for mounting via virtiofs.
 ///
 /// Accepts a stdin pipe (`-`), a `.tar`/`.tar.gz` file path, or an
 /// already-resolved `local:<sha256>` cache reference. Returns the path to the
-/// extracted layers directory and the canonical `local:<sha256>` reference that
+/// cache directory holding the raw archive (to mount through
+/// `packed_layers_dir`) and the canonical `local:<sha256>` reference that
 /// callers should persist so subsequent boots resolve straight from the cache.
 pub fn prepare_image_archive(image_ref: &str) -> Result<(PathBuf, String)> {
     // Already-resolved cache reference (e.g. on `machine start`): the source
     // archive is gone, so this must resolve from the cache or fail clearly.
     if let Some(hash) = image_ref.strip_prefix("local:") {
-        let layers_dir = cache_layers_dir(hash)?;
-        let marker = cache_dir_of(&layers_dir).join(EXTRACT_MARKER);
-        if marker.exists() && layers_dir.exists() {
-            return Ok((layers_dir, image_ref.to_string()));
+        let dir = cache_dir(hash)?;
+        if is_staged(&dir) {
+            return Ok((dir, image_ref.to_string()));
         }
         return Err(Error::config(
             "prepare_image_archive",
@@ -57,13 +61,21 @@ pub fn prepare_image_archive(image_ref: &str) -> Result<(PathBuf, String)> {
         ));
     }
 
-    // Obtain a seekable handle to the archive plus the SHA-256 of its bytes
-    // (the cache key). A stdin stream is single-pass, so it is buffered to a
-    // tempfile while hashing; on-disk archives are hashed in place and reopened
-    // for extraction — no second full-size copy.
-    let mut tmp_guard = None;
-    let (hash, archive_file) = if image_ref == "-" {
-        let mut tmp = tempfile::NamedTempFile::new().map_err(|e| {
+    // Hash the archive bytes (the cache key). A stdin stream is single-pass, so
+    // it is buffered to a tempfile while hashing; on-disk archives are hashed in
+    // place. Either way the raw archive is then staged into the cache as
+    // `archive.tar` for the agent to flatten with crane.
+    if image_ref == "-" {
+        // Buffer into the cache base so the later `persist` (a rename) stays on
+        // the same filesystem as the destination.
+        let base = cache_base()?;
+        fs::create_dir_all(&base).map_err(|e| {
+            Error::config(
+                "prepare_image_archive",
+                format!("failed to create cache dir: {e}"),
+            )
+        })?;
+        let mut tmp = tempfile::NamedTempFile::new_in(&base).map_err(|e| {
             Error::config(
                 "prepare_image_archive",
                 format!("failed to create temp file: {e}"),
@@ -71,14 +83,20 @@ pub fn prepare_image_archive(image_ref: &str) -> Result<(PathBuf, String)> {
         })?;
         let mut stdin = std::io::stdin().lock();
         let hash = buffer_and_hash(&mut stdin, tmp.as_file_mut())?;
-        let file = tmp.reopen().map_err(|e| {
-            Error::config(
-                "prepare_image_archive",
-                format!("failed to reopen temp archive: {e}"),
-            )
+        let dir = cache_dir(&hash)?;
+        let resolved = format!("local:{hash}");
+        if is_staged(&dir) {
+            return Ok((dir, resolved));
+        }
+        stage(&dir, |dest| {
+            tmp.persist(dest).map(|_| ()).map_err(|e| {
+                Error::config(
+                    "prepare_image_archive",
+                    format!("failed to persist staged archive: {e}"),
+                )
+            })
         })?;
-        tmp_guard = Some(tmp);
-        (hash, file)
+        Ok((dir, resolved))
     } else {
         let path = Path::new(image_ref);
         if !path.exists() {
@@ -88,59 +106,20 @@ pub fn prepare_image_archive(image_ref: &str) -> Result<(PathBuf, String)> {
             ));
         }
         let hash = hash_file(path)?;
-        let file = fs::File::open(path).map_err(|e| {
-            Error::config(
-                "prepare_image_archive",
-                format!("failed to open archive '{image_ref}': {e}"),
-            )
-        })?;
-        (hash, file)
-    };
-    // Keep the stdin tempfile (if any) alive until extraction completes.
-    let _tmp_guard = tmp_guard;
-
-    let layers_dir = cache_layers_dir(&hash)?;
-    let cache_dir = cache_dir_of(&layers_dir);
-    let marker = cache_dir.join(EXTRACT_MARKER);
-    let resolved_ref = format!("local:{hash}");
-
-    // Cache hit — extraction already complete.
-    if marker.exists() && layers_dir.exists() {
-        return Ok((layers_dir, resolved_ref));
+        let dir = cache_dir(&hash)?;
+        let resolved = format!("local:{hash}");
+        if is_staged(&dir) {
+            return Ok((dir, resolved));
+        }
+        stage(&dir, |dest| link_or_copy(path, dest))?;
+        Ok((dir, resolved))
     }
-
-    // Clean any stale/partial extraction before re-extracting.
-    if cache_dir.exists() {
-        let _ = fs::remove_dir_all(&cache_dir);
-    }
-    fs::create_dir_all(&layers_dir).map_err(|e| {
-        Error::config(
-            "prepare_image_archive",
-            format!("failed to create layers dir: {e}"),
-        )
-    })?;
-
-    let result =
-        decompress_file(archive_file).and_then(|reader| extract_archive(reader, &layers_dir));
-    if let Err(e) = result {
-        let _ = fs::remove_dir_all(&cache_dir);
-        return Err(e);
-    }
-
-    fs::write(&marker, "").map_err(|e| {
-        Error::config(
-            "prepare_image_archive",
-            format!("failed to write extraction marker: {e}"),
-        )
-    })?;
-
-    Ok((layers_dir, resolved_ref))
 }
 
-/// Resolve an optional image reference, extracting it when it is a local image
+/// Resolve an optional image reference, staging it when it is a local image
 /// archive (stdin pipe, `.tar`/`.tar.gz` file, or resolved `local:<hash>`).
 ///
-/// Returns `Some((packed_layers_dir, resolved_ref))` for archives — the layers
+/// Returns `Some((packed_layers_dir, resolved_ref))` for archives — the cache
 /// directory to mount via virtiofs and the canonical `local:<hash>` reference
 /// to persist — or `None` when `image` is absent or a normal registry ref.
 pub fn resolve_if_archive(image: Option<&str>) -> Result<Option<(PathBuf, String)>> {
@@ -150,23 +129,81 @@ pub fn resolve_if_archive(image: Option<&str>) -> Result<Option<(PathBuf, String
     }
 }
 
-/// `~/.cache/smolvm/image-archives/<hash>/layers`.
-fn cache_layers_dir(hash: &str) -> Result<PathBuf> {
-    let base = dirs::cache_dir()
+/// `~/.cache/smolvm/image-archives`.
+fn cache_base() -> Result<PathBuf> {
+    let base = cache_root()
         .ok_or_else(|| Error::config("prepare_image_archive", "no cache directory available"))?;
-    Ok(base
-        .join("smolvm")
-        .join("image-archives")
-        .join(hash)
-        .join("layers"))
+    Ok(base.join("smolvm").join("image-archives"))
 }
 
-/// The parent (`<hash>`) directory of a `.../layers` path.
-fn cache_dir_of(layers_dir: &Path) -> PathBuf {
-    layers_dir
-        .parent()
-        .map(Path::to_path_buf)
-        .unwrap_or_else(|| layers_dir.to_path_buf())
+/// `~/.cache/smolvm/image-archives/<hash>`.
+fn cache_dir(hash: &str) -> Result<PathBuf> {
+    Ok(cache_base()?.join(hash))
+}
+
+#[cfg(not(test))]
+fn cache_root() -> Option<PathBuf> {
+    dirs::cache_dir()
+}
+
+/// In tests, an optional per-thread cache root keeps the content-addressed
+/// cache inside a tempdir instead of the real `~/.cache`.
+#[cfg(test)]
+fn cache_root() -> Option<PathBuf> {
+    tests::CACHE_ROOT_OVERRIDE
+        .with(|c| c.borrow().clone())
+        .or_else(dirs::cache_dir)
+}
+
+/// True when `dir` holds a fully staged archive (both the tar and its marker).
+fn is_staged(dir: &Path) -> bool {
+    dir.join(STAGE_MARKER).exists() && dir.join(ARCHIVE_FILE).exists()
+}
+
+/// Stage an archive into `dir` by running `place` to put the bytes at
+/// `dir/archive.tar`, then writing the completion marker. Any partial state is
+/// cleaned up on failure so the next attempt starts fresh.
+fn stage<F>(dir: &Path, place: F) -> Result<()>
+where
+    F: FnOnce(&Path) -> Result<()>,
+{
+    if dir.exists() {
+        let _ = fs::remove_dir_all(dir);
+    }
+    fs::create_dir_all(dir).map_err(|e| {
+        Error::config(
+            "prepare_image_archive",
+            format!("failed to create cache dir: {e}"),
+        )
+    })?;
+
+    let archive_path = dir.join(ARCHIVE_FILE);
+    if let Err(e) = place(&archive_path) {
+        let _ = fs::remove_dir_all(dir);
+        return Err(e);
+    }
+
+    if let Err(e) = fs::write(dir.join(STAGE_MARKER), b"") {
+        let _ = fs::remove_dir_all(dir);
+        return Err(Error::config(
+            "prepare_image_archive",
+            format!("failed to write stage marker: {e}"),
+        ));
+    }
+    Ok(())
+}
+
+/// Hardlink `src` to `dest`, falling back to a copy across filesystems.
+fn link_or_copy(src: &Path, dest: &Path) -> Result<()> {
+    if fs::hard_link(src, dest).is_ok() {
+        return Ok(());
+    }
+    fs::copy(src, dest).map(|_| ()).map_err(|e| {
+        Error::config(
+            "prepare_image_archive",
+            format!("failed to stage archive '{}': {e}", src.display()),
+        )
+    })
 }
 
 /// Stream `reader` into `out` while computing the SHA-256 of the bytes.
@@ -200,217 +237,6 @@ fn buffer_and_hash<R: Read>(reader: &mut R, out: &mut fs::File) -> Result<String
     Ok(hex::encode(hasher.finalize()))
 }
 
-/// Unpack an image archive (Docker or OCI layout) into `layers_dir`.
-fn extract_archive<R: Read>(reader: R, layers_dir: &Path) -> Result<()> {
-    let staging = tempfile::tempdir().map_err(|e| {
-        Error::config(
-            "extract_archive",
-            format!("failed to create staging dir: {e}"),
-        )
-    })?;
-    let mut archive = tar::Archive::new(reader);
-    archive.unpack(staging.path()).map_err(|e| {
-        Error::config(
-            "extract_archive",
-            format!("failed to unpack image archive: {e}"),
-        )
-    })?;
-
-    let root = staging.path();
-    if root.join("manifest.json").exists() {
-        extract_docker_archive(root, layers_dir)
-    } else if root.join("index.json").exists() {
-        extract_oci_archive(root, layers_dir)
-    } else {
-        Err(Error::config(
-            "extract_archive",
-            "unrecognized image archive: no manifest.json (docker) or index.json (OCI) found",
-        ))
-    }
-}
-
-/// Extract a `docker save` archive (`manifest.json` + uncompressed layer tars).
-fn extract_docker_archive(root: &Path, layers_dir: &Path) -> Result<()> {
-    let manifest = read_json(&root.join("manifest.json"))?;
-    let first = manifest
-        .as_array()
-        .and_then(|a| a.first())
-        .ok_or_else(|| Error::config("extract_docker_archive", "empty manifest.json"))?;
-
-    let config_file = first["Config"]
-        .as_str()
-        .ok_or_else(|| Error::config("extract_docker_archive", "manifest.json missing Config"))?;
-    copy_config(&root.join(config_file), layers_dir)?;
-
-    let layers = first["Layers"]
-        .as_array()
-        .ok_or_else(|| Error::config("extract_docker_archive", "manifest.json missing Layers"))?;
-    for (index, layer) in layers.iter().enumerate() {
-        let rel = layer.as_str().ok_or_else(|| {
-            Error::config(
-                "extract_docker_archive",
-                "invalid layer path in manifest.json",
-            )
-        })?;
-        let name = rel.replace('/', "_").replace(".tar", "");
-        extract_layer(&root.join(rel), &layer_dest(layers_dir, index, &name))?;
-    }
-    Ok(())
-}
-
-/// Extract an OCI layout archive (`index.json` + gzip layer blobs).
-fn extract_oci_archive(root: &Path, layers_dir: &Path) -> Result<()> {
-    let index = read_json(&root.join("index.json"))?;
-    let manifest_digest = index["manifests"]
-        .as_array()
-        .and_then(|manifests| pick_manifest(manifests))
-        .and_then(|m| m["digest"].as_str())
-        .ok_or_else(|| Error::config("extract_oci_archive", "index.json has no manifest entry"))?;
-
-    let manifest = resolve_manifest(root, manifest_digest)?;
-
-    let config_digest = manifest["config"]["digest"]
-        .as_str()
-        .ok_or_else(|| Error::config("extract_oci_archive", "manifest missing config digest"))?;
-    copy_config(&blob_path(root, config_digest)?, layers_dir)?;
-
-    let layers = manifest["layers"]
-        .as_array()
-        .ok_or_else(|| Error::config("extract_oci_archive", "manifest missing layers"))?;
-    for (index, layer) in layers.iter().enumerate() {
-        let digest = layer["digest"].as_str().ok_or_else(|| {
-            Error::config("extract_oci_archive", "invalid layer digest in manifest")
-        })?;
-        let short = digest.strip_prefix("sha256:").unwrap_or(digest);
-        let short = &short[..short.len().min(12)];
-        extract_layer(
-            &blob_path(root, digest)?,
-            &layer_dest(layers_dir, index, short),
-        )?;
-    }
-    Ok(())
-}
-
-/// Follow `index.json` entries (descending through nested indexes) until an
-/// image manifest with a `layers` array is found.
-fn resolve_manifest(root: &Path, digest: &str) -> Result<serde_json::Value> {
-    let mut current = digest.to_string();
-    for _ in 0..4 {
-        let blob = read_json(&blob_path(root, &current)?)?;
-        if blob.get("layers").is_some() {
-            return Ok(blob);
-        }
-        let next = blob["manifests"]
-            .as_array()
-            .and_then(|manifests| pick_manifest(manifests))
-            .and_then(|m| m["digest"].as_str().map(String::from));
-        match next {
-            Some(d) => current = d,
-            None => break,
-        }
-    }
-    Err(Error::config(
-        "extract_oci_archive",
-        "could not resolve image manifest from index.json",
-    ))
-}
-
-/// Prefer the manifest entry matching the host architecture, else the first.
-fn pick_manifest(manifests: &[serde_json::Value]) -> Option<&serde_json::Value> {
-    let arch = host_oci_arch();
-    manifests
-        .iter()
-        .find(|m| {
-            m["platform"]["architecture"].as_str() == Some(arch)
-                && m["platform"]["os"].as_str().is_none_or(|os| os == "linux")
-        })
-        .or_else(|| manifests.first())
-}
-
-/// Host architecture using OCI naming (`amd64`/`arm64`).
-fn host_oci_arch() -> &'static str {
-    match std::env::consts::ARCH {
-        "x86_64" => "amd64",
-        "aarch64" => "arm64",
-        other => other,
-    }
-}
-
-/// Map an OCI `algo:hex` digest to its `blobs/<algo>/<hex>` path.
-fn blob_path(root: &Path, digest: &str) -> Result<PathBuf> {
-    let (algo, hex) = digest
-        .split_once(':')
-        .ok_or_else(|| Error::config("extract_oci_archive", format!("invalid digest: {digest}")))?;
-    Ok(root.join("blobs").join(algo).join(hex))
-}
-
-/// Copy the image config blob to `<layers_dir>/config.json` (read by the agent
-/// to recover Entrypoint/Cmd/Env), if present.
-fn copy_config(src: &Path, layers_dir: &Path) -> Result<()> {
-    if src.exists() {
-        fs::copy(src, layers_dir.join("config.json")).map_err(|e| {
-            Error::config(
-                "extract_archive",
-                format!("failed to copy image config: {e}"),
-            )
-        })?;
-    }
-    Ok(())
-}
-
-/// Extract a single layer tar (gzip-compressed or plain) into `dest`.
-fn extract_layer(src: &Path, dest: &Path) -> Result<()> {
-    fs::create_dir_all(dest)
-        .map_err(|e| Error::config("extract_layer", format!("failed to create layer dir: {e}")))?;
-    let file = fs::File::open(src).map_err(|e| {
-        Error::config(
-            "extract_layer",
-            format!("failed to open layer '{}': {e}", src.display()),
-        )
-    })?;
-    unpack_tar(decompress_file(file)?, dest)
-}
-
-/// gzip stream identifier (leading magic bytes).
-const GZIP_MAGIC: [u8; 2] = [0x1f, 0x8b];
-
-/// Wrap `file` in a reader that transparently decompresses gzip input, detected
-/// from leading magic bytes; uncompressed input is read as-is.
-///
-/// Used for both the outer image archive (so `.tar.gz` works) and individual
-/// layer blobs (Docker layers are plain; OCI layers are gzip).
-fn decompress_file(mut file: fs::File) -> Result<Box<dyn Read>> {
-    let mut magic = [0u8; 2];
-    let n = read_up_to(&mut file, &mut magic)?;
-    file.seek(SeekFrom::Start(0)).map_err(|e| {
-        Error::config("extract_archive", format!("failed to rewind archive: {e}"))
-    })?;
-    if magic[..n].starts_with(&GZIP_MAGIC) {
-        Ok(Box::new(flate2::read::GzDecoder::new(file)))
-    } else {
-        Ok(Box::new(file))
-    }
-}
-
-/// Read up to `buf.len()` bytes, tolerating short reads and `Interrupted`.
-fn read_up_to<R: Read>(reader: &mut R, buf: &mut [u8]) -> Result<usize> {
-    let mut filled = 0;
-    while filled < buf.len() {
-        match reader.read(&mut buf[filled..]) {
-            Ok(0) => break,
-            Ok(n) => filled += n,
-            Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => {}
-            Err(e) => {
-                return Err(Error::config(
-                    "extract_archive",
-                    format!("failed to read archive header: {e}"),
-                ))
-            }
-        }
-    }
-    Ok(filled)
-}
-
 /// Stream a file through SHA-256 without copying it, returning the hex digest.
 fn hash_file(path: &Path) -> Result<String> {
     let mut file = fs::File::open(path).map_err(|e| {
@@ -436,150 +262,20 @@ fn hash_file(path: &Path) -> Result<String> {
     Ok(hex::encode(hasher.finalize()))
 }
 
-/// Unpack a tar stream into `dest`.
-fn unpack_tar<R: Read>(reader: R, dest: &Path) -> Result<()> {
-    let mut archive = tar::Archive::new(reader);
-    archive.unpack(dest).map_err(|e| {
-        Error::config(
-            "extract_layer",
-            format!("failed to extract layer into '{}': {e}", dest.display()),
-        )
-    })
-}
-
-/// `<layers_dir>/<NNNN>_<name>` — the indexed per-layer directory the agent
-/// scans in `create_packed_image_info`.
-fn layer_dest(layers_dir: &Path, index: usize, name: &str) -> PathBuf {
-    layers_dir.join(format!("{index:04}_{name}"))
-}
-
-/// Read and parse a JSON file into a [`serde_json::Value`].
-fn read_json(path: &Path) -> Result<serde_json::Value> {
-    let content = fs::read_to_string(path).map_err(|e| {
-        Error::config(
-            "extract_archive",
-            format!("failed to read '{}': {e}", path.display()),
-        )
-    })?;
-    serde_json::from_str(&content).map_err(|e| {
-        Error::config(
-            "extract_archive",
-            format!("failed to parse '{}': {e}", path.display()),
-        )
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use flate2::write::GzEncoder;
-    use flate2::Compression;
 
-    /// Build an in-memory tar archive from `(path, bytes)` entries.
-    fn make_tar(entries: &[(&str, Vec<u8>)]) -> Vec<u8> {
-        let mut builder = tar::Builder::new(Vec::new());
-        for (name, data) in entries {
-            let mut header = tar::Header::new_gnu();
-            header.set_size(data.len() as u64);
-            header.set_mode(0o644);
-            builder
-                .append_data(&mut header, name, data.as_slice())
-                .unwrap();
-        }
-        builder.into_inner().unwrap()
+    thread_local! {
+        /// Per-thread cache root override so each test writes into its own
+        /// tempdir (race-free across the parallel test runner).
+        pub(super) static CACHE_ROOT_OVERRIDE: std::cell::RefCell<Option<PathBuf>> =
+            const { std::cell::RefCell::new(None) };
     }
 
-    fn gzip(data: &[u8]) -> Vec<u8> {
-        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
-        encoder.write_all(data).unwrap();
-        encoder.finish().unwrap()
-    }
-
-    /// Write `bytes` to a temp file and return an open, rewound handle to it.
-    fn temp_file_with(bytes: &[u8]) -> fs::File {
-        let mut tmp = tempfile::NamedTempFile::new().unwrap();
-        tmp.write_all(bytes).unwrap();
-        tmp.flush().unwrap();
-        tmp.reopen().unwrap()
-    }
-
-    #[test]
-    fn test_extract_docker_archive_layout() {
-        let layer_tar = make_tar(&[("hello.txt", b"hi".to_vec())]);
-        let config = br#"{"architecture":"amd64","config":{"Cmd":["/bin/sh"]}}"#.to_vec();
-        let manifest = br#"[{"Config":"config.json","Layers":["layer0.tar"]}]"#.to_vec();
-        let archive = make_tar(&[
-            ("manifest.json", manifest),
-            ("config.json", config),
-            ("layer0.tar", layer_tar),
-        ]);
-
-        let layers_dir = tempfile::tempdir().unwrap();
-        extract_archive(archive.as_slice(), layers_dir.path()).unwrap();
-
-        assert!(layers_dir.path().join("config.json").exists());
-        let layer_file = layers_dir.path().join("0000_layer0").join("hello.txt");
-        assert_eq!(std::fs::read_to_string(layer_file).unwrap(), "hi");
-    }
-
-    #[test]
-    fn test_extract_oci_archive_layout() {
-        let layer_tar = make_tar(&[("data.txt", b"oci".to_vec())]);
-        let layer_gz = gzip(&layer_tar);
-        let config = br#"{"architecture":"arm64","config":{"Entrypoint":["/run"]}}"#.to_vec();
-        let manifest =
-            br#"{"config":{"digest":"sha256:cfg"},"layers":[{"digest":"sha256:lyr"}]}"#.to_vec();
-        let index = br#"{"manifests":[{"digest":"sha256:man"}]}"#.to_vec();
-        let archive = make_tar(&[
-            ("oci-layout", br#"{"imageLayoutVersion":"1.0.0"}"#.to_vec()),
-            ("index.json", index),
-            ("blobs/sha256/man", manifest),
-            ("blobs/sha256/cfg", config),
-            ("blobs/sha256/lyr", layer_gz),
-        ]);
-
-        let layers_dir = tempfile::tempdir().unwrap();
-        extract_archive(archive.as_slice(), layers_dir.path()).unwrap();
-
-        assert!(layers_dir.path().join("config.json").exists());
-        let layer_file = layers_dir.path().join("0000_lyr").join("data.txt");
-        assert_eq!(std::fs::read_to_string(layer_file).unwrap(), "oci");
-    }
-
-    #[test]
-    fn test_gzipped_outer_archive() {
-        // `docker save | gzip` / a `.tar.gz` file: the whole archive is gzip
-        // wrapped and must be decompressed before the tar is read.
-        let layer_tar = make_tar(&[("hello.txt", b"hi".to_vec())]);
-        let config = br#"{"architecture":"amd64"}"#.to_vec();
-        let manifest = br#"[{"Config":"config.json","Layers":["layer0.tar"]}]"#.to_vec();
-        let archive = make_tar(&[
-            ("manifest.json", manifest),
-            ("config.json", config),
-            ("layer0.tar", layer_tar),
-        ]);
-
-        let layers_dir = tempfile::tempdir().unwrap();
-        let reader = decompress_file(temp_file_with(&gzip(&archive))).unwrap();
-        extract_archive(reader, layers_dir.path()).unwrap();
-
-        let layer_file = layers_dir.path().join("0000_layer0").join("hello.txt");
-        assert_eq!(std::fs::read_to_string(layer_file).unwrap(), "hi");
-    }
-
-    #[test]
-    fn test_missing_manifest_rejected() {
-        let archive = make_tar(&[("random.txt", b"nope".to_vec())]);
-        let layers_dir = tempfile::tempdir().unwrap();
-        assert!(extract_archive(archive.as_slice(), layers_dir.path()).is_err());
-    }
-
-    #[test]
-    fn test_archive_ref_cache_miss_errors() {
-        let result = prepare_image_archive(
-            "local:0000000000000000000000000000000000000000000000000000000000000000",
-        );
-        assert!(result.is_err());
+    /// Redirect the content-addressed cache into `dir` for the current test.
+    fn use_cache_root(dir: &Path) {
+        CACHE_ROOT_OVERRIDE.with(|c| *c.borrow_mut() = Some(dir.to_path_buf()));
     }
 
     #[test]
@@ -590,5 +286,57 @@ mod tests {
         assert!(is_image_archive("img.tar.gz"));
         assert!(!is_image_archive("alpine"));
         assert!(!is_image_archive("ghcr.io/owner/repo:v1"));
+    }
+
+    #[test]
+    fn test_stage_from_file_produces_cache_dir() {
+        // A real `docker save` tarball is not needed here: host-side staging is
+        // format-agnostic (extraction is delegated to the in-VM crane). Any
+        // bytes exercise hashing + staging.
+        let tmp = tempfile::tempdir().unwrap();
+        use_cache_root(tmp.path());
+        let archive = tmp.path().join("image.tar");
+        fs::write(&archive, b"fake docker save archive").unwrap();
+
+        let (dir, resolved) = prepare_image_archive(archive.to_str().unwrap()).unwrap();
+
+        assert!(resolved.starts_with("local:"));
+        assert!(is_staged(&dir));
+        assert!(dir.starts_with(tmp.path()));
+        assert_eq!(
+            fs::read(dir.join(ARCHIVE_FILE)).unwrap(),
+            b"fake docker save archive"
+        );
+
+        // A resolved `local:<hash>` ref now resolves straight from the cache.
+        let (dir2, _) = prepare_image_archive(&resolved).unwrap();
+        assert_eq!(dir, dir2);
+    }
+
+    #[test]
+    fn test_stage_is_content_addressed_and_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        use_cache_root(tmp.path());
+        let a = tmp.path().join("a.tar");
+        let b = tmp.path().join("b.tar");
+        fs::write(&a, b"identical bytes").unwrap();
+        fs::write(&b, b"identical bytes").unwrap();
+
+        let (dir_a, ref_a) = prepare_image_archive(a.to_str().unwrap()).unwrap();
+        // Same bytes → same hash → same cache dir (cache hit, no error).
+        let (dir_b, ref_b) = prepare_image_archive(b.to_str().unwrap()).unwrap();
+
+        assert_eq!(ref_a, ref_b);
+        assert_eq!(dir_a, dir_b);
+    }
+
+    #[test]
+    fn test_local_ref_cache_miss_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        use_cache_root(tmp.path());
+        let result = prepare_image_archive(
+            "local:0000000000000000000000000000000000000000000000000000000000000000",
+        );
+        assert!(result.is_err());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,8 @@ pub mod dns_filter;
 pub mod dns_filter_listener;
 /// Language-neutral embedded runtime support shared by SDK adapters.
 pub mod embedded;
+/// Docker/OCI image archive support (stdin pipe and `.tar` files).
+pub mod image_archive;
 pub mod log_rotation;
 pub mod network;
 pub mod platform;


### PR DESCRIPTION
Support `--image -` (stdin) and `--image path.tar[.gz]` so machines can run from `docker save` / `podman save` output without a registry — useful for CI, air-gapped environments, and fast local iteration.

The host extracts the archive into a content-addressed cache laid out like the packed layers of a `.smolmachine` and mounts it via virtiofs. The resolved reference is persisted as `local:<hash>`, so later boots (and `machine start`) skip extraction and start straight from the cache.

- New `image_archive` module: classify, hash, and extract Docker and OCI tar layouts, transparently decompressing a gzip outer archive and gzip layers; on-disk archives are hashed in place (no second full-size copy)
- Recover Entrypoint/Cmd/Env/WorkingDir/User/arch from the archive's config.json in the agent's packed-image path
- normalize_image_ref passes resolved `local:<hash>` refs through verbatim
- Route run/create/start through a single resolve_if_archive helper

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/316">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->