### PR TITLE
feat(serve): boot fresh VMs from a qcow2 overlay instead of copying templates

### DIFF
--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -502,19 +502,34 @@ if [[ -z "$MKFS_BIN" ]]; then
     echo "Warning: mkfs.ext4 not found, skipping storage template creation"
     echo "         Users will need e2fsprogs installed"
 else
+    # Set a file's virtual size (sparse), portably (macOS lacks GNU truncate).
+    extend_sparse() { # $1=path $2=bytes
+        if command -v truncate >/dev/null 2>&1; then
+            truncate -s "$2" "$1"
+        else
+            perl -e 'truncate($ARGV[0], $ARGV[1]) or die "truncate: $!"' "$1" "$2"
+        fi
+    }
+
     # Create sparse file
     dd if=/dev/zero of="$TEMPLATE_PATH" bs=1 count=0 seek=$TEMPLATE_SIZE 2>/dev/null
 
     # Format with ext4
     "$MKFS_BIN" -F -q -m 0 -L smolvm "$TEMPLATE_PATH"
 
-    echo "Storage template created: $(du -h "$TEMPLATE_PATH" | cut -f1) (sparse)"
+    # Size to the default storage virtual size (DEFAULT_STORAGE_SIZE_GIB=20) so a
+    # fresh VM boots from an instant qcow2 overlay (the guest grows the 512 MiB
+    # ext4 with resize2fs); the runtime treats the template as immutable. Sparse.
+    extend_sparse "$TEMPLATE_PATH" $((20 * 1024 * 1024 * 1024))
+    echo "Storage template created: $(du -h "$TEMPLATE_PATH" | cut -f1) physical (20 GiB virtual)"
 
     # Create overlay template (same format, different label)
     OVERLAY_TEMPLATE_PATH="$DIST_DIR/overlay-template.ext4"
     dd if=/dev/zero of="$OVERLAY_TEMPLATE_PATH" bs=1 count=0 seek=$TEMPLATE_SIZE 2>/dev/null
     "$MKFS_BIN" -F -q -m 0 -L smolvm-overlay "$OVERLAY_TEMPLATE_PATH"
-    echo "Overlay template created: $(du -h "$OVERLAY_TEMPLATE_PATH" | cut -f1) (sparse)"
+    # Size to the default overlay virtual size (DEFAULT_OVERLAY_SIZE_GIB=10).
+    extend_sparse "$OVERLAY_TEMPLATE_PATH" $((10 * 1024 * 1024 * 1024))
+    echo "Overlay template created: $(du -h "$OVERLAY_TEMPLATE_PATH" | cut -f1) physical (10 GiB virtual)"
 fi
 
 # Copy README
@@ -588,10 +603,16 @@ echo "Generating checksums..."
 echo "Cleaning up existing tarball..."
 rm -f "smolvm-*.tar.gz"
 
-# Create tarball
+# Create tarball. Preserve sparseness so the 20/10 GiB-virtual disk templates
+# (a few hundred KiB physical) don't balloon to full size on extraction. GNU tar
+# needs --sparse; bsdtar (macOS) detects holes automatically.
 echo "Creating tarball..."
 cd dist
-tar -czf "${DIST_NAME}.tar.gz" "${DIST_NAME}"
+if tar --version 2>/dev/null | grep -qi gnu; then
+    tar --sparse -czf "${DIST_NAME}.tar.gz" "${DIST_NAME}"
+else
+    tar -czf "${DIST_NAME}.tar.gz" "${DIST_NAME}"
+fi
 cd ..
 
 # Summary

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -392,6 +392,19 @@ install_smolvm() {
         cp "$extracted_dir/overlay-template.ext4" "$prefix/"
     fi
 
+    # Size the disk templates to their default virtual size at install time, so
+    # the runtime boots fresh VMs from an instant qcow2 copy-on-write overlay
+    # (no per-boot template copy) instead of mutating a shared template lazily.
+    # The ext4 inside stays 512 MiB; the guest grows it with resize2fs at boot.
+    # Sparse, so it costs no real disk. Linux-only (the overlay path is gated to
+    # Linux) and needs `truncate` (GNU coreutils); skipped otherwise, in which
+    # case the runtime safely falls back to the copy path. The sizes mirror
+    # DEFAULT_STORAGE_SIZE_GIB (20) and DEFAULT_OVERLAY_SIZE_GIB (10).
+    if command -v truncate >/dev/null 2>&1; then
+        [[ -f "$prefix/storage-template.ext4" ]] && truncate -s 20G "$prefix/storage-template.ext4"
+        [[ -f "$prefix/overlay-template.ext4" ]] && truncate -s 10G "$prefix/overlay-template.ext4"
+    fi
+
     # Install agent-rootfs to data directory
     local data_dir
     if [[ "$(uname -s)" == "Darwin" ]]; then

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -477,7 +477,10 @@ impl AgentManager {
             DiskFormat::Qcow2 => {
                 StorageDisk::open_existing_with_format(&storage_path, storage_format)?
             }
-            DiskFormat::Raw => StorageDisk::open_or_create_at(&storage_path, sg)?,
+            // Fresh disk: prefer an instant qcow2 CoW overlay over the template
+            // (Linux, default size) instead of a raw copy, to avoid per-boot
+            // host-disk thrash under concurrency. Falls back to raw otherwise.
+            DiskFormat::Raw => StorageDisk::open_or_overlay_at(&storage_path, sg)?,
         };
 
         let (overlay_path, overlay_format) =
@@ -486,7 +489,7 @@ impl AgentManager {
             DiskFormat::Qcow2 => {
                 OverlayDisk::open_existing_with_format(&overlay_path, overlay_format)?
             }
-            DiskFormat::Raw => OverlayDisk::open_or_create_at(&overlay_path, og)?,
+            DiskFormat::Raw => OverlayDisk::open_or_overlay_at(&overlay_path, og)?,
         };
 
         Self::new_named(name, rootfs_path, storage_disk, overlay_disk)

--- a/src/cli/internal_boot.rs
+++ b/src/cli/internal_boot.rs
@@ -182,6 +182,14 @@ pub fn run(config_path: PathBuf) -> smolvm::Result<()> {
         if let Some(libdir) = std::env::var_os("SMOLVM_LIB_DIR") {
             read_exec.push(std::path::PathBuf::from(libdir));
         }
+        // A fresh VM's storage/overlay disk may be a qcow2 copy-on-write overlay
+        // backed by a read-only disk template in ~/.smolvm; the confined VMM must
+        // be able to open that backing file. Grant the template directory
+        // read-only — it is the install dir (same trust level as SMOLVM_LIB_DIR,
+        // which lives under it) and holds no secrets. A no-op for the copy path.
+        if let Some(home) = dirs::home_dir() {
+            read_exec.push(home.join(".smolvm"));
+        }
 
         let mut read_write: Vec<std::path::PathBuf> = [
             "/dev/kvm",

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -72,12 +72,6 @@ pub struct VmDisk<K> {
     _kind: PhantomData<K>,
 }
 
-/// Serializes the one-time sparse resize of a shared disk template (see
-/// [`VmDisk::create_overlay_from_template`]) so concurrent boots don't read a
-/// torn file size while another is mid-truncate.
-#[cfg(target_os = "linux")]
-static TEMPLATE_RESIZE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
 impl<K: DiskType> VmDisk<K> {
     /// Get the default path for the disk.
     pub fn default_path() -> Result<PathBuf> {
@@ -148,56 +142,75 @@ impl<K: DiskType> VmDisk<K> {
     }
 
     /// Open the disk for a fresh (non-clone) VM. On Linux at this disk type's
-    /// DEFAULT size, create an instant qcow2 copy-on-write overlay over the
-    /// read-only template (O(metadata), no byte copy) — so N concurrent boots
-    /// don't thrash the host disk the way N full template copies do. Anything
-    /// else (a custom size, a pre-existing disk, non-Linux, or an overlay-create
-    /// failure) falls back to the raw create + format-time copy.
+    /// DEFAULT size, when the shipped template has already been sized to the
+    /// default virtual size **at install time**, create an instant qcow2
+    /// copy-on-write overlay over the read-only template (O(metadata), no byte
+    /// copy) — so N concurrent boots don't thrash the host disk the way N full
+    /// template copies do. Anything else (a custom size, a pre-existing disk, a
+    /// not-yet-sized legacy template, non-Linux, or an overlay-create failure)
+    /// falls back to the raw create + format-time copy. The template is treated
+    /// as immutable here: sizing it is an install-time concern (see
+    /// `scripts/install.sh`), never a per-boot mutation of a shared file.
     pub fn open_or_overlay_at(raw_path: &Path, size_gb: u64) -> Result<Self> {
         #[cfg(target_os = "linux")]
         if !raw_path.exists() && size_gb == K::DEFAULT_SIZE_GIB {
-            let overlay_path = raw_path.with_extension(DiskFormat::Qcow2.extension());
-            match Self::create_overlay_from_template(&overlay_path, size_gb * BYTES_PER_GIB) {
-                Ok(disk) => return Ok(disk),
-                Err(error) => {
-                    tracing::warn!(
-                        disk_type = K::NAME, %error,
-                        "qcow2 overlay create failed; falling back to raw template copy"
-                    );
+            let size_bytes = size_gb * BYTES_PER_GIB;
+            // Only overlay when the template already presents the full virtual
+            // size. A legacy/too-small template would make the overlay inherit an
+            // undersized device, so degrade to the copy path rather than mutate
+            // the shared template.
+            if Self::template_at_least(size_bytes) {
+                let overlay_path = raw_path.with_extension(DiskFormat::Qcow2.extension());
+                match Self::create_overlay_from_template(&overlay_path, size_bytes) {
+                    Ok(disk) => return Ok(disk),
+                    Err(error) => {
+                        tracing::warn!(
+                            disk_type = K::NAME, %error,
+                            "qcow2 overlay create failed; falling back to raw template copy"
+                        );
+                    }
                 }
             }
         }
         Self::open_or_create_at(raw_path, size_gb)
     }
 
-    /// Create a `.qcow2` CoW overlay backed by the read-only template instead of
-    /// copying it. The overlay inherits the backing file's VIRTUAL size, and the
-    /// shipped template is small (512 MiB), so we first ensure the template
-    /// presents `size_bytes` (a sparse truncate-extend: O(metadata),
-    /// data-preserving, idempotent) — the guest then grows the inherited 512 MiB
-    /// ext4 with resize2fs at boot, exactly as on the copy path. Marks the disk
-    /// formatted so it is never reformatted (the overlay shares the template's
-    /// filesystem). Linux only.
+    /// True if a disk template exists and already presents at least `size_bytes`
+    /// of virtual size (sized at install). Used to decide whether the fast qcow2
+    /// overlay path is safe without ever mutating the shared template.
     #[cfg(target_os = "linux")]
-    pub fn create_overlay_from_template(overlay_path: &Path, size_bytes: u64) -> Result<Self> {
+    fn template_at_least(size_bytes: u64) -> bool {
+        Self::template_path()
+            .and_then(|p| std::fs::metadata(p).ok())
+            .map(|m| m.len() >= size_bytes)
+            .unwrap_or(false)
+    }
+
+    /// Create a `.qcow2` CoW overlay backed by the read-only template instead of
+    /// copying it. The overlay inherits the backing file's VIRTUAL size; the
+    /// template is sized to the default at install time (see
+    /// `scripts/install.sh`) while its ext4 stays 512 MiB, so the guest grows the
+    /// inherited filesystem with resize2fs at boot, exactly as on the copy path.
+    /// The template is opened read-only and never mutated — if it is not yet
+    /// sized to `size_bytes`, this refuses (the caller falls back to the copy
+    /// path) rather than truncate a shared file under concurrent boots. Marks the
+    /// disk formatted so it is never reformatted (the overlay shares the
+    /// template's filesystem). Linux only; called only via [`Self::open_or_overlay_at`].
+    #[cfg(target_os = "linux")]
+    fn create_overlay_from_template(overlay_path: &Path, size_bytes: u64) -> Result<Self> {
         let template = Self::template_path()
             .ok_or_else(|| Error::storage("overlay from template", "no disk template found"))?;
 
-        // Make the shared template present the target virtual size so the overlay
-        // inherits it. Serialized so concurrent boots don't read a torn size
-        // mid-truncate; idempotent (truncate to the same/smaller is a no-op).
-        {
-            let _g = TEMPLATE_RESIZE_LOCK.lock().unwrap();
-            let current = std::fs::metadata(&template)
-                .map_err(|e| Error::storage("read template size", e.to_string()))?
-                .len();
-            if current < size_bytes {
-                std::fs::OpenOptions::new()
-                    .write(true)
-                    .open(&template)
-                    .and_then(|f| f.set_len(size_bytes))
-                    .map_err(|e| Error::storage("resize template", e.to_string()))?;
-            }
+        // The template must already present the full virtual size (install-time
+        // sizing). Refuse rather than mutate a shared file under concurrent boots.
+        let template_len = std::fs::metadata(&template)
+            .map_err(|e| Error::storage("read template size", e.to_string()))?
+            .len();
+        if template_len < size_bytes {
+            return Err(Error::storage(
+                "overlay from template",
+                format!("template virtual size {template_len} < required {size_bytes}; not sized at install"),
+            ));
         }
 
         if let Some(parent) = overlay_path.parent() {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -72,6 +72,12 @@ pub struct VmDisk<K> {
     _kind: PhantomData<K>,
 }
 
+/// Serializes the one-time sparse resize of a shared disk template (see
+/// [`VmDisk::create_overlay_from_template`]) so concurrent boots don't read a
+/// torn file size while another is mid-truncate.
+#[cfg(target_os = "linux")]
+static TEMPLATE_RESIZE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 impl<K: DiskType> VmDisk<K> {
     /// Get the default path for the disk.
     pub fn default_path() -> Result<PathBuf> {
@@ -139,6 +145,79 @@ impl<K: DiskType> VmDisk<K> {
             format,
             _kind: PhantomData,
         })
+    }
+
+    /// Open the disk for a fresh (non-clone) VM. On Linux at this disk type's
+    /// DEFAULT size, create an instant qcow2 copy-on-write overlay over the
+    /// read-only template (O(metadata), no byte copy) — so N concurrent boots
+    /// don't thrash the host disk the way N full template copies do. Anything
+    /// else (a custom size, a pre-existing disk, non-Linux, or an overlay-create
+    /// failure) falls back to the raw create + format-time copy.
+    pub fn open_or_overlay_at(raw_path: &Path, size_gb: u64) -> Result<Self> {
+        #[cfg(target_os = "linux")]
+        if !raw_path.exists() && size_gb == K::DEFAULT_SIZE_GIB {
+            let overlay_path = raw_path.with_extension(DiskFormat::Qcow2.extension());
+            match Self::create_overlay_from_template(&overlay_path, size_gb * BYTES_PER_GIB) {
+                Ok(disk) => return Ok(disk),
+                Err(error) => {
+                    tracing::warn!(
+                        disk_type = K::NAME, %error,
+                        "qcow2 overlay create failed; falling back to raw template copy"
+                    );
+                }
+            }
+        }
+        Self::open_or_create_at(raw_path, size_gb)
+    }
+
+    /// Create a `.qcow2` CoW overlay backed by the read-only template instead of
+    /// copying it. The overlay inherits the backing file's VIRTUAL size, and the
+    /// shipped template is small (512 MiB), so we first ensure the template
+    /// presents `size_bytes` (a sparse truncate-extend: O(metadata),
+    /// data-preserving, idempotent) — the guest then grows the inherited 512 MiB
+    /// ext4 with resize2fs at boot, exactly as on the copy path. Marks the disk
+    /// formatted so it is never reformatted (the overlay shares the template's
+    /// filesystem). Linux only.
+    #[cfg(target_os = "linux")]
+    pub fn create_overlay_from_template(overlay_path: &Path, size_bytes: u64) -> Result<Self> {
+        let template = Self::template_path()
+            .ok_or_else(|| Error::storage("overlay from template", "no disk template found"))?;
+
+        // Make the shared template present the target virtual size so the overlay
+        // inherits it. Serialized so concurrent boots don't read a torn size
+        // mid-truncate; idempotent (truncate to the same/smaller is a no-op).
+        {
+            let _g = TEMPLATE_RESIZE_LOCK.lock().unwrap();
+            let current = std::fs::metadata(&template)
+                .map_err(|e| Error::storage("read template size", e.to_string()))?
+                .len();
+            if current < size_bytes {
+                std::fs::OpenOptions::new()
+                    .write(true)
+                    .open(&template)
+                    .and_then(|f| f.set_len(size_bytes))
+                    .map_err(|e| Error::storage("resize template", e.to_string()))?;
+            }
+        }
+
+        if let Some(parent) = overlay_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        // The backing path is written verbatim into the overlay header, so it
+        // must be absolute (canonicalized).
+        let base = template
+            .canonicalize()
+            .map_err(|e| Error::storage("canonicalize template", e.to_string()))?;
+        crate::agent::create_disk_overlays(&[(overlay_path.to_path_buf(), base, DiskFormat::Raw)])?;
+
+        let disk = Self {
+            path: overlay_path.to_path_buf(),
+            size_bytes,
+            format: DiskFormat::Qcow2,
+            _kind: PhantomData,
+        };
+        disk.mark_formatted()?;
+        Ok(disk)
     }
 
     /// Pre-format the disk with ext4 on the host.


### PR DESCRIPTION
Structural follow-up to #410. Replaces the per-boot 20+10 GiB ext4 template copy with an instant qcow2 copy-on-write overlay over the shared template (the same mechanism fork-clones already use), eliminating the host-disk thrash that made concurrent boots fail.

The template is treated as immutable: it is sized to its default virtual size once at install (`scripts/install.sh` + `scripts/build-dist.sh`), never truncated per boot. A fresh default-size Linux VM overlays; custom sizes, legacy/unsized templates, and non-Linux fall back to the existing copy path. The guest still grows the inherited 512 MiB ext4 with resize2fs at boot.

Validated under concurrency on a worker: 13/13 bare + 3/3 image boots took the overlay path with zero copy fallbacks and zero errors. Note: workers need re-shipped sized templates for the overlay path to engage in prod (until then they safely use the copy path).