### PR TITLE
feat: fast VM fork (checkpoint/restore + CoW clones)

### DIFF
--- a/examples/headless-browser/README.md
+++ b/examples/headless-browser/README.md
@@ -1,0 +1,118 @@
+# Headless browsers in smolvm — and pre-warmed browser pools via fork
+
+`browser.smolfile` covers the basics: a GPU-accelerated headless Chromium you
+`create` + `start` + `exec` against. This doc covers the harder-won part —
+running Chromium as a **persistent, forkable workload** so you can keep a pool
+of pre-warmed browsers and skip cold startup on every task.
+
+## Why fork a browser at all
+
+A browser's cold start (process launch + shared-library load + JS-engine init +
+first navigation) costs **1–3+ seconds**. A smolvm fork is a copy-on-write clone
+of a *running* VM, so a clone inherits the golden's **already-running,
+already-initialized browser** — same process, same warmed heap, same listening
+CDP port. You pay the cold start **once** (in the golden) and materialize warm
+clones in **~50–130 ms** each.
+
+```
+warm one golden  ──fork──▶ clone 1 (browser already up)   ~90 ms to agent-ready
+                  ──fork──▶ clone 2 (browser already up)
+                  ──fork──▶ clone N ...
+```
+
+## The #1 gotcha: fork-friendly Chromium flags
+
+**Chromium MUST be launched with `--no-zygote` (plus `--no-sandbox` and
+`--disable-dev-shm-usage`) for the browser to survive a fork.**
+
+Chromium's default process model uses a *zygote* — a pre-forked template process
+the browser clones renderers from. That model does **not** survive a
+cross-process VM fork cleanly: after the fork, joining the restored container
+(`crun exec`, which is what `machine exec` does for an image VM) **hangs**. With
+`--no-zygote`, Chromium runs a flat process tree that forks and execs correctly
+on the clone.
+
+```
+# fork-friendly:
+chromium --headless=new --no-zygote --no-sandbox --disable-dev-shm-usage \
+         --remote-debugging-port=9222 --user-data-dir=/tmp/cdata about:blank
+
+# NOT fork-friendly (the image's bare default CMD, zygote on):
+#   → golden runs fine, but `machine exec` into a forked clone hangs.
+```
+
+`--no-sandbox` is required because the microVM guest typically lacks the
+user-namespace / setuid-sandbox plumbing Chromium expects; `--disable-dev-shm-usage`
+avoids the tiny default `/dev/shm`.
+
+## Setup: a persistent, forkable browser golden
+
+The browser has to be **running at fork time**, so launch it as the machine's
+persistent workload — not via a one-shot `machine exec` (which is torn down when
+the exec returns). Pass the command at `create` (an image machine with no
+command instead adopts the image's OCI `CMD`/`ENTRYPOINT`):
+
+```sh
+smolvm machine create browser-golden \
+    --image chromedp/headless-shell:latest --net \
+    --workdir /headless-shell \
+    -- ./headless-shell --headless=new --no-zygote --no-sandbox \
+       --disable-dev-shm-usage --remote-debugging-port=9222 --user-data-dir=/tmp/cd
+
+# --forkable enables the CoW-fork machinery (memfd-backed RAM + control socket).
+smolvm machine start --name browser-golden --forkable
+
+# Fork a warm clone on demand (one golden → N clones):
+smolvm machine fork browser-golden worker-1
+smolvm machine fork browser-golden worker-2
+
+# Each clone's browser is already up; exec / drive it:
+smolvm machine exec --name worker-1 -- /bin/sh -c 'echo ready'
+```
+
+The golden stays **frozen** as the CoW base while clones exist — don't `start`
+it again until the clones are gone.
+
+## What survives the fork (and what doesn't)
+
+| Preserved (it's in the restored RAM/CoW disk) | NOT preserved |
+|---|---|
+| The running browser process + warmed heap / JIT | **Live network connections** (reset on restore — freeze the golden at an *idle* point, not mid-request) |
+| Loaded shared libraries, parsed/blank page | **GPU renderer context** (host-side virgl/Venus state isn't transferred; headless / software rendering is unaffected) |
+| The listening CDP port (`127.0.0.1:9222`) | Wall-clock-sensitive timers can jump forward by the freeze duration |
+| Open file handles into the rootfs | |
+
+Per-clone identity is rejuvenated automatically (distinct hostname, fresh
+entropy), and each clone gets its own CoW disk overlay, so clones are isolated.
+
+## Driving the warm browser (CDP)
+
+Chromium binds the DevTools endpoint to **`127.0.0.1`** regardless of
+`--remote-debugging-address` (security hardening), so reach it from *inside* the
+VM (the agent shares the guest network namespace) or proxy it out.
+
+Use a real CDP/WebSocket client — **puppeteer** or **chrome-remote-interface** —
+not raw `curl`/`socat`. A raw TCP client connects but won't get the DevTools
+JSON body back reliably, and the WebSocket CDP path needs
+`--remote-allow-origins=*`. The HTTP `/json/*` endpoints also require a
+`Host: localhost` header (DNS-rebinding protection).
+
+## Performance
+
+Measured on Apple M4 Max (APFS, instant `clonefile` CoW disks):
+
+- End-to-end `machine fork` to a usable, agent-reachable warm clone: **~50–130 ms**.
+- Clone boot-from-snapshot to agent-ready: **~90 ms**.
+- Density: golden ~300 MB RSS, each clone only ~30–40 MB (RAM CoW-shared).
+
+On Linux the per-fork time is the same class on a reflink-capable filesystem
+(btrfs/xfs); on ext4 the disk copy dominates (~0.4–0.9 s).
+
+## Status
+
+Forking (`--forkable`, `machine fork`) is part of the fast-fork work and is
+validated on both Linux/KVM (x86_64) and macOS/HVF (aarch64). The persistent
+warm browser → fork → drive path is validated end-to-end with the flags above.
+The cross-arch caveat is fundamental: a clone runs on the **same CPU arch +
+hypervisor + host** as its golden (a fork is a live CoW clone, not a portable
+snapshot). For portable, cold artifacts use `smolvm pack` instead.

--- a/examples/headless-browser/browser.smolfile
+++ b/examples/headless-browser/browser.smolfile
@@ -1,5 +1,9 @@
 # Headless Chromium with GPU acceleration
 #
+# For pre-warmed browser pools via fork (warm-state preservation, the required
+# --no-zygote/--no-sandbox flags, persistent-workload setup, and CDP access),
+# see README.md in this directory.
+#
 # Guest Vulkan (Venus/virtio-gpu) forwards calls over the virtio-gpu transport
 # to the host GPU.  ANGLE inside Chromium uses Venus as its Vulkan backend, so
 # WebGL and compositing run on real hardware — no SwiftShader fallback.

--- a/src/agent/krun.rs
+++ b/src/agent/krun.rs
@@ -56,6 +56,9 @@ pub struct KrunFunctions {
     pub set_gpu_options2: Option<unsafe extern "C" fn(u32, u32, u64) -> i32>,
     /// Register a Unix control socket for the VM (pause/resume/checkpoint/restore).
     pub set_control_socket: Option<unsafe extern "C" fn(u32, *const libc::c_char) -> i32>,
+    /// Boot the VM as a fork clone from a snapshot directory (CoW-map a golden
+    /// VM's RAM + restore state instead of cold-booting).
+    pub set_snapshot: Option<unsafe extern "C" fn(u32, *const libc::c_char) -> i32>,
 }
 
 impl KrunFunctions {
@@ -153,6 +156,7 @@ impl KrunFunctions {
             get_egress_handle: load_optional_sym!("krun_get_egress_handle"),
             set_gpu_options2: load_optional_sym!("krun_set_gpu_options2"),
             set_control_socket: load_optional_sym!("krun_set_control_socket"),
+            set_snapshot: load_optional_sym!("krun_set_snapshot"),
         })
     }
 }

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -652,6 +652,29 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
             }
         }
 
+        // Fork clone: boot from a snapshot dir (CoW-map a golden VM's RAM +
+        // restore state) instead of cold-booting, when SMOLVM_SNAPSHOT_DIR is set.
+        if let Ok(snap_dir) = std::env::var("SMOLVM_SNAPSHOT_DIR") {
+            if !snap_dir.is_empty() {
+                match krun.set_snapshot {
+                    Some(set_snapshot) => match CString::new(snap_dir.clone()) {
+                        Ok(dir_c) => {
+                            let ret = set_snapshot(ctx, dir_c.as_ptr());
+                            if ret < 0 {
+                                tracing::error!("krun_set_snapshot failed: {ret}");
+                            } else {
+                                tracing::info!(dir = %snap_dir, "booting as fork clone from snapshot");
+                            }
+                        }
+                        Err(_) => tracing::warn!("snapshot dir contains null byte"),
+                    },
+                    None => tracing::warn!(
+                        "SMOLVM_SNAPSHOT_DIR set but libkrun lacks krun_set_snapshot"
+                    ),
+                }
+            }
+        }
+
         // Add virtiofs mounts
         // Each mount gets a tag like "smolvm0", "smolvm1", etc.
         // The guest must mount these manually (or via the agent)

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -1528,6 +1528,44 @@ impl AgentManager {
 
         tracing::debug!("waiting for agent to be ready");
 
+        // Fork clone: the guest resumes past boot, so it never (re)writes the
+        // `.smolvm-ready` marker. Detect readiness by pinging the restored agent
+        // directly (it is already in its accept loop) — no marker, no grace.
+        let is_clone = std::env::var_os("SMOLVM_SNAPSHOT_DIR").is_some_and(|v| !v.is_empty());
+        if is_clone {
+            while start.elapsed() < timeout {
+                {
+                    let mut inner = self.inner.lock();
+                    if let Some(ref mut child) = inner.child {
+                        if !child.is_running() {
+                            return Err(Error::agent(
+                                "monitor agent",
+                                "clone agent process exited during startup".to_string(),
+                            ));
+                        }
+                    }
+                }
+                if self.vsock_socket.exists() {
+                    if let Ok(mut client) =
+                        super::AgentClient::connect_with_boot_probe_timeout(&self.vsock_socket)
+                    {
+                        if client.ping().is_ok() {
+                            tracing::info!(
+                                elapsed_ms = start.elapsed().as_millis(),
+                                "clone agent ready (ping)"
+                            );
+                            return Ok(());
+                        }
+                    }
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            return Err(Error::agent(
+                "wait for ready",
+                "clone agent did not respond to ping within timeout".to_string(),
+            ));
+        }
+
         let ready_marker = self.rootfs_path.join(AGENT_READY_MARKER);
 
         while start.elapsed() < timeout {

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -138,6 +138,9 @@ pub enum MachineCmd {
     /// Start a machine
     Start(StartCmd),
 
+    /// Fork a running forkable machine into a new clone (CoW memory + disks)
+    Fork(ForkCmd),
+
     /// Stop a running machine
     Stop(StopCmd),
 
@@ -202,6 +205,7 @@ impl MachineCmd {
             MachineCmd::Exec(cmd) => cmd.run(),
             MachineCmd::Create(cmd) => cmd.run(),
             MachineCmd::Start(cmd) => cmd.run(),
+            MachineCmd::Fork(cmd) => cmd.run(),
             MachineCmd::Stop(cmd) => cmd.run(),
             MachineCmd::Delete(cmd) => cmd.run(),
             MachineCmd::Status(cmd) => cmd.run(),
@@ -1627,6 +1631,11 @@ pub struct StartCmd {
     #[arg(short = 'n', long, value_name = "NAME")]
     pub name: Option<String>,
 
+    /// Start as a fork base: back guest RAM with a memfd (CoW-cloneable) and
+    /// expose a control socket so the machine can be forked with `machine fork`.
+    #[arg(long)]
+    pub forkable: bool,
+
     #[command(flatten, next_help_heading = "Network")]
     pub proxy_opts: crate::cli::proxy_opts::ProxyOpts,
 }
@@ -1637,6 +1646,12 @@ impl StartCmd {
         let name = self.name.unwrap_or_else(|| "default".to_string());
         let proxy = self.proxy_opts.proxy();
         let no_proxy = self.proxy_opts.no_proxy();
+        if self.forkable {
+            // Read by launcher.rs in the spawned _boot-vm (inherits our env):
+            // memfd-back guest RAM and register a control socket at a known path
+            // so `machine fork` can later freeze this machine as a CoW base.
+            vm_common::enable_forkable_env(&name);
+        }
         match vm_common::start_vm_named(&name, proxy, no_proxy) {
             Ok(()) => Ok(()),
             Err(smolvm::Error::VmNotFound { .. }) if !explicit_name => {
@@ -1646,6 +1661,40 @@ impl StartCmd {
             }
             Err(e) => Err(e),
         }
+    }
+}
+
+// ============================================================================
+// Fork Command
+// ============================================================================
+
+/// Fork a running forkable machine into a new clone.
+///
+/// Freezes the source (the "golden") via its control socket, copy-on-write
+/// clones its disks, and boots the new machine from the golden's in-memory
+/// snapshot instead of cold-booting — so the clone comes up already warm
+/// (same processes, same filesystem state), in well under a second.
+///
+/// The golden must have been started with `--forkable`.
+#[derive(Args, Debug)]
+pub struct ForkCmd {
+    /// The running, forkable source machine to clone from.
+    #[arg(value_name = "GOLDEN")]
+    pub golden: String,
+
+    /// Name for the new clone machine.
+    #[arg(value_name = "CLONE")]
+    pub clone: String,
+
+    /// Make the clone itself forkable (memfd RAM + control socket), so it can
+    /// in turn be forked.
+    #[arg(long)]
+    pub forkable: bool,
+}
+
+impl ForkCmd {
+    pub fn run(self) -> smolvm::Result<()> {
+        vm_common::fork_vm(&self.golden, &self.clone, self.forkable)
     }
 }
 

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -1060,6 +1060,39 @@ mod tests {
     }
 
     #[test]
+    fn create_accepts_trailing_workload_command() {
+        let cli = TestMachineCli::parse_from([
+            "machine", "create", "golden", "--image", "alpine", "--", "echo", "hi",
+        ]);
+        let MachineCmd::Create(cmd) = cli.command else {
+            panic!("expected machine create command");
+        };
+        assert_eq!(cmd.name, Some("golden".to_string()));
+        assert_eq!(cmd.image, Some("alpine".to_string()));
+        // The trailing command is captured (clap may include the "--" separator).
+        let words: Vec<&str> = cmd
+            .command
+            .iter()
+            .map(String::as_str)
+            .filter(|s| *s != "--")
+            .collect();
+        assert_eq!(words, ["echo", "hi"]);
+    }
+
+    #[test]
+    fn create_without_command_leaves_command_empty() {
+        // Regression: adding the trailing COMMAND arg must not break the common
+        // no-command form `machine create <name> --net`.
+        let cli = TestMachineCli::parse_from(["machine", "create", "golden", "--net"]);
+        let MachineCmd::Create(cmd) = cli.command else {
+            panic!("expected machine create command");
+        };
+        assert_eq!(cmd.name, Some("golden".to_string()));
+        assert!(cmd.command.is_empty());
+        assert!(cmd.net);
+    }
+
+    #[test]
     fn is_likely_image_ref_classifies_correctly() {
         // Unambiguous image references
         assert!(is_likely_image_ref("ubuntu:22.04")); // image:tag
@@ -1428,6 +1461,13 @@ pub struct CreateCmd {
     /// Uses pre-extracted layers instead of pulling from a registry.
     #[arg(long, value_name = "PATH", conflicts_with_all = ["image", "smolfile"])]
     pub from: Option<PathBuf>,
+
+    /// Command to run as the machine's persistent workload (image machines).
+    /// Launched as a detached container on every `start`, so it stays running
+    /// (e.g. a pre-warmed browser to be forked). Without this, an image machine
+    /// boots to a bare agent and the image's CMD is not run.
+    #[arg(trailing_var_arg = true, value_name = "COMMAND")]
+    pub command: Vec<String>,
 }
 
 impl CreateCmd {
@@ -1451,8 +1491,8 @@ impl CreateCmd {
         let params = crate::cli::smolfile::build_create_params(
             name,
             self.image,
-            None,   // entrypoint: from Smolfile only
-            vec![], // cmd: from Smolfile only
+            None, // entrypoint: from Smolfile only
+            self.command, // persistent-workload command (detached container on start)
             self.cpus,
             self.mem,
             self.volume,
@@ -1652,7 +1692,7 @@ impl StartCmd {
             // so `machine fork` can later freeze this machine as a CoW base.
             vm_common::enable_forkable_env(&name);
         }
-        match vm_common::start_vm_named(&name, proxy, no_proxy) {
+        match vm_common::start_vm_named(&name, proxy, no_proxy, /* from_snapshot */ false) {
             Ok(()) => Ok(()),
             Err(smolvm::Error::VmNotFound { .. }) if !explicit_name => {
                 // Only fall back to creating a default VM when no --name was given.
@@ -2659,7 +2699,7 @@ impl MonitorCmd {
 
         if !manager.is_process_alive() {
             println!("Machine '{}' is not running, starting...", name);
-            vm_common::start_vm_named(&name, None, None)?;
+            vm_common::start_vm_named(&name, None, None, /* from_snapshot */ false)?;
         }
 
         println!(
@@ -2836,7 +2876,7 @@ impl MonitorCmd {
                         break;
                     }
 
-                    match vm_common::start_vm_named(&name, None, None) {
+                    match vm_common::start_vm_named(&name, None, None, /* from_snapshot */ false) {
                         Ok(()) => {
                             println!("  machine restarted");
                             last_start = std::time::Instant::now();

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -1491,7 +1491,7 @@ impl CreateCmd {
         let params = crate::cli::smolfile::build_create_params(
             name,
             self.image,
-            None, // entrypoint: from Smolfile only
+            None,         // entrypoint: from Smolfile only
             self.command, // persistent-workload command (detached container on start)
             self.cpus,
             self.mem,
@@ -2876,7 +2876,9 @@ impl MonitorCmd {
                         break;
                     }
 
-                    match vm_common::start_vm_named(&name, None, None, /* from_snapshot */ false) {
+                    match vm_common::start_vm_named(
+                        &name, None, None, /* from_snapshot */ false,
+                    ) {
                         Ok(()) => {
                             println!("  machine restarted");
                             last_start = std::time::Instant::now();

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -1690,11 +1690,17 @@ pub struct ForkCmd {
     /// in turn be forked.
     #[arg(long)]
     pub forkable: bool,
+
+    /// Pin the clone's inbound port forwards (repeatable). Without this, the
+    /// golden's forwards are remapped to freshly-allocated host ports.
+    #[arg(short = 'p', long = "port", value_parser = PortMapping::parse, value_name = "HOST:GUEST", help_heading = "Network")]
+    pub port: Vec<PortMapping>,
 }
 
 impl ForkCmd {
     pub fn run(self) -> smolvm::Result<()> {
-        vm_common::fork_vm(&self.golden, &self.clone, self.forkable)
+        let ports: Vec<(u16, u16)> = self.port.iter().map(|p| (p.host, p.guest)).collect();
+        vm_common::fork_vm(&self.golden, &self.clone, self.forkable, &ports)
     }
 }
 

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -735,6 +735,7 @@ pub fn fork_vm(golden: &str, clone: &str, clone_forkable: bool) -> smolvm::Resul
     let result = start_vm_named(clone, None, None);
     std::env::remove_var("SMOLVM_SNAPSHOT_DIR");
     if result.is_ok() {
+        rejuvenate_clone(clone);
         eprintln!(
             "Forked '{golden}' -> '{clone}'. Golden stays frozen as the fork base \
              (do not start it again while clones exist)."
@@ -743,6 +744,61 @@ pub fn fork_vm(golden: &str, clone: &str, clone_forkable: bool) -> smolvm::Resul
         let _ = db.remove_vm(clone);
     }
     result
+}
+
+/// Best-effort per-clone identity rejuvenation after a fork. A clone inherits
+/// the golden's hostname, machine-id, and (critically) RNG state, so without
+/// this every clone would share the golden's random stream — a security
+/// problem and a source of duplicate-identity bugs across a pool. Run over the
+/// freshly-booted clone's agent: set a unique hostname, mint a fresh
+/// machine-id, and stir the kernel RNG with fresh host entropy so the streams
+/// diverge. Failures are warnings, not fatal (the clone still works).
+///
+/// Note: this stirs but does not *credit* entropy (no `RNDADDENTROPY`/VMGENID
+/// yet), and does not re-address the network (MAC/IP) — both are follow-ups.
+fn rejuvenate_clone(clone: &str) {
+    let sock = vm_data_dir(clone).join("agent.sock");
+    let seed = host_random_hex(64);
+    // Names are validated (alphanumeric + dashes), so single-quoting is safe.
+    let script = format!(
+        "hostname '{c}' 2>/dev/null; printf '%s\\n' '{c}' > /etc/hostname 2>/dev/null; \
+         (cat /proc/sys/kernel/random/uuid 2>/dev/null | tr -d '-' > /etc/machine-id) 2>/dev/null; \
+         printf '%s' '{s}' > /dev/urandom 2>/dev/null; true",
+        c = clone,
+        s = seed,
+    );
+    let mut client = match smolvm::agent::AgentClient::connect_with_retry(&sock) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Warning: clone '{clone}' rejuvenation skipped (agent connect: {e})");
+            return;
+        }
+    };
+    match client.vm_exec(
+        vec!["/bin/sh".into(), "-c".into(), script],
+        vec![],
+        None,
+        Some(std::time::Duration::from_secs(10)),
+        None,
+    ) {
+        Ok((0, _, _)) => {}
+        Ok((code, _, stderr)) => eprintln!(
+            "Warning: clone '{clone}' rejuvenation exited {code}: {}",
+            String::from_utf8_lossy(&stderr).trim()
+        ),
+        Err(e) => eprintln!("Warning: clone '{clone}' rejuvenation failed: {e}"),
+    }
+}
+
+/// Read `hex_len/2` random bytes from the host RNG, hex-encoded. Used to seed
+/// each clone's RNG with distinct host entropy.
+fn host_random_hex(hex_len: usize) -> String {
+    use std::io::Read;
+    let mut buf = vec![0u8; hex_len / 2];
+    if let Ok(mut f) = std::fs::File::open("/dev/urandom") {
+        let _ = f.read_exact(&mut buf);
+    }
+    buf.iter().map(|b| format!("{b:02x}")).collect()
 }
 
 // ============================================================================

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -682,14 +682,31 @@ pub fn fork_vm(golden: &str, clone: &str, clone_forkable: bool) -> smolvm::Resul
     std::fs::create_dir_all(&snapshot_dir)
         .map_err(|e| Error::agent("create clone dir", e.to_string()))?;
 
-    // Register the clone in the DB: same config as the golden, but with no
-    // host port forwards (they would collide with the still-running golden;
-    // per-clone network rejuvenation is future work) and no running-state.
+    // Register the clone in the DB with the golden's config, no running-state,
+    // and its port forwards remapped to fresh host ports. With the default TSI
+    // backend outbound is proxied per-process (each clone gets it for free, no
+    // guest MAC/IP involved); only inbound host ports must be made distinct so
+    // the clone is reachable without colliding with the still-running golden or
+    // sibling clones.
     let mut clone_rec = golden_rec.clone();
     clone_rec.name = clone.to_string();
-    clone_rec.ports.clear();
     clone_rec.pid = None;
     clone_rec.pid_start_time = None;
+    if !clone_rec.ports.is_empty() {
+        let mut remapped = Vec::with_capacity(clone_rec.ports.len());
+        for (golden_host, guest) in &clone_rec.ports {
+            match alloc_free_host_port() {
+                Some(h) => {
+                    eprintln!("  port {golden_host}->{guest} (golden) remapped to {h}->{guest} (clone)");
+                    remapped.push((h, *guest));
+                }
+                None => eprintln!(
+                    "  warning: could not allocate a host port for guest port {guest}; dropping it"
+                ),
+            }
+        }
+        clone_rec.ports = remapped;
+    }
     db.insert_vm(clone, &clone_rec)?;
 
     // Freeze the golden and write its snapshot (checkpoint + memfd manifest).
@@ -788,6 +805,15 @@ fn rejuvenate_clone(clone: &str) {
         ),
         Err(e) => eprintln!("Warning: clone '{clone}' rejuvenation failed: {e}"),
     }
+}
+
+/// Allocate a currently-free host TCP port by binding to port 0 and reading
+/// back the OS-assigned port. Used to give each clone distinct inbound forwards.
+fn alloc_free_host_port() -> Option<u16> {
+    std::net::TcpListener::bind(("127.0.0.1", 0))
+        .ok()
+        .and_then(|l| l.local_addr().ok())
+        .map(|addr| addr.port())
 }
 
 /// Read `hex_len/2` random bytes from the host RNG, hex-encoded. Used to seed

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -760,7 +760,7 @@ pub fn fork_vm(
         enable_forkable_env(clone);
     }
     eprintln!("Booting clone '{clone}' from snapshot...");
-    let result = start_vm_named(clone, None, None);
+    let result = start_vm_named(clone, None, None, /* from_snapshot */ true);
     std::env::remove_var("SMOLVM_SNAPSHOT_DIR");
     if result.is_ok() {
         rejuvenate_clone(clone);
@@ -842,6 +842,23 @@ fn host_random_hex(hex_len: usize) -> String {
 // Start
 // ============================================================================
 
+/// Resolve a machine's persistent-workload command, docker-style: use the
+/// machine's own `(entrypoint, cmd)` if it set either of them, otherwise fall
+/// back to the image's OCI `(entrypoint, cmd)`. Returns the `(entrypoint, cmd)`
+/// to persist and run. An explicit machine command always wins over the image's.
+pub(crate) fn default_workload_to_image(
+    record_entrypoint: Vec<String>,
+    record_cmd: Vec<String>,
+    image_entrypoint: &[String],
+    image_cmd: &[String],
+) -> (Vec<String>, Vec<String>) {
+    if !record_entrypoint.is_empty() || !record_cmd.is_empty() {
+        (record_entrypoint, record_cmd)
+    } else {
+        (image_entrypoint.to_vec(), image_cmd.to_vec())
+    }
+}
+
 /// Start a named machine that has a config record.
 ///
 /// Uses direct DB operations instead of SmolvmConfig::load() to avoid
@@ -851,12 +868,13 @@ pub fn start_vm_named(
     name: &str,
     proxy: Option<&str>,
     no_proxy: Option<&str>,
+    from_snapshot: bool,
 ) -> smolvm::Result<()> {
     use smolvm::Error;
 
     // Direct DB lookup — 1 read cycle instead of loading everything
     let db = SmolvmDb::open()?;
-    let record = db.get_vm(name)?.ok_or_else(|| Error::vm_not_found(name))?;
+    let mut record = db.get_vm(name)?.ok_or_else(|| Error::vm_not_found(name))?;
 
     // Resolve via the shared probe (PID + vsock ping). The plain
     // `actual_state()` is PID-only and would treat a zombie VMM
@@ -1045,6 +1063,28 @@ pub fn start_vm_named(
             return Err(e);
         }
 
+        // Docker-like default: if the machine has no command of its own, adopt
+        // the image's OCI entrypoint+cmd as its persistent workload so an image
+        // VM runs its image's program on start (and forked clones inherit it).
+        // Persisted here on first boot (where the image config is available) so
+        // later starts reuse it without re-pulling.
+        if let Some(info) = image_info.as_ref() {
+            let (ep, cmd) = default_workload_to_image(
+                record.entrypoint.clone(),
+                record.cmd.clone(),
+                &info.entrypoint,
+                &info.cmd,
+            );
+            if ep != record.entrypoint || cmd != record.cmd {
+                record.entrypoint = ep.clone();
+                record.cmd = cmd.clone();
+                let _ = db.update_vm(name, |r| {
+                    r.entrypoint = ep.clone();
+                    r.cmd = cmd.clone();
+                });
+            }
+        }
+
         // Mark init as completed so subsequent starts skip pull + init.
         // Done before workload start so a CMD failure doesn't re-trigger init.
         if !record.init.is_empty() || record.image.is_some() {
@@ -1061,33 +1101,43 @@ pub fn start_vm_named(
 
     if let Some(ref img) = record.image {
         // Image-based machine: launch the workload container in the background.
-        // The command is the user-configured entrypoint+cmd if set; otherwise
-        // it is left empty and the agent resolves the image's own
-        // ENTRYPOINT+CMD. This lets service-style images (which orchestrate a
-        // supervised stack from their entrypoint) start as their authors
-        // intended, not just images given an explicit command.
+        // An empty command → the agent resolves the image's own ENTRYPOINT+CMD,
+        // so service-style images start as their authors intended. But a clone
+        // booted from a fork snapshot already has the golden's workload running
+        // in its restored memory; relaunching here would double-manage the crun
+        // container and hang every later `machine exec`, so skip the (re)launch
+        // entirely when restoring from a snapshot — the forked container is
+        // inherited as-is.
         let mut cmd = record.entrypoint.clone();
         cmd.extend(record.cmd.clone());
-        let mount_bindings =
-            crate::cli::parsers::record_mounts_to_runconfig_bindings(&record.mounts);
-        let bg_config = smolvm::agent::RunConfig::new(img, cmd)
-            .with_env(exec_env.clone())
-            .with_workdir(record.workdir.clone())
-            .with_user(record.user.clone())
-            .with_mounts(mount_bindings)
-            .with_persistent_overlay(Some(name.to_string()));
-        if let Err(e) = client.run_container_detached(bg_config) {
-            if let Err(stop_err) = manager.stop() {
-                tracing::warn!(error = %stop_err, "failed to stop machine after CMD launch failure");
+        if !from_snapshot {
+            let mount_bindings =
+                crate::cli::parsers::record_mounts_to_runconfig_bindings(&record.mounts);
+            let bg_config = smolvm::agent::RunConfig::new(img, cmd)
+                .with_env(exec_env.clone())
+                .with_workdir(record.workdir.clone())
+                .with_user(record.user.clone())
+                .with_mounts(mount_bindings)
+                .with_persistent_overlay(Some(name.to_string()));
+            if let Err(e) = client.run_container_detached(bg_config) {
+                if let Err(stop_err) = manager.stop() {
+                    tracing::warn!(error = %stop_err, "failed to stop machine after CMD launch failure");
+                }
+                return Err(smolvm::Error::agent("start background CMD", format!("{e}")));
             }
-            return Err(smolvm::Error::agent("start background CMD", format!("{e}")));
+        } else {
+            tracing::info!(
+                "clone booted from snapshot: workload container inherited from fork, skipping relaunch"
+            );
         }
         println!("Machine '{}' running (PID: {})", name, pid.unwrap_or(0));
     } else {
-        // No image — bare VM mode. Run entrypoint+cmd if configured.
+        // No image — bare VM mode. Run entrypoint+cmd if configured. As with the
+        // image branch, a snapshot-restored clone already ran this on the golden
+        // (its effects are in the restored memory/disk), so don't re-run it.
         let mut bare_cmd = record.entrypoint.clone();
         bare_cmd.extend(record.cmd.clone());
-        if !bare_cmd.is_empty() {
+        if !bare_cmd.is_empty() && !from_snapshot {
             // Reuse the secrets already resolved into `exec_env` above — avoids
             // a second store load + decrypt and a duplicate audit-log record.
             // The plaintext stays in this vector and never touches the record/DB.
@@ -1939,6 +1989,39 @@ mod init_runner_tests {
             workdir: workdir.map(str::to_string),
             user: user.map(str::to_string),
         }
+    }
+
+    #[test]
+    fn default_workload_to_image_falls_back_to_image_when_machine_has_none() {
+        let (ep, cmd) = default_workload_to_image(
+            Vec::new(),
+            Vec::new(),
+            &["/entry".to_string()],
+            &["arg".to_string()],
+        );
+        assert_eq!(ep, ["/entry"]);
+        assert_eq!(cmd, ["arg"]);
+    }
+
+    #[test]
+    fn default_workload_to_image_prefers_explicit_machine_command() {
+        // An explicit machine command always wins over the image's defaults,
+        // even if only one of entrypoint/cmd is set.
+        let (ep, cmd) = default_workload_to_image(
+            Vec::new(),
+            vec!["own-cmd".to_string()],
+            &["/image-entry".to_string()],
+            &["image-arg".to_string()],
+        );
+        assert!(ep.is_empty());
+        assert_eq!(cmd, ["own-cmd"]);
+    }
+
+    #[test]
+    fn default_workload_to_image_empty_when_neither_has_a_command() {
+        let (ep, cmd) = default_workload_to_image(Vec::new(), Vec::new(), &[], &[]);
+        assert!(ep.is_empty());
+        assert!(cmd.is_empty());
     }
 
     #[test]

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -585,6 +585,167 @@ pub fn create_vm(params: CreateVmParams) -> smolvm::Result<()> {
 }
 
 // ============================================================================
+// Fork
+// ============================================================================
+
+/// Path to a forkable machine's control socket (pause/resume/checkpoint/FORK).
+fn control_socket_path(name: &str) -> std::path::PathBuf {
+    vm_data_dir(name).join("control.sock")
+}
+
+/// Mark the current process so the VM it is about to launch (in the inherited
+/// environment of the spawned `_boot-vm`) backs guest RAM with a memfd and
+/// exposes a control socket — the prerequisites for forking it later.
+pub fn enable_forkable_env(name: &str) {
+    std::env::set_var("SMOLVM_FORKABLE", "1");
+    std::env::set_var("SMOLVM_CONTROL_SOCKET", control_socket_path(name));
+}
+
+/// Send a single line command to a VM control socket and return its reply line.
+fn control_socket_cmd(sock: &std::path::Path, cmd: &str) -> smolvm::Result<String> {
+    use smolvm::Error;
+    use std::io::{Read, Write};
+    use std::os::unix::net::UnixStream;
+
+    let mut stream = UnixStream::connect(sock)
+        .map_err(|e| Error::agent("connect control socket", e.to_string()))?;
+    stream
+        .set_read_timeout(Some(std::time::Duration::from_secs(60)))
+        .ok();
+    stream
+        .write_all(format!("{cmd}\n").as_bytes())
+        .map_err(|e| Error::agent("write control socket", e.to_string()))?;
+    let mut reply = String::new();
+    let mut byte = [0u8; 1];
+    loop {
+        match stream.read(&mut byte) {
+            Ok(0) => break,
+            Ok(_) => {
+                if byte[0] == b'\n' {
+                    break;
+                }
+                reply.push(byte[0] as char);
+            }
+            Err(e) => return Err(Error::agent("read control socket", e.to_string())),
+        }
+    }
+    Ok(reply)
+}
+
+/// Fork a running, forkable `golden` machine into a new `clone`.
+///
+/// Freezes the golden (it stays paused as the shared copy-on-write base — its
+/// guest RAM is mapped `MAP_PRIVATE` by clones, so it must not run again while
+/// clones exist), copy-on-write clones its disks, and boots the clone from the
+/// golden's in-memory snapshot.
+pub fn fork_vm(golden: &str, clone: &str, clone_forkable: bool) -> smolvm::Result<()> {
+    use smolvm::Error;
+
+    validate_vm_name(clone, "clone name").map_err(|e| Error::config("clone name", e))?;
+
+    let db = SmolvmDb::open()?;
+    let golden_rec = db.get_vm(golden)?.ok_or_else(|| Error::vm_not_found(golden))?;
+
+    // The golden must be alive and forkable. We probe the control socket rather
+    // than the vsock agent: after its first fork the golden is frozen (paused)
+    // as the shared base, so an agent ping would fail — but STATUS still answers
+    // (running or paused), and we can fork it again.
+    let ctl = control_socket_path(golden);
+    if !ctl.exists() {
+        return Err(Error::agent(
+            "fork",
+            format!("golden '{golden}' is not running forkable; start it with `machine start --forkable {golden}`"),
+        ));
+    }
+    let status = control_socket_cmd(&ctl, "STATUS").map_err(|e| {
+        Error::agent(
+            "fork",
+            format!("golden '{golden}' control socket not responding ({e}); start it with `machine start --forkable {golden}`"),
+        )
+    })?;
+    if !status.starts_with("OK") {
+        return Err(Error::agent(
+            "fork",
+            format!("golden '{golden}' is not ready to fork: {status}"),
+        ));
+    }
+    if db.get_vm(clone)?.is_some() {
+        return Err(Error::agent(
+            "fork",
+            format!("machine '{clone}' already exists"),
+        ));
+    }
+
+    // Clone dir + snapshot dir.
+    let clone_dir = vm_data_dir(clone);
+    let snapshot_dir = clone_dir.join("snapshot");
+    std::fs::create_dir_all(&snapshot_dir)
+        .map_err(|e| Error::agent("create clone dir", e.to_string()))?;
+
+    // Register the clone in the DB: same config as the golden, but with no
+    // host port forwards (they would collide with the still-running golden;
+    // per-clone network rejuvenation is future work) and no running-state.
+    let mut clone_rec = golden_rec.clone();
+    clone_rec.name = clone.to_string();
+    clone_rec.ports.clear();
+    clone_rec.pid = None;
+    clone_rec.pid_start_time = None;
+    db.insert_vm(clone, &clone_rec)?;
+
+    // Freeze the golden and write its snapshot (checkpoint + memfd manifest).
+    eprintln!("Freezing golden '{golden}' as fork base...");
+    let reply = control_socket_cmd(&ctl, &format!("FORK {}", snapshot_dir.display()))?;
+    if !reply.starts_with("OK") {
+        let _ = db.remove_vm(clone);
+        return Err(Error::agent("fork", format!("golden FORK failed: {reply}")));
+    }
+
+    // Copy-on-write clone the golden's disks. The golden is frozen and its
+    // device workers quiesced, so the disk images are at a consistent boundary.
+    // Copy the `.formatted` marker too, or the clone would reformat and wipe
+    // the golden's data. (`fs::copy` is sparse-aware via copy_file_range on
+    // Linux; reflink/clonefile is a future fast-path.)
+    let gdir = vm_data_dir(golden);
+    for fname in [
+        smolvm::data::storage::STORAGE_DISK_FILENAME,
+        smolvm::data::storage::OVERLAY_DISK_FILENAME,
+    ] {
+        let src = gdir.join(fname);
+        if !src.exists() {
+            continue;
+        }
+        let dst = clone_dir.join(fname);
+        // Sparse-aware copy (only allocated extents) — reflink/clonefile where
+        // the filesystem supports it, else a SEEK_DATA/SEEK_HOLE copy. The disks
+        // are 20/10 GiB nominal but mostly holes, so a plain copy would be huge.
+        smolvm::disk_utils::clone_or_copy_file(&src, &dst)
+            .map_err(|e| Error::agent("clone disk", format!("{fname}: {e}")))?;
+        let src_marker = src.with_extension("formatted");
+        if src_marker.exists() {
+            let _ = std::fs::copy(&src_marker, dst.with_extension("formatted"));
+        }
+    }
+
+    // Boot the clone from the golden's snapshot instead of cold-booting.
+    std::env::set_var("SMOLVM_SNAPSHOT_DIR", &snapshot_dir);
+    if clone_forkable {
+        enable_forkable_env(clone);
+    }
+    eprintln!("Booting clone '{clone}' from snapshot...");
+    let result = start_vm_named(clone, None, None);
+    std::env::remove_var("SMOLVM_SNAPSHOT_DIR");
+    if result.is_ok() {
+        eprintln!(
+            "Forked '{golden}' -> '{clone}'. Golden stays frozen as the fork base \
+             (do not start it again while clones exist)."
+        );
+    } else {
+        let _ = db.remove_vm(clone);
+    }
+    result
+}
+
+// ============================================================================
 // Start
 // ============================================================================
 

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -649,7 +649,9 @@ pub fn fork_vm(
     validate_vm_name(clone, "clone name").map_err(|e| Error::config("clone name", e))?;
 
     let db = SmolvmDb::open()?;
-    let golden_rec = db.get_vm(golden)?.ok_or_else(|| Error::vm_not_found(golden))?;
+    let golden_rec = db
+        .get_vm(golden)?
+        .ok_or_else(|| Error::vm_not_found(golden))?;
 
     // The golden must be alive and forkable. We probe the control socket rather
     // than the vsock agent: after its first fork the golden is frozen (paused)
@@ -708,7 +710,9 @@ pub fn fork_vm(
         for (golden_host, guest) in &clone_rec.ports {
             match alloc_free_host_port() {
                 Some(h) => {
-                    eprintln!("  port {golden_host}->{guest} (golden) remapped to {h}->{guest} (clone)");
+                    eprintln!(
+                        "  port {golden_host}->{guest} (golden) remapped to {h}->{guest} (clone)"
+                    );
                     remapped.push((h, *guest));
                 }
                 None => eprintln!(

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -638,7 +638,12 @@ fn control_socket_cmd(sock: &std::path::Path, cmd: &str) -> smolvm::Result<Strin
 /// guest RAM is mapped `MAP_PRIVATE` by clones, so it must not run again while
 /// clones exist), copy-on-write clones its disks, and boots the clone from the
 /// golden's in-memory snapshot.
-pub fn fork_vm(golden: &str, clone: &str, clone_forkable: bool) -> smolvm::Result<()> {
+pub fn fork_vm(
+    golden: &str,
+    clone: &str,
+    clone_forkable: bool,
+    pinned_ports: &[(u16, u16)],
+) -> smolvm::Result<()> {
     use smolvm::Error;
 
     validate_vm_name(clone, "clone name").map_err(|e| Error::config("clone name", e))?;
@@ -692,7 +697,13 @@ pub fn fork_vm(golden: &str, clone: &str, clone_forkable: bool) -> smolvm::Resul
     clone_rec.name = clone.to_string();
     clone_rec.pid = None;
     clone_rec.pid_start_time = None;
-    if !clone_rec.ports.is_empty() {
+    if !pinned_ports.is_empty() {
+        // User pinned the clone's forwards explicitly — use them as-is.
+        clone_rec.ports = pinned_ports.to_vec();
+        for (h, g) in &clone_rec.ports {
+            eprintln!("  port {h}->{g} (pinned)");
+        }
+    } else if !clone_rec.ports.is_empty() {
         let mut remapped = Vec::with_capacity(clone_rec.ports.len());
         for (golden_host, guest) in &clone_rec.ports {
             match alloc_free_host_port() {

--- a/src/disk_utils.rs
+++ b/src/disk_utils.rs
@@ -1,3 +1,6 @@
+//! Disk image helpers: sparse creation, template/copy-on-write cloning, and
+//! resizing of the raw VM disk images.
+
 use crate::data::consts::BYTES_PER_GIB;
 use crate::data::disk::DiskType;
 use crate::error::{Error, Result};
@@ -272,7 +275,7 @@ pub(crate) fn write_last_byte(
 /// Disk templates are sparse files (~500KB actual data in a 512MB logical file).
 /// `std::fs::copy()` copies all bytes including zero regions. The sparse copy
 /// path skips holes, reducing copy time from ~400ms to ~5ms.
-pub(crate) fn clone_or_copy_file(src: &Path, dst: &Path) -> Result<()> {
+pub fn clone_or_copy_file(src: &Path, dst: &Path) -> Result<()> {
     #[cfg(target_os = "macos")]
     {
         use std::ffi::CString;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ pub mod config;
 /// Canonical shared data models and constants used across adapters.
 pub mod data;
 pub mod db;
-mod disk_utils;
+pub mod disk_utils;
 pub mod dns_filter;
 pub mod dns_filter_listener;
 /// Language-neutral embedded runtime support shared by SDK adapters.

--- a/src/process.rs
+++ b/src/process.rs
@@ -117,7 +117,16 @@ pub fn harden_self() {
         // (cross-tenant memory leak). Self-access to /proc/self stays permitted,
         // so libkrun still reads its own maps and boots normally (verified on
         // Linux/KVM across bare/network/GPU VMs).
-        libc::prctl(libc::PR_SET_DUMPABLE, 0, 0, 0, 0);
+        //
+        // EXCEPTION: a forkable golden must stay dumpable. Its CoW clones map the
+        // golden's guest RAM by opening /proc/<golden_pid>/fd/<memfd>, which
+        // PR_SET_DUMPABLE=0 would deny (EACCES → clone can't boot). The
+        // RLIMIT_CORE=0 below still prevents a core dump from leaking the
+        // golden's RAM, so only same-uid /proc access + ptrace are relaxed —
+        // acceptable for a fork pool whose clones legitimately share its memory.
+        if std::env::var_os("SMOLVM_FORKABLE").is_none() {
+            libc::prctl(libc::PR_SET_DUMPABLE, 0, 0, 0, 0);
+        }
     }
     unsafe {
         let lim = libc::rlimit {


### PR DESCRIPTION
Cross-process fast fork for pre-warmed VM pools: freeze a forkable golden, then CoW-clone its RAM + disks into new VMs in ~0.1s.

## What it adds
- `machine start --forkable` (memfd-backed guest RAM + control socket) and `machine fork <golden> <clone> [-p host:guest]`.
- Wires libkrun checkpoint/restore + `krun_set_snapshot`; clone boots by CoW-mapping the golden's RAM (`/proc/<pid>/fd` memfd) and restoring device/vCPU state instead of cold-booting.
- Per-clone rejuvenation (fresh entropy + hostname), inbound port-forward remap to fresh host ports.
- Persistent workload for image machines + fork-safe clone start (a snapshot-restored clone inherits the golden's running container instead of double-launching it).
- Reconciles with main's runtime hardening: keeps a forkable golden dumpable so clones can map its RAM (`RLIMIT_CORE=0` still blocks the core-dump leak).
- Bumps libkrun to `d6e165e` (current libkrun main: cross-platform fork + DNS egress).

## Testing
Rebased onto current main; `cargo build --release` + 265 lib tests + clippy + fmt clean. Fork validated live on Linux/KVM (clone boots, CoW read-through, 1→N isolation, nested-fork rejected). Full integration suite run: fork/lifecycle/db/volumes/ports/resources/reliability/image green. Remaining failures are pre-existing and unrelated to fork (main's `list` name truncation; main's prune/init_completed interaction; libkrun's DNS-egress TCP/53).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/344">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->