### PR TITLE
Exec stdin for image-backed machines

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -1950,6 +1950,7 @@ fn handle_request(
             tty: false,
             detached: false,
             persistent_overlay_id,
+            stdin_data,
             background,
         } => {
             if background {
@@ -1972,6 +1973,7 @@ fn handle_request(
                     &mounts,
                     timeout_ms,
                     persistent_overlay_id.as_deref(),
+                    stdin_data.as_deref(),
                     client_fd,
                 )
             }
@@ -4343,9 +4345,10 @@ fn handle_run(
     mounts: &[(String, String, bool)],
     timeout_ms: Option<u64>,
     persistent_overlay_id: Option<&str>,
+    stdin_data: Option<&str>,
     client_fd: Option<std::os::unix::io::RawFd>,
 ) -> AgentResponse {
-    info!(image = %image, command = ?command, mounts = ?mounts, timeout_ms = ?timeout_ms, persistent = persistent_overlay_id.is_some(), "running command");
+    info!(image = %image, command = ?command, mounts = ?mounts, timeout_ms = ?timeout_ms, persistent = persistent_overlay_id.is_some(), stdin = stdin_data.is_some(), "running command");
 
     match storage::run_command(
         image,
@@ -4356,6 +4359,7 @@ fn handle_run(
         mounts,
         timeout_ms,
         persistent_overlay_id,
+        stdin_data,
         client_fd,
     ) {
         Ok(result) => oversized_output_error(&result.stdout, &result.stderr).unwrap_or(

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -2120,6 +2120,7 @@ pub fn run_command(
     mounts: &[(String, String, bool)],
     timeout_ms: Option<u64>,
     persistent_overlay_id: Option<&str>,
+    stdin_data: Option<&str>,
     client_fd: Option<std::os::unix::io::RawFd>,
 ) -> Result<RunResult> {
     // Validate inputs
@@ -2181,7 +2182,13 @@ pub fn run_command(
         let container_id = generate_container_id();
 
         // Run with crun
-        let result = run_with_crun(&bundle_path, &container_id, timeout_ms, client_fd);
+        let result = run_with_crun(
+            &bundle_path,
+            &container_id,
+            timeout_ms,
+            stdin_data,
+            client_fd,
+        );
 
         // Note: virtiofs mounts are left in place for reuse
         // They will be cleaned up when the overlay is cleaned up or the VM shuts down
@@ -2505,6 +2512,7 @@ fn run_with_crun(
     bundle_dir: &Path,
     container_id: &str,
     timeout_ms: Option<u64>,
+    stdin_data: Option<&str>,
     client_fd: Option<std::os::unix::io::RawFd>,
 ) -> Result<RunResult> {
     info!(
@@ -2515,19 +2523,38 @@ fn run_with_crun(
     );
 
     // Spawn the container using CrunCommand.
-    // stdin_null() is critical: without it, crun inherits the agent's vsock
-    // stdin, and /bin/sh reads protocol bytes instead of user input, hanging.
-    let mut child = CrunCommand::run(bundle_dir, container_id)
-        .stdin_null()
-        .capture_output()
-        .spawn()
-        .map_err(|e| {
-            StorageError::new(format!(
-                "failed to spawn crun: {}. Is crun installed at {}?",
-                e,
-                paths::CRUN_PATH
-            ))
-        })?;
+    // stdin_null() is critical when no input is supplied: without it, crun
+    // inherits the agent's vsock stdin, and /bin/sh reads protocol bytes
+    // instead of user input, hanging. With input, pipe it in and close the
+    // pipe so the command sees EOF (same contract as the bare-VM exec path).
+    let builder = CrunCommand::run(bundle_dir, container_id);
+    let builder = if stdin_data.is_some() {
+        builder.stdin_piped()
+    } else {
+        builder.stdin_null()
+    };
+    let mut child = builder.capture_output().spawn().map_err(|e| {
+        StorageError::new(format!(
+            "failed to spawn crun: {}. Is crun installed at {}?",
+            e,
+            paths::CRUN_PATH
+        ))
+    })?;
+
+    // Write stdin on a separate thread so the wait/timeout loop stays live
+    // even if the child never reads and the pipe buffer fills. Dropping the
+    // handle closes the pipe → EOF.
+    let _stdin_writer = stdin_data.and_then(|data| {
+        child.stdin.take().map(|mut child_stdin| {
+            let data = data.to_owned();
+            std::thread::Builder::new()
+                .name("run-stdin".into())
+                .spawn(move || {
+                    use std::io::Write;
+                    let _ = child_stdin.write_all(data.as_bytes());
+                })
+        })
+    });
 
     // Capture container_id for the cleanup closure
     let cid = container_id.to_string();

--- a/crates/smolvm-protocol/src/lib.rs
+++ b/crates/smolvm-protocol/src/lib.rs
@@ -294,6 +294,10 @@ pub enum AgentRequest {
         /// created and destroyed after the run.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         persistent_overlay_id: Option<String>,
+        /// Data to pipe to the command's stdin (non-interactive runs only).
+        /// The pipe is closed after writing, so the command sees EOF.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        stdin_data: Option<String>,
         /// Spawn the container and return immediately with the crun PID.
         /// The container runs detached; stdout/stderr go to /dev/null.
         /// Incompatible with `interactive` and `tty`.

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -159,6 +159,9 @@ pub struct RunConfig {
     /// Persistent overlay ID. If set, the overlay persists across exec sessions
     /// so filesystem changes (e.g. package installs) survive.
     pub persistent_overlay_id: Option<String>,
+    /// Data to pipe to the command's stdin (non-interactive runs only). The
+    /// pipe is closed after writing so the command sees EOF.
+    pub stdin: Option<String>,
 }
 
 impl RunConfig {
@@ -178,6 +181,7 @@ impl RunConfig {
             timeout: None,
             tty: false,
             persistent_overlay_id: None,
+            stdin: None,
         }
     }
 
@@ -214,6 +218,12 @@ impl RunConfig {
     /// Enable TTY mode.
     pub fn with_tty(mut self, tty: bool) -> Self {
         self.tty = tty;
+        self
+    }
+
+    /// Set stdin data piped to the command (non-interactive runs).
+    pub fn with_stdin(mut self, stdin: Option<String>) -> Self {
+        self.stdin = stdin;
         self
     }
 
@@ -1130,6 +1140,7 @@ impl AgentClient {
             tty: false,
             detached: false,
             persistent_overlay_id: config.persistent_overlay_id,
+            stdin_data: config.stdin,
             background: false,
         })?;
 
@@ -1154,6 +1165,7 @@ impl AgentClient {
             tty: false,
             detached: false,
             persistent_overlay_id: config.persistent_overlay_id,
+            stdin_data: None,
             background: true,
         })?;
 
@@ -1194,6 +1206,7 @@ impl AgentClient {
             tty: false,
             detached: false,
             persistent_overlay_id: config.persistent_overlay_id,
+            stdin_data: None,
             background: false,
         })?;
 
@@ -1228,6 +1241,7 @@ impl AgentClient {
                 tty,
                 detached: false,
                 persistent_overlay_id: config.persistent_overlay_id,
+                stdin_data: None,
                 background: false,
             },
             tty,
@@ -1262,6 +1276,7 @@ impl AgentClient {
             tty: false,
             detached: true,
             persistent_overlay_id: config.persistent_overlay_id,
+            stdin_data: None,
             background: false,
         })?;
         let (exit_code, stdout, _) = expect_completed(resp, "run container detached")?;
@@ -1457,6 +1472,7 @@ impl AgentClient {
                 tty,
                 detached: false,
                 persistent_overlay_id: config.persistent_overlay_id,
+                stdin_data: None,
                 background: false,
             },
             input,

--- a/src/api/handlers/exec.rs
+++ b/src/api/handlers/exec.rs
@@ -132,8 +132,7 @@ pub async fn exec_command(
     // per-machine persistent overlay so filesystem changes persist across exec
     // sessions. Without this, exec runs in the bare agent VM (no `python3`,
     // etc.) — the image is never entered. Plain machines exec in the VM
-    // directly via `vm_exec`. (The `Run` path does not carry stdin yet, so
-    // stdin is ignored for image-machine exec — tracked separately.)
+    // directly via `vm_exec`.
     let machine_image = state
         .db()
         .get_vm(&id)
@@ -151,6 +150,7 @@ pub async fn exec_command(
                 .collect::<Vec<_>>()
         };
         let overlay_id = id.clone();
+        let stdin_data = stdin_data.clone();
         with_machine_client_traced(&entry, tid, move |c| {
             // Pull only if the image isn't already present — avoids a registry
             // round-trip on every exec, and works once cached even on
@@ -163,7 +163,8 @@ pub async fn exec_command(
                 .with_workdir(workdir)
                 .with_mounts(mounts_config)
                 .with_timeout(timeout)
-                .with_persistent_overlay(Some(overlay_id));
+                .with_persistent_overlay(Some(overlay_id))
+                .with_stdin(stdin_data);
             c.run_non_interactive(config)
         })
         .await?


### PR DESCRIPTION
`AgentRequest::Run` (the image-machine exec path) never carried stdin — only bare-VM `Exec` did — so API exec `stdin` was silently dropped for every image-backed machine (the common cloud case). Adds `stdin_data` to the Run protocol (serde-default, backward compatible), pipes it into the crun child on a writer thread with EOF-on-close (same contract as the Exec path), and threads it through `RunConfig`/the serve exec handler.

Verified locally (serve, image machine: `cat` echoes piped input) and live on the cloud fleet — the previously-skipped Linzumi stdin e2e now passes 6/6 against api.smolmachines.com.