### PR TITLE
fix(serve): bound concurrent boots and reap VM children selectively

### DIFF
--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -1458,6 +1458,13 @@ impl AgentManager {
             .map_err(|e| Error::agent("spawn boot subprocess", e.to_string()))?;
 
         let child_pid = child.id() as i32;
+        // Register the detached VM PID for the serve supervisor's selective
+        // reaper. The boot subprocess owns its process group and is never
+        // `wait()`ed, so it would zombie on exit; the supervisor tick reaps it.
+        // (In non-serve callers without a supervisor this is a harmless no-op —
+        // the sweep is only driven from serve.) The `child` handle drops without
+        // waiting (Rust `Child::drop` is a no-op), leaving the PID for the sweep.
+        crate::process::register_vm_child(child_pid);
         tracing::info!(
             pid = child_pid,
             spawn_ms = spawn_start.elapsed().as_millis(),

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -1365,7 +1365,16 @@ impl AgentManager {
         let t_launch = Instant::now();
 
         let resources_for_config = resources.clone();
-        self.prepare_for_launch(&mounts, &ports, resources)?;
+        // Bound concurrent disk-prep across ALL boot paths (this is the chokepoint
+        // they share): unbounded parallel template copies thrash the host disk so
+        // each balloons (3.8s → 50s under ~13 concurrent boots) and the start
+        // times out. The permit is held only across `prepare_for_launch` (the disk
+        // copy), then released before the VMM spawn. Process-wide; tune with
+        // SMOLVM_BOOT_CONCURRENCY.
+        {
+            let _boot_permit = crate::process::acquire_boot_permit();
+            self.prepare_for_launch(&mounts, &ports, resources)?;
+        }
         tracing::info!(
             elapsed_ms = t_launch.elapsed().as_millis(),
             "boot: disks ready"

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -635,6 +635,20 @@ pub async fn start_machine(
     let ports = record.port_mappings();
     let resources = record.vm_resources();
 
+    // Bound concurrent boots on this node: each boot's disk prep contends for the
+    // host disk, so unbounded concurrency thrashes it (a single boot's ~3.8s disk
+    // copy balloons past the request timeout under ~13 simultaneous boots). Hold
+    // this permit only across disk-prep + VMM spawn below; it is released before
+    // the workload-container launch so throughput doesn't collapse to serial.
+    // Acquired AFTER the running/zombie short-circuits so a no-op start never
+    // consumes a permit, and after the lifecycle lock so a `stop` (which takes no
+    // permit) of this machine is never blocked behind a boot queue.
+    let boot_permit = state
+        .boot_semaphore()
+        .acquire_owned()
+        .await
+        .map_err(|_| ApiError::internal("boot semaphore closed"))?;
+
     // Start agent VM in blocking task.
     // Uses subprocess launch to avoid macOS fork-in-multithreaded-process issue.
     let name_clone = name.clone();
@@ -661,6 +675,10 @@ pub async fn start_machine(
     .await
     .map_err(|e| ApiError::internal(format!("task error: {}", e)))?
     .map_err(ApiError::internal)?;
+
+    // Disk prep + VMM spawn are done; release the boot permit so the next queued
+    // boot proceeds while this handler finishes the (non-disk) workload launch.
+    drop(boot_permit);
 
     // Register in ApiState so exec/run/container endpoints can find it
     state.insert_machine(&name, machine_entry_from_record(&record, manager));

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -635,19 +635,10 @@ pub async fn start_machine(
     let ports = record.port_mappings();
     let resources = record.vm_resources();
 
-    // Bound concurrent boots on this node: each boot's disk prep contends for the
-    // host disk, so unbounded concurrency thrashes it (a single boot's ~3.8s disk
-    // copy balloons past the request timeout under ~13 simultaneous boots). Hold
-    // this permit only across disk-prep + VMM spawn below; it is released before
-    // the workload-container launch so throughput doesn't collapse to serial.
-    // Acquired AFTER the running/zombie short-circuits so a no-op start never
-    // consumes a permit, and after the lifecycle lock so a `stop` (which takes no
-    // permit) of this machine is never blocked behind a boot queue.
-    let boot_permit = state
-        .boot_semaphore()
-        .acquire_owned()
-        .await
-        .map_err(|_| ApiError::internal("boot semaphore closed"))?;
+    // Note: concurrent-boot bounding lives at the chokepoint all boot paths share
+    // (`AgentManager::start_via_subprocess` → a process-wide sync gate), not here,
+    // so the supervisor + reconnect boot paths are bounded too. See
+    // `smolvm::process::acquire_boot_permit`.
 
     // Start agent VM in blocking task.
     // Uses subprocess launch to avoid macOS fork-in-multithreaded-process issue.
@@ -675,10 +666,6 @@ pub async fn start_machine(
     .await
     .map_err(|e| ApiError::internal(format!("task error: {}", e)))?
     .map_err(ApiError::internal)?;
-
-    // Disk prep + VMM spawn are done; release the boot permit so the next queued
-    // boot proceeds while this handler finishes the (non-disk) workload launch.
-    drop(boot_permit);
 
     // Register in ApiState so exec/run/container endpoints can find it
     state.insert_machine(&name, machine_entry_from_record(&record, manager));

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -54,6 +54,29 @@ pub struct ApiState {
     /// Previous CPU samples per VM PID, used to compute the fractional-CPU
     /// rate as a delta over wall time. Pruned on each sample to drop dead PIDs.
     cpu_samples: parking_lot::Mutex<HashMap<i32, CpuSample>>,
+    /// Bounds concurrent VM boots on this node. Each boot full-copies (or, with
+    /// CoW overlays, prepares) its disks; unbounded concurrency thrashes the host
+    /// disk so each copy balloons (3.8s → 50s under ~13 concurrent boots) and the
+    /// start request times out. A small bound serializes enough that every boot
+    /// takes the fast path. Acquired in `start_machine` around disk-prep + launch
+    /// only (NOT held across the workload container start). Override via
+    /// `SMOLVM_BOOT_CONCURRENCY`. Scope: this API server only (the per-machine
+    /// `lifecycle_locks` above bound a single name; this bounds across names).
+    boot_semaphore: Arc<tokio::sync::Semaphore>,
+}
+
+/// Default max concurrent VM boots per node (overridable via
+/// `SMOLVM_BOOT_CONCURRENCY`). Mirrors the smolfleet op-queue's 4-worker throttle.
+const DEFAULT_BOOT_CONCURRENCY: usize = 4;
+
+/// Resolve the boot-concurrency bound from `SMOLVM_BOOT_CONCURRENCY`, clamped to
+/// at least 1, falling back to [`DEFAULT_BOOT_CONCURRENCY`].
+fn boot_concurrency() -> usize {
+    std::env::var("SMOLVM_BOOT_CONCURRENCY")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|&n| n >= 1)
+        .unwrap_or(DEFAULT_BOOT_CONCURRENCY)
 }
 
 /// Internal machine entry with manager and configuration.
@@ -191,6 +214,7 @@ impl ApiState {
             lifecycle_locks: RwLock::new(HashMap::new()),
             db,
             cpu_samples: parking_lot::Mutex::new(HashMap::new()),
+            boot_semaphore: Arc::new(tokio::sync::Semaphore::new(boot_concurrency())),
         })
     }
 
@@ -204,7 +228,15 @@ impl ApiState {
             lifecycle_locks: RwLock::new(HashMap::new()),
             db,
             cpu_samples: parking_lot::Mutex::new(HashMap::new()),
+            boot_semaphore: Arc::new(tokio::sync::Semaphore::new(boot_concurrency())),
         }
+    }
+
+    /// Permit pool bounding concurrent VM boots on this node. Acquire an owned
+    /// permit (`state.boot_semaphore().acquire_owned()`) around disk-prep + launch
+    /// in `start_machine`; hold it only until the VMM is spawned.
+    pub fn boot_semaphore(&self) -> Arc<tokio::sync::Semaphore> {
+        self.boot_semaphore.clone()
     }
 
     /// Load existing machines from persistent database.

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -54,29 +54,6 @@ pub struct ApiState {
     /// Previous CPU samples per VM PID, used to compute the fractional-CPU
     /// rate as a delta over wall time. Pruned on each sample to drop dead PIDs.
     cpu_samples: parking_lot::Mutex<HashMap<i32, CpuSample>>,
-    /// Bounds concurrent VM boots on this node. Each boot full-copies (or, with
-    /// CoW overlays, prepares) its disks; unbounded concurrency thrashes the host
-    /// disk so each copy balloons (3.8s → 50s under ~13 concurrent boots) and the
-    /// start request times out. A small bound serializes enough that every boot
-    /// takes the fast path. Acquired in `start_machine` around disk-prep + launch
-    /// only (NOT held across the workload container start). Override via
-    /// `SMOLVM_BOOT_CONCURRENCY`. Scope: this API server only (the per-machine
-    /// `lifecycle_locks` above bound a single name; this bounds across names).
-    boot_semaphore: Arc<tokio::sync::Semaphore>,
-}
-
-/// Default max concurrent VM boots per node (overridable via
-/// `SMOLVM_BOOT_CONCURRENCY`). Mirrors the smolfleet op-queue's 4-worker throttle.
-const DEFAULT_BOOT_CONCURRENCY: usize = 4;
-
-/// Resolve the boot-concurrency bound from `SMOLVM_BOOT_CONCURRENCY`, clamped to
-/// at least 1, falling back to [`DEFAULT_BOOT_CONCURRENCY`].
-fn boot_concurrency() -> usize {
-    std::env::var("SMOLVM_BOOT_CONCURRENCY")
-        .ok()
-        .and_then(|s| s.parse::<usize>().ok())
-        .filter(|&n| n >= 1)
-        .unwrap_or(DEFAULT_BOOT_CONCURRENCY)
 }
 
 /// Internal machine entry with manager and configuration.
@@ -214,7 +191,6 @@ impl ApiState {
             lifecycle_locks: RwLock::new(HashMap::new()),
             db,
             cpu_samples: parking_lot::Mutex::new(HashMap::new()),
-            boot_semaphore: Arc::new(tokio::sync::Semaphore::new(boot_concurrency())),
         })
     }
 
@@ -228,15 +204,7 @@ impl ApiState {
             lifecycle_locks: RwLock::new(HashMap::new()),
             db,
             cpu_samples: parking_lot::Mutex::new(HashMap::new()),
-            boot_semaphore: Arc::new(tokio::sync::Semaphore::new(boot_concurrency())),
         }
-    }
-
-    /// Permit pool bounding concurrent VM boots on this node. Acquire an owned
-    /// permit (`state.boot_semaphore().acquire_owned()`) around disk-prep + launch
-    /// in `start_machine`; hold it only until the VMM is spawned.
-    pub fn boot_semaphore(&self) -> Arc<tokio::sync::Semaphore> {
-        self.boot_semaphore.clone()
     }
 
     /// Load existing machines from persistent database.

--- a/src/api/supervisor.rs
+++ b/src/api/supervisor.rs
@@ -41,6 +41,10 @@ impl Supervisor {
         loop {
             tokio::select! {
                 _ = ticker.tick() => {
+                    // Reap exited VM boot subprocesses (selective, per registered
+                    // PID) BEFORE the health check, so a just-crashed VM's zombie
+                    // is gone and `is_alive` reports it crashed this same tick.
+                    crate::process::reap_vm_children();
                     self.check_all_machines().await;
                 }
                 _ = self.shutdown_rx.changed() => {

--- a/src/api/supervisor.rs
+++ b/src/api/supervisor.rs
@@ -152,6 +152,17 @@ impl Supervisor {
         let lifecycle = self.state.lifecycle_lock(name);
         let _guard = lifecycle.lock().await;
 
+        // Re-check liveness now that we hold the lock. We may have queued this
+        // restart while the machine was mid-boot (an API start or an earlier
+        // restart held the lock); by the time we acquire it the boot may have
+        // completed, so re-launching would kill+reboot a healthy machine and —
+        // under concurrent boots — double the disk-prep load. If it's alive
+        // again, there's nothing to restart.
+        if self.state.is_machine_alive(name) {
+            tracing::debug!(machine = %name, "machine came back alive before restart; skipping");
+            return Ok(());
+        }
+
         let entry = match self.state.get_machine(name) {
             Ok(entry) => entry,
             Err(_) => {

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -173,8 +173,12 @@ impl ServeStartCmd {
             }
         }
 
-        // Install SIGCHLD handler to reap zombie VM child processes.
-        smolvm::process::install_sigchld_handler();
+        // VM boot subprocesses are detached and would zombie on exit; they are
+        // reaped SELECTIVELY (per registered PID) by the supervisor tick via
+        // smolvm::process::reap_vm_children(). We deliberately do NOT install the
+        // global waitpid(-1) SIGCHLD handler here: serve's concurrent boots run
+        // busctl/mkfs `.output()` subprocesses that a global reaper would steal,
+        // causing ECHILD ("No child processes") and failed scope adoption.
 
         // Install Prometheus metrics recorder and mark start time
         if let Some(handle) = smolvm::api::install_metrics_recorder() {

--- a/src/process.rs
+++ b/src/process.rs
@@ -5,6 +5,7 @@
 
 use std::os::fd::IntoRawFd;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use crate::error::{Error, Result};
@@ -577,10 +578,64 @@ pub fn drop_privileges(_uid: u32, _gid: u32) -> std::result::Result<(), String> 
     Ok(())
 }
 
-/// Install a SIGCHLD handler to automatically reap zombie child processes.
+/// PIDs of detached VM boot subprocesses to reap. Registered by
+/// [`register_vm_child`] right after spawn (the boot subprocess is intentionally
+/// detached — own process group, never `wait()`ed — so it becomes a zombie on
+/// exit). Swept by [`reap_vm_children`] from the supervisor tick.
 ///
-/// This function installs a signal handler that calls waitpid(-1, WNOHANG) to
-/// reap any terminated child processes, preventing zombie accumulation.
+/// This is the SELECTIVE reaper used by `serve`, replacing a global
+/// `waitpid(-1)` SIGCHLD handler. An unscoped `waitpid(-1)` steals the exit
+/// status from ANY exited child — including the `busctl` / `mkfs` / `resize2fs`
+/// subprocesses that `.output()`/`.wait()` callers (e.g. systemd-scope adoption)
+/// are actively waiting on — producing `ECHILD` ("No child processes") races
+/// under concurrent VM boots. Reaping only registered VM PIDs leaves those
+/// transient subprocesses to their own waits. Mirrors the guest agent's
+/// `BG_CHILDREN` pattern (`crates/smolvm-agent/src/main.rs`).
+static VM_CHILDREN: OnceLock<Mutex<Vec<i32>>> = OnceLock::new();
+
+fn vm_children() -> &'static Mutex<Vec<i32>> {
+    VM_CHILDREN.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Track a detached VM boot subprocess PID so a later [`reap_vm_children`] sweep
+/// reaps it. The Rust `Child` handle's `Drop` does not `wait()`, so the caller
+/// can let it drop after recording the PID.
+pub fn register_vm_child(pid: i32) {
+    vm_children().lock().unwrap().push(pid);
+}
+
+/// Reap any exited registered VM children (non-blocking, per-PID). Called from
+/// the serve supervisor tick. Scoped to registered PIDs so it never steals an
+/// exit status from a sibling `.output()`/`.wait()` (the `ECHILD` fix).
+#[cfg(target_os = "linux")]
+pub fn reap_vm_children() {
+    let mut guard = vm_children().lock().unwrap();
+    guard.retain(|&pid| {
+        let ret = unsafe { libc::waitpid(pid, std::ptr::null_mut(), libc::WNOHANG) };
+        match ret {
+            // >0 = reaped; drop from tracking.
+            r if r > 0 => false,
+            // 0 = still running; keep for the next sweep.
+            0 => true,
+            // <0 = error (typically ECHILD — already gone). Drop either way.
+            _ => false,
+        }
+    });
+}
+
+/// No-op on non-Linux: VM scope adoption + the serve supervisor reaper are
+/// Linux-only; nothing registers VM children here.
+#[cfg(not(target_os = "linux"))]
+pub fn reap_vm_children() {}
+
+/// Install a GLOBAL SIGCHLD handler that reaps every terminated child via
+/// `waitpid(-1, WNOHANG)`. Used only by the `pack_run` fork-pool paths (single
+/// process, no concurrent `.output()` subprocesses racing it).
+///
+/// **Do NOT use this in `serve`** — its concurrent VM boots run `busctl`/`mkfs`
+/// `.output()` calls that this handler would reap out from under, causing
+/// `ECHILD`. `serve` uses the selective [`register_vm_child`]/[`reap_vm_children`]
+/// pair instead.
 ///
 /// The handler is only installed once; subsequent calls are no-ops.
 ///
@@ -1685,6 +1740,38 @@ mod tests {
             unsafe { libc::getuid() },
             1,
             "drop must not have taken effect"
+        );
+    }
+
+    /// The selective reaper drains registered VM PIDs once they exit, and a
+    /// non-child PID (would-be ECHILD) is dropped without affecting others.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn reap_vm_children_is_scoped_and_drains() {
+        // A real short-lived child: register its PID and forget the handle so the
+        // reaper (not Child::drop) reaps it.
+        let child = std::process::Command::new("true")
+            .spawn()
+            .expect("spawn true");
+        let real_pid = child.id() as i32;
+        std::mem::forget(child);
+        register_vm_child(real_pid);
+        // A PID we never parented → waitpid returns ECHILD → must be dropped.
+        register_vm_child(i32::MAX);
+
+        // Sweep until the registry drains (the real child exits ~immediately).
+        let mut drained = false;
+        for _ in 0..50 {
+            reap_vm_children();
+            if vm_children().lock().unwrap().is_empty() {
+                drained = true;
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        assert!(
+            drained,
+            "registry should drain: real child reaped, bogus PID dropped on ECHILD"
         );
     }
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -5,7 +5,7 @@
 
 use std::os::fd::IntoRawFd;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Condvar, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use crate::error::{Error, Result};
@@ -576,6 +576,66 @@ pub fn drop_privileges(uid: u32, gid: u32) -> std::result::Result<(), String> {
 #[cfg(not(target_os = "linux"))]
 pub fn drop_privileges(_uid: u32, _gid: u32) -> std::result::Result<(), String> {
     Ok(())
+}
+
+/// Process-wide gate bounding concurrent VM disk-prep / boot. Every boot path —
+/// the API `start_machine`, the supervisor's restart/reconnect, and startup
+/// reconnect — funnels through `AgentManager::start_via_subprocess`, which
+/// acquires a [`BootPermit`] around `prepare_for_launch` (the per-boot disk
+/// copy). Unbounded concurrency thrashes the host disk so each copy balloons
+/// (3.8s → 50s under ~13 simultaneous boots) and the start request times out;
+/// bounding to a few in-flight keeps every copy on the fast path. A synchronous
+/// gate (Mutex + Condvar) because the acquire happens in blocking context (inside
+/// `spawn_blocking`), where an async `tokio::sync::Semaphore` does not fit.
+struct BootGate {
+    /// Available permits.
+    permits: Mutex<usize>,
+    cv: Condvar,
+}
+
+static BOOT_GATE: OnceLock<BootGate> = OnceLock::new();
+
+/// Max concurrent VM boots per node (overridable via `SMOLVM_BOOT_CONCURRENCY`,
+/// clamped to ≥1). Mirrors the smolfleet op-queue's 4-worker throttle.
+fn boot_concurrency() -> usize {
+    std::env::var("SMOLVM_BOOT_CONCURRENCY")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|&n| n >= 1)
+        .unwrap_or(4)
+}
+
+fn boot_gate() -> &'static BootGate {
+    BOOT_GATE.get_or_init(|| BootGate {
+        permits: Mutex::new(boot_concurrency()),
+        cv: Condvar::new(),
+    })
+}
+
+/// RAII permit from [`acquire_boot_permit`]; returns the permit to the gate on
+/// drop.
+pub struct BootPermit {
+    _private: (),
+}
+
+impl Drop for BootPermit {
+    fn drop(&mut self) {
+        let gate = boot_gate();
+        *gate.permits.lock().unwrap() += 1;
+        gate.cv.notify_one();
+    }
+}
+
+/// Acquire a permit from the process-wide boot gate, blocking until one is free.
+/// Hold it across the contended disk-prep, then let it drop. See [`BootGate`].
+pub fn acquire_boot_permit() -> BootPermit {
+    let gate = boot_gate();
+    let mut permits = gate.permits.lock().unwrap();
+    while *permits == 0 {
+        permits = gate.cv.wait(permits).unwrap();
+    }
+    *permits -= 1;
+    BootPermit { _private: () }
 }
 
 /// PIDs of detached VM boot subprocesses to reap. Registered by
@@ -1741,6 +1801,25 @@ mod tests {
             1,
             "drop must not have taken effect"
         );
+    }
+
+    /// The boot gate hands out permits, returns them on drop, and lets multiple
+    /// permits (up to the bound, default ≥4) coexist without deadlocking.
+    #[test]
+    fn boot_gate_acquire_release_roundtrip() {
+        // Roundtrip: acquire then drop then re-acquire must not deadlock.
+        let p = acquire_boot_permit();
+        drop(p);
+        let _p2 = acquire_boot_permit();
+        // A second concurrent permit coexists (default bound is 4).
+        let _p3 = acquire_boot_permit();
+        // Returning a permit from another thread wakes a waiter — exercise the
+        // notify path by dropping on a thread while the main thread holds permits.
+        let h = std::thread::spawn(|| {
+            let p = acquire_boot_permit();
+            drop(p);
+        });
+        h.join().unwrap();
     }
 
     /// The selective reaper drains registered VM PIDs once they exit, and a


### PR DESCRIPTION
Concurrent VM boots could fail under load for two reasons: a global SIGCHLD reaper stole busctl's exit status (ECHILD, so systemd-scope adoption failed), and unbounded disk-copy concurrency thrashed the host disk until start requests timed out. Now reap only registered VM PIDs from the supervisor tick, and bound concurrent boots with a semaphore (SMOLVM_BOOT_CONCURRENCY, default 4).