### PR TITLE
feat: accept a registry identity token on machine create

### DIFF
--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -1081,6 +1081,7 @@ mod tests {
             image: None,
             from: None,
             registry_ref: None,
+            registry_identity_token: None,
         }
     }
 

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -219,7 +219,8 @@ pub async fn create_machine(
     // If registry_ref is set, pull the artifact from the registry and treat as `from`
     let mut req = req;
     if let Some(ref registry_ref) = req.registry_ref.clone() {
-        let pulled_path = pull_from_registry(registry_ref).await?;
+        let pulled_path =
+            pull_from_registry(registry_ref, req.registry_identity_token.as_deref()).await?;
         req.from = Some(pulled_path);
         req.registry_ref = None;
     }
@@ -896,7 +897,10 @@ pub async fn resize_machine(
     Ok(Json(record_to_info(&name, &record)))
 }
 
-async fn pull_from_registry(registry_ref: &str) -> Result<String, ApiError> {
+async fn pull_from_registry(
+    registry_ref: &str,
+    identity_token: Option<&str>,
+) -> Result<String, ApiError> {
     let parsed = crate::registry::Reference::parse(registry_ref)
         .map_err(|e| ApiError::BadRequest(format!("invalid registry reference: {}", e)))?;
 
@@ -919,7 +923,11 @@ async fn pull_from_registry(registry_ref: &str) -> Result<String, ApiError> {
 
     let mut client = smolvm_registry::RegistryClient::new(base_url);
 
-    if let Some(entry) = settings.machines.registries.get(effective_registry) {
+    // A request-supplied identity token (the control plane's short-lived,
+    // tenant-scoped pull token) takes precedence over any persisted credential.
+    if let Some(token) = identity_token {
+        client = client.with_identity_token(token.to_string());
+    } else if let Some(entry) = settings.machines.registries.get(effective_registry) {
         if let Some(ref token) = entry.identity_token {
             client = client.with_identity_token(token.clone());
         }

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -405,6 +405,12 @@ pub struct CreateMachineRequest {
     /// Mutually exclusive with `image` and `from`.
     #[serde(default)]
     pub registry_ref: Option<String>,
+    /// Bearer credential (an OCI Distribution `identity_token`) to present when
+    /// pulling `registry_ref`. The control plane supplies a short-lived,
+    /// tenant-scoped token here so a node can fetch a tenant's private
+    /// `.smolmachine`. Takes precedence over any persisted registry credential.
+    #[serde(default)]
+    pub registry_identity_token: Option<String>,
 }
 
 /// Request to execute a command in a machine.


### PR DESCRIPTION
Adds `registry_identity_token` to the machine create request and uses it in `pull_from_registry` (precedence over persisted creds) so a node can pull a private `.smolmachine` with a short-lived, tenant-scoped token minted by the control plane. Part of the multi-tenant registry work (R3).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/338">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->