### PR TITLE
fix: update two stale test expectations the code moved past

### DIFF
--- a/crates/smolvm-protocol/src/retry.rs
+++ b/crates/smolvm-protocol/src/retry.rs
@@ -404,7 +404,7 @@ mod tests {
         assert_eq!(network.initial_delay, Duration::from_millis(500));
 
         let connection = RetryConfig::for_connection();
-        assert_eq!(connection.max_attempts, 3);
-        assert_eq!(connection.initial_delay, Duration::from_millis(50));
+        assert_eq!(connection.max_attempts, 6);
+        assert_eq!(connection.initial_delay, Duration::from_millis(100));
     }
 }

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -1731,7 +1731,9 @@ mod init_runner_tests {
             &[],
             "vm",
         );
-        assert_eq!(config.image, "debian:slim");
+        // Image is canonicalized by `RunConfig::new` (normalize_image_ref):
+        // bare `debian:slim` → fully-qualified `docker.io/library/debian:slim`.
+        assert_eq!(config.image, "docker.io/library/debian:slim");
         assert_eq!(config.env, env);
         assert_eq!(config.workdir.as_deref(), Some("/work"));
         assert_eq!(config.user.as_deref(), Some("steam"));


### PR DESCRIPTION
Using copilot to generate summaries since i just end up leaving it empty

Two unit tests were asserting values the code intentionally changed. Neither is run by CI, so the drift sat unnoticed on main.

## The two failures
- **`retry::tests::test_config_presets`** (smolvm-protocol) — expected `for_connection()` `max_attempts = 3` / `initial_delay = 50ms`. The concurrent-spin-up work (`ef19c48`) bumped these to **6 / 100ms**. Code is right; test was stale.
- **`vm_common::build_init_run_config_threads_env_workdir_image`** (smolvm bin) — expected the bare ref `debian:slim`. `RunConfig::new` now canonicalizes via `normalize_image_ref` to **`docker.io/library/debian:slim`**. Code is right; test asserted the pre-normalization string.

Both are corrected to match current behavior.

## Why CI never caught them
`ci.yml` runs `cargo test --lib` (smolvm **library** only) + `cargo test -p smolvm-agent --bins`. That skips:
- the smolvm **binary** tests (where the vm_common test lives), and
- every other member crate's tests (smolvm-protocol, -pack, -network, -registry).

So `cargo test --workspace` had two failures while CI stayed green. With this PR, `cargo test --workspace --no-fail-fast` is **green end to end (0 failures)**.

Follow-up worth considering (not in this PR): broaden the CI test step toward `cargo test --workspace` (likely `--exclude smolvm-napi`, the Node-addon crate) so this coverage gap can't hide regressions again.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/328">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->