### PR TITLE
Bump the workspace to 1.5.2 for the storage-template sparse-copy fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2263,7 +2263,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smolfile"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -2289,7 +2289,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "async-stream",
  "axum",
@@ -2344,7 +2344,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-agent"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "flate2",
  "lazy_static",
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "libc",
  "libloading",
@@ -2373,11 +2373,11 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda-codegen"
-version = "1.5.1"
+version = "1.5.2"
 
 [[package]]
 name = "smolvm-cuda-guest"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "smolvm-cuda",
  "vsock",
@@ -2385,7 +2385,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda-shim"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "smolvm-cuda",
  "vsock",
@@ -2393,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cudart-shim"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "libc",
  "smolvm-cuda",
@@ -2402,7 +2402,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-network"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "crossbeam-queue",
  "humantime",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-pack"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -2433,7 +2433,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "base64",
  "serde",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "bytes",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ resolver = "2"
 
 [package]
 name = "smolvm"
-version = "1.5.1"
+version = "1.5.2"
 edition = "2021"
 description = "OCI-native microVM runtime"
 license = "Apache-2.0"
@@ -34,12 +34,12 @@ name = "smolvm"
 path = "src/main.rs"
 
 [dependencies]
-smolvm-network = { path = "crates/smolvm-network", version = "1.5.1" }
-smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.5.1" }
-smolvm-cuda = { path = "crates/smolvm-cuda", version = "1.5.1" }
-smolvm-pack = { path = "crates/smolvm-pack", version = "1.5.1" }
-smolvm-registry = { path = "crates/smolvm-registry", version = "1.5.1" }
-smolfile = { path = "crates/smolvm-smolfile", version = "1.5.1" }
+smolvm-network = { path = "crates/smolvm-network", version = "1.5.2" }
+smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.5.2" }
+smolvm-cuda = { path = "crates/smolvm-cuda", version = "1.5.2" }
+smolvm-pack = { path = "crates/smolvm-pack", version = "1.5.2" }
+smolvm-registry = { path = "crates/smolvm-registry", version = "1.5.2" }
+smolfile = { path = "crates/smolvm-smolfile", version = "1.5.2" }
 thiserror = "1"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
@@ -122,7 +122,7 @@ windows-sys = { version = "0.60", features = [
 
 [dev-dependencies]
 tempfile = "3"
-smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.5.1" }
+smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.5.2" }
 regex = "1"
 
 [build-dependencies]

--- a/crates/smolvm-agent/Cargo.toml
+++ b/crates/smolvm-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-agent"
-version = "1.5.1"
+version = "1.5.2"
 edition = "2021"
 description = "Guest agent for smolvm VMs (handles OCI operations and command execution)"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ name = "smolvm-agent"
 path = "src/main.rs"
 
 [dependencies]
-smolvm-protocol = { path = "../smolvm-protocol", version = "1.5.1" }
+smolvm-protocol = { path = "../smolvm-protocol", version = "1.5.2" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/crates/smolvm-cuda-codegen/Cargo.toml
+++ b/crates/smolvm-cuda-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda-codegen"
-version = "1.5.1"
+version = "1.5.2"
 edition = "2021"
 description = "Generates forward-to-host-lib marshaling (guest stubs + host dispatch) from a function spec"
 license = "Apache-2.0"

--- a/crates/smolvm-cuda-guest/Cargo.toml
+++ b/crates/smolvm-cuda-guest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda-guest"
-version = "1.5.1"
+version = "1.5.2"
 edition = "2021"
 description = "Guest-side CUDA-over-vsock runner for smolvm microVMs (Linux)"
 license = "Apache-2.0"

--- a/crates/smolvm-cuda-shim/Cargo.toml
+++ b/crates/smolvm-cuda-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda-shim"
-version = "1.5.1"
+version = "1.5.2"
 edition = "2021"
 description = "Guest-side libcuda.so.1 drop-in: CUDA Driver API over smolvm's vsock RPC"
 license = "Apache-2.0"

--- a/crates/smolvm-cuda/Cargo.toml
+++ b/crates/smolvm-cuda/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda"
-version = "1.5.1"
+version = "1.5.2"
 edition = "2021"
 description = "CUDA Driver-API remoting over vsock for smolvm guests"
 license = "Apache-2.0"

--- a/crates/smolvm-cudart-shim/Cargo.toml
+++ b/crates/smolvm-cudart-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cudart-shim"
-version = "1.5.1"
+version = "1.5.2"
 edition = "2021"
 description = "Guest-side libcudart.so drop-in: CUDA Runtime API lowered to smolvm's Driver-API vsock RPC"
 license = "Apache-2.0"

--- a/crates/smolvm-network/Cargo.toml
+++ b/crates/smolvm-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-network"
-version = "1.5.1"
+version = "1.5.2"
 edition = "2021"
 description = "Host-side virtio-net runtime for smolvm"
 license = "Apache-2.0"

--- a/crates/smolvm-pack/Cargo.toml
+++ b/crates/smolvm-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-pack"
-version = "1.5.1"
+version = "1.5.2"
 edition = "2021"
 description = "Single-binary packaging for smolvm"
 license = "Apache-2.0"
@@ -10,7 +10,7 @@ repository = "https://github.com/smol-machines/smolvm"
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-smolvm-protocol = { path = "../smolvm-protocol", version = "1.5.1" }
+smolvm-protocol = { path = "../smolvm-protocol", version = "1.5.2" }
 tar = "0.4"
 zstd = "0.13"
 crc32fast = "1.4"

--- a/crates/smolvm-protocol/Cargo.toml
+++ b/crates/smolvm-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-protocol"
-version = "1.5.1"
+version = "1.5.2"
 edition = "2021"
 description = "Protocol types for smolvm host-guest communication"
 license = "Apache-2.0"

--- a/crates/smolvm-registry/Cargo.toml
+++ b/crates/smolvm-registry/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "smolvm-registry"
-version = "1.5.1"
+version = "1.5.2"
 edition = "2021"
 description = "OCI Distribution client for smolmachines registry"
 license = "Apache-2.0"
 repository = "https://github.com/smol-machines/smolvm"
 
 [dependencies]
-smolvm-pack = { path = "../smolvm-pack", version = "1.5.1" }
+smolvm-pack = { path = "../smolvm-pack", version = "1.5.2" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "json"] }
 sha2 = "0.10"
 bytes = "1"

--- a/crates/smolvm-smolfile/Cargo.toml
+++ b/crates/smolvm-smolfile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolfile"
-version = "1.5.1"
+version = "1.5.2"
 edition = "2021"
 description = "Smolfile specification and parser for smolvm microVM workloads"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ keywords = ["smolvm", "microvm", "configuration"]
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 thiserror = "1"
-smolvm-protocol = { path = "../smolvm-protocol", version = "1.5.1" }
+smolvm-protocol = { path = "../smolvm-protocol", version = "1.5.2" }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
Version-only bump to 1.5.2 so the pack-create storage-template sparseness fix ships in a release.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/608">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->