### PR TITLE
fix: persist .smolmachine layers per VM

### DIFF
--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -114,6 +114,76 @@ pub struct LaunchFeatures {
     pub extra_disks: Vec<(std::path::PathBuf, bool)>,
 }
 
+impl LaunchFeatures {
+    /// Wire pre-extracted OCI layers for a machine created from a `.smolmachine`.
+    ///
+    /// `layers_cache_dir` is the machine's OWN extraction directory (under its
+    /// [`vm_data_dir`](crate::agent::vm_data_dir), via
+    /// [`machine_layers_cache_dir`](crate::agent::machine_layers_cache_dir)), not
+    /// the shared content-addressed pack cache. The bundle is extracted there
+    /// once at create time, so every subsequent start is independent of the
+    /// original `.smolmachine` file. When `source_smolmachine` is `None` the
+    /// machine is image/registry-sourced and `self` is returned unchanged.
+    ///
+    /// Normal path: the layers are already extracted, so this only acquires a
+    /// lease (re-mounting the case-sensitive volume on macOS; a no-op on Linux)
+    /// and points `packed_layers_dir` at it — no dependency on the sidecar.
+    /// Fallback path: if the per-machine directory has no extracted layers (a
+    /// machine created before this layout, or an interrupted create), extract
+    /// from the `source_smolmachine` sidecar, which must still exist in that case.
+    ///
+    /// This is the single source of truth shared by every start path — the CLI
+    /// `machine start` and the API start/ensure/restart handlers — so they
+    /// cannot drift apart and silently drop the bundled layers.
+    ///
+    /// Performs blocking filesystem work; on async paths call it from within a
+    /// `spawn_blocking` context.
+    pub fn with_packed_layers(
+        mut self,
+        layers_cache_dir: &Path,
+        source_smolmachine: Option<&str>,
+    ) -> Result<Self> {
+        let Some(sidecar_path) = source_smolmachine else {
+            return Ok(self);
+        };
+
+        if !smolvm_pack::extract::is_extracted(layers_cache_dir) {
+            // Fallback: layers not yet extracted into this machine's own dir
+            // (pre-this-layout machine, or an interrupted create). Extract from
+            // the source bundle, which must still be present in that case.
+            let sidecar = Path::new(sidecar_path);
+            if !sidecar.exists() {
+                return Err(Error::agent(
+                    "start machine",
+                    format!(
+                        "packed layers are not extracted for this machine and its \
+                         source .smolmachine is missing: {}\nRe-create the machine \
+                         from the bundle.",
+                        sidecar_path
+                    ),
+                ));
+            }
+            let footer = smolvm_pack::packer::read_footer_from_sidecar(sidecar)
+                .map_err(|e| Error::agent("read sidecar footer", e.to_string()))?;
+            smolvm_pack::extract::extract_sidecar(sidecar, layers_cache_dir, &footer, false, false)
+                .map_err(|e| Error::agent("extract sidecar", e.to_string()))?;
+        }
+
+        let layers_lease = smolvm_pack::extract::acquire_layers_lease(layers_cache_dir, false)
+            .map_err(|e| Error::agent("acquire layers lease", e.to_string()))?;
+        self.packed_layers_dir = Some(layers_lease.path.clone());
+        // Leak the lease so the case-sensitive layers volume stays mounted for
+        // the VM's lifetime (macOS only; a no-op on Linux). Unlike the previous
+        // shared-cache design, this volume is owned 1:1 by the machine: the stop
+        // and delete handlers detach it unconditionally via
+        // `force_detach_layers_volume`, so no co-tenant can be relying on it and
+        // no lease outlives the machine.
+        std::mem::forget(layers_lease);
+
+        Ok(self)
+    }
+}
+
 /// Configuration for launching an agent VM.
 pub struct LaunchConfig<'a> {
     /// Path to the agent rootfs directory.
@@ -702,6 +772,27 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
                         "krun_add_virtiofs failed for packed layers",
                     ));
                 }
+            } else {
+                // packed_layers_dir was set — which only happens after
+                // `with_packed_layers` acquired the lease — but the directory is
+                // not on disk at mount time. On macOS that means the per-machine
+                // case-sensitive layers volume isn't mounted (e.g. a concurrent
+                // stop/delete detached it). Mounting nothing would silently fall
+                // the guest back to a registry pull and break offline runs, and the
+                // launcher has no path to re-extract or re-mount here. Rather than
+                // boot a VM that is doomed to fail offline, free the context and
+                // fail fast with an actionable error.
+                krun_free_ctx(ctx);
+                return Err(Error::agent(
+                    "add packed layers virtiofs",
+                    format!(
+                        "packed layers directory not found at {}: this machine's \
+                         layers volume is not mounted, so the guest cannot use its \
+                         bundled image and an offline run would fail. Restart the \
+                         machine, or re-create it from the .smolmachine bundle.",
+                        layers_dir.display()
+                    ),
+                ));
             }
         }
 

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -181,6 +181,21 @@ pub fn vm_data_dir(name: &str) -> PathBuf {
     vm_cache_root().join(vm_dir_hash(name))
 }
 
+/// Per-machine extraction directory for a `.smolmachine` bundle's OCI layers.
+///
+/// Unlike the shared content-addressed pack cache (`smolvm-pack/<checksum>`),
+/// this lives *under* the machine's own [`vm_data_dir`], which means:
+/// - it is reclaimed for free when the data dir is removed on delete;
+/// - it is outside `pack prune`'s scope (never reaped while the machine exists);
+/// - the macOS case-sensitive layers volume is owned 1:1 by the machine, so the
+///   stop/delete paths can detach it unconditionally with no co-tenant risk.
+///
+/// The subdir is `pack` (deliberately not `layers`) so it cannot collide with
+/// the `layers/` subtree that `extract_sidecar` creates *inside* this directory.
+pub fn machine_layers_cache_dir(name: &str) -> PathBuf {
+    vm_data_dir(name).join("pack")
+}
+
 /// Cache root: `<cache_dir>/smolvm/vms/`.
 pub fn vm_cache_root() -> PathBuf {
     dirs::cache_dir()
@@ -790,6 +805,56 @@ impl AgentManager {
         self.ensure_running_with_full_config(mounts, Vec::new(), resources, Default::default())
     }
 
+    /// Re-attach this machine's pre-extracted packed layers if the caller did
+    /// not already wire them.
+    ///
+    /// The implicit-start preflight (`ensure_machine_running`) passes
+    /// `default()` features when the VM is already up, to skip the macOS hdiutil
+    /// mount on the exec hot path. If that preflight then detects a config
+    /// change and restarts, the relaunch would otherwise drop the packed layers
+    /// and the guest would fall back to a registry pull (broken offline). The
+    /// layers are discoverable from the machine name alone — derive the
+    /// per-machine directory, re-acquire the lease, and set `packed_layers_dir`.
+    /// A no-op when layers are already wired (an explicit-start path set
+    /// `packed_layers_dir` and its mount is still live), when this is not a named
+    /// machine, or when nothing was extracted (image/registry-sourced machine).
+    /// macOS mount cost only; a compile-time no-op on Linux.
+    fn rewire_packed_layers_if_extracted(
+        &self,
+        features: &mut launcher::LaunchFeatures,
+    ) -> Result<()> {
+        if features.packed_layers_dir.is_some() {
+            return Ok(());
+        }
+        let Some(name) = self.name.as_deref() else {
+            return Ok(());
+        };
+        let cache_dir = machine_layers_cache_dir(name);
+        if !smolvm_pack::extract::is_extracted(&cache_dir) {
+            return Ok(());
+        }
+        // This runs only on the relaunch path, after stop()/reset_stale_running_state,
+        // so no live VM is using the volume. The original start leaked a lease to keep
+        // it mounted; drop that stale mount (and its lease files) before acquiring a
+        // fresh one, so a config-change restart doesn't stack a second lease/mount on
+        // the first. Gated by the same conditions as the re-acquire below, so the
+        // explicit-start paths (features already `Some`, mount still live) return
+        // early above and never detach. macOS hdiutil detach; a no-op on Linux.
+        smolvm_pack::extract::force_detach_layers_volume(&cache_dir);
+        match smolvm_pack::extract::acquire_layers_lease(&cache_dir, false) {
+            Ok(lease) => {
+                features.packed_layers_dir = Some(lease.path.clone());
+                // Keep the volume mounted for the VM's lifetime; the stop/delete
+                // handlers detach it (see `machine_layers_cache_dir`).
+                std::mem::forget(lease);
+            }
+            Err(e) => {
+                return Err(Error::agent("re-attach packed layers", e.to_string()));
+            }
+        }
+        Ok(())
+    }
+
     /// Ensure the agent is running with the specified mounts, ports, and resources.
     ///
     /// If the agent is running with different configuration, it will be restarted.
@@ -799,7 +864,7 @@ impl AgentManager {
         mounts: Vec<HostMount>,
         ports: Vec<PortMapping>,
         resources: VmResources,
-        features: launcher::LaunchFeatures,
+        mut features: launcher::LaunchFeatures,
     ) -> Result<bool> {
         // Check if agent is already running with the same configuration.
         // try_connect_existing restores config from disk on reconnect,
@@ -846,6 +911,10 @@ impl AgentManager {
             // Reset to Stopped so start_with_full_config can proceed.
             self.reset_stale_running_state();
         }
+
+        // Re-attach packed layers if a config-change restart dropped them
+        // (see `rewire_packed_layers_if_extracted`).
+        self.rewire_packed_layers_if_extracted(&mut features)?;
 
         // Start with new config
         self.start_with_full_config(mounts, ports, resources, features)?;
@@ -1237,7 +1306,7 @@ impl AgentManager {
         mounts: Vec<HostMount>,
         ports: Vec<PortMapping>,
         resources: VmResources,
-        features: launcher::LaunchFeatures,
+        mut features: launcher::LaunchFeatures,
     ) -> Result<bool> {
         // Check if agent is already running (same logic as ensure_running_with_full_config)
         if self.try_connect_existing().is_some() {
@@ -1274,6 +1343,10 @@ impl AgentManager {
         } else {
             self.reset_stale_running_state();
         }
+
+        // Re-attach packed layers if a config-change restart dropped them
+        // (see `rewire_packed_layers_if_extracted`).
+        self.rewire_packed_layers_if_extracted(&mut features)?;
 
         self.start_via_subprocess(mounts, ports, resources, features)?;
         Ok(true)
@@ -1752,5 +1825,51 @@ mod tests {
             std::fs::read_to_string(dir.join("name")).unwrap(),
             "first-vm",
         );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn rewire_packed_layers_returns_lease_failure() {
+        let temp = tempfile::tempdir().unwrap();
+
+        let name = format!(
+            "review-rewire-lease-failure-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        struct VmDataCleanup(String);
+        impl Drop for VmDataCleanup {
+            fn drop(&mut self) {
+                smolvm_pack::extract::force_detach_layers_volume(&machine_layers_cache_dir(
+                    &self.0,
+                ));
+                let _ = std::fs::remove_dir_all(vm_data_dir(&self.0));
+            }
+        }
+        let _cleanup = VmDataCleanup(name.clone());
+
+        let storage = StorageDisk::open_or_create_at(&temp.path().join("storage.img"), 1).unwrap();
+        let overlay = OverlayDisk::open_or_create_at(&temp.path().join("overlay.img"), 1).unwrap();
+        let manager =
+            AgentManager::new_named(&name, temp.path().join("rootfs"), storage, overlay).unwrap();
+
+        let cache_dir = machine_layers_cache_dir(&name);
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        std::fs::write(cache_dir.join(".smolvm-extracted"), "").unwrap();
+        std::fs::write(cache_dir.join("layers-cs.sparseimage"), b"not a disk image").unwrap();
+
+        let mut features = launcher::LaunchFeatures::default();
+        let err = manager
+            .rewire_packed_layers_if_extracted(&mut features)
+            .expect_err("restart must fail when packed layers cannot be reattached");
+
+        assert!(
+            err.to_string().contains("re-attach packed layers"),
+            "unexpected error: {err}"
+        );
+        assert!(features.packed_layers_dir.is_none());
     }
 }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -21,8 +21,8 @@ pub use client::{
 pub use krun::KrunFunctions;
 pub use launcher::{find_lib_dir, launch_agent_vm, LaunchConfig, LaunchFeatures, VmDisks};
 pub use manager::{
-    docker_config_dir, docker_config_mount, ensure_vm_dir, vm_cache_root, vm_data_dir, vm_dir_hash,
-    AgentManager, AgentState,
+    docker_config_dir, docker_config_mount, ensure_vm_dir, machine_layers_cache_dir, vm_cache_root,
+    vm_data_dir, vm_dir_hash, AgentManager, AgentState,
 };
 
 /// Agent VM name.

--- a/src/api/handlers/exec.rs
+++ b/src/api/handlers/exec.rs
@@ -477,14 +477,14 @@ pub async fn exec_interactive(
         let input_pump = tokio::spawn(async move {
             while let Some(Ok(msg)) = ws_rx.next().await {
                 match msg {
-                    Message::Binary(b) => {
+                    Message::Binary(b)
                         if in_tx
                             .send(crate::agent::InteractiveInput::Stdin(b.to_vec()))
-                            .is_err()
-                        {
-                            break;
-                        }
+                            .is_err() =>
+                    {
+                        break;
                     }
+                    Message::Binary(_) => {}
                     Message::Text(t) => {
                         // Control frames are JSON; anything else is treated as raw stdin.
                         match serde_json::from_str::<serde_json::Value>(t.as_str()) {

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -131,6 +131,7 @@ fn machine_entry_from_record(record: &VmRecord, manager: AgentManager) -> Machin
         resources: vm_resources_to_spec(record.vm_resources()),
         restart: record.restart.clone(),
         network: record.network,
+        source_smolmachine: record.source_smolmachine.clone(),
     }
 }
 
@@ -257,12 +258,8 @@ pub async fn create_machine(
         }
         let manifest = smolvm_pack::packer::read_manifest_from_sidecar(path)
             .map_err(|e| ApiError::internal(format!("read .smolmachine: {}", e)))?;
-        let footer = smolvm_pack::packer::read_footer_from_sidecar(path)
-            .map_err(|e| ApiError::internal(format!("read sidecar footer: {}", e)))?;
-        let cache_dir = smolvm_pack::extract::get_cache_dir(footer.checksum)
-            .map_err(|e| ApiError::internal(format!("get cache dir: {}", e)))?;
-        smolvm_pack::extract::extract_sidecar(path, &cache_dir, &footer, false, false)
-            .map_err(|e| ApiError::internal(format!("extract sidecar: {}", e)))?;
+        // Extraction happens after the agent manager creates this machine's data
+        // dir (below), so the layers land in the machine's own dir, not here.
         let canonical = path
             .canonicalize()
             .unwrap_or_else(|_| path.to_path_buf())
@@ -324,6 +321,59 @@ pub async fn create_machine(
     .await
     .map_err(|e| ApiError::internal(format!("task error: {}", e)))??;
 
+    // Extract the bundle's OCI layers into this machine's own data dir (created
+    // by the manager above) rather than the shared pack cache, so every start is
+    // independent of the .smolmachine file surviving and the macOS layers volume
+    // is owned 1:1 by the machine. Extraction mounts the case-sensitive volume on
+    // macOS; detach it immediately so a created-but-unstarted machine leaves
+    // nothing mounted (invariant: the per-machine layers volume is mounted iff
+    // the VM is running). The name was reserved above, so this never clobbers
+    // another machine's layers.
+    if let Some(ref sidecar_path) = source_smolmachine {
+        let name = name.clone();
+        let sidecar_path = sidecar_path.clone();
+        tokio::task::spawn_blocking(move || -> Result<(), ApiError> {
+            let path = std::path::Path::new(&sidecar_path);
+            let cache_dir = crate::agent::machine_layers_cache_dir(&name);
+            let result = (|| {
+                smolvm_pack::extract::force_detach_layers_volume(&cache_dir);
+                match std::fs::remove_dir_all(&cache_dir) {
+                    Ok(()) => {}
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(e) => {
+                        return Err(ApiError::internal(format!(
+                            "clear packed layers cache: {}",
+                            e
+                        )));
+                    }
+                }
+                let footer = smolvm_pack::packer::read_footer_from_sidecar(path)
+                    .map_err(|e| ApiError::internal(format!("read sidecar footer: {}", e)))?;
+                smolvm_pack::extract::extract_sidecar(path, &cache_dir, &footer, false, false)
+                    .map_err(|e| ApiError::internal(format!("extract sidecar: {}", e)))
+            })();
+            // Detach the case-sensitive volume mounted during extraction so a
+            // created-but-unstarted machine leaves nothing mounted, and so the
+            // rollback below can remove the data dir cleanly (macOS; no-op on Linux).
+            smolvm_pack::extract::force_detach_layers_volume(&cache_dir);
+            if let Err(e) = result {
+                // Extraction failed after the manager created the machine's data
+                // dir. guard.complete() will not run, so no DB record persists and
+                // the name is released on drop — but the on-disk dir would be left
+                // orphaned. Roll it back so a retry starts clean. Best-effort: a
+                // remove failure only leaves the orphan, never a worse state.
+                // cache_dir is <vm_data_dir>/pack, so its parent is the data dir.
+                if let Some(vm_dir) = cache_dir.parent() {
+                    let _ = std::fs::remove_dir_all(vm_dir);
+                }
+                return Err(e);
+            }
+            Ok(())
+        })
+        .await
+        .map_err(|e| ApiError::internal(format!("task error: {}", e)))??;
+    }
+
     let resources = ResourceSpec {
         cpus: Some(cpus),
         memory_mb: Some(mem),
@@ -335,7 +385,7 @@ pub async fn create_machine(
     };
 
     // Complete registration: persists to DB + registers in ApiState
-    guard.complete(MachineRegistration {
+    let complete_result = guard.complete(MachineRegistration {
         manager,
         mounts: req.mounts.clone(),
         ports: req.ports.clone(),
@@ -363,7 +413,24 @@ pub async fn create_machine(
         cmd,
         env,
         workdir,
-    })?;
+    });
+    if let Err(e) = complete_result {
+        let data_dir = vm_data_dir(&name);
+        smolvm_pack::extract::force_detach_layers_volume(&crate::agent::machine_layers_cache_dir(
+            &name,
+        ));
+        if let Err(remove_err) = std::fs::remove_dir_all(&data_dir) {
+            if remove_err.kind() != std::io::ErrorKind::NotFound {
+                tracing::warn!(
+                    machine = %name,
+                    dir = %data_dir.display(),
+                    error = %remove_err,
+                    "failed to remove machine data dir after create commit failure"
+                );
+            }
+        }
+        return Err(e);
+    }
 
     // Fetch the persisted record for the response
     let db = state.db();
@@ -443,6 +510,16 @@ pub async fn start_machine(
     State(state): State<Arc<ApiState>>,
     Path(name): Path<String>,
 ) -> Result<Json<MachineInfo>, ApiError> {
+    // Hold the per-machine lifecycle lock across the whole start so a concurrent
+    // stop/delete cannot detach the macOS layers volume between our acquire+mount
+    // and the launch, nor launch a guest into the launcher's missing-dir error
+    // (review finding #3). Acquired before the DB read and resolve_state probe
+    // below so the "is it running?" decision and the launch happen under one held
+    // lock; it is the outermost lock (the entry mutex is taken later, inside the
+    // spawn_blocking). Linux: the guarded detach/mount are no-ops.
+    let lifecycle = state.lifecycle_lock(&name);
+    let _guard = lifecycle.lock().await;
+
     // Get VM record from database
     let db = state.db();
     let record = db
@@ -511,12 +588,19 @@ pub async fn start_machine(
     let name_clone = name.clone();
     let storage_gb = record.storage_gb;
     let overlay_gb = record.overlay_gb;
+    let source_smolmachine = record.source_smolmachine.clone();
     let (manager, pid) = tokio::task::spawn_blocking(move || {
         let manager = AgentManager::for_vm_with_sizes(&name_clone, storage_gb, overlay_gb)
             .map_err(|e| format!("failed to create agent manager: {}", e))?;
 
+        // Wire pre-extracted layers if this machine was created from a .smolmachine.
+        let features = crate::api::state::build_launch_features(
+            Some(&name_clone),
+            source_smolmachine.as_deref(),
+        )
+        .map_err(|e| format!("failed to prepare packed layers: {}", e))?;
         let _ = manager
-            .ensure_running_via_subprocess(mounts, ports, resources, Default::default())
+            .ensure_running_via_subprocess(mounts, ports, resources, features)
             .map_err(|e| format!("failed to start machine: {}", e))?;
 
         let pid = manager.child_pid();
@@ -575,6 +659,16 @@ pub async fn stop_machine(
     State(state): State<Arc<ApiState>>,
     Path(name): Path<String>,
 ) -> Result<Json<MachineInfo>, ApiError> {
+    // Hold the per-machine lifecycle lock across the whole stop so the layers
+    // volume detach below cannot race a concurrent start's acquire+mount+launch
+    // (review finding #3). Acquired before the DB read and actual_state() probe
+    // so the liveness check and the detach act on the same held lock — without
+    // it, stop could decide "running" off a snapshot a concurrent start has
+    // already superseded, then detach a volume that start just mounted. Outermost
+    // lock; the entry mutex is not taken here. Linux: detach is a no-op.
+    let lifecycle = state.lifecycle_lock(&name);
+    let _guard = lifecycle.lock().await;
+
     // Get VM record from database
     let db = state.db();
     let record = db
@@ -585,7 +679,23 @@ pub async fn stop_machine(
     // Check state
     let actual_state = record.actual_state();
     if actual_state != RecordState::Running {
-        // Already stopped, just return current info
+        // Not running. If a prior start mounted the layers volume but the VM
+        // then failed to boot (or the server crashed while running), the volume
+        // could still be mounted — detach it so a stopped machine never holds a
+        // mount (invariant: the per-machine layers volume is mounted iff the VM
+        // is running). Safe: actual_state() probed liveness, so the process is
+        // confirmed dead and nothing is using the volume. macOS hdiutil detach;
+        // a no-op on Linux.
+        if record.source_smolmachine.is_some() {
+            let name_clone = name.clone();
+            tokio::task::spawn_blocking(move || {
+                smolvm_pack::extract::force_detach_layers_volume(
+                    &crate::agent::machine_layers_cache_dir(&name_clone),
+                );
+            })
+            .await
+            .map_err(|e| ApiError::internal(format!("task error: {}", e)))?;
+        }
         return Ok(Json(record_to_info(&name, &record)));
     }
 
@@ -599,7 +709,7 @@ pub async fn stop_machine(
     let entry = state.get_machine(&name).ok();
     let name_clone = name.clone();
     let stopped = tokio::task::spawn_blocking(move || {
-        if let Some(ref entry) = entry {
+        let ok = if let Some(ref entry) = entry {
             let e = entry.lock();
             match e.manager.stop() {
                 Ok(()) => true,
@@ -610,7 +720,17 @@ pub async fn stop_machine(
             }
         } else {
             shutdown_machine_process(&name_clone, pid, pid_start_time)
+        };
+        if ok {
+            // Process is gone — detach this machine's case-sensitive layers
+            // volume (macOS hdiutil mount; no-op on Linux). The volume lives
+            // under the machine's own data dir and is owned 1:1 by it, so the
+            // detach is unconditional and re-acquired on the next start.
+            smolvm_pack::extract::force_detach_layers_volume(
+                &crate::agent::machine_layers_cache_dir(&name_clone),
+            );
         }
+        ok
     })
     .await
     .map_err(|e| ApiError::internal(format!("task error: {}", e)))?;
@@ -658,6 +778,15 @@ pub async fn delete_machine(
     State(state): State<Arc<ApiState>>,
     Path(name): Path<String>,
 ) -> Result<Json<DeleteResponse>, ApiError> {
+    // Hold the per-machine lifecycle lock across the whole delete so the layers
+    // volume detach (before the data-dir removal) cannot race a concurrent
+    // start's acquire+mount+launch (review finding #3). Acquired before the DB
+    // read so the existence check, shutdown, detach, and removal all happen under
+    // one held lock. Outermost lock; the entry mutex is not taken here. Linux:
+    // detach is a no-op.
+    let lifecycle = state.lifecycle_lock(&name);
+    let _guard = lifecycle.lock().await;
+
     let db = state.db();
 
     // Check if VM exists and get its state
@@ -673,7 +802,17 @@ pub async fn delete_machine(
     // Stop if running (in blocking task)
     let name_clone = name.clone();
     let stopped = tokio::task::spawn_blocking(move || {
-        shutdown_machine_process(&name_clone, pid, pid_start_time)
+        let ok = shutdown_machine_process(&name_clone, pid, pid_start_time);
+        if ok {
+            // Process is gone — detach this machine's case-sensitive layers
+            // volume (macOS hdiutil mount; no-op on Linux) before the data dir is
+            // removed below, otherwise `rm -rf` fails with "Resource busy". The
+            // volume is owned 1:1 by this machine, so the detach is unconditional.
+            smolvm_pack::extract::force_detach_layers_volume(
+                &crate::agent::machine_layers_cache_dir(&name_clone),
+            );
+        }
+        ok
     })
     .await
     .map_err(|e| ApiError::internal(format!("task error: {}", e)))?;

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -27,6 +27,28 @@ pub struct ApiState {
     /// Reserved machine names (creation in progress).
     /// This prevents race conditions during machine creation.
     reserved_names: RwLock<HashSet<String>>,
+    /// Per-machine lifecycle locks serializing start/stop/delete/restart.
+    ///
+    /// On macOS, stop/delete `hdiutil`-detach a machine's case-sensitive
+    /// packed-layers volume while a concurrent start acquires+mounts+launches
+    /// against it. Without exclusion a detach can pull the volume out from under
+    /// a freshly-launched VM serving it over virtiofs, or a guest launched in the
+    /// detach window hits the launcher's missing-dir error (review finding #3).
+    /// Each lifecycle handler `.lock().await`s this per-name async mutex as its
+    /// outermost lock — before any DB read or `MachineEntry` mutex — and holds it
+    /// for the whole operation, so mount and detach can never interleave for one
+    /// machine. Lock order is lifecycle (tokio, async) → entry (parking_lot,
+    /// inside `spawn_blocking`); no entry-holding path ever takes lifecycle, so
+    /// there is no inversion. On Linux the guarded detach/mount are compile-time
+    /// no-ops, making this harmless serialization. Scope: the API server only —
+    /// the embedded (`control.rs`) and CLI (`vm_common.rs`) paths are separate
+    /// processes with no shared in-process lock.
+    ///
+    /// Entries are created on first use and never removed: the map is bounded by
+    /// the number of distinct machine names, so a retained `Arc<Mutex<()>>` per
+    /// deleted name is negligible, and never removing avoids handing two callers
+    /// different mutexes for the same name (which would defeat the exclusion).
+    lifecycle_locks: RwLock<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
     /// Database for persistent state.
     db: SmolvmDb,
     /// Previous CPU samples per VM PID, used to compute the fractional-CPU
@@ -48,6 +70,11 @@ pub struct MachineEntry {
     pub restart: RestartConfig,
     /// Whether outbound network access is enabled.
     pub network: bool,
+    /// Path to the `.smolmachine` sidecar this machine was created from, if any.
+    /// When set, the start paths mount the bundle's pre-extracted OCI layers via
+    /// virtiofs instead of having the guest pull from a registry. `None` for
+    /// image/registry-sourced machines. Mirrors `VmRecord::source_smolmachine`.
+    pub source_smolmachine: Option<String>,
 }
 
 /// Parameters for registering a new machine.
@@ -97,16 +124,19 @@ pub struct MachineRegistration {
 pub struct ReservationGuard<'a> {
     state: &'a ApiState,
     name: String,
+    token: String,
     completed: bool,
 }
 
 impl<'a> ReservationGuard<'a> {
     /// Reserve a machine name. Returns a guard that auto-releases on drop.
     pub fn new(state: &'a ApiState, name: String) -> Result<Self, ApiError> {
-        state.reserve_machine_name(&name)?;
+        let token = SmolvmDb::create_reservation_token();
+        state.reserve_machine_name(&name, &token)?;
         Ok(Self {
             state,
             name,
+            token,
             completed: false,
         })
     }
@@ -120,18 +150,18 @@ impl<'a> ReservationGuard<'a> {
     ///
     /// This transfers ownership of the name to the machine registry.
     pub fn complete(mut self, registration: MachineRegistration) -> Result<(), ApiError> {
-        // Mark as completed before calling complete_machine_registration
-        // (which will remove from reservations internally)
-        self.completed = true;
         self.state
-            .complete_machine_registration(self.name.clone(), registration)
+            .complete_machine_registration(self.name.clone(), &self.token, registration)?;
+        self.completed = true;
+        Ok(())
     }
 }
 
 impl Drop for ReservationGuard<'_> {
     fn drop(&mut self) {
         if !self.completed {
-            self.state.release_machine_reservation(&self.name);
+            self.state
+                .release_machine_reservation(&self.name, &self.token);
             tracing::debug!(machine = %self.name, "reservation guard released on drop");
         }
     }
@@ -151,6 +181,7 @@ impl ApiState {
         Ok(Self {
             machines: RwLock::new(HashMap::new()),
             reserved_names: RwLock::new(HashSet::new()),
+            lifecycle_locks: RwLock::new(HashMap::new()),
             db,
             cpu_samples: parking_lot::Mutex::new(HashMap::new()),
         })
@@ -163,6 +194,7 @@ impl ApiState {
         Self {
             machines: RwLock::new(HashMap::new()),
             reserved_names: RwLock::new(HashSet::new()),
+            lifecycle_locks: RwLock::new(HashMap::new()),
             db,
             cpu_samples: parking_lot::Mutex::new(HashMap::new()),
         }
@@ -255,6 +287,7 @@ impl ApiState {
                             resources,
                             restart: record.restart.clone(),
                             network: record.network,
+                            source_smolmachine: record.source_smolmachine.clone(),
                         })),
                     );
                     loaded.push(name.clone());
@@ -281,6 +314,28 @@ impl ApiState {
             .get(name)
             .cloned()
             .ok_or_else(|| ApiError::NotFound(format!("machine '{}' not found", name)))
+    }
+
+    /// Get the per-machine lifecycle lock for `name`, creating it on first use.
+    ///
+    /// Callers `.lock().await` the returned mutex at the top of
+    /// start/stop/delete/restart and hold the guard for the whole operation so
+    /// the macOS layers-volume mount (start) and detach (stop/delete) can never
+    /// interleave for one machine. See the `lifecycle_locks` field docs for the
+    /// lock-ordering and scope contract.
+    pub fn lifecycle_lock(&self, name: &str) -> Arc<tokio::sync::Mutex<()>> {
+        // Fast path: the lock already exists (the common case after first use).
+        if let Some(lock) = self.lifecycle_locks.read().get(name) {
+            return lock.clone();
+        }
+        // Slow path: create it under the write lock. `or_insert_with` collapses
+        // the race where two callers reach here for the same name concurrently —
+        // both end up with the same `Arc`, preserving mutual exclusion.
+        self.lifecycle_locks
+            .write()
+            .entry(name.to_string())
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
     }
 
     /// Remove a machine from the registry (also removes from database).
@@ -488,7 +543,7 @@ impl ApiState {
     /// - `release_machine_reservation()` is called (failure/cleanup)
     ///
     /// Returns `Err(Conflict)` if the name is already taken or reserved.
-    pub fn reserve_machine_name(&self, name: &str) -> Result<(), ApiError> {
+    pub fn reserve_machine_name(&self, name: &str, token: &str) -> Result<(), ApiError> {
         // First check: machine existence (early exit for common case).
         // Use separate scope to release read lock before acquiring write lock.
         // This prevents lock-order inversion with complete_machine_registration.
@@ -522,16 +577,23 @@ impl ApiState {
             )));
         }
 
-        // Also check database for persisted machines not yet loaded
-        if let Ok(Some(_)) = self.db.get_vm(name) {
-            return Err(ApiError::Conflict(format!(
-                "machine '{}' already exists in database",
-                name
-            )));
+        reserved.insert(name.to_string());
+
+        match self.db.reserve_vm_create(name, token) {
+            Ok(true) => {}
+            Ok(false) => {
+                reserved.remove(name);
+                return Err(ApiError::Conflict(format!(
+                    "machine '{}' already exists or is being created",
+                    name
+                )));
+            }
+            Err(e) => {
+                reserved.remove(name);
+                return Err(ApiError::database(e));
+            }
         }
 
-        // Reserve the name
-        reserved.insert(name.to_string());
         tracing::debug!(machine = %name, "reserved machine name");
         Ok(())
     }
@@ -539,10 +601,13 @@ impl ApiState {
     /// Release a machine name reservation.
     ///
     /// Call this if machine creation fails after `reserve_machine_name()`.
-    pub fn release_machine_reservation(&self, name: &str) {
+    pub fn release_machine_reservation(&self, name: &str, token: &str) {
         let mut reserved = self.reserved_names.write();
         if reserved.remove(name) {
             tracing::debug!(machine = %name, "released machine name reservation");
+        }
+        if let Err(e) = self.db.release_vm_create_reservation(name, token) {
+            tracing::warn!(machine = %name, error = %e, "failed to release DB create reservation");
         }
     }
 
@@ -553,17 +618,9 @@ impl ApiState {
     pub fn complete_machine_registration(
         &self,
         name: String,
+        token: &str,
         reg: MachineRegistration,
     ) -> Result<(), ApiError> {
-        // Remove from reservations
-        {
-            let mut reserved = self.reserved_names.write();
-            if !reserved.remove(&name) {
-                // Name wasn't reserved - this is a programming error
-                tracing::warn!(machine = %name, "completing registration for non-reserved name");
-            }
-        }
-
         // Persist to database (with conflict detection)
         let mut record = VmRecord::new_with_restart(
             name.clone(),
@@ -582,15 +639,23 @@ impl ApiState {
         record.storage_gb = reg.resources.storage_gb;
         record.overlay_gb = reg.resources.overlay_gb;
         record.image = reg.image;
-        record.source_smolmachine = reg.source_smolmachine;
+        record.source_smolmachine = reg.source_smolmachine.clone();
         record.entrypoint = reg.entrypoint;
         record.cmd = reg.cmd;
         record.env = reg.env;
         record.workdir = reg.workdir;
 
-        // Use insert_vm_if_not_exists for atomic database insert
-        match self.db.insert_vm_if_not_exists(&name, &record) {
+        // Complete the cross-process create reservation and insert the VM row
+        // atomically. Only after that succeeds do we publish the in-memory entry.
+        match self.db.commit_reserved_vm(&name, token, &record) {
             Ok(true) => {
+                {
+                    let mut reserved = self.reserved_names.write();
+                    if !reserved.remove(&name) {
+                        // Name wasn't reserved - this is a programming error
+                        tracing::warn!(machine = %name, "completing registration for non-reserved name");
+                    }
+                }
                 // Successfully inserted, now add to in-memory registry
                 let mut machines = self.machines.write();
                 machines.insert(
@@ -602,14 +667,15 @@ impl ApiState {
                         resources: reg.resources,
                         restart: reg.restart,
                         network: reg.network,
+                        source_smolmachine: reg.source_smolmachine,
                     })),
                 );
                 Ok(())
             }
             Ok(false) => {
-                // Name already exists in database (shouldn't happen with reservation)
+                // Name already exists or the DB reservation was lost.
                 Err(ApiError::Conflict(format!(
-                    "machine '{}' already exists in database",
+                    "machine '{}' already exists or is no longer reserved",
                     name
                 )))
             }
@@ -758,11 +824,43 @@ where
 // Shared Machine Helpers
 // ============================================================================
 
+/// Build `LaunchFeatures` for an API-driven machine start.
+///
+/// Thin wrapper over [`crate::agent::LaunchFeatures::with_packed_layers`]
+/// — the single source of truth shared with the CLI and embedded start paths.
+/// When the machine was created from a `.smolmachine` artifact
+/// (`source_smolmachine` is set), its pre-extracted OCI layers — extracted into
+/// the machine's own data dir at create time, keyed by `machine_name` — are
+/// mounted via virtiofs so the guest uses them instead of pulling from a
+/// registry; otherwise default features are returned. Without it the three API
+/// start entrypoints (`start_machine`, `ensure_machine_running`, supervisor
+/// restart) would pass `packed_layers_dir = None` and the guest would fall back
+/// to a network pull. Performs blocking filesystem work — call from within a
+/// `spawn_blocking` context.
+pub fn build_launch_features(
+    machine_name: Option<&str>,
+    source_smolmachine: Option<&str>,
+) -> crate::Result<crate::agent::LaunchFeatures> {
+    let features = crate::agent::LaunchFeatures::default();
+    match machine_name {
+        Some(name) => features.with_packed_layers(
+            &crate::agent::machine_layers_cache_dir(name),
+            source_smolmachine,
+        ),
+        None => Ok(features),
+    }
+}
+
 /// Ensure a machine is running, starting it if needed.
 ///
 /// This is the shared preflight check used by exec, container, and image handlers.
 /// It converts the machine's mount/port/resource config and calls
 /// `ensure_running_with_full_config` in a blocking task.
+///
+/// On the not-already-up path this mounts the machine's macOS layers volume, so
+/// callers MUST hold the per-machine lifecycle lock (see `ensure_running_and_persist`,
+/// the only caller) for the duration, or the mount can race a concurrent
+/// stop/delete detach (review finding #3).
 pub async fn ensure_machine_running(
     entry: &Arc<parking_lot::Mutex<MachineEntry>>,
 ) -> crate::Result<()> {
@@ -778,12 +876,28 @@ pub async fn ensure_machine_running(
         let resources = resource_spec_to_vm_resources(&entry.resources, entry.network);
 
         // Use subprocess launch to avoid macOS fork-in-multithreaded-process issue.
-        entry.manager.ensure_running_via_subprocess(
-            mounts,
-            ports,
-            resources,
-            Default::default(),
-        )?;
+        //
+        // Build the packed-layers features only when the VM is not already up.
+        // This preflight runs on every implicit-start request (exec/run/files/
+        // images); when the VM is already running `ensure_running_via_subprocess`
+        // returns early (discarding `features`) as long as the mount/port/resource
+        // config is unchanged. Acquiring the layers lease on that hot path is
+        // wasted work — on macOS it re-mounts the case-sensitive volume via
+        // hdiutil — so gate it on the same already-running check.
+        //
+        // The gated `default()` is safe across the relaunch branch too: if the
+        // preflight detects a mount/port/resource change and restarts the VM,
+        // `ensure_running_via_subprocess` re-attaches this machine's pre-extracted
+        // packed layers itself (see `rewire_packed_layers_if_extracted`), so the
+        // restart keeps using them instead of falling back to a registry pull.
+        let features = if entry.manager.try_connect_existing().is_some() {
+            crate::agent::LaunchFeatures::default()
+        } else {
+            build_launch_features(entry.manager.name(), entry.source_smolmachine.as_deref())?
+        };
+        entry
+            .manager
+            .ensure_running_via_subprocess(mounts, ports, resources, features)?;
         Ok(())
     })
     .await
@@ -800,6 +914,17 @@ pub async fn ensure_running_and_persist(
     name: &str,
     entry: &Arc<parking_lot::Mutex<MachineEntry>>,
 ) -> crate::Result<()> {
+    // Hold the per-machine lifecycle lock across the implicit-start preflight.
+    // ensure_machine_running mounts the macOS layers volume (via with_packed_layers)
+    // when the VM is not already up — exactly like the explicit start_machine — so
+    // it must exclude against a concurrent stop/delete detach the same way (review
+    // finding #3 covers "start/ensure"). Acquired before ensure_machine_running's
+    // spawn_blocking takes the entry mutex, preserving the lifecycle → entry order;
+    // released before the caller's actual exec/file/image op, which neither mounts
+    // nor detaches. On Linux the guarded mount is a no-op, so this is harmless.
+    let lifecycle = state.lifecycle_lock(name);
+    let _guard = lifecycle.lock().await;
+
     ensure_machine_running(entry).await?;
 
     let pid = {
@@ -1047,7 +1172,8 @@ mod tests {
         );
 
         // Name should be available for reuse
-        assert!(state.reserve_machine_name("dead-machine").is_ok());
+        let token = SmolvmDb::create_reservation_token();
+        assert!(state.reserve_machine_name("dead-machine", &token).is_ok());
     }
 
     #[test]

--- a/src/api/supervisor.rs
+++ b/src/api/supervisor.rs
@@ -137,6 +137,17 @@ impl Supervisor {
 
     /// Attempt to restart a machine.
     async fn restart_machine(&self, name: &str) -> crate::Result<()> {
+        // Hold the per-machine lifecycle lock across the acquire+mount+launch so a
+        // concurrent user-initiated stop/delete cannot detach the macOS layers
+        // volume out from under this restart (review finding #3). Acquired before
+        // get_machine and the entry-mutex lock taken inside the spawn_blocking
+        // below, keeping the lifecycle → entry lock order that start/stop/delete
+        // also follow. If a user op holds it, this restart blocks until that op
+        // completes (operations are bounded), then re-derives state from the DB.
+        // Linux: the guarded mount is a no-op.
+        let lifecycle = self.state.lifecycle_lock(name);
+        let _guard = lifecycle.lock().await;
+
         let entry = match self.state.get_machine(name) {
             Ok(entry) => entry,
             Err(_) => {
@@ -163,16 +174,20 @@ impl Supervisor {
         let mounts = record.host_mounts();
         let ports = record.port_mappings();
         let resources = record.vm_resources();
+        let source_smolmachine = record.source_smolmachine.clone();
+        let name_for_features = name.to_string();
 
         let entry_clone = entry.clone();
         let start_result = tokio::task::spawn_blocking(move || {
             let entry = entry_clone.lock();
-            entry.manager.ensure_running_via_subprocess(
-                mounts,
-                ports,
-                resources,
-                Default::default(),
-            )
+            // Wire pre-extracted layers if this machine was created from a .smolmachine.
+            let features = crate::api::state::build_launch_features(
+                Some(&name_for_features),
+                source_smolmachine.as_deref(),
+            )?;
+            entry
+                .manager
+                .ensure_running_via_subprocess(mounts, ports, resources, features)
         })
         .await
         .map_err(|e| crate::Error::agent("ensure running", e.to_string()))?;

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -1492,14 +1492,11 @@ impl CreateCmd {
         let manifest = smolvm_pack::packer::read_manifest_from_sidecar(sidecar_path)
             .map_err(|e| smolvm::Error::agent("read .smolmachine", e.to_string()))?;
 
-        // Pre-extract the sidecar so first `machine start` is fast.
+        // Read the footer now; the bundle is extracted into the machine's own
+        // data dir after `create_vm` succeeds (below), so a duplicate-name create
+        // cannot clobber an existing machine's layers.
         let footer = smolvm_pack::packer::read_footer_from_sidecar(sidecar_path)
             .map_err(|e| smolvm::Error::agent("read sidecar footer", e.to_string()))?;
-        let cache_dir = smolvm_pack::extract::get_cache_dir(footer.checksum)
-            .map_err(|e| smolvm::Error::agent("get cache dir", e.to_string()))?;
-        println!("Extracting .smolmachine assets...");
-        smolvm_pack::extract::extract_sidecar(sidecar_path, &cache_dir, &footer, false, false)
-            .map_err(|e| smolvm::Error::agent("extract sidecar", e.to_string()))?;
 
         // Resolve the canonical path for storage in VmRecord.
         let canonical_path = sidecar_path
@@ -1512,6 +1509,9 @@ impl CreateCmd {
             .name
             .clone()
             .unwrap_or_else(smolvm::util::generate_machine_name);
+        // `name` is moved into `params` below; keep a copy for the post-create
+        // extraction that targets this machine's own data dir.
+        let name_for_layers = name.clone();
 
         // CLI flags override manifest defaults.
         let cpus = if self.cpus != DEFAULT_MICROVM_CPU_COUNT {
@@ -1561,7 +1561,71 @@ impl CreateCmd {
             source_smolmachine: Some(canonical_path),
         };
 
-        vm_common::create_vm(params)
+        let record = vm_common::build_vm_record(&params)?;
+        let reservation = vm_common::CreateVmReservation::reserve(&name_for_layers)?;
+
+        // Create the machine data dir while the DB reservation is held, then
+        // extract before publishing the VM row. Other processes either see the
+        // reservation conflict or the finished VM, never a half-created record.
+        let create_result = (|| -> smolvm::Result<()> {
+            let _manager = AgentManager::for_vm_with_sizes(
+                &name_for_layers,
+                params.storage_gb,
+                params.overlay_gb,
+            )?;
+
+            let cache_dir = smolvm::agent::machine_layers_cache_dir(&name_for_layers);
+            smolvm_pack::extract::force_detach_layers_volume(&cache_dir);
+            match std::fs::remove_dir_all(&cache_dir) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => {
+                    return Err(smolvm::Error::agent(
+                        "clear packed layers cache",
+                        e.to_string(),
+                    ));
+                }
+            }
+
+            println!("Extracting .smolmachine assets...");
+            let result = smolvm_pack::extract::extract_sidecar(
+                sidecar_path,
+                &cache_dir,
+                &footer,
+                false,
+                false,
+            )
+            .map_err(|e| smolvm::Error::agent("extract sidecar", e.to_string()));
+            // Detach unconditionally: extraction mounts the case-sensitive volume on
+            // macOS even when it later fails, so the detach must run on both success
+            // and failure paths to honor the "mounted iff running" invariant.
+            smolvm_pack::extract::force_detach_layers_volume(&cache_dir);
+            result?;
+
+            reservation.commit(&record)?;
+            Ok(())
+        })();
+
+        if let Err(e) = create_result {
+            smolvm_pack::extract::force_detach_layers_volume(
+                &smolvm::agent::machine_layers_cache_dir(&name_for_layers),
+            );
+            let data_dir = smolvm::agent::vm_data_dir(&name_for_layers);
+            if let Err(remove_err) = std::fs::remove_dir_all(&data_dir) {
+                if remove_err.kind() != std::io::ErrorKind::NotFound {
+                    tracing::warn!(
+                        machine = %name_for_layers,
+                        dir = %data_dir.display(),
+                        error = %remove_err,
+                        "failed to remove machine data dir after create failure"
+                    );
+                }
+            }
+            return Err(e);
+        }
+
+        vm_common::print_create_success(&params);
+        Ok(())
     }
 }
 

--- a/src/cli/parsers.rs
+++ b/src/cli/parsers.rs
@@ -147,9 +147,13 @@ mod tests {
         // Resolve a well-known hostname — should return at least one IP
         let cidrs = resolve_host_to_cidrs("one.one.one.one").unwrap();
         assert!(!cidrs.is_empty());
-        // All results should be /32 CIDRs
+        // IPv4 results should be /32 CIDRs; IPv6 results should be /128 CIDRs.
         for cidr in &cidrs {
-            assert!(cidr.ends_with("/32"), "expected /32 CIDR, got {}", cidr);
+            assert!(
+                cidr.ends_with("/32") || cidr.ends_with("/128"),
+                "expected host CIDR, got {}",
+                cidr
+            );
         }
     }
 

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -440,22 +440,83 @@ pub struct CreateVmParams {
 
 /// Create a named machine configuration (does not start it).
 pub fn create_vm(params: CreateVmParams) -> smolvm::Result<()> {
+    let record = build_vm_record(&params)?;
+    let reservation = CreateVmReservation::reserve(&params.name)?;
+    reservation.commit(&record)?;
+    print_create_success(&params);
+    Ok(())
+}
+
+/// Cross-process reservation held while a create operation prepares any
+/// name-derived on-disk state. Dropping it releases the DB reservation unless
+/// it was committed.
+pub(crate) struct CreateVmReservation {
+    db: SmolvmDb,
+    name: String,
+    token: String,
+    completed: bool,
+}
+
+impl CreateVmReservation {
+    pub(crate) fn reserve(name: &str) -> smolvm::Result<Self> {
+        let db = SmolvmDb::open()?;
+        let token = SmolvmDb::create_reservation_token();
+        if !db.reserve_vm_create(name, &token)? {
+            return Err(smolvm::Error::config(
+                "create machine",
+                format!("machine '{}' already exists or is being created", name),
+            ));
+        }
+        Ok(Self {
+            db,
+            name: name.to_string(),
+            token,
+            completed: false,
+        })
+    }
+
+    pub(crate) fn commit(mut self, record: &VmRecord) -> smolvm::Result<()> {
+        if !self
+            .db
+            .commit_reserved_vm(&self.name, &self.token, record)?
+        {
+            return Err(smolvm::Error::config(
+                "create machine",
+                format!(
+                    "machine '{}' already exists or is no longer reserved",
+                    self.name
+                ),
+            ));
+        }
+        self.completed = true;
+        Ok(())
+    }
+}
+
+impl Drop for CreateVmReservation {
+    fn drop(&mut self) {
+        if !self.completed {
+            if let Err(e) = self
+                .db
+                .release_vm_create_reservation(&self.name, &self.token)
+            {
+                tracing::warn!(
+                    machine = %self.name,
+                    error = %e,
+                    "failed to release DB create reservation"
+                );
+            }
+        }
+    }
+}
+
+pub(crate) fn build_vm_record(params: &CreateVmParams) -> smolvm::Result<VmRecord> {
     // Validate name before touching the database. The on-disk layout uses
     // a hash-derived directory (see `vm_data_dir`), so the name itself has
     // no impact on socket path length — only character sanity + a generous
     // length cap are needed here.
     validate_vm_name(&params.name, "machine name")
         .map_err(|reason| smolvm::Error::config("create machine", reason))?;
-
-    let mut config = SmolvmConfig::load()?;
-
-    // Check if already exists
-    if config.get_vm(&params.name).is_some() {
-        return Err(smolvm::Error::config(
-            "create machine",
-            format!("machine '{}' already exists", params.name),
-        ));
-    }
 
     // Parse and validate volume mounts
     let mounts = HostMount::parse(&params.volume)?
@@ -473,6 +534,7 @@ pub fn create_vm(params: CreateVmParams) -> smolvm::Result<()> {
     let restart = smolvm::config::RestartConfig {
         policy: params
             .restart_policy
+            .clone()
             .unwrap_or(smolvm::config::RestartPolicy::Never),
         max_retries: params.restart_max_retries.unwrap_or(0),
         max_backoff_secs: params.restart_max_backoff_secs.unwrap_or(0),
@@ -512,9 +574,10 @@ pub fn create_vm(params: CreateVmParams) -> smolvm::Result<()> {
     record.dns_filter_hosts = params.dns_filter_hosts.clone();
     record.source_smolmachine = params.source_smolmachine.clone();
 
-    // Store in config (persisted immediately to database)
-    config.insert_vm(params.name.clone(), record)?;
+    Ok(record)
+}
 
+pub(crate) fn print_create_success(params: &CreateVmParams) {
     println!("Created machine: {}", params.name);
     println!("  CPUs: {}, Memory: {} MiB", params.cpus, params.mem);
     if !params.volume.is_empty() {
@@ -534,8 +597,6 @@ pub fn create_vm(params: CreateVmParams) -> smolvm::Result<()> {
         "Then use 'smolvm machine exec --name {} -- <command>' to run commands",
         params.name
     );
-
-    Ok(())
 }
 
 // ============================================================================
@@ -647,40 +708,20 @@ pub fn start_vm_named(
         None
     };
 
-    let mut features = smolvm::agent::LaunchFeatures {
+    // If the machine was created from a .smolmachine, this acquires a lease on
+    // the machine's own pre-extracted layers (extracted at create time) and sets
+    // packed_layers_dir so the launcher mounts them via virtiofs — the guest uses
+    // the pre-extracted layers instead of pulling, with no dependency on the
+    // original bundle file. Shared with the API and embedded start paths.
+    let features = smolvm::agent::LaunchFeatures {
         ssh_agent_socket,
         dns_filter_hosts: record.dns_filter_hosts.clone(),
-        packed_layers_dir: None,
-        extra_disks: Vec::new(),
-    };
-
-    // If machine was created from .smolmachine, extract layers to cache and
-    // mount via virtiofs so the agent uses pre-extracted layers instead of
-    // pulling from a registry.
-    if let Some(ref sidecar_path) = record.source_smolmachine {
-        let sidecar = std::path::Path::new(sidecar_path);
-        if !sidecar.exists() {
-            return Err(Error::agent(
-                "start machine",
-                format!(
-                    "source .smolmachine not found: {}\nThe file may have been moved or deleted.",
-                    sidecar_path
-                ),
-            ));
-        }
-        let footer = smolvm_pack::packer::read_footer_from_sidecar(sidecar)
-            .map_err(|e| Error::agent("read sidecar footer", e.to_string()))?;
-        let cache_dir = smolvm_pack::extract::get_cache_dir(footer.checksum)
-            .map_err(|e| Error::agent("get cache dir", e.to_string()))?;
-        smolvm_pack::extract::extract_sidecar(sidecar, &cache_dir, &footer, false, false)
-            .map_err(|e| Error::agent("extract sidecar", e.to_string()))?;
-        let layers_lease = smolvm_pack::extract::acquire_layers_lease(&cache_dir, false)
-            .map_err(|e| Error::agent("acquire layers lease", e.to_string()))?;
-        features.packed_layers_dir = Some(layers_lease.path.clone());
-        // Leak the lease — the volume must stay mounted while the VM runs.
-        // Cleanup happens via `pack prune` or on next `machine start`.
-        std::mem::forget(layers_lease);
+        ..Default::default()
     }
+    .with_packed_layers(
+        &smolvm::agent::machine_layers_cache_dir(name),
+        record.source_smolmachine.as_deref(),
+    )?;
 
     let _ = manager
         .ensure_running_with_full_config(mounts, ports, resources, features)
@@ -1052,6 +1093,14 @@ pub fn stop_vm_named(name: &str) -> smolvm::Result<()> {
     match resolved {
         RecordState::Unreachable => {
             cli_recover_if_unreachable(name);
+            // Process is gone — detach the layers volume so a non-running
+            // machine never holds a mount (invariant: mounted iff running).
+            // macOS hdiutil detach; a no-op on Linux.
+            if record.source_smolmachine.is_some() {
+                smolvm_pack::extract::force_detach_layers_volume(
+                    &smolvm::agent::machine_layers_cache_dir(name),
+                );
+            }
             println!("Stopped machine: {}", name);
             return Ok(());
         }
@@ -1059,6 +1108,15 @@ pub fn stop_vm_named(name: &str) -> smolvm::Result<()> {
             // fall through to the normal stop path
         }
         other => {
+            // Not running. If a prior start mounted the layers volume but the
+            // VM failed to boot, it could still be mounted — detach it. Safe:
+            // resolve_state() probed liveness, so the process is confirmed dead.
+            // macOS hdiutil detach; a no-op on Linux.
+            if record.source_smolmachine.is_some() {
+                smolvm_pack::extract::force_detach_layers_volume(
+                    &smolvm::agent::machine_layers_cache_dir(name),
+                );
+            }
             println!("Machine '{}' is not running (state: {})", name, other);
             return Ok(());
         }
@@ -1069,6 +1127,15 @@ pub fn stop_vm_named(name: &str) -> smolvm::Result<()> {
     let manager = AgentManager::for_vm(name)
         .map_err(|e| smolvm::Error::agent("create agent manager", e.to_string()))?;
     manager.stop()?;
+
+    // Detach the machine's case-sensitive layers volume now that its process is
+    // gone (macOS hdiutil mount; no-op on Linux). The volume is owned 1:1 by this
+    // machine, so the detach is safe and re-acquired on the next start.
+    if record.source_smolmachine.is_some() {
+        smolvm_pack::extract::force_detach_layers_volume(&smolvm::agent::machine_layers_cache_dir(
+            name,
+        ));
+    }
 
     config.update_vm(name, |r| {
         r.state = RecordState::Stopped;
@@ -1092,6 +1159,19 @@ pub fn stop_vm_default() -> smolvm::Result<()> {
 
     // Update database record if it exists
     if let Ok(mut config) = SmolvmConfig::load() {
+        // Detach the per-machine layers volume now that the process is gone, so a
+        // bundle-sourced default machine never holds a mount while stopped (macOS
+        // hdiutil; no-op on Linux). Gated on the record so non-bundle machines are
+        // untouched; the volume is owned 1:1 by "default" and re-acquired on start.
+        let is_bundle = config
+            .get_vm("default")
+            .map(|r| r.source_smolmachine.is_some())
+            .unwrap_or(false);
+        if is_bundle {
+            smolvm_pack::extract::force_detach_layers_volume(
+                &smolvm::agent::machine_layers_cache_dir("default"),
+            );
+        }
         config.update_vm("default", |r| {
             r.state = RecordState::Stopped;
             r.pid = None;
@@ -1164,20 +1244,17 @@ pub fn delete_vm(name: &str, force: bool, options: DeleteVmOptions) -> smolvm::R
     // Remove from config (persists immediately to database)
     config.remove_vm(name);
 
-    // If the machine was created from a .smolmachine sidecar, release the
-    // case-sensitive volume (macOS hdiutil mount). The lease was intentionally
-    // leaked with `std::mem::forget` at start time so the volume stayed
-    // mounted while the VM ran. On delete we must detach it, otherwise
-    // `rm -rf` of the pack cache fails with "Resource busy".
-    if let Some(ref sidecar_path) = record.source_smolmachine {
-        let sidecar = std::path::Path::new(sidecar_path);
-        if sidecar.exists() {
-            if let Ok(footer) = smolvm_pack::packer::read_footer_from_sidecar(sidecar) {
-                if let Ok(cache_dir) = smolvm_pack::extract::get_cache_dir(footer.checksum) {
-                    smolvm_pack::extract::force_detach_layers_volume(&cache_dir);
-                }
-            }
-        }
+    // If the machine was created from a .smolmachine, detach its case-sensitive
+    // layers volume (macOS hdiutil mount; no-op on Linux) before removing the
+    // data dir below — otherwise the `rm -rf` fails with "Resource busy". The
+    // lease was intentionally leaked with `std::mem::forget` at start time so the
+    // volume stayed mounted while the VM ran. The volume lives under this
+    // machine's own data dir and is owned 1:1 by it, so the detach is
+    // unconditional and cannot affect any other machine.
+    if record.source_smolmachine.is_some() {
+        smolvm_pack::extract::force_detach_layers_volume(&smolvm::agent::machine_layers_cache_dir(
+            name,
+        ));
     }
 
     let data_dir = vm_data_dir(name);

--- a/src/db.rs
+++ b/src/db.rs
@@ -23,6 +23,10 @@ use std::time::Duration;
 /// from concurrent CLI processes (e.g., 10-20 VMs starting simultaneously).
 const BUSY_TIMEOUT: Duration = Duration::from_secs(15);
 
+/// Long enough for a legitimate slow create/extract, short enough that a
+/// crashed creator does not reserve a name forever.
+const CREATE_RESERVATION_TTL_SECS: u64 = 60 * 60;
+
 /// Extension trait to convert errors into `Error::database`.
 trait DbResultExt<T> {
     fn db_err(self, operation: impl Into<String>) -> Result<T>;
@@ -83,6 +87,12 @@ impl SmolvmDb {
             "CREATE TABLE IF NOT EXISTS vms (
                  name TEXT PRIMARY KEY NOT NULL,
                  data BLOB NOT NULL
+             );
+             CREATE TABLE IF NOT EXISTS vm_create_reservations (
+                 name TEXT PRIMARY KEY NOT NULL,
+                 owner_token TEXT NOT NULL,
+                 owner_pid INTEGER NOT NULL,
+                 created_at INTEGER NOT NULL
              );
              CREATE TABLE IF NOT EXISTS config (
                  key TEXT PRIMARY KEY NOT NULL,
@@ -155,17 +165,160 @@ impl SmolvmDb {
     /// Insert a VM record only if it doesn't already exist.
     ///
     /// Returns `Ok(true)` if inserted, `Ok(false)` if the name already exists.
-    /// Atomicity is provided by SQLite's `INSERT OR IGNORE`.
+    /// Atomicity is provided by SQLite's `INSERT OR IGNORE`. A name with an
+    /// active create reservation is treated as already taken so older callers
+    /// that have not been threaded through the reservation API cannot clobber a
+    /// machine whose per-machine data directory is being prepared.
     pub fn insert_vm_if_not_exists(&self, name: &str, record: &VmRecord) -> Result<bool> {
         let json = serde_json::to_vec(record).db_err("serialize vm record")?;
         self.with_conn(|conn| {
             let changed = conn
                 .execute(
-                    "INSERT OR IGNORE INTO vms (name, data) VALUES (?1, ?2)",
+                    "INSERT OR IGNORE INTO vms (name, data)
+                     SELECT ?1, ?2
+                     WHERE NOT EXISTS (
+                         SELECT 1 FROM vm_create_reservations WHERE name = ?1
+                     )",
                     params![name, json],
                 )
                 .db_err(format!("insert vm '{}'", name))?;
             Ok(changed == 1)
+        })
+    }
+
+    /// Generate an opaque token identifying this process's create reservation.
+    pub fn create_reservation_token() -> String {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        format!(
+            "{}-{}-{}",
+            std::process::id(),
+            crate::util::current_timestamp(),
+            nanos
+        )
+    }
+
+    /// Reserve a VM name across processes before touching its data directory.
+    ///
+    /// Returns `Ok(false)` when the VM already exists or another live creator
+    /// owns the reservation. Dead/stale reservations are reaped before the
+    /// insert attempt so a crashed creator does not permanently wedge a name.
+    pub fn reserve_vm_create(&self, name: &str, owner_token: &str) -> Result<bool> {
+        let owner_pid = i64::from(std::process::id());
+        let now = crate::util::current_timestamp();
+        let stale_before = now.saturating_sub(CREATE_RESERVATION_TTL_SECS);
+
+        self.with_conn(|conn| {
+            let tx = conn.transaction().db_err("begin create reservation")?;
+
+            if let Some((existing_pid, created_at)) = tx
+                .query_row(
+                    "SELECT owner_pid, created_at
+                     FROM vm_create_reservations
+                     WHERE name = ?1",
+                    params![name],
+                    |row| Ok((row.get::<_, i64>(0)?, row.get::<_, u64>(1)?)),
+                )
+                .optional()
+                .db_err(format!("read create reservation '{}'", name))?
+            {
+                let pid_alive =
+                    existing_pid > 0 && crate::process::is_alive(existing_pid as libc::pid_t);
+                if !pid_alive || created_at <= stale_before {
+                    tx.execute(
+                        "DELETE FROM vm_create_reservations WHERE name = ?1",
+                        params![name],
+                    )
+                    .db_err(format!("remove stale create reservation '{}'", name))?;
+                }
+            }
+
+            let exists: bool = tx
+                .query_row(
+                    "SELECT EXISTS(SELECT 1 FROM vms WHERE name = ?1)",
+                    params![name],
+                    |row| row.get(0),
+                )
+                .db_err(format!("check vm '{}'", name))?;
+            if exists {
+                tx.commit().db_err("commit create reservation check")?;
+                return Ok(false);
+            }
+
+            let changed = tx
+                .execute(
+                    "INSERT OR IGNORE INTO vm_create_reservations
+                     (name, owner_token, owner_pid, created_at)
+                     VALUES (?1, ?2, ?3, ?4)",
+                    params![name, owner_token, owner_pid, now],
+                )
+                .db_err(format!("reserve vm '{}'", name))?;
+
+            tx.commit().db_err("commit create reservation")?;
+            Ok(changed == 1)
+        })
+    }
+
+    /// Persist a VM record and release the matching create reservation atomically.
+    ///
+    /// Returns `Ok(false)` if the caller does not own the reservation or if the
+    /// VM row already exists.
+    pub fn commit_reserved_vm(
+        &self,
+        name: &str,
+        owner_token: &str,
+        record: &VmRecord,
+    ) -> Result<bool> {
+        let json = serde_json::to_vec(record).db_err("serialize vm record")?;
+        self.with_conn(|conn| {
+            let tx = conn.transaction().db_err("begin reserved vm commit")?;
+
+            let owns_reservation: bool = tx
+                .query_row(
+                    "SELECT EXISTS(
+                         SELECT 1 FROM vm_create_reservations
+                         WHERE name = ?1 AND owner_token = ?2
+                     )",
+                    params![name, owner_token],
+                    |row| row.get(0),
+                )
+                .db_err(format!("check create reservation '{}'", name))?;
+            if !owns_reservation {
+                tx.commit().db_err("commit reservation ownership check")?;
+                return Ok(false);
+            }
+
+            let changed = tx
+                .execute(
+                    "INSERT OR IGNORE INTO vms (name, data) VALUES (?1, ?2)",
+                    params![name, json],
+                )
+                .db_err(format!("insert reserved vm '{}'", name))?;
+
+            tx.execute(
+                "DELETE FROM vm_create_reservations
+                 WHERE name = ?1 AND owner_token = ?2",
+                params![name, owner_token],
+            )
+            .db_err(format!("release create reservation '{}'", name))?;
+
+            tx.commit().db_err("commit reserved vm")?;
+            Ok(changed == 1)
+        })
+    }
+
+    /// Release a create reservation if it is still owned by `owner_token`.
+    pub fn release_vm_create_reservation(&self, name: &str, owner_token: &str) -> Result<()> {
+        self.with_conn(|conn| {
+            conn.execute(
+                "DELETE FROM vm_create_reservations
+                 WHERE name = ?1 AND owner_token = ?2",
+                params![name, owner_token],
+            )
+            .db_err(format!("release create reservation '{}'", name))?;
+            Ok(())
         })
     }
 
@@ -521,6 +674,48 @@ mod tests {
 
         let vms = db.list_vms().unwrap();
         assert_eq!(vms.len(), 2);
+    }
+
+    #[test]
+    fn test_create_reservation_blocks_unreserved_insert() {
+        let (_dir, db) = temp_db();
+        let token = SmolvmDb::create_reservation_token();
+        let record = VmRecord::new("reserved-vm".to_string(), 1, 512, vec![], vec![], false);
+
+        assert!(db.reserve_vm_create("reserved-vm", &token).unwrap());
+        assert!(
+            !db.insert_vm_if_not_exists("reserved-vm", &record).unwrap(),
+            "legacy unreserved insert must not publish a reserved name"
+        );
+        assert!(
+            db.get_vm("reserved-vm").unwrap().is_none(),
+            "reservation must not create a visible VM row"
+        );
+
+        assert!(db
+            .commit_reserved_vm("reserved-vm", &token, &record)
+            .unwrap());
+        assert!(db.get_vm("reserved-vm").unwrap().is_some());
+    }
+
+    #[test]
+    fn test_create_reservation_is_exclusive_and_releasable() {
+        let (_dir, db) = temp_db();
+        let first = SmolvmDb::create_reservation_token();
+        let second = SmolvmDb::create_reservation_token();
+
+        assert!(db.reserve_vm_create("contested", &first).unwrap());
+        assert!(
+            !db.reserve_vm_create("contested", &second).unwrap(),
+            "second live creator must not reserve the same name"
+        );
+
+        db.release_vm_create_reservation("contested", &first)
+            .unwrap();
+        assert!(
+            db.reserve_vm_create("contested", &second).unwrap(),
+            "released reservation should make the name available"
+        );
     }
 
     #[test]

--- a/src/embedded/control.rs
+++ b/src/embedded/control.rs
@@ -114,6 +114,13 @@ pub fn stop_vm(db: &SmolvmDb, name: &str) -> Result<()> {
         .map_err(|e| Error::agent("create agent manager", e.to_string()))?;
     manager.try_connect_existing();
     manager.stop()?;
+    // Detach the per-machine layers volume if a (possibly cross-tool) bundle start
+    // left it mounted. Unconditional on purpose: the embedded record may carry no
+    // source_smolmachine even when a CLI/API `machine create <bundle>` extracted and
+    // mounted this name's volume in the shared DB, so we cannot gate on it.
+    // force_detach is infallible and no-ops when unmounted; macOS hdiutil detach, a
+    // compile-time no-op on Linux.
+    smolvm_pack::extract::force_detach_layers_volume(&crate::agent::machine_layers_cache_dir(name));
     mark_stopped(db, name)
 }
 
@@ -125,6 +132,13 @@ pub fn delete_vm(db: &SmolvmDb, name: &str) -> Result<()> {
     }
 
     let data_dir = crate::agent::vm_data_dir(name);
+    // Detach the per-machine layers volume before removing the data dir, else on
+    // macOS the live mountpoint under it makes remove_dir_all fail with "Resource
+    // busy", stranding both the mount and the data dir. Unconditional on purpose:
+    // the embedded record may carry no source_smolmachine even when a CLI/API create
+    // mounted this name's volume. hdiutil detach; a no-op on Linux and when nothing
+    // is mounted.
+    smolvm_pack::extract::force_detach_layers_volume(&crate::agent::machine_layers_cache_dir(name));
     if data_dir.exists() {
         std::fs::remove_dir_all(&data_dir).map_err(|e| {
             Error::storage(

--- a/tests/test_api.sh
+++ b/tests/test_api.sh
@@ -453,6 +453,86 @@ test_api_create_from_smolmachine() {
     rm -rf "$tmpdir"
 }
 
+# Regression test for the .smolmachine layer-drop bug. Unlike the /exec test
+# above (which runs in the base agent rootfs and passes even when the bundled
+# layers are dropped — a false negative), /run enters an overlay built from the
+# bundled image, so it requires the packed layers to be mounted into the guest.
+# The machine has no network, so /run cannot fall back to a registry pull: if the
+# start path drops packed_layers_dir, /run hard-fails "image not found". This is
+# RED on a start path that passes Default::default() and GREEN once the packed
+# layers are wired through. It also proves the image tag resolves *through* the
+# packed layers, not merely that packed_layers_dir is set.
+test_api_run_from_smolmachine_offline() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    local pack_output="$tmpdir/api-run-from-pack"
+
+    # Pack alpine:latest into a .smolmachine bundle.
+    $SMOLVM pack create --image alpine:latest -o "$pack_output" --cpus 1 --mem 512 2>&1 >/dev/null || {
+        echo "SKIP: pack create failed"
+        rm -rf "$tmpdir"
+        return 0
+    }
+    local sidecar
+    sidecar=$(cd "$tmpdir" && pwd)/api-run-from-pack.smolmachine
+    [[ -f "$sidecar" ]] || { echo "FAIL: no sidecar"; rm -rf "$tmpdir"; return 1; }
+
+    local vm_name="api-run-from-$$"
+
+    # Create from bundle (network defaults off → no registry fallback for /run).
+    local create_resp
+    create_resp=$("${CURL[@]}" -s -X POST "$API_URL/api/v1/machines" \
+        -H "Content-Type: application/json" \
+        -d "{\"name\": \"$vm_name\", \"from\": \"$sidecar\", \"memoryMb\": 512}")
+    echo "$create_resp" | grep -q "$vm_name" || {
+        echo "FAIL: create response missing name: $create_resp"
+        rm -rf "$tmpdir"; return 1
+    }
+
+    # Start
+    local start_resp
+    start_resp=$("${CURL[@]}" -s -X POST "$API_URL/api/v1/machines/$vm_name/start")
+    echo "$start_resp" | grep -q "running" || {
+        echo "FAIL: start failed: $start_resp"
+        "${CURL[@]}" -s -X DELETE "$API_URL/api/v1/machines/$vm_name" >/dev/null
+        rm -rf "$tmpdir"; return 1
+    }
+
+    # Bug 1 (layer-drop on start): /run the bundled image offline. Reaches the
+    # guest's image overlay, which needs the packed layers mounted.
+    local run_resp
+    run_resp=$("${CURL[@]}" -s -X POST "$API_URL/api/v1/machines/$vm_name/run" \
+        -H "Content-Type: application/json" \
+        -d '{"image": "alpine:latest", "command": ["cat", "/etc/os-release"]}')
+
+    # Bug 2 (eager sidecar extraction on the running-VM preflight): remove the
+    # .smolmachine while the VM is running, then exercise the implicit-start
+    # preflight again. The running guest already has its layers mounted, so
+    # losing the original bundle must NOT fail the request.
+    rm -f "$sidecar"
+    local rerun_resp
+    rerun_resp=$("${CURL[@]}" -s -X POST "$API_URL/api/v1/machines/$vm_name/run" \
+        -H "Content-Type: application/json" \
+        -d '{"image": "alpine:latest", "command": ["true"]}')
+
+    "${CURL[@]}" -s -X POST "$API_URL/api/v1/machines/$vm_name/stop" >/dev/null
+    "${CURL[@]}" -s -X DELETE "$API_URL/api/v1/machines/$vm_name" >/dev/null
+    rm -rf "$tmpdir"
+
+    if echo "$run_resp" | grep -qi "image not found"; then
+        echo "FAIL: bundled layers were dropped on start — /run could not find the image offline: $run_resp"
+        return 1
+    fi
+    echo "$run_resp" | grep -qi "alpine" || {
+        echo "FAIL: /run did not enter the bundled image overlay: $run_resp"
+        return 1
+    }
+    if echo "$rerun_resp" | grep -qi "source .smolmachine not found"; then
+        echo "FAIL: running-VM preflight re-extracted the .smolmachine and failed after the bundle was removed: $rerun_resp"
+        return 1
+    fi
+}
+
 test_api_from_and_image_conflict() {
     local resp
     resp=$("${CURL[@]}" -s -X POST "$API_URL/api/v1/machines" \
@@ -480,6 +560,7 @@ echo "--- Create from .smolmachine via API ---"
 echo ""
 
 run_test "API: create from .smolmachine" test_api_create_from_smolmachine || true
+run_test "API: run from .smolmachine (offline)" test_api_run_from_smolmachine_offline || true
 run_test "API: from + image conflict" test_api_from_and_image_conflict || true
 run_test "API: from nonexistent sidecar" test_api_from_nonexistent_sidecar || true
 


### PR DESCRIPTION
## Summary

- Rewire `.smolmachine` packed layers from every CLI/API start path so server-side starts no longer fall back to registry pulls.
- Extract bundle layers into each VM data dir and cleanly detach/roll back on failure.
- Add DB-backed create reservations, commit VM rows only after extraction, and fail startup when packed-layer rewire or lease setup fails.
- Keep the macOS packed-layer regression test from mutating `HOME` / `XDG_*`, avoiding parallel CI races with path tests.
- Preserve upstream's manager-based API stop behavior during the rebase and apply the current clippy match-arm cleanup in interactive exec.

## Why

Machines created from `.smolmachine` bundles could persist the bundle source but start through API paths with default launch features, ignoring the packed layers. That broke offline `/run` once the bundle sidecar was gone, and stale per-machine caches could win cross-process create races.

## Validation

- `cargo check --all-targets`
- `cargo test --all-targets`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --lib`
- `cargo test -p smolvm-agent --bins`
- `cargo test agent::manager::tests:: -- --nocapture` repeated 5x with default parallelism after the upstream rebase
- Real VM repro: stale `busybox` cache was replaced by the `alpine` bundle layer, and offline `/run cat /etc/alpine-release` returned `exitCode: 0` with `3.19.9`.

## Boot performance

Measured with signed release binaries on real local VMs, comparing the base runtime to this PR's runtime changes with isolated short `HOME`s and the same agent rootfs/libkrun.

| Path | Base avg | PR avg | Impact |
|---|---:|---:|---:|
| CLI bare `machine start` | 108.7 ms | 106.2 ms | no regression |
| CLI bare `start + exec true` | 129.3 ms | 131.4 ms | noise-level |
| API bare fresh `/start` | 121.6 ms | 119.0 ms | no regression |
| CLI `.smolmachine` `machine start` | 130.6 ms | 319.8 ms | +189 ms |
| CLI `.smolmachine` `start + exec true` | 155.9 ms | 330.5 ms | +175 ms |
| API `.smolmachine` fresh `/start` | parent not comparable | 308.6 ms | corrected path cost |

Normal/non-packed boot is effectively unchanged. Packed `.smolmachine` cold start is about 180-190 ms slower on macOS because the corrected path now attaches the per-VM case-sensitive layers image on each cold start; the old server path was faster partly because it skipped the packed layers and could boot into a broken offline `/run` state.