### PR TITLE
fix(macos): bundle a net-enabled libkrun so virtio-net works

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -140,7 +140,7 @@ script = [
 '''
 set -e
 ARCH=$(uname -m)
-make -C libkrun BLK=1 GPU=1
+make -C libkrun BLK=1 NET=1 GPU=1
 if [ "$(uname -s)" = "Darwin" ]; then
   # macOS: the dylib lives in lib/ (alongside libkrunfw.5.dylib).
   cp libkrun/target/release/libkrun.dylib lib/libkrun.dylib

--- a/lib/libkrun.dylib
+++ b/lib/libkrun.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cb530ebc1e2754e4fabab9e39d1ae12cd7568e608e6ada248ad61f0d62b4fa35
-size 6091584
+oid sha256:04b4e7f1799544ddc10f3e414ec2f030096513e41ce6fe40e01869ed35a4831f
+size 6154688


### PR DESCRIPTION
The `build-libkrun` task built the macOS dylib without `NET=1`, so the bundled libkrun lacked `krun_add_net_unixstream` and virtio-net failed on macOS — this adds `NET=1` and rebuilds the dylib with the full `BLK=1 NET=1 GPU=1` feature set, verified on macOS/HVF (virtio-net: network 20/20 + ports 2/2; GPU: probe passes and `/dev/dri/renderD128` present with `--gpu`).