### PR TITLE
Preserve smolmachine layers when repacking VMs

### DIFF
--- a/crates/smolvm-pack/src/assets.rs
+++ b/crates/smolvm-pack/src/assets.rs
@@ -12,23 +12,23 @@ use std::path::{Path, PathBuf};
 use crate::format::{AssetEntry, AssetInventory, LayerEntry};
 use crate::{PackError, Result};
 
-/// Convert a digest string to a short filename for layer tars.
+/// Convert a digest string to a filename for layer tars.
 ///
-/// Expects `sha256:<64-hex-chars>` format. Returns error if the digest
-/// portion (after prefix strip) is shorter than 12 characters.
+/// Strips an optional `sha256:` prefix and uses the full remaining digest hex.
+/// Returns an error if the digest portion is shorter than 12 characters.
 fn digest_to_filename(digest: &str) -> Result<String> {
-    let short = digest.strip_prefix("sha256:").unwrap_or(digest);
-    if short.len() < 12 {
+    let hex = digest.strip_prefix("sha256:").unwrap_or(digest);
+    if hex.len() < 12 {
         return Err(PackError::Io(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
             format!(
                 "digest too short for filename: '{}' ({} chars, need 12)",
                 digest,
-                short.len()
+                hex.len()
             ),
         )));
     }
-    Ok(format!("{}.tar", &short[..12]))
+    Ok(format!("{}.tar", hex))
 }
 
 /// Compression level for zstd (3 = zstd default, fast with good ratio).

--- a/crates/smolvm-pack/src/extract.rs
+++ b/crates/smolvm-pack/src/extract.rs
@@ -429,7 +429,9 @@ fn normalize_path(path: &Path) -> PathBuf {
     components.iter().collect()
 }
 
-fn resolve_cache_asset_path(
+/// Resolve a manifest asset path against an extraction cache without allowing
+/// absolute paths, parent components, or symlink traversal outside the cache.
+pub fn resolve_cache_asset_path(
     cache_dir: &Path,
     asset_rel_path: &str,
     context: &str,
@@ -823,7 +825,7 @@ fn extract_sidecar_inner(
             m.assets
                 .layers
                 .iter()
-                .filter_map(|l| short_layer_id(&l.digest))
+                .filter_map(|l| layer_id_from_asset_path(&l.path))
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default();
@@ -925,12 +927,16 @@ pub unsafe fn extract_from_section(
 /// can be mis-stacked. Must match the agent's `LAYER_ORDER_FILE`.
 const LAYER_ORDER_FILE: &str = "layer-order";
 
-/// Short layer id (first 12 hex of the digest) used as the on-disk layer dir
-/// name — mirrors `assets::digest_to_filename` minus the `.tar`. Returns `None`
-/// for a digest too short to form a valid id.
-fn short_layer_id(digest: &str) -> Option<String> {
-    let hex = digest.strip_prefix("sha256:").unwrap_or(digest);
-    (hex.len() >= 12).then(|| hex[..12].to_string())
+/// Layer id used as the on-disk layer dir name, derived from the manifest asset
+/// path stem so old short paths and new full-digest paths both preserve order.
+fn layer_id_from_asset_path(path: &str) -> Option<String> {
+    let rel = Path::new(path);
+    (!rel.is_absolute())
+        .then_some(rel)?
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.is_empty())
+        .map(ToOwned::to_owned)
 }
 
 /// Post-process extracted assets: unpack agent rootfs, OCI layers, fix

--- a/src/cli/pack.rs
+++ b/src/cli/pack.rs
@@ -93,6 +93,10 @@ pub struct PackCreateCmd {
     #[arg(long = "from-vm", value_name = "VM_NAME")]
     pub from_vm: Option<String>,
 
+    /// For image-backed VMs created from a .smolmachine, rebuild lower layers from vm.image instead of preserving imported artifact layers.
+    #[arg(long = "rebase-from-image", requires = "from_vm")]
+    pub rebase_from_image: bool,
+
     /// Output file path for the packed binary
     #[arg(short = 'o', long, value_name = "PATH")]
     pub output: PathBuf,
@@ -520,6 +524,7 @@ impl PackCreateCmd {
         let vm_dir = smolvm::agent::vm_data_dir(&vm_name);
         let (overlay_disk, overlay_fmt) = resolve_disk_image(&vm_dir, OVERLAY_DISK_FILENAME);
         let is_image_based = vm.image.is_some();
+        let is_artifact_sourced_container = is_image_based && vm.source_smolmachine.is_some();
         if !is_image_based && !overlay_disk.exists() {
             return Err(Error::agent(
                 "pack from VM",
@@ -542,10 +547,34 @@ impl PackCreateCmd {
         let mut collector = AssetCollector::new(staging_dir.clone())
             .map_err(|e| Error::agent("collect assets", e.to_string()))?;
 
-        // 4. For image-based VMs, export OCI layers + container overlay via temp VM.
-        // The container overlay (installed packages) lives inside the VM's ext4
-        // storage disk which can't be read on macOS — a temp VM mounts it for us.
-        if is_image_based {
+        // 4. For image-based VMs, preserve imported artifact layers by default
+        // and append the current container overlay. The explicit rebase path keeps
+        // the historical behavior of rebuilding lower layers from vm.image.
+        if is_artifact_sourced_container && !self.rebase_from_image {
+            let source_smolmachine = vm.source_smolmachine.clone().unwrap();
+            let source_path = Path::new(&source_smolmachine);
+            let source_manifest = if source_path.exists() {
+                Some(
+                    smolvm_pack::packer::read_manifest_from_sidecar(source_path)
+                        .map_err(|e| Error::agent("read .smolmachine", e.to_string()))?,
+                )
+            } else {
+                None
+            };
+
+            self.collect_base_assets(&mut collector)?;
+            let imported_layers =
+                match self.imported_layers_from_cache(&vm_name, source_manifest.as_ref())? {
+                    Some(layers) => layers,
+                    None => self.imported_layers_from_source_sidecar(
+                        &vm_name,
+                        &source_smolmachine,
+                        temp_dir.path(),
+                    )?,
+                };
+            self.add_imported_layers(&mut collector, imported_layers)?;
+            self.export_container_overlay_from_vm(&mut collector, &vm_name, &vm_dir)?;
+        } else if is_image_based {
             let image = vm.image.clone().unwrap();
             // A locally-sourced image (`--image -` / `--image file.tar` / a rootfs
             // dir) is flattened on boot and has no registry manifest, so the
@@ -564,170 +593,9 @@ impl PackCreateCmd {
                     ),
                 ));
             }
-            // Attach the source storage disk with its real on-disk format so a
-            // qcow2 (default-size) disk is presented correctly and mounts in the
-            // temp VM — hardcoding raw would hand libkrun qcow2 bytes as raw.
-            let (storage_disk, storage_fmt) = resolve_disk_image(&vm_dir, STORAGE_DISK_FILENAME);
 
             self.collect_base_assets(&mut collector)?;
-
-            // Start temp VM with source VM's storage disk attached as an extra
-            // virtio-blk device. virtiofs can only share directories, not files,
-            // so we pass the ext4 disk image as a third block device (/dev/vdc).
-            // Same alphanumeric-first-char constraint as the image-pack
-            // path above; see the comment there for rationale.
-            let pack_vm_name = format!(
-                "pack-fromvm-{}-{}",
-                std::process::id(),
-                std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_nanos()
-            );
-            let vm_data = smolvm::agent::vm_data_dir(&pack_vm_name);
-
-            println!("Starting agent VM to export layers...");
-            let manager = AgentManager::for_vm(&pack_vm_name)?;
-            let features = smolvm::agent::LaunchFeatures {
-                extra_disks: vec![(storage_disk.clone(), false, storage_fmt)],
-                ..Default::default()
-            };
-            manager.start_with_full_config(
-                Vec::new(),
-                Vec::new(),
-                VmResources {
-                    cpus: 4,
-                    memory_mib: 8192,
-                    network: true,
-                    network_backend: None,
-                    dns: None,
-                    gpu: false,
-                    gpu_vram_mib: None,
-                    storage_gib: None,
-                    overlay_gib: None,
-                    allowed_cidrs: None,
-                },
-                features,
-            )?;
-
-            // Closure ensures the temp VM is always stopped, even on early errors
-            // (pull failure, export failure, etc.). Export errors propagate; stop
-            // failures are logged but don't mask the original error.
-            let export_result: smolvm::Result<()> = (|| {
-                let mut client = manager.connect()?;
-
-                // Mount the source VM's storage disk inside the guest.
-                // It appears as /dev/vdc (3rd block device after storage + overlay).
-                let (exit_code, _, stderr) = client.vm_exec(
-                    vec![
-                        "sh".to_string(),
-                        "-c".to_string(),
-                        "mkdir -p /mnt/source-storage && mount /dev/vdc /mnt/source-storage"
-                            .to_string(),
-                    ],
-                    vec![],
-                    None,
-                    None,
-                    None,
-                )?;
-                if exit_code != 0 {
-                    return Err(Error::agent(
-                        "mount source storage in temp VM",
-                        format!(
-                            "mount failed (exit {}): {}",
-                            exit_code,
-                            String::from_utf8_lossy(&stderr)
-                        ),
-                    ));
-                }
-
-                // Pull the same image (layers are cached on the source storage,
-                // but the agent needs the manifest to know the layer list).
-                let image_info = crate::cli::pull_with_progress(
-                    &mut client,
-                    &image,
-                    None,
-                    self.proxy_opts.proxy(),
-                    self.proxy_opts.no_proxy(),
-                )?;
-
-                // Export base image layers
-                println!("Exporting {} layers...", image_info.layer_count);
-                for (i, layer_digest) in image_info.layers.iter().enumerate() {
-                    let prefix = format!(
-                        "  Layer {}/{}: {}",
-                        i + 1,
-                        image_info.layer_count,
-                        &layer_digest[..std::cmp::min(19, layer_digest.len())]
-                    );
-                    print!("{}...", prefix);
-                    let _ = std::io::Write::flush(&mut std::io::stdout());
-                    let layer_file = collector.layer_staging_path(layer_digest);
-                    self.export_layer_to_file(
-                        &mut client,
-                        &image_info.digest,
-                        i,
-                        &layer_file,
-                        &prefix,
-                    )?;
-                    collector
-                        .register_layer(layer_digest)
-                        .map_err(|e| Error::agent("collect layers", e.to_string()))?;
-                }
-
-                // Export the container overlay upper dir as an additional layer.
-                // The source VM's storage disk is mounted at /mnt/source-storage.
-                let overlay_dir =
-                    format!("/mnt/source-storage/overlays/persistent-{}/upper", vm_name);
-                println!("Exporting container overlay...");
-                let overlay_hash =
-                    hex::encode(Sha256::digest(format!("overlay-{}", vm_name).as_bytes()));
-                let overlay_digest = format!("sha256:{}", overlay_hash);
-                let overlay_layer_file = collector.layer_staging_path(&overlay_digest);
-
-                // Use the agent to tar the overlay dir
-                let (exit_code, _, stderr) = client.vm_exec(
-                    vec![
-                        "sh".to_string(),
-                        "-c".to_string(),
-                        format!(
-                            "if [ -d '{}' ] && [ \"$(ls -A '{}')\" ]; then \
-                             tar cf /tmp/overlay-export.tar -C '{}' . 2>/dev/null; \
-                             echo OVERLAY_OK; \
-                             else echo OVERLAY_EMPTY; fi",
-                            overlay_dir, overlay_dir, overlay_dir
-                        ),
-                    ],
-                    vec![],
-                    None,
-                    None,
-                    None,
-                )?;
-
-                if exit_code == 0 {
-                    // Download the tar from the temp VM
-                    let tar_data = client.read_file("/tmp/overlay-export.tar")?;
-                    if !tar_data.is_empty() {
-                        std::fs::write(&overlay_layer_file, &tar_data)
-                            .map_err(|e| Error::agent("write overlay layer", e.to_string()))?;
-                        collector
-                            .register_layer(&overlay_digest)
-                            .map_err(|e| Error::agent("register overlay layer", e.to_string()))?;
-                        println!("  Overlay layer: {} bytes", tar_data.len());
-                    }
-                } else {
-                    tracing::debug!(stderr = %String::from_utf8_lossy(&stderr), "overlay export: no container changes found");
-                }
-
-                Ok(())
-            })();
-
-            // Always stop the temp VM and clean up
-            if let Err(e) = manager.stop() {
-                warn!(error = %e, "failed to stop pack temp VM");
-            }
-            let _ = std::fs::remove_dir_all(&vm_data);
-            export_result?;
+            self.export_registry_image_layers_from_vm(&mut collector, &vm_name, &vm_dir, &image)?;
         } else {
             // Bare VM: just collect base assets, no layers needed.
             self.collect_base_assets(&mut collector)?;
@@ -833,6 +701,366 @@ impl PackCreateCmd {
         }
 
         self.finalize_pack(manifest, collector, staging_dir)
+    }
+
+    fn export_registry_image_layers_from_vm(
+        &self,
+        collector: &mut AssetCollector,
+        vm_name: &str,
+        vm_dir: &Path,
+        image: &str,
+    ) -> smolvm::Result<()> {
+        let (storage_disk, storage_fmt) = resolve_disk_image(vm_dir, STORAGE_DISK_FILENAME);
+        let pack_vm_name = format!(
+            "pack-fromvm-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        );
+        let vm_data = smolvm::agent::vm_data_dir(&pack_vm_name);
+
+        println!("Starting agent VM to export layers...");
+        let manager = AgentManager::for_vm(&pack_vm_name)?;
+        let features = smolvm::agent::LaunchFeatures {
+            extra_disks: vec![(storage_disk.clone(), false, storage_fmt)],
+            ..Default::default()
+        };
+        manager.start_with_full_config(
+            Vec::new(),
+            Vec::new(),
+            VmResources {
+                cpus: 4,
+                memory_mib: 8192,
+                network: true,
+                network_backend: None,
+                dns: None,
+                gpu: false,
+                gpu_vram_mib: None,
+                storage_gib: None,
+                overlay_gib: None,
+                allowed_cidrs: None,
+            },
+            features,
+        )?;
+
+        let export_result: smolvm::Result<()> = (|| {
+            let mut client = manager.connect()?;
+            let (exit_code, _, stderr) = client.vm_exec(
+                vec![
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    "mkdir -p /mnt/source-storage && mount /dev/vdc /mnt/source-storage"
+                        .to_string(),
+                ],
+                vec![],
+                None,
+                None,
+                None,
+            )?;
+            if exit_code != 0 {
+                return Err(Error::agent(
+                    "mount source storage in temp VM",
+                    format!(
+                        "mount failed (exit {}): {}",
+                        exit_code,
+                        String::from_utf8_lossy(&stderr)
+                    ),
+                ));
+            }
+
+            let image_info = crate::cli::pull_with_progress(
+                &mut client,
+                image,
+                None,
+                self.proxy_opts.proxy(),
+                self.proxy_opts.no_proxy(),
+            )?;
+
+            println!("Exporting {} layers...", image_info.layer_count);
+            for (i, layer_digest) in image_info.layers.iter().enumerate() {
+                let prefix = format!(
+                    "  Layer {}/{}: {}",
+                    i + 1,
+                    image_info.layer_count,
+                    &layer_digest[..std::cmp::min(19, layer_digest.len())]
+                );
+                print!("{}...", prefix);
+                let _ = std::io::Write::flush(&mut std::io::stdout());
+                let layer_file = collector.layer_staging_path(layer_digest);
+                self.export_layer_to_file(
+                    &mut client,
+                    &image_info.digest,
+                    i,
+                    &layer_file,
+                    &prefix,
+                )?;
+                collector
+                    .register_layer(layer_digest)
+                    .map_err(|e| Error::agent("collect layers", e.to_string()))?;
+            }
+
+            self.export_container_overlay_from_mounted_storage(collector, &mut client, vm_name)?;
+
+            Ok(())
+        })();
+
+        if let Err(e) = manager.stop() {
+            warn!(error = %e, "failed to stop pack temp VM");
+        }
+        let _ = std::fs::remove_dir_all(&vm_data);
+        export_result
+    }
+
+    fn export_container_overlay_from_mounted_storage(
+        &self,
+        collector: &mut AssetCollector,
+        client: &mut AgentClient,
+        vm_name: &str,
+    ) -> smolvm::Result<()> {
+        let overlay_dir = format!("/mnt/source-storage/overlays/persistent-{}/upper", vm_name);
+        println!("Exporting container overlay...");
+        let (exit_code, _, stderr) = client.vm_exec(
+            vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                format!(
+                    "if [ -d '{}' ] && [ \"$(ls -A '{}')\" ]; then \
+                     tar cf /tmp/overlay-export.tar -C '{}' . 2>/dev/null; \
+                     echo OVERLAY_OK; \
+                     else echo OVERLAY_EMPTY; fi",
+                    overlay_dir, overlay_dir, overlay_dir
+                ),
+            ],
+            vec![],
+            None,
+            None,
+            None,
+        )?;
+
+        if exit_code == 0 {
+            let tar_data = client.read_file("/tmp/overlay-export.tar")?;
+            if !tar_data.is_empty() {
+                let overlay_hash = hex::encode(Sha256::digest(&tar_data));
+                let overlay_digest = format!("sha256:{}", overlay_hash);
+                let overlay_layer_file = collector.layer_staging_path(&overlay_digest);
+                std::fs::write(&overlay_layer_file, &tar_data)
+                    .map_err(|e| Error::agent("write overlay layer", e.to_string()))?;
+                collector
+                    .register_layer(&overlay_digest)
+                    .map_err(|e| Error::agent("register overlay layer", e.to_string()))?;
+                println!("  Overlay layer: {} bytes", tar_data.len());
+            }
+        } else {
+            tracing::debug!(stderr = %String::from_utf8_lossy(&stderr), "overlay export: no container changes found");
+        }
+
+        Ok(())
+    }
+
+    fn export_container_overlay_from_vm(
+        &self,
+        collector: &mut AssetCollector,
+        vm_name: &str,
+        vm_dir: &Path,
+    ) -> smolvm::Result<()> {
+        let (storage_disk, storage_fmt) = resolve_disk_image(vm_dir, STORAGE_DISK_FILENAME);
+        let pack_vm_name = format!(
+            "pack-fromvm-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        );
+        let vm_data = smolvm::agent::vm_data_dir(&pack_vm_name);
+
+        println!("Starting agent VM to export container overlay...");
+        let manager = AgentManager::for_vm(&pack_vm_name)?;
+        let features = smolvm::agent::LaunchFeatures {
+            extra_disks: vec![(storage_disk.clone(), false, storage_fmt)],
+            ..Default::default()
+        };
+        manager.start_with_full_config(
+            Vec::new(),
+            Vec::new(),
+            VmResources {
+                cpus: 4,
+                memory_mib: 8192,
+                network: true,
+                network_backend: None,
+                dns: None,
+                gpu: false,
+                gpu_vram_mib: None,
+                storage_gib: None,
+                overlay_gib: None,
+                allowed_cidrs: None,
+            },
+            features,
+        )?;
+
+        let export_result: smolvm::Result<()> = (|| {
+            let mut client = manager.connect()?;
+            let (exit_code, _, stderr) = client.vm_exec(
+                vec![
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    "mkdir -p /mnt/source-storage && mount /dev/vdc /mnt/source-storage"
+                        .to_string(),
+                ],
+                vec![],
+                None,
+                None,
+                None,
+            )?;
+            if exit_code != 0 {
+                return Err(Error::agent(
+                    "mount source storage in temp VM",
+                    format!(
+                        "mount failed (exit {}): {}",
+                        exit_code,
+                        String::from_utf8_lossy(&stderr)
+                    ),
+                ));
+            }
+
+            self.export_container_overlay_from_mounted_storage(collector, &mut client, vm_name)?;
+
+            Ok(())
+        })();
+
+        if let Err(e) = manager.stop() {
+            warn!(error = %e, "failed to stop pack temp VM");
+        }
+        let _ = std::fs::remove_dir_all(&vm_data);
+        export_result
+    }
+
+    fn imported_layers_from_cache(
+        &self,
+        vm_name: &str,
+        source_manifest: Option<&PackManifest>,
+    ) -> smolvm::Result<Option<Vec<(String, PathBuf)>>> {
+        let cache_dir = smolvm::agent::machine_layers_cache_dir(vm_name);
+        let pack_content_dir =
+            smolvm::agent::read_shared_pack_pointer(&cache_dir).unwrap_or(cache_dir);
+        let layers_dir = pack_content_dir.join("layers");
+
+        if let Some(manifest) = source_manifest {
+            let mut layers = Vec::new();
+            for layer in &manifest.assets.layers {
+                let path = smolvm_pack::extract::resolve_cache_asset_path(
+                    &pack_content_dir,
+                    &layer.path,
+                    "source layer",
+                )
+                .map_err(|e| Error::agent("resolve source layer", e.to_string()))?;
+                if !path.exists() {
+                    return Ok(None);
+                }
+                layers.push((layer.digest.clone(), path));
+            }
+            return Ok(Some(layers));
+        }
+
+        let order_path = layers_dir.join("layer-order");
+        if let Ok(contents) = std::fs::read_to_string(&order_path) {
+            let mut layers = Vec::new();
+            for id in contents.lines().map(str::trim).filter(|id| !id.is_empty()) {
+                let path = layers_dir.join(format!("{id}.tar"));
+                if !path.exists() {
+                    return Ok(None);
+                }
+                layers.push((format!("sha256:{id}"), path));
+            }
+            return Ok(Some(layers));
+        }
+
+        let mut tar_layers = Vec::new();
+        if let Ok(entries) = std::fs::read_dir(&layers_dir) {
+            for entry in entries {
+                let entry = entry.map_err(|e| Error::agent("read source layers", e.to_string()))?;
+                let path = entry.path();
+                if path.extension().and_then(|s| s.to_str()) == Some("tar") {
+                    tar_layers.push(path);
+                }
+            }
+        }
+        if tar_layers.len() == 1 {
+            let path = tar_layers.pop().unwrap();
+            if let Some(id) = path.file_stem().and_then(|s| s.to_str()) {
+                return Ok(Some(vec![(format!("sha256:{id}"), path)]));
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn imported_layers_from_source_sidecar(
+        &self,
+        vm_name: &str,
+        source_smolmachine: &str,
+        temp_dir: &Path,
+    ) -> smolvm::Result<Vec<(String, PathBuf)>> {
+        let source_path = Path::new(source_smolmachine);
+        let fail = || {
+            Error::agent(
+                "pack from VM",
+                format!(
+                    "VM '{vm_name}' was created from a .smolmachine artifact, but its imported layer closure could not be read from cache or source artifact: {source_smolmachine}"
+                ),
+            )
+        };
+        if !source_path.exists() {
+            return Err(fail());
+        }
+
+        let source_manifest =
+            smolvm_pack::packer::read_manifest_from_sidecar(source_path).map_err(|_| fail())?;
+        let footer =
+            smolvm_pack::packer::read_footer_from_sidecar(source_path).map_err(|_| fail())?;
+        let source_cache_dir = temp_dir.join("source-pack");
+        std::fs::create_dir_all(&source_cache_dir).map_err(|_| fail())?;
+        smolvm_pack::extract::extract_sidecar(source_path, &source_cache_dir, &footer, true, false)
+            .map_err(|_| fail())?;
+
+        let mut layers = Vec::new();
+        for layer in &source_manifest.assets.layers {
+            let path = smolvm_pack::extract::resolve_cache_asset_path(
+                &source_cache_dir,
+                &layer.path,
+                "source layer",
+            )
+            .map_err(|_| fail())?;
+            if !path.exists() {
+                return Err(fail());
+            }
+            layers.push((layer.digest.clone(), path));
+        }
+        Ok(layers)
+    }
+
+    fn add_imported_layers(
+        &self,
+        collector: &mut AssetCollector,
+        layers: Vec<(String, PathBuf)>,
+    ) -> smolvm::Result<()> {
+        for (_, path) in &layers {
+            if !path.exists() {
+                return Err(Error::agent(
+                    "collect source layers",
+                    format!("source layer not found: {}", path.display()),
+                ));
+            }
+        }
+
+        for (digest, path) in layers {
+            collector
+                .add_layer_from_file(&digest, &path)
+                .map_err(|e| Error::agent("collect source layers", e.to_string()))?;
+        }
+        Ok(())
     }
 
     /// Flatten a qcow2 CoW overlay into a standalone raw disk image.

--- a/tests/README.md
+++ b/tests/README.md
@@ -52,7 +52,7 @@ These are not included in the default run. Pass the group name explicitly:
 | `api` | `test_api.sh` | 25 |
 | `virtio-net` | `test_virtio_net.sh` | 6 |
 | `smolfile` | `test_smolfile.sh` | 49 |
-| `pack` / `pack-quick` | `test_pack.sh` | 37 |
+| `pack` / `pack-quick` | `test_pack.sh` | 39 |
 | `gpu` | `test_gpu.sh` | 14 |
 
 ### Environment variables

--- a/tests/test_pack.sh
+++ b/tests/test_pack.sh
@@ -827,6 +827,218 @@ test_from_vm_image_overlay() {
     rm -f "$pack_output" "$pack_output.smolmachine"
 }
 
+# Regression: default --from-vm repack preserves imported artifact layers.
+#
+# A machine created from a .smolmachine has two kinds of container state:
+# imported layers from the source artifact, and the current writable overlay.
+# Repacking it without --rebase-from-image must keep both.
+test_from_vm_imported_layers_preserved_on_repack() {
+    local vm_a="from-vm-nested-a-$$"
+    local vm_b="from-vm-nested-b-$$"
+    local vm_c="from-vm-nested-c-$$"
+    local pack_a="$TEST_DIR/from-vm-nested-a"
+    local pack_b="$TEST_DIR/from-vm-nested-b"
+
+    cleanup_from_vm_imported_layers_preserved() {
+        $SMOLVM machine stop --name "$vm_c" 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_c" -f 2>/dev/null || true
+        $SMOLVM machine stop --name "$vm_b" 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_b" -f 2>/dev/null || true
+        $SMOLVM machine stop --name "$vm_a" 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_a" -f 2>/dev/null || true
+        rm -f "$pack_a" "$pack_a.smolmachine" "$pack_b" "$pack_b.smolmachine"
+    }
+
+    # Cleanup any leftovers
+    cleanup_from_vm_imported_layers_preserved
+
+    echo "  Step 1: Create source image VM with artifact marker..."
+    $SMOLVM machine create --name "$vm_a" --image alpine:latest --net 2>&1 || {
+        cleanup_from_vm_imported_layers_preserved; return 1
+    }
+    $SMOLVM machine start --name "$vm_a" 2>&1 || {
+        cleanup_from_vm_imported_layers_preserved; return 1
+    }
+    $SMOLVM machine exec --name "$vm_a" -- sh -c "echo inherited > /artifact-origin.txt" 2>&1 || {
+        echo "FAIL: could not write source artifact marker"
+        cleanup_from_vm_imported_layers_preserved; return 1
+    }
+    $SMOLVM machine stop --name "$vm_a" 2>&1 || {
+        cleanup_from_vm_imported_layers_preserved; return 1
+    }
+
+    echo "  Step 2: Pack source VM..."
+    $SMOLVM pack create --from-vm "$vm_a" -o "$pack_a" 2>&1 || {
+        echo "FAIL: pack source VM failed"
+        cleanup_from_vm_imported_layers_preserved; return 1
+    }
+    [[ -f "$pack_a.smolmachine" ]] || {
+        echo "FAIL: no source .smolmachine sidecar produced"
+        cleanup_from_vm_imported_layers_preserved; return 1
+    }
+
+    echo "  Step 3: Create nested VM and verify inherited marker..."
+    $SMOLVM machine create --name "$vm_b" --from "$pack_a.smolmachine" --net 2>&1 || {
+        echo "FAIL: nested machine create --from failed"
+        cleanup_from_vm_imported_layers_preserved; return 1
+    }
+    $SMOLVM machine start --name "$vm_b" 2>&1 || {
+        echo "FAIL: nested machine start failed"
+        cleanup_from_vm_imported_layers_preserved; return 1
+    }
+    local inherited_result
+    inherited_result=$($SMOLVM machine exec --name "$vm_b" -- cat /artifact-origin.txt 2>&1)
+    [[ "$inherited_result" == *"inherited"* ]] || {
+        echo "FAIL: inherited marker missing in nested VM (got: $inherited_result)"
+        cleanup_from_vm_imported_layers_preserved; return 1
+    }
+    $SMOLVM machine exec --name "$vm_b" -- sh -c "echo nested > /nested-mutation.txt" 2>&1 || {
+        echo "FAIL: could not write nested mutation marker"
+        cleanup_from_vm_imported_layers_preserved; return 1
+    }
+    $SMOLVM machine stop --name "$vm_b" 2>&1 || {
+        cleanup_from_vm_imported_layers_preserved; return 1
+    }
+
+    echo "  Step 4: Repack nested VM without rebase..."
+    $SMOLVM pack create --from-vm "$vm_b" -o "$pack_b" 2>&1 || {
+        echo "FAIL: repack nested VM failed"
+        cleanup_from_vm_imported_layers_preserved; return 1
+    }
+    [[ -f "$pack_b.smolmachine" ]] || {
+        echo "FAIL: no nested .smolmachine sidecar produced"
+        cleanup_from_vm_imported_layers_preserved; return 1
+    }
+
+    echo "  Step 5: Create final VM and verify both markers..."
+    $SMOLVM machine create --name "$vm_c" --from "$pack_b.smolmachine" --net 2>&1 || {
+        echo "FAIL: final machine create --from failed"
+        cleanup_from_vm_imported_layers_preserved; return 1
+    }
+    $SMOLVM machine start --name "$vm_c" 2>&1 || {
+        echo "FAIL: final machine start failed"
+        cleanup_from_vm_imported_layers_preserved; return 1
+    }
+    inherited_result=$($SMOLVM machine exec --name "$vm_c" -- cat /artifact-origin.txt 2>&1)
+    [[ "$inherited_result" == *"inherited"* ]] || {
+        echo "FAIL: inherited marker missing after repack (got: $inherited_result)"
+        cleanup_from_vm_imported_layers_preserved; return 1
+    }
+    local nested_result
+    nested_result=$($SMOLVM machine exec --name "$vm_c" -- cat /nested-mutation.txt 2>&1)
+    [[ "$nested_result" == *"nested"* ]] || {
+        echo "FAIL: nested marker missing after repack (got: $nested_result)"
+        cleanup_from_vm_imported_layers_preserved; return 1
+    }
+
+    cleanup_from_vm_imported_layers_preserved
+}
+
+# Regression: --rebase-from-image intentionally rebuilds lower image layers and
+# drops imported artifact layers, while keeping the current writable overlay.
+test_from_vm_rebase_from_image_drops_imported_layers() {
+    local vm_a="from-vm-rebase-a-$$"
+    local vm_b="from-vm-rebase-b-$$"
+    local vm_c="from-vm-rebase-c-$$"
+    local pack_a="$TEST_DIR/from-vm-rebase-a"
+    local pack_b="$TEST_DIR/from-vm-rebase-b"
+
+    cleanup_from_vm_rebase_layers() {
+        $SMOLVM machine stop --name "$vm_c" 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_c" -f 2>/dev/null || true
+        $SMOLVM machine stop --name "$vm_b" 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_b" -f 2>/dev/null || true
+        $SMOLVM machine stop --name "$vm_a" 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_a" -f 2>/dev/null || true
+        rm -f "$pack_a" "$pack_a.smolmachine" "$pack_b" "$pack_b.smolmachine"
+    }
+
+    # Cleanup any leftovers
+    cleanup_from_vm_rebase_layers
+
+    echo "  Step 1: Create source image VM with artifact marker..."
+    $SMOLVM machine create --name "$vm_a" --image alpine:latest --net 2>&1 || {
+        cleanup_from_vm_rebase_layers; return 1
+    }
+    $SMOLVM machine start --name "$vm_a" 2>&1 || {
+        cleanup_from_vm_rebase_layers; return 1
+    }
+    $SMOLVM machine exec --name "$vm_a" -- sh -c "echo inherited > /artifact-origin.txt" 2>&1 || {
+        echo "FAIL: could not write source artifact marker"
+        cleanup_from_vm_rebase_layers; return 1
+    }
+    $SMOLVM machine stop --name "$vm_a" 2>&1 || {
+        cleanup_from_vm_rebase_layers; return 1
+    }
+
+    echo "  Step 2: Pack source VM..."
+    $SMOLVM pack create --from-vm "$vm_a" -o "$pack_a" 2>&1 || {
+        echo "FAIL: pack source VM failed"
+        cleanup_from_vm_rebase_layers; return 1
+    }
+    [[ -f "$pack_a.smolmachine" ]] || {
+        echo "FAIL: no source .smolmachine sidecar produced"
+        cleanup_from_vm_rebase_layers; return 1
+    }
+
+    echo "  Step 3: Create nested VM and write mutation marker..."
+    $SMOLVM machine create --name "$vm_b" --from "$pack_a.smolmachine" --net 2>&1 || {
+        echo "FAIL: nested machine create --from failed"
+        cleanup_from_vm_rebase_layers; return 1
+    }
+    $SMOLVM machine start --name "$vm_b" 2>&1 || {
+        echo "FAIL: nested machine start failed"
+        cleanup_from_vm_rebase_layers; return 1
+    }
+    local inherited_result
+    inherited_result=$($SMOLVM machine exec --name "$vm_b" -- cat /artifact-origin.txt 2>&1)
+    [[ "$inherited_result" == *"inherited"* ]] || {
+        echo "FAIL: inherited marker missing in nested VM (got: $inherited_result)"
+        cleanup_from_vm_rebase_layers; return 1
+    }
+    $SMOLVM machine exec --name "$vm_b" -- sh -c "echo nested > /nested-mutation.txt" 2>&1 || {
+        echo "FAIL: could not write nested mutation marker"
+        cleanup_from_vm_rebase_layers; return 1
+    }
+    $SMOLVM machine stop --name "$vm_b" 2>&1 || {
+        cleanup_from_vm_rebase_layers; return 1
+    }
+
+    echo "  Step 4: Repack nested VM with --rebase-from-image..."
+    $SMOLVM pack create --from-vm "$vm_b" --rebase-from-image -o "$pack_b" 2>&1 || {
+        echo "FAIL: rebase repack nested VM failed"
+        cleanup_from_vm_rebase_layers; return 1
+    }
+    [[ -f "$pack_b.smolmachine" ]] || {
+        echo "FAIL: no rebased .smolmachine sidecar produced"
+        cleanup_from_vm_rebase_layers; return 1
+    }
+
+    echo "  Step 5: Create final VM and verify rebase semantics..."
+    $SMOLVM machine create --name "$vm_c" --from "$pack_b.smolmachine" --net 2>&1 || {
+        echo "FAIL: final machine create --from failed"
+        cleanup_from_vm_rebase_layers; return 1
+    }
+    $SMOLVM machine start --name "$vm_c" 2>&1 || {
+        echo "FAIL: final machine start failed"
+        cleanup_from_vm_rebase_layers; return 1
+    }
+    local presence_result
+    presence_result=$($SMOLVM machine exec --name "$vm_c" -- sh -c 'if [ -e /artifact-origin.txt ]; then echo PRESENT; else echo ABSENT; fi' 2>&1)
+    [[ "$presence_result" == *"ABSENT"* ]] || {
+        echo "FAIL: inherited marker present after --rebase-from-image (got: $presence_result)"
+        cleanup_from_vm_rebase_layers; return 1
+    }
+    local nested_result
+    nested_result=$($SMOLVM machine exec --name "$vm_c" -- cat /nested-mutation.txt 2>&1)
+    [[ "$nested_result" == *"nested"* ]] || {
+        echo "FAIL: nested marker missing after --rebase-from-image (got: $nested_result)"
+        cleanup_from_vm_rebase_layers; return 1
+    }
+
+    cleanup_from_vm_rebase_layers
+}
+
 # =============================================================================
 # Debian Pack Roundtrip (Char device entry regression)
 #
@@ -1367,6 +1579,8 @@ if [[ "$QUICK_MODE" != "true" ]]; then
     echo ""
 
     run_test "from-vm-image: container overlay captured" test_from_vm_image_overlay || true
+    run_test "from-vm-image: imported layers preserved on repack" test_from_vm_imported_layers_preserved_on_repack || true
+    run_test "from-vm-image: rebase flag drops imported layers" test_from_vm_rebase_from_image_drops_imported_layers || true
 
     echo ""
     echo "Running Debian Pack Roundtrip Tests..."


### PR DESCRIPTION
## Summary

Fixes `pack create --from-vm` for VMs that were created from a `.smolmachine`.

The default path now preserves the layers from the source artifact and adds the VM’s current writable overlay on top. That means repacking a packed VM should produce another self-contained packed VM, instead of silently dropping layers that only existed in the original artifact.

I also added `--rebase-from-image` for the old behavior, where we intentionally rebuild from `vm.image` and drop imported artifact layers.

## What changed

- Preserve imported `.smolmachine` layers by default when repacking.
- Add `--rebase-from-image` as the explicit lossy/rebase mode.
- Use content-derived digests for exported overlay layers.
- Use full digest filenames for layer tars.
- Keep layer ordering compatible with both old short layer paths and new full digest paths.
- Add E2E coverage for the default preservation path and the explicit rebase path.

One caveat: `cargo make test` hit an unrelated bare-VM startup flake in `test_machine_start`:

```text
monitor agent: agent process exited during startup
```

Rerunning the bare suite directly passed:

```bash
./tests/run_tests.sh bare
# 25 passed
```


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/507">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->