### PR TITLE
fix(agent): cross-platform ResolvedLaunch — repair macOS agent build broken on main by #473

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -2915,7 +2915,9 @@ fn handle_interactive_run(
 /// paths both go through it, and a *future* launch path won't compile without
 /// resolving. That's what keeps Env/WorkingDir/User from being silently dropped
 /// on some path — the failure mode this type exists to make impossible.
-#[cfg(target_os = "linux")]
+///
+/// Defined on all platforms: the shared `handle_interactive_run` constructs one,
+/// and the macOS build compiles the agent (as stubs) for `cargo test`.
 struct ResolvedLaunch {
     command: Vec<String>,
     env: Vec<(String, String)>,
@@ -2923,7 +2925,6 @@ struct ResolvedLaunch {
     user: Option<String>,
 }
 
-#[cfg(target_os = "linux")]
 impl ResolvedLaunch {
     /// Merge the request's launch params with the image's OCI config:
     /// - **command**: the request's, else the image's `ENTRYPOINT` + `CMD`
@@ -2967,7 +2968,6 @@ impl ResolvedLaunch {
 /// Layer the request's env over an image's OCI `Env` (each `"KEY=VAL"`): the
 /// request wins on key conflicts, image entries fill in the rest — matching how
 /// a container runtime composes image + run-time environment.
-#[cfg(target_os = "linux")]
 fn merge_image_env(
     image_env: Vec<String>,
     request_env: Vec<(String, String)>,
@@ -3652,19 +3652,20 @@ fn spawn_interactive_command(
 
 /// Non-Linux stub for spawn_interactive_command.
 #[cfg(not(target_os = "linux"))]
-#[allow(clippy::too_many_arguments)]
 fn spawn_interactive_command(
     rootfs: &str,
-    command: &[String],
-    env: &[(String, String)],
-    workdir: Option<&str>,
-    user: Option<&str>,
+    launch: &ResolvedLaunch,
     mounts: &[(String, String, bool)],
     _tty: bool,
     _persistent_overlay_id: Option<&str>,
     unprivileged: bool,
 ) -> Result<(Child, Option<()>), Box<dyn std::error::Error>> {
     use std::path::Path;
+
+    let command: &[String] = &launch.command;
+    let env: &[(String, String)] = &launch.env;
+    let workdir: Option<&str> = launch.workdir.as_deref();
+    let user: Option<&str> = launch.user.as_deref();
 
     if command.is_empty() {
         return Err("empty command".into());


### PR DESCRIPTION
#473's chokepoint refactor gated `ResolvedLaunch`/`resolve`/`merge_image_env` to `target_os=linux`, but the shared `handle_interactive_run` constructs one and the macOS `spawn_interactive_command` stub kept the old signature — so the Linux build passed while the macOS 'agent unit tests' build on `main` fails to compile. This makes those three cross-platform (they use only the already-shared `query_image`) and updates the macOS stub to `&ResolvedLaunch`. Verified: Linux musl builds, macOS `cargo test -p smolvm-agent` = 94 passed, fmt clean. **main is currently red — merge to green it.**

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/474">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->