### PR TITLE
Bundle the libkrunfw guest kernel with /proc/smolvm-fsnotify

### DIFF
--- a/.github/workflows/build-libkrun.yml
+++ b/.github/workflows/build-libkrun.yml
@@ -15,6 +15,11 @@ name: Build libkrun (linux, glibc 2.35)
 
 on:
   workflow_dispatch:
+    inputs:
+      rebuild_libkrunfw:
+        description: "Rebuild libkrunfw from source (full guest-kernel rebuild) instead of reusing the committed .so. Needed when a libkrunfw patch changed the guest kernel."
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -40,8 +45,18 @@ jobs:
             /opt/hostedtoolcache/CodeQL 2>/dev/null || true
           df -h / | tail -1
 
-      - name: Build libkrun (SKIP_LIBKRUNFW, GPU=1)
-        run: SKIP_LIBKRUNFW=1 GPU=1 ./scripts/build-libkrun-linux.sh
+      # By default reuse the committed libkrunfw.so (skips the multi-minute guest
+      # kernel rebuild). When a libkrunfw patch changed the guest kernel, dispatch
+      # with rebuild_libkrunfw=true so libkrunfw.so is rebuilt from the submodule
+      # source and picked up here.
+      - name: Build libkrun (GPU=1)
+        run: |
+          if [ "${{ inputs.rebuild_libkrunfw }}" = "true" ]; then
+            echo "Rebuilding libkrunfw from source"
+            GPU=1 ./scripts/build-libkrun-linux.sh
+          else
+            SKIP_LIBKRUNFW=1 GPU=1 ./scripts/build-libkrun-linux.sh
+          fi
 
       - name: Assert glibc floor <= 2.35
         run: |

--- a/.github/workflows/build-libkrun.yml
+++ b/.github/workflows/build-libkrun.yml
@@ -75,3 +75,37 @@ jobs:
           name: libkrun-linux-${{ matrix.arch }}
           path: lib/linux-${{ matrix.arch }}/
           if-no-files-found: error
+
+  # Cross-build the Windows libkrunfw.dll (guest kernel wrapped for a Windows
+  # host) with mingw-w64 on Linux. The kernel builds with native gcc; only the
+  # final bundle link uses the mingw toolchain (Makefile OS=Windows path). Only
+  # runs when refreshing libkrunfw, since the .dll wraps the guest kernel.
+  windows-libkrunfw:
+    name: libkrunfw.dll (windows cross)
+    if: ${{ inputs.rebuild_libkrunfw }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          lfs: false
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
+            /opt/hostedtoolcache/CodeQL 2>/dev/null || true
+
+      - name: Install build + mingw toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y make gcc bc bison flex libelf-dev libssl-dev \
+            python3-pyelftools curl xz-utils cpio kmod gcc-mingw-w64-x86-64
+
+      - name: Build libkrunfw.dll (mingw cross)
+        run: cd libkrunfw && make OS=Windows -j"$(nproc)"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: libkrunfw-windows-x86_64
+          path: libkrunfw/libkrunfw.dll
+          if-no-files-found: error

--- a/lib/libkrun.provenance
+++ b/lib/libkrun.provenance
@@ -3,4 +3,4 @@
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
 libkrun=6687f4d5b89bf7b6cd0e1cf92889fad81a00238d
-libkrunfw=392573f22f46bb1f2c864476ba3764170fe29507
+libkrunfw=e8f581cdbe758ae7f48322b00b79de599f1291ce

--- a/lib/libkrunfw.5.dylib
+++ b/lib/libkrunfw.5.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:52edcfc959758b08354dd125b4ab8f4d460fb44875b76138862d4cfe51da4f39
+oid sha256:3539cf296df21a64c0b768a2b48ea035bbaaf1c824c45b807ac6e9e8ab49ea11
 size 13118480

--- a/lib/libkrunfw.5.dylib
+++ b/lib/libkrunfw.5.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e2038a8a5c70fa73b28386bb2754deb7f2c3d03bc2ff54efb02e04db012f537d
-size 13243040
+oid sha256:52edcfc959758b08354dd125b4ab8f4d460fb44875b76138862d4cfe51da4f39
+size 13118480

--- a/lib/linux-aarch64/libkrun.provenance
+++ b/lib/linux-aarch64/libkrun.provenance
@@ -3,4 +3,4 @@
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
 libkrun=6687f4d5b89bf7b6cd0e1cf92889fad81a00238d
-libkrunfw=392573f22f46bb1f2c864476ba3764170fe29507
+libkrunfw=e8f581cdbe758ae7f48322b00b79de599f1291ce

--- a/lib/linux-aarch64/libkrunfw.so.5.5.0
+++ b/lib/linux-aarch64/libkrunfw.so.5.5.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:22a8004567a6734b1003305362e41c7b09b9e3a5f7ae8d3c8d162b7553da6326
-size 13305448
+oid sha256:4569f64d735e8bdacffe611a4035eeb93689acded694d50be8dbeb51b47e26b6
+size 13239912

--- a/lib/linux-x86_64/libkrun.provenance
+++ b/lib/linux-x86_64/libkrun.provenance
@@ -3,4 +3,4 @@
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
 libkrun=6687f4d5b89bf7b6cd0e1cf92889fad81a00238d
-libkrunfw=392573f22f46bb1f2c864476ba3764170fe29507
+libkrunfw=e8f581cdbe758ae7f48322b00b79de599f1291ce

--- a/lib/linux-x86_64/libkrunfw.so.5.5.0
+++ b/lib/linux-x86_64/libkrunfw.so.5.5.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4457da98849d6ddc5021bce34798676aa8c446e1cdfe3714a8aeb04046a1e53b
-size 14878304
+oid sha256:abe25057de5dd7087ec49e181c02135b7eea9f3a6cffe6ce04374b928ea714fc
+size 14878392

--- a/lib/windows-x86_64/libkrun.provenance
+++ b/lib/windows-x86_64/libkrun.provenance
@@ -3,4 +3,4 @@
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
 libkrun=6687f4d5b89bf7b6cd0e1cf92889fad81a00238d
-libkrunfw=392573f22f46bb1f2c864476ba3764170fe29507
+libkrunfw=e8f581cdbe758ae7f48322b00b79de599f1291ce

--- a/lib/windows-x86_64/libkrunfw.dll
+++ b/lib/windows-x86_64/libkrunfw.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:927ff74ca150d2e3d204ca506689e8c57db5bf6edab26dd1483f0c340af60756
+oid sha256:82e81b1c1bf789723033c6b66df3fcaccae307b3deb2349edfb3be13209a2cc8
 size 19338676


### PR DESCRIPTION
Ships the guest-kernel interface behind host→guest inotify (hot-reload) so it is present in the bundle, not just on branches.

- Bumps the libkrunfw submodule to the commit that adds /proc/smolvm-fsnotify.
- Ships the rebuilt macOS arm64 libkrunfw.dylib (validated: host edits fire guest inotify).
- Adds a rebuild_libkrunfw dispatch input to build-libkrun.yml to refresh the Linux .so from source (the default still reuses the committed .so to skip the multi-minute kernel rebuild).

Linux x86_64 + aarch64 libkrunfw.so are being rebuilt via the dispatched workflow and will be committed to this branch. Windows libkrunfw.dll rebuild is a follow-up (built out-of-band, matching the existing krun.dll process).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/548">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->