### PR TITLE
Add secure native display support for graphical guests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.13.0",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex 1.3.0",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,7 +330,16 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -326,6 +353,27 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
@@ -398,6 +446,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -520,6 +577,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "des"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +632,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "enumflags2"
@@ -622,6 +694,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,6 +724,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
+ "crc32fast",
  "miniz_oxide",
  "zlib-rs",
 ]
@@ -821,6 +903,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
@@ -1145,6 +1233,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1155,6 +1252,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1181,6 +1287,38 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "krun_display"
+version = "0.1.0"
+dependencies = [
+ "bindgen",
+ "bitflags 2.13.0",
+ "log",
+ "static_assertions",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "krun_input"
+version = "0.1.0"
+dependencies = [
+ "bindgen",
+ "bitflags 2.13.0",
+ "libc",
+ "log",
+ "static_assertions",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "kvm-bindings"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a537873e15e8daabb416667e606d9b0abc2a8fb9a45bd5853b888ae0ead82f9"
+dependencies = [
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -1211,6 +1349,16 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "libredox"
@@ -1336,7 +1484,7 @@ dependencies = [
  "hashbrown 0.15.5",
  "metrics",
  "quanta",
- "rand",
+ "rand 0.9.4",
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
@@ -1356,6 +1504,12 @@ dependencies = [
  "mime",
  "unicase",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1388,6 +1542,28 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1479,6 +1655,19 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -1595,7 +1784,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1644,12 +1833,33 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1659,7 +1869,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1677,7 +1896,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1786,6 +2005,17 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "rfb-encodings"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8256cc2cc1352ecdad7954cf053ae8c619067fe36b32ca4f3095a9079eaab0c0"
+dependencies = [
+ "bytes",
+ "flate2",
+ "png",
 ]
 
 [[package]]
@@ -1920,6 +2150,20 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustvncserver"
+version = "2.2.1"
+dependencies = [
+ "bytes",
+ "des",
+ "flate2",
+ "log",
+ "rand 0.8.6",
+ "rfb-encodings",
+ "thiserror 1.0.69",
+ "tokio",
+]
 
 [[package]]
 name = "ryu"
@@ -2078,6 +2322,12 @@ dependencies = [
 
 [[package]]
 name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
@@ -2151,22 +2401,27 @@ dependencies = [
  "axum-server",
  "base64",
  "clap",
+ "crossbeam-channel",
  "dirs",
  "futures-util",
  "hex",
  "humantime",
  "ipnet",
+ "krun_display",
+ "krun_input",
  "landlock",
  "libc",
  "metrics",
  "metrics-exporter-prometheus",
  "parking_lot",
  "pkg-config",
+ "rand 0.8.6",
  "regex",
  "rusqlite",
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
+ "rustvncserver",
  "seccompiler",
  "serde",
  "serde_json",
@@ -2185,6 +2440,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "utils",
  "utoipa",
  "utoipa-axum",
  "utoipa-swagger-ui",
@@ -2197,7 +2453,7 @@ version = "1.2.4"
 dependencies = [
  "lazy_static",
  "libc",
- "nix",
+ "nix 0.27.1",
  "parking_lot",
  "serde",
  "serde_json",
@@ -2285,6 +2541,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -2713,7 +2975,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.9.4",
  "sha1",
  "thiserror 2.0.18",
 ]
@@ -2777,6 +3039,19 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utils"
+version = "0.1.0"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossbeam-channel",
+ "kvm-bindings",
+ "libc",
+ "log",
+ "nix 0.30.1",
+ "vmm-sys-util",
+]
 
 [[package]]
 name = "utoipa"
@@ -2857,6 +3132,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vmm-sys-util"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d21f366bf22bfba3e868349978766a965cbe628c323d58e026be80b8357ab789"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,12 @@ tokio-stream = "0.1"
 parking_lot = "0.12"
 async-stream = "0.3"
 futures-util = "0.3"
+crossbeam-channel = "0.5"
+rand = "0.8"
+rustvncserver = { path = "../rustvncserver" }
+krun_display = { path = "libkrun/src/krun_display", features = ["bindgen_clang_runtime"] }
+krun_input = { path = "libkrun/src/krun_input", features = ["bindgen_clang_runtime"] }
+krun_utils = { package = "utils", path = "libkrun/src/utils" }
 
 # OpenAPI documentation
 utoipa = { version = "5", features = ["axum_extras"] }

--- a/Licenses.md
+++ b/Licenses.md
@@ -4,9 +4,9 @@ smolvm bundles the following third-party libraries in the `lib/` directory.
 
 ## libkrun
 
-- **Version:** 1.15.1
+- **Version:** 1.17.3, local display fork commit `4e523339b3c05bf4edf957ffa2bca34f18d3c726`
 - **License:** Apache License 2.0
-- **Source:** https://github.com/containers/libkrun
+- **Source:** https://github.com/smol-machines/libkrun
 - **Copyright:** The libkrun Authors
 
 Licensed under the Apache License, Version 2.0. You may obtain a copy of the License at:
@@ -14,9 +14,9 @@ http://www.apache.org/licenses/LICENSE-2.0
 
 ## libkrunfw
 
-- **Version:** 4.x
+- **Version:** 5.4.0, local input-enabled fork commit `25b9d8d12122d6b361015d477bf18ee91238c0c8`
 - **License:** LGPL-2.1-only (library), GPL-2.0-only (bundled Linux kernel)
-- **Source:** https://github.com/containers/libkrunfw
+- **Source:** https://github.com/smol-machines/libkrunfw
 - **Copyright:** The libkrunfw Authors
 
 libkrunfw is a library that bundles the Linux kernel for use with libkrun.
@@ -25,8 +25,8 @@ libkrunfw is a library that bundles the Linux kernel for use with libkrun.
 
 In compliance with LGPL-2.1 and GPL-2.0, the complete source code for libkrunfw and the bundled Linux kernel is available at:
 
-- **libkrunfw:** https://github.com/containers/libkrunfw
-- **Linux kernel (with patches):** https://github.com/containers/libkrunfw/tree/main/patches
+- **libkrunfw:** https://github.com/smol-machines/libkrunfw
+- **Linux kernel (with patches):** https://github.com/smol-machines/libkrunfw/tree/main/patches
 
 To obtain the exact source code corresponding to the bundled binary, check out the version tag matching the library version from the repository above.
 
@@ -38,3 +38,12 @@ You have the right to:
 - Reverse engineer the library for debugging purposes
 
 If you distribute a modified version of libkrunfw, you must make your modifications available under the same license.
+
+## rustvncserver
+
+- **Version:** 2.2.1, local listener fork commit `5d339c9daf74519e1f4ae6a75a84fbfff70e143e`
+- **License:** Apache License 2.0
+- **Source:** https://github.com/cap12312/rustvncserver
+
+The local fork adds explicit loopback-address and prebound-listener APIs. See
+`docs/native-display.md` for the source-distribution boundary.

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -8,9 +8,11 @@
 //!
 //! Communication is via vsock on port 6000.
 
+#[cfg(target_os = "linux")]
+use smolvm_protocol::guest_env;
 use smolvm_protocol::{
-    error_codes, guest_env, ports, AgentRequest, AgentResponse, Envelope, RegistryAuth,
-    AGENT_READY_MARKER, LAYER_CHUNK_SIZE, PROTOCOL_VERSION,
+    error_codes, ports, AgentRequest, AgentResponse, Envelope, RegistryAuth, AGENT_READY_MARKER,
+    LAYER_CHUNK_SIZE, PROTOCOL_VERSION,
 };
 use std::io::{Read, Write};
 use std::os::unix::io::AsRawFd;
@@ -168,6 +170,7 @@ fn main() {
     #[cfg(target_os = "linux")]
     if std::env::var(guest_env::GPU).as_deref() == Ok(guest_env::VALUE_ON) {
         setup_gpu_dev_nodes();
+        setup_input_dev_nodes();
     }
 
     // Set up persistent rootfs overlay (if /dev/vdb exists).
@@ -185,6 +188,7 @@ fn main() {
     // "No backend was able to open a seat."
     #[cfg(target_os = "linux")]
     if std::env::var(guest_env::GPU).as_deref() == Ok(guest_env::VALUE_ON) {
+        setup_input_udev_metadata();
         start_seatd();
     }
 
@@ -648,6 +652,177 @@ fn setup_gpu_dev_nodes() {
     }
 }
 
+/// Create `/dev/input/event*` nodes for the host-provided virtio input devices.
+///
+/// The initramfs uses a plain tmpfs for `/dev`, so devtmpfs does not populate
+/// the keyboard and pointer nodes even though the kernel registered them in
+/// sysfs. Graphical containers need the real nodes for libinput/evdev.
+#[cfg(target_os = "linux")]
+fn setup_input_dev_nodes() {
+    let sysfs_input = std::path::Path::new("/sys/class/input");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
+    let events = loop {
+        let events: Vec<_> = std::fs::read_dir(sysfs_input)
+            .map(|entries| {
+                entries
+                    .flatten()
+                    .filter(|entry| entry.file_name().to_string_lossy().starts_with("event"))
+                    .collect()
+            })
+            .unwrap_or_default();
+        if !events.is_empty() || std::time::Instant::now() >= deadline {
+            break events;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    };
+    if events.is_empty() {
+        return;
+    }
+
+    let _ = std::fs::create_dir_all("/dev/input");
+    for entry in events {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        let Ok(device) = std::fs::read_to_string(entry.path().join("dev")) else {
+            continue;
+        };
+        let Some((major, minor)) = parse_device_number(&device) else {
+            continue;
+        };
+        let Ok(path) = std::ffi::CString::new(format!("/dev/input/{name}")) else {
+            continue;
+        };
+        unsafe {
+            libc::mknod(
+                path.as_ptr(),
+                libc::S_IFCHR | 0o666,
+                libc::makedev(major, minor),
+            );
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", test))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InputDeviceKind {
+    Keyboard,
+    Pointer,
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn input_capability_enabled(capabilities: &str, event_type: u32) -> bool {
+    let word_index = (event_type / 64) as usize;
+    let bit_index = event_type % 64;
+    capabilities
+        .split_whitespace()
+        .rev()
+        .nth(word_index)
+        .and_then(|word| u64::from_str_radix(word, 16).ok())
+        .is_some_and(|word| word & (1_u64 << bit_index) != 0)
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn classify_input_device(name: &str, event_capabilities: &str) -> Option<InputDeviceKind> {
+    let name = name.to_ascii_lowercase();
+    if name.contains("keyboard") {
+        return Some(InputDeviceKind::Keyboard);
+    }
+    if ["mouse", "pointer", "touchpad", "tablet"]
+        .iter()
+        .any(|kind| name.contains(kind))
+    {
+        return Some(InputDeviceKind::Pointer);
+    }
+
+    // EV_REL (2) and EV_ABS (3) identify pointer-like devices. Check them
+    // before EV_KEY (1), because mice also advertise EV_KEY for buttons.
+    if input_capability_enabled(event_capabilities, 2)
+        || input_capability_enabled(event_capabilities, 3)
+    {
+        Some(InputDeviceKind::Pointer)
+    } else if input_capability_enabled(event_capabilities, 1) {
+        Some(InputDeviceKind::Keyboard)
+    } else {
+        None
+    }
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn input_udev_metadata(kind: InputDeviceKind) -> &'static str {
+    match kind {
+        InputDeviceKind::Keyboard => {
+            "E:ID_INPUT=1\nE:ID_INPUT_KEY=1\nE:ID_INPUT_KEYBOARD=1\nE:ID_SEAT=seat0\nG:seat\nQ:seat\nV:1\n"
+        }
+        InputDeviceKind::Pointer => {
+            "E:ID_INPUT=1\nE:ID_INPUT_MOUSE=1\nE:ID_SEAT=seat0\nG:seat\nQ:seat\nV:1\n"
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn parse_device_number(device: &str) -> Option<(u32, u32)> {
+    let (major, minor) = device.trim().split_once(':')?;
+    Some((major.parse().ok()?, minor.parse().ok()?))
+}
+
+/// Populate the minimal udev database records libinput uses for seat discovery.
+///
+/// The guest does not run systemd-udevd, so the normal `input_id` builtin never
+/// tags the virtio keyboard and pointer. Weston can open the event nodes only
+/// after their `ID_INPUT_*` and `seat` properties exist under `/run/udev/data`.
+/// This runs after `pivot_root`, ensuring the records live in the active root
+/// and can be bind-mounted into graphical OCI workloads.
+#[cfg(target_os = "linux")]
+fn setup_input_udev_metadata() {
+    let sysfs_input = std::path::Path::new("/sys/class/input");
+    let Ok(entries) = std::fs::read_dir(sysfs_input) else {
+        return;
+    };
+    let data_dir = std::path::Path::new("/run/udev/data");
+    if let Err(error) = std::fs::create_dir_all(data_dir) {
+        boot_log(
+            "WARN",
+            &format!("failed to create {}: {error}", data_dir.display()),
+        );
+        return;
+    }
+
+    let mut records_written = 0_u32;
+    for entry in entries
+        .flatten()
+        .filter(|entry| entry.file_name().to_string_lossy().starts_with("event"))
+    {
+        let device_dir = entry.path().join("device");
+        let Ok(device) = std::fs::read_to_string(entry.path().join("dev")) else {
+            continue;
+        };
+        let Some((major, minor)) = parse_device_number(&device) else {
+            continue;
+        };
+        let name = std::fs::read_to_string(device_dir.join("name")).unwrap_or_default();
+        let capabilities =
+            std::fs::read_to_string(device_dir.join("capabilities/ev")).unwrap_or_default();
+        let Some(kind) = classify_input_device(name.trim(), capabilities.trim()) else {
+            continue;
+        };
+        let record_path = data_dir.join(format!("c{major}:{minor}"));
+        match std::fs::write(&record_path, input_udev_metadata(kind)) {
+            Ok(()) => records_written += 1,
+            Err(error) => boot_log(
+                "WARN",
+                &format!("failed to write {}: {error}", record_path.display()),
+            ),
+        }
+    }
+
+    if records_written > 0 {
+        boot_log(
+            "INFO",
+            &format!("installed {records_written} input udev metadata record(s)"),
+        );
+    }
+}
+
 /// Start the seatd seat manager daemon.
 ///
 /// seatd provides the seat management API that Wayland compositors (Weston, sway)
@@ -682,6 +857,12 @@ fn start_seatd() {
     {
         Ok(child) => {
             boot_log("INFO", &format!("seatd started (PID {})", child.id()));
+            let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
+            while !std::path::Path::new("/run/seatd.sock").exists()
+                && std::time::Instant::now() < deadline
+            {
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
             // Detach — seatd runs for the lifetime of the VM
             std::mem::forget(child);
         }
@@ -5234,6 +5415,50 @@ mod bg_reap_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn input_device_classification_prefers_pointer_axes_over_button_keys() {
+        assert_eq!(
+            classify_input_device("unknown virtio device", "b"),
+            Some(InputDeviceKind::Pointer)
+        );
+    }
+
+    #[test]
+    fn input_device_classification_uses_device_identity() {
+        assert_eq!(
+            classify_input_device("SmolVM Virtual Keyboard", "0"),
+            Some(InputDeviceKind::Keyboard)
+        );
+        assert_eq!(
+            classify_input_device("SmolVM Absolute Pointer", "0"),
+            Some(InputDeviceKind::Pointer)
+        );
+    }
+
+    #[test]
+    fn input_device_classification_ignores_non_input_event_sources() {
+        assert_eq!(classify_input_device("Power Button", "1"), None);
+    }
+
+    #[test]
+    fn input_udev_metadata_matches_libinput_contract() {
+        assert_eq!(
+            input_udev_metadata(InputDeviceKind::Keyboard),
+            "E:ID_INPUT=1\nE:ID_INPUT_KEY=1\nE:ID_INPUT_KEYBOARD=1\nE:ID_SEAT=seat0\nG:seat\nQ:seat\nV:1\n"
+        );
+        assert_eq!(
+            input_udev_metadata(InputDeviceKind::Pointer),
+            "E:ID_INPUT=1\nE:ID_INPUT_MOUSE=1\nE:ID_SEAT=seat0\nG:seat\nQ:seat\nV:1\n"
+        );
+    }
+
+    #[test]
+    fn parse_device_number_rejects_malformed_sysfs_values() {
+        assert_eq!(parse_device_number("13:64\n"), Some((13, 64)));
+        assert_eq!(parse_device_number("13"), None);
+        assert_eq!(parse_device_number("input:keyboard"), None);
+    }
 
     #[test]
     #[cfg(unix)]

--- a/crates/smolvm-agent/src/oci.rs
+++ b/crates/smolvm-agent/src/oci.rs
@@ -125,6 +125,25 @@ struct ResolvedUser {
     home: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+struct GraphicsDeviceAvailability {
+    dri: bool,
+    input: bool,
+    seatd: bool,
+    udev_data: bool,
+}
+
+impl GraphicsDeviceAvailability {
+    fn detect() -> Self {
+        Self {
+            dri: Path::new("/dev/dri").exists(),
+            input: Path::new("/dev/input").exists(),
+            seatd: Path::new("/run/seatd.sock").exists(),
+            udev_data: Path::new("/run/udev/data").exists(),
+        }
+    }
+}
+
 pub fn resolve_process_identity(
     rootfs: &Path,
     user_spec: Option<&str>,
@@ -598,29 +617,60 @@ impl OciSpec {
     /// special configuration — if the VM was started with `--gpu`, the devices
     /// appear automatically inside every container.
     pub fn add_gpu_devices_if_available(&mut self) {
-        if self.mounts.iter().any(|m| m.destination == "/dev/dri") {
-            return;
+        self.add_graphics_devices(GraphicsDeviceAvailability::detect());
+    }
+
+    fn add_graphics_devices(&mut self, available: GraphicsDeviceAvailability) {
+        if available.dri && !self.mounts.iter().any(|m| m.destination == "/dev/dri") {
+            self.mounts.push(OciMount {
+                destination: "/dev/dri".to_string(),
+                mount_type: Some("bind".to_string()),
+                source: "/dev/dri".to_string(),
+                options: vec!["bind".to_string(), "rprivate".to_string()],
+            });
         }
 
-        let dri_path = std::path::Path::new("/dev/dri");
-        if !dri_path.exists() {
-            return;
+        if available.input && !self.mounts.iter().any(|m| m.destination == "/dev/input") {
+            self.mounts.push(OciMount {
+                destination: "/dev/input".to_string(),
+                mount_type: Some("bind".to_string()),
+                source: "/dev/input".to_string(),
+                options: vec!["bind".to_string(), "rprivate".to_string()],
+            });
         }
 
-        // Bind-mount /dev/dri from the VM's devtmpfs into the container.
-        //
-        // A bind mount is used rather than linux.devices entries because crun
-        // sets up a fresh tmpfs at /dev; the /dev/dri sub-directory does not
-        // exist in that tmpfs, so mknod silently fails for any device node
-        // whose parent directory is missing.  A bind mount is equivalent to
-        // `--device /dev/dri` in Docker/Podman, and crun creates the
-        // destination directory automatically when it does not yet exist.
-        self.mounts.push(OciMount {
-            destination: "/dev/dri".to_string(),
-            mount_type: Some("bind".to_string()),
-            source: "/dev/dri".to_string(),
-            options: vec!["bind".to_string(), "rprivate".to_string()],
-        });
+        // libinput reads udev's runtime database to discover ID_INPUT_* and
+        // seat tags. The agent synthesizes those records for the virtio input
+        // devices because this minimal guest does not run systemd-udevd.
+        if available.input
+            && available.udev_data
+            && !self.mounts.iter().any(|m| m.destination == "/run/udev")
+        {
+            self.mounts.push(OciMount {
+                destination: "/run/udev".to_string(),
+                mount_type: Some("bind".to_string()),
+                source: "/run/udev".to_string(),
+                options: vec!["bind".to_string(), "ro".to_string(), "rprivate".to_string()],
+            });
+        }
+
+        if available.seatd
+            && !self
+                .mounts
+                .iter()
+                .any(|m| m.destination == "/run/seatd.sock")
+        {
+            self.mounts.push(OciMount {
+                destination: "/run/seatd.sock".to_string(),
+                mount_type: Some("bind".to_string()),
+                source: "/run/seatd.sock".to_string(),
+                options: vec!["bind".to_string()],
+            });
+        }
+        if available.seatd {
+            self.add_env("LIBSEAT_BACKEND", "seatd");
+            self.add_env("SEATD_SOCK", "/run/seatd.sock");
+        }
     }
 
     /// Write the OCI spec to a config.json file in the bundle directory.
@@ -952,6 +1002,34 @@ fn default_devices() -> Vec<OciDevice> {
             major: 5,
             minor: 0,
             file_mode: Some(0o666),
+            uid: Some(0),
+            gid: Some(0),
+        },
+        // Linux virtual terminals used by direct DRM compositors.
+        OciDevice {
+            device_type: "c".to_string(),
+            path: "/dev/tty0".to_string(),
+            major: 4,
+            minor: 0,
+            file_mode: Some(0o666),
+            uid: Some(0),
+            gid: Some(0),
+        },
+        OciDevice {
+            device_type: "c".to_string(),
+            path: "/dev/tty1".to_string(),
+            major: 4,
+            minor: 1,
+            file_mode: Some(0o666),
+            uid: Some(0),
+            gid: Some(0),
+        },
+        OciDevice {
+            device_type: "c".to_string(),
+            path: "/dev/console".to_string(),
+            major: 5,
+            minor: 1,
+            file_mode: Some(0o600),
             uid: Some(0),
             gid: Some(0),
         },
@@ -1350,6 +1428,92 @@ mod tests {
         // Values just under limit should pass
         let ok_value = "x".repeat(32 * 1024);
         assert!(validate_env_vars(&[("KEY".to_string(), ok_value)]).is_ok());
+    }
+
+    #[test]
+    fn graphics_devices_add_input_metadata_as_read_only() {
+        let identity = ProcessIdentity::root();
+        let mut spec = OciSpec::new(&["echo".to_string()], &[], "/", false, &identity, false);
+
+        spec.add_graphics_devices(GraphicsDeviceAvailability {
+            dri: true,
+            input: true,
+            seatd: true,
+            udev_data: true,
+        });
+
+        let udev = spec
+            .mounts
+            .iter()
+            .find(|mount| mount.destination == "/run/udev")
+            .expect("udev metadata mount");
+        assert_eq!(udev.source, "/run/udev");
+        assert!(udev.options.contains(&"ro".to_string()));
+        assert!(spec
+            .mounts
+            .iter()
+            .any(|mount| mount.destination == "/dev/input"));
+        assert!(spec
+            .process
+            .env
+            .contains(&"LIBSEAT_BACKEND=seatd".to_string()));
+        assert!(spec
+            .process
+            .env
+            .contains(&"SEATD_SOCK=/run/seatd.sock".to_string()));
+    }
+
+    #[test]
+    fn graphics_devices_do_not_expose_udev_without_input_devices() {
+        let identity = ProcessIdentity::root();
+        let mut spec = OciSpec::new(&["echo".to_string()], &[], "/", false, &identity, false);
+
+        spec.add_graphics_devices(GraphicsDeviceAvailability {
+            udev_data: true,
+            ..GraphicsDeviceAvailability::default()
+        });
+
+        assert!(!spec
+            .mounts
+            .iter()
+            .any(|mount| mount.destination == "/run/udev"));
+    }
+
+    #[test]
+    fn graphics_device_mounts_and_environment_are_idempotent() {
+        let identity = ProcessIdentity::root();
+        let mut spec = OciSpec::new(&["echo".to_string()], &[], "/", false, &identity, false);
+        let available = GraphicsDeviceAvailability {
+            dri: true,
+            input: true,
+            seatd: true,
+            udev_data: true,
+        };
+
+        spec.add_graphics_devices(available);
+        spec.add_graphics_devices(available);
+
+        for destination in ["/dev/dri", "/dev/input", "/run/udev", "/run/seatd.sock"] {
+            assert_eq!(
+                spec.mounts
+                    .iter()
+                    .filter(|mount| mount.destination == destination)
+                    .count(),
+                1,
+                "duplicate mount for {destination}"
+            );
+        }
+        for variable in ["LIBSEAT_BACKEND=", "SEATD_SOCK="] {
+            assert_eq!(
+                spec.process
+                    .env
+                    .iter()
+                    .filter(|entry| entry.starts_with(variable))
+                    .count(),
+                1,
+                "duplicate environment variable for {variable}"
+            );
+        }
     }
 
     #[test]

--- a/docs/native-display.md
+++ b/docs/native-display.md
@@ -1,0 +1,207 @@
+# Native display helper
+
+Last verified: 2026-06-25
+
+This fork adds an opt-in native graphical console to SmolVM 1.2.4 without
+changing the lifecycle of machines started by the stock CLI.
+
+```text
+smolvm machine start --name NAME --display
+smolvm machine display --name NAME --json
+```
+
+Display must be selected before the VMM enters `krun_start_enter`; it cannot be
+attached to an already-running libkrun context. A machine already running
+without display must be stopped before it is restarted with `--display`.
+
+## Persistent Debian/Weston profile
+
+The repository includes a restart-safe graphical fixture at
+`examples/weston-desktop/weston.smolfile`:
+
+```bash
+smolvm machine create --name debian-gui \
+  -s examples/weston-desktop/weston.smolfile
+smolvm machine start --name debian-gui --display
+```
+
+The first start installs Weston, Xwayland, DBus, fonts, icons, and udev into the
+machine's persistent OCI overlay. The stored entrypoint then launches Weston as
+the machine workload. Later stop/start cycles do not require package
+installation or a manual compositor command:
+
+```bash
+smolvm machine stop --name debian-gui
+smolvm machine start --name debian-gui --display
+```
+
+`--display` remains a per-launch requirement because the framebuffer and input
+devices must be configured before libkrun starts. The Smolfile persists the
+guest workload; it does not make the host display bridge attachable at runtime.
+Weston writes its persistent diagnostic log to `/var/log/weston.log`.
+
+## Transport contract
+
+- The VMM process owns the framebuffer and input bridge for exactly one VM
+  launch.
+- libkrun provides a bounded, damage-aware framebuffer callback and virtual
+  keyboard plus absolute-pointer devices.
+- `rustvncserver` exposes the framebuffer as password-protected RFB on an
+  ephemeral `127.0.0.1` port.
+- A per-launch eight-character credential is returned only over
+  `<machine>/display-runtime/endpoint.sock`.
+- The runtime directory is mode `0700`, the Unix socket is mode `0600`, and the
+  server verifies that the connecting process has the same effective UID.
+- `machine ls --json` publishes only `display_ready: true|false`; it never
+  publishes the port or credential.
+- Endpoint JSON is limited to 4096 bytes and accepts only the `vnc` protocol,
+  `127.0.0.1`, a nonzero port, and a nonempty password. Debug and parse errors
+  redact the password.
+
+The frame callback has three reusable buffers and a two-frame worker queue. A
+slow client drops and recycles stale frames instead of blocking the virtio-gpu
+thread. Input readiness is level-triggered on macOS so a batched Linux input
+event and its `SYN_REPORT` remain visible until both are consumed. Disconnecting
+the RFB client releases all tracked keys and pointer buttons.
+
+## Guest input and seat discovery
+
+The input path spans the host VMM, minimal guest rootfs, and graphical OCI
+workload:
+
+1. libkrun exposes a virtual keyboard and absolute pointer alongside the KMS
+   scanout.
+2. The guest agent polls for their sysfs `event*` entries and creates the
+   corresponding `/dev/input/event*` character devices before switching to the
+   persistent root.
+3. After `pivot_root`, the agent classifies the devices from their kernel name
+   and EV_KEY/EV_REL/EV_ABS capabilities, then writes the minimal libinput udev
+   records under `/run/udev/data/c<major>:<minor>`.
+4. Graphical OCI workloads receive `/dev/input`, the seatd socket, and a
+   read-only bind mount of `/run/udev`. They also receive
+   `LIBSEAT_BACKEND=seatd` and `SEATD_SOCK=/run/seatd.sock`.
+
+This synthetic runtime metadata replaces the `systemd-udevd input_id` step that
+does not run in the minimal agent rootfs. It is created only for GPU-enabled
+guests and is harmless when no input devices are present. A desktop image may
+contain the `udev` userspace package for libudev consumers, but it does not need
+to start a second udev daemon or inject records manually.
+
+## Native build requirements
+
+The helper requires both the host libkrun input feature and the guest kernel
+driver:
+
+```text
+make -C libkrun BLK=1 NET=1 GPU=1 INPUT=1
+CONFIG_VIRTIO_INPUT=y
+```
+
+The pinned macOS GPU build also requires the `virglrenderer` formula from the
+maintained libkrun Homebrew tap:
+
+```bash
+brew tap libkrun/krun
+brew trust --formula libkrun/krun/virglrenderer
+brew install libkrun/krun/virglrenderer
+```
+
+The resulting library must report all four required features:
+
+```text
+net=1
+block=1
+gpu=1
+input=1
+```
+
+`libkrunfw` still builds its Linux kernel in a Linux VM on macOS. Rebuild the
+pinned firmware after enabling `CONFIG_VIRTIO_INPUT`, then bundle that
+`libkrunfw.5.dylib` with the custom libkrun.
+
+The bundled agent rootfs is a third required input. It must contain the current
+Linux `smolvm-agent` binary, which creates the event nodes and udev metadata,
+and the `seatd` package used by graphical workloads:
+
+```bash
+cargo make build-agent
+cargo make agent-rootfs
+```
+
+For a direct development run, point the helper at the matching rootfs:
+
+```bash
+DYLD_LIBRARY_PATH=./lib \
+SMOLVM_AGENT_ROOTFS=./target/agent-rootfs \
+./target/release/smolvm machine start --name debian-gui --display
+```
+
+Packaged display helpers use `scripts/smolvm-display-wrapper.sh`, which selects
+the `agent-rootfs` beside the helper through `SMOLVM_AGENT_ROOTFS`. Rebuild and
+ship libkrun, libkrunfw, the host helper, and the agent rootfs as one validated
+set. A new framebuffer helper paired with an older rootfs can display frames
+while silently lacking keyboard/pointer discovery.
+
+## Current source boundary
+
+The fast-loop source checkout resolves `rustvncserver` from the sibling
+`../rustvncserver` fork. That fork adds explicit-address and prebound-listener
+entry points so the helper can bind loopback port zero without a
+close-and-rebind race. Before distributing source, publish the reviewed fork or
+vendor an exact revision and replace the sibling path dependency. Do not ship a
+source package that depends on an undeclared adjacent checkout.
+
+## Client and fullscreen boundary
+
+The SmolVM helper owns the loopback RFB endpoint, framebuffer updates, and input
+event injection. It does not own application layout, pane composition, window
+fullscreen, or display reconnection UX.
+
+Local Machines waits for `display_ready`, retrieves the credential-bearing
+endpoint through `machine display --json`, and embeds the RFB surface beside
+its shell and log panes. Its Display fullscreen control switches to an
+app-local immersive layout: inventory, toolbar, and docked auxiliary panes are
+hidden while the same RFB surface stays attached, and active Logs/Shell can be
+shown in an overlay. Native macOS app fullscreen remains a separate standard
+window operation. Neither mode changes the guest KMS mode, creates another
+display session, or stops the VM. Stopping the VM closes the endpoint, after
+which a client must wait for the next `--display` launch and connect to its new
+per-launch credential.
+
+## Machine JSON inventory
+
+`machine list --json` and `machine status --json` share the same per-machine
+object. Display clients can consume these non-secret lifecycle fields without
+probing private runtime files:
+
+- `display_ready`: true only for a running machine with a live endpoint.
+- `forkable`: true only while the fork control socket reports a usable running
+  or frozen base.
+- `fork_base_state`: `"running"`, `"frozen"`, or null.
+- `golden`: the persisted parent name for a clone, or null.
+- `dependent_clones`: names of clones that currently depend on the machine.
+
+These fork fields describe warm-fork inventory; they do not imply display
+availability, and they never expose the display port or credential.
+
+## Acceptance checks
+
+1. `krun_has_feature` reports GPU and INPUT support.
+2. A display-aware guest sees `/dev/dri/card0`, virtual input event devices,
+   matching `/run/udev/data` records, and a live seatd socket.
+3. A graphical OCI workload sees `/dev/input`, read-only `/run/udev`, and can
+   initialize libinput without manual udev record injection.
+4. `machine ls --json` reports `display_ready: true` only while the rendezvous
+   server is live.
+5. `machine display --name NAME --json` returns a loopback endpoint to the same
+   user and does not start or repair a VM.
+6. A client receives changing non-black frames and can inject one key and one
+   pointer event.
+7. The Debian/Weston fixture returns to its desktop after stop/start when the
+   next start includes `--display`.
+8. Immersive Display mode hides app chrome and docked panes while preserving
+   the same RFB session; native app fullscreen remains independently usable.
+9. Stopping the VM removes the endpoint and terminates the RFB listener.
+
+The guest still needs a DRM/KMS graphical workload or compositor. Enabling the
+host bridge alone does not turn a headless root filesystem into a desktop.

--- a/examples/weston-desktop/README.md
+++ b/examples/weston-desktop/README.md
@@ -1,0 +1,51 @@
+# Persistent Debian/Weston desktop
+
+This example creates a Debian graphical machine whose desktop command and
+installed packages persist across normal `machine stop` / `machine start`
+cycles. It uses smolvm's native display transport, virtual keyboard and
+absolute pointer, and the guest agent's seatd/libinput plumbing.
+
+## Create and start
+
+From the repository root:
+
+```bash
+smolvm machine create --name debian-gui \
+  -s examples/weston-desktop/weston.smolfile
+smolvm machine start --name debian-gui --display
+```
+
+The first start installs Weston and Xwayland into the persistent image overlay.
+Later starts skip package installation and launch the desktop immediately.
+
+Read the loopback-only display endpoint with:
+
+```bash
+smolvm machine display --name debian-gui --json
+```
+
+Local Machines performs that endpoint exchange automatically when its Display
+pane opens.
+
+## Restart proof
+
+```bash
+smolvm machine stop --name debian-gui
+smolvm machine start --name debian-gui --display
+```
+
+The `--display` flag is required on each start because it requests the host
+framebuffer and keyboard/pointer bridge. No package installation, udev record
+injection, or manual Weston command is required after creation.
+
+## Diagnostics
+
+If the compositor exits, inspect its log from the persistent machine:
+
+```bash
+smolvm machine exec --name debian-gui -- tail -n 200 /var/log/weston.log
+```
+
+The reference profile uses Pixman intentionally. smolvm's native scanout path
+provides a 2D virtio-gpu display; 3D rendering can be enabled separately when a
+guest image and host libkrun build both advertise a compatible virgl path.

--- a/examples/weston-desktop/weston.smolfile
+++ b/examples/weston-desktop/weston.smolfile
@@ -1,0 +1,42 @@
+# Persistent Debian desktop for smolvm's native display transport.
+#
+# Create once:
+#   smolvm machine create --name debian-gui \
+#     -s examples/weston-desktop/weston.smolfile
+#
+# Start (including after every explicit stop):
+#   smolvm machine start --name debian-gui --display
+
+image = "debian:bookworm-slim"
+entrypoint = ["/bin/sh", "-lc"]
+cmd = ["""
+set -eu
+rm -rf /tmp/weston-runtime
+install -d -m 700 /tmp/weston-runtime
+install -d -m 1777 /tmp/.X11-unix
+exec dbus-run-session -- weston \
+  --backend=drm-backend.so \
+  --tty=1 \
+  --use-pixman \
+  --current-mode \
+  --idle-time=0 \
+  --xwayland \
+  --log=/var/log/weston.log
+"""]
+env = [
+    "XDG_RUNTIME_DIR=/tmp/weston-runtime",
+    "LIBSEAT_BACKEND=seatd",
+    "SEATD_SOCK=/run/seatd.sock",
+]
+
+cpus = 2
+memory = 2048
+storage = 20
+overlay = 4
+net = true
+gpu = true
+
+[dev]
+init = [
+    "command -v weston >/dev/null 2>&1 || { mkdir -p /var/lib/apt/lists/partial; apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends weston xwayland dbus-x11 fonts-dejavu-core adwaita-icon-theme udev; }",
+]

--- a/lib/libkrun.dylib
+++ b/lib/libkrun.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c27cc61a09aa1948ef6e42c3ded897c926e0b021b61590bace6c472e962e29f6
-size 6090832
+oid sha256:e9cc94a2e143e1a03339e4cc74274770319abf2a7c5552c8b7ce89f608548f90
+size 6127984

--- a/lib/libkrunfw.5.dylib
+++ b/lib/libkrunfw.5.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d1d7091c8067c9219f793b18dc673b47688966f12f947f9ec083c518498cd0d2
-size 13315472
+oid sha256:b9ecc54cd4d82df326f440de388b319bcddbbce11f079f2a548623a6a45e6e3b
+size 13052816

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -13,7 +13,7 @@ set -e
 WITH_LOCAL_LIBKRUN=0
 SKIP_AGENT_BUILD=0
 LOCAL_LIBKRUN_DIR=""
-LIBKRUN_MAKE_FLAGS="${LIBKRUN_MAKE_FLAGS:-BLK=1 NET=1 GPU=1}"
+LIBKRUN_MAKE_FLAGS="${LIBKRUN_MAKE_FLAGS:-BLK=1 NET=1 GPU=1 INPUT=1}"
 
 print_help() {
     cat <<'EOF'
@@ -29,7 +29,7 @@ Options:
   -h, --help                 Show this help text
 
 Environment:
-  LIBKRUN_MAKE_FLAGS   make flags for local libkrun build (default: BLK=1 NET=1 GPU=1)
+  LIBKRUN_MAKE_FLAGS   make flags for local libkrun build (default: BLK=1 NET=1 GPU=1 INPUT=1)
   LIBCLANG_PATH        path to libclang.dylib (auto-detected from brew llvm on macOS)
   LIB_DIR              Override bundled library directory used by smolvm build
   CODESIGN_IDENTITY    macOS code signing identity (default: - for ad-hoc)

--- a/scripts/smolvm-display-wrapper.sh
+++ b/scripts/smolvm-display-wrapper.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export DYLD_LIBRARY_PATH="$SCRIPT_DIR/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+
+if [ -d "$SCRIPT_DIR/agent-rootfs" ]; then
+    export SMOLVM_AGENT_ROOTFS="${SMOLVM_AGENT_ROOTFS:-$SCRIPT_DIR/agent-rootfs}"
+fi
+
+exec "$SCRIPT_DIR/smolvm-bin" "$@"

--- a/src/agent/boot_config.rs
+++ b/src/agent/boot_config.rs
@@ -57,4 +57,7 @@ pub struct BootConfig {
     /// lets the `pack --from-vm` exporter attach a source qcow2 disk read-only.
     #[serde(default)]
     pub extra_disks: Vec<(PathBuf, bool, DiskFormat)>,
+    /// Optional mode-0600 rendezvous socket for a native display launch.
+    #[serde(default)]
+    pub display_socket: Option<PathBuf>,
 }

--- a/src/agent/display.rs
+++ b/src/agent/display.rs
@@ -1,0 +1,1155 @@
+//! Native libkrun display/input bridge for Local Machines.
+//!
+//! The VM owns the framebuffer callbacks. A bounded worker publishes those
+//! frames through a password-protected RFB server bound only to loopback, while
+//! a mode-0600 Unix rendezvous socket returns the per-launch endpoint.
+
+use crossbeam_channel::{bounded, Receiver, Sender, TryRecvError};
+use krun_display::{
+    DisplayBackendBasicFramebuffer, DisplayBackendError, DisplayBackendNew, IntoDisplayBackend,
+    Rect, ResourceFormat,
+};
+use krun_input::{
+    InputAbsInfo, InputBackendError, InputDeviceIds, InputEvent, InputEventType, InputEventsImpl,
+    InputQueryConfig, IntoInputConfig, IntoInputEvents, ObjectNew,
+};
+use krun_utils::pollable_channel::{
+    pollable_channel, PollableChannelReciever, PollableChannelSender,
+};
+use rand::{distributions::Alphanumeric, Rng};
+use rustvncserver::{server::ServerEvent, VncServer};
+use serde::{Deserialize, Serialize};
+use std::array;
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::io::Read;
+use std::net::Ipv4Addr;
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd};
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::net::UnixStream as StdUnixStream;
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::Duration;
+use tokio::io::AsyncWriteExt;
+use tokio::net::{TcpListener, UnixListener, UnixStream};
+use tokio::sync::mpsc;
+
+/// Default native scanout width.
+pub const DISPLAY_WIDTH: u32 = 1_440;
+/// Default native scanout height.
+pub const DISPLAY_HEIGHT: u32 = 900;
+const DISPLAY_BUFFERS: usize = 3;
+const FRAME_QUEUE_DEPTH: usize = 2;
+const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
+
+const EV_SYN: u16 = 0;
+const EV_KEY: u16 = 1;
+const EV_REL: u16 = 2;
+const EV_ABS: u16 = 3;
+const SYN_REPORT: u16 = 0;
+const REL_WHEEL: u16 = 8;
+const ABS_X: u16 = 0;
+const ABS_Y: u16 = 1;
+const BTN_LEFT: u16 = 272;
+const BTN_RIGHT: u16 = 273;
+const BTN_MIDDLE: u16 = 274;
+const BUS_VIRTUAL: u16 = 0x06;
+const INPUT_PROP_POINTER: u16 = 0;
+
+/// Secret-bearing loopback endpoint returned only through the rendezvous socket.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct DisplayEndpoint {
+    /// Transport protocol. Currently always `vnc`.
+    pub protocol: String,
+    /// Loopback host.
+    pub host: String,
+    /// Ephemeral loopback TCP port.
+    pub port: u16,
+    /// Per-launch VNC credential.
+    pub password: String,
+}
+
+impl fmt::Debug for DisplayEndpoint {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DisplayEndpoint")
+            .field("protocol", &self.protocol)
+            .field("host", &self.host)
+            .field("port", &self.port)
+            .field("password", &"[REDACTED]")
+            .finish()
+    }
+}
+
+/// Environment flag consumed by the named-machine start path.
+pub const DISPLAY_ENV: &str = "SMOLVM_DISPLAY";
+
+/// Derives the per-machine rendezvous socket without reading secret material.
+pub fn endpoint_socket(machine_name: &str) -> PathBuf {
+    super::vm_data_dir(machine_name)
+        .join("display-runtime")
+        .join("endpoint.sock")
+}
+
+/// Returns whether a live VMM is accepting rendezvous connections.
+pub fn endpoint_is_ready(machine_name: &str) -> bool {
+    StdUnixStream::connect(endpoint_socket(machine_name)).is_ok()
+}
+
+/// Reads and validates the current secret endpoint without starting a VM.
+pub fn read_endpoint(machine_name: &str) -> Result<DisplayEndpoint, String> {
+    let mut stream = StdUnixStream::connect(endpoint_socket(machine_name))
+        .map_err(|error| format!("display is not available: {error}"))?;
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .map_err(|error| format!("configure display endpoint timeout: {error}"))?;
+    let mut bytes = Vec::with_capacity(256);
+    stream
+        .by_ref()
+        .take(4_097)
+        .read_to_end(&mut bytes)
+        .map_err(|error| format!("read display endpoint: {error}"))?;
+    decode_endpoint(&bytes)
+}
+
+fn decode_endpoint(bytes: &[u8]) -> Result<DisplayEndpoint, String> {
+    if bytes.len() > 4_096 {
+        return Err("display endpoint exceeded the 4096-byte limit".into());
+    }
+    let endpoint: DisplayEndpoint = serde_json::from_slice(&bytes)
+        .map_err(|_| "display endpoint returned invalid JSON".to_string())?;
+    if endpoint.protocol != "vnc"
+        || endpoint.host != "127.0.0.1"
+        || endpoint.port == 0
+        || endpoint.password.is_empty()
+    {
+        return Err("display endpoint failed validation".into());
+    }
+    Ok(endpoint)
+}
+
+#[derive(Clone)]
+struct DisplayBackendConfig {
+    frame_tx: mpsc::Sender<FrameEvent>,
+    width: u32,
+    height: u32,
+}
+
+/// Owns callback userdata and the worker that serves one VM display.
+pub struct DisplayBridge {
+    backend: DisplayBackendConfig,
+    keyboard_rx: PollableChannelReciever<InputEvent>,
+    pointer_rx: PollableChannelReciever<InputEvent>,
+    pointer_options: PointerOptions,
+}
+
+impl DisplayBridge {
+    /// Starts the bounded RFB and input bridge and waits for endpoint readiness.
+    ///
+    /// The bridge is boxed before any callback vtable can borrow its fields.
+    /// libkrun keeps those userdata pointers for the VM lifetime, so moving the
+    /// bridge value after constructing a vtable would invalidate them.
+    pub fn start(endpoint_socket: &Path) -> Result<Box<Self>, String> {
+        let (frame_tx, frame_rx) = mpsc::channel(FRAME_QUEUE_DEPTH);
+        let (keyboard_tx, keyboard_rx) =
+            pollable_channel().map_err(|error| format!("create keyboard input queue: {error}"))?;
+        let (pointer_tx, pointer_rx) =
+            pollable_channel().map_err(|error| format!("create pointer input queue: {error}"))?;
+        let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(1);
+        let endpoint_socket = endpoint_socket.to_path_buf();
+
+        thread::Builder::new()
+            .name("smolvm-display".into())
+            .spawn(move || {
+                let runtime = match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(runtime) => runtime,
+                    Err(error) => {
+                        let _ = ready_tx.send(Err(format!("create display runtime: {error}")));
+                        return;
+                    }
+                };
+                runtime.block_on(run_bridge(
+                    endpoint_socket,
+                    frame_rx,
+                    keyboard_tx,
+                    pointer_tx,
+                    ready_tx,
+                ));
+            })
+            .map_err(|error| format!("spawn display worker: {error}"))?;
+
+        ready_rx
+            .recv()
+            .map_err(|error| format!("display worker exited before readiness: {error}"))??;
+
+        Ok(Box::new(Self {
+            backend: DisplayBackendConfig {
+                frame_tx,
+                width: DISPLAY_WIDTH,
+                height: DISPLAY_HEIGHT,
+            },
+            keyboard_rx,
+            pointer_rx,
+            pointer_options: PointerOptions {
+                width: DISPLAY_WIDTH,
+                height: DISPLAY_HEIGHT,
+            },
+        }))
+    }
+
+    /// Builds the libkrun display callback vtable.
+    pub fn display_backend(&self) -> krun_display::DisplayBackend<'_> {
+        RfbDisplayBackend::into_display_backend(Some(&self.backend))
+    }
+
+    /// Builds the virtual keyboard capability vtable.
+    pub fn keyboard_config(&self) -> krun_input::InputConfigBackend<'_> {
+        KeyboardConfig::into_input_config(None)
+    }
+
+    /// Builds the virtual keyboard event-provider vtable.
+    pub fn keyboard_events(&self) -> krun_input::InputEventProviderBackend<'_> {
+        BridgeInputEventProvider::into_input_events(Some(&self.keyboard_rx))
+    }
+
+    /// Builds the absolute pointer capability vtable.
+    pub fn pointer_config(&self) -> krun_input::InputConfigBackend<'_> {
+        PointerConfig::into_input_config(Some(&self.pointer_options))
+    }
+
+    /// Builds the absolute pointer event-provider vtable.
+    pub fn pointer_events(&self) -> krun_input::InputEventProviderBackend<'_> {
+        BridgeInputEventProvider::into_input_events(Some(&self.pointer_rx))
+    }
+}
+
+enum FrameEvent {
+    Update {
+        width: u32,
+        height: u32,
+        format: ResourceFormat,
+        damage: Option<Rect>,
+        buffer: Vec<u8>,
+        recycle: Sender<Vec<u8>>,
+    },
+}
+
+struct Scanout {
+    width: u32,
+    height: u32,
+    format: ResourceFormat,
+    available_tx: Sender<Vec<u8>>,
+    available_rx: Receiver<Vec<u8>>,
+    current: Option<Vec<u8>>,
+}
+
+struct RfbDisplayBackend {
+    config: DisplayBackendConfig,
+    scanouts: [Option<Scanout>; krun_display::MAX_DISPLAYS],
+}
+
+impl DisplayBackendNew<DisplayBackendConfig> for RfbDisplayBackend {
+    fn new(userdata: Option<&DisplayBackendConfig>) -> Self {
+        Self {
+            config: userdata
+                .expect("display backend config is required")
+                .clone(),
+            scanouts: array::from_fn(|_| None),
+        }
+    }
+}
+
+impl DisplayBackendBasicFramebuffer for RfbDisplayBackend {
+    fn configure_scanout(
+        &mut self,
+        scanout_id: u32,
+        _display_width: u32,
+        _display_height: u32,
+        width: u32,
+        height: u32,
+        format: ResourceFormat,
+    ) -> Result<(), DisplayBackendError> {
+        let index =
+            usize::try_from(scanout_id).map_err(|_| DisplayBackendError::InvalidScanoutId)?;
+        if index >= self.scanouts.len()
+            || width == 0
+            || height == 0
+            || width > self.config.width
+            || height > self.config.height
+            || frame_len(width, height).is_none()
+        {
+            return Err(DisplayBackendError::InvalidParam);
+        }
+
+        let (available_tx, available_rx) = bounded(DISPLAY_BUFFERS);
+        for _ in 0..DISPLAY_BUFFERS {
+            available_tx
+                .try_send(Vec::new())
+                .map_err(|_| DisplayBackendError::InternalError)?;
+        }
+        self.scanouts[index] = Some(Scanout {
+            width,
+            height,
+            format,
+            available_tx,
+            available_rx,
+            current: None,
+        });
+        Ok(())
+    }
+
+    fn disable_scanout(&mut self, scanout_id: u32) -> Result<(), DisplayBackendError> {
+        let index =
+            usize::try_from(scanout_id).map_err(|_| DisplayBackendError::InvalidScanoutId)?;
+        let slot = self
+            .scanouts
+            .get_mut(index)
+            .ok_or(DisplayBackendError::InvalidScanoutId)?;
+        *slot = None;
+        Ok(())
+    }
+
+    fn alloc_frame(&mut self, scanout_id: u32) -> Result<(u32, &mut [u8]), DisplayBackendError> {
+        let scanout = self.scanout_mut(scanout_id)?;
+        if scanout.current.is_some() {
+            return Err(DisplayBackendError::OutOfBuffers);
+        }
+        let mut buffer = scanout
+            .available_rx
+            .try_recv()
+            .map_err(|error| match error {
+                TryRecvError::Empty => DisplayBackendError::OutOfBuffers,
+                TryRecvError::Disconnected => DisplayBackendError::InternalError,
+            })?;
+        let length =
+            frame_len(scanout.width, scanout.height).ok_or(DisplayBackendError::InvalidParam)?;
+        buffer.resize(length, 0);
+        scanout.current = Some(buffer);
+        Ok((
+            1,
+            scanout
+                .current
+                .as_mut()
+                .expect("frame was set")
+                .as_mut_slice(),
+        ))
+    }
+
+    fn present_frame(
+        &mut self,
+        scanout_id: u32,
+        frame_id: u32,
+        damage: Option<&Rect>,
+    ) -> Result<(), DisplayBackendError> {
+        if frame_id != 1 {
+            return Err(DisplayBackendError::InvalidParam);
+        }
+        let frame_tx = self.config.frame_tx.clone();
+        let scanout = self.scanout_mut(scanout_id)?;
+        let buffer = scanout
+            .current
+            .take()
+            .ok_or(DisplayBackendError::InvalidParam)?;
+        let event = FrameEvent::Update {
+            width: scanout.width,
+            height: scanout.height,
+            format: scanout.format,
+            damage: damage.copied(),
+            buffer,
+            recycle: scanout.available_tx.clone(),
+        };
+
+        if let Err(error) = frame_tx.try_send(event) {
+            let event = match error {
+                mpsc::error::TrySendError::Full(event)
+                | mpsc::error::TrySendError::Closed(event) => event,
+            };
+            let FrameEvent::Update {
+                buffer, recycle, ..
+            } = event;
+            let _ = recycle.try_send(buffer);
+        }
+        Ok(())
+    }
+}
+
+impl RfbDisplayBackend {
+    fn scanout_mut(&mut self, scanout_id: u32) -> Result<&mut Scanout, DisplayBackendError> {
+        let index =
+            usize::try_from(scanout_id).map_err(|_| DisplayBackendError::InvalidScanoutId)?;
+        self.scanouts
+            .get_mut(index)
+            .and_then(Option::as_mut)
+            .ok_or(DisplayBackendError::InvalidScanoutId)
+    }
+}
+
+async fn run_bridge(
+    endpoint_socket: PathBuf,
+    mut frame_rx: mpsc::Receiver<FrameEvent>,
+    keyboard_tx: PollableChannelSender<InputEvent>,
+    pointer_tx: PollableChannelSender<InputEvent>,
+    ready_tx: std::sync::mpsc::SyncSender<Result<(), String>>,
+) {
+    let password: String = rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(8)
+        .map(char::from)
+        .collect();
+    let (server, mut server_events) = VncServer::new(
+        DISPLAY_WIDTH as u16,
+        DISPLAY_HEIGHT as u16,
+        "SmolVM".into(),
+        Some(password.clone()),
+    );
+    let server = std::sync::Arc::new(server);
+    let framebuffer = server.framebuffer().clone();
+
+    let vnc_listener = match TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await {
+        Ok(listener) => listener,
+        Err(error) => {
+            let _ = ready_tx.send(Err(format!("bind loopback RFB endpoint: {error}")));
+            return;
+        }
+    };
+    let port = match vnc_listener.local_addr() {
+        Ok(address) => address.port(),
+        Err(error) => {
+            let _ = ready_tx.send(Err(format!("read loopback RFB endpoint: {error}")));
+            return;
+        }
+    };
+    let _ = std::fs::remove_file(&endpoint_socket);
+    let endpoint_listener = match UnixListener::bind(&endpoint_socket) {
+        Ok(listener) => listener,
+        Err(error) => {
+            let _ = ready_tx.send(Err(format!("bind display rendezvous: {error}")));
+            return;
+        }
+    };
+    let _endpoint_cleanup = EndpointSocketCleanup(endpoint_socket.clone());
+    if let Err(error) =
+        std::fs::set_permissions(&endpoint_socket, std::fs::Permissions::from_mode(0o600))
+    {
+        let _ = ready_tx.send(Err(format!("secure display rendezvous: {error}")));
+        return;
+    }
+
+    let endpoint = DisplayEndpoint {
+        protocol: "vnc".into(),
+        host: "127.0.0.1".into(),
+        port,
+        password,
+    };
+    let endpoint_json = match serde_json::to_vec(&endpoint) {
+        Ok(json) => json,
+        Err(error) => {
+            let _ = ready_tx.send(Err(format!("encode display endpoint: {error}")));
+            return;
+        }
+    };
+    let _ = ready_tx.send(Ok(()));
+
+    let serve_vnc = server.listen_listener(vnc_listener);
+    let serve_endpoint = serve_endpoint(endpoint_listener, endpoint_json);
+    let frames = async move {
+        while let Some(event) = frame_rx.recv().await {
+            let FrameEvent::Update {
+                width,
+                height,
+                format,
+                damage,
+                buffer,
+                recycle,
+            } = event;
+            if let Some((rgba, x, y, crop_width, crop_height)) =
+                rgba_damage(&buffer, width, height, format, damage.as_ref())
+            {
+                let _ = framebuffer
+                    .update_cropped(&rgba, x, y, crop_width, crop_height)
+                    .await;
+            }
+            let _ = recycle.try_send(buffer);
+        }
+    };
+    let inputs = async move {
+        let mut clients = HashMap::<usize, ClientInputState>::new();
+        while let Some(event) = server_events.recv().await {
+            match event {
+                ServerEvent::ClientConnected { client_id } => {
+                    clients.entry(client_id).or_default();
+                }
+                ServerEvent::ClientDisconnected { client_id } => {
+                    if let Some(mut client) = clients.remove(&client_id) {
+                        client.release_all(&keyboard_tx, &pointer_tx);
+                    }
+                }
+                ServerEvent::KeyPress {
+                    client_id,
+                    down,
+                    key,
+                } => {
+                    if let Some(code) = keysym_to_linux(key) {
+                        clients
+                            .entry(client_id)
+                            .or_default()
+                            .send_key(code, down, &keyboard_tx);
+                    }
+                }
+                ServerEvent::PointerMove {
+                    client_id,
+                    x,
+                    y,
+                    button_mask,
+                } => {
+                    clients.entry(client_id).or_default().pointer.send(
+                        x,
+                        y,
+                        button_mask,
+                        &pointer_tx,
+                    );
+                }
+                _ => {}
+            }
+        }
+    };
+
+    tokio::select! {
+        result = serve_vnc => {
+            if let Err(error) = result {
+                tracing::error!(%error, "SmolVM RFB server stopped");
+            }
+        }
+        _ = serve_endpoint => {}
+        _ = frames => {}
+        _ = inputs => {}
+    }
+}
+
+struct EndpointSocketCleanup(PathBuf);
+
+impl Drop for EndpointSocketCleanup {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+async fn serve_endpoint(listener: UnixListener, endpoint_json: Vec<u8>) {
+    loop {
+        let Ok((mut stream, _)) = listener.accept().await else {
+            return;
+        };
+        if !same_user(&stream) {
+            continue;
+        }
+        let mut response = endpoint_json.clone();
+        response.push(b'\n');
+        let _ = stream.write_all(&response).await;
+        let _ = stream.shutdown().await;
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn same_user(stream: &UnixStream) -> bool {
+    let mut uid = 0;
+    let mut gid = 0;
+    let result = unsafe { libc::getpeereid(stream.as_raw_fd(), &mut uid, &mut gid) };
+    result == 0 && uid == unsafe { libc::geteuid() }
+}
+
+#[cfg(target_os = "linux")]
+fn same_user(stream: &UnixStream) -> bool {
+    let mut credential = libc::ucred {
+        pid: 0,
+        uid: 0,
+        gid: 0,
+    };
+    let mut length = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+    let result = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_PEERCRED,
+            (&mut credential as *mut libc::ucred).cast(),
+            &mut length,
+        )
+    };
+    result == 0 && credential.uid == unsafe { libc::geteuid() }
+}
+
+fn frame_len(width: u32, height: u32) -> Option<usize> {
+    let length = usize::try_from(width)
+        .ok()?
+        .checked_mul(usize::try_from(height).ok()?)?
+        .checked_mul(ResourceFormat::BYTES_PER_PIXEL)?;
+    (length <= MAX_FRAME_BYTES).then_some(length)
+}
+
+fn rgba_damage(
+    frame: &[u8],
+    width: u32,
+    height: u32,
+    format: ResourceFormat,
+    damage: Option<&Rect>,
+) -> Option<(Vec<u8>, u16, u16, u16, u16)> {
+    if frame.len() != frame_len(width, height)?
+        || width > u16::MAX as u32
+        || height > u16::MAX as u32
+    {
+        return None;
+    }
+    let (x, y, crop_width, crop_height) = match damage {
+        Some(rect)
+            if rect.width > 0
+                && rect.height > 0
+                && rect.x.checked_add(rect.width)? <= width
+                && rect.y.checked_add(rect.height)? <= height =>
+        {
+            (rect.x, rect.y, rect.width, rect.height)
+        }
+        _ => (0, 0, width, height),
+    };
+    let output_len = frame_len(crop_width, crop_height)?;
+    let mut output = Vec::with_capacity(output_len);
+    for row in y..(y + crop_height) {
+        for column in x..(x + crop_width) {
+            let offset = usize::try_from(row)
+                .ok()?
+                .checked_mul(usize::try_from(width).ok()?)?
+                .checked_add(usize::try_from(column).ok()?)?
+                .checked_mul(ResourceFormat::BYTES_PER_PIXEL)?;
+            let pixel: [u8; 4] = frame.get(offset..offset + 4)?.try_into().ok()?;
+            output.extend_from_slice(&rgba_pixel(pixel, format));
+        }
+    }
+    Some((
+        output,
+        x as u16,
+        y as u16,
+        crop_width as u16,
+        crop_height as u16,
+    ))
+}
+
+fn rgba_pixel(pixel: [u8; 4], format: ResourceFormat) -> [u8; 4] {
+    match format {
+        ResourceFormat::BGRA => [pixel[2], pixel[1], pixel[0], pixel[3]],
+        ResourceFormat::BGRX => [pixel[2], pixel[1], pixel[0], 255],
+        ResourceFormat::ARGB => [pixel[1], pixel[2], pixel[3], pixel[0]],
+        ResourceFormat::XRGB => [pixel[1], pixel[2], pixel[3], 255],
+        ResourceFormat::RGBA => pixel,
+        ResourceFormat::XBGR => [pixel[3], pixel[2], pixel[1], 255],
+        ResourceFormat::ABGR => [pixel[3], pixel[2], pixel[1], pixel[0]],
+        ResourceFormat::RGBX => [pixel[0], pixel[1], pixel[2], 255],
+    }
+}
+
+struct BridgeInputEventProvider {
+    rx: PollableChannelReciever<InputEvent>,
+}
+
+impl ObjectNew<PollableChannelReciever<InputEvent>> for BridgeInputEventProvider {
+    fn new(userdata: Option<&PollableChannelReciever<InputEvent>>) -> Self {
+        Self {
+            rx: userdata.expect("input event receiver is required").clone(),
+        }
+    }
+}
+
+impl InputEventsImpl for BridgeInputEventProvider {
+    fn get_read_notify_fd(&self) -> Result<BorrowedFd<'_>, InputBackendError> {
+        Ok(self.rx.as_fd())
+    }
+
+    fn next_event(&mut self) -> Result<Option<InputEvent>, InputBackendError> {
+        self.rx
+            .try_recv()
+            .map_err(|_| InputBackendError::InternalError)
+    }
+}
+
+#[derive(Clone, Copy)]
+struct KeyboardConfig;
+
+impl ObjectNew<()> for KeyboardConfig {
+    fn new(_userdata: Option<&()>) -> Self {
+        Self
+    }
+}
+
+impl InputQueryConfig for KeyboardConfig {
+    fn query_device_name(&self, buffer: &mut [u8]) -> Result<u8, InputBackendError> {
+        copy_name(buffer, b"SmolVM Virtual Keyboard")
+    }
+
+    fn query_serial_name(&self, buffer: &mut [u8]) -> Result<u8, InputBackendError> {
+        copy_name(buffer, b"SMOLVM-KBD")
+    }
+
+    fn query_device_ids(&self, ids: &mut InputDeviceIds) -> Result<(), InputBackendError> {
+        *ids = InputDeviceIds {
+            bustype: BUS_VIRTUAL,
+            vendor: 0x534d,
+            product: 1,
+            version: 1,
+        };
+        Ok(())
+    }
+
+    fn query_event_capabilities(
+        &self,
+        event_type: u8,
+        buffer: &mut [u8],
+    ) -> Result<u8, InputBackendError> {
+        match InputEventType::try_from(event_type as u16) {
+            Ok(InputEventType::Syn) => set_bits(buffer, &[SYN_REPORT]),
+            Ok(InputEventType::Key) => {
+                let keys: Vec<u16> = (1..=248).collect();
+                set_bits(buffer, &keys)
+            }
+            _ => Ok(0),
+        }
+    }
+
+    fn query_abs_info(&self, _axis: u8, _info: &mut InputAbsInfo) -> Result<(), InputBackendError> {
+        Ok(())
+    }
+
+    fn query_properties(&self, _buffer: &mut [u8]) -> Result<u8, InputBackendError> {
+        Ok(0)
+    }
+}
+
+#[derive(Clone, Copy)]
+struct PointerOptions {
+    width: u32,
+    height: u32,
+}
+
+#[derive(Clone, Copy)]
+struct PointerConfig(PointerOptions);
+
+impl ObjectNew<PointerOptions> for PointerConfig {
+    fn new(userdata: Option<&PointerOptions>) -> Self {
+        Self(*userdata.expect("pointer options are required"))
+    }
+}
+
+impl InputQueryConfig for PointerConfig {
+    fn query_device_name(&self, buffer: &mut [u8]) -> Result<u8, InputBackendError> {
+        copy_name(buffer, b"SmolVM Absolute Pointer")
+    }
+
+    fn query_serial_name(&self, buffer: &mut [u8]) -> Result<u8, InputBackendError> {
+        copy_name(buffer, b"SMOLVM-PTR")
+    }
+
+    fn query_device_ids(&self, ids: &mut InputDeviceIds) -> Result<(), InputBackendError> {
+        *ids = InputDeviceIds {
+            bustype: BUS_VIRTUAL,
+            vendor: 0x534d,
+            product: 2,
+            version: 1,
+        };
+        Ok(())
+    }
+
+    fn query_event_capabilities(
+        &self,
+        event_type: u8,
+        buffer: &mut [u8],
+    ) -> Result<u8, InputBackendError> {
+        match InputEventType::try_from(event_type as u16) {
+            Ok(InputEventType::Syn) => set_bits(buffer, &[SYN_REPORT]),
+            Ok(InputEventType::Key) => set_bits(buffer, &[BTN_LEFT, BTN_RIGHT, BTN_MIDDLE]),
+            Ok(InputEventType::Abs) => set_bits(buffer, &[ABS_X, ABS_Y]),
+            Ok(InputEventType::Rel) => set_bits(buffer, &[REL_WHEEL]),
+            _ => Ok(0),
+        }
+    }
+
+    fn query_abs_info(&self, axis: u8, info: &mut InputAbsInfo) -> Result<(), InputBackendError> {
+        let max = match axis as u16 {
+            ABS_X => self.0.width.saturating_sub(1),
+            ABS_Y => self.0.height.saturating_sub(1),
+            _ => 0,
+        };
+        *info = InputAbsInfo {
+            min: 0,
+            max,
+            fuzz: 0,
+            flat: 0,
+            res: 0,
+        };
+        Ok(())
+    }
+
+    fn query_properties(&self, buffer: &mut [u8]) -> Result<u8, InputBackendError> {
+        set_bits(buffer, &[INPUT_PROP_POINTER])
+    }
+}
+
+fn copy_name(buffer: &mut [u8], name: &[u8]) -> Result<u8, InputBackendError> {
+    let length = buffer.len().min(name.len()).min(u8::MAX as usize);
+    buffer[..length].copy_from_slice(&name[..length]);
+    Ok(length as u8)
+}
+
+fn set_bits(buffer: &mut [u8], bits: &[u16]) -> Result<u8, InputBackendError> {
+    let mut last = None;
+    for bit in bits {
+        let byte = usize::from(*bit / 8);
+        if byte >= buffer.len() {
+            return Err(InputBackendError::InvalidParam);
+        }
+        buffer[byte] |= 1 << (*bit % 8);
+        last = Some(last.map_or(byte, |current: usize| current.max(byte)));
+    }
+    Ok(last.map_or(0, |byte| (byte + 1).min(u8::MAX as usize) as u8))
+}
+
+#[derive(Default)]
+struct PointerState {
+    buttons: u8,
+}
+
+impl PointerState {
+    fn send(&mut self, x: u16, y: u16, buttons: u8, sender: &PollableChannelSender<InputEvent>) {
+        let mut events = vec![
+            input_event(
+                EV_ABS,
+                ABS_X,
+                u32::from(x).min(DISPLAY_WIDTH.saturating_sub(1)),
+            ),
+            input_event(
+                EV_ABS,
+                ABS_Y,
+                u32::from(y).min(DISPLAY_HEIGHT.saturating_sub(1)),
+            ),
+        ];
+        for (mask, code) in [(1, BTN_LEFT), (2, BTN_MIDDLE), (4, BTN_RIGHT)] {
+            if self.buttons & mask != buttons & mask {
+                events.push(input_event(EV_KEY, code, u32::from(buttons & mask != 0)));
+            }
+        }
+        if buttons & 8 != 0 {
+            events.push(input_event(EV_REL, REL_WHEEL, 1));
+        }
+        if buttons & 16 != 0 {
+            events.push(input_event(EV_REL, REL_WHEEL, u32::MAX));
+        }
+        events.push(input_event(EV_SYN, SYN_REPORT, 0));
+        self.buttons = buttons & 0b0000_0111;
+        let _ = sender.send_many(events);
+    }
+
+    fn release_all(&mut self, sender: &PollableChannelSender<InputEvent>) {
+        if self.buttons == 0 {
+            return;
+        }
+        let mut events = Vec::with_capacity(4);
+        for (mask, code) in [(1, BTN_LEFT), (2, BTN_MIDDLE), (4, BTN_RIGHT)] {
+            if self.buttons & mask != 0 {
+                events.push(input_event(EV_KEY, code, 0));
+            }
+        }
+        events.push(input_event(EV_SYN, SYN_REPORT, 0));
+        self.buttons = 0;
+        let _ = sender.send_many(events);
+    }
+}
+
+#[derive(Default)]
+struct ClientInputState {
+    keys: HashSet<u16>,
+    pointer: PointerState,
+}
+
+impl ClientInputState {
+    fn send_key(&mut self, code: u16, down: bool, sender: &PollableChannelSender<InputEvent>) {
+        let changed = if down {
+            self.keys.insert(code)
+        } else {
+            self.keys.remove(&code)
+        };
+        if changed {
+            let _ = sender.send_many([
+                input_event(EV_KEY, code, u32::from(down)),
+                input_event(EV_SYN, SYN_REPORT, 0),
+            ]);
+        }
+    }
+
+    fn release_all(
+        &mut self,
+        keyboard: &PollableChannelSender<InputEvent>,
+        pointer: &PollableChannelSender<InputEvent>,
+    ) {
+        if !self.keys.is_empty() {
+            let mut events: Vec<_> = self
+                .keys
+                .drain()
+                .map(|code| input_event(EV_KEY, code, 0))
+                .collect();
+            events.push(input_event(EV_SYN, SYN_REPORT, 0));
+            let _ = keyboard.send_many(events);
+        }
+        self.pointer.release_all(pointer);
+    }
+}
+
+fn input_event(event_type: u16, code: u16, value: u32) -> InputEvent {
+    InputEvent {
+        type_: event_type,
+        code,
+        value,
+    }
+}
+
+fn keysym_to_linux(keysym: u32) -> Option<u16> {
+    let lower = if (b'A' as u32..=b'Z' as u32).contains(&keysym) {
+        keysym + 32
+    } else {
+        keysym
+    };
+    Some(match lower {
+        0x0061 => 30, // a
+        0x0062 => 48,
+        0x0063 => 46,
+        0x0064 => 32,
+        0x0065 => 18,
+        0x0066 => 33,
+        0x0067 => 34,
+        0x0068 => 35,
+        0x0069 => 23,
+        0x006a => 36,
+        0x006b => 37,
+        0x006c => 38,
+        0x006d => 50,
+        0x006e => 49,
+        0x006f => 24,
+        0x0070 => 25,
+        0x0071 => 16,
+        0x0072 => 19,
+        0x0073 => 31,
+        0x0074 => 20,
+        0x0075 => 22,
+        0x0076 => 47,
+        0x0077 => 17,
+        0x0078 => 45,
+        0x0079 => 21,
+        0x007a => 44,          // z
+        0x0031 | 0x0021 => 2,  // 1 !
+        0x0032 | 0x0040 => 3,  // 2 @
+        0x0033 | 0x0023 => 4,  // 3 #
+        0x0034 | 0x0024 => 5,  // 4 $
+        0x0035 | 0x0025 => 6,  // 5 %
+        0x0036 | 0x005e => 7,  // 6 ^
+        0x0037 | 0x0026 => 8,  // 7 &
+        0x0038 | 0x002a => 9,  // 8 *
+        0x0039 | 0x0028 => 10, // 9 (
+        0x0030 | 0x0029 => 11, // 0 )
+        0x002d | 0x005f => 12, // - _
+        0x003d | 0x002b => 13, // = +
+        0x005b | 0x007b => 26, // [ {
+        0x005d | 0x007d => 27, // ] }
+        0x003b | 0x003a => 39, // ; :
+        0x0027 | 0x0022 => 40, // ' "
+        0x0060 | 0x007e => 41, // ` ~
+        0x005c | 0x007c => 43, // \ |
+        0x002c | 0x003c => 51, // , <
+        0x002e | 0x003e => 52, // . >
+        0x002f | 0x003f => 53, // / ?
+        0x0020 => 57,
+        0xff08 => 14, // Backspace
+        0xff09 => 15, // Tab
+        0xff0d => 28, // Return
+        0xff1b => 1,  // Escape
+        0xff50 => 102,
+        0xff51 => 105,
+        0xff52 => 103,
+        0xff53 => 106,
+        0xff54 => 108,
+        0xff55 => 104,
+        0xff56 => 109,
+        0xff57 => 107,
+        0xffff => 111,
+        0xffe1 => 42,
+        0xffe2 => 54,
+        0xffe3 => 29,
+        0xffe4 => 97,
+        0xffe7 | 0xffe9 => 56,
+        0xffe8 | 0xffea => 100,
+        0xffbe..=0xffc9 => 59 + (lower - 0xffbe) as u16,
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frame_length_is_checked_and_bounded() {
+        assert_eq!(frame_len(1_440, 900), Some(5_184_000));
+        assert_eq!(frame_len(u32::MAX, u32::MAX), None);
+        assert_eq!(frame_len(16_384, 16_384), None);
+    }
+
+    #[test]
+    fn converts_bgra_damage_to_rgba() {
+        let frame = vec![3, 2, 1, 4, 30, 20, 10, 40];
+        let damage = Rect {
+            x: 1,
+            y: 0,
+            width: 1,
+            height: 1,
+        };
+        let (rgba, x, y, width, height) =
+            rgba_damage(&frame, 2, 1, ResourceFormat::BGRA, Some(&damage)).unwrap();
+        assert_eq!(rgba, vec![10, 20, 30, 40]);
+        assert_eq!((x, y, width, height), (1, 0, 1, 1));
+    }
+
+    #[test]
+    fn converts_every_supported_pixel_format_to_rgba() {
+        for (format, input, expected) in [
+            (ResourceFormat::BGRA, [3, 2, 1, 4], [1, 2, 3, 4]),
+            (ResourceFormat::BGRX, [3, 2, 1, 4], [1, 2, 3, 255]),
+            (ResourceFormat::ARGB, [4, 1, 2, 3], [1, 2, 3, 4]),
+            (ResourceFormat::XRGB, [4, 1, 2, 3], [1, 2, 3, 255]),
+            (ResourceFormat::RGBA, [1, 2, 3, 4], [1, 2, 3, 4]),
+            (ResourceFormat::XBGR, [4, 3, 2, 1], [1, 2, 3, 255]),
+            (ResourceFormat::ABGR, [4, 3, 2, 1], [1, 2, 3, 4]),
+            (ResourceFormat::RGBX, [1, 2, 3, 4], [1, 2, 3, 255]),
+        ] {
+            assert_eq!(rgba_pixel(input, format), expected);
+        }
+    }
+
+    #[test]
+    fn maps_common_rfb_keysyms_to_linux_keys() {
+        assert_eq!(keysym_to_linux('a' as u32), Some(30));
+        assert_eq!(keysym_to_linux('A' as u32), Some(30));
+        assert_eq!(keysym_to_linux('-' as u32), Some(12));
+        assert_eq!(keysym_to_linux('_' as u32), Some(12));
+        assert_eq!(keysym_to_linux('/' as u32), Some(53));
+        assert_eq!(keysym_to_linux('?' as u32), Some(53));
+        assert_eq!(keysym_to_linux(0xff0d), Some(28));
+        assert_eq!(keysym_to_linux(0x10ffff), None);
+    }
+
+    #[test]
+    fn endpoint_debug_output_never_contains_the_password() {
+        let endpoint = DisplayEndpoint {
+            protocol: "vnc".into(),
+            host: "127.0.0.1".into(),
+            port: 59_001,
+            password: "secret42".into(),
+        };
+        let output = format!("{endpoint:?}");
+        assert!(!output.contains("secret42"));
+        assert!(output.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn endpoint_decoder_accepts_only_bounded_loopback_vnc() {
+        let valid = br#"{"protocol":"vnc","host":"127.0.0.1","port":5901,"password":"secret42"}"#;
+        assert_eq!(decode_endpoint(valid).unwrap().port, 5901);
+
+        for invalid in [
+            br#"{"protocol":"http","host":"127.0.0.1","port":5901,"password":"secret42"}"#
+                .as_slice(),
+            br#"{"protocol":"vnc","host":"0.0.0.0","port":5901,"password":"secret42"}"#.as_slice(),
+            br#"{"protocol":"vnc","host":"127.0.0.1","port":0,"password":"secret42"}"#.as_slice(),
+            br#"{"protocol":"vnc","host":"127.0.0.1","port":5901,"password":""}"#.as_slice(),
+            br#"not-json-secret42"#.as_slice(),
+        ] {
+            let error = decode_endpoint(invalid).unwrap_err();
+            assert!(!error.contains("secret42"));
+        }
+
+        let oversized = vec![b'x'; 4_097];
+        assert!(decode_endpoint(&oversized)
+            .unwrap_err()
+            .contains("4096-byte"));
+    }
+
+    #[test]
+    fn full_frame_queue_recycles_the_dropped_buffer() {
+        let (frame_tx, frame_rx) = mpsc::channel(FRAME_QUEUE_DEPTH);
+        let config = DisplayBackendConfig {
+            frame_tx,
+            width: 4,
+            height: 4,
+        };
+        let mut backend = RfbDisplayBackend::new(Some(&config));
+        backend
+            .configure_scanout(0, 4, 4, 4, 4, ResourceFormat::RGBA)
+            .unwrap();
+
+        for _ in 0..=FRAME_QUEUE_DEPTH {
+            backend.alloc_frame(0).unwrap();
+            backend.present_frame(0, 1, None).unwrap();
+        }
+
+        assert_eq!(frame_rx.len(), FRAME_QUEUE_DEPTH);
+        assert!(backend.alloc_frame(0).is_ok());
+    }
+
+    #[test]
+    fn boxed_bridge_keeps_callback_userdata_stable_when_owner_moves() {
+        let (frame_tx, _frame_rx) = mpsc::channel(FRAME_QUEUE_DEPTH);
+        let (_keyboard_tx, keyboard_rx) = pollable_channel().unwrap();
+        let (_pointer_tx, pointer_rx) = pollable_channel().unwrap();
+        let bridge = Box::new(DisplayBridge {
+            backend: DisplayBackendConfig {
+                frame_tx,
+                width: DISPLAY_WIDTH,
+                height: DISPLAY_HEIGHT,
+            },
+            keyboard_rx,
+            pointer_rx,
+            pointer_options: PointerOptions {
+                width: DISPLAY_WIDTH,
+                height: DISPLAY_HEIGHT,
+            },
+        });
+
+        let userdata = bridge.display_backend().create_userdata;
+        let moved_owner = Some(bridge);
+        let expected = std::ptr::from_ref(&moved_owner.as_ref().unwrap().backend).cast();
+        assert_eq!(userdata, expected);
+    }
+
+    #[test]
+    fn disconnect_releases_pressed_keys_and_pointer_buttons() {
+        let (keyboard_tx, keyboard_rx) = pollable_channel().unwrap();
+        let (pointer_tx, pointer_rx) = pollable_channel().unwrap();
+        let mut client = ClientInputState::default();
+
+        client.send_key(30, true, &keyboard_tx);
+        client.pointer.send(10, 20, 1, &pointer_tx);
+        while keyboard_rx.try_recv().unwrap().is_some() {}
+        while pointer_rx.try_recv().unwrap().is_some() {}
+        client.release_all(&keyboard_tx, &pointer_tx);
+
+        let key_release = keyboard_rx.try_recv().unwrap().unwrap();
+        assert_eq!(
+            (key_release.type_, key_release.code, key_release.value),
+            (EV_KEY, 30, 0)
+        );
+        let pointer_release = pointer_rx.try_recv().unwrap().unwrap();
+        assert_eq!(
+            (
+                pointer_release.type_,
+                pointer_release.code,
+                pointer_release.value
+            ),
+            (EV_KEY, BTN_LEFT, 0)
+        );
+    }
+}

--- a/src/agent/krun.rs
+++ b/src/agent/krun.rs
@@ -54,6 +54,16 @@ pub struct KrunFunctions {
     >,
     pub get_egress_handle: Option<unsafe extern "C" fn(u32) -> *mut libc::c_void>,
     pub set_gpu_options2: Option<unsafe extern "C" fn(u32, u32, u64) -> i32>,
+    /// Reports whether an optional libkrun feature was compiled in.
+    pub has_feature: Option<unsafe extern "C" fn(u64) -> i32>,
+    /// Adds a host-visible scanout to the virtio-gpu device.
+    pub add_display: Option<unsafe extern "C" fn(u32, u32, u32) -> i32>,
+    /// Installs the callback vtable used to receive guest framebuffer updates.
+    pub set_display_backend: Option<unsafe extern "C" fn(u32, *const libc::c_void, usize) -> i32>,
+    /// Adds a custom virtio-input device backed by callback vtables.
+    pub add_input_device: Option<
+        unsafe extern "C" fn(u32, *const libc::c_void, usize, *const libc::c_void, usize) -> i32,
+    >,
     /// Register a Unix control socket for the VM (pause/resume/checkpoint/restore).
     pub set_control_socket: Option<unsafe extern "C" fn(u32, *const libc::c_char) -> i32>,
     /// Boot the VM as a fork clone from a snapshot directory (CoW-map a golden
@@ -159,6 +169,10 @@ impl KrunFunctions {
             add_net_unixstream: load_optional_sym!("krun_add_net_unixstream"),
             get_egress_handle: load_optional_sym!("krun_get_egress_handle"),
             set_gpu_options2: load_optional_sym!("krun_set_gpu_options2"),
+            has_feature: load_optional_sym!("krun_has_feature"),
+            add_display: load_optional_sym!("krun_add_display"),
+            set_display_backend: load_optional_sym!("krun_set_display_backend"),
+            add_input_device: load_optional_sym!("krun_add_input_device"),
             set_control_socket: load_optional_sym!("krun_set_control_socket"),
             set_snapshot: load_optional_sym!("krun_set_snapshot"),
             create_disk_overlay: load_optional_sym!("krun_create_disk_overlay"),

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -18,7 +18,8 @@ use smolvm_network::{
     VirtioNetworkRuntime,
 };
 use smolvm_protocol::{guest_env, ports};
-use std::ffi::CString;
+use std::ffi::{c_void, CString};
+use std::mem::size_of_val;
 use std::os::fd::RawFd;
 use std::path::{Path, PathBuf};
 
@@ -164,6 +165,8 @@ pub struct LaunchFeatures {
     /// Additional disk images to attach to the VM (path, read_only, format).
     /// Appear as /dev/vdc, /dev/vdd, ... after the storage and overlay disks.
     pub extra_disks: Vec<(std::path::PathBuf, bool, DiskFormat)>,
+    /// Expose a native scanout and input bridge for this VM launch.
+    pub display: bool,
 }
 
 impl LaunchFeatures {
@@ -276,6 +279,8 @@ pub struct LaunchConfig<'a> {
     /// surface `egressBytes` in the machine info, the same per-VM-dir bridge the
     /// vsock/console paths use. `None` disables egress telemetry (e.g. TSI).
     pub egress_telemetry: Option<&'a Path>,
+    /// Mode-0600 Unix rendezvous socket used to obtain the loopback display endpoint.
+    pub display_socket: Option<&'a Path>,
 }
 
 /// Launch the agent VM using libkrun.
@@ -311,6 +316,7 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
         dns_filter_enabled,
         egress_refresh_hosts,
         egress_telemetry,
+        display_socket,
     } = config;
 
     crate::network::validate_requested_network_backend(resources, None, port_mappings.len())?;
@@ -386,8 +392,8 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
         // Enable GPU if requested (virgl for OpenGL + Venus for Vulkan via virtio-gpu).
         // Requires libkrun built with `gpu` feature and host virglrenderer.
         // On macOS, also requires MoltenVK (Vulkan → Metal translation).
-        if resources.gpu {
-            let virgl_flags = super::gpu_virgl_flags();
+        if resources.gpu || display_socket.is_some() {
+            let virgl_flags = super::gpu_virgl_flags(display_socket.is_some());
             // Size the GPU shared-memory region. Caller may override
             // via `--gpu-vram <MiB>` (CLI) or `gpu_vram = N` (Smolfile);
             // default is `DEFAULT_GPU_VRAM_MIB`.
@@ -418,6 +424,93 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
             }
             tracing::info!("GPU enabled (Venus/Vulkan via virtio-gpu)");
         }
+
+        // A display backend and input devices must be installed before
+        // krun_start_enter consumes the configuration context. The bridge stays
+        // alive on this stack for the VM process lifetime.
+        let _display_bridge = if let Some(endpoint_socket) = display_socket {
+            macro_rules! required_display_symbol {
+                ($symbol:expr, $name:literal) => {
+                    match $symbol {
+                        Some(symbol) => symbol,
+                        None => {
+                            krun_free_ctx(ctx);
+                            return Err(Error::agent(
+                                "configure display",
+                                concat!("libkrun does not expose ", $name),
+                            ));
+                        }
+                    }
+                };
+            }
+
+            let has_feature = required_display_symbol!(krun.has_feature, "krun_has_feature");
+            if has_feature(4) != 1 {
+                krun_free_ctx(ctx);
+                return Err(Error::agent(
+                    "configure display",
+                    "libkrun was built without INPUT=1",
+                ));
+            }
+            let add_display = required_display_symbol!(krun.add_display, "krun_add_display");
+            let set_display_backend =
+                required_display_symbol!(krun.set_display_backend, "krun_set_display_backend");
+            let add_input_device =
+                required_display_symbol!(krun.add_input_device, "krun_add_input_device");
+
+            let bridge = super::display::DisplayBridge::start(endpoint_socket)
+                .map_err(|error| Error::agent("start display bridge", error))?;
+            let display_id = add_display(
+                ctx,
+                super::display::DISPLAY_WIDTH,
+                super::display::DISPLAY_HEIGHT,
+            );
+            if display_id < 0 {
+                krun_free_ctx(ctx);
+                return Err(Error::agent(
+                    "configure display",
+                    format!("krun_add_display failed (ret={display_id})"),
+                ));
+            }
+
+            let display_backend = bridge.display_backend();
+            let result = set_display_backend(
+                ctx,
+                std::ptr::from_ref(&display_backend).cast::<c_void>(),
+                size_of_val(&display_backend),
+            );
+            if result < 0 {
+                krun_free_ctx(ctx);
+                return Err(Error::agent(
+                    "configure display",
+                    format!("krun_set_display_backend failed (ret={result})"),
+                ));
+            }
+
+            for (config_backend, events_backend) in [
+                (bridge.keyboard_config(), bridge.keyboard_events()),
+                (bridge.pointer_config(), bridge.pointer_events()),
+            ] {
+                let result = add_input_device(
+                    ctx,
+                    std::ptr::from_ref(&config_backend).cast::<c_void>(),
+                    size_of_val(&config_backend),
+                    std::ptr::from_ref(&events_backend).cast::<c_void>(),
+                    size_of_val(&events_backend),
+                );
+                if result < 0 {
+                    krun_free_ctx(ctx);
+                    return Err(Error::agent(
+                        "configure display input",
+                        format!("krun_add_input_device failed (ret={result})"),
+                    ));
+                }
+            }
+            tracing::info!(display_id, "native display and input enabled");
+            Some(bridge)
+        } else {
+            None
+        };
 
         // Helper: evaluate a fallible expression, freeing ctx if it fails.
         // Replaces bare `?` which would leak the libkrun context.
@@ -961,7 +1054,7 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
         // kernel lacks the driver; without this check the user sees
         // "VM started" and discovers missing GPU only when their
         // workload hits a rendering call.
-        if resources.gpu {
+        if resources.gpu || display_socket.is_some() {
             let gpu_env = format!("{}={}", guest_env::GPU, guest_env::VALUE_ON);
             if let Ok(cs) = CString::new(gpu_env) {
                 env_strings.push(cs);

--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -144,7 +144,7 @@ pub fn launch_agent_vm_dynamic(
     // Flag logic lives in super::gpu_virgl_flags() — see mod.rs for the full
     // explanation of each flag's purpose on Linux vs macOS.
     if config.resources.gpu {
-        let virgl_flags = super::gpu_virgl_flags();
+        let virgl_flags = super::gpu_virgl_flags(false);
         let vram_mib = config.resources.effective_gpu_vram_mib();
         let vram_bytes: u64 = (vram_mib as u64) * crate::data::consts::BYTES_PER_MIB;
 

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -9,6 +9,7 @@ use crate::process::{self, ChildProcess};
 use crate::storage::{DiskFormat, OverlayDisk, StorageDisk};
 use parking_lot::Mutex;
 use smolvm_protocol::AGENT_READY_MARKER;
+use std::os::unix::fs::PermissionsExt;
 use std::os::unix::process::CommandExt as _;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -1472,6 +1473,23 @@ impl AgentManager {
             .overlay_gib
             .unwrap_or(crate::storage::DEFAULT_OVERLAY_SIZE_GIB);
 
+        let display_socket = if features.display {
+            let runtime_dir = self
+                .vsock_socket
+                .parent()
+                .unwrap_or_else(|| std::path::Path::new("/tmp"))
+                .join("display-runtime");
+            std::fs::create_dir_all(&runtime_dir)
+                .map_err(|e| Error::agent("create display runtime", e.to_string()))?;
+            std::fs::set_permissions(&runtime_dir, std::fs::Permissions::from_mode(0o700))
+                .map_err(|e| Error::agent("secure display runtime", e.to_string()))?;
+            let socket = runtime_dir.join("endpoint.sock");
+            let _ = std::fs::remove_file(&socket);
+            Some(socket)
+        } else {
+            None
+        };
+
         // Write boot config to a file the subprocess will read
         let config = BootConfig {
             rootfs_path: self.rootfs_path.clone(),
@@ -1489,6 +1507,7 @@ impl AgentManager {
             dns_filter_hosts: features.dns_filter_hosts,
             packed_layers_dir: features.packed_layers_dir,
             extra_disks: features.extra_disks,
+            display_socket,
         };
         let config_path = self
             .storage_disk
@@ -1716,6 +1735,18 @@ impl AgentManager {
             if let Err(e) = std::fs::remove_file(path) {
                 if e.kind() != std::io::ErrorKind::NotFound {
                     tracing::debug!(error = %e, path = %path.display(), "failed to remove marker file");
+                }
+            }
+        }
+        if let Some(parent) = self.vsock_socket.parent() {
+            let runtime_dir = parent.join("display-runtime");
+            if let Err(error) = std::fs::remove_dir_all(&runtime_dir) {
+                if error.kind() != std::io::ErrorKind::NotFound {
+                    tracing::debug!(
+                        %error,
+                        path = %runtime_dir.display(),
+                        "failed to remove display runtime"
+                    );
                 }
             }
         }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod boot_config;
 mod client;
+pub mod display;
 mod krun;
 mod launcher;
 pub mod launcher_dynamic;
@@ -49,13 +50,13 @@ pub const AGENT_VM_NAME: &str = "smolvm-agent";
 ///             in-process Venus which fails (version stays 0).  With get_server_fd
 ///             provided in the callbacks struct, virglrenderer uses the externally
 ///             spawned virgl_render_server instead of fork/exec-ing its own process.
-fn gpu_virgl_flags() -> u32 {
+fn gpu_virgl_flags(software_display: bool) -> u32 {
     #[cfg(target_os = "linux")]
     {
-        (1 << 0) | (1 << 3) | (1 << 6) | (1 << 9)
+        (1 << 0) | (1 << 3) | (1 << 6) | (1 << 9) | if software_display { 1 << 31 } else { 0 }
     }
     #[cfg(not(target_os = "linux"))]
     {
-        (1 << 6) | (1 << 7)
+        (1 << 6) | (1 << 7) | if software_display { 1 << 31 } else { 0 }
     }
 }

--- a/src/cli/internal_boot.rs
+++ b/src/cli/internal_boot.rs
@@ -376,6 +376,7 @@ pub fn run(config_path: PathBuf) -> smolvm::Result<()> {
             .as_ref()
             .is_some_and(|hosts| !hosts.is_empty()),
         egress_refresh_hosts: config.dns_filter_hosts.clone(),
+        display_socket: config.display_socket.as_deref(),
     });
 
     // If we get here, launch_agent_vm returned (should only happen on error)

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -188,6 +188,9 @@ pub enum MachineCmd {
     /// Start a machine
     Start(StartCmd),
 
+    /// Read the live native-display endpoint without starting the machine
+    Display(DisplayCmd),
+
     /// Fork a running forkable machine into a new clone (CoW memory + disks)
     Fork(ForkCmd),
 
@@ -255,6 +258,7 @@ impl MachineCmd {
             MachineCmd::Exec(cmd) => cmd.run(),
             MachineCmd::Create(cmd) => cmd.run(),
             MachineCmd::Start(cmd) => cmd.run(),
+            MachineCmd::Display(cmd) => cmd.run(),
             MachineCmd::Fork(cmd) => cmd.run(),
             MachineCmd::Stop(cmd) => cmd.run(),
             MachineCmd::Delete(cmd) => cmd.run(),
@@ -1033,6 +1037,7 @@ impl RunCmd {
             dns_filter_hosts: params.dns_filter_hosts.clone(),
             packed_layers_dir,
             extra_disks: Vec::new(),
+            display: false,
         };
 
         let freshly_started = manager
@@ -1640,6 +1645,20 @@ mod tests {
         // the old `machine create myvm` habit — must error, not be silently
         // captured as the workload command.
         assert!(TestMachineCli::try_parse_from(["machine", "create", "myvm"]).is_err());
+    }
+
+    #[test]
+    fn start_parses_display_for_named_and_default_machine() {
+        for arguments in [
+            vec!["machine", "start", "--display"],
+            vec!["machine", "start", "--name", "gui", "--display"],
+        ] {
+            let cli = TestMachineCli::parse_from(arguments);
+            let MachineCmd::Start(command) = cli.command else {
+                panic!("expected machine start command");
+            };
+            assert!(command.display);
+        }
     }
 
     #[test]
@@ -2419,6 +2438,10 @@ pub struct StartCmd {
     #[arg(long)]
     pub forkable: bool,
 
+    /// Start with a native display and keyboard/pointer input bridge.
+    #[arg(long)]
+    pub display: bool,
+
     #[command(flatten, next_help_heading = "Network")]
     pub proxy_opts: crate::cli::proxy_opts::ProxyOpts,
 }
@@ -2435,15 +2458,58 @@ impl StartCmd {
             // so `machine fork` can later freeze this machine as a CoW base.
             vm_common::enable_forkable_env(&name);
         }
-        match vm_common::start_vm_named(&name, proxy, no_proxy, /* from_snapshot */ false) {
-            Ok(()) => Ok(()),
-            Err(smolvm::Error::VmNotFound { .. }) if !explicit_name => {
-                // Only fall back to creating a default VM when no --name was given.
-                // With an explicit --name, VmNotFound is a real error.
-                vm_common::start_vm_default(proxy, no_proxy)
-            }
-            Err(e) => Err(e),
+        let previous_display = self
+            .display
+            .then(|| std::env::var_os(smolvm::agent::display::DISPLAY_ENV));
+        if self.display {
+            std::env::set_var(smolvm::agent::display::DISPLAY_ENV, "1");
         }
+        let result =
+            match vm_common::start_vm_named(&name, proxy, no_proxy, /* from_snapshot */ false) {
+                Ok(()) => Ok(()),
+                Err(smolvm::Error::VmNotFound { .. }) if !explicit_name => {
+                    // Only fall back to creating a default VM when no --name was given.
+                    // With an explicit --name, VmNotFound is a real error.
+                    vm_common::start_vm_default(proxy, no_proxy, self.display)
+                }
+                Err(e) => Err(e),
+            };
+        if let Some(previous_display) = previous_display {
+            match previous_display {
+                Some(value) => std::env::set_var(smolvm::agent::display::DISPLAY_ENV, value),
+                None => std::env::remove_var(smolvm::agent::display::DISPLAY_ENV),
+            }
+        }
+        result
+    }
+}
+
+/// Read a running machine's native-display endpoint.
+#[derive(Args, Debug)]
+pub struct DisplayCmd {
+    /// Running machine name.
+    #[arg(short = 'n', long, value_name = "NAME")]
+    pub name: String,
+
+    /// Print the credential-bearing endpoint as JSON for a local client.
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl DisplayCmd {
+    pub fn run(self) -> smolvm::Result<()> {
+        let endpoint = smolvm::agent::display::read_endpoint(&self.name)
+            .map_err(|error| smolvm::Error::agent("read display endpoint", error))?;
+        if self.json {
+            let output = serde_json::to_string(&endpoint).map_err(|error| {
+                smolvm::Error::agent("encode display endpoint", error.to_string())
+            })?;
+            println!("{output}");
+        } else {
+            println!("Display ready on {}:{}", endpoint.host, endpoint.port);
+            println!("Use --json to retrieve credentials for a local display client.");
+        }
+        Ok(())
     }
 }
 

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -663,16 +663,19 @@ pub fn enable_forkable_env(name: &str) {
 }
 
 /// Send a single line command to a VM control socket and return its reply line.
-fn control_socket_cmd(sock: &std::path::Path, cmd: &str) -> smolvm::Result<String> {
+fn control_socket_cmd_with_timeout(
+    sock: &std::path::Path,
+    cmd: &str,
+    timeout: std::time::Duration,
+) -> smolvm::Result<String> {
     use smolvm::Error;
     use std::io::{Read, Write};
     use std::os::unix::net::UnixStream;
 
     let mut stream = UnixStream::connect(sock)
         .map_err(|e| Error::agent("connect control socket", e.to_string()))?;
-    stream
-        .set_read_timeout(Some(std::time::Duration::from_secs(60)))
-        .ok();
+    stream.set_read_timeout(Some(timeout)).ok();
+    stream.set_write_timeout(Some(timeout)).ok();
     stream
         .write_all(format!("{cmd}\n").as_bytes())
         .map_err(|e| Error::agent("write control socket", e.to_string()))?;
@@ -691,6 +694,29 @@ fn control_socket_cmd(sock: &std::path::Path, cmd: &str) -> smolvm::Result<Strin
         }
     }
     Ok(reply)
+}
+
+fn control_socket_cmd(sock: &std::path::Path, cmd: &str) -> smolvm::Result<String> {
+    control_socket_cmd_with_timeout(sock, cmd, std::time::Duration::from_secs(60))
+}
+
+fn fork_base_state_from_status(status: &str) -> Option<&'static str> {
+    match status.trim() {
+        "OK running" => Some("running"),
+        "OK paused" => Some("frozen"),
+        _ => None,
+    }
+}
+
+fn probe_fork_base_state(name: &str) -> Option<&'static str> {
+    let socket = control_socket_path(name);
+    if !socket.exists() {
+        return None;
+    }
+    let status =
+        control_socket_cmd_with_timeout(&socket, "STATUS", std::time::Duration::from_millis(250))
+            .ok()?;
+    fork_base_state_from_status(&status)
 }
 
 /// Fork a running, forkable `golden` machine into a new `clone`.
@@ -1008,6 +1034,14 @@ pub fn start_vm_named(
     // `exec` failed.
     match smolvm::agent::state_probe::resolve_state(name, &record) {
         RecordState::Running => {
+            if std::env::var_os(smolvm::agent::display::DISPLAY_ENV).is_some()
+                && !smolvm::agent::display::endpoint_is_ready(name)
+            {
+                return Err(Error::agent(
+                    "start machine with display",
+                    "machine is already running without a display; stop it before starting with --display",
+                ));
+            }
             let pid_suffix = format_pid_suffix(record.pid);
             println!("Machine '{}' already running{}", name, pid_suffix);
             return Ok(());
@@ -1098,6 +1132,7 @@ pub fn start_vm_named(
     let mut features = smolvm::agent::LaunchFeatures {
         ssh_agent_socket,
         dns_filter_hosts: record.dns_filter_hosts.clone(),
+        display: std::env::var_os(smolvm::agent::display::DISPLAY_ENV).is_some(),
         ..Default::default()
     }
     .with_packed_layers(
@@ -1421,10 +1456,20 @@ fn check_port_conflicts(
 }
 
 /// Start the default machine.
-pub fn start_vm_default(proxy: Option<&str>, no_proxy: Option<&str>) -> smolvm::Result<()> {
+pub fn start_vm_default(
+    proxy: Option<&str>,
+    no_proxy: Option<&str>,
+    display: bool,
+) -> smolvm::Result<()> {
     let manager = AgentManager::new_default()?;
 
     if manager.try_connect_existing().is_some() {
+        if display && !smolvm::agent::display::endpoint_is_ready("default") {
+            return Err(smolvm::Error::agent(
+                "start machine with display",
+                "machine is already running without a display; stop it before starting with --display",
+            ));
+        }
         let pid_suffix = format_pid_suffix(manager.child_pid());
         println!("Machine 'default' already running{}", pid_suffix);
         manager.detach();
@@ -1437,7 +1482,15 @@ pub fn start_vm_default(proxy: Option<&str>, no_proxy: Option<&str>) -> smolvm::
     cli_recover_if_unreachable("default");
 
     eprintln!("Starting machine 'default'...");
-    manager.ensure_running()?;
+    manager.ensure_running_with_full_config(
+        Vec::new(),
+        Vec::new(),
+        smolvm::data::resources::VmResources::default(),
+        smolvm::agent::LaunchFeatures {
+            display,
+            ..Default::default()
+        },
+    )?;
 
     let mut config = SmolvmConfig::load()?;
     persist_named_running(&mut config, "default", manager.child_pid(), None)?;
@@ -1782,7 +1835,11 @@ where
 
 /// Build the per-machine JSON object shared by `machine list --json` and
 /// `machine status --json` so the two outputs never drift apart.
-fn machine_status_json(name: &str, record: &VmRecord) -> serde_json::Value {
+fn machine_status_json(
+    name: &str,
+    record: &VmRecord,
+    dependent_clones: &[String],
+) -> serde_json::Value {
     // Resolve via vsock probe so the JSON reflects truth (Unreachable vs
     // Running) instead of trusting the PID-only check.
     let actual_state = smolvm::agent::state_probe::resolve_state(name, record);
@@ -1796,6 +1853,7 @@ fn machine_status_json(name: &str, record: &VmRecord) -> serde_json::Value {
             argv.join(" ")
         }
     });
+    let fork_base_state = probe_fork_base_state(name);
 
     let mut obj = serde_json::json!({
         "name": name,
@@ -1814,6 +1872,12 @@ fn machine_status_json(name: &str, record: &VmRecord) -> serde_json::Value {
         "ephemeral": record.ephemeral,
         "gpu": record.gpu.unwrap_or(false),
         "gpu_vram_mib": record.gpu_vram_mib,
+        "display_ready": actual_state == RecordState::Running
+            && smolvm::agent::display::endpoint_is_ready(name),
+        "forkable": fork_base_state.is_some(),
+        "fork_base_state": fork_base_state,
+        "golden": record.golden,
+        "dependent_clones": dependent_clones,
         "restart_policy": record.restart.policy.to_string(),
         "restart_max_retries": record.restart.max_retries,
         "restart_count": record.restart.restart_count,
@@ -1836,8 +1900,14 @@ pub fn status_vm_json(name: &Option<String>) -> smolvm::Result<()> {
     let config = SmolvmConfig::load()?;
     // Build the owned JSON value inside the match so the borrow of `config`
     // ends before `config` is dropped.
-    let obj = match config.list_vms().find(|(n, _)| *n == &label) {
-        Some((_, record)) => machine_status_json(&label, record),
+    let vms: Vec<_> = config.list_vms().collect();
+    let dependent_clones = vms
+        .iter()
+        .filter(|(_, candidate)| candidate.golden.as_deref() == Some(label.as_str()))
+        .map(|(name, _)| (*name).clone())
+        .collect::<Vec<_>>();
+    let obj = match vms.iter().find(|(name, _)| *name == &label) {
+        Some((_, record)) => machine_status_json(&label, record, &dependent_clones),
         None => {
             return Err(smolvm::Error::config(
                 "machine status",
@@ -1874,7 +1944,14 @@ pub fn list_vms(verbose: bool, json: bool) -> smolvm::Result<()> {
     if json {
         let json_vms: Vec<_> = vms
             .iter()
-            .map(|(name, record)| machine_status_json(name, record))
+            .map(|(name, record)| {
+                let dependent_clones = vms
+                    .iter()
+                    .filter(|(_, candidate)| candidate.golden.as_deref() == Some(name.as_str()))
+                    .map(|(clone_name, _)| (*clone_name).clone())
+                    .collect::<Vec<_>>();
+                machine_status_json(name, record, &dependent_clones)
+            })
             .collect();
         let json = serde_json::to_string_pretty(&json_vms)
             .map_err(|e| smolvm::Error::config("serialize json", e.to_string()))?;
@@ -2505,5 +2582,13 @@ mod init_runner_tests {
                 ("BAZ".to_string(), "from-cli".to_string()),
             ]
         );
+    }
+
+    #[test]
+    fn fork_base_status_maps_only_healthy_control_states() {
+        assert_eq!(fork_base_state_from_status("OK running\n"), Some("running"));
+        assert_eq!(fork_base_state_from_status("OK paused\n"), Some("frozen"));
+        assert_eq!(fork_base_state_from_status("ERR EIO unavailable\n"), None);
+        assert_eq!(fork_base_state_from_status("OK stopped\n"), None);
     }
 }


### PR DESCRIPTION
## Summary

Adds an opt-in native display path for persistent SmolVM machines and a graphical guest fixture for end-to-end validation.

The new path is intentionally launch-scoped: a display must be requested before libkrun starts, using `smolvm machine start --name NAME --display`. Display metadata stays non-secret in inventory through `display_ready`, while credentials are fetched only through `smolvm machine display --name NAME --json` over a same-user local rendezvous path.

## Scope

- Adds host-side display transport in `src/agent/display.rs` using libkrun framebuffer/input callbacks and a loopback password-protected RFB server.
- Adds `--display` to the persistent machine start path and `machine display --json` for credential-bearing endpoint retrieval.
- Extends machine JSON with `display_ready` so clients can advertise display capability without probing private runtime files.
- Updates the guest agent/rootfs path to surface virtual input devices and runtime udev/libinput metadata for graphical workloads.
- Bundles updated libkrun/libkrunfw artifacts with GPU/input support and updates the display helper wrapper/build packaging path.
- Adds `docs/native-display.md` plus a Debian/Weston graphical fixture under `examples/weston-desktop/`.

## Client Contract

This is the fork Local Machines consumes through its separate helper path:

```text
~/.local/share/local-machines/smolvm-display/smolvm
```

The stock `~/.local/bin/smolvm` remains truthfully headless. Local Machines only offers Display when all of these are true:

- the display-aware helper is installed,
- the row is a persistent running machine,
- inventory reports `display_ready: true`,
- `machine display --json` returns a safe loopback VNC endpoint.

## Validation Notes

The acceptance path is documented in `docs/native-display.md`. The key checks are:

- libkrun reports GPU and INPUT support,
- a graphical guest sees `/dev/dri`, `/dev/input`, `/run/udev/data`, and seatd,
- `machine ls --json` exposes only `display_ready`, not port/password,
- `machine display --json` returns a same-user loopback VNC endpoint without starting or repairing the VM,
- a client receives changing non-black frames and can inject keyboard/pointer input,
- stopping the VM removes the endpoint and listener.

## Notes

This branch is based on upstream `v1.2.4` and contains one commit: `767767d Add secure native display and graphical guests`.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/480">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->