### PR TITLE
fix: build linux dists on glibc 2.35 for Ubuntu 22.04+ compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,13 +130,18 @@ jobs:
             rootfs_arch: aarch64
             agent_arch: aarch64
             lib_dir: lib
+          # Linux dist binaries build on 22.04 (glibc 2.35), NOT ubuntu-latest
+          # (24.04 = glibc 2.39). Symbol versioning is backward-compatible only,
+          # so the build host's glibc is the MINIMUM a user needs at runtime —
+          # a 2.39-built binary dies on 22.04 with "GLIBC_2.39 not found". 2.35
+          # covers Ubuntu 22.04+ / Debian 12+ / RHEL 9+.
           - platform: linux-x86_64
-            runner: ubuntu-latest
+            runner: ubuntu-22.04
             rootfs_arch: x86_64
             agent_arch: x86_64
             lib_dir: lib/linux-x86_64
           - platform: linux-arm64
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-22.04-arm
             rootfs_arch: aarch64
             agent_arch: aarch64
             lib_dir: lib/linux-aarch64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,6 +227,23 @@ jobs:
             -s -k "$KEYCHAIN_PASSWORD" build.keychain
           rm /tmp/certificate.p12
 
+      # Check out the unified `smol` CLI (a separate repo) into ./smol so
+      # build-dist.sh builds and bundles it alongside the engine — one tarball
+      # serves both `smol` and `smolvm`. Requires repo secret SMOL_REPO_TOKEN
+      # with read access to smol-machines/smol. If unset, the step is skipped and
+      # an engine-only tarball is produced. Ref is left at the smol default
+      # branch (its versioning is independent of the engine tag); pin a ref here
+      # if you want reproducible smol-CLI releases.
+      - name: Check out smol CLI source
+        if: env.SMOL_REPO_TOKEN != ''
+        uses: actions/checkout@v6
+        with:
+          repository: smol-machines/smol
+          path: smol
+          token: ${{ secrets.SMOL_REPO_TOKEN }}
+        env:
+          SMOL_REPO_TOKEN: ${{ secrets.SMOL_REPO_TOKEN }}
+
       - name: Build distribution tarball
         run: ./scripts/build-dist.sh --skip-agent-build
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ version = "0.8.2"
 edition = "2021"
 description = "OCI-native microVM runtime"
 license = "Apache-2.0"
-repository = "https://github.com/smolvm/smolvm"
+repository = "https://github.com/smol-machines/smolvm"
 keywords = ["microvm", "container", "virtualization"]
 categories = ["virtualization", "command-line-utilities"]
 
@@ -29,11 +29,11 @@ name = "smolvm"
 path = "src/main.rs"
 
 [dependencies]
-smolvm-network = { path = "crates/smolvm-network" }
-smolvm-protocol = { path = "crates/smolvm-protocol" }
-smolvm-pack = { path = "crates/smolvm-pack" }
-smolvm-registry = { path = "crates/smolvm-registry" }
-smolfile = { path = "crates/smolvm-smolfile" }
+smolvm-network = { path = "crates/smolvm-network", version = "0.8.2" }
+smolvm-protocol = { path = "crates/smolvm-protocol", version = "0.8.2" }
+smolvm-pack = { path = "crates/smolvm-pack", version = "0.8.2" }
+smolvm-registry = { path = "crates/smolvm-registry", version = "0.8.2" }
+smolfile = { path = "crates/smolvm-smolfile", version = "0.8.2" }
 thiserror = "1"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
@@ -76,7 +76,7 @@ landlock = "0.4"
 
 [dev-dependencies]
 tempfile = "3"
-smolvm-protocol = { path = "crates/smolvm-protocol" }
+smolvm-protocol = { path = "crates/smolvm-protocol", version = "0.8.2" }
 regex = "1"
 
 [build-dependencies]

--- a/crates/smolvm-agent/Cargo.toml
+++ b/crates/smolvm-agent/Cargo.toml
@@ -4,13 +4,14 @@ version = "0.8.2"
 edition = "2021"
 description = "Guest agent for smolvm VMs (handles OCI operations and command execution)"
 license = "Apache-2.0"
+repository = "https://github.com/smol-machines/smolvm"
 
 [[bin]]
 name = "smolvm-agent"
 path = "src/main.rs"
 
 [dependencies]
-smolvm-protocol = { path = "../smolvm-protocol" }
+smolvm-protocol = { path = "../smolvm-protocol", version = "0.8.2" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/crates/smolvm-network/Cargo.toml
+++ b/crates/smolvm-network/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.8.2"
 edition = "2021"
 description = "Host-side virtio-net runtime for smolvm"
 license = "Apache-2.0"
+repository = "https://github.com/smol-machines/smolvm"
 
 [dependencies]
 crossbeam-queue = "0.3"

--- a/crates/smolvm-pack/Cargo.toml
+++ b/crates/smolvm-pack/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.8.2"
 edition = "2021"
 description = "Single-binary packaging for smolvm"
 license = "Apache-2.0"
+repository = "https://github.com/smol-machines/smolvm"
 
 [dependencies]
 serde = { workspace = true }

--- a/crates/smolvm-protocol/Cargo.toml
+++ b/crates/smolvm-protocol/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.8.2"
 edition = "2021"
 description = "Protocol types for smolvm host-guest communication"
 license = "Apache-2.0"
+repository = "https://github.com/smol-machines/smolvm"
 
 [dependencies]
 base64 = { workspace = true }

--- a/crates/smolvm-registry/Cargo.toml
+++ b/crates/smolvm-registry/Cargo.toml
@@ -4,9 +4,10 @@ version = "0.8.2"
 edition = "2021"
 description = "OCI Distribution client for smolmachines registry"
 license = "Apache-2.0"
+repository = "https://github.com/smol-machines/smolvm"
 
 [dependencies]
-smolvm-pack = { path = "../smolvm-pack" }
+smolvm-pack = { path = "../smolvm-pack", version = "0.8.2" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "json"] }
 sha2 = "0.10"
 bytes = "1"

--- a/lib/linux-aarch64/libkrun.so
+++ b/lib/linux-aarch64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:951e0bd7673378c0597aa7dad50f97f2e52e94e265c4d416cf1fd5235f83b96b
-size 6662232
+oid sha256:00ae1e189f1face0ea1dba0aac0f16eaaabf6d1a18064fbc9503f9723db3a540
+size 6543248

--- a/lib/linux-aarch64/libkrun.so.1.17.3
+++ b/lib/linux-aarch64/libkrun.so.1.17.3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:951e0bd7673378c0597aa7dad50f97f2e52e94e265c4d416cf1fd5235f83b96b
-size 6662232
+oid sha256:00ae1e189f1face0ea1dba0aac0f16eaaabf6d1a18064fbc9503f9723db3a540
+size 6543248

--- a/lib/linux-x86_64/libkrun.so
+++ b/lib/linux-x86_64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1cddfbfd041cd6835ef6fec7bf32ceef8d99dbc3ecdad2d609e85b47e72a8281
-size 7338560
+oid sha256:d5fb55c857ccfa47234e2798904db720cc79b186138c342531360732a935dee7
+size 7928832

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -250,6 +250,20 @@ fi
 echo "Building release binaries..."
 LIBKRUN_BUNDLE="$WORK_LIB_DIR" cargo build --release --bin smolvm
 
+# Build the unified `smol` CLI if its source is present (it lives in a sibling
+# repo checked out at ./smol). It is a separate cargo workspace that depends on
+# the engine by path, so build it from inside ./smol with an ABSOLUTE
+# LIBKRUN_BUNDLE so its build.rs finds the same bundled libraries we ship.
+BUILD_SMOL=0
+if [[ -f "./smol/Cargo.toml" ]]; then
+    echo "Building unified smol CLI..."
+    _ABS_LIB_BUNDLE="$(cd "$WORK_LIB_DIR" && pwd)"
+    ( cd ./smol && LIBKRUN_BUNDLE="$_ABS_LIB_BUNDLE" cargo build --release --bin smol )
+    BUILD_SMOL=1
+else
+    echo "smol CLI source (./smol) not found — building engine-only distribution"
+fi
+
 # Build smolvm-agent for Linux (size-optimized)
 if [[ "$SKIP_AGENT_BUILD" == "1" ]]; then
     echo "Skipping agent build (--skip-agent-build)"
@@ -299,6 +313,11 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
     fi
     echo "Signing binary (identity: $IDENTITY)..."
     codesign "${CODESIGN_ARGS[@]}" ./target/release/smolvm
+    # The smol binary also calls the macOS hypervisor, so it needs the same
+    # entitlements + signature (otherwise it cannot start a VM).
+    if [[ "$BUILD_SMOL" == "1" ]]; then
+        codesign "${CODESIGN_ARGS[@]}" ./smol/target/release/smol
+    fi
 fi
 
 # Create distribution directory
@@ -312,6 +331,15 @@ cp ./target/release/smolvm "$DIST_DIR/smolvm-bin"
 # Copy wrapper script
 cp ./scripts/smolvm-wrapper.sh "$DIST_DIR/smolvm"
 chmod +x "$DIST_DIR/smolvm"
+
+# Copy the unified smol CLI (binary renamed to smol-bin + its own wrapper).
+# The wrapper points at the same lib/ and agent-rootfs, so one tarball serves
+# both `smol` (the user-facing CLI) and `smolvm` (the lower-level engine).
+if [[ "$BUILD_SMOL" == "1" ]]; then
+    cp ./smol/target/release/smol "$DIST_DIR/smol-bin"
+    cp ./scripts/smol-wrapper.sh "$DIST_DIR/smol"
+    chmod +x "$DIST_DIR/smol"
+fi
 
 # Copy libraries
 if [[ "$(uname -s)" == "Darwin" ]]; then

--- a/scripts/build-libkrun-linux.sh
+++ b/scripts/build-libkrun-linux.sh
@@ -21,6 +21,11 @@
 # Usage:  ./scripts/build-libkrun-linux.sh
 #   GPU=0                 skip the GPU feature (drops the virglrenderer dep)
 #   SKIP_DEPS=1           assume build deps are already installed
+#   SKIP_LIBKRUNFW=1      reuse the committed lib/linux-<arch>/libkrunfw.so and
+#                         rebuild ONLY libkrun. libkrunfw is host-glibc-independent
+#                         (it wraps a guest-kernel blob; its floor is GLIBC_2.2),
+#                         so when the goal is lowering libkrun's glibc floor there's
+#                         no need to recompile the kernel — skips the slow step.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -63,8 +68,15 @@ if [ -d .git ]; then
     git submodule update --init libkrun libkrunfw || true
     git lfs pull 2>/dev/null || true
 fi
-[ -f libkrunfw/Makefile ] && [ -d libkrun/src ] \
-    || { echo "ERROR: libkrun/ and libkrunfw/ source must be present (clone or rsync them here)." >&2; exit 1; }
+[ -d libkrun/src ] \
+    || { echo "ERROR: libkrun/ source must be present (clone or rsync it here)." >&2; exit 1; }
+# Only the libkrunfw kernel source is needed when we actually rebuild it — under
+# SKIP_LIBKRUNFW the committed lib/linux-<arch>/libkrunfw.so is reused, so a
+# light rsync of just libkrun/ + lib/ is enough (no multi-GB kernel tree).
+if [[ "${SKIP_LIBKRUNFW:-0}" != "1" ]]; then
+    [ -f libkrunfw/Makefile ] \
+        || { echo "ERROR: libkrunfw/ source must be present (or set SKIP_LIBKRUNFW=1 to reuse the committed lib)." >&2; exit 1; }
+fi
 
 # bindgen needs to find libclang at runtime on some distros.
 if [[ -z "${LIBCLANG_PATH:-}" ]]; then
@@ -73,13 +85,18 @@ if [[ -z "${LIBCLANG_PATH:-}" ]]; then
 fi
 
 # --- 2. libkrunfw (guest kernel) ---------------------------------------------
-echo "--- building libkrunfw (kernel ${ARCH}; this is the slow step) ---"
-# Build from INSIDE the dir, NOT `make -C`: `-C` auto-enables -w (print-dir),
-# which lands in MAKEFLAGS as a bare `w`; the kernel's `$(MAKE) $(MAKEFLAGS)`
-# recipe then dies with "No rule to make target 'w'". -j scales the kernel build.
-( cd libkrunfw && make clean >/dev/null 2>&1 || true; make -j"$(nproc)" GUESTARCH="${ARCH}" )
-KRUNFW_SO="$(ls -1 libkrunfw/libkrunfw.so.*.*.* 2>/dev/null | head -1)"
-[[ -n "$KRUNFW_SO" ]] || { echo "ERROR: libkrunfw build produced no .so" >&2; exit 1; }
+if [[ "${SKIP_LIBKRUNFW:-0}" == "1" ]]; then
+    echo "--- SKIP_LIBKRUNFW=1: reusing committed ${LIBDIR}/libkrunfw.so.* (host-glibc-independent) ---"
+    KRUNFW_SO=""   # signals "do not re-assemble libkrunfw" below
+else
+    echo "--- building libkrunfw (kernel ${ARCH}; this is the slow step) ---"
+    # Build from INSIDE the dir, NOT `make -C`: `-C` auto-enables -w (print-dir),
+    # which lands in MAKEFLAGS as a bare `w`; the kernel's `$(MAKE) $(MAKEFLAGS)`
+    # recipe then dies with "No rule to make target 'w'". -j scales the kernel build.
+    ( cd libkrunfw && make clean >/dev/null 2>&1 || true; make -j"$(nproc)" GUESTARCH="${ARCH}" )
+    KRUNFW_SO="$(ls -1 libkrunfw/libkrunfw.so.*.*.* 2>/dev/null | head -1)"
+    [[ -n "$KRUNFW_SO" ]] || { echo "ERROR: libkrunfw build produced no .so" >&2; exit 1; }
+fi
 
 # --- 3. init (static guest-arch ELF, built natively) -------------------------
 echo "--- building guest init (native ${ARCH} ELF) ---"
@@ -109,7 +126,11 @@ assemble() {
     ln -sf "${base}.${major}" "$LIBDIR/${base}"  # libkrunfw.so   -> .so.5
 }
 
-assemble "$KRUNFW_SO" "libkrunfw.so"
+if [[ -n "$KRUNFW_SO" ]]; then
+    assemble "$KRUNFW_SO" "libkrunfw.so"
+else
+    echo "--- keeping committed ${LIBDIR}/libkrunfw.so (SKIP_LIBKRUNFW) ---"
+fi
 # libkrun: x86_64 keeps libkrun.so as a real file too — mirror that.
 KRUN_FNAME="$(basename "$KRUN_SO")"; KRUN_VER="${KRUN_FNAME#libkrun.so.}"; KRUN_MAJOR="${KRUN_VER%%.*}"
 cp -f "$KRUN_SO" "$LIBDIR/$KRUN_FNAME"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -350,6 +350,12 @@ install_smolvm() {
     if [[ -f "$prefix/smolvm-bin" ]]; then
         rm -f "$prefix/smolvm-bin"
     fi
+    if [[ -f "$prefix/smol" ]]; then
+        rm -f "$prefix/smol"
+    fi
+    if [[ -f "$prefix/smol-bin" ]]; then
+        rm -f "$prefix/smol-bin"
+    fi
     if [[ -f "$prefix/smolvm-stub" ]]; then
         rm -f "$prefix/smolvm-stub"
     fi
@@ -366,6 +372,17 @@ install_smolvm() {
     cp "$extracted_dir/smolvm-bin" "$prefix/"
     chmod +x "$prefix/smolvm"
     chmod +x "$prefix/smolvm-bin"
+
+    # Copy the unified `smol` CLI if the distribution includes it. Older
+    # engine-only tarballs won't have it; newer ones ship both.
+    local has_smol=false
+    if [[ -f "$extracted_dir/smol" ]] && [[ -f "$extracted_dir/smol-bin" ]]; then
+        cp "$extracted_dir/smol" "$prefix/"
+        cp "$extracted_dir/smol-bin" "$prefix/"
+        chmod +x "$prefix/smol"
+        chmod +x "$prefix/smol-bin"
+        has_smol=true
+    fi
 
     # Copy disk templates if present
     if [[ -f "$extracted_dir/storage-template.ext4" ]]; then
@@ -406,11 +423,37 @@ install_smolvm() {
     # Cleanup
     rm -rf "$tmp_dir"
 
-    # Create symlink in bin directory
+    # macOS: files downloaded via curl carry a com.apple.quarantine attribute,
+    # and Gatekeeper will refuse to run the binaries (which call the hypervisor)
+    # until it's cleared. Strip it from the whole install tree, then check the
+    # code signature so we can warn clearly instead of failing cryptically.
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        if command -v xattr &> /dev/null; then
+            xattr -dr com.apple.quarantine "$prefix" 2>/dev/null || true
+        fi
+        if command -v codesign &> /dev/null; then
+            local _sig_bin="$prefix/smolvm-bin"
+            [[ "$has_smol" == true ]] && _sig_bin="$prefix/smol-bin"
+            if ! codesign --verify --deep "$_sig_bin" 2>/dev/null; then
+                warn "The installed binary is not validly code-signed."
+                warn "It needs the com.apple.security.hypervisor entitlement to start VMs."
+            elif command -v spctl &> /dev/null && ! spctl --assess --type execute "$_sig_bin" &> /dev/null; then
+                warn "Binary is signed but not notarized by Apple."
+                warn "It will run (quarantine was cleared), but Gatekeeper may warn on first launch."
+            fi
+        fi
+    fi
+
+    # Create symlinks in bin directory. `smol` is the primary, user-facing CLI;
+    # `smolvm` remains available as the lower-level engine command.
     mkdir -p "$BIN_DIR"
     ln -sf "$prefix/smolvm" "$BIN_DIR/smolvm"
-
-    success "smolvm $version installed to $prefix"
+    if [[ "$has_smol" == true ]]; then
+        ln -sf "$prefix/smol" "$BIN_DIR/smol"
+        success "smol $version installed to $prefix (also installed: smolvm)"
+    else
+        success "smolvm $version installed to $prefix"
+    fi
 }
 
 # Modify shell profile to add to PATH

--- a/scripts/smol-wrapper.sh
+++ b/scripts/smol-wrapper.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# smol - the unified Smol Machines CLI (local microVMs + cloud)
+# This wrapper sets up the library path and runs the smol binary.
+#
+# It mirrors smolvm-wrapper.sh: the `smol` binary embeds the same engine, so it
+# discovers libkrun/libkrunfw and the agent rootfs the same way (relative to its
+# own install directory), making the distribution relocatable.
+
+set -e
+
+# Resolve symlinks to get the actual script location
+resolve_symlink() {
+    local target="$1"
+    while [[ -L "$target" ]]; do
+        local link_dir
+        link_dir="$(cd "$(dirname "$target")" && pwd)"
+        target="$(readlink "$target")"
+        # Handle relative symlinks
+        if [[ "$target" != /* ]]; then
+            target="$link_dir/$target"
+        fi
+    done
+    echo "$target"
+}
+
+# Get the directory where the actual script lives (resolving symlinks)
+SCRIPT_PATH="$(resolve_symlink "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+
+# The actual binary and libraries are in the same directory
+SMOL_BIN="$SCRIPT_DIR/smol-bin"
+SMOL_LIB="$SCRIPT_DIR/lib"
+SMOL_BUNDLED_ROOTFS="$SCRIPT_DIR/agent-rootfs"
+
+if [[ -d "$SMOL_BUNDLED_ROOTFS" ]]; then
+    export SMOLVM_AGENT_ROOTFS="${SMOLVM_AGENT_ROOTFS:-$SMOL_BUNDLED_ROOTFS}"
+fi
+
+# Check if binary exists
+if [[ ! -x "$SMOL_BIN" ]]; then
+    echo "Error: smol binary not found at $SMOL_BIN" >&2
+    echo "Make sure you extracted the full distribution." >&2
+    exit 1
+fi
+
+# Check if libraries exist
+if [[ ! -d "$SMOL_LIB" ]]; then
+    echo "Error: library directory not found at $SMOL_LIB" >&2
+    echo "Make sure you extracted the full distribution." >&2
+    exit 1
+fi
+
+# Set library path based on OS and run
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    export DYLD_LIBRARY_PATH="$SMOL_LIB${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+else
+    export LD_LIBRARY_PATH="$SMOL_LIB${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+exec "$SMOL_BIN" "$@"


### PR DESCRIPTION
Fixes #303.

Binaries built on `ubuntu-latest` (24.04 / glibc 2.39) fail on older distros with `version GLIBC_2.39 not found`. glibc symbol versioning is backward-compatible only, so the build host's glibc is the runtime floor.

Two walls, both fixed:

- **`smolvm-bin`** (the reported `smolvm --help` crash): build the `linux-x86_64` and `linux-arm64` dist binaries on `ubuntu-22.04` runners (glibc 2.35) instead of `ubuntu-latest`. The bundled `smol` CLI benefits too (same runner).
- **bundled `libkrun.so`** (hit at `smolvm run`, dlopen time): rebuilt on 22.04 for both arches, dropping the floor from `GLIBC_2.39` to `GLIBC_2.34`. `libkrunfw.so` untouched (already `GLIBC_2.2`).

Also adds `SKIP_LIBKRUNFW=1` to `scripts/build-libkrun-linux.sh` so the libkrun-only rebuild skips the slow kernel compile.

New floor: **GLIBC 2.34** → Ubuntu 22.04+, Debian 11+, RHEL 9+.

Verified: both rebuilt `.so` report max `GLIBC_2.34` via symbol-version scan; libkrun compiled fresh from the current source on each arch.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/345">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->