### PR TITLE
fix: reap orphaned smol-vmm on parent death + bound pack cache

### DIFF
--- a/crates/smolvm-pack/src/extract.rs
+++ b/crates/smolvm-pack/src/extract.rs
@@ -400,6 +400,109 @@ pub fn is_extracted(cache_dir: &Path) -> bool {
     cache_dir.join(EXTRACTION_MARKER).exists()
 }
 
+/// Maximum total size of the pack extraction cache before LRU eviction kicks in.
+/// Override with `SMOLVM_PACK_CACHE_MAX_BYTES` (in bytes); default 5 GiB.
+pub fn pack_cache_max_bytes() -> u64 {
+    const DEFAULT: u64 = 5 * 1024 * 1024 * 1024;
+    std::env::var("SMOLVM_PACK_CACHE_MAX_BYTES")
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(DEFAULT)
+}
+
+/// Real (sparse-aware) disk usage of a single file. Extraction dirs contain
+/// large *sparse* overlay disks (e.g. a 10 GiB disk holding ~50 MB), so we must
+/// count allocated blocks, not the apparent length — otherwise the cap would
+/// over-count by orders of magnitude and evict far too aggressively.
+#[cfg(unix)]
+fn file_disk_usage(meta: &fs::Metadata) -> u64 {
+    use std::os::unix::fs::MetadataExt;
+    meta.blocks().saturating_mul(512)
+}
+#[cfg(not(unix))]
+fn file_disk_usage(meta: &fs::Metadata) -> u64 {
+    meta.len()
+}
+
+/// Recursive real disk usage of a directory tree (best-effort; unreadable
+/// entries count as zero). Does not follow symlinks.
+fn dir_disk_usage(path: &Path) -> u64 {
+    let mut total = 0u64;
+    let entries = match fs::read_dir(path) {
+        Ok(e) => e,
+        Err(_) => return 0,
+    };
+    for entry in entries.flatten() {
+        let meta = match entry.metadata() {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if meta.is_dir() {
+            total = total.saturating_add(dir_disk_usage(&entry.path()));
+        } else if meta.is_file() {
+            total = total.saturating_add(file_disk_usage(&meta));
+        }
+    }
+    total
+}
+
+/// Evict least-recently-modified extraction directories under `cache_root` until
+/// the cache's total real disk usage is at or below `max_bytes`. Skips
+/// directories with active leases (a running pack/VM) — they are never evicted,
+/// even if that leaves the cache over the cap. Best-effort: per-entry errors are
+/// skipped. Returns the number of bytes freed.
+///
+/// This is what bounds the otherwise-unbounded extraction cache; it runs
+/// automatically after a new (cache-miss) extraction, and keeps the newest
+/// entries (including the one just written) by evicting oldest-first.
+pub fn evict_cache_to_size(cache_root: &Path, max_bytes: u64) -> u64 {
+    let mut entries: Vec<(PathBuf, std::time::SystemTime, u64)> = Vec::new();
+    let read_dir = match fs::read_dir(cache_root) {
+        Ok(rd) => rd,
+        Err(_) => return 0,
+    };
+    for entry in read_dir.flatten() {
+        let path = entry.path();
+        let meta = match fs::metadata(&path) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if !meta.is_dir() {
+            continue; // skip *.lock files and other non-extraction entries
+        }
+        let modified = meta.modified().unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+        entries.push((path, modified, dir_disk_usage(&entry.path())));
+    }
+
+    let total: u64 = entries.iter().map(|(_, _, s)| *s).sum();
+    if total <= max_bytes {
+        return 0;
+    }
+
+    // Oldest first — evict least-recently-used.
+    entries.sort_by_key(|(_, modified, _)| *modified);
+
+    let mut over = total - max_bytes;
+    let mut freed = 0u64;
+    for (path, _, size) in entries {
+        if over == 0 {
+            break;
+        }
+        if has_active_leases(&path) {
+            continue; // never evict a running pack/VM
+        }
+        force_detach_layers_volume(&path);
+        if fs::remove_dir_all(&path).is_ok() {
+            // Also drop the adjacent <checksum>.lock file, if any.
+            let _ = fs::remove_file(path.with_extension("lock"));
+            freed = freed.saturating_add(size);
+            over = over.saturating_sub(size);
+        }
+    }
+    freed
+}
+
 /// Check if footer indicates sidecar mode.
 fn is_sidecar_mode(footer: &PackFooter) -> bool {
     footer.assets_offset == 0
@@ -485,6 +588,19 @@ pub fn extract_sidecar(
     // directory so the next attempt starts fresh.
     if result.is_err() && cache_dir.exists() && !is_extracted(cache_dir) {
         let _ = fs::remove_dir_all(cache_dir);
+    }
+
+    // After a successful new extraction (cache miss — the early-return above
+    // handles cache hits), cap the cache so old, unused extractions don't grow
+    // without bound. LRU + lease-aware: keeps the newest (incl. what we just
+    // wrote) and never evicts a running pack.
+    if result.is_ok() {
+        if let Some(root) = cache_dir.parent() {
+            let freed = evict_cache_to_size(root, pack_cache_max_bytes());
+            if freed > 0 && debug {
+                eprintln!("debug: pack cache evicted {freed} bytes to stay under cap");
+            }
+        }
     }
 
     result
@@ -2243,5 +2359,61 @@ mod tests {
         );
         assert_eq!(fs::read_to_string(dest.join("after.txt")).unwrap(), "after");
         assert!(!dest.join("unknown-type-entry").exists());
+    }
+
+    #[test]
+    fn test_evict_cache_to_size_lru() {
+        use std::ffi::CString;
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let mk = |name: &str, mtime_secs: i64| {
+            let d = root.join(name);
+            fs::create_dir_all(&d).unwrap();
+            fs::write(d.join("data"), vec![0u8; 1024 * 1024]).unwrap(); // ~1 MiB real
+            let c = CString::new(d.to_string_lossy().as_bytes()).unwrap();
+            let tv = libc::timeval {
+                tv_sec: mtime_secs,
+                tv_usec: 0,
+            };
+            let times = [tv, tv];
+            unsafe {
+                libc::utimes(c.as_ptr(), times.as_ptr());
+            }
+            d
+        };
+        let old = mk("aaaa", 1_000_000);
+        let mid = mk("bbbb", 2_000_000);
+        let new = mk("cccc", 3_000_000);
+
+        // Total (~3 MiB) is under the cap → nothing evicted.
+        assert_eq!(evict_cache_to_size(root, 100 * 1024 * 1024), 0);
+        assert!(old.exists() && mid.exists() && new.exists());
+
+        // Cap (~2.5 MiB) forces evicting the single oldest entry, LRU-first.
+        let freed = evict_cache_to_size(root, 5 * 1024 * 1024 / 2);
+        assert!(freed > 0, "expected some bytes freed");
+        assert!(!old.exists(), "oldest extraction should be evicted");
+        assert!(mid.exists() && new.exists(), "newer extractions kept");
+    }
+
+    // Lease tracking is a macOS case-sensitive-volume concept; on Linux
+    // `has_active_leases` is always false (layers live at cache_dir/layers).
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_evict_cache_skips_active_lease() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let d = root.join("aaaa");
+        fs::create_dir_all(&d).unwrap();
+        fs::write(d.join("data"), vec![0u8; 2 * 1024 * 1024]).unwrap();
+        // Simulate a running pack: a live daemon lease file (current PID).
+        let leases = d.join(LEASES_DIR);
+        fs::create_dir_all(&leases).unwrap();
+        fs::write(leases.join("daemon"), format!("{}", std::process::id())).unwrap();
+        assert!(has_active_leases(&d), "live lease should be detected");
+        // Cap of 0 would evict everything — but the active lease must be spared.
+        let freed = evict_cache_to_size(root, 0);
+        assert_eq!(freed, 0, "leased extraction must not be evicted");
+        assert!(d.exists());
     }
 }

--- a/examples/orphan_test.rs
+++ b/examples/orphan_test.rs
@@ -1,0 +1,42 @@
+//! Manual verification harness for the parent-death watchdog (orphaned-VMM leak).
+//!
+//! Mimics an SDK embedder: it owns a VM in-process (sets SMOLVM_BOOT_BINARY,
+//! never detaches), prints its pid, then blocks forever. The driver script
+//! `kill -9`s this process to simulate a host crash and asserts the `_boot-vm`
+//! VMM exits instead of orphaning. Run via `cargo run --example orphan_test`.
+use smolvm::embedded::{EmbeddedRuntime, MachineSpec};
+use smolvm::VmResources;
+
+fn main() {
+    let name = std::env::var("ORPHAN_TEST_VM").unwrap_or_else(|_| "orphan-test".into());
+    let rt = EmbeddedRuntime::new().expect("create embedded runtime");
+
+    let spec = MachineSpec {
+        name: name.clone(),
+        mounts: vec![],
+        ports: vec![],
+        resources: VmResources {
+            cpus: 1,
+            memory_mib: 512,
+            network: true,
+            ..Default::default()
+        },
+        persistent: false,
+    };
+    let _ = rt.create_machine(spec); // ignore "already exists" on reruns
+    rt.start_machine(&name).expect("start machine");
+
+    let pid = rt.pid(&name).unwrap_or(-1);
+    // Sentinel the driver greps for: embedder pid + the VMM child pid.
+    println!(
+        "ORPHAN_TEST_READY embedder={} vmm={}",
+        std::process::id(),
+        pid
+    );
+    use std::io::Write;
+    let _ = std::io::stdout().flush();
+
+    loop {
+        std::thread::sleep(std::time::Duration::from_secs(3600));
+    }
+}

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -1276,11 +1276,24 @@ impl AgentManager {
         let spawn_start = Instant::now();
         // Embedders (e.g. the Node SDK, where current_exe is `node`) can point the
         // boot subprocess at a `_boot-vm`-capable, signed helper binary instead of self.
-        let boot_exe = std::env::var_os("SMOLVM_BOOT_BINARY")
+        let boot_binary = std::env::var_os("SMOLVM_BOOT_BINARY");
+        // An in-process embedder (the Node/Python SDK) sets SMOLVM_BOOT_BINARY and
+        // owns the VM's lifetime — when that host process dies, the VM must die
+        // too, or it leaks as an orphan holding the VM's full RAM. The CLI (which
+        // detaches the VM on purpose) and `serve` (which reconnects to surviving
+        // VMs) don't set it, so they keep today's behavior. We pass the resulting
+        // flag down so the boot subprocess only arms its parent-death watchdog in
+        // the embedder case. See `cli/internal_boot::run`.
+        let watch_parent = boot_binary.is_some();
+        let boot_exe = boot_binary
             .map(std::path::PathBuf::from)
             .unwrap_or_else(|| exe.clone());
         let child = std::process::Command::new(&boot_exe)
             .args(["_boot-vm", &config_path.to_string_lossy()])
+            .env(
+                "SMOLVM_BOOT_WATCH_PARENT",
+                if watch_parent { "1" } else { "0" },
+            )
             .stdin(std::process::Stdio::null())
             // SMOLVM_BOOT_DEBUG=1 surfaces the boot subprocess's stdout/stderr so
             // embedded-host launch failures can be diagnosed (normally silenced).

--- a/src/cli/internal_boot.rs
+++ b/src/cli/internal_boot.rs
@@ -31,6 +31,40 @@ fn open_boot_disk<K: DiskType>(path: &Path, size_gb: u64) -> smolvm::Result<VmDi
 pub fn run(config_path: PathBuf) -> smolvm::Result<()> {
     let t_proc = std::time::Instant::now();
 
+    // --- Parent-death watchdog ---------------------------------------------
+    // This VMM (`smol-vmm _boot-vm`) is always spawned by an embedding parent:
+    // the API server, a fleet node, or — for the SDKs — the Node/Python
+    // in-process runtime. If that parent dies *abnormally* (panic, uncaught
+    // exception, `process.exit`/`os._exit`, crash, or SIGKILL) it never runs
+    // teardown, so without this watchdog the VMM would be reparented to init and
+    // keep running forever, holding the VM's full RAM — an orphaned-process leak.
+    //
+    // Detection is by reparenting: when the real parent dies the kernel reparents
+    // this process (to init/launchd, or a subreaper), so `getppid()` changes from
+    // the value captured here at startup. The watcher polls for that change and
+    // exits; the OS then tears the VM down with us. Polling (rather than an
+    // inherited-pipe EOF) needs no fd plumbing, survives the
+    // `close_inherited_fds_from(3)` call below, and uses only syscalls already in
+    // the seccomp allowlist (`getppid`, `nanosleep`). Catches every death mode,
+    // including SIGKILL, which no parent-side exit handler can. Started first so
+    // it also covers a parent dying mid-boot.
+    //
+    // Armed only when an in-process embedder (the SDK) owns the VM's lifetime —
+    // the manager signals this via SMOLVM_BOOT_WATCH_PARENT=1. The CLI detaches
+    // its VM on purpose and `serve` reconnects to surviving VMs, so for those the
+    // parent exiting is normal and the watchdog stays off.
+    if std::env::var_os("SMOLVM_BOOT_WATCH_PARENT").as_deref() == Some(std::ffi::OsStr::new("1")) {
+        let original_ppid = unsafe { libc::getppid() };
+        let _ = std::thread::Builder::new()
+            .name("parent-death-watch".into())
+            .spawn(move || loop {
+                std::thread::sleep(std::time::Duration::from_millis(500));
+                if unsafe { libc::getppid() } != original_ppid {
+                    smolvm::process::exit_child(0);
+                }
+            });
+    }
+
     // Read boot config
     let config_data = std::fs::read(&config_path)
         .map_err(|e| smolvm::Error::agent("read boot config", e.to_string()))?;


### PR DESCRIPTION
Engine half of the smolmachines 0.1.3 release — the SDK CI rebuilds `smol-vmm` from `main`, so this must land before tagging v0.1.3. Adds a parent-death watchdog so the VMM is reaped when its embedder dies (any exit mode incl. SIGKILL), armed only for embedder-owned VMs (`SMOLVM_BOOT_BINARY`). Also bounds the pack extraction cache with LRU, lease-/sparse-aware size-cap eviction. Verified: e2e orphan reap, detached-CLI regression, and `cargo check`/pack tests green on `main`.