### PR TITLE
fix: reliably kill _boot-vm child on start failure to prevent orphans

### DIFF
--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -1544,7 +1544,27 @@ impl AgentManager {
                 Ok(())
             }
             Err(e) => {
-                process::terminate(child_pid);
+                // The _boot-vm child may be stuck inside krun_start_enter()
+                // where SIGTERM alone may not kill it (the VM run loop can
+                // mask signals). Use the full SIGTERM -> wait -> SIGKILL
+                // sequence so the child is reliably dead before we return,
+                // preventing an orphaned process from holding ports/sockets
+                // and making every subsequent start attempt fail permanently.
+                if let Err(kill_err) = process::stop_vm_process(
+                    child_pid,
+                    AGENT_STOP_TIMEOUT,
+                    process::VM_SIGKILL_TIMEOUT,
+                ) {
+                    tracing::warn!(
+                        pid = child_pid,
+                        error = %kill_err,
+                        "failed to kill _boot-vm child after start failure; \
+                         process may be orphaned"
+                    );
+                }
+                // Remove the PID file written earlier in this function so a
+                // stale PID doesn't confuse future reconnect attempts.
+                let _ = std::fs::remove_file(&self.pid_file);
                 let mut inner = self.inner.lock();
                 inner.state = AgentState::Stopped;
                 inner.child = None;

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -817,7 +817,10 @@ pub fn start_vm_named(
             ));
         }
         RecordState::Stopped | RecordState::Created | RecordState::Failed => {
-            // Normal start path.
+            // Normal start path. Kill any orphaned _boot-vm process left by
+            // a previous failed start — if one is holding ports/sockets, this
+            // fresh start would hit the same error without this cleanup.
+            kill_orphaned_boot_process(name);
         }
     }
 
@@ -1397,6 +1400,12 @@ pub fn stop_vm_named(name: &str) -> smolvm::Result<()> {
                     &smolvm::agent::machine_layers_cache_dir(name),
                 );
             }
+            // Defense-in-depth: a failed `machine start` may have left an
+            // orphaned _boot-vm process that the DB doesn't know about (PID
+            // never persisted). Check the on-disk PID file and, if the
+            // process is alive and its argv matches this VM's boot config
+            // path, kill it so the user doesn't have to hunt it manually.
+            kill_orphaned_boot_process(name);
             println!("Machine '{}' is not running (state: {})", name, other);
             return Ok(());
         }
@@ -1425,6 +1434,58 @@ pub fn stop_vm_named(name: &str) -> smolvm::Result<()> {
 
     println!("Stopped machine: {}", name);
     Ok(())
+}
+
+/// Kill an orphaned `_boot-vm` process for a machine that the DB thinks is
+/// not running.
+///
+/// When `machine start` fails after spawning the `_boot-vm` child (e.g.,
+/// EADDRINUSE in the virtio-net runtime), `finalize_launch` kills the child
+/// with SIGTERM + SIGKILL. But if that cleanup itself fails (or a pre-fix
+/// binary left an orphan), this fallback catches it: read the on-disk PID
+/// file, verify the process argv matches this VM's boot-config path, and
+/// kill it. Best-effort — never fails the caller.
+fn kill_orphaned_boot_process(name: &str) {
+    let data_dir = smolvm::agent::vm_data_dir(name);
+    let pid_file = data_dir.join("agent.pid");
+    let boot_config = data_dir.join("boot-config.json");
+
+    let content = match std::fs::read_to_string(&pid_file) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+    let pid: i32 = match content.lines().next().and_then(|l| l.trim().parse().ok()) {
+        Some(p) => p,
+        None => return,
+    };
+
+    if !smolvm::process::is_alive(pid) {
+        // Stale PID file — clean it up.
+        let _ = std::fs::remove_file(&pid_file);
+        return;
+    }
+
+    // Verify the process is actually our _boot-vm for this VM (not a
+    // recycled PID belonging to something else).
+    if !smolvm::process::cmdline_contains(pid, &boot_config.to_string_lossy()) {
+        return;
+    }
+
+    eprintln!(
+        "Killing orphaned _boot-vm process (PID {}) for machine '{}'",
+        pid, name
+    );
+    if let Err(e) = smolvm::process::stop_vm_process(
+        pid,
+        std::time::Duration::from_secs(2),
+        smolvm::process::VM_SIGKILL_TIMEOUT,
+    ) {
+        tracing::warn!(
+            pid, error = %e,
+            "failed to kill orphaned _boot-vm process"
+        );
+    }
+    let _ = std::fs::remove_file(&pid_file);
 }
 
 /// Stop the default machine.


### PR DESCRIPTION
## Summary

Fixes #582 -- when `machine start` fails after spawning the `_boot-vm` subprocess (e.g., EADDRINUSE from the virtio-net runtime), the child process could survive as an orphan holding ports and sockets, making every subsequent start attempt fail permanently and unrecoverably without manually killing the PID.

## Root Cause

In `AgentManager::finalize_launch()` (`src/agent/manager.rs`), when `wait_for_ready()` fails, the error path only sent a fire-and-forget `SIGTERM` via `process::terminate(child_pid)`:

```rust
Err(e) => {
    process::terminate(child_pid);  // fire-and-forget SIGTERM -- may not kill!
    // ...
}
```

The `_boot-vm` process inside `krun_start_enter()` could ignore `SIGTERM` (the VM run loop can mask signals), leaving the child alive as an orphan. Since the PID was never recorded in the DB (the error occurs before `start_vm_named` persists the running state), `machine stop` couldn't find or kill the orphan.

## Fix

Three layers of defense:

### 1. Primary fix: reliable kill in `finalize_launch()` error path

Replace `process::terminate(child_pid)` with `process::stop_vm_process(child_pid, AGENT_STOP_TIMEOUT, VM_SIGKILL_TIMEOUT)` -- the same SIGTERM -> poll -> SIGKILL -> poll sequence used by `stop_vm_process()` throughout the codebase. This ensures the child is reliably dead before returning the error.

### 2. PID file cleanup

Remove the stale `agent.pid` file written earlier in `finalize_launch()` when the boot fails, so it doesn't confuse future reconnect attempts.

### 3. Defense-in-depth: orphan detection in `start` and `stop`

Add `kill_orphaned_boot_process()` -- called when `machine start` or `machine stop` operates on a non-running machine. It reads the on-disk PID file, verifies the process argv matches this VM's `boot-config.json` path (safe against PID reuse), and kills it. This catches:
- Orphans left by pre-fix smolvm binaries
- Orphans from edge cases where the primary kill itself fails

## Testing

- `cargo check` passes cleanly
- The fix uses `stop_vm_process()` which is already well-tested throughout the codebase (used by `stop_vm_process` in the normal stop path, by the supervisor reaper, and by the API handlers)
- The `cmdline_contains()` identity check is the same fallback already used in `stop_vm_process()` (`src/agent/manager.rs:2020`) for normal teardown


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/583">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->