### PR TITLE
Fix init readiness race for machine run

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -206,23 +206,28 @@ fn main() {
     // Set up signal handlers for graceful shutdown (sync before exit)
     setup_signal_handlers();
 
-    // Signal readiness to host IMMEDIATELY after vsock listener is active.
-    // The host detects this marker, then connects and sends its first request.
-    // That connection takes ~10-30ms, giving us time to finish deferred init
-    // below before the first request arrives.
-    signal_ready_to_host();
-    boot_log(
-        "INFO",
-        &format!("boot ready_sent uptime_ms={}", uptime_ms()),
-    );
-
-    // --- Deferred init: runs while host is detecting marker + connecting ---
+    // --- Deferred init: runs before the host is allowed to send requests ---
+    //
+    // Keep the ready marker hidden until the guest has completed the boot-time
+    // work that init commands may depend on:
+    // - guest networking
+    // - storage mount
+    // - packed layers
+    // - volume mounts and /workspace setup
+    // - SSH agent / DNS proxy bridges
+    //
+    // `machine run` can reach init very quickly, so signaling readiness too
+    // early creates a race where init starts before the guest is actually ready
+    // to resolve or connect to the network. Named-machine startup has enough
+    // extra host-side work to mostly hide this, but the guest itself should not
+    // report "ready" until the boot prerequisites are complete.
     // Storage mount is behind a OnceLock (ensure_storage_mounted) so it
     // happens exactly once — either here or on first storage-dependent request.
 
     let start_uptime = uptime_ms();
 
-    // Initialize logging (deferred past ready signal — uses boot_log before this).
+    // Initialize logging after deferred boot work begins; boot_log is still
+    // used for the earliest readiness breadcrumbs.
     tracing_subscriber::fmt()
         .json()
         .with_env_filter(
@@ -234,7 +239,7 @@ fn main() {
     info!(
         version = env!("CARGO_PKG_VERSION"),
         uptime_ms = start_uptime,
-        "smolvm-agent started, vsock listener already ready"
+        "smolvm-agent started, deferred boot work in progress"
     );
 
     let t0 = uptime_ms();
@@ -341,6 +346,13 @@ fn main() {
         total_startup_ms = uptime_ms() - start_uptime,
         uptime_ms = uptime_ms(),
         "agent init complete, entering accept loop"
+    );
+
+    // Only now is the guest safe to accept host requests for init/exec.
+    signal_ready_to_host();
+    boot_log(
+        "INFO",
+        &format!("boot ready_sent uptime_ms={}", uptime_ms()),
     );
 
     // Start accepting connections (listener already bound)

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -269,10 +269,6 @@ fn main() {
         }
     }
 
-    // Mount storage disk eagerly during deferred init. If a request arrives
-    // before this point, ensure_storage_mounted() handles the mount on demand.
-    ensure_storage_mounted();
-
     // Initialize packed layers support (if SMOLVM_PACKED_LAYERS env var is set)
     let t0 = uptime_ms();
     if let Some(packed_dir) = storage::get_packed_layers_dir() {
@@ -349,11 +345,20 @@ fn main() {
     );
 
     // Only now is the guest safe to accept host requests for init/exec.
+    // Network is configured above; storage is mounted below while the host is
+    // establishing its vsock connection (~10-30ms), so the accept loop always
+    // sees storage ready without that mount adding to the user-visible boot time.
     signal_ready_to_host();
     boot_log(
         "INFO",
         &format!("boot ready_sent uptime_ms={}", uptime_ms()),
     );
+
+    // Mount storage after signaling ready. The accept loop has not started yet,
+    // so no request can arrive before this completes. The OnceLock in
+    // ensure_storage_mounted() also guards any concurrent call from a request
+    // that races in the brief window on very fast hosts.
+    ensure_storage_mounted();
 
     // Start accepting connections (listener already bound)
     if let Err(e) = run_server_with_listener(listener) {


### PR DESCRIPTION
Fix:#232
## Summary

Fix a readiness race in `smolvm machine run` where `[dev].init` could start before the guest had finished boot-time network setup.

The guest agent previously signaled readiness too early, which meant ephemeral runs could begin init commands before outbound networking was actually usable. That showed up as `npm install` failing with `EAI_AGAIN` even when `net = true` was set.

## What changed

- Delay the guest ready signal until after deferred boot work completes.
- Ensure network setup, storage mount, packed layers, volume mounts, `/workspace`, SSH agent bridge, and DNS proxy setup finish before init can start.
- Update the boot logs so they match the new readiness boundary.

## Why this fixes the bug

`machine run` starts init as soon as the guest reports ready. By moving the ready signal to the end of boot, init cannot race ahead of network configuration anymore.

## Verification

- Ran `cargo fmt --all`
- Reviewed the boot sequence in `crates/smolvm-agent/src/main.rs`
- Confirmed the shared init path used by `machine run` and `machine create/start`


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/371">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->