### PR TITLE
Validate content digests before they become filesystem paths

### DIFF
--- a/crates/smolvm-pack/src/assets.rs
+++ b/crates/smolvm-pack/src/assets.rs
@@ -28,6 +28,16 @@ fn digest_to_filename(digest: &str) -> Result<String> {
             ),
         )));
     }
+    // The filename becomes `layers/{hex}.tar` joined onto the staging dir, so
+    // the digest MUST be pure hex — otherwise a malicious `.smolmachine` with a
+    // digest like `sha256:../../evil` would write the layer bytes outside the
+    // staging root (path traversal). A real content digest is always hex.
+    if !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(PackError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("digest is not valid hex: '{}'", digest),
+        )));
+    }
     Ok(format!("{}.tar", hex))
 }
 
@@ -722,6 +732,27 @@ pub fn crc32_file_range(path: &Path, offset: u64, size: u64) -> Result<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn digest_to_filename_rejects_path_traversal() {
+        // A valid hex digest is accepted.
+        assert_eq!(
+            digest_to_filename("sha256:abcdef012345").unwrap(),
+            "abcdef012345.tar"
+        );
+        // Non-hex / traversal digests are rejected before becoming a path.
+        for bad in [
+            "sha256:../../../../etc/evil",
+            "sha256:..%2f..%2fevil",
+            "sha256:abc/def/ghij",
+            "sha256:abcdefabcdeZ",
+        ] {
+            assert!(
+                digest_to_filename(bad).is_err(),
+                "should reject non-hex digest: {bad}"
+            );
+        }
+    }
 
     #[test]
     fn test_find_last_data_byte_all_zero() {

--- a/crates/smolvm-registry/src/pull.rs
+++ b/crates/smolvm-registry/src/pull.rs
@@ -62,6 +62,12 @@ pub async fn pull(
     let digest = &layer.digest;
     let size = layer.size;
 
+    // Validate the digest format BEFORE it is used to build any cache filesystem
+    // path. `BlobCache::blob_path` only does `digest.replace(':', "_")`, leaving
+    // `/` and `..` intact, so an attacker-controlled manifest digest could
+    // otherwise create a `.partial` file or touch atime outside the cache dir.
+    crate::client::validate_digest(digest)?;
+
     // 3. Check cache.
     if let Some(cached_path) = cache.get(digest) {
         tracing::info!(digest = %digest, "blob found in cache");


### PR DESCRIPTION
A malicious .smolmachine or manifest could put path-traversal characters in a layer/blob digest that pack and the registry cache turned straight into a file path; both now require the digest be well-formed hex before it is used, so a crafted digest can no longer write or touch files outside the staging/cache directory.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/537">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->