### PR TITLE
fix(agent-rootfs): bake in /mnt mount points so RO/from-scratch rootfs boots

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -712,6 +712,34 @@ fn log_gpu_status() {
     }
 }
 
+/// Ensure a mount-point directory exists on the agent rootfs, logging a WARN
+/// (rather than failing) if it can't be created.
+///
+/// The boot-critical mount points (/mnt/{overlay,storage,newroot}) are baked
+/// into the rootfs at build time — see the `mkdir` block in
+/// scripts/build-agent-rootfs.sh. This runtime `create_dir_all` is a backstop
+/// for rootfs images that predate that change or are assembled differently.
+///
+/// On a writable rootfs the dir already exists (no-op) or is created here. On a
+/// read-only rootfs the mkdir fails; we surface that as a WARN so the resulting
+/// failed overlay/storage mount is diagnosable instead of presenting as a
+/// silent boot-without-persistence. It also flags drift: a newly added `/mnt`
+/// mount point that wasn't baked into the build script will WARN here on a RO
+/// rootfs rather than fail mysteriously.
+#[cfg(target_os = "linux")]
+fn ensure_mount_dir(path: &str) {
+    if let Err(e) = std::fs::create_dir_all(path) {
+        boot_log(
+            "WARN",
+            &format!(
+                "could not create mount point {} ({}); rootfs may be read-only and \
+                 missing baked-in mount dirs — the following mount will likely fail",
+                path, e
+            ),
+        );
+    }
+}
+
 /// Set up persistent rootfs overlay using overlayfs on /dev/vdb.
 ///
 /// If /dev/vdb exists (overlay disk attached by host), this function:
@@ -792,7 +820,7 @@ fn setup_persistent_rootfs() {
         return;
     }
 
-    let _ = std::fs::create_dir_all(OVERLAY_MOUNT);
+    ensure_mount_dir(OVERLAY_MOUNT);
 
     // Probe and mount storage disk in parallel with the overlay ext4 operations.
     // Spawning here (before the /dev/vdb ext4 mount) lets storage work overlap
@@ -800,7 +828,7 @@ fn setup_persistent_rootfs() {
     // the /dev/vdb ext4 mount itself (~10ms, req=4–17). On warm boots this
     // removes storage mount latency from the critical path entirely.
     let storage_handle = if Path::new(STORAGE_DEVICE).exists() {
-        let _ = std::fs::create_dir_all(STORAGE_TEMP_MOUNT);
+        ensure_mount_dir(STORAGE_TEMP_MOUNT);
         Some(std::thread::spawn(|| {
             // Resize before mount — template may be smaller than device.
             // Skip if filesystem already fills the device (subsequent boots).
@@ -916,7 +944,7 @@ fn setup_persistent_rootfs() {
     // Create overlay directories
     let _ = std::fs::create_dir_all(format!("{}/upper", OVERLAY_MOUNT));
     let _ = std::fs::create_dir_all(format!("{}/work", OVERLAY_MOUNT));
-    let _ = std::fs::create_dir_all(NEWROOT);
+    ensure_mount_dir(NEWROOT);
 
     // Mount overlayfs: initramfs (lower, read-only) + persistent disk (upper)
     let overlay_src = cstr("overlay");

--- a/scripts/build-agent-rootfs.sh
+++ b/scripts/build-agent-rootfs.sh
@@ -206,6 +206,27 @@ mkdir -p "$OUTPUT_DIR/storage"
 mkdir -p "$OUTPUT_DIR/etc/init.d"
 mkdir -p "$OUTPUT_DIR/run"
 
+# Bake in the agent's /mnt mount points so the rootfs is self-sufficient.
+#
+# At boot, setup_persistent_rootfs() (crates/smolvm-agent/src/main.rs) mounts
+# the overlay/storage disks and stages pivot_root under these paths BEFORE any
+# writable overlay exists — its create_dir_all() calls run against the agent
+# rootfs itself. On a read-only rootfs, or one built from scratch without the
+# Alpine base's empty /mnt, those mkdirs fail, the mounts fail, and the VM
+# boots without its persistent overlay. Pre-creating the dirs here makes those
+# runtime create_dir_all() calls a no-op (the agent keeps them as a backstop
+# and WARNs if a mount point is ever missing on a RO rootfs).
+#
+# Keep this list in sync with the agent's mount-point constants:
+#   /mnt/overlay  OVERLAY_MOUNT       } setup_persistent_rootfs(), required at
+#   /mnt/storage  STORAGE_TEMP_MOUNT  } boot before the overlay is writable
+#   /mnt/newroot  NEWROOT             }
+#   /mnt/virtiofs paths::VIRTIOFS_MOUNT_ROOT  parent for per-tag virtiofs shares
+#   /mnt/rosetta  vm::rosetta::ROSETTA_GUEST_PATH  macOS Rosetta binfmt share
+for mnt_dir in overlay storage newroot virtiofs rosetta; do
+    mkdir -p "$OUTPUT_DIR/mnt/$mnt_dir"
+done
+
 # Remove existing init (it's a symlink to busybox) and replace with
 # symlink to the agent binary. The agent handles overlayfs setup +
 # pivot_root internally before starting the vsock listener.


### PR DESCRIPTION
## Problem

When the agent rootfs is read-only, or built from scratch without the Alpine base, the VM **silently boots without its persistent overlay**.

At boot, `setup_persistent_rootfs()` mounts the overlay/storage disks and stages `pivot_root` under `/mnt/{overlay,storage,newroot}` — *before* any writable overlay exists, so its `create_dir_all()` calls run against the agent rootfs itself. The build script only ever created `/storage`, `/etc/init.d`, and `/run`; the `/mnt` mount points worked solely because:
1. the Alpine base ships an empty `/mnt`, and
2. the rootfs was writable at boot so the agent could `mkdir` the submounts.

Remove either condition (a read-only rootfs — cf. the v1.0.3 RO-rootfs resolv fix — or a from-scratch build) and the mkdirs fail, the mounts fail, and the VM boots without persistence. The failure was **silent**: the agent used `let _ = create_dir_all(...)`, discarding the error.

## Fix

- **`scripts/build-agent-rootfs.sh`** — bake `/mnt/{overlay,storage,newroot,virtiofs,rosetta}` into the rootfs so it's self-sufficient regardless of mount mode. The list is documented against the agent's mount-point constants to keep the two in sync.
- **`crates/smolvm-agent/src/main.rs`** — route the three boot-critical `create_dir_all` sites through a new `ensure_mount_dir()` that logs a `WARN` instead of swallowing the error. It stays as a runtime backstop, and the WARN also surfaces drift (a new `/mnt` mount point not baked into the build script gets flagged on a RO rootfs rather than failing mysteriously). `/upper` and `/work` stay best-effort — they live on the already-mounted writable overlay disk, not the RO rootfs.

## Tested end-to-end (real libkrun VMs, macOS arm64)

Cross-compiled the agent (aarch64-musl), built a fresh rootfs via the patched script, ran a properly code-signed from-source CLI:

| Test | Result |
|------|--------|
| Fresh-from-scratch rootfs has all 5 `/mnt` dirs | ✅ deterministic |
| Persistent machine boots; `/` mounts as overlay, `/storage` from `/dev/vda` | ✅ `persistent rootfs overlay active (pivot_root done)` |
| Marker written, machine restarted, read back | ✅ persisted |
| **Read-only `/mnt`, empty** (pre-fix) | `/` = virtiofs — overlay **fails**, new WARN fires, then `ERROR: failed to mount overlay` |
| **Read-only `/mnt`, baked dirs** (this fix) | `/` = **overlay active**, persistence works, no WARN |

The last two rows are the clincher: identical read-only rootfs, and the only difference — the baked-in dirs — flips it from broken to working.

## Notes

- `pack`'s `collect_agent_rootfs` uses `tar::append_dir_all` (includes empty dirs), so the baked mount points propagate into `.smolmachine` bundles; nix and pack both consume the build script's output, so it's the single source of truth.
- No automated test added — the only faithful one is a full rootfs-build-and-boot (heavy). The WARN provides runtime protection instead. A cheap CI guard (assert the script output contains the 5 dirs) is a reasonable follow-up if desired.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/420">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->