### PR TITLE
fix(registry): resolve multi-arch pull by guest arch, not host platform

### DIFF
--- a/crates/smolvm-registry/src/client.rs
+++ b/crates/smolvm-registry/src/client.rs
@@ -480,11 +480,27 @@ impl RegistryClient {
         }
 
         let index: OciIndex = serde_json::from_slice(&doc_bytes)?;
-        let want = OciPlatform::current();
+        // .smolmachine sidecars are cross-platform — libkrun is provided by the
+        // installed CLI, not bundled — so only the GUEST architecture matters, and
+        // the guest is always linux. Select by architecture: prefer an os=linux
+        // entry, but fall back to architecture alone so an index whose `os` was
+        // mislabeled with the build host (e.g. darwin/arm64 for an arm64 pack) still
+        // resolves. The host OS is irrelevant to which sidecar to pull.
+        let arch = OciPlatform::current().architecture;
         let entry = index
             .manifests
             .iter()
-            .find(|m| m.platform.as_ref() == Some(&want))
+            .find(|m| {
+                m.platform
+                    .as_ref()
+                    .is_some_and(|p| p.os == "linux" && p.architecture == arch)
+            })
+            .or_else(|| {
+                index
+                    .manifests
+                    .iter()
+                    .find(|m| m.platform.as_ref().is_some_and(|p| p.architecture == arch))
+            })
             .ok_or_else(|| {
                 let available: Vec<String> = index
                     .manifests
@@ -492,8 +508,7 @@ impl RegistryClient {
                     .filter_map(|m| m.platform.as_ref().map(|p| p.label()))
                     .collect();
                 RegistryError::InvalidManifest(format!(
-                    "no {} build available for this machine; the registry has: {}",
-                    want.label(),
+                    "no linux/{arch} build available for this machine; the registry has: {}",
                     if available.is_empty() {
                         "(none)".into()
                     } else {
@@ -501,7 +516,7 @@ impl RegistryClient {
                     }
                 ))
             })?;
-        tracing::info!(platform = %want.label(), digest = %entry.digest, "selected index entry");
+        tracing::info!(arch = %arch, digest = %entry.digest, "selected index entry");
         Ok(self.get_manifest_raw(repo, &entry.digest).await?.0)
     }
 

--- a/crates/smolvm-registry/src/client.rs
+++ b/crates/smolvm-registry/src/client.rs
@@ -482,10 +482,10 @@ impl RegistryClient {
         let index: OciIndex = serde_json::from_slice(&doc_bytes)?;
         // .smolmachine sidecars are cross-platform — libkrun is provided by the
         // installed CLI, not bundled — so only the GUEST architecture matters, and
-        // the guest is always linux. Select by architecture: prefer an os=linux
-        // entry, but fall back to architecture alone so an index whose `os` was
-        // mislabeled with the build host (e.g. darwin/arm64 for an arm64 pack) still
-        // resolves. The host OS is irrelevant to which sidecar to pull.
+        // the guest is always Linux. An index entry must therefore be keyed
+        // `linux/<arch>`; match it strictly. A wrong/missing `os` is bad index data
+        // and must fail loudly (the error below lists what was published) rather than
+        // be silently tolerated. The host OS is irrelevant to which sidecar to pull.
         let arch = OciPlatform::current().architecture;
         let entry = index
             .manifests
@@ -494,12 +494,6 @@ impl RegistryClient {
                 m.platform
                     .as_ref()
                     .is_some_and(|p| p.os == "linux" && p.architecture == arch)
-            })
-            .or_else(|| {
-                index
-                    .manifests
-                    .iter()
-                    .find(|m| m.platform.as_ref().is_some_and(|p| p.architecture == arch))
             })
             .ok_or_else(|| {
                 let available: Vec<String> = index


### PR DESCRIPTION
`pack pull` of a multi-arch `library/*` index resolved the entry by the exact HOST platform (`OciPlatform::current()`, e.g. `darwin/arm64`). But `.smolmachine` sidecars are cross-platform — libkrun is provided by the installed CLI, not bundled — so only the GUEST architecture matters and the host OS is irrelevant. Host-matching meant a Linux-arm64 host couldn't pull a Mac-built arm64 artifact (and the published indexes are arm64-as-darwin + amd64-as-linux).

Now `get_manifest_resolved` selects by architecture: prefers an `os=linux` entry, falls back to architecture alone so an index whose `os` was mislabeled with the build host (e.g. `darwin/arm64`) still resolves.

Verified e2e on macOS arm64: `pack pull registry.smolmachines.com/library/alpine:latest -o alpine.smolmachine` → `machine create --from` → `start` → `exec` boots Alpine 3.23.4. 38 registry tests pass.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/360">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->