### PR TITLE
fix(agent): give privileged --image VMs bare-VM /proc and /storage parity

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -2972,6 +2972,7 @@ fn write_oci_bundle(
     }
 
     storage::add_workspace_fallback(&mut spec, mounts);
+    storage::add_storage_fallback(&mut spec, mounts, unprivileged);
 
     ssh_agent::inject_into_container(&mut spec);
     spec.write_to(bundle_path)
@@ -3641,6 +3642,7 @@ fn spawn_interactive_command(
     }
 
     storage::add_workspace_fallback(&mut spec, mounts);
+    storage::add_storage_fallback(&mut spec, mounts, unprivileged);
 
     // Forward SSH agent into the container if enabled at boot.
     ssh_agent::inject_into_container(&mut spec);

--- a/crates/smolvm-agent/src/oci.rs
+++ b/crates/smolvm-agent/src/oci.rs
@@ -535,25 +535,40 @@ impl OciSpec {
                     },
                 ],
                 devices: default_devices(),
-                masked_paths: vec![
-                    "/proc/asound".to_string(),
-                    "/proc/acpi".to_string(),
-                    "/proc/kcore".to_string(),
-                    "/proc/keys".to_string(),
-                    "/proc/latency_stats".to_string(),
-                    "/proc/timer_list".to_string(),
-                    "/proc/timer_stats".to_string(),
-                    "/proc/sched_debug".to_string(),
-                    "/proc/scsi".to_string(),
-                    "/sys/firmware".to_string(),
-                ],
-                readonly_paths: vec![
-                    "/proc/bus".to_string(),
-                    "/proc/fs".to_string(),
-                    "/proc/irq".to_string(),
-                    "/proc/sys".to_string(),
-                    "/proc/sysrq-trigger".to_string(),
-                ],
+                // Mask/freeze the standard runc set of /proc and /sys paths only in
+                // unprivileged mode. In the default VM-grade mode the microVM is the
+                // security boundary (same rationale as the full capability set and the
+                // writable cgroup/tmpfs mounts above), so the workload gets a bare-VM
+                // /proc: an independent VM has all of /proc rw and unmasked, and
+                // freezing /proc/sys read-only here breaks in-VM init systems and
+                // docker-in-VM, which must write net.ipv4.ip_forward and friends.
+                masked_paths: if unprivileged {
+                    vec![
+                        "/proc/asound".to_string(),
+                        "/proc/acpi".to_string(),
+                        "/proc/kcore".to_string(),
+                        "/proc/keys".to_string(),
+                        "/proc/latency_stats".to_string(),
+                        "/proc/timer_list".to_string(),
+                        "/proc/timer_stats".to_string(),
+                        "/proc/sched_debug".to_string(),
+                        "/proc/scsi".to_string(),
+                        "/sys/firmware".to_string(),
+                    ]
+                } else {
+                    vec![]
+                },
+                readonly_paths: if unprivileged {
+                    vec![
+                        "/proc/bus".to_string(),
+                        "/proc/fs".to_string(),
+                        "/proc/irq".to_string(),
+                        "/proc/sys".to_string(),
+                        "/proc/sysrq-trigger".to_string(),
+                    ]
+                } else {
+                    vec![]
+                },
             },
             mounts: default_mounts(unprivileged),
             hostname: Some("container".to_string()),
@@ -1350,6 +1365,42 @@ mod tests {
         // Values just under limit should pass
         let ok_value = "x".repeat(32 * 1024);
         assert!(validate_env_vars(&[("KEY".to_string(), ok_value)]).is_ok());
+    }
+
+    #[test]
+    fn privileged_spec_leaves_proc_unrestricted_unprivileged_keeps_runc_hardening() {
+        let identity = ProcessIdentity::root();
+
+        // VM-grade (default, unprivileged=false): the microVM is the boundary, so
+        // /proc is a bare-VM /proc — nothing masked, nothing frozen read-only. This
+        // is what lets docker-in-VM write /proc/sys/net/ipv4/ip_forward.
+        let privileged = OciSpec::new(&["sh".to_string()], &[], "/", false, &identity, false);
+        assert!(
+            privileged.linux.masked_paths.is_empty(),
+            "privileged spec must not mask any /proc paths"
+        );
+        assert!(
+            privileged.linux.readonly_paths.is_empty(),
+            "privileged spec must not freeze /proc/sys read-only"
+        );
+
+        // Unprivileged opt-in (untrusted code): the standard runc masked/readonly
+        // set is preserved for defense-in-depth.
+        let unprivileged = OciSpec::new(&["sh".to_string()], &[], "/", false, &identity, true);
+        assert!(
+            unprivileged
+                .linux
+                .readonly_paths
+                .contains(&"/proc/sys".to_string()),
+            "unprivileged spec must keep /proc/sys read-only"
+        );
+        assert!(
+            unprivileged
+                .linux
+                .masked_paths
+                .contains(&"/proc/kcore".to_string()),
+            "unprivileged spec must keep /proc/kcore masked"
+        );
     }
 
     #[test]

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -415,6 +415,46 @@ pub fn add_workspace_fallback(spec: &mut OciSpec, mounts: &[(String, String, boo
     }
 }
 
+/// Expose the per-VM `/storage` disk inside privileged containers, so an
+/// `--image` machine has the same filesystem topology as a bare VM: `/storage`
+/// (and therefore `/storage/docker`, `/storage/workspace`, …) resolves to the
+/// ext4 disk identically with or without `--image`, and bind-mounts the workload
+/// makes against it — e.g. docker-in-VM binding `/storage/docker` →
+/// `/var/lib/docker` so overlay2 lands on ext4, not the rootfs overlay — work
+/// the same in a container as in a bare VM.
+///
+/// Privileged-only: when `unprivileged` the container is a defense-in-depth
+/// boundary for untrusted code, so it must NOT see the VM's storage disk (its
+/// image archives and overlay plumbing). `/storage` is per-machine, so for a
+/// privileged workload — where the microVM is the security boundary — exposing
+/// it crosses no isolation boundary; it only mirrors what a bare VM already has.
+///
+/// Skipped when the user already mounted something at `/storage`, and a no-op
+/// when the disk isn't mounted (bare agent rootfs / no storage disk).
+pub fn add_storage_fallback(
+    spec: &mut OciSpec,
+    mounts: &[(String, String, bool)],
+    unprivileged: bool,
+) {
+    // Decide policy first (testable without a mounted disk), then gate on the
+    // disk actually being present (a no-op on a bare agent rootfs).
+    if should_expose_storage(mounts, unprivileged) && Path::new(STORAGE_ROOT).exists() {
+        spec.add_bind_mount(STORAGE_ROOT, STORAGE_ROOT, false);
+    }
+}
+
+/// Policy for [`add_storage_fallback`]: a privileged workload that hasn't already
+/// claimed `/storage` should see the VM's storage disk. Unprivileged containers
+/// never do (defense-in-depth boundary for untrusted code).
+fn should_expose_storage(mounts: &[(String, String, bool)], unprivileged: bool) -> bool {
+    if unprivileged {
+        return false;
+    }
+    !mounts
+        .iter()
+        .any(|(_, path, _)| path.trim_end_matches('/') == STORAGE_ROOT)
+}
+
 /// Name of the optional index file (written into the packed-layers dir at
 /// extraction time) recording the layers in OCI order, bottom-most first, one
 /// short layer id per line.
@@ -2639,6 +2679,7 @@ pub fn run_command(
         }
 
         add_workspace_fallback(&mut spec, mounts);
+        add_storage_fallback(&mut spec, mounts, unprivileged);
 
         // Forward SSH agent into the container if enabled at boot.
         crate::ssh_agent::inject_into_container(&mut spec);
@@ -2729,6 +2770,7 @@ pub fn spawn_in_overlay(
     }
 
     add_workspace_fallback(&mut spec, mounts);
+    add_storage_fallback(&mut spec, mounts, unprivileged);
 
     crate::ssh_agent::inject_into_container(&mut spec);
     spec.add_gpu_devices_if_available();
@@ -3620,6 +3662,25 @@ mod tests {
     fn env_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn storage_exposed_only_to_privileged_workloads_without_a_user_storage_mount() {
+        // Privileged (default) and no user mount at /storage → expose it, so an
+        // --image VM sees /storage like a bare VM (docker-in-VM bind targets work).
+        assert!(should_expose_storage(&[], false));
+
+        // Unprivileged (untrusted code) never sees the VM's storage disk.
+        assert!(!should_expose_storage(&[], true));
+
+        // The user already claimed /storage (e.g. -v host:/storage) → don't clobber
+        // it, even when privileged. Trailing slash is normalized.
+        let user_mount = vec![("tag".to_string(), "/storage/".to_string(), false)];
+        assert!(!should_expose_storage(&user_mount, false));
+
+        // A user mount elsewhere doesn't suppress the /storage fallback.
+        let other_mount = vec![("tag".to_string(), "/data".to_string(), false)];
+        assert!(should_expose_storage(&other_mount, false));
     }
 
     #[test]

--- a/examples/docker-in-vm/docker.smolfile
+++ b/examples/docker-in-vm/docker.smolfile
@@ -1,8 +1,13 @@
 # Docker inside a smolvm microVM
 #
-# Runs Docker Engine in a bare Alpine VM. No OCI image or crun involved —
-# init commands run directly in the VM as root via VmExec, so Docker gets
-# full kernel privileges without any capability restrictions.
+# Runs Docker Engine in a bare Alpine VM. Init commands run directly in the VM
+# as root via VmExec, so Docker gets full kernel privileges without any
+# capability restrictions.
+#
+# This also works with `--image`: a privileged (default) image-based machine
+# runs in an OCI container, but /storage is bind-mounted into it, so the same
+# `mount --bind /storage/docker /var/lib/docker` resolves to the ext4 disk just
+# as in a bare VM.
 #
 # ── Kernel requirements ───────────────────────────────────────────────────────
 #

--- a/tests/test_machine_image_proc_storage.sh
+++ b/tests/test_machine_image_proc_storage.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+#
+# Image-Backed /proc and /storage Parity Tests
+#
+# Regression coverage for two asymmetries between bare-VM and --image machines:
+#
+#   1. --image froze a chunk of /proc read-only (runc's readonlyPaths), so
+#      docker-in-VM could not write /proc/sys/net/ipv4/ip_forward.
+#   2. --image did not expose the per-VM /storage disk inside the container, so
+#      the docker-in-VM bind-mount pattern
+#      (`mount --bind /storage/docker /var/lib/docker`) broke.
+#
+# Both are fixed by treating a privileged (default) image machine like a bare
+# VM: /proc is unrestricted and /storage is bind-mounted into the container.
+# An unprivileged image machine keeps the full runc hardening.
+#
+# Part of the smolvm test suite. Run with:
+#   ./tests/test_machine_image_proc_storage.sh
+#
+
+source "$(dirname "$0")/common.sh"
+init_smolvm
+
+log_info "Pre-flight cleanup: killing orphan processes..."
+kill_orphan_smolvm_processes
+
+trap cleanup_machine EXIT
+
+echo ""
+echo "=========================================="
+echo "  Image-Backed /proc + /storage Parity"
+echo "=========================================="
+echo ""
+
+# A privileged --image VM must have a writable /proc/sys, like a bare VM, so an
+# init system / dockerd can set sysctls. Before the fix crun applied runc's
+# readonlyPaths and this write failed with EROFS.
+test_image_proc_sys_is_writable() {
+    local out
+    out=$(run_with_timeout 120 $SMOLVM machine run --net --image alpine -- \
+        sh -c 'echo 1 > /proc/sys/net/ipv4/ip_forward && cat /proc/sys/net/ipv4/ip_forward' 2>&1)
+    local rc=$?
+    [[ $rc -eq 124 ]] && { echo "FAIL: timed out booting image VM"; return 1; }
+    echo "$out" | grep -qx '1' || {
+        echo "FAIL: /proc/sys/net/ipv4/ip_forward not writable under --image"
+        echo "  output: $out"
+        return 1
+    }
+}
+
+# Corollary: /proc/sys must not be a read-only bind in privileged mode. runc's
+# readonlyPaths shows up as a `ro` mount line on the path; its absence means the
+# path inherits the writable top-level /proc mount.
+test_image_proc_sys_not_readonly_bind() {
+    local out
+    out=$(run_with_timeout 90 $SMOLVM machine run --net --image alpine -- \
+        sh -c 'mount | grep " /proc/sys " || true' 2>&1)
+    local rc=$?
+    [[ $rc -eq 124 ]] && { echo "FAIL: timed out booting image VM"; return 1; }
+    if echo "$out" | grep -q '\bro\b'; then
+        echo "FAIL: /proc/sys still mounted read-only under --image"
+        echo "  output: $out"
+        return 1
+    fi
+}
+
+# A privileged --image VM must see the per-VM /storage ext4 disk inside the
+# container, so /storage/* resolves to the disk exactly as in a bare VM.
+test_image_storage_disk_visible() {
+    local out
+    out=$(run_with_timeout 90 $SMOLVM machine run --net --image alpine -- \
+        sh -c 'mount | grep " /storage " || true' 2>&1)
+    local rc=$?
+    [[ $rc -eq 124 ]] && { echo "FAIL: timed out booting image VM"; return 1; }
+    echo "$out" | grep -q ' /storage ' || {
+        echo "FAIL: /storage not mounted inside --image container"
+        echo "  output: $out"
+        return 1
+    }
+    echo "$out" | grep -q 'ext4' || {
+        echo "FAIL: /storage is not the ext4 disk under --image"
+        echo "  output: $out"
+        return 1
+    }
+}
+
+# The docker-in-VM bind-mount pattern works under --image. Binding
+# /var/lib/docker onto /storage/docker must land on the ext4 disk (so dockerd's
+# overlay2 nests correctly), proven by a file written through the bind appearing
+# on the /storage side.
+test_image_docker_bind_resolves_to_storage() {
+    local out
+    out=$(run_with_timeout 90 $SMOLVM machine run --net --image alpine -- sh -c '
+        set -e
+        mkdir -p /storage/docker /var/lib/docker
+        mount --bind /storage/docker /var/lib/docker
+        : > /var/lib/docker/probe
+        test -f /storage/docker/probe
+        # Confirm /var/lib/docker now resolves onto the ext4 storage disk.
+        mount | grep " /var/lib/docker " | grep -q ext4
+        echo BIND_OK' 2>&1)
+    local rc=$?
+    [[ $rc -eq 124 ]] && { echo "FAIL: timed out booting image VM"; return 1; }
+    echo "$out" | grep -q 'BIND_OK' || {
+        echo "FAIL: bind-mount of /var/lib/docker onto /storage did not resolve to ext4"
+        echo "  output: $out"
+        return 1
+    }
+}
+
+# Guard the security boundary: an UNPRIVILEGED image container must NOT get the
+# relaxed /proc or the /storage disk — the hardening is retained for untrusted
+# code. `machine run --unprivileged` opts into the restricted profile.
+test_unprivileged_image_keeps_hardening() {
+    # /proc/sys read-only (write must fail) and /storage absent.
+    local out
+    out=$(run_with_timeout 90 $SMOLVM machine run --net --unprivileged --image alpine -- sh -c '
+        if echo 1 > /proc/sys/net/ipv4/ip_forward 2>/dev/null; then echo PROC_WRITABLE; else echo PROC_RO; fi
+        if mount | grep -q " /storage "; then echo STORAGE_VISIBLE; else echo STORAGE_HIDDEN; fi' 2>&1)
+    local rc=$?
+    [[ $rc -eq 124 ]] && { echo "FAIL: timed out booting unprivileged image VM"; return 1; }
+    # If --unprivileged is unsupported by this build, skip rather than fail.
+    if echo "$out" | grep -qiE 'error|unexpected argument|unknown'; then
+        echo "SKIP: --unprivileged not supported by this build: $out"
+        return 0
+    fi
+    echo "$out" | grep -q 'PROC_RO' || {
+        echo "FAIL: unprivileged container got a writable /proc/sys (hardening lost)"
+        echo "  output: $out"
+        return 1
+    }
+    echo "$out" | grep -q 'STORAGE_HIDDEN' || {
+        echo "FAIL: unprivileged container saw /storage (disk leak)"
+        echo "  output: $out"
+        return 1
+    }
+}
+
+run_test "Image /proc/sys is writable (ip_forward settable)" test_image_proc_sys_is_writable || true
+run_test "Image /proc/sys is not a read-only bind" test_image_proc_sys_not_readonly_bind || true
+run_test "Image container sees the /storage ext4 disk" test_image_storage_disk_visible || true
+run_test "Docker bind-mount onto /storage resolves to ext4" test_image_docker_bind_resolves_to_storage || true
+run_test "Unprivileged image keeps /proc + /storage hardening" test_unprivileged_image_keeps_hardening || true
+
+print_summary "Image /proc + /storage Parity Tests"


### PR DESCRIPTION
Privileged (default) `--image` machines now match bare VMs — /proc is left unrestricted and the per-VM /storage disk is bind-mounted into the container — so docker-in-VM can set sysctls and the `/storage/docker` bind-mount works, while unprivileged image machines keep full runc hardening (closes #467, #468).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/470">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->