### PR TITLE
fix: offload DNS off the poll loop and copy-truncate live log rotation

### DIFF
--- a/crates/smolvm-network/src/dns_relay.rs
+++ b/crates/smolvm-network/src/dns_relay.rs
@@ -1,0 +1,497 @@
+//! Off-poll-thread DNS resolver for the virtio-net backend.
+//!
+//! Context
+//! =======
+//!
+//! Guest DNS (UDP/TCP :53) is intercepted by the gateway and forwarded to an
+//! upstream resolver (`stack.rs::process_dns_queries` / `process_dns_tcp`). The
+//! upstream exchange is a *blocking* host socket round trip with a 2-second
+//! timeout. It used to run inline on the single virtio-net poll thread — the
+//! thread that owns the smoltcp interface and every one of that VM's TCP/UDP/
+//! ICMP sockets. A slow or dead resolver therefore stalled *all* of the guest's
+//! traffic for up to 2 seconds (head-of-line block).
+//!
+//! This module moves that blocking resolution off the poll thread, mirroring
+//! the UDP/ICMP relay offload ([`crate::udp_relay`]). The poll loop only:
+//!   1. reads a guest query out of its smoltcp DNS socket,
+//!   2. applies the egress allow-host policy itself (cheap, no host I/O),
+//!   3. hands allowed queries to this relay over a channel, and
+//!   4. later picks the answer back up via the shared relay wake + channel and
+//!      writes it into the guest socket — never blocking on the resolver.
+//!
+//! Egress policy (allow/deny, `learn_ip_records`) stays on the poll thread so
+//! [`EgressPolicy`](crate::egress::EgressPolicy) is never shared across threads;
+//! only the raw upstream forward is offloaded.
+//!
+//! ```text
+//! guest :53 query -> smoltcp gateway socket
+//!   -> poll loop: classify (allow-host) -> allowed?
+//!        no  -> answer NXDOMAIN/SERVFAIL immediately (no relay)
+//!        yes -> assign id, remember reply context, channel (id, query) to relay
+//!   -> relay thread: UDP -> non-blocking connected host socket + poller
+//!                    TCP -> bounded detached worker (rare path)
+//!   -> answer bytes -> channel back -> reply_wake
+//!   -> poll loop: learn A/AAAA records, write answer into the guest socket
+//! ```
+//!
+//! DNS is low-volume and its answers are quick, so the tables here are small and
+//! loss under saturation just makes a guest see a normal DNS timeout.
+
+use crate::queues::WakePipe;
+use crate::virtio_net_log;
+use polling::{Event, Events};
+use std::io::{Read, Write};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream, UdpSocket as HostUdpSocket};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc::{self, Receiver, SyncSender, TryRecvError, TrySendError};
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// DNS service port.
+const DNS_PORT: u16 = 53;
+/// Upstream exchange timeout, matching the previous inline behaviour.
+const UPSTREAM_TIMEOUT: Duration = Duration::from_secs(2);
+/// Largest DNS message we accept back (EDNS0 / DNS-over-TCP bound).
+const DNS_MAX_MSG: usize = 4096;
+/// Max in-flight queries buffered in each channel direction.
+const CHANNEL_CAPACITY: usize = 256;
+/// Max concurrent in-flight UDP queries with a live host socket.
+const MAX_INFLIGHT_UDP: usize = 256;
+/// Max concurrent in-flight DNS-over-TCP worker threads.
+const MAX_INFLIGHT_TCP: usize = 64;
+/// Relay thread poll ceiling so shutdown and deadlines are noticed promptly.
+const RELAY_POLL_MAX_MS: u64 = 250;
+
+/// Which upstream transport a query must use.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DnsTransport {
+    Udp,
+    Tcp,
+}
+
+/// A query handed from the poll loop to the relay thread.
+pub struct DnsQuery {
+    /// Correlation id chosen by the poll loop; echoed back in the response.
+    pub id: u64,
+    /// Transport to reach the upstream resolver on.
+    pub transport: DnsTransport,
+    /// Upstream resolver address.
+    pub upstream: Ipv4Addr,
+    /// Raw DNS query message (no TCP length prefix).
+    pub query: Vec<u8>,
+}
+
+/// A resolved answer handed back to the poll loop.
+pub struct DnsResponse {
+    /// The id of the originating [`DnsQuery`].
+    pub id: u64,
+    /// Raw DNS answer message, or `None` on error/timeout (guest sees a normal
+    /// DNS timeout — identical to the old inline `forward` error path).
+    pub answer: Option<Vec<u8>>,
+}
+
+/// Channel pair connecting the poll loop and the DNS relay thread.
+pub struct DnsRelayChannels {
+    /// Poll loop -> relay thread.
+    pub to_relay: SyncSender<DnsQuery>,
+    /// Relay thread -> poll loop.
+    pub from_relay: Receiver<DnsResponse>,
+    /// Wakes the relay thread after `to_relay` sends.
+    pub relay_thread_wake: WakePipe,
+}
+
+/// Start the DNS relay thread. Returns the poll-loop-side channel endpoints.
+///
+/// `reply_wake` is the smoltcp poll loop's existing relay wake pipe — pulsed
+/// whenever an answer is queued so the loop wakes to deliver it. The thread
+/// exits when `shutdown` reports true (checked at least once per
+/// [`RELAY_POLL_MAX_MS`]).
+pub fn start_dns_relay(
+    reply_wake: Arc<WakePipe>,
+    shutdown: Arc<dyn Fn() -> bool + Send + Sync>,
+) -> DnsRelayChannels {
+    let (to_relay_tx, to_relay_rx) = mpsc::sync_channel(CHANNEL_CAPACITY);
+    let (from_relay_tx, from_relay_rx) = mpsc::sync_channel(CHANNEL_CAPACITY);
+    let relay_thread_wake = WakePipe::new();
+    let thread_wake = relay_thread_wake.clone();
+
+    let _ = thread::Builder::new()
+        .name("smolvm-dns-relay".into())
+        .spawn(move || {
+            run_dns_relay(
+                to_relay_rx,
+                from_relay_tx,
+                thread_wake,
+                reply_wake,
+                shutdown,
+            );
+        });
+
+    DnsRelayChannels {
+        to_relay: to_relay_tx,
+        from_relay: from_relay_rx,
+        relay_thread_wake,
+    }
+}
+
+/// One in-flight UDP query: a non-blocking connected host socket awaiting its
+/// single response, and the deadline after which we give up.
+struct InflightUdp {
+    socket: HostUdpSocket,
+    deadline: Instant,
+}
+
+/// Send one answer back to the poll loop. Returns `true` if the caller should
+/// wake the poll loop, `false` if the channel is closed (relay should exit).
+fn deliver_answer(inbound: &SyncSender<DnsResponse>, id: u64, answer: Option<Vec<u8>>) -> bool {
+    match inbound.try_send(DnsResponse { id, answer }) {
+        Ok(()) => true,
+        Err(TrySendError::Full(_)) => {
+            virtio_net_log!(
+                "virtio-net: dropping DNS answer id={} (inbound queue full)",
+                id
+            );
+            true
+        }
+        Err(TrySendError::Disconnected(_)) => false,
+    }
+}
+
+fn run_dns_relay(
+    outbound: Receiver<DnsQuery>,
+    inbound: SyncSender<DnsResponse>,
+    wake: WakePipe,
+    reply_wake: Arc<WakePipe>,
+    shutdown: Arc<dyn Fn() -> bool + Send + Sync>,
+) {
+    let mut inflight: std::collections::HashMap<u64, InflightUdp> =
+        std::collections::HashMap::new();
+    let mut recv_buf = vec![0u8; DNS_MAX_MSG];
+    let tcp_inflight = Arc::new(AtomicUsize::new(0));
+
+    loop {
+        if shutdown() {
+            return;
+        }
+
+        let mut woke_reply = false;
+
+        // Outbound: queries handed over by the poll loop.
+        loop {
+            match outbound.try_recv() {
+                Ok(query) => match query.transport {
+                    DnsTransport::Udp => {
+                        if inflight.len() >= MAX_INFLIGHT_UDP {
+                            virtio_net_log!(
+                                "virtio-net: dropping DNS query id={} (in-flight UDP table full)",
+                                query.id
+                            );
+                            woke_reply |= deliver_answer(&inbound, query.id, None);
+                            continue;
+                        }
+                        let upstream = SocketAddr::new(IpAddr::V4(query.upstream), DNS_PORT);
+                        match start_udp_query(upstream, &query.query) {
+                            Ok(socket) => {
+                                inflight.insert(
+                                    query.id,
+                                    InflightUdp {
+                                        socket,
+                                        deadline: Instant::now() + UPSTREAM_TIMEOUT,
+                                    },
+                                );
+                            }
+                            Err(err) => {
+                                virtio_net_log!(
+                                    "virtio-net: DNS/UDP upstream send failed id={} error={}",
+                                    query.id,
+                                    err
+                                );
+                                woke_reply |= deliver_answer(&inbound, query.id, None);
+                            }
+                        }
+                    }
+                    DnsTransport::Tcp => {
+                        spawn_tcp_query(&inbound, &reply_wake, &tcp_inflight, query);
+                    }
+                },
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => return,
+            }
+        }
+
+        // Inbound: block on "wake OR any in-flight UDP socket readable", exactly
+        // like the UDP relay. Each socket is registered at key `slot + 1`.
+        let poller = wake.poller();
+        let ids: Vec<u64> = inflight.keys().copied().collect();
+        for (slot, id) in ids.iter().enumerate() {
+            // SAFETY: the socket is owned by `inflight` and is deleted from the
+            // poller below before it can be dropped.
+            let _ = unsafe { poller.add(&inflight[id].socket, Event::readable(slot + 1)) };
+        }
+
+        // Wake no later than the nearest deadline so timeouts fire on time.
+        let now = Instant::now();
+        let mut wait = Duration::from_millis(RELAY_POLL_MAX_MS);
+        for f in inflight.values() {
+            let remaining = f.deadline.saturating_duration_since(now);
+            if remaining < wait {
+                wait = remaining;
+            }
+        }
+
+        let mut events = Events::new();
+        let _ = poller.wait(&mut events, Some(wait));
+
+        let mut ready: Vec<bool> = vec![false; ids.len()];
+        for event in events.iter() {
+            if event.key >= 1 && event.key - 1 < ready.len() {
+                ready[event.key - 1] = true;
+            }
+        }
+
+        // Deregister every socket before mutating `inflight`.
+        for id in &ids {
+            let _ = poller.delete(&inflight[id].socket);
+        }
+
+        // Deliver ready answers; expire the rest past their deadline.
+        let now = Instant::now();
+        for (slot, id) in ids.iter().enumerate() {
+            if ready[slot] {
+                let answer = inflight
+                    .get(id)
+                    .and_then(|f| match f.socket.recv(&mut recv_buf) {
+                        Ok(len) => Some(recv_buf[..len].to_vec()),
+                        Err(_) => None,
+                    });
+                match answer {
+                    Some(bytes) => {
+                        inflight.remove(id);
+                        woke_reply |= deliver_answer(&inbound, *id, Some(bytes));
+                    }
+                    // Spurious readiness with nothing to read: leave it in flight
+                    // to be retried or expired.
+                    None if inflight.get(id).is_some_and(|f| f.deadline <= now) => {
+                        inflight.remove(id);
+                        woke_reply |= deliver_answer(&inbound, *id, None);
+                    }
+                    None => {}
+                }
+            } else if inflight.get(id).is_some_and(|f| f.deadline <= now) {
+                inflight.remove(id);
+                woke_reply |= deliver_answer(&inbound, *id, None);
+            }
+        }
+
+        if woke_reply {
+            reply_wake.wake();
+        }
+    }
+}
+
+/// Open a non-blocking host UDP socket connected to the upstream resolver and
+/// send the query. The single response is collected later by the poll section.
+fn start_udp_query(upstream: SocketAddr, query: &[u8]) -> std::io::Result<HostUdpSocket> {
+    let bind: SocketAddr = if upstream.is_ipv4() {
+        (Ipv4Addr::UNSPECIFIED, 0).into()
+    } else {
+        (std::net::Ipv6Addr::UNSPECIFIED, 0).into()
+    };
+    let socket = HostUdpSocket::bind(bind)?;
+    socket.connect(upstream)?;
+    socket.set_nonblocking(true)?;
+    socket.send(query)?;
+    Ok(socket)
+}
+
+/// Resolve a DNS-over-TCP query on a bounded, detached worker thread.
+///
+/// DNS/TCP is the rare fallback path (truncated/large answers). Rather than
+/// build a non-blocking length-prefixed TCP state machine, each query gets its
+/// own short-lived worker so a slow TCP resolver never blocks the UDP fast path
+/// or the poll loop. The worker count is capped; over the cap the query is
+/// answered as a timeout.
+fn spawn_tcp_query(
+    inbound: &SyncSender<DnsResponse>,
+    reply_wake: &Arc<WakePipe>,
+    tcp_inflight: &Arc<AtomicUsize>,
+    query: DnsQuery,
+) {
+    if tcp_inflight.load(Ordering::Relaxed) >= MAX_INFLIGHT_TCP {
+        virtio_net_log!(
+            "virtio-net: dropping DNS/TCP query id={} (worker cap reached)",
+            query.id
+        );
+        if deliver_answer(inbound, query.id, None) {
+            reply_wake.wake();
+        }
+        return;
+    }
+    tcp_inflight.fetch_add(1, Ordering::Relaxed);
+    let worker_inbound = inbound.clone();
+    let worker_wake = reply_wake.clone();
+    let worker_inflight = tcp_inflight.clone();
+    let id = query.id;
+    let spawned = thread::Builder::new()
+        .name("smolvm-dns-tcp".into())
+        .spawn(move || {
+            let upstream = SocketAddr::new(IpAddr::V4(query.upstream), DNS_PORT);
+            let answer = forward_dns_query_tcp(upstream, &query.query).ok();
+            if deliver_answer(&worker_inbound, id, answer) {
+                worker_wake.wake();
+            }
+            worker_inflight.fetch_sub(1, Ordering::Relaxed);
+        });
+    if spawned.is_err() {
+        // Could not spawn: undo the reservation and answer as a timeout.
+        tcp_inflight.fetch_sub(1, Ordering::Relaxed);
+        if deliver_answer(inbound, id, None) {
+            reply_wake.wake();
+        }
+    }
+}
+
+/// Forward one DNS query to the upstream resolver over TCP (length-prefixed, per
+/// RFC 1035 §4.2.2) and return the raw response message. Blocking host TCP
+/// exchange with a short timeout — runs only on a detached worker, never the
+/// poll thread.
+fn forward_dns_query_tcp(upstream: SocketAddr, query: &[u8]) -> std::io::Result<Vec<u8>> {
+    use std::io::{Error, ErrorKind};
+    let len = u16::try_from(query.len())
+        .map_err(|_| Error::new(ErrorKind::InvalidInput, "DNS query too large for TCP"))?;
+    let mut stream = TcpStream::connect_timeout(&upstream, UPSTREAM_TIMEOUT)?;
+    stream.set_read_timeout(Some(UPSTREAM_TIMEOUT))?;
+    stream.set_write_timeout(Some(UPSTREAM_TIMEOUT))?;
+    stream.write_all(&len.to_be_bytes())?;
+    stream.write_all(query)?;
+    stream.flush()?;
+
+    let mut len_buf = [0u8; 2];
+    stream.read_exact(&mut len_buf)?;
+    let resp_len = u16::from_be_bytes(len_buf) as usize;
+    if resp_len == 0 || resp_len > DNS_MAX_MSG {
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            "upstream DNS/TCP response length out of range",
+        ));
+    }
+    let mut response = vec![0u8; resp_len];
+    stream.read_exact(&mut response)?;
+    Ok(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicBool;
+
+    /// `start_udp_query` sends off a non-blocking connected socket; its single
+    /// response is collected later without blocking. Exercises the real fn
+    /// against a loopback echo "resolver" (arbitrary port, so no port-53 dep).
+    #[test]
+    fn start_udp_query_sends_and_receives_nonblocking() {
+        let upstream = HostUdpSocket::bind("127.0.0.1:0").unwrap();
+        let upstream_addr = upstream.local_addr().unwrap();
+        let resolver = thread::spawn(move || {
+            let mut buf = [0u8; 512];
+            upstream
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .unwrap();
+            let (n, peer) = upstream.recv_from(&mut buf).unwrap();
+            upstream.send_to(&buf[..n], peer).unwrap();
+        });
+
+        let sock = start_udp_query(upstream_addr, b"\x12\x34hello-dns").unwrap();
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let mut buf = [0u8; 512];
+        loop {
+            match sock.recv(&mut buf) {
+                Ok(n) => {
+                    assert_eq!(&buf[..n], b"\x12\x34hello-dns");
+                    break;
+                }
+                Err(_) if Instant::now() < deadline => {
+                    thread::sleep(Duration::from_millis(5));
+                }
+                Err(e) => panic!("no DNS answer: {e}"),
+            }
+        }
+        resolver.join().unwrap();
+    }
+
+    /// End-to-end through the relay thread: a live upstream on port 53 needs
+    /// privileges, so this proves the *offload contract* — the poll thread only
+    /// sends/receives channel messages and never blocks — using an unreachable
+    /// upstream that must resolve to a timeout answer, promptly and off-thread.
+    #[test]
+    fn poll_thread_never_blocks_on_dead_resolver() {
+        let reply_wake = Arc::new(WakePipe::new());
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_flag = stop.clone();
+        let channels = start_dns_relay(
+            reply_wake.clone(),
+            Arc::new(move || stop_flag.load(Ordering::Relaxed)),
+        );
+
+        // 192.0.2.1 is TEST-NET-1 (RFC 5737): guaranteed unroutable, so the
+        // upstream never answers and the relay must time it out for us.
+        let started = Instant::now();
+        channels
+            .to_relay
+            .send(DnsQuery {
+                id: 7,
+                transport: DnsTransport::Udp,
+                upstream: Ipv4Addr::new(192, 0, 2, 1),
+                query: b"\x00\x00query".to_vec(),
+            })
+            .unwrap();
+        channels.relay_thread_wake.wake();
+
+        // The send returned immediately (offloaded); this thread is free.
+        assert!(started.elapsed() < Duration::from_millis(50));
+
+        // The answer (a timeout -> None) arrives via the channel, driven by the
+        // relay thread, within a bit over the 2s upstream timeout.
+        let resp = channels
+            .from_relay
+            .recv_timeout(Duration::from_secs(4))
+            .expect("relay must always answer, even on timeout");
+        assert_eq!(resp.id, 7);
+        assert!(resp.answer.is_none());
+
+        stop.store(true, Ordering::Relaxed);
+        channels.relay_thread_wake.wake();
+    }
+
+    /// The real `forward_dns_query_tcp` resolves against a length-prefixed host
+    /// TCP resolver (arbitrary loopback port) and returns the raw, unprefixed
+    /// answer message. This is the code the detached DNS/TCP worker runs.
+    #[test]
+    fn forward_dns_query_tcp_round_trips() {
+        use std::net::TcpListener;
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        // Minimal DNS-over-TCP resolver: read the length-prefixed query, reply
+        // with a length-prefixed canned answer.
+        let server = thread::spawn(move || {
+            let (mut sock, _) = listener.accept().unwrap();
+            let mut len_buf = [0u8; 2];
+            sock.read_exact(&mut len_buf).unwrap();
+            let qlen = u16::from_be_bytes(len_buf) as usize;
+            let mut q = vec![0u8; qlen];
+            sock.read_exact(&mut q).unwrap();
+            assert_eq!(&q, b"tcp-query");
+            let answer = b"answer-bytes";
+            sock.write_all(&(answer.len() as u16).to_be_bytes())
+                .unwrap();
+            sock.write_all(answer).unwrap();
+        });
+
+        let resp = forward_dns_query_tcp(addr, b"tcp-query").unwrap();
+        assert_eq!(resp, b"answer-bytes");
+        server.join().unwrap();
+    }
+}

--- a/crates/smolvm-network/src/lib.rs
+++ b/crates/smolvm-network/src/lib.rs
@@ -59,6 +59,7 @@
 
 pub mod device;
 pub mod dns;
+pub mod dns_relay;
 pub mod egress;
 // The libkrun frame bridge speaks over an AF_UNIX stream socket, available on
 // both Unix and Windows (10 1809+), so the whole stack is cross-platform.

--- a/crates/smolvm-network/src/stack.rs
+++ b/crates/smolvm-network/src/stack.rs
@@ -52,6 +52,7 @@
 
 use crate::device::VirtioNetworkDevice;
 use crate::dns;
+use crate::dns_relay::{self, DnsQuery, DnsResponse, DnsTransport};
 use crate::egress::EgressPolicy;
 use crate::icmp_relay;
 use crate::queues::NetworkFrameQueues;
@@ -72,8 +73,8 @@ use smoltcp::wire::{
     EthernetAddress, EthernetFrame, EthernetProtocol, HardwareAddress, IpAddress, IpCidr,
     IpListenEndpoint, IpProtocol, IpVersion, Ipv4Packet, Ipv6Packet, TcpPacket, UdpPacket,
 };
-use std::io::{Read, Write};
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket as HostUdpSocket};
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::atomic::Ordering;
 use std::sync::mpsc::{Receiver, SyncSender, TryRecvError, TrySendError};
 use std::sync::Arc;
@@ -226,6 +227,17 @@ fn run_network_stack(
             Arc::new(move || shutdown_queues.is_shutting_down()),
         )
     };
+    // DNS resolution is offloaded to its own thread so the blocking upstream
+    // exchange never stalls this poll loop (which owns every one of the VM's
+    // sockets). Egress policy stays here; only the raw forward is offloaded.
+    let dns_channels = {
+        let shutdown_queues = queues.clone();
+        dns_relay::start_dns_relay(
+            relay_wake.clone(),
+            Arc::new(move || shutdown_queues.is_shutting_down()),
+        )
+    };
+    let mut dns_gateway = DnsGateway::new();
 
     // The smoltcp loop is driven by poller wakeups rather than busy spinning.
     // guest_wake  -> new guest frame or shutdown
@@ -315,18 +327,38 @@ fn run_network_stack(
         // Move payloads between established smoltcp TCP sockets and host relay
         // threads, and service the DNS gateway socket.
         relays.relay_data(&mut sockets);
-        process_dns_queries(
+        // Enqueue guest DNS queries to the offload thread (or answer blocked
+        // ones locally), then deliver any answers it has produced back to the
+        // guest. Neither step blocks on the upstream resolver.
+        let mut woke_dns = false;
+        woke_dns |= dispatch_dns_udp(
             dns_socket_handle,
             &mut sockets,
             &egress,
             config.upstream_dns,
+            &mut dns_gateway,
+            &dns_channels.to_relay,
         );
-        process_dns_tcp(
+        woke_dns |= process_dns_tcp(
             &dns_tcp_handles,
             &mut dns_tcp_conns,
             &mut sockets,
             &egress,
             config.upstream_dns,
+            &mut dns_gateway,
+            &dns_channels.to_relay,
+        );
+        if woke_dns {
+            dns_channels.relay_thread_wake.wake();
+        }
+        deliver_dns_responses(
+            dns_socket_handle,
+            &dns_tcp_handles,
+            &mut dns_tcp_conns,
+            &mut sockets,
+            &egress,
+            &mut dns_gateway,
+            &dns_channels.from_relay,
         );
 
         // General UDP: forward staged guest datagrams to the relay thread,
@@ -676,154 +708,201 @@ fn relay_accepted_tcp_connection(
     }
 }
 
-fn process_dns_queries(
-    dns_socket_handle: SocketHandle,
-    sockets: &mut SocketSet<'_>,
-    egress: &EgressPolicy,
-    upstream_dns: Ipv4Addr,
-) {
-    // Phase 1 DNS model:
-    // guest UDP/53 -> smoltcp gateway socket -> host UDP socket -> upstream DNS
-    //               <-               response bytes               <-
-    let socket = sockets.get_mut::<UdpSocket>(dns_socket_handle);
-    while socket.can_recv() {
-        let (query, metadata) = match socket.recv() {
-            Ok((q, m)) => (q.to_vec(), m),
-            Err(_) => break,
-        };
-        virtio_net_log!(
-            "virtio-net: forwarding guest DNS query guest={} local_address={:?} query_len={} upstream_dns={}",
-            metadata.endpoint,
-            metadata.local_address,
-            query.len(),
-            upstream_dns
-        );
-        // Apply the same allow-host filter as TCP (see `filtered_dns_response`),
-        // forwarding allowed queries over the host's UDP stack.
-        let response =
-            match filtered_dns_response(&query, egress, |q| forward_dns_query(upstream_dns, q)) {
-                Some(response) => response,
-                None => continue,
-            };
-        virtio_net_log!(
-            "virtio-net: forwarded DNS response back to guest guest={} response_len={}",
-            metadata.endpoint,
-            response.len()
-        );
+/// Bound on outstanding forwarded DNS queries (UDP context) awaiting an answer
+/// from the offload thread. Every enqueued query eventually yields a response
+/// (answer or timeout) that clears its entry, so this is only a safety ceiling
+/// against a wedged relay; DNS volume is far below it in practice.
+const MAX_PENDING_DNS: usize = 512;
 
-        let response_meta = UdpMetadata {
-            endpoint: metadata.endpoint,
-            local_address: metadata.local_address,
-            meta: Default::default(),
-        };
-        let _ = socket.send_slice(&response, response_meta);
+/// Poll-loop-side DNS state: the id generator and the reply context for each
+/// in-flight *UDP* query. TCP context lives on the owning [`DnsTcpConn`]
+/// (`awaiting`), since a DNS/TCP query is pinned to one listener socket.
+struct DnsGateway {
+    next_id: u64,
+    pending_udp: HashMap<u64, PendingDnsUdp>,
+}
+
+/// The guest-reply context we must remember while a UDP query is off-thread.
+struct PendingDnsUdp {
+    endpoint: smoltcp::wire::IpEndpoint,
+    local_address: Option<IpAddress>,
+    /// Whether to learn A/AAAA answer records into the egress allow-list.
+    learn: bool,
+}
+
+impl DnsGateway {
+    fn new() -> Self {
+        Self {
+            next_id: 0,
+            pending_udp: HashMap::new(),
+        }
+    }
+
+    fn next_id(&mut self) -> u64 {
+        let id = self.next_id;
+        self.next_id = self.next_id.wrapping_add(1);
+        id
     }
 }
 
-fn forward_dns_query(upstream_dns: Ipv4Addr, query: &[u8]) -> std::io::Result<Vec<u8>> {
-    // This is intentionally a plain host UDP exchange rather than a smoltcp
-    // socket-to-socket relay. Once the guest packet reaches the gateway, the
-    // simplest MVP path is to proxy it with the host kernel's UDP stack.
-    //
-    // Rough shell equivalent:
-    //   send raw DNS message to `<upstream_dns>:53`
-    //   wait up to 2 seconds for one reply
-    let socket = HostUdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0))?;
-    socket.set_read_timeout(Some(Duration::from_secs(2)))?;
-    let local_addr = socket.local_addr()?;
-    virtio_net_log!(
-        "virtio-net: sending DNS query to upstream resolver local_addr={} upstream_dns={} query_len={}",
-        local_addr,
-        upstream_dns,
-        query.len()
-    );
-    socket.send_to(query, (upstream_dns, DNS_SOCKET_PORT))?;
-
-    let mut buffer = vec![0u8; DNS_BUFFER_BYTES];
-    let (bytes_read, _) = socket.recv_from(&mut buffer)?;
-    buffer.truncate(bytes_read);
-    virtio_net_log!(
-        "virtio-net: received DNS response from upstream resolver upstream_dns={} response_len={}",
-        upstream_dns,
-        buffer.len()
-    );
-    Ok(buffer)
+/// The decision for a single guest DNS query, made on the poll thread using the
+/// egress allow-host policy (no host I/O). Mirrors the previous inline filter.
+enum DnsDecision {
+    /// Answer the guest immediately with these raw DNS message bytes
+    /// (blocked -> NXDOMAIN, unparseable -> SERVFAIL).
+    Immediate(Vec<u8>),
+    /// Forward the query upstream via the offload thread; `learn` records the
+    /// answer's A/AAAA IPs into the egress allow-list when it returns.
+    Forward { learn: bool },
 }
 
-/// Apply the allow-host DNS policy to a single query and produce the response
-/// bytes to return to the guest, or `None` to drop (a forwarding error on an
-/// allowed query — the guest sees a normal DNS timeout).
-///
-/// Shared by the UDP and TCP gateway paths so both enforce identical policy:
-/// only allow-listed names are forwarded (`forward`); others get NXDOMAIN; an
-/// unparseable query gets SERVFAIL. Answer A/AAAA records of allowed queries are
-/// learned as temporary egress IPs so the follow-up connection passes the
-/// filter. Mirrors libkrun's TSI DNS filter.
-fn filtered_dns_response(
-    query: &[u8],
-    egress: &EgressPolicy,
-    forward: impl FnOnce(&[u8]) -> std::io::Result<Vec<u8>>,
-) -> Option<Vec<u8>> {
+/// Classify a query under the allow-host policy. When the DNS filter is
+/// inactive everything is forwarded (no learning); otherwise only allow-listed
+/// names are forwarded and learned, others get NXDOMAIN and unparseable ones
+/// SERVFAIL. Identical policy to the old `filtered_dns_response`.
+fn classify_dns_query(query: &[u8], egress: &EgressPolicy) -> DnsDecision {
     if !egress.dns_filter_active() {
-        return match forward(query) {
-            Ok(response) => Some(response),
-            Err(err) => {
-                virtio_net_log!("virtio-net: host DNS forwarding failed error={}", err);
-                None
-            }
-        };
+        return DnsDecision::Forward { learn: false };
     }
     match dns::question_name(query) {
-        Some(name) if egress.hostname_allowed(&name) => match forward(query) {
-            Ok(response) => {
-                egress.learn_ip_records(&dns::answer_ip_records(&response));
-                Some(response)
-            }
-            Err(err) => {
-                virtio_net_log!("virtio-net: host DNS forwarding failed error={}", err);
-                None
-            }
-        },
+        Some(name) if egress.hostname_allowed(&name) => DnsDecision::Forward { learn: true },
         Some(name) => {
             virtio_net_log!(
                 "virtio-net: blocking DNS query by allow-host policy name={}",
                 name
             );
-            Some(dns::error_response(query, dns::DNS_RCODE_NXDOMAIN))
+            DnsDecision::Immediate(dns::error_response(query, dns::DNS_RCODE_NXDOMAIN))
         }
-        None => Some(dns::error_response(query, dns::DNS_RCODE_SERVFAIL)),
+        None => DnsDecision::Immediate(dns::error_response(query, dns::DNS_RCODE_SERVFAIL)),
     }
 }
 
-/// Forward one DNS query to the upstream resolver over TCP (length-prefixed, per
-/// RFC 1035 §4.2.2) and return the raw response message. Synchronous host TCP
-/// exchange with a short timeout, matching the UDP path's MVP shape.
-fn forward_dns_query_tcp(upstream_dns: Ipv4Addr, query: &[u8]) -> std::io::Result<Vec<u8>> {
-    use std::io::{Error, ErrorKind};
-    let len = u16::try_from(query.len())
-        .map_err(|_| Error::new(ErrorKind::InvalidInput, "DNS query too large for TCP"))?;
-    let mut stream = std::net::TcpStream::connect_timeout(
-        &SocketAddr::new(IpAddr::V4(upstream_dns), DNS_SOCKET_PORT),
-        Duration::from_secs(2),
-    )?;
-    stream.set_read_timeout(Some(Duration::from_secs(2)))?;
-    stream.set_write_timeout(Some(Duration::from_secs(2)))?;
-    stream.write_all(&len.to_be_bytes())?;
-    stream.write_all(query)?;
-    stream.flush()?;
-
-    let mut len_buf = [0u8; 2];
-    stream.read_exact(&mut len_buf)?;
-    let resp_len = u16::from_be_bytes(len_buf) as usize;
-    if resp_len == 0 || resp_len > DNS_TCP_MAX_MSG {
-        return Err(Error::new(
-            ErrorKind::InvalidData,
-            "upstream DNS/TCP response length out of range",
-        ));
+/// Drain guest UDP/53 queries out of the gateway socket. Blocked queries are
+/// answered inline (no host I/O); allowed queries are handed to the DNS offload
+/// thread and their reply context remembered. Returns true if anything was
+/// enqueued (the caller then wakes the relay thread). Never blocks upstream.
+fn dispatch_dns_udp(
+    dns_socket_handle: SocketHandle,
+    sockets: &mut SocketSet<'_>,
+    egress: &EgressPolicy,
+    upstream_dns: Ipv4Addr,
+    gateway: &mut DnsGateway,
+    to_relay: &SyncSender<DnsQuery>,
+) -> bool {
+    let mut queued = false;
+    let socket = sockets.get_mut::<UdpSocket>(dns_socket_handle);
+    while socket.can_recv() {
+        // Copy out the query and the Copy reply-context fields, releasing the
+        // recv borrow before we may re-borrow the socket to answer inline.
+        let (query, endpoint, local_address) = match socket.recv() {
+            Ok((q, m)) => (q.to_vec(), m.endpoint, m.local_address),
+            Err(_) => break,
+        };
+        match classify_dns_query(&query, egress) {
+            DnsDecision::Immediate(response) => {
+                let response_meta = UdpMetadata {
+                    endpoint,
+                    local_address,
+                    meta: Default::default(),
+                };
+                let _ = socket.send_slice(&response, response_meta);
+            }
+            DnsDecision::Forward { learn } => {
+                if gateway.pending_udp.len() >= MAX_PENDING_DNS {
+                    virtio_net_log!("virtio-net: dropping guest DNS query (pending table full)");
+                    continue;
+                }
+                let id = gateway.next_id();
+                gateway.pending_udp.insert(
+                    id,
+                    PendingDnsUdp {
+                        endpoint,
+                        local_address,
+                        learn,
+                    },
+                );
+                match to_relay.try_send(DnsQuery {
+                    id,
+                    transport: DnsTransport::Udp,
+                    upstream: upstream_dns,
+                    query,
+                }) {
+                    Ok(()) => queued = true,
+                    Err(TrySendError::Full(_)) => {
+                        gateway.pending_udp.remove(&id);
+                        virtio_net_log!("virtio-net: dropping guest DNS query (relay queue full)");
+                    }
+                    Err(TrySendError::Disconnected(_)) => {
+                        gateway.pending_udp.remove(&id);
+                        return queued;
+                    }
+                }
+            }
+        }
     }
-    let mut response = vec![0u8; resp_len];
-    stream.read_exact(&mut response)?;
-    Ok(response)
+    queued
+}
+
+/// Deliver answers produced by the DNS offload thread back into the guest-facing
+/// smoltcp sockets. UDP answers are matched by id to their remembered reply
+/// context; TCP answers are matched to the listener whose connection is awaiting
+/// that id. A `None` answer (upstream error/timeout) is dropped for UDP (the
+/// guest sees a normal DNS timeout) and closes the TCP connection empty-handed.
+fn deliver_dns_responses(
+    dns_socket_handle: SocketHandle,
+    dns_tcp_handles: &[SocketHandle],
+    dns_tcp_conns: &mut [DnsTcpConn],
+    sockets: &mut SocketSet<'_>,
+    egress: &EgressPolicy,
+    gateway: &mut DnsGateway,
+    from_relay: &Receiver<DnsResponse>,
+) {
+    while let Ok(response) = from_relay.try_recv() {
+        if let Some(pending) = gateway.pending_udp.remove(&response.id) {
+            if let Some(answer) = response.answer {
+                if pending.learn {
+                    egress.learn_ip_records(&dns::answer_ip_records(&answer));
+                }
+                let socket = sockets.get_mut::<UdpSocket>(dns_socket_handle);
+                let response_meta = UdpMetadata {
+                    endpoint: pending.endpoint,
+                    local_address: pending.local_address,
+                    meta: Default::default(),
+                };
+                let _ = socket.send_slice(&answer, response_meta);
+            }
+            continue;
+        }
+
+        // Otherwise it is a DNS/TCP answer: find the awaiting listener.
+        for (handle, conn) in dns_tcp_handles.iter().zip(dns_tcp_conns.iter_mut()) {
+            match conn.awaiting {
+                Some(pending) if pending.id == response.id => {
+                    conn.awaiting = None;
+                    if let Some(answer) = response.answer {
+                        if pending.learn {
+                            egress.learn_ip_records(&dns::answer_ip_records(&answer));
+                        }
+                        frame_dns_tcp_response(conn, &answer);
+                    }
+                    conn.done = true;
+                    let socket = sockets.get_mut::<tcp::Socket>(*handle);
+                    drain_dns_tcp_tx(socket, conn);
+                    break;
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+/// Append a framed (2-byte length prefix + message) DNS response to a
+/// connection's pending TX buffer.
+fn frame_dns_tcp_response(conn: &mut DnsTcpConn, response: &[u8]) {
+    if let Ok(resp_len) = u16::try_from(response.len()) {
+        conn.tx.extend_from_slice(&resp_len.to_be_bytes());
+        conn.tx.extend_from_slice(response);
+    }
 }
 
 /// Create the pool of smoltcp TCP listening sockets bound to the gateway's
@@ -859,6 +938,17 @@ struct DnsTcpConn {
     tx_sent: usize,
     /// The query has been answered (or rejected); drain `tx` then close.
     done: bool,
+    /// Set once the query has been handed to the DNS offload thread and we are
+    /// waiting for its answer (carries the correlation id + learn flag). While
+    /// set, the connection is parked — `deliver_dns_responses` completes it.
+    awaiting: Option<DnsTcpPending>,
+}
+
+/// Correlation state for a DNS/TCP query parked on the offload thread.
+#[derive(Clone, Copy)]
+struct DnsTcpPending {
+    id: u64,
+    learn: bool,
 }
 
 /// Service the DNS-over-TCP listening sockets: accept a connection, read the
@@ -871,7 +961,10 @@ fn process_dns_tcp(
     sockets: &mut SocketSet<'_>,
     egress: &EgressPolicy,
     upstream_dns: Ipv4Addr,
-) {
+    gateway: &mut DnsGateway,
+    to_relay: &SyncSender<DnsQuery>,
+) -> bool {
+    let mut queued = false;
     for (handle, conn) in handles.iter().zip(conns.iter_mut()) {
         let socket = sockets.get_mut::<tcp::Socket>(*handle);
 
@@ -880,13 +973,19 @@ fn process_dns_tcp(
         // socket is still draining (e.g. TIME-WAIT) the error is ignored and the
         // next poll retries.
         if !socket.is_open() {
-            if !conn.rx.is_empty() || !conn.tx.is_empty() || conn.done {
+            if !conn.rx.is_empty() || !conn.tx.is_empty() || conn.done || conn.awaiting.is_some() {
                 *conn = DnsTcpConn::default();
             }
             let _ = socket.listen(IpListenEndpoint {
                 addr: None,
                 port: DNS_SOCKET_PORT,
             });
+            continue;
+        }
+
+        // Parked awaiting the offload thread's answer: nothing to do here until
+        // `deliver_dns_responses` fills `tx` / sets `done`.
+        if conn.awaiting.is_some() {
             continue;
         }
 
@@ -926,19 +1025,39 @@ fn process_dns_tcp(
                     query.len(),
                     upstream_dns
                 );
-                if let Some(response) = filtered_dns_response(&query, egress, |q| {
-                    forward_dns_query_tcp(upstream_dns, q)
-                }) {
-                    if let Ok(resp_len) = u16::try_from(response.len()) {
-                        conn.tx.extend_from_slice(&resp_len.to_be_bytes());
-                        conn.tx.extend_from_slice(&response);
+                match classify_dns_query(&query, egress) {
+                    DnsDecision::Immediate(response) => {
+                        frame_dns_tcp_response(conn, &response);
+                        conn.done = true;
+                        drain_dns_tcp_tx(socket, conn);
+                    }
+                    DnsDecision::Forward { learn } => {
+                        // Hand the query to the offload thread and park the
+                        // connection; the poll loop stays free.
+                        let id = gateway.next_id();
+                        match to_relay.try_send(DnsQuery {
+                            id,
+                            transport: DnsTransport::Tcp,
+                            upstream: upstream_dns,
+                            query,
+                        }) {
+                            Ok(()) => {
+                                conn.awaiting = Some(DnsTcpPending { id, learn });
+                                queued = true;
+                            }
+                            Err(_) => {
+                                // Relay unavailable/full: close empty-handed
+                                // (guest sees EOF, then retries — DNS semantics).
+                                conn.done = true;
+                                socket.close();
+                            }
+                        }
                     }
                 }
-                conn.done = true;
-                drain_dns_tcp_tx(socket, conn);
             }
         }
     }
+    queued
 }
 
 /// Write as much of the pending framed response as the socket will accept; once

--- a/src/log_rotation.rs
+++ b/src/log_rotation.rs
@@ -41,6 +41,25 @@ pub fn rotate_if_needed(log_path: &Path) -> io::Result<bool> {
 /// Force rotate a log file regardless of size.
 ///
 /// Rotates the log file following the same pattern as `rotate_if_needed`.
+///
+/// The active (live) log is rotated with **copy-truncate** semantics rather
+/// than a rename. The live console log is written by libkrun through an
+/// intentionally-leaked append fd bound to the file's inode for the VM's whole
+/// lifetime (see `KrunFunctions::console_output_to_file`). A `rename` would
+/// leave that leaked fd pointing at the renamed inode (`.1`), so libkrun would
+/// keep appending to `.1` — which then rotates onward and gets deleted, losing
+/// all live output, while `tail agent-console.log` sees a frozen file.
+///
+/// Instead we copy the live file's contents to `.1` and then truncate the
+/// original in place. Because the leaked fd is `O_APPEND`, its next write lands
+/// at offset 0 of the now-empty inode, so the writer stays valid and continues
+/// into the same file. Already-rotated `.1`/`.2`/`.3` files are nobody's live
+/// fd, so they are still shifted with plain renames.
+///
+/// Tradeoff: like `logrotate`'s own `copytruncate`, any bytes written between
+/// the copy and the truncate are lost. We minimise that window by truncating
+/// immediately after the copy; under active writing a tiny loss is the accepted
+/// copy-truncate semantics.
 pub fn rotate(log_path: &Path) -> io::Result<()> {
     let log_str = log_path.display().to_string();
 
@@ -50,7 +69,8 @@ pub fn rotate(log_path: &Path) -> io::Result<()> {
         fs::remove_file(&oldest)?;
     }
 
-    // Rotate existing files: .2 -> .3, .1 -> .2
+    // Rotate existing files: .2 -> .3, .1 -> .2 (plain renames — nothing holds
+    // an open fd to these already-rotated files).
     for i in (1..MAX_LOG_FILES).rev() {
         let from = format!("{}.{}", log_str, i);
         let to = format!("{}.{}", log_str, i + 1);
@@ -59,10 +79,22 @@ pub fn rotate(log_path: &Path) -> io::Result<()> {
         }
     }
 
-    // Move current log to .1
+    // Copy-truncate the live log to .1, preserving the leaked writer fd's inode.
     let first_rotated = format!("{}.1", log_str);
-    fs::rename(log_path, &first_rotated)?;
+    fs::copy(log_path, &first_rotated)?;
+    truncate_in_place(log_path)?;
 
+    Ok(())
+}
+
+/// Truncate a file to zero length in place, keeping its inode (and therefore any
+/// already-open fds) valid. Uses `OpenOptions::write(true).truncate(true)` which
+/// maps to `open(..., O_TRUNC)` — it does not create a new inode.
+fn truncate_in_place(log_path: &Path) -> io::Result<()> {
+    fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(log_path)?;
     Ok(())
 }
 
@@ -145,8 +177,9 @@ mod tests {
         // Force rotate to test the rotation logic
         rotate(&log_path).unwrap();
 
-        // Original file should be gone, .1 should exist
-        assert!(!log_path.exists());
+        // Copy-truncate keeps the live file (now empty) and copies data to .1.
+        assert!(log_path.exists());
+        assert_eq!(fs::metadata(&log_path).unwrap().len(), 0);
         let rotated = dir.path().join("test.log.1");
         assert!(rotated.exists());
     }
@@ -163,8 +196,10 @@ mod tests {
 
         rotate(&log_path).unwrap();
 
-        // Check rotation happened correctly
-        assert!(!log_path.exists());
+        // Check rotation happened correctly. Copy-truncate leaves the live file
+        // present but empty; its data is copied into .1.
+        assert!(log_path.exists());
+        assert_eq!(fs::metadata(&log_path).unwrap().len(), 0);
         assert_eq!(
             fs::read_to_string(dir.path().join("test.log.1")).unwrap(),
             "current"
@@ -225,6 +260,53 @@ mod tests {
         assert!(!log_path.exists());
         assert!(!dir.path().join("test.log.1").exists());
         assert!(!dir.path().join("test.log.2").exists());
+    }
+
+    // Regression test for C2: rotation must not rename the live file out from
+    // under a writer that holds a leaked append fd (as libkrun does for the VM
+    // console). Copy-truncate must keep that fd valid and pointing at the same
+    // inode, so pre-rotation data lands in .1 and post-rotation writes via the
+    // held fd land in the (now truncated) live file — no data lost.
+    #[test]
+    fn test_copytruncate_preserves_open_append_fd() {
+        use std::fs::OpenOptions;
+
+        let dir = TempDir::new().unwrap();
+        let log_path = dir.path().join("agent-console.log");
+
+        // Open an append fd and keep it open across the rotation, mirroring the
+        // leaked libkrun console fd.
+        let mut writer = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_path)
+            .unwrap();
+
+        writer.write_all(b"before-rotation\n").unwrap();
+        writer.flush().unwrap();
+
+        rotate(&log_path).unwrap();
+
+        // The pre-rotation data was copied into .1.
+        assert_eq!(
+            fs::read_to_string(dir.path().join("agent-console.log.1")).unwrap(),
+            "before-rotation\n"
+        );
+        // The live file still exists (same inode) and was truncated to empty.
+        assert!(log_path.exists());
+        assert_eq!(fs::metadata(&log_path).unwrap().len(), 0);
+
+        // The still-open append fd keeps writing to the same inode; O_APPEND
+        // means the next write lands at offset 0 of the truncated file.
+        writer.write_all(b"after-rotation\n").unwrap();
+        writer.flush().unwrap();
+
+        // Post-rotation data is in the live file, not leaked into .1.
+        assert_eq!(fs::read_to_string(&log_path).unwrap(), "after-rotation\n");
+        assert_eq!(
+            fs::read_to_string(dir.path().join("agent-console.log.1")).unwrap(),
+            "before-rotation\n"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes two availability bugs: log rotation now copy-truncates the live console log so the leaked libkrun writer fd is preserved, and DNS resolution is offloaded to a dedicated relay thread so a slow resolver no longer blocks all guest traffic for up to 2s.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/528">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->