### PR TITLE
feat(serve): add /api/v1/volumes provision + deprovision endpoints

### DIFF
--- a/src/api/handlers/mod.rs
+++ b/src/api/handlers/mod.rs
@@ -6,6 +6,7 @@ pub mod health;
 pub mod images;
 pub mod machines;
 pub mod node;
+pub mod volumes;
 
 use crate::api::error::ApiError;
 use crate::api::state::MachineEntry;

--- a/src/api/handlers/volumes.rs
+++ b/src/api/handlers/volumes.rs
@@ -1,0 +1,102 @@
+//! Volume provisioning endpoints — node-side storage for the control plane.
+//!
+//! smolfleet's `create_volume`/`delete_volume` call these to materialize a volume
+//! ON the worker (not on the control plane's own disk, which the worker can't
+//! see). For the `local` backend a volume is simply a directory under the smolvm
+//! data dir; the worker virtiofs-shares it into a guest at mount time. Future
+//! backends (PD, NFS) attach real storage here. See smolfleet
+//! docs/d3-replicated-volumes.md.
+
+use axum::{extract::Path, http::StatusCode, Json};
+use serde::{Deserialize, Serialize};
+
+use crate::api::error::ApiError;
+
+/// Request body for `POST /api/v1/volumes`.
+#[derive(Deserialize)]
+pub struct ProvisionVolumeRequest {
+    /// Control-plane volume id (e.g. `vol-<hex>`); names the on-node directory.
+    pub id: String,
+    /// Requested size. Advisory for the `local` backend (a plain directory has no
+    /// hard quota); honored once size-bearing backends (PD) land.
+    #[serde(default)]
+    pub size_gb: u64,
+}
+
+/// Response body for `POST /api/v1/volumes`.
+#[derive(Serialize)]
+pub struct ProvisionVolumeResponse {
+    /// Host path the volume is mounted at on this node — becomes a workload mount
+    /// `source`.
+    pub node_path: String,
+}
+
+/// Base directory for node-local volumes: `<data_local_dir>/smolvm/volumes`.
+fn volumes_base() -> std::path::PathBuf {
+    dirs::data_local_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .join("smolvm")
+        .join("volumes")
+}
+
+/// Reject ids that could escape the volumes base (path traversal / separators).
+/// The control plane generates `vol-<hex>`; this is defense in depth.
+fn safe_volume_id(id: &str) -> Result<(), ApiError> {
+    let ok = !id.is_empty()
+        && id.len() <= 128
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_');
+    if ok {
+        Ok(())
+    } else {
+        Err(ApiError::BadRequest(format!("invalid volume id: {id:?}")))
+    }
+}
+
+/// `POST /api/v1/volumes` — create the backing storage and return its host path.
+pub async fn provision_volume(
+    Json(req): Json<ProvisionVolumeRequest>,
+) -> Result<Json<ProvisionVolumeResponse>, ApiError> {
+    safe_volume_id(&req.id)?;
+    let path = volumes_base().join(&req.id);
+    std::fs::create_dir_all(&path).map_err(ApiError::internal)?;
+    let node_path = path.to_string_lossy().to_string();
+    tracing::info!(volume_id = %req.id, node_path = %node_path, size_gb = req.size_gb, "provisioned local volume");
+    Ok(Json(ProvisionVolumeResponse { node_path }))
+}
+
+/// `DELETE /api/v1/volumes/{id}` — tear down the backing storage. Idempotent:
+/// deleting an already-absent volume succeeds.
+pub async fn deprovision_volume(Path(id): Path<String>) -> Result<StatusCode, ApiError> {
+    safe_volume_id(&id)?;
+    let path = volumes_base().join(&id);
+    match std::fs::remove_dir_all(&path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {} // already gone
+        Err(e) => return Err(ApiError::internal(e)),
+    }
+    tracing::info!(volume_id = %id, "deprovisioned local volume");
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_path_traversal_ids() {
+        assert!(safe_volume_id("vol-abc123").is_ok());
+        assert!(safe_volume_id("vol_1").is_ok());
+        assert!(safe_volume_id("../etc").is_err());
+        assert!(safe_volume_id("a/b").is_err());
+        assert!(safe_volume_id("").is_err());
+        assert!(safe_volume_id(&"x".repeat(200)).is_err());
+    }
+
+    #[test]
+    fn volumes_base_is_under_smolvm() {
+        let b = volumes_base();
+        assert!(b.ends_with("smolvm/volumes"), "got {b:?}");
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -191,8 +191,17 @@ pub fn create_router(state: Arc<ApiState>, cors_origins: Vec<String>) -> Router 
         .merge(logs_route)
         .merge(machine_routes_with_timeout);
 
+    // Volume provisioning (node-side storage for the control plane): create the
+    // backing storage on THIS worker and return its host path. See
+    // handlers::volumes.
+    let volume_routes = Router::new()
+        .route("/", post(handlers::volumes::provision_volume))
+        .route("/{id}", delete(handlers::volumes::deprovision_volume));
+
     // API v1 routes
-    let api_v1 = Router::new().nest("/machines", machine_routes);
+    let api_v1 = Router::new()
+        .nest("/machines", machine_routes)
+        .nest("/volumes", volume_routes);
 
     // CORS: Use configured origins, or default to localhost for security.
     let default_origins = || {


### PR DESCRIPTION


## Why
The control plane (smolfleet) used to create volume directories on its OWN disk and hand that path to a worker's smolvm as a virtiofs mount source — a path the worker can't see. This adds the missing node-side RPC so a volume is materialized ON the worker that mounts it.

## This PR
- `POST /api/v1/volumes` — `{id, size_gb}` → create `<data_local_dir>/smolvm/volumes/<id>` on this worker, return `{node_path}`.
- `DELETE /api/v1/volumes/{id}` — remove it (idempotent: already-gone is success).
- Path-traversal guard on the id (alphanumeric/`-`/`_`, ≤128); `size_gb` is advisory for the `local` backend (a directory has no quota — honored when the PD backend lands in D3a).

## Tests
`rejects_path_traversal_ids`, `volumes_base_is_under_smolvm`. Lib check + clippy clean (smolvm's missing_docs + clippy gates satisfied).