### PR TITLE
feat(image): boot from local images with no registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ smolvm machine create --name my-vm --from ./my-python.smolmachine
 smolvm machine start --name my-vm
 smolvm machine exec --name my-vm -- pip install requests
 
-# Local images — boot offline, no registry (CI, air-gapped, fast iteration)
+# Use local container images (CI, air-gapped, fast iteration)
 docker save myapp:latest -o myapp.tar
 smolvm machine run --image ./myapp.tar -- ./app           # from a docker/podman save archive
 docker save myapp:latest | smolvm machine run --image - -- ./app   # from stdin
@@ -61,7 +61,7 @@ smolvm machine create --name myvm --image ./myapp.tar     # persistent, from a l
 | Persistent dev environment | `machine create` → `machine start` → `machine exec` |
 | Ship software as a binary | `smolvm pack create --image IMAGE -o OUTPUT` |
 | Fast persistent machine from packed artifact | `machine create --name NAME --from FILE.smolmachine` |
-| Boot a local image offline (CI / air-gapped / no registry) | `--image ./archive.tar`, `--image -` (stdin), or `--image ./rootfs/` |
+| Use local container images (CI / air-gapped / fast iteration) | `--image ./archive.tar`, `--image -` (stdin), or `--image ./rootfs/` |
 | Use git/ssh with private keys safely | Add `--ssh-agent` to run or create |
 | Inject API keys / tokens without putting them on the command line | `--secret-env`/`--secret-file` flags or Smolfile `[secrets]` |
 | Minimal VM without image | `smolvm machine run -s Smolfile` (bare VM) |
@@ -127,12 +127,12 @@ python-dev@sha256:abcdef0123...                   # digest reference (immutable)
 
 Default registry: `registry.smolmachines.com`. Digest references require `sha256:` followed by exactly 64 hex characters.
 
-### Local image sources
+### Local container images
 
-`--image` also accepts a local source, so a machine can boot with no registry —
-useful for CI, air-gapped hosts, and fast local iteration. smolvm stays a microVM
-runtime and delegates all image work (flatten, whiteouts, config) to container
-tooling (`crane`/`docker`/`podman`); the archive is flattened with `crane export`.
+`--image` also accepts a local source — useful for CI, air-gapped hosts, and fast
+local iteration. smolvm stays a microVM runtime and delegates all image work
+(flatten, whiteouts, config) to container tooling (`crane`/`docker`/`podman`); the
+archive is flattened with `crane export`.
 
 ```
 ./image.tar  ./image.tar.gz  ./image.tgz   # a `docker save` / `podman save` archive (gzip ok)
@@ -144,6 +144,9 @@ A source is treated as local when it starts with `/`, `./`, `../`, is `-`, or en
 `.tar`/`.tar.gz`/`.tgz`; everything else is a registry reference (so bare `alpine`
 still pulls). Archives are cached content-addressed by hash and re-resolved on
 `machine start`. `--image -` cannot be combined with `-i`/`-t` (both read stdin).
+
+smolvm boots images, it does not build them: a Dockerfile passed to `--image` is
+rejected with a hint to build first (`docker build … && docker save … | … --image -`).
 
 ## Key Flags
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,13 @@ smolvm pack create --image python:3.12-alpine -o ./my-python
 smolvm machine create --name my-vm --from ./my-python.smolmachine
 smolvm machine start --name my-vm
 smolvm machine exec --name my-vm -- pip install requests
+
+# Local images — boot offline, no registry (CI, air-gapped, fast iteration)
+docker save myapp:latest -o myapp.tar
+smolvm machine run --image ./myapp.tar -- ./app           # from a docker/podman save archive
+docker save myapp:latest | smolvm machine run --image - -- ./app   # from stdin
+smolvm machine run --image ./rootfs/ -- ./app             # from an unpacked rootfs dir
+smolvm machine create --name myvm --image ./myapp.tar     # persistent, from a local archive
 ```
 
 ## When to Use What
@@ -54,6 +61,7 @@ smolvm machine exec --name my-vm -- pip install requests
 | Persistent dev environment | `machine create` → `machine start` → `machine exec` |
 | Ship software as a binary | `smolvm pack create --image IMAGE -o OUTPUT` |
 | Fast persistent machine from packed artifact | `machine create --name NAME --from FILE.smolmachine` |
+| Boot a local image offline (CI / air-gapped / no registry) | `--image ./archive.tar`, `--image -` (stdin), or `--image ./rootfs/` |
 | Use git/ssh with private keys safely | Add `--ssh-agent` to run or create |
 | Inject API keys / tokens without putting them on the command line | `--secret-env`/`--secret-file` flags or Smolfile `[secrets]` |
 | Minimal VM without image | `smolvm machine run -s Smolfile` (bare VM) |
@@ -119,11 +127,29 @@ python-dev@sha256:abcdef0123...                   # digest reference (immutable)
 
 Default registry: `registry.smolmachines.com`. Digest references require `sha256:` followed by exactly 64 hex characters.
 
+### Local image sources
+
+`--image` also accepts a local source, so a machine can boot with no registry —
+useful for CI, air-gapped hosts, and fast local iteration. smolvm stays a microVM
+runtime and delegates all image work (flatten, whiteouts, config) to container
+tooling (`crane`/`docker`/`podman`); the archive is flattened with `crane export`.
+
+```
+./image.tar  ./image.tar.gz  ./image.tgz   # a `docker save` / `podman save` archive (gzip ok)
+-                                           # the same archive streamed on stdin
+./rootfs/                                   # an already-unpacked root filesystem directory
+```
+
+A source is treated as local when it starts with `/`, `./`, `../`, is `-`, or ends in
+`.tar`/`.tar.gz`/`.tgz`; everything else is a registry reference (so bare `alpine`
+still pulls). Archives are cached content-addressed by hash and re-resolved on
+`machine start`. `--image -` cannot be combined with `-i`/`-t` (both read stdin).
+
 ## Key Flags
 
 | Flag | Short | Used on | Description |
 |------|-------|---------|-------------|
-| `--image` | `-I` | run, create, pack create | OCI image |
+| `--image` | `-I` | run, create, pack create | OCI image, or a local source: a `docker save` archive (`./img.tar`, or `-` for stdin) or unpacked rootfs dir (`./rootfs/`) |
 | `--name` | `-n` | run, start, stop, status, exec, update | Machine name (default: "default") |
 | `--net` | | run, create | Enable outbound networking (off by default) |
 | `--gpu` | | run, create | Enable GPU acceleration (Vulkan via virtio-gpu) |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2202,6 +2202,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smolvm-protocol",
+ "tar",
  "tempfile",
  "tracing",
  "tracing-subscriber",

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ smolvm pack create --image python:3.12-alpine -o ./python312
 # Python 3.12.x — isolated, no pyenv/venv/conda needed
 ```
 
-**Boot local images offline — no registry** — for CI, air-gapped hosts, and fast iteration. Feed `--image` a `docker save` / `podman save` archive, pipe one on stdin, or point it at an unpacked rootfs directory. Image work is delegated to your container tooling; smolvm just boots the result.
+**Use local container images** — for CI, air-gapped hosts, and fast iteration. Feed `--image` a `docker save` / `podman save` archive, pipe one on stdin, or point it at an unpacked rootfs directory. Image work is delegated to your container tooling; smolvm just boots the result.
 
 ```bash
 # build locally, run in the VM with no push/pull

--- a/README.md
+++ b/README.md
@@ -68,6 +68,20 @@ smolvm pack create --image python:3.12-alpine -o ./python312
 # Python 3.12.x — isolated, no pyenv/venv/conda needed
 ```
 
+**Boot local images offline — no registry** — for CI, air-gapped hosts, and fast iteration. Feed `--image` a `docker save` / `podman save` archive, pipe one on stdin, or point it at an unpacked rootfs directory. Image work is delegated to your container tooling; smolvm just boots the result.
+
+```bash
+# build locally, run in the VM with no push/pull
+docker build -t myapp .
+docker save myapp | smolvm machine run --image - -- ./app
+
+# from an archive file (boots with no network)
+smolvm machine run --image ./myapp.tar -- ./app
+
+# from an already-unpacked rootfs directory
+smolvm machine run --image ./rootfs/ -- ./app
+```
+
 **Persistent machines for development** — create, stop, start. Installed packages survive restarts.
 
 ```bash

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -2320,6 +2320,13 @@ fn prepare_overlay_from_packed(
     workload_id: &str,
     packed_dir: &Path,
 ) -> Result<OverlayInfo> {
+    // An unpacked-image directory IS the rootfs — one lowerdir, not its subdirs
+    // treated as separate layers.
+    if is_rootfs_dir(packed_dir) {
+        return OverlaySetup::new(workload_id)?
+            .execute_or_remount(vec![packed_dir.display().to_string()]);
+    }
+
     // Find layer directories in packed_dir
     // Packed layers are named by short digest (first 12 chars of sha256)
     let mut layer_dirs: Vec<PathBuf> = Vec::new();
@@ -2387,8 +2394,24 @@ fn get_image_lowerdirs(image: &str) -> Result<Vec<String>> {
         .collect())
 }
 
+/// Whether `dir` is itself a root filesystem (an unpacked-image directory,
+/// `--image ./rootfs/`) rather than a set of layer subdirs — detected by the
+/// presence of standard top-level rootfs directories. A `.smolmachine`'s
+/// packed-layers dir holds per-layer subdirs, not these, so it reads as false.
+fn is_rootfs_dir(dir: &Path) -> bool {
+    ["bin", "usr", "etc", "sbin"]
+        .iter()
+        .any(|d| dir.join(d).is_dir())
+}
+
 /// Build lowerdir list from pre-packed layer directories.
 fn get_packed_lowerdirs(packed_dir: &Path) -> Result<Vec<String>> {
+    // An unpacked-image directory IS the rootfs — one lowerdir, not its subdirs
+    // treated as separate layers.
+    if is_rootfs_dir(packed_dir) {
+        return Ok(vec![packed_dir.display().to_string()]);
+    }
+
     let mut layer_dirs: Vec<PathBuf> = Vec::new();
 
     let entries = std::fs::read_dir(packed_dir)

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -503,35 +503,55 @@ const ARCHIVE_EXTRACTED_MARKER: &str = ".extracted";
 /// If `packed_dir` is a staged local image archive (it contains `archive.tar`),
 /// flatten it once into a rootfs on the storage disk and return that directory
 /// (holding `0000_rootfs/` + `config.json`). Returns `None` for an ordinary
-/// packed-layers dir (a `.smolmachine`'s pre-extracted layers). Idempotent: the
-/// marker lets the image-info and overlay paths share one flatten, and restarts
-/// reuse it.
+/// packed-layers dir (a `.smolmachine`'s pre-extracted layers).
+///
+/// The output is keyed by the virtiofs mount-point name (constant per VM, since
+/// `/storage` is per-machine), and the completion marker stores the archive's
+/// size+mtime signature. A start reuses the flatten only when that signature
+/// still matches, so a machine re-created from a different image on a reused
+/// disk re-flattens instead of booting the old rootfs. The marker is written
+/// last, so the image-info and overlay paths share one flatten within a start.
 fn ensure_archive_flattened(packed_dir: &Path) -> Result<Option<PathBuf>> {
     let archive = packed_dir.join(ARCHIVE_FILE_NAME);
     if !archive.exists() {
         return Ok(None);
     }
-    // Key the output by the archive's cache-dir name (its content hash) so the
-    // same image reuses one flattened rootfs across machines.
     let key = packed_dir
         .file_name()
         .and_then(|n| n.to_str())
         .unwrap_or("archive");
     let out_base = Path::new(STORAGE_ROOT).join("image-archives").join(key);
-    if out_base.join(ARCHIVE_EXTRACTED_MARKER).exists() {
+    let marker = out_base.join(ARCHIVE_EXTRACTED_MARKER);
+    let signature = archive_signature(&archive)?;
+    if std::fs::read_to_string(&marker).ok().as_deref() == Some(signature.as_str()) {
         return Ok(Some(out_base));
     }
+
+    // First flatten, or the archive changed under a reused disk: rebuild.
+    let _ = std::fs::remove_dir_all(&out_base);
     let rootfs = out_base.join(ARCHIVE_ROOTFS_DIR);
     std::fs::create_dir_all(&rootfs)?;
     info!(archive = %archive.display(), rootfs = %rootfs.display(), "flattening local image archive");
     flatten_archive(&archive, &rootfs)?;
-    // Best-effort config recovery; a missing config just means no default
-    // entrypoint/cmd (the user can still pass an explicit command).
-    if let Err(e) = recover_archive_config(&archive, &out_base.join(ARCHIVE_CONFIG_FILE)) {
-        warn!(error = %e, "could not recover image config from archive");
-    }
-    std::fs::File::create(out_base.join(ARCHIVE_EXTRACTED_MARKER))?;
+    // Recover the image config before writing the marker, so a later reuse can
+    // rely on config.json being present. A docker/podman `save` always carries
+    // one.
+    recover_archive_config(&archive, &out_base.join(ARCHIVE_CONFIG_FILE))?;
+    std::fs::write(&marker, signature)?;
     Ok(Some(out_base))
+}
+
+/// A cheap content signature for a staged archive (size + mtime), used to
+/// invalidate a stale flatten when a reused disk's archive changed.
+fn archive_signature(archive: &Path) -> Result<String> {
+    let meta = std::fs::metadata(archive)?;
+    let mtime = meta
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    Ok(format!("{}:{}", meta.len(), mtime))
 }
 
 /// Feed an archive to `cmd`'s stdin, transparently `gunzip`-ing a gzipped outer
@@ -609,26 +629,42 @@ fn flatten_archive(archive: &Path, rootfs: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Recover the image config (Entrypoint/Cmd/Env/…) by delegating to
-/// `crane config`, writing the JSON to `dest`.
+/// Recover the image config (Entrypoint/Cmd/Env/…) from a `docker save` archive
+/// and write it to `dest`. The archive's `manifest.json` names the config blob
+/// under its `Config` key; both are small JSON members extracted with `tar`
+/// (image metadata, not layer/rootfs assembly — that stays delegated to crane).
 fn recover_archive_config(archive: &Path, dest: &Path) -> Result<()> {
-    let mut config_cmd = Command::new("crane");
-    config_cmd
-        .args(["config", "-"])
-        .stdout(Stdio::piped())
+    let manifest_bytes = extract_tar_member(archive, "manifest.json")?;
+    let manifest: serde_json::Value = serde_json::from_slice(&manifest_bytes)
+        .map_err(|e| StorageError::new(format!("parse archive manifest.json: {e}")))?;
+    let config_path = manifest[0]["Config"].as_str().ok_or_else(|| {
+        StorageError::new("archive manifest.json has no Config entry".to_string())
+    })?;
+    let config_bytes = extract_tar_member(archive, config_path)?;
+    std::fs::write(dest, &config_bytes)?;
+    Ok(())
+}
+
+/// Extract a single named member from an archive to memory via `tar -xO`,
+/// transparently `gunzip`-ing a gzipped outer archive.
+fn extract_tar_member(archive: &Path, member: &str) -> Result<Vec<u8>> {
+    let mut tar = Command::new("tar");
+    tar.args(["-x", "-O", "-f", "-"])
+        .arg(member)
         .stderr(Stdio::null());
-    let gunzip = pipe_archive_into(&mut config_cmd, archive)?;
-    let out = config_cmd
+    let gunzip = pipe_archive_into(&mut tar, archive)?;
+    let out = tar
         .output()
-        .map_err(|e| StorageError::new(format!("failed to run crane config: {e}")))?;
+        .map_err(|e| StorageError::new(format!("failed to run tar: {e}")))?;
     if let Some(mut g) = gunzip {
         let _ = g.wait();
     }
-    if !out.status.success() {
-        return Err(StorageError::new("crane config failed".to_string()));
+    if !out.status.success() || out.stdout.is_empty() {
+        return Err(StorageError::new(format!(
+            "could not read '{member}' from archive"
+        )));
     }
-    std::fs::write(dest, &out.stdout)?;
-    Ok(())
+    Ok(out.stdout)
 }
 
 /// Whether a file begins with the gzip magic bytes (`1f 8b`).
@@ -1722,6 +1758,16 @@ where
 pub fn query_image(image: &str) -> Result<Option<ImageInfo>> {
     let image = normalize_image_ref(image);
     let image = image.as_str();
+
+    // Packed layers (a `.smolmachine` or a staged local image archive/dir):
+    // synthesize image info without a registry manifest, mirroring the pull
+    // path. A local image archive is flattened into a rootfs first.
+    if let Some(packed_dir) = get_packed_layers_dir() {
+        let flattened = ensure_archive_flattened(packed_dir)?;
+        let effective = flattened.as_deref().unwrap_or(packed_dir);
+        return Ok(Some(create_packed_image_info(image, effective)?));
+    }
+
     let root = Path::new(STORAGE_ROOT);
     let manifest_path = root
         .join(MANIFESTS_DIR)
@@ -2671,9 +2717,13 @@ pub fn prepare_for_run_persistent(image: &str, overlay_id: &str) -> Result<Prepa
     validate_storage_id(overlay_id, "persistent overlay id")?;
     let workload_id = format!("persistent-{}", overlay_id);
 
-    // Resolve image layers (same logic as prepare_overlay)
+    // Resolve image layers (same logic as prepare_overlay). A local image
+    // archive is flattened into a rootfs first; a packed-layers dir is used
+    // as-is.
     let lowerdirs = if let Some(packed_dir) = get_packed_layers_dir() {
-        get_packed_lowerdirs(&packed_dir)?
+        let flattened = ensure_archive_flattened(packed_dir)?;
+        let effective = flattened.as_deref().unwrap_or(packed_dir);
+        get_packed_lowerdirs(effective)?
     } else {
         get_image_lowerdirs(image)?
     };

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -458,6 +458,11 @@ fn create_packed_image_info(image: &str, packed_dir: &Path) -> Result<ImageInfo>
     #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
     let architecture = "unknown".to_string();
 
+    // For a flattened local archive these come from the recovered image config;
+    // a .smolmachine has no config.json so they stay empty (its config lives in
+    // the PackManifest).
+    let (entrypoint, cmd, env, workdir, user) = read_packed_image_config(packed_dir);
+
     Ok(ImageInfo {
         reference: image.to_string(),
         digest: "packed".to_string(), // No real digest available for packed images
@@ -467,13 +472,219 @@ fn create_packed_image_info(image: &str, packed_dir: &Path) -> Result<ImageInfo>
         os: "linux".to_string(),
         layer_count: layer_dirs.len(),
         layers: layer_dirs,
-        // Packed mode: config is in the PackManifest, not the image
-        entrypoint: Vec::new(),
-        cmd: Vec::new(),
-        env: Vec::new(),
-        workdir: None,
-        user: None,
+        entrypoint,
+        cmd,
+        env,
+        workdir,
+        user,
     })
+}
+
+// =============================================================================
+// Local image archives (`docker save` / `podman save`)
+// =============================================================================
+//
+// smolvm delegates turning a saved-image archive into a rootfs to the bundled
+// `crane` (and `gunzip`/`tar`) rather than parsing OCI layers itself. The host
+// stages `archive.tar` into a content-addressed dir mounted via virtiofs as the
+// packed-layers dir; here we flatten it once into a rootfs on the writable
+// storage disk, recover the image config, and present it as a single packed
+// layer that the existing overlay path consumes.
+
+/// Filename the host stages the saved-image archive under.
+const ARCHIVE_FILE_NAME: &str = "archive.tar";
+/// Subdir the flattened rootfs is written to (a single packed "layer").
+const ARCHIVE_ROOTFS_DIR: &str = "0000_rootfs";
+/// Recovered image config (`crane config` output) beside the rootfs.
+const ARCHIVE_CONFIG_FILE: &str = "config.json";
+/// Marker written once a flatten completes, so restarts reuse it.
+const ARCHIVE_EXTRACTED_MARKER: &str = ".extracted";
+
+/// If `packed_dir` is a staged local image archive (it contains `archive.tar`),
+/// flatten it once into a rootfs on the storage disk and return that directory
+/// (holding `0000_rootfs/` + `config.json`). Returns `None` for an ordinary
+/// packed-layers dir (a `.smolmachine`'s pre-extracted layers). Idempotent: the
+/// marker lets the image-info and overlay paths share one flatten, and restarts
+/// reuse it.
+fn ensure_archive_flattened(packed_dir: &Path) -> Result<Option<PathBuf>> {
+    let archive = packed_dir.join(ARCHIVE_FILE_NAME);
+    if !archive.exists() {
+        return Ok(None);
+    }
+    // Key the output by the archive's cache-dir name (its content hash) so the
+    // same image reuses one flattened rootfs across machines.
+    let key = packed_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("archive");
+    let out_base = Path::new(STORAGE_ROOT).join("image-archives").join(key);
+    if out_base.join(ARCHIVE_EXTRACTED_MARKER).exists() {
+        return Ok(Some(out_base));
+    }
+    let rootfs = out_base.join(ARCHIVE_ROOTFS_DIR);
+    std::fs::create_dir_all(&rootfs)?;
+    info!(archive = %archive.display(), rootfs = %rootfs.display(), "flattening local image archive");
+    flatten_archive(&archive, &rootfs)?;
+    // Best-effort config recovery; a missing config just means no default
+    // entrypoint/cmd (the user can still pass an explicit command).
+    if let Err(e) = recover_archive_config(&archive, &out_base.join(ARCHIVE_CONFIG_FILE)) {
+        warn!(error = %e, "could not recover image config from archive");
+    }
+    std::fs::File::create(out_base.join(ARCHIVE_EXTRACTED_MARKER))?;
+    Ok(Some(out_base))
+}
+
+/// Feed an archive to `cmd`'s stdin, transparently `gunzip`-ing a gzipped outer
+/// archive. Returns the spawned `gunzip` child (if any) to wait on afterwards.
+fn pipe_archive_into(cmd: &mut Command, archive: &Path) -> Result<Option<std::process::Child>> {
+    let file = std::fs::File::open(archive)?;
+    if !is_gzip(archive)? {
+        cmd.stdin(Stdio::from(file));
+        return Ok(None);
+    }
+    let mut gunzip = Command::new("gunzip")
+        .arg("-c")
+        .stdin(file)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| StorageError::new(format!("failed to spawn gunzip: {e}")))?;
+    let out = gunzip
+        .stdout
+        .take()
+        .ok_or_else(|| StorageError::new("failed to capture gunzip stdout".to_string()))?;
+    cmd.stdin(Stdio::from(out));
+    Ok(Some(gunzip))
+}
+
+/// Flatten a `docker save` archive into `rootfs`, delegating to the bundled
+/// `crane export`. The flattened tar is a single layer with no whiteouts, so
+/// plain `tar -x` is sufficient (no per-layer handling needed).
+fn flatten_archive(archive: &Path, rootfs: &Path) -> Result<()> {
+    // crane export - - : read an image tarball from stdin, write a flat rootfs
+    // tar to stdout.
+    let mut crane = Command::new("crane");
+    crane
+        .args(["export", "-", "-"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    let gunzip = pipe_archive_into(&mut crane, archive)?;
+
+    let mut crane_child = crane
+        .spawn()
+        .map_err(|e| StorageError::new(format!("failed to spawn crane export: {e}")))?;
+    let crane_out = crane_child
+        .stdout
+        .take()
+        .ok_or_else(|| StorageError::new("failed to capture crane stdout".to_string()))?;
+
+    let tar_out = Command::new("tar")
+        .arg("-x")
+        .arg("-C")
+        .arg(rootfs)
+        .stdin(Stdio::from(crane_out))
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| StorageError::new(format!("failed to run tar: {e}")))?;
+
+    let crane_status = crane_child
+        .wait()
+        .map_err(|e| StorageError::new(format!("failed to wait for crane: {e}")))?;
+    if let Some(mut g) = gunzip {
+        let _ = g.wait();
+    }
+
+    if !crane_status.success() {
+        return Err(StorageError::new(
+            "crane export failed (is this a docker/podman `save` archive?)".to_string(),
+        ));
+    }
+    if !tar_out.status.success() {
+        return Err(StorageError::new(format!(
+            "extracting flattened rootfs failed: {}",
+            String::from_utf8_lossy(&tar_out.stderr)
+        )));
+    }
+    Ok(())
+}
+
+/// Recover the image config (Entrypoint/Cmd/Env/…) by delegating to
+/// `crane config`, writing the JSON to `dest`.
+fn recover_archive_config(archive: &Path, dest: &Path) -> Result<()> {
+    let mut config_cmd = Command::new("crane");
+    config_cmd
+        .args(["config", "-"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    let gunzip = pipe_archive_into(&mut config_cmd, archive)?;
+    let out = config_cmd
+        .output()
+        .map_err(|e| StorageError::new(format!("failed to run crane config: {e}")))?;
+    if let Some(mut g) = gunzip {
+        let _ = g.wait();
+    }
+    if !out.status.success() {
+        return Err(StorageError::new("crane config failed".to_string()));
+    }
+    std::fs::write(dest, &out.stdout)?;
+    Ok(())
+}
+
+/// Whether a file begins with the gzip magic bytes (`1f 8b`).
+fn is_gzip(path: &Path) -> Result<bool> {
+    use std::io::Read;
+    let mut magic = [0u8; 2];
+    match std::fs::File::open(path)?.read(&mut magic) {
+        Ok(2) => Ok(magic == [0x1f, 0x8b]),
+        _ => Ok(false),
+    }
+}
+
+/// Read `Entrypoint`/`Cmd`/`Env`/`WorkingDir`/`User` from a recovered image
+/// `config.json` (the `crane config` output) in `packed_dir`, defaulting to
+/// empty when absent — a `.smolmachine` has no such file.
+#[allow(clippy::type_complexity)]
+fn read_packed_image_config(
+    packed_dir: &Path,
+) -> (
+    Vec<String>,
+    Vec<String>,
+    Vec<String>,
+    Option<String>,
+    Option<String>,
+) {
+    let empty = (Vec::new(), Vec::new(), Vec::new(), None, None);
+    let Ok(content) = std::fs::read_to_string(packed_dir.join(ARCHIVE_CONFIG_FILE)) else {
+        return empty;
+    };
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return empty;
+    };
+    let cfg = &json["config"];
+    let string_list = |key: &str| -> Vec<String> {
+        cfg[key]
+            .as_array()
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default()
+    };
+    let non_empty = |key: &str| -> Option<String> {
+        cfg[key]
+            .as_str()
+            .filter(|s| !s.is_empty())
+            .map(String::from)
+    };
+    (
+        string_list("Entrypoint"),
+        string_list("Cmd"),
+        string_list("Env"),
+        non_empty("WorkingDir"),
+        non_empty("User"),
+    )
 }
 
 /// Error type for storage operations.
@@ -1213,6 +1424,11 @@ where
     // If packed layers are available, return synthetic image info
     if let Some(packed_dir) = get_packed_layers_dir() {
         info!(image = %image, "using packed layers, skipping network pull");
+        // A local image archive is flattened into a rootfs first; an ordinary
+        // packed-layers dir is used as-is.
+        if let Some(flattened) = ensure_archive_flattened(packed_dir)? {
+            return create_packed_image_info(image, &flattened);
+        }
         return create_packed_image_info(image, packed_dir);
     }
 
@@ -2023,7 +2239,11 @@ pub fn prepare_overlay(image: &str, workload_id: &str) -> Result<OverlayInfo> {
     // Check if we have packed layers available
     if let Some(packed_dir) = get_packed_layers_dir() {
         info!(image = %image, packed_dir = %packed_dir.display(), "using packed layers");
-        return prepare_overlay_from_packed(image, workload_id, packed_dir);
+        // A local image archive is flattened into a rootfs (a single packed
+        // layer) first; an ordinary packed-layers dir is used as-is.
+        let flattened = ensure_archive_flattened(packed_dir)?;
+        let effective = flattened.as_deref().unwrap_or(packed_dir);
+        return prepare_overlay_from_packed(image, workload_id, effective);
     }
 
     // Ensure image exists

--- a/crates/smolvm-protocol/src/image_ref.rs
+++ b/crates/smolvm-protocol/src/image_ref.rs
@@ -37,6 +37,12 @@
 ///            "ghcr.io/owner/repo:v1");
 /// ```
 pub fn normalize_image_ref(image: &str) -> String {
+    // Local image sources (host-resolved `local:<hash>` / `local-dir:<path>`)
+    // are not registry references — pass them through unchanged.
+    if image.starts_with("local:") || image.starts_with("local-dir:") {
+        return image.to_string();
+    }
+
     // 1. Resolve index.docker.io alias.
     let owned;
     let image = if let Some(rest) = image.strip_prefix("index.docker.io/") {

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -585,6 +585,17 @@ impl RunCmd {
             (self.interactive, self.tty)
         };
 
+        // `--image -` consumes stdin to read the archive; `-i`/`-t` also bind
+        // stdin to the guest. They cannot both own stdin.
+        if self.image.as_deref() == Some("-") && (interactive || tty) {
+            return Err(smolvm::Error::config(
+                "machine run",
+                "`--image -` reads the image archive from stdin and cannot be \
+                 combined with -i/-t, which also use stdin.\n\
+                 Pipe the archive from a file instead: --image ./image.tar",
+            ));
+        }
+
         // Detect the common mistake of passing an image reference as a positional
         // argument instead of using --image.  clap's trailing_var_arg captures any
         // positional before "--" into `command`, so `smolvm machine run ubuntu:22.04

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -662,10 +662,34 @@ impl RunCmd {
             None
         };
 
+        // Resolve the image source on the host before launch: registry refs
+        // pass through to the guest pull; a local `docker save` archive or an
+        // unpacked rootfs directory is staged/validated and mounted via
+        // virtiofs (the `.smolmachine` packed-layers path), so no pull happens.
+        let raw_image = self.image.clone().or(params.image.clone());
+        let mut packed_layers_dir = None;
+        let image = match raw_image.as_deref() {
+            Some(img) => {
+                use smolvm::data::image_source::{classify, resolve, ResolvedImage};
+                match resolve(classify(img))? {
+                    ResolvedImage::Registry(reference) => Some(reference),
+                    ResolvedImage::Local {
+                        reference,
+                        packed_layers_dir: dir,
+                    } => {
+                        packed_layers_dir = Some(dir);
+                        Some(reference)
+                    }
+                }
+            }
+            None => None,
+        };
+        let uses_packed_layers = packed_layers_dir.is_some();
+
         let features = smolvm::agent::LaunchFeatures {
             ssh_agent_socket,
             dns_filter_hosts: params.dns_filter_hosts.clone(),
-            packed_layers_dir: None,
+            packed_layers_dir,
             extra_disks: Vec::new(),
         };
 
@@ -685,7 +709,7 @@ impl RunCmd {
                 params.cpus,
                 params.mem,
                 params.net,
-                self.image.clone().or(params.image.clone()),
+                image.clone(),
             );
         }
 
@@ -697,10 +721,11 @@ impl RunCmd {
         let sigint_guard = manager.child_pid().map(smolvm::process::SigintGuard::new);
 
         // Resolve image: CLI > Smolfile > None (bare VM)
-        let image = self.image.clone().or(params.image.clone());
-
-        // Pull image if one is specified
-        let image_info = if let Some(ref img) = image {
+        // Pull only registry images; a local source's layers are already
+        // mounted via virtiofs and the guest assembles its rootfs from them.
+        let image_info = if uses_packed_layers {
+            None
+        } else if let Some(ref img) = image {
             match crate::cli::pull_with_progress(
                 &mut client,
                 img,

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -1696,9 +1696,24 @@ impl CreateCmd {
             .name
             .unwrap_or_else(smolvm::util::generate_machine_name);
 
+        // Resolve a local image source (archive/dir) on the host now: stage it
+        // into the content-addressed cache and persist the resulting `local:…`
+        // reference, so `start` re-derives the mount dir without a registry
+        // pull. Registry refs pass through unchanged.
+        let image = match self.image.as_deref() {
+            Some(img) => {
+                use smolvm::data::image_source::{classify, resolve, ResolvedImage};
+                Some(match resolve(classify(img))? {
+                    ResolvedImage::Registry(reference) => reference,
+                    ResolvedImage::Local { reference, .. } => reference,
+                })
+            }
+            None => None,
+        };
+
         let params = crate::cli::smolfile::build_create_params(
             name,
-            self.image,
+            image,
             None,         // entrypoint: from Smolfile only
             self.command, // persistent-workload command (detached container on start)
             self.cpus,

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -1095,7 +1095,7 @@ pub fn start_vm_named(
     // packed_layers_dir so the launcher mounts them via virtiofs — the guest uses
     // the pre-extracted layers instead of pulling, with no dependency on the
     // original bundle file. Shared with the API and embedded start paths.
-    let features = smolvm::agent::LaunchFeatures {
+    let mut features = smolvm::agent::LaunchFeatures {
         ssh_agent_socket,
         dns_filter_hosts: record.dns_filter_hosts.clone(),
         ..Default::default()
@@ -1104,6 +1104,18 @@ pub fn start_vm_named(
         &smolvm::agent::machine_layers_cache_dir(name),
         record.source_smolmachine.as_deref(),
     )?;
+    // A machine created from a local image archive/dir persists a `local:…`
+    // reference; re-derive its virtiofs mount dir so the guest assembles the
+    // rootfs from it instead of pulling.
+    if features.packed_layers_dir.is_none() {
+        if let Some(dir) = record
+            .image
+            .as_deref()
+            .and_then(smolvm::data::image_source::packed_layers_dir_for_ref)
+        {
+            features.packed_layers_dir = Some(dir);
+        }
+    }
 
     let _ = manager
         .ensure_running_with_full_config(mounts, ports, resources, features)
@@ -1134,7 +1146,12 @@ pub fn start_vm_named(
     // starts, skip both — image manifests/layers persist on the storage disk
     // and the container overlay is remounted (not recreated).
     if !record.init_completed {
-        let image_info = if record.source_smolmachine.is_some() {
+        let uses_packed_layers = record.source_smolmachine.is_some()
+            || record
+                .image
+                .as_deref()
+                .is_some_and(smolvm::data::image_source::is_local_ref);
+        let image_info = if uses_packed_layers {
             // Layers already mounted via virtiofs — no pull needed.
             None
         } else if let Some(ref image) = record.image {

--- a/src/data/image_source.rs
+++ b/src/data/image_source.rs
@@ -1,0 +1,354 @@
+//! Classifying the `--image` value into an image *source*.
+//!
+//! smolvm is a microVM runtime, not a container runtime: it does not parse OCI
+//! manifests, extract layers, or apply whiteouts itself. It delegates producing
+//! a root filesystem to container-specific tooling (the guest's bundled `crane`
+//! for registries and `docker save` archives, or the user for an already-
+//! unpacked directory). This module's only job is to decide *which* kind of
+//! source the user gave, so the right delegation runs.
+//!
+//! Detection is intentionally conservative so a bare registry reference is never
+//! mistaken for a local path:
+//! - `-` → an archive streamed on stdin (`docker save img | smolvm … --image -`).
+//! - an explicit path (`/…`, `./…`, `../…`) or an archive-extensioned name
+//!   (`*.tar`, `*.tar.gz`, `*.tgz`) → a local source. A directory is used as a
+//!   ready-made rootfs; anything else is treated as a `docker save` archive.
+//! - everything else (`alpine`, `repo:tag`, `ghcr.io/owner/repo@sha256:…`) → a
+//!   registry reference, even if a same-named file happens to sit in the cwd.
+
+use crate::{Error, Result};
+use sha2::{Digest, Sha256};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+/// Where a machine's root filesystem comes from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImageSource {
+    /// An OCI registry reference (`alpine`, `repo:tag`, `repo@sha256:…`).
+    /// Resolved by the guest agent pulling with `crane` — the existing path.
+    Registry(String),
+    /// A `docker save` / `podman save` tar archive (optionally gzipped), read
+    /// from a file or stdin. Flattened into a rootfs by `crane export`.
+    Archive(ArchiveInput),
+    /// An already-unpacked root filesystem directory (apptainer-style). Used
+    /// as-is — no extraction.
+    Directory(PathBuf),
+}
+
+/// Where an [`ImageSource::Archive`]'s bytes come from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ArchiveInput {
+    /// Read the archive from this file path.
+    File(PathBuf),
+    /// Read the archive from stdin (`--image -`).
+    Stdin,
+}
+
+/// Known archive filename suffixes that mark a bare name as a local archive
+/// even without an explicit path prefix (e.g. `image.tar` in the cwd).
+const ARCHIVE_SUFFIXES: [&str; 3] = [".tar", ".tar.gz", ".tgz"];
+
+/// Classify a `--image` value into its [`ImageSource`].
+///
+/// This decides *intent* only; whether the path actually exists (and is a valid
+/// archive) is validated when the source is resolved, so a missing `./foo.tar`
+/// produces a clear "no such file" rather than a confusing registry error.
+pub fn classify(image: &str) -> ImageSource {
+    if image == "-" {
+        return ImageSource::Archive(ArchiveInput::Stdin);
+    }
+    if looks_local(image) {
+        let path = Path::new(image);
+        // Only an existing directory is treated as a ready-made rootfs; a
+        // missing path or a regular file is treated as an archive (resolve
+        // surfaces a clear error if it's absent).
+        if path.is_dir() {
+            return ImageSource::Directory(path.to_path_buf());
+        }
+        return ImageSource::Archive(ArchiveInput::File(path.to_path_buf()));
+    }
+    ImageSource::Registry(image.to_string())
+}
+
+/// Whether a value should be treated as a local path rather than a registry
+/// reference: an explicit path prefix or a known archive suffix.
+fn looks_local(image: &str) -> bool {
+    image.starts_with('/')
+        || image.starts_with("./")
+        || image.starts_with("../")
+        || ARCHIVE_SUFFIXES
+            .iter()
+            .any(|suffix| image.ends_with(suffix))
+}
+
+/// A classified source resolved into something launchable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolvedImage {
+    /// Pulled from a registry by the guest agent — the existing path.
+    Registry(String),
+    /// A local source materialized on the host. `reference` is the stable ref
+    /// persisted on the machine record; `packed_layers_dir` is mounted into the
+    /// guest via virtiofs (the same path `.smolmachine` layers use).
+    Local {
+        /// Stable `local:<hash>` / `local-dir:<path>` reference to persist on
+        /// the machine record so later starts re-resolve to the same source.
+        reference: String,
+        /// Host directory mounted into the guest via virtiofs — the staged
+        /// archive's cache dir, or the rootfs directory itself.
+        packed_layers_dir: PathBuf,
+    },
+}
+
+/// Largest archive accepted. The staged copy plus the guest's flattened rootfs
+/// both consume disk, so this guards against runaway/hostile inputs while still
+/// covering very large dev images.
+const MAX_ARCHIVE_BYTES: u64 = 8 * 1024 * 1024 * 1024;
+/// Streaming hash/copy buffer.
+const COPY_CHUNK: usize = 1 << 20;
+/// Filename the staged archive is stored under inside its cache dir.
+const ARCHIVE_FILE: &str = "archive.tar";
+
+/// Resolve a classified [`ImageSource`] into a [`ResolvedImage`].
+///
+/// Registry refs pass straight through (the guest pulls them). Archives are
+/// content-hashed and staged into a shared cache, so identical inputs dedupe
+/// and re-runs skip the staging; directories are validated and used in place.
+/// Both local kinds yield a `packed_layers_dir` to mount and a `local:…`
+/// reference to persist on the machine record.
+pub fn resolve(source: ImageSource) -> Result<ResolvedImage> {
+    match source {
+        ImageSource::Registry(reference) => Ok(ResolvedImage::Registry(reference)),
+        ImageSource::Directory(path) => resolve_directory(&path),
+        ImageSource::Archive(input) => resolve_archive(input),
+    }
+}
+
+fn resolve_directory(path: &Path) -> Result<ResolvedImage> {
+    let canonical = path.canonicalize().map_err(|e| {
+        Error::config(
+            "--image",
+            format!("cannot use rootfs directory {}: {}", path.display(), e),
+        )
+    })?;
+    if !canonical.is_dir() {
+        return Err(Error::config(
+            "--image",
+            format!("{} is not a directory", canonical.display()),
+        ));
+    }
+    Ok(ResolvedImage::Local {
+        reference: format!("local-dir:{}", canonical.display()),
+        packed_layers_dir: canonical,
+    })
+}
+
+fn resolve_archive(input: ArchiveInput) -> Result<ResolvedImage> {
+    let cache_base = archive_cache_base()?;
+    std::fs::create_dir_all(&cache_base)?;
+    let hash = match input {
+        ArchiveInput::File(path) => stage_from_file(&path, &cache_base)?,
+        ArchiveInput::Stdin => stage_from_stdin(&cache_base)?,
+    };
+    Ok(ResolvedImage::Local {
+        reference: format!("local:{hash}"),
+        packed_layers_dir: cache_base.join(hash),
+    })
+}
+
+/// Hash an on-disk archive and hardlink (or copy) it into `cache/<hash>/`.
+fn stage_from_file(path: &Path, cache_base: &Path) -> Result<String> {
+    let meta = std::fs::metadata(path).map_err(|e| {
+        Error::config(
+            "--image",
+            format!("cannot read archive {}: {}", path.display(), e),
+        )
+    })?;
+    if !meta.is_file() {
+        return Err(Error::config(
+            "--image",
+            format!("{} is not a file", path.display()),
+        ));
+    }
+    if meta.len() > MAX_ARCHIVE_BYTES {
+        return Err(too_large(meta.len()));
+    }
+    let hash = hash_file(path)?;
+    let archive_path = cache_base.join(&hash).join(ARCHIVE_FILE);
+    if !archive_path.exists() {
+        std::fs::create_dir_all(archive_path.parent().expect("hash dir has a parent"))?;
+        link_or_copy(path, &archive_path)?;
+    }
+    Ok(hash)
+}
+
+/// Stream stdin to a temp file (hashing as we go), then place it at
+/// `cache/<hash>/`. Single-pass, so one write is unavoidable.
+fn stage_from_stdin(cache_base: &Path) -> Result<String> {
+    let mut tmp = tempfile::NamedTempFile::new_in(cache_base)?;
+    let mut hasher = Sha256::new();
+    let mut stdin = std::io::stdin().lock();
+    let mut buf = vec![0u8; COPY_CHUNK];
+    let mut total: u64 = 0;
+    loop {
+        let n = stdin.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        total += n as u64;
+        if total > MAX_ARCHIVE_BYTES {
+            return Err(too_large(total));
+        }
+        hasher.update(&buf[..n]);
+        tmp.write_all(&buf[..n])?;
+    }
+    tmp.flush()?;
+    let hash = hex::encode(hasher.finalize());
+    let archive_path = cache_base.join(&hash).join(ARCHIVE_FILE);
+    if archive_path.exists() {
+        return Ok(hash); // already staged; the temp file is dropped/removed
+    }
+    std::fs::create_dir_all(archive_path.parent().expect("hash dir has a parent"))?;
+    tmp.persist(&archive_path)
+        .map_err(|e| Error::storage("stage stdin archive", e.to_string()))?;
+    Ok(hash)
+}
+
+fn hash_file(path: &Path) -> Result<String> {
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buf = vec![0u8; COPY_CHUNK];
+    loop {
+        let n = file.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(hex::encode(hasher.finalize()))
+}
+
+/// Hardlink `src` into the cache, copying as a fallback across filesystems.
+fn link_or_copy(src: &Path, dst: &Path) -> Result<()> {
+    if std::fs::hard_link(src, dst).is_ok() {
+        return Ok(());
+    }
+    std::fs::copy(src, dst)?;
+    Ok(())
+}
+
+fn archive_cache_base() -> Result<PathBuf> {
+    let base = dirs::cache_dir()
+        .ok_or_else(|| Error::storage("image archive cache", "no cache directory available"))?;
+    Ok(base.join("smolvm-image-archives"))
+}
+
+fn too_large(bytes: u64) -> Error {
+    Error::config(
+        "--image",
+        format!("image archive is {bytes} bytes, over the {MAX_ARCHIVE_BYTES}-byte limit"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_refs_are_not_treated_as_local() {
+        for r in [
+            "alpine",
+            "alpine:3.20",
+            "ghcr.io/owner/repo",
+            "ghcr.io/owner/repo:v1",
+            "repo@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            "localhost:5000/myimage:dev",
+        ] {
+            assert_eq!(classify(r), ImageSource::Registry(r.to_string()), "{r}");
+        }
+    }
+
+    #[test]
+    fn stdin_dash_is_an_archive() {
+        assert_eq!(classify("-"), ImageSource::Archive(ArchiveInput::Stdin));
+    }
+
+    #[test]
+    fn archive_extensions_and_paths_are_local_archives() {
+        // Suffix-based (bare name in cwd) — file need not exist to classify.
+        for a in ["image.tar", "image.tar.gz", "image.tgz"] {
+            assert_eq!(
+                classify(a),
+                ImageSource::Archive(ArchiveInput::File(PathBuf::from(a))),
+                "{a}"
+            );
+        }
+        // Explicit path prefixes, even without an archive extension.
+        for a in ["./img", "/abs/img.tar", "../up/img"] {
+            assert_eq!(
+                classify(a),
+                ImageSource::Archive(ArchiveInput::File(PathBuf::from(a))),
+                "{a}"
+            );
+        }
+    }
+
+    #[test]
+    fn existing_directory_is_a_directory_source() {
+        let dir = tempfile::tempdir().unwrap();
+        // Reference it with an explicit path prefix so it reads as local.
+        let as_path = format!("{}/.", dir.path().display());
+        match classify(&as_path) {
+            ImageSource::Directory(p) => assert!(p.is_dir()),
+            other => panic!("expected Directory, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bare_name_matching_a_cwd_file_still_resolves_to_registry() {
+        // A registry ref like `alpine` must not be hijacked by a same-named
+        // file: it isn't an explicit path and has no archive suffix.
+        assert_eq!(
+            classify("alpine"),
+            ImageSource::Registry("alpine".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_registry_passes_through() {
+        assert_eq!(
+            resolve(ImageSource::Registry("alpine".into())).unwrap(),
+            ResolvedImage::Registry("alpine".into())
+        );
+    }
+
+    #[test]
+    fn stage_from_file_hashes_and_dedupes() {
+        let cache = tempfile::tempdir().unwrap();
+        let src = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(src.path(), b"fake docker save archive").unwrap();
+
+        let h1 = stage_from_file(src.path(), cache.path()).unwrap();
+        let staged = cache.path().join(&h1).join(ARCHIVE_FILE);
+        assert!(staged.exists(), "archive staged at {}", staged.display());
+        assert_eq!(std::fs::read(&staged).unwrap(), b"fake docker save archive");
+
+        // Identical content → identical hash, idempotent (no error, reused).
+        let h2 = stage_from_file(src.path(), cache.path()).unwrap();
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn resolve_directory_yields_local_with_the_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        match resolve_directory(dir.path()).unwrap() {
+            ResolvedImage::Local {
+                reference,
+                packed_layers_dir,
+            } => {
+                assert!(reference.starts_with("local-dir:"));
+                assert_eq!(packed_layers_dir, dir.path().canonicalize().unwrap());
+            }
+            other => panic!("expected Local, got {other:?}"),
+        }
+    }
+}

--- a/src/data/image_source.rs
+++ b/src/data/image_source.rs
@@ -81,6 +81,45 @@ fn looks_local(image: &str) -> bool {
             .any(|suffix| image.ends_with(suffix))
 }
 
+/// Whether a local path is a Dockerfile rather than an image archive — so we can
+/// reject it with a build-first hint instead of a confusing flatten failure.
+/// Detected by the conventional name (`Dockerfile`/`Containerfile`, or a
+/// `*.Dockerfile`/`*.Containerfile` suffix) or a first meaningful line of `FROM`.
+fn looks_like_dockerfile(path: &Path) -> bool {
+    if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+        let lower = name.to_ascii_lowercase();
+        if lower == "dockerfile"
+            || lower == "containerfile"
+            || lower.ends_with(".dockerfile")
+            || lower.ends_with(".containerfile")
+        {
+            return true;
+        }
+    }
+    // Content sniff over the first few KB only (never slurp a multi-GB archive):
+    // skip blank/comment lines; a Dockerfile opens with FROM (or an ARG before
+    // it). A tar archive's header is binary, so the UTF-8 read simply fails.
+    let mut head = [0u8; 4096];
+    let Ok(mut file) = std::fs::File::open(path) else {
+        return false;
+    };
+    let Ok(n) = std::io::Read::read(&mut file, &mut head) else {
+        return false;
+    };
+    let Ok(text) = std::str::from_utf8(&head[..n]) else {
+        return false;
+    };
+    for line in text.lines().take(50) {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let word = line.split_whitespace().next().unwrap_or("");
+        return word.eq_ignore_ascii_case("FROM") || word.eq_ignore_ascii_case("ARG");
+    }
+    false
+}
+
 /// A classified source resolved into something launchable.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ResolvedImage {
@@ -167,6 +206,18 @@ fn stage_from_file(path: &Path, cache_base: &Path) -> Result<String> {
         return Err(Error::config(
             "--image",
             format!("{} is not a file", path.display()),
+        ));
+    }
+    if looks_like_dockerfile(path) {
+        return Err(Error::config(
+            "--image",
+            format!(
+                "{} looks like a Dockerfile, not an image.\n\
+                 smolvm boots images, it does not build them — build first, then \
+                 pass the result:\n  \
+                 docker build -t myapp . && docker save myapp | smolvm machine run --image - -- ...",
+                path.display()
+            ),
         ));
     }
     if meta.len() > MAX_ARCHIVE_BYTES {
@@ -312,6 +363,41 @@ mod tests {
                 "{a}"
             );
         }
+    }
+
+    #[test]
+    fn dockerfiles_are_rejected_with_a_build_hint() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // By name: `Dockerfile` (any case) and `*.Dockerfile`.
+        for name in [
+            "Dockerfile",
+            "dockerfile",
+            "Containerfile",
+            "app.Dockerfile",
+        ] {
+            let p = dir.path().join(name);
+            std::fs::write(&p, b"unreadable as a name test").unwrap();
+            assert!(looks_like_dockerfile(&p), "{name}");
+        }
+
+        // By content: a file not named Dockerfile but opening with FROM.
+        let by_content = dir.path().join("build-recipe");
+        std::fs::write(
+            &by_content,
+            b"# build\nFROM alpine:3.20\nRUN apk add curl\n",
+        )
+        .unwrap();
+        assert!(looks_like_dockerfile(&by_content));
+
+        // A binary archive must not be mistaken for a Dockerfile.
+        let archive = dir.path().join("image.bin");
+        std::fs::write(&archive, [0u8, 1, 2, 0xff, b'F', b'R', b'O', b'M']).unwrap();
+        assert!(!looks_like_dockerfile(&archive));
+
+        // And resolve surfaces the build-first hint, not a flatten failure.
+        let err = stage_from_file(&dir.path().join("Dockerfile"), dir.path()).unwrap_err();
+        assert!(err.to_string().contains("build"), "{err}");
     }
 
     #[test]

--- a/src/data/image_source.rs
+++ b/src/data/image_source.rs
@@ -137,7 +137,7 @@ fn resolve_directory(path: &Path) -> Result<ResolvedImage> {
         ));
     }
     Ok(ResolvedImage::Local {
-        reference: format!("local-dir:{}", canonical.display()),
+        reference: format!("{LOCAL_DIR_PREFIX}{}", canonical.display()),
         packed_layers_dir: canonical,
     })
 }
@@ -150,7 +150,7 @@ fn resolve_archive(input: ArchiveInput) -> Result<ResolvedImage> {
         ArchiveInput::Stdin => stage_from_stdin(&cache_base)?,
     };
     Ok(ResolvedImage::Local {
-        reference: format!("local:{hash}"),
+        reference: format!("{LOCAL_ARCHIVE_PREFIX}{hash}"),
         packed_layers_dir: cache_base.join(hash),
     })
 }
@@ -234,6 +234,28 @@ fn link_or_copy(src: &Path, dst: &Path) -> Result<()> {
     }
     std::fs::copy(src, dst)?;
     Ok(())
+}
+
+/// Reference prefixes produced by [`resolve`] for the two local-source kinds.
+const LOCAL_ARCHIVE_PREFIX: &str = "local:";
+const LOCAL_DIR_PREFIX: &str = "local-dir:";
+
+/// Whether a persisted image reference points at a local source (produced by
+/// [`resolve`]) rather than a registry.
+pub fn is_local_ref(reference: &str) -> bool {
+    reference.starts_with(LOCAL_ARCHIVE_PREFIX) || reference.starts_with(LOCAL_DIR_PREFIX)
+}
+
+/// Map a persisted `local:…`/`local-dir:…` reference back to the host directory
+/// to mount into the guest via virtiofs, so a later `start` re-resolves to the
+/// same source without re-staging. Returns `None` for a registry reference. The
+/// directory may be gone if the archive cache was pruned — `start` then fails
+/// with a clear "no such directory" rather than silently pulling.
+pub fn packed_layers_dir_for_ref(reference: &str) -> Option<PathBuf> {
+    if let Some(hash) = reference.strip_prefix(LOCAL_ARCHIVE_PREFIX) {
+        return archive_cache_base().ok().map(|base| base.join(hash));
+    }
+    reference.strip_prefix(LOCAL_DIR_PREFIX).map(PathBuf::from)
 }
 
 fn archive_cache_base() -> Result<PathBuf> {
@@ -335,6 +357,25 @@ mod tests {
         // Identical content → identical hash, idempotent (no error, reused).
         let h2 = stage_from_file(src.path(), cache.path()).unwrap();
         assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn local_refs_round_trip_to_a_packed_layers_dir() {
+        assert!(is_local_ref("local:abc123"));
+        assert!(is_local_ref("local-dir:/srv/rootfs"));
+        assert!(!is_local_ref("alpine"));
+        assert!(!is_local_ref("ghcr.io/o/r:v1"));
+
+        // A dir ref maps straight back to the directory.
+        assert_eq!(
+            packed_layers_dir_for_ref("local-dir:/srv/rootfs"),
+            Some(PathBuf::from("/srv/rootfs"))
+        );
+        // An archive ref maps under the shared cache base, keyed by hash.
+        let dir = packed_layers_dir_for_ref("local:deadbeef").unwrap();
+        assert!(dir.ends_with("smolvm-image-archives/deadbeef"));
+        // Registry refs have no packed-layers dir.
+        assert_eq!(packed_layers_dir_for_ref("alpine"), None);
     }
 
     #[test]

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -7,6 +7,8 @@ pub mod disk;
 /// Canonical error types used by the shared data layer.
 #[path = "errors.rs"]
 pub mod error;
+/// Classifying `--image` into a registry ref, local archive, or rootfs dir.
+pub mod image_source;
 /// Canonical network-related data models.
 pub mod network;
 /// Canonical resource configuration data models.

--- a/tests/README.md
+++ b/tests/README.md
@@ -29,7 +29,7 @@ SMOLVM_SKIP_SLOW=1 ./tests/run_tests.sh   # skip tests with long sleeps (~5 min)
 | `reliability` | `test_reliability.sh` | 5 | Concurrency, state probe, ls-does-not-kill-vm |
 | `run` | `test_machine_run.sh` | 25 | Ephemeral `machine run` scenarios |
 | `image` | `test_machine_image.sh` | 13 | Image-based VMs, exec-join, large stdout |
-| `local-image` | `test_machine_local_image.sh` | 5 | Offline boot: save-archive (file/stdin), rootfs dir, stdin guard (needs docker) |
+| `local-image` | `test_machine_local_image.sh` | 6 | Local images: save-archive (file/stdin), rootfs dir, stdin + Dockerfile guards (needs docker) |
 | `packed` | `test_machine_packed.sh` | 2 | `.smolmachine` create and cp |
 
 ### Extended suites (opt-in only)

--- a/tests/README.md
+++ b/tests/README.md
@@ -10,7 +10,7 @@ against real VMs — no mocking.
 Single entry point for all test suites.
 
 ```bash
-./tests/run_tests.sh                      # all 11 feature suites (~10 min)
+./tests/run_tests.sh                      # all 12 feature suites (~10 min)
 SMOLVM_SKIP_SLOW=1 ./tests/run_tests.sh   # skip tests with long sleeps (~5 min)
 ./tests/run_tests.sh bare network         # specific groups only
 ```
@@ -29,6 +29,7 @@ SMOLVM_SKIP_SLOW=1 ./tests/run_tests.sh   # skip tests with long sleeps (~5 min)
 | `reliability` | `test_reliability.sh` | 5 | Concurrency, state probe, ls-does-not-kill-vm |
 | `run` | `test_machine_run.sh` | 25 | Ephemeral `machine run` scenarios |
 | `image` | `test_machine_image.sh` | 13 | Image-based VMs, exec-join, large stdout |
+| `local-image` | `test_machine_local_image.sh` | 5 | Offline boot: save-archive (file/stdin), rootfs dir, stdin guard (needs docker) |
 | `packed` | `test_machine_packed.sh` | 2 | `.smolmachine` create and cp |
 
 ### Extended suites (opt-in only)

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -18,6 +18,7 @@
 #   reliability     test_reliability.sh
 #   run             test_machine_run.sh
 #   image           test_machine_image.sh
+#   local-image     test_machine_local_image.sh
 #   packed          test_machine_packed.sh
 #
 # Extended suites (opt-in only, not run by default):
@@ -58,6 +59,7 @@ get_suite() {
         reliability) echo "$SCRIPT_DIR/test_reliability.sh" ;;
         run)         echo "$SCRIPT_DIR/test_machine_run.sh" ;;
         image)       echo "$SCRIPT_DIR/test_machine_image.sh" ;;
+        local-image) echo "$SCRIPT_DIR/test_machine_local_image.sh" ;;
         packed)      echo "$SCRIPT_DIR/test_machine_packed.sh" ;;
         cli)         echo "$SCRIPT_DIR/test_cli.sh" ;;
         api)         echo "$SCRIPT_DIR/test_api.sh" ;;
@@ -122,7 +124,7 @@ if [[ $# -eq 0 ]]; then
     done
 
     # Sequential suites -- run one at a time.
-    for _name in bare db reliability storage run image network volumes ports packed; do
+    for _name in bare db reliability storage run image local-image network volumes ports packed; do
         run_suite "$_name"
     done
 
@@ -150,7 +152,7 @@ else
         fi
         get_suite "$group" > /dev/null || {
             echo "Unknown group: $group"
-            echo "Feature suites: bare db network volumes ports storage resources reliability run image packed"
+            echo "Feature suites: bare db network volumes ports storage resources reliability run image local-image packed"
             echo "Extended suites: cli api virtio-net smolfile pack pack-quick gpu scale"
             echo "Other: bench"
             exit 1

--- a/tests/test_machine_local_image.sh
+++ b/tests/test_machine_local_image.sh
@@ -128,6 +128,23 @@ test_stdin_guard_rejects_interactive() {
     return 0
 }
 
+# A Dockerfile is not an image — reject with a build-first hint, not a flatten error.
+test_dockerfile_rejected_with_hint() {
+    local dockerfile="$FIXTURE_DIR/Dockerfile"
+    printf 'FROM alpine:3.20\nRUN apk add curl\n' > "$dockerfile"
+
+    local output exit_code=0
+    output=$($SMOLVM machine run --image "$dockerfile" -- true 2>&1) || exit_code=$?
+    [[ $exit_code -ne 0 ]] || {
+        echo "FAIL: a Dockerfile should be rejected"
+        return 1
+    }
+    echo "$output" | grep -qi "Dockerfile" || {
+        echo "FAIL: expected a build-first hint, got: $output"
+        return 1
+    }
+}
+
 # Persistent lifecycle from an archive: create, start, exec, stop, restart.
 # Restart re-derives the local source and reopens the same on-disk rootfs.
 test_persistent_create_start_restart() {
@@ -174,6 +191,7 @@ run_test "Ephemeral: boot from docker-save archive file (offline)" test_ephemera
 run_test "Ephemeral: boot from archive on stdin (--image -)" test_ephemeral_from_stdin || true
 run_test "Ephemeral: boot from unpacked rootfs dir (#398)" test_ephemeral_from_rootfs_dir || true
 run_test "Guard: --image - with -it rejected before boot" test_stdin_guard_rejects_interactive || true
+run_test "Guard: Dockerfile rejected with build-first hint" test_dockerfile_rejected_with_hint || true
 run_test "Persistent: create/start/restart from archive" test_persistent_create_start_restart || true
 
 print_summary "Local Image Tests"

--- a/tests/test_machine_local_image.sh
+++ b/tests/test_machine_local_image.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+#
+# Local / Offline Image Tests
+#
+# Exercises booting a machine from a local image source with NO registry:
+#   - a `docker save` archive passed as a file (--image ./image.tar)
+#   - the same archive streamed on stdin (--image -)
+#   - an unpacked rootfs directory (--image ./rootfs/)
+# plus persistent create/start/restart from an archive and the stdin-conflict
+# guard. None of these tests pass --net: booting without networking proves the
+# image is sourced locally and no pull happens.
+#
+# Requires docker (to produce the archive/rootfs fixtures). Skips cleanly when
+# docker is unavailable.
+#
+# Part of the smolvm test suite. Run with: ./tests/test_machine_local_image.sh
+#
+
+source "$(dirname "$0")/common.sh"
+init_smolvm
+
+log_info "Pre-flight cleanup: killing orphan processes..."
+kill_orphan_smolvm_processes
+
+# Fixtures built once for the whole suite.
+FIXTURE_DIR=""
+ARCHIVE=""
+ROOTFS_DIR=""
+
+build_fixtures() {
+    FIXTURE_DIR=$(mktemp -d)
+    ARCHIVE="$FIXTURE_DIR/alpine-save.tar"
+    ROOTFS_DIR="$FIXTURE_DIR/alpine-rootfs"
+
+    # docker-save archive (OCI image tarball, multi-layer with config).
+    docker save alpine:latest -o "$ARCHIVE" 2>/dev/null || return 1
+
+    # Unpacked rootfs (flat filesystem) via docker export.
+    mkdir -p "$ROOTFS_DIR"
+    local cid
+    cid=$(docker create alpine:latest 2>/dev/null) || return 1
+    docker export "$cid" 2>/dev/null | tar -x -C "$ROOTFS_DIR" 2>/dev/null
+    docker rm "$cid" >/dev/null 2>&1 || true
+
+    [[ -s "$ARCHIVE" ]] && [[ -d "$ROOTFS_DIR/bin" ]]
+}
+
+cleanup_local_image() {
+    $SMOLVM machine stop --name "$PERSIST_VM" 2>/dev/null || true
+    $SMOLVM machine delete --name "$PERSIST_VM" -f 2>/dev/null || true
+    [[ -n "$FIXTURE_DIR" ]] && rm -rf "$FIXTURE_DIR"
+}
+PERSIST_VM="local-image-persist-$$"
+trap cleanup_local_image EXIT
+
+echo ""
+echo "=========================================="
+echo "  Local / Offline Image Tests"
+echo "=========================================="
+echo ""
+
+if ! command -v docker >/dev/null 2>&1; then
+    log_skip "docker not available — local-image fixtures cannot be built"
+    print_summary "Local Image Tests"
+    exit 0
+fi
+
+if ! build_fixtures; then
+    log_skip "could not build docker fixtures (is the docker daemon running?)"
+    print_summary "Local Image Tests"
+    exit 0
+fi
+
+# Ephemeral run from a docker-save archive file. No --net: proves offline.
+test_ephemeral_from_archive_file() {
+    local output
+    output=$(run_with_timeout 90 $SMOLVM machine run --image "$ARCHIVE" \
+        -- sh -c 'cat /etc/os-release | head -1' 2>&1)
+    [[ $? -eq 124 ]] && { echo "TIMEOUT booting from archive file"; return 1; }
+    echo "$output" | grep -q "Alpine" || {
+        echo "FAIL: expected Alpine rootfs from archive, got: $output"
+        return 1
+    }
+}
+
+# Same archive, streamed on stdin via --image -.
+test_ephemeral_from_stdin() {
+    local output
+    output=$(run_with_timeout 90 bash -c \
+        "cat '$ARCHIVE' | '$SMOLVM' machine run --image - -- sh -c 'cat /etc/alpine-release'" 2>&1)
+    [[ $? -eq 124 ]] && { echo "TIMEOUT booting from stdin archive"; return 1; }
+    # alpine-release is a bare version string like 3.24.0
+    echo "$output" | grep -qE '^[0-9]+\.[0-9]+' || {
+        echo "FAIL: expected an alpine-release version from stdin archive, got: $output"
+        return 1
+    }
+}
+
+# Unpacked rootfs directory (#398). The directory IS the rootfs (single lowerdir).
+test_ephemeral_from_rootfs_dir() {
+    local output
+    output=$(run_with_timeout 90 $SMOLVM machine run --image "$ROOTFS_DIR" \
+        -- sh -c 'cat /etc/os-release | head -1' 2>&1)
+    [[ $? -eq 124 ]] && { echo "TIMEOUT booting from rootfs dir"; return 1; }
+    echo "$output" | grep -q "Alpine" || {
+        echo "FAIL: expected Alpine rootfs from directory, got: $output"
+        return 1
+    }
+}
+
+# `--image -` and -i/-t both consume stdin: reject before any VM boots.
+test_stdin_guard_rejects_interactive() {
+    local output exit_code=0
+    output=$(echo "" | $SMOLVM machine run --image - -it 2>&1) || exit_code=$?
+    [[ $exit_code -ne 0 ]] || {
+        echo "FAIL: --image - with -it should have been rejected"
+        return 1
+    }
+    echo "$output" | grep -q "cannot be" || {
+        echo "FAIL: expected a stdin-conflict error, got: $output"
+        return 1
+    }
+    # The rejection must happen before launch — no VM should have started.
+    echo "$output" | grep -q "Starting ephemeral machine" && {
+        echo "FAIL: VM started before the guard fired"
+        return 1
+    }
+    return 0
+}
+
+# Persistent lifecycle from an archive: create, start, exec, stop, restart.
+# Restart re-derives the local source and reopens the same on-disk rootfs.
+test_persistent_create_start_restart() {
+    $SMOLVM machine delete --name "$PERSIST_VM" -f 2>/dev/null || true
+
+    $SMOLVM machine create --name "$PERSIST_VM" --image "$ARCHIVE" 2>&1 || {
+        echo "FAIL: create from archive failed"; return 1
+    }
+
+    run_with_timeout 90 $SMOLVM machine start --name "$PERSIST_VM" 2>&1 || {
+        echo "FAIL: first start failed"; return 1
+    }
+
+    local first
+    first=$(run_with_timeout 30 $SMOLVM machine exec --name "$PERSIST_VM" \
+        -- cat /etc/os-release 2>&1)
+    echo "$first" | grep -q "Alpine" || {
+        echo "FAIL: not Alpine after first start: $first"; return 1
+    }
+
+    # Write a marker, then stop + start: a persistent local image keeps its disk.
+    run_with_timeout 30 $SMOLVM machine exec --name "$PERSIST_VM" \
+        -- sh -c 'echo persisted > /root/marker' 2>&1 || {
+        echo "FAIL: could not write marker"; return 1
+    }
+
+    $SMOLVM machine stop --name "$PERSIST_VM" 2>&1 || { echo "FAIL: stop failed"; return 1; }
+    run_with_timeout 90 $SMOLVM machine start --name "$PERSIST_VM" 2>&1 || {
+        echo "FAIL: restart failed (overlay/disk did not reopen)"; return 1
+    }
+
+    local marker
+    marker=$(run_with_timeout 30 $SMOLVM machine exec --name "$PERSIST_VM" \
+        -- cat /root/marker 2>&1)
+    echo "$marker" | grep -q "persisted" || {
+        echo "FAIL: marker not persisted across restart: $marker"; return 1
+    }
+
+    $SMOLVM machine stop --name "$PERSIST_VM" 2>/dev/null || true
+    $SMOLVM machine delete --name "$PERSIST_VM" -f 2>/dev/null || true
+}
+
+run_test "Ephemeral: boot from docker-save archive file (offline)" test_ephemeral_from_archive_file || true
+run_test "Ephemeral: boot from archive on stdin (--image -)" test_ephemeral_from_stdin || true
+run_test "Ephemeral: boot from unpacked rootfs dir (#398)" test_ephemeral_from_rootfs_dir || true
+run_test "Guard: --image - with -it rejected before boot" test_stdin_guard_rejects_interactive || true
+run_test "Persistent: create/start/restart from archive" test_persistent_create_start_restart || true
+
+print_summary "Local Image Tests"


### PR DESCRIPTION
Classify `--image` into registry, archive (file or `-` stdin), or unpacked rootfs directory. Archives stage to a content-addressed cache and flatten in-guest via `crane export`; a rootfs directory mounts as a single overlay lowerdir. smolvm stays a microVM runtime — all image/layer work is delegated to container tooling — and `--image -` is rejected with `-i`/`-t` since both consume stdin.

Tested offline (no `--net`) across all source types plus persistent create/start/restart; adds `tests/test_machine_local_image.sh` (5/5).