### PR TITLE
fix: machine names are flags everywhere (--name)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,16 +11,16 @@ smolvm machine run --net -it --image alpine -- /bin/sh   # interactive shell
 smolvm machine run --net --image python:3.12-alpine -- python3 script.py
 
 # Persistent (survives across exec sessions and stop/start)
-smolvm machine create --net myvm
+smolvm machine create --net --name myvm
 smolvm machine start --name myvm
 smolvm machine exec --name myvm -- apk add python3   # installs persist
 smolvm machine exec --name myvm -- which python3      # still there
 smolvm machine shell --name myvm               # interactive shell (auto-starts if stopped)
 smolvm machine stop --name myvm
-smolvm machine delete myvm
+smolvm machine delete --name myvm
 
 # Image-based persistent (filesystem changes persist across exec sessions)
-smolvm machine create --net --image ubuntu myvm
+smolvm machine create --net --image ubuntu --name myvm
 smolvm machine start --name myvm
 smolvm machine exec --name myvm -- apt-get update
 smolvm machine exec --name myvm -- apt-get install -y python3
@@ -28,7 +28,7 @@ smolvm machine exec --name myvm -- which python3      # still there after exit+r
 
 # SSH agent forwarding (git/ssh without exposing keys)
 smolvm machine run --ssh-agent --net --image alpine -- ssh-add -l
-smolvm machine create myvm --ssh-agent --net
+smolvm machine create --name myvm --ssh-agent --net
 
 # Inject secrets into workload env (referenced from host env var / file)
 smolvm machine run --secret-env OPENAI_API_KEY=OPENAI_API_KEY -- ./app
@@ -39,7 +39,7 @@ smolvm pack create --image python:3.12-alpine -o ./my-python
 ./my-python run -- python3 -c "print('hello')"
 
 # Create machine from packed artifact (fast start, no pull)
-smolvm machine create my-vm --from ./my-python.smolmachine
+smolvm machine create --name my-vm --from ./my-python.smolmachine
 smolvm machine start --name my-vm
 smolvm machine exec --name my-vm -- pip install requests
 ```
@@ -53,11 +53,11 @@ smolvm machine exec --name my-vm -- pip install requests
 | Interactive shell (persistent) | `smolvm machine shell --name NAME` |
 | Persistent dev environment | `machine create` → `machine start` → `machine exec` |
 | Ship software as a binary | `smolvm pack create --image IMAGE -o OUTPUT` |
-| Fast persistent machine from packed artifact | `machine create NAME --from FILE.smolmachine` |
+| Fast persistent machine from packed artifact | `machine create --name NAME --from FILE.smolmachine` |
 | Use git/ssh with private keys safely | Add `--ssh-agent` to run or create |
 | Inject API keys / tokens without putting them on the command line | `--secret-env`/`--secret-file` flags or Smolfile `[secrets]` |
 | Minimal VM without image | `smolvm machine run -s Smolfile` (bare VM) |
-| Change mounts/ports/resources on existing VM | `machine update NAME -v ./src:/app -p 8080:8080` |
+| Change mounts/ports/resources on existing VM | `machine update --name NAME -v ./src:/app -p 8080:8080` |
 | Declarative VM config | Create a Smolfile, use `--smolfile`/`-s` flag |
 
 ### Persistence Model
@@ -71,20 +71,20 @@ smolvm machine exec --name my-vm -- pip install requests
 
 ## CLI Structure
 
-All commands use named flags (no positional args except `machine create NAME` and `machine delete NAME`).
+All commands use named flags (no positional args except `machine create --name NAME` and `machine delete --name NAME`).
 
 ```
 smolvm machine run --image IMAGE [-- COMMAND]     # ephemeral
 smolvm machine exec --name NAME [-- COMMAND]      # run in existing VM
 smolvm machine shell [--name NAME]                # interactive shell (auto-starts)
-smolvm machine create NAME [OPTIONS]              # create persistent
-smolvm machine create NAME --from FILE.smolmachine  # from packed artifact
+smolvm machine create --name NAME [OPTIONS]              # create persistent
+smolvm machine create --name NAME --from FILE.smolmachine  # from packed artifact
 smolvm machine start [--name NAME]                # start (default: "default")
 smolvm machine stop [--name NAME]                 # stop
-smolvm machine delete NAME [-f]                   # delete
+smolvm machine delete --name NAME [-f]                   # delete
 smolvm machine status [--name NAME]               # check state
 smolvm machine ls [--json]                        # list all
-smolvm machine update NAME [OPTIONS]              # modify stopped machine settings
+smolvm machine update --name NAME [OPTIONS]              # modify stopped machine settings
 smolvm machine cp SRC DST                         # copy files (host↔VM)
 smolvm machine exec --stream --name NAME -- CMD   # streaming output
 smolvm machine monitor [--name NAME]              # foreground health + restart
@@ -100,7 +100,7 @@ smolvm config registries edit                     # registry auth
 # built-in store. Attach them on the command line or in a Smolfile [secrets].
 smolvm machine run    --secret-env GUEST_VAR=HOST_VAR     # from host env var
 smolvm machine run    --secret-file GUEST_VAR=/abs/path   # from host file
-smolvm machine create NAME --secret-env GUEST_VAR=HOST_VAR  # persists the ref
+smolvm machine create --name NAME --secret-env GUEST_VAR=HOST_VAR  # persists the ref
 smolvm machine exec --name NAME --secret-env GUEST_VAR=HOST_VAR -- cmd
 ```
 
@@ -254,7 +254,7 @@ Forward the host's SSH agent into the VM so git, ssh, and scp work with your key
 ```bash
 # CLI flag
 smolvm machine run --ssh-agent --net --image alpine -- ssh-add -l
-smolvm machine create myvm --ssh-agent --net
+smolvm machine create --name myvm --ssh-agent --net
 
 # Smolfile
 # [auth]
@@ -292,7 +292,7 @@ smolvm machine run --gpu --image alpine -- sh -c '
 # → deviceName = Virtio-GPU Venus (Intel(R) UHD Graphics ...)
 
 # Persistent GPU machine
-smolvm machine create browser --gpu --gpu-vram 2048
+smolvm machine create --name browser --gpu --gpu-vram 2048
 smolvm machine start --name browser
 smolvm machine exec --name browser -- \
   chromium --headless=new --no-sandbox --use-gl=angle --use-angle=vulkan \
@@ -323,7 +323,7 @@ Attach refs on the command line:
 ```bash
 # From a host environment variable (GUEST_VAR=HOST_VAR)
 smolvm machine run    --secret-env OPENAI_API_KEY=OPENAI_API_KEY -- ./app
-smolvm machine create web --secret-env DATABASE_URL=PROD_DB_URL   # persists the ref
+smolvm machine create --name web --secret-env DATABASE_URL=PROD_DB_URL   # persists the ref
 smolvm machine exec --name web --secret-env TOKEN=CI_TOKEN -- ./deploy
 
 # From a host file (GUEST_VAR=/absolute/path)
@@ -387,7 +387,7 @@ run — the host mount takes priority and the storage workspace is skipped:
 
 ```bash
 # Typical agent workflow: copy code in, execute, extract results
-smolvm machine create r-sandbox --image r-base:latest --net
+smolvm machine create --name r-sandbox --image r-base:latest --net
 smolvm machine start --name r-sandbox
 
 smolvm machine cp analysis.R r-sandbox:/workspace/analysis.R
@@ -472,7 +472,7 @@ The packed binary runs as a normal executable:
 
 Alternatively, create a named machine from the `.smolmachine` for full lifecycle management:
 ```bash
-smolvm machine create my-vm --from my-app.smolmachine
+smolvm machine create --name my-vm --from my-app.smolmachine
 smolvm machine start --name my-vm            # ~250ms boot, no image pull
 smolvm machine exec --name my-vm -- pip install x   # fully persistent
 smolvm machine stop --name my-vm

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ smolvm pack create --image python:3.12-alpine -o ./python312
 **Persistent machines for development** — create, stop, start. Installed packages survive restarts.
 
 ```bash
-smolvm machine create --net myvm
+smolvm machine create --net --name myvm
 smolvm machine start --name myvm
 smolvm machine exec --name myvm -- apk add sl
 smolvm machine exec --name myvm -it -- /bin/sh
@@ -106,7 +106,7 @@ ssh_agent = true
 ```
 
 ```bash
-smolvm machine create myvm -s Smolfile
+smolvm machine create --name myvm -s Smolfile
 smolvm machine start --name myvm
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,7 +17,7 @@ smolvm machine run -d -s examples/doom-web/doom.smolfile
 open http://localhost:8080
 
 # Headless Chromium with GPU acceleration
-smolvm machine create browser -s examples/headless-browser/browser.smolfile
+smolvm machine create --name browser -s examples/headless-browser/browser.smolfile
 smolvm machine start --name browser
 smolvm machine exec --name browser -- \
   chromium --headless=new --no-sandbox --disable-dev-shm-usage \
@@ -30,7 +30,7 @@ smolvm machine exec --name browser -- base64 /tmp/out.png | base64 -d > out.png
 ### Persistent microVMs
 
 ```bash
-smolvm machine create dev -s examples/python-app/python.smolfile
+smolvm machine create --name dev -s examples/python-app/python.smolfile
 smolvm machine start --name dev
 smolvm machine exec --name dev -- python3 --version
 smolvm machine stop --name dev

--- a/examples/docker-in-vm/docker.smolfile
+++ b/examples/docker-in-vm/docker.smolfile
@@ -39,7 +39,7 @@
 #
 # ── Create and start ─────────────────────────────────────────────────────────
 #
-#   smolvm machine create docker -s examples/docker-in-vm/docker.smolfile --net-backend virtio-net
+#   smolvm machine create --name docker -s examples/docker-in-vm/docker.smolfile --net-backend virtio-net
 #   smolvm machine start --name docker
 #
 # ── Start dockerd ─────────────────────────────────────────────────────────────

--- a/examples/headless-browser/README.md
+++ b/examples/headless-browser/README.md
@@ -53,7 +53,7 @@ the exec returns). Pass the command at `create` (an image machine with no
 command instead adopts the image's OCI `CMD`/`ENTRYPOINT`):
 
 ```sh
-smolvm machine create browser-golden \
+smolvm machine create --name browser-golden \
     --image chromedp/headless-shell:latest --net \
     --workdir /headless-shell \
     -- ./headless-shell --headless=new --no-zygote --no-sandbox \
@@ -63,8 +63,8 @@ smolvm machine create browser-golden \
 smolvm machine start --name browser-golden --forkable
 
 # Fork a warm clone on demand (one golden → N clones):
-smolvm machine fork browser-golden worker-1
-smolvm machine fork browser-golden worker-2
+smolvm machine fork --golden browser-golden --name worker-1
+smolvm machine fork --golden browser-golden --name worker-2
 
 # Each clone's browser is already up; exec / drive it:
 smolvm machine exec --name worker-1 -- /bin/sh -c 'echo ready'

--- a/examples/headless-browser/browser.smolfile
+++ b/examples/headless-browser/browser.smolfile
@@ -14,7 +14,7 @@
 #
 # ── Setup (one time) ─────────────────────────────────────────────────────────
 #
-#   smolvm machine create browser -s examples/headless-browser/browser.smolfile
+#   smolvm machine create --name browser -s examples/headless-browser/browser.smolfile
 #   smolvm machine start --name browser
 #
 # ── Take a screenshot ────────────────────────────────────────────────────────

--- a/examples/local-llm/local-llm.smolfile
+++ b/examples/local-llm/local-llm.smolfile
@@ -9,7 +9,7 @@
 #
 # ── Setup (runs once, takes ~5 min to build llama.cpp) ───────────────────────
 #
-#   smolvm machine create llm -s examples/local-llm/local-llm.smolfile
+#   smolvm machine create --name llm -s examples/local-llm/local-llm.smolfile
 #   smolvm machine start --name llm
 #
 # ── Download a model ────────────────────────────────────────────────────────

--- a/examples/node-app/node.smolfile
+++ b/examples/node-app/node.smolfile
@@ -1,7 +1,7 @@
 # Node.js dev environment in a hardware-isolated microVM
 #
 #   smolvm machine run -s examples/node-app/node.smolfile
-#   smolvm machine create dev -s node.smolfile
+#   smolvm machine create --name dev -s node.smolfile
 #   smolvm machine start --name dev
 #   smolvm machine exec --name dev -- node -e "console.log('hello')"
 

--- a/examples/python-app/python.smolfile
+++ b/examples/python-app/python.smolfile
@@ -1,7 +1,7 @@
 # Python dev environment in a hardware-isolated microVM
 #
 #   smolvm machine run -s examples/python-app/python.smolfile
-#   smolvm machine create dev -s python.smolfile
+#   smolvm machine create --name dev -s python.smolfile
 #   smolvm machine start --name dev
 #   smolvm machine exec --name dev -- python3 --version
 

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -555,12 +555,12 @@ USAGE
 Run the 'smolvm' script (not smolvm-bin directly):
 
   ./smolvm machine run --net --image alpine -- echo "Hello World"
-  ./smolvm machine create --net myvm
+  ./smolvm machine create --net --name myvm
   ./smolvm machine start --name myvm
   ./smolvm machine exec --name myvm -- /bin/sh
   ./smolvm machine ls
   ./smolvm machine stop --name myvm
-  ./smolvm machine delete myvm
+  ./smolvm machine delete --name myvm
 
 TROUBLESHOOTING
 ===============

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -506,7 +506,7 @@ impl RunCmd {
                 return Err(Error::config(
                     "machine run -d --name",
                     format!(
-                        "a machine named '{}' already exists. Use 'machine start --name {}' to start it, or 'machine delete {} -f' to remove it.",
+                        "a machine named '{}' already exists. Use 'machine start --name {}' to start it, or 'machine delete --name {} -f' to remove it.",
                         vm_name, vm_name, vm_name
                     ),
                 ));
@@ -1206,7 +1206,7 @@ mod tests {
     #[test]
     fn create_accepts_trailing_workload_command() {
         let cli = TestMachineCli::parse_from([
-            "machine", "create", "golden", "--image", "alpine", "--", "echo", "hi",
+            "machine", "create", "--name", "golden", "--image", "alpine", "--", "echo", "hi",
         ]);
         let MachineCmd::Create(cmd) = cli.command else {
             panic!("expected machine create command");
@@ -1226,14 +1226,22 @@ mod tests {
     #[test]
     fn create_without_command_leaves_command_empty() {
         // Regression: adding the trailing COMMAND arg must not break the common
-        // no-command form `machine create <name> --net`.
-        let cli = TestMachineCli::parse_from(["machine", "create", "golden", "--net"]);
+        // no-command form `machine create --name <name> --net`.
+        let cli = TestMachineCli::parse_from(["machine", "create", "--name", "golden", "--net"]);
         let MachineCmd::Create(cmd) = cli.command else {
             panic!("expected machine create command");
         };
         assert_eq!(cmd.name, Some("golden".to_string()));
         assert!(cmd.command.is_empty());
         assert!(cmd.net);
+    }
+
+    #[test]
+    fn create_rejects_bare_positional_name() {
+        // Machine names are flags everywhere (issue #370). A bare positional —
+        // the old `machine create myvm` habit — must error, not be silently
+        // captured as the workload command.
+        assert!(TestMachineCli::try_parse_from(["machine", "create", "myvm"]).is_err());
     }
 
     #[test]
@@ -1534,12 +1542,12 @@ impl ShellCmd {
 /// `smolvm machine exec --name <name> -- <command>` to run commands inside.
 ///
 /// Examples:
-///   smolvm machine create myvm
-///   smolvm machine create webserver --cpus 2 --mem 1024 -p 80:80
+///   smolvm machine create --name myvm
+///   smolvm machine create --name webserver --cpus 2 --mem 1024 -p 80:80
 #[derive(Args, Debug)]
 pub struct CreateCmd {
     /// Name for the machine (auto-generated if omitted)
-    #[arg(value_name = "NAME")]
+    #[arg(short = 'n', long, value_name = "NAME")]
     pub name: Option<String>,
 
     /// Container image (e.g., alpine, python:3.12-alpine)
@@ -1642,7 +1650,11 @@ pub struct CreateCmd {
     /// Launched as a detached container on every `start`, so it stays running
     /// (e.g. a pre-warmed browser to be forked). Without this, an image machine
     /// boots to a bare agent and the image's CMD is not run.
-    #[arg(trailing_var_arg = true, value_name = "COMMAND")]
+    ///
+    /// `last = true` requires the `--` separator. With the machine name now a
+    /// flag, a bare positional (an old-style `machine create myvm`) must fail
+    /// loudly instead of being silently captured as the workload command.
+    #[arg(last = true, value_name = "COMMAND")]
     pub command: Vec<String>,
 }
 
@@ -1962,11 +1974,11 @@ impl StartCmd {
 #[derive(Args, Debug)]
 pub struct ForkCmd {
     /// The running, forkable source machine to clone from.
-    #[arg(value_name = "GOLDEN")]
+    #[arg(long, value_name = "NAME")]
     pub golden: String,
 
     /// Name for the new clone machine.
-    #[arg(value_name = "CLONE")]
+    #[arg(short = 'n', long = "name", value_name = "NAME")]
     pub clone: String,
 
     /// Make the clone itself forkable (memfd RAM + control socket), so it can
@@ -2021,7 +2033,7 @@ impl StopCmd {
 #[derive(Args, Debug)]
 pub struct DeleteCmd {
     /// Machine to delete
-    #[arg(value_name = "NAME")]
+    #[arg(short = 'n', long, value_name = "NAME")]
     pub name: String,
 
     /// Skip confirmation prompt
@@ -2164,14 +2176,14 @@ impl ResizeCmd {
 /// `machine start`. The machine must be stopped.
 ///
 /// Examples:
-///   smolvm machine update myvm -v ./src:/app -p 8080:8080
-///   smolvm machine update myvm --cpus 4 --mem 4096
-///   smolvm machine update myvm --remove-volume ./src:/app
-///   smolvm machine update myvm --net -e DEBUG=1
+///   smolvm machine update --name myvm -v ./src:/app -p 8080:8080
+///   smolvm machine update --name myvm --cpus 4 --mem 4096
+///   smolvm machine update --name myvm --remove-volume ./src:/app
+///   smolvm machine update --name myvm --net -e DEBUG=1
 #[derive(Args, Debug)]
 pub struct UpdateCmd {
     /// Machine to update
-    #[arg(value_name = "NAME")]
+    #[arg(short = 'n', long, value_name = "NAME")]
     pub name: String,
 
     /// Add volume mount (HOST:GUEST[:ro])
@@ -2470,6 +2482,7 @@ impl UpdateCmd {
 #[derive(Args, Debug)]
 pub struct DataDirCmd {
     /// Machine name.
+    #[arg(short = 'n', long, value_name = "NAME")]
     pub name: String,
 }
 

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -735,13 +735,13 @@ pub fn fork_vm(
     if !ctl.exists() {
         return Err(Error::agent(
             "fork",
-            format!("golden '{golden}' is not running forkable; start it with `machine start --forkable {golden}`"),
+            format!("golden '{golden}' is not running forkable; start it with `machine start --forkable --name {golden}`"),
         ));
     }
     let status = control_socket_cmd(&ctl, "STATUS").map_err(|e| {
         Error::agent(
             "fork",
-            format!("golden '{golden}' control socket not responding ({e}); start it with `machine start --forkable {golden}`"),
+            format!("golden '{golden}' control socket not responding ({e}); start it with `machine start --forkable --name {golden}`"),
         )
     })?;
     if !status.starts_with("OK") {

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -212,12 +212,12 @@ print_summary() {
 
 # Get the data directory for a named machine.
 #
-# Delegates to `smolvm machine data-dir <name>` so the test helper never
+# Delegates to `smolvm machine data-dir --name <name>` so the test helper never
 # duplicates the hash logic. If Rust changes the on-disk layout, the test
 # suite automatically picks it up via this CLI call.
 vm_data_dir() {
     local name="${1:-default}"
-    $SMOLVM machine data-dir "$name" 2>/dev/null
+    $SMOLVM machine data-dir --name "$name" 2>/dev/null
 }
 
 # Cleanup helper - stop machine and remove named "default" from DB
@@ -225,7 +225,7 @@ vm_data_dir() {
 # manual testing or previous test runs).
 cleanup_machine() {
     $SMOLVM machine stop 2>/dev/null || true
-    $SMOLVM machine delete default -f 2>/dev/null || true
+    $SMOLVM machine delete --name default -f 2>/dev/null || true
 }
 
 # Verify that a VM's data directory was removed after deletion.
@@ -249,8 +249,8 @@ ensure_machine_running() {
     if [[ "$with_net" == "true" ]]; then
         # Stop and delete existing default VM, recreate with --net
         $SMOLVM machine stop 2>/dev/null || true
-        $SMOLVM machine delete default -f 2>/dev/null || true
-        $SMOLVM machine create default --net 2>/dev/null || true
+        $SMOLVM machine delete --name default -f 2>/dev/null || true
+        $SMOLVM machine create --name default --net 2>/dev/null || true
     fi
     $SMOLVM machine start 2>/dev/null || true
 
@@ -258,9 +258,9 @@ ensure_machine_running() {
     # the process is dead (stale PID), do a full cleanup and restart.
     if ! $SMOLVM machine exec -- true 2>/dev/null; then
         $SMOLVM machine stop 2>/dev/null || true
-        $SMOLVM machine delete default -f 2>/dev/null || true
+        $SMOLVM machine delete --name default -f 2>/dev/null || true
         if [[ "$with_net" == "true" ]]; then
-            $SMOLVM machine create default --net 2>/dev/null || true
+            $SMOLVM machine create --name default --net 2>/dev/null || true
         fi
         $SMOLVM machine start 2>/dev/null || true
     fi

--- a/tests/test_db.sh
+++ b/tests/test_db.sh
@@ -24,10 +24,10 @@ test_db_persistence_across_restart() {
 
     # Clean up any existing
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     # Create a named VM with specific configuration
-    $SMOLVM machine create "$vm_name" --cpus 2 --mem 1024 2>&1
+    $SMOLVM machine create --name "$vm_name" --cpus 2 --mem 1024 2>&1
 
     # Verify it was created with correct config
     local list_output
@@ -39,12 +39,12 @@ test_db_persistence_across_restart() {
 
     if [[ "$list_output" != *'"cpus": 2'* ]] || [[ "$list_output" != *'"memory_mib": 1024'* ]]; then
         echo "VM configuration not persisted correctly"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     fi
 
     # Clean up
-    $SMOLVM machine delete "$vm_name" -f 2>&1
+    $SMOLVM machine delete --name "$vm_name" -f 2>&1
     ensure_data_dir_deleted "$vm_name"
 }
 
@@ -53,17 +53,17 @@ test_db_vm_state_update() {
 
     # Clean up any existing
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     # Create a named VM
-    $SMOLVM machine create "$vm_name" 2>&1
+    $SMOLVM machine create --name "$vm_name" 2>&1
 
     # Check initial state is "created"
     local initial_state
     initial_state=$($SMOLVM machine ls --json 2>&1)
     if [[ "$initial_state" != *'"state": "created"'* ]]; then
         echo "Initial state should be 'created'"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     fi
 
@@ -76,7 +76,7 @@ test_db_vm_state_update() {
     if [[ "$running_state" != *'"state": "running"'* ]]; then
         echo "State should be 'running' after start"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     fi
 
@@ -88,7 +88,7 @@ test_db_vm_state_update() {
     stopped_state=$($SMOLVM machine ls --json 2>&1)
 
     # Clean up
-    $SMOLVM machine delete "$vm_name" -f 2>&1
+    $SMOLVM machine delete --name "$vm_name" -f 2>&1
     ensure_data_dir_deleted "$vm_name"
 
     [[ "$stopped_state" == *'"state": "stopped"'* ]]
@@ -98,10 +98,10 @@ test_db_delete_removes_from_db() {
     local vm_name="db-delete-test-$$"
 
     # Clean up any existing
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     # Create a VM
-    $SMOLVM machine create "$vm_name" 2>&1
+    $SMOLVM machine create --name "$vm_name" 2>&1
 
     # Verify it exists
     local before_delete
@@ -112,7 +112,7 @@ test_db_delete_removes_from_db() {
     fi
 
     # Delete it
-    $SMOLVM machine delete "$vm_name" -f 2>&1
+    $SMOLVM machine delete --name "$vm_name" -f 2>&1
     ensure_data_dir_deleted "$vm_name"
 
     # Verify it's gone

--- a/tests/test_gpu.sh
+++ b/tests/test_gpu.sh
@@ -25,7 +25,7 @@ GPU_FEDORA_MACHINE="gpu-fedora-$$"
 
 cleanup_gpu() {
     "$SMOLVM" machine stop --name "$GPU_FEDORA_MACHINE" 2>/dev/null || true
-    "$SMOLVM" machine delete "$GPU_FEDORA_MACHINE" -f 2>/dev/null || true
+    "$SMOLVM" machine delete --name "$GPU_FEDORA_MACHINE" -f 2>/dev/null || true
 }
 trap cleanup_gpu EXIT
 
@@ -157,18 +157,18 @@ test_named_machine_gpu_persists() {
     # deserialise → launcher → krun_set_gpu_options2.
     local name="gpu-named-$$"
     "$SMOLVM" machine stop --name "$name" 2>/dev/null || true
-    "$SMOLVM" machine delete "$name" -f 2>/dev/null || true
+    "$SMOLVM" machine delete --name "$name" -f 2>/dev/null || true
 
-    "$SMOLVM" machine create "$name" --gpu --net --image alpine:latest 2>&1 || return 1
+    "$SMOLVM" machine create --name "$name" --gpu --net --image alpine:latest 2>&1 || return 1
     "$SMOLVM" machine start --name "$name" 2>&1 || {
-        "$SMOLVM" machine delete "$name" -f 2>/dev/null; return 1
+        "$SMOLVM" machine delete --name "$name" -f 2>/dev/null; return 1
     }
 
     local out rc=0
     out=$("$SMOLVM" machine exec --name "$name" -- ls /dev/dri/renderD128 2>&1) || rc=$?
 
     "$SMOLVM" machine stop --name "$name" 2>/dev/null || true
-    "$SMOLVM" machine delete "$name" -f 2>/dev/null || true
+    "$SMOLVM" machine delete --name "$name" -f 2>/dev/null || true
 
     [[ $rc -eq 0 ]] && [[ "$out" == *"renderD128"* ]] || {
         echo "FAIL: renderD128 absent in named GPU machine (got: $out, exit $rc)"
@@ -275,15 +275,15 @@ echo "Running Vulkan workload tests (Fedora 42 + patched Mesa)..."
 
 test_fedora_gpu_setup() {
     "$SMOLVM" machine stop --name "$GPU_FEDORA_MACHINE" 2>/dev/null || true
-    "$SMOLVM" machine delete "$GPU_FEDORA_MACHINE" -f 2>/dev/null || true
+    "$SMOLVM" machine delete --name "$GPU_FEDORA_MACHINE" -f 2>/dev/null || true
 
     echo "  Creating Fedora 42 GPU machine (this pulls ~600 MB on first run)..."
-    "$SMOLVM" machine create "$GPU_FEDORA_MACHINE" \
+    "$SMOLVM" machine create --name "$GPU_FEDORA_MACHINE" \
         --image fedora:42 --gpu --net 2>&1 || return 1
 
     echo "  Starting machine..."
     "$SMOLVM" machine start --name "$GPU_FEDORA_MACHINE" 2>&1 || {
-        "$SMOLVM" machine delete "$GPU_FEDORA_MACHINE" -f 2>/dev/null
+        "$SMOLVM" machine delete --name "$GPU_FEDORA_MACHINE" -f 2>/dev/null
         return 1
     }
 
@@ -359,7 +359,7 @@ test_render_node_in_fedora_container() {
 
 test_fedora_gpu_cleanup() {
     "$SMOLVM" machine stop --name "$GPU_FEDORA_MACHINE" 2>&1 || true
-    "$SMOLVM" machine delete "$GPU_FEDORA_MACHINE" -f 2>/dev/null || true
+    "$SMOLVM" machine delete --name "$GPU_FEDORA_MACHINE" -f 2>/dev/null || true
 }
 
 run_test "GPU: Fedora 42 + patched Mesa setup" test_fedora_gpu_setup || true

--- a/tests/test_machine_bare.sh
+++ b/tests/test_machine_bare.sh
@@ -147,13 +147,13 @@ test_machine_exec_failed_does_not_kill_vm() {
 test_sigterm_during_exec_does_not_stall_vm() {
     local name="bug12-sigterm-$$"
     $SMOLVM machine stop --name "$name" 2>/dev/null || true
-    $SMOLVM machine delete "$name" -f 2>/dev/null || true
-    $SMOLVM machine create "$name" 2>&1 | tail -1 || return 1
+    $SMOLVM machine delete --name "$name" -f 2>/dev/null || true
+    $SMOLVM machine create --name "$name" 2>&1 | tail -1 || return 1
     $SMOLVM machine start --name "$name" 2>&1 | tail -1 || {
-        $SMOLVM machine delete "$name" -f 2>/dev/null; return 1
+        $SMOLVM machine delete --name "$name" -f 2>/dev/null; return 1
     }
     wait_vm_ready --name "$name" || {
-        $SMOLVM machine delete "$name" -f 2>/dev/null; return 1
+        $SMOLVM machine delete --name "$name" -f 2>/dev/null; return 1
     }
 
     # Start a long-running exec, then SIGTERM the client mid-flight.
@@ -180,7 +180,7 @@ test_sigterm_during_exec_does_not_stall_vm() {
     [[ "$result" == *"survived"* ]] || {
         echo "FAIL: exec after SIGTERM failed: $result"
         $SMOLVM machine stop --name "$name" 2>/dev/null
-        $SMOLVM machine delete "$name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$name" -f 2>/dev/null
         return 1
     }
 
@@ -190,24 +190,24 @@ test_sigterm_during_exec_does_not_stall_vm() {
     if [[ "$over_threshold" == "yes" ]]; then
         echo "FAIL: next exec took ${elapsed}s (>5s) — agent stalled on orphan child?"
         $SMOLVM machine stop --name "$name" 2>/dev/null
-        $SMOLVM machine delete "$name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$name" -f 2>/dev/null
         return 1
     fi
 
     $SMOLVM machine stop --name "$name" 2>/dev/null || true
-    $SMOLVM machine delete "$name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$name" -f 2>/dev/null || true
 }
 
 test_exec_timeout_does_not_stall_vm() {
     local name="bug20-timeout-$$"
     $SMOLVM machine stop --name "$name" 2>/dev/null || true
-    $SMOLVM machine delete "$name" -f 2>/dev/null || true
-    $SMOLVM machine create "$name" 2>&1 | tail -1 || return 1
+    $SMOLVM machine delete --name "$name" -f 2>/dev/null || true
+    $SMOLVM machine create --name "$name" 2>&1 | tail -1 || return 1
     $SMOLVM machine start --name "$name" 2>&1 | tail -1 || {
-        $SMOLVM machine delete "$name" -f 2>/dev/null; return 1
+        $SMOLVM machine delete --name "$name" -f 2>/dev/null; return 1
     }
     wait_vm_ready --name "$name" || {
-        $SMOLVM machine delete "$name" -f 2>/dev/null; return 1
+        $SMOLVM machine delete --name "$name" -f 2>/dev/null; return 1
     }
 
     # Short timeout, long-running command with sub-processes — timeout should
@@ -228,7 +228,7 @@ test_exec_timeout_does_not_stall_vm() {
     [[ "$result" == *"alive"* ]] || {
         echo "FAIL: exec after timeout failed: $result"
         $SMOLVM machine stop --name "$name" 2>/dev/null
-        $SMOLVM machine delete "$name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$name" -f 2>/dev/null
         return 1
     }
 
@@ -237,12 +237,12 @@ test_exec_timeout_does_not_stall_vm() {
     if [[ "$over_threshold" == "yes" ]]; then
         echo "FAIL: next exec took ${elapsed}s (>5s) — agent stalled after timeout?"
         $SMOLVM machine stop --name "$name" 2>/dev/null
-        $SMOLVM machine delete "$name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$name" -f 2>/dev/null
         return 1
     fi
 
     $SMOLVM machine stop --name "$name" 2>/dev/null || true
-    $SMOLVM machine delete "$name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$name" -f 2>/dev/null || true
 }
 
 test_machine_named_vm() {
@@ -250,26 +250,26 @@ test_machine_named_vm() {
 
     # Clean up any existing
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     # Create the named VM first
-    $SMOLVM machine create "$vm_name" 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" 2>&1 || return 1
 
     # Start
-    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1; }
 
     # Check status
     local status
     status=$($SMOLVM machine status --name "$vm_name" 2>&1)
     if [[ "$status" != *"running"* ]]; then
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     fi
 
     # Stop and delete
     $SMOLVM machine stop --name "$vm_name" 2>&1
-    $SMOLVM machine delete "$vm_name" -f 2>&1
+    $SMOLVM machine delete --name "$vm_name" -f 2>&1
     ensure_data_dir_deleted "$vm_name"
 }
 
@@ -278,17 +278,17 @@ test_machine_create_prints_named_start_hint() {
     local output
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
-    output=$($SMOLVM machine create "$vm_name" 2>&1) || return 1
+    output=$($SMOLVM machine create --name "$vm_name" 2>&1) || return 1
 
     [[ "$output" == *"Use 'smolvm machine start --name $vm_name' to start the machine"* ]] || {
         echo "$output"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
 
-    $SMOLVM machine delete "$vm_name" -f 2>&1
+    $SMOLVM machine delete --name "$vm_name" -f 2>&1
     ensure_data_dir_deleted "$vm_name"
 }
 
@@ -318,9 +318,9 @@ test_file_upload_download() {
     local vm_name="cp-test-$$"
 
     # Create and start a machine
-    $SMOLVM machine create "$vm_name" 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" 2>&1 || return 1
     run_with_timeout 30 $SMOLVM machine start --name "$vm_name" 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1
     }
 
     # Upload a file
@@ -329,7 +329,7 @@ test_file_upload_download() {
     $SMOLVM machine cp /tmp/smolvm-cp-test.txt "$vm_name":/tmp/uploaded.txt 2>&1 || {
         echo "Upload failed"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         rm -f /tmp/smolvm-cp-test.txt
         return 1
     }
@@ -339,14 +339,14 @@ test_file_upload_download() {
     exec_result=$($SMOLVM machine exec --name "$vm_name" -- cat /tmp/uploaded.txt 2>&1) || {
         echo "Exec after upload failed"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         rm -f /tmp/smolvm-cp-test.txt
         return 1
     }
     [[ "$exec_result" == *"$upload_content"* ]] || {
         echo "Upload content mismatch: expected '$upload_content', got '$exec_result'"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         rm -f /tmp/smolvm-cp-test.txt
         return 1
     }
@@ -356,7 +356,7 @@ test_file_upload_download() {
     $SMOLVM machine cp "$vm_name":/tmp/to-download.txt /tmp/smolvm-downloaded.txt 2>&1 || {
         echo "Download failed"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         rm -f /tmp/smolvm-cp-test.txt /tmp/smolvm-downloaded.txt
         return 1
     }
@@ -365,14 +365,14 @@ test_file_upload_download() {
     [[ "$downloaded" == *"hello from VM"* ]] || {
         echo "Download content mismatch: '$downloaded'"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         rm -f /tmp/smolvm-cp-test.txt /tmp/smolvm-downloaded.txt
         return 1
     }
 
     # Cleanup
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
     rm -f /tmp/smolvm-cp-test.txt /tmp/smolvm-downloaded.txt
 }
 
@@ -380,36 +380,36 @@ test_streaming_exec() {
     # Start a machine, run a command with --stream, verify output arrives
     $SMOLVM machine stop 2>/dev/null || true
 
-    $SMOLVM machine create stream-test-$$ 2>&1 || return 1
+    $SMOLVM machine create --name stream-test-$$ 2>&1 || return 1
     run_with_timeout 30 $SMOLVM machine start --name stream-test-$$ 2>&1 || {
-        $SMOLVM machine delete stream-test-$$ -f 2>/dev/null; return 1
+        $SMOLVM machine delete --name stream-test-$$ -f 2>/dev/null; return 1
     }
 
     # Streaming exec — output should contain the echoed text
     local result
     result=$(run_with_timeout 15 $SMOLVM machine exec --stream --name stream-test-$$ -- sh -c "echo 'stream-line-1' && echo 'stream-line-2' && echo 'done'" 2>&1)
-    [[ $? -eq 124 ]] && { echo "TIMEOUT"; $SMOLVM machine stop --name stream-test-$$ 2>/dev/null; $SMOLVM machine delete stream-test-$$ -f 2>/dev/null; return 1; }
+    [[ $? -eq 124 ]] && { echo "TIMEOUT"; $SMOLVM machine stop --name stream-test-$$ 2>/dev/null; $SMOLVM machine delete --name stream-test-$$ -f 2>/dev/null; return 1; }
 
     [[ "$result" == *"stream-line-1"* ]] && [[ "$result" == *"stream-line-2"* ]] && [[ "$result" == *"done"* ]] || {
         echo "Missing streaming output: $result"
         $SMOLVM machine stop --name stream-test-$$ 2>/dev/null
-        $SMOLVM machine delete stream-test-$$ -f 2>/dev/null
+        $SMOLVM machine delete --name stream-test-$$ -f 2>/dev/null
         return 1
     }
 
     # Cleanup
     $SMOLVM machine stop --name stream-test-$$ 2>/dev/null
-    $SMOLVM machine delete stream-test-$$ -f 2>/dev/null
+    $SMOLVM machine delete --name stream-test-$$ -f 2>/dev/null
 }
 
 test_agent_json_logs() {
     local vm_name="observability-test-$$"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
-    $SMOLVM machine create "$vm_name" 2>&1 || return 1
-    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+    $SMOLVM machine create --name "$vm_name" 2>&1 || return 1
+    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1; }
 
     # Run a command to generate agent log entries
     $SMOLVM machine exec --name "$vm_name" -- echo "observability-test" 2>&1 || true
@@ -425,7 +425,7 @@ test_agent_json_logs() {
     cp "$console_log" "$saved_log" 2>/dev/null || true
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     if [[ ! -s "$saved_log" ]]; then
         echo "Console log not found or empty at $console_log"
@@ -534,20 +534,20 @@ test_docker_in_vm() {
 
     echo "phase: pre-cleanup"
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     # ── Create ────────────────────────────────────────────────────────────────
     echo "phase: create"
     local output
-    output=$($SMOLVM machine create "$vm_name" \
+    output=$($SMOLVM machine create --name "$vm_name" \
         -s "$smolfile" --net-backend virtio-net 2>&1) || {
-        echo "FAIL: machine create failed"
+        echo "FAIL: machine create --name failed"
         echo "$output"
         return 1
     }
     [[ "$output" == *"Init commands: 4"* ]] || {
         echo "FAIL: expected 4 init commands, got: $output"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
 
@@ -556,14 +556,14 @@ test_docker_in_vm() {
     output=$($SMOLVM machine start --name "$vm_name" 2>&1) || {
         echo "FAIL: first machine start failed"
         echo "$output"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
     [[ "$output" == *"Running 4 init command"* ]] || {
         echo "FAIL: expected 4 init commands to run on first start"
         echo "$output"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
 
@@ -573,14 +573,14 @@ test_docker_in_vm() {
         echo "FAIL: dockerd failed to start"
         echo "$output"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
     [[ "$output" == *"dockerd-ready"* ]] || {
         echo "FAIL: dockerd did not report ready"
         echo "$output"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
 
@@ -600,11 +600,11 @@ test_docker_in_vm() {
         echo "FAIL: storage driver or bind-mount check failed"
         echo "$output"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
-    [[ "$output" == *"storage-driver-ok"* ]] || { echo "FAIL: $output"; $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true; $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true; return 1; }
-    [[ "$output" == *"bind-mount-ok"* ]]    || { echo "FAIL: $output"; $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true; $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true; return 1; }
+    [[ "$output" == *"storage-driver-ok"* ]] || { echo "FAIL: $output"; $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true; $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true; return 1; }
+    [[ "$output" == *"bind-mount-ok"* ]]    || { echo "FAIL: $output"; $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true; $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true; return 1; }
 
     # ── Assert: docker run executes a container ───────────────────────────────
     echo "phase: docker-run"
@@ -613,13 +613,13 @@ test_docker_in_vm() {
         echo "FAIL: docker run failed"
         echo "$output"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
     [[ "$output" == *"docker-in-vm-ok"* ]] || {
         echo "FAIL: expected docker-in-vm-ok, got: $output"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
 
@@ -630,13 +630,13 @@ test_docker_in_vm() {
         echo "FAIL: docker bridge networking failed"
         echo "$output"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
     [[ "$output" == *'"url"'* ]] || {
         echo "FAIL: expected JSON response with url field, got: $output"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
 
@@ -650,13 +650,13 @@ test_docker_in_vm() {
         echo "FAIL: docker build or run of built image failed"
         echo "$output"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
     [[ "$output" == *"built-image-run-ok"* ]] || {
         echo "FAIL: expected built-image-run-ok, got: $output"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
 
@@ -664,7 +664,7 @@ test_docker_in_vm() {
     echo "phase: stop"
     $SMOLVM machine stop --name "$vm_name" 2>&1 || {
         echo "FAIL: machine stop failed"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
 
@@ -672,13 +672,13 @@ test_docker_in_vm() {
     output=$($SMOLVM machine start --name "$vm_name" 2>&1) || {
         echo "FAIL: machine restart failed"
         echo "$output"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
     [[ "$output" == *"Init already completed"* ]] || {
         echo "FAIL: init should be skipped on restart, got: $output"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
 
@@ -688,14 +688,14 @@ test_docker_in_vm() {
         echo "FAIL: dockerd failed to start after VM restart"
         echo "$output"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
     [[ "$output" == *"dockerd-ready"* ]] || {
         echo "FAIL: dockerd not ready after VM restart"
         echo "$output"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
 
@@ -711,17 +711,17 @@ test_docker_in_vm() {
         echo "FAIL: post-restart image persistence check failed"
         echo "$output"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
-    [[ "$output" == *"alpine-persists"* ]]      || { echo "FAIL: $output"; $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true; $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true; return 1; }
-    [[ "$output" == *"built-image-persists"* ]] || { echo "FAIL: $output"; $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true; $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true; return 1; }
-    [[ "$output" == *"post-restart-run-ok"* ]]  || { echo "FAIL: $output"; $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true; $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true; return 1; }
+    [[ "$output" == *"alpine-persists"* ]]      || { echo "FAIL: $output"; $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true; $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true; return 1; }
+    [[ "$output" == *"built-image-persists"* ]] || { echo "FAIL: $output"; $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true; $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true; return 1; }
+    [[ "$output" == *"post-restart-run-ok"* ]]  || { echo "FAIL: $output"; $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true; $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true; return 1; }
 
     # ── Cleanup ───────────────────────────────────────────────────────────────
     echo "phase: cleanup"
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 }
 
 
@@ -756,8 +756,8 @@ _EXEC_STDIN_MACHINE="exec-stdin-$$"
 
 test_exec_cat_no_interactive() {
     "$SMOLVM" machine stop --name "$_EXEC_STDIN_MACHINE" 2>/dev/null || true
-    "$SMOLVM" machine delete "$_EXEC_STDIN_MACHINE" -f 2>/dev/null || true
-    "$SMOLVM" machine create "$_EXEC_STDIN_MACHINE" 2>/dev/null || return 1
+    "$SMOLVM" machine delete --name "$_EXEC_STDIN_MACHINE" -f 2>/dev/null || true
+    "$SMOLVM" machine create --name "$_EXEC_STDIN_MACHINE" 2>/dev/null || return 1
     "$SMOLVM" machine start --name "$_EXEC_STDIN_MACHINE" 2>/dev/null || return 1
 
     local out exit_code=0
@@ -765,7 +765,7 @@ test_exec_cat_no_interactive() {
         || exit_code=$?
 
     "$SMOLVM" machine stop --name "$_EXEC_STDIN_MACHINE" 2>/dev/null || true
-    "$SMOLVM" machine delete "$_EXEC_STDIN_MACHINE" -f 2>/dev/null || true
+    "$SMOLVM" machine delete --name "$_EXEC_STDIN_MACHINE" -f 2>/dev/null || true
 
     if echo "$out" | grep -qi "connection closed"; then
         echo "FAIL: got 'connection closed'"
@@ -782,8 +782,8 @@ test_exec_tty_piped_stdin_terminates() {
     # still reach the child. Without EOF propagation a stdin reader (cat)
     # never terminates and the exec session hangs.
     "$SMOLVM" machine stop --name "$_EXEC_STDIN_MACHINE" 2>/dev/null || true
-    "$SMOLVM" machine delete "$_EXEC_STDIN_MACHINE" -f 2>/dev/null || true
-    "$SMOLVM" machine create "$_EXEC_STDIN_MACHINE" 2>/dev/null || return 1
+    "$SMOLVM" machine delete --name "$_EXEC_STDIN_MACHINE" -f 2>/dev/null || true
+    "$SMOLVM" machine create --name "$_EXEC_STDIN_MACHINE" 2>/dev/null || return 1
     "$SMOLVM" machine start --name "$_EXEC_STDIN_MACHINE" 2>/dev/null || return 1
 
     # Newline-terminated input: the PTY line buffer is empty when EOF
@@ -802,7 +802,7 @@ test_exec_tty_piped_stdin_terminates() {
         >/dev/null 2>&1 || exit_code_partial=$?
 
     "$SMOLVM" machine stop --name "$_EXEC_STDIN_MACHINE" 2>/dev/null || true
-    "$SMOLVM" machine delete "$_EXEC_STDIN_MACHINE" -f 2>/dev/null || true
+    "$SMOLVM" machine delete --name "$_EXEC_STDIN_MACHINE" -f 2>/dev/null || true
 
     [[ $exit_code -ne 124 ]] || { echo "FAIL: 'exec --tty -i' with piped stdin timed out (PTY EOF not propagated)"; return 1; }
     [[ $exit_code_partial -ne 124 ]] || { echo "FAIL: 'exec --tty -i' with unterminated stdin timed out (PTY EOF not propagated)"; return 1; }
@@ -818,8 +818,8 @@ _DROP_MACHINE="drop-safe-$$"
 
 test_machine_survives_rapid_exec() {
     "$SMOLVM" machine stop --name "$_DROP_MACHINE" 2>/dev/null || true
-    "$SMOLVM" machine delete "$_DROP_MACHINE" -f 2>/dev/null || true
-    "$SMOLVM" machine create "$_DROP_MACHINE" 2>/dev/null || return 1
+    "$SMOLVM" machine delete --name "$_DROP_MACHINE" -f 2>/dev/null || true
+    "$SMOLVM" machine create --name "$_DROP_MACHINE" 2>/dev/null || return 1
     "$SMOLVM" machine start --name "$_DROP_MACHINE" 2>/dev/null || return 1
 
     local i
@@ -828,13 +828,13 @@ test_machine_survives_rapid_exec() {
         out=$(run_with_timeout 15 "$SMOLVM" machine exec --name "$_DROP_MACHINE" -- echo "alive-$i" 2>/dev/null) \
             || exit_code=$?
         [[ $exit_code -eq 0 ]] || {
-            "$SMOLVM" machine delete "$_DROP_MACHINE" -f 2>/dev/null || true
+            "$SMOLVM" machine delete --name "$_DROP_MACHINE" -f 2>/dev/null || true
             echo "FAIL: exec #$i failed (exit $exit_code)"; return 1
         }
     done
 
     "$SMOLVM" machine stop --name "$_DROP_MACHINE" 2>/dev/null || true
-    "$SMOLVM" machine delete "$_DROP_MACHINE" -f 2>/dev/null || true
+    "$SMOLVM" machine delete --name "$_DROP_MACHINE" -f 2>/dev/null || true
 }
 
 run_test "Drop-safety: machine survives 5 rapid execs" test_machine_survives_rapid_exec || true

--- a/tests/test_machine_image.sh
+++ b/tests/test_machine_image.sh
@@ -23,73 +23,73 @@ test_create_with_image() {
     local vm_name="create-image-test-$$"
 
     # Create with --image (new feature), start, exec, verify, cleanup
-    $SMOLVM machine create "$vm_name" --image alpine:latest --net 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --image alpine:latest --net 2>&1 || return 1
 
     # Should appear in list (use --json for full names)
     $SMOLVM machine ls --json 2>&1 | grep -q "$vm_name" || {
         echo "Machine not in list"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         return 1
     }
 
     # Start — should auto-pull the image
     local start_result
     start_result=$(run_with_timeout 60 $SMOLVM machine start --name "$vm_name" 2>&1)
-    [[ $? -eq 124 ]] && { echo "TIMEOUT on start"; $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+    [[ $? -eq 124 ]] && { echo "TIMEOUT on start"; $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1; }
     [[ "$start_result" == *"Pulling"* ]] || [[ "$start_result" == *"Started"* ]] || [[ "$start_result" == *"already running"* ]] || {
         echo "Start failed: $start_result"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         return 1
     }
 
     # Exec — verify we're in the right image
     local exec_result
     exec_result=$(run_with_timeout 30 $SMOLVM machine exec --name "$vm_name" -- cat /etc/os-release 2>&1)
-    [[ $? -eq 124 ]] && { echo "TIMEOUT on exec"; $SMOLVM machine stop --name "$vm_name" 2>/dev/null; $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+    [[ $? -eq 124 ]] && { echo "TIMEOUT on exec"; $SMOLVM machine stop --name "$vm_name" 2>/dev/null; $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1; }
     [[ "$exec_result" == *"Alpine"* ]] || {
         echo "Not running Alpine: $exec_result"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         return 1
     }
 
     # Cleanup
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
 }
 
 test_create_with_image_and_env() {
     local vm_name="create-env-test-$$"
 
     # Create with --image + env + workdir
-    $SMOLVM machine create "$vm_name" --image alpine:latest --net \
+    $SMOLVM machine create --name "$vm_name" --image alpine:latest --net \
         -e TEST_VAR=from_create -w /tmp 2>&1 || return 1
 
     run_with_timeout 60 $SMOLVM machine start --name "$vm_name" 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         return 1
     }
 
     # Verify workdir was persisted (init commands run in /tmp)
     local pwd_result
     pwd_result=$(run_with_timeout 30 $SMOLVM machine exec --name "$vm_name" -- pwd 2>&1)
-    [[ $? -eq 124 ]] && { echo "TIMEOUT"; $SMOLVM machine stop --name "$vm_name" 2>/dev/null; $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+    [[ $? -eq 124 ]] && { echo "TIMEOUT"; $SMOLVM machine stop --name "$vm_name" 2>/dev/null; $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1; }
 
     # Cleanup
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
 }
 
 test_update_settings_applied_on_start() {
     # Verify update changes cpus, ports, network, and that they take effect.
     # Also verifies update refuses a running VM.
     $SMOLVM machine stop 2>/dev/null || true
-    $SMOLVM machine delete default -f 2>/dev/null || true
-    $SMOLVM machine create default 2>&1 || return 1
+    $SMOLVM machine delete --name default -f 2>/dev/null || true
+    $SMOLVM machine create --name default 2>&1 || return 1
 
     # Update multiple settings at once
     local output
-    output=$($SMOLVM machine update default --cpus 2 --mem 1024 -p 9090:9090 --net 2>&1) || {
+    output=$($SMOLVM machine update --name default --cpus 2 --mem 1024 -p 9090:9090 --net 2>&1) || {
         echo "update failed: $output"; return 1
     }
     [[ "$output" == *"cpus"* ]] || { echo "expected cpus in output: $output"; return 1; }
@@ -102,26 +102,26 @@ test_update_settings_applied_on_start() {
 
     # Update on running VM should fail
     local exit_code=0
-    $SMOLVM machine update default --mem 2048 2>&1 || exit_code=$?
+    $SMOLVM machine update --name default --mem 2048 2>&1 || exit_code=$?
     [[ $exit_code -ne 0 ]] || { echo "update should fail on running VM"; return 1; }
 
     $SMOLVM machine stop 2>/dev/null || true
-    $SMOLVM machine delete default -f 2>/dev/null || true
+    $SMOLVM machine delete --name default -f 2>/dev/null || true
 }
 
 test_update_env_applied_on_start() {
     # Env vars from the DB record are applied in image-based exec.
     $SMOLVM machine stop 2>/dev/null || true
-    $SMOLVM machine delete default -f 2>/dev/null || true
-    $SMOLVM machine create --net --image alpine default 2>&1 || return 1
+    $SMOLVM machine delete --name default -f 2>/dev/null || true
+    $SMOLVM machine create --net --image alpine --name default 2>&1 || return 1
 
-    $SMOLVM machine update default -e MY_VAR=hello 2>&1 || return 1
+    $SMOLVM machine update --name default -e MY_VAR=hello 2>&1 || return 1
 
     $SMOLVM machine start 2>&1 || return 1
     local val
     val=$($SMOLVM machine exec -- sh -c 'echo $MY_VAR' 2>&1)
     $SMOLVM machine stop 2>/dev/null || true
-    $SMOLVM machine delete default -f 2>/dev/null || true
+    $SMOLVM machine delete --name default -f 2>/dev/null || true
 
     [[ "$val" == "hello" ]] || { echo "expected MY_VAR=hello, got: $val"; return 1; }
 }
@@ -129,8 +129,8 @@ test_update_env_applied_on_start() {
 test_exec_image_large_stdout_does_not_crash_vm() {
     # Same test but for image-backed exec (the actual bug path)
     $SMOLVM machine stop 2>/dev/null || true
-    $SMOLVM machine delete default -f 2>/dev/null || true
-    $SMOLVM machine create --net --image alpine default 2>&1 || return 1
+    $SMOLVM machine delete --name default -f 2>/dev/null || true
+    $SMOLVM machine create --net --image alpine --name default 2>&1 || return 1
     $SMOLVM machine start 2>&1 || return 1
 
     local output
@@ -157,13 +157,13 @@ test_exec_image_large_stdout_does_not_crash_vm() {
     }
 
     $SMOLVM machine stop 2>/dev/null || true
-    $SMOLVM machine delete default -f 2>/dev/null || true
+    $SMOLVM machine delete --name default -f 2>/dev/null || true
 }
 
 test_exec_joined_large_stdout_does_not_crash_vm() {
     # Same test but through the joined crun exec path (detached main container)
     $SMOLVM machine stop 2>/dev/null || true
-    $SMOLVM machine delete default -f 2>/dev/null || true
+    $SMOLVM machine delete --name default -f 2>/dev/null || true
     $SMOLVM machine run -d --net --image alpine -- sleep 300 2>&1 || return 1
 
     local output
@@ -190,13 +190,13 @@ test_exec_joined_large_stdout_does_not_crash_vm() {
     }
 
     $SMOLVM machine stop 2>/dev/null || true
-    $SMOLVM machine delete default -f 2>/dev/null || true
+    $SMOLVM machine delete --name default -f 2>/dev/null || true
 }
 
 test_exec_joins_main_container() {
     # machine run -d creates a fresh VM, so no need for ensure_machine_running
     $SMOLVM machine stop 2>/dev/null || true
-    $SMOLVM machine delete default -f 2>/dev/null || true
+    $SMOLVM machine delete --name default -f 2>/dev/null || true
 
     log_info "Starting detached workload: sleep 300..."
     local run_output
@@ -277,7 +277,7 @@ test_ephemeral_run_is_isolated() {
 test_exec_recovers_after_main_container_exits() {
     # Start a detached container with a short-lived command
     $SMOLVM machine stop 2>/dev/null || true
-    $SMOLVM machine delete default -f 2>/dev/null || true
+    $SMOLVM machine delete --name default -f 2>/dev/null || true
     $SMOLVM machine run -d --net --image alpine -- sleep 2 2>&1 || return 1
 
     # Wait for the main container to exit naturally
@@ -307,7 +307,7 @@ test_exec_join_timeout_does_not_kill_main_container() {
     ps_before=$(run_with_timeout 10 $SMOLVM machine exec -- ps -ef 2>&1) || true
     if ! echo "$ps_before" | grep -q "sleep"; then
         $SMOLVM machine stop 2>/dev/null || true
-        $SMOLVM machine delete default -f 2>/dev/null || true
+        $SMOLVM machine delete --name default -f 2>/dev/null || true
         $SMOLVM machine run -d --net --image alpine -- sleep 300 2>&1 || return 1
     fi
 
@@ -346,7 +346,7 @@ test_exec_join_documents_user_behavior() {
     # Document current crun exec user behavior for images with a non-root USER.
     # Some crun versions may run joined exec as root unless --user is explicit.
     $SMOLVM machine stop 2>/dev/null || true
-    $SMOLVM machine delete default -f 2>/dev/null || true
+    $SMOLVM machine delete --name default -f 2>/dev/null || true
     $SMOLVM machine run -d --net --image nginxinc/nginx-unprivileged:stable-alpine -- sleep 300 2>&1 || {
         echo "SKIP: could not start nginx-unprivileged image"
         return 0

--- a/tests/test_machine_packed.sh
+++ b/tests/test_machine_packed.sh
@@ -33,12 +33,12 @@ test_create_from_smolmachine() {
     [[ -f "$pack_output.smolmachine" ]] || { echo "FAIL: no sidecar"; return 1; }
 
     # 2. Create a named machine from it
-    $SMOLVM machine create "$vm_name" --from "$pack_output.smolmachine" 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --from "$pack_output.smolmachine" 2>&1 || return 1
 
     # 3. Start the machine (should NOT pull — uses extracted layers)
     $SMOLVM machine start --name "$vm_name" 2>&1 || {
         echo "FAIL: start failed"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; rm -rf "$tmpdir"; return 1
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; rm -rf "$tmpdir"; return 1
     }
 
     # 4. Exec works
@@ -47,7 +47,7 @@ test_create_from_smolmachine() {
     [[ "$exec_result" == *"from-sm-ok"* ]] || {
         echo "FAIL: exec failed: $exec_result"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; rm -rf "$tmpdir"; return 1
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; rm -rf "$tmpdir"; return 1
     }
 
     # 5. Persistence: write then read
@@ -57,32 +57,32 @@ test_create_from_smolmachine() {
     [[ "$read_result" == *"persist"* ]] || {
         echo "FAIL: persistence failed"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; rm -rf "$tmpdir"; return 1
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; rm -rf "$tmpdir"; return 1
     }
 
     # 6. Stop and restart — persistence survives
     $SMOLVM machine stop --name "$vm_name" 2>&1 || true
     $SMOLVM machine start --name "$vm_name" 2>&1 || {
         echo "FAIL: restart failed"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; rm -rf "$tmpdir"; return 1
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; rm -rf "$tmpdir"; return 1
     }
     read_result=$($SMOLVM machine exec --name "$vm_name" -- cat /tmp/sm.txt 2>&1)
     [[ "$read_result" == *"persist"* ]] || {
         echo "FAIL: persistence across restart failed"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; rm -rf "$tmpdir"; return 1
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; rm -rf "$tmpdir"; return 1
     }
 
     # 7. Shows in ls
     $SMOLVM machine ls --json 2>&1 | grep -q "$vm_name" || {
         echo "FAIL: not in ls"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; rm -rf "$tmpdir"; return 1
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; rm -rf "$tmpdir"; return 1
     }
 
     # 8. Cleanup
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     rm -rf "$tmpdir"
 }
 
@@ -92,36 +92,36 @@ test_cp_preserves_state_on_packed_vm() {
     pack_dir=$(mktemp -d)
 
     # Create source VM, write marker, pack it
-    $SMOLVM machine create "cp-pack-src-$$" --image alpine:latest --net 2>&1 || return 1
+    $SMOLVM machine create --name "cp-pack-src-$$" --image alpine:latest --net 2>&1 || return 1
     $SMOLVM machine start --name "cp-pack-src-$$" 2>&1 || {
-        $SMOLVM machine delete "cp-pack-src-$$" -f 2>/dev/null; return 1
+        $SMOLVM machine delete --name "cp-pack-src-$$" -f 2>/dev/null; return 1
     }
     $SMOLVM machine exec --name "cp-pack-src-$$" -- sh -c 'echo marker > /etc/pack-marker' 2>&1
     $SMOLVM machine stop --name "cp-pack-src-$$" 2>&1
     $SMOLVM pack create --from-vm "cp-pack-src-$$" -o "$pack_dir/packed" 2>&1 || {
-        $SMOLVM machine delete "cp-pack-src-$$" -f 2>/dev/null; rm -rf "$pack_dir"; return 1
+        $SMOLVM machine delete --name "cp-pack-src-$$" -f 2>/dev/null; rm -rf "$pack_dir"; return 1
     }
-    $SMOLVM machine delete "cp-pack-src-$$" -f 2>/dev/null
+    $SMOLVM machine delete --name "cp-pack-src-$$" -f 2>/dev/null
 
     # Create destination from pack, start, mutate via exec
-    $SMOLVM machine create "$vm_name" --from "$pack_dir/packed.smolmachine" --net 2>&1 || {
+    $SMOLVM machine create --name "$vm_name" --from "$pack_dir/packed.smolmachine" --net 2>&1 || {
         rm -rf "$pack_dir"; return 1
     }
     $SMOLVM machine start --name "$vm_name" 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; rm -rf "$pack_dir"; return 1
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; rm -rf "$pack_dir"; return 1
     }
     $SMOLVM machine exec --name "$vm_name" -- adduser -D alice 2>&1
 
     # Verify alice exists before cp
     local before
     before=$($SMOLVM machine exec --name "$vm_name" -- id alice 2>&1) || {
-        echo "alice not found before cp"; $SMOLVM machine delete "$vm_name" -f 2>/dev/null; rm -rf "$pack_dir"; return 1
+        echo "alice not found before cp"; $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; rm -rf "$pack_dir"; return 1
     }
 
     # Run cp
     echo "probe" > "$pack_dir/probe.txt"
     $SMOLVM machine cp "$pack_dir/probe.txt" "$vm_name":/tmp/probe.txt 2>&1 || {
-        echo "cp failed"; $SMOLVM machine delete "$vm_name" -f 2>/dev/null; rm -rf "$pack_dir"; return 1
+        echo "cp failed"; $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; rm -rf "$pack_dir"; return 1
     }
 
     # Verify alice STILL exists after cp
@@ -129,7 +129,7 @@ test_cp_preserves_state_on_packed_vm() {
     after=$($SMOLVM machine exec --name "$vm_name" -- id alice 2>&1) || {
         echo "FAIL: alice gone after cp"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         rm -rf "$pack_dir"
         return 1
     }
@@ -140,13 +140,13 @@ test_cp_preserves_state_on_packed_vm() {
     [[ "$probe" == *"probe"* ]] || {
         echo "FAIL: probe file missing after cp"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         rm -rf "$pack_dir"
         return 1
     }
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
     rm -rf "$pack_dir"
 }
 

--- a/tests/test_machine_run.sh
+++ b/tests/test_machine_run.sh
@@ -147,14 +147,14 @@ test_machine_run_image_default_user() {
 
 test_machine_run_detached() {
     $SMOLVM machine stop 2>/dev/null || true
-    $SMOLVM machine delete default -f 2>/dev/null || true
+    $SMOLVM machine delete --name default -f 2>/dev/null || true
 
     local run_output exit_code=0
     run_output=$($SMOLVM machine run -d --net --image alpine:latest 2>&1) || exit_code=$?
 
     if [[ $exit_code -ne 0 ]]; then
         $SMOLVM machine stop 2>/dev/null || true
-        $SMOLVM machine delete default -f 2>/dev/null || true
+        $SMOLVM machine delete --name default -f 2>/dev/null || true
         echo "Setup failed: machine run -d returned $exit_code: $run_output"
         return 1
     fi
@@ -164,7 +164,7 @@ test_machine_run_detached() {
     list_output=$($SMOLVM machine ls --json 2>&1)
 
     $SMOLVM machine stop 2>/dev/null || true
-    $SMOLVM machine delete default -f 2>/dev/null || true
+    $SMOLVM machine delete --name default -f 2>/dev/null || true
 
     [[ "$list_output" == *'"name": "default"'* ]] && \
     [[ "$list_output" == *'"state": "running"'* ]]
@@ -172,7 +172,7 @@ test_machine_run_detached() {
 
 test_machine_run_detached_with_command() {
     $SMOLVM machine stop 2>/dev/null || true
-    $SMOLVM machine delete default -f 2>/dev/null || true
+    $SMOLVM machine delete --name default -f 2>/dev/null || true
 
     local run_output exit_code=0
     run_output=$($SMOLVM machine run -d --net --image alpine:latest -- \
@@ -180,7 +180,7 @@ test_machine_run_detached_with_command() {
 
     if [[ $exit_code -ne 0 ]]; then
         $SMOLVM machine stop 2>/dev/null || true
-        $SMOLVM machine delete default -f 2>/dev/null || true
+        $SMOLVM machine delete --name default -f 2>/dev/null || true
         echo "Setup failed: machine run -d returned $exit_code: $run_output"
         return 1
     fi
@@ -194,7 +194,7 @@ test_machine_run_detached_with_command() {
     done
 
     $SMOLVM machine stop 2>/dev/null || true
-    $SMOLVM machine delete default -f 2>/dev/null || true
+    $SMOLVM machine delete --name default -f 2>/dev/null || true
 
     if [[ "$file_output" != *"issue198_fixed"* ]]; then
         echo "FAIL: command was not executed by 'machine run -d --image X -- cmd'"
@@ -264,7 +264,7 @@ test_machine_run_detached_volume_workspace() {
     echo "detached-workspace-marker" > "$tmpdir/probe.txt"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     local run_output exit_code=0
     run_output=$(run_with_timeout 120 $SMOLVM machine run -d --net \
@@ -275,7 +275,7 @@ test_machine_run_detached_volume_workspace() {
     if [[ $exit_code -ne 0 ]]; then
         echo "FAIL: machine run -d failed: $run_output"
         rm -rf "$tmpdir"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     fi
 
@@ -284,13 +284,13 @@ test_machine_run_detached_volume_workspace() {
     exec_out=$(run_with_timeout 30 $SMOLVM machine exec --name "$vm_name" -- cat /workspace/probe.txt 2>&1) || {
         echo "FAIL: exec failed: $exec_out"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         rm -rf "$tmpdir"
         return 1
     }
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     rm -rf "$tmpdir"
 
     if ! echo "$exec_out" | grep -q "detached-workspace-marker"; then
@@ -304,7 +304,7 @@ test_machine_start_restores_workload() {
     local vm_name="start-restores-workload-$$"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     # Create persistent VM with a long-running workload
     local run_output exit_code=0
@@ -320,27 +320,27 @@ test_machine_start_restores_workload() {
     ps_before=$(run_with_timeout 30 $SMOLVM machine exec --name "$vm_name" -- ps -ef 2>&1) || {
         echo "FAIL: exec before stop failed: $ps_before"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
     if ! echo "$ps_before" | grep -q "sleep"; then
         echo "FAIL: expected 'sleep infinity' in ps before stop, got:"
         echo "$ps_before"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     fi
 
     # Stop and restart
     $SMOLVM machine stop --name "$vm_name" 2>&1 || {
         echo "FAIL: machine stop failed"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
     local start_output
     start_output=$(run_with_timeout 120 $SMOLVM machine start --name "$vm_name" 2>&1) || {
         echo "FAIL: machine start failed: $start_output"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
 
@@ -349,7 +349,7 @@ test_machine_start_restores_workload() {
     ps_after=$(run_with_timeout 30 $SMOLVM machine exec --name "$vm_name" -- ps -ef 2>&1) || {
         echo "FAIL: exec after restart failed: $ps_after"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
     if ! echo "$ps_after" | grep -q "sleep"; then
@@ -359,19 +359,19 @@ test_machine_start_restores_workload() {
         echo "ps after restart:"
         echo "$ps_after"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     fi
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 }
 
 test_machine_start_restores_workload_smolfile() {
     local vm_name="start-restores-sf-$$"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     local tmpdir
     tmpdir=$(mktemp -d)
@@ -393,7 +393,7 @@ EOF
 
     if [[ $exit_code -ne 0 ]]; then
         echo "FAIL: machine run -d -s Smolfile.toml failed: $run_output"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     fi
 
@@ -402,27 +402,27 @@ EOF
     ps_before=$(run_with_timeout 30 $SMOLVM machine exec --name "$vm_name" -- ps -ef 2>&1) || {
         echo "FAIL: exec before stop failed: $ps_before"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
     if ! echo "$ps_before" | grep -q "sleep"; then
         echo "FAIL: expected 'sleep infinity' in ps before stop, got:"
         echo "$ps_before"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     fi
 
     # Stop and restart
     $SMOLVM machine stop --name "$vm_name" 2>&1 || {
         echo "FAIL: machine stop failed"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
     local start_output
     start_output=$(run_with_timeout 120 $SMOLVM machine start --name "$vm_name" 2>&1) || {
         echo "FAIL: machine start failed: $start_output"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
 
@@ -431,7 +431,7 @@ EOF
     ps_after=$(run_with_timeout 30 $SMOLVM machine exec --name "$vm_name" -- ps -ef 2>&1) || {
         echo "FAIL: exec after restart failed: $ps_after"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
     if ! echo "$ps_after" | grep -q "sleep"; then
@@ -441,12 +441,12 @@ EOF
         echo "ps after restart:"
         echo "$ps_after"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     fi
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 }
 
 test_machine_run_timeout() {
@@ -508,13 +508,13 @@ test_ephemeral_shows_in_list_while_running() {
     echo "$list_result" | grep -q "$name" || {
         echo "Detached run not in list: $list_result"
         $SMOLVM machine stop --name "$name" 2>/dev/null || true
-        $SMOLVM machine delete "$name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$name" -f 2>/dev/null || true
         return 1
     }
 
     # Clean up
     $SMOLVM machine stop --name "$name" 2>/dev/null || true
-    $SMOLVM machine delete "$name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$name" -f 2>/dev/null || true
 }
 
 test_run_no_command_errors() {
@@ -572,17 +572,17 @@ test_init_skipped_on_restart() {
     local vm_name="init-skip-$$"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     # Create with init command and start — first boot should run init
-    $SMOLVM machine create "$vm_name" --net --init "echo INIT_RAN" 2>&1
+    $SMOLVM machine create --name "$vm_name" --net --init "echo INIT_RAN" 2>&1
     local first_start
     first_start=$($SMOLVM machine start --name "$vm_name" 2>&1)
     echo "$first_start"
 
     if [[ "$first_start" != *"Running 1 init command"* ]]; then
         echo "FAIL: first start should run init"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     fi
 
@@ -593,7 +593,7 @@ test_init_skipped_on_restart() {
     echo "$second_start"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     if [[ "$second_start" == *"Running"*"init command"* ]]; then
         echo "FAIL: second start should NOT re-run init"

--- a/tests/test_network.sh
+++ b/tests/test_network.sh
@@ -69,11 +69,11 @@ test_machine_network_disabled_by_default() {
 
     # Clean up any existing
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     # Create VM without --net (network disabled by default)
-    $SMOLVM machine create "$vm_name" 2>&1 || return 1
-    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+    $SMOLVM machine create --name "$vm_name" 2>&1 || return 1
+    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1; }
 
     # DNS resolution should fail when network is disabled
     local exit_code=0
@@ -81,7 +81,7 @@ test_machine_network_disabled_by_default() {
 
     # Clean up
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     ensure_data_dir_deleted "$vm_name"
 
     # Should fail (non-zero exit code) because network is disabled
@@ -93,11 +93,11 @@ test_machine_network_dns_resolution() {
 
     # Clean up any existing
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     # Create VM with --net (network enabled)
-    $SMOLVM machine create "$vm_name" --net 2>&1 || return 1
-    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+    $SMOLVM machine create --name "$vm_name" --net 2>&1 || return 1
+    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1; }
 
     # Test DNS resolution
     local output exit_code=0
@@ -105,7 +105,7 @@ test_machine_network_dns_resolution() {
 
     # Clean up
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     ensure_data_dir_deleted "$vm_name"
 
     # Should succeed and contain resolved address info
@@ -117,11 +117,11 @@ test_machine_network_multiple_dns_lookups() {
 
     # Clean up any existing
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     # Create VM with --net (network enabled)
-    $SMOLVM machine create "$vm_name" --net 2>&1 || return 1
-    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+    $SMOLVM machine create --name "$vm_name" --net 2>&1 || return 1
+    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1; }
 
     # Test multiple DNS lookups
     local output exit_code=0
@@ -129,7 +129,7 @@ test_machine_network_multiple_dns_lookups() {
 
     # Clean up
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     ensure_data_dir_deleted "$vm_name"
 
     # Should succeed and contain addresses for both
@@ -140,18 +140,18 @@ test_machine_egress_allow_cidr_permitted() {
     local vm_name="egress-allow-test-$$"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     # Create VM allowing only Cloudflare DNS
-    $SMOLVM machine create "$vm_name" --allow-cidr 1.1.1.1/32 2>&1 || return 1
-    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+    $SMOLVM machine create --name "$vm_name" --allow-cidr 1.1.1.1/32 2>&1 || return 1
+    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1; }
 
     # DNS lookup to allowed IP should succeed
     local output exit_code=0
     output=$($SMOLVM machine exec --name "$vm_name" -- nslookup cloudflare.com 1.1.1.1 2>&1) || exit_code=$?
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     ensure_data_dir_deleted "$vm_name"
 
     [[ $exit_code -eq 0 ]] && [[ "$output" == *"Address"* ]]
@@ -161,19 +161,19 @@ test_machine_egress_allow_cidr_blocked() {
     local vm_name="egress-block-test-$$"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     # Create VM allowing only a private range. ensure_dns_in_cidrs also
     # auto-adds the host's DNS resolver so the VM can still resolve names.
-    $SMOLVM machine create "$vm_name" --allow-cidr 10.0.0.0/8 2>&1 || return 1
-    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+    $SMOLVM machine create --name "$vm_name" --allow-cidr 10.0.0.0/8 2>&1 || return 1
+    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1; }
 
     # A destination outside 10.0.0.0/8 (and not the auto-added resolver) blocked.
     local blocked_rc=0
     assert_egress_blocked "$vm_name" || blocked_rc=1
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     ensure_data_dir_deleted "$vm_name"
 
     [[ $blocked_rc -eq 0 ]]
@@ -183,17 +183,17 @@ test_machine_egress_outbound_localhost_only() {
     local vm_name="egress-localhost-test-$$"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
-    $SMOLVM machine create "$vm_name" --outbound-localhost-only 2>&1 || return 1
-    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+    $SMOLVM machine create --name "$vm_name" --outbound-localhost-only 2>&1 || return 1
+    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1; }
 
     # Loopback-only egress: every external destination must be blocked.
     local blocked_rc=0
     assert_egress_blocked "$vm_name" || blocked_rc=1
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     ensure_data_dir_deleted "$vm_name"
 
     [[ $blocked_rc -eq 0 ]]
@@ -202,9 +202,9 @@ test_machine_egress_outbound_localhost_only() {
 test_machine_egress_invalid_cidr_rejected() {
     local vm_name="egress-invalid-test-$$"
     local output exit_code=0
-    output=$($SMOLVM machine create "$vm_name" --allow-cidr "not-a-cidr" 2>&1) || exit_code=$?
+    output=$($SMOLVM machine create --name "$vm_name" --allow-cidr "not-a-cidr" 2>&1) || exit_code=$?
 
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     [[ $exit_code -ne 0 ]] && [[ "$output" == *"invalid"* ]]
 }
@@ -213,18 +213,18 @@ test_machine_egress_allow_host_permitted() {
     local vm_name="egress-host-allow-test-$$"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     # Create VM allowing only one.one.one.one (resolves to 1.1.1.1)
-    $SMOLVM machine create "$vm_name" --allow-host one.one.one.one 2>&1 || return 1
-    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+    $SMOLVM machine create --name "$vm_name" --allow-host one.one.one.one 2>&1 || return 1
+    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1; }
 
     # DNS lookup to allowed host's IP should succeed
     local output exit_code=0
     output=$($SMOLVM machine exec --name "$vm_name" -- nslookup cloudflare.com 1.1.1.1 2>&1) || exit_code=$?
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     ensure_data_dir_deleted "$vm_name"
 
     [[ $exit_code -eq 0 ]] && [[ "$output" == *"Address"* ]]
@@ -234,18 +234,18 @@ test_machine_egress_allow_host_blocked() {
     local vm_name="egress-host-block-test-$$"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     # Create VM allowing only one.one.one.one. A host outside the allowlist
     # (and not the auto-added resolver) must be blocked.
-    $SMOLVM machine create "$vm_name" --allow-host one.one.one.one 2>&1 || return 1
-    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+    $SMOLVM machine create --name "$vm_name" --allow-host one.one.one.one 2>&1 || return 1
+    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1; }
 
     local blocked_rc=0
     assert_egress_blocked "$vm_name" || blocked_rc=1
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     ensure_data_dir_deleted "$vm_name"
 
     [[ $blocked_rc -eq 0 ]]
@@ -254,9 +254,9 @@ test_machine_egress_allow_host_blocked() {
 test_machine_egress_allow_host_invalid_rejected() {
     local vm_name="egress-host-invalid-test-$$"
     local output exit_code=0
-    output=$($SMOLVM machine create "$vm_name" --allow-host "this-does-not-exist.invalid" 2>&1) || exit_code=$?
+    output=$($SMOLVM machine create --name "$vm_name" --allow-host "this-does-not-exist.invalid" 2>&1) || exit_code=$?
 
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     # Should fail with a resolution error (hard error, not warning)
     [[ $exit_code -ne 0 ]] && [[ "$output" == *"failed to resolve"* ]]
@@ -265,9 +265,9 @@ test_machine_egress_allow_host_invalid_rejected() {
 test_machine_egress_allow_host_port_rejected() {
     local vm_name="egress-host-port-test-$$"
     local output exit_code=0
-    output=$($SMOLVM machine create "$vm_name" --allow-host "example.com:443" 2>&1) || exit_code=$?
+    output=$($SMOLVM machine create --name "$vm_name" --allow-host "example.com:443" 2>&1) || exit_code=$?
 
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     # Should fail — port suffixes are not supported
     [[ $exit_code -ne 0 ]] && [[ "$output" == *"port suffixes are not supported"* ]]
@@ -277,11 +277,11 @@ test_machine_dns_filter_blocks_resolution() {
     local vm_name="dns-filter-test-$$"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     # Create VM allowing only one.one.one.one
-    $SMOLVM machine create "$vm_name" --allow-host one.one.one.one 2>&1 || return 1
-    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+    $SMOLVM machine create --name "$vm_name" --allow-host one.one.one.one 2>&1 || return 1
+    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1; }
 
     # Resolving an allowed domain should work
     local exit_code_allowed=0
@@ -293,7 +293,7 @@ test_machine_dns_filter_blocks_resolution() {
     $SMOLVM machine exec --name "$vm_name" -- nslookup attacker-test.example 2>&1 || exit_code_blocked=$?
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     ensure_data_dir_deleted "$vm_name"
 
     [[ $exit_code_allowed -eq 0 ]] && [[ $exit_code_blocked -ne 0 ]]
@@ -334,11 +334,11 @@ test_dns_filter_tcp_allowed() {
     local vm_name="dns-tcp-allowed-$$"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
-    $SMOLVM machine create "$vm_name" --allow-host one.one.one.one 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --allow-host one.one.one.one 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 \
-        || { $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+        || { $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1; }
 
     # Minimal A query for "one.one.one.one" (33 DNS bytes = 0x21).
     # TCP DNS framing: 2-byte BE length prefix + raw DNS query.
@@ -349,7 +349,7 @@ test_dns_filter_tcp_allowed() {
         '\x00\x21\x12\x34\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\x03one\x03one\x03one\x03one\x00\x00\x01\x00\x01')
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     ensure_data_dir_deleted "$vm_name"
 
     [[ "$rcode" -eq 0 ]] || { echo "FAIL: expected RCODE=0 (NOERROR), got RCODE=$rcode"; return 1; }
@@ -359,11 +359,11 @@ test_dns_filter_tcp_blocked() {
     local vm_name="dns-tcp-blocked-$$"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
-    $SMOLVM machine create "$vm_name" --allow-host one.one.one.one 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --allow-host one.one.one.one 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 \
-        || { $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+        || { $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1; }
 
     # A query for "attacker.invalid" (34 DNS bytes = 0x22).
     # Name: \x08attacker (9 bytes) + \x07invalid (8 bytes) + \x00 (1 byte) = 18 bytes.
@@ -373,7 +373,7 @@ test_dns_filter_tcp_blocked() {
         '\x00\x22\x12\x34\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\x08attacker\x07invalid\x00\x00\x01\x00\x01')
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     ensure_data_dir_deleted "$vm_name"
 
     [[ "$rcode" -eq 3 ]] || { echo "FAIL: expected RCODE=3 (NXDOMAIN), got RCODE=$rcode"; return 1; }
@@ -383,27 +383,27 @@ test_machine_allow_host_persists_across_restart() {
     local vm_name="dns-persist-test-$$"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     # Create with --allow-host, start, stop, start again
-    $SMOLVM machine create "$vm_name" --allow-host one.one.one.one 2>&1 || return 1
-    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+    $SMOLVM machine create --name "$vm_name" --allow-host one.one.one.one 2>&1 || return 1
+    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1; }
 
     # Verify egress works
     local exit_code=0
     $SMOLVM machine exec --name "$vm_name" -- nslookup one.one.one.one 1.1.1.1 2>&1 || exit_code=$?
-    [[ $exit_code -ne 0 ]] && { $SMOLVM machine stop --name "$vm_name" 2>/dev/null; $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+    [[ $exit_code -ne 0 ]] && { $SMOLVM machine stop --name "$vm_name" 2>/dev/null; $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1; }
 
     # Stop and restart — config should persist from VmRecord
     $SMOLVM machine stop --name "$vm_name" 2>&1 || return 1
-    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1; }
 
     # Egress restriction must still hold after the restart.
     local blocked_rc=0
     assert_egress_blocked "$vm_name" || blocked_rc=1
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     ensure_data_dir_deleted "$vm_name"
 
     [[ $blocked_rc -eq 0 ]]
@@ -419,7 +419,7 @@ test_smolfile_allow_hosts_stale_cidr_regression() {
     fi
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     local tmpdir
     tmpdir=$(mktemp -d)
@@ -433,7 +433,7 @@ EOF
 
     (
         cd "$tmpdir"
-        $SMOLVM machine create "$vm_name" -s Smolfile.toml 2>&1
+        $SMOLVM machine create --name "$vm_name" -s Smolfile.toml 2>&1
     ) || { rm -rf "$tmpdir"; return 1; }
 
     # Determine DB path (matches SmolvmDb::default_path logic)
@@ -451,11 +451,11 @@ EOF
     # CAST both ways: TEXT for JSON manipulation, then back to BLOB for storage.
     sqlite3 "$db_path" \
         "UPDATE vms SET data = CAST(json_set(CAST(data AS TEXT), '$.allowed_cidrs', json('[\"192.0.2.0/24\"]')) AS BLOB) WHERE name = '$vm_name'" \
-        2>&1 || { echo "sqlite3 update failed"; rm -rf "$tmpdir"; $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+        2>&1 || { echo "sqlite3 update failed"; rm -rf "$tmpdir"; $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1; }
 
     # Start — fix must re-resolve allow_hosts and override the stale CIDRs
     $SMOLVM machine start --name "$vm_name" 2>&1 \
-        || { rm -rf "$tmpdir"; $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+        || { rm -rf "$tmpdir"; $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1; }
 
     # Probe egress using 1.0.0.1 as the resolver — also a valid IP for
     # one.one.one.one, but NOT auto-added by ensure_dns_in_cidrs (which only
@@ -465,8 +465,8 @@ EOF
     $SMOLVM machine exec --name "$vm_name" -- nslookup one.one.one.one 1.0.0.1 2>&1 || exit_code=$?
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
-    # Fallback: if machine delete failed due to a corrupt DB row (e.g. from a
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
+    # Fallback: if machine delete --name failed due to a corrupt DB row (e.g. from a
     # botched sqlite3 update), remove the row directly so it doesn't poison
     # subsequent test runs that scan all rows.
     sqlite3 "$db_path" "DELETE FROM vms WHERE name = '$vm_name'" 2>/dev/null || true
@@ -480,7 +480,7 @@ test_smolfile_allow_hosts_egress_basic() {
     local vm_name="allow-hosts-sf-basic-$$"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     local tmpdir
     tmpdir=$(mktemp -d)
@@ -492,11 +492,11 @@ EOF
 
     (
         cd "$tmpdir"
-        $SMOLVM machine create "$vm_name" -s Smolfile.toml 2>&1
+        $SMOLVM machine create --name "$vm_name" -s Smolfile.toml 2>&1
     ) || { rm -rf "$tmpdir"; return 1; }
 
     $SMOLVM machine start --name "$vm_name" 2>&1 \
-        || { rm -rf "$tmpdir"; $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+        || { rm -rf "$tmpdir"; $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1; }
 
     # Probe 1: 1.1.1.1 — always in the egress policy via ensure_dns_in_cidrs.
     # Verifies the policy doesn't block what it should allow, but does NOT
@@ -516,7 +516,7 @@ EOF
     assert_egress_blocked "$vm_name" || blocked_rc=1
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     rm -rf "$tmpdir"
     ensure_data_dir_deleted "$vm_name"
 
@@ -528,7 +528,7 @@ test_egress_refresh_thread_stability() {
     local vm_name="egress-refresh-smoke-$$"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     local tmpdir
     tmpdir=$(mktemp -d)
@@ -540,13 +540,13 @@ EOF
 
     (
         cd "$tmpdir"
-        $SMOLVM machine create "$vm_name" -s Smolfile.toml 2>&1
+        $SMOLVM machine create --name "$vm_name" -s Smolfile.toml 2>&1
     ) || { rm -rf "$tmpdir"; return 1; }
 
     # Start with a 10-second refresh interval so the thread fires twice during
     # the test window without making the test slow.
     SMOLVM_EGRESS_REFRESH_SECS=10 $SMOLVM machine start --name "$vm_name" 2>&1 \
-        || { rm -rf "$tmpdir"; $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+        || { rm -rf "$tmpdir"; $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1; }
 
     # Verify egress works immediately after start.
     local exit_code_before=0
@@ -564,7 +564,7 @@ EOF
         || exit_code_after=$?
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     rm -rf "$tmpdir"
     ensure_data_dir_deleted "$vm_name"
 

--- a/tests/test_pack.sh
+++ b/tests/test_pack.sh
@@ -634,11 +634,11 @@ FROM_VM_OUTPUT="$TEST_DIR/test-from-vm"
 test_from_vm_setup() {
     # Create a named VM with network, install a package, then stop it
     $SMOLVM machine stop --name "$FROM_VM_NAME" 2>/dev/null || true
-    $SMOLVM machine delete "$FROM_VM_NAME" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$FROM_VM_NAME" -f 2>/dev/null || true
 
-    $SMOLVM machine create "$FROM_VM_NAME" --net 2>&1 || return 1
+    $SMOLVM machine create --name "$FROM_VM_NAME" --net 2>&1 || return 1
     $SMOLVM machine start --name "$FROM_VM_NAME" 2>&1 || {
-        $SMOLVM machine delete "$FROM_VM_NAME" -f 2>/dev/null
+        $SMOLVM machine delete --name "$FROM_VM_NAME" -f 2>/dev/null
         return 1
     }
 
@@ -652,12 +652,12 @@ test_from_vm_setup() {
     local which_output
     which_output=$($SMOLVM machine exec --name "$FROM_VM_NAME" -- which curl 2>&1) || {
         $SMOLVM machine stop --name "$FROM_VM_NAME" 2>/dev/null || true
-        $SMOLVM machine delete "$FROM_VM_NAME" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$FROM_VM_NAME" -f 2>/dev/null || true
         return 1
     }
     [[ "$which_output" == *"/usr/bin/curl"* ]] || {
         $SMOLVM machine stop --name "$FROM_VM_NAME" 2>/dev/null || true
-        $SMOLVM machine delete "$FROM_VM_NAME" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$FROM_VM_NAME" -f 2>/dev/null || true
         return 1
     }
 
@@ -669,11 +669,11 @@ test_from_vm_rejects_running() {
     # --from-vm should fail if the VM is still running
     local vm_name="pack-running-test-$$"
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
-    $SMOLVM machine create "$vm_name" 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         return 1
     }
 
@@ -682,7 +682,7 @@ test_from_vm_rejects_running() {
 
     # Clean up
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     [[ $exit_code -ne 0 ]]
 }
@@ -714,7 +714,7 @@ test_from_vm_run_finds_installed_package() {
 
 test_from_vm_cleanup() {
     $SMOLVM machine stop --name "$FROM_VM_NAME" 2>/dev/null || true
-    $SMOLVM machine delete "$FROM_VM_NAME" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$FROM_VM_NAME" -f 2>/dev/null || true
     rm -f "$FROM_VM_OUTPUT" "$FROM_VM_OUTPUT.smolmachine"
     return 0
 }
@@ -737,16 +737,16 @@ test_from_vm_image_overlay() {
 
     # Cleanup any leftovers
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     $SMOLVM machine stop --name "$machine_name" 2>/dev/null || true
-    $SMOLVM machine delete "$machine_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$machine_name" -f 2>/dev/null || true
     rm -f "$pack_output" "$pack_output.smolmachine"
 
     # 1. Create image-based VM, install curl, verify, stop
     echo "  Step 1: Create image-based VM and install curl..."
-    $SMOLVM machine create "$vm_name" --image alpine:latest --net 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --image alpine:latest --net 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1
     }
     $SMOLVM machine exec --name "$vm_name" -- apk add --no-cache curl 2>&1 || true
     local which_result
@@ -754,7 +754,7 @@ test_from_vm_image_overlay() {
     [[ "$which_result" == *"/usr/bin/curl"* ]] || {
         echo "FAIL: curl not installed in source VM"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1
     }
     $SMOLVM machine stop --name "$vm_name" 2>&1 || return 1
 
@@ -762,11 +762,11 @@ test_from_vm_image_overlay() {
     echo "  Step 2: Pack image-based VM with --from-vm..."
     $SMOLVM pack create --from-vm "$vm_name" -o "$pack_output" 2>&1 || {
         echo "FAIL: pack --from-vm failed"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1
     }
     [[ -f "$pack_output.smolmachine" ]] || {
         echo "FAIL: no .smolmachine sidecar produced"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1
     }
 
     # 3. Run packed binary — curl must be present
@@ -775,21 +775,21 @@ test_from_vm_image_overlay() {
     run_result=$(run_with_timeout 60 $SMOLVM pack run --sidecar "$pack_output.smolmachine" -- which curl 2>&1)
     [[ "$run_result" == *"/usr/bin/curl"* ]] || {
         echo "FAIL: curl not found in packed binary (got: $run_result)"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         rm -f "$pack_output" "$pack_output.smolmachine"; return 1
     }
 
     # 4. Create machine from .smolmachine — curl must be present
     echo "  Step 4: Create machine from .smolmachine and verify curl..."
-    $SMOLVM machine create "$machine_name" --from "$pack_output.smolmachine" --net 2>&1 || {
+    $SMOLVM machine create --name "$machine_name" --from "$pack_output.smolmachine" --net 2>&1 || {
         echo "FAIL: machine create --from failed"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         rm -f "$pack_output" "$pack_output.smolmachine"; return 1
     }
     $SMOLVM machine start --name "$machine_name" 2>&1 || {
         echo "FAIL: machine start failed"
-        $SMOLVM machine delete "$machine_name" -f 2>/dev/null
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$machine_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         rm -f "$pack_output" "$pack_output.smolmachine"; return 1
     }
     local exec_result
@@ -797,8 +797,8 @@ test_from_vm_image_overlay() {
     [[ "$exec_result" == *"/usr/bin/curl"* ]] || {
         echo "FAIL: curl not found in machine from .smolmachine (got: $exec_result)"
         $SMOLVM machine stop --name "$machine_name" 2>/dev/null
-        $SMOLVM machine delete "$machine_name" -f 2>/dev/null
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$machine_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         rm -f "$pack_output" "$pack_output.smolmachine"; return 1
     }
 
@@ -807,23 +807,23 @@ test_from_vm_image_overlay() {
     $SMOLVM machine stop --name "$machine_name" 2>&1 || true
     $SMOLVM machine start --name "$machine_name" 2>&1 || {
         echo "FAIL: restart failed"
-        $SMOLVM machine delete "$machine_name" -f 2>/dev/null
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$machine_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         rm -f "$pack_output" "$pack_output.smolmachine"; return 1
     }
     exec_result=$($SMOLVM machine exec --name "$machine_name" -- which curl 2>&1)
     [[ "$exec_result" == *"/usr/bin/curl"* ]] || {
         echo "FAIL: curl not found after restart (got: $exec_result)"
         $SMOLVM machine stop --name "$machine_name" 2>/dev/null
-        $SMOLVM machine delete "$machine_name" -f 2>/dev/null
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$machine_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         rm -f "$pack_output" "$pack_output.smolmachine"; return 1
     }
 
     # Cleanup
     $SMOLVM machine stop --name "$machine_name" 2>/dev/null || true
-    $SMOLVM machine delete "$machine_name" -f 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$machine_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     rm -f "$pack_output" "$pack_output.smolmachine"
 }
 
@@ -849,15 +849,15 @@ test_from_vm_debian_roundtrip() {
 
     # Cleanup any leftovers
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     $SMOLVM machine stop --name "$from_name" 2>/dev/null || true
-    $SMOLVM machine delete "$from_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$from_name" -f 2>/dev/null || true
 
     # 1. Create a Debian-based VM
     echo "  Step 1: Creating Debian VM..."
-    $SMOLVM machine create "$vm_name" --image python:3.12-slim --net 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --image python:3.12-slim --net 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1
     }
 
     # 2. Install a package that creates Char entries via update-alternatives
@@ -866,7 +866,7 @@ test_from_vm_debian_roundtrip() {
         bash -c "apt-get update -qq && apt-get install -y -qq man-db >/dev/null 2>&1" || {
         echo "FAIL: apt-get install failed"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1
     }
 
     # 3. Write a test file (appears late in tar stream — after Char entries)
@@ -879,7 +879,7 @@ test_from_vm_debian_roundtrip() {
     [[ "$content" == *"debian-roundtrip-ok"* ]] || {
         echo "FAIL: test marker not written (got: '$content')"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1
     }
 
     # 4. Stop and pack
@@ -887,19 +887,19 @@ test_from_vm_debian_roundtrip() {
     $SMOLVM machine stop --name "$vm_name" 2>&1
     $SMOLVM pack create --from-vm "$vm_name" -o "$pack_output" 2>&1 || {
         echo "FAIL: pack create --from-vm failed"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1
     }
 
     # 5. Create a new machine from the pack
     echo "  Step 5: Creating machine from pack..."
-    $SMOLVM machine create "$from_name" --from "$pack_output.smolmachine" 2>&1 || {
+    $SMOLVM machine create --name "$from_name" --from "$pack_output.smolmachine" 2>&1 || {
         echo "FAIL: machine create --from failed (Char device extraction bug)"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1
     }
     $SMOLVM machine start --name "$from_name" 2>&1 || {
         echo "FAIL: machine start failed"
-        $SMOLVM machine delete "$from_name" -f 2>/dev/null
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+        $SMOLVM machine delete --name "$from_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1
     }
 
     # 6. Verify test file survived the roundtrip
@@ -908,23 +908,23 @@ test_from_vm_debian_roundtrip() {
     result=$($SMOLVM machine exec --name "$from_name" -- cat /test-marker.txt 2>&1) || {
         echo "FAIL: test marker missing after roundtrip (Char device data loss)"
         $SMOLVM machine stop --name "$from_name" 2>/dev/null
-        $SMOLVM machine delete "$from_name" -f 2>/dev/null
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+        $SMOLVM machine delete --name "$from_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1
     }
 
     [[ "$result" == *"debian-roundtrip-ok"* ]] || {
         echo "FAIL: test marker content mismatch (got: '$result')"
         $SMOLVM machine stop --name "$from_name" 2>/dev/null
-        $SMOLVM machine delete "$from_name" -f 2>/dev/null
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+        $SMOLVM machine delete --name "$from_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1
     }
 
     echo "  Test marker survived Debian pack/unpack roundtrip"
 
     # Cleanup
     $SMOLVM machine stop --name "$from_name" 2>/dev/null || true
-    $SMOLVM machine delete "$from_name" -f 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$from_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     rm -f "$pack_output" "$pack_output.smolmachine"
 }
 
@@ -935,24 +935,24 @@ test_from_vm_short_name() {
     local pack_output="$TEST_DIR/from-vm-short"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     rm -f "$pack_output" "$pack_output.smolmachine"
 
     # Create, start, modify, stop
-    $SMOLVM machine create "$vm_name" --image alpine:latest --net 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --image alpine:latest --net 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1
     }
     $SMOLVM machine exec --name "$vm_name" -- touch /etc/short-name-marker 2>&1 || true
     $SMOLVM machine stop --name "$vm_name" 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1
     }
 
     # Pack — this is where the panic used to occur
     local exit_code=0
     $SMOLVM pack create --from-vm "$vm_name" -o "$pack_output" 2>&1 || exit_code=$?
 
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     rm -f "$pack_output" "$pack_output.smolmachine"
 
     [[ $exit_code -eq 0 ]] || {
@@ -1214,10 +1214,10 @@ test_multi_layer_first_exec_fast() {
 
     # Create machine from .smolmachine
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
-    $SMOLVM machine create "$vm_name" --from "$pack_output.smolmachine" --net 2>&1 || return 1
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine create --name "$vm_name" --from "$pack_output.smolmachine" --net 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1
     }
     sleep 2
 
@@ -1235,7 +1235,7 @@ test_multi_layer_first_exec_fast() {
     [[ "$result" == *"fast"* ]] || {
         echo "FAIL: exec failed: $result"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1
     }
 
     # Verify it was fast
@@ -1244,13 +1244,13 @@ test_multi_layer_first_exec_fast() {
     if [[ "$over_threshold" == "yes" ]]; then
         echo "FAIL: first exec took ${elapsed}s (>${MAX_FIRST_EXEC_SECS}s) — multi-layer overlay merge regression?"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1
     fi
 
     # Also verify stop/start doesn't regress
     $SMOLVM machine stop --name "$vm_name" 2>&1 || true
     $SMOLVM machine start --name "$vm_name" 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1
     }
     sleep 2
 
@@ -1264,19 +1264,19 @@ test_multi_layer_first_exec_fast() {
     [[ "$result" == *"still-fast"* ]] || {
         echo "FAIL: exec after restart failed: $result"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1
     }
 
     over_threshold=$(python3 -c "print('yes' if $t_end - $t_start > $MAX_FIRST_EXEC_SECS else 'no')" 2>/dev/null || echo "no")
     if [[ "$over_threshold" == "yes" ]]; then
         echo "FAIL: exec after restart took ${elapsed}s (>${MAX_FIRST_EXEC_SECS}s)"
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1
     fi
 
     # Cleanup
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 }
 
 # =============================================================================

--- a/tests/test_ports.sh
+++ b/tests/test_ports.sh
@@ -23,12 +23,12 @@ test_machine_port_mapping_http() {
     local vm_name="test-vm-portmap"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     # Create and start VM with port mapping (host 18199 -> guest 8080)
-    $SMOLVM machine create "$vm_name" -p 18199:8080 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" -p 18199:8080 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         return 1
     }
 
@@ -50,7 +50,7 @@ test_machine_port_mapping_http() {
 
     # Cleanup
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     ensure_data_dir_deleted "$vm_name"
 
     [[ $curl_rc -eq 0 ]] && [[ "$output" == *"ok"* ]]
@@ -60,12 +60,12 @@ test_port_conflict_across_vms() {
     local vm_a="port-conflict-a-$$"
     local vm_b="port-conflict-b-$$"
 
-    $SMOLVM machine create "$vm_a" -p 19876:80 --net 2>&1 >/dev/null || return 1
-    $SMOLVM machine create "$vm_b" -p 19876:80 --net 2>&1 >/dev/null || return 1
+    $SMOLVM machine create --name "$vm_a" -p 19876:80 --net 2>&1 >/dev/null || return 1
+    $SMOLVM machine create --name "$vm_b" -p 19876:80 --net 2>&1 >/dev/null || return 1
 
     $SMOLVM machine start --name "$vm_a" 2>&1 >/dev/null || {
-        $SMOLVM machine delete "$vm_a" -f 2>/dev/null
-        $SMOLVM machine delete "$vm_b" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_a" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_b" -f 2>/dev/null
         return 1
     }
 
@@ -77,8 +77,8 @@ test_port_conflict_across_vms() {
     [[ "$output" == *"already in use"* ]] || { echo "expected 'already in use' message"; }
 
     $SMOLVM machine stop --name "$vm_a" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_a" -f 2>/dev/null || true
-    $SMOLVM machine delete "$vm_b" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_a" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_b" -f 2>/dev/null || true
 
     [[ $exit_code -ne 0 ]]
 }

--- a/tests/test_reliability.sh
+++ b/tests/test_reliability.sh
@@ -23,8 +23,8 @@ test_concurrent_machine_start() {
     local vm_a="conc-start-a-$$"
     local vm_b="conc-start-b-$$"
 
-    $SMOLVM machine create "$vm_a" --cpus 1 --mem 256 2>&1 >/dev/null || return 1
-    $SMOLVM machine create "$vm_b" --cpus 1 --mem 256 2>&1 >/dev/null || return 1
+    $SMOLVM machine create --name "$vm_a" --cpus 1 --mem 256 2>&1 >/dev/null || return 1
+    $SMOLVM machine create --name "$vm_b" --cpus 1 --mem 256 2>&1 >/dev/null || return 1
 
     # Start both simultaneously — previously the second would fail with DB lock error
     $SMOLVM machine start --name "$vm_a" 2>&1 >/dev/null &
@@ -45,8 +45,8 @@ test_concurrent_machine_start() {
 
     $SMOLVM machine stop --name "$vm_a" 2>/dev/null || true
     $SMOLVM machine stop --name "$vm_b" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_a" -f 2>/dev/null || true
-    $SMOLVM machine delete "$vm_b" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_a" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_b" -f 2>/dev/null || true
 
     [[ "$status_a" == *"running"* ]] && [[ "$status_b" == *"running"* ]]
 }
@@ -79,12 +79,12 @@ test_machine_ls_does_not_kill_vm() {
 test_named_vm_survives_ls() {
     skip_if_slow && return 0
     # Same regression test but with a named VM — the customer's exact scenario:
-    # machine create X --from .smolmachine → machine start → machine ls shows stopped.
+    # machine create --name X --from .smolmachine → machine start → machine ls shows stopped.
     # Verify over 60 seconds with interleaved ls + exec.
     local name="ls-probe-test"
     $SMOLVM machine stop --name "$name" 2>/dev/null || true
-    $SMOLVM machine delete "$name" -f 2>/dev/null || true
-    $SMOLVM machine create "$name" 2>&1 || return 1
+    $SMOLVM machine delete --name "$name" -f 2>/dev/null || true
+    $SMOLVM machine create --name "$name" 2>&1 || return 1
     $SMOLVM machine start --name "$name" 2>&1 || return 1
 
     # Wait for agent to be fully ready
@@ -93,17 +93,17 @@ test_named_vm_survives_ls() {
     for i in 1 2 3 4 5 6; do
         local state
         state=$($SMOLVM machine ls 2>&1 | grep "$name" | awk '{print $2}')
-        [[ "$state" == "running" ]] || { echo "VM '$name' died after ls #$i (state: $state)"; $SMOLVM machine delete "$name" -f 2>/dev/null; return 1; }
+        [[ "$state" == "running" ]] || { echo "VM '$name' died after ls #$i (state: $state)"; $SMOLVM machine delete --name "$name" -f 2>/dev/null; return 1; }
         sleep 10
     done
 
     # Exec must work after 60 seconds of ls probing
     local result
     result=$($SMOLVM machine exec --name "$name" -- echo "alive" 2>&1)
-    [[ "$result" == *"alive"* ]] || { echo "exec failed: $result"; $SMOLVM machine delete "$name" -f 2>/dev/null; return 1; }
+    [[ "$result" == *"alive"* ]] || { echo "exec failed: $result"; $SMOLVM machine delete --name "$name" -f 2>/dev/null; return 1; }
 
     $SMOLVM machine stop --name "$name" 2>&1 || true
-    $SMOLVM machine delete "$name" -f 2>&1 || true
+    $SMOLVM machine delete --name "$name" -f 2>&1 || true
 }
 
 test_state_probe_tolerates_busy_agent() {

--- a/tests/test_resize.sh
+++ b/tests/test_resize.sh
@@ -20,7 +20,7 @@ for vm_name in test-vm-resize-happy test-vm-resize-running test-vm-resize-shrink
     nonexistent-vm-resize-test test-vm-resize-noparams test-vm-resize-storage-only \
     test-vm-resize-overlay-only; do
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     rm -rf "$(vm_data_dir "$vm_name")"
 done
 
@@ -43,18 +43,18 @@ test_machine_resize_happy_path() {
     local vm_name="test-vm-resize-happy"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     rm -rf "$(vm_data_dir "$vm_name")"
 
     # Create VM with small resources
-    $SMOLVM machine create "$vm_name" --storage 5 --overlay 2 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --storage 5 --overlay 2 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         rm -rf "$(vm_data_dir "$vm_name")"
         return 1
     }
     $SMOLVM machine stop --name "$vm_name" 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         rm -rf "$(vm_data_dir "$vm_name")"
         return 1
     }
@@ -66,13 +66,13 @@ test_machine_resize_happy_path() {
     # Verify resize output contains expected messages
     if [[ "$resize_output" != *"Resizing machine"* ]]; then
         echo "Resize output should contain 'Resizing machine'"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         rm -rf "$(vm_data_dir "$vm_name")"
         return 1
     fi
 
     # Clean up
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     rm -rf "$(vm_data_dir "$vm_name")"
     ensure_data_dir_deleted "$vm_name"
 
@@ -85,12 +85,12 @@ test_machine_resize_running_vm_rejected() {
     local vm_name="test-vm-resize-running"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     # Create and start VM
-    $SMOLVM machine create "$vm_name" --storage 5 --overlay 2 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --storage 5 --overlay 2 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         return 1
     }
 
@@ -101,7 +101,7 @@ test_machine_resize_running_vm_rejected() {
 
     # Clean up
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     ensure_data_dir_deleted "$vm_name"
 
     # Should fail with non-zero exit code
@@ -113,16 +113,16 @@ test_machine_resize_shrink_rejected() {
     local vm_name="test-vm-resize-shrink"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     # Create VM with 10 GiB storage
-    $SMOLVM machine create "$vm_name" --storage 10 --overlay 5 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --storage 10 --overlay 5 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         return 1
     }
     $SMOLVM machine stop --name "$vm_name" 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         return 1
     }
 
@@ -132,7 +132,7 @@ test_machine_resize_shrink_rejected() {
     resize_output=$($SMOLVM machine resize --name "$vm_name" --storage 5 2>&1) || exit_code=$?
 
     # Clean up
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     ensure_data_dir_deleted "$vm_name"
 
     # Should fail with non-zero exit code and error message about shrinking
@@ -184,16 +184,16 @@ test_machine_resize_no_params_rejected() {
     local vm_name="test-vm-resize-noparams"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     # Create VM
-    $SMOLVM machine create "$vm_name" --storage 5 --overlay 2 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --storage 5 --overlay 2 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         return 1
     }
     $SMOLVM machine stop --name "$vm_name" 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         return 1
     }
 
@@ -203,7 +203,7 @@ test_machine_resize_no_params_rejected() {
     resize_output=$($SMOLVM machine resize --name "$vm_name" 2>&1) || exit_code=$?
 
     # Clean up
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     ensure_data_dir_deleted "$vm_name"
 
     # Should fail with non-zero exit code
@@ -215,18 +215,18 @@ test_machine_resize_storage_only() {
     local vm_name="test-vm-resize-storage-only"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     rm -rf "$(vm_data_dir "$vm_name")"
 
     # Create VM with small resources
-    $SMOLVM machine create "$vm_name" --storage 5 --overlay 2 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --storage 5 --overlay 2 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         rm -rf "$(vm_data_dir "$vm_name")"
         return 1
     }
     $SMOLVM machine stop --name "$vm_name" 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         rm -rf "$(vm_data_dir "$vm_name")"
         return 1
     }
@@ -236,7 +236,7 @@ test_machine_resize_storage_only() {
     resize_output=$($SMOLVM machine resize --name "$vm_name" --storage 15 2>&1)
 
     # Clean up
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     rm -rf "$(vm_data_dir "$vm_name")"
     ensure_data_dir_deleted "$vm_name"
 
@@ -250,19 +250,19 @@ test_machine_resize_overlay_only() {
 
     # Aggressive cleanup - stop, delete, and remove directory
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     rm -rf "$(vm_data_dir "$vm_name")"
     sleep 0.5
 
     # Create VM with small resources
-    $SMOLVM machine create "$vm_name" --storage 5 --overlay 2 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --storage 5 --overlay 2 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         rm -rf "$(vm_data_dir "$vm_name")"
         return 1
     }
     $SMOLVM machine stop --name "$vm_name" 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         rm -rf "$(vm_data_dir "$vm_name")"
         return 1
     }
@@ -274,7 +274,7 @@ test_machine_resize_overlay_only() {
         echo "DEBUG: overlay disk is $overlay_size, expected 2.0G"
         echo "DEBUG: listing directory:"
         ls -lh "$(vm_data_dir "$vm_name")/" 2>/dev/null || true
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         rm -rf "$(vm_data_dir "$vm_name")"
         return 1
     fi
@@ -285,7 +285,7 @@ test_machine_resize_overlay_only() {
     echo "RESIZE OUTPUT: '$resize_output'"
 
     # Clean up
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     rm -rf "$(vm_data_dir "$vm_name")"
     ensure_data_dir_deleted "$vm_name"
 

--- a/tests/test_resources.sh
+++ b/tests/test_resources.sh
@@ -42,30 +42,30 @@ test_resource_mem_below_minimum_rejected() {
 test_name_length_44_chars_accepted() {
     local name="sandbox-7f3e2d1c-9a8b-4e5f-b123-456789abcdef"
     [[ ${#name} -eq 44 ]] || { echo "test bug: expected 44 chars, got ${#name}"; return 1; }
-    $SMOLVM machine delete "$name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$name" -f 2>/dev/null || true
 
     local output exit_code=0
-    output=$($SMOLVM machine create "$name" 2>&1) || exit_code=$?
+    output=$($SMOLVM machine create --name "$name" 2>&1) || exit_code=$?
     if [[ $exit_code -ne 0 ]]; then
         echo "expected 44-char name to succeed, got error: $output"
         return 1
     fi
-    $SMOLVM machine delete "$name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$name" -f 2>/dev/null || true
 }
 
 test_name_length_75_chars_accepted_via_hash_path() {
     local name
     name=$(printf 'a%.0s' {1..75})
     [[ ${#name} -eq 75 ]] || return 1
-    $SMOLVM machine delete "$name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$name" -f 2>/dev/null || true
 
     local output exit_code=0
-    output=$($SMOLVM machine create "$name" 2>&1) || exit_code=$?
+    output=$($SMOLVM machine create --name "$name" 2>&1) || exit_code=$?
     if [[ $exit_code -ne 0 ]]; then
         echo "expected 75-char name to succeed (hash path keeps socket bounded), got: $output"
         return 1
     fi
-    $SMOLVM machine delete "$name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$name" -f 2>/dev/null || true
 }
 
 test_name_length_sanity_cap_rejects_absurd_names() {
@@ -74,7 +74,7 @@ test_name_length_sanity_cap_rejects_absurd_names() {
     [[ ${#name} -eq 200 ]] || return 1
 
     local output exit_code=0
-    output=$($SMOLVM machine create "$name" 2>&1) || exit_code=$?
+    output=$($SMOLVM machine create --name "$name" 2>&1) || exit_code=$?
     [[ $exit_code -ne 0 ]] || { echo "expected 200-char name to be rejected"; return 1; }
     [[ "$output" == *"too long"* ]] || {
         echo "expected length-cap error, got: $output"
@@ -96,8 +96,8 @@ test_start_nonexistent_name_rejected() {
 test_auto_generated_names() {
     # Auto-generate: create with no name, verify format + appears in list
     local result1 result2
-    result1=$($SMOLVM machine create 2>&1) || return 1
-    result2=$($SMOLVM machine create 2>&1) || return 1
+    result1=$($SMOLVM machine create --name 2>&1) || return 1
+    result2=$($SMOLVM machine create --name 2>&1) || return 1
 
     local name1 name2
     name1=$(echo "$result1" | grep "Created machine:" | grep -oE "vm-[a-f0-9]{8}" | head -1)
@@ -114,21 +114,21 @@ test_auto_generated_names() {
     list_result=$($SMOLVM machine ls --json 2>&1)
     [[ "$list_result" == *"$name1"* ]] && [[ "$list_result" == *"$name2"* ]] || {
         echo "Auto-named machines not in list"
-        $SMOLVM machine delete "$name1" -f 2>/dev/null
-        $SMOLVM machine delete "$name2" -f 2>/dev/null
+        $SMOLVM machine delete --name "$name1" -f 2>/dev/null
+        $SMOLVM machine delete --name "$name2" -f 2>/dev/null
         return 1
     }
 
     # Explicit name still works
     local explicit="explicit-test-$$"
-    $SMOLVM machine create "$explicit" 2>&1 || { echo "Explicit name failed"; return 1; }
+    $SMOLVM machine create --name "$explicit" 2>&1 || { echo "Explicit name failed"; return 1; }
     list_result=$($SMOLVM machine ls --json 2>&1)
     [[ "$list_result" == *"$explicit"* ]] || { echo "Explicit name not in list"; return 1; }
 
     # Cleanup
-    $SMOLVM machine delete "$name1" -f 2>/dev/null
-    $SMOLVM machine delete "$name2" -f 2>/dev/null
-    $SMOLVM machine delete "$explicit" -f 2>/dev/null
+    $SMOLVM machine delete --name "$name1" -f 2>/dev/null
+    $SMOLVM machine delete --name "$name2" -f 2>/dev/null
+    $SMOLVM machine delete --name "$explicit" -f 2>/dev/null
 }
 
 
@@ -137,21 +137,21 @@ test_create_rejects_zero_valued_disks() {
     # NOT persist a machine — otherwise the failure only surfaces later at
     # `machine start`, leaving an unstartable machine in the list.
     local name="zero-disk-test-$$"
-    $SMOLVM machine delete "$name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$name" -f 2>/dev/null || true
 
     local exit_code=0
-    $SMOLVM machine create "$name" --storage 0 2>&1 || exit_code=$?
+    $SMOLVM machine create --name "$name" --storage 0 2>&1 || exit_code=$?
     [[ $exit_code -ne 0 ]] || {
         echo "--storage 0 should be rejected at create"
-        $SMOLVM machine delete "$name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$name" -f 2>/dev/null
         return 1
     }
 
     exit_code=0
-    $SMOLVM machine create "$name" --overlay 0 2>&1 || exit_code=$?
+    $SMOLVM machine create --name "$name" --overlay 0 2>&1 || exit_code=$?
     [[ $exit_code -ne 0 ]] || {
         echo "--overlay 0 should be rejected at create"
-        $SMOLVM machine delete "$name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$name" -f 2>/dev/null
         return 1
     }
 
@@ -160,7 +160,7 @@ test_create_rejects_zero_valued_disks() {
     list=$($SMOLVM machine ls --json 2>&1)
     [[ "$list" != *"$name"* ]] || {
         echo "a rejected create persisted the machine anyway"
-        $SMOLVM machine delete "$name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$name" -f 2>/dev/null
         return 1
     }
 }
@@ -188,22 +188,22 @@ test_exec_nonexistent_machine_reports_not_found() {
 test_status_json_output() {
     # `machine status` supports `--json`, mirroring `machine list --json`.
     local name="status-json-test-$$"
-    $SMOLVM machine delete "$name" -f 2>/dev/null || true
-    $SMOLVM machine create "$name" 2>&1 || { echo "setup: create failed"; return 1; }
+    $SMOLVM machine delete --name "$name" -f 2>/dev/null || true
+    $SMOLVM machine create --name "$name" 2>&1 || { echo "setup: create failed"; return 1; }
 
     local output exit_code=0
     output=$($SMOLVM machine status --name "$name" --json 2>&1) || exit_code=$?
     if [[ $exit_code -ne 0 ]]; then
         echo "status --json should succeed, got: $output"
-        $SMOLVM machine delete "$name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$name" -f 2>/dev/null
         return 1
     fi
     [[ "$output" == "{"* && "$output" == *"\"name\""* && "$output" == *"$name"* ]] || {
         echo "status --json did not return the expected JSON object: $output"
-        $SMOLVM machine delete "$name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$name" -f 2>/dev/null
         return 1
     }
-    $SMOLVM machine delete "$name" -f 2>/dev/null
+    $SMOLVM machine delete --name "$name" -f 2>/dev/null
 
     # `--json` on a machine that does not exist must error.
     exit_code=0

--- a/tests/test_scale.sh
+++ b/tests/test_scale.sh
@@ -31,12 +31,12 @@ test_10_concurrent_vms() {
 
     for i in $(seq 1 $COUNT); do
         $SMOLVM machine stop --name "scale-$i" 2>/dev/null || true
-        $SMOLVM machine delete "scale-$i" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "scale-$i" -f 2>/dev/null || true
     done
 
     # Create
     for i in $(seq 1 $COUNT); do
-        $SMOLVM machine create "scale-$i" --mem 512 --cpus 1 2>/dev/null || {
+        $SMOLVM machine create --name "scale-$i" --mem 512 --cpus 1 2>/dev/null || {
             echo "FAIL: create scale-$i failed"; return 1
         }
     done
@@ -74,7 +74,7 @@ test_10_concurrent_vms() {
     # Cleanup
     for i in $(seq 1 $COUNT); do
         $SMOLVM machine stop --name "scale-$i" 2>/dev/null || true
-        $SMOLVM machine delete "scale-$i" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "scale-$i" -f 2>/dev/null || true
     done
 
     echo "  running: $running/$COUNT, exec: $exec_pass/$COUNT, start_fails: $start_fails"
@@ -95,12 +95,12 @@ test_concurrent_exec_storm() {
 
     for i in $(seq 1 $COUNT); do
         $SMOLVM machine stop --name "storm-$i" 2>/dev/null || true
-        $SMOLVM machine delete "storm-$i" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "storm-$i" -f 2>/dev/null || true
     done
 
     # Create and start sequentially (scale test above covers concurrent start)
     for i in $(seq 1 $COUNT); do
-        $SMOLVM machine create "storm-$i" --mem 512 --cpus 1 2>/dev/null || return 1
+        $SMOLVM machine create --name "storm-$i" --mem 512 --cpus 1 2>/dev/null || return 1
         $SMOLVM machine start --name "storm-$i" 2>/dev/null || return 1
     done
 
@@ -125,7 +125,7 @@ test_concurrent_exec_storm() {
     # Cleanup
     for i in $(seq 1 $COUNT); do
         $SMOLVM machine stop --name "storm-$i" 2>/dev/null || true
-        $SMOLVM machine delete "storm-$i" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "storm-$i" -f 2>/dev/null || true
     done
 
     local total=$((COUNT * EXECS_PER_VM))
@@ -142,15 +142,15 @@ run_test "Scale: 50 concurrent execs across 10 VMs" test_concurrent_exec_storm |
 test_rapid_lifecycle() {
     local i
     for i in $(seq 1 5); do
-        $SMOLVM machine create "rapid-$$" --mem 512 --cpus 1 2>/dev/null || {
+        $SMOLVM machine create --name "rapid-$$" --mem 512 --cpus 1 2>/dev/null || {
             echo "FAIL: create iteration $i"; return 1
         }
         $SMOLVM machine start --name "rapid-$$" 2>/dev/null || {
             echo "FAIL: start iteration $i"
-            $SMOLVM machine delete "rapid-$$" -f 2>/dev/null; return 1
+            $SMOLVM machine delete --name "rapid-$$" -f 2>/dev/null; return 1
         }
         $SMOLVM machine stop --name "rapid-$$" 2>/dev/null || true
-        $SMOLVM machine delete "rapid-$$" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "rapid-$$" -f 2>/dev/null || true
     done
     echo "  5 create-start-stop-delete cycles completed"
 }

--- a/tests/test_secrets.sh
+++ b/tests/test_secrets.sh
@@ -40,7 +40,7 @@ export "$SECRET_NAME=$SECRET_VALUE"
 cleanup_vm() {
     local name="$1"
     $SMOLVM machine stop --name "$name" 2>/dev/null || true
-    $SMOLVM machine delete "$name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$name" -f 2>/dev/null || true
 }
 
 cleanup_secrets_test() {
@@ -71,7 +71,7 @@ test_secret_reaches_guest_exec() {
     local vm="secret-exec-$$"
     cleanup_vm "$vm"
     write_smolfile "$SECRET_TMPDIR/Smolfile.exec"
-    $SMOLVM machine create "$vm" --smolfile "$SECRET_TMPDIR/Smolfile.exec" 2>&1 || return 1
+    $SMOLVM machine create --name "$vm" --smolfile "$SECRET_TMPDIR/Smolfile.exec" 2>&1 || return 1
     $SMOLVM machine start --name "$vm" 2>&1 || { cleanup_vm "$vm"; return 1; }
     # `env` (busybox) prints the whole environment — robust across rootfs builds.
     local output
@@ -88,7 +88,7 @@ test_secret_reaches_guest_init() {
     cleanup_vm "$vm"
     write_smolfile "$SECRET_TMPDIR/Smolfile.init" \
         "init = [\"printenv $SECRET_NAME > /tmp/secret-out.txt\"]"
-    $SMOLVM machine create "$vm" --smolfile "$SECRET_TMPDIR/Smolfile.init" 2>&1 || return 1
+    $SMOLVM machine create --name "$vm" --smolfile "$SECRET_TMPDIR/Smolfile.init" 2>&1 || return 1
     $SMOLVM machine start --name "$vm" 2>&1 || { cleanup_vm "$vm"; return 1; }
     local output
     output=$($SMOLVM machine exec --name "$vm" -- cat /tmp/secret-out.txt 2>&1)
@@ -103,7 +103,7 @@ test_plaintext_not_in_db() {
     local vm="secret-nodb-$$"
     cleanup_vm "$vm"
     write_smolfile "$SECRET_TMPDIR/Smolfile.nodb"
-    $SMOLVM machine create "$vm" --smolfile "$SECRET_TMPDIR/Smolfile.nodb" 2>&1 || return 1
+    $SMOLVM machine create --name "$vm" --smolfile "$SECRET_TMPDIR/Smolfile.nodb" 2>&1 || return 1
     # Start too, so any persist-on-run path also executes.
     $SMOLVM machine start --name "$vm" 2>&1 || { cleanup_vm "$vm"; return 1; }
     # The ref NAME may legitimately appear in the record; the VALUE must not.
@@ -124,7 +124,7 @@ test_plaintext_not_in_pack() {
     local vm="secret-nopack-$$"
     cleanup_vm "$vm"
     write_smolfile "$SECRET_TMPDIR/Smolfile.nopack"
-    $SMOLVM machine create "$vm" --smolfile "$SECRET_TMPDIR/Smolfile.nopack" 2>&1 || return 1
+    $SMOLVM machine create --name "$vm" --smolfile "$SECRET_TMPDIR/Smolfile.nopack" 2>&1 || return 1
     $SMOLVM machine start --name "$vm" 2>&1 || { cleanup_vm "$vm"; return 1; }
     $SMOLVM machine stop --name "$vm" 2>&1 || true
     local pack="$SECRET_TMPDIR/out.smolmachine"
@@ -145,7 +145,7 @@ test_secret_reresolves_after_restart() {
     local vm="secret-restart-$$"
     cleanup_vm "$vm"
     write_smolfile "$SECRET_TMPDIR/Smolfile.restart"
-    $SMOLVM machine create "$vm" --smolfile "$SECRET_TMPDIR/Smolfile.restart" 2>&1 || return 1
+    $SMOLVM machine create --name "$vm" --smolfile "$SECRET_TMPDIR/Smolfile.restart" 2>&1 || return 1
     $SMOLVM machine start --name "$vm" 2>&1 || { cleanup_vm "$vm"; return 1; }
     $SMOLVM machine stop --name "$vm" 2>&1 || true
     $SMOLVM machine start --name "$vm" 2>&1 || { cleanup_vm "$vm"; return 1; }

--- a/tests/test_smolfile.sh
+++ b/tests/test_smolfile.sh
@@ -3,7 +3,7 @@
 # Smolfile tests for smolvm.
 #
 # Tests the `--smolfile` and `--init` functionality for both
-# machine create commands.
+# machine create --name commands.
 #
 # Usage:
 #   ./tests/test_smolfile.sh
@@ -33,7 +33,7 @@ trap 'rm -rf "$SMOLFILE_TMPDIR"; cleanup_machine' EXIT
 cleanup_vm() {
     local name="$1"
     $SMOLVM machine stop --name "$name" 2>/dev/null || true
-    $SMOLVM machine delete "$name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$name" -f 2>/dev/null || true
 }
 
 # =============================================================================
@@ -45,7 +45,7 @@ test_init_flag_creates_file() {
     cleanup_vm "$vm_name"
 
     # Create VM with --init that creates a marker file
-    $SMOLVM machine create "$vm_name" --init "echo 'init-ran' > /tmp/init-marker.txt" 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --init "echo 'init-ran' > /tmp/init-marker.txt" 2>&1 || return 1
 
     # Start VM (init should run)
     $SMOLVM machine start --name "$vm_name" 2>&1 || { cleanup_vm "$vm_name"; return 1; }
@@ -63,7 +63,7 @@ test_init_flag_multiple_commands() {
     cleanup_vm "$vm_name"
 
     # Create VM with multiple --init flags
-    $SMOLVM machine create "$vm_name" \
+    $SMOLVM machine create --name "$vm_name" \
         --init "echo 'first' > /tmp/init1.txt" \
         --init "echo 'second' > /tmp/init2.txt" \
         2>&1 || return 1
@@ -85,7 +85,7 @@ test_init_flag_with_env() {
     cleanup_vm "$vm_name"
 
     # Create VM with --init and -e
-    $SMOLVM machine create "$vm_name" \
+    $SMOLVM machine create --name "$vm_name" \
         -e MY_VAR=hello_from_env \
         --init 'echo "$MY_VAR" > /tmp/env-test.txt' \
         2>&1 || return 1
@@ -106,7 +106,7 @@ test_init_flag_with_workdir() {
     cleanup_vm "$vm_name"
 
     # Create VM with --init and -w
-    $SMOLVM machine create "$vm_name" \
+    $SMOLVM machine create --name "$vm_name" \
         -w /tmp \
         --init "pwd > cwd.txt" \
         2>&1 || return 1
@@ -127,7 +127,7 @@ test_init_runs_on_every_start() {
     cleanup_vm "$vm_name"
 
     # Create VM with --init that appends to a file
-    $SMOLVM machine create "$vm_name" \
+    $SMOLVM machine create --name "$vm_name" \
         --init 'echo "boot" >> /tmp/boot-count.txt' \
         2>&1 || return 1
 
@@ -186,7 +186,7 @@ net = true
 init = ["command -v dpkg > /tmp/dpkg-path.txt"]
 EOF
 
-    $SMOLVM machine create "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.initcontainer" 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.initcontainer" 2>&1 || return 1
 
     # Start should pull the image, then run init *in* the container.
     $SMOLVM machine start --name "$vm_name" 2>&1 || { cleanup_vm "$vm_name"; return 1; }
@@ -221,7 +221,7 @@ net = true
 init = ["test -f /etc/debian_version"]
 EOF
 
-    $SMOLVM machine create "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.initafter" 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.initafter" 2>&1 || return 1
 
     # Capture start output — must show pull happens before init runs.
     local start_output
@@ -267,7 +267,7 @@ init = [
 ]
 EOF
 
-    $SMOLVM machine create "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.initpersist" 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.initpersist" 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 || { cleanup_vm "$vm_name"; return 1; }
 
     # Exec must see the package installed by init. If the overlay ID
@@ -301,7 +301,7 @@ net = true
 init = ["apt-get install -y bogus-pkg-does-not-exist-xyz"]
 EOF
 
-    $SMOLVM machine create "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.initfail" 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.initfail" 2>&1 || return 1
 
     # Start must fail; the error must include pacman's output explaining
     # why. Capture stderr too — the error prints there.
@@ -335,7 +335,7 @@ init = [
 EOF
 
     # Create VM from Smolfile
-    $SMOLVM machine create "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.basic" 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.basic" 2>&1 || return 1
 
     # Verify config was applied
     local list_output
@@ -368,7 +368,7 @@ init = [
 ]
 EOF
 
-    $SMOLVM machine create "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.env" 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.env" 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 || { cleanup_vm "$vm_name"; return 1; }
 
     local output
@@ -388,7 +388,7 @@ memory = 256
 EOF
 
     # CLI --mem should override Smolfile memory
-    $SMOLVM machine create "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.override" --mem 1024 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.override" --mem 1024 2>&1 || return 1
 
     local list_output
     list_output=$($SMOLVM machine ls --json 2>&1)
@@ -410,7 +410,7 @@ init = [
 EOF
 
     # CLI --init should extend, not replace
-    $SMOLVM machine create "$vm_name" \
+    $SMOLVM machine create --name "$vm_name" \
         --smolfile "$SMOLFILE_TMPDIR/Smolfile.extend" \
         --init "echo 'from-cli' > /tmp/cli-source.txt" \
         2>&1 || return 1
@@ -430,7 +430,7 @@ test_smolfile_not_found_errors() {
     cleanup_vm "$vm_name"
 
     local exit_code=0
-    $SMOLVM machine create "$vm_name" --smolfile "/nonexistent/Smolfile" 2>&1 || exit_code=$?
+    $SMOLVM machine create --name "$vm_name" --smolfile "/nonexistent/Smolfile" 2>&1 || exit_code=$?
 
     cleanup_vm "$vm_name"
     [[ $exit_code -ne 0 ]]
@@ -445,7 +445,7 @@ this is not valid toml {{{
 EOF
 
     local exit_code=0
-    $SMOLVM machine create "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.bad" 2>&1 || exit_code=$?
+    $SMOLVM machine create --name "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.bad" 2>&1 || exit_code=$?
 
     cleanup_vm "$vm_name"
     [[ $exit_code -ne 0 ]]
@@ -461,7 +461,7 @@ typo_field = "oops"
 EOF
 
     local exit_code=0
-    $SMOLVM machine create "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.unknown" 2>&1 || exit_code=$?
+    $SMOLVM machine create --name "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.unknown" 2>&1 || exit_code=$?
 
     cleanup_vm "$vm_name"
     [[ $exit_code -ne 0 ]]
@@ -480,7 +480,7 @@ EOF
 
     # Create VM WITHOUT --smolfile, even though Smolfile exists in CWD
     # The Smolfile should NOT be auto-detected
-    (cd "$SMOLFILE_TMPDIR" && $SMOLVM machine create "$vm_name" 2>&1) || return 1
+    (cd "$SMOLFILE_TMPDIR" && $SMOLVM machine create --name "$vm_name" 2>&1) || return 1
 
     # Verify default config was used (not Smolfile config)
     local list_output
@@ -510,7 +510,7 @@ net = true
 EOF
 
     # Create + start — image from Smolfile should be picked up
-    $SMOLVM machine create "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.image" 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.image" 2>&1 || return 1
 
     # Verify image is persisted in the record
     local list_output
@@ -532,7 +532,7 @@ EOF
     local exit_code=0
     local vm_name="smolfile-ep-$$"
     cleanup_vm "$vm_name"
-    $SMOLVM machine create "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.ep" 2>&1 || exit_code=$?
+    $SMOLVM machine create --name "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.ep" 2>&1 || exit_code=$?
 
     cleanup_vm "$vm_name"
     [[ $exit_code -eq 0 ]]
@@ -548,7 +548,7 @@ EOF
     local exit_code=0
     local vm_name="smolfile-cmd-$$"
     cleanup_vm "$vm_name"
-    $SMOLVM machine create "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.cmd" 2>&1 || exit_code=$?
+    $SMOLVM machine create --name "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.cmd" 2>&1 || exit_code=$?
 
     cleanup_vm "$vm_name"
     [[ $exit_code -eq 0 ]]
@@ -574,7 +574,7 @@ EOF
     local exit_code=0
     local vm_name="smolfile-artifact-$$"
     cleanup_vm "$vm_name"
-    $SMOLVM machine create "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.artifact" 2>&1 || exit_code=$?
+    $SMOLVM machine create --name "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.artifact" 2>&1 || exit_code=$?
 
     cleanup_vm "$vm_name"
     [[ $exit_code -eq 0 ]]
@@ -592,7 +592,7 @@ EOF
     local exit_code=0
     local vm_name="smolfile-pack-$$"
     cleanup_vm "$vm_name"
-    $SMOLVM machine create "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.pack" 2>&1 || exit_code=$?
+    $SMOLVM machine create --name "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.pack" 2>&1 || exit_code=$?
 
     cleanup_vm "$vm_name"
     [[ $exit_code -eq 0 ]]
@@ -616,7 +616,7 @@ EOF
     local exit_code=0
     local vm_name="smolfile-dev-$$"
     cleanup_vm "$vm_name"
-    $SMOLVM machine create "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.dev" 2>&1 || exit_code=$?
+    $SMOLVM machine create --name "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.dev" 2>&1 || exit_code=$?
 
     cleanup_vm "$vm_name"
     [[ $exit_code -eq 0 ]]
@@ -636,7 +636,7 @@ init = [
 ]
 EOF
 
-    $SMOLVM machine create "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.devinit" 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.devinit" 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 || { cleanup_vm "$vm_name"; return 1; }
 
     local output
@@ -695,7 +695,7 @@ EOF
     local exit_code=0
     local vm_name="smolfile-full-$$"
     cleanup_vm "$vm_name"
-    $SMOLVM machine create "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.full" 2>&1 || exit_code=$?
+    $SMOLVM machine create --name "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.full" 2>&1 || exit_code=$?
 
     cleanup_vm "$vm_name"
     [[ $exit_code -eq 0 ]]
@@ -830,7 +830,7 @@ memory = 512
 net = true
 EOF
 
-    $SMOLVM machine create "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.autoct" 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.autoct" 2>&1 || return 1
 
     # Start should auto-pull image and create container
     local start_output
@@ -888,7 +888,7 @@ EOF
     local exit_code=0
     local vm_name="smolfile-badsec-$$"
     cleanup_vm "$vm_name"
-    $SMOLVM machine create "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.badsection" 2>&1 || exit_code=$?
+    $SMOLVM machine create --name "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.badsection" 2>&1 || exit_code=$?
 
     cleanup_vm "$vm_name"
     [[ $exit_code -ne 0 ]]
@@ -902,7 +902,7 @@ test_ls_verbose_shows_init() {
     local vm_name="smolfile-verbose-$$"
     cleanup_vm "$vm_name"
 
-    $SMOLVM machine create "$vm_name" \
+    $SMOLVM machine create --name "$vm_name" \
         --init "echo hello" \
         --init "echo world" \
         -e FOO=bar \
@@ -942,7 +942,7 @@ EOF
     cleanup_vm "$vm_name"
 
     # Create should succeed (restart config stored in VmRecord)
-    $SMOLVM machine create "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.restart" 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.restart" 2>&1 || return 1
 
     # Verify machine was created
     $SMOLVM machine ls --json 2>&1 | grep -q "$vm_name" || return 1
@@ -969,7 +969,7 @@ EOF
     cleanup_vm "$vm_name"
 
     # Create should succeed (health + restart config stored)
-    $SMOLVM machine create "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.health" 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.health" 2>&1 || return 1
 
     # Verify machine was created
     $SMOLVM machine ls --json 2>&1 | grep -q "$vm_name" || return 1
@@ -985,7 +985,7 @@ test_smolfile_monitor_basic() {
     $SMOLVM machine stop 2>/dev/null || true
 
     # Create and start a machine
-    $SMOLVM machine create --net "$vm_name" 2>&1 || return 1
+    $SMOLVM machine create --net --name "$vm_name" 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 || return 1
 
     # Verify the VM is running before testing monitor
@@ -1067,7 +1067,7 @@ test_ssh_agent_flag_creates_socket() {
     cleanup_vm "$vm_name"
 
     # Create VM with --ssh-agent
-    $SMOLVM machine create "$vm_name" --ssh-agent --net 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --ssh-agent --net 2>&1 || return 1
 
     # Start VM
     $SMOLVM machine start --name "$vm_name" 2>&1 || return 1
@@ -1094,7 +1094,7 @@ test_ssh_agent_lists_host_keys() {
         return 0
     fi
 
-    $SMOLVM machine create "$vm_name" --ssh-agent --net 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --ssh-agent --net 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 || return 1
 
     # Install openssh-client. apk may return non-zero from trigger
@@ -1121,7 +1121,7 @@ test_ssh_agent_not_present_without_flag() {
     cleanup_vm "$vm_name"
 
     # Create VM WITHOUT --ssh-agent
-    $SMOLVM machine create "$vm_name" --net 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --net 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 || return 1
 
     # Socket should NOT exist
@@ -1145,7 +1145,7 @@ EOF
     local vm_name="ssh-agent-smolfile-$$"
     cleanup_vm "$vm_name"
 
-    $SMOLVM machine create "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.ssh" 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.ssh" 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 || return 1
 
     # Socket should exist (enabled via Smolfile)
@@ -1165,7 +1165,7 @@ test_ssh_agent_fails_without_host_socket() {
     unset SSH_AUTH_SOCK
 
     # Create should succeed (flag is just stored)
-    $SMOLVM machine create "$vm_name" --ssh-agent 2>&1 || { export SSH_AUTH_SOCK="$saved_sock"; return 1; }
+    $SMOLVM machine create --name "$vm_name" --ssh-agent 2>&1 || { export SSH_AUTH_SOCK="$saved_sock"; return 1; }
 
     # Start should fail with clear error
     local output
@@ -1195,7 +1195,7 @@ test_ssh_agent_forwarded_to_container_exec() {
     fi
 
     # Image-based machine: exec goes through crun container, not direct VM exec.
-    $SMOLVM machine create "$vm_name" --image alpine:latest --ssh-agent --net 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --image alpine:latest --ssh-agent --net 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 || return 1
 
     # SSH_AUTH_SOCK must be set inside the container.
@@ -1261,7 +1261,7 @@ allow_hosts = ["one.one.one.one"]
 EOF
 
     # Create VM from Smolfile with [network] section
-    $SMOLVM machine create "$vm_name" -s "$SMOLFILE_TMPDIR/network.smolfile" 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" -s "$SMOLFILE_TMPDIR/network.smolfile" 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 || { cleanup_vm "$vm_name"; return 1; }
 
     # Allowed host's IP should be reachable
@@ -1288,7 +1288,7 @@ net = true
 allow_cidrs = ["1.1.1.1/32"]
 EOF
 
-    $SMOLVM machine create "$vm_name" -s "$SMOLFILE_TMPDIR/network-cidr.smolfile" 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" -s "$SMOLFILE_TMPDIR/network-cidr.smolfile" 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 || { cleanup_vm "$vm_name"; return 1; }
 
     # Allowed CIDR should work
@@ -1316,7 +1316,7 @@ allow_hosts = ["one.one.one.one"]
 allow_cidrs = ["8.8.8.0/24"]
 EOF
 
-    $SMOLVM machine create "$vm_name" -s "$SMOLFILE_TMPDIR/network-mixed.smolfile" 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" -s "$SMOLFILE_TMPDIR/network-mixed.smolfile" 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 || { cleanup_vm "$vm_name"; return 1; }
 
     # Both should be reachable
@@ -1353,7 +1353,7 @@ memory = 512
 workdir = "/tmp"
 EOF
 
-    $SMOLVM machine create "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.execwd" 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.execwd" 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 || { cleanup_vm "$vm_name"; return 1; }
 
     # exec without --workdir should inherit Smolfile workdir
@@ -1374,7 +1374,7 @@ memory = 512
 workdir = "/tmp"
 EOF
 
-    $SMOLVM machine create "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.execwdover" 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --smolfile "$SMOLFILE_TMPDIR/Smolfile.execwdover" 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 || { cleanup_vm "$vm_name"; return 1; }
 
     # exec with explicit -w should override Smolfile workdir

--- a/tests/test_storage.sh
+++ b/tests/test_storage.sh
@@ -24,11 +24,11 @@ test_machine_overlay_root_active() {
 
     # Clean up any existing
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     # Create and start VM
-    $SMOLVM machine create "$vm_name" 2>&1 || return 1
-    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+    $SMOLVM machine create --name "$vm_name" 2>&1 || return 1
+    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1; }
 
     # Check that root is an overlay mount
     local output exit_code=0
@@ -36,7 +36,7 @@ test_machine_overlay_root_active() {
 
     # Clean up
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     ensure_data_dir_deleted "$vm_name"
 
     [[ $exit_code -eq 0 ]] && [[ "$output" == *"overlay on / type overlay"* ]]
@@ -47,18 +47,18 @@ test_machine_rootfs_persists_across_reboot() {
 
     # Clean up any existing
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     # Create and start VM
-    $SMOLVM machine create "$vm_name" 2>&1 || return 1
-    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+    $SMOLVM machine create --name "$vm_name" 2>&1 || return 1
+    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1; }
 
     # Write a marker file to the rootfs
     local exit_code=0
     $SMOLVM machine exec --name "$vm_name" -- sh -c "echo persistence-test-ok > /tmp/overlay-test-marker" 2>&1 || exit_code=$?
     if [[ $exit_code -ne 0 ]]; then
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     fi
 
@@ -66,18 +66,18 @@ test_machine_rootfs_persists_across_reboot() {
     local output
     output=$($SMOLVM machine exec --name "$vm_name" -- cat /tmp/overlay-test-marker 2>&1) || {
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
     if [[ "$output" != *"persistence-test-ok"* ]]; then
         $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     fi
 
     # Stop and restart the VM
-    $SMOLVM machine stop --name "$vm_name" 2>&1 || { $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
-    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1; }
+    $SMOLVM machine stop --name "$vm_name" 2>&1 || { $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1; }
+    $SMOLVM machine start --name "$vm_name" 2>&1 || { $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1; }
 
     # Verify the file survived the reboot
     exit_code=0
@@ -85,7 +85,7 @@ test_machine_rootfs_persists_across_reboot() {
 
     # Clean up
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     ensure_data_dir_deleted "$vm_name"
 
     [[ $exit_code -eq 0 ]] && [[ "$output" == *"persistence-test-ok"* ]]
@@ -95,12 +95,12 @@ test_machine_overlay_size() {
     local vm_name="test-vm-overlay-size"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     # Create VM with custom overlay size (4 GiB)
-    $SMOLVM machine create "$vm_name" --overlay 4 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" --overlay 4 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         return 1
     }
 
@@ -110,7 +110,7 @@ test_machine_overlay_size() {
 
     # Cleanup
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     ensure_data_dir_deleted "$vm_name"
 
     # The 4GB overlay should show ~3800-4096 MB total (ext4 overhead)
@@ -123,15 +123,15 @@ test_machine_overlay_size() {
 test_machine_images() {
     # Start default machine and check images command
     $SMOLVM machine stop 2>/dev/null || true
-    $SMOLVM machine delete default -f 2>/dev/null || true
-    $SMOLVM machine create --net default 2>/dev/null || true
+    $SMOLVM machine delete --name default -f 2>/dev/null || true
+    $SMOLVM machine create --net --name default 2>/dev/null || true
     $SMOLVM machine start --name default 2>/dev/null || true
 
     local output
     output=$($SMOLVM machine images --name default 2>&1)
 
     $SMOLVM machine stop 2>/dev/null || true
-    $SMOLVM machine delete default -f 2>/dev/null || true
+    $SMOLVM machine delete --name default -f 2>/dev/null || true
 
     # Should show storage info
     [[ "$output" == *"Storage"* ]] || [[ "$output" == *"storage"* ]]
@@ -139,15 +139,15 @@ test_machine_images() {
 
 test_machine_prune_dry_run() {
     $SMOLVM machine stop 2>/dev/null || true
-    $SMOLVM machine delete default -f 2>/dev/null || true
-    $SMOLVM machine create --net default 2>/dev/null || true
+    $SMOLVM machine delete --name default -f 2>/dev/null || true
+    $SMOLVM machine create --net --name default 2>/dev/null || true
     $SMOLVM machine start --name default 2>/dev/null || true
 
     local output
     output=$($SMOLVM machine prune --name default --dry-run 2>&1)
 
     $SMOLVM machine stop 2>/dev/null || true
-    $SMOLVM machine delete default -f 2>/dev/null || true
+    $SMOLVM machine delete --name default -f 2>/dev/null || true
 
     # Should complete without error
     [[ $? -eq 0 ]] || [[ "$output" == *"unreferenced"* ]] || [[ "$output" == *"No unreferenced"* ]]
@@ -232,8 +232,8 @@ test_prune_all_refuses_on_running_vm() {
 test_prune_all_removes_images() {
     # Start with a clean machine that has an image cached
     $SMOLVM machine stop 2>/dev/null || true
-    $SMOLVM machine delete default -f 2>/dev/null || true
-    $SMOLVM machine create --image alpine --net default 2>&1 || return 1
+    $SMOLVM machine delete --name default -f 2>/dev/null || true
+    $SMOLVM machine create --image alpine --net --name default 2>&1 || return 1
     $SMOLVM machine start 2>&1 || return 1
 
     # Verify the image is cached
@@ -250,18 +250,18 @@ test_prune_all_removes_images() {
     local output
     output=$($SMOLVM machine prune --name default --all 2>&1) || {
         echo "prune --all failed: $output"
-        $SMOLVM machine delete default -f 2>/dev/null
+        $SMOLVM machine delete --name default -f 2>/dev/null
         return 1
     }
     [[ "$output" == *"Removed"* ]] || [[ "$output" == *"No cached images"* ]] || {
         echo "unexpected prune output: $output"
-        $SMOLVM machine delete default -f 2>/dev/null
+        $SMOLVM machine delete --name default -f 2>/dev/null
         return 1
     }
 
     # Restart and verify images are gone
     $SMOLVM machine start 2>&1 || {
-        $SMOLVM machine delete default -f 2>/dev/null
+        $SMOLVM machine delete --name default -f 2>/dev/null
         return 1
     }
 
@@ -269,7 +269,7 @@ test_prune_all_removes_images() {
     images_after=$($SMOLVM machine images --name default 2>&1)
 
     $SMOLVM machine stop 2>/dev/null || true
-    $SMOLVM machine delete default -f 2>/dev/null || true
+    $SMOLVM machine delete --name default -f 2>/dev/null || true
 
     # After prune --all, no images should remain
     if echo "$images_after" | grep -qE "^[a-z].*[0-9]+ MB"; then

--- a/tests/test_virtio_net.sh
+++ b/tests/test_virtio_net.sh
@@ -68,10 +68,10 @@ test_machine_create_virtio_net_works() {
     local vm_name="virtio-create-test-$$"
     local output
 
-    output=$($SMOLVM machine create "$vm_name" --net --net-backend virtio-net 2>&1) || {
-        echo "expected virtio-net machine create to succeed"
+    output=$($SMOLVM machine create --name "$vm_name" --net --net-backend virtio-net 2>&1) || {
+        echo "expected virtio-net machine create --name to succeed"
         echo "$output"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
 
@@ -79,49 +79,49 @@ test_machine_create_virtio_net_works() {
     list_output=$($SMOLVM machine ls --json 2>&1)
     [[ "$list_output" == *"$vm_name"* ]] || {
         echo "virtio-net create should persist machine state"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
 
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 }
 
 test_machine_create_start_exec_virtio_net_works() {
     cleanup_machine
     local vm_name="virtio-create-start-exec-test-$$"
 
-    $SMOLVM machine create "$vm_name" --image "$VIRTIO_TEST_IMAGE" --net --net-backend virtio-net >/dev/null 2>&1 || {
-        echo "expected virtio-net machine create to succeed before start"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine create --name "$vm_name" --image "$VIRTIO_TEST_IMAGE" --net --net-backend virtio-net >/dev/null 2>&1 || {
+        echo "expected virtio-net machine create --name to succeed before start"
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
 
     $SMOLVM machine start --name "$vm_name" >/dev/null 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f >/dev/null 2>&1 || true
+        $SMOLVM machine delete --name "$vm_name" -f >/dev/null 2>&1 || true
         return 1
     }
     probe_running_virtio_guest_network "$vm_name" || {
         $SMOLVM machine stop --name "$vm_name" >/dev/null 2>&1 || true
-        $SMOLVM machine delete "$vm_name" -f >/dev/null 2>&1 || true
+        $SMOLVM machine delete --name "$vm_name" -f >/dev/null 2>&1 || true
         return 1
     }
 
     $SMOLVM machine stop --name "$vm_name" >/dev/null 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f >/dev/null 2>&1 || true
+        $SMOLVM machine delete --name "$vm_name" -f >/dev/null 2>&1 || true
         return 1
     }
     $SMOLVM machine start --name "$vm_name" >/dev/null 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f >/dev/null 2>&1 || true
+        $SMOLVM machine delete --name "$vm_name" -f >/dev/null 2>&1 || true
         return 1
     }
     probe_running_virtio_guest_network "$vm_name" || {
         $SMOLVM machine stop --name "$vm_name" >/dev/null 2>&1 || true
-        $SMOLVM machine delete "$vm_name" -f >/dev/null 2>&1 || true
+        $SMOLVM machine delete --name "$vm_name" -f >/dev/null 2>&1 || true
         return 1
     }
 
     $SMOLVM machine stop --name "$vm_name" >/dev/null 2>&1 || true
-    $SMOLVM machine delete "$vm_name" -f >/dev/null 2>&1 || true
+    $SMOLVM machine delete --name "$vm_name" -f >/dev/null 2>&1 || true
 }
 
 test_machine_run_virtio_net_works() {
@@ -206,10 +206,10 @@ test_machine_create_virtio_net_policy_rejected() {
     local exit_code=0
     local output
 
-    output=$($SMOLVM machine create "$vm_name" --net --net-backend virtio-net --allow-cidr 1.1.1.1/32 2>&1) || exit_code=$?
+    output=$($SMOLVM machine create --name "$vm_name" --net --net-backend virtio-net --allow-cidr 1.1.1.1/32 2>&1) || exit_code=$?
     [[ $exit_code -ne 0 ]] || {
         echo "expected create failure for virtio-net policy request"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
         return 1
     }
     [[ "$output" == *"allow-cidr/allow-host policies are not supported"* ]] || {

--- a/tests/test_volumes.sh
+++ b/tests/test_volumes.sh
@@ -24,7 +24,7 @@ test_machine_volume_mount_visible_to_exec() {
 
     # Clean up any existing
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     # Create a host directory with a test file
     local tmpdir
@@ -32,12 +32,12 @@ test_machine_volume_mount_visible_to_exec() {
     echo "volume-mount-marker-54321" > "$tmpdir/testfile.txt"
 
     # Create and start VM with volume mount
-    $SMOLVM machine create "$vm_name" -v "$tmpdir:/mnt/hostdata" 2>&1 || {
+    $SMOLVM machine create --name "$vm_name" -v "$tmpdir:/mnt/hostdata" 2>&1 || {
         rm -rf "$tmpdir"
         return 1
     }
     $SMOLVM machine start --name "$vm_name" 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         rm -rf "$tmpdir"
         return 1
     }
@@ -48,7 +48,7 @@ test_machine_volume_mount_visible_to_exec() {
 
     # Cleanup
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     rm -rf "$tmpdir"
     ensure_data_dir_deleted "$vm_name"
 
@@ -59,17 +59,17 @@ test_volume_mount_workspace_is_virtiofs_not_symlink() {
     local vm_name="vol-ws-virtiofs-$$"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     local tmpdir
     tmpdir=$(mktemp -d)
     echo "host-workspace-content" > "$tmpdir/host.txt"
 
-    $SMOLVM machine create "$vm_name" -v "$tmpdir:/workspace" 2>&1 || {
+    $SMOLVM machine create --name "$vm_name" -v "$tmpdir:/workspace" 2>&1 || {
         rm -rf "$tmpdir"; return 1
     }
     $SMOLVM machine start --name "$vm_name" 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         rm -rf "$tmpdir"; return 1
     }
 
@@ -78,7 +78,7 @@ test_volume_mount_workspace_is_virtiofs_not_symlink() {
     link_check=$($SMOLVM machine exec --name "$vm_name" -- sh -c '[ -L /workspace ] && echo SYMLINK || echo MOUNT' 2>&1)
     if [[ "$link_check" == *"SYMLINK"* ]]; then
         echo "FAIL: /workspace is a symlink, expected virtiofs bind mount"
-        $SMOLVM machine stop --name "$vm_name" 2>/dev/null; $SMOLVM machine delete "$vm_name" -f 2>/dev/null; rm -rf "$tmpdir"
+        $SMOLVM machine stop --name "$vm_name" 2>/dev/null; $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; rm -rf "$tmpdir"
         return 1
     fi
 
@@ -87,7 +87,7 @@ test_volume_mount_workspace_is_virtiofs_not_symlink() {
     content=$($SMOLVM machine exec --name "$vm_name" -- cat /workspace/host.txt 2>&1)
     if [[ "$content" != *"host-workspace-content"* ]]; then
         echo "FAIL: host file not visible at /workspace: $content"
-        $SMOLVM machine stop --name "$vm_name" 2>/dev/null; $SMOLVM machine delete "$vm_name" -f 2>/dev/null; rm -rf "$tmpdir"
+        $SMOLVM machine stop --name "$vm_name" 2>/dev/null; $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; rm -rf "$tmpdir"
         return 1
     fi
 
@@ -95,12 +95,12 @@ test_volume_mount_workspace_is_virtiofs_not_symlink() {
     $SMOLVM machine exec --name "$vm_name" -- sh -c 'echo guest-wrote > /workspace/guest.txt' 2>&1
     if [[ ! -f "$tmpdir/guest.txt" ]] || [[ "$(cat "$tmpdir/guest.txt")" != *"guest-wrote"* ]]; then
         echo "FAIL: guest write not visible on host"
-        $SMOLVM machine stop --name "$vm_name" 2>/dev/null; $SMOLVM machine delete "$vm_name" -f 2>/dev/null; rm -rf "$tmpdir"
+        $SMOLVM machine stop --name "$vm_name" 2>/dev/null; $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; rm -rf "$tmpdir"
         return 1
     fi
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     rm -rf "$tmpdir"
 }
 
@@ -108,17 +108,17 @@ test_volume_mount_arbitrary_path() {
     local vm_name="vol-arb-path-$$"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     local tmpdir
     tmpdir=$(mktemp -d)
     echo "arbitrary-path-content" > "$tmpdir/data.txt"
 
-    $SMOLVM machine create "$vm_name" -v "$tmpdir:/data" 2>&1 || {
+    $SMOLVM machine create --name "$vm_name" -v "$tmpdir:/data" 2>&1 || {
         rm -rf "$tmpdir"; return 1
     }
     $SMOLVM machine start --name "$vm_name" 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         rm -rf "$tmpdir"; return 1
     }
 
@@ -126,7 +126,7 @@ test_volume_mount_arbitrary_path() {
     content=$($SMOLVM machine exec --name "$vm_name" -- cat /data/data.txt 2>&1)
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     rm -rf "$tmpdir"
 
     [[ "$content" == *"arbitrary-path-content"* ]]
@@ -136,11 +136,11 @@ test_default_workspace_symlink_without_volume() {
     local vm_name="vol-ws-default-$$"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
-    $SMOLVM machine create "$vm_name" 2>&1 || return 1
+    $SMOLVM machine create --name "$vm_name" 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 || {
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null; return 1
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1
     }
 
     # /workspace should be a symlink to /storage/workspace
@@ -148,7 +148,7 @@ test_default_workspace_symlink_without_volume() {
     target=$($SMOLVM machine exec --name "$vm_name" -- readlink /workspace 2>&1)
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     [[ "$target" == *"/storage/workspace"* ]]
 }
@@ -157,20 +157,20 @@ test_image_exec_volume_mount_visible() {
     local vm_name="imgexec-vol-test-$$"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     local tmpdir
     tmpdir=$(mktemp -d)
     echo "exec-volume-regression-marker" > "$tmpdir/marker.txt"
 
-    $SMOLVM machine create "$vm_name" --image alpine:latest --net \
+    $SMOLVM machine create --name "$vm_name" --image alpine:latest --net \
         -v "$tmpdir:/hostdata" 2>&1 || { rm -rf "$tmpdir"; return 1; }
 
     local start_out
     start_out=$(run_with_timeout 90 $SMOLVM machine start --name "$vm_name" 2>&1)
     if [[ $? -eq 124 ]]; then
         echo "TIMEOUT on start"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         rm -rf "$tmpdir"
         return 1
     fi
@@ -180,7 +180,7 @@ test_image_exec_volume_mount_visible() {
     local exec_rc=$?
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     rm -rf "$tmpdir"
 
     [[ $exec_rc -eq 124 ]] && { echo "TIMEOUT on exec"; return 1; }
@@ -191,7 +191,7 @@ test_image_exec_volume_mount_visible_smolfile() {
     local vm_name="imgexec-sf-vol-test-$$"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
     local tmpdir
     tmpdir=$(mktemp -d)
@@ -211,14 +211,14 @@ EOF
 
     (
         cd "$tmpdir"
-        $SMOLVM machine create "$vm_name" -s Smolfile.toml 2>&1
+        $SMOLVM machine create --name "$vm_name" -s Smolfile.toml 2>&1
     ) || { rm -rf "$tmpdir"; return 1; }
 
     local start_out
     start_out=$(run_with_timeout 90 $SMOLVM machine start --name "$vm_name" 2>&1)
     if [[ $? -eq 124 ]]; then
         echo "TIMEOUT on start"
-        $SMOLVM machine delete "$vm_name" -f 2>/dev/null
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         rm -rf "$tmpdir"
         return 1
     fi
@@ -228,7 +228,7 @@ EOF
     local exec_rc=$?
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
-    $SMOLVM machine delete "$vm_name" -f 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     rm -rf "$tmpdir"
 
     [[ $exec_rc -eq 124 ]] && { echo "TIMEOUT on exec"; return 1; }


### PR DESCRIPTION
All machine subcommands now take `-n/--name` (fork: `--golden` + `--name`); old positionals error loudly instead of parsing as something else. Tests, docs, examples updated. Fixes #370