### PR TITLE
feat(api): report cpuMillis for sub-second CPU telemetry

### DIFF
--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -117,6 +117,11 @@ fn record_to_info(name: &str, record: &VmRecord) -> MachineInfo {
         cpu_seconds: pid
             .and_then(crate::process::process_stats)
             .map(|s| s.cpu_time_ns / 1_000_000_000),
+        // Same consumed CPU in milliseconds — sub-second precision so consumers
+        // don't quantize a barely-busy process up to a whole second.
+        cpu_millis: pid
+            .and_then(crate::process::process_stats)
+            .map(|s| s.cpu_time_ns / 1_000_000),
         // Current RSS (MiB) of the VMM process — an instantaneous gauge the
         // control plane integrates over time for active-memory billing.
         rss_mb: pid

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -1102,6 +1102,7 @@ pub fn machine_entry_to_info(name: String, entry: &MachineEntry) -> MachineInfo 
         .child_pid()
         .and_then(crate::process::process_stats);
     let cpu_seconds = stats.map(|s| s.cpu_time_ns / 1_000_000_000);
+    let cpu_millis = stats.map(|s| s.cpu_time_ns / 1_000_000);
     let rss_mb = stats.map(|s| s.rss_bytes / (1024 * 1024));
 
     MachineInfo {
@@ -1129,6 +1130,7 @@ pub fn machine_entry_to_info(name: String, entry: &MachineEntry) -> MachineInfo 
         overlay_gb: entry.resources.overlay_gb,
         egress_bytes,
         cpu_seconds,
+        cpu_millis,
         rss_mb,
         created_at: 0,
     }

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -533,6 +533,13 @@ pub struct MachineInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(example = 42)]
     pub cpu_seconds: Option<u64>,
+    /// Same consumed CPU but in MILLISECONDS — sub-second precision so consumers
+    /// integrating this don't quantize a barely-busy process up to a whole second.
+    /// Derived from the same nanosecond sample as `cpu_seconds`. Omitted for
+    /// stopped machines (no live process to sample).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = 42830)]
+    pub cpu_millis: Option<u64>,
     /// Current resident memory (RSS) of the machine's VMM process, in MiB, sampled
     /// live from the host. Unlike CPU this is an instantaneous gauge (not a
     /// counter); the control plane integrates it over time for active-memory


### PR DESCRIPTION
Adds a millisecond-precision `cpuMillis` field to MachineInfo alongside `cpuSeconds`, derived from the same nanosecond sample, so consumers don't quantize a barely-busy process up to a whole second.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/431">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->