### PR TITLE
Brokered P2P layer-blob sharing (engine side)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2320,6 +2320,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "toml",
  "tower-http",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,8 @@ rustls-pemfile = "2"
 rustls-pki-types = "1"
 tower-http = { version = "0.6", features = ["cors", "trace", "timeout"] }
 tokio-stream = "0.1"
+# ReaderStream for streaming a cached blob from disk to a peer (GET /p2p/blob).
+tokio-util = { version = "0.7", features = ["io"] }
 parking_lot = "0.12"
 async-stream = "0.3"
 futures-util = "0.3"

--- a/crates/smolvm-registry/src/client.rs
+++ b/crates/smolvm-registry/src/client.rs
@@ -58,7 +58,11 @@ async fn read_body_capped(mut resp: reqwest::Response, cap: usize, what: &str) -
 }
 
 /// Validate that a digest string matches the expected `sha256:<64 hex chars>` format.
-pub(crate) fn validate_digest(digest: &str) -> Result<()> {
+///
+/// Public so callers that build a filesystem path (e.g. the serve-side P2P blob
+/// handler) can reject a malformed, path-traversing digest at their boundary,
+/// exactly as `pull` does before touching the cache.
+pub fn validate_digest(digest: &str) -> Result<()> {
     if let Some(hex_part) = digest.strip_prefix("sha256:") {
         if hex_part.len() == 64 && hex_part.chars().all(|c| c.is_ascii_hexdigit()) {
             return Ok(());

--- a/crates/smolvm-registry/src/lib.rs
+++ b/crates/smolvm-registry/src/lib.rs
@@ -5,11 +5,12 @@
 
 pub mod cache;
 pub mod client;
+pub mod peer;
 pub mod pull;
 pub mod push;
 
 pub use cache::BlobCache;
-pub use client::RegistryClient;
+pub use client::{validate_digest, RegistryClient};
 pub use pull::{pull, PullResult};
 pub use push::{push, PushResult};
 

--- a/crates/smolvm-registry/src/peer.rs
+++ b/crates/smolvm-registry/src/peer.rs
@@ -1,0 +1,356 @@
+//! Brokered peer-to-peer layer-blob fetch.
+//!
+//! On a cache miss, before falling back to the registry, [`pull`](crate::pull)
+//! can fetch a layer blob from a sibling fleet node's `GET /p2p/blob/<digest>`
+//! endpoint over node→node mTLS. The candidate peers are supplied by the control
+//! plane (in the machine-create request body); when none are supplied, none of
+//! this code runs and the pull path is byte-for-byte the registry path.
+//!
+//! ## Trust model / security
+//!
+//! The serve-side `GET /p2p/blob/<digest>` is reachable by ANY client whose cert
+//! chains to the fleet node-CA, so on a MULTI-TENANT fleet it is a cross-tenant
+//! read oracle for private blobs: a node that knows (or guesses) another
+//! tenant's private layer digest can read that layer. This is bounded by mTLS
+//! (only fleet nodes reach it) and by sha256 pre-image resistance (you must
+//! already possess the exact digest), but it is NOT tenant-scoped.
+//!
+//! A broker-minted, request-scoped token binding the requester to the specific
+//! reference's layer digests (verified at the app layer on top of mTLS) is
+//! REQUIRED before enabling P2P on a multi-tenant fleet that hosts PRIVATE
+//! artifacts. As shipped, P2P is safe on single-tenant or public-artifact fleets
+//! and is off by default (peers only arrive when the control plane sends them).
+
+use crate::cache::BlobCache;
+use crate::pull::{stream_verify_adopt, PullResult};
+use crate::{RegistryError, Result};
+use std::path::Path;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+/// The node's own mTLS material, REUSED from the serve listener (`serve_tls.rs`):
+/// a node presents its server cert/key as the *client* identity to a peer, and
+/// trusts peer server certs chained to the same node-CA.
+const ENV_CERT: &str = "SMOLVM_SERVE_TLS_CERT";
+const ENV_KEY: &str = "SMOLVM_SERVE_TLS_KEY";
+const ENV_CLIENT_CA: &str = "SMOLVM_SERVE_TLS_CLIENT_CA";
+
+/// Bound on how long a single dead/unreachable peer may stall a launch before we
+/// give up on it and move to the next peer (and ultimately the registry).
+const PEER_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+/// Idle-read bound: abort a peer that accepts the connection but then stalls
+/// mid-body. This is per-read, not a whole-response deadline, so a large but
+/// steady blob transfer is never cut off.
+const PEER_READ_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Process-wide node→node mTLS client, built once from the serve-TLS env vars.
+///
+/// Returns `None` (P2P disabled, registry-only) if the mTLS material is absent or
+/// unparseable — a node with no serve identity simply never does P2P.
+pub(crate) fn peer_client() -> Option<&'static reqwest::Client> {
+    static CLIENT: OnceLock<Option<reqwest::Client>> = OnceLock::new();
+    CLIENT
+        .get_or_init(|| match build_peer_client() {
+            Ok(client) => Some(client),
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "P2P blob fetch disabled: could not build node->node mTLS client"
+                );
+                None
+            }
+        })
+        .as_ref()
+}
+
+/// Build the node→node mTLS client: our node cert/key as the client identity,
+/// trusting only the fleet node-CA (built-in roots disabled — peers are private
+/// fleet nodes, never public CAs).
+fn build_peer_client() -> std::result::Result<reqwest::Client, String> {
+    let cert = read_env_file(ENV_CERT)?;
+    let key = read_env_file(ENV_KEY)?;
+    let ca = read_env_file(ENV_CLIENT_CA)?;
+
+    // reqwest's rustls identity wants the cert chain and private key in a single
+    // PEM buffer.
+    let mut identity_pem = cert;
+    identity_pem.push(b'\n');
+    identity_pem.extend_from_slice(&key);
+    let identity = reqwest::Identity::from_pem(&identity_pem)
+        .map_err(|e| format!("build client identity from {ENV_CERT}/{ENV_KEY}: {e}"))?;
+
+    let ca_cert = reqwest::Certificate::from_pem(&ca)
+        .map_err(|e| format!("parse node CA from {ENV_CLIENT_CA}: {e}"))?;
+
+    reqwest::Client::builder()
+        .use_rustls_tls()
+        // Peers are private fleet nodes signed by our node-CA; do not trust the
+        // public web PKI for node→node traffic.
+        .tls_built_in_root_certs(false)
+        .add_root_certificate(ca_cert)
+        .identity(identity)
+        .connect_timeout(PEER_CONNECT_TIMEOUT)
+        .read_timeout(PEER_READ_TIMEOUT)
+        .build()
+        .map_err(|e| format!("build node->node mTLS client: {e}"))
+}
+
+/// Read the file named by env var `name`. Errs (rather than panics) so a missing
+/// or unreadable cert just disables P2P instead of taking the process down.
+fn read_env_file(name: &str) -> std::result::Result<Vec<u8>, String> {
+    let path = std::env::var_os(name)
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| format!("{name} is unset"))?;
+    std::fs::read(&path).map_err(|e| format!("read {name} ({}): {e}", Path::new(&path).display()))
+}
+
+/// Try each peer's `GET /p2p/blob/<digest>` in order, returning the first blob
+/// that streams and verifies against `digest`. Returns `None` when every peer
+/// fails — the caller then falls back to the registry.
+///
+/// Never returns `Err`: a peer failure (connect / timeout / non-200 / 404 /
+/// digest mismatch) is logged and the next peer is tried. Any `.partial` a
+/// failed attempt leaves is removed so the next source (peer or registry) starts
+/// from a clean slate.
+pub(crate) async fn fetch_blob_from_peers(
+    client: &reqwest::Client,
+    peers: &[String],
+    digest: &str,
+    output: Option<&Path>,
+    cache: &BlobCache,
+) -> Option<PullResult> {
+    let partial_path = cache.blob_path_for(digest).with_extension("partial");
+
+    for peer in peers {
+        match fetch_one(client, peer, digest, output, cache).await {
+            Ok(result) => {
+                tracing::info!(peer = %peer, digest = %digest, "fetched layer blob from peer (P2P)");
+                return Some(result);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    peer = %peer,
+                    digest = %digest,
+                    error = %e,
+                    "P2P peer fetch failed; trying next source"
+                );
+                // Drop any partial this attempt wrote so the next peer / the
+                // registry fallback starts clean.
+                let _ = tokio::fs::remove_file(&partial_path).await;
+            }
+        }
+    }
+    None
+}
+
+/// Fetch one blob from a single peer: `GET <peer>/p2p/blob/<digest>`, check the
+/// status, then stream→hash→verify→adopt through the shared pull helper.
+async fn fetch_one(
+    client: &reqwest::Client,
+    peer: &str,
+    digest: &str,
+    output: Option<&Path>,
+    cache: &BlobCache,
+) -> Result<PullResult> {
+    let url = format!("{}/p2p/blob/{}", peer.trim_end_matches('/'), digest);
+    let resp = client.get(&url).send().await.map_err(RegistryError::Http)?;
+
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        return Err(RegistryError::BlobNotFound(digest.to_string()));
+    }
+    if !resp.status().is_success() {
+        return Err(RegistryError::ApiError {
+            status: resp.status().as_u16(),
+            body: resp.text().await.unwrap_or_default(),
+        });
+    }
+
+    // Identical verification + cache accounting to the registry path: the digest
+    // is re-checked while streaming, so a lying peer can never poison the cache.
+    stream_verify_adopt(resp.bytes_stream(), digest, output, cache).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    // A valid, well-formed sha256 digest of the test blob below. Computed once
+    // so the tests assert against a real content address, not a placeholder.
+    fn blob_and_digest() -> (Vec<u8>, String) {
+        use sha2::{Digest, Sha256};
+        let data = b"the-quick-brown-fox-p2p-blob".to_vec();
+        let digest = format!("sha256:{}", hex::encode(Sha256::digest(&data)));
+        (data, digest)
+    }
+
+    fn cache() -> (tempfile::TempDir, BlobCache) {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = BlobCache::open(tmp.path().to_path_buf(), 1024 * 1024).unwrap();
+        (tmp, cache)
+    }
+
+    /// Mount `GET /p2p/blob/<digest>` on `server` returning `status` with `body`.
+    async fn mount_blob(server: &MockServer, digest: &str, status: u16, body: Vec<u8>) {
+        Mock::given(method("GET"))
+            .and(path(format!("/p2p/blob/{digest}")))
+            .respond_with(ResponseTemplate::new(status).set_body_bytes(body))
+            .mount(server)
+            .await;
+    }
+
+    /// Peer hit → the blob is adopted into the cache and returned. The registry
+    /// is never consulted (this helper takes no registry at all).
+    #[tokio::test]
+    async fn peer_hit_adopts_blob() {
+        let (data, digest) = blob_and_digest();
+        let (_tmp, cache) = cache();
+        let peer = MockServer::start().await;
+        mount_blob(&peer, &digest, 200, data.clone()).await;
+
+        let client = reqwest::Client::new();
+        let result = fetch_blob_from_peers(&client, &[peer.uri()], &digest, None, &cache)
+            .await
+            .expect("peer hit must yield a result");
+
+        assert_eq!(result.digest, digest);
+        assert_eq!(result.size, data.len() as u64);
+        assert!(!result.cached);
+        // Adopted through the same LRU path — a subsequent cache lookup hits.
+        let cached = cache
+            .get(&digest)
+            .expect("blob must be in cache after peer fetch");
+        assert_eq!(std::fs::read(cached).unwrap(), data);
+    }
+
+    /// First peer 404s; the fetch cleanly falls through to the next peer.
+    #[tokio::test]
+    async fn peer_404_falls_through_to_next_peer() {
+        let (data, digest) = blob_and_digest();
+        let (_tmp, cache) = cache();
+
+        let miss = MockServer::start().await;
+        mount_blob(&miss, &digest, 404, Vec::new()).await;
+        let hit = MockServer::start().await;
+        mount_blob(&hit, &digest, 200, data.clone()).await;
+
+        let client = reqwest::Client::new();
+        let result =
+            fetch_blob_from_peers(&client, &[miss.uri(), hit.uri()], &digest, None, &cache)
+                .await
+                .expect("second peer must satisfy the fetch");
+        assert_eq!(result.size, data.len() as u64);
+    }
+
+    /// A peer that returns the WRONG bytes (digest mismatch) is skipped, its
+    /// partial is cleaned up, and the next peer succeeds.
+    #[tokio::test]
+    async fn peer_digest_mismatch_falls_through_and_cleans_partial() {
+        let (data, digest) = blob_and_digest();
+        let (_tmp, cache) = cache();
+
+        let liar = MockServer::start().await;
+        mount_blob(&liar, &digest, 200, b"totally-different-bytes".to_vec()).await;
+        let honest = MockServer::start().await;
+        mount_blob(&honest, &digest, 200, data.clone()).await;
+
+        let client = reqwest::Client::new();
+        let result =
+            fetch_blob_from_peers(&client, &[liar.uri(), honest.uri()], &digest, None, &cache)
+                .await
+                .expect("honest peer must satisfy the fetch");
+        assert_eq!(result.size, data.len() as u64);
+
+        // No leftover partial from the mismatching peer.
+        let partial = cache.blob_path_for(&digest).with_extension("partial");
+        assert!(!partial.exists(), "partial must be cleaned after mismatch");
+    }
+
+    /// A peer that stalls past the client's timeout is abandoned; the next peer
+    /// serves the blob. Uses a test-local client with a tiny timeout (production
+    /// uses connect+read timeouts).
+    #[tokio::test]
+    async fn peer_timeout_falls_through() {
+        let (data, digest) = blob_and_digest();
+        let (_tmp, cache) = cache();
+
+        let slow = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/p2p/blob/{digest}")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(data.clone())
+                    .set_delay(Duration::from_secs(30)),
+            )
+            .mount(&slow)
+            .await;
+        let fast = MockServer::start().await;
+        mount_blob(&fast, &digest, 200, data.clone()).await;
+
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_millis(150))
+            .build()
+            .unwrap();
+        let result =
+            fetch_blob_from_peers(&client, &[slow.uri(), fast.uri()], &digest, None, &cache)
+                .await
+                .expect("fast peer must satisfy the fetch after the slow one times out");
+        assert_eq!(result.size, data.len() as u64);
+    }
+
+    /// Every peer fails → `None`, so the caller falls back to the registry. The
+    /// cache stays empty and no partial is left behind.
+    #[tokio::test]
+    async fn all_peers_fail_returns_none() {
+        let (_data, digest) = blob_and_digest();
+        let (_tmp, cache) = cache();
+
+        let a = MockServer::start().await;
+        mount_blob(&a, &digest, 404, Vec::new()).await;
+        let b = MockServer::start().await;
+        mount_blob(&b, &digest, 500, b"boom".to_vec()).await;
+
+        let client = reqwest::Client::new();
+        let result =
+            fetch_blob_from_peers(&client, &[a.uri(), b.uri()], &digest, None, &cache).await;
+        assert!(result.is_none(), "all-peers-fail must return None");
+        assert!(cache.get(&digest).is_none(), "cache must stay empty");
+        let partial = cache.blob_path_for(&digest).with_extension("partial");
+        assert!(!partial.exists(), "no partial should remain");
+    }
+
+    /// An unreachable peer (connection refused) is a clean failure, not a panic:
+    /// the next peer serves the blob. Covers the connect-error branch that a real
+    /// connect timeout also takes.
+    #[tokio::test]
+    async fn unreachable_peer_falls_through() {
+        let (data, digest) = blob_and_digest();
+        let (_tmp, cache) = cache();
+
+        let hit = MockServer::start().await;
+        mount_blob(&hit, &digest, 200, data.clone()).await;
+
+        let client = reqwest::Client::new();
+        // Port 1 has nothing listening → connection refused.
+        let dead = "http://127.0.0.1:1".to_string();
+        let result = fetch_blob_from_peers(&client, &[dead, hit.uri()], &digest, None, &cache)
+            .await
+            .expect("live peer must satisfy the fetch");
+        assert_eq!(result.size, data.len() as u64);
+    }
+
+    /// With the serve-TLS env vars unset, no peer client can be built, so P2P is
+    /// disabled (registry-only). Guarded by a mutex because it mutates process
+    /// env; other suites don't touch these vars.
+    #[test]
+    fn build_peer_client_errs_when_env_unset() {
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        for v in [ENV_CERT, ENV_KEY, ENV_CLIENT_CA] {
+            std::env::remove_var(v);
+        }
+        let err = build_peer_client().unwrap_err();
+        assert!(err.contains(ENV_CERT), "{err}");
+    }
+}

--- a/crates/smolvm-registry/src/pull.rs
+++ b/crates/smolvm-registry/src/pull.rs
@@ -4,7 +4,8 @@
 //! 1. Fetch the OCI manifest by tag or digest
 //! 2. Parse the manifest to find the layer blob digest
 //! 3. Check the local cache for the blob
-//! 4. If not cached, stream the blob to disk while computing the digest
+//! 4. If not cached, try any brokered P2P peers, then stream from the registry,
+//!    computing the digest while writing
 //! 5. Verify the digest and adopt into cache
 
 use crate::cache::BlobCache;
@@ -33,12 +34,19 @@ pub struct PullResult {
 /// `repo` is the OCI repository path (e.g., "python-dev").
 /// `reference` is the tag or digest (e.g., "latest" or "sha256:abc...").
 /// If `output` is Some, the blob is copied there. Otherwise it's only cached.
+///
+/// `blob_peers` are optional brokered P2P peers (node base URLs, e.g.
+/// `https://<addr>:<port>`) supplied by the control plane. On a cache miss the
+/// layer blob is fetched from a peer's `GET /p2p/blob/<digest>` (over node→node
+/// mTLS) before the registry. When `blob_peers` is empty the peer block is
+/// skipped entirely and the registry path is byte-for-byte what it was before.
 pub async fn pull(
     client: &RegistryClient,
     repo: &str,
     reference: &str,
     output: Option<&Path>,
     cache: &BlobCache,
+    blob_peers: &[String],
 ) -> Result<PullResult> {
     // 1. Fetch the manifest, resolving a multi-platform index to this machine's
     //    host-platform entry (Docker-style fan-out). Shared with `inspect`.
@@ -84,17 +92,60 @@ pub async fn pull(
         });
     }
 
-    // 4. Stream blob to disk while computing digest.
+    // 4. Brokered P2P: try sibling nodes before hitting the registry. Inert when
+    //    `blob_peers` is empty — the registry path below is then reached
+    //    byte-for-byte as before. Peers arrive only from the control plane, and
+    //    a node with no serve-TLS identity has no peer client, so this is also a
+    //    no-op there.
+    if !blob_peers.is_empty() {
+        if let Some(peer_client) = crate::peer::peer_client() {
+            if let Some(result) =
+                crate::peer::fetch_blob_from_peers(peer_client, blob_peers, digest, output, cache)
+                    .await
+            {
+                return Ok(result);
+            }
+            tracing::info!(digest = %digest, "no peer served the blob; falling back to registry");
+        }
+    }
+
+    // 5. Stream blob from the registry to disk while computing + verifying the
+    //    digest, then adopt into cache.
     tracing::info!(digest = %digest, size, "downloading blob...");
 
+    let stream = client.pull_blob_stream(repo, digest).await?;
+    let result = stream_verify_adopt(stream, digest, output, cache).await?;
+
+    tracing::info!(digest = %digest, size = result.size, "pull complete");
+
+    Ok(result)
+}
+
+/// Stream `stream` into the cache's `.partial` file for `digest`, hashing while
+/// writing, verify the digest, adopt into the cache, and copy to `output` if
+/// requested.
+///
+/// Shared by the registry pull path and the P2P peer-fetch path so a blob
+/// obtained either way goes through identical digest verification and the same
+/// LRU/size accounting ([`BlobCache::adopt`]). On a digest mismatch the
+/// `.partial` is removed before returning the error. A mid-stream transport
+/// error propagates as-is (leaving the `.partial`, which the next attempt
+/// truncates via `File::create`), matching the original registry pull behavior.
+pub(crate) async fn stream_verify_adopt<S>(
+    stream: S,
+    digest: &str,
+    output: Option<&Path>,
+    cache: &BlobCache,
+) -> Result<PullResult>
+where
+    S: futures_util::Stream<Item = reqwest::Result<bytes::Bytes>>,
+{
     let partial_path = cache.blob_path_for(digest).with_extension("partial");
     let mut file = tokio::fs::File::create(&partial_path).await?;
     let mut hasher = Sha256::new();
     let mut total_bytes: u64 = 0;
 
-    let stream = client.pull_blob_stream(repo, digest).await?;
     let mut stream = std::pin::pin!(stream);
-
     while let Some(chunk_result) = stream.next().await {
         let chunk: bytes::Bytes = chunk_result.map_err(RegistryError::Http)?;
         hasher.update(&chunk);
@@ -104,7 +155,7 @@ pub async fn pull(
     file.flush().await?;
     drop(file);
 
-    // 5. Verify digest.
+    // Verify digest.
     let actual = format!("sha256:{}", hex::encode(hasher.finalize()));
     if actual != *digest {
         if let Err(e) = tokio::fs::remove_file(&partial_path).await {
@@ -120,10 +171,10 @@ pub async fn pull(
         });
     }
 
-    // 6. Adopt into cache.
+    // Adopt into cache (handles eviction + atomic rename).
     let cached_path = cache.adopt(digest, total_bytes)?;
 
-    // 7. Copy to output if requested.
+    // Copy to output if requested.
     let result_path = if let Some(out) = output {
         tokio::fs::copy(&cached_path, out).await?;
         PathBuf::from(out)
@@ -131,12 +182,72 @@ pub async fn pull(
         cached_path
     };
 
-    tracing::info!(digest = %digest, size = total_bytes, "pull complete");
-
     Ok(PullResult {
         path: result_path,
-        digest: digest.clone(),
+        digest: digest.to_string(),
         size: total_bytes,
         cached: false,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{CONFIG_MEDIA_TYPE, MANIFEST_MEDIA_TYPE};
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// With empty `blob_peers`, `pull` takes the registry path exactly as before:
+    /// fetch the manifest, then stream the layer blob from `/v2/.../blobs/...`,
+    /// verify, and adopt. No peer client is built or consulted.
+    #[tokio::test]
+    async fn empty_blob_peers_uses_registry_path() {
+        use sha2::{Digest, Sha256};
+
+        let data = b"registry-path-layer-bytes".to_vec();
+        let digest = format!("sha256:{}", hex::encode(Sha256::digest(&data)));
+        let config_digest =
+            "sha256:1111111111111111111111111111111111111111111111111111111111111111";
+
+        let manifest = serde_json::json!({
+            "schemaVersion": 2,
+            "mediaType": MANIFEST_MEDIA_TYPE,
+            "config": { "mediaType": CONFIG_MEDIA_TYPE, "digest": config_digest, "size": 2 },
+            "layers": [ { "mediaType": LAYER_MEDIA_TYPE, "digest": digest, "size": data.len() } ],
+        });
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v2/myrepo/manifests/latest"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_raw(serde_json::to_vec(&manifest).unwrap(), MANIFEST_MEDIA_TYPE),
+            )
+            .mount(&server)
+            .await;
+        // The layer blob endpoint must be hit exactly once on the registry path.
+        Mock::given(method("GET"))
+            .and(path(format!("/v2/myrepo/blobs/{digest}")))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(data.clone()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = BlobCache::open(tmp.path().to_path_buf(), 1024 * 1024).unwrap();
+        let client = RegistryClient::new(server.uri());
+
+        let result = pull(&client, "myrepo", "latest", None, &cache, &[])
+            .await
+            .expect("registry pull must succeed");
+
+        assert_eq!(result.digest, digest);
+        assert_eq!(result.size, data.len() as u64);
+        assert!(!result.cached);
+        assert!(
+            cache.get(&digest).is_some(),
+            "blob must be adopted into cache"
+        );
+        // MockServer drop asserts the blob endpoint's expect(1) was satisfied.
+    }
 }

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -336,8 +336,12 @@ pub async fn create_machine(
     // If registry_ref is set, pull the artifact from the registry and treat as `from`
     let mut req = req;
     if let Some(ref registry_ref) = req.registry_ref.clone() {
-        let pulled_path =
-            pull_from_registry(registry_ref, req.registry_identity_token.as_deref()).await?;
+        let pulled_path = pull_from_registry(
+            registry_ref,
+            req.registry_identity_token.as_deref(),
+            &req.blob_peers,
+        )
+        .await?;
         req.from = Some(pulled_path);
         req.registry_ref = None;
     }
@@ -1746,6 +1750,7 @@ pub async fn export_machine(
 async fn pull_from_registry(
     registry_ref: &str,
     identity_token: Option<&str>,
+    blob_peers: &[String],
 ) -> Result<String, ApiError> {
     let parsed = crate::registry::Reference::parse(registry_ref)
         .map_err(|e| ApiError::BadRequest(format!("invalid registry reference: {}", e)))?;
@@ -1792,7 +1797,7 @@ async fn pull_from_registry(
         "pulling .smolmachine from registry"
     );
 
-    let result = smolvm_registry::pull(&client, &repo, tag_or_digest, None, &cache)
+    let result = smolvm_registry::pull(&client, &repo, tag_or_digest, None, &cache, blob_peers)
         .await
         .map_err(|e| match &e {
             // A missing image/manifest is the caller's mistake (typo'd ref, or a
@@ -1996,6 +2001,7 @@ mod tests {
             from: None,
             registry_ref: None,
             registry_identity_token: None,
+            blob_peers: vec![],
             secrets: Default::default(),
         }
     }

--- a/src/api/handlers/mod.rs
+++ b/src/api/handlers/mod.rs
@@ -6,6 +6,7 @@ pub mod health;
 pub mod images;
 pub mod machines;
 pub mod node;
+pub mod p2p;
 pub mod volumes;
 
 use crate::api::error::ApiError;

--- a/src/api/handlers/p2p.rs
+++ b/src/api/handlers/p2p.rs
@@ -1,0 +1,141 @@
+//! Brokered peer-to-peer blob serving.
+//!
+//! `GET /p2p/blob/{digest}` streams a content-addressed layer blob straight from
+//! this node's local blob cache to a sibling fleet node, so a `create` on
+//! another node can pull a hot `.smolmachine` layer from a peer instead of the
+//! registry. Read-only and content-addressed.
+//!
+//! ## Security
+//!
+//! This endpoint is mTLS-gated by the serve listener by construction (like
+//! `/drain`, see the router comment): only a client whose cert chains to the
+//! fleet node-CA can reach it. It is NOT tenant-scoped, so on a multi-tenant
+//! fleet it is a cross-tenant read oracle for private blobs, bounded only by
+//! mTLS + sha256 digest entropy. See [`smolvm_registry::peer`] for the full
+//! trust model and the scoped-token requirement before enabling P2P on a
+//! multi-tenant fleet that hosts private artifacts.
+
+use axum::{
+    body::Body,
+    extract::Path,
+    http::{header, StatusCode},
+    response::{IntoResponse, Response},
+};
+use smolvm_registry::BlobCache;
+use tokio_util::io::ReaderStream;
+
+use crate::api::error::ApiError;
+
+/// Serve a cached layer blob by digest to a peer node.
+///
+/// Opens the default blob cache and delegates to [`serve_blob_from`], which does
+/// the digest validation, lookup, and streaming.
+pub async fn serve_blob(Path(digest): Path<String>) -> Result<Response, ApiError> {
+    let cache = BlobCache::open_default()
+        .map_err(|e| ApiError::internal(format!("open blob cache: {e}")))?;
+    serve_blob_from(&cache, &digest).await
+}
+
+/// Validate the digest, look it up in `cache`, and stream it.
+///
+/// The digest is validated first — the path segment is attacker-influenced and
+/// is used to build a cache filesystem path — then looked up: a miss is `404`, a
+/// hit streams the file from disk. The body is streamed (never buffered) because
+/// a `.smolmachine` layer can be hundreds of MB / multiple GB.
+async fn serve_blob_from(cache: &BlobCache, digest: &str) -> Result<Response, ApiError> {
+    // Reject a malformed / path-traversing digest before it is used to build any
+    // cache path (mirrors the check `pull` runs before touching the cache).
+    smolvm_registry::validate_digest(digest)
+        .map_err(|e| ApiError::BadRequest(format!("invalid blob digest: {e}")))?;
+
+    let Some(path) = cache.get(digest) else {
+        return Err(ApiError::NotFound(format!("blob not cached: {digest}")));
+    };
+
+    let file = tokio::fs::File::open(&path)
+        .await
+        .map_err(|e| ApiError::internal(format!("open cached blob: {e}")))?;
+    let len = file
+        .metadata()
+        .await
+        .map(|m| m.len())
+        .map_err(|e| ApiError::internal(format!("stat cached blob: {e}")))?;
+
+    let body = Body::from_stream(ReaderStream::new(file));
+    Ok((
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, "application/octet-stream".to_string()),
+            (header::CONTENT_LENGTH, len.to_string()),
+        ],
+        body,
+    )
+        .into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+    use sha2::{Digest, Sha256};
+
+    fn temp_cache() -> (tempfile::TempDir, BlobCache) {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = BlobCache::open(tmp.path().to_path_buf(), 1024 * 1024).unwrap();
+        (tmp, cache)
+    }
+
+    fn digest_of(data: &[u8]) -> String {
+        format!("sha256:{}", hex::encode(Sha256::digest(data)))
+    }
+
+    #[tokio::test]
+    async fn present_blob_streams_with_content_length() {
+        let data = b"p2p-served-blob-bytes".to_vec();
+        let digest = digest_of(&data);
+        let (_tmp, cache) = temp_cache();
+        cache.put(&digest, &data).unwrap();
+
+        let resp = serve_blob_from(&cache, &digest)
+            .await
+            .expect("present blob must serve 200")
+            .into_response();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers()
+                .get(header::CONTENT_LENGTH)
+                .and_then(|v| v.to_str().ok()),
+            Some(data.len().to_string().as_str())
+        );
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(body.as_ref(), data.as_slice());
+    }
+
+    #[tokio::test]
+    async fn absent_blob_is_404() {
+        let (_tmp, cache) = temp_cache();
+        let digest = digest_of(b"never-cached");
+        let err = serve_blob_from(&cache, &digest)
+            .await
+            .expect_err("absent blob must be an error");
+        assert!(matches!(err, ApiError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn malformed_digest_is_400() {
+        let (_tmp, cache) = temp_cache();
+
+        // Malformed digest is rejected before any cache access.
+        let err = serve_blob_from(&cache, "sha256:not-a-real-digest")
+            .await
+            .expect_err("malformed digest must be rejected");
+        assert!(matches!(err, ApiError::BadRequest(_)));
+
+        // A path-traversal attempt is likewise a 400, never a filesystem read.
+        let err = serve_blob_from(&cache, "../../etc/passwd")
+            .await
+            .expect_err("path-traversal digest must be rejected");
+        assert!(matches!(err, ApiError::BadRequest(_)));
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -164,6 +164,13 @@ pub fn create_router(state: Arc<ApiState>, cors_origins: Vec<String>) -> Router 
     // loopback door is localhost). See docs/lossless-serve-restart.md.
     let drain_route = Router::new().route("/drain", post(handlers::machines::drain_node));
 
+    // Brokered P2P blob serving: hand a cached layer blob to a sibling node so a
+    // create on another node can pull it from a peer instead of the registry.
+    // Read-only, content-addressed, and mTLS-gated by the listener by
+    // construction (like /drain, see the comment above). No request timeout:
+    // blobs can be large.
+    let p2p_route = Router::new().route("/p2p/blob/{digest}", get(handlers::p2p::serve_blob));
+
     // Long-lived streaming routes (no request timeout): SSE logs and the
     // interactive PTY WebSocket both outlive the 5-minute API timeout.
     let logs_route = Router::new()
@@ -270,6 +277,7 @@ pub fn create_router(state: Arc<ApiState>, cors_origins: Vec<String>) -> Router 
         .merge(health_route)
         .merge(capacity_route)
         .merge(drain_route)
+        .merge(p2p_route)
         .merge(metrics_route)
         .nest("/api/v1", api_v1)
         .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -497,6 +497,12 @@ pub struct CreateMachineRequest {
     /// `.smolmachine`. Takes precedence over any persisted registry credential.
     #[serde(default)]
     pub registry_identity_token: Option<String>,
+    /// Brokered P2P blob peers: node base URLs (`https://<addr>:<port>`) supplied
+    /// by the control plane. On a cache miss the layer blob is fetched from a
+    /// peer's `GET /p2p/blob/<digest>` (over node→node mTLS) before the registry.
+    /// Empty (the default) ⇒ registry-only, byte-for-byte as before.
+    #[serde(default)]
+    pub blob_peers: Vec<String>,
     /// Secret refs attached to the machine. Resolved at every
     /// subsequent exec against the host's env/files. Rejected unless empty;
     /// accepted — `from_env`/`from_file` on the API surface would let

--- a/src/cli/pack.rs
+++ b/src/cli/pack.rs
@@ -1814,6 +1814,20 @@ impl PackPullCmd {
         let cache = smolvm_registry::BlobCache::open_default()
             .map_err(|e| Error::agent("open blob cache", e.to_string()))?;
 
+        // Optional brokered P2P peers for this one-shot CLI pull. Process-global
+        // env is fine here (single-shot command). Comma-separated node base URLs;
+        // empty/unset ⇒ registry-only.
+        let blob_peers: Vec<String> = std::env::var("SMOLVM_BLOB_PEERS")
+            .ok()
+            .map(|v| {
+                v.split(',')
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(String::from)
+                    .collect()
+            })
+            .unwrap_or_default();
+
         let result = rt
             .block_on(smolvm_registry::pull(
                 &client,
@@ -1821,6 +1835,7 @@ impl PackPullCmd {
                 tag_or_digest,
                 self.output.as_deref(),
                 &cache,
+                &blob_peers,
             ))
             .map_err(|e| Error::agent("registry pull", e.to_string()))?;
 


### PR DESCRIPTION
Adds optional node-to-node P2P layer-blob fetch/serve to the engine: on a cache miss `smolvm_registry::pull` tries each control-plane-supplied peer's `GET /p2p/blob/<digest>` over node-to-node mTLS before the registry (clean fallback on any peer failure), each node serves its local blob cache at that same route, and the whole thing is inert — the registry path is byte-for-byte unchanged — when no `blobPeers` are supplied.

**Security:** `GET /p2p/blob/<digest>` is reachable by any node-CA-signed client, so on a multi-tenant fleet it is a cross-tenant read oracle for private blobs (bounded by mTLS + sha256 digest entropy, but not tenant-scoped). A broker-minted, request-scoped token binding the requester to the reference's layer digests (verified at the app layer on top of mTLS) is REQUIRED before enabling P2P on a multi-tenant fleet with PRIVATE artifacts; v1 is safe on single-tenant / public-artifact fleets and is off by default (peers only arrive when the control plane sends them).


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/566">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->