### PR TITLE
feat(serve): mTLS for fleet serve API (client-cert verify, fail-closed)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,6 +146,28 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "axum"
@@ -203,6 +234,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "fs-err",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -313,6 +366,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -500,6 +562,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +667,22 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs-err"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+dependencies = [
+ "autocfg",
+ "tokio",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1791,12 +1875,22 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1815,6 +1909,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2053,6 +2148,7 @@ version = "1.0.3"
 dependencies = [
  "async-stream",
  "axum",
+ "axum-server",
  "base64",
  "clap",
  "dirs",
@@ -2068,6 +2164,9 @@ dependencies = [
  "pkg-config",
  "regex",
  "rusqlite",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
  "seccompiler",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,13 @@ tempfile = "3"
 # HTTP API server
 tokio = { version = "1", features = ["full"] }
 axum = { version = "0.8", features = ["macros", "ws"] }
+# mTLS for the fleet serve API (control↔node). axum-server's rustls acceptor
+# does the TLS handshake + client-cert verification; rustls-pemfile parses the
+# CA/cert/key PEMs handed to us at enrollment.
+axum-server = { version = "0.7", features = ["tls-rustls"] }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
+rustls-pemfile = "2"
+rustls-pki-types = "1"
 tower-http = { version = "0.6", features = ["cors", "trace", "timeout"] }
 tokio-stream = "0.1"
 parking_lot = "0.12"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -10,6 +10,7 @@ pub mod pack_run;
 pub mod parsers;
 pub mod proxy_opts;
 pub mod serve;
+pub mod serve_tls;
 pub mod smolfile;
 pub mod vm_common;
 

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -200,9 +200,17 @@ impl ServeStartCmd {
         let drain_state = state.clone();
         let app = smolvm::api::create_router(state, self.cors_origins.clone());
 
+        // Resolve the serve API's TLS posture before binding. In fleet mode this
+        // is fail-closed: a missing/partial mTLS config aborts startup rather
+        // than silently serving plain HTTP (control↔node mTLS, increment 3).
+        let tls = super::serve_tls::resolve_tls().map_err(|e| smolvm::error::Error::Config {
+            operation: "serve tls".to_string(),
+            reason: e.to_string(),
+        })?;
+
         // Listen server on TCP or Unix socket
         match listen_target {
-            ListenTarget::Tcp(addr) => self.serve_tcp(addr, app).await?,
+            ListenTarget::Tcp(addr) => self.serve_tcp(addr, app, tls).await?,
             #[cfg(unix)]
             ListenTarget::Unix(path) => self.serve_unix(path, app).await?,
         }
@@ -231,7 +239,16 @@ impl ServeStartCmd {
         Ok(())
     }
 
-    async fn serve_tcp(&self, addr: SocketAddr, app: Router) -> Result<()> {
+    async fn serve_tcp(
+        &self,
+        addr: SocketAddr,
+        app: Router,
+        tls: Option<std::sync::Arc<rustls::ServerConfig>>,
+    ) -> Result<()> {
+        if let Some(tls_config) = tls {
+            return Self::serve_tcp_tls(addr, app, tls_config).await;
+        }
+
         let listener = tokio::net::TcpListener::bind(addr)
             .await
             .map_err(smolvm::error::Error::Io)?;
@@ -241,6 +258,35 @@ impl ServeStartCmd {
 
         axum::serve(listener, app)
             .with_graceful_shutdown(shutdown_signal())
+            .await
+            .map_err(smolvm::error::Error::Io)
+    }
+
+    /// HTTPS variant with mutual TLS (fleet mode). `axum-server`'s rustls
+    /// acceptor performs the handshake + client-cert verification configured in
+    /// `tls_config`; graceful shutdown is driven through its `Handle` (the
+    /// `axum::serve` graceful-shutdown future doesn't apply here).
+    async fn serve_tcp_tls(
+        addr: SocketAddr,
+        app: Router,
+        tls_config: std::sync::Arc<rustls::ServerConfig>,
+    ) -> Result<()> {
+        let rustls_config = axum_server::tls_rustls::RustlsConfig::from_config(tls_config);
+        let handle = axum_server::Handle::new();
+
+        // Trip graceful shutdown on the same signal the plain path observes.
+        let shutdown_handle = handle.clone();
+        tokio::spawn(async move {
+            shutdown_signal().await;
+            shutdown_handle.graceful_shutdown(Some(std::time::Duration::from_secs(5)));
+        });
+
+        tracing::info!(address = %addr, "starting HTTPS API server (mTLS, client cert required)");
+        println!("smolvm API server listening on https://{} (mTLS)", addr);
+
+        axum_server::bind_rustls(addr, rustls_config)
+            .handle(handle)
+            .serve(app.into_make_service())
             .await
             .map_err(smolvm::error::Error::Io)
     }

--- a/src/cli/serve_tls.rs
+++ b/src/cli/serve_tls.rs
@@ -6,9 +6,12 @@
 //! cert (the control plane) may connect. This module builds the rustls
 //! `ServerConfig` that enforces `require_and_verify_client_cert`.
 //!
-//! **Fail-closed:** in fleet mode (`SMOLVM_PUBLISH_ADDR` set) the serve API
-//! refuses to start without TLS configured — it must never fall back to plain
-//! HTTP / the interim bearer token when it believes it is fleet-managed.
+//! **Fail-closed:** when `SMOLVM_SERVE_REQUIRE_MTLS=1` the serve API refuses to
+//! start without TLS configured — it must never fall back to plain HTTP / the
+//! interim bearer token when the deploy declared it should be mTLS-protected.
+//! This is a DEDICATED opt-in, deliberately NOT keyed off `SMOLVM_PUBLISH_ADDR`
+//! (which every worker sets for the published-port datapath — overloading it
+//! would make plain-HTTP workers refuse to boot).
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -23,12 +26,17 @@ const ENV_CERT: &str = "SMOLVM_SERVE_TLS_CERT";
 const ENV_KEY: &str = "SMOLVM_SERVE_TLS_KEY";
 /// Env var holding the PEM node-CA cert used to verify the control's client cert.
 const ENV_CLIENT_CA: &str = "SMOLVM_SERVE_TLS_CLIENT_CA";
-/// Fleet-mode indicator (also drives force-virtio in the launch path).
-const ENV_FLEET: &str = "SMOLVM_PUBLISH_ADDR";
+/// Dedicated opt-in: the deploy declares this serve API MUST run mTLS. When set,
+/// a missing/partial cert config is fatal (fail-closed) rather than a silent
+/// fall-back to plain HTTP. NOT keyed off `SMOLVM_PUBLISH_ADDR` (see module doc).
+const ENV_REQUIRE_MTLS: &str = "SMOLVM_SERVE_REQUIRE_MTLS";
 
-/// True when this serve process believes it is fleet-managed.
-pub fn fleet_mode() -> bool {
-    std::env::var_os(ENV_FLEET).is_some()
+/// True when the deploy has declared this serve API must be mTLS-protected.
+pub fn require_mtls() -> bool {
+    matches!(
+        std::env::var(ENV_REQUIRE_MTLS).ok().as_deref(),
+        Some("1") | Some("true")
+    )
 }
 
 fn env_path(name: &str) -> Option<PathBuf> {
@@ -40,8 +48,8 @@ fn env_path(name: &str) -> Option<PathBuf> {
 /// Resolve the serve API's TLS posture from the environment.
 ///
 /// - All three TLS env vars set ⇒ `Ok(Some(config))` (mTLS, client cert required).
-/// - None set, not fleet mode ⇒ `Ok(None)` (plain HTTP, local/dev).
-/// - **Fleet mode but TLS not fully configured ⇒ `Err` (fail-closed).**
+/// - None set, mTLS not required ⇒ `Ok(None)` (plain HTTP, local/dev/non-mTLS worker).
+/// - **`SMOLVM_SERVE_REQUIRE_MTLS` set but TLS not fully configured ⇒ `Err` (fail-closed).**
 /// - A partial config (some but not all vars) ⇒ `Err` (misconfiguration).
 pub fn resolve_tls() -> Result<Option<Arc<ServerConfig>>, String> {
     let cert = env_path(ENV_CERT);
@@ -53,10 +61,10 @@ pub fn resolve_tls() -> Result<Option<Arc<ServerConfig>>, String> {
             Ok(Some(build_server_config(&cert, &key, &client_ca)?))
         }
         (None, None, None) => {
-            if fleet_mode() {
+            if require_mtls() {
                 Err(format!(
-                    "fleet mode ({ENV_FLEET} set) requires mTLS, but {ENV_CERT}/{ENV_KEY}/{ENV_CLIENT_CA} are unset — \
-                     refusing to start a fleet serve API without client-cert verification (fail-closed)"
+                    "{ENV_REQUIRE_MTLS} is set but {ENV_CERT}/{ENV_KEY}/{ENV_CLIENT_CA} are unset — \
+                     refusing to start without client-cert verification (fail-closed)"
                 ))
             } else {
                 Ok(None)
@@ -138,26 +146,37 @@ mod tests {
     }
 
     fn clear() {
-        for v in [ENV_CERT, ENV_KEY, ENV_CLIENT_CA, ENV_FLEET] {
+        for v in [ENV_CERT, ENV_KEY, ENV_CLIENT_CA, ENV_REQUIRE_MTLS] {
             std::env::remove_var(v);
         }
     }
 
     #[test]
-    fn no_env_no_fleet_is_plain_http() {
+    fn no_env_not_required_is_plain_http() {
         let _g = lock();
         clear();
         assert!(resolve_tls().unwrap().is_none());
     }
 
     #[test]
-    fn fleet_without_tls_fails_closed() {
+    fn require_mtls_without_tls_fails_closed() {
         let _g = lock();
         clear();
-        std::env::set_var(ENV_FLEET, "0.0.0.0");
+        std::env::set_var(ENV_REQUIRE_MTLS, "1");
         let err = resolve_tls().unwrap_err();
         assert!(err.contains("fail-closed"), "{err}");
         clear();
+    }
+
+    #[test]
+    fn publish_addr_alone_does_not_force_mtls() {
+        // A worker sets SMOLVM_PUBLISH_ADDR for the datapath; that must NOT make
+        // a plain-HTTP serve refuse to start.
+        let _g = lock();
+        clear();
+        std::env::set_var("SMOLVM_PUBLISH_ADDR", "0.0.0.0");
+        assert!(resolve_tls().unwrap().is_none());
+        std::env::remove_var("SMOLVM_PUBLISH_ADDR");
     }
 
     #[test]

--- a/src/cli/serve_tls.rs
+++ b/src/cli/serve_tls.rs
@@ -1,0 +1,172 @@
+//! mTLS for the fleet serve API (control↔node, increment 3 of the mTLS plan).
+//!
+//! In a fleet, the worker runs `smolvm serve` and is driven by the control
+//! plane. That channel must be mutually authenticated: the node presents a
+//! CA-signed **server** cert, and only a client presenting a CA-signed **client**
+//! cert (the control plane) may connect. This module builds the rustls
+//! `ServerConfig` that enforces `require_and_verify_client_cert`.
+//!
+//! **Fail-closed:** in fleet mode (`SMOLVM_PUBLISH_ADDR` set) the serve API
+//! refuses to start without TLS configured — it must never fall back to plain
+//! HTTP / the interim bearer token when it believes it is fleet-managed.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use rustls::server::WebPkiClientVerifier;
+use rustls::{RootCertStore, ServerConfig};
+use rustls_pki_types::{pem::PemObject, CertificateDer, PrivateKeyDer};
+
+/// Env var holding the node's PEM **server** cert (signed by the node-CA).
+const ENV_CERT: &str = "SMOLVM_SERVE_TLS_CERT";
+/// Env var holding the node's PEM private key.
+const ENV_KEY: &str = "SMOLVM_SERVE_TLS_KEY";
+/// Env var holding the PEM node-CA cert used to verify the control's client cert.
+const ENV_CLIENT_CA: &str = "SMOLVM_SERVE_TLS_CLIENT_CA";
+/// Fleet-mode indicator (also drives force-virtio in the launch path).
+const ENV_FLEET: &str = "SMOLVM_PUBLISH_ADDR";
+
+/// True when this serve process believes it is fleet-managed.
+pub fn fleet_mode() -> bool {
+    std::env::var_os(ENV_FLEET).is_some()
+}
+
+fn env_path(name: &str) -> Option<PathBuf> {
+    std::env::var_os(name)
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from)
+}
+
+/// Resolve the serve API's TLS posture from the environment.
+///
+/// - All three TLS env vars set ⇒ `Ok(Some(config))` (mTLS, client cert required).
+/// - None set, not fleet mode ⇒ `Ok(None)` (plain HTTP, local/dev).
+/// - **Fleet mode but TLS not fully configured ⇒ `Err` (fail-closed).**
+/// - A partial config (some but not all vars) ⇒ `Err` (misconfiguration).
+pub fn resolve_tls() -> Result<Option<Arc<ServerConfig>>, String> {
+    let cert = env_path(ENV_CERT);
+    let key = env_path(ENV_KEY);
+    let client_ca = env_path(ENV_CLIENT_CA);
+
+    match (cert, key, client_ca) {
+        (Some(cert), Some(key), Some(client_ca)) => {
+            Ok(Some(build_server_config(&cert, &key, &client_ca)?))
+        }
+        (None, None, None) => {
+            if fleet_mode() {
+                Err(format!(
+                    "fleet mode ({ENV_FLEET} set) requires mTLS, but {ENV_CERT}/{ENV_KEY}/{ENV_CLIENT_CA} are unset — \
+                     refusing to start a fleet serve API without client-cert verification (fail-closed)"
+                ))
+            } else {
+                Ok(None)
+            }
+        }
+        _ => Err(format!(
+            "incomplete serve TLS config: set all of {ENV_CERT}, {ENV_KEY}, {ENV_CLIENT_CA} (or none)"
+        )),
+    }
+}
+
+/// Build a rustls server config that requires + verifies a client cert chained
+/// to the node-CA.
+fn build_server_config(
+    cert_path: &Path,
+    key_path: &Path,
+    client_ca_path: &Path,
+) -> Result<Arc<ServerConfig>, String> {
+    // Pin the ring provider explicitly rather than relying on a process-global
+    // install — avoids ordering hazards if anything else touches rustls.
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+
+    // Client-cert trust anchor: the node-CA. Only the control plane holds a
+    // client cert signed by it.
+    let mut roots = RootCertStore::empty();
+    for ca in CertificateDer::pem_file_iter(client_ca_path)
+        .map_err(|e| format!("read client CA {}: {e}", client_ca_path.display()))?
+    {
+        let ca = ca.map_err(|e| format!("parse client CA cert: {e}"))?;
+        roots
+            .add(ca)
+            .map_err(|e| format!("add client CA to root store: {e}"))?;
+    }
+    if roots.is_empty() {
+        return Err(format!(
+            "client CA {} contained no certificates",
+            client_ca_path.display()
+        ));
+    }
+    let verifier = WebPkiClientVerifier::builder_with_provider(Arc::new(roots), provider.clone())
+        .build()
+        .map_err(|e| format!("build client-cert verifier: {e}"))?;
+
+    // Our server identity (node server cert + key).
+    let certs: Vec<CertificateDer<'static>> = CertificateDer::pem_file_iter(cert_path)
+        .map_err(|e| format!("read server cert {}: {e}", cert_path.display()))?
+        .collect::<Result<_, _>>()
+        .map_err(|e| format!("parse server cert chain: {e}"))?;
+    if certs.is_empty() {
+        return Err(format!(
+            "server cert {} contained no certificates",
+            cert_path.display()
+        ));
+    }
+    let key = PrivateKeyDer::from_pem_file(key_path)
+        .map_err(|e| format!("read server key {}: {e}", key_path.display()))?;
+
+    let mut config = ServerConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(|e| format!("rustls protocol versions: {e}"))?
+        .with_client_cert_verifier(verifier)
+        .with_single_cert(certs, key)
+        .map_err(|e| format!("install server cert/key: {e}"))?;
+    // axum-server speaks h2 + http/1.1; advertise both via ALPN.
+    config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+
+    Ok(Arc::new(config))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // resolve_tls reads process env; these run serially via a shared guard to
+    // avoid cross-test interference on the shared env vars.
+    fn lock() -> std::sync::MutexGuard<'static, ()> {
+        static L: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        L.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    fn clear() {
+        for v in [ENV_CERT, ENV_KEY, ENV_CLIENT_CA, ENV_FLEET] {
+            std::env::remove_var(v);
+        }
+    }
+
+    #[test]
+    fn no_env_no_fleet_is_plain_http() {
+        let _g = lock();
+        clear();
+        assert!(resolve_tls().unwrap().is_none());
+    }
+
+    #[test]
+    fn fleet_without_tls_fails_closed() {
+        let _g = lock();
+        clear();
+        std::env::set_var(ENV_FLEET, "0.0.0.0");
+        let err = resolve_tls().unwrap_err();
+        assert!(err.contains("fail-closed"), "{err}");
+        clear();
+    }
+
+    #[test]
+    fn partial_tls_config_is_rejected() {
+        let _g = lock();
+        clear();
+        std::env::set_var(ENV_CERT, "/tmp/x.crt");
+        let err = resolve_tls().unwrap_err();
+        assert!(err.contains("incomplete"), "{err}");
+        clear();
+    }
+}


### PR DESCRIPTION
Adds optional mutual TLS to `smolvm serve`. When `SMOLVM_SERVE_TLS_CERT`/`_KEY`/`_CLIENT_CA` are set, the API serves HTTPS and requires a client cert chained to the node-CA. In fleet mode (`SMOLVM_PUBLISH_ADDR` set) it is fail-closed: startup aborts if mTLS isn't configured. No change to local/dev (plain HTTP when no TLS env set).