### PR TITLE
cuda: cuBLASLt descriptor fast path — eager decode 2x on loopback, in-VM eager beats native

### DIFF
--- a/crates/smolvm-cuda/src/host/gpu.rs
+++ b/crates/smolvm-cuda/src/host/gpu.rs
@@ -1349,9 +1349,24 @@ impl CublasLt {
         &self,
         func: u16,
         args: &[u8],
-        vh: &std::collections::HashMap<u64, u64>,
+        vh: &mut std::collections::HashMap<u64, u64>,
         streams: &std::collections::HashMap<u64, u64>,
     ) -> (i32, Vec<u8>) {
+        // Fire-and-forget creates append a guest-minted virtual id after the
+        // regular args; register it so later (deferred) calls resolve.
+        fn register_vh(
+            vh: &mut std::collections::HashMap<u64, u64>,
+            args: &[u8],
+            fixed: usize,
+            real: u64,
+        ) {
+            if args.len() >= fixed + 8 {
+                let id = u64::from_le_bytes(args[fixed..fixed + 8].try_into().unwrap());
+                if id & VHANDLE_TAG != 0 {
+                    vh.insert(id, real);
+                }
+            }
+        }
         // sizeof(cublasLtMatmulHeuristicResult_t): algo[64] + workspaceSize(8)
         // + state(4) + wavesCount(4) + reserved[4](16) = 96 bytes.
         const HEUR_RESULT_SZ: usize = 96;
@@ -1365,15 +1380,21 @@ impl CublasLt {
                 let scale = rd_i32(4);
                 let mut d: *mut c_void = std::ptr::null_mut();
                 let st = unsafe { (self.desc_create)(&mut d, compute, scale) };
+                register_vh(vh, args, 8, d as u64);
                 (st, (d as u64).to_le_bytes().to_vec())
             }
-            1 => (
-                unsafe { (self.desc_destroy)(rd_u64(0) as *mut c_void) },
-                Vec::new(),
-            ),
+            1 => {
+                let id = rd_u64(0);
+                let real = vh_resolve(vh, id);
+                vh.remove(&id);
+                (
+                    unsafe { (self.desc_destroy)(real as *mut c_void) },
+                    Vec::new(),
+                )
+            }
             2 => {
                 // desc_set_attr(desc, attr, buf, size)
-                let desc = rd_u64(0) as *mut c_void;
+                let desc = vh_resolve(vh, rd_u64(0)) as *mut c_void;
                 let attr = rd_i32(8);
                 let buf = &args[12..];
                 let st =
@@ -1388,14 +1409,20 @@ impl CublasLt {
                 let ld = rd_i64(20);
                 let mut l: *mut c_void = std::ptr::null_mut();
                 let st = unsafe { (self.layout_create)(&mut l, ty, rows, cols, ld) };
+                register_vh(vh, args, 28, l as u64);
                 (st, (l as u64).to_le_bytes().to_vec())
             }
-            4 => (
-                unsafe { (self.layout_destroy)(rd_u64(0) as *mut c_void) },
-                Vec::new(),
-            ),
+            4 => {
+                let id = rd_u64(0);
+                let real = vh_resolve(vh, id);
+                vh.remove(&id);
+                (
+                    unsafe { (self.layout_destroy)(real as *mut c_void) },
+                    Vec::new(),
+                )
+            }
             5 => {
-                let layout = rd_u64(0) as *mut c_void;
+                let layout = vh_resolve(vh, rd_u64(0)) as *mut c_void;
                 let attr = rd_i32(8);
                 let buf = &args[12..];
                 let st =
@@ -1406,14 +1433,20 @@ impl CublasLt {
                 // pref_create() -> handle
                 let mut p: *mut c_void = std::ptr::null_mut();
                 let st = unsafe { (self.pref_create)(&mut p) };
+                register_vh(vh, args, 0, p as u64);
                 (st, (p as u64).to_le_bytes().to_vec())
             }
-            7 => (
-                unsafe { (self.pref_destroy)(rd_u64(0) as *mut c_void) },
-                Vec::new(),
-            ),
+            7 => {
+                let id = rd_u64(0);
+                let real = vh_resolve(vh, id);
+                vh.remove(&id);
+                (
+                    unsafe { (self.pref_destroy)(real as *mut c_void) },
+                    Vec::new(),
+                )
+            }
             8 => {
-                let pref = rd_u64(0) as *mut c_void;
+                let pref = vh_resolve(vh, rd_u64(0)) as *mut c_void;
                 let attr = rd_i32(8);
                 let buf = &args[12..];
                 let st =
@@ -1424,12 +1457,12 @@ impl CublasLt {
                 // algo_get_heuristic(light, opDesc, A, B, C, D, pref, requested)
                 //   -> returnCount + returnCount * heuristicResult structs.
                 let light = vh_resolve(vh, rd_u64(0)) as *mut c_void;
-                let op = rd_u64(8) as *mut c_void;
-                let a = rd_u64(16) as *mut c_void;
-                let b = rd_u64(24) as *mut c_void;
-                let c = rd_u64(32) as *mut c_void;
-                let d = rd_u64(40) as *mut c_void;
-                let pref = rd_u64(48) as *mut c_void;
+                let op = vh_resolve(vh, rd_u64(8)) as *mut c_void;
+                let a = vh_resolve(vh, rd_u64(16)) as *mut c_void;
+                let b = vh_resolve(vh, rd_u64(24)) as *mut c_void;
+                let c = vh_resolve(vh, rd_u64(32)) as *mut c_void;
+                let d = vh_resolve(vh, rd_u64(40)) as *mut c_void;
+                let pref = vh_resolve(vh, rd_u64(48)) as *mut c_void;
                 let requested = rd_i32(56).max(0);
                 let mut results = vec![0u8; requested as usize * HEUR_RESULT_SZ];
                 let mut count: c_int = 0;
@@ -1456,17 +1489,17 @@ impl CublasLt {
                 // matmul(light, desc, alpha[16], A, Adesc, B, Bdesc, beta[16],
                 //   C, Cdesc, D, Ddesc, algo[64], workspace, wsSize, stream)
                 let light = vh_resolve(vh, rd_u64(0)) as *mut c_void;
-                let desc = rd_u64(8) as *mut c_void;
+                let desc = vh_resolve(vh, rd_u64(8)) as *mut c_void;
                 let alpha = &args[16..32];
                 let a = rd_u64(32) as *mut c_void;
-                let adesc = rd_u64(40) as *mut c_void;
+                let adesc = vh_resolve(vh, rd_u64(40)) as *mut c_void;
                 let b = rd_u64(48) as *mut c_void;
-                let bdesc = rd_u64(56) as *mut c_void;
+                let bdesc = vh_resolve(vh, rd_u64(56)) as *mut c_void;
                 let beta = &args[64..80];
                 let c = rd_u64(80) as *mut c_void;
-                let cdesc = rd_u64(88) as *mut c_void;
+                let cdesc = vh_resolve(vh, rd_u64(88)) as *mut c_void;
                 let dd = rd_u64(96) as *mut c_void;
-                let ddesc = rd_u64(104) as *mut c_void;
+                let ddesc = vh_resolve(vh, rd_u64(104)) as *mut c_void;
                 let algo = &args[112..176];
                 let algo_present = rd_u64(176) != 0;
                 let workspace = rd_u64(184) as *mut c_void;
@@ -2199,11 +2232,12 @@ impl GpuBackend {
                         }
                     }
                 }
-                Ok(self
-                    .cublaslt
-                    .as_ref()
-                    .unwrap()
-                    .dispatch(func, args, &self.vhandles, streams))
+                Ok(self.cublaslt.as_ref().unwrap().dispatch(
+                    func,
+                    args,
+                    &mut self.vhandles,
+                    streams,
+                ))
             }
             LIB_CUDNN_BN => {
                 if self.cudnn_bn.is_none() {

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -1783,6 +1783,19 @@ pub extern "C" fn cudaFuncGetAttributes(attr: *mut c_void, _func: *const c_void)
 /// The runtime and driver enum values coincide, so `attr` passes through.
 #[no_mangle]
 pub extern "C" fn cudaFuncSetAttribute(func: *const c_void, attr: c_int, value: c_int) -> c_int {
+    // Kernels re-assert the same attribute before every launch (FlashAttention
+    // raises the shared-memory cap each call) — skip repeats, each was a sync
+    // round-trip.
+    static APPLIED: Mutex<Option<HashMap<(usize, c_int), c_int>>> = Mutex::new(None);
+    if APPLIED
+        .lock()
+        .unwrap()
+        .get_or_insert_with(HashMap::new)
+        .get(&(func as usize, attr))
+        == Some(&value)
+    {
+        return CUDA_SUCCESS;
+    }
     let r = with_state(|s| {
         let fid = s
             .funcs
@@ -1793,6 +1806,13 @@ pub extern "C" fn cudaFuncSetAttribute(func: *const c_void, attr: c_int, value: 
             .func_set_attribute(fid, attr, value)
             .map_err(map_err)
     });
+    if r.is_ok() {
+        APPLIED
+            .lock()
+            .unwrap()
+            .get_or_insert_with(HashMap::new)
+            .insert((func as usize, attr), value);
+    }
     set_last(r.err().unwrap_or(CUDA_SUCCESS))
 }
 #[no_mangle]
@@ -2446,6 +2466,51 @@ pub extern "C" fn cudnnBackendExecute(
 const LIB_CUBLASLT: u8 = 4;
 const CUBLAS_STATUS_SUCCESS: c_int = 0;
 const CUBLAS_STATUS_NOT_INITIALIZED: c_int = 1;
+
+// ---- cuBLASLt descriptor fast path -------------------------------------------
+// torch builds desc + layouts + preference around EVERY Linear matmul; sync
+// round-trips here dominated eager decode (125k of 184k). Creates are
+// fire-and-forget with guest-minted virtual ids (bit-63-tagged, host maps
+// them), Set/Destroy defer, and AlgoGetHeuristic memoizes on the CONTENT of
+// the descriptors (ids change every step; the shapes repeat).
+/// Live Lt handle → content fingerprint (create args + every attr write).
+static LT_FP: Mutex<Option<HashMap<u64, Vec<u8>>>> = Mutex::new(None);
+/// Heuristic memo entry: (status, out blob).
+type LtHeurEntry = (c_int, Vec<u8>);
+/// Heuristic memo: concatenated fingerprints + request → result.
+static LT_HEUR_MEMO: Mutex<Option<HashMap<Vec<u8>, LtHeurEntry>>> = Mutex::new(None);
+
+fn lt_mint(create_args: &[u8]) -> u64 {
+    // Share the process-wide virtual-handle counter (alloc_vhandle) — a
+    // second counter minted colliding ids and clobbered the host's map.
+    let id = alloc_vhandle();
+    let mut g = LT_FP.lock().unwrap();
+    g.get_or_insert_with(HashMap::new)
+        .insert(id, create_args.to_vec());
+    id
+}
+
+fn lt_fp_append(handle: u64, attr: c_int, buf: &[u8]) {
+    let mut g = LT_FP.lock().unwrap();
+    if let Some(fp) = g.get_or_insert_with(HashMap::new).get_mut(&handle) {
+        fp.extend_from_slice(&attr.to_le_bytes());
+        fp.extend_from_slice(&(buf.len() as u32).to_le_bytes());
+        fp.extend_from_slice(buf);
+    }
+}
+
+fn lt_fp_of(handle: u64) -> Vec<u8> {
+    let mut g = LT_FP.lock().unwrap();
+    g.get_or_insert_with(HashMap::new)
+        .get(&handle)
+        .cloned()
+        .unwrap_or_else(|| handle.to_le_bytes().to_vec())
+}
+
+fn lt_fp_drop(handle: u64) {
+    let mut g = LT_FP.lock().unwrap();
+    g.get_or_insert_with(HashMap::new).remove(&handle);
+}
 /// sizeof(cublasLtMatmulHeuristicResult_t): algo[64]+workspaceSize(8)+state(4)
 /// +wavesCount(4)+reserved[4](16). Must match the host.
 const LT_HEUR_RESULT_SZ: usize = 96;
@@ -2485,26 +2550,26 @@ pub extern "C" fn cublasLtMatmulDescCreate(
     if matmul_desc.is_null() {
         return CUBLAS_STATUS_NOT_INITIALIZED;
     }
-    let mut a = Vec::with_capacity(8);
+    let mut a = Vec::with_capacity(16);
     a.extend_from_slice(&compute_type.to_le_bytes());
     a.extend_from_slice(&scale_type.to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_CUBLASLT, 0, a)) {
-        Ok((0, out)) if out.len() >= 8 => {
-            unsafe {
-                *matmul_desc = u64::from_le_bytes(out[..8].try_into().unwrap()) as *mut c_void
-            };
+    let vh = lt_mint(&a);
+    a.extend_from_slice(&vh.to_le_bytes());
+    match with_client(|c| c.lib_call_deferred(LIB_CUBLASLT, 0, a)) {
+        Ok(()) => {
+            unsafe { *matmul_desc = vh as *mut c_void };
             CUBLAS_STATUS_SUCCESS
         }
-        Ok((st, _)) => st,
         Err(_) => CUBLAS_STATUS_NOT_INITIALIZED,
     }
 }
 
 #[no_mangle]
 pub extern "C" fn cublasLtMatmulDescDestroy(matmul_desc: *mut c_void) -> c_int {
+    lt_fp_drop(matmul_desc as u64);
     let a = (matmul_desc as u64).to_le_bytes().to_vec();
-    match with_client(|c| c.lib_call(LIB_CUBLASLT, 1, a)) {
-        Ok((st, _)) => st,
+    match with_client(|c| c.lib_call_deferred(LIB_CUBLASLT, 1, a)) {
+        Ok(()) => CUBLAS_STATUS_SUCCESS,
         Err(_) => CUBLAS_STATUS_NOT_INITIALIZED,
     }
 }
@@ -2521,11 +2586,15 @@ fn lt_set_attr(
     let mut a = Vec::with_capacity(12 + size);
     a.extend_from_slice(&(handle as u64).to_le_bytes());
     a.extend_from_slice(&attr.to_le_bytes());
-    if size > 0 && !buf.is_null() {
-        a.extend_from_slice(unsafe { std::slice::from_raw_parts(buf as *const u8, size) });
-    }
-    match with_client(|c| c.lib_call(LIB_CUBLASLT, func, a)) {
-        Ok((st, _)) => st,
+    let bytes: &[u8] = if size > 0 && !buf.is_null() {
+        unsafe { std::slice::from_raw_parts(buf as *const u8, size) }
+    } else {
+        &[]
+    };
+    a.extend_from_slice(bytes);
+    lt_fp_append(handle as u64, attr, bytes);
+    match with_client(|c| c.lib_call_deferred(LIB_CUBLASLT, func, a)) {
+        Ok(()) => CUBLAS_STATUS_SUCCESS,
         Err(_) => CUBLAS_STATUS_NOT_INITIALIZED,
     }
 }
@@ -2551,28 +2620,28 @@ pub extern "C" fn cublasLtMatrixLayoutCreate(
     if mat_layout.is_null() {
         return CUBLAS_STATUS_NOT_INITIALIZED;
     }
-    let mut a = Vec::with_capacity(28);
+    let mut a = Vec::with_capacity(36);
     a.extend_from_slice(&data_type.to_le_bytes());
     a.extend_from_slice(&rows.to_le_bytes());
     a.extend_from_slice(&cols.to_le_bytes());
     a.extend_from_slice(&ld.to_le_bytes());
-    match with_client(|c| c.lib_call(LIB_CUBLASLT, 3, a)) {
-        Ok((0, out)) if out.len() >= 8 => {
-            unsafe {
-                *mat_layout = u64::from_le_bytes(out[..8].try_into().unwrap()) as *mut c_void
-            };
+    let vh = lt_mint(&a);
+    a.extend_from_slice(&vh.to_le_bytes());
+    match with_client(|c| c.lib_call_deferred(LIB_CUBLASLT, 3, a)) {
+        Ok(()) => {
+            unsafe { *mat_layout = vh as *mut c_void };
             CUBLAS_STATUS_SUCCESS
         }
-        Ok((st, _)) => st,
         Err(_) => CUBLAS_STATUS_NOT_INITIALIZED,
     }
 }
 
 #[no_mangle]
 pub extern "C" fn cublasLtMatrixLayoutDestroy(mat_layout: *mut c_void) -> c_int {
+    lt_fp_drop(mat_layout as u64);
     let a = (mat_layout as u64).to_le_bytes().to_vec();
-    match with_client(|c| c.lib_call(LIB_CUBLASLT, 4, a)) {
-        Ok((st, _)) => st,
+    match with_client(|c| c.lib_call_deferred(LIB_CUBLASLT, 4, a)) {
+        Ok(()) => CUBLAS_STATUS_SUCCESS,
         Err(_) => CUBLAS_STATUS_NOT_INITIALIZED,
     }
 }
@@ -2592,21 +2661,22 @@ pub extern "C" fn cublasLtMatmulPreferenceCreate(pref: *mut *mut c_void) -> c_in
     if pref.is_null() {
         return CUBLAS_STATUS_NOT_INITIALIZED;
     }
-    match with_client(|c| c.lib_call(LIB_CUBLASLT, 6, Vec::new())) {
-        Ok((0, out)) if out.len() >= 8 => {
-            unsafe { *pref = u64::from_le_bytes(out[..8].try_into().unwrap()) as *mut c_void };
+    let vh = lt_mint(&[]);
+    match with_client(|c| c.lib_call_deferred(LIB_CUBLASLT, 6, vh.to_le_bytes().to_vec())) {
+        Ok(()) => {
+            unsafe { *pref = vh as *mut c_void };
             CUBLAS_STATUS_SUCCESS
         }
-        Ok((st, _)) => st,
         Err(_) => CUBLAS_STATUS_NOT_INITIALIZED,
     }
 }
 
 #[no_mangle]
 pub extern "C" fn cublasLtMatmulPreferenceDestroy(pref: *mut c_void) -> c_int {
+    lt_fp_drop(pref as u64);
     let a = (pref as u64).to_le_bytes().to_vec();
-    match with_client(|c| c.lib_call(LIB_CUBLASLT, 7, a)) {
-        Ok((st, _)) => st,
+    match with_client(|c| c.lib_call_deferred(LIB_CUBLASLT, 7, a)) {
+        Ok(()) => CUBLAS_STATUS_SUCCESS,
         Err(_) => CUBLAS_STATUS_NOT_INITIALIZED,
     }
 }
@@ -2635,6 +2705,42 @@ pub extern "C" fn cublasLtMatmulAlgoGetHeuristic(
     heuristic_results_array: *mut c_void,
     return_algo_count: *mut c_int,
 ) -> c_int {
+    // Memo key: the CONTENT of every descriptor (ids change per step; the
+    // shapes repeat every decode step, so this hits ~always after warmup).
+    let mut key = Vec::new();
+    for h in [operation_desc, a_desc, b_desc, c_desc, d_desc, preference] {
+        let fp = lt_fp_of(h as u64);
+        key.extend_from_slice(&(fp.len() as u32).to_le_bytes());
+        key.extend_from_slice(&fp);
+    }
+    key.extend_from_slice(&requested_algo_count.to_le_bytes());
+    if let Some((st, out)) = LT_HEUR_MEMO
+        .lock()
+        .unwrap()
+        .get_or_insert_with(HashMap::new)
+        .get(&key)
+        .cloned()
+    {
+        if st == 0 && out.len() >= 8 {
+            let count = i64::from_le_bytes(out[..8].try_into().unwrap()).max(0) as usize;
+            if !return_algo_count.is_null() {
+                unsafe { *return_algo_count = count as c_int };
+            }
+            let bytes = &out[8..];
+            if !heuristic_results_array.is_null() {
+                let n = bytes.len().min(count * LT_HEUR_RESULT_SZ);
+                unsafe {
+                    std::ptr::copy_nonoverlapping(
+                        bytes.as_ptr(),
+                        heuristic_results_array as *mut u8,
+                        n,
+                    )
+                };
+            }
+            return CUBLAS_STATUS_SUCCESS;
+        }
+        return st;
+    }
     let mut a = Vec::with_capacity(60);
     a.extend_from_slice(&(light_handle as u64).to_le_bytes());
     a.extend_from_slice(&(operation_desc as u64).to_le_bytes());
@@ -2646,6 +2752,11 @@ pub extern "C" fn cublasLtMatmulAlgoGetHeuristic(
     a.extend_from_slice(&requested_algo_count.to_le_bytes());
     match with_client(|c| c.lib_call(LIB_CUBLASLT, 9, a)) {
         Ok((0, out)) if out.len() >= 8 => {
+            LT_HEUR_MEMO
+                .lock()
+                .unwrap()
+                .get_or_insert_with(HashMap::new)
+                .insert(key, (0, out.clone()));
             let count = i64::from_le_bytes(out[..8].try_into().unwrap()).max(0) as usize;
             if !return_algo_count.is_null() {
                 unsafe { *return_algo_count = count as c_int };


### PR DESCRIPTION
The Lt descriptor churn around every Linear matmul was 125k of 184k sync round-trips in eager decode. Creates fire-and-forget via shared virtual handles, attribute/destroy defer, AlgoGetHeuristic memoizes on descriptor content, repeated cudaFuncSetAttribute dedups: opt-125m eager 138 -> 274 tok/s loopback and 61.7 -> 687.5 tok/s in-VM (beats native eager, 652).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/593">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->