### PR TITLE
release: smolvm 1.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2190,7 +2190,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 
 [package]
 name = "smolvm"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2021"
 description = "OCI-native microVM runtime"
 license = "Apache-2.0"


### PR DESCRIPTION
Bumps the engine to 1.3.2 for the shared-store rootfs fix (#503), boot-gate removal (#501), and fast machine delete (#502).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/504">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->