### PR TITLE
fix(net): honor --dns on the TSI backend, and unify the launchers' guest-network env

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -139,6 +139,28 @@ fn boottime_ms() -> u64 {
     (ts.tv_sec as u64) * 1000 + (ts.tv_nsec as u64) / 1_000_000
 }
 
+/// Decide what to write to `/etc/resolv.conf` on the TSI (no-virtio) path, or
+/// `None` to leave the existing file untouched.
+///
+/// The host delivers a `--dns` override through one of two mechanisms depending
+/// on the boot path: it either forwards it as `guest_env::DNS`, or it writes the
+/// nameserver straight into the rootfs's resolv.conf before boot (the libkrun
+/// backend's `setup_dns`). This one function honors both: an explicit override
+/// wins, and otherwise we only repair a stale loopback/empty resolv.conf (left
+/// by a prior `--allow-host` run that pointed at the local DNS proxy) — we never
+/// clobber a valid nameserver the host already wrote. The old code wrote the
+/// hardcoded public resolvers unconditionally, which both dropped `--dns` and
+/// overwrote `setup_dns`'s value, so `--dns` never took effect on TSI.
+fn tsi_resolv_conf(dns_override: Option<&str>, current: &str) -> Option<String> {
+    match dns_override.map(str::trim) {
+        Some(dns) if !dns.is_empty() => Some(format!("nameserver {dns}\n")),
+        _ if current.contains("127.0.0.1") || current.trim().is_empty() => {
+            Some("nameserver 1.1.1.1\nnameserver 8.8.8.8\n".to_string())
+        }
+        _ => None,
+    }
+}
+
 fn main() {
     // Quick --version check (used by init script to detect rootfs updates)
     if std::env::args().any(|a| a == "--version") {
@@ -253,14 +275,20 @@ fn main() {
         Ok(false) => {
             // TSI mode or no network. The overlay may contain a stale
             // "nameserver 127.0.0.1" written by a previous --allow-host run.
-            // TSI forwards UDP to 1.1.1.1 directly, so reset resolv.conf to a
-            // known-good value unless the DNS filter proxy is about to
-            // overwrite it with 127.0.0.1 anyway.
+            // TSI forwards UDP to the resolver directly, so reset resolv.conf to
+            // a known-good value unless the DNS filter proxy is about to
+            // overwrite it with 127.0.0.1 anyway. Honor an explicit `--dns`
+            // override (forwarded by the host as guest_env::DNS) — the virtio
+            // path already derives the guest resolver from the same env var, so
+            // both backends now agree on which nameserver the guest uses. This
+            // is what makes `--dns` work on a network where the public resolvers
+            // (1.1.1.1/8.8.8.8) are blocked.
             if !dns_proxy::is_enabled() {
-                let _ = std::fs::write(
-                    "/etc/resolv.conf",
-                    "nameserver 1.1.1.1\nnameserver 8.8.8.8\n",
-                );
+                let dns_override = std::env::var(guest_env::DNS).ok();
+                let current = std::fs::read_to_string("/etc/resolv.conf").unwrap_or_default();
+                if let Some(new) = tsi_resolv_conf(dns_override.as_deref(), &current) {
+                    let _ = std::fs::write("/etc/resolv.conf", new);
+                }
             }
         }
         Err(err) => {
@@ -5238,6 +5266,46 @@ mod bg_reap_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Regression for `--dns` being silently dropped on the TSI backend: an
+    // explicit override must win over whatever is currently in resolv.conf,
+    // otherwise a guest on a network where 1.1.1.1/8.8.8.8 are unreachable can
+    // never pull an image.
+    #[test]
+    fn tsi_resolv_conf_override_wins_over_current() {
+        assert_eq!(
+            tsi_resolv_conf(Some("9.9.9.9"), "nameserver 8.8.8.8\n").as_deref(),
+            Some("nameserver 9.9.9.9\n")
+        );
+        // Surrounding whitespace is trimmed rather than written into resolv.conf.
+        assert_eq!(
+            tsi_resolv_conf(Some(" 10.0.0.2 "), "").as_deref(),
+            Some("nameserver 10.0.0.2\n")
+        );
+    }
+
+    // Without an override, a valid host-written resolv.conf (e.g. the libkrun
+    // backend's setup_dns) must be PRESERVED, not clobbered — this is the other
+    // half of the same bug.
+    #[test]
+    fn tsi_resolv_conf_preserves_valid_host_written_file() {
+        assert_eq!(tsi_resolv_conf(None, "nameserver 9.9.9.9\n"), None);
+        // A blank override is treated as "no override", so preservation applies.
+        assert_eq!(tsi_resolv_conf(Some("  "), "nameserver 10.0.0.2\n"), None);
+    }
+
+    // A stale loopback (left by a prior --allow-host run) or an empty file is
+    // repaired to the public resolvers.
+    #[test]
+    fn tsi_resolv_conf_repairs_stale_loopback_or_empty() {
+        let public = "nameserver 1.1.1.1\nnameserver 8.8.8.8\n";
+        assert_eq!(
+            tsi_resolv_conf(None, "nameserver 127.0.0.1\n").as_deref(),
+            Some(public)
+        );
+        assert_eq!(tsi_resolv_conf(None, "").as_deref(), Some(public));
+        assert_eq!(tsi_resolv_conf(None, "   \n").as_deref(), Some(public));
+    }
 
     #[test]
     #[cfg(unix)]

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -1003,59 +1003,13 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
         // guest path.
         let _ = &dns_filter_socket;
 
-        if let Some(network) = guest_network {
-            env_strings.push(cstr(&format!(
-                "{}={}",
-                guest_env::BACKEND,
-                guest_env::BACKEND_VIRTIO_NET
-            )));
-            env_strings.push(cstr(&format!(
-                "{}={}",
-                guest_env::GUEST_IP,
-                network.guest_ip
-            )));
-            env_strings.push(cstr(&format!(
-                "{}={}",
-                guest_env::GATEWAY,
-                network.gateway_ip
-            )));
-            env_strings.push(cstr(&format!(
-                "{}={}",
-                guest_env::PREFIX_LEN,
-                network.prefix_len
-            )));
-            env_strings.push(cstr(&format!(
-                "{}={}",
-                guest_env::GUEST_MAC,
-                format_mac(network.guest_mac)
-            )));
-            env_strings.push(cstr(&format!(
-                "{}={}",
-                guest_env::GUEST_IP6,
-                network.guest_ip6
-            )));
-            env_strings.push(cstr(&format!(
-                "{}={}",
-                guest_env::GATEWAY6,
-                network.gateway_ip6
-            )));
-            env_strings.push(cstr(&format!(
-                "{}={}",
-                guest_env::PREFIX_LEN6,
-                network.prefix_len6
-            )));
-            env_strings.push(cstr(&format!("{}={}", guest_env::DNS, network.dns_server)));
-        }
-
-        // TSI has no host-side gateway: the guest's datagrams are proxied to
-        // their real destination, so a custom resolver (--dns) must become the
-        // guest's resolv.conf nameserver directly. (virtio-net already pushed
-        // its gateway address above and routes the override as the upstream.)
-        if guest_network.is_none() {
-            if let Some(dns) = resources.dns {
-                env_strings.push(cstr(&format!("{}={}", guest_env::DNS, dns)));
-            }
-        }
+        // Guest-network env vars — virtio-net interface config plus the TSI
+        // `--dns` override — are built in one shared place so the static and
+        // dynamic launchers can't diverge (see `agent::guest_network_env`).
+        env_strings.extend(crate::agent::guest_network_env(
+            guest_network,
+            resources.dns,
+        ));
 
         // Tell the agent about pre-extracted packed layers
         if packed_layers_dir.is_some_and(|d| d.exists()) {
@@ -1205,13 +1159,6 @@ fn select_network_plan(
     let dns_filter_placeholder = [String::from("configured")];
     let dns_filter_hosts = dns_filter_enabled.then_some(dns_filter_placeholder.as_slice());
     plan_launch_network(resources, dns_filter_hosts, port_count)
-}
-
-fn format_mac(mac: [u8; 6]) -> String {
-    format!(
-        "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
-        mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
-    )
 }
 
 /// Resolve a hostname to /32 CIDR strings for the egress-refresh thread.

--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -392,56 +392,15 @@ pub fn launch_agent_vm_dynamic(
         }
     }
 
-    if let Some(network) = guest_network {
-        env_strings.push(cstr(&format!(
-            "{}={}",
-            guest_env::BACKEND,
-            guest_env::BACKEND_VIRTIO_NET
-        )));
-        env_strings.push(cstr(&format!(
-            "{}={}",
-            guest_env::GUEST_IP,
-            network.guest_ip
-        )));
-        env_strings.push(cstr(&format!(
-            "{}={}",
-            guest_env::GATEWAY,
-            network.gateway_ip
-        )));
-        env_strings.push(cstr(&format!(
-            "{}={}",
-            guest_env::PREFIX_LEN,
-            network.prefix_len
-        )));
-        env_strings.push(cstr(&format!(
-            "{}={}",
-            guest_env::GUEST_MAC,
-            format_mac(network.guest_mac)
-        )));
-        env_strings.push(cstr(&format!(
-            "{}={}",
-            guest_env::GUEST_IP6,
-            network.guest_ip6
-        )));
-        env_strings.push(cstr(&format!(
-            "{}={}",
-            guest_env::GATEWAY6,
-            network.gateway_ip6
-        )));
-        env_strings.push(cstr(&format!(
-            "{}={}",
-            guest_env::PREFIX_LEN6,
-            network.prefix_len6
-        )));
-        env_strings.push(cstr(&format!("{}={}", guest_env::DNS, network.dns_server)));
-    } else if let Some(dns) = config.resources.dns {
-        // TSI backend: there is no host-side gateway to route a resolver
-        // override through, so the custom `--dns` value must become the guest's
-        // resolv.conf nameserver directly. The static launcher does the same
-        // (launcher.rs); without this, `--dns` is silently dropped on TSI (the
-        // default backend) and the guest falls back to 1.1.1.1/8.8.8.8.
-        env_strings.push(cstr(&format!("{}={}", guest_env::DNS, dns)));
-    }
+    // Guest-network env vars — virtio-net interface config plus the TSI `--dns`
+    // override — are built in one shared place so the static and dynamic
+    // launchers can't diverge (see `agent::guest_network_env`). The dynamic
+    // launcher having open-coded this is exactly how it once dropped `--dns` on
+    // TSI (PR #466).
+    env_strings.extend(crate::agent::guest_network_env(
+        guest_network,
+        config.resources.dns,
+    ));
 
     let mut envp: Vec<*const libc::c_char> = env_strings.iter().map(|s| s.as_ptr()).collect();
     envp.push(std::ptr::null());
@@ -520,13 +479,6 @@ fn create_unix_stream_pair() -> std::io::Result<(RawFd, RawFd)> {
         return Err(std::io::Error::last_os_error());
     }
     Ok((fds[0], fds[1]))
-}
-
-fn format_mac(mac: [u8; 6]) -> String {
-    format!(
-        "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
-        mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
-    )
 }
 
 /// Raise file descriptor limits (required by libkrun).

--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -434,6 +434,13 @@ pub fn launch_agent_vm_dynamic(
             network.prefix_len6
         )));
         env_strings.push(cstr(&format!("{}={}", guest_env::DNS, network.dns_server)));
+    } else if let Some(dns) = config.resources.dns {
+        // TSI backend: there is no host-side gateway to route a resolver
+        // override through, so the custom `--dns` value must become the guest's
+        // resolv.conf nameserver directly. The static launcher does the same
+        // (launcher.rs); without this, `--dns` is silently dropped on TSI (the
+        // default backend) and the guest falls back to 1.1.1.1/8.8.8.8.
+        env_strings.push(cstr(&format!("{}={}", guest_env::DNS, dns)));
     }
 
     let mut envp: Vec<*const libc::c_char> = env_strings.iter().map(|s| s.as_ptr()).collect();

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -60,3 +60,51 @@ fn gpu_virgl_flags() -> u32 {
         (1 << 6) | (1 << 7)
     }
 }
+
+/// Build the guest-network environment variables handed to the agent at boot.
+///
+/// Shared by both the static (`launcher.rs`) and dynamic (`launcher_dynamic.rs`)
+/// launchers — like [`gpu_virgl_flags`] — so the two can never silently diverge.
+/// They previously each open-coded this block, and the dynamic one drifted: it
+/// omitted the TSI `--dns` override, silently dropping `--dns` on the default
+/// backend (PR #466). With one source of truth, the guest's resolver is decided
+/// in exactly one place and the agent remains the sole writer of resolv.conf.
+///
+/// `guest_network` is `Some` for virtio-net (the agent derives its resolver from
+/// `dns_server`, the gateway address). For TSI it is `None`: there is no host
+/// gateway to route a resolver through, so a `--dns` override must be passed
+/// straight through for the agent to write into resolv.conf.
+pub(crate) fn guest_network_env(
+    guest_network: Option<smolvm_network::GuestNetworkConfig>,
+    dns_override: Option<std::net::Ipv4Addr>,
+) -> Vec<std::ffi::CString> {
+    use smolvm_protocol::guest_env;
+    let mut env: Vec<std::ffi::CString> = Vec::new();
+    let mut push = |key: &str, val: String| {
+        env.push(std::ffi::CString::new(format!("{key}={val}")).expect("env var contains NUL"));
+    };
+    if let Some(n) = guest_network {
+        push(
+            guest_env::BACKEND,
+            guest_env::BACKEND_VIRTIO_NET.to_string(),
+        );
+        push(guest_env::GUEST_IP, n.guest_ip.to_string());
+        push(guest_env::GATEWAY, n.gateway_ip.to_string());
+        push(guest_env::PREFIX_LEN, n.prefix_len.to_string());
+        push(guest_env::GUEST_MAC, format_mac(n.guest_mac));
+        push(guest_env::GUEST_IP6, n.guest_ip6.to_string());
+        push(guest_env::GATEWAY6, n.gateway_ip6.to_string());
+        push(guest_env::PREFIX_LEN6, n.prefix_len6.to_string());
+        push(guest_env::DNS, n.dns_server.to_string());
+    } else if let Some(dns) = dns_override {
+        push(guest_env::DNS, dns.to_string());
+    }
+    env
+}
+
+fn format_mac(mac: [u8; 6]) -> String {
+    format!(
+        "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+        mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
+    )
+}


### PR DESCRIPTION
The guest agent's TSI branch clobbered /etc/resolv.conf with hardcoded 1.1.1.1/8.8.8.8 — dropping `--dns` and overwriting the host-written nameserver, so in-VM pulls failed wherever the public resolvers are blocked — so the agent now honors the override and preserves a valid host-written resolv.conf, and the two launchers' duplicated guest-network env (the root cause of the divergence) is hoisted into one shared `agent::guest_network_env` (e2e-validated: TSI `--dns 9.9.9.9`→`nameserver 9.9.9.9`, virtio→gateway resolver).