### PR TITLE
feat(serve): fork endpoint + per-VM uid isolation + seccomp/landlock hardening

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -385,12 +385,16 @@ fn signal_ready_to_host() {
 
     let content = uptime_ms().to_string();
 
+    // The host gives each VM its own marker name (SMOLVM_READY_MARKER) so
+    // concurrent boots don't race on one shared rootfs file and, under uid
+    // isolation, the host can pre-create it owned by this VM's uid. Fall back to
+    // the shared protocol constant if the host didn't set it (older host).
+    let marker =
+        std::env::var(guest_env::READY_MARKER).unwrap_or_else(|_| AGENT_READY_MARKER.to_string());
+
     // Try /oldroot first (overlay mode: virtiofs is the lower layer after pivot_root)
     // Before pivot_root: virtiofs is at /, so the / path works.
-    let paths = [
-        format!("/oldroot/{}", AGENT_READY_MARKER),
-        format!("/{}", AGENT_READY_MARKER),
-    ];
+    let paths = [format!("/oldroot/{}", marker), format!("/{}", marker)];
 
     for path in &paths {
         if Path::new(path).parent().map_or(false, |p| p.exists()) {

--- a/crates/smolvm-protocol/src/guest_env.rs
+++ b/crates/smolvm-protocol/src/guest_env.rs
@@ -23,6 +23,12 @@ pub const VALUE_ON: &str = "1";
 /// This is a boolean sentinel — the value is [`VALUE_ON`] when set.
 pub const GPU: &str = "SMOLVM_GPU";
 
+/// Filename of this VM's readiness marker, written by the agent into the virtiofs
+/// rootfs when boot completes. Per VM (so concurrent boots don't race on one
+/// shared file); the host pre-creates and polls the same name. Unset → the agent
+/// falls back to the shared [`crate::AGENT_READY_MARKER`] constant.
+pub const READY_MARKER: &str = "SMOLVM_READY_MARKER";
+
 /// Selects whether the guest should configure a real virtio NIC.
 pub const BACKEND: &str = "SMOLVM_NETWORK_BACKEND";
 /// Canonical backend value meaning "configure guest virtio-net".

--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -154,6 +154,12 @@ pub fn prepare_fork(
     let snapshot_dir = gdir.join("fork-snapshots").join(clone);
     std::fs::create_dir_all(&snapshot_dir)
         .map_err(|e| Error::agent("create snapshot dir", e.to_string()))?;
+    // Under per-VM uid isolation (privileged launcher) the frozen golden VMM runs
+    // as its own unprivileged uid and writes the snapshot here via the FORK
+    // command below, so hand this dir to that uid. No-op unless privileged.
+    if let Some((uid, gid)) = crate::process::vm_drop_ids(&gdir, None) {
+        let _ = crate::process::chown_tree(&snapshot_dir, uid, gid);
+    }
 
     // Register the clone in the DB with the golden's config, no running-state,
     // and its port forwards remapped to fresh host ports. With the default TSI

--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -156,11 +156,15 @@ pub fn prepare_fork(
         .map_err(|e| Error::agent("create snapshot dir", e.to_string()))?;
     // Under per-VM uid isolation (privileged launcher) the frozen golden VMM runs
     // as its own unprivileged uid and writes the snapshot here via the FORK
-    // command below, so hand this dir to that uid. No-op unless privileged.
-    if let Some((uid, gid)) =
+    // command below, so hand this dir to that uid. No-op unless privileged; if the
+    // drop is active the golden's uid lookup must succeed (fail closed).
+    if let Some(result) =
         crate::process::vm_drop_ids(&crate::agent::vm_uid_registry_dir(), &gdir, None)
     {
-        let _ = crate::process::chown_tree(&snapshot_dir, uid, gid);
+        let (uid, gid) =
+            result.map_err(|e| Error::agent("fork: resolve golden uid", e.to_string()))?;
+        crate::process::chown_tree(&snapshot_dir, uid, gid)
+            .map_err(|e| Error::agent("fork: chown snapshot dir", e.to_string()))?;
     }
 
     // Register the clone in the DB with the golden's config, no running-state,

--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -157,7 +157,9 @@ pub fn prepare_fork(
     // Under per-VM uid isolation (privileged launcher) the frozen golden VMM runs
     // as its own unprivileged uid and writes the snapshot here via the FORK
     // command below, so hand this dir to that uid. No-op unless privileged.
-    if let Some((uid, gid)) = crate::process::vm_drop_ids(&gdir, None) {
+    if let Some((uid, gid)) =
+        crate::process::vm_drop_ids(&crate::agent::vm_uid_registry_dir(), &gdir, None)
+    {
         let _ = crate::process::chown_tree(&snapshot_dir, uid, gid);
     }
 

--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -1,0 +1,345 @@
+//! Live fork mechanics shared by the CLI (`machine fork`) and the serve API
+//! (`POST /api/v1/machines/{id}/fork`).
+//!
+//! A fork freezes a running, forkable golden machine — it stays paused as the
+//! shared copy-on-write base — snapshots its memfd-backed RAM + device state,
+//! gives the clone copy-on-write disk overlays, and lets the caller boot the
+//! clone from that snapshot. The boot itself differs between callers (the CLI
+//! uses `start_vm_named`; the API uses `AgentManager`), so it stays out of here;
+//! everything up to and including the snapshot + disk clone is shared so the two
+//! entry points can never silently diverge.
+
+use crate::agent::{resolve_disk_image, vm_data_dir, AgentClient};
+use crate::config::VmRecord;
+use crate::data::validate_vm_name;
+use crate::db::SmolvmDb;
+use crate::{Error, Result};
+use std::path::{Path, PathBuf};
+
+/// Path to a forkable machine's control socket (pause/resume/checkpoint/FORK).
+pub fn control_socket_path(name: &str) -> PathBuf {
+    vm_data_dir(name).join("control.sock")
+}
+
+/// Send a single line command to a VM control socket and return its reply line.
+pub fn control_socket_cmd(sock: &Path, cmd: &str) -> Result<String> {
+    use std::io::{Read, Write};
+    use std::os::unix::net::UnixStream;
+
+    let mut stream = UnixStream::connect(sock)
+        .map_err(|e| Error::agent("connect control socket", e.to_string()))?;
+    stream
+        .set_read_timeout(Some(std::time::Duration::from_secs(60)))
+        .ok();
+    stream
+        .write_all(format!("{cmd}\n").as_bytes())
+        .map_err(|e| Error::agent("write control socket", e.to_string()))?;
+    let mut reply = String::new();
+    let mut byte = [0u8; 1];
+    loop {
+        match stream.read(&mut byte) {
+            Ok(0) => break,
+            Ok(_) => {
+                if byte[0] == b'\n' {
+                    break;
+                }
+                reply.push(byte[0] as char);
+            }
+            Err(e) => return Err(Error::agent("read control socket", e.to_string())),
+        }
+    }
+    Ok(reply)
+}
+
+/// The result of preparing a fork: the golden is frozen + snapshotted and the
+/// clone's DB record + copy-on-write disks exist on disk. The caller boots the
+/// clone from `snapshot_dir`, then calls [`rejuvenate_clone`].
+pub struct PreparedFork {
+    /// Directory holding the golden's checkpoint + memfd manifest. Pass it as the
+    /// clone's `LaunchFeatures::snapshot_dir` to boot from it instead of cold.
+    pub snapshot_dir: PathBuf,
+    /// The clone's freshly-inserted DB record (golden's config, remapped ports).
+    pub clone_record: VmRecord,
+    /// Per-port inbound remap as `(golden_host, guest, clone_host)`, for the
+    /// caller to log. Empty when the golden has no forwards. When ports were
+    /// pinned, `golden_host == clone_host`.
+    pub port_remaps: Vec<(u16, u16, u16)>,
+}
+
+/// Freeze a running, forkable `golden`, snapshot it, register `clone` in the DB
+/// with copy-on-write disks, and return everything the caller needs to boot the
+/// clone. Launch-agnostic: the actual boot is the caller's job (CLI via
+/// `start_vm_named`, API via `AgentManager`), keyed off the returned
+/// `snapshot_dir`.
+///
+/// On any failure after the clone record is inserted, the record and its data
+/// directory are cleaned up before returning the error, so a failed fork leaves
+/// no half-registered clone behind.
+pub fn prepare_fork(
+    db: &SmolvmDb,
+    golden: &str,
+    clone: &str,
+    pinned_ports: &[(u16, u16)],
+    clone_forkable: bool,
+) -> Result<PreparedFork> {
+    validate_vm_name(clone, "clone name").map_err(|e| Error::config("clone name", e))?;
+
+    // Nested fork is unsupported: a clone boots from a copy-on-write MAP_PRIVATE
+    // mapping of the golden's RAM, not a fresh memfd, so it cannot itself be
+    // re-forked (its FORK would fail with "no memfd-backed RAM"). Reject
+    // `forkable` up front instead of producing a clone that looks forkable but
+    // isn't.
+    if clone_forkable {
+        return Err(Error::agent(
+            "fork",
+            "nested fork is not supported: a clone cannot be re-forked, so `forkable` \
+             on a fork has no effect (drop it)",
+        ));
+    }
+
+    let golden_rec = db
+        .get_vm(golden)?
+        .ok_or_else(|| Error::vm_not_found(golden))?;
+
+    // The golden must be alive and forkable. We probe the control socket rather
+    // than the vsock agent: after its first fork the golden is frozen (paused)
+    // as the shared base, so an agent ping would fail — but STATUS still answers
+    // (running or paused), and we can fork it again.
+    let ctl = control_socket_path(golden);
+    if !ctl.exists() {
+        return Err(Error::agent(
+            "fork",
+            format!("golden '{golden}' is not running forkable; start it with `machine start --forkable --name {golden}`"),
+        ));
+    }
+    let status = control_socket_cmd(&ctl, "STATUS").map_err(|e| {
+        Error::agent(
+            "fork",
+            format!("golden '{golden}' control socket not responding ({e}); start it with `machine start --forkable --name {golden}`"),
+        )
+    })?;
+    if !status.starts_with("OK") {
+        return Err(Error::agent(
+            "fork",
+            format!("golden '{golden}' is not ready to fork: {status}"),
+        ));
+    }
+    if db.get_vm(clone)?.is_some() {
+        return Err(Error::agent(
+            "fork",
+            format!("machine '{clone}' already exists"),
+        ));
+    }
+
+    // Clone dir + snapshot dir. A leftover data directory with no DB record is
+    // an orphan from a previously crashed fork; its stale qcow2 overlays would
+    // make `krun_create_disk_overlay` fail (rc=-5, it refuses to overwrite an
+    // existing target). The DB check above guarantees no live clone owns this
+    // name, so clearing the directory is safe.
+    let clone_dir = vm_data_dir(clone);
+    if clone_dir.exists() {
+        std::fs::remove_dir_all(&clone_dir)
+            .map_err(|e| Error::agent("clear orphan clone dir", e.to_string()))?;
+    }
+    let snapshot_dir = clone_dir.join("snapshot");
+    std::fs::create_dir_all(&snapshot_dir)
+        .map_err(|e| Error::agent("create clone dir", e.to_string()))?;
+
+    // Register the clone in the DB with the golden's config, no running-state,
+    // and its port forwards remapped to fresh host ports. With the default TSI
+    // backend outbound is proxied per-process (each clone gets it for free, no
+    // guest MAC/IP involved); only inbound host ports must be made distinct so
+    // the clone is reachable without colliding with the still-running golden or
+    // sibling clones.
+    let mut clone_rec = golden_rec.clone();
+    clone_rec.name = clone.to_string();
+    clone_rec.pid = None;
+    clone_rec.pid_start_time = None;
+    let mut port_remaps = Vec::new();
+    if !pinned_ports.is_empty() {
+        // User pinned the clone's forwards explicitly — use them as-is.
+        clone_rec.ports = pinned_ports.to_vec();
+        for (h, g) in &clone_rec.ports {
+            port_remaps.push((*h, *g, *h));
+        }
+    } else if !clone_rec.ports.is_empty() {
+        let mut remapped = Vec::with_capacity(clone_rec.ports.len());
+        for (golden_host, guest) in &clone_rec.ports {
+            match alloc_free_host_port() {
+                Some(h) => {
+                    port_remaps.push((*golden_host, *guest, h));
+                    remapped.push((h, *guest));
+                }
+                None => tracing::warn!(
+                    guest,
+                    "could not allocate a host port for fork clone; dropping forward"
+                ),
+            }
+        }
+        clone_rec.ports = remapped;
+    }
+    clone_rec.golden = Some(golden.to_string());
+    let gdir = vm_data_dir(golden);
+    db.insert_vm(clone, &clone_rec)?;
+
+    // Freeze the golden and write its snapshot (checkpoint + memfd manifest).
+    let cleanup = || {
+        let _ = db.remove_vm(clone);
+        let _ = std::fs::remove_dir_all(&clone_dir);
+    };
+    let reply = match control_socket_cmd(&ctl, &format!("FORK {}", snapshot_dir.display())) {
+        Ok(r) => r,
+        Err(e) => {
+            cleanup();
+            return Err(e);
+        }
+    };
+    if !reply.starts_with("OK") {
+        cleanup();
+        return Err(Error::agent("fork", format!("golden FORK failed: {reply}")));
+    }
+
+    if let Err(e) = clone_fork_disks(&gdir, &clone_dir) {
+        cleanup();
+        return Err(e);
+    }
+
+    Ok(PreparedFork {
+        snapshot_dir,
+        clone_record: clone_rec,
+        port_remaps,
+    })
+}
+
+/// Give the clone its own disks. The golden is frozen with its block workers
+/// quiesced and flushed, so its images are a consistent backing. On Linux each
+/// disk is a qcow2 copy-on-write overlay over the golden's — filesystem
+/// independent, so the overlay starts near-empty and the fork is O(metadata)
+/// regardless of how much data the golden holds. macOS clonefiles the disks
+/// (APFS CoW). Either way the `.formatted` marker is copied so the clone never
+/// reformats and wipes the inherited filesystem.
+fn clone_fork_disks(gdir: &Path, clone_dir: &Path) -> Result<()> {
+    // The golden's actual disks that exist, resolved by file presence (`.qcow2`
+    // if the golden is itself a clone, else `.raw`) — the same single source of
+    // truth the agent manager uses. Each entry pairs the canonical `.raw`
+    // filename (for naming the clone's disk) with the golden's real backing file
+    // and its format.
+    let disks: Vec<(&str, PathBuf, crate::data::disk::DiskFormat)> = [
+        crate::data::storage::STORAGE_DISK_FILENAME,
+        crate::data::storage::OVERLAY_DISK_FILENAME,
+    ]
+    .into_iter()
+    .map(|raw| {
+        let (src, fmt) = resolve_disk_image(gdir, raw);
+        (raw, src, fmt)
+    })
+    .filter(|(_, src, _)| src.exists())
+    .collect();
+
+    #[cfg(target_os = "linux")]
+    {
+        // Each clone disk is a qcow2 CoW overlay over the golden's disk. Build
+        // all overlay specs first so libkrun is loaded once for the batch
+        // (absolute backing path: it's written verbatim into the overlay
+        // header), then copy the `.formatted` markers so the clone never
+        // reformats and wipes the inherited filesystem.
+        let mut specs = Vec::with_capacity(disks.len());
+        for (raw, src, fmt) in &disks {
+            let base = src
+                .canonicalize()
+                .map_err(|e| Error::agent("clone disk", format!("{}: {e}", src.display())))?;
+            let overlay = clone_dir.join(Path::new(raw).with_extension("qcow2"));
+            specs.push((overlay, base, *fmt));
+        }
+        crate::agent::create_disk_overlays(&specs)?;
+        for (raw, _, _) in &disks {
+            // Marker basename is the disk stem + ".formatted" (same for the
+            // golden's `.raw`/`.qcow2` and the clone's `.qcow2`).
+            let marker = Path::new(raw).with_extension("formatted");
+            let src_marker = gdir.join(&marker);
+            if src_marker.exists() {
+                let _ = std::fs::copy(&src_marker, clone_dir.join(&marker));
+            }
+        }
+    }
+    #[cfg(target_os = "macos")]
+    {
+        // macOS uses clonefile (APFS CoW), keeping the golden's disk format.
+        for (_, src, _) in &disks {
+            let dst = clone_dir.join(src.file_name().unwrap());
+            crate::disk_utils::clone_or_copy_file(src, &dst)
+                .map_err(|e| Error::agent("clone disk", format!("{}: {e}", src.display())))?;
+            let src_marker = src.with_extension("formatted");
+            if src_marker.exists() {
+                let _ = std::fs::copy(&src_marker, dst.with_extension("formatted"));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Best-effort per-clone identity rejuvenation after a fork. A clone inherits
+/// the golden's hostname, machine-id, and (critically) RNG state, so without
+/// this every clone would share the golden's random stream — a security problem
+/// and a source of duplicate-identity bugs across a pool. Run over the
+/// freshly-booted clone's agent: set a unique hostname, mint a fresh machine-id,
+/// and stir the kernel RNG with fresh host entropy so the streams diverge.
+/// Failures are warnings, not fatal (the clone still works).
+///
+/// Note: this stirs but does not *credit* entropy (no `RNDADDENTROPY`/VMGENID
+/// yet), and does not re-address the network (MAC/IP) — both are follow-ups.
+pub fn rejuvenate_clone(clone: &str) {
+    let sock = vm_data_dir(clone).join("agent.sock");
+    let seed = host_random_hex(64);
+    // Names are validated (alphanumeric + dashes), so single-quoting is safe.
+    let script = format!(
+        "hostname '{c}' 2>/dev/null; printf '%s\\n' '{c}' > /etc/hostname 2>/dev/null; \
+         (cat /proc/sys/kernel/random/uuid 2>/dev/null | tr -d '-' > /etc/machine-id) 2>/dev/null; \
+         printf '%s' '{s}' > /dev/urandom 2>/dev/null; true",
+        c = clone,
+        s = seed,
+    );
+    let mut client = match AgentClient::connect_with_retry(&sock) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(clone, error = %e, "clone rejuvenation skipped (agent connect)");
+            return;
+        }
+    };
+    match client.vm_exec(
+        vec!["/bin/sh".into(), "-c".into(), script],
+        vec![],
+        None,
+        Some(std::time::Duration::from_secs(10)),
+        None,
+    ) {
+        Ok((0, _, _)) => {}
+        Ok((code, _, stderr)) => tracing::warn!(
+            clone,
+            code,
+            stderr = %String::from_utf8_lossy(&stderr).trim(),
+            "clone rejuvenation exited non-zero"
+        ),
+        Err(e) => tracing::warn!(clone, error = %e, "clone rejuvenation failed"),
+    }
+}
+
+/// Allocate a currently-free host TCP port by binding to port 0 and reading back
+/// the OS-assigned port. Used to give each clone distinct inbound forwards.
+fn alloc_free_host_port() -> Option<u16> {
+    std::net::TcpListener::bind(("127.0.0.1", 0))
+        .ok()
+        .and_then(|l| l.local_addr().ok())
+        .map(|addr| addr.port())
+}
+
+/// Read `hex_len/2` random bytes from the host RNG, hex-encoded. Used to seed
+/// each clone's RNG with distinct host entropy.
+fn host_random_hex(hex_len: usize) -> String {
+    use std::io::Read;
+    let mut buf = vec![0u8; hex_len / 2];
+    if let Ok(mut f) = std::fs::File::open("/dev/urandom") {
+        let _ = f.read_exact(&mut buf);
+    }
+    buf.iter().map(|b| format!("{b:02x}")).collect()
+}

--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -141,9 +141,19 @@ pub fn prepare_fork(
         std::fs::remove_dir_all(&clone_dir)
             .map_err(|e| Error::agent("clear orphan clone dir", e.to_string()))?;
     }
-    let snapshot_dir = clone_dir.join("snapshot");
-    std::fs::create_dir_all(&snapshot_dir)
+    std::fs::create_dir_all(&clone_dir)
         .map_err(|e| Error::agent("create clone dir", e.to_string()))?;
+
+    // The golden writes its frozen snapshot (checkpoint + memfd manifest) here.
+    // It lives under the GOLDEN's data dir, not the clone's: under Landlock the
+    // frozen golden VMM is confined to its own data dir, so it can write here but
+    // could not write into a separate clone's dir. The clone — which already needs
+    // read access to the golden's dir for its copy-on-write disk backing — reads
+    // the snapshot from the same place. See `internal_boot`'s Landlock grants.
+    let gdir = vm_data_dir(golden);
+    let snapshot_dir = gdir.join("fork-snapshots").join(clone);
+    std::fs::create_dir_all(&snapshot_dir)
+        .map_err(|e| Error::agent("create snapshot dir", e.to_string()))?;
 
     // Register the clone in the DB with the golden's config, no running-state,
     // and its port forwards remapped to fresh host ports. With the default TSI
@@ -179,13 +189,13 @@ pub fn prepare_fork(
         clone_rec.ports = remapped;
     }
     clone_rec.golden = Some(golden.to_string());
-    let gdir = vm_data_dir(golden);
     db.insert_vm(clone, &clone_rec)?;
 
     // Freeze the golden and write its snapshot (checkpoint + memfd manifest).
     let cleanup = || {
         let _ = db.remove_vm(clone);
         let _ = std::fs::remove_dir_all(&clone_dir);
+        let _ = std::fs::remove_dir_all(&snapshot_dir);
     };
     let reply = match control_socket_cmd(&ctl, &format!("FORK {}", snapshot_dir.display())) {
         Ok(r) => r,

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -976,6 +976,13 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
             }
         }
 
+        // Forward this VM's per-VM readiness-marker name into the guest env (the
+        // manager set it on this boot subprocess) so the agent writes the marker
+        // the host pre-created and polls. See manager::ready_marker_name.
+        if let Ok(marker) = std::env::var(guest_env::READY_MARKER) {
+            env_strings.push(cstr(&format!("{}={}", guest_env::READY_MARKER, marker)));
+        }
+
         // DNS allow-host filtering is now enforced inside libkrun (see the
         // egress policy above). The guest-side DNS proxy is intentionally NOT
         // started: the guest keeps its default resolv.conf (1.1.1.1/8.8.8.8) so

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -1221,6 +1221,28 @@ impl AgentManager {
         self.start_with_full_config(mounts, Vec::new(), resources, Default::default())
     }
 
+    /// This VM's readiness-marker filename — **per VM** (`<base>.<vm-hash>`), not
+    /// the shared protocol constant. A per-VM marker means concurrent boots can't
+    /// race on one shared file, and under uid isolation each marker is pre-created
+    /// 0600 owned by that VM's uid instead of world-writable. The host passes this
+    /// name to the guest agent via the `SMOLVM_READY_MARKER` guest env var so both
+    /// sides agree.
+    fn ready_marker_name(&self) -> String {
+        let hash = self
+            .storage_disk
+            .path()
+            .parent()
+            .and_then(|p| p.file_name())
+            .and_then(|n| n.to_str())
+            .unwrap_or("default");
+        format!("{}.{}", AGENT_READY_MARKER, hash)
+    }
+
+    /// Host path of this VM's per-VM readiness marker.
+    fn ready_marker_path(&self) -> PathBuf {
+        self.rootfs_path.join(self.ready_marker_name())
+    }
+
     /// Common pre-launch setup: validate state, pre-format disks, clean markers.
     ///
     /// Called by both `start_with_full_config` (fork) and `start_via_subprocess`.
@@ -1355,30 +1377,10 @@ impl AgentManager {
             });
         }
 
-        // Clean up old socket and stale markers
+        // Clean up old socket and this VM's stale (per-VM) readiness marker.
         let _ = std::fs::remove_file(&self.vsock_socket);
-        let ready_marker = self.rootfs_path.join(AGENT_READY_MARKER);
-        let _ = std::fs::remove_file(&ready_marker);
+        let _ = std::fs::remove_file(self.ready_marker_path());
         let _ = std::fs::remove_file(&self.startup_error_log);
-
-        // Per-VM uid isolation: the VMM drops to an unprivileged uid that can't
-        // write the shared, host-user-owned agent rootfs, so the guest's
-        // readiness-marker write (and the Landlock pre-create) would fail and
-        // readiness would limp to the slow vsock fallback. We're root here, so
-        // pre-create the marker world-writable; the dropped guest overwrites it
-        // with content. It already lives in a host-user-writable dir, so 0666
-        // doesn't meaningfully widen exposure. No-op unless the uid drop applies.
-        #[cfg(target_os = "linux")]
-        if crate::process::vm_uid_drop_active() {
-            use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
-            let _ = std::fs::OpenOptions::new()
-                .create(true)
-                .write(true)
-                .truncate(true)
-                .mode(0o666)
-                .open(&ready_marker);
-            let _ = std::fs::set_permissions(&ready_marker, std::fs::Permissions::from_mode(0o666));
-        }
 
         Ok(())
     }
@@ -1540,26 +1542,73 @@ impl AgentManager {
         // opt out with SMOLVM_VM_UID_DROP=off. See process::vm_drop_ids.
         let data_dir = self.storage_disk.path().parent().map(|p| p.to_path_buf());
         let registry = vm_uid_registry_dir();
-        let uid_env: Vec<(&str, String)> = match data_dir.as_deref().and_then(|d| {
-            crate::process::vm_drop_ids(&registry, d, features.snapshot_dir.as_deref())
-                .map(|ids| (d, ids))
-        }) {
-            Some((d, (uid, gid))) => {
+        let mut uid_env: Vec<(&str, String)> = Vec::new();
+        if let Some(d) = data_dir.as_deref() {
+            if let Some(result) =
+                crate::process::vm_drop_ids(&registry, d, features.snapshot_dir.as_deref())
+            {
+                // The drop is active — allocation MUST succeed or we refuse to boot
+                // (fail closed; never silently run the VMM over-privileged).
+                let (uid, gid) = result.map_err(|e| {
+                    Error::agent(
+                        "allocate per-VM uid (refusing to boot over-privileged)",
+                        e.to_string(),
+                    )
+                })?;
                 crate::process::chown_tree(d, uid, gid)
                     .map_err(|e| Error::agent("chown vm data dir for uid drop", e.to_string()))?;
                 #[cfg(target_os = "linux")]
                 {
                     use std::os::unix::fs::PermissionsExt;
+                    // 0700: a sibling VM's uid — or a Landlock-exempt clone — must
+                    // not be able to read this VM's disks.
                     let _ = std::fs::set_permissions(d, std::fs::Permissions::from_mode(0o700));
                 }
+                // The dropped uid must traverse to its 0700 data dir, the shared
+                // rootfs, and the disk templates. The data dir itself stays 0700;
+                // widen only the ancestor chains (execute-only). Resilient to a
+                // restrictive umask on the runtime-created intermediates.
+                crate::process::ensure_traversable(&registry);
+                if let Some(parent) = d.parent() {
+                    crate::process::ensure_traversable(parent);
+                }
+                crate::process::ensure_traversable(&self.rootfs_path);
+                if let Some(home) = dirs::home_dir() {
+                    crate::process::ensure_traversable(&home.join(".smolvm"));
+                }
+                // Pre-create this VM's per-VM readiness marker owned by its uid
+                // (0600): the dropped guest can overwrite it but couldn't create a
+                // file in the shared, host-user-owned rootfs. Per-VM name + 0600 =
+                // no shared-marker race and no world-writable file.
+                #[cfg(target_os = "linux")]
+                {
+                    use std::os::unix::ffi::OsStrExt;
+                    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+                    let marker = self.ready_marker_path();
+                    if std::fs::OpenOptions::new()
+                        .create(true)
+                        .write(true)
+                        .truncate(true)
+                        .mode(0o600)
+                        .open(&marker)
+                        .is_ok()
+                    {
+                        let _ = std::fs::set_permissions(
+                            &marker,
+                            std::fs::Permissions::from_mode(0o600),
+                        );
+                        if let Ok(c) = std::ffi::CString::new(marker.as_os_str().as_bytes()) {
+                            unsafe { libc::lchown(c.as_ptr(), uid, uid) };
+                        }
+                    }
+                }
                 tracing::info!(uid, vm_dir = %d.display(), "per-VM uid isolation enabled");
-                vec![
+                uid_env = vec![
                     ("SMOLVM_VM_UID", uid.to_string()),
                     ("SMOLVM_VM_GID", gid.to_string()),
-                ]
+                ];
             }
-            None => Vec::new(),
-        };
+        }
 
         // Write boot config to a file the subprocess will read
         let config = BootConfig {
@@ -1623,6 +1672,13 @@ impl AgentManager {
             .envs(fork_env)
             // Per-VM uid drop (privileged launcher only) — see uid_env above.
             .envs(uid_env)
+            // Per-VM readiness marker name — forwarded by the launcher into the
+            // guest env so the agent writes this VM's own marker (no shared-marker
+            // race). The host polls the same path.
+            .env(
+                smolvm_protocol::guest_env::READY_MARKER,
+                self.ready_marker_name(),
+            )
             .stdin(std::process::Stdio::null())
             // SMOLVM_BOOT_DEBUG=1 surfaces the boot subprocess's stdout/stderr so
             // embedded-host launch failures can be diagnosed (normally silenced).
@@ -1806,7 +1862,15 @@ impl AgentManager {
     ///
     /// Only call after the VM process is confirmed dead.
     fn cleanup_marker_files(&self) {
-        for path in [&self.pid_file, &self.config_file, &self.vsock_socket] {
+        // Include the per-VM readiness marker so the shared rootfs doesn't
+        // accumulate one stale marker per VM ever booted.
+        let ready_marker = self.ready_marker_path();
+        for path in [
+            &self.pid_file,
+            &self.config_file,
+            &self.vsock_socket,
+            &ready_marker,
+        ] {
             if let Err(e) = std::fs::remove_file(path) {
                 if e.kind() != std::io::ErrorKind::NotFound {
                     tracing::debug!(error = %e, path = %path.display(), "failed to remove marker file");
@@ -2053,7 +2117,7 @@ impl AgentManager {
             ));
         }
 
-        let ready_marker = self.rootfs_path.join(AGENT_READY_MARKER);
+        let ready_marker = self.ready_marker_path();
 
         while start.elapsed() < timeout {
             // Check if child process is still alive

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -1351,6 +1351,28 @@ impl AgentManager {
         let _ = std::fs::remove_file(&ready_marker);
         let _ = std::fs::remove_file(&self.startup_error_log);
 
+        // Per-VM uid isolation: the VMM drops to an unprivileged uid that can't
+        // write the shared, host-user-owned agent rootfs, so the guest's
+        // readiness-marker write (and the Landlock pre-create) would fail and
+        // readiness would limp to the slow vsock fallback. We're root here, so
+        // pre-create the marker world-writable; the dropped guest overwrites it
+        // with content. It already lives in a host-user-writable dir, so 0666
+        // doesn't meaningfully widen exposure. No-op unless the uid drop applies.
+        #[cfg(target_os = "linux")]
+        if let Some(data_dir) = self.storage_disk.path().parent() {
+            if crate::process::vm_drop_ids(data_dir, None).is_some() {
+                use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+                let _ = std::fs::OpenOptions::new()
+                    .create(true)
+                    .write(true)
+                    .truncate(true)
+                    .mode(0o666)
+                    .open(&ready_marker);
+                let _ =
+                    std::fs::set_permissions(&ready_marker, std::fs::Permissions::from_mode(0o666));
+            }
+        }
+
         Ok(())
     }
 
@@ -1500,6 +1522,30 @@ impl AgentManager {
         };
         self.inner.lock().is_clone = features.snapshot_dir.is_some();
 
+        // Per-VM uid isolation: when running privileged (root `serve`), give this
+        // VMM its own dedicated unprivileged uid so a guest→VMM escape is contained
+        // to one VM. We're still root here, so chown the VM's data dir (disks,
+        // sockets, logs) to that uid; `internal_boot` does the actual setuid drop
+        // from the inherited SMOLVM_VM_UID. A fork clone shares its golden's uid
+        // (vm_drop_ids derives it from the snapshot path) so it can map the
+        // golden's memfd. No-op unless privileged; opt out with
+        // SMOLVM_VM_UID_DROP=off. See process::vm_drop_ids.
+        let data_dir = self.storage_disk.path().parent().map(|p| p.to_path_buf());
+        let uid_env: Vec<(&str, String)> = match data_dir.as_deref().and_then(|d| {
+            crate::process::vm_drop_ids(d, features.snapshot_dir.as_deref()).map(|ids| (d, ids))
+        }) {
+            Some((d, (uid, gid))) => {
+                crate::process::chown_tree(d, uid, gid)
+                    .map_err(|e| Error::agent("chown vm data dir for uid drop", e.to_string()))?;
+                tracing::info!(uid, vm_dir = %d.display(), "per-VM uid isolation enabled");
+                vec![
+                    ("SMOLVM_VM_UID", uid.to_string()),
+                    ("SMOLVM_VM_GID", gid.to_string()),
+                ]
+            }
+            None => Vec::new(),
+        };
+
         // Write boot config to a file the subprocess will read
         let config = BootConfig {
             rootfs_path: self.rootfs_path.clone(),
@@ -1560,6 +1606,8 @@ impl AgentManager {
             // Forkable / fork-clone vars set explicitly on the child (not via
             // inherited process-global env) — see fork_env above.
             .envs(fork_env)
+            // Per-VM uid drop (privileged launcher only) — see uid_env above.
+            .envs(uid_env)
             .stdin(std::process::Stdio::null())
             // SMOLVM_BOOT_DEBUG=1 surfaces the boot subprocess's stdout/stderr so
             // embedded-host launch failures can be diagnosed (normally silenced).

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -307,6 +307,16 @@ pub fn vm_cache_root() -> PathBuf {
         .join("vms")
 }
 
+/// Per-node registry for the collision-free per-VM uid allocator
+/// (`<cache_dir>/smolvm/uids/`), a sibling of the VM data dirs. Root-managed; the
+/// dropped VMMs never touch it. See `process::allocate_vm_uid`.
+pub fn vm_uid_registry_dir() -> PathBuf {
+    vm_cache_root()
+        .parent()
+        .map(|p| p.join("uids"))
+        .unwrap_or_else(|| PathBuf::from("/tmp/smolvm-uids"))
+}
+
 /// Compute the 16-hex-char directory name for a VM.
 ///
 /// Uses SHA-256 truncated to 8 bytes. The specific hash function doesn't
@@ -1359,18 +1369,15 @@ impl AgentManager {
         // with content. It already lives in a host-user-writable dir, so 0666
         // doesn't meaningfully widen exposure. No-op unless the uid drop applies.
         #[cfg(target_os = "linux")]
-        if let Some(data_dir) = self.storage_disk.path().parent() {
-            if crate::process::vm_drop_ids(data_dir, None).is_some() {
-                use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
-                let _ = std::fs::OpenOptions::new()
-                    .create(true)
-                    .write(true)
-                    .truncate(true)
-                    .mode(0o666)
-                    .open(&ready_marker);
-                let _ =
-                    std::fs::set_permissions(&ready_marker, std::fs::Permissions::from_mode(0o666));
-            }
+        if crate::process::vm_uid_drop_active() {
+            use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+            let _ = std::fs::OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .mode(0o666)
+                .open(&ready_marker);
+            let _ = std::fs::set_permissions(&ready_marker, std::fs::Permissions::from_mode(0o666));
         }
 
         Ok(())
@@ -1523,20 +1530,28 @@ impl AgentManager {
         self.inner.lock().is_clone = features.snapshot_dir.is_some();
 
         // Per-VM uid isolation: when running privileged (root `serve`), give this
-        // VMM its own dedicated unprivileged uid so a guest→VMM escape is contained
-        // to one VM. We're still root here, so chown the VM's data dir (disks,
-        // sockets, logs) to that uid; `internal_boot` does the actual setuid drop
-        // from the inherited SMOLVM_VM_UID. A fork clone shares its golden's uid
-        // (vm_drop_ids derives it from the snapshot path) so it can map the
-        // golden's memfd. No-op unless privileged; opt out with
-        // SMOLVM_VM_UID_DROP=off. See process::vm_drop_ids.
+        // VMM its own dedicated, collision-free unprivileged uid so a guest→VMM
+        // escape is contained to one VM. We're still root here, so chown the VM's
+        // data dir (disks, sockets, logs) to that uid and tighten it to 0700 (so
+        // a sibling VM's uid — or a Landlock-exempt clone — can't read its disks);
+        // `internal_boot` does the actual setuid drop from the inherited
+        // SMOLVM_VM_UID. A fork clone shares its golden's uid (resolved from the
+        // snapshot path) so it can map the golden's memfd. No-op unless privileged;
+        // opt out with SMOLVM_VM_UID_DROP=off. See process::vm_drop_ids.
         let data_dir = self.storage_disk.path().parent().map(|p| p.to_path_buf());
+        let registry = vm_uid_registry_dir();
         let uid_env: Vec<(&str, String)> = match data_dir.as_deref().and_then(|d| {
-            crate::process::vm_drop_ids(d, features.snapshot_dir.as_deref()).map(|ids| (d, ids))
+            crate::process::vm_drop_ids(&registry, d, features.snapshot_dir.as_deref())
+                .map(|ids| (d, ids))
         }) {
             Some((d, (uid, gid))) => {
                 crate::process::chown_tree(d, uid, gid)
                     .map_err(|e| Error::agent("chown vm data dir for uid drop", e.to_string()))?;
+                #[cfg(target_os = "linux")]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    let _ = std::fs::set_permissions(d, std::fs::Permissions::from_mode(0o700));
+                }
                 tracing::info!(uid, vm_dir = %d.display(), "per-VM uid isolation enabled");
                 vec![
                     ("SMOLVM_VM_UID", uid.to_string()),
@@ -1864,6 +1879,11 @@ impl AgentManager {
     pub fn cleanup_data_dir(&self) {
         if let Some(ref name) = self.name {
             let dir = vm_data_dir(name);
+            // Release this VM's per-VM uid (if any) back to the allocator before
+            // the dir — which holds the `.vm-uid` record — is removed. A fork
+            // clone has no uid of its own (it shares its golden's), so this is a
+            // no-op for it. See process::free_vm_uid.
+            crate::process::free_vm_uid(&vm_uid_registry_dir(), &dir);
             if dir.exists() {
                 if let Err(e) = std::fs::remove_dir_all(&dir) {
                     tracing::debug!(

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod boot_config;
 mod client;
+pub mod fork;
 mod krun;
 mod launcher;
 pub mod launcher_dynamic;

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -27,7 +27,7 @@ pub use launcher::{
 pub use manager::{
     disk_used_mb, docker_config_dir, docker_config_mount, ensure_vm_dir, machine_layers_cache_dir,
     read_egress_telemetry, resolve_disk_image, vm_cache_root, vm_data_dir, vm_dir_hash,
-    AgentManager, AgentState,
+    vm_uid_registry_dir, AgentManager, AgentState,
 };
 
 /// Agent VM name.

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -23,7 +23,7 @@
 //! Recommended: keep names short and descriptive (e.g., "dev-vm", "test-1").
 
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     Json,
 };
 use std::sync::Arc;
@@ -36,9 +36,9 @@ use crate::api::state::{
     ReservationGuard,
 };
 use crate::api::types::{
-    ApiErrorResponse, CreateMachineRequest, DeleteResponse, EnvVar, ExecResponse,
+    ApiErrorResponse, CreateMachineRequest, DeleteResponse, EnvVar, ExecResponse, ForkRequest,
     ListMachinesResponse, MachineExecRequest, MachineInfo, MountInfo, MountSpec, PortSpec,
-    ResizeMachineRequest, ResourceSpec,
+    ResizeMachineRequest, ResourceSpec, StartMachineQuery,
 };
 use crate::api::validate_command;
 use crate::api::TraceId;
@@ -690,7 +690,8 @@ fn classify_launch_error(e: String) -> ApiError {
     path = "/api/v1/machines/{name}/start",
     tag = "Machines",
     params(
-        ("name" = String, Path, description = "Machine name")
+        ("name" = String, Path, description = "Machine name"),
+        ("forkable" = Option<bool>, Query, description = "Start as a fork base (memfd RAM + control socket)")
     ),
     responses(
         (status = 200, description = "Machine started", body = MachineInfo),
@@ -702,6 +703,7 @@ fn classify_launch_error(e: String) -> ApiError {
 pub async fn start_machine(
     State(state): State<Arc<ApiState>>,
     Path(name): Path<String>,
+    Query(query): Query<StartMachineQuery>,
 ) -> Result<Json<MachineInfo>, ApiError> {
     // Hold the per-machine lifecycle lock across the whole start so a concurrent
     // stop/delete cannot detach the macOS layers volume between our acquire+mount
@@ -787,16 +789,23 @@ pub async fn start_machine(
     let storage_gb = record.storage_gb;
     let overlay_gb = record.overlay_gb;
     let source_smolmachine = record.source_smolmachine.clone();
+    let forkable = query.forkable;
     let (manager, pid) = tokio::task::spawn_blocking(move || {
         let manager = AgentManager::for_vm_with_sizes(&name_clone, storage_gb, overlay_gb)
             .map_err(|e| format!("failed to create agent manager: {}", e))?;
 
         // Wire pre-extracted layers if this machine was created from a .smolmachine.
-        let features = crate::api::state::build_launch_features(
+        let mut features = crate::api::state::build_launch_features(
             Some(&name_clone),
             source_smolmachine.as_deref(),
         )
         .map_err(|e| format!("failed to prepare packed layers: {}", e))?;
+        // Forkable start: memfd-back guest RAM and expose a control socket at the
+        // machine's known path so it can later be forked via the fork endpoint.
+        if forkable {
+            features.forkable = true;
+            features.control_socket = Some(crate::agent::fork::control_socket_path(&name_clone));
+        }
         let _ = manager
             .ensure_running_via_subprocess(mounts, ports, resources, features)
             .map_err(|e| format!("failed to start machine: {}", e))?;
@@ -886,6 +895,148 @@ pub async fn start_machine(
     // may falsely report "stopped" on macOS due to setsid/session-leader
     // PID visibility issues.
     let mut info = record_to_info(&name, &record);
+    info.state = "running".to_string();
+    info.pid = pid;
+    Ok(Json(info))
+}
+
+/// Classify a fork-preparation failure into the right HTTP status. The golden
+/// missing is a 404; the golden not being forkable / not yet ready, or the clone
+/// name already being taken, is a 409; a nested-fork request is a 400; anything
+/// else is a 500.
+fn classify_fork_error(e: SmolvmError) -> ApiError {
+    let msg = e.to_string();
+    let lc = msg.to_ascii_lowercase();
+    if lc.contains("nested fork") {
+        ApiError::BadRequest(msg)
+    } else if lc.contains("already exists")
+        || lc.contains("not running forkable")
+        || lc.contains("control socket not responding")
+        || lc.contains("not ready to fork")
+    {
+        // Clone name taken, or the golden isn't a ready fork base — both 409.
+        ApiError::Conflict(msg)
+    } else if lc.contains("not found") {
+        ApiError::NotFound(msg)
+    } else {
+        ApiError::Internal(msg)
+    }
+}
+
+/// Fork a running, forkable golden machine into a new clone (copy-on-write
+/// memory + disks).
+#[utoipa::path(
+    post,
+    path = "/api/v1/machines/{name}/fork",
+    tag = "Machines",
+    params(
+        ("name" = String, Path, description = "Golden (source) machine name")
+    ),
+    request_body = ForkRequest,
+    responses(
+        (status = 200, description = "Clone forked and running", body = MachineInfo),
+        (status = 400, description = "Invalid request (e.g. nested fork)", body = ApiErrorResponse),
+        (status = 404, description = "Golden machine not found", body = ApiErrorResponse),
+        (status = 409, description = "Golden not forkable, or clone name already exists", body = ApiErrorResponse),
+        (status = 500, description = "Fork failed", body = ApiErrorResponse)
+    )
+)]
+pub async fn fork_machine(
+    State(state): State<Arc<ApiState>>,
+    Path(golden): Path<String>,
+    Json(req): Json<ForkRequest>,
+) -> Result<Json<MachineInfo>, ApiError> {
+    let clone = req.name.clone();
+    let pinned_ports: Vec<(u16, u16)> = req.ports.iter().map(|p| (p.host, p.guest)).collect();
+
+    // Serialize lifecycle on the CLONE name so a concurrent start/stop/delete of
+    // the same clone can't race the fork's register + boot. The golden is only
+    // read + frozen via its control socket, which tolerates concurrent forks.
+    let lifecycle = state.lifecycle_lock(&clone);
+    let _guard = lifecycle.lock().await;
+
+    // Phase 1: freeze + snapshot the golden, register the clone with CoW disks.
+    // This is unix-socket IO + disk work, so it runs on the blocking pool. Its
+    // failures carry precondition semantics (404/409/400), mapped distinctly
+    // from the boot failures below.
+    let prep = {
+        let db = state.db().clone();
+        let golden_b = golden.clone();
+        let clone_b = clone.clone();
+        let ports = pinned_ports.clone();
+        tokio::task::spawn_blocking(move || {
+            crate::agent::fork::prepare_fork(
+                &db, &golden_b, &clone_b, &ports, /* clone_forkable */ false,
+            )
+        })
+        .await
+        .map_err(|e| ApiError::internal(format!("task error: {}", e)))?
+        .map_err(classify_fork_error)?
+    };
+
+    // Phase 2: boot the clone from the golden's in-memory snapshot (warm — its
+    // processes are already running in the restored RAM, so unlike a cold start
+    // there is no image workload to launch), then rejuvenate its identity.
+    let clone_b = clone.clone();
+    let db = state.db().clone();
+    let (manager, pid, clone_record) = tokio::task::spawn_blocking(move || {
+        let record = prep.clone_record;
+        let mounts = record.host_mounts();
+        let ports = record.port_mappings();
+        let resources = record.vm_resources();
+
+        let manager =
+            AgentManager::for_vm_with_sizes(&clone_b, record.storage_gb, record.overlay_gb)
+                .map_err(|e| format!("failed to create agent manager: {}", e))?;
+
+        let mut features = crate::api::state::build_launch_features(
+            Some(&clone_b),
+            record.source_smolmachine.as_deref(),
+        )
+        .map_err(|e| format!("failed to prepare packed layers: {}", e))?;
+        // Boot from the golden's snapshot instead of cold-booting.
+        features.snapshot_dir = Some(prep.snapshot_dir);
+
+        if let Err(e) = manager.ensure_running_via_subprocess(mounts, ports, resources, features) {
+            // Boot failed: roll back the clone registration so a failed fork
+            // leaves nothing half-created.
+            let _ = db.remove_vm(&clone_b);
+            let _ = std::fs::remove_dir_all(vm_data_dir(&clone_b));
+            return Err(format!("failed to boot clone: {}", e));
+        }
+
+        // Give the clone a fresh identity (hostname, machine-id, RNG) so it does
+        // not share the golden's random stream.
+        crate::agent::fork::rejuvenate_clone(&clone_b);
+
+        let pid = manager.child_pid();
+        Ok::<_, String>((manager, pid, record))
+    })
+    .await
+    .map_err(|e| ApiError::internal(format!("task error: {}", e)))?
+    .map_err(classify_launch_error)?;
+
+    // Register the clone so exec/run endpoints can reach it.
+    state.insert_machine(&clone, machine_entry_from_record(&clone_record, manager));
+
+    // Persist the running state.
+    let pid_start_time = pid.and_then(process_start_time);
+    let record = state
+        .db()
+        .update_vm(&clone, |r| {
+            r.state = RecordState::Running;
+            r.pid = pid;
+            r.pid_start_time = pid_start_time;
+        })
+        .map_err(ApiError::database)?
+        .ok_or_else(|| {
+            ApiError::NotFound(format!(
+                "clone '{}' disappeared from database during fork",
+                clone
+            ))
+        })?;
+
+    let mut info = record_to_info(&clone, &record);
     info.state = "running".to_string();
     info.pid = pid;
     Ok(Json(info))

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -1348,6 +1348,11 @@ pub async fn delete_machine(
     // Remove VM data directory (disk images, sockets, etc.)
     let data_dir = vm_data_dir(&name);
     if data_dir.exists() {
+        // Release this VM's per-VM uid (if any) back to the allocator before the
+        // dir holding its `.vm-uid` record is removed, so a high-churn cloud node
+        // doesn't leak the uid range. A fork clone has no uid of its own (it
+        // shares its golden's). See process::free_vm_uid.
+        crate::process::free_vm_uid(&crate::agent::vm_uid_registry_dir(), &data_dir);
         if let Err(e) = std::fs::remove_dir_all(&data_dir) {
             tracing::warn!(error = %e, "failed to remove VM data directory: {}", data_dir.display());
         }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -85,6 +85,7 @@ use state::ApiState;
         handlers::machines::list_machines,
         handlers::machines::get_machine,
         handlers::machines::start_machine,
+        handlers::machines::fork_machine,
         handlers::machines::stop_machine,
         handlers::machines::delete_machine,
         handlers::machines::exec_machine,
@@ -105,6 +106,8 @@ use state::ApiState;
         types::LogsQuery,
         types::MachineExecRequest,
         types::ResizeMachineRequest,
+        types::ForkRequest,
+        types::StartMachineQuery,
         // Response types
         types::HealthResponse,
         types::CapacityResponse,
@@ -168,6 +171,7 @@ pub fn create_router(state: Arc<ApiState>, cors_origins: Vec<String>) -> Router 
         .route("/", get(handlers::machines::list_machines))
         .route("/{id}", get(handlers::machines::get_machine))
         .route("/{id}/start", post(handlers::machines::start_machine))
+        .route("/{id}/fork", post(handlers::machines::fork_machine))
         .route("/{id}/stop", post(handlers::machines::stop_machine))
         .route("/{id}", delete(handlers::machines::delete_machine))
         // Exec routes

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -606,3 +606,27 @@ pub struct ResizeMachineRequest {
     #[schema(example = 20)]
     pub overlay_gb: Option<u64>,
 }
+
+/// Query string for `POST /machines/{name}/start`.
+#[derive(Debug, Default, Deserialize, ToSchema)]
+pub struct StartMachineQuery {
+    /// Start as a fork base: back the guest RAM with a memfd (copy-on-write
+    /// cloneable) and expose a control socket so the machine can later be forked
+    /// with `POST /machines/{name}/fork`. The golden freezes after its first fork.
+    #[serde(default)]
+    pub forkable: bool,
+}
+
+/// Request to fork a running, forkable golden machine into a new clone.
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ForkRequest {
+    /// Name for the new clone machine.
+    #[schema(example = "clone-1")]
+    pub name: String,
+    /// Pin the clone's inbound port forwards. Without this, the golden's
+    /// forwards are remapped to freshly-allocated host ports so the clone does
+    /// not collide with the still-running golden or sibling clones.
+    #[serde(default)]
+    pub ports: Vec<PortSpec>,
+}

--- a/src/cli/cleanup_ephemeral.rs
+++ b/src/cli/cleanup_ephemeral.rs
@@ -32,6 +32,12 @@ pub fn run(vm_name: &str, pid: i32, start_time: u64, ephemeral_name: &str) {
                 return false;
             }
             if data_dir.is_dir() {
+                // Release this VM's per-VM uid before its `.vm-uid` record goes
+                // with the dir. `machine run` is the highest-churn path, so
+                // freeing it here keeps the uid registry small (the allocator
+                // self-heals stale entries too, but proactively freeing avoids
+                // buildup).
+                smolvm::process::free_vm_uid(&smolvm::agent::vm_uid_registry_dir(), &data_dir);
                 std::fs::remove_dir_all(&data_dir).is_ok()
             } else {
                 !data_dir.exists()

--- a/src/cli/internal_boot.rs
+++ b/src/cli/internal_boot.rs
@@ -158,6 +158,15 @@ pub fn run(config_path: PathBuf) -> smolvm::Result<()> {
             eprintln!("[uid-drop] failed, refusing to boot over-privileged: {e}");
             smolvm::process::exit_child(1);
         }
+        // The setuid above clears the dumpable flag. A forkable golden's clones
+        // map its guest-RAM memfd via /proc/<golden>/fd, which ptrace_may_access
+        // denies on a non-dumpable target even at a uid match — so re-assert
+        // dumpable here (after the drop) for a forkable VM, or fork breaks under
+        // per-VM uid isolation. See process::set_dumpable.
+        #[cfg(target_os = "linux")]
+        if std::env::var_os("SMOLVM_FORKABLE").is_some() {
+            smolvm::process::set_dumpable(true);
+        }
     }
 
     // A fork clone restores by mapping the golden's guest-RAM memfd, opened via

--- a/src/cli/internal_boot.rs
+++ b/src/cli/internal_boot.rs
@@ -269,7 +269,13 @@ pub fn run(config_path: PathBuf) -> smolvm::Result<()> {
         // be able to tamper with. Landlock needs an existing path to build the
         // rule, so pre-create it empty; the guest overwrites it with content
         // and the host treats non-empty as ready (see manager.rs wait loop).
-        let ready_marker = config.rootfs_path.join(smolvm_protocol::AGENT_READY_MARKER);
+        // The marker name is per-VM (the host passes it via SMOLVM_READY_MARKER so
+        // concurrent boots don't share one file); fall back to the shared constant
+        // if unset. Granting/pre-creating the WRONG name would leave the agent's
+        // real (per-VM) write Landlock-denied → readiness limps to the vsock grace.
+        let marker_name = std::env::var(smolvm_protocol::guest_env::READY_MARKER)
+            .unwrap_or_else(|_| smolvm_protocol::AGENT_READY_MARKER.to_string());
+        let ready_marker = config.rootfs_path.join(marker_name);
         let _ = std::fs::File::create(&ready_marker);
         read_write.push(ready_marker);
 

--- a/src/cli/internal_boot.rs
+++ b/src/cli/internal_boot.rs
@@ -160,6 +160,15 @@ pub fn run(config_path: PathBuf) -> smolvm::Result<()> {
         }
     }
 
+    // A fork clone restores by mapping the golden's guest-RAM memfd, opened via
+    // /proc/<golden_pid>/fd/<N> — an anonymous inode with no filesystem path.
+    // Landlock is path-based and cannot grant access to a pathless object, so a
+    // Landlock-confined clone can never open the memfd (EACCES → can't boot).
+    // Clones therefore skip Landlock; they stay confined by seccomp, the per-VM
+    // uid drop, and the cgroup. Goldens and normal VMs are unaffected.
+    #[cfg(target_os = "linux")]
+    let is_fork_clone = std::env::var_os("SMOLVM_SNAPSHOT_DIR").is_some();
+
     // Confine the VMM's filesystem view via Landlock — BEFORE seccomp (whose
     // allowlist omits the landlock_* syscalls) and before libkrun loads. Granted:
     // read+exec on rootfs/libs/system dirs, read-write on this VM's own data dir
@@ -168,7 +177,14 @@ pub fn run(config_path: PathBuf) -> smolvm::Result<()> {
     // derived per-VM from the boot config. Gated by SMOLVM_LANDLOCK=enforce
     // (unset = off); fails closed. See docs/runtime-isolation-hardening.md.
     #[cfg(target_os = "linux")]
-    if std::env::var("SMOLVM_LANDLOCK").as_deref() == Ok("enforce") {
+    if std::env::var("SMOLVM_LANDLOCK").as_deref() == Ok("enforce") && is_fork_clone {
+        eprintln!(
+            "[landlock] fork clone skips Landlock (must map the golden's pathless \
+             memfd); still confined by seccomp + uid drop + cgroup"
+        );
+    }
+    #[cfg(target_os = "linux")]
+    if std::env::var("SMOLVM_LANDLOCK").as_deref() == Ok("enforce") && !is_fork_clone {
         let mut read_exec: Vec<std::path::PathBuf> = [
             "/usr", "/lib", "/lib64", "/bin", "/sbin", "/etc", "/opt", "/proc", "/sys",
         ]

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -103,6 +103,28 @@ impl ServeStartCmd {
         // before the tokio runtime, so set_var is safe.
         smolvm::process::apply_system_data_root(/* allow_auto */ true);
 
+        // Lock the state dirs holding machine records / credentials / config down
+        // to 0700 so a Landlock-exempt fork clone (which runs as its golden's uid)
+        // can't read other tenants' data through the now world-traversable data
+        // root. These sit OUTSIDE the traversable VM-data/rootfs chains, so this
+        // doesn't affect VM boots.
+        #[cfg(target_os = "linux")]
+        if smolvm::process::vm_uid_drop_active() {
+            use std::os::unix::fs::PermissionsExt;
+            let mut sensitive: Vec<std::path::PathBuf> = Vec::new();
+            if let Some(d) = dirs::data_local_dir().or_else(dirs::data_dir) {
+                sensitive.push(d.join("smolvm").join("server"));
+                sensitive.push(d.join("smolvm").join("node-credentials"));
+            }
+            if let Some(h) = dirs::home_dir() {
+                sensitive.push(h.join(".config").join("smolvm"));
+            }
+            for dir in sensitive {
+                let _ = std::fs::create_dir_all(&dir);
+                let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700));
+            }
+        }
+
         let listen_target = ListenTarget::parse(&self.listen)?;
 
         // Set up verbose logging if requested

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -95,6 +95,14 @@ impl ServeStartCmd {
             std::env::set_var("SMOLVM_LOG_FORMAT", "json");
         }
 
+        // Data root. Per-VM uid isolation needs every smolvm path traversable by
+        // the dropped uids; XDG-under-a-700-home isn't, a system data root is.
+        // serve additionally auto-defaults to /var/lib/smolvm when privileged
+        // (allow_auto = true). An explicit SMOLVM_DATA_DIR was already applied for
+        // every command in main(); calling again is idempotent. Single-threaded
+        // before the tokio runtime, so set_var is safe.
+        smolvm::process::apply_system_data_root(/* allow_auto */ true);
+
         let listen_target = ListenTarget::parse(&self.listen)?;
 
         // Set up verbose logging if requested

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -152,6 +152,30 @@ impl ServeStartCmd {
             }
         }
 
+        // Per-VM uid isolation preflight. When serve is privileged each VMM drops
+        // to its own unprivileged uid (process::vm_drop_ids), containing a
+        // guest→VMM escape to one VM. That only works if the data root is
+        // traversable (others-execute) by the drop uid — an XDG-under-a-700-home
+        // layout is not, and the VMM would die with a cryptic readiness timeout.
+        // Warn loudly with the fix instead. Opt out with SMOLVM_VM_UID_DROP=off.
+        #[cfg(target_os = "linux")]
+        if smolvm::process::vm_uid_drop_active() {
+            let cache_root = smolvm::agent::vm_cache_root();
+            match smolvm::process::first_nontraversable_ancestor(&cache_root) {
+                Some(blocker) => tracing::warn!(
+                    blocker = %blocker.display(),
+                    "per-VM uid isolation is active but {b} is not traversable (o+x) by \
+                     unprivileged uids — VMMs will fail to start. Use a world-traversable data \
+                     root (e.g. run serve with HOME=/var/lib/smolvm) or `chmod o+x {b}`, or \
+                     disable with SMOLVM_VM_UID_DROP=off",
+                    b = blocker.display(),
+                ),
+                None => tracing::info!(
+                    "per-VM uid isolation active (each VMM drops to its own unprivileged uid)"
+                ),
+            }
+        }
+
         // Create the runtime with signal handling enabled
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .enable_all()

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -649,11 +649,6 @@ pub(crate) fn print_create_success(params: &CreateVmParams) {
 // Fork
 // ============================================================================
 
-/// Path to a forkable machine's control socket (pause/resume/checkpoint/FORK).
-fn control_socket_path(name: &str) -> std::path::PathBuf {
-    vm_data_dir(name).join("control.sock")
-}
-
 /// Per-launch fork parameters, threaded into `start_vm_named` instead of mutating
 /// process-global env vars. The launcher (in the spawned `_boot-vm`) reads these
 /// from its own env, which the manager now sets explicitly on the child — so the
@@ -673,40 +668,9 @@ pub struct ForkLaunch {
 pub fn forkable_launch(name: &str) -> ForkLaunch {
     ForkLaunch {
         forkable: true,
-        control_socket: Some(control_socket_path(name)),
+        control_socket: Some(smolvm::agent::fork::control_socket_path(name)),
         snapshot_dir: None,
     }
-}
-
-/// Send a single line command to a VM control socket and return its reply line.
-fn control_socket_cmd(sock: &std::path::Path, cmd: &str) -> smolvm::Result<String> {
-    use smolvm::Error;
-    use std::io::{Read, Write};
-    use std::os::unix::net::UnixStream;
-
-    let mut stream = UnixStream::connect(sock)
-        .map_err(|e| Error::agent("connect control socket", e.to_string()))?;
-    stream
-        .set_read_timeout(Some(std::time::Duration::from_secs(60)))
-        .ok();
-    stream
-        .write_all(format!("{cmd}\n").as_bytes())
-        .map_err(|e| Error::agent("write control socket", e.to_string()))?;
-    let mut reply = String::new();
-    let mut byte = [0u8; 1];
-    loop {
-        match stream.read(&mut byte) {
-            Ok(0) => break,
-            Ok(_) => {
-                if byte[0] == b'\n' {
-                    break;
-                }
-                reply.push(byte[0] as char);
-            }
-            Err(e) => return Err(Error::agent("read control socket", e.to_string())),
-        }
-    }
-    Ok(reply)
 }
 
 /// Fork a running, forkable `golden` machine into a new `clone`.
@@ -721,180 +685,21 @@ pub fn fork_vm(
     clone_forkable: bool,
     pinned_ports: &[(u16, u16)],
 ) -> smolvm::Result<()> {
-    use smolvm::Error;
-
-    validate_vm_name(clone, "clone name").map_err(|e| Error::config("clone name", e))?;
-
-    // Nested fork is unsupported: a clone boots from a copy-on-write MAP_PRIVATE
-    // mapping of the golden's RAM, not a fresh memfd, so it cannot itself be
-    // re-forked (its FORK would fail with "no memfd-backed RAM"). Reject
-    // `--forkable` up front instead of producing a clone that looks forkable but
-    // isn't.
-    if clone_forkable {
-        return Err(Error::agent(
-            "fork",
-            "nested fork is not supported: a clone cannot be re-forked, so `--forkable` \
-             on a fork has no effect (drop it)",
-        ));
-    }
-
     let db = SmolvmDb::open()?;
-    let golden_rec = db
-        .get_vm(golden)?
-        .ok_or_else(|| Error::vm_not_found(golden))?;
 
-    // The golden must be alive and forkable. We probe the control socket rather
-    // than the vsock agent: after its first fork the golden is frozen (paused)
-    // as the shared base, so an agent ping would fail — but STATUS still answers
-    // (running or paused), and we can fork it again.
-    let ctl = control_socket_path(golden);
-    if !ctl.exists() {
-        return Err(Error::agent(
-            "fork",
-            format!("golden '{golden}' is not running forkable; start it with `machine start --forkable --name {golden}`"),
-        ));
-    }
-    let status = control_socket_cmd(&ctl, "STATUS").map_err(|e| {
-        Error::agent(
-            "fork",
-            format!("golden '{golden}' control socket not responding ({e}); start it with `machine start --forkable --name {golden}`"),
-        )
-    })?;
-    if !status.starts_with("OK") {
-        return Err(Error::agent(
-            "fork",
-            format!("golden '{golden}' is not ready to fork: {status}"),
-        ));
-    }
-    if db.get_vm(clone)?.is_some() {
-        return Err(Error::agent(
-            "fork",
-            format!("machine '{clone}' already exists"),
-        ));
-    }
-
-    // Clone dir + snapshot dir.
-    let clone_dir = vm_data_dir(clone);
-    let snapshot_dir = clone_dir.join("snapshot");
-    std::fs::create_dir_all(&snapshot_dir)
-        .map_err(|e| Error::agent("create clone dir", e.to_string()))?;
-
-    // Register the clone in the DB with the golden's config, no running-state,
-    // and its port forwards remapped to fresh host ports. With the default TSI
-    // backend outbound is proxied per-process (each clone gets it for free, no
-    // guest MAC/IP involved); only inbound host ports must be made distinct so
-    // the clone is reachable without colliding with the still-running golden or
-    // sibling clones.
-    let mut clone_rec = golden_rec.clone();
-    clone_rec.name = clone.to_string();
-    clone_rec.pid = None;
-    clone_rec.pid_start_time = None;
-    if !pinned_ports.is_empty() {
-        // User pinned the clone's forwards explicitly — use them as-is.
-        clone_rec.ports = pinned_ports.to_vec();
-        for (h, g) in &clone_rec.ports {
-            eprintln!("  port {h}->{g} (pinned)");
-        }
-    } else if !clone_rec.ports.is_empty() {
-        let mut remapped = Vec::with_capacity(clone_rec.ports.len());
-        for (golden_host, guest) in &clone_rec.ports {
-            match alloc_free_host_port() {
-                Some(h) => {
-                    eprintln!(
-                        "  port {golden_host}->{guest} (golden) remapped to {h}->{guest} (clone)"
-                    );
-                    remapped.push((h, *guest));
-                }
-                None => eprintln!(
-                    "  warning: could not allocate a host port for guest port {guest}; dropping it"
-                ),
-            }
-        }
-        clone_rec.ports = remapped;
-    }
-    clone_rec.golden = Some(golden.to_string());
-    let gdir = vm_data_dir(golden);
-    db.insert_vm(clone, &clone_rec)?;
-
-    // Freeze the golden and write its snapshot (checkpoint + memfd manifest).
+    // Freeze + snapshot the golden, register the clone (CoW disks + DB record).
+    // The launch-agnostic mechanics live in the lib (`agent::fork`) so the CLI
+    // and the serve API share one implementation.
     eprintln!("Freezing golden '{golden}' as fork base...");
-    let reply = control_socket_cmd(&ctl, &format!("FORK {}", snapshot_dir.display()))?;
-    if !reply.starts_with("OK") {
-        let _ = db.remove_vm(clone);
-        let _ = std::fs::remove_dir_all(&clone_dir);
-        return Err(Error::agent("fork", format!("golden FORK failed: {reply}")));
-    }
-
-    // Give the clone its own disks. The golden is frozen with its block workers
-    // quiesced and flushed, so its images are a consistent backing. On Linux
-    // each disk is a qcow2 copy-on-write overlay over the golden's — filesystem
-    // independent, so the overlay starts near-empty and the fork is O(metadata)
-    // regardless of how much data the golden holds. macOS clonefiles the disks
-    // (APFS CoW). Either way the `.formatted` marker is copied so the clone
-    // never reformats and wipes the inherited filesystem.
-    let clone_disks = || -> smolvm::Result<()> {
-        // The golden's actual disks that exist, resolved by file presence
-        // (`.qcow2` if the golden is itself a clone, else `.raw`) — the same
-        // single source of truth the agent manager uses. Each entry pairs the
-        // canonical `.raw` filename (for naming the clone's disk) with the
-        // golden's real backing file and its format.
-        let disks: Vec<(&str, std::path::PathBuf, smolvm::data::disk::DiskFormat)> = [
-            smolvm::data::storage::STORAGE_DISK_FILENAME,
-            smolvm::data::storage::OVERLAY_DISK_FILENAME,
-        ]
-        .into_iter()
-        .map(|raw| {
-            let (src, fmt) = smolvm::agent::resolve_disk_image(&gdir, raw);
-            (raw, src, fmt)
-        })
-        .filter(|(_, src, _)| src.exists())
-        .collect();
-
-        #[cfg(target_os = "linux")]
-        {
-            // Each clone disk is a qcow2 CoW overlay over the golden's disk.
-            // Build all overlay specs first so libkrun is loaded once for the
-            // batch (absolute backing path: it's written verbatim into the
-            // overlay header), then copy the `.formatted` markers so the clone
-            // never reformats and wipes the inherited filesystem.
-            let mut specs = Vec::with_capacity(disks.len());
-            for (raw, src, fmt) in &disks {
-                let base = src
-                    .canonicalize()
-                    .map_err(|e| Error::agent("clone disk", format!("{}: {e}", src.display())))?;
-                let overlay = clone_dir.join(std::path::Path::new(raw).with_extension("qcow2"));
-                specs.push((overlay, base, *fmt));
-            }
-            smolvm::agent::create_disk_overlays(&specs)?;
-            for (raw, _, _) in &disks {
-                // Marker basename is the disk stem + ".formatted" (same for the
-                // golden's `.raw`/`.qcow2` and the clone's `.qcow2`).
-                let marker = std::path::Path::new(raw).with_extension("formatted");
-                let src_marker = gdir.join(&marker);
-                if src_marker.exists() {
-                    let _ = std::fs::copy(&src_marker, clone_dir.join(&marker));
-                }
-            }
+    let prep = smolvm::agent::fork::prepare_fork(&db, golden, clone, pinned_ports, clone_forkable)?;
+    for (golden_host, guest, clone_host) in &prep.port_remaps {
+        if pinned_ports.is_empty() {
+            eprintln!(
+                "  port {golden_host}->{guest} (golden) remapped to {clone_host}->{guest} (clone)"
+            );
+        } else {
+            eprintln!("  port {clone_host}->{guest} (pinned)");
         }
-        #[cfg(target_os = "macos")]
-        {
-            // macOS uses clonefile (APFS CoW), keeping the golden's disk format.
-            for (_, src, _) in &disks {
-                let dst = clone_dir.join(src.file_name().unwrap());
-                smolvm::disk_utils::clone_or_copy_file(src, &dst)
-                    .map_err(|e| Error::agent("clone disk", format!("{}: {e}", src.display())))?;
-                let src_marker = src.with_extension("formatted");
-                if src_marker.exists() {
-                    let _ = std::fs::copy(&src_marker, dst.with_extension("formatted"));
-                }
-            }
-        }
-        Ok(())
-    };
-    if let Err(e) = clone_disks() {
-        let _ = db.remove_vm(clone);
-        let _ = std::fs::remove_dir_all(&clone_dir);
-        return Err(e);
     }
 
     // Boot the clone from the golden's snapshot instead of cold-booting.
@@ -905,85 +710,21 @@ pub fn fork_vm(
         None,
         /* from_snapshot */ true,
         ForkLaunch {
-            snapshot_dir: Some(snapshot_dir.clone()),
+            snapshot_dir: Some(prep.snapshot_dir.clone()),
             ..Default::default()
         },
     );
     if result.is_ok() {
-        rejuvenate_clone(clone);
+        smolvm::agent::fork::rejuvenate_clone(clone);
         eprintln!(
             "Forked '{golden}' -> '{clone}'. Golden stays frozen as the fork base \
              (do not start it again while clones exist)."
         );
     } else {
         let _ = db.remove_vm(clone);
-        let _ = std::fs::remove_dir_all(&clone_dir);
+        let _ = std::fs::remove_dir_all(vm_data_dir(clone));
     }
     result
-}
-
-/// Best-effort per-clone identity rejuvenation after a fork. A clone inherits
-/// the golden's hostname, machine-id, and (critically) RNG state, so without
-/// this every clone would share the golden's random stream — a security
-/// problem and a source of duplicate-identity bugs across a pool. Run over the
-/// freshly-booted clone's agent: set a unique hostname, mint a fresh
-/// machine-id, and stir the kernel RNG with fresh host entropy so the streams
-/// diverge. Failures are warnings, not fatal (the clone still works).
-///
-/// Note: this stirs but does not *credit* entropy (no `RNDADDENTROPY`/VMGENID
-/// yet), and does not re-address the network (MAC/IP) — both are follow-ups.
-fn rejuvenate_clone(clone: &str) {
-    let sock = vm_data_dir(clone).join("agent.sock");
-    let seed = host_random_hex(64);
-    // Names are validated (alphanumeric + dashes), so single-quoting is safe.
-    let script = format!(
-        "hostname '{c}' 2>/dev/null; printf '%s\\n' '{c}' > /etc/hostname 2>/dev/null; \
-         (cat /proc/sys/kernel/random/uuid 2>/dev/null | tr -d '-' > /etc/machine-id) 2>/dev/null; \
-         printf '%s' '{s}' > /dev/urandom 2>/dev/null; true",
-        c = clone,
-        s = seed,
-    );
-    let mut client = match smolvm::agent::AgentClient::connect_with_retry(&sock) {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!("Warning: clone '{clone}' rejuvenation skipped (agent connect: {e})");
-            return;
-        }
-    };
-    match client.vm_exec(
-        vec!["/bin/sh".into(), "-c".into(), script],
-        vec![],
-        None,
-        Some(std::time::Duration::from_secs(10)),
-        None,
-    ) {
-        Ok((0, _, _)) => {}
-        Ok((code, _, stderr)) => eprintln!(
-            "Warning: clone '{clone}' rejuvenation exited {code}: {}",
-            String::from_utf8_lossy(&stderr).trim()
-        ),
-        Err(e) => eprintln!("Warning: clone '{clone}' rejuvenation failed: {e}"),
-    }
-}
-
-/// Allocate a currently-free host TCP port by binding to port 0 and reading
-/// back the OS-assigned port. Used to give each clone distinct inbound forwards.
-fn alloc_free_host_port() -> Option<u16> {
-    std::net::TcpListener::bind(("127.0.0.1", 0))
-        .ok()
-        .and_then(|l| l.local_addr().ok())
-        .map(|addr| addr.port())
-}
-
-/// Read `hex_len/2` random bytes from the host RNG, hex-encoded. Used to seed
-/// each clone's RNG with distinct host entropy.
-fn host_random_hex(hex_len: usize) -> String {
-    use std::io::Read;
-    let mut buf = vec![0u8; hex_len / 2];
-    if let Ok(mut f) = std::fs::File::open("/dev/urandom") {
-        let _ = f.read_exact(&mut buf);
-    }
-    buf.iter().map(|b| format!("{b:02x}")).collect()
 }
 
 // ============================================================================

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -1498,6 +1498,9 @@ pub fn delete_vm(name: &str, force: bool, options: DeleteVmOptions) -> smolvm::R
     let data_dir = vm_data_dir(name);
     if data_dir.exists() {
         println!("Cleaning up data directory for vm: {}", name);
+        // Release this VM's per-VM uid (if any) before the dir holding its
+        // `.vm-uid` record is removed. See process::free_vm_uid.
+        smolvm::process::free_vm_uid(&smolvm::agent::vm_uid_registry_dir(), &data_dir);
         if let Err(e) = std::fs::remove_dir_all(&data_dir) {
             tracing::warn!(error = %e, "Failed to remove VM data directory: {}", data_dir.display());
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,12 @@ enum Commands {
 }
 
 fn main() {
+    // Honor an explicit SMOLVM_DATA_DIR for EVERY command (so the CLI and serve
+    // agree on where smolvm state lives) before anything computes a path. The
+    // auto /var/lib/smolvm default is serve-only (applied in its run()). Done
+    // first, single-threaded, so the set_var is safe.
+    smolvm::process::apply_system_data_root(/* allow_auto */ false);
+
     // Auto-detect packed binary mode BEFORE parsing the normal CLI.
     // If this executable has a `.smolmachine` sidecar, appended assets,
     // or a Mach-O section with packed data, run as a packed binary instead.

--- a/src/process.rs
+++ b/src/process.rs
@@ -138,6 +138,23 @@ pub fn harden_self() {
     }
 }
 
+/// (Re)assert the process's `PR_SET_DUMPABLE` flag.
+///
+/// `setuid()` clears dumpable, after which `ptrace_may_access` denies even a
+/// same-uid reader of `/proc/<pid>/{mem,fd}` without `CAP_SYS_PTRACE`. A forkable
+/// golden's clones map its guest-RAM memfd via `/proc/<golden>/fd`, so the
+/// forkable boot re-asserts dumpable *after* its per-VM uid drop — without this,
+/// fork breaks under uid isolation. Only the golden's own uid (under per-VM uids,
+/// exactly its clones) can reach it. Linux-only; no-op elsewhere.
+#[cfg(target_os = "linux")]
+pub fn set_dumpable(dumpable: bool) {
+    unsafe { libc::prctl(libc::PR_SET_DUMPABLE, i32::from(dumpable), 0, 0, 0) };
+}
+
+/// No-op where `prctl` isn't applicable (macOS dev).
+#[cfg(not(target_os = "linux"))]
+pub fn set_dumpable(_dumpable: bool) {}
+
 // ============================================================================
 // Per-VM cgroup v2 resource caps (noisy-neighbor / host-DoS containment)
 //
@@ -581,6 +598,136 @@ pub fn drop_privileges(uid: u32, gid: u32) -> std::result::Result<(), String> {
 /// No-op stub where privilege dropping isn't applicable (macOS dev).
 #[cfg(not(target_os = "linux"))]
 pub fn drop_privileges(_uid: u32, _gid: u32) -> std::result::Result<(), String> {
+    Ok(())
+}
+
+// ============================================================================
+// Per-VM uid allocation (defense-in-depth for a guest→VMM escape)
+//
+// When the launcher runs privileged (root `serve`), each VMM is dropped to its
+// own dedicated unprivileged uid so a guest→VMM escape is contained to that one
+// VM: it can't ptrace/read other tenants' VMMs (different uid), reach their
+// disks (different ownership), or touch root/host files. The uid is derived
+// deterministically from the VM's data dir (stable across restarts, no
+// allocation state), mapped into a high range well clear of system, regular,
+// `nobody`, and systemd-DynamicUser uids. A fork clone uses its GOLDEN's uid so
+// it can map the golden's guest-RAM memfd via /proc/<golden>/fd (same uid).
+// ============================================================================
+
+/// Base of the reserved per-VM uid range. Above normal system (<1000), user
+/// (1000–60000), `nobody` (65534), and systemd DynamicUser (61184–65519) uids.
+const VM_UID_BASE: u32 = 2_000_000;
+/// Span of the per-VM uid range: uids land in `[BASE, BASE+SPAN)`. Wide enough
+/// that birthday collisions need thousands of concurrent VMs (a collision only
+/// weakens cross-VM isolation between the two colliding VMs, never correctness).
+const VM_UID_SPAN: u32 = 100_000_000;
+
+/// Whether per-VM uid isolation applies here: the launcher is privileged (so it
+/// can chown + setuid) and the operator hasn't opted out with
+/// `SMOLVM_VM_UID_DROP=off`.
+#[cfg(target_os = "linux")]
+pub fn vm_uid_drop_active() -> bool {
+    let is_root = unsafe { libc::geteuid() } == 0;
+    let opted_out =
+        std::env::var_os("SMOLVM_VM_UID_DROP").as_deref() == Some(std::ffi::OsStr::new("off"));
+    is_root && !opted_out
+}
+
+/// No-op where the uid drop isn't applicable (macOS dev).
+#[cfg(not(target_os = "linux"))]
+pub fn vm_uid_drop_active() -> bool {
+    false
+}
+
+/// Per-VM uid isolation needs every ancestor of the data root to be traversable
+/// (others-execute) by the drop uid, or the dropped VMM can't reach its own
+/// files (it fails with a cryptic readiness timeout). Returns the first ancestor
+/// of `path` (walking up) that a non-owner can't traverse, or `None` if the whole
+/// chain is fine. `serve` uses it to warn the operator up front.
+#[cfg(target_os = "linux")]
+pub fn first_nontraversable_ancestor(path: &std::path::Path) -> Option<std::path::PathBuf> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut cur = Some(path);
+    while let Some(dir) = cur {
+        if let Ok(meta) = std::fs::metadata(dir) {
+            if meta.is_dir() && meta.permissions().mode() & 0o001 == 0 {
+                return Some(dir.to_path_buf());
+            }
+        }
+        cur = dir.parent();
+    }
+    None
+}
+
+/// No-op where the uid drop isn't applicable (macOS dev).
+#[cfg(not(target_os = "linux"))]
+pub fn first_nontraversable_ancestor(_path: &std::path::Path) -> Option<std::path::PathBuf> {
+    None
+}
+
+/// Deterministic per-VM uid from a data dir whose basename is the 16-hex VM
+/// hash. Falls back to the base uid if the name isn't hex (never panics).
+pub fn vm_uid_for_dir(data_dir: &std::path::Path) -> u32 {
+    let name = data_dir.file_name().and_then(|n| n.to_str()).unwrap_or("0");
+    let prefix = name.get(..8).unwrap_or(name);
+    let v = u32::from_str_radix(prefix, 16).unwrap_or(0);
+    VM_UID_BASE + (v % VM_UID_SPAN)
+}
+
+/// The `(uid, gid)` a VM's VMM should drop to, or `None` when the uid drop
+/// doesn't apply (unprivileged launcher, or `SMOLVM_VM_UID_DROP=off`). For a
+/// fork clone (`snapshot_dir` set, laid out as `<golden_dir>/fork-snapshots/
+/// <clone>`), the id is derived from the GOLDEN's dir so the clone shares the
+/// golden's uid and can map its memfd. gid mirrors uid (a per-VM group).
+#[cfg(target_os = "linux")]
+pub fn vm_drop_ids(
+    data_dir: &std::path::Path,
+    snapshot_dir: Option<&std::path::Path>,
+) -> Option<(u32, u32)> {
+    if !vm_uid_drop_active() {
+        return None;
+    }
+    let uid_dir = match snapshot_dir {
+        Some(snap) => snap.parent().and_then(|p| p.parent()).unwrap_or(data_dir),
+        None => data_dir,
+    };
+    let uid = vm_uid_for_dir(uid_dir);
+    Some((uid, uid))
+}
+
+/// No-op where the uid drop isn't applicable (macOS dev).
+#[cfg(not(target_os = "linux"))]
+pub fn vm_drop_ids(
+    _data_dir: &std::path::Path,
+    _snapshot_dir: Option<&std::path::Path>,
+) -> Option<(u32, u32)> {
+    None
+}
+
+/// Recursively `lchown` `path` to `(uid, gid)` (symlinks not followed). Used by
+/// the privileged launcher to hand a VM's data dir + disks + sockets to the uid
+/// its VMM will drop to. Linux-only; the caller is root.
+#[cfg(target_os = "linux")]
+pub fn chown_tree(path: &std::path::Path, uid: u32, gid: u32) -> std::io::Result<()> {
+    use std::os::unix::ffi::OsStrExt;
+    let c = std::ffi::CString::new(path.as_os_str().as_bytes())
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;
+    if unsafe { libc::lchown(c.as_ptr(), uid, gid) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // Recurse into real directories only (not symlinked ones).
+    let meta = std::fs::symlink_metadata(path)?;
+    if meta.file_type().is_dir() {
+        for entry in std::fs::read_dir(path)? {
+            chown_tree(&entry?.path(), uid, gid)?;
+        }
+    }
+    Ok(())
+}
+
+/// No-op where chown isn't applicable (macOS dev).
+#[cfg(not(target_os = "linux"))]
+pub fn chown_tree(_path: &std::path::Path, _uid: u32, _gid: u32) -> std::io::Result<()> {
     Ok(())
 }
 
@@ -1807,6 +1954,39 @@ mod tests {
             1,
             "drop must not have taken effect"
         );
+    }
+
+    #[test]
+    fn vm_uid_is_deterministic_and_in_reserved_range() {
+        let d = std::path::Path::new("/cache/vms/78f42d8fd6d4a576");
+        let u = vm_uid_for_dir(d);
+        assert_eq!(
+            u,
+            vm_uid_for_dir(d),
+            "uid must be stable for a given VM dir"
+        );
+        assert!(
+            (VM_UID_BASE..VM_UID_BASE + VM_UID_SPAN).contains(&u),
+            "uid {u} outside the reserved range"
+        );
+        // Distinct VMs (almost always) get distinct uids.
+        assert_ne!(
+            vm_uid_for_dir(std::path::Path::new("/cache/vms/78f42d8fd6d4a576")),
+            vm_uid_for_dir(std::path::Path::new("/cache/vms/aaaaaaaaaaaaaaaa")),
+        );
+        // A non-hex basename must not panic.
+        let _ = vm_uid_for_dir(std::path::Path::new("/cache/vms/not-hex-name"));
+    }
+
+    #[test]
+    fn clone_uid_matches_its_golden() {
+        // A clone's snapshot dir is `<golden_dir>/fork-snapshots/<clone>`. Its uid
+        // must equal the golden's (so it can map the golden's memfd), i.e. the
+        // derivation two levels up from the snapshot dir == the golden's dir uid.
+        let golden = std::path::Path::new("/cache/vms/78f42d8fd6d4a576");
+        let snap = golden.join("fork-snapshots").join("myclone");
+        let derived = vm_uid_for_dir(snap.parent().unwrap().parent().unwrap());
+        assert_eq!(derived, vm_uid_for_dir(golden));
     }
 
     /// The boot gate hands out permits, returns them on drop, and lets multiple

--- a/src/process.rs
+++ b/src/process.rs
@@ -796,9 +796,16 @@ pub fn free_vm_uid(registry_dir: &std::path::Path, key_dir: &std::path::Path) {
 #[cfg(not(target_os = "linux"))]
 pub fn free_vm_uid(_registry_dir: &std::path::Path, _key_dir: &std::path::Path) {}
 
-/// The `(uid, gid)` a VM's VMM should drop to — allocated **collision-free** from
-/// `registry_dir` — or `None` when the drop doesn't apply (unprivileged launcher,
-/// or `SMOLVM_VM_UID_DROP=off`). A fork clone (`snapshot_dir` set, laid out as
+/// The `(uid, gid)` a VM's VMM should drop to, allocated **collision-free** from
+/// `registry_dir`. Returns:
+/// - `None` — the drop doesn't apply (unprivileged launcher, or
+///   `SMOLVM_VM_UID_DROP=off`); boot proceeds without a drop.
+/// - `Some(Err(_))` — the drop is **active but allocation failed**; the caller
+///   MUST refuse to boot (fail closed — never silently run the VMM over-
+///   privileged, the same contract as `drop_privileges`).
+/// - `Some(Ok((uid, gid)))` — drop to this id.
+///
+/// A fork clone (`snapshot_dir` set, laid out as
 /// `<golden_dir>/fork-snapshots/<clone>`) resolves to the GOLDEN's uid so it can
 /// map the golden's memfd. gid mirrors uid (a per-VM group).
 #[cfg(target_os = "linux")]
@@ -806,7 +813,7 @@ pub fn vm_drop_ids(
     registry_dir: &std::path::Path,
     data_dir: &std::path::Path,
     snapshot_dir: Option<&std::path::Path>,
-) -> Option<(u32, u32)> {
+) -> Option<std::io::Result<(u32, u32)>> {
     if !vm_uid_drop_active() {
         return None;
     }
@@ -814,9 +821,13 @@ pub fn vm_drop_ids(
         Some(snap) => snap.parent().and_then(|p| p.parent()).unwrap_or(data_dir),
         None => data_dir,
     };
-    let vm_key = key_dir.file_name()?.to_str()?;
-    let uid = allocate_vm_uid(registry_dir, key_dir, vm_key).ok()?;
-    Some((uid, uid))
+    let Some(vm_key) = key_dir.file_name().and_then(|n| n.to_str()) else {
+        return Some(Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "VM data dir name is not valid UTF-8",
+        )));
+    };
+    Some(allocate_vm_uid(registry_dir, key_dir, vm_key).map(|uid| (uid, uid)))
 }
 
 /// No-op where the uid drop isn't applicable (macOS dev).
@@ -825,9 +836,36 @@ pub fn vm_drop_ids(
     _registry_dir: &std::path::Path,
     _data_dir: &std::path::Path,
     _snapshot_dir: Option<&std::path::Path>,
-) -> Option<(u32, u32)> {
+) -> Option<std::io::Result<(u32, u32)>> {
     None
 }
+
+/// Add others-execute to `dir` and every ancestor that lacks it, so a dropped
+/// VMM uid can traverse to it. Execute-only (no read): traversal works but the
+/// dirs can't be listed and file contents stay governed by their own perms.
+/// Used under uid isolation for the data/rootfs/template path chains. Idempotent,
+/// best-effort. Linux-only.
+#[cfg(target_os = "linux")]
+pub fn ensure_traversable(dir: &std::path::Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let mut cur = Some(dir);
+    while let Some(d) = cur {
+        if d.as_os_str().is_empty() {
+            break;
+        }
+        if let Ok(meta) = std::fs::metadata(d) {
+            let mode = meta.permissions().mode();
+            if meta.is_dir() && mode & 0o001 == 0 {
+                let _ = std::fs::set_permissions(d, std::fs::Permissions::from_mode(mode | 0o001));
+            }
+        }
+        cur = d.parent();
+    }
+}
+
+/// No-op where the uid drop isn't applicable (macOS dev).
+#[cfg(not(target_os = "linux"))]
+pub fn ensure_traversable(_dir: &std::path::Path) {}
 
 /// Recursively `lchown` `path` to `(uid, gid)` (symlinks not followed). Used by
 /// the privileged launcher to hand a VM's data dir + disks + sockets to the uid

--- a/src/process.rs
+++ b/src/process.rs
@@ -616,10 +616,11 @@ pub fn drop_privileges(_uid: u32, _gid: u32) -> std::result::Result<(), String> 
 
 /// Base of the reserved per-VM uid range. Above normal system (<1000), user
 /// (1000–60000), `nobody` (65534), and systemd DynamicUser (61184–65519) uids.
+#[cfg(target_os = "linux")]
 const VM_UID_BASE: u32 = 2_000_000;
-/// Span of the per-VM uid range: uids land in `[BASE, BASE+SPAN)`. Wide enough
-/// that birthday collisions need thousands of concurrent VMs (a collision only
-/// weakens cross-VM isolation between the two colliding VMs, never correctness).
+/// Span of the per-VM uid range: the allocator hands out the lowest free uid in
+/// `[BASE, BASE+SPAN)`. 100M is far more than any node hosts at once.
+#[cfg(target_os = "linux")]
 const VM_UID_SPAN: u32 = 100_000_000;
 
 /// Whether per-VM uid isolation applies here: the launcher is privileged (so it
@@ -638,6 +639,49 @@ pub fn vm_uid_drop_active() -> bool {
 pub fn vm_uid_drop_active() -> bool {
     false
 }
+
+/// Relocate all smolvm state under a single system data root by pointing `HOME`
+/// at it before any path is computed — every `dirs::`-derived path (VM dirs,
+/// agent rootfs, templates, server DB) follows. This is what lets per-VM uid
+/// isolation's dropped uids traverse to their data (an XDG-under-a-700-home
+/// layout can't). `SMOLVM_DATA_DIR` is honored for **every** command (so the CLI
+/// and serve agree); `allow_auto` additionally defaults to `/var/lib/smolvm` when
+/// privileged with the uid drop active and no XDG override (serve only — a
+/// one-off root CLI invocation shouldn't silently switch roots). Must be called
+/// single-threaded, before the tokio runtime, so `set_var` is safe.
+#[cfg(target_os = "linux")]
+pub fn apply_system_data_root(allow_auto: bool) {
+    let root = if let Some(explicit) = std::env::var_os("SMOLVM_DATA_DIR") {
+        std::path::PathBuf::from(explicit)
+    } else if allow_auto
+        && vm_uid_drop_active()
+        && std::env::var_os("XDG_CACHE_HOME").is_none()
+        && std::env::var_os("XDG_DATA_HOME").is_none()
+    {
+        std::path::PathBuf::from("/var/lib/smolvm")
+    } else {
+        return;
+    };
+    match std::fs::create_dir_all(&root) {
+        Ok(()) => {
+            use std::os::unix::fs::PermissionsExt;
+            // 0755 so dropped VMM uids can traverse to their data.
+            let _ = std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o755));
+        }
+        Err(e) => {
+            tracing::warn!(root = %root.display(), error = %e, "failed to create smolvm data root")
+        }
+    }
+    std::env::set_var("HOME", &root);
+    std::env::remove_var("XDG_CACHE_HOME");
+    std::env::remove_var("XDG_DATA_HOME");
+    std::env::remove_var("XDG_CONFIG_HOME");
+    tracing::info!(data_root = %root.display(), "smolvm state rooted at a system data dir");
+}
+
+/// No-op where the data root isn't applicable (macOS dev).
+#[cfg(not(target_os = "linux"))]
+pub fn apply_system_data_root(_allow_auto: bool) {}
 
 /// Per-VM uid isolation needs every ancestor of the data root to be traversable
 /// (others-execute) by the drop uid, or the dropped VMM can't reach its own
@@ -665,39 +709,120 @@ pub fn first_nontraversable_ancestor(_path: &std::path::Path) -> Option<std::pat
     None
 }
 
-/// Deterministic per-VM uid from a data dir whose basename is the 16-hex VM
-/// hash. Falls back to the base uid if the name isn't hex (never panics).
-pub fn vm_uid_for_dir(data_dir: &std::path::Path) -> u32 {
-    let name = data_dir.file_name().and_then(|n| n.to_str()).unwrap_or("0");
-    let prefix = name.get(..8).unwrap_or(name);
-    let v = u32::from_str_radix(prefix, 16).unwrap_or(0);
-    VM_UID_BASE + (v % VM_UID_SPAN)
+/// The VM key recorded in registry marker `registry_dir/<uid>`, if present.
+#[cfg(target_os = "linux")]
+fn uid_marker_key(registry_dir: &std::path::Path, uid: u32) -> Option<String> {
+    std::fs::read_to_string(registry_dir.join(uid.to_string()))
+        .ok()
+        .map(|s| s.trim().to_string())
 }
 
-/// The `(uid, gid)` a VM's VMM should drop to, or `None` when the uid drop
-/// doesn't apply (unprivileged launcher, or `SMOLVM_VM_UID_DROP=off`). For a
-/// fork clone (`snapshot_dir` set, laid out as `<golden_dir>/fork-snapshots/
-/// <clone>`), the id is derived from the GOLDEN's dir so the clone shares the
-/// golden's uid and can map its memfd. gid mirrors uid (a per-VM group).
+/// The uid already registered to `vm_key` (scan), or `None` if unallocated.
+#[cfg(target_os = "linux")]
+fn registered_uid(registry_dir: &std::path::Path, vm_key: &str) -> Option<u32> {
+    for e in std::fs::read_dir(registry_dir).ok()?.flatten() {
+        let uid = e.file_name().to_str().and_then(|s| s.parse::<u32>().ok());
+        if let Some(uid) = uid {
+            if uid_marker_key(registry_dir, uid).as_deref() == Some(vm_key) {
+                return Some(uid);
+            }
+        }
+    }
+    None
+}
+
+/// Allocate a stable, **collision-free** unprivileged uid for the VM identified
+/// by `vm_key` (its data-dir hash), recording the assignment in `registry_dir`
+/// so no two live VMs ever share a uid. Idempotent — the same key returns the
+/// same uid until [`free_vm_uid`] releases it; the result is cached in
+/// `key_dir/.vm-uid` to skip the scan on restart. Claims the lowest free uid in
+/// the reserved range atomically (`O_EXCL`) so concurrent boots can't collide.
+#[cfg(target_os = "linux")]
+pub fn allocate_vm_uid(
+    registry_dir: &std::path::Path,
+    key_dir: &std::path::Path,
+    vm_key: &str,
+) -> std::io::Result<u32> {
+    std::fs::create_dir_all(registry_dir)?;
+    let cache = key_dir.join(".vm-uid");
+    // Fast path: a cached uid whose marker still belongs to us.
+    if let Some(uid) = std::fs::read_to_string(&cache)
+        .ok()
+        .and_then(|s| s.trim().parse::<u32>().ok())
+    {
+        if uid_marker_key(registry_dir, uid).as_deref() == Some(vm_key) {
+            return Ok(uid);
+        }
+    }
+    // Registered under our key already (cache lost)?
+    if let Some(uid) = registered_uid(registry_dir, vm_key) {
+        let _ = std::fs::write(&cache, uid.to_string());
+        return Ok(uid);
+    }
+    // Claim the lowest free uid atomically.
+    for uid in VM_UID_BASE..VM_UID_BASE.saturating_add(VM_UID_SPAN) {
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(registry_dir.join(uid.to_string()))
+        {
+            Ok(mut f) => {
+                use std::io::Write;
+                f.write_all(vm_key.as_bytes())?;
+                let _ = std::fs::write(&cache, uid.to_string());
+                return Ok(uid);
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(e) => return Err(e),
+        }
+    }
+    Err(std::io::Error::other("per-VM uid range exhausted"))
+}
+
+/// Release the uid registered to the VM at `key_dir` (on VM delete) so it can be
+/// reused. No-op if the VM had no uid (drop inactive, or a fork clone — which
+/// shares its golden's uid and never claims its own). Linux-only.
+#[cfg(target_os = "linux")]
+pub fn free_vm_uid(registry_dir: &std::path::Path, key_dir: &std::path::Path) {
+    if let Some(uid) = std::fs::read_to_string(key_dir.join(".vm-uid"))
+        .ok()
+        .and_then(|s| s.trim().parse::<u32>().ok())
+    {
+        let _ = std::fs::remove_file(registry_dir.join(uid.to_string()));
+    }
+}
+
+/// No-op where the uid drop isn't applicable (macOS dev).
+#[cfg(not(target_os = "linux"))]
+pub fn free_vm_uid(_registry_dir: &std::path::Path, _key_dir: &std::path::Path) {}
+
+/// The `(uid, gid)` a VM's VMM should drop to — allocated **collision-free** from
+/// `registry_dir` — or `None` when the drop doesn't apply (unprivileged launcher,
+/// or `SMOLVM_VM_UID_DROP=off`). A fork clone (`snapshot_dir` set, laid out as
+/// `<golden_dir>/fork-snapshots/<clone>`) resolves to the GOLDEN's uid so it can
+/// map the golden's memfd. gid mirrors uid (a per-VM group).
 #[cfg(target_os = "linux")]
 pub fn vm_drop_ids(
+    registry_dir: &std::path::Path,
     data_dir: &std::path::Path,
     snapshot_dir: Option<&std::path::Path>,
 ) -> Option<(u32, u32)> {
     if !vm_uid_drop_active() {
         return None;
     }
-    let uid_dir = match snapshot_dir {
+    let key_dir = match snapshot_dir {
         Some(snap) => snap.parent().and_then(|p| p.parent()).unwrap_or(data_dir),
         None => data_dir,
     };
-    let uid = vm_uid_for_dir(uid_dir);
+    let vm_key = key_dir.file_name()?.to_str()?;
+    let uid = allocate_vm_uid(registry_dir, key_dir, vm_key).ok()?;
     Some((uid, uid))
 }
 
 /// No-op where the uid drop isn't applicable (macOS dev).
 #[cfg(not(target_os = "linux"))]
 pub fn vm_drop_ids(
+    _registry_dir: &std::path::Path,
     _data_dir: &std::path::Path,
     _snapshot_dir: Option<&std::path::Path>,
 ) -> Option<(u32, u32)> {
@@ -1956,37 +2081,60 @@ mod tests {
         );
     }
 
-    #[test]
-    fn vm_uid_is_deterministic_and_in_reserved_range() {
-        let d = std::path::Path::new("/cache/vms/78f42d8fd6d4a576");
-        let u = vm_uid_for_dir(d);
-        assert_eq!(
-            u,
-            vm_uid_for_dir(d),
-            "uid must be stable for a given VM dir"
-        );
-        assert!(
-            (VM_UID_BASE..VM_UID_BASE + VM_UID_SPAN).contains(&u),
-            "uid {u} outside the reserved range"
-        );
-        // Distinct VMs (almost always) get distinct uids.
-        assert_ne!(
-            vm_uid_for_dir(std::path::Path::new("/cache/vms/78f42d8fd6d4a576")),
-            vm_uid_for_dir(std::path::Path::new("/cache/vms/aaaaaaaaaaaaaaaa")),
-        );
-        // A non-hex basename must not panic.
-        let _ = vm_uid_for_dir(std::path::Path::new("/cache/vms/not-hex-name"));
+    #[cfg(target_os = "linux")]
+    fn tmp_registry(tag: &str) -> std::path::PathBuf {
+        let d = std::env::temp_dir().join(format!("smolvm-uidtest-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&d);
+        std::fs::create_dir_all(d.join("reg")).unwrap();
+        d
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
-    fn clone_uid_matches_its_golden() {
-        // A clone's snapshot dir is `<golden_dir>/fork-snapshots/<clone>`. Its uid
-        // must equal the golden's (so it can map the golden's memfd), i.e. the
-        // derivation two levels up from the snapshot dir == the golden's dir uid.
-        let golden = std::path::Path::new("/cache/vms/78f42d8fd6d4a576");
-        let snap = golden.join("fork-snapshots").join("myclone");
-        let derived = vm_uid_for_dir(snap.parent().unwrap().parent().unwrap());
-        assert_eq!(derived, vm_uid_for_dir(golden));
+    fn allocate_vm_uid_is_stable_collision_free_and_freeable() {
+        let base = tmp_registry("alloc");
+        let reg = base.join("reg");
+        let a = base.join("vm-a");
+        let b = base.join("vm-b");
+        std::fs::create_dir_all(&a).unwrap();
+        std::fs::create_dir_all(&b).unwrap();
+
+        let ua = allocate_vm_uid(&reg, &a, "aaaa").unwrap();
+        let ub = allocate_vm_uid(&reg, &b, "bbbb").unwrap();
+        // In range, distinct (collision-free), and stable on re-allocation.
+        assert!((VM_UID_BASE..VM_UID_BASE + VM_UID_SPAN).contains(&ua));
+        assert_ne!(ua, ub, "distinct VMs must get distinct uids");
+        assert_eq!(
+            ua,
+            allocate_vm_uid(&reg, &a, "aaaa").unwrap(),
+            "must be stable"
+        );
+
+        // Free A, then a new VM reuses A's released uid (lowest-free).
+        free_vm_uid(&reg, &a);
+        let c = base.join("vm-c");
+        std::fs::create_dir_all(&c).unwrap();
+        assert_eq!(
+            allocate_vm_uid(&reg, &c, "cccc").unwrap(),
+            ua,
+            "freed uid is reused"
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn registered_uid_recovers_assignment_when_cache_lost() {
+        let base = tmp_registry("recover");
+        let reg = base.join("reg");
+        let a = base.join("vm-a");
+        std::fs::create_dir_all(&a).unwrap();
+        let ua = allocate_vm_uid(&reg, &a, "key-a").unwrap();
+        // Drop the per-VM cache; the registry still maps key -> uid.
+        let _ = std::fs::remove_file(a.join(".vm-uid"));
+        assert_eq!(allocate_vm_uid(&reg, &a, "key-a").unwrap(), ua);
+        let _ = std::fs::remove_dir_all(&base);
     }
 
     /// The boot gate hands out permits, returns them on drop, and lets multiple

--- a/src/process.rs
+++ b/src/process.rs
@@ -672,6 +672,18 @@ pub fn apply_system_data_root(allow_auto: bool) {
             tracing::warn!(root = %root.display(), error = %e, "failed to create smolvm data root")
         }
     }
+    // Registry auth (crane/docker) falls back to `$HOME/.docker`, which we're about
+    // to move off the operator's real home — pin DOCKER_CONFIG to the ORIGINAL
+    // `~/.docker` (if it exists and the operator hasn't set DOCKER_CONFIG) so
+    // private image pulls keep finding their credentials after the relocation.
+    if std::env::var_os("DOCKER_CONFIG").is_none() {
+        if let Some(dir) = dirs::home_dir()
+            .map(|h| h.join(".docker"))
+            .filter(|d| d.is_dir())
+        {
+            std::env::set_var("DOCKER_CONFIG", dir);
+        }
+    }
     std::env::set_var("HOME", &root);
     std::env::remove_var("XDG_CACHE_HOME");
     std::env::remove_var("XDG_DATA_HOME");
@@ -759,12 +771,30 @@ pub fn allocate_vm_uid(
         let _ = std::fs::write(&cache, uid.to_string());
         return Ok(uid);
     }
-    // Claim the lowest free uid atomically.
+    // Claim the lowest free uid atomically. A uid whose marker points at a VM
+    // whose data dir is gone is STALE — a delete path that didn't free it, or a
+    // crash — so reclaim it. This makes the registry self-healing across every
+    // delete path (no leak even if some path forgets to call `free_vm_uid`). The
+    // VM data dirs are the registry's sibling (`<…>/smolvm/uids` ⇄ `…/vms`); a
+    // marker only exists after its VM's data dir was created, so "marker present
+    // but data dir absent" reliably means deleted, never mid-boot.
+    let vms_dir = registry_dir.parent().map(|p| p.join("vms"));
     for uid in VM_UID_BASE..VM_UID_BASE.saturating_add(VM_UID_SPAN) {
+        let marker = registry_dir.join(uid.to_string());
+        if let Some(key) = uid_marker_key(registry_dir, uid) {
+            let live = vms_dir
+                .as_ref()
+                .map(|v| v.join(&key).exists())
+                .unwrap_or(true);
+            if live {
+                continue; // held by a live VM
+            }
+            let _ = std::fs::remove_file(&marker); // stale → reclaim below
+        }
         match std::fs::OpenOptions::new()
             .write(true)
             .create_new(true)
-            .open(registry_dir.join(uid.to_string()))
+            .open(&marker)
         {
             Ok(mut f) => {
                 use std::io::Write;
@@ -772,7 +802,7 @@ pub fn allocate_vm_uid(
                 let _ = std::fs::write(&cache, uid.to_string());
                 return Ok(uid);
             }
-            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue, // raced
             Err(e) => return Err(e),
         }
     }
@@ -2119,21 +2149,27 @@ mod tests {
         );
     }
 
+    /// `(base, registry, vms)` laid out as production: `<base>/smolvm/{uids,vms}`,
+    /// so the allocator's `registry.parent()/vms` resolves to `vms`. A VM's data
+    /// dir is `vms/<vm_key>`.
     #[cfg(target_os = "linux")]
-    fn tmp_registry(tag: &str) -> std::path::PathBuf {
-        let d = std::env::temp_dir().join(format!("smolvm-uidtest-{tag}-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&d);
-        std::fs::create_dir_all(d.join("reg")).unwrap();
-        d
+    fn tmp_uid_dirs(tag: &str) -> (std::path::PathBuf, std::path::PathBuf, std::path::PathBuf) {
+        let base =
+            std::env::temp_dir().join(format!("smolvm-uidtest-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        let reg = base.join("smolvm").join("uids");
+        let vms = base.join("smolvm").join("vms");
+        std::fs::create_dir_all(&reg).unwrap();
+        std::fs::create_dir_all(&vms).unwrap();
+        (base, reg, vms)
     }
 
     #[cfg(target_os = "linux")]
     #[test]
     fn allocate_vm_uid_is_stable_collision_free_and_freeable() {
-        let base = tmp_registry("alloc");
-        let reg = base.join("reg");
-        let a = base.join("vm-a");
-        let b = base.join("vm-b");
+        let (base, reg, vms) = tmp_uid_dirs("alloc");
+        let a = vms.join("aaaa");
+        let b = vms.join("bbbb");
         std::fs::create_dir_all(&a).unwrap();
         std::fs::create_dir_all(&b).unwrap();
 
@@ -2150,7 +2186,7 @@ mod tests {
 
         // Free A, then a new VM reuses A's released uid (lowest-free).
         free_vm_uid(&reg, &a);
-        let c = base.join("vm-c");
+        let c = vms.join("cccc");
         std::fs::create_dir_all(&c).unwrap();
         assert_eq!(
             allocate_vm_uid(&reg, &c, "cccc").unwrap(),
@@ -2164,14 +2200,39 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn registered_uid_recovers_assignment_when_cache_lost() {
-        let base = tmp_registry("recover");
-        let reg = base.join("reg");
-        let a = base.join("vm-a");
+        let (base, reg, vms) = tmp_uid_dirs("recover");
+        let a = vms.join("key-a");
         std::fs::create_dir_all(&a).unwrap();
         let ua = allocate_vm_uid(&reg, &a, "key-a").unwrap();
         // Drop the per-VM cache; the registry still maps key -> uid.
         let _ = std::fs::remove_file(a.join(".vm-uid"));
         assert_eq!(allocate_vm_uid(&reg, &a, "key-a").unwrap(), ua);
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn allocator_self_heals_leaked_uid_when_vm_dir_gone() {
+        let (base, reg, vms) = tmp_uid_dirs("selfheal");
+        let a = vms.join("aaaa");
+        std::fs::create_dir_all(&a).unwrap();
+        let ua = allocate_vm_uid(&reg, &a, "aaaa").unwrap();
+
+        // Simulate a delete path that removed the VM's data dir WITHOUT calling
+        // free_vm_uid: the registry marker is now leaked.
+        std::fs::remove_dir_all(&a).unwrap();
+        assert!(reg.join(ua.to_string()).exists(), "marker is leaked");
+
+        // A new VM reclaims that stale uid (its VM dir is gone) — no permanent
+        // leak even though the delete path forgot to free it.
+        let b = vms.join("bbbb");
+        std::fs::create_dir_all(&b).unwrap();
+        assert_eq!(
+            allocate_vm_uid(&reg, &b, "bbbb").unwrap(),
+            ua,
+            "stale (data-dir-gone) uid must be reclaimed"
+        );
+
         let _ = std::fs::remove_dir_all(&base);
     }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -395,7 +395,12 @@ fn build_seccomp_program(enforce: bool) -> std::result::Result<seccompiler::BpfP
         libc::SYS_prctl, libc::SYS_prlimit64, libc::SYS_getrusage,
         libc::SYS_sysinfo, libc::SYS_uname, libc::SYS_getrandom,
         libc::SYS_getuid, libc::SYS_geteuid, libc::SYS_getgid, libc::SYS_getegid,
-        libc::SYS_capget, libc::SYS_setpgid,
+        // capget/capset: virtiofs drops CAP_FSETID around a passthrough write/
+        // create (`drop_effective_cap`, via the `caps` crate) so the kernel
+        // strips setuid/setgid bits on non-owner writes — same root-VMM /
+        // non-root-guest passthrough path as setres{u,g}id below. A cap-dropped
+        // VMM can't raise caps outside its bounding set, so this grants nothing.
+        libc::SYS_capget, libc::SYS_capset, libc::SYS_setpgid,
         // accept4 + sock{name,peername}: the published-port listener threads
         // (smolvm-tcp-*) and virtio-net path. Rust's TcpListener uses accept4,
         // not accept — the audit run logged these (288/51/52 on x86_64) because

--- a/src/process.rs
+++ b/src/process.rs
@@ -412,6 +412,18 @@ fn build_seccomp_program(enforce: bool) -> std::result::Result<seccompiler::BpfP
         libc::SYS_fchmod, libc::SYS_fdatasync, libc::SYS_utimensat, libc::SYS_copy_file_range,
         libc::SYS_fsetxattr, libc::SYS_fremovexattr,
         libc::SYS_lgetxattr, libc::SYS_lsetxattr, libc::SYS_llistxattr, libc::SYS_lremovexattr,
+        // virtiofs scopes each request to the guest process's uid/gid before
+        // touching the host fs (so DAC checks run as the guest user, not as a
+        // root VMM) via per-thread setres{u,g}id — passthrough.rs `scoped_cred!`
+        // / `set_creds`. Reached only when the VMM keeps CAP_SETUID (root, no
+        // per-VM uid drop) AND a NON-root guest process does fs I/O: a path a
+        // single-uid (all-root) trace never exercises, which is why a diverse-
+        // workload review caught it and the original audit didn't. Without these
+        // an unprivileged guest writing through virtiofs SIGSYS-kills the VMM
+        // under `enforce`. Safe to allow: a capability-dropped (uid-isolated)
+        // VMM still can't escalate — the kernel enforces CAP_SETUID regardless,
+        // so the syscall just EPERMs. Matches virtiofsd's own allowlist.
+        libc::SYS_setresuid, libc::SYS_setresgid,
     ];
 
     // Legacy syscalls present only on x86_64; aarch64 exposes only the *at/p

--- a/src/process.rs
+++ b/src/process.rs
@@ -339,11 +339,17 @@ fn build_seccomp_program(enforce: bool) -> std::result::Result<seccompiler::BpfP
         libc::SYS_ftruncate, libc::SYS_fstat, libc::SYS_newfstatat, libc::SYS_statx,
         libc::SYS_fstatfs, libc::SYS_statfs, libc::SYS_fcntl, libc::SYS_flock,
         libc::SYS_dup, libc::SYS_dup3, libc::SYS_getdents64,
-        libc::SYS_readlinkat, libc::SYS_faccessat, libc::SYS_umask,
+        libc::SYS_readlinkat, libc::SYS_faccessat, libc::SYS_faccessat2, libc::SYS_umask,
         libc::SYS_fgetxattr, libc::SYS_flistxattr, libc::SYS_pipe2,
         // memory (guest RAM, dlopen of libkrun)
         libc::SYS_mmap, libc::SYS_munmap, libc::SYS_mremap, libc::SYS_mprotect,
         libc::SYS_madvise, libc::SYS_brk,
+        // memfd_create: a forkable machine (`machine start --forkable`) backs its
+        // guest RAM with a memfd so clones can MAP_PRIVATE it copy-on-write. Used
+        // only on the fork base, but harmless (anonymous in-memory file, no host
+        // fs reach) to allow for every VM. Without it a forkable boot is SIGSYS-
+        // killed under `seccomp=enforce`.
+        libc::SYS_memfd_create,
         // KVM + device ioctls, eventfd plumbing
         libc::SYS_ioctl, libc::SYS_eventfd2,
         // epoll / poll event loops (virtio, vsock/TSI)
@@ -352,7 +358,7 @@ fn build_seccomp_program(enforce: bool) -> std::result::Result<seccompiler::BpfP
         // sockets (vsock/TSI data path, host networking)
         libc::SYS_socket, libc::SYS_socketpair, libc::SYS_connect, libc::SYS_bind,
         libc::SYS_listen, libc::SYS_accept, libc::SYS_sendto, libc::SYS_recvfrom,
-        libc::SYS_sendmsg, libc::SYS_recvmsg, libc::SYS_setsockopt,
+        libc::SYS_sendmsg, libc::SYS_sendmmsg, libc::SYS_recvmsg, libc::SYS_setsockopt,
         libc::SYS_getsockopt, libc::SYS_shutdown,
         // threads & synchronization (vCPU/worker threads, render-thread priority)
         libc::SYS_clone, libc::SYS_clone3, libc::SYS_futex, libc::SYS_set_robust_list,


### PR DESCRIPTION
- `POST /machines/{id}/fork` + `--forkable` start (CoW memory/disks clone, KVM).
- Per-VM uid drop: each VMM runs as its own unprivileged uid (collision-free, self-healing allocator). Root serve relocates state to `/var/lib`.
- Fork + diverse workloads run under default `seccomp=enforce` + `landlock=enforce`; allowlist covers virtiofs per-request credential scoping (`setres{u,g}id`, `capset`), validated against a KVM repro.
- Linux/KVM only; hardening is opt-in (`SMOLVM_SECCOMP=enforce`, root serve for uid drop).