### PR TITLE
build(release): Windows x86_64 dist artifact + bump to 1.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,11 +325,80 @@ jobs:
           path: dist/smolvm-*.tar.gz
 
   # ==========================================================================
+  # Build Windows distribution (cross-compiled; zipped)
+  # ==========================================================================
+  build-dist-windows:
+    name: Build dist (windows-x86_64)
+    needs: [build-agent, build-rootfs]
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER: x86_64-w64-mingw32-gcc
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          lfs: true
+
+      - name: Pull LFS files
+        run: git lfs pull
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-gnu
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          # mingw: cross-link smolvm.exe; clang/libclang: bindgen in build deps
+          # (matches the CI windows job); e2fsprogs: pre-format disk templates
+          # (Windows has no host mkfs.ext4); zip: package the dist.
+          sudo apt-get install -y gcc-mingw-w64-x86-64 clang libclang-dev e2fsprogs zip
+
+      - name: Verify Windows libraries
+        run: |
+          ls -la lib/windows-x86_64/
+          file lib/windows-x86_64/*.dll
+
+      - name: Download rootfs (x86_64)
+        uses: actions/download-artifact@v8
+        with:
+          name: rootfs-x86_64
+          path: /tmp/rootfs-dl/
+
+      - name: Extract rootfs
+        run: |
+          mkdir -p target/agent-rootfs
+          sudo tar -xf /tmp/rootfs-dl/agent-rootfs.tar -C target/agent-rootfs
+
+      - name: Download agent binary (x86_64)
+        uses: actions/download-artifact@v8
+        with:
+          name: agent-x86_64
+          path: /tmp/agent/
+
+      # The rootfs artifact ships agent-less; inject the freshly built agent and
+      # repoint /sbin/init at it (same as the Unix build-dist.sh path).
+      - name: Inject agent into rootfs
+        run: |
+          sudo cp /tmp/agent/smolvm-agent target/agent-rootfs/usr/local/bin/smolvm-agent
+          sudo chmod +x target/agent-rootfs/usr/local/bin/smolvm-agent
+          sudo ln -sf /usr/local/bin/smolvm-agent target/agent-rootfs/sbin/init
+
+      - name: Build Windows distribution
+        run: ./scripts/build-dist-windows.sh
+        env:
+          LIB_DIR: lib/windows-x86_64
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: dist-windows-x86_64
+          path: dist/smolvm-*-windows-x86_64.zip
+
+  # ==========================================================================
   # Create GitHub Release
   # ==========================================================================
   release:
     name: Create Release
-    needs: build-dist
+    needs: [build-dist, build-dist-windows]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -349,7 +418,7 @@ jobs:
       - name: Generate checksums
         run: |
           cd dist
-          sha256sum *.tar.gz > checksums.sha256
+          sha256sum *.tar.gz *.zip > checksums.sha256
           cat checksums.sha256
 
       - name: Create GitHub Release
@@ -360,4 +429,5 @@ jobs:
             --title "smolvm ${{ github.ref_name }}" \
             --generate-notes \
             dist/*.tar.gz \
+            dist/*.zip \
             dist/checksums.sha256

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2151,7 +2151,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smolfile"
-version = "1.2.5"
+version = "1.3.0"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -2177,7 +2177,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.2.5"
+version = "1.3.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -2229,7 +2229,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-agent"
-version = "1.2.5"
+version = "1.3.0"
 dependencies = [
  "lazy_static",
  "libc",
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-network"
-version = "1.2.5"
+version = "1.3.0"
 dependencies = [
  "crossbeam-queue",
  "humantime",
@@ -2258,7 +2258,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-pack"
-version = "1.2.5"
+version = "1.3.0"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -2277,7 +2277,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.2.5"
+version = "1.3.0"
 dependencies = [
  "base64",
  "serde",
@@ -2287,7 +2287,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.2.5"
+version = "1.3.0"
 dependencies = [
  "bytes",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "smolvm"
-version = "1.2.5"
+version = "1.3.0"
 edition = "2021"
 description = "OCI-native microVM runtime"
 license = "Apache-2.0"
@@ -29,11 +29,11 @@ name = "smolvm"
 path = "src/main.rs"
 
 [dependencies]
-smolvm-network = { path = "crates/smolvm-network", version = "1.2.5" }
-smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.2.5" }
-smolvm-pack = { path = "crates/smolvm-pack", version = "1.2.5" }
-smolvm-registry = { path = "crates/smolvm-registry", version = "1.2.5" }
-smolfile = { path = "crates/smolvm-smolfile", version = "1.2.5" }
+smolvm-network = { path = "crates/smolvm-network", version = "1.3.0" }
+smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.3.0" }
+smolvm-pack = { path = "crates/smolvm-pack", version = "1.3.0" }
+smolvm-registry = { path = "crates/smolvm-registry", version = "1.3.0" }
+smolfile = { path = "crates/smolvm-smolfile", version = "1.3.0" }
 thiserror = "1"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
@@ -111,7 +111,7 @@ windows-sys = { version = "0.60", features = [
 
 [dev-dependencies]
 tempfile = "3"
-smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.2.5" }
+smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.3.0" }
 regex = "1"
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Known Limitations
 * macOS: binary must be signed with Hypervisor.framework entitlements.
 * `--ssh-agent` requires an SSH agent running on the host (`SSH_AUTH_SOCK` must be set).
 * GPU acceleration requires libkrun built with `GPU=1` and virglrenderer + a Vulkan driver on the host (see [GPU Acceleration](#gpu-acceleration) below).
-* Windows: networking uses the transparent socket layer (TSI) — `--net` gives TCP/UDP and inbound port-forwarding, but virtio-net, GPU acceleration, and fork/snapshot are not available. Pack *create* needs `storage-template.ext4` / `overlay-template.ext4` next to `smolvm.exe` (Windows has no host `mkfs.ext4`).
+* Windows: `--net` works the same as on other platforms (virtio-net with inbound port-forwarding; TSI for outbound-only VMs), as do `machine exec` / interactive sessions and `machine stats`. Not yet available on Windows: GPU acceleration and `machine fork` / snapshot. Pack *create* needs `storage-template.ext4` / `overlay-template.ext4` next to `smolvm.exe` (Windows has no host `mkfs.ext4`).
 
 GPU Acceleration
 ----------------

--- a/crates/smolvm-agent/Cargo.toml
+++ b/crates/smolvm-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-agent"
-version = "1.2.5"
+version = "1.3.0"
 edition = "2021"
 description = "Guest agent for smolvm VMs (handles OCI operations and command execution)"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ name = "smolvm-agent"
 path = "src/main.rs"
 
 [dependencies]
-smolvm-protocol = { path = "../smolvm-protocol", version = "1.2.5" }
+smolvm-protocol = { path = "../smolvm-protocol", version = "1.3.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/crates/smolvm-network/Cargo.toml
+++ b/crates/smolvm-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-network"
-version = "1.2.5"
+version = "1.3.0"
 edition = "2021"
 description = "Host-side virtio-net runtime for smolvm"
 license = "Apache-2.0"

--- a/crates/smolvm-pack/Cargo.toml
+++ b/crates/smolvm-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-pack"
-version = "1.2.5"
+version = "1.3.0"
 edition = "2021"
 description = "Single-binary packaging for smolvm"
 license = "Apache-2.0"
@@ -10,7 +10,7 @@ repository = "https://github.com/smol-machines/smolvm"
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-smolvm-protocol = { path = "../smolvm-protocol", version = "1.2.5" }
+smolvm-protocol = { path = "../smolvm-protocol", version = "1.3.0" }
 tar = "0.4"
 zstd = "0.13"
 crc32fast = "1.4"

--- a/crates/smolvm-protocol/Cargo.toml
+++ b/crates/smolvm-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-protocol"
-version = "1.2.5"
+version = "1.3.0"
 edition = "2021"
 description = "Protocol types for smolvm host-guest communication"
 license = "Apache-2.0"

--- a/crates/smolvm-registry/Cargo.toml
+++ b/crates/smolvm-registry/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "smolvm-registry"
-version = "1.2.5"
+version = "1.3.0"
 edition = "2021"
 description = "OCI Distribution client for smolmachines registry"
 license = "Apache-2.0"
 repository = "https://github.com/smol-machines/smolvm"
 
 [dependencies]
-smolvm-pack = { path = "../smolvm-pack", version = "1.2.5" }
+smolvm-pack = { path = "../smolvm-pack", version = "1.3.0" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "json"] }
 sha2 = "0.10"
 bytes = "1"

--- a/crates/smolvm-smolfile/Cargo.toml
+++ b/crates/smolvm-smolfile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolfile"
-version = "1.2.5"
+version = "1.3.0"
 edition = "2021"
 description = "Smolfile specification and parser for smolvm microVM workloads"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ keywords = ["smolvm", "microvm", "configuration"]
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 thiserror = "1"
-smolvm-protocol = { path = "../smolvm-protocol", version = "1.2.5" }
+smolvm-protocol = { path = "../smolvm-protocol", version = "1.3.0" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/scripts/build-dist-windows.sh
+++ b/scripts/build-dist-windows.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Build a distributable smolvm package for Windows (x86_64).
+#
+# Unlike build-dist.sh (which builds a native Unix dist), this is a CROSS build:
+# it runs on a Linux host, cross-compiles smolvm.exe with the mingw-w64 toolchain,
+# and assembles the layout that boots on Windows/WHP — smolvm.exe with krun.dll +
+# libkrunfw.dll beside it (Windows resolves DLLs from the exe's directory), the
+# Linux x86_64 agent-rootfs, and the pre-formatted ext4 disk templates. The guest
+# is Linux, so the rootfs/templates are the same artifacts the linux-x86_64 dist
+# ships; only the host binary + libraries are Windows-specific.
+#
+# Output: dist/smolvm-<version>-windows-x86_64.zip
+#
+# Inputs (mirrors build-dist.sh --skip-agent-build):
+#   target/agent-rootfs/                  Linux x86_64 rootfs with smolvm-agent baked in
+#   $LIB_DIR (default lib/windows-x86_64) krun.dll + libkrunfw.dll
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_ROOT"
+
+VERSION="${VERSION:-$(grep '^version' Cargo.toml | head -1 | cut -d'"' -f2)}"
+PLATFORM="windows-x86_64"
+DIST_NAME="smolvm-${VERSION}-${PLATFORM}"
+DIST_DIR="dist/${DIST_NAME}"
+LIB_DIR="${LIB_DIR:-lib/windows-x86_64}"
+TARGET="x86_64-pc-windows-gnu"
+ROOTFS_SRC="$PROJECT_ROOT/target/agent-rootfs"
+
+# The Windows host dlopens libkrun at runtime (libloading), so the cross build
+# has no link-time libkrun dependency — only the mingw linker is required.
+export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="${CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER:-x86_64-w64-mingw32-gcc}"
+
+echo "Building smolvm Windows distribution: ${DIST_NAME}"
+
+# --- Preconditions ---------------------------------------------------------
+for dll in krun.dll libkrunfw.dll; do
+    if [[ ! -f "$LIB_DIR/$dll" ]]; then
+        echo "Error: $dll not found in $LIB_DIR (set LIB_DIR to the Windows lib dir)" >&2
+        exit 1
+    fi
+done
+if [[ ! -d "$ROOTFS_SRC" ]]; then
+    echo "Error: target/agent-rootfs not found." >&2
+    echo "       Run ./scripts/build-agent-rootfs.sh --arch x86_64 first (CI downloads it)." >&2
+    exit 1
+fi
+if ! command -v "$CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER" >/dev/null 2>&1; then
+    echo "Error: mingw linker $CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER not found." >&2
+    echo "       Install gcc-mingw-w64-x86-64 (apt) or x86_64-w64-mingw32-gcc (brew)." >&2
+    exit 1
+fi
+
+# --- Cross-build smolvm.exe -------------------------------------------------
+echo "Cross-compiling smolvm.exe for $TARGET..."
+rustup target list --installed 2>/dev/null | grep -q "$TARGET" || rustup target add "$TARGET"
+cargo build --release --target "$TARGET" --bin smolvm
+EXE="target/$TARGET/release/smolvm.exe"
+[[ -f "$EXE" ]] || { echo "Error: cross build did not produce $EXE" >&2; exit 1; }
+
+# --- Assemble the dist directory -------------------------------------------
+echo "Assembling distribution..."
+rm -rf "$DIST_DIR"
+mkdir -p "$DIST_DIR"
+
+# Host binary + DLLs sit together; Windows resolves krun.dll (and its
+# libkrunfw.dll dependency) from the directory containing smolvm.exe.
+cp "$EXE" "$DIST_DIR/smolvm.exe"
+cp "$LIB_DIR/krun.dll" "$DIST_DIR/krun.dll"
+cp "$LIB_DIR/libkrunfw.dll" "$DIST_DIR/libkrunfw.dll"
+
+# Linux x86_64 guest rootfs (cp -a preserves the busybox symlinks). The caller
+# must have placed the smolvm-agent binary into the rootfs already — the rootfs
+# artifact itself ships agent-less (the agent is injected per-dist, like the
+# Unix build-dist.sh path).
+if [[ ! -f "$ROOTFS_SRC/usr/local/bin/smolvm-agent" ]]; then
+    echo "Error: target/agent-rootfs is missing usr/local/bin/smolvm-agent." >&2
+    echo "       Inject the Linux x86_64 agent into the rootfs before packaging." >&2
+    exit 1
+fi
+mkdir -p "$DIST_DIR/agent-rootfs"
+cp -a "$ROOTFS_SRC"/. "$DIST_DIR/agent-rootfs/"
+echo "Agent rootfs size: $(du -sh "$DIST_DIR/agent-rootfs" | cut -f1)"
+
+# --- Pre-formatted ext4 disk templates -------------------------------------
+# Windows has no host mkfs.ext4, so the release ships pre-formatted templates
+# next to smolvm.exe (pack/create copies them instead of formatting at runtime).
+if command -v mkfs.ext4 >/dev/null 2>&1; then
+    echo "Creating disk templates..."
+    # Set a file's virtual (sparse) size portably — macOS lacks GNU truncate.
+    extend_sparse() { # $1=path $2=bytes
+        if command -v truncate >/dev/null 2>&1; then
+            truncate -s "$2" "$1"
+        else
+            perl -e 'truncate($ARGV[0], $ARGV[1]) or die "truncate: $!"' "$1" "$2"
+        fi
+    }
+    make_template() { # $1=path $2=label $3=virtual_bytes
+        dd if=/dev/zero of="$1" bs=1 count=0 seek=$((512 * 1024 * 1024)) 2>/dev/null
+        mkfs.ext4 -F -q -m 0 -L "$2" "$1"
+        extend_sparse "$1" "$3"
+    }
+    make_template "$DIST_DIR/storage-template.ext4" smolvm        $((20 * 1024 * 1024 * 1024))
+    make_template "$DIST_DIR/overlay-template.ext4" smolvm-overlay $((10 * 1024 * 1024 * 1024))
+    echo "Templates: storage (20 GiB virtual), overlay (10 GiB virtual), sparse"
+else
+    echo "Error: mkfs.ext4 not found — install e2fsprogs to build the Windows dist." >&2
+    exit 1
+fi
+
+# --- README ----------------------------------------------------------------
+cat > "$DIST_DIR/README.txt" <<EOF
+smolvm ${VERSION} — OCI-native microVM runtime (Windows x86_64)
+
+REQUIREMENTS
+  - Windows 10/11 x86_64 with the Windows Hypervisor Platform (WHP) feature
+    enabled (Settings > Optional features, or:
+      dism /online /enable-feature /featurename:HypervisorPlatform /all)
+
+INSTALL
+  Unzip this archive anywhere and keep all files together. krun.dll and
+  libkrunfw.dll must stay beside smolvm.exe. Optionally add the folder to PATH.
+
+USAGE (run smolvm.exe directly)
+  smolvm.exe machine run --net --image alpine -- echo "Hello from Windows"
+  smolvm.exe machine create --net --name myvm
+  smolvm.exe machine start --name myvm
+  smolvm.exe machine exec --name myvm -- /bin/sh
+  smolvm.exe machine stats --name myvm
+  smolvm.exe machine stop --name myvm
+
+NOT YET SUPPORTED ON WINDOWS
+  GPU acceleration; machine fork / snapshot.
+
+More: https://github.com/smol-machines/smolvm
+EOF
+
+# --- Checksums + zip --------------------------------------------------------
+echo "Generating checksums..."
+( cd "$DIST_DIR" && sha256sum smolvm.exe krun.dll libkrunfw.dll > checksums.txt )
+
+echo "Creating zip..."
+( cd dist && rm -f "${DIST_NAME}.zip" && zip -qr "${DIST_NAME}.zip" "${DIST_NAME}" )
+
+echo ""
+echo "Distribution package created: dist/${DIST_NAME}.zip"
+echo "Contents:"
+ls -la "$DIST_DIR"


### PR DESCRIPTION
Adds a Windows release artifact (cross-built `smolvm.exe` zipped with `krun.dll`/`libkrunfw.dll`, the Linux x86_64 agent-rootfs, and pre-formatted ext4 templates — the layout proven on the WHP hardware), bumps the workspace to 1.3.0, and corrects the stale README that claimed virtio-net is unavailable on Windows.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/493">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->