### PR TITLE
nix/smolvm: Update to latest github release

### DIFF
--- a/nix/smolvm.nix
+++ b/nix/smolvm.nix
@@ -7,23 +7,24 @@
   gcc-unwrapped,
   bzip2,
 }: let
-  version = "0.8.2";
+  version = "1.4.7";
 
   releases = {
     x86_64-linux = {
       asset = "smolvm-${version}-linux-x86_64.tar.gz";
       root = "smolvm-${version}-linux-x86_64";
-      hash = "sha256-FEzCyn9yauzy/ydXZxeD2DK1cXVg2XYlOil6UeUKJeA=";
+      hash = "sha256-KmdN7GDx+u4PB3RqWGDnSXgtC+4JoGnTn2HFUADLTfc=";
     };
     aarch64-linux = {
       asset = "smolvm-${version}-linux-arm64.tar.gz";
       root = "smolvm-${version}-linux-arm64";
-      hash = "sha256-214tjfCntQbk40FiX3TleC9c2xQA0GuTAzJ1QDisn18=";
+      hash = "sha256-SFwSbfO9K7stwcq60IwMQ7ceKvDpBYkHcFJnnUtxL80=";
     };
     aarch64-darwin = {
       asset = "smolvm-${version}-darwin-arm64.tar.gz";
       root = "smolvm-${version}-darwin-arm64";
-      hash = "sha256-jDHrgsq/Ca0UKahufRHMuA2B/i4Y2JKKUpDqWmVWKgI=";
+      hash = "sha256-pJkgLg9uCnNZUz/MEtnbpof3YkcLLfWGLt5UL02PQjo=";
+
     };
   };
 


### PR DESCRIPTION
The nix packages are a little weird in that they fetch releases instead of build, also pinned to specific releases. Update the pin for now, and in the future either get actual nix builds going or add automation to bump this on releases.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/571">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->