### PR TITLE
feat: run an image's OCI ENTRYPOINT/CMD when no command is given

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -2742,6 +2742,36 @@ fn handle_interactive_run(
 #[cfg(target_os = "linux")]
 const CONSOLE_SOCKET_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
+/// Resolve the command for a container run.
+///
+/// If the caller supplied a command, use it verbatim. Otherwise fall back to
+/// the image's OCI `ENTRYPOINT` + `CMD` (read from the stored image config),
+/// so an image can run its own init without the caller having to know it.
+/// Errors if no command was given and the image defines neither.
+#[cfg(target_os = "linux")]
+fn resolve_image_command(
+    image: &str,
+    command: Vec<String>,
+) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    if !command.is_empty() {
+        return Ok(command);
+    }
+    match storage::query_image(image)? {
+        Some(info) => {
+            let mut resolved = info.entrypoint;
+            resolved.extend(info.cmd);
+            if resolved.is_empty() {
+                return Err(format!(
+                    "no command given and image '{image}' defines no entrypoint or cmd"
+                )
+                .into());
+            }
+            Ok(resolved)
+        }
+        None => Err(format!("image not found: {image}").into()),
+    }
+}
+
 /// Write an OCI bundle (`config.json`) and return a freshly generated container ID.
 ///
 /// Shared by [`handle_run_detached`] and [`spawn_interactive_command`] to avoid
@@ -2810,7 +2840,7 @@ fn handle_run_detached(
 
     ensure_storage_mounted();
 
-    let (image, command, env, workdir, user, mounts, persistent_overlay_id) = match request {
+    let (image, mut command, env, workdir, user, mounts, persistent_overlay_id) = match request {
         AgentRequest::Run {
             image,
             command,
@@ -2838,14 +2868,9 @@ fn handle_run_detached(
         }
     };
 
-    // Validate inputs before creating any overlay state.
-    if command.is_empty() {
-        send_response(
-            stream,
-            &AgentResponse::error("empty command", error_codes::INVALID_REQUEST),
-        )?;
-        return Ok(());
-    }
+    // An empty command is allowed here: it means "run the image's own
+    // ENTRYPOINT/CMD". We resolve it from the image config below, after the
+    // image has been prepared (so its config is guaranteed present).
 
     let overlay_id = match persistent_overlay_id {
         Some(id) => id,
@@ -2875,6 +2900,23 @@ fn handle_run_detached(
             return Ok(());
         }
     };
+
+    // Resolve the command from the image's OCI ENTRYPOINT+CMD when the caller
+    // gave none — this is what lets service-style images (whose ENTRYPOINT
+    // orchestrates a supervised stack) run as their authors intended.
+    if command.is_empty() {
+        command = match resolve_image_command(&image, command) {
+            Ok(c) => c,
+            Err(e) => {
+                send_response(
+                    stream,
+                    &AgentResponse::error(e.to_string(), error_codes::INVALID_REQUEST),
+                )?;
+                return Ok(());
+            }
+        };
+        info!(image = %image, command = ?command, "resolved command from image config");
+    }
 
     if let Err(e) = storage::setup_mounts(&prepared.rootfs_path, &mounts) {
         send_response(

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -753,24 +753,27 @@ pub fn start_vm_named(
     }
 
     if let Some(ref img) = record.image {
-        // Image-based machine: start background CMD if configured.
+        // Image-based machine: launch the workload container in the background.
+        // The command is the user-configured entrypoint+cmd if set; otherwise
+        // it is left empty and the agent resolves the image's own
+        // ENTRYPOINT+CMD. This lets service-style images (which orchestrate a
+        // supervised stack from their entrypoint) start as their authors
+        // intended, not just images given an explicit command.
         let mut cmd = record.entrypoint.clone();
         cmd.extend(record.cmd.clone());
-        if !cmd.is_empty() {
-            let mount_bindings =
-                crate::cli::parsers::record_mounts_to_runconfig_bindings(&record.mounts);
-            let bg_config = smolvm::agent::RunConfig::new(img, cmd)
-                .with_env(record.env.clone())
-                .with_workdir(record.workdir.clone())
-                .with_user(record.user.clone())
-                .with_mounts(mount_bindings)
-                .with_persistent_overlay(Some(name.to_string()));
-            if let Err(e) = client.run_container_detached(bg_config) {
-                if let Err(stop_err) = manager.stop() {
-                    tracing::warn!(error = %stop_err, "failed to stop machine after CMD launch failure");
-                }
-                return Err(smolvm::Error::agent("start background CMD", format!("{e}")));
+        let mount_bindings =
+            crate::cli::parsers::record_mounts_to_runconfig_bindings(&record.mounts);
+        let bg_config = smolvm::agent::RunConfig::new(img, cmd)
+            .with_env(record.env.clone())
+            .with_workdir(record.workdir.clone())
+            .with_user(record.user.clone())
+            .with_mounts(mount_bindings)
+            .with_persistent_overlay(Some(name.to_string()));
+        if let Err(e) = client.run_container_detached(bg_config) {
+            if let Err(stop_err) = manager.stop() {
+                tracing::warn!(error = %stop_err, "failed to stop machine after CMD launch failure");
             }
+            return Err(smolvm::Error::agent("start background CMD", format!("{e}")));
         }
         println!("Machine '{}' running (PID: {})", name, pid.unwrap_or(0));
     } else {


### PR DESCRIPTION
<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/320">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->