### PR TITLE
Add device attribute and primary context ops to CUDA protocol

### DIFF
--- a/crates/smolvm-cuda/src/client.rs
+++ b/crates/smolvm-cuda/src/client.rs
@@ -82,6 +82,23 @@ impl<S: Read + Write> Client<S> {
         }
     }
 
+    pub fn device_get(&mut self, ordinal: i32) -> Result<i32> {
+        match self.call(&Request::DeviceGet { ordinal }, Op::DeviceGet)? {
+            Response::Count(d) => Ok(d),
+            _ => Err(CudaRpcError::Protocol("expected Count")),
+        }
+    }
+
+    pub fn device_get_attribute(&mut self, attrib: i32, device: i32) -> Result<i32> {
+        match self.call(
+            &Request::DeviceGetAttribute { attrib, device },
+            Op::DeviceGetAttribute,
+        )? {
+            Response::Count(v) => Ok(v),
+            _ => Err(CudaRpcError::Protocol("expected Count")),
+        }
+    }
+
     pub fn ctx_create(&mut self, device: i32) -> Result<u64> {
         match self.call(&Request::CtxCreate { device }, Op::CtxCreate)? {
             Response::Handle(h) => Ok(h),
@@ -92,6 +109,24 @@ impl<S: Read + Write> Client<S> {
     pub fn ctx_destroy(&mut self, ctx: u64) -> Result<()> {
         self.call(&Request::CtxDestroy { ctx }, Op::CtxDestroy)
             .map(|_| ())
+    }
+
+    pub fn device_primary_ctx_retain(&mut self, device: i32) -> Result<u64> {
+        match self.call(
+            &Request::DevicePrimaryCtxRetain { device },
+            Op::DevicePrimaryCtxRetain,
+        )? {
+            Response::Handle(h) => Ok(h),
+            _ => Err(CudaRpcError::Protocol("expected Handle")),
+        }
+    }
+
+    pub fn device_primary_ctx_release(&mut self, device: i32) -> Result<()> {
+        self.call(
+            &Request::DevicePrimaryCtxRelease { device },
+            Op::DevicePrimaryCtxRelease,
+        )
+        .map(|_| ())
     }
 
     pub fn module_load_data(&mut self, image: &[u8]) -> Result<u64> {

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -31,8 +31,12 @@ pub trait Backend: Send {
     fn device_get_count(&mut self) -> CuResult<i32>;
     fn device_get_name(&mut self, device: i32) -> CuResult<String>;
     fn device_total_mem(&mut self, device: i32) -> CuResult<u64>;
+    fn device_get(&mut self, ordinal: i32) -> CuResult<i32>;
+    fn device_get_attribute(&mut self, attrib: i32, device: i32) -> CuResult<i32>;
     fn ctx_create(&mut self, device: i32) -> CuResult<u64>;
     fn ctx_destroy(&mut self, ctx: u64) -> CuResult<()>;
+    fn device_primary_ctx_retain(&mut self, device: i32) -> CuResult<u64>;
+    fn device_primary_ctx_release(&mut self, device: i32) -> CuResult<()>;
     fn module_load_data(&mut self, image: &[u8]) -> CuResult<u64>;
     fn module_get_function(&mut self, module: u64, name: &str) -> CuResult<u64>;
     fn mem_alloc(&mut self, bytes: u64) -> CuResult<u64>;
@@ -59,6 +63,7 @@ struct Session {
     modules: HashMap<u64, u64>,
     functions: HashMap<u64, u64>,
     contexts: HashMap<u64, u64>,
+    primary_contexts: HashMap<i32, u64>,
 }
 
 impl Session {
@@ -91,6 +96,10 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         Request::DeviceGetCount => b.device_get_count().map(Response::Count),
         Request::DeviceGetName { device } => b.device_get_name(device).map(Response::Name),
         Request::DeviceTotalMem { device } => b.device_total_mem(device).map(Response::Bytes),
+        Request::DeviceGet { ordinal } => b.device_get(ordinal).map(Response::Count),
+        Request::DeviceGetAttribute { attrib, device } => {
+            b.device_get_attribute(attrib, device).map(Response::Count)
+        }
         Request::CtxCreate { device } => {
             let raw = b.ctx_create(device)?;
             let id = sess.mint();
@@ -102,6 +111,19 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             b.ctx_destroy(raw)?;
             sess.contexts.remove(&ctx);
             Ok(Response::Ok)
+        }
+        Request::DevicePrimaryCtxRetain { device } => {
+            let raw = b.device_primary_ctx_retain(device)?;
+            let id = sess.mint();
+            sess.primary_contexts.insert(device, id);
+            sess.contexts.insert(id, raw);
+            Ok(Response::Handle(id))
+        }
+        Request::DevicePrimaryCtxRelease { device } => {
+            if let Some(id) = sess.primary_contexts.remove(&device) {
+                sess.contexts.remove(&id);
+            }
+            b.device_primary_ctx_release(device).map(|_| Response::Ok)
         }
         Request::ModuleLoadData { image } => {
             let raw = b.module_load_data(&image)?;
@@ -194,10 +216,22 @@ impl Backend for CpuBackend {
     fn device_total_mem(&mut self, _device: i32) -> CuResult<u64> {
         Ok(1 << 30)
     }
+    fn device_get(&mut self, ordinal: i32) -> CuResult<i32> {
+        if ordinal == 0 { Ok(0) } else { Err(CUDA_ERROR_INVALID_HANDLE) }
+    }
+    fn device_get_attribute(&mut self, _attrib: i32, _device: i32) -> CuResult<i32> {
+        Ok(0)
+    }
     fn ctx_create(&mut self, _device: i32) -> CuResult<u64> {
         Ok(self.handle())
     }
     fn ctx_destroy(&mut self, _ctx: u64) -> CuResult<()> {
+        Ok(())
+    }
+    fn device_primary_ctx_retain(&mut self, _device: i32) -> CuResult<u64> {
+        Ok(self.handle())
+    }
+    fn device_primary_ctx_release(&mut self, _device: i32) -> CuResult<()> {
         Ok(())
     }
     fn module_load_data(&mut self, _image: &[u8]) -> CuResult<u64> {

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -217,7 +217,11 @@ impl Backend for CpuBackend {
         Ok(1 << 30)
     }
     fn device_get(&mut self, ordinal: i32) -> CuResult<i32> {
-        if ordinal == 0 { Ok(0) } else { Err(CUDA_ERROR_INVALID_HANDLE) }
+        if ordinal == 0 {
+            Ok(0)
+        } else {
+            Err(CUDA_ERROR_INVALID_HANDLE)
+        }
     }
     fn device_get_attribute(&mut self, _attrib: i32, _device: i32) -> CuResult<i32> {
         Ok(0)

--- a/crates/smolvm-cuda/src/host/gpu.rs
+++ b/crates/smolvm-cuda/src/host/gpu.rs
@@ -30,8 +30,12 @@ pub struct GpuBackend {
     device_get_count: unsafe extern "C" fn(*mut c_int) -> CuResultCode,
     device_get_name: unsafe extern "C" fn(*mut c_char, c_int, c_int) -> CuResultCode,
     device_total_mem: unsafe extern "C" fn(*mut usize, c_int) -> CuResultCode,
+    device_get: unsafe extern "C" fn(*mut c_int, c_int) -> CuResultCode,
+    device_get_attribute: unsafe extern "C" fn(*mut c_int, c_int, c_int) -> CuResultCode,
     ctx_create: unsafe extern "C" fn(*mut *mut c_void, c_uint, c_int) -> CuResultCode,
     ctx_destroy: unsafe extern "C" fn(*mut c_void) -> CuResultCode,
+    primary_ctx_retain: unsafe extern "C" fn(*mut *mut c_void, c_int) -> CuResultCode,
+    primary_ctx_release: unsafe extern "C" fn(c_int) -> CuResultCode,
     module_load_data: unsafe extern "C" fn(*mut *mut c_void, *const c_void) -> CuResultCode,
     module_get_function:
         unsafe extern "C" fn(*mut *mut c_void, *mut c_void, *const c_char) -> CuResultCode,
@@ -76,8 +80,12 @@ impl GpuBackend {
                 device_get_count: sym(&lib, b"cuDeviceGetCount\0")?,
                 device_get_name: sym(&lib, b"cuDeviceGetName\0")?,
                 device_total_mem: sym(&lib, b"cuDeviceTotalMem_v2\0")?,
+                device_get: sym(&lib, b"cuDeviceGet\0")?,
+                device_get_attribute: sym(&lib, b"cuDeviceGetAttribute\0")?,
                 ctx_create: sym(&lib, b"cuCtxCreate_v2\0")?,
                 ctx_destroy: sym(&lib, b"cuCtxDestroy_v2\0")?,
+                primary_ctx_retain: sym(&lib, b"cuDevicePrimaryCtxRetain\0")?,
+                primary_ctx_release: sym(&lib, b"cuDevicePrimaryCtxRelease_v2\0")?,
                 module_load_data: sym(&lib, b"cuModuleLoadData\0")?,
                 module_get_function: sym(&lib, b"cuModuleGetFunction\0")?,
                 mem_alloc: sym(&lib, b"cuMemAlloc_v2\0")?,
@@ -130,6 +138,16 @@ impl Backend for GpuBackend {
         unsafe { chk((self.device_total_mem)(&mut bytes, device))? };
         Ok(bytes as u64)
     }
+    fn device_get(&mut self, ordinal: i32) -> CuResult<i32> {
+        let mut dev: c_int = 0;
+        unsafe { chk((self.device_get)(&mut dev, ordinal))? };
+        Ok(dev)
+    }
+    fn device_get_attribute(&mut self, attrib: i32, device: i32) -> CuResult<i32> {
+        let mut val: c_int = 0;
+        unsafe { chk((self.device_get_attribute)(&mut val, attrib, device))? };
+        Ok(val)
+    }
     fn ctx_create(&mut self, device: i32) -> CuResult<u64> {
         let mut ctx: *mut c_void = std::ptr::null_mut();
         unsafe { chk((self.ctx_create)(&mut ctx, 0, device))? };
@@ -137,6 +155,14 @@ impl Backend for GpuBackend {
     }
     fn ctx_destroy(&mut self, ctx: u64) -> CuResult<()> {
         unsafe { chk((self.ctx_destroy)(ctx as *mut c_void)) }
+    }
+    fn device_primary_ctx_retain(&mut self, device: i32) -> CuResult<u64> {
+        let mut ctx: *mut c_void = std::ptr::null_mut();
+        unsafe { chk((self.primary_ctx_retain)(&mut ctx, device))? };
+        Ok(ctx as u64)
+    }
+    fn device_primary_ctx_release(&mut self, device: i32) -> CuResult<()> {
+        unsafe { chk((self.primary_ctx_release)(device)) }
     }
     fn module_load_data(&mut self, image: &[u8]) -> CuResult<u64> {
         // cuModuleLoadData reads a NUL-terminated PTX string or a cubin blob.

--- a/crates/smolvm-cuda/src/proto.rs
+++ b/crates/smolvm-cuda/src/proto.rs
@@ -26,8 +26,12 @@ pub enum Op {
     DeviceGetCount = 0x02,
     DeviceGetName = 0x03,
     DeviceTotalMem = 0x04,
+    DeviceGet = 0x05,
+    DeviceGetAttribute = 0x06,
     CtxCreate = 0x10,
     CtxDestroy = 0x11,
+    DevicePrimaryCtxRetain = 0x12,
+    DevicePrimaryCtxRelease = 0x13,
     ModuleLoadData = 0x20,
     ModuleGetFunction = 0x21,
     MemAlloc = 0x30,
@@ -45,8 +49,12 @@ impl Op {
             0x02 => Op::DeviceGetCount,
             0x03 => Op::DeviceGetName,
             0x04 => Op::DeviceTotalMem,
+            0x05 => Op::DeviceGet,
+            0x06 => Op::DeviceGetAttribute,
             0x10 => Op::CtxCreate,
             0x11 => Op::CtxDestroy,
+            0x12 => Op::DevicePrimaryCtxRetain,
+            0x13 => Op::DevicePrimaryCtxRelease,
             0x20 => Op::ModuleLoadData,
             0x21 => Op::ModuleGetFunction,
             0x30 => Op::MemAlloc,
@@ -71,11 +79,25 @@ pub enum Request {
     DeviceTotalMem {
         device: i32,
     },
+    DeviceGet {
+        ordinal: i32,
+    },
+    /// Query a device attribute by its integer id (CUdevice_attribute enum).
+    DeviceGetAttribute {
+        attrib: i32,
+        device: i32,
+    },
     CtxCreate {
         device: i32,
     },
     CtxDestroy {
         ctx: u64,
+    },
+    DevicePrimaryCtxRetain {
+        device: i32,
+    },
+    DevicePrimaryCtxRelease {
+        device: i32,
     },
     ModuleLoadData {
         image: Vec<u8>,
@@ -244,6 +266,15 @@ pub fn encode_request(req: &Request) -> Vec<u8> {
             w_u8(&mut b, Op::DeviceTotalMem as u8);
             w_i32(&mut b, *device);
         }
+        Request::DeviceGet { ordinal } => {
+            w_u8(&mut b, Op::DeviceGet as u8);
+            w_i32(&mut b, *ordinal);
+        }
+        Request::DeviceGetAttribute { attrib, device } => {
+            w_u8(&mut b, Op::DeviceGetAttribute as u8);
+            w_i32(&mut b, *attrib);
+            w_i32(&mut b, *device);
+        }
         Request::CtxCreate { device } => {
             w_u8(&mut b, Op::CtxCreate as u8);
             w_i32(&mut b, *device);
@@ -251,6 +282,14 @@ pub fn encode_request(req: &Request) -> Vec<u8> {
         Request::CtxDestroy { ctx } => {
             w_u8(&mut b, Op::CtxDestroy as u8);
             w_u64(&mut b, *ctx);
+        }
+        Request::DevicePrimaryCtxRetain { device } => {
+            w_u8(&mut b, Op::DevicePrimaryCtxRetain as u8);
+            w_i32(&mut b, *device);
+        }
+        Request::DevicePrimaryCtxRelease { device } => {
+            w_u8(&mut b, Op::DevicePrimaryCtxRelease as u8);
+            w_i32(&mut b, *device);
         }
         Request::ModuleLoadData { image } => {
             w_u8(&mut b, Op::ModuleLoadData as u8);
@@ -315,8 +354,15 @@ pub fn decode_request(payload: &[u8]) -> io::Result<Request> {
         Op::DeviceGetCount => Request::DeviceGetCount,
         Op::DeviceGetName => Request::DeviceGetName { device: c.i32()? },
         Op::DeviceTotalMem => Request::DeviceTotalMem { device: c.i32()? },
+        Op::DeviceGet => Request::DeviceGet { ordinal: c.i32()? },
+        Op::DeviceGetAttribute => Request::DeviceGetAttribute {
+            attrib: c.i32()?,
+            device: c.i32()?,
+        },
         Op::CtxCreate => Request::CtxCreate { device: c.i32()? },
         Op::CtxDestroy => Request::CtxDestroy { ctx: c.u64()? },
+        Op::DevicePrimaryCtxRetain => Request::DevicePrimaryCtxRetain { device: c.i32()? },
+        Op::DevicePrimaryCtxRelease => Request::DevicePrimaryCtxRelease { device: c.i32()? },
         Op::ModuleLoadData => Request::ModuleLoadData { image: c.bytes()? },
         Op::ModuleGetFunction => Request::ModuleGetFunction {
             module: c.u64()?,
@@ -383,10 +429,10 @@ pub fn decode_response(op: Op, payload: &[u8]) -> io::Result<(i32, Response)> {
         return Ok((status, Response::Ok));
     }
     let body = match op {
-        Op::DeviceGetCount => Response::Count(c.i32()?),
+        Op::DeviceGetCount | Op::DeviceGet | Op::DeviceGetAttribute => Response::Count(c.i32()?),
         Op::DeviceGetName => Response::Name(c.string()?),
         Op::DeviceTotalMem => Response::Bytes(c.u64()?),
-        Op::CtxCreate => Response::Handle(c.u64()?),
+        Op::CtxCreate | Op::DevicePrimaryCtxRetain => Response::Handle(c.u64()?),
         Op::ModuleLoadData | Op::ModuleGetFunction => Response::Handle(c.u64()?),
         Op::MemAlloc => Response::Dptr(c.u64()?),
         Op::MemcpyDtoH => Response::Data(c.bytes()?),
@@ -395,7 +441,8 @@ pub fn decode_response(op: Op, payload: &[u8]) -> io::Result<(i32, Response)> {
         | Op::MemFree
         | Op::MemcpyHtoD
         | Op::LaunchKernel
-        | Op::CtxSynchronize => Response::Ok,
+        | Op::CtxSynchronize
+        | Op::DevicePrimaryCtxRelease => Response::Ok,
     };
     Ok((status, body))
 }
@@ -416,8 +463,15 @@ mod tests {
         roundtrip(Request::DeviceGetCount);
         roundtrip(Request::DeviceGetName { device: 3 });
         roundtrip(Request::DeviceTotalMem { device: 0 });
+        roundtrip(Request::DeviceGet { ordinal: 0 });
+        roundtrip(Request::DeviceGetAttribute {
+            attrib: 75,
+            device: 0,
+        });
         roundtrip(Request::CtxCreate { device: 1 });
         roundtrip(Request::CtxDestroy { ctx: 0xdead_beef });
+        roundtrip(Request::DevicePrimaryCtxRetain { device: 0 });
+        roundtrip(Request::DevicePrimaryCtxRelease { device: 0 });
         roundtrip(Request::ModuleLoadData {
             image: b".version 7.0\n".to_vec(),
         });
@@ -459,7 +513,11 @@ mod tests {
                 Response::Name("NVIDIA GeForce RTX 3070".into()),
             ),
             (Op::DeviceTotalMem, Response::Bytes(8 << 30)),
+            (Op::DeviceGet, Response::Count(0)),
+            (Op::DeviceGetAttribute, Response::Count(128)),
             (Op::CtxCreate, Response::Handle(99)),
+            (Op::DevicePrimaryCtxRetain, Response::Handle(55)),
+            (Op::DevicePrimaryCtxRelease, Response::Ok),
             (Op::ModuleLoadData, Response::Handle(1)),
             (Op::MemAlloc, Response::Dptr(0x7f00_0000)),
             (Op::MemcpyDtoH, Response::Data(vec![9, 8, 7])),


### PR DESCRIPTION
## Summary

- Adds 4 new CUDA Driver API operations: `DeviceGet`, `DeviceGetAttribute`, `DevicePrimaryCtxRetain`, `DevicePrimaryCtxRelease`
- Wired through all four layers: proto.rs, host.rs (dispatch + Backend trait + CpuBackend), host/gpu.rs (GpuBackend + dlopen), client.rs
- Primary context handles are tracked in a `primary_contexts: HashMap<i32, u64>` keyed by device ordinal, and cross-registered in the existing `contexts` table so they work with any context-scoped operation

## Why

PyTorch does **not** use `cuCtxCreate` — it uses `cuDevicePrimaryCtxRetain` to get a shared context per device. At startup, PyTorch also calls `cuDeviceGetAttribute` ~20 times to query compute capability, max threads, shared memory size, etc. Without these ops, `torch.cuda.is_available()` crashes immediately.

`DeviceGet` is the standard way to convert an ordinal (0, 1, ...) to a `CUdevice` handle, which the attribute and primary context functions require.

## Test plan

- [x] `cargo test -p smolvm-cuda` — all 8 tests pass (including new roundtrip coverage for all 4 ops)
- [x] `cargo check` — full crate graph compiles cleanly
- [ ] Real GPU validation on DGX Spark (deferred to e2e PR)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/552">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->