### PR TITLE
Run streamed exec inside the persistent container overlay on image machines so SDK streamed changes survive

### DIFF
--- a/src/embedded/handle.rs
+++ b/src/embedded/handle.rs
@@ -99,18 +99,6 @@ impl VmHandle {
         self.client_mut()?.read_file(path)
     }
 
-    /// Execute a command with streaming stdout/stderr events.
-    pub fn exec_streaming(
-        &mut self,
-        command: Vec<String>,
-        env: Vec<(String, String)>,
-        workdir: Option<String>,
-        timeout: Option<Duration>,
-    ) -> Result<Vec<ExecEvent>> {
-        self.client_mut()?
-            .vm_exec_streaming(command, env, workdir, timeout)
-    }
-
     /// Execute a command, delivering stdout/stderr/exit events LIVE via the
     /// callback as each frame arrives (no buffering). SDKs bridge this to a
     /// language-native iterator (Python generator / JS async iterator).
@@ -124,6 +112,19 @@ impl VmHandle {
     ) -> Result<()> {
         self.client_mut()?
             .vm_exec_streaming_with(command, env, workdir, timeout, on_event)
+    }
+
+    /// Stream a command's output LIVE while running it inside the image's
+    /// container overlay (the `RunConfig` carries the persistent-overlay id).
+    /// The streaming counterpart of `run` — used for image machines so streamed
+    /// execs share the same container filesystem + persistence as non-streaming
+    /// execs, instead of running in the bare agent rootfs.
+    pub fn run_streaming_with<F: FnMut(ExecEvent)>(
+        &mut self,
+        config: RunConfig,
+        on_event: F,
+    ) -> Result<()> {
+        self.client_mut()?.run_streaming_with(config, on_event)
     }
 
     /// Stop the VM and drop the cached agent client.

--- a/src/embedded/runtime.rs
+++ b/src/embedded/runtime.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock, RwLock};
 use std::time::Duration;
 
-use crate::agent::ExecEvent;
+use crate::agent::{ExecEvent, RunConfig};
 use crate::config::RecordState;
 use crate::db::SmolvmDb;
 use crate::embedded::control::{self, MachineSpec};
@@ -204,6 +204,13 @@ impl EmbeddedRuntime {
         handle.read_file(path)
     }
 
+    /// The machine's image, if it is an image (container-workload) machine.
+    /// Streamed execs on such a machine must run inside its persistent container
+    /// overlay so their writes survive — matching non-streaming exec.
+    fn image_of(&self, name: &str) -> Option<String> {
+        self.db.get_vm(name).ok().flatten().and_then(|r| r.image)
+    }
+
     /// Execute a command and collect streaming output events.
     pub fn exec_streaming(
         &self,
@@ -213,9 +220,9 @@ impl EmbeddedRuntime {
         workdir: Option<String>,
         timeout: Option<Duration>,
     ) -> Result<Vec<ExecEvent>> {
-        let handle = self.started_handle(name)?;
-        let mut handle = lock_handle(&handle)?;
-        handle.exec_streaming(command, env, workdir, timeout)
+        let mut events = Vec::new();
+        self.exec_streaming_with(name, command, env, workdir, timeout, |e| events.push(e))?;
+        Ok(events)
     }
 
     /// Execute a command, delivering streaming output events LIVE via the
@@ -230,9 +237,24 @@ impl EmbeddedRuntime {
         timeout: Option<Duration>,
         on_event: F,
     ) -> Result<()> {
+        let image = self.image_of(name);
         let handle = self.started_handle(name)?;
         let mut handle = lock_handle(&handle)?;
-        handle.exec_streaming_with(command, env, workdir, timeout, on_event)
+        match image {
+            // Image machine: stream inside the machine's persistent container
+            // overlay so streamed installs/writes persist across execs and
+            // restarts, like non-streaming exec. Keyed by machine name.
+            Some(image) => {
+                let config = RunConfig::new(image, command)
+                    .with_env(env)
+                    .with_workdir(workdir)
+                    .with_timeout(timeout)
+                    .with_persistent_overlay(Some(name.to_string()));
+                handle.run_streaming_with(config, on_event)
+            }
+            // Bare VM: stream directly against the guest.
+            None => handle.exec_streaming_with(command, env, workdir, timeout, on_event),
+        }
     }
 
     /// Get the child PID if the machine is running.


### PR DESCRIPTION
The embedded runtime's streaming exec ran image machines in the bare agent rootfs, so streamed installs and writes from the SDK exec_stream API were invisible to later execs and lost on restart; it now routes image machines through the persistent container overlay like non-streaming exec, keyed by machine name.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/534">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->