### PR TITLE
cuda: auto-stage guest shims into --cuda containers and auto-discover host CUDA libraries

### DIFF
--- a/crates/smolvm-agent/src/cuda.rs
+++ b/crates/smolvm-agent/src/cuda.rs
@@ -21,29 +21,170 @@ pub fn zerocopy_enabled() -> bool {
     std::env::var(ZEROCOPY_ENV).as_deref() == Ok("1")
 }
 
-/// Forward the CUDA zero-copy opt-in from the agent env into the workload
-/// container spec. Used on the fresh-container path (`crun run`/`create`, which
-/// reads env from the bundle spec). No-op unless CUDA zero-copy was requested.
-pub fn inject_into_container(spec: &mut crate::oci::OciSpec) {
-    inject_into_container_if(spec, zerocopy_enabled());
+/// Where the guest CUDA shims ship inside the VM rootfs (from the agent
+/// rootfs). Absent on builds without CUDA shim bundling — every staging step
+/// degrades to a no-op so `--cuda` still works in the manual-setup mode.
+const GUEST_SHIM_DIR: &str = "/usr/local/lib/smolvm-cuda";
+/// Where the shim dir is bind-mounted inside the workload container, and put
+/// on `LD_LIBRARY_PATH` so the loader finds `libcuda.so.1` there.
+const CONTAINER_SHIM_DIR: &str = "/opt/smolvm-cuda";
+/// The runtime shim file inside [`GUEST_SHIM_DIR`] (one cdylib exports the
+/// whole cudart/cuBLAS/cuBLASLt/cuDNN surface; it is staged under each soname).
+const RUNTIME_SHIM: &str = "libcudart-shim.so";
+/// The driver shim (`libcuda.so.1`) inside [`GUEST_SHIM_DIR`].
+const DRIVER_SHIM: &str = "libcuda.so.1";
+
+/// The pip-bundled NVIDIA sonames PyTorch's `libtorch_cuda.so` resolves via
+/// DT_RPATH. RPATH is searched *before* `LD_LIBRARY_PATH`, so the only way to
+/// interpose is to place the shim at these exact paths (a read-only bind mount
+/// over each file). CUDA 12 and 11 wheel layouts.
+const RPATH_PINNED_SONAMES: &[&str] = &[
+    "libcudart.so.12",
+    "libcublas.so.12",
+    "libcublasLt.so.12",
+    "libcudnn.so.9",
+    "libcudart.so.11.0",
+    "libcublas.so.11",
+    "libcublasLt.so.11",
+    "libcudnn.so.8",
+];
+
+/// Forward the CUDA opt-in into the workload container spec and, when the
+/// guest shims are bundled, stage them so an unmodified PyTorch works with no
+/// user setup: the shim dir rides `LD_LIBRARY_PATH` (covers `libcuda.so.1`,
+/// which nothing RPATH-pins) and the runtime shim is bind-mounted over each
+/// pip-bundled NVIDIA library found in the image rootfs (RPATH-pinned, so env
+/// vars can't reach them). Used on the fresh-container path (`crun run`/
+/// `create`). No-op unless CUDA was requested.
+pub fn inject_into_container(spec: &mut crate::oci::OciSpec, rootfs: &std::path::Path) {
+    inject_into_container_if(spec, rootfs, zerocopy_enabled());
 }
 
-/// Testable core of [`inject_into_container`]: sets the env var when `enabled`.
-fn inject_into_container_if(spec: &mut crate::oci::OciSpec, enabled: bool) {
+/// Testable core of [`inject_into_container`].
+fn inject_into_container_if(
+    spec: &mut crate::oci::OciSpec,
+    rootfs: &std::path::Path,
+    enabled: bool,
+) {
     if !enabled {
         return;
     }
     spec.add_env(ZEROCOPY_ENV, "1");
+    stage_shims(spec, rootfs, std::path::Path::new(GUEST_SHIM_DIR));
 }
 
-/// Append the CUDA zero-copy opt-in to an explicit exec env when enabled. Used
-/// on the `crun exec` path (joining a persistent machine's keep-alive
-/// container), where the workload env is passed via `--env` rather than
-/// inherited from the container spec, so the spec injection above doesn't reach
-/// it. No-op when disabled or already present.
+/// Bind-mount the bundled shims into the container. Split from the gate so
+/// tests can point `shim_dir` at a fixture.
+fn stage_shims(
+    spec: &mut crate::oci::OciSpec,
+    rootfs: &std::path::Path,
+    shim_dir: &std::path::Path,
+) {
+    let runtime = shim_dir.join(RUNTIME_SHIM);
+    let driver = shim_dir.join(DRIVER_SHIM);
+    if !runtime.is_file() || !driver.is_file() {
+        return; // shims not bundled — manual staging still works
+    }
+
+    // Driver shim: the whole shim dir at a stable path + LD_LIBRARY_PATH.
+    // `libcuda.so.1` is resolved through the normal loader search (no RPATH in
+    // the way), and this also lets users link the runtime shim directly.
+    spec.add_bind_mount(&shim_dir.to_string_lossy(), CONTAINER_SHIM_DIR, true);
+    append_ld_library_path(&mut spec.process.env, CONTAINER_SHIM_DIR);
+
+    // Runtime shim over each RPATH-pinned pip-bundled NVIDIA library.
+    let runtime_src = runtime.to_string_lossy();
+    for hit in find_rpath_pinned_libs(rootfs) {
+        let dest = format!(
+            "/{}",
+            hit.strip_prefix(rootfs).unwrap_or(&hit).to_string_lossy()
+        );
+        spec.add_bind_mount(&runtime_src, &dest, true);
+    }
+}
+
+/// Append `dir` to the spec's `LD_LIBRARY_PATH`, preserving an image-provided
+/// value; creates the variable if absent, skips if already present.
+fn append_ld_library_path(env: &mut Vec<String>, dir: &str) {
+    for e in env.iter_mut() {
+        if let Some(v) = e.strip_prefix("LD_LIBRARY_PATH=") {
+            if v.split(':').any(|p| p == dir) {
+                return;
+            }
+            *e = format!("LD_LIBRARY_PATH={v}:{dir}");
+            return;
+        }
+    }
+    env.push(format!("LD_LIBRARY_PATH={dir}"));
+}
+
+/// Find pip-bundled NVIDIA libraries in the image rootfs: files named like the
+/// RPATH-pinned sonames under a `site-packages`/`dist-packages` → `nvidia`
+/// wheel layout. Bounded walk: skips pseudo-filesystems and never follows
+/// symlinks (wheel layouts don't use them and cycles would hang the boot).
+fn find_rpath_pinned_libs(rootfs: &std::path::Path) -> Vec<std::path::PathBuf> {
+    const SKIP_TOP: &[&str] = &["proc", "sys", "dev", "run", "tmp", "boot"];
+    const MAX_DEPTH: usize = 16;
+    let mut hits = Vec::new();
+    let mut stack: Vec<(std::path::PathBuf, usize)> = vec![(rootfs.to_path_buf(), 0)];
+    while let Some((dir, depth)) = stack.pop() {
+        if depth >= MAX_DEPTH {
+            continue;
+        }
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        for entry in entries.flatten() {
+            let ft = match entry.file_type() {
+                Ok(t) => t,
+                Err(_) => continue,
+            };
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if ft.is_dir() && !ft.is_symlink() {
+                if depth == 0 && SKIP_TOP.contains(&name.as_ref()) {
+                    continue;
+                }
+                stack.push((entry.path(), depth + 1));
+            } else if ft.is_file() && RPATH_PINNED_SONAMES.contains(&name.as_ref()) {
+                let p = entry.path();
+                let s = p.to_string_lossy();
+                if s.contains("/nvidia/")
+                    && (s.contains("/site-packages/") || s.contains("/dist-packages/"))
+                {
+                    hits.push(p);
+                }
+            }
+        }
+    }
+    hits.sort();
+    hits
+}
+
+/// Append the CUDA opt-in (and the shim dir's loader path) to an explicit exec
+/// env when enabled. Used on the `crun exec` path (joining a persistent
+/// machine's keep-alive container), where the workload env is passed via
+/// `--env` rather than inherited from the container spec, so the spec injection
+/// above doesn't reach it. The bind mounts themselves were established when the
+/// keep-alive container was created. No-op when disabled or already present.
 pub fn augment_exec_env(mut env: Vec<(String, String)>) -> Vec<(String, String)> {
-    if zerocopy_enabled() && !env.iter().any(|(k, _)| k == ZEROCOPY_ENV) {
+    if !zerocopy_enabled() {
+        return env;
+    }
+    if !env.iter().any(|(k, _)| k == ZEROCOPY_ENV) {
         env.push((ZEROCOPY_ENV.to_string(), "1".to_string()));
+    }
+    match env.iter_mut().find(|(k, _)| k == "LD_LIBRARY_PATH") {
+        Some((_, v)) => {
+            if !v.split(':').any(|p| p == CONTAINER_SHIM_DIR) {
+                *v = format!("{v}:{CONTAINER_SHIM_DIR}");
+            }
+        }
+        None => env.push((
+            "LD_LIBRARY_PATH".to_string(),
+            CONTAINER_SHIM_DIR.to_string(),
+        )),
     }
     env
 }
@@ -67,14 +208,14 @@ mod tests {
     #[test]
     fn injects_when_enabled() {
         let mut s = spec();
-        inject_into_container_if(&mut s, true);
+        inject_into_container_if(&mut s, std::path::Path::new("/nonexistent"), true);
         assert!(s.process.env.iter().any(|e| e == "SMOLVM_CUDA_ZEROCOPY=1"));
     }
 
     #[test]
     fn noop_when_disabled() {
         let mut s = spec();
-        inject_into_container_if(&mut s, false);
+        inject_into_container_if(&mut s, std::path::Path::new("/nonexistent"), false);
         assert!(!s
             .process
             .env
@@ -85,7 +226,66 @@ mod tests {
     #[test]
     fn augment_exec_env_is_idempotent() {
         let base = vec![("SMOLVM_CUDA_ZEROCOPY".to_string(), "1".to_string())];
-        // Already present → unchanged regardless of gate.
+        // Gate off in tests (env var unset) → unchanged.
         assert_eq!(augment_exec_env(base.clone()), base);
+    }
+
+    #[test]
+    fn ld_library_path_append_preserves_existing() {
+        let mut env = vec!["LD_LIBRARY_PATH=/usr/local/nvidia/lib".to_string()];
+        append_ld_library_path(&mut env, CONTAINER_SHIM_DIR);
+        assert_eq!(
+            env[0],
+            format!("LD_LIBRARY_PATH=/usr/local/nvidia/lib:{CONTAINER_SHIM_DIR}")
+        );
+        // Idempotent.
+        append_ld_library_path(&mut env, CONTAINER_SHIM_DIR);
+        assert_eq!(env.len(), 1);
+        assert_eq!(env[0].matches(CONTAINER_SHIM_DIR).count(), 1);
+    }
+
+    #[test]
+    fn ld_library_path_created_when_absent() {
+        let mut env = vec!["PATH=/usr/bin".to_string()];
+        append_ld_library_path(&mut env, CONTAINER_SHIM_DIR);
+        assert!(env.contains(&format!("LD_LIBRARY_PATH={CONTAINER_SHIM_DIR}")));
+    }
+
+    #[test]
+    fn finds_and_overmounts_wheel_libs() {
+        let tmp = std::env::temp_dir().join(format!("cuda-stage-test-{}", std::process::id()));
+        let rootfs = tmp.join("rootfs");
+        let wheel = rootfs.join("usr/lib/python3.11/site-packages/nvidia/cublas/lib");
+        std::fs::create_dir_all(&wheel).unwrap();
+        std::fs::write(wheel.join("libcublas.so.12"), b"real").unwrap();
+        std::fs::write(wheel.join("libnvblas.so.12"), b"other").unwrap(); // not pinned
+                                                                          // A same-named file outside a wheel layout must NOT match.
+        let stray = rootfs.join("opt/other");
+        std::fs::create_dir_all(&stray).unwrap();
+        std::fs::write(stray.join("libcublas.so.12"), b"stray").unwrap();
+
+        let hits = find_rpath_pinned_libs(&rootfs);
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].ends_with("nvidia/cublas/lib/libcublas.so.12"));
+
+        // With a shim fixture present, staging adds the dir mount + overmount.
+        let shim_dir = tmp.join("shims");
+        std::fs::create_dir_all(&shim_dir).unwrap();
+        std::fs::write(shim_dir.join(RUNTIME_SHIM), b"shim").unwrap();
+        std::fs::write(shim_dir.join(DRIVER_SHIM), b"shim").unwrap();
+        let mut s = spec();
+        stage_shims(&mut s, &rootfs, &shim_dir);
+        assert!(s.mounts.iter().any(|m| m.destination == CONTAINER_SHIM_DIR));
+        assert!(s.mounts.iter().any(|m| m
+            .destination
+            .ends_with("nvidia/cublas/lib/libcublas.so.12")
+            && m.source.ends_with(RUNTIME_SHIM)));
+        assert!(s
+            .process
+            .env
+            .iter()
+            .any(|e| e.starts_with("LD_LIBRARY_PATH=") && e.contains(CONTAINER_SHIM_DIR)));
+
+        std::fs::remove_dir_all(&tmp).ok();
     }
 }

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -3141,7 +3141,7 @@ fn write_oci_bundle(
     storage::add_storage_fallback(&mut spec, mounts, unprivileged);
 
     ssh_agent::inject_into_container(&mut spec);
-    cuda::inject_into_container(&mut spec);
+    cuda::inject_into_container(&mut spec, rootfs_path);
     spec.write_to(bundle_path)
         .map_err(|e| format!("failed to write OCI spec: {}", e))?;
 
@@ -3897,7 +3897,7 @@ fn spawn_interactive_command(
 
     // Forward SSH agent into the container if enabled at boot.
     ssh_agent::inject_into_container(&mut spec);
-    cuda::inject_into_container(&mut spec);
+    cuda::inject_into_container(&mut spec, rootfs_path);
 
     spec.write_to(&bundle_path)
         .map_err(|e| format!("failed to write OCI spec: {}", e))?;

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -2728,7 +2728,7 @@ pub fn run_command(
 
         // Forward SSH agent into the container if enabled at boot.
         crate::ssh_agent::inject_into_container(&mut spec);
-        crate::cuda::inject_into_container(&mut spec);
+        crate::cuda::inject_into_container(&mut spec, Path::new(&prepared.rootfs_path));
 
         // Write config.json to bundle
         spec.write_to(&bundle_path)
@@ -2819,7 +2819,7 @@ pub fn spawn_in_overlay(
     add_storage_fallback(&mut spec, mounts, unprivileged);
 
     crate::ssh_agent::inject_into_container(&mut spec);
-    crate::cuda::inject_into_container(&mut spec);
+    crate::cuda::inject_into_container(&mut spec, Path::new(&prepared.rootfs_path));
     spec.add_gpu_devices_if_available();
 
     spec.write_to(&bundle_path)

--- a/crates/smolvm-cuda-codegen/src/main.rs
+++ b/crates/smolvm-cuda-codegen/src/main.rs
@@ -79,7 +79,8 @@ struct Lib {
     name: &'static str,
     id: u8,
     /// Default soname to dlopen on the host if the env override is unset.
-    default_so: &'static str,
+    /// Sonames to probe via `open_host_lib`, most-specific last.
+    default_sos: &'static [&'static str],
     funcs: Vec<Fun>,
 }
 
@@ -138,7 +139,7 @@ fn cublas_spec() -> Lib {
     Lib {
         name: "cublas",
         id: 1,
-        default_so: "libcublas.so",
+        default_sos: &["libcublas.so", "libcublas.so.13", "libcublas.so.12"],
         funcs: vec![
             Fun {
                 sym: "cublasCreate_v2",
@@ -283,7 +284,7 @@ fn cudnn_spec() -> Lib {
     Lib {
         name: "cudnn",
         id: 2,
-        default_so: "libcudnn.so",
+        default_sos: &["libcudnn.so", "libcudnn.so.9", "libcudnn.so.8"],
         funcs: vec![
             create("cudnnCreate"),
             f("cudnnDestroy", vec![h()]),
@@ -501,9 +502,13 @@ fn gen_host(lib: &Lib) -> String {
     // Loader.
     let _ = writeln!(
         s,
-        "impl GenLib {{\n    pub fn load() -> Result<GenLib, String> {{\n        let path = std::env::var(\"SMOLVM_{}_LIB\").unwrap_or_else(|_| \"{}\".into());\n        unsafe {{\n            let lib = Library::new(&path).map_err(|e| format!(\"load {{path}}: {{e}}\"))?;\n            Ok(GenLib {{",
+        "impl GenLib {{\n    pub fn load() -> Result<GenLib, String> {{\n        unsafe {{\n            let lib = super::open_host_lib(\"SMOLVM_{}_LIB\", &[{}])?;\n            Ok(GenLib {{",
         lib.name.to_uppercase(),
-        lib.default_so
+        lib.default_sos
+            .iter()
+            .map(|s| format!("\"{s}\""))
+            .collect::<Vec<_>>()
+            .join(", ")
     );
     for f in &lib.funcs {
         let _ = writeln!(

--- a/crates/smolvm-cuda/src/generated/cublas_host.rs
+++ b/crates/smolvm-cuda/src/generated/cublas_host.rs
@@ -16,9 +16,8 @@ pub struct GenLib { _lib: Library,
 }
 impl GenLib {
     pub fn load() -> Result<GenLib, String> {
-        let path = std::env::var("SMOLVM_CUBLAS_LIB").unwrap_or_else(|_| "libcublas.so".into());
         unsafe {
-            let lib = Library::new(&path).map_err(|e| format!("load {path}: {e}"))?;
+            let lib = super::open_host_lib("SMOLVM_CUBLAS_LIB", &["libcublas.so", "libcublas.so.13", "libcublas.so.12"])?;
             Ok(GenLib {
                 f_cublasCreate_v2: sym(&lib, b"cublasCreate_v2\0")?,
                 f_cublasDestroy_v2: sym(&lib, b"cublasDestroy_v2\0")?,

--- a/crates/smolvm-cuda/src/generated/cudnn_host.rs
+++ b/crates/smolvm-cuda/src/generated/cudnn_host.rs
@@ -17,9 +17,8 @@ pub struct GenLib { _lib: Library,
 }
 impl GenLib {
     pub fn load() -> Result<GenLib, String> {
-        let path = std::env::var("SMOLVM_CUDNN_LIB").unwrap_or_else(|_| "libcudnn.so".into());
         unsafe {
-            let lib = Library::new(&path).map_err(|e| format!("load {path}: {e}"))?;
+            let lib = super::open_host_lib("SMOLVM_CUDNN_LIB", &["libcudnn.so", "libcudnn.so.9", "libcudnn.so.8"])?;
             Ok(GenLib {
                 f_cudnnCreate: sym(&lib, b"cudnnCreate\0")?,
                 f_cudnnDestroy: sym(&lib, b"cudnnDestroy\0")?,

--- a/crates/smolvm-cuda/src/host/gpu.rs
+++ b/crates/smolvm-cuda/src/host/gpu.rs
@@ -176,11 +176,47 @@ struct Cublas {
     ) -> c_int,
 }
 
+/// Open a host CUDA library with auto-discovery: an env override wins, then
+/// the plain soname (dlopen's ldconfig search), then the usual CUDA install
+/// prefixes. Removes the need to export `SMOLVM_*_LIB` on typical hosts, where
+/// the toolkit lives under `/opt/cuda` or `/usr/local/cuda` without ldconfig
+/// entries.
+pub(super) fn open_host_lib(env_var: &str, sonames: &[&str]) -> Result<Library, String> {
+    if let Ok(path) = std::env::var(env_var) {
+        // SAFETY: loading a user-designated shared library.
+        return unsafe { Library::new(&path).map_err(|e| format!("load {path}: {e}")) };
+    }
+    const PREFIXES: &[&str] = &[
+        "", // plain soname: dlopen's own ldconfig search
+        "/opt/cuda/lib64/",
+        "/usr/local/cuda/lib64/",
+        "/usr/lib/x86_64-linux-gnu/",
+        "/usr/lib64/",
+        "/usr/lib/",
+    ];
+    let mut last_err = String::new();
+    for soname in sonames {
+        for prefix in PREFIXES {
+            let cand = format!("{prefix}{soname}");
+            // SAFETY: probing well-known system library locations.
+            match unsafe { Library::new(&cand) } {
+                Ok(lib) => return Ok(lib),
+                Err(e) => last_err = format!("load {cand}: {e}"),
+            }
+        }
+    }
+    Err(format!(
+        "{last_err} (set {env_var} to the library path if it lives elsewhere)"
+    ))
+}
+
 impl Cublas {
     fn load() -> Result<Cublas, String> {
-        let path = std::env::var("SMOLVM_CUBLAS_LIB").unwrap_or_else(|_| "libcublas.so".into());
         unsafe {
-            let lib = Library::new(&path).map_err(|e| format!("load {path}: {e}"))?;
+            let lib = open_host_lib(
+                "SMOLVM_CUBLAS_LIB",
+                &["libcublas.so", "libcublas.so.13", "libcublas.so.12"],
+            )?;
             let c = Cublas {
                 create: sym(&lib, b"cublasCreate_v2\0")?,
                 destroy: sym(&lib, b"cublasDestroy_v2\0")?,
@@ -847,9 +883,11 @@ struct CudnnBackend {
 
 impl CudnnBackend {
     fn load() -> Result<CudnnBackend, String> {
-        let path = std::env::var("SMOLVM_CUDNN_LIB").unwrap_or_else(|_| "libcudnn.so".into());
         unsafe {
-            let lib = Library::new(&path).map_err(|e| format!("load {path}: {e}"))?;
+            let lib = open_host_lib(
+                "SMOLVM_CUDNN_LIB",
+                &["libcudnn.so", "libcudnn.so.9", "libcudnn.so.8"],
+            )?;
             let b = CudnnBackend {
                 create: sym(&lib, b"cudnnBackendCreateDescriptor\0")?,
                 destroy: sym(&lib, b"cudnnBackendDestroyDescriptor\0")?,
@@ -989,9 +1027,11 @@ struct CublasLt {
 impl CublasLt {
     fn load() -> Result<CublasLt, String> {
         // cuBLASLt ships in its own soname; fall back to the cuBLAS path's dir.
-        let path = std::env::var("SMOLVM_CUBLASLT_LIB").unwrap_or_else(|_| "libcublasLt.so".into());
         unsafe {
-            let lib = Library::new(&path).map_err(|e| format!("load {path}: {e}"))?;
+            let lib = open_host_lib(
+                "SMOLVM_CUBLASLT_LIB",
+                &["libcublasLt.so", "libcublasLt.so.13", "libcublasLt.so.12"],
+            )?;
             let b = CublasLt {
                 matmul: sym(&lib, b"cublasLtMatmul\0")?,
                 algo_get_heuristic: sym(&lib, b"cublasLtMatmulAlgoGetHeuristic\0")?,
@@ -1325,9 +1365,11 @@ struct CudnnBn {
 
 impl CudnnBn {
     fn load() -> Result<CudnnBn, String> {
-        let path = std::env::var("SMOLVM_CUDNN_LIB").unwrap_or_else(|_| "libcudnn.so".into());
         unsafe {
-            let lib = Library::new(&path).map_err(|e| format!("load {path}: {e}"))?;
+            let lib = open_host_lib(
+                "SMOLVM_CUDNN_LIB",
+                &["libcudnn.so", "libcudnn.so.9", "libcudnn.so.8"],
+            )?;
             let b = CudnnBn {
                 set_nd: sym(&lib, b"cudnnSetTensorNdDescriptor\0")?,
                 derive_bn: sym(&lib, b"cudnnDeriveBNTensorDescriptor\0")?,

--- a/scripts/build-agent-rootfs.sh
+++ b/scripts/build-agent-rootfs.sh
@@ -295,6 +295,29 @@ if [[ -n "${CUDA_GUEST_BINARY:-}" ]] && [[ -f "${CUDA_GUEST_BINARY}" ]]; then
     chmod +x "$OUTPUT_DIR/usr/local/bin/smolvm-cuda-run"
 fi
 
+# CUDA guest shims: glibc cdylibs the agent bind-mounts into workload
+# containers on `--cuda` (see crates/smolvm-agent/src/cuda.rs). They are loaded
+# by the container's glibc — not by the (musl) agent — so they build for the
+# native gnu target. Best-effort: without them `--cuda` still works, the user
+# just stages shims manually; cross-arch rootfs builds skip them.
+if [[ "$NO_BUILD_AGENT" != "1" && "$(uname -s)" == "Linux" && "$(uname -m)" == "$ALPINE_ARCH" ]] \
+    && command -v cargo &> /dev/null; then
+    echo "Building CUDA guest shims (native gnu target)..."
+    if cargo build --release -p smolvm-cudart-shim -p smolvm-cuda-shim \
+        --manifest-path "$PROJECT_ROOT/Cargo.toml"; then
+        mkdir -p "$OUTPUT_DIR/usr/local/lib/smolvm-cuda"
+        cp "$PROJECT_ROOT/target/release/libcudart.so" \
+            "$OUTPUT_DIR/usr/local/lib/smolvm-cuda/libcudart-shim.so"
+        cp "$PROJECT_ROOT/target/release/libcuda.so" \
+            "$OUTPUT_DIR/usr/local/lib/smolvm-cuda/libcuda.so.1"
+        echo "Installed CUDA guest shims"
+    else
+        echo "CUDA guest shim build failed — rootfs ships without auto-staging"
+    fi
+else
+    echo "Skipping CUDA guest shims (cross-arch or no cargo) — auto-staging disabled in this rootfs"
+fi
+
 echo ""
 echo "Agent rootfs created at: $OUTPUT_DIR"
 if [[ -n "${AGENT_BINARY:-}" ]]; then


### PR DESCRIPTION
With `--cuda`, the agent now bind-mounts the bundled guest shims over pip-installed NVIDIA libraries found in the image (DT_RPATH-pinned, so in-place replacement is the only interposition that works) and puts the driver shim on the container's loader path, and the host daemon probes standard CUDA install locations instead of requiring SMOLVM_*_LIB env vars — so an unmodified PyTorch image works with zero user setup.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/585">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->