### PR TITLE
cuda(shim): trace kernel-launch failure modes to pinpoint #597

### DIFF
--- a/crates/smolvm-cuda-shim/src/lib.rs
+++ b/crates/smolvm-cuda-shim/src/lib.rs
@@ -939,6 +939,26 @@ pub extern "C" fn cuLaunchKernelEx(
     }
     // SAFETY: caller passes a valid CUlaunchConfig.
     let c = unsafe { &*(config as *const CuLaunchConfig) };
+    // The attribute array is dropped when lowering to the plain launch. If a
+    // kernel *requires* an attribute (e.g. a cluster dimension or cooperative
+    // launch), that silent drop produces a launch the driver may reject with
+    // INVALID_VALUE — a prime suspect for fused-SDPA-backward failures (#597).
+    // Surface it under the trace env so the gap is diagnosable on a GPU host.
+    if c.num_attrs != 0 && shim_trace_on() {
+        eprintln!(
+            "[shim] cuLaunchKernelEx func={:#x} grid=[{},{},{}] block=[{},{},{}] \
+             shared={} DROPPING {} launch attribute(s) (see #597)",
+            func as u64,
+            c.grid_x,
+            c.grid_y,
+            c.grid_z,
+            c.block_x,
+            c.block_y,
+            c.block_z,
+            c.shared_bytes,
+            c.num_attrs,
+        );
+    }
     cuLaunchKernel(
         func,
         c.grid_x,
@@ -1085,7 +1105,16 @@ pub extern "C" fn cuLaunchKernel(
         Vec::new()
     } else {
         if kernel_params.is_null() {
-            // The `extra` buffer-pointer convention is not implemented.
+            // The `extra` buffer-pointer convention (CU_LAUNCH_PARAM_BUFFER_*)
+            // is not implemented — some kernels pass args this way instead of a
+            // kernelParams array. Trace it: another #597 suspect.
+            if shim_trace_on() {
+                eprintln!(
+                    "[shim] cuLaunchKernel func={fh:#x} params via `extra` buffer \
+                     convention (extra={}) — UNSUPPORTED (see #597)",
+                    if extra.is_null() { "null" } else { "set" },
+                );
+            }
             return if extra.is_null() {
                 CUDA_ERROR_INVALID_VALUE
             } else {
@@ -1101,7 +1130,7 @@ pub extern "C" fn cuLaunchKernel(
             })
             .collect()
     };
-    ret(with_state(|s| {
+    let code = ret(with_state(|s| {
         s.client.launch_kernel(
             fh,
             [grid_x, grid_y, grid_z],
@@ -1110,7 +1139,17 @@ pub extern "C" fn cuLaunchKernel(
             stream as u64,
             &params,
         )
-    }))
+    }));
+    // Log launches that the host/driver rejected — pinpoints which kernel and
+    // param shape yields INVALID_VALUE (fused-attention backward, #597).
+    if code != CUDA_SUCCESS && shim_trace_on() {
+        eprintln!(
+            "[shim] cuLaunchKernel func={fh:#x} grid=[{grid_x},{grid_y},{grid_z}] \
+             block=[{block_x},{block_y},{block_z}] shared={shared_bytes} nparams={} -> err {code}",
+            params.len(),
+        );
+    }
+    code
 }
 
 // ---- streams / events ----------------------------------------------------------------
@@ -1371,13 +1410,11 @@ pub extern "C" fn cuGetProcAddress_v2(
     }
 }
 
-/// When `SMOLVM_CUDA_SHIM_TRACE` is set, log each cuGetProcAddress lookup and
-/// whether the shim served it — the fastest way to enumerate the surface a
-/// given CUDA runtime needs. No-op otherwise.
-fn trace_proc(name: &str, hit: bool) {
+/// Whether `SMOLVM_CUDA_SHIM_TRACE` is set (cached after first read).
+fn shim_trace_on() -> bool {
     use std::sync::atomic::{AtomicU8, Ordering};
     static ENABLED: AtomicU8 = AtomicU8::new(0); // 0=unknown, 1=on, 2=off
-    let on = match ENABLED.load(Ordering::Relaxed) {
+    match ENABLED.load(Ordering::Relaxed) {
         1 => true,
         2 => false,
         _ => {
@@ -1385,8 +1422,14 @@ fn trace_proc(name: &str, hit: bool) {
             ENABLED.store(if on { 1 } else { 2 }, Ordering::Relaxed);
             on
         }
-    };
-    if on {
+    }
+}
+
+/// When `SMOLVM_CUDA_SHIM_TRACE` is set, log each cuGetProcAddress lookup and
+/// whether the shim served it — the fastest way to enumerate the surface a
+/// given CUDA runtime needs. No-op otherwise.
+fn trace_proc(name: &str, hit: bool) {
+    if shim_trace_on() {
         eprintln!(
             "[shim] cuGetProcAddress {name} -> {}",
             if hit { "hit" } else { "MISS" }


### PR DESCRIPTION
> **Draft / investigation:** this instruments the launch path to confirm the
> root cause of #597 on a GPU host; it does not itself fix the failure. The fix
> follows once the traces below identify which path is at fault. No local
> toolchain here to compile — CI build + a GPU trace run are the validation.

## Background (#597)

Fused scaled-dot-product-attention **backward** kernels fail through the CUDA
remoting path with `RuntimeError: CUDA error: invalid argument`, while:

- `torch.randn(...).sum().backward()` (matmul) — works
- HF Llama forward — works
- HF Llama backward with **math** SDPA (`enable_math_sdp(True)`, flash/mem-eff
  off) — works
- HF Llama backward with default **fused** SDPA — **fails**

Repro (needs a GPU host + shims staged):

```bash
smolvm machine run --net --cuda --mem 16384 --image ./torch-cuda.tar -- \
  sh -c 'pip install -q transformers accelerate && python3 -c "
import torch
from transformers import AutoModelForCausalLM
m = AutoModelForCausalLM.from_pretrained(\"hf-internal-testing/tiny-random-LlamaForCausalLM\", device_map=\"cuda\")
x = torch.randint(0, 100, (1, 8), device=\"cuda\")
m(x, labels=x).loss.backward()"'
```

The failure is in the driver-API kernel-launch path (these are PyTorch's own
fused kernels in `libtorch_cuda.so`, not cuBLAS/cuDNN). Three candidate causes,
all in the launch path:

1. **`cuLaunchKernelEx` drops the launch-attribute array** (`lib.rs`) — a
   required attribute (cluster/cooperative/etc.) silently dropped → the lowered
   plain launch is rejected.
2. **`extra` param-buffer convention** (`CU_LAUNCH_PARAM_BUFFER_POINTER`) — some
   kernels pass args this way; the shim returns NOT_SUPPORTED.
3. **rejected launch config / params** — grid/block/shared or reconstructed
   `kernelParams` the driver rejects with INVALID_VALUE.

## What this PR adds

`SMOLVM_CUDA_SHIM_TRACE`-gated logging (cached flag, off the success hot path):

- `cuLaunchKernelEx`: logs when a launch carries a **non-empty attribute array**
  that we drop (cause #1).
- `cuLaunchKernel`: logs use of the unsupported **`extra`** convention (#2), and
  logs **any launch the host/driver rejects** with func handle, grid/block/
  shared, param count, and error code (#3).

Extracts `shim_trace_on()` and reuses it from `trace_proc`. No behavior change
with the flag unset.

## How to use it to land the fix

On a GPU host, run the repro with `SMOLVM_CUDA_SHIM_TRACE=1` +
`CUDA_LAUNCH_BLOCKING=1` and read which line fires at the failing backward:

- a `DROPPING N launch attribute(s)` line → implement attribute forwarding
  (extend the wire `LaunchKernel` op + host `cuLaunchKernelEx`).
- an `extra` line → implement the param-buffer convention.
- a plain `-> err 1` launch line → inspect that kernel's grid/block/shared/params.

## Validation status

- [ ] CI build
- [ ] GPU trace run identifying the failing path (then a follow-up fix PR)

Refs #597.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/603">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->