### PR TITLE
Remove the process-wide boot-concurrency gate

### DIFF
--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -1601,16 +1601,12 @@ impl AgentManager {
         let t_launch = Instant::now();
 
         let resources_for_config = resources.clone();
-        // Bound concurrent disk-prep across ALL boot paths (this is the chokepoint
-        // they share): unbounded parallel template copies thrash the host disk so
-        // each balloons (3.8s → 50s under ~13 concurrent boots) and the start
-        // times out. The permit is held only across `prepare_for_launch` (the disk
-        // copy), then released before the VMM spawn. Process-wide; tune with
-        // SMOLVM_BOOT_CONCURRENCY.
-        {
-            let _boot_permit = crate::process::acquire_boot_permit();
-            self.prepare_for_launch(&mounts, &ports, resources)?;
-        }
+        // Per-boot disk-prep (template copy). Formerly bounded by a process-wide
+        // boot gate to avoid host-disk thrash on slow/shared storage; removed
+        // after metal measurements showed disk-prep at ~1ms (NVMe + qcow2 thin
+        // clone) with flat boot latency from 8 → 32 concurrent boots — the gate
+        // was non-binding and only serialized needlessly.
+        self.prepare_for_launch(&mounts, &ports, resources)?;
         tracing::info!(
             elapsed_ms = t_launch.elapsed().as_millis(),
             "boot: disks ready"

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -813,11 +813,6 @@ pub async fn start_machine(
     let ports = record.port_mappings();
     let resources = record.vm_resources();
 
-    // Note: concurrent-boot bounding lives at the chokepoint all boot paths share
-    // (`AgentManager::start_via_subprocess` → a process-wide sync gate), not here,
-    // so the supervisor + reconnect boot paths are bounded too. See
-    // `smolvm::process::acquire_boot_permit`.
-
     // Start agent VM in blocking task.
     // Uses subprocess launch to avoid macOS fork-in-multithreaded-process issue.
     let name_clone = name.clone();

--- a/src/process.rs
+++ b/src/process.rs
@@ -6,7 +6,7 @@
 #[cfg(unix)]
 use std::os::fd::IntoRawFd;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Condvar, Mutex, OnceLock};
+use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use crate::error::{Error, Result};
@@ -1339,66 +1339,6 @@ pub fn setup_pack_idmap_mount(
     close_tree();
     close_userns();
     result
-}
-
-/// Process-wide gate bounding concurrent VM disk-prep / boot. Every boot path —
-/// the API `start_machine`, the supervisor's restart/reconnect, and startup
-/// reconnect — funnels through `AgentManager::start_via_subprocess`, which
-/// acquires a [`BootPermit`] around `prepare_for_launch` (the per-boot disk
-/// copy). Unbounded concurrency thrashes the host disk so each copy balloons
-/// (3.8s → 50s under ~13 simultaneous boots) and the start request times out;
-/// bounding to a few in-flight keeps every copy on the fast path. A synchronous
-/// gate (Mutex + Condvar) because the acquire happens in blocking context (inside
-/// `spawn_blocking`), where an async `tokio::sync::Semaphore` does not fit.
-struct BootGate {
-    /// Available permits.
-    permits: Mutex<usize>,
-    cv: Condvar,
-}
-
-static BOOT_GATE: OnceLock<BootGate> = OnceLock::new();
-
-/// Max concurrent VM boots per node (overridable via `SMOLVM_BOOT_CONCURRENCY`,
-/// clamped to ≥1). Mirrors the smolfleet op-queue's 4-worker throttle.
-fn boot_concurrency() -> usize {
-    std::env::var("SMOLVM_BOOT_CONCURRENCY")
-        .ok()
-        .and_then(|s| s.parse::<usize>().ok())
-        .filter(|&n| n >= 1)
-        .unwrap_or(4)
-}
-
-fn boot_gate() -> &'static BootGate {
-    BOOT_GATE.get_or_init(|| BootGate {
-        permits: Mutex::new(boot_concurrency()),
-        cv: Condvar::new(),
-    })
-}
-
-/// RAII permit from [`acquire_boot_permit`]; returns the permit to the gate on
-/// drop.
-pub struct BootPermit {
-    _private: (),
-}
-
-impl Drop for BootPermit {
-    fn drop(&mut self) {
-        let gate = boot_gate();
-        *gate.permits.lock().unwrap() += 1;
-        gate.cv.notify_one();
-    }
-}
-
-/// Acquire a permit from the process-wide boot gate, blocking until one is free.
-/// Hold it across the contended disk-prep, then let it drop. See [`BootGate`].
-pub fn acquire_boot_permit() -> BootPermit {
-    let gate = boot_gate();
-    let mut permits = gate.permits.lock().unwrap();
-    while *permits == 0 {
-        permits = gate.cv.wait(permits).unwrap();
-    }
-    *permits -= 1;
-    BootPermit { _private: () }
 }
 
 /// PIDs of detached VM boot subprocesses to reap. Registered by
@@ -2786,25 +2726,6 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&base);
-    }
-
-    /// The boot gate hands out permits, returns them on drop, and lets multiple
-    /// permits (up to the bound, default ≥4) coexist without deadlocking.
-    #[test]
-    fn boot_gate_acquire_release_roundtrip() {
-        // Roundtrip: acquire then drop then re-acquire must not deadlock.
-        let p = acquire_boot_permit();
-        drop(p);
-        let _p2 = acquire_boot_permit();
-        // A second concurrent permit coexists (default bound is 4).
-        let _p3 = acquire_boot_permit();
-        // Returning a permit from another thread wakes a waiter — exercise the
-        // notify path by dropping on a thread while the main thread holds permits.
-        let h = std::thread::spawn(|| {
-            let p = acquire_boot_permit();
-            drop(p);
-        });
-        h.join().unwrap();
     }
 
     /// The selective reaper drains registered VM PIDs once they exit, and a


### PR DESCRIPTION
Removes the process-wide boot-concurrency gate, now measured to serialize nothing on the NVMe metal fleet (~1ms disk-prep, flat boot latency from 8 to 32 concurrent).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/501">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
