### PR TITLE
fix: consistent exit codes and validation for stop/data-dir/--image

### DIFF
--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -12,7 +12,7 @@
 use crate::cli::flush_output;
 use crate::cli::format_bytes;
 use crate::cli::parsers::{
-    mounts_to_virtiofs_bindings, parse_cidr, parse_duration, parse_env_list,
+    mounts_to_virtiofs_bindings, parse_cidr, parse_duration, parse_env_list, parse_image,
 };
 use crate::cli::vm_common::{self, DeleteVmOptions};
 use clap::{Args, Subcommand};
@@ -237,7 +237,7 @@ impl MachineCmd {
 pub struct RunCmd {
     /// Container image (e.g., alpine, ubuntu:22.04, ghcr.io/org/image).
     /// Optional when a Smolfile provides the image, or for bare VM mode.
-    #[arg(short = 'I', long, value_name = "IMAGE")]
+    #[arg(short = 'I', long, value_name = "IMAGE", value_parser = parse_image)]
     pub image: Option<String>,
 
     /// Name a persistent machine when used with --detach.
@@ -1305,7 +1305,7 @@ pub struct CreateCmd {
     pub name: Option<String>,
 
     /// Container image (e.g., alpine, python:3.12-alpine)
-    #[arg(short = 'I', long, value_name = "IMAGE")]
+    #[arg(short = 'I', long, value_name = "IMAGE", value_parser = parse_image)]
     pub image: Option<String>,
 
     /// Number of virtual CPUs
@@ -2078,6 +2078,13 @@ pub struct DataDirCmd {
 
 impl DataDirCmd {
     pub fn run(self) -> smolvm::Result<()> {
+        // Error (exit 1) for a machine that does not exist, rather than
+        // printing a computed path for a name that was never created —
+        // consistent with `status`/`start`/`delete`.
+        let config = smolvm::config::SmolvmConfig::load()?;
+        if config.get_vm(&self.name).is_none() {
+            return Err(smolvm::Error::vm_not_found(&self.name));
+        }
         let dir = smolvm::agent::vm_data_dir(&self.name);
         println!("{}", dir.display());
         Ok(())

--- a/src/cli/parsers.rs
+++ b/src/cli/parsers.rs
@@ -27,6 +27,16 @@ pub fn parse_gpu_vram_mib(s: &str) -> Result<u32, String> {
     Ok(v)
 }
 
+/// Parse and validate an image reference. Rejects empty/whitespace-only
+/// values at CLI parse time so `--image ""` errors immediately instead of
+/// creating an unusable machine that only fails once the VM starts.
+pub fn parse_image(s: &str) -> Result<String, String> {
+    if s.trim().is_empty() {
+        return Err("image reference must not be empty".to_string());
+    }
+    Ok(s.to_string())
+}
+
 // Env parsing delegated to the library.
 pub use smolvm::util::{parse_env_list, parse_env_spec};
 

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -1031,10 +1031,11 @@ pub fn stop_vm_named(name: &str) -> smolvm::Result<()> {
                 println!("Stopping machine '{}'...", name);
                 manager.stop()?;
                 println!("Machine '{}' stopped", name);
-            } else {
-                println!("Machine '{}' not found or not running", name);
+                return Ok(());
             }
-            return Ok(());
+            // Not in config and no running VM with this name — genuinely
+            // not found. Exit non-zero, consistent with status/start/delete.
+            return Err(smolvm::Error::vm_not_found(name));
         }
     };
 


### PR DESCRIPTION
<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/321">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->