### PR TITLE
fix: properly name images with digests

### DIFF
--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -13,7 +13,9 @@ use crate::oci::{generate_container_id, OciSpec};
 use crate::paths;
 use crate::process::{WaitResult, TIMEOUT_EXIT_CODE};
 use smolvm_protocol::guest_env;
-use smolvm_protocol::{normalize_image_ref, ImageInfo, OverlayInfo, RegistryAuth, StorageStatus};
+use smolvm_protocol::{
+    image_repo, normalize_image_ref, ImageInfo, OverlayInfo, RegistryAuth, StorageStatus,
+};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::OnceLock;
@@ -1148,7 +1150,7 @@ where
         // Build crane command
         let mut crane_cmd = Command::new("crane");
         crane_cmd.arg("blob");
-        crane_cmd.arg(format!("{}@{}", image, layer_digest));
+        crane_cmd.arg(format!("{}@{}", image_repo(image), layer_digest));
         if let Some(p) = oci_platform {
             crane_cmd.arg("--platform").arg(p);
         }

--- a/crates/smolvm-protocol/src/image_ref.rs
+++ b/crates/smolvm-protocol/src/image_ref.rs
@@ -46,28 +46,13 @@ pub fn normalize_image_ref(image: &str) -> String {
         image
     };
 
-    // 2. Separate digest — everything after '@'.  When a digest is present
-    //    the tag is informational and is dropped (digest is authoritative).
-    let (ref_no_digest, digest) = match image.split_once('@') {
-        Some((left, right)) => (left, Some(right)),
-        None => (image, None),
-    };
-
-    // 3. Separate tag.  The last ':' with no '/' after it is the tag
-    //    separator.  A colon that is part of a registry hostname (e.g.
-    //    `localhost:5000/repo`) always has a '/' after it, so this rule
-    //    correctly distinguishes the two cases.
-    let (ref_no_tag, tag) = match ref_no_digest.rfind(':') {
-        Some(pos) if !ref_no_digest[pos..].contains('/') => {
-            (&ref_no_digest[..pos], Some(&ref_no_digest[pos + 1..]))
-        }
-        _ => (ref_no_digest, None),
-    };
+    // 2. and 3. Separate the digest, and the tag from the bare repository.
+    let (ref_no_tag, tag, digest) = split_suffix(image);
 
     // 4. Detect registry: the first '/'-delimited component is a registry
     //    hostname when it contains '.' or ':' (port).  Everything else is
     //    an implicit docker.io reference.
-    let (registry, path) = registry_and_path(ref_no_tag);
+    let (registry, path) = split_registry(ref_no_tag);
 
     // 5. Single-component docker.io paths get the `library/` prefix.
     let canonical_path = if registry == "docker.io" && !path.contains('/') {
@@ -85,10 +70,48 @@ pub fn normalize_image_ref(image: &str) -> String {
     format!("{registry}/{canonical_path}{suffix}")
 }
 
+/// Split an image reference into `(repo, tag, digest)`.
+///
+/// The repo is the `registry/repository` portion with no suffix.
+///
+/// The digest is everything after '@'.  When a digest is present the tag is
+/// informational (the digest is authoritative), but both are still returned.
+///
+/// The tag separator is the last ':' with no '/' after it.  A colon that is
+/// part of a registry hostname (e.g. `localhost:5000/repo`) always has a '/'
+/// after it, so this rule does not mistake a port for a tag.
+fn split_suffix(image: &str) -> (&str, Option<&str>, Option<&str>) {
+    let (ref_no_digest, digest) = match image.split_once('@') {
+        Some((left, right)) => (left, Some(right)),
+        None => (image, None),
+    };
+    let (repo, tag) = match ref_no_digest.rfind(':') {
+        Some(pos) if !ref_no_digest[pos..].contains('/') => {
+            (&ref_no_digest[..pos], Some(&ref_no_digest[pos + 1..]))
+        }
+        _ => (ref_no_digest, None),
+    };
+    (repo, tag, digest)
+}
+
+/// Strip the tag and/or digest suffix from an image reference, returning the registry/repo
+///
+/// # Examples
+///
+/// ```
+/// use smolvm_protocol::image_repo;
+///
+/// assert_eq!(image_repo("ghcr.io/owner/repo@sha256:abc"), "ghcr.io/owner/repo");
+/// assert_eq!(image_repo("ghcr.io/owner/repo:v1"), "ghcr.io/owner/repo");
+/// ```
+pub fn image_repo(image: &str) -> &str {
+    split_suffix(image).0
+}
+
 /// Split a tag-free, digest-free image string into `(registry, path)`.
 ///
 /// Returns `("docker.io", whole_string)` when no explicit registry is found.
-fn registry_and_path(image: &str) -> (&str, &str) {
+fn split_registry(image: &str) -> (&str, &str) {
     if let Some(slash) = image.find('/') {
         let prefix = &image[..slash];
         if prefix.contains('.') || prefix.contains(':') {
@@ -154,6 +177,30 @@ mod tests {
         assert_eq!(
             normalize_image_ref(&format!("alpine:3.20@{digest}")),
             format!("docker.io/library/alpine@{digest}"),
+        );
+    }
+
+    #[test]
+    fn test_image_repo() {
+        let digest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+        // Digest suffix is stripped.
+        assert_eq!(
+            image_repo(&format!("ghcr.io/owner/repo@{digest}")),
+            "ghcr.io/owner/repo",
+        );
+        // Tag suffix is stripped.
+        assert_eq!(image_repo("ghcr.io/owner/repo:v1"), "ghcr.io/owner/repo");
+        // No suffix — returned unchanged.
+        assert_eq!(image_repo("ghcr.io/owner/repo"), "ghcr.io/owner/repo");
+        // Port in registry — colon-detection must not confuse port with tag.
+        assert_eq!(
+            image_repo("localhost:5000/myimage:dev"),
+            "localhost:5000/myimage",
+        );
+        assert_eq!(
+            image_repo("localhost:5000/myimage"),
+            "localhost:5000/myimage"
         );
     }
 }

--- a/crates/smolvm-protocol/src/lib.rs
+++ b/crates/smolvm-protocol/src/lib.rs
@@ -23,7 +23,7 @@ pub mod image_ref;
 pub mod retry;
 pub mod secrets;
 
-pub use image_ref::normalize_image_ref;
+pub use image_ref::{image_repo, normalize_image_ref};
 pub use secrets::{SecretRef, SecretSourceKind};
 
 /// Serde helper for encoding `Vec<u8>` as a base64 string in JSON.


### PR DESCRIPTION
previously, pulling a layer builds the crane blob refernce as `image@layer_digest`, but if the image already has a digest pinned, ie if `image` is `repository@sha256:<manifest>`, we get an invalid refence with two `@`:

`repository@sha256:<manifest>@sha256:<layer≥`

To fix this, we now call `image_repo` to strip the existing tag (even though we don't use tag here) and digest suffixes before appending the layer digest, so the new reference is always in the format of `repository@sha256:<layer>`, with no tag or digest.