### PR TITLE
Report a per-process boot id in the capacity endpoint so a serve restart is detectable

### DIFF
--- a/src/api/handlers/node.rs
+++ b/src/api/handlers/node.rs
@@ -8,6 +8,20 @@ use std::sync::Arc;
 use crate::api::state::ApiState;
 use crate::api::types::CapacityResponse;
 
+/// Id minted once per serve process (pid + startup nanos — unique across a restart,
+/// dependency-free). Constant for the process lifetime; a change tells the control
+/// the serve restarted and wiped its warm pool. Lazily initialized on first read.
+fn boot_id() -> &'static str {
+    static BOOT_ID: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    BOOT_ID.get_or_init(|| {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        format!("{}-{}", std::process::id(), nanos)
+    })
+}
+
 /// Report live node capacity — current allocations + real utilization across
 /// all running machines on this host.
 ///
@@ -47,6 +61,7 @@ pub async fn capacity(State(state): State<Arc<ApiState>>) -> Response {
         used_cpus,
         used_memory_mb,
         used_disk_gb,
+        boot_id: boot_id().to_string(),
     })
     .into_response()
 }

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -398,6 +398,11 @@ pub struct CapacityResponse {
     pub used_memory_mb: u64,
     /// Real disk (GB) consumed by VM storage + overlay files.
     pub used_disk_gb: u64,
+    /// Opaque id minted once per serve process. It changes iff the serve restarts
+    /// — the signal the control uses to detect that this node's warm pool (and any
+    /// in-memory VM state) was wiped, so it can prune the now-stale pool records.
+    #[serde(default)]
+    pub boot_id: String,
 }
 
 // ============================================================================


### PR DESCRIPTION
Report a per-process boot id in the capacity endpoint so the control can detect a serve restart and prune the node's now-stale warm pool.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/563">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->