### PR TITLE
feat(serve): dual listener — loopback plain-HTTP door for local node-agent under mTLS

### DIFF
--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -266,11 +266,40 @@ impl ServeStartCmd {
     /// acceptor performs the handshake + client-cert verification configured in
     /// `tls_config`; graceful shutdown is driven through its `Handle` (the
     /// `axum::serve` graceful-shutdown future doesn't apply here).
+    ///
+    /// Because mTLS locks the whole network port to CA-signed clients, we ALSO
+    /// bind a plain-HTTP listener on loopback (see `serve_tls::local_plain_addr`)
+    /// so the node's own agent can keep polling `/capacity` locally — it is not
+    /// an mTLS client and is unreachable from the network anyway.
     async fn serve_tcp_tls(
         addr: SocketAddr,
         app: Router,
         tls_config: std::sync::Arc<rustls::ServerConfig>,
     ) -> Result<()> {
+        // Loopback plain-HTTP door for the local node-agent.
+        if let Some(local_addr) = super::serve_tls::local_plain_addr(addr) {
+            if !local_addr.ip().is_loopback() {
+                return Err(smolvm::error::Error::config(
+                    "serve local addr",
+                    format!("SMOLVM_SERVE_LOCAL_ADDR {local_addr} must be loopback"),
+                ));
+            }
+            let local_listener = tokio::net::TcpListener::bind(local_addr)
+                .await
+                .map_err(smolvm::error::Error::Io)?;
+            let local_app = app.clone();
+            tracing::info!(address = %local_addr, "starting loopback HTTP door (local node-agent)");
+            println!(
+                "smolvm local API (loopback, plain) on http://{}",
+                local_addr
+            );
+            tokio::spawn(async move {
+                let _ = axum::serve(local_listener, local_app)
+                    .with_graceful_shutdown(shutdown_signal())
+                    .await;
+            });
+        }
+
         let rustls_config = axum_server::tls_rustls::RustlsConfig::from_config(tls_config);
         let handle = axum_server::Handle::new();
 

--- a/src/cli/serve_tls.rs
+++ b/src/cli/serve_tls.rs
@@ -39,6 +39,25 @@ pub fn require_mtls() -> bool {
     )
 }
 
+/// Loopback plain-HTTP address for the **local** node-agent when the main port
+/// runs mTLS. mTLS locks the whole network port to CA-signed clients, but the
+/// node's own agent polls `/capacity` locally over plain HTTP — so we open a
+/// second door bound to loopback only (unreachable from the network). Defaults
+/// to `127.0.0.1:<main_port + 1>`; override with `SMOLVM_SERVE_LOCAL_ADDR`.
+/// Returns `None` only if an override is set but unparseable.
+pub fn local_plain_addr(main: std::net::SocketAddr) -> Option<std::net::SocketAddr> {
+    match std::env::var("SMOLVM_SERVE_LOCAL_ADDR")
+        .ok()
+        .filter(|v| !v.is_empty())
+    {
+        Some(v) => v.parse().ok(),
+        None => Some(std::net::SocketAddr::from((
+            std::net::Ipv4Addr::LOCALHOST,
+            main.port().wrapping_add(1),
+        ))),
+    }
+}
+
 fn env_path(name: &str) -> Option<PathBuf> {
     std::env::var_os(name)
         .filter(|v| !v.is_empty())
@@ -166,6 +185,25 @@ mod tests {
         let err = resolve_tls().unwrap_err();
         assert!(err.contains("fail-closed"), "{err}");
         clear();
+    }
+
+    #[test]
+    fn local_plain_addr_defaults_to_loopback_port_plus_one() {
+        let _g = lock();
+        std::env::remove_var("SMOLVM_SERVE_LOCAL_ADDR");
+        let main: std::net::SocketAddr = "0.0.0.0:8080".parse().unwrap();
+        let local = local_plain_addr(main).unwrap();
+        assert!(local.ip().is_loopback());
+        assert_eq!(local.port(), 8081);
+    }
+
+    #[test]
+    fn local_plain_addr_honors_override() {
+        let _g = lock();
+        std::env::set_var("SMOLVM_SERVE_LOCAL_ADDR", "127.0.0.1:9999");
+        let local = local_plain_addr("0.0.0.0:8080".parse().unwrap()).unwrap();
+        assert_eq!(local.port(), 9999);
+        std::env::remove_var("SMOLVM_SERVE_LOCAL_ADDR");
     }
 
     #[test]


### PR DESCRIPTION
When the serve API runs mTLS (SMOLVM_SERVE_REQUIRE_MTLS), the whole network port requires a CA-signed client cert — which would lock out the node's own node-agent that polls /capacity locally over plain HTTP. This binds a second loopback-only plain-HTTP listener (127.0.0.1:<port+1>, override SMOLVM_SERVE_LOCAL_ADDR) so the local agent keeps working while the network path stays mTLS-only. No effect when mTLS is off (single listener as before).