### PR TITLE
fix(prune): --all keeps a machine's in-use image; fix auto-name e2e test

### DIFF
--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -2761,33 +2761,60 @@ impl PruneCmd {
 
             if images.is_empty() {
                 println!("No cached images to remove.");
-                return Ok(());
-            }
-
-            let total_size: u64 = images.iter().map(|i| i.size).sum();
-
-            if self.dry_run {
-                println!(
-                    "Would remove {} images ({})",
-                    images.len(),
-                    format_bytes(total_size)
-                );
-                for image in &images {
+            } else if record.image.is_some() {
+                // An image-backed machine needs its cached image to restart, so
+                // purging it would brick a *stopped* machine ("image not found"
+                // on the next start). Keep the cache and reclaim only
+                // unreferenced layers; to reclaim everything, delete the machine.
+                let total_size: u64 = images.iter().map(|i| i.size).sum();
+                if self.dry_run {
+                    let would_free = client.garbage_collect(true, false)?;
                     println!(
-                        "  - {} ({}, {} layers)",
-                        image.reference,
-                        format_bytes(image.size),
-                        image.layer_count
+                        "Machine '{}' is image-backed: would keep {} cached image(s) ({}) it needs to restart, and free {} of unreferenced layers.",
+                        self.name,
+                        images.len(),
+                        format_bytes(total_size),
+                        format_bytes(would_free)
+                    );
+                } else {
+                    let freed = client.garbage_collect(false, false)?;
+                    println!(
+                        "Kept {} cached image(s) in use by machine '{}'; freed {} of unreferenced layers.",
+                        images.len(),
+                        self.name,
+                        format_bytes(freed)
+                    );
+                    eprintln!(
+                        "(--all keeps images a machine needs to restart; to reclaim everything: smolvm machine delete --name {})",
+                        self.name
                     );
                 }
             } else {
-                println!("Removing all cached images...");
-                let freed = client.garbage_collect(false, true)?;
-                println!(
-                    "Removed {} images, freed {}",
-                    images.len(),
-                    format_bytes(freed)
-                );
+                // Bare VM: nothing depends on the image cache, so purge all.
+                let total_size: u64 = images.iter().map(|i| i.size).sum();
+                if self.dry_run {
+                    println!(
+                        "Would remove {} images ({})",
+                        images.len(),
+                        format_bytes(total_size)
+                    );
+                    for image in &images {
+                        println!(
+                            "  - {} ({}, {} layers)",
+                            image.reference,
+                            format_bytes(image.size),
+                            image.layer_count
+                        );
+                    }
+                } else {
+                    println!("Removing all cached images...");
+                    let freed = client.garbage_collect(false, true)?;
+                    println!(
+                        "Removed {} images, freed {}",
+                        images.len(),
+                        format_bytes(freed)
+                    );
+                }
             }
         } else if self.dry_run {
             println!("Scanning for unreferenced layers...");

--- a/tests/test_resources.sh
+++ b/tests/test_resources.sh
@@ -94,10 +94,11 @@ test_start_nonexistent_name_rejected() {
 }
 
 test_auto_generated_names() {
-    # Auto-generate: create with no name, verify format + appears in list
+    # Auto-generate: create with no --name at all (omitting --name triggers the
+    # vm-XXXXXXXX auto-name; `--name` with no value is a CLI error, not auto-gen).
     local result1 result2
-    result1=$($SMOLVM machine create --name 2>&1) || return 1
-    result2=$($SMOLVM machine create --name 2>&1) || return 1
+    result1=$($SMOLVM machine create 2>&1) || { echo "auto-name create #1 failed: $result1"; return 1; }
+    result2=$($SMOLVM machine create 2>&1) || { echo "auto-name create #2 failed: $result2"; return 1; }
 
     local name1 name2
     name1=$(echo "$result1" | grep "Created machine:" | grep -oE "vm-[a-f0-9]{8}" | head -1)
@@ -119,8 +120,9 @@ test_auto_generated_names() {
         return 1
     }
 
-    # Explicit name still works
-    local explicit="explicit-test-$$"
+    # Explicit name still works. Use a unique suffix so a dirty/concurrent box
+    # (leftover machines) can't collide or false-match.
+    local explicit="explicit-test-$$-$RANDOM"
     $SMOLVM machine create --name "$explicit" 2>&1 || { echo "Explicit name failed"; return 1; }
     list_result=$($SMOLVM machine ls --json 2>&1)
     [[ "$list_result" == *"$explicit"* ]] || { echo "Explicit name not in list"; return 1; }

--- a/tests/test_storage.sh
+++ b/tests/test_storage.sh
@@ -229,55 +229,48 @@ test_prune_all_refuses_on_running_vm() {
     [[ "$status" == *"running"* ]] || { echo "VM stopped after rejected prune --all"; return 1; }
 }
 
-test_prune_all_removes_images() {
-    # Start with a clean machine that has an image cached
+test_prune_all_keeps_in_use_image() {
+    # An image-backed machine needs its cached image to restart, so `prune --all`
+    # must keep it (and reclaim only unreferenced layers) rather than brick a
+    # stopped machine with "image not found" on the next start.
     $SMOLVM machine stop 2>/dev/null || true
     $SMOLVM machine delete --name default -f 2>/dev/null || true
     $SMOLVM machine create --image alpine --net --name default 2>&1 || return 1
     $SMOLVM machine start 2>&1 || return 1
 
-    # Verify the image is cached
+    # Verify the image is cached and the VM is reachable
     $SMOLVM machine exec -- true 2>&1 || { echo "VM not reachable"; return 1; }
-
-    # Check images before prune
-    local images_before
-    images_before=$($SMOLVM machine images --name default 2>&1)
 
     # Stop the VM (prune --all requires it)
     $SMOLVM machine stop 2>&1
 
-    # Run prune --all
+    # Run prune --all: it must keep the in-use image, not remove it.
     local output
     output=$($SMOLVM machine prune --name default --all 2>&1) || {
         echo "prune --all failed: $output"
         $SMOLVM machine delete --name default -f 2>/dev/null
         return 1
     }
-    [[ "$output" == *"Removed"* ]] || [[ "$output" == *"No cached images"* ]] || {
-        echo "unexpected prune output: $output"
+    [[ "$output" == *"Kept"* ]] || [[ "$output" == *"image-backed"* ]] || {
+        echo "expected prune --all to keep the in-use image, got: $output"
         $SMOLVM machine delete --name default -f 2>/dev/null
         return 1
     }
 
-    # Restart and verify images are gone
+    # The machine must still restart — its image was kept, not pruned.
     $SMOLVM machine start 2>&1 || {
+        echo "FAIL: machine could not restart after prune --all (image was pruned)"
         $SMOLVM machine delete --name default -f 2>/dev/null
         return 1
     }
-
-    local images_after
-    images_after=$($SMOLVM machine images --name default 2>&1)
+    $SMOLVM machine exec -- true 2>&1 || {
+        echo "FAIL: VM not reachable after prune + restart"
+        $SMOLVM machine delete --name default -f 2>/dev/null
+        return 1
+    }
 
     $SMOLVM machine stop 2>/dev/null || true
     $SMOLVM machine delete --name default -f 2>/dev/null || true
-
-    # After prune --all, no images should remain
-    if echo "$images_after" | grep -qE "^[a-z].*[0-9]+ MB"; then
-        echo "FAIL: images still present after prune --all"
-        echo "Before: $images_before"
-        echo "After: $images_after"
-        return 1
-    fi
 }
 
 test_storage_resize_and_large_pull() {
@@ -336,7 +329,7 @@ run_test "Images: does not stop running VM" test_images_does_not_stop_running_vm
 run_test "Prune: works on running VM without stopping it" test_prune_on_running_vm || true
 run_test "Prune --dry-run: works on running VM" test_prune_dry_run_on_running_vm || true
 run_test "Prune --all: refuses on running VM" test_prune_all_refuses_on_running_vm || true
-run_test "Prune --all: removes cached images" test_prune_all_removes_images || true
+run_test "Prune --all: keeps in-use image, machine still restarts" test_prune_all_keeps_in_use_image || true
 run_test "Storage: resize + large image pull (fresh disk)" test_storage_resize_and_large_pull || true
 run_test "Storage: /dev/vda mounted as ext4 with correct size" test_storage_mounted_as_ext4 || true
 


### PR DESCRIPTION
`machine prune --all` deleted the cached image an image-backed machine needs to restart (bricking a stopped machine with "image not found"), so it now keeps that image and reclaims only unreferenced layers; also fixes the auto-generated-names e2e test, which used `create --name` (a CLI error) instead of bare `create`.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/417">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->