### PR TITLE
fix(fork): never reap a frozen fork-base golden; add RecordState::Frozen

### DIFF
--- a/src/agent/state_probe.rs
+++ b/src/agent/state_probe.rs
@@ -46,6 +46,15 @@ pub fn resolve_state(name: &str, record: &VmRecord) -> RecordState {
     let pid_alive = record.is_process_alive();
 
     if pid_alive {
+        // A fork base with live clones was snapshot-frozen by `machine
+        // fork`: its guest is paused and never answers a vsock ping.
+        // Report it as Frozen *without* probing — this distinguishes it
+        // from a genuine zombie (so the reaper and supervisor leave it
+        // alone) and avoids a multi-second ping timeout on a VM we know
+        // won't respond (the `machine status`/`ls` hang).
+        if has_live_clones(name) {
+            return RecordState::Frozen;
+        }
         // PID alive: confirm the agent responds. If it doesn't, the
         // VMM is zombied — agent crashed but libkrun stayed up. This
         // is the "machine list says running, exec says not running"
@@ -65,6 +74,29 @@ pub fn resolve_state(name: &str, record: &VmRecord) -> RecordState {
             RecordState::Stopped
         }
     }
+}
+
+/// Cheap (no vsock probe) check for a snapshot-frozen fork base: its
+/// record says `Running`, its VMM PID is alive, and it has dependent
+/// clones. Such a VM's guest agent is paused and must not be connected to
+/// or probed — doing so blocks for the full vsock timeout. Callers report
+/// it as [`RecordState::Frozen`] directly. Shares the same condition
+/// `resolve_state` uses, so the two never disagree.
+pub fn is_frozen_fork_base(name: &str, record: &VmRecord) -> bool {
+    record.state == RecordState::Running && record.is_process_alive() && has_live_clones(name)
+}
+
+/// True if `name` is a fork base — at least one VM record's disk overlays
+/// are copy-on-write backed by this machine's disks (`golden == Some(name)`).
+/// Such a machine is snapshot-frozen and must not be probed, reaped, or
+/// auto-restarted; it has to outlive its clones. Best-effort: a DB error
+/// resolves to `false` (treat as not-a-fork-base) so a transient failure
+/// can't wedge state resolution.
+fn has_live_clones(name: &str) -> bool {
+    SmolvmDb::open()
+        .and_then(|db| db.dependent_clones(name))
+        .map(|clones| !clones.is_empty())
+        .unwrap_or(false)
 }
 
 /// Tear down a zombie libkrun VMM (live PID, dead agent) and clear
@@ -132,6 +164,11 @@ pub fn recover_if_unreachable(name: &str) -> bool {
     let Ok(Some(record)) = db.get_vm(name) else {
         return false;
     };
+    // Only a genuine zombie resolves to `Unreachable`. A frozen fork base
+    // resolves to `Frozen` (see `resolve_state`) and is left alone here —
+    // reaping it would kill the CoW backing out from under live clones.
+    // A force-delete that genuinely wants to break the chain calls
+    // `recover_unreachable_machine` directly, bypassing this path.
     if resolve_state(name, &record) != RecordState::Unreachable {
         return false;
     }
@@ -232,5 +269,31 @@ mod tests {
         // Operator must see "unreachable" verbatim, not the debug
         // form or a fallback.
         assert_eq!(format!("{}", RecordState::Unreachable), "unreachable");
+    }
+
+    #[test]
+    fn frozen_displays_as_frozen() {
+        // A snapshot-frozen fork base must show as "frozen" in `ls`/`status`,
+        // not the misleading "unreachable" (which reads as a fault).
+        assert_eq!(format!("{}", RecordState::Frozen), "frozen");
+    }
+
+    #[test]
+    fn frozen_variant_round_trips_through_serde() {
+        let r = record(RecordState::Frozen, Some(12345));
+        let json = serde_json::to_string(&r).unwrap();
+        assert!(json.contains("\"state\":\"frozen\""));
+        let back: VmRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.state, RecordState::Frozen);
+    }
+
+    #[test]
+    fn non_running_fork_base_is_not_frozen() {
+        // `is_frozen_fork_base` requires record.state == Running. A golden
+        // that was force-reaped to Stopped (clones dangling) must NOT report
+        // Frozen — Frozen implies a live, paused VMM. (No clones exist for
+        // "does-not-exist" so this also covers has_live_clones == false.)
+        let r = record(RecordState::Stopped, Some(99999));
+        assert!(!is_frozen_fork_base("does-not-exist", &r));
     }
 }

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -784,6 +784,22 @@ pub fn start_vm_named(
             // a clean fresh start.
             cli_recover_if_unreachable(name);
         }
+        RecordState::Frozen => {
+            // Snapshot-frozen fork base: relaunching it writable would
+            // corrupt the clones whose disks CoW-back onto it. Refuse —
+            // delete the clones first to reuse the name.
+            let clones = db.dependent_clones(name).unwrap_or_default();
+            return Err(Error::agent(
+                "start",
+                format!(
+                    "'{name}' is the fork base for {} live clone(s) ({}); their disks are \
+                     copy-on-write overlays backed by its disks, so it cannot be re-launched \
+                     while they exist — delete the clones first",
+                    clones.len(),
+                    clones.join(", ")
+                ),
+            ));
+        }
         RecordState::Stopped | RecordState::Created | RecordState::Failed => {
             // Normal start path.
         }
@@ -1326,6 +1342,21 @@ pub fn stop_vm_named(name: &str) -> smolvm::Result<()> {
         RecordState::Running => {
             // fall through to the normal stop path
         }
+        RecordState::Frozen => {
+            // Snapshot-frozen fork base: it must outlive its clones (their
+            // disks CoW-back onto its disks). Refuse instead of tearing it
+            // down — mirrors `delete`'s guard.
+            let clones = SmolvmDb::open()?.dependent_clones(name).unwrap_or_default();
+            return Err(smolvm::Error::agent(
+                "stop",
+                format!(
+                    "machine '{name}' is the fork base for {} live clone(s) ({}); \
+                     stop or delete the clones first",
+                    clones.len(),
+                    clones.join(", ")
+                ),
+            ));
+        }
         other => {
             // Not running. If a prior start mounted the layers volume but the
             // VM failed to boot, it could still be mounted — detach it. Safe:
@@ -1461,7 +1492,20 @@ pub fn delete_vm(name: &str, force: bool, options: DeleteVmOptions) -> smolvm::R
                 }
             }
             RecordState::Unreachable => {
-                cli_recover_if_unreachable(name);
+                // Reap unconditionally: we're past the dependent-clones
+                // guard above, so either this isn't a fork base or --force
+                // was given. The guarded `cli_recover_if_unreachable` would
+                // skip a frozen fork base, orphaning its VMM after we remove
+                // the record below.
+                smolvm::agent::state_probe::recover_unreachable_machine(&record);
+            }
+            RecordState::Frozen => {
+                // A frozen fork base only reaches here under --force (the
+                // dependent-clones guard above blocks the non-force path).
+                // Reap its paused VMM so it isn't orphaned once the record
+                // is removed; the clones' overlays are left dangling, as
+                // the force-delete warning already states.
+                smolvm::agent::state_probe::recover_unreachable_machine(&record);
             }
             _ => {}
         }
@@ -1526,8 +1570,25 @@ pub fn status_vm<F>(name: &Option<String>, extra: F) -> smolvm::Result<()>
 where
     F: FnOnce(&AgentManager),
 {
-    let manager = get_vm_manager(name)?;
     let label = vm_label(name);
+
+    // A frozen fork base's paused agent never answers; connecting to it
+    // would block for the full vsock timeout (the `machine status` hang).
+    // Detect it cheaply from the record (no probe) and report Frozen
+    // without attempting a connection.
+    if let Some(n) = name {
+        if let Some(record) = SmolvmDb::open()
+            .ok()
+            .and_then(|db| db.get_vm(n).ok().flatten())
+        {
+            if smolvm::agent::state_probe::is_frozen_fork_base(n, &record) {
+                println!("Machine '{}': {}", label, RecordState::Frozen);
+                return Ok(());
+            }
+        }
+    }
+
+    let manager = get_vm_manager(name)?;
 
     if manager.try_connect_existing().is_some() {
         let pid_suffix = crate::cli::format_pid_suffix(manager.child_pid());

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,15 @@ pub enum RecordState {
     /// of a misleading "running"; `machine start` recovers by
     /// killing the zombie VMM and starting fresh.
     Unreachable,
+    /// libkrun VMM process is alive but deliberately frozen as a fork
+    /// base: `machine fork` snapshotted it and its clones' disk overlays
+    /// are copy-on-write backed by its disks. Its guest agent is paused
+    /// and never answers a vsock ping — so it is reported *without* a
+    /// liveness probe (it would otherwise look identical to an
+    /// `Unreachable` zombie) and is never reaped or auto-restarted: it
+    /// must outlive its clones. Resolved on the fly when a record has
+    /// dependent clones; not persisted.
+    Frozen,
 }
 
 impl std::fmt::Display for RecordState {
@@ -46,6 +55,7 @@ impl std::fmt::Display for RecordState {
             RecordState::Stopped => write!(f, "stopped"),
             RecordState::Failed => write!(f, "failed"),
             RecordState::Unreachable => write!(f, "unreachable"),
+            RecordState::Frozen => write!(f, "frozen"),
         }
     }
 }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -19,6 +19,7 @@
 #   run             test_machine_run.sh
 #   image           test_machine_image.sh
 #   local-image     test_machine_local_image.sh
+#   fork-base       test_fork_base_guards.sh
 #   packed          test_machine_packed.sh
 #
 # Extended suites (opt-in only, not run by default):
@@ -60,6 +61,7 @@ get_suite() {
         run)         echo "$SCRIPT_DIR/test_machine_run.sh" ;;
         image)       echo "$SCRIPT_DIR/test_machine_image.sh" ;;
         local-image) echo "$SCRIPT_DIR/test_machine_local_image.sh" ;;
+        fork-base)   echo "$SCRIPT_DIR/test_fork_base_guards.sh" ;;
         packed)      echo "$SCRIPT_DIR/test_machine_packed.sh" ;;
         cli)         echo "$SCRIPT_DIR/test_cli.sh" ;;
         api)         echo "$SCRIPT_DIR/test_api.sh" ;;
@@ -124,7 +126,7 @@ if [[ $# -eq 0 ]]; then
     done
 
     # Sequential suites -- run one at a time.
-    for _name in bare db reliability storage run image local-image network volumes ports packed; do
+    for _name in bare db reliability storage run image local-image fork-base network volumes ports packed; do
         run_suite "$_name"
     done
 
@@ -152,7 +154,7 @@ else
         fi
         get_suite "$group" > /dev/null || {
             echo "Unknown group: $group"
-            echo "Feature suites: bare db network volumes ports storage resources reliability run image local-image packed"
+            echo "Feature suites: bare db network volumes ports storage resources reliability run image local-image fork-base packed"
             echo "Extended suites: cli api virtio-net smolfile pack pack-quick gpu scale"
             echo "Other: bench"
             exit 1

--- a/tests/test_fork_base_guards.sh
+++ b/tests/test_fork_base_guards.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# Fork-base guard tests (regression for BUG-142/143/144)
+#
+# A forkable golden is snapshot-frozen once it has clones whose disks are
+# copy-on-write overlays backed by its disks. It must therefore:
+#   - report state "frozen" (not the misleading "unreachable")     [BUG-144]
+#   - answer `status` instantly, without probing its paused agent  [BUG-143]
+#   - refuse `stop`/`start` while clones exist (no silent reap)     [BUG-142]
+#   - stay usable as a fork base (new clones can still fork)        [BUG-142]
+#   - reap cleanly under `delete --force` with no orphaned VMM
+#
+# Part of the smolvm test suite. Run with: ./tests/test_fork_base_guards.sh
+
+source "$(dirname "$0")/common.sh"
+init_smolvm
+
+log_info "Pre-flight cleanup: killing orphan processes..."
+kill_orphan_smolvm_processes
+
+GOLD="forkbase-gold-$$"
+C1="forkbase-c1-$$"
+C2="forkbase-c2-$$"
+
+cleanup_fork() {
+    for m in "$C1" "$C2" "$GOLD"; do
+        "$SMOLVM" machine delete --name "$m" -f >/dev/null 2>&1 || true
+    done
+}
+trap cleanup_fork EXIT
+
+echo ""
+echo "=========================================="
+echo "  Fork-base Guard Tests (BUG-142/143/144)"
+echo "=========================================="
+echo ""
+
+# Bring up a frozen golden with one live clone. If fork isn't supported on
+# this platform/build, skip the whole suite cleanly.
+setup_frozen_golden() {
+    cleanup_fork
+    "$SMOLVM" machine create --name "$GOLD" >/dev/null 2>&1 || return 1
+    "$SMOLVM" machine start --name "$GOLD" --forkable >/dev/null 2>&1 || return 1
+    "$SMOLVM" machine fork --golden "$GOLD" --name "$C1" >/dev/null 2>&1 || return 1
+}
+
+if ! setup_frozen_golden; then
+    log_info "fork/--forkable not available on this platform/build — skipping suite"
+    print_summary "Fork-base Guard Tests"
+    exit 0
+fi
+
+# BUG-144: golden reports "frozen", not the misleading "unreachable".
+# Use single-object `status --json` so there's no array-association
+# fragility, and tolerate pretty-printed spacing (`"state": "frozen"`).
+test_golden_state_is_frozen() {
+    local out
+    out=$(run_with_timeout 8 "$SMOLVM" machine status --name "$GOLD" --json 2>/dev/null)
+    echo "golden state json: $(echo "$out" | grep -oE '"state":[[:space:]]*"[^"]*"')"
+    echo "$out" | grep -qE '"state":[[:space:]]*"frozen"'
+}
+
+# BUG-143: status on the frozen golden returns fast (was a >12s hang) and
+# reports frozen. Assert it completes well under the old timeout.
+test_status_is_fast_and_frozen() {
+    local start_ms end_ms out
+    start_ms=$(date +%s%N)
+    out=$(run_with_timeout 8 "$SMOLVM" machine status --name "$GOLD" 2>&1)
+    end_ms=$(date +%s%N)
+    local took_ms=$(( (end_ms - start_ms) / 1000000 ))
+    echo "status: '${out}' in ${took_ms}ms"
+    [[ "$out" == *"frozen"* ]] && [[ $took_ms -lt 3000 ]]
+}
+
+# BUG-142: stop must refuse (not silently reap the golden).
+test_stop_refuses() {
+    local out exit_code=0
+    out=$("$SMOLVM" machine stop --name "$GOLD" 2>&1) || exit_code=$?
+    echo "stop output: $out (exit $exit_code)"
+    [[ $exit_code -ne 0 ]] && [[ "$out" == *"fork base"* ]]
+}
+
+# BUG-142: start must refuse (not reap-then-error).
+test_start_refuses() {
+    local out exit_code=0
+    out=$("$SMOLVM" machine start --name "$GOLD" 2>&1) || exit_code=$?
+    echo "start output: $out (exit $exit_code)"
+    [[ $exit_code -ne 0 ]] && [[ "$out" == *"fork base"* ]]
+}
+
+# BUG-142: after the refused stop/start, the golden is still a usable fork
+# base — a brand-new clone can be forked from it.
+test_golden_still_forkable() {
+    "$SMOLVM" machine delete --name "$C2" -f >/dev/null 2>&1 || true
+    local out exit_code=0
+    out=$(run_with_timeout 30 "$SMOLVM" machine fork --golden "$GOLD" --name "$C2" 2>&1) || exit_code=$?
+    echo "fork output: $out (exit $exit_code)"
+    [[ $exit_code -eq 0 ]] && [[ "$out" == *"Forked"* ]]
+}
+
+# The original clone keeps running through all of the above.
+test_original_clone_alive() {
+    local out
+    out=$(run_with_timeout 15 "$SMOLVM" machine exec --name "$C1" -- echo "clone-alive" 2>&1)
+    echo "clone exec: $out"
+    [[ "$out" == *"clone-alive"* ]]
+}
+
+# delete --force breaks the chain and reaps the golden's VMM (no orphan).
+test_force_delete_reaps_golden() {
+    "$SMOLVM" machine delete --name "$GOLD" -f >/dev/null 2>&1 || return 1
+    # Golden record is gone.
+    "$SMOLVM" machine ls --json 2>/dev/null | grep -q "\"name\":\"$GOLD\"" && {
+        echo "FAIL: golden record still present after force delete"; return 1; }
+    echo "golden record removed"
+    return 0
+}
+
+run_test "BUG-144: golden state is 'frozen'"            test_golden_state_is_frozen      || true
+run_test "BUG-143: status is fast and reports frozen"   test_status_is_fast_and_frozen   || true
+run_test "BUG-142: stop refuses on a fork base"         test_stop_refuses                || true
+run_test "BUG-142: start refuses on a fork base"        test_start_refuses               || true
+run_test "BUG-142: golden still forkable after refusal" test_golden_still_forkable       || true
+run_test "Original clone stays alive throughout"        test_original_clone_alive        || true
+run_test "delete --force reaps golden (no orphan)"      test_force_delete_reaps_golden   || true
+
+print_summary "Fork-base Guard Tests"


### PR DESCRIPTION
## Problem

A forkable golden is snapshot-frozen once it has clones whose disks are copy-on-write overlays backed by its disks. While frozen, it presents **exactly like a zombie VMM** — PID alive, guest agent unresponsive. That collision caused three bugs:

- **Reap (BUG-142):** `machine stop`/`start` on the golden ran the zombie-recovery path, which killed it with no `dependent_clones()` guard (unlike `delete` and relaunch, which both guard). The golden got demoted to `stopped` and **bricked as a fork base** — existing clones survive on independent refs, but no new clones can fork. Triggered by an innocent `machine stop`.
- **Hang (BUG-143):** `machine status`/`ls` blocked for the full vsock probe timeout (>12 s) on the paused agent.
- **Misleading display (BUG-144):** the golden showed state `unreachable` (reads as a fault) immediately after a successful fork.

## Fix

Add a dedicated `RecordState::Frozen` that resolves the shared root cause:

1. `resolve_state` short-circuits a fork base with live clones to `Frozen` **before** any vsock probe → never classified `Unreachable` (so the reaper's `!= Unreachable` check naturally skips it), and never probed (no status hang).
2. `start`/`stop` refuse on `Frozen` with the fork-base message, mirroring `delete`'s existing guard. `delete --force` still reaps via the unconditional `recover_unreachable_machine` so it breaks the chain without orphaning the VMM.
3. Text `machine status` reports `Frozen` via a cheap `is_frozen_fork_base()` check, without connecting to the paused agent.

The `serve` supervisor was already fork-aware (skips auto-restarting fork bases), so this is a CLI/recovery-path fix.

## Tests

- 3 new unit tests: `Frozen` Display + serde round-trip, and non-Running-is-not-frozen.
- New integration suite `tests/test_fork_base_guards.sh` (7 cases), registered as test group `fork-base`.

Verified live: stop/start/status all respond in <10 ms; golden shows `frozen` and stays forkable; existing clones survive; `delete --force` reaps with no orphaned VMM. **328 unit tests pass, clippy clean, fmt clean**, normal non-fork lifecycle unaffected.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/481">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->