### PR TITLE
fix: forward host value for key-only -e and reject duplicate mount targets

### DIFF
--- a/src/data/storage.rs
+++ b/src/data/storage.rs
@@ -124,7 +124,28 @@ impl HostMount {
 
     /// Parse multiple mount specifications.
     pub fn parse(specs: &[String]) -> Result<Vec<Self>> {
-        specs.iter().map(|spec| Self::_parse(spec)).collect()
+        let mounts: Vec<Self> = specs
+            .iter()
+            .map(|spec| Self::_parse(spec))
+            .collect::<Result<_>>()?;
+
+        // Reject duplicate guest targets. Silently letting a later `-v`
+        // shadow an earlier one (second-wins) hides a likely user mistake
+        // and makes the effective mount ambiguous.
+        let mut seen = std::collections::HashSet::new();
+        for m in &mounts {
+            if !seen.insert(&m.target) {
+                return Err(Error::mount(
+                    "validate mounts",
+                    format!(
+                        "duplicate mount target: {} is specified more than once",
+                        m.target.display()
+                    ),
+                ));
+            }
+        }
+
+        Ok(mounts)
     }
 
     fn validate(mount: &Self) -> Result<()> {
@@ -189,6 +210,26 @@ impl HostMount {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    #[test]
+    fn parse_rejects_duplicate_target() {
+        // Sources must exist (HostMount::_parse validates source presence),
+        // so use real temp directories.
+        let base = std::env::temp_dir();
+        let a = base.join("smolvm_dup_a");
+        let b = base.join("smolvm_dup_b");
+        std::fs::create_dir_all(&a).unwrap();
+        std::fs::create_dir_all(&b).unwrap();
+        let (a, b) = (a.to_string_lossy(), b.to_string_lossy());
+
+        let err = HostMount::parse(&[format!("{a}:/app"), format!("{b}:/app")]).unwrap_err();
+        assert!(
+            err.to_string().contains("duplicate mount target"),
+            "expected duplicate-target error, got: {err}"
+        );
+        // Distinct targets are fine.
+        assert!(HostMount::parse(&[format!("{a}:/app"), format!("{b}:/data")]).is_ok());
+    }
 
     fn parse_one(spec: &str) -> HostMount {
         HostMount::parse(&[spec.to_string()]).unwrap().remove(0)

--- a/src/util.rs
+++ b/src/util.rs
@@ -62,15 +62,29 @@ pub fn libkrun_filename() -> &'static str {
     lib_name
 }
 
-/// Parse a single `KEY=VALUE` environment variable specification.
+/// Parse a single environment variable specification.
 ///
-/// Returns `None` if the string has no `=` or the key is empty.
+/// - `KEY=VALUE` → `Some((KEY, VALUE))`.
+/// - `KEY` (no `=`) → forwards the host's current value for `KEY` (Docker
+///   `-e KEY` semantics); `None` if the host variable is unset.
+/// - empty key (`=VALUE`) or empty spec → `None`.
 pub fn parse_env_spec(spec: &str) -> Option<(String, String)> {
-    let (key, value) = spec.split_once('=')?;
-    if key.is_empty() {
-        None
-    } else {
-        Some((key.to_string(), value.to_string()))
+    match spec.split_once('=') {
+        Some((key, value)) => {
+            if key.is_empty() {
+                None
+            } else {
+                Some((key.to_string(), value.to_string()))
+            }
+        }
+        None => {
+            if spec.is_empty() {
+                None
+            } else {
+                // Key-only form: forward the value from the host environment.
+                std::env::var(spec).ok().map(|v| (spec.to_string(), v))
+            }
+        }
     }
 }
 
@@ -85,6 +99,35 @@ pub fn parse_env_list(env_args: &[String]) -> Vec<(String, String)> {
 mod tests {
     use super::*;
     use std::collections::HashSet;
+
+    #[test]
+    fn parse_env_spec_key_value() {
+        assert_eq!(
+            parse_env_spec("FOO=bar"),
+            Some(("FOO".to_string(), "bar".to_string()))
+        );
+        // Empty value is allowed.
+        assert_eq!(
+            parse_env_spec("FOO="),
+            Some(("FOO".to_string(), String::new()))
+        );
+        // Empty key is rejected.
+        assert_eq!(parse_env_spec("=bar"), None);
+        assert_eq!(parse_env_spec(""), None);
+    }
+
+    #[test]
+    fn parse_env_spec_key_only_forwards_host_value() {
+        let key = "SMOLVM_TEST_ENV_FWD_XYZ";
+        std::env::set_var(key, "host_value");
+        assert_eq!(
+            parse_env_spec(key),
+            Some((key.to_string(), "host_value".to_string()))
+        );
+        std::env::remove_var(key);
+        // Unset host var → skipped.
+        assert_eq!(parse_env_spec(key), None);
+    }
 
     #[test]
     fn test_generate_ids() {


### PR DESCRIPTION
<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/322">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->