### PR TITLE
fix(agent): VM-grade container so any image (incl. systemd) boots

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -2004,6 +2004,7 @@ fn handle_request(
             interactive: false,
             tty: false,
             detached: false,
+            unprivileged,
             persistent_overlay_id,
             stdin_data,
             background,
@@ -2017,6 +2018,7 @@ fn handle_request(
                     user.as_deref(),
                     &mounts,
                     persistent_overlay_id.as_deref(),
+                    unprivileged,
                 )
             } else {
                 handle_run(
@@ -2030,6 +2032,7 @@ fn handle_request(
                     persistent_overlay_id.as_deref(),
                     stdin_data.as_deref(),
                     client_fd,
+                    unprivileged,
                 )
             }
         }
@@ -2728,38 +2731,50 @@ fn handle_interactive_run(
     request: AgentRequest,
 ) -> Result<(), Box<dyn std::error::Error>> {
     ensure_storage_mounted();
-    let (image, command, env, workdir, user, mounts, timeout_ms, tty, persistent_overlay_id) =
-        match request {
-            AgentRequest::Run {
-                image,
-                command,
-                env,
-                workdir,
-                user,
-                mounts,
-                timeout_ms,
-                tty,
-                persistent_overlay_id,
-                ..
-            } => (
-                image,
-                command,
-                env,
-                workdir,
-                user,
-                mounts,
-                timeout_ms,
-                tty,
-                persistent_overlay_id,
-            ),
-            _ => {
-                send_response(
-                    stream,
-                    &AgentResponse::error("expected Run request", error_codes::INVALID_REQUEST),
-                )?;
-                return Ok(());
-            }
-        };
+    let (
+        image,
+        command,
+        env,
+        workdir,
+        user,
+        mounts,
+        timeout_ms,
+        tty,
+        persistent_overlay_id,
+        unprivileged,
+    ) = match request {
+        AgentRequest::Run {
+            image,
+            command,
+            env,
+            workdir,
+            user,
+            mounts,
+            timeout_ms,
+            tty,
+            persistent_overlay_id,
+            unprivileged,
+            ..
+        } => (
+            image,
+            command,
+            env,
+            workdir,
+            user,
+            mounts,
+            timeout_ms,
+            tty,
+            persistent_overlay_id,
+            unprivileged,
+        ),
+        _ => {
+            send_response(
+                stream,
+                &AgentResponse::error("expected Run request", error_codes::INVALID_REQUEST),
+            )?;
+            return Ok(());
+        }
+    };
 
     let is_persistent = persistent_overlay_id.is_some();
     info!(image = %image, command = ?command, tty = tty, persistent = is_persistent, "starting interactive run");
@@ -2804,6 +2819,7 @@ fn handle_interactive_run(
         &mounts,
         tty,
         persistent_overlay_id.as_deref(),
+        unprivileged,
     ) {
         Ok(result) => result,
         Err(e) => {
@@ -2881,6 +2897,7 @@ fn resolve_image_command(
 /// duplicating the identity-resolve → spec-build → mount-wiring → write sequence.
 /// The only caller-controlled variation is `tty` (detached: always `false`).
 #[cfg(target_os = "linux")]
+#[allow(clippy::too_many_arguments)]
 fn write_oci_bundle(
     rootfs_path: &std::path::Path,
     bundle_path: &std::path::Path,
@@ -2890,12 +2907,13 @@ fn write_oci_bundle(
     user: Option<&str>,
     mounts: &[(String, String, bool)],
     tty: bool,
+    unprivileged: bool,
 ) -> Result<String, Box<dyn std::error::Error>> {
     use std::path::Path;
 
     let workdir_str = workdir.unwrap_or("/");
     let identity = oci::resolve_process_identity(rootfs_path, user)?;
-    let mut spec = oci::OciSpec::new(command, env, workdir_str, tty, &identity);
+    let mut spec = oci::OciSpec::new(command, env, workdir_str, tty, &identity, unprivileged);
 
     if tty {
         // Give the PTY a non-zero starting size. The host follows up with a
@@ -2948,33 +2966,36 @@ fn handle_run_detached(
 
     ensure_storage_mounted();
 
-    let (image, mut command, env, workdir, user, mounts, persistent_overlay_id) = match request {
-        AgentRequest::Run {
-            image,
-            command,
-            env,
-            workdir,
-            user,
-            mounts,
-            persistent_overlay_id,
-            ..
-        } => (
-            image,
-            command,
-            env,
-            workdir,
-            user,
-            mounts,
-            persistent_overlay_id,
-        ),
-        _ => {
-            send_response(
-                stream,
-                &AgentResponse::error("expected Run request", error_codes::INVALID_REQUEST),
-            )?;
-            return Ok(());
-        }
-    };
+    let (image, mut command, env, workdir, user, mounts, persistent_overlay_id, unprivileged) =
+        match request {
+            AgentRequest::Run {
+                image,
+                command,
+                env,
+                workdir,
+                user,
+                mounts,
+                persistent_overlay_id,
+                unprivileged,
+                ..
+            } => (
+                image,
+                command,
+                env,
+                workdir,
+                user,
+                mounts,
+                persistent_overlay_id,
+                unprivileged,
+            ),
+            _ => {
+                send_response(
+                    stream,
+                    &AgentResponse::error("expected Run request", error_codes::INVALID_REQUEST),
+                )?;
+                return Ok(());
+            }
+        };
 
     // An empty command is allowed here: it means "run the image's own
     // ENTRYPOINT/CMD". We resolve it from the image config below, after the
@@ -3072,6 +3093,7 @@ fn handle_run_detached(
         user.as_deref(),
         &mounts,
         false,
+        unprivileged,
     ) {
         Ok(id) => id,
         Err(e) => {
@@ -3400,6 +3422,7 @@ static CONSOLE_SOCKET_WORKS: std::sync::atomic::AtomicBool =
 /// resize message is silently applied to the wrong terminal. See GH
 /// #156.
 #[cfg(target_os = "linux")]
+#[allow(clippy::too_many_arguments)]
 fn spawn_interactive_command(
     rootfs: &str,
     command: &[String],
@@ -3409,6 +3432,7 @@ fn spawn_interactive_command(
     mounts: &[(String, String, bool)],
     tty: bool,
     persistent_overlay_id: Option<&str>,
+    unprivileged: bool,
 ) -> Result<(Child, Option<pty::PtyMaster>), Box<dyn std::error::Error>> {
     use std::io::Read as _;
     use std::os::unix::io::AsRawFd as _;
@@ -3446,6 +3470,7 @@ fn spawn_interactive_command(
         user,
         mounts,
         tty,
+        unprivileged,
     )?;
 
     // Persist the container ID so subsequent execs join this container.
@@ -3541,6 +3566,7 @@ fn spawn_interactive_command(
 
 /// Non-Linux stub for spawn_interactive_command.
 #[cfg(not(target_os = "linux"))]
+#[allow(clippy::too_many_arguments)]
 fn spawn_interactive_command(
     rootfs: &str,
     command: &[String],
@@ -3550,6 +3576,7 @@ fn spawn_interactive_command(
     mounts: &[(String, String, bool)],
     _tty: bool,
     _persistent_overlay_id: Option<&str>,
+    unprivileged: bool,
 ) -> Result<(Child, Option<()>), Box<dyn std::error::Error>> {
     use std::path::Path;
 
@@ -3569,7 +3596,7 @@ fn spawn_interactive_command(
 
     let workdir_str = workdir.unwrap_or("/");
     let identity = oci::resolve_process_identity(rootfs_path, user)?;
-    let mut spec = oci::OciSpec::new(command, env, workdir_str, false, &identity);
+    let mut spec = oci::OciSpec::new(command, env, workdir_str, false, &identity, unprivileged);
     spec.add_gpu_devices_if_available();
 
     for (tag, container_path, read_only) in mounts {
@@ -4342,6 +4369,7 @@ fn test_tcp_syscall(target: &str) -> serde_json::Value {
 /// would leak because nothing waits for the container to exit to clean it
 /// up. The returned PID is the crun process, which stays alive as long as
 /// the container's init process runs.
+#[allow(clippy::too_many_arguments)]
 fn handle_run_background(
     image: &str,
     command: &[String],
@@ -4350,6 +4378,7 @@ fn handle_run_background(
     user: Option<&str>,
     mounts: &[(String, String, bool)],
     persistent_overlay_id: Option<&str>,
+    unprivileged: bool,
 ) -> AgentResponse {
     info!(image = %image, command = ?command, mounts = ?mounts, "running command in background");
 
@@ -4360,7 +4389,16 @@ fn handle_run_background(
         );
     };
 
-    match storage::spawn_in_overlay(image, command, env, workdir, user, mounts, overlay_id) {
+    match storage::spawn_in_overlay(
+        image,
+        command,
+        env,
+        workdir,
+        user,
+        mounts,
+        overlay_id,
+        unprivileged,
+    ) {
         Ok(pid) => AgentResponse::Completed {
             exit_code: 0,
             stdout: format!("{}", pid).into_bytes(),
@@ -4391,6 +4429,7 @@ fn oversized_output_error(stdout: &[u8], stderr: &[u8]) -> Option<AgentResponse>
     None
 }
 
+#[allow(clippy::too_many_arguments)]
 fn handle_run(
     image: &str,
     command: &[String],
@@ -4402,6 +4441,7 @@ fn handle_run(
     persistent_overlay_id: Option<&str>,
     stdin_data: Option<&str>,
     client_fd: Option<std::os::unix::io::RawFd>,
+    unprivileged: bool,
 ) -> AgentResponse {
     info!(image = %image, command = ?command, mounts = ?mounts, timeout_ms = ?timeout_ms, persistent = persistent_overlay_id.is_some(), stdin = stdin_data.is_some(), "running command");
 
@@ -4416,6 +4456,7 @@ fn handle_run(
         persistent_overlay_id,
         stdin_data,
         client_fd,
+        unprivileged,
     ) {
         Ok(result) => oversized_output_error(&result.stdout, &result.stderr).unwrap_or(
             AgentResponse::Completed {

--- a/crates/smolvm-agent/src/oci.rs
+++ b/crates/smolvm-agent/src/oci.rs
@@ -475,12 +475,15 @@ impl OciSpec {
         }
         env_strings.extend(env.iter().map(|(k, v)| format!("{}={}", k, v)));
 
-        // Default capabilities for root containers
+        // VM-grade capabilities: the microVM is the security boundary, so the
+        // in-VM workload gets a full capability set (see `full_capabilities`). This
+        // is what lets init systems (systemd as PID 1) and tmpfs-mounting workloads
+        // run — the README's "boot any image" promise.
         let capabilities = OciCapabilities {
-            bounding: default_capabilities(),
-            effective: default_capabilities(),
+            bounding: full_capabilities(),
+            effective: full_capabilities(),
             inheritable: vec![],
-            permitted: default_capabilities(),
+            permitted: full_capabilities(),
             ambient: vec![],
         };
 
@@ -804,6 +807,8 @@ pub fn generate_container_id() -> String {
 }
 
 /// Default Linux capabilities for root containers.
+// Retained as the fallback for a future opt-in unprivileged mode (`--unprivileged`).
+#[allow(dead_code)]
 fn default_capabilities() -> Vec<String> {
     vec![
         "CAP_CHOWN".to_string(),
@@ -821,6 +826,62 @@ fn default_capabilities() -> Vec<String> {
         "CAP_KILL".to_string(),
         "CAP_AUDIT_WRITE".to_string(),
     ]
+}
+
+/// Full capability set for a "VM-grade" workload. smolvm runs one workload per
+/// microVM, so the KVM boundary — not the in-VM container — is the security
+/// boundary; dropping capabilities here protects nothing (an escape lands in the
+/// VM's own single-tenant kernel) while breaking legitimate images that expect a
+/// real machine (systemd/OpenRC as PID 1, or anything that mounts a tmpfs). So the
+/// default container is effectively privileged. An opt-in unprivileged mode can
+/// fall back to [`default_capabilities`] for defense-in-depth with untrusted code.
+fn full_capabilities() -> Vec<String> {
+    [
+        "CAP_AUDIT_CONTROL",
+        "CAP_AUDIT_READ",
+        "CAP_AUDIT_WRITE",
+        "CAP_BLOCK_SUSPEND",
+        "CAP_BPF",
+        "CAP_CHECKPOINT_RESTORE",
+        "CAP_CHOWN",
+        "CAP_DAC_OVERRIDE",
+        "CAP_DAC_READ_SEARCH",
+        "CAP_FOWNER",
+        "CAP_FSETID",
+        "CAP_IPC_LOCK",
+        "CAP_IPC_OWNER",
+        "CAP_KILL",
+        "CAP_LEASE",
+        "CAP_LINUX_IMMUTABLE",
+        "CAP_MAC_ADMIN",
+        "CAP_MAC_OVERRIDE",
+        "CAP_MKNOD",
+        "CAP_NET_ADMIN",
+        "CAP_NET_BIND_SERVICE",
+        "CAP_NET_BROADCAST",
+        "CAP_NET_RAW",
+        "CAP_PERFMON",
+        "CAP_SETFCAP",
+        "CAP_SETGID",
+        "CAP_SETPCAP",
+        "CAP_SETUID",
+        "CAP_SYS_ADMIN",
+        "CAP_SYS_BOOT",
+        "CAP_SYS_CHROOT",
+        "CAP_SYS_MODULE",
+        "CAP_SYS_NICE",
+        "CAP_SYS_PACCT",
+        "CAP_SYS_PTRACE",
+        "CAP_SYS_RAWIO",
+        "CAP_SYS_RESOURCE",
+        "CAP_SYS_TIME",
+        "CAP_SYS_TTY_CONFIG",
+        "CAP_SYSLOG",
+        "CAP_WAKE_ALARM",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect()
 }
 
 /// Default device nodes for container execution.
@@ -965,7 +1026,8 @@ fn default_mounts() -> Vec<OciMount> {
                 "ro".to_string(),
             ],
         },
-        // /sys/fs/cgroup - cgroup filesystem (read-only)
+        // /sys/fs/cgroup - cgroup2, writable so an init system (systemd) can manage
+        // its own cgroup subtree. Safe: the VM is the boundary and is single-tenant.
         OciMount {
             destination: "/sys/fs/cgroup".to_string(),
             mount_type: Some("cgroup2".to_string()),
@@ -974,7 +1036,44 @@ fn default_mounts() -> Vec<OciMount> {
                 "nosuid".to_string(),
                 "noexec".to_string(),
                 "nodev".to_string(),
-                "ro".to_string(),
+                "rw".to_string(),
+            ],
+        },
+        // /run, /run/lock, /tmp - tmpfs that init systems and many services expect
+        // to set up at boot. Pre-providing them means the workload doesn't have to
+        // mount them itself (and lets read-only-rootfs images still have writable
+        // runtime dirs).
+        OciMount {
+            destination: "/run".to_string(),
+            mount_type: Some("tmpfs".to_string()),
+            source: "tmpfs".to_string(),
+            options: vec![
+                "nosuid".to_string(),
+                "nodev".to_string(),
+                "mode=0755".to_string(),
+                "size=65536k".to_string(),
+            ],
+        },
+        OciMount {
+            destination: "/run/lock".to_string(),
+            mount_type: Some("tmpfs".to_string()),
+            source: "tmpfs".to_string(),
+            options: vec![
+                "nosuid".to_string(),
+                "nodev".to_string(),
+                "noexec".to_string(),
+                "mode=1777".to_string(),
+                "size=5120k".to_string(),
+            ],
+        },
+        OciMount {
+            destination: "/tmp".to_string(),
+            mount_type: Some("tmpfs".to_string()),
+            source: "tmpfs".to_string(),
+            options: vec![
+                "nosuid".to_string(),
+                "nodev".to_string(),
+                "mode=1777".to_string(),
             ],
         },
     ]

--- a/crates/smolvm-agent/src/oci.rs
+++ b/crates/smolvm-agent/src/oci.rs
@@ -1163,6 +1163,7 @@ mod tests {
             "/",
             false,
             &ProcessIdentity::root(),
+            false,
         );
 
         assert_eq!(spec.oci_version, "1.0.2");
@@ -1181,6 +1182,7 @@ mod tests {
             "/",
             true,
             &ProcessIdentity::root(),
+            false,
         );
         spec.process.console_size = Some(OciConsoleSize {
             height: 24,
@@ -1203,6 +1205,7 @@ mod tests {
             "/",
             true,
             &ProcessIdentity::root(),
+            false,
         );
         let json = serde_json::to_value(&spec).unwrap();
         assert!(
@@ -1221,6 +1224,7 @@ mod tests {
             "/",
             false,
             &ProcessIdentity::root(),
+            false,
         );
         spec.add_bind_mount("/host/path", "/container/path", true);
 
@@ -1324,6 +1328,7 @@ mod tests {
                 },
                 home: Some("/home/steam".to_string()),
             },
+            false,
         );
 
         assert!(spec.process.env.contains(&"HOME=/home/steam".to_string()));
@@ -1351,7 +1356,7 @@ mod tests {
     fn test_gpu_devices_added_when_dri_exists() {
         // On a system with /dev/dri (GPU-enabled VM), a bind mount is added
         let identity = ProcessIdentity::root();
-        let mut spec = OciSpec::new(&["echo".to_string()], &[], "/", false, &identity);
+        let mut spec = OciSpec::new(&["echo".to_string()], &[], "/", false, &identity, false);
         let mounts_before = spec.mounts.len();
         spec.add_gpu_devices_if_available();
 
@@ -1372,7 +1377,7 @@ mod tests {
     #[test]
     fn test_gpu_devices_are_not_added_twice() {
         let identity = ProcessIdentity::root();
-        let mut spec = OciSpec::new(&["echo".to_string()], &[], "/", false, &identity);
+        let mut spec = OciSpec::new(&["echo".to_string()], &[], "/", false, &identity, false);
         spec.mounts.push(super::OciMount {
             destination: "/dev/dri".to_string(),
             mount_type: Some("bind".to_string()),
@@ -1394,7 +1399,7 @@ mod tests {
     #[test]
     fn test_gpu_devices_correct_properties() {
         let identity = ProcessIdentity::root();
-        let mut spec = OciSpec::new(&["echo".to_string()], &[], "/", false, &identity);
+        let mut spec = OciSpec::new(&["echo".to_string()], &[], "/", false, &identity, false);
         // Manually push a GPU bind mount to verify expected properties
         spec.mounts.push(super::OciMount {
             destination: "/dev/dri".to_string(),

--- a/crates/smolvm-agent/src/oci.rs
+++ b/crates/smolvm-agent/src/oci.rs
@@ -462,6 +462,7 @@ impl OciSpec {
         workdir: &str,
         tty: bool,
         identity: &ProcessIdentity,
+        unprivileged: bool,
     ) -> Self {
         // Build environment variables
         let mut env_strings = vec![
@@ -475,15 +476,21 @@ impl OciSpec {
         }
         env_strings.extend(env.iter().map(|(k, v)| format!("{}={}", k, v)));
 
-        // VM-grade capabilities: the microVM is the security boundary, so the
-        // in-VM workload gets a full capability set (see `full_capabilities`). This
-        // is what lets init systems (systemd as PID 1) and tmpfs-mounting workloads
-        // run — the README's "boot any image" promise.
+        // Capabilities. Default is VM-grade (full set): the microVM is the security
+        // boundary, so the in-VM workload runs privileged — that's what lets init
+        // systems (systemd as PID 1) and tmpfs-mounting workloads boot (the "boot
+        // any image" promise). `unprivileged` opts into the restricted set for
+        // defense-in-depth with untrusted code.
+        let caps = if unprivileged {
+            default_capabilities()
+        } else {
+            full_capabilities()
+        };
         let capabilities = OciCapabilities {
-            bounding: full_capabilities(),
-            effective: full_capabilities(),
+            bounding: caps.clone(),
+            effective: caps.clone(),
             inheritable: vec![],
-            permitted: full_capabilities(),
+            permitted: caps,
             ambient: vec![],
         };
 
@@ -548,7 +555,7 @@ impl OciSpec {
                     "/proc/sysrq-trigger".to_string(),
                 ],
             },
-            mounts: default_mounts(),
+            mounts: default_mounts(unprivileged),
             hostname: Some("container".to_string()),
         }
     }
@@ -952,8 +959,8 @@ fn default_devices() -> Vec<OciDevice> {
 }
 
 /// Default mounts for container execution.
-fn default_mounts() -> Vec<OciMount> {
-    vec![
+fn default_mounts(unprivileged: bool) -> Vec<OciMount> {
+    let mut mounts = vec![
         // /proc - process information
         OciMount {
             destination: "/proc".to_string(),
@@ -1026,24 +1033,26 @@ fn default_mounts() -> Vec<OciMount> {
                 "ro".to_string(),
             ],
         },
-        // /sys/fs/cgroup - cgroup2, writable so an init system (systemd) can manage
-        // its own cgroup subtree. Safe: the VM is the boundary and is single-tenant.
-        OciMount {
-            destination: "/sys/fs/cgroup".to_string(),
-            mount_type: Some("cgroup2".to_string()),
-            source: "cgroup".to_string(),
-            options: vec![
-                "nosuid".to_string(),
-                "noexec".to_string(),
-                "nodev".to_string(),
-                "rw".to_string(),
-            ],
-        },
-        // /run, /run/lock, /tmp - tmpfs that init systems and many services expect
-        // to set up at boot. Pre-providing them means the workload doesn't have to
-        // mount them itself (and lets read-only-rootfs images still have writable
-        // runtime dirs).
-        OciMount {
+    ];
+    // /sys/fs/cgroup — cgroup2. Writable by default so an init system (systemd) can
+    // manage its own cgroup subtree; read-only in unprivileged mode.
+    mounts.push(OciMount {
+        destination: "/sys/fs/cgroup".to_string(),
+        mount_type: Some("cgroup2".to_string()),
+        source: "cgroup".to_string(),
+        options: vec![
+            "nosuid".to_string(),
+            "noexec".to_string(),
+            "nodev".to_string(),
+            if unprivileged { "ro" } else { "rw" }.to_string(),
+        ],
+    });
+    if !unprivileged {
+        // tmpfs that init systems and many services set up at boot. Pre-providing
+        // them means the workload doesn't have to mount them itself, and read-only
+        // rootfs images still get writable runtime dirs. Omitted when unprivileged
+        // (the workload can't mount, but also isn't expected to be an init system).
+        mounts.push(OciMount {
             destination: "/run".to_string(),
             mount_type: Some("tmpfs".to_string()),
             source: "tmpfs".to_string(),
@@ -1053,8 +1062,8 @@ fn default_mounts() -> Vec<OciMount> {
                 "mode=0755".to_string(),
                 "size=65536k".to_string(),
             ],
-        },
-        OciMount {
+        });
+        mounts.push(OciMount {
             destination: "/run/lock".to_string(),
             mount_type: Some("tmpfs".to_string()),
             source: "tmpfs".to_string(),
@@ -1065,8 +1074,8 @@ fn default_mounts() -> Vec<OciMount> {
                 "mode=1777".to_string(),
                 "size=5120k".to_string(),
             ],
-        },
-        OciMount {
+        });
+        mounts.push(OciMount {
             destination: "/tmp".to_string(),
             mount_type: Some("tmpfs".to_string()),
             source: "tmpfs".to_string(),
@@ -1075,8 +1084,9 @@ fn default_mounts() -> Vec<OciMount> {
                 "nodev".to_string(),
                 "mode=1777".to_string(),
             ],
-        },
-    ]
+        });
+    }
+    mounts
 }
 
 #[cfg(test)]

--- a/crates/smolvm-agent/src/ssh_agent.rs
+++ b/crates/smolvm-agent/src/ssh_agent.rs
@@ -74,6 +74,7 @@ mod tests {
             "/",
             false,
             &ProcessIdentity::root(),
+            false,
         );
         let mounts_before = spec.mounts.len();
         let envs_before = spec.process.env.len();
@@ -97,6 +98,7 @@ mod tests {
             "/",
             false,
             &ProcessIdentity::root(),
+            false,
         );
 
         inject_into_container_if(&mut spec, true);
@@ -132,6 +134,7 @@ mod tests {
             "/",
             false,
             &ProcessIdentity::root(),
+            false,
         );
         spec.process
             .env

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -2569,6 +2569,7 @@ pub fn run_command(
     persistent_overlay_id: Option<&str>,
     stdin_data: Option<&str>,
     client_fd: Option<std::os::unix::io::RawFd>,
+    unprivileged: bool,
 ) -> Result<RunResult> {
     // Validate inputs
     crate::oci::validate_image_reference(image).map_err(StorageError::new)?;
@@ -2595,7 +2596,7 @@ pub fn run_command(
         let workdir_str = workdir.unwrap_or("/");
         let identity = crate::oci::resolve_process_identity(Path::new(&prepared.rootfs_path), user)
             .map_err(StorageError::new)?;
-        let mut spec = OciSpec::new(command, env, workdir_str, false, &identity);
+        let mut spec = OciSpec::new(command, env, workdir_str, false, &identity, unprivileged);
         spec.add_gpu_devices_if_available();
 
         // Add virtiofs bind mounts to OCI spec
@@ -2669,6 +2670,7 @@ pub fn spawn_in_overlay(
     user: Option<&str>,
     mounts: &[(String, String, bool)],
     persistent_overlay_id: &str,
+    unprivileged: bool,
 ) -> Result<u32> {
     crate::oci::validate_image_reference(image).map_err(StorageError::new)?;
     crate::oci::validate_env_vars(env).map_err(StorageError::new)?;
@@ -2686,7 +2688,7 @@ pub fn spawn_in_overlay(
     let workdir_str = workdir.unwrap_or("/");
     let identity = crate::oci::resolve_process_identity(Path::new(&prepared.rootfs_path), user)
         .map_err(StorageError::new)?;
-    let mut spec = OciSpec::new(command, env, workdir_str, false, &identity);
+    let mut spec = OciSpec::new(command, env, workdir_str, false, &identity, unprivileged);
 
     for (tag, container_path, read_only) in mounts {
         let virtiofs_mount = Path::new(paths::VIRTIOFS_MOUNT_ROOT).join(tag);

--- a/crates/smolvm-protocol/src/lib.rs
+++ b/crates/smolvm-protocol/src/lib.rs
@@ -288,6 +288,13 @@ pub enum AgentRequest {
         /// Returns a `Completed` response with `stdout` containing the container ID.
         #[serde(default)]
         detached: bool,
+        /// Run the workload as an unprivileged container: restricted capabilities,
+        /// read-only cgroup, and no extra tmpfs. The default (false) is "VM-grade"
+        /// — since the microVM is the isolation boundary, the workload gets a full
+        /// capability set and the mounts an init system needs (so any image, incl.
+        /// systemd, boots). Opt in for defense-in-depth when running untrusted code.
+        #[serde(default)]
+        unprivileged: bool,
         /// If set, use a persistent overlay that survives across exec sessions.
         /// The overlay is identified by this ID (typically the machine name)
         /// and reused on subsequent runs. If not set, an ephemeral overlay is

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -162,6 +162,9 @@ pub struct RunConfig {
     /// Data to pipe to the command's stdin (non-interactive runs only). The
     /// pipe is closed after writing so the command sees EOF.
     pub stdin: Option<String>,
+    /// Run as an unprivileged container (restricted caps, ro cgroup, no extra
+    /// tmpfs). Default false = "VM-grade" (the microVM is the boundary).
+    pub unprivileged: bool,
 }
 
 impl RunConfig {
@@ -182,6 +185,7 @@ impl RunConfig {
             tty: false,
             persistent_overlay_id: None,
             stdin: None,
+            unprivileged: false,
         }
     }
 
@@ -230,6 +234,12 @@ impl RunConfig {
     /// Set persistent overlay ID for cross-session filesystem persistence.
     pub fn with_persistent_overlay(mut self, id: Option<String>) -> Self {
         self.persistent_overlay_id = id;
+        self
+    }
+
+    /// Run as an unprivileged container (defense-in-depth for untrusted code).
+    pub fn with_unprivileged(mut self, unprivileged: bool) -> Self {
+        self.unprivileged = unprivileged;
         self
     }
 }
@@ -1139,6 +1149,7 @@ impl AgentClient {
             interactive: false,
             tty: false,
             detached: false,
+            unprivileged: config.unprivileged,
             persistent_overlay_id: config.persistent_overlay_id,
             stdin_data: config.stdin,
             background: false,
@@ -1164,6 +1175,7 @@ impl AgentClient {
             interactive: false,
             tty: false,
             detached: false,
+            unprivileged: config.unprivileged,
             persistent_overlay_id: config.persistent_overlay_id,
             stdin_data: None,
             background: true,
@@ -1205,6 +1217,7 @@ impl AgentClient {
             interactive: true,
             tty: false,
             detached: false,
+            unprivileged: config.unprivileged,
             persistent_overlay_id: config.persistent_overlay_id,
             stdin_data: None,
             background: false,
@@ -1240,6 +1253,7 @@ impl AgentClient {
                 interactive: true,
                 tty,
                 detached: false,
+                unprivileged: config.unprivileged,
                 persistent_overlay_id: config.persistent_overlay_id,
                 stdin_data: None,
                 background: false,
@@ -1275,6 +1289,7 @@ impl AgentClient {
             interactive: false,
             tty: false,
             detached: true,
+            unprivileged: config.unprivileged,
             persistent_overlay_id: config.persistent_overlay_id,
             stdin_data: None,
             background: false,
@@ -1471,6 +1486,7 @@ impl AgentClient {
                 interactive: true,
                 tty,
                 detached: false,
+                unprivileged: config.unprivileged,
                 persistent_overlay_id: config.persistent_overlay_id,
                 stdin_data: None,
                 background: false,

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -469,6 +469,14 @@ pub struct RunCmd {
     #[arg(long, help_heading = "Resources")]
     pub rebuild_init_cache: bool,
 
+    /// Run the workload as an unprivileged container: restricted capabilities,
+    /// read-only cgroup, and no extra tmpfs. By default the workload is "VM-grade"
+    /// (the microVM is the isolation boundary, so it gets full privileges and any
+    /// image — incl. systemd — boots). Use this for defense-in-depth with untrusted
+    /// code. `init` always runs VM-grade (it needs privileges for apt/mounts).
+    #[arg(long, help_heading = "Security")]
+    pub unprivileged: bool,
+
     #[command(flatten, next_help_heading = "Network")]
     pub proxy_opts: crate::cli::proxy_opts::ProxyOpts,
 }
@@ -1191,7 +1199,8 @@ impl RunCmd {
                         .with_workdir(defaults.workdir.clone())
                         .with_user(defaults.user.clone())
                         .with_mounts(mount_bindings.clone())
-                        .with_persistent_overlay(Some(vm_name.clone()));
+                        .with_persistent_overlay(Some(vm_name.clone()))
+                        .with_unprivileged(self.unprivileged);
                     client.run_container_detached(run_config)?;
                 }
 
@@ -1300,7 +1309,8 @@ impl RunCmd {
                         .with_mounts(mount_bindings)
                         .with_timeout(self.timeout)
                         .with_tty(tty)
-                        .with_persistent_overlay(Some(vm_name.clone()));
+                        .with_persistent_overlay(Some(vm_name.clone()))
+                        .with_unprivileged(self.unprivileged);
                     client.run_interactive(config)?
                 } else {
                     let config = RunConfig::new(img, command)
@@ -1309,7 +1319,8 @@ impl RunCmd {
                         .with_user(defaults.user)
                         .with_mounts(mount_bindings)
                         .with_timeout(self.timeout)
-                        .with_persistent_overlay(Some(vm_name.clone()));
+                        .with_persistent_overlay(Some(vm_name.clone()))
+                        .with_unprivileged(self.unprivileged);
                     let (exit_code, stdout, stderr) = client.run_non_interactive(config)?;
                     if !stdout.is_empty() {
                         let _ = std::io::stdout().write_all(&stdout);


### PR DESCRIPTION
Closes #446. The microVM is the security boundary (one workload per VM), so the in-VM workload now runs **VM-grade by default** — full capability set, writable cgroup2, and tmpfs /run+/run/lock+/tmp — which is what lets any image boot, including systemd-as-PID1. Adds a **`--unprivileged`** opt-out (wired CLI → RunConfig → protocol → agent → OciSpec) that restores the restricted caps / read-only cgroup / no-extra-tmpfs for defense-in-depth with untrusted code; init always runs VM-grade. Validated on KVM: jrei/systemd-debian boots to `systemctl is-system-running` = running by default, and `--unprivileged` correctly drops to CAP a80425fb / read-only cgroup / mount-/run-denied.