### PR TITLE
refactor(fork): carry forkable/snapshot in LaunchFeatures, drop process-global env

### DIFF
--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -164,6 +164,14 @@ pub struct LaunchFeatures {
     /// Additional disk images to attach to the VM (path, read_only, format).
     /// Appear as /dev/vdc, /dev/vdd, ... after the storage and overlay disks.
     pub extra_disks: Vec<(std::path::PathBuf, bool, DiskFormat)>,
+    /// Start as a fork base: back guest RAM with a memfd (copy-on-write
+    /// cloneable) and expose `control_socket` so the machine can be forked.
+    pub forkable: bool,
+    /// Boot this VM as a fork clone, restoring from the golden's snapshot at
+    /// this directory (set on the clone; `None` for a normal cold boot).
+    pub snapshot_dir: Option<std::path::PathBuf>,
+    /// Control socket path for a forkable machine (pause/resume/checkpoint/FORK).
+    pub control_socket: Option<std::path::PathBuf>,
 }
 
 impl LaunchFeatures {

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -152,6 +152,13 @@ struct AgentInner {
     config_state: ConfigState,
     /// If true, the agent has been detached and should not be stopped on drop.
     detached: bool,
+    /// True for the most recent launch via a fork snapshot. A clone resumes past
+    /// boot and never (re)writes the `.smolvm-ready` marker, so `wait_for_ready`
+    /// must detect readiness by pinging the restored agent instead. Set per-launch
+    /// in `start_via_subprocess` from `LaunchFeatures.snapshot_dir` — this carries
+    /// the flag without a process-global env var (unsafe in the multithreaded
+    /// `serve` process where concurrent forks would race).
+    is_clone: bool,
     /// Held while the VM is running. Released on stop/Drop to allow other
     /// processes to start the VM. The kernel releases the lock automatically
     /// if the process crashes.
@@ -502,6 +509,7 @@ impl AgentManager {
                 resources: VmResources::default(),
                 config_state: ConfigState::Unknown,
                 detached: false,
+                is_clone: false,
                 #[cfg(unix)]
                 vm_lock_handle: None,
             })),
@@ -1472,6 +1480,26 @@ impl AgentManager {
             .overlay_gib
             .unwrap_or(crate::storage::DEFAULT_OVERLAY_SIZE_GIB);
 
+        // Forkable / fork-clone launch params are carried PER-PROCESS — set on
+        // the boot subprocess's own env below (and on `self.is_clone`), never via
+        // `std::env::set_var`. A process-global env var is a data race in the
+        // multithreaded `serve` process, where concurrent forks would clobber
+        // each other (and `set_var` is `unsafe` in edition 2024 for that reason).
+        let fork_env: Vec<(&str, String)> = {
+            let mut v = Vec::new();
+            if features.forkable {
+                v.push(("SMOLVM_FORKABLE", "1".to_string()));
+            }
+            if let Some(ref ctl) = features.control_socket {
+                v.push(("SMOLVM_CONTROL_SOCKET", ctl.to_string_lossy().into_owned()));
+            }
+            if let Some(ref snap) = features.snapshot_dir {
+                v.push(("SMOLVM_SNAPSHOT_DIR", snap.to_string_lossy().into_owned()));
+            }
+            v
+        };
+        self.inner.lock().is_clone = features.snapshot_dir.is_some();
+
         // Write boot config to a file the subprocess will read
         let config = BootConfig {
             rootfs_path: self.rootfs_path.clone(),
@@ -1529,6 +1557,9 @@ impl AgentManager {
                 "SMOLVM_BOOT_WATCH_PARENT",
                 if watch_parent { "1" } else { "0" },
             )
+            // Forkable / fork-clone vars set explicitly on the child (not via
+            // inherited process-global env) — see fork_env above.
+            .envs(fork_env)
             .stdin(std::process::Stdio::null())
             // SMOLVM_BOOT_DEBUG=1 surfaces the boot subprocess's stdout/stderr so
             // embedded-host launch failures can be diagnosed (normally silenced).
@@ -1919,7 +1950,7 @@ impl AgentManager {
         // Fork clone: the guest resumes past boot, so it never (re)writes the
         // `.smolvm-ready` marker. Detect readiness by pinging the restored agent
         // directly (it is already in its accept loop) — no marker, no grace.
-        let is_clone = std::env::var_os("SMOLVM_SNAPSHOT_DIR").is_some_and(|v| !v.is_empty());
+        let is_clone = self.inner.lock().is_clone;
         if is_clone {
             while start.elapsed() < timeout {
                 {

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -1033,6 +1033,7 @@ impl RunCmd {
             dns_filter_hosts: params.dns_filter_hosts.clone(),
             packed_layers_dir,
             extra_disks: Vec::new(),
+            ..Default::default()
         };
 
         let freshly_started = manager
@@ -2429,13 +2430,14 @@ impl StartCmd {
         let name = self.name.unwrap_or_else(|| "default".to_string());
         let proxy = self.proxy_opts.proxy();
         let no_proxy = self.proxy_opts.no_proxy();
-        if self.forkable {
-            // Read by launcher.rs in the spawned _boot-vm (inherits our env):
-            // memfd-back guest RAM and register a control socket at a known path
-            // so `machine fork` can later freeze this machine as a CoW base.
-            vm_common::enable_forkable_env(&name);
-        }
-        match vm_common::start_vm_named(&name, proxy, no_proxy, /* from_snapshot */ false) {
+        // Forkable start: memfd-back guest RAM and register a control socket at a
+        // known path so `machine fork` can later freeze this machine as a CoW base.
+        let fork = if self.forkable {
+            vm_common::forkable_launch(&name)
+        } else {
+            vm_common::ForkLaunch::default()
+        };
+        match vm_common::start_vm_named(&name, proxy, no_proxy, /* from_snapshot */ false, fork) {
             Ok(()) => Ok(()),
             Err(smolvm::Error::VmNotFound { .. }) if !explicit_name => {
                 // Only fall back to creating a default VM when no --name was given.
@@ -3470,7 +3472,13 @@ impl MonitorCmd {
 
         if !manager.is_process_alive() {
             println!("Machine '{}' is not running, starting...", name);
-            vm_common::start_vm_named(&name, None, None, /* from_snapshot */ false)?;
+            vm_common::start_vm_named(
+                &name,
+                None,
+                None,
+                /* from_snapshot */ false,
+                vm_common::ForkLaunch::default(),
+            )?;
         }
 
         println!(
@@ -3648,7 +3656,11 @@ impl MonitorCmd {
                     }
 
                     match vm_common::start_vm_named(
-                        &name, None, None, /* from_snapshot */ false,
+                        &name,
+                        None,
+                        None,
+                        /* from_snapshot */ false,
+                        vm_common::ForkLaunch::default(),
                     ) {
                         Ok(()) => {
                             println!("  machine restarted");

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -2437,7 +2437,9 @@ impl StartCmd {
         } else {
             vm_common::ForkLaunch::default()
         };
-        match vm_common::start_vm_named(&name, proxy, no_proxy, /* from_snapshot */ false, fork) {
+        match vm_common::start_vm_named(
+            &name, proxy, no_proxy, /* from_snapshot */ false, fork,
+        ) {
             Ok(()) => Ok(()),
             Err(smolvm::Error::VmNotFound { .. }) if !explicit_name => {
                 // Only fall back to creating a default VM when no --name was given.

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -654,12 +654,28 @@ fn control_socket_path(name: &str) -> std::path::PathBuf {
     vm_data_dir(name).join("control.sock")
 }
 
-/// Mark the current process so the VM it is about to launch (in the inherited
-/// environment of the spawned `_boot-vm`) backs guest RAM with a memfd and
-/// exposes a control socket — the prerequisites for forking it later.
-pub fn enable_forkable_env(name: &str) {
-    std::env::set_var("SMOLVM_FORKABLE", "1");
-    std::env::set_var("SMOLVM_CONTROL_SOCKET", control_socket_path(name));
+/// Per-launch fork parameters, threaded into `start_vm_named` instead of mutating
+/// process-global env vars. The launcher (in the spawned `_boot-vm`) reads these
+/// from its own env, which the manager now sets explicitly on the child — so the
+/// long-lived `serve` process never does a racy `std::env::set_var`.
+#[derive(Debug, Default, Clone)]
+pub struct ForkLaunch {
+    /// Start as a fork base: memfd-back guest RAM and expose `control_socket`.
+    pub forkable: bool,
+    /// Boot as a fork clone, restoring from the golden's snapshot at this dir.
+    pub snapshot_dir: Option<std::path::PathBuf>,
+    /// Control socket path (set together with `forkable`).
+    pub control_socket: Option<std::path::PathBuf>,
+}
+
+/// Fork parameters for starting `name` as a forkable base (memfd RAM + a control
+/// socket at the machine's known path), so `machine fork` can later freeze it.
+pub fn forkable_launch(name: &str) -> ForkLaunch {
+    ForkLaunch {
+        forkable: true,
+        control_socket: Some(control_socket_path(name)),
+        snapshot_dir: None,
+    }
 }
 
 /// Send a single line command to a VM control socket and return its reply line.
@@ -882,10 +898,17 @@ pub fn fork_vm(
     }
 
     // Boot the clone from the golden's snapshot instead of cold-booting.
-    std::env::set_var("SMOLVM_SNAPSHOT_DIR", &snapshot_dir);
     eprintln!("Booting clone '{clone}' from snapshot...");
-    let result = start_vm_named(clone, None, None, /* from_snapshot */ true);
-    std::env::remove_var("SMOLVM_SNAPSHOT_DIR");
+    let result = start_vm_named(
+        clone,
+        None,
+        None,
+        /* from_snapshot */ true,
+        ForkLaunch {
+            snapshot_dir: Some(snapshot_dir.clone()),
+            ..Default::default()
+        },
+    );
     if result.is_ok() {
         rejuvenate_clone(clone);
         eprintln!(
@@ -994,6 +1017,7 @@ pub fn start_vm_named(
     proxy: Option<&str>,
     no_proxy: Option<&str>,
     from_snapshot: bool,
+    fork: ForkLaunch,
 ) -> smolvm::Result<()> {
     use smolvm::Error;
 
@@ -1104,6 +1128,11 @@ pub fn start_vm_named(
         &smolvm::agent::machine_layers_cache_dir(name),
         record.source_smolmachine.as_deref(),
     )?;
+    // Fork params (forkable base / clone-from-snapshot) — carried per-launch into
+    // the boot subprocess's env by the manager, not via process-global env vars.
+    features.forkable = fork.forkable;
+    features.snapshot_dir = fork.snapshot_dir;
+    features.control_socket = fork.control_socket;
     // A machine created from a local image archive/dir persists a `local:…`
     // reference; re-derive its virtiofs mount dir so the guest assembles the
     // rootfs from it instead of pulling.


### PR DESCRIPTION
Forkable/clone plumbing set three process-global env vars (`set_var`) from the CLI, a data race in the multithreaded `serve` process; this carries them per-launch via `LaunchFeatures` + a per-child `.envs()` so the engine can fork safely, with no behavior change (verified on KVM: normal start, `--forkable` start, and fork-clone all still work).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/455">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->