### PR TITLE
fix(release): drop the obsolete guest-init build step (libkrun 2.0.0 embeds init)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,18 +253,11 @@ jobs:
         env:
           SMOL_REPO_TOKEN: ${{ secrets.SMOL_REPO_TOKEN }}
 
-      # Rebuild the guest init (PID 1) for the target arch. libkrun/init/init is
-      # a committed binary that does not track arch, and this job uses prebuilt
-      # libkrun libs rather than building libkrun — so without this the dist would
-      # ship whatever arch was committed (the x86_64 release once shipped the
-      # aarch64 init, issue #365). Each runner is native to its target, so a plain
-      # static compile produces the correct arch; build-dist.sh asserts it.
-      - name: Build guest init for target arch (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          cc -O2 -static -Wall -o libkrun/init/init \
-            libkrun/init/init.c libkrun/init/dhcp.c
-          file libkrun/init/init
+      # No separate guest-init build: libkrun 2.0.0 embeds the guest init
+      # (krun-init) directly in libkrun.so (INIT_BLOB is on by default), so the
+      # old per-arch `cc init/init.c` step is gone — init.c no longer exists in
+      # the 2.0.0 submodule, and a VM boots from the embedded init with no
+      # external init.krun (verified). build-dist.sh no longer bundles init.krun.
 
       - name: Build distribution tarball
         run: ./scripts/build-dist.sh --skip-agent-build

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -423,15 +423,20 @@ else
     fi
 fi
 
-# Copy init.krun for Linux (required by libkrunfw kernel)
+# Copy init.krun for Linux only if a real (non-empty) init binary is present.
+# libkrun 2.0.0 embeds the guest init (krun-init) in libkrun.so (INIT_BLOB on by
+# default), so no external init.krun is needed — a VM boots from the embedded
+# init (verified). The committed `libkrun/init/init` is now an empty placeholder,
+# so the `-s` (non-empty) checks skip it; a real prebuilt init still gets bundled
+# for older libkrun builds that expect an external init.krun.
 if [[ "$(uname -s)" == "Linux" ]]; then
-    # Look for init.krun in libkrun submodule or system locations
+    # Look for a non-empty init.krun in the submodule or system locations.
     INIT_KRUN=""
-    if [[ -n "$LOCAL_INIT_KRUN" ]] && [[ -f "$LOCAL_INIT_KRUN" ]]; then
+    if [[ -n "$LOCAL_INIT_KRUN" ]] && [[ -s "$LOCAL_INIT_KRUN" ]]; then
         INIT_KRUN="$LOCAL_INIT_KRUN"
-    elif [[ -f "$PROJECT_ROOT/libkrun/init/init" ]]; then
+    elif [[ -s "$PROJECT_ROOT/libkrun/init/init" ]]; then
         INIT_KRUN="$PROJECT_ROOT/libkrun/init/init"
-    elif [[ -f "/usr/local/share/smolvm/init.krun" ]]; then
+    elif [[ -s "/usr/local/share/smolvm/init.krun" ]]; then
         INIT_KRUN="/usr/local/share/smolvm/init.krun"
     fi
 
@@ -460,7 +465,7 @@ if [[ "$(uname -s)" == "Linux" ]]; then
         fi
         echo "init.krun arch OK ($init_desc)"
     else
-        echo "Warning: init.krun not found - users may need to build libkrun init"
+        echo "No external init.krun bundled (libkrun 2.0.0 embeds the guest init)."
     fi
 fi
 


### PR DESCRIPTION
The release pipeline's `cc libkrun/init/init.c` step has been broken since the libkrun 2.0.0 migration (#465) — init.c no longer exists and 2.0.0 embeds the guest init in libkrun.so (INIT_BLOB default), so the external init.krun is vestigial; this removes the dead step and stops bundling init.krun. Verified on KVM: a VM boots from the embedded init with no external init.krun and unchanged boot time (~0.2s).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/495">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->