### PR TITLE
fix: release the VM lock on stop so a machine can restart

### DIFF
--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -502,6 +502,25 @@ impl AgentManager {
         }
     }
 
+    /// Force the in-memory state back to `Stopped` and release the per-VM lock,
+    /// after the VM process has already been stopped out-of-band (the HTTP stop
+    /// path kills the recorded PID directly rather than via this manager).
+    ///
+    /// The serve process holds the `vm.lock` flock for the lifetime of the
+    /// registry's `AgentManager`; if `vm_lock_handle` is not dropped here, the
+    /// serve process keeps holding the lock and a subsequent start fails to
+    /// re-acquire it ("another process is already starting or running this VM").
+    /// Only call once the process is confirmed dead.
+    pub fn mark_stopped(&self) {
+        let mut inner = self.inner.lock();
+        inner.state = AgentState::Stopped;
+        inner.child = None;
+        #[cfg(unix)]
+        {
+            inner.vm_lock_handle = None;
+        }
+    }
+
     /// Return consistent (state, pid) for API status responses.
     ///
     /// Clears the PID when effective state is `Stopped`, so clients never

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -622,6 +622,14 @@ pub async fn stop_machine(
         )));
     }
 
+    // The VM process is confirmed dead, but the long-lived registry manager for
+    // this machine still holds the per-VM `vm.lock` flock in this serve process.
+    // Release it so a subsequent start can re-acquire the lock; otherwise start
+    // fails with "another process is already starting or running this VM".
+    if let Ok(entry) = state.get_machine(&name) {
+        entry.lock().manager.mark_stopped();
+    }
+
     // Persist state to database and get updated record — only after confirmed stop
     let record = db
         .update_vm(&name, |r| {


### PR DESCRIPTION
Found in QA of the hosted-platform e2e: stopping a machine and starting it again failed — `POST /stop` returned 200 but `POST /start` then 500'd with *"another process is already starting or running this VM"*, leaving the machine in `error`.

## Root cause
`serve` keeps a long-lived `AgentManager` per machine in the registry, and that manager holds the per-VM `vm.lock` `flock` for the VM's lifetime. The HTTP stop path kills the VM process by PID via a *transient* manager but never released the **registry** manager's lock — so the serve process kept holding the `flock`, and the next start hit `EWOULDBLOCK` in `prepare_for_launch`. Confirmed via `lsof` (the serve PID held `vm.lock` after stop).

## Fix
- Add `AgentManager::mark_stopped()` — resets in-memory state to `Stopped` and drops `child` + `vm_lock_handle`.
- Call it from `stop_machine` once the VM process is confirmed dead, releasing the lock so a subsequent start can re-acquire it.

## Verified
On the live local stack (smolvm + smolfleet control plane): create → start → exec → **stop → start → started**, and exec works after restart. Compiles clean against current `main`.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/335">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->