### PR TITLE
fix(macos): add allow-jit entitlement so forkable VMs can boot

### DIFF
--- a/crates/smolvm-pack/src/signing.rs
+++ b/crates/smolvm-pack/src/signing.rs
@@ -19,6 +19,11 @@ use crate::Result;
 /// - `hypervisor`: access to Hypervisor.framework for the microVM
 /// - `cs.disable-library-validation`: allow dlopen of libkrun from
 ///   the extracted cache directory (ad-hoc signed libraries)
+/// - `cs.allow-jit`: a forkable golden (`machine start --forkable`) maps guest
+///   RAM from a file-backed region that HVF executes guest code from; under the
+///   hardened runtime that needs a JIT entitlement or `krun_start_enter` returns
+///   -22. (`allow-unsigned-executable-memory` also works; `allow-jit` is the
+///   narrower capability. Harmless for non-forkable VMs, which use anon RAM.)
 #[cfg(target_os = "macos")]
 const HYPERVISOR_ENTITLEMENTS: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -27,6 +32,8 @@ const HYPERVISOR_ENTITLEMENTS: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
     <key>com.apple.security.hypervisor</key>
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.allow-jit</key>
     <true/>
 </dict>
 </plist>

--- a/smolvm.entitlements
+++ b/smolvm.entitlements
@@ -6,5 +6,7 @@
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
Forkable golden VMs map guest RAM from a file-backed region HVF executes guest code from, which the macOS hardened runtime blocks (`krun_start_enter -22`) without a JIT entitlement; this adds `com.apple.security.cs.allow-jit` to the entitlements used by release/pack signing.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/505">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->