### PR TITLE
fix(api): run handler DB I/O off the reactor + writer/reader DB pool

### DIFF
--- a/src/api/handlers/exec.rs
+++ b/src/api/handlers/exec.rs
@@ -81,11 +81,7 @@ pub async fn exec_command(
     if req.background {
         let command = req.command.clone();
         let workdir = req.workdir.clone();
-        let machine_image = state
-            .db()
-            .get_vm(&id)
-            .map_err(ApiError::database)?
-            .and_then(|r| r.image);
+        let machine_image = state.lookup_vm(&id).await?.and_then(|r| r.image);
         let pid = if let Some(image) = machine_image {
             let mounts_config = {
                 let e = entry.lock();
@@ -133,11 +129,7 @@ pub async fn exec_command(
     // sessions. Without this, exec runs in the bare agent VM (no `python3`,
     // etc.) — the image is never entered. Plain machines exec in the VM
     // directly via `vm_exec`.
-    let machine_image = state
-        .db()
-        .get_vm(&id)
-        .map_err(ApiError::database)?
-        .and_then(|r| r.image);
+    let machine_image = state.lookup_vm(&id).await?.and_then(|r| r.image);
 
     let start = std::time::Instant::now();
     let (exit_code, stdout, stderr) = if let Some(image) = machine_image {
@@ -230,11 +222,7 @@ pub async fn exec_stream(
     // overlay keyed by machine name); plain machines stream from the VM
     // directly. Without this, streaming exec on an image machine produces no
     // output (the agent-base streaming path doesn't enter the container).
-    let machine_image = state
-        .db()
-        .get_vm(&id)
-        .map_err(ApiError::database)?
-        .and_then(|r| r.image);
+    let machine_image = state.lookup_vm(&id).await?.and_then(|r| r.image);
 
     // Run streaming exec via the machine client (vsock is synchronous)
     let start = std::time::Instant::now();
@@ -405,11 +393,7 @@ pub async fn exec_interactive(
         .await
         .map_err(classify_ensure_running_error)?;
 
-    let machine_image = state
-        .db()
-        .get_vm(&id)
-        .map_err(ApiError::database)?
-        .and_then(|r| r.image);
+    let machine_image = state.lookup_vm(&id).await?.and_then(|r| r.image);
 
     let command = vec![q.cmd.clone().unwrap_or_else(|| "/bin/sh".to_string())];
     let init_size = (q.cols.unwrap_or(80), q.rows.unwrap_or(24));

--- a/src/api/handlers/files.rs
+++ b/src/api/handlers/files.rs
@@ -53,11 +53,7 @@ pub async fn upload_file(
         .await
         .map_err(classify_ensure_running_error)?;
 
-    let machine_image = state
-        .db()
-        .get_vm(&id)
-        .map_err(ApiError::database)?
-        .and_then(|r| r.image);
+    let machine_image = state.lookup_vm(&id).await?.and_then(|r| r.image);
 
     let file_path = file_path.trim_start_matches('/');
     let guest_path = format!("/{}", file_path);
@@ -119,11 +115,7 @@ pub async fn download_file(
         .await
         .map_err(classify_ensure_running_error)?;
 
-    let machine_image = state
-        .db()
-        .get_vm(&id)
-        .map_err(ApiError::database)?
-        .and_then(|r| r.image);
+    let machine_image = state.lookup_vm(&id).await?.and_then(|r| r.image);
 
     let file_path = file_path.trim_start_matches('/');
     let guest_path = format!("/{}", file_path);

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -609,11 +609,10 @@ pub async fn create_machine(
         return Err(e);
     }
 
-    // Fetch the persisted record for the response
-    let db = state.db();
-    let record = db
-        .get_vm(&name)
-        .map_err(ApiError::database)?
+    // Fetch the persisted record for the response (off the reactor).
+    let record = state
+        .lookup_vm(&name)
+        .await?
         .ok_or_else(|| ApiError::internal("machine disappeared after creation".to_string()))?;
 
     Ok(Json(record_to_info(&name, &record)))
@@ -632,9 +631,10 @@ pub async fn create_machine(
 pub async fn list_machines(
     State(state): State<Arc<ApiState>>,
 ) -> Result<Json<ListMachinesResponse>, ApiError> {
-    let db = state.db();
-    let vms = db.list_vms().map_err(ApiError::database)?;
-
+    // Read off the reactor: an inline synchronous `list_vms()` here let a stalled
+    // write park the worker pool and wedge the liveness probes (this is the path
+    // the control plane polls every reconcile). See tests/reactor_wedge.rs.
+    let vms = state.list_vm_records().await?;
     let machines: Vec<MachineInfo> = vms
         .iter()
         .map(|(name, record)| record_to_info(name, record))
@@ -660,10 +660,9 @@ pub async fn get_machine(
     State(state): State<Arc<ApiState>>,
     Path(name): Path<String>,
 ) -> Result<Json<MachineInfo>, ApiError> {
-    let db = state.db();
-    let record = db
-        .get_vm(&name)
-        .map_err(ApiError::database)?
+    let record = state
+        .lookup_vm(&name)
+        .await?
         .ok_or_else(|| ApiError::NotFound(format!("machine '{}' not found", name)))?;
 
     Ok(Json(record_to_info(&name, &record)))
@@ -715,11 +714,10 @@ pub async fn start_machine(
     let lifecycle = state.lifecycle_lock(&name);
     let _guard = lifecycle.lock().await;
 
-    // Get VM record from database
-    let db = state.db();
-    let record = db
-        .get_vm(&name)
-        .map_err(ApiError::database)?
+    // Get VM record from database (off the reactor)
+    let record = state
+        .lookup_vm(&name)
+        .await?
         .ok_or_else(|| ApiError::NotFound(format!("machine '{}' not found", name)))?;
 
     // Resolve via the shared probe (PID + vsock ping) so we don't
@@ -875,14 +873,14 @@ pub async fn start_machine(
     // Capture start time for PID verification
     let pid_start_time = pid.and_then(process_start_time);
 
-    // Persist state to database
-    let record = db
-        .update_vm(&name, |r| {
+    // Persist state to database (off the reactor)
+    let record = state
+        .update_vm(&name, move |r| {
             r.state = RecordState::Running;
             r.pid = pid;
             r.pid_start_time = pid_start_time;
         })
-        .map_err(ApiError::database)?
+        .await?
         .ok_or_else(|| {
             ApiError::NotFound(format!(
                 "machine '{}' disappeared from database during start",
@@ -1022,13 +1020,12 @@ pub async fn fork_machine(
     // Persist the running state.
     let pid_start_time = pid.and_then(process_start_time);
     let record = state
-        .db()
-        .update_vm(&clone, |r| {
+        .update_vm(&clone, move |r| {
             r.state = RecordState::Running;
             r.pid = pid;
             r.pid_start_time = pid_start_time;
         })
-        .map_err(ApiError::database)?
+        .await?
         .ok_or_else(|| {
             ApiError::NotFound(format!(
                 "clone '{}' disappeared from database during fork",
@@ -1070,11 +1067,10 @@ pub async fn stop_machine(
     let lifecycle = state.lifecycle_lock(&name);
     let _guard = lifecycle.lock().await;
 
-    // Get VM record from database
-    let db = state.db();
-    let record = db
-        .get_vm(&name)
-        .map_err(ApiError::database)?
+    // Get VM record from database (off the reactor)
+    let record = state
+        .lookup_vm(&name)
+        .await?
         .ok_or_else(|| ApiError::NotFound(format!("machine '{}' not found", name)))?;
 
     // Check state
@@ -1152,13 +1148,13 @@ pub async fn stop_machine(
     }
 
     // Persist state to database and get updated record — only after confirmed stop
-    let record = db
+    let record = state
         .update_vm(&name, |r| {
             r.state = RecordState::Stopped;
             r.pid = None;
             r.pid_start_time = None;
         })
-        .map_err(ApiError::database)?
+        .await?
         .ok_or_else(|| {
             ApiError::NotFound(format!(
                 "machine '{}' disappeared from database during stop",
@@ -1189,14 +1185,14 @@ pub async fn drain_node(State(state): State<Arc<ApiState>>) -> axum::http::Statu
 /// the control plane can reschedule. Best-effort, concurrent, and bounded so it
 /// fits inside the host's termination grace period.
 pub async fn drain_machines(state: &Arc<ApiState>) {
-    let running: Vec<(String, Option<i32>, Option<u64>)> = match state.db().list_vms() {
+    let running: Vec<(String, Option<i32>, Option<u64>)> = match state.list_vm_records().await {
         Ok(vms) => vms
             .into_iter()
             .filter(|(_, r)| r.actual_state() == RecordState::Running && r.is_process_alive())
             .map(|(name, r)| (name, r.pid, r.pid_start_time))
             .collect(),
         Err(e) => {
-            tracing::error!(error = %e, "drain: failed to list machines");
+            tracing::error!(error = ?e, "drain: failed to list machines");
             return;
         }
     };
@@ -1228,11 +1224,13 @@ pub async fn drain_machines(state: &Arc<ApiState>) {
             if let Ok(entry) = state.get_machine(&name) {
                 entry.lock().manager.mark_stopped();
             }
-            let _ = state.db().update_vm(&name, |r| {
-                r.state = RecordState::Stopped;
-                r.pid = None;
-                r.pid_start_time = None;
-            });
+            let _ = state
+                .update_vm(&name, |r| {
+                    r.state = RecordState::Stopped;
+                    r.pid = None;
+                    r.pid_start_time = None;
+                })
+                .await;
             tracing::info!(machine = %name, stopped, "drain: machine stopped");
         }));
     }
@@ -1277,12 +1275,10 @@ pub async fn delete_machine(
     let lifecycle = state.lifecycle_lock(&name);
     let _guard = lifecycle.lock().await;
 
-    let db = state.db();
-
-    // Check if VM exists and get its state
-    let record = db
-        .get_vm(&name)
-        .map_err(ApiError::database)?
+    // Check if VM exists and get its state (off the reactor)
+    let record = state
+        .lookup_vm(&name)
+        .await?
         .ok_or_else(|| ApiError::NotFound(format!("machine '{}' not found", name)))?;
 
     // Get PID and start time from database record
@@ -1464,13 +1460,10 @@ pub async fn resize_machine(
     Path(name): Path<String>,
     Json(req): Json<ResizeMachineRequest>,
 ) -> Result<Json<MachineInfo>, ApiError> {
-    let db = state.db();
-
-    let record = db
-        .get_vm(&name)
-        .map_err(ApiError::database)?
-        .ok_or_else(|| ApiError::NotFound(format!("machine '{}' not found", name)))?
-        .clone();
+    let record = state
+        .lookup_vm(&name)
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("machine '{}' not found", name)))?;
 
     let actual_state = record.actual_state();
     match actual_state {
@@ -1524,16 +1517,17 @@ pub async fn resize_machine(
         }
     }
 
-    let record = db
-        .update_vm(&name, |r| {
-            if let Some(s) = req.storage_gb {
+    let (storage_gb, overlay_gb) = (req.storage_gb, req.overlay_gb);
+    let record = state
+        .update_vm(&name, move |r| {
+            if let Some(s) = storage_gb {
                 r.storage_gb = Some(s);
             }
-            if let Some(o) = req.overlay_gb {
+            if let Some(o) = overlay_gb {
                 r.overlay_gb = Some(o);
             }
         })
-        .map_err(ApiError::database)?
+        .await?
         .ok_or_else(|| {
             ApiError::NotFound(format!("machine '{}' disappeared during resize", name))
         })?;

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -734,8 +734,52 @@ impl ApiState {
     }
 
     /// Get the underlying database handle.
+    ///
+    /// Prefer the async helpers below (`lookup_vm`/`list_vm_records`/`update_vm`)
+    /// from async request handlers: `SmolvmDb`'s methods are synchronous SQLite
+    /// I/O, and calling them directly on the tokio reactor lets a stalled write
+    /// (under create/delete churn) park the worker pool and wedge the liveness
+    /// probes. The helpers run the I/O on the blocking pool. `db()` itself is for
+    /// synchronous contexts (CLI, embedded runtime, inside an existing
+    /// `spawn_blocking`). See `tests/reactor_wedge.rs`.
     pub fn db(&self) -> &SmolvmDb {
         &self.db
+    }
+
+    /// Off-reactor VM lookup. Runs the blocking SQLite read on the blocking pool.
+    pub async fn lookup_vm(&self, name: &str) -> Result<Option<VmRecord>, ApiError> {
+        let db = self.db.clone();
+        let name = name.to_string();
+        tokio::task::spawn_blocking(move || db.get_vm(&name))
+            .await
+            .map_err(|e| ApiError::internal(format!("db lookup_vm task join: {e}")))?
+            .map_err(ApiError::database)
+    }
+
+    /// Off-reactor full VM listing. Runs the blocking SQLite scan on the blocking
+    /// pool (reads use the connection-pool, so this never serializes behind a write).
+    pub async fn list_vm_records(&self) -> Result<Vec<(String, VmRecord)>, ApiError> {
+        let db = self.db.clone();
+        tokio::task::spawn_blocking(move || db.list_vms())
+            .await
+            .map_err(|e| ApiError::internal(format!("db list_vm_records task join: {e}")))?
+            .map_err(ApiError::database)
+    }
+
+    /// Off-reactor read-modify-write of a VM record. Runs the synchronous
+    /// transaction on the blocking pool so the write — which holds the single
+    /// writer connection and may wait out `busy_timeout` under contention — never
+    /// parks a reactor worker thread.
+    pub async fn update_vm<F>(&self, name: &str, f: F) -> Result<Option<VmRecord>, ApiError>
+    where
+        F: FnOnce(&mut VmRecord) + Send + 'static,
+    {
+        let db = self.db.clone();
+        let name = name.to_string();
+        tokio::task::spawn_blocking(move || db.update_vm(&name, f))
+            .await
+            .map_err(|e| ApiError::internal(format!("db update_vm task join: {e}")))?
+            .map_err(ApiError::database)
     }
 
     /// Insert a machine entry directly into the in-memory registry.

--- a/src/db.rs
+++ b/src/db.rs
@@ -11,7 +11,7 @@
 
 use crate::config::VmRecord;
 use crate::error::{Error, Result};
-use parking_lot::Mutex;
+use parking_lot::{Condvar, Mutex};
 use rusqlite::{params, Connection, OptionalExtension};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -27,6 +27,106 @@ const BUSY_TIMEOUT: Duration = Duration::from_secs(15);
 /// crashed creator does not reserve a name forever.
 const CREATE_RESERVATION_TTL_SECS: u64 = 60 * 60;
 
+/// Max SQLite connections held open by the pool. WAL allows these to read
+/// concurrently (writes still serialize at the SQLite layer, gated by
+/// `busy_timeout`), so a slow write can no longer block reads — the prior
+/// single-`Mutex<Connection>` design serialized EVERY db call, which let a
+/// stalled write park the async reactor and wedge the liveness probes
+/// (see `tests/reactor_wedge.rs`). Sized to comfortably cover the API server's
+/// concurrent handlers without holding a large fan of file descriptors.
+const POOL_MAX_CONNS: usize = 8;
+
+/// A small fixed-capacity pool of SQLite connections to the same database file.
+///
+/// Each connection is opened with the WAL pragmas + `busy_timeout`, so multiple
+/// readers proceed in parallel and a writer only blocks other *writers*. A
+/// connection is checked out for the duration of one `with_conn` closure and
+/// returned on drop (discarded if the closure panicked, so a half-applied
+/// statement can't be handed to the next caller). Checkout blocks only when all
+/// `POOL_MAX_CONNS` are in use — never behind an unrelated read.
+struct ConnPool {
+    path: PathBuf,
+    inner: Mutex<PoolInner>,
+    available: Condvar,
+}
+
+struct PoolInner {
+    /// Connections opened and not currently checked out.
+    idle: Vec<Connection>,
+    /// Total connections in existence (idle + checked out).
+    open: usize,
+}
+
+impl ConnPool {
+    fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            inner: Mutex::new(PoolInner {
+                idle: Vec::new(),
+                open: 0,
+            }),
+            available: Condvar::new(),
+        }
+    }
+
+    /// Take a connection, opening a new one (up to `POOL_MAX_CONNS`) or waiting
+    /// for one to be returned. Opening happens outside the lock so a slow open
+    /// never blocks other checkouts/checkins.
+    fn checkout(&self) -> Result<Connection> {
+        let mut inner = self.inner.lock();
+        loop {
+            if let Some(conn) = inner.idle.pop() {
+                return Ok(conn);
+            }
+            if inner.open < POOL_MAX_CONNS {
+                inner.open += 1;
+                drop(inner);
+                match SmolvmDb::open_connection(&self.path) {
+                    Ok(conn) => return Ok(conn),
+                    Err(e) => {
+                        // Roll back the reservation and let a waiter retry.
+                        self.inner.lock().open -= 1;
+                        self.available.notify_one();
+                        return Err(e);
+                    }
+                }
+            }
+            // Pool saturated: wait for a checkin.
+            self.available.wait(&mut inner);
+        }
+    }
+
+    fn checkin(&self, conn: Connection) {
+        self.inner.lock().idle.push(conn);
+        self.available.notify_one();
+    }
+
+    /// Drop a connection without returning it (used when its closure panicked,
+    /// so its possibly-dirty state is not reused). Frees a slot for a new open.
+    fn discard(&self) {
+        self.inner.lock().open -= 1;
+        self.available.notify_one();
+    }
+}
+
+/// RAII guard returning a checked-out connection to the pool on drop.
+struct PooledConn<'a> {
+    pool: &'a ConnPool,
+    conn: Option<Connection>,
+}
+
+impl Drop for PooledConn<'_> {
+    fn drop(&mut self) {
+        if let Some(conn) = self.conn.take() {
+            if std::thread::panicking() {
+                self.pool.discard();
+            } else {
+                self.pool.checkin(conn);
+            }
+        }
+    }
+}
+
 /// Extension trait to convert errors into `Error::database`.
 trait DbResultExt<T> {
     fn db_err(self, operation: impl Into<String>) -> Result<T>;
@@ -40,36 +140,64 @@ impl<T, E: std::fmt::Display> DbResultExt<T> for std::result::Result<T, E> {
 
 /// Thread-safe database handle for smolvm state persistence.
 ///
-/// The SQLite `Connection` is opened lazily on first use and cached for the
-/// lifetime of the `SmolvmDb` instance. The Mutex serialises access within
-/// the process; cross-process concurrency is handled by SQLite's WAL mode
-/// and busy_timeout.
+/// Uses the standard WAL split: a single dedicated WRITER connection (behind a
+/// mutex) serializes all mutations in-process — so they never contend at the
+/// SQLite write-lock layer (no `SQLITE_BUSY` spinning) — while READS go through a
+/// small pool of separate connections that run concurrently under WAL. A reader
+/// therefore never waits on the writer, so a stalled write can no longer park the
+/// async reactor that serves the liveness probes (the single-`Mutex<Connection>`
+/// failure mode; see `tests/reactor_wedge.rs`). Connections open lazily.
+/// Cross-process concurrency is still handled by WAL + busy_timeout.
 #[derive(Clone)]
 pub struct SmolvmDb {
     path: PathBuf,
-    handle: Arc<Mutex<Option<Connection>>>,
+    /// Single connection serializing writes (and the rare read that must observe
+    /// its own just-committed write on the same connection). Opened on first use.
+    writer: Arc<Mutex<Option<Connection>>>,
+    /// Pool of connections for concurrent reads. Never used for writes.
+    readers: Arc<ConnPool>,
 }
 
 impl std::fmt::Debug for SmolvmDb {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SmolvmDb")
             .field("path", &self.path)
-            .field("open", &self.handle.lock().is_some())
+            .field("writer_open", &self.writer.lock().is_some())
+            .field("reader_conns", &self.readers.inner.lock().open)
             .finish()
     }
 }
 
 impl SmolvmDb {
-    /// Run a closure with the cached connection, opening it on first use.
+    /// Run a closure with the single writer connection, opening it on first use.
+    /// Serializes all writers in-process so they never collide at the SQLite
+    /// write lock. Use for every mutation (and any read that must see a write it
+    /// just made on this connection).
     fn with_conn<T, F>(&self, f: F) -> Result<T>
     where
         F: FnOnce(&mut Connection) -> Result<T>,
     {
-        let mut guard = self.handle.lock();
+        let mut guard = self.writer.lock();
         if guard.is_none() {
             *guard = Some(Self::open_connection(&self.path)?);
         }
-        f(guard.as_mut().unwrap())
+        f(guard.as_mut().expect("writer connection present"))
+    }
+
+    /// Run a closure with a pooled READ connection. Concurrent reads use
+    /// different connections (up to `POOL_MAX_CONNS`) and, under WAL, never block
+    /// on the writer — so a stalled write can't serialize or wedge reads. MUST
+    /// NOT be used for writes (that would reintroduce SQLite write contention).
+    fn with_read_conn<T, F>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut Connection) -> Result<T>,
+    {
+        let conn = self.readers.checkout()?;
+        let mut guard = PooledConn {
+            pool: &self.readers,
+            conn: Some(conn),
+        };
+        f(guard.conn.as_mut().expect("reader connection present"))
     }
 
     /// Open the SQLite connection, configure pragmas, and ensure tables exist.
@@ -124,7 +252,8 @@ impl SmolvmDb {
 
         Ok(Self {
             path: path.to_path_buf(),
-            handle: Arc::new(Mutex::new(None)),
+            writer: Arc::new(Mutex::new(None)),
+            readers: Arc::new(ConnPool::new(path.to_path_buf())),
         })
     }
 
@@ -324,7 +453,7 @@ impl SmolvmDb {
 
     /// Get a VM record by name.
     pub fn get_vm(&self, name: &str) -> Result<Option<VmRecord>> {
-        self.with_conn(|conn| {
+        self.with_read_conn(|conn| {
             let data: Option<Vec<u8>> = conn
                 .query_row(
                     "SELECT data FROM vms WHERE name = ?1",
@@ -379,7 +508,7 @@ impl SmolvmDb {
 
     /// List all VM records.
     pub fn list_vms(&self) -> Result<Vec<(String, VmRecord)>> {
-        self.with_conn(|conn| {
+        self.with_read_conn(|conn| {
             let mut stmt = conn
                 .prepare_cached("SELECT name, data FROM vms")
                 .db_err("prepare list_vms")?;
@@ -612,6 +741,64 @@ mod tests {
         assert_eq!(removed.name, "test-vm");
 
         assert!(db.get_vm("test-vm").unwrap().is_none());
+    }
+
+    /// A read must not block behind a stalled write. Before the connection pool,
+    /// every db call shared one `Mutex<Connection>`, so a write stalled on
+    /// SQLite's `busy_timeout` held that mutex and serialized ALL reads behind
+    /// it — the serialization that let a stalled write park the async reactor and
+    /// wedge the liveness probes in production (see `tests/reactor_wedge.rs`).
+    /// With the pool the read uses a different WAL connection and returns at once.
+    /// Pre-pool this asserts in ~15s (busy_timeout) and fails; post-pool ~ms.
+    #[test]
+    fn read_does_not_block_behind_a_stalled_write() {
+        let (dir, db) = temp_db();
+        let path = dir.path().join("test.db");
+        db.insert_vm(
+            "m0",
+            &VmRecord::new("m0".to_string(), 1, 256, vec![], vec![], false),
+        )
+        .unwrap();
+
+        // Warm the pool to 2 idle connections so the read below reuses one rather
+        // than opening a fresh connection while the external write lock is held.
+        std::thread::scope(|s| {
+            for _ in 0..2 {
+                s.spawn(|| {
+                    let _ = db.get_vm("m0");
+                    std::thread::sleep(Duration::from_millis(60));
+                });
+            }
+        });
+
+        // A second connection to the same file holds the SQLite write lock —
+        // exactly what concurrent cross-process create-reservations do under churn.
+        let blocker = Connection::open(&path).unwrap();
+        blocker.busy_timeout(Duration::from_secs(30)).unwrap();
+        blocker.execute_batch("BEGIN IMMEDIATE").unwrap();
+
+        // A SmolvmDb write now stalls on busy_timeout, holding one pooled connection.
+        let db_w = db.clone();
+        let writer = std::thread::spawn(move || {
+            let _ = db_w.insert_vm(
+                "m1",
+                &VmRecord::new("m1".to_string(), 1, 256, vec![], vec![], false),
+            );
+        });
+        std::thread::sleep(Duration::from_millis(300)); // let the write grab a conn + stall
+
+        // Concurrent read on a DIFFERENT pooled connection (WAL): must be immediate.
+        let start = std::time::Instant::now();
+        let got = db.get_vm("m0").unwrap();
+        let elapsed = start.elapsed();
+        assert!(got.is_some(), "read returned no record");
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "read blocked {elapsed:?} behind a stalled write — the pool is not isolating reads from writes"
+        );
+
+        blocker.execute_batch("COMMIT").ok();
+        let _ = writer.join();
     }
 
     #[test]


### PR DESCRIPTION
Inline synchronous `SmolvmDb` calls in async handlers parked the reactor on the single connection mutex when a write stalled (busy_timeout) and wedged the liveness probes; this routes all handler DB I/O off the reactor via an async `ApiState` facade and splits `SmolvmDb` into a dedicated writer + reader pool so reads never serialize behind a write.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/472">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->