### PR TITLE
feat(serve): lossless restart — per-VM systemd scopes + detach + explicit drain

### DIFF
--- a/docs/lossless-serve-restart.md
+++ b/docs/lossless-serve-restart.md
@@ -1,0 +1,174 @@
+# Lossless `smolvm serve` restart
+
+## Goal
+
+Restart the `smolvm` serve process (the node runtime / local API) — for a binary
+upgrade **or** an unexpected crash-auto-restart — **without killing or orphaning
+running VMs**, and reconnect to them afterward so exec / interactive / management
+keep working.
+
+This turns a fleet serve upgrade from a drain-everything operation into a rolling
+`systemctl restart` that running workloads sail through.
+
+## Scope — what "lossless" does and does NOT cover
+
+The key distinction is **guest compute vs. host control-plane**. Processes
+*inside* the VM (a job, a server, an agent task) live in the guest kernel, not in
+serve, so they keep executing across a serve restart. What blips is the host-side
+control channel for the ~1–3 s restart window: new exec/API calls fail and
+**attached interactive sessions drop** (the WebSocket dies; the guest-side shell
+process survives but the terminal must reconnect). Published-port traffic can blip
+for that window too.
+
+| Update type | Lossless? |
+|---|---|
+| **serve binary upgrade** (node runtime) | ✅ yes — the target win |
+| serve **crash** / systemd auto-restart | ✅ yes (scopes cover it) |
+| **libkrun upgrade** (hypervisor dylib) | ❌ no — only new VMs get it; running VMs keep the loaded copy |
+| **host kernel / OS / instance reboot** | ❌ no — kills every host process, VMs included |
+| guest rootfs / agent | ❌ no for running VMs (baked at boot) |
+
+Infrastructure-level updates (libkrun, kernel, host reboot, instance replacement)
+still bounce VMs — those need drain+reschedule today, and live-migration
+(libkrun checkpoint/restore + the fork-clone work) long term. "Lossless restart"
+≠ "survives anything."
+
+## Why it's hard: three independent kill vectors
+
+A running VM is, today, a child process of `smolvm-node.service` in that unit's
+**delegated cgroup**. Three separate mechanisms tear it down on restart:
+
+1. **serve signals the PID** — `impl Drop for AgentManager` (`src/agent/manager.rs`)
+   calls `stop()` (SIGTERM/SIGKILL) when the manager owns the child and isn't
+   `detached`. serve never detached on shutdown (the CLI does).
+2. **systemd kills the service cgroup** — default `KillMode=control-group` SIGKILLs
+   the whole subtree on unit stop. (`KillMode=process` mitigates; scopes make it moot.)
+3. **systemd refuses to recreate the cgroup** — on `systemctl restart`, a surviving
+   VM left in the service's delegated cgroup yields **`status=219/CGROUP`**: the new
+   serve never starts and crash-loops. This fires on *any* unit (re)start, including
+   systemd's automatic crash-restart.
+
+Losslessness requires neutralizing all three plus reconnect. Missing any one still
+kills the VM or crash-loops serve.
+
+## The model: VMs become systemd scopes; serve becomes a reconnecting manager
+
+Invert ownership: each VM becomes its own first-class systemd unit
+`smolvm-vm-<id>.scope`, owned by PID1 in a **sibling cgroup** (not under the service).
+serve *attaches to* and *detaches from* VMs instead of *containing* them — the
+libvirt/`machined` pattern, and the supported way to put externally-forked
+processes under systemd cgroup management.
+
+```
+serve.start_vm():
+  fork _boot-vm  ──►  PID
+  StartTransientUnit("smolvm-vm-<id>.scope", PIDs=[PID],
+                     properties=[MemoryMax, CPUQuota, TasksMax, CPUWeight])
+        └─ systemd adopts PID into a sibling cgroup + applies caps
+
+serve dies / restarts:
+  detach_all()  → Drop won't signal the PID            (vector 1)
+  VM reparents to init; scope persists                 (systemd owns the cgroup)
+  new serve starts in a CLEAN service cgroup           (no 219 — VM isn't there)
+
+new serve startup:
+  list_vms() (DB)  ✕  enumerate smolvm-vm-*.scope      (cross-check / reconcile)
+  for each live VM: reconnect agent.sock + ping        (vector 3 → reconnect)
+
+machine stop/delete:
+  kill PID  →  scope auto-GCs when its last process exits   (no extra teardown)
+```
+
+Scopes auto-remove when empty, so stop/delete needs no special scope teardown —
+killing the VM PID is enough and systemd reaps the scope.
+
+## Plan (phased)
+
+**Phase 1 — Scoped VM launch (`manager.rs`, core change).** After forking
+`_boot-vm`, `busctl StartTransientUnit` creates `smolvm-vm-<id>.scope` adopting the
+PID, with per-VM caps ported from the current cgroup code to scope properties.
+**Availability gate + fallback** (`systemd_scope::is_available()`): requires
+`/run/systemd/system` + `busctl` + **root** (system-bus `StartTransientUnit` needs
+root/polkit; serve is root on the worker). Anything else — macOS dev, containers,
+OpenRC, **or an unprivileged local Linux `serve`** — returns false and routes to the
+existing delegated-cgroup placement, which keeps resource caps (just not lossless,
+fine for dev). The root gate specifically prevents a non-root local serve from
+entering scope-mode and then failing every adopt *uncapped* (scope-mode skips the
+cgroup fallback). One detection point, two launch paths sharing everything
+downstream. Accept the microsecond fork→adopt race (only risks a brand-new VM).
+A runtime adopt failure *after* the gate passed (broken D-Bus) logs loudly; the VM
+runs uncapped + not-restart-safe. Future: support the per-user bus (`busctl --user`)
+for unprivileged local serve.
+
+**Phase 2 — Detach on shutdown (DONE).** `ApiState::detach_all()` on serve's
+non-drain shutdown path. Still required: scopes stop *systemd* from killing the VM;
+detach is the only thing that stops serve's *application-level* signal.
+
+**Phase 3 — Reliable reconnect.** `try_connect_existing` (connect `agent.sock` +
+`ping`) works once serve actually starts; add a supervisor **retry loop** (bounded
+backoff) for "alive but not yet reachable" machines so reconnect absorbs agent
+settle time. Cross-check DB vs. enumerated scopes and reconcile drift.
+
+**Phase 4 — Drain decoupling.** Remove `SMOLVM_DRAIN_ON_SHUTDOWN` from the worker
+unit + Terraform. Preserve clean decommission via an **explicit control-driven
+drain**: the autoscaler calls a serve drain trigger before `provider.terminate()`.
+Drain becomes a deliberate decommission step, never a restart side-effect.
+
+**Phase 5 — Crash-restart.** Falls out for free: with VMs in scopes, systemd's
+automatic restart of a crashed serve also starts clean and reconnects. (This is why
+a self-re-exec trick is insufficient — it covers only planned upgrades.)
+
+**Phase 6 — Validation (gate before fleet rollout).** Idle VM survives a
+`systemctl restart` (same PID) + reconnect + exec, ×3. Busy VM: restart while an
+interactive exec streams → VM survives, session drops, fresh exec reconnects. Crash
+sim: `kill -9` serve → auto-restart → survive + reconnect. Caps enforced on the
+scope. Fallback: macOS/non-systemd still boots via direct fork.
+
+**Phase 7 — Rollout.** Deploy to workers (one-time bounce — legacy VMs in the old
+service cgroup still drop on that first restart); new VMs launch in scopes; every
+subsequent restart is lossless. Codify unit/TF changes.
+
+## Decisions & trade-offs
+
+| Decision | Choice | Why |
+|---|---|---|
+| Scope vs hand-rolled cgroup move | **Scope** | Supported API; hand-moving fights `Delegate=` and is systemd-version-fragile |
+| Scope vs self-re-exec | **Scope** | re-exec misses crash-restart; scopes cover both |
+| Scope vs separate `vmd` daemon | **Scope** | daemon-split is the same losslessness at ~3× the architecture; revisit only if API/VM need independent scaling |
+| fork-then-adopt race | **Accept** | window is microseconds, only risks a brand-new VM |
+| non-systemd hosts | **Fallback to direct fork** | contains systemd coupling to the cloud worker; keeps dev/CI working |
+
+## Risks
+
+- **Blast radius** — touches the most critical path (VM spawn). Mitigate with the
+  dual-path fallback (dev unaffected) and the Phase 6 validation gate.
+- **systemd version differences** in scope/property semantics — pin behavior in an
+  integration test on the actual worker image.
+- **Reconnect to a busy VM** — the guest agent must tolerate a client vanishing
+  mid-stream (the accept-loop design suggests it does; Phase 6's busy-VM test proves it).
+
+## Status
+
+- **Phases 1 + 2 implemented + validated live on worker-1 (2026-06-14).** A VM was
+  placed (landed in `smolvm-vm-<id>.scope`, a sibling cgroup), serve restarted, and:
+  VM PID survived; the scope stayed `active`; serve started clean (**no
+  `219/CGROUP`**); `reconnected to machine ... pid=Some(<vm>)` (the live VM, not a
+  stale record); and exec returned `LOSSLESS_OK_x86_64` (exit 0, 38 ms) through the
+  reconnected serve. Scope binary sha `921eb504`.
+- New `src/systemd_scope.rs` (busctl `StartTransientUnit`, no D-Bus crate);
+  `serve.rs` chooses scope-mode when systemd is present (else delegated-cgroup
+  fallback); `manager.rs` adopts the forked PID after fork. `internal_boot.rs`
+  needed no change (it already skips self-placement when `SMOLVM_CGROUP_ROOT` is
+  unset).
+- **Phase 3 (reconnect retry) is now optional** — validation showed the existing
+  `try_connect_existing` reconnects immediately once serve can start; the retry
+  loop is belt-and-suspenders, not load-bearing.
+- **Phase 4 code DONE (compiles):** explicit drain trigger — smolvm `POST /drain`
+  (`handlers::machines::drain_node` → `drain_machines`, control-only via the mTLS
+  listener); smolfleet `RuntimeDriver::drain()` (default no-op) + `SmolvmDriver`
+  POST impl; autoscaler drains before `provider.terminate()` (best-effort, never
+  blocks decommission). Ops half (remove `SMOLVM_DRAIN_ON_SHUTDOWN` from units + TF)
+  pairs with the Phase 7 binary rollout.
+- Pending: Phase 3 (optional retry hardening), Phase 4 ops (env removal), Phase 6
+  busy-VM + crash-sim live cases, Phase 7 PR + fleet rollout. Code uncommitted
+  across both repos; worker-1 reverted to fleet-standard `d8f57614`. See task #210.

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -1464,6 +1464,40 @@ impl AgentManager {
             "boot: subprocess spawned"
         );
 
+        // Lossless-restart placement: on a systemd host, adopt the just-forked VM
+        // into its own `smolvm-vm-<id>.scope` (sibling unit, owned by PID1) so a
+        // later `serve` restart can't kill or `219/CGROUP`-crash on it. Serve set
+        // SMOLVM_VM_USE_SCOPE at startup and did NOT set SMOLVM_CGROUP_ROOT, so the
+        // boot subprocess skipped self-placement and the VM is still in serve's
+        // cgroup for this microsecond window — the adopt moves it out. Caps mirror
+        // process::place_in_cgroup (CGROUP_MEM_OVERHEAD_MIB=768, CGROUP_PIDS_MAX
+        // =1024) as scope properties. Best-effort: on failure the VM keeps running
+        // (just not restart-safe), same as an uncapped cgroup join.
+        #[cfg(target_os = "linux")]
+        if std::env::var_os("SMOLVM_VM_USE_SCOPE").is_some() {
+            if let Some(name) = self.name() {
+                let caps = crate::systemd_scope::ScopeCaps {
+                    memory_max_bytes: Some(
+                        (resources_for_config.memory_mib as u64 + 768) * 1024 * 1024,
+                    ),
+                    cpu_quota_usec_per_sec: Some(
+                        (resources_for_config.cpus.max(1) as u64) * 1_000_000,
+                    ),
+                    tasks_max: Some(1024),
+                };
+                if let Err(e) = crate::systemd_scope::adopt_into_scope(name, child_pid, &caps) {
+                    // Only reachable when is_available() said yes (root + systemd +
+                    // busctl) but the bus call still failed — effectively a broken
+                    // D-Bus. The VM keeps running but stays in serve's cgroup,
+                    // uncapped and not restart-safe. Loud so the operator notices.
+                    tracing::warn!(
+                        error = %e, pid = child_pid,
+                        "failed to adopt VM into systemd scope; VM left in service cgroup — uncapped and NOT restart-safe"
+                    );
+                }
+            }
+        }
+
         self.finalize_launch(child_pid, &mounts, &ports, &resources_for_config)
     }
 

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -872,13 +872,25 @@ pub async fn stop_machine(
     Ok(Json(record_to_info(&name, &record)))
 }
 
-/// Gracefully stop every running VM before the server exits. Opt-in via
-/// `SMOLVM_DRAIN_ON_SHUTDOWN` (set by cloud workers); off by default so a dev
-/// Ctrl-C or `serve` restart leaves VMs running for reconnect. Without draining,
-/// a host teardown (e.g. autoscaler scale-in) hard-kills running VMs; draining
-/// stops them cleanly — flushing disk state and marking them stopped so the
-/// control plane can reschedule. Best-effort, concurrent, and bounded so it fits
-/// inside the host's termination grace period.
+/// `POST /drain` — explicit, control-initiated node drain (decommission).
+///
+/// Once serve restarts are lossless (per-VM systemd scopes + detach), drain is no
+/// longer a side-effect of process shutdown — it's a deliberate decommission step.
+/// The control plane (autoscaler scale-in) calls this BEFORE terminating the host
+/// so VMs flush cleanly. Control-only by construction: the serve listener is mTLS-
+/// gated, and the loopback door is localhost. See docs/lossless-serve-restart.md.
+pub async fn drain_node(State(state): State<Arc<ApiState>>) -> axum::http::StatusCode {
+    tracing::info!("drain requested via API (node decommission)");
+    drain_machines(&state).await;
+    axum::http::StatusCode::OK
+}
+
+/// Gracefully stop every running VM. Two callers: the opt-in shutdown path
+/// (`SMOLVM_DRAIN_ON_SHUTDOWN`, legacy — being retired now that restart is
+/// lossless) and the explicit `POST /drain` decommission endpoint ([`drain_node`]).
+/// Draining stops VMs cleanly — flushing disk state and marking them stopped so
+/// the control plane can reschedule. Best-effort, concurrent, and bounded so it
+/// fits inside the host's termination grace period.
 pub async fn drain_machines(state: &Arc<ApiState>) {
     let running: Vec<(String, Option<i32>, Option<u64>)> = match state.db().list_vms() {
         Ok(vms) => vms

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -148,6 +148,11 @@ pub fn create_router(state: Arc<ApiState>, cors_origins: Vec<String>) -> Router 
     // Node capacity introspection (polled by a fleet node-agent over HTTP).
     let capacity_route = Router::new().route("/capacity", get(handlers::node::capacity));
 
+    // Explicit, control-initiated node drain (decommission). Stops all VMs
+    // cleanly. Control-only by construction (the listener is mTLS-gated; the
+    // loopback door is localhost). See docs/lossless-serve-restart.md.
+    let drain_route = Router::new().route("/drain", post(handlers::machines::drain_node));
+
     // Long-lived streaming routes (no request timeout): SSE logs and the
     // interactive PTY WebSocket both outlive the 5-minute API timeout.
     let logs_route = Router::new()
@@ -242,6 +247,7 @@ pub fn create_router(state: Arc<ApiState>, cors_origins: Vec<String>) -> Router 
     Router::new()
         .merge(health_route)
         .merge(capacity_route)
+        .merge(drain_route)
         .merge(metrics_route)
         .nest("/api/v1", api_v1)
         .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -443,6 +443,28 @@ impl ApiState {
         (total, running)
     }
 
+    /// Disarm every machine manager's `Drop` so a non-draining `serve` shutdown
+    /// (e.g. a binary-upgrade restart) leaves running VMs alive for the next
+    /// process to reconnect to, instead of `AgentManager::drop` tearing each one
+    /// down via `stop()`. Mirrors the CLI's detach-before-exit (`SigintGuard`
+    /// disarm + `manager.detach()`). The drain path does the opposite — it stops
+    /// VMs cleanly — so this is invoked ONLY on the survive-and-reconnect path.
+    /// Uses a blocking lock per entry: missing one would let its VM be killed.
+    pub fn detach_all(&self) {
+        let machines = self.machines.read();
+        let mut detached = 0usize;
+        for entry in machines.values() {
+            entry.lock().manager.detach();
+            detached += 1;
+        }
+        if detached > 0 {
+            tracing::info!(
+                count = detached,
+                "detached machine managers on shutdown; VMs left running for reconnect"
+            );
+        }
+    }
+
     /// Compute total allocated resources across all running machines.
     /// Returns (allocated_cpus, allocated_memory_mb).
     pub fn allocated_resources(&self) -> (u32, u64) {

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -105,15 +105,26 @@ impl ServeStartCmd {
             tracing::info!("verbose logging enabled");
         }
 
-        // Untrusted multi-tenant hardening: when this serve process runs
-        // under a cgroup v2 delegation (a systemd unit with `Delegate=yes`),
-        // establish a delegated root and advertise it via SMOLVM_CGROUP_ROOT so
-        // every VM boot subprocess places itself in a per-VM cgroup with
-        // cpu/pids/memory caps. Best-effort: a no-op (None) when not delegated.
+        // Per-VM resource isolation + lossless-restart placement. Two paths:
+        //
+        // - systemd host: adopt each VM into its OWN `smolvm-vm-<id>.scope` after
+        //   fork (a sibling unit owned by PID1), so a `serve` restart doesn't kill
+        //   or orphan it — the VM isn't in the service cgroup, so systemd won't hit
+        //   `219/CGROUP` recreating the unit. Caps become scope properties. We do
+        //   NOT set SMOLVM_CGROUP_ROOT here so the VM boot subprocess skips
+        //   self-placement; the parent adopts it instead. See
+        //   docs/lossless-serve-restart.md.
+        // - non-systemd (dev/containers): fall back to a delegated cgroup root
+        //   advertised via SMOLVM_CGROUP_ROOT so every VM boot subprocess places
+        //   itself in a per-VM cgroup. No lossless restart there, which is fine.
+        //
         // Done here — single-threaded, before the tokio runtime — so set_var is
         // safe. See docs/runtime-isolation-hardening.md.
         #[cfg(target_os = "linux")]
-        if let Some(root) = smolvm::process::setup_cgroup_delegation_root() {
+        if smolvm::systemd_scope::is_available() {
+            std::env::set_var("SMOLVM_VM_USE_SCOPE", "1");
+            tracing::info!("per-VM systemd transient scopes enabled (lossless serve restart)");
+        } else if let Some(root) = smolvm::process::setup_cgroup_delegation_root() {
             tracing::info!(cgroup_root = %root.display(), "per-VM cgroup resource caps enabled");
             std::env::set_var("SMOLVM_CGROUP_ROOT", &root);
         }
@@ -225,6 +236,13 @@ impl ServeStartCmd {
             .unwrap_or(false);
         if drain {
             smolvm::api::handlers::machines::drain_machines(&drain_state).await;
+        } else {
+            // Non-draining shutdown (a binary-upgrade restart): VMs must survive
+            // for the next `serve` process to reconnect to. Skipping drain isn't
+            // enough — `AgentManager::drop` stops any VM it owns, so tearing down
+            // `ApiState` would kill every running VM. Disarm each manager's Drop
+            // first, mirroring the CLI's detach-before-exit.
+            drain_state.detach_all();
         }
 
         // Signal all background tasks to stop

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ pub mod secrets;
 pub mod settings;
 pub mod smolfile;
 pub mod storage;
+pub mod systemd_scope;
 pub mod util;
 pub mod vm;
 

--- a/src/systemd_scope.rs
+++ b/src/systemd_scope.rs
@@ -1,0 +1,191 @@
+//! Place a VM process in its own **systemd transient scope** so it survives a
+//! `serve` restart.
+//!
+//! Today a VM is a child process inside `smolvm-node.service`'s delegated cgroup.
+//! On `systemctl restart`, a surviving VM left in that cgroup makes systemd fail
+//! to recreate the unit (`status=219/CGROUP`) → serve crash-loops. Adopting the
+//! VM into its own `smolvm-vm-<id>.scope` (a sibling unit owned by PID1) moves it
+//! out of the service cgroup, so serve can restart and reconnect to the still-
+//! running VM. See `docs/lossless-serve-restart.md`.
+//!
+//! Implemented by shelling out to `busctl` (ships with systemd — no D-Bus crate
+//! dependency, and absent exactly where scopes wouldn't work anyway). The caller
+//! forks the VM normally (retaining stdio/fd/process-group control), then calls
+//! [`adopt_into_scope`] on the resulting PID. systemd's `StartTransientUnit`
+//! with a `PIDs=` property moves the process into the scope's cgroup and applies
+//! the resource caps as unit properties. Scopes auto-remove when their last
+//! process exits, so machine stop/delete needs no extra teardown.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::error::{Error, Result};
+
+/// Resource caps applied to the VM's scope (as systemd unit properties).
+///
+/// Mirrors the per-VM cgroup limits set by [`crate::process::place_in_cgroup`]:
+/// `MemoryMax` ↔ `memory.max`, `CPUQuotaPerSecUSec` ↔ `cpu.max`, `TasksMax` ↔
+/// `pids.max`.
+#[derive(Debug, Default, Clone)]
+pub struct ScopeCaps {
+    /// Hard memory ceiling in bytes (`MemoryMax`). `None` = uncapped.
+    pub memory_max_bytes: Option<u64>,
+    /// CPU quota in microseconds-of-CPU-time per real second
+    /// (`CPUQuotaPerSecUSec`). For N vCPUs uncapped-overcommit, pass
+    /// `N * 1_000_000`. `None` = uncapped.
+    pub cpu_quota_usec_per_sec: Option<u64>,
+    /// Max number of tasks/PIDs (`TasksMax`). `None` = systemd default.
+    pub tasks_max: Option<u64>,
+}
+
+/// True iff we can actually create system-bus transient scopes here: a systemd
+/// host (`/run/systemd/system`, à la `sd_booted()`), `busctl` present, AND we run
+/// as root.
+///
+/// The root check matters: `StartTransientUnit` on the **system** bus needs root
+/// (or polkit), and serve runs as root on the cloud worker. Without it, an
+/// unprivileged local `serve` would pass the systemd check, enter scope-mode,
+/// then have every adopt rejected — leaving VMs uncapped (scope-mode skips the
+/// cgroup fallback). Returning false instead routes the caller to direct cgroup
+/// placement, which keeps resource caps (it just isn't lossless — fine for dev).
+///
+/// Non-systemd hosts (macOS dev, OpenRC, bare containers) also return false.
+/// Future: support the per-user systemd bus (`busctl --user`) so an unprivileged
+/// local serve can still get scopes.
+pub fn is_available() -> bool {
+    // SAFETY: geteuid() is always-safe (no args, no global state mutation).
+    let is_root = unsafe { libc::geteuid() } == 0;
+    is_root && Path::new("/run/systemd/system").is_dir() && busctl_path().is_some()
+}
+
+/// Locate `busctl` (PATH, then the usual absolute locations — serve may run with
+/// a minimal `PATH`).
+fn busctl_path() -> Option<PathBuf> {
+    for cand in ["/usr/bin/busctl", "/bin/busctl", "/usr/local/bin/busctl"] {
+        let p = Path::new(cand);
+        if p.exists() {
+            return Some(p.to_path_buf());
+        }
+    }
+    // Fall back to PATH resolution via the shell-less which-equivalent.
+    std::env::var_os("PATH").and_then(|paths| {
+        std::env::split_paths(&paths)
+            .map(|d| d.join("busctl"))
+            .find(|p| p.exists())
+    })
+}
+
+/// systemd unit names allow `[A-Za-z0-9:_.\-]`; sanitize the machine id and clamp
+/// length so the scope name is always valid. Collisions are avoided by the caller
+/// using unique machine ids; a dead scope self-removes when its VM exits.
+pub fn scope_name(machine_id: &str) -> String {
+    let safe: String = machine_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | ':') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .take(200)
+        .collect();
+    format!("smolvm-vm-{safe}.scope")
+}
+
+/// Adopt an already-forked VM `pid` into its own transient scope with `caps`.
+///
+/// Returns `Err` if systemd rejects the request (e.g. the PID already exited, or
+/// the bus call failed); the caller should fall back to plain cgroup placement
+/// rather than failing the launch.
+pub fn adopt_into_scope(machine_id: &str, pid: i32, caps: &ScopeCaps) -> Result<()> {
+    let busctl = busctl_path()
+        .ok_or_else(|| Error::agent("vm scope", "busctl not found; cannot create scope"))?;
+    let name = scope_name(machine_id);
+
+    // Build the a(sv) property list in busctl's positional encoding:
+    //   <prop-name> <variant-type> <variant-value...>
+    // PIDs is an array of u32 (`au`): "au <count> <elem...>".
+    let mut props: Vec<String> = Vec::new();
+    let mut nprops: u32 = 0;
+
+    props.extend(["PIDs".into(), "au".into(), "1".into(), pid.to_string()]);
+    nprops += 1;
+    props.extend([
+        "Description".into(),
+        "s".into(),
+        format!("smolvm VM {machine_id}"),
+    ]);
+    nprops += 1;
+    if let Some(m) = caps.memory_max_bytes {
+        props.extend(["MemoryMax".into(), "t".into(), m.to_string()]);
+        nprops += 1;
+    }
+    if let Some(q) = caps.cpu_quota_usec_per_sec {
+        props.extend(["CPUQuotaPerSecUSec".into(), "t".into(), q.to_string()]);
+        nprops += 1;
+    }
+    if let Some(t) = caps.tasks_max {
+        props.extend(["TasksMax".into(), "t".into(), t.to_string()]);
+        nprops += 1;
+    }
+
+    // StartTransientUnit(name: s, mode: s, properties: a(sv), aux: a(sa(sv))).
+    // mode "fail": error if the unit already exists (a stale same-name scope must
+    // have been GC'd first — it would have been, when its VM exited).
+    let mut args: Vec<String> = vec![
+        "call".into(),
+        "org.freedesktop.systemd1".into(),
+        "/org/freedesktop/systemd1".into(),
+        "org.freedesktop.systemd1.Manager".into(),
+        "StartTransientUnit".into(),
+        "ssa(sv)a(sa(sv))".into(),
+        name.clone(),
+        "fail".into(),
+        nprops.to_string(),
+    ];
+    args.extend(props);
+    args.push("0".into()); // empty aux array
+
+    let out = Command::new(&busctl)
+        .args(&args)
+        .output()
+        .map_err(|e| Error::agent("vm scope", format!("busctl spawn failed: {e}")))?;
+
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        return Err(Error::agent(
+            "vm scope",
+            format!("StartTransientUnit {name} failed: {}", stderr.trim()),
+        ));
+    }
+    tracing::info!(scope = %name, pid, "adopted VM into systemd transient scope");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scope_name_sanitizes_and_suffixes() {
+        assert_eq!(
+            scope_name("machine-abc123"),
+            "smolvm-vm-machine-abc123.scope"
+        );
+        // Illegal chars (slash, space) collapse to underscore.
+        assert_eq!(scope_name("a/b c"), "smolvm-vm-a_b_c.scope");
+        // Allowed punctuation is preserved.
+        assert_eq!(scope_name("m_1.2:3"), "smolvm-vm-m_1.2:3.scope");
+    }
+
+    #[test]
+    fn scope_name_is_bounded() {
+        let long = "x".repeat(500);
+        let n = scope_name(&long);
+        assert!(n.starts_with("smolvm-vm-"));
+        assert!(n.ends_with(".scope"));
+        // sanitized body clamped to 200 chars + fixed prefix/suffix.
+        assert!(n.len() <= "smolvm-vm-".len() + 200 + ".scope".len());
+    }
+}


### PR DESCRIPTION
Makes a `smolvm serve` restart (binary upgrade or crash-auto-restart) leave running VMs alive and reconnect to them, so a worker upgrade doesn't bounce workloads. Design: `docs/lossless-serve-restart.md`.

Three kill vectors, three fixes:
- **Drop kills the VM** → `ApiState::detach_all()` on serve's non-drain shutdown path disarms each manager's Drop (the CLI already did this; serve didn't).
- **systemd kills/refuses the cgroup** (`219/CGROUP` on restart with a surviving VM in the service's delegated cgroup) → each VM is adopted into its own `smolvm-vm-<id>.scope` (sibling unit, owned by PID1) via `busctl StartTransientUnit` (`src/systemd_scope.rs`, no D-Bus crate). Caps become scope properties. `serve` picks scope-mode only when systemd + busctl + root; else the existing delegated-cgroup fallback (dev/macOS unaffected, caps intact).
- **reconnect** → the existing `try_connect_existing` path just works once serve can start (agent.sock survives — libkrun owns it).

Also decouples drain from shutdown: new `POST /drain` endpoint (`drain_node`) for explicit, control-initiated decommission, so the autoscaler drains a node before terminating it instead of relying on `SMOLVM_DRAIN_ON_SHUTDOWN`.

Validated live on a worker: VM placed in `smolvm-vm-*.scope`, serve restarted, VM survived, no `219`, reconnected to the live VM, exec returned after restart. Pending: busy-VM + crash-sim stress cases, unit/TF env removal, fleet rollout.