### PR TITLE
fix(api): report /health machine counts from the DB, not the stale in-memory map

### DIFF
--- a/src/api/handlers/health.rs
+++ b/src/api/handlers/health.rs
@@ -24,10 +24,16 @@ pub fn mark_server_start() {
     )
 )]
 pub async fn health(State(state): State<Arc<ApiState>>) -> Json<HealthResponse> {
-    let counts = state.machine_counts();
-    let machines = Some(MachineCountsResponse {
-        total: counts.0,
-        running: counts.1,
+    // Count from the authoritative DB (off-reactor), the same source `/machines`
+    // reads. The in-memory machine map retains entries for VMs removed
+    // out-of-band — an ephemeral cleanup or a CLI/other-process delete — which
+    // made `/health.machines.total` report a stale count that diverged from
+    // `/machines` and the DB (a monitoring/scheduling consumer then saw ghost
+    // machines). Falls back to `None` if the DB read fails.
+    let machines = state.list_vm_records().await.ok().map(|vms| {
+        let total = vms.len();
+        let running = vms.iter().filter(|(_, r)| r.is_process_alive()).count();
+        MachineCountsResponse { total, running }
     });
     let uptime = SERVER_START.get().map(|t| t.elapsed().as_secs());
 


### PR DESCRIPTION
## Problem
`/health` computed `machines.total`/`running` from the in-memory machine map (`machine_counts`). That map retains entries for VMs removed **out-of-band** — an ephemeral cleanup or a CLI/other-process delete writes the shared DB but never notifies a running server's map. So `/health` reported a **stale total** that diverged from `/machines` and the DB; a monitoring/scheduling consumer (incl. smolfleet capacity/health checks) then saw **ghost machines**.

Observed: DB / CLI / `GET /api/v1/machines` all reported `0`, while `/health` reported `total:2` (entries the server reconnected to at startup, then deleted).

## Fix
Count from the authoritative DB off-reactor via `list_vm_records()` — the same source `/machines` uses (and the same off-reactor read that avoids the liveness-probe wedge) — with `running` = records whose PID is alive.

## Verification
Deterministic repro: API-create a machine (enters map + DB), then delete its record out-of-band via the CLI. After the fix `/health.total` reports `0` (the DB), not the ghost `1` from the map — matching `/machines`. 330 unit tests pass, fmt clean.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/485">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->