### PR TITLE
virtio-net fixes for Linux fleet nodes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -60,6 +60,15 @@ fn has_library(name: &str) -> bool {
 }
 
 fn main() {
+    // Build scripts run on the HOST: `cfg!(target_os)` here describes the
+    // build machine, not the artifact. Cross-compiling smolvm from macOS to
+    // Linux (zigbuild) must NOT emit macOS-only linker args (-sectcreate,
+    // -weak-lkrun) — gate every emission on the actual compile target.
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    if target_os != "macos" {
+        return;
+    }
+
     // On macOS, create a placeholder __SMOLVM,__smolvm Mach-O section.
     // This section is replaced with real data by `smolvm pack --single-file`.
     // The placeholder marker is NOT the SMOLSECT magic, so detect.rs won't

--- a/build.rs
+++ b/build.rs
@@ -65,30 +65,28 @@ fn main() {
     // Linux (zigbuild) must NOT emit macOS-only linker args (-sectcreate,
     // -weak-lkrun) — gate every emission on the actual compile target.
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
-    if target_os != "macos" {
-        return;
-    }
+    if target_os == "macos" {
+        // On macOS, create a placeholder __SMOLVM,__smolvm Mach-O section.
+        // This section is replaced with real data by `smolvm pack --single-file`.
+        // The placeholder marker is NOT the SMOLSECT magic, so detect.rs won't
+        // false-positive on a normal smolvm binary.
+        #[cfg(target_os = "macos")]
+        {
+            use std::io::Write;
+            let out_dir = std::env::var("OUT_DIR").unwrap();
+            let placeholder_path = format!("{}/smolvm_placeholder.bin", out_dir);
+            let mut f = std::fs::File::create(&placeholder_path).unwrap();
+            f.write_all(b"SMOLVM_SECTION_PLACEHOLDER_V1").unwrap();
+            f.write_all(&[0u8; 4]).unwrap();
+            println!(
+                "cargo:rustc-link-arg=-Wl,-sectcreate,__SMOLVM,__smolvm,{}",
+                placeholder_path
+            );
+        }
 
-    // On macOS, create a placeholder __SMOLVM,__smolvm Mach-O section.
-    // This section is replaced with real data by `smolvm pack --single-file`.
-    // The placeholder marker is NOT the SMOLSECT magic, so detect.rs won't
-    // false-positive on a normal smolvm binary.
-    #[cfg(target_os = "macos")]
-    {
-        use std::io::Write;
-        let out_dir = std::env::var("OUT_DIR").unwrap();
-        let placeholder_path = format!("{}/smolvm_placeholder.bin", out_dir);
-        let mut f = std::fs::File::create(&placeholder_path).unwrap();
-        f.write_all(b"SMOLVM_SECTION_PLACEHOLDER_V1").unwrap();
-        f.write_all(&[0u8; 4]).unwrap();
-        println!(
-            "cargo:rustc-link-arg=-Wl,-sectcreate,__SMOLVM,__smolvm,{}",
-            placeholder_path
-        );
+        #[cfg(target_os = "macos")]
+        link_libkrun();
     }
-
-    #[cfg(target_os = "macos")]
-    link_libkrun();
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/smolvm-agent/src/network/linux.rs
+++ b/crates/smolvm-agent/src/network/linux.rs
@@ -312,8 +312,44 @@ fn add_default_route_v6(gateway: Ipv6Addr) -> Result<(), String> {
 /// DNS configuration in a minimal Linux guest is usually conveyed through
 /// `/etc/resolv.conf`, and that is enough for the MVP.
 fn write_resolv_conf(dns_server: Ipv4Addr) -> Result<(), String> {
-    std::fs::write("/etc/resolv.conf", format!("nameserver {}\n", dns_server))
-        .map_err(|err| format!("failed to write /etc/resolv.conf: {}", err))
+    let contents = format!("nameserver {}\n", dns_server);
+    let direct_err = match std::fs::write("/etc/resolv.conf", &contents) {
+        Ok(()) => return Ok(()),
+        Err(err) => err,
+    };
+
+    // Read-only /etc (the Linux agent rootfs boots read-only — same trap class
+    // as the read-only /tmp): stage the file on the tmpfs /tmp and bind-mount
+    // it over /etc/resolv.conf. And in NO case may DNS config kill the boot —
+    // the interface, routes, and egress NAT are already up; a guest without
+    // resolv.conf still serves published ports and numeric egress — so any
+    // residual failure degrades to a WARN instead of an Err (which the caller
+    // treats as fatal for PID 1).
+    let staged = "/tmp/.smolvm-resolv.conf";
+    if let Err(e) = std::fs::write(staged, &contents) {
+        tracing::warn!(error = %e, original = %direct_err,
+            "resolv.conf unwritable and tmpfs staging failed; continuing without DNS config");
+        return Ok(());
+    }
+    let src = std::ffi::CString::new(staged).expect("static path");
+    let dst = std::ffi::CString::new("/etc/resolv.conf").expect("static path");
+    let rc = unsafe {
+        libc::mount(
+            src.as_ptr(),
+            dst.as_ptr(),
+            std::ptr::null(),
+            libc::MS_BIND,
+            std::ptr::null(),
+        )
+    };
+    if rc != 0 {
+        tracing::warn!(
+            error = %std::io::Error::last_os_error(),
+            original = %direct_err,
+            "resolv.conf bind-mount fallback failed; continuing without DNS config"
+        );
+    }
+    Ok(())
 }
 
 /// Create a datagram socket used only as an ioctl control handle.

--- a/crates/smolvm-network/src/tcp_listeners.rs
+++ b/crates/smolvm-network/src/tcp_listeners.rs
@@ -73,23 +73,38 @@ impl TcpPortListeners {
         let shutdown = Arc::new(AtomicBool::new(false));
         let mut handles = Vec::with_capacity(port_mappings.len());
 
+        // Published ports bind loopback by default. `SMOLVM_PUBLISH_ADDR`
+        // widens that for fleet nodes whose ingress proxy connects from
+        // another host (the control plane): `0.0.0.0` (or any address) makes
+        // the cross-host hop possible — pair it with a firewall on the port
+        // range, since whatever can reach the address can reach the port.
+        let publish_addr: Ipv4Addr = std::env::var("SMOLVM_PUBLISH_ADDR")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(Ipv4Addr::LOCALHOST);
+        let publish_v6 = if publish_addr == Ipv4Addr::UNSPECIFIED {
+            Ipv6Addr::UNSPECIFIED
+        } else {
+            Ipv6Addr::LOCALHOST
+        };
+
         for mapping in port_mappings {
-            // The IPv4 loopback listener is required; the IPv6 one is
-            // best-effort so hosts without IPv6 still publish normally.
-            let listener = match TcpListener::bind((Ipv4Addr::LOCALHOST, mapping.host)) {
+            // The IPv4 listener is required; the IPv6 one is best-effort so
+            // hosts without IPv6 still publish normally.
+            let listener = match TcpListener::bind((publish_addr, mapping.host)) {
                 Ok(listener) => listener,
                 Err(err) => {
                     shutdown_all(&shutdown, &mut handles);
                     return Err(err);
                 }
             };
-            let listener_v6 = match TcpListener::bind((Ipv6Addr::LOCALHOST, mapping.host)) {
+            let listener_v6 = match TcpListener::bind((publish_v6, mapping.host)) {
                 Ok(listener) => Some(listener),
                 Err(err) => {
                     tracing::debug!(
                         host_port = mapping.host,
                         error = %err,
-                        "skipping IPv6 loopback listener for published port"
+                        "skipping IPv6 listener for published port"
                     );
                     None
                 }


### PR DESCRIPTION
Three fixes found bringing machine ingress live on the GCP fleet:

1. **Agent: resolv.conf on a read-only rootfs killed the boot.** The Linux agent rootfs boots read-only; writing /etc/resolv.conf failed with EACCES and the error was fatal to PID 1 (VM stopped, host saw a monitor timeout). Now stages the file on the tmpfs /tmp and bind-mounts it over /etc/resolv.conf, and DNS config failure degrades to a WARN — the interface/routes/NAT are already up.
2. **Published ports: honor SMOLVM_PUBLISH_ADDR.** The listener hardcoded loopback, making cross-host ingress (control-plane proxy → node) impossible; the env var (paired with the subnet firewall on the port range) widens the bind. 0.0.0.0 also switches the v6 listener to [::].
3. **build.rs: gate on CARGO_CFG_TARGET_OS.** cfg!(target_os) in a build script reads the HOST, so cross-compiling from macOS leaked -sectcreate/-weak-lkrun into the Linux link.

Verified live end-to-end: public internet → api.smolmachines.com /proxy → worker virtio gateway → container, HTTP 200.