### PR TITLE
fix(release): ship a target-arch guest init for Linux x86_64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,6 +253,19 @@ jobs:
         env:
           SMOL_REPO_TOKEN: ${{ secrets.SMOL_REPO_TOKEN }}
 
+      # Rebuild the guest init (PID 1) for the target arch. libkrun/init/init is
+      # a committed binary that does not track arch, and this job uses prebuilt
+      # libkrun libs rather than building libkrun — so without this the dist would
+      # ship whatever arch was committed (the x86_64 release once shipped the
+      # aarch64 init, issue #365). Each runner is native to its target, so a plain
+      # static compile produces the correct arch; build-dist.sh asserts it.
+      - name: Build guest init for target arch (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          cc -O2 -static -Wall -o libkrun/init/init \
+            libkrun/init/init.c libkrun/init/dhcp.c
+          file libkrun/init/init
+
       - name: Build distribution tarball
         run: ./scripts/build-dist.sh --skip-agent-build
         env:

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -439,6 +439,26 @@ if [[ "$(uname -s)" == "Linux" ]]; then
         echo "Copying init.krun from $INIT_KRUN..."
         cp "$INIT_KRUN" "$DIST_DIR/init.krun"
         chmod +x "$DIST_DIR/init.krun"
+
+        # init.krun runs as the guest PID 1, so it must match the target arch.
+        # libkrun/init/init is a committed binary that does NOT track the build
+        # host's arch, so a native dist build can silently ship a wrong-arch init
+        # (the x86_64 release once shipped the aarch64 init). Linux dist builds
+        # run natively, so the correct arch is `uname -m`; fail loudly otherwise.
+        host_arch="$(uname -m)"
+        case "$host_arch" in
+            x86_64)  want="x86-64" ;;
+            aarch64|arm64) want="aarch64" ;;
+            *)       want="" ;;
+        esac
+        init_desc="$(file -b "$DIST_DIR/init.krun")"
+        if [[ -n "$want" ]] && [[ "$init_desc" != *"$want"* ]]; then
+            echo "ERROR: init.krun is the wrong architecture for a $host_arch build." >&2
+            echo "       expected '$want', got: $init_desc" >&2
+            echo "       source: $INIT_KRUN — rebuild it for $host_arch (see scripts/build-libkrun-linux.sh)." >&2
+            exit 1
+        fi
+        echo "init.krun arch OK ($init_desc)"
     else
         echo "Warning: init.krun not found - users may need to build libkrun init"
     fi


### PR DESCRIPTION
The Linux x86_64 release tarball shipped an **aarch64** `init.krun` (issue #365) — both arch tarballs had the same hash.

Root cause: the `build-dist` release job uses prebuilt libkrun libraries and never rebuilds libkrun, so it copied the committed `libkrun/init/init` (an aarch64 binary that does not track arch) into every tarball. Building from source worked only because `build-libkrun-linux.sh` recompiles the init for the native arch.

Fix:
- Rebuild the guest init from source for the target arch in the release workflow before packaging (each runner is native to its target, so a static `cc` compile yields the correct arch).
- Assert in `build-dist.sh` that `init.krun` matches the build host arch, so a wrong-arch init fails the build instead of shipping silently.

Verified locally: the assertion rejects the committed aarch64 init on an x86_64 host and accepts a freshly compiled x86_64 init.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/414">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->