### PR TITLE
docs(security): clarify workload isolation model

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ smolvm machine exec --name myvm -it -- /bin/sh
 smolvm machine stop --name myvm
 ```
 
-**Use git and SSH without copying private keys into the guest** — forward your host SSH agent into the VM. The guest can ask the agent to sign with any forwarded key while the socket is available, so forward it only to workloads you trust. Requires an SSH agent running on your host (`ssh-add -l` to check).
+**Use git and SSH without copying private keys into the guest.** Forward your host SSH agent into the VM. The guest can ask the agent to sign with any forwarded key while the socket is available, so forward it only to workloads you trust. Requires an SSH agent running on your host (`ssh-add -l` to check).
 
 ```bash
 smolvm machine run --ssh-agent --net --image alpine -- sh -c "apk add -q openssh-client && ssh-add -l"
@@ -149,7 +149,7 @@ smolvm strengthens the guest/host boundary by giving each workload a separate VM
 * In standalone local use, smolvm's state and control endpoints are scoped to the invoking user's environment. For hostile local co-tenants, add host-level account separation and OS confinement around the VMM process. This section does not describe the separate smolmachines cloud control plane or its tenant-isolation guarantees.
 * Release archives publish SHA-256 checksums and the installer rejects a mismatch when the checksum file is available. Releases are not currently signed or accompanied by provenance attestations, and the installer permits installation when the checksum file cannot be downloaded.
 
-Treat root in the guest as untrusted. The VM boundary limits its direct access to the host, while every explicitly forwarded capability—mounts, network access, ports, and SSH agent access—becomes part of the workload's authority.
+Treat root in the guest as untrusted. The VM boundary limits its direct access to the host, while every explicitly forwarded capability, including mounts, network access, ports, and SSH agent access, becomes part of the workload's authority.
 
 Comparison
 ----------

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ smolvm strengthens the guest/host boundary by giving each workload a separate VM
 * Host directories passed with `--volume` are intentionally exposed to the guest with the requested access. Do not mount secrets or sensitive paths into an untrusted workload.
 * `--ssh-agent` does not copy private key material into the guest, but it grants the guest access to the forwarded agent socket and therefore the ability to request signatures while the VM is running.
 * Networking is disabled by default. Enabling `--net`, port forwarding, or host services expands the workload's reachable surface.
-* smolvm's local state and control endpoints are scoped to the invoking user's environment. For hostile local co-tenants, add host-level account separation and OS confinement around the VMM process.
+* In standalone local use, smolvm's state and control endpoints are scoped to the invoking user's environment. For hostile local co-tenants, add host-level account separation and OS confinement around the VMM process. This section does not describe the separate smolmachines cloud control plane or its tenant-isolation guarantees.
 * Release archives publish SHA-256 checksums and the installer rejects a mismatch when the checksum file is available. Releases are not currently signed or accompanied by provenance attestations, and the installer permits installation when the checksum file cannot be downloaded.
 
 Treat root in the guest as untrusted. The VM boundary limits its direct access to the host, while every explicitly forwarded capability—mounts, network access, ports, and SSH agent access—becomes part of the workload's authority.

--- a/README.md
+++ b/README.md
@@ -95,11 +95,11 @@ smolvm machine exec --name myvm -it -- /bin/sh
 smolvm machine stop --name myvm
 ```
 
-**Use git and SSH without exposing keys** — forward your host SSH agent into the VM. Private keys never enter the guest — the hypervisor enforces this. Requires an SSH agent running on your host (`ssh-add -l` to check).
+**Use git and SSH without copying private keys into the guest** — forward your host SSH agent into the VM. The guest can ask the agent to sign with any forwarded key while the socket is available, so forward it only to workloads you trust. Requires an SSH agent running on your host (`ssh-add -l` to check).
 
 ```bash
 smolvm machine run --ssh-agent --net --image alpine -- sh -c "apk add -q openssh-client && ssh-add -l"
-# lists your host keys, but they can't be extracted from inside the VM
+# lists your host keys; private key material remains in the host agent
 
 smolvm machine exec --name myvm -- git clone git@github.com:org/private-repo.git
 ```
@@ -131,18 +131,32 @@ More examples: [python](https://github.com/smol-machines/smolvm/tree/main/exampl
 How It Works
 ------------
 
-Each workload gets real hardware isolation — its own kernel on [Hypervisor.framework](https://developer.apple.com/documentation/hypervisor) (macOS), KVM (Linux), or the [Windows Hypervisor Platform](https://learn.microsoft.com/en-us/virtualization/api/) (Windows). [libkrun](https://github.com/containers/libkrun) VMM with custom kernel: [libkrunfw](https://github.com/smol-machines/libkrunfw). Pack it into a `.smolmachine` and it runs anywhere the host architecture matches, with zero dependencies.
+Each workload runs in a hardware-virtualized VM with its own guest kernel on [Hypervisor.framework](https://developer.apple.com/documentation/hypervisor) (macOS), KVM (Linux), or the [Windows Hypervisor Platform](https://learn.microsoft.com/en-us/virtualization/api/) (Windows). [libkrun](https://github.com/containers/libkrun) is the VMM and [libkrunfw](https://github.com/smol-machines/libkrunfw) supplies the guest kernel. Pack it into a `.smolmachine` and it runs anywhere the host architecture matches, with zero dependencies.
 
 Images use the [OCI](https://opencontainers.org/) format — the same open standard Docker uses. Any image on Docker Hub, ghcr.io, or other OCI registries can be pulled and booted as a microVM. No Docker daemon required.
 
 Defaults: 4 vCPUs, 8 GiB RAM. Memory is elastic via virtio balloon — the host only commits what the guest actually uses and reclaims the rest automatically. vCPU threads sleep in the hypervisor when idle, so over-provisioning has near-zero cost. Override with `--cpus` and `--mem`.
+
+Security Model
+--------------
+
+smolvm strengthens the guest/host boundary by giving each workload a separate VM and guest kernel. It is not, by itself, a hardened multi-user control plane:
+
+* The `smolvm` CLI and VMM processes run with the permissions of the invoking host user. That user account, the host OS, the hypervisor backend, libkrun, and smolvm are in the trusted computing base.
+* Host directories passed with `--volume` are intentionally exposed to the guest with the requested access. Do not mount secrets or sensitive paths into an untrusted workload.
+* `--ssh-agent` does not copy private key material into the guest, but it grants the guest access to the forwarded agent socket and therefore the ability to request signatures while the VM is running.
+* Networking is disabled by default. Enabling `--net`, port forwarding, or host services expands the workload's reachable surface.
+* smolvm's local state and control endpoints are scoped to the invoking user's environment. For hostile local co-tenants, add host-level account separation and OS confinement around the VMM process.
+* Release archives publish SHA-256 checksums and the installer rejects a mismatch when the checksum file is available. Releases are not currently signed or accompanied by provenance attestations, and the installer permits installation when the checksum file cannot be downloaded.
+
+Treat root in the guest as untrusted. The VM boundary limits its direct access to the host, while every explicitly forwarded capability—mounts, network access, ports, and SSH agent access—becomes part of the workload's authority.
 
 Comparison
 ----------
 
 |                     | smolvm | Containers | Colima | QEMU | Firecracker | Kata |
 |---------------------|--------|------------|--------|------|-------------|------|
-| Isolation           | VM per workload | Namespace (shared kernel) | Namespace (1 VM) | Separate VM | Separate VM | VM per container |
+| Workload boundary   | VM + guest kernel | Namespace + shared kernel | Namespace inside shared VM | VM + guest kernel | VM + guest kernel | VM per container |
 | Boot time           | <200ms | ~100ms | ~seconds | ~15-30s | <125ms | ~500ms |
 | Architecture        | Library (libkrun) | Daemon | Daemon (in VM) | Process | Process | Runtime stack |
 | Per-workload VMs    | Yes | No | No (shared) | Yes | Yes | Yes |


### PR DESCRIPTION
## Problem

The README describes "real hardware isolation" and says the hypervisor protects
forwarded SSH keys without defining the host-side trust boundary or the authority
explicitly forwarded into a guest. That framing can lead users to treat the VM
boundary as a complete security guarantee, especially when evaluating untrusted
workloads or hostile local co-tenants.

The documentation should distinguish three things clearly:

1. the isolation mechanism smolvm provides -- a hardware-virtualized VM with a
   separate guest kernel;
2. the host components and user account that remain trusted; and
3. the capabilities a caller deliberately grants to a workload, such as mounts,
   networking, forwarded ports, and SSH-agent access.

Without that distinction, the comparison table implies a stronger and more
uniform security conclusion than the underlying mechanisms support.

## Changes

- Replace broad isolation claims with the concrete boundary: a hardware-
  virtualized VM and separate guest kernel.
- Document the host-side trusted computing base and local co-tenant assumptions.
- Scope those local-runtime statements explicitly so they are not mistaken for a
  description of the separate smolmachines cloud control plane.
- Explain that volumes, networking, ports, and SSH-agent forwarding deliberately
  expand guest authority.
- Distinguish keeping private key material in the host agent from allowing the
  guest to request signatures.
- Document checksum verification and the current lack of signed releases or
  provenance attestations.
- Rename the comparison row from `Isolation` to `Workload boundary` so it compares
  mechanisms instead of implying equivalent security guarantees.

## Why this framing

The live documentation treats the local embedded runtime / CLI and the cloud
transport as separate deployment modes. This PR follows that model: it documents
the standalone runtime boundary precisely while avoiding unsupported claims about
cloud tenant isolation.

The goal is not to weaken smolvm's positioning. It is to make the security claim
useful: reviewers and users can see what the VM boundary protects, what remains in
the trusted computing base, and which opt-in integrations intentionally cross the
boundary.

## Verified

- Audited the wording against the live docs at `https://smolmachines.com/docs/`,
  including installation, machines, mounts, resources, and GPU guidance.
- Cross-checked the current CLI/VMM process model, volume and SSH-agent forwarding,
  network defaults, and installer checksum behavior in the repository.
- Confirmed the release publishes checksums but no signature or provenance assets.
- `git diff --check` -- OK.
- Documentation-only change; no runtime code paths changed.

Closes #227.