### PR TITLE
fix(agent): reject non-regular files in read_file (dir poison + dev hang)

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -2626,7 +2626,35 @@ fn handle_streaming_file_read(
             return Ok(());
         }
     };
-    let size = file.metadata().ok().map(|m| m.len()).unwrap_or(0);
+    // Only stream regular files. Directories and special files (e.g. /dev/zero,
+    // FIFOs) `open()` successfully but misbehave on read — a directory fails with
+    // EISDIR *after* the chunk stream has started (desyncing the wire and bricking
+    // the connection), and an unbounded device never EOFs (hangs the caller). We
+    // must reject them with a clean error BEFORE the first DataChunk frame.
+    let metadata = match file.metadata() {
+        Ok(m) => m,
+        Err(e) => {
+            send_response(
+                stream,
+                &AgentResponse::error(
+                    format!("failed to stat {}: {}", path, e),
+                    error_codes::FILE_IO_FAILED,
+                ),
+            )?;
+            return Ok(());
+        }
+    };
+    if !metadata.is_file() {
+        send_response(
+            stream,
+            &AgentResponse::error(
+                format!("not a regular file: {}", path),
+                error_codes::FILE_IO_FAILED,
+            ),
+        )?;
+        return Ok(());
+    }
+    let size = metadata.len();
     info!(path = %path, size, "streaming file read");
     send_data_chunks(
         stream,

--- a/examples/readfile_fix_test.rs
+++ b/examples/readfile_fix_test.rs
@@ -1,0 +1,71 @@
+//! Verifies the read_file non-regular-file fix: reading a directory or an
+//! unbounded special file must return a CLEAN error and NOT poison the agent
+//! connection (previously a dir read bricked the machine; /dev/zero hung).
+use smolvm::embedded::{EmbeddedRuntime, MachineSpec};
+use smolvm::VmResources;
+use std::time::Duration;
+
+fn main() {
+    let rt = EmbeddedRuntime::new().expect("runtime");
+    let name = "readfile-fix-test";
+    let _ = rt.create_machine(MachineSpec {
+        name: name.into(),
+        mounts: vec![],
+        ports: vec![],
+        resources: VmResources {
+            cpus: 1,
+            memory_mib: 512,
+            network: false,
+            ..Default::default()
+        },
+        persistent: false,
+    });
+    rt.start_machine(name).expect("start");
+
+    let echo = |label: &str| match rt.exec(
+        name,
+        vec!["echo".into(), label.into()],
+        vec![],
+        None,
+        Some(Duration::from_secs(10)),
+    ) {
+        Ok((code, out, _)) => println!(
+            "  {label}: HEALTHY exit={code} out={:?}",
+            String::from_utf8_lossy(&out).trim()
+        ),
+        Err(e) => println!("  {label}: POISONED → {e}"),
+    };
+
+    echo("before");
+    match rt.read_file(name, "/tmp") {
+        Ok(b) => println!("readFile(/tmp dir): UNEXPECTED ok ({} bytes)", b.len()),
+        Err(e) => println!("readFile(/tmp dir): clean error → {e}"),
+    }
+    echo("after-dir");
+    match rt.read_file(name, "/dev/zero") {
+        Ok(b) => println!("readFile(/dev/zero): UNEXPECTED ok ({} bytes)", b.len()),
+        Err(e) => println!("readFile(/dev/zero): clean error → {e}"),
+    }
+    echo("after-devzero");
+    // sanity: a real file still reads
+    let _ = rt.exec(
+        name,
+        vec![
+            "sh".into(),
+            "-c".into(),
+            "echo content > /tmp/real.txt".into(),
+        ],
+        vec![],
+        None,
+        None,
+    );
+    match rt.read_file(name, "/tmp/real.txt") {
+        Ok(b) => println!(
+            "readFile(/tmp/real.txt): ok → {:?}",
+            String::from_utf8_lossy(&b).trim()
+        ),
+        Err(e) => println!("readFile(/tmp/real.txt): UNEXPECTED error → {e}"),
+    }
+
+    rt.delete_machine(name).expect("delete");
+}

--- a/examples/reattach_test.rs
+++ b/examples/reattach_test.rs
@@ -1,0 +1,64 @@
+//! Verifies start-or-reconnect for a stopped persistent machine — the path the
+//! SDK's local `Machine.connect()` now uses (native connect → start_machine).
+use smolvm::embedded::{EmbeddedRuntime, MachineSpec};
+use smolvm::VmResources;
+
+fn main() {
+    let rt = EmbeddedRuntime::new().expect("runtime");
+    let name = "reattach-test";
+    let _ = rt.delete_machine(name); // clean slate
+
+    rt.create_machine(MachineSpec {
+        name: name.into(),
+        mounts: vec![],
+        ports: vec![],
+        resources: VmResources {
+            cpus: 1,
+            memory_mib: 512,
+            network: false,
+            ..Default::default()
+        },
+        persistent: true,
+    })
+    .expect("create");
+    rt.start_machine(name).expect("start");
+    rt.exec(
+        name,
+        vec![
+            "sh".into(),
+            "-c".into(),
+            "echo survived-restart > /root/persist.txt".into(),
+        ],
+        vec![],
+        None,
+        None,
+    )
+    .expect("write");
+    println!("wrote /root/persist.txt; stopping machine...");
+    rt.stop_machine(name).expect("stop");
+
+    println!("reattaching to stopped persistent machine via start_machine() ...");
+    rt.start_machine(name)
+        .expect("reattach (start-or-reconnect)");
+    let (code, out, _) = rt
+        .exec(
+            name,
+            vec!["cat".into(), "/root/persist.txt".into()],
+            vec![],
+            None,
+            None,
+        )
+        .expect("read after reattach");
+    let content = String::from_utf8_lossy(&out);
+    println!("readback: exit={code} content={:?}", content.trim());
+    println!(
+        "{}",
+        if content.trim() == "survived-restart" {
+            "RESULT: PASS — reattached + data persisted"
+        } else {
+            "RESULT: FAIL"
+        }
+    );
+
+    rt.delete_machine(name).expect("delete");
+}


### PR DESCRIPTION
0.1.3 SDK found that `readFile` on a **directory** poisons the agent connection (every later op → "connection closed", machine bricked) and on `/dev/zero` hangs forever. Root cause: the agent `open()`d any path then streamed; a dir fails `EISDIR` *after* the chunk stream starts (desyncing the wire), and unbounded devices never EOF. Fix: check `metadata.is_file()` before streaming and return a clean error (regular files unaffected). Verified e2e: dir + /dev/zero now error cleanly and the machine stays healthy; regular files still read. 

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/354">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->