### PR TITLE
Display init commands progress

### DIFF
--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -263,7 +263,18 @@ pub(crate) fn run_init_commands(
                 context.overlay_id,
             )
             .with_tty(true);
-            client.run_interactive(config)?;
+            // Interactive run streams the command's output live so the user sees
+            // progress (a slow compile, apt-get, etc.). The output isn't buffered
+            // here, so on a non-zero exit we report just the code — the detail was
+            // already printed above. Not checking the exit code would silently
+            // ignore a failed init command (e.g. a broken `apt install`).
+            let exit_code = client.run_interactive(config)?;
+            if exit_code != 0 {
+                return Err(smolvm::Error::agent(
+                    "init",
+                    format_init_failure(i, exit_code, "", ""),
+                ));
+            }
         } else {
             let (exit_code, stdout, stderr) = client.vm_exec(
                 init_argv(cmd),

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -252,7 +252,7 @@ pub(crate) fn run_init_commands(
     }
     println!("Running {} init command(s)...", init.len());
     for (i, cmd) in init.iter().enumerate() {
-        let (exit_code, stdout, stderr) = if let Some(image) = context.image {
+        if let Some(image) = context.image {
             let defaults =
                 resolve_image_runtime_defaults(context.image_info, context.env, context.workdir);
             let config = build_init_run_config(
@@ -261,30 +261,31 @@ pub(crate) fn run_init_commands(
                 &defaults,
                 context.record_mounts,
                 context.overlay_id,
-            );
-            client.run_non_interactive(config)?
+            )
+            .with_tty(true);
+            client.run_interactive(config)?;
         } else {
-            client.vm_exec(
+            let (exit_code, stdout, stderr) = client.vm_exec(
                 init_argv(cmd),
                 context.env.to_vec(),
                 context.workdir.map(|s| s.to_string()),
                 None,
                 None,
-            )?
+            )?;
+            if exit_code != 0 {
+                // Init output is generally text — lossy conversion is fine for
+                // error messages. Binary init output isn't a real use case.
+                return Err(smolvm::Error::agent(
+                    "init",
+                    format_init_failure(
+                        i,
+                        exit_code,
+                        &String::from_utf8_lossy(&stdout),
+                        &String::from_utf8_lossy(&stderr),
+                    ),
+                ));
+            }
         };
-        if exit_code != 0 {
-            // Init output is generally text — lossy conversion is fine for
-            // error messages. Binary init output isn't a real use case.
-            return Err(smolvm::Error::agent(
-                "init",
-                format_init_failure(
-                    i,
-                    exit_code,
-                    &String::from_utf8_lossy(&stdout),
-                    &String::from_utf8_lossy(&stderr),
-                ),
-            ));
-        }
     }
     Ok(())
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -1181,7 +1181,7 @@ fn make_idmap_userns(uid: u32, gid: u32) -> std::io::Result<libc::c_int> {
         if unsafe { libc::unshare(libc::CLONE_NEWUSER) } != 0 {
             unsafe { libc::_exit(1) };
         }
-        let sig: [u8; 1] = [b'r'];
+        let sig: [u8; 1] = *b"r";
         unsafe {
             libc::write(ready[1], sig.as_ptr() as *const libc::c_void, 1);
         }
@@ -1203,7 +1203,7 @@ fn make_idmap_userns(uid: u32, gid: u32) -> std::io::Result<libc::c_int> {
     // Write the maps from the privileged parent. A single entry mapping host id
     // `uid`/`gid` is permitted via the ns-creator's CAP_SETUID/CAP_SETGID path.
     let finish = |result: std::io::Result<libc::c_int>| -> std::io::Result<libc::c_int> {
-        let go_w: [u8; 1] = [b'x'];
+        let go_w: [u8; 1] = *b"x";
         unsafe {
             libc::write(go[1], go_w.as_ptr() as *const libc::c_void, 1);
             libc::close(go[1]);


### PR DESCRIPTION
The init commands stdout were not displayed, meaning we had no idea of the progress. If some commands are very slow (compiling,…) it was not clear to the user if something was happening or not.

(not sure about the `tty` part)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/573">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->