### PR TITLE
Bump the libkrunfw submodule to 6.12.95 so overlay re-cuts carry the current guest kernel

### DIFF
--- a/lib/libkrun.provenance
+++ b/lib/libkrun.provenance
@@ -3,4 +3,4 @@
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
 libkrun=6687f4d5b89bf7b6cd0e1cf92889fad81a00238d
-libkrunfw=e8f581cdbe758ae7f48322b00b79de599f1291ce
+libkrunfw=37f73dadb7e64610642d7041c163b8dbf0e9a1ef

--- a/lib/libkrunfw.5.dylib
+++ b/lib/libkrunfw.5.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3539cf296df21a64c0b768a2b48ea035bbaaf1c824c45b807ac6e9e8ab49ea11
+oid sha256:3ddcca79131bdbbd3f1d4dc2832459d990c303252260ff1329c0321d0e955935
 size 13118480

--- a/lib/linux-aarch64/libkrun.provenance
+++ b/lib/linux-aarch64/libkrun.provenance
@@ -3,4 +3,4 @@
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
 libkrun=6687f4d5b89bf7b6cd0e1cf92889fad81a00238d
-libkrunfw=e8f581cdbe758ae7f48322b00b79de599f1291ce
+libkrunfw=37f73dadb7e64610642d7041c163b8dbf0e9a1ef

--- a/lib/linux-aarch64/libkrunfw.so.5.5.0
+++ b/lib/linux-aarch64/libkrunfw.so.5.5.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4569f64d735e8bdacffe611a4035eeb93689acded694d50be8dbeb51b47e26b6
+oid sha256:7da48d831e85c9908d713dd24f860a1324f4554a63804c3cc7e8a90dcf3dcfe3
 size 13239912

--- a/lib/linux-x86_64/libkrun.provenance
+++ b/lib/linux-x86_64/libkrun.provenance
@@ -3,4 +3,4 @@
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
 libkrun=6687f4d5b89bf7b6cd0e1cf92889fad81a00238d
-libkrunfw=e8f581cdbe758ae7f48322b00b79de599f1291ce
+libkrunfw=37f73dadb7e64610642d7041c163b8dbf0e9a1ef

--- a/lib/linux-x86_64/libkrunfw.so.5.5.0
+++ b/lib/linux-x86_64/libkrunfw.so.5.5.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:abe25057de5dd7087ec49e181c02135b7eea9f3a6cffe6ce04374b928ea714fc
+oid sha256:7a50055fa114459642ae45e4492f81a5ced2e4cbc5226eb715cb34c637c6b8e5
 size 14878392

--- a/lib/windows-x86_64/libkrun.provenance
+++ b/lib/windows-x86_64/libkrun.provenance
@@ -3,4 +3,4 @@
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
 libkrun=6687f4d5b89bf7b6cd0e1cf92889fad81a00238d
-libkrunfw=e8f581cdbe758ae7f48322b00b79de599f1291ce
+libkrunfw=37f73dadb7e64610642d7041c163b8dbf0e9a1ef

--- a/lib/windows-x86_64/libkrunfw.dll
+++ b/lib/windows-x86_64/libkrunfw.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:82e81b1c1bf789723033c6b66df3fcaccae307b3deb2349edfb3be13209a2cc8
+oid sha256:d07efdc977572b50797c5cc9656d2d3ba9db06f54568a59bea402d5c9d58bdb6
 size 19338676


### PR DESCRIPTION
Advances the libkrunfw submodule from e8f581c to 37f73da (smol-machines/libkrunfw#11), moving the bundled guest kernel from 6.12.94 to 6.12.95 — the current 6.12 longterm point release — plus the #10 kernel-download-retry fix. Routine guest-kernel hygiene; stays on the 6.12 LTS line so all 33 out-of-tree patches continue to apply (validated: both x86_64 and aarch64 build with zero rejects and boot cleanly). The prod fleet's libkrunfw.so was already swapped in-place per node; this makes the bump durable so a future overlay re-cut ships the same kernel rather than reverting to 6.12.94.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/567">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->