### PR TITLE
Return 404 for a missing registry image and carry raw exec output bytes alongside the lossy text

### DIFF
--- a/src/api/handlers/exec.rs
+++ b/src/api/handlers/exec.rs
@@ -110,9 +110,12 @@ pub async fn exec_command(
             })
             .await?
         };
+        let stdout = format!("pid={pid}\n");
         return Ok(Json(ExecResponse {
             exit_code: 0,
-            stdout: format!("pid={pid}\n"),
+            stdout_b64: stdout.clone().into_bytes(),
+            stdout,
+            stderr_b64: Vec::new(),
             stderr: String::new(),
         }));
     }
@@ -172,6 +175,8 @@ pub async fn exec_command(
         exit_code,
         stdout: String::from_utf8_lossy(&stdout).into_owned(),
         stderr: String::from_utf8_lossy(&stderr).into_owned(),
+        stdout_b64: stdout,
+        stderr_b64: stderr,
     }))
 }
 
@@ -357,6 +362,8 @@ pub async fn run_command(
         exit_code,
         stdout: String::from_utf8_lossy(&stdout).into_owned(),
         stderr: String::from_utf8_lossy(&stderr).into_owned(),
+        stdout_b64: stdout,
+        stderr_b64: stderr,
     }))
 }
 

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -1527,6 +1527,8 @@ pub async fn exec_machine(
             exit_code,
             stdout: String::from_utf8_lossy(&stdout).into_owned(),
             stderr: String::from_utf8_lossy(&stderr).into_owned(),
+            stdout_b64: stdout,
+            stderr_b64: stderr,
         })
     })
     .await
@@ -1792,7 +1794,17 @@ async fn pull_from_registry(
 
     let result = smolvm_registry::pull(&client, &repo, tag_or_digest, None, &cache)
         .await
-        .map_err(|e| ApiError::internal(format!("registry pull failed: {}", e)))?;
+        .map_err(|e| match &e {
+            // A missing image/manifest is the caller's mistake (typo'd ref, or a
+            // bare name that resolved to an empty repo) — surface it as 404, not a
+            // 500. A 500 here misreports a client error as a server fault and
+            // pollutes the fleet error-rate SLO on every bad reference.
+            smolvm_registry::RegistryError::BlobNotFound(_)
+            | smolvm_registry::RegistryError::ApiError { status: 404, .. } => {
+                ApiError::NotFound(format!("image not found in registry: {}", e))
+            }
+            _ => ApiError::internal(format!("registry pull failed: {}", e)),
+        })?;
 
     tracing::info!(path = %result.path.display(), cached = result.cached, "pull complete");
 

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -174,25 +174,31 @@ impl EnvVar {
 
 /// Command execution result.
 ///
-/// **Encoding note**: `stdout` and `stderr` are UTF-8 text. Non-UTF-8 bytes
-/// in the underlying command output are replaced with the Unicode
-/// replacement character (U+FFFD). This is a limitation of JSON-over-HTTP,
-/// not of smolvm itself — the agent preserves bytes end-to-end. If you need
-/// binary output (image bytes, tarballs, etc.), use the CLI `smolvm machine
-/// exec` which writes raw bytes to stdout/stderr, or pipe through `base64`
-/// inside the command.
+/// **Encoding note**: `stdout`/`stderr` are a lossy UTF-8 view (non-UTF-8 bytes
+/// become U+FFFD) kept for older clients. `stdoutB64`/`stderrB64` carry the raw,
+/// byte-exact output (base64) and should be preferred by callers that need
+/// binary-safe results (image bytes, tarballs, etc.) — the agent preserves
+/// bytes end-to-end and these fields do too.
 #[derive(Debug, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ExecResponse {
     /// Exit code.
     #[schema(example = 0)]
     pub exit_code: i32,
-    /// Standard output as UTF-8 text. Non-UTF-8 bytes → U+FFFD.
+    /// Standard output, lossy UTF-8 (non-UTF-8 bytes → U+FFFD). Prefer `stdoutB64`.
     #[schema(example = "hello\n")]
     pub stdout: String,
-    /// Standard error as UTF-8 text. Non-UTF-8 bytes → U+FFFD.
+    /// Standard error, lossy UTF-8 (non-UTF-8 bytes → U+FFFD). Prefer `stderrB64`.
     #[schema(example = "")]
     pub stderr: String,
+    /// Raw stdout bytes, base64-encoded — byte-exact, binary-safe.
+    #[serde(with = "smolvm_protocol::base64_bytes")]
+    #[schema(value_type = String)]
+    pub stdout_b64: Vec<u8>,
+    /// Raw stderr bytes, base64-encoded — byte-exact, binary-safe.
+    #[serde(with = "smolvm_protocol::base64_bytes")]
+    #[schema(value_type = String)]
+    pub stderr_b64: Vec<u8>,
 }
 
 /// Request to export a stopped machine to a `.smolmachine` and push it to a


### PR DESCRIPTION
Return 404 for a missing registry image and carry raw exec output bytes alongside the lossy text.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/565">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->