### PR TITLE
fix(run): local --image works with init; truthful image-ingest errors (#459)

### DIFF
--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -626,7 +626,10 @@ fn flatten_archive(archive: &Path, rootfs: &Path) -> Result<()> {
     crane
         .args(["export", "-", "-"])
         .stdout(Stdio::piped())
-        .stderr(Stdio::null());
+        // Capture (don't discard) crane's stderr so a failure reports the REAL
+        // reason — e.g. "file manifest.json not found in tar" for an empty or
+        // truncated archive — instead of a misleading guess.
+        .stderr(Stdio::piped());
     let gunzip = pipe_archive_into(&mut crane, archive)?;
 
     let mut crane_child = crane
@@ -636,6 +639,10 @@ fn flatten_archive(archive: &Path, rootfs: &Path) -> Result<()> {
         .stdout
         .take()
         .ok_or_else(|| StorageError::new("failed to capture crane stdout".to_string()))?;
+    let mut crane_err = crane_child
+        .stderr
+        .take()
+        .ok_or_else(|| StorageError::new("failed to capture crane stderr".to_string()))?;
 
     let tar_out = Command::new("tar")
         .arg("-x")
@@ -655,9 +662,19 @@ fn flatten_archive(archive: &Path, rootfs: &Path) -> Result<()> {
     }
 
     if !crane_status.success() {
-        return Err(StorageError::new(
-            "crane export failed (is this a docker/podman `save` archive?)".to_string(),
-        ));
+        // crane's stderr is a single short line; reading it after the process
+        // exits (its stdout was drained by `tar`) cannot deadlock.
+        let mut stderr = String::new();
+        let _ = std::io::Read::read_to_string(&mut crane_err, &mut stderr);
+        let stderr = stderr.trim();
+        return Err(StorageError::new(format!(
+            "crane export failed{} (is the image a valid `docker save` / OCI archive?)",
+            if stderr.is_empty() {
+                String::new()
+            } else {
+                format!(": {stderr}")
+            }
+        )));
     }
     if !tar_out.status.success() {
         return Err(StorageError::new(format!(

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -588,6 +588,18 @@ fn init_layer_key(image: Option<&str>, init: &[String], env: &[String]) -> Strin
     hex::encode(h.finalize())[..16].to_string()
 }
 
+/// Whether a `--image` value is an init-cache-bakeable source. Only registry
+/// refs are: the bake snapshots via `pack create --from-vm`, which sources base
+/// layers by pulling the image's registry manifest. A local archive or rootfs
+/// dir has no registry manifest (it is flattened on boot), so it takes the
+/// direct, uncached init path instead of a broken bake (#459).
+fn image_bakeable(image: Option<&str>) -> bool {
+    matches!(
+        image.map(smolvm::data::image_source::classify),
+        Some(smolvm::data::image_source::ImageSource::Registry(_))
+    )
+}
+
 /// Bake `image + init` into a cached `.smolmachine` (or reuse an existing one) and
 /// return its path. Runs the well-tested `machine create/start/stop` + `pack create
 /// --from-vm` flow as subprocesses of this same binary: create a temp machine from
@@ -599,6 +611,10 @@ fn ensure_init_layer(
     smolfile: Option<&Path>,
     rebuild: bool,
 ) -> smolvm::Result<PathBuf> {
+    // The bake here only ever receives a registry image: `ensure_init_layer` is
+    // gated on `image_bakeable()` (local archives/dirs take the direct path),
+    // because the `pack create --from-vm` snapshot below cannot source a local
+    // image's layers (they're flattened, with no registry manifest to pull).
     let key = init_layer_key(params.image.as_deref(), &params.init, &params.env);
     let dir = init_layer_cache_dir();
     std::fs::create_dir_all(&dir)
@@ -844,7 +860,17 @@ impl RunCmd {
         // that artifact, so init's cost (e.g. `apt install`) is paid once and reused
         // on every later run instead of re-running on each ephemeral boot. Skipped for
         // detached/persistent runs (`-d`) and when `--no-init-cache` is set.
-        if !self.no_init_cache && !self.detach && params.image.is_some() && !params.init.is_empty()
+        //
+        // Only REGISTRY images are baked. A local image (`--image -` / `--image
+        // file.tar` / a rootfs dir) is flattened with no registry manifest, so the
+        // bake's `pack create --from-vm` snapshot can't source its layers; and a
+        // `--image -` archive can't be re-read by the bake's child subprocess
+        // (null stdin) anyway. Local images take the direct path below, which
+        // stages the archive once in this process and runs init inline (#459).
+        if !self.no_init_cache
+            && !self.detach
+            && image_bakeable(params.image.as_deref())
+            && !params.init.is_empty()
         {
             let cached =
                 ensure_init_layer(&params, self.smolfile.as_deref(), self.rebuild_init_cache)?;

--- a/src/cli/pack.rs
+++ b/src/cli/pack.rs
@@ -546,6 +546,23 @@ impl PackCreateCmd {
         // storage disk which can't be read on macOS — a temp VM mounts it for us.
         if is_image_based {
             let image = vm.image.clone().unwrap();
+            // A locally-sourced image (`--image -` / `--image file.tar` / a rootfs
+            // dir) is flattened on boot and has no registry manifest, so the
+            // layer-export path below — which pulls that manifest to enumerate base
+            // layers — cannot source it. Fail with a clear, actionable message
+            // instead of a confusing registry "UNAUTHORIZED" on `local:<hash>`.
+            if smolvm::data::image_source::is_local_ref(&image) {
+                return Err(Error::agent(
+                    "pack from VM",
+                    format!(
+                        "VM '{vm_name}' was created from a local image ({image}). \
+                         `pack create --from-vm` can only snapshot VMs created from a \
+                         REGISTRY image — local archives and rootfs directories are \
+                         flattened on boot and have no registry manifest to re-pull. \
+                         Recreate the machine from a registry reference to pack it."
+                    ),
+                ));
+            }
             // Attach the source storage disk with its real on-disk format so a
             // qcow2 (default-size) disk is presented correctly and mounts in the
             // temp VM — hardcoding raw would hand libkrun qcow2 bytes as raw.


### PR DESCRIPTION
Fixes #459: local `--image` (e.g. piped `docker save`) now takes the direct init path instead of the bake that staged an empty archive from a null-stdin child, with a clear error for `pack create --from-vm` on local images and crane's real stderr surfaced on ingest failure.