### PR TITLE
Windows parity: machine CPU/RSS stats + sparse disk-template copy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ landlock = "0.4"
 windows-sys = { version = "0.60", features = [
     "Win32_Foundation",
     "Win32_System_Threading",
+    "Win32_System_ProcessStatus",
     "Win32_System_LibraryLoader",
     "Win32_System_Console",
     "Win32_System_IO",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ windows-sys = { version = "0.60", features = [
     "Win32_System_LibraryLoader",
     "Win32_System_Console",
     "Win32_System_IO",
+    "Win32_Storage_FileSystem",
     "Win32_Networking_WinSock",
 ] }
 

--- a/src/disk_utils.rs
+++ b/src/disk_utils.rs
@@ -424,10 +424,19 @@ fn sparse_copy_windows(src: &Path, dst: &Path) -> std::io::Result<u64> {
 
     let mut total: u64 = 0;
     let mut buf = vec![0u8; 1024 * 1024];
-    let mut out: Vec<AllocatedRange> = vec![AllocatedRange { file_offset: 0, length: 0 }; 1024];
+    let mut out: Vec<AllocatedRange> = vec![
+        AllocatedRange {
+            file_offset: 0,
+            length: 0
+        };
+        1024
+    ];
     // Query allocated ranges starting at 0; the FSCTL fills as many as fit, and
     // signals ERROR_MORE_DATA when there are more (resume past the last range).
-    let mut query = AllocatedRange { file_offset: 0, length: src_len as i64 };
+    let mut query = AllocatedRange {
+        file_offset: 0,
+        length: src_len as i64,
+    };
     loop {
         let mut returned: u32 = 0;
         // SAFETY: src handle is live; `query` is a valid input record; `out` is a
@@ -444,7 +453,8 @@ fn sparse_copy_windows(src: &Path, dst: &Path) -> std::io::Result<u64> {
                 std::ptr::null_mut(),
             )
         };
-        let more = ok == 0 && std::io::Error::last_os_error().raw_os_error() == Some(ERROR_MORE_DATA);
+        let more =
+            ok == 0 && std::io::Error::last_os_error().raw_os_error() == Some(ERROR_MORE_DATA);
         if ok == 0 && !more {
             return Err(std::io::Error::last_os_error());
         }
@@ -578,7 +588,10 @@ mod tests {
             logical_len,
             "clone must preserve logical length"
         );
-        assert_eq!(src_bytes, dst_bytes, "clone must be byte-identical to source");
+        assert_eq!(
+            src_bytes, dst_bytes,
+            "clone must be byte-identical to source"
+        );
         assert_eq!(&dst_bytes[..head.len()], head);
         assert_eq!(&dst_bytes[dst_bytes.len() - tail.len()..], tail);
 

--- a/src/disk_utils.rs
+++ b/src/disk_utils.rs
@@ -383,14 +383,28 @@ pub fn clone_or_copy_file(src: &Path, dst: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Copy a sparse file on Windows/NTFS without materialising its holes: mark the
-/// destination sparse, then write only the non-zero 256 KiB chunks (zero runs
-/// are left as unallocated holes, and the trailing hole is covered by `set_len`).
-/// Mirrors the Linux `SEEK_HOLE`/`SEEK_DATA` path so a large-virtual template
-/// stays small on disk instead of growing to its full logical size on copy.
+/// Copy a sparse file on Windows/NTFS by replicating only its allocated regions,
+/// leaving holes as holes — the Win32 analogue of the Linux `SEEK_HOLE`/`SEEK_DATA`
+/// path. A scan-and-skip-zeros copy would have to read the whole logical size
+/// (20+ GiB for a disk image) and, worse, allocate any non-zero region it finds;
+/// `FSCTL_QUERY_ALLOCATED_RANGES` reports exactly the regions NTFS has backed, so
+/// a 20 GiB image holding a few MB copies a few MB.
 #[cfg(windows)]
 fn sparse_copy_windows(src: &Path, dst: &Path) -> std::io::Result<u64> {
     use std::io::{Read, Seek, SeekFrom, Write};
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::System::IO::DeviceIoControl;
+
+    // FSCTL_QUERY_ALLOCATED_RANGES (winioctl.h) + its in/out record. LARGE_INTEGER
+    // fields are signed 64-bit byte counts.
+    const FSCTL_QUERY_ALLOCATED_RANGES: u32 = 0x0009_40CF;
+    const ERROR_MORE_DATA: i32 = 234;
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct AllocatedRange {
+        file_offset: i64,
+        length: i64,
+    }
 
     let mut src_file = std::fs::File::open(src)?;
     let src_len = src_file.metadata()?.len();
@@ -404,26 +418,65 @@ fn sparse_copy_windows(src: &Path, dst: &Path) -> std::io::Result<u64> {
     if src_len == 0 {
         return Ok(0);
     }
-    // Mark sparse BEFORE extending so the hole regions are never allocated.
+    // Mark sparse BEFORE extending so the holes are never allocated.
     mark_file_sparse(&dst_file)?;
     dst_file.set_len(src_len)?;
 
-    let mut offset: u64 = 0;
     let mut total: u64 = 0;
-    let mut buf = vec![0u8; 256 * 1024];
+    let mut buf = vec![0u8; 1024 * 1024];
+    let mut out: Vec<AllocatedRange> = vec![AllocatedRange { file_offset: 0, length: 0 }; 1024];
+    // Query allocated ranges starting at 0; the FSCTL fills as many as fit, and
+    // signals ERROR_MORE_DATA when there are more (resume past the last range).
+    let mut query = AllocatedRange { file_offset: 0, length: src_len as i64 };
     loop {
-        let n = src_file.read(&mut buf)?;
-        if n == 0 {
+        let mut returned: u32 = 0;
+        // SAFETY: src handle is live; `query` is a valid input record; `out` is a
+        // valid, correctly-sized output array; `returned` is a writable out-param.
+        let ok = unsafe {
+            DeviceIoControl(
+                src_file.as_raw_handle(),
+                FSCTL_QUERY_ALLOCATED_RANGES,
+                &query as *const _ as *const core::ffi::c_void,
+                std::mem::size_of::<AllocatedRange>() as u32,
+                out.as_mut_ptr() as *mut core::ffi::c_void,
+                (out.len() * std::mem::size_of::<AllocatedRange>()) as u32,
+                &mut returned,
+                std::ptr::null_mut(),
+            )
+        };
+        let more = ok == 0 && std::io::Error::last_os_error().raw_os_error() == Some(ERROR_MORE_DATA);
+        if ok == 0 && !more {
+            return Err(std::io::Error::last_os_error());
+        }
+        let count = returned as usize / std::mem::size_of::<AllocatedRange>();
+        if count == 0 {
             break;
         }
-        let chunk = &buf[..n];
-        if chunk.iter().any(|&b| b != 0) {
-            dst_file.seek(SeekFrom::Start(offset))?;
-            dst_file.write_all(chunk)?;
-            total += n as u64;
+        let mut resume = query.file_offset;
+        for r in &out[..count] {
+            let mut pos = r.file_offset as u64;
+            let end = (r.file_offset + r.length) as u64;
+            while pos < end {
+                let want = std::cmp::min((end - pos) as usize, buf.len());
+                src_file.seek(SeekFrom::Start(pos))?;
+                src_file.read_exact(&mut buf[..want])?;
+                dst_file.seek(SeekFrom::Start(pos))?;
+                dst_file.write_all(&buf[..want])?;
+                pos += want as u64;
+                total += want as u64;
+            }
+            resume = r.file_offset + r.length;
         }
-        offset += n as u64;
+        if !more {
+            break;
+        }
+        query.file_offset = resume;
+        query.length = src_len as i64 - resume;
+        if query.length <= 0 {
+            break;
+        }
     }
+    tracing::debug!(total, "sparse_copy_windows: allocated-range copy done");
     Ok(total)
 }
 

--- a/src/disk_utils.rs
+++ b/src/disk_utils.rs
@@ -360,8 +360,71 @@ pub fn clone_or_copy_file(src: &Path, dst: &Path) -> Result<()> {
         }
     }
 
+    #[cfg(windows)]
+    {
+        // std::fs::copy materialises holes on NTFS, so a large-virtual sparse
+        // template (e.g. a 10 GiB overlay with ~50 MB of real data) balloons to
+        // its full logical size. Copy sparsely instead, mirroring the Linux path.
+        match sparse_copy_windows(src, dst) {
+            Ok(bytes) => {
+                tracing::debug!(
+                    src = %src.display(), dst = %dst.display(),
+                    bytes_copied = bytes, "windows sparse copy succeeded"
+                );
+                return Ok(());
+            }
+            Err(e) => {
+                tracing::debug!(src = %src.display(), error = %e, "windows sparse copy failed, falling back to fs::copy");
+            }
+        }
+    }
+
     std::fs::copy(src, dst).map_err(|e| Error::storage("copy file", e.to_string()))?;
     Ok(())
+}
+
+/// Copy a sparse file on Windows/NTFS without materialising its holes: mark the
+/// destination sparse, then write only the non-zero 256 KiB chunks (zero runs
+/// are left as unallocated holes, and the trailing hole is covered by `set_len`).
+/// Mirrors the Linux `SEEK_HOLE`/`SEEK_DATA` path so a large-virtual template
+/// stays small on disk instead of growing to its full logical size on copy.
+#[cfg(windows)]
+fn sparse_copy_windows(src: &Path, dst: &Path) -> std::io::Result<u64> {
+    use std::io::{Read, Seek, SeekFrom, Write};
+
+    let mut src_file = std::fs::File::open(src)?;
+    let src_len = src_file.metadata()?.len();
+    if dst.exists() {
+        std::fs::remove_file(dst)?;
+    }
+    let mut dst_file = std::fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(dst)?;
+    if src_len == 0 {
+        return Ok(0);
+    }
+    // Mark sparse BEFORE extending so the hole regions are never allocated.
+    mark_file_sparse(&dst_file)?;
+    dst_file.set_len(src_len)?;
+
+    let mut offset: u64 = 0;
+    let mut total: u64 = 0;
+    let mut buf = vec![0u8; 256 * 1024];
+    loop {
+        let n = src_file.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        let chunk = &buf[..n];
+        if chunk.iter().any(|&b| b != 0) {
+            dst_file.seek(SeekFrom::Start(offset))?;
+            dst_file.write_all(chunk)?;
+            total += n as u64;
+        }
+        offset += n as u64;
+    }
+    Ok(total)
 }
 
 /// Copy only data regions of a sparse file via SEEK_HOLE/SEEK_DATA.
@@ -424,4 +487,68 @@ fn sparse_copy(src: &Path, dst: &Path) -> std::io::Result<u64> {
         offset = data_end;
     }
     Ok(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Seek, SeekFrom, Write};
+
+    /// `clone_or_copy_file` must reproduce a sparse file byte-for-byte on every
+    /// platform — including the Windows sparse-copy path, which skips zero runs.
+    /// We build a file with a head data region, a large hole, and a tail data
+    /// region, then assert the clone's length and full contents match.
+    #[test]
+    fn clone_or_copy_preserves_sparse_contents() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src.img");
+        let dst = dir.path().join("dst.img");
+
+        let logical_len: u64 = 8 * 1024 * 1024; // 8 MiB logical
+        let head = b"HEAD-DATA-REGION";
+        let tail = b"TAIL-DATA-REGION";
+        {
+            let mut f = std::fs::File::create(&src).unwrap();
+            f.write_all(head).unwrap();
+            f.set_len(logical_len).unwrap();
+            f.seek(SeekFrom::Start(logical_len - tail.len() as u64))
+                .unwrap();
+            f.write_all(tail).unwrap();
+        }
+
+        clone_or_copy_file(&src, &dst).expect("clone_or_copy_file");
+
+        let src_bytes = std::fs::read(&src).unwrap();
+        let dst_bytes = std::fs::read(&dst).unwrap();
+        assert_eq!(
+            dst_bytes.len() as u64,
+            logical_len,
+            "clone must preserve logical length"
+        );
+        assert_eq!(src_bytes, dst_bytes, "clone must be byte-identical to source");
+        assert_eq!(&dst_bytes[..head.len()], head);
+        assert_eq!(&dst_bytes[dst_bytes.len() - tail.len()..], tail);
+
+        // On Windows the whole point is that the clone stays sparse — the 8 MiB
+        // hole must NOT be allocated on disk. GetCompressedFileSizeW reports the
+        // real on-disk allocation; assert it's a tiny fraction of the logical size.
+        #[cfg(windows)]
+        {
+            use std::os::windows::ffi::OsStrExt;
+            use windows_sys::Win32::Storage::FileSystem::GetCompressedFileSizeW;
+            let wide: Vec<u16> = dst
+                .as_os_str()
+                .encode_wide()
+                .chain(std::iter::once(0))
+                .collect();
+            let mut high: u32 = 0;
+            // SAFETY: `wide` is a valid NUL-terminated path; `high` is a writable out-param.
+            let low = unsafe { GetCompressedFileSizeW(wide.as_ptr(), &mut high) };
+            let allocated = ((high as u64) << 32) | (low as u64);
+            assert!(
+                allocated < logical_len / 2,
+                "sparse clone must not allocate the full {logical_len} bytes (got {allocated} allocated)"
+            );
+        }
+    }
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -131,8 +131,55 @@ mod win {
         if ok == 0 {
             None
         } else {
-            Some(((creation.dwHighDateTime as u64) << 32) | (creation.dwLowDateTime as u64))
+            Some(filetime_to_u64(&creation))
         }
+    }
+
+    /// Combine a FILETIME's high/low halves into a single u64 (100 ns ticks).
+    fn filetime_to_u64(ft: &windows_sys::Win32::Foundation::FILETIME) -> u64 {
+        ((ft.dwHighDateTime as u64) << 32) | (ft.dwLowDateTime as u64)
+    }
+
+    /// Sample cumulative CPU time (ns) and resident set size (bytes) for a
+    /// process. Mirrors the Linux `/proc/<pid>/{stat,statm}` and macOS
+    /// `proc_pidinfo` sampling so `machine monitor` reports live CPU/RSS on
+    /// Windows too. Returns `None` if the process is gone or stats are
+    /// unavailable.
+    pub fn process_stats(pid: u32) -> Option<(u64, u64)> {
+        use windows_sys::Win32::Foundation::FILETIME;
+        use windows_sys::Win32::System::ProcessStatus::{
+            GetProcessMemoryInfo, PROCESS_MEMORY_COUNTERS,
+        };
+        use windows_sys::Win32::System::Threading::GetProcessTimes;
+
+        let handle = open(pid, PROCESS_QUERY_LIMITED_INFORMATION)?;
+
+        let zero = FILETIME {
+            dwLowDateTime: 0,
+            dwHighDateTime: 0,
+        };
+        let (mut creation, mut exit, mut kernel, mut user) = (zero, zero, zero, zero);
+        // SAFETY: handle is live for the call; all four FILETIME out-params are
+        // valid, writable locals.
+        let times_ok =
+            unsafe { GetProcessTimes(handle, &mut creation, &mut exit, &mut kernel, &mut user) };
+
+        let mut pmc: PROCESS_MEMORY_COUNTERS = unsafe { std::mem::zeroed() };
+        let pmc_size = std::mem::size_of::<PROCESS_MEMORY_COUNTERS>() as u32;
+        pmc.cb = pmc_size;
+        // SAFETY: handle is live; pmc is a valid, correctly-sized counters buffer.
+        let mem_ok = unsafe { GetProcessMemoryInfo(handle, &mut pmc, pmc_size) };
+
+        unsafe { CloseHandle(handle) };
+        if times_ok == 0 || mem_ok == 0 {
+            return None;
+        }
+
+        // GetProcessTimes' kernel/user are 100 ns ticks; sum and scale to ns.
+        let cpu_time_ns = filetime_to_u64(&kernel)
+            .saturating_add(filetime_to_u64(&user))
+            .saturating_mul(100);
+        Some((cpu_time_ns, pmc.WorkingSetSize as u64))
     }
 }
 
@@ -1566,9 +1613,20 @@ pub fn process_stats(pid: Pid) -> Option<ProcessStats> {
     })
 }
 
+/// Sample CPU time and RSS for a process on Windows via the Win32 process APIs
+/// (`GetProcessTimes` + `GetProcessMemoryInfo`).
+#[cfg(windows)]
+pub fn process_stats(pid: Pid) -> Option<ProcessStats> {
+    let (cpu_time_ns, rss_bytes) = win::process_stats(pid as u32)?;
+    Some(ProcessStats {
+        cpu_time_ns,
+        rss_bytes,
+    })
+}
+
 /// Sample CPU time and RSS for a process (stub on platforms without a
-/// supported implementation; e.g. Windows). Always returns `None`.
-#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+/// supported implementation). Always returns `None`.
+#[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
 pub fn process_stats(_pid: Pid) -> Option<ProcessStats> {
     None
 }
@@ -2565,6 +2623,32 @@ mod tests {
         assert!(
             drained,
             "registry should drain: real child reaped, bogus PID dropped on ECHILD"
+        );
+    }
+
+    /// `process_stats` must report live CPU/RSS for our own (alive) process on
+    /// every supported host — macOS, Linux, and Windows (where it previously
+    /// returned None). RSS is always > 0 for a running process; CPU time is
+    /// cumulative and may legitimately read 0 very early, so we only assert RSS.
+    #[cfg(any(target_os = "macos", target_os = "linux", windows))]
+    #[test]
+    fn process_stats_samples_self() {
+        let me = std::process::id() as Pid;
+        let stats = process_stats(me).expect("process_stats must sample the current process");
+        assert!(
+            stats.rss_bytes > 0,
+            "a live process must have non-zero RSS, got {}",
+            stats.rss_bytes
+        );
+    }
+
+    /// A PID that does not exist must yield None, not a bogus sample.
+    #[cfg(any(target_os = "macos", target_os = "linux", windows))]
+    #[test]
+    fn process_stats_dead_pid_is_none() {
+        assert!(
+            process_stats(i32::MAX as Pid).is_none(),
+            "stats for a non-existent PID must be None"
         );
     }
 }


### PR DESCRIPTION
Closing Windows-vs-Linux/macOS behavior gaps. Hardware-validated on real WHP.

**1. Per-process CPU/RSS (`src/process.rs`)** — `process_stats` was a `None` stub on Windows, so the machine info/metrics API reported no live CPU/memory. Implemented via `GetProcessTimes` + `GetProcessMemoryInfo`, matching the Linux `/proc` and macOS `proc_pidinfo` paths.

**2. Sparse disk-template copy (`src/disk_utils.rs`)** — `clone_or_copy_file` fell through to dense `std::fs::copy` on Windows, ballooning sparse templates to full logical size. Implemented a Windows sparse copy that replicates only the source's **allocated ranges** via `FSCTL_QUERY_ALLOCATED_RANGES` (the Win32 analogue of Linux `SEEK_HOLE`/`SEEK_DATA`). A naive scan-and-skip-zeros approach was tried first but over-copies a file held open by a running VM (it sees cached/mapped non-zero pages for nominal holes) — the allocated-ranges query avoids that and copies a few MB of a 20 GiB image.

Validated: `clippy --all-targets -D warnings` clean (Windows cross); unit tests pass on macOS **and real Windows/WHP hardware** (3/3, incl. a `GetCompressedFileSizeW` assertion that the clone stays sparse on NTFS, and the allocated-ranges copy proven on a real 20 GiB forkable-VM disk).

Remaining parity gaps (virtio-net, GPU, CoW `machine fork`) are tracked separately — they need libkrun/WHP backend work.