### PR TITLE
build: re-vendor linux-x86_64 libkrun with GPU (fixes #369)

### DIFF
--- a/lib/linux-x86_64/libkrun.so
+++ b/lib/linux-x86_64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2409f174c947bd6c97069ca888861a724b88a57c841baa3ca823421764f2f6a7
-size 7581152
+oid sha256:66bbcbbecd50c7cddc746ddfee9b011888d79e6014988aa7de73266253ade920
+size 7948480

--- a/lib/linux-x86_64/libkrun.so.1.17.3
+++ b/lib/linux-x86_64/libkrun.so.1.17.3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2409f174c947bd6c97069ca888861a724b88a57c841baa3ca823421764f2f6a7
-size 7581152
+oid sha256:66bbcbbecd50c7cddc746ddfee9b011888d79e6014988aa7de73266253ade920
+size 7948480


### PR DESCRIPTION
The committed .so was built without GPU=1 — zero virgl symbols, so `--gpu` booted with no /dev/dri. Rebuilt via `scripts/build-libkrun-linux.sh` in debian:11: GPU symbols back, block-CoW/virtio-net intact, glibc floor drops 2.34→2.30. Verified live: `--gpu` shows card0+renderD128, cold boot and fork work. Fixes #369