### PR TITLE
feat(api): report diskUsedMb (actual used disk)

### DIFF
--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -181,6 +181,43 @@ pub fn vm_data_dir(name: &str) -> PathBuf {
     vm_cache_root().join(vm_dir_hash(name))
 }
 
+/// Actual host disk consumed by a machine's data dir, in MiB. Sums *real blocks*
+/// (`st_blocks × 512`), not apparent file lengths — the disk images are sparse, so
+/// a 20 GiB image that the guest has barely written to consumes only a few MiB.
+/// This is the gauge the control integrates over time for active-disk billing.
+/// `None` if the dir can't be read (machine gone / not yet created).
+#[cfg(target_os = "linux")]
+pub fn disk_used_mb(name: &str) -> Option<u64> {
+    use std::os::unix::fs::MetadataExt;
+    fn walk_blocks(dir: &Path) -> u64 {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return 0;
+        };
+        let mut total = 0u64;
+        for entry in entries.flatten() {
+            let Ok(meta) = entry.metadata() else { continue };
+            if meta.is_dir() {
+                total = total.saturating_add(walk_blocks(&entry.path()));
+            } else {
+                // st_blocks is in 512-byte units regardless of the fs block size.
+                total = total.saturating_add(meta.blocks().saturating_mul(512));
+            }
+        }
+        total
+    }
+    let dir = vm_data_dir(name);
+    if !dir.exists() {
+        return None;
+    }
+    Some(walk_blocks(&dir) / (1024 * 1024))
+}
+
+/// macOS host has no VMs (dev stub) — no disk to measure.
+#[cfg(not(target_os = "linux"))]
+pub fn disk_used_mb(_name: &str) -> Option<u64> {
+    None
+}
+
 /// Resolve the on-disk image for a `.raw` disk filename in `dir`. A fork clone
 /// has a `.qcow2` copy-on-write overlay in place of the raw disk, so prefer that
 /// when present; otherwise fall back to the raw disk. The file on disk is the

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -24,7 +24,7 @@ pub use launcher::{
     LaunchFeatures, VmDisks,
 };
 pub use manager::{
-    docker_config_dir, docker_config_mount, ensure_vm_dir, machine_layers_cache_dir,
+    disk_used_mb, docker_config_dir, docker_config_mount, ensure_vm_dir, machine_layers_cache_dir,
     read_egress_telemetry, resolve_disk_image, vm_cache_root, vm_data_dir, vm_dir_hash,
     AgentManager, AgentState,
 };

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -127,6 +127,9 @@ fn record_to_info(name: &str, record: &VmRecord) -> MachineInfo {
         rss_mb: pid
             .and_then(crate::process::process_stats)
             .map(|s| s.rss_bytes / (1024 * 1024)),
+        // Actual used disk (sparse-image blocks) — a gauge for active-disk billing,
+        // measured from the data dir regardless of whether the VMM is running.
+        disk_used_mb: crate::agent::disk_used_mb(name),
         created_at: record.created_at,
     }
 }

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -1104,6 +1104,9 @@ pub fn machine_entry_to_info(name: String, entry: &MachineEntry) -> MachineInfo 
     let cpu_seconds = stats.map(|s| s.cpu_time_ns / 1_000_000_000);
     let cpu_millis = stats.map(|s| s.cpu_time_ns / 1_000_000);
     let rss_mb = stats.map(|s| s.rss_bytes / (1024 * 1024));
+    // Actual used disk (sparse-image blocks) — a gauge the control integrates for
+    // active-disk billing. Independent of whether there's a live VMM process.
+    let disk_used_mb = crate::agent::disk_used_mb(&name);
 
     MachineInfo {
         name,
@@ -1132,6 +1135,7 @@ pub fn machine_entry_to_info(name: String, entry: &MachineEntry) -> MachineInfo 
         cpu_seconds,
         cpu_millis,
         rss_mb,
+        disk_used_mb,
         created_at: 0,
     }
 }

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -547,6 +547,13 @@ pub struct MachineInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(example = 128)]
     pub rss_mb: Option<u64>,
+    /// Actual host disk consumed by this machine's data dir, in MiB (real blocks of
+    /// the sparse disk images, not provisioned capacity). An instantaneous gauge the
+    /// control integrates over time for active-disk billing. Omitted when the data
+    /// dir can't be read.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = 256)]
+    pub disk_used_mb: Option<u64>,
     /// Creation timestamp (seconds since Unix epoch).
     pub created_at: u64,
 }


### PR DESCRIPTION
Adds a `diskUsedMb` gauge to MachineInfo measuring the real host blocks a machine's sparse disk images consume, so consumers can meter actual disk use instead of provisioned capacity.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/432">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->