### PR TITLE
fix(net): published ports auto-select virtio-net (TSI is outbound-only)

### DIFF
--- a/src/network/launch.rs
+++ b/src/network/launch.rs
@@ -50,7 +50,18 @@ pub fn plan_launch_network(
         };
     }
 
-    match resources.network_backend.unwrap_or(NetworkBackend::Tsi) {
+    // Published ports need the inbound path, which only virtio-net provides.
+    // When the caller didn't pick a backend explicitly, default to virtio-net
+    // IFF there are ports (TSI otherwise — it's lighter for outbound-only VMs).
+    // This is ONE rule in the shared launch path, so a machine that's reachable
+    // on a laptop is reachable in the fleet by construction — no per-deployment
+    // backend wiring to drift between local and cloud.
+    let backend = resources.network_backend.unwrap_or(if has_ports {
+        NetworkBackend::VirtioNet
+    } else {
+        NetworkBackend::Tsi
+    });
+    match backend {
         NetworkBackend::Tsi => LaunchNetworkPlan {
             backend: EffectiveNetworkBackend::Tsi,
         },
@@ -70,14 +81,21 @@ pub fn validate_requested_network_backend(
     dns_filter_hosts: Option<&[String]>,
     port_count: usize,
 ) -> crate::Result<()> {
-    let backend = resources.network_backend.unwrap_or(NetworkBackend::Tsi);
+    // Mirror plan_launch_network's default: unset backend + ports ⇒ virtio-net.
+    // So only an EXPLICIT `--net-backend tsi` alongside ports is a misconfig.
+    let backend = resources.network_backend.unwrap_or(if port_count > 0 {
+        NetworkBackend::VirtioNet
+    } else {
+        NetworkBackend::Tsi
+    });
 
-    // Published ports require the inbound path that only virtio-net has.
+    // Published ports require the inbound path that only virtio-net has. With the
+    // default above this only fires when the caller EXPLICITLY forced TSI + ports.
     if port_count > 0 && backend != NetworkBackend::VirtioNet {
         return Err(crate::Error::config(
             "ports",
             "published ports require the virtio-net backend (TSI is outbound-only); \
-             set network backend to virtio-net",
+             remove --net-backend tsi or set it to virtio-net",
         ));
     }
 
@@ -183,11 +201,36 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_ports_require_virtio() {
-        // Ports on the default (TSI) backend are rejected — TSI has no inbound path.
-        let resources = resources();
+    fn test_ports_default_to_virtio() {
+        // Ports with NO explicit backend now auto-select virtio-net (the inbound
+        // path) — both in the plan and in validation, so it "just works".
+        let mut resources = resources();
+        resources.network = true;
+        let plan = plan_launch_network(&resources, None, 1);
+        assert_eq!(plan.backend, EffectiveNetworkBackend::VirtioNet);
+        validate_requested_network_backend(&resources, None, 1).unwrap();
+    }
+
+    #[test]
+    fn test_validate_ports_explicit_tsi_rejected() {
+        // Only an EXPLICIT TSI choice alongside ports is a misconfig (TSI has no
+        // inbound path); the auto-default case above is allowed.
+        let mut resources = resources();
+        resources.network = true;
+        resources.network_backend = Some(NetworkBackend::Tsi);
         let err = validate_requested_network_backend(&resources, None, 1).unwrap_err();
         assert!(err.to_string().contains("require the virtio-net backend"));
+    }
+
+    #[test]
+    fn test_no_ports_defaults_to_tsi() {
+        // Outbound-only VMs keep the lighter TSI default — no virtio overhead.
+        let mut resources = resources();
+        resources.network = true;
+        assert_eq!(
+            plan_launch_network(&resources, None, 0).backend,
+            EffectiveNetworkBackend::Tsi
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem
Published ports were silently unreachable (the cloud `/proxy` 502'd). `plan_launch_network` defaulted every VM to the TSI backend, which is **outbound-only** — it binds the host port but can't forward inbound, so connections reset. The serve path also never called `validate_requested_network_backend`, so the misconfig surfaced as a runtime 502 instead of an error.

## Fix
One rule in the shared launch path: when `network_backend` is unset, **default to virtio-net iff there are published ports** (TSI otherwise). `validate_*` mirrors it, so only an *explicit* `--net-backend tsi` alongside ports is rejected. Because every entry point (CLI, `smol pack run`/`.smolmachine`, `smol deploy` → serve) funnels through `plan_launch_network`, local and cloud get identical behavior — no per-path wiring to drift, and `.smolmachine` bakes no backend so it stays portable.

## Validation
- 27 network unit tests green (added: ports→virtio default, explicit-tsi+ports rejected, no-ports→tsi).
- Local e2e: `machine create -p 18080:80 --net` (no backend) → `curl localhost:18080` = HTTP 200 nginx. Since TSI can't forward inbound, the 200 proves virtio was selected and the macOS smoltcp datapath forwards. No libkrun rebuild needed (both libs already export `krun_add_net_unixstream`).

Cloud rollout (rebuild x86_64 overlay + roll to workers) is the follow-up.