### PR TITLE
fix(serve): let hardened VMM boot ported VMs and load bundled libkrun

### DIFF
--- a/src/cli/internal_boot.rs
+++ b/src/cli/internal_boot.rs
@@ -218,6 +218,16 @@ pub fn run(config_path: PathBuf) -> smolvm::Result<()> {
         if let Some(ref d) = config.packed_layers_dir {
             read_exec.push(d.clone());
         }
+        // Grant read+exec on the directory libkrun/libkrunfw are actually
+        // dlopen'd from, resolved EXACTLY like the loader (`find_lib_dir`):
+        // `SMOLVM_LIB_DIR` if it holds the libs, else exe-relative bundle paths
+        // (`lib/`, `../../lib/linux-<arch>`, …). Consulting only `SMOLVM_LIB_DIR`
+        // denied the bundled/dev layout — where the libs live in an exe-relative
+        // `lib/` dir and the env var is unset — making `libkrunfw.so` fail to
+        // load under enforce ("cannot open shared object file: Permission denied").
+        if let Some(lib_dir) = smolvm::agent::find_lib_dir() {
+            read_exec.push(lib_dir);
+        }
         if let Some(libdir) = std::env::var_os("SMOLVM_LIB_DIR") {
             read_exec.push(std::path::PathBuf::from(libdir));
         }

--- a/src/process.rs
+++ b/src/process.rs
@@ -512,6 +512,10 @@ fn build_seccomp_program(enforce: bool) -> std::result::Result<seccompiler::BpfP
         // epoll / poll event loops (virtio, vsock/TSI)
         libc::SYS_epoll_create1, libc::SYS_epoll_ctl,
         libc::SYS_epoll_pwait, libc::SYS_ppoll,
+        // timerfd — the virtio-net host network stack's event loop arms timers
+        // (TCP retransmit/poll) via timerfd; without these the VMM is SIGSYS-killed
+        // at start as soon as a published port enables virtio-net.
+        libc::SYS_timerfd_create, libc::SYS_timerfd_settime, libc::SYS_timerfd_gettime,
         // sockets (vsock/TSI data path, host networking)
         libc::SYS_socket, libc::SYS_socketpair, libc::SYS_connect, libc::SYS_bind,
         libc::SYS_listen, libc::SYS_accept, libc::SYS_sendto, libc::SYS_recvfrom,


### PR DESCRIPTION
## Problem

Under the API server's default hardening (`--seccomp enforce`, `--landlock enforce`), starting a VM failed in two ways the CLI path never hits — so **every image/ported deploy on a hardened node** (the smolfleet node path) was broken:

1. **Landlock denied the bundled libkrun dir.** The allowlist only granted `SMOLVM_LIB_DIR`, but the loader (`find_lib_dir`) also resolves exe-relative bundle paths (`lib/`, `../../lib/linux-<arch>`). A bundle/dev layout got `cannot open shared object file: Permission denied` on `libkrunfw.so` at load time.
2. **Seccomp SIGSYS-killed the VMM** as soon as a published port enabled the virtio-net backend: its host network stack arms TCP timers via `timerfd_settime`, and none of `timerfd_create`/`settime`/`gettime` were in the allowlist. (Bare VMs — no port → no virtio-net — were unaffected, which is why it went unnoticed.)

## Fix
1. Grant landlock the directory `find_lib_dir()` actually resolves (same logic the loader uses), in addition to `SMOLVM_LIB_DIR`.
2. Add `SYS_timerfd_create`/`settime`/`gettime` to the seccomp allowlist (benign timer primitives — no escape surface for a confined VMM).

## Verification
Under **full default hardening (seccomp enforce + landlock enforce)**, a published-port VM now `start`s (200) and `exec`s (`{"exitCode":0,"stdout":"ported-vm-boots-under-full-hardening"}`) — was a 500/SIGSYS before. **328 unit tests pass**, fmt clean. The landlock/seccomp VM-boot path needs a hardening-capable runner for an integration test (follow-up).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/483">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->