### PR TITLE
fix(registry): upload blobs in a single streamed request

### DIFF
--- a/crates/smolvm-registry/src/client.rs
+++ b/crates/smolvm-registry/src/client.rs
@@ -16,24 +16,6 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
-/// Default chunk size for chunked blob upload: 16 MiB — comfortably under common
-/// proxy request-body caps (e.g. Cloudflare Free/Pro = 100 MB). Override with the
-/// `SMOLVM_REGISTRY_CHUNK_MB` env var. Blobs at or below this size still take the
-/// monolithic single-PUT path; only larger ones are chunked.
-const DEFAULT_CHUNK_MB: usize = 16;
-
-/// The configured upload chunk size in bytes (see [`DEFAULT_CHUNK_MB`]). Also the
-/// threshold above which a blob is uploaded chunked rather than monolithically.
-pub(crate) fn upload_chunk_size() -> usize {
-    std::env::var("SMOLVM_REGISTRY_CHUNK_MB")
-        .ok()
-        .and_then(|s| s.trim().parse::<usize>().ok())
-        .filter(|&m| m > 0)
-        .unwrap_or(DEFAULT_CHUNK_MB)
-        * 1024
-        * 1024
-}
-
 /// Validate that a digest string matches the expected `sha256:<64 hex chars>` format.
 pub(crate) fn validate_digest(digest: &str) -> Result<()> {
     if let Some(hex_part) = digest.strip_prefix("sha256:") {

--- a/crates/smolvm-registry/src/push.rs
+++ b/crates/smolvm-registry/src/push.rs
@@ -71,31 +71,33 @@ pub async fn push(
     let manifest = smolvm_pack::read_manifest_from_sidecar(smolmachine_path)?;
     let config_json = serde_json::to_vec_pretty(&manifest)?;
 
-    // 3. Upload the sidecar as the layer blob. Large blobs go chunked (POST +
-    // per-chunk PATCH + PUT) so a body-size-capping proxy in front of the
-    // registry (e.g. Cloudflare, which 413s a multi-hundred-MB monolithic PUT)
-    // never sees an oversized request; smaller blobs keep the single-PUT stream.
-    let chunk_size = crate::client::upload_chunk_size();
-    if layer_size as usize > chunk_size {
-        tracing::info!(chunk_size, "uploading sidecar blob (chunked)...");
-        client
-            .push_blob_chunked(repo, &layer_digest, smolmachine_path, chunk_size)
-            .await?;
-    } else {
-        // The factory reopens the file on each call so that a 401 mid-upload can
-        // be retried with a fresh stream. The OS page cache makes reopens cheap.
-        tracing::info!("uploading sidecar blob...");
-        let path = smolmachine_path.to_path_buf();
-        client
-            .push_blob_stream(repo, &layer_digest, layer_size, move || {
-                // std::fs::File::open is synchronous but fast (just a syscall).
-                let file = std::fs::File::open(&path).map_err(crate::RegistryError::from)?;
-                let async_file = tokio::fs::File::from_std(file);
-                let stream = tokio_util::io::ReaderStream::with_capacity(async_file, 256 * 1024);
-                Ok(reqwest::Body::wrap_stream(stream))
-            })
-            .await?;
-    }
+    // 3. Upload the sidecar as the layer blob in a SINGLE streamed request.
+    //
+    // We deliberately do NOT split it into resumable per-chunk PATCH uploads.
+    // The registry's S3 backend is Cloudflare R2, which (unlike AWS S3) requires
+    // every non-final part of a multipart upload to be the same size. zot maps
+    // each OCI PATCH chunk onto an R2 multipart part, so unequal client chunks
+    // (e.g. 16 MiB + a smaller remainder) fail R2's CompleteMultipartUpload with
+    // `400 InvalidPart: All non-trailing parts must have the same length`, which
+    // the registry surfaces as a 500 on the finalizing PUT. Streaming the whole
+    // blob in one request lets the registry's storage driver choose uniform part
+    // sizes, which R2 accepts.
+    //
+    // Corollary: the registry's push path must NOT sit behind a request-body cap
+    // (e.g. an orange-cloud Cloudflare proxy that 413s large bodies). The body
+    // factory reopens the file per attempt so a 401 mid-upload retries with a
+    // fresh stream; the OS page cache makes reopens cheap.
+    tracing::info!("uploading sidecar blob...");
+    let path = smolmachine_path.to_path_buf();
+    client
+        .push_blob_stream(repo, &layer_digest, layer_size, move || {
+            // std::fs::File::open is synchronous but fast (just a syscall).
+            let file = std::fs::File::open(&path).map_err(crate::RegistryError::from)?;
+            let async_file = tokio::fs::File::from_std(file);
+            let stream = tokio_util::io::ReaderStream::with_capacity(async_file, 256 * 1024);
+            Ok(reqwest::Body::wrap_stream(stream))
+        })
+        .await?;
 
     // 4. Upload config blob (small, buffered is fine).
     tracing::info!("uploading config blob...");


### PR DESCRIPTION
Chunked OCI blob uploads made zot emit unequal Cloudflare R2 multipart parts, which R2 rejects with `400 InvalidPart: All non-trailing parts must have the same length` (surfaced as a 500 on the finalizing PUT); stream each blob in one request so the storage driver picks uniform parts (the registry push path must not sit behind a request-body cap).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/462">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->