### PR TITLE
fix(crates): version-pin smolvm-protocol dep in smolfile + pack

### DIFF
--- a/crates/smolvm-pack/Cargo.toml
+++ b/crates/smolvm-pack/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/smol-machines/smolvm"
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-smolvm-protocol = { path = "../smolvm-protocol" }
+smolvm-protocol = { path = "../smolvm-protocol", version = "0.9.0" }
 tar = "0.4"
 zstd = "0.13"
 crc32fast = "1.4"

--- a/crates/smolvm-smolfile/Cargo.toml
+++ b/crates/smolvm-smolfile/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["smolvm", "microvm", "configuration"]
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 thiserror = "1"
-smolvm-protocol = { path = "../smolvm-protocol" }
+smolvm-protocol = { path = "../smolvm-protocol", version = "0.9.0" }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
The secret store added `smolvm-protocol` as a dependency to `smolvm-smolfile` and `smolvm-pack`, but path-only (no `version`) — which crates.io rejects on publish. Pinned to `0.9.0`.

Already used to publish the 0.9.0 crate line (protocol, smolfile, network, pack, registry all live on crates.io at 0.9.0); this brings `main` into sync with the published manifests so future publishes work from a clean checkout.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/349">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->