### PR TITLE
fix(registry): add a remediation hint to the opaque token-service 401 error

### DIFF
--- a/crates/smolvm-registry/src/client.rs
+++ b/crates/smolvm-registry/src/client.rs
@@ -935,12 +935,19 @@ impl RegistryClient {
         };
 
         if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            // A 401 here usually means there's no usable registry credential
+            // (none configured, or it's invalid/expired) — the body is often
+            // empty, so without a hint the failure is opaque. Stay CLI-agnostic
+            // (smolvm and smol both use this client).
+            let hint = if status.as_u16() == 401 {
+                " — the registry credential is missing, invalid, or expired; re-authenticate to this registry"
+            } else {
+                ""
+            };
             return Err(RegistryError::Authentication {
-                message: format!(
-                    "token service returned {}: {}",
-                    resp.status(),
-                    resp.text().await.unwrap_or_default()
-                ),
+                message: format!("token service returned {status}: {body}{hint}"),
             });
         }
 


### PR DESCRIPTION
A token-service 401 (often with an empty body) now appends that the registry credential is missing, invalid, or expired, instead of failing opaquely.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/490">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->