### PR TITLE
feat(api): report consumed active CPU seconds per machine in MachineInfo

### DIFF
--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -110,6 +110,13 @@ fn record_to_info(name: &str, record: &VmRecord) -> MachineInfo {
         // flushes. Surfaced here so the control plane reads it from the machine
         // list exactly like disk size — no bespoke endpoint.
         egress_bytes: crate::agent::read_egress_telemetry(name),
+        // Live consumed CPU-seconds for the VMM child, sampled from the host
+        // (user+system CPU time). Resets on restart — the control plane treats it
+        // as a monotonic-with-resets counter and accumulates the durable total.
+        // `None` when stopped (pid cleared) or the process vanished mid-sample.
+        cpu_seconds: pid
+            .and_then(crate::process::process_stats)
+            .map(|s| s.cpu_time_ns / 1_000_000_000),
         created_at: record.created_at,
     }
 }

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -1094,6 +1094,14 @@ pub fn machine_entry_to_info(name: String, entry: &MachineEntry) -> MachineInfo 
         "stopped"
     };
     let egress_bytes = crate::agent::read_egress_telemetry(&name);
+    // Live consumed CPU-seconds for the VMM child (host-sampled, resets on
+    // restart); the control plane accumulates the durable total. None when there
+    // is no live process to sample.
+    let cpu_seconds = entry
+        .manager
+        .child_pid()
+        .and_then(crate::process::process_stats)
+        .map(|s| s.cpu_time_ns / 1_000_000_000);
 
     MachineInfo {
         name,
@@ -1119,6 +1127,7 @@ pub fn machine_entry_to_info(name: String, entry: &MachineEntry) -> MachineInfo 
         storage_gb: entry.resources.storage_gb,
         overlay_gb: entry.resources.overlay_gb,
         egress_bytes,
+        cpu_seconds,
         created_at: 0,
     }
 }

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -526,6 +526,13 @@ pub struct MachineInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(example = 1048576)]
     pub egress_bytes: Option<u64>,
+    /// Consumed CPU-seconds (user+system) of the machine's CURRENT VMM process,
+    /// sampled live from the host. Resets to 0 on a VM restart — it's a stateless
+    /// snapshot; the control plane accumulates a durable total from it. Omitted
+    /// for stopped machines (no live process to sample).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = 42)]
+    pub cpu_seconds: Option<u64>,
     /// Creation timestamp (seconds since Unix epoch).
     pub created_at: u64,
 }


### PR DESCRIPTION
Surfaces each machine's consumed active CPU seconds (user+system time of the current VMM process) on `MachineInfo.cpuSeconds`.