### PR TITLE
feat: machine snapshot capture and restore for cloud durability and fork

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -11,6 +11,7 @@ mod krun;
 mod launcher;
 pub mod launcher_dynamic;
 mod manager;
+pub mod overlay_export;
 pub mod pod_net;
 pub mod state_probe;
 pub mod terminal;
@@ -35,6 +36,7 @@ pub use manager::{
     resolve_disk_image, shared_pack_cache_root, shared_pack_pointer_path, vm_cache_root,
     vm_data_dir, vm_dir_hash, vm_uid_registry_dir, AgentManager, AgentState, SHARED_PACK_POINTER,
 };
+pub use overlay_export::{capture_overlay_tar, seed_overlay_tar, tar_overlay_upper, OverlayTar};
 
 /// Agent VM name.
 pub const AGENT_VM_NAME: &str = "smolvm-agent";

--- a/src/agent/overlay_export.rs
+++ b/src/agent/overlay_export.rs
@@ -1,0 +1,218 @@
+//! Shared container-overlay transfer over a short-lived helper VM.
+//!
+//! Capturing a stopped image-machine's container overlay is the common atom
+//! behind three features: packaging a machine into a `.smolmachine` (`pack
+//! create --from-vm`), the cloud snapshot endpoint, and — in reverse — seeding
+//! an overlay from a snapshot tar (restore/fork). All of them boot a helper VM
+//! with the machine's `storage.raw` attached as `/dev/vdc` and `tar` the overlay
+//! `upper` dir; this module is the single place that knows how.
+
+use std::path::Path;
+
+use crate::agent::{vm_data_dir, AgentClient, AgentManager, LaunchFeatures, VmResources};
+use crate::data::disk::DiskFormat;
+use crate::error::{Error, Result};
+
+/// A captured container overlay.
+pub struct OverlayTar {
+    /// The overlay `upper` dir as a tar archive. Always a valid archive — an
+    /// empty-dir tar when the machine has no overlay yet — so callers can treat
+    /// the bytes uniformly.
+    pub tar: Vec<u8>,
+    /// Whether the overlay actually held any files. Callers that package the
+    /// tar as an image layer (pack) skip empty overlays; the snapshot endpoint
+    /// keeps the (valid, empty) archive regardless.
+    pub had_content: bool,
+}
+
+/// Tar the container overlay `upper` dir for `vm_name` inside a helper VM that
+/// already has the source storage mounted at `mount_point`. Always produces a
+/// valid archive (an empty dir when there's no overlay) and reports whether the
+/// overlay held content.
+pub fn tar_overlay_upper(
+    client: &mut AgentClient,
+    mount_point: &str,
+    vm_name: &str,
+) -> Result<OverlayTar> {
+    let upper = format!("{}/overlays/persistent-{}/upper", mount_point, vm_name);
+    // Always emit a valid tar: the overlay's contents when present, else an
+    // empty dir. Echo a marker so the host can tell the two apart. The `tar cf
+    // -C <upper> .` invocation is byte-identical to the legacy pack path, so an
+    // exported layer's digest is unchanged.
+    let script = format!(
+        "mkdir -p /tmp/empty && \
+         if [ -d '{u}' ] && [ -n \"$(ls -A '{u}' 2>/dev/null)\" ]; then \
+             tar cf /tmp/overlay.tar -C '{u}' . && echo HAS_CONTENT; \
+         else \
+             tar cf /tmp/overlay.tar -C /tmp/empty . && echo EMPTY; \
+         fi",
+        u = upper
+    );
+    let (code, stdout, stderr) = client.vm_exec(
+        vec!["sh".into(), "-c".into(), script],
+        vec![],
+        None,
+        None,
+        None,
+    )?;
+    if code != 0 {
+        return Err(Error::agent(
+            "tar container overlay",
+            format!(
+                "tar failed (exit {}): {}",
+                code,
+                String::from_utf8_lossy(&stderr)
+            ),
+        ));
+    }
+    let had_content = String::from_utf8_lossy(&stdout).contains("HAS_CONTENT");
+    let tar = client.read_file("/tmp/overlay.tar")?;
+    Ok(OverlayTar { tar, had_content })
+}
+
+/// Boot a short-lived helper VM with `storage_path` attached as `/dev/vdc`,
+/// mount it, and hand a connected client to `f`. The helper VM is always
+/// stopped and its data dir removed, even if `f` errors.
+fn with_overlay_helper_vm<T>(
+    storage_path: &Path,
+    storage_fmt: DiskFormat,
+    read_only: bool,
+    f: impl FnOnce(&mut AgentClient) -> Result<T>,
+) -> Result<T> {
+    // Unique helper-VM name (pid + nanos); first char alphanumeric, matching the
+    // VM-name constraint the pack-from-vm path documents.
+    let helper_name = format!(
+        "overlay-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    );
+    let helper_data = vm_data_dir(&helper_name);
+
+    let manager = AgentManager::for_vm(&helper_name)?;
+    let features = LaunchFeatures {
+        extra_disks: vec![(storage_path.to_path_buf(), read_only, storage_fmt)],
+        ..Default::default()
+    };
+    // Lean fixed sizing: mounting a disk and (un)taring one directory needs no
+    // network and little memory. This intentionally under-provisions relative to
+    // a workload VM.
+    manager.start_with_full_config(
+        Vec::new(),
+        Vec::new(),
+        VmResources {
+            cpus: 2,
+            memory_mib: 2048,
+            network: false,
+            network_backend: None,
+            gpu: false,
+            gpu_vram_mib: None,
+            cuda: false,
+            rosetta: false,
+            storage_gib: None,
+            overlay_gib: None,
+            allowed_cidrs: None,
+            dns: None,
+        },
+        features,
+    )?;
+
+    let mount_flag = if read_only { "-o ro " } else { "" };
+    let result: Result<T> = (|| {
+        let mut client = manager.connect()?;
+        let (code, _, stderr) = client.vm_exec(
+            vec![
+                "sh".into(),
+                "-c".into(),
+                format!("mkdir -p /mnt/src && mount {}/dev/vdc /mnt/src", mount_flag),
+            ],
+            vec![],
+            None,
+            None,
+            None,
+        )?;
+        if code != 0 {
+            return Err(Error::agent(
+                "mount source storage in helper VM",
+                format!(
+                    "mount failed (exit {}): {}",
+                    code,
+                    String::from_utf8_lossy(&stderr)
+                ),
+            ));
+        }
+        f(&mut client)
+    })();
+
+    if let Err(e) = manager.stop() {
+        tracing::warn!(helper = %helper_name, error = %e, "failed to stop overlay helper VM");
+    }
+    let _ = std::fs::remove_dir_all(&helper_data);
+    result
+}
+
+/// Boot a read-only helper VM and capture the machine's container overlay as a
+/// tar. Used by both `pack create --from-vm` and the cloud snapshot endpoint.
+pub fn capture_overlay_tar(
+    vm_name: &str,
+    storage_path: &Path,
+    storage_fmt: DiskFormat,
+) -> Result<OverlayTar> {
+    with_overlay_helper_vm(storage_path, storage_fmt, true, |client| {
+        tar_overlay_upper(client, "/mnt/src", vm_name)
+    })
+}
+
+/// Boot a read-write helper VM and seed the machine's container overlay from a
+/// snapshot tar, replacing any prior overlay state. Syncs and unmounts inside
+/// the guest so the write reaches the host disk image before teardown. On the
+/// machine's next start, the agent's overlay setup finds the existing `upper`
+/// and remounts it (preserving the restored state) instead of creating a blank
+/// one. The inverse of [`capture_overlay_tar`].
+pub fn seed_overlay_tar(
+    vm_name: &str,
+    storage_path: &Path,
+    storage_fmt: DiskFormat,
+    tar: &[u8],
+) -> Result<()> {
+    let vm_name = vm_name.to_string();
+    with_overlay_helper_vm(storage_path, storage_fmt, false, move |client| {
+        // Push the snapshot tar into the helper VM (auto-chunked over vsock).
+        client.write_file("/tmp/restore.tar", tar, None)?;
+
+        // Replace the persistent overlay's upper dir with the snapshot contents.
+        // Removing the whole overlay root first guarantees the agent takes the
+        // "existing upper → remount preserving it" path (not a stale merged-mount
+        // reuse) on the next start; `work`/`merged` are recreated at mount time.
+        // sync + umount so the write lands on the host disk before teardown.
+        let overlay_root = format!("/mnt/src/overlays/persistent-{}", vm_name);
+        let script = format!(
+            "set -e; \
+             rm -rf '{root}'; \
+             mkdir -p '{root}/upper'; \
+             tar xf /tmp/restore.tar -C '{root}/upper'; \
+             sync; umount /mnt/src",
+            root = overlay_root
+        );
+        let (code, _, stderr) = client.vm_exec(
+            vec!["sh".into(), "-c".into(), script],
+            vec![],
+            None,
+            None,
+            None,
+        )?;
+        if code != 0 {
+            return Err(Error::agent(
+                "seed container overlay",
+                format!(
+                    "apply overlay failed (exit {}): {}",
+                    code,
+                    String::from_utf8_lossy(&stderr)
+                ),
+            ));
+        }
+        Ok(())
+    })
+}

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -30,9 +30,7 @@ use axum::{
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::agent::{
-    vm_data_dir, AgentClient, AgentManager, HostMount, LaunchFeatures, VmResources,
-};
+use crate::agent::{resolve_disk_image, vm_data_dir, AgentClient, AgentManager, HostMount};
 use crate::api::error::ApiError;
 use crate::api::state::{
     vm_resources_to_spec, with_machine_client_traced, ApiState, MachineEntry, MachineRegistration,
@@ -52,6 +50,7 @@ use crate::process::{
     is_alive, is_our_process_strict, process_start_time, stop_vm_process, VM_SIGKILL_TIMEOUT,
     VM_SIGTERM_TIMEOUT,
 };
+use crate::storage::STORAGE_DISK_FILENAME;
 use crate::storage::{expand_disk, DEFAULT_OVERLAY_SIZE_GIB, DEFAULT_STORAGE_SIZE_GIB};
 use crate::util::generate_machine_name;
 use crate::Error as SmolvmError;
@@ -1825,146 +1824,22 @@ pub async fn snapshot_machine(
     Ok(Bytes::from(tar))
 }
 
-/// Boot a short-lived, network-less helper VM with `storage_path` attached as
-/// the 3rd block device (`/dev/vdc`, after the helper's own storage + overlay
-/// disks). Used by both snapshot capture and restore to reach a stopped
-/// machine's ext4 storage disk that unprivileged `serve` can't host-mount.
-/// `read_only` sets the virtio-blk attachment mode. Returns the manager plus
-/// the helper's name + data dir so the caller can stop and clean it up.
-fn start_overlay_helper_vm(
-    storage_path: &std::path::Path,
-    read_only: bool,
-) -> Result<(AgentManager, String, std::path::PathBuf), ApiError> {
-    // Unique helper-VM name (pid + nanos); first char alphanumeric — same
-    // constraint the pack-from-vm path documents.
-    let helper_name = format!(
-        "snap-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos()
-    );
-    let helper_data = vm_data_dir(&helper_name);
-
-    let manager = AgentManager::for_vm(&helper_name)
-        .map_err(|e| ApiError::internal(format!("helper VM manager: {}", e)))?;
-
-    let features = LaunchFeatures {
-        extra_disks: vec![(
-            storage_path.to_path_buf(),
-            read_only,
-            crate::data::disk::DiskFormat::Raw,
-        )],
-        ..Default::default()
-    };
-    manager
-        .start_with_full_config(
-            Vec::new(),
-            Vec::new(),
-            VmResources {
-                cpus: 2,
-                memory_mib: 2048,
-                network: false,
-                network_backend: None,
-                gpu: false,
-                gpu_vram_mib: None,
-                cuda: false,
-                rosetta: false,
-                storage_gib: None,
-                overlay_gib: None,
-                allowed_cidrs: None,
-                dns: None,
-            },
-            features,
-        )
-        .map_err(|e| ApiError::internal(format!("start helper VM: {}", e)))?;
-
-    Ok((manager, helper_name, helper_data))
-}
-
-/// Boot a short-lived helper VM, mount the source machine's storage disk, tar
-/// its container overlay upper dir, and return the tar bytes. A missing/empty
-/// overlay yields a valid empty (single `./` entry) archive rather than an
-/// error, so a never-modified machine still snapshots cleanly. The helper VM is
-/// always stopped and its data dir removed, even on error.
+/// Capture a stopped image-machine's container overlay as a tar. Thin wrapper
+/// over the shared [`crate::agent::capture_overlay_tar`] primitive (the same one
+/// `pack create --from-vm` uses), mapping its error to [`ApiError`]. A
+/// never-modified machine yields a valid empty archive rather than an error.
 fn capture_overlay_blocking(vm_name: &str) -> Result<Vec<u8>, ApiError> {
-    let storage_path = vm_data_dir(vm_name).join("storage.raw");
+    let vm_dir = vm_data_dir(vm_name);
+    let (storage_path, storage_fmt) = resolve_disk_image(&vm_dir, STORAGE_DISK_FILENAME);
     if !storage_path.exists() {
         return Err(ApiError::NotFound(format!(
             "machine '{}' has no storage disk to snapshot",
             vm_name
         )));
     }
-
-    // Capture never writes the source disk → attach it read-only.
-    let (manager, helper_name, helper_data) = start_overlay_helper_vm(&storage_path, true)?;
-
-    // Closure so the helper VM is always stopped/cleaned, even on early error.
-    let result: Result<Vec<u8>, ApiError> = (|| {
-        let mut client = manager
-            .connect()
-            .map_err(|e| ApiError::internal(format!("connect helper VM: {}", e)))?;
-
-        // Mount the source storage disk (/dev/vdc) read-only.
-        let (code, _, stderr) = client
-            .vm_exec(
-                vec![
-                    "sh".into(),
-                    "-c".into(),
-                    "mkdir -p /mnt/src && mount -o ro /dev/vdc /mnt/src".into(),
-                ],
-                vec![],
-                None,
-                None,
-                None,
-            )
-            .map_err(|e| ApiError::internal(format!("mount exec: {}", e)))?;
-        if code != 0 {
-            return Err(ApiError::internal(format!(
-                "mount source disk failed (exit {}): {}",
-                code,
-                String::from_utf8_lossy(&stderr)
-            )));
-        }
-
-        // Tar the container overlay upper dir. Missing/empty → tar an empty dir
-        // so the result is always a valid archive.
-        let upper = format!("/mnt/src/overlays/persistent-{}/upper", vm_name);
-        let script = format!(
-            "mkdir -p /tmp/empty && \
-             if [ -d '{u}' ]; then tar cf /tmp/snap.tar -C '{u}' . ; \
-             else tar cf /tmp/snap.tar -C /tmp/empty . ; fi",
-            u = upper
-        );
-        let (code, _, stderr) = client
-            .vm_exec(
-                vec!["sh".into(), "-c".into(), script],
-                vec![],
-                None,
-                None,
-                None,
-            )
-            .map_err(|e| ApiError::internal(format!("tar exec: {}", e)))?;
-        if code != 0 {
-            return Err(ApiError::internal(format!(
-                "tar overlay failed (exit {}): {}",
-                code,
-                String::from_utf8_lossy(&stderr)
-            )));
-        }
-
-        client
-            .read_file("/tmp/snap.tar")
-            .map_err(|e| ApiError::internal(format!("read snapshot tar: {}", e)))
-    })();
-
-    if let Err(e) = manager.stop() {
-        tracing::warn!(helper = %helper_name, error = %e, "failed to stop snapshot helper VM");
-    }
-    let _ = std::fs::remove_dir_all(&helper_data);
-
-    result
+    crate::agent::capture_overlay_tar(vm_name, &storage_path, storage_fmt)
+        .map(|o| o.tar)
+        .map_err(|e| ApiError::internal(format!("capture overlay: {}", e)))
 }
 
 /// Seed a stopped image-machine's container overlay from a snapshot tar (the
@@ -2020,95 +1895,20 @@ pub async fn restore_machine(
     ))
 }
 
-/// Boot a helper VM, mount the source machine's storage disk read-write, and
-/// untar `tar` into a fresh `overlays/persistent-{vm_name}/upper`, replacing any
-/// prior overlay state. Syncs + unmounts inside the guest before stopping so the
-/// write reaches the host disk image. The helper VM is always stopped and its
-/// data dir removed, even on error.
+/// Seed the machine's container overlay from a snapshot tar. Thin wrapper over
+/// the shared [`crate::agent::seed_overlay_tar`] primitive (the inverse of
+/// capture), mapping its error to [`ApiError`].
 fn apply_overlay_blocking(vm_name: &str, tar: Vec<u8>) -> Result<(), ApiError> {
-    let storage_path = vm_data_dir(vm_name).join("storage.raw");
+    let vm_dir = vm_data_dir(vm_name);
+    let (storage_path, storage_fmt) = resolve_disk_image(&vm_dir, STORAGE_DISK_FILENAME);
     if !storage_path.exists() {
         return Err(ApiError::NotFound(format!(
             "machine '{}' has no storage disk to restore into",
             vm_name
         )));
     }
-
-    // Restore writes the source disk → attach it read-write.
-    let (manager, helper_name, helper_data) = start_overlay_helper_vm(&storage_path, false)?;
-
-    let result: Result<(), ApiError> = (|| {
-        let mut client = manager
-            .connect()
-            .map_err(|e| ApiError::internal(format!("connect helper VM: {}", e)))?;
-
-        // Mount the source storage disk (/dev/vdc) read-write.
-        let (code, _, stderr) = client
-            .vm_exec(
-                vec![
-                    "sh".into(),
-                    "-c".into(),
-                    "mkdir -p /mnt/src && mount /dev/vdc /mnt/src".into(),
-                ],
-                vec![],
-                None,
-                None,
-                None,
-            )
-            .map_err(|e| ApiError::internal(format!("mount exec: {}", e)))?;
-        if code != 0 {
-            return Err(ApiError::internal(format!(
-                "mount source disk failed (exit {}): {}",
-                code,
-                String::from_utf8_lossy(&stderr)
-            )));
-        }
-
-        // Push the snapshot tar into the helper VM (auto-chunked over vsock).
-        client
-            .write_file("/tmp/restore.tar", &tar, None)
-            .map_err(|e| ApiError::internal(format!("write restore tar: {}", e)))?;
-
-        // Replace the persistent overlay's upper dir with the snapshot contents.
-        // Removing the whole overlay root first guarantees the agent's overlay
-        // setup takes the "existing upper → remount preserving it" path (not a
-        // stale-merged-mount reuse) on the next start. `work`/`merged` are
-        // recreated by the agent at mount time. sync + umount so the write lands
-        // on the host disk image before the helper VM is torn down.
-        let overlay_root = format!("/mnt/src/overlays/persistent-{}", vm_name);
-        let script = format!(
-            "set -e; \
-             rm -rf '{root}'; \
-             mkdir -p '{root}/upper'; \
-             tar xf /tmp/restore.tar -C '{root}/upper'; \
-             sync; umount /mnt/src",
-            root = overlay_root
-        );
-        let (code, _, stderr) = client
-            .vm_exec(
-                vec!["sh".into(), "-c".into(), script],
-                vec![],
-                None,
-                None,
-                None,
-            )
-            .map_err(|e| ApiError::internal(format!("untar exec: {}", e)))?;
-        if code != 0 {
-            return Err(ApiError::internal(format!(
-                "apply overlay failed (exit {}): {}",
-                code,
-                String::from_utf8_lossy(&stderr)
-            )));
-        }
-        Ok(())
-    })();
-
-    if let Err(e) = manager.stop() {
-        tracing::warn!(helper = %helper_name, error = %e, "failed to stop restore helper VM");
-    }
-    let _ = std::fs::remove_dir_all(&helper_data);
-
-    result
+    crate::agent::seed_overlay_tar(vm_name, &storage_path, storage_fmt, &tar)
+        .map_err(|e| ApiError::internal(format!("seed overlay: {}", e)))
 }
 
 async fn pull_from_registry(

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -23,13 +23,16 @@
 //! Recommended: keep names short and descriptive (e.g., "dev-vm", "test-1").
 
 use axum::{
+    body::Bytes,
     extract::{Path, Query, State},
     Json,
 };
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::agent::{vm_data_dir, AgentClient, AgentManager, HostMount};
+use crate::agent::{
+    vm_data_dir, AgentClient, AgentManager, HostMount, LaunchFeatures, VmResources,
+};
 use crate::api::error::ApiError;
 use crate::api::state::{
     vm_resources_to_spec, with_machine_client_traced, ApiState, MachineEntry, MachineRegistration,
@@ -1748,6 +1751,202 @@ pub async fn export_machine(
     }))
 }
 
+/// Guard for [`snapshot_machine`]: a machine is snapshottable iff it is
+/// image-based (the container overlay only exists for image machines; bare VMs
+/// persist via their overlay disk) and not currently running (the capture
+/// mounts its ext4 disk, which would corrupt a disk a live VMM holds open).
+/// Pure over the resolved state so the branches are unit-testable.
+fn check_snapshottable(name: &str, record: &VmRecord, state: RecordState) -> Result<(), ApiError> {
+    if record.image.is_none() {
+        return Err(ApiError::BadRequest(
+            "snapshot is only supported for image-based machines".into(),
+        ));
+    }
+    if state == RecordState::Running {
+        return Err(ApiError::Conflict(format!(
+            "machine '{}' must be stopped before snapshot (capture mounts its disk)",
+            name
+        )));
+    }
+    Ok(())
+}
+
+/// Capture a stopped image-machine's container overlay (the filesystem delta
+/// over its base image) and stream it back as a tar archive.
+///
+/// This is the node-side half of cloud machine snapshots (durability + fork):
+/// the control plane calls it through the driver, then uploads the bytes to
+/// object storage. We return ONLY the overlay delta — the base image is
+/// reproducible from the registry, so a snapshot is just the delta plus the
+/// recorded base-image pointer (kept in the control plane's
+/// `machine_snapshots` row).
+///
+/// Mechanism: the overlay's upper dir lives inside the machine's ext4 storage
+/// disk, which `serve` (running unprivileged) cannot host-mount. So we boot a
+/// short-lived helper VM with that disk attached as `/dev/vdc`, mount it inside
+/// the guest, and `tar` the overlay upper dir — the same idiom
+/// `pack create --from-vm` uses, minus the OCI-layer export.
+///
+/// The machine MUST be stopped (409 otherwise): the helper VM mounts the
+/// machine's ext4 disk, and doing that while the machine's own VMM still holds
+/// it open risks filesystem corruption.
+#[utoipa::path(
+    post,
+    path = "/api/v1/machines/{id}/snapshot",
+    tag = "Machines",
+    params(("id" = String, Path, description = "Machine name")),
+    responses(
+        (status = 200, description = "Overlay tar archive", content_type = "application/octet-stream"),
+        (status = 400, description = "Not an image-based machine"),
+        (status = 404, description = "Machine not found"),
+        (status = 409, description = "Machine is running (must be stopped)"),
+        (status = 500, description = "Capture failed")
+    )
+)]
+pub async fn snapshot_machine(
+    State(state): State<Arc<ApiState>>,
+    Path(id): Path<String>,
+) -> Result<Bytes, ApiError> {
+    let record = state
+        .db()
+        .get_vm(&id)
+        .map_err(ApiError::database)?
+        .ok_or_else(|| ApiError::NotFound(format!("machine '{}' not found", id)))?;
+
+    // `actual_state()` probes liveness, so a machine the DB thinks is stopped
+    // but whose process is still alive is correctly rejected below.
+    check_snapshottable(&id, &record, record.actual_state())?;
+
+    let name = id.clone();
+    let tar = tokio::task::spawn_blocking(move || capture_overlay_blocking(&name))
+        .await
+        .map_err(|e| ApiError::internal(format!("snapshot task failed: {}", e)))??;
+
+    Ok(Bytes::from(tar))
+}
+
+/// Boot a short-lived helper VM, mount the source machine's storage disk, tar
+/// its container overlay upper dir, and return the tar bytes. A missing/empty
+/// overlay yields a valid empty (single `./` entry) archive rather than an
+/// error, so a never-modified machine still snapshots cleanly. The helper VM is
+/// always stopped and its data dir removed, even on error.
+fn capture_overlay_blocking(vm_name: &str) -> Result<Vec<u8>, ApiError> {
+    let storage_path = vm_data_dir(vm_name).join("storage.raw");
+    if !storage_path.exists() {
+        return Err(ApiError::NotFound(format!(
+            "machine '{}' has no storage disk to snapshot",
+            vm_name
+        )));
+    }
+
+    // Unique helper-VM name (pid + nanos); first char alphanumeric — same
+    // constraint the pack-from-vm path documents.
+    let helper_name = format!(
+        "snap-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    );
+    let helper_data = vm_data_dir(&helper_name);
+
+    let manager = AgentManager::for_vm(&helper_name)
+        .map_err(|e| ApiError::internal(format!("helper VM manager: {}", e)))?;
+
+    // No network needed — we only mount + tar a local disk. The source storage
+    // disk is attached read-only as the 3rd block device (/dev/vdc), after the
+    // helper's own storage + overlay disks.
+    let features = LaunchFeatures {
+        extra_disks: vec![(storage_path.clone(), false)],
+        ..Default::default()
+    };
+    manager
+        .start_with_full_config(
+            Vec::new(),
+            Vec::new(),
+            VmResources {
+                cpus: 2,
+                memory_mib: 2048,
+                network: false,
+                network_backend: None,
+                gpu: false,
+                gpu_vram_mib: None,
+                storage_gib: None,
+                overlay_gib: None,
+                allowed_cidrs: None,
+            },
+            features,
+        )
+        .map_err(|e| ApiError::internal(format!("start helper VM: {}", e)))?;
+
+    // Closure so the helper VM is always stopped/cleaned, even on early error.
+    let result: Result<Vec<u8>, ApiError> = (|| {
+        let mut client = manager
+            .connect()
+            .map_err(|e| ApiError::internal(format!("connect helper VM: {}", e)))?;
+
+        // Mount the source storage disk (/dev/vdc) read-only.
+        let (code, _, stderr) = client
+            .vm_exec(
+                vec![
+                    "sh".into(),
+                    "-c".into(),
+                    "mkdir -p /mnt/src && mount -o ro /dev/vdc /mnt/src".into(),
+                ],
+                vec![],
+                None,
+                None,
+                None,
+            )
+            .map_err(|e| ApiError::internal(format!("mount exec: {}", e)))?;
+        if code != 0 {
+            return Err(ApiError::internal(format!(
+                "mount source disk failed (exit {}): {}",
+                code,
+                String::from_utf8_lossy(&stderr)
+            )));
+        }
+
+        // Tar the container overlay upper dir. Missing/empty → tar an empty dir
+        // so the result is always a valid archive.
+        let upper = format!("/mnt/src/overlays/persistent-{}/upper", vm_name);
+        let script = format!(
+            "mkdir -p /tmp/empty && \
+             if [ -d '{u}' ]; then tar cf /tmp/snap.tar -C '{u}' . ; \
+             else tar cf /tmp/snap.tar -C /tmp/empty . ; fi",
+            u = upper
+        );
+        let (code, _, stderr) = client
+            .vm_exec(
+                vec!["sh".into(), "-c".into(), script],
+                vec![],
+                None,
+                None,
+                None,
+            )
+            .map_err(|e| ApiError::internal(format!("tar exec: {}", e)))?;
+        if code != 0 {
+            return Err(ApiError::internal(format!(
+                "tar overlay failed (exit {}): {}",
+                code,
+                String::from_utf8_lossy(&stderr)
+            )));
+        }
+
+        client
+            .read_file("/tmp/snap.tar")
+            .map_err(|e| ApiError::internal(format!("read snapshot tar: {}", e)))
+    })();
+
+    if let Err(e) = manager.stop() {
+        tracing::warn!(helper = %helper_name, error = %e, "failed to stop snapshot helper VM");
+    }
+    let _ = std::fs::remove_dir_all(&helper_data);
+
+    result
+}
+
 async fn pull_from_registry(
     registry_ref: &str,
     identity_token: Option<&str>,
@@ -1867,6 +2066,36 @@ mod tests {
             classify_launch_error("failed to start machine: kernel panic".to_string()),
             ApiError::Internal(_)
         ));
+    }
+
+    #[test]
+    fn check_snapshottable_rejects_bare_vm() {
+        // A bare VM has no container overlay to capture → BadRequest, even when
+        // stopped.
+        let record = VmRecord::new("bare".into(), 2, 1024, vec![], vec![], false);
+        let err = check_snapshottable("bare", &record, RecordState::Stopped).unwrap_err();
+        assert!(matches!(err, ApiError::BadRequest(_)));
+    }
+
+    #[test]
+    fn check_snapshottable_rejects_running_image_machine() {
+        // Capturing mounts the machine's ext4 disk, so a running machine must be
+        // refused with a 409 (not silently corrupt the live disk).
+        let mut record = VmRecord::new("img".into(), 2, 1024, vec![], vec![], false);
+        record.image = Some("alpine:3.20".into());
+        let err = check_snapshottable("img", &record, RecordState::Running).unwrap_err();
+        match err {
+            ApiError::Conflict(msg) => assert!(msg.contains("stopped"), "msg: {}", msg),
+            other => panic!("expected Conflict, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn check_snapshottable_accepts_stopped_image_machine() {
+        let mut record = VmRecord::new("img".into(), 2, 1024, vec![], vec![], false);
+        record.image = Some("alpine:3.20".into());
+        assert!(check_snapshottable("img", &record, RecordState::Stopped).is_ok());
+        assert!(check_snapshottable("img", &record, RecordState::Created).is_ok());
     }
 
     #[test]

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -1825,20 +1825,16 @@ pub async fn snapshot_machine(
     Ok(Bytes::from(tar))
 }
 
-/// Boot a short-lived helper VM, mount the source machine's storage disk, tar
-/// its container overlay upper dir, and return the tar bytes. A missing/empty
-/// overlay yields a valid empty (single `./` entry) archive rather than an
-/// error, so a never-modified machine still snapshots cleanly. The helper VM is
-/// always stopped and its data dir removed, even on error.
-fn capture_overlay_blocking(vm_name: &str) -> Result<Vec<u8>, ApiError> {
-    let storage_path = vm_data_dir(vm_name).join("storage.raw");
-    if !storage_path.exists() {
-        return Err(ApiError::NotFound(format!(
-            "machine '{}' has no storage disk to snapshot",
-            vm_name
-        )));
-    }
-
+/// Boot a short-lived, network-less helper VM with `storage_path` attached as
+/// the 3rd block device (`/dev/vdc`, after the helper's own storage + overlay
+/// disks). Used by both snapshot capture and restore to reach a stopped
+/// machine's ext4 storage disk that unprivileged `serve` can't host-mount.
+/// `read_only` sets the virtio-blk attachment mode. Returns the manager plus
+/// the helper's name + data dir so the caller can stop and clean it up.
+fn start_overlay_helper_vm(
+    storage_path: &std::path::Path,
+    read_only: bool,
+) -> Result<(AgentManager, String, std::path::PathBuf), ApiError> {
     // Unique helper-VM name (pid + nanos); first char alphanumeric — same
     // constraint the pack-from-vm path documents.
     let helper_name = format!(
@@ -1854,11 +1850,12 @@ fn capture_overlay_blocking(vm_name: &str) -> Result<Vec<u8>, ApiError> {
     let manager = AgentManager::for_vm(&helper_name)
         .map_err(|e| ApiError::internal(format!("helper VM manager: {}", e)))?;
 
-    // No network needed — we only mount + tar a local disk. The source storage
-    // disk is attached read-only as the 3rd block device (/dev/vdc), after the
-    // helper's own storage + overlay disks.
     let features = LaunchFeatures {
-        extra_disks: vec![(storage_path.clone(), false)],
+        extra_disks: vec![(
+            storage_path.to_path_buf(),
+            read_only,
+            crate::data::disk::DiskFormat::Raw,
+        )],
         ..Default::default()
     };
     manager
@@ -1872,13 +1869,36 @@ fn capture_overlay_blocking(vm_name: &str) -> Result<Vec<u8>, ApiError> {
                 network_backend: None,
                 gpu: false,
                 gpu_vram_mib: None,
+                cuda: false,
+                rosetta: false,
                 storage_gib: None,
                 overlay_gib: None,
                 allowed_cidrs: None,
+                dns: None,
             },
             features,
         )
         .map_err(|e| ApiError::internal(format!("start helper VM: {}", e)))?;
+
+    Ok((manager, helper_name, helper_data))
+}
+
+/// Boot a short-lived helper VM, mount the source machine's storage disk, tar
+/// its container overlay upper dir, and return the tar bytes. A missing/empty
+/// overlay yields a valid empty (single `./` entry) archive rather than an
+/// error, so a never-modified machine still snapshots cleanly. The helper VM is
+/// always stopped and its data dir removed, even on error.
+fn capture_overlay_blocking(vm_name: &str) -> Result<Vec<u8>, ApiError> {
+    let storage_path = vm_data_dir(vm_name).join("storage.raw");
+    if !storage_path.exists() {
+        return Err(ApiError::NotFound(format!(
+            "machine '{}' has no storage disk to snapshot",
+            vm_name
+        )));
+    }
+
+    // Capture never writes the source disk → attach it read-only.
+    let (manager, helper_name, helper_data) = start_overlay_helper_vm(&storage_path, true)?;
 
     // Closure so the helper VM is always stopped/cleaned, even on early error.
     let result: Result<Vec<u8>, ApiError> = (|| {
@@ -1941,6 +1961,150 @@ fn capture_overlay_blocking(vm_name: &str) -> Result<Vec<u8>, ApiError> {
 
     if let Err(e) = manager.stop() {
         tracing::warn!(helper = %helper_name, error = %e, "failed to stop snapshot helper VM");
+    }
+    let _ = std::fs::remove_dir_all(&helper_data);
+
+    result
+}
+
+/// Seed a stopped image-machine's container overlay from a snapshot tar (the
+/// inverse of [`snapshot_machine`]).
+///
+/// This is the restore/fork half of cloud machine snapshots: the control plane
+/// downloads a snapshot's overlay bytes from object storage and POSTs them here
+/// to seed the machine's persistent overlay BEFORE its first boot. On the next
+/// start, the agent's overlay setup finds the existing upper layer and remounts
+/// it (preserving the restored state) instead of creating a blank overlay. For
+/// **rehydrate**, the target is a freshly-rescheduled machine; for **fork**, a
+/// brand-new machine with its own identity — both reduce to seeding
+/// `overlays/persistent-{id}/upper`.
+///
+/// Same constraints as snapshot: image-based (400 for bare) and stopped (409),
+/// since the helper VM mounts the machine's ext4 disk read-write.
+#[utoipa::path(
+    post,
+    path = "/api/v1/machines/{id}/restore",
+    tag = "Machines",
+    request_body(content = Vec<u8>, description = "Overlay tar archive", content_type = "application/octet-stream"),
+    params(("id" = String, Path, description = "Machine name")),
+    responses(
+        (status = 200, description = "Overlay restored"),
+        (status = 400, description = "Not an image-based machine"),
+        (status = 404, description = "Machine not found"),
+        (status = 409, description = "Machine is running (must be stopped)"),
+        (status = 500, description = "Restore failed")
+    )
+)]
+pub async fn restore_machine(
+    State(state): State<Arc<ApiState>>,
+    Path(id): Path<String>,
+    body: Bytes,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let record = state
+        .db()
+        .get_vm(&id)
+        .map_err(ApiError::database)?
+        .ok_or_else(|| ApiError::NotFound(format!("machine '{}' not found", id)))?;
+
+    check_snapshottable(&id, &record, record.actual_state())?;
+
+    let name = id.clone();
+    let tar = body.to_vec();
+    let bytes = tar.len() as u64;
+    tokio::task::spawn_blocking(move || apply_overlay_blocking(&name, tar))
+        .await
+        .map_err(|e| ApiError::internal(format!("restore task failed: {}", e)))??;
+
+    Ok(Json(
+        serde_json::json!({ "restored": true, "id": id, "bytes": bytes }),
+    ))
+}
+
+/// Boot a helper VM, mount the source machine's storage disk read-write, and
+/// untar `tar` into a fresh `overlays/persistent-{vm_name}/upper`, replacing any
+/// prior overlay state. Syncs + unmounts inside the guest before stopping so the
+/// write reaches the host disk image. The helper VM is always stopped and its
+/// data dir removed, even on error.
+fn apply_overlay_blocking(vm_name: &str, tar: Vec<u8>) -> Result<(), ApiError> {
+    let storage_path = vm_data_dir(vm_name).join("storage.raw");
+    if !storage_path.exists() {
+        return Err(ApiError::NotFound(format!(
+            "machine '{}' has no storage disk to restore into",
+            vm_name
+        )));
+    }
+
+    // Restore writes the source disk → attach it read-write.
+    let (manager, helper_name, helper_data) = start_overlay_helper_vm(&storage_path, false)?;
+
+    let result: Result<(), ApiError> = (|| {
+        let mut client = manager
+            .connect()
+            .map_err(|e| ApiError::internal(format!("connect helper VM: {}", e)))?;
+
+        // Mount the source storage disk (/dev/vdc) read-write.
+        let (code, _, stderr) = client
+            .vm_exec(
+                vec![
+                    "sh".into(),
+                    "-c".into(),
+                    "mkdir -p /mnt/src && mount /dev/vdc /mnt/src".into(),
+                ],
+                vec![],
+                None,
+                None,
+                None,
+            )
+            .map_err(|e| ApiError::internal(format!("mount exec: {}", e)))?;
+        if code != 0 {
+            return Err(ApiError::internal(format!(
+                "mount source disk failed (exit {}): {}",
+                code,
+                String::from_utf8_lossy(&stderr)
+            )));
+        }
+
+        // Push the snapshot tar into the helper VM (auto-chunked over vsock).
+        client
+            .write_file("/tmp/restore.tar", &tar, None)
+            .map_err(|e| ApiError::internal(format!("write restore tar: {}", e)))?;
+
+        // Replace the persistent overlay's upper dir with the snapshot contents.
+        // Removing the whole overlay root first guarantees the agent's overlay
+        // setup takes the "existing upper → remount preserving it" path (not a
+        // stale-merged-mount reuse) on the next start. `work`/`merged` are
+        // recreated by the agent at mount time. sync + umount so the write lands
+        // on the host disk image before the helper VM is torn down.
+        let overlay_root = format!("/mnt/src/overlays/persistent-{}", vm_name);
+        let script = format!(
+            "set -e; \
+             rm -rf '{root}'; \
+             mkdir -p '{root}/upper'; \
+             tar xf /tmp/restore.tar -C '{root}/upper'; \
+             sync; umount /mnt/src",
+            root = overlay_root
+        );
+        let (code, _, stderr) = client
+            .vm_exec(
+                vec!["sh".into(), "-c".into(), script],
+                vec![],
+                None,
+                None,
+                None,
+            )
+            .map_err(|e| ApiError::internal(format!("untar exec: {}", e)))?;
+        if code != 0 {
+            return Err(ApiError::internal(format!(
+                "apply overlay failed (exit {}): {}",
+                code,
+                String::from_utf8_lossy(&stderr)
+            )));
+        }
+        Ok(())
+    })();
+
+    if let Err(e) = manager.stop() {
+        tracing::warn!(helper = %helper_name, error = %e, "failed to stop restore helper VM");
     }
     let _ = std::fs::remove_dir_all(&helper_data);
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -91,6 +91,7 @@ use state::ApiState;
         handlers::machines::exec_machine,
         handlers::machines::resize_machine,
         handlers::machines::export_machine,
+        handlers::machines::snapshot_machine,
     ),
     components(schemas(
         // Request types
@@ -172,13 +173,16 @@ pub fn create_router(state: Arc<ApiState>, cors_origins: Vec<String>) -> Router 
     let p2p_route = Router::new().route("/p2p/blob/{digest}", get(handlers::p2p::serve_blob));
 
     // Long-lived streaming routes (no request timeout): SSE logs and the
-    // interactive PTY WebSocket both outlive the 5-minute API timeout.
+    // interactive PTY WebSocket both outlive the 5-minute API timeout, as does
+    // snapshot capture (boots a helper VM + tars the overlay). The node bounds
+    // these itself; the control-plane driver sends them with no client timeout.
     let logs_route = Router::new()
         .route("/{id}/logs", get(handlers::exec::stream_logs))
         .route(
             "/{id}/exec/interactive",
             get(handlers::exec::exec_interactive),
-        );
+        )
+        .route("/{id}/snapshot", post(handlers::machines::snapshot_machine));
 
     // Machine routes with timeout
     let machine_routes_with_timeout = Router::new()

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -26,7 +26,7 @@ pub mod supervisor;
 pub mod types;
 
 use axum::{
-    extract::Request,
+    extract::{DefaultBodyLimit, Request},
     http::{HeaderValue, StatusCode},
     middleware::{self, Next},
     response::Response,
@@ -92,6 +92,7 @@ use state::ApiState;
         handlers::machines::resize_machine,
         handlers::machines::export_machine,
         handlers::machines::snapshot_machine,
+        handlers::machines::restore_machine,
     ),
     components(schemas(
         // Request types
@@ -182,7 +183,16 @@ pub fn create_router(state: Arc<ApiState>, cors_origins: Vec<String>) -> Router 
             "/{id}/exec/interactive",
             get(handlers::exec::exec_interactive),
         )
-        .route("/{id}/snapshot", post(handlers::machines::snapshot_machine));
+        .route("/{id}/snapshot", post(handlers::machines::snapshot_machine))
+        // Restore seeds a machine's overlay from an uploaded snapshot tar; the
+        // body is the whole overlay archive, so lift the 2 MB default body limit
+        // (4 GiB cap). The listener is mTLS-gated in prod, so the caller is the
+        // trusted control plane.
+        .route(
+            "/{id}/restore",
+            post(handlers::machines::restore_machine)
+                .layer(DefaultBodyLimit::max(4 * 1024 * 1024 * 1024)),
+        );
 
     // Machine routes with timeout
     let machine_routes_with_timeout = Router::new()

--- a/src/cli/pack.rs
+++ b/src/cli/pack.rs
@@ -820,52 +820,45 @@ impl PackCreateCmd {
         export_result
     }
 
+    /// Register a captured container overlay as an image layer, skipping empty
+    /// overlays (a never-modified machine adds no layer). The layer digest is
+    /// `sha256` over the tar bytes, so it's stable across the capture callers.
+    fn register_overlay_layer(
+        collector: &mut AssetCollector,
+        overlay: &smolvm::agent::OverlayTar,
+    ) -> smolvm::Result<()> {
+        if !overlay.had_content {
+            tracing::debug!("overlay export: no container changes found");
+            return Ok(());
+        }
+        let overlay_digest = format!("sha256:{}", hex::encode(Sha256::digest(&overlay.tar)));
+        let overlay_layer_file = collector.layer_staging_path(&overlay_digest);
+        std::fs::write(&overlay_layer_file, &overlay.tar)
+            .map_err(|e| Error::agent("write overlay layer", e.to_string()))?;
+        collector
+            .register_layer(&overlay_digest)
+            .map_err(|e| Error::agent("register overlay layer", e.to_string()))?;
+        println!("  Overlay layer: {} bytes", overlay.tar.len());
+        Ok(())
+    }
+
+    /// Export the container overlay from a helper VM that already has the source
+    /// storage mounted at `/mnt/source-storage` (used by the image-layers path,
+    /// which needs the same VM online to pull base layers).
     fn export_container_overlay_from_mounted_storage(
         &self,
         collector: &mut AssetCollector,
         client: &mut AgentClient,
         vm_name: &str,
     ) -> smolvm::Result<()> {
-        let overlay_dir = format!("/mnt/source-storage/overlays/persistent-{}/upper", vm_name);
         println!("Exporting container overlay...");
-        let (exit_code, _, stderr) = client.vm_exec(
-            vec![
-                "sh".to_string(),
-                "-c".to_string(),
-                format!(
-                    "if [ -d '{}' ] && [ \"$(ls -A '{}')\" ]; then \
-                     tar cf /tmp/overlay-export.tar -C '{}' . 2>/dev/null; \
-                     echo OVERLAY_OK; \
-                     else echo OVERLAY_EMPTY; fi",
-                    overlay_dir, overlay_dir, overlay_dir
-                ),
-            ],
-            vec![],
-            None,
-            None,
-            None,
-        )?;
-
-        if exit_code == 0 {
-            let tar_data = client.read_file("/tmp/overlay-export.tar")?;
-            if !tar_data.is_empty() {
-                let overlay_hash = hex::encode(Sha256::digest(&tar_data));
-                let overlay_digest = format!("sha256:{}", overlay_hash);
-                let overlay_layer_file = collector.layer_staging_path(&overlay_digest);
-                std::fs::write(&overlay_layer_file, &tar_data)
-                    .map_err(|e| Error::agent("write overlay layer", e.to_string()))?;
-                collector
-                    .register_layer(&overlay_digest)
-                    .map_err(|e| Error::agent("register overlay layer", e.to_string()))?;
-                println!("  Overlay layer: {} bytes", tar_data.len());
-            }
-        } else {
-            tracing::debug!(stderr = %String::from_utf8_lossy(&stderr), "overlay export: no container changes found");
-        }
-
-        Ok(())
+        let overlay = smolvm::agent::tar_overlay_upper(client, "/mnt/source-storage", vm_name)?;
+        Self::register_overlay_layer(collector, &overlay)
     }
 
+    /// Export just the container overlay of a stopped machine — the same shared
+    /// capture the cloud snapshot endpoint uses, wrapped to register the result
+    /// as an image layer.
     fn export_container_overlay_from_vm(
         &self,
         collector: &mut AssetCollector,
@@ -873,77 +866,9 @@ impl PackCreateCmd {
         vm_dir: &Path,
     ) -> smolvm::Result<()> {
         let (storage_disk, storage_fmt) = resolve_disk_image(vm_dir, STORAGE_DISK_FILENAME);
-        let pack_vm_name = format!(
-            "pack-fromvm-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_nanos()
-        );
-        let vm_data = smolvm::agent::vm_data_dir(&pack_vm_name);
-
         println!("Starting agent VM to export container overlay...");
-        let manager = AgentManager::for_vm(&pack_vm_name)?;
-        let features = smolvm::agent::LaunchFeatures {
-            extra_disks: vec![(storage_disk.clone(), false, storage_fmt)],
-            ..Default::default()
-        };
-        manager.start_with_full_config(
-            Vec::new(),
-            Vec::new(),
-            VmResources {
-                cpus: 4,
-                memory_mib: 8192,
-                network: true,
-                network_backend: None,
-                dns: None,
-                gpu: false,
-                cuda: false,
-                gpu_vram_mib: None,
-                rosetta: false,
-                storage_gib: None,
-                overlay_gib: None,
-                allowed_cidrs: None,
-            },
-            features,
-        )?;
-
-        let export_result: smolvm::Result<()> = (|| {
-            let mut client = manager.connect()?;
-            let (exit_code, _, stderr) = client.vm_exec(
-                vec![
-                    "sh".to_string(),
-                    "-c".to_string(),
-                    "mkdir -p /mnt/source-storage && mount /dev/vdc /mnt/source-storage"
-                        .to_string(),
-                ],
-                vec![],
-                None,
-                None,
-                None,
-            )?;
-            if exit_code != 0 {
-                return Err(Error::agent(
-                    "mount source storage in temp VM",
-                    format!(
-                        "mount failed (exit {}): {}",
-                        exit_code,
-                        String::from_utf8_lossy(&stderr)
-                    ),
-                ));
-            }
-
-            self.export_container_overlay_from_mounted_storage(collector, &mut client, vm_name)?;
-
-            Ok(())
-        })();
-
-        if let Err(e) = manager.stop() {
-            warn!(error = %e, "failed to stop pack temp VM");
-        }
-        let _ = std::fs::remove_dir_all(&vm_data);
-        export_result
+        let overlay = smolvm::agent::capture_overlay_tar(vm_name, &storage_disk, storage_fmt)?;
+        Self::register_overlay_layer(collector, &overlay)
     }
 
     fn imported_layers_from_cache(

--- a/tests/snapshot_capture_live.rs
+++ b/tests/snapshot_capture_live.rs
@@ -1,316 +1,182 @@
-//! Live validation of the snapshot-capture helper-VM mechanism.
+//! Live validation of the shared container-overlay primitive (capture + seed).
 //!
-//! This exercises the exact path `snapshot_machine`'s `capture_overlay_blocking`
-//! uses — boot a helper VM with a source machine's storage disk attached as
-//! `/dev/vdc`, mount it read-only, and `tar` the container overlay upper dir —
-//! against a REAL ext4 `storage.raw`, using only public `smolvm` API.
+//! Exercises the REAL `agent::capture_overlay_tar` / `agent::seed_overlay_tar` —
+//! the exact functions `pack create --from-vm`, the snapshot endpoint, and
+//! restore all route through — by booting helper VMs against a synthetic ext4
+//! `storage.raw` built in-test with `mkfs.ext4 -d` (no root required).
 //!
-//! Ignored by default (needs a libkrun dylib + a real storage disk). Run with:
+//! `#[ignore]` by default: needs a libkrun dylib to boot a VM, plus `mkfs.ext4`
+//! (Linux, e2fsprogs) to build the disk. The boot-helper binary is located
+//! automatically via `CARGO_BIN_EXE_smolvm`, so `SMOLVM_BOOT_BINARY` does NOT
+//! need to be set by hand. Run with:
 //!   SMOLVM_LIB_DIR=/path/to/lib \
-//!   SNAP_TEST_STORAGE=/path/to/vms/<id>/storage.raw \
 //!   cargo test --test snapshot_capture_live -- --ignored --nocapture
+//!
+//! Without the `SMOLVM_BOOT_BINARY` shim below, these tests would silently
+//! "fail to boot" (`boot process exited code 0 before agent ready`): under
+//! `cargo test`, `current_exe()` is the test harness, which has no `_boot-vm`
+//! subcommand, so `start_via_subprocess` spawns a process that exits instantly.
 
-use smolvm::agent::{AgentManager, LaunchFeatures, VmResources};
+use smolvm::agent::{capture_overlay_tar, seed_overlay_tar};
 use smolvm::storage::DiskFormat;
+use std::path::PathBuf;
 
-#[test]
-#[ignore]
-fn helper_vm_captures_overlay_tar() {
-    let storage = std::env::var("SNAP_TEST_STORAGE")
-        .expect("set SNAP_TEST_STORAGE to a machine storage.raw path");
-    let storage_path = std::path::PathBuf::from(&storage);
-    assert!(storage_path.exists(), "storage disk not found: {}", storage);
+const VM: &str = "snaplive";
 
-    let helper = format!("snaptest-helper-{}", std::process::id());
-    let manager = AgentManager::for_vm(&helper).expect("helper manager");
-
-    let features = LaunchFeatures {
-        extra_disks: vec![(storage_path, false, DiskFormat::Raw)],
-        ..Default::default()
-    };
-    manager
-        .start_with_full_config(
-            Vec::new(),
-            Vec::new(),
-            VmResources {
-                cpus: 2,
-                memory_mib: 2048,
-                network: false,
-                network_backend: None,
-                gpu: false,
-                gpu_vram_mib: None,
-                cuda: false,
-                rosetta: false,
-                storage_gib: None,
-                overlay_gib: None,
-                allowed_cidrs: None,
-                dns: None,
-            },
-            features,
-        )
-        .expect("start helper VM");
-
-    let outcome = {
-        let mut client = manager.connect().expect("connect helper VM");
-
-        // Mount the source storage disk (/dev/vdc) read-only.
-        let (code, _, stderr) = client
-            .vm_exec(
-                vec![
-                    "sh".into(),
-                    "-c".into(),
-                    "mkdir -p /mnt/src && mount -o ro /dev/vdc /mnt/src".into(),
-                ],
-                vec![],
-                None,
-                None,
-                None,
-            )
-            .expect("mount exec");
-        assert_eq!(
-            code,
-            0,
-            "mount /dev/vdc failed: {}",
-            String::from_utf8_lossy(&stderr)
-        );
-
-        // Show what overlays exist — this is what a real capture would tar.
-        let (_, out, _) = client
-            .vm_exec(
-                vec![
-                    "sh".into(),
-                    "-c".into(),
-                    "ls -1 /mnt/src/overlays 2>/dev/null; \
-                     echo '---upper sizes---'; \
-                     du -sh /mnt/src/overlays/*/upper 2>/dev/null | head"
-                        .into(),
-                ],
-                vec![],
-                None,
-                None,
-                None,
-            )
-            .expect("list overlays exec");
-        println!("[overlays on disk]\n{}", String::from_utf8_lossy(&out));
-
-        // Tar the FIRST persistent overlay's upper dir if one exists, else tar an
-        // empty dir — same empty-safe behavior as capture_overlay_blocking.
-        let script = "set -e; \
-             U=$(ls -d /mnt/src/overlays/persistent-*/upper 2>/dev/null | head -1); \
-             mkdir -p /tmp/empty; \
-             if [ -n \"$U\" ]; then echo \"capturing $U\"; tar cf /tmp/snap.tar -C \"$U\" . ; \
-             else echo 'no persistent overlay; empty tar'; tar cf /tmp/snap.tar -C /tmp/empty . ; fi; \
-             echo \"tar bytes: $(wc -c < /tmp/snap.tar)\"";
-        let (code, out, stderr) = client
-            .vm_exec(
-                vec!["sh".into(), "-c".into(), script.into()],
-                vec![],
-                None,
-                None,
-                None,
-            )
-            .expect("tar exec");
-        println!("[tar step]\n{}", String::from_utf8_lossy(&out));
-        assert_eq!(code, 0, "tar failed: {}", String::from_utf8_lossy(&stderr));
-
-        // Read the tar back out — this is the byte stream the endpoint returns.
-        let tar = client.read_file("/tmp/snap.tar").expect("read snap.tar");
-        assert!(!tar.is_empty(), "snapshot tar is unexpectedly empty");
-        // A valid (even empty) tar is >= 512 bytes (one zeroed record block).
-        assert!(
-            tar.len() >= 512,
-            "snapshot tar too small to be a valid archive: {} bytes",
-            tar.len()
-        );
-        println!(
-            "[captured] {} tar bytes read back from helper VM",
-            tar.len()
-        );
-        tar.len()
-    };
-
-    let _ = manager.stop();
-    println!("helper VM stopped; captured {} bytes", outcome);
+/// Point the boot subprocess at the freshly-built `smolvm` binary. Cargo builds
+/// the `smolvm` bin before integration tests and exposes its path via
+/// `CARGO_BIN_EXE_smolvm`; the harness binary that `current_exe()` returns can't
+/// serve `_boot-vm`. Idempotent, and only sets the var if the caller hasn't.
+fn ensure_boot_binary() {
+    if std::env::var_os("SMOLVM_BOOT_BINARY").is_none() {
+        std::env::set_var("SMOLVM_BOOT_BINARY", env!("CARGO_BIN_EXE_smolvm"));
+    }
 }
 
-/// Round-trip the RESTORE write path: seed an overlay into a real ext4 disk via
-/// one helper VM, then prove it survived (sync + umount + VM teardown reached
-/// the host disk image) by reading it back in a SECOND helper VM. This is the
-/// property capture's read-only test can't cover.
-///
-/// Writes to a COW copy of SNAP_TEST_STORAGE so the source disk is untouched.
-/// Run with the same env as `helper_vm_captures_overlay_tar` (see module docs).
-#[test]
-#[ignore]
-fn restore_seeds_overlay_persistently() {
-    let src = std::env::var("SNAP_TEST_STORAGE")
-        .expect("set SNAP_TEST_STORAGE to a machine storage.raw path");
-    // COW copy (clonefile on APFS) so the original disk is never modified.
-    let scratch = format!("/tmp/snaptest-restore-{}.raw", std::process::id());
-    let status = std::process::Command::new("cp")
-        .args(["-c", src.as_str(), scratch.as_str()])
-        .status()
-        .expect("cp -c");
-    assert!(status.success(), "failed to COW-copy disk");
-    let scratch_path = std::path::PathBuf::from(&scratch);
-    let _cleanup = DropFile(scratch.clone());
-
-    // Build a tiny overlay tar host-side containing a known marker file.
-    let stage = format!("/tmp/snaptest-stage-{}", std::process::id());
-    std::fs::create_dir_all(format!("{}/etc", stage)).unwrap();
-    std::fs::write(format!("{}/RESTORE_MARKER", stage), b"durable-restore\n").unwrap();
-    std::fs::write(format!("{}/etc/myconf", stage), b"hello\n").unwrap();
-    let tar_path = format!("/tmp/snaptest-overlay-{}.tar", std::process::id());
-    let status = std::process::Command::new("tar")
-        .args(["cf", tar_path.as_str(), "-C", stage.as_str(), "."])
-        .status()
-        .expect("tar");
-    assert!(status.success(), "failed to build overlay tar");
-    let tar = std::fs::read(&tar_path).unwrap();
-    let _t = DropFile(tar_path);
-    let _s = DropDir(stage);
-    println!("[restore] staged overlay tar: {} bytes", tar.len());
-
-    let overlay_id = "roundtrip";
-
-    // --- Phase 1: write the overlay into the scratch disk via a helper VM. ---
-    {
-        let wname = format!("snaptest-w-{}", std::process::id());
-        let m = AgentManager::for_vm(&wname).expect("writer manager");
-        m.start_with_full_config(
-            Vec::new(),
-            Vec::new(),
-            helper_resources(),
-            LaunchFeatures {
-                extra_disks: vec![(scratch_path.clone(), false, DiskFormat::Raw)], // read-write
-                ..Default::default()
-            },
-        )
-        .expect("start writer VM");
-
-        {
-            let mut c = m.connect().expect("connect writer");
-            let (code, _, e) = c
-                .vm_exec(
-                    sh("mkdir -p /mnt/src && mount /dev/vdc /mnt/src"),
-                    vec![],
-                    None,
-                    None,
-                    None,
-                )
-                .expect("mount rw");
-            assert_eq!(code, 0, "mount rw failed: {}", String::from_utf8_lossy(&e));
-
-            c.write_file("/tmp/restore.tar", &tar, None)
-                .expect("push tar");
-
-            let root = format!("/mnt/src/overlays/persistent-{}", overlay_id);
-            let script = format!(
-                "set -e; rm -rf '{r}'; mkdir -p '{r}/upper'; \
-                 tar xf /tmp/restore.tar -C '{r}/upper'; sync; umount /mnt/src",
-                r = root
-            );
-            let (code, _, e) = c
-                .vm_exec(sh(&script), vec![], None, None, None)
-                .expect("untar");
-            assert_eq!(code, 0, "untar failed: {}", String::from_utf8_lossy(&e));
+/// Build a synthetic ext4 `storage.raw` holding `overlays/persistent-<VM>/upper`
+/// populated with `files` (relative path → contents). Uses `mkfs.ext4 -d` so no
+/// root/loop-mount is needed. Panics with a clear message if `mkfs.ext4` is
+/// absent — the test is explicitly opt-in (`--ignored`), so a silent skip would
+/// just re-create the gap this file exists to close.
+fn build_storage_disk(files: &[(&str, &[u8])]) -> Disk {
+    let base = std::env::temp_dir().join(format!("snaplive-{}", std::process::id()));
+    let stage = base.join("stage");
+    let upper = stage.join(format!("overlays/persistent-{}/upper", VM));
+    std::fs::create_dir_all(&upper).unwrap();
+    for (rel, contents) in files {
+        let p = upper.join(rel);
+        if let Some(parent) = p.parent() {
+            std::fs::create_dir_all(parent).unwrap();
         }
-        let _ = m.stop();
-        println!("[restore] phase 1 done — overlay written + VM torn down");
+        std::fs::write(&p, contents).unwrap();
     }
 
-    // --- Phase 2: a fresh helper VM must see the persisted marker. ---
-    {
-        let rname = format!("snaptest-r-{}", std::process::id());
-        let m = AgentManager::for_vm(&rname).expect("reader manager");
-        m.start_with_full_config(
-            Vec::new(),
-            Vec::new(),
-            helper_resources(),
-            LaunchFeatures {
-                extra_disks: vec![(scratch_path.clone(), true, DiskFormat::Raw)], // read-only verify
-                ..Default::default()
-            },
-        )
-        .expect("start reader VM");
-
-        let found = {
-            let mut c = m.connect().expect("connect reader");
-            let (code, _, e) = c
-                .vm_exec(
-                    sh("mkdir -p /mnt/src && mount -o ro /dev/vdc /mnt/src"),
-                    vec![],
-                    None,
-                    None,
-                    None,
-                )
-                .expect("mount ro");
-            assert_eq!(code, 0, "mount ro failed: {}", String::from_utf8_lossy(&e));
-
-            let upper = format!("/mnt/src/overlays/persistent-{}/upper", overlay_id);
-            let (code, out, _) = c
-                .vm_exec(
-                    sh(&format!(
-                        "cat '{u}/RESTORE_MARKER' 2>/dev/null; echo '|'; cat '{u}/etc/myconf' 2>/dev/null",
-                        u = upper
-                    )),
-                    vec![],
-                    None,
-                    None,
-                    None,
-                )
-                .expect("read marker");
-            assert_eq!(code, 0, "read marker exec failed");
-            String::from_utf8_lossy(&out).to_string()
-        };
-        let _ = m.stop();
-
-        println!("[restore] phase 2 read back: {:?}", found);
-        assert!(
-            found.contains("durable-restore"),
-            "RESTORE_MARKER did not persist across VM teardown: {:?}",
-            found
-        );
-        assert!(
-            found.contains("hello"),
-            "nested etc/myconf missing: {:?}",
-            found
-        );
-        println!("[restore] PASS — overlay persisted across helper-VM teardown");
-    }
+    let disk = base.join("storage.raw");
+    let status = std::process::Command::new("mkfs.ext4")
+        .args([
+            "-F",
+            "-q",
+            "-d",
+            &stage.to_string_lossy(),
+            &disk.to_string_lossy(),
+            "128M",
+        ])
+        .status()
+        .expect("run mkfs.ext4 (install e2fsprogs; this test needs Linux)");
+    assert!(status.success(), "mkfs.ext4 failed to build the test disk");
+    Disk { disk, base }
 }
 
-fn helper_resources() -> VmResources {
-    VmResources {
-        cpus: 2,
-        memory_mib: 2048,
-        network: false,
-        network_backend: None,
-        gpu: false,
-        gpu_vram_mib: None,
-        cuda: false,
-        rosetta: false,
-        storage_gib: None,
-        overlay_gib: None,
-        allowed_cidrs: None,
-        dns: None,
-    }
+struct Disk {
+    disk: PathBuf,
+    base: PathBuf,
 }
-
-fn sh(script: &str) -> Vec<String> {
-    vec!["sh".into(), "-c".into(), script.into()]
-}
-
-struct DropFile(String);
-impl Drop for DropFile {
+impl Drop for Disk {
     fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.0);
+        let _ = std::fs::remove_dir_all(&self.base);
     }
 }
 
-struct DropDir(String);
-impl Drop for DropDir {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_dir_all(&self.0);
-    }
+fn tar_has(tar: &[u8], name: &str) -> bool {
+    // tar stores each member's path as ASCII in its 512-byte header.
+    String::from_utf8_lossy(tar).contains(name)
+}
+
+/// Capture must boot a read-only helper VM, mount the disk, and return the
+/// overlay `upper` dir as a tar with the expected files.
+#[test]
+#[ignore]
+fn capture_overlay_reads_persisted_overlay() {
+    ensure_boot_binary();
+    let d = build_storage_disk(&[("MARKER", b"capture-me\n"), ("etc/conf", b"nested\n")]);
+
+    let cap = capture_overlay_tar(VM, &d.disk, DiskFormat::Raw).expect("capture_overlay_tar");
+    println!(
+        "[capture] {} tar bytes, had_content={}",
+        cap.tar.len(),
+        cap.had_content
+    );
+    assert!(cap.had_content, "expected a non-empty overlay");
+    assert!(
+        cap.tar.len() >= 512,
+        "tar too small to be valid: {}",
+        cap.tar.len()
+    );
+    assert!(tar_has(&cap.tar, "MARKER"), "captured tar missing MARKER");
+    assert!(tar_has(&cap.tar, "conf"), "captured tar missing etc/conf");
+    println!("[capture] PASS — overlay contents captured via shared primitive");
+}
+
+/// Empty-safe: a never-modified overlay still yields a valid (empty) archive.
+#[test]
+#[ignore]
+fn capture_empty_overlay_is_valid_archive() {
+    ensure_boot_binary();
+    let d = build_storage_disk(&[]); // upper dir exists but is empty
+
+    let cap = capture_overlay_tar(VM, &d.disk, DiskFormat::Raw).expect("capture_overlay_tar");
+    println!(
+        "[empty] {} tar bytes, had_content={}",
+        cap.tar.len(),
+        cap.had_content
+    );
+    assert!(
+        !cap.had_content,
+        "empty overlay should report had_content=false"
+    );
+    assert!(
+        cap.tar.len() >= 512,
+        "empty tar must still be a valid archive"
+    );
+    println!("[empty] PASS — empty overlay yields a valid empty archive");
+}
+
+/// Round-trip the RESTORE write path: seed an overlay into a real ext4 disk
+/// (read-write helper VM, sync + umount + teardown), then prove it reached the
+/// host disk image by re-capturing it in a fresh (read-only) helper VM. Also
+/// proves the replace semantics: prior overlay content is gone.
+#[test]
+#[ignore]
+fn seed_then_capture_roundtrips() {
+    ensure_boot_binary();
+    // Start with an OLD overlay so we can prove seed replaces it.
+    let d = build_storage_disk(&[("OLD_MARKER", b"stale\n")]);
+
+    // Build the new overlay tar host-side.
+    let stage = std::env::temp_dir().join(format!("snaplive-seed-{}", std::process::id()));
+    std::fs::create_dir_all(stage.join("etc")).unwrap();
+    std::fs::write(stage.join("SEEDED_MARKER"), b"durable-restore\n").unwrap();
+    std::fs::write(stage.join("etc/myconf"), b"hello\n").unwrap();
+    let tar_path = std::env::temp_dir().join(format!("snaplive-seed-{}.tar", std::process::id()));
+    let ok = std::process::Command::new("tar")
+        .args([
+            "cf",
+            &tar_path.to_string_lossy(),
+            "-C",
+            &stage.to_string_lossy(),
+            ".",
+        ])
+        .status()
+        .expect("tar")
+        .success();
+    assert!(ok, "failed to build overlay tar");
+    let tar = std::fs::read(&tar_path).unwrap();
+
+    seed_overlay_tar(VM, &d.disk, DiskFormat::Raw, &tar).expect("seed_overlay_tar");
+    let cap = capture_overlay_tar(VM, &d.disk, DiskFormat::Raw).expect("recapture");
+    println!("[roundtrip] recaptured {} tar bytes", cap.tar.len());
+
+    assert!(
+        tar_has(&cap.tar, "SEEDED_MARKER"),
+        "seeded marker did not persist"
+    );
+    assert!(tar_has(&cap.tar, "myconf"), "nested seeded file missing");
+    assert!(
+        !tar_has(&cap.tar, "OLD_MARKER"),
+        "prior overlay survived a replace-seed"
+    );
+    println!("[roundtrip] PASS — seed persisted across teardown and replaced prior overlay");
+
+    let _ = std::fs::remove_file(&tar_path);
+    let _ = std::fs::remove_dir_all(&stage);
 }

--- a/tests/snapshot_capture_live.rs
+++ b/tests/snapshot_capture_live.rs
@@ -11,6 +11,7 @@
 //!   cargo test --test snapshot_capture_live -- --ignored --nocapture
 
 use smolvm::agent::{AgentManager, LaunchFeatures, VmResources};
+use smolvm::storage::DiskFormat;
 
 #[test]
 #[ignore]
@@ -24,7 +25,7 @@ fn helper_vm_captures_overlay_tar() {
     let manager = AgentManager::for_vm(&helper).expect("helper manager");
 
     let features = LaunchFeatures {
-        extra_disks: vec![(storage_path, false)],
+        extra_disks: vec![(storage_path, false, DiskFormat::Raw)],
         ..Default::default()
     };
     manager
@@ -38,9 +39,12 @@ fn helper_vm_captures_overlay_tar() {
                 network_backend: None,
                 gpu: false,
                 gpu_vram_mib: None,
+                cuda: false,
+                rosetta: false,
                 storage_gib: None,
                 overlay_gib: None,
                 allowed_cidrs: None,
+                dns: None,
             },
             features,
         )
@@ -127,4 +131,186 @@ fn helper_vm_captures_overlay_tar() {
 
     let _ = manager.stop();
     println!("helper VM stopped; captured {} bytes", outcome);
+}
+
+/// Round-trip the RESTORE write path: seed an overlay into a real ext4 disk via
+/// one helper VM, then prove it survived (sync + umount + VM teardown reached
+/// the host disk image) by reading it back in a SECOND helper VM. This is the
+/// property capture's read-only test can't cover.
+///
+/// Writes to a COW copy of SNAP_TEST_STORAGE so the source disk is untouched.
+/// Run with the same env as `helper_vm_captures_overlay_tar` (see module docs).
+#[test]
+#[ignore]
+fn restore_seeds_overlay_persistently() {
+    let src = std::env::var("SNAP_TEST_STORAGE")
+        .expect("set SNAP_TEST_STORAGE to a machine storage.raw path");
+    // COW copy (clonefile on APFS) so the original disk is never modified.
+    let scratch = format!("/tmp/snaptest-restore-{}.raw", std::process::id());
+    let status = std::process::Command::new("cp")
+        .args(["-c", src.as_str(), scratch.as_str()])
+        .status()
+        .expect("cp -c");
+    assert!(status.success(), "failed to COW-copy disk");
+    let scratch_path = std::path::PathBuf::from(&scratch);
+    let _cleanup = DropFile(scratch.clone());
+
+    // Build a tiny overlay tar host-side containing a known marker file.
+    let stage = format!("/tmp/snaptest-stage-{}", std::process::id());
+    std::fs::create_dir_all(format!("{}/etc", stage)).unwrap();
+    std::fs::write(format!("{}/RESTORE_MARKER", stage), b"durable-restore\n").unwrap();
+    std::fs::write(format!("{}/etc/myconf", stage), b"hello\n").unwrap();
+    let tar_path = format!("/tmp/snaptest-overlay-{}.tar", std::process::id());
+    let status = std::process::Command::new("tar")
+        .args(["cf", tar_path.as_str(), "-C", stage.as_str(), "."])
+        .status()
+        .expect("tar");
+    assert!(status.success(), "failed to build overlay tar");
+    let tar = std::fs::read(&tar_path).unwrap();
+    let _t = DropFile(tar_path);
+    let _s = DropDir(stage);
+    println!("[restore] staged overlay tar: {} bytes", tar.len());
+
+    let overlay_id = "roundtrip";
+
+    // --- Phase 1: write the overlay into the scratch disk via a helper VM. ---
+    {
+        let wname = format!("snaptest-w-{}", std::process::id());
+        let m = AgentManager::for_vm(&wname).expect("writer manager");
+        m.start_with_full_config(
+            Vec::new(),
+            Vec::new(),
+            helper_resources(),
+            LaunchFeatures {
+                extra_disks: vec![(scratch_path.clone(), false, DiskFormat::Raw)], // read-write
+                ..Default::default()
+            },
+        )
+        .expect("start writer VM");
+
+        {
+            let mut c = m.connect().expect("connect writer");
+            let (code, _, e) = c
+                .vm_exec(
+                    sh("mkdir -p /mnt/src && mount /dev/vdc /mnt/src"),
+                    vec![],
+                    None,
+                    None,
+                    None,
+                )
+                .expect("mount rw");
+            assert_eq!(code, 0, "mount rw failed: {}", String::from_utf8_lossy(&e));
+
+            c.write_file("/tmp/restore.tar", &tar, None)
+                .expect("push tar");
+
+            let root = format!("/mnt/src/overlays/persistent-{}", overlay_id);
+            let script = format!(
+                "set -e; rm -rf '{r}'; mkdir -p '{r}/upper'; \
+                 tar xf /tmp/restore.tar -C '{r}/upper'; sync; umount /mnt/src",
+                r = root
+            );
+            let (code, _, e) = c
+                .vm_exec(sh(&script), vec![], None, None, None)
+                .expect("untar");
+            assert_eq!(code, 0, "untar failed: {}", String::from_utf8_lossy(&e));
+        }
+        let _ = m.stop();
+        println!("[restore] phase 1 done — overlay written + VM torn down");
+    }
+
+    // --- Phase 2: a fresh helper VM must see the persisted marker. ---
+    {
+        let rname = format!("snaptest-r-{}", std::process::id());
+        let m = AgentManager::for_vm(&rname).expect("reader manager");
+        m.start_with_full_config(
+            Vec::new(),
+            Vec::new(),
+            helper_resources(),
+            LaunchFeatures {
+                extra_disks: vec![(scratch_path.clone(), true, DiskFormat::Raw)], // read-only verify
+                ..Default::default()
+            },
+        )
+        .expect("start reader VM");
+
+        let found = {
+            let mut c = m.connect().expect("connect reader");
+            let (code, _, e) = c
+                .vm_exec(
+                    sh("mkdir -p /mnt/src && mount -o ro /dev/vdc /mnt/src"),
+                    vec![],
+                    None,
+                    None,
+                    None,
+                )
+                .expect("mount ro");
+            assert_eq!(code, 0, "mount ro failed: {}", String::from_utf8_lossy(&e));
+
+            let upper = format!("/mnt/src/overlays/persistent-{}/upper", overlay_id);
+            let (code, out, _) = c
+                .vm_exec(
+                    sh(&format!(
+                        "cat '{u}/RESTORE_MARKER' 2>/dev/null; echo '|'; cat '{u}/etc/myconf' 2>/dev/null",
+                        u = upper
+                    )),
+                    vec![],
+                    None,
+                    None,
+                    None,
+                )
+                .expect("read marker");
+            assert_eq!(code, 0, "read marker exec failed");
+            String::from_utf8_lossy(&out).to_string()
+        };
+        let _ = m.stop();
+
+        println!("[restore] phase 2 read back: {:?}", found);
+        assert!(
+            found.contains("durable-restore"),
+            "RESTORE_MARKER did not persist across VM teardown: {:?}",
+            found
+        );
+        assert!(
+            found.contains("hello"),
+            "nested etc/myconf missing: {:?}",
+            found
+        );
+        println!("[restore] PASS — overlay persisted across helper-VM teardown");
+    }
+}
+
+fn helper_resources() -> VmResources {
+    VmResources {
+        cpus: 2,
+        memory_mib: 2048,
+        network: false,
+        network_backend: None,
+        gpu: false,
+        gpu_vram_mib: None,
+        cuda: false,
+        rosetta: false,
+        storage_gib: None,
+        overlay_gib: None,
+        allowed_cidrs: None,
+        dns: None,
+    }
+}
+
+fn sh(script: &str) -> Vec<String> {
+    vec!["sh".into(), "-c".into(), script.into()]
+}
+
+struct DropFile(String);
+impl Drop for DropFile {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+struct DropDir(String);
+impl Drop for DropDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
 }

--- a/tests/snapshot_capture_live.rs
+++ b/tests/snapshot_capture_live.rs
@@ -1,0 +1,130 @@
+//! Live validation of the snapshot-capture helper-VM mechanism.
+//!
+//! This exercises the exact path `snapshot_machine`'s `capture_overlay_blocking`
+//! uses — boot a helper VM with a source machine's storage disk attached as
+//! `/dev/vdc`, mount it read-only, and `tar` the container overlay upper dir —
+//! against a REAL ext4 `storage.raw`, using only public `smolvm` API.
+//!
+//! Ignored by default (needs a libkrun dylib + a real storage disk). Run with:
+//!   SMOLVM_LIB_DIR=/path/to/lib \
+//!   SNAP_TEST_STORAGE=/path/to/vms/<id>/storage.raw \
+//!   cargo test --test snapshot_capture_live -- --ignored --nocapture
+
+use smolvm::agent::{AgentManager, LaunchFeatures, VmResources};
+
+#[test]
+#[ignore]
+fn helper_vm_captures_overlay_tar() {
+    let storage = std::env::var("SNAP_TEST_STORAGE")
+        .expect("set SNAP_TEST_STORAGE to a machine storage.raw path");
+    let storage_path = std::path::PathBuf::from(&storage);
+    assert!(storage_path.exists(), "storage disk not found: {}", storage);
+
+    let helper = format!("snaptest-helper-{}", std::process::id());
+    let manager = AgentManager::for_vm(&helper).expect("helper manager");
+
+    let features = LaunchFeatures {
+        extra_disks: vec![(storage_path, false)],
+        ..Default::default()
+    };
+    manager
+        .start_with_full_config(
+            Vec::new(),
+            Vec::new(),
+            VmResources {
+                cpus: 2,
+                memory_mib: 2048,
+                network: false,
+                network_backend: None,
+                gpu: false,
+                gpu_vram_mib: None,
+                storage_gib: None,
+                overlay_gib: None,
+                allowed_cidrs: None,
+            },
+            features,
+        )
+        .expect("start helper VM");
+
+    let outcome = {
+        let mut client = manager.connect().expect("connect helper VM");
+
+        // Mount the source storage disk (/dev/vdc) read-only.
+        let (code, _, stderr) = client
+            .vm_exec(
+                vec![
+                    "sh".into(),
+                    "-c".into(),
+                    "mkdir -p /mnt/src && mount -o ro /dev/vdc /mnt/src".into(),
+                ],
+                vec![],
+                None,
+                None,
+                None,
+            )
+            .expect("mount exec");
+        assert_eq!(
+            code,
+            0,
+            "mount /dev/vdc failed: {}",
+            String::from_utf8_lossy(&stderr)
+        );
+
+        // Show what overlays exist — this is what a real capture would tar.
+        let (_, out, _) = client
+            .vm_exec(
+                vec![
+                    "sh".into(),
+                    "-c".into(),
+                    "ls -1 /mnt/src/overlays 2>/dev/null; \
+                     echo '---upper sizes---'; \
+                     du -sh /mnt/src/overlays/*/upper 2>/dev/null | head"
+                        .into(),
+                ],
+                vec![],
+                None,
+                None,
+                None,
+            )
+            .expect("list overlays exec");
+        println!("[overlays on disk]\n{}", String::from_utf8_lossy(&out));
+
+        // Tar the FIRST persistent overlay's upper dir if one exists, else tar an
+        // empty dir — same empty-safe behavior as capture_overlay_blocking.
+        let script = "set -e; \
+             U=$(ls -d /mnt/src/overlays/persistent-*/upper 2>/dev/null | head -1); \
+             mkdir -p /tmp/empty; \
+             if [ -n \"$U\" ]; then echo \"capturing $U\"; tar cf /tmp/snap.tar -C \"$U\" . ; \
+             else echo 'no persistent overlay; empty tar'; tar cf /tmp/snap.tar -C /tmp/empty . ; fi; \
+             echo \"tar bytes: $(wc -c < /tmp/snap.tar)\"";
+        let (code, out, stderr) = client
+            .vm_exec(
+                vec!["sh".into(), "-c".into(), script.into()],
+                vec![],
+                None,
+                None,
+                None,
+            )
+            .expect("tar exec");
+        println!("[tar step]\n{}", String::from_utf8_lossy(&out));
+        assert_eq!(code, 0, "tar failed: {}", String::from_utf8_lossy(&stderr));
+
+        // Read the tar back out — this is the byte stream the endpoint returns.
+        let tar = client.read_file("/tmp/snap.tar").expect("read snap.tar");
+        assert!(!tar.is_empty(), "snapshot tar is unexpectedly empty");
+        // A valid (even empty) tar is >= 512 bytes (one zeroed record block).
+        assert!(
+            tar.len() >= 512,
+            "snapshot tar too small to be a valid archive: {} bytes",
+            tar.len()
+        );
+        println!(
+            "[captured] {} tar bytes read back from helper VM",
+            tar.len()
+        );
+        tar.len()
+    };
+
+    let _ = manager.stop();
+    println!("helper VM stopped; captured {} bytes", outcome);
+}


### PR DESCRIPTION
Node-side machine snapshot capture and restore that streams a stopped image-machine's container overlay to and from a tar via a short-lived helper VM, completing the engine half of cloud snapshot durability and fork.
