### PR TITLE
fix(vm-pack): reject cross-arch artifacts on create --from + serve

### DIFF
--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -327,6 +327,11 @@ pub async fn create_machine(
         }
         let manifest = smolvm_pack::packer::read_manifest_from_sidecar(path)
             .map_err(|e| ApiError::internal(format!("read .smolmachine: {}", e)))?;
+        // Reject a cross-architecture artifact up front (400, not a mid-boot 500):
+        // a packed VM/image carries native binaries that cannot run under a
+        // different-arch guest kernel. Guest arch must match; host OS need not.
+        crate::platform::ensure_artifact_arch_matches_host(&manifest.platform)
+            .map_err(|e| ApiError::BadRequest(e.to_string()))?;
         // Extraction happens after the agent manager creates this machine's data
         // dir (below), so the layers land in the machine's own dir, not here.
         let canonical = path

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -1830,6 +1830,11 @@ impl CreateCmd {
         let manifest = smolvm_pack::packer::read_manifest_from_sidecar(sidecar_path)
             .map_err(|e| smolvm::Error::agent("read .smolmachine", e.to_string()))?;
 
+        // Reject a cross-architecture artifact up front: a packed VM/image carries
+        // native binaries and cannot boot under a different-arch guest kernel. Only
+        // the guest arch must match — the host OS does not (see the fn's docs).
+        smolvm::platform::ensure_artifact_arch_matches_host(&manifest.platform)?;
+
         // Read the footer now; the bundle is extracted into the machine's own
         // data dir after `create_vm` succeeds (below), so a duplicate-name create
         // cannot clobber an existing machine's layers.

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -207,6 +207,41 @@ pub fn native_platform() -> &'static str {
     CURRENT_PLATFORM.oci_platform()
 }
 
+/// Reject a packed artifact whose guest CPU architecture differs from this host's.
+///
+/// A `.smolmachine` carries architecture-specific native binaries — a VM-mode pack
+/// holds a compiled guest rootfs, an image-mode pack holds per-arch OCI layers — so
+/// an `arm64` artifact cannot run under an `amd64` guest kernel, or vice versa. Used
+/// by `machine create --from` and the serve create handler before they extract or
+/// boot, so the failure is an immediate, actionable message rather than a cryptic
+/// exec-format crash mid-boot.
+///
+/// Unlike the single-file `pack run` path — which additionally requires a matching
+/// host OS because it dlopens the libs bundled *into* the executable — a sidecar
+/// rehydrated via `create --from` boots through the HOST's own libkrun, so only the
+/// guest ARCHITECTURE must match; the host OS (macOS vs Linux) is irrelevant. That
+/// is what lets a VM packed on a Mac rehydrate on a same-arch Linux node.
+///
+/// `artifact_platform` is the manifest's guest platform (e.g. `"linux/arm64"`). A
+/// blank or unrecognized arch is allowed through rather than risk falsely rejecting
+/// an otherwise-valid artifact.
+pub fn ensure_artifact_arch_matches_host(artifact_platform: &str) -> crate::Result<()> {
+    let host_arch = Arch::current().oci_arch();
+    let artifact_arch = artifact_platform.rsplit('/').next().unwrap_or("").trim();
+    if matches!(artifact_arch, "amd64" | "arm64") && artifact_arch != host_arch {
+        return Err(crate::Error::agent(
+            "platform mismatch",
+            format!(
+                "this artifact is built for architecture '{artifact_arch}' (platform \
+                 '{artifact_platform}'), but this host is '{host_arch}'. A packed VM or image \
+                 carries native binaries and cannot run on a different CPU architecture — re-pack \
+                 on an '{artifact_arch}' host, or use an '{host_arch}' artifact."
+            ),
+        ));
+    }
+    Ok(())
+}
+
 /// Get the platform-specific VM executor.
 ///
 /// Returns an executor that handles platform differences in VM execution,
@@ -237,6 +272,24 @@ pub fn rosetta() -> linux::LinuxRosetta {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_artifact_arch_guard() {
+        let host = Arch::current().oci_arch();
+        let other = if host == "amd64" { "arm64" } else { "amd64" };
+
+        // Matching arch (with the linux/ prefix) is accepted.
+        assert!(ensure_artifact_arch_matches_host(&format!("linux/{host}")).is_ok());
+        // Bare arch string also accepted when it matches.
+        assert!(ensure_artifact_arch_matches_host(host).is_ok());
+        // The opposite arch is rejected.
+        assert!(ensure_artifact_arch_matches_host(&format!("linux/{other}")).is_err());
+        // Host OS is irrelevant — only the arch matters (Mac-built pack on Linux).
+        assert!(ensure_artifact_arch_matches_host(&format!("darwin/{host}")).is_ok());
+        // Blank / unrecognized arch is allowed through rather than false-rejected.
+        assert!(ensure_artifact_arch_matches_host("").is_ok());
+        assert!(ensure_artifact_arch_matches_host("linux/riscv64").is_ok());
+    }
 
     #[test]
     fn test_current_platform_is_valid() {


### PR DESCRIPTION
`machine create --from` and the serve create handler now reject a `.smolmachine` whose guest CPU arch differs from the host's (400 on serve) instead of failing mid-boot with an exec-format crash; the check is arch-only since a sidecar boots via the host's libkrun, so a Mac-built pack still rehydrates on a same-arch Linux node. `pack run` keeps its stricter host-OS+arch check (it loads bundled libs).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/443">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->