### PR TITLE
fix(windows): ship agent-rootfs as a tarball; resolve libs/rootfs next to smolvm.exe

### DIFF
--- a/scripts/build-dist-windows.sh
+++ b/scripts/build-dist-windows.sh
@@ -5,7 +5,7 @@
 # it runs on a Linux host, cross-compiles smolvm.exe with the mingw-w64 toolchain,
 # and assembles the layout that boots on Windows/WHP — smolvm.exe with krun.dll +
 # libkrunfw.dll beside it (Windows resolves DLLs from the exe's directory), the
-# Linux x86_64 agent-rootfs, and the pre-formatted ext4 disk templates. The guest
+# Linux x86_64 agent-rootfs (as a tarball), and the pre-formatted ext4 disk templates. The guest
 # is Linux, so the rootfs/templates are the same artifacts the linux-x86_64 dist
 # ships; only the host binary + libraries are Windows-specific.
 #
@@ -70,18 +70,25 @@ cp "$EXE" "$DIST_DIR/smolvm.exe"
 cp "$LIB_DIR/krun.dll" "$DIST_DIR/krun.dll"
 cp "$LIB_DIR/libkrunfw.dll" "$DIST_DIR/libkrunfw.dll"
 
-# Linux x86_64 guest rootfs (cp -a preserves the busybox symlinks). The caller
-# must have placed the smolvm-agent binary into the rootfs already — the rootfs
-# artifact itself ships agent-less (the agent is injected per-dist, like the
-# Unix build-dist.sh path).
+# Ship the Linux x86_64 guest rootfs as a TARBALL, not an extracted dir: a `.zip`
+# can't carry the dir tree (busybox symlinks, modes, special files) — that is what
+# broke the first attempt. smolvm.exe extracts `agent-rootfs.tar.gz` on first run
+# via ensure_extracted_rootfs (Windows `tar.exe`; symlinks it can't make are
+# skipped, tolerated by the runtime). The caller must have injected the agent
+# binary into the rootfs already (the rootfs artifact ships agent-less).
 if [[ ! -f "$ROOTFS_SRC/usr/local/bin/smolvm-agent" ]]; then
     echo "Error: target/agent-rootfs is missing usr/local/bin/smolvm-agent." >&2
     echo "       Inject the Linux x86_64 agent into the rootfs before packaging." >&2
     exit 1
 fi
-mkdir -p "$DIST_DIR/agent-rootfs"
-cp -a "$ROOTFS_SRC"/. "$DIST_DIR/agent-rootfs/"
-echo "Agent rootfs size: $(du -sh "$DIST_DIR/agent-rootfs" | cut -f1)"
+# The rootfs is extracted as root in CI; use sudo to read any restricted files,
+# then hand the tarball back to the runner user so the later `zip` can read it.
+TAR_SUDO=""
+if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then TAR_SUDO="sudo"; fi
+echo "Packing agent-rootfs.tar.gz..."
+$TAR_SUDO tar -czf "$DIST_DIR/agent-rootfs.tar.gz" -C "$ROOTFS_SRC" .
+[[ -n "$TAR_SUDO" ]] && $TAR_SUDO chown "$(id -u):$(id -g)" "$DIST_DIR/agent-rootfs.tar.gz"
+echo "Agent rootfs tarball: $(du -h "$DIST_DIR/agent-rootfs.tar.gz" | cut -f1)"
 
 # --- Pre-formatted ext4 disk templates -------------------------------------
 # Windows has no host mkfs.ext4, so the release ships pre-formatted templates
@@ -138,7 +145,7 @@ EOF
 
 # --- Checksums + zip --------------------------------------------------------
 echo "Generating checksums..."
-( cd "$DIST_DIR" && sha256sum smolvm.exe krun.dll libkrunfw.dll > checksums.txt )
+( cd "$DIST_DIR" && sha256sum smolvm.exe krun.dll libkrunfw.dll agent-rootfs.tar.gz > checksums.txt )
 
 echo "Creating zip..."
 ( cd dist && rm -f "${DIST_NAME}.zip" && zip -qr "${DIST_NAME}.zip" "${DIST_NAME}" )

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -94,6 +94,11 @@ pub fn find_lib_dir() -> Option<PathBuf> {
 
     let candidates = [
         exe_dir.join("lib"),
+        // The Windows release ships krun.dll / libkrunfw.dll directly beside
+        // smolvm.exe (no lib/ subdir, no wrapper to set SMOLVM_LIB_DIR), matching
+        // the convention that Windows resolves DLLs from the executable's own
+        // directory. Harmless on Unix dists, where the libs live in lib/.
+        exe_dir.to_path_buf(),
         exe_dir.join("../lib"),
         exe_dir.join("../../lib"),
         exe_dir.join(format!("../../lib/linux-{}", std::env::consts::ARCH)),

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -683,6 +683,28 @@ impl AgentManager {
             return Self::ensure_extracted_rootfs(Path::new(&tar));
         }
 
+        // Distribution layout: the binary sits next to its rootfs. The macOS /
+        // Linux tarballs use a wrapper script that sets SMOLVM_AGENT_ROOTFS, but
+        // the Windows release ships `smolvm.exe` with no wrapper, so resolve the
+        // rootfs relative to the executable: prefer an already-extracted
+        // `agent-rootfs/` dir, else extract a bundled `agent-rootfs.tar[.gz]`
+        // once (a `.zip` can't carry the Linux dir tree with its symlinks/modes).
+        if let Some(exe_dir) = std::env::current_exe()
+            .ok()
+            .and_then(|p| p.parent().map(Path::to_path_buf))
+        {
+            let dir = exe_dir.join("agent-rootfs");
+            if dir.is_dir() {
+                return Ok(dir);
+            }
+            for name in ["agent-rootfs.tar.gz", "agent-rootfs.tar"] {
+                let tar = exe_dir.join(name);
+                if tar.is_file() {
+                    return Self::ensure_extracted_rootfs(&tar);
+                }
+            }
+        }
+
         let data_dir = dirs::data_local_dir()
             .or_else(dirs::data_dir)
             .ok_or_else(|| Error::storage("resolve path", "could not determine data directory"))?;
@@ -732,11 +754,23 @@ impl AgentManager {
             .status()
             .map_err(|e| Error::storage("extract rootfs tar", e.to_string()))?;
         if !status.success() {
-            let _ = std::fs::remove_dir_all(&tmp);
-            return Err(Error::storage(
-                "extract rootfs tar",
-                format!("tar exited with {status}"),
-            ));
+            // On Windows, `tar` can't recreate the rootfs's busybox symlinks
+            // without symlink privilege (Developer Mode / elevation) and exits
+            // non-zero with warnings — but the real files (notably the agent)
+            // still extract. Treat the result as usable as long as the agent
+            // binary landed; otherwise it's a genuine extraction failure.
+            let agent_present = tmp.join("usr/local/bin/smolvm-agent").exists();
+            if !agent_present {
+                let _ = std::fs::remove_dir_all(&tmp);
+                return Err(Error::storage(
+                    "extract rootfs tar",
+                    format!("tar exited with {status} and the agent binary was not extracted"),
+                ));
+            }
+            tracing::warn!(
+                "rootfs tar extraction exited with {status} (host could not create some \
+                 symlinks); continuing — the agent binary extracted successfully"
+            );
         }
         let _ = std::fs::write(tmp.join(".extracted"), b"");
         // Atomic publish; if another process won the race, just use theirs.


### PR DESCRIPTION
The first 1.3.0 Windows dist failed because it zipped the *extracted* Linux rootfs (zip can't carry busybox symlinks / modes / special files). This ships `agent-rootfs.tar.gz` instead — `smolvm.exe` extracts it on first run via the existing tarball path — and fixes two related gaps the WHP smoke test surfaced: `find_lib_dir` now also checks the executable's own directory (the Windows layout puts krun.dll/libkrunfw.dll beside smolvm.exe, no lib/ subdir), and rootfs extraction no longer hard-fails when the host can't create symlinks. Verified on WHP hardware that `machine start` now resolves the bundled libraries and reaches running.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/496">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->