### PR TITLE
Fold an image's own registry into a scoped egress allow-list so the in-guest base-image pull is not blocked

### DIFF
--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -217,6 +217,41 @@ pub struct LaunchFeatures {
 }
 
 impl LaunchFeatures {
+    /// Fold an image's own registry into the enforced DNS egress filter so a
+    /// scoped machine's in-guest base-image pull isn't blocked by its own
+    /// allow-list.
+    ///
+    /// An image-based machine pulls its base image inside the guest on first
+    /// boot, subject to `dns_filter_hosts` (applied at VM boot). Scoping egress
+    /// to only, say, an LLM API would otherwise fail the pull with a DNS-lookup
+    /// error for the registry. Call this only when a fresh remote pull will
+    /// happen (first boot, registry-sourced). No-op when the filter is unset or
+    /// empty, when layers are packed/local (`uses_packed_layers`), or when the
+    /// reference is a `local:` source — none of which pull over the network.
+    ///
+    /// Only the enforced launch policy is widened; the caller's stored
+    /// `dns_filter_hosts` on the record keeps exactly the hosts the user asked
+    /// for. Mirrors the control plane's `create_body` registry-fold.
+    pub fn allow_image_pull_egress(&mut self, image: Option<&str>, uses_packed_layers: bool) {
+        let Some(hosts) = self.dns_filter_hosts.as_mut() else {
+            return;
+        };
+        if hosts.is_empty() || uses_packed_layers {
+            return;
+        }
+        let Some(image) = image else {
+            return;
+        };
+        if crate::data::image_source::is_local_ref(image) {
+            return;
+        }
+        for host in crate::registry::registry_pull_hosts(image) {
+            if !hosts.iter().any(|h| h.eq_ignore_ascii_case(&host)) {
+                hosts.push(host);
+            }
+        }
+    }
+
     /// Wire pre-extracted OCI layers for a machine created from a `.smolmachine`.
     ///
     /// `layers_cache_dir` is the machine's OWN extraction directory (under its
@@ -1451,6 +1486,62 @@ fn raise_fd_limits() {
 mod tests {
     use super::*;
     use std::fs;
+
+    fn scoped(hosts: &[&str]) -> LaunchFeatures {
+        LaunchFeatures {
+            dns_filter_hosts: Some(hosts.iter().map(|h| h.to_string()).collect()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn allow_image_pull_egress_folds_registry_into_scope() {
+        let mut f = scoped(&["api.anthropic.com"]);
+        f.allow_image_pull_egress(Some("ghcr.io/acme/app:1"), false);
+        assert_eq!(
+            f.dns_filter_hosts.unwrap(),
+            vec!["api.anthropic.com".to_string(), "ghcr.io".to_string()]
+        );
+    }
+
+    #[test]
+    fn allow_image_pull_egress_dockerhub_adds_both_apexes_without_dupes() {
+        // docker.io already listed by the user; the fold must add docker.com but
+        // not re-add docker.io.
+        let mut f = scoped(&["docker.io", "pypi.org"]);
+        f.allow_image_pull_egress(Some("alpine"), false);
+        assert_eq!(
+            f.dns_filter_hosts.unwrap(),
+            vec![
+                "docker.io".to_string(),
+                "pypi.org".to_string(),
+                "docker.com".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn allow_image_pull_egress_noop_when_unscoped_or_packed_or_local() {
+        // No filter set → unscoped machine, nothing to widen.
+        let mut f = LaunchFeatures::default();
+        f.allow_image_pull_egress(Some("alpine"), false);
+        assert!(f.dns_filter_hosts.is_none());
+
+        // Packed layers (.smolmachine / local dir) → no in-guest pull.
+        let mut f = scoped(&["api.anthropic.com"]);
+        f.allow_image_pull_egress(Some("alpine"), true);
+        assert_eq!(f.dns_filter_hosts.unwrap(), vec!["api.anthropic.com"]);
+
+        // A `local:` reference is host-assembled, never pulled.
+        let mut f = scoped(&["api.anthropic.com"]);
+        f.allow_image_pull_egress(Some("local:abc123"), false);
+        assert_eq!(f.dns_filter_hosts.unwrap(), vec!["api.anthropic.com"]);
+
+        // Bare VM (no image) → nothing to fold.
+        let mut f = scoped(&["api.anthropic.com"]);
+        f.allow_image_pull_egress(None, false);
+        assert_eq!(f.dns_filter_hosts.unwrap(), vec!["api.anthropic.com"]);
+    }
 
     /// Build a machine `pack` dir plus a `.pack-shared` pointer in its parent that
     /// names `shared`, mirroring what create writes when the pack lands in the

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -1072,13 +1072,18 @@ impl RunCmd {
         };
         let uses_packed_layers = packed_layers_dir.is_some();
 
-        let features = smolvm::agent::LaunchFeatures {
+        let mut features = smolvm::agent::LaunchFeatures {
             ssh_agent_socket,
             dns_filter_hosts: params.dns_filter_hosts.clone(),
             packed_layers_dir,
             extra_disks: Vec::new(),
             ..Default::default()
         };
+
+        // This launch pulls a registry image in-guest, subject to the egress
+        // filter — fold its registry into the enforced policy so a hostname
+        // scope doesn't block its own pull.
+        features.allow_image_pull_egress(image.as_deref(), uses_packed_layers);
 
         let freshly_started = manager
             .ensure_running_with_full_config(mounts.clone(), ports, resources, features)

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -909,6 +909,17 @@ pub fn start_vm_named(
         }
     }
 
+    // First boot pulls the base image in-guest, subject to the egress filter —
+    // fold the image's registry into the enforced policy so a hostname scope
+    // doesn't block its own pull. Subsequent starts skip the pull, so they keep
+    // the user's scope unwidened.
+    if !record.init_completed {
+        features.allow_image_pull_egress(
+            record.image.as_deref(),
+            features.packed_layers_dir.is_some(),
+        );
+    }
+
     let _ = manager
         .ensure_running_with_full_config(mounts, ports, resources, features)
         .map_err(|e| Error::agent("start machine", e.to_string()))?;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -201,6 +201,26 @@ pub fn extract_registry(image: &str) -> String {
     DEFAULT_REGISTRY.to_string()
 }
 
+/// Hosts to add to a hostname egress allow-list so a scoped machine can still
+/// PULL this image in-guest on first boot.
+///
+/// The DNS filter matches exact-or-subdomain, so a single apex covers a
+/// registry's sub-hosts. Docker Hub is the exception: its manifests live under
+/// `docker.io` but blobs are served from a `docker.com` CDN, so both apexes are
+/// needed. Every other registry needs only its own host.
+///
+/// Mirrors the control plane's `source_registry_hosts` so a machine's pull
+/// behaves identically whether launched locally or via smolfleet.
+pub fn registry_pull_hosts(image: &str) -> Vec<String> {
+    match extract_registry(image).as_str() {
+        "docker.io" | "index.docker.io" | "registry-1.docker.io" => {
+            vec!["docker.io".to_string(), "docker.com".to_string()]
+        }
+        host if host.ends_with("smolmachines.com") => vec!["smolmachines.com".to_string()],
+        host => vec![host.to_string()],
+    }
+}
+
 /// Rewrite an image reference to use a different registry.
 ///
 /// # Examples
@@ -488,6 +508,35 @@ mod tests {
             "registry.example.com"
         );
         assert_eq!(extract_registry("localhost:5000/image"), "localhost:5000");
+    }
+
+    #[test]
+    fn test_registry_pull_hosts_dockerhub_two_apexes() {
+        // Docker Hub serves blobs from a docker.com CDN, so both apexes are
+        // needed; a bare/library ref defaults to Docker Hub.
+        let expect = vec!["docker.io".to_string(), "docker.com".to_string()];
+        assert_eq!(registry_pull_hosts("alpine"), expect);
+        assert_eq!(registry_pull_hosts("library/alpine:3.19"), expect);
+        assert_eq!(registry_pull_hosts("docker.io/library/nginx"), expect);
+        assert_eq!(registry_pull_hosts("registry-1.docker.io/foo/bar"), expect);
+    }
+
+    #[test]
+    fn test_registry_pull_hosts_explicit_registry() {
+        // A single apex covers the registry's sub-hosts via subdomain matching.
+        assert_eq!(registry_pull_hosts("ghcr.io/acme/app:1"), vec!["ghcr.io"]);
+        assert_eq!(
+            registry_pull_hosts("registry.example.com:5000/img"),
+            vec!["registry.example.com:5000"]
+        );
+    }
+
+    #[test]
+    fn test_registry_pull_hosts_smolmachines_apex() {
+        assert_eq!(
+            registry_pull_hosts("registry.smolmachines.com/lib/alpine"),
+            vec!["smolmachines.com"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
A machine created with a hostname egress scope (`--allow-host`) and an image source pulls its base image in-guest on first boot, subject to that same scope, so the pull failed unless the user also listed the image's registry; the enforced launch policy now folds in the source registry's host(s) on the boot that pulls, while the stored policy keeps exactly the hosts the user set.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/518">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->