### PR TITLE
feat(network): per-VM egress byte counter on virtio-net device

### DIFF
--- a/crates/smolvm-network/src/device.rs
+++ b/crates/smolvm-network/src/device.rs
@@ -132,6 +132,10 @@ impl phy::Device for VirtioNetworkDevice {
         // smoltcp asks for the next ingress frame only after the poll loop has
         // already staged it. If nothing is staged, there is nothing to receive.
         let frame = self.staged_guest_frame.take()?;
+        // This is the single point where a guest-outbound frame is accepted into
+        // the stack (frames the poll loop dropped never reach here), so it's the
+        // natural place to meter egress. Count the full ethernet frame.
+        self.queues.add_egress_bytes(frame.len() as u64);
         Some((DeviceRxToken { frame }, DeviceTxToken { device: self }))
     }
 
@@ -195,5 +199,45 @@ impl<'a> phy::TxToken for DeviceTxToken<'a> {
             tracing::debug!("dropping outbound ethernet frame because the guest queue is full");
         }
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::queues::DEFAULT_FRAME_QUEUE_CAPACITY;
+    use smoltcp::phy::{Device, RxToken};
+
+    #[test]
+    fn receive_counts_guest_outbound_bytes_as_egress() {
+        let queues = NetworkFrameQueues::shared(DEFAULT_FRAME_QUEUE_CAPACITY);
+        let mut dev = VirtioNetworkDevice::new(queues.clone(), 1500);
+        assert_eq!(queues.egress_bytes(), 0, "starts at zero");
+
+        // A guest frame must be staged before smoltcp's receive() can take it.
+        queues.guest_to_host.push(vec![0u8; 100]).unwrap();
+        assert!(dev.stage_next_frame().is_some());
+        let (rx, _tx) = dev.receive(Instant::ZERO).expect("frame available");
+        rx.consume(|f| assert_eq!(f.len(), 100));
+        assert_eq!(queues.egress_bytes(), 100, "one frame metered");
+
+        // A second frame accumulates.
+        queues.guest_to_host.push(vec![0u8; 40]).unwrap();
+        assert!(dev.stage_next_frame().is_some());
+        let (rx, _tx) = dev.receive(Instant::ZERO).expect("frame available");
+        rx.consume(|_| {});
+        assert_eq!(queues.egress_bytes(), 140, "cumulative");
+    }
+
+    #[test]
+    fn dropped_staged_frame_is_not_metered() {
+        let queues = NetworkFrameQueues::shared(DEFAULT_FRAME_QUEUE_CAPACITY);
+        let mut dev = VirtioNetworkDevice::new(queues.clone(), 1500);
+        queues.guest_to_host.push(vec![0u8; 100]).unwrap();
+        assert!(dev.stage_next_frame().is_some());
+        // The poll loop drops frames it won't forward (e.g. unsupported UDP);
+        // those never reach the stack, so they must not bill egress.
+        dev.drop_staged_frame();
+        assert_eq!(queues.egress_bytes(), 0, "dropped frame not metered");
     }
 }

--- a/crates/smolvm-network/src/lib.rs
+++ b/crates/smolvm-network/src/lib.rs
@@ -287,6 +287,23 @@ pub fn start_virtio_network(
     })
 }
 
+impl VirtioNetworkRuntime {
+    /// Cumulative guest-outbound (egress) bytes on this NIC since boot, at the
+    /// ethernet-frame level. The launcher polls this to surface per-machine
+    /// egress to the node API for billing. TSI VMs have no virtio runtime, so
+    /// egress is unavailable for them (a documented metering gap).
+    pub fn egress_bytes(&self) -> u64 {
+        self.queues.egress_bytes()
+    }
+
+    /// A cheap, cloneable read handle to this NIC's egress counter, so the
+    /// launcher can spawn a thread that periodically flushes the value to the
+    /// VM's runtime dir for the node API to read (the runtime is not `Clone`).
+    pub fn egress_counter(&self) -> std::sync::Arc<std::sync::atomic::AtomicU64> {
+        self.queues.egress_counter()
+    }
+}
+
 impl Drop for VirtioNetworkRuntime {
     /// Shut down the worker threads in a bounded, cooperative way.
     ///

--- a/crates/smolvm-network/src/queues.rs
+++ b/crates/smolvm-network/src/queues.rs
@@ -52,7 +52,7 @@
 
 use crossbeam_queue::ArrayQueue;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -84,6 +84,12 @@ pub struct NetworkFrameQueues {
     pub relay_wake: WakePipe,
     /// Signals that the helper process should shut down.
     shutting_down: AtomicBool,
+    /// Cumulative guest-outbound (egress) bytes for this NIC since boot, at the
+    /// ethernet-frame level — every guest frame accepted into the stack is
+    /// counted. Used for per-machine egress billing/telemetry. Held behind an
+    /// `Arc` so the runtime owner can hand a cheap read handle to a flush thread
+    /// without exposing the rest of the queue set.
+    egress_bytes: Arc<AtomicU64>,
 }
 
 impl NetworkFrameQueues {
@@ -96,7 +102,25 @@ impl NetworkFrameQueues {
             host_wake: WakePipe::new(),
             relay_wake: WakePipe::new(),
             shutting_down: AtomicBool::new(false),
+            egress_bytes: Arc::new(AtomicU64::new(0)),
         })
+    }
+
+    /// Add `n` guest-outbound bytes to the egress counter. Relaxed ordering is
+    /// fine: the counter is a monotonic statistic, not a synchronization point.
+    pub fn add_egress_bytes(&self, n: u64) {
+        self.egress_bytes.fetch_add(n, Ordering::Relaxed);
+    }
+
+    /// Cumulative guest-outbound bytes for this NIC since boot.
+    pub fn egress_bytes(&self) -> u64 {
+        self.egress_bytes.load(Ordering::Relaxed)
+    }
+
+    /// A cheap, cloneable read handle to the egress counter, for a flush thread
+    /// owned by the launcher (the runtime itself is not `Clone`).
+    pub fn egress_counter(&self) -> Arc<AtomicU64> {
+        self.egress_bytes.clone()
     }
 
     /// Mark the runtime as shutting down and wake all waiters.

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -271,6 +271,11 @@ pub struct LaunchConfig<'a> {
     /// libkrun. This keeps the egress allow-list accurate for long-running VMs
     /// hitting CDN-backed hosts whose IPs rotate.
     pub egress_refresh_hosts: Option<Vec<String>>,
+    /// Where to flush this VM's cumulative egress byte count (virtio-net only).
+    /// A background thread writes it here every few seconds; serve reads it to
+    /// surface `egressBytes` in the machine info, the same per-VM-dir bridge the
+    /// vsock/console paths use. `None` disables egress telemetry (e.g. TSI).
+    pub egress_telemetry: Option<&'a Path>,
 }
 
 /// Launch the agent VM using libkrun.
@@ -305,6 +310,7 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
         extra_disks,
         dns_filter_enabled,
         egress_refresh_hosts,
+        egress_telemetry,
     } = config;
 
     crate::network::validate_requested_network_backend(resources, None, port_mappings.len())?;
@@ -630,6 +636,14 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
                     ));
                 }
 
+                // Flush this NIC's egress counter to the per-VM dir so serve can
+                // bill it (parity with how disk size reaches the node API).
+                if let Some(path) = egress_telemetry {
+                    crate::agent::manager::spawn_egress_flush(
+                        path.to_path_buf(),
+                        runtime.egress_counter(),
+                    );
+                }
                 virtio_network_runtime = Some(runtime);
 
                 tracing::info!("network backend: virtio-net");

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -209,6 +209,51 @@ pub fn machine_layers_cache_dir(name: &str) -> PathBuf {
     vm_data_dir(name).join("pack")
 }
 
+/// Per-VM egress telemetry file: `<vm_data_dir>/egress`. The launcher (running
+/// in the VM subprocess) periodically writes the NIC's cumulative egress byte
+/// count here; serve (the parent) reads it when building `MachineInfo`, so
+/// egress reaches the node API through the same per-VM dir that already bridges
+/// sockets and console between the two processes. Resolved from the name on both
+/// sides, so no path needs to be threaded across the process boundary.
+pub fn egress_telemetry_file(name: &str) -> PathBuf {
+    vm_data_dir(name).join("egress")
+}
+
+/// How often the VM subprocess flushes its egress counter to disk. The control
+/// plane's egress rollup runs on a multi-minute cadence, so a value this small
+/// keeps the file comfortably fresh while writing only a few bytes.
+const EGRESS_FLUSH_SECS: u64 = 15;
+
+/// Spawn a detached thread (in the VM subprocess) that periodically writes the
+/// NIC's cumulative egress byte count to the per-VM telemetry file. serve reads
+/// that file when building `MachineInfo`, so egress reaches the node API the
+/// same way disk size does. The thread exits when the subprocess does; the last
+/// value persists in the file even after exit, so a stopped machine's final
+/// egress is still readable. Best-effort: a write error never affects the VM.
+pub fn spawn_egress_flush(
+    path: std::path::PathBuf,
+    counter: std::sync::Arc<std::sync::atomic::AtomicU64>,
+) {
+    std::thread::spawn(move || loop {
+        let bytes = counter.load(std::sync::atomic::Ordering::Relaxed);
+        if let Err(e) = std::fs::write(&path, bytes.to_string()) {
+            tracing::debug!(path = ?path, error = %e, "egress telemetry flush failed");
+        }
+        std::thread::sleep(std::time::Duration::from_secs(EGRESS_FLUSH_SECS));
+    });
+}
+
+/// Read the per-VM egress telemetry file written by [`spawn_egress_flush`].
+/// Returns `None` if the file is absent (TSI VM, or not yet flushed) or
+/// unparseable — egress is simply unavailable for that machine.
+pub fn read_egress_telemetry(name: &str) -> Option<u64> {
+    std::fs::read_to_string(egress_telemetry_file(name))
+        .ok()?
+        .trim()
+        .parse()
+        .ok()
+}
+
 /// Cache root: `<cache_dir>/smolvm/vms/`.
 pub fn vm_cache_root() -> PathBuf {
     dirs::cache_dir()

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -25,7 +25,8 @@ pub use launcher::{
 };
 pub use manager::{
     docker_config_dir, docker_config_mount, ensure_vm_dir, machine_layers_cache_dir,
-    resolve_disk_image, vm_cache_root, vm_data_dir, vm_dir_hash, AgentManager, AgentState,
+    read_egress_telemetry, resolve_disk_image, vm_cache_root, vm_data_dir, vm_dir_hash,
+    AgentManager, AgentState,
 };
 
 /// Agent VM name.

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -106,6 +106,10 @@ fn record_to_info(name: &str, record: &VmRecord) -> MachineInfo {
         // when unset.
         storage_gb: Some(record.storage_gb.unwrap_or(DEFAULT_STORAGE_SIZE_GIB)),
         overlay_gb: Some(record.overlay_gb.unwrap_or(DEFAULT_OVERLAY_SIZE_GIB)),
+        // Cumulative egress, read from the per-VM telemetry file the subprocess
+        // flushes. Surfaced here so the control plane reads it from the machine
+        // list exactly like disk size — no bespoke endpoint.
+        egress_bytes: crate::agent::read_egress_telemetry(name),
         created_at: record.created_at,
     }
 }

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -1093,6 +1093,7 @@ pub fn machine_entry_to_info(name: String, entry: &MachineEntry) -> MachineInfo 
     } else {
         "stopped"
     };
+    let egress_bytes = crate::agent::read_egress_telemetry(&name);
 
     MachineInfo {
         name,
@@ -1117,6 +1118,7 @@ pub fn machine_entry_to_info(name: String, entry: &MachineEntry) -> MachineInfo 
         allowed_cidrs: entry.resources.allowed_cidrs.clone(),
         storage_gb: entry.resources.storage_gb,
         overlay_gb: entry.resources.overlay_gb,
+        egress_bytes,
         created_at: 0,
     }
 }

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -519,6 +519,13 @@ pub struct MachineInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(example = 2)]
     pub overlay_gb: Option<u64>,
+    /// Cumulative guest-outbound (egress) bytes since boot, for billing. Present
+    /// only for virtio-net machines that have reported a value; omitted for TSI
+    /// or machines that haven't flushed yet. Surfaced the same way `storage_gb`
+    /// is, so the control plane reads both from the machine list.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = 1048576)]
+    pub egress_bytes: Option<u64>,
     /// Creation timestamp (seconds since Unix epoch).
     pub created_at: u64,
 }

--- a/src/cli/internal_boot.rs
+++ b/src/cli/internal_boot.rs
@@ -353,11 +353,17 @@ pub fn run(config_path: PathBuf) -> smolvm::Result<()> {
 
     proc_timing!("ready to launch");
 
+    // Egress telemetry lands in the per-VM dir (the vsock socket's parent), the
+    // same dir serve resolves from the machine name — so no name needs threading
+    // across the process boundary.
+    let egress_telemetry_path = config.vsock_socket.parent().map(|dir| dir.join("egress"));
+
     let result = launch_agent_vm(&LaunchConfig {
         rootfs_path: &config.rootfs_path,
         disks: &disks,
         vsock_socket: &config.vsock_socket,
         console_log: config.console_log.as_deref(),
+        egress_telemetry: egress_telemetry_path.as_deref(),
         mounts: &config.mounts,
         port_mappings: &config.ports,
         resources: config.resources,


### PR DESCRIPTION
First increment of per-VM egress metering (for the networking-by-GB billing dimension). Counts guest-outbound bytes at the one chokepoint where a frame enters the stack.

- `NetworkFrameQueues` gains an `AtomicU64` egress counter + `add_egress_bytes`/`egress_bytes` (shared across the device, bridge, and runtime handle).
- `VirtioNetworkDevice::receive()` meters each guest-outbound ethernet frame — frames the poll loop drops (unsupported UDP etc.) never reach here, so they aren't billed.
- `VirtioNetworkRuntime::egress_bytes()` exposes the cumulative count to the launcher.
- Tests: cumulative metering through `receive()`; dropped staged frames not metered.

In fleet mode (`SMOLVM_PUBLISH_ADDR` set) ALL machines route through virtio-net, so this covers 100% of hosted-fleet egress with no libkrun change. Remaining (separate PRs): launcher polls the counter → writes to the VM runtime dir (child→serve IPC, since serve has no app-level telemetry channel); serve surfaces `egressBytes` in MachineInfo; driver flips `egress_metering: true`. Control plane is already wired end-to-end.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/426">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->