### PR TITLE
fix(network): preserve TCP relay bytes under backpressure

### DIFF
--- a/crates/smolvm-network/src/tcp_relay.rs
+++ b/crates/smolvm-network/src/tcp_relay.rs
@@ -35,7 +35,7 @@ use std::collections::{HashMap, HashSet};
 use std::io::{self, Read, Write};
 use std::net::{Ipv4Addr, Shutdown, SocketAddr, TcpStream};
 use std::sync::atomic::{AtomicU8, Ordering};
-use std::sync::mpsc::{self, Receiver, SyncSender, TryRecvError};
+use std::sync::mpsc::{self, Receiver, SyncSender, TryRecvError, TrySendError};
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
@@ -93,6 +93,9 @@ struct TrackedConnection {
     pending_proxy_endpoints: Option<PendingProxyEndpoints>,
     // once true, a dedicated host relay thread exists
     relay_spawned: bool,
+    // partial guest->host payload already consumed from smoltcp but not yet
+    // accepted by the relay thread channel
+    buffered_guest_data: Option<Vec<u8>>,
     // partial host->guest payload not yet fully accepted by smoltcp
     buffered_proxy_data: Option<(Vec<u8>, usize)>,
     // bounded retry count for closing with unsent buffered data
@@ -242,6 +245,7 @@ impl TcpRelayTable {
                     relay_target: RelayTarget::Connect(destination),
                 }),
                 relay_spawned: false,
+                buffered_guest_data: None,
                 buffered_proxy_data: None,
                 close_attempts: 0,
                 exit_state,
@@ -332,6 +336,7 @@ impl TcpRelayTable {
                     relay_target: RelayTarget::Attached(host_stream),
                 }),
                 relay_spawned: false,
+                buffered_guest_data: None,
                 buffered_proxy_data: None,
                 close_attempts: 0,
                 exit_state,
@@ -380,11 +385,12 @@ impl TcpRelayTable {
                 RelayExitMode::Running => {}
             }
 
-            while socket.can_recv() {
+            flush_guest_data(connection);
+            while connection.buffered_guest_data.is_none() && socket.can_recv() {
                 match socket.recv_slice(&mut read_buffer) {
                     Ok(bytes_read) if bytes_read > 0 => {
                         let payload = read_buffer[..bytes_read].to_vec();
-                        if connection.to_proxy.try_send(payload).is_err() {
+                        if !send_guest_payload(connection, payload) {
                             break;
                         }
                     }
@@ -477,7 +483,7 @@ impl TcpRelayTable {
 /// - connect a host `TcpStream` to the guest-requested destination
 /// - copy bytes guest->host from `from_smoltcp`
 /// - copy bytes host->guest into `to_smoltcp`
-/// - wake the poll loop when host->guest data arrives
+/// - wake the poll loop when host->guest data arrives or guest->host backpressure eases
 /// - report termination mode through `exit_state`
 pub fn spawn_tcp_relay(
     destination: SocketAddr,
@@ -584,29 +590,60 @@ fn tcp_relay_loop(
     stream.set_nonblocking(true)?;
 
     let mut guest_write_closed = false;
+    let mut guest_channel_closed = false;
+    let mut pending_guest_data: Option<(Vec<u8>, usize)> = None;
     let mut read_buffer = [0u8; RELAY_BUFFER_BYTES];
 
     loop {
         let mut did_work = false;
 
-        loop {
+        if pending_guest_data.is_none() && !guest_channel_closed {
             match from_smoltcp.try_recv() {
                 Ok(payload) => {
-                    stream.write_all(&payload)?;
+                    pending_guest_data = Some((payload, 0));
+                    // Consuming from the bounded guest->host channel may free
+                    // capacity for a payload buffered in the smoltcp poll
+                    // thread. Wake it so backpressure clears promptly even for
+                    // one-way guest->host streams.
+                    relay_wake.wake();
                     did_work = true;
                 }
-                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Empty) => {}
                 Err(TryRecvError::Disconnected) => {
-                    // The guest side closed its write half. Mirror that toward
-                    // the remote peer once, then keep reading until the remote
-                    // side closes too.
-                    if !guest_write_closed {
-                        let _ = stream.shutdown(Shutdown::Write);
-                        guest_write_closed = true;
-                    }
-                    break;
+                    guest_channel_closed = true;
                 }
             }
+        }
+
+        if let Some((payload, offset)) = &mut pending_guest_data {
+            while *offset < payload.len() {
+                match stream.write(&payload[*offset..]) {
+                    Ok(0) => {
+                        return Err(io::Error::new(
+                            io::ErrorKind::WriteZero,
+                            "host TCP relay wrote zero bytes",
+                        ));
+                    }
+                    Ok(bytes_written) => {
+                        *offset += bytes_written;
+                        did_work = true;
+                    }
+                    Err(err) if err.kind() == io::ErrorKind::WouldBlock => break,
+                    Err(err) if err.kind() == io::ErrorKind::Interrupted => continue,
+                    Err(err) => return Err(err),
+                }
+            }
+
+            if *offset >= payload.len() {
+                pending_guest_data = None;
+            }
+        }
+
+        if guest_channel_closed && pending_guest_data.is_none() && !guest_write_closed {
+            // The guest side closed its write half. Mirror that toward the
+            // remote peer only after all buffered guest bytes were written.
+            let _ = stream.shutdown(Shutdown::Write);
+            guest_write_closed = true;
         }
 
         match stream.read(&mut read_buffer) {
@@ -625,6 +662,24 @@ fn tcp_relay_loop(
         if !did_work {
             thread::sleep(PROXY_IDLE_SLEEP);
         }
+    }
+}
+
+fn flush_guest_data(connection: &mut TrackedConnection) {
+    let Some(payload) = connection.buffered_guest_data.take() else {
+        return;
+    };
+    send_guest_payload(connection, payload);
+}
+
+fn send_guest_payload(connection: &mut TrackedConnection, payload: Vec<u8>) -> bool {
+    match connection.to_proxy.try_send(payload) {
+        Ok(()) => true,
+        Err(TrySendError::Full(payload)) => {
+            connection.buffered_guest_data = Some(payload);
+            false
+        }
+        Err(TrySendError::Disconnected(_)) => false,
     }
 }
 
@@ -667,5 +722,43 @@ fn flush_proxy_data(socket: &mut tcp::Socket<'_>, connection: &mut TrackedConnec
             }
             Err(TryRecvError::Empty | TryRecvError::Disconnected) => break,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_connection(to_proxy: SyncSender<Vec<u8>>) -> TrackedConnection {
+        let (_from_proxy_tx, from_proxy) = mpsc::sync_channel(CHANNEL_CAPACITY);
+        TrackedConnection {
+            source: SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 12_345),
+            destination: SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 80),
+            to_proxy,
+            from_proxy,
+            pending_proxy_endpoints: None,
+            relay_spawned: true,
+            buffered_guest_data: None,
+            buffered_proxy_data: None,
+            close_attempts: 0,
+            exit_state: RelayExitState::new(),
+            reserved_published_port: None,
+        }
+    }
+
+    #[test]
+    fn guest_payload_is_buffered_when_relay_channel_is_full() {
+        let (to_proxy, from_smoltcp) = mpsc::sync_channel(1);
+        to_proxy.send(vec![1]).unwrap();
+        let mut connection = test_connection(to_proxy);
+
+        assert!(!send_guest_payload(&mut connection, vec![2]));
+        assert_eq!(connection.buffered_guest_data.as_deref(), Some(&[2][..]));
+
+        assert_eq!(from_smoltcp.recv().unwrap(), vec![1]);
+        flush_guest_data(&mut connection);
+
+        assert!(connection.buffered_guest_data.is_none());
+        assert_eq!(from_smoltcp.recv().unwrap(), vec![2]);
     }
 }


### PR DESCRIPTION
while connecting vscode and jetbrains (gateway, IDEs) to smolvm vms I encountered several ssh errors.

This PR fixes TCP relay byte loss/corruption under backpressure in the virtio-net path. Previously, guest→host payloads consumed from smoltcp could be dropped when the bounded relay channel was full, and nonblocking host socket writes used write_all, which can fail before all bytes are written. 

This buffers unsent guest payloads, tracks partial host writes by offset, and only shuts down the host write half after pending bytes are flushed. The fix preserves bounded backpressure and adds a regression test for the channel-full path. This addresses SSH/TLS stream corruption seen as MAC errors, invalid packet lengths, and TLS bad_record_mac under heavy Remote SSH traffic.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/367">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->