### PR TITLE
Windows parity: virtio-net networking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2250,7 +2250,6 @@ version = "1.2.5"
 dependencies = [
  "crossbeam-queue",
  "humantime",
- "libc",
  "polling",
  "smoltcp",
  "socket2",

--- a/crates/smolvm-network/Cargo.toml
+++ b/crates/smolvm-network/Cargo.toml
@@ -28,11 +28,6 @@ smoltcp = { version = "0.13", default-features = false, features = [
 socket2 = "0.6"
 tracing = { workspace = true }
 
-# The libkrun virtio-net bridge speaks over a Unix-domain stream socket and uses
-# raw `setsockopt`/`fcntl`; those primitives only exist on Unix hosts.
-[target.'cfg(unix)'.dependencies]
-libc = "0.2"
-
 [features]
 # Exposes fuzz-only entrypoints (e.g. fuzz_classify_guest_frame). Never enabled in normal builds.
 fuzzing = []

--- a/crates/smolvm-network/src/frame_stream.rs
+++ b/crates/smolvm-network/src/frame_stream.rs
@@ -39,57 +39,67 @@
 //! ```
 
 use crate::queues::NetworkFrameQueues;
+use socket2::Socket;
 use std::io::{self, Read, Write};
 use std::net::Shutdown;
-use std::os::fd::{AsRawFd, FromRawFd, RawFd};
-use std::os::unix::net::UnixStream;
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 
 const FRAME_HEADER_LEN: usize = 4;
-const SOCKET_SENDBUF_BYTES: libc::c_int = 16 * 1024 * 1024;
+const SOCKET_SENDBUF_BYTES: usize = 16 * 1024 * 1024;
 const MAX_FRAME_LEN: usize = 64 * 1024;
 
 /// Running libkrun unix-stream bridge for one virtio NIC.
 ///
 /// The bridge owns:
-/// - a control clone of the Unix stream used to trigger shutdown
+/// - the shared AF_UNIX stream socket (used to trigger shutdown via `shutdown`)
 /// - a reader thread for guest->host frames
 /// - a writer thread for host->guest frames
+///
+/// The transport is an AF_UNIX stream socket, wrapped in [`socket2::Socket`] so
+/// the same code serves Unix hosts and Windows (10 1809+ has native AF_UNIX).
+/// On Unix the launcher hands us one end of a `socketpair`; on Windows it hands
+/// us the socket it `accept`ed from libkrun on a per-VM path.
+///
+/// The socket is shared via `Arc` and the reader/writer threads use it through
+/// `&Socket` (socket2 implements `Read`/`Write` for `&Socket`), rather than
+/// `try_clone`-ing it three ways: duplicating an AF_UNIX socket handle is
+/// unreliable on Windows (a clone may not observe the peer's writes), which
+/// silently stalled all guest traffic. Concurrent read + write on one socket is
+/// safe — the directions are independent.
 pub struct FrameStreamBridge {
-    control: UnixStream,
+    socket: Arc<Socket>,
     queues: Arc<NetworkFrameQueues>,
     reader_handle: Option<JoinHandle<()>>,
     writer_handle: Option<JoinHandle<()>>,
 }
 
-/// Start the libkrun unix-stream reader and writer threads for one virtio NIC.
+/// Start the libkrun stream reader and writer threads for one virtio NIC.
+///
+/// Takes ownership of an already-connected AF_UNIX stream socket to libkrun.
 pub fn start_frame_stream_bridge(
-    fd: RawFd,
+    stream: Socket,
     queues: Arc<NetworkFrameQueues>,
 ) -> io::Result<FrameStreamBridge> {
-    // SAFETY: ownership of the provided host-side socket fd transfers here.
-    let stream = unsafe { UnixStream::from_raw_fd(fd) };
-    set_socket_send_buffer(&stream)?;
-    // create 3 handles for the unix socket
-    let control = stream.try_clone()?;
-    let reader = stream.try_clone()?;
-    let writer = stream;
+    set_socket_send_buffer(&stream);
+    let socket = Arc::new(stream);
 
+    let reader_socket = socket.clone();
     let reader_handle = thread::Builder::new()
         .name("smolvm-net-reader".into())
         .spawn({
             let queues = queues.clone();
-            move || run_reader(reader, queues)
+            move || run_reader(reader_socket, queues)
         })?;
 
+    let writer_socket = socket.clone();
     let writer_queues = queues.clone();
     let writer_handle = thread::Builder::new()
         .name("smolvm-net-writer".into())
-        .spawn(move || run_writer(writer, writer_queues))?;
+        .spawn(move || run_writer(writer_socket, writer_queues))?;
 
     Ok(FrameStreamBridge {
-        control,
+        socket,
         queues,
         reader_handle: Some(reader_handle),
         writer_handle: Some(writer_handle),
@@ -100,11 +110,11 @@ impl Drop for FrameStreamBridge {
     /// Request shutdown and join the reader/writer workers.
     ///
     /// `shutdown(Shutdown::Both)` is the important part here: it forces any
-    /// blocking read/write on the other stream clones to wake up and fail,
-    /// which lets the threads notice shutdown and return.
+    /// blocking read/write on the shared socket to wake up and fail, which lets
+    /// the threads notice shutdown and return.
     fn drop(&mut self) {
         self.queues.begin_shutdown();
-        let _ = self.control.shutdown(Shutdown::Both);
+        let _ = self.socket.shutdown(Shutdown::Both);
 
         if let Some(handle) = self.reader_handle.take() {
             let _ = handle.join();
@@ -115,11 +125,12 @@ impl Drop for FrameStreamBridge {
     }
 }
 
-fn run_reader(mut reader: UnixStream, queues: Arc<NetworkFrameQueues>) {
+fn run_reader(reader: Arc<Socket>, queues: Arc<NetworkFrameQueues>) {
     // Reader thread:
     // libkrun -> Unix stream -> guest_to_host queue -> smoltcp poll loop
+    let mut sock: &Socket = &reader;
     loop {
-        match read_frame(&mut reader) {
+        match read_frame(&mut sock) {
             Ok(frame) => {
                 if queues.guest_to_host.push(frame).is_ok() {
                     queues.guest_wake.wake();
@@ -136,9 +147,10 @@ fn run_reader(mut reader: UnixStream, queues: Arc<NetworkFrameQueues>) {
     }
 }
 
-fn run_writer(mut writer: UnixStream, queues: Arc<NetworkFrameQueues>) {
+fn run_writer(writer: Arc<Socket>, queues: Arc<NetworkFrameQueues>) {
     // Writer thread:
     // smoltcp / host runtime -> host_to_guest queue -> Unix stream -> libkrun
+    let mut sock: &Socket = &writer;
     loop {
         if queues.is_shutting_down() && queues.host_to_guest.is_empty() {
             return;
@@ -154,7 +166,7 @@ fn run_writer(mut writer: UnixStream, queues: Arc<NetworkFrameQueues>) {
         }
 
         while let Some(frame) = queues.host_to_guest.pop() {
-            if let Err(err) = write_frame(&mut writer, &frame) {
+            if let Err(err) = write_frame(&mut sock, &frame) {
                 queues.begin_shutdown();
                 tracing::debug!(error = %err, "virtio-net writer thread stopped");
                 return;
@@ -243,37 +255,18 @@ fn write_all<W: Write>(writer: &mut W, mut buf: &[u8]) -> io::Result<()> {
     Ok(())
 }
 
-/// set_socket_send_buffer is used to set the "send buffer size" of the provided unix socket.this unix socket is
-/// used to send the Ethernet frames toward libkrun. Setting a large "send buffer size" is helpful for bursty
-/// traffics. This is because we can burst multiple Ethernet frames before the consumer catches up. The
-/// kernel may clamp the requested size, so failure here is logged but not treated as fatal.
-fn set_socket_send_buffer(stream: &UnixStream) -> io::Result<()> {
-    // using the default 16 MiB as the send buffer size
-    let size = SOCKET_SENDBUF_BYTES;
-    // syscall to set the option of a provided socket. Read this:
-    let result = unsafe {
-        libc::setsockopt(
-            // this is the fd of the target socket.
-            stream.as_raw_fd(),
-            // the option to be set is a general socket-level option
-            libc::SOL_SOCKET,
-            // the option name is “the send buffer size”
-            libc::SO_SNDBUF,
-            // and here is the value we want to set for that option (passing it as a c_int pointer)
-            (&size as *const libc::c_int).cast(),
-            // this is needed only because setsockopt is a generic syscall,
-            // and the kernel needs to know how many bytes that option value takes
-            std::mem::size_of_val(&size) as libc::socklen_t,
-        )
-    };
-    if result < 0 {
+/// Increase the socket's send-buffer size (SO_SNDBUF). This stream carries
+/// Ethernet frames toward libkrun; a large send buffer absorbs bursts so we can
+/// queue several frames before libkrun catches up. The OS may clamp the request,
+/// and the option is non-critical, so a failure is logged and ignored.
+/// `socket2` issues the platform `setsockopt` so this works on Unix and Windows.
+fn set_socket_send_buffer(stream: &Socket) {
+    if let Err(err) = stream.set_send_buffer_size(SOCKET_SENDBUF_BYTES) {
         tracing::warn!(
-            error = %io::Error::last_os_error(),
+            error = %err,
             "failed to increase SO_SNDBUF for virtio-net unixstream"
         );
-        return Ok(());
     }
-    Ok(())
 }
 
 #[cfg(test)]
@@ -314,8 +307,10 @@ mod tests {
         assert_eq!(read_frame(&mut input).unwrap(), vec![7, 8, 9]);
     }
 
+    #[cfg(unix)]
     #[test]
     fn unix_stream_round_trip_multiple_frames() {
+        use std::os::unix::net::UnixStream;
         let (mut left, mut right) = UnixStream::pair().unwrap();
         write_frame(&mut left, &[1, 2, 3]).unwrap();
         write_frame(&mut left, &[4, 5]).unwrap();

--- a/crates/smolvm-network/src/lib.rs
+++ b/crates/smolvm-network/src/lib.rs
@@ -60,10 +60,8 @@
 pub mod device;
 pub mod dns;
 pub mod egress;
-// The libkrun frame bridge speaks over a Unix-domain stream socket, so it only
-// exists on Unix hosts. The rest of the stack (smoltcp loop, TCP/UDP/ICMP
-// relays) is cross-platform.
-#[cfg(unix)]
+// The libkrun frame bridge speaks over an AF_UNIX stream socket, available on
+// both Unix and Windows (10 1809+), so the whole stack is cross-platform.
 pub mod frame_stream;
 pub mod icmp_relay;
 pub mod queues;
@@ -74,25 +72,17 @@ pub mod udp_relay;
 
 pub use egress::EgressPolicy;
 
+use socket2::Socket;
 use std::fmt;
-// `io` and the stack/listener constructors below are only used by the Unix-only
-// `start_virtio_network` entry point.
-#[cfg(unix)]
 use std::io;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-#[cfg(unix)]
-use std::os::fd::RawFd;
 use std::thread::JoinHandle;
 use std::time::SystemTime;
 
-#[cfg(unix)]
 use frame_stream::{start_frame_stream_bridge, FrameStreamBridge};
 use queues::NetworkFrameQueues;
-#[cfg(unix)]
 use queues::DEFAULT_FRAME_QUEUE_CAPACITY;
-#[cfg(unix)]
 use stack::{start_network_stack, VirtioPollConfig};
-#[cfg(unix)]
 use tcp_listeners::create_tcp_channel;
 use tcp_listeners::TcpPortListeners;
 
@@ -216,7 +206,6 @@ pub(crate) use virtio_net_log;
 /// as shutting down, wakes blocked workers, and joins the poll thread.
 pub struct VirtioNetworkRuntime {
     queues: std::sync::Arc<NetworkFrameQueues>,
-    #[cfg(unix)]
     _frame_bridge: FrameStreamBridge,
     published_ports: Option<TcpPortListeners>,
     poll_handle: Option<JoinHandle<()>>,
@@ -266,24 +255,24 @@ pub struct VirtioNetworkRuntime {
 /// - published host TCP connections can be forwarded toward guest listeners
 /// - the poll loop starts acting as the guest-visible gateway
 ///
-/// Only available on Unix: the libkrun frame bridge it builds requires a
-/// Unix-domain stream socket.
-#[cfg(unix)]
+/// Cross-platform: the libkrun frame bridge speaks over an AF_UNIX stream
+/// socket, available on Unix and Windows (10 1809+). The caller supplies the
+/// already-connected host-side socket (Unix: one end of a `socketpair`;
+/// Windows: the socket `accept`ed from libkrun on the per-VM path).
 pub fn start_virtio_network(
-    host_fd: RawFd,
+    host_stream: Socket,
     guest_network: GuestNetworkConfig,
     published_ports: &[PortMapping],
     egress: EgressPolicy,
 ) -> io::Result<VirtioNetworkRuntime> {
     virtio_net_log!(
-        "virtio-net: starting runtime host_fd={} guest_ip={} gateway_ip={} dns_server={}",
-        host_fd,
+        "virtio-net: starting runtime guest_ip={} gateway_ip={} dns_server={}",
         guest_network.guest_ip,
         guest_network.gateway_ip,
         guest_network.dns_server
     );
     let queues = NetworkFrameQueues::shared(DEFAULT_FRAME_QUEUE_CAPACITY);
-    let frame_bridge = start_frame_stream_bridge(host_fd, queues.clone())?;
+    let frame_bridge = start_frame_stream_bridge(host_stream, queues.clone())?;
     // tcp_sender sends the accepted TCP connections to the channel
     // tcp_receiver receives the accepted TCP connections via the channel, and let it be consumed in poll thread.
     let (tcp_sender, tcp_receiver) = create_tcp_channel();
@@ -335,6 +324,19 @@ impl VirtioNetworkRuntime {
     /// VM's runtime dir for the node API to read (the runtime is not `Clone`).
     pub fn egress_counter(&self) -> std::sync::Arc<std::sync::atomic::AtomicU64> {
         self.queues.egress_counter()
+    }
+
+    /// Take ownership of the runtime and block until the libkrun stream closes
+    /// (the frame reader marks the queues shutting down on EOF), then drop it for
+    /// a graceful shutdown. Used on Windows, where the runtime is built on the
+    /// `accept` thread: that thread parks here so the runtime — and its worker
+    /// threads — live for the whole VM lifetime instead of being dropped at the
+    /// end of the `accept` callback.
+    pub fn block_until_shutdown(self) {
+        while !self.queues.is_shutting_down() {
+            std::thread::sleep(std::time::Duration::from_millis(200));
+        }
+        // `self` drops here, joining the worker threads.
     }
 }
 

--- a/lib/libkrun.provenance
+++ b/lib/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=e47cf6a7dab299b72a742b69f2d1d30f0191e36b
+libkrun=e962f75c404cb23e6c2cc86be91a848b755f1bbd
 libkrunfw=392573f22f46bb1f2c864476ba3764170fe29507

--- a/lib/linux-aarch64/libkrun.provenance
+++ b/lib/linux-aarch64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=e47cf6a7dab299b72a742b69f2d1d30f0191e36b
+libkrun=e962f75c404cb23e6c2cc86be91a848b755f1bbd
 libkrunfw=392573f22f46bb1f2c864476ba3764170fe29507

--- a/lib/linux-x86_64/libkrun.provenance
+++ b/lib/linux-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=e47cf6a7dab299b72a742b69f2d1d30f0191e36b
+libkrun=e962f75c404cb23e6c2cc86be91a848b755f1bbd
 libkrunfw=392573f22f46bb1f2c864476ba3764170fe29507

--- a/lib/windows-x86_64/krun.dll
+++ b/lib/windows-x86_64/krun.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e1cfbbb7a88ff25d39e6c479b92aae3609529336ae5b8f2bdbde039c9e0df69b
-size 10348921
+oid sha256:05a91bd40a4c5b936293099d5917de367bba21b5fed7a14607c483126736f42d
+size 10348716

--- a/lib/windows-x86_64/libkrun.provenance
+++ b/lib/windows-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=e47cf6a7dab299b72a742b69f2d1d30f0191e36b
+libkrun=e962f75c404cb23e6c2cc86be91a848b755f1bbd
 libkrunfw=392573f22f46bb1f2c864476ba3764170fe29507

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -8,24 +8,21 @@ use crate::data::consts::{ENV_SMOLVM_KRUN_LOG_LEVEL, ENV_SMOLVM_LIB_DIR};
 use crate::data::disk::DiskFormat;
 use crate::data::storage::HostMount;
 use crate::error::{Error, Result};
-use crate::network::backend::TSI_FEATURE_HIJACK_INET;
-// Only used by the unix-only virtio-net path.
-#[cfg(unix)]
 use crate::network::backend::COMPAT_NET_FEATURES;
+use crate::network::backend::TSI_FEATURE_HIJACK_INET;
 use crate::network::{plan_launch_network, EffectiveNetworkBackend};
 use crate::storage::{OverlayDisk, StorageDisk};
 use crate::util::{libkrun_filename, libkrunfw_filename};
 
-use smolvm_network::{GuestNetworkConfig, VirtioNetworkRuntime};
-// `VirtioPortMapping` is only used by the unix-only virtio-net path.
-#[cfg(unix)]
 use smolvm_network::PortMapping as VirtioPortMapping;
-// `start_virtio_network` is `#[cfg(unix)]` in smolvm-network; virtio-net
-// networking is unix-only, so the import is gated to match.
-#[cfg(unix)]
-use smolvm_network::start_virtio_network;
+use smolvm_network::{start_virtio_network, GuestNetworkConfig, VirtioNetworkRuntime};
 use smolvm_protocol::{guest_env, ports};
+use socket2::Socket;
+#[cfg(windows)]
+use socket2::{Domain, SockAddr, Type};
 use std::ffi::CString;
+#[cfg(unix)]
+use std::os::fd::FromRawFd;
 // `std::os::fd` does not exist on Windows. Keep the `RawFd` name working in
 // signatures on both platforms via a portable alias.
 #[cfg(unix)]
@@ -529,11 +526,10 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
         let network_plan = select_network_plan(resources, *dns_filter_enabled, port_mappings.len());
 
         // `mut` is only needed on unix (the VirtioNet arm assigns it); on
-        // Windows that arm diverges, so the binding is never reassigned.
+        // Windows the runtime is owned by the accept thread, so the launcher's
+        // binding stays `None`.
         #[cfg_attr(not(unix), allow(unused_mut))]
         let mut virtio_network_runtime: Option<VirtioNetworkRuntime> = None;
-        // Explicit type: on Windows the VirtioNet arm diverges (`!`), so the
-        // element type can no longer be inferred from the arms alone.
         let guest_network: Option<GuestNetworkConfig> = match network_plan.backend {
             EffectiveNetworkBackend::None => {
                 // Upstream libkrun no longer creates an implicit vsock (the old
@@ -634,56 +630,57 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
                 None
             }
             EffectiveNetworkBackend::VirtioNet => {
-                // virtio-net networking relies on unix socketpair fds and the
-                // unix-only `start_virtio_network`; it is unsupported on Windows.
-                #[cfg(not(unix))]
-                {
-                    krun_free_ctx(ctx);
-                    return Err(Error::agent(
-                        "configure virtio-net",
-                        "virtio-net networking is not supported on Windows",
-                    ));
-                }
-                #[cfg(unix)]
-                {
-                    let add_net_unixstream = krun.add_net_unixstream.ok_or_else(|| {
+                let add_net_unixstream = krun.add_net_unixstream.ok_or_else(|| {
                     Error::agent(
                         "configure virtio-net",
                         "libkrun does not expose krun_add_net_unixstream; update libkrun or use --net-backend tsi",
                     )
                 })?;
-                    // virtio-net carries guest networking, but the host-guest control
-                    // channel still rides vsock. Upstream libkrun no longer creates an
-                    // implicit vsock, so add it explicitly (no TSI hijacking — virtio-net
-                    // owns the network path); otherwise krun_add_vsock_port2 below fails
-                    // with ENODEV.
-                    if krun_add_vsock(ctx, 0) < 0 {
-                        krun_free_ctx(ctx);
-                        return Err(Error::agent("configure vsock", "krun_add_vsock failed"));
-                    }
+                // virtio-net carries guest networking, but the host-guest control
+                // channel still rides vsock. Upstream libkrun no longer creates an
+                // implicit vsock, so add it explicitly (no TSI hijacking — virtio-net
+                // owns the network path); otherwise krun_add_vsock_port2 below fails
+                // with ENODEV.
+                if krun_add_vsock(ctx, 0) < 0 {
+                    krun_free_ctx(ctx);
+                    return Err(Error::agent("configure vsock", "krun_add_vsock failed"));
+                }
 
-                    let mut guest_network = GuestNetworkConfig::default();
-                    // A custom resolver (--dns) becomes the gateway's upstream: the
-                    // guest still points at the gateway (100.96.0.1), which forwards
-                    // queries to this address instead of the default.
-                    if let Some(dns) = resources.dns {
-                        guest_network.upstream_dns = dns;
-                    }
-                    let mut guest_mac = guest_network.guest_mac;
+                let mut guest_network = GuestNetworkConfig::default();
+                // A custom resolver (--dns) becomes the gateway's upstream: the
+                // guest still points at the gateway (100.96.0.1), which forwards
+                // queries to this address instead of the default.
+                if let Some(dns) = resources.dns {
+                    guest_network.upstream_dns = dns;
+                }
+                let mut guest_mac = guest_network.guest_mac;
+
+                let virtio_port_mappings: Vec<VirtioPortMapping> = port_mappings
+                    .iter()
+                    .map(|mapping| VirtioPortMapping::new(mapping.host, mapping.guest))
+                    .collect();
+                let egress = smolvm_network::EgressPolicy::new(
+                    resources.allowed_cidrs.as_deref(),
+                    egress_refresh_hosts.as_deref(),
+                );
+                let egress_path = egress_telemetry.map(|p| p.to_path_buf());
+
+                // The host and guest ends of the virtio-net channel are an AF_UNIX
+                // stream. On Unix we hand libkrun one end of a socketpair fd and run
+                // the gateway on the other immediately. Windows has no socketpair
+                // for AF_UNIX, so we bind a listener on a per-VM path, hand libkrun
+                // the path, and accept its connection (made when the VM boots inside
+                // the blocking `krun_start_enter`) on a background thread.
+                #[cfg(unix)]
+                {
                     let (host_fd, guest_fd) = create_unix_stream_pair().map_err(|e| {
                         Error::agent("configure virtio-net", format!("socketpair failed: {e}"))
                     })?;
-
-                    let virtio_port_mappings: Vec<VirtioPortMapping> = port_mappings
-                        .iter()
-                        .map(|mapping| VirtioPortMapping::new(mapping.host, mapping.guest))
-                        .collect();
-                    let egress = smolvm_network::EgressPolicy::new(
-                        resources.allowed_cidrs.as_deref(),
-                        egress_refresh_hosts.as_deref(),
-                    );
+                    // SAFETY: ownership of the host-side socketpair fd transfers
+                    // here (already inside the function's outer `unsafe` block).
+                    let host_stream = Socket::from_raw_fd(host_fd);
                     let runtime = match start_virtio_network(
-                        host_fd,
+                        host_stream,
                         guest_network,
                         &virtio_port_mappings,
                         egress,
@@ -718,17 +715,85 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
 
                     // Flush this NIC's egress counter to the per-VM dir so serve can
                     // bill it (parity with how disk size reaches the node API).
-                    if let Some(path) = egress_telemetry {
-                        crate::agent::manager::spawn_egress_flush(
-                            path.to_path_buf(),
-                            runtime.egress_counter(),
-                        );
+                    if let Some(path) = egress_path {
+                        crate::agent::manager::spawn_egress_flush(path, runtime.egress_counter());
                     }
                     virtio_network_runtime = Some(runtime);
-
-                    tracing::info!("network backend: virtio-net");
-                    Some(guest_network)
                 }
+                #[cfg(windows)]
+                {
+                    // Per-VM AF_UNIX path for the net channel, a sibling of the
+                    // agent-control vsock socket (already a working AF_UNIX path).
+                    let net_sock_path = vsock_socket.with_extension("net");
+                    let listener = bind_unix_listener(&net_sock_path).map_err(|e| {
+                        krun_free_ctx(ctx);
+                        Error::agent(
+                            "configure virtio-net",
+                            format!("failed to bind virtio-net socket: {e}"),
+                        )
+                    })?;
+                    let path_c = try_or_free_ctx!(
+                        path_to_cstring(&net_sock_path),
+                        "configure virtio-net",
+                        "virtio-net socket path contains null byte"
+                    );
+                    if add_net_unixstream(
+                        ctx,
+                        path_c.as_ptr(),
+                        -1,
+                        guest_mac.as_mut_ptr(),
+                        COMPAT_NET_FEATURES,
+                        0,
+                    ) < 0
+                    {
+                        krun_free_ctx(ctx);
+                        return Err(Error::agent(
+                            "configure virtio-net",
+                            "krun_add_net_unixstream failed",
+                        ));
+                    }
+
+                    // libkrun connects to the path while the VM boots inside the
+                    // blocking krun_start_enter, so accept on a background thread.
+                    // The accepted runtime owns its worker threads and parks here
+                    // until libkrun closes the stream (VM exit) for a clean teardown.
+                    let spawn = std::thread::Builder::new()
+                        .name("smolvm-net-accept".into())
+                        .spawn(move || match listener.accept() {
+                            Ok((sock, _)) => match start_virtio_network(
+                                sock,
+                                guest_network,
+                                &virtio_port_mappings,
+                                egress,
+                            ) {
+                                Ok(runtime) => {
+                                    if let Some(path) = egress_path {
+                                        crate::agent::manager::spawn_egress_flush(
+                                            path,
+                                            runtime.egress_counter(),
+                                        );
+                                    }
+                                    runtime.block_until_shutdown();
+                                }
+                                Err(err) => {
+                                    tracing::error!(error = %err, "virtio-net runtime failed to start");
+                                }
+                            },
+                            Err(err) => {
+                                tracing::warn!(error = %err, "virtio-net accept failed");
+                            }
+                        });
+                    if let Err(e) = spawn {
+                        krun_free_ctx(ctx);
+                        return Err(Error::agent(
+                            "configure virtio-net",
+                            format!("failed to spawn virtio-net accept thread: {e}"),
+                        ));
+                    }
+                }
+
+                tracing::info!("network backend: virtio-net");
+                Some(guest_network)
             }
         };
 
@@ -1219,6 +1284,19 @@ fn create_unix_stream_pair() -> std::io::Result<(RawFd, RawFd)> {
         return Err(std::io::Error::last_os_error());
     }
     Ok((fds[0], fds[1]))
+}
+
+// Windows has no AF_UNIX `socketpair`, so the virtio-net host end binds a
+// listener on a per-VM path and accepts the connection libkrun makes to it.
+#[cfg(windows)]
+pub(crate) fn bind_unix_listener(path: &Path) -> std::io::Result<Socket> {
+    // A leftover socket file from a previous run would make bind fail with
+    // EADDRINUSE, so clear it first (ignore "not found").
+    let _ = std::fs::remove_file(path);
+    let listener = Socket::new(Domain::UNIX, Type::STREAM, None)?;
+    listener.bind(&SockAddr::unix(path)?)?;
+    listener.listen(1)?;
+    Ok(listener)
 }
 
 fn select_network_plan(

--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -6,21 +6,17 @@
 //!
 //! The static FFI path in `launcher.rs` remains untouched for normal operations.
 
-use crate::network::backend::TSI_FEATURE_HIJACK_INET;
-// Only used by the unix-only virtio-net path.
-#[cfg(unix)]
 use crate::network::backend::COMPAT_NET_FEATURES;
+use crate::network::backend::TSI_FEATURE_HIJACK_INET;
 use crate::network::{plan_launch_network, EffectiveNetworkBackend};
-use smolvm_network::{GuestNetworkConfig, VirtioNetworkRuntime};
-// `VirtioPortMapping` is only used by the unix-only virtio-net path.
-#[cfg(unix)]
 use smolvm_network::PortMapping as VirtioPortMapping;
-// `start_virtio_network` is `#[cfg(unix)]` in smolvm-network; virtio-net
-// networking is unix-only, so the import is gated to match.
-#[cfg(unix)]
-use smolvm_network::start_virtio_network;
+use smolvm_network::{start_virtio_network, GuestNetworkConfig, VirtioNetworkRuntime};
 use smolvm_protocol::{guest_env, ports};
+#[cfg(unix)]
+use socket2::Socket;
 use std::ffi::CString;
+#[cfg(unix)]
+use std::os::fd::FromRawFd;
 // `std::os::fd` does not exist on Windows. Keep the `RawFd` name working in
 // signatures on both platforms via a portable alias.
 #[cfg(unix)]
@@ -208,11 +204,9 @@ pub fn launch_agent_vm_dynamic(
     let network_plan = plan_launch_network(&config.resources, None, config.port_mappings.len());
 
     // `mut` is only needed on unix (the VirtioNet arm assigns it); on Windows
-    // that arm diverges, so the binding is never reassigned.
+    // the runtime is owned by the accept thread, so the binding stays `None`.
     #[cfg_attr(not(unix), allow(unused_mut))]
     let mut virtio_network_runtime: Option<VirtioNetworkRuntime> = None;
-    // Explicit type: on Windows the VirtioNet arm diverges (`!`), so the
-    // element type can no longer be inferred from the arms alone.
     let guest_network: Option<GuestNetworkConfig> = match network_plan.backend {
         EffectiveNetworkBackend::None => {
             // Upstream libkrun no longer creates an implicit vsock; add explicitly.
@@ -278,50 +272,53 @@ pub fn launch_agent_vm_dynamic(
             None
         }
         EffectiveNetworkBackend::VirtioNet => {
-            // virtio-net networking relies on unix socketpair fds and the
-            // unix-only `start_virtio_network`; it is unsupported on Windows.
-            #[cfg(not(unix))]
-            {
-                free_ctx_on_err!("virtio-net networking is not supported on Windows");
-            }
-            #[cfg(unix)]
-            {
-                let add_net_unixstream = krun.add_net_unixstream.ok_or_else(|| {
+            let add_net_unixstream = krun.add_net_unixstream.ok_or_else(|| {
                 "libkrun does not expose krun_add_net_unixstream; update libkrun or use --net-backend tsi"
                     .to_string()
             })?;
 
-                // virtio-net carries guest networking, but the host-guest control
-                // channel still rides vsock. Upstream libkrun no longer creates an
-                // implicit vsock, so add it explicitly (no TSI hijacking — virtio-net
-                // owns the network path); otherwise krun_add_vsock_port2 below fails
-                // with ENODEV.
-                if unsafe { (krun.add_vsock)(ctx, 0) } < 0 {
-                    free_ctx_on_err!("krun_add_vsock failed");
-                }
+            // virtio-net carries guest networking, but the host-guest control
+            // channel still rides vsock. Upstream libkrun no longer creates an
+            // implicit vsock, so add it explicitly (no TSI hijacking — virtio-net
+            // owns the network path); otherwise krun_add_vsock_port2 below fails
+            // with ENODEV.
+            if unsafe { (krun.add_vsock)(ctx, 0) } < 0 {
+                free_ctx_on_err!("krun_add_vsock failed");
+            }
 
-                let guest_network = GuestNetworkConfig::default();
-                let mut guest_mac = guest_network.guest_mac;
+            let guest_network = GuestNetworkConfig::default();
+            let mut guest_mac = guest_network.guest_mac;
+            let port_mappings: Vec<VirtioPortMapping> = config
+                .port_mappings
+                .iter()
+                .map(|(host, guest)| VirtioPortMapping::new(*host, *guest))
+                .collect();
+            let egress = smolvm_network::EgressPolicy::from_allowed_cidrs(
+                config.resources.allowed_cidrs.as_deref(),
+            );
+
+            // The host/guest ends of the virtio-net channel are an AF_UNIX
+            // stream: a socketpair fd on Unix, a per-VM path listener libkrun
+            // connects to on Windows. Mirrors the static launcher's VirtioNet arm.
+            #[cfg(unix)]
+            {
                 let (host_fd, guest_fd) =
                     create_unix_stream_pair().map_err(|e| format!("socketpair failed: {e}"))?;
-                let port_mappings: Vec<VirtioPortMapping> = config
-                    .port_mappings
-                    .iter()
-                    .map(|(host, guest)| VirtioPortMapping::new(*host, *guest))
-                    .collect();
-                let egress = smolvm_network::EgressPolicy::from_allowed_cidrs(
-                    config.resources.allowed_cidrs.as_deref(),
-                );
-
-                let runtime =
-                    match start_virtio_network(host_fd, guest_network, &port_mappings, egress) {
-                        Ok(runtime) => runtime,
-                        Err(err) => {
-                            // SAFETY: guest_fd was created by socketpair above and not moved elsewhere.
-                            unsafe { libc::close(guest_fd) };
-                            return Err(format!("failed to start virtio network runtime: {err}"));
-                        }
-                    };
+                // SAFETY: ownership of the host-side socketpair fd transfers here.
+                let host_stream = unsafe { Socket::from_raw_fd(host_fd) };
+                let runtime = match start_virtio_network(
+                    host_stream,
+                    guest_network,
+                    &port_mappings,
+                    egress,
+                ) {
+                    Ok(runtime) => runtime,
+                    Err(err) => {
+                        // SAFETY: guest_fd was created by socketpair above and not moved elsewhere.
+                        unsafe { libc::close(guest_fd) };
+                        return Err(format!("failed to start virtio network runtime: {err}"));
+                    }
+                };
 
                 if unsafe {
                     (add_net_unixstream)(
@@ -340,10 +337,55 @@ pub fn launch_agent_vm_dynamic(
                 }
 
                 virtio_network_runtime = Some(runtime);
-
-                tracing::info!("network backend: virtio-net");
-                Some(guest_network)
             }
+            #[cfg(windows)]
+            {
+                let net_sock_path = config.vsock_socket.with_extension("net");
+                let listener = match super::launcher::bind_unix_listener(&net_sock_path) {
+                    Ok(listener) => listener,
+                    Err(e) => free_ctx_on_err!(format!("failed to bind virtio-net socket: {e}")),
+                };
+                let path_c = match path_to_cstring(&net_sock_path) {
+                    Ok(path_c) => path_c,
+                    Err(_) => free_ctx_on_err!("virtio-net socket path contains null byte"),
+                };
+                if unsafe {
+                    (add_net_unixstream)(
+                        ctx,
+                        path_c.as_ptr(),
+                        -1,
+                        guest_mac.as_mut_ptr(),
+                        COMPAT_NET_FEATURES,
+                        0,
+                    )
+                } < 0
+                {
+                    free_ctx_on_err!("krun_add_net_unixstream failed");
+                }
+
+                // libkrun connects to the path while the VM boots inside the
+                // blocking krun_start_enter, so accept on a background thread; the
+                // runtime parks there until libkrun closes the stream (VM exit).
+                let spawn = std::thread::Builder::new()
+                    .name("smolvm-net-accept".into())
+                    .spawn(move || match listener.accept() {
+                        Ok((sock, _)) => {
+                            match start_virtio_network(sock, guest_network, &port_mappings, egress) {
+                                Ok(runtime) => runtime.block_until_shutdown(),
+                                Err(err) => {
+                                    tracing::error!(error = %err, "virtio-net runtime failed to start")
+                                }
+                            }
+                        }
+                        Err(err) => tracing::warn!(error = %err, "virtio-net accept failed"),
+                    });
+                if let Err(e) = spawn {
+                    free_ctx_on_err!(format!("failed to spawn virtio-net accept thread: {e}"));
+                }
+            }
+
+            tracing::info!("network backend: virtio-net");
+            Some(guest_network)
         }
     };
 

--- a/src/network/launch.rs
+++ b/src/network/launch.rs
@@ -75,16 +75,9 @@ pub fn plan_launch_network(
             NetworkBackend::Tsi
         },
     );
-    // virtio-net is not available on Windows. libkrun's TSI carries inbound
-    // published ports on every platform (it opens the host listener when the
-    // guest binds a mapped port) and enforces egress via krun_set_egress_policy,
-    // so route the default through TSI there instead of the missing backend.
-    #[cfg(windows)]
-    let backend = if backend == NetworkBackend::VirtioNet {
-        NetworkBackend::Tsi
-    } else {
-        backend
-    };
+    // virtio-net works on Windows too: the host-side smolvm-network gateway is
+    // cross-platform and libkrun's net device bridges over an AF_UNIX path
+    // (Windows 10 1809+ has native AF_UNIX). See launcher's VirtioNet arm.
     match backend {
         NetworkBackend::Tsi => LaunchNetworkPlan {
             backend: EffectiveNetworkBackend::Tsi,
@@ -116,8 +109,6 @@ pub fn validate_requested_network_backend(
     // Mirror plan_launch_network's default: unset backend + (ports OR egress
     // policy) ⇒ virtio-net. So only an EXPLICIT `--net-backend tsi` alongside
     // ports/egress is a misconfig.
-    // Only read by the virtio-net requirement checks below (non-Windows).
-    #[cfg_attr(windows, allow(unused_variables))]
     let backend = resources
         .network_backend
         .unwrap_or(if port_count > 0 || has_egress_policy {
@@ -126,29 +117,23 @@ pub fn validate_requested_network_backend(
             NetworkBackend::Tsi
         });
 
-    // On Windows virtio-net is unavailable; libkrun's TSI carries inbound ports
-    // and enforces the egress policy (krun_set_egress_policy), so the virtio-net
-    // requirements below don't apply there.
-    #[cfg(not(windows))]
-    {
-        // Published ports require the inbound path that only virtio-net has. With
-        // the default above this only fires when the caller EXPLICITLY forced TSI.
-        if port_count > 0 && backend != NetworkBackend::VirtioNet {
-            return Err(crate::Error::config(
-                "ports",
-                "published ports require the virtio-net backend (TSI is outbound-only); \
-                 remove --net-backend tsi or set it to virtio-net",
-            ));
-        }
+    // Published ports require the inbound path that only virtio-net has. With
+    // the default above this only fires when the caller EXPLICITLY forced TSI.
+    if port_count > 0 && backend != NetworkBackend::VirtioNet {
+        return Err(crate::Error::config(
+            "ports",
+            "published ports require the virtio-net backend (TSI is outbound-only); \
+             remove --net-backend tsi or set it to virtio-net",
+        ));
+    }
 
-        // Same for an egress policy — fires only on EXPLICIT TSI + policy.
-        if has_egress_policy && backend != NetworkBackend::VirtioNet {
-            return Err(crate::Error::config(
-                "egress",
-                "egress policy (--allow-cidr/--allow-host/--outbound-localhost-only) requires the \
-                 virtio-net backend; TSI does not enforce it. Remove --net-backend tsi or set it to virtio-net",
-            ));
-        }
+    // Same for an egress policy — fires only on EXPLICIT TSI + policy.
+    if has_egress_policy && backend != NetworkBackend::VirtioNet {
+        return Err(crate::Error::config(
+            "egress",
+            "egress policy (--allow-cidr/--allow-host/--outbound-localhost-only) requires the \
+             virtio-net backend; TSI does not enforce it. Remove --net-backend tsi or set it to virtio-net",
+        ));
     }
 
     if resources.network_backend != Some(NetworkBackend::VirtioNet) {


### PR DESCRIPTION
Brings real virtio-net networking (not just TSI) to Windows/WHP — guest NIC, ARP/gateway, TCP egress and DNS-by-name, plus egress-policy enforcement that TSI silently skips — verified end-to-end on the thinkpad; depends on smol-machines/libkrun#25 (merge first).