### PR TITLE
virtiofs: give user volumes and packed layers a DAX window

### DIFF
--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -553,6 +553,15 @@ pub fn launch_agent_vm_dynamic(
         free_ctx_on_err!("krun_set_exec failed");
     }
 
+    // Every virtiofs mount gets a DAX window (like the root fs above): without
+    // DAX, virtiofs falls back to writeback caching where each file access is a
+    // FUSE round-trip over the virtio queue — pathological for read-heavy mounts
+    // with many files (a multi-GB Python venv took minutes just to import, and a
+    // single file larger than the window stalled entirely). 2 GiB exceeds any
+    // realistic single mapped file; the window is virtual host address space
+    // backed on demand, so oversizing costs nothing until touched.
+    const VIRTIOFS_DAX_WINDOW: u64 = 1 << 31;
+
     // Add virtiofs mount for packed layers (AFTER set_exec)
     if config.layers_dir.exists() {
         let layers_tag = cstr("smolvm_layers");
@@ -561,7 +570,16 @@ pub fn launch_agent_vm_dynamic(
             "layers dir path contains null byte"
         );
         // SAFETY: ctx is valid, tag and path are valid C strings
-        if unsafe { (krun.add_virtiofs)(ctx, layers_tag.as_ptr(), layers_path.as_ptr()) } < 0 {
+        if unsafe {
+            add_virtiofs3(
+                ctx,
+                layers_tag.as_ptr(),
+                layers_path.as_ptr(),
+                VIRTIOFS_DAX_WINDOW,
+                false,
+            )
+        } < 0
+        {
             free_ctx_on_err!("krun_add_virtiofs failed for packed layers");
         }
     }
@@ -578,7 +596,16 @@ pub fn launch_agent_vm_dynamic(
         );
 
         // SAFETY: ctx is valid, tag and host_path are valid C strings
-        if unsafe { (krun.add_virtiofs)(ctx, tag.as_ptr(), host_path.as_ptr()) } < 0 {
+        if unsafe {
+            add_virtiofs3(
+                ctx,
+                tag.as_ptr(),
+                host_path.as_ptr(),
+                VIRTIOFS_DAX_WINDOW,
+                mount.read_only,
+            )
+        } < 0
+        {
             free_ctx_on_err!(format!(
                 "krun_add_virtiofs failed for '{}' - requested mount cannot be attached",
                 mount.tag

--- a/src/vm/backend/libkrun.rs
+++ b/src/vm/backend/libkrun.rs
@@ -238,13 +238,34 @@ impl LibkrunVm {
                 return Err(Error::vm_creation("failed to set exec command"));
             }
 
-            // Add virtiofs mounts for host directories
+            // Add virtiofs mounts for host directories. Prefer krun_add_virtiofs3
+            // with a DAX window (like the root fs): without DAX, virtiofs falls
+            // back to writeback caching where every file access is a FUSE
+            // round-trip over the virtio queue — pathological for read-heavy
+            // mounts with many files (e.g. a multi-GB Python venv taking minutes
+            // just to import). DAX maps file contents through a coherent host
+            // window, giving near-native read throughput. Fall back to the plain
+            // API only on an older libkrun that lacks virtiofs3.
+            // 2 GiB: the window must exceed the largest single file mapped from
+            // the volume, or mapping that file stalls (a 902 MB libtorch_cuda.so
+            // hung against a 512 MB window). The window is virtual host address
+            // space backed on demand, so oversizing costs nothing until touched.
+            const VIRTIOFS_DAX_WINDOW: u64 = 1 << 31;
             for (i, mount) in config.mounts.iter().enumerate() {
                 let tag = CString::new(HostMount::mount_tag(i))
                     .map_err(|_| Error::mount("create mount tag", "tag contains null byte"))?;
                 let path = path_to_cstring(&mount.source)?;
 
-                if krun_add_virtiofs(ctx, tag.as_ptr(), path.as_ptr()) < 0 {
+                // `krun_add_virtiofs3` is already unwrapped above (the root fs
+                // requires it), so use it directly with a DAX window.
+                let ret = krun_add_virtiofs3(
+                    ctx,
+                    tag.as_ptr(),
+                    path.as_ptr(),
+                    VIRTIOFS_DAX_WINDOW,
+                    mount.read_only,
+                );
+                if ret < 0 {
                     tracing::warn!(
                         "failed to add virtiofs mount: {} -> {}",
                         mount.source.display(),


### PR DESCRIPTION
User `-v` volumes and packed-layer mounts used plain krun_add_virtiofs (no DAX), dropping virtiofs to writeback caching where every file access is a FUSE round-trip — a multi-GB mount (e.g. a Python venv) took minutes to read and a single file larger than the window stalled entirely; they now get a 2 GiB DAX window like the root fs.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/581">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->