### PR TITLE
bump: v1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2118,7 +2118,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smolfile"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -2144,7 +2144,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-stream",
  "axum",
@@ -2193,7 +2193,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-agent"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "lazy_static",
  "libc",
@@ -2210,7 +2210,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-network"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "crossbeam-queue",
  "humantime",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-pack"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -2240,7 +2240,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "base64",
  "serde",
@@ -2250,7 +2250,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytes",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "smolvm"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 description = "OCI-native microVM runtime"
 license = "Apache-2.0"
@@ -29,11 +29,11 @@ name = "smolvm"
 path = "src/main.rs"
 
 [dependencies]
-smolvm-network = { path = "crates/smolvm-network", version = "1.1.0" }
-smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.1.0" }
-smolvm-pack = { path = "crates/smolvm-pack", version = "1.1.0" }
-smolvm-registry = { path = "crates/smolvm-registry", version = "1.1.0" }
-smolfile = { path = "crates/smolvm-smolfile", version = "1.1.0" }
+smolvm-network = { path = "crates/smolvm-network", version = "1.1.1" }
+smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.1.1" }
+smolvm-pack = { path = "crates/smolvm-pack", version = "1.1.1" }
+smolvm-registry = { path = "crates/smolvm-registry", version = "1.1.1" }
+smolfile = { path = "crates/smolvm-smolfile", version = "1.1.1" }
 thiserror = "1"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
@@ -89,7 +89,7 @@ landlock = "0.4"
 
 [dev-dependencies]
 tempfile = "3"
-smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.1.0" }
+smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.1.1" }
 regex = "1"
 
 [build-dependencies]

--- a/crates/smolvm-agent/Cargo.toml
+++ b/crates/smolvm-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-agent"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 description = "Guest agent for smolvm VMs (handles OCI operations and command execution)"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ name = "smolvm-agent"
 path = "src/main.rs"
 
 [dependencies]
-smolvm-protocol = { path = "../smolvm-protocol", version = "1.1.0" }
+smolvm-protocol = { path = "../smolvm-protocol", version = "1.1.1" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/crates/smolvm-network/Cargo.toml
+++ b/crates/smolvm-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-network"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 description = "Host-side virtio-net runtime for smolvm"
 license = "Apache-2.0"

--- a/crates/smolvm-pack/Cargo.toml
+++ b/crates/smolvm-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-pack"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 description = "Single-binary packaging for smolvm"
 license = "Apache-2.0"
@@ -10,7 +10,7 @@ repository = "https://github.com/smol-machines/smolvm"
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-smolvm-protocol = { path = "../smolvm-protocol", version = "1.1.0" }
+smolvm-protocol = { path = "../smolvm-protocol", version = "1.1.1" }
 tar = "0.4"
 zstd = "0.13"
 crc32fast = "1.4"

--- a/crates/smolvm-protocol/Cargo.toml
+++ b/crates/smolvm-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-protocol"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 description = "Protocol types for smolvm host-guest communication"
 license = "Apache-2.0"

--- a/crates/smolvm-registry/Cargo.toml
+++ b/crates/smolvm-registry/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "smolvm-registry"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 description = "OCI Distribution client for smolmachines registry"
 license = "Apache-2.0"
 repository = "https://github.com/smol-machines/smolvm"
 
 [dependencies]
-smolvm-pack = { path = "../smolvm-pack", version = "1.1.0" }
+smolvm-pack = { path = "../smolvm-pack", version = "1.1.1" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "json"] }
 sha2 = "0.10"
 bytes = "1"

--- a/crates/smolvm-smolfile/Cargo.toml
+++ b/crates/smolvm-smolfile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolfile"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 description = "Smolfile specification and parser for smolvm microVM workloads"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ keywords = ["smolvm", "microvm", "configuration"]
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 thiserror = "1"
-smolvm-protocol = { path = "../smolvm-protocol", version = "1.1.0" }
+smolvm-protocol = { path = "../smolvm-protocol", version = "1.1.1" }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
Patch release: fixes the 1.1.0 image-layer ownership regression (#418) and the prune --all in-use-image gap (#417). Tag v1.1.1 after merge to rebuild the agent + publish.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/419">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->