### PR TITLE
fix(serve): reclaim leaked VM data dirs on startup (dead-record + dangling)

### DIFF
--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -286,6 +286,19 @@ impl ApiState {
                 if let Err(e) = self.db.remove_vm(&name) {
                     tracing::warn!(machine = %name, error = %e, "failed to remove dead machine from database");
                 }
+                // Reclaim the data dir too. Removing only the DB record leaks the
+                // machine's storage + overlay images (multi-GB sparse files) — and
+                // since the record is gone, nothing will ever clean them up later.
+                // On a long-lived node that churns/crashes machines this is a slow
+                // disk-fill across server restarts. The `pid.is_some()` guard above
+                // means we only touch machines that were started and then died, not
+                // intentionally-stopped (pid=None) machines whose disks must persist.
+                let dir = crate::agent::vm_data_dir(&name);
+                if dir.exists() {
+                    if let Err(e) = std::fs::remove_dir_all(&dir) {
+                        tracing::warn!(machine = %name, error = %e, "failed to remove dead machine data dir");
+                    }
+                }
                 continue;
             }
 
@@ -1467,6 +1480,12 @@ mod tests {
         record.state = RecordState::Running;
         state.db.insert_vm("dead-machine", &record).unwrap();
 
+        // Give it a data dir with a marker file — reconciliation must reclaim it,
+        // not just the DB record (otherwise the disks leak across restarts).
+        let data_dir = crate::agent::vm_data_dir("dead-machine");
+        std::fs::create_dir_all(&data_dir).unwrap();
+        std::fs::write(data_dir.join("storage.raw"), b"x").unwrap();
+
         // Verify record exists before load
         assert!(state.db.get_vm("dead-machine").unwrap().is_some());
 
@@ -1478,6 +1497,12 @@ mod tests {
         assert!(
             state.db.get_vm("dead-machine").unwrap().is_none(),
             "dead machine DB record should be removed"
+        );
+
+        // Data dir should be reclaimed too (no disk leak).
+        assert!(
+            !data_dir.exists(),
+            "dead machine data dir should be removed, not leaked"
         );
 
         // Name should be available for reuse


### PR DESCRIPTION
`smolvm serve` leaked VM data dirs two ways across restarts, a slow disk-fill on long-lived nodes: (1) startup reconciliation reaped a dead machine's DB record but left its storage+overlay images, and (2) dirs whose record was already gone (legacy leaks, CLI ephemeral orphans) were never collected at all. This removes the data dir alongside the record for dead machines, and adds a startup filesystem GC of record-less VM dirs — confined to the real `serve` process (never `load_persisted_machines`, so tests/embedders can't wipe live dirs) and limited to `vm_dir_hash`-shaped names so the shared pack store is never touched.

Validated live: a node with 85 dirs but 5 live machines reclaimed 78 dangling dirs on startup, keeping all 5 machines.
