### PR TITLE
Document Windows/WHP support and make dist checksums portable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,16 @@
 
 A tool to build and run portable, self-contained virtual machines locally. <200ms boot time. No daemon, no Docker.
 
+## Platform Support
+
+| Host | Guest | Hypervisor | Requirements |
+|------|-------|------------|--------------|
+| macOS Apple Silicon | arm64 Linux | Hypervisor.framework | macOS 11+ |
+| Linux x86_64 / aarch64 | matching Linux | KVM | `/dev/kvm` |
+| Windows x86_64 | x86_64 Linux | Windows Hypervisor Platform (WHP) | WHP feature enabled |
+
+Windows caveats (run, persistent machines, volumes, port-forwarding, pack create/run, and interactive TTY all work): networking is TSI-only (TCP/UDP + inbound `-p`, no virtio-net); no GPU acceleration; no fork/snapshot. `pack create` needs `storage-template.ext4` / `overlay-template.ext4` beside `smolvm.exe` (Windows has no host `mkfs.ext4`). Set `SMOLVM_LIB_DIR` (folder holding `krun.dll` + `libkrunfw.dll`) and `SMOLVM_AGENT_ROOTFS` when running from a non-standard layout.
+
 ## Quick Reference
 
 ```bash
@@ -304,6 +314,8 @@ Requires `SSH_AUTH_SOCK` to be set on the host. If missing, smolvm exits with an
 ## GPU Acceleration
 
 Enable the host GPU inside a VM with `--gpu`. Guest Vulkan talks to the host GPU via virtio-gpu/Venus; ANGLE uses it as the WebGL/OpenGL ES backend.
+
+Not available on Windows (WHP) — `--gpu` has no effect there.
 
 **Host setup:**
 - macOS — bundled, no extra installs needed.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ smolvm
 Ship and run software with isolation by default.
 
 This is a CLI tool that lets you:
-1. Manage and run custom Linux virtual machines locally with: sub-second cold start, cross-platform (macOS, Linux), elastic memory usage.
+1. Manage and run custom Linux virtual machines locally with: sub-second cold start, cross-platform (macOS, Linux, Windows), elastic memory usage.
 2. Pack a stateful virtual machine into a single file (.smolmachine) to rehydrate on any supported platform.
 
 Install
@@ -29,6 +29,8 @@ curl -sSL https://smolmachines.com/install.sh | bash && smolvm --help
 ```
 
 Or download from [GitHub Releases](https://github.com/smol-machines/smolvm/releases), and place it into `~/.local/share/`.
+
+**Windows:** download the `windows-x86_64` release (bundles `krun.dll` + `libkrunfw.dll`), unzip it, and run `smolvm.exe`. Requires the [Windows Hypervisor Platform](https://learn.microsoft.com/en-us/virtualization/api/) (WHP) feature enabled.
 
 Quick Start
 -----------
@@ -129,7 +131,7 @@ More examples: [python](https://github.com/smol-machines/smolvm/tree/main/exampl
 How It Works
 ------------
 
-Each workload gets real hardware isolation — its own kernel on [Hypervisor.framework](https://developer.apple.com/documentation/hypervisor) (macOS) or KVM (Linux). [libkrun](https://github.com/containers/libkrun) VMM with custom kernel: [libkrunfw](https://github.com/smol-machines/libkrunfw). Pack it into a `.smolmachine` and it runs anywhere the host architecture matches, with zero dependencies.
+Each workload gets real hardware isolation — its own kernel on [Hypervisor.framework](https://developer.apple.com/documentation/hypervisor) (macOS), KVM (Linux), or the [Windows Hypervisor Platform](https://learn.microsoft.com/en-us/virtualization/api/) (Windows). [libkrun](https://github.com/containers/libkrun) VMM with custom kernel: [libkrunfw](https://github.com/smol-machines/libkrunfw). Pack it into a `.smolmachine` and it runs anywhere the host architecture matches, with zero dependencies.
 
 Images use the [OCI](https://opencontainers.org/) format — the same open standard Docker uses. Any image on Docker Hub, ghcr.io, or other OCI registries can be pulled and booted as a microVM. No Docker daemon required.
 
@@ -157,6 +159,7 @@ Platform Support
 | macOS Intel | x86_64 Linux | macOS 11+ (untested) |
 | Linux x86_64 | x86_64 Linux | KVM (`/dev/kvm`) |
 | Linux aarch64 | aarch64 Linux | KVM (`/dev/kvm`) |
+| Windows x86_64 | x86_64 Linux | Windows Hypervisor Platform (WHP) enabled |
 
 Known Limitations
 -----------------
@@ -166,6 +169,7 @@ Known Limitations
 * macOS: binary must be signed with Hypervisor.framework entitlements.
 * `--ssh-agent` requires an SSH agent running on the host (`SSH_AUTH_SOCK` must be set).
 * GPU acceleration requires libkrun built with `GPU=1` and virglrenderer + a Vulkan driver on the host (see [GPU Acceleration](#gpu-acceleration) below).
+* Windows: networking uses the transparent socket layer (TSI) — `--net` gives TCP/UDP and inbound port-forwarding, but virtio-net, GPU acceleration, and fork/snapshot are not available. Pack *create* needs `storage-template.ext4` / `overlay-template.ext4` next to `smolvm.exe` (Windows has no host `mkfs.ext4`).
 
 GPU Acceleration
 ----------------

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -614,9 +614,19 @@ TROUBLESHOOTING
 For more information: https://github.com/smolvm/smolvm
 EOF
 
-# Generate checksums
+# Generate checksums. Use sha256sum where available (Linux/coreutils, incl.
+# Arch) and fall back to `shasum -a 256` (the macOS default, which has no
+# sha256sum). Both emit the same "<hash>  <file>" format.
 echo "Generating checksums..."
-(cd "$DIST_DIR" && shasum -a 256 smolvm smolvm-bin lib/* > checksums.txt)
+if command -v sha256sum >/dev/null 2>&1; then
+    SHA256_CMD=(sha256sum)
+elif command -v shasum >/dev/null 2>&1; then
+    SHA256_CMD=(shasum -a 256)
+else
+    echo "Error: neither sha256sum nor shasum found; cannot generate checksums" >&2
+    exit 1
+fi
+(cd "$DIST_DIR" && "${SHA256_CMD[@]}" smolvm smolvm-bin lib/* > checksums.txt)
 
 # Delete existing tarball. This is because when a new release is created, there could be 
 # tarball of the old release left in dist/, and ./install-local.sh may pick up the wrong tarball


### PR DESCRIPTION
Now that #475 (the Windows/WHP port) has merged, this targets `main` directly.

- **README / AGENTS.md**: add Windows x86_64 (WHP) as a first-class platform — install note, platform-support tables, the WHP hypervisor alongside Hypervisor.framework/KVM, and the Windows caveats (TSI-only networking, no virtio-net/GPU/fork-snapshot, the `storage-template.ext4` pack-create dependency, `SMOLVM_LIB_DIR`/`SMOLVM_AGENT_ROOTFS`).
- **scripts/build-dist.sh**: checksum step now prefers `sha256sum` and falls back to `shasum -a 256` (stock macOS has no `sha256sum`; some Linux hosts have no `shasum`) — both emit the same format. Surfaced while building the Linux release during cross-platform validation.