### PR TITLE
cuda: llama.cpp + CUDA 13, correctness hardening, cuBLAS BLAS ops, and remote latency/coldstart cuts

### DIFF
--- a/crates/smolvm-cuda-codegen/src/main.rs
+++ b/crates/smolvm-cuda-codegen/src/main.rs
@@ -143,6 +143,163 @@ fn cublas_spec() -> Lib {
             i("batchCount"),
         ],
     };
+    // ---- BLAS Level 1/2/3 (device-pointer ops with host scalars) ----
+    // Reduction ops (dot/nrm2/asum/amax) are omitted deliberately: their
+    // result pointer is host- or device-resident depending on the handle's
+    // pointer mode, which this uniform marshaling can't disambiguate — they
+    // stay honest NOT_SUPPORTED stubs rather than risk a silently-wrong result.
+    let ic = i; // alias for closures below
+    let dp = |n, ety: &'static str, m: bool| {
+        p(
+            n,
+            leak(format!("*{} {ety}", if m { "mut" } else { "const" })),
+            DevPtr,
+        )
+    };
+    let hin = |n, ety: &'static str| p(n, leak(format!("*const {ety}")), HostInScalar(ety));
+    let axpy = |sym, real, ety: &'static str| Fun {
+        sym,
+        real,
+        params: vec![
+            handle(),
+            ic("n"),
+            hin("alpha", ety),
+            dp("x", ety, false),
+            ic("incx"),
+            dp("y", ety, true),
+            ic("incy"),
+        ],
+    };
+    let scal = |sym, real, ety: &'static str| Fun {
+        sym,
+        real,
+        params: vec![
+            handle(),
+            ic("n"),
+            hin("alpha", ety),
+            dp("x", ety, true),
+            ic("incx"),
+        ],
+    };
+    let copyswap = |sym, real, ety: &'static str| Fun {
+        sym,
+        real,
+        params: vec![
+            handle(),
+            ic("n"),
+            dp("x", ety, true),
+            ic("incx"),
+            dp("y", ety, true),
+            ic("incy"),
+        ],
+    };
+    let gemv = |sym, real, ety: &'static str| Fun {
+        sym,
+        real,
+        params: vec![
+            handle(),
+            ic("trans"),
+            ic("m"),
+            ic("n"),
+            hin("alpha", ety),
+            dp("A", ety, false),
+            ic("lda"),
+            dp("x", ety, false),
+            ic("incx"),
+            hin("beta", ety),
+            dp("y", ety, true),
+            ic("incy"),
+        ],
+    };
+    let ger = |sym, real, ety: &'static str| Fun {
+        sym,
+        real,
+        params: vec![
+            handle(),
+            ic("m"),
+            ic("n"),
+            hin("alpha", ety),
+            dp("x", ety, false),
+            ic("incx"),
+            dp("y", ety, false),
+            ic("incy"),
+            dp("A", ety, true),
+            ic("lda"),
+        ],
+    };
+    let geam = |sym, real, ety: &'static str| Fun {
+        sym,
+        real,
+        params: vec![
+            handle(),
+            ic("transa"),
+            ic("transb"),
+            ic("m"),
+            ic("n"),
+            hin("alpha", ety),
+            dp("A", ety, false),
+            ic("lda"),
+            hin("beta", ety),
+            dp("B", ety, false),
+            ic("ldb"),
+            dp("C", ety, true),
+            ic("ldc"),
+        ],
+    };
+    let syrk = |sym, real, ety: &'static str| Fun {
+        sym,
+        real,
+        params: vec![
+            handle(),
+            ic("uplo"),
+            ic("trans"),
+            ic("n"),
+            ic("k"),
+            hin("alpha", ety),
+            dp("A", ety, false),
+            ic("lda"),
+            hin("beta", ety),
+            dp("C", ety, true),
+            ic("ldc"),
+        ],
+    };
+    let symm = |sym, real, ety: &'static str| Fun {
+        sym,
+        real,
+        params: vec![
+            handle(),
+            ic("side"),
+            ic("uplo"),
+            ic("m"),
+            ic("n"),
+            hin("alpha", ety),
+            dp("A", ety, false),
+            ic("lda"),
+            dp("B", ety, false),
+            ic("ldb"),
+            hin("beta", ety),
+            dp("C", ety, true),
+            ic("ldc"),
+        ],
+    };
+    let trsm = |sym, real, ety: &'static str| Fun {
+        sym,
+        real,
+        params: vec![
+            handle(),
+            ic("side"),
+            ic("uplo"),
+            ic("trans"),
+            ic("diag"),
+            ic("m"),
+            ic("n"),
+            hin("alpha", ety),
+            dp("A", ety, false),
+            ic("lda"),
+            dp("B", ety, true),
+            ic("ldb"),
+        ],
+    };
     Lib {
         name: "cublas",
         id: 1,
@@ -294,6 +451,27 @@ fn cublas_spec() -> Lib {
                     i("algo"),
                 ],
             },
+            // BLAS Level 1/2/3 — appended (indices grow; existing ones stable).
+            axpy("cublasSaxpy_v2", "cublasSaxpy_v2", "f32"),
+            axpy("cublasDaxpy_v2", "cublasDaxpy_v2", "f64"),
+            scal("cublasSscal_v2", "cublasSscal_v2", "f32"),
+            scal("cublasDscal_v2", "cublasDscal_v2", "f64"),
+            copyswap("cublasScopy_v2", "cublasScopy_v2", "f32"),
+            copyswap("cublasDcopy_v2", "cublasDcopy_v2", "f64"),
+            copyswap("cublasSswap_v2", "cublasSswap_v2", "f32"),
+            copyswap("cublasDswap_v2", "cublasDswap_v2", "f64"),
+            gemv("cublasSgemv_v2", "cublasSgemv_v2", "f32"),
+            gemv("cublasDgemv_v2", "cublasDgemv_v2", "f64"),
+            ger("cublasSger_v2", "cublasSger_v2", "f32"),
+            ger("cublasDger_v2", "cublasDger_v2", "f64"),
+            geam("cublasSgeam", "cublasSgeam", "f32"),
+            geam("cublasDgeam", "cublasDgeam", "f64"),
+            syrk("cublasSsyrk_v2", "cublasSsyrk_v2", "f32"),
+            syrk("cublasDsyrk_v2", "cublasDsyrk_v2", "f64"),
+            symm("cublasSsymm_v2", "cublasSsymm_v2", "f32"),
+            symm("cublasDsymm_v2", "cublasDsymm_v2", "f64"),
+            trsm("cublasStrsm_v2", "cublasStrsm_v2", "f32"),
+            trsm("cublasDtrsm_v2", "cublasDtrsm_v2", "f64"),
         ],
     }
 }

--- a/crates/smolvm-cuda-codegen/src/main.rs
+++ b/crates/smolvm-cuda-codegen/src/main.rs
@@ -264,6 +264,36 @@ fn cublas_spec() -> Lib {
                     i("algo"),
                 ],
             },
+            // cublasGemmBatchedEx — pointer-array batched GEMM (llama.cpp's
+            // ggml-cuda attention batching). The A/B/C arrays are arrays OF
+            // device pointers living in device memory, so they forward as
+            // plain device pointers.
+            Fun {
+                sym: "cublasGemmBatchedEx",
+                real: "cublasGemmBatchedEx",
+                params: vec![
+                    handle(),
+                    i("transa"),
+                    i("transb"),
+                    i("m"),
+                    i("n"),
+                    i("k"),
+                    p("alpha", "*const f32", HostInScalar("f32")),
+                    p("Aarray", "*const c_void", DevPtr),
+                    i("Atype"),
+                    i("lda"),
+                    p("Barray", "*const c_void", DevPtr),
+                    i("Btype"),
+                    i("ldb"),
+                    p("beta", "*const f32", HostInScalar("f32")),
+                    p("Carray", "*mut c_void", DevPtr),
+                    i("Ctype"),
+                    i("ldc"),
+                    i("batchCount"),
+                    i("computeType"),
+                    i("algo"),
+                ],
+            },
         ],
     }
 }

--- a/crates/smolvm-cuda-shim/src/lib.rs
+++ b/crates/smolvm-cuda-shim/src/lib.rs
@@ -362,9 +362,21 @@ pub extern "C" fn cuDeviceTotalMem_v2(bytes: *mut usize, device: c_int) -> c_int
 
 #[no_mangle]
 pub extern "C" fn cuDeviceGetAttribute(pi: *mut c_int, attrib: c_int, device: c_int) -> c_int {
+    // Immutable — memoize to spare a host round-trip per repeat.
+    static DEV_ATTRS: Mutex<Option<HashMap<(c_int, c_int), c_int>>> = Mutex::new(None);
+    if let Ok(mut g) = DEV_ATTRS.lock() {
+        if let Some(&v) = g.get_or_insert_with(HashMap::new).get(&(device, attrib)) {
+            return ret(unsafe { out(pi, v) });
+        }
+    }
     ret(
-        with_state(|s| s.client.device_get_attribute(attrib, device))
-            .and_then(|v| unsafe { out(pi, v) }),
+        with_state(|s| s.client.device_get_attribute(attrib, device)).and_then(|v| {
+            if let Ok(mut g) = DEV_ATTRS.lock() {
+                g.get_or_insert_with(HashMap::new)
+                    .insert((device, attrib), v);
+            }
+            unsafe { out(pi, v) }
+        }),
     )
 }
 

--- a/crates/smolvm-cuda/build.rs
+++ b/crates/smolvm-cuda/build.rs
@@ -1,0 +1,37 @@
+//! Emit `SMOLVM_PROTO_HASH`: a fingerprint of the wire-defining source, so a
+//! shim and a server built from different source (the classic "rebuilt one
+//! binary, not the other" stale-binary trap that silently corrupts results)
+//! fail the connect handshake loudly instead. The hash covers only files both
+//! the client (shim) and the host (server) compile, i.e. the wire contract —
+//! not host-only backend code, which doesn't change the byte protocol.
+//!
+//! FNV-1a (not `DefaultHasher`) so the value is reproducible across toolchains
+//! and platforms: a guest-built shim and a host-built server must agree.
+
+fn fnv1a(seed: u64, bytes: &[u8]) -> u64 {
+    let mut h = seed;
+    for &b in bytes {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
+
+fn main() {
+    let files = [
+        "src/proto.rs",
+        "src/client.rs",
+        "src/ring.rs",
+        "src/generated/cublas_guest.rs",
+        "src/generated/cudnn_guest.rs",
+    ];
+    // A manual epoch to force a bump on wire changes the file set misses.
+    const PROTO_EPOCH: &[u8] = b"epoch-1";
+    let mut h = fnv1a(0xcbf2_9ce4_8422_2325, PROTO_EPOCH);
+    for f in files {
+        println!("cargo:rerun-if-changed={f}");
+        let bytes = std::fs::read(f).unwrap_or_default();
+        h = fnv1a(h, &bytes);
+    }
+    println!("cargo:rustc-env=SMOLVM_PROTO_HASH={h:016x}");
+}

--- a/crates/smolvm-cuda/src/client.rs
+++ b/crates/smolvm-cuda/src/client.rs
@@ -639,7 +639,13 @@ impl<S: Read + Write> Client<S> {
     }
 
     pub fn init(&mut self) -> Result<()> {
-        self.call(&Request::Init, Op::Init).map(|_| ())
+        self.call(
+            &Request::Init {
+                proto_hash: crate::PROTO_HASH,
+            },
+            Op::Init,
+        )
+        .map(|_| ())
     }
 
     pub fn device_get_count(&mut self) -> Result<i32> {

--- a/crates/smolvm-cuda/src/client.rs
+++ b/crates/smolvm-cuda/src/client.rs
@@ -933,6 +933,16 @@ impl<S: Read + Write> Client<S> {
     /// Per-parameter byte sizes of the kernel's arguments, in declaration order.
     /// Set a `CUfunction_attribute` on the host function (round-trip: the caller
     /// — Triton — checks the status to decide whether the kernel can run).
+    pub fn func_get_attribute(&mut self, function: u64, attrib: i32) -> Result<i32> {
+        match self.call(
+            &Request::FuncGetAttribute { function, attrib },
+            Op::FuncGetAttribute,
+        )? {
+            Response::Count(v) => Ok(v),
+            _ => Err(CudaRpcError::Protocol("expected Count")),
+        }
+    }
+
     pub fn func_set_attribute(&mut self, function: u64, attrib: i32, value: i32) -> Result<()> {
         self.call(
             &Request::FuncSetAttribute {

--- a/crates/smolvm-cuda/src/client.rs
+++ b/crates/smolvm-cuda/src/client.rs
@@ -816,12 +816,23 @@ impl<S: Read + Write> Client<S> {
         .map(|_| ())
     }
 
-    /// Returns the raw `cudaGraph_t` (an opaque host pointer to the guest).
-    pub fn stream_end_capture(&mut self, stream: u64) -> Result<u64> {
-        match self.call(&Request::StreamEndCapture { stream }, Op::StreamEndCapture)? {
-            Response::Handle(h) => Ok(h),
-            _ => Err(CudaRpcError::Protocol("expected Handle")),
-        }
+    /// Fire-and-forget begin-capture: the host starts capture when this drains,
+    /// and subsequent (also-deferred) launches record in order. Saves a host
+    /// round-trip per captured graph (coldstart over a network).
+    pub fn stream_begin_capture_deferred(&mut self, stream: u64, mode: i32) -> Result<()> {
+        self.call_deferred(
+            &Request::StreamBeginCapture { stream, mode },
+            Op::StreamBeginCapture,
+        )
+    }
+
+    /// Fire-and-forget end-capture: the guest supplies a virtual graph handle
+    /// it minted; the host maps it to the real captured graph when it drains.
+    pub fn stream_end_capture_deferred(&mut self, stream: u64, graph_vh: u64) -> Result<()> {
+        self.call_deferred(
+            &Request::StreamEndCapture { stream, graph_vh },
+            Op::StreamEndCapture,
+        )
     }
 
     /// `(capture_status, capture_id)` straight from the host driver.
@@ -835,11 +846,13 @@ impl<S: Read + Write> Client<S> {
         }
     }
 
-    pub fn graph_instantiate(&mut self, graph: u64) -> Result<u64> {
-        match self.call(&Request::GraphInstantiate { graph }, Op::GraphInstantiate)? {
-            Response::Handle(h) => Ok(h),
-            _ => Err(CudaRpcError::Protocol("expected Handle")),
-        }
+    /// Fire-and-forget instantiate: `graph` is a virtual graph handle; the
+    /// guest supplies a virtual exec handle the host maps to the real exec.
+    pub fn graph_instantiate_deferred(&mut self, graph: u64, exec_vh: u64) -> Result<()> {
+        self.call_deferred(
+            &Request::GraphInstantiate { graph, exec_vh },
+            Op::GraphInstantiate,
+        )
     }
 
     /// Replay an instantiated graph — the hot path (one message replays every

--- a/crates/smolvm-cuda/src/client.rs
+++ b/crates/smolvm-cuda/src/client.rs
@@ -116,6 +116,27 @@ fn sync_forced(req: &Request, op: Op) -> bool {
     false
 }
 
+/// Bench/diagnostic: `SMOLVM_CUDA_RTT_DELAY_US` sleeps this many microseconds
+/// per host round-trip, modeling a remote server's network RTT. Batched
+/// deferred work pays it once per fence (as a real network would), so the
+/// resulting throughput-vs-latency curve shows how tolerant each mode is of
+/// distance. Read once (env lookups aren't free on the hot path).
+fn rtt_tax() {
+    use std::sync::atomic::{AtomicI64, Ordering};
+    static US: AtomicI64 = AtomicI64::new(-1);
+    let mut v = US.load(Ordering::Relaxed);
+    if v == -1 {
+        v = std::env::var("SMOLVM_CUDA_RTT_DELAY_US")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+        US.store(v, Ordering::Relaxed);
+    }
+    if v > 0 {
+        std::thread::sleep(std::time::Duration::from_micros(v as u64));
+    }
+}
+
 /// Round-trip one encoded request over a [`Bridge`], growing the response
 /// buffer when the callee reports it too small (the callee stashes the
 /// response; an empty request fetches the stash).
@@ -385,6 +406,7 @@ impl<S: Read + Write> Client<S> {
     /// One sync round-trip over the rings.
     fn ring_roundtrip(&mut self, frame: &[u8]) -> Result<Vec<u8>> {
         self.ring_push(frame)?;
+        rtt_tax();
         self.ring_pop_response()
     }
 
@@ -440,6 +462,7 @@ impl<S: Read + Write> Client<S> {
         self.wbuf.extend_from_slice(&1u32.to_le_bytes());
         self.wbuf.push(crate::proto::FENCE_OP);
         self.flush_wbuf()?;
+        rtt_tax();
         let payload =
             read_msg(&mut self.stream)?.ok_or(CudaRpcError::Protocol("host closed mid-fence"))?;
         if payload.len() >= 4 {
@@ -560,6 +583,7 @@ impl<S: Read + Write> Client<S> {
             // (drain) and the MAX_DEFERRED backstop.
             self.flush_wbuf()?;
             write_msg(&mut self.stream, &encode_request(req))?;
+            rtt_tax();
             read_msg(&mut self.stream)?.ok_or(CudaRpcError::Protocol("host closed mid-call"))?
         };
         let (status, resp) = decode_response(op, &payload)?;
@@ -635,6 +659,7 @@ impl<S: Read + Write> Client<S> {
         // Flush, don't fence — see `call`.
         self.flush_wbuf()?;
         write_msg(&mut self.stream, payload)?;
+        rtt_tax();
         read_msg(&mut self.stream)?.ok_or(CudaRpcError::Protocol("host closed mid-call"))
     }
 

--- a/crates/smolvm-cuda/src/generated/cublas_guest.rs
+++ b/crates/smolvm-cuda/src/generated/cublas_guest.rs
@@ -270,3 +270,337 @@ pub extern "C" fn cublasGemmBatchedEx(handle: *mut c_void, transa: c_int, transb
     // No output params: fire-and-forget (failures surface as sticky async errors).
     match with_client(|c| c.lib_call_deferred(LIB_ID, 14, a)) { Ok(()) => 0, Err(_) => 1 }
 }
+#[no_mangle]
+pub extern "C" fn cublasSaxpy_v2(handle: *mut c_void, n: c_int, alpha: *const f32, x: *const f32, incx: c_int, y: *mut f32, incy: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f32).to_le_bytes());
+    a.extend_from_slice(&(x as u64).to_le_bytes());
+    a.extend_from_slice(&(incx as i32).to_le_bytes());
+    a.extend_from_slice(&(y as u64).to_le_bytes());
+    a.extend_from_slice(&(incy as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 15, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasDaxpy_v2(handle: *mut c_void, n: c_int, alpha: *const f64, x: *const f64, incx: c_int, y: *mut f64, incy: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f64).to_le_bytes());
+    a.extend_from_slice(&(x as u64).to_le_bytes());
+    a.extend_from_slice(&(incx as i32).to_le_bytes());
+    a.extend_from_slice(&(y as u64).to_le_bytes());
+    a.extend_from_slice(&(incy as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 16, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasSscal_v2(handle: *mut c_void, n: c_int, alpha: *const f32, x: *mut f32, incx: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f32).to_le_bytes());
+    a.extend_from_slice(&(x as u64).to_le_bytes());
+    a.extend_from_slice(&(incx as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 17, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasDscal_v2(handle: *mut c_void, n: c_int, alpha: *const f64, x: *mut f64, incx: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f64).to_le_bytes());
+    a.extend_from_slice(&(x as u64).to_le_bytes());
+    a.extend_from_slice(&(incx as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 18, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasScopy_v2(handle: *mut c_void, n: c_int, x: *mut f32, incx: c_int, y: *mut f32, incy: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    a.extend_from_slice(&(x as u64).to_le_bytes());
+    a.extend_from_slice(&(incx as i32).to_le_bytes());
+    a.extend_from_slice(&(y as u64).to_le_bytes());
+    a.extend_from_slice(&(incy as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 19, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasDcopy_v2(handle: *mut c_void, n: c_int, x: *mut f64, incx: c_int, y: *mut f64, incy: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    a.extend_from_slice(&(x as u64).to_le_bytes());
+    a.extend_from_slice(&(incx as i32).to_le_bytes());
+    a.extend_from_slice(&(y as u64).to_le_bytes());
+    a.extend_from_slice(&(incy as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 20, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasSswap_v2(handle: *mut c_void, n: c_int, x: *mut f32, incx: c_int, y: *mut f32, incy: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    a.extend_from_slice(&(x as u64).to_le_bytes());
+    a.extend_from_slice(&(incx as i32).to_le_bytes());
+    a.extend_from_slice(&(y as u64).to_le_bytes());
+    a.extend_from_slice(&(incy as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 21, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasDswap_v2(handle: *mut c_void, n: c_int, x: *mut f64, incx: c_int, y: *mut f64, incy: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    a.extend_from_slice(&(x as u64).to_le_bytes());
+    a.extend_from_slice(&(incx as i32).to_le_bytes());
+    a.extend_from_slice(&(y as u64).to_le_bytes());
+    a.extend_from_slice(&(incy as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 22, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasSgemv_v2(handle: *mut c_void, trans: c_int, m: c_int, n: c_int, alpha: *const f32, A: *const f32, lda: c_int, x: *const f32, incx: c_int, beta: *const f32, y: *mut f32, incy: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(trans as i32).to_le_bytes());
+    a.extend_from_slice(&(m as i32).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f32).to_le_bytes());
+    a.extend_from_slice(&(A as u64).to_le_bytes());
+    a.extend_from_slice(&(lda as i32).to_le_bytes());
+    a.extend_from_slice(&(x as u64).to_le_bytes());
+    a.extend_from_slice(&(incx as i32).to_le_bytes());
+    if beta.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *beta } as f32).to_le_bytes());
+    a.extend_from_slice(&(y as u64).to_le_bytes());
+    a.extend_from_slice(&(incy as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 23, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasDgemv_v2(handle: *mut c_void, trans: c_int, m: c_int, n: c_int, alpha: *const f64, A: *const f64, lda: c_int, x: *const f64, incx: c_int, beta: *const f64, y: *mut f64, incy: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(trans as i32).to_le_bytes());
+    a.extend_from_slice(&(m as i32).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f64).to_le_bytes());
+    a.extend_from_slice(&(A as u64).to_le_bytes());
+    a.extend_from_slice(&(lda as i32).to_le_bytes());
+    a.extend_from_slice(&(x as u64).to_le_bytes());
+    a.extend_from_slice(&(incx as i32).to_le_bytes());
+    if beta.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *beta } as f64).to_le_bytes());
+    a.extend_from_slice(&(y as u64).to_le_bytes());
+    a.extend_from_slice(&(incy as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 24, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasSger_v2(handle: *mut c_void, m: c_int, n: c_int, alpha: *const f32, x: *const f32, incx: c_int, y: *const f32, incy: c_int, A: *mut f32, lda: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(m as i32).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f32).to_le_bytes());
+    a.extend_from_slice(&(x as u64).to_le_bytes());
+    a.extend_from_slice(&(incx as i32).to_le_bytes());
+    a.extend_from_slice(&(y as u64).to_le_bytes());
+    a.extend_from_slice(&(incy as i32).to_le_bytes());
+    a.extend_from_slice(&(A as u64).to_le_bytes());
+    a.extend_from_slice(&(lda as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 25, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasDger_v2(handle: *mut c_void, m: c_int, n: c_int, alpha: *const f64, x: *const f64, incx: c_int, y: *const f64, incy: c_int, A: *mut f64, lda: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(m as i32).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f64).to_le_bytes());
+    a.extend_from_slice(&(x as u64).to_le_bytes());
+    a.extend_from_slice(&(incx as i32).to_le_bytes());
+    a.extend_from_slice(&(y as u64).to_le_bytes());
+    a.extend_from_slice(&(incy as i32).to_le_bytes());
+    a.extend_from_slice(&(A as u64).to_le_bytes());
+    a.extend_from_slice(&(lda as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 26, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasSgeam(handle: *mut c_void, transa: c_int, transb: c_int, m: c_int, n: c_int, alpha: *const f32, A: *const f32, lda: c_int, beta: *const f32, B: *const f32, ldb: c_int, C: *mut f32, ldc: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(transa as i32).to_le_bytes());
+    a.extend_from_slice(&(transb as i32).to_le_bytes());
+    a.extend_from_slice(&(m as i32).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f32).to_le_bytes());
+    a.extend_from_slice(&(A as u64).to_le_bytes());
+    a.extend_from_slice(&(lda as i32).to_le_bytes());
+    if beta.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *beta } as f32).to_le_bytes());
+    a.extend_from_slice(&(B as u64).to_le_bytes());
+    a.extend_from_slice(&(ldb as i32).to_le_bytes());
+    a.extend_from_slice(&(C as u64).to_le_bytes());
+    a.extend_from_slice(&(ldc as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 27, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasDgeam(handle: *mut c_void, transa: c_int, transb: c_int, m: c_int, n: c_int, alpha: *const f64, A: *const f64, lda: c_int, beta: *const f64, B: *const f64, ldb: c_int, C: *mut f64, ldc: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(transa as i32).to_le_bytes());
+    a.extend_from_slice(&(transb as i32).to_le_bytes());
+    a.extend_from_slice(&(m as i32).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f64).to_le_bytes());
+    a.extend_from_slice(&(A as u64).to_le_bytes());
+    a.extend_from_slice(&(lda as i32).to_le_bytes());
+    if beta.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *beta } as f64).to_le_bytes());
+    a.extend_from_slice(&(B as u64).to_le_bytes());
+    a.extend_from_slice(&(ldb as i32).to_le_bytes());
+    a.extend_from_slice(&(C as u64).to_le_bytes());
+    a.extend_from_slice(&(ldc as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 28, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasSsyrk_v2(handle: *mut c_void, uplo: c_int, trans: c_int, n: c_int, k: c_int, alpha: *const f32, A: *const f32, lda: c_int, beta: *const f32, C: *mut f32, ldc: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(uplo as i32).to_le_bytes());
+    a.extend_from_slice(&(trans as i32).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    a.extend_from_slice(&(k as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f32).to_le_bytes());
+    a.extend_from_slice(&(A as u64).to_le_bytes());
+    a.extend_from_slice(&(lda as i32).to_le_bytes());
+    if beta.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *beta } as f32).to_le_bytes());
+    a.extend_from_slice(&(C as u64).to_le_bytes());
+    a.extend_from_slice(&(ldc as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 29, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasDsyrk_v2(handle: *mut c_void, uplo: c_int, trans: c_int, n: c_int, k: c_int, alpha: *const f64, A: *const f64, lda: c_int, beta: *const f64, C: *mut f64, ldc: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(uplo as i32).to_le_bytes());
+    a.extend_from_slice(&(trans as i32).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    a.extend_from_slice(&(k as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f64).to_le_bytes());
+    a.extend_from_slice(&(A as u64).to_le_bytes());
+    a.extend_from_slice(&(lda as i32).to_le_bytes());
+    if beta.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *beta } as f64).to_le_bytes());
+    a.extend_from_slice(&(C as u64).to_le_bytes());
+    a.extend_from_slice(&(ldc as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 30, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasSsymm_v2(handle: *mut c_void, side: c_int, uplo: c_int, m: c_int, n: c_int, alpha: *const f32, A: *const f32, lda: c_int, B: *const f32, ldb: c_int, beta: *const f32, C: *mut f32, ldc: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(side as i32).to_le_bytes());
+    a.extend_from_slice(&(uplo as i32).to_le_bytes());
+    a.extend_from_slice(&(m as i32).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f32).to_le_bytes());
+    a.extend_from_slice(&(A as u64).to_le_bytes());
+    a.extend_from_slice(&(lda as i32).to_le_bytes());
+    a.extend_from_slice(&(B as u64).to_le_bytes());
+    a.extend_from_slice(&(ldb as i32).to_le_bytes());
+    if beta.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *beta } as f32).to_le_bytes());
+    a.extend_from_slice(&(C as u64).to_le_bytes());
+    a.extend_from_slice(&(ldc as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 31, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasDsymm_v2(handle: *mut c_void, side: c_int, uplo: c_int, m: c_int, n: c_int, alpha: *const f64, A: *const f64, lda: c_int, B: *const f64, ldb: c_int, beta: *const f64, C: *mut f64, ldc: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(side as i32).to_le_bytes());
+    a.extend_from_slice(&(uplo as i32).to_le_bytes());
+    a.extend_from_slice(&(m as i32).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f64).to_le_bytes());
+    a.extend_from_slice(&(A as u64).to_le_bytes());
+    a.extend_from_slice(&(lda as i32).to_le_bytes());
+    a.extend_from_slice(&(B as u64).to_le_bytes());
+    a.extend_from_slice(&(ldb as i32).to_le_bytes());
+    if beta.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *beta } as f64).to_le_bytes());
+    a.extend_from_slice(&(C as u64).to_le_bytes());
+    a.extend_from_slice(&(ldc as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 32, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasStrsm_v2(handle: *mut c_void, side: c_int, uplo: c_int, trans: c_int, diag: c_int, m: c_int, n: c_int, alpha: *const f32, A: *const f32, lda: c_int, B: *mut f32, ldb: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(side as i32).to_le_bytes());
+    a.extend_from_slice(&(uplo as i32).to_le_bytes());
+    a.extend_from_slice(&(trans as i32).to_le_bytes());
+    a.extend_from_slice(&(diag as i32).to_le_bytes());
+    a.extend_from_slice(&(m as i32).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f32).to_le_bytes());
+    a.extend_from_slice(&(A as u64).to_le_bytes());
+    a.extend_from_slice(&(lda as i32).to_le_bytes());
+    a.extend_from_slice(&(B as u64).to_le_bytes());
+    a.extend_from_slice(&(ldb as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 33, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasDtrsm_v2(handle: *mut c_void, side: c_int, uplo: c_int, trans: c_int, diag: c_int, m: c_int, n: c_int, alpha: *const f64, A: *const f64, lda: c_int, B: *mut f64, ldb: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(side as i32).to_le_bytes());
+    a.extend_from_slice(&(uplo as i32).to_le_bytes());
+    a.extend_from_slice(&(trans as i32).to_le_bytes());
+    a.extend_from_slice(&(diag as i32).to_le_bytes());
+    a.extend_from_slice(&(m as i32).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f64).to_le_bytes());
+    a.extend_from_slice(&(A as u64).to_le_bytes());
+    a.extend_from_slice(&(lda as i32).to_le_bytes());
+    a.extend_from_slice(&(B as u64).to_le_bytes());
+    a.extend_from_slice(&(ldb as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 34, a)) { Ok(()) => 0, Err(_) => 1 }
+}

--- a/crates/smolvm-cuda/src/generated/cublas_guest.rs
+++ b/crates/smolvm-cuda/src/generated/cublas_guest.rs
@@ -242,3 +242,31 @@ pub extern "C" fn cublasGemmStridedBatchedEx(handle: *mut c_void, transa: c_int,
     // No output params: fire-and-forget (failures surface as sticky async errors).
     match with_client(|c| c.lib_call_deferred(LIB_ID, 13, a)) { Ok(()) => 0, Err(_) => 1 }
 }
+#[no_mangle]
+pub extern "C" fn cublasGemmBatchedEx(handle: *mut c_void, transa: c_int, transb: c_int, m: c_int, n: c_int, k: c_int, alpha: *const f32, Aarray: *const c_void, Atype: c_int, lda: c_int, Barray: *const c_void, Btype: c_int, ldb: c_int, beta: *const f32, Carray: *mut c_void, Ctype: c_int, ldc: c_int, batchCount: c_int, computeType: c_int, algo: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(transa as i32).to_le_bytes());
+    a.extend_from_slice(&(transb as i32).to_le_bytes());
+    a.extend_from_slice(&(m as i32).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    a.extend_from_slice(&(k as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f32).to_le_bytes());
+    a.extend_from_slice(&(Aarray as u64).to_le_bytes());
+    a.extend_from_slice(&(Atype as i32).to_le_bytes());
+    a.extend_from_slice(&(lda as i32).to_le_bytes());
+    a.extend_from_slice(&(Barray as u64).to_le_bytes());
+    a.extend_from_slice(&(Btype as i32).to_le_bytes());
+    a.extend_from_slice(&(ldb as i32).to_le_bytes());
+    if beta.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *beta } as f32).to_le_bytes());
+    a.extend_from_slice(&(Carray as u64).to_le_bytes());
+    a.extend_from_slice(&(Ctype as i32).to_le_bytes());
+    a.extend_from_slice(&(ldc as i32).to_le_bytes());
+    a.extend_from_slice(&(batchCount as i32).to_le_bytes());
+    a.extend_from_slice(&(computeType as i32).to_le_bytes());
+    a.extend_from_slice(&(algo as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 14, a)) { Ok(()) => 0, Err(_) => 1 }
+}

--- a/crates/smolvm-cuda/src/generated/cublas_host.rs
+++ b/crates/smolvm-cuda/src/generated/cublas_host.rs
@@ -15,6 +15,26 @@ pub struct GenLib { _lib: Library,
     f_cublasGemmEx: unsafe extern "C" fn(*mut c_void, c_int, c_int, c_int, c_int, c_int, *const f32, *const c_void, c_int, c_int, *const c_void, c_int, c_int, *const f32, *mut c_void, c_int, c_int, c_int, c_int) -> c_int,
     f_cublasGemmStridedBatchedEx: unsafe extern "C" fn(*mut c_void, c_int, c_int, c_int, c_int, c_int, *const f32, *const c_void, c_int, c_int, i64, *const c_void, c_int, c_int, i64, *const f32, *mut c_void, c_int, c_int, i64, c_int, c_int, c_int) -> c_int,
     f_cublasGemmBatchedEx: unsafe extern "C" fn(*mut c_void, c_int, c_int, c_int, c_int, c_int, *const f32, *const c_void, c_int, c_int, *const c_void, c_int, c_int, *const f32, *mut c_void, c_int, c_int, c_int, c_int, c_int) -> c_int,
+    f_cublasSaxpy_v2: unsafe extern "C" fn(*mut c_void, c_int, *const f32, *const f32, c_int, *mut f32, c_int) -> c_int,
+    f_cublasDaxpy_v2: unsafe extern "C" fn(*mut c_void, c_int, *const f64, *const f64, c_int, *mut f64, c_int) -> c_int,
+    f_cublasSscal_v2: unsafe extern "C" fn(*mut c_void, c_int, *const f32, *mut f32, c_int) -> c_int,
+    f_cublasDscal_v2: unsafe extern "C" fn(*mut c_void, c_int, *const f64, *mut f64, c_int) -> c_int,
+    f_cublasScopy_v2: unsafe extern "C" fn(*mut c_void, c_int, *mut f32, c_int, *mut f32, c_int) -> c_int,
+    f_cublasDcopy_v2: unsafe extern "C" fn(*mut c_void, c_int, *mut f64, c_int, *mut f64, c_int) -> c_int,
+    f_cublasSswap_v2: unsafe extern "C" fn(*mut c_void, c_int, *mut f32, c_int, *mut f32, c_int) -> c_int,
+    f_cublasDswap_v2: unsafe extern "C" fn(*mut c_void, c_int, *mut f64, c_int, *mut f64, c_int) -> c_int,
+    f_cublasSgemv_v2: unsafe extern "C" fn(*mut c_void, c_int, c_int, c_int, *const f32, *const f32, c_int, *const f32, c_int, *const f32, *mut f32, c_int) -> c_int,
+    f_cublasDgemv_v2: unsafe extern "C" fn(*mut c_void, c_int, c_int, c_int, *const f64, *const f64, c_int, *const f64, c_int, *const f64, *mut f64, c_int) -> c_int,
+    f_cublasSger_v2: unsafe extern "C" fn(*mut c_void, c_int, c_int, *const f32, *const f32, c_int, *const f32, c_int, *mut f32, c_int) -> c_int,
+    f_cublasDger_v2: unsafe extern "C" fn(*mut c_void, c_int, c_int, *const f64, *const f64, c_int, *const f64, c_int, *mut f64, c_int) -> c_int,
+    f_cublasSgeam: unsafe extern "C" fn(*mut c_void, c_int, c_int, c_int, c_int, *const f32, *const f32, c_int, *const f32, *const f32, c_int, *mut f32, c_int) -> c_int,
+    f_cublasDgeam: unsafe extern "C" fn(*mut c_void, c_int, c_int, c_int, c_int, *const f64, *const f64, c_int, *const f64, *const f64, c_int, *mut f64, c_int) -> c_int,
+    f_cublasSsyrk_v2: unsafe extern "C" fn(*mut c_void, c_int, c_int, c_int, c_int, *const f32, *const f32, c_int, *const f32, *mut f32, c_int) -> c_int,
+    f_cublasDsyrk_v2: unsafe extern "C" fn(*mut c_void, c_int, c_int, c_int, c_int, *const f64, *const f64, c_int, *const f64, *mut f64, c_int) -> c_int,
+    f_cublasSsymm_v2: unsafe extern "C" fn(*mut c_void, c_int, c_int, c_int, c_int, *const f32, *const f32, c_int, *const f32, c_int, *const f32, *mut f32, c_int) -> c_int,
+    f_cublasDsymm_v2: unsafe extern "C" fn(*mut c_void, c_int, c_int, c_int, c_int, *const f64, *const f64, c_int, *const f64, c_int, *const f64, *mut f64, c_int) -> c_int,
+    f_cublasStrsm_v2: unsafe extern "C" fn(*mut c_void, c_int, c_int, c_int, c_int, c_int, c_int, *const f32, *const f32, c_int, *mut f32, c_int) -> c_int,
+    f_cublasDtrsm_v2: unsafe extern "C" fn(*mut c_void, c_int, c_int, c_int, c_int, c_int, c_int, *const f64, *const f64, c_int, *mut f64, c_int) -> c_int,
 }
 impl GenLib {
     pub fn load() -> Result<GenLib, String> {
@@ -36,6 +56,26 @@ impl GenLib {
                 f_cublasGemmEx: sym(&lib, b"cublasGemmEx\0")?,
                 f_cublasGemmStridedBatchedEx: sym(&lib, b"cublasGemmStridedBatchedEx\0")?,
                 f_cublasGemmBatchedEx: sym(&lib, b"cublasGemmBatchedEx\0")?,
+                f_cublasSaxpy_v2: sym(&lib, b"cublasSaxpy_v2\0")?,
+                f_cublasDaxpy_v2: sym(&lib, b"cublasDaxpy_v2\0")?,
+                f_cublasSscal_v2: sym(&lib, b"cublasSscal_v2\0")?,
+                f_cublasDscal_v2: sym(&lib, b"cublasDscal_v2\0")?,
+                f_cublasScopy_v2: sym(&lib, b"cublasScopy_v2\0")?,
+                f_cublasDcopy_v2: sym(&lib, b"cublasDcopy_v2\0")?,
+                f_cublasSswap_v2: sym(&lib, b"cublasSswap_v2\0")?,
+                f_cublasDswap_v2: sym(&lib, b"cublasDswap_v2\0")?,
+                f_cublasSgemv_v2: sym(&lib, b"cublasSgemv_v2\0")?,
+                f_cublasDgemv_v2: sym(&lib, b"cublasDgemv_v2\0")?,
+                f_cublasSger_v2: sym(&lib, b"cublasSger_v2\0")?,
+                f_cublasDger_v2: sym(&lib, b"cublasDger_v2\0")?,
+                f_cublasSgeam: sym(&lib, b"cublasSgeam\0")?,
+                f_cublasDgeam: sym(&lib, b"cublasDgeam\0")?,
+                f_cublasSsyrk_v2: sym(&lib, b"cublasSsyrk_v2\0")?,
+                f_cublasDsyrk_v2: sym(&lib, b"cublasDsyrk_v2\0")?,
+                f_cublasSsymm_v2: sym(&lib, b"cublasSsymm_v2\0")?,
+                f_cublasDsymm_v2: sym(&lib, b"cublasDsymm_v2\0")?,
+                f_cublasStrsm_v2: sym(&lib, b"cublasStrsm_v2\0")?,
+                f_cublasDtrsm_v2: sym(&lib, b"cublasDtrsm_v2\0")?,
                 _lib: lib,
             })
         }
@@ -269,6 +309,296 @@ impl GenLib {
                 let algo = __c.i32();
                 let mut out = Vec::new();
                 let st = unsafe { (self.f_cublasGemmBatchedEx)(handle, transa as c_int, transb as c_int, m as c_int, n as c_int, k as c_int, &alpha_v, Aarray, Atype as c_int, lda as c_int, Barray, Btype as c_int, ldb as c_int, &beta_v, Carray, Ctype as c_int, ldc as c_int, batchCount as c_int, computeType as c_int, algo as c_int) };
+                (st, out)
+            }
+            15 => {
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let n = __c.i32();
+                let alpha_v = __c.f32();
+                let x = __c.u64() as *const f32;
+                let incx = __c.i32();
+                let y = __c.u64() as *mut f32;
+                let incy = __c.i32();
+                let mut out = Vec::new();
+                let st = unsafe { (self.f_cublasSaxpy_v2)(handle, n as c_int, &alpha_v, x, incx as c_int, y, incy as c_int) };
+                (st, out)
+            }
+            16 => {
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let n = __c.i32();
+                let alpha_v = __c.f64();
+                let x = __c.u64() as *const f64;
+                let incx = __c.i32();
+                let y = __c.u64() as *mut f64;
+                let incy = __c.i32();
+                let mut out = Vec::new();
+                let st = unsafe { (self.f_cublasDaxpy_v2)(handle, n as c_int, &alpha_v, x, incx as c_int, y, incy as c_int) };
+                (st, out)
+            }
+            17 => {
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let n = __c.i32();
+                let alpha_v = __c.f32();
+                let x = __c.u64() as *mut f32;
+                let incx = __c.i32();
+                let mut out = Vec::new();
+                let st = unsafe { (self.f_cublasSscal_v2)(handle, n as c_int, &alpha_v, x, incx as c_int) };
+                (st, out)
+            }
+            18 => {
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let n = __c.i32();
+                let alpha_v = __c.f64();
+                let x = __c.u64() as *mut f64;
+                let incx = __c.i32();
+                let mut out = Vec::new();
+                let st = unsafe { (self.f_cublasDscal_v2)(handle, n as c_int, &alpha_v, x, incx as c_int) };
+                (st, out)
+            }
+            19 => {
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let n = __c.i32();
+                let x = __c.u64() as *mut f32;
+                let incx = __c.i32();
+                let y = __c.u64() as *mut f32;
+                let incy = __c.i32();
+                let mut out = Vec::new();
+                let st = unsafe { (self.f_cublasScopy_v2)(handle, n as c_int, x, incx as c_int, y, incy as c_int) };
+                (st, out)
+            }
+            20 => {
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let n = __c.i32();
+                let x = __c.u64() as *mut f64;
+                let incx = __c.i32();
+                let y = __c.u64() as *mut f64;
+                let incy = __c.i32();
+                let mut out = Vec::new();
+                let st = unsafe { (self.f_cublasDcopy_v2)(handle, n as c_int, x, incx as c_int, y, incy as c_int) };
+                (st, out)
+            }
+            21 => {
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let n = __c.i32();
+                let x = __c.u64() as *mut f32;
+                let incx = __c.i32();
+                let y = __c.u64() as *mut f32;
+                let incy = __c.i32();
+                let mut out = Vec::new();
+                let st = unsafe { (self.f_cublasSswap_v2)(handle, n as c_int, x, incx as c_int, y, incy as c_int) };
+                (st, out)
+            }
+            22 => {
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let n = __c.i32();
+                let x = __c.u64() as *mut f64;
+                let incx = __c.i32();
+                let y = __c.u64() as *mut f64;
+                let incy = __c.i32();
+                let mut out = Vec::new();
+                let st = unsafe { (self.f_cublasDswap_v2)(handle, n as c_int, x, incx as c_int, y, incy as c_int) };
+                (st, out)
+            }
+            23 => {
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let trans = __c.i32();
+                let m = __c.i32();
+                let n = __c.i32();
+                let alpha_v = __c.f32();
+                let A = __c.u64() as *const f32;
+                let lda = __c.i32();
+                let x = __c.u64() as *const f32;
+                let incx = __c.i32();
+                let beta_v = __c.f32();
+                let y = __c.u64() as *mut f32;
+                let incy = __c.i32();
+                let mut out = Vec::new();
+                let st = unsafe { (self.f_cublasSgemv_v2)(handle, trans as c_int, m as c_int, n as c_int, &alpha_v, A, lda as c_int, x, incx as c_int, &beta_v, y, incy as c_int) };
+                (st, out)
+            }
+            24 => {
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let trans = __c.i32();
+                let m = __c.i32();
+                let n = __c.i32();
+                let alpha_v = __c.f64();
+                let A = __c.u64() as *const f64;
+                let lda = __c.i32();
+                let x = __c.u64() as *const f64;
+                let incx = __c.i32();
+                let beta_v = __c.f64();
+                let y = __c.u64() as *mut f64;
+                let incy = __c.i32();
+                let mut out = Vec::new();
+                let st = unsafe { (self.f_cublasDgemv_v2)(handle, trans as c_int, m as c_int, n as c_int, &alpha_v, A, lda as c_int, x, incx as c_int, &beta_v, y, incy as c_int) };
+                (st, out)
+            }
+            25 => {
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let m = __c.i32();
+                let n = __c.i32();
+                let alpha_v = __c.f32();
+                let x = __c.u64() as *const f32;
+                let incx = __c.i32();
+                let y = __c.u64() as *const f32;
+                let incy = __c.i32();
+                let A = __c.u64() as *mut f32;
+                let lda = __c.i32();
+                let mut out = Vec::new();
+                let st = unsafe { (self.f_cublasSger_v2)(handle, m as c_int, n as c_int, &alpha_v, x, incx as c_int, y, incy as c_int, A, lda as c_int) };
+                (st, out)
+            }
+            26 => {
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let m = __c.i32();
+                let n = __c.i32();
+                let alpha_v = __c.f64();
+                let x = __c.u64() as *const f64;
+                let incx = __c.i32();
+                let y = __c.u64() as *const f64;
+                let incy = __c.i32();
+                let A = __c.u64() as *mut f64;
+                let lda = __c.i32();
+                let mut out = Vec::new();
+                let st = unsafe { (self.f_cublasDger_v2)(handle, m as c_int, n as c_int, &alpha_v, x, incx as c_int, y, incy as c_int, A, lda as c_int) };
+                (st, out)
+            }
+            27 => {
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let transa = __c.i32();
+                let transb = __c.i32();
+                let m = __c.i32();
+                let n = __c.i32();
+                let alpha_v = __c.f32();
+                let A = __c.u64() as *const f32;
+                let lda = __c.i32();
+                let beta_v = __c.f32();
+                let B = __c.u64() as *const f32;
+                let ldb = __c.i32();
+                let C = __c.u64() as *mut f32;
+                let ldc = __c.i32();
+                let mut out = Vec::new();
+                let st = unsafe { (self.f_cublasSgeam)(handle, transa as c_int, transb as c_int, m as c_int, n as c_int, &alpha_v, A, lda as c_int, &beta_v, B, ldb as c_int, C, ldc as c_int) };
+                (st, out)
+            }
+            28 => {
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let transa = __c.i32();
+                let transb = __c.i32();
+                let m = __c.i32();
+                let n = __c.i32();
+                let alpha_v = __c.f64();
+                let A = __c.u64() as *const f64;
+                let lda = __c.i32();
+                let beta_v = __c.f64();
+                let B = __c.u64() as *const f64;
+                let ldb = __c.i32();
+                let C = __c.u64() as *mut f64;
+                let ldc = __c.i32();
+                let mut out = Vec::new();
+                let st = unsafe { (self.f_cublasDgeam)(handle, transa as c_int, transb as c_int, m as c_int, n as c_int, &alpha_v, A, lda as c_int, &beta_v, B, ldb as c_int, C, ldc as c_int) };
+                (st, out)
+            }
+            29 => {
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let uplo = __c.i32();
+                let trans = __c.i32();
+                let n = __c.i32();
+                let k = __c.i32();
+                let alpha_v = __c.f32();
+                let A = __c.u64() as *const f32;
+                let lda = __c.i32();
+                let beta_v = __c.f32();
+                let C = __c.u64() as *mut f32;
+                let ldc = __c.i32();
+                let mut out = Vec::new();
+                let st = unsafe { (self.f_cublasSsyrk_v2)(handle, uplo as c_int, trans as c_int, n as c_int, k as c_int, &alpha_v, A, lda as c_int, &beta_v, C, ldc as c_int) };
+                (st, out)
+            }
+            30 => {
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let uplo = __c.i32();
+                let trans = __c.i32();
+                let n = __c.i32();
+                let k = __c.i32();
+                let alpha_v = __c.f64();
+                let A = __c.u64() as *const f64;
+                let lda = __c.i32();
+                let beta_v = __c.f64();
+                let C = __c.u64() as *mut f64;
+                let ldc = __c.i32();
+                let mut out = Vec::new();
+                let st = unsafe { (self.f_cublasDsyrk_v2)(handle, uplo as c_int, trans as c_int, n as c_int, k as c_int, &alpha_v, A, lda as c_int, &beta_v, C, ldc as c_int) };
+                (st, out)
+            }
+            31 => {
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let side = __c.i32();
+                let uplo = __c.i32();
+                let m = __c.i32();
+                let n = __c.i32();
+                let alpha_v = __c.f32();
+                let A = __c.u64() as *const f32;
+                let lda = __c.i32();
+                let B = __c.u64() as *const f32;
+                let ldb = __c.i32();
+                let beta_v = __c.f32();
+                let C = __c.u64() as *mut f32;
+                let ldc = __c.i32();
+                let mut out = Vec::new();
+                let st = unsafe { (self.f_cublasSsymm_v2)(handle, side as c_int, uplo as c_int, m as c_int, n as c_int, &alpha_v, A, lda as c_int, B, ldb as c_int, &beta_v, C, ldc as c_int) };
+                (st, out)
+            }
+            32 => {
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let side = __c.i32();
+                let uplo = __c.i32();
+                let m = __c.i32();
+                let n = __c.i32();
+                let alpha_v = __c.f64();
+                let A = __c.u64() as *const f64;
+                let lda = __c.i32();
+                let B = __c.u64() as *const f64;
+                let ldb = __c.i32();
+                let beta_v = __c.f64();
+                let C = __c.u64() as *mut f64;
+                let ldc = __c.i32();
+                let mut out = Vec::new();
+                let st = unsafe { (self.f_cublasDsymm_v2)(handle, side as c_int, uplo as c_int, m as c_int, n as c_int, &alpha_v, A, lda as c_int, B, ldb as c_int, &beta_v, C, ldc as c_int) };
+                (st, out)
+            }
+            33 => {
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let side = __c.i32();
+                let uplo = __c.i32();
+                let trans = __c.i32();
+                let diag = __c.i32();
+                let m = __c.i32();
+                let n = __c.i32();
+                let alpha_v = __c.f32();
+                let A = __c.u64() as *const f32;
+                let lda = __c.i32();
+                let B = __c.u64() as *mut f32;
+                let ldb = __c.i32();
+                let mut out = Vec::new();
+                let st = unsafe { (self.f_cublasStrsm_v2)(handle, side as c_int, uplo as c_int, trans as c_int, diag as c_int, m as c_int, n as c_int, &alpha_v, A, lda as c_int, B, ldb as c_int) };
+                (st, out)
+            }
+            34 => {
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let side = __c.i32();
+                let uplo = __c.i32();
+                let trans = __c.i32();
+                let diag = __c.i32();
+                let m = __c.i32();
+                let n = __c.i32();
+                let alpha_v = __c.f64();
+                let A = __c.u64() as *const f64;
+                let lda = __c.i32();
+                let B = __c.u64() as *mut f64;
+                let ldb = __c.i32();
+                let mut out = Vec::new();
+                let st = unsafe { (self.f_cublasDtrsm_v2)(handle, side as c_int, uplo as c_int, trans as c_int, diag as c_int, m as c_int, n as c_int, &alpha_v, A, lda as c_int, B, ldb as c_int) };
                 (st, out)
             }
             _ => (super::super::CUDA_ERROR_NOT_FOUND, Vec::new()),

--- a/crates/smolvm-cuda/src/generated/cublas_host.rs
+++ b/crates/smolvm-cuda/src/generated/cublas_host.rs
@@ -14,6 +14,7 @@ pub struct GenLib { _lib: Library,
     f_cublasGetProperty: unsafe extern "C" fn(c_int, *mut c_int) -> c_int,
     f_cublasGemmEx: unsafe extern "C" fn(*mut c_void, c_int, c_int, c_int, c_int, c_int, *const f32, *const c_void, c_int, c_int, *const c_void, c_int, c_int, *const f32, *mut c_void, c_int, c_int, c_int, c_int) -> c_int,
     f_cublasGemmStridedBatchedEx: unsafe extern "C" fn(*mut c_void, c_int, c_int, c_int, c_int, c_int, *const f32, *const c_void, c_int, c_int, i64, *const c_void, c_int, c_int, i64, *const f32, *mut c_void, c_int, c_int, i64, c_int, c_int, c_int) -> c_int,
+    f_cublasGemmBatchedEx: unsafe extern "C" fn(*mut c_void, c_int, c_int, c_int, c_int, c_int, *const f32, *const c_void, c_int, c_int, *const c_void, c_int, c_int, *const f32, *mut c_void, c_int, c_int, c_int, c_int, c_int) -> c_int,
 }
 impl GenLib {
     pub fn load() -> Result<GenLib, String> {
@@ -34,6 +35,7 @@ impl GenLib {
                 f_cublasGetProperty: sym(&lib, b"cublasGetProperty\0")?,
                 f_cublasGemmEx: sym(&lib, b"cublasGemmEx\0")?,
                 f_cublasGemmStridedBatchedEx: sym(&lib, b"cublasGemmStridedBatchedEx\0")?,
+                f_cublasGemmBatchedEx: sym(&lib, b"cublasGemmBatchedEx\0")?,
                 _lib: lib,
             })
         }
@@ -242,6 +244,31 @@ impl GenLib {
                 let algo = __c.i32();
                 let mut out = Vec::new();
                 let st = unsafe { (self.f_cublasGemmStridedBatchedEx)(handle, transa as c_int, transb as c_int, m as c_int, n as c_int, k as c_int, &alpha_v, A, Atype as c_int, lda as c_int, strideA as i64, B, Btype as c_int, ldb as c_int, strideB as i64, &beta_v, C, Ctype as c_int, ldc as c_int, strideC as i64, batchCount as c_int, computeType as c_int, algo as c_int) };
+                (st, out)
+            }
+            14 => {
+                let handle = super::vh_resolve(__vh, __c.u64()) as *mut c_void;
+                let transa = __c.i32();
+                let transb = __c.i32();
+                let m = __c.i32();
+                let n = __c.i32();
+                let k = __c.i32();
+                let alpha_v = __c.f32();
+                let Aarray = __c.u64() as *const c_void;
+                let Atype = __c.i32();
+                let lda = __c.i32();
+                let Barray = __c.u64() as *const c_void;
+                let Btype = __c.i32();
+                let ldb = __c.i32();
+                let beta_v = __c.f32();
+                let Carray = __c.u64() as *mut c_void;
+                let Ctype = __c.i32();
+                let ldc = __c.i32();
+                let batchCount = __c.i32();
+                let computeType = __c.i32();
+                let algo = __c.i32();
+                let mut out = Vec::new();
+                let st = unsafe { (self.f_cublasGemmBatchedEx)(handle, transa as c_int, transb as c_int, m as c_int, n as c_int, k as c_int, &alpha_v, Aarray, Atype as c_int, lda as c_int, Barray, Btype as c_int, ldb as c_int, &beta_v, Carray, Ctype as c_int, ldc as c_int, batchCount as c_int, computeType as c_int, algo as c_int) };
                 (st, out)
             }
             _ => (super::super::CUDA_ERROR_NOT_FOUND, Vec::new()),

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -677,7 +677,21 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         Ok(sess.events.get(&event).copied().unwrap_or(event))
     }
     let r: CuResult<Response> = (|| match req {
-        Request::Init => b.init().map(|_| Response::Ok),
+        Request::Init { proto_hash } => {
+            if proto_hash != crate::PROTO_HASH {
+                eprintln!(
+                    "[smolvm-cuda] PROTOCOL MISMATCH: client wire hash {:016x} != server {:016x} \
+                     — the guest shim and host server were built from different source. \
+                     Rebuild and restage both. Refusing the connection to avoid corruption.",
+                    proto_hash,
+                    crate::PROTO_HASH
+                );
+                // CUDA_ERROR_NOT_SUPPORTED — surfaced at cuInit, loud and early.
+                Err(CUDA_ERROR_NOT_SUPPORTED)
+            } else {
+                b.init().map(|_| Response::Ok)
+            }
+        }
         Request::DeviceGetCount => b.device_get_count().map(Response::Count),
         Request::DeviceGetName { device } => b.device_get_name(device).map(Response::Name),
         Request::DeviceTotalMem { device } => b.device_total_mem(device).map(Response::Bytes),
@@ -1798,5 +1812,32 @@ mod tests {
         let (st, _) = dispatch(&mut sess, &mut b, Request::MemAlloc { bytes: mb / 4 });
         assert_eq!(st, 0);
         std::env::remove_var("SMOLVM_CUDA_VRAM_LIMIT_MB");
+    }
+    // The connect handshake rejects a client whose wire fingerprint differs
+    // (stale shim/server), so protocol skew fails loudly instead of decoding
+    // the wrong bytes and corrupting silently.
+    #[test]
+    fn init_rejects_proto_mismatch() {
+        let mut sess = Session::default();
+        let mut b = CpuBackend::default();
+        let (st, _) = dispatch(
+            &mut sess,
+            &mut b,
+            Request::Init {
+                proto_hash: crate::PROTO_HASH,
+            },
+        );
+        assert_eq!(st, 0, "matching proto hash must connect");
+        let (st, _) = dispatch(
+            &mut sess,
+            &mut b,
+            Request::Init {
+                proto_hash: crate::PROTO_HASH ^ 0x1,
+            },
+        );
+        assert_eq!(
+            st, CUDA_ERROR_NOT_SUPPORTED,
+            "mismatched proto hash must be rejected"
+        );
     }
 }

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -20,6 +20,8 @@ pub type CuResult<T> = Result<T, i32>;
 
 /// `CUDA_ERROR_INVALID_HANDLE`.
 pub const CUDA_ERROR_INVALID_HANDLE: i32 = 400;
+/// Bit-63 marks a guest-minted virtual handle (see `raw_graph`, cublas vh).
+const VHANDLE_TAG: u64 = 1 << 63;
 /// `CUDA_ERROR_NOT_FOUND`.
 pub const CUDA_ERROR_NOT_FOUND: i32 = 500;
 pub const CUDA_ERROR_NOT_SUPPORTED: i32 = 801;
@@ -263,6 +265,10 @@ struct Session {
     streams: HashMap<u64, u64>,
     events: HashMap<u64, u64>,
     cublas_handles: HashMap<u64, u64>,
+    /// Guest-minted virtual graph/exec handles → real (bit-63 tagged). Lets
+    /// EndCapture / GraphInstantiate be fire-and-forget: the guest invents the
+    /// handle, the host maps it when it materializes the real one.
+    graph_vhandles: HashMap<u64, u64>,
     /// Live resources this connection created, reclaimed when it ends —
     /// a guest that dies mid-run must not leak GPU memory (device
     /// allocations are the multi-GB hazard; modules/streams/events are
@@ -303,6 +309,16 @@ fn reclaim_session(sess: &mut Session, b: &mut dyn Backend) {
     }
     for e in std::mem::take(&mut sess.owned_events) {
         let _ = b.event_destroy(e);
+    }
+    for (vh, real) in std::mem::take(&mut sess.graph_vhandles) {
+        // Exec handles (used by GraphLaunch) vs graphs — try exec destroy
+        // first, then graph destroy; the wrong one errors harmlessly.
+        let _ = if vh != 0 {
+            b.graph_exec_destroy(real)
+                .or_else(|_| b.graph_destroy(real))
+        } else {
+            Ok(())
+        };
     }
     for _ in 0..std::mem::take(&mut sess.primary_retains) {
         let _ = b.primary_ctx_release(0);
@@ -676,6 +692,14 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             Ok(sess.streams.get(&stream).copied().unwrap_or(stream))
         }
     }
+    fn raw_graph(sess: &Session, h: u64) -> u64 {
+        // Virtual graph/exec handle → real; untagged values pass through.
+        if h & VHANDLE_TAG != 0 {
+            sess.graph_vhandles.get(&h).copied().unwrap_or(0)
+        } else {
+            h
+        }
+    }
     fn raw_event(sess: &Session, event: u64) -> CuResult<u64> {
         // Same raw-on-the-wire convention as streams.
         Ok(sess.events.get(&event).copied().unwrap_or(event))
@@ -841,24 +865,42 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         Request::ThreadExchangeCaptureMode { mode } => {
             b.thread_exchange_capture_mode(mode).map(Response::Count)
         }
-        Request::StreamEndCapture { stream } => {
+        Request::StreamEndCapture { stream, graph_vh } => {
             let raw = raw_stream(sess, stream)?;
-            b.stream_end_capture(raw).map(Response::Handle)
+            let g = b.stream_end_capture(raw)?;
+            if graph_vh & VHANDLE_TAG != 0 {
+                sess.graph_vhandles.insert(graph_vh, g);
+            }
+            Ok(Response::Handle(g))
         }
         Request::StreamCaptureInfo { stream } => {
             let raw = raw_stream(sess, stream)?;
             b.stream_capture_info(raw)
                 .map(|(st, id)| Response::Pair(st, id))
         }
-        Request::GraphInstantiate { graph } => b.graph_instantiate(graph).map(Response::Handle),
+        Request::GraphInstantiate { graph, exec_vh } => {
+            let real_graph = raw_graph(sess, graph);
+            let e = b.graph_instantiate(real_graph)?;
+            if exec_vh & VHANDLE_TAG != 0 {
+                sess.graph_vhandles.insert(exec_vh, e);
+            }
+            Ok(Response::Handle(e))
+        }
         Request::GraphLaunch { graph_exec, stream } => {
             let raw = raw_stream(sess, stream)?;
-            b.graph_launch(graph_exec, raw).map(|_| Response::Ok)
+            b.graph_launch(raw_graph(sess, graph_exec), raw)
+                .map(|_| Response::Ok)
         }
         Request::GraphExecDestroy { graph_exec } => {
-            b.graph_exec_destroy(graph_exec).map(|_| Response::Ok)
+            let real = raw_graph(sess, graph_exec);
+            sess.graph_vhandles.remove(&graph_exec);
+            b.graph_exec_destroy(real).map(|_| Response::Ok)
         }
-        Request::GraphDestroy { graph } => b.graph_destroy(graph).map(|_| Response::Ok),
+        Request::GraphDestroy { graph } => {
+            let real = raw_graph(sess, graph);
+            sess.graph_vhandles.remove(&graph);
+            b.graph_destroy(real).map(|_| Response::Ok)
+        }
         Request::GraphGetNodes { graph } => b.graph_get_node_count(graph).map(Response::Bytes),
         Request::MemsetD8Async {
             dptr,

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -46,6 +46,10 @@ pub trait Backend: Send {
     fn func_get_param_info(&mut self, function: u64) -> CuResult<Vec<u32>>;
     /// Set a `CUfunction_attribute` (e.g. raise max dynamic shared memory).
     fn func_set_attribute(&mut self, function: u64, attrib: i32, value: i32) -> CuResult<()>;
+    /// Read a `CUfunction_attribute`; default 0 (CPU backend has no kernels).
+    fn func_get_attribute(&mut self, _function: u64, _attrib: i32) -> CuResult<i32> {
+        Ok(0)
+    }
     fn mem_alloc(&mut self, bytes: u64) -> CuResult<u64>;
     fn mem_free(&mut self, dptr: u64) -> CuResult<()>;
     /// Copy with stream ordering: prior work on `stream` (0 = legacy default)
@@ -763,6 +767,10 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             let raw_fn = raw(&sess.functions, function)?;
             b.func_set_attribute(raw_fn, attrib, value)
                 .map(|_| Response::Ok)
+        }
+        Request::FuncGetAttribute { function, attrib } => {
+            let raw_fn = raw(&sess.functions, function)?;
+            b.func_get_attribute(raw_fn, attrib).map(Response::Count)
         }
         Request::MemAlloc { bytes } => {
             // Per-connection VRAM quota (SMOLVM_CUDA_VRAM_LIMIT_MB on the

--- a/crates/smolvm-cuda/src/host/gpu.rs
+++ b/crates/smolvm-cuda/src/host/gpu.rs
@@ -47,6 +47,7 @@ pub struct GpuBackend {
     func_get_param_info:
         Option<unsafe extern "C" fn(*mut c_void, usize, *mut usize, *mut usize) -> CuResultCode>,
     func_set_attribute: unsafe extern "C" fn(*mut c_void, c_int, c_int) -> CuResultCode,
+    func_get_attribute: unsafe extern "C" fn(*mut c_int, c_int, *mut c_void) -> CuResultCode,
     mem_alloc: unsafe extern "C" fn(*mut u64, usize) -> CuResultCode,
     mem_free: unsafe extern "C" fn(u64) -> CuResultCode,
     memcpy_htod: unsafe extern "C" fn(u64, *const c_void, usize) -> CuResultCode,
@@ -343,6 +344,7 @@ impl GpuBackend {
                 module_unload: sym(&lib, b"cuModuleUnload\0")?,
                 func_get_param_info: sym(&lib, b"cuFuncGetParamInfo\0").ok(),
                 func_set_attribute: sym(&lib, b"cuFuncSetAttribute\0")?,
+                func_get_attribute: sym(&lib, b"cuFuncGetAttribute\0")?,
                 mem_alloc: sym(&lib, b"cuMemAlloc_v2\0")?,
                 mem_free: sym(&lib, b"cuMemFree_v2\0")?,
                 memcpy_htod: sym(&lib, b"cuMemcpyHtoD_v2\0")?,
@@ -545,6 +547,17 @@ impl Backend for GpuBackend {
                 value,
             ))
         }
+    }
+    fn func_get_attribute(&mut self, function: u64, attrib: i32) -> CuResult<i32> {
+        let mut v = 0;
+        unsafe {
+            chk((self.func_get_attribute)(
+                &mut v,
+                attrib,
+                function as *mut c_void,
+            ))?
+        };
+        Ok(v)
     }
     fn mem_alloc(&mut self, bytes: u64) -> CuResult<u64> {
         let mut dptr: u64 = 0;

--- a/crates/smolvm-cuda/src/lib.rs
+++ b/crates/smolvm-cuda/src/lib.rs
@@ -15,6 +15,26 @@ pub mod proto;
 /// Shared-memory command/completion rings (low-latency in-VM transport).
 pub mod ring;
 
+/// Fingerprint of the wire-defining source (see `build.rs`). The client sends
+/// it in the `Init` handshake; the host rejects a mismatch, turning a stale
+/// shim/server pairing into a loud error instead of silent data corruption.
+pub const PROTO_HASH: u64 = {
+    // env! gives the hex string from build.rs; parse it at compile time.
+    let s = env!("SMOLVM_PROTO_HASH").as_bytes();
+    let mut v = 0u64;
+    let mut i = 0;
+    while i < s.len() {
+        let d = match s[i] {
+            b'0'..=b'9' => s[i] - b'0',
+            b'a'..=b'f' => s[i] - b'a' + 10,
+            _ => 0,
+        };
+        v = v * 16 + d as u64;
+        i += 1;
+    }
+    v
+};
+
 /// Shared-memory bulk-data channel (zero-copy memcpy). Linux-only.
 #[cfg(target_os = "linux")]
 pub mod shm;

--- a/crates/smolvm-cuda/src/proto.rs
+++ b/crates/smolvm-cuda/src/proto.rs
@@ -201,7 +201,11 @@ impl Op {
 /// A decoded request. Handles are opaque ids; device pointers are real values.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Request {
-    Init,
+    /// Connect handshake. `proto_hash` is the client's wire fingerprint
+    /// (`crate::PROTO_HASH`); the host rejects a mismatch (stale binary).
+    Init {
+        proto_hash: u64,
+    },
     DeviceGetCount,
     DeviceGetName {
         device: i32,
@@ -668,7 +672,10 @@ pub fn read_msg<R: Read>(r: &mut R) -> io::Result<Option<Vec<u8>>> {
 pub fn encode_request(req: &Request) -> Vec<u8> {
     let mut b = Vec::new();
     match req {
-        Request::Init => w_u8(&mut b, Op::Init as u8),
+        Request::Init { proto_hash } => {
+            w_u8(&mut b, Op::Init as u8);
+            w_u64(&mut b, *proto_hash);
+        }
         Request::DeviceGetCount => w_u8(&mut b, Op::DeviceGetCount as u8),
         Request::DeviceGetName { device } => {
             w_u8(&mut b, Op::DeviceGetName as u8);
@@ -1114,7 +1121,9 @@ pub fn decode_request(payload: &[u8]) -> io::Result<Request> {
     let mut c = Cur::new(payload);
     let op = Op::from_u8(c.u8()?).ok_or_else(bad)?;
     Ok(match op {
-        Op::Init => Request::Init,
+        Op::Init => Request::Init {
+            proto_hash: c.u64()?,
+        },
         Op::DeviceGetCount => Request::DeviceGetCount,
         Op::DeviceGetName => Request::DeviceGetName { device: c.i32()? },
         Op::DeviceTotalMem => Request::DeviceTotalMem { device: c.i32()? },
@@ -1477,7 +1486,9 @@ mod tests {
 
     #[test]
     fn request_roundtrips() {
-        roundtrip(Request::Init);
+        roundtrip(Request::Init {
+            proto_hash: 0xdeadbeef,
+        });
         roundtrip(Request::DeviceGetCount);
         roundtrip(Request::DeviceGetName { device: 3 });
         roundtrip(Request::DeviceTotalMem { device: 0 });

--- a/crates/smolvm-cuda/src/proto.rs
+++ b/crates/smolvm-cuda/src/proto.rs
@@ -47,6 +47,7 @@ pub enum Op {
     ModuleUnload = 0x22,
     FuncGetParamInfo = 0x23,
     FuncSetAttribute = 0x24,
+    FuncGetAttribute = 0x25,
     MemAlloc = 0x30,
     MemFree = 0x31,
     MemcpyHtoD = 0x32,
@@ -142,6 +143,7 @@ impl Op {
             0x22 => Op::ModuleUnload,
             0x23 => Op::FuncGetParamInfo,
             0x24 => Op::FuncSetAttribute,
+            0x25 => Op::FuncGetAttribute,
             0x30 => Op::MemAlloc,
             0x31 => Op::MemFree,
             0x32 => Op::MemcpyHtoD,
@@ -256,6 +258,14 @@ pub enum Request {
         function: u64,
         attrib: i32,
         value: i32,
+    },
+    /// Read a `CUfunction_attribute` (max-threads, num-regs, shared/local
+    /// bytes, ptx/binary version) — forwarded so `cudaFuncGetAttributes`
+    /// returns real values instead of fakes (num_regs=0 divides by zero in
+    /// occupancy math).
+    FuncGetAttribute {
+        function: u64,
+        attrib: i32,
     },
     MemAlloc {
         bytes: u64,
@@ -728,6 +738,11 @@ pub fn encode_request(req: &Request) -> Vec<u8> {
             w_u8(&mut b, Op::FuncGetParamInfo as u8);
             w_u64(&mut b, *function);
         }
+        Request::FuncGetAttribute { function, attrib } => {
+            w_u8(&mut b, Op::FuncGetAttribute as u8);
+            w_u64(&mut b, *function);
+            w_i32(&mut b, *attrib);
+        }
         Request::FuncSetAttribute {
             function,
             attrib,
@@ -1149,6 +1164,10 @@ pub fn decode_request(payload: &[u8]) -> io::Result<Request> {
             attrib: c.i32()?,
             value: c.i32()?,
         },
+        Op::FuncGetAttribute => Request::FuncGetAttribute {
+            function: c.u64()?,
+            attrib: c.i32()?,
+        },
         Op::MemAlloc => Request::MemAlloc { bytes: c.u64()? },
         Op::MemFree => Request::MemFree { dptr: c.u64()? },
         Op::MemcpyHtoD => Request::MemcpyHtoD {
@@ -1412,7 +1431,8 @@ pub fn decode_response(op: Op, payload: &[u8]) -> io::Result<(i32, Response)> {
         | Op::DeviceGetAttribute
         | Op::ThreadExchangeCaptureMode
         | Op::StreamQuery
-        | Op::EventQuery => Response::Count(c.i32()?),
+        | Op::EventQuery
+        | Op::FuncGetAttribute => Response::Count(c.i32()?),
         Op::DeviceGetName => Response::Name(c.string()?),
         Op::DeviceTotalMem => Response::Bytes(c.u64()?),
         Op::CtxCreate | Op::PrimaryCtxRetain => Response::Handle(c.u64()?),

--- a/crates/smolvm-cuda/src/proto.rs
+++ b/crates/smolvm-cuda/src/proto.rs
@@ -318,9 +318,15 @@ pub enum Request {
     },
     StreamEndCapture {
         stream: u64,
+        /// Guest-minted virtual graph handle (bit-63 tagged). The host maps it
+        /// to the real captured graph so EndCapture can be fire-and-forget.
+        graph_vh: u64,
     },
     GraphInstantiate {
         graph: u64,
+        /// Guest-minted virtual exec handle; host maps it to the real
+        /// instantiated exec so GraphInstantiate can be fire-and-forget.
+        exec_vh: u64,
     },
     GraphLaunch {
         graph_exec: u64,
@@ -819,13 +825,15 @@ pub fn encode_request(req: &Request) -> Vec<u8> {
             w_u64(&mut b, *stream);
             w_i32(&mut b, *mode);
         }
-        Request::StreamEndCapture { stream } => {
+        Request::StreamEndCapture { stream, graph_vh } => {
             w_u8(&mut b, Op::StreamEndCapture as u8);
             w_u64(&mut b, *stream);
+            w_u64(&mut b, *graph_vh);
         }
-        Request::GraphInstantiate { graph } => {
+        Request::GraphInstantiate { graph, exec_vh } => {
             w_u8(&mut b, Op::GraphInstantiate as u8);
             w_u64(&mut b, *graph);
+            w_u64(&mut b, *exec_vh);
         }
         Request::GraphLaunch { graph_exec, stream } => {
             w_u8(&mut b, Op::GraphLaunch as u8);
@@ -1216,8 +1224,14 @@ pub fn decode_request(payload: &[u8]) -> io::Result<Request> {
             stream: c.u64()?,
             mode: c.i32()?,
         },
-        Op::StreamEndCapture => Request::StreamEndCapture { stream: c.u64()? },
-        Op::GraphInstantiate => Request::GraphInstantiate { graph: c.u64()? },
+        Op::StreamEndCapture => Request::StreamEndCapture {
+            stream: c.u64()?,
+            graph_vh: c.u64()?,
+        },
+        Op::GraphInstantiate => Request::GraphInstantiate {
+            graph: c.u64()?,
+            exec_vh: c.u64()?,
+        },
         Op::GraphLaunch => Request::GraphLaunch {
             graph_exec: c.u64()?,
             stream: c.u64()?,

--- a/crates/smolvm-cudart-shim/src/cublas_stubs.rs
+++ b/crates/smolvm-cudart-shim/src/cublas_stubs.rs
@@ -64,10 +64,6 @@ pub extern "C" fn cublasDgelsBatched() -> c_int {
     stub("cublasDgelsBatched")
 }
 #[no_mangle]
-pub extern "C" fn cublasDgemv_v2() -> c_int {
-    stub("cublasDgemv_v2")
-}
-#[no_mangle]
 pub extern "C" fn cublasDgeqrfBatched() -> c_int {
     stub("cublasDgeqrfBatched")
 }
@@ -86,10 +82,6 @@ pub extern "C" fn cublasDotEx() -> c_int {
 #[no_mangle]
 pub extern "C" fn cublasDtrsmBatched() -> c_int {
     stub("cublasDtrsmBatched")
-}
-#[no_mangle]
-pub extern "C" fn cublasDtrsm_v2() -> c_int {
-    stub("cublasDtrsm_v2")
 }
 #[no_mangle]
 pub extern "C" fn cublasGetPointerMode_v2() -> c_int {
@@ -112,10 +104,6 @@ pub extern "C" fn cublasSgemmEx() -> c_int {
     stub("cublasSgemmEx")
 }
 #[no_mangle]
-pub extern "C" fn cublasSgemv_v2() -> c_int {
-    stub("cublasSgemv_v2")
-}
-#[no_mangle]
 pub extern "C" fn cublasSgeqrfBatched() -> c_int {
     stub("cublasSgeqrfBatched")
 }
@@ -130,10 +118,6 @@ pub extern "C" fn cublasSgetrsBatched() -> c_int {
 #[no_mangle]
 pub extern "C" fn cublasStrsmBatched() -> c_int {
     stub("cublasStrsmBatched")
-}
-#[no_mangle]
-pub extern "C" fn cublasStrsm_v2() -> c_int {
-    stub("cublasStrsm_v2")
 }
 #[no_mangle]
 pub extern "C" fn cublasZdotc_v2() -> c_int {
@@ -647,20 +631,8 @@ pub extern "C" fn cublasDasum_v2() -> c_int {
     stub("cublasDasum_v2")
 }
 #[no_mangle]
-pub extern "C" fn cublasDaxpy_v2() -> c_int {
-    stub("cublasDaxpy_v2")
-}
-#[no_mangle]
-pub extern "C" fn cublasDcopy_v2() -> c_int {
-    stub("cublasDcopy_v2")
-}
-#[no_mangle]
 pub extern "C" fn cublasDgemmBatched() -> c_int {
     stub("cublasDgemmBatched")
-}
-#[no_mangle]
-pub extern "C" fn cublasDger_v2() -> c_int {
-    stub("cublasDger_v2")
 }
 #[no_mangle]
 pub extern "C" fn cublasDnrm2_v2() -> c_int {
@@ -683,18 +655,6 @@ pub extern "C" fn cublasDrot_v2() -> c_int {
     stub("cublasDrot_v2")
 }
 #[no_mangle]
-pub extern "C" fn cublasDscal_v2() -> c_int {
-    stub("cublasDscal_v2")
-}
-#[no_mangle]
-pub extern "C" fn cublasDswap_v2() -> c_int {
-    stub("cublasDswap_v2")
-}
-#[no_mangle]
-pub extern "C" fn cublasDsymm_v2() -> c_int {
-    stub("cublasDsymm_v2")
-}
-#[no_mangle]
 pub extern "C" fn cublasDsymv_v2() -> c_int {
     stub("cublasDsymv_v2")
 }
@@ -705,10 +665,6 @@ pub extern "C" fn cublasDsyr2k_v2() -> c_int {
 #[no_mangle]
 pub extern "C" fn cublasDsyr2_v2() -> c_int {
     stub("cublasDsyr2_v2")
-}
-#[no_mangle]
-pub extern "C" fn cublasDsyrk_v2() -> c_int {
-    stub("cublasDsyrk_v2")
 }
 #[no_mangle]
 pub extern "C" fn cublasDsyr_v2() -> c_int {
@@ -779,20 +735,12 @@ pub extern "C" fn cublasSasum_v2() -> c_int {
     stub("cublasSasum_v2")
 }
 #[no_mangle]
-pub extern "C" fn cublasSaxpy_v2() -> c_int {
-    stub("cublasSaxpy_v2")
-}
-#[no_mangle]
 pub extern "C" fn cublasScasum_v2() -> c_int {
     stub("cublasScasum_v2")
 }
 #[no_mangle]
 pub extern "C" fn cublasScnrm2_v2() -> c_int {
     stub("cublasScnrm2_v2")
-}
-#[no_mangle]
-pub extern "C" fn cublasScopy_v2() -> c_int {
-    stub("cublasScopy_v2")
 }
 #[no_mangle]
 pub extern "C" fn cublasSetMatrixAsync() -> c_int {
@@ -805,10 +753,6 @@ pub extern "C" fn cublasSetVectorAsync() -> c_int {
 #[no_mangle]
 pub extern "C" fn cublasSgemmBatched() -> c_int {
     stub("cublasSgemmBatched")
-}
-#[no_mangle]
-pub extern "C" fn cublasSger_v2() -> c_int {
-    stub("cublasSger_v2")
 }
 #[no_mangle]
 pub extern "C" fn cublasSnrm2_v2() -> c_int {
@@ -831,18 +775,6 @@ pub extern "C" fn cublasSrot_v2() -> c_int {
     stub("cublasSrot_v2")
 }
 #[no_mangle]
-pub extern "C" fn cublasSscal_v2() -> c_int {
-    stub("cublasSscal_v2")
-}
-#[no_mangle]
-pub extern "C" fn cublasSswap_v2() -> c_int {
-    stub("cublasSswap_v2")
-}
-#[no_mangle]
-pub extern "C" fn cublasSsymm_v2() -> c_int {
-    stub("cublasSsymm_v2")
-}
-#[no_mangle]
 pub extern "C" fn cublasSsymv_v2() -> c_int {
     stub("cublasSsymv_v2")
 }
@@ -853,10 +785,6 @@ pub extern "C" fn cublasSsyr2k_v2() -> c_int {
 #[no_mangle]
 pub extern "C" fn cublasSsyr2_v2() -> c_int {
     stub("cublasSsyr2_v2")
-}
-#[no_mangle]
-pub extern "C" fn cublasSsyrk_v2() -> c_int {
-    stub("cublasSsyrk_v2")
 }
 #[no_mangle]
 pub extern "C" fn cublasSsyr_v2() -> c_int {

--- a/crates/smolvm-cudart-shim/src/cublas_stubs.rs
+++ b/crates/smolvm-cudart-shim/src/cublas_stubs.rs
@@ -534,19 +534,6 @@ pub extern "C" fn cudaStreamGetPriority(_s: *mut c_void, priority: *mut c_int) -
     }
     0
 }
-/// `cudaLaunchHostFunc` — run a host callback in stream order. Our serving thread
-/// is in-order, so all prior work is done: invoke it immediately.
-#[no_mangle]
-pub extern "C" fn cudaLaunchHostFunc(
-    _s: *mut c_void,
-    func: Option<unsafe extern "C" fn(*mut c_void)>,
-    user_data: *mut c_void,
-) -> c_int {
-    if let Some(f) = func {
-        unsafe { f(user_data) }
-    }
-    0
-}
 #[no_mangle]
 pub extern "C" fn cudaMemcpy2DAsync() -> c_int {
     rt_stub("cudaMemcpy2DAsync")

--- a/crates/smolvm-cudart-shim/src/generated/cublas_guest.rs
+++ b/crates/smolvm-cudart-shim/src/generated/cublas_guest.rs
@@ -270,3 +270,337 @@ pub extern "C" fn cublasGemmBatchedEx(handle: *mut c_void, transa: c_int, transb
     // No output params: fire-and-forget (failures surface as sticky async errors).
     match with_client(|c| c.lib_call_deferred(LIB_ID, 14, a)) { Ok(()) => 0, Err(_) => 1 }
 }
+#[no_mangle]
+pub extern "C" fn cublasSaxpy_v2(handle: *mut c_void, n: c_int, alpha: *const f32, x: *const f32, incx: c_int, y: *mut f32, incy: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f32).to_le_bytes());
+    a.extend_from_slice(&(x as u64).to_le_bytes());
+    a.extend_from_slice(&(incx as i32).to_le_bytes());
+    a.extend_from_slice(&(y as u64).to_le_bytes());
+    a.extend_from_slice(&(incy as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 15, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasDaxpy_v2(handle: *mut c_void, n: c_int, alpha: *const f64, x: *const f64, incx: c_int, y: *mut f64, incy: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f64).to_le_bytes());
+    a.extend_from_slice(&(x as u64).to_le_bytes());
+    a.extend_from_slice(&(incx as i32).to_le_bytes());
+    a.extend_from_slice(&(y as u64).to_le_bytes());
+    a.extend_from_slice(&(incy as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 16, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasSscal_v2(handle: *mut c_void, n: c_int, alpha: *const f32, x: *mut f32, incx: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f32).to_le_bytes());
+    a.extend_from_slice(&(x as u64).to_le_bytes());
+    a.extend_from_slice(&(incx as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 17, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasDscal_v2(handle: *mut c_void, n: c_int, alpha: *const f64, x: *mut f64, incx: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f64).to_le_bytes());
+    a.extend_from_slice(&(x as u64).to_le_bytes());
+    a.extend_from_slice(&(incx as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 18, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasScopy_v2(handle: *mut c_void, n: c_int, x: *mut f32, incx: c_int, y: *mut f32, incy: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    a.extend_from_slice(&(x as u64).to_le_bytes());
+    a.extend_from_slice(&(incx as i32).to_le_bytes());
+    a.extend_from_slice(&(y as u64).to_le_bytes());
+    a.extend_from_slice(&(incy as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 19, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasDcopy_v2(handle: *mut c_void, n: c_int, x: *mut f64, incx: c_int, y: *mut f64, incy: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    a.extend_from_slice(&(x as u64).to_le_bytes());
+    a.extend_from_slice(&(incx as i32).to_le_bytes());
+    a.extend_from_slice(&(y as u64).to_le_bytes());
+    a.extend_from_slice(&(incy as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 20, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasSswap_v2(handle: *mut c_void, n: c_int, x: *mut f32, incx: c_int, y: *mut f32, incy: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    a.extend_from_slice(&(x as u64).to_le_bytes());
+    a.extend_from_slice(&(incx as i32).to_le_bytes());
+    a.extend_from_slice(&(y as u64).to_le_bytes());
+    a.extend_from_slice(&(incy as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 21, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasDswap_v2(handle: *mut c_void, n: c_int, x: *mut f64, incx: c_int, y: *mut f64, incy: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    a.extend_from_slice(&(x as u64).to_le_bytes());
+    a.extend_from_slice(&(incx as i32).to_le_bytes());
+    a.extend_from_slice(&(y as u64).to_le_bytes());
+    a.extend_from_slice(&(incy as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 22, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasSgemv_v2(handle: *mut c_void, trans: c_int, m: c_int, n: c_int, alpha: *const f32, A: *const f32, lda: c_int, x: *const f32, incx: c_int, beta: *const f32, y: *mut f32, incy: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(trans as i32).to_le_bytes());
+    a.extend_from_slice(&(m as i32).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f32).to_le_bytes());
+    a.extend_from_slice(&(A as u64).to_le_bytes());
+    a.extend_from_slice(&(lda as i32).to_le_bytes());
+    a.extend_from_slice(&(x as u64).to_le_bytes());
+    a.extend_from_slice(&(incx as i32).to_le_bytes());
+    if beta.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *beta } as f32).to_le_bytes());
+    a.extend_from_slice(&(y as u64).to_le_bytes());
+    a.extend_from_slice(&(incy as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 23, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasDgemv_v2(handle: *mut c_void, trans: c_int, m: c_int, n: c_int, alpha: *const f64, A: *const f64, lda: c_int, x: *const f64, incx: c_int, beta: *const f64, y: *mut f64, incy: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(trans as i32).to_le_bytes());
+    a.extend_from_slice(&(m as i32).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f64).to_le_bytes());
+    a.extend_from_slice(&(A as u64).to_le_bytes());
+    a.extend_from_slice(&(lda as i32).to_le_bytes());
+    a.extend_from_slice(&(x as u64).to_le_bytes());
+    a.extend_from_slice(&(incx as i32).to_le_bytes());
+    if beta.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *beta } as f64).to_le_bytes());
+    a.extend_from_slice(&(y as u64).to_le_bytes());
+    a.extend_from_slice(&(incy as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 24, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasSger_v2(handle: *mut c_void, m: c_int, n: c_int, alpha: *const f32, x: *const f32, incx: c_int, y: *const f32, incy: c_int, A: *mut f32, lda: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(m as i32).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f32).to_le_bytes());
+    a.extend_from_slice(&(x as u64).to_le_bytes());
+    a.extend_from_slice(&(incx as i32).to_le_bytes());
+    a.extend_from_slice(&(y as u64).to_le_bytes());
+    a.extend_from_slice(&(incy as i32).to_le_bytes());
+    a.extend_from_slice(&(A as u64).to_le_bytes());
+    a.extend_from_slice(&(lda as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 25, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasDger_v2(handle: *mut c_void, m: c_int, n: c_int, alpha: *const f64, x: *const f64, incx: c_int, y: *const f64, incy: c_int, A: *mut f64, lda: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(m as i32).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f64).to_le_bytes());
+    a.extend_from_slice(&(x as u64).to_le_bytes());
+    a.extend_from_slice(&(incx as i32).to_le_bytes());
+    a.extend_from_slice(&(y as u64).to_le_bytes());
+    a.extend_from_slice(&(incy as i32).to_le_bytes());
+    a.extend_from_slice(&(A as u64).to_le_bytes());
+    a.extend_from_slice(&(lda as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 26, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasSgeam(handle: *mut c_void, transa: c_int, transb: c_int, m: c_int, n: c_int, alpha: *const f32, A: *const f32, lda: c_int, beta: *const f32, B: *const f32, ldb: c_int, C: *mut f32, ldc: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(transa as i32).to_le_bytes());
+    a.extend_from_slice(&(transb as i32).to_le_bytes());
+    a.extend_from_slice(&(m as i32).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f32).to_le_bytes());
+    a.extend_from_slice(&(A as u64).to_le_bytes());
+    a.extend_from_slice(&(lda as i32).to_le_bytes());
+    if beta.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *beta } as f32).to_le_bytes());
+    a.extend_from_slice(&(B as u64).to_le_bytes());
+    a.extend_from_slice(&(ldb as i32).to_le_bytes());
+    a.extend_from_slice(&(C as u64).to_le_bytes());
+    a.extend_from_slice(&(ldc as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 27, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasDgeam(handle: *mut c_void, transa: c_int, transb: c_int, m: c_int, n: c_int, alpha: *const f64, A: *const f64, lda: c_int, beta: *const f64, B: *const f64, ldb: c_int, C: *mut f64, ldc: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(transa as i32).to_le_bytes());
+    a.extend_from_slice(&(transb as i32).to_le_bytes());
+    a.extend_from_slice(&(m as i32).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f64).to_le_bytes());
+    a.extend_from_slice(&(A as u64).to_le_bytes());
+    a.extend_from_slice(&(lda as i32).to_le_bytes());
+    if beta.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *beta } as f64).to_le_bytes());
+    a.extend_from_slice(&(B as u64).to_le_bytes());
+    a.extend_from_slice(&(ldb as i32).to_le_bytes());
+    a.extend_from_slice(&(C as u64).to_le_bytes());
+    a.extend_from_slice(&(ldc as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 28, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasSsyrk_v2(handle: *mut c_void, uplo: c_int, trans: c_int, n: c_int, k: c_int, alpha: *const f32, A: *const f32, lda: c_int, beta: *const f32, C: *mut f32, ldc: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(uplo as i32).to_le_bytes());
+    a.extend_from_slice(&(trans as i32).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    a.extend_from_slice(&(k as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f32).to_le_bytes());
+    a.extend_from_slice(&(A as u64).to_le_bytes());
+    a.extend_from_slice(&(lda as i32).to_le_bytes());
+    if beta.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *beta } as f32).to_le_bytes());
+    a.extend_from_slice(&(C as u64).to_le_bytes());
+    a.extend_from_slice(&(ldc as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 29, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasDsyrk_v2(handle: *mut c_void, uplo: c_int, trans: c_int, n: c_int, k: c_int, alpha: *const f64, A: *const f64, lda: c_int, beta: *const f64, C: *mut f64, ldc: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(uplo as i32).to_le_bytes());
+    a.extend_from_slice(&(trans as i32).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    a.extend_from_slice(&(k as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f64).to_le_bytes());
+    a.extend_from_slice(&(A as u64).to_le_bytes());
+    a.extend_from_slice(&(lda as i32).to_le_bytes());
+    if beta.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *beta } as f64).to_le_bytes());
+    a.extend_from_slice(&(C as u64).to_le_bytes());
+    a.extend_from_slice(&(ldc as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 30, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasSsymm_v2(handle: *mut c_void, side: c_int, uplo: c_int, m: c_int, n: c_int, alpha: *const f32, A: *const f32, lda: c_int, B: *const f32, ldb: c_int, beta: *const f32, C: *mut f32, ldc: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(side as i32).to_le_bytes());
+    a.extend_from_slice(&(uplo as i32).to_le_bytes());
+    a.extend_from_slice(&(m as i32).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f32).to_le_bytes());
+    a.extend_from_slice(&(A as u64).to_le_bytes());
+    a.extend_from_slice(&(lda as i32).to_le_bytes());
+    a.extend_from_slice(&(B as u64).to_le_bytes());
+    a.extend_from_slice(&(ldb as i32).to_le_bytes());
+    if beta.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *beta } as f32).to_le_bytes());
+    a.extend_from_slice(&(C as u64).to_le_bytes());
+    a.extend_from_slice(&(ldc as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 31, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasDsymm_v2(handle: *mut c_void, side: c_int, uplo: c_int, m: c_int, n: c_int, alpha: *const f64, A: *const f64, lda: c_int, B: *const f64, ldb: c_int, beta: *const f64, C: *mut f64, ldc: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(side as i32).to_le_bytes());
+    a.extend_from_slice(&(uplo as i32).to_le_bytes());
+    a.extend_from_slice(&(m as i32).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f64).to_le_bytes());
+    a.extend_from_slice(&(A as u64).to_le_bytes());
+    a.extend_from_slice(&(lda as i32).to_le_bytes());
+    a.extend_from_slice(&(B as u64).to_le_bytes());
+    a.extend_from_slice(&(ldb as i32).to_le_bytes());
+    if beta.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *beta } as f64).to_le_bytes());
+    a.extend_from_slice(&(C as u64).to_le_bytes());
+    a.extend_from_slice(&(ldc as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 32, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasStrsm_v2(handle: *mut c_void, side: c_int, uplo: c_int, trans: c_int, diag: c_int, m: c_int, n: c_int, alpha: *const f32, A: *const f32, lda: c_int, B: *mut f32, ldb: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(side as i32).to_le_bytes());
+    a.extend_from_slice(&(uplo as i32).to_le_bytes());
+    a.extend_from_slice(&(trans as i32).to_le_bytes());
+    a.extend_from_slice(&(diag as i32).to_le_bytes());
+    a.extend_from_slice(&(m as i32).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f32).to_le_bytes());
+    a.extend_from_slice(&(A as u64).to_le_bytes());
+    a.extend_from_slice(&(lda as i32).to_le_bytes());
+    a.extend_from_slice(&(B as u64).to_le_bytes());
+    a.extend_from_slice(&(ldb as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 33, a)) { Ok(()) => 0, Err(_) => 1 }
+}
+#[no_mangle]
+pub extern "C" fn cublasDtrsm_v2(handle: *mut c_void, side: c_int, uplo: c_int, trans: c_int, diag: c_int, m: c_int, n: c_int, alpha: *const f64, A: *const f64, lda: c_int, B: *mut f64, ldb: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(side as i32).to_le_bytes());
+    a.extend_from_slice(&(uplo as i32).to_le_bytes());
+    a.extend_from_slice(&(trans as i32).to_le_bytes());
+    a.extend_from_slice(&(diag as i32).to_le_bytes());
+    a.extend_from_slice(&(m as i32).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f64).to_le_bytes());
+    a.extend_from_slice(&(A as u64).to_le_bytes());
+    a.extend_from_slice(&(lda as i32).to_le_bytes());
+    a.extend_from_slice(&(B as u64).to_le_bytes());
+    a.extend_from_slice(&(ldb as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 34, a)) { Ok(()) => 0, Err(_) => 1 }
+}

--- a/crates/smolvm-cudart-shim/src/generated/cublas_guest.rs
+++ b/crates/smolvm-cudart-shim/src/generated/cublas_guest.rs
@@ -242,3 +242,31 @@ pub extern "C" fn cublasGemmStridedBatchedEx(handle: *mut c_void, transa: c_int,
     // No output params: fire-and-forget (failures surface as sticky async errors).
     match with_client(|c| c.lib_call_deferred(LIB_ID, 13, a)) { Ok(()) => 0, Err(_) => 1 }
 }
+#[no_mangle]
+pub extern "C" fn cublasGemmBatchedEx(handle: *mut c_void, transa: c_int, transb: c_int, m: c_int, n: c_int, k: c_int, alpha: *const f32, Aarray: *const c_void, Atype: c_int, lda: c_int, Barray: *const c_void, Btype: c_int, ldb: c_int, beta: *const f32, Carray: *mut c_void, Ctype: c_int, ldc: c_int, batchCount: c_int, computeType: c_int, algo: c_int) -> c_int {
+    let mut a: Vec<u8> = Vec::new();
+    a.extend_from_slice(&(handle as u64).to_le_bytes());
+    a.extend_from_slice(&(transa as i32).to_le_bytes());
+    a.extend_from_slice(&(transb as i32).to_le_bytes());
+    a.extend_from_slice(&(m as i32).to_le_bytes());
+    a.extend_from_slice(&(n as i32).to_le_bytes());
+    a.extend_from_slice(&(k as i32).to_le_bytes());
+    if alpha.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *alpha } as f32).to_le_bytes());
+    a.extend_from_slice(&(Aarray as u64).to_le_bytes());
+    a.extend_from_slice(&(Atype as i32).to_le_bytes());
+    a.extend_from_slice(&(lda as i32).to_le_bytes());
+    a.extend_from_slice(&(Barray as u64).to_le_bytes());
+    a.extend_from_slice(&(Btype as i32).to_le_bytes());
+    a.extend_from_slice(&(ldb as i32).to_le_bytes());
+    if beta.is_null() { return 1; }
+    a.extend_from_slice(&(unsafe { *beta } as f32).to_le_bytes());
+    a.extend_from_slice(&(Carray as u64).to_le_bytes());
+    a.extend_from_slice(&(Ctype as i32).to_le_bytes());
+    a.extend_from_slice(&(ldc as i32).to_le_bytes());
+    a.extend_from_slice(&(batchCount as i32).to_le_bytes());
+    a.extend_from_slice(&(computeType as i32).to_le_bytes());
+    a.extend_from_slice(&(algo as i32).to_le_bytes());
+    // No output params: fire-and-forget (failures surface as sticky async errors).
+    match with_client(|c| c.lib_call_deferred(LIB_ID, 14, a)) { Ok(()) => 0, Err(_) => 1 }
+}

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -1631,12 +1631,14 @@ pub extern "C" fn cudaStreamBeginCapture(stream: *mut c_void, mode: c_int) -> c_
             s.client
                 .stream_begin_capture(stream as u64, mode)
                 .map_err(map_err)?;
-            // Fetch the driver's capture id once; the allocator re-reads it
-            // through the local queries below.
-            let (_, id) = s
-                .client
-                .stream_capture_info(stream as u64)
-                .map_err(map_err)?;
+            // The capture id is torch-visible only (its allocator correlates
+            // capture state through the local GetCaptureInfo queries); the
+            // host tracks capture by stream, not id. So mint it locally
+            // instead of round-tripping cuStreamGetCaptureInfo — that saved
+            // one host RTT per captured graph (vLLM captures ~1400, dominating
+            // coldstart over a network).
+            static NEXT_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+            let id = NEXT_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             s.capture = Some((stream as u64, id));
             Ok(())
         }) {
@@ -1752,22 +1754,25 @@ pub extern "C" fn cudaGraphLaunch(graph_exec: *mut c_void, stream: *mut c_void) 
 /// empty captures. Filling a caller-provided node array is not supported.
 #[no_mangle]
 pub extern "C" fn cudaGraphGetNodes(
-    graph: *mut c_void,
+    _graph: *mut c_void,
     nodes: *mut *mut c_void,
     num_nodes: *mut usize,
 ) -> c_int {
     if num_nodes.is_null() {
         return set_last(CUDA_ERROR_INVALID_VALUE);
     }
-    match with_client(|c| c.graph_get_node_count(graph as u64)) {
-        Ok(n) => {
-            if !nodes.is_null() {
-                return set_last(CUDA_ERROR_INVALID_VALUE);
-            }
-            set_last(unsafe { out(num_nodes, n as usize) })
-        }
-        Err(e) => set_last(e),
+    // The real node list is never requested (nodes != NULL is rejected below);
+    // torch calls this only with nodes = NULL to check for an EMPTY graph and
+    // warn. A captured decode graph is never empty, so answer the count query
+    // locally with a non-zero value instead of a host round-trip — fetching
+    // the true count cost one RTT per captured graph (~1400), dominating
+    // coldstart over a network. (This can only suppress a cosmetic empty-graph
+    // warning, never cause wrong behavior — unlike the fake-data stubs that
+    // were replaced with real values.)
+    if !nodes.is_null() {
+        return set_last(CUDA_ERROR_INVALID_VALUE);
     }
+    set_last(unsafe { out(num_nodes, 1usize) })
 }
 
 #[no_mangle]

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -472,17 +472,30 @@ pub extern "C" fn cudaMalloc(dev_ptr: *mut *mut c_void, size: usize) -> c_int {
     )
 }
 
-/// `cudaMallocManaged` served as plain device memory: bitsandbytes links it
-/// (its paged optimizers host-access managed pointers — those would fault —
-/// but its 4-bit/8-bit compute paths only need the symbol to resolve and the
-/// pointer to be device-valid).
+/// `cudaMallocManaged` — unified memory the CPU and GPU both access by the same
+/// pointer. Through API remoting to a discrete GPU that cannot page-fault into
+/// guest RAM, that is unserviceable: a guest-CPU dereference of a real host
+/// device address reads garbage. So by default we FAIL (writing a NULL
+/// out-pointer), turning silent corruption into an immediate, obvious crash —
+/// this is exactly bitsandbytes' *paged* optimizer path (`get_paged` wraps the
+/// pointer as a host numpy array). `SMOLVM_CUDA_MANAGED=device` restores the
+/// old device-backed behavior for workloads that only ever touch the pointer
+/// on the GPU (never on the CPU); use it only when you know that holds.
 #[no_mangle]
 pub extern "C" fn cudaMallocManaged(
     dev_ptr: *mut *mut c_void,
     size: usize,
     _flags: c_uint,
 ) -> c_int {
-    cudaMalloc(dev_ptr, size)
+    if std::env::var("SMOLVM_CUDA_MANAGED").as_deref() == Ok("device") {
+        return cudaMalloc(dev_ptr, size);
+    }
+    if !dev_ptr.is_null() {
+        unsafe { *dev_ptr = std::ptr::null_mut() };
+    }
+    // cudaErrorNotSupported: host-coherent managed memory can't cross the
+    // forwarding boundary. (SMOLVM_CUDA_MANAGED=device to override.)
+    set_last(801)
 }
 
 /// Managed-memory prefetch hint: nothing to do, our "managed" memory is
@@ -1030,6 +1043,26 @@ pub extern "C" fn cudaStreamSynchronize(stream: *mut c_void) -> c_int {
         Ok(()) => CUDA_SUCCESS,
         Err(e) => e,
     })
+}
+
+/// `cudaLaunchHostFunc` — a host callback that must run AFTER all prior work on
+/// `stream`. The deferred pipeline means that prior work may not have executed
+/// host-side yet, so we synchronize the stream first; invoking the callback
+/// immediately (as the old stub did) let it observe stale GPU results.
+#[no_mangle]
+pub extern "C" fn cudaLaunchHostFunc(
+    stream: *mut c_void,
+    func: Option<unsafe extern "C" fn(*mut c_void)>,
+    user_data: *mut c_void,
+) -> c_int {
+    let rc = with_client(|c| c.stream_synchronize(stream as u64));
+    if let Err(e) = rc {
+        return set_last(e);
+    }
+    if let Some(f) = func {
+        unsafe { f(user_data) };
+    }
+    CUDA_SUCCESS
 }
 
 // ---- device queries, events, stream/mempool surface (PyTorch runtime API) ----
@@ -1752,7 +1785,12 @@ pub extern "C" fn cudaStreamAddCallback(
     user_data: *mut c_void,
     _flags: c_uint,
 ) -> c_int {
-    // Work up to here has already run, so invoke the callback immediately.
+    // The callback must run after all prior work on `stream`. Under the
+    // deferred pipeline that work may not have executed host-side yet, so
+    // synchronize first — invoking it immediately let it observe stale results.
+    if let Err(e) = with_client(|c| c.stream_synchronize(stream as u64)) {
+        return set_last(e);
+    }
     if let Some(cb) = callback {
         unsafe { cb(stream, CUDA_SUCCESS, user_data) };
     }

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -1843,8 +1843,14 @@ pub extern "C" fn cudaMemPoolSetAttribute(
 pub extern "C" fn cudaMemPoolGetAttribute(
     _pool: *mut c_void,
     _attr: c_int,
-    _value: *mut c_void,
+    value: *mut c_void,
 ) -> c_int {
+    // Every mempool attribute is an 8-byte value (thresholds are u64, the
+    // bool/used/reserved counters are i64). Write a defined 0 rather than
+    // leaving the caller's buffer as stack garbage.
+    if !value.is_null() {
+        unsafe { (value as *mut u64).write_unaligned(0) };
+    }
     set_last(CUDA_SUCCESS)
 }
 #[no_mangle]
@@ -1915,20 +1921,45 @@ pub extern "C" fn cudaPointerGetAttributes(attr: *mut c_void, ptr: *const c_void
     set_last(CUDA_SUCCESS)
 }
 #[no_mangle]
-pub extern "C" fn cudaFuncGetAttributes(attr: *mut c_void, _func: *const c_void) -> c_int {
+pub extern "C" fn cudaFuncGetAttributes(attr: *mut c_void, func: *const c_void) -> c_int {
     if attr.is_null() {
         return set_last(CUDA_ERROR_INVALID_VALUE);
     }
-    // cudaFuncAttributes prefix: sharedSizeBytes, constSizeBytes, localSizeBytes
-    // (size_t) then maxThreadsPerBlock, numRegs, ptxVersion, binaryVersion (int).
-    unsafe {
-        std::ptr::write_bytes(attr as *mut u8, 0, 72);
-        let ints = (attr as *mut u8).add(24) as *mut c_int;
-        *ints = 1024; // maxThreadsPerBlock
-        *ints.add(2) = 86; // ptxVersion (sm_86)
-        *ints.add(3) = 86; // binaryVersion
-    }
-    set_last(CUDA_SUCCESS)
+    // cudaFuncAttributes: sharedSizeBytes, constSizeBytes, localSizeBytes
+    // (size_t @ 0/8/16) then maxThreadsPerBlock, numRegs, ptxVersion,
+    // binaryVersion (i32 @ 24/28/32/36). Forward the real values — the old
+    // fixed fakes (numRegs=0) divided by zero in occupancy math.
+    unsafe { std::ptr::write_bytes(attr as *mut u8, 0, 72) };
+    // CUfunction_attribute: MAX_THREADS_PER_BLOCK=0, SHARED=1, CONST=2,
+    // LOCAL=3, NUM_REGS=4, PTX_VERSION=5, BINARY_VERSION=6.
+    let r = with_state(|s| {
+        let fid = s
+            .funcs
+            .get(&(func as usize))
+            .ok_or(CUDA_ERROR_INVALID_DEVICE_POINTER)?
+            .fid;
+        let get = |s: &mut ShimState, a: i32| s.client.func_get_attribute(fid, a).unwrap_or(0);
+        let shared = get(s, 1);
+        let cst = get(s, 2);
+        let local = get(s, 3);
+        let max_tpb = get(s, 0);
+        let num_regs = get(s, 4);
+        let ptx = get(s, 5);
+        let bin = get(s, 6);
+        unsafe {
+            let base = attr as *mut u8;
+            (base as *mut usize).write_unaligned(shared.max(0) as usize);
+            (base.add(8) as *mut usize).write_unaligned(cst.max(0) as usize);
+            (base.add(16) as *mut usize).write_unaligned(local.max(0) as usize);
+            let ints = base.add(24) as *mut c_int;
+            *ints = if max_tpb > 0 { max_tpb } else { 1024 };
+            *ints.add(1) = if num_regs > 0 { num_regs } else { 1 }; // never 0 (occupancy div)
+            *ints.add(2) = if ptx > 0 { ptx } else { 86 };
+            *ints.add(3) = if bin > 0 { bin } else { 86 };
+        }
+        Ok(())
+    });
+    set_last(r.err().unwrap_or(CUDA_SUCCESS))
 }
 /// Forward the shared-memory opt-in (`cudaFuncAttributeMaxDynamicSharedMemorySize`
 /// = 8, matching the driver's `CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES`)
@@ -1995,7 +2026,13 @@ pub extern "C" fn cudaHostGetDevicePointer(
     host: *mut c_void,
     _flags: c_uint,
 ) -> c_int {
-    set_last(unsafe { out(p_device, host) }) // unified addressing
+    // Unified-addressing convention: device VA == host VA. Correct for the
+    // memcpy path (the host recognizes guest-RAM addresses and DMAs them).
+    // KNOWN LIMITATION: a mapped host pointer passed as a KERNEL ARG can't be
+    // dereferenced by the host GPU (a guest VA isn't device-addressable) — that
+    // needs true unified memory we don't have. No validated workload does this;
+    // those that would should use explicit cudaMemcpy instead.
+    set_last(unsafe { out(p_device, host) })
 }
 #[no_mangle]
 pub extern "C" fn cudaDeviceCanAccessPeer(can: *mut c_int, _device: c_int, _peer: c_int) -> c_int {

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -1628,15 +1628,15 @@ const CAPTURE_ACTIVE: c_int = 1;
 pub extern "C" fn cudaStreamBeginCapture(stream: *mut c_void, mode: c_int) -> c_int {
     set_last(
         match with_state(|s| {
+            // Fire-and-forget: the host starts capture when this drains, and
+            // the (also-deferred) launches record in order. The capture id is
+            // torch-visible only (its allocator correlates via the local
+            // GetCaptureInfo queries; the host tracks capture by stream), so
+            // mint it locally. Both save a host round-trip per captured graph,
+            // which dominates coldstart over a network (~1400 graphs).
             s.client
-                .stream_begin_capture(stream as u64, mode)
+                .stream_begin_capture_deferred(stream as u64, mode)
                 .map_err(map_err)?;
-            // The capture id is torch-visible only (its allocator correlates
-            // capture state through the local GetCaptureInfo queries); the
-            // host tracks capture by stream, not id. So mint it locally
-            // instead of round-tripping cuStreamGetCaptureInfo — that saved
-            // one host RTT per captured graph (vLLM captures ~1400, dominating
-            // coldstart over a network).
             static NEXT_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
             let id = NEXT_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             s.capture = Some((stream as u64, id));
@@ -1655,12 +1655,14 @@ pub extern "C" fn cudaStreamEndCapture(stream: *mut c_void, graph: *mut *mut c_v
     }
     set_last(
         match with_state(|s| {
-            let g = s
-                .client
-                .stream_end_capture(stream as u64)
+            // Mint a virtual graph handle; the host maps it to the real
+            // captured graph when this deferred end drains.
+            let vh = alloc_vhandle();
+            s.client
+                .stream_end_capture_deferred(stream as u64, vh)
                 .map_err(map_err)?;
             s.capture = None;
-            Ok(g)
+            Ok(vh)
         }) {
             Ok(g) => unsafe { out(graph, g as *mut c_void) },
             Err(e) => {
@@ -1733,10 +1735,18 @@ pub extern "C" fn cudaGraphInstantiateWithFlags(
     if graph_exec.is_null() {
         return set_last(CUDA_ERROR_INVALID_VALUE);
     }
-    set_last(match with_client(|c| c.graph_instantiate(graph as u64)) {
-        Ok(e) => unsafe { out(graph_exec, e as *mut c_void) },
-        Err(e) => e,
-    })
+    set_last(
+        match with_client(|c| {
+            // Mint a virtual exec handle; host maps it when this deferred
+            // instantiate drains (graph is itself a virtual graph handle).
+            let exec_vh = alloc_vhandle();
+            c.graph_instantiate_deferred(graph as u64, exec_vh)?;
+            Ok(exec_vh)
+        }) {
+            Ok(e) => unsafe { out(graph_exec, e as *mut c_void) },
+            Err(e) => e,
+        },
+    )
 }
 
 #[no_mangle]

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -724,13 +724,14 @@ mod guestmem {
     }
 }
 
-/// Bump-allocate `size` bytes (16-aligned) from the shared region.
+/// Bump-allocate `size` bytes (256-aligned: ggml asserts host buffers hit
+/// TENSOR_ALIGNMENT, and 256 also matches cudaHostAlloc's real alignment).
 #[allow(clippy::needless_return)] // `return` is load-bearing across the cfg arms
 fn shm_alloc(size: usize) -> Option<*mut u8> {
     #[cfg(target_os = "linux")]
     {
         let r = shm_region()?;
-        let sz = (size as u64 + 15) & !15;
+        let sz = (size as u64 + 255) & !255;
         let off = SHM_NEXT.fetch_add(sz, Ordering::Relaxed);
         if off + sz > r.len() as u64 {
             return None; // region exhausted → caller falls back
@@ -772,7 +773,7 @@ fn cuda_host_malloc(ptr: *mut *mut c_void, size: usize) -> c_int {
     if let Some(mem) = shm_alloc(size) {
         return set_last(unsafe { out(ptr, mem as *mut c_void) });
     }
-    let layout = match std::alloc::Layout::from_size_align(size, 16) {
+    let layout = match std::alloc::Layout::from_size_align(size, 256) {
         Ok(l) => l,
         Err(_) => return set_last(CUDA_ERROR_INVALID_VALUE),
     };
@@ -1199,6 +1200,121 @@ const _: () = {
     assert!(std::mem::offset_of!(CudaDeviceProp, reserved_shared_mem_per_block) == 720);
     assert!(std::mem::size_of::<CudaDeviceProp>() == 1032);
 };
+
+/// CUDA 13 entry point: 13.x renamed the symbol back from `_v2` AND changed
+/// the struct (1008 bytes, clock-rate fields removed, everything after
+/// `canMapHostMemory` shifted). Callers compiled against 13.x land here;
+/// 12.x callers keep `_v2` and its layout. Offsets measured from the 13.3
+/// headers (scratchpad probe), values fetched like the 12.x path.
+#[no_mangle]
+pub extern "C" fn cudaGetDeviceProperties(prop: *mut c_void, device: c_int) -> c_int {
+    if prop.is_null() {
+        return set_last(CUDA_ERROR_INVALID_VALUE);
+    }
+    unsafe { std::ptr::write_bytes(prop as *mut u8, 0, 1008) };
+    set_last(
+        with_state(|s| {
+            let a = |s: &mut ShimState, attr: i32, dflt: i32| {
+                s.client.device_get_attribute(attr, device).unwrap_or(dflt)
+            };
+            let name = s.client.device_get_name(device).unwrap_or_default();
+            let uuid = s.client.device_get_uuid(device).unwrap_or([0; 16]);
+            let total = s.client.device_total_mem(device).unwrap_or(0);
+            let base = prop as *mut u8;
+            let wi = |off: usize, v: i32| unsafe { base.add(off).cast::<i32>().write_unaligned(v) };
+            let wu = |off: usize, v: u64| unsafe { base.add(off).cast::<u64>().write_unaligned(v) };
+            let nb = name.as_bytes();
+            let n = nb.len().min(255);
+            unsafe {
+                std::ptr::copy_nonoverlapping(nb.as_ptr(), base, n);
+                std::ptr::copy_nonoverlapping(uuid.as_ptr(), base.add(256), 16);
+            }
+            wu(288, total); // totalGlobalMem
+            wu(296, a(s, A_MAX_SHMEM_PER_BLOCK, 49152) as u64);
+            wi(304, a(s, A_MAX_REGS_PER_BLOCK, 65536));
+            wi(308, a(s, A_WARP_SIZE, 32));
+            wu(312, 2147483647); // memPitch
+            wi(320, a(s, A_MAX_THREADS_PER_BLOCK, 1024));
+            wi(324, a(s, A_MAX_BLOCK_DIM_X, 1024));
+            wi(328, a(s, A_MAX_BLOCK_DIM_Y, 1024));
+            wi(332, a(s, A_MAX_BLOCK_DIM_Z, 64));
+            wi(336, a(s, A_MAX_GRID_DIM_X, 2147483647));
+            wi(340, a(s, A_MAX_GRID_DIM_Y, 65535));
+            wi(344, a(s, A_MAX_GRID_DIM_Z, 65535));
+            wu(352, a(s, A_TOTAL_CONST_MEM, 65536) as u64);
+            wi(360, a(s, A_COMPUTE_MAJOR, 8));
+            wi(364, a(s, A_COMPUTE_MINOR, 6));
+            wu(368, 512); // textureAlignment
+            wu(376, 32); // texturePitchAlignment
+            wi(384, a(s, A_MP_COUNT, 1));
+            wi(392, 1); // canMapHostMemory
+            wi(560, a(s, A_CONCURRENT_KERNELS, 1));
+            wi(584, a(s, A_ASYNC_ENGINE_COUNT, 2));
+            wi(588, 1); // unifiedAddressing
+            wi(592, a(s, A_MEMORY_BUS_WIDTH, 0));
+            wi(596, a(s, A_L2_CACHE_SIZE, 0));
+            wi(600, a(s, A_MAX_PERSISTING_L2, 0));
+            wi(604, a(s, A_MAX_THREADS_PER_MP, 1536));
+            wi(608, 1); // streamPrioritiesSupported
+            wi(612, 1); // globalL1CacheSupported
+            wi(616, 1); // localL1CacheSupported
+            wu(624, a(s, A_MAX_SHMEM_PER_MP, 102400) as u64);
+            wi(632, a(s, A_MAX_REGS_PER_MP, 65536));
+            wi(636, a(s, A_MANAGED_MEMORY, 1));
+            wi(656, a(s, A_CONCURRENT_MANAGED_ACCESS, 1));
+            wi(660, a(s, A_COMPUTE_PREEMPTION, 1));
+            wi(668, a(s, A_COOPERATIVE_LAUNCH, 1));
+            wu(672, a(s, A_MAX_SHMEM_PER_BLOCK_OPTIN, 101376) as u64);
+            wi(688, a(s, A_MAX_BLOCKS_PER_MP, 16));
+            wi(692, a(s, A_MAX_ACCESS_POLICY_WINDOW, 0));
+            wu(696, a(s, A_RESERVED_SHMEM_PER_BLOCK, 0) as u64);
+            wi(704, a(s, A_HOST_REGISTER_SUPPORTED, 1));
+            Ok(())
+        })
+        .err()
+        .unwrap_or(CUDA_SUCCESS),
+    )
+}
+
+/// Device-flag scheduling hints have no effect through forwarding.
+#[no_mangle]
+pub extern "C" fn cudaSetDeviceFlags(_flags: c_uint) -> c_int {
+    CUDA_SUCCESS
+}
+
+/// Whole-graph exec update: report "update failed" — ggml (and torch) fall
+/// back to destroying and re-instantiating the graph, which we forward.
+#[no_mangle]
+pub extern "C" fn cudaGraphExecUpdate(
+    _exec: *mut c_void,
+    _graph: *mut c_void,
+    result_info: *mut c_void,
+) -> c_int {
+    if !result_info.is_null() {
+        // cudaGraphExecUpdateResultInfo { result, errorNode, errorFromNode }
+        unsafe { std::ptr::write_bytes(result_info as *mut u8, 0, 24) };
+    }
+    910 // cudaErrorGraphExecUpdateFailure
+}
+
+/// Cooperative launches need grid-wide sync the transport can't fake; the
+/// caller sees NotSupported and picks a non-cooperative path.
+#[no_mangle]
+pub extern "C" fn cudaLaunchCooperativeKernel(
+    _func: *const c_void,
+    _grid: Dim3,
+    _block: Dim3,
+    _args: *mut *mut c_void,
+    _shared: usize,
+    _stream: *mut c_void,
+) -> c_int {
+    set_last(801) // cudaErrorNotSupported
+}
+
+#[no_mangle]
+pub extern "C" fn cublasGetStatusString(_status: c_int) -> *const c_char {
+    c"cublas status (forwarded by smolvm)".as_ptr()
+}
 
 #[no_mangle]
 pub extern "C" fn cudaGetDeviceProperties_v2(prop: *mut c_void, device: c_int) -> c_int {

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -1963,6 +1963,15 @@ pub extern "C" fn cudaFuncGetAttributes(attr: *mut c_void, func: *const c_void) 
     // binaryVersion (i32 @ 24/28/32/36). Forward the real values — the old
     // fixed fakes (numRegs=0) divided by zero in occupancy math.
     unsafe { std::ptr::write_bytes(attr as *mut u8, 0, 72) };
+    // Kernel attributes are immutable — memoize the packed 72-byte blob per
+    // function (torch may query per-launch; each miss is 7 host round-trips).
+    static FUNC_ATTRS: Mutex<Option<HashMap<usize, [u8; 72]>>> = Mutex::new(None);
+    if let Ok(mut g) = FUNC_ATTRS.lock() {
+        if let Some(blob) = g.get_or_insert_with(HashMap::new).get(&(func as usize)) {
+            unsafe { std::ptr::copy_nonoverlapping(blob.as_ptr(), attr as *mut u8, 72) };
+            return set_last(CUDA_SUCCESS);
+        }
+    }
     // CUfunction_attribute: MAX_THREADS_PER_BLOCK=0, SHARED=1, CONST=2,
     // LOCAL=3, NUM_REGS=4, PTX_VERSION=5, BINARY_VERSION=6.
     let r = with_state(|s| {
@@ -1992,6 +2001,14 @@ pub extern "C" fn cudaFuncGetAttributes(attr: *mut c_void, func: *const c_void) 
         }
         Ok(())
     });
+    if r.is_ok() {
+        if let Ok(mut g) = FUNC_ATTRS.lock() {
+            let mut blob = [0u8; 72];
+            unsafe { std::ptr::copy_nonoverlapping(attr as *const u8, blob.as_mut_ptr(), 72) };
+            g.get_or_insert_with(HashMap::new)
+                .insert(func as usize, blob);
+        }
+    }
     set_last(r.err().unwrap_or(CUDA_SUCCESS))
 }
 /// Forward the shared-memory opt-in (`cudaFuncAttributeMaxDynamicSharedMemorySize`

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -445,8 +445,16 @@ pub extern "C" fn cudaDeviceSynchronize() -> c_int {
 
 #[no_mangle]
 pub extern "C" fn cudaDriverGetVersion(version: *mut c_int) -> c_int {
+    static CACHED: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(0);
+    let c = CACHED.load(std::sync::atomic::Ordering::Relaxed);
+    if c != 0 {
+        return set_last(unsafe { out(version, c) });
+    }
     set_last(match with_client(|c| c.driver_get_version()) {
-        Ok(v) => unsafe { out(version, v) },
+        Ok(v) => {
+            CACHED.store(v, std::sync::atomic::Ordering::Relaxed);
+            unsafe { out(version, v) }
+        }
         Err(e) => e,
     })
 }
@@ -1115,11 +1123,36 @@ const A_MAX_ACCESS_POLICY_WINDOW: i32 = 109;
 const A_RESERVED_SHMEM_PER_BLOCK: i32 = 111;
 const A_TIMELINE_SEMAPHORE: i32 = 114;
 
+/// Immutable per-(device, attribute) cache (see cudaDeviceGetAttribute).
+static DEV_ATTRS: Mutex<Option<HashMap<(c_int, c_int), c_int>>> = Mutex::new(None);
+fn dev_attr_cached(device: c_int, attr: c_int) -> Option<c_int> {
+    DEV_ATTRS
+        .lock()
+        .ok()?
+        .get_or_insert_with(HashMap::new)
+        .get(&(device, attr))
+        .copied()
+}
+fn dev_attr_store(device: c_int, attr: c_int, v: c_int) {
+    if let Ok(mut g) = DEV_ATTRS.lock() {
+        g.get_or_insert_with(HashMap::new).insert((device, attr), v);
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn cudaDeviceGetAttribute(value: *mut c_int, attr: c_int, device: c_int) -> c_int {
+    // Device attributes are immutable — memoize to spare a host round-trip on
+    // every repeat (torch queries them thousands of times; a remote server's
+    // network RTT makes each one expensive).
+    if let Some(v) = dev_attr_cached(device, attr) {
+        return set_last(unsafe { out(value, v) });
+    }
     set_last(
         match with_client(|c| c.device_get_attribute(attr, device)) {
-            Ok(v) => unsafe { out(value, v) },
+            Ok(v) => {
+                dev_attr_store(device, attr, v);
+                unsafe { out(value, v) }
+            }
             Err(e) => e,
         },
     )


### PR DESCRIPTION
Forwarding improvements on top of the merged fast path: llama.cpp/CUDA-13 support (Qwen Q4_K_M at 80% native), a version handshake + managed-memory fail-loud + real func-attributes (kills silent-wrongness classes), 20 real cuBLAS Level-1/2/3 ops, immutable-query caching that flattens the remote decode latency curve, and fire-and-forget graph capture. Validated in-VM: vLLM graphs 97% of native, bitsandbytes QLoRA and Unsloth fine-tune converge.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/607">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->