### PR TITLE
Fix the clippy byte_char_slices lint failing CI on main

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -1181,7 +1181,7 @@ fn make_idmap_userns(uid: u32, gid: u32) -> std::io::Result<libc::c_int> {
         if unsafe { libc::unshare(libc::CLONE_NEWUSER) } != 0 {
             unsafe { libc::_exit(1) };
         }
-        let sig: [u8; 1] = [b'r'];
+        let sig: [u8; 1] = *b"r";
         unsafe {
             libc::write(ready[1], sig.as_ptr() as *const libc::c_void, 1);
         }
@@ -1203,7 +1203,7 @@ fn make_idmap_userns(uid: u32, gid: u32) -> std::io::Result<libc::c_int> {
     // Write the maps from the privileged parent. A single entry mapping host id
     // `uid`/`gid` is permitted via the ns-creator's CAP_SETUID/CAP_SETGID path.
     let finish = |result: std::io::Result<libc::c_int>| -> std::io::Result<libc::c_int> {
-        let go_w: [u8; 1] = [b'x'];
+        let go_w: [u8; 1] = *b"x";
         unsafe {
             libc::write(go[1], go_w.as_ptr() as *const libc::c_void, 1);
             libc::close(go[1]);


### PR DESCRIPTION
Clippy 1.97 promoted byte_char_slices to a default-deny lint, so `cargo clippy -- -D warnings` now fails main on two single-byte array literals in the userns fork sync (`[b'r']`, `[b'x']`) — the Linux x86_64 and aarch64 CI jobs went red on the newest commit. Write them as `*b"r"` / `*b"x"`, which keeps the exact `[u8; 1]` type and runtime behaviour while satisfying the lint.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/575">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->