### PR TITLE
feat(api): 409 PORT_IN_USE on host-port bind conflict

### DIFF
--- a/src/api/errors.rs
+++ b/src/api/errors.rs
@@ -15,6 +15,11 @@ pub enum ApiError {
     NotFound(String),
     /// Conflict - resource already exists or invalid state (409).
     Conflict(String),
+    /// A published host port could not be bound because it is already in use
+    /// (409). Distinct from `Conflict` so the control plane can recognize this
+    /// specific, retryable failure (reallocate a different port and retry)
+    /// instead of treating it as a generic 500/409.
+    PortConflict(String),
     /// Bad request - invalid input (400).
     BadRequest(String),
     /// Request timeout (408).
@@ -47,6 +52,7 @@ impl IntoResponse for ApiError {
         let (status, code, message) = match self {
             ApiError::NotFound(msg) => (StatusCode::NOT_FOUND, "NOT_FOUND", msg),
             ApiError::Conflict(msg) => (StatusCode::CONFLICT, "CONFLICT", msg),
+            ApiError::PortConflict(msg) => (StatusCode::CONFLICT, "PORT_IN_USE", msg),
             ApiError::BadRequest(msg) => (StatusCode::BAD_REQUEST, "BAD_REQUEST", msg),
             ApiError::Timeout => (
                 StatusCode::REQUEST_TIMEOUT,

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -544,6 +544,21 @@ pub async fn get_machine(
     Ok(Json(record_to_info(&name, &record)))
 }
 
+/// Classify a VM launch/boot failure. A published host-port bind conflict — the
+/// virtio-net runtime couldn't bind `0.0.0.0:<hostPort>` because something
+/// (typically an orphaned VMM) still holds it — is surfaced as `PortConflict`
+/// (409 `PORT_IN_USE`), which the control plane recognizes and retries on a
+/// freshly-allocated port. Everything else stays a 500. Matching is scoped to
+/// the virtio-net path so an unrelated AddrInUse can't be mistaken for it.
+fn classify_launch_error(e: String) -> ApiError {
+    let lc = e.to_ascii_lowercase();
+    if lc.contains("address already in use") && lc.contains("virtio") {
+        ApiError::PortConflict(e)
+    } else {
+        ApiError::Internal(e)
+    }
+}
+
 /// Start a machine.
 #[utoipa::path(
     post,
@@ -555,6 +570,7 @@ pub async fn get_machine(
     responses(
         (status = 200, description = "Machine started", body = MachineInfo),
         (status = 404, description = "Machine not found", body = ApiErrorResponse),
+        (status = 409, description = "A published host port is already in use (PORT_IN_USE)", body = ApiErrorResponse),
         (status = 500, description = "Failed to start", body = ApiErrorResponse)
     )
 )]
@@ -665,7 +681,7 @@ pub async fn start_machine(
     })
     .await
     .map_err(|e| ApiError::internal(format!("task error: {}", e)))?
-    .map_err(ApiError::internal)?;
+    .map_err(classify_launch_error)?;
 
     // Register in ApiState so exec/run/container endpoints can find it
     state.insert_machine(&name, machine_entry_from_record(&record, manager));
@@ -1311,6 +1327,33 @@ mod tests {
     use super::*;
     use crate::db::SmolvmDb;
     use tempfile::TempDir;
+
+    #[test]
+    fn classify_launch_error_flags_virtio_port_conflict() {
+        // The real virtio-net host-port bind failure → retryable PortConflict.
+        let e = "agent operation failed: configure virtio-net: failed to start virtio network \
+                 runtime: Address already in use (os error 98)"
+            .to_string();
+        assert!(matches!(
+            classify_launch_error(e),
+            ApiError::PortConflict(_)
+        ));
+    }
+
+    #[test]
+    fn classify_launch_error_keeps_others_internal() {
+        // An unrelated AddrInUse (no virtio context) must NOT be treated as a
+        // published-port conflict — reallocating a port wouldn't help.
+        assert!(matches!(
+            classify_launch_error("bind vsock: Address already in use".to_string()),
+            ApiError::Internal(_)
+        ));
+        // A generic boot failure stays a 500.
+        assert!(matches!(
+            classify_launch_error("failed to start machine: kernel panic".to_string()),
+            ApiError::Internal(_)
+        ));
+    }
 
     #[test]
     fn test_record_to_info() {


### PR DESCRIPTION
When a published-port VM fails to boot because its host port is already bound (virtio-net Address-already-in-use), the serve now returns 409 PORT_IN_USE instead of a generic 500, so the control plane can reallocate a different port and retry. Pairs with smolcloud#52.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/413">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->