### PR TITLE
Add stream and event ops to CUDA-over-vsock protocol

### DIFF
--- a/crates/smolvm-cuda/src/client.rs
+++ b/crates/smolvm-cuda/src/client.rs
@@ -177,4 +177,46 @@ impl<S: Read + Write> Client<S> {
         self.call(&Request::CtxSynchronize, Op::CtxSynchronize)
             .map(|_| ())
     }
+
+    pub fn stream_create(&mut self, flags: u32) -> Result<u64> {
+        match self.call(&Request::StreamCreate { flags }, Op::StreamCreate)? {
+            Response::Handle(h) => Ok(h),
+            _ => Err(CudaRpcError::Protocol("expected Handle")),
+        }
+    }
+
+    pub fn stream_destroy(&mut self, stream: u64) -> Result<()> {
+        self.call(&Request::StreamDestroy { stream }, Op::StreamDestroy)
+            .map(|_| ())
+    }
+
+    pub fn stream_synchronize(&mut self, stream: u64) -> Result<()> {
+        self.call(
+            &Request::StreamSynchronize { stream },
+            Op::StreamSynchronize,
+        )
+        .map(|_| ())
+    }
+
+    pub fn event_create(&mut self, flags: u32) -> Result<u64> {
+        match self.call(&Request::EventCreate { flags }, Op::EventCreate)? {
+            Response::Handle(h) => Ok(h),
+            _ => Err(CudaRpcError::Protocol("expected Handle")),
+        }
+    }
+
+    pub fn event_destroy(&mut self, event: u64) -> Result<()> {
+        self.call(&Request::EventDestroy { event }, Op::EventDestroy)
+            .map(|_| ())
+    }
+
+    pub fn event_elapsed_time(&mut self, start: u64, end: u64) -> Result<f32> {
+        match self.call(
+            &Request::EventElapsedTime { start, end },
+            Op::EventElapsedTime,
+        )? {
+            Response::Float(ms) => Ok(ms),
+            _ => Err(CudaRpcError::Protocol("expected Float")),
+        }
+    }
 }

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -49,6 +49,12 @@ pub trait Backend: Send {
         params: &[Vec<u8>],
     ) -> CuResult<()>;
     fn ctx_synchronize(&mut self) -> CuResult<()>;
+    fn stream_create(&mut self, flags: u32) -> CuResult<u64>;
+    fn stream_destroy(&mut self, stream: u64) -> CuResult<()>;
+    fn stream_synchronize(&mut self, stream: u64) -> CuResult<()>;
+    fn event_create(&mut self, flags: u32) -> CuResult<u64>;
+    fn event_destroy(&mut self, event: u64) -> CuResult<()>;
+    fn event_elapsed_time(&mut self, start: u64, end: u64) -> CuResult<f32>;
 }
 
 /// Per-connection opaque→raw handle translation. Ids are dense and monotonic so
@@ -59,6 +65,8 @@ struct Session {
     modules: HashMap<u64, u64>,
     functions: HashMap<u64, u64>,
     contexts: HashMap<u64, u64>,
+    streams: HashMap<u64, u64>,
+    events: HashMap<u64, u64>,
 }
 
 impl Session {
@@ -133,6 +141,40 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
                 .map(|_| Response::Ok)
         }
         Request::CtxSynchronize => b.ctx_synchronize().map(|_| Response::Ok),
+        Request::StreamCreate { flags } => {
+            let raw = b.stream_create(flags)?;
+            let id = sess.mint();
+            sess.streams.insert(id, raw);
+            Ok(Response::Handle(id))
+        }
+        Request::StreamDestroy { stream } => {
+            let raw = raw(&sess.streams, stream)?;
+            b.stream_destroy(raw)?;
+            sess.streams.remove(&stream);
+            Ok(Response::Ok)
+        }
+        Request::StreamSynchronize { stream } => {
+            let raw = raw(&sess.streams, stream)?;
+            b.stream_synchronize(raw).map(|_| Response::Ok)
+        }
+        Request::EventCreate { flags } => {
+            let raw = b.event_create(flags)?;
+            let id = sess.mint();
+            sess.events.insert(id, raw);
+            Ok(Response::Handle(id))
+        }
+        Request::EventDestroy { event } => {
+            let raw = raw(&sess.events, event)?;
+            b.event_destroy(raw)?;
+            sess.events.remove(&event);
+            Ok(Response::Ok)
+        }
+        Request::EventElapsedTime { start, end } => {
+            let raw_start = raw(&sess.events, start)?;
+            let raw_end = raw(&sess.events, end)?;
+            b.event_elapsed_time(raw_start, raw_end)
+                .map(Response::Float)
+        }
     })();
     match r {
         Ok(resp) => (0, resp),
@@ -275,6 +317,24 @@ impl Backend for CpuBackend {
     }
     fn ctx_synchronize(&mut self) -> CuResult<()> {
         Ok(())
+    }
+    fn stream_create(&mut self, _flags: u32) -> CuResult<u64> {
+        Ok(self.handle())
+    }
+    fn stream_destroy(&mut self, _stream: u64) -> CuResult<()> {
+        Ok(())
+    }
+    fn stream_synchronize(&mut self, _stream: u64) -> CuResult<()> {
+        Ok(())
+    }
+    fn event_create(&mut self, _flags: u32) -> CuResult<u64> {
+        Ok(self.handle())
+    }
+    fn event_destroy(&mut self, _event: u64) -> CuResult<()> {
+        Ok(())
+    }
+    fn event_elapsed_time(&mut self, _start: u64, _end: u64) -> CuResult<f32> {
+        Ok(0.0)
     }
 }
 

--- a/crates/smolvm-cuda/src/host/gpu.rs
+++ b/crates/smolvm-cuda/src/host/gpu.rs
@@ -54,6 +54,12 @@ pub struct GpuBackend {
         *mut *mut c_void,
     ) -> CuResultCode,
     ctx_synchronize: unsafe extern "C" fn() -> CuResultCode,
+    stream_create: unsafe extern "C" fn(*mut *mut c_void, c_uint) -> CuResultCode,
+    stream_destroy: unsafe extern "C" fn(*mut c_void) -> CuResultCode,
+    stream_synchronize: unsafe extern "C" fn(*mut c_void) -> CuResultCode,
+    event_create: unsafe extern "C" fn(*mut *mut c_void, c_uint) -> CuResultCode,
+    event_destroy: unsafe extern "C" fn(*mut c_void) -> CuResultCode,
+    event_elapsed_time: unsafe extern "C" fn(*mut f32, *mut c_void, *mut c_void) -> CuResultCode,
 }
 
 unsafe fn sym<T>(lib: &Library, name: &[u8]) -> Result<T, String> {
@@ -86,6 +92,12 @@ impl GpuBackend {
                 memcpy_dtoh: sym(&lib, b"cuMemcpyDtoH_v2\0")?,
                 launch_kernel: sym(&lib, b"cuLaunchKernel\0")?,
                 ctx_synchronize: sym(&lib, b"cuCtxSynchronize\0")?,
+                stream_create: sym(&lib, b"cuStreamCreate\0")?,
+                stream_destroy: sym(&lib, b"cuStreamDestroy_v2\0")?,
+                stream_synchronize: sym(&lib, b"cuStreamSynchronize\0")?,
+                event_create: sym(&lib, b"cuEventCreate\0")?,
+                event_destroy: sym(&lib, b"cuEventDestroy_v2\0")?,
+                event_elapsed_time: sym(&lib, b"cuEventElapsedTime\0")?,
                 _lib: lib,
             };
             Ok(b)
@@ -229,5 +241,35 @@ impl Backend for GpuBackend {
     }
     fn ctx_synchronize(&mut self) -> CuResult<()> {
         unsafe { chk((self.ctx_synchronize)()) }
+    }
+    fn stream_create(&mut self, flags: u32) -> CuResult<u64> {
+        let mut stream: *mut c_void = std::ptr::null_mut();
+        unsafe { chk((self.stream_create)(&mut stream, flags))? };
+        Ok(stream as u64)
+    }
+    fn stream_destroy(&mut self, stream: u64) -> CuResult<()> {
+        unsafe { chk((self.stream_destroy)(stream as *mut c_void)) }
+    }
+    fn stream_synchronize(&mut self, stream: u64) -> CuResult<()> {
+        unsafe { chk((self.stream_synchronize)(stream as *mut c_void)) }
+    }
+    fn event_create(&mut self, flags: u32) -> CuResult<u64> {
+        let mut event: *mut c_void = std::ptr::null_mut();
+        unsafe { chk((self.event_create)(&mut event, flags))? };
+        Ok(event as u64)
+    }
+    fn event_destroy(&mut self, event: u64) -> CuResult<()> {
+        unsafe { chk((self.event_destroy)(event as *mut c_void)) }
+    }
+    fn event_elapsed_time(&mut self, start: u64, end: u64) -> CuResult<f32> {
+        let mut ms: f32 = 0.0;
+        unsafe {
+            chk((self.event_elapsed_time)(
+                &mut ms,
+                start as *mut c_void,
+                end as *mut c_void,
+            ))?
+        };
+        Ok(ms)
     }
 }

--- a/crates/smolvm-cuda/src/proto.rs
+++ b/crates/smolvm-cuda/src/proto.rs
@@ -36,6 +36,12 @@ pub enum Op {
     MemcpyDtoH = 0x33,
     LaunchKernel = 0x40,
     CtxSynchronize = 0x50,
+    StreamCreate = 0x51,
+    StreamDestroy = 0x52,
+    StreamSynchronize = 0x53,
+    EventCreate = 0x54,
+    EventDestroy = 0x55,
+    EventElapsedTime = 0x56,
 }
 
 impl Op {
@@ -55,6 +61,12 @@ impl Op {
             0x33 => Op::MemcpyDtoH,
             0x40 => Op::LaunchKernel,
             0x50 => Op::CtxSynchronize,
+            0x51 => Op::StreamCreate,
+            0x52 => Op::StreamDestroy,
+            0x53 => Op::StreamSynchronize,
+            0x54 => Op::EventCreate,
+            0x55 => Op::EventDestroy,
+            0x56 => Op::EventElapsedTime,
             _ => return None,
         })
     }
@@ -110,12 +122,32 @@ pub enum Request {
         params: Vec<Vec<u8>>,
     },
     CtxSynchronize,
+    StreamCreate {
+        flags: u32,
+    },
+    StreamDestroy {
+        stream: u64,
+    },
+    StreamSynchronize {
+        stream: u64,
+    },
+    EventCreate {
+        flags: u32,
+    },
+    EventDestroy {
+        event: u64,
+    },
+    /// Returns elapsed milliseconds between two events as an `f32`.
+    EventElapsedTime {
+        start: u64,
+        end: u64,
+    },
 }
 
 /// A decoded successful response body (the `status == 0` payload).
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Response {
-    /// No return value beyond status (Init, CtxDestroy, MemFree, Memcpy*, Launch, Sync).
+    /// No return value beyond status.
     Ok,
     Count(i32),
     Name(String),
@@ -123,6 +155,7 @@ pub enum Response {
     Handle(u64),
     Dptr(u64),
     Data(Vec<u8>),
+    Float(f32),
 }
 
 // ---- low-level primitives -------------------------------------------------
@@ -137,6 +170,9 @@ fn w_u32(b: &mut Vec<u8>, v: u32) {
     b.extend_from_slice(&v.to_le_bytes());
 }
 fn w_u64(b: &mut Vec<u8>, v: u64) {
+    b.extend_from_slice(&v.to_le_bytes());
+}
+fn w_f32(b: &mut Vec<u8>, v: f32) {
     b.extend_from_slice(&v.to_le_bytes());
 }
 fn w_bytes(b: &mut Vec<u8>, v: &[u8]) {
@@ -178,6 +214,9 @@ impl<'a> Cur<'a> {
     }
     fn u64(&mut self) -> io::Result<u64> {
         Ok(u64::from_le_bytes(self.take(8)?.try_into().unwrap()))
+    }
+    fn f32(&mut self) -> io::Result<f32> {
+        Ok(f32::from_le_bytes(self.take(4)?.try_into().unwrap()))
     }
     fn bytes(&mut self) -> io::Result<Vec<u8>> {
         let n = self.u64()? as usize;
@@ -303,6 +342,31 @@ pub fn encode_request(req: &Request) -> Vec<u8> {
             }
         }
         Request::CtxSynchronize => w_u8(&mut b, Op::CtxSynchronize as u8),
+        Request::StreamCreate { flags } => {
+            w_u8(&mut b, Op::StreamCreate as u8);
+            w_u32(&mut b, *flags);
+        }
+        Request::StreamDestroy { stream } => {
+            w_u8(&mut b, Op::StreamDestroy as u8);
+            w_u64(&mut b, *stream);
+        }
+        Request::StreamSynchronize { stream } => {
+            w_u8(&mut b, Op::StreamSynchronize as u8);
+            w_u64(&mut b, *stream);
+        }
+        Request::EventCreate { flags } => {
+            w_u8(&mut b, Op::EventCreate as u8);
+            w_u32(&mut b, *flags);
+        }
+        Request::EventDestroy { event } => {
+            w_u8(&mut b, Op::EventDestroy as u8);
+            w_u64(&mut b, *event);
+        }
+        Request::EventElapsedTime { start, end } => {
+            w_u8(&mut b, Op::EventElapsedTime as u8);
+            w_u64(&mut b, *start);
+            w_u64(&mut b, *end);
+        }
     }
     b
 }
@@ -353,6 +417,15 @@ pub fn decode_request(payload: &[u8]) -> io::Result<Request> {
             }
         }
         Op::CtxSynchronize => Request::CtxSynchronize,
+        Op::StreamCreate => Request::StreamCreate { flags: c.u32()? },
+        Op::StreamDestroy => Request::StreamDestroy { stream: c.u64()? },
+        Op::StreamSynchronize => Request::StreamSynchronize { stream: c.u64()? },
+        Op::EventCreate => Request::EventCreate { flags: c.u32()? },
+        Op::EventDestroy => Request::EventDestroy { event: c.u64()? },
+        Op::EventElapsedTime => Request::EventElapsedTime {
+            start: c.u64()?,
+            end: c.u64()?,
+        },
     })
 }
 
@@ -369,6 +442,7 @@ pub fn encode_response(status: i32, resp: &Response) -> Vec<u8> {
             Response::Name(s) => w_str(&mut b, s),
             Response::Bytes(v) | Response::Handle(v) | Response::Dptr(v) => w_u64(&mut b, *v),
             Response::Data(d) => w_bytes(&mut b, d),
+            Response::Float(v) => w_f32(&mut b, *v),
         }
     }
     b
@@ -390,12 +464,17 @@ pub fn decode_response(op: Op, payload: &[u8]) -> io::Result<(i32, Response)> {
         Op::ModuleLoadData | Op::ModuleGetFunction => Response::Handle(c.u64()?),
         Op::MemAlloc => Response::Dptr(c.u64()?),
         Op::MemcpyDtoH => Response::Data(c.bytes()?),
+        Op::StreamCreate | Op::EventCreate => Response::Handle(c.u64()?),
+        Op::EventElapsedTime => Response::Float(c.f32()?),
         Op::Init
         | Op::CtxDestroy
         | Op::MemFree
         | Op::MemcpyHtoD
         | Op::LaunchKernel
-        | Op::CtxSynchronize => Response::Ok,
+        | Op::CtxSynchronize
+        | Op::StreamDestroy
+        | Op::StreamSynchronize
+        | Op::EventDestroy => Response::Ok,
     };
     Ok((status, body))
 }
@@ -448,6 +527,15 @@ mod tests {
             ],
         });
         roundtrip(Request::CtxSynchronize);
+        roundtrip(Request::StreamCreate { flags: 1 });
+        roundtrip(Request::StreamDestroy { stream: 0xaa });
+        roundtrip(Request::StreamSynchronize { stream: 0xbb });
+        roundtrip(Request::EventCreate { flags: 0 });
+        roundtrip(Request::EventDestroy { event: 0xcc });
+        roundtrip(Request::EventElapsedTime {
+            start: 0x10,
+            end: 0x20,
+        });
     }
 
     #[test]
@@ -464,6 +552,12 @@ mod tests {
             (Op::MemAlloc, Response::Dptr(0x7f00_0000)),
             (Op::MemcpyDtoH, Response::Data(vec![9, 8, 7])),
             (Op::CtxSynchronize, Response::Ok),
+            (Op::StreamCreate, Response::Handle(42)),
+            (Op::StreamDestroy, Response::Ok),
+            (Op::StreamSynchronize, Response::Ok),
+            (Op::EventCreate, Response::Handle(99)),
+            (Op::EventDestroy, Response::Ok),
+            (Op::EventElapsedTime, Response::Float(1.5)),
         ] {
             let enc = encode_response(0, &resp);
             let (status, dec) = decode_response(op, &enc).expect("decode");


### PR DESCRIPTION
Six new Driver API operations across all four layers (proto, host dispatch, GPU backend, client): StreamCreate, StreamDestroy, StreamSynchronize, EventCreate, EventDestroy, EventElapsedTime.

Streams enable async GPU pipelines (required for PyTorch's execution model). Events enable GPU-side timing. Both use the same opaque handle table pattern as modules/functions/contexts.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/550">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->