### PR TITLE
Add /dev/kmsg to the container device set so nested Kubernetes works out of the box

### DIFF
--- a/crates/smolvm-agent/src/oci.rs
+++ b/crates/smolvm-agent/src/oci.rs
@@ -970,6 +970,22 @@ fn default_devices() -> Vec<OciDevice> {
             uid: Some(0),
             gid: Some(0),
         },
+        // /dev/kmsg - kernel log device. The kubelet (k3s/k3d, kind, most
+        // Kubernetes-in-Docker) hard-requires it and refuses to start without
+        // it ("failed to create kubelet: open /dev/kmsg: no such file or
+        // directory"). Bare VMs get it from devtmpfs, but the container /dev is
+        // built from this list, so add it here so nested Kubernetes works out
+        // of the box. Each machine is its own microVM, so exposing its kernel
+        // log to the container is not a cross-tenant concern.
+        OciDevice {
+            device_type: "c".to_string(),
+            path: "/dev/kmsg".to_string(),
+            major: 1,
+            minor: 11,
+            file_mode: Some(0o644),
+            uid: Some(0),
+            gid: Some(0),
+        },
     ]
 }
 
@@ -1204,6 +1220,17 @@ mod tests {
         assert!(spec.process.env.contains(&"HOME=/root".to_string()));
         assert!(!spec.process.terminal);
         assert!(spec.process.console_size.is_none());
+
+        // /dev/kmsg (1:11) must be in the container's device set — the kubelet
+        // (k3s/k3d, kind) refuses to start without it, so nested Kubernetes
+        // works out of the box.
+        let kmsg = spec
+            .linux
+            .devices
+            .iter()
+            .find(|d| d.path == "/dev/kmsg")
+            .expect("/dev/kmsg device present");
+        assert_eq!((kmsg.device_type.as_str(), kmsg.major, kmsg.minor), ("c", 1, 11));
     }
 
     #[test]

--- a/crates/smolvm-agent/src/oci.rs
+++ b/crates/smolvm-agent/src/oci.rs
@@ -1230,7 +1230,10 @@ mod tests {
             .iter()
             .find(|d| d.path == "/dev/kmsg")
             .expect("/dev/kmsg device present");
-        assert_eq!((kmsg.device_type.as_str(), kmsg.major, kmsg.minor), ("c", 1, 11));
+        assert_eq!(
+            (kmsg.device_type.as_str(), kmsg.major, kmsg.minor),
+            ("c", 1, 11)
+        );
     }
 
     #[test]

--- a/examples/docker-in-vm/docker.smolfile
+++ b/examples/docker-in-vm/docker.smolfile
@@ -77,6 +77,26 @@
 #
 #   smolvm machine exec -i --name docker -- docker run --rm -i alpine sh
 #
+# ── Kubernetes (K3d / kind) ───────────────────────────────────────────────────
+#
+#   The guest kernel + this setup run k3s. The engine now creates /dev/kmsg in
+#   the container /dev (the kubelet hard-requires it), so K3d works with no extra
+#   prep beyond a running dockerd:
+#
+#     smolvm machine exec --name docker -- sh -c '
+#       curl -sL https://github.com/k3d-io/k3d/releases/latest/download/k3d-linux-$(uname -m | sed s/aarch64/arm64/;s/x86_64/amd64/) -o /usr/local/bin/k3d
+#       chmod +x /usr/local/bin/k3d
+#       k3d cluster create dev --no-lb
+#       kubectl get nodes'          # -> node Ready
+#
+# ── Cloud (smolmachines) note ─────────────────────────────────────────────────
+#
+#   On the cloud platform each `exec` runs in its own mount namespace, so the
+#   `mount --bind` above is invisible to dockerd. Point docker's data-root
+#   straight at the ext4 disk instead:
+#
+#     dockerd --data-root=/storage/docker --storage-driver=overlay2
+#
 # ── Stop ─────────────────────────────────────────────────────────────────────
 #
 #   smolvm machine stop --name docker


### PR DESCRIPTION
Image-based machines built their container /dev from a fixed device list that lacked /dev/kmsg, so the kubelet refused to start (open /dev/kmsg: no such file or directory) and K3d/kind clusters failed; adding the device (char 1:11) lets a k3s node reach Ready with no manual prep, and the docker-in-vm example gains K3d plus a cloud data-root note.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/538">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->