### PR TITLE
Bump the engine to 1.3.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2164,7 +2164,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smolfile"
-version = "1.3.8"
+version = "1.3.9"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -2190,7 +2190,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.3.8"
+version = "1.3.9"
 dependencies = [
  "async-stream",
  "axum",
@@ -2243,7 +2243,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-agent"
-version = "1.3.8"
+version = "1.3.9"
 dependencies = [
  "lazy_static",
  "libc",
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-network"
-version = "1.3.8"
+version = "1.3.9"
 dependencies = [
  "crossbeam-queue",
  "humantime",
@@ -2288,7 +2288,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-pack"
-version = "1.3.8"
+version = "1.3.9"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -2307,7 +2307,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.3.8"
+version = "1.3.9"
 dependencies = [
  "base64",
  "serde",
@@ -2317,7 +2317,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.3.8"
+version = "1.3.9"
 dependencies = [
  "bytes",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 
 [package]
 name = "smolvm"
-version = "1.3.8"
+version = "1.3.9"
 edition = "2021"
 description = "OCI-native microVM runtime"
 license = "Apache-2.0"

--- a/crates/smolvm-agent/Cargo.toml
+++ b/crates/smolvm-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-agent"
-version = "1.3.8"
+version = "1.3.9"
 edition = "2021"
 description = "Guest agent for smolvm VMs (handles OCI operations and command execution)"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ name = "smolvm-agent"
 path = "src/main.rs"
 
 [dependencies]
-smolvm-protocol = { path = "../smolvm-protocol", version = "1.3.8" }
+smolvm-protocol = { path = "../smolvm-protocol", version = "1.3.9" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/crates/smolvm-network/Cargo.toml
+++ b/crates/smolvm-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-network"
-version = "1.3.8"
+version = "1.3.9"
 edition = "2021"
 description = "Host-side virtio-net runtime for smolvm"
 license = "Apache-2.0"

--- a/crates/smolvm-pack/Cargo.toml
+++ b/crates/smolvm-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-pack"
-version = "1.3.8"
+version = "1.3.9"
 edition = "2021"
 description = "Single-binary packaging for smolvm"
 license = "Apache-2.0"
@@ -10,7 +10,7 @@ repository = "https://github.com/smol-machines/smolvm"
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-smolvm-protocol = { path = "../smolvm-protocol", version = "1.3.8" }
+smolvm-protocol = { path = "../smolvm-protocol", version = "1.3.9" }
 tar = "0.4"
 zstd = "0.13"
 crc32fast = "1.4"

--- a/crates/smolvm-protocol/Cargo.toml
+++ b/crates/smolvm-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-protocol"
-version = "1.3.8"
+version = "1.3.9"
 edition = "2021"
 description = "Protocol types for smolvm host-guest communication"
 license = "Apache-2.0"

--- a/crates/smolvm-registry/Cargo.toml
+++ b/crates/smolvm-registry/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "smolvm-registry"
-version = "1.3.8"
+version = "1.3.9"
 edition = "2021"
 description = "OCI Distribution client for smolmachines registry"
 license = "Apache-2.0"
 repository = "https://github.com/smol-machines/smolvm"
 
 [dependencies]
-smolvm-pack = { path = "../smolvm-pack", version = "1.3.8" }
+smolvm-pack = { path = "../smolvm-pack", version = "1.3.9" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "json"] }
 sha2 = "0.10"
 bytes = "1"

--- a/crates/smolvm-smolfile/Cargo.toml
+++ b/crates/smolvm-smolfile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolfile"
-version = "1.3.8"
+version = "1.3.9"
 edition = "2021"
 description = "Smolfile specification and parser for smolvm microVM workloads"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ keywords = ["smolvm", "microvm", "configuration"]
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 thiserror = "1"
-smolvm-protocol = { path = "../smolvm-protocol", version = "1.3.8" }
+smolvm-protocol = { path = "../smolvm-protocol", version = "1.3.9" }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
Cuts engine 1.3.9, whose agent adds /dev/kmsg to the container device set so the kubelet runs and nested Kubernetes (K3d, kind) works out of the box; the release pipeline rebuilds the agent and agent-rootfs from this tag.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/539">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->