### PR TITLE
Forward an egress hostname allow-list from the machine API into the DNS filter so machines can be scoped to a fixed set of hosts

### DIFF
--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -98,6 +98,7 @@ fn record_to_info(name: &str, record: &VmRecord) -> MachineInfo {
         network: record.network,
         network_backend: record.network_backend,
         allowed_cidrs: record.allowed_cidrs.clone(),
+        allowed_hosts: record.dns_filter_hosts.clone(),
         // Report the RESOLVED provisioned disk sizes, not the request echo: a
         // machine created without an explicit size still gets a real disk at the
         // node default, and billing/telemetry need the actual allocated GiB, not
@@ -161,7 +162,12 @@ fn machine_entry_from_record(record: &VmRecord, manager: AgentManager) -> Machin
         manager,
         mounts,
         ports,
-        resources: vm_resources_to_spec(record.vm_resources()),
+        resources: ResourceSpec {
+            // VmResources carries no hostname allow-list, so graft it back from the
+            // record — otherwise a reloaded machine would silently lose allowed_hosts.
+            allowed_hosts: record.dns_filter_hosts.clone(),
+            ..vm_resources_to_spec(record.vm_resources())
+        },
         restart: record.restart.clone(),
         network: record.network,
         secret_refs: record.secret_refs.clone(),
@@ -598,6 +604,7 @@ pub async fn create_machine(
         storage_gb: req.storage_gb,
         overlay_gb: req.overlay_gb,
         allowed_cidrs: req.allowed_cidrs.clone(),
+        allowed_hosts: req.allowed_hosts.clone(),
         network_backend: req.network_backend,
     };
 
@@ -837,6 +844,7 @@ pub async fn start_machine(
     let storage_gb = record.storage_gb;
     let overlay_gb = record.overlay_gb;
     let source_smolmachine = record.source_smolmachine.clone();
+    let dns_filter_hosts = record.dns_filter_hosts.clone();
     let forkable = query.forkable;
     let (manager, pid) = tokio::task::spawn_blocking(move || {
         let manager = AgentManager::for_vm_with_sizes(&name_clone, storage_gb, overlay_gb)
@@ -846,6 +854,7 @@ pub async fn start_machine(
         let mut features = crate::api::state::build_launch_features(
             Some(&name_clone),
             source_smolmachine.as_deref(),
+            dns_filter_hosts,
         )
         .map_err(|e| format!("failed to prepare packed layers: {}", e))?;
         // Forkable start: memfd-back guest RAM and expose a control socket at the
@@ -1040,6 +1049,7 @@ pub async fn fork_machine(
         let mut features = crate::api::state::build_launch_features(
             Some(&clone_b),
             record.source_smolmachine.as_deref(),
+            record.dns_filter_hosts.clone(),
         )
         .map_err(|e| format!("failed to prepare packed layers: {}", e))?;
         // Boot from the golden's snapshot instead of cold-booting.
@@ -1821,6 +1831,7 @@ mod tests {
             storage_gb: None,
             overlay_gb: None,
             allowed_cidrs: None,
+            allowed_hosts: None,
             network_backend: None,
             restart: None,
             image: None,

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -345,6 +345,7 @@ impl ApiState {
                 storage_gb: record.storage_gb,
                 overlay_gb: record.overlay_gb,
                 allowed_cidrs: record.allowed_cidrs.clone(),
+                allowed_hosts: record.dns_filter_hosts.clone(),
                 network_backend: record.network_backend,
             };
 
@@ -815,6 +816,7 @@ impl ApiState {
         // Persist egress policy + backend selection from the request (previously
         // dropped here, so API-created machines silently lost both).
         record.allowed_cidrs = reg.resources.allowed_cidrs.clone();
+        record.dns_filter_hosts = reg.resources.allowed_hosts.clone();
         record.network_backend = reg.resources.network_backend;
         record.image = reg.image;
         record.source_smolmachine = reg.source_smolmachine.clone();
@@ -1084,15 +1086,21 @@ where
 pub fn build_launch_features(
     machine_name: Option<&str>,
     source_smolmachine: Option<&str>,
+    dns_filter_hosts: Option<Vec<String>>,
 ) -> crate::Result<crate::agent::LaunchFeatures> {
     let features = crate::agent::LaunchFeatures::default();
-    match machine_name {
+    let mut features = match machine_name {
         Some(name) => features.with_packed_layers(
             &crate::agent::machine_layers_cache_dir(name),
             source_smolmachine,
-        ),
-        None => Ok(features),
-    }
+        )?,
+        None => features,
+    };
+    // Carry the egress hostname allow-list into the boot config; `internal_boot`
+    // starts the DNS filter for these names and learns their answers into the
+    // egress allow-list (parity with the CLI `--allow-host` path).
+    features.dns_filter_hosts = dns_filter_hosts;
+    Ok(features)
 }
 
 /// Ensure a machine is running, starting it if needed.
@@ -1137,7 +1145,11 @@ pub async fn ensure_machine_running(
         let features = if entry.manager.try_connect_existing().is_some() {
             crate::agent::LaunchFeatures::default()
         } else {
-            build_launch_features(entry.manager.name(), entry.source_smolmachine.as_deref())?
+            build_launch_features(
+                entry.manager.name(),
+                entry.source_smolmachine.as_deref(),
+                entry.resources.allowed_hosts.clone(),
+            )?
         };
         entry
             .manager
@@ -1273,6 +1285,9 @@ pub fn vm_resources_to_spec(res: VmResources) -> ResourceSpec {
         storage_gb: res.storage_gib,
         overlay_gb: res.overlay_gib,
         allowed_cidrs: res.allowed_cidrs,
+        // VmResources has no hostname allow-list; callers that need it graft it
+        // back from the source record (see the MachineEntry reload path).
+        allowed_hosts: None,
         network_backend: res.network_backend,
     }
 }
@@ -1339,6 +1354,7 @@ pub fn machine_entry_to_info(name: String, entry: &MachineEntry) -> MachineInfo 
         network: entry.network,
         network_backend: entry.resources.network_backend,
         allowed_cidrs: entry.resources.allowed_cidrs.clone(),
+        allowed_hosts: entry.resources.allowed_hosts.clone(),
         storage_gb: entry.resources.storage_gb,
         overlay_gb: entry.resources.overlay_gb,
         egress_bytes,
@@ -1389,6 +1405,7 @@ mod tests {
             storage_gb: None,
             overlay_gb: None,
             allowed_cidrs: None,
+            allowed_hosts: None,
             network_backend: None,
         };
         let res = resource_spec_to_vm_resources(&spec, false);
@@ -1399,6 +1416,19 @@ mod tests {
         // Test with network enabled
         let res = resource_spec_to_vm_resources(&spec, true);
         assert!(res.network);
+    }
+
+    #[test]
+    fn build_launch_features_carries_allowed_hosts() {
+        // The serve-API launch path must forward the egress hostname allow-list
+        // into the boot config, so `internal_boot` starts the DNS filter for it.
+        let hosts = vec!["api.anthropic.com".to_string(), "pypi.org".to_string()];
+        let features = build_launch_features(None, None, Some(hosts.clone())).unwrap();
+        assert_eq!(features.dns_filter_hosts, Some(hosts));
+
+        // No hostname policy stays None (unrestricted egress, unchanged behavior).
+        let features = build_launch_features(None, None, None).unwrap();
+        assert_eq!(features.dns_filter_hosts, None);
     }
 
     #[test]
@@ -1439,6 +1469,7 @@ mod tests {
                     storage_gb: None,
                     overlay_gb: None,
                     allowed_cidrs: None,
+                    allowed_hosts: None,
                     network_backend: None,
                 },
                 restart: RestartConfig::default(),
@@ -1500,6 +1531,7 @@ mod tests {
                     storage_gb: None,
                     overlay_gb: None,
                     allowed_cidrs: None,
+                    allowed_hosts: None,
                     network_backend: None,
                 },
                 restart: RestartConfig::default(),

--- a/src/api/supervisor.rs
+++ b/src/api/supervisor.rs
@@ -288,6 +288,7 @@ impl Supervisor {
         let ports = record.port_mappings();
         let resources = record.vm_resources();
         let source_smolmachine = record.source_smolmachine.clone();
+        let dns_filter_hosts = record.dns_filter_hosts.clone();
         let name_for_features = name.to_string();
 
         let entry_clone = entry.clone();
@@ -297,6 +298,7 @@ impl Supervisor {
             let features = crate::api::state::build_launch_features(
                 Some(&name_for_features),
                 source_smolmachine.as_deref(),
+                dns_filter_hosts,
             )?;
             entry
                 .manager

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -104,6 +104,11 @@ pub struct ResourceSpec {
     /// Omit for unrestricted egress. Empty list denies all egress.
     #[serde(default)]
     pub allowed_cidrs: Option<Vec<String>>,
+    /// Allowed egress hostnames. When set, DNS answers for these names (and their
+    /// subdomains) are learned into the egress allow-list so the machine can reach
+    /// them by name. Combine with `allowed_cidrs` to also permit fixed ranges.
+    #[serde(default)]
+    pub allowed_hosts: Option<Vec<String>>,
     /// Network backend: `tsi` (default, outbound-only) or `virtio-net`
     /// (required for published `ports`). Omit for the default (TSI).
     #[serde(default)]
@@ -416,6 +421,10 @@ pub struct CreateMachineRequest {
     /// Allowed egress CIDR ranges.
     #[serde(default)]
     pub allowed_cidrs: Option<Vec<String>>,
+    /// Allowed egress hostnames (and their subdomains); DNS answers for these
+    /// names are learned into the egress allow-list.
+    #[serde(default)]
+    pub allowed_hosts: Option<Vec<String>>,
     /// Network backend: `tsi` (default, outbound-only) or `virtio-net`.
     /// Published `ports` require `virtio-net` (TSI has no inbound path).
     #[serde(default)]
@@ -511,6 +520,9 @@ pub struct MachineInfo {
     /// Allowed egress CIDRs. Omitted when unrestricted; an empty list denies all.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_cidrs: Option<Vec<String>>,
+    /// Allowed egress hostnames. Omitted when unset. Echoes back what `create` accepted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_hosts: Option<Vec<String>>,
     /// Storage disk size in GiB.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(example = 20)]


### PR DESCRIPTION
Forward an egress hostname allow-list from the machine API into the DNS filter so machines can be scoped to a fixed set of hosts.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/509">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->