### PR TITLE
feat(embedded): forkable start + fork in embedded runtime; watchdog opt-out

### DIFF
--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -172,6 +172,12 @@ pub struct LaunchFeatures {
     pub snapshot_dir: Option<std::path::PathBuf>,
     /// Control socket path for a forkable machine (pause/resume/checkpoint/FORK).
     pub control_socket: Option<std::path::PathBuf>,
+    /// Override the parent-death watchdog. `None` = default (arm it iff a
+    /// separate boot binary is used, i.e. an in-process SDK embedder whose VM
+    /// must die with it). `Some(false)` forces it off — for a CLI that sets
+    /// `SMOLVM_BOOT_BINARY` (so `current_exe` need not handle `_boot-vm`) yet
+    /// DETACHES the VM to persist after the CLI exits (e.g. `smol start`/`fork`).
+    pub watch_parent: Option<bool>,
 }
 
 impl LaunchFeatures {

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -1657,7 +1657,12 @@ impl AgentManager {
         // VMs) don't set it, so they keep today's behavior. We pass the resulting
         // flag down so the boot subprocess only arms its parent-death watchdog in
         // the embedder case. See `cli/internal_boot::run`.
-        let watch_parent = boot_binary.is_some();
+        //
+        // A CLI that sets SMOLVM_BOOT_BINARY (because its own `current_exe` can't
+        // serve `_boot-vm`, e.g. `smol`) but DETACHES the VM must opt out via
+        // `features.watch_parent = Some(false)` — otherwise its persistent
+        // machines die the moment the CLI process exits.
+        let watch_parent = features.watch_parent.unwrap_or(boot_binary.is_some());
         let boot_exe = boot_binary
             .map(std::path::PathBuf::from)
             .unwrap_or_else(|| exe.clone());

--- a/src/embedded/control.rs
+++ b/src/embedded/control.rs
@@ -76,6 +76,12 @@ pub fn start_vm(db: &SmolvmDb, name: &str) -> Result<VmHandle> {
 }
 
 fn start_vm_from_record(record: &VmRecord) -> Result<VmHandle> {
+    launch_from_record(record, LaunchFeatures::default())
+}
+
+/// Boot `record` with the given launch features and return a handle. Shared by
+/// the plain, forkable-golden, and fork-clone start paths so they can't drift.
+fn launch_from_record(record: &VmRecord, features: LaunchFeatures) -> Result<VmHandle> {
     let manager =
         AgentManager::for_vm_with_sizes(&record.name, record.storage_gb, record.overlay_gb)
             .map_err(|e| Error::agent("create agent manager", e.to_string()))?;
@@ -85,11 +91,64 @@ fn start_vm_from_record(record: &VmRecord) -> Result<VmHandle> {
             record.host_mounts(),
             record.port_mappings(),
             record.vm_resources(),
-            LaunchFeatures::default(),
+            features,
         )
         .map_err(|e| Error::agent("start machine", e.to_string()))?;
 
     Ok(VmHandle::new(manager, None))
+}
+
+/// Start a persisted VM as a FORKABLE fork base: its guest RAM is backed by a
+/// memfd (copy-on-write cloneable) and a control socket is exposed so the machine
+/// can later be forked with [`fork_vm`]. Same mechanics as the CLI's
+/// `machine start --forkable`, surfaced for the embedded SDK.
+pub fn start_forkable_vm(db: &SmolvmDb, name: &str) -> Result<VmHandle> {
+    let record = get_record(db, name)?;
+    let features = LaunchFeatures {
+        forkable: true,
+        control_socket: Some(crate::agent::fork::control_socket_path(name)),
+        ..LaunchFeatures::default()
+    };
+    let handle = launch_from_record(&record, features)?;
+    mark_running(db, name, handle.child_pid())?;
+    Ok(handle)
+}
+
+/// Fork a running, forkable `golden` into a new `clone` via copy-on-write guest
+/// RAM + disks (same host). Freezes the golden (it stays paused as the shared
+/// base — clones map its RAM `MAP_PRIVATE`, so it must not run again while clones
+/// exist), boots the clone from the golden's snapshot, and returns the clone's
+/// handle. `pinned_ports` are `(host, guest)` inbound forwards for the clone;
+/// empty means the golden's forwards are remapped to freshly-allocated host
+/// ports. Shares `agent::fork` with the CLI/serve fork paths.
+pub fn fork_vm(
+    db: &SmolvmDb,
+    golden: &str,
+    clone: &str,
+    pinned_ports: &[(u16, u16)],
+) -> Result<VmHandle> {
+    // Freeze + snapshot the golden, register the clone (CoW disks + DB record).
+    // `clone_forkable = false`: a clone can't itself be re-forked (nested fork).
+    let prep = crate::agent::fork::prepare_fork(db, golden, clone, pinned_ports, false)?;
+
+    // Boot the clone from the golden's in-memory snapshot instead of cold-booting.
+    let features = LaunchFeatures {
+        snapshot_dir: Some(prep.snapshot_dir.clone()),
+        ..LaunchFeatures::default()
+    };
+    match launch_from_record(&prep.clone_record, features) {
+        Ok(handle) => {
+            crate::agent::fork::rejuvenate_clone(clone);
+            mark_running(db, clone, handle.child_pid())?;
+            Ok(handle)
+        }
+        Err(e) => {
+            // prepare_fork already registered the clone; roll it back on boot failure.
+            let _ = db.remove_vm(clone);
+            let _ = std::fs::remove_dir_all(crate::agent::vm_data_dir(clone));
+            Err(e)
+        }
+    }
 }
 
 /// Connect to an already-running VM and return a cached handle.

--- a/src/embedded/runtime.rs
+++ b/src/embedded/runtime.rs
@@ -58,6 +58,39 @@ impl EmbeddedRuntime {
         })
     }
 
+    /// Start (or reconnect to) a persisted machine as a FORKABLE fork base and
+    /// cache its handle. Like [`start_machine`](Self::start_machine) but boots
+    /// with memfd-backed guest RAM + a control socket so it can later be forked
+    /// with [`fork_machine`](Self::fork_machine) — the basis for local RL rollout
+    /// branching.
+    pub fn start_forkable_machine(&self, name: &str) -> Result<()> {
+        self.with_name_lock(name, || {
+            if let Some(handle) = self.cached_handle(name)? {
+                if lock_handle(&handle)?.is_process_alive() {
+                    return Ok(());
+                }
+                self.remove_cached_handle(name)?;
+            }
+
+            let handle = control::start_forkable_vm(&self.db, name)?;
+            self.insert_handle(name, handle)?;
+            Ok(())
+        })
+    }
+
+    /// Fork a running, forkable `golden` into a new `clone` (copy-on-write guest
+    /// RAM + disks, same host) and cache the clone's handle so it can be exec'd
+    /// by name. `ports` are `(host, guest)` inbound forwards for the clone; empty
+    /// remaps the golden's forwards to fresh host ports. The golden freezes as the
+    /// shared base and must not be started again while clones exist.
+    pub fn fork_machine(&self, golden: &str, clone: &str, ports: &[(u16, u16)]) -> Result<()> {
+        self.with_name_lock(clone, || {
+            let handle = control::fork_vm(&self.db, golden, clone, ports)?;
+            self.insert_handle(clone, handle)?;
+            Ok(())
+        })
+    }
+
     /// Connect to an already-running machine and cache its handle.
     pub fn connect_machine(&self, name: &str) -> Result<()> {
         self.with_name_lock(name, || {


### PR DESCRIPTION
Engine support for fork across the SDK **and** CLI.

**Embedded fork** (for the in-process SDK bindings → local live-RAM fork):
- `control::start_forkable_vm` / `fork_vm`, `EmbeddedRuntime::start_forkable_machine` / `fork_machine` — surface the existing `agent::fork` mechanics through `smolvm::embedded`. Same code path as `machine fork` (KVM-validated); no change to existing start/exec.

**Watchdog opt-out** (`LaunchFeatures.watch_parent`):
- `watch_parent` was hard-wired to `boot_binary.is_some()`, assuming only in-process SDK embedders set `SMOLVM_BOOT_BINARY`. A CLI whose own exe can't serve `_boot-vm` (e.g. `smol`) must set it too, yet detaches the VM to persist — so its machines were killed the instant the CLI exited. `LaunchFeatures.watch_parent` (`None` = today's default; `Some(false)` = detach-and-persist) lets such a CLI opt out. No change for the SDK or the engine CLI.

Validated on macOS/HVF + Linux/T480. Paired with smol#30 (SDK + CLI fork).