### PR TITLE
fix: redact registry credentials from agent request logs

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -1644,13 +1644,13 @@ fn handle_connection(stream: &mut impl ReadWrite) -> Result<(), Box<dyn std::err
         patch_timeout_ms(&mut request, &buf[..len]);
 
         let _span = if let Some(ref tid) = trace_id {
-            tracing::info_span!("request", trace_id = %tid, method = ?request)
+            tracing::info_span!("request", trace_id = %tid, method = %request.log_summary())
         } else {
-            tracing::info_span!("request", method = ?request)
+            tracing::info_span!("request", method = %request.log_summary())
         };
         let _guard = _span.enter();
 
-        debug!(?request, "received request");
+        debug!(method = %request.log_summary(), "received request");
 
         // Check if this is an interactive run request
         if let AgentRequest::Run {
@@ -1748,7 +1748,7 @@ fn handle_connection(stream: &mut impl ReadWrite) -> Result<(), Box<dyn std::err
         // already handled cleanup.
         if write_session.is_some() {
             debug!(
-                method = ?request,
+                method = %request.log_summary(),
                 "dropping in-flight FileWrite session: non-chunk request arrived"
             );
             write_session = None;

--- a/crates/smolvm-protocol/src/lib.rs
+++ b/crates/smolvm-protocol/src/lib.rs
@@ -376,6 +376,44 @@ pub enum AgentRequest {
     },
 }
 
+impl AgentRequest {
+    /// A log-safe one-line summary of the request.
+    ///
+    /// This string is written to the machine's console log, which is exposed
+    /// over the logs API — so it must NEVER include credential- or data-bearing
+    /// fields: registry `auth`, `env` (which can carry host-resolved secrets),
+    /// `proxy` (may embed credentials), or `data` (file/stdin bytes). Only the
+    /// variant name plus a non-secret identifier (image) is emitted.
+    ///
+    /// The match is exhaustive with no catch-all on purpose: adding a new
+    /// variant forces a compile error here, so redaction is a deliberate
+    /// decision rather than an accidental leak in some future request type.
+    pub fn log_summary(&self) -> String {
+        match self {
+            AgentRequest::Ping => "Ping".into(),
+            AgentRequest::Pull { image, .. } => format!("Pull {{ image: {image} }}"),
+            AgentRequest::Query { image, .. } => format!("Query {{ image: {image} }}"),
+            AgentRequest::ListImages => "ListImages".into(),
+            AgentRequest::GarbageCollect { .. } => "GarbageCollect".into(),
+            AgentRequest::PrepareOverlay { .. } => "PrepareOverlay".into(),
+            AgentRequest::CleanupOverlay { .. } => "CleanupOverlay".into(),
+            AgentRequest::FormatStorage => "FormatStorage".into(),
+            AgentRequest::StorageStatus => "StorageStatus".into(),
+            AgentRequest::NetworkTest { .. } => "NetworkTest".into(),
+            AgentRequest::Shutdown => "Shutdown".into(),
+            AgentRequest::ExportLayer { .. } => "ExportLayer".into(),
+            AgentRequest::VmExec { .. } => "VmExec".into(),
+            AgentRequest::Run { image, .. } => format!("Run {{ image: {image} }}"),
+            AgentRequest::Stdin { .. } => "Stdin".into(),
+            AgentRequest::Resize { .. } => "Resize".into(),
+            AgentRequest::FileWrite { .. } => "FileWrite".into(),
+            AgentRequest::FileWriteBegin { .. } => "FileWriteBegin".into(),
+            AgentRequest::FileWriteChunk { .. } => "FileWriteChunk".into(),
+            AgentRequest::FileRead { .. } => "FileRead".into(),
+        }
+    }
+}
+
 /// Agent response types.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "status", rename_all = "snake_case")]
@@ -671,12 +709,26 @@ pub struct StorageStatus {
 }
 
 /// Registry authentication credentials for pulling images.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// `Debug` is hand-written to redact the password: this value is carried inside
+/// `AgentRequest::Pull`, and any `{:?}` of that request (e.g. a tracing span)
+/// would otherwise serialize the token verbatim into the machine's console log,
+/// which is exposed over the logs API.
+#[derive(Clone, Serialize, Deserialize)]
 pub struct RegistryAuth {
     /// Username for authentication.
     pub username: String,
     /// Password or token for authentication.
     pub password: String,
+}
+
+impl std::fmt::Debug for RegistryAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RegistryAuth")
+            .field("username", &self.username)
+            .field("password", &"***")
+            .finish()
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
The guest agent logged each request via `?request` Debug, and `RegistryAuth` derived `Debug` printed the password — so a registry token (e.g. a Docker Hub PAT) leaked into the machine's console log, which is exposed over the logs API.

- `RegistryAuth` now has a hand-written `Debug` that redacts the password.
- Request log sites use a new exhaustive `AgentRequest::log_summary()` (variant + image only) instead of dumping the full request, so `env`/`auth`/`proxy`/`data` can't leak. The match has no catch-all, so a future variant forces a compile error rather than a silent leak.

Verified on a live VM: an authed image pull now shows `has_auth: true` with zero occurrences of the token in logs.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/337">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->