### PR TITLE
feat: graceful VM drain on shutdown

### DIFF
--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -648,6 +648,72 @@ pub async fn stop_machine(
     Ok(Json(record_to_info(&name, &record)))
 }
 
+/// Gracefully stop every running VM before the server exits. Opt-in via
+/// `SMOLVM_DRAIN_ON_SHUTDOWN` (set by cloud workers); off by default so a dev
+/// Ctrl-C or `serve` restart leaves VMs running for reconnect. Without draining,
+/// a host teardown (e.g. autoscaler scale-in) hard-kills running VMs; draining
+/// stops them cleanly — flushing disk state and marking them stopped so the
+/// control plane can reschedule. Best-effort, concurrent, and bounded so it fits
+/// inside the host's termination grace period.
+pub async fn drain_machines(state: &Arc<ApiState>) {
+    let running: Vec<(String, Option<i32>, Option<u64>)> = match state.db().list_vms() {
+        Ok(vms) => vms
+            .into_iter()
+            .filter(|(_, r)| r.actual_state() == RecordState::Running && r.is_process_alive())
+            .map(|(name, r)| (name, r.pid, r.pid_start_time))
+            .collect(),
+        Err(e) => {
+            tracing::error!(error = %e, "drain: failed to list machines");
+            return;
+        }
+    };
+    if running.is_empty() {
+        return;
+    }
+    tracing::info!(count = running.len(), "draining running machines before shutdown");
+
+    let mut handles = Vec::with_capacity(running.len());
+    for (name, pid, pid_start_time) in running {
+        let state = state.clone();
+        handles.push(tokio::spawn(async move {
+            let name_for_kill = name.clone();
+            let entry = state.get_machine(&name).ok();
+            let stopped = tokio::task::spawn_blocking(move || {
+                // Prefer the registered manager (holds the flock); fall back to a
+                // PID-verified signal — same path as the stop handler.
+                let via_manager = entry
+                    .as_ref()
+                    .map(|e| e.lock().manager.stop().is_ok())
+                    .unwrap_or(false);
+                via_manager || shutdown_machine_process(&name_for_kill, pid, pid_start_time)
+            })
+            .await
+            .unwrap_or(false);
+            if let Ok(entry) = state.get_machine(&name) {
+                entry.lock().manager.mark_stopped();
+            }
+            let _ = state.db().update_vm(&name, |r| {
+                r.state = RecordState::Stopped;
+                r.pid = None;
+                r.pid_start_time = None;
+            });
+            tracing::info!(machine = %name, stopped, "drain: machine stopped");
+        }));
+    }
+
+    let drain_all = async {
+        for h in handles {
+            let _ = h.await;
+        }
+    };
+    if tokio::time::timeout(std::time::Duration::from_secs(25), drain_all)
+        .await
+        .is_err()
+    {
+        tracing::warn!("drain: deadline reached before all machines stopped");
+    }
+}
+
 /// Delete a machine.
 #[utoipa::path(
     delete,

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -670,7 +670,10 @@ pub async fn drain_machines(state: &Arc<ApiState>) {
     if running.is_empty() {
         return;
     }
-    tracing::info!(count = running.len(), "draining running machines before shutdown");
+    tracing::info!(
+        count = running.len(),
+        "draining running machines before shutdown"
+    );
 
     let mut handles = Vec::with_capacity(running.len());
     for (name, pid, pid_start_time) in running {

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -197,6 +197,7 @@ impl ServeStartCmd {
         });
 
         // Create router
+        let drain_state = state.clone();
         let app = smolvm::api::create_router(state, self.cors_origins.clone());
 
         // Listen server on TCP or Unix socket
@@ -204,6 +205,18 @@ impl ServeStartCmd {
             ListenTarget::Tcp(addr) => self.serve_tcp(addr, app).await?,
             #[cfg(unix)]
             ListenTarget::Unix(path) => self.serve_unix(path, app).await?,
+        }
+
+        // The HTTP server has stopped accepting (graceful shutdown on SIGTERM).
+        // VMs survive a normal `serve` restart (reconnect on next start), so this
+        // is opt-in: on a host teardown (autoscaler scale-in) set
+        // SMOLVM_DRAIN_ON_SHUTDOWN to stop running VMs cleanly — flushing disk
+        // state — instead of letting the host hard-kill them.
+        let drain = std::env::var("SMOLVM_DRAIN_ON_SHUTDOWN")
+            .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
+            .unwrap_or(false);
+        if drain {
+            smolvm::api::handlers::machines::drain_machines(&drain_state).await;
         }
 
         // Signal all background tasks to stop
@@ -346,7 +359,8 @@ impl Drop for UnixSocketGuard {
 }
 
 /// Wait for shutdown signal.
-/// Note: VMs are NOT stopped on server shutdown - they run independently.
+/// Note: VMs run independently and survive a normal shutdown/restart; they are
+/// only stopped when SMOLVM_DRAIN_ON_SHUTDOWN is set (see run_server).
 /// Use DELETE /api/v1/machines/:id to stop specific VMs.
 async fn shutdown_signal() {
     let ctrl_c = async {


### PR DESCRIPTION
Opt-in via SMOLVM_DRAIN_ON_SHUTDOWN: on SIGTERM (autoscaler scale-in / host teardown) stop running microVMs cleanly — flush disk state, mark stopped so the control plane can reschedule — instead of leaving them to be hard-killed. Off by default (dev Ctrl-C / serve restart still leave VMs running for reconnect). Concurrent + bounded (25s) to fit the host grace period. Cloud-init workers set the env + TimeoutStopSec (smolfleet side).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/343">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->