### PR TITLE
fix: don't require libvirglrenderer unless the GPU path runs (Linux)

### DIFF
--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -173,7 +173,16 @@ refresh_bundled_libs_from_local() {
     rm -rf "$LOCAL_STAGE_DIR"
     mkdir -p "$LOCAL_STAGE_DIR"
 
-    run_make "$repo" "$flags"
+    # On Linux, link with partial RELRO so libkrun's symbols bind lazily. Full
+    # RELRO forces BIND_NOW, which would defeat the lazy virglrenderer loading
+    # (RTLD_LAZY in src/agent/krun.rs + the patchelf --remove-needed below) that
+    # lets one GPU-enabled libkrun load on non-GPU hosts. Harmless for the
+    # install step and non-cargo builds; not applicable to macOS dylibs.
+    if [[ "$(uname -s)" == "Linux" ]]; then
+        RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }-C relro-level=partial" run_make "$repo" "$flags"
+    else
+        run_make "$repo" "$flags"
+    fi
     run_make "$repo" "$flags" install "DESTDIR=$LOCAL_STAGE_DIR" "PREFIX=/usr/local"
 
     if [[ ! -d "$STAGED_LIB_DIR" ]]; then
@@ -349,6 +358,23 @@ else
 
     copy_so_with_symlinks libkrun required
     copy_so_with_symlinks libkrunfw required
+
+    # Strip the hard NEEDED on virglrenderer from the GPU-enabled libkrun so a
+    # host without it can still dlopen libkrun (paired with the RTLD_LAZY load in
+    # src/agent/krun.rs). virglrenderer is loaded by soname at runtime only when
+    # the GPU path actually runs — so one build serves both GPU and non-GPU hosts.
+    if command -v patchelf >/dev/null 2>&1; then
+        for lk in "$DIST_DIR"/lib/libkrun.so*; do
+            [[ -f "$lk" && ! -L "$lk" ]] || continue
+            if patchelf --print-needed "$lk" 2>/dev/null | grep -q libvirglrenderer; then
+                patchelf --remove-needed libvirglrenderer.so.1 "$lk"
+                echo "Stripped libvirglrenderer NEEDED from $(basename "$lk") — GPU stays optional at runtime"
+            fi
+        done
+    else
+        echo "Warning: patchelf not found — libkrun keeps its hard virglrenderer NEEDED;"
+        echo "         non-GPU Linux hosts will fail to load it. Install patchelf in the build env."
+    fi
 
     # Bundle GPU rendering libraries if present (virglrenderer chain for Venus/Vulkan).
     # libMoltenVK is macOS-only — not included here.

--- a/src/agent/krun.rs
+++ b/src/agent/krun.rs
@@ -80,7 +80,13 @@ impl KrunFunctions {
         let lib_path_c = CString::new(lib_path.to_string_lossy().as_bytes())
             .map_err(|_| "invalid library path")?;
 
-        let handle = libc::dlopen(lib_path_c.as_ptr(), libc::RTLD_NOW | libc::RTLD_LOCAL);
+        // RTLD_LAZY (not RTLD_NOW): a single libkrun built with the GPU feature
+        // references virglrenderer, but on Linux that NEEDED entry is stripped at
+        // package time so a host without virglrenderer can still load it. Lazy
+        // binding defers the virgl symbols until the GPU path actually calls them;
+        // preload_linux_gpu_dependencies() loads virglrenderer first when a GPU
+        // host has it. Non-GPU hosts never bind those symbols.
+        let handle = libc::dlopen(lib_path_c.as_ptr(), libc::RTLD_LAZY | libc::RTLD_LOCAL);
         if handle.is_null() {
             let err = dlerror_message();
             libc::dlclose(fw_handle);
@@ -167,6 +173,14 @@ fn preload_linux_gpu_dependencies(lib_dir: &Path) {
         let path = lib_dir.join(lib_name);
         if path.exists() {
             dlopen_global(&path);
+        } else {
+            // Not bundled: try the host's copy by soname. A GPU host has
+            // virglrenderer (and its X11/DRM/Mesa chain) installed system-wide;
+            // loading it RTLD_GLOBAL here lets libkrun's lazily-bound virgl
+            // symbols resolve when the GPU path runs. Best-effort — on a non-GPU
+            // host it simply isn't found, which is fine: those symbols are never
+            // called, and the libkrun NEEDED entry was stripped at package time.
+            dlopen_global_soname(lib_name);
         }
     }
 
@@ -198,4 +212,16 @@ fn dlopen_global(path: &Path) -> bool {
     }
 
     true
+}
+
+/// Load a library by soname (no path), letting the dynamic loader search the
+/// host's standard library directories. Used to pick up a GPU host's
+/// system-installed virglrenderer when it isn't bundled. Best-effort: on a
+/// non-GPU host the library is absent, which is expected and not an error.
+#[cfg(target_os = "linux")]
+fn dlopen_global_soname(soname: &str) -> bool {
+    let Ok(soname_c) = CString::new(soname) else {
+        return false;
+    };
+    unsafe { !libc::dlopen(soname_c.as_ptr(), libc::RTLD_NOW | libc::RTLD_GLOBAL).is_null() }
 }


### PR DESCRIPTION
The bundled libkrun is built with the GPU feature, which links virglrenderer as a hard NEEDED dependency — so on a Linux host without it, dlopen(libkrun) fails before any VM can start, even without --gpu:

  load libkrun: ... libvirglrenderer.so.1: cannot open shared object file

Make virglrenderer optional at runtime while keeping a single build:
- build libkrun with partial RELRO (lazy binding); full RELRO's BIND_NOW would force eager symbol resolution and defeat the rest
- strip the libvirglrenderer NEEDED from the packaged libkrun via patchelf
- load libkrun with RTLD_LAZY so the virgl symbols bind only when the GPU path calls them
- preload virglrenderer by soname when present, so a GPU host's system copy (and its X11/DRM/Mesa chain) is picked up for --gpu

A non-GPU host now loads libkrun and boots VMs without virglrenderer; a GPU host still gets GPU. Verified end to end on Linux.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/329">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->