### PR TITLE
fix(cli): ephemeral machine run leaks VM data dirs on non-graceful exit

### DIFF
--- a/crates/smolvm-pack/src/extract.rs
+++ b/crates/smolvm-pack/src/extract.rs
@@ -715,6 +715,76 @@ pub fn extract_sidecar(
     // Lock released on drop of lock_file
 }
 
+/// Whether the shared content-addressed pack store is usable on this host.
+///
+/// The shared store extracts each build-constant pack exactly once per node into
+/// `_shared/<checksum>` (root-owned, read-only) and presents it to each VM via a
+/// per-VM idmapped bind mount, instead of re-extracting + re-chowning a private
+/// copy per machine. That mechanism is Linux-only (idmapped mounts, kernel ≥5.12)
+/// and the per-VM uid isolation it preserves only exists on the Linux fleet.
+/// `SMOLVM_DISABLE_SHARED_EXTRACT` is a kill-switch to fall back to the per-machine
+/// path without a redeploy.
+pub fn shared_extract_enabled() -> bool {
+    cfg!(target_os = "linux") && std::env::var_os("SMOLVM_DISABLE_SHARED_EXTRACT").is_none()
+}
+
+/// Directory holding the shared copy for one pack checksum, under `shared_root`.
+pub fn shared_pack_dir(shared_root: &Path, checksum: u32) -> PathBuf {
+    shared_root.join(format!("{:08x}", checksum))
+}
+
+/// Extract a sidecar pack ONCE into the shared content-addressed store and return
+/// the path to the shared copy (`shared_root/<checksum>`).
+///
+/// Unlike [`extract_sidecar`] (which writes a private per-machine copy), this is
+/// keyed purely by `footer.checksum` (a CRC32 content fingerprint), so every
+/// machine on a node whose pack hashes identically reuses the same extracted tree.
+/// The build-constant agent-rootfs (~28.6 MB / 362 files) therefore decodes once
+/// per node instead of once per machine — the cold-start tax this removes.
+///
+/// The shared copy is left **root-owned** (the extractor runs as root and the tar
+/// crate does not preserve ownership by default, so all files land `root:root`)
+/// and the store directories are locked to `0700 root`. No other uid can read the
+/// copy directly; a VM reaches it only through its own idmapped bind mount, which
+/// re-presents on-disk uid 0 as that VM's uid — preserving the per-VM isolation
+/// (#456) without a per-machine chown.
+///
+/// Idempotent + concurrency-safe: delegates to [`extract_sidecar`], whose flock +
+/// `.smolvm-extracted` marker serialize concurrent first extractions of the same
+/// checksum and make a warm hit a no-op.
+pub fn extract_sidecar_shared(
+    sidecar_path: &Path,
+    shared_root: &Path,
+    footer: &PackFooter,
+    debug: bool,
+) -> std::io::Result<PathBuf> {
+    let shared_dir = shared_pack_dir(shared_root, footer.checksum);
+    extract_sidecar(sidecar_path, &shared_dir, footer, false, debug)?;
+    // Lock down the store so a dropped per-VM uid can't read the shared copy
+    // directly (it must go through its idmapped mount). Best-effort: traversal
+    // by root (the VMM before it drops privileges) is unaffected by 0700.
+    restrict_to_owner(shared_root);
+    restrict_to_owner(&shared_dir);
+    Ok(shared_dir)
+}
+
+/// Set a directory to `0700` (owner-only) if possible. Best-effort; errors are
+/// swallowed because the store is already root-owned and root traversal ignores
+/// the mode — this only hardens against a *dropped* sibling uid reading the copy.
+fn restrict_to_owner(dir: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(meta) = fs::metadata(dir) {
+            let mut perms = meta.permissions();
+            perms.set_mode(0o700);
+            let _ = fs::set_permissions(dir, perms);
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = dir;
+}
+
 /// Inner extraction logic (called under the lock).
 fn extract_sidecar_inner(
     sidecar_path: &Path,

--- a/crates/smolvm-pack/tests/shared_extract.rs
+++ b/crates/smolvm-pack/tests/shared_extract.rs
@@ -127,7 +127,10 @@ fn shared_extraction_is_content_addressed_idempotent_and_locked_down() {
     //    extracted tree — no second decode, no second store dir. This is the
     //    cold-start tax the shared store removes.
     let shared_dir2 = extract_sidecar_shared(&sidecar, &shared_root, &footer, false).unwrap();
-    assert_eq!(shared_dir2, shared_dir, "second machine must reuse the copy");
+    assert_eq!(
+        shared_dir2, shared_dir,
+        "second machine must reuse the copy"
+    );
     let store_dirs: Vec<_> = fs::read_dir(&shared_root)
         .unwrap()
         .filter_map(|e| e.ok())
@@ -144,7 +147,13 @@ fn shared_extraction_is_content_addressed_idempotent_and_locked_down() {
     //    directly — it must go through its own idmapped mount (#456 isolation).
     for dir in [&shared_root, &shared_dir] {
         let mode = fs::metadata(dir).unwrap().permissions().mode() & 0o777;
-        assert_eq!(mode, 0o700, "{} must be 0700, got {:o}", dir.display(), mode);
+        assert_eq!(
+            mode,
+            0o700,
+            "{} must be 0700, got {:o}",
+            dir.display(),
+            mode
+        );
     }
 }
 

--- a/crates/smolvm-pack/tests/shared_extract.rs
+++ b/crates/smolvm-pack/tests/shared_extract.rs
@@ -1,0 +1,167 @@
+//! End-to-end test of the shared, content-addressed pack extraction
+//! (`extract_sidecar_shared`) against a *real* `.smolmachine` sidecar — real
+//! zstd stream, real tar, real footer/checksum — on a real filesystem.
+//!
+//! Linux-only: the shared store backs the Linux fleet's per-VM idmapped bind
+//! mount (kernel ≥5.12); macOS uses a per-machine case-sensitive sparse image,
+//! so the whole module compiles to nothing elsewhere. This validates the
+//! *extraction half* (extract-once, content-addressed, locked down); the mount
+//! half is validated by the root crate's `tests/idmap_mount.rs`.
+#![cfg(target_os = "linux")]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+use smolvm_pack::assets::AssetCollector;
+use smolvm_pack::extract::{extract_sidecar, extract_sidecar_shared, shared_extract_enabled};
+use smolvm_pack::format::PackManifest;
+use smolvm_pack::{read_footer_from_sidecar, sidecar_path_for, Packer};
+
+/// Build a tiny but *valid* OCI-style layer: a raw tar archive carrying one
+/// file. `post_process_extraction` untars every `layers/*.tar`, so the payload
+/// must be a real tar (a raw byte blob would fail with "failed to read entire
+/// block" — exactly what a real OCI layer never does).
+fn layer_tar(filename: &str, content: &[u8]) -> Vec<u8> {
+    let mut builder = tar::Builder::new(Vec::new());
+    let mut header = tar::Header::new_gnu();
+    header.set_entry_type(tar::EntryType::Regular);
+    header.set_size(content.len() as u64);
+    header.set_mode(0o644);
+    header.set_cksum();
+    builder.append_data(&mut header, filename, content).unwrap();
+    builder.into_inner().unwrap()
+}
+
+/// Build a real sidecar `.smolmachine` carrying two OCI layers, returning the
+/// sidecar path (under `dir`).
+fn build_real_sidecar(dir: &Path) -> std::path::PathBuf {
+    let stub_path = dir.join("stub");
+    fs::write(&stub_path, b"#!/bin/sh\necho stub").unwrap();
+
+    let mut collector = AssetCollector::new(dir.join("staging")).unwrap();
+    collector
+        .add_layer(
+            "sha256:aaa111aaa111bbb222",
+            &layer_tar("etc/base.conf", b"base layer file"),
+        )
+        .unwrap();
+    collector
+        .add_layer(
+            "sha256:ccc333ccc333ddd444",
+            &layer_tar("etc/top.conf", b"top layer file"),
+        )
+        .unwrap();
+
+    let manifest = PackManifest::new(
+        "test:latest".to_string(),
+        "sha256:test".to_string(),
+        "linux/x86_64".to_string(),
+        "linux/x86_64".to_string(),
+    );
+
+    let output = dir.join("packed");
+    Packer::new(manifest)
+        .with_stub(&stub_path)
+        .with_assets(collector)
+        .pack(&output)
+        .unwrap();
+
+    sidecar_path_for(&output)
+}
+
+/// Recursively collect (relative-path -> file bytes) for every regular file in a
+/// tree, so the shared extraction can be compared byte-for-byte to a plain one.
+fn file_map(root: &Path) -> std::collections::BTreeMap<String, Vec<u8>> {
+    let mut out = std::collections::BTreeMap::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        for entry in fs::read_dir(&d).unwrap() {
+            let entry = entry.unwrap();
+            let ft = entry.file_type().unwrap();
+            let p = entry.path();
+            if ft.is_dir() {
+                stack.push(p);
+            } else if ft.is_file() {
+                let rel = p.strip_prefix(root).unwrap().to_string_lossy().to_string();
+                out.insert(rel, fs::read(&p).unwrap());
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn shared_extraction_is_content_addressed_idempotent_and_locked_down() {
+    let tmp = tempfile::tempdir().unwrap();
+    let sidecar = build_real_sidecar(tmp.path());
+    let footer = read_footer_from_sidecar(&sidecar).unwrap();
+
+    let shared_root = tmp.path().join("_shared");
+    let pack_plain = tmp.path().join("vm-plain/pack");
+
+    // First machine extracts into the shared store; a plain per-machine
+    // extraction is the byte-for-byte reference.
+    let shared_dir = extract_sidecar_shared(&sidecar, &shared_root, &footer, false).unwrap();
+    extract_sidecar(&sidecar, &pack_plain, &footer, false, false).unwrap();
+
+    // 1) Content-addressed: the shared copy lives at `_shared/<checksum>`.
+    assert_eq!(
+        shared_dir,
+        shared_root.join(format!("{:08x}", footer.checksum)),
+        "shared dir must be keyed by the footer checksum"
+    );
+    assert!(shared_dir.is_dir(), "shared extraction dir must exist");
+
+    // 2) The shared view is byte-identical to a plain per-machine extraction —
+    //    the idmapped mount only remaps ownership, never content.
+    let reference = file_map(&pack_plain);
+    assert!(!reference.is_empty(), "extraction produced no files");
+    assert_eq!(
+        file_map(&shared_dir),
+        reference,
+        "shared content must match a plain extraction byte-for-byte"
+    );
+
+    // 3) Idempotent reuse: a second machine with the same checksum reuses the one
+    //    extracted tree — no second decode, no second store dir. This is the
+    //    cold-start tax the shared store removes.
+    let shared_dir2 = extract_sidecar_shared(&sidecar, &shared_root, &footer, false).unwrap();
+    assert_eq!(shared_dir2, shared_dir, "second machine must reuse the copy");
+    let store_dirs: Vec<_> = fs::read_dir(&shared_root)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().is_dir())
+        .collect();
+    assert_eq!(
+        store_dirs.len(),
+        1,
+        "only one content-addressed extraction may exist for one checksum"
+    );
+
+    // 4) Locked down to 0700: the store root and the checksum dir are owner-only,
+    //    so a sibling VM dropped to a *different* uid cannot read the shared copy
+    //    directly — it must go through its own idmapped mount (#456 isolation).
+    for dir in [&shared_root, &shared_dir] {
+        let mode = fs::metadata(dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700, "{} must be 0700, got {:o}", dir.display(), mode);
+    }
+}
+
+#[test]
+fn kill_switch_disables_the_shared_store() {
+    // The handler consults `shared_extract_enabled()` to choose the shared vs
+    // per-machine path; `SMOLVM_DISABLE_SHARED_EXTRACT` forces the fallback
+    // without a redeploy. (Run as its own test fn so the env mutation cannot race
+    // the content test on cargo's parallel test threads.)
+    assert!(
+        shared_extract_enabled(),
+        "shared store should be enabled by default on Linux"
+    );
+    std::env::set_var("SMOLVM_DISABLE_SHARED_EXTRACT", "1");
+    assert!(
+        !shared_extract_enabled(),
+        "kill-switch must disable the shared store"
+    );
+    std::env::remove_var("SMOLVM_DISABLE_SHARED_EXTRACT");
+}

--- a/src/agent/boot_config.rs
+++ b/src/agent/boot_config.rs
@@ -51,8 +51,19 @@ pub struct BootConfig {
     #[serde(default)]
     pub dns_filter_hosts: Option<Vec<String>>,
     /// Pre-extracted OCI layers directory for .smolmachine-sourced machines.
+    /// When `pack_idmap_source` is set, this is an empty per-VM mountpoint the
+    /// boot subprocess idmap-binds the shared pack onto; otherwise it is the
+    /// directory holding the extracted pack directly.
     #[serde(default)]
     pub packed_layers_dir: Option<PathBuf>,
+    /// Root-owned shared pack directory (`_shared/<checksum>`) to present at
+    /// `packed_layers_dir` via a per-VM idmapped bind mount that maps on-disk
+    /// uid 0 -> the VM's dropped uid. Set only when per-VM uid isolation is
+    /// active (Linux fleet); the mount lives in the boot subprocess's private
+    /// mount namespace and is torn down automatically on exit. When `None`,
+    /// `packed_layers_dir` is consumed as-is (no idmap mount).
+    #[serde(default)]
+    pub pack_idmap_source: Option<PathBuf>,
     /// Additional disk images to attach (path, read_only, format). The format
     /// lets the `pack --from-vm` exporter attach a source qcow2 disk read-only.
     #[serde(default)]

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -181,6 +181,12 @@ pub struct LaunchFeatures {
     /// When set, the launcher mounts this directory via virtiofs so the agent
     /// can use pre-extracted layers instead of pulling from a registry.
     pub packed_layers_dir: Option<std::path::PathBuf>,
+    /// Root-owned shared pack copy (`_shared/<checksum>`) to present at
+    /// `packed_layers_dir` via a per-VM idmapped bind mount. Set by
+    /// [`with_packed_layers`](LaunchFeatures::with_packed_layers) when create
+    /// wrote a shared pointer; the manager keeps it only when the per-VM uid drop
+    /// is active (else it collapses `packed_layers_dir` onto the shared copy).
+    pub pack_idmap_source: Option<std::path::PathBuf>,
     /// Additional disk images to attach to the VM (path, read_only, format).
     /// Appear as /dev/vdc, /dev/vdd, ... after the storage and overlay disks.
     pub extra_disks: Vec<(std::path::PathBuf, bool, DiskFormat)>,
@@ -232,6 +238,19 @@ impl LaunchFeatures {
         let Some(sidecar_path) = source_smolmachine else {
             return Ok(self);
         };
+
+        // Shared pack store: if create extracted the pack into the node's shared
+        // content-addressed store and dropped a pointer beside this machine, the
+        // per-machine `pack` dir is an empty mountpoint. Point `packed_layers_dir`
+        // at it and carry the shared copy as the idmap source; the manager keeps
+        // the idmap only when the per-VM uid drop is active (else it collapses
+        // `packed_layers_dir` onto the shared copy directly). No lease — the
+        // shared copy is never the macOS case-sensitive volume (Linux-only path).
+        if let Some(shared) = super::read_shared_pack_pointer(layers_cache_dir) {
+            self.packed_layers_dir = Some(layers_cache_dir.to_path_buf());
+            self.pack_idmap_source = Some(shared);
+            return Ok(self);
+        }
 
         if !smolvm_pack::extract::is_extracted(layers_cache_dir) {
             // Fallback: layers not yet extracted into this machine's own dir

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -187,6 +187,16 @@ pub fn vm_data_dir(name: &str) -> PathBuf {
     vm_cache_root().join(vm_dir_hash(name))
 }
 
+/// Node-shared, content-addressed pack store: `<vm_cache_root>/_shared`. Each
+/// build-constant pack is extracted here once per node under `<checksum>/`
+/// (root-owned, read-only) and presented to every machine via a per-VM idmapped
+/// bind mount — instead of a private per-machine extraction + chown. The `_`
+/// prefix cannot collide with a 16-hex [`vm_dir_hash`], so it sits safely beside
+/// the per-machine data dirs on the same filesystem.
+pub fn shared_pack_cache_root() -> PathBuf {
+    vm_cache_root().join("_shared")
+}
+
 /// Actual host disk consumed by a machine's data dir, in MiB. Sums *real blocks*
 /// (`st_blocks × 512`), not apparent file lengths — the disk images are sparse, so
 /// a 20 GiB image that the guest has barely written to consumes only a few MiB.
@@ -250,6 +260,32 @@ pub fn resolve_disk_image(dir: &Path, raw_filename: &str) -> (PathBuf, DiskForma
 /// the `layers/` subtree that `extract_sidecar` creates *inside* this directory.
 pub fn machine_layers_cache_dir(name: &str) -> PathBuf {
     vm_data_dir(name).join("pack")
+}
+
+/// Filename of the shared-pack pointer dropped beside a machine's
+/// [`machine_layers_cache_dir`] when create extracted the pack into the node's
+/// shared content-addressed store (`_shared/<checksum>`) instead of a private
+/// per-machine copy. Its contents are the absolute path of that shared copy.
+pub const SHARED_PACK_POINTER: &str = ".pack-shared";
+
+/// Path of the shared-pack pointer for a machine, given its layers cache dir
+/// (`<vm_data_dir>/pack`). The pointer sits in the parent (`<vm_data_dir>`) so it
+/// is not shadowed when the `pack` mountpoint is idmap-bound at boot.
+pub fn shared_pack_pointer_path(layers_cache_dir: &std::path::Path) -> PathBuf {
+    layers_cache_dir
+        .parent()
+        .unwrap_or(layers_cache_dir)
+        .join(SHARED_PACK_POINTER)
+}
+
+/// Read the shared-pack pointer for a machine, returning the shared copy's path
+/// iff the pointer exists and names an existing directory. A stale pointer (the
+/// shared copy was evicted) reads as `None`, so callers fall back to the
+/// per-machine extraction path.
+pub fn read_shared_pack_pointer(layers_cache_dir: &std::path::Path) -> Option<PathBuf> {
+    let raw = std::fs::read_to_string(shared_pack_pointer_path(layers_cache_dir)).ok()?;
+    let shared = PathBuf::from(raw.trim());
+    shared.is_dir().then_some(shared)
 }
 
 /// Per-VM egress telemetry file: `<vm_data_dir>/egress`. The launcher (running
@@ -1524,7 +1560,7 @@ impl AgentManager {
         mounts: Vec<HostMount>,
         ports: Vec<PortMapping>,
         resources: VmResources,
-        features: launcher::LaunchFeatures,
+        mut features: launcher::LaunchFeatures,
     ) -> Result<()> {
         use super::boot_config::BootConfig;
 
@@ -1585,6 +1621,21 @@ impl AgentManager {
         let data_dir = self.storage_disk.path().parent().map(|p| p.to_path_buf());
         let registry = vm_uid_registry_dir();
         let mut uid_env: Vec<(&str, String)> = Vec::new();
+        // Shared pack store: `with_packed_layers` sets `pack_idmap_source` when
+        // create wrote a `_shared/<checksum>` pointer, leaving `packed_layers_dir`
+        // an empty per-VM mountpoint. Ensure that mountpoint exists BEFORE the
+        // uid-drop chown_tree below, so it's owned by the VM's uid (harmless — the
+        // idmap bind covers it at boot) rather than left for chown to miss.
+        if features.pack_idmap_source.is_some() {
+            if let Some(ref mountpoint) = features.packed_layers_dir {
+                let _ = std::fs::create_dir_all(mountpoint);
+            }
+        }
+        // Whether the per-VM uid drop is active for this boot. The idmapped pack
+        // bind mount needs CAP_SYS_ADMIN (root) — the same precondition as the
+        // drop — so we only keep `pack_idmap_source` when the drop is active;
+        // otherwise the VMM stays root and reads the shared copy directly.
+        let mut uid_drop_active = false;
         if let Some(d) = data_dir.as_deref() {
             if let Some(result) =
                 crate::process::vm_drop_ids(&registry, d, features.snapshot_dir.as_deref())
@@ -1649,8 +1700,25 @@ impl AgentManager {
                     ("SMOLVM_VM_UID", uid.to_string()),
                     ("SMOLVM_VM_GID", gid.to_string()),
                 ];
+                uid_drop_active = true;
             }
         }
+
+        // Resolve how the shared pack is presented to the guest. With the uid
+        // drop active, keep the idmap source so `internal_boot` (still root, in a
+        // private mount namespace) idmap-binds the root-owned shared copy onto the
+        // empty `packed_layers_dir` mountpoint, mapping on-disk uid 0 -> vm_uid.
+        // Without the drop (non-root `serve`, or SMOLVM_VM_UID_DROP=off), there is
+        // no second uid to isolate from, so collapse the indirection: point
+        // `packed_layers_dir` straight at the shared copy and read it as root.
+        let pack_idmap_source = if uid_drop_active {
+            features.pack_idmap_source.take()
+        } else {
+            if let Some(shared) = features.pack_idmap_source.take() {
+                features.packed_layers_dir = Some(shared);
+            }
+            None
+        };
 
         // Write boot config to a file the subprocess will read
         let config = BootConfig {
@@ -1668,6 +1736,7 @@ impl AgentManager {
             ssh_agent_socket: features.ssh_agent_socket,
             dns_filter_hosts: features.dns_filter_hosts,
             packed_layers_dir: features.packed_layers_dir,
+            pack_idmap_source,
             extra_disks: features.extra_disks,
         };
         let config_path = self

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -27,8 +27,9 @@ pub use launcher::{
 };
 pub use manager::{
     disk_used_mb, docker_config_dir, docker_config_mount, ensure_vm_dir, machine_layers_cache_dir,
-    prune_orphaned_ready_markers, read_egress_telemetry, resolve_disk_image, vm_cache_root,
-    vm_data_dir, vm_dir_hash, vm_uid_registry_dir, AgentManager, AgentState,
+    prune_orphaned_ready_markers, read_egress_telemetry, read_shared_pack_pointer,
+    resolve_disk_image, shared_pack_cache_root, shared_pack_pointer_path, vm_cache_root,
+    vm_data_dir, vm_dir_hash, vm_uid_registry_dir, AgentManager, AgentState, SHARED_PACK_POINTER,
 };
 
 /// Agent VM name.

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -480,9 +480,7 @@ pub async fn create_machine(
                         &footer,
                         false,
                     )
-                    .map_err(|e| {
-                        ApiError::internal(format!("extract sidecar (shared): {}", e))
-                    })?;
+                    .map_err(|e| ApiError::internal(format!("extract sidecar (shared): {}", e)))?;
                     std::fs::create_dir_all(&cache_dir).map_err(|e| {
                         ApiError::internal(format!("create pack mountpoint: {}", e))
                     })?;

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -461,21 +461,54 @@ pub async fn create_machine(
             let path = std::path::Path::new(&sidecar_path);
             let cache_dir = crate::agent::machine_layers_cache_dir(&name);
             let result = (|| {
-                smolvm_pack::extract::force_detach_layers_volume(&cache_dir);
-                match std::fs::remove_dir_all(&cache_dir) {
-                    Ok(()) => {}
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                    Err(e) => {
-                        return Err(ApiError::internal(format!(
-                            "clear packed layers cache: {}",
-                            e
-                        )));
-                    }
-                }
                 let footer = smolvm_pack::packer::read_footer_from_sidecar(path)
                     .map_err(|e| ApiError::internal(format!("read sidecar footer: {}", e)))?;
-                smolvm_pack::extract::extract_sidecar(path, &cache_dir, &footer, false, false)
-                    .map_err(|e| ApiError::internal(format!("extract sidecar: {}", e)))
+                if smolvm_pack::extract::shared_extract_enabled() {
+                    // Shared content-addressed store: extract the build-constant
+                    // pack ONCE per node into `_shared/<checksum>` (root-owned,
+                    // read-only) instead of a private per-machine copy, and drop a
+                    // pointer beside this machine. The per-machine `pack` dir is
+                    // left an empty mountpoint that the boot path idmap-binds the
+                    // shared copy onto (mapping on-disk uid 0 -> the VM's dropped
+                    // uid), so a 28.6 MB / 362-file agent-rootfs decodes once per
+                    // node rather than once per machine — the cold-start tax this
+                    // removes — with the per-VM uid isolation (#456) preserved.
+                    let shared_root = crate::agent::shared_pack_cache_root();
+                    let shared_dir = smolvm_pack::extract::extract_sidecar_shared(
+                        path,
+                        &shared_root,
+                        &footer,
+                        false,
+                    )
+                    .map_err(|e| {
+                        ApiError::internal(format!("extract sidecar (shared): {}", e))
+                    })?;
+                    std::fs::create_dir_all(&cache_dir).map_err(|e| {
+                        ApiError::internal(format!("create pack mountpoint: {}", e))
+                    })?;
+                    let pointer = crate::agent::shared_pack_pointer_path(&cache_dir);
+                    std::fs::write(&pointer, shared_dir.to_string_lossy().as_bytes()).map_err(
+                        |e| ApiError::internal(format!("write shared pack pointer: {}", e)),
+                    )?;
+                    Ok(())
+                } else {
+                    // Per-machine extraction: macOS case-sensitive layers volume
+                    // (owned 1:1 by the machine), or the `SMOLVM_DISABLE_SHARED_EXTRACT`
+                    // kill-switch. Wipe any prior cache first for a clean slate.
+                    smolvm_pack::extract::force_detach_layers_volume(&cache_dir);
+                    match std::fs::remove_dir_all(&cache_dir) {
+                        Ok(()) => {}
+                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                        Err(e) => {
+                            return Err(ApiError::internal(format!(
+                                "clear packed layers cache: {}",
+                                e
+                            )));
+                        }
+                    }
+                    smolvm_pack::extract::extract_sidecar(path, &cache_dir, &footer, false, false)
+                        .map_err(|e| ApiError::internal(format!("extract sidecar: {}", e)))
+                }
             })();
             // Detach the case-sensitive volume mounted during extraction so a
             // created-but-unstarted machine leaves nothing mounted, and so the
@@ -514,9 +547,15 @@ pub async fn create_machine(
             .unwrap_or_else(|| vm_data_dir(&name));
         let seed_result = tokio::task::spawn_blocking(move || -> Result<(), ApiError> {
             let cache_dir = crate::agent::machine_layers_cache_dir(&name2);
+            // With the shared store, the pack contents live in `_shared/<checksum>`
+            // (the per-machine `pack` dir is an empty mountpoint), so seed the
+            // VM-mode disk templates from the shared copy. Falls back to the
+            // per-machine dir when no pointer was written (macOS / kill-switch).
+            let pack_content_dir =
+                crate::agent::read_shared_pack_pointer(&cache_dir).unwrap_or(cache_dir);
             crate::storage::seed_vm_mode_disks(
                 &disk_dir,
-                &cache_dir,
+                &pack_content_dir,
                 seed.overlay_template.as_deref(),
                 seed.storage_template.as_deref(),
                 seed.overlay_logical_size,

--- a/src/cli/cleanup_ephemeral.rs
+++ b/src/cli/cleanup_ephemeral.rs
@@ -1,6 +1,6 @@
 //! Detached cleanup helper for ephemeral `machine run` VMs.
 //!
-//! Invoked as `smolvm _cleanup-ephemeral <vm-name> <pid> <start-time> <ephemeral-name>`
+//! Invoked as `smolvm _cleanup-ephemeral <vm-name> <pid> <start-time>`
 //! after the parent CLI has flushed output and is about to exit. Running out of
 //! process lets the parent return the guest's exit code immediately while disk
 //! removal and process teardown happen asynchronously.
@@ -16,10 +16,12 @@ use smolvm::agent::{vm_cache_root, vm_data_dir};
 use std::path::Path;
 
 /// Entry point for the `_cleanup-ephemeral` subcommand.
-pub fn run(vm_name: &str, pid: i32, start_time: u64, ephemeral_name: &str) {
+pub fn run(vm_name: &str, pid: i32, start_time: u64) {
     let data_dir = vm_data_dir(vm_name);
     let cache_root = vm_cache_root();
-    let ephemeral_name = ephemeral_name.to_owned();
+    // The ephemeral DB record is keyed by the VM's own name (see `RunCmd::run`),
+    // so deregistration and dir removal target the same name.
+    let record_name = vm_name.to_owned();
     run_inner(
         pid,
         start_time,
@@ -43,7 +45,7 @@ pub fn run(vm_name: &str, pid: i32, start_time: u64, ephemeral_name: &str) {
                 !data_dir.exists()
             }
         },
-        move || deregister_ephemeral_vm(&ephemeral_name),
+        move || deregister_ephemeral_vm(&record_name),
     );
 }
 

--- a/src/cli/internal_boot.rs
+++ b/src/cli/internal_boot.rs
@@ -148,6 +148,38 @@ pub fn run(config_path: PathBuf) -> smolvm::Result<()> {
         );
     }
 
+    // Shared pack store: present the node's root-owned shared pack copy at this
+    // VM's `packed_layers_dir` via a per-VM idmapped bind mount (on-disk uid 0 ->
+    // this VM's uid), in a private mount namespace that's torn down on exit. Done
+    // here while still privileged (needs CAP_SYS_ADMIN) and BEFORE the uid drop
+    // and Landlock/seccomp. The manager only sets `pack_idmap_source` when the uid
+    // drop is active, so SMOLVM_VM_UID is guaranteed present; fail closed if not.
+    #[cfg(target_os = "linux")]
+    if let Some(ref shared) = config.pack_idmap_source {
+        let target = match config.packed_layers_dir {
+            Some(ref t) => t,
+            None => {
+                eprintln!("[pack-idmap] idmap source set without a mountpoint; refusing to boot");
+                smolvm::process::exit_child(1);
+            }
+        };
+        let uid: u32 = std::env::var("SMOLVM_VM_UID")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| {
+                eprintln!("[pack-idmap] idmap source set without SMOLVM_VM_UID; refusing to boot");
+                smolvm::process::exit_child(1);
+            });
+        let gid: u32 = std::env::var("SMOLVM_VM_GID")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(uid);
+        if let Err(e) = smolvm::process::setup_pack_idmap_mount(shared, target, uid, gid) {
+            eprintln!("[pack-idmap] failed to mount shared pack, refusing to boot: {e}");
+            smolvm::process::exit_child(1);
+        }
+    }
+
     // Drop to an unprivileged uid before touching the guest, so a guest→VMM
     // escape can't signal/ptrace the supervisor or neighbor VMs nor reach
     // root-owned host files. Gated by SMOLVM_VM_UID (+ optional SMOLVM_VM_GID,

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -27,6 +27,11 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+/// How many orphaned ephemeral VMs `machine run` reaps per boot. Small so the
+/// hot path never stalls on a large backlog; a heavier backlog drains over
+/// successive runs (and other commands sweep without a cap).
+const EPHEMERAL_RUN_SWEEP_CAP: usize = 8;
+
 /// Resolve `--allow-cidr`, `--allow-host`, and `--outbound-localhost-only` into a CIDR list,
 /// net flag, and the original hostname list (for DNS filtering).
 ///
@@ -246,10 +251,15 @@ pub enum MachineCmd {
 
 impl MachineCmd {
     pub fn run(self) -> smolvm::Result<()> {
-        // Skip orphan cleanup for ephemeral `machine run` — it creates and
-        // immediately destroys its VM, so stale records don't affect it.
-        // Other commands (ls, exec, create, etc.) clean up first.
-        if !matches!(self, MachineCmd::Run(_)) {
+        // Reclaim orphaned ephemeral VMs before doing work. `machine run` uses a
+        // BOUNDED sweep: a workflow that only ever calls `machine run` would
+        // otherwise never reclaim a data dir left by a run whose detached cleanup
+        // helper didn't finish (Ctrl-C / SIGKILL / host sleep mid-run). The cap
+        // keeps the boot hot path from stalling on a large backlog — it drains
+        // over successive runs. Other commands sweep everything.
+        if matches!(self, MachineCmd::Run(_)) {
+            super::vm_common::cleanup_orphaned_ephemeral_vms_bounded(EPHEMERAL_RUN_SWEEP_CAP);
+        } else {
             super::vm_common::cleanup_orphaned_ephemeral_vms();
         }
 

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -142,12 +142,7 @@ fn parse_cli_secret_refs(
 ///
 /// Returns `false` if spawn fails (binary not found, exec error, etc.).
 /// The caller falls back to synchronous cleanup in that case.
-fn try_spawn_detached_cleanup(
-    vm_name: &str,
-    pid: i32,
-    start_time: Option<u64>,
-    ephemeral_name: &str,
-) -> bool {
+fn try_spawn_detached_cleanup(vm_name: &str, pid: i32, start_time: Option<u64>) -> bool {
     // Require a verified start time so the helper can use is_our_process_strict
     // before sending SIGKILL. Without it, fall back to synchronous cleanup.
     let start_time_val = match start_time {
@@ -163,7 +158,6 @@ fn try_spawn_detached_cleanup(
         .arg(vm_name)
         .arg(pid.to_string())
         .arg(start_time_val.to_string())
-        .arg(ephemeral_name)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null());
@@ -1086,21 +1080,19 @@ impl RunCmd {
             .ensure_running_with_full_config(mounts.clone(), ports, resources, features)
             .map_err(|e| Error::agent("start machine", e.to_string()))?;
 
-        // Register ephemeral VM for tracking (machine list, orphan cleanup).
+        // Register the ephemeral VM for tracking (machine list, orphan cleanup),
+        // keyed by the VM's OWN name. The orphan sweep only has the DB record and
+        // locates the disks via `vm_data_dir(record.name)`, so the record name
+        // MUST be the VM name — a separate generated name would hash to a
+        // different, nonexistent dir and the sweep would delete the record but
+        // leak the real (multi-GB) data dir.
+        //
         // Detached runs are tracked via persist_named_running instead — skip
         // ephemeral registration so the detach path does not leave an
         // unreachable orphan record after persist_named_running succeeds.
-        // Key the ephemeral record by the VM's OWN name, not a fresh random one.
-        // The orphan sweep only has the DB record and locates the disks via
-        // `vm_data_dir(record.name)`; a separate generated name hashes to a
-        // different, nonexistent dir, so the sweep would delete the record but
-        // leak the real (multi-GB) data dir. The detached cleanup helper is
-        // passed `vm_name` explicitly so it was already correct — this aligns the
-        // non-graceful (sweep) path with it.
-        let ephemeral_name = vm_name.clone();
         if !self.detach {
             vm_common::register_ephemeral_vm(
-                &ephemeral_name,
+                &vm_name,
                 manager.child_pid(),
                 params.cpus,
                 params.mem,
@@ -1201,7 +1193,7 @@ impl RunCmd {
                 // (manager.kill() at line ~563/655) and avoids the
                 // graceful-shutdown latency `stop()` adds when no one
                 // is going to use this VM again.
-                vm_common::deregister_ephemeral_vm(&ephemeral_name);
+                vm_common::deregister_ephemeral_vm(&vm_name);
                 manager.kill();
                 return Err(e);
             }
@@ -1391,12 +1383,11 @@ impl RunCmd {
                 // Spawn a detached helper so the parent exits immediately after
                 // flushing output. Falls back to synchronous cleanup if spawn fails.
                 let (pid, start_time) = manager.pid_and_start_time().unwrap_or((0, None));
-                if pid > 0 && try_spawn_detached_cleanup(&vm_name, pid, start_time, &ephemeral_name)
-                {
+                if pid > 0 && try_spawn_detached_cleanup(&vm_name, pid, start_time) {
                     std::process::exit(exit_code);
                 }
                 // Fallback: synchronous cleanup (helper spawn failed).
-                vm_common::deregister_ephemeral_vm(&ephemeral_name);
+                vm_common::deregister_ephemeral_vm(&vm_name);
                 manager.kill();
                 manager.cleanup_data_dir();
                 std::process::exit(exit_code);
@@ -1543,12 +1534,11 @@ impl RunCmd {
                 // Spawn a detached helper so the parent exits immediately after
                 // flushing output. Falls back to synchronous cleanup if spawn fails.
                 let (pid, start_time) = manager.pid_and_start_time().unwrap_or((0, None));
-                if pid > 0 && try_spawn_detached_cleanup(&vm_name, pid, start_time, &ephemeral_name)
-                {
+                if pid > 0 && try_spawn_detached_cleanup(&vm_name, pid, start_time) {
                     std::process::exit(exit_code);
                 }
                 // Fallback: synchronous cleanup (helper spawn failed).
-                vm_common::deregister_ephemeral_vm(&ephemeral_name);
+                vm_common::deregister_ephemeral_vm(&vm_name);
                 manager.kill();
                 manager.cleanup_data_dir();
                 std::process::exit(exit_code);

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -1090,7 +1090,14 @@ impl RunCmd {
         // Detached runs are tracked via persist_named_running instead — skip
         // ephemeral registration so the detach path does not leave an
         // unreachable orphan record after persist_named_running succeeds.
-        let ephemeral_name = smolvm::util::generate_machine_name();
+        // Key the ephemeral record by the VM's OWN name, not a fresh random one.
+        // The orphan sweep only has the DB record and locates the disks via
+        // `vm_data_dir(record.name)`; a separate generated name hashes to a
+        // different, nonexistent dir, so the sweep would delete the record but
+        // leak the real (multi-GB) data dir. The detached cleanup helper is
+        // passed `vm_name` explicitly so it was already correct — this aligns the
+        // non-graceful (sweep) path with it.
+        let ephemeral_name = vm_name.clone();
         if !self.detach {
             vm_common::register_ephemeral_vm(
                 &ephemeral_name,

--- a/src/cli/pack_run.rs
+++ b/src/cli/pack_run.rs
@@ -431,6 +431,7 @@ impl PackRunCmd {
                 ssh_agent_socket: None,
                 dns_filter_hosts: None,
                 packed_layers_dir: Some(layers_dir.to_path_buf()),
+                pack_idmap_source: None,
                 extra_disks: vec![],
             };
 
@@ -1402,6 +1403,7 @@ fn run_from_cache(
             ssh_agent_socket: None,
             dns_filter_hosts: None,
             packed_layers_dir: Some(layers_dir.to_path_buf()),
+            pack_idmap_source: None,
             extra_disks: vec![],
         };
         let config_path = runtime_dir.path().join("boot-config.json");

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -1962,39 +1962,72 @@ pub fn deregister_ephemeral_vm(name: &str) {
     }
 }
 
-/// Clean up orphaned ephemeral VM records.
+/// Names of ephemeral VMs that are orphans (dead or PID-less), capped at `limit`.
 ///
-/// Called once at CLI startup. Scans for ephemeral records whose PID is no
-/// longer alive and removes them. Fast path: if no ephemeral records exist,
-/// this is a single DB read (~0.2ms).
+/// Pure (no I/O) so the reaping policy is unit-testable: given the VM list and a
+/// liveness probe, it returns at most `limit` orphan names in list order. A
+/// non-ephemeral or still-alive record is never returned.
+fn orphaned_ephemeral_names<'a>(
+    vms: &'a [(String, VmRecord)],
+    is_alive: impl Fn(i32) -> bool,
+    limit: usize,
+) -> Vec<&'a str> {
+    let mut out = Vec::new();
+    for (name, record) in vms {
+        if out.len() >= limit {
+            break;
+        }
+        if !record.ephemeral {
+            continue;
+        }
+        let is_orphan = match record.pid {
+            Some(pid) => !is_alive(pid),
+            None => true, // No PID recorded — stale
+        };
+        if is_orphan {
+            out.push(name.as_str());
+        }
+    }
+    out
+}
+
+/// Clean up ALL orphaned ephemeral VM records.
+///
+/// Called at the start of every machine command EXCEPT `machine run` (which uses
+/// the bounded variant on its hot path). Fast path: if no ephemeral records
+/// exist, this is a single DB read (~0.2ms).
 pub fn cleanup_orphaned_ephemeral_vms() {
+    cleanup_orphaned_ephemeral_vms_bounded(usize::MAX);
+}
+
+/// Clean up orphaned ephemeral VM records, removing at most `limit` of them.
+///
+/// `machine run` is the one hot-path caller and passes a small cap: a workflow
+/// that ONLY ever calls `machine run` (e.g. a wrapper that spawns a fresh
+/// ephemeral VM per task) never reaches the unbounded sweep above, so any run
+/// whose detached `_cleanup-ephemeral` helper didn't finish (Ctrl-C / SIGKILL /
+/// host sleep mid-run) would leak its data dir forever. The cap lets such a
+/// backlog self-heal over a few runs instead of stalling one boot on a large
+/// `remove_dir_all` storm. Removal order follows the DB list order. Fast path:
+/// no ephemeral records → a single DB read.
+pub fn cleanup_orphaned_ephemeral_vms_bounded(limit: usize) {
+    if limit == 0 {
+        return;
+    }
     let db = match SmolvmDb::open() {
         Ok(db) => db,
         Err(_) => return,
     };
-
     let vms = match db.list_vms() {
         Ok(vms) => vms,
         Err(_) => return,
     };
-
-    for (name, record) in &vms {
-        if !record.ephemeral {
-            continue;
-        }
-
-        let is_orphan = match record.pid {
-            Some(pid) => !smolvm::process::is_alive(pid),
-            None => true, // No PID recorded — stale
-        };
-
-        if is_orphan {
-            tracing::debug!(name = %name, pid = ?record.pid, "cleaning up orphaned ephemeral VM");
-            let _ = db.remove_vm(name);
-            let dir = smolvm::agent::vm_data_dir(name);
-            if dir.exists() {
-                let _ = std::fs::remove_dir_all(&dir);
-            }
+    for name in orphaned_ephemeral_names(&vms, smolvm::process::is_alive, limit) {
+        tracing::debug!(name = %name, "cleaning up orphaned ephemeral VM");
+        let _ = db.remove_vm(name);
+        let dir = smolvm::agent::vm_data_dir(name);
+        if dir.exists() {
+            let _ = std::fs::remove_dir_all(&dir);
         }
     }
 }
@@ -2002,6 +2035,40 @@ pub fn cleanup_orphaned_ephemeral_vms() {
 #[cfg(test)]
 mod init_runner_tests {
     use super::*;
+
+    // The ephemeral-reap policy: only ephemeral + (dead or PID-less) records, in
+    // list order, capped at `limit`. Persistent and still-alive VMs are never
+    // returned — this is what keeps the bounded `machine run` sweep from touching
+    // a concurrent run's live VM.
+    #[test]
+    fn orphaned_ephemeral_names_filters_and_caps() {
+        use smolvm::config::VmRecord;
+        let mk = |name: &str, ephemeral: bool, pid: Option<i32>| {
+            let mut r = VmRecord::new(name.to_string(), 1, 256, vec![], vec![], false);
+            r.ephemeral = ephemeral;
+            r.pid = pid;
+            (name.to_string(), r)
+        };
+        let vms = vec![
+            mk("persistent", false, Some(10)), // not ephemeral -> skip
+            mk("alive", true, Some(20)),       // ephemeral but alive -> skip
+            mk("dead1", true, Some(30)),       // ephemeral + dead -> orphan
+            mk("nopid", true, None),           // ephemeral + no PID -> orphan
+            mk("dead2", true, Some(40)),       // ephemeral + dead -> orphan
+        ];
+        let alive = |pid: i32| pid == 20; // only the live VM's PID is alive
+
+        assert_eq!(
+            orphaned_ephemeral_names(&vms, alive, usize::MAX),
+            vec!["dead1", "nopid", "dead2"]
+        );
+        assert_eq!(
+            orphaned_ephemeral_names(&vms, alive, 2),
+            vec!["dead1", "nopid"],
+            "cap limits how many are reaped per call"
+        );
+        assert!(orphaned_ephemeral_names(&vms, alive, 0).is_empty());
+    }
 
     fn sample_image_info(env: Vec<&str>, workdir: Option<&str>, user: Option<&str>) -> ImageInfo {
         ImageInfo {

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -1967,11 +1967,11 @@ pub fn deregister_ephemeral_vm(name: &str) {
 /// Pure (no I/O) so the reaping policy is unit-testable: given the VM list and a
 /// liveness probe, it returns at most `limit` orphan names in list order. A
 /// non-ephemeral or still-alive record is never returned.
-fn orphaned_ephemeral_names<'a>(
-    vms: &'a [(String, VmRecord)],
+fn orphaned_ephemeral_names(
+    vms: &[(String, VmRecord)],
     is_alive: impl Fn(i32) -> bool,
     limit: usize,
-) -> Vec<&'a str> {
+) -> Vec<&str> {
     let mut out = Vec::new();
     for (name, record) in vms {
         if out.len() >= limit {

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,14 +49,12 @@ enum Commands {
     /// Internal: clean up an ephemeral VM after its command exits (not for direct use)
     #[command(name = "_cleanup-ephemeral", hide = true)]
     CleanupEphemeral {
-        /// Ephemeral VM name (used to compute data directory path)
+        /// Ephemeral VM name (its data dir + DB record are both keyed by this)
         vm_name: String,
         /// VM process PID
         pid: i32,
         /// Process start time for PID-reuse verification (0 = unknown, skips strict check)
         start_time: u64,
-        /// Ephemeral DB record name (may differ from vm_name)
-        ephemeral_name: String,
     },
 }
 
@@ -104,9 +102,8 @@ fn main() {
             vm_name,
             pid,
             start_time,
-            ephemeral_name,
         } => {
-            cli::cleanup_ephemeral::run(&vm_name, pid, start_time, &ephemeral_name);
+            cli::cleanup_ephemeral::run(&vm_name, pid, start_time);
             Ok(())
         }
     };

--- a/src/process.rs
+++ b/src/process.rs
@@ -1282,8 +1282,9 @@ pub fn setup_pack_idmap_mount(
     // Clone the shared subtree into a detached mount object. mount_setattr's idmap
     // requires a freshly-cloned mount with no other users, which OPEN_TREE_CLONE
     // provides; AT_RECURSIVE covers any submounts.
-    let open_flags: libc::c_uint =
-        libc::OPEN_TREE_CLONE | libc::AT_RECURSIVE as libc::c_uint | libc::O_CLOEXEC as libc::c_uint;
+    let open_flags: libc::c_uint = libc::OPEN_TREE_CLONE
+        | libc::AT_RECURSIVE as libc::c_uint
+        | libc::O_CLOEXEC as libc::c_uint;
     let tree = unsafe {
         libc::syscall(
             libc::SYS_open_tree,

--- a/src/process.rs
+++ b/src/process.rs
@@ -1132,6 +1132,214 @@ pub fn chown_tree(_path: &std::path::Path, _uid: u32, _gid: u32) -> std::io::Res
     Ok(())
 }
 
+/// Build a user namespace whose single-entry uid/gid maps make on-disk id 0
+/// appear as `(uid, gid)` *through an idmapped mount*, and return an fd to its
+/// `/proc/<pid>/ns/user` (the open fd keeps the namespace alive after the helper
+/// process exits).
+///
+/// Mechanics (validated against kernels 6.17/6.18): fork a helper that
+/// `unshare(CLONE_NEWUSER)`s and blocks; the parent (still privileged) writes the
+/// child's `uid_map`/`gid_map`. A map line is `<nsid> <hostid> <count>`, and an
+/// idmapped mount treats the ON-DISK id as an nsid and maps it DOWN to a host
+/// kuid — so to surface on-disk 0 as host `uid` we write `0 <uid> 1` (NOT
+/// `<uid> 0 1`, which surfaces the overflow uid and denies every read). The
+/// parent MUST wait until the child is inside the new userns before writing the
+/// maps (a two-pipe handshake), or the write races the `unshare` and fails EPERM.
+/// `setgroups` is denied before `gid_map` (required to write a gid map).
+#[cfg(target_os = "linux")]
+fn make_idmap_userns(uid: u32, gid: u32) -> std::io::Result<libc::c_int> {
+    let errno = || std::io::Error::last_os_error();
+    // ready: child -> parent (userns created); go: parent -> child (maps written).
+    let mut ready = [-1i32; 2];
+    let mut go = [-1i32; 2];
+    if unsafe { libc::pipe(ready.as_mut_ptr()) } != 0 {
+        return Err(errno());
+    }
+    if unsafe { libc::pipe(go.as_mut_ptr()) } != 0 {
+        let e = errno();
+        unsafe {
+            libc::close(ready[0]);
+            libc::close(ready[1]);
+        }
+        return Err(e);
+    }
+    let pid = unsafe { libc::fork() };
+    if pid < 0 {
+        let e = errno();
+        unsafe {
+            libc::close(ready[0]);
+            libc::close(ready[1]);
+            libc::close(go[0]);
+            libc::close(go[1]);
+        }
+        return Err(e);
+    }
+    if pid == 0 {
+        // CHILD: async-signal-safe calls only (post-fork in a possibly threaded
+        // process). Become a fresh userns, signal the parent, block until the maps
+        // are written, then exit — the parent's open ns fd keeps the userns alive.
+        if unsafe { libc::unshare(libc::CLONE_NEWUSER) } != 0 {
+            unsafe { libc::_exit(1) };
+        }
+        let sig: [u8; 1] = [b'r'];
+        unsafe {
+            libc::write(ready[1], sig.as_ptr() as *const libc::c_void, 1);
+        }
+        let mut got = 0u8;
+        unsafe {
+            libc::read(go[0], &mut got as *mut u8 as *mut libc::c_void, 1);
+            libc::_exit(0);
+        }
+    }
+
+    // PARENT. Close the ends we don't use, then wait for the child's "ready".
+    unsafe {
+        libc::close(ready[1]);
+        libc::close(go[0]);
+    }
+    let mut got = 0u8;
+    let _ = unsafe { libc::read(ready[0], &mut got as *mut u8 as *mut libc::c_void, 1) };
+
+    // Write the maps from the privileged parent. A single entry mapping host id
+    // `uid`/`gid` is permitted via the ns-creator's CAP_SETUID/CAP_SETGID path.
+    let finish = |result: std::io::Result<libc::c_int>| -> std::io::Result<libc::c_int> {
+        let go_w: [u8; 1] = [b'x'];
+        unsafe {
+            libc::write(go[1], go_w.as_ptr() as *const libc::c_void, 1);
+            libc::close(go[1]);
+            libc::close(ready[0]);
+            let mut status = 0;
+            libc::waitpid(pid, &mut status, 0);
+        }
+        result
+    };
+    if let Err(e) = std::fs::write(format!("/proc/{pid}/uid_map"), format!("0 {uid} 1\n")) {
+        return finish(Err(e));
+    }
+    // Must deny setgroups(2) before a gid_map may be written in a userns.
+    let _ = std::fs::write(format!("/proc/{pid}/setgroups"), "deny");
+    if let Err(e) = std::fs::write(format!("/proc/{pid}/gid_map"), format!("0 {gid} 1\n")) {
+        return finish(Err(e));
+    }
+    let ns_path = std::ffi::CString::new(format!("/proc/{pid}/ns/user")).unwrap();
+    let nsfd = unsafe { libc::open(ns_path.as_ptr(), libc::O_RDONLY | libc::O_CLOEXEC) };
+    if nsfd < 0 {
+        return finish(Err(errno()));
+    }
+    finish(Ok(nsfd))
+}
+
+/// Present the root-owned shared pack at `shared` onto the per-VM mountpoint
+/// `target` via an idmapped bind mount that maps on-disk uid/gid 0 -> `(uid, gid)`
+/// — so the VMM (about to drop to that uid) reads every file as its owner, while
+/// the underlying shared copy stays root-only on disk (a sibling VM's uid can't
+/// read it directly). This is what lets one root-owned shared copy replace the
+/// per-machine extract + chown while preserving the per-VM uid isolation (#456).
+///
+/// The mount is made in a fresh **private** mount namespace, so it is visible only
+/// to this VMM process (and the libkrun threads it later spawns) and is torn down
+/// automatically when the process exits — no teardown plumbing, no propagation to
+/// the host or sibling VMs. MUST run while still privileged (CAP_SYS_ADMIN) and
+/// BEFORE Landlock/seccomp/`drop_privileges`. Linux ≥ 5.12.
+#[cfg(target_os = "linux")]
+pub fn setup_pack_idmap_mount(
+    shared: &std::path::Path,
+    target: &std::path::Path,
+    uid: u32,
+    gid: u32,
+) -> std::io::Result<()> {
+    use std::os::unix::ffi::OsStrExt;
+    let errno = || std::io::Error::last_os_error();
+
+    // Our own mount namespace: the idmap mount lives and dies with this process.
+    if unsafe { libc::unshare(libc::CLONE_NEWNS) } != 0 {
+        return Err(errno());
+    }
+    // Don't propagate mounts back into the host's mount namespace.
+    if unsafe {
+        libc::mount(
+            std::ptr::null(),
+            c"/".as_ptr(),
+            std::ptr::null(),
+            libc::MS_REC | libc::MS_PRIVATE,
+            std::ptr::null(),
+        )
+    } != 0
+    {
+        return Err(errno());
+    }
+
+    let userns_fd = make_idmap_userns(uid, gid)?;
+    let close_userns = || unsafe {
+        libc::close(userns_fd);
+    };
+
+    let shared_c = std::ffi::CString::new(shared.as_os_str().as_bytes())
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;
+    let target_c = std::ffi::CString::new(target.as_os_str().as_bytes())
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;
+
+    // Clone the shared subtree into a detached mount object. mount_setattr's idmap
+    // requires a freshly-cloned mount with no other users, which OPEN_TREE_CLONE
+    // provides; AT_RECURSIVE covers any submounts.
+    let open_flags: libc::c_uint =
+        libc::OPEN_TREE_CLONE | libc::AT_RECURSIVE as libc::c_uint | libc::O_CLOEXEC as libc::c_uint;
+    let tree = unsafe {
+        libc::syscall(
+            libc::SYS_open_tree,
+            libc::AT_FDCWD,
+            shared_c.as_ptr(),
+            open_flags,
+        )
+    } as libc::c_int;
+    if tree < 0 {
+        let e = errno();
+        close_userns();
+        return Err(e);
+    }
+    let close_tree = || unsafe {
+        libc::close(tree);
+    };
+
+    // Attach the idmap (recursively) to the cloned tree.
+    let mut attr: libc::mount_attr = unsafe { std::mem::zeroed() };
+    attr.attr_set = libc::MOUNT_ATTR_IDMAP;
+    attr.userns_fd = userns_fd as u64;
+    let rc = unsafe {
+        libc::syscall(
+            libc::SYS_mount_setattr,
+            tree,
+            c"".as_ptr(),
+            (libc::AT_EMPTY_PATH | libc::AT_RECURSIVE) as libc::c_uint,
+            &attr as *const libc::mount_attr,
+            std::mem::size_of::<libc::mount_attr>() as libc::size_t,
+        )
+    };
+    if rc != 0 {
+        let e = errno();
+        close_tree();
+        close_userns();
+        return Err(e);
+    }
+
+    // Move the now-idmapped tree onto the per-VM mountpoint.
+    let rc = unsafe {
+        libc::syscall(
+            libc::SYS_move_mount,
+            tree,
+            c"".as_ptr(),
+            libc::AT_FDCWD,
+            target_c.as_ptr(),
+            libc::MOVE_MOUNT_F_EMPTY_PATH as libc::c_uint,
+        )
+    };
+    let result = if rc != 0 { Err(errno()) } else { Ok(()) };
+    // The kernel holds its own references now; our fds are no longer needed.
+    close_tree();
+    close_userns();
+    result
+}
+
 /// Process-wide gate bounding concurrent VM disk-prep / boot. Every boot path —
 /// the API `start_machine`, the supervisor's restart/reconnect, and startup
 /// reconnect — funnels through `AgentManager::start_via_subprocess`, which

--- a/tests/idmap_e2e_boot.sh
+++ b/tests/idmap_e2e_boot.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Full-VM e2e for the shared content-addressed pack store + per-VM idmapped
+# bind mount. Drives the *serve API* (the cloud/node path that the shared store
+# targets) as root so the per-VM uid drop (#456) is active and the idmap mount
+# fires. Validates: (1) shared store extracts ONCE into _shared/<checksum>,
+# root-owned 0700; (2) a second machine from the same .smolmachine REUSES it
+# (no second decode); (3) each machine leaves an empty `pack` mountpoint + a
+# `.pack-shared` pointer; (4) both guests BOOT and exec reads files (proving the
+# idmap mount presented the root-owned pack as the VM's dropped uid); (5) the
+# on-disk shared copy stays root:root (isolation preserved).
+#
+# Run as root on a Linux/KVM box:  sudo SMOLVM=... SMOLVM_LIB_DIR=... ./idmap_e2e_boot.sh /path/to/x.smolmachine
+set -u
+
+SMOLVM="${SMOLVM:?set SMOLVM to the smolvm binary}"
+SIDECAR="${1:?usage: idmap_e2e_boot.sh <file.smolmachine>}"
+DATA_DIR="${SMOLVM_DATA_DIR:-/tmp/idmap-e2e-data}"
+SOCK="/tmp/idmap-e2e.sock"
+CURL=(curl -s --unix-socket "$SOCK")
+URL="http://localhost"
+PASS=0; FAIL=0
+ok()   { echo "  PASS: $*"; PASS=$((PASS+1)); }
+bad()  { echo "  FAIL: $*"; FAIL=$((FAIL+1)); }
+
+# Fresh, world-traversable data root so the dropped VM uid can reach its dirs.
+rm -rf "$DATA_DIR"; mkdir -p "$DATA_DIR"; chmod 755 "$DATA_DIR"
+export SMOLVM_DATA_DIR="$DATA_DIR"
+
+# Seed the node-constant guest agent-rootfs (the serve API gates `start` on it
+# via "verify rootfs"). It's install-state, not part of the per-image pack the
+# shared store optimizes, so we copy a known-good tree in rather than re-install.
+AGENT_ROOTFS_SRC="${AGENT_ROOTFS_SRC:-$HOME/.local/share/smolvm/agent-rootfs}"
+if [ -d "$AGENT_ROOTFS_SRC" ]; then
+  mkdir -p "$DATA_DIR/.local/share/smolvm"
+  cp -a "$AGENT_ROOTFS_SRC" "$DATA_DIR/.local/share/smolvm/agent-rootfs"
+  chmod -R a+rX "$DATA_DIR/.local/share/smolvm"
+else
+  echo "[!] no agent-rootfs at $AGENT_ROOTFS_SRC — boot steps will fail (set AGENT_ROOTFS_SRC)"
+fi
+
+echo "[*] euid=$(id -u) (expect 0 for uid-drop), data=$DATA_DIR, sidecar=$SIDECAR"
+
+rm -f "$SOCK"
+"$SMOLVM" serve start -l "unix://$SOCK" >"$DATA_DIR/serve.log" 2>&1 &
+SERVE_PID=$!
+cleanup() {
+  "${CURL[@]}" -X DELETE "$URL/api/v1/machines/e2e-a" >/dev/null 2>&1 || true
+  "${CURL[@]}" -X DELETE "$URL/api/v1/machines/e2e-b" >/dev/null 2>&1 || true
+  kill "$SERVE_PID" 2>/dev/null || true; wait "$SERVE_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+for i in $(seq 1 50); do "${CURL[@]}" "$URL/health" >/dev/null 2>&1 && break; sleep 0.2; done
+"${CURL[@]}" "$URL/health" | grep -q '"status":"ok"' && ok "serve up" || { bad "serve did not start"; cat "$DATA_DIR/serve.log"; exit 1; }
+
+create() {
+  "${CURL[@]}" -o /dev/null -w "%{http_code}" -X POST "$URL/api/v1/machines" \
+    -H 'Content-Type: application/json' -d "{\"name\":\"$1\",\"from\":\"$SIDECAR\",\"cpus\":1,\"mem\":512}"
+}
+
+# --- Create machine A: first extraction populates the shared store ----------
+echo "[*] creating e2e-a"
+[ "$(create e2e-a)" = "200" ] && ok "create e2e-a 200" || bad "create e2e-a !=200"
+
+# Layout: SMOLVM_DATA_DIR becomes $HOME, so the store is $HOME/.cache/smolvm/vms.
+VMS_ROOT="$(find "$DATA_DIR" -type d -path '*/smolvm/vms' | head -1)"
+SHARED_ROOT="$VMS_ROOT/_shared"
+[ -d "$SHARED_ROOT" ] && ok "shared root exists: $SHARED_ROOT" || bad "no shared root (vms=$VMS_ROOT)"
+CKDIR="$(find "$SHARED_ROOT" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | head -1)"
+[ -n "$CKDIR" ] && ok "shared checksum dir: $(basename "$CKDIR")" || bad "no shared checksum dir"
+# Root-owned + 0700 (isolation): a sibling dropped-uid cannot read it directly.
+own="$(stat -c '%U:%G %a' "$CKDIR" 2>/dev/null)"
+[ "$own" = "root:root 700" ] && ok "shared dir is root:root 0700" || bad "shared dir perms = $own (want root:root 700)"
+# Per-machine: empty `pack` mountpoint + a pointer to the shared dir.
+PACK_A="$(find "$VMS_ROOT" -mindepth 2 -maxdepth 2 -name pack -type d 2>/dev/null | grep -v _shared | head -1)"
+PTR_A="$(dirname "$PACK_A")/.pack-shared"
+[ -f "$PTR_A" ] && ok "pointer written: $PTR_A -> $(cat "$PTR_A")" || bad "no .pack-shared pointer"
+[ -z "$(ls -A "$PACK_A" 2>/dev/null)" ] && ok "pack mountpoint is empty (pre-boot)" || bad "pack mountpoint not empty"
+
+# --- Create machine B from the SAME sidecar: must REUSE, not re-extract ------
+echo "[*] creating e2e-b (same sidecar)"
+[ "$(create e2e-b)" = "200" ] && ok "create e2e-b 200" || bad "create e2e-b !=200"
+NDIRS="$(find "$SHARED_ROOT" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+[ "$NDIRS" = "1" ] && ok "still ONE shared dir after 2 creates (reuse, no re-decode)" || bad "shared dirs=$NDIRS (expected 1)"
+
+# --- Boot both: idmap mount presents the root-owned pack as each VM's uid ----
+boot_and_exec() {
+  local n="$1"
+  local st; st="$("${CURL[@]}" -X POST "$URL/api/v1/machines/$n/start")"
+  echo "$st" | grep -q '"state":"running"' && ok "$n booted (state=running)" || { bad "$n did not boot"; echo "$st"; }
+  local ex; ex="$("${CURL[@]}" -X POST "$URL/api/v1/machines/$n/exec" -H 'Content-Type: application/json' -d '{"command":["cat","/etc/os-release"]}')"
+  echo "$ex" | grep -qi 'alpine\|linux' && ok "$n exec read rootfs through idmap mount" || { bad "$n exec failed"; echo "$ex" | head -c 400; }
+}
+boot_and_exec e2e-a
+boot_and_exec e2e-b
+
+# --- Isolation: shared copy still root-owned after both VMs booted -----------
+own2="$(stat -c '%U:%G %a' "$CKDIR" 2>/dev/null)"
+[ "$own2" = "root:root 700" ] && ok "shared copy still root:root 0700 post-boot" || bad "shared perms changed: $own2"
+
+# --- The two VMMs dropped to DIFFERENT uids (per-VM isolation #456) ----------
+uids="$(ps -eo uid,args | grep '[_]boot-vm' | awk '{print $1}' | sort -u)"
+nuid="$(echo "$uids" | grep -c .)"
+echo "[*] live _boot-vm uids: $(echo $uids | tr '\n' ' ')"
+[ "$nuid" -ge 2 ] && ok "VMMs run under >=2 distinct dropped uids" || echo "  INFO: distinct boot-vm uids=$nuid (VMs may share or have exited)"
+
+echo ""
+echo "==== idmap e2e: $PASS passed, $FAIL failed ===="
+[ "$FAIL" = "0" ]

--- a/tests/idmap_mount.rs
+++ b/tests/idmap_mount.rs
@@ -1,0 +1,84 @@
+//! Validates the shared-pack idmapped-bind-mount mechanism on a real Linux
+//! kernel (>= 5.12). This is the novel piece of the shared content-addressed
+//! pack store: one root-owned copy of the build-constant pack is extracted per
+//! node, then presented at each VM's `pack` mountpoint via an idmapped bind
+//! mount that maps the on-disk uid/gid 0 down to the VM's dropped uid (#456).
+//!
+//! Root-only (needs CAP_SYS_ADMIN for unshare/open_tree/mount_setattr/move_mount)
+//! and Linux-only, so it is `#[ignore]`d by default. Run on the test box with:
+//!   sudo -E cargo test --release --test idmap_mount -- --ignored --test-threads=1
+#![cfg(target_os = "linux")]
+
+use std::os::unix::fs::MetadataExt;
+
+/// A distinctive uid/gid well outside any real account, matching the
+/// 2_000_000+ range #456 drops VMM processes into.
+const TEST_UID: u32 = 2_000_123;
+const TEST_GID: u32 = 2_000_123;
+
+#[test]
+#[ignore = "requires root (CAP_SYS_ADMIN) and Linux >= 5.12"]
+fn idmap_mount_presents_root_owned_pack_as_vm_uid() {
+    // SAFETY of the in-process mount-ns mutation: setup_pack_idmap_mount does
+    // unshare(CLONE_NEWNS), so the bind mount is visible only to this thread's
+    // private mount namespace and vanishes when the test process exits. Run with
+    // --test-threads=1 so no sibling test races on the namespace.
+    let root = std::env::temp_dir().join(format!("smolvm-idmap-test-{}", std::process::id()));
+    let shared = root.join("shared");
+    let target = root.join("target");
+    std::fs::create_dir_all(&shared).expect("mkdir shared");
+    std::fs::create_dir_all(&target).expect("mkdir target");
+
+    // A root-owned (extraction-as-root => uid 0) file + nested dir, mirroring the
+    // agent-rootfs tree the real pack contains.
+    let file = shared.join("hello");
+    std::fs::write(&file, b"pack contents").expect("write shared file");
+    let nested_dir = shared.join("sub");
+    std::fs::create_dir_all(&nested_dir).expect("mkdir nested");
+    let nested_file = nested_dir.join("deep");
+    std::fs::write(&nested_file, b"deep contents").expect("write nested file");
+
+    // Precondition: on disk the files are owned by uid/gid 0.
+    let pre = std::fs::metadata(&file).expect("stat pre");
+    assert_eq!(pre.uid(), 0, "shared file must start root-owned");
+    assert_eq!(pre.gid(), 0, "shared file must start root-group");
+
+    // Exercise the mechanism under test.
+    smolvm::process::setup_pack_idmap_mount(&shared, &target, TEST_UID, TEST_GID)
+        .expect("setup_pack_idmap_mount failed");
+
+    // Through the idmapped mount, on-disk uid 0 must surface as the VM uid — this
+    // is what lets the soon-to-drop VMM read every pack file as its owner.
+    let mapped = std::fs::metadata(target.join("hello")).expect("stat mapped file");
+    assert_eq!(
+        mapped.uid(),
+        TEST_UID,
+        "idmapped mount must surface on-disk uid 0 as the VM uid"
+    );
+    assert_eq!(
+        mapped.gid(),
+        TEST_GID,
+        "idmapped mount must surface on-disk gid 0 as the VM gid"
+    );
+    // Contents must read through unchanged (it is the same inode, just remapped).
+    let body = std::fs::read(target.join("hello")).expect("read mapped file");
+    assert_eq!(body, b"pack contents", "mapped file contents must match");
+
+    // AT_RECURSIVE must remap nested entries too, not just the top level.
+    let mapped_deep =
+        std::fs::metadata(target.join("sub").join("deep")).expect("stat mapped nested");
+    assert_eq!(
+        mapped_deep.uid(),
+        TEST_UID,
+        "nested entries must be remapped (AT_RECURSIVE)"
+    );
+
+    // Isolation invariant: the underlying shared copy is untouched on disk — a
+    // sibling VM dropped to a *different* uid still sees it as root-only and so
+    // cannot read it directly (only its own idmapped view maps it).
+    let post = std::fs::metadata(&file).expect("stat post");
+    assert_eq!(post.uid(), 0, "on-disk shared copy must stay root-owned");
+
+    // Best-effort cleanup; the private mount ns tears down on process exit anyway.
+    let _ = std::fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
The orphan sweep keyed each ephemeral VM's DB record by a freshly generated name, but the disks live under `vm_data_dir(vm_name)`, so on a non-graceful `machine run` exit (Ctrl-C / SIGKILL / host sleep) the sweep deleted the record yet removed the wrong directory — leaking the real multi-GB data dir; this keys the record by the VM's own name so the sweep reclaims the right dir, and also makes `machine run` itself run a bounded orphan sweep so a pure-`run` workflow (which never hits any other command) actually self-heals.

Validated end-to-end: an ephemeral `machine run` SIGKILLed mid-run leaves its data dir orphaned, and the next `machine run` reclaims it.
