### PR TITLE
Enforce read-only host mounts at the virtiofs device instead of only in the guest

### DIFF
--- a/crates/smolvm-pack/src/extract.rs
+++ b/crates/smolvm-pack/src/extract.rs
@@ -1768,6 +1768,86 @@ mod tests {
         assert_eq!(fs::read(&outside).unwrap(), b"untouched");
     }
 
+    /// Build a tar archive carrying a single symlink entry whose link target
+    /// is `link_target`, plus (optionally) a trailing regular-file entry.
+    fn make_symlink_tar(name: &str, link_target: &str) -> Vec<u8> {
+        let mut builder = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Symlink);
+        header.set_size(0);
+        header.set_mode(0o777);
+        builder.append_link(&mut header, name, link_target).unwrap();
+        builder.into_inner().unwrap()
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_safe_unpack_rejects_symlink_entry_escaping_dest_relative() {
+        // A crafted tar entry `evil -> ../../outside.bin` must be rejected by
+        // safe_unpack before it is materialized: otherwise a later write
+        // through `evil` would land outside the extraction directory.
+        let temp_dir = tempfile::tempdir().unwrap();
+        let outside = temp_dir.path().join("outside.bin");
+        fs::write(&outside, b"untouched").unwrap();
+
+        let dest = temp_dir.path().join("dest");
+        fs::create_dir(&dest).unwrap();
+
+        let tar_bytes = make_symlink_tar("evil", "../../outside.bin");
+        let mut archive = tar::Archive::new(tar_bytes.as_slice());
+        let result = safe_unpack(&mut archive, &dest);
+
+        assert!(
+            result.is_err(),
+            "escaping relative symlink must be rejected"
+        );
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::InvalidData);
+        assert!(!dest.join("evil").exists(), "symlink must not be created");
+        assert_eq!(fs::read(&outside).unwrap(), b"untouched");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_safe_unpack_rejects_symlink_entry_escaping_dest_absolute() {
+        // An absolute-target symlink `evil -> /etc/passwd` is jailed to
+        // `dest/etc/passwd`, staying inside dest, so it is allowed. But an
+        // absolute target with `..` that climbs out (`/../escape`) must be
+        // rejected — this guards the absolute-symlink jailing branch.
+        let temp_dir = tempfile::tempdir().unwrap();
+        let dest = temp_dir.path().join("dest");
+        fs::create_dir(&dest).unwrap();
+
+        let tar_bytes = make_symlink_tar("evil", "/../../escape");
+        let mut archive = tar::Archive::new(tar_bytes.as_slice());
+        let result = safe_unpack(&mut archive, &dest);
+
+        assert!(
+            result.is_err(),
+            "escaping absolute symlink must be rejected"
+        );
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::InvalidData);
+        assert!(!dest.join("evil").exists(), "symlink must not be created");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_safe_unpack_allows_in_dest_symlink() {
+        // A well-behaved relative symlink that stays within dest is accepted.
+        let temp_dir = tempfile::tempdir().unwrap();
+        let dest = temp_dir.path().join("dest");
+        fs::create_dir(&dest).unwrap();
+
+        let tar_bytes = make_symlink_tar("link", "target");
+        let mut archive = tar::Archive::new(tar_bytes.as_slice());
+        safe_unpack(&mut archive, &dest).unwrap();
+
+        let meta = fs::symlink_metadata(dest.join("link")).unwrap();
+        assert!(
+            meta.file_type().is_symlink(),
+            "in-dest symlink should exist"
+        );
+    }
+
     #[test]
     fn test_unpack_sparse_preserves_data_integrity() {
         let temp_dir = tempfile::tempdir().unwrap();

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -1101,7 +1101,31 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
                 "adding virtiofs mount"
             );
 
-            if krun_add_virtiofs(ctx, tag.as_ptr(), host_path.as_ptr()) < 0 {
+            // Read-only mounts must be enforced host-side by the virtiofs
+            // device (krun_add_virtiofs3's read_only flag), not only by the
+            // guest's bind-remount: a root process in the guest can undo a
+            // guest-side remount, but it cannot make the host server accept
+            // writes. Fail closed if the symbol is missing rather than
+            // silently attaching the mount writable.
+            if mount.read_only {
+                let Some(add_virtiofs3) = krun_add_virtiofs3 else {
+                    krun_free_ctx(ctx);
+                    return Err(Error::agent(
+                        "add virtiofs mount",
+                        "read-only mounts require libkrun with krun_add_virtiofs3",
+                    ));
+                };
+                if add_virtiofs3(ctx, tag.as_ptr(), host_path.as_ptr(), 0, true) < 0 {
+                    krun_free_ctx(ctx);
+                    return Err(Error::agent(
+                        "add virtiofs mount",
+                        format!(
+                            "krun_add_virtiofs3 failed for '{}' - requested mount cannot be attached",
+                            mount.source.display()
+                        ),
+                    ));
+                }
+            } else if krun_add_virtiofs(ctx, tag.as_ptr(), host_path.as_ptr()) < 0 {
                 krun_free_ctx(ctx);
                 return Err(Error::agent(
                     "add virtiofs mount",


### PR DESCRIPTION
Read-only bind mounts were enforced only by the guest-side remount, which a root process in the guest can undo; this routes read-only mounts through krun_add_virtiofs3 so the host virtiofs server rejects writes, and adds tar-slip symlink-escape tests to the packer.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/524">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->