### PR TITLE
fix(agent): preserve file ownership when extracting registry image layers

### DIFF
--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -1358,6 +1358,12 @@ fn extract_oci_layer<R: std::io::Read>(reader: R, dest: &Path) -> std::io::Resul
     let mut archive = tar::Archive::new(reader);
     archive.set_preserve_permissions(true);
     archive.set_preserve_mtime(true);
+    // Preserve the archive's uid/gid. The agent runs as root (CAP_CHOWN) so this
+    // chowns each entry to the image's intended owner; without it every file is
+    // owned by root, breaking images that ship non-root-owned paths (e.g. a
+    // `node`/`postgres` user's home or data dir). The previous busybox `tar`
+    // preserved ownership by default — the Rust-tar rewrite dropped it.
+    archive.set_preserve_ownerships(true);
     archive.set_overwrite(true);
 
     for entry in archive.entries()? {


### PR DESCRIPTION
The 1.1.0 Rust-tar rewrite of registry layer extraction (`extract_oci_layer`) set permissions+mtime but dropped `set_preserve_ownerships`, so non-root-owned image paths (a `node`/`postgres` user's home, etc.) ended up owned by root; restore it (the agent runs as root with CAP_CHOWN). Local-image archives were unaffected — they flatten via the system `tar`.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/418">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->