### PR TITLE
Add a /readyz dispatch-readiness probe that exercises the blocking pool

### DIFF
--- a/src/api/handlers/health.rs
+++ b/src/api/handlers/health.rs
@@ -1,10 +1,16 @@
 //! Health check endpoint.
 
+use axum::http::StatusCode;
 use axum::{extract::State, Json};
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::api::state::ApiState;
 use crate::api::types::{HealthResponse, MachineCountsResponse};
+
+/// Deadline for the `/readyz` blocking-pool round-trip. Generous vs. a no-op task
+/// on a healthy pool (microseconds); only a genuinely saturated pool misses it.
+const READYZ_BUDGET: Duration = Duration::from_secs(2);
 
 /// Server start time for uptime calculation.
 static SERVER_START: std::sync::OnceLock<std::time::Instant> = std::sync::OnceLock::new();
@@ -43,4 +49,45 @@ pub async fn health(State(state): State<Arc<ApiState>>) -> Json<HealthResponse> 
         machines,
         uptime_seconds: uptime,
     })
+}
+
+/// Readiness probe that exercises the **blocking pool** — the resource VM
+/// start/exec/stop dispatch depends on.
+///
+/// `/health` is pure-async and keeps returning 200 even when the blocking pool is
+/// exhausted, so the control's data-plane probe couldn't distinguish a wedged node
+/// (start/exec timing out) from a healthy one, and never auto-cordoned it (the
+/// 2026-07-05 worker-1 wedge). This round-trips a no-op `spawn_blocking` task under
+/// a deadline: on a healthy pool it returns 200 in microseconds; if the pool can't
+/// service it in [`READYZ_BUDGET`] the node is dispatch-wedged and it returns 503,
+/// which the control treats as a data-plane failure and cordons.
+#[utoipa::path(
+    get,
+    path = "/readyz",
+    tag = "Health",
+    responses(
+        (status = 200, description = "Dispatch path (blocking pool) is responsive"),
+        (status = 503, description = "Blocking pool saturated — node is dispatch-wedged")
+    )
+)]
+pub async fn readyz() -> StatusCode {
+    let probe = tokio::task::spawn_blocking(|| ());
+    match tokio::time::timeout(READYZ_BUDGET, probe).await {
+        Ok(Ok(())) => StatusCode::OK,
+        // Timed out (pool saturated) or the task panicked/was cancelled — either way
+        // the dispatch path is not servicing work; report unready.
+        _ => StatusCode::SERVICE_UNAVAILABLE,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // On a healthy runtime the blocking-pool round-trip completes well inside the
+    // budget, so readiness reports OK.
+    #[tokio::test]
+    async fn readyz_ok_when_pool_responsive() {
+        assert_eq!(readyz().await, StatusCode::OK);
+    }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -148,8 +148,13 @@ pub fn validate_command(cmd: &[String]) -> Result<(), ApiError> {
 /// `cors_origins` specifies allowed CORS origins. If empty, defaults to
 /// localhost:8080 and localhost:3000 (both http and 127.0.0.1 variants).
 pub fn create_router(state: Arc<ApiState>, cors_origins: Vec<String>) -> Router {
-    // Health check route
-    let health_route = Router::new().route("/health", get(handlers::health::health));
+    // Health check route. `/health` is liveness (pure-async, always answers);
+    // `/readyz` is a dispatch-path readiness probe that exercises the blocking pool
+    // so the control can detect — and cordon — a node whose start/exec are wedged
+    // even while `/health` still returns 200.
+    let health_route = Router::new()
+        .route("/health", get(handlers::health::health))
+        .route("/readyz", get(handlers::health::readyz));
 
     // Node capacity introspection (polled by a fleet node-agent over HTTP).
     let capacity_route = Router::new().route("/capacity", get(handlers::node::capacity));


### PR DESCRIPTION
Add a /readyz probe that round-trips the blocking pool so the control can detect and cordon a node whose dispatch is wedged while /health still returns 200.