### PR TITLE
fix(net): egress hard-floor — deny metadata/internal for all guests 

### DIFF
--- a/crates/smolvm-network/src/egress.rs
+++ b/crates/smolvm-network/src/egress.rs
@@ -93,17 +93,65 @@ struct AllowList {
     learned: Mutex<HashMap<IpAddr, Instant>>,
 }
 
+/// Whether the platform hard-floor is disabled (trusted single-tenant / local
+/// dev). Default false: link-local/metadata/private/loopback are always denied.
+fn allow_private_egress() -> bool {
+    std::env::var("SMOLVM_EGRESS_ALLOW_PRIVATE")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+/// IPv4 destinations the gateway must NEVER relay to (platform hard-floor).
+fn is_reserved_v4(v4: Ipv4Addr) -> bool {
+    v4.is_loopback()        // 127.0.0.0/8
+        || v4.is_link_local() // 169.254.0.0/16 — incl. 169.254.169.254 (cloud metadata)
+        || v4.is_private()    // 10/8, 172.16/12, 192.168/16 — host/control internal subnet
+        || v4.is_unspecified()
+        || v4.is_broadcast()
+        // 100.64.0.0/10 (CGNAT) — the gateway's own guest/gateway addresses live here.
+        || matches!(v4.octets(), [100, b, ..] if (64..=127).contains(&b))
+}
+
+/// Destinations the gateway must NEVER relay a guest connection to, regardless
+/// of the tenant allow-list — the platform's hard floor. Blocks the cloud
+/// metadata server, the host/control internal subnets, loopback, and the
+/// gateway's own CGNAT range, so a guest cannot steal host credentials, pivot to
+/// the control plane / worker node API, or reach co-resident tenants over the
+/// internal network. Also defeats DNS-rebinding (a learned IP in these ranges is
+/// still denied). Override only for trusted single-tenant/local use with
+/// `SMOLVM_EGRESS_ALLOW_PRIVATE=1`.
+fn is_reserved_destination(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => is_reserved_v4(v4),
+        IpAddr::V6(v6) => {
+            v6.is_loopback()
+                || v6.is_unspecified()
+                || (v6.segments()[0] & 0xffc0) == 0xfe80 // fe80::/10 link-local
+                || (v6.segments()[0] & 0xfe00) == 0xfc00 // fc00::/7 unique-local
+                // IPv4-mapped (::ffff:a.b.c.d) must not bypass the v4 floor.
+                || v6.to_ipv4_mapped().is_some_and(is_reserved_v4)
+        }
+    }
+}
+
 /// Outbound egress policy enforced by the gateway before opening a host
-/// connection. `unrestricted` allows everything (no policy configured).
+/// connection. `unrestricted` allows everything EXCEPT the platform hard-floor
+/// (`is_reserved_destination`), unless `allow_private` is set.
 #[derive(Clone)]
 pub struct EgressPolicy {
     inner: Option<Arc<AllowList>>,
+    /// When false (default), the hard-floor denies metadata/internal/loopback
+    /// regardless of the allow-list. Set via `SMOLVM_EGRESS_ALLOW_PRIVATE=1`.
+    allow_private: bool,
 }
 
 impl EgressPolicy {
-    /// No policy — every destination is allowed.
+    /// No allow-list — every destination is allowed EXCEPT the platform hard-floor.
     pub fn unrestricted() -> Self {
-        Self { inner: None }
+        Self {
+            inner: None,
+            allow_private: allow_private_egress(),
+        }
     }
 
     /// Build from `VmResources::allowed_cidrs` and the `--allow-host` list.
@@ -137,6 +185,7 @@ impl EgressPolicy {
                 allowed_hosts,
                 learned: Mutex::new(HashMap::new()),
             })),
+            allow_private: allow_private_egress(),
         }
     }
 
@@ -171,6 +220,12 @@ impl EgressPolicy {
 
     /// Whether an outbound connection to `ip` (v4 or v6) is permitted.
     pub fn allows(&self, ip: IpAddr) -> bool {
+        // Platform hard-floor: metadata/internal/loopback are denied regardless
+        // of the allow-list (and even when unrestricted), unless explicitly
+        // overridden for trusted single-tenant/local use.
+        if !self.allow_private && is_reserved_destination(ip) {
+            return false;
+        }
         match &self.inner {
             None => true,
             Some(list) => {
@@ -246,11 +301,51 @@ mod tests {
 
     #[test]
     fn cidr_membership_v4() {
-        let policy = EgressPolicy::new(Some(&["10.0.0.0/8".into(), "1.1.1.1".into()]), None);
-        assert!(policy.allows_v4(Ipv4Addr::new(10, 5, 6, 7)));
+        // Public CIDRs only — private ranges are denied by the hard-floor below.
+        let policy = EgressPolicy::new(Some(&["8.8.8.0/24".into(), "1.1.1.1".into()]), None);
+        assert!(policy.allows_v4(Ipv4Addr::new(8, 8, 8, 7)));
         assert!(policy.allows_v4(Ipv4Addr::new(1, 1, 1, 1)));
         assert!(!policy.allows_v4(Ipv4Addr::new(1, 1, 1, 2)));
-        assert!(!policy.allows_v4(Ipv4Addr::new(11, 0, 0, 1)));
+        assert!(!policy.allows_v4(Ipv4Addr::new(9, 0, 0, 1)));
+    }
+
+    #[test]
+    fn hard_floor_denies_metadata_internal_loopback_even_unrestricted() {
+        let p = EgressPolicy::unrestricted();
+        // The exact things the live probe reached.
+        assert!(!p.allows_v4(Ipv4Addr::new(169, 254, 169, 254))); // cloud metadata
+        assert!(!p.allows_v4(Ipv4Addr::new(10, 0, 0, 4))); // worker/control internal
+        assert!(!p.allows_v4(Ipv4Addr::new(127, 0, 0, 1))); // loopback
+        assert!(!p.allows_v4(Ipv4Addr::new(192, 168, 1, 1)));
+        assert!(!p.allows_v4(Ipv4Addr::new(172, 16, 0, 1)));
+        assert!(!p.allows_v4(Ipv4Addr::new(100, 96, 0, 1))); // gateway CGNAT
+                                                             // Public internet still flows.
+        assert!(p.allows_v4(Ipv4Addr::new(1, 1, 1, 1)));
+        assert!(p.allows_v4(Ipv4Addr::new(8, 8, 8, 8)));
+    }
+
+    #[test]
+    fn hard_floor_overrides_allowlist_and_learned_ips() {
+        // A tenant cannot re-open the floor by allow-listing a private range...
+        let p = EgressPolicy::new(Some(&["10.0.0.0/8".into()]), None);
+        assert!(!p.allows_v4(Ipv4Addr::new(10, 0, 0, 4)));
+        // ...nor via DNS-rebinding: a learned internal IP stays denied.
+        let p2 = EgressPolicy::new(None, Some(&["evil.test".into()]));
+        let meta = IpAddr::V4(Ipv4Addr::new(169, 254, 169, 254));
+        p2.learn_ip_records(&[(meta, 300)]);
+        assert!(!p2.allows(meta));
+    }
+
+    #[test]
+    fn hard_floor_blocks_ipv4_mapped_v6_bypass() {
+        let p = EgressPolicy::unrestricted();
+        let mapped: Ipv6Addr = "::ffff:169.254.169.254".parse().unwrap();
+        assert!(!p.allows_v6(mapped));
+        // v6 link-local / ULA also denied.
+        assert!(!p.allows_v6("fe80::1".parse().unwrap()));
+        assert!(!p.allows_v6("fc00::1".parse().unwrap()));
+        // global unicast v6 allowed.
+        assert!(p.allows_v6("2606:4700::1111".parse().unwrap()));
     }
 
     #[test]

--- a/crates/smolvm-network/src/udp_relay.rs
+++ b/crates/smolvm-network/src/udp_relay.rs
@@ -520,9 +520,11 @@ mod tests {
         assert!(should_relay_udp("1.2.3.4:123".parse().unwrap(), &open));
         assert!(!should_relay_udp("1.2.3.4:53".parse().unwrap(), &open));
 
-        let restricted = EgressPolicy::from_allowed_cidrs(Some(&["10.0.0.0/8".into()]));
+        // Public CIDR — a private allow-list entry would be overridden by the
+        // egress hard-floor (see egress.rs tests).
+        let restricted = EgressPolicy::from_allowed_cidrs(Some(&["8.8.8.0/24".into()]));
         assert!(should_relay_udp(
-            "10.1.2.3:123".parse().unwrap(),
+            "8.8.8.3:123".parse().unwrap(),
             &restricted
         ));
         assert!(!should_relay_udp(

--- a/src/network/launch.rs
+++ b/src/network/launch.rs
@@ -53,14 +53,21 @@ pub fn plan_launch_network(
     // Published ports need the inbound path, which only virtio-net provides.
     // When the caller didn't pick a backend explicitly, default to virtio-net
     // IFF there are ports (TSI otherwise — it's lighter for outbound-only VMs).
-    // This is ONE rule in the shared launch path, so a machine that's reachable
-    // on a laptop is reachable in the fleet by construction — no per-deployment
-    // backend wiring to drift between local and cloud.
-    let backend = resources.network_backend.unwrap_or(if has_ports {
-        NetworkBackend::VirtioNet
-    } else {
-        NetworkBackend::Tsi
-    });
+    //
+    // Fleet/multi-tenant mode (SMOLVM_PUBLISH_ADDR set) additionally routes ALL
+    // machines through virtio-net, so the egress hard-floor (the smolvm-network
+    // `EgressPolicy` that denies metadata/internal/loopback) applies to no-ports
+    // machines too. TSI's egress filter lives in libkrun and may not carry the
+    // floor, so a default outbound-only tenant VM must not silently fall to TSI
+    // on a fleet node. Outside fleet mode, no-ports VMs keep the lighter default.
+    let fleet_mode = std::env::var_os("SMOLVM_PUBLISH_ADDR").is_some();
+    let backend = resources
+        .network_backend
+        .unwrap_or(if has_ports || fleet_mode {
+            NetworkBackend::VirtioNet
+        } else {
+            NetworkBackend::Tsi
+        });
     match backend {
         NetworkBackend::Tsi => LaunchNetworkPlan {
             backend: EffectiveNetworkBackend::Tsi,


### PR DESCRIPTION
Egress floor: deny metadata/internal/loopback (169.254/16, RFC1918, 100.64/10, 127/8, v6 link-local/ULA/IPv4-mapped) ahead of the allow-list, including when unrestricted. Override with `SMOLVM_EGRESS_ALLOW_PRIVATE=1`.