### PR TITLE
Cap layer-export size and reap the interactive-exec child on error

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -5154,11 +5154,25 @@ fn handle_interactive_vm_exec(
     // Send Started response
     send_response(stream, &AgentResponse::Started)?;
 
-    // Run the appropriate interactive I/O loop
-    let exit_code = match pty_master {
+    // Run the appropriate interactive I/O loop. Every Ok path inside the loops
+    // already reaps the child (try_wait auto-reaps on exit; timeout and host
+    // disconnect both kill+wait). The Err paths — a malformed/oversized inbound
+    // frame, a Stdin parse failure, a try_wait/drain error — do NOT, so reap
+    // here before propagating. The agent is PID 1 with no global waitpid(-1)
+    // reaper, so an unreaped interactive child would linger as a zombie holding
+    // its stdio/PTY fds. Mirrors the loop's own kill_child_on_disconnect.
+    let loop_result = match pty_master {
         #[cfg(target_os = "linux")]
-        Some(pty) => run_interactive_loop_pty(stream, &mut child, pty, timeout_ms)?,
-        _ => run_interactive_loop(stream, &mut child, timeout_ms)?,
+        Some(pty) => run_interactive_loop_pty(stream, &mut child, pty, timeout_ms),
+        _ => run_interactive_loop(stream, &mut child, timeout_ms),
+    };
+    let exit_code = match loop_result {
+        Ok(code) => code,
+        Err(e) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(e);
+        }
     };
 
     // Send Exited response

--- a/src/cli/pack.rs
+++ b/src/cli/pack.rs
@@ -1243,7 +1243,7 @@ impl PackCreateCmd {
         dest: &std::path::Path,
         progress_prefix: &str,
     ) -> smolvm::Result<()> {
-        use smolvm_protocol::AgentRequest;
+        use smolvm_protocol::{AgentRequest, FILE_TRANSFER_MAX_TOTAL};
         use std::io::Write;
         use std::time::{Duration, Instant};
 
@@ -1283,10 +1283,24 @@ impl PackCreateCmd {
             match response {
                 AgentResponse::DataChunk { data, done } => {
                     if !data.is_empty() {
+                        // Cap the cumulative export size the same way the file-read
+                        // paths do (client.rs): a compromised or buggy guest must not
+                        // be able to exhaust the host disk with an endless chunk stream.
+                        let next_total = total_bytes.saturating_add(data.len() as u64);
+                        if next_total > FILE_TRANSFER_MAX_TOTAL {
+                            let _ = std::fs::remove_file(dest);
+                            return Err(Error::agent(
+                                "export layer",
+                                format!(
+                                    "guest streamed {} bytes, exceeding the {} byte cap",
+                                    next_total, FILE_TRANSFER_MAX_TOTAL
+                                ),
+                            ));
+                        }
                         file.write_all(&data).map_err(|e| {
                             Error::agent("export layer", format!("write failed: {}", e))
                         })?;
-                        total_bytes += data.len() as u64;
+                        total_bytes = next_total;
 
                         // Update progress every 500ms
                         if last_progress.elapsed() >= Duration::from_millis(500) {


### PR DESCRIPTION
Bounds the layer export to the existing 4 GiB transfer cap and reaps the interactive-exec child on the I/O loop's error paths so a misbehaving guest can neither exhaust the host disk nor leave a zombie holding its fds.