### PR TITLE
feat(api): report per-machine resident memory (rss_mb) in MachineInfo

### DIFF
--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -117,6 +117,11 @@ fn record_to_info(name: &str, record: &VmRecord) -> MachineInfo {
         cpu_seconds: pid
             .and_then(crate::process::process_stats)
             .map(|s| s.cpu_time_ns / 1_000_000_000),
+        // Current RSS (MiB) of the VMM process — an instantaneous gauge the
+        // control plane integrates over time for active-memory billing.
+        rss_mb: pid
+            .and_then(crate::process::process_stats)
+            .map(|s| s.rss_bytes / (1024 * 1024)),
         created_at: record.created_at,
     }
 }

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -1097,11 +1097,12 @@ pub fn machine_entry_to_info(name: String, entry: &MachineEntry) -> MachineInfo 
     // Live consumed CPU-seconds for the VMM child (host-sampled, resets on
     // restart); the control plane accumulates the durable total. None when there
     // is no live process to sample.
-    let cpu_seconds = entry
+    let stats = entry
         .manager
         .child_pid()
-        .and_then(crate::process::process_stats)
-        .map(|s| s.cpu_time_ns / 1_000_000_000);
+        .and_then(crate::process::process_stats);
+    let cpu_seconds = stats.map(|s| s.cpu_time_ns / 1_000_000_000);
+    let rss_mb = stats.map(|s| s.rss_bytes / (1024 * 1024));
 
     MachineInfo {
         name,
@@ -1128,6 +1129,7 @@ pub fn machine_entry_to_info(name: String, entry: &MachineEntry) -> MachineInfo 
         overlay_gb: entry.resources.overlay_gb,
         egress_bytes,
         cpu_seconds,
+        rss_mb,
         created_at: 0,
     }
 }

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -533,6 +533,13 @@ pub struct MachineInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(example = 42)]
     pub cpu_seconds: Option<u64>,
+    /// Current resident memory (RSS) of the machine's VMM process, in MiB, sampled
+    /// live from the host. Unlike CPU this is an instantaneous gauge (not a
+    /// counter); the control plane integrates it over time for active-memory
+    /// billing. Omitted for stopped machines (no live process to sample).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = 128)]
+    pub rss_mb: Option<u64>,
     /// Creation timestamp (seconds since Unix epoch).
     pub created_at: u64,
 }


### PR DESCRIPTION
Surfaces each machine's current resident memory (RSS, in MiB) of its VMM process on `MachineInfo.rss_mb`.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/430">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->