### PR TITLE
cuda: pipelined async forwarding, CUDA graph capture/replay, and cross-connection ordering — vLLM runs end-to-end with CUDA graphs

### DIFF
--- a/crates/smolvm-cuda-codegen/src/main.rs
+++ b/crates/smolvm-cuda-codegen/src/main.rs
@@ -393,11 +393,13 @@ fn gen_guest(lib: &Lib) -> String {
                 s,
                 "#[no_mangle]\npub extern \"C\" fn {}(handle_out: *mut *mut c_void) -> c_int {{\n    \
                  if handle_out.is_null() {{ return 1; }}\n    \
-                 match with_client(|c| c.lib_call(LIB_ID, {idx}, Vec::new())) {{\n        \
-                 Ok((0, out)) if out.len() >= 8 => {{\n            \
-                 let h = u64::from_le_bytes(out[..8].try_into().unwrap());\n            \
-                 unsafe {{ *handle_out = h as *mut c_void }};\n            0\n        }}\n        \
-                 Ok((st, _)) => st,\n        Err(_) => 1,\n    }}\n}}",
+                 // Fire-and-forget create: return a guest-assigned virtual id\n    \
+                 // immediately; the host materializes the real descriptor and\n    \
+                 // maps the id (see vh_resolve on the host side).\n    \
+                 let vh = super::alloc_vhandle();\n    \
+                 match with_client(|c| c.lib_call_deferred(LIB_ID, {idx}, vh.to_le_bytes().to_vec())) {{\n        \
+                 Ok(()) => {{ unsafe {{ *handle_out = vh as *mut c_void }}; 0 }}\n        \
+                 Err(_) => 1,\n    }}\n}}",
                 f.sym
             );
             continue;
@@ -453,7 +455,7 @@ fn gen_guest(lib: &Lib) -> String {
         if outs.is_empty() {
             let _ = writeln!(
                 s,
-                "    match with_client(|c| c.lib_call(LIB_ID, {idx}, a)) {{ Ok((st, _)) => st, Err(_) => 1 }}\n}}"
+                "    // No output params: fire-and-forget (failures surface as sticky async errors).\n    match with_client(|c| c.lib_call_deferred(LIB_ID, {idx}, a)) {{ Ok(()) => 0, Err(_) => 1 }}\n}}"
             );
         } else {
             let _ = writeln!(
@@ -524,13 +526,13 @@ fn gen_host(lib: &Lib) -> String {
     // Dispatch.
     let _ = writeln!(
         s,
-        "    pub fn dispatch(&self, func: u16, args: &[u8]) -> (i32, Vec<u8>) {{\n        let mut __c = GenCur {{ b: args, p: 0 }};\n        match func {{"
+        "    pub fn dispatch(&self, func: u16, args: &[u8], __vh: &mut std::collections::HashMap<u64, u64>) -> (i32, Vec<u8>) {{\n        let mut __c = GenCur {{ b: args, p: 0 }};\n        match func {{"
     );
     for (idx, f) in lib.funcs.iter().enumerate() {
         if is_create(f) {
             let _ = writeln!(
                 s,
-                "            {idx} => {{ let mut h: *mut c_void = std::ptr::null_mut(); let st = unsafe {{ (self.f_{})(&mut h) }}; (st, (h as u64).to_le_bytes().to_vec()) }}",
+                "            {idx} => {{ let mut h: *mut c_void = std::ptr::null_mut(); let st = unsafe {{ (self.f_{})(&mut h) }}; if st == 0 && args.len() >= 8 {{ let id = u64::from_le_bytes(args[..8].try_into().unwrap()); if id & super::VHANDLE_TAG != 0 {{ __vh.insert(id, h as u64); }} }} (st, (h as u64).to_le_bytes().to_vec()) }}",
                 f.real
             );
             continue;
@@ -544,7 +546,26 @@ fn gen_host(lib: &Lib) -> String {
                     let _ = writeln!(binds, "                let {} = __c.{t}();", p.name);
                     call.push(format!("{} as {}", p.name, p.cty));
                 }
-                Kind::Handle | Kind::DevPtr => {
+                Kind::Handle => {
+                    // May be a guest-assigned virtual id — resolve to the real
+                    // pointer (untagged values pass through). Destroy calls
+                    // also retire the mapping so the table doesn't grow.
+                    if f.sym.contains("Destroy") {
+                        let _ = writeln!(
+                            binds,
+                            "                let __raw = __c.u64();\n                let {} = super::vh_resolve(__vh, __raw) as {};\n                if __raw & super::VHANDLE_TAG != 0 {{ __vh.remove(&__raw); }}",
+                            p.name, p.cty
+                        );
+                    } else {
+                        let _ = writeln!(
+                            binds,
+                            "                let {} = super::vh_resolve(__vh, __c.u64()) as {};",
+                            p.name, p.cty
+                        );
+                    }
+                    call.push(p.name.to_string());
+                }
+                Kind::DevPtr => {
                     let _ = writeln!(
                         binds,
                         "                let {} = __c.u64() as {};",

--- a/crates/smolvm-cuda-codegen/src/main.rs
+++ b/crates/smolvm-cuda-codegen/src/main.rs
@@ -48,6 +48,7 @@ fn pointee(cty: &str) -> &str {
 /// Wire size in bytes of a scalar type name.
 fn wire_size(t: &str) -> usize {
     match t {
+        "u16" => 2, // __half forwarded bitwise
         "i32" | "u32" | "f32" => 4,
         _ => 8,
     }
@@ -152,6 +153,9 @@ fn cublas_spec() -> Lib {
                 params: vec![handle()],
             },
             gemm("cublasSgemm_v2", "cublasSgemm_v2", "f32"),
+            // __half forwarded bitwise as u16 (the value is never interpreted
+            // guest-side; the host passes a pointer to the same 2 bytes).
+            gemm("cublasHgemm", "cublasHgemm", "u16"),
             gemm("cublasDgemm_v2", "cublasDgemm_v2", "f64"),
             gemm_strided(
                 "cublasSgemmStridedBatched",
@@ -607,7 +611,7 @@ fn gen_host(lib: &Lib) -> String {
     // A tiny cursor with the scalar readers the generated code uses.
     let _ = writeln!(
         s,
-        "struct GenCur<'a> {{ b: &'a [u8], p: usize }}\nimpl GenCur<'_> {{\n    fn take(&mut self, n: usize) -> [u8; 8] {{ let mut o = [0u8; 8]; let end = (self.p + n).min(self.b.len()); o[..end - self.p].copy_from_slice(&self.b[self.p..end]); self.p = end; o }}\n    fn i32(&mut self) -> i32 {{ i32::from_le_bytes(self.take(4)[..4].try_into().unwrap()) }}\n    fn i64(&mut self) -> i64 {{ i64::from_le_bytes(self.take(8)) }}\n    fn u64(&mut self) -> u64 {{ u64::from_le_bytes(self.take(8)) }}\n    fn f32(&mut self) -> f32 {{ f32::from_le_bytes(self.take(4)[..4].try_into().unwrap()) }}\n    fn f64(&mut self) -> f64 {{ f64::from_le_bytes(self.take(8)) }}\n}}"
+        "struct GenCur<'a> {{ b: &'a [u8], p: usize }}\nimpl GenCur<'_> {{\n    fn take(&mut self, n: usize) -> [u8; 8] {{ let mut o = [0u8; 8]; let end = (self.p + n).min(self.b.len()); o[..end - self.p].copy_from_slice(&self.b[self.p..end]); self.p = end; o }}\n    fn u16(&mut self) -> u16 {{ u16::from_le_bytes(self.take(2)[..2].try_into().unwrap()) }}\n    fn i32(&mut self) -> i32 {{ i32::from_le_bytes(self.take(4)[..4].try_into().unwrap()) }}\n    fn i64(&mut self) -> i64 {{ i64::from_le_bytes(self.take(8)) }}\n    fn u64(&mut self) -> u64 {{ u64::from_le_bytes(self.take(8)) }}\n    fn f32(&mut self) -> f32 {{ f32::from_le_bytes(self.take(4)[..4].try_into().unwrap()) }}\n    fn f64(&mut self) -> f64 {{ f64::from_le_bytes(self.take(8)) }}\n}}"
     );
     s
 }

--- a/crates/smolvm-cuda-codegen/src/main.rs
+++ b/crates/smolvm-cuda-codegen/src/main.rs
@@ -26,9 +26,15 @@ use std::fmt::Write as _;
 enum Kind {
     /// A machine scalar passed by value. `.0` is the Rust scalar type.
     Scalar(&'static str),
-    /// An opaque host handle (cuBLAS/cuDNN handle, stream, …) — pass the pointer
+    /// An opaque host handle (cuBLAS/cuDNN handle, …) — pass the pointer
     /// value by reference; the guest never dereferences it.
     Handle,
+    /// A `cudaStream_t`. Streams are session-mapped small ids on the wire (the
+    /// host mints them at StreamCreate), so the host must translate through the
+    /// session stream table — NOT vh_resolve — or the raw id reaches the real
+    /// library as a pointer and crashes it. 0 and the legacy constants
+    /// (0x1/0x2) pass through.
+    Stream,
     /// A real device address — pass by value.
     DevPtr,
     /// A host input scalar behind a pointer (cuBLAS alpha/beta) — read `*p` on
@@ -171,7 +177,7 @@ fn cublas_spec() -> Lib {
             Fun {
                 sym: "cublasSetStream_v2",
                 real: "cublasSetStream_v2",
-                params: vec![handle(), p("stream", "*mut c_void", Handle)],
+                params: vec![handle(), p("stream", "*mut c_void", Stream)],
             },
             Fun {
                 sym: "cublasSetWorkspace_v2",
@@ -294,7 +300,7 @@ fn cudnn_spec() -> Lib {
             f("cudnnDestroy", vec![h()]),
             f(
                 "cudnnSetStream",
-                vec![h(), p("stream", "*mut c_void", Handle)],
+                vec![h(), p("stream", "*mut c_void", Stream)],
             ),
             create("cudnnCreateTensorDescriptor"),
             f(
@@ -430,7 +436,7 @@ fn gen_guest(lib: &Lib) -> String {
                         p.name
                     );
                 }
-                Kind::Handle | Kind::DevPtr => {
+                Kind::Handle | Kind::Stream | Kind::DevPtr => {
                     let _ = writeln!(
                         s,
                         "    a.extend_from_slice(&({} as u64).to_le_bytes());",
@@ -530,7 +536,7 @@ fn gen_host(lib: &Lib) -> String {
     // Dispatch.
     let _ = writeln!(
         s,
-        "    pub fn dispatch(&self, func: u16, args: &[u8], __vh: &mut std::collections::HashMap<u64, u64>) -> (i32, Vec<u8>) {{\n        let mut __c = GenCur {{ b: args, p: 0 }};\n        match func {{"
+        "    pub fn dispatch(&self, func: u16, args: &[u8], __vh: &mut std::collections::HashMap<u64, u64>, __streams: &std::collections::HashMap<u64, u64>) -> (i32, Vec<u8>) {{\n        let mut __c = GenCur {{ b: args, p: 0 }};\n        let _ = __streams;\n        match func {{"
     );
     for (idx, f) in lib.funcs.iter().enumerate() {
         if is_create(f) {
@@ -567,6 +573,14 @@ fn gen_host(lib: &Lib) -> String {
                             p.name, p.cty
                         );
                     }
+                    call.push(p.name.to_string());
+                }
+                Kind::Stream => {
+                    let _ = writeln!(
+                        binds,
+                        "                let {} = super::stream_resolve(__streams, __c.u64()) as {};",
+                        p.name, p.cty
+                    );
                     call.push(p.name.to_string());
                 }
                 Kind::DevPtr => {

--- a/crates/smolvm-cuda-guest/src/main.rs
+++ b/crates/smolvm-cuda-guest/src/main.rs
@@ -64,8 +64,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let da = cu.mem_alloc(bytes)?;
     let db = cu.mem_alloc(bytes)?;
     let dc = cu.mem_alloc(bytes)?;
-    cu.memcpy_htod(da, as_bytes(&a))?;
-    cu.memcpy_htod(db, as_bytes(&b))?;
+    cu.memcpy_htod(da, as_bytes(&a), 0)?;
+    cu.memcpy_htod(db, as_bytes(&b), 0)?;
 
     // kernelParams: one little-endian blob per arg, in declaration order.
     let params = vec![
@@ -75,11 +75,11 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         (n as u32).to_le_bytes().to_vec(),
     ];
     let block = 256u32;
-    let grid = ((n as u32) + block - 1) / block;
+    let grid = (n as u32).div_ceil(block);
     cu.launch_kernel(func, [grid, 1, 1], [block, 1, 1], 0, 0, &params)?;
     cu.ctx_synchronize()?;
 
-    let out = cu.memcpy_dtoh(dc, bytes)?;
+    let out = cu.memcpy_dtoh(dc, bytes, 0)?;
     let c: Vec<f32> = out
         .chunks_exact(4)
         .map(|p| f32::from_le_bytes(p.try_into().unwrap()))

--- a/crates/smolvm-cuda-shim/src/driver_stubs.rs
+++ b/crates/smolvm-cuda-shim/src/driver_stubs.rs
@@ -1230,14 +1230,6 @@ pub extern "C" fn cuLogsUnregisterCallback() -> c_int {
     801
 }
 #[no_mangle]
-pub extern "C" fn cuMemAddressFree() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuMemAddressReserve() -> c_int {
-    801
-}
-#[no_mangle]
 pub extern "C" fn cuMemAdvise() -> c_int {
     801
 }
@@ -1582,10 +1574,6 @@ pub extern "C" fn cuMemcpyWithAttributesAsync_ptsz() -> c_int {
     801
 }
 #[no_mangle]
-pub extern "C" fn cuMemCreate() -> c_int {
-    801
-}
-#[no_mangle]
 pub extern "C" fn cuMemDiscardAndPrefetchBatchAsync() -> c_int {
     801
 }
@@ -1631,10 +1619,6 @@ pub extern "C" fn cuMemGetAddressRange() -> c_int {
 }
 #[no_mangle]
 pub extern "C" fn cuMemGetAddressRange_v2() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuMemGetAllocationGranularity() -> c_int {
     801
 }
 #[no_mangle]
@@ -1695,10 +1679,6 @@ pub extern "C" fn cuMemHostUnregister() -> c_int {
 }
 #[no_mangle]
 pub extern "C" fn cuMemImportFromShareableHandle() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuMemMap() -> c_int {
     801
 }
 #[no_mangle]
@@ -1786,15 +1766,7 @@ pub extern "C" fn cuMemRangeGetAttributes() -> c_int {
     801
 }
 #[no_mangle]
-pub extern "C" fn cuMemRelease() -> c_int {
-    801
-}
-#[no_mangle]
 pub extern "C" fn cuMemRetainAllocationHandle() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuMemSetAccess() -> c_int {
     801
 }
 #[no_mangle]
@@ -1915,10 +1887,6 @@ pub extern "C" fn cuMemsetD8_v2_ptds() -> c_int {
 }
 #[no_mangle]
 pub extern "C" fn cuMemSetMemPool() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuMemUnmap() -> c_int {
     801
 }
 #[no_mangle]

--- a/crates/smolvm-cuda-shim/src/driver_stubs.rs
+++ b/crates/smolvm-cuda-shim/src/driver_stubs.rs
@@ -174,9 +174,6 @@ pub extern "C" fn cuCtxGetId() -> c_int {
     801
 }
 #[no_mangle]
-pub extern "C" fn cuCtxGetLimit() -> c_int {
-    801
-}
 #[no_mangle]
 pub extern "C" fn cuCtxGetSharedMemConfig() -> c_int {
     801
@@ -210,9 +207,6 @@ pub extern "C" fn cuCtxSetFlags() -> c_int {
     801
 }
 #[no_mangle]
-pub extern "C" fn cuCtxSetLimit() -> c_int {
-    801
-}
 #[no_mangle]
 pub extern "C" fn cuCtxSetSharedMemConfig() -> c_int {
     801
@@ -446,9 +440,6 @@ pub extern "C" fn cuFuncSetBlockShape() -> c_int {
     801
 }
 #[no_mangle]
-pub extern "C" fn cuFuncSetCacheConfig() -> c_int {
-    801
-}
 #[no_mangle]
 pub extern "C" fn cuFuncSetSharedMemConfig() -> c_int {
     801
@@ -1110,13 +1101,7 @@ pub extern "C" fn cuLaunchHostFunc_v2_ptsz() -> c_int {
     801
 }
 #[no_mangle]
-pub extern "C" fn cuLaunchKernelEx() -> c_int {
-    801
-}
 #[no_mangle]
-pub extern "C" fn cuLaunchKernelEx_ptsz() -> c_int {
-    801
-}
 #[no_mangle]
 pub extern "C" fn cuLaunchKernel_ptsz() -> c_int {
     801
@@ -2026,9 +2011,6 @@ pub extern "C" fn cuOccupancyAvailableDynamicSMemPerBlock() -> c_int {
     801
 }
 #[no_mangle]
-pub extern "C" fn cuOccupancyMaxActiveClusters() -> c_int {
-    801
-}
 #[no_mangle]
 pub extern "C" fn cuOccupancyMaxPotentialBlockSize() -> c_int {
     801
@@ -2062,13 +2044,7 @@ pub extern "C" fn cuParamSetv() -> c_int {
     801
 }
 #[no_mangle]
-pub extern "C" fn cuPointerGetAttribute() -> c_int {
-    801
-}
 #[no_mangle]
-pub extern "C" fn cuPointerGetAttributes() -> c_int {
-    801
-}
 #[no_mangle]
 pub extern "C" fn cuPointerSetAttribute() -> c_int {
     801
@@ -2171,10 +2147,6 @@ pub extern "C" fn cuStreamCopyAttributes() -> c_int {
 }
 #[no_mangle]
 pub extern "C" fn cuStreamCopyAttributes_ptsz() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuStreamCreateWithPriority() -> c_int {
     801
 }
 #[no_mangle]

--- a/crates/smolvm-cuda-shim/src/driver_stubs.rs
+++ b/crates/smolvm-cuda-shim/src/driver_stubs.rs
@@ -174,7 +174,6 @@ pub extern "C" fn cuCtxGetId() -> c_int {
     801
 }
 #[no_mangle]
-#[no_mangle]
 pub extern "C" fn cuCtxGetSharedMemConfig() -> c_int {
     801
 }
@@ -206,7 +205,6 @@ pub extern "C" fn cuCtxSetCacheConfig() -> c_int {
 pub extern "C" fn cuCtxSetFlags() -> c_int {
     801
 }
-#[no_mangle]
 #[no_mangle]
 pub extern "C" fn cuCtxSetSharedMemConfig() -> c_int {
     801
@@ -439,7 +437,6 @@ pub extern "C" fn cuFuncLoad() -> c_int {
 pub extern "C" fn cuFuncSetBlockShape() -> c_int {
     801
 }
-#[no_mangle]
 #[no_mangle]
 pub extern "C" fn cuFuncSetSharedMemConfig() -> c_int {
     801
@@ -1100,8 +1097,6 @@ pub extern "C" fn cuLaunchHostFunc_v2() -> c_int {
 pub extern "C" fn cuLaunchHostFunc_v2_ptsz() -> c_int {
     801
 }
-#[no_mangle]
-#[no_mangle]
 #[no_mangle]
 pub extern "C" fn cuLaunchKernel_ptsz() -> c_int {
     801
@@ -2011,7 +2006,6 @@ pub extern "C" fn cuOccupancyAvailableDynamicSMemPerBlock() -> c_int {
     801
 }
 #[no_mangle]
-#[no_mangle]
 pub extern "C" fn cuOccupancyMaxPotentialBlockSize() -> c_int {
     801
 }
@@ -2043,8 +2037,6 @@ pub extern "C" fn cuParamSetTexRef() -> c_int {
 pub extern "C" fn cuParamSetv() -> c_int {
     801
 }
-#[no_mangle]
-#[no_mangle]
 #[no_mangle]
 pub extern "C" fn cuPointerSetAttribute() -> c_int {
     801

--- a/crates/smolvm-cuda-shim/src/lib.rs
+++ b/crates/smolvm-cuda-shim/src/lib.rs
@@ -53,13 +53,16 @@ const SHIM_CUDA_VERSION: c_int = 12040;
 
 // ---- transport ---------------------------------------------------------------
 
-/// One concrete byte stream to the host CUDA server.
+/// One concrete byte stream to the host CUDA server. `Bridged` owns no
+/// socket: the client routes through the runtime shim's connection instead
+/// and never touches its stream.
 enum Stream {
     #[cfg(target_os = "linux")]
     Vsock(vsock::VsockStream),
     Tcp(std::net::TcpStream),
     #[cfg(unix)]
     Unix(std::os::unix::net::UnixStream),
+    Bridged,
 }
 
 impl Read for Stream {
@@ -70,6 +73,7 @@ impl Read for Stream {
             Stream::Tcp(s) => s.read(buf),
             #[cfg(unix)]
             Stream::Unix(s) => s.read(buf),
+            Stream::Bridged => Err(std::io::Error::other("bridged client has no stream")),
         }
     }
 }
@@ -81,6 +85,7 @@ impl Write for Stream {
             Stream::Tcp(s) => s.write(buf),
             #[cfg(unix)]
             Stream::Unix(s) => s.write(buf),
+            Stream::Bridged => Err(std::io::Error::other("bridged client has no stream")),
         }
     }
     fn flush(&mut self) -> std::io::Result<()> {
@@ -90,6 +95,7 @@ impl Write for Stream {
             Stream::Tcp(s) => s.flush(),
             #[cfg(unix)]
             Stream::Unix(s) => s.flush(),
+            Stream::Bridged => Ok(()),
         }
     }
 }
@@ -145,21 +151,28 @@ fn ensure_connected(guard: &mut Option<ShimState>) -> Result<(), c_int> {
     if guard.is_some() {
         return Ok(());
     }
-    let stream = connect()?;
-    let mut client = Client::new(stream);
-    // This connection shares one guest program-order stream with the runtime
-    // shim's connection. Two independently flushed deferred queues let the
-    // host execute their work out of order — recorded misorder in a CUDA
-    // graph replays wrong (paged-attention reads garbage indices → 700).
-    // Driver-side traffic (Triton launches) is low-volume: run it sync, and
-    // fence the runtime connection before each op (see fence_runtime).
-    client.set_defer_enabled(false);
+    // Preferred: ride the runtime shim's connection (both shims loaded, one
+    // program-ordered pipeline, full deferral). Fallback: own connection —
+    // then this traffic shares one guest program-order stream with the
+    // runtime shim's connection, and two independently flushed deferred
+    // queues would let the host execute work out of order (recorded misorder
+    // in a CUDA graph replays wrong), so run every op sync and fence the
+    // runtime connection before each one (see fence_runtime).
+    let mut client = match resolve_bridge() {
+        Some(bridge) => Client::new_bridged(Stream::Bridged, bridge),
+        None => {
+            let mut c = Client::new(connect()?);
+            c.set_defer_enabled(false);
+            c
+        }
+    };
     if let Err(e) = client.init() {
         return Err(match e {
             CudaRpcError::Cuda(code) => code as c_int,
             _ => CUDA_ERROR_NO_DEVICE,
         });
     }
+    BRIDGED.store(client.is_bridged(), std::sync::atomic::Ordering::Relaxed);
     *guard = Some(ShimState {
         client,
         param_sizes: HashMap::new(),
@@ -167,6 +180,41 @@ fn ensure_connected(guard: &mut Option<ShimState>) -> Result<(), c_int> {
         ctx_stack: Vec::new(),
     });
     Ok(())
+}
+
+/// Set once at connect: this shim's client rides the runtime shim's
+/// connection, so the per-op runtime fence is unnecessary.
+static BRIDGED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// The runtime shim's bridge exports, if it's loaded in this process.
+/// All three must resolve or none are used. `SMOLVM_CUDA_BRIDGE=0` forces the
+/// standalone fallback (kill-switch, mirrors `SMOLVM_CUDA_ASYNC=0`).
+fn resolve_bridge() -> Option<smolvm_cuda::client::Bridge> {
+    if std::env::var("SMOLVM_CUDA_BRIDGE").as_deref() == Ok("0") {
+        return None;
+    }
+    extern "C" {
+        fn dlsym(handle: *mut c_void, symbol: *const c_char) -> *mut c_void;
+    }
+    // glibc: RTLD_DEFAULT == NULL (this shim is glibc-only).
+    unsafe {
+        let quiet = dlsym(std::ptr::null_mut(), c"smolvm_cudart_bridge_quiet".as_ptr());
+        let call = dlsym(std::ptr::null_mut(), c"smolvm_cudart_bridge_call".as_ptr());
+        let drain = dlsym(std::ptr::null_mut(), c"smolvm_cudart_bridge_drain".as_ptr());
+        if quiet.is_null() || call.is_null() || drain.is_null() {
+            return None;
+        }
+        Some(smolvm_cuda::client::Bridge {
+            quiet: std::mem::transmute::<*mut c_void, unsafe extern "C" fn(*const u8, usize) -> i32>(
+                quiet,
+            ),
+            call: std::mem::transmute::<
+                *mut c_void,
+                unsafe extern "C" fn(*const u8, usize, *mut u8, usize) -> isize,
+            >(call),
+            drain: std::mem::transmute::<*mut c_void, unsafe extern "C" fn() -> i32>(drain),
+        })
+    }
 }
 
 /// Run `f` against the connected client, translating errors to `CUresult`.
@@ -198,7 +246,10 @@ fn fence_runtime() {
 }
 
 fn with_state<T>(f: impl FnOnce(&mut ShimState) -> Result<T, CudaRpcError>) -> Result<T, c_int> {
-    fence_runtime();
+    // Bridged: program order is inherent (one pipeline), no fence needed.
+    if !BRIDGED.load(std::sync::atomic::Ordering::Relaxed) {
+        fence_runtime();
+    }
     let mut guard = match STATE.lock() {
         Ok(g) => g,
         Err(_) => return Err(CUDA_ERROR_UNKNOWN),
@@ -675,7 +726,7 @@ pub extern "C" fn cuMemcpyHtoD_v2(dptr: u64, src: *const c_void, bytes: usize) -
         return CUDA_ERROR_INVALID_VALUE;
     }
     let data = unsafe { std::slice::from_raw_parts(src as *const u8, bytes) };
-    ret(with_state(|s| s.client.memcpy_htod(dptr, data)))
+    ret(with_state(|s| s.client.memcpy_htod(dptr, data, 0)))
 }
 
 #[no_mangle]
@@ -683,7 +734,7 @@ pub extern "C" fn cuMemcpyDtoH_v2(dst: *mut c_void, dptr: u64, bytes: usize) -> 
     if dst.is_null() && bytes > 0 {
         return CUDA_ERROR_INVALID_VALUE;
     }
-    match with_state(|s| s.client.memcpy_dtoh(dptr, bytes as u64)) {
+    match with_state(|s| s.client.memcpy_dtoh(dptr, bytes as u64, 0)) {
         Ok(data) => {
             if data.len() != bytes {
                 return CUDA_ERROR_UNKNOWN;

--- a/crates/smolvm-cuda-shim/src/lib.rs
+++ b/crates/smolvm-cuda-shim/src/lib.rs
@@ -635,6 +635,104 @@ unsafe fn module_image_len(image: *const c_void) -> Result<usize, c_int> {
         + 1)
 }
 
+// ---- VMM (torch expandable-segments allocator) --------------------------------
+// Prop/desc structs are read at fixed offsets: CUmemAllocationProp.location.id
+// sits at byte 12, CUmemAccessDesc.location.id at byte 4.
+
+#[no_mangle]
+pub extern "C" fn cuMemAddressReserve(
+    ptr: *mut u64,
+    size: usize,
+    align: usize,
+    _addr_hint: u64,
+    _flags: u64,
+) -> c_int {
+    match with_state(|s| s.client.mem_address_reserve(size as u64, align as u64)) {
+        Ok(va) => ret(unsafe { out(ptr, va) }),
+        Err(code) => code,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn cuMemCreate(
+    handle: *mut u64,
+    size: usize,
+    prop: *const c_void,
+    _flags: u64,
+) -> c_int {
+    let device = if prop.is_null() {
+        0
+    } else {
+        unsafe { ((prop as *const u8).add(12) as *const c_int).read_unaligned() }
+    };
+    match with_state(|s| s.client.mem_create(size as u64, device)) {
+        Ok(h) => ret(unsafe { out(handle, h) }),
+        Err(code) => code,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn cuMemMap(
+    ptr: u64,
+    size: usize,
+    offset: usize,
+    handle: u64,
+    _flags: u64,
+) -> c_int {
+    ret(with_state(|s| {
+        s.client.mem_map(ptr, size as u64, offset as u64, handle)
+    }))
+}
+
+#[no_mangle]
+pub extern "C" fn cuMemSetAccess(
+    ptr: u64,
+    size: usize,
+    desc: *const c_void,
+    _count: usize,
+) -> c_int {
+    let device = if desc.is_null() {
+        0
+    } else {
+        unsafe { ((desc as *const u8).add(4) as *const c_int).read_unaligned() }
+    };
+    ret(with_state(|s| {
+        s.client.mem_set_access(ptr, size as u64, device)
+    }))
+}
+
+#[no_mangle]
+pub extern "C" fn cuMemUnmap(ptr: u64, size: usize) -> c_int {
+    ret(with_state(|s| s.client.mem_unmap(ptr, size as u64)))
+}
+
+#[no_mangle]
+pub extern "C" fn cuMemRelease(handle: u64) -> c_int {
+    ret(with_state(|s| s.client.mem_release(handle)))
+}
+
+#[no_mangle]
+pub extern "C" fn cuMemAddressFree(ptr: u64, size: usize) -> c_int {
+    ret(with_state(|s| s.client.mem_address_free(ptr, size as u64)))
+}
+
+#[no_mangle]
+pub extern "C" fn cuMemGetAllocationGranularity(
+    granularity: *mut usize,
+    prop: *const c_void,
+    flags: c_uint,
+) -> c_int {
+    let device = if prop.is_null() {
+        0
+    } else {
+        unsafe { ((prop as *const u8).add(12) as *const c_int).read_unaligned() }
+    };
+    match with_state(|s| s.client.mem_get_allocation_granularity(device, flags)) {
+        Ok(g) => ret(unsafe { out(granularity, g as usize) }),
+        Err(code) => code,
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn cuModuleLoadData(module: *mut *mut c_void, image: *const c_void) -> c_int {
     let len = match unsafe { module_image_len(image) } {

--- a/crates/smolvm-cuda-shim/src/lib.rs
+++ b/crates/smolvm-cuda-shim/src/lib.rs
@@ -722,6 +722,154 @@ pub extern "C" fn cuMemcpyDtoDAsync_v2(
 
 // ---- kernel launch ----------------------------------------------------------------
 
+/// `CUlaunchConfig` (CUDA 12): dims + shared bytes + stream + an attribute
+/// array we don't forward (clusters/programmatic completion — not used by the
+/// Triton kernels that launch through this entry point).
+#[repr(C)]
+struct CuLaunchConfig {
+    grid_x: c_uint,
+    grid_y: c_uint,
+    grid_z: c_uint,
+    block_x: c_uint,
+    block_y: c_uint,
+    block_z: c_uint,
+    shared_bytes: c_uint,
+    stream: *mut c_void,
+    attrs: *mut c_void,
+    num_attrs: c_uint,
+}
+
+/// Attribute-carrying launch (Triton/torch.compile's launcher). The attributes
+/// are ignored; everything else lowers onto the plain launch path.
+#[no_mangle]
+pub extern "C" fn cuLaunchKernelEx(
+    config: *const c_void,
+    func: *mut c_void,
+    kernel_params: *mut *mut c_void,
+    extra: *mut *mut c_void,
+) -> c_int {
+    if config.is_null() {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    // SAFETY: caller passes a valid CUlaunchConfig.
+    let c = unsafe { &*(config as *const CuLaunchConfig) };
+    cuLaunchKernel(
+        func,
+        c.grid_x,
+        c.grid_y,
+        c.grid_z,
+        c.block_x,
+        c.block_y,
+        c.block_z,
+        c.shared_bytes,
+        c.stream,
+        kernel_params,
+        extra,
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn cuLaunchKernelEx_ptsz(
+    config: *const c_void,
+    func: *mut c_void,
+    kernel_params: *mut *mut c_void,
+    extra: *mut *mut c_void,
+) -> c_int {
+    cuLaunchKernelEx(config, func, kernel_params, extra)
+}
+
+/// Pointer attributes. Every device pointer we hand out is the host's real
+/// `CUdeviceptr`, so a pointer the guest holds is a device pointer: report
+/// memory-type Device, device-pointer = the value itself, ordinal 0, not
+/// managed. Range/host-pointer queries return the pointer / null respectively.
+/// vLLM's allocator and Triton link these; a stub error broke import.
+#[no_mangle]
+pub extern "C" fn cuPointerGetAttribute(
+    data: *mut c_void,
+    attribute: c_int,
+    ptr: u64,
+) -> c_int {
+    if data.is_null() {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    // CUpointer_attribute: 1=CONTEXT, 2=MEMORY_TYPE, 3=DEVICE_POINTER,
+    // 4=HOST_POINTER, 6=BUFFER_ID, 7=IS_MANAGED, 9=DEVICE_ORDINAL,
+    // 11=RANGE_START_ADDR, 12=RANGE_SIZE, 13=MAPPED.
+    unsafe {
+        match attribute {
+            2 => *(data as *mut c_uint) = 2, // CU_MEMORYTYPE_DEVICE
+            3 | 11 => *(data as *mut u64) = ptr,
+            12 => *(data as *mut usize) = 0,
+            4 => *(data as *mut u64) = 0, // no host mapping
+            7 => *(data as *mut c_int) = 0,
+            9 => *(data as *mut c_int) = 0,
+            13 => *(data as *mut c_int) = 1,
+            _ => *(data as *mut u64) = 0,
+        }
+    }
+    CUDA_SUCCESS
+}
+
+/// Batched pointer-attribute query: fill each requested attribute per the
+/// single-attribute logic above.
+#[no_mangle]
+pub extern "C" fn cuPointerGetAttributes(
+    num_attributes: c_uint,
+    attributes: *const c_int,
+    data: *const *mut c_void,
+    ptr: u64,
+) -> c_int {
+    if attributes.is_null() || data.is_null() {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    for i in 0..num_attributes as isize {
+        let attr = unsafe { *attributes.offset(i) };
+        let out = unsafe { *data.offset(i) };
+        if !out.is_null() {
+            cuPointerGetAttribute(out, attr, ptr);
+        }
+    }
+    CUDA_SUCCESS
+}
+
+/// Cache-config is a scheduling hint the host driver applies at launch; a
+/// no-op here is correct (work runs on the host's real function).
+#[no_mangle]
+pub extern "C" fn cuFuncSetCacheConfig(_func: *mut c_void, _config: c_int) -> c_int {
+    CUDA_SUCCESS
+}
+
+/// Context limits (stack size, printf FIFO, malloc heap): report a generous
+/// value on get, accept any set. Triton reads the stack-size limit during
+/// launcher setup; a stub error there aborted the launch.
+#[no_mangle]
+pub extern "C" fn cuCtxGetLimit(pvalue: *mut usize, _limit: c_int) -> c_int {
+    if pvalue.is_null() {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    unsafe { *pvalue = 8 * 1024 * 1024 };
+    CUDA_SUCCESS
+}
+#[no_mangle]
+pub extern "C" fn cuCtxSetLimit(_limit: c_int, _value: usize) -> c_int {
+    CUDA_SUCCESS
+}
+
+/// No cluster support (clusters are an sm_90+ feature we don't forward);
+/// reporting 0 max clusters keeps Triton on the standard, non-cluster launch.
+#[no_mangle]
+pub extern "C" fn cuOccupancyMaxActiveClusters(
+    num_clusters: *mut c_int,
+    _func: *mut c_void,
+    _config: *const c_void,
+) -> c_int {
+    if num_clusters.is_null() {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    unsafe { *num_clusters = 0 };
+    CUDA_SUCCESS
+}
+
 #[no_mangle]
 #[allow(clippy::too_many_arguments)]
 pub extern "C" fn cuLaunchKernel(
@@ -787,6 +935,22 @@ pub extern "C" fn cuLaunchKernel(
 
 #[no_mangle]
 pub extern "C" fn cuStreamCreate(stream: *mut *mut c_void, flags: c_uint) -> c_int {
+    match with_state(|s| s.client.stream_create(flags)) {
+        Ok(h) => ret(unsafe { out(stream, h as *mut c_void) }),
+        Err(code) => code,
+    }
+}
+
+// PyTorch's stream pool (used for CUDA-graph capture) creates streams here.
+// Priority is advisory scheduling only; forward as a plain stream. A stub that
+// left `stream` unwritten fed callers an uninitialized handle → a bad-pointer
+// crash inside cuBLAS during graph capture.
+#[no_mangle]
+pub extern "C" fn cuStreamCreateWithPriority(
+    stream: *mut *mut c_void,
+    flags: c_uint,
+    _priority: c_int,
+) -> c_int {
     match with_state(|s| s.client.stream_create(flags)) {
         Ok(h) => ret(unsafe { out(stream, h as *mut c_void) }),
         Err(code) => code,
@@ -939,6 +1103,7 @@ fn proc_table(name: &str) -> Option<*mut c_void> {
         "cuMemGetInfo" => cuMemGetInfo_v2,
         "cuLaunchKernel" => cuLaunchKernel,
         "cuStreamCreate" => cuStreamCreate,
+        "cuStreamCreateWithPriority" => cuStreamCreateWithPriority,
         "cuStreamDestroy" => cuStreamDestroy_v2,
         "cuStreamSynchronize" => cuStreamSynchronize,
         "cuStreamQuery" => cuStreamQuery,
@@ -1075,9 +1240,15 @@ pub extern "C" fn cuFuncGetAttribute(pi: *mut c_int, attrib: c_int, _func: *mut 
     }
     CUDA_SUCCESS
 }
+// Triton/vLLM kernels needing >48 KiB shared memory must raise
+// CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES here before launching, or the
+// launch fails with INVALID_VALUE. Forward it so the host function's real limit
+// is raised; Triton checks the return to decide whether the kernel can run.
 #[no_mangle]
-pub extern "C" fn cuFuncSetAttribute() -> c_int {
-    CUDA_SUCCESS
+pub extern "C" fn cuFuncSetAttribute(func: *mut c_void, attrib: c_int, value: c_int) -> c_int {
+    ret(with_state(|s| {
+        s.client.func_set_attribute(func as u64, attrib, value)
+    }))
 }
 #[no_mangle]
 pub extern "C" fn cuLaunchCooperativeKernel() -> c_int {

--- a/crates/smolvm-cuda-shim/src/lib.rs
+++ b/crates/smolvm-cuda-shim/src/lib.rs
@@ -104,7 +104,10 @@ fn connect() -> Result<Stream, c_int> {
     let spec = std::env::var("SMOLVM_CUDA_RPC").unwrap_or_default();
     if let Some(addr) = spec.strip_prefix("tcp:") {
         return std::net::TcpStream::connect(addr)
-            .map(Stream::Tcp)
+            .map(|s| {
+                let _ = s.set_nodelay(true); // low-latency request/response
+                Stream::Tcp(s)
+            })
             .map_err(|_| CUDA_ERROR_NO_DEVICE);
     }
     #[cfg(unix)]

--- a/crates/smolvm-cuda-shim/src/lib.rs
+++ b/crates/smolvm-cuda-shim/src/lib.rs
@@ -147,6 +147,13 @@ fn ensure_connected(guard: &mut Option<ShimState>) -> Result<(), c_int> {
     }
     let stream = connect()?;
     let mut client = Client::new(stream);
+    // This connection shares one guest program-order stream with the runtime
+    // shim's connection. Two independently flushed deferred queues let the
+    // host execute their work out of order — recorded misorder in a CUDA
+    // graph replays wrong (paged-attention reads garbage indices → 700).
+    // Driver-side traffic (Triton launches) is low-volume: run it sync, and
+    // fence the runtime connection before each op (see fence_runtime).
+    client.set_defer_enabled(false);
     if let Err(e) = client.init() {
         return Err(match e {
             CudaRpcError::Cuda(code) => code as c_int,
@@ -164,7 +171,34 @@ fn ensure_connected(guard: &mut Option<ShimState>) -> Result<(), c_int> {
 
 /// Run `f` against the connected client, translating errors to `CUresult`.
 /// Auto-connects on first use (see [`ensure_connected`]).
+/// Settle the runtime shim's deferred pipeline before running one of our ops,
+/// so guest program order holds across the two connections. The hook is
+/// exported by the runtime shim (`smolvm_cudart_fence` in libcudart); resolved
+/// lazily because either shim can load first. dlsym cost is paid only until
+/// the symbol appears (a process without the runtime shim keeps probing, but
+/// such a process has no cross-connection ordering to preserve anyway).
+fn fence_runtime() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    extern "C" {
+        fn dlsym(handle: *mut c_void, symbol: *const c_char) -> *mut c_void;
+    }
+    // glibc: RTLD_DEFAULT == NULL (this shim is glibc-only).
+    static HOOK: AtomicUsize = AtomicUsize::new(0);
+    let mut p = HOOK.load(Ordering::Relaxed);
+    if p == 0 {
+        p = unsafe { dlsym(std::ptr::null_mut(), c"smolvm_cudart_fence".as_ptr()) } as usize;
+        if p != 0 {
+            HOOK.store(p, Ordering::Relaxed);
+        }
+    }
+    if p != 0 {
+        let f: extern "C" fn() = unsafe { std::mem::transmute::<usize, extern "C" fn()>(p) };
+        f();
+    }
+}
+
 fn with_state<T>(f: impl FnOnce(&mut ShimState) -> Result<T, CudaRpcError>) -> Result<T, c_int> {
+    fence_runtime();
     let mut guard = match STATE.lock() {
         Ok(g) => g,
         Err(_) => return Err(CUDA_ERROR_UNKNOWN),
@@ -784,11 +818,7 @@ pub extern "C" fn cuLaunchKernelEx_ptsz(
 /// managed. Range/host-pointer queries return the pointer / null respectively.
 /// vLLM's allocator and Triton link these; a stub error broke import.
 #[no_mangle]
-pub extern "C" fn cuPointerGetAttribute(
-    data: *mut c_void,
-    attribute: c_int,
-    ptr: u64,
-) -> c_int {
+pub extern "C" fn cuPointerGetAttribute(data: *mut c_void, attribute: c_int, ptr: u64) -> c_int {
     if data.is_null() {
         return CUDA_ERROR_INVALID_VALUE;
     }
@@ -968,17 +998,26 @@ pub extern "C" fn cuStreamSynchronize(stream: *mut c_void) -> c_int {
 }
 
 #[no_mangle]
-pub extern "C" fn cuStreamQuery(_stream: *mut c_void) -> c_int {
-    CUDA_SUCCESS // all work completes synchronously
+pub extern "C" fn cuStreamQuery(stream: *mut c_void) -> c_int {
+    // Honest completion status (0 or 600-NotReady) now that work runs on real
+    // side streams.
+    match with_state(|s| s.client.stream_query(stream as u64)) {
+        Ok(code) => code,
+        Err(e) => e,
+    }
 }
 
 #[no_mangle]
 pub extern "C" fn cuStreamWaitEvent(
-    _stream: *mut c_void,
-    _event: *mut c_void,
-    _flags: c_uint,
+    stream: *mut c_void,
+    event: *mut c_void,
+    flags: c_uint,
 ) -> c_int {
-    CUDA_SUCCESS // recorded events are already complete
+    // Real cross-stream ordering edge (a graph dependency during capture).
+    ret(with_state(|s| {
+        s.client
+            .stream_wait_event(stream as u64, event as u64, flags)
+    }))
 }
 
 #[no_mangle]

--- a/crates/smolvm-cuda/examples/gpu_loopback.rs
+++ b/crates/smolvm-cuda/examples/gpu_loopback.rs
@@ -75,8 +75,8 @@ fn main() {
     let da = cu.mem_alloc(bytes).expect("alloc a");
     let db = cu.mem_alloc(bytes).expect("alloc b");
     let dc = cu.mem_alloc(bytes).expect("alloc c");
-    cu.memcpy_htod(da, bytemuck(&a)).expect("h2d a");
-    cu.memcpy_htod(db, bytemuck(&b)).expect("h2d b");
+    cu.memcpy_htod(da, bytemuck(&a), 0).expect("h2d a");
+    cu.memcpy_htod(db, bytemuck(&b), 0).expect("h2d b");
 
     let block = 256u32;
     let grid = (n as u32).div_ceil(block);
@@ -96,7 +96,7 @@ fn main() {
     .expect("launch");
     cu.ctx_synchronize().expect("sync");
 
-    let out = cu.memcpy_dtoh(dc, bytes).expect("d2h");
+    let out = cu.memcpy_dtoh(dc, bytes, 0).expect("d2h");
     let c: Vec<f32> = out
         .chunks_exact(4)
         .map(|p| f32::from_le_bytes(p.try_into().unwrap()))

--- a/crates/smolvm-cuda/examples/shim_server.rs
+++ b/crates/smolvm-cuda/examples/shim_server.rs
@@ -26,13 +26,15 @@ fn main() {
     println!("SHIM-SERVER-READY {addr} {backend_kind}");
     for stream in listener.incoming() {
         let Ok(stream) = stream else { continue };
-        let _ = stream.set_nodelay(true); // low-latency request/response
+        let __r = stream.set_nodelay(true); // low-latency request/response
         std::thread::spawn(move || {
             let mut backend: Box<dyn Backend> = match GpuBackend::load() {
                 Ok(b) => Box::new(b),
                 Err(_) => Box::<CpuBackend>::default(),
             };
-            let _ = serve(stream, backend.as_mut());
+            if let Err(e) = serve(stream, backend.as_mut()) {
+                eprintln!("[conn-err] {e}");
+            }
         });
     }
 }

--- a/crates/smolvm-cuda/src/client.rs
+++ b/crates/smolvm-cuda/src/client.rs
@@ -65,9 +65,81 @@ fn count_sync(req: &Request, op: Op) {
     }
 }
 
+/// C-ABI hooks into another shim's connection in the same process, resolved
+/// via `dlsym`. The driver shim (`libcuda.so.1`) routes its traffic through
+/// the runtime shim's connection with these, so the host sees ONE
+/// program-ordered pipeline instead of two independently flushed queues (two
+/// queues let the host execute work out of guest program order — fatal once
+/// CUDA-graph capture records the misorder).
+#[derive(Clone, Copy)]
+pub struct Bridge {
+    /// Append one encoded request to the shared pipeline, fire-and-forget.
+    /// Nonzero return = transport failure (op-level failures surface later as
+    /// sticky asynchronous errors on the owning connection).
+    pub quiet: unsafe extern "C" fn(req: *const u8, len: usize) -> i32,
+    /// Send one encoded request, receive its response payload (status still
+    /// in-band). Returns the response length; -1 = transport failure; any
+    /// other negative = `cap` too small, retry with `-ret` bytes and an empty
+    /// request to fetch the stashed response.
+    pub call: unsafe extern "C" fn(req: *const u8, len: usize, resp: *mut u8, cap: usize) -> isize,
+    /// Settle the shared pipeline (fence); returns the first collected
+    /// quiet-failure status, 0 if none.
+    pub drain: unsafe extern "C" fn() -> i32,
+}
+
+/// Debug bisection (`SMOLVM_CUDA_SYNC_OPS=LaunchKernel,LibCall1,LibCall4:10`):
+/// force the named op kinds — optionally narrowed to a library id and
+/// function index for `LibCall` — to synchronous round-trips while the rest
+/// stay deferred, to isolate which deferred class corrupts a failing workload.
+fn sync_forced(req: &Request, op: Op) -> bool {
+    use std::sync::OnceLock;
+    static SET: OnceLock<Vec<String>> = OnceLock::new();
+    let set = SET.get_or_init(|| {
+        std::env::var("SMOLVM_CUDA_SYNC_OPS")
+            .unwrap_or_default()
+            .split(',')
+            .filter(|s| !s.is_empty())
+            .map(|s| s.trim().to_ascii_lowercase())
+            .collect()
+    });
+    if set.is_empty() {
+        return false;
+    }
+    let kind = format!("{op:?}").to_ascii_lowercase();
+    if set.contains(&kind) {
+        return true;
+    }
+    if let Request::LibCall { lib, func, .. } = req {
+        return set.contains(&format!("libcall{lib}"))
+            || set.contains(&format!("libcall{lib}:{func}"));
+    }
+    false
+}
+
+/// Round-trip one encoded request over a [`Bridge`], growing the response
+/// buffer when the callee reports it too small (the callee stashes the
+/// response; an empty request fetches the stash).
+fn bridge_call_vec(b: &Bridge, req: &[u8]) -> Result<Vec<u8>> {
+    let mut buf = vec![0u8; 4096];
+    let mut ret = unsafe { (b.call)(req.as_ptr(), req.len(), buf.as_mut_ptr(), buf.len()) };
+    if ret < -1 {
+        buf = vec![0u8; (-ret) as usize];
+        ret = unsafe { (b.call)(std::ptr::null(), 0, buf.as_mut_ptr(), buf.len()) };
+    }
+    if ret >= 0 {
+        buf.truncate(ret as usize);
+        Ok(buf)
+    } else {
+        Err(CudaRpcError::Protocol("bridge call failed"))
+    }
+}
+
 /// A CUDA Driver-API client over one connection to the host server.
 pub struct Client<S> {
     stream: S,
+    /// When set, this client owns no connection: every request rides another
+    /// shim's connection through these hooks (see [`Bridge`]).
+    bridge: Option<Bridge>,
     /// Count of quiet (fire-and-forget) requests since the last fence. Quiet
     /// requests produce no responses; a fence settles them all at once.
     deferred: usize,
@@ -95,11 +167,24 @@ impl<S: Read + Write> Client<S> {
     pub fn new(stream: S) -> Self {
         Client {
             stream,
+            bridge: None,
             deferred: 0,
             sticky: 0,
             defer_enabled: std::env::var("SMOLVM_CUDA_ASYNC").as_deref() != Ok("0"),
             wbuf: Vec::new(),
         }
+    }
+
+    /// A client that owns no connection: every request rides another shim's
+    /// connection via `bridge`. `stream` is never read or written.
+    pub fn new_bridged(stream: S, bridge: Bridge) -> Self {
+        let mut c = Self::new(stream);
+        c.bridge = Some(bridge);
+        c
+    }
+
+    pub fn is_bridged(&self) -> bool {
+        self.bridge.is_some()
     }
 
     /// Send everything buffered by deferred calls.
@@ -126,6 +211,13 @@ impl<S: Read + Write> Client<S> {
     /// wake-up on vsock), so one fence reply carries the first failure among
     /// them.
     pub fn drain(&mut self) -> Result<()> {
+        if let Some(b) = self.bridge {
+            let st = unsafe { (b.drain)() };
+            if st != 0 && self.sticky == 0 {
+                self.sticky = st;
+            }
+            return Ok(());
+        }
         if self.deferred == 0 {
             return self.flush_wbuf();
         }
@@ -160,8 +252,21 @@ impl<S: Read + Write> Client<S> {
     }
 
     fn call_deferred_kind(&mut self, req: &Request, op: Op, _is_libcall: bool) -> Result<()> {
-        if !self.defer_enabled {
+        if !self.defer_enabled || sync_forced(req, op) {
             return self.call(req, op).map(|_| ());
+        }
+        if let Some(b) = self.bridge {
+            // Push into the owning connection's pipeline NOW — buffering here
+            // would re-create the two-queue reorder the bridge exists to kill.
+            if self.sticky != 0 {
+                return Err(CudaRpcError::Cuda(std::mem::take(&mut self.sticky)));
+            }
+            let payload = encode_request(req);
+            let rc = unsafe { (b.quiet)(payload.as_ptr(), payload.len()) };
+            if rc != 0 {
+                return Err(CudaRpcError::Cuda(rc));
+            }
+            return Ok(());
         }
         if self.deferred >= MAX_DEFERRED {
             self.drain()?;
@@ -196,15 +301,59 @@ impl<S: Read + Write> Client<S> {
         if std::env::var_os("SMOLVM_CUDA_COUNT_SYNC").is_some() {
             count_sync(req, op);
         }
-        self.drain()?;
-        write_msg(&mut self.stream, &encode_request(req))?;
-        let payload =
-            read_msg(&mut self.stream)?.ok_or(CudaRpcError::Protocol("host closed mid-call"))?;
+        let payload = if let Some(b) = self.bridge {
+            bridge_call_vec(&b, &encode_request(req))?
+        } else {
+            self.drain()?;
+            write_msg(&mut self.stream, &encode_request(req))?;
+            read_msg(&mut self.stream)?.ok_or(CudaRpcError::Protocol("host closed mid-call"))?
+        };
         let (status, resp) = decode_response(op, &payload)?;
         if status != 0 {
             return Err(CudaRpcError::Cuda(status));
         }
         Ok(resp)
+    }
+
+    /// Serve a bridged peer: append one pre-encoded request to this
+    /// connection's deferred pipeline, preserving arrival order. In strict
+    /// mode (`SMOLVM_CUDA_ASYNC=0`) the request round-trips instead and a
+    /// failure status is collected as this connection's sticky error.
+    pub fn raw_quiet(&mut self, payload: &[u8]) -> Result<()> {
+        if !self.defer_enabled {
+            let resp = self.raw_call(payload)?;
+            if resp.len() >= 4 {
+                let st = i32::from_le_bytes(resp[..4].try_into().unwrap());
+                if st != 0 && self.sticky == 0 {
+                    self.sticky = st;
+                }
+            }
+            return Ok(());
+        }
+        if self.deferred >= MAX_DEFERRED {
+            self.drain()?;
+        }
+        if self.sticky != 0 {
+            return Err(CudaRpcError::Cuda(std::mem::take(&mut self.sticky)));
+        }
+        self.wbuf
+            .extend_from_slice(&((payload.len() + 1) as u32).to_le_bytes());
+        self.wbuf.push(crate::proto::QUIET_PREFIX);
+        self.wbuf.extend_from_slice(payload);
+        self.deferred += 1;
+        if self.wbuf.len() >= WBUF_FLUSH {
+            self.flush_wbuf()?;
+        }
+        Ok(())
+    }
+
+    /// Serve a bridged peer: one pre-encoded synchronous round-trip. Returns
+    /// the raw response payload — the status stays in-band for the peer to
+    /// decode, so nothing is lost to error mapping.
+    pub fn raw_call(&mut self, payload: &[u8]) -> Result<Vec<u8>> {
+        self.drain()?;
+        write_msg(&mut self.stream, payload)?;
+        read_msg(&mut self.stream)?.ok_or(CudaRpcError::Protocol("host closed mid-call"))
     }
 
     pub fn init(&mut self) -> Result<()> {
@@ -281,20 +430,28 @@ impl<S: Read + Write> Client<S> {
         self.call_deferred(&Request::MemFree { dptr }, Op::MemFree)
     }
 
-    pub fn memcpy_htod(&mut self, dptr: u64, data: &[u8]) -> Result<()> {
+    pub fn memcpy_htod(&mut self, dptr: u64, data: &[u8], stream: u64) -> Result<()> {
         // Deferred: the bytes are copied into the request, so the caller may
         // reuse its buffer immediately — synchronous-memcpy semantics hold.
         self.call_deferred(
             &Request::MemcpyHtoD {
                 dptr,
+                stream,
                 data: data.to_vec(),
             },
             Op::MemcpyHtoD,
         )
     }
 
-    pub fn memcpy_dtoh(&mut self, dptr: u64, bytes: u64) -> Result<Vec<u8>> {
-        match self.call(&Request::MemcpyDtoH { dptr, bytes }, Op::MemcpyDtoH)? {
+    pub fn memcpy_dtoh(&mut self, dptr: u64, bytes: u64, stream: u64) -> Result<Vec<u8>> {
+        match self.call(
+            &Request::MemcpyDtoH {
+                dptr,
+                bytes,
+                stream,
+            },
+            Op::MemcpyDtoH,
+        )? {
             Response::Data(d) => Ok(d),
             _ => Err(CudaRpcError::Protocol("expected Data")),
         }
@@ -736,18 +893,40 @@ impl<S: Read + Write> Client<S> {
     }
 
     /// Zero-copy H2D via the shared region (data already written at `offset`).
-    pub fn memcpy_shm_htod(&mut self, dptr: u64, offset: u64, size: u64) -> Result<()> {
+    pub fn memcpy_shm_htod(
+        &mut self,
+        dptr: u64,
+        offset: u64,
+        size: u64,
+        stream: u64,
+    ) -> Result<()> {
         self.call(
-            &Request::MemcpyShmHtoD { dptr, offset, size },
+            &Request::MemcpyShmHtoD {
+                dptr,
+                offset,
+                size,
+                stream,
+            },
             Op::MemcpyShmHtoD,
         )
         .map(|_| ())
     }
 
     /// Zero-copy D2H via the shared region (host writes into `offset`).
-    pub fn memcpy_shm_dtoh(&mut self, offset: u64, dptr: u64, size: u64) -> Result<()> {
+    pub fn memcpy_shm_dtoh(
+        &mut self,
+        offset: u64,
+        dptr: u64,
+        size: u64,
+        stream: u64,
+    ) -> Result<()> {
         self.call(
-            &Request::MemcpyShmDtoH { offset, dptr, size },
+            &Request::MemcpyShmDtoH {
+                offset,
+                dptr,
+                size,
+                stream,
+            },
             Op::MemcpyShmDtoH,
         )
         .map(|_| ())
@@ -755,9 +934,18 @@ impl<S: Read + Write> Client<S> {
 
     /// Zero-copy H2D from guest RAM: the host gathers `segments` (guest-physical)
     /// and DMAs to `dptr`.
-    pub fn memcpy_gpa_htod(&mut self, dptr: u64, segments: Vec<(u64, u64)>) -> Result<()> {
+    pub fn memcpy_gpa_htod(
+        &mut self,
+        dptr: u64,
+        segments: Vec<(u64, u64)>,
+        stream: u64,
+    ) -> Result<()> {
         self.call(
-            &Request::MemcpyGpaHtoD { dptr, segments },
+            &Request::MemcpyGpaHtoD {
+                dptr,
+                stream,
+                segments,
+            },
             Op::MemcpyGpaHtoD,
         )
         .map(|_| ())
@@ -765,11 +953,119 @@ impl<S: Read + Write> Client<S> {
 
     /// Zero-copy D2H to guest RAM: the host DMAs from `dptr` and scatters into
     /// `segments` (guest-physical).
-    pub fn memcpy_gpa_dtoh(&mut self, dptr: u64, segments: Vec<(u64, u64)>) -> Result<()> {
+    pub fn memcpy_gpa_dtoh(
+        &mut self,
+        dptr: u64,
+        segments: Vec<(u64, u64)>,
+        stream: u64,
+    ) -> Result<()> {
         self.call(
-            &Request::MemcpyGpaDtoH { dptr, segments },
+            &Request::MemcpyGpaDtoH {
+                dptr,
+                stream,
+                segments,
+            },
             Op::MemcpyGpaDtoH,
         )
         .map(|_| ())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proto::QUIET_PREFIX;
+    use std::sync::Mutex;
+
+    /// What the fake bridge callee observed / will serve.
+    static QUIET_LOG: Mutex<Vec<Vec<u8>>> = Mutex::new(Vec::new());
+    static PENDING: Mutex<Option<Vec<u8>>> = Mutex::new(None);
+    static RESPONSE: Mutex<Vec<u8>> = Mutex::new(Vec::new());
+
+    unsafe extern "C" fn fake_quiet(req: *const u8, len: usize) -> i32 {
+        let bytes = unsafe { std::slice::from_raw_parts(req, len) }.to_vec();
+        QUIET_LOG.lock().unwrap().push(bytes);
+        0
+    }
+    unsafe extern "C" fn fake_call(
+        req: *const u8,
+        _len: usize,
+        resp: *mut u8,
+        cap: usize,
+    ) -> isize {
+        let payload = if req.is_null() {
+            PENDING.lock().unwrap().take().expect("no stashed response")
+        } else {
+            RESPONSE.lock().unwrap().clone()
+        };
+        if payload.len() > cap {
+            let n = payload.len() as isize;
+            *PENDING.lock().unwrap() = Some(payload);
+            return -n;
+        }
+        unsafe { std::ptr::copy_nonoverlapping(payload.as_ptr(), resp, payload.len()) };
+        payload.len() as isize
+    }
+    unsafe extern "C" fn fake_drain() -> i32 {
+        7 // pretend a quiet failure was collected
+    }
+
+    fn bridge() -> Bridge {
+        Bridge {
+            quiet: fake_quiet,
+            call: fake_call,
+            drain: fake_drain,
+        }
+    }
+
+    /// io::Empty satisfies Client<S>'s bounds; a bridged client never touches it.
+    fn client() -> Client<std::io::Cursor<Vec<u8>>> {
+        Client::new_bridged(std::io::Cursor::new(Vec::new()), bridge())
+    }
+
+    #[test]
+    fn bridged_deferred_ops_push_immediately() {
+        QUIET_LOG.lock().unwrap().clear();
+        let mut c = client();
+        c.set_defer_enabled(true);
+        c.mem_free(0xAB).unwrap();
+        let log = QUIET_LOG.lock().unwrap();
+        assert_eq!(log.len(), 1, "quiet op must reach the bridge at call time");
+        assert_eq!(log[0], encode_request(&Request::MemFree { dptr: 0xAB }));
+    }
+
+    #[test]
+    fn bridged_call_retries_oversized_response() {
+        // Encoded Count response for DeviceGetCount, padded past the caller's
+        // first 4 KiB buffer to force the stash-and-retry path.
+        let mut resp = 0i32.to_le_bytes().to_vec(); // status 0
+        resp.extend_from_slice(&3i32.to_le_bytes()); // count 3
+        resp.resize(8192, 0);
+        *RESPONSE.lock().unwrap() = resp;
+        let mut c = client();
+        assert_eq!(c.device_get_count().unwrap(), 3);
+        assert!(PENDING.lock().unwrap().is_none(), "stash must be consumed");
+    }
+
+    #[test]
+    fn bridged_drain_collects_sticky() {
+        let mut c = client();
+        c.drain().unwrap();
+        assert_eq!(c.take_sticky(), 7);
+    }
+
+    #[test]
+    fn raw_quiet_frames_like_call_deferred() {
+        // Serving side: raw_quiet must produce the same wire framing as a
+        // native deferred call, so bridged traffic is indistinguishable.
+        let mut direct: Client<std::io::Cursor<Vec<u8>>> =
+            Client::new(std::io::Cursor::new(Vec::new()));
+        direct.set_defer_enabled(true);
+        let payload = encode_request(&Request::MemFree { dptr: 0xCD });
+        direct.raw_quiet(&payload).unwrap();
+        let mut expect = ((payload.len() + 1) as u32).to_le_bytes().to_vec();
+        expect.push(QUIET_PREFIX);
+        expect.extend_from_slice(&payload);
+        assert_eq!(direct.wbuf, expect);
     }
 }

--- a/crates/smolvm-cuda/src/client.rs
+++ b/crates/smolvm-cuda/src/client.rs
@@ -36,17 +36,158 @@ impl From<io::Error> for CudaRpcError {
 
 pub type Result<T> = std::result::Result<T, CudaRpcError>;
 
+/// Debug profiling (`SMOLVM_CUDA_COUNT_SYNC=1`): tally synchronous round-trips
+/// per op, dumped to stderr every 4096 calls, to show what still serializes an
+/// asynchronously-pipelined workload. For `LibCall` the tally key includes the
+/// library id and function index.
+fn count_sync(req: &Request, op: Op) {
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+    static COUNTS: Mutex<Option<HashMap<String, u64>>> = Mutex::new(None);
+    let key = match req {
+        Request::LibCall { lib, func, .. } => format!("LibCall(lib={lib},func={func})"),
+        Request::ModuleGetFunction { name, .. } => format!("ModuleGetFunction({name})"),
+        Request::FuncGetParamInfo { function } => format!("FuncGetParamInfo(fid={function})"),
+        Request::ModuleLoadData { image } => format!("ModuleLoadData(len={})", image.len()),
+        _ => format!("{op:?}"),
+    };
+    let mut g = COUNTS.lock().unwrap();
+    let m = g.get_or_insert_with(HashMap::new);
+    *m.entry(key).or_insert(0) += 1;
+    let total: u64 = m.values().sum();
+    if total % 4096 == 0 {
+        let mut v: Vec<_> = m.iter().collect();
+        v.sort_by(|a, b| b.1.cmp(a.1));
+        eprintln!("[sync-counts after {total}]");
+        for (k, n) in v.iter().take(12) {
+            eprintln!("  {n:>8}  {k}");
+        }
+    }
+}
+
 /// A CUDA Driver-API client over one connection to the host server.
 pub struct Client<S> {
     stream: S,
+    /// Count of quiet (fire-and-forget) requests since the last fence. Quiet
+    /// requests produce no responses; a fence settles them all at once.
+    deferred: usize,
+    /// First non-zero status collected from a deferred response — surfaced at
+    /// the next launch/synchronize, mirroring CUDA's asynchronous ("sticky")
+    /// error reporting.
+    sticky: i32,
+    /// Kill-switch: `SMOLVM_CUDA_ASYNC=0` restores strict per-call round-trips.
+    defer_enabled: bool,
+    /// Framed-but-unsent deferred requests. Batching them into one write turns
+    /// a launch storm's thousand syscalls into a handful; flushed before any
+    /// read (a response can only exist for a request the host has seen).
+    wbuf: Vec<u8>,
 }
+
+/// Outstanding-response cap. Responses are ~8 bytes, so even the smallest
+/// socket buffer holds far more than this; the cap just bounds how much work
+/// can race ahead of an error being noticed.
+const MAX_DEFERRED: usize = 512;
+/// Flush the deferred-write buffer beyond this size even without a sync point,
+/// so bulk H2D byte-shipping doesn't accumulate unbounded copies in memory.
+const WBUF_FLUSH: usize = 256 * 1024;
 
 impl<S: Read + Write> Client<S> {
     pub fn new(stream: S) -> Self {
-        Client { stream }
+        Client {
+            stream,
+            deferred: 0,
+            sticky: 0,
+            defer_enabled: std::env::var("SMOLVM_CUDA_ASYNC").as_deref() != Ok("0"),
+            wbuf: Vec::new(),
+        }
+    }
+
+    /// Send everything buffered by deferred calls.
+    fn flush_wbuf(&mut self) -> Result<()> {
+        if !self.wbuf.is_empty() {
+            self.stream.write_all(&self.wbuf)?;
+            self.stream.flush()?;
+            self.wbuf.clear();
+        }
+        Ok(())
+    }
+
+    /// Settle all fire-and-forget work with a single fence round-trip: quiet
+    /// requests produce no per-op responses (each response read costs a guest
+    /// wake-up on vsock), so one fence reply carries the first failure among
+    /// them.
+    fn drain(&mut self) -> Result<()> {
+        if self.deferred == 0 {
+            return self.flush_wbuf();
+        }
+        self.deferred = 0;
+        self.wbuf.extend_from_slice(&1u32.to_le_bytes());
+        self.wbuf.push(crate::proto::FENCE_OP);
+        self.flush_wbuf()?;
+        let payload =
+            read_msg(&mut self.stream)?.ok_or(CudaRpcError::Protocol("host closed mid-fence"))?;
+        if payload.len() >= 4 {
+            let status = i32::from_le_bytes(payload[..4].try_into().unwrap());
+            if status != 0 && self.sticky == 0 {
+                self.sticky = status;
+            }
+        }
+        Ok(())
+    }
+
+    /// Take (and clear) the sticky asynchronous error, if any. Non-blocking:
+    /// reports failures already collected by a past drain, the way
+    /// `cudaGetLastError` reports asynchronous errors observed so far.
+    pub fn take_sticky(&mut self) -> i32 {
+        std::mem::take(&mut self.sticky)
+    }
+
+    /// Send `req` without waiting for its (status-only) response. Ordering is
+    /// preserved — the host serves one request at a time in arrival order — so
+    /// the deferred work is complete by the time any later round-trip returns.
+    /// Fails fast if an earlier deferred op already failed (sticky).
+    fn call_deferred(&mut self, req: &Request, op: Op) -> Result<()> {
+        self.call_deferred_kind(req, op, false)
+    }
+
+    fn call_deferred_kind(&mut self, req: &Request, op: Op, _is_libcall: bool) -> Result<()> {
+        if !self.defer_enabled {
+            return self.call(req, op).map(|_| ());
+        }
+        if self.deferred >= MAX_DEFERRED {
+            self.drain()?;
+        }
+        if self.sticky != 0 {
+            return Err(CudaRpcError::Cuda(std::mem::take(&mut self.sticky)));
+        }
+        // Frame into the batch buffer as a QUIET request (no response) — one
+        // write syscall per sync point (or per WBUF_FLUSH bytes), and one
+        // fence reply per drain instead of one reply per request.
+        let payload = encode_request(req);
+        self.wbuf
+            .extend_from_slice(&((payload.len() + 1) as u32).to_le_bytes());
+        self.wbuf.push(crate::proto::QUIET_PREFIX);
+        self.wbuf.extend_from_slice(&payload);
+        self.deferred += 1;
+        if self.wbuf.len() >= WBUF_FLUSH {
+            self.flush_wbuf()?;
+        }
+        Ok(())
+    }
+
+    /// Fire-and-forget `LibCall` for library functions with no output
+    /// parameters (GEMMs, conv/batch-norm executes, stream setters): the call
+    /// reports optimistic success and a real failure surfaces as a sticky
+    /// asynchronous error, like a failed kernel launch.
+    pub fn lib_call_deferred(&mut self, lib: u8, func: u16, args: Vec<u8>) -> Result<()> {
+        self.call_deferred_kind(&Request::LibCall { lib, func, args }, Op::LibCall, true)
     }
 
     fn call(&mut self, req: &Request, op: Op) -> Result<Response> {
+        if std::env::var_os("SMOLVM_CUDA_COUNT_SYNC").is_some() {
+            count_sync(req, op);
+        }
+        self.drain()?;
         write_msg(&mut self.stream, &encode_request(req))?;
         let payload =
             read_msg(&mut self.stream)?.ok_or(CudaRpcError::Protocol("host closed mid-call"))?;
@@ -127,19 +268,20 @@ impl<S: Read + Write> Client<S> {
     }
 
     pub fn mem_free(&mut self, dptr: u64) -> Result<()> {
-        self.call(&Request::MemFree { dptr }, Op::MemFree)
-            .map(|_| ())
+        // Deferred: status-only, and callers ignore free failures anyway.
+        self.call_deferred(&Request::MemFree { dptr }, Op::MemFree)
     }
 
     pub fn memcpy_htod(&mut self, dptr: u64, data: &[u8]) -> Result<()> {
-        self.call(
+        // Deferred: the bytes are copied into the request, so the caller may
+        // reuse its buffer immediately — synchronous-memcpy semantics hold.
+        self.call_deferred(
             &Request::MemcpyHtoD {
                 dptr,
                 data: data.to_vec(),
             },
             Op::MemcpyHtoD,
         )
-        .map(|_| ())
     }
 
     pub fn memcpy_dtoh(&mut self, dptr: u64, bytes: u64) -> Result<Vec<u8>> {
@@ -159,7 +301,10 @@ impl<S: Read + Write> Client<S> {
         stream: u64,
         params: &[Vec<u8>],
     ) -> Result<()> {
-        self.call(
+        // Deferred: kernel launches are asynchronous by CUDA contract; launch
+        // failures surface at the next synchronize (or as a sticky error),
+        // exactly like a real asynchronous launch error.
+        self.call_deferred(
             &Request::LaunchKernel {
                 function,
                 grid,
@@ -170,12 +315,16 @@ impl<S: Read + Write> Client<S> {
             },
             Op::LaunchKernel,
         )
-        .map(|_| ())
     }
 
     pub fn ctx_synchronize(&mut self) -> Result<()> {
-        self.call(&Request::CtxSynchronize, Op::CtxSynchronize)
-            .map(|_| ())
+        self.call(&Request::CtxSynchronize, Op::CtxSynchronize)?;
+        // Surface any asynchronous failure collected while draining, the way
+        // cudaDeviceSynchronize reports errors from earlier async work.
+        match self.take_sticky() {
+            0 => Ok(()),
+            code => Err(CudaRpcError::Cuda(code)),
+        }
     }
 
     pub fn driver_get_version(&mut self) -> Result<i32> {
@@ -246,8 +395,8 @@ impl<S: Read + Write> Client<S> {
     }
 
     pub fn memset_d8(&mut self, dptr: u64, value: u8, bytes: u64) -> Result<()> {
-        self.call(&Request::MemsetD8 { dptr, value, bytes }, Op::MemsetD8)
-            .map(|_| ())
+        // Deferred: status-only device-side work, same contract as a launch.
+        self.call_deferred(&Request::MemsetD8 { dptr, value, bytes }, Op::MemsetD8)
     }
 
     /// Returns `(free, total)` device memory in bytes.

--- a/crates/smolvm-cuda/src/client.rs
+++ b/crates/smolvm-cuda/src/client.rs
@@ -1174,6 +1174,63 @@ impl<S: Read + Write> Client<S> {
         }
     }
 
+    // ---- VMM (torch expandable-segments) — sync control-plane ops ----
+    pub fn mem_address_reserve(&mut self, size: u64, align: u64) -> Result<u64> {
+        match self.call(
+            &Request::MemAddressReserve { size, align },
+            Op::MemAddressReserve,
+        )? {
+            Response::Dptr(va) => Ok(va),
+            _ => Err(CudaRpcError::Protocol("expected Dptr")),
+        }
+    }
+    pub fn mem_create(&mut self, size: u64, device: i32) -> Result<u64> {
+        match self.call(&Request::MemCreate { size, device }, Op::MemCreate)? {
+            Response::Handle(h) => Ok(h),
+            _ => Err(CudaRpcError::Protocol("expected Handle")),
+        }
+    }
+    pub fn mem_map(&mut self, va: u64, size: u64, offset: u64, handle: u64) -> Result<()> {
+        self.call(
+            &Request::MemMap {
+                va,
+                size,
+                offset,
+                handle,
+            },
+            Op::MemMap,
+        )
+        .map(|_| ())
+    }
+    pub fn mem_set_access(&mut self, va: u64, size: u64, device: i32) -> Result<()> {
+        self.call(
+            &Request::MemSetAccess { va, size, device },
+            Op::MemSetAccess,
+        )
+        .map(|_| ())
+    }
+    pub fn mem_unmap(&mut self, va: u64, size: u64) -> Result<()> {
+        self.call(&Request::MemUnmap { va, size }, Op::MemUnmap)
+            .map(|_| ())
+    }
+    pub fn mem_release(&mut self, handle: u64) -> Result<()> {
+        self.call(&Request::MemRelease { handle }, Op::MemRelease)
+            .map(|_| ())
+    }
+    pub fn mem_address_free(&mut self, va: u64, size: u64) -> Result<()> {
+        self.call(&Request::MemAddressFree { va, size }, Op::MemAddressFree)
+            .map(|_| ())
+    }
+    pub fn mem_get_allocation_granularity(&mut self, device: i32, flags: u32) -> Result<u64> {
+        match self.call(
+            &Request::MemGetAllocationGranularity { device, flags },
+            Op::MemGetAllocationGranularity,
+        )? {
+            Response::Bytes(g) => Ok(g),
+            _ => Err(CudaRpcError::Protocol("expected Bytes")),
+        }
+    }
+
     /// Zero-copy H2D via the shared region (data already written at `offset`).
     pub fn memcpy_shm_htod(
         &mut self,

--- a/crates/smolvm-cuda/src/client.rs
+++ b/crates/smolvm-cuda/src/client.rs
@@ -317,6 +317,95 @@ impl<S: Read + Write> Client<S> {
         )
     }
 
+    pub fn stream_begin_capture(&mut self, stream: u64, mode: i32) -> Result<()> {
+        self.call(
+            &Request::StreamBeginCapture { stream, mode },
+            Op::StreamBeginCapture,
+        )
+        .map(|_| ())
+    }
+
+    /// Returns the raw `cudaGraph_t` (an opaque host pointer to the guest).
+    pub fn stream_end_capture(&mut self, stream: u64) -> Result<u64> {
+        match self.call(&Request::StreamEndCapture { stream }, Op::StreamEndCapture)? {
+            Response::Handle(h) => Ok(h),
+            _ => Err(CudaRpcError::Protocol("expected Handle")),
+        }
+    }
+
+    /// `(capture_status, capture_id)` straight from the host driver.
+    pub fn stream_capture_info(&mut self, stream: u64) -> Result<(u64, u64)> {
+        match self.call(
+            &Request::StreamCaptureInfo { stream },
+            Op::StreamCaptureInfo,
+        )? {
+            Response::Pair(a, b) => Ok((a, b)),
+            _ => Err(CudaRpcError::Protocol("expected Pair")),
+        }
+    }
+
+    pub fn graph_instantiate(&mut self, graph: u64) -> Result<u64> {
+        match self.call(&Request::GraphInstantiate { graph }, Op::GraphInstantiate)? {
+            Response::Handle(h) => Ok(h),
+            _ => Err(CudaRpcError::Protocol("expected Handle")),
+        }
+    }
+
+    /// Replay an instantiated graph — the hot path (one message replays every
+    /// captured kernel), so it pipelines like a kernel launch.
+    pub fn graph_launch(&mut self, graph_exec: u64, stream: u64) -> Result<()> {
+        self.call_deferred(
+            &Request::GraphLaunch { graph_exec, stream },
+            Op::GraphLaunch,
+        )
+    }
+
+    /// Node count of a captured graph (count-only query; PyTorch uses it to
+    /// warn about empty captures).
+    pub fn graph_get_node_count(&mut self, graph: u64) -> Result<u64> {
+        match self.call(&Request::GraphGetNodes { graph }, Op::GraphGetNodes)? {
+            Response::Bytes(n) => Ok(n),
+            _ => Err(CudaRpcError::Protocol("expected Bytes")),
+        }
+    }
+
+    pub fn graph_exec_destroy(&mut self, graph_exec: u64) -> Result<()> {
+        self.call_deferred(
+            &Request::GraphExecDestroy { graph_exec },
+            Op::GraphExecDestroy,
+        )
+    }
+
+    pub fn graph_destroy(&mut self, graph: u64) -> Result<()> {
+        self.call_deferred(&Request::GraphDestroy { graph }, Op::GraphDestroy)
+    }
+
+    /// Stream-ordered memset: capture-safe (recorded into an active graph).
+    pub fn memset_d8_async(&mut self, dptr: u64, value: u8, bytes: u64, stream: u64) -> Result<()> {
+        self.call_deferred(
+            &Request::MemsetD8Async {
+                dptr,
+                value,
+                bytes,
+                stream,
+            },
+            Op::MemsetD8Async,
+        )
+    }
+
+    /// Stream-ordered device copy: capture-safe.
+    pub fn memcpy_dtod_async(&mut self, dst: u64, src: u64, bytes: u64, stream: u64) -> Result<()> {
+        self.call_deferred(
+            &Request::MemcpyDtoDAsync {
+                dst,
+                src,
+                bytes,
+                stream,
+            },
+            Op::MemcpyDtoDAsync,
+        )
+    }
+
     pub fn ctx_synchronize(&mut self) -> Result<()> {
         self.call(&Request::CtxSynchronize, Op::CtxSynchronize)?;
         // Surface any asynchronous failure collected while draining, the way

--- a/crates/smolvm-cuda/src/client.rs
+++ b/crates/smolvm-cuda/src/client.rs
@@ -465,6 +465,20 @@ impl<S: Read + Write> Client<S> {
     }
 
     /// Per-parameter byte sizes of the kernel's arguments, in declaration order.
+    /// Set a `CUfunction_attribute` on the host function (round-trip: the caller
+    /// — Triton — checks the status to decide whether the kernel can run).
+    pub fn func_set_attribute(&mut self, function: u64, attrib: i32, value: i32) -> Result<()> {
+        self.call(
+            &Request::FuncSetAttribute {
+                function,
+                attrib,
+                value,
+            },
+            Op::FuncSetAttribute,
+        )
+        .map(|_| ())
+    }
+
     pub fn func_get_param_info(&mut self, function: u64) -> Result<Vec<u32>> {
         match self.call(
             &Request::FuncGetParamInfo { function },

--- a/crates/smolvm-cuda/src/client.rs
+++ b/crates/smolvm-cuda/src/client.rs
@@ -134,9 +134,28 @@ fn bridge_call_vec(b: &Bridge, req: &[u8]) -> Result<Vec<u8>> {
     }
 }
 
+/// Shared-memory ring transport state (in-VM fast path; see `crate::ring`).
+pub struct ClientRing {
+    /// Guest→host requests (this side produces).
+    req: crate::ring::Ring,
+    /// Host→guest completions (this side consumes).
+    resp: crate::ring::Ring,
+    /// Guest VAs of the bounce pages: staging for oversized traffic in both
+    /// directions (requests chunk guest→host, responses spill host→guest —
+    /// never simultaneously, the queue is strictly request-then-response).
+    bounce: Vec<*mut u8>,
+    page_size: usize,
+}
+
+// SAFETY: raw pointers reference process-owned pinned pages; the shim holds
+// the client behind a mutex.
+unsafe impl Send for ClientRing {}
+
 /// A CUDA Driver-API client over one connection to the host server.
 pub struct Client<S> {
     stream: S,
+    /// Shared-memory ring transport, when negotiated (in-VM fast path).
+    ring: Option<ClientRing>,
     /// When set, this client owns no connection: every request rides another
     /// shim's connection through these hooks (see [`Bridge`]).
     bridge: Option<Bridge>,
@@ -167,6 +186,7 @@ impl<S: Read + Write> Client<S> {
     pub fn new(stream: S) -> Self {
         Client {
             stream,
+            ring: None,
             bridge: None,
             deferred: 0,
             sticky: 0,
@@ -185,6 +205,187 @@ impl<S: Read + Write> Client<S> {
 
     pub fn is_bridged(&self) -> bool {
         self.bridge.is_some()
+    }
+
+    /// Negotiate the shared-memory ring transport (in-VM fast path). `req`,
+    /// `resp` and `bounce` are (page VAs, page GPAs) of zeroed, mlocked,
+    /// page-aligned guest allocations. On Ok the connection switches: the
+    /// socket carries only doorbell bytes from here on.
+    #[allow(clippy::type_complexity)]
+    pub fn ring_setup(
+        &mut self,
+        page_size: usize,
+        req: (Vec<*mut u8>, Vec<u64>),
+        resp: (Vec<*mut u8>, Vec<u64>),
+        bounce: (Vec<*mut u8>, Vec<u64>),
+    ) -> Result<()> {
+        self.call(
+            &Request::RingSetup {
+                page_size: page_size as u32,
+                req_pages: req.1,
+                resp_pages: resp.1,
+                bounce_pages: bounce.1,
+            },
+            Op::RingSetup,
+        )?;
+        // SAFETY: pages are owned by the shim and stay mapped + resident for
+        // the process lifetime (mlocked, never freed).
+        self.ring = Some(ClientRing {
+            req: unsafe { crate::ring::Ring::from_pages(req.0, page_size) },
+            resp: unsafe { crate::ring::Ring::from_pages(resp.0, page_size) },
+            bounce: bounce.0,
+            page_size,
+        });
+        Ok(())
+    }
+
+    pub fn is_ring(&self) -> bool {
+        self.ring.is_some()
+    }
+
+    /// Push one frame (socket-payload bytes: QUIET/FENCE prefix included) to
+    /// the request ring. Oversized frames chunk through the bounce pages:
+    /// each chunk record is acked by the host before the pages are reused,
+    /// except the last — the caller's own response wait covers it, so every
+    /// oversized frame MUST be a sync op (quiet callers upgrade to sync).
+    fn ring_push(&mut self, frame: &[u8]) -> Result<()> {
+        use crate::ring::{INLINE_MAX, LEN_INDIRECT};
+        if frame.len() <= INLINE_MAX {
+            let ring = self.ring.as_ref().expect("ring transport");
+            while !ring.req.try_push(frame, 0) {
+                std::hint::spin_loop(); // host drains continuously
+            }
+            if ring.req.take_parked() {
+                self.stream.write_all(&[1u8])?;
+                self.stream.flush()?;
+            }
+            return Ok(());
+        }
+        let (bounce_cap, page_size) = {
+            let ring = self.ring.as_ref().expect("ring transport");
+            (ring.bounce.len() * ring.page_size, ring.page_size)
+        };
+        let total = frame.len();
+        let mut off = 0;
+        while off < total {
+            let chunk = (total - off).min(bounce_cap);
+            {
+                let ring = self.ring.as_ref().expect("ring transport");
+                for (i, piece) in frame[off..off + chunk].chunks(page_size).enumerate() {
+                    // SAFETY: bounce pages are live shim allocations of
+                    // page_size bytes each; piece fits by construction.
+                    unsafe {
+                        std::ptr::copy_nonoverlapping(piece.as_ptr(), ring.bounce[i], piece.len());
+                    }
+                }
+                let mut rec = [0u8; 16];
+                rec[..8].copy_from_slice(&(total as u64).to_le_bytes());
+                rec[8..].copy_from_slice(&(chunk as u64).to_le_bytes());
+                while !ring.req.try_push(&rec, LEN_INDIRECT) {
+                    std::hint::spin_loop();
+                }
+                if ring.req.take_parked() {
+                    self.stream.write_all(&[1u8])?;
+                    self.stream.flush()?;
+                }
+            }
+            off += chunk;
+            if off < total {
+                // Host acks each non-final chunk once copied out; the final
+                // chunk is covered by the operation's own response.
+                let _ack = self.ring_pop_response()?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Await exactly one completion record: spin briefly, then park and block
+    /// on a doorbell byte.
+    fn ring_pop_response(&mut self) -> Result<Vec<u8>> {
+        use crate::ring::LEN_INDIRECT;
+        loop {
+            {
+                let ring = self.ring.as_ref().expect("ring transport");
+                let mut popped = ring.resp.try_pop();
+                if popped.is_none() {
+                    for _ in 0..20_000 {
+                        popped = ring.resp.try_pop();
+                        if popped.is_some() {
+                            break;
+                        }
+                        std::hint::spin_loop();
+                    }
+                }
+                if let Some((payload, flags)) = popped {
+                    if flags & LEN_INDIRECT == 0 {
+                        return Ok(payload);
+                    }
+                    // Oversized response: [total][chunk] records, each chunk
+                    // staged in the bounce pages; we post a continue record
+                    // after copying each non-final chunk out.
+                    let mut hdr = payload;
+                    let mut buf: Vec<u8> = Vec::new();
+                    loop {
+                        if hdr.len() < 16 {
+                            return Err(CudaRpcError::Protocol("ring: short indirect"));
+                        }
+                        let total = u64::from_le_bytes(hdr[..8].try_into().unwrap()) as usize;
+                        let chunk = u64::from_le_bytes(hdr[8..16].try_into().unwrap()) as usize;
+                        if chunk > ring.bounce.len() * ring.page_size {
+                            return Err(CudaRpcError::Protocol("ring: bounce overrun"));
+                        }
+                        let mut left = chunk;
+                        for &page in &ring.bounce {
+                            if left == 0 {
+                                break;
+                            }
+                            let take = left.min(ring.page_size);
+                            // SAFETY: bounce pages are live shim allocations.
+                            unsafe {
+                                buf.extend_from_slice(std::slice::from_raw_parts(
+                                    page as *const u8,
+                                    take,
+                                ));
+                            }
+                            left -= take;
+                        }
+                        if buf.len() >= total {
+                            return Ok(buf);
+                        }
+                        // More chunks: tell the host the pages are free.
+                        while !ring.req.try_push(&[0xFF; 16], LEN_INDIRECT) {
+                            std::hint::spin_loop();
+                        }
+                        hdr = loop {
+                            if let Some((p, f)) = ring.resp.try_pop() {
+                                if f & LEN_INDIRECT == 0 {
+                                    return Err(CudaRpcError::Protocol("ring: expected chunk"));
+                                }
+                                break p;
+                            }
+                            std::hint::spin_loop();
+                        };
+                    }
+                }
+                if ring.resp.park() {
+                    continue; // record landed while parking
+                }
+            }
+            // Blocked: wait for the host's doorbell byte on the socket.
+            let mut byte = [0u8; 1];
+            match self.stream.read(&mut byte) {
+                Ok(0) => return Err(CudaRpcError::Protocol("host closed ring connection")),
+                Ok(_) => {}
+                Err(e) => return Err(e.into()),
+            }
+            self.ring.as_ref().expect("ring transport").resp.unpark();
+        }
+    }
+
+    /// One sync round-trip over the rings.
+    fn ring_roundtrip(&mut self, frame: &[u8]) -> Result<Vec<u8>> {
+        self.ring_push(frame)?;
+        self.ring_pop_response()
     }
 
     /// Send everything buffered by deferred calls.
@@ -211,6 +412,20 @@ impl<S: Read + Write> Client<S> {
     /// wake-up on vsock), so one fence reply carries the first failure among
     /// them.
     pub fn drain(&mut self) -> Result<()> {
+        if self.ring.is_some() {
+            if self.deferred == 0 {
+                return Ok(());
+            }
+            self.deferred = 0;
+            let resp = self.ring_roundtrip(&[crate::proto::FENCE_OP])?;
+            if resp.len() >= 4 {
+                let status = i32::from_le_bytes(resp[..4].try_into().unwrap());
+                if status != 0 && self.sticky == 0 {
+                    self.sticky = status;
+                }
+            }
+            return Ok(());
+        }
         if let Some(b) = self.bridge {
             let st = unsafe { (b.drain)() };
             if st != 0 && self.sticky == 0 {
@@ -268,6 +483,34 @@ impl<S: Read + Write> Client<S> {
             }
             return Ok(());
         }
+        if self.ring.is_some() {
+            if self.deferred >= MAX_DEFERRED {
+                self.drain()?;
+            }
+            if self.sticky != 0 {
+                return Err(CudaRpcError::Cuda(std::mem::take(&mut self.sticky)));
+            }
+            let payload = encode_request(req);
+            if payload.len() < crate::ring::INLINE_MAX {
+                let mut frame = Vec::with_capacity(payload.len() + 1);
+                frame.push(crate::proto::QUIET_PREFIX);
+                frame.extend_from_slice(&payload);
+                self.ring_push(&frame)?;
+                self.deferred += 1;
+            } else {
+                // Oversized quiet frames go indirect, which needs the staging
+                // buffer alive until consumption — round-trip instead and
+                // fold a failure into the sticky slot.
+                let resp = self.ring_roundtrip(&payload)?;
+                if resp.len() >= 4 {
+                    let st = i32::from_le_bytes(resp[..4].try_into().unwrap());
+                    if st != 0 && self.sticky == 0 {
+                        self.sticky = st;
+                    }
+                }
+            }
+            return Ok(());
+        }
         if self.deferred >= MAX_DEFERRED {
             self.drain()?;
         }
@@ -301,7 +544,9 @@ impl<S: Read + Write> Client<S> {
         if std::env::var_os("SMOLVM_CUDA_COUNT_SYNC").is_some() {
             count_sync(req, op);
         }
-        let payload = if let Some(b) = self.bridge {
+        let payload = if self.ring.is_some() {
+            self.ring_roundtrip(&encode_request(req))?
+        } else if let Some(b) = self.bridge {
             bridge_call_vec(&b, &encode_request(req))?
         } else {
             // Flush, don't fence: the host serves in arrival order, so this
@@ -326,6 +571,30 @@ impl<S: Read + Write> Client<S> {
     /// mode (`SMOLVM_CUDA_ASYNC=0`) the request round-trips instead and a
     /// failure status is collected as this connection's sticky error.
     pub fn raw_quiet(&mut self, payload: &[u8]) -> Result<()> {
+        if self.ring.is_some() && self.defer_enabled {
+            if self.deferred >= MAX_DEFERRED {
+                self.drain()?;
+            }
+            if self.sticky != 0 {
+                return Err(CudaRpcError::Cuda(std::mem::take(&mut self.sticky)));
+            }
+            if payload.len() < crate::ring::INLINE_MAX {
+                let mut frame = Vec::with_capacity(payload.len() + 1);
+                frame.push(crate::proto::QUIET_PREFIX);
+                frame.extend_from_slice(payload);
+                self.ring_push(&frame)?;
+                self.deferred += 1;
+            } else {
+                let resp = self.ring_roundtrip(payload)?;
+                if resp.len() >= 4 {
+                    let st = i32::from_le_bytes(resp[..4].try_into().unwrap());
+                    if st != 0 && self.sticky == 0 {
+                        self.sticky = st;
+                    }
+                }
+            }
+            return Ok(());
+        }
         if !self.defer_enabled {
             let resp = self.raw_call(payload)?;
             if resp.len() >= 4 {
@@ -357,6 +626,9 @@ impl<S: Read + Write> Client<S> {
     /// the raw response payload — the status stays in-band for the peer to
     /// decode, so nothing is lost to error mapping.
     pub fn raw_call(&mut self, payload: &[u8]) -> Result<Vec<u8>> {
+        if self.ring.is_some() {
+            return self.ring_roundtrip(payload);
+        }
         // Flush, don't fence — see `call`.
         self.flush_wbuf()?;
         write_msg(&mut self.stream, payload)?;

--- a/crates/smolvm-cuda/src/client.rs
+++ b/crates/smolvm-cuda/src/client.rs
@@ -445,6 +445,9 @@ impl<S: Read + Write> Client<S> {
         if payload.len() >= 4 {
             let status = i32::from_le_bytes(payload[..4].try_into().unwrap());
             if status != 0 && self.sticky == 0 {
+                if std::env::var_os("SMOLVM_CUDA_TRACE_STICKY").is_some() {
+                    eprintln!("[sticky] fence collected {status}");
+                }
                 self.sticky = status;
             }
         }

--- a/crates/smolvm-cuda/src/client.rs
+++ b/crates/smolvm-cuda/src/client.rs
@@ -55,7 +55,7 @@ fn count_sync(req: &Request, op: Op) {
     let m = g.get_or_insert_with(HashMap::new);
     *m.entry(key).or_insert(0) += 1;
     let total: u64 = m.values().sum();
-    if total % 4096 == 0 {
+    if total.is_multiple_of(4096) {
         let mut v: Vec<_> = m.iter().collect();
         v.sort_by(|a, b| b.1.cmp(a.1));
         eprintln!("[sync-counts after {total}]");

--- a/crates/smolvm-cuda/src/client.rs
+++ b/crates/smolvm-cuda/src/client.rs
@@ -112,11 +112,20 @@ impl<S: Read + Write> Client<S> {
         Ok(())
     }
 
+    /// Force every op to a synchronous round-trip (disable the deferred
+    /// pipeline). Used by the driver shim: it shares one guest program-order
+    /// stream with the runtime shim's connection, and two independently
+    /// flushed deferred queues would let the host execute their work out of
+    /// program order (fatal once CUDA-graph capture records the misorder).
+    pub fn set_defer_enabled(&mut self, on: bool) {
+        self.defer_enabled = on;
+    }
+
     /// Settle all fire-and-forget work with a single fence round-trip: quiet
     /// requests produce no per-op responses (each response read costs a guest
     /// wake-up on vsock), so one fence reply carries the first failure among
     /// them.
-    fn drain(&mut self) -> Result<()> {
+    pub fn drain(&mut self) -> Result<()> {
         if self.deferred == 0 {
             return self.flush_wbuf();
         }
@@ -315,6 +324,18 @@ impl<S: Read + Write> Client<S> {
             },
             Op::LaunchKernel,
         )
+    }
+
+    /// Exchange the serving thread's stream-capture interaction mode; returns
+    /// the previous mode. Sync: the caller's next op must see the new mode.
+    pub fn thread_exchange_capture_mode(&mut self, mode: i32) -> Result<i32> {
+        match self.call(
+            &Request::ThreadExchangeCaptureMode { mode },
+            Op::ThreadExchangeCaptureMode,
+        )? {
+            Response::Count(old) => Ok(old),
+            _ => Err(CudaRpcError::Protocol("expected Count")),
+        }
     }
 
     pub fn stream_begin_capture(&mut self, stream: u64, mode: i32) -> Result<()> {
@@ -528,6 +549,35 @@ impl<S: Read + Write> Client<S> {
             Op::StreamSynchronize,
         )
         .map(|_| ())
+    }
+
+    /// Raw `cuStreamQuery` code: 0 complete, 600 not ready.
+    pub fn stream_query(&mut self, stream: u64) -> Result<i32> {
+        match self.call(&Request::StreamQuery { stream }, Op::StreamQuery)? {
+            Response::Count(code) => Ok(code),
+            _ => Err(CudaRpcError::Protocol("expected Count")),
+        }
+    }
+
+    /// Deferred like a launch: a stream-ordered dependency edge whose failure
+    /// surfaces at the next fence, exactly like an async launch error.
+    pub fn stream_wait_event(&mut self, stream: u64, event: u64, flags: u32) -> Result<()> {
+        self.call_deferred(
+            &Request::StreamWaitEvent {
+                stream,
+                event,
+                flags,
+            },
+            Op::StreamWaitEvent,
+        )
+    }
+
+    /// Raw `cuEventQuery` code: 0 complete, 600 not ready.
+    pub fn event_query(&mut self, event: u64) -> Result<i32> {
+        match self.call(&Request::EventQuery { event }, Op::EventQuery)? {
+            Response::Count(code) => Ok(code),
+            _ => Err(CudaRpcError::Protocol("expected Count")),
+        }
     }
 
     pub fn event_create(&mut self, flags: u32) -> Result<u64> {

--- a/crates/smolvm-cuda/src/client.rs
+++ b/crates/smolvm-cuda/src/client.rs
@@ -304,7 +304,13 @@ impl<S: Read + Write> Client<S> {
         let payload = if let Some(b) = self.bridge {
             bridge_call_vec(&b, &encode_request(req))?
         } else {
-            self.drain()?;
+            // Flush, don't fence: the host serves in arrival order, so this
+            // request's response already proves every deferred request before
+            // it was consumed. A fence here would double the RTT of every
+            // sync op under deferred load just to surface quiet failures a
+            // little earlier — they still surface at explicit sync points
+            // (drain) and the MAX_DEFERRED backstop.
+            self.flush_wbuf()?;
             write_msg(&mut self.stream, &encode_request(req))?;
             read_msg(&mut self.stream)?.ok_or(CudaRpcError::Protocol("host closed mid-call"))?
         };
@@ -351,7 +357,8 @@ impl<S: Read + Write> Client<S> {
     /// the raw response payload — the status stays in-band for the peer to
     /// decode, so nothing is lost to error mapping.
     pub fn raw_call(&mut self, payload: &[u8]) -> Result<Vec<u8>> {
-        self.drain()?;
+        // Flush, don't fence — see `call`.
+        self.flush_wbuf()?;
         write_msg(&mut self.stream, payload)?;
         read_msg(&mut self.stream)?.ok_or(CudaRpcError::Protocol("host closed mid-call"))
     }

--- a/crates/smolvm-cuda/src/generated/cublas_guest.rs
+++ b/crates/smolvm-cuda/src/generated/cublas_guest.rs
@@ -3,13 +3,12 @@ const LIB_ID: u8 = 1;
 #[no_mangle]
 pub extern "C" fn cublasCreate_v2(handle_out: *mut *mut c_void) -> c_int {
     if handle_out.is_null() { return 1; }
-    match with_client(|c| c.lib_call(LIB_ID, 0, Vec::new())) {
-        Ok((0, out)) if out.len() >= 8 => {
-            let h = u64::from_le_bytes(out[..8].try_into().unwrap());
-            unsafe { *handle_out = h as *mut c_void };
-            0
-        }
-        Ok((st, _)) => st,
+    // Fire-and-forget create: return a guest-assigned virtual id
+    // immediately; the host materializes the real descriptor and
+    // maps the id (see vh_resolve on the host side).
+    let vh = super::alloc_vhandle();
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 0, vh.to_le_bytes().to_vec())) {
+        Ok(()) => { unsafe { *handle_out = vh as *mut c_void }; 0 }
         Err(_) => 1,
     }
 }
@@ -17,7 +16,8 @@ pub extern "C" fn cublasCreate_v2(handle_out: *mut *mut c_void) -> c_int {
 pub extern "C" fn cublasDestroy_v2(handle: *mut c_void) -> c_int {
     let mut a: Vec<u8> = Vec::new();
     a.extend_from_slice(&(handle as u64).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 1, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 1, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasSgemm_v2(handle: *mut c_void, transa: c_int, transb: c_int, m: c_int, n: c_int, k: c_int, alpha: *const f32, A: *const f32, lda: c_int, B: *const f32, ldb: c_int, beta: *const f32, C: *mut f32, ldc: c_int) -> c_int {
@@ -38,7 +38,8 @@ pub extern "C" fn cublasSgemm_v2(handle: *mut c_void, transa: c_int, transb: c_i
     a.extend_from_slice(&(unsafe { *beta } as f32).to_le_bytes());
     a.extend_from_slice(&(C as u64).to_le_bytes());
     a.extend_from_slice(&(ldc as i32).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 2, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 2, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasDgemm_v2(handle: *mut c_void, transa: c_int, transb: c_int, m: c_int, n: c_int, k: c_int, alpha: *const f64, A: *const f64, lda: c_int, B: *const f64, ldb: c_int, beta: *const f64, C: *mut f64, ldc: c_int) -> c_int {
@@ -59,7 +60,8 @@ pub extern "C" fn cublasDgemm_v2(handle: *mut c_void, transa: c_int, transb: c_i
     a.extend_from_slice(&(unsafe { *beta } as f64).to_le_bytes());
     a.extend_from_slice(&(C as u64).to_le_bytes());
     a.extend_from_slice(&(ldc as i32).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 3, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 3, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasSgemmStridedBatched(handle: *mut c_void, transa: c_int, transb: c_int, m: c_int, n: c_int, k: c_int, alpha: *const f32, A: *const f32, lda: c_int, strideA: i64, B: *const f32, ldb: c_int, strideB: i64, beta: *const f32, C: *mut f32, ldc: c_int, strideC: i64, batchCount: c_int) -> c_int {
@@ -84,7 +86,8 @@ pub extern "C" fn cublasSgemmStridedBatched(handle: *mut c_void, transa: c_int, 
     a.extend_from_slice(&(ldc as i32).to_le_bytes());
     a.extend_from_slice(&(strideC as i64).to_le_bytes());
     a.extend_from_slice(&(batchCount as i32).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 4, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 4, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasDgemmStridedBatched(handle: *mut c_void, transa: c_int, transb: c_int, m: c_int, n: c_int, k: c_int, alpha: *const f64, A: *const f64, lda: c_int, strideA: i64, B: *const f64, ldb: c_int, strideB: i64, beta: *const f64, C: *mut f64, ldc: c_int, strideC: i64, batchCount: c_int) -> c_int {
@@ -109,14 +112,16 @@ pub extern "C" fn cublasDgemmStridedBatched(handle: *mut c_void, transa: c_int, 
     a.extend_from_slice(&(ldc as i32).to_le_bytes());
     a.extend_from_slice(&(strideC as i64).to_le_bytes());
     a.extend_from_slice(&(batchCount as i32).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 5, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 5, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasSetStream_v2(handle: *mut c_void, stream: *mut c_void) -> c_int {
     let mut a: Vec<u8> = Vec::new();
     a.extend_from_slice(&(handle as u64).to_le_bytes());
     a.extend_from_slice(&(stream as u64).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 6, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 6, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasSetWorkspace_v2(handle: *mut c_void, workspace: *mut c_void, size: usize) -> c_int {
@@ -124,14 +129,16 @@ pub extern "C" fn cublasSetWorkspace_v2(handle: *mut c_void, workspace: *mut c_v
     a.extend_from_slice(&(handle as u64).to_le_bytes());
     a.extend_from_slice(&(workspace as u64).to_le_bytes());
     a.extend_from_slice(&(size as u64).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 7, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 7, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasSetMathMode(handle: *mut c_void, mode: c_int) -> c_int {
     let mut a: Vec<u8> = Vec::new();
     a.extend_from_slice(&(handle as u64).to_le_bytes());
     a.extend_from_slice(&(mode as i32).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 8, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 8, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasGetMathMode(handle: *mut c_void, mode: *mut c_int) -> c_int {
@@ -179,7 +186,8 @@ pub extern "C" fn cublasGemmEx(handle: *mut c_void, transa: c_int, transb: c_int
     a.extend_from_slice(&(ldc as i32).to_le_bytes());
     a.extend_from_slice(&(computeType as i32).to_le_bytes());
     a.extend_from_slice(&(algo as i32).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 11, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 11, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasGemmStridedBatchedEx(handle: *mut c_void, transa: c_int, transb: c_int, m: c_int, n: c_int, k: c_int, alpha: *const f32, A: *const c_void, Atype: c_int, lda: c_int, strideA: i64, B: *const c_void, Btype: c_int, ldb: c_int, strideB: i64, beta: *const f32, C: *mut c_void, Ctype: c_int, ldc: c_int, strideC: i64, batchCount: c_int, computeType: c_int, algo: c_int) -> c_int {
@@ -209,5 +217,6 @@ pub extern "C" fn cublasGemmStridedBatchedEx(handle: *mut c_void, transa: c_int,
     a.extend_from_slice(&(batchCount as i32).to_le_bytes());
     a.extend_from_slice(&(computeType as i32).to_le_bytes());
     a.extend_from_slice(&(algo as i32).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 12, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 12, a)) { Ok(()) => 0, Err(_) => 1 }
 }

--- a/crates/smolvm-cuda/src/generated/cublas_guest.rs
+++ b/crates/smolvm-cuda/src/generated/cublas_guest.rs
@@ -42,6 +42,28 @@ pub extern "C" fn cublasSgemm_v2(handle: *mut c_void, transa: c_int, transb: c_i
     match with_client(|c| c.lib_call_deferred(LIB_ID, 2, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
+pub extern "C" fn cublasHgemm(handle: *mut c_void, transa: c_int, transb: c_int, m: c_int, n: c_int, k: c_int, alpha: *const u16, A: *const u16, lda: c_int, B: *const u16, ldb: c_int, beta: *const u16, C: *mut u16, ldc: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(transa as i32).to_le_bytes());
+    a.extend_from_slice(&(transb as i32).to_le_bytes());
+    a.extend_from_slice(&(m as i32).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    a.extend_from_slice(&(k as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as u16).to_le_bytes());
+    a.extend_from_slice(&(A as u64).to_le_bytes());
+    a.extend_from_slice(&(lda as i32).to_le_bytes());
+    a.extend_from_slice(&(B as u64).to_le_bytes());
+    a.extend_from_slice(&(ldb as i32).to_le_bytes());
+    if beta.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *beta } as u16).to_le_bytes());
+    a.extend_from_slice(&(C as u64).to_le_bytes());
+    a.extend_from_slice(&(ldc as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 3, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
 pub extern "C" fn cublasDgemm_v2(handle: *mut c_void, transa: c_int, transb: c_int, m: c_int, n: c_int, k: c_int, alpha: *const f64, A: *const f64, lda: c_int, B: *const f64, ldb: c_int, beta: *const f64, C: *mut f64, ldc: c_int) -> c_int {
     let mut a: Vec<u8> = Vec::new();
     a.extend_from_slice(&(handle as u64).to_le_bytes());
@@ -61,7 +83,7 @@ pub extern "C" fn cublasDgemm_v2(handle: *mut c_void, transa: c_int, transb: c_i
     a.extend_from_slice(&(C as u64).to_le_bytes());
     a.extend_from_slice(&(ldc as i32).to_le_bytes());
     // No output params: fire-and-forget (failures surface as sticky async errors).
-    match with_client(|c| c.lib_call_deferred(LIB_ID, 3, a)) { Ok(()) => 0, Err(_) => 1 }
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 4, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasSgemmStridedBatched(handle: *mut c_void, transa: c_int, transb: c_int, m: c_int, n: c_int, k: c_int, alpha: *const f32, A: *const f32, lda: c_int, strideA: i64, B: *const f32, ldb: c_int, strideB: i64, beta: *const f32, C: *mut f32, ldc: c_int, strideC: i64, batchCount: c_int) -> c_int {
@@ -87,7 +109,7 @@ pub extern "C" fn cublasSgemmStridedBatched(handle: *mut c_void, transa: c_int, 
     a.extend_from_slice(&(strideC as i64).to_le_bytes());
     a.extend_from_slice(&(batchCount as i32).to_le_bytes());
     // No output params: fire-and-forget (failures surface as sticky async errors).
-    match with_client(|c| c.lib_call_deferred(LIB_ID, 4, a)) { Ok(()) => 0, Err(_) => 1 }
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 5, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasDgemmStridedBatched(handle: *mut c_void, transa: c_int, transb: c_int, m: c_int, n: c_int, k: c_int, alpha: *const f64, A: *const f64, lda: c_int, strideA: i64, B: *const f64, ldb: c_int, strideB: i64, beta: *const f64, C: *mut f64, ldc: c_int, strideC: i64, batchCount: c_int) -> c_int {
@@ -113,7 +135,7 @@ pub extern "C" fn cublasDgemmStridedBatched(handle: *mut c_void, transa: c_int, 
     a.extend_from_slice(&(strideC as i64).to_le_bytes());
     a.extend_from_slice(&(batchCount as i32).to_le_bytes());
     // No output params: fire-and-forget (failures surface as sticky async errors).
-    match with_client(|c| c.lib_call_deferred(LIB_ID, 5, a)) { Ok(()) => 0, Err(_) => 1 }
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 6, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasSetStream_v2(handle: *mut c_void, stream: *mut c_void) -> c_int {
@@ -121,7 +143,7 @@ pub extern "C" fn cublasSetStream_v2(handle: *mut c_void, stream: *mut c_void) -
     a.extend_from_slice(&(handle as u64).to_le_bytes());
     a.extend_from_slice(&(stream as u64).to_le_bytes());
     // No output params: fire-and-forget (failures surface as sticky async errors).
-    match with_client(|c| c.lib_call_deferred(LIB_ID, 6, a)) { Ok(()) => 0, Err(_) => 1 }
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 7, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasSetWorkspace_v2(handle: *mut c_void, workspace: *mut c_void, size: usize) -> c_int {
@@ -130,7 +152,7 @@ pub extern "C" fn cublasSetWorkspace_v2(handle: *mut c_void, workspace: *mut c_v
     a.extend_from_slice(&(workspace as u64).to_le_bytes());
     a.extend_from_slice(&(size as u64).to_le_bytes());
     // No output params: fire-and-forget (failures surface as sticky async errors).
-    match with_client(|c| c.lib_call_deferred(LIB_ID, 7, a)) { Ok(()) => 0, Err(_) => 1 }
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 8, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasSetMathMode(handle: *mut c_void, mode: c_int) -> c_int {
@@ -138,13 +160,13 @@ pub extern "C" fn cublasSetMathMode(handle: *mut c_void, mode: c_int) -> c_int {
     a.extend_from_slice(&(handle as u64).to_le_bytes());
     a.extend_from_slice(&(mode as i32).to_le_bytes());
     // No output params: fire-and-forget (failures surface as sticky async errors).
-    match with_client(|c| c.lib_call_deferred(LIB_ID, 8, a)) { Ok(()) => 0, Err(_) => 1 }
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 9, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasGetMathMode(handle: *mut c_void, mode: *mut c_int) -> c_int {
     let mut a: Vec<u8> = Vec::new();
     a.extend_from_slice(&(handle as u64).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 9, a)) {
+    match with_client(|c| c.lib_call(LIB_ID, 10, a)) {
         Ok((st, out)) => { let mut o = 0usize;
             if !mode.is_null() && out.len() >= o + 4 { unsafe { *mode = i32::from_le_bytes(out[o..o + 4].try_into().unwrap()) as _ }; } o += 4;
             let _ = o; st }
@@ -155,7 +177,7 @@ pub extern "C" fn cublasGetMathMode(handle: *mut c_void, mode: *mut c_int) -> c_
 pub extern "C" fn cublasGetProperty(prop_type: c_int, value: *mut c_int) -> c_int {
     let mut a: Vec<u8> = Vec::new();
     a.extend_from_slice(&(prop_type as i32).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 10, a)) {
+    match with_client(|c| c.lib_call(LIB_ID, 11, a)) {
         Ok((st, out)) => { let mut o = 0usize;
             if !value.is_null() && out.len() >= o + 4 { unsafe { *value = i32::from_le_bytes(out[o..o + 4].try_into().unwrap()) as _ }; } o += 4;
             let _ = o; st }
@@ -187,7 +209,7 @@ pub extern "C" fn cublasGemmEx(handle: *mut c_void, transa: c_int, transb: c_int
     a.extend_from_slice(&(computeType as i32).to_le_bytes());
     a.extend_from_slice(&(algo as i32).to_le_bytes());
     // No output params: fire-and-forget (failures surface as sticky async errors).
-    match with_client(|c| c.lib_call_deferred(LIB_ID, 11, a)) { Ok(()) => 0, Err(_) => 1 }
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 12, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasGemmStridedBatchedEx(handle: *mut c_void, transa: c_int, transb: c_int, m: c_int, n: c_int, k: c_int, alpha: *const f32, A: *const c_void, Atype: c_int, lda: c_int, strideA: i64, B: *const c_void, Btype: c_int, ldb: c_int, strideB: i64, beta: *const f32, C: *mut c_void, Ctype: c_int, ldc: c_int, strideC: i64, batchCount: c_int, computeType: c_int, algo: c_int) -> c_int {
@@ -218,5 +240,5 @@ pub extern "C" fn cublasGemmStridedBatchedEx(handle: *mut c_void, transa: c_int,
     a.extend_from_slice(&(computeType as i32).to_le_bytes());
     a.extend_from_slice(&(algo as i32).to_le_bytes());
     // No output params: fire-and-forget (failures surface as sticky async errors).
-    match with_client(|c| c.lib_call_deferred(LIB_ID, 12, a)) { Ok(()) => 0, Err(_) => 1 }
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 13, a)) { Ok(()) => 0, Err(_) => 1 }
 }

--- a/crates/smolvm-cuda/src/generated/cublas_host.rs
+++ b/crates/smolvm-cuda/src/generated/cublas_host.rs
@@ -36,18 +36,20 @@ impl GenLib {
             })
         }
     }
-    pub fn dispatch(&self, func: u16, args: &[u8]) -> (i32, Vec<u8>) {
+    pub fn dispatch(&self, func: u16, args: &[u8], __vh: &mut std::collections::HashMap<u64, u64>) -> (i32, Vec<u8>) {
         let mut __c = GenCur { b: args, p: 0 };
         match func {
-            0 => { let mut h: *mut c_void = std::ptr::null_mut(); let st = unsafe { (self.f_cublasCreate_v2)(&mut h) }; (st, (h as u64).to_le_bytes().to_vec()) }
+            0 => { let mut h: *mut c_void = std::ptr::null_mut(); let st = unsafe { (self.f_cublasCreate_v2)(&mut h) }; if st == 0 && args.len() >= 8 { let id = u64::from_le_bytes(args[..8].try_into().unwrap()); if id & super::VHANDLE_TAG != 0 { __vh.insert(id, h as u64); } } (st, (h as u64).to_le_bytes().to_vec()) }
             1 => {
-                let handle = __c.u64() as *mut c_void;
+                let __raw = __c.u64();
+                let handle = super::vh_resolve(__vh, __raw) as *mut c_void;
+                if __raw & super::VHANDLE_TAG != 0 { __vh.remove(&__raw); }
                 let mut out = Vec::new();
                 let st = unsafe { (self.f_cublasDestroy_v2)(handle) };
                 (st, out)
             }
             2 => {
-                let handle = __c.u64() as *mut c_void;
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
                 let transa = __c.i32();
                 let transb = __c.i32();
                 let m = __c.i32();
@@ -66,7 +68,7 @@ impl GenLib {
                 (st, out)
             }
             3 => {
-                let handle = __c.u64() as *mut c_void;
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
                 let transa = __c.i32();
                 let transb = __c.i32();
                 let m = __c.i32();
@@ -85,7 +87,7 @@ impl GenLib {
                 (st, out)
             }
             4 => {
-                let handle = __c.u64() as *mut c_void;
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
                 let transa = __c.i32();
                 let transb = __c.i32();
                 let m = __c.i32();
@@ -108,7 +110,7 @@ impl GenLib {
                 (st, out)
             }
             5 => {
-                let handle = __c.u64() as *mut c_void;
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
                 let transa = __c.i32();
                 let transb = __c.i32();
                 let m = __c.i32();
@@ -131,14 +133,14 @@ impl GenLib {
                 (st, out)
             }
             6 => {
-                let handle = __c.u64() as *mut c_void;
-                let stream = __c.u64() as *mut c_void;
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let stream = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
                 let mut out = Vec::new();
                 let st = unsafe { (self.f_cublasSetStream_v2)(handle, stream) };
                 (st, out)
             }
             7 => {
-                let handle = __c.u64() as *mut c_void;
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
                 let workspace = __c.u64() as *mut c_void;
                 let size = __c.u64();
                 let mut out = Vec::new();
@@ -146,14 +148,14 @@ impl GenLib {
                 (st, out)
             }
             8 => {
-                let handle = __c.u64() as *mut c_void;
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
                 let mode = __c.i32();
                 let mut out = Vec::new();
                 let st = unsafe { (self.f_cublasSetMathMode)(handle, mode as c_int) };
                 (st, out)
             }
             9 => {
-                let handle = __c.u64() as *mut c_void;
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
                 let mut mode_v: c_int = 0 as c_int;
                 let mut out = Vec::new();
                 let st = unsafe { (self.f_cublasGetMathMode)(handle, &mut mode_v) };
@@ -169,7 +171,7 @@ impl GenLib {
                 (st, out)
             }
             11 => {
-                let handle = __c.u64() as *mut c_void;
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
                 let transa = __c.i32();
                 let transb = __c.i32();
                 let m = __c.i32();
@@ -193,7 +195,7 @@ impl GenLib {
                 (st, out)
             }
             12 => {
-                let handle = __c.u64() as *mut c_void;
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
                 let transa = __c.i32();
                 let transb = __c.i32();
                 let m = __c.i32();

--- a/crates/smolvm-cuda/src/generated/cublas_host.rs
+++ b/crates/smolvm-cuda/src/generated/cublas_host.rs
@@ -3,6 +3,7 @@ pub struct GenLib { _lib: Library,
     f_cublasCreate_v2: unsafe extern "C" fn(*mut *mut c_void) -> c_int,
     f_cublasDestroy_v2: unsafe extern "C" fn(*mut c_void) -> c_int,
     f_cublasSgemm_v2: unsafe extern "C" fn(*mut c_void, c_int, c_int, c_int, c_int, c_int, *const f32, *const f32, c_int, *const f32, c_int, *const f32, *mut f32, c_int) -> c_int,
+    f_cublasHgemm: unsafe extern "C" fn(*mut c_void, c_int, c_int, c_int, c_int, c_int, *const u16, *const u16, c_int, *const u16, c_int, *const u16, *mut u16, c_int) -> c_int,
     f_cublasDgemm_v2: unsafe extern "C" fn(*mut c_void, c_int, c_int, c_int, c_int, c_int, *const f64, *const f64, c_int, *const f64, c_int, *const f64, *mut f64, c_int) -> c_int,
     f_cublasSgemmStridedBatched: unsafe extern "C" fn(*mut c_void, c_int, c_int, c_int, c_int, c_int, *const f32, *const f32, c_int, i64, *const f32, c_int, i64, *const f32, *mut f32, c_int, i64, c_int) -> c_int,
     f_cublasDgemmStridedBatched: unsafe extern "C" fn(*mut c_void, c_int, c_int, c_int, c_int, c_int, *const f64, *const f64, c_int, i64, *const f64, c_int, i64, *const f64, *mut f64, c_int, i64, c_int) -> c_int,
@@ -22,6 +23,7 @@ impl GenLib {
                 f_cublasCreate_v2: sym(&lib, b"cublasCreate_v2\0")?,
                 f_cublasDestroy_v2: sym(&lib, b"cublasDestroy_v2\0")?,
                 f_cublasSgemm_v2: sym(&lib, b"cublasSgemm_v2\0")?,
+                f_cublasHgemm: sym(&lib, b"cublasHgemm\0")?,
                 f_cublasDgemm_v2: sym(&lib, b"cublasDgemm_v2\0")?,
                 f_cublasSgemmStridedBatched: sym(&lib, b"cublasSgemmStridedBatched\0")?,
                 f_cublasDgemmStridedBatched: sym(&lib, b"cublasDgemmStridedBatched\0")?,
@@ -74,6 +76,25 @@ impl GenLib {
                 let m = __c.i32();
                 let n = __c.i32();
                 let k = __c.i32();
+                let alpha_v = __c.u16();
+                let A = __c.u64() as *const u16;
+                let lda = __c.i32();
+                let B = __c.u64() as *const u16;
+                let ldb = __c.i32();
+                let beta_v = __c.u16();
+                let C = __c.u64() as *mut u16;
+                let ldc = __c.i32();
+                let mut out = Vec::new();
+                let st = unsafe { (self.f_cublasHgemm)(handle, transa as c_int, transb as c_int, m as c_int, n as c_int, k as c_int, &alpha_v, A, lda as c_int, B, ldb as c_int, &beta_v, C, ldc as c_int) };
+                (st, out)
+            }
+            4 => {
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let transa = __c.i32();
+                let transb = __c.i32();
+                let m = __c.i32();
+                let n = __c.i32();
+                let k = __c.i32();
                 let alpha_v = __c.f64();
                 let A = __c.u64() as *const f64;
                 let lda = __c.i32();
@@ -86,7 +107,7 @@ impl GenLib {
                 let st = unsafe { (self.f_cublasDgemm_v2)(handle, transa as c_int, transb as c_int, m as c_int, n as c_int, k as c_int, &alpha_v, A, lda as c_int, B, ldb as c_int, &beta_v, C, ldc as c_int) };
                 (st, out)
             }
-            4 => {
+            5 => {
                 let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
                 let transa = __c.i32();
                 let transb = __c.i32();
@@ -109,7 +130,7 @@ impl GenLib {
                 let st = unsafe { (self.f_cublasSgemmStridedBatched)(handle, transa as c_int, transb as c_int, m as c_int, n as c_int, k as c_int, &alpha_v, A, lda as c_int, strideA as i64, B, ldb as c_int, strideB as i64, &beta_v, C, ldc as c_int, strideC as i64, batchCount as c_int) };
                 (st, out)
             }
-            5 => {
+            6 => {
                 let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
                 let transa = __c.i32();
                 let transb = __c.i32();
@@ -132,14 +153,14 @@ impl GenLib {
                 let st = unsafe { (self.f_cublasDgemmStridedBatched)(handle, transa as c_int, transb as c_int, m as c_int, n as c_int, k as c_int, &alpha_v, A, lda as c_int, strideA as i64, B, ldb as c_int, strideB as i64, &beta_v, C, ldc as c_int, strideC as i64, batchCount as c_int) };
                 (st, out)
             }
-            6 => {
+            7 => {
                 let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
                 let stream = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
                 let mut out = Vec::new();
                 let st = unsafe { (self.f_cublasSetStream_v2)(handle, stream) };
                 (st, out)
             }
-            7 => {
+            8 => {
                 let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
                 let workspace = __c.u64() as *mut c_void;
                 let size = __c.u64();
@@ -147,14 +168,14 @@ impl GenLib {
                 let st = unsafe { (self.f_cublasSetWorkspace_v2)(handle, workspace, size as usize) };
                 (st, out)
             }
-            8 => {
+            9 => {
                 let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
                 let mode = __c.i32();
                 let mut out = Vec::new();
                 let st = unsafe { (self.f_cublasSetMathMode)(handle, mode as c_int) };
                 (st, out)
             }
-            9 => {
+            10 => {
                 let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
                 let mut mode_v: c_int = 0 as c_int;
                 let mut out = Vec::new();
@@ -162,7 +183,7 @@ impl GenLib {
                 out.extend_from_slice(&(mode_v as i32).to_le_bytes());
                 (st, out)
             }
-            10 => {
+            11 => {
                 let prop_type = __c.i32();
                 let mut value_v: c_int = 0 as c_int;
                 let mut out = Vec::new();
@@ -170,7 +191,7 @@ impl GenLib {
                 out.extend_from_slice(&(value_v as i32).to_le_bytes());
                 (st, out)
             }
-            11 => {
+            12 => {
                 let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
                 let transa = __c.i32();
                 let transb = __c.i32();
@@ -194,7 +215,7 @@ impl GenLib {
                 let st = unsafe { (self.f_cublasGemmEx)(handle, transa as c_int, transb as c_int, m as c_int, n as c_int, k as c_int, &alpha_v, A, Atype as c_int, lda as c_int, B, Btype as c_int, ldb as c_int, &beta_v, C, Ctype as c_int, ldc as c_int, computeType as c_int, algo as c_int) };
                 (st, out)
             }
-            12 => {
+            13 => {
                 let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
                 let transa = __c.i32();
                 let transb = __c.i32();
@@ -229,6 +250,7 @@ impl GenLib {
 struct GenCur<'a> { b: &'a [u8], p: usize }
 impl GenCur<'_> {
     fn take(&mut self, n: usize) -> [u8; 8] { let mut o = [0u8; 8]; let end = (self.p + n).min(self.b.len()); o[..end - self.p].copy_from_slice(&self.b[self.p..end]); self.p = end; o }
+    fn u16(&mut self) -> u16 { u16::from_le_bytes(self.take(2)[..2].try_into().unwrap()) }
     fn i32(&mut self) -> i32 { i32::from_le_bytes(self.take(4)[..4].try_into().unwrap()) }
     fn i64(&mut self) -> i64 { i64::from_le_bytes(self.take(8)) }
     fn u64(&mut self) -> u64 { u64::from_le_bytes(self.take(8)) }

--- a/crates/smolvm-cuda/src/generated/cublas_host.rs
+++ b/crates/smolvm-cuda/src/generated/cublas_host.rs
@@ -38,8 +38,9 @@ impl GenLib {
             })
         }
     }
-    pub fn dispatch(&self, func: u16, args: &[u8], __vh: &mut std::collections::HashMap<u64, u64>) -> (i32, Vec<u8>) {
+    pub fn dispatch(&self, func: u16, args: &[u8], __vh: &mut std::collections::HashMap<u64, u64>, __streams: &std::collections::HashMap<u64, u64>) -> (i32, Vec<u8>) {
         let mut __c = GenCur { b: args, p: 0 };
+        let _ = __streams;
         match func {
             0 => { let mut h: *mut c_void = std::ptr::null_mut(); let st = unsafe { (self.f_cublasCreate_v2)(&mut h) }; if st == 0 && args.len() >= 8 { let id = u64::from_le_bytes(args[..8].try_into().unwrap()); if id & super::VHANDLE_TAG != 0 { __vh.insert(id, h as u64); } } (st, (h as u64).to_le_bytes().to_vec()) }
             1 => {
@@ -155,7 +156,7 @@ impl GenLib {
             }
             7 => {
                 let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
-                let stream = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let stream = super::stream_resolve(__streams, __c.u64()) as *mut c_void;
                 let mut out = Vec::new();
                 let st = unsafe { (self.f_cublasSetStream_v2)(handle, stream) };
                 (st, out)

--- a/crates/smolvm-cuda/src/generated/cudnn_guest.rs
+++ b/crates/smolvm-cuda/src/generated/cudnn_guest.rs
@@ -3,13 +3,12 @@ const LIB_ID: u8 = 2;
 #[no_mangle]
 pub extern "C" fn cudnnCreate(handle_out: *mut *mut c_void) -> c_int {
     if handle_out.is_null() { return 1; }
-    match with_client(|c| c.lib_call(LIB_ID, 0, Vec::new())) {
-        Ok((0, out)) if out.len() >= 8 => {
-            let h = u64::from_le_bytes(out[..8].try_into().unwrap());
-            unsafe { *handle_out = h as *mut c_void };
-            0
-        }
-        Ok((st, _)) => st,
+    // Fire-and-forget create: return a guest-assigned virtual id
+    // immediately; the host materializes the real descriptor and
+    // maps the id (see vh_resolve on the host side).
+    let vh = super::alloc_vhandle();
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 0, vh.to_le_bytes().to_vec())) {
+        Ok(()) => { unsafe { *handle_out = vh as *mut c_void }; 0 }
         Err(_) => 1,
     }
 }
@@ -17,25 +16,26 @@ pub extern "C" fn cudnnCreate(handle_out: *mut *mut c_void) -> c_int {
 pub extern "C" fn cudnnDestroy(handle: *mut c_void) -> c_int {
     let mut a: Vec<u8> = Vec::new();
     a.extend_from_slice(&(handle as u64).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 1, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 1, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cudnnSetStream(handle: *mut c_void, stream: *mut c_void) -> c_int {
     let mut a: Vec<u8> = Vec::new();
     a.extend_from_slice(&(handle as u64).to_le_bytes());
     a.extend_from_slice(&(stream as u64).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 2, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 2, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cudnnCreateTensorDescriptor(handle_out: *mut *mut c_void) -> c_int {
     if handle_out.is_null() { return 1; }
-    match with_client(|c| c.lib_call(LIB_ID, 3, Vec::new())) {
-        Ok((0, out)) if out.len() >= 8 => {
-            let h = u64::from_le_bytes(out[..8].try_into().unwrap());
-            unsafe { *handle_out = h as *mut c_void };
-            0
-        }
-        Ok((st, _)) => st,
+    // Fire-and-forget create: return a guest-assigned virtual id
+    // immediately; the host materializes the real descriptor and
+    // maps the id (see vh_resolve on the host side).
+    let vh = super::alloc_vhandle();
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 3, vh.to_le_bytes().to_vec())) {
+        Ok(()) => { unsafe { *handle_out = vh as *mut c_void }; 0 }
         Err(_) => 1,
     }
 }
@@ -49,24 +49,25 @@ pub extern "C" fn cudnnSetTensor4dDescriptor(t: *mut c_void, fmt: c_int, dtype: 
     a.extend_from_slice(&(c as i32).to_le_bytes());
     a.extend_from_slice(&(h as i32).to_le_bytes());
     a.extend_from_slice(&(w as i32).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 4, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 4, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cudnnDestroyTensorDescriptor(t: *mut c_void) -> c_int {
     let mut a: Vec<u8> = Vec::new();
     a.extend_from_slice(&(t as u64).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 5, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 5, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cudnnCreateFilterDescriptor(handle_out: *mut *mut c_void) -> c_int {
     if handle_out.is_null() { return 1; }
-    match with_client(|c| c.lib_call(LIB_ID, 6, Vec::new())) {
-        Ok((0, out)) if out.len() >= 8 => {
-            let h = u64::from_le_bytes(out[..8].try_into().unwrap());
-            unsafe { *handle_out = h as *mut c_void };
-            0
-        }
-        Ok((st, _)) => st,
+    // Fire-and-forget create: return a guest-assigned virtual id
+    // immediately; the host materializes the real descriptor and
+    // maps the id (see vh_resolve on the host side).
+    let vh = super::alloc_vhandle();
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 6, vh.to_le_bytes().to_vec())) {
+        Ok(()) => { unsafe { *handle_out = vh as *mut c_void }; 0 }
         Err(_) => 1,
     }
 }
@@ -80,24 +81,25 @@ pub extern "C" fn cudnnSetFilter4dDescriptor(f: *mut c_void, dtype: c_int, fmt: 
     a.extend_from_slice(&(c as i32).to_le_bytes());
     a.extend_from_slice(&(h as i32).to_le_bytes());
     a.extend_from_slice(&(w as i32).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 7, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 7, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cudnnDestroyFilterDescriptor(f: *mut c_void) -> c_int {
     let mut a: Vec<u8> = Vec::new();
     a.extend_from_slice(&(f as u64).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 8, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 8, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cudnnCreateConvolutionDescriptor(handle_out: *mut *mut c_void) -> c_int {
     if handle_out.is_null() { return 1; }
-    match with_client(|c| c.lib_call(LIB_ID, 9, Vec::new())) {
-        Ok((0, out)) if out.len() >= 8 => {
-            let h = u64::from_le_bytes(out[..8].try_into().unwrap());
-            unsafe { *handle_out = h as *mut c_void };
-            0
-        }
-        Ok((st, _)) => st,
+    // Fire-and-forget create: return a guest-assigned virtual id
+    // immediately; the host materializes the real descriptor and
+    // maps the id (see vh_resolve on the host side).
+    let vh = super::alloc_vhandle();
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 9, vh.to_le_bytes().to_vec())) {
+        Ok(()) => { unsafe { *handle_out = vh as *mut c_void }; 0 }
         Err(_) => 1,
     }
 }
@@ -113,13 +115,15 @@ pub extern "C" fn cudnnSetConvolution2dDescriptor(cv: *mut c_void, pad_h: c_int,
     a.extend_from_slice(&(dil_w as i32).to_le_bytes());
     a.extend_from_slice(&(mode as i32).to_le_bytes());
     a.extend_from_slice(&(ctype as i32).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 10, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 10, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cudnnDestroyConvolutionDescriptor(cv: *mut c_void) -> c_int {
     let mut a: Vec<u8> = Vec::new();
     a.extend_from_slice(&(cv as u64).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 11, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 11, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cudnnGetConvolutionForwardWorkspaceSize(handle: *mut c_void, x: *mut c_void, w: *mut c_void, cv: *mut c_void, y: *mut c_void, algo: c_int, size: *mut usize) -> c_int {
@@ -155,5 +159,6 @@ pub extern "C" fn cudnnConvolutionForward(handle: *mut c_void, alpha: *const f32
     a.extend_from_slice(&(unsafe { *beta } as f32).to_le_bytes());
     a.extend_from_slice(&(yDesc as u64).to_le_bytes());
     a.extend_from_slice(&(y as u64).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 13, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 13, a)) { Ok(()) => 0, Err(_) => 1 }
 }

--- a/crates/smolvm-cuda/src/generated/cudnn_host.rs
+++ b/crates/smolvm-cuda/src/generated/cudnn_host.rs
@@ -38,26 +38,28 @@ impl GenLib {
             })
         }
     }
-    pub fn dispatch(&self, func: u16, args: &[u8]) -> (i32, Vec<u8>) {
+    pub fn dispatch(&self, func: u16, args: &[u8], __vh: &mut std::collections::HashMap<u64, u64>) -> (i32, Vec<u8>) {
         let mut __c = GenCur { b: args, p: 0 };
         match func {
-            0 => { let mut h: *mut c_void = std::ptr::null_mut(); let st = unsafe { (self.f_cudnnCreate)(&mut h) }; (st, (h as u64).to_le_bytes().to_vec()) }
+            0 => { let mut h: *mut c_void = std::ptr::null_mut(); let st = unsafe { (self.f_cudnnCreate)(&mut h) }; if st == 0 && args.len() >= 8 { let id = u64::from_le_bytes(args[..8].try_into().unwrap()); if id & super::VHANDLE_TAG != 0 { __vh.insert(id, h as u64); } } (st, (h as u64).to_le_bytes().to_vec()) }
             1 => {
-                let handle = __c.u64() as *mut c_void;
+                let __raw = __c.u64();
+                let handle = super::vh_resolve(__vh, __raw) as *mut c_void;
+                if __raw & super::VHANDLE_TAG != 0 { __vh.remove(&__raw); }
                 let mut out = Vec::new();
                 let st = unsafe { (self.f_cudnnDestroy)(handle) };
                 (st, out)
             }
             2 => {
-                let handle = __c.u64() as *mut c_void;
-                let stream = __c.u64() as *mut c_void;
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let stream = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
                 let mut out = Vec::new();
                 let st = unsafe { (self.f_cudnnSetStream)(handle, stream) };
                 (st, out)
             }
-            3 => { let mut h: *mut c_void = std::ptr::null_mut(); let st = unsafe { (self.f_cudnnCreateTensorDescriptor)(&mut h) }; (st, (h as u64).to_le_bytes().to_vec()) }
+            3 => { let mut h: *mut c_void = std::ptr::null_mut(); let st = unsafe { (self.f_cudnnCreateTensorDescriptor)(&mut h) }; if st == 0 && args.len() >= 8 { let id = u64::from_le_bytes(args[..8].try_into().unwrap()); if id & super::VHANDLE_TAG != 0 { __vh.insert(id, h as u64); } } (st, (h as u64).to_le_bytes().to_vec()) }
             4 => {
-                let t = __c.u64() as *mut c_void;
+                let t = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
                 let fmt = __c.i32();
                 let dtype = __c.i32();
                 let n = __c.i32();
@@ -69,14 +71,16 @@ impl GenLib {
                 (st, out)
             }
             5 => {
-                let t = __c.u64() as *mut c_void;
+                let __raw = __c.u64();
+                let t = super::vh_resolve(__vh, __raw) as *mut c_void;
+                if __raw & super::VHANDLE_TAG != 0 { __vh.remove(&__raw); }
                 let mut out = Vec::new();
                 let st = unsafe { (self.f_cudnnDestroyTensorDescriptor)(t) };
                 (st, out)
             }
-            6 => { let mut h: *mut c_void = std::ptr::null_mut(); let st = unsafe { (self.f_cudnnCreateFilterDescriptor)(&mut h) }; (st, (h as u64).to_le_bytes().to_vec()) }
+            6 => { let mut h: *mut c_void = std::ptr::null_mut(); let st = unsafe { (self.f_cudnnCreateFilterDescriptor)(&mut h) }; if st == 0 && args.len() >= 8 { let id = u64::from_le_bytes(args[..8].try_into().unwrap()); if id & super::VHANDLE_TAG != 0 { __vh.insert(id, h as u64); } } (st, (h as u64).to_le_bytes().to_vec()) }
             7 => {
-                let f = __c.u64() as *mut c_void;
+                let f = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
                 let dtype = __c.i32();
                 let fmt = __c.i32();
                 let k = __c.i32();
@@ -88,14 +92,16 @@ impl GenLib {
                 (st, out)
             }
             8 => {
-                let f = __c.u64() as *mut c_void;
+                let __raw = __c.u64();
+                let f = super::vh_resolve(__vh, __raw) as *mut c_void;
+                if __raw & super::VHANDLE_TAG != 0 { __vh.remove(&__raw); }
                 let mut out = Vec::new();
                 let st = unsafe { (self.f_cudnnDestroyFilterDescriptor)(f) };
                 (st, out)
             }
-            9 => { let mut h: *mut c_void = std::ptr::null_mut(); let st = unsafe { (self.f_cudnnCreateConvolutionDescriptor)(&mut h) }; (st, (h as u64).to_le_bytes().to_vec()) }
+            9 => { let mut h: *mut c_void = std::ptr::null_mut(); let st = unsafe { (self.f_cudnnCreateConvolutionDescriptor)(&mut h) }; if st == 0 && args.len() >= 8 { let id = u64::from_le_bytes(args[..8].try_into().unwrap()); if id & super::VHANDLE_TAG != 0 { __vh.insert(id, h as u64); } } (st, (h as u64).to_le_bytes().to_vec()) }
             10 => {
-                let cv = __c.u64() as *mut c_void;
+                let cv = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
                 let pad_h = __c.i32();
                 let pad_w = __c.i32();
                 let u = __c.i32();
@@ -109,17 +115,19 @@ impl GenLib {
                 (st, out)
             }
             11 => {
-                let cv = __c.u64() as *mut c_void;
+                let __raw = __c.u64();
+                let cv = super::vh_resolve(__vh, __raw) as *mut c_void;
+                if __raw & super::VHANDLE_TAG != 0 { __vh.remove(&__raw); }
                 let mut out = Vec::new();
                 let st = unsafe { (self.f_cudnnDestroyConvolutionDescriptor)(cv) };
                 (st, out)
             }
             12 => {
-                let handle = __c.u64() as *mut c_void;
-                let x = __c.u64() as *mut c_void;
-                let w = __c.u64() as *mut c_void;
-                let cv = __c.u64() as *mut c_void;
-                let y = __c.u64() as *mut c_void;
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let x = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let w = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let cv = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let y = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
                 let algo = __c.i32();
                 let mut size_v: usize = 0 as usize;
                 let mut out = Vec::new();
@@ -128,18 +136,18 @@ impl GenLib {
                 (st, out)
             }
             13 => {
-                let handle = __c.u64() as *mut c_void;
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
                 let alpha_v = __c.f32();
-                let xDesc = __c.u64() as *mut c_void;
+                let xDesc = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
                 let x = __c.u64() as *mut c_void;
-                let wDesc = __c.u64() as *mut c_void;
+                let wDesc = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
                 let w = __c.u64() as *mut c_void;
-                let convDesc = __c.u64() as *mut c_void;
+                let convDesc = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
                 let algo = __c.i32();
                 let workspace = __c.u64() as *mut c_void;
                 let wsSize = __c.u64();
                 let beta_v = __c.f32();
-                let yDesc = __c.u64() as *mut c_void;
+                let yDesc = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
                 let y = __c.u64() as *mut c_void;
                 let mut out = Vec::new();
                 let st = unsafe { (self.f_cudnnConvolutionForward)(handle, &alpha_v, xDesc, x, wDesc, w, convDesc, algo as c_int, workspace, wsSize as usize, &beta_v, yDesc, y) };

--- a/crates/smolvm-cuda/src/generated/cudnn_host.rs
+++ b/crates/smolvm-cuda/src/generated/cudnn_host.rs
@@ -160,6 +160,7 @@ impl GenLib {
 struct GenCur<'a> { b: &'a [u8], p: usize }
 impl GenCur<'_> {
     fn take(&mut self, n: usize) -> [u8; 8] { let mut o = [0u8; 8]; let end = (self.p + n).min(self.b.len()); o[..end - self.p].copy_from_slice(&self.b[self.p..end]); self.p = end; o }
+    fn u16(&mut self) -> u16 { u16::from_le_bytes(self.take(2)[..2].try_into().unwrap()) }
     fn i32(&mut self) -> i32 { i32::from_le_bytes(self.take(4)[..4].try_into().unwrap()) }
     fn i64(&mut self) -> i64 { i64::from_le_bytes(self.take(8)) }
     fn u64(&mut self) -> u64 { u64::from_le_bytes(self.take(8)) }

--- a/crates/smolvm-cuda/src/generated/cudnn_host.rs
+++ b/crates/smolvm-cuda/src/generated/cudnn_host.rs
@@ -38,8 +38,9 @@ impl GenLib {
             })
         }
     }
-    pub fn dispatch(&self, func: u16, args: &[u8], __vh: &mut std::collections::HashMap<u64, u64>) -> (i32, Vec<u8>) {
+    pub fn dispatch(&self, func: u16, args: &[u8], __vh: &mut std::collections::HashMap<u64, u64>, __streams: &std::collections::HashMap<u64, u64>) -> (i32, Vec<u8>) {
         let mut __c = GenCur { b: args, p: 0 };
+        let _ = __streams;
         match func {
             0 => { let mut h: *mut c_void = std::ptr::null_mut(); let st = unsafe { (self.f_cudnnCreate)(&mut h) }; if st == 0 && args.len() >= 8 { let id = u64::from_le_bytes(args[..8].try_into().unwrap()); if id & super::VHANDLE_TAG != 0 { __vh.insert(id, h as u64); } } (st, (h as u64).to_le_bytes().to_vec()) }
             1 => {
@@ -52,7 +53,7 @@ impl GenLib {
             }
             2 => {
                 let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
-                let stream = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let stream = super::stream_resolve(__streams, __c.u64()) as *mut c_void;
                 let mut out = Vec::new();
                 let st = unsafe { (self.f_cudnnSetStream)(handle, stream) };
                 (st, out)

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -22,6 +22,7 @@ pub type CuResult<T> = Result<T, i32>;
 pub const CUDA_ERROR_INVALID_HANDLE: i32 = 400;
 /// `CUDA_ERROR_NOT_FOUND`.
 pub const CUDA_ERROR_NOT_FOUND: i32 = 500;
+pub const CUDA_ERROR_NOT_SUPPORTED: i32 = 801;
 
 /// A CUDA Driver-API implementation. Handles returned here are the backend's
 /// own raw values (e.g. real `CUmodule` pointers); [`serve`] hides them behind
@@ -61,6 +62,26 @@ pub trait Backend: Send {
     ) -> CuResult<()>;
     fn ctx_synchronize(&mut self) -> CuResult<()>;
     fn stream_create(&mut self, flags: u32) -> CuResult<u64>;
+    /// Begin capturing `stream`'s work into a CUDA graph (mode per
+    /// `cudaStreamCaptureMode`).
+    fn stream_begin_capture(&mut self, stream: u64, mode: i32) -> CuResult<()>;
+    /// End capture; returns the raw `cudaGraph_t`.
+    fn stream_end_capture(&mut self, stream: u64) -> CuResult<u64>;
+    /// `(capture_status, capture_id)` for `stream`.
+    fn stream_capture_info(&mut self, stream: u64) -> CuResult<(u64, u64)>;
+    /// Instantiate a captured graph; returns the raw `cudaGraphExec_t`.
+    fn graph_instantiate(&mut self, graph: u64) -> CuResult<u64>;
+    /// Replay an instantiated graph on `stream`.
+    fn graph_launch(&mut self, graph_exec: u64, stream: u64) -> CuResult<()>;
+    fn graph_exec_destroy(&mut self, graph_exec: u64) -> CuResult<()>;
+    fn graph_destroy(&mut self, graph: u64) -> CuResult<()>;
+    /// Number of nodes in a captured graph (PyTorch warns on empty graphs).
+    fn graph_get_node_count(&mut self, graph: u64) -> CuResult<u64>;
+    /// Stream-ordered memset (capture-safe; the sync form would invalidate an
+    /// active capture).
+    fn memset_d8_async(&mut self, dptr: u64, value: u8, bytes: u64, stream: u64) -> CuResult<()>;
+    /// Stream-ordered device-to-device copy (capture-safe).
+    fn memcpy_dtod_async(&mut self, dst: u64, src: u64, bytes: u64, stream: u64) -> CuResult<()>;
     fn stream_destroy(&mut self, stream: u64) -> CuResult<()>;
     fn stream_synchronize(&mut self, stream: u64) -> CuResult<()>;
     fn event_create(&mut self, flags: u32) -> CuResult<u64>;
@@ -182,7 +203,13 @@ pub fn serve<S: Read + Write>(mut stream: S, backend: &mut dyn Backend) -> std::
             // Quiet wrapper: execute the inner request, reply with nothing.
             Some(&crate::proto::QUIET_PREFIX) => {
                 let req = decode_request(&payload[1..])?;
+                if std::env::var_os("SMOLVM_CUDA_HOST_OPLOG").is_some() {
+                    eprintln!("[op~] 0x{:02x} len={}", payload[1], payload.len());
+                }
                 let (status, _) = dispatch(&mut sess, backend, req);
+                if status != 0 && std::env::var_os("SMOLVM_CUDA_HOST_OPLOG").is_some() {
+                    eprintln!("[op~!] status={status}");
+                }
                 if status != 0 && quiet_sticky == 0 {
                     quiet_sticky = status;
                 }
@@ -194,7 +221,13 @@ pub fn serve<S: Read + Write>(mut stream: S, backend: &mut dyn Backend) -> std::
             }
             _ => {
                 let req = decode_request(&payload)?;
+                if std::env::var_os("SMOLVM_CUDA_HOST_OPLOG").is_some() {
+                    eprintln!("[op] 0x{:02x} len={}", payload[0], payload.len());
+                }
                 let (status, resp) = dispatch(&mut sess, backend, req);
+                if status != 0 && std::env::var_os("SMOLVM_CUDA_HOST_OPLOG").is_some() {
+                    eprintln!("[op!] status={status}");
+                }
                 let out = encode_response(status, &resp);
                 write_msg(&mut stream, &out)?;
             }
@@ -311,6 +344,49 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             let id = sess.mint();
             sess.streams.insert(id, raw);
             Ok(Response::Handle(id))
+        }
+        Request::StreamBeginCapture { stream, mode } => {
+            let raw = raw_stream(sess, stream)?;
+            b.stream_begin_capture(raw, mode).map(|_| Response::Ok)
+        }
+        Request::StreamEndCapture { stream } => {
+            let raw = raw_stream(sess, stream)?;
+            b.stream_end_capture(raw).map(Response::Handle)
+        }
+        Request::StreamCaptureInfo { stream } => {
+            let raw = raw_stream(sess, stream)?;
+            b.stream_capture_info(raw)
+                .map(|(st, id)| Response::Pair(st, id))
+        }
+        Request::GraphInstantiate { graph } => b.graph_instantiate(graph).map(Response::Handle),
+        Request::GraphLaunch { graph_exec, stream } => {
+            let raw = raw_stream(sess, stream)?;
+            b.graph_launch(graph_exec, raw).map(|_| Response::Ok)
+        }
+        Request::GraphExecDestroy { graph_exec } => {
+            b.graph_exec_destroy(graph_exec).map(|_| Response::Ok)
+        }
+        Request::GraphDestroy { graph } => b.graph_destroy(graph).map(|_| Response::Ok),
+        Request::GraphGetNodes { graph } => b.graph_get_node_count(graph).map(Response::Bytes),
+        Request::MemsetD8Async {
+            dptr,
+            value,
+            bytes,
+            stream,
+        } => {
+            let raw = raw_stream(sess, stream)?;
+            b.memset_d8_async(dptr, value, bytes, raw)
+                .map(|_| Response::Ok)
+        }
+        Request::MemcpyDtoDAsync {
+            dst,
+            src,
+            bytes,
+            stream,
+        } => {
+            let raw = raw_stream(sess, stream)?;
+            b.memcpy_dtod_async(dst, src, bytes, raw)
+                .map(|_| Response::Ok)
         }
         Request::StreamDestroy { stream } => {
             let raw = raw(&sess.streams, stream)?;
@@ -671,6 +747,36 @@ impl Backend for CpuBackend {
     // synchronously, so create/destroy mint handles and the rest are no-ops.
     fn stream_create(&mut self, _flags: u32) -> CuResult<u64> {
         Ok(self.handle())
+    }
+    fn stream_begin_capture(&mut self, _stream: u64, _mode: i32) -> CuResult<()> {
+        Err(CUDA_ERROR_NOT_SUPPORTED)
+    }
+    fn stream_end_capture(&mut self, _stream: u64) -> CuResult<u64> {
+        Err(CUDA_ERROR_NOT_SUPPORTED)
+    }
+    fn stream_capture_info(&mut self, _stream: u64) -> CuResult<(u64, u64)> {
+        Ok((0, 0)) // cudaStreamCaptureStatusNone
+    }
+    fn graph_instantiate(&mut self, _graph: u64) -> CuResult<u64> {
+        Err(CUDA_ERROR_NOT_SUPPORTED)
+    }
+    fn graph_launch(&mut self, _graph_exec: u64, _stream: u64) -> CuResult<()> {
+        Err(CUDA_ERROR_NOT_SUPPORTED)
+    }
+    fn graph_exec_destroy(&mut self, _graph_exec: u64) -> CuResult<()> {
+        Err(CUDA_ERROR_NOT_SUPPORTED)
+    }
+    fn graph_destroy(&mut self, _graph: u64) -> CuResult<()> {
+        Err(CUDA_ERROR_NOT_SUPPORTED)
+    }
+    fn graph_get_node_count(&mut self, _graph: u64) -> CuResult<u64> {
+        Err(CUDA_ERROR_NOT_SUPPORTED)
+    }
+    fn memset_d8_async(&mut self, dptr: u64, value: u8, bytes: u64, _stream: u64) -> CuResult<()> {
+        self.memset_d8(dptr, value, bytes)
+    }
+    fn memcpy_dtod_async(&mut self, dst: u64, src: u64, bytes: u64, _stream: u64) -> CuResult<()> {
+        self.memcpy_dtod(dst, src, bytes)
     }
     fn stream_destroy(&mut self, _stream: u64) -> CuResult<()> {
         Ok(())

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -703,14 +703,13 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             // Per-connection VRAM quota (SMOLVM_CUDA_VRAM_LIMIT_MB on the
             // host): a guest may not allocate past its budget — the CUDA-
             // native failure (out of memory) surfaces to the app.
-            static LIMIT: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
-            let limit = *LIMIT.get_or_init(|| {
-                std::env::var("SMOLVM_CUDA_VRAM_LIMIT_MB")
-                    .ok()
-                    .and_then(|v| v.parse::<u64>().ok())
-                    .map(|mb| mb * 1024 * 1024)
-                    .unwrap_or(u64::MAX)
-            });
+            // Read per call (allocations are rare): also keeps the limit
+            // adjustable and test-deterministic, unlike a process cache.
+            let limit = std::env::var("SMOLVM_CUDA_VRAM_LIMIT_MB")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .map(|mb| mb * 1024 * 1024)
+                .unwrap_or(u64::MAX);
             let used: u64 = sess.owned_dptrs.values().sum();
             if used.saturating_add(bytes) > limit {
                 return Err(2); // CUDA_ERROR_OUT_OF_MEMORY
@@ -1683,8 +1682,8 @@ mod tests {
         server.join().unwrap();
     }
     // A connection may not allocate past SMOLVM_CUDA_VRAM_LIMIT_MB; freeing
-    // returns budget. (Env is process-global — this test sets it before the
-    // OnceLock is first read; fine while it's the only quota test.)
+    // returns budget. (Env is process-global; restored at the end so
+    // parallel tests never see the 1 MB cap on their own allocations.)
     #[test]
     fn vram_quota_enforced() {
         std::env::set_var("SMOLVM_CUDA_VRAM_LIMIT_MB", "1");
@@ -1707,5 +1706,6 @@ mod tests {
         assert_eq!(st, 0);
         let (st, _) = dispatch(&mut sess, &mut b, Request::MemAlloc { bytes: mb / 4 });
         assert_eq!(st, 0);
+        std::env::remove_var("SMOLVM_CUDA_VRAM_LIMIT_MB");
     }
 }

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -48,8 +48,13 @@ pub trait Backend: Send {
     fn func_set_attribute(&mut self, function: u64, attrib: i32, value: i32) -> CuResult<()>;
     fn mem_alloc(&mut self, bytes: u64) -> CuResult<u64>;
     fn mem_free(&mut self, dptr: u64) -> CuResult<()>;
-    fn memcpy_htod(&mut self, dptr: u64, data: &[u8]) -> CuResult<()>;
-    fn memcpy_dtoh(&mut self, dptr: u64, bytes: u64) -> CuResult<Vec<u8>>;
+    /// Copy with stream ordering: prior work on `stream` (0 = legacy default)
+    /// must complete first. Torch's pool streams are created non-blocking, so
+    /// a NULL-stream copy does NOT order against them — dropping `stream`
+    /// makes a `cudaMemcpyAsync` overwrite buffers still-running kernels read.
+    fn memcpy_htod(&mut self, dptr: u64, data: &[u8], stream: u64) -> CuResult<()>;
+    /// See `memcpy_htod` for the `stream` contract.
+    fn memcpy_dtoh(&mut self, dptr: u64, bytes: u64, stream: u64) -> CuResult<Vec<u8>>;
     fn memcpy_dtod(&mut self, dst: u64, src: u64, bytes: u64) -> CuResult<()>;
     fn memset_d8(&mut self, dptr: u64, value: u8, bytes: u64) -> CuResult<()>;
     fn mem_get_info(&mut self) -> CuResult<(u64, u64)>;
@@ -168,11 +173,23 @@ pub trait Backend: Send {
 
     /// Zero-copy H2D: DMA `size` bytes from shared-region `offset` to `dptr`.
     /// Default: no shared region → caller must fall back to byte-shipping.
-    fn memcpy_shm_htod(&mut self, _dptr: u64, _offset: u64, _size: u64) -> CuResult<()> {
+    fn memcpy_shm_htod(
+        &mut self,
+        _dptr: u64,
+        _offset: u64,
+        _size: u64,
+        _stream: u64,
+    ) -> CuResult<()> {
         Err(CUDA_ERROR_NOT_FOUND)
     }
     /// Zero-copy D2H: DMA `size` bytes from `dptr` to shared-region `offset`.
-    fn memcpy_shm_dtoh(&mut self, _offset: u64, _dptr: u64, _size: u64) -> CuResult<()> {
+    fn memcpy_shm_dtoh(
+        &mut self,
+        _offset: u64,
+        _dptr: u64,
+        _size: u64,
+        _stream: u64,
+    ) -> CuResult<()> {
         Err(CUDA_ERROR_NOT_FOUND)
     }
 
@@ -181,11 +198,21 @@ pub trait Backend: Send {
     /// by the embedder. Guest RAM is usually split around the 4 GiB PCI hole.
     fn set_guest_ram(&mut self, _regions: Vec<(u64, u64, u64)>) {}
     /// Zero-copy H2D from guest RAM: gather `segments` and DMA to `dptr`.
-    fn memcpy_gpa_htod(&mut self, _dptr: u64, _segments: &[(u64, u64)]) -> CuResult<()> {
+    fn memcpy_gpa_htod(
+        &mut self,
+        _dptr: u64,
+        _segments: &[(u64, u64)],
+        _stream: u64,
+    ) -> CuResult<()> {
         Err(CUDA_ERROR_NOT_FOUND)
     }
     /// Zero-copy D2H to guest RAM: DMA from `dptr` and scatter into `segments`.
-    fn memcpy_gpa_dtoh(&mut self, _dptr: u64, _segments: &[(u64, u64)]) -> CuResult<()> {
+    fn memcpy_gpa_dtoh(
+        &mut self,
+        _dptr: u64,
+        _segments: &[(u64, u64)],
+        _stream: u64,
+    ) -> CuResult<()> {
         Err(CUDA_ERROR_NOT_FOUND)
     }
 }
@@ -349,8 +376,16 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         }
         Request::MemAlloc { bytes } => b.mem_alloc(bytes).map(Response::Dptr),
         Request::MemFree { dptr } => b.mem_free(dptr).map(|_| Response::Ok),
-        Request::MemcpyHtoD { dptr, data } => b.memcpy_htod(dptr, &data).map(|_| Response::Ok),
-        Request::MemcpyDtoH { dptr, bytes } => b.memcpy_dtoh(dptr, bytes).map(Response::Data),
+        Request::MemcpyHtoD { dptr, stream, data } => b
+            .memcpy_htod(dptr, &data, raw_stream(sess, stream)?)
+            .map(|_| Response::Ok),
+        Request::MemcpyDtoH {
+            dptr,
+            bytes,
+            stream,
+        } => b
+            .memcpy_dtoh(dptr, bytes, raw_stream(sess, stream)?)
+            .map(Response::Data),
         Request::MemcpyDtoD { dst, src, bytes } => {
             b.memcpy_dtod(dst, src, bytes).map(|_| Response::Ok)
         }
@@ -572,18 +607,36 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         Request::LibCall { lib, func, args } => b
             .lib_call(lib, func, &args, &sess.streams)
             .map(|(status, out)| Response::LibResult(status, out)),
-        Request::MemcpyShmHtoD { dptr, offset, size } => {
-            b.memcpy_shm_htod(dptr, offset, size).map(|_| Response::Ok)
-        }
-        Request::MemcpyShmDtoH { offset, dptr, size } => {
-            b.memcpy_shm_dtoh(offset, dptr, size).map(|_| Response::Ok)
-        }
-        Request::MemcpyGpaHtoD { dptr, segments } => {
-            b.memcpy_gpa_htod(dptr, &segments).map(|_| Response::Ok)
-        }
-        Request::MemcpyGpaDtoH { dptr, segments } => {
-            b.memcpy_gpa_dtoh(dptr, &segments).map(|_| Response::Ok)
-        }
+        Request::MemcpyShmHtoD {
+            dptr,
+            offset,
+            size,
+            stream,
+        } => b
+            .memcpy_shm_htod(dptr, offset, size, raw_stream(sess, stream)?)
+            .map(|_| Response::Ok),
+        Request::MemcpyShmDtoH {
+            offset,
+            dptr,
+            size,
+            stream,
+        } => b
+            .memcpy_shm_dtoh(offset, dptr, size, raw_stream(sess, stream)?)
+            .map(|_| Response::Ok),
+        Request::MemcpyGpaHtoD {
+            dptr,
+            stream,
+            segments,
+        } => b
+            .memcpy_gpa_htod(dptr, &segments, raw_stream(sess, stream)?)
+            .map(|_| Response::Ok),
+        Request::MemcpyGpaDtoH {
+            dptr,
+            stream,
+            segments,
+        } => b
+            .memcpy_gpa_dtoh(dptr, &segments, raw_stream(sess, stream)?)
+            .map(|_| Response::Ok),
     })();
     match r {
         Ok(resp) => (0, resp),
@@ -717,7 +770,7 @@ impl Backend for CpuBackend {
             .map(|_| ())
             .ok_or(CUDA_ERROR_INVALID_HANDLE)
     }
-    fn memcpy_htod(&mut self, dptr: u64, data: &[u8]) -> CuResult<()> {
+    fn memcpy_htod(&mut self, dptr: u64, data: &[u8], _stream: u64) -> CuResult<()> {
         let buf = self.mem.get_mut(&dptr).ok_or(CUDA_ERROR_INVALID_HANDLE)?;
         if data.len() > buf.len() {
             return Err(CUDA_ERROR_INVALID_HANDLE);
@@ -725,7 +778,7 @@ impl Backend for CpuBackend {
         buf[..data.len()].copy_from_slice(data);
         Ok(())
     }
-    fn memcpy_dtoh(&mut self, dptr: u64, bytes: u64) -> CuResult<Vec<u8>> {
+    fn memcpy_dtoh(&mut self, dptr: u64, bytes: u64, _stream: u64) -> CuResult<Vec<u8>> {
         let buf = self.mem.get(&dptr).ok_or(CUDA_ERROR_INVALID_HANDLE)?;
         let n = bytes as usize;
         if n > buf.len() {
@@ -970,11 +1023,23 @@ mod tests {
             .iter()
             .flat_map(|v| v.to_le_bytes())
             .collect();
-        dispatch(&mut sess, &mut b, Request::MemcpyHtoD { dptr: da, data: a });
         dispatch(
             &mut sess,
             &mut b,
-            Request::MemcpyHtoD { dptr: db, data: bb },
+            Request::MemcpyHtoD {
+                dptr: da,
+                stream: 0,
+                data: a,
+            },
+        );
+        dispatch(
+            &mut sess,
+            &mut b,
+            Request::MemcpyHtoD {
+                dptr: db,
+                stream: 0,
+                data: bb,
+            },
         );
         let params = vec![
             da.to_le_bytes().to_vec(),
@@ -1001,6 +1066,7 @@ mod tests {
             Request::MemcpyDtoH {
                 dptr: dc,
                 bytes: 16,
+                stream: 0,
             },
         )
         .1
@@ -1111,8 +1177,8 @@ mod tests {
         let bb: Vec<u8> = (0..n)
             .flat_map(|i| ((2 * i) as f32).to_le_bytes())
             .collect();
-        cli.memcpy_htod(da, &a).unwrap();
-        cli.memcpy_htod(db, &bb).unwrap();
+        cli.memcpy_htod(da, &a, 0).unwrap();
+        cli.memcpy_htod(db, &bb, 0).unwrap();
         cli.launch_kernel(
             func,
             [1, 1, 1],
@@ -1128,7 +1194,7 @@ mod tests {
         )
         .unwrap();
         cli.ctx_synchronize().unwrap();
-        let out = cli.memcpy_dtoh(dc, (n * 4) as u64).unwrap();
+        let out = cli.memcpy_dtoh(dc, (n * 4) as u64, 0).unwrap();
         let c: Vec<f32> = out
             .chunks(4)
             .map(|p| f32::from_le_bytes(p.try_into().unwrap()))

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -172,11 +172,33 @@ impl Session {
 /// request is dispatched to `backend`; returns on clean EOF.
 pub fn serve<S: Read + Write>(mut stream: S, backend: &mut dyn Backend) -> std::io::Result<()> {
     let mut sess = Session::default();
+    // First failure among quiet (fire-and-forget) requests since the last
+    // fence. Quiet requests get no response at all — the client collects
+    // failures with one Fence round-trip instead of reading N per-op replies,
+    // which on vsock cost a guest wake-up each.
+    let mut quiet_sticky: i32 = 0;
     while let Some(payload) = read_msg(&mut stream)? {
-        let req = decode_request(&payload)?;
-        let (status, resp) = dispatch(&mut sess, backend, req);
-        let out = encode_response(status, &resp);
-        write_msg(&mut stream, &out)?;
+        match payload.first() {
+            // Quiet wrapper: execute the inner request, reply with nothing.
+            Some(&crate::proto::QUIET_PREFIX) => {
+                let req = decode_request(&payload[1..])?;
+                let (status, _) = dispatch(&mut sess, backend, req);
+                if status != 0 && quiet_sticky == 0 {
+                    quiet_sticky = status;
+                }
+            }
+            // Fence: report (and clear) the sticky quiet failure.
+            Some(&crate::proto::FENCE_OP) if payload.len() == 1 => {
+                let st = std::mem::take(&mut quiet_sticky);
+                write_msg(&mut stream, &encode_response(st, &Response::Ok))?;
+            }
+            _ => {
+                let req = decode_request(&payload)?;
+                let (status, resp) = dispatch(&mut sess, backend, req);
+                let out = encode_response(status, &resp);
+                write_msg(&mut stream, &out)?;
+            }
+        }
     }
     Ok(())
 }

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -221,6 +221,31 @@ pub trait Backend: Send {
     fn gpa_to_hva(&mut self, _gpa: u64, _len: u64) -> Option<u64> {
         None
     }
+    // VMM (torch expandable-segments allocator). Defaults: unsupported.
+    fn mem_address_reserve(&mut self, _size: u64, _align: u64) -> CuResult<u64> {
+        Err(CUDA_ERROR_NOT_SUPPORTED)
+    }
+    fn mem_create(&mut self, _size: u64, _device: i32) -> CuResult<u64> {
+        Err(CUDA_ERROR_NOT_SUPPORTED)
+    }
+    fn mem_map(&mut self, _va: u64, _size: u64, _offset: u64, _handle: u64) -> CuResult<()> {
+        Err(CUDA_ERROR_NOT_SUPPORTED)
+    }
+    fn mem_set_access(&mut self, _va: u64, _size: u64, _device: i32) -> CuResult<()> {
+        Err(CUDA_ERROR_NOT_SUPPORTED)
+    }
+    fn mem_unmap(&mut self, _va: u64, _size: u64) -> CuResult<()> {
+        Err(CUDA_ERROR_NOT_SUPPORTED)
+    }
+    fn mem_release(&mut self, _handle: u64) -> CuResult<()> {
+        Err(CUDA_ERROR_NOT_SUPPORTED)
+    }
+    fn mem_address_free(&mut self, _va: u64, _size: u64) -> CuResult<()> {
+        Err(CUDA_ERROR_NOT_SUPPORTED)
+    }
+    fn mem_get_allocation_granularity(&mut self, _device: i32, _flags: u32) -> CuResult<u64> {
+        Err(CUDA_ERROR_NOT_SUPPORTED)
+    }
 }
 
 /// Per-connection opaque→raw handle translation. Ids are dense and monotonic so
@@ -239,6 +264,11 @@ struct Session {
     /// allocations are the multi-GB hazard; modules/streams/events are
     /// hygiene). Raw backend handles.
     owned_dptrs: HashMap<u64, u64>, // dptr → size (also the quota ledger)
+    /// VMM state for reclaim: physical handles → size (quota ledger too),
+    /// live mappings (va → size), and address reservations (va → size).
+    owned_vmm_handles: HashMap<u64, u64>,
+    owned_vmm_maps: HashMap<u64, u64>,
+    owned_vmm_reservations: HashMap<u64, u64>,
     owned_modules: std::collections::HashSet<u64>,
     owned_streams: std::collections::HashSet<u64>,
     owned_events: std::collections::HashSet<u64>,
@@ -250,6 +280,16 @@ struct Session {
 fn reclaim_session(sess: &mut Session, b: &mut dyn Backend) {
     for (d, _size) in std::mem::take(&mut sess.owned_dptrs) {
         let _ = b.mem_free(d);
+    }
+    // VMM teardown order: unmap, release physical, free reservations.
+    for (va, size) in std::mem::take(&mut sess.owned_vmm_maps) {
+        let _ = b.mem_unmap(va, size);
+    }
+    for (h, _size) in std::mem::take(&mut sess.owned_vmm_handles) {
+        let _ = b.mem_release(h);
+    }
+    for (va, size) in std::mem::take(&mut sess.owned_vmm_reservations) {
+        let _ = b.mem_address_free(va, size);
     }
     for m in std::mem::take(&mut sess.owned_modules) {
         let _ = b.module_unload(m);
@@ -605,6 +645,17 @@ fn serve_rings<S: Read + Write>(
     }
 }
 
+/// Per-connection VRAM budget (`SMOLVM_CUDA_VRAM_LIMIT_MB`), read per
+/// allocation: rare calls, and staying uncached keeps it adjustable and
+/// test-deterministic.
+fn vram_limit() -> u64 {
+    std::env::var("SMOLVM_CUDA_VRAM_LIMIT_MB")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(|mb| mb * 1024 * 1024)
+        .unwrap_or(u64::MAX)
+}
+
 fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Response) {
     // Translate an opaque id to the backend's raw handle, or error.
     fn raw(map: &HashMap<u64, u64>, id: u64) -> CuResult<u64> {
@@ -703,14 +754,9 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             // Per-connection VRAM quota (SMOLVM_CUDA_VRAM_LIMIT_MB on the
             // host): a guest may not allocate past its budget — the CUDA-
             // native failure (out of memory) surfaces to the app.
-            // Read per call (allocations are rare): also keeps the limit
-            // adjustable and test-deterministic, unlike a process cache.
-            let limit = std::env::var("SMOLVM_CUDA_VRAM_LIMIT_MB")
-                .ok()
-                .and_then(|v| v.parse::<u64>().ok())
-                .map(|mb| mb * 1024 * 1024)
-                .unwrap_or(u64::MAX);
-            let used: u64 = sess.owned_dptrs.values().sum();
+            let limit = vram_limit();
+            let used: u64 = sess.owned_dptrs.values().sum::<u64>()
+                + sess.owned_vmm_handles.values().sum::<u64>();
             if used.saturating_add(bytes) > limit {
                 return Err(2); // CUDA_ERROR_OUT_OF_MEMORY
             }
@@ -996,6 +1042,51 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         // Handled by the serve loop (transport concern, not a backend op);
         // reaching dispatch means the transport doesn't support rings.
         Request::RingSetup { .. } => Err(CUDA_ERROR_NOT_SUPPORTED),
+        Request::MemAddressReserve { size, align } => {
+            b.mem_address_reserve(size, align).map(|va| {
+                sess.owned_vmm_reservations.insert(va, size);
+                Response::Dptr(va)
+            })
+        }
+        Request::MemCreate { size, device } => {
+            let limit = vram_limit();
+            let used: u64 = sess.owned_dptrs.values().sum::<u64>()
+                + sess.owned_vmm_handles.values().sum::<u64>();
+            if used.saturating_add(size) > limit {
+                return Err(2); // CUDA_ERROR_OUT_OF_MEMORY
+            }
+            b.mem_create(size, device).map(|h| {
+                sess.owned_vmm_handles.insert(h, size);
+                Response::Handle(h)
+            })
+        }
+        Request::MemMap {
+            va,
+            size,
+            offset,
+            handle,
+        } => b.mem_map(va, size, offset, handle).map(|_| {
+            sess.owned_vmm_maps.insert(va, size);
+            Response::Ok
+        }),
+        Request::MemSetAccess { va, size, device } => {
+            b.mem_set_access(va, size, device).map(|_| Response::Ok)
+        }
+        Request::MemUnmap { va, size } => {
+            sess.owned_vmm_maps.remove(&va);
+            b.mem_unmap(va, size).map(|_| Response::Ok)
+        }
+        Request::MemRelease { handle } => {
+            sess.owned_vmm_handles.remove(&handle);
+            b.mem_release(handle).map(|_| Response::Ok)
+        }
+        Request::MemAddressFree { va, size } => {
+            sess.owned_vmm_reservations.remove(&va);
+            b.mem_address_free(va, size).map(|_| Response::Ok)
+        }
+        Request::MemGetAllocationGranularity { device, flags } => b
+            .mem_get_allocation_granularity(device, flags)
+            .map(Response::Bytes),
     })();
     match r {
         Ok(resp) => (0, resp),

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -215,6 +215,12 @@ pub trait Backend: Send {
     ) -> CuResult<()> {
         Err(CUDA_ERROR_NOT_FOUND)
     }
+    /// Host virtual address of `len` bytes at guest-physical `gpa`, when the
+    /// embedder mapped guest RAM (in-VM only). Rings need long-lived page
+    /// mappings, unlike the per-call `memcpy_gpa_*` segment reads.
+    fn gpa_to_hva(&mut self, _gpa: u64, _len: u64) -> Option<u64> {
+        None
+    }
 }
 
 /// Per-connection opaque→raw handle translation. Ids are dense and monotonic so
@@ -272,6 +278,28 @@ pub fn serve<S: Read + Write>(mut stream: S, backend: &mut dyn Backend) -> std::
                 if std::env::var_os("SMOLVM_CUDA_HOST_OPLOG").is_some() {
                     eprintln!("[op] 0x{:02x} len={}", payload[0], payload.len());
                 }
+                // Transport upgrade: switch this connection to shared-memory
+                // rings and never return to socket framing (the socket then
+                // carries only doorbell bytes).
+                if let Request::RingSetup {
+                    page_size,
+                    req_pages,
+                    resp_pages,
+                    bounce_pages,
+                } = req
+                {
+                    match HostRings::map(backend, page_size, &req_pages, &resp_pages, &bounce_pages)
+                    {
+                        Ok(rings) => {
+                            write_msg(&mut stream, &encode_response(0, &Response::Ok))?;
+                            return serve_rings(stream, backend, sess, quiet_sticky, rings);
+                        }
+                        Err(code) => {
+                            write_msg(&mut stream, &encode_response(code, &Response::Ok))?;
+                            continue;
+                        }
+                    }
+                }
                 let (status, resp) = dispatch(&mut sess, backend, req);
                 if status != 0 && std::env::var_os("SMOLVM_CUDA_HOST_OPLOG").is_some() {
                     eprintln!("[op!] status={status}");
@@ -282,6 +310,257 @@ pub fn serve<S: Read + Write>(mut stream: S, backend: &mut dyn Backend) -> std::
         }
     }
     Ok(())
+}
+
+/// Host mappings of the guest's rings + bounce buffer.
+struct HostRings {
+    req: crate::ring::Ring,
+    resp: crate::ring::Ring,
+    /// Bounce pages (host VAs) for responses too large for an inline record.
+    bounce: Vec<*mut u8>,
+    page_size: usize,
+}
+
+impl HostRings {
+    fn map(
+        backend: &mut dyn Backend,
+        page_size: u32,
+        req_pages: &[u64],
+        resp_pages: &[u64],
+        bounce_pages: &[u64],
+    ) -> Result<HostRings, i32> {
+        let ps = page_size as usize;
+        if ps < crate::ring::HEADER_SIZE + crate::ring::RECORD_SIZE
+            || req_pages.is_empty()
+            || resp_pages.is_empty()
+        {
+            return Err(1); // CUDA_ERROR_INVALID_VALUE
+        }
+        let mut map_all = |gpas: &[u64]| -> Result<Vec<*mut u8>, i32> {
+            gpas.iter()
+                .map(|&gpa| {
+                    backend
+                        .gpa_to_hva(gpa, page_size as u64)
+                        .map(|hva| hva as *mut u8)
+                        .ok_or(CUDA_ERROR_NOT_SUPPORTED)
+                })
+                .collect()
+        };
+        let req = map_all(req_pages)?;
+        let resp = map_all(resp_pages)?;
+        let bounce = map_all(bounce_pages)?;
+        // SAFETY: pages are backed by mapped guest RAM for the VM's lifetime.
+        Ok(HostRings {
+            req: unsafe { crate::ring::Ring::from_pages(req, ps) },
+            resp: unsafe { crate::ring::Ring::from_pages(resp, ps) },
+            bounce,
+            page_size: ps,
+        })
+    }
+
+    /// Copy an oversized response into the bounce buffer. Returns false when
+    /// it doesn't fit (protocol error surfaced to the guest as a status).
+    fn write_bounce(&self, bytes: &[u8]) -> bool {
+        if bytes.len() > self.bounce.len() * self.page_size {
+            return false;
+        }
+        for (i, chunk) in bytes.chunks(self.page_size).enumerate() {
+            // SAFETY: chunk fits within bounce page i (checked above).
+            unsafe {
+                std::ptr::copy_nonoverlapping(chunk.as_ptr(), self.bounce[i], chunk.len());
+            }
+        }
+        true
+    }
+}
+
+/// Ring-mode serve loop: requests pop from the guest's request ring,
+/// responses push to the completion ring; the socket carries doorbells only.
+fn serve_rings<S: Read + Write>(
+    mut stream: S,
+    backend: &mut dyn Backend,
+    mut sess: Session,
+    mut quiet_sticky: i32,
+    rings: HostRings,
+) -> std::io::Result<()> {
+    use crate::ring::LEN_INDIRECT;
+    let oplog = std::env::var_os("SMOLVM_CUDA_HOST_OPLOG").is_some();
+    // Reassembly buffer for oversized frames arriving as bounce chunks.
+    let mut pending: Vec<u8> = Vec::new();
+    // Push one response. Oversized ones chunk through the bounce pages: the
+    // guest posts a continue record (16×0xFF, LEN_INDIRECT) on the request
+    // ring after copying each non-final chunk out — unambiguous because a
+    // blocked guest can't send anything else. Doorbell on park either way.
+    fn respond<S: Read + Write>(
+        rings: &HostRings,
+        stream: &mut S,
+        bytes: &[u8],
+    ) -> std::io::Result<()> {
+        let kick = |stream: &mut S| -> std::io::Result<()> {
+            if rings_take_parked(rings) {
+                stream.write_all(&[1u8])?;
+                stream.flush()?;
+            }
+            Ok(())
+        };
+        fn rings_take_parked(rings: &HostRings) -> bool {
+            rings.resp.take_parked()
+        }
+        if bytes.len() <= crate::ring::INLINE_MAX {
+            while !rings.resp.try_push(bytes, 0) {
+                std::hint::spin_loop(); // guest drains sync responses promptly
+            }
+            return kick(stream);
+        }
+        let cap = rings.bounce.len() * rings.page_size;
+        let total = bytes.len();
+        let mut off = 0;
+        while off < total {
+            let chunk = (total - off).min(cap);
+            if !rings.write_bounce(&bytes[off..off + chunk]) {
+                return Err(std::io::Error::other("ring: bounce write failed"));
+            }
+            let mut hdr = [0u8; 16];
+            hdr[..8].copy_from_slice(&(total as u64).to_le_bytes());
+            hdr[8..].copy_from_slice(&(chunk as u64).to_le_bytes());
+            while !rings.resp.try_push(&hdr, LEN_INDIRECT) {
+                std::hint::spin_loop();
+            }
+            kick(stream)?;
+            off += chunk;
+            if off < total {
+                // Await the guest's continue record before refilling.
+                loop {
+                    if let Some((p, f)) = rings.req.try_pop() {
+                        if f & LEN_INDIRECT != 0 && p == [0xFF; 16] {
+                            break;
+                        }
+                        return Err(std::io::Error::other("ring: expected continue"));
+                    }
+                    std::hint::spin_loop();
+                }
+            }
+        }
+        Ok(())
+    }
+    loop {
+        let (payload, flags) = match rings.req.try_pop() {
+            Some(rec) => rec,
+            None => {
+                // Adaptive wait: spin briefly, then park and block on a
+                // doorbell byte from the guest.
+                let mut found = None;
+                for _ in 0..20_000 {
+                    if let Some(rec) = rings.req.try_pop() {
+                        found = Some(rec);
+                        break;
+                    }
+                    std::hint::spin_loop();
+                }
+                match found {
+                    Some(rec) => rec,
+                    None => {
+                        if !rings.req.park() {
+                            let mut byte = [0u8; 1];
+                            match stream.read(&mut byte) {
+                                Ok(0) => return Ok(()), // guest closed
+                                Ok(_) => {}
+                                Err(e) => return Err(e),
+                            }
+                            rings.req.unpark();
+                        }
+                        continue;
+                    }
+                }
+            }
+        };
+        // Oversized frame: chunks arrive through the bounce pages. Every
+        // non-final chunk is acked (so the guest can refill the pages); the
+        // final chunk completes the frame, which dispatches below and whose
+        // own response closes the exchange.
+        let frame: Vec<u8> = if flags & LEN_INDIRECT != 0 {
+            if payload.len() < 16 {
+                return Err(std::io::Error::other("ring: short chunk record"));
+            }
+            let total = u64::from_le_bytes(payload[..8].try_into().unwrap()) as usize;
+            let chunk = u64::from_le_bytes(payload[8..16].try_into().unwrap()) as usize;
+            if total > crate::proto::MAX_MSG || chunk > rings.bounce.len() * rings.page_size {
+                return Err(std::io::Error::other("ring: oversized chunk"));
+            }
+            let mut left = chunk;
+            for &page in &rings.bounce {
+                if left == 0 {
+                    break;
+                }
+                let take = left.min(rings.page_size);
+                // SAFETY: bounce pages are mapped guest RAM.
+                unsafe {
+                    pending.extend_from_slice(std::slice::from_raw_parts(page, take));
+                }
+                left -= take;
+            }
+            if pending.len() < total {
+                // Ack the chunk so the guest may refill the bounce pages.
+                respond(&rings, &mut stream, &encode_response(0, &Response::Ok))?;
+                continue;
+            }
+            std::mem::take(&mut pending)
+        } else {
+            payload
+        };
+        match frame.first() {
+            Some(&crate::proto::QUIET_PREFIX) => {
+                let req = match decode_request(&frame[1..]) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        eprintln!(
+                            "[ring-dbg] malformed QUIET frame len={} head={:02x?}",
+                            frame.len(),
+                            &frame[..frame.len().min(12)]
+                        );
+                        return Err(e);
+                    }
+                };
+                if oplog {
+                    eprintln!("[op~] 0x{:02x} len={}", frame[1], frame.len());
+                }
+                let (status, _) = dispatch(&mut sess, backend, req);
+                if status != 0 {
+                    if oplog {
+                        eprintln!("[op~!] status={status}");
+                    }
+                    if quiet_sticky == 0 {
+                        quiet_sticky = status;
+                    }
+                }
+            }
+            Some(&crate::proto::FENCE_OP) if frame.len() == 1 => {
+                let st = std::mem::take(&mut quiet_sticky);
+                respond(&rings, &mut stream, &encode_response(st, &Response::Ok))?;
+            }
+            _ => {
+                let req = match decode_request(&frame) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        eprintln!(
+                            "[ring-dbg] malformed frame len={} head={:02x?}",
+                            frame.len(),
+                            &frame[..frame.len().min(12)]
+                        );
+                        return Err(e);
+                    }
+                };
+                if oplog {
+                    eprintln!("[op] 0x{:02x} len={}", frame[0], frame.len());
+                }
+                let (status, resp) = dispatch(&mut sess, backend, req);
+                if status != 0 && oplog {
+                    eprintln!("[op!] status={status}");
+                }
+                respond(&rings, &mut stream, &encode_response(status, &resp))?;
+            }
+        }
+    }
 }
 
 fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Response) {
@@ -637,6 +916,9 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         } => b
             .memcpy_gpa_dtoh(dptr, &segments, raw_stream(sess, stream)?)
             .map(|_| Response::Ok),
+        // Handled by the serve loop (transport concern, not a backend op);
+        // reaching dispatch means the transport doesn't support rings.
+        Request::RingSetup { .. } => Err(CUDA_ERROR_NOT_SUPPORTED),
     })();
     match r {
         Ok(resp) => (0, resp),
@@ -657,6 +939,9 @@ pub struct CpuBackend {
     mem: HashMap<u64, Vec<u8>>,
     fn_names: HashMap<u64, String>,
     next_handle: u64,
+    /// Guest-RAM mappings, same shape as the GPU backend's — lets the ring
+    /// transport (and its tests) run without a GPU.
+    guest_ram: Vec<(u64, u64, u64)>,
 }
 
 impl Default for CpuBackend {
@@ -666,6 +951,7 @@ impl Default for CpuBackend {
             mem: HashMap::new(),
             fn_names: HashMap::new(),
             next_handle: 1,
+            guest_ram: Vec::new(),
         }
     }
 }
@@ -688,6 +974,14 @@ fn read_u32(p: &[u8]) -> Option<u32> {
 impl Backend for CpuBackend {
     fn init(&mut self) -> CuResult<()> {
         Ok(())
+    }
+    fn set_guest_ram(&mut self, regions: Vec<(u64, u64, u64)>) {
+        self.guest_ram = regions;
+    }
+    fn gpa_to_hva(&mut self, gpa: u64, len: u64) -> Option<u64> {
+        self.guest_ram.iter().find_map(|&(gs, hva, rlen)| {
+            (gpa >= gs && gpa.checked_add(len)? <= gs + rlen).then(|| hva + (gpa - gs))
+        })
     }
     fn device_get_count(&mut self) -> CuResult<i32> {
         Ok(1)
@@ -1202,6 +1496,112 @@ mod tests {
         let expect: Vec<f32> = (0..n).map(|i| (3 * i) as f32).collect();
         assert_eq!(c, expect);
         drop(cli); // closes client_side → server sees EOF
+        server.join().unwrap();
+    }
+    // Ring transport end-to-end: handshake over the socket, then requests
+    // (inline quiet, indirect oversized, fence) through shared memory with
+    // bounce-buffer responses — no GPU, no VM.
+    #[test]
+    fn ring_transport_end_to_end() {
+        use std::sync::atomic::AtomicUsize;
+        use std::sync::mpsc::{Receiver, Sender};
+        struct Chan {
+            tx: Sender<u8>,
+            rx: Receiver<u8>,
+        }
+        impl Write for Chan {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                for &x in buf {
+                    self.tx
+                        .send(x)
+                        .map_err(|_| std::io::ErrorKind::BrokenPipe)?;
+                }
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        impl Read for Chan {
+            fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+                if buf.is_empty() {
+                    return Ok(0);
+                }
+                match self.rx.recv() {
+                    Ok(b) => {
+                        buf[0] = b;
+                        Ok(1)
+                    }
+                    Err(_) => Ok(0), // EOF
+                }
+            }
+        }
+
+        // In-process fake guest RAM: identity-mapped (GPA == host VA), so
+        // any heap address — ring pages and indirect staging buffers alike —
+        // resolves. The aligned ring pages are leaked so both threads may
+        // hold pointers.
+        const PAGES: usize = 64;
+        const PAGE: usize = 4096;
+        let _ = AtomicUsize::new(0); // (kept import happy on older toolchains)
+        let layout = std::alloc::Layout::from_size_align(PAGES * PAGE, PAGE).unwrap();
+        // SAFETY: fresh allocation, zeroed, intentionally leaked.
+        let hva = unsafe {
+            let p = std::alloc::alloc_zeroed(layout);
+            assert!(!p.is_null());
+            p as usize
+        };
+
+        let (c2s_tx, c2s_rx) = std::sync::mpsc::channel();
+        let (s2c_tx, s2c_rx) = std::sync::mpsc::channel();
+        let server_side = Chan {
+            tx: s2c_tx,
+            rx: c2s_rx,
+        };
+        let client_side = Chan {
+            tx: c2s_tx,
+            rx: s2c_rx,
+        };
+        let server = std::thread::spawn(move || {
+            let mut b = CpuBackend::default();
+            b.set_guest_ram(vec![(0, 0, u64::MAX / 2)]); // identity: hva == gpa
+            let r = serve(server_side, &mut b);
+            eprintln!("[test] serve exited: {r:?}");
+        });
+
+        let mut cli = Client::new(client_side);
+        cli.init().unwrap();
+        let vas = |r: std::ops::Range<usize>| -> Vec<*mut u8> {
+            r.map(|i| (hva + i * PAGE) as *mut u8).collect()
+        };
+        let gpas = |r: std::ops::Range<usize>| -> Vec<u64> {
+            r.map(|i| (hva + i * PAGE) as u64).collect()
+        };
+        cli.ring_setup(
+            PAGE,
+            (vas(0..8), gpas(0..8)),
+            (vas(8..16), gpas(8..16)),
+            (vas(16..24), gpas(16..24)),
+        )
+        .unwrap();
+        assert!(cli.is_ring());
+
+        // Sync op over the ring (inline both ways).
+        assert_eq!(cli.device_get_count().unwrap(), 1);
+        let d = cli.mem_alloc(8192).unwrap();
+        // Deferred quiet op, inline record.
+        cli.memcpy_htod(d, &[9u8; 64], 0).unwrap();
+        // Fence over the ring settles it.
+        cli.drain().unwrap();
+        assert_eq!(cli.take_sticky(), 0);
+        // Oversized write: multi-chunk through the 32 KiB bounce staging.
+        let big: Vec<u8> = (0..100_000u32).map(|i| (i % 251) as u8).collect();
+        let d2 = cli.mem_alloc(big.len() as u64).unwrap();
+        cli.memcpy_htod(d2, &big, 0).unwrap();
+        // Oversized read: response spills through the same bounce pages.
+        let back = cli.memcpy_dtoh(d2, big.len() as u64, 0).unwrap();
+        assert_eq!(back, big);
+        drop(cli);
         server.join().unwrap();
     }
 }

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -44,6 +44,8 @@ pub trait Backend: Send {
     fn module_unload(&mut self, module: u64) -> CuResult<()>;
     /// Per-parameter byte sizes of the kernel's arguments, in declaration order.
     fn func_get_param_info(&mut self, function: u64) -> CuResult<Vec<u32>>;
+    /// Set a `CUfunction_attribute` (e.g. raise max dynamic shared memory).
+    fn func_set_attribute(&mut self, function: u64, attrib: i32, value: i32) -> CuResult<()>;
     fn mem_alloc(&mut self, bytes: u64) -> CuResult<u64>;
     fn mem_free(&mut self, dptr: u64) -> CuResult<()>;
     fn memcpy_htod(&mut self, dptr: u64, data: &[u8]) -> CuResult<()>;
@@ -313,6 +315,15 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
                 out.extend_from_slice(&s.to_le_bytes());
             }
             Ok(Response::Data(out))
+        }
+        Request::FuncSetAttribute {
+            function,
+            attrib,
+            value,
+        } => {
+            let raw_fn = raw(&sess.functions, function)?;
+            b.func_set_attribute(raw_fn, attrib, value)
+                .map(|_| Response::Ok)
         }
         Request::MemAlloc { bytes } => b.mem_alloc(bytes).map(Response::Dptr),
         Request::MemFree { dptr } => b.mem_free(dptr).map(|_| Response::Ok),
@@ -646,6 +657,10 @@ impl Backend for CpuBackend {
             "vecadd" => Ok(vec![8, 8, 8, 4]),
             _ => Err(CUDA_ERROR_NOT_FOUND),
         }
+    }
+    fn func_set_attribute(&mut self, _function: u64, _attrib: i32, _value: i32) -> CuResult<()> {
+        // CPU emulation has no shared-memory limits to raise.
+        Ok(())
     }
     fn mem_alloc(&mut self, bytes: u64) -> CuResult<u64> {
         let dptr = self.next_dptr;

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -234,6 +234,35 @@ struct Session {
     streams: HashMap<u64, u64>,
     events: HashMap<u64, u64>,
     cublas_handles: HashMap<u64, u64>,
+    /// Live resources this connection created, reclaimed when it ends —
+    /// a guest that dies mid-run must not leak GPU memory (device
+    /// allocations are the multi-GB hazard; modules/streams/events are
+    /// hygiene). Raw backend handles.
+    owned_dptrs: std::collections::HashSet<u64>,
+    owned_modules: std::collections::HashSet<u64>,
+    owned_streams: std::collections::HashSet<u64>,
+    owned_events: std::collections::HashSet<u64>,
+    primary_retains: u32,
+}
+
+/// Free everything a finished connection still owns. Failures are ignored —
+/// the driver may already have reclaimed (context destruction, device reset).
+fn reclaim_session(sess: &mut Session, b: &mut dyn Backend) {
+    for d in std::mem::take(&mut sess.owned_dptrs) {
+        let _ = b.mem_free(d);
+    }
+    for m in std::mem::take(&mut sess.owned_modules) {
+        let _ = b.module_unload(m);
+    }
+    for st in std::mem::take(&mut sess.owned_streams) {
+        let _ = b.stream_destroy(st);
+    }
+    for e in std::mem::take(&mut sess.owned_events) {
+        let _ = b.event_destroy(e);
+    }
+    for _ in 0..std::mem::take(&mut sess.primary_retains) {
+        let _ = b.primary_ctx_release(0);
+    }
 }
 
 impl Session {
@@ -245,8 +274,20 @@ impl Session {
 
 /// Serve one CUDA-RPC connection to completion (until the peer closes). Each
 /// request is dispatched to `backend`; returns on clean EOF.
-pub fn serve<S: Read + Write>(mut stream: S, backend: &mut dyn Backend) -> std::io::Result<()> {
+pub fn serve<S: Read + Write>(stream: S, backend: &mut dyn Backend) -> std::io::Result<()> {
     let mut sess = Session::default();
+    let r = serve_inner(stream, backend, &mut sess);
+    // The connection is over (guest exit, crash, or transport error): free
+    // everything it still owns so a dead client can't hold GPU memory.
+    reclaim_session(&mut sess, backend);
+    r
+}
+
+fn serve_inner<S: Read + Write>(
+    mut stream: S,
+    backend: &mut dyn Backend,
+    sess: &mut Session,
+) -> std::io::Result<()> {
     // First failure among quiet (fire-and-forget) requests since the last
     // fence. Quiet requests get no response at all — the client collects
     // failures with one Fence round-trip instead of reading N per-op replies,
@@ -260,7 +301,7 @@ pub fn serve<S: Read + Write>(mut stream: S, backend: &mut dyn Backend) -> std::
                 if std::env::var_os("SMOLVM_CUDA_HOST_OPLOG").is_some() {
                     eprintln!("[op~] 0x{:02x} len={}", payload[1], payload.len());
                 }
-                let (status, _) = dispatch(&mut sess, backend, req);
+                let (status, _) = dispatch(sess, backend, req);
                 if status != 0 && std::env::var_os("SMOLVM_CUDA_HOST_OPLOG").is_some() {
                     eprintln!("[op~!] status={status}");
                 }
@@ -293,6 +334,7 @@ pub fn serve<S: Read + Write>(mut stream: S, backend: &mut dyn Backend) -> std::
                         Ok(rings) => {
                             write_msg(&mut stream, &encode_response(0, &Response::Ok))?;
                             return serve_rings(stream, backend, sess, quiet_sticky, rings);
+                            // (session reclaimed by `serve` on return)
                         }
                         Err(code) => {
                             write_msg(&mut stream, &encode_response(code, &Response::Ok))?;
@@ -300,7 +342,7 @@ pub fn serve<S: Read + Write>(mut stream: S, backend: &mut dyn Backend) -> std::
                         }
                     }
                 }
-                let (status, resp) = dispatch(&mut sess, backend, req);
+                let (status, resp) = dispatch(sess, backend, req);
                 if status != 0 && std::env::var_os("SMOLVM_CUDA_HOST_OPLOG").is_some() {
                     eprintln!("[op!] status={status}");
                 }
@@ -379,7 +421,7 @@ impl HostRings {
 fn serve_rings<S: Read + Write>(
     mut stream: S,
     backend: &mut dyn Backend,
-    mut sess: Session,
+    sess: &mut Session,
     mut quiet_sticky: i32,
     rings: HostRings,
 ) -> std::io::Result<()> {
@@ -524,7 +566,7 @@ fn serve_rings<S: Read + Write>(
                 if oplog {
                     eprintln!("[op~] 0x{:02x} len={}", frame[1], frame.len());
                 }
-                let (status, _) = dispatch(&mut sess, backend, req);
+                let (status, _) = dispatch(sess, backend, req);
                 if status != 0 {
                     if oplog {
                         eprintln!("[op~!] status={status}");
@@ -553,7 +595,7 @@ fn serve_rings<S: Read + Write>(
                 if oplog {
                     eprintln!("[op] 0x{:02x} len={}", frame[0], frame.len());
                 }
-                let (status, resp) = dispatch(&mut sess, backend, req);
+                let (status, resp) = dispatch(sess, backend, req);
                 if status != 0 && oplog {
                     eprintln!("[op!] status={status}");
                 }
@@ -609,15 +651,18 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         }
         Request::PrimaryCtxRetain { device } => {
             let raw = b.primary_ctx_retain(device)?;
+            sess.primary_retains += 1;
             let id = sess.mint();
             sess.contexts.insert(id, raw);
             Ok(Response::Handle(id))
         }
         Request::PrimaryCtxRelease { device } => {
+            sess.primary_retains = sess.primary_retains.saturating_sub(1);
             b.primary_ctx_release(device).map(|_| Response::Ok)
         }
         Request::ModuleLoadData { image } => {
             let raw = b.module_load_data(&image)?;
+            sess.owned_modules.insert(raw);
             let id = sess.mint();
             sess.modules.insert(id, raw);
             Ok(Response::Handle(id))
@@ -632,6 +677,7 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         Request::ModuleUnload { module } => {
             let raw_mod = raw(&sess.modules, module)?;
             b.module_unload(raw_mod)?;
+            sess.owned_modules.remove(&raw_mod);
             sess.modules.remove(&module);
             Ok(Response::Ok)
         }
@@ -653,8 +699,14 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             b.func_set_attribute(raw_fn, attrib, value)
                 .map(|_| Response::Ok)
         }
-        Request::MemAlloc { bytes } => b.mem_alloc(bytes).map(Response::Dptr),
-        Request::MemFree { dptr } => b.mem_free(dptr).map(|_| Response::Ok),
+        Request::MemAlloc { bytes } => b.mem_alloc(bytes).map(|d| {
+            sess.owned_dptrs.insert(d);
+            Response::Dptr(d)
+        }),
+        Request::MemFree { dptr } => {
+            sess.owned_dptrs.remove(&dptr);
+            b.mem_free(dptr).map(|_| Response::Ok)
+        }
         Request::MemcpyHtoD { dptr, stream, data } => b
             .memcpy_htod(dptr, &data, raw_stream(sess, stream)?)
             .map(|_| Response::Ok),
@@ -693,7 +745,10 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         // on one is garbage on the other: torch's capture stream (runtime)
         // fed to a Triton kernel launch (driver) came back INVALID_HANDLE.
         // Raw pointers are valid on every connection, like device pointers.
-        Request::StreamCreate { flags } => b.stream_create(flags).map(Response::Handle),
+        Request::StreamCreate { flags } => b.stream_create(flags).map(|st| {
+            sess.owned_streams.insert(st);
+            Response::Handle(st)
+        }),
         Request::StreamBeginCapture { stream, mode } => {
             let raw = raw_stream(sess, stream)?;
             b.stream_begin_capture(raw, mode).map(|_| Response::Ok)
@@ -743,6 +798,7 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         Request::StreamDestroy { stream } => {
             let raw = raw_stream(sess, stream)?;
             b.stream_destroy(raw)?;
+            sess.owned_streams.remove(&raw);
             sess.streams.remove(&stream);
             Ok(Response::Ok)
         }
@@ -767,10 +823,14 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         // Events are raw host pointers on the wire, same as streams (see
         // StreamCreate): context-scoped, and one guest process talks over
         // several connections that must all understand the same handle.
-        Request::EventCreate { flags } => b.event_create(flags).map(Response::Handle),
+        Request::EventCreate { flags } => b.event_create(flags).map(|e| {
+            sess.owned_events.insert(e);
+            Response::Handle(e)
+        }),
         Request::EventDestroy { event } => {
             let raw = raw_event(sess, event)?;
             b.event_destroy(raw)?;
+            sess.owned_events.remove(&raw);
             sess.events.remove(&event);
             Ok(Response::Ok)
         }

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -67,6 +67,17 @@ pub trait Backend: Send {
     /// Begin capturing `stream`'s work into a CUDA graph (mode per
     /// `cudaStreamCaptureMode`).
     fn stream_begin_capture(&mut self, stream: u64, mode: i32) -> CuResult<()>;
+    /// Exchange this (serving) thread's capture interaction mode; returns the
+    /// previous mode. Lets a guest run capture-unsafe calls (allocator growth)
+    /// under `cudaStreamCaptureModeRelaxed` exactly like PyTorch does natively.
+    fn thread_exchange_capture_mode(&mut self, mode: i32) -> CuResult<i32>;
+    /// Raw `cuStreamQuery` code as a value (0 complete, 600 not ready) — not
+    /// an error, so it rides the response body.
+    fn stream_query(&mut self, stream: u64) -> CuResult<i32>;
+    /// `cuStreamWaitEvent`: make `stream` wait for `event`.
+    fn stream_wait_event(&mut self, stream: u64, event: u64, flags: u32) -> CuResult<()>;
+    /// Raw `cuEventQuery` code as a value (0 complete, 600 not ready).
+    fn event_query(&mut self, event: u64) -> CuResult<i32>;
     /// End capture; returns the raw `cudaGraph_t`.
     fn stream_end_capture(&mut self, stream: u64) -> CuResult<u64>;
     /// `(capture_status, capture_id)` for `stream`.
@@ -142,8 +153,16 @@ pub trait Backend: Send {
     ) -> CuResult<()>;
 
     /// Generic forward-to-host-lib dispatch (code-generated per function).
-    /// Returns `(library_status, serialized_outputs)`. Default: unsupported.
-    fn lib_call(&mut self, _lib: u8, _func: u16, _args: &[u8]) -> CuResult<(i32, Vec<u8>)> {
+    /// `streams` is the session's stream table (wire id → raw host stream) for
+    /// resolving `cudaStream_t` parameters. Returns `(library_status,
+    /// serialized_outputs)`. Default: unsupported.
+    fn lib_call(
+        &mut self,
+        _lib: u8,
+        _func: u16,
+        _args: &[u8],
+        _streams: &HashMap<u64, u64>,
+    ) -> CuResult<(i32, Vec<u8>)> {
         Err(CUDA_ERROR_NOT_FOUND)
     }
 
@@ -246,14 +265,17 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
     // Translate an opaque stream id: 0 is the default stream (passes through),
     // anything else must be a live minted id.
     fn raw_stream(sess: &Session, stream: u64) -> CuResult<u64> {
+        // Streams are raw host pointers on the wire (see StreamCreate below);
+        // the table only translates ids minted by pre-raw-stream guests.
         if stream == 0 {
             Ok(0)
         } else {
-            sess.streams
-                .get(&stream)
-                .copied()
-                .ok_or(CUDA_ERROR_INVALID_HANDLE)
+            Ok(sess.streams.get(&stream).copied().unwrap_or(stream))
         }
+    }
+    fn raw_event(sess: &Session, event: u64) -> CuResult<u64> {
+        // Same raw-on-the-wire convention as streams.
+        Ok(sess.events.get(&event).copied().unwrap_or(event))
     }
     let r: CuResult<Response> = (|| match req {
         Request::Init => b.init().map(|_| Response::Ok),
@@ -350,15 +372,20 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
                 .map(|_| Response::Ok)
         }
         Request::CtxSynchronize => b.ctx_synchronize().map(|_| Response::Ok),
-        Request::StreamCreate { flags } => {
-            let raw = b.stream_create(flags)?;
-            let id = sess.mint();
-            sess.streams.insert(id, raw);
-            Ok(Response::Handle(id))
-        }
+        // Streams hand back the RAW host pointer, not a session-minted id.
+        // Streams are context-scoped and every connection retains the same
+        // device primary context — but one guest process holds SEPARATE
+        // connections (runtime shim + driver shim), so a per-session id minted
+        // on one is garbage on the other: torch's capture stream (runtime)
+        // fed to a Triton kernel launch (driver) came back INVALID_HANDLE.
+        // Raw pointers are valid on every connection, like device pointers.
+        Request::StreamCreate { flags } => b.stream_create(flags).map(Response::Handle),
         Request::StreamBeginCapture { stream, mode } => {
             let raw = raw_stream(sess, stream)?;
             b.stream_begin_capture(raw, mode).map(|_| Response::Ok)
+        }
+        Request::ThreadExchangeCaptureMode { mode } => {
+            b.thread_exchange_capture_mode(mode).map(Response::Count)
         }
         Request::StreamEndCapture { stream } => {
             let raw = raw_stream(sess, stream)?;
@@ -400,7 +427,7 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
                 .map(|_| Response::Ok)
         }
         Request::StreamDestroy { stream } => {
-            let raw = raw(&sess.streams, stream)?;
+            let raw = raw_stream(sess, stream)?;
             b.stream_destroy(raw)?;
             sess.streams.remove(&stream);
             Ok(Response::Ok)
@@ -409,30 +436,46 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             let raw = raw_stream(sess, stream)?;
             b.stream_synchronize(raw).map(|_| Response::Ok)
         }
-        Request::EventCreate { flags } => {
-            let raw = b.event_create(flags)?;
-            let id = sess.mint();
-            sess.events.insert(id, raw);
-            Ok(Response::Handle(id))
+        Request::StreamQuery { stream } => {
+            let raw = raw_stream(sess, stream)?;
+            b.stream_query(raw).map(Response::Count)
         }
+        Request::StreamWaitEvent {
+            stream,
+            event,
+            flags,
+        } => {
+            let raw_s = raw_stream(sess, stream)?;
+            let raw_e = raw_event(sess, event)?;
+            b.stream_wait_event(raw_s, raw_e, flags)
+                .map(|_| Response::Ok)
+        }
+        // Events are raw host pointers on the wire, same as streams (see
+        // StreamCreate): context-scoped, and one guest process talks over
+        // several connections that must all understand the same handle.
+        Request::EventCreate { flags } => b.event_create(flags).map(Response::Handle),
         Request::EventDestroy { event } => {
-            let raw = raw(&sess.events, event)?;
+            let raw = raw_event(sess, event)?;
             b.event_destroy(raw)?;
             sess.events.remove(&event);
             Ok(Response::Ok)
         }
         Request::EventRecord { event, stream } => {
-            let raw_ev = raw(&sess.events, event)?;
+            let raw_ev = raw_event(sess, event)?;
             let raw_str = raw_stream(sess, stream)?;
             b.event_record(raw_ev, raw_str).map(|_| Response::Ok)
         }
         Request::EventSynchronize { event } => {
-            let raw_ev = raw(&sess.events, event)?;
+            let raw_ev = raw_event(sess, event)?;
             b.event_synchronize(raw_ev).map(|_| Response::Ok)
         }
+        Request::EventQuery { event } => {
+            let raw_ev = raw_event(sess, event)?;
+            b.event_query(raw_ev).map(Response::Count)
+        }
         Request::EventElapsedTime { start, end } => {
-            let raw_start = raw(&sess.events, start)?;
-            let raw_end = raw(&sess.events, end)?;
+            let raw_start = raw_event(sess, start)?;
+            let raw_end = raw_event(sess, end)?;
             b.event_elapsed_time(raw_start, raw_end)
                 .map(Response::Millis)
         }
@@ -527,7 +570,7 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             .map(|_| Response::Ok)
         }
         Request::LibCall { lib, func, args } => b
-            .lib_call(lib, func, &args)
+            .lib_call(lib, func, &args, &sess.streams)
             .map(|(status, out)| Response::LibResult(status, out)),
         Request::MemcpyShmHtoD { dptr, offset, size } => {
             b.memcpy_shm_htod(dptr, offset, size).map(|_| Response::Ok)
@@ -765,6 +808,19 @@ impl Backend for CpuBackend {
     }
     fn stream_begin_capture(&mut self, _stream: u64, _mode: i32) -> CuResult<()> {
         Err(CUDA_ERROR_NOT_SUPPORTED)
+    }
+    fn thread_exchange_capture_mode(&mut self, mode: i32) -> CuResult<i32> {
+        // No capture machinery in CPU emulation; echo the mode back.
+        Ok(mode)
+    }
+    fn stream_query(&mut self, _stream: u64) -> CuResult<i32> {
+        Ok(0) // everything executes synchronously
+    }
+    fn stream_wait_event(&mut self, _stream: u64, _event: u64, _flags: u32) -> CuResult<()> {
+        Ok(()) // in-order execution: the dependency already holds
+    }
+    fn event_query(&mut self, _event: u64) -> CuResult<i32> {
+        Ok(0)
     }
     fn stream_end_capture(&mut self, _stream: u64) -> CuResult<u64> {
         Err(CUDA_ERROR_NOT_SUPPORTED)

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -238,7 +238,7 @@ struct Session {
     /// a guest that dies mid-run must not leak GPU memory (device
     /// allocations are the multi-GB hazard; modules/streams/events are
     /// hygiene). Raw backend handles.
-    owned_dptrs: std::collections::HashSet<u64>,
+    owned_dptrs: HashMap<u64, u64>, // dptr → size (also the quota ledger)
     owned_modules: std::collections::HashSet<u64>,
     owned_streams: std::collections::HashSet<u64>,
     owned_events: std::collections::HashSet<u64>,
@@ -248,7 +248,7 @@ struct Session {
 /// Free everything a finished connection still owns. Failures are ignored —
 /// the driver may already have reclaimed (context destruction, device reset).
 fn reclaim_session(sess: &mut Session, b: &mut dyn Backend) {
-    for d in std::mem::take(&mut sess.owned_dptrs) {
+    for (d, _size) in std::mem::take(&mut sess.owned_dptrs) {
         let _ = b.mem_free(d);
     }
     for m in std::mem::take(&mut sess.owned_modules) {
@@ -699,12 +699,30 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             b.func_set_attribute(raw_fn, attrib, value)
                 .map(|_| Response::Ok)
         }
-        Request::MemAlloc { bytes } => b.mem_alloc(bytes).map(|d| {
-            sess.owned_dptrs.insert(d);
-            Response::Dptr(d)
-        }),
+        Request::MemAlloc { bytes } => {
+            // Per-connection VRAM quota (SMOLVM_CUDA_VRAM_LIMIT_MB on the
+            // host): a guest may not allocate past its budget — the CUDA-
+            // native failure (out of memory) surfaces to the app.
+            static LIMIT: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
+            let limit = *LIMIT.get_or_init(|| {
+                std::env::var("SMOLVM_CUDA_VRAM_LIMIT_MB")
+                    .ok()
+                    .and_then(|v| v.parse::<u64>().ok())
+                    .map(|mb| mb * 1024 * 1024)
+                    .unwrap_or(u64::MAX)
+            });
+            let used: u64 = sess.owned_dptrs.values().sum();
+            if used.saturating_add(bytes) > limit {
+                return Err(2); // CUDA_ERROR_OUT_OF_MEMORY
+            }
+            b.mem_alloc(bytes).map(|d| {
+                sess.owned_dptrs.insert(d, bytes);
+                Response::Dptr(d)
+            })
+        }
         Request::MemFree { dptr } => {
             sess.owned_dptrs.remove(&dptr);
+            // (removal returns the freed size to the quota ledger)
             b.mem_free(dptr).map(|_| Response::Ok)
         }
         Request::MemcpyHtoD { dptr, stream, data } => b
@@ -1663,5 +1681,31 @@ mod tests {
         assert_eq!(back, big);
         drop(cli);
         server.join().unwrap();
+    }
+    // A connection may not allocate past SMOLVM_CUDA_VRAM_LIMIT_MB; freeing
+    // returns budget. (Env is process-global — this test sets it before the
+    // OnceLock is first read; fine while it's the only quota test.)
+    #[test]
+    fn vram_quota_enforced() {
+        std::env::set_var("SMOLVM_CUDA_VRAM_LIMIT_MB", "1");
+        let mut sess = Session::default();
+        let mut b = CpuBackend::default();
+        let mb = 1024 * 1024;
+        let (st, r) = dispatch(&mut sess, &mut b, Request::MemAlloc { bytes: mb / 2 });
+        assert_eq!(st, 0);
+        let d1 = match r {
+            Response::Dptr(d) => d,
+            _ => unreachable!(),
+        };
+        // Second half-MB fits exactly; a byte more must fail with OOM(2).
+        let (st, _) = dispatch(&mut sess, &mut b, Request::MemAlloc { bytes: mb / 2 });
+        assert_eq!(st, 0);
+        let (st, _) = dispatch(&mut sess, &mut b, Request::MemAlloc { bytes: 1 });
+        assert_eq!(st, 2, "over-quota alloc must report OUT_OF_MEMORY");
+        // Freeing restores budget.
+        let (st, _) = dispatch(&mut sess, &mut b, Request::MemFree { dptr: d1 });
+        assert_eq!(st, 0);
+        let (st, _) = dispatch(&mut sess, &mut b, Request::MemAlloc { bytes: mb / 4 });
+        assert_eq!(st, 0);
     }
 }

--- a/crates/smolvm-cuda/src/host/gpu.rs
+++ b/crates/smolvm-cuda/src/host/gpu.rs
@@ -105,6 +105,11 @@ pub struct GpuBackend {
     cublaslt: Option<CublasLt>,
     /// Legacy cuDNN batch-norm (Ex) forwarder — PyTorch's `BatchNorm2d` path.
     cudnn_bn: Option<CudnnBn>,
+    /// Guest-assigned virtual handle (bit 63 set) → real host descriptor
+    /// pointer. Lets the guest fire-and-forget descriptor creation: it invents
+    /// the id, the host materializes and maps it, and every later reference is
+    /// translated here. Real pointers (bit 63 clear) pass through untouched.
+    vhandles: std::collections::HashMap<u64, u64>,
     /// Host mappings of guest RAM, each `(gpa_start, host_va, len)`, for
     /// zero-copy `memcpy_gpa_*` (via `krun_get_guest_ram`). Empty outside a
     /// microVM / on older libkrun. Guest RAM is usually split into a low and a
@@ -332,6 +337,7 @@ impl GpuBackend {
                 cublas_gen: None,
                 cudnn_gen: None,
                 cudnn_backend: None,
+                vhandles: std::collections::HashMap::new(),
                 cublaslt: None,
                 cudnn_bn: None,
                 guest_ram: Vec::new(),
@@ -903,29 +909,63 @@ impl CudnnBackend {
 
     /// `func` selects the entry point; `args` is the hand-packed little-endian
     /// argument blob (see the guest shim). Returns `(cudnnStatus, out_bytes)`.
-    fn dispatch(&self, func: u16, args: &[u8]) -> (i32, Vec<u8>) {
+    /// Descriptor handles may be guest-assigned virtual ids (`vh`); attribute
+    /// arrays of type `CUDNN_TYPE_BACKEND_DESCRIPTOR` embed handles and are
+    /// translated element-wise.
+    fn dispatch(
+        &self,
+        func: u16,
+        args: &[u8],
+        vh: &mut std::collections::HashMap<u64, u64>,
+    ) -> (i32, Vec<u8>) {
+        /// `cudnnBackendAttributeType_t` values whose 8-byte elements are
+        /// handles the guest may know only by virtual id: HANDLE(0) — the
+        /// cudnnHandle_t itself — and BACKEND_DESCRIPTOR(15). VOID_PTR(6)
+        /// elements are device pointers (untagged), translated harmlessly.
+        fn handle_bearing(ty: i32) -> bool {
+            matches!(ty, 0 | 6 | 15)
+        }
+        const TYPE_BACKEND_DESCRIPTOR: i32 = 15;
         let rd_u64 = |a: &[u8], o: usize| u64::from_le_bytes(a[o..o + 8].try_into().unwrap());
         let rd_i32 = |a: &[u8], o: usize| i32::from_le_bytes(a[o..o + 4].try_into().unwrap());
         let rd_i64 = |a: &[u8], o: usize| i64::from_le_bytes(a[o..o + 8].try_into().unwrap());
         match func {
             0 => {
-                // create(type) -> handle
+                // create(type[, virtual-id]) -> handle. With a virtual id the
+                // guest fired-and-forgot: map it and reply with the real
+                // pointer (ignored by a pipelining guest, used by an old one).
                 let ty = rd_i32(args, 0);
                 let mut desc: *mut c_void = std::ptr::null_mut();
                 let st = unsafe { (self.create)(ty, &mut desc) };
+                if st == 0 && args.len() >= 12 {
+                    let id = rd_u64(args, 4);
+                    if id & VHANDLE_TAG != 0 {
+                        vh.insert(id, desc as u64);
+                    }
+                }
                 (st, (desc as u64).to_le_bytes().to_vec())
             }
             1 => {
-                let desc = rd_u64(args, 0) as *mut c_void;
+                let id = rd_u64(args, 0);
+                let desc = vh_resolve(vh, id) as *mut c_void;
+                if id & VHANDLE_TAG != 0 {
+                    vh.remove(&id);
+                }
                 (unsafe { (self.destroy)(desc) }, Vec::new())
             }
             2 => {
                 // set_attr(desc, name, type, count, elements...)
-                let desc = rd_u64(args, 0) as *mut c_void;
+                let desc = vh_resolve(vh, rd_u64(args, 0)) as *mut c_void;
                 let name = rd_i32(args, 8);
                 let ty = rd_i32(args, 12);
                 let count = rd_i64(args, 16);
-                let elems = &args[24..];
+                let mut elems = args[24..].to_vec();
+                if handle_bearing(ty) {
+                    for chunk in elems.chunks_exact_mut(8) {
+                        let h = u64::from_le_bytes(chunk.try_into().unwrap());
+                        chunk.copy_from_slice(&vh_resolve(vh, h).to_le_bytes());
+                    }
+                }
                 let st = unsafe { (self.set_attr)(desc, name, ty, count, elems.as_ptr().cast()) };
                 (st, Vec::new())
             }
@@ -933,8 +973,9 @@ impl CudnnBackend {
                 // get_attr(desc, name, type, requestedCount, input_bytes) -> count + bytes.
                 // For descriptor-array attributes the caller pre-creates the
                 // descriptors and passes their handles in; cuDNN populates them
-                // in place. So seed the buffer with the forwarded input.
-                let desc = rd_u64(args, 0) as *mut c_void;
+                // in place. So seed the buffer with the forwarded input
+                // (translated — the guest may pass virtual ids).
+                let desc = vh_resolve(vh, rd_u64(args, 0)) as *mut c_void;
                 let name = rd_i32(args, 8);
                 let ty = rd_i32(args, 12);
                 let req = rd_i64(args, 16);
@@ -943,6 +984,12 @@ impl CudnnBackend {
                 let mut buf = vec![0u8; cap];
                 let seed = input.len().min(cap);
                 buf[..seed].copy_from_slice(&input[..seed]);
+                if handle_bearing(ty) {
+                    for chunk in buf[..seed].chunks_exact_mut(8) {
+                        let h = u64::from_le_bytes(chunk.try_into().unwrap());
+                        chunk.copy_from_slice(&vh_resolve(vh, h).to_le_bytes());
+                    }
+                }
                 let mut count: i64 = 0;
                 let ptr = if cap == 0 {
                     std::ptr::null_mut()
@@ -956,14 +1003,14 @@ impl CudnnBackend {
                 (st, out)
             }
             4 => {
-                let desc = rd_u64(args, 0) as *mut c_void;
+                let desc = vh_resolve(vh, rd_u64(args, 0)) as *mut c_void;
                 (unsafe { (self.finalize)(desc) }, Vec::new())
             }
             5 => {
                 // execute(handle, plan, variantPack)
-                let handle = rd_u64(args, 0) as *mut c_void;
-                let plan = rd_u64(args, 8) as *mut c_void;
-                let vpack = rd_u64(args, 16) as *mut c_void;
+                let handle = vh_resolve(vh, rd_u64(args, 0)) as *mut c_void;
+                let plan = vh_resolve(vh, rd_u64(args, 8)) as *mut c_void;
+                let vpack = vh_resolve(vh, rd_u64(args, 16)) as *mut c_void;
                 (unsafe { (self.execute)(handle, plan, vpack) }, Vec::new())
             }
             _ => (super::CUDA_ERROR_NOT_FOUND, Vec::new()),
@@ -1054,7 +1101,12 @@ impl CublasLt {
 
     /// `func` selects the entry point; `args` is the hand-packed little-endian
     /// argument blob (see the guest shim). Returns `(cublasStatus, out_bytes)`.
-    fn dispatch(&self, func: u16, args: &[u8]) -> (i32, Vec<u8>) {
+    fn dispatch(
+        &self,
+        func: u16,
+        args: &[u8],
+        vh: &std::collections::HashMap<u64, u64>,
+    ) -> (i32, Vec<u8>) {
         // sizeof(cublasLtMatmulHeuristicResult_t): algo[64] + workspaceSize(8)
         // + state(4) + wavesCount(4) + reserved[4](16) = 96 bytes.
         const HEUR_RESULT_SZ: usize = 96;
@@ -1126,7 +1178,7 @@ impl CublasLt {
             9 => {
                 // algo_get_heuristic(light, opDesc, A, B, C, D, pref, requested)
                 //   -> returnCount + returnCount * heuristicResult structs.
-                let light = rd_u64(0) as *mut c_void;
+                let light = vh_resolve(vh, rd_u64(0)) as *mut c_void;
                 let op = rd_u64(8) as *mut c_void;
                 let a = rd_u64(16) as *mut c_void;
                 let b = rd_u64(24) as *mut c_void;
@@ -1158,7 +1210,7 @@ impl CublasLt {
             10 => {
                 // matmul(light, desc, alpha[16], A, Adesc, B, Bdesc, beta[16],
                 //   C, Cdesc, D, Ddesc, algo[64], workspace, wsSize, stream)
-                let light = rd_u64(0) as *mut c_void;
+                let light = vh_resolve(vh, rd_u64(0)) as *mut c_void;
                 let desc = rd_u64(8) as *mut c_void;
                 let alpha = &args[16..32];
                 let a = rd_u64(32) as *mut c_void;
@@ -1216,11 +1268,31 @@ impl CublasLt {
     }
 }
 
+/// The tag bit marking a guest-assigned virtual handle. Host userspace
+/// pointers and CUDA device VAs never have bit 63 set, so tagged values are
+/// unambiguous on the wire.
+const VHANDLE_TAG: u64 = 1 << 63;
+
+/// Resolve a possibly-virtual handle against the map: tagged values must be
+/// mapped (0 → guaranteed invalid-handle error from the library), real
+/// pointers pass through.
+fn vh_resolve(map: &std::collections::HashMap<u64, u64>, h: u64) -> u64 {
+    if h & VHANDLE_TAG != 0 {
+        map.get(&h).copied().unwrap_or(0)
+    } else {
+        h
+    }
+}
+
 /// Little-endian cursor over a hand-packed argument blob (host side of the
 /// batchnorm forwarder). Mirrors the guest shim's packing exactly.
 struct Cur<'a> {
     b: &'a [u8],
     p: usize,
+    /// Virtual-handle map for resolving guest-assigned descriptor ids in
+    /// [`Cur::ptr`]. Device pointers and real host pointers pass through
+    /// (bit 63 clear).
+    vh: &'a std::collections::HashMap<u64, u64>,
 }
 impl Cur<'_> {
     fn take(&mut self, n: usize) -> &[u8] {
@@ -1241,7 +1313,7 @@ impl Cur<'_> {
         f64::from_le_bytes(self.take(8).try_into().unwrap())
     }
     fn ptr(&mut self) -> *mut c_void {
-        self.u64() as *mut c_void
+        vh_resolve(self.vh, self.u64()) as *mut c_void
     }
 }
 
@@ -1391,8 +1463,13 @@ impl CudnnBn {
         }
     }
 
-    fn dispatch(&self, func: u16, args: &[u8]) -> (i32, Vec<u8>) {
-        let mut c = Cur { b: args, p: 0 };
+    fn dispatch(
+        &self,
+        func: u16,
+        args: &[u8],
+        vh: &std::collections::HashMap<u64, u64>,
+    ) -> (i32, Vec<u8>) {
+        let mut c = Cur { b: args, p: 0, vh };
         match func {
             0 => {
                 // set_nd(desc, dataType, nbDims, dimA[], strideA[])
@@ -1764,7 +1841,11 @@ impl GpuBackend {
                         }
                     }
                 }
-                Ok(self.cublas_gen.as_ref().unwrap().dispatch(func, args))
+                Ok(self
+                    .cublas_gen
+                    .as_ref()
+                    .unwrap()
+                    .dispatch(func, args, &mut self.vhandles))
             }
             LIB_CUDNN => {
                 if self.cudnn_gen.is_none() {
@@ -1776,7 +1857,11 @@ impl GpuBackend {
                         }
                     }
                 }
-                Ok(self.cudnn_gen.as_ref().unwrap().dispatch(func, args))
+                Ok(self
+                    .cudnn_gen
+                    .as_ref()
+                    .unwrap()
+                    .dispatch(func, args, &mut self.vhandles))
             }
             LIB_CUDNN_BACKEND => {
                 if self.cudnn_backend.is_none() {
@@ -1788,7 +1873,11 @@ impl GpuBackend {
                         }
                     }
                 }
-                Ok(self.cudnn_backend.as_ref().unwrap().dispatch(func, args))
+                Ok(self
+                    .cudnn_backend
+                    .as_ref()
+                    .unwrap()
+                    .dispatch(func, args, &mut self.vhandles))
             }
             LIB_CUBLASLT => {
                 if self.cublaslt.is_none() {
@@ -1800,7 +1889,11 @@ impl GpuBackend {
                         }
                     }
                 }
-                Ok(self.cublaslt.as_ref().unwrap().dispatch(func, args))
+                Ok(self
+                    .cublaslt
+                    .as_ref()
+                    .unwrap()
+                    .dispatch(func, args, &self.vhandles))
             }
             LIB_CUDNN_BN => {
                 if self.cudnn_bn.is_none() {
@@ -1812,7 +1905,11 @@ impl GpuBackend {
                         }
                     }
                 }
-                Ok(self.cudnn_bn.as_ref().unwrap().dispatch(func, args))
+                Ok(self
+                    .cudnn_bn
+                    .as_ref()
+                    .unwrap()
+                    .dispatch(func, args, &self.vhandles))
             }
             _ => Err(super::CUDA_ERROR_NOT_FOUND),
         }

--- a/crates/smolvm-cuda/src/host/gpu.rs
+++ b/crates/smolvm-cuda/src/host/gpu.rs
@@ -82,6 +82,20 @@ pub struct GpuBackend {
     ) -> CuResultCode,
     ctx_synchronize: unsafe extern "C" fn() -> CuResultCode,
     stream_create: unsafe extern "C" fn(*mut *mut c_void, c_uint) -> CuResultCode,
+    // CUDA graphs (capture on the real driver; replay = one launch).
+    stream_begin_capture: unsafe extern "C" fn(*mut c_void, c_int) -> CuResultCode,
+    stream_end_capture: unsafe extern "C" fn(*mut c_void, *mut *mut c_void) -> CuResultCode,
+    stream_get_capture_info:
+        unsafe extern "C" fn(*mut c_void, *mut c_int, *mut u64) -> CuResultCode,
+    graph_instantiate_with_flags:
+        unsafe extern "C" fn(*mut *mut c_void, *mut c_void, u64) -> CuResultCode,
+    graph_launch: unsafe extern "C" fn(*mut c_void, *mut c_void) -> CuResultCode,
+    graph_exec_destroy: unsafe extern "C" fn(*mut c_void) -> CuResultCode,
+    graph_destroy: unsafe extern "C" fn(*mut c_void) -> CuResultCode,
+    graph_get_nodes:
+        unsafe extern "C" fn(*mut c_void, *mut *mut c_void, *mut usize) -> CuResultCode,
+    memset_d8_async: unsafe extern "C" fn(u64, u8, usize, *mut c_void) -> CuResultCode,
+    memcpy_dtod_async: unsafe extern "C" fn(u64, u64, usize, *mut c_void) -> CuResultCode,
     stream_destroy: unsafe extern "C" fn(*mut c_void) -> CuResultCode,
     stream_synchronize: unsafe extern "C" fn(*mut c_void) -> CuResultCode,
     event_create: unsafe extern "C" fn(*mut *mut c_void, c_uint) -> CuResultCode,
@@ -325,6 +339,24 @@ impl GpuBackend {
                 launch_kernel: sym(&lib, b"cuLaunchKernel\0")?,
                 ctx_synchronize: sym(&lib, b"cuCtxSynchronize\0")?,
                 stream_create: sym(&lib, b"cuStreamCreate\0")?,
+                stream_begin_capture: sym2(
+                    &lib,
+                    b"cuStreamBeginCapture_v2\0",
+                    b"cuStreamBeginCapture\0",
+                )?,
+                stream_end_capture: sym(&lib, b"cuStreamEndCapture\0")?,
+                stream_get_capture_info: sym2(
+                    &lib,
+                    b"cuStreamGetCaptureInfo\0",
+                    b"cuStreamGetCaptureInfo_v2\0",
+                )?,
+                graph_instantiate_with_flags: sym(&lib, b"cuGraphInstantiateWithFlags\0")?,
+                graph_launch: sym(&lib, b"cuGraphLaunch\0")?,
+                graph_exec_destroy: sym(&lib, b"cuGraphExecDestroy\0")?,
+                graph_destroy: sym(&lib, b"cuGraphDestroy\0")?,
+                graph_get_nodes: sym(&lib, b"cuGraphGetNodes\0")?,
+                memset_d8_async: sym(&lib, b"cuMemsetD8Async\0")?,
+                memcpy_dtod_async: sym2(&lib, b"cuMemcpyDtoDAsync_v2\0", b"cuMemcpyDtoDAsync\0")?,
                 stream_destroy: sym2(&lib, b"cuStreamDestroy_v2\0", b"cuStreamDestroy\0")?,
                 stream_synchronize: sym(&lib, b"cuStreamSynchronize\0")?,
                 event_create: sym(&lib, b"cuEventCreate\0")?,
@@ -690,6 +722,82 @@ impl Backend for GpuBackend {
         let mut s: *mut c_void = std::ptr::null_mut();
         unsafe { chk((self.stream_create)(&mut s, flags))? };
         Ok(s as u64)
+    }
+    fn stream_begin_capture(&mut self, stream: u64, mode: i32) -> CuResult<()> {
+        unsafe { chk((self.stream_begin_capture)(stream as *mut c_void, mode)) }
+    }
+    fn stream_end_capture(&mut self, stream: u64) -> CuResult<u64> {
+        let mut g: *mut c_void = std::ptr::null_mut();
+        unsafe { chk((self.stream_end_capture)(stream as *mut c_void, &mut g))? };
+        Ok(g as u64)
+    }
+    fn stream_capture_info(&mut self, stream: u64) -> CuResult<(u64, u64)> {
+        let mut status: c_int = 0;
+        let mut id: u64 = 0;
+        unsafe {
+            chk((self.stream_get_capture_info)(
+                stream as *mut c_void,
+                &mut status,
+                &mut id,
+            ))?
+        };
+        Ok((status as u64, id))
+    }
+    fn graph_instantiate(&mut self, graph: u64) -> CuResult<u64> {
+        let mut e: *mut c_void = std::ptr::null_mut();
+        unsafe {
+            chk((self.graph_instantiate_with_flags)(
+                &mut e,
+                graph as *mut c_void,
+                0,
+            ))?
+        };
+        Ok(e as u64)
+    }
+    fn graph_launch(&mut self, graph_exec: u64, stream: u64) -> CuResult<()> {
+        unsafe {
+            chk((self.graph_launch)(
+                graph_exec as *mut c_void,
+                stream as *mut c_void,
+            ))
+        }
+    }
+    fn graph_exec_destroy(&mut self, graph_exec: u64) -> CuResult<()> {
+        unsafe { chk((self.graph_exec_destroy)(graph_exec as *mut c_void)) }
+    }
+    fn graph_destroy(&mut self, graph: u64) -> CuResult<()> {
+        unsafe { chk((self.graph_destroy)(graph as *mut c_void)) }
+    }
+    fn graph_get_node_count(&mut self, graph: u64) -> CuResult<u64> {
+        let mut n: usize = 0;
+        unsafe {
+            chk((self.graph_get_nodes)(
+                graph as *mut c_void,
+                std::ptr::null_mut(),
+                &mut n,
+            ))?
+        };
+        Ok(n as u64)
+    }
+    fn memset_d8_async(&mut self, dptr: u64, value: u8, bytes: u64, stream: u64) -> CuResult<()> {
+        unsafe {
+            chk((self.memset_d8_async)(
+                dptr,
+                value,
+                bytes as usize,
+                stream as *mut c_void,
+            ))
+        }
+    }
+    fn memcpy_dtod_async(&mut self, dst: u64, src: u64, bytes: u64, stream: u64) -> CuResult<()> {
+        unsafe {
+            chk((self.memcpy_dtod_async)(
+                dst,
+                src,
+                bytes as usize,
+                stream as *mut c_void,
+            ))
+        }
     }
     fn stream_destroy(&mut self, stream: u64) -> CuResult<()> {
         unsafe { chk((self.stream_destroy)(stream as *mut c_void)) }

--- a/crates/smolvm-cuda/src/host/gpu.rs
+++ b/crates/smolvm-cuda/src/host/gpu.rs
@@ -102,6 +102,18 @@ pub struct GpuBackend {
     stream_synchronize: unsafe extern "C" fn(*mut c_void) -> CuResultCode,
     stream_query: unsafe extern "C" fn(*mut c_void) -> CuResultCode,
     stream_wait_event: unsafe extern "C" fn(*mut c_void, *mut c_void, c_uint) -> CuResultCode,
+    // VMM (all optional: pre-Pascal drivers lack them; ops report NOT_SUPPORTED)
+    vmm_address_reserve:
+        Option<unsafe extern "C" fn(*mut u64, usize, usize, u64, u64) -> CuResultCode>,
+    vmm_create: Option<unsafe extern "C" fn(*mut u64, usize, *const VmmProp, u64) -> CuResultCode>,
+    vmm_map: Option<unsafe extern "C" fn(u64, usize, usize, u64, u64) -> CuResultCode>,
+    vmm_set_access:
+        Option<unsafe extern "C" fn(u64, usize, *const VmmAccessDesc, usize) -> CuResultCode>,
+    vmm_unmap: Option<unsafe extern "C" fn(u64, usize) -> CuResultCode>,
+    vmm_release: Option<unsafe extern "C" fn(u64) -> CuResultCode>,
+    vmm_address_free: Option<unsafe extern "C" fn(u64, usize) -> CuResultCode>,
+    vmm_granularity:
+        Option<unsafe extern "C" fn(*mut usize, *const VmmProp, c_uint) -> CuResultCode>,
     event_query: unsafe extern "C" fn(*mut c_void) -> CuResultCode,
     event_create: unsafe extern "C" fn(*mut *mut c_void, c_uint) -> CuResultCode,
     event_destroy: unsafe extern "C" fn(*mut c_void) -> CuResultCode,
@@ -368,6 +380,14 @@ impl GpuBackend {
                 stream_synchronize: sym(&lib, b"cuStreamSynchronize\0")?,
                 stream_query: sym(&lib, b"cuStreamQuery\0")?,
                 stream_wait_event: sym(&lib, b"cuStreamWaitEvent\0")?,
+                vmm_address_reserve: sym(&lib, b"cuMemAddressReserve\0").ok(),
+                vmm_create: sym(&lib, b"cuMemCreate\0").ok(),
+                vmm_map: sym(&lib, b"cuMemMap\0").ok(),
+                vmm_set_access: sym(&lib, b"cuMemSetAccess\0").ok(),
+                vmm_unmap: sym(&lib, b"cuMemUnmap\0").ok(),
+                vmm_release: sym(&lib, b"cuMemRelease\0").ok(),
+                vmm_address_free: sym(&lib, b"cuMemAddressFree\0").ok(),
+                vmm_granularity: sym(&lib, b"cuMemGetAllocationGranularity\0").ok(),
                 event_query: sym(&lib, b"cuEventQuery\0")?,
                 event_create: sym(&lib, b"cuEventCreate\0")?,
                 event_destroy: sym2(&lib, b"cuEventDestroy_v2\0", b"cuEventDestroy\0")?,
@@ -473,12 +493,16 @@ impl Backend for GpuBackend {
             buf.push(0);
         }
         let mut module: *mut c_void = std::ptr::null_mut();
-        unsafe {
-            chk((self.module_load_data)(
-                &mut module,
-                buf.as_ptr() as *const c_void,
-            ))?
-        };
+        let code = unsafe { (self.module_load_data)(&mut module, buf.as_ptr() as *const c_void) };
+        if code != 0 {
+            // Debug: keep failing images for cuobjdump post-mortem.
+            if let Some(dir) = std::env::var_os("SMOLVM_CUDA_DUMP_BAD_MODULES") {
+                let n = buf.len();
+                let path = std::path::Path::new(&dir).join(format!("badmod-{code}-{n}.bin"));
+                let _ = std::fs::write(path, &buf);
+            }
+            return Err(code);
+        }
         Ok(module as u64)
     }
     fn module_get_function(&mut self, module: u64, name: &str) -> CuResult<u64> {
@@ -601,6 +625,58 @@ impl Backend for GpuBackend {
         self.guest_ram.iter().find_map(|&(gs, hva, rlen)| {
             (gpa >= gs && gpa.checked_add(len)? <= gs + rlen).then(|| hva + (gpa - gs))
         })
+    }
+
+    fn mem_address_reserve(&mut self, size: u64, align: u64) -> CuResult<u64> {
+        let f = self
+            .vmm_address_reserve
+            .ok_or(super::CUDA_ERROR_NOT_SUPPORTED)?;
+        let mut va = 0u64;
+        unsafe { chk(f(&mut va, size as usize, align as usize, 0, 0))? };
+        Ok(va)
+    }
+    fn mem_create(&mut self, size: u64, device: i32) -> CuResult<u64> {
+        let f = self.vmm_create.ok_or(super::CUDA_ERROR_NOT_SUPPORTED)?;
+        let prop = vmm_prop(device);
+        let mut h = 0u64;
+        unsafe { chk(f(&mut h, size as usize, &prop, 0))? };
+        Ok(h)
+    }
+    fn mem_map(&mut self, va: u64, size: u64, offset: u64, handle: u64) -> CuResult<()> {
+        let f = self.vmm_map.ok_or(super::CUDA_ERROR_NOT_SUPPORTED)?;
+        unsafe { chk(f(va, size as usize, offset as usize, handle, 0)) }
+    }
+    fn mem_set_access(&mut self, va: u64, size: u64, device: i32) -> CuResult<()> {
+        let f = self.vmm_set_access.ok_or(super::CUDA_ERROR_NOT_SUPPORTED)?;
+        let desc = VmmAccessDesc {
+            location_type: 1,
+            location_id: device,
+            flags: 3,
+        };
+        unsafe { chk(f(va, size as usize, &desc, 1)) }
+    }
+    fn mem_unmap(&mut self, va: u64, size: u64) -> CuResult<()> {
+        let f = self.vmm_unmap.ok_or(super::CUDA_ERROR_NOT_SUPPORTED)?;
+        unsafe { chk(f(va, size as usize)) }
+    }
+    fn mem_release(&mut self, handle: u64) -> CuResult<()> {
+        let f = self.vmm_release.ok_or(super::CUDA_ERROR_NOT_SUPPORTED)?;
+        unsafe { chk(f(handle)) }
+    }
+    fn mem_address_free(&mut self, va: u64, size: u64) -> CuResult<()> {
+        let f = self
+            .vmm_address_free
+            .ok_or(super::CUDA_ERROR_NOT_SUPPORTED)?;
+        unsafe { chk(f(va, size as usize)) }
+    }
+    fn mem_get_allocation_granularity(&mut self, device: i32, flags: u32) -> CuResult<u64> {
+        let f = self
+            .vmm_granularity
+            .ok_or(super::CUDA_ERROR_NOT_SUPPORTED)?;
+        let prop = vmm_prop(device);
+        let mut g = 0usize;
+        unsafe { chk(f(&mut g, &prop, flags))? };
+        Ok(g as u64)
     }
 
     fn memcpy_gpa_htod(&mut self, dptr: u64, segments: &[(u64, u64)], stream: u64) -> CuResult<()> {
@@ -1904,6 +1980,37 @@ impl Drop for GpuBackend {
                 unsafe { free(addr as *mut c_void) };
             }
         }
+    }
+}
+
+/// `CUmemAllocationProp` prefix we populate: pinned device memory on one
+/// device, no export handles. Zeroed tail keeps future fields defined.
+#[repr(C)]
+pub struct VmmProp {
+    type_: c_int, // CU_MEM_ALLOCATION_TYPE_PINNED = 1
+    requested_handle_types: c_int,
+    location_type: c_int, // CU_MEM_LOCATION_TYPE_DEVICE = 1
+    location_id: c_int,
+    win32_handle_meta: *mut c_void,
+    alloc_flags: [u8; 8],
+}
+
+/// `CUmemAccessDesc`: device location + RW flags.
+#[repr(C)]
+pub struct VmmAccessDesc {
+    location_type: c_int,
+    location_id: c_int,
+    flags: c_int, // CU_MEM_ACCESS_FLAGS_PROT_READWRITE = 3
+}
+
+fn vmm_prop(device: i32) -> VmmProp {
+    VmmProp {
+        type_: 1,
+        requested_handle_types: 0,
+        location_type: 1,
+        location_id: device,
+        win32_handle_meta: std::ptr::null_mut(),
+        alloc_flags: [0; 8],
     }
 }
 

--- a/crates/smolvm-cuda/src/host/gpu.rs
+++ b/crates/smolvm-cuda/src/host/gpu.rs
@@ -530,7 +530,8 @@ impl Backend for GpuBackend {
     fn mem_free(&mut self, dptr: u64) -> CuResult<()> {
         unsafe { chk((self.mem_free)(dptr)) }
     }
-    fn memcpy_htod(&mut self, dptr: u64, data: &[u8]) -> CuResult<()> {
+    fn memcpy_htod(&mut self, dptr: u64, data: &[u8], stream: u64) -> CuResult<()> {
+        self.wait_stream(stream)?;
         unsafe {
             chk((self.memcpy_htod)(
                 dptr,
@@ -539,7 +540,8 @@ impl Backend for GpuBackend {
             ))
         }
     }
-    fn memcpy_dtoh(&mut self, dptr: u64, bytes: u64) -> CuResult<Vec<u8>> {
+    fn memcpy_dtoh(&mut self, dptr: u64, bytes: u64, stream: u64) -> CuResult<Vec<u8>> {
+        self.wait_stream(stream)?;
         let mut out = vec![0u8; bytes as usize];
         unsafe {
             chk((self.memcpy_dtoh)(
@@ -565,9 +567,10 @@ impl Backend for GpuBackend {
     // The shared-memory data channel is Linux-only (`crate::shm`); on other
     // platforms these fall back to the trait's not-supported default.
     #[cfg(target_os = "linux")]
-    fn memcpy_shm_htod(&mut self, dptr: u64, offset: u64, size: u64) -> CuResult<()> {
+    fn memcpy_shm_htod(&mut self, dptr: u64, offset: u64, size: u64, stream: u64) -> CuResult<()> {
         // Read straight from the shared region (no bytes over the socket) and
         // DMA to the GPU — one copy instead of three.
+        self.wait_stream(stream)?;
         let region = crate::shm::get_or_create().ok_or(super::CUDA_ERROR_NOT_FOUND)?;
         let src = region
             .checked(offset, size)
@@ -581,7 +584,8 @@ impl Backend for GpuBackend {
         }
     }
     #[cfg(target_os = "linux")]
-    fn memcpy_shm_dtoh(&mut self, offset: u64, dptr: u64, size: u64) -> CuResult<()> {
+    fn memcpy_shm_dtoh(&mut self, offset: u64, dptr: u64, size: u64, stream: u64) -> CuResult<()> {
+        self.wait_stream(stream)?;
         let region = crate::shm::get_or_create().ok_or(super::CUDA_ERROR_NOT_FOUND)?;
         let dst = region
             .checked(offset, size)
@@ -593,10 +597,11 @@ impl Backend for GpuBackend {
         self.guest_ram = regions;
     }
 
-    fn memcpy_gpa_htod(&mut self, dptr: u64, segments: &[(u64, u64)]) -> CuResult<()> {
+    fn memcpy_gpa_htod(&mut self, dptr: u64, segments: &[(u64, u64)], stream: u64) -> CuResult<()> {
         if self.guest_ram.is_empty() {
             return Err(super::CUDA_ERROR_NOT_FOUND);
         }
+        self.wait_stream(stream)?;
         self.ensure_guest_ram_pinned();
         zc_trace_segments("H2D", segments);
         // Few segments: DMA each straight from its guest-RAM host mapping to the
@@ -651,10 +656,11 @@ impl Backend for GpuBackend {
         Ok(())
     }
 
-    fn memcpy_gpa_dtoh(&mut self, dptr: u64, segments: &[(u64, u64)]) -> CuResult<()> {
+    fn memcpy_gpa_dtoh(&mut self, dptr: u64, segments: &[(u64, u64)], stream: u64) -> CuResult<()> {
         if self.guest_ram.is_empty() {
             return Err(super::CUDA_ERROR_NOT_FOUND);
         }
+        self.wait_stream(stream)?;
         self.ensure_guest_ram_pinned();
         zc_trace_segments("D2H", segments);
         if segments.len() <= ZC_DIRECT_MAX_SEGMENTS {
@@ -1896,6 +1902,18 @@ impl Drop for GpuBackend {
 }
 
 impl GpuBackend {
+    /// Order a blocking copy after prior work on `stream`. Torch creates its
+    /// pool streams non-blocking, so the NULL-stream blocking `cuMemcpy*` our
+    /// copies use does NOT wait for them — without this wait, a stream-ordered
+    /// `cudaMemcpyAsync` from the guest could overwrite (or read) memory that
+    /// kernels still running on `stream` are using.
+    fn wait_stream(&mut self, stream: u64) -> CuResult<()> {
+        if stream == 0 {
+            return Ok(()); // legacy default stream: blocking copies already order
+        }
+        unsafe { chk((self.stream_synchronize)(stream as *mut c_void)) }
+    }
+
     /// Pin the guest-RAM host mappings into the current CUDA context on the first
     /// zero-copy transfer, so subsequent DMAs from guest RAM run at full pinned
     /// bandwidth (~9 GB/s) instead of the ~3 GB/s pageable path. Best-effort and

--- a/crates/smolvm-cuda/src/host/gpu.rs
+++ b/crates/smolvm-cuda/src/host/gpu.rs
@@ -46,6 +46,7 @@ pub struct GpuBackend {
     /// [`Backend::func_get_param_info`] reports `CUDA_ERROR_NOT_SUPPORTED`.
     func_get_param_info:
         Option<unsafe extern "C" fn(*mut c_void, usize, *mut usize, *mut usize) -> CuResultCode>,
+    func_set_attribute: unsafe extern "C" fn(*mut c_void, c_int, c_int) -> CuResultCode,
     mem_alloc: unsafe extern "C" fn(*mut u64, usize) -> CuResultCode,
     mem_free: unsafe extern "C" fn(u64) -> CuResultCode,
     memcpy_htod: unsafe extern "C" fn(u64, *const c_void, usize) -> CuResultCode,
@@ -325,6 +326,7 @@ impl GpuBackend {
                 module_get_function: sym(&lib, b"cuModuleGetFunction\0")?,
                 module_unload: sym(&lib, b"cuModuleUnload\0")?,
                 func_get_param_info: sym(&lib, b"cuFuncGetParamInfo\0").ok(),
+                func_set_attribute: sym(&lib, b"cuFuncSetAttribute\0")?,
                 mem_alloc: sym(&lib, b"cuMemAlloc_v2\0")?,
                 mem_free: sym(&lib, b"cuMemFree_v2\0")?,
                 memcpy_htod: sym(&lib, b"cuMemcpyHtoD_v2\0")?,
@@ -502,6 +504,9 @@ impl Backend for GpuBackend {
             }
         }
         Ok(sizes)
+    }
+    fn func_set_attribute(&mut self, function: u64, attrib: i32, value: i32) -> CuResult<()> {
+        unsafe { chk((self.func_set_attribute)(function as *mut c_void, attrib, value)) }
     }
     fn mem_alloc(&mut self, bytes: u64) -> CuResult<u64> {
         let mut dptr: u64 = 0;

--- a/crates/smolvm-cuda/src/host/gpu.rs
+++ b/crates/smolvm-cuda/src/host/gpu.rs
@@ -597,6 +597,12 @@ impl Backend for GpuBackend {
         self.guest_ram = regions;
     }
 
+    fn gpa_to_hva(&mut self, gpa: u64, len: u64) -> Option<u64> {
+        self.guest_ram.iter().find_map(|&(gs, hva, rlen)| {
+            (gpa >= gs && gpa.checked_add(len)? <= gs + rlen).then(|| hva + (gpa - gs))
+        })
+    }
+
     fn memcpy_gpa_htod(&mut self, dptr: u64, segments: &[(u64, u64)], stream: u64) -> CuResult<()> {
         if self.guest_ram.is_empty() {
             return Err(super::CUDA_ERROR_NOT_FOUND);

--- a/crates/smolvm-cuda/src/host/gpu.rs
+++ b/crates/smolvm-cuda/src/host/gpu.rs
@@ -1082,7 +1082,6 @@ impl CudnnBackend {
         fn handle_bearing(ty: i32) -> bool {
             matches!(ty, 0 | 6 | 15)
         }
-        const TYPE_BACKEND_DESCRIPTOR: i32 = 15;
         let rd_u64 = |a: &[u8], o: usize| u64::from_le_bytes(a[o..o + 8].try_into().unwrap());
         let rd_i32 = |a: &[u8], o: usize| i32::from_le_bytes(a[o..o + 4].try_into().unwrap());
         let rd_i64 = |a: &[u8], o: usize| i64::from_le_bytes(a[o..o + 8].try_into().unwrap());

--- a/crates/smolvm-cuda/src/host/gpu.rs
+++ b/crates/smolvm-cuda/src/host/gpu.rs
@@ -85,6 +85,7 @@ pub struct GpuBackend {
     stream_create: unsafe extern "C" fn(*mut *mut c_void, c_uint) -> CuResultCode,
     // CUDA graphs (capture on the real driver; replay = one launch).
     stream_begin_capture: unsafe extern "C" fn(*mut c_void, c_int) -> CuResultCode,
+    thread_exchange_capture_mode: unsafe extern "C" fn(*mut c_int) -> CuResultCode,
     stream_end_capture: unsafe extern "C" fn(*mut c_void, *mut *mut c_void) -> CuResultCode,
     stream_get_capture_info:
         unsafe extern "C" fn(*mut c_void, *mut c_int, *mut u64) -> CuResultCode,
@@ -99,6 +100,9 @@ pub struct GpuBackend {
     memcpy_dtod_async: unsafe extern "C" fn(u64, u64, usize, *mut c_void) -> CuResultCode,
     stream_destroy: unsafe extern "C" fn(*mut c_void) -> CuResultCode,
     stream_synchronize: unsafe extern "C" fn(*mut c_void) -> CuResultCode,
+    stream_query: unsafe extern "C" fn(*mut c_void) -> CuResultCode,
+    stream_wait_event: unsafe extern "C" fn(*mut c_void, *mut c_void, c_uint) -> CuResultCode,
+    event_query: unsafe extern "C" fn(*mut c_void) -> CuResultCode,
     event_create: unsafe extern "C" fn(*mut *mut c_void, c_uint) -> CuResultCode,
     event_destroy: unsafe extern "C" fn(*mut c_void) -> CuResultCode,
     event_record: unsafe extern "C" fn(*mut c_void, *mut c_void) -> CuResultCode,
@@ -346,6 +350,7 @@ impl GpuBackend {
                     b"cuStreamBeginCapture_v2\0",
                     b"cuStreamBeginCapture\0",
                 )?,
+                thread_exchange_capture_mode: sym(&lib, b"cuThreadExchangeStreamCaptureMode\0")?,
                 stream_end_capture: sym(&lib, b"cuStreamEndCapture\0")?,
                 stream_get_capture_info: sym2(
                     &lib,
@@ -361,6 +366,9 @@ impl GpuBackend {
                 memcpy_dtod_async: sym2(&lib, b"cuMemcpyDtoDAsync_v2\0", b"cuMemcpyDtoDAsync\0")?,
                 stream_destroy: sym2(&lib, b"cuStreamDestroy_v2\0", b"cuStreamDestroy\0")?,
                 stream_synchronize: sym(&lib, b"cuStreamSynchronize\0")?,
+                stream_query: sym(&lib, b"cuStreamQuery\0")?,
+                stream_wait_event: sym(&lib, b"cuStreamWaitEvent\0")?,
+                event_query: sym(&lib, b"cuEventQuery\0")?,
                 event_create: sym(&lib, b"cuEventCreate\0")?,
                 event_destroy: sym2(&lib, b"cuEventDestroy_v2\0", b"cuEventDestroy\0")?,
                 event_record: sym(&lib, b"cuEventRecord\0")?,
@@ -506,7 +514,13 @@ impl Backend for GpuBackend {
         Ok(sizes)
     }
     fn func_set_attribute(&mut self, function: u64, attrib: i32, value: i32) -> CuResult<()> {
-        unsafe { chk((self.func_set_attribute)(function as *mut c_void, attrib, value)) }
+        unsafe {
+            chk((self.func_set_attribute)(
+                function as *mut c_void,
+                attrib,
+                value,
+            ))
+        }
     }
     fn mem_alloc(&mut self, bytes: u64) -> CuResult<u64> {
         let mut dptr: u64 = 0;
@@ -726,7 +740,15 @@ impl Backend for GpuBackend {
     fn stream_create(&mut self, flags: u32) -> CuResult<u64> {
         let mut s: *mut c_void = std::ptr::null_mut();
         unsafe { chk((self.stream_create)(&mut s, flags))? };
+        if std::env::var_os("SMOLVM_CUDA_HOST_OPLOG").is_some() {
+            eprintln!("[strm] host created {:#x}", s as u64);
+        }
         Ok(s as u64)
+    }
+    fn thread_exchange_capture_mode(&mut self, mode: i32) -> CuResult<i32> {
+        let mut m: c_int = mode;
+        unsafe { chk((self.thread_exchange_capture_mode)(&mut m))? };
+        Ok(m)
     }
     fn stream_begin_capture(&mut self, stream: u64, mode: i32) -> CuResult<()> {
         unsafe { chk((self.stream_begin_capture)(stream as *mut c_void, mode)) }
@@ -806,6 +828,22 @@ impl Backend for GpuBackend {
     }
     fn stream_destroy(&mut self, stream: u64) -> CuResult<()> {
         unsafe { chk((self.stream_destroy)(stream as *mut c_void)) }
+    }
+    fn stream_query(&mut self, stream: u64) -> CuResult<i32> {
+        // 600 (NOT_READY) is a status, not an error — return the raw code.
+        Ok(unsafe { (self.stream_query)(stream as *mut c_void) })
+    }
+    fn stream_wait_event(&mut self, stream: u64, event: u64, flags: u32) -> CuResult<()> {
+        unsafe {
+            chk((self.stream_wait_event)(
+                stream as *mut c_void,
+                event as *mut c_void,
+                flags,
+            ))
+        }
+    }
+    fn event_query(&mut self, event: u64) -> CuResult<i32> {
+        Ok(unsafe { (self.event_query)(event as *mut c_void) })
     }
     fn stream_synchronize(&mut self, stream: u64) -> CuResult<()> {
         unsafe { chk((self.stream_synchronize)(stream as *mut c_void)) }
@@ -961,8 +999,14 @@ impl Backend for GpuBackend {
         })
     }
 
-    fn lib_call(&mut self, lib: u8, func: u16, args: &[u8]) -> CuResult<(i32, Vec<u8>)> {
-        self.gen_lib_call(lib, func, args)
+    fn lib_call(
+        &mut self,
+        lib: u8,
+        func: u16,
+        args: &[u8],
+        streams: &std::collections::HashMap<u64, u64>,
+    ) -> CuResult<(i32, Vec<u8>)> {
+        self.gen_lib_call(lib, func, args, streams)
     }
 }
 
@@ -1219,6 +1263,7 @@ impl CublasLt {
         func: u16,
         args: &[u8],
         vh: &std::collections::HashMap<u64, u64>,
+        streams: &std::collections::HashMap<u64, u64>,
     ) -> (i32, Vec<u8>) {
         // sizeof(cublasLtMatmulHeuristicResult_t): algo[64] + workspaceSize(8)
         // + state(4) + wavesCount(4) + reserved[4](16) = 96 bytes.
@@ -1339,7 +1384,8 @@ impl CublasLt {
                 let algo_present = rd_u64(176) != 0;
                 let workspace = rd_u64(184) as *mut c_void;
                 let ws_size = rd_u64(192) as usize;
-                let stream = rd_u64(200) as *mut c_void;
+                // Session-minted stream id → real host stream (see stream_resolve).
+                let stream = stream_resolve(streams, rd_u64(200)) as *mut c_void;
                 let algo_ptr = if algo_present {
                     algo.as_ptr().cast()
                 } else {
@@ -1394,6 +1440,19 @@ fn vh_resolve(map: &std::collections::HashMap<u64, u64>, h: u64) -> u64 {
         map.get(&h).copied().unwrap_or(0)
     } else {
         h
+    }
+}
+
+/// Resolve a wire `cudaStream_t` against the session stream table. Streams are
+/// session-minted small ids (see `StreamCreate` in host.rs), so passing one
+/// straight to a real library would be read as a pointer and crash it. 0 (the
+/// default stream) and unmapped values (the legacy 0x1/0x2 stream constants)
+/// pass through.
+fn stream_resolve(map: &std::collections::HashMap<u64, u64>, s: u64) -> u64 {
+    if s == 0 {
+        0
+    } else {
+        map.get(&s).copied().unwrap_or(s)
     }
 }
 
@@ -1942,7 +2001,13 @@ impl GpuBackend {
     }
 
     /// Dispatch a generic `LibCall` to the code-generated handler for `lib`.
-    fn gen_lib_call(&mut self, lib: u8, func: u16, args: &[u8]) -> CuResult<(i32, Vec<u8>)> {
+    fn gen_lib_call(
+        &mut self,
+        lib: u8,
+        func: u16,
+        args: &[u8],
+        streams: &std::collections::HashMap<u64, u64>,
+    ) -> CuResult<(i32, Vec<u8>)> {
         match lib {
             LIB_CUBLAS => {
                 if self.cublas_gen.is_none() {
@@ -1954,11 +2019,12 @@ impl GpuBackend {
                         }
                     }
                 }
-                Ok(self
-                    .cublas_gen
-                    .as_ref()
-                    .unwrap()
-                    .dispatch(func, args, &mut self.vhandles))
+                Ok(self.cublas_gen.as_ref().unwrap().dispatch(
+                    func,
+                    args,
+                    &mut self.vhandles,
+                    streams,
+                ))
             }
             LIB_CUDNN => {
                 if self.cudnn_gen.is_none() {
@@ -1970,11 +2036,12 @@ impl GpuBackend {
                         }
                     }
                 }
-                Ok(self
-                    .cudnn_gen
-                    .as_ref()
-                    .unwrap()
-                    .dispatch(func, args, &mut self.vhandles))
+                Ok(self.cudnn_gen.as_ref().unwrap().dispatch(
+                    func,
+                    args,
+                    &mut self.vhandles,
+                    streams,
+                ))
             }
             LIB_CUDNN_BACKEND => {
                 if self.cudnn_backend.is_none() {
@@ -2006,7 +2073,7 @@ impl GpuBackend {
                     .cublaslt
                     .as_ref()
                     .unwrap()
-                    .dispatch(func, args, &self.vhandles))
+                    .dispatch(func, args, &self.vhandles, streams))
             }
             LIB_CUDNN_BN => {
                 if self.cudnn_bn.is_none() {

--- a/crates/smolvm-cuda/src/lib.rs
+++ b/crates/smolvm-cuda/src/lib.rs
@@ -12,6 +12,8 @@
 
 pub mod client;
 pub mod proto;
+/// Shared-memory command/completion rings (low-latency in-VM transport).
+pub mod ring;
 
 /// Shared-memory bulk-data channel (zero-copy memcpy). Linux-only.
 #[cfg(target_os = "linux")]

--- a/crates/smolvm-cuda/src/proto.rs
+++ b/crates/smolvm-cuda/src/proto.rs
@@ -237,11 +237,18 @@ pub enum Request {
     },
     MemcpyHtoD {
         dptr: u64,
+        /// Stream whose prior work must complete before the copy (0 = legacy
+        /// default). Guest `cudaMemcpyAsync` semantics: the copy is ordered
+        /// within this stream, and torch's pool streams are non-blocking, so
+        /// a NULL-stream copy would NOT wait for them.
+        stream: u64,
         data: Vec<u8>,
     },
     MemcpyDtoH {
         dptr: u64,
         bytes: u64,
+        /// See `MemcpyHtoD::stream`.
+        stream: u64,
     },
     MemcpyDtoD {
         dst: u64,
@@ -414,22 +421,30 @@ pub enum Request {
         dptr: u64,
         offset: u64,
         size: u64,
+        /// See `MemcpyHtoD::stream`.
+        stream: u64,
     },
     /// Zero-copy D2H: copy `size` bytes from `dptr` to shared-region `offset`.
     MemcpyShmDtoH {
         offset: u64,
         dptr: u64,
         size: u64,
+        /// See `MemcpyHtoD::stream`.
+        stream: u64,
     },
     /// Zero-copy H2D from guest RAM: gather `segments` (each `(gpa, len)`, in
     /// buffer order) and copy to `dptr`.
     MemcpyGpaHtoD {
         dptr: u64,
+        /// See `MemcpyHtoD::stream`.
+        stream: u64,
         segments: Vec<(u64, u64)>,
     },
     /// Zero-copy D2H to guest RAM: copy from `dptr` and scatter into `segments`.
     MemcpyGpaDtoH {
         dptr: u64,
+        /// See `MemcpyHtoD::stream`.
+        stream: u64,
         segments: Vec<(u64, u64)>,
     },
 }
@@ -653,15 +668,21 @@ pub fn encode_request(req: &Request) -> Vec<u8> {
             w_u8(&mut b, Op::MemFree as u8);
             w_u64(&mut b, *dptr);
         }
-        Request::MemcpyHtoD { dptr, data } => {
+        Request::MemcpyHtoD { dptr, stream, data } => {
             w_u8(&mut b, Op::MemcpyHtoD as u8);
             w_u64(&mut b, *dptr);
+            w_u64(&mut b, *stream);
             w_bytes(&mut b, data);
         }
-        Request::MemcpyDtoH { dptr, bytes } => {
+        Request::MemcpyDtoH {
+            dptr,
+            bytes,
+            stream,
+        } => {
             w_u8(&mut b, Op::MemcpyDtoH as u8);
             w_u64(&mut b, *dptr);
             w_u64(&mut b, *bytes);
+            w_u64(&mut b, *stream);
         }
         Request::MemcpyDtoD { dst, src, bytes } => {
             w_u8(&mut b, Op::MemcpyDtoD as u8);
@@ -900,26 +921,48 @@ pub fn encode_request(req: &Request) -> Vec<u8> {
             w_u32(&mut b, *func as u32);
             w_bytes(&mut b, args);
         }
-        Request::MemcpyShmHtoD { dptr, offset, size } => {
+        Request::MemcpyShmHtoD {
+            dptr,
+            offset,
+            size,
+            stream,
+        } => {
             w_u8(&mut b, Op::MemcpyShmHtoD as u8);
             w_u64(&mut b, *dptr);
             w_u64(&mut b, *offset);
             w_u64(&mut b, *size);
+            w_u64(&mut b, *stream);
         }
-        Request::MemcpyShmDtoH { offset, dptr, size } => {
+        Request::MemcpyShmDtoH {
+            offset,
+            dptr,
+            size,
+            stream,
+        } => {
             w_u8(&mut b, Op::MemcpyShmDtoH as u8);
             w_u64(&mut b, *offset);
             w_u64(&mut b, *dptr);
             w_u64(&mut b, *size);
+            w_u64(&mut b, *stream);
         }
-        Request::MemcpyGpaHtoD { dptr, segments } => {
+        Request::MemcpyGpaHtoD {
+            dptr,
+            stream,
+            segments,
+        } => {
             w_u8(&mut b, Op::MemcpyGpaHtoD as u8);
             w_u64(&mut b, *dptr);
+            w_u64(&mut b, *stream);
             w_gpa_segments(&mut b, segments);
         }
-        Request::MemcpyGpaDtoH { dptr, segments } => {
+        Request::MemcpyGpaDtoH {
+            dptr,
+            stream,
+            segments,
+        } => {
             w_u8(&mut b, Op::MemcpyGpaDtoH as u8);
             w_u64(&mut b, *dptr);
+            w_u64(&mut b, *stream);
             w_gpa_segments(&mut b, segments);
         }
     }
@@ -968,11 +1011,13 @@ pub fn decode_request(payload: &[u8]) -> io::Result<Request> {
         Op::MemFree => Request::MemFree { dptr: c.u64()? },
         Op::MemcpyHtoD => Request::MemcpyHtoD {
             dptr: c.u64()?,
+            stream: c.u64()?,
             data: c.bytes()?,
         },
         Op::MemcpyDtoH => Request::MemcpyDtoH {
             dptr: c.u64()?,
             bytes: c.u64()?,
+            stream: c.u64()?,
         },
         Op::MemcpyDtoD => Request::MemcpyDtoD {
             dst: c.u64()?,
@@ -1104,18 +1149,22 @@ pub fn decode_request(payload: &[u8]) -> io::Result<Request> {
             dptr: c.u64()?,
             offset: c.u64()?,
             size: c.u64()?,
+            stream: c.u64()?,
         },
         Op::MemcpyShmDtoH => Request::MemcpyShmDtoH {
             offset: c.u64()?,
             dptr: c.u64()?,
             size: c.u64()?,
+            stream: c.u64()?,
         },
         Op::MemcpyGpaHtoD => Request::MemcpyGpaHtoD {
             dptr: c.u64()?,
+            stream: c.u64()?,
             segments: r_gpa_segments(&mut c)?,
         },
         Op::MemcpyGpaDtoH => Request::MemcpyGpaDtoH {
             dptr: c.u64()?,
+            stream: c.u64()?,
             segments: r_gpa_segments(&mut c)?,
         },
     })
@@ -1253,11 +1302,13 @@ mod tests {
         roundtrip(Request::MemFree { dptr: 0x7f00_0000 });
         roundtrip(Request::MemcpyHtoD {
             dptr: 0x7f00_0000,
+            stream: 0x7001,
             data: vec![1, 2, 3, 4],
         });
         roundtrip(Request::MemcpyDtoH {
             dptr: 0x7f00_0000,
             bytes: 16,
+            stream: 0x7001,
         });
         roundtrip(Request::LaunchKernel {
             function: 7,

--- a/crates/smolvm-cuda/src/proto.rs
+++ b/crates/smolvm-cuda/src/proto.rs
@@ -18,6 +18,15 @@ use std::io::{self, Read, Write};
 /// Maximum accepted message payload (256 MiB) — bounds a hostile/length field.
 pub const MAX_MSG: usize = 256 * 1024 * 1024;
 
+/// First byte of a *quiet* request frame: the server executes the wrapped
+/// request (encoded normally after this byte) and sends **no response**; the
+/// first failing status is held until the next [`FENCE_OP`]. Chosen outside
+/// the [`Op`] value space.
+pub const QUIET_PREFIX: u8 = 0x7F;
+/// Single-byte fence request: replies with (and clears) the first failing
+/// status among quiet requests since the previous fence.
+pub const FENCE_OP: u8 = 0x7E;
+
 /// Request opcodes. Stable wire values — append only.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]

--- a/crates/smolvm-cuda/src/proto.rs
+++ b/crates/smolvm-cuda/src/proto.rs
@@ -63,6 +63,20 @@ pub enum Op {
     EventRecord = 0x72,
     EventSynchronize = 0x73,
     EventElapsedTime = 0x74,
+    // CUDA graphs: capture forwarded to the host driver (which records the
+    // stream's work into a graph), replayed with a single GraphLaunch.
+    StreamBeginCapture = 0xC0,
+    StreamEndCapture = 0xC1,
+    GraphInstantiate = 0xC2,
+    GraphLaunch = 0xC3,
+    GraphExecDestroy = 0xC4,
+    GraphDestroy = 0xC5,
+    StreamCaptureInfo = 0xC6,
+    // Stream-ordered variants (capture-safe: the sync forms would invalidate
+    // an active capture and cannot be recorded into a graph).
+    MemsetD8Async = 0xC7,
+    MemcpyDtoDAsync = 0xC8,
+    GraphGetNodes = 0xC9,
     // nvcomp (forward-to-host-lib): batched Deflate decompression. Device-pointer
     // args are real host device addresses, forwarded by value.
     NvcompDeflateTempSize = 0x80,
@@ -116,6 +130,16 @@ impl Op {
             0x36 => Op::MemGetInfo,
             0x40 => Op::LaunchKernel,
             0x50 => Op::CtxSynchronize,
+            0xC0 => Op::StreamBeginCapture,
+            0xC1 => Op::StreamEndCapture,
+            0xC2 => Op::GraphInstantiate,
+            0xC3 => Op::GraphLaunch,
+            0xC4 => Op::GraphExecDestroy,
+            0xC5 => Op::GraphDestroy,
+            0xC6 => Op::StreamCaptureInfo,
+            0xC7 => Op::MemsetD8Async,
+            0xC8 => Op::MemcpyDtoDAsync,
+            0xC9 => Op::GraphGetNodes,
             0x60 => Op::StreamCreate,
             0x61 => Op::StreamDestroy,
             0x62 => Op::StreamSynchronize,
@@ -224,6 +248,44 @@ pub enum Request {
         params: Vec<Vec<u8>>,
     },
     CtxSynchronize,
+    StreamBeginCapture {
+        stream: u64,
+        mode: i32,
+    },
+    StreamEndCapture {
+        stream: u64,
+    },
+    GraphInstantiate {
+        graph: u64,
+    },
+    GraphLaunch {
+        graph_exec: u64,
+        stream: u64,
+    },
+    GraphExecDestroy {
+        graph_exec: u64,
+    },
+    GraphDestroy {
+        graph: u64,
+    },
+    StreamCaptureInfo {
+        stream: u64,
+    },
+    GraphGetNodes {
+        graph: u64,
+    },
+    MemsetD8Async {
+        dptr: u64,
+        value: u8,
+        bytes: u64,
+        stream: u64,
+    },
+    MemcpyDtoDAsync {
+        dst: u64,
+        src: u64,
+        bytes: u64,
+        stream: u64,
+    },
     StreamCreate {
         flags: u32,
     },
@@ -583,6 +645,64 @@ pub fn encode_request(req: &Request) -> Vec<u8> {
             }
         }
         Request::CtxSynchronize => w_u8(&mut b, Op::CtxSynchronize as u8),
+        Request::StreamBeginCapture { stream, mode } => {
+            w_u8(&mut b, Op::StreamBeginCapture as u8);
+            w_u64(&mut b, *stream);
+            w_i32(&mut b, *mode);
+        }
+        Request::StreamEndCapture { stream } => {
+            w_u8(&mut b, Op::StreamEndCapture as u8);
+            w_u64(&mut b, *stream);
+        }
+        Request::GraphInstantiate { graph } => {
+            w_u8(&mut b, Op::GraphInstantiate as u8);
+            w_u64(&mut b, *graph);
+        }
+        Request::GraphLaunch { graph_exec, stream } => {
+            w_u8(&mut b, Op::GraphLaunch as u8);
+            w_u64(&mut b, *graph_exec);
+            w_u64(&mut b, *stream);
+        }
+        Request::GraphExecDestroy { graph_exec } => {
+            w_u8(&mut b, Op::GraphExecDestroy as u8);
+            w_u64(&mut b, *graph_exec);
+        }
+        Request::GraphDestroy { graph } => {
+            w_u8(&mut b, Op::GraphDestroy as u8);
+            w_u64(&mut b, *graph);
+        }
+        Request::StreamCaptureInfo { stream } => {
+            w_u8(&mut b, Op::StreamCaptureInfo as u8);
+            w_u64(&mut b, *stream);
+        }
+        Request::GraphGetNodes { graph } => {
+            w_u8(&mut b, Op::GraphGetNodes as u8);
+            w_u64(&mut b, *graph);
+        }
+        Request::MemsetD8Async {
+            dptr,
+            value,
+            bytes,
+            stream,
+        } => {
+            w_u8(&mut b, Op::MemsetD8Async as u8);
+            w_u64(&mut b, *dptr);
+            w_u8(&mut b, *value);
+            w_u64(&mut b, *bytes);
+            w_u64(&mut b, *stream);
+        }
+        Request::MemcpyDtoDAsync {
+            dst,
+            src,
+            bytes,
+            stream,
+        } => {
+            w_u8(&mut b, Op::MemcpyDtoDAsync as u8);
+            w_u64(&mut b, *dst);
+            w_u64(&mut b, *src);
+            w_u64(&mut b, *bytes);
+            w_u64(&mut b, *stream);
+        }
         Request::StreamCreate { flags } => {
             w_u8(&mut b, Op::StreamCreate as u8);
             w_u32(&mut b, *flags);
@@ -804,6 +924,34 @@ pub fn decode_request(payload: &[u8]) -> io::Result<Request> {
             }
         }
         Op::CtxSynchronize => Request::CtxSynchronize,
+        Op::StreamBeginCapture => Request::StreamBeginCapture {
+            stream: c.u64()?,
+            mode: c.i32()?,
+        },
+        Op::StreamEndCapture => Request::StreamEndCapture { stream: c.u64()? },
+        Op::GraphInstantiate => Request::GraphInstantiate { graph: c.u64()? },
+        Op::GraphLaunch => Request::GraphLaunch {
+            graph_exec: c.u64()?,
+            stream: c.u64()?,
+        },
+        Op::GraphExecDestroy => Request::GraphExecDestroy {
+            graph_exec: c.u64()?,
+        },
+        Op::GraphDestroy => Request::GraphDestroy { graph: c.u64()? },
+        Op::StreamCaptureInfo => Request::StreamCaptureInfo { stream: c.u64()? },
+        Op::GraphGetNodes => Request::GraphGetNodes { graph: c.u64()? },
+        Op::MemsetD8Async => Request::MemsetD8Async {
+            dptr: c.u64()?,
+            value: c.u8()?,
+            bytes: c.u64()?,
+            stream: c.u64()?,
+        },
+        Op::MemcpyDtoDAsync => Request::MemcpyDtoDAsync {
+            dst: c.u64()?,
+            src: c.u64()?,
+            bytes: c.u64()?,
+            stream: c.u64()?,
+        },
         Op::StreamCreate => Request::StreamCreate { flags: c.u32()? },
         Op::StreamDestroy => Request::StreamDestroy { stream: c.u64()? },
         Op::StreamSynchronize => Request::StreamSynchronize { stream: c.u64()? },
@@ -936,6 +1084,9 @@ pub fn decode_response(op: Op, payload: &[u8]) -> io::Result<(i32, Response)> {
         Op::CtxCreate | Op::PrimaryCtxRetain => Response::Handle(c.u64()?),
         Op::ModuleLoadData | Op::ModuleGetFunction => Response::Handle(c.u64()?),
         Op::StreamCreate | Op::EventCreate => Response::Handle(c.u64()?),
+        Op::StreamEndCapture | Op::GraphInstantiate => Response::Handle(c.u64()?),
+        Op::GraphGetNodes => Response::Bytes(c.u64()?),
+        Op::StreamCaptureInfo => Response::Pair(c.u64()?, c.u64()?),
         Op::MemAlloc => Response::Dptr(c.u64()?),
         Op::MemcpyDtoH | Op::DeviceGetUuid | Op::FuncGetParamInfo => Response::Data(c.bytes()?),
         Op::MemGetInfo => Response::Pair(c.u64()?, c.u64()?),
@@ -947,6 +1098,12 @@ pub fn decode_response(op: Op, payload: &[u8]) -> io::Result<(i32, Response)> {
         Op::LibCall => Response::LibResult(c.i32()?, c.bytes()?),
         Op::EventElapsedTime => Response::Millis(f32::from_bits(c.u32()?)),
         Op::Init
+        | Op::StreamBeginCapture
+        | Op::GraphLaunch
+        | Op::GraphExecDestroy
+        | Op::GraphDestroy
+        | Op::MemsetD8Async
+        | Op::MemcpyDtoDAsync
         | Op::CtxDestroy
         | Op::PrimaryCtxRelease
         | Op::ModuleUnload

--- a/crates/smolvm-cuda/src/proto.rs
+++ b/crates/smolvm-cuda/src/proto.rs
@@ -111,6 +111,16 @@ pub enum Op {
     /// completion ring, and a bounce buffer for oversized responses. After
     /// the host acks, the socket carries only doorbell bytes.
     RingSetup = 0xD0,
+    // CUDA VMM (virtual memory management) — torch's expandable-segments
+    // allocator. Control-plane ops, all synchronous.
+    MemAddressReserve = 0xE0,
+    MemCreate = 0xE1,
+    MemMap = 0xE2,
+    MemSetAccess = 0xE3,
+    MemUnmap = 0xE4,
+    MemRelease = 0xE5,
+    MemAddressFree = 0xE6,
+    MemGetAllocationGranularity = 0xE7,
 }
 
 impl Op {
@@ -175,6 +185,14 @@ impl Op {
             0xB2 => Op::MemcpyGpaHtoD,
             0xB3 => Op::MemcpyGpaDtoH,
             0xD0 => Op::RingSetup,
+            0xE0 => Op::MemAddressReserve,
+            0xE1 => Op::MemCreate,
+            0xE2 => Op::MemMap,
+            0xE3 => Op::MemSetAccess,
+            0xE4 => Op::MemUnmap,
+            0xE5 => Op::MemRelease,
+            0xE6 => Op::MemAddressFree,
+            0xE7 => Op::MemGetAllocationGranularity,
             _ => return None,
         })
     }
@@ -461,6 +479,44 @@ pub enum Request {
         req_pages: Vec<u64>,
         resp_pages: Vec<u64>,
         bounce_pages: Vec<u64>,
+    },
+    /// VMM: reserve a virtual address range (no backing).
+    MemAddressReserve {
+        size: u64,
+        align: u64,
+    },
+    /// VMM: create a physical allocation on `device`.
+    MemCreate {
+        size: u64,
+        device: i32,
+    },
+    /// VMM: back `va` with `handle` at `offset`.
+    MemMap {
+        va: u64,
+        size: u64,
+        offset: u64,
+        handle: u64,
+    },
+    /// VMM: grant `device` read/write access to the mapped range.
+    MemSetAccess {
+        va: u64,
+        size: u64,
+        device: i32,
+    },
+    MemUnmap {
+        va: u64,
+        size: u64,
+    },
+    MemRelease {
+        handle: u64,
+    },
+    MemAddressFree {
+        va: u64,
+        size: u64,
+    },
+    MemGetAllocationGranularity {
+        device: i32,
+        flags: u32,
     },
 }
 
@@ -995,6 +1051,53 @@ pub fn encode_request(req: &Request) -> Vec<u8> {
                 }
             }
         }
+        Request::MemAddressReserve { size, align } => {
+            w_u8(&mut b, Op::MemAddressReserve as u8);
+            w_u64(&mut b, *size);
+            w_u64(&mut b, *align);
+        }
+        Request::MemCreate { size, device } => {
+            w_u8(&mut b, Op::MemCreate as u8);
+            w_u64(&mut b, *size);
+            w_i32(&mut b, *device);
+        }
+        Request::MemMap {
+            va,
+            size,
+            offset,
+            handle,
+        } => {
+            w_u8(&mut b, Op::MemMap as u8);
+            w_u64(&mut b, *va);
+            w_u64(&mut b, *size);
+            w_u64(&mut b, *offset);
+            w_u64(&mut b, *handle);
+        }
+        Request::MemSetAccess { va, size, device } => {
+            w_u8(&mut b, Op::MemSetAccess as u8);
+            w_u64(&mut b, *va);
+            w_u64(&mut b, *size);
+            w_i32(&mut b, *device);
+        }
+        Request::MemUnmap { va, size } => {
+            w_u8(&mut b, Op::MemUnmap as u8);
+            w_u64(&mut b, *va);
+            w_u64(&mut b, *size);
+        }
+        Request::MemRelease { handle } => {
+            w_u8(&mut b, Op::MemRelease as u8);
+            w_u64(&mut b, *handle);
+        }
+        Request::MemAddressFree { va, size } => {
+            w_u8(&mut b, Op::MemAddressFree as u8);
+            w_u64(&mut b, *va);
+            w_u64(&mut b, *size);
+        }
+        Request::MemGetAllocationGranularity { device, flags } => {
+            w_u8(&mut b, Op::MemGetAllocationGranularity as u8);
+            w_i32(&mut b, *device);
+            w_u32(&mut b, *flags);
+        }
     }
     b
 }
@@ -1215,6 +1318,38 @@ pub fn decode_request(payload: &[u8]) -> io::Result<Request> {
                 bounce_pages,
             }
         }
+        Op::MemAddressReserve => Request::MemAddressReserve {
+            size: c.u64()?,
+            align: c.u64()?,
+        },
+        Op::MemCreate => Request::MemCreate {
+            size: c.u64()?,
+            device: c.i32()?,
+        },
+        Op::MemMap => Request::MemMap {
+            va: c.u64()?,
+            size: c.u64()?,
+            offset: c.u64()?,
+            handle: c.u64()?,
+        },
+        Op::MemSetAccess => Request::MemSetAccess {
+            va: c.u64()?,
+            size: c.u64()?,
+            device: c.i32()?,
+        },
+        Op::MemUnmap => Request::MemUnmap {
+            va: c.u64()?,
+            size: c.u64()?,
+        },
+        Op::MemRelease => Request::MemRelease { handle: c.u64()? },
+        Op::MemAddressFree => Request::MemAddressFree {
+            va: c.u64()?,
+            size: c.u64()?,
+        },
+        Op::MemGetAllocationGranularity => Request::MemGetAllocationGranularity {
+            device: c.i32()?,
+            flags: c.u32()?,
+        },
     })
 }
 
@@ -1317,7 +1452,15 @@ pub fn decode_response(op: Op, payload: &[u8]) -> io::Result<(i32, Response)> {
         | Op::MemcpyShmDtoH
         | Op::MemcpyGpaHtoD
         | Op::MemcpyGpaDtoH
-        | Op::RingSetup => Response::Ok,
+        | Op::RingSetup
+        | Op::MemMap
+        | Op::MemSetAccess
+        | Op::MemUnmap
+        | Op::MemRelease
+        | Op::MemAddressFree => Response::Ok,
+        Op::MemAddressReserve => Response::Dptr(c.u64()?),
+        Op::MemCreate => Response::Handle(c.u64()?),
+        Op::MemGetAllocationGranularity => Response::Bytes(c.u64()?),
     };
     Ok((status, body))
 }

--- a/crates/smolvm-cuda/src/proto.rs
+++ b/crates/smolvm-cuda/src/proto.rs
@@ -106,6 +106,11 @@ pub enum Op {
     /// guest memory directly (one DMA if contiguous, gather otherwise).
     MemcpyGpaHtoD = 0xB2,
     MemcpyGpaDtoH = 0xB3,
+    /// Switch this connection to shared-memory rings (see `crate::ring`):
+    /// the payload names the guest-physical pages of the request ring, the
+    /// completion ring, and a bounce buffer for oversized responses. After
+    /// the host acks, the socket carries only doorbell bytes.
+    RingSetup = 0xD0,
 }
 
 impl Op {
@@ -169,6 +174,7 @@ impl Op {
             0xB1 => Op::MemcpyShmDtoH,
             0xB2 => Op::MemcpyGpaHtoD,
             0xB3 => Op::MemcpyGpaDtoH,
+            0xD0 => Op::RingSetup,
             _ => return None,
         })
     }
@@ -447,6 +453,15 @@ pub enum Request {
         stream: u64,
         segments: Vec<(u64, u64)>,
     },
+    /// Switch to shared-memory rings. Page lists are guest-physical addresses
+    /// of `page_size`-sized pages; `bounce` receives responses too large for
+    /// an inline completion record.
+    RingSetup {
+        page_size: u32,
+        req_pages: Vec<u64>,
+        resp_pages: Vec<u64>,
+        bounce_pages: Vec<u64>,
+    },
 }
 
 /// A decoded successful response body (the `status == 0` payload).
@@ -493,12 +508,12 @@ fn w_str(b: &mut Vec<u8>, v: &str) {
 /// Cursor-based reader over an in-memory payload. Every accessor is
 /// bounds-checked so a malformed/hostile message yields `InvalidData`, never a
 /// panic.
-struct Cur<'a> {
+pub(crate) struct Cur<'a> {
     b: &'a [u8],
     p: usize,
 }
 impl<'a> Cur<'a> {
-    fn new(b: &'a [u8]) -> Self {
+    pub(crate) fn new(b: &'a [u8]) -> Self {
         Cur { b, p: 0 }
     }
     fn take(&mut self, n: usize) -> io::Result<&'a [u8]> {
@@ -516,10 +531,10 @@ impl<'a> Cur<'a> {
     fn i32(&mut self) -> io::Result<i32> {
         Ok(i32::from_le_bytes(self.take(4)?.try_into().unwrap()))
     }
-    fn u32(&mut self) -> io::Result<u32> {
+    pub(crate) fn u32(&mut self) -> io::Result<u32> {
         Ok(u32::from_le_bytes(self.take(4)?.try_into().unwrap()))
     }
-    fn u64(&mut self) -> io::Result<u64> {
+    pub(crate) fn u64(&mut self) -> io::Result<u64> {
         Ok(u64::from_le_bytes(self.take(8)?.try_into().unwrap()))
     }
     fn bytes(&mut self) -> io::Result<Vec<u8>> {
@@ -965,6 +980,21 @@ pub fn encode_request(req: &Request) -> Vec<u8> {
             w_u64(&mut b, *stream);
             w_gpa_segments(&mut b, segments);
         }
+        Request::RingSetup {
+            page_size,
+            req_pages,
+            resp_pages,
+            bounce_pages,
+        } => {
+            w_u8(&mut b, Op::RingSetup as u8);
+            w_u32(&mut b, *page_size);
+            for pages in [req_pages, resp_pages, bounce_pages] {
+                w_u32(&mut b, pages.len() as u32);
+                for gpa in pages {
+                    w_u64(&mut b, *gpa);
+                }
+            }
+        }
     }
     b
 }
@@ -1167,6 +1197,24 @@ pub fn decode_request(payload: &[u8]) -> io::Result<Request> {
             stream: c.u64()?,
             segments: r_gpa_segments(&mut c)?,
         },
+        Op::RingSetup => {
+            let page_size = c.u32()?;
+            let mut lists = [const { Vec::new() }; 3];
+            for list in lists.iter_mut() {
+                let n = c.u32()? as usize;
+                list.reserve(n.min(1 << 16));
+                for _ in 0..n {
+                    list.push(c.u64()?);
+                }
+            }
+            let [req_pages, resp_pages, bounce_pages] = lists;
+            Request::RingSetup {
+                page_size,
+                req_pages,
+                resp_pages,
+                bounce_pages,
+            }
+        }
     })
 }
 
@@ -1268,7 +1316,8 @@ pub fn decode_response(op: Op, payload: &[u8]) -> io::Result<(i32, Response)> {
         | Op::MemcpyShmHtoD
         | Op::MemcpyShmDtoH
         | Op::MemcpyGpaHtoD
-        | Op::MemcpyGpaDtoH => Response::Ok,
+        | Op::MemcpyGpaDtoH
+        | Op::RingSetup => Response::Ok,
     };
     Ok((status, body))
 }

--- a/crates/smolvm-cuda/src/proto.rs
+++ b/crates/smolvm-cuda/src/proto.rs
@@ -46,6 +46,7 @@ pub enum Op {
     ModuleGetFunction = 0x21,
     ModuleUnload = 0x22,
     FuncGetParamInfo = 0x23,
+    FuncSetAttribute = 0x24,
     MemAlloc = 0x30,
     MemFree = 0x31,
     MemcpyHtoD = 0x32,
@@ -121,6 +122,7 @@ impl Op {
             0x21 => Op::ModuleGetFunction,
             0x22 => Op::ModuleUnload,
             0x23 => Op::FuncGetParamInfo,
+            0x24 => Op::FuncSetAttribute,
             0x30 => Op::MemAlloc,
             0x31 => Op::MemFree,
             0x32 => Op::MemcpyHtoD,
@@ -209,6 +211,15 @@ pub enum Request {
     /// order — what a generic client needs to serialize `kernelParams` blobs.
     FuncGetParamInfo {
         function: u64,
+    },
+    /// Raise/set a `CUfunction_attribute` on the host function — chiefly
+    /// `CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES`, which Triton/vLLM
+    /// kernels needing >48 KiB shared memory must opt into before launching, or
+    /// the launch fails with `INVALID_VALUE`.
+    FuncSetAttribute {
+        function: u64,
+        attrib: i32,
+        value: i32,
     },
     MemAlloc {
         bytes: u64,
@@ -590,6 +601,16 @@ pub fn encode_request(req: &Request) -> Vec<u8> {
             w_u8(&mut b, Op::FuncGetParamInfo as u8);
             w_u64(&mut b, *function);
         }
+        Request::FuncSetAttribute {
+            function,
+            attrib,
+            value,
+        } => {
+            w_u8(&mut b, Op::FuncSetAttribute as u8);
+            w_u64(&mut b, *function);
+            w_i32(&mut b, *attrib);
+            w_i32(&mut b, *value);
+        }
         Request::MemAlloc { bytes } => {
             w_u8(&mut b, Op::MemAlloc as u8);
             w_u64(&mut b, *bytes);
@@ -882,6 +903,11 @@ pub fn decode_request(payload: &[u8]) -> io::Result<Request> {
         },
         Op::ModuleUnload => Request::ModuleUnload { module: c.u64()? },
         Op::FuncGetParamInfo => Request::FuncGetParamInfo { function: c.u64()? },
+        Op::FuncSetAttribute => Request::FuncSetAttribute {
+            function: c.u64()?,
+            attrib: c.i32()?,
+            value: c.i32()?,
+        },
         Op::MemAlloc => Request::MemAlloc { bytes: c.u64()? },
         Op::MemFree => Request::MemFree { dptr: c.u64()? },
         Op::MemcpyHtoD => Request::MemcpyHtoD {
@@ -1107,6 +1133,7 @@ pub fn decode_response(op: Op, payload: &[u8]) -> io::Result<(i32, Response)> {
         | Op::CtxDestroy
         | Op::PrimaryCtxRelease
         | Op::ModuleUnload
+        | Op::FuncSetAttribute
         | Op::MemFree
         | Op::MemcpyHtoD
         | Op::MemcpyDtoD
@@ -1191,6 +1218,11 @@ mod tests {
         roundtrip(Request::PrimaryCtxRelease { device: 0 });
         roundtrip(Request::ModuleUnload { module: 7 });
         roundtrip(Request::FuncGetParamInfo { function: 9 });
+        roundtrip(Request::FuncSetAttribute {
+            function: 9,
+            attrib: 8,
+            value: 73728,
+        });
         roundtrip(Request::MemcpyDtoD {
             dst: 0x2000,
             src: 0x1000,

--- a/crates/smolvm-cuda/src/proto.rs
+++ b/crates/smolvm-cuda/src/proto.rs
@@ -59,11 +59,14 @@ pub enum Op {
     StreamCreate = 0x60,
     StreamDestroy = 0x61,
     StreamSynchronize = 0x62,
+    StreamQuery = 0x63,
     EventCreate = 0x70,
     EventDestroy = 0x71,
     EventRecord = 0x72,
     EventSynchronize = 0x73,
     EventElapsedTime = 0x74,
+    StreamWaitEvent = 0x75,
+    EventQuery = 0x76,
     // CUDA graphs: capture forwarded to the host driver (which records the
     // stream's work into a graph), replayed with a single GraphLaunch.
     StreamBeginCapture = 0xC0,
@@ -78,6 +81,7 @@ pub enum Op {
     MemsetD8Async = 0xC7,
     MemcpyDtoDAsync = 0xC8,
     GraphGetNodes = 0xC9,
+    ThreadExchangeCaptureMode = 0xCA,
     // nvcomp (forward-to-host-lib): batched Deflate decompression. Device-pointer
     // args are real host device addresses, forwarded by value.
     NvcompDeflateTempSize = 0x80,
@@ -142,14 +146,18 @@ impl Op {
             0xC7 => Op::MemsetD8Async,
             0xC8 => Op::MemcpyDtoDAsync,
             0xC9 => Op::GraphGetNodes,
+            0xCA => Op::ThreadExchangeCaptureMode,
             0x60 => Op::StreamCreate,
             0x61 => Op::StreamDestroy,
             0x62 => Op::StreamSynchronize,
+            0x63 => Op::StreamQuery,
             0x70 => Op::EventCreate,
             0x71 => Op::EventDestroy,
             0x72 => Op::EventRecord,
             0x73 => Op::EventSynchronize,
             0x74 => Op::EventElapsedTime,
+            0x75 => Op::StreamWaitEvent,
+            0x76 => Op::EventQuery,
             0x80 => Op::NvcompDeflateTempSize,
             0x81 => Op::NvcompDeflateDecompress,
             0x90 => Op::CublasCreate,
@@ -285,6 +293,14 @@ pub enum Request {
     GraphGetNodes {
         graph: u64,
     },
+    /// `cuThreadExchangeStreamCaptureMode` on the serving thread. PyTorch's
+    /// allocator wraps its capture-time `cudaMalloc` in a thread-local
+    /// relaxed-mode guard; each connection is served by one host thread, so
+    /// forwarding the exchange preserves the per-thread semantics. Returns the
+    /// previous mode.
+    ThreadExchangeCaptureMode {
+        mode: i32,
+    },
     MemsetD8Async {
         dptr: u64,
         value: u8,
@@ -305,6 +321,24 @@ pub enum Request {
     },
     StreamSynchronize {
         stream: u64,
+    },
+    /// `cuStreamQuery`: 0 = all work complete, 600 = not ready (raw code in
+    /// the Count response; the guest surfaces it as its own return).
+    StreamQuery {
+        stream: u64,
+    },
+    /// Make `stream` wait for `event` — the cross-stream ordering edge. Once
+    /// work really runs on side streams (and graph capture records these as
+    /// graph dependencies), dropping it means racy replays.
+    StreamWaitEvent {
+        stream: u64,
+        event: u64,
+        flags: u32,
+    },
+    /// `cuEventQuery`: 0 = complete, 600 = not ready. PyTorch's allocator
+    /// polls this to decide when freed blocks are safe to reuse.
+    EventQuery {
+        event: u64,
     },
     EventCreate {
         flags: u32,
@@ -700,6 +734,10 @@ pub fn encode_request(req: &Request) -> Vec<u8> {
             w_u8(&mut b, Op::GraphGetNodes as u8);
             w_u64(&mut b, *graph);
         }
+        Request::ThreadExchangeCaptureMode { mode } => {
+            w_u8(&mut b, Op::ThreadExchangeCaptureMode as u8);
+            w_i32(&mut b, *mode);
+        }
         Request::MemsetD8Async {
             dptr,
             value,
@@ -735,6 +773,24 @@ pub fn encode_request(req: &Request) -> Vec<u8> {
         Request::StreamSynchronize { stream } => {
             w_u8(&mut b, Op::StreamSynchronize as u8);
             w_u64(&mut b, *stream);
+        }
+        Request::StreamQuery { stream } => {
+            w_u8(&mut b, Op::StreamQuery as u8);
+            w_u64(&mut b, *stream);
+        }
+        Request::StreamWaitEvent {
+            stream,
+            event,
+            flags,
+        } => {
+            w_u8(&mut b, Op::StreamWaitEvent as u8);
+            w_u64(&mut b, *stream);
+            w_u64(&mut b, *event);
+            w_u32(&mut b, *flags);
+        }
+        Request::EventQuery { event } => {
+            w_u8(&mut b, Op::EventQuery as u8);
+            w_u64(&mut b, *event);
         }
         Request::EventCreate { flags } => {
             w_u8(&mut b, Op::EventCreate as u8);
@@ -966,6 +1022,7 @@ pub fn decode_request(payload: &[u8]) -> io::Result<Request> {
         Op::GraphDestroy => Request::GraphDestroy { graph: c.u64()? },
         Op::StreamCaptureInfo => Request::StreamCaptureInfo { stream: c.u64()? },
         Op::GraphGetNodes => Request::GraphGetNodes { graph: c.u64()? },
+        Op::ThreadExchangeCaptureMode => Request::ThreadExchangeCaptureMode { mode: c.i32()? },
         Op::MemsetD8Async => Request::MemsetD8Async {
             dptr: c.u64()?,
             value: c.u8()?,
@@ -981,6 +1038,13 @@ pub fn decode_request(payload: &[u8]) -> io::Result<Request> {
         Op::StreamCreate => Request::StreamCreate { flags: c.u32()? },
         Op::StreamDestroy => Request::StreamDestroy { stream: c.u64()? },
         Op::StreamSynchronize => Request::StreamSynchronize { stream: c.u64()? },
+        Op::StreamQuery => Request::StreamQuery { stream: c.u64()? },
+        Op::StreamWaitEvent => Request::StreamWaitEvent {
+            stream: c.u64()?,
+            event: c.u64()?,
+            flags: c.u32()?,
+        },
+        Op::EventQuery => Request::EventQuery { event: c.u64()? },
         Op::EventCreate => Request::EventCreate { flags: c.u32()? },
         Op::EventDestroy => Request::EventDestroy { event: c.u64()? },
         Op::EventRecord => Request::EventRecord {
@@ -1102,9 +1166,12 @@ pub fn decode_response(op: Op, payload: &[u8]) -> io::Result<(i32, Response)> {
         return Ok((status, Response::Ok));
     }
     let body = match op {
-        Op::DeviceGetCount | Op::DriverGetVersion | Op::DeviceGetAttribute => {
-            Response::Count(c.i32()?)
-        }
+        Op::DeviceGetCount
+        | Op::DriverGetVersion
+        | Op::DeviceGetAttribute
+        | Op::ThreadExchangeCaptureMode
+        | Op::StreamQuery
+        | Op::EventQuery => Response::Count(c.i32()?),
         Op::DeviceGetName => Response::Name(c.string()?),
         Op::DeviceTotalMem => Response::Bytes(c.u64()?),
         Op::CtxCreate | Op::PrimaryCtxRetain => Response::Handle(c.u64()?),
@@ -1142,6 +1209,7 @@ pub fn decode_response(op: Op, payload: &[u8]) -> io::Result<(i32, Response)> {
         | Op::CtxSynchronize
         | Op::StreamDestroy
         | Op::StreamSynchronize
+        | Op::StreamWaitEvent
         | Op::EventDestroy
         | Op::EventRecord
         | Op::EventSynchronize
@@ -1245,6 +1313,14 @@ mod tests {
         });
         roundtrip(Request::EventSynchronize { event: 4 });
         roundtrip(Request::EventElapsedTime { start: 4, end: 5 });
+        roundtrip(Request::StreamQuery { stream: 3 });
+        roundtrip(Request::StreamWaitEvent {
+            stream: 3,
+            event: 4,
+            flags: 0,
+        });
+        roundtrip(Request::EventQuery { event: 4 });
+        roundtrip(Request::ThreadExchangeCaptureMode { mode: 2 });
     }
 
     #[test]

--- a/crates/smolvm-cuda/src/ring.rs
+++ b/crates/smolvm-cuda/src/ring.rs
@@ -1,0 +1,303 @@
+//! Shared-memory command/completion rings: the low-latency transport between
+//! a guest shim and the host CUDA service.
+//!
+//! The guest allocates two rings in its own RAM (request: guest→host,
+//! completion: host→guest) and hands their guest-physical page lists to the
+//! host over the bootstrap vsock connection (`Request::RingSetup`). The host
+//! already maps guest RAM for zero-copy transfers, so both sides then share
+//! the rings at memory speed: a sync round-trip costs ~1-2µs of polling
+//! instead of a vsock wakeup (~50-70µs).
+//!
+//! Layout (one ring): a 64-byte header page-prefix followed by `capacity`
+//! fixed-size records. Records never straddle a page boundary
+//! (`RECORD_SIZE` divides the page size), because guest pages are physically
+//! discontiguous — each side addresses record `i` through a per-page mapping
+//! table, not one flat pointer.
+//!
+//! Record publish protocol: the producer writes payload then `len`, then
+//! stores the slot's wrapping sequence number with release ordering; the
+//! consumer reads the sequence with acquire ordering and only then the
+//! payload — a torn read is impossible because a slot's sequence only
+//! becomes valid after its bytes are complete.
+//!
+//! Doorbells: pure polling burns a core, so each side may park. A consumer
+//! that decides to sleep sets `PARKED` in its ring's header *then re-checks
+//! for new records* (the producer's publish-then-check mirrors it) and blocks
+//! on the bootstrap vsock socket; a producer that sees `PARKED` after
+//! publishing clears it and writes one byte to the socket. The socket carries
+//! only doorbells after ring setup — every request and response rides the
+//! rings, preserving the single program-ordered queue.
+
+use std::sync::atomic::{AtomicU32, Ordering};
+
+/// Bytes per record. Divides 4096 so records never straddle a guest page.
+/// Sized so common frames stay inline: a Triton launch with ~30 pointer args
+/// serializes to ~300 bytes, cudnn attribute blobs run to ~1 KiB.
+pub const RECORD_SIZE: usize = 1024;
+/// Per-record header: sequence (u32) + payload length (u32).
+pub const RECORD_HDR: usize = 8;
+/// Largest payload that fits inline in one record.
+pub const INLINE_MAX: usize = RECORD_SIZE - RECORD_HDR;
+/// Ring header size (one cache line, at the start of the first page).
+pub const HEADER_SIZE: usize = 64;
+
+/// Consumer-parked flag in the header `flags` word: the producer must clear
+/// it and kick the doorbell after publishing.
+pub const FLAG_PARKED: u32 = 1;
+
+/// Payload `len` flag bit: the record body is not the payload itself but a
+/// list of `(gpa: u64, len: u64)` segments the consumer must gather from
+/// guest RAM (requests too large for a record — H2D byte-ship, fatbins).
+pub const LEN_INDIRECT: u32 = 1 << 31;
+
+/// Offsets within the 64-byte header.
+const OFF_HEAD: usize = 0; // producer: next sequence to publish (u32)
+const OFF_TAIL: usize = 8; // consumer: next sequence to consume (u32)
+const OFF_FLAGS: usize = 16; // FLAG_PARKED etc.
+
+/// One side of a ring: raw per-page pointers into the shared memory. The
+/// guest builds this over its own allocation; the host over its mapping of
+/// the same guest pages. `pages[0]` begins with the header; records start at
+/// `HEADER_SIZE` and continue across pages (each page after the first is
+/// wall-to-wall records).
+pub struct Ring {
+    pages: Vec<*mut u8>,
+    page_size: usize,
+    capacity: u32,
+}
+
+// SAFETY: the ring is shared memory by design; all cross-thread access goes
+// through atomics with acquire/release ordering per the publish protocol.
+unsafe impl Send for Ring {}
+unsafe impl Sync for Ring {}
+
+impl Ring {
+    /// Records that fit in `pages` (first page loses `HEADER_SIZE` bytes).
+    pub fn capacity_for(num_pages: usize, page_size: usize) -> u32 {
+        let first = (page_size - HEADER_SIZE) / RECORD_SIZE;
+        let rest = (num_pages - 1) * (page_size / RECORD_SIZE);
+        (first + rest) as u32
+    }
+
+    /// Wrap `pages` (each `page_size` bytes, zeroed by the creator).
+    ///
+    /// # Safety
+    /// Every pointer must be valid for `page_size` bytes for the ring's
+    /// lifetime, and the memory must not be moved or unmapped.
+    pub unsafe fn from_pages(pages: Vec<*mut u8>, page_size: usize) -> Ring {
+        let capacity = Self::capacity_for(pages.len(), page_size);
+        Ring {
+            pages,
+            page_size,
+            capacity,
+        }
+    }
+
+    pub fn capacity(&self) -> u32 {
+        self.capacity
+    }
+
+    fn header_atomic(&self, off: usize) -> &AtomicU32 {
+        // SAFETY: header lives in the first page, within HEADER_SIZE.
+        unsafe { AtomicU32::from_ptr(self.pages[0].add(off) as *mut u32) }
+    }
+
+    /// (page pointer, offset) of record `slot`.
+    fn record_ptr(&self, slot: u32) -> *mut u8 {
+        let first_cap = (self.page_size - HEADER_SIZE) / RECORD_SIZE;
+        let slot = slot as usize;
+        if slot < first_cap {
+            // SAFETY: slot bounds-checked against the first page's capacity.
+            unsafe { self.pages[0].add(HEADER_SIZE + slot * RECORD_SIZE) }
+        } else {
+            let per_page = self.page_size / RECORD_SIZE;
+            let rest = slot - first_cap;
+            let page = 1 + rest / per_page;
+            // SAFETY: capacity_for bounds slots to the page list.
+            unsafe { self.pages[page].add((rest % per_page) * RECORD_SIZE) }
+        }
+    }
+
+    /// Producer: try to publish `payload` (with `flags` OR-ed into its
+    /// length). Returns false when the ring is full.
+    pub fn try_push(&self, payload: &[u8], flags: u32) -> bool {
+        debug_assert!(payload.len() <= INLINE_MAX);
+        let head = self.header_atomic(OFF_HEAD);
+        let tail = self.header_atomic(OFF_TAIL);
+        let seq = head.load(Ordering::Relaxed);
+        if seq.wrapping_sub(tail.load(Ordering::Acquire)) >= self.capacity {
+            return false; // full
+        }
+        let slot = seq % self.capacity;
+        let rec = self.record_ptr(slot);
+        // SAFETY: rec points at a full RECORD_SIZE record inside our pages;
+        // the slot is ours until we bump `head` (single producer).
+        unsafe {
+            std::ptr::copy_nonoverlapping(payload.as_ptr(), rec.add(RECORD_HDR), payload.len());
+            (rec.add(4) as *mut u32).write_volatile(payload.len() as u32 | flags);
+            // Publish: sequence write is the release gate for the payload.
+            AtomicU32::from_ptr(rec as *mut u32).store(seq.wrapping_add(1), Ordering::Release);
+        }
+        head.store(seq.wrapping_add(1), Ordering::Release);
+        true
+    }
+
+    /// Consumer: read the next record if one is published. Returns
+    /// `(payload, flags)`.
+    pub fn try_pop(&self) -> Option<(Vec<u8>, u32)> {
+        let tail = self.header_atomic(OFF_TAIL);
+        let seq = tail.load(Ordering::Relaxed);
+        let slot = seq % self.capacity;
+        let rec = self.record_ptr(slot);
+        // SAFETY: reading the slot's sequence atomically; payload only after
+        // the acquire load observes the publish.
+        let published = unsafe { AtomicU32::from_ptr(rec as *mut u32).load(Ordering::Acquire) };
+        if published != seq.wrapping_add(1) {
+            return None;
+        }
+        let (len_flags, payload) = unsafe {
+            let lf = (rec.add(4) as *const u32).read_volatile();
+            let len = (lf & !LEN_INDIRECT) as usize;
+            let mut buf = vec![0u8; len.min(INLINE_MAX)];
+            std::ptr::copy_nonoverlapping(rec.add(RECORD_HDR), buf.as_mut_ptr(), buf.len());
+            (lf, buf)
+        };
+        tail.store(seq.wrapping_add(1), Ordering::Release);
+        Some((payload, len_flags & LEN_INDIRECT))
+    }
+
+    /// Consumer: about to block — set the parked flag. Returns true if new
+    /// records were published in the meantime (caller must NOT sleep).
+    pub fn park(&self) -> bool {
+        self.header_atomic(OFF_FLAGS)
+            .fetch_or(FLAG_PARKED, Ordering::SeqCst);
+        // Re-check after the flag is visible: a producer that published
+        // before seeing the flag would not kick.
+        let head = self.header_atomic(OFF_HEAD).load(Ordering::SeqCst);
+        let tail = self.header_atomic(OFF_TAIL).load(Ordering::Relaxed);
+        if head != tail {
+            self.unpark();
+            return true;
+        }
+        false
+    }
+
+    pub fn unpark(&self) {
+        self.header_atomic(OFF_FLAGS)
+            .fetch_and(!FLAG_PARKED, Ordering::SeqCst);
+    }
+
+    /// Producer: does the consumer need a doorbell kick? (Checked after
+    /// publishing; clears the flag when set so exactly one kick is sent.)
+    pub fn take_parked(&self) -> bool {
+        let flags = self.header_atomic(OFF_FLAGS);
+        if flags.load(Ordering::SeqCst) & FLAG_PARKED != 0 {
+            flags.fetch_and(!FLAG_PARKED, Ordering::SeqCst) & FLAG_PARKED != 0
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_ring(num_pages: usize) -> (Ring, Vec<Vec<u8>>) {
+        let page = 4096;
+        let mut backing: Vec<Vec<u8>> = (0..num_pages).map(|_| vec![0u8; page]).collect();
+        let pages: Vec<*mut u8> = backing.iter_mut().map(|p| p.as_mut_ptr()).collect();
+        // SAFETY: backing outlives the ring within each test.
+        (unsafe { Ring::from_pages(pages, page) }, backing)
+    }
+
+    #[test]
+    fn push_pop_roundtrip() {
+        let (ring, _keep) = make_ring(2);
+        assert!(ring.try_push(b"hello", 0));
+        assert!(ring.try_push(b"world", LEN_INDIRECT));
+        let (a, f_a) = ring.try_pop().unwrap();
+        let (b, f_b) = ring.try_pop().unwrap();
+        assert_eq!((a.as_slice(), f_a), (b"hello".as_slice(), 0));
+        assert_eq!((b.as_slice(), f_b), (b"world".as_slice(), LEN_INDIRECT));
+        assert!(ring.try_pop().is_none());
+    }
+
+    #[test]
+    fn fills_and_wraps() {
+        let (ring, _keep) = make_ring(1);
+        let cap = ring.capacity();
+        for i in 0..cap {
+            assert!(ring.try_push(&[i as u8], 0), "push {i}");
+        }
+        assert!(!ring.try_push(b"x", 0), "must report full");
+        for i in 0..cap {
+            assert_eq!(ring.try_pop().unwrap().0, vec![i as u8]);
+        }
+        // Wrapped sequences keep working past capacity.
+        for round in 0..3u32 {
+            assert!(ring.try_push(&round.to_le_bytes(), 0));
+            assert_eq!(ring.try_pop().unwrap().0, round.to_le_bytes());
+        }
+    }
+
+    #[test]
+    fn record_slots_never_straddle_pages() {
+        let (ring, keep) = make_ring(3);
+        let page = 4096;
+        for slot in 0..ring.capacity() {
+            let p = ring.record_ptr(slot) as usize;
+            let off_in_page = keep
+                .iter()
+                .map(|b| b.as_ptr() as usize)
+                .filter(|&base| p >= base && p < base + page)
+                .map(|base| p - base)
+                .next()
+                .expect("record outside all pages");
+            assert!(off_in_page + RECORD_SIZE <= page, "slot {slot} straddles");
+        }
+    }
+
+    #[test]
+    fn park_sees_concurrent_publish() {
+        let (ring, _keep) = make_ring(1);
+        assert!(!ring.park(), "empty ring parks");
+        ring.unpark();
+        assert!(ring.try_push(b"x", 0));
+        assert!(ring.park(), "publish before park must cancel the sleep");
+        // Producer-side doorbell handoff.
+        assert!(ring.try_pop().is_some());
+        assert!(!ring.park());
+        assert!(ring.try_push(b"y", 0));
+        assert!(ring.take_parked(), "producer collects exactly one kick");
+        assert!(!ring.take_parked());
+    }
+
+    #[test]
+    fn cross_thread_stream() {
+        use std::sync::Arc;
+        let (ring, keep) = make_ring(4);
+        let ring = Arc::new(ring);
+        let producer = {
+            let ring = Arc::clone(&ring);
+            std::thread::spawn(move || {
+                for i in 0..10_000u32 {
+                    while !ring.try_push(&i.to_le_bytes(), 0) {
+                        std::hint::spin_loop();
+                    }
+                }
+            })
+        };
+        let mut expected = 0u32;
+        while expected < 10_000 {
+            if let Some((payload, _)) = ring.try_pop() {
+                assert_eq!(payload, expected.to_le_bytes());
+                expected += 1;
+            } else {
+                std::hint::spin_loop();
+            }
+        }
+        producer.join().unwrap();
+        drop(keep);
+    }
+}

--- a/crates/smolvm-cudart-shim/src/cublas_stubs.rs
+++ b/crates/smolvm-cudart-shim/src/cublas_stubs.rs
@@ -471,29 +471,11 @@ pub extern "C" fn cudaGraphDebugDotPrint() -> c_int {
     rt_stub("cudaGraphDebugDotPrint")
 }
 #[no_mangle]
-pub extern "C" fn cudaGraphDestroy() -> c_int {
-    rt_stub("cudaGraphDestroy")
-}
 #[no_mangle]
-pub extern "C" fn cudaGraphExecDestroy() -> c_int {
-    rt_stub("cudaGraphExecDestroy")
-}
 #[no_mangle]
-pub extern "C" fn cudaGraphGetNodes() -> c_int {
-    rt_stub("cudaGraphGetNodes")
-}
 #[no_mangle]
-pub extern "C" fn cudaGraphInstantiate() -> c_int {
-    rt_stub("cudaGraphInstantiate")
-}
 #[no_mangle]
-pub extern "C" fn cudaGraphInstantiateWithFlags() -> c_int {
-    rt_stub("cudaGraphInstantiateWithFlags")
-}
 #[no_mangle]
-pub extern "C" fn cudaGraphLaunch() -> c_int {
-    rt_stub("cudaGraphLaunch")
-}
 #[no_mangle]
 pub extern "C" fn cudaIpcCloseMemHandle() -> c_int {
     rt_stub("cudaIpcCloseMemHandle")
@@ -523,13 +505,7 @@ pub extern "C" fn cudaRegisterVar() -> c_int {
     rt_stub("cudaRegisterVar")
 }
 #[no_mangle]
-pub extern "C" fn cudaStreamBeginCapture() -> c_int {
-    rt_stub("cudaStreamBeginCapture")
-}
 #[no_mangle]
-pub extern "C" fn cudaStreamEndCapture() -> c_int {
-    rt_stub("cudaStreamEndCapture")
-}
 
 /// `__cudaRegisterVar` — registers a __device__/__constant__ global. No-op:
 /// forwarded workloads that don't use cudaMemcpyToSymbol never need the mapping.

--- a/crates/smolvm-cudart-shim/src/cublas_stubs.rs
+++ b/crates/smolvm-cudart-shim/src/cublas_stubs.rs
@@ -471,12 +471,6 @@ pub extern "C" fn cudaGraphDebugDotPrint() -> c_int {
     rt_stub("cudaGraphDebugDotPrint")
 }
 #[no_mangle]
-#[no_mangle]
-#[no_mangle]
-#[no_mangle]
-#[no_mangle]
-#[no_mangle]
-#[no_mangle]
 pub extern "C" fn cudaIpcCloseMemHandle() -> c_int {
     rt_stub("cudaIpcCloseMemHandle")
 }
@@ -504,9 +498,6 @@ pub extern "C" fn cudaMemcpyPeerAsync() -> c_int {
 pub extern "C" fn cudaRegisterVar() -> c_int {
     rt_stub("cudaRegisterVar")
 }
-#[no_mangle]
-#[no_mangle]
-
 /// `__cudaRegisterVar` — registers a __device__/__constant__ global. No-op:
 /// forwarded workloads that don't use cudaMemcpyToSymbol never need the mapping.
 #[no_mangle]

--- a/crates/smolvm-cudart-shim/src/generated/cublas_guest.rs
+++ b/crates/smolvm-cudart-shim/src/generated/cublas_guest.rs
@@ -3,13 +3,12 @@ const LIB_ID: u8 = 1;
 #[no_mangle]
 pub extern "C" fn cublasCreate_v2(handle_out: *mut *mut c_void) -> c_int {
     if handle_out.is_null() { return 1; }
-    match with_client(|c| c.lib_call(LIB_ID, 0, Vec::new())) {
-        Ok((0, out)) if out.len() >= 8 => {
-            let h = u64::from_le_bytes(out[..8].try_into().unwrap());
-            unsafe { *handle_out = h as *mut c_void };
-            0
-        }
-        Ok((st, _)) => st,
+    // Fire-and-forget create: return a guest-assigned virtual id
+    // immediately; the host materializes the real descriptor and
+    // maps the id (see vh_resolve on the host side).
+    let vh = super::alloc_vhandle();
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 0, vh.to_le_bytes().to_vec())) {
+        Ok(()) => { unsafe { *handle_out = vh as *mut c_void }; 0 }
         Err(_) => 1,
     }
 }
@@ -17,7 +16,8 @@ pub extern "C" fn cublasCreate_v2(handle_out: *mut *mut c_void) -> c_int {
 pub extern "C" fn cublasDestroy_v2(handle: *mut c_void) -> c_int {
     let mut a: Vec<u8> = Vec::new();
     a.extend_from_slice(&(handle as u64).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 1, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 1, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasSgemm_v2(handle: *mut c_void, transa: c_int, transb: c_int, m: c_int, n: c_int, k: c_int, alpha: *const f32, A: *const f32, lda: c_int, B: *const f32, ldb: c_int, beta: *const f32, C: *mut f32, ldc: c_int) -> c_int {
@@ -38,7 +38,8 @@ pub extern "C" fn cublasSgemm_v2(handle: *mut c_void, transa: c_int, transb: c_i
     a.extend_from_slice(&(unsafe { *beta } as f32).to_le_bytes());
     a.extend_from_slice(&(C as u64).to_le_bytes());
     a.extend_from_slice(&(ldc as i32).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 2, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 2, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasDgemm_v2(handle: *mut c_void, transa: c_int, transb: c_int, m: c_int, n: c_int, k: c_int, alpha: *const f64, A: *const f64, lda: c_int, B: *const f64, ldb: c_int, beta: *const f64, C: *mut f64, ldc: c_int) -> c_int {
@@ -59,7 +60,8 @@ pub extern "C" fn cublasDgemm_v2(handle: *mut c_void, transa: c_int, transb: c_i
     a.extend_from_slice(&(unsafe { *beta } as f64).to_le_bytes());
     a.extend_from_slice(&(C as u64).to_le_bytes());
     a.extend_from_slice(&(ldc as i32).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 3, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 3, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasSgemmStridedBatched(handle: *mut c_void, transa: c_int, transb: c_int, m: c_int, n: c_int, k: c_int, alpha: *const f32, A: *const f32, lda: c_int, strideA: i64, B: *const f32, ldb: c_int, strideB: i64, beta: *const f32, C: *mut f32, ldc: c_int, strideC: i64, batchCount: c_int) -> c_int {
@@ -84,7 +86,8 @@ pub extern "C" fn cublasSgemmStridedBatched(handle: *mut c_void, transa: c_int, 
     a.extend_from_slice(&(ldc as i32).to_le_bytes());
     a.extend_from_slice(&(strideC as i64).to_le_bytes());
     a.extend_from_slice(&(batchCount as i32).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 4, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 4, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasDgemmStridedBatched(handle: *mut c_void, transa: c_int, transb: c_int, m: c_int, n: c_int, k: c_int, alpha: *const f64, A: *const f64, lda: c_int, strideA: i64, B: *const f64, ldb: c_int, strideB: i64, beta: *const f64, C: *mut f64, ldc: c_int, strideC: i64, batchCount: c_int) -> c_int {
@@ -109,14 +112,16 @@ pub extern "C" fn cublasDgemmStridedBatched(handle: *mut c_void, transa: c_int, 
     a.extend_from_slice(&(ldc as i32).to_le_bytes());
     a.extend_from_slice(&(strideC as i64).to_le_bytes());
     a.extend_from_slice(&(batchCount as i32).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 5, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 5, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasSetStream_v2(handle: *mut c_void, stream: *mut c_void) -> c_int {
     let mut a: Vec<u8> = Vec::new();
     a.extend_from_slice(&(handle as u64).to_le_bytes());
     a.extend_from_slice(&(stream as u64).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 6, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 6, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasSetWorkspace_v2(handle: *mut c_void, workspace: *mut c_void, size: usize) -> c_int {
@@ -124,14 +129,16 @@ pub extern "C" fn cublasSetWorkspace_v2(handle: *mut c_void, workspace: *mut c_v
     a.extend_from_slice(&(handle as u64).to_le_bytes());
     a.extend_from_slice(&(workspace as u64).to_le_bytes());
     a.extend_from_slice(&(size as u64).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 7, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 7, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasSetMathMode(handle: *mut c_void, mode: c_int) -> c_int {
     let mut a: Vec<u8> = Vec::new();
     a.extend_from_slice(&(handle as u64).to_le_bytes());
     a.extend_from_slice(&(mode as i32).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 8, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 8, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasGetMathMode(handle: *mut c_void, mode: *mut c_int) -> c_int {
@@ -179,7 +186,8 @@ pub extern "C" fn cublasGemmEx(handle: *mut c_void, transa: c_int, transb: c_int
     a.extend_from_slice(&(ldc as i32).to_le_bytes());
     a.extend_from_slice(&(computeType as i32).to_le_bytes());
     a.extend_from_slice(&(algo as i32).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 11, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 11, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasGemmStridedBatchedEx(handle: *mut c_void, transa: c_int, transb: c_int, m: c_int, n: c_int, k: c_int, alpha: *const f32, A: *const c_void, Atype: c_int, lda: c_int, strideA: i64, B: *const c_void, Btype: c_int, ldb: c_int, strideB: i64, beta: *const f32, C: *mut c_void, Ctype: c_int, ldc: c_int, strideC: i64, batchCount: c_int, computeType: c_int, algo: c_int) -> c_int {
@@ -209,5 +217,6 @@ pub extern "C" fn cublasGemmStridedBatchedEx(handle: *mut c_void, transa: c_int,
     a.extend_from_slice(&(batchCount as i32).to_le_bytes());
     a.extend_from_slice(&(computeType as i32).to_le_bytes());
     a.extend_from_slice(&(algo as i32).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 12, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 12, a)) { Ok(()) => 0, Err(_) => 1 }
 }

--- a/crates/smolvm-cudart-shim/src/generated/cublas_guest.rs
+++ b/crates/smolvm-cudart-shim/src/generated/cublas_guest.rs
@@ -42,6 +42,28 @@ pub extern "C" fn cublasSgemm_v2(handle: *mut c_void, transa: c_int, transb: c_i
     match with_client(|c| c.lib_call_deferred(LIB_ID, 2, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
+pub extern "C" fn cublasHgemm(handle: *mut c_void, transa: c_int, transb: c_int, m: c_int, n: c_int, k: c_int, alpha: *const u16, A: *const u16, lda: c_int, B: *const u16, ldb: c_int, beta: *const u16, C: *mut u16, ldc: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(transa as i32).to_le_bytes());
+    a.extend_from_slice(&(transb as i32).to_le_bytes());
+    a.extend_from_slice(&(m as i32).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    a.extend_from_slice(&(k as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as u16).to_le_bytes());
+    a.extend_from_slice(&(A as u64).to_le_bytes());
+    a.extend_from_slice(&(lda as i32).to_le_bytes());
+    a.extend_from_slice(&(B as u64).to_le_bytes());
+    a.extend_from_slice(&(ldb as i32).to_le_bytes());
+    if beta.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *beta } as u16).to_le_bytes());
+    a.extend_from_slice(&(C as u64).to_le_bytes());
+    a.extend_from_slice(&(ldc as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 3, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
 pub extern "C" fn cublasDgemm_v2(handle: *mut c_void, transa: c_int, transb: c_int, m: c_int, n: c_int, k: c_int, alpha: *const f64, A: *const f64, lda: c_int, B: *const f64, ldb: c_int, beta: *const f64, C: *mut f64, ldc: c_int) -> c_int {
     let mut a: Vec<u8> = Vec::new();
     a.extend_from_slice(&(handle as u64).to_le_bytes());
@@ -61,7 +83,7 @@ pub extern "C" fn cublasDgemm_v2(handle: *mut c_void, transa: c_int, transb: c_i
     a.extend_from_slice(&(C as u64).to_le_bytes());
     a.extend_from_slice(&(ldc as i32).to_le_bytes());
     // No output params: fire-and-forget (failures surface as sticky async errors).
-    match with_client(|c| c.lib_call_deferred(LIB_ID, 3, a)) { Ok(()) => 0, Err(_) => 1 }
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 4, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasSgemmStridedBatched(handle: *mut c_void, transa: c_int, transb: c_int, m: c_int, n: c_int, k: c_int, alpha: *const f32, A: *const f32, lda: c_int, strideA: i64, B: *const f32, ldb: c_int, strideB: i64, beta: *const f32, C: *mut f32, ldc: c_int, strideC: i64, batchCount: c_int) -> c_int {
@@ -87,7 +109,7 @@ pub extern "C" fn cublasSgemmStridedBatched(handle: *mut c_void, transa: c_int, 
     a.extend_from_slice(&(strideC as i64).to_le_bytes());
     a.extend_from_slice(&(batchCount as i32).to_le_bytes());
     // No output params: fire-and-forget (failures surface as sticky async errors).
-    match with_client(|c| c.lib_call_deferred(LIB_ID, 4, a)) { Ok(()) => 0, Err(_) => 1 }
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 5, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasDgemmStridedBatched(handle: *mut c_void, transa: c_int, transb: c_int, m: c_int, n: c_int, k: c_int, alpha: *const f64, A: *const f64, lda: c_int, strideA: i64, B: *const f64, ldb: c_int, strideB: i64, beta: *const f64, C: *mut f64, ldc: c_int, strideC: i64, batchCount: c_int) -> c_int {
@@ -113,7 +135,7 @@ pub extern "C" fn cublasDgemmStridedBatched(handle: *mut c_void, transa: c_int, 
     a.extend_from_slice(&(strideC as i64).to_le_bytes());
     a.extend_from_slice(&(batchCount as i32).to_le_bytes());
     // No output params: fire-and-forget (failures surface as sticky async errors).
-    match with_client(|c| c.lib_call_deferred(LIB_ID, 5, a)) { Ok(()) => 0, Err(_) => 1 }
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 6, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasSetStream_v2(handle: *mut c_void, stream: *mut c_void) -> c_int {
@@ -121,7 +143,7 @@ pub extern "C" fn cublasSetStream_v2(handle: *mut c_void, stream: *mut c_void) -
     a.extend_from_slice(&(handle as u64).to_le_bytes());
     a.extend_from_slice(&(stream as u64).to_le_bytes());
     // No output params: fire-and-forget (failures surface as sticky async errors).
-    match with_client(|c| c.lib_call_deferred(LIB_ID, 6, a)) { Ok(()) => 0, Err(_) => 1 }
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 7, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasSetWorkspace_v2(handle: *mut c_void, workspace: *mut c_void, size: usize) -> c_int {
@@ -130,7 +152,7 @@ pub extern "C" fn cublasSetWorkspace_v2(handle: *mut c_void, workspace: *mut c_v
     a.extend_from_slice(&(workspace as u64).to_le_bytes());
     a.extend_from_slice(&(size as u64).to_le_bytes());
     // No output params: fire-and-forget (failures surface as sticky async errors).
-    match with_client(|c| c.lib_call_deferred(LIB_ID, 7, a)) { Ok(()) => 0, Err(_) => 1 }
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 8, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasSetMathMode(handle: *mut c_void, mode: c_int) -> c_int {
@@ -138,13 +160,13 @@ pub extern "C" fn cublasSetMathMode(handle: *mut c_void, mode: c_int) -> c_int {
     a.extend_from_slice(&(handle as u64).to_le_bytes());
     a.extend_from_slice(&(mode as i32).to_le_bytes());
     // No output params: fire-and-forget (failures surface as sticky async errors).
-    match with_client(|c| c.lib_call_deferred(LIB_ID, 8, a)) { Ok(()) => 0, Err(_) => 1 }
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 9, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasGetMathMode(handle: *mut c_void, mode: *mut c_int) -> c_int {
     let mut a: Vec<u8> = Vec::new();
     a.extend_from_slice(&(handle as u64).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 9, a)) {
+    match with_client(|c| c.lib_call(LIB_ID, 10, a)) {
         Ok((st, out)) => { let mut o = 0usize;
             if !mode.is_null() && out.len() >= o + 4 { unsafe { *mode = i32::from_le_bytes(out[o..o + 4].try_into().unwrap()) as _ }; } o += 4;
             let _ = o; st }
@@ -155,7 +177,7 @@ pub extern "C" fn cublasGetMathMode(handle: *mut c_void, mode: *mut c_int) -> c_
 pub extern "C" fn cublasGetProperty(prop_type: c_int, value: *mut c_int) -> c_int {
     let mut a: Vec<u8> = Vec::new();
     a.extend_from_slice(&(prop_type as i32).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 10, a)) {
+    match with_client(|c| c.lib_call(LIB_ID, 11, a)) {
         Ok((st, out)) => { let mut o = 0usize;
             if !value.is_null() && out.len() >= o + 4 { unsafe { *value = i32::from_le_bytes(out[o..o + 4].try_into().unwrap()) as _ }; } o += 4;
             let _ = o; st }
@@ -187,7 +209,7 @@ pub extern "C" fn cublasGemmEx(handle: *mut c_void, transa: c_int, transb: c_int
     a.extend_from_slice(&(computeType as i32).to_le_bytes());
     a.extend_from_slice(&(algo as i32).to_le_bytes());
     // No output params: fire-and-forget (failures surface as sticky async errors).
-    match with_client(|c| c.lib_call_deferred(LIB_ID, 11, a)) { Ok(()) => 0, Err(_) => 1 }
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 12, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cublasGemmStridedBatchedEx(handle: *mut c_void, transa: c_int, transb: c_int, m: c_int, n: c_int, k: c_int, alpha: *const f32, A: *const c_void, Atype: c_int, lda: c_int, strideA: i64, B: *const c_void, Btype: c_int, ldb: c_int, strideB: i64, beta: *const f32, C: *mut c_void, Ctype: c_int, ldc: c_int, strideC: i64, batchCount: c_int, computeType: c_int, algo: c_int) -> c_int {
@@ -218,5 +240,5 @@ pub extern "C" fn cublasGemmStridedBatchedEx(handle: *mut c_void, transa: c_int,
     a.extend_from_slice(&(computeType as i32).to_le_bytes());
     a.extend_from_slice(&(algo as i32).to_le_bytes());
     // No output params: fire-and-forget (failures surface as sticky async errors).
-    match with_client(|c| c.lib_call_deferred(LIB_ID, 12, a)) { Ok(()) => 0, Err(_) => 1 }
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 13, a)) { Ok(()) => 0, Err(_) => 1 }
 }

--- a/crates/smolvm-cudart-shim/src/generated/cudnn_guest.rs
+++ b/crates/smolvm-cudart-shim/src/generated/cudnn_guest.rs
@@ -3,13 +3,12 @@ const LIB_ID: u8 = 2;
 #[no_mangle]
 pub extern "C" fn cudnnCreate(handle_out: *mut *mut c_void) -> c_int {
     if handle_out.is_null() { return 1; }
-    match with_client(|c| c.lib_call(LIB_ID, 0, Vec::new())) {
-        Ok((0, out)) if out.len() >= 8 => {
-            let h = u64::from_le_bytes(out[..8].try_into().unwrap());
-            unsafe { *handle_out = h as *mut c_void };
-            0
-        }
-        Ok((st, _)) => st,
+    // Fire-and-forget create: return a guest-assigned virtual id
+    // immediately; the host materializes the real descriptor and
+    // maps the id (see vh_resolve on the host side).
+    let vh = super::alloc_vhandle();
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 0, vh.to_le_bytes().to_vec())) {
+        Ok(()) => { unsafe { *handle_out = vh as *mut c_void }; 0 }
         Err(_) => 1,
     }
 }
@@ -17,25 +16,26 @@ pub extern "C" fn cudnnCreate(handle_out: *mut *mut c_void) -> c_int {
 pub extern "C" fn cudnnDestroy(handle: *mut c_void) -> c_int {
     let mut a: Vec<u8> = Vec::new();
     a.extend_from_slice(&(handle as u64).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 1, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 1, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cudnnSetStream(handle: *mut c_void, stream: *mut c_void) -> c_int {
     let mut a: Vec<u8> = Vec::new();
     a.extend_from_slice(&(handle as u64).to_le_bytes());
     a.extend_from_slice(&(stream as u64).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 2, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 2, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cudnnCreateTensorDescriptor(handle_out: *mut *mut c_void) -> c_int {
     if handle_out.is_null() { return 1; }
-    match with_client(|c| c.lib_call(LIB_ID, 3, Vec::new())) {
-        Ok((0, out)) if out.len() >= 8 => {
-            let h = u64::from_le_bytes(out[..8].try_into().unwrap());
-            unsafe { *handle_out = h as *mut c_void };
-            0
-        }
-        Ok((st, _)) => st,
+    // Fire-and-forget create: return a guest-assigned virtual id
+    // immediately; the host materializes the real descriptor and
+    // maps the id (see vh_resolve on the host side).
+    let vh = super::alloc_vhandle();
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 3, vh.to_le_bytes().to_vec())) {
+        Ok(()) => { unsafe { *handle_out = vh as *mut c_void }; 0 }
         Err(_) => 1,
     }
 }
@@ -49,24 +49,25 @@ pub extern "C" fn cudnnSetTensor4dDescriptor(t: *mut c_void, fmt: c_int, dtype: 
     a.extend_from_slice(&(c as i32).to_le_bytes());
     a.extend_from_slice(&(h as i32).to_le_bytes());
     a.extend_from_slice(&(w as i32).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 4, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 4, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cudnnDestroyTensorDescriptor(t: *mut c_void) -> c_int {
     let mut a: Vec<u8> = Vec::new();
     a.extend_from_slice(&(t as u64).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 5, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 5, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cudnnCreateFilterDescriptor(handle_out: *mut *mut c_void) -> c_int {
     if handle_out.is_null() { return 1; }
-    match with_client(|c| c.lib_call(LIB_ID, 6, Vec::new())) {
-        Ok((0, out)) if out.len() >= 8 => {
-            let h = u64::from_le_bytes(out[..8].try_into().unwrap());
-            unsafe { *handle_out = h as *mut c_void };
-            0
-        }
-        Ok((st, _)) => st,
+    // Fire-and-forget create: return a guest-assigned virtual id
+    // immediately; the host materializes the real descriptor and
+    // maps the id (see vh_resolve on the host side).
+    let vh = super::alloc_vhandle();
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 6, vh.to_le_bytes().to_vec())) {
+        Ok(()) => { unsafe { *handle_out = vh as *mut c_void }; 0 }
         Err(_) => 1,
     }
 }
@@ -80,24 +81,25 @@ pub extern "C" fn cudnnSetFilter4dDescriptor(f: *mut c_void, dtype: c_int, fmt: 
     a.extend_from_slice(&(c as i32).to_le_bytes());
     a.extend_from_slice(&(h as i32).to_le_bytes());
     a.extend_from_slice(&(w as i32).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 7, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 7, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cudnnDestroyFilterDescriptor(f: *mut c_void) -> c_int {
     let mut a: Vec<u8> = Vec::new();
     a.extend_from_slice(&(f as u64).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 8, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 8, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cudnnCreateConvolutionDescriptor(handle_out: *mut *mut c_void) -> c_int {
     if handle_out.is_null() { return 1; }
-    match with_client(|c| c.lib_call(LIB_ID, 9, Vec::new())) {
-        Ok((0, out)) if out.len() >= 8 => {
-            let h = u64::from_le_bytes(out[..8].try_into().unwrap());
-            unsafe { *handle_out = h as *mut c_void };
-            0
-        }
-        Ok((st, _)) => st,
+    // Fire-and-forget create: return a guest-assigned virtual id
+    // immediately; the host materializes the real descriptor and
+    // maps the id (see vh_resolve on the host side).
+    let vh = super::alloc_vhandle();
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 9, vh.to_le_bytes().to_vec())) {
+        Ok(()) => { unsafe { *handle_out = vh as *mut c_void }; 0 }
         Err(_) => 1,
     }
 }
@@ -113,13 +115,15 @@ pub extern "C" fn cudnnSetConvolution2dDescriptor(cv: *mut c_void, pad_h: c_int,
     a.extend_from_slice(&(dil_w as i32).to_le_bytes());
     a.extend_from_slice(&(mode as i32).to_le_bytes());
     a.extend_from_slice(&(ctype as i32).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 10, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 10, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cudnnDestroyConvolutionDescriptor(cv: *mut c_void) -> c_int {
     let mut a: Vec<u8> = Vec::new();
     a.extend_from_slice(&(cv as u64).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 11, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 11, a)) { Ok(()) => 0, Err(_) => 1 }
 }
 #[no_mangle]
 pub extern "C" fn cudnnGetConvolutionForwardWorkspaceSize(handle: *mut c_void, x: *mut c_void, w: *mut c_void, cv: *mut c_void, y: *mut c_void, algo: c_int, size: *mut usize) -> c_int {
@@ -155,5 +159,6 @@ pub extern "C" fn cudnnConvolutionForward(handle: *mut c_void, alpha: *const f32
     a.extend_from_slice(&(unsafe { *beta } as f32).to_le_bytes());
     a.extend_from_slice(&(yDesc as u64).to_le_bytes());
     a.extend_from_slice(&(y as u64).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_ID, 13, a)) { Ok((st, _)) => st, Err(_) => 1 }
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 13, a)) { Ok(()) => 0, Err(_) => 1 }
 }

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -223,6 +223,79 @@ pub extern "C" fn smolvm_cudart_fence() {
     }
 }
 
+// ---- driver-shim bridge -------------------------------------------------------
+// The driver shim (`libcuda.so.1`) dlsym-resolves these three and routes ALL
+// its traffic through this connection, giving the host one program-ordered
+// pipeline for both shims (see smolvm-cuda's `client::Bridge`). Op statuses
+// stay in-band in the response payload — nothing is lost to error mapping.
+
+/// A response too large for the caller's buffer, parked until the caller
+/// retries with a big-enough one (null request = fetch).
+static BRIDGE_PENDING: Mutex<Option<Vec<u8>>> = Mutex::new(None);
+
+/// Fire-and-forget: append one encoded request to the shared pipeline.
+/// Nonzero = transport failure.
+#[no_mangle]
+pub extern "C" fn smolvm_cudart_bridge_quiet(req: *const u8, len: usize) -> i32 {
+    if req.is_null() {
+        return 1;
+    }
+    let bytes = unsafe { std::slice::from_raw_parts(req, len) };
+    match with_client(|c| c.raw_quiet(bytes)) {
+        Ok(()) => 0,
+        Err(_) => 999,
+    }
+}
+
+/// Synchronous round-trip: send one encoded request, write the response
+/// payload into `resp`. Returns the response length; -1 = transport failure;
+/// other negatives = `cap` too small, retry with `-ret` capacity and a null
+/// request to collect the stashed response.
+#[no_mangle]
+pub extern "C" fn smolvm_cudart_bridge_call(
+    req: *const u8,
+    req_len: usize,
+    resp: *mut u8,
+    cap: usize,
+) -> isize {
+    let payload = if req.is_null() {
+        match BRIDGE_PENDING.lock().map(|mut g| g.take()) {
+            Ok(Some(p)) => p,
+            _ => return -1,
+        }
+    } else {
+        let bytes = unsafe { std::slice::from_raw_parts(req, req_len) };
+        match with_client(|c| c.raw_call(bytes)) {
+            Ok(p) => p,
+            Err(_) => return -1,
+        }
+    };
+    if payload.len() > cap {
+        let n = payload.len() as isize;
+        match BRIDGE_PENDING.lock() {
+            Ok(mut g) => {
+                *g = Some(payload);
+                -n
+            }
+            Err(_) => -1,
+        }
+    } else {
+        unsafe { std::ptr::copy_nonoverlapping(payload.as_ptr(), resp, payload.len()) };
+        payload.len() as isize
+    }
+}
+
+/// Fence the shared pipeline; returns (and consumes) the first collected
+/// quiet-failure status, so the bridged caller can surface it.
+#[no_mangle]
+pub extern "C" fn smolvm_cudart_bridge_drain() -> i32 {
+    with_client(|c| {
+        c.drain()?;
+        Ok(c.take_sticky())
+    })
+    .unwrap_or(999)
+}
+
 fn with_client<T>(
     f: impl FnOnce(&mut Client<Stream>) -> Result<T, CudaRpcError>,
 ) -> Result<T, c_int> {
@@ -671,7 +744,7 @@ fn resolve_kind(s: &ShimState, dst: *const c_void, src: *const c_void, kind: c_i
     }
 }
 
-fn do_memcpy(dst: *mut c_void, src: *const c_void, n: usize, kind: c_int) -> c_int {
+fn do_memcpy(dst: *mut c_void, src: *const c_void, n: usize, kind: c_int, stream: u64) -> c_int {
     with_state(|s| {
         let kind = resolve_kind(s, dst, src, kind);
         match kind {
@@ -687,7 +760,7 @@ fn do_memcpy(dst: *mut c_void, src: *const c_void, n: usize, kind: c_int) -> c_i
                 // segments; the host reads guest RAM directly. Fall back to
                 // byte-shipping if the host can't serve it (no mapping).
                 if let Some(segs) = guestmem::segments(src as usize, n) {
-                    if s.client.memcpy_gpa_htod(dst as u64, segs).is_ok() {
+                    if s.client.memcpy_gpa_htod(dst as u64, segs, stream).is_ok() {
                         return Ok(());
                     }
                 }
@@ -695,15 +768,17 @@ fn do_memcpy(dst: *mut c_void, src: *const c_void, n: usize, kind: c_int) -> c_i
                 if let Some(off) = shm_offset(src) {
                     return s
                         .client
-                        .memcpy_shm_htod(dst as u64, off, n as u64)
+                        .memcpy_shm_htod(dst as u64, off, n as u64, stream)
                         .map_err(map_err);
                 }
                 let data = unsafe { std::slice::from_raw_parts(src as *const u8, n) };
-                s.client.memcpy_htod(dst as u64, data).map_err(map_err)
+                s.client
+                    .memcpy_htod(dst as u64, data, stream)
+                    .map_err(map_err)
             }
             MEMCPY_DTOH => {
                 if let Some(segs) = guestmem::segments(dst as usize, n) {
-                    if s.client.memcpy_gpa_dtoh(src as u64, segs).is_ok() {
+                    if s.client.memcpy_gpa_dtoh(src as u64, segs, stream).is_ok() {
                         return Ok(());
                     }
                 }
@@ -711,12 +786,12 @@ fn do_memcpy(dst: *mut c_void, src: *const c_void, n: usize, kind: c_int) -> c_i
                     // Host writes straight into the shared region at `off`.
                     return s
                         .client
-                        .memcpy_shm_dtoh(off, src as u64, n as u64)
+                        .memcpy_shm_dtoh(off, src as u64, n as u64, stream)
                         .map_err(map_err);
                 }
                 let data = s
                     .client
-                    .memcpy_dtoh(src as u64, n as u64)
+                    .memcpy_dtoh(src as u64, n as u64, stream)
                     .map_err(map_err)?;
                 if data.len() != n {
                     return Err(CUDA_ERROR_UNKNOWN);
@@ -737,7 +812,7 @@ fn do_memcpy(dst: *mut c_void, src: *const c_void, n: usize, kind: c_int) -> c_i
 
 #[no_mangle]
 pub extern "C" fn cudaMemcpy(dst: *mut c_void, src: *const c_void, n: usize, kind: c_int) -> c_int {
-    set_last(do_memcpy(dst, src, n, kind))
+    set_last(do_memcpy(dst, src, n, kind, 0))
 }
 
 #[no_mangle]
@@ -762,9 +837,12 @@ pub extern "C" fn cudaMemcpyAsync(
             },
         );
     }
-    // Other kinds execute synchronously; ordering within a stream is preserved
-    // because all work runs on the host's single serving thread in call order.
-    set_last(do_memcpy(dst, src, n, kind))
+    // Other kinds complete before returning (the CUDA API permits a more
+    // synchronous implementation), but the host orders the copy after prior
+    // work on `stream` first — torch's non-blocking pool streams don't order
+    // against the NULL-stream copy the host uses, so dropping the stream let
+    // a copy overwrite buffers that still-running kernels were reading.
+    set_last(do_memcpy(dst, src, n, kind, stream as u64))
 }
 
 #[no_mangle]
@@ -851,12 +929,37 @@ const A_MAX_SHMEM_PER_BLOCK: i32 = 8;
 const A_TOTAL_CONST_MEM: i32 = 9;
 const A_WARP_SIZE: i32 = 10;
 const A_MAX_REGS_PER_BLOCK: i32 = 12;
+const A_CLOCK_RATE: i32 = 13;
 const A_MP_COUNT: i32 = 16;
+const A_KERNEL_EXEC_TIMEOUT: i32 = 17;
+const A_CONCURRENT_KERNELS: i32 = 31;
+const A_PCI_BUS_ID: i32 = 33;
+const A_PCI_DEVICE_ID: i32 = 34;
+const A_MEMORY_CLOCK_RATE: i32 = 36;
+const A_MEMORY_BUS_WIDTH: i32 = 37;
+const A_L2_CACHE_SIZE: i32 = 38;
 const A_MAX_THREADS_PER_MP: i32 = 39;
+const A_ASYNC_ENGINE_COUNT: i32 = 40;
+const A_PCI_DOMAIN_ID: i32 = 50;
 const A_COMPUTE_MAJOR: i32 = 75;
 const A_COMPUTE_MINOR: i32 = 76;
 const A_MAX_SHMEM_PER_MP: i32 = 81;
 const A_MAX_REGS_PER_MP: i32 = 82;
+const A_MANAGED_MEMORY: i32 = 83;
+const A_CONCURRENT_MANAGED_ACCESS: i32 = 89;
+const A_COMPUTE_PREEMPTION: i32 = 90;
+const A_COOPERATIVE_LAUNCH: i32 = 95;
+const A_COOPERATIVE_MULTI_DEVICE: i32 = 96;
+const A_SINGLE_TO_DOUBLE_PERF: i32 = 87;
+const A_MAX_SHMEM_PER_BLOCK_OPTIN: i32 = 97;
+const A_HOST_REGISTER_SUPPORTED: i32 = 99;
+const A_SPARSE_CUDA_ARRAY: i32 = 112;
+const A_READ_ONLY_HOST_REGISTER: i32 = 113;
+const A_MAX_BLOCKS_PER_MP: i32 = 106;
+const A_MAX_PERSISTING_L2: i32 = 108;
+const A_MAX_ACCESS_POLICY_WINDOW: i32 = 109;
+const A_RESERVED_SHMEM_PER_BLOCK: i32 = 111;
+const A_TIMELINE_SEMAPHORE: i32 = 114;
 
 #[no_mangle]
 pub extern "C" fn cudaDeviceGetAttribute(value: *mut c_int, attr: c_int, device: c_int) -> c_int {
@@ -879,12 +982,15 @@ pub extern "C" fn cudaMemGetInfo(free: *mut usize, total: *mut usize) -> c_int {
     })
 }
 
-/// `cudaDeviceProp` (CUDA 12.x prefix). Only the fields PyTorch reads are set;
-/// the caller's ~1 KiB struct is zeroed first so the rest is well-defined.
+/// `cudaDeviceProp`, the exact CUDA 12.x layout (1032 bytes). Offsets verified
+/// against the real bundled `libcudart.so.12` filling the struct on this
+/// machine, and pinned by the compile-time assertions below — a missing field
+/// silently shifts everything after it (that bug has bitten twice: uuid, and a
+/// mis-sized texture block that landed the tail up to 76 bytes off).
 #[repr(C)]
 struct CudaDeviceProp {
     name: [u8; 256],
-    uuid: [u8; 16], // cudaUUID_t — MUST be here or every field below is 16B off
+    uuid: [u8; 16],
     luid: [u8; 8],
     luid_device_node_mask: c_uint,
     total_global_mem: usize,
@@ -895,15 +1001,19 @@ struct CudaDeviceProp {
     max_threads_per_block: c_int,
     max_threads_dim: [c_int; 3],
     max_grid_size: [c_int; 3],
+    clock_rate: c_int,
     total_const_mem: usize,
     major: c_int,
     minor: c_int,
     texture_alignment: usize,
     texture_pitch_alignment: usize,
+    device_overlap: c_int,
     multi_processor_count: c_int,
+    kernel_exec_timeout_enabled: c_int,
     integrated: c_int,
     can_map_host_memory: c_int,
-    _tex_surf: [c_int; 63], // maxTexture*/maxSurface* block (offsets kept, unused)
+    compute_mode: c_int,
+    _tex_surf: [c_int; 40], // maxTexture*/maxSurface* block (unused, left zero)
     surface_alignment: usize,
     concurrent_kernels: c_int,
     ecc_enabled: c_int,
@@ -913,6 +1023,7 @@ struct CudaDeviceProp {
     tcc_driver: c_int,
     async_engine_count: c_int,
     unified_addressing: c_int,
+    memory_clock_rate: c_int,
     memory_bus_width: c_int,
     l2_cache_size: c_int,
     persisting_l2_cache_max_size: c_int,
@@ -926,16 +1037,48 @@ struct CudaDeviceProp {
     is_multi_gpu_board: c_int,
     multi_gpu_board_group_id: c_int,
     host_native_atomic_supported: c_int,
+    single_to_double_precision_perf_ratio: c_int,
     pageable_memory_access: c_int,
     concurrent_managed_access: c_int,
     compute_preemption_supported: c_int,
     can_use_host_pointer_for_registered_mem: c_int,
     cooperative_launch: c_int,
+    cooperative_multi_device_launch: c_int,
     shared_mem_per_block_optin: usize,
     pageable_memory_access_uses_host_page_tables: c_int,
     direct_managed_mem_access_from_host: c_int,
     max_blocks_per_multiprocessor: c_int,
+    access_policy_max_window_size: c_int,
+    reserved_shared_mem_per_block: usize,
+    host_register_supported: c_int,
+    sparse_cuda_array_supported: c_int,
+    host_register_read_only_supported: c_int,
+    timeline_semaphore_interop_supported: c_int,
+    memory_pools_supported: c_int,
+    gpu_direct_rdma_supported: c_int,
+    gpu_direct_rdma_flush_writes_options: c_uint,
+    gpu_direct_rdma_writes_ordering: c_int,
+    memory_pool_supported_handle_types: c_uint,
+    deferred_mapping_cuda_array_supported: c_int,
+    ipc_event_supported: c_int,
+    cluster_launch: c_int,
+    unified_function_pointers: c_int,
+    _reserved: [c_int; 63],
 }
+
+// Anchor offsets measured from the real 12.4 cudart on this machine; a layout
+// drift fails the build instead of shipping a silently shifted struct.
+const _: () = {
+    assert!(std::mem::offset_of!(CudaDeviceProp, clock_rate) == 348);
+    assert!(std::mem::offset_of!(CudaDeviceProp, multi_processor_count) == 388);
+    assert!(std::mem::offset_of!(CudaDeviceProp, _tex_surf) == 408);
+    assert!(std::mem::offset_of!(CudaDeviceProp, memory_clock_rate) == 608);
+    assert!(std::mem::offset_of!(CudaDeviceProp, max_threads_per_multiprocessor) == 624);
+    assert!(std::mem::offset_of!(CudaDeviceProp, regs_per_multiprocessor) == 648);
+    assert!(std::mem::offset_of!(CudaDeviceProp, shared_mem_per_block_optin) == 696);
+    assert!(std::mem::offset_of!(CudaDeviceProp, reserved_shared_mem_per_block) == 720);
+    assert!(std::mem::size_of::<CudaDeviceProp>() == 1032);
+};
 
 #[no_mangle]
 pub extern "C" fn cudaGetDeviceProperties_v2(prop: *mut c_void, device: c_int) -> c_int {
@@ -951,6 +1094,7 @@ pub extern "C" fn cudaGetDeviceProperties_v2(prop: *mut c_void, device: c_int) -
                 s.client.device_get_attribute(attr, device).unwrap_or(dflt)
             };
             let name = s.client.device_get_name(device).unwrap_or_default();
+            let uuid = s.client.device_get_uuid(device).unwrap_or([0; 16]);
             let total = s.client.device_total_mem(device).unwrap_or(0);
             let major = a(s, A_COMPUTE_MAJOR, 8);
             let minor = a(s, A_COMPUTE_MINOR, 6);
@@ -973,46 +1117,84 @@ pub extern "C" fn cudaGetDeviceProperties_v2(prop: *mut c_void, device: c_int) -
                 a(s, A_MAX_GRID_DIM_Y, 65535),
                 a(s, A_MAX_GRID_DIM_Z, 65535),
             );
+            let clock = a(s, A_CLOCK_RATE, 0);
+            let mem_clock = a(s, A_MEMORY_CLOCK_RATE, 0);
+            let bus_width = a(s, A_MEMORY_BUS_WIDTH, 0);
+            let l2 = a(s, A_L2_CACHE_SIZE, 0);
+            let persist_l2 = a(s, A_MAX_PERSISTING_L2, 0);
+            let engines = a(s, A_ASYNC_ENGINE_COUNT, 2);
+            let timeout = a(s, A_KERNEL_EXEC_TIMEOUT, 0);
+            let shmem_optin = a(s, A_MAX_SHMEM_PER_BLOCK_OPTIN, shmem_mp);
+            let reserved_shmem = a(s, A_RESERVED_SHMEM_PER_BLOCK, 0);
+            let max_blocks_mp = a(s, A_MAX_BLOCKS_PER_MP, 16);
+            let access_window = a(s, A_MAX_ACCESS_POLICY_WINDOW, 0);
+            let (pci_bus, pci_dev, pci_dom) = (
+                a(s, A_PCI_BUS_ID, 0),
+                a(s, A_PCI_DEVICE_ID, 0),
+                a(s, A_PCI_DOMAIN_ID, 0),
+            );
             // SAFETY: `prop` points at a caller-provided cudaDeviceProp we zeroed.
             let p = unsafe { &mut *(prop as *mut CudaDeviceProp) };
             let nb = name.as_bytes();
             let n = nb.len().min(255);
             p.name[..n].copy_from_slice(&nb[..n]);
+            p.uuid = uuid;
             p.total_global_mem = total as usize;
             p.shared_mem_per_block = shmem_blk as usize;
             p.regs_per_block = regs_blk;
             p.warp_size = warp;
+            p.mem_pitch = 2147483647;
             p.max_threads_per_block = max_tpb;
             p.max_threads_dim = [bx, by, bz];
             p.max_grid_size = [gx, gy, gz];
+            p.clock_rate = clock;
             p.total_const_mem = const_mem as usize;
             p.major = major;
             p.minor = minor;
+            p.texture_alignment = 512;
+            p.texture_pitch_alignment = 32;
+            p.device_overlap = (engines > 0) as c_int;
             p.multi_processor_count = mp;
+            p.kernel_exec_timeout_enabled = timeout;
             p.can_map_host_memory = 1;
-            p.concurrent_kernels = 1;
+            p.surface_alignment = 512;
+            p.concurrent_kernels = a(s, A_CONCURRENT_KERNELS, 1);
+            p.pci_bus_id = pci_bus;
+            p.pci_device_id = pci_dev;
+            p.pci_domain_id = pci_dom;
+            p.async_engine_count = engines;
             p.unified_addressing = 1;
+            p.memory_clock_rate = mem_clock;
+            p.memory_bus_width = bus_width;
+            p.l2_cache_size = l2;
+            p.persisting_l2_cache_max_size = persist_l2;
             p.max_threads_per_multiprocessor = max_tpm;
             p.stream_priorities_supported = 1;
             p.global_l1_cache_supported = 1;
             p.local_l1_cache_supported = 1;
             p.shared_mem_per_multiprocessor = shmem_mp as usize;
             p.regs_per_multiprocessor = regs_mp;
-            p.managed_memory = 1;
-            p.concurrent_managed_access = 1;
-            p.cooperative_launch = 1;
-            p.compute_preemption_supported = 1;
-            p.shared_mem_per_block_optin = shmem_mp as usize;
-            p.max_blocks_per_multiprocessor = 16;
-            // The hand-built struct tail diverges from CUDA 12.4's cudaDeviceProp
-            // by a few bytes, so PyTorch reads multiProcessorCount /
-            // maxThreadsPerMultiProcessor as 0 and divides by zero in its RNG
-            // launch config. Write those two at their verified real offsets.
-            unsafe {
-                let base = prop as *mut u8;
-                base.add(388).cast::<c_int>().write_unaligned(mp);
-                base.add(624).cast::<c_int>().write_unaligned(max_tpm);
-            }
+            p.managed_memory = a(s, A_MANAGED_MEMORY, 1);
+            p.single_to_double_precision_perf_ratio = a(s, A_SINGLE_TO_DOUBLE_PERF, 32);
+            p.concurrent_managed_access = a(s, A_CONCURRENT_MANAGED_ACCESS, 1);
+            p.compute_preemption_supported = a(s, A_COMPUTE_PREEMPTION, 1);
+            p.cooperative_launch = a(s, A_COOPERATIVE_LAUNCH, 1);
+            p.cooperative_multi_device_launch = a(s, A_COOPERATIVE_MULTI_DEVICE, 1);
+            p.shared_mem_per_block_optin = shmem_optin as usize;
+            p.max_blocks_per_multiprocessor = max_blocks_mp;
+            p.access_policy_max_window_size = access_window;
+            p.reserved_shared_mem_per_block = reserved_shmem as usize;
+            p.host_register_supported = a(s, A_HOST_REGISTER_SUPPORTED, 1);
+            p.timeline_semaphore_interop_supported = a(s, A_TIMELINE_SEMAPHORE, 1);
+            p.sparse_cuda_array_supported = a(s, A_SPARSE_CUDA_ARRAY, 0);
+            p.host_register_read_only_supported = a(s, A_READ_ONLY_HOST_REGISTER, 0);
+            // Deliberately NOT mirrored from the host GPU: capabilities that
+            // would steer callers onto paths forwarding can't honor. Pageable /
+            // registered host memory is guest RAM the host GPU can't reach by
+            // that pointer, mempools + IPC events are stubbed.
+            // (pageable_memory_access, can_use_host_pointer_for_registered_mem,
+            //  memory_pools_supported, memory_pool_supported_handle_types,
+            //  ipc_event_supported stay 0.)
             Ok(())
         })
         .err()

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -154,6 +154,11 @@ struct ShimState {
     host_allocs: HashMap<usize, std::alloc::Layout>,
     /// Live device allocations, to classify pointers for cudaMemcpyDefault.
     dev_allocs: HashSet<u64>,
+    /// Active CUDA graph capture, `(stream_handle, capture_id)`. Kept
+    /// guest-side so the per-launch hot queries (`cudaStreamIsCapturing`,
+    /// `cudaStreamGetCaptureInfo` — PyTorch's allocator calls them constantly)
+    /// answer locally instead of round-tripping.
+    capture: Option<(u64, u64)>,
 }
 
 static STATE: Mutex<Option<ShimState>> = Mutex::new(None);
@@ -167,6 +172,16 @@ thread_local! {
 
 fn set_last(code: c_int) -> c_int {
     if code != CUDA_SUCCESS {
+        if std::env::var_os("SMOLVM_CUDA_SHIM_TRACE").is_some() {
+            eprintln!(
+                "[shim-err] code={code} from {:?}",
+                std::backtrace::Backtrace::force_capture()
+                    .to_string()
+                    .lines()
+                    .nth(6)
+                    .unwrap_or("?")
+            );
+        }
         LAST_ERROR.with(|e| e.set(code));
     }
     code
@@ -209,6 +224,7 @@ fn with_client<T>(
             funcs: HashMap::new(),
             host_allocs: HashMap::new(),
             dev_allocs: HashSet::new(),
+            capture: None,
         });
     }
     let st = guard.as_mut().ok_or(CUDA_ERROR_INITIALIZATION)?;
@@ -705,10 +721,24 @@ pub extern "C" fn cudaMemcpyAsync(
     src: *const c_void,
     n: usize,
     kind: c_int,
-    _stream: *mut c_void,
+    stream: *mut c_void,
 ) -> c_int {
-    // Executed synchronously; ordering within a stream is preserved because all
-    // work runs on the host's single serving thread in call order.
+    // Device-to-device goes through the stream-ordered driver call: it
+    // pipelines like a launch and — critically — records into an active graph
+    // capture instead of invalidating it (the sync form is capture-unsafe).
+    let resolved = with_state(|s| Ok(resolve_kind(s, dst, src, kind))).unwrap_or(kind);
+    if resolved == MEMCPY_DTOD {
+        return set_last(
+            match with_client(|c| {
+                c.memcpy_dtod_async(dst as u64, src as u64, n as u64, stream as u64)
+            }) {
+                Ok(()) => CUDA_SUCCESS,
+                Err(e) => e,
+            },
+        );
+    }
+    // Other kinds execute synchronously; ordering within a stream is preserved
+    // because all work runs on the host's single serving thread in call order.
     set_last(do_memcpy(dst, src, n, kind))
 }
 
@@ -727,9 +757,18 @@ pub extern "C" fn cudaMemsetAsync(
     dev_ptr: *mut c_void,
     value: c_int,
     count: usize,
-    _stream: *mut c_void,
+    stream: *mut c_void,
 ) -> c_int {
-    cudaMemset(dev_ptr, value, count)
+    // Stream-ordered driver call: pipelines, and records into an active graph
+    // capture instead of invalidating it.
+    set_last(
+        match with_client(|c| {
+            c.memset_d8_async(dev_ptr as u64, value as u8, count as u64, stream as u64)
+        }) {
+            Ok(()) => CUDA_SUCCESS,
+            Err(e) => e,
+        },
+    )
 }
 
 // ---- streams ----------------------------------------------------------------
@@ -1047,26 +1086,179 @@ pub extern "C" fn cudaStreamWaitEvent(
 pub extern "C" fn cudaStreamQuery(_stream: *mut c_void) -> c_int {
     set_last(CUDA_SUCCESS) // always idle: prior work already ran
 }
+// ---- CUDA graphs -------------------------------------------------------------
+// Capture happens on the HOST driver: Begin/End forward, and every launch /
+// stream-ordered op issued in between lands on the capturing host stream and is
+// recorded (not executed) by the real driver. Replay is a single GraphLaunch
+// message for the whole graph — the antidote to per-launch round-trips in
+// launch-bound inference. The hot capture-status queries answer from the
+// guest-side `capture` field, costing nothing outside capture.
+
+/// cudaStreamCaptureStatusActive.
+const CAPTURE_ACTIVE: c_int = 1;
+
 #[no_mangle]
-pub extern "C" fn cudaStreamIsCapturing(_stream: *mut c_void, status: *mut c_int) -> c_int {
-    set_last(unsafe { out(status, 0) }) // cudaStreamCaptureStatusNone
+pub extern "C" fn cudaStreamBeginCapture(stream: *mut c_void, mode: c_int) -> c_int {
+    set_last(
+        match with_state(|s| {
+            s.client
+                .stream_begin_capture(stream as u64, mode)
+                .map_err(map_err)?;
+            // Fetch the driver's capture id once; the allocator re-reads it
+            // through the local queries below.
+            let (_, id) = s
+                .client
+                .stream_capture_info(stream as u64)
+                .map_err(map_err)?;
+            s.capture = Some((stream as u64, id));
+            Ok(())
+        }) {
+            Ok(()) => CUDA_SUCCESS,
+            Err(e) => e,
+        },
+    )
 }
+
+#[no_mangle]
+pub extern "C" fn cudaStreamEndCapture(stream: *mut c_void, graph: *mut *mut c_void) -> c_int {
+    if graph.is_null() {
+        return set_last(CUDA_ERROR_INVALID_VALUE);
+    }
+    set_last(
+        match with_state(|s| {
+            let g = s
+                .client
+                .stream_end_capture(stream as u64)
+                .map_err(map_err)?;
+            s.capture = None;
+            Ok(g)
+        }) {
+            Ok(g) => unsafe { out(graph, g as *mut c_void) },
+            Err(e) => {
+                let _ = with_state(|s| {
+                    s.capture = None;
+                    Ok(())
+                });
+                e
+            }
+        },
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn cudaStreamIsCapturing(stream: *mut c_void, status: *mut c_int) -> c_int {
+    let active = with_state(|s| Ok(matches!(s.capture, Some((cs, _)) if cs == stream as u64)))
+        .unwrap_or(false);
+    set_last(unsafe { out(status, if active { CAPTURE_ACTIVE } else { 0 }) })
+}
+
 #[no_mangle]
 pub extern "C" fn cudaStreamGetCaptureInfo_v2(
-    _stream: *mut c_void,
+    stream: *mut c_void,
     status: *mut c_int,
     id: *mut u64,
-    _graph: *mut *mut c_void,
-    _deps: *mut *mut *const c_void,
-    _num_deps: *mut usize,
+    graph: *mut *mut c_void,
+    deps: *mut *mut *const c_void,
+    num_deps: *mut usize,
 ) -> c_int {
+    let cap = with_state(|s| Ok(s.capture)).unwrap_or(None);
+    let (st, cid) = match cap {
+        Some((cs, cid)) if cs == stream as u64 => (CAPTURE_ACTIVE, cid),
+        _ => (0, 0),
+    };
     unsafe {
-        let _ = out(status, 0);
+        let _ = out(status, st);
         if !id.is_null() {
-            let _ = out(id, 0u64);
+            let _ = out(id, cid);
+        }
+        if !graph.is_null() {
+            let _ = out(graph, std::ptr::null_mut());
+        }
+        if !deps.is_null() {
+            let _ = out(deps, std::ptr::null_mut());
+        }
+        if !num_deps.is_null() {
+            let _ = out(num_deps, 0usize);
         }
     }
     set_last(CUDA_SUCCESS)
+}
+
+#[no_mangle]
+pub extern "C" fn cudaGraphInstantiate(
+    graph_exec: *mut *mut c_void,
+    graph: *mut c_void,
+    _error_node: *mut *mut c_void,
+    _log_buffer: *mut c_char,
+    _buffer_size: usize,
+) -> c_int {
+    cudaGraphInstantiateWithFlags(graph_exec, graph, 0)
+}
+
+#[no_mangle]
+pub extern "C" fn cudaGraphInstantiateWithFlags(
+    graph_exec: *mut *mut c_void,
+    graph: *mut c_void,
+    _flags: u64,
+) -> c_int {
+    if graph_exec.is_null() {
+        return set_last(CUDA_ERROR_INVALID_VALUE);
+    }
+    set_last(match with_client(|c| c.graph_instantiate(graph as u64)) {
+        Ok(e) => unsafe { out(graph_exec, e as *mut c_void) },
+        Err(e) => e,
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn cudaGraphLaunch(graph_exec: *mut c_void, stream: *mut c_void) -> c_int {
+    // The whole point: one pipelined message replays every captured kernel.
+    set_last(
+        match with_client(|c| c.graph_launch(graph_exec as u64, stream as u64)) {
+            Ok(()) => CUDA_SUCCESS,
+            Err(e) => e,
+        },
+    )
+}
+
+/// Count-only node query (`nodes == NULL`): PyTorch uses it to warn about
+/// empty captures. Filling a caller-provided node array is not supported.
+#[no_mangle]
+pub extern "C" fn cudaGraphGetNodes(
+    graph: *mut c_void,
+    nodes: *mut *mut c_void,
+    num_nodes: *mut usize,
+) -> c_int {
+    if num_nodes.is_null() {
+        return set_last(CUDA_ERROR_INVALID_VALUE);
+    }
+    match with_client(|c| c.graph_get_node_count(graph as u64)) {
+        Ok(n) => {
+            if !nodes.is_null() {
+                return set_last(CUDA_ERROR_INVALID_VALUE);
+            }
+            set_last(unsafe { out(num_nodes, n as usize) })
+        }
+        Err(e) => set_last(e),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn cudaGraphExecDestroy(graph_exec: *mut c_void) -> c_int {
+    set_last(
+        match with_client(|c| c.graph_exec_destroy(graph_exec as u64)) {
+            Ok(()) => CUDA_SUCCESS,
+            Err(e) => e,
+        },
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn cudaGraphDestroy(graph: *mut c_void) -> c_int {
+    set_last(match with_client(|c| c.graph_destroy(graph as u64)) {
+        Ok(()) => CUDA_SUCCESS,
+        Err(e) => e,
+    })
 }
 #[no_mangle]
 pub extern "C" fn cudaThreadExchangeStreamCaptureMode(_mode: *mut c_int) -> c_int {

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -1461,6 +1461,10 @@ fn do_launch(
     stream: u64,
     args: *mut *mut c_void,
 ) -> c_int {
+    // Debug bisection: drop launches entirely to isolate marshaling cost.
+    if std::env::var_os("SMOLVM_CUDA_NOOP_LAUNCH").is_some() {
+        return CUDA_SUCCESS;
+    }
     with_state(|s| {
         let rec = s
             .funcs
@@ -1568,6 +1572,7 @@ pub extern "C" fn __cudaLaunchKernel_ptsz(
 
 #[no_mangle]
 pub extern "C" fn cudaGetLastError() -> c_int {
+    merge_sticky_async_error();
     LAST_ERROR.with(|e| {
         let v = e.get();
         e.set(CUDA_SUCCESS);
@@ -1577,7 +1582,22 @@ pub extern "C" fn cudaGetLastError() -> c_int {
 
 #[no_mangle]
 pub extern "C" fn cudaPeekAtLastError() -> c_int {
+    merge_sticky_async_error();
     LAST_ERROR.with(|e| e.get())
+}
+
+/// Fold any sticky asynchronous-pipeline error (a deferred launch/memcpy that
+/// failed on the host) into the thread's last-error slot. Non-blocking: it
+/// only reports failures already observed, matching how `cudaGetLastError`
+/// reports asynchronous errors "seen so far" without synchronizing.
+fn merge_sticky_async_error() {
+    let _ = with_state(|s| {
+        let code = s.client.take_sticky();
+        if code != 0 {
+            set_last(map_err(CudaRpcError::Cuda(code)));
+        }
+        Ok(())
+    });
 }
 
 #[no_mangle]
@@ -1693,6 +1713,15 @@ mod gen_cudnn {
 // pointers, so attribute arrays ship as raw bytes sized by the attribute type.
 const LIB_CUDNN_BACKEND: u8 = 3;
 
+/// Guest-assigned virtual descriptor ids (bit 63 tags them; host userspace
+/// pointers and device VAs never set it). Lets create calls fire-and-forget:
+/// we invent the id, the host maps it to the real descriptor it creates.
+pub(crate) fn alloc_vhandle() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static NEXT: AtomicU64 = AtomicU64::new((1 << 63) | 1);
+    NEXT.fetch_add(1, Ordering::Relaxed)
+}
+
 /// Byte size of one `cudnnBackendAttributeType_t` element (must match host).
 fn cudnn_be_elem_size(t: c_int) -> usize {
     match t {
@@ -1711,14 +1740,17 @@ pub extern "C" fn cudnnBackendCreateDescriptor(
     if descriptor.is_null() {
         return 2000; // CUDNN_STATUS_BAD_PARAM
     }
-    let a = descriptor_type.to_le_bytes().to_vec();
-    match with_client(|c| c.lib_call(LIB_CUDNN_BACKEND, 0, a)) {
-        Ok((0, out)) if out.len() >= 8 => {
-            let h = u64::from_le_bytes(out[..8].try_into().unwrap());
-            unsafe { *descriptor = h as *mut c_void };
+    // Fire-and-forget: hand back a virtual id now; the host materializes the
+    // descriptor and maps the id. A creation failure surfaces on the next
+    // synchronous call touching it (Finalize/GetAttribute).
+    let vh = alloc_vhandle();
+    let mut a = descriptor_type.to_le_bytes().to_vec();
+    a.extend_from_slice(&vh.to_le_bytes());
+    match with_client(|c| c.lib_call_deferred(LIB_CUDNN_BACKEND, 0, a)) {
+        Ok(()) => {
+            unsafe { *descriptor = vh as *mut c_void };
             0
         }
-        Ok((st, _)) => st,
         Err(_) => 1,
     }
 }
@@ -1726,8 +1758,8 @@ pub extern "C" fn cudnnBackendCreateDescriptor(
 #[no_mangle]
 pub extern "C" fn cudnnBackendDestroyDescriptor(descriptor: *mut c_void) -> c_int {
     let a = (descriptor as u64).to_le_bytes().to_vec();
-    match with_client(|c| c.lib_call(LIB_CUDNN_BACKEND, 1, a)) {
-        Ok((st, _)) => st,
+    match with_client(|c| c.lib_call_deferred(LIB_CUDNN_BACKEND, 1, a)) {
+        Ok(()) => 0,
         Err(_) => 1,
     }
 }
@@ -1751,8 +1783,8 @@ pub extern "C" fn cudnnBackendSetAttribute(
             std::slice::from_raw_parts(array_of_elements as *const u8, n)
         });
     }
-    match with_client(|c| c.lib_call(LIB_CUDNN_BACKEND, 2, a)) {
-        Ok((st, _)) => st,
+    match with_client(|c| c.lib_call_deferred(LIB_CUDNN_BACKEND, 2, a)) {
+        Ok(()) => 0,
         Err(_) => 1,
     }
 }
@@ -1789,9 +1821,20 @@ pub extern "C" fn cudnnBackendGetAttribute(
                 let cap =
                     (requested_element_count.max(0) as usize) * cudnn_be_elem_size(attribute_type);
                 let n = bytes.len().min(cap);
-                unsafe {
-                    std::ptr::copy_nonoverlapping(bytes.as_ptr(), array_of_elements as *mut u8, n)
-                };
+                // Descriptor arrays are populated *in place*: the returned
+                // pointers are the caller's own descriptors, so keep the ids
+                // the caller passed (they may be virtual) instead of the real
+                // host pointers the server sees.
+                const TYPE_BACKEND_DESCRIPTOR: c_int = 15;
+                if attribute_type != TYPE_BACKEND_DESCRIPTOR {
+                    unsafe {
+                        std::ptr::copy_nonoverlapping(
+                            bytes.as_ptr(),
+                            array_of_elements as *mut u8,
+                            n,
+                        )
+                    };
+                }
             }
             0
         }
@@ -1819,8 +1862,8 @@ pub extern "C" fn cudnnBackendExecute(
     a.extend_from_slice(&(handle as u64).to_le_bytes());
     a.extend_from_slice(&(execution_plan as u64).to_le_bytes());
     a.extend_from_slice(&(variant_pack as u64).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_CUDNN_BACKEND, 5, a)) {
-        Ok((st, _)) => st,
+    match with_client(|c| c.lib_call_deferred(LIB_CUDNN_BACKEND, 5, a)) {
+        Ok(()) => 0,
         Err(_) => 1,
     }
 }
@@ -2109,8 +2152,8 @@ pub extern "C" fn cublasLtMatmul(
     buf.extend_from_slice(&(workspace as u64).to_le_bytes());
     buf.extend_from_slice(&(workspace_size_in_bytes as u64).to_le_bytes());
     buf.extend_from_slice(&(stream as u64).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_CUBLASLT, 10, buf)) {
-        Ok((st, _)) => st,
+    match with_client(|c| c.lib_call_deferred(LIB_CUBLASLT, 10, buf)) {
+        Ok(()) => CUBLAS_STATUS_SUCCESS,
         Err(_) => CUBLAS_STATUS_NOT_INITIALIZED,
     }
 }
@@ -2152,6 +2195,10 @@ pub extern "C" fn cudnnSetTensorNdDescriptor(
     a.extend_from_slice(&(tensor_desc as u64).to_le_bytes());
     a.extend_from_slice(&data_type.to_le_bytes());
     a.extend_from_slice(&nb_dims.to_le_bytes());
+    // Record this descriptor\'s content fingerprint (everything after the
+    // handle) so pure size queries over it can be memoized soundly — the
+    // handle value alone is reusable across different shapes.
+    record_desc_fingerprint(tensor_desc as u64, &a[8..]);
     for arr in [dim_a, stride_a] {
         for i in 0..n {
             let v = if arr.is_null() {
@@ -2162,8 +2209,8 @@ pub extern "C" fn cudnnSetTensorNdDescriptor(
             a.extend_from_slice(&v.to_le_bytes());
         }
     }
-    match with_client(|c| c.lib_call(LIB_CUDNN_BN, 0, a)) {
-        Ok((st, _)) => st,
+    match with_client(|c| c.lib_call_deferred(LIB_CUDNN_BN, 0, a)) {
+        Ok(()) => 0,
         Err(_) => 1,
     }
 }
@@ -2205,8 +2252,8 @@ pub extern "C" fn cudnnBatchNormalizationForwardInference(
         a.extend_from_slice(&p.to_le_bytes());
     }
     a.extend_from_slice(&epsilon.to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_CUDNN_BN, 2, a)) {
-        Ok((st, _)) => st,
+    match with_client(|c| c.lib_call_deferred(LIB_CUDNN_BN, 2, a)) {
+        Ok(()) => 0,
         Err(_) => 1,
     }
 }
@@ -2274,8 +2321,8 @@ pub extern "C" fn cudnnBatchNormalizationForwardTrainingEx(
     a.extend_from_slice(&(ws_size as u64).to_le_bytes());
     a.extend_from_slice(&(reserve as u64).to_le_bytes());
     a.extend_from_slice(&(reserve_size as u64).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_CUDNN_BN, 3, a)) {
-        Ok((st, _)) => st,
+    match with_client(|c| c.lib_call_deferred(LIB_CUDNN_BN, 3, a)) {
+        Ok(()) => 0,
         Err(_) => 1,
     }
 }
@@ -2353,19 +2400,81 @@ pub extern "C" fn cudnnBatchNormalizationBackwardEx(
     a.extend_from_slice(&(ws_size as u64).to_le_bytes());
     a.extend_from_slice(&(reserve as u64).to_le_bytes());
     a.extend_from_slice(&(reserve_size as u64).to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_CUDNN_BN, 4, a)) {
-        Ok((st, _)) => st,
+    match with_client(|c| c.lib_call_deferred(LIB_CUDNN_BN, 4, a)) {
+        Ok(()) => 0,
         Err(_) => 1,
     }
 }
 
+/// Tensor-descriptor content fingerprints (dtype + dims + strides from the
+/// last `cudnnSetTensorNdDescriptor`), keyed by handle value. A handle alone
+/// is not a stable identity — destroy/create can reuse the address — so size
+/// memoization keys on these contents instead.
+static DESC_FP: Mutex<Option<HashMap<u64, Vec<u8>>>> = Mutex::new(None);
+
+fn record_desc_fingerprint(desc: u64, contents: &[u8]) {
+    if let Ok(mut g) = DESC_FP.lock() {
+        g.get_or_insert_with(HashMap::new)
+            .insert(desc, contents.to_vec());
+    }
+}
+
+/// Rewrite a BN size-query arg blob into a content-addressed memo key: every
+/// descriptor handle is replaced by its recorded fingerprint. `None` (do not
+/// cache) if any non-null descriptor has no fingerprint on record.
+fn bn_memo_key(func: u16, args: &[u8]) -> Option<Vec<u8>> {
+    // Layouts (see the three Get*Size wrappers): handle u64, mode i32, ops i32,
+    // then only u64 descriptor handles (5/7 for the workspace queries, act+x
+    // for the reserve query). The leading cudnn handle is identity-stable.
+    if args.len() < 16 || (args.len() - 16) % 8 != 0 {
+        return None;
+    }
+    let fps = DESC_FP.lock().ok()?;
+    let fps = fps.as_ref()?;
+    let mut key = Vec::with_capacity(args.len() * 4);
+    key.extend_from_slice(&func.to_le_bytes());
+    key.extend_from_slice(&args[..16]);
+    for chunk in args[16..].chunks_exact(8) {
+        let h = u64::from_le_bytes(chunk.try_into().unwrap());
+        if h == 0 {
+            key.push(0);
+            continue;
+        }
+        let fp = fps.get(&h)?; // unknown descriptor → uncacheable
+        key.extend_from_slice(&(fp.len() as u32).to_le_bytes());
+        key.extend_from_slice(fp);
+    }
+    Some(key)
+}
+
 /// Shared tail for the three `Get...Size` queries: forward the packed args and
-/// write the returned `size_t` through `size_out`.
+/// write the returned `size_t` through `size_out`. Memoized on the descriptor
+/// *contents* (not handles): the sizes are pure functions of those contents,
+/// and PyTorch re-queries them on every batch-norm invocation (~150 sync
+/// round-trips per ResNet training step without the cache).
 fn bn_size_call(func: u16, args: Vec<u8>, size_out: *mut usize) -> c_int {
+    static MEMO: Mutex<Option<HashMap<Vec<u8>, usize>>> = Mutex::new(None);
+    let key = bn_memo_key(func, &args);
+    if let Some(k) = &key {
+        if let Ok(mut g) = MEMO.lock() {
+            if let Some(sz) = g.get_or_insert_with(HashMap::new).get(k) {
+                if !size_out.is_null() {
+                    unsafe { *size_out = *sz };
+                }
+                return 0;
+            }
+        }
+    }
     match with_client(|c| c.lib_call(LIB_CUDNN_BN, func, args)) {
         Ok((0, out)) if out.len() >= 8 => {
+            let sz = u64::from_le_bytes(out[..8].try_into().unwrap()) as usize;
             if !size_out.is_null() {
-                unsafe { *size_out = u64::from_le_bytes(out[..8].try_into().unwrap()) as usize };
+                unsafe { *size_out = sz };
+            }
+            if let Some(k) = key {
+                if let Ok(mut g) = MEMO.lock() {
+                    g.get_or_insert_with(HashMap::new).insert(k, sz);
+                }
             }
             0
         }

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -1413,9 +1413,22 @@ pub extern "C" fn cudaFuncGetAttributes(attr: *mut c_void, _func: *const c_void)
     }
     set_last(CUDA_SUCCESS)
 }
+/// Forward the shared-memory opt-in (`cudaFuncAttributeMaxDynamicSharedMemorySize`
+/// = 8, matching the driver's `CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES`)
+/// to the host function. FlashAttention/cutlass kernels needing >48 KiB shared
+/// memory raise it here before launching, or the launch fails with INVALID_VALUE.
+/// The runtime and driver enum values coincide, so `attr` passes through.
 #[no_mangle]
-pub extern "C" fn cudaFuncSetAttribute(_func: *const c_void, _attr: c_int, _value: c_int) -> c_int {
-    set_last(CUDA_SUCCESS)
+pub extern "C" fn cudaFuncSetAttribute(func: *const c_void, attr: c_int, value: c_int) -> c_int {
+    let r = with_state(|s| {
+        let fid = s
+            .funcs
+            .get(&(func as usize))
+            .ok_or(CUDA_ERROR_INVALID_DEVICE_POINTER)?
+            .fid;
+        s.client.func_set_attribute(fid, attr, value).map_err(map_err)
+    });
+    set_last(r.err().unwrap_or(CUDA_SUCCESS))
 }
 #[no_mangle]
 pub extern "C" fn cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -176,14 +176,9 @@ thread_local! {
 fn set_last(code: c_int) -> c_int {
     if code != CUDA_SUCCESS {
         if std::env::var_os("SMOLVM_CUDA_SHIM_TRACE").is_some() {
-            eprintln!(
-                "[shim-err] code={code} from {:?}",
-                std::backtrace::Backtrace::force_capture()
-                    .to_string()
-                    .lines()
-                    .nth(6)
-                    .unwrap_or("?")
-            );
+            let bt = std::backtrace::Backtrace::force_capture().to_string();
+            let frames: Vec<&str> = bt.lines().take(16).collect();
+            eprintln!("[shim-err] code={code} frames:\n{}", frames.join("\n"));
         }
         LAST_ERROR.with(|e| e.set(code));
     }
@@ -199,9 +194,19 @@ fn map_err(e: CudaRpcError) -> c_int {
             2 => CUDA_ERROR_MEMORY_ALLOCATION,
             200 | 218 => CUDA_ERROR_INVALID_VALUE, // invalid image / PTX
             400 => CUDA_ERROR_INVALID_RESOURCE_HANDLE,
-            _ => CUDA_ERROR_UNKNOWN,
+            other => {
+                if std::env::var_os("SMOLVM_CUDA_SHIM_TRACE").is_some() {
+                    eprintln!("[map-err] unmapped driver code {other}");
+                }
+                CUDA_ERROR_UNKNOWN
+            }
         },
-        CudaRpcError::Io(_) | CudaRpcError::Protocol(_) => CUDA_ERROR_UNKNOWN,
+        CudaRpcError::Io(_) | CudaRpcError::Protocol(_) => {
+            if std::env::var_os("SMOLVM_CUDA_SHIM_TRACE").is_some() {
+                eprintln!("[map-err] transport: {e}");
+            }
+            CUDA_ERROR_UNKNOWN
+        }
     }
 }
 
@@ -830,6 +835,21 @@ fn resolve_kind(s: &ShimState, dst: *const c_void, src: *const c_void, kind: c_i
 }
 
 fn do_memcpy(dst: *mut c_void, src: *const c_void, n: usize, kind: c_int, stream: u64) -> c_int {
+    let dbg = std::env::var_os("SMOLVM_CUDA_TRACE_MEMCPY").is_some();
+    let r = do_memcpy_inner(dst, src, n, kind, stream);
+    if dbg && r != CUDA_SUCCESS {
+        eprintln!("[memcpy-err] kind={kind} n={n} -> {r}");
+    }
+    r
+}
+
+fn do_memcpy_inner(
+    dst: *mut c_void,
+    src: *const c_void,
+    n: usize,
+    kind: c_int,
+    stream: u64,
+) -> c_int {
     with_state(|s| {
         let kind = resolve_kind(s, dst, src, kind);
         match kind {
@@ -856,10 +876,17 @@ fn do_memcpy(dst: *mut c_void, src: *const c_void, n: usize, kind: c_int, stream
                         .memcpy_shm_htod(dst as u64, off, n as u64, stream)
                         .map_err(map_err);
                 }
+                // Chunk: one frame must stay far below the transport's
+                // 256 MiB message cap (a 272 MiB embedding tensor here killed
+                // the connection). Host-synchronous copies chunk safely.
                 let data = unsafe { std::slice::from_raw_parts(src as *const u8, n) };
-                s.client
-                    .memcpy_htod(dst as u64, data, stream)
-                    .map_err(map_err)
+                const CHUNK: usize = 64 * 1024 * 1024;
+                for (i, piece) in data.chunks(CHUNK).enumerate() {
+                    s.client
+                        .memcpy_htod(dst as u64 + (i * CHUNK) as u64, piece, stream)
+                        .map_err(map_err)?;
+                }
+                Ok(())
             }
             MEMCPY_DTOH => {
                 if let Some(segs) = guestmem::segments(dst as usize, n) {
@@ -874,14 +901,22 @@ fn do_memcpy(dst: *mut c_void, src: *const c_void, n: usize, kind: c_int, stream
                         .memcpy_shm_dtoh(off, src as u64, n as u64, stream)
                         .map_err(map_err);
                 }
-                let data = s
-                    .client
-                    .memcpy_dtoh(src as u64, n as u64, stream)
-                    .map_err(map_err)?;
-                if data.len() != n {
-                    return Err(CUDA_ERROR_UNKNOWN);
+                const CHUNK: usize = 64 * 1024 * 1024; // see H2D: stay under the frame cap
+                let mut off = 0;
+                while off < n {
+                    let c = (n - off).min(CHUNK);
+                    let data = s
+                        .client
+                        .memcpy_dtoh(src as u64 + off as u64, c as u64, stream)
+                        .map_err(map_err)?;
+                    if data.len() != c {
+                        return Err(CUDA_ERROR_UNKNOWN);
+                    }
+                    unsafe {
+                        std::ptr::copy_nonoverlapping(data.as_ptr(), (dst as *mut u8).add(off), c)
+                    };
+                    off += c;
                 }
-                unsafe { std::ptr::copy_nonoverlapping(data.as_ptr(), dst as *mut u8, n) };
                 Ok(())
             }
             MEMCPY_DTOD => s

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -2438,7 +2438,7 @@ const LIB_CUDNN_BN: u8 = 5;
 /// stub that returned an int caused a segfault. The exact text is cosmetic.
 #[no_mangle]
 pub extern "C" fn cudnnGetErrorString(_status: c_int) -> *const c_char {
-    b"cudnn status (forwarded by smolvm)\0".as_ptr() as *const c_char
+    c"cudnn status (forwarded by smolvm)".as_ptr()
 }
 
 /// Read a host float behind a `*const c_void` (cuDNN alpha/beta), 0.0 if null.
@@ -2694,7 +2694,7 @@ fn bn_memo_key(func: u16, args: &[u8]) -> Option<Vec<u8>> {
     // Layouts (see the three Get*Size wrappers): handle u64, mode i32, ops i32,
     // then only u64 descriptor handles (5/7 for the workspace queries, act+x
     // for the reserve query). The leading cudnn handle is identity-stable.
-    if args.len() < 16 || (args.len() - 16) % 8 != 0 {
+    if args.len() < 16 || !(args.len() - 16).is_multiple_of(8) {
         return None;
     }
     let fps = DESC_FP.lock().ok()?;

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -296,17 +296,77 @@ pub extern "C" fn smolvm_cudart_bridge_drain() -> i32 {
     .unwrap_or(999)
 }
 
+/// Allocate one ring region: pinned pages + their per-page GPAs.
+fn ring_alloc_pages(pages: usize) -> Option<(Vec<*mut u8>, Vec<u64>)> {
+    const PAGE: usize = 4096;
+    let base = guestmem::alloc(pages * PAGE)? as usize;
+    // Zero (also faults every page in before pagemap reads).
+    unsafe { std::ptr::write_bytes(base as *mut u8, 0, pages * PAGE) };
+    let segs = guestmem::segments(base, pages * PAGE)?;
+    let mut gpas = Vec::with_capacity(pages);
+    for (gpa, len) in segs {
+        let mut off = 0;
+        while off < len {
+            gpas.push(gpa + off);
+            off += PAGE as u64;
+        }
+    }
+    if gpas.len() != pages {
+        return None;
+    }
+    Some((
+        (0..pages).map(|i| (base + i * PAGE) as *mut u8).collect(),
+        gpas,
+    ))
+}
+
+/// Try to switch `client` to the shared-memory ring transport. Failure is
+/// fine — the connection simply stays on the socket.
+fn ring_try_setup(client: &mut Client<Stream>) {
+    const PAGE: usize = 4096;
+    let trace = std::env::var_os("SMOLVM_CUDA_SHIM_TRACE").is_some();
+    let Some(req) = ring_alloc_pages(32) else {
+        if trace {
+            eprintln!("[ring] no pinned pages (zerocopy off?) — socket mode");
+        }
+        return;
+    };
+    let (Some(resp), Some(bounce)) = (ring_alloc_pages(8), ring_alloc_pages(64)) else {
+        return;
+    };
+    match client.ring_setup(PAGE, req, resp, bounce) {
+        Ok(()) => {
+            if trace {
+                eprintln!("[ring] shared-memory rings active");
+            }
+        }
+        Err(e) => {
+            if trace {
+                eprintln!("[ring] setup rejected ({e}) — socket mode");
+            }
+        }
+    }
+}
+
 fn with_client<T>(
     f: impl FnOnce(&mut Client<Stream>) -> Result<T, CudaRpcError>,
 ) -> Result<T, c_int> {
     let mut guard = STATE.lock().map_err(|_| CUDA_ERROR_UNKNOWN)?;
     if guard.is_none() {
         let stream = connect()?;
+        #[cfg(target_os = "linux")]
+        let try_ring = matches!(stream, Stream::Vsock(_))
+            && std::env::var("SMOLVM_CUDA_RING").as_deref() != Ok("0");
+        #[cfg(not(target_os = "linux"))]
+        let try_ring = false;
         let mut client = Client::new(stream);
         client.init().map_err(|_| CUDA_ERROR_INITIALIZATION)?;
         let _ = client
             .primary_ctx_retain(0)
             .map_err(|_| CUDA_ERROR_INITIALIZATION)?;
+        if try_ring {
+            ring_try_setup(&mut client); // best-effort; socket mode on failure
+        }
         *guard = Some(ShimState {
             client,
             initialized: true,

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -467,6 +467,31 @@ pub extern "C" fn cudaMalloc(dev_ptr: *mut *mut c_void, size: usize) -> c_int {
     )
 }
 
+/// `cudaMallocManaged` served as plain device memory: bitsandbytes links it
+/// (its paged optimizers host-access managed pointers — those would fault —
+/// but its 4-bit/8-bit compute paths only need the symbol to resolve and the
+/// pointer to be device-valid).
+#[no_mangle]
+pub extern "C" fn cudaMallocManaged(
+    dev_ptr: *mut *mut c_void,
+    size: usize,
+    _flags: c_uint,
+) -> c_int {
+    cudaMalloc(dev_ptr, size)
+}
+
+/// Managed-memory prefetch hint: nothing to do, our "managed" memory is
+/// always device-resident.
+#[no_mangle]
+pub extern "C" fn cudaMemPrefetchAsync(
+    _dev_ptr: *const c_void,
+    _count: usize,
+    _dst_device: c_int,
+    _stream: *mut c_void,
+) -> c_int {
+    CUDA_SUCCESS
+}
+
 /// Is `p` inside any live device allocation (base ≤ p < base+size)?
 fn dev_contains(allocs: &std::collections::BTreeMap<u64, u64>, p: u64) -> bool {
     allocs

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -32,7 +32,7 @@
 use smolvm_cuda::client::{Client, CudaRpcError};
 mod cublas_stubs;
 use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::ffi::{c_char, c_int, c_uint, c_void, CStr, CString};
 use std::io::{Read, Write};
 use std::sync::Mutex;
@@ -152,8 +152,11 @@ struct ShimState {
     funcs: HashMap<usize, FuncRec>,
     /// Host pinned-memory allocations (guest RAM) → layout, for cudaFreeHost.
     host_allocs: HashMap<usize, std::alloc::Layout>,
-    /// Live device allocations, to classify pointers for cudaMemcpyDefault.
-    dev_allocs: HashSet<u64>,
+    /// Live device allocations, base → size. Range-queried (not exact-match):
+    /// PyTorch's caching allocator suballocates, so tensor data pointers are
+    /// interior to a cudaMalloc'd block — `cudaPointerGetAttributes` on one
+    /// must still report Device or torch's `getDeviceFromPtr` throws.
+    dev_allocs: std::collections::BTreeMap<u64, u64>,
     /// Active CUDA graph capture, `(stream_handle, capture_id)`. Kept
     /// guest-side so the per-launch hot queries (`cudaStreamIsCapturing`,
     /// `cudaStreamGetCaptureInfo` — PyTorch's allocator calls them constantly)
@@ -206,6 +209,20 @@ fn map_err(e: CudaRpcError) -> c_int {
 /// client. The first call performs `cuInit` + `cuDevicePrimaryCtxRetain(0)`
 /// (which the host binds current on its serving thread), matching how the CUDA
 /// runtime brings up its device on first use.
+/// Cross-shim ordering hook, dlsym'd by the driver shim (`libcuda.so.1`).
+/// The two shims hold separate connections to the host, i.e. two ordering
+/// domains for one guest program-order stream; the driver shim fences this
+/// connection before each of its own ops so runtime-issued work (deferred in
+/// the pipeline) executes first. No-op before the runtime connection exists.
+#[no_mangle]
+pub extern "C" fn smolvm_cudart_fence() {
+    if let Ok(mut guard) = STATE.lock() {
+        if let Some(st) = guard.as_mut() {
+            let _ = st.client.drain();
+        }
+    }
+}
+
 fn with_client<T>(
     f: impl FnOnce(&mut Client<Stream>) -> Result<T, CudaRpcError>,
 ) -> Result<T, c_int> {
@@ -223,7 +240,7 @@ fn with_client<T>(
             modules: HashMap::new(),
             funcs: HashMap::new(),
             host_allocs: HashMap::new(),
-            dev_allocs: HashSet::new(),
+            dev_allocs: std::collections::BTreeMap::new(),
             capture: None,
         });
     }
@@ -308,13 +325,21 @@ pub extern "C" fn cudaMalloc(dev_ptr: *mut *mut c_void, size: usize) -> c_int {
     set_last(
         match with_state(|s| {
             let d = s.client.mem_alloc(size as u64).map_err(map_err)?;
-            s.dev_allocs.insert(d);
+            s.dev_allocs.insert(d, size as u64);
             Ok(d)
         }) {
             Ok(d) => unsafe { out(dev_ptr, d as *mut c_void) },
             Err(e) => e,
         },
     )
+}
+
+/// Is `p` inside any live device allocation (base ≤ p < base+size)?
+fn dev_contains(allocs: &std::collections::BTreeMap<u64, u64>, p: u64) -> bool {
+    allocs
+        .range(..=p)
+        .next_back()
+        .is_some_and(|(base, size)| p < base + size)
 }
 
 #[no_mangle]
@@ -636,8 +661,8 @@ fn resolve_kind(s: &ShimState, dst: *const c_void, src: *const c_void, kind: c_i
     if kind != MEMCPY_DEFAULT {
         return kind;
     }
-    let dst_dev = s.dev_allocs.contains(&(dst as u64));
-    let src_dev = s.dev_allocs.contains(&(src as u64));
+    let dst_dev = dev_contains(&s.dev_allocs, dst as u64);
+    let src_dev = dev_contains(&s.dev_allocs, src as u64);
     match (src_dev, dst_dev) {
         (false, true) => MEMCPY_HTOD,
         (true, false) => MEMCPY_DTOH,
@@ -1043,9 +1068,15 @@ pub extern "C" fn cudaEventSynchronize(event: *mut c_void) -> c_int {
     })
 }
 #[no_mangle]
-pub extern "C" fn cudaEventQuery(_event: *mut c_void) -> c_int {
-    // Serving thread runs work in call order, so a recorded event is complete.
-    set_last(CUDA_SUCCESS)
+pub extern "C" fn cudaEventQuery(event: *mut c_void) -> c_int {
+    // Must be honest: PyTorch's allocator polls this to decide when freed
+    // blocks are safe to reuse. Always answering "complete" caused premature
+    // reuse (ILLEGAL_ADDRESS) once work really ran on side streams. NotReady
+    // (600) latches into last-error exactly like real cudart; torch clears it.
+    set_last(match with_client(|c| c.event_query(event as u64)) {
+        Ok(code) => code,
+        Err(e) => e,
+    })
 }
 #[no_mangle]
 pub extern "C" fn cudaEventElapsedTime(
@@ -1076,15 +1107,27 @@ pub extern "C" fn cudaStreamCreateWithPriority(
 }
 #[no_mangle]
 pub extern "C" fn cudaStreamWaitEvent(
-    _stream: *mut c_void,
-    _event: *mut c_void,
-    _flags: c_uint,
+    stream: *mut c_void,
+    event: *mut c_void,
+    flags: c_uint,
 ) -> c_int {
-    set_last(CUDA_SUCCESS) // in-order execution on the serving thread
+    // A real cross-stream ordering edge now that work runs on side streams
+    // (and a graph dependency during capture) — dropping it made replays racy
+    // (ILLEGAL_ADDRESS). Deferred like a launch.
+    set_last(
+        match with_client(|c| c.stream_wait_event(stream as u64, event as u64, flags)) {
+            Ok(()) => CUDA_SUCCESS,
+            Err(e) => e,
+        },
+    )
 }
 #[no_mangle]
-pub extern "C" fn cudaStreamQuery(_stream: *mut c_void) -> c_int {
-    set_last(CUDA_SUCCESS) // always idle: prior work already ran
+pub extern "C" fn cudaStreamQuery(stream: *mut c_void) -> c_int {
+    // Honest completion status (0 or 600-NotReady), same as cudaEventQuery.
+    set_last(match with_client(|c| c.stream_query(stream as u64)) {
+        Ok(code) => code,
+        Err(e) => e,
+    })
 }
 // ---- CUDA graphs -------------------------------------------------------------
 // Capture happens on the HOST driver: Begin/End forward, and every launch /
@@ -1261,8 +1304,26 @@ pub extern "C" fn cudaGraphDestroy(graph: *mut c_void) -> c_int {
     })
 }
 #[no_mangle]
-pub extern "C" fn cudaThreadExchangeStreamCaptureMode(_mode: *mut c_int) -> c_int {
-    set_last(CUDA_SUCCESS)
+pub extern "C" fn cudaThreadExchangeStreamCaptureMode(mode: *mut c_int) -> c_int {
+    // PyTorch's allocator wraps capture-time cudaMalloc in a relaxed-mode
+    // guard via this call. The per-thread mode must take effect on the HOST
+    // thread that will execute the malloc — each connection is served by one
+    // host thread, so forwarding maps the semantics exactly. A no-op here
+    // leaves the host thread in global mode and the malloc fails with 900
+    // (cudaErrorStreamCaptureUnsupported), invalidating the capture.
+    if mode.is_null() {
+        return set_last(CUDA_ERROR_INVALID_VALUE);
+    }
+    let new_mode = unsafe { *mode };
+    set_last(
+        match with_client(|c| c.thread_exchange_capture_mode(new_mode)) {
+            Ok(old) => {
+                unsafe { *mode = old };
+                CUDA_SUCCESS
+            }
+            Err(e) => e,
+        },
+    )
 }
 /// `cudaStreamCallback_t` = `void (*)(cudaStream_t, cudaError_t, void*)`.
 type StreamCallback = unsafe extern "C" fn(*mut c_void, c_int, *mut c_void);
@@ -1365,7 +1426,7 @@ pub extern "C" fn cudaPointerGetAttributes(attr: *mut c_void, ptr: *const c_void
     // unregistered, and PyTorch's `is_pinned()` relies on that: reporting Host
     // for arbitrary pointers made `pin_memory()` a silent no-op, so pinned
     // transfers never reached the zero-copy path.
-    let is_dev = with_state(|s| Ok(s.dev_allocs.contains(&(ptr as u64)))).unwrap_or(false);
+    let is_dev = with_state(|s| Ok(dev_contains(&s.dev_allocs, ptr as u64))).unwrap_or(false);
     let is_pinned_host = !is_dev
         && (guestmem::is_pinned(ptr as usize)
             || shm_offset(ptr).is_some()
@@ -1426,7 +1487,9 @@ pub extern "C" fn cudaFuncSetAttribute(func: *const c_void, attr: c_int, value: 
             .get(&(func as usize))
             .ok_or(CUDA_ERROR_INVALID_DEVICE_POINTER)?
             .fid;
-        s.client.func_set_attribute(fid, attr, value).map_err(map_err)
+        s.client
+            .func_set_attribute(fid, attr, value)
+            .map_err(map_err)
     });
     set_last(r.err().unwrap_or(CUDA_SUCCESS))
 }


### PR DESCRIPTION
Continues #585 with the commits that landed after its merge — async pipelining, CUDA graph forwarding, vLLM enablement — plus stream-ordered host copies, a byte-exact cudaDeviceProp, one shared connection for both shims, and fence elision: opt-1.3b decodes at 94% of native over loopback (293.8 vs 311.8 tok/s) and 69% inside a vsock microVM; opt-125m in-VM improved 378 -> 426 tok/s.