### PR TITLE
feat(image): make max image-archive size overridable (closes #438)

### DIFF
--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -293,6 +293,13 @@ pub struct RunCmd {
     #[arg(short = 'I', long, value_name = "IMAGE", value_parser = parse_image)]
     pub image: Option<String>,
 
+    /// Raise the max accepted local image-archive size (e.g. 16GiB, 512M, or a
+    /// raw byte count); default 8GiB. For legitimately large images — sets
+    /// SMOLVM_MAX_IMAGE_BYTES for this run.
+    #[arg(long = "max-image-size", value_name = "SIZE",
+          value_parser = crate::cli::parsers::parse_size_bytes, help_heading = "Execution")]
+    pub max_image_size: Option<u64>,
+
     /// Run a packed `.smolmachine` artifact ephemerally (the VM is discarded on
     /// exit) — the one-shot equivalent of `machine create --from … + start`.
     /// CPU/memory fall back to the artifact's baked manifest unless overridden.
@@ -458,6 +465,12 @@ pub struct RunCmd {
 impl RunCmd {
     pub fn run(self) -> smolvm::Result<()> {
         use smolvm::Error;
+
+        // --max-image-size raises the archive cap for this invocation by setting
+        // the env var the resolver reads (image_source::max_archive_bytes).
+        if let Some(bytes) = self.max_image_size {
+            std::env::set_var("SMOLVM_MAX_IMAGE_BYTES", bytes.to_string());
+        }
 
         // `--from`: run a packed .smolmachine artifact ephemerally, reusing the
         // proven pack-run path. Resource flags fall back to the artifact's baked
@@ -1585,6 +1598,13 @@ pub struct CreateCmd {
     #[arg(short = 'I', long, value_name = "IMAGE", value_parser = parse_image)]
     pub image: Option<String>,
 
+    /// Raise the max accepted local image-archive size (e.g. 16GiB, 512M, or a
+    /// raw byte count); default 8GiB. For legitimately large images — sets
+    /// SMOLVM_MAX_IMAGE_BYTES for this run.
+    #[arg(long = "max-image-size", value_name = "SIZE",
+          value_parser = crate::cli::parsers::parse_size_bytes)]
+    pub max_image_size: Option<u64>,
+
     /// Number of virtual CPUs
     #[arg(long, default_value_t = DEFAULT_MICROVM_CPU_COUNT, value_name = "N")]
     pub cpus: u8,
@@ -1691,6 +1711,11 @@ pub struct CreateCmd {
 
 impl CreateCmd {
     pub fn run(self) -> smolvm::Result<()> {
+        // --max-image-size raises the archive cap for this invocation by setting
+        // the env var the resolver reads (image_source::max_archive_bytes).
+        if let Some(bytes) = self.max_image_size {
+            std::env::set_var("SMOLVM_MAX_IMAGE_BYTES", bytes.to_string());
+        }
         // Branch for --from: create machine from .smolmachine artifact.
         if let Some(ref sidecar_path) = self.from {
             return self.run_from_smolmachine(sidecar_path);

--- a/src/cli/parsers.rs
+++ b/src/cli/parsers.rs
@@ -27,6 +27,41 @@ pub fn parse_gpu_vram_mib(s: &str) -> Result<u32, String> {
     Ok(v)
 }
 
+/// Parse a byte size like `16GiB`, `16G`, `512M`, or a plain byte count
+/// (`17179869184`). Suffixes are binary (1K = 1024); `K/M/G/T`, optionally with
+/// a trailing `i` and/or `B`, are accepted case-insensitively. Used for
+/// `--max-image-size`.
+pub fn parse_size_bytes(s: &str) -> Result<u64, String> {
+    let t = s.trim();
+    if t.is_empty() {
+        return Err("size must not be empty".to_string());
+    }
+    let split = t
+        .find(|c: char| !c.is_ascii_digit() && c != '.')
+        .unwrap_or(t.len());
+    let (num, unit) = t.split_at(split);
+    let value: f64 = num
+        .parse()
+        .map_err(|_| format!("'{s}' is not a valid size (expected a number, optional K/M/G/T)"))?;
+    let mult: u64 = match unit.trim().to_ascii_lowercase().as_str() {
+        "" | "b" => 1,
+        "k" | "ki" | "kib" | "kb" => 1 << 10,
+        "m" | "mi" | "mib" | "mb" => 1 << 20,
+        "g" | "gi" | "gib" | "gb" => 1 << 30,
+        "t" | "ti" | "tib" | "tb" => 1u64 << 40,
+        other => {
+            return Err(format!(
+                "invalid size unit '{other}' in '{s}' (use K, M, G, or T)"
+            ))
+        }
+    };
+    let bytes = (value * mult as f64) as u64;
+    if bytes == 0 {
+        return Err(format!("size '{s}' must be greater than zero"));
+    }
+    Ok(bytes)
+}
+
 /// Parse and validate an image reference. Rejects empty/whitespace-only
 /// values at CLI parse time so `--image ""` errors immediately instead of
 /// creating an unusable machine that only fails once the VM starts.
@@ -238,5 +273,22 @@ mod tests {
         let from_record =
             record_mounts_to_runconfig_bindings(&[("/tmp".to_string(), "/app".to_string(), true)]);
         assert_eq!(from_parsed, from_record);
+    }
+
+    #[test]
+    fn parse_size_bytes_units_and_errors() {
+        assert_eq!(parse_size_bytes("1024"), Ok(1024));
+        assert_eq!(parse_size_bytes("16GiB"), Ok(16 * 1024 * 1024 * 1024));
+        assert_eq!(parse_size_bytes("16G"), Ok(16 * 1024 * 1024 * 1024));
+        assert_eq!(parse_size_bytes("512M"), Ok(512 * 1024 * 1024));
+        assert_eq!(parse_size_bytes("2k"), Ok(2048));
+        assert_eq!(
+            parse_size_bytes("1.5G"),
+            Ok(1024 * 1024 * 1024 + 512 * 1024 * 1024)
+        );
+        assert!(parse_size_bytes("").is_err());
+        assert!(parse_size_bytes("0").is_err());
+        assert!(parse_size_bytes("abc").is_err());
+        assert!(parse_size_bytes("10X").is_err());
     }
 }

--- a/src/data/image_source.rs
+++ b/src/data/image_source.rs
@@ -139,9 +139,21 @@ pub enum ResolvedImage {
 }
 
 /// Largest archive accepted. The staged copy plus the guest's flattened rootfs
-/// both consume disk, so this guards against runaway/hostile inputs while still
-/// covering very large dev images.
-const MAX_ARCHIVE_BYTES: u64 = 8 * 1024 * 1024 * 1024;
+/// both consume disk, so the default guards against runaway/hostile inputs while
+/// still covering very large dev images.
+///
+/// Override with `SMOLVM_MAX_IMAGE_BYTES` (in bytes), or per-invocation with the
+/// `--max-image-size` flag on `machine run`/`machine create` (which sets that
+/// env var). A legitimate large image is a valid reason to raise it; the cap
+/// only exists to bound disk use for untrusted inputs.
+pub fn max_archive_bytes() -> u64 {
+    const DEFAULT: u64 = 8 * 1024 * 1024 * 1024;
+    std::env::var("SMOLVM_MAX_IMAGE_BYTES")
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(DEFAULT)
+}
 /// Streaming hash/copy buffer.
 const COPY_CHUNK: usize = 1 << 20;
 /// Filename the staged archive is stored under inside its cache dir.
@@ -220,7 +232,7 @@ fn stage_from_file(path: &Path, cache_base: &Path) -> Result<String> {
             ),
         ));
     }
-    if meta.len() > MAX_ARCHIVE_BYTES {
+    if meta.len() > max_archive_bytes() {
         return Err(too_large(meta.len()));
     }
     let hash = hash_file(path)?;
@@ -246,7 +258,7 @@ fn stage_from_stdin(cache_base: &Path) -> Result<String> {
             break;
         }
         total += n as u64;
-        if total > MAX_ARCHIVE_BYTES {
+        if total > max_archive_bytes() {
             return Err(too_large(total));
         }
         hasher.update(&buf[..n]);
@@ -316,9 +328,14 @@ fn archive_cache_base() -> Result<PathBuf> {
 }
 
 fn too_large(bytes: u64) -> Error {
+    let limit = max_archive_bytes();
     Error::config(
         "--image",
-        format!("image archive is {bytes} bytes, over the {MAX_ARCHIVE_BYTES}-byte limit"),
+        format!(
+            "image archive is {bytes} bytes, over the {limit}-byte limit. \
+             Raise it with --max-image-size (e.g. --max-image-size 16GiB) or the \
+             SMOLVM_MAX_IMAGE_BYTES env var if this is a legitimate large image."
+        ),
     )
 }
 


### PR DESCRIPTION
The 8 GiB local-archive cap was hardcoded; make it overridable for legitimate large images via the SMOLVM_MAX_IMAGE_BYTES env var and a --max-image-size flag (16GiB / 512M / raw bytes) on machine run and create, with the over-limit error pointing at both. Closes #438.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/440">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->