### PR TITLE
Propagate host file changes into the guest as fsnotify events for -v mounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,6 +410,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,6 +701,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futures"
@@ -1154,6 +1172,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea94e891b3606826e9c998be69ddca42247dad8ad50b1649a5cb7e1c9ae06fd"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1190,6 +1228,26 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
 ]
 
 [[package]]
@@ -1388,6 +1446,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
@@ -1420,6 +1490,25 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.13.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2207,6 +2296,7 @@ dependencies = [
  "libloading",
  "metrics",
  "metrics-exporter-prometheus",
+ "notify",
  "parking_lot",
  "pkg-config",
  "regex",
@@ -2533,7 +2623,7 @@ checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.2.1",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,9 @@ socket2 = "0.6"
 dirs = "5"
 sha2 = "0.10"
 hex = "0.4"
+# Host filesystem watcher (FSEvents on macOS, inotify on Linux) that drives
+# host→guest fsnotify propagation for -v mounts. See src/agent/fsnotify_watch.rs.
+notify = "6"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -9,8 +9,8 @@
 //! Communication is via vsock on port 6000.
 
 use smolvm_protocol::{
-    error_codes, guest_env, ports, AgentRequest, AgentResponse, Envelope, RegistryAuth,
-    AGENT_READY_MARKER, LAYER_CHUNK_SIZE, PROTOCOL_VERSION,
+    error_codes, guest_env, ports, AgentRequest, AgentResponse, Envelope, FsNotifyEvent,
+    RegistryAuth, AGENT_READY_MARKER, LAYER_CHUNK_SIZE, PROTOCOL_VERSION,
 };
 use std::io::{Read, Write};
 use std::os::unix::io::AsRawFd;
@@ -1711,6 +1711,48 @@ fn patch_timeout_ms(request: &mut AgentRequest, raw: &[u8]) {
 }
 
 /// Handle a single connection.
+/// Replay host-originated filesystem changes as guest fsnotify events.
+///
+/// Writes one `"<mask_hex> <path>\n"` line per event to `/proc/smolvm-fsnotify`
+/// (provided by the libkrunfw kernel patch), which resolves the path and fires
+/// the matching fsnotify event on the guest inode. Because the container's view
+/// of a `-v` mount is a bind of the same virtiofs inode, a watcher inside the
+/// container wakes up exactly as if the change had happened in the guest.
+///
+/// Best-effort: a path that no longer resolves (e.g. a delete arriving after the
+/// host watcher already saw the unlink) is skipped, not fatal. Returns the count
+/// of events that fired.
+fn handle_fsnotify(events: &[FsNotifyEvent]) -> AgentResponse {
+    const PROC_PATH: &str = "/proc/smolvm-fsnotify";
+
+    let mut file = match std::fs::OpenOptions::new().write(true).open(PROC_PATH) {
+        Ok(f) => f,
+        Err(e) => {
+            // Kernel without the patch (older libkrunfw): degrade gracefully so
+            // hosts on new + old kernels both work — the mount still serves
+            // reads, only event delivery is unavailable.
+            debug!(error = %e, "fsnotify inject unavailable ({PROC_PATH} missing)");
+            return AgentResponse::ok_with_data(
+                serde_json::json!({ "fired": 0, "supported": false }),
+            );
+        }
+    };
+
+    let mut fired = 0u32;
+    for ev in events {
+        // Each write() is one event; the kernel handler parses exactly one line.
+        let line = format!("{:x} {}\n", ev.mask, ev.path);
+        match file.write_all(line.as_bytes()) {
+            Ok(()) => fired += 1,
+            Err(e) => {
+                debug!(path = %ev.path, mask = ev.mask, error = %e, "fsnotify inject skipped")
+            }
+        }
+    }
+
+    AgentResponse::ok_with_data(serde_json::json!({ "fired": fired, "supported": true }))
+}
+
 fn handle_connection(stream: &mut impl ReadWrite) -> Result<(), Box<dyn std::error::Error>> {
     let mut buf = vec![0u8; REQUEST_BUFFER_SIZE];
 
@@ -1955,6 +1997,8 @@ fn handle_request(
         AgentRequest::Ping => AgentResponse::Pong {
             version: PROTOCOL_VERSION,
         },
+
+        AgentRequest::FsNotify { events } => handle_fsnotify(&events),
 
         // Pull is handled separately in handle_streaming_pull for progress streaming
         AgentRequest::Pull { .. } => unreachable!("Pull handled before match"),

--- a/crates/smolvm-protocol/src/lib.rs
+++ b/crates/smolvm-protocol/src/lib.rs
@@ -135,6 +135,39 @@ pub mod cid {
     pub const ANY: u32 = u32::MAX;
 }
 
+/// fsnotify event masks, mirroring the kernel's `FS_*` bits in
+/// `include/linux/fsnotify_backend.h`. Shared by the host watcher (which maps a
+/// host filesystem event to one of these) and the guest agent (which forwards
+/// the raw bits to `/proc/smolvm-fsnotify`). Only the subset relevant to
+/// file-watching tools is defined.
+pub mod fsnotify_mask {
+    /// File was modified.
+    pub const FS_MODIFY: u32 = 0x0000_0002;
+    /// Metadata changed (chmod/chown/utimes).
+    pub const FS_ATTRIB: u32 = 0x0000_0004;
+    /// Writable file was closed.
+    pub const FS_CLOSE_WRITE: u32 = 0x0000_0008;
+    /// File was moved away from the watched dir.
+    pub const FS_MOVED_FROM: u32 = 0x0000_0040;
+    /// File was moved into the watched dir.
+    pub const FS_MOVED_TO: u32 = 0x0000_0080;
+    /// Subfile was created.
+    pub const FS_CREATE: u32 = 0x0000_0100;
+    /// Subfile was deleted.
+    pub const FS_DELETE: u32 = 0x0000_0200;
+    /// Event occurred against a directory.
+    pub const FS_ISDIR: u32 = 0x4000_0000;
+}
+
+/// A single host-originated filesystem change to replay into the guest.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FsNotifyEvent {
+    /// Guest-side absolute path the event occurred on (virtiofs staging path).
+    pub path: String,
+    /// `fsnotify_mask::FS_*` bitmask for the event.
+    pub mask: u32,
+}
+
 // ============================================================================
 // Agent Protocol (OCI Operations)
 // ============================================================================
@@ -145,6 +178,22 @@ pub mod cid {
 pub enum AgentRequest {
     /// Ping to check if agent is alive.
     Ping,
+
+    /// Inject host-originated fsnotify events into the guest.
+    ///
+    /// virtiofs does not deliver host-side file changes to the guest as
+    /// fsnotify/inotify events, so inotify-based hot-reload (Vite, webpack,
+    /// nodemon) never fires when a mounted file is edited on the host. The host
+    /// watches the mount source and sends the resulting events here; the agent
+    /// writes them to `/proc/smolvm-fsnotify`, which fires the matching event on
+    /// the guest inode so watchers on the (bind-mounted) container path wake up.
+    /// Each `path` is a guest-side absolute path (the virtiofs staging path),
+    /// `mask` an `fsnotify_mask::FS_*` bitmask.
+    FsNotify {
+        /// Host-originated filesystem changes to replay as guest fsnotify events.
+        #[serde(default)]
+        events: Vec<FsNotifyEvent>,
+    },
 
     /// Pull an OCI image and extract layers.
     Pull {
@@ -407,6 +456,7 @@ impl AgentRequest {
     pub fn log_summary(&self) -> String {
         match self {
             AgentRequest::Ping => "Ping".into(),
+            AgentRequest::FsNotify { events } => format!("FsNotify {{ count: {} }}", events.len()),
             AgentRequest::Pull { image, .. } => format!("Pull {{ image: {image} }}"),
             AgentRequest::Query { image, .. } => format!("Query {{ image: {image} }}"),
             AgentRequest::ListImages => "ListImages".into(),

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -9,9 +9,9 @@ use crate::registry::{extract_registry, rewrite_image_registry, RegistryAuth};
 use crate::settings::SmolSettings;
 use smolvm_protocol::normalize_image_ref;
 use smolvm_protocol::{
-    encode_message, AgentRequest, AgentResponse, Envelope, ImageInfo, OverlayInfo, StorageStatus,
-    FILE_TRANSFER_MAX_TOTAL, FILE_WRITE_CHUNK_SIZE, FILE_WRITE_SINGLE_SHOT_MAX, MAX_FRAME_SIZE,
-    PROTOCOL_VERSION,
+    encode_message, AgentRequest, AgentResponse, Envelope, FsNotifyEvent, ImageInfo, OverlayInfo,
+    StorageStatus, FILE_TRANSFER_MAX_TOTAL, FILE_WRITE_CHUNK_SIZE, FILE_WRITE_SINGLE_SHOT_MAX,
+    MAX_FRAME_SIZE, PROTOCOL_VERSION,
 };
 use std::io::{Read, Write};
 use std::path::Path;
@@ -599,6 +599,21 @@ impl AgentClient {
             }
             AgentResponse::Error { message, .. } => Err(Error::agent("ping", message)),
             _ => Err(Error::agent("ping", "unexpected response type")),
+        }
+    }
+
+    /// Replay host-originated filesystem changes into the guest as fsnotify
+    /// events so inotify-based watchers on `-v` mounts fire. Used by the host
+    /// [`FsNotifyWatcher`](super::FsNotifyWatcher); a stale connection surfaces as
+    /// an error the watcher treats as "VM gone, stop".
+    pub fn fsnotify(&mut self, events: Vec<FsNotifyEvent>) -> Result<()> {
+        if events.is_empty() {
+            return Ok(());
+        }
+        match self.request(&AgentRequest::FsNotify { events })? {
+            AgentResponse::Ok { .. } => Ok(()),
+            AgentResponse::Error { message, .. } => Err(Error::agent("fsnotify", message)),
+            _ => Err(Error::agent("fsnotify", "unexpected response type")),
         }
     }
 

--- a/src/agent/fsnotify_watch.rs
+++ b/src/agent/fsnotify_watch.rs
@@ -1,0 +1,338 @@
+//! Host → guest fsnotify propagation for `-v` mounts.
+//!
+//! virtiofs serves file *contents* to the guest, but it does not deliver
+//! host-side change *notifications*. A file-watcher inside the guest (Vite,
+//! webpack, nodemon, `inotifywait`) therefore never fires when a mounted file is
+//! edited on the host — the classic reason "hot reload doesn't work in a
+//! container on macOS". Because smolvm ships its own guest kernel (libkrunfw),
+//! we can close this gap end to end:
+//!
+//! 1. This watcher runs on the host, watching each mounted source directory via
+//!    the OS-native mechanism (FSEvents on macOS, inotify on Linux).
+//! 2. For every change it maps the host path to the guest-side virtiofs path and
+//!    sends it to the agent over a dedicated vsock connection
+//!    ([`AgentRequest::FsNotify`]).
+//! 3. The agent writes it to `/proc/smolvm-fsnotify` (a libkrunfw kernel patch),
+//!    which fires the matching fsnotify event on the guest inode.
+//!
+//! Because the container's view of a `-v` mount is a bind of the same virtiofs
+//! inode, a watcher inside the container wakes up exactly as if the change had
+//! happened locally.
+//!
+//! The watcher is best-effort and self-contained: if the kernel lacks the patch,
+//! or the connection drops when the VM exits, propagation simply stops — the
+//! mount still serves reads. Dropping [`FsNotifyWatcher`] stops the thread.
+
+use crate::agent::AgentClient;
+use crate::data::storage::HostMount;
+use notify::{Event, EventKind, RecursiveMode, Watcher};
+use smolvm_protocol::{fsnotify_mask, FsNotifyEvent};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
+use std::sync::Arc;
+use std::thread::JoinHandle;
+use std::time::Duration;
+use tracing::{debug, info, warn};
+
+/// Guest mountpoint root for virtiofs devices. MUST match the agent's
+/// `paths::VIRTIOFS_MOUNT_ROOT` — the agent stages each `-v` device at
+/// `<root>/smolvm{index}` and binds it into the container, so events fired on
+/// that path reach the container's bind of the same inode.
+const GUEST_VIRTIOFS_ROOT: &str = "/mnt/virtiofs";
+
+/// How long to coalesce a burst of change events before sending. An editor save
+/// typically emits several events (write, close, attrib); batching de-dupes them
+/// into one round-trip while keeping latency well under a human-perceptible
+/// reload delay.
+const COALESCE_WINDOW: Duration = Duration::from_millis(25);
+
+/// A single watched mount: host source directory → guest virtiofs staging base.
+struct WatchTarget {
+    host_source: PathBuf,
+    /// e.g. `/mnt/virtiofs/smolvm0`
+    guest_base: String,
+}
+
+/// Propagates host file changes under `-v` mounts into the guest as fsnotify
+/// events for the lifetime of the value. Drop to stop.
+pub struct FsNotifyWatcher {
+    stop: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl FsNotifyWatcher {
+    /// Start watching the source directory of every mount and replaying changes
+    /// into the guest. `mounts` must be in the same order passed to VM start, so
+    /// index `i` maps to virtiofs tag `smolvm{i}`.
+    ///
+    /// Returns `None` (non-fatal) when there is nothing to watch or the watcher
+    /// thread can't be spawned — the mount still works, only live change
+    /// notifications are unavailable.
+    pub fn start(socket_path: PathBuf, mounts: &[HostMount]) -> Option<Self> {
+        // Opt-out escape hatch: setting SMOL_NO_HOT_RELOAD disables host FS
+        // watching entirely (e.g. very large trees, or privacy preference).
+        if std::env::var_os("SMOL_NO_HOT_RELOAD").is_some() {
+            return None;
+        }
+
+        // Only directories can be recursively watched; a file-target mount (rare)
+        // is skipped. Read-only mounts are still watched: the host may edit them
+        // (that is exactly the read-only-source hot-reload case).
+        let targets: Vec<WatchTarget> = mounts
+            .iter()
+            .enumerate()
+            .filter(|(_, m)| m.source.is_dir())
+            .map(|(i, m)| WatchTarget {
+                host_source: m.source.clone(),
+                guest_base: format!("{GUEST_VIRTIOFS_ROOT}/smolvm{i}"),
+            })
+            .collect();
+        if targets.is_empty() {
+            return None;
+        }
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_thread = stop.clone();
+        let handle = std::thread::Builder::new()
+            .name("fsnotify-watch".into())
+            .spawn(move || run_watch(socket_path, targets, stop_thread))
+            .ok()?;
+
+        Some(Self {
+            stop,
+            handle: Some(handle),
+        })
+    }
+}
+
+impl Drop for FsNotifyWatcher {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+/// Watcher thread body: owns the OS watcher + a dedicated agent connection.
+fn run_watch(socket_path: PathBuf, targets: Vec<WatchTarget>, stop: Arc<AtomicBool>) {
+    let (tx, rx) = mpsc::channel::<notify::Result<Event>>();
+
+    let mut watcher = match notify::recommended_watcher(move |res| {
+        // The receiver is dropped only when this thread exits, so a send error
+        // just means we're shutting down.
+        let _ = tx.send(res);
+    }) {
+        Ok(w) => w,
+        Err(e) => {
+            warn!(error = %e, "failed to create host fs watcher; hot-reload propagation disabled");
+            return;
+        }
+    };
+
+    for t in &targets {
+        if let Err(e) = watcher.watch(&t.host_source, RecursiveMode::Recursive) {
+            warn!(path = %t.host_source.display(), error = %e, "failed to watch mount source");
+        }
+    }
+
+    // A dedicated connection so injected events never interleave with the
+    // command's own request/response stream on the primary connection.
+    let mut client = match AgentClient::connect_with_retry(&socket_path) {
+        Ok(c) => c,
+        Err(e) => {
+            debug!(error = %e, "fsnotify watcher could not connect to agent; disabled");
+            return;
+        }
+    };
+
+    info!(
+        mounts = targets.len(),
+        "host→guest fsnotify propagation active (hot-reload)"
+    );
+
+    while !stop.load(Ordering::SeqCst) {
+        // Block briefly so we notice `stop` without a busy loop.
+        let first = match rx.recv_timeout(Duration::from_millis(200)) {
+            Ok(Ok(ev)) => ev,
+            Ok(Err(_)) => continue, // watcher-level error event; ignore
+            Err(mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        };
+
+        let mut batch = Vec::new();
+        collect_events(&first, &targets, &mut batch);
+
+        // Coalesce the rest of the burst (a save fans out into several events).
+        let deadline = std::time::Instant::now() + COALESCE_WINDOW;
+        while let Some(remaining) = deadline.checked_duration_since(std::time::Instant::now()) {
+            match rx.recv_timeout(remaining) {
+                Ok(Ok(ev)) => collect_events(&ev, &targets, &mut batch),
+                Ok(Err(_)) => {}
+                Err(_) => break,
+            }
+        }
+
+        if batch.is_empty() {
+            continue;
+        }
+        dedup(&mut batch);
+
+        if let Err(e) = client.fsnotify(batch) {
+            // The VM has almost certainly gone away (the command exited). Stop
+            // quietly rather than spinning on a dead socket.
+            debug!(error = %e, "fsnotify inject failed; stopping watcher");
+            break;
+        }
+    }
+}
+
+/// Translate one host event into guest-side [`FsNotifyEvent`]s, appended to `out`.
+fn collect_events(event: &Event, targets: &[WatchTarget], out: &mut Vec<FsNotifyEvent>) {
+    for host_path in &event.paths {
+        let Some(t) = targets
+            .iter()
+            .find(|t| host_path.starts_with(&t.host_source))
+        else {
+            continue;
+        };
+        let Ok(rel) = host_path.strip_prefix(&t.host_source) else {
+            continue;
+        };
+        // The watched root itself firing (empty rel) carries no useful child.
+        if rel.as_os_str().is_empty() {
+            continue;
+        }
+
+        if host_path.exists() {
+            // Create/modify/attrib on an existing path: fire directly on it.
+            // fsnotify_dentry() in the guest propagates to the parent dir's
+            // watchers with the child name, so both file- and dir-watches fire.
+            out.push(FsNotifyEvent {
+                path: join_guest(&t.guest_base, rel),
+                mask: mask_for(&event.kind, host_path),
+            });
+        } else if let Some(parent) = rel.parent() {
+            // Deleted / moved away: the exact path no longer resolves in the
+            // guest, so fire a MODIFY on the (still-present) parent directory.
+            // Directory watchers re-scan and observe the removal.
+            out.push(FsNotifyEvent {
+                path: join_guest(&t.guest_base, parent),
+                mask: fsnotify_mask::FS_MODIFY | fsnotify_mask::FS_ISDIR,
+            });
+        }
+    }
+}
+
+/// Join a guest base path with a host-relative path, normalizing separators.
+fn join_guest(base: &str, rel: &Path) -> String {
+    let rel = rel.to_string_lossy();
+    if rel.is_empty() {
+        base.to_string()
+    } else {
+        format!("{base}/{rel}")
+    }
+}
+
+/// Map a notify [`EventKind`] to the closest `FS_*` mask.
+fn mask_for(kind: &EventKind, path: &Path) -> u32 {
+    use notify::event::ModifyKind;
+
+    let base = match kind {
+        EventKind::Create(_) => fsnotify_mask::FS_CREATE,
+        EventKind::Modify(ModifyKind::Metadata(_)) => fsnotify_mask::FS_ATTRIB,
+        // A rename whose destination exists reads as a create in the new dir.
+        EventKind::Modify(ModifyKind::Name(_)) => fsnotify_mask::FS_CREATE,
+        EventKind::Modify(_) => fsnotify_mask::FS_MODIFY,
+        // Anything else that left the file present is treated as a content change
+        // — the safe default that wakes content watchers.
+        _ => fsnotify_mask::FS_MODIFY,
+    };
+
+    if path.is_dir() {
+        base | fsnotify_mask::FS_ISDIR
+    } else {
+        base
+    }
+}
+
+/// Sort + drop duplicate (path, mask) pairs produced within one burst.
+fn dedup(batch: &mut Vec<FsNotifyEvent>) {
+    batch.sort_by(|a, b| a.path.cmp(&b.path).then(a.mask.cmp(&b.mask)));
+    batch.dedup_by(|a, b| a.path == b.path && a.mask == b.mask);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn target() -> WatchTarget {
+        WatchTarget {
+            host_source: PathBuf::from("/host/project"),
+            guest_base: "/mnt/virtiofs/smolvm0".to_string(),
+        }
+    }
+
+    #[test]
+    fn join_guest_maps_relative_paths() {
+        assert_eq!(
+            join_guest("/mnt/virtiofs/smolvm0", Path::new("src/app.js")),
+            "/mnt/virtiofs/smolvm0/src/app.js"
+        );
+        assert_eq!(
+            join_guest("/mnt/virtiofs/smolvm0", Path::new("")),
+            "/mnt/virtiofs/smolvm0"
+        );
+    }
+
+    #[test]
+    fn deleted_path_fires_parent_dir_modify() {
+        // A path that does not exist on disk maps to a MODIFY on its parent.
+        let targets = vec![target()];
+        let ev = Event {
+            kind: EventKind::Remove(notify::event::RemoveKind::File),
+            paths: vec![PathBuf::from("/host/project/src/gone.js")],
+            attrs: Default::default(),
+        };
+        let mut out = Vec::new();
+        collect_events(&ev, &targets, &mut out);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].path, "/mnt/virtiofs/smolvm0/src");
+        assert_eq!(
+            out[0].mask & fsnotify_mask::FS_MODIFY,
+            fsnotify_mask::FS_MODIFY
+        );
+    }
+
+    #[test]
+    fn path_outside_any_mount_is_ignored() {
+        let targets = vec![target()];
+        let ev = Event {
+            kind: EventKind::Modify(notify::event::ModifyKind::Data(
+                notify::event::DataChange::Any,
+            )),
+            paths: vec![PathBuf::from("/somewhere/else/x.js")],
+            attrs: Default::default(),
+        };
+        let mut out = Vec::new();
+        collect_events(&ev, &targets, &mut out);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn dedup_collapses_duplicate_events() {
+        let mut batch = vec![
+            FsNotifyEvent {
+                path: "/a".into(),
+                mask: fsnotify_mask::FS_MODIFY,
+            },
+            FsNotifyEvent {
+                path: "/a".into(),
+                mask: fsnotify_mask::FS_MODIFY,
+            },
+        ];
+        dedup(&mut batch);
+        assert_eq!(batch.len(), 1);
+    }
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -6,6 +6,7 @@
 pub mod boot_config;
 mod client;
 pub mod fork;
+mod fsnotify_watch;
 mod krun;
 mod launcher;
 pub mod launcher_dynamic;
@@ -20,6 +21,7 @@ pub use crate::data::storage::HostMount;
 pub use client::{
     AgentClient, ExecEvent, InteractiveInput, InteractiveOutput, PullOptions, RunConfig,
 };
+pub use fsnotify_watch::FsNotifyWatcher;
 pub use krun::KrunFunctions;
 pub use launcher::{
     create_disk_overlays, find_lib_dir, launch_agent_vm, DiskOverlaySpec, LaunchConfig,


### PR DESCRIPTION
virtiofs serves file contents to the guest but never delivers host-side change notifications, so inotify-based hot-reload (Vite, webpack, nodemon) does not fire when a mounted file is edited on the host — the same limitation every VM-based container runtime has on macOS.

This closes that gap end to end. A host filesystem watcher (FSEvents on macOS, inotify on Linux) watches each -v mount source; for every change it maps the host path to the guest virtiofs staging path and sends it to the agent over a dedicated vsock connection. The agent writes it to /proc/smolvm-fsnotify — a small libkrunfw kernel interface — which fires the matching fsnotify event on the guest inode. Because the container's view of the mount is a bind of the same inode, a watcher inside the container wakes up exactly as if the change happened locally.

Requires the companion libkrunfw kernel patch that adds /proc/smolvm-fsnotify. Without it the feature degrades to a no-op (the mount still serves reads). Set SMOL_NO_HOT_RELOAD to disable the watcher. Validated on macOS: editing a mounted file on the host fires MODIFY/CREATE inside the container.

Pairs with the smol CLI change that starts the watcher for a run's lifetime.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/547">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->