### PR TITLE
release: smolvm 1.3.1 — lazy-bound libkrun (GPU-less boot fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2177,7 +2177,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "smolvm"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 description = "OCI-native microVM runtime"
 license = "Apache-2.0"

--- a/lib/libkrun.provenance
+++ b/lib/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=e962f75c404cb23e6c2cc86be91a848b755f1bbd
+libkrun=3f9e0e4eaf7923d965669be37f0a283b38b0dbf3
 libkrunfw=392573f22f46bb1f2c864476ba3764170fe29507

--- a/lib/linux-aarch64/libkrun.provenance
+++ b/lib/linux-aarch64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=e962f75c404cb23e6c2cc86be91a848b755f1bbd
+libkrun=3f9e0e4eaf7923d965669be37f0a283b38b0dbf3
 libkrunfw=392573f22f46bb1f2c864476ba3764170fe29507

--- a/lib/linux-aarch64/libkrun.so
+++ b/lib/linux-aarch64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:02c7e0f837e3816f4f00c4ab9d905c3997b7bb4d14b6e956648dcb628ffc0ebb
-size 6717000
+oid sha256:eb9823eeba1b733b55e646c5ae44ef2ac599a933d72de624e8ed7687dd1f8193
+size 6740000

--- a/lib/linux-aarch64/libkrun.so.2.0.0
+++ b/lib/linux-aarch64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:02c7e0f837e3816f4f00c4ab9d905c3997b7bb4d14b6e956648dcb628ffc0ebb
-size 6717000
+oid sha256:eb9823eeba1b733b55e646c5ae44ef2ac599a933d72de624e8ed7687dd1f8193
+size 6740000

--- a/lib/linux-x86_64/libkrun.provenance
+++ b/lib/linux-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=e962f75c404cb23e6c2cc86be91a848b755f1bbd
+libkrun=3f9e0e4eaf7923d965669be37f0a283b38b0dbf3
 libkrunfw=392573f22f46bb1f2c864476ba3764170fe29507

--- a/lib/linux-x86_64/libkrun.so
+++ b/lib/linux-x86_64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1ed200ef6dc3de2ff3dce4b6fdf363f4eace61345dfbb7bdc140f67ec3b2563a
-size 7926992
+oid sha256:daecd0cde6fc73d125b45c9321626e969884984f677032d41cef38db468b361e
+size 7823680

--- a/lib/linux-x86_64/libkrun.so.2.0.0
+++ b/lib/linux-x86_64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1ed200ef6dc3de2ff3dce4b6fdf363f4eace61345dfbb7bdc140f67ec3b2563a
-size 7926992
+oid sha256:daecd0cde6fc73d125b45c9321626e969884984f677032d41cef38db468b361e
+size 7823680

--- a/lib/windows-x86_64/libkrun.provenance
+++ b/lib/windows-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=e962f75c404cb23e6c2cc86be91a848b755f1bbd
+libkrun=3f9e0e4eaf7923d965669be37f0a283b38b0dbf3
 libkrunfw=392573f22f46bb1f2c864476ba3764170fe29507

--- a/scripts/build-libkrun-linux.sh
+++ b/scripts/build-libkrun-linux.sh
@@ -98,11 +98,29 @@ else
     [[ -n "$KRUNFW_SO" ]] || { echo "ERROR: libkrunfw build produced no .so" >&2; exit 1; }
 fi
 
-# --- 3. init (static guest-arch ELF, built natively) -------------------------
-echo "--- building guest init (native ${ARCH} ELF) ---"
-cc -O2 -static -Wall -o libkrun/init/init libkrun/init/init.c libkrun/init/dhcp.c
-file libkrun/init/init | grep -q 'statically linked' \
-    || { echo "ERROR: init/init is not a static ELF" >&2; exit 1; }
+# --- 3. init (guest PID-1) ---------------------------------------------------
+# Two libkrun layouts, auto-detected by the presence of init/init.c:
+#  - old (<= libkrun 1.x): PID-1 is a static C init compiled here and handed to
+#    the build via KRUN_INIT_BINARY_PATH.
+#  - libkrun 2.0+: PID-1 is a Rust crate (init/) that src/init_blob/build.rs
+#    cross-compiles to musl ITSELF. `init/init` is only an empty placeholder, and
+#    KRUN_INIT_BINARY_PATH must be LEFT UNSET — init_blob/build.rs uses that var
+#    verbatim when set, so pointing it at the empty placeholder embeds a 0-byte
+#    init and bricks the guest (PID-1 dies, VM never reaches agent-ready). The
+#    musl std target must be present or the init links dynamically and can't run
+#    as the guest's PID 1.
+INIT_ENV=()
+if [[ -f libkrun/init/init.c ]]; then
+    echo "--- building guest init (legacy C; native ${ARCH} ELF) ---"
+    cc -O2 -static -Wall -o libkrun/init/init libkrun/init/init.c libkrun/init/dhcp.c
+    file libkrun/init/init | grep -q 'statically linked' \
+        || { echo "ERROR: init/init is not a static ELF" >&2; exit 1; }
+    INIT_ENV=("KRUN_INIT_BINARY_PATH=$(realpath libkrun/init/init)")
+else
+    echo "--- guest init: Rust crate (init_blob cross-compiles to musl) ---"
+    rustup target add "${ARCH}-unknown-linux-musl" >/dev/null 2>&1 \
+        || echo "WARN: could not add ${ARCH}-unknown-linux-musl; init may link dynamically"
+fi
 
 # --- 4. libkrun (VMM) --------------------------------------------------------
 echo "--- building libkrun (BLK=1 NET=1 ${GPU_FLAG}) ---"
@@ -113,8 +131,9 @@ echo "--- building libkrun (BLK=1 NET=1 ${GPU_FLAG}) ---"
 # resolve the now-unprovided virgl symbols and fail the load. Must match the
 # relro-level=partial that build-dist.sh applies on its own libkrun compiles.
 ( cd libkrun && make clean >/dev/null 2>&1 || true; \
+  env "${INIT_ENV[@]}" \
   RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }-C relro-level=partial" \
-  KRUN_INIT_BINARY_PATH="$(realpath init/init)" make --no-print-directory BLK=1 NET=1 "${GPU_FLAG}" )
+  make --no-print-directory BLK=1 NET=1 "${GPU_FLAG}" )
 KRUN_SO="$(ls -1 libkrun/target/release/libkrun.so.*.*.* 2>/dev/null | head -1)"
 [[ -n "$KRUN_SO" ]] || { echo "ERROR: libkrun build produced no .so" >&2; exit 1; }
 


### PR DESCRIPTION
Hotfix for the v1.3.0 fleet-wide boot regression on GPU-less hosts.

**Root cause:** v1.3.0's \`libkrun.so.2\` linked \`-z now\` (BIND_NOW / DF_1_NOW / full RELRO). That overrides the engine's \`RTLD_LAZY\` dlopen and forces eager resolution of the ~31 undefined \`virgl_renderer_*\` symbols, which live in libvirglrenderer (dlopen'd only on a GPU request, absent on GPU-less hosts). So \`dlopen(libkrun)\` fails at load with \`undefined symbol: virgl_renderer_poll\` and every microVM boot dies.

**Fix (3 parts):**
- libkrun bumped to the on-main lazy-bind commit (\`3f9e0e4\`): \`build.rs\` appends \`-Wl,-z,lazy\`, keeping partial RELRO but dropping eager PLT binding. Verified: rebuilt \`.so\` has no BIND_NOW / DF_1_NOW on both arches; the UND virgl symbols now defer (never called without a GPU).
- \`scripts/build-libkrun-linux.sh\`: support the libkrun 2.0 Rust-init layout (no \`init/init.c\`) — leave \`KRUN_INIT_BINARY_PATH\` unset so \`init_blob/build.rs\` cross-compiles the real musl PID-1 instead of embedding the empty placeholder.
- Rebuilt \`lib/linux-{x86_64,aarch64}/libkrun.so\` via CI (lazy-bound), committed via LFS.

This affects every smolvm user on a GPU-less Linux host, not just the cloud fleet.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/500">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->