### PR TITLE
fix: report 128+signal exit code for signal-killed exec processes

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -3436,7 +3436,7 @@ fn run_interactive_loop(
                 &mut stdout_buf,
                 &mut stderr_buf,
             )?;
-            return Ok(status.code().unwrap_or(-1));
+            return Ok(process::exit_code_from_status(&status));
         }
 
         // Check timeout
@@ -3651,7 +3651,7 @@ fn run_interactive_loop_pty(
                     Err(_) => break,
                 }
             }
-            return Ok(status.code().unwrap_or(-1));
+            return Ok(process::exit_code_from_status(&status));
         }
 
         // Check timeout.
@@ -3743,7 +3743,7 @@ fn run_interactive_loop_pty(
         // If the slave closed, the process is exiting — reap it now.
         if slave_closed {
             let status = child.wait()?;
-            return Ok(status.code().unwrap_or(-1));
+            return Ok(process::exit_code_from_status(&status));
         }
 
         // Read incoming request from host — only when poll confirms data
@@ -4577,7 +4577,7 @@ fn handle_vm_exec(
 
     let exit_code = loop {
         match child.try_wait() {
-            Ok(Some(status)) => break status.code().unwrap_or(-1),
+            Ok(Some(status)) => break process::exit_code_from_status(&status),
             Ok(None) => {
                 // Client disconnected — kill the orphan child so the accept
                 // loop isn't blocked waiting for it. Fixes BUG-12/20: SIGTERM

--- a/crates/smolvm-agent/src/process.rs
+++ b/crates/smolvm-agent/src/process.rs
@@ -10,6 +10,24 @@ use std::time::{Duration, Instant};
 /// Exit code used when a command is killed due to timeout.
 pub const TIMEOUT_EXIT_CODE: i32 = 124;
 
+/// Map a process exit status to a numeric exit code.
+///
+/// Normal exit → the process's exit code. Terminated by a signal (where
+/// `ExitStatus::code()` is `None`) → `128 + signal`, matching shell
+/// convention (SIGINT → 130, SIGTERM → 143), so callers and scripts can
+/// distinguish a signal kill from a normal exit instead of seeing an
+/// opaque 255.
+pub fn exit_code_from_status(status: &std::process::ExitStatus) -> i32 {
+    use std::os::unix::process::ExitStatusExt;
+    if let Some(code) = status.code() {
+        code
+    } else if let Some(sig) = status.signal() {
+        128 + sig
+    } else {
+        -1
+    }
+}
+
 /// Per-stream output cap for non-interactive exec. Vec<u8> is base64-encoded
 /// in JSON frames (4/3 expansion). Two streams at this cap must fit within the
 /// 32 MB frame limit with room for JSON overhead:
@@ -183,7 +201,7 @@ pub fn wait_with_timeout(
             Ok(Some(status)) => {
                 // Process completed — join drains to get full output.
                 let output = join_pipe_drains(stdout_drain, stderr_drain);
-                let exit_code = status.code().unwrap_or(-1);
+                let exit_code = exit_code_from_status(&status);
                 return Ok(WaitResult::Completed { exit_code, output });
             }
             Ok(None) => {
@@ -376,7 +394,7 @@ where
                 }
                 // Final drain after threads are done (or timed out).
                 drain_channels(&stdout_rx, &stderr_rx, &mut stdout_buf, &mut stderr_buf);
-                let exit_code = status.code().unwrap_or(-1);
+                let exit_code = exit_code_from_status(&status);
                 return Ok(WaitResult::Completed {
                     exit_code,
                     output: ChildOutput {


### PR DESCRIPTION
<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/324">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->