### PR TITLE
Official Arch Linux pacman repository

### DIFF
--- a/.github/workflows/pacman-repo.yml
+++ b/.github/workflows/pacman-repo.yml
@@ -1,0 +1,79 @@
+name: Publish pacman repo
+
+# Builds Arch packages from the release binaries and publishes them to
+# rolling releases (pacman-repo-x86_64 / pacman-repo-aarch64) that serve
+# as pacman repository endpoints. See docs/install/arch.md.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to package (e.g. v1.5.0)'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:base-devel
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Resolve tag
+        id: tag
+        run: |
+          TAG='${{ github.event.release.tag_name || inputs.tag }}'
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "pkgver=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Install tooling
+        run: pacman -Syu --noconfirm pacman-contrib github-cli git
+
+      - uses: actions/checkout@v4
+
+      - name: Prepare build user
+        run: |
+          useradd -m builder
+          echo 'builder ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/builder
+          cp -r packaging/arch /home/builder/build
+          chown -R builder /home/builder/build
+
+      - name: Build packages (both arches; repackage-only, no compilation)
+        run: |
+          cd /home/builder/build
+          sed -i "s/^pkgver=.*/pkgver=${{ steps.tag.outputs.pkgver }}/; s/^pkgrel=.*/pkgrel=1/" PKGBUILD
+          sudo -u builder updpkgsums
+          sudo -u builder makepkg -df --noconfirm
+          sudo -u builder env CARCH=aarch64 makepkg -df --noconfirm --ignorearch
+          ls -l *.pkg.tar.zst
+
+      - name: Publish to rolling pacman repo releases
+        run: |
+          git config --global --add safe.directory "$PWD"
+          cd /home/builder/build
+          for arch in x86_64 aarch64; do
+            roll="pacman-repo-$arch"
+            mkdir -p "repo-$arch" && cd "repo-$arch"
+            cp ../smolvm-*-"$arch".pkg.tar.zst .
+            # fetch existing db (first run: absent)
+            gh release download "$roll" -R "$GITHUB_REPOSITORY" \
+              -p 'smol-machines.db.tar.gz' -p 'smol-machines.files.tar.gz' 2>/dev/null || true
+            repo-add smol-machines.db.tar.gz smolvm-*-"$arch".pkg.tar.zst
+            # rolling release exists? create once
+            gh release view "$roll" -R "$GITHUB_REPOSITORY" >/dev/null 2>&1 || \
+              gh release create "$roll" -R "$GITHUB_REPOSITORY" --prerelease \
+                --title "pacman repo ($arch)" \
+                --notes "Rolling pacman repository endpoint for $arch. Do not delete. See docs/install/arch.md."
+            # upload package + db (db symlink targets must be uploaded as real files)
+            cp --remove-destination "$(readlink -f smol-machines.db)" smol-machines.db
+            cp --remove-destination "$(readlink -f smol-machines.files)" smol-machines.files
+            gh release upload "$roll" -R "$GITHUB_REPOSITORY" --clobber \
+              smolvm-*-"$arch".pkg.tar.zst \
+              smol-machines.db.tar.gz smol-machines.files.tar.gz \
+              smol-machines.db smol-machines.files
+            cd ..
+          done

--- a/docs/install-arch.md
+++ b/docs/install-arch.md
@@ -1,0 +1,40 @@
+# Installing smolvm on Arch Linux
+
+smolvm ships an **official pacman repository** maintained by the smol-machines
+team. It serves prebuilt packages for `x86_64` and `aarch64`, updated
+automatically with every release.
+
+> The `smolvm`, `smolvm-bin` and `smolvm-git` packages on the AUR are
+> third-party and not maintained by us. As of 1.4.7 they link against the
+> stock Arch `libkrun`, which lacks six symbols smolvm needs — disk overlays,
+> snapshots and egress policy do not work with those packages. The official
+> package bundles the smol-machines libkrun fork and is fully functional.
+
+## Setup
+
+Add the repository to `/etc/pacman.conf`:
+
+```ini
+[smol-machines]
+SigLevel = Optional TrustAll
+Server = https://github.com/smol-machines/smolvm/releases/download/pacman-repo-$arch
+```
+
+Then install:
+
+```sh
+sudo pacman -Sy smolvm
+```
+
+Upgrades arrive with your normal `pacman -Syu`.
+
+## Notes
+
+- The repository is served from rolling GitHub releases
+  (`pacman-repo-x86_64`, `pacman-repo-aarch64`); packages are built by CI
+  from the signed release artifacts (`.github/workflows/pacman-repo.yml`).
+- Package signing (GPG) is planned; until then integrity is provided by
+  sha256-pinned sources built in CI and served over HTTPS.
+- The package bundles the smol-machines `libkrun`/`libkrunfw` fork under
+  `/usr/lib/smolvm/lib` — it does not conflict with the system `libkrun`
+  package, which other software may continue to use.

--- a/packaging/arch/.gitignore
+++ b/packaging/arch/.gitignore
@@ -1,0 +1,5 @@
+*.pkg.tar.zst
+*.tar.gz
+src/
+pkg/
+LICENSE-*

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,0 +1,68 @@
+# Maintainer: BinSquare <hebinsquared@gmail.com>
+# Official smol-machines package — served from the smol-machines pacman repo.
+# Repackages the upstream release binaries (includes the smol-machines
+# libkrun fork, soname libkrun.so.2, which stock Arch libkrun cannot replace:
+# disk overlays, snapshots, egress policy and control-socket support need it).
+pkgname=smolvm
+pkgver=1.5.0
+pkgrel=1
+pkgdesc='Build & run portable, lightweight, self-contained virtual machines (official smol-machines package)'
+arch=('x86_64' 'aarch64')
+url='https://github.com/smol-machines/smolvm'
+license=('Apache-2.0')
+depends=(
+    'seatd'
+    'crun'
+    'jq'
+    'e2fsprogs'
+    'util-linux'
+    'libcap'
+    'gzip'
+    'tar'
+)
+options=(!debug !strip)
+conflicts=('smolvm-bin' 'smolvm-git')
+source=(
+    "LICENSE-$pkgver::https://raw.githubusercontent.com/smol-machines/$pkgname/refs/tags/v$pkgver/LICENSE"
+)
+source_x86_64=(
+    "$pkgname-$pkgver-linux-x86_64.tar.gz::$url/releases/download/v$pkgver/$pkgname-$pkgver-linux-x86_64.tar.gz"
+)
+source_aarch64=(
+    "$pkgname-$pkgver-linux-arm64.tar.gz::$url/releases/download/v$pkgver/$pkgname-$pkgver-linux-arm64.tar.gz"
+)
+sha256sums=(
+    'ac6a4050f2f415a02f3c223ddee932a07de627bc143059e9a1ea9df088e46909'
+)
+sha256sums_x86_64=(
+    '986bc230befea542af18d85a849fca056a18d728c9c7b75cfca382adb0fe1a64'
+)
+sha256sums_aarch64=(
+    'f3e339635359b29cb60407e5d7deac3d4199870d8af2034c37c74f0f1c5530e8'
+)
+
+package() {
+    case "$CARCH" in
+        x86_64)  _dir="$pkgname-$pkgver-linux-x86_64" ;;
+        aarch64) _dir="$pkgname-$pkgver-linux-arm64" ;;
+    esac
+    cd "$_dir"
+
+    # Point the wrapper at the packaged locations instead of script-relative ones
+    sed -i \
+        -e 's|^SMOLVM_BIN=.*|SMOLVM_BIN=/usr/lib/smolvm/smolvm-bin|' \
+        -e 's|^SMOLVM_LIB=.*|SMOLVM_LIB=/usr/lib/smolvm/lib|' \
+        -e 's|^SMOLVM_BUNDLED_ROOTFS=.*|SMOLVM_BUNDLED_ROOTFS=/usr/lib/smolvm/agent-rootfs|' \
+        smolvm
+
+    install -Dm0755 smolvm "$pkgdir/usr/bin/smolvm"
+    install -Dm0755 smolvm-bin "$pkgdir/usr/lib/smolvm/smolvm-bin"
+    cp -a lib "$pkgdir/usr/lib/smolvm/lib"
+    cp -r agent-rootfs "$pkgdir/usr/lib/smolvm/agent-rootfs"
+    # pre-formatted storage template (optional at runtime; saves a mkfs on first pack)
+    install -Dm644 storage-template.ext4 "$pkgdir/usr/lib/smolvm/storage-template.ext4"
+    install -Dm644 "../LICENSE-$pkgver" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+    install -Dm644 README.txt "$pkgdir/usr/share/doc/$pkgname/README.txt"
+}
+
+# vim: ts=4 sw=4 et:


### PR DESCRIPTION
Adds an official pacman repository — a PKGBUILD repackaging the release binaries with the bundled libkrun fork (stock Arch libkrun lacks the six disk/snapshot/egress symbols smolvm dlopens), a CI workflow publishing x86_64 + aarch64 packages on each release, and install docs — replacing the third-party AUR packages that patch out the bundled libs and silently break disk overlays, snapshots, and egress policy.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/591">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
