### PR TITLE
feat(registry): OCI image-index support — one tag fans out by platform

### DIFF
--- a/crates/smolvm-registry/src/client.rs
+++ b/crates/smolvm-registry/src/client.rs
@@ -354,7 +354,11 @@ impl RegistryClient {
         // (the registry validates the Content-Type against the body's mediaType).
         let media_type = serde_json::from_slice::<serde_json::Value>(manifest)
             .ok()
-            .and_then(|v| v.get("mediaType").and_then(|m| m.as_str()).map(String::from))
+            .and_then(|v| {
+                v.get("mediaType")
+                    .and_then(|m| m.as_str())
+                    .map(String::from)
+            })
             .unwrap_or_else(|| MANIFEST_MEDIA_TYPE.to_string());
         let url = format!("{}/v2/{}/manifests/{}", self.base_url, repo, reference);
         let resp = self
@@ -435,7 +439,10 @@ impl RegistryClient {
             .await?;
 
         if resp.status() == reqwest::StatusCode::NOT_FOUND {
-            return Err(RegistryError::BlobNotFound(format!("{}:{}", repo, reference)));
+            return Err(RegistryError::BlobNotFound(format!(
+                "{}:{}",
+                repo, reference
+            )));
         }
         if !resp.status().is_success() {
             return Err(RegistryError::ApiError {

--- a/crates/smolvm-registry/src/client.rs
+++ b/crates/smolvm-registry/src/client.rs
@@ -7,7 +7,7 @@
 //! - Blob download (GET)
 //! - Manifest put/get (PUT/GET)
 
-use crate::{RegistryError, Result, MANIFEST_MEDIA_TYPE};
+use crate::{RegistryError, Result, INDEX_MEDIA_TYPE, MANIFEST_MEDIA_TYPE};
 use reqwest::header::{ACCEPT, CONTENT_LENGTH, CONTENT_TYPE, LOCATION, WWW_AUTHENTICATE};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
@@ -350,11 +350,17 @@ impl RegistryClient {
 
     /// Upload a manifest for the given reference (tag or digest).
     pub async fn put_manifest(&self, repo: &str, reference: &str, manifest: &[u8]) -> Result<()> {
+        // Honor the document's own `mediaType` so this also PUTs an image index
+        // (the registry validates the Content-Type against the body's mediaType).
+        let media_type = serde_json::from_slice::<serde_json::Value>(manifest)
+            .ok()
+            .and_then(|v| v.get("mediaType").and_then(|m| m.as_str()).map(String::from))
+            .unwrap_or_else(|| MANIFEST_MEDIA_TYPE.to_string());
         let url = format!("{}/v2/{}/manifests/{}", self.base_url, repo, reference);
         let resp = self
             .send_replayable(
                 self.request(reqwest::Method::PUT, &url)
-                    .header(CONTENT_TYPE, MANIFEST_MEDIA_TYPE)
+                    .header(CONTENT_TYPE, media_type)
                     .body(manifest.to_vec()),
             )
             .await?;
@@ -411,6 +417,40 @@ impl RegistryClient {
         }
 
         Ok(resp.bytes().await?.to_vec())
+    }
+
+    /// Fetch a manifest OR image index by reference, returning the raw bytes and
+    /// the document's media type. Unlike [`get_manifest`], this accepts (and does
+    /// not reject) an image index — the caller decides whether to resolve it to a
+    /// platform manifest. Used by `pull` for multi-arch fan-out.
+    pub async fn get_manifest_raw(&self, repo: &str, reference: &str) -> Result<(Vec<u8>, String)> {
+        let url = format!("{}/v2/{}/manifests/{}", self.base_url, repo, reference);
+        let resp = self
+            .send_replayable(
+                self.request(reqwest::Method::GET, &url)
+                    // Advertise BOTH so the registry hands back an index as an
+                    // index (not a server-side-selected manifest).
+                    .header(ACCEPT, format!("{INDEX_MEDIA_TYPE}, {MANIFEST_MEDIA_TYPE}")),
+            )
+            .await?;
+
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Err(RegistryError::BlobNotFound(format!("{}:{}", repo, reference)));
+        }
+        if !resp.status().is_success() {
+            return Err(RegistryError::ApiError {
+                status: resp.status().as_u16(),
+                body: resp.text().await.unwrap_or_default(),
+            });
+        }
+
+        let content_type = resp
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        Ok((resp.bytes().await?.to_vec(), content_type))
     }
 
     /// Resolve a Location header value against the registry base URL.

--- a/crates/smolvm-registry/src/lib.rs
+++ b/crates/smolvm-registry/src/lib.rs
@@ -73,20 +73,30 @@ impl OciPlatform {
             "x86_64" => "amd64",
             other => other,
         };
-        Self { os: os.to_string(), architecture: architecture.to_string(), variant: None }
+        Self {
+            os: os.to_string(),
+            architecture: architecture.to_string(),
+            variant: None,
+        }
     }
 
     /// Parse a `host_platform` string (`"darwin/arm64"`, `"linux/x86_64"`) into a
     /// platform descriptor, normalizing the arch (`x86_64`→`amd64`,
     /// `aarch64`→`arm64`) so index entries and `current()` always agree.
     pub fn parse(host_platform: &str) -> Self {
-        let (os, arch) = host_platform.split_once('/').unwrap_or(("linux", host_platform));
+        let (os, arch) = host_platform
+            .split_once('/')
+            .unwrap_or(("linux", host_platform));
         let architecture = match arch {
             "x86_64" => "amd64",
             "aarch64" => "arm64",
             other => other,
         };
-        Self { os: os.to_string(), architecture: architecture.to_string(), variant: None }
+        Self {
+            os: os.to_string(),
+            architecture: architecture.to_string(),
+            variant: None,
+        }
     }
 
     /// Human label, e.g. `linux/amd64`.
@@ -198,7 +208,10 @@ mod platform_tests {
     fn parse_normalizes_arch_and_os() {
         // host_platform strings (as written into PackManifest) → OCI platform.
         let p = OciPlatform::parse("darwin/arm64");
-        assert_eq!((p.os.as_str(), p.architecture.as_str()), ("darwin", "arm64"));
+        assert_eq!(
+            (p.os.as_str(), p.architecture.as_str()),
+            ("darwin", "arm64")
+        );
         // x86_64/aarch64 normalize to amd64/arm64 so index entries and current()
         // always compare equal.
         assert_eq!(OciPlatform::parse("linux/x86_64").architecture, "amd64");
@@ -245,11 +258,18 @@ mod platform_tests {
         assert_eq!(back.manifests.len(), 2);
         // pull's selection: find the entry whose platform == the wanted one.
         let want = OciPlatform::parse("linux/amd64");
-        let hit = back.manifests.iter().find(|m| m.platform.as_ref() == Some(&want)).unwrap();
+        let hit = back
+            .manifests
+            .iter()
+            .find(|m| m.platform.as_ref() == Some(&want))
+            .unwrap();
         assert_eq!(hit.digest, "sha256:bbb");
         // a platform not present → no match (pull would 404 with the available list).
         let miss = OciPlatform::parse("windows/amd64");
-        assert!(back.manifests.iter().all(|m| m.platform.as_ref() != Some(&miss)));
+        assert!(back
+            .manifests
+            .iter()
+            .all(|m| m.platform.as_ref() != Some(&miss)));
     }
 }
 

--- a/crates/smolvm-registry/src/lib.rs
+++ b/crates/smolvm-registry/src/lib.rs
@@ -43,6 +43,80 @@ pub struct OciDescriptor {
     pub size: u64,
 }
 
+/// OCI image index media type — a multi-platform "fan-out" manifest that points
+/// at one single-platform manifest per (os, arch). A single tag (e.g.
+/// `alpine:latest`) can carry an index so `pull` auto-selects the caller's
+/// platform, exactly like a Docker manifest list.
+pub const INDEX_MEDIA_TYPE: &str = "application/vnd.oci.image.index.v1+json";
+
+/// The platform a manifest targets, as it appears in an index entry. For
+/// smolmachines this is the **host** platform the artifact runs on (it bundles
+/// host-specific libkrun), e.g. `os=linux, architecture=amd64`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OciPlatform {
+    pub os: String,
+    pub architecture: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub variant: Option<String>,
+}
+
+impl OciPlatform {
+    /// The platform of the process running right now, in OCI form (`darwin`/
+    /// `linux`, `arm64`/`amd64`) — matches `PackManifest.host_platform`.
+    pub fn current() -> Self {
+        let os = match std::env::consts::OS {
+            "macos" => "darwin",
+            other => other,
+        };
+        let architecture = match std::env::consts::ARCH {
+            "aarch64" => "arm64",
+            "x86_64" => "amd64",
+            other => other,
+        };
+        Self { os: os.to_string(), architecture: architecture.to_string(), variant: None }
+    }
+
+    /// Parse a `host_platform` string (`"darwin/arm64"`, `"linux/x86_64"`) into a
+    /// platform descriptor, normalizing the arch (`x86_64`→`amd64`,
+    /// `aarch64`→`arm64`) so index entries and `current()` always agree.
+    pub fn parse(host_platform: &str) -> Self {
+        let (os, arch) = host_platform.split_once('/').unwrap_or(("linux", host_platform));
+        let architecture = match arch {
+            "x86_64" => "amd64",
+            "aarch64" => "arm64",
+            other => other,
+        };
+        Self { os: os.to_string(), architecture: architecture.to_string(), variant: None }
+    }
+
+    /// Human label, e.g. `linux/amd64`.
+    pub fn label(&self) -> String {
+        format!("{}/{}", self.os, self.architecture)
+    }
+}
+
+/// One entry in an [`OciIndex`]: a manifest descriptor plus the platform it
+/// targets.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OciIndexManifest {
+    pub media_type: String,
+    pub digest: String,
+    pub size: u64,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub platform: Option<OciPlatform>,
+}
+
+/// OCI image index — references one manifest per platform so a single tag fans
+/// out by architecture.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OciIndex {
+    pub schema_version: u32,
+    pub media_type: String,
+    pub manifests: Vec<OciIndexManifest>,
+}
+
 /// Error type for registry operations.
 #[derive(Debug, thiserror::Error)]
 pub enum RegistryError {
@@ -114,6 +188,69 @@ fn is_loopback_ipv4(s: &str) -> bool {
         return false;
     }
     parts[0] == "127" && parts[1..].iter().all(|p| p.parse::<u8>().is_ok())
+}
+
+#[cfg(test)]
+mod platform_tests {
+    use super::*;
+
+    #[test]
+    fn parse_normalizes_arch_and_os() {
+        // host_platform strings (as written into PackManifest) → OCI platform.
+        let p = OciPlatform::parse("darwin/arm64");
+        assert_eq!((p.os.as_str(), p.architecture.as_str()), ("darwin", "arm64"));
+        // x86_64/aarch64 normalize to amd64/arm64 so index entries and current()
+        // always compare equal.
+        assert_eq!(OciPlatform::parse("linux/x86_64").architecture, "amd64");
+        assert_eq!(OciPlatform::parse("linux/aarch64").architecture, "arm64");
+        assert_eq!(OciPlatform::parse("linux/amd64").label(), "linux/amd64");
+        // Missing slash → defaults os to linux.
+        assert_eq!(OciPlatform::parse("amd64").os, "linux");
+    }
+
+    #[test]
+    fn current_matches_parse_of_its_own_label() {
+        // The selection in pull compares an index entry to current(); a manifest
+        // pushed FROM this machine must therefore round-trip equal.
+        let cur = OciPlatform::current();
+        assert_eq!(OciPlatform::parse(&cur.label()), cur);
+        assert!(matches!(cur.architecture.as_str(), "arm64" | "amd64"));
+        assert!(matches!(cur.os.as_str(), "darwin" | "linux" | "windows"));
+    }
+
+    #[test]
+    fn index_round_trips_and_entry_selection_works() {
+        let index = OciIndex {
+            schema_version: 2,
+            media_type: INDEX_MEDIA_TYPE.to_string(),
+            manifests: vec![
+                OciIndexManifest {
+                    media_type: MANIFEST_MEDIA_TYPE.to_string(),
+                    digest: "sha256:aaa".into(),
+                    size: 10,
+                    platform: Some(OciPlatform::parse("linux/arm64")),
+                },
+                OciIndexManifest {
+                    media_type: MANIFEST_MEDIA_TYPE.to_string(),
+                    digest: "sha256:bbb".into(),
+                    size: 20,
+                    platform: Some(OciPlatform::parse("linux/amd64")),
+                },
+            ],
+        };
+        // serde round-trip (camelCase mediaType/schemaVersion).
+        let json = serde_json::to_vec(&index).unwrap();
+        assert!(String::from_utf8_lossy(&json).contains("\"mediaType\""));
+        let back: OciIndex = serde_json::from_slice(&json).unwrap();
+        assert_eq!(back.manifests.len(), 2);
+        // pull's selection: find the entry whose platform == the wanted one.
+        let want = OciPlatform::parse("linux/amd64");
+        let hit = back.manifests.iter().find(|m| m.platform.as_ref() == Some(&want)).unwrap();
+        assert_eq!(hit.digest, "sha256:bbb");
+        // a platform not present → no match (pull would 404 with the available list).
+        let miss = OciPlatform::parse("windows/amd64");
+        assert!(back.manifests.iter().all(|m| m.platform.as_ref() != Some(&miss)));
+    }
 }
 
 #[cfg(test)]

--- a/crates/smolvm-registry/src/pull.rs
+++ b/crates/smolvm-registry/src/pull.rs
@@ -64,7 +64,11 @@ pub async fn pull(
                 RegistryError::InvalidManifest(format!(
                     "no {} build available for this machine; the registry has: {}",
                     want.label(),
-                    if available.is_empty() { "(none)".into() } else { available.join(", ") }
+                    if available.is_empty() {
+                        "(none)".into()
+                    } else {
+                        available.join(", ")
+                    }
                 ))
             })?;
         tracing::info!(platform = %want.label(), digest = %entry.digest, "selected index entry");

--- a/crates/smolvm-registry/src/pull.rs
+++ b/crates/smolvm-registry/src/pull.rs
@@ -9,7 +9,9 @@
 
 use crate::cache::BlobCache;
 use crate::client::RegistryClient;
-use crate::{OciManifest, RegistryError, Result, LAYER_MEDIA_TYPE};
+use crate::{
+    OciIndex, OciManifest, OciPlatform, RegistryError, Result, INDEX_MEDIA_TYPE, LAYER_MEDIA_TYPE,
+};
 use futures_util::StreamExt;
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
@@ -40,9 +42,37 @@ pub async fn pull(
     output: Option<&Path>,
     cache: &BlobCache,
 ) -> Result<PullResult> {
-    // 1. Fetch manifest.
+    // 1. Fetch the manifest OR image index at the reference.
     tracing::info!(repo = %repo, reference = %reference, "fetching manifest...");
-    let manifest_bytes = client.get_manifest(repo, reference).await?;
+    let (doc_bytes, content_type) = client.get_manifest_raw(repo, reference).await?;
+
+    // If it's a multi-platform index, pick the entry for THIS machine's host
+    // platform and resolve to that single-platform manifest (Docker-style fan-out).
+    let manifest_bytes = if content_type.contains(INDEX_MEDIA_TYPE) || is_index(&doc_bytes) {
+        let index: OciIndex = serde_json::from_slice(&doc_bytes)?;
+        let want = OciPlatform::current();
+        let entry = index
+            .manifests
+            .iter()
+            .find(|m| m.platform.as_ref() == Some(&want))
+            .ok_or_else(|| {
+                let available: Vec<String> = index
+                    .manifests
+                    .iter()
+                    .filter_map(|m| m.platform.as_ref().map(|p| p.label()))
+                    .collect();
+                RegistryError::InvalidManifest(format!(
+                    "no {} build available for this machine; the registry has: {}",
+                    want.label(),
+                    if available.is_empty() { "(none)".into() } else { available.join(", ") }
+                ))
+            })?;
+        tracing::info!(platform = %want.label(), digest = %entry.digest, "selected index entry");
+        client.get_manifest_raw(repo, &entry.digest).await?.0
+    } else {
+        doc_bytes
+    };
+
     let manifest: OciManifest = serde_json::from_slice(&manifest_bytes)?;
 
     // 2. Find the smolmachine layer.
@@ -131,4 +161,17 @@ pub async fn pull(
         size: total_bytes,
         cached: false,
     })
+}
+
+/// Body-level fallback for detecting an image index when the registry didn't set
+/// a reliable `Content-Type` — an index has a `manifests` array (and/or the index
+/// `mediaType`), where a single manifest has `config`/`layers`.
+fn is_index(bytes: &[u8]) -> bool {
+    serde_json::from_slice::<serde_json::Value>(bytes)
+        .ok()
+        .map(|v| {
+            v.get("manifests").is_some()
+                || v.get("mediaType").and_then(|m| m.as_str()) == Some(INDEX_MEDIA_TYPE)
+        })
+        .unwrap_or(false)
 }

--- a/crates/smolvm-registry/src/push.rs
+++ b/crates/smolvm-registry/src/push.rs
@@ -118,8 +118,12 @@ pub async fn push(
     let platform = OciPlatform::parse(&manifest.host_platform);
     let platform_tag = format!("{reference}-{}-{}", platform.os, platform.architecture);
     tracing::info!(digest = %manifest_digest, platform = %platform.label(), "uploading manifest...");
-    client.put_manifest(repo, &manifest_digest, &manifest_json).await?;
-    client.put_manifest(repo, &platform_tag, &manifest_json).await?;
+    client
+        .put_manifest(repo, &manifest_digest, &manifest_json)
+        .await?;
+    client
+        .put_manifest(repo, &platform_tag, &manifest_json)
+        .await?;
 
     // 7. Maintain an image index at `reference` so the tag fans out by platform.
     //    Merge with any existing index (replacing this platform's entry); a
@@ -131,9 +135,11 @@ pub async fn push(
         platform: Some(platform.clone()),
     };
     let mut manifests = match client.get_manifest_raw(repo, reference).await {
-        Ok((bytes, ct)) if ct.contains(INDEX_MEDIA_TYPE) => serde_json::from_slice::<OciIndex>(&bytes)
-            .map(|i| i.manifests)
-            .unwrap_or_default(),
+        Ok((bytes, ct)) if ct.contains(INDEX_MEDIA_TYPE) => {
+            serde_json::from_slice::<OciIndex>(&bytes)
+                .map(|i| i.manifests)
+                .unwrap_or_default()
+        }
         _ => Vec::new(),
     };
     manifests.retain(|m| m.platform.as_ref() != Some(&platform));

--- a/crates/smolvm-registry/src/push.rs
+++ b/crates/smolvm-registry/src/push.rs
@@ -9,7 +9,8 @@
 
 use crate::client::RegistryClient;
 use crate::{
-    OciDescriptor, OciManifest, Result, CONFIG_MEDIA_TYPE, LAYER_MEDIA_TYPE, MANIFEST_MEDIA_TYPE,
+    OciDescriptor, OciIndex, OciIndexManifest, OciManifest, OciPlatform, Result, CONFIG_MEDIA_TYPE,
+    INDEX_MEDIA_TYPE, LAYER_MEDIA_TYPE, MANIFEST_MEDIA_TYPE,
 };
 use sha2::{Digest, Sha256};
 use std::path::Path;
@@ -24,6 +25,11 @@ pub struct PushResult {
     pub layer_size: u64,
     /// Digest of the OCI manifest.
     pub manifest_digest: String,
+    /// Host platform this artifact targets (e.g. `linux/amd64`).
+    pub platform: String,
+    /// The per-platform tag the manifest was also tagged under (e.g.
+    /// `latest-linux-amd64`).
+    pub platform_tag: String,
 }
 
 /// Push a `.smolmachine` sidecar to the registry.
@@ -103,21 +109,51 @@ pub async fn push(
     };
 
     let manifest_json = serde_json::to_vec_pretty(&oci_manifest)?;
+    let manifest_size = manifest_json.len() as u64;
     let manifest_digest = format!("sha256:{}", hex::encode(Sha256::digest(&manifest_json)));
 
-    // 6. PUT manifest.
-    tracing::info!(reference = %reference, "uploading manifest...");
-    client.put_manifest(repo, reference, &manifest_json).await?;
+    // 6. Store the single-platform manifest content-addressably (by digest), and
+    //    also tag it per platform (e.g. `latest-linux-amd64`) so a specific
+    //    platform is directly pullable.
+    let platform = OciPlatform::parse(&manifest.host_platform);
+    let platform_tag = format!("{reference}-{}-{}", platform.os, platform.architecture);
+    tracing::info!(digest = %manifest_digest, platform = %platform.label(), "uploading manifest...");
+    client.put_manifest(repo, &manifest_digest, &manifest_json).await?;
+    client.put_manifest(repo, &platform_tag, &manifest_json).await?;
 
-    tracing::info!(
-        digest = %manifest_digest,
-        layer_size,
-        "push complete"
-    );
+    // 7. Maintain an image index at `reference` so the tag fans out by platform.
+    //    Merge with any existing index (replacing this platform's entry); a
+    //    legacy single-manifest tag is replaced by a fresh index.
+    let entry = OciIndexManifest {
+        media_type: MANIFEST_MEDIA_TYPE.to_string(),
+        digest: manifest_digest.clone(),
+        size: manifest_size,
+        platform: Some(platform.clone()),
+    };
+    let mut manifests = match client.get_manifest_raw(repo, reference).await {
+        Ok((bytes, ct)) if ct.contains(INDEX_MEDIA_TYPE) => serde_json::from_slice::<OciIndex>(&bytes)
+            .map(|i| i.manifests)
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    };
+    manifests.retain(|m| m.platform.as_ref() != Some(&platform));
+    manifests.push(entry);
+    let index = OciIndex {
+        schema_version: 2,
+        media_type: INDEX_MEDIA_TYPE.to_string(),
+        manifests,
+    };
+    let index_json = serde_json::to_vec_pretty(&index)?;
+    tracing::info!(reference = %reference, platforms = index.manifests.len(), "updating image index...");
+    client.put_manifest(repo, reference, &index_json).await?;
+
+    tracing::info!(digest = %manifest_digest, layer_size, "push complete");
 
     Ok(PushResult {
         layer_digest,
         layer_size,
         manifest_digest,
+        platform: platform.label(),
+        platform_tag,
     })
 }


### PR DESCRIPTION
Single-platform `.smolmachine`s previously couldn't share a tag (smolvm rejected OCI indexes). This adds Docker-style multi-arch: push maintains an OCI image index at the tag (merging per-platform entries) + per-platform tags; pull selects the entry matching the running machine's host platform.

**Verified end-to-end with real artifacts**: `library/alpine:idx-test` pushed from a darwin/arm64 Mac AND a linux/amd64 box (over Tailscale) → one tag, 2-entry index, each machine pulls its own arch. Unit tests + 38 registry tests green.

Follow-ups: re-seed the public library multi-platform; surface platforms in `smol push`/the site gallery.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/351">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->