### PR TITLE
Preserve sparseness when copying the storage template during pack creation

### DIFF
--- a/crates/smolvm-pack/src/assets.rs
+++ b/crates/smolvm-pack/src/assets.rs
@@ -356,7 +356,11 @@ impl AssetCollector {
         // Try to copy from an existing pre-formatted template first.
         // This avoids requiring e2fsprogs on the build machine.
         if let Some(existing) = find_existing_template("storage-template.ext4") {
-            fs::copy(&existing, &template_path)?;
+            // Hole-preserving copy: the shipped storage-template.ext4 is a large
+            // (multi-GiB) sparse file, and a plain fs::copy densifies it into its
+            // full logical size of zeros on some Linux filesystems/mounts —
+            // ballooning the staging dir and failing pack builds with ENOSPC.
+            crate::extract::sparse_copy(&existing, &template_path)?;
             let metadata = fs::metadata(&template_path)?;
             self.inventory.storage_template = Some(AssetEntry {
                 path: TEMPLATE_NAME.to_string(),

--- a/crates/smolvm-pack/src/extract.rs
+++ b/crates/smolvm-pack/src/extract.rs
@@ -1806,7 +1806,11 @@ pub fn extract_libs_from_binary(exe_path: &Path, debug: bool) -> std::io::Result
 /// APFS/ext4/xfs/NTFS alike. Reading over holes costs no disk I/O (the kernel
 /// serves zero pages from cache), so scanning even a mostly-empty 20 GiB
 /// template is fast.
-fn sparse_copy(src: &Path, dst: &Path) -> std::io::Result<()> {
+///
+/// Used on both ends: the extract/run side here, and the pack-create side in
+/// `assets::create_storage_template` when it copies the pre-formatted
+/// `storage-template.ext4` into the staging directory.
+pub(crate) fn sparse_copy(src: &Path, dst: &Path) -> std::io::Result<()> {
     let mut src_file = File::open(src)?;
     let size = src_file.metadata()?.len();
 


### PR DESCRIPTION
Pack creation copied the pre-formatted storage-template.ext4 into the staging directory with a plain fs::copy, which densifies the large sparse template into its full logical size of zeros on some Linux filesystems and fails pack builds with ENOSPC; this reuses the hole-preserving copy already used on the extract side.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/604">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->