### PR TITLE
fix(agent,disk): bound stalled-body reads with a deadline; guard disk-resize overflow

### DIFF
--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -1927,12 +1927,33 @@ impl AgentClient {
     ///
     /// If `propagate_initial_wouldblock` is true and WouldBlock occurs before
     /// any bytes are read, the error is propagated (preserves read timeout
-    /// behavior). Once any bytes are consumed, EAGAIN is always retried.
+    /// behavior). Once any bytes are consumed, EAGAIN is retried.
+    ///
+    /// # Stall protection
+    ///
+    /// When the socket has a read timeout configured, the retry loop is bounded
+    /// by a wall-clock *idle* deadline. Without it, a peer that writes a valid
+    /// length prefix and then stalls mid-frame (fewer body bytes than declared,
+    /// without closing) would spin this loop at 1ms forever, pinning the host
+    /// thread and the per-machine client lock and defeating every client-level
+    /// timeout. The idle deadline is reset on every byte of progress, so a
+    /// slow-but-steady body is never penalized — only a body that delivers *no*
+    /// bytes for a full read-timeout window fails, with a `TimedOut` error.
+    ///
+    /// When no read timeout is configured (interactive sessions), WouldBlock is
+    /// treated as the spurious macOS vsock EAGAIN it is meant to be, and the loop
+    /// retries indefinitely as before — there is no deadline to enforce.
     fn read_exact_retry(
         &mut self,
         buf: &mut [u8],
         propagate_initial_wouldblock: bool,
     ) -> std::io::Result<()> {
+        // Idle window: how long we tolerate zero progress before declaring a
+        // stall. Derived from the socket's configured read timeout so it tracks
+        // the caller's intent; `None` means blocking mode (no deadline).
+        let idle_window = self.stream.read_timeout().ok().flatten();
+        let mut deadline = idle_window.map(|w| std::time::Instant::now() + w);
+
         let mut pos = 0;
         while pos < buf.len() {
             match self.stream.read(&mut buf[pos..]) {
@@ -1942,13 +1963,29 @@ impl AgentClient {
                         "connection closed",
                     ));
                 }
-                Ok(n) => pos += n,
+                Ok(n) => {
+                    pos += n;
+                    // Progress made — extend the idle deadline.
+                    if let Some(w) = idle_window {
+                        deadline = Some(std::time::Instant::now() + w);
+                    }
+                }
                 Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                     if pos == 0 && propagate_initial_wouldblock {
                         // No data consumed yet and caller wants timeout errors — propagate
                         return Err(e);
                     }
-                    // Either mid-read or caller wants full retry — must retry
+                    // Mid-read (or caller wants full retry). Retry, but bail out
+                    // if the idle deadline has passed so a stalled mid-frame body
+                    // can't busy-spin forever.
+                    if let Some(d) = deadline {
+                        if std::time::Instant::now() >= d {
+                            return Err(std::io::Error::new(
+                                std::io::ErrorKind::TimedOut,
+                                "timed out reading frame body: peer stalled mid-frame",
+                            ));
+                        }
+                    }
                     std::thread::sleep(std::time::Duration::from_millis(1));
                     continue;
                 }
@@ -2439,5 +2476,108 @@ mod run_streaming_tests {
             ]
         );
         server.join().expect("server thread joined cleanly");
+    }
+}
+
+#[cfg(test)]
+mod stalled_body_tests {
+    //! Regression for the busy-spin-forever on a stalled mid-frame body.
+    //!
+    //! A peer that writes a valid 4-byte length prefix and then delivers fewer
+    //! body bytes than declared (without closing the socket) used to pin the
+    //! host thread in a 1ms retry loop with no wall-clock bound, defeating every
+    //! client-level timeout. `read_exact_retry` now honors a wall-clock idle
+    //! deadline derived from the socket read timeout, so `receive()` must return
+    //! a timeout error promptly instead of hanging.
+    use super::*;
+    use std::io::Write;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn receive_times_out_on_stalled_mid_frame_body() {
+        let (client_stream, mut server_stream) = UdsStream::pair().unwrap();
+
+        // Short read timeout so the test is fast: the idle deadline tracks this.
+        let read_timeout = Duration::from_millis(150);
+        client_stream
+            .set_read_timeout(Some(read_timeout))
+            .expect("set client read timeout");
+
+        // Server: declare a 64-byte body, then send only 3 bytes and STALL —
+        // hold the socket open (never drop it) so the client never sees EOF.
+        let server = std::thread::spawn(move || {
+            let declared_len: u32 = 64;
+            server_stream
+                .write_all(&declared_len.to_be_bytes())
+                .expect("write length prefix");
+            server_stream
+                .write_all(&[1u8, 2, 3])
+                .expect("write partial body");
+            server_stream.flush().expect("flush");
+            // Stall: keep the connection open well past the client's deadline so
+            // the client cannot rely on EOF to unblock.
+            std::thread::sleep(Duration::from_secs(3));
+            drop(server_stream);
+        });
+
+        let mut client = AgentClient::from_stream(client_stream);
+
+        let start = Instant::now();
+        let result = client.receive();
+        let elapsed = start.elapsed();
+
+        assert!(
+            result.is_err(),
+            "receive() must error on a stalled mid-frame body, not return Ok"
+        );
+        // Must return within a small multiple of the read timeout — nowhere near
+        // the server's 3s hold, proving it did not busy-spin until EOF.
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "receive() should time out promptly (got {elapsed:?}); it must not \
+             spin until the peer closes"
+        );
+
+        server.join().expect("server thread joined");
+    }
+
+    #[test]
+    fn read_exact_retry_bounds_stalled_read_without_eof() {
+        // Drive read_exact_retry directly: header-style non-propagating read of a
+        // buffer larger than what the peer sends, with the peer stalling.
+        let (client_stream, mut server_stream) = UdsStream::pair().unwrap();
+        client_stream
+            .set_read_timeout(Some(Duration::from_millis(100)))
+            .expect("set read timeout");
+
+        let server = std::thread::spawn(move || {
+            server_stream.write_all(&[0xAAu8]).expect("write one byte");
+            server_stream.flush().expect("flush");
+            std::thread::sleep(Duration::from_secs(3));
+            drop(server_stream);
+        });
+
+        let mut client = AgentClient::from_stream(client_stream);
+
+        let start = Instant::now();
+        // Ask for 8 bytes but only 1 will ever arrive; propagate=false forces the
+        // retry path (the same path receive() uses for the body).
+        let mut buf = [0u8; 8];
+        let err = client
+            .read_exact_retry(&mut buf, false)
+            .expect_err("stalled read must return a bounded error");
+        let elapsed = start.elapsed();
+
+        assert_eq!(
+            err.kind(),
+            std::io::ErrorKind::TimedOut,
+            "stalled mid-buffer read must surface a TimedOut error"
+        );
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "read_exact_retry must not busy-spin until EOF (got {elapsed:?})"
+        );
+
+        server.join().expect("server thread joined");
     }
 }

--- a/src/disk_utils.rs
+++ b/src/disk_utils.rs
@@ -124,7 +124,18 @@ pub(crate) fn copy_disk_from_template<D: DiskType>(
 pub(crate) fn expand_sparse_disk<D: DiskType>(path: &Path, new_size_gb: u64) -> Result<()> {
     use std::fs::OpenOptions;
 
-    let new_size_bytes = new_size_gb * BYTES_PER_GIB;
+    // Use checked_mul so an absurd request (e.g. 2^34 GiB) returns a clean
+    // error instead of overflowing u64 — which would debug-panic or, in release,
+    // wrap to a tiny/zero byte count and silently truncate the sparse file.
+    let new_size_bytes = new_size_gb.checked_mul(BYTES_PER_GIB).ok_or_else(|| {
+        Error::storage(
+            "expand disk",
+            format!(
+                "requested size {} GiB is too large (overflows the maximum addressable byte count)",
+                new_size_gb
+            ),
+        )
+    })?;
     let current_size = std::fs::metadata(path)
         .map_err(|e| Error::storage("get disk metadata", e.to_string()))?
         .len();
@@ -616,5 +627,47 @@ mod tests {
                 "sparse clone must not allocate the full {logical_len} bytes (got {allocated} allocated)"
             );
         }
+    }
+
+    /// Regression: `expand_sparse_disk` must reject a size whose byte count
+    /// overflows u64 with a clean `Err`, never a panic (debug) or a wrapped /
+    /// zero-length sparse file (release). `2^34 GiB * 2^30 bytes/GiB = 2^64`,
+    /// which is exactly the u64 overflow boundary.
+    #[test]
+    fn expand_rejects_overflowing_size_gb() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("overflow.img");
+        // The path need not exist: the overflow check runs before any file I/O,
+        // so this must fail on the multiply, not on a missing-file error.
+        let overflow_gb: u64 = 1u64 << 34; // * BYTES_PER_GIB (2^30) == 2^64
+        let err = expand_sparse_disk::<crate::data::disk::Storage>(&path, overflow_gb)
+            .expect_err("overflowing size_gb must return Err, not panic or truncate");
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("too large") && msg.contains("overflow"),
+            "expected an overflow error, got: {msg}"
+        );
+        assert!(
+            !path.exists(),
+            "no disk file should be created when the size overflows"
+        );
+    }
+
+    /// A merely-large-but-valid size must not be rejected by the overflow guard
+    /// (it will fail later on the missing file, proving the multiply succeeded).
+    #[test]
+    fn expand_allows_large_but_valid_size_gb() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missing.img");
+        // 1 GiB below the overflow boundary — the multiply is fine; the call
+        // then fails reading metadata of the nonexistent path.
+        let big_gb: u64 = (1u64 << 34) - 1;
+        let err = expand_sparse_disk::<crate::data::disk::Storage>(&path, big_gb)
+            .expect_err("nonexistent path should fail after a successful multiply");
+        let msg = format!("{}", err);
+        assert!(
+            !msg.contains("too large"),
+            "a valid (non-overflowing) size must not trip the overflow guard: {msg}"
+        );
     }
 }


### PR DESCRIPTION
Give mid-frame body reads a wall-clock idle deadline so a stalled peer times out instead of busy-spinning forever, and use checked_mul on disk-resize sizing so an overflowing size_gb returns a clean error instead of panicking or truncating.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/525">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->