### PR TITLE
fix(deps): patch quinn-proto DoS (RUSTSEC-2026-0185) + add cargo-audit CI gate

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,13 @@
+# cargo-audit configuration.
+#
+# The advisories below are "unmaintained" notices (not vulnerabilities) for
+# transitive dependencies we don't pull directly and can't drop without a major
+# bump of an upstream crate. They're listed here — with intent — so a real
+# vulnerability is never lost in warning noise. Revisit when upstreams migrate
+# (e.g. rustls-pemfile -> rustls-pki-types).
+[advisories]
+ignore = [
+    "RUSTSEC-2024-0436", # paste — unmaintained (transitive, macro deps)
+    "RUSTSEC-2026-0173", # proc-macro-error2 — unmaintained (transitive)
+    "RUSTSEC-2025-0134", # rustls-pemfile — unmaintained (transitive, TLS)
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,18 @@ jobs:
       - name: Bundled libkrun matches the pinned submodule
         run: ./scripts/check-libkrun-provenance.sh
 
+  audit:
+    name: Cargo Audit
+    runs-on: ubuntu-latest
+    # Scans Cargo.lock for RustSec advisories — no engine/libkrun needed. Honors
+    # .cargo/audit.toml, which ignores documented unmaintained-transitive notices
+    # so a real vulnerability stands out instead of hiding in warning noise.
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@cargo-audit
+      - run: cargo audit
+
   # ==========================================================================
   # macOS Build & Test (Apple Silicon)
   # ==========================================================================

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1588,9 +1588,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
Patches RUSTSEC-2026-0185 — a remote memory-exhaustion DoS in quinn-proto (out-of-order QUIC stream reassembly), transitive via reqwest. Low exposure (client, not a QUIC server) but no reason to carry a flagged version.

It sat undetected because smolvm had **no dependency-advisory gate**, so this PR also adds a `Cargo Audit` CI job (scans Cargo.lock only — no engine/libkrun) plus a `.cargo/audit.toml` that ignores the three documented unmaintained-transitive notices (paste, proc-macro-error2, rustls-pemfile). Now future real advisories fail CI instead of hiding in warning noise — matching the smol + smolcloud gates.