### PR TITLE
chore: bump workspace to 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "smolvm"
-version = "0.8.2"
+version = "0.9.0"
 edition = "2021"
 description = "OCI-native microVM runtime"
 license = "Apache-2.0"
@@ -29,11 +29,11 @@ name = "smolvm"
 path = "src/main.rs"
 
 [dependencies]
-smolvm-network = { path = "crates/smolvm-network", version = "0.8.2" }
-smolvm-protocol = { path = "crates/smolvm-protocol", version = "0.8.2" }
-smolvm-pack = { path = "crates/smolvm-pack", version = "0.8.2" }
-smolvm-registry = { path = "crates/smolvm-registry", version = "0.8.2" }
-smolfile = { path = "crates/smolvm-smolfile", version = "0.8.2" }
+smolvm-network = { path = "crates/smolvm-network", version = "0.9.0" }
+smolvm-protocol = { path = "crates/smolvm-protocol", version = "0.9.0" }
+smolvm-pack = { path = "crates/smolvm-pack", version = "0.9.0" }
+smolvm-registry = { path = "crates/smolvm-registry", version = "0.9.0" }
+smolfile = { path = "crates/smolvm-smolfile", version = "0.9.0" }
 thiserror = "1"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
@@ -85,7 +85,7 @@ landlock = "0.4"
 
 [dev-dependencies]
 tempfile = "3"
-smolvm-protocol = { path = "crates/smolvm-protocol", version = "0.8.2" }
+smolvm-protocol = { path = "crates/smolvm-protocol", version = "0.9.0" }
 regex = "1"
 
 [build-dependencies]

--- a/crates/smolvm-agent/Cargo.toml
+++ b/crates/smolvm-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-agent"
-version = "0.8.2"
+version = "0.9.0"
 edition = "2021"
 description = "Guest agent for smolvm VMs (handles OCI operations and command execution)"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ name = "smolvm-agent"
 path = "src/main.rs"
 
 [dependencies]
-smolvm-protocol = { path = "../smolvm-protocol", version = "0.8.2" }
+smolvm-protocol = { path = "../smolvm-protocol", version = "0.9.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/crates/smolvm-network/Cargo.toml
+++ b/crates/smolvm-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-network"
-version = "0.8.2"
+version = "0.9.0"
 edition = "2021"
 description = "Host-side virtio-net runtime for smolvm"
 license = "Apache-2.0"

--- a/crates/smolvm-pack/Cargo.toml
+++ b/crates/smolvm-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-pack"
-version = "0.8.2"
+version = "0.9.0"
 edition = "2021"
 description = "Single-binary packaging for smolvm"
 license = "Apache-2.0"

--- a/crates/smolvm-protocol/Cargo.toml
+++ b/crates/smolvm-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-protocol"
-version = "0.8.2"
+version = "0.9.0"
 edition = "2021"
 description = "Protocol types for smolvm host-guest communication"
 license = "Apache-2.0"

--- a/crates/smolvm-registry/Cargo.toml
+++ b/crates/smolvm-registry/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "smolvm-registry"
-version = "0.8.2"
+version = "0.9.0"
 edition = "2021"
 description = "OCI Distribution client for smolmachines registry"
 license = "Apache-2.0"
 repository = "https://github.com/smol-machines/smolvm"
 
 [dependencies]
-smolvm-pack = { path = "../smolvm-pack", version = "0.8.2" }
+smolvm-pack = { path = "../smolvm-pack", version = "0.9.0" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "json"] }
 sha2 = "0.10"
 bytes = "1"

--- a/crates/smolvm-smolfile/Cargo.toml
+++ b/crates/smolvm-smolfile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolfile"
-version = "0.8.2"
+version = "0.9.0"
 edition = "2021"
 description = "Smolfile specification and parser for smolvm microVM workloads"
 license = "Apache-2.0"


### PR DESCRIPTION
Cuts **v0.9.0** — a minor bump because the headline new capability since 0.8.x is the **host-side secret store** (#330: refs-only persistence; plaintext resolved on the host at exec, never in the DB or pack). The fast VM fork wave (#344/#332) is reserved for the next big bump.

Also ships the two user-blocking fixes:
- **#303** — linux dists build on glibc 2.35, so install + `smolvm --help` work on Ubuntu 22.04+.
- **#317** — bundled libkrun virglrenderer is optional, so `smolvm run` works without a GPU.

…plus seccomp-aarch64, drain-on-shutdown, registry identity token, and the bundled `smol` CLI.

Bumps all 6 member crates + root + internal dep pins to 0.9.0 (workspace resolves clean). After merge, tag `v0.9.0` to fire the release (pipeline now carries the glibc-2.35 runners + patchelf strip from #345/#346).

(Branch name is `binbin-release-0-8-3` — cosmetic; the release is 0.9.0.)