### PR TITLE
fix(delete): force-kill the VM systemd scope so a stuck machine can't orphan

### DIFF
--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -224,21 +224,47 @@ fn shutdown_machine_process(
             tracing::debug!(pid, name, "PID already dead");
         }
 
-        // Post-check: verify the process is actually gone.
+        // Post-check: verify the process is actually gone. If it outlived the
+        // pid-targeted SIGKILL (or the recorded pid is wrong), fall back to
+        // killing the systemd transient scope — its cgroup owns every process the
+        // VM spawned — then wait briefly for the SIGKILL to land. Only give up if
+        // STILL alive.
         if is_alive(pid) {
-            tracing::warn!(pid, name, "process still alive after shutdown attempts");
-            return false;
-        }
-    } else {
-        // No PID available — check if VM is still reachable via vsock.
-        if let Some(ref manager) = manager {
-            if let Ok(mut client) = AgentClient::connect(manager.vsock_socket()) {
-                if client.ping().is_ok() {
-                    tracing::warn!(name, "VM still reachable via vsock but no PID to signal");
-                    return false;
+            let _ = crate::systemd_scope::kill_scope(name);
+            for _ in 0..10 {
+                if !is_alive(pid) {
+                    break;
                 }
+                std::thread::sleep(std::time::Duration::from_millis(300));
+            }
+            if is_alive(pid) {
+                tracing::warn!(pid, name, "process still alive after shutdown + scope kill");
+                return false;
             }
         }
+    } else {
+        // No recorded pid — the pid-based kill can't run at all, which is exactly
+        // how a stuck/crash-looping VM becomes an un-deletable orphan (delete 500s
+        // "still alive; not removing" while the node keeps running the VM). Kill
+        // the transient scope's cgroup directly and confirm via vsock that the VM
+        // is actually gone.
+        let _ = crate::systemd_scope::kill_scope(name);
+        for _ in 0..10 {
+            let reachable = manager
+                .as_ref()
+                .and_then(|m| AgentClient::connect(m.vsock_socket()).ok())
+                .map(|mut c| c.ping().is_ok())
+                .unwrap_or(false);
+            if !reachable {
+                return true;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(300));
+        }
+        tracing::warn!(
+            name,
+            "VM still reachable via vsock after scope kill; no PID to signal"
+        );
+        return false;
     }
 
     true

--- a/src/systemd_scope.rs
+++ b/src/systemd_scope.rs
@@ -171,6 +171,65 @@ pub fn adopt_into_scope(machine_id: &str, pid: i32, caps: &ScopeCaps) -> Result<
     Ok(())
 }
 
+/// Force-kill a VM's transient scope: SIGKILL every process in its cgroup.
+///
+/// This is the AUTHORITATIVE teardown when the pid-based delete can't confirm
+/// death — no recorded pid, or a process that outlived SIGKILL-by-pid. The scope
+/// owns every process the VM spawned regardless of the pid we happened to record,
+/// so killing the cgroup is what stops a stuck/crash-looping VM that would
+/// otherwise become an un-deletable orphan (control marks it deleted, the node
+/// keeps running it). Returns `Ok(true)` on a successful kill OR a missing scope
+/// (already gone == teardown done). Non-Linux / no-busctl hosts return `Ok(false)`
+/// — nothing scope-based to stop; the caller falls back to its pid path.
+pub fn kill_scope(machine_id: &str) -> Result<bool> {
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = machine_id;
+        Ok(false)
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let Some(busctl) = busctl_path() else {
+            return Ok(false);
+        };
+        let name = scope_name(machine_id);
+        // KillUnit(name: s, who: s, signal: i): SIGKILL (9) every process in the
+        // scope ("all"). SIGKILL is uncatchable, so a wedged VM dies immediately;
+        // the emptied scope then self-GCs. `ssi` is the busctl arg signature.
+        let out = Command::new(&busctl)
+            .args([
+                "call",
+                "org.freedesktop.systemd1",
+                "/org/freedesktop/systemd1",
+                "org.freedesktop.systemd1.Manager",
+                "KillUnit",
+                "ssi",
+                &name,
+                "all",
+                "9",
+            ])
+            .output()
+            .map_err(|e| Error::agent("vm scope", format!("busctl spawn failed: {e}")))?;
+        if out.status.success() {
+            tracing::info!(scope = %name, "SIGKILLed VM transient scope (forced teardown)");
+            return Ok(true);
+        }
+        // A scope that already exited is not loaded — teardown is effectively done.
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        if stderr.contains("not loaded")
+            || stderr.contains("NoSuchUnit")
+            || stderr.contains("not found")
+        {
+            tracing::debug!(scope = %name, "scope already gone on kill");
+            return Ok(true);
+        }
+        Err(Error::agent(
+            "vm scope",
+            format!("KillUnit {name} failed: {}", stderr.trim()),
+        ))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Machine delete refused to remove a VM whose recorded pid was missing (or that outlived SIGKILL-by-pid), returning 500 'still alive; not removing' while the control marked it deleted — leaving an orphaned, crash-looping VM (real incident: codex-box). Adds systemd_scope::kill_scope (busctl KillUnit SIGKILL over the scope cgroup) as the authoritative teardown fallback in both delete paths.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/515">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->