### PR TITLE
fix(serve): prevent runtime-heartbeat wedge from a stuck guest agent

### DIFF
--- a/src/api/handlers/node.rs
+++ b/src/api/handlers/node.rs
@@ -1,5 +1,7 @@
 //! Node-level introspection endpoints.
 
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
 use axum::{extract::State, Json};
 use std::sync::Arc;
 
@@ -18,10 +20,24 @@ use crate::api::types::CapacityResponse;
     path = "/capacity",
     tag = "Node",
     responses(
-        (status = 200, description = "Live node capacity", body = CapacityResponse)
+        (status = 200, description = "Live node capacity", body = CapacityResponse),
+        (status = 503, description = "Main runtime stalled — node is unschedulable")
     )
 )]
-pub async fn capacity(State(state): State<Arc<ApiState>>) -> Json<CapacityResponse> {
+pub async fn capacity(State(state): State<Arc<ApiState>>) -> Response {
+    // If the main runtime stopped heartbeating, the lifecycle path (boot/stop/
+    // exec) is wedged even though this loopback door — on its own runtime — can
+    // still answer. Report 503 so the node-agent's existing self-cordon drains
+    // this node instead of the control scheduling onto a black hole. The agent
+    // treats 503 like any poll failure and self-heals once heartbeats resume.
+    if state.runtime_stalled() {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "main runtime stalled; node unschedulable",
+        )
+            .into_response();
+    }
+
     let (allocated_cpus, allocated_memory_mb) = state.allocated_resources();
     let (used_cpus, used_memory_mb, used_disk_gb) = state.real_utilization();
 
@@ -32,6 +48,7 @@ pub async fn capacity(State(state): State<Arc<ApiState>>) -> Json<CapacityRespon
         used_memory_mb,
         used_disk_gb,
     })
+    .into_response()
 }
 
 #[cfg(test)]
@@ -39,18 +56,44 @@ mod tests {
     use super::*;
     use crate::db::SmolvmDb;
 
+    use axum::body::to_bytes;
+
     #[tokio::test]
     async fn capacity_reports_zero_on_an_idle_node() {
         let dir = tempfile::tempdir().unwrap();
         let db = SmolvmDb::open_at(&dir.path().join("test.db")).unwrap();
         let state = Arc::new(ApiState::with_db(db));
+        // A fresh state has heartbeat 0 == "now", so it is not yet stalled.
 
         // No running machines → nothing allocated and nothing in use.
-        let Json(cap) = capacity(State(state)).await;
-        assert_eq!(cap.allocated_cpus, 0);
-        assert_eq!(cap.allocated_memory_mb, 0);
-        assert_eq!(cap.used_cpus, 0.0);
-        assert_eq!(cap.used_memory_mb, 0);
-        assert_eq!(cap.used_disk_gb, 0);
+        let resp = capacity(State(state)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let cap: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(cap["allocated_cpus"], 0);
+        assert_eq!(cap["allocated_memory_mb"], 0);
+        assert_eq!(cap["used_cpus"], 0.0);
+        assert_eq!(cap["used_memory_mb"], 0);
+        assert_eq!(cap["used_disk_gb"], 0);
+    }
+
+    #[tokio::test]
+    async fn capacity_returns_503_when_runtime_heartbeat_is_stale() {
+        // Force an immediate stall window so the missing heartbeat counts as stalled.
+        std::env::set_var("SMOLVM_RUNTIME_STALE_SECS", "1");
+        let dir = tempfile::tempdir().unwrap();
+        let db = SmolvmDb::open_at(&dir.path().join("test.db")).unwrap();
+        let state = Arc::new(ApiState::with_db(db));
+
+        // Let the 1s stall window elapse with no supervisor heartbeat.
+        tokio::time::sleep(std::time::Duration::from_millis(1_100)).await;
+        let resp = capacity(State(state.clone())).await;
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        // A heartbeat clears the stall and capacity answers 200 again.
+        state.beat_runtime_heartbeat();
+        let resp = capacity(State(state)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        std::env::remove_var("SMOLVM_RUNTIME_STALE_SECS");
     }
 }

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -54,6 +54,19 @@ pub struct ApiState {
     /// Previous CPU samples per VM PID, used to compute the fractional-CPU
     /// rate as a delta over wall time. Pruned on each sample to drop dead PIDs.
     cpu_samples: parking_lot::Mutex<HashMap<i32, CpuSample>>,
+    /// Monotonic base for the runtime-liveness heartbeat. All heartbeat values
+    /// are millis elapsed since this instant, so they're a single lock-free
+    /// `AtomicU64` instead of a mutex-guarded `Instant`.
+    started_at: std::time::Instant,
+    /// Milliseconds (since `started_at`) of the supervisor's last tick. The
+    /// supervisor bumps this every `CHECK_INTERVAL` from the main runtime, so a
+    /// stale value means the main runtime's timer wheel stopped being driven
+    /// (a reactor stall) or the supervisor task itself wedged. The loopback
+    /// `/capacity` listener — which runs on its OWN runtime and so keeps
+    /// answering even when the main runtime is stuck — reads this to report the
+    /// node as unschedulable (HTTP 503) the moment the main runtime stops
+    /// making progress, turning a silent wedge into a fast, honest drain signal.
+    runtime_heartbeat_ms: std::sync::atomic::AtomicU64,
 }
 
 /// Internal machine entry with manager and configuration.
@@ -191,6 +204,8 @@ impl ApiState {
             lifecycle_locks: RwLock::new(HashMap::new()),
             db,
             cpu_samples: parking_lot::Mutex::new(HashMap::new()),
+            started_at: std::time::Instant::now(),
+            runtime_heartbeat_ms: std::sync::atomic::AtomicU64::new(0),
         })
     }
 
@@ -204,7 +219,48 @@ impl ApiState {
             lifecycle_locks: RwLock::new(HashMap::new()),
             db,
             cpu_samples: parking_lot::Mutex::new(HashMap::new()),
+            started_at: std::time::Instant::now(),
+            runtime_heartbeat_ms: std::sync::atomic::AtomicU64::new(0),
         }
+    }
+
+    /// How long the main runtime may go without a supervisor heartbeat before
+    /// the loopback `/capacity` door reports the node as stalled. Defaults to
+    /// 4× the supervisor's 5s tick (`SMOLVM_RUNTIME_STALE_SECS` overrides), so
+    /// a few slow ticks never flap the node but a genuine reactor wedge drains
+    /// it within ~20s + the node-agent's own cordon grace.
+    fn runtime_stale_after_ms() -> u64 {
+        std::env::var("SMOLVM_RUNTIME_STALE_SECS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .filter(|&s| s > 0)
+            .map(|s| s * 1000)
+            .unwrap_or(20_000)
+    }
+
+    /// Record that the main runtime is making progress. Called from the
+    /// supervisor's tick — a value only advances if the runtime's timer wheel
+    /// fired the tick, so it is a true liveness signal for the main reactor.
+    pub fn beat_runtime_heartbeat(&self) {
+        let elapsed = self.started_at.elapsed().as_millis() as u64;
+        self.runtime_heartbeat_ms
+            .store(elapsed, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Whether the main runtime has gone too long without a heartbeat — i.e. the
+    /// supervisor tick stopped firing, which on a multi-thread runtime means the
+    /// IO/timer driver is no longer being driven. Read from the loopback door's
+    /// dedicated runtime so it stays accurate even when the main runtime is
+    /// wedged. The window before the first heartbeat is treated as healthy
+    /// (startup), since `elapsed - 0 = elapsed` only crosses the threshold once
+    /// the runtime has actually been up longer than the stall window without a
+    /// single supervisor tick — which is itself a real stall.
+    pub fn runtime_stalled(&self) -> bool {
+        let now = self.started_at.elapsed().as_millis() as u64;
+        let last = self
+            .runtime_heartbeat_ms
+            .load(std::sync::atomic::Ordering::Relaxed);
+        now.saturating_sub(last) > Self::runtime_stale_after_ms()
     }
 
     /// Load existing machines from persistent database.

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -933,8 +933,17 @@ impl ApiState {
     /// reuse, and covers orphan processes not tracked in-memory.
     pub fn is_machine_alive(&self, name: &str) -> bool {
         if let Some(entry) = self.machines.read().get(name) {
-            let entry = entry.lock();
-            entry.manager.is_process_alive()
+            // This runs on the supervisor's heartbeat path, so it must never
+            // block. A `MachineEntry` whose lock is currently held is, by
+            // definition, actively in use (mid agent I/O) — i.e. alive — so we
+            // treat lock contention as "alive" rather than parking the
+            // supervisor on it. Blocking here behind a single busy/stuck
+            // machine would stall the runtime heartbeat and mark the entire
+            // node unschedulable.
+            match entry.try_lock() {
+                Some(entry) => entry.manager.is_process_alive(),
+                None => true,
+            }
         } else {
             false
         }
@@ -956,11 +965,22 @@ where
 {
     let entry_clone = entry.clone();
     tokio::task::spawn_blocking(move || {
-        let entry = entry_clone.lock();
-        let mut client = entry.manager.connect()?;
-        if let Some(tid) = trace_id {
-            client.set_trace_id(tid);
-        }
+        // Acquire a connected client under the per-machine lock, then RELEASE
+        // the lock before running the (potentially long, unbounded-blocking)
+        // agent operation. `connect()` returns an owned `AgentClient` over its
+        // own socket, so `op` needs no lock once connected. Holding the
+        // `MachineEntry` lock across blocking agent I/O lets a hung guest agent
+        // pin the lock indefinitely, which blocks the supervisor's liveness
+        // probe (`is_machine_alive`) and stalls the whole runtime heartbeat —
+        // marking the node unschedulable behind a single stuck exec.
+        let mut client = {
+            let entry = entry_clone.lock();
+            let mut client = entry.manager.connect()?;
+            if let Some(tid) = trace_id {
+                client.set_trace_id(tid);
+            }
+            client
+        };
         op(&mut client)
     })
     .await?
@@ -1372,6 +1392,65 @@ mod tests {
             state.remove_machine("remove-test-m1"),
             Err(ApiError::NotFound(_))
         ));
+    }
+
+    // REGRESSION (runtime-wedge): the supervisor's liveness probe must NEVER
+    // block on the per-machine `MachineEntry` lock. A machine that is mid
+    // agent-I/O (e.g. a stuck exec) holds that lock; if `is_machine_alive`
+    // blocked on it, one wedged machine would stall the supervisor heartbeat
+    // and mark the whole node unschedulable (the 503/black-hole wedge observed
+    // under concurrent boots). With the entry lock held, `is_machine_alive`
+    // must return promptly, reporting the in-use machine as alive.
+    #[test]
+    fn is_machine_alive_does_not_block_when_entry_locked() {
+        use std::time::Duration;
+
+        let (_dir, state) = temp_api_state();
+        let record = VmRecord::new("busy-m1".into(), 1, 512, vec![], vec![], false);
+        state.db.insert_vm("busy-m1", &record).unwrap();
+        let manager = AgentManager::for_vm("busy-m1").unwrap();
+        state.insert_machine(
+            "busy-m1",
+            MachineEntry {
+                manager,
+                mounts: vec![],
+                ports: vec![],
+                resources: ResourceSpec {
+                    cpus: None,
+                    memory_mb: None,
+                    network: None,
+                    gpu: None,
+                    storage_gb: None,
+                    overlay_gb: None,
+                    allowed_cidrs: None,
+                    network_backend: None,
+                },
+                restart: RestartConfig::default(),
+                network: false,
+                secret_refs: Default::default(),
+                source_smolmachine: None,
+            },
+        );
+
+        // Hold the entry lock to simulate an in-flight agent op pinning it.
+        let entry = state.get_machine("busy-m1").unwrap();
+        let held = entry.lock();
+
+        // The probe must finish without waiting on the held lock. If it blocked,
+        // the scoped thread would still be running after the grace period.
+        std::thread::scope(|s| {
+            let h = s.spawn(|| state.is_machine_alive("busy-m1"));
+            std::thread::sleep(Duration::from_millis(200));
+            assert!(
+                h.is_finished(),
+                "is_machine_alive blocked on a held MachineEntry lock — would stall the supervisor"
+            );
+            assert!(
+                h.join().unwrap(),
+                "a locked (actively in-use) machine must read as alive"
+            );
+        });
+        drop(held);
     }
 
     // ========================================================================

--- a/src/api/supervisor.rs
+++ b/src/api/supervisor.rs
@@ -64,6 +64,12 @@ impl Supervisor {
         loop {
             tokio::select! {
                 _ = ticker.tick() => {
+                    // The tick firing proves the main runtime's timer wheel is
+                    // still being driven — record it so the loopback `/capacity`
+                    // door (on its own runtime) can report the node stalled if
+                    // these ever stop. Bump BEFORE the work below so a slow
+                    // health check doesn't itself register as a stall.
+                    self.state.beat_runtime_heartbeat();
                     // Reap exited VM boot subprocesses (selective, per registered
                     // PID) BEFORE the health check, so a just-crashed VM's zombie
                     // is gone and `is_alive` reports it crashed this same tick.

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -364,20 +364,54 @@ impl ServeStartCmd {
                     format!("SMOLVM_SERVE_LOCAL_ADDR {local_addr} must be loopback"),
                 ));
             }
-            let local_listener = tokio::net::TcpListener::bind(local_addr)
-                .await
+            // Bind synchronously, then hand the std listener to a DEDICATED
+            // single-thread runtime on its own OS thread. The loopback door's
+            // whole job is liveness (`/capacity`), and it must keep answering
+            // even when the main multi-thread runtime's reactor stalls under
+            // load — which is exactly when the node-agent most needs a truthful
+            // answer. Sharing the main runtime lets a stall silently wedge the
+            // accept loop (a TCP timeout the agent can't distinguish from a dead
+            // node); an isolated reactor turns that into a fast `503` driven by
+            // the runtime-liveness heartbeat (see `ApiState::runtime_stalled`).
+            let std_listener =
+                std::net::TcpListener::bind(local_addr).map_err(smolvm::error::Error::Io)?;
+            std_listener
+                .set_nonblocking(true)
                 .map_err(smolvm::error::Error::Io)?;
             let local_app = app.clone();
-            tracing::info!(address = %local_addr, "starting loopback HTTP door (local node-agent)");
+            tracing::info!(address = %local_addr, "starting loopback HTTP door (local node-agent, isolated runtime)");
             println!(
                 "smolvm local API (loopback, plain) on http://{}",
                 local_addr
             );
-            tokio::spawn(async move {
-                let _ = axum::serve(local_listener, local_app)
-                    .with_graceful_shutdown(shutdown_signal())
-                    .await;
-            });
+            std::thread::Builder::new()
+                .name("smolvm-loopback-api".to_string())
+                .spawn(move || {
+                    let rt = match tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                    {
+                        Ok(rt) => rt,
+                        Err(e) => {
+                            tracing::error!(error = %e, "loopback door runtime failed to build");
+                            return;
+                        }
+                    };
+                    rt.block_on(async move {
+                        // Register the listener with THIS runtime's reactor.
+                        let listener = match tokio::net::TcpListener::from_std(std_listener) {
+                            Ok(l) => l,
+                            Err(e) => {
+                                tracing::error!(error = %e, "loopback door listener registration failed");
+                                return;
+                            }
+                        };
+                        let _ = axum::serve(listener, local_app)
+                            .with_graceful_shutdown(shutdown_signal())
+                            .await;
+                    });
+                })
+                .map_err(smolvm::error::Error::Io)?;
         }
 
         let rustls_config = axum_server::tls_rustls::RustlsConfig::from_config(tls_config);


### PR DESCRIPTION
Releases the per-machine lock before blocking agent I/O and treats lock contention as alive on the liveness path, so a single hung guest agent can no longer stall the runtime heartbeat and black-hole the node's /capacity; adds a 503 self-cordon on the loopback door as a safety net.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/478">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->