### PR TITLE
fix(vm-pack): VM-mode --from packs work end-to-end (export + import)

### DIFF
--- a/src/agent/boot_config.rs
+++ b/src/agent/boot_config.rs
@@ -8,6 +8,7 @@
 //!
 //! This module defines the serializable config passed to that subprocess.
 
+use crate::data::disk::DiskFormat;
 use crate::data::network::PortMapping;
 use crate::data::resources::VmResources;
 use crate::data::storage::HostMount;
@@ -52,7 +53,8 @@ pub struct BootConfig {
     /// Pre-extracted OCI layers directory for .smolmachine-sourced machines.
     #[serde(default)]
     pub packed_layers_dir: Option<PathBuf>,
-    /// Additional disk images to attach (path, read_only).
+    /// Additional disk images to attach (path, read_only, format). The format
+    /// lets the `pack --from-vm` exporter attach a source qcow2 disk read-only.
     #[serde(default)]
-    pub extra_disks: Vec<(PathBuf, bool)>,
+    pub extra_disks: Vec<(PathBuf, bool, DiskFormat)>,
 }

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -161,9 +161,9 @@ pub struct LaunchFeatures {
     /// When set, the launcher mounts this directory via virtiofs so the agent
     /// can use pre-extracted layers instead of pulling from a registry.
     pub packed_layers_dir: Option<std::path::PathBuf>,
-    /// Additional disk images to attach to the VM (path, read_only).
+    /// Additional disk images to attach to the VM (path, read_only, format).
     /// Appear as /dev/vdc, /dev/vdd, ... after the storage and overlay disks.
-    pub extra_disks: Vec<(std::path::PathBuf, bool)>,
+    pub extra_disks: Vec<(std::path::PathBuf, bool, DiskFormat)>,
 }
 
 impl LaunchFeatures {
@@ -260,8 +260,8 @@ pub struct LaunchConfig<'a> {
     /// Pre-extracted OCI layers directory for .smolmachine-sourced machines.
     /// Mounted via virtiofs as "smolvm_layers" so the agent uses packed layers.
     pub packed_layers_dir: Option<&'a Path>,
-    /// Additional disk images (path, read_only). Appear as /dev/vdc, /dev/vdd, ...
-    pub extra_disks: &'a [(std::path::PathBuf, bool)],
+    /// Additional disk images (path, read_only, format). Appear as /dev/vdc, /dev/vdd, ...
+    pub extra_disks: &'a [(std::path::PathBuf, bool, DiskFormat)],
     /// Whether DNS filtering was configured for this launch, even if the
     /// host-side proxy socket could not be created.
     pub dns_filter_enabled: bool,
@@ -703,7 +703,7 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
 
         // Add extra disks (e.g., source VM storage for --from-vm export)
         // These appear as /dev/vdc, /dev/vdd, ... after storage and overlay
-        for (i, (disk_path, read_only)) in extra_disks.iter().enumerate() {
+        for (i, (disk_path, read_only, format)) in extra_disks.iter().enumerate() {
             let block_id_str = format!("extra{}", i);
             let block_id = try_or_free_ctx!(
                 CString::new(block_id_str.as_str()),
@@ -715,7 +715,14 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
                 "add extra disk",
                 "path contains null byte"
             );
-            if krun_add_disk2(ctx, block_id.as_ptr(), path.as_ptr(), 0, *read_only) < 0 {
+            if krun_add_disk2(
+                ctx,
+                block_id.as_ptr(),
+                path.as_ptr(),
+                format.to_krun_u32(),
+                *read_only,
+            ) < 0
+            {
                 krun_free_ctx(ctx);
                 return Err(Error::agent(
                     "add extra disk",

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -220,6 +220,24 @@ fn shutdown_machine_process(name: &str, pid: Option<i32>, pid_start_time: Option
     true
 }
 
+/// Disks to restore for a VM-mode (`--from-vm`) pack. Unlike an image pack (OCI
+/// layers), a VM-mode `.smolmachine` carries the source VM's overlay + storage
+/// DISKS — the actual rootfs (`/bin/sh`, files written before packing). They must
+/// be seeded onto the new machine's disks or it boots with only the bare
+/// agent-rootfs. `pack run` does this; the API create path must too.
+struct VmModeSeed {
+    overlay_template: Option<String>,
+    storage_template: Option<String>,
+    /// Original (pre-truncation) virtual size of the overlay disk. The packed
+    /// template has its trailing zero extent stripped, so the disk must be
+    /// ftruncated back to this before boot or it isn't a valid full filesystem.
+    overlay_logical_size: Option<u64>,
+    /// Requested disk sizes (GiB) from the create request, honored as a lower
+    /// bound on the seeded disks (the guest grows the inherited fs with resize2fs).
+    storage_gb: Option<u64>,
+    overlay_gb: Option<u64>,
+}
+
 /// Create a new machine.
 #[utoipa::path(
     post,
@@ -298,6 +316,7 @@ pub async fn create_machine(
         manifest_mem,
         manifest_net,
         manifest_secret_refs,
+        vm_seed,
     ) = if let Some(ref sidecar_path) = req.from {
         let path = std::path::Path::new(sidecar_path);
         if !path.exists() {
@@ -337,8 +356,41 @@ pub async fn create_machine(
                 },
             )?;
         }
+        // VM-mode packs carry disks, not layers — capture the templates so the
+        // machine's overlay/storage disks can be seeded from them below.
+        let vm_seed = if manifest.mode == smolvm_pack::format::PackMode::Vm {
+            Some(VmModeSeed {
+                overlay_template: manifest
+                    .assets
+                    .overlay_template
+                    .as_ref()
+                    .map(|t| t.path.clone()),
+                storage_template: manifest
+                    .assets
+                    .storage_template
+                    .as_ref()
+                    .map(|t| t.path.clone()),
+                overlay_logical_size: manifest.assets.overlay_logical_size,
+                storage_gb: req.storage_gb,
+                overlay_gb: req.overlay_gb,
+            })
+        } else {
+            None
+        };
+        // A VM-mode pack is NOT a container/image machine: its `image` is the
+        // synthetic `vm://<name>` label, not a pullable ref. `record.image.is_some()`
+        // is the universal "container machine" signal (exec routing, workload
+        // launch, pull-on-start, re-pack), so storing the vm:// label would make
+        // exec run `crun` over a nonexistent image instead of `vm_exec` in the VM
+        // (the /bin/sh-not-found bug). Store None so every consumer treats it as a
+        // VM; provenance lives in `source_smolmachine`.
+        let image = if vm_seed.is_some() {
+            None
+        } else {
+            Some(manifest.image)
+        };
         (
-            Some(manifest.image),
+            image,
             Some(canonical),
             manifest.entrypoint,
             manifest.cmd,
@@ -348,6 +400,7 @@ pub async fn create_machine(
             manifest.mem,
             manifest.network,
             manifest.secret_refs,
+            vm_seed,
         )
     } else {
         (
@@ -361,6 +414,7 @@ pub async fn create_machine(
             crate::data::resources::DEFAULT_MICROVM_MEMORY_MIB,
             req.network,
             Default::default(),
+            None,
         )
     };
 
@@ -438,6 +492,42 @@ pub async fn create_machine(
         })
         .await
         .map_err(|e| ApiError::internal(format!("task error: {}", e)))??;
+    }
+
+    // VM-mode pack: seed this machine's overlay + storage disks from the packed
+    // templates (extracted above) so a start boots the source VM's rootfs rather
+    // than the bare agent-rootfs (the /bin/sh-missing bug). `open_or_create_at`
+    // reuses an existing disk, so seeding once at create persists across starts.
+    // Mirrors `pack_run`'s VM-mode disk restore (`setup_vm_overlay` +
+    // `create_or_copy_storage_disk`).
+    if let Some(seed) = vm_seed {
+        let name2 = name.clone();
+        let disk_dir = manager
+            .storage_path()
+            .parent()
+            .map(std::path::Path::to_path_buf)
+            .unwrap_or_else(|| vm_data_dir(&name));
+        let seed_result = tokio::task::spawn_blocking(move || -> Result<(), ApiError> {
+            let cache_dir = crate::agent::machine_layers_cache_dir(&name2);
+            crate::storage::seed_vm_mode_disks(
+                &disk_dir,
+                &cache_dir,
+                seed.overlay_template.as_deref(),
+                seed.storage_template.as_deref(),
+                seed.overlay_logical_size,
+                seed.overlay_gb,
+                seed.storage_gb,
+            )
+            .map_err(|e| ApiError::internal(format!("seed VM-mode disks: {}", e)))
+        })
+        .await
+        .map_err(|e| ApiError::internal(format!("task error: {}", e)))?;
+        // On failure roll back the data dir the manager created, so a retry starts
+        // clean (the reservation guard releases the name but leaves the dir).
+        if let Err(e) = seed_result {
+            let _ = std::fs::remove_dir_all(vm_data_dir(&name));
+            return Err(e);
+        }
     }
 
     let resources = ResourceSpec {

--- a/src/cli/internal_boot.rs
+++ b/src/cli/internal_boot.rs
@@ -221,7 +221,7 @@ pub fn run(config_path: PathBuf) -> smolvm::Result<()> {
         if let Some(parent) = config.ssh_agent_socket.as_ref().and_then(|s| s.parent()) {
             read_write.push(parent.to_path_buf());
         }
-        for (path, read_only) in &config.extra_disks {
+        for (path, read_only, _format) in &config.extra_disks {
             if *read_only {
                 read_exec.push(path.clone());
             } else {

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -1836,6 +1836,30 @@ impl CreateCmd {
         let footer = smolvm_pack::packer::read_footer_from_sidecar(sidecar_path)
             .map_err(|e| smolvm::Error::agent("read sidecar footer", e.to_string()))?;
 
+        // A VM-mode pack (`--from-vm`) carries the source VM's overlay+storage
+        // DISKS (the real rootfs), not OCI layers. Capture the templates before
+        // `manifest` is moved into `params`; the disks are seeded from them after
+        // extraction below, or the machine boots the bare agent-rootfs with no
+        // /bin/sh (mirrors pack_run + the serve API create path).
+        let vm_seed: Option<(Option<String>, Option<String>, Option<u64>)> =
+            if manifest.mode == smolvm_pack::format::PackMode::Vm {
+                Some((
+                    manifest
+                        .assets
+                        .overlay_template
+                        .as_ref()
+                        .map(|t| t.path.clone()),
+                    manifest
+                        .assets
+                        .storage_template
+                        .as_ref()
+                        .map(|t| t.path.clone()),
+                    manifest.assets.overlay_logical_size,
+                ))
+            } else {
+                None
+            };
+
         // Resolve the canonical path for storage in VmRecord.
         let canonical_path = sidecar_path
             .canonicalize()
@@ -1882,7 +1906,15 @@ impl CreateCmd {
         let params = vm_common::CreateVmParams {
             secret_refs: manifest.secret_refs,
             name,
-            image: Some(manifest.image),
+            // A VM-mode pack is a VM, not a container: its synthetic `vm://<name>`
+            // label would make exec/start/re-pack treat it as a pullable image
+            // (the /bin/sh-not-found bug). None routes every `image.is_some()`
+            // consumer to VM behavior; provenance is in `source_smolmachine`.
+            image: if vm_seed.is_some() {
+                None
+            } else {
+                Some(manifest.image)
+            },
             entrypoint: manifest.entrypoint,
             cmd: manifest.cmd,
             cpus,
@@ -1923,7 +1955,7 @@ impl CreateCmd {
         // extract before publishing the VM row. Other processes either see the
         // reservation conflict or the finished VM, never a half-created record.
         let create_result = (|| -> smolvm::Result<()> {
-            let _manager = AgentManager::for_vm_with_sizes(
+            let manager = AgentManager::for_vm_with_sizes(
                 &name_for_layers,
                 params.storage_gb,
                 params.overlay_gb,
@@ -1956,6 +1988,32 @@ impl CreateCmd {
             // and failure paths to honor the "mounted iff running" invariant.
             smolvm_pack::extract::force_detach_layers_volume(&cache_dir);
             result?;
+
+            // VM-mode pack: seed this machine's overlay+storage disks from the
+            // packed templates so a start boots the source VM's rootfs rather than
+            // the bare agent-rootfs. Shared with the serve API create path: it
+            // resizes the truncated templates into valid raw disks and removes the
+            // manager's default `.qcow2` overlays so the start resolves these.
+            // (Writing the resized copy onto `manager.overlay_path()` — the default
+            // `.qcow2` — handed the guest raw bytes named `.qcow2`, the /bin/sh-missing
+            // bug's disk counterpart.)
+            if let Some((overlay_template, storage_template, overlay_logical_size)) = &vm_seed {
+                let disk_dir = manager
+                    .storage_path()
+                    .parent()
+                    .map(std::path::Path::to_path_buf)
+                    .unwrap_or_else(|| smolvm::agent::vm_data_dir(&name_for_layers));
+                smolvm::storage::seed_vm_mode_disks(
+                    &disk_dir,
+                    &cache_dir,
+                    overlay_template.as_deref(),
+                    storage_template.as_deref(),
+                    *overlay_logical_size,
+                    params.overlay_gb,
+                    params.storage_gb,
+                )
+                .map_err(|e| smolvm::Error::agent("seed VM-mode disks", e.to_string()))?;
+            }
 
             reservation.commit(&record)?;
             Ok(())

--- a/src/cli/pack.rs
+++ b/src/cli/pack.rs
@@ -8,8 +8,10 @@
 //! - Configuration manifest
 
 use clap::{Args, Subcommand};
-use smolvm::agent::{AgentClient, AgentManager, VmResources};
+use smolvm::agent::{resolve_disk_image, AgentClient, AgentManager, VmResources};
+use smolvm::data::disk::DiskFormat;
 use smolvm::data::resources::DEFAULT_MICROVM_CPU_COUNT;
+use smolvm::storage::{OVERLAY_DISK_FILENAME, STORAGE_DISK_FILENAME};
 
 /// Default memory for packed VMs. Same as machine create — memory is elastic
 /// via virtio balloon, so the host only commits what the guest actually uses.
@@ -23,7 +25,7 @@ use smolvm_pack::format::{PackManifest, PackMode};
 use smolvm_pack::packer::Packer;
 use smolvm_pack::signing::sign_with_hypervisor_entitlements;
 use smolvm_protocol::AgentResponse;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tracing::{debug, info, warn};
 
 /// Package and run self-contained VM executables.
@@ -509,14 +511,20 @@ impl PackCreateCmd {
             ));
         }
 
-        // 2. Locate overlay disk
-        let overlay_path = smolvm::agent::vm_data_dir(&vm_name).join("overlay.raw");
-        if !overlay_path.exists() {
+        // 2. Locate the VM's disks. Default-size machines on Linux get qcow2 CoW
+        // overlays (overlay.qcow2 / storage.qcow2), not `.raw`, so resolve whichever
+        // format exists rather than hardcoding `.raw`. The overlay template is only
+        // consumed by VM-mode (bare) restores — container restores ignore it — so it
+        // is required only for non-image VMs.
+        let vm_dir = smolvm::agent::vm_data_dir(&vm_name);
+        let (overlay_disk, overlay_fmt) = resolve_disk_image(&vm_dir, OVERLAY_DISK_FILENAME);
+        let is_image_based = vm.image.is_some();
+        if !is_image_based && !overlay_disk.exists() {
             return Err(Error::agent(
                 "pack from VM",
                 format!(
                     "overlay disk not found at {}. The VM may not have been started yet.",
-                    overlay_path.display()
+                    overlay_disk.display()
                 ),
             ));
         }
@@ -533,14 +541,15 @@ impl PackCreateCmd {
         let mut collector = AssetCollector::new(staging_dir.clone())
             .map_err(|e| Error::agent("collect assets", e.to_string()))?;
 
-        let is_image_based = vm.image.is_some();
-
         // 4. For image-based VMs, export OCI layers + container overlay via temp VM.
         // The container overlay (installed packages) lives inside the VM's ext4
         // storage disk which can't be read on macOS — a temp VM mounts it for us.
         if is_image_based {
             let image = vm.image.clone().unwrap();
-            let storage_path = smolvm::agent::vm_data_dir(&vm_name).join("storage.raw");
+            // Attach the source storage disk with its real on-disk format so a
+            // qcow2 (default-size) disk is presented correctly and mounts in the
+            // temp VM — hardcoding raw would hand libkrun qcow2 bytes as raw.
+            let (storage_disk, storage_fmt) = resolve_disk_image(&vm_dir, STORAGE_DISK_FILENAME);
 
             self.collect_base_assets(&mut collector)?;
 
@@ -562,7 +571,7 @@ impl PackCreateCmd {
             println!("Starting agent VM to export layers...");
             let manager = AgentManager::for_vm(&pack_vm_name)?;
             let features = smolvm::agent::LaunchFeatures {
-                extra_disks: vec![(storage_path.clone(), false)],
+                extra_disks: vec![(storage_disk.clone(), false, storage_fmt)],
                 ..Default::default()
             };
             manager.start_with_full_config(
@@ -705,11 +714,25 @@ impl PackCreateCmd {
             self.collect_base_assets(&mut collector)?;
         }
 
-        // Add overlay template from VM (bare VM rootfs state)
-        println!("Copying overlay disk ({})...", overlay_path.display());
-        collector
-            .add_overlay_template(&overlay_path)
-            .map_err(|e| Error::agent("collect overlay", e.to_string()))?;
+        // Add the overlay template (the VM's rootfs state). VM-mode restores boot
+        // from it; container restores ignore it entirely (every import path gates
+        // `overlay_template` on `PackMode::Vm`), so skip it for image-based VMs
+        // rather than flatten a qcow2 for nothing. A default-size overlay is a qcow2
+        // CoW image, which must be flattened to a raw before it can be a template.
+        if !is_image_based {
+            let overlay_for_pack = match overlay_fmt {
+                DiskFormat::Raw => overlay_disk.clone(),
+                DiskFormat::Qcow2 => {
+                    let flat = temp_dir.path().join("overlay-flat.raw");
+                    self.flatten_qcow2_to_raw(&overlay_disk, &flat)?;
+                    flat
+                }
+            };
+            println!("Copying overlay disk ({})...", overlay_for_pack.display());
+            collector
+                .add_overlay_template(&overlay_for_pack)
+                .map_err(|e| Error::agent("collect overlay", e.to_string()))?;
+        }
 
         // 5. Resolve Smolfile overrides if provided
         //    Precedence: CLI > [artifact] > Smolfile top-level > VmRecord > default
@@ -791,6 +814,98 @@ impl PackCreateCmd {
         }
 
         self.finalize_pack(manifest, collector, staging_dir)
+    }
+
+    /// Flatten a qcow2 CoW overlay into a standalone raw disk image.
+    ///
+    /// Default-size machines use a qcow2 overlay backed by the install's default
+    /// template, but a pack's overlay template must be a flat raw. There is no
+    /// host-side qcow2 reader (smolvm deliberately takes no qemu-img dependency),
+    /// so the conversion runs inside a throwaway agent VM: the source qcow2 is
+    /// attached read-only (libkrun resolves its backing chain) as `/dev/vdc`
+    /// alongside a fresh raw output as `/dev/vdd`, and the guest `dd`s one into the
+    /// other. `add_overlay_template` then strips trailing zeros so a mostly-empty
+    /// overlay still packs small, and extraction re-sparsifies it on import.
+    fn flatten_qcow2_to_raw(&self, qcow2_path: &Path, dest_raw: &Path) -> smolvm::Result<()> {
+        let virtual_size = read_qcow2_virtual_size(qcow2_path)?;
+        {
+            let f = std::fs::File::create(dest_raw)
+                .map_err(|e| Error::agent("create flatten target", e.to_string()))?;
+            f.set_len(virtual_size)
+                .map_err(|e| Error::agent("size flatten target", e.to_string()))?;
+        }
+
+        let flatten_vm_name = format!(
+            "pack-flatten-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        );
+        let vm_data = smolvm::agent::vm_data_dir(&flatten_vm_name);
+        println!("Flattening qcow2 overlay to raw...");
+        let manager = AgentManager::for_vm(&flatten_vm_name)?;
+        let features = smolvm::agent::LaunchFeatures {
+            // vdc = source qcow2 (read-only), vdd = fresh raw output.
+            extra_disks: vec![
+                (qcow2_path.to_path_buf(), true, DiskFormat::Qcow2),
+                (dest_raw.to_path_buf(), false, DiskFormat::Raw),
+            ],
+            ..Default::default()
+        };
+        manager.start_with_full_config(
+            Vec::new(),
+            Vec::new(),
+            VmResources {
+                cpus: 2,
+                memory_mib: 2048,
+                network: false,
+                network_backend: None,
+                gpu: false,
+                gpu_vram_mib: None,
+                storage_gib: None,
+                overlay_gib: None,
+                allowed_cidrs: None,
+            },
+            features,
+        )?;
+
+        let result: smolvm::Result<()> = (|| {
+            let mut client = manager.connect()?;
+            let (exit_code, _, stderr) = client.vm_exec(
+                vec![
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    // busybox dd lacks GNU `conv=sparse`, so do a plain full copy
+                    // and `sync`. The output is dense on the temp disk, but
+                    // `add_overlay_template` strips trailing zeros so the pack stays
+                    // small; the imported overlay is re-sparsified on extraction.
+                    "dd if=/dev/vdc of=/dev/vdd bs=1M && sync".to_string(),
+                ],
+                vec![],
+                None,
+                None,
+                None,
+            )?;
+            if exit_code != 0 {
+                return Err(Error::agent(
+                    "flatten qcow2 overlay",
+                    format!(
+                        "dd failed (exit {}): {}",
+                        exit_code,
+                        String::from_utf8_lossy(&stderr)
+                    ),
+                ));
+            }
+            Ok(())
+        })();
+
+        if let Err(e) = manager.stop() {
+            warn!(error = %e, "failed to stop pack flatten VM");
+        }
+        let _ = std::fs::remove_dir_all(&vm_data);
+        result
     }
 
     /// Collect base assets shared by both image and VM packing modes:
@@ -1654,6 +1769,29 @@ fn fmt_bytes(bytes: u64) -> String {
     } else {
         format!("{} MB", bytes / (1024 * 1024))
     }
+}
+
+/// Read a qcow2 image's virtual (guest-visible) size from its header — the
+/// big-endian `u64` at byte offset 24, per the qcow2 spec. Lets the flatten path
+/// size its raw output correctly without a qcow2 library.
+fn read_qcow2_virtual_size(path: &Path) -> smolvm::Result<u64> {
+    use std::io::{Read, Seek, SeekFrom};
+    let mut f = std::fs::File::open(path).map_err(|e| Error::agent("open qcow2", e.to_string()))?;
+    let mut magic = [0u8; 4];
+    f.read_exact(&mut magic)
+        .map_err(|e| Error::agent("read qcow2 magic", e.to_string()))?;
+    if &magic != b"QFI\xfb" {
+        return Err(Error::agent(
+            "read qcow2",
+            format!("{} is not a qcow2 image (bad magic)", path.display()),
+        ));
+    }
+    f.seek(SeekFrom::Start(24))
+        .map_err(|e| Error::agent("seek qcow2 size", e.to_string()))?;
+    let mut buf = [0u8; 8];
+    f.read_exact(&mut buf)
+        .map_err(|e| Error::agent("read qcow2 size", e.to_string()))?;
+    Ok(u64::from_be_bytes(buf))
 }
 
 /// A simple terminal spinner that prints a rotating character every 200ms.

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -27,6 +27,66 @@ use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
 
+/// Seed a VM-mode machine's overlay+storage disks from extracted pack templates so
+/// it boots the source VM's filesystem rather than a freshly-mkfs'd empty overlay.
+///
+/// VM-mode (`--from-vm`) packs carry the source VM's rootfs DISKS, but the packed
+/// template has its trailing zero extent stripped — it is NOT a usable disk until
+/// [`smolvm_pack::extract::copy_overlay_template`] ftruncates it back to
+/// `overlay_logical_size`. The caller's [`AgentManager`] has already created default
+/// `.qcow2` overlays backed by the EMPTY default template; this removes them and
+/// writes the resized RAW disks under their place so [`resolve_disk_image`] picks
+/// these at start. A `.formatted` marker stops the host from reformatting the
+/// inherited (already-formatted) filesystem; the guest still grows it with resize2fs.
+///
+/// `disk_dir` is the machine's data dir (the parent of `manager.storage_path()`).
+/// Shared by both the serve API create path and the `smolvm machine create --from`
+/// CLI path so a VM-mode pack restores identically through either entry point.
+///
+/// [`AgentManager`]: crate::agent::AgentManager
+/// [`resolve_disk_image`]: crate::agent::manager::resolve_disk_image
+pub fn seed_vm_mode_disks(
+    disk_dir: &Path,
+    cache_dir: &Path,
+    overlay_template: Option<&str>,
+    storage_template: Option<&str>,
+    overlay_logical_size: Option<u64>,
+    overlay_gb: Option<u64>,
+    storage_gb: Option<u64>,
+) -> std::io::Result<()> {
+    // Drop the manager's default qcow2 overlays (backed by the empty default
+    // template) so the resized raw disks below are what start resolves.
+    for raw_filename in [STORAGE_DISK_FILENAME, OVERLAY_DISK_FILENAME] {
+        let stem = Path::new(raw_filename);
+        let _ = std::fs::remove_file(disk_dir.join(stem.with_extension("qcow2")));
+    }
+
+    // Resize the packed templates into valid raw disks, exactly like `pack_run`'s
+    // `setup_vm_overlay`. The overlay template is ftruncated back to its logical
+    // size; the storage template is copied (or an empty disk created) verbatim.
+    smolvm_pack::extract::copy_overlay_template(
+        cache_dir,
+        overlay_template,
+        &disk_dir.join(OVERLAY_DISK_FILENAME),
+        overlay_gb,
+        overlay_logical_size,
+    )?;
+    smolvm_pack::extract::create_or_copy_storage_disk(
+        cache_dir,
+        storage_template,
+        &disk_dir.join(STORAGE_DISK_FILENAME),
+        storage_gb,
+    )?;
+
+    // The copied disks carry the source VM's already-formatted ext4; mark them so
+    // neither host nor guest reformats (the guest still grows them with resize2fs).
+    for raw_filename in [STORAGE_DISK_FILENAME, OVERLAY_DISK_FILENAME] {
+        let stem = Path::new(raw_filename);
+        std::fs::write(disk_dir.join(stem.with_extension("formatted")), b"")?;
+    }
+    Ok(())
+}
+
 /// Disk format version info (stored at `/.smolvm/version.json` in ext4 disk).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DiskVersion {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -31,13 +31,17 @@ use std::path::{Path, PathBuf};
 /// it boots the source VM's filesystem rather than a freshly-mkfs'd empty overlay.
 ///
 /// VM-mode (`--from-vm`) packs carry the source VM's rootfs DISKS, but the packed
-/// template has its trailing zero extent stripped — it is NOT a usable disk until
-/// [`smolvm_pack::extract::copy_overlay_template`] ftruncates it back to
-/// `overlay_logical_size`. The caller's [`AgentManager`] has already created default
-/// `.qcow2` overlays backed by the EMPTY default template; this removes them and
-/// writes the resized RAW disks under their place so [`resolve_disk_image`] picks
+/// template has its trailing zero extent stripped, so the disk must be grown back to
+/// its logical size before boot. The caller's [`AgentManager`] has already created
+/// default `.qcow2` overlays backed by the EMPTY default template; this removes them
+/// and writes the seeded RAW disks under their place so [`resolve_disk_image`] picks
 /// these at start. A `.formatted` marker stops the host from reformatting the
 /// inherited (already-formatted) filesystem; the guest still grows it with resize2fs.
+///
+/// The template → disk copy uses [`crate::disk_utils::clone_or_copy_file`] (clonefile
+/// CoW on macOS, `SEEK_HOLE` sparse copy on Linux), NOT a dense `fs::copy`: the
+/// templates are sparse (~25 MiB of real data in a multi-GiB logical file), so a dense
+/// copy would balloon every machine to its full logical size (~28 GiB) on disk.
 ///
 /// `disk_dir` is the machine's data dir (the parent of `manager.storage_path()`).
 /// Shared by both the serve API create path and the `smolvm machine create --from`
@@ -55,36 +59,105 @@ pub fn seed_vm_mode_disks(
     storage_gb: Option<u64>,
 ) -> std::io::Result<()> {
     // Drop the manager's default qcow2 overlays (backed by the empty default
-    // template) so the resized raw disks below are what start resolves.
+    // template) so the seeded raw disks below are what start resolves.
     for raw_filename in [STORAGE_DISK_FILENAME, OVERLAY_DISK_FILENAME] {
         let stem = Path::new(raw_filename);
         let _ = std::fs::remove_file(disk_dir.join(stem.with_extension("qcow2")));
     }
 
-    // Resize the packed templates into valid raw disks, exactly like `pack_run`'s
-    // `setup_vm_overlay`. The overlay template is ftruncated back to its logical
-    // size; the storage template is copied (or an empty disk created) verbatim.
-    smolvm_pack::extract::copy_overlay_template(
+    // The overlay carries the rootfs and is grown back to its (pre-truncation)
+    // logical size; storage to the requested size. Both VM-mode templates are
+    // normally present, but tolerate a missing one with an empty disk.
+    seed_one_disk(
         cache_dir,
         overlay_template,
         &disk_dir.join(OVERLAY_DISK_FILENAME),
-        overlay_gb,
         overlay_logical_size,
+        overlay_gb,
     )?;
-    smolvm_pack::extract::create_or_copy_storage_disk(
+    seed_one_disk(
         cache_dir,
         storage_template,
         &disk_dir.join(STORAGE_DISK_FILENAME),
+        None,
         storage_gb,
     )?;
-
-    // The copied disks carry the source VM's already-formatted ext4; mark them so
-    // neither host nor guest reformats (the guest still grows them with resize2fs).
-    for raw_filename in [STORAGE_DISK_FILENAME, OVERLAY_DISK_FILENAME] {
-        let stem = Path::new(raw_filename);
-        std::fs::write(disk_dir.join(stem.with_extension("formatted")), b"")?;
-    }
     Ok(())
+}
+
+/// Sparse-copy one packed template into `dest`, grow it to the largest of its copied
+/// size / the source's logical size / any requested size, and mark it formatted
+/// (the copy carries the source's ext4; the guest grows it with resize2fs). With no
+/// template, write an empty sparse disk for the guest to format (no formatted marker).
+fn seed_one_disk(
+    cache_dir: &Path,
+    template: Option<&str>,
+    dest: &Path,
+    logical_size: Option<u64>,
+    size_gb_override: Option<u64>,
+) -> std::io::Result<()> {
+    let _ = std::fs::remove_file(dest);
+    let formatted_marker = dest.with_extension("formatted");
+
+    let Some(rel) = template else {
+        // No template (rare for VM mode): an empty sparse disk the guest formats.
+        let _ = std::fs::remove_file(&formatted_marker);
+        let size = size_gb_override
+            .map(|gb| gb * BYTES_PER_GIB)
+            .unwrap_or(512 * 1024 * 1024);
+        std::fs::File::create(dest)?.set_len(size)?;
+        return Ok(());
+    };
+
+    let src = resolve_template_in_cache(cache_dir, rel)?;
+    if !src.exists() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("VM-mode template not found: {}", src.display()),
+        ));
+    }
+    crate::disk_utils::clone_or_copy_file(&src, dest)
+        .map_err(|e| std::io::Error::other(e.to_string()))?;
+
+    // Grow back to the logical/requested size (set_len extends sparsely; the guest
+    // resize2fs expands the ext4 to fill it at boot).
+    let copied = std::fs::metadata(dest)?.len();
+    let target = [
+        Some(copied),
+        logical_size,
+        size_gb_override.map(|gb| gb * BYTES_PER_GIB),
+    ]
+    .into_iter()
+    .flatten()
+    .max()
+    .unwrap_or(copied);
+    if target > copied {
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(dest)?
+            .set_len(target)?;
+    }
+
+    std::fs::write(&formatted_marker, b"")?;
+    Ok(())
+}
+
+/// Resolve a pack template's relative path within `cache_dir`, rejecting anything
+/// that isn't a plain in-tree path (no `..`, absolute, or other escaping component)
+/// so a hostile pack manifest can't redirect the copy outside the cache.
+fn resolve_template_in_cache(cache_dir: &Path, rel: &str) -> std::io::Result<PathBuf> {
+    let rel_path = Path::new(rel);
+    let safe = !rel.is_empty()
+        && rel_path
+            .components()
+            .all(|c| matches!(c, std::path::Component::Normal(_)));
+    if !safe {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("invalid VM-mode template path: {rel:?}"),
+        ));
+    }
+    Ok(cache_dir.join(rel_path))
 }
 
 /// Disk format version info (stored at `/.smolvm/version.json` in ext4 disk).


### PR DESCRIPTION
Makes `pack --from-vm` → `machine create --from` work for VM-mode snapshots end-to-end: the exporter resolves qcow2 vs raw disks (default-size machines use qcow2) and flattens the overlay to a raw template via a throwaway agent VM; the importer seeds the machine's overlay/storage from the pack templates with a sparse copy and stores `image=None` so exec routes to `vm_exec` instead of crun. Validated on macOS and Linux/KVM: container and bare default-size `--from-vm` round-trip with byte-identical content.