### PR TITLE
fix(agent): automatically synchronize guest clock to prevent sleep/re…

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -1604,11 +1604,11 @@ fn handle_connection(stream: &mut impl ReadWrite) -> Result<(), Box<dyn std::err
 
         // Parse request (Envelope wraps the request with an optional trace_id).
         // Falls back to bare AgentRequest for backward compatibility with old hosts.
-        let (mut request, trace_id) =
+        let (mut request, trace_id, host_timestamp) =
             match serde_json::from_slice::<Envelope<AgentRequest>>(&buf[..len]) {
-                Ok(env) => (env.body, env.trace_id),
+                Ok(env) => (env.body, env.trace_id, env.host_timestamp),
                 Err(_) => match serde_json::from_slice::<AgentRequest>(&buf[..len]) {
-                    Ok(req) => (req, None),
+                    Ok(req) => (req, None, None),
                     Err(e) => {
                         warn!(error = %e, "invalid request");
                         send_response(
@@ -1622,6 +1622,11 @@ fn handle_connection(stream: &mut impl ReadWrite) -> Result<(), Box<dyn std::err
                     }
                 },
             };
+
+        // Synchronize guest clock with host if host_timestamp is provided
+        if let Some(host_ts) = host_timestamp {
+            sync_clock(host_ts);
+        }
 
         // Work around serde flatten + internally-tagged enum limitation:
         // fields with #[serde(default)] can be silently dropped during
@@ -4402,6 +4407,50 @@ fn handle_streaming_export_layer(
     }
     let _ = child.wait();
     result
+}
+
+/// Synchronize guest system clock with host system clock.
+///
+/// Compares guest time with the host time (in milliseconds). If they differ
+/// by more than a threshold (500ms), adjusts the guest clock to match the host.
+fn sync_clock(host_timestamp_ms: i64) {
+    let mut guest_ts = libc::timespec { tv_sec: 0, tv_nsec: 0 };
+    // SAFETY: guest_ts is a valid, mutable timespec structure allocated on the stack.
+    let ret = unsafe { libc::clock_gettime(libc::CLOCK_REALTIME, &mut guest_ts) };
+    if ret == 0 {
+        let guest_ms = (guest_ts.tv_sec as i64 * 1000) + (guest_ts.tv_nsec as i64 / 1_000_000);
+        let diff = (host_timestamp_ms - guest_ms).abs();
+        if diff > 500 {
+            let secs = host_timestamp_ms / 1000;
+            let nsecs = (host_timestamp_ms % 1000) * 1_000_000;
+            let ts = libc::timespec {
+                tv_sec: secs as _,
+                tv_nsec: nsecs as _,
+            };
+            // SAFETY: ts is a valid timespec, and smolvm-agent runs with root capabilities
+            // (specifically CAP_SYS_TIME) in the VM.
+            let ret = unsafe { libc::clock_settime(libc::CLOCK_REALTIME, &ts) };
+            if ret < 0 {
+                let err = std::io::Error::last_os_error();
+                warn!(
+                    error = %err,
+                    host = host_timestamp_ms,
+                    guest = guest_ms,
+                    "failed to sync guest clock with host"
+                );
+            } else {
+                info!(
+                    host = host_timestamp_ms,
+                    guest_before = guest_ms,
+                    drift_ms = host_timestamp_ms - guest_ms,
+                    "guest clock synchronized with host"
+                );
+            }
+        }
+    } else {
+        let err = std::io::Error::last_os_error();
+        warn!(error = %err, "failed to read guest system clock");
+    }
 }
 
 /// Handle storage status request.

--- a/crates/smolvm-pack/src/extract.rs
+++ b/crates/smolvm-pack/src/extract.rs
@@ -236,6 +236,7 @@ fn safe_unpack<R: Read>(archive: &mut tar::Archive<R>, dest: &Path) -> std::io::
         // Ensure parent directories are writable before extracting any entry.
         // OCI layer tars may set restrictive directory modes (e.g., dr-xr-xr-x)
         // before child entries, which prevents creating files or subdirectories.
+        #[cfg(unix)]
         if let Some(parent) = full_path.parent() {
             if parent.is_dir() {
                 let _ = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o755));
@@ -284,6 +285,7 @@ fn safe_unpack<R: Read>(archive: &mut tar::Archive<R>, dest: &Path) -> std::io::
             // After extracting a directory, force it writable so subsequent
             // entries (children) can be created inside it. Final permissions
             // are applied after the loop.
+            #[cfg(unix)]
             if entry_type == tar::EntryType::Directory && full_path.is_dir() {
                 let _ =
                     std::fs::set_permissions(&full_path, std::fs::Permissions::from_mode(0o755));
@@ -292,6 +294,7 @@ fn safe_unpack<R: Read>(archive: &mut tar::Archive<R>, dest: &Path) -> std::io::
     }
 
     // Apply deferred directory permissions now that all children are written.
+    #[cfg(unix)]
     for (path, mode) in deferred_dir_modes {
         if path.is_dir() {
             let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(mode));

--- a/crates/smolvm-protocol/src/lib.rs
+++ b/crates/smolvm-protocol/src/lib.rs
@@ -802,6 +802,9 @@ pub struct Envelope<T> {
     /// Trace ID for correlating host API requests to agent operations.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub trace_id: Option<String>,
+    /// Optional host timestamp (unix time in milliseconds) for clock sync.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub host_timestamp: Option<i64>,
     /// The wrapped message.
     #[serde(flatten)]
     pub body: T,
@@ -810,15 +813,32 @@ pub struct Envelope<T> {
 impl<T> Envelope<T> {
     /// Create an envelope with no trace ID.
     pub fn new(body: T) -> Self {
+        let host_timestamp = Some(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as i64,
+        );
         Self {
             trace_id: None,
+            host_timestamp,
             body,
         }
     }
 
     /// Create an envelope with an optional trace ID.
     pub fn with_trace_id(body: T, trace_id: Option<String>) -> Self {
-        Self { trace_id, body }
+        let host_timestamp = Some(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as i64,
+        );
+        Self {
+            trace_id,
+            host_timestamp,
+            body,
+        }
     }
 }
 
@@ -1127,6 +1147,24 @@ mod tests {
         // Deserialize back — Envelope<AgentRequest> with flatten
         let parsed: Envelope<AgentRequest> = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.trace_id.as_deref(), Some("abc123"));
+        assert!(matches!(parsed.body, AgentRequest::Ping));
+    }
+
+    #[test]
+    fn test_envelope_serialization_with_host_timestamp() {
+        let req = AgentRequest::Ping;
+        let envelope = Envelope::with_trace_id(&req, Some("abc123".to_string()));
+        let json = serde_json::to_string(&envelope).unwrap();
+
+        // trace_id and host_timestamp should be flattened alongside the method tag
+        assert!(json.contains("\"trace_id\":\"abc123\""));
+        assert!(json.contains("\"host_timestamp\":"));
+        assert!(json.contains("\"method\":\"ping\""));
+
+        // Deserialize back — Envelope<AgentRequest> with flatten
+        let parsed: Envelope<AgentRequest> = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.trace_id.as_deref(), Some("abc123"));
+        assert!(parsed.host_timestamp.is_some());
         assert!(matches!(parsed.body, AgentRequest::Ping));
     }
 


### PR DESCRIPTION
close:#301
Description
On macOS hosts, the guest microVM's wall clock drifts after the host enters a sleep/resume cycle. Because capabilities are restricted within the container sandbox namespaces (CAP_SYS_TIME is dropped), standard in-guest NTP sync or manual adjustments (date -s) fail with Operation not permitted.

This PR implements an automatic, hypervisor-assisted time synchronization mechanism by utilizing the host-to-guest vsock communication channel.

Whenever the host establishes a connection (e.g., executing a command or performing background liveness/health probes), it embeds its current system timestamp inside the message Envelope. The guest agent daemon (running with root privileges) checks this timestamp and adjusts the guest clock accordingly.

Changes
crates/smolvm-protocol
Added an optional host_timestamp field (Unix epoch in milliseconds) to Envelope<T>.
Updated constructors Envelope::new() and Envelope::with_trace_id() to automatically populate the host_timestamp using std::time::SystemTime.
Added unit tests verifying serialization and deserialization of the updated envelope format.
crates/smolvm-agent
Updated the connection handler to extract host_timestamp from incoming requests.
Added a sync_clock() utility using libc::clock_gettime and libc::clock_settime(CLOCK_REALTIME) to adjust the VM system clock if the drift relative to the host is greater than 500ms.
crates/smolvm-pack
Guarded Unix-only std::fs::Permissions::from_mode() calls with #[cfg(unix)] to restore compilation capabilities on Windows developer hosts.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/333">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->