### PR TITLE
Fail closed to a strict egress floor on serve nodes

### DIFF
--- a/crates/smolvm-network/src/egress.rs
+++ b/crates/smolvm-network/src/egress.rs
@@ -118,7 +118,30 @@ enum FloorMode {
 /// Resolve the floor from the deployment context. Read once at policy creation
 /// (never per-packet): explicit local override wins, else fleet ⇒ strict, else
 /// the metadata-only local default.
+/// Parse an explicit `SMOLVM_EGRESS_FLOOR` value into a mode. Returns `None`
+/// for an absent/unrecognized value so the caller falls back to the inferred
+/// default. Pure (no env) so it is unit-testable.
+fn parse_floor_override(v: &str) -> Option<FloorMode> {
+    match v.trim().to_ascii_lowercase().as_str() {
+        "strict" => Some(FloorMode::Strict),
+        "metadata" | "metadata-only" | "metadataonly" => Some(FloorMode::MetadataOnly),
+        "off" | "none" => Some(FloorMode::Off),
+        _ => None,
+    }
+}
+
 fn floor_mode() -> FloorMode {
+    // Explicit override wins (highest precedence). A multi-tenant node sets
+    // `SMOLVM_EGRESS_FLOOR=strict` so the floor is fail-closed and never
+    // silently degrades to metadata-only if `SMOLVM_PUBLISH_ADDR` is missing
+    // from the environment (a dropped unit override, a new provisioner, or a
+    // manual launch must NOT quietly expose the host LAN / control plane /
+    // co-tenants to a guest). `metadata`/`off` allow a deliberate downgrade.
+    if let Ok(v) = std::env::var("SMOLVM_EGRESS_FLOOR") {
+        if let Some(mode) = parse_floor_override(&v) {
+            return mode;
+        }
+    }
     let allow_private = std::env::var("SMOLVM_EGRESS_ALLOW_PRIVATE")
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
         .unwrap_or(false);
@@ -318,6 +341,25 @@ impl EgressPolicy {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn floor_override_parsing() {
+        assert_eq!(parse_floor_override("strict"), Some(FloorMode::Strict));
+        assert_eq!(parse_floor_override("  STRICT "), Some(FloorMode::Strict));
+        assert_eq!(
+            parse_floor_override("metadata"),
+            Some(FloorMode::MetadataOnly)
+        );
+        assert_eq!(
+            parse_floor_override("metadata-only"),
+            Some(FloorMode::MetadataOnly)
+        );
+        assert_eq!(parse_floor_override("off"), Some(FloorMode::Off));
+        assert_eq!(parse_floor_override("none"), Some(FloorMode::Off));
+        // Unrecognized falls through to the inferred default (None).
+        assert_eq!(parse_floor_override(""), None);
+        assert_eq!(parse_floor_override("yes"), None);
+    }
 
     #[test]
     fn unrestricted_allows_everything() {

--- a/crates/smolvm-network/src/egress.rs
+++ b/crates/smolvm-network/src/egress.rs
@@ -115,9 +115,6 @@ enum FloorMode {
     Strict,
 }
 
-/// Resolve the floor from the deployment context. Read once at policy creation
-/// (never per-packet): explicit local override wins, else fleet ⇒ strict, else
-/// the metadata-only local default.
 /// Parse an explicit `SMOLVM_EGRESS_FLOOR` value into a mode. Returns `None`
 /// for an absent/unrecognized value so the caller falls back to the inferred
 /// default. Pure (no env) so it is unit-testable.
@@ -130,6 +127,9 @@ fn parse_floor_override(v: &str) -> Option<FloorMode> {
     }
 }
 
+/// Resolve the floor from the deployment context. Read once at policy creation
+/// (never per-packet): explicit `SMOLVM_EGRESS_FLOOR` override wins, else the
+/// `ALLOW_PRIVATE` opt-out, else fleet ⇒ strict, else the metadata-only default.
 fn floor_mode() -> FloorMode {
     // Explicit override wins (highest precedence). A multi-tenant node sets
     // `SMOLVM_EGRESS_FLOOR=strict` so the floor is fail-closed and never

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -183,6 +183,18 @@ impl ServeStartCmd {
             }
         }
 
+        // Default-on, fail-closed: a `serve` node hosts untrusted tenant guests,
+        // so force the STRICT egress floor (blocks cloud metadata, host LAN, the
+        // control plane, loopback, and co-resident tenants) rather than inferring
+        // it from `SMOLVM_PUBLISH_ADDR`. A dropped publish-addr must NOT silently
+        // downgrade the floor to metadata-only and expose the host loopback door
+        // to a guest. Single-tenant/self-host operators can opt down with
+        // `SMOLVM_EGRESS_FLOOR=metadata|off`. Inherited by the spawned `_boot-vm`.
+        if std::env::var_os("SMOLVM_EGRESS_FLOOR").is_none() {
+            std::env::set_var("SMOLVM_EGRESS_FLOOR", "strict");
+            tracing::info!("egress floor set to strict (multi-tenant serve default)");
+        }
+
         // Per-VM uid isolation preflight. When serve is privileged each VMM drops
         // to its own unprivileged uid (process::vm_drop_ids), containing a
         // guest→VMM escape to one VM. That only works if the data root is


### PR DESCRIPTION
The egress floor previously degraded to metadata-only (RFC1918/loopback reachable) whenever SMOLVM_PUBLISH_ADDR was unset, so a dropped env var silently exposed the host LAN and the loopback control door to guests; serve now forces a strict floor via a new SMOLVM_EGRESS_FLOOR override that operators can deliberately opt down.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/536">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->