### PR TITLE
fix(boot): carve out landlock write for the agent ready marker

### DIFF
--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -1865,7 +1865,15 @@ impl AgentManager {
                 }
             }
 
-            if ready_marker.exists() {
+            // Ready when the marker is present AND non-empty. The guest writes
+            // its uptime (always non-empty) into it. Under SMOLVM_LANDLOCK the
+            // confined VMM pre-creates this file empty so Landlock can grant
+            // write on just this one file (see internal_boot.rs) — so existence
+            // alone would false-positive; require content.
+            if std::fs::metadata(&ready_marker)
+                .map(|m| m.len() > 0)
+                .unwrap_or(false)
+            {
                 let elapsed = start.elapsed();
                 tracing::info!(elapsed_ms = elapsed.as_millis(), "agent ready (marker)");
                 return Ok(());

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -1879,17 +1879,25 @@ impl AgentManager {
                 return Ok(());
             }
 
-            // After long grace, fall back to socket ping for very old agents
-            // that don't write the ready marker at all.
+            // After long grace, fall back to socket ping. This is the intended
+            // path only for pre-marker agents; for a current agent the marker
+            // never appearing is a real fault (e.g. a Landlock rule denying the
+            // marker write — see internal_boot.rs) that silently cost us the
+            // whole probe grace. Logged at WARN so the degradation can't hide.
             if start.elapsed() >= socket_probe_grace && self.vsock_socket.exists() {
                 if let Ok(mut client) =
                     super::AgentClient::connect_with_boot_probe_timeout(&self.vsock_socket)
                 {
                     if client.ping().is_ok() {
                         let elapsed = start.elapsed();
-                        tracing::info!(
+                        let landlock = std::env::var("SMOLVM_LANDLOCK").unwrap_or_default();
+                        tracing::warn!(
                             elapsed_ms = elapsed.as_millis(),
-                            "agent ready (socket fallback)"
+                            landlock = %landlock,
+                            "agent ready via SOCKET FALLBACK — ready marker never appeared; \
+                             boot was delayed by the probe grace. If a current agent, this is a \
+                             fault (under SMOLVM_LANDLOCK=enforce the ready-marker carve-out in \
+                             internal_boot.rs is likely broken)"
                         );
                         return Ok(());
                     }

--- a/src/cli/internal_boot.rs
+++ b/src/cli/internal_boot.rs
@@ -236,6 +236,18 @@ pub fn run(config_path: PathBuf) -> smolvm::Result<()> {
             }
         }
 
+        // The guest agent signals boot-readiness by writing a marker file into
+        // the virtiofs rootfs, which the host polls. The rootfs is granted
+        // read-exec above, so that FUSE write would be denied here. Carve out
+        // write on JUST that one marker file — never the rootfs dir, which
+        // holds the shared agent binary/init/libs a guest→VMM escape must not
+        // be able to tamper with. Landlock needs an existing path to build the
+        // rule, so pre-create it empty; the guest overwrites it with content
+        // and the host treats non-empty as ready (see manager.rs wait loop).
+        let ready_marker = config.rootfs_path.join(smolvm_protocol::AGENT_READY_MARKER);
+        let _ = std::fs::File::create(&ready_marker);
+        read_write.push(ready_marker);
+
         if let Err(e) = smolvm::process::restrict_filesystem(&read_exec, &read_write) {
             eprintln!("[landlock] restriction failed, refusing to boot unconfined: {e}");
             smolvm::process::exit_child(1);


### PR DESCRIPTION
Under `SMOLVM_LANDLOCK=enforce` the read-only rootfs blocked the agent's `.smolvm-ready` marker write so boot silently fell back to the slow socket probe; grant landlock write on just that one marker file, and warn loudly if the fallback is ever taken.