### PR TITLE
Fix shebang

### DIFF
--- a/crates/smolvm-pack/src/extract.rs
+++ b/crates/smolvm-pack/src/extract.rs
@@ -2288,7 +2288,7 @@ mod tests {
         header.set_path("usr/good3.sh").unwrap();
         header.set_cksum();
         builder
-            .append_data(&mut header, "usr/good3.sh", &b"#!/bin/bash"[..])
+            .append_data(&mut header, "usr/good3.sh", &b"#!/usr/bin/env bash"[..])
             .unwrap();
 
         // Another char device whiteout
@@ -2336,7 +2336,7 @@ mod tests {
         );
         assert_eq!(
             fs::read_to_string(dest.join("usr/good3.sh")).unwrap(),
-            "#!/bin/bash"
+            "#!/usr/bin/env bash"
         );
         assert_eq!(
             fs::read_to_string(dest.join("usr/good4.dat")).unwrap(),

--- a/scripts/build-agent-rootfs.sh
+++ b/scripts/build-agent-rootfs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Build the agent VM rootfs
 #
 # This script creates an Alpine-based rootfs with:

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Build a distributable smolvm package
 #
 # Usage:

--- a/scripts/build-embedded-node.sh
+++ b/scripts/build-embedded-node.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Install smolvm from a local tarball or build directory
 #
 # Usage:

--- a/scripts/rebuild-agent.sh
+++ b/scripts/rebuild-agent.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Rebuild the smolvm-agent binary for Linux and install it
 #
 # Usage: ./scripts/rebuild-agent.sh [--clean]

--- a/scripts/smol-wrapper.sh
+++ b/scripts/smol-wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # smol - the unified Smol Machines CLI (local microVMs + cloud)
 # This wrapper sets up the library path and runs the smol binary.
 #

--- a/scripts/smolvm-wrapper.sh
+++ b/scripts/smolvm-wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # smolvm - OCI-native microVM runtime
 # This wrapper sets up the library path and runs the smolvm binary.
 

--- a/scripts/update-formula.sh
+++ b/scripts/update-formula.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Update the Homebrew formula with SHA256 hashes from dist/ tarballs
 #
 # Usage: ./scripts/update-formula.sh

--- a/sdks/node/scripts/build-current-platform.sh
+++ b/sdks/node/scripts/build-current-platform.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/sdks/node/scripts/build-platform-package.sh
+++ b/sdks/node/scripts/build-platform-package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/sdks/node/scripts/smoke-install.sh
+++ b/sdks/node/scripts/smoke-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/sdks/scripts/stage-embedded-libs.sh
+++ b/sdks/scripts/stage-embedded-libs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/tests/bench_vm_startup.sh
+++ b/tests/bench_vm_startup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Benchmark: microVM startup time
 #
 # Measures the time to start the smolvm agent VM from cold state.

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Common test utilities for smolvm integration tests.
 #

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # run_tests.sh -- primary test runner for smolvm
 #

--- a/tests/test_api.sh
+++ b/tests/test_api.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # End-to-end HTTP API tests for smolvm.
 #

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # CLI tests for smolvm.
 #

--- a/tests/test_db.sh
+++ b/tests/test_db.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Database State Tests
 #

--- a/tests/test_gpu.sh
+++ b/tests/test_gpu.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # GPU acceleration integration tests for smolvm.
 #

--- a/tests/test_machine_bare.sh
+++ b/tests/test_machine_bare.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Bare VM Tests (lifecycle, exec, shell, file I/O, observability)
 #

--- a/tests/test_machine_image.sh
+++ b/tests/test_machine_image.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Image-Backed Machine Tests
 #

--- a/tests/test_machine_local_image.sh
+++ b/tests/test_machine_local_image.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Local / Offline Image Tests
 #

--- a/tests/test_machine_packed.sh
+++ b/tests/test_machine_packed.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Packed Machine Tests
 #

--- a/tests/test_machine_run.sh
+++ b/tests/test_machine_run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Machine Run (Ephemeral) Tests
 #

--- a/tests/test_network.sh
+++ b/tests/test_network.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Network and Egress Tests
 #

--- a/tests/test_pack.sh
+++ b/tests/test_pack.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Pack tests for smolvm.
 #

--- a/tests/test_pack_registry.sh
+++ b/tests/test_pack_registry.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Registry push/pull integration tests for smolvm pack.
 #

--- a/tests/test_ports.sh
+++ b/tests/test_ports.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Port Mapping Tests
 #

--- a/tests/test_reliability.sh
+++ b/tests/test_reliability.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Reliability and Concurrency Tests
 #

--- a/tests/test_resize.sh
+++ b/tests/test_resize.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Resize feature tests for smolvm.
 # Runs only the resize-related integration tests.

--- a/tests/test_resources.sh
+++ b/tests/test_resources.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Resource Validation and Naming Tests
 #

--- a/tests/test_scale.sh
+++ b/tests/test_scale.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Scale tests for smolvm.
 #

--- a/tests/test_secrets.sh
+++ b/tests/test_secrets.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # End-to-end tests for host-side secret references.
 #

--- a/tests/test_smolfile.sh
+++ b/tests/test_smolfile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Smolfile tests for smolvm.
 #

--- a/tests/test_storage.sh
+++ b/tests/test_storage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Storage Tests (overlay, prune, resize)
 #

--- a/tests/test_virtio_net.sh
+++ b/tests/test_virtio_net.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # virtio-net tests for smolvm.
 #

--- a/tests/test_volumes.sh
+++ b/tests/test_volumes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Volume Mount Tests
 #

--- a/tests/test_wrapper.sh
+++ b/tests/test_wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Wrapper tests for release archive behavior.
 #
@@ -21,7 +21,7 @@ make_release_fixture() {
     chmod +x "$release_dir/smolvm"
 
     cat > "$release_dir/smolvm-bin" <<'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 printf 'SMOLVM_AGENT_ROOTFS=%s\n' "${SMOLVM_AGENT_ROOTFS-}"
 EOF
     chmod +x "$release_dir/smolvm-bin"


### PR DESCRIPTION
`bash` is not required to be under `/bin/bash` path on all systems.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/469">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->