### PR TITLE
fix: pack inspect resolves image indexes like pull

### DIFF
--- a/crates/smolvm-registry/src/client.rs
+++ b/crates/smolvm-registry/src/client.rs
@@ -7,7 +7,7 @@
 //! - Blob download (GET)
 //! - Manifest put/get (PUT/GET)
 
-use crate::{RegistryError, Result, INDEX_MEDIA_TYPE, MANIFEST_MEDIA_TYPE};
+use crate::{OciIndex, OciPlatform, RegistryError, Result, INDEX_MEDIA_TYPE, MANIFEST_MEDIA_TYPE};
 use reqwest::header::{ACCEPT, CONTENT_LENGTH, CONTENT_TYPE, LOCATION, WWW_AUTHENTICATE};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
@@ -458,6 +458,51 @@ impl RegistryClient {
             .unwrap_or("")
             .to_string();
         Ok((resp.bytes().await?.to_vec(), content_type))
+    }
+
+    /// Fetch the manifest at `reference`, resolving an OCI image index to THIS
+    /// machine's host-platform entry (Docker-style fan-out), and return the
+    /// single-platform manifest bytes. Shared by `pull` and `inspect` so both
+    /// resolve a multi-arch tag identically (a plain manifest passes through).
+    pub async fn get_manifest_resolved(&self, repo: &str, reference: &str) -> Result<Vec<u8>> {
+        let (doc_bytes, content_type) = self.get_manifest_raw(repo, reference).await?;
+
+        let is_index = content_type.contains(INDEX_MEDIA_TYPE)
+            || serde_json::from_slice::<serde_json::Value>(&doc_bytes)
+                .ok()
+                .map(|v| {
+                    v.get("manifests").is_some()
+                        || v.get("mediaType").and_then(|m| m.as_str()) == Some(INDEX_MEDIA_TYPE)
+                })
+                .unwrap_or(false);
+        if !is_index {
+            return Ok(doc_bytes);
+        }
+
+        let index: OciIndex = serde_json::from_slice(&doc_bytes)?;
+        let want = OciPlatform::current();
+        let entry = index
+            .manifests
+            .iter()
+            .find(|m| m.platform.as_ref() == Some(&want))
+            .ok_or_else(|| {
+                let available: Vec<String> = index
+                    .manifests
+                    .iter()
+                    .filter_map(|m| m.platform.as_ref().map(|p| p.label()))
+                    .collect();
+                RegistryError::InvalidManifest(format!(
+                    "no {} build available for this machine; the registry has: {}",
+                    want.label(),
+                    if available.is_empty() {
+                        "(none)".into()
+                    } else {
+                        available.join(", ")
+                    }
+                ))
+            })?;
+        tracing::info!(platform = %want.label(), digest = %entry.digest, "selected index entry");
+        Ok(self.get_manifest_raw(repo, &entry.digest).await?.0)
     }
 
     /// Resolve a Location header value against the registry base URL.

--- a/crates/smolvm-registry/src/pull.rs
+++ b/crates/smolvm-registry/src/pull.rs
@@ -9,9 +9,7 @@
 
 use crate::cache::BlobCache;
 use crate::client::RegistryClient;
-use crate::{
-    OciIndex, OciManifest, OciPlatform, RegistryError, Result, INDEX_MEDIA_TYPE, LAYER_MEDIA_TYPE,
-};
+use crate::{OciManifest, RegistryError, Result, LAYER_MEDIA_TYPE};
 use futures_util::StreamExt;
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
@@ -42,40 +40,10 @@ pub async fn pull(
     output: Option<&Path>,
     cache: &BlobCache,
 ) -> Result<PullResult> {
-    // 1. Fetch the manifest OR image index at the reference.
+    // 1. Fetch the manifest, resolving a multi-platform index to this machine's
+    //    host-platform entry (Docker-style fan-out). Shared with `inspect`.
     tracing::info!(repo = %repo, reference = %reference, "fetching manifest...");
-    let (doc_bytes, content_type) = client.get_manifest_raw(repo, reference).await?;
-
-    // If it's a multi-platform index, pick the entry for THIS machine's host
-    // platform and resolve to that single-platform manifest (Docker-style fan-out).
-    let manifest_bytes = if content_type.contains(INDEX_MEDIA_TYPE) || is_index(&doc_bytes) {
-        let index: OciIndex = serde_json::from_slice(&doc_bytes)?;
-        let want = OciPlatform::current();
-        let entry = index
-            .manifests
-            .iter()
-            .find(|m| m.platform.as_ref() == Some(&want))
-            .ok_or_else(|| {
-                let available: Vec<String> = index
-                    .manifests
-                    .iter()
-                    .filter_map(|m| m.platform.as_ref().map(|p| p.label()))
-                    .collect();
-                RegistryError::InvalidManifest(format!(
-                    "no {} build available for this machine; the registry has: {}",
-                    want.label(),
-                    if available.is_empty() {
-                        "(none)".into()
-                    } else {
-                        available.join(", ")
-                    }
-                ))
-            })?;
-        tracing::info!(platform = %want.label(), digest = %entry.digest, "selected index entry");
-        client.get_manifest_raw(repo, &entry.digest).await?.0
-    } else {
-        doc_bytes
-    };
+    let manifest_bytes = client.get_manifest_resolved(repo, reference).await?;
 
     let manifest: OciManifest = serde_json::from_slice(&manifest_bytes)?;
 
@@ -165,17 +133,4 @@ pub async fn pull(
         size: total_bytes,
         cached: false,
     })
-}
-
-/// Body-level fallback for detecting an image index when the registry didn't set
-/// a reliable `Content-Type` — an index has a `manifests` array (and/or the index
-/// `mediaType`), where a single manifest has `config`/`layers`.
-fn is_index(bytes: &[u8]) -> bool {
-    serde_json::from_slice::<serde_json::Value>(bytes)
-        .ok()
-        .map(|v| {
-            v.get("manifests").is_some()
-                || v.get("mediaType").and_then(|m| m.as_str()) == Some(INDEX_MEDIA_TYPE)
-        })
-        .unwrap_or(false)
 }

--- a/src/cli/pack.rs
+++ b/src/cli/pack.rs
@@ -1477,9 +1477,11 @@ async fn run_inspect(
     tag_or_digest: &str,
     json_output: bool,
 ) -> smolvm::Result<()> {
-    // Fetch OCI manifest (~200 bytes).
+    // Fetch the OCI manifest (~200 bytes), resolving a multi-platform index to
+    // this machine's host-platform entry — same as `pull`, so inspect agrees with
+    // what pull would actually download instead of rejecting multi-arch tags.
     let manifest_bytes = client
-        .get_manifest(repo, tag_or_digest)
+        .get_manifest_resolved(repo, tag_or_digest)
         .await
         .map_err(|e| Error::agent("fetch manifest", e.to_string()))?;
 


### PR DESCRIPTION
## What
`pack inspect` used `get_manifest` (which rejects OCI image indexes), so inspecting a multi-arch tag errored *"OCI image indexes are not supported"* even though `pack pull` resolved it fine. Now both share one resolver.

- Extracted the index→host-platform resolution into **`RegistryClient::get_manifest_resolved`** (a plain manifest passes through; an index resolves to this machine's host-platform entry, Docker-style).
- `pull` and `inspect` both call it — they agree by construction, no duplicated logic.

## Verified
- `cargo test -p smolvm-registry` → 38 pass; fmt clean; builds.
- `smolvm pack inspect registry.smolmachines.com/library/alpine:latest` (a real 2-platform index) now resolves to the host entry and prints metadata, instead of erroring.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/355">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->