### PR TITLE
feat(boot): shared content-addressed pack store with per-VM idmapped mount

### DIFF
--- a/crates/smolvm-pack/src/extract.rs
+++ b/crates/smolvm-pack/src/extract.rs
@@ -715,6 +715,76 @@ pub fn extract_sidecar(
     // Lock released on drop of lock_file
 }
 
+/// Whether the shared content-addressed pack store is usable on this host.
+///
+/// The shared store extracts each build-constant pack exactly once per node into
+/// `_shared/<checksum>` (root-owned, read-only) and presents it to each VM via a
+/// per-VM idmapped bind mount, instead of re-extracting + re-chowning a private
+/// copy per machine. That mechanism is Linux-only (idmapped mounts, kernel ≥5.12)
+/// and the per-VM uid isolation it preserves only exists on the Linux fleet.
+/// `SMOLVM_DISABLE_SHARED_EXTRACT` is a kill-switch to fall back to the per-machine
+/// path without a redeploy.
+pub fn shared_extract_enabled() -> bool {
+    cfg!(target_os = "linux") && std::env::var_os("SMOLVM_DISABLE_SHARED_EXTRACT").is_none()
+}
+
+/// Directory holding the shared copy for one pack checksum, under `shared_root`.
+pub fn shared_pack_dir(shared_root: &Path, checksum: u32) -> PathBuf {
+    shared_root.join(format!("{:08x}", checksum))
+}
+
+/// Extract a sidecar pack ONCE into the shared content-addressed store and return
+/// the path to the shared copy (`shared_root/<checksum>`).
+///
+/// Unlike [`extract_sidecar`] (which writes a private per-machine copy), this is
+/// keyed purely by `footer.checksum` (a CRC32 content fingerprint), so every
+/// machine on a node whose pack hashes identically reuses the same extracted tree.
+/// The build-constant agent-rootfs (~28.6 MB / 362 files) therefore decodes once
+/// per node instead of once per machine — the cold-start tax this removes.
+///
+/// The shared copy is left **root-owned** (the extractor runs as root and the tar
+/// crate does not preserve ownership by default, so all files land `root:root`)
+/// and the store directories are locked to `0700 root`. No other uid can read the
+/// copy directly; a VM reaches it only through its own idmapped bind mount, which
+/// re-presents on-disk uid 0 as that VM's uid — preserving the per-VM isolation
+/// (#456) without a per-machine chown.
+///
+/// Idempotent + concurrency-safe: delegates to [`extract_sidecar`], whose flock +
+/// `.smolvm-extracted` marker serialize concurrent first extractions of the same
+/// checksum and make a warm hit a no-op.
+pub fn extract_sidecar_shared(
+    sidecar_path: &Path,
+    shared_root: &Path,
+    footer: &PackFooter,
+    debug: bool,
+) -> std::io::Result<PathBuf> {
+    let shared_dir = shared_pack_dir(shared_root, footer.checksum);
+    extract_sidecar(sidecar_path, &shared_dir, footer, false, debug)?;
+    // Lock down the store so a dropped per-VM uid can't read the shared copy
+    // directly (it must go through its idmapped mount). Best-effort: traversal
+    // by root (the VMM before it drops privileges) is unaffected by 0700.
+    restrict_to_owner(shared_root);
+    restrict_to_owner(&shared_dir);
+    Ok(shared_dir)
+}
+
+/// Set a directory to `0700` (owner-only) if possible. Best-effort; errors are
+/// swallowed because the store is already root-owned and root traversal ignores
+/// the mode — this only hardens against a *dropped* sibling uid reading the copy.
+fn restrict_to_owner(dir: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(meta) = fs::metadata(dir) {
+            let mut perms = meta.permissions();
+            perms.set_mode(0o700);
+            let _ = fs::set_permissions(dir, perms);
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = dir;
+}
+
 /// Inner extraction logic (called under the lock).
 fn extract_sidecar_inner(
     sidecar_path: &Path,

--- a/crates/smolvm-pack/tests/shared_extract.rs
+++ b/crates/smolvm-pack/tests/shared_extract.rs
@@ -127,7 +127,10 @@ fn shared_extraction_is_content_addressed_idempotent_and_locked_down() {
     //    extracted tree — no second decode, no second store dir. This is the
     //    cold-start tax the shared store removes.
     let shared_dir2 = extract_sidecar_shared(&sidecar, &shared_root, &footer, false).unwrap();
-    assert_eq!(shared_dir2, shared_dir, "second machine must reuse the copy");
+    assert_eq!(
+        shared_dir2, shared_dir,
+        "second machine must reuse the copy"
+    );
     let store_dirs: Vec<_> = fs::read_dir(&shared_root)
         .unwrap()
         .filter_map(|e| e.ok())
@@ -144,7 +147,13 @@ fn shared_extraction_is_content_addressed_idempotent_and_locked_down() {
     //    directly — it must go through its own idmapped mount (#456 isolation).
     for dir in [&shared_root, &shared_dir] {
         let mode = fs::metadata(dir).unwrap().permissions().mode() & 0o777;
-        assert_eq!(mode, 0o700, "{} must be 0700, got {:o}", dir.display(), mode);
+        assert_eq!(
+            mode,
+            0o700,
+            "{} must be 0700, got {:o}",
+            dir.display(),
+            mode
+        );
     }
 }
 

--- a/crates/smolvm-pack/tests/shared_extract.rs
+++ b/crates/smolvm-pack/tests/shared_extract.rs
@@ -1,0 +1,167 @@
+//! End-to-end test of the shared, content-addressed pack extraction
+//! (`extract_sidecar_shared`) against a *real* `.smolmachine` sidecar — real
+//! zstd stream, real tar, real footer/checksum — on a real filesystem.
+//!
+//! Linux-only: the shared store backs the Linux fleet's per-VM idmapped bind
+//! mount (kernel ≥5.12); macOS uses a per-machine case-sensitive sparse image,
+//! so the whole module compiles to nothing elsewhere. This validates the
+//! *extraction half* (extract-once, content-addressed, locked down); the mount
+//! half is validated by the root crate's `tests/idmap_mount.rs`.
+#![cfg(target_os = "linux")]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+use smolvm_pack::assets::AssetCollector;
+use smolvm_pack::extract::{extract_sidecar, extract_sidecar_shared, shared_extract_enabled};
+use smolvm_pack::format::PackManifest;
+use smolvm_pack::{read_footer_from_sidecar, sidecar_path_for, Packer};
+
+/// Build a tiny but *valid* OCI-style layer: a raw tar archive carrying one
+/// file. `post_process_extraction` untars every `layers/*.tar`, so the payload
+/// must be a real tar (a raw byte blob would fail with "failed to read entire
+/// block" — exactly what a real OCI layer never does).
+fn layer_tar(filename: &str, content: &[u8]) -> Vec<u8> {
+    let mut builder = tar::Builder::new(Vec::new());
+    let mut header = tar::Header::new_gnu();
+    header.set_entry_type(tar::EntryType::Regular);
+    header.set_size(content.len() as u64);
+    header.set_mode(0o644);
+    header.set_cksum();
+    builder.append_data(&mut header, filename, content).unwrap();
+    builder.into_inner().unwrap()
+}
+
+/// Build a real sidecar `.smolmachine` carrying two OCI layers, returning the
+/// sidecar path (under `dir`).
+fn build_real_sidecar(dir: &Path) -> std::path::PathBuf {
+    let stub_path = dir.join("stub");
+    fs::write(&stub_path, b"#!/bin/sh\necho stub").unwrap();
+
+    let mut collector = AssetCollector::new(dir.join("staging")).unwrap();
+    collector
+        .add_layer(
+            "sha256:aaa111aaa111bbb222",
+            &layer_tar("etc/base.conf", b"base layer file"),
+        )
+        .unwrap();
+    collector
+        .add_layer(
+            "sha256:ccc333ccc333ddd444",
+            &layer_tar("etc/top.conf", b"top layer file"),
+        )
+        .unwrap();
+
+    let manifest = PackManifest::new(
+        "test:latest".to_string(),
+        "sha256:test".to_string(),
+        "linux/x86_64".to_string(),
+        "linux/x86_64".to_string(),
+    );
+
+    let output = dir.join("packed");
+    Packer::new(manifest)
+        .with_stub(&stub_path)
+        .with_assets(collector)
+        .pack(&output)
+        .unwrap();
+
+    sidecar_path_for(&output)
+}
+
+/// Recursively collect (relative-path -> file bytes) for every regular file in a
+/// tree, so the shared extraction can be compared byte-for-byte to a plain one.
+fn file_map(root: &Path) -> std::collections::BTreeMap<String, Vec<u8>> {
+    let mut out = std::collections::BTreeMap::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        for entry in fs::read_dir(&d).unwrap() {
+            let entry = entry.unwrap();
+            let ft = entry.file_type().unwrap();
+            let p = entry.path();
+            if ft.is_dir() {
+                stack.push(p);
+            } else if ft.is_file() {
+                let rel = p.strip_prefix(root).unwrap().to_string_lossy().to_string();
+                out.insert(rel, fs::read(&p).unwrap());
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn shared_extraction_is_content_addressed_idempotent_and_locked_down() {
+    let tmp = tempfile::tempdir().unwrap();
+    let sidecar = build_real_sidecar(tmp.path());
+    let footer = read_footer_from_sidecar(&sidecar).unwrap();
+
+    let shared_root = tmp.path().join("_shared");
+    let pack_plain = tmp.path().join("vm-plain/pack");
+
+    // First machine extracts into the shared store; a plain per-machine
+    // extraction is the byte-for-byte reference.
+    let shared_dir = extract_sidecar_shared(&sidecar, &shared_root, &footer, false).unwrap();
+    extract_sidecar(&sidecar, &pack_plain, &footer, false, false).unwrap();
+
+    // 1) Content-addressed: the shared copy lives at `_shared/<checksum>`.
+    assert_eq!(
+        shared_dir,
+        shared_root.join(format!("{:08x}", footer.checksum)),
+        "shared dir must be keyed by the footer checksum"
+    );
+    assert!(shared_dir.is_dir(), "shared extraction dir must exist");
+
+    // 2) The shared view is byte-identical to a plain per-machine extraction —
+    //    the idmapped mount only remaps ownership, never content.
+    let reference = file_map(&pack_plain);
+    assert!(!reference.is_empty(), "extraction produced no files");
+    assert_eq!(
+        file_map(&shared_dir),
+        reference,
+        "shared content must match a plain extraction byte-for-byte"
+    );
+
+    // 3) Idempotent reuse: a second machine with the same checksum reuses the one
+    //    extracted tree — no second decode, no second store dir. This is the
+    //    cold-start tax the shared store removes.
+    let shared_dir2 = extract_sidecar_shared(&sidecar, &shared_root, &footer, false).unwrap();
+    assert_eq!(shared_dir2, shared_dir, "second machine must reuse the copy");
+    let store_dirs: Vec<_> = fs::read_dir(&shared_root)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().is_dir())
+        .collect();
+    assert_eq!(
+        store_dirs.len(),
+        1,
+        "only one content-addressed extraction may exist for one checksum"
+    );
+
+    // 4) Locked down to 0700: the store root and the checksum dir are owner-only,
+    //    so a sibling VM dropped to a *different* uid cannot read the shared copy
+    //    directly — it must go through its own idmapped mount (#456 isolation).
+    for dir in [&shared_root, &shared_dir] {
+        let mode = fs::metadata(dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700, "{} must be 0700, got {:o}", dir.display(), mode);
+    }
+}
+
+#[test]
+fn kill_switch_disables_the_shared_store() {
+    // The handler consults `shared_extract_enabled()` to choose the shared vs
+    // per-machine path; `SMOLVM_DISABLE_SHARED_EXTRACT` forces the fallback
+    // without a redeploy. (Run as its own test fn so the env mutation cannot race
+    // the content test on cargo's parallel test threads.)
+    assert!(
+        shared_extract_enabled(),
+        "shared store should be enabled by default on Linux"
+    );
+    std::env::set_var("SMOLVM_DISABLE_SHARED_EXTRACT", "1");
+    assert!(
+        !shared_extract_enabled(),
+        "kill-switch must disable the shared store"
+    );
+    std::env::remove_var("SMOLVM_DISABLE_SHARED_EXTRACT");
+}

--- a/src/agent/boot_config.rs
+++ b/src/agent/boot_config.rs
@@ -51,8 +51,19 @@ pub struct BootConfig {
     #[serde(default)]
     pub dns_filter_hosts: Option<Vec<String>>,
     /// Pre-extracted OCI layers directory for .smolmachine-sourced machines.
+    /// When `pack_idmap_source` is set, this is an empty per-VM mountpoint the
+    /// boot subprocess idmap-binds the shared pack onto; otherwise it is the
+    /// directory holding the extracted pack directly.
     #[serde(default)]
     pub packed_layers_dir: Option<PathBuf>,
+    /// Root-owned shared pack directory (`_shared/<checksum>`) to present at
+    /// `packed_layers_dir` via a per-VM idmapped bind mount that maps on-disk
+    /// uid 0 -> the VM's dropped uid. Set only when per-VM uid isolation is
+    /// active (Linux fleet); the mount lives in the boot subprocess's private
+    /// mount namespace and is torn down automatically on exit. When `None`,
+    /// `packed_layers_dir` is consumed as-is (no idmap mount).
+    #[serde(default)]
+    pub pack_idmap_source: Option<PathBuf>,
     /// Additional disk images to attach (path, read_only, format). The format
     /// lets the `pack --from-vm` exporter attach a source qcow2 disk read-only.
     #[serde(default)]

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -181,6 +181,12 @@ pub struct LaunchFeatures {
     /// When set, the launcher mounts this directory via virtiofs so the agent
     /// can use pre-extracted layers instead of pulling from a registry.
     pub packed_layers_dir: Option<std::path::PathBuf>,
+    /// Root-owned shared pack copy (`_shared/<checksum>`) to present at
+    /// `packed_layers_dir` via a per-VM idmapped bind mount. Set by
+    /// [`with_packed_layers`](LaunchFeatures::with_packed_layers) when create
+    /// wrote a shared pointer; the manager keeps it only when the per-VM uid drop
+    /// is active (else it collapses `packed_layers_dir` onto the shared copy).
+    pub pack_idmap_source: Option<std::path::PathBuf>,
     /// Additional disk images to attach to the VM (path, read_only, format).
     /// Appear as /dev/vdc, /dev/vdd, ... after the storage and overlay disks.
     pub extra_disks: Vec<(std::path::PathBuf, bool, DiskFormat)>,
@@ -232,6 +238,19 @@ impl LaunchFeatures {
         let Some(sidecar_path) = source_smolmachine else {
             return Ok(self);
         };
+
+        // Shared pack store: if create extracted the pack into the node's shared
+        // content-addressed store and dropped a pointer beside this machine, the
+        // per-machine `pack` dir is an empty mountpoint. Point `packed_layers_dir`
+        // at it and carry the shared copy as the idmap source; the manager keeps
+        // the idmap only when the per-VM uid drop is active (else it collapses
+        // `packed_layers_dir` onto the shared copy directly). No lease — the
+        // shared copy is never the macOS case-sensitive volume (Linux-only path).
+        if let Some(shared) = super::read_shared_pack_pointer(layers_cache_dir) {
+            self.packed_layers_dir = Some(layers_cache_dir.to_path_buf());
+            self.pack_idmap_source = Some(shared);
+            return Ok(self);
+        }
 
         if !smolvm_pack::extract::is_extracted(layers_cache_dir) {
             // Fallback: layers not yet extracted into this machine's own dir

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -187,6 +187,16 @@ pub fn vm_data_dir(name: &str) -> PathBuf {
     vm_cache_root().join(vm_dir_hash(name))
 }
 
+/// Node-shared, content-addressed pack store: `<vm_cache_root>/_shared`. Each
+/// build-constant pack is extracted here once per node under `<checksum>/`
+/// (root-owned, read-only) and presented to every machine via a per-VM idmapped
+/// bind mount — instead of a private per-machine extraction + chown. The `_`
+/// prefix cannot collide with a 16-hex [`vm_dir_hash`], so it sits safely beside
+/// the per-machine data dirs on the same filesystem.
+pub fn shared_pack_cache_root() -> PathBuf {
+    vm_cache_root().join("_shared")
+}
+
 /// Actual host disk consumed by a machine's data dir, in MiB. Sums *real blocks*
 /// (`st_blocks × 512`), not apparent file lengths — the disk images are sparse, so
 /// a 20 GiB image that the guest has barely written to consumes only a few MiB.
@@ -250,6 +260,32 @@ pub fn resolve_disk_image(dir: &Path, raw_filename: &str) -> (PathBuf, DiskForma
 /// the `layers/` subtree that `extract_sidecar` creates *inside* this directory.
 pub fn machine_layers_cache_dir(name: &str) -> PathBuf {
     vm_data_dir(name).join("pack")
+}
+
+/// Filename of the shared-pack pointer dropped beside a machine's
+/// [`machine_layers_cache_dir`] when create extracted the pack into the node's
+/// shared content-addressed store (`_shared/<checksum>`) instead of a private
+/// per-machine copy. Its contents are the absolute path of that shared copy.
+pub const SHARED_PACK_POINTER: &str = ".pack-shared";
+
+/// Path of the shared-pack pointer for a machine, given its layers cache dir
+/// (`<vm_data_dir>/pack`). The pointer sits in the parent (`<vm_data_dir>`) so it
+/// is not shadowed when the `pack` mountpoint is idmap-bound at boot.
+pub fn shared_pack_pointer_path(layers_cache_dir: &std::path::Path) -> PathBuf {
+    layers_cache_dir
+        .parent()
+        .unwrap_or(layers_cache_dir)
+        .join(SHARED_PACK_POINTER)
+}
+
+/// Read the shared-pack pointer for a machine, returning the shared copy's path
+/// iff the pointer exists and names an existing directory. A stale pointer (the
+/// shared copy was evicted) reads as `None`, so callers fall back to the
+/// per-machine extraction path.
+pub fn read_shared_pack_pointer(layers_cache_dir: &std::path::Path) -> Option<PathBuf> {
+    let raw = std::fs::read_to_string(shared_pack_pointer_path(layers_cache_dir)).ok()?;
+    let shared = PathBuf::from(raw.trim());
+    shared.is_dir().then_some(shared)
 }
 
 /// Per-VM egress telemetry file: `<vm_data_dir>/egress`. The launcher (running
@@ -1524,7 +1560,7 @@ impl AgentManager {
         mounts: Vec<HostMount>,
         ports: Vec<PortMapping>,
         resources: VmResources,
-        features: launcher::LaunchFeatures,
+        mut features: launcher::LaunchFeatures,
     ) -> Result<()> {
         use super::boot_config::BootConfig;
 
@@ -1585,6 +1621,21 @@ impl AgentManager {
         let data_dir = self.storage_disk.path().parent().map(|p| p.to_path_buf());
         let registry = vm_uid_registry_dir();
         let mut uid_env: Vec<(&str, String)> = Vec::new();
+        // Shared pack store: `with_packed_layers` sets `pack_idmap_source` when
+        // create wrote a `_shared/<checksum>` pointer, leaving `packed_layers_dir`
+        // an empty per-VM mountpoint. Ensure that mountpoint exists BEFORE the
+        // uid-drop chown_tree below, so it's owned by the VM's uid (harmless — the
+        // idmap bind covers it at boot) rather than left for chown to miss.
+        if features.pack_idmap_source.is_some() {
+            if let Some(ref mountpoint) = features.packed_layers_dir {
+                let _ = std::fs::create_dir_all(mountpoint);
+            }
+        }
+        // Whether the per-VM uid drop is active for this boot. The idmapped pack
+        // bind mount needs CAP_SYS_ADMIN (root) — the same precondition as the
+        // drop — so we only keep `pack_idmap_source` when the drop is active;
+        // otherwise the VMM stays root and reads the shared copy directly.
+        let mut uid_drop_active = false;
         if let Some(d) = data_dir.as_deref() {
             if let Some(result) =
                 crate::process::vm_drop_ids(&registry, d, features.snapshot_dir.as_deref())
@@ -1649,8 +1700,25 @@ impl AgentManager {
                     ("SMOLVM_VM_UID", uid.to_string()),
                     ("SMOLVM_VM_GID", gid.to_string()),
                 ];
+                uid_drop_active = true;
             }
         }
+
+        // Resolve how the shared pack is presented to the guest. With the uid
+        // drop active, keep the idmap source so `internal_boot` (still root, in a
+        // private mount namespace) idmap-binds the root-owned shared copy onto the
+        // empty `packed_layers_dir` mountpoint, mapping on-disk uid 0 -> vm_uid.
+        // Without the drop (non-root `serve`, or SMOLVM_VM_UID_DROP=off), there is
+        // no second uid to isolate from, so collapse the indirection: point
+        // `packed_layers_dir` straight at the shared copy and read it as root.
+        let pack_idmap_source = if uid_drop_active {
+            features.pack_idmap_source.take()
+        } else {
+            if let Some(shared) = features.pack_idmap_source.take() {
+                features.packed_layers_dir = Some(shared);
+            }
+            None
+        };
 
         // Write boot config to a file the subprocess will read
         let config = BootConfig {
@@ -1668,6 +1736,7 @@ impl AgentManager {
             ssh_agent_socket: features.ssh_agent_socket,
             dns_filter_hosts: features.dns_filter_hosts,
             packed_layers_dir: features.packed_layers_dir,
+            pack_idmap_source,
             extra_disks: features.extra_disks,
         };
         let config_path = self

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -27,8 +27,9 @@ pub use launcher::{
 };
 pub use manager::{
     disk_used_mb, docker_config_dir, docker_config_mount, ensure_vm_dir, machine_layers_cache_dir,
-    prune_orphaned_ready_markers, read_egress_telemetry, resolve_disk_image, vm_cache_root,
-    vm_data_dir, vm_dir_hash, vm_uid_registry_dir, AgentManager, AgentState,
+    prune_orphaned_ready_markers, read_egress_telemetry, read_shared_pack_pointer,
+    resolve_disk_image, shared_pack_cache_root, shared_pack_pointer_path, vm_cache_root,
+    vm_data_dir, vm_dir_hash, vm_uid_registry_dir, AgentManager, AgentState, SHARED_PACK_POINTER,
 };
 
 /// Agent VM name.

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -480,9 +480,7 @@ pub async fn create_machine(
                         &footer,
                         false,
                     )
-                    .map_err(|e| {
-                        ApiError::internal(format!("extract sidecar (shared): {}", e))
-                    })?;
+                    .map_err(|e| ApiError::internal(format!("extract sidecar (shared): {}", e)))?;
                     std::fs::create_dir_all(&cache_dir).map_err(|e| {
                         ApiError::internal(format!("create pack mountpoint: {}", e))
                     })?;

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -461,21 +461,54 @@ pub async fn create_machine(
             let path = std::path::Path::new(&sidecar_path);
             let cache_dir = crate::agent::machine_layers_cache_dir(&name);
             let result = (|| {
-                smolvm_pack::extract::force_detach_layers_volume(&cache_dir);
-                match std::fs::remove_dir_all(&cache_dir) {
-                    Ok(()) => {}
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                    Err(e) => {
-                        return Err(ApiError::internal(format!(
-                            "clear packed layers cache: {}",
-                            e
-                        )));
-                    }
-                }
                 let footer = smolvm_pack::packer::read_footer_from_sidecar(path)
                     .map_err(|e| ApiError::internal(format!("read sidecar footer: {}", e)))?;
-                smolvm_pack::extract::extract_sidecar(path, &cache_dir, &footer, false, false)
-                    .map_err(|e| ApiError::internal(format!("extract sidecar: {}", e)))
+                if smolvm_pack::extract::shared_extract_enabled() {
+                    // Shared content-addressed store: extract the build-constant
+                    // pack ONCE per node into `_shared/<checksum>` (root-owned,
+                    // read-only) instead of a private per-machine copy, and drop a
+                    // pointer beside this machine. The per-machine `pack` dir is
+                    // left an empty mountpoint that the boot path idmap-binds the
+                    // shared copy onto (mapping on-disk uid 0 -> the VM's dropped
+                    // uid), so a 28.6 MB / 362-file agent-rootfs decodes once per
+                    // node rather than once per machine — the cold-start tax this
+                    // removes — with the per-VM uid isolation (#456) preserved.
+                    let shared_root = crate::agent::shared_pack_cache_root();
+                    let shared_dir = smolvm_pack::extract::extract_sidecar_shared(
+                        path,
+                        &shared_root,
+                        &footer,
+                        false,
+                    )
+                    .map_err(|e| {
+                        ApiError::internal(format!("extract sidecar (shared): {}", e))
+                    })?;
+                    std::fs::create_dir_all(&cache_dir).map_err(|e| {
+                        ApiError::internal(format!("create pack mountpoint: {}", e))
+                    })?;
+                    let pointer = crate::agent::shared_pack_pointer_path(&cache_dir);
+                    std::fs::write(&pointer, shared_dir.to_string_lossy().as_bytes()).map_err(
+                        |e| ApiError::internal(format!("write shared pack pointer: {}", e)),
+                    )?;
+                    Ok(())
+                } else {
+                    // Per-machine extraction: macOS case-sensitive layers volume
+                    // (owned 1:1 by the machine), or the `SMOLVM_DISABLE_SHARED_EXTRACT`
+                    // kill-switch. Wipe any prior cache first for a clean slate.
+                    smolvm_pack::extract::force_detach_layers_volume(&cache_dir);
+                    match std::fs::remove_dir_all(&cache_dir) {
+                        Ok(()) => {}
+                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                        Err(e) => {
+                            return Err(ApiError::internal(format!(
+                                "clear packed layers cache: {}",
+                                e
+                            )));
+                        }
+                    }
+                    smolvm_pack::extract::extract_sidecar(path, &cache_dir, &footer, false, false)
+                        .map_err(|e| ApiError::internal(format!("extract sidecar: {}", e)))
+                }
             })();
             // Detach the case-sensitive volume mounted during extraction so a
             // created-but-unstarted machine leaves nothing mounted, and so the
@@ -514,9 +547,15 @@ pub async fn create_machine(
             .unwrap_or_else(|| vm_data_dir(&name));
         let seed_result = tokio::task::spawn_blocking(move || -> Result<(), ApiError> {
             let cache_dir = crate::agent::machine_layers_cache_dir(&name2);
+            // With the shared store, the pack contents live in `_shared/<checksum>`
+            // (the per-machine `pack` dir is an empty mountpoint), so seed the
+            // VM-mode disk templates from the shared copy. Falls back to the
+            // per-machine dir when no pointer was written (macOS / kill-switch).
+            let pack_content_dir =
+                crate::agent::read_shared_pack_pointer(&cache_dir).unwrap_or(cache_dir);
             crate::storage::seed_vm_mode_disks(
                 &disk_dir,
-                &cache_dir,
+                &pack_content_dir,
                 seed.overlay_template.as_deref(),
                 seed.storage_template.as_deref(),
                 seed.overlay_logical_size,

--- a/src/cli/internal_boot.rs
+++ b/src/cli/internal_boot.rs
@@ -148,6 +148,38 @@ pub fn run(config_path: PathBuf) -> smolvm::Result<()> {
         );
     }
 
+    // Shared pack store: present the node's root-owned shared pack copy at this
+    // VM's `packed_layers_dir` via a per-VM idmapped bind mount (on-disk uid 0 ->
+    // this VM's uid), in a private mount namespace that's torn down on exit. Done
+    // here while still privileged (needs CAP_SYS_ADMIN) and BEFORE the uid drop
+    // and Landlock/seccomp. The manager only sets `pack_idmap_source` when the uid
+    // drop is active, so SMOLVM_VM_UID is guaranteed present; fail closed if not.
+    #[cfg(target_os = "linux")]
+    if let Some(ref shared) = config.pack_idmap_source {
+        let target = match config.packed_layers_dir {
+            Some(ref t) => t,
+            None => {
+                eprintln!("[pack-idmap] idmap source set without a mountpoint; refusing to boot");
+                smolvm::process::exit_child(1);
+            }
+        };
+        let uid: u32 = std::env::var("SMOLVM_VM_UID")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| {
+                eprintln!("[pack-idmap] idmap source set without SMOLVM_VM_UID; refusing to boot");
+                smolvm::process::exit_child(1);
+            });
+        let gid: u32 = std::env::var("SMOLVM_VM_GID")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(uid);
+        if let Err(e) = smolvm::process::setup_pack_idmap_mount(shared, target, uid, gid) {
+            eprintln!("[pack-idmap] failed to mount shared pack, refusing to boot: {e}");
+            smolvm::process::exit_child(1);
+        }
+    }
+
     // Drop to an unprivileged uid before touching the guest, so a guest→VMM
     // escape can't signal/ptrace the supervisor or neighbor VMs nor reach
     // root-owned host files. Gated by SMOLVM_VM_UID (+ optional SMOLVM_VM_GID,

--- a/src/cli/pack_run.rs
+++ b/src/cli/pack_run.rs
@@ -431,6 +431,7 @@ impl PackRunCmd {
                 ssh_agent_socket: None,
                 dns_filter_hosts: None,
                 packed_layers_dir: Some(layers_dir.to_path_buf()),
+                pack_idmap_source: None,
                 extra_disks: vec![],
             };
 
@@ -1402,6 +1403,7 @@ fn run_from_cache(
             ssh_agent_socket: None,
             dns_filter_hosts: None,
             packed_layers_dir: Some(layers_dir.to_path_buf()),
+            pack_idmap_source: None,
             extra_disks: vec![],
         };
         let config_path = runtime_dir.path().join("boot-config.json");

--- a/src/process.rs
+++ b/src/process.rs
@@ -1282,8 +1282,9 @@ pub fn setup_pack_idmap_mount(
     // Clone the shared subtree into a detached mount object. mount_setattr's idmap
     // requires a freshly-cloned mount with no other users, which OPEN_TREE_CLONE
     // provides; AT_RECURSIVE covers any submounts.
-    let open_flags: libc::c_uint =
-        libc::OPEN_TREE_CLONE | libc::AT_RECURSIVE as libc::c_uint | libc::O_CLOEXEC as libc::c_uint;
+    let open_flags: libc::c_uint = libc::OPEN_TREE_CLONE
+        | libc::AT_RECURSIVE as libc::c_uint
+        | libc::O_CLOEXEC as libc::c_uint;
     let tree = unsafe {
         libc::syscall(
             libc::SYS_open_tree,

--- a/src/process.rs
+++ b/src/process.rs
@@ -1132,6 +1132,214 @@ pub fn chown_tree(_path: &std::path::Path, _uid: u32, _gid: u32) -> std::io::Res
     Ok(())
 }
 
+/// Build a user namespace whose single-entry uid/gid maps make on-disk id 0
+/// appear as `(uid, gid)` *through an idmapped mount*, and return an fd to its
+/// `/proc/<pid>/ns/user` (the open fd keeps the namespace alive after the helper
+/// process exits).
+///
+/// Mechanics (validated against kernels 6.17/6.18): fork a helper that
+/// `unshare(CLONE_NEWUSER)`s and blocks; the parent (still privileged) writes the
+/// child's `uid_map`/`gid_map`. A map line is `<nsid> <hostid> <count>`, and an
+/// idmapped mount treats the ON-DISK id as an nsid and maps it DOWN to a host
+/// kuid — so to surface on-disk 0 as host `uid` we write `0 <uid> 1` (NOT
+/// `<uid> 0 1`, which surfaces the overflow uid and denies every read). The
+/// parent MUST wait until the child is inside the new userns before writing the
+/// maps (a two-pipe handshake), or the write races the `unshare` and fails EPERM.
+/// `setgroups` is denied before `gid_map` (required to write a gid map).
+#[cfg(target_os = "linux")]
+fn make_idmap_userns(uid: u32, gid: u32) -> std::io::Result<libc::c_int> {
+    let errno = || std::io::Error::last_os_error();
+    // ready: child -> parent (userns created); go: parent -> child (maps written).
+    let mut ready = [-1i32; 2];
+    let mut go = [-1i32; 2];
+    if unsafe { libc::pipe(ready.as_mut_ptr()) } != 0 {
+        return Err(errno());
+    }
+    if unsafe { libc::pipe(go.as_mut_ptr()) } != 0 {
+        let e = errno();
+        unsafe {
+            libc::close(ready[0]);
+            libc::close(ready[1]);
+        }
+        return Err(e);
+    }
+    let pid = unsafe { libc::fork() };
+    if pid < 0 {
+        let e = errno();
+        unsafe {
+            libc::close(ready[0]);
+            libc::close(ready[1]);
+            libc::close(go[0]);
+            libc::close(go[1]);
+        }
+        return Err(e);
+    }
+    if pid == 0 {
+        // CHILD: async-signal-safe calls only (post-fork in a possibly threaded
+        // process). Become a fresh userns, signal the parent, block until the maps
+        // are written, then exit — the parent's open ns fd keeps the userns alive.
+        if unsafe { libc::unshare(libc::CLONE_NEWUSER) } != 0 {
+            unsafe { libc::_exit(1) };
+        }
+        let sig: [u8; 1] = [b'r'];
+        unsafe {
+            libc::write(ready[1], sig.as_ptr() as *const libc::c_void, 1);
+        }
+        let mut got = 0u8;
+        unsafe {
+            libc::read(go[0], &mut got as *mut u8 as *mut libc::c_void, 1);
+            libc::_exit(0);
+        }
+    }
+
+    // PARENT. Close the ends we don't use, then wait for the child's "ready".
+    unsafe {
+        libc::close(ready[1]);
+        libc::close(go[0]);
+    }
+    let mut got = 0u8;
+    let _ = unsafe { libc::read(ready[0], &mut got as *mut u8 as *mut libc::c_void, 1) };
+
+    // Write the maps from the privileged parent. A single entry mapping host id
+    // `uid`/`gid` is permitted via the ns-creator's CAP_SETUID/CAP_SETGID path.
+    let finish = |result: std::io::Result<libc::c_int>| -> std::io::Result<libc::c_int> {
+        let go_w: [u8; 1] = [b'x'];
+        unsafe {
+            libc::write(go[1], go_w.as_ptr() as *const libc::c_void, 1);
+            libc::close(go[1]);
+            libc::close(ready[0]);
+            let mut status = 0;
+            libc::waitpid(pid, &mut status, 0);
+        }
+        result
+    };
+    if let Err(e) = std::fs::write(format!("/proc/{pid}/uid_map"), format!("0 {uid} 1\n")) {
+        return finish(Err(e));
+    }
+    // Must deny setgroups(2) before a gid_map may be written in a userns.
+    let _ = std::fs::write(format!("/proc/{pid}/setgroups"), "deny");
+    if let Err(e) = std::fs::write(format!("/proc/{pid}/gid_map"), format!("0 {gid} 1\n")) {
+        return finish(Err(e));
+    }
+    let ns_path = std::ffi::CString::new(format!("/proc/{pid}/ns/user")).unwrap();
+    let nsfd = unsafe { libc::open(ns_path.as_ptr(), libc::O_RDONLY | libc::O_CLOEXEC) };
+    if nsfd < 0 {
+        return finish(Err(errno()));
+    }
+    finish(Ok(nsfd))
+}
+
+/// Present the root-owned shared pack at `shared` onto the per-VM mountpoint
+/// `target` via an idmapped bind mount that maps on-disk uid/gid 0 -> `(uid, gid)`
+/// — so the VMM (about to drop to that uid) reads every file as its owner, while
+/// the underlying shared copy stays root-only on disk (a sibling VM's uid can't
+/// read it directly). This is what lets one root-owned shared copy replace the
+/// per-machine extract + chown while preserving the per-VM uid isolation (#456).
+///
+/// The mount is made in a fresh **private** mount namespace, so it is visible only
+/// to this VMM process (and the libkrun threads it later spawns) and is torn down
+/// automatically when the process exits — no teardown plumbing, no propagation to
+/// the host or sibling VMs. MUST run while still privileged (CAP_SYS_ADMIN) and
+/// BEFORE Landlock/seccomp/`drop_privileges`. Linux ≥ 5.12.
+#[cfg(target_os = "linux")]
+pub fn setup_pack_idmap_mount(
+    shared: &std::path::Path,
+    target: &std::path::Path,
+    uid: u32,
+    gid: u32,
+) -> std::io::Result<()> {
+    use std::os::unix::ffi::OsStrExt;
+    let errno = || std::io::Error::last_os_error();
+
+    // Our own mount namespace: the idmap mount lives and dies with this process.
+    if unsafe { libc::unshare(libc::CLONE_NEWNS) } != 0 {
+        return Err(errno());
+    }
+    // Don't propagate mounts back into the host's mount namespace.
+    if unsafe {
+        libc::mount(
+            std::ptr::null(),
+            c"/".as_ptr(),
+            std::ptr::null(),
+            libc::MS_REC | libc::MS_PRIVATE,
+            std::ptr::null(),
+        )
+    } != 0
+    {
+        return Err(errno());
+    }
+
+    let userns_fd = make_idmap_userns(uid, gid)?;
+    let close_userns = || unsafe {
+        libc::close(userns_fd);
+    };
+
+    let shared_c = std::ffi::CString::new(shared.as_os_str().as_bytes())
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;
+    let target_c = std::ffi::CString::new(target.as_os_str().as_bytes())
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;
+
+    // Clone the shared subtree into a detached mount object. mount_setattr's idmap
+    // requires a freshly-cloned mount with no other users, which OPEN_TREE_CLONE
+    // provides; AT_RECURSIVE covers any submounts.
+    let open_flags: libc::c_uint =
+        libc::OPEN_TREE_CLONE | libc::AT_RECURSIVE as libc::c_uint | libc::O_CLOEXEC as libc::c_uint;
+    let tree = unsafe {
+        libc::syscall(
+            libc::SYS_open_tree,
+            libc::AT_FDCWD,
+            shared_c.as_ptr(),
+            open_flags,
+        )
+    } as libc::c_int;
+    if tree < 0 {
+        let e = errno();
+        close_userns();
+        return Err(e);
+    }
+    let close_tree = || unsafe {
+        libc::close(tree);
+    };
+
+    // Attach the idmap (recursively) to the cloned tree.
+    let mut attr: libc::mount_attr = unsafe { std::mem::zeroed() };
+    attr.attr_set = libc::MOUNT_ATTR_IDMAP;
+    attr.userns_fd = userns_fd as u64;
+    let rc = unsafe {
+        libc::syscall(
+            libc::SYS_mount_setattr,
+            tree,
+            c"".as_ptr(),
+            (libc::AT_EMPTY_PATH | libc::AT_RECURSIVE) as libc::c_uint,
+            &attr as *const libc::mount_attr,
+            std::mem::size_of::<libc::mount_attr>() as libc::size_t,
+        )
+    };
+    if rc != 0 {
+        let e = errno();
+        close_tree();
+        close_userns();
+        return Err(e);
+    }
+
+    // Move the now-idmapped tree onto the per-VM mountpoint.
+    let rc = unsafe {
+        libc::syscall(
+            libc::SYS_move_mount,
+            tree,
+            c"".as_ptr(),
+            libc::AT_FDCWD,
+            target_c.as_ptr(),
+            libc::MOVE_MOUNT_F_EMPTY_PATH as libc::c_uint,
+        )
+    };
+    let result = if rc != 0 { Err(errno()) } else { Ok(()) };
+    // The kernel holds its own references now; our fds are no longer needed.
+    close_tree();
+    close_userns();
+    result
+}
+
 /// Process-wide gate bounding concurrent VM disk-prep / boot. Every boot path —
 /// the API `start_machine`, the supervisor's restart/reconnect, and startup
 /// reconnect — funnels through `AgentManager::start_via_subprocess`, which

--- a/tests/idmap_e2e_boot.sh
+++ b/tests/idmap_e2e_boot.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Full-VM e2e for the shared content-addressed pack store + per-VM idmapped
+# bind mount. Drives the *serve API* (the cloud/node path that the shared store
+# targets) as root so the per-VM uid drop (#456) is active and the idmap mount
+# fires. Validates: (1) shared store extracts ONCE into _shared/<checksum>,
+# root-owned 0700; (2) a second machine from the same .smolmachine REUSES it
+# (no second decode); (3) each machine leaves an empty `pack` mountpoint + a
+# `.pack-shared` pointer; (4) both guests BOOT and exec reads files (proving the
+# idmap mount presented the root-owned pack as the VM's dropped uid); (5) the
+# on-disk shared copy stays root:root (isolation preserved).
+#
+# Run as root on a Linux/KVM box:  sudo SMOLVM=... SMOLVM_LIB_DIR=... ./idmap_e2e_boot.sh /path/to/x.smolmachine
+set -u
+
+SMOLVM="${SMOLVM:?set SMOLVM to the smolvm binary}"
+SIDECAR="${1:?usage: idmap_e2e_boot.sh <file.smolmachine>}"
+DATA_DIR="${SMOLVM_DATA_DIR:-/tmp/idmap-e2e-data}"
+SOCK="/tmp/idmap-e2e.sock"
+CURL=(curl -s --unix-socket "$SOCK")
+URL="http://localhost"
+PASS=0; FAIL=0
+ok()   { echo "  PASS: $*"; PASS=$((PASS+1)); }
+bad()  { echo "  FAIL: $*"; FAIL=$((FAIL+1)); }
+
+# Fresh, world-traversable data root so the dropped VM uid can reach its dirs.
+rm -rf "$DATA_DIR"; mkdir -p "$DATA_DIR"; chmod 755 "$DATA_DIR"
+export SMOLVM_DATA_DIR="$DATA_DIR"
+
+# Seed the node-constant guest agent-rootfs (the serve API gates `start` on it
+# via "verify rootfs"). It's install-state, not part of the per-image pack the
+# shared store optimizes, so we copy a known-good tree in rather than re-install.
+AGENT_ROOTFS_SRC="${AGENT_ROOTFS_SRC:-$HOME/.local/share/smolvm/agent-rootfs}"
+if [ -d "$AGENT_ROOTFS_SRC" ]; then
+  mkdir -p "$DATA_DIR/.local/share/smolvm"
+  cp -a "$AGENT_ROOTFS_SRC" "$DATA_DIR/.local/share/smolvm/agent-rootfs"
+  chmod -R a+rX "$DATA_DIR/.local/share/smolvm"
+else
+  echo "[!] no agent-rootfs at $AGENT_ROOTFS_SRC — boot steps will fail (set AGENT_ROOTFS_SRC)"
+fi
+
+echo "[*] euid=$(id -u) (expect 0 for uid-drop), data=$DATA_DIR, sidecar=$SIDECAR"
+
+rm -f "$SOCK"
+"$SMOLVM" serve start -l "unix://$SOCK" >"$DATA_DIR/serve.log" 2>&1 &
+SERVE_PID=$!
+cleanup() {
+  "${CURL[@]}" -X DELETE "$URL/api/v1/machines/e2e-a" >/dev/null 2>&1 || true
+  "${CURL[@]}" -X DELETE "$URL/api/v1/machines/e2e-b" >/dev/null 2>&1 || true
+  kill "$SERVE_PID" 2>/dev/null || true; wait "$SERVE_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+for i in $(seq 1 50); do "${CURL[@]}" "$URL/health" >/dev/null 2>&1 && break; sleep 0.2; done
+"${CURL[@]}" "$URL/health" | grep -q '"status":"ok"' && ok "serve up" || { bad "serve did not start"; cat "$DATA_DIR/serve.log"; exit 1; }
+
+create() {
+  "${CURL[@]}" -o /dev/null -w "%{http_code}" -X POST "$URL/api/v1/machines" \
+    -H 'Content-Type: application/json' -d "{\"name\":\"$1\",\"from\":\"$SIDECAR\",\"cpus\":1,\"mem\":512}"
+}
+
+# --- Create machine A: first extraction populates the shared store ----------
+echo "[*] creating e2e-a"
+[ "$(create e2e-a)" = "200" ] && ok "create e2e-a 200" || bad "create e2e-a !=200"
+
+# Layout: SMOLVM_DATA_DIR becomes $HOME, so the store is $HOME/.cache/smolvm/vms.
+VMS_ROOT="$(find "$DATA_DIR" -type d -path '*/smolvm/vms' | head -1)"
+SHARED_ROOT="$VMS_ROOT/_shared"
+[ -d "$SHARED_ROOT" ] && ok "shared root exists: $SHARED_ROOT" || bad "no shared root (vms=$VMS_ROOT)"
+CKDIR="$(find "$SHARED_ROOT" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | head -1)"
+[ -n "$CKDIR" ] && ok "shared checksum dir: $(basename "$CKDIR")" || bad "no shared checksum dir"
+# Root-owned + 0700 (isolation): a sibling dropped-uid cannot read it directly.
+own="$(stat -c '%U:%G %a' "$CKDIR" 2>/dev/null)"
+[ "$own" = "root:root 700" ] && ok "shared dir is root:root 0700" || bad "shared dir perms = $own (want root:root 700)"
+# Per-machine: empty `pack` mountpoint + a pointer to the shared dir.
+PACK_A="$(find "$VMS_ROOT" -mindepth 2 -maxdepth 2 -name pack -type d 2>/dev/null | grep -v _shared | head -1)"
+PTR_A="$(dirname "$PACK_A")/.pack-shared"
+[ -f "$PTR_A" ] && ok "pointer written: $PTR_A -> $(cat "$PTR_A")" || bad "no .pack-shared pointer"
+[ -z "$(ls -A "$PACK_A" 2>/dev/null)" ] && ok "pack mountpoint is empty (pre-boot)" || bad "pack mountpoint not empty"
+
+# --- Create machine B from the SAME sidecar: must REUSE, not re-extract ------
+echo "[*] creating e2e-b (same sidecar)"
+[ "$(create e2e-b)" = "200" ] && ok "create e2e-b 200" || bad "create e2e-b !=200"
+NDIRS="$(find "$SHARED_ROOT" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+[ "$NDIRS" = "1" ] && ok "still ONE shared dir after 2 creates (reuse, no re-decode)" || bad "shared dirs=$NDIRS (expected 1)"
+
+# --- Boot both: idmap mount presents the root-owned pack as each VM's uid ----
+boot_and_exec() {
+  local n="$1"
+  local st; st="$("${CURL[@]}" -X POST "$URL/api/v1/machines/$n/start")"
+  echo "$st" | grep -q '"state":"running"' && ok "$n booted (state=running)" || { bad "$n did not boot"; echo "$st"; }
+  local ex; ex="$("${CURL[@]}" -X POST "$URL/api/v1/machines/$n/exec" -H 'Content-Type: application/json' -d '{"command":["cat","/etc/os-release"]}')"
+  echo "$ex" | grep -qi 'alpine\|linux' && ok "$n exec read rootfs through idmap mount" || { bad "$n exec failed"; echo "$ex" | head -c 400; }
+}
+boot_and_exec e2e-a
+boot_and_exec e2e-b
+
+# --- Isolation: shared copy still root-owned after both VMs booted -----------
+own2="$(stat -c '%U:%G %a' "$CKDIR" 2>/dev/null)"
+[ "$own2" = "root:root 700" ] && ok "shared copy still root:root 0700 post-boot" || bad "shared perms changed: $own2"
+
+# --- The two VMMs dropped to DIFFERENT uids (per-VM isolation #456) ----------
+uids="$(ps -eo uid,args | grep '[_]boot-vm' | awk '{print $1}' | sort -u)"
+nuid="$(echo "$uids" | grep -c .)"
+echo "[*] live _boot-vm uids: $(echo $uids | tr '\n' ' ')"
+[ "$nuid" -ge 2 ] && ok "VMMs run under >=2 distinct dropped uids" || echo "  INFO: distinct boot-vm uids=$nuid (VMs may share or have exited)"
+
+echo ""
+echo "==== idmap e2e: $PASS passed, $FAIL failed ===="
+[ "$FAIL" = "0" ]

--- a/tests/idmap_mount.rs
+++ b/tests/idmap_mount.rs
@@ -1,0 +1,84 @@
+//! Validates the shared-pack idmapped-bind-mount mechanism on a real Linux
+//! kernel (>= 5.12). This is the novel piece of the shared content-addressed
+//! pack store: one root-owned copy of the build-constant pack is extracted per
+//! node, then presented at each VM's `pack` mountpoint via an idmapped bind
+//! mount that maps the on-disk uid/gid 0 down to the VM's dropped uid (#456).
+//!
+//! Root-only (needs CAP_SYS_ADMIN for unshare/open_tree/mount_setattr/move_mount)
+//! and Linux-only, so it is `#[ignore]`d by default. Run on the test box with:
+//!   sudo -E cargo test --release --test idmap_mount -- --ignored --test-threads=1
+#![cfg(target_os = "linux")]
+
+use std::os::unix::fs::MetadataExt;
+
+/// A distinctive uid/gid well outside any real account, matching the
+/// 2_000_000+ range #456 drops VMM processes into.
+const TEST_UID: u32 = 2_000_123;
+const TEST_GID: u32 = 2_000_123;
+
+#[test]
+#[ignore = "requires root (CAP_SYS_ADMIN) and Linux >= 5.12"]
+fn idmap_mount_presents_root_owned_pack_as_vm_uid() {
+    // SAFETY of the in-process mount-ns mutation: setup_pack_idmap_mount does
+    // unshare(CLONE_NEWNS), so the bind mount is visible only to this thread's
+    // private mount namespace and vanishes when the test process exits. Run with
+    // --test-threads=1 so no sibling test races on the namespace.
+    let root = std::env::temp_dir().join(format!("smolvm-idmap-test-{}", std::process::id()));
+    let shared = root.join("shared");
+    let target = root.join("target");
+    std::fs::create_dir_all(&shared).expect("mkdir shared");
+    std::fs::create_dir_all(&target).expect("mkdir target");
+
+    // A root-owned (extraction-as-root => uid 0) file + nested dir, mirroring the
+    // agent-rootfs tree the real pack contains.
+    let file = shared.join("hello");
+    std::fs::write(&file, b"pack contents").expect("write shared file");
+    let nested_dir = shared.join("sub");
+    std::fs::create_dir_all(&nested_dir).expect("mkdir nested");
+    let nested_file = nested_dir.join("deep");
+    std::fs::write(&nested_file, b"deep contents").expect("write nested file");
+
+    // Precondition: on disk the files are owned by uid/gid 0.
+    let pre = std::fs::metadata(&file).expect("stat pre");
+    assert_eq!(pre.uid(), 0, "shared file must start root-owned");
+    assert_eq!(pre.gid(), 0, "shared file must start root-group");
+
+    // Exercise the mechanism under test.
+    smolvm::process::setup_pack_idmap_mount(&shared, &target, TEST_UID, TEST_GID)
+        .expect("setup_pack_idmap_mount failed");
+
+    // Through the idmapped mount, on-disk uid 0 must surface as the VM uid — this
+    // is what lets the soon-to-drop VMM read every pack file as its owner.
+    let mapped = std::fs::metadata(target.join("hello")).expect("stat mapped file");
+    assert_eq!(
+        mapped.uid(),
+        TEST_UID,
+        "idmapped mount must surface on-disk uid 0 as the VM uid"
+    );
+    assert_eq!(
+        mapped.gid(),
+        TEST_GID,
+        "idmapped mount must surface on-disk gid 0 as the VM gid"
+    );
+    // Contents must read through unchanged (it is the same inode, just remapped).
+    let body = std::fs::read(target.join("hello")).expect("read mapped file");
+    assert_eq!(body, b"pack contents", "mapped file contents must match");
+
+    // AT_RECURSIVE must remap nested entries too, not just the top level.
+    let mapped_deep =
+        std::fs::metadata(target.join("sub").join("deep")).expect("stat mapped nested");
+    assert_eq!(
+        mapped_deep.uid(),
+        TEST_UID,
+        "nested entries must be remapped (AT_RECURSIVE)"
+    );
+
+    // Isolation invariant: the underlying shared copy is untouched on disk — a
+    // sibling VM dropped to a *different* uid still sees it as root-only and so
+    // cannot read it directly (only its own idmapped view maps it).
+    let post = std::fs::metadata(&file).expect("stat post");
+    assert_eq!(post.uid(), 0, "on-disk shared copy must stay root-owned");
+
+    // Best-effort cleanup; the private mount ns tears down on process exit anyway.
+    let _ = std::fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
Extract the build-constant pack once per node into a content-addressed `_shared/<checksum>` store and present it to each VM via a private idmapped bind mount (on-disk uid 0 → the VM's dropped uid), removing the redundant per-machine re-extract+re-chown cold-start tax while preserving #456 per-VM uid isolation (Linux only; macOS unchanged).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/494">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->