### PR TITLE
cuda: make the remoting crate consumable standalone (de-brand config, README, docs)

### DIFF
--- a/crates/smolvm-cuda-shim/src/lib.rs
+++ b/crates/smolvm-cuda-shim/src/lib.rs
@@ -6,7 +6,7 @@
 //! CUDA runtime's dlopen of the driver — run their GPU work on the host GPU
 //! with no code changes.
 //!
-//! Transport is chosen by `SMOLVM_CUDA_RPC`:
+//! Transport is chosen by `CUDA_REMOTE_ENDPOINT` (or legacy `SMOLVM_CUDA_RPC`):
 //!   * unset / `vsock` — AF_VSOCK to host CID 2, port 7000 (production, in-guest)
 //!   * `tcp:HOST:PORT` — TCP (host-side testing against a loopback server)
 //!   * `unix:/path`    — AF_UNIX (host-side testing against the real cuda.sock)
@@ -101,7 +101,7 @@ impl Write for Stream {
 }
 
 fn connect() -> Result<Stream, c_int> {
-    let spec = std::env::var("SMOLVM_CUDA_RPC").unwrap_or_default();
+    let spec = smolvm_cuda::config::transport_spec();
     if let Some(addr) = spec.strip_prefix("tcp:") {
         return std::net::TcpStream::connect(addr)
             .map(|s| {
@@ -119,9 +119,8 @@ fn connect() -> Result<Stream, c_int> {
     #[cfg(target_os = "linux")]
     {
         // smolvm's reserved CUDA port on the host CID (smolvm_protocol::ports::CUDA).
-        const HOST_CID: u32 = 2;
-        const CUDA_PORT: u32 = 7000;
-        vsock::VsockStream::connect_with_cid_port(HOST_CID, CUDA_PORT)
+        let (cid, port) = smolvm_cuda::config::vsock_default();
+        vsock::VsockStream::connect_with_cid_port(cid, port)
             .map(Stream::Vsock)
             .map_err(|_| CUDA_ERROR_NO_DEVICE)
     }

--- a/crates/smolvm-cuda/README.md
+++ b/crates/smolvm-cuda/README.md
@@ -1,0 +1,92 @@
+# smolvm-cuda
+
+CUDA API remoting: run an **unmodified** CUDA application (PyTorch, vLLM,
+llama.cpp, …) against an NVIDIA GPU that lives in another process, another host,
+or on the far side of a VM boundary — with **no driver and no CUDA toolkit in
+the client**. The client marshals `cudaX*`/`cu*` calls over a byte stream; a
+host process replays them on the real GPU and ships results back.
+
+Originally built for [smolvm](../../) microVMs, but the core has **no dependency
+on smolvm or libkrun** and is usable standalone. Two ways to consume it:
+
+## 1. As a drop-in shim (any CUDA app, no Rust, no smolvm)
+
+Build the two shims and the server, then point any CUDA program at a remote GPU
+host by preloading the shims — the program thinks it has a local GPU:
+
+```sh
+# on the GPU host: start the server
+cargo run --release -p smolvm-cuda --example shim_server -- 0.0.0.0:7000
+
+# on the client (no GPU, no CUDA toolkit needed): point the app at it
+export CUDA_REMOTE_ENDPOINT=tcp:GPU_HOST:7000
+export LD_LIBRARY_PATH=/path/to/shims   # dir with libcudart.so.12 + libcuda.so.1
+python train.py                          # runs on the remote GPU, unchanged
+```
+
+`CUDA_REMOTE_ENDPOINT` accepts `tcp:HOST:PORT`, `unix:/path`, or `vsock`
+(defaults to host CID 2 / port 7000, overridable with `CUDA_REMOTE_VSOCK`).
+
+The shims are `smolvm-cudart-shim` (→ `libcudart.so.12`, the runtime API) and
+`smolvm-cuda-shim` (→ `libcuda.so.1`, the driver API). Stage them over the
+application's CUDA libraries (they export the same symbols).
+
+## 2. As a Rust library
+
+The transport is any `Read + Write`, and the backend is a trait — so you can
+embed remoting into your own runtime, VMM, or GPU broker:
+
+```rust
+use smolvm_cuda::client::Client;
+use smolvm_cuda::host::{serve, GpuBackend};
+
+// client side (guest): marshal over any stream you own
+let mut cli = Client::new(your_stream);   // TcpStream, VsockStream, a pipe, …
+cli.init()?;
+let dptr = cli.mem_alloc(4096)?;
+// … cli.launch_kernel(), cli.memcpy_htod(), cli.graph_launch() …
+
+// host side (has the GPU): dispatch onto the real driver
+let mut backend = GpuBackend::load()?;     // dlopen's libcuda.so.1
+serve(your_stream, &mut backend)?;         // one connection, in call order
+```
+
+See `examples/gpu_loopback.rs` for a complete client+server in one process.
+
+## Extension seams
+
+- **Transport** — `Client<S: Read + Write>`. Bring your own stream. Built-in:
+  TCP, Unix, AF_VSOCK. For same-host VMs there is also a zero-copy shared-memory
+  ring path (see `ring`), which needs the host to map guest RAM (below).
+- **Backend** (`host::Backend`) — `GpuBackend` (real driver via `dlopen`) and
+  `CpuBackend` (GPU-less emulation for testing) ship in-box; implement your own
+  to record/replay, meter, or target a different device.
+- **Guest memory** (`Backend::gpa_to_hva`) — the only VM-specific seam. The
+  embedder provides guest-physical → host-virtual mappings so the rings can DMA
+  guest RAM directly. Non-VM consumers skip it and use the socket transport
+  (fully functional, just not zero-copy).
+
+## Coverage & honesty
+
+This forwards the surface that has been exercised end-to-end (PyTorch training +
+inference, vLLM, llama.cpp, Triton, FlashAttention, bitsandbytes, cuBLAS/cuBLASLt,
+cuDNN v8, CUDA graphs, the VMM allocator). Everything else is an **honest
+`NOT_SUPPORTED` stub** — a workload that needs an unimplemented call fails
+loudly, it does not silently return wrong data. A connect-time protocol
+handshake likewise rejects a client/server built from mismatched source rather
+than corrupting.
+
+Not yet forwarded: cuSOLVER/cuFFT/cuRAND/NCCL, complex (C/Z) BLAS, and reduction
+BLAS (whose result-pointer mode can't be disambiguated safely). The cuBLAS/cuDNN
+surface is generated from a small spec (`smolvm-cuda-codegen`), so extending it
+is mechanical.
+
+## Performance
+
+Same-host (shared-memory rings), forwarded vs native on an RTX 3070: vLLM
+CUDA-graph decode ~97%, llama.cpp ~98%. Over a network the story is
+latency-bound — decode pays ~1.3 synchronizations per token (fine under ~1 ms
+RTT, degraded but usable at multi-ms), and cold start is dominated by the
+framework's own synchronization barriers during warmup. Immutable device/kernel
+queries are cached client-side to keep the per-token round-trip count near its
+floor.

--- a/crates/smolvm-cuda/src/config.rs
+++ b/crates/smolvm-cuda/src/config.rs
@@ -1,0 +1,37 @@
+//! Endpoint configuration for the guest shims, read from the environment.
+//!
+//! De-branded so the shims are usable as a standalone "forward CUDA to another
+//! host" tool without smolvm: a consumer sets `CUDA_REMOTE_ENDPOINT`. The
+//! legacy `SMOLVM_CUDA_RPC` name is still honored (smolvm sets it), so existing
+//! deployments keep working.
+
+/// The transport spec, e.g. `tcp:HOST:PORT`, `unix:/path`, or `vsock`.
+/// Checks `CUDA_REMOTE_ENDPOINT` first, then `SMOLVM_CUDA_RPC`. Empty = the
+/// default vsock transport (in-guest).
+pub fn transport_spec() -> String {
+    std::env::var("CUDA_REMOTE_ENDPOINT")
+        .or_else(|_| std::env::var("SMOLVM_CUDA_RPC"))
+        .unwrap_or_default()
+}
+
+/// Default AF_VSOCK `(cid, port)` for the in-guest transport. Overridable via
+/// `CUDA_REMOTE_VSOCK=<cid>:<port>`; defaults to host CID 2, port 7000.
+pub fn vsock_default() -> (u32, u32) {
+    const DEFAULT_CID: u32 = 2;
+    const DEFAULT_PORT: u32 = 7000;
+    match std::env::var("CUDA_REMOTE_VSOCK") {
+        Ok(v) => {
+            let mut parts = v.splitn(2, ':');
+            let cid = parts
+                .next()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(DEFAULT_CID);
+            let port = parts
+                .next()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(DEFAULT_PORT);
+            (cid, port)
+        }
+        Err(_) => (DEFAULT_CID, DEFAULT_PORT),
+    }
+}

--- a/crates/smolvm-cuda/src/lib.rs
+++ b/crates/smolvm-cuda/src/lib.rs
@@ -1,8 +1,16 @@
-//! CUDA Driver-API remoting for smolvm: a guest microVM forwards `cu*` calls
-//! over vsock to a host server that runs them on the host's NVIDIA GPU.
+//! CUDA API remoting: run an unmodified CUDA app against a GPU in another
+//! process/host/VM, with no driver in the client. The client marshals
+//! `cudaX*`/`cu*` calls over a byte stream; a host replays them on the real GPU.
+//!
+//! Built for smolvm microVMs, but the core depends on nothing smolvm-specific
+//! and is consumable standalone — see `README.md` for the drop-in-shim and
+//! Rust-library usage. The transport is any `Read + Write`; the backend is a
+//! trait; the only VM-specific seam is [`host::Backend::gpa_to_hva`] (guest-RAM
+//! mapping for the zero-copy rings), which non-VM consumers can ignore.
 //!
 //! - `proto` — the wire protocol (framing, request/response codec). No deps.
 //! - `client` — guest-side marshalling over any `Read`/`Write` stream.
+//! - `config` — endpoint config from the environment (`CUDA_REMOTE_ENDPOINT`).
 //! - `host` — host-side dispatch with a `Backend` trait; ships a real GPU
 //!   backend (`GpuBackend`, `gpu` feature) and a CPU emulation backend
 //!   (`CpuBackend`) for GPU-less verification.
@@ -11,6 +19,8 @@
 //! pull only `proto` + `client` (no `libloading`), keeping the musl build lean.
 
 pub mod client;
+/// Environment-driven endpoint config for the guest shims (de-branded).
+pub mod config;
 pub mod proto;
 /// Shared-memory command/completion rings (low-latency in-VM transport).
 pub mod ring;

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! Interpose it with `LD_PRELOAD=/path/libcudart.so.11.0` (or stage it ahead of
 //! the program's own copy on `LD_LIBRARY_PATH`). Transport is selected by
-//! `SMOLVM_CUDA_RPC` exactly as the libcuda shim: unset/`vsock` (in-guest),
+//! `CUDA_REMOTE_ENDPOINT` (or legacy `SMOLVM_CUDA_RPC`) exactly as the libcuda shim: unset/`vsock` (in-guest),
 //! `tcp:HOST:PORT`, or `unix:/path` (host-side testing).
 //!
 //! Semantics: work executes synchronously on the host, so `*Async` calls and
@@ -107,7 +107,7 @@ impl Write for Stream {
 }
 
 fn connect() -> Result<Stream, c_int> {
-    let spec = std::env::var("SMOLVM_CUDA_RPC").unwrap_or_default();
+    let spec = smolvm_cuda::config::transport_spec();
     if let Some(addr) = spec.strip_prefix("tcp:") {
         return std::net::TcpStream::connect(addr)
             .map(|s| {
@@ -124,9 +124,8 @@ fn connect() -> Result<Stream, c_int> {
     }
     #[cfg(target_os = "linux")]
     {
-        const HOST_CID: u32 = 2;
-        const CUDA_PORT: u32 = 7000;
-        vsock::VsockStream::connect_with_cid_port(HOST_CID, CUDA_PORT)
+        let (cid, port) = smolvm_cuda::config::vsock_default();
+        vsock::VsockStream::connect_with_cid_port(cid, port)
             .map(Stream::Vsock)
             .map_err(|_| CUDA_ERROR_NO_DEVICE)
     }


### PR DESCRIPTION
Exposes the already-decoupled core (transport = any Read+Write, backend = a trait, guest-RAM mapping = an embedder seam) as a consumable library + drop-in shim tool: shims read CUDA_REMOTE_ENDPOINT (legacy SMOLVM_CUDA_RPC still honored), a README documents both usage modes and honest coverage, and the crate carries publish metadata. No wire change. Stacked on #607.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/609">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->