### PR TITLE
fix: exec edge cases — idempotent delete + clear error on large output

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -4313,6 +4313,27 @@ fn handle_run_background(
     }
 }
 
+/// Non-streaming exec/run returns the whole output in a single wire frame. If it
+/// would exceed the frame budget, return a clear error instead of attempting an
+/// oversized frame — which otherwise fails mid-send and surfaces to the caller as
+/// a confusing connection drop / SIGPIPE-truncated result. Large output should
+/// use streaming exec (`exec_stream`/`execStream`). The budget leaves headroom
+/// under MAX_FRAME_SIZE for base64 of the byte fields (~4/3) plus the JSON envelope.
+fn oversized_output_error(stdout: &[u8], stderr: &[u8]) -> Option<AgentResponse> {
+    const BUDGET: usize = 20 * 1024 * 1024; // ~20 MiB raw → ~27 MiB base64, under the 32 MiB frame
+    let total = stdout.len() + stderr.len();
+    if total > BUDGET {
+        return Some(AgentResponse::error(
+            format!(
+                "command output too large ({total} bytes; limit {BUDGET}). \
+                 Use streaming exec (exec_stream / execStream) for large output."
+            ),
+            error_codes::EXEC_FAILED,
+        ));
+    }
+    None
+}
+
 fn handle_run(
     image: &str,
     command: &[String],
@@ -4337,11 +4358,13 @@ fn handle_run(
         persistent_overlay_id,
         client_fd,
     ) {
-        Ok(result) => AgentResponse::Completed {
-            exit_code: result.exit_code,
-            stdout: result.stdout,
-            stderr: result.stderr,
-        },
+        Ok(result) => oversized_output_error(&result.stdout, &result.stderr).unwrap_or(
+            AgentResponse::Completed {
+                exit_code: result.exit_code,
+                stdout: result.stdout,
+                stderr: result.stderr,
+            },
+        ),
         Err(e) => AgentResponse::from_err(e, error_codes::RUN_FAILED),
     }
 }
@@ -4718,8 +4741,11 @@ fn handle_vm_exec(
         std::thread::Builder::new()
             .name("exec-stdout".into())
             .spawn(move || {
+                // Read ONE byte past the cap so the handler can tell "exactly at
+                // cap" from "overflowed" and return a clear error instead of a
+                // silently truncated result (+ a SIGPIPE exit on the child).
                 let mut buf = Vec::new();
-                let _ = out.take(MAX_OUTPUT as u64).read_to_end(&mut buf);
+                let _ = out.take(MAX_OUTPUT as u64 + 1).read_to_end(&mut buf);
                 buf
             })
     });
@@ -4729,7 +4755,7 @@ fn handle_vm_exec(
             .name("exec-stderr".into())
             .spawn(move || {
                 let mut buf = Vec::new();
-                let _ = err.take(MAX_OUTPUT as u64).read_to_end(&mut buf);
+                let _ = err.take(MAX_OUTPUT as u64 + 1).read_to_end(&mut buf);
                 buf
             })
     });
@@ -4827,6 +4853,18 @@ fn handle_vm_exec(
         }
     }
 
+    // If either stream exceeded the cap (we read one byte past it), the output
+    // was truncated and the child likely took a SIGPIPE — return a clear error
+    // instead of a silently-truncated success. Large output should stream.
+    if stdout.len() > MAX_OUTPUT || stderr.len() > MAX_OUTPUT {
+        return AgentResponse::error(
+            format!(
+                "command output exceeded {MAX_OUTPUT} bytes and was truncated. \
+                 Use streaming exec (exec_stream / execStream) for large output."
+            ),
+            error_codes::EXEC_FAILED,
+        );
+    }
     AgentResponse::Completed {
         exit_code,
         stdout,

--- a/examples/doubledelete_test.rs
+++ b/examples/doubledelete_test.rs
@@ -1,0 +1,27 @@
+//! Verifies delete_machine is idempotent (double-delete no longer errors).
+use smolvm::embedded::{EmbeddedRuntime, MachineSpec};
+use smolvm::VmResources;
+
+fn main() {
+    let rt = EmbeddedRuntime::new().expect("runtime");
+    let name = "doubledelete-test";
+    let _ = rt.delete_machine(name); // clean slate
+    rt.create_machine(MachineSpec {
+        name: name.into(),
+        mounts: vec![],
+        ports: vec![],
+        resources: VmResources {
+            cpus: 1,
+            memory_mib: 512,
+            network: false,
+            ..Default::default()
+        },
+        persistent: false,
+    })
+    .expect("create");
+    rt.delete_machine(name).expect("first delete");
+    match rt.delete_machine(name) {
+        Ok(()) => println!("PASS: second delete is idempotent (no error)"),
+        Err(e) => println!("FAIL: second delete errored: {e}"),
+    }
+}

--- a/examples/largeoutput_test.rs
+++ b/examples/largeoutput_test.rs
@@ -1,0 +1,67 @@
+//! Verifies the large-output guard: a huge non-streaming exec returns a CLEAR
+//! error (not a SIGPIPE-truncated result) and leaves the machine HEALTHY.
+use smolvm::embedded::{EmbeddedRuntime, MachineSpec};
+use smolvm::VmResources;
+
+fn main() {
+    let rt = EmbeddedRuntime::new().expect("runtime");
+    let name = "largeoutput-test";
+    let _ = rt.delete_machine(name);
+    let _ = rt.create_machine(MachineSpec {
+        name: name.into(),
+        mounts: vec![],
+        ports: vec![],
+        resources: VmResources {
+            cpus: 1,
+            memory_mib: 1024,
+            network: false,
+            ..Default::default()
+        },
+        persistent: false,
+    });
+    rt.start_machine(name).expect("start");
+    // small output: works
+    let (c, out, _) = rt
+        .exec(
+            name,
+            vec!["echo".into(), "small".into()],
+            vec![],
+            None,
+            None,
+        )
+        .unwrap();
+    println!(
+        "small exec: exit={c} out={:?}",
+        String::from_utf8_lossy(&out).trim()
+    );
+    // ~40 MiB output: expect a clean error, not a truncated/SIGPIPE result
+    match rt.exec(
+        name,
+        vec![
+            "sh".into(),
+            "-c".into(),
+            "head -c 41943040 /dev/zero | tr '\\0' a".into(),
+        ],
+        vec![],
+        None,
+        None,
+    ) {
+        Ok((c, out, _)) => println!("BIG exec: UNEXPECTED ok exit={c} len={}", out.len()),
+        Err(e) => println!("BIG exec: clean error -> {e}"),
+    }
+    // machine still healthy?
+    match rt.exec(
+        name,
+        vec!["echo".into(), "after".into()],
+        vec![],
+        None,
+        None,
+    ) {
+        Ok((_, out, _)) => println!(
+            "after BIG: HEALTHY out={:?}",
+            String::from_utf8_lossy(&out).trim()
+        ),
+        Err(e) => println!("after BIG: POISONED -> {e}"),
+    }
+    rt.delete_machine(name).expect("delete");
+}

--- a/src/embedded/runtime.rs
+++ b/src/embedded/runtime.rs
@@ -96,7 +96,13 @@ impl EmbeddedRuntime {
                 let _ = control::stop_vm(&self.db, name);
             }
 
-            control::delete_vm(&self.db, name)?;
+            // Idempotent: deleting an already-deleted machine is a no-op success
+            // (the desired end state — gone — already holds). Lets SDK callers
+            // call delete() more than once without an error.
+            match control::delete_vm(&self.db, name) {
+                Ok(()) | Err(crate::Error::VmNotFound { .. }) => {}
+                Err(e) => return Err(e),
+            }
             self.remove_name_lock(name)?;
             Ok(())
         })


### PR DESCRIPTION
Two minor QA-found sharp edges:
- `delete_machine` is now idempotent — a second delete() is a no-op success instead of "vm not found" (SDK callers can delete more than once).
- bare `exec` with output over the 11 MiB cap now returns a CLEAR error ("output exceeded … use streaming exec") instead of a silently-truncated result + SIGPIPE exit; the machine stays healthy. The reader reads one byte past the cap to detect overflow. Large output should use exec_stream.

Verified e2e (double-delete no-ops; 40 MiB exec → clean error, machine healthy). For a 0.1.5.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/357">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->