### PR TITLE
Add `cuda` field to Smolfile parser

### DIFF
--- a/crates/smolvm-smolfile/src/lib.rs
+++ b/crates/smolvm-smolfile/src/lib.rs
@@ -22,6 +22,7 @@
 //! | `cpus` | int | No | Number of vCPUs (default: 1). |
 //! | `memory` | int | No | Memory in MiB (default: 256). |
 //! | `net` | bool | No | Enable outbound networking via NAT. |
+//! | `cuda` | bool | No | Enable CUDA-over-vsock (host NVIDIA GPU). |
 //! | `storage` | int | No | Storage disk size in GiB. |
 //! | `overlay` | int | No | Overlay disk size in GiB. |
 //! | `ports` | string[] | No | Port mappings (`"host:guest"`). Prefer `[dev] ports`. |
@@ -237,6 +238,9 @@ pub struct Smolfile {
     /// GPU VRAM (shared memory region) size in MiB. Ignored unless
     /// `gpu = true`. Default comes from `DEFAULT_GPU_VRAM_MIB` (4 GiB).
     pub gpu_vram: Option<u32>,
+    /// Enable CUDA-over-vsock: remote guest CUDA Driver-API calls to the
+    /// host NVIDIA GPU. Linux-only; requires a host NVIDIA driver.
+    pub cuda: Option<bool>,
     /// Storage disk size in GiB.
     pub storage: Option<u64>,
     /// Overlay disk size in GiB.
@@ -539,6 +543,18 @@ protocol = "http"
 
         assert_eq!(sf.auth.unwrap().ssh_agent, Some(true));
         assert_eq!(sf.service.unwrap().port, Some(8080));
+    }
+
+    #[test]
+    fn parse_cuda_field() {
+        let sf = parse("cuda = true").unwrap();
+        assert_eq!(sf.cuda, Some(true));
+
+        let sf = parse("cuda = false").unwrap();
+        assert_eq!(sf.cuda, Some(false));
+
+        let sf = parse("").unwrap();
+        assert_eq!(sf.cuda, None);
     }
 
     #[test]

--- a/src/cli/smolfile.rs
+++ b/src/cli/smolfile.rs
@@ -277,9 +277,7 @@ pub fn build_create_params(
         health_retries,
         health_startup_grace_secs,
         ssh_agent: sf.auth.as_ref().and_then(|a| a.ssh_agent).unwrap_or(false),
-        // No Smolfile field yet; CLI `--cuda` is applied by the caller via
-        // `self.cuda || params.cuda` (mirrors how ssh_agent's CLI override works).
-        cuda: false,
+        cuda: sf.cuda.unwrap_or(false),
         gpu,
         gpu_vram_mib: sf.gpu_vram,
         dns_filter_hosts: if sf_allow_hosts.is_empty() {


### PR DESCRIPTION
Wire `cuda = true` in Smolfile through to CreateVmParams, matching the existing pattern for `gpu` and `net`. The CLI `--cuda` flag still wins via the caller's `self.cuda || params.cuda` merge.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/549">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->