### PR TITLE
fix: stop a running machine before delete to avoid orphaned VM process

### DIFF
--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -1643,7 +1643,12 @@ impl DeleteCmd {
             &self.name,
             self.force,
             DeleteVmOptions {
-                stop_if_running: false,
+                // Stop the VM before removing its config and data dir.
+                // Without this, deleting a running machine orphans the
+                // `_boot-vm` process (leaking host RAM) and removes the data
+                // dir out from under the live VM. The API delete handler and
+                // `delete_vm`'s own teardown already do this.
+                stop_if_running: true,
             },
         )
     }


### PR DESCRIPTION
<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/323">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->