### PR TITLE
feat: copy-on-write block disks for fork clones

### DIFF
--- a/src/agent/krun.rs
+++ b/src/agent/krun.rs
@@ -59,6 +59,10 @@ pub struct KrunFunctions {
     /// Boot the VM as a fork clone from a snapshot directory (CoW-map a golden
     /// VM's RAM + restore state instead of cold-booting).
     pub set_snapshot: Option<unsafe extern "C" fn(u32, *const libc::c_char) -> i32>,
+    /// Create a qcow2 copy-on-write overlay backed by an existing disk image
+    /// (used for fork-clone block disks). Pure filesystem op; takes no ctx.
+    pub create_disk_overlay:
+        Option<unsafe extern "C" fn(*const libc::c_char, *const libc::c_char, u32) -> i32>,
 }
 
 impl KrunFunctions {
@@ -157,6 +161,7 @@ impl KrunFunctions {
             set_gpu_options2: load_optional_sym!("krun_set_gpu_options2"),
             set_control_socket: load_optional_sym!("krun_set_control_socket"),
             set_snapshot: load_optional_sym!("krun_set_snapshot"),
+            create_disk_overlay: load_optional_sym!("krun_create_disk_overlay"),
         })
     }
 }

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -5,6 +5,7 @@
 //! DYLD_LIBRARY_PATH is still available for dlopen.
 
 use crate::data::consts::{ENV_SMOLVM_KRUN_LOG_LEVEL, ENV_SMOLVM_LIB_DIR};
+use crate::data::disk::DiskFormat;
 use crate::data::storage::HostMount;
 use crate::error::{Error, Result};
 use crate::network::backend::{COMPAT_NET_FEATURES, TSI_FEATURE_HIJACK_INET};
@@ -85,6 +86,57 @@ pub fn find_lib_dir() -> Option<PathBuf> {
     }
 
     None
+}
+
+/// A qcow2 copy-on-write overlay to create: `(overlay_path, base_path, base_format)`.
+/// `base_path` must be absolute — it is written verbatim into the overlay header,
+/// and imago resolves a relative backing path against the overlay's own directory.
+pub type DiskOverlaySpec = (PathBuf, PathBuf, DiskFormat);
+
+/// Create the given qcow2 copy-on-write overlays, loading libkrun once for the
+/// whole batch (overlay creation is a pure filesystem op, but the only place the
+/// `krun_create_disk_overlay` symbol lives is libkrun). Stops at the first error.
+pub fn create_disk_overlays(specs: &[DiskOverlaySpec]) -> Result<()> {
+    if specs.is_empty() {
+        return Ok(());
+    }
+    let lib_dir = find_lib_dir().ok_or_else(|| {
+        Error::agent(
+            "create disk overlay",
+            "could not locate the libkrun library directory",
+        )
+    })?;
+    let krun = unsafe { KrunFunctions::load(&lib_dir) }
+        .map_err(|e| Error::agent("create disk overlay", e))?;
+    let create = krun.create_disk_overlay.ok_or_else(|| {
+        Error::agent(
+            "create disk overlay",
+            "libkrun is missing krun_create_disk_overlay (rebuild libkrun)",
+        )
+    })?;
+
+    for (overlay, base, base_format) in specs {
+        let overlay_c = path_to_cstring(overlay)?;
+        let base_c = path_to_cstring(base)?;
+        let rc = unsafe {
+            create(
+                overlay_c.as_ptr(),
+                base_c.as_ptr(),
+                base_format.to_krun_u32(),
+            )
+        };
+        if rc < 0 {
+            return Err(Error::agent(
+                "create disk overlay",
+                format!(
+                    "krun_create_disk_overlay failed (rc={rc}) for {} <- {}",
+                    overlay.display(),
+                    base.display()
+                ),
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Launch the agent VM (call in the forked child process).
@@ -518,7 +570,15 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
             "add storage disk",
             "path contains null byte"
         );
-        if krun_add_disk2(ctx, block_id.as_ptr(), disk_path.as_ptr(), 0, false) < 0 {
+        let storage_format = disks.storage.format().to_krun_u32();
+        if krun_add_disk2(
+            ctx,
+            block_id.as_ptr(),
+            disk_path.as_ptr(),
+            storage_format,
+            false,
+        ) < 0
+        {
             krun_free_ctx(ctx);
             return Err(Error::agent(
                 "add storage disk",
@@ -535,7 +595,15 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
                 "add overlay disk",
                 "path contains null byte"
             );
-            if krun_add_disk2(ctx, overlay_id.as_ptr(), overlay_path.as_ptr(), 0, false) < 0 {
+            let overlay_format = overlay.format().to_krun_u32();
+            if krun_add_disk2(
+                ctx,
+                overlay_id.as_ptr(),
+                overlay_path.as_ptr(),
+                overlay_format,
+                false,
+            ) < 0
+            {
                 krun_free_ctx(ctx);
                 return Err(Error::agent(
                     "add overlay disk",

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -6,7 +6,7 @@
 use crate::data::validate_vm_name;
 use crate::error::{Error, Result};
 use crate::process::{self, ChildProcess};
-use crate::storage::{OverlayDisk, StorageDisk};
+use crate::storage::{DiskFormat, OverlayDisk, StorageDisk};
 use parking_lot::Mutex;
 use smolvm_protocol::AGENT_READY_MARKER;
 use std::os::unix::process::CommandExt as _;
@@ -179,6 +179,19 @@ struct AgentInner {
 /// name-path exceeds the kernel socket budget, so we don't offer it.
 pub fn vm_data_dir(name: &str) -> PathBuf {
     vm_cache_root().join(vm_dir_hash(name))
+}
+
+/// Resolve the on-disk image for a `.raw` disk filename in `dir`. A fork clone
+/// has a `.qcow2` copy-on-write overlay in place of the raw disk, so prefer that
+/// when present; otherwise fall back to the raw disk. The file on disk is the
+/// single source of truth for the format (no format is stored in the record).
+pub fn resolve_disk_image(dir: &Path, raw_filename: &str) -> (PathBuf, DiskFormat) {
+    let qcow2 = dir.join(Path::new(raw_filename).with_extension("qcow2"));
+    if qcow2.exists() {
+        (qcow2, DiskFormat::Qcow2)
+    } else {
+        (dir.join(raw_filename), DiskFormat::Raw)
+    }
 }
 
 /// Cache root: `<cache_dir>/smolvm/vms/`.
@@ -440,11 +453,26 @@ impl AgentManager {
         // different name).
         let storage_dir = ensure_vm_dir(&name)?;
 
-        let storage_path = storage_dir.join(crate::storage::STORAGE_DISK_FILENAME);
-        let storage_disk = StorageDisk::open_or_create_at(&storage_path, sg)?;
+        // A fork clone has a `.qcow2` copy-on-write overlay in place of the
+        // `.raw` disk; detect it by file presence (the on-disk file is the
+        // source of truth) and open it as-is rather than creating/formatting.
+        let (storage_path, storage_format) =
+            resolve_disk_image(&storage_dir, crate::storage::STORAGE_DISK_FILENAME);
+        let storage_disk = match storage_format {
+            DiskFormat::Qcow2 => {
+                StorageDisk::open_existing_with_format(&storage_path, storage_format)?
+            }
+            DiskFormat::Raw => StorageDisk::open_or_create_at(&storage_path, sg)?,
+        };
 
-        let overlay_path = storage_dir.join(crate::storage::OVERLAY_DISK_FILENAME);
-        let overlay_disk = OverlayDisk::open_or_create_at(&overlay_path, og)?;
+        let (overlay_path, overlay_format) =
+            resolve_disk_image(&storage_dir, crate::storage::OVERLAY_DISK_FILENAME);
+        let overlay_disk = match overlay_format {
+            DiskFormat::Qcow2 => {
+                OverlayDisk::open_existing_with_format(&overlay_path, overlay_format)?
+            }
+            DiskFormat::Raw => OverlayDisk::open_or_create_at(&overlay_path, og)?,
+        };
 
         Self::new_named(name, rootfs_path, storage_disk, overlay_disk)
     }
@@ -457,6 +485,23 @@ impl AgentManager {
     /// Get the VM name if this is a named agent.
     pub fn name(&self) -> Option<&str> {
         self.name.as_deref()
+    }
+
+    /// Names of VMs forked from this one. Their block disks are copy-on-write
+    /// overlays backed by this VM's disks, so it must not be re-launched with
+    /// writable disks while they exist. Best-effort: on a registry read error,
+    /// returns empty rather than blocking the launch.
+    fn dependent_clones(&self) -> Vec<String> {
+        let Some(name) = self.name() else {
+            return Vec::new(); // the unnamed/default manager is never a fork base
+        };
+        match crate::db::SmolvmDb::open().and_then(|db| db.dependent_clones(name)) {
+            Ok(clones) => clones,
+            Err(e) => {
+                tracing::warn!(vm = name, error = %e, "could not check for dependent clones");
+                Vec::new()
+            }
+        }
     }
 
     /// Get the default path for the agent rootfs.
@@ -943,6 +988,27 @@ impl AgentManager {
         ports: &[PortMapping],
         resources: VmResources,
     ) -> Result<()> {
+        // Refuse to (re)launch a fork base while clones depend on it. Clones
+        // CoW-read this VM's disks by path; re-running it would reopen them
+        // writable and silently corrupt every clone. Clones don't need the base
+        // process alive, so refusing is safe — delete the clones first to reuse
+        // the name. Covers every launch path (CLI fork + subprocess) since both
+        // funnel through here.
+        let clones = self.dependent_clones();
+        if !clones.is_empty() {
+            return Err(Error::agent(
+                "start agent",
+                format!(
+                    "'{}' is a fork base for {} live clone(s) ({}); their disks are \
+                     copy-on-write overlays backed by its disks, so it cannot be \
+                     re-launched while they exist — delete the clones first",
+                    self.name().unwrap_or_default(),
+                    clones.len(),
+                    clones.join(", ")
+                ),
+            ));
+        }
+
         // Validate resources before doing anything else.
         resources.validate()?;
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -19,10 +19,13 @@ pub use client::{
     AgentClient, ExecEvent, InteractiveInput, InteractiveOutput, PullOptions, RunConfig,
 };
 pub use krun::KrunFunctions;
-pub use launcher::{find_lib_dir, launch_agent_vm, LaunchConfig, LaunchFeatures, VmDisks};
+pub use launcher::{
+    create_disk_overlays, find_lib_dir, launch_agent_vm, DiskOverlaySpec, LaunchConfig,
+    LaunchFeatures, VmDisks,
+};
 pub use manager::{
-    docker_config_dir, docker_config_mount, ensure_vm_dir, vm_cache_root, vm_data_dir, vm_dir_hash,
-    AgentManager, AgentState,
+    docker_config_dir, docker_config_mount, ensure_vm_dir, resolve_disk_image, vm_cache_root,
+    vm_data_dir, vm_dir_hash, AgentManager, AgentState,
 };
 
 /// Agent VM name.

--- a/src/api/supervisor.rs
+++ b/src/api/supervisor.rs
@@ -160,6 +160,25 @@ impl Supervisor {
             }
         };
 
+        // Never auto-restart a fork base: clones CoW-read its disks by path, so
+        // relaunching it writable would corrupt them. Clones keep working
+        // without the base process, so skipping is safe (and avoids thrashing,
+        // since `prepare_for_launch` would refuse the launch anyway).
+        match self.state.db().dependent_clones(name) {
+            Ok(clones) if !clones.is_empty() => {
+                tracing::warn!(
+                    machine = %name,
+                    clones = %clones.join(", "),
+                    "not auto-restarting: machine is a fork base with live clones"
+                );
+                return Ok(());
+            }
+            Ok(_) => {}
+            Err(e) => {
+                tracing::warn!(machine = %name, error = %e, "could not check dependent clones; proceeding")
+            }
+        }
+
         let mounts = record.host_mounts();
         let ports = record.port_mappings();
         let resources = record.vm_resources();

--- a/src/cli/internal_boot.rs
+++ b/src/cli/internal_boot.rs
@@ -8,7 +8,21 @@
 
 use smolvm::agent::boot_config::BootConfig;
 use smolvm::agent::{launch_agent_vm, LaunchConfig, VmDisks};
-use std::path::PathBuf;
+use smolvm::data::disk::{DiskFormat, DiskType};
+use smolvm::storage::VmDisk;
+use std::path::{Path, PathBuf};
+
+/// Open a boot disk honoring its on-disk format. A fork clone's disk path ends
+/// in `.qcow2` (a copy-on-write overlay, opened as-is over its backing image);
+/// every other disk is a raw image that may need creating/formatting. The path
+/// is the single source of truth for the format — see `agent::resolve_disk_image`.
+fn open_boot_disk<K: DiskType>(path: &Path, size_gb: u64) -> smolvm::Result<VmDisk<K>> {
+    if path.extension().and_then(|e| e.to_str()) == Some("qcow2") {
+        VmDisk::<K>::open_existing_with_format(path, DiskFormat::Qcow2)
+    } else {
+        VmDisk::<K>::open_or_create_at(path, size_gb)
+    }
+}
 
 /// Run the boot subprocess.
 ///
@@ -225,8 +239,8 @@ pub fn run(config_path: PathBuf) -> smolvm::Result<()> {
     }
     proc_timing!("fds closed");
 
-    // Open storage and overlay disks
-    let storage_disk = match smolvm::storage::StorageDisk::open_or_create_at(
+    // Open storage and overlay disks, honoring qcow2 fork-clone overlays.
+    let storage_disk = match open_boot_disk::<smolvm::storage::Storage>(
         &config.storage_disk_path,
         config.storage_size_gb,
     ) {
@@ -241,7 +255,7 @@ pub fn run(config_path: PathBuf) -> smolvm::Result<()> {
     };
     proc_timing!("storage opened");
 
-    let overlay_disk = match smolvm::storage::OverlayDisk::open_or_create_at(
+    let overlay_disk = match open_boot_disk::<smolvm::storage::Overlay>(
         &config.overlay_disk_path,
         config.overlay_size_gb,
     ) {

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -648,6 +648,19 @@ pub fn fork_vm(
 
     validate_vm_name(clone, "clone name").map_err(|e| Error::config("clone name", e))?;
 
+    // Nested fork is unsupported: a clone boots from a copy-on-write MAP_PRIVATE
+    // mapping of the golden's RAM, not a fresh memfd, so it cannot itself be
+    // re-forked (its FORK would fail with "no memfd-backed RAM"). Reject
+    // `--forkable` up front instead of producing a clone that looks forkable but
+    // isn't.
+    if clone_forkable {
+        return Err(Error::agent(
+            "fork",
+            "nested fork is not supported: a clone cannot be re-forked, so `--forkable` \
+             on a fork has no effect (drop it)",
+        ));
+    }
+
     let db = SmolvmDb::open()?;
     let golden_rec = db
         .get_vm(golden)?
@@ -731,6 +744,7 @@ pub fn fork_vm(
     let reply = control_socket_cmd(&ctl, &format!("FORK {}", snapshot_dir.display()))?;
     if !reply.starts_with("OK") {
         let _ = db.remove_vm(clone);
+        let _ = std::fs::remove_dir_all(&clone_dir);
         return Err(Error::agent("fork", format!("golden FORK failed: {reply}")));
     }
 
@@ -802,14 +816,12 @@ pub fn fork_vm(
     };
     if let Err(e) = clone_disks() {
         let _ = db.remove_vm(clone);
+        let _ = std::fs::remove_dir_all(&clone_dir);
         return Err(e);
     }
 
     // Boot the clone from the golden's snapshot instead of cold-booting.
     std::env::set_var("SMOLVM_SNAPSHOT_DIR", &snapshot_dir);
-    if clone_forkable {
-        enable_forkable_env(clone);
-    }
     eprintln!("Booting clone '{clone}' from snapshot...");
     let result = start_vm_named(clone, None, None, /* from_snapshot */ true);
     std::env::remove_var("SMOLVM_SNAPSHOT_DIR");
@@ -821,6 +833,7 @@ pub fn fork_vm(
         );
     } else {
         let _ = db.remove_vm(clone);
+        let _ = std::fs::remove_dir_all(&clone_dir);
     }
     result
 }
@@ -1650,18 +1663,23 @@ where
         println!("Machine '{}': running{}", label, pid_suffix);
         extra(&manager);
         manager.detach();
-    } else {
-        // Only report "not running" when the machine actually exists.
-        // A missing DB record with an explicit name is "not found".
-        if let Some(ref n) = name {
-            let exists = SmolvmDb::open()
-                .ok()
-                .and_then(|db| db.get_vm(n).ok().flatten())
-                .is_some();
-            if !exists {
-                return Err(smolvm::Error::vm_not_found(n));
+    } else if let Some(ref n) = name {
+        // Agent not reachable. Report the precise state from the registry
+        // (stopped / failed / created / unreachable), consistent with
+        // `machine list`, instead of a flat "not running". A missing record
+        // with an explicit name is "not found".
+        match SmolvmDb::open()
+            .ok()
+            .and_then(|db| db.get_vm(n).ok().flatten())
+        {
+            Some(record) => {
+                let state = smolvm::agent::state_probe::resolve_state(n, &record);
+                println!("Machine '{}': {}", label, state);
             }
+            None => return Err(smolvm::Error::vm_not_found(n)),
         }
+    } else {
+        // Default/unnamed VM: no record to resolve.
         println!("Machine '{}': not running", label);
     }
 

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -722,6 +722,8 @@ pub fn fork_vm(
         }
         clone_rec.ports = remapped;
     }
+    clone_rec.golden = Some(golden.to_string());
+    let gdir = vm_data_dir(golden);
     db.insert_vm(clone, &clone_rec)?;
 
     // Freeze the golden and write its snapshot (checkpoint + memfd manifest).
@@ -732,30 +734,75 @@ pub fn fork_vm(
         return Err(Error::agent("fork", format!("golden FORK failed: {reply}")));
     }
 
-    // Copy-on-write clone the golden's disks. The golden is frozen and its
-    // device workers quiesced, so the disk images are at a consistent boundary.
-    // Copy the `.formatted` marker too, or the clone would reformat and wipe
-    // the golden's data. (`fs::copy` is sparse-aware via copy_file_range on
-    // Linux; reflink/clonefile is a future fast-path.)
-    let gdir = vm_data_dir(golden);
-    for fname in [
-        smolvm::data::storage::STORAGE_DISK_FILENAME,
-        smolvm::data::storage::OVERLAY_DISK_FILENAME,
-    ] {
-        let src = gdir.join(fname);
-        if !src.exists() {
-            continue;
+    // Give the clone its own disks. The golden is frozen with its block workers
+    // quiesced and flushed, so its images are a consistent backing. On Linux
+    // each disk is a qcow2 copy-on-write overlay over the golden's — filesystem
+    // independent, so the overlay starts near-empty and the fork is O(metadata)
+    // regardless of how much data the golden holds. macOS clonefiles the disks
+    // (APFS CoW). Either way the `.formatted` marker is copied so the clone
+    // never reformats and wipes the inherited filesystem.
+    let clone_disks = || -> smolvm::Result<()> {
+        // The golden's actual disks that exist, resolved by file presence
+        // (`.qcow2` if the golden is itself a clone, else `.raw`) — the same
+        // single source of truth the agent manager uses. Each entry pairs the
+        // canonical `.raw` filename (for naming the clone's disk) with the
+        // golden's real backing file and its format.
+        let disks: Vec<(&str, std::path::PathBuf, smolvm::data::disk::DiskFormat)> = [
+            smolvm::data::storage::STORAGE_DISK_FILENAME,
+            smolvm::data::storage::OVERLAY_DISK_FILENAME,
+        ]
+        .into_iter()
+        .map(|raw| {
+            let (src, fmt) = smolvm::agent::resolve_disk_image(&gdir, raw);
+            (raw, src, fmt)
+        })
+        .filter(|(_, src, _)| src.exists())
+        .collect();
+
+        #[cfg(target_os = "linux")]
+        {
+            // Each clone disk is a qcow2 CoW overlay over the golden's disk.
+            // Build all overlay specs first so libkrun is loaded once for the
+            // batch (absolute backing path: it's written verbatim into the
+            // overlay header), then copy the `.formatted` markers so the clone
+            // never reformats and wipes the inherited filesystem.
+            let mut specs = Vec::with_capacity(disks.len());
+            for (raw, src, fmt) in &disks {
+                let base = src
+                    .canonicalize()
+                    .map_err(|e| Error::agent("clone disk", format!("{}: {e}", src.display())))?;
+                let overlay = clone_dir.join(std::path::Path::new(raw).with_extension("qcow2"));
+                specs.push((overlay, base, *fmt));
+            }
+            smolvm::agent::create_disk_overlays(&specs)?;
+            for (raw, _, _) in &disks {
+                // Marker basename is the disk stem + ".formatted" (same for the
+                // golden's `.raw`/`.qcow2` and the clone's `.qcow2`).
+                let marker = std::path::Path::new(raw).with_extension("formatted");
+                let src_marker = gdir.join(&marker);
+                if src_marker.exists() {
+                    let _ = std::fs::copy(&src_marker, clone_dir.join(&marker));
+                }
+            }
         }
-        let dst = clone_dir.join(fname);
-        // Sparse-aware copy (only allocated extents) — reflink/clonefile where
-        // the filesystem supports it, else a SEEK_DATA/SEEK_HOLE copy. The disks
-        // are 20/10 GiB nominal but mostly holes, so a plain copy would be huge.
-        smolvm::disk_utils::clone_or_copy_file(&src, &dst)
-            .map_err(|e| Error::agent("clone disk", format!("{fname}: {e}")))?;
-        let src_marker = src.with_extension("formatted");
-        if src_marker.exists() {
-            let _ = std::fs::copy(&src_marker, dst.with_extension("formatted"));
+        #[cfg(target_os = "macos")]
+        {
+            // macOS uses clonefile (APFS CoW), keeping the golden's disk format.
+            for (_, src, _) in &disks {
+                let dst = clone_dir.join(src.file_name().unwrap());
+                smolvm::disk_utils::clone_or_copy_file(src, &dst)
+                    .map_err(|e| Error::agent("clone disk", format!("{}: {e}", src.display())))?;
+                let src_marker = src.with_extension("formatted");
+                if src_marker.exists() {
+                    let _ = std::fs::copy(&src_marker, dst.with_extension("formatted"));
+                }
+            }
         }
+        Ok(())
+    };
+    if let Err(e) = clone_disks() {
+        let _ = db.remove_vm(clone);
+        return Err(e);
     }
 
     // Boot the clone from the golden's snapshot instead of cold-booting.
@@ -1491,6 +1538,29 @@ pub fn delete_vm(name: &str, force: bool, options: DeleteVmOptions) -> smolvm::R
         .get_vm(name)
         .ok_or_else(|| smolvm::Error::vm_not_found(name))?
         .clone();
+
+    // A golden's disks are the copy-on-write backing for its clones' overlays,
+    // so it must outlive them. Refuse to delete a golden while clones depend on
+    // it (unless forced, in which case the clones' overlays are left dangling).
+    let dependent_clones = SmolvmDb::open()?.dependent_clones(name)?;
+    if !dependent_clones.is_empty() {
+        if !force {
+            return Err(smolvm::Error::agent(
+                "delete",
+                format!(
+                    "machine '{name}' is the fork base for {} clone(s) ({}); \
+                     delete the clones first, or use --force to break them",
+                    dependent_clones.len(),
+                    dependent_clones.join(", ")
+                ),
+            ));
+        }
+        tracing::warn!(
+            golden = name,
+            clones = %dependent_clones.join(", "),
+            "force-deleting a golden; dependent clones' disk overlays will dangle"
+        );
+    }
 
     // Stop if running (machine run does this). Use the shared
     // resolver so an `Unreachable` VM (live PID, dead agent) is also

--- a/src/config.rs
+++ b/src/config.rs
@@ -478,6 +478,14 @@ pub struct VmRecord {
     /// them via virtiofs instead of pulling the image from a registry.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_smolmachine: Option<String>,
+
+    /// Name of the golden VM this machine was forked from, if any. A clone's
+    /// block disks are copy-on-write overlays backed by the golden's disks, so
+    /// the golden must outlive its clones. The disk *format* is not recorded
+    /// here — it is derived from the on-disk file (`.qcow2` vs `.raw`), which is
+    /// the single source of truth (see `agent::resolve_disk_image`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub golden: Option<String>,
 }
 
 /// Deserialize `created_at` from either a legacy JSON string `"1705312345"` or
@@ -554,6 +562,7 @@ impl VmRecord {
             dns_filter_hosts: None,
             ephemeral: false,
             source_smolmachine: None,
+            golden: None,
         }
     }
 
@@ -604,6 +613,7 @@ impl VmRecord {
             dns_filter_hosts: None,
             ephemeral: false,
             source_smolmachine: None,
+            golden: None,
         }
     }
 

--- a/src/data/disk.rs
+++ b/src/data/disk.rs
@@ -1,9 +1,42 @@
 //! Canonical shared disk type metadata.
 
+use serde::{Deserialize, Serialize};
+
 use crate::data::storage::{
     DEFAULT_OVERLAY_SIZE_GIB, DEFAULT_STORAGE_SIZE_GIB, OVERLAY_DISK_FILENAME,
     STORAGE_DISK_FILENAME,
 };
+
+/// On-disk image format for a VM's block disks. Fork clones attach a `Qcow2`
+/// copy-on-write overlay backed by the golden's `Raw` disk; every other VM uses
+/// `Raw` directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DiskFormat {
+    /// A flat raw disk image.
+    #[default]
+    Raw,
+    /// A qcow2 image, used as a copy-on-write overlay over a backing disk.
+    Qcow2,
+}
+
+impl DiskFormat {
+    /// File extension used for disks of this format.
+    pub fn extension(self) -> &'static str {
+        match self {
+            DiskFormat::Raw => "raw",
+            DiskFormat::Qcow2 => "qcow2",
+        }
+    }
+
+    /// The disk-format integer libkrun's `krun_add_disk2` expects.
+    pub fn to_krun_u32(self) -> u32 {
+        match self {
+            DiskFormat::Raw => 0,
+            DiskFormat::Qcow2 => 1,
+        }
+    }
+}
 
 /// Marker type for the persistent rootfs overlay disk.
 #[derive(Debug, Clone, Copy)]
@@ -41,4 +74,33 @@ impl DiskType for Storage {
     const DEFAULT_SIZE_GIB: u64 = DEFAULT_STORAGE_SIZE_GIB;
     const TEMPLATE_FILENAME: &'static str = "storage-template.ext4";
     const VOLUME_LABEL: &'static str = "smolvm";
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disk_format_defaults_to_raw() {
+        assert_eq!(DiskFormat::default(), DiskFormat::Raw);
+    }
+
+    #[test]
+    fn disk_format_extension_and_krun_value() {
+        assert_eq!(DiskFormat::Raw.extension(), "raw");
+        assert_eq!(DiskFormat::Qcow2.extension(), "qcow2");
+        // Must match libkrun's ImageType: Raw=0, Qcow2=1.
+        assert_eq!(DiskFormat::Raw.to_krun_u32(), 0);
+        assert_eq!(DiskFormat::Qcow2.to_krun_u32(), 1);
+    }
+
+    #[test]
+    fn disk_format_serde_roundtrip_lowercase() {
+        assert_eq!(
+            serde_json::to_string(&DiskFormat::Qcow2).unwrap(),
+            "\"qcow2\""
+        );
+        let parsed: DiskFormat = serde_json::from_str("\"raw\"").unwrap();
+        assert_eq!(parsed, DiskFormat::Raw);
+    }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -249,6 +249,18 @@ impl SmolvmDb {
         })
     }
 
+    /// Names of VMs forked from `golden`. Their block disks are copy-on-write
+    /// overlays backed by the golden's disks, so the golden must outlive them
+    /// and must not be re-run with writable disks while they exist.
+    pub fn dependent_clones(&self, golden: &str) -> Result<Vec<String>> {
+        Ok(self
+            .list_vms()?
+            .into_iter()
+            .filter(|(_, r)| r.golden.as_deref() == Some(golden))
+            .map(|(name, _)| name)
+            .collect())
+    }
+
     /// Update a VM record in place using a closure.
     ///
     /// Returns the updated record if found, `None` if not found. Read +

--- a/src/disk_utils.rs
+++ b/src/disk_utils.rs
@@ -304,6 +304,10 @@ pub fn clone_or_copy_file(src: &Path, dst: &Path) -> Result<()> {
 
     #[cfg(target_os = "linux")]
     {
+        // TODO(reflink): try a FICLONE ioctl before sparse_copy for true
+        // copy-on-write on btrfs/XFS hosts. (Fork clones already get
+        // filesystem-independent block CoW via qcow2 overlays; this would only
+        // speed up the remaining full-copy callers on reflink-capable hosts.)
         match sparse_copy(src, dst) {
             Ok(bytes) => {
                 tracing::debug!(

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -16,7 +16,7 @@
 //! and overlay filesystem management.
 
 use crate::data::consts::BYTES_PER_GIB;
-pub use crate::data::disk::{DiskType, Overlay, Storage};
+pub use crate::data::disk::{DiskFormat, DiskType, Overlay, Storage};
 pub use crate::data::storage::{
     DEFAULT_OVERLAY_SIZE_GIB, DEFAULT_STORAGE_SIZE_GIB, OVERLAY_DISK_FILENAME,
     STORAGE_DISK_FILENAME,
@@ -68,6 +68,7 @@ impl DiskVersion {
 pub struct VmDisk<K> {
     path: PathBuf,
     size_bytes: u64,
+    format: DiskFormat,
     _kind: PhantomData<K>,
 }
 
@@ -112,6 +113,7 @@ impl<K: DiskType> VmDisk<K> {
             Ok(Self {
                 path: path.to_path_buf(),
                 size_bytes: metadata.len(),
+                format: DiskFormat::Raw,
                 _kind: PhantomData,
             })
         } else {
@@ -119,9 +121,24 @@ impl<K: DiskType> VmDisk<K> {
             Ok(Self {
                 path: path.to_path_buf(),
                 size_bytes,
+                format: DiskFormat::Raw,
                 _kind: PhantomData,
             })
         }
+    }
+
+    /// Open an existing disk image with an explicit on-disk format, without
+    /// creating or formatting it. Used for fork-clone qcow2 overlays, which are
+    /// created up front by the fork path and inherit the backing disk's
+    /// already-formatted filesystem.
+    pub fn open_existing_with_format(path: &Path, format: DiskFormat) -> Result<Self> {
+        let metadata = std::fs::metadata(path)?;
+        Ok(Self {
+            path: path.to_path_buf(),
+            size_bytes: metadata.len(),
+            format,
+            _kind: PhantomData,
+        })
     }
 
     /// Pre-format the disk with ext4 on the host.
@@ -132,6 +149,13 @@ impl<K: DiskType> VmDisk<K> {
     ///
     /// The template approach eliminates the e2fsprogs dependency for end users.
     pub fn ensure_formatted(&self) -> Result<()> {
+        if self.format == DiskFormat::Qcow2 {
+            // A qcow2 CoW overlay inherits its backing disk's already-formatted
+            // filesystem; formatting it would write a fresh fs into the overlay
+            // and diverge from the backing image.
+            return Ok(());
+        }
+
         if !self.needs_format() {
             tracing::debug!(
                 path = %self.path.display(),
@@ -153,6 +177,11 @@ impl<K: DiskType> VmDisk<K> {
     /// Get the path to the disk image.
     pub fn path(&self) -> &Path {
         &self.path
+    }
+
+    /// Get the on-disk image format (raw, or qcow2 for fork-clone overlays).
+    pub fn format(&self) -> DiskFormat {
+        self.format
     }
 
     /// Get the disk size in bytes.


### PR DESCRIPTION
Stacked on `binbin-fast-fork`. Fork clones now attach a qcow2 copy-on-write overlay
over the golden's disk (Linux) instead of a full sparse copy, so a fork is O(metadata)
regardless of golden data size and dense pools are space-cheap. macOS keeps clonefile
(APFS CoW). The guest sees a normal block device; no agent changes.

- `agent::create_disk_overlays`: FFI to libkrun's new `krun_create_disk_overlay`,
  loading libkrun once per fork batch.
- Disk format derived from the on-disk file (`.qcow2` vs `.raw`) via
  `agent::resolve_disk_image` — a single source of truth used by the manager,
  `fork_vm`, and the `_boot-vm` subprocess (fixes the subprocess opening a clone's
  qcow2 as raw, and a clone-of-clone losing its disk).
- Fork-base protection: refuse to (re)launch or auto-restart a VM whose disks back
  live clones (`prepare_for_launch` guard + supervisor skip), and refuse to delete it
  without `--force`.
- Bumps the libkrun submodule to the CoW-overlay commit (libkrun#17) and refreshes the
  bundled `libkrun.so`.

Requires libkrun smol-machines/libkrun#17.

Verified live (Linux/KVM): fork = 196K overlay over a 649MB golden, O(metadata); clone
reads through correctly; write isolation; golden raw immutable across clone writes;
base re-launch refused while clones exist; clone survives base stop. 256 lib tests +
clippy + fmt clean.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/332">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->