### PR TITLE
release: bundle CUDA shims + smolvm-cuda-run in agent-rootfs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,11 @@ jobs:
   build-cuda:
     name: Build CUDA shims (${{ matrix.arch }})
     needs: ci
-    runs-on: ubuntu-latest
+    # 22.04 (glibc 2.35), NOT ubuntu-latest (24.04 = 2.39): the shims are glibc
+    # cdylibs linked here, so the build host's glibc is their runtime floor. A
+    # 2.39 shim breaks common workload guests (Debian 12 = 2.36, Ubuntu 22.04 =
+    # 2.35). Same reasoning as build-dist / build-libkrun.
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,11 +77,87 @@ jobs:
           path: target/${{ matrix.target }}/release-small/smolvm-agent
 
   # ==========================================================================
+  # Build CUDA guest shims + runner (both architectures)
+  #
+  # The shims are glibc cdylibs (loaded by the workload container's glibc, not
+  # the musl agent); smolvm-cuda-run is a musl guest binary. Built here per arch
+  # — including cross-compiled aarch64 — and handed to build-rootfs, so release
+  # rootfs images ship CUDA auto-staging even though that job runs --no-build-agent.
+  # ==========================================================================
+  build-cuda:
+    name: Build CUDA shims (${{ matrix.arch }})
+    needs: ci
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - arch: x86_64
+            musl_target: x86_64-unknown-linux-musl
+            gnu_target: x86_64-unknown-linux-gnu
+            linker_pkg: ""
+            musl_linker_env: ""
+            gnu_linker_env: ""
+          - arch: aarch64
+            musl_target: aarch64-unknown-linux-musl
+            gnu_target: aarch64-unknown-linux-gnu
+            linker_pkg: gcc-aarch64-linux-gnu
+            musl_linker_env: CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc
+            gnu_linker_env: CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.musl_target }}, ${{ matrix.gnu_target }}
+
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: cuda-${{ matrix.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: cuda-${{ matrix.arch }}-cargo-
+
+      - name: Install cross-compilation tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools ${{ matrix.linker_pkg }}
+
+      # smolvm-cuda-run: guest-side CUDA runner, musl (matches the guest userland).
+      - name: Build smolvm-cuda-run
+        run: |
+          ${{ matrix.musl_linker_env }} \
+          cargo build --profile release-small -p smolvm-cuda-guest --target ${{ matrix.musl_target }}
+
+      # Shims: glibc cdylibs the agent bind-mounts into --cuda workload containers.
+      - name: Build CUDA guest shims
+        run: |
+          ${{ matrix.gnu_linker_env }} \
+          cargo build --release -p smolvm-cudart-shim -p smolvm-cuda-shim --target ${{ matrix.gnu_target }}
+
+      - name: Collect CUDA artifacts
+        run: |
+          mkdir -p /tmp/cuda
+          cp target/${{ matrix.musl_target }}/release-small/smolvm-cuda-run /tmp/cuda/smolvm-cuda-run
+          cp target/${{ matrix.gnu_target }}/release/libcudart.so /tmp/cuda/libcudart-shim.so
+          cp target/${{ matrix.gnu_target }}/release/libcuda.so   /tmp/cuda/libcuda.so.1
+          file /tmp/cuda/*
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: cuda-${{ matrix.arch }}
+          path: /tmp/cuda/
+
+  # ==========================================================================
   # Build agent rootfs (both architectures)
   # ==========================================================================
   build-rootfs:
     name: Build rootfs (${{ matrix.arch }})
-    needs: build-agent
+    needs: [build-agent, build-cuda]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -97,11 +173,33 @@ jobs:
           name: agent-${{ matrix.arch }}
           path: /tmp/agent/
 
+      - name: Download CUDA artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: cuda-${{ matrix.arch }}
+          path: /tmp/cuda/
+
       - name: Build rootfs
         run: |
-          chmod +x /tmp/agent/smolvm-agent
+          chmod +x /tmp/agent/smolvm-agent /tmp/cuda/smolvm-cuda-run
           AGENT_BINARY=/tmp/agent/smolvm-agent \
+          CUDA_GUEST_BINARY=/tmp/cuda/smolvm-cuda-run \
+          CUDART_SHIM_BINARY=/tmp/cuda/libcudart-shim.so \
+          CUDA_DRIVER_SHIM_BINARY=/tmp/cuda/libcuda.so.1 \
             ./scripts/build-agent-rootfs.sh --arch ${{ matrix.arch }} --no-build-agent
+
+      - name: Verify CUDA artifacts bundled
+        run: |
+          for f in \
+            usr/local/lib/smolvm-cuda/libcudart-shim.so \
+            usr/local/lib/smolvm-cuda/libcuda.so.1 \
+            usr/local/bin/smolvm-cuda-run; do
+            if [[ ! -f "target/agent-rootfs/$f" ]]; then
+              echo "::error::missing $f in agent-rootfs (CUDA auto-staging would be disabled)"
+              exit 1
+            fi
+          done
+          echo "CUDA shims + runner present in agent-rootfs"
 
       - name: Package rootfs as tarball
         run: |

--- a/scripts/build-agent-rootfs.sh
+++ b/scripts/build-agent-rootfs.sh
@@ -308,43 +308,60 @@ fi
 # CUDA guest shims: glibc cdylibs the agent bind-mounts into workload
 # containers on `--cuda` (see crates/smolvm-agent/src/cuda.rs). They are loaded
 # by the container's glibc — not by the (musl) agent — so they build for the
-# native gnu target. Best-effort: without them `--cuda` still works, the user
-# just stages shims manually; cross-arch rootfs builds skip them.
-if [[ "$NO_BUILD_AGENT" != "1" && "$(uname -s)" == "Linux" && "$(uname -m)" == "$ALPINE_ARCH" ]] \
+# native gnu target.
+#
+# Two ways to supply them, in priority order:
+#   1. Prebuilt paths via CUDART_SHIM_BINARY + CUDA_DRIVER_SHIM_BINARY (how the
+#      release workflow ships them: built once per arch, incl. cross-compiled
+#      aarch64, then installed here regardless of --no-build-agent).
+#   2. Native `cargo build` fallback (local dev on a matching-arch Linux host).
+# Best-effort: without them `--cuda` still works, the user just stages shims
+# manually.
+CUDART_SHIM_SRC="${CUDART_SHIM_BINARY:-}"
+CUDA_DRIVER_SHIM_SRC="${CUDA_DRIVER_SHIM_BINARY:-}"
+
+if { [[ -z "$CUDART_SHIM_SRC" ]] || [[ -z "$CUDA_DRIVER_SHIM_SRC" ]]; } \
+    && [[ "$NO_BUILD_AGENT" != "1" && "$(uname -s)" == "Linux" && "$(uname -m)" == "$ALPINE_ARCH" ]] \
     && command -v cargo &> /dev/null; then
     echo "Building CUDA guest shims (native gnu target)..."
     if cargo build --release -p smolvm-cudart-shim -p smolvm-cuda-shim \
         --manifest-path "$PROJECT_ROOT/Cargo.toml"; then
-        mkdir -p "$OUTPUT_DIR/usr/local/lib/smolvm-cuda"
-        cp "$PROJECT_ROOT/target/release/libcudart.so" \
-            "$OUTPUT_DIR/usr/local/lib/smolvm-cuda/libcudart-shim.so"
-        cp "$PROJECT_ROOT/target/release/libcuda.so" \
-            "$OUTPUT_DIR/usr/local/lib/smolvm-cuda/libcuda.so.1"
-        echo "Installed CUDA guest shims"
-        # Stamp the shims' wire fingerprint into the rootfs so the host can flag a
-        # stale rootfs at boot (internal_boot's warn_if_stale_cuda_shim) instead of
-        # leaving the user with an opaque cuInit failure. Read it from the guest
-        # runner (built from the same smolvm-cuda source as the shims, so the same
-        # PROTO_HASH); fall back to a quick native build of that same binary.
-        PROTO_HASH=""
-        if [[ -n "${CUDA_GUEST_BINARY:-}" && -x "${CUDA_GUEST_BINARY:-}" ]]; then
-            PROTO_HASH="$("$CUDA_GUEST_BINARY" --proto-hash 2>/dev/null || true)"
-        fi
-        if [[ -z "$PROTO_HASH" ]]; then
-            PROTO_HASH="$(cargo run --release -q -p smolvm-cuda-guest \
-                --manifest-path "$PROJECT_ROOT/Cargo.toml" -- --proto-hash 2>/dev/null || true)"
-        fi
-        if [[ -n "$PROTO_HASH" ]]; then
-            printf '%s\n' "$PROTO_HASH" > "$OUTPUT_DIR/usr/local/lib/smolvm-cuda/proto-hash"
-            echo "Stamped CUDA shim proto-hash: $PROTO_HASH"
-        else
-            echo "Could not determine CUDA proto-hash — rootfs left unstamped (boot check skips)"
-        fi
+        CUDART_SHIM_SRC="${CUDART_SHIM_SRC:-$PROJECT_ROOT/target/release/libcudart.so}"
+        CUDA_DRIVER_SHIM_SRC="${CUDA_DRIVER_SHIM_SRC:-$PROJECT_ROOT/target/release/libcuda.so}"
     else
         echo "CUDA guest shim build failed — rootfs ships without auto-staging"
     fi
+fi
+
+if [[ -n "$CUDART_SHIM_SRC" && -f "$CUDART_SHIM_SRC" \
+      && -n "$CUDA_DRIVER_SHIM_SRC" && -f "$CUDA_DRIVER_SHIM_SRC" ]]; then
+    echo "Installing CUDA guest shims..."
+    mkdir -p "$OUTPUT_DIR/usr/local/lib/smolvm-cuda"
+    cp "$CUDART_SHIM_SRC" "$OUTPUT_DIR/usr/local/lib/smolvm-cuda/libcudart-shim.so"
+    cp "$CUDA_DRIVER_SHIM_SRC" "$OUTPUT_DIR/usr/local/lib/smolvm-cuda/libcuda.so.1"
+    echo "Installed CUDA guest shims"
+    # Stamp the shims' wire fingerprint into the rootfs so the host can flag a
+    # stale rootfs at boot (internal_boot's warn_if_stale_cuda_shim) instead of
+    # leaving the user with an opaque cuInit failure. Works for both the prebuilt
+    # (release) and native-build paths. Read it from the guest runner (built from
+    # the same smolvm-cuda source as the shims, so the same PROTO_HASH); fall back
+    # to a quick native build of that same binary when cargo is available.
+    PROTO_HASH=""
+    if [[ -n "${CUDA_GUEST_BINARY:-}" && -x "${CUDA_GUEST_BINARY:-}" ]]; then
+        PROTO_HASH="$("$CUDA_GUEST_BINARY" --proto-hash 2>/dev/null || true)"
+    fi
+    if [[ -z "$PROTO_HASH" ]] && command -v cargo &> /dev/null; then
+        PROTO_HASH="$(cargo run --release -q -p smolvm-cuda-guest \
+            --manifest-path "$PROJECT_ROOT/Cargo.toml" -- --proto-hash 2>/dev/null || true)"
+    fi
+    if [[ -n "$PROTO_HASH" ]]; then
+        printf '%s\n' "$PROTO_HASH" > "$OUTPUT_DIR/usr/local/lib/smolvm-cuda/proto-hash"
+        echo "Stamped CUDA shim proto-hash: $PROTO_HASH"
+    else
+        echo "Could not determine CUDA proto-hash — rootfs left unstamped (boot check skips)"
+    fi
 else
-    echo "Skipping CUDA guest shims (cross-arch or no cargo) — auto-staging disabled in this rootfs"
+    echo "Skipping CUDA guest shims (no prebuilt paths, cross-arch, or no cargo) — auto-staging disabled in this rootfs"
 fi
 
 echo ""


### PR DESCRIPTION
Fixes #596.

## Problem
Release `agent-rootfs` ships empty `/usr/local/lib/smolvm-cuda/` (no `smolvm-cuda-run`). `--cuda` → err 801 until manual shim build/copy.

Cause: `build-rootfs` uses `--no-build-agent`; shim install was gated on `NO_BUILD_AGENT != 1`.

## Change
- `build-agent-rootfs.sh`: install via `CUDART_SHIM_BINARY` / `CUDA_DRIVER_SHIM_BINARY` / `CUDA_GUEST_BINARY` regardless of `--no-build-agent`; keep native cargo fallback; stamp `proto-hash` on that path.
- `release.yml`: `build-cuda` job → gnu cdylibs + musl `smolvm-cuda-run` per arch → `build-rootfs` consumes + asserts presence.
- Build host pinned **ubuntu-22.04** (glibc 2.35). Guests load these cdylibs; 24.04/2.39 would raise the guest floor (same class as #636 host-libkrun).

## Proof checklist (Bin asks)

| Check | Result | Where |
|-------|--------|-------|
| x86_64 packaged rootfs enables `--cuda` with **no** manual shim install | **PASS** | Lambda A10, Ubuntu 22.04 |
| aarch64 gnu cdylib links on an **arm instance** (before release-CI iteration) | **PASS** | AWS Graviton `t4g.small`, Ubuntu 24.04 |

### x86_64 packaged rootfs (Lambda A10, Ubuntu 22.04)

Branch tip used for packaging path: `1890d407` (later tip includes 22.04 runner pin + rebase onto current `main`).

```bash
cargo build --release -p smolvm-cudart-shim -p smolvm-cuda-shim
cargo build --profile release-small -p smolvm-cuda-guest -p smolvm-agent \
  --target x86_64-unknown-linux-musl

CUDART_SHIM_BINARY=$PWD/target/release/libcudart.so \
CUDA_DRIVER_SHIM_BINARY=$PWD/target/release/libcuda.so \
CUDA_GUEST_BINARY=$PWD/target/x86_64-unknown-linux-musl/release-small/smolvm-cuda-run \
AGENT_BINARY=$PWD/target/x86_64-unknown-linux-musl/release-small/smolvm-agent \
  ./scripts/build-agent-rootfs.sh --arch x86_64 --no-build-agent
# sha256(cargo) == sha256(rootfs); proto-hash stamped
# NO post-hoc cp into smolvm-cuda/

./smolvm machine run --net --cuda --image portal-cuda.tar -- \
  python3 -c "import torch; print('cuda:', torch.cuda.is_available())"
# → cuda: True
```

### aarch64 gnu cdylib link (AWS Graviton, Ubuntu 24.04)

Tip: `5e7a1602` (rebased onto current `main`). Native build — no cross linker, no release-CI lottery:

```bash
cargo build --release \
  -p smolvm-cudart-shim -p smolvm-cuda-shim \
  --target aarch64-unknown-linux-gnu
```

| Artifact | `file` | size |
|----------|--------|------|
| `libcudart.so` | ELF 64-bit LSB shared object, ARM aarch64, dynamically linked, stripped | 857128 B |
| `libcuda.so` | ELF 64-bit LSB shared object, ARM aarch64, dynamically linked, stripped | 463624 B |

`ldd` resolves against host glibc (`libc.so.6`, `libgcc_s.so.1`, `/lib/ld-linux-aarch64.so.1`). **PASS.**

Note: release still **builds** these cdylibs on ubuntu-22.04 runners (glibc 2.35 floor for guests). The arm-instance proof is linkability on aarch64; the 22.04 pin keeps the shipped floor.

## Host note (orthogonal)
Stock **v1.6.0 / v1.6.1** `lib/libkrun.so` needed GLIBC_2.39 on Ubuntu 22.04 hosts — fixed in [#644](https://github.com/smol-machines/smolvm/pull/644) / **v1.6.2**. Does not affect the agent-rootfs packaging claim.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/601">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->