### PR TITLE
Add a node serve route to export a stopped machine to a .smolmachine

### DIFF
--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -1671,11 +1671,10 @@ pub async fn export_machine(
     // still being written) can't be snapshotted into an inconsistent image.
     let name_probe = name.clone();
     let record_probe = record.clone();
-    let resolved = tokio::task::spawn_blocking(move || {
-        resolve_machine_state(&name_probe, &record_probe)
-    })
-    .await
-    .map_err(|e| ApiError::internal(format!("task error: {}", e)))?;
+    let resolved =
+        tokio::task::spawn_blocking(move || resolve_machine_state(&name_probe, &record_probe))
+            .await
+            .map_err(|e| ApiError::internal(format!("task error: {}", e)))?;
     if resolved != RecordState::Stopped {
         return Err(ApiError::Conflict(
             "machine must be stopped to export".to_string(),
@@ -1707,7 +1706,10 @@ pub async fn export_machine(
         .map_err(|e| ApiError::internal(format!("spawn pack export: {}", e)))?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(ApiError::internal(format!("pack export failed: {}", stderr)));
+        return Err(ApiError::internal(format!(
+            "pack export failed: {}",
+            stderr
+        )));
     }
 
     // Read back the PackManifest from the sidecar footer for the response.
@@ -1724,8 +1726,7 @@ pub async fn export_machine(
     } else {
         format!("https://{}", req.reference_host)
     };
-    let client =
-        smolvm_registry::RegistryClient::new(base_url).with_token(req.push_token.clone());
+    let client = smolvm_registry::RegistryClient::new(base_url).with_token(req.push_token.clone());
 
     let result = smolvm_registry::push(&client, &req.repo, &req.tag, &tmp_path)
         .await

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -36,9 +36,9 @@ use crate::api::state::{
     ReservationGuard,
 };
 use crate::api::types::{
-    ApiErrorResponse, CreateMachineRequest, DeleteResponse, EnvVar, ExecResponse, ForkRequest,
-    ListMachinesResponse, MachineExecRequest, MachineInfo, MountInfo, MountSpec, PortSpec,
-    ResizeMachineRequest, ResourceSpec, StartMachineQuery,
+    ApiErrorResponse, CreateMachineRequest, DeleteResponse, EnvVar, ExecResponse, ExportRequest,
+    ExportResponse, ForkRequest, ListMachinesResponse, MachineExecRequest, MachineInfo, MountInfo,
+    MountSpec, PortSpec, ResizeMachineRequest, ResourceSpec, StartMachineQuery,
 };
 use crate::api::validate_command;
 use crate::api::TraceId;
@@ -1630,6 +1630,114 @@ pub async fn resize_machine(
         })?;
 
     Ok(Json(record_to_info(&name, &record)))
+}
+
+/// Export a stopped machine to a `.smolmachine` and push it directly to a
+/// registry.
+///
+/// The machine must be stopped: exporting a running VM would snapshot an
+/// inconsistent overlay. The `.smolmachine` is produced by subprocessing this
+/// same binary's `pack create --from-vm <name>` (the tested path that boots a
+/// helper VM to export the container overlay), then streamed to the registry
+/// with the control-plane-minted, pre-scoped OCI bearer.
+#[utoipa::path(
+    post,
+    path = "/api/v1/machines/{name}/export",
+    tag = "Machines",
+    params(
+        ("name" = String, Path, description = "Machine name")
+    ),
+    request_body = ExportRequest,
+    responses(
+        (status = 200, description = "Machine exported and pushed", body = ExportResponse),
+        (status = 404, description = "Machine not found", body = ApiErrorResponse),
+        (status = 409, description = "Machine is not stopped", body = ApiErrorResponse),
+        (status = 500, description = "Export or push failed", body = ApiErrorResponse)
+    )
+)]
+pub async fn export_machine(
+    State(state): State<Arc<ApiState>>,
+    Path(id): Path<String>,
+    Json(req): Json<ExportRequest>,
+) -> Result<Json<ExportResponse>, ApiError> {
+    // Resolve the machine record; the path id is the machine name in this API.
+    let record = state
+        .lookup_vm(&id)
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("machine '{}' not found", id)))?;
+    let name = id;
+
+    // Require STOPPED via the shared probe so a running VM (whose overlay is
+    // still being written) can't be snapshotted into an inconsistent image.
+    let name_probe = name.clone();
+    let record_probe = record.clone();
+    let resolved = tokio::task::spawn_blocking(move || {
+        resolve_machine_state(&name_probe, &record_probe)
+    })
+    .await
+    .map_err(|e| ApiError::internal(format!("task error: {}", e)))?;
+    if resolved != RecordState::Stopped {
+        return Err(ApiError::Conflict(
+            "machine must be stopped to export".to_string(),
+        ));
+    }
+
+    // Build the .smolmachine by subprocessing this binary's tested export path.
+    // The serve handlers and the pack CLI share the same on-disk SmolvmDb, so
+    // `pack create --from-vm <name>` sees the serve-managed machine.
+    let tmp = tempfile::Builder::new()
+        .suffix(".smolmachine")
+        .tempfile()
+        .map_err(|e| ApiError::internal(format!("create temp file: {}", e)))?;
+    let tmp_path = tmp.path().to_path_buf();
+    let exe =
+        std::env::current_exe().map_err(|e| ApiError::internal(format!("current_exe: {}", e)))?;
+
+    let output = tokio::process::Command::new(&exe)
+        .args([
+            "pack",
+            "create",
+            "--from-vm",
+            &name,
+            "-o",
+            &tmp_path.to_string_lossy(),
+        ])
+        .output()
+        .await
+        .map_err(|e| ApiError::internal(format!("spawn pack export: {}", e)))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(ApiError::internal(format!("pack export failed: {}", stderr)));
+    }
+
+    // Read back the PackManifest from the sidecar footer for the response.
+    let manifest = smolvm_pack::read_manifest_from_sidecar(&tmp_path)
+        .map_err(|e| ApiError::internal(format!("read exported manifest: {}", e)))?;
+    let manifest_json = serde_json::to_string(&manifest)
+        .map_err(|e| ApiError::internal(format!("serialize manifest: {}", e)))?;
+
+    // Push directly to the registry using the pre-scoped bearer token. The
+    // control mints a tenant-scoped OCI bearer, so use the raw token path
+    // (.with_token), not /v2/auth.
+    let base_url = if smolvm_registry::is_local_registry(&req.reference_host) {
+        format!("http://{}", req.reference_host)
+    } else {
+        format!("https://{}", req.reference_host)
+    };
+    let client =
+        smolvm_registry::RegistryClient::new(base_url).with_token(req.push_token.clone());
+
+    let result = smolvm_registry::push(&client, &req.repo, &req.tag, &tmp_path)
+        .await
+        .map_err(|e| ApiError::internal(format!("registry push failed: {}", e)))?;
+
+    // tmp drops here, deleting the sidecar.
+    Ok(Json(ExportResponse {
+        digest: result.manifest_digest,
+        size_bytes: result.layer_size,
+        platform: result.platform,
+        manifest: manifest_json,
+    }))
 }
 
 async fn pull_from_registry(

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -90,6 +90,7 @@ use state::ApiState;
         handlers::machines::delete_machine,
         handlers::machines::exec_machine,
         handlers::machines::resize_machine,
+        handlers::machines::export_machine,
     ),
     components(schemas(
         // Request types
@@ -107,6 +108,7 @@ use state::ApiState;
         types::MachineExecRequest,
         types::ResizeMachineRequest,
         types::ForkRequest,
+        types::ExportRequest,
         types::StartMachineQuery,
         // Response types
         types::HealthResponse,
@@ -115,6 +117,7 @@ use state::ApiState;
         types::MountInfo,
         types::ListMachinesResponse,
         types::ExecResponse,
+        types::ExportResponse,
         types::ImageInfo,
         types::ListImagesResponse,
         types::PullImageResponse,
@@ -173,6 +176,7 @@ pub fn create_router(state: Arc<ApiState>, cors_origins: Vec<String>) -> Router 
         .route("/{id}/start", post(handlers::machines::start_machine))
         .route("/{id}/fork", post(handlers::machines::fork_machine))
         .route("/{id}/stop", post(handlers::machines::stop_machine))
+        .route("/{id}/export", post(handlers::machines::export_machine))
         .route("/{id}", delete(handlers::machines::delete_machine))
         // Exec routes
         .route("/{id}/exec", post(handlers::exec::exec_command))

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -195,6 +195,42 @@ pub struct ExecResponse {
     pub stderr: String,
 }
 
+/// Request to export a stopped machine to a `.smolmachine` and push it to a
+/// registry. The control plane mints a pre-scoped OCI bearer (`push_token`)
+/// that authorizes the write against `reference_host`.
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportRequest {
+    /// Repository to push into (e.g. `tenant/my-machine`).
+    #[schema(example = "tenant/my-machine")]
+    pub repo: String,
+    /// Tag to push under (e.g. `latest`).
+    #[schema(example = "latest")]
+    pub tag: String,
+    /// Pre-scoped OCI bearer token minted by the control plane.
+    pub push_token: String,
+    /// Registry host to push to (e.g. `registry.smolmachines.com`).
+    #[schema(example = "registry.smolmachines.com")]
+    pub reference_host: String,
+}
+
+/// Result of exporting a machine to a registry.
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportResponse {
+    /// Digest of the pushed OCI manifest (reference as `repo@<digest>`).
+    #[schema(example = "sha256:abc123")]
+    pub digest: String,
+    /// Size of the `.smolmachine` sidecar blob in bytes.
+    #[schema(example = 104857600)]
+    pub size_bytes: u64,
+    /// Host platform the artifact targets (e.g. `linux/amd64`).
+    #[schema(example = "linux/amd64")]
+    pub platform: String,
+    /// The `PackManifest` JSON carried in the sidecar footer.
+    pub manifest: String,
+}
+
 /// Request to run a command in an image.
 #[derive(Debug, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
Adds POST /api/v1/machines/{id}/export to the serve API. The handler resolves the machine by name, requires it to be stopped via the shared state probe, builds a .smolmachine by subprocessing this binary's tested pack create --from-vm export path, and streams the sidecar directly to the registry using a pre-scoped OCI bearer token supplied by the control plane. It returns the pushed manifest digest, sidecar size, target platform, and the PackManifest JSON. Engine-only; no control-plane or CLI changes.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/556">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->