### PR TITLE
Kill a wedged VM identified by its unique boot-config argv so teardown never leaks an untracked live orphan

### DIFF
--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -1982,6 +1982,17 @@ impl AgentManager {
     /// 2. **PID start-time** — strict comparison guards against PID reuse
     ///
     /// If either method confirms identity, sends SIGTERM (then SIGKILL on timeout).
+    /// Path to this VM's `boot-config.json` — the unique per-VM argument passed to
+    /// the `_boot-vm` subprocess. Must mirror the construction at launch (next to
+    /// the storage disk) so a teardown can identify the live VM process by argv.
+    fn boot_config_path(&self) -> std::path::PathBuf {
+        self.storage_disk
+            .path()
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new("/tmp"))
+            .join("boot-config.json")
+    }
+
     /// Returns `Ok(())` if the process is confirmed dead, `Err` if still alive
     /// or identity could not be verified.
     fn stop_vm_process(&self, pid: crate::process::Pid, start_time: Option<u64>) -> Result<()> {
@@ -1995,11 +2006,18 @@ impl AgentManager {
             false
         };
 
-        // Identity check: vsock acknowledgement OR strict PID start-time match.
-        // We intentionally do NOT use the lenient is_our_process() here because
-        // it treats any alive PID as "ours" when start_time is None — which risks
-        // killing an unrelated process if the OS reused the PID.
-        let identity_ok = shutdown_acked || process::is_our_process_strict(pid, start_time);
+        // Identity check: vsock acknowledgement OR strict PID start-time match OR
+        // an argv match on this VM's unique boot-config path. We intentionally do
+        // NOT use the lenient is_our_process() here because it treats any alive
+        // PID as "ours" when start_time is None — which risks killing an unrelated
+        // process if the OS reused the PID. The cmdline fallback is safe for the
+        // same reason it's specific: only our `_boot-vm <this-vm>/boot-config.json`
+        // process carries that exact path, so it recovers the case where the agent
+        // vsock is wedged (no ack) AND the start-time record is missing — the exact
+        // combination that otherwise leaks a live orphan the control can never see.
+        let identity_ok = shutdown_acked
+            || process::is_our_process_strict(pid, start_time)
+            || process::cmdline_contains(pid, &self.boot_config_path().to_string_lossy());
 
         if identity_ok {
             if !process::is_our_process_strict(pid, start_time) {
@@ -2090,12 +2108,22 @@ impl AgentManager {
                 Some((pid, start_time)) => {
                     if process::kill_verified(pid, start_time) {
                         Some(pid)
+                    } else if process::cmdline_contains(
+                        pid,
+                        &self.boot_config_path().to_string_lossy(),
+                    ) {
+                        // Start-time unverifiable, but the live PID's argv carries
+                        // this VM's unique boot-config path — unambiguously ours,
+                        // so kill it rather than leak a live orphan.
+                        process::kill(pid);
+                        Some(pid)
                     } else {
                         if process::is_alive(pid) {
                             tracing::warn!(
                                 pid,
-                                "skipping kill: pid-file PID is alive but start-time \
-                                 unverified (possible PID reuse)"
+                                "skipping kill: pid-file PID is alive but neither \
+                                 start-time nor argv identify it as ours (possible \
+                                 PID reuse)"
                             );
                         }
                         None

--- a/src/process.rs
+++ b/src/process.rs
@@ -2876,9 +2876,6 @@ mod tests {
 
         let _ = child.kill();
         let _ = child.wait();
-        assert!(
-            !cmdline_contains(pid, &token),
-            "a dead PID must not match"
-        );
+        assert!(!cmdline_contains(pid, &token), "a dead PID must not match");
     }
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -1866,6 +1866,61 @@ pub fn kill_verified(pid: Pid, start_time: Option<u64>) -> bool {
     }
 }
 
+/// Identity fallback for our own VM subprocess when start-time can't be verified.
+///
+/// A live VM is `smolvm-bin _boot-vm <this-vm>/boot-config.json`; that config
+/// path is unique per VM, so an alive PID whose argv contains it is unambiguously
+/// our VM — a recycled PID belonging to an unrelated process could not carry that
+/// exact argument. Lets a teardown confidently kill a VM whose agent vsock is
+/// wedged (so no shutdown ack) and whose start-time record is missing, instead of
+/// leaking it as an untracked orphan. Returns false if the PID is dead or its
+/// argv can't be read / doesn't match.
+pub fn cmdline_contains(pid: Pid, needle: &str) -> bool {
+    if needle.is_empty() || !is_alive(pid) {
+        return false;
+    }
+    match read_cmdline(pid) {
+        Some(cmd) => cmd.contains(needle),
+        None => false,
+    }
+}
+
+/// Read a process's argv as a single space-joined string (best-effort).
+#[cfg(target_os = "linux")]
+fn read_cmdline(pid: Pid) -> Option<String> {
+    // /proc/<pid>/cmdline is NUL-separated argv; join with spaces so a
+    // `contains` on a path substring works regardless of arg boundaries.
+    let raw = std::fs::read(format!("/proc/{pid}/cmdline")).ok()?;
+    if raw.is_empty() {
+        return None;
+    }
+    Some(
+        raw.split(|b| *b == 0)
+            .map(|s| String::from_utf8_lossy(s))
+            .collect::<Vec<_>>()
+            .join(" "),
+    )
+}
+
+/// Read a process's argv (macOS: via `ps -o command=`). Best-effort; the orphan
+/// leak this guards is Linux-prod, so macOS just needs to not misfire.
+#[cfg(not(target_os = "linux"))]
+fn read_cmdline(pid: Pid) -> Option<String> {
+    let out = std::process::Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", "command="])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if s.is_empty() {
+        None
+    } else {
+        Some(s)
+    }
+}
+
 /// Gracefully stop a process.
 ///
 /// 1. Sends SIGTERM
@@ -2783,6 +2838,47 @@ mod tests {
         assert!(
             process_stats(i32::MAX as Pid).is_none(),
             "stats for a non-existent PID must be None"
+        );
+    }
+
+    /// A live process's argv is matchable by a unique substring, and a
+    /// non-matching needle / dead PID / empty needle all return false — the
+    /// identity fallback must be specific enough not to misfire.
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[test]
+    fn cmdline_contains_matches_only_its_own_argv() {
+        let token = format!("smolvm-cmdline-probe-{}", std::process::id());
+        // A long-lived process whose argv carries our unique token. The token is
+        // embedded in the `-c` script itself, and the trailing `; :` makes it a
+        // COMPOUND command so the shell can't exec-optimize into `sleep` (which
+        // would drop the shell's argv, and with it our token, on macOS).
+        let mut child = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(format!("sleep 30; : {token}"))
+            .spawn()
+            .expect("spawn sh");
+        let pid = child.id() as Pid;
+        // Give the OS a beat to expose argv.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        assert!(
+            cmdline_contains(pid, &token),
+            "argv containing the unique token must match"
+        );
+        assert!(
+            !cmdline_contains(pid, "a-token-that-is-not-in-argv"),
+            "a non-matching needle must not match"
+        );
+        assert!(
+            !cmdline_contains(pid, ""),
+            "an empty needle must never match"
+        );
+
+        let _ = child.kill();
+        let _ = child.wait();
+        assert!(
+            !cmdline_contains(pid, &token),
+            "a dead PID must not match"
         );
     }
 }


### PR DESCRIPTION
When a VM's agent vsock is unresponsive and its start-time record is missing, teardown refused to kill the process to avoid PID-reuse risk, leaking a live orphan the control plane could never see or reap; matching the process by the unique boot-config path in its argv makes the kill safe and closes the pool-VM drift.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/532">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->