### PR TITLE
Kubernetes containerd-shim-v2 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,8 +227,16 @@ jobs:
         env:
           LIBRARY_PATH: /usr/local/lib
           LD_LIBRARY_PATH: /usr/local/lib
-      # Note: Full VM integration tests require KVM + real libkrun.
-      # Run integration tests locally on a machine with KVM access.
+
+      # The Kubernetes containerd-shim runtime: its Task-state-machine and
+      # pod-lifecycle tests run on the MockBackend, so they need no KVM.
+      - name: Run K8s shim unit tests
+        run: cargo test -p smolvm-shim --target ${{ matrix.target }}
+        env:
+          LIBRARY_PATH: /usr/local/lib
+          LD_LIBRARY_PATH: /usr/local/lib
+      # Note: Full VM integration tests (and critest CRI conformance) require
+      # KVM + real libkrun. Run those locally on a machine with KVM access.
 
   # ==========================================================================
   # Windows Build & Lint (cross-compiled from Linux, mingw-w64 / GNU target)

--- a/.github/workflows/critest.yml
+++ b/.github/workflows/critest.yml
@@ -1,0 +1,106 @@
+name: critest (K8s CRI conformance)
+
+# CRI conformance for the Kubernetes containerd shim runtime. critest boots a
+# real microVM per pod, so it needs /dev/kvm — GitHub-hosted runners don't have
+# nested virt. It runs on a SELF-HOSTED runner labelled `kvm` that is provisioned
+# with:
+#   - containerd 2.x with the smolvm runtime registered
+#     ([plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.smolvm]
+#      runtime_type = 'io.containerd.smolvm.v2'), plus a CNI (e.g. the bridge
+#     plugin in /opt/cni/bin with a conflist in /etc/cni/net.d),
+#   - the smolvm runtime base under /var/lib/smolvm (libkrun, init.krun,
+#     smolvm-vmm, agent-rootfs) — see scripts/install-k8s-runtime.sh,
+#   - critest + crictl (cri-tools) on PATH,
+#   - the Rust toolchain with the x86_64-unknown-linux-musl target.
+#
+# Manual (workflow_dispatch) only: it requires a self-hosted KVM runner, so it is
+# not wired to push events — dispatch it once a labelled runner is online. Add a
+# `push: { branches: [k8s-shim] }` trigger then if you want it on every push.
+
+on:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  critest:
+    name: critest (self-hosted KVM)
+    runs-on: [self-hosted, linux, kvm]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build the shim (host) and agent (musl)
+        run: |
+          cargo build --release -p smolvm-shim
+          cargo build --release -p smolvm-agent --target x86_64-unknown-linux-musl
+
+      - name: Install shim + agent over the provisioned runtime base
+        run: |
+          sudo ./scripts/install-k8s-runtime.sh --shim target/release/containerd-shim-smolvm-v2
+          sudo cp target/x86_64-unknown-linux-musl/release/smolvm-agent \
+            /var/lib/smolvm/agent-rootfs/usr/local/bin/smolvm-agent
+
+      - name: Run critest (does not gate the job — the xfail check below does)
+        run: |
+          sudo crictl rmp -fa || true
+          # critest exits non-zero because of the known xfails; the next step
+          # decides pass/fail from the JUnit report, so don't let this fail here.
+          sudo critest \
+            -runtime-endpoint unix:///run/containerd/containerd.sock \
+            -runtime-handler smolvm \
+            --ginkgo.junit-report critest-report.xml | tee critest.log || true
+
+      - name: Conformance gate (fail only on unexpected regressions)
+        run: |
+          python3 - <<'PY'
+          import sys, re, xml.etree.ElementTree as ET
+
+          # A VM-per-pod runtime cannot pass these (Kata skips them too):
+          #   - host IPC / host Network namespace sharing (guest has its own kernel ns)
+          #   - mount propagation rshared/rslave/rprivate (needs a shared mount ns
+          #     across the VM boundary)
+          # And port-forward is deferred until the shim owns the stream via the
+          # containerd sandbox-controller API (proxying into the guest over vsock).
+          # See docs/kubernetes-runtime.md. Any failure NOT in this set is a real
+          # regression and fails the job.
+          KNOWN_XFAILS = [
+              r"HostIpc is true",
+              r"HostNetwork is true",
+              r"should support portforward",       # both portforward specs
+              r"mount with 'rprivate'",
+              r"mount with 'rshared'",
+              r"mount with 'rslave'",
+          ]
+
+          tree = ET.parse("critest-report.xml")
+          failures = [
+              tc.get("name")
+              for tc in tree.iter("testcase")
+              if tc.find("failure") is not None or tc.find("error") is not None
+          ]
+          unexpected = [
+              name for name in failures
+              if not any(re.search(p, name) for p in KNOWN_XFAILS)
+          ]
+
+          print(f"{len(failures)} failure(s); {len(unexpected)} unexpected regression(s).")
+          for name in failures:
+              tag = "REGRESSION" if name in unexpected else "xfail"
+              print(f"  [{tag}] {name}")
+
+          if unexpected:
+              print("\nFAIL: unexpected critest regressions above.")
+              sys.exit(1)
+          print("\nOK: only the documented VM-per-pod xfails failed.")
+          PY
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: critest-results
+          path: |
+            critest.log
+            critest-report.xml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -114,6 +114,120 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.4",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if 1.0.4",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if 1.0.4",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,7 +246,24 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -233,7 +364,7 @@ checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -265,6 +396,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,6 +420,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -317,6 +467,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
@@ -326,6 +482,20 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "cgroups-rs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efc46cf39fc5922b840030e0e5b378ce5caa9a824a675a95c6dec2c2c9ce9468"
+dependencies = [
+ "bit-vec",
+ "libc",
+ "log",
+ "nix 0.25.1",
+ "thiserror 1.0.69",
+ "zbus",
+]
 
 [[package]]
 name = "clap"
@@ -355,10 +525,10 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -392,6 +562,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "containerd-shim"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a886cc76f89aab452d78a9034a62426468175d795d0fb2ee57338fe075cbdc0a"
+dependencies = [
+ "async-trait",
+ "cgroups-rs",
+ "containerd-shim-protos",
+ "futures",
+ "go-flag",
+ "libc",
+ "log",
+ "mio 1.2.1",
+ "nix 0.31.3",
+ "oci-spec",
+ "serde",
+ "serde_json",
+ "sha2",
+ "signal-hook",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "which 8.0.4",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "containerd-shim-protos"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f714d7ff4f5e9d5f9b57d27152d70c8cab6639284e5c4f7dfaca774a7b94fa52"
+dependencies = [
+ "async-trait",
+ "protobuf",
+ "ttrpc",
+ "ttrpc-codegen",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,7 +637,20 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -415,6 +659,16 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -450,6 +704,41 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -505,7 +794,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -527,6 +816,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-new"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,7 +834,38 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -576,7 +907,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -586,12 +917,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
 dependencies = [
  "enumflags2_derive",
+ "serde",
 ]
 
 [[package]]
@@ -602,7 +946,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -619,6 +963,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -645,7 +1010,7 @@ version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
 ]
 
@@ -654,6 +1019,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
@@ -761,6 +1132,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,7 +1152,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -816,7 +1200,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "libc",
  "wasi",
@@ -829,7 +1213,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "libc",
  "r-efi 5.3.0",
@@ -843,11 +1227,31 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "getset"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "go-flag"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4a40c9ca507513f573aabaf6a8558173a1ac9aa1363d8de30c7f89b34f8d2b"
+dependencies = [
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -862,7 +1266,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -877,6 +1281,12 @@ checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -923,6 +1333,15 @@ dependencies = [
 
 [[package]]
 name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -938,6 +1357,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "http"
@@ -1140,6 +1568,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1158,6 +1592,16 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1205,6 +1649,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1226,10 +1679,25 @@ version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "futures-util",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "kqueue"
@@ -1286,7 +1754,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "windows-link",
 ]
 
@@ -1309,6 +1777,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1336,6 +1810,9 @@ name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lru-slab"
@@ -1372,6 +1849,15 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -1396,7 +1882,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
 dependencies = [
  "base64",
- "indexmap",
+ "indexmap 2.14.0",
  "metrics",
  "metrics-util",
  "quanta",
@@ -1469,15 +1955,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if 1.0.4",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if 1.0.4",
+ "libc",
+ "memoffset 0.7.1",
+ "pin-utils",
+]
+
+[[package]]
 name = "nix"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
  "bitflags 2.13.0",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
- "memoffset",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -1487,10 +2004,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.13.0",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases",
  "libc",
- "memoffset",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -1538,6 +2055,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "oci-spec"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8445a2631507cec628a15fdd6154b54a3ab3f20ed4fe9d73a3b8b7a4e1ba03a"
+dependencies = [
+ "const_format",
+ "derive_builder",
+ "getset",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1556,6 +2090,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,7 +2121,7 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -1591,10 +2141,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+dependencies = [
+ "fixedbitset",
+ "indexmap 1.9.3",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "pkg-config"
@@ -1608,11 +2185,11 @@ version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -1653,7 +2230,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -1675,7 +2261,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1685,6 +2271,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
+dependencies = [
+ "bytes",
+ "heck 0.3.3",
+ "itertools",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost",
+ "prost-types",
+ "tempfile",
+ "which 4.4.2",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
+dependencies = [
+ "bytes",
+ "prost",
+]
+
+[[package]]
+name = "protobuf"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-codegen"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d3976825c0014bbd2f3b34f0001876604fe87e0c86cd8fa54251530f1544ace"
+dependencies = [
+ "anyhow",
+ "once_cell",
+ "protobuf",
+ "protobuf-parse",
+ "regex",
+ "tempfile",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-parse"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4aeaa1f2460f1d348eeaeed86aea999ce98c1bded6f089ff8514c9d9dbdc973"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "log",
+ "protobuf",
+ "protobuf-support",
+ "tempfile",
+ "thiserror 1.0.69",
+ "which 4.4.2",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1931,7 +2619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "getrandom 0.2.17",
  "libc",
  "untrusted",
@@ -1972,7 +2660,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn",
+ "syn 2.0.117",
  "walkdir",
 ]
 
@@ -1994,6 +2682,19 @@ checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2001,7 +2702,7 @@ dependencies = [
  "bitflags 2.13.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2129,7 +2830,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2154,6 +2855,17 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2183,7 +2895,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -2196,7 +2908,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures",
  "digest",
 ]
@@ -2207,7 +2919,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures",
  "digest",
 ]
@@ -2226,6 +2938,16 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -2280,7 +3002,7 @@ checksum = "5f73d40463bba65efc9adc6370b56df76d563cc46e2482bba58351b4afb7535e"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",
- "cfg-if",
+ "cfg-if 1.0.4",
  "defmt 0.3.100",
  "heapless",
  "log",
@@ -2351,7 +3073,7 @@ dependencies = [
  "libc",
  "nix 0.27.1",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "ruzstd",
  "serde",
  "serde_json",
@@ -2407,6 +3129,7 @@ version = "1.5.2"
 dependencies = [
  "crossbeam-queue",
  "humantime",
+ "libc",
  "polling",
  "smoltcp",
  "socket2",
@@ -2472,6 +3195,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "smolvm-shim"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "containerd-shim",
+ "containerd-shim-protos",
+ "log",
+ "nix 0.27.1",
+ "serde",
+ "serde_json",
+ "smolvm",
+ "smolvm-protocol",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2500,10 +3240,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2533,7 +3302,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2556,7 +3325,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -2586,7 +3355,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2597,7 +3366,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2606,7 +3375,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -2690,7 +3459,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2740,6 +3509,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-vsock"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b319ef9394889dab2e1b4f0085b45ba11d0c79dc9d1a9d1afc057d009d0f1c7"
+dependencies = [
+ "bytes",
+ "futures",
+ "libc",
+ "tokio",
+ "vsock",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2747,8 +3529,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -2761,17 +3543,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -2848,7 +3660,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2910,6 +3722,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttrpc"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f12efe237328bbe3b3b50503627f7cc9e74cfae34ffa8438561916623cd8f50"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "byteorder",
+ "crossbeam",
+ "futures",
+ "libc",
+ "log",
+ "nix 0.26.4",
+ "protobuf",
+ "protobuf-codegen",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-vsock",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "ttrpc-codegen"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e5c657ef5cea6f6c6073c1be0787ba4482f42a569d4821e467daec795271f86"
+dependencies = [
+ "protobuf",
+ "protobuf-codegen",
+ "protobuf-support",
+ "ttrpc-compiler",
+]
+
+[[package]]
+name = "ttrpc-compiler"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aa71f4a44711b3b9cc10ed0c7e239ff0fe4b8e6c900a142fb3bb26401385718"
+dependencies = [
+ "derive-new",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "protobuf",
+ "protobuf-codegen",
+ "tempfile",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2931,7 +3792,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "static_assertions",
 ]
 
@@ -2940,6 +3801,17 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset 0.9.1",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unicase"
@@ -2952,6 +3824,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-xid"
@@ -3001,7 +3879,7 @@ version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -3029,7 +3907,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3058,10 +3936,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
+name = "uuid"
+version = "1.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+dependencies = [
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "vcpkg"
@@ -3134,7 +4029,7 @@ version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
@@ -3170,7 +4065,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3200,7 +4095,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -3226,7 +4121,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.13.0",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -3257,6 +4152,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "which"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3528,6 +4444,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wiremock"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3572,7 +4497,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -3583,10 +4508,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
- "indexmap",
+ "heck 0.5.0",
+ "indexmap 2.14.0",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3602,7 +4527,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3615,7 +4540,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -3634,7 +4559,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -3657,7 +4582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -3679,8 +4604,69 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "5.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28b97f866896a4be7aefd2b5a8e01bb6773d19a775d54ab28b4d094b9a4480e"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix 1.1.4",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.3",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e05ad887425eecf5e8384dc2406a4a9313eb73468712fc1cdea362eb4fe0469"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039ca249fee9559680f3a9f05b55e0761fee51af4f6c1e7d8c1f31e549721d2"
+dependencies = [
+ "serde",
+ "winnow 1.0.3",
+ "zvariant",
 ]
 
 [[package]]
@@ -3700,7 +4686,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3720,7 +4706,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3741,7 +4727,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3774,7 +4760,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3786,7 +4772,7 @@ dependencies = [
  "arbitrary",
  "crc32fast",
  "flate2",
- "indexmap",
+ "indexmap 2.14.0",
  "memchr",
  "zopfli",
 ]
@@ -3841,4 +4827,44 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cf057bb00bf5c9ad77abb6147b0ca4818236a1858416e9d988e40d6322fefa7"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.3",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8118ca6bda77bfc0ab51d660db0c955f2505eef854c9a449435bccb616933b31"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 1.0.3",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/smolvm-pack",
     "crates/smolvm-protocol",
     "crates/smolvm-registry",
+    "crates/smolvm-shim",
     "crates/smolvm-smolfile",
 ]
 resolver = "2"

--- a/crates/smolvm-agent/src/crun.rs
+++ b/crates/smolvm-agent/src/crun.rs
@@ -50,9 +50,17 @@ impl CrunCommand {
     /// instead of the default `/run/crun`, which may not be writable when the
     /// rootfs is an overlayfs with an initramfs lower layer.
     fn new() -> Self {
+        Self::new_with_cgroup(paths::CRUN_CGROUP_MANAGER)
+    }
+
+    /// Like [`new`](Self::new) but with an explicit cgroup manager. Pods pass
+    /// `"cgroupfs"` (after delegating a writable cgroup2) so crun creates a
+    /// per-container cgroup and enforces resource limits; everything else uses
+    /// the `disabled` default (libkrun mounts cgroup2 read-only by default).
+    fn new_with_cgroup(manager: &str) -> Self {
         let mut cmd = Command::new(paths::CRUN_PATH);
         cmd.args(["--root", paths::CRUN_ROOT_DIR]);
-        cmd.args(["--cgroup-manager", paths::CRUN_CGROUP_MANAGER]);
+        cmd.args(["--cgroup-manager", manager]);
         Self {
             cmd,
             pending_positionals: Vec::new(),
@@ -84,7 +92,18 @@ impl CrunCommand {
     /// The container id is deferred so later builder calls (e.g.
     /// `console_socket`) can still insert options before the positional.
     pub fn run(bundle_dir: &Path, container_id: &str) -> Self {
-        let mut c = Self::new();
+        Self::run_managed(bundle_dir, container_id, paths::CRUN_CGROUP_MANAGER)
+    }
+
+    /// [`run`](Self::run) with the cgroupfs manager, so crun creates a
+    /// per-container cgroup and enforces the spec's resource limits (memory/
+    /// pids → OOM). Only safe once cgroup2 is writable and delegated.
+    pub fn run_cgroupfs(bundle_dir: &Path, container_id: &str) -> Self {
+        Self::run_managed(bundle_dir, container_id, "cgroupfs")
+    }
+
+    fn run_managed(bundle_dir: &Path, container_id: &str, manager: &str) -> Self {
+        let mut c = Self::new_with_cgroup(manager);
         c.cmd
             .args(["run", "--bundle", &bundle_dir.to_string_lossy()]);
         c.pending_positionals = vec![container_id.to_string()];
@@ -100,7 +119,31 @@ impl CrunCommand {
     /// size / resize, which crun does not propagate in stdio-relay mode. crun's own
     /// stdio is unused, so it's nulled.
     pub fn run_with_console(bundle_dir: &Path, container_id: &str, console_socket: &Path) -> Self {
-        let mut c = Self::new();
+        Self::run_with_console_managed(
+            bundle_dir,
+            container_id,
+            console_socket,
+            paths::CRUN_CGROUP_MANAGER,
+        )
+    }
+
+    /// [`run_with_console`](Self::run_with_console) with the cgroupfs manager
+    /// (pod containers; see [`run_cgroupfs`](Self::run_cgroupfs)).
+    pub fn run_with_console_cgroupfs(
+        bundle_dir: &Path,
+        container_id: &str,
+        console_socket: &Path,
+    ) -> Self {
+        Self::run_with_console_managed(bundle_dir, container_id, console_socket, "cgroupfs")
+    }
+
+    fn run_with_console_managed(
+        bundle_dir: &Path,
+        container_id: &str,
+        console_socket: &Path,
+        manager: &str,
+    ) -> Self {
+        let mut c = Self::new_with_cgroup(manager);
         c.cmd.args([
             "run",
             "--bundle",
@@ -137,11 +180,27 @@ impl CrunCommand {
         if let Some(wd) = workdir {
             c.cmd.args(["--cwd", wd]);
         }
-        c.cmd.arg(container_id).args(command);
+        // Defer the container id + command so `.user()` (and any later option)
+        // can still insert flags before the positionals in `spawn`.
+        c.pending_positionals = std::iter::once(container_id.to_string())
+            .chain(command.iter().cloned())
+            .collect();
         c.cmd.stdin(Stdio::null());
         c.cmd.stdout(Stdio::null());
         c.cmd.stderr(Stdio::piped());
         c
+    }
+
+    /// Run the exec/run as `--user UID[:GID]` (or a username crun resolves against
+    /// the container's /etc/passwd). No-op when `user` is None. Used so `crun exec`
+    /// honours the container's configured user (CRI RunAsUser/RunAsUserName) —
+    /// without it, exec defaults to uid 0. Inserted before the deferred positional
+    /// arguments.
+    pub fn user(mut self, user: Option<&str>) -> Self {
+        if let Some(u) = user.filter(|s| !s.is_empty()) {
+            self.cmd.arg("--user").arg(u);
+        }
+        self
     }
 
     /// Start a container: `crun start <id>`
@@ -186,10 +245,33 @@ impl CrunCommand {
         c
     }
 
+    /// Execute a command in a running container from a full OCI Process spec:
+    /// `crun exec --process <file> <id>`. Unlike the flag-based [`Self::exec`],
+    /// this honors every field of the process — notably `user.additionalGids`
+    /// (CRI SupplementalGroups), which crun exec has no flag for. Non-TTY
+    /// (piped) stdio; the process file must set `terminal: false`.
+    pub fn exec_with_process(container_id: &str, process_file: &Path) -> Self {
+        let mut c = Self::new();
+        c.cmd.arg("exec").arg("--process").arg(process_file);
+        c.pending_positionals = vec![container_id.to_string()];
+        c
+    }
+
     /// Kill a container: `crun kill <id> <signal>`
     pub fn kill(container_id: &str, signal: &str) -> Self {
         let mut c = Self::new();
         c.cmd.args(["kill", container_id, signal]);
+        c
+    }
+
+    /// Kill every process in a container: `crun kill --all <id> <signal>`
+    ///
+    /// Used by the pod-container path (`PodSignal { all: true }`). May fail
+    /// when no per-container cgroup exists (cgroup manager is disabled);
+    /// callers fall back to signalling the process tree directly.
+    pub fn kill_all(container_id: &str, signal: &str) -> Self {
+        let mut c = Self::new();
+        c.cmd.args(["kill", "--all", container_id, signal]);
         c
     }
 

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -85,6 +85,7 @@ mod docker_bridge;
 mod network;
 mod oci;
 mod paths;
+mod pod;
 mod process;
 #[cfg(target_os = "linux")]
 mod pty;
@@ -1882,6 +1883,14 @@ fn handle_connection(stream: &mut impl ReadWrite) -> Result<(), Box<dyn std::err
             continue;
         }
 
+        // PodStart streams the pod container's (or exec process's) I/O on
+        // this connection — Started → Stdout/Stderr → Exited, with Stdin and
+        // Resize handled by the interactive pumps — like interactive Run.
+        if let AgentRequest::PodStart { .. } = &request {
+            pod::handle_pod_start(stream, request)?;
+            continue;
+        }
+
         // Handle Pull with progress streaming
         if let AgentRequest::Pull {
             ref image,
@@ -2223,6 +2232,40 @@ fn handle_request(
             "streaming file read must be handled at connection level",
             error_codes::INTERNAL_ERROR,
         ),
+
+        // Pod-container lifecycle (containerd shim v2 datapath, see pod.rs).
+        AgentRequest::PodCreate {
+            id,
+            rootfs_rel,
+            spec_json,
+            tty,
+        } => pod::handle_pod_create(&id, &rootfs_rel, &spec_json, tty),
+
+        // PodStart streams on the connection; routed in handle_connection.
+        AgentRequest::PodStart { .. } => AgentResponse::error(
+            "pod start must be handled at connection level",
+            error_codes::INTERNAL_ERROR,
+        ),
+
+        AgentRequest::PodExec {
+            id,
+            exec_id,
+            process_json,
+            tty,
+        } => pod::handle_pod_exec(&id, &exec_id, &process_json, tty),
+
+        AgentRequest::PodSignal {
+            id,
+            exec_id,
+            signal,
+            all,
+        } => pod::handle_pod_signal(&id, exec_id.as_deref(), signal, all),
+
+        AgentRequest::PodPids { id } => pod::handle_pod_pids(&id),
+
+        AgentRequest::PodStats { id } => pod::handle_pod_stats(&id),
+
+        AgentRequest::PodDelete { id, exec_id } => pod::handle_pod_delete(&id, exec_id.as_deref()),
     }
 }
 
@@ -3018,7 +3061,13 @@ fn handle_interactive_run(
     };
 
     // Send Exited response
-    send_response(stream, &AgentResponse::Exited { exit_code })?;
+    send_response(
+        stream,
+        &AgentResponse::Exited {
+            exit_code,
+            oom: false,
+        },
+    )?;
     maybe_cleanup(&prepared.workload_id);
 
     Ok(())
@@ -3524,6 +3573,7 @@ fn spawn_exec_in_container(
                 workdir,
                 console.path(),
             )
+            .user(launch.user.as_deref())
             .spawn()?;
             match console.recv_master(std::time::Duration::from_secs(3)) {
                 Ok(pty_master) => {
@@ -3567,6 +3617,7 @@ fn spawn_exec_in_container(
         // SAFETY: slave_fd is a valid open fd from openpty.
         let child = unsafe {
             crun::CrunCommand::exec(container_id, env, command, workdir, true)
+                .user(launch.user.as_deref())
                 .stdin_from_fd(libc::dup(slave_raw))
                 .stdout_from_fd(libc::dup(slave_raw))
                 .stderr_from_fd(libc::dup(slave_raw))
@@ -3576,6 +3627,7 @@ fn spawn_exec_in_container(
         Ok((child, Some(pty_master)))
     } else {
         let child = crun::CrunCommand::exec(container_id, env, command, workdir, false)
+            .user(launch.user.as_deref())
             .stdin_piped()
             .capture_output()
             .spawn()?;
@@ -3727,10 +3779,7 @@ fn spawn_interactive_command(
     persistent_overlay_id: Option<&str>,
     unprivileged: bool,
 ) -> Result<(Child, Option<pty::PtyMaster>), Box<dyn std::error::Error>> {
-    use std::io::Read as _;
-    use std::os::unix::io::AsRawFd as _;
     use std::path::Path;
-    use std::sync::atomic::Ordering;
 
     if launch.command.is_empty() {
         return Err("empty command".into());
@@ -3795,14 +3844,43 @@ fn spawn_interactive_command(
         "spawning interactive container with crun"
     );
 
+    // The single-container `Run` path keeps cgroups disabled (its VM is the
+    // limit); per-container cgroups are a pod-only concern.
+    spawn_crun_run(&bundle_path, &container_id, tty, false)
+}
+
+/// Launch a container with `crun run` and hand back the child plus the PTY
+/// master when `tty` is set (console-socket handshake, with the stdio-PTY
+/// fallback). This is the spawn tail shared by interactive `Run`
+/// ([`spawn_interactive_command`]) and pod containers
+/// ([`pod::handle_pod_start`] → `start_init_process`); the bundle must
+/// already be written.
+#[cfg(target_os = "linux")]
+fn spawn_crun_run(
+    bundle_path: &std::path::Path,
+    container_id: &str,
+    tty: bool,
+    cgroups: bool,
+) -> Result<(Child, Option<pty::PtyMaster>), Box<dyn std::error::Error>> {
+    use std::io::Read as _;
+    use std::os::unix::io::AsRawFd as _;
+    use std::sync::atomic::Ordering;
+
     if tty {
         // Preferred path: take the container's console over a socket so the
         // master we hold is the process's real tty (resize works).
         if CONSOLE_SOCKET_WORKS.load(Ordering::Relaxed) {
-            let console = pty::ConsoleSocket::bind(&container_id)?;
-            let mut child =
-                crun::CrunCommand::run_with_console(&bundle_path, &container_id, console.path())
-                    .spawn()?;
+            let console = pty::ConsoleSocket::bind(container_id)?;
+            let cmd = if cgroups {
+                crun::CrunCommand::run_with_console_cgroupfs(
+                    bundle_path,
+                    container_id,
+                    console.path(),
+                )
+            } else {
+                crun::CrunCommand::run_with_console(bundle_path, container_id, console.path())
+            };
+            let mut child = cmd.spawn()?;
             match console.recv_master(std::time::Duration::from_secs(3)) {
                 Ok(pty_master) => {
                     let _ = pty_master.set_window_size(80, 24);
@@ -3839,7 +3917,7 @@ fn spawn_interactive_command(
                     // The failed `crun run --console-socket` may have registered
                     // container state under this id; clear it so the fallback
                     // `crun run` with the same id doesn't hit "already exists".
-                    let _ = crun::CrunCommand::delete(&container_id, true).output();
+                    let _ = crun::CrunCommand::delete(container_id, true).output();
                 }
             }
         }
@@ -3848,9 +3926,13 @@ fn spawn_interactive_command(
         let (pty_master, slave_fd) = pty::open_pty(80, 24)?;
         let slave_raw = slave_fd.as_raw_fd();
         // SAFETY: slave_fd is a valid open fd from openpty.
+        let base = if cgroups {
+            crun::CrunCommand::run_cgroupfs(bundle_path, container_id)
+        } else {
+            crun::CrunCommand::run(bundle_path, container_id)
+        };
         let child = unsafe {
-            crun::CrunCommand::run(&bundle_path, &container_id)
-                .stdin_from_fd(libc::dup(slave_raw))
+            base.stdin_from_fd(libc::dup(slave_raw))
                 .stdout_from_fd(libc::dup(slave_raw))
                 .stderr_from_fd(libc::dup(slave_raw))
                 .spawn()?
@@ -3858,10 +3940,12 @@ fn spawn_interactive_command(
         drop(slave_fd);
         Ok((child, Some(pty_master)))
     } else {
-        let child = crun::CrunCommand::run(&bundle_path, &container_id)
-            .stdin_piped()
-            .capture_output()
-            .spawn()?;
+        let base = if cgroups {
+            crun::CrunCommand::run_cgroupfs(bundle_path, container_id)
+        } else {
+            crun::CrunCommand::run(bundle_path, container_id)
+        };
+        let child = base.stdin_piped().capture_output().spawn()?;
         Ok((child, None))
     }
 }
@@ -5462,7 +5546,13 @@ fn handle_interactive_vm_exec(
     };
 
     // Send Exited response
-    send_response(stream, &AgentResponse::Exited { exit_code })?;
+    send_response(
+        stream,
+        &AgentResponse::Exited {
+            exit_code,
+            oom: false,
+        },
+    )?;
 
     Ok(())
 }

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -4932,7 +4932,10 @@ fn handle_run(
     // USER stays root. Bare-VM exec (`handle_vm_exec`) never reaches here, so it
     // is unaffected.
     let image_user = if user.is_none() {
-        storage::query_image(image).ok().flatten().and_then(|i| i.user)
+        storage::query_image(image)
+            .ok()
+            .flatten()
+            .and_then(|i| i.user)
     } else {
         None
     };

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -4873,6 +4873,7 @@ fn run_in_keepalive_container(
             launch.workdir.as_deref(),
             false,
         )
+        .user(launch.user.as_deref())
         .capture_output()
         .stdin_piped()
         .spawn()?;
@@ -4888,6 +4889,7 @@ fn run_in_keepalive_container(
             launch.workdir.as_deref(),
             false,
         )
+        .user(launch.user.as_deref())
         .capture_output()
         .stdin_null()
         .output()?
@@ -4922,6 +4924,19 @@ fn handle_run(
     let mut env = env.to_vec();
     ssh_agent::inject_into_env(&mut env);
     let env = &env[..];
+
+    // Honor the image's default USER when the request doesn't pin one, so every
+    // container-run path (the keep-alive `crun exec` below and the fresh-container
+    // fallback) runs as the uid the image expects — matching the workload
+    // container itself. An explicit request user still wins; an image with no
+    // USER stays root. Bare-VM exec (`handle_vm_exec`) never reaches here, so it
+    // is unaffected.
+    let image_user = if user.is_none() {
+        storage::query_image(image).ok().flatten().and_then(|i| i.user)
+    } else {
+        None
+    };
+    let user = user.or(image_user.as_deref());
 
     // On a persistent machine, run inside the long-lived keep-alive container so
     // backgrounded processes survive across execs. Fall back to a fresh container

--- a/crates/smolvm-agent/src/oci.rs
+++ b/crates/smolvm-agent/src/oci.rs
@@ -78,7 +78,11 @@ pub struct OciConsoleSize {
 pub struct OciUser {
     pub uid: u32,
     pub gid: u32,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        rename = "additionalGids",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub additional_gids: Vec<u32>,
 }
 

--- a/crates/smolvm-agent/src/pod.rs
+++ b/crates/smolvm-agent/src/pod.rs
@@ -1,0 +1,1803 @@
+//! Kubernetes pod-container support (containerd shim v2 datapath).
+//!
+//! The host-side shim (`containerd-shim-smolvm-v2`) drives ordinary OCI
+//! containers inside the sandbox VM through six requests: `PodCreate`
+//! (validate + stash), `PodStart` (run with streaming I/O on the request
+//! connection), `PodExec` (stash an exec process), `PodSignal`, `PodPids`
+//! and `PodDelete`. See `docs/kubernetes-runtime.md` for the architecture.
+//!
+//! Unlike the existing `Run` path, the container's rootfs is NOT an image the
+//! agent pulled itself: containerd unpacks the snapshotter mount on the host
+//! and the shim bind-mounts it under the sandbox's single shared virtiofs dir
+//! (shares are fixed at VM boot; pod containers are created afterwards). The
+//! guest therefore resolves each container's rootfs as
+//! `<VIRTIOFS_MOUNT_ROOT>/<POD_SHARE_TAG>/<rootfs_rel>`.
+//!
+//! This module follows the crate's existing conventions: plain std sync
+//! primitives + threads (no async), crun via [`crate::crun::CrunCommand`],
+//! and the same `Started` → `Stdout`/`Stderr` → `Exited` streaming contract
+//! as interactive `Run` (the I/O pumps `run_interactive_loop` /
+//! `run_interactive_loop_pty` are reused directly).
+
+use std::collections::HashMap;
+use std::path::{Component, Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+use smolvm_protocol::{error_codes, AgentResponse};
+use tracing::{info, warn};
+
+use crate::crun;
+use crate::paths;
+
+/// The fixed virtiofs share tag the shim uses for the sandbox's single shared
+/// directory. Every pod container's rootfs lives underneath it.
+pub const POD_SHARE_TAG: &str = "podshare";
+
+/// Guest directory holding per-pod-container state (crun bundle dirs).
+const POD_STATE_DIR: &str = "/storage/containers/pods";
+
+// ============================================================================
+// Registry
+// ============================================================================
+
+/// Lifecycle of a pod container inside the guest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PodState {
+    /// Stashed by `PodCreate`; nothing running.
+    Created,
+    /// Init process launched by `PodStart`.
+    Running,
+    /// Init process exited (exit status already streamed).
+    Exited,
+}
+
+/// Process settings extracted from an OCI Process JSON object (the container
+/// init's `process` from the spec, or an exec's `process_json`).
+#[derive(Debug, Clone)]
+struct StashedProcess {
+    /// argv (OCI `process.args`).
+    args: Vec<String>,
+    /// Environment as (key, value) pairs (from OCI `process.env` "K=V" list).
+    env: Vec<(String, String)>,
+    /// Working directory (OCI `process.cwd`), if given.
+    cwd: Option<String>,
+    /// "uid[:gid]" string derived from OCI `process.user`, resolved against
+    /// the rootfs at start time via `oci::resolve_process_identity`. When only a
+    /// username is given (CRI `RunAsUserName`), that name is used and resolved
+    /// against the rootfs /etc/passwd.
+    user: Option<String>,
+    /// Supplemental group IDs (OCI `process.user.additionalGids`, from the CRI
+    /// `SupplementalGroups`). Applied to the container process.
+    additional_gids: Vec<u32>,
+}
+
+/// A CRI mount (volume, or a generated file like resolv.conf/hosts/hostname) the
+/// shim materialized into the pod share; the agent copies it into the container's
+/// writable overlay at `destination` before start. `source` is the guest path of
+/// the shim's copy under the virtiofs pod share.
+#[derive(Debug, Clone)]
+struct PodMount {
+    /// Guest path of the shim's copy (under `<VIRTIOFS>/podshare/<id>/mounts/N`).
+    source: String,
+    /// Absolute container path to place it at.
+    destination: String,
+}
+
+/// An exec process registered by `PodExec`, started by `PodStart { exec_id }`.
+#[derive(Debug, Clone)]
+struct ExecEntry {
+    process: StashedProcess,
+    /// Raw OCI Process JSON from containerd. Used to run `crun exec --process`
+    /// (which honors supplemental groups) when the process has additionalGids —
+    /// the flag-based path can only set uid:gid.
+    process_json: String,
+    /// Allocate a PTY for the exec process.
+    tty: bool,
+    /// PID of the `crun exec` child while the exec is running. crun cannot
+    /// target exec processes by id, so `PodSignal { exec_id }` kills this pid
+    /// (or its first child — the actual exec'd process — when visible in
+    /// /proc) directly with kill(2).
+    pid: Option<u32>,
+}
+
+/// Everything the agent knows about one pod container.
+#[derive(Debug, Clone)]
+struct PodContainer {
+    /// Resolved guest rootfs path under the shared virtiofs mount.
+    rootfs: PathBuf,
+    /// Init process settings stashed at `PodCreate`.
+    process: StashedProcess,
+    /// Mount the rootfs read-only (OCI `root.readonly`).
+    readonly_rootfs: bool,
+    /// Container UTS hostname (OCI `hostname`, from the pod sandbox).
+    hostname: Option<String>,
+    /// CRI mounts (volumes + generated /etc files) to materialize into the
+    /// writable overlay before start.
+    mounts: Vec<PodMount>,
+    /// OCI `process.noNewPrivileges` (CRI allowPrivilegeEscalation=false). Only
+    /// set by containers that request it, so this is false for most.
+    no_new_privileges: bool,
+    /// The raw host OCI spec. Its securityContext fields are grafted onto the
+    /// guest bundle so the container runs with exactly the capabilities,
+    /// seccomp profile, rlimits, masked/readonly paths, and sysctls Kubernetes
+    /// requested — not smolvm's full-capability VM default (which critest
+    /// rejects). Stored whole so new fields don't need new plumbing.
+    host_spec: serde_json::Value,
+    /// Allocate a PTY for the init process.
+    tty: bool,
+    state: PodState,
+    /// Container init PID (guest view), cached lazily from `crun state`.
+    init_pid: Option<u32>,
+    /// Registered exec processes by exec_id.
+    execs: HashMap<String, ExecEntry>,
+}
+
+/// Global id → container registry. A plain Mutex-guarded map: pod request
+/// rates are tiny (a handful of containers per sandbox) and every handler
+/// takes the lock only to read/update bookkeeping — never across a spawned
+/// process or a streaming loop.
+fn registry() -> &'static Mutex<HashMap<String, PodContainer>> {
+    static PODS: OnceLock<Mutex<HashMap<String, PodContainer>>> = OnceLock::new();
+    PODS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Lock the registry, recovering from a poisoned lock (a panic in another
+/// connection thread must not wedge every future pod request).
+fn lock_registry() -> std::sync::MutexGuard<'static, HashMap<String, PodContainer>> {
+    registry()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+// ============================================================================
+// Validation / parsing helpers
+// ============================================================================
+
+/// Validate a container or exec id: non-empty, bounded, and made of the
+/// characters containerd task ids use. The id becomes a path component of the
+/// bundle dir and a crun positional, so this also keeps path traversal and
+/// option injection out.
+fn validate_id(id: &str) -> Result<(), String> {
+    if id.is_empty() {
+        return Err("id must not be empty".into());
+    }
+    if id.len() > 200 {
+        return Err("id too long (max 200 chars)".into());
+    }
+    if id == "." || id == ".." || id.starts_with('-') {
+        return Err(format!("invalid id: {id}"));
+    }
+    if !id
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '-'))
+    {
+        return Err(format!(
+            "invalid id '{id}': only [A-Za-z0-9_.-] characters allowed"
+        ));
+    }
+    Ok(())
+}
+
+/// Resolve a container rootfs path relative to the sandbox's shared virtiofs
+/// mount: `<VIRTIOFS_MOUNT_ROOT>/<POD_SHARE_TAG>/<rootfs_rel>`. Rejects
+/// absolute paths and any non-plain component (`..`, etc.) so the shim can't
+/// point a bundle outside the shared dir.
+fn resolve_pod_rootfs(rootfs_rel: &str) -> Result<PathBuf, String> {
+    if rootfs_rel.is_empty() {
+        return Err("rootfs_rel must not be empty".into());
+    }
+    let rel = Path::new(rootfs_rel);
+    if rel.is_absolute() {
+        return Err("rootfs_rel must be relative to the pod share".into());
+    }
+    for component in rel.components() {
+        match component {
+            Component::Normal(_) => {}
+            _ => {
+                return Err(format!(
+                    "rootfs_rel '{rootfs_rel}' must be a plain relative path (no '..' or '.')"
+                ))
+            }
+        }
+    }
+    Ok(Path::new(paths::VIRTIOFS_MOUNT_ROOT)
+        .join(POD_SHARE_TAG)
+        .join(rel))
+}
+
+/// Extract the fields the agent grafts onto its own guest bundle from an OCI
+/// Process JSON object: args/env/cwd/user. Host-specific fields
+/// (capabilities, rlimits, apparmor, ...) are intentionally ignored — the
+/// guest bundle template supplies VM-grade defaults (the microVM is the
+/// security boundary).
+fn parse_oci_process(process: &serde_json::Value) -> Result<StashedProcess, String> {
+    let args: Vec<String> = process
+        .get("args")
+        .and_then(|a| a.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    if args.is_empty() {
+        return Err("process.args missing or empty".into());
+    }
+
+    let env: Vec<(String, String)> = process
+        .get("env")
+        .and_then(|e| e.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str())
+                .filter_map(|entry| entry.split_once('='))
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let cwd = process
+        .get("cwd")
+        .and_then(|c| c.as_str())
+        .filter(|s| !s.is_empty())
+        .map(String::from);
+
+    // OCI Process.user carries numeric uid/gid, or a username (CRI
+    // RunAsUserName). Render as "uid:gid" (numeric) or the username for
+    // oci::resolve_process_identity, which accepts either.
+    let user = process.get("user").and_then(|u| {
+        if let Some(uid) = u.get("uid").and_then(|v| v.as_u64()) {
+            Some(match u.get("gid").and_then(|v| v.as_u64()) {
+                Some(gid) => format!("{uid}:{gid}"),
+                None => uid.to_string(),
+            })
+        } else {
+            u.get("username")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(String::from)
+        }
+    });
+
+    // Supplemental groups (CRI SupplementalGroups → OCI additionalGids).
+    let additional_gids: Vec<u32> = process
+        .get("user")
+        .and_then(|u| u.get("additionalGids"))
+        .and_then(|g| g.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_u64().map(|n| n as u32))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Ok(StashedProcess {
+        args,
+        env,
+        cwd,
+        user,
+        additional_gids,
+    })
+}
+
+/// Extract the CRI mounts the shim materialized into the pod share: those whose
+/// `source` was rewritten to a path under the guest pod-share mount. Everything
+/// else (proc/sysfs/tmpfs/... provided by the default OCI spec) is ignored.
+fn parse_pod_mounts(spec: &serde_json::Value) -> Vec<PodMount> {
+    let prefix = format!("{}/{}/", paths::VIRTIOFS_MOUNT_ROOT, POD_SHARE_TAG);
+    spec.get("mounts")
+        .and_then(|m| m.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|m| {
+                    let source = m.get("source").and_then(|s| s.as_str())?;
+                    if !source.starts_with(&prefix) {
+                        return None;
+                    }
+                    let destination = m.get("destination").and_then(|d| d.as_str())?;
+                    if destination.is_empty() {
+                        return None;
+                    }
+                    Some(PodMount {
+                        source: source.to_string(),
+                        destination: destination.to_string(),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Per-container state directory (holds the crun bundle).
+fn pod_dir(id: &str) -> PathBuf {
+    PathBuf::from(POD_STATE_DIR).join(id)
+}
+
+// ============================================================================
+// PID helpers
+// ============================================================================
+
+/// Container init PID from `crun state <id>` (guest view). None if the
+/// container isn't registered/running or the state JSON is unusable.
+fn crun_state_pid(id: &str) -> Option<u32> {
+    let output = crun::CrunCommand::state(id)
+        .capture_output()
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
+    let pid = v.get("pid")?.as_i64()?;
+    u32::try_from(pid).ok().filter(|p| *p > 0)
+}
+
+/// Block until `crun run` has registered the container (its state DB entry
+/// exists, so `crun exec`/`state`/`kill` can find it) or the container exits or
+/// a short deadline elapses. Returns the init pid if the container came up.
+///
+/// `crun run` forks and returns before the container is registered; without this
+/// wait a client that execs immediately after StartContainer (critest does) hits
+/// "container not found". crun writes state before starting the container's
+/// process, so this is normally a few ms; the deadline caps a container that
+/// exits instantly (nothing to wait for) so Start still returns promptly.
+#[cfg(target_os = "linux")]
+fn wait_for_crun_running(id: &str, child: &mut std::process::Child) -> Option<u32> {
+    use std::time::{Duration, Instant};
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        if let Some(pid) = crun_state_pid(id) {
+            return Some(pid);
+        }
+        // The container already exited (instant-exit command) — crun tore down
+        // its state, so there is nothing left to wait for.
+        if matches!(child.try_wait(), Ok(Some(_))) {
+            return None;
+        }
+        if Instant::now() >= deadline {
+            return None;
+        }
+        std::thread::sleep(Duration::from_millis(5));
+    }
+}
+
+/// Non-Linux builds don't run crun; report no pid without polling.
+#[cfg(not(target_os = "linux"))]
+fn wait_for_crun_running(_id: &str, _child: &mut std::process::Child) -> Option<u32> {
+    None
+}
+
+/// Snapshot of (pid, ppid) pairs from /proc. Empty when /proc is unreadable
+/// (non-Linux test builds).
+fn proc_parent_pairs() -> Vec<(u32, u32)> {
+    let mut pairs = Vec::new();
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return pairs;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(pid) = name.to_str().and_then(|s| s.parse::<u32>().ok()) else {
+            continue;
+        };
+        let Ok(stat) = std::fs::read_to_string(entry.path().join("stat")) else {
+            continue;
+        };
+        // /proc/<pid>/stat: "pid (comm) state ppid ..." — comm may itself
+        // contain spaces and parens, so split at the LAST ')'.
+        let Some((_, rest)) = stat.rsplit_once(')') else {
+            continue;
+        };
+        let mut fields = rest.split_whitespace();
+        let _state = fields.next();
+        if let Some(ppid) = fields.next().and_then(|p| p.parse::<u32>().ok()) {
+            pairs.push((pid, ppid));
+        }
+    }
+    pairs
+}
+
+/// `root` plus all its descendants, from a single /proc snapshot. Used for
+/// `PodPids` — with the crun cgroup manager disabled there is no per-container
+/// cgroup.procs file to read, so the process tree under init IS the container.
+fn descendant_pids(root: u32) -> Vec<u32> {
+    let pairs = proc_parent_pairs();
+    let mut pids = vec![root];
+    let mut i = 0;
+    while i < pids.len() {
+        let parent = pids[i];
+        for (pid, ppid) in &pairs {
+            if *ppid == parent && !pids.contains(pid) {
+                pids.push(*pid);
+            }
+        }
+        i += 1;
+    }
+    pids
+}
+
+/// First child of `parent` visible in /proc. Used to refine a tracked
+/// `crun exec` monitor pid to the actual exec'd process.
+fn first_child_pid(parent: u32) -> Option<u32> {
+    proc_parent_pairs()
+        .into_iter()
+        .find(|(_, ppid)| *ppid == parent)
+        .map(|(pid, _)| pid)
+}
+
+/// kill(2) wrapper. Returns true if the signal was delivered.
+fn kill_pid(pid: u32, signal: u32) -> bool {
+    // SAFETY: plain kill(2); no memory involved.
+    unsafe { libc::kill(pid as libc::pid_t, signal as libc::c_int) == 0 }
+}
+
+// ============================================================================
+// PodCreate / PodExec — stash only
+// ============================================================================
+
+/// `PodCreate`: validate the request and stash the container's launch
+/// settings. Nothing runs until `PodStart`; no dirs are created either, so a
+/// failed create leaves zero guest state.
+pub fn handle_pod_create(id: &str, rootfs_rel: &str, spec_json: &str, tty: bool) -> AgentResponse {
+    if let Err(e) = validate_id(id) {
+        return AgentResponse::error(e, error_codes::INVALID_REQUEST);
+    }
+    let rootfs = match resolve_pod_rootfs(rootfs_rel) {
+        Ok(p) => p,
+        Err(e) => return AgentResponse::error(e, error_codes::INVALID_REQUEST),
+    };
+    let spec: serde_json::Value = match serde_json::from_str(spec_json) {
+        Ok(v) => v,
+        Err(e) => {
+            return AgentResponse::error(
+                format!("invalid spec_json: {e}"),
+                error_codes::INVALID_REQUEST,
+            )
+        }
+    };
+    let Some(process_value) = spec.get("process") else {
+        return AgentResponse::error("spec_json has no process", error_codes::INVALID_REQUEST);
+    };
+    let process = match parse_oci_process(process_value) {
+        Ok(p) => p,
+        Err(e) => return AgentResponse::error(e, error_codes::INVALID_REQUEST),
+    };
+    let readonly_rootfs = spec
+        .get("root")
+        .and_then(|r| r.get("readonly"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let hostname = spec
+        .get("hostname")
+        .and_then(|h| h.as_str())
+        .filter(|s| !s.is_empty())
+        .map(String::from);
+
+    let mounts = parse_pod_mounts(&spec);
+    let no_new_privileges = spec
+        .pointer("/process/noNewPrivileges")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let mut reg = lock_registry();
+    if reg.contains_key(id) {
+        return AgentResponse::error(
+            format!("pod container '{id}' already exists"),
+            error_codes::INVALID_REQUEST,
+        );
+    }
+    info!(id = %id, rootfs = %rootfs.display(), tty = tty, mounts = mounts.len(), "pod container created (stashed)");
+    reg.insert(
+        id.to_string(),
+        PodContainer {
+            rootfs,
+            process,
+            readonly_rootfs,
+            hostname,
+            mounts,
+            no_new_privileges,
+            host_spec: spec,
+            tty,
+            state: PodState::Created,
+            init_pid: None,
+            execs: HashMap::new(),
+        },
+    );
+    AgentResponse::ok(None)
+}
+
+/// `PodExec`: stash an exec process spec for a known container. Started later
+/// by `PodStart { exec_id }`.
+pub fn handle_pod_exec(id: &str, exec_id: &str, process_json: &str, tty: bool) -> AgentResponse {
+    if let Err(e) = validate_id(exec_id) {
+        return AgentResponse::error(e, error_codes::INVALID_REQUEST);
+    }
+    let process_value: serde_json::Value = match serde_json::from_str(process_json) {
+        Ok(v) => v,
+        Err(e) => {
+            return AgentResponse::error(
+                format!("invalid process_json: {e}"),
+                error_codes::INVALID_REQUEST,
+            )
+        }
+    };
+    let process = match parse_oci_process(&process_value) {
+        Ok(p) => p,
+        Err(e) => return AgentResponse::error(e, error_codes::INVALID_REQUEST),
+    };
+
+    let mut reg = lock_registry();
+    let Some(pod) = reg.get_mut(id) else {
+        return AgentResponse::error(
+            format!("unknown pod container: {id}"),
+            error_codes::NOT_FOUND,
+        );
+    };
+    if pod.execs.contains_key(exec_id) {
+        return AgentResponse::error(
+            format!("exec '{exec_id}' already registered for container '{id}'"),
+            error_codes::INVALID_REQUEST,
+        );
+    }
+    info!(id = %id, exec_id = %exec_id, tty = tty, "pod exec process registered");
+    pod.execs.insert(
+        exec_id.to_string(),
+        ExecEntry {
+            process,
+            process_json: process_json.to_string(),
+            tty,
+            pid: None,
+        },
+    );
+    AgentResponse::ok(None)
+}
+
+// ============================================================================
+// PodSignal / PodPids / PodDelete
+// ============================================================================
+
+/// `PodSignal`: signal the container's init (optionally the whole container
+/// with `all`) or one exec process.
+pub fn handle_pod_signal(id: &str, exec_id: Option<&str>, signal: u32, all: bool) -> AgentResponse {
+    // Snapshot what we need under the lock; the actual kills happen after
+    // release (never hold the registry across a subprocess).
+    let (state, init_pid, exec_pid) = {
+        let reg = lock_registry();
+        let Some(pod) = reg.get(id) else {
+            return AgentResponse::error(
+                format!("unknown pod container: {id}"),
+                error_codes::NOT_FOUND,
+            );
+        };
+        let exec_pid = match exec_id {
+            Some(e) => match pod.execs.get(e) {
+                Some(entry) => Some(entry.pid),
+                None => {
+                    return AgentResponse::error(
+                        format!("unknown exec '{e}' for container '{id}'"),
+                        error_codes::NOT_FOUND,
+                    )
+                }
+            },
+            None => None,
+        };
+        (pod.state, pod.init_pid, exec_pid)
+    };
+
+    // Exec case: crun can't target exec processes by id, so kill(2) the
+    // tracked pid directly — refined to its first child (the actual exec'd
+    // process) when visible, since the tracked pid is the crun monitor.
+    if let Some(tracked) = exec_pid {
+        let Some(tracked) = tracked else {
+            // Registered but never started (or already reaped): nothing to
+            // signal; treat as success like signalling a dead process group.
+            return AgentResponse::ok(None);
+        };
+        let target = first_child_pid(tracked).unwrap_or(tracked);
+        if !kill_pid(target, signal) {
+            warn!(id = %id, exec_id = ?exec_id, pid = target, signal = signal, "exec kill(2) failed (process already gone?)");
+        }
+        return AgentResponse::ok(None);
+    }
+
+    // Container case. Signalling a not-running container is a no-op success —
+    // stop paths are retried and must be idempotent.
+    if state != PodState::Running {
+        return AgentResponse::ok(None);
+    }
+    let cmd = if all {
+        crun::CrunCommand::kill_all(id, &signal.to_string())
+    } else {
+        crun::CrunCommand::kill(id, &signal.to_string())
+    };
+    match cmd.capture_output().output() {
+        Ok(output) if output.status.success() => AgentResponse::ok(None),
+        // crun refused (e.g. `--all` without a cgroup, or state raced away):
+        // fall back to kill(2) on the tracked process tree.
+        other => {
+            if let Ok(output) = &other {
+                warn!(id = %id, stderr = %String::from_utf8_lossy(&output.stderr).trim(), "crun kill failed; falling back to kill(2)");
+            }
+            let init = crun_state_pid(id).or(init_pid);
+            match init {
+                Some(init) => {
+                    let targets = if all {
+                        descendant_pids(init)
+                    } else {
+                        vec![init]
+                    };
+                    for pid in targets {
+                        let _ = kill_pid(pid, signal);
+                    }
+                    AgentResponse::ok(None)
+                }
+                None => AgentResponse::ok(None), // already gone — idempotent
+            }
+        }
+    }
+}
+
+/// `PodPids`: list the container's PIDs (guest view): init plus descendants
+/// from a /proc snapshot. With the crun cgroup manager disabled there is no
+/// per-container cgroup.procs, so the process tree under init is the source
+/// of truth; falls back to just the tracked init pid.
+pub fn handle_pod_pids(id: &str) -> AgentResponse {
+    let cached = {
+        let reg = lock_registry();
+        let Some(pod) = reg.get(id) else {
+            return AgentResponse::error(
+                format!("unknown pod container: {id}"),
+                error_codes::NOT_FOUND,
+            );
+        };
+        pod.init_pid
+    };
+
+    // Prefer the live pid from crun state (survives agent bookkeeping races),
+    // then the cached one.
+    let init = crun_state_pid(id).or(cached);
+    let Some(init) = init else {
+        return AgentResponse::Pids { pids: vec![] };
+    };
+
+    // Cache for later PodSignal fallbacks.
+    if cached != Some(init) {
+        if let Some(pod) = lock_registry().get_mut(id) {
+            pod.init_pid = Some(init);
+        }
+    }
+
+    let pids = descendant_pids(init);
+    AgentResponse::Pids { pids }
+}
+
+/// `PodStats`: sample the container's resource usage. crun runs with its cgroup
+/// manager disabled (no per-container cgroup), so usage is summed from /proc over
+/// the container's process tree. The shim maps this into containerd's cgroups
+/// metrics for CRI `ContainerStats`. A stopped/absent container reports zeros
+/// (still a valid, decodable sample) rather than an error, so `ListContainerStats`
+/// keeps working across a container's lifecycle.
+pub fn handle_pod_stats(id: &str) -> AgentResponse {
+    let cached = {
+        let reg = lock_registry();
+        let Some(pod) = reg.get(id) else {
+            return AgentResponse::error(
+                format!("unknown pod container: {id}"),
+                error_codes::NOT_FOUND,
+            );
+        };
+        pod.init_pid
+    };
+
+    let Some(init) = crun_state_pid(id).or(cached) else {
+        return AgentResponse::Stats {
+            cpu_usage_ns: 0,
+            memory_bytes: 0,
+        };
+    };
+
+    let pids = descendant_pids(init);
+    let (cpu_ticks, memory_bytes) = read_proc_usage(&pids);
+    AgentResponse::Stats {
+        cpu_usage_ns: ticks_to_ns(cpu_ticks),
+        memory_bytes,
+    }
+}
+
+/// Sum CPU time (clock ticks: utime+stime) and resident memory (bytes) across
+/// `pids` by reading `/proc/<pid>/stat` and `/proc/<pid>/statm`.
+#[cfg(target_os = "linux")]
+fn read_proc_usage(pids: &[u32]) -> (u64, u64) {
+    let mut cpu_ticks: u64 = 0;
+    let mut memory_bytes: u64 = 0;
+    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) }.max(4096) as u64;
+    for &pid in pids {
+        // /proc/<pid>/stat: the comm field (2) may contain spaces and ')', so
+        // parse the fields after the LAST ')'. utime (field 14) and stime (15)
+        // are indices 11 and 12 of that remainder (field 3 = state is index 0).
+        if let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) {
+            if let Some((_, rest)) = stat.rsplit_once(')') {
+                let f: Vec<&str> = rest.split_whitespace().collect();
+                let utime = f.get(11).and_then(|s| s.parse::<u64>().ok()).unwrap_or(0);
+                let stime = f.get(12).and_then(|s| s.parse::<u64>().ok()).unwrap_or(0);
+                cpu_ticks = cpu_ticks.saturating_add(utime).saturating_add(stime);
+            }
+        }
+        // /proc/<pid>/statm: field 2 (resident) is in pages.
+        if let Ok(statm) = std::fs::read_to_string(format!("/proc/{pid}/statm")) {
+            if let Some(res) = statm
+                .split_whitespace()
+                .nth(1)
+                .and_then(|s| s.parse::<u64>().ok())
+            {
+                memory_bytes = memory_bytes.saturating_add(res.saturating_mul(page_size));
+            }
+        }
+    }
+    (cpu_ticks, memory_bytes)
+}
+
+/// Convert clock ticks (from /proc) to nanoseconds using `_SC_CLK_TCK`.
+#[cfg(target_os = "linux")]
+fn ticks_to_ns(ticks: u64) -> u64 {
+    let hz = (unsafe { libc::sysconf(libc::_SC_CLK_TCK) }).max(1) as u64;
+    ticks.saturating_mul(1_000_000_000) / hz
+}
+
+/// Non-Linux builds have no /proc process usage to read.
+#[cfg(not(target_os = "linux"))]
+fn read_proc_usage(_pids: &[u32]) -> (u64, u64) {
+    (0, 0)
+}
+
+/// Non-Linux stub matching [`ticks_to_ns`].
+#[cfg(not(target_os = "linux"))]
+fn ticks_to_ns(ticks: u64) -> u64 {
+    ticks
+}
+
+/// `PodDelete`: drop an exec registration, or tear down the whole container
+/// (crun delete --force best-effort + bundle dir removal + registry entry).
+/// Idempotent: deleting something unknown is Ok.
+pub fn handle_pod_delete(id: &str, exec_id: Option<&str>) -> AgentResponse {
+    if let Some(exec) = exec_id {
+        if let Some(pod) = lock_registry().get_mut(id) {
+            pod.execs.remove(exec);
+        }
+        return AgentResponse::ok(None);
+    }
+
+    let existed = lock_registry().remove(id).is_some();
+    // Best-effort: `crun run` auto-deletes on exit, and the container may
+    // never have started; ignore failures.
+    let _ = crun::CrunCommand::delete(id, true)
+        .discard_output()
+        .output();
+    // Only touch the bundle dir for ids we actually created (or whose dir
+    // exists) — pod_dir(id) is validated-id-safe but stay conservative.
+    if validate_id(id).is_ok() {
+        let dir = pod_dir(id);
+        if dir.exists() {
+            if let Err(e) = std::fs::remove_dir_all(&dir) {
+                warn!(id = %id, error = %e, "failed to remove pod state dir");
+            }
+        }
+    }
+    info!(id = %id, existed = existed, "pod container deleted");
+    AgentResponse::ok(None)
+}
+
+// ============================================================================
+// PodStart — streaming (connection-level handler)
+// ============================================================================
+
+/// `PodStart`: launch the container's init process (or a registered exec
+/// process) and stream its I/O on THIS connection, exactly like interactive
+/// `Run`: `Started` → `Stdout`/`Stderr`... → `Exited`, with `Stdin`/`Resize`
+/// requests handled by the reused I/O pumps.
+#[cfg(target_os = "linux")]
+pub fn handle_pod_start(
+    stream: &mut impl crate::ReadWrite,
+    request: smolvm_protocol::AgentRequest,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (id, exec_id) = match request {
+        smolvm_protocol::AgentRequest::PodStart { id, exec_id } => (id, exec_id),
+        _ => {
+            crate::send_response(
+                stream,
+                &AgentResponse::error("expected PodStart request", error_codes::INVALID_REQUEST),
+            )?;
+            return Ok(());
+        }
+    };
+    match exec_id {
+        Some(exec_id) => start_exec_process(stream, &id, &exec_id),
+        None => start_init_process(stream, &id),
+    }
+}
+
+/// Non-Linux stub so `cargo test` on macOS compiles the dispatch.
+#[cfg(not(target_os = "linux"))]
+pub fn handle_pod_start(
+    stream: &mut impl crate::ReadWrite,
+    _request: smolvm_protocol::AgentRequest,
+) -> Result<(), Box<dyn std::error::Error>> {
+    crate::send_response(
+        stream,
+        &AgentResponse::error(
+            "pod containers not supported on this platform",
+            error_codes::INTERNAL_ERROR,
+        ),
+    )?;
+    Ok(())
+}
+
+/// Write the crun bundle for a pod container: the crate's standard guest spec
+/// (same template + injections as `write_oci_bundle` for `Run`), with
+/// `root.path` pointed at the shared-virtiofs rootfs instead of an overlay.
+#[cfg(target_os = "linux")]
+fn write_pod_bundle(
+    pod: &PodContainer,
+    id: &str,
+    bundle: &Path,
+    mount_binds: &[(PathBuf, String)],
+) -> Result<(), String> {
+    let identity = crate::oci::resolve_process_identity(&pod.rootfs, pod.process.user.as_deref())?;
+    // unprivileged=false: pods get the VM-grade default capability set — the
+    // microVM is the security boundary, same rationale as `Run`.
+    let mut spec = crate::oci::OciSpec::new(
+        &pod.process.args,
+        &pod.process.env,
+        pod.process.cwd.as_deref().unwrap_or("/"),
+        pod.tty,
+        &identity,
+        false,
+    );
+    if pod.tty {
+        // Non-zero starting size; the shim follows up with a Resize carrying
+        // the real dimensions once the session starts (same as `Run`).
+        spec.process.console_size = Some(crate::oci::OciConsoleSize {
+            height: 24,
+            width: 80,
+        });
+    }
+    // The rootfs is an absolute path under the shared virtiofs mount, not the
+    // bundle-relative "rootfs" the overlay paths use.
+    spec.root.path = pod.rootfs.to_string_lossy().into_owned();
+    spec.root.readonly = pod.readonly_rootfs;
+
+    // Pod UTS hostname and supplemental groups from the CRI config.
+    if pod.hostname.is_some() {
+        spec.hostname = pod.hostname.clone();
+    }
+    spec.process.user.additional_gids = pod.process.additional_gids.clone();
+    spec.process.no_new_privileges = pod.no_new_privileges;
+
+    // Shared PID namespace (SharePidMode=POD). CRI marks it with a non-empty
+    // `path` on the incoming pid namespace (that host path is meaningless in the
+    // guest); when set, join the pod's guest-side pause pid namespace instead of
+    // creating a fresh one, so PID 1 in the container is the pause and pod
+    // containers see each other. An empty path (CONTAINER) keeps its own.
+    let pod_pid_shared = matches!(
+        pod.host_spec.pointer("/linux/namespaces"),
+        Some(serde_json::Value::Array(ns)) if ns.iter().any(|n|
+            n.get("type").and_then(|t| t.as_str()) == Some("pid")
+                && n.get("path")
+                    .and_then(|p| p.as_str())
+                    .map(|s| !s.is_empty())
+                    .unwrap_or(false))
+    );
+    if pod_pid_shared {
+        match ensure_pod_pause_pidns() {
+            Ok(pause) => {
+                let ns_path = format!("/proc/{pause}/ns/pid");
+                for n in spec.linux.namespaces.iter_mut() {
+                    if n.ns_type == "pid" {
+                        n.path = Some(ns_path.clone());
+                    }
+                }
+            }
+            Err(e) => {
+                warn!(error = %e, "pod pid share: pause namespace unavailable; container keeps its own pid namespace")
+            }
+        }
+    }
+
+    // Give the container its own cgroup namespace so `/sys/fs/cgroup` is rooted
+    // at the container's own cgroup. Container-aware runtimes (the JVM, the Go
+    // runtime, etc.) size themselves from `/sys/fs/cgroup/{memory.max,cpu.max}`;
+    // without the namespace the container sees the limitless cgroup2 root, whose
+    // `memory.max` doesn't exist, and mis-sizes to the whole VM. crun mounts
+    // cgroup2 for the namespace when it manages the cgroup (cgroupfs).
+    if !spec.linux.namespaces.iter().any(|n| n.ns_type == "cgroup") {
+        spec.linux.namespaces.push(crate::oci::OciNamespace {
+            ns_type: "cgroup".to_string(),
+            path: None,
+        });
+    }
+
+    spec.add_gpu_devices_if_available();
+
+    // CRI mounts (volumes + generated /etc/resolv.conf, /etc/hosts) as bind mounts.
+    // Added last so they layer on TOP of the default mounts (e.g. a volume at
+    // /tmp/foo mounts over the default tmpfs at /tmp).
+    for (source, destination) in mount_binds {
+        spec.add_bind_mount(&source.to_string_lossy(), destination, false);
+    }
+
+    // Preserve synthetic CRI mounts the shim did NOT rewrite to the pod share:
+    // tmpfs (and similar) at custom destinations the default bundle doesn't
+    // provide. Bind mounts to host paths are the CRI volumes, already handled
+    // above via the pod-share rewrite; the default proc/sys/dev/cgroup mounts
+    // are already present.
+    if let Some(host_mounts) = pod.host_spec.get("mounts").and_then(|m| m.as_array()) {
+        let existing: std::collections::HashSet<String> =
+            spec.mounts.iter().map(|m| m.destination.clone()).collect();
+        for m in host_mounts {
+            let ty = m.get("type").and_then(|v| v.as_str()).unwrap_or("");
+            let dest = m.get("destination").and_then(|v| v.as_str()).unwrap_or("");
+            if dest.is_empty() || ty == "bind" || ty.is_empty() || existing.contains(dest) {
+                continue;
+            }
+            let options = m
+                .get("options")
+                .and_then(|o| o.as_array())
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default();
+            spec.mounts.push(crate::oci::OciMount {
+                destination: dest.to_string(),
+                mount_type: Some(ty.to_string()),
+                source: m
+                    .get("source")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(ty)
+                    .to_string(),
+                options,
+            });
+        }
+    }
+
+    // Same injections as Run's bundle build (write_oci_bundle).
+    crate::ssh_agent::inject_into_container(&mut spec);
+    crate::rosetta::inject_into_container(&mut spec);
+    crate::cuda::inject_into_container(&mut spec, &pod.rootfs);
+
+    // Graft the container's securityContext from the host OCI spec so the
+    // container runs with exactly what Kubernetes requested. OciSpec models
+    // capabilities/rlimits/masked+readonly paths but not seccomp or sysctls, so
+    // serialize and merge at the JSON level uniformly.
+    let mut cfg = serde_json::to_value(&spec).map_err(|e| format!("serialize OCI spec: {e}"))?;
+    graft_security_context(&mut cfg, &pod.host_spec);
+    // Pin the container under a known pod-cgroup parent (`/sys/fs/cgroup/smolvm/<id>`)
+    // so OOM detection can read the parent's aggregate `memory.events.oom_kill`
+    // after crun deletes the leaf on exit. Ignored when crun runs cgroup-disabled.
+    cfg["linux"]["cgroupsPath"] =
+        serde_json::Value::String(format!("{POD_CGROUP_PARENT_REL}/{id}"));
+    let json =
+        serde_json::to_string_pretty(&cfg).map_err(|e| format!("serialize OCI spec: {e}"))?;
+    std::fs::write(bundle.join("config.json"), json)
+        .map_err(|e| format!("failed to write OCI spec: {e}"))
+}
+
+/// Overlay the container's securityContext from the host OCI spec onto the
+/// serialized guest bundle. Pods must honor exactly the capabilities, seccomp
+/// profile, rlimits, masked/readonly paths, sysctls, and numeric uid/gid that
+/// Kubernetes requested (critest asserts each) rather than smolvm's VM-grade
+/// full-capability default. Every field copied here is host-agnostic — syscall
+/// names, in-container paths, capability names, numeric ids — so it transfers
+/// into the guest verbatim. `/process` and `/linux` always exist in the
+/// serialized spec, so keyed assignment auto-vivifies the leaf objects.
+fn graft_security_context(cfg: &mut serde_json::Value, host: &serde_json::Value) {
+    for key in [
+        "capabilities",
+        "rlimits",
+        "oomScoreAdj",
+        "apparmorProfile",
+        "noNewPrivileges",
+    ] {
+        if let Some(v) = host.pointer(&format!("/process/{key}")) {
+            cfg["process"][key] = v.clone();
+        }
+    }
+    // Numeric uid/gid are authoritative (CRI RunAsUser/RunAsGroup); grafting
+    // them corrects the case where identity resolution defaulted to root.
+    for id in ["uid", "gid"] {
+        if let Some(n) = host
+            .pointer(&format!("/process/user/{id}"))
+            .and_then(|v| v.as_u64())
+        {
+            cfg["process"]["user"][id] = n.into();
+        }
+    }
+    for key in ["seccomp", "sysctl", "maskedPaths", "readonlyPaths"] {
+        if let Some(v) = host.pointer(&format!("/linux/{key}")) {
+            cfg["linux"][key] = v.clone();
+        }
+    }
+    // Cgroup limits (memory/cpu/pids). Without these the container is
+    // unbounded and the OOM/limit tests fail — the VM's memory, not the
+    // container's requested limit, would decide. crun applies them in-guest.
+    if let Some(res) = host.pointer("/linux/resources") {
+        let mut res = res.clone();
+        // The guest kernel is built without swap, so cgroup2 exposes no
+        // `memory.swap.max`. kubelet nonetheless pins swap (e.g. sets it to 0 to
+        // enforce no-swap under cgroup v2), and crun then aborts the container
+        // with "opening file `memory.swap.max' for writing: No such file". A swap
+        // cap is meaningless in a swapless VM, so drop it — from both the OCI
+        // memory.swap field and the cgroup2 unified passthrough.
+        if let Some(mem) = res.get_mut("memory").and_then(|m| m.as_object_mut()) {
+            mem.remove("swap");
+        }
+        if let Some(unified) = res.get_mut("unified").and_then(|u| u.as_object_mut()) {
+            unified.remove("memory.swap.max");
+        }
+        cfg["linux"]["resources"] = res;
+    }
+}
+
+/// Copy each materialized CRI mount from the (read-only) pod share into the
+/// container's writable overlay `rootfs` at its destination. `cp -aT` makes the
+/// destination a faithful copy of the source whether it is a file (resolv.conf,
+/// hosts, hostname) or a directory (a volume), preserving modes/owners/symlinks.
+/// Parent directories are created first. Reads from the read-only virtiofs share
+/// are fine — only writes to it fail — and the target lives on the writable
+/// overlay upper.
+#[cfg(target_os = "linux")]
+fn materialize_pod_mounts(id: &str, mounts: &[PodMount]) -> Vec<(PathBuf, String)> {
+    // Copy each mount from the read-only share to a per-container writable dir on
+    // /storage, then bind it into the container. Bind mounts (added to the OCI
+    // spec) layer ON TOP of the default mounts, so a volume at /tmp/foo survives
+    // the default tmpfs at /tmp (copying into the overlay would be shadowed by it).
+    // The copy makes the volume writable + guest-local (correct emptyDir/configMap
+    // /secret semantics; smolvm's virtiofs share is read-only so a live bind of the
+    // host source couldn't be written).
+    let base = Path::new("/storage/pods").join(id).join("mnt");
+    let mut binds = Vec::new();
+    for (n, m) in mounts.iter().enumerate() {
+        let dst = base.join(n.to_string());
+        if let Some(parent) = dst.parent() {
+            if std::fs::create_dir_all(parent).is_err() {
+                continue;
+            }
+        }
+        // Native recursive copy (follows symlinks) rather than shelling out to
+        // `cp` — the guest's `cp` exits non-zero with no diagnostic on some
+        // virtiofs→/storage copies, and this gives precise errors and handles the
+        // symlink-volume case (dereference so the container sees the content).
+        match copy_tree(Path::new(&m.source), &dst) {
+            Ok(()) => binds.push((dst, m.destination.clone())),
+            Err(e) => warn!(
+                source = %m.source, dest = %m.destination, error = %e,
+                "failed to materialize mount (container starts without it)"
+            ),
+        }
+    }
+    binds
+}
+
+/// Recursively copy `src` to `dst`, following symlinks (so a symlinked volume
+/// source yields the pointed-to content, matching the CRI's bind semantics).
+/// Regular files and directories are copied; special files (devices/fifos/
+/// sockets) are skipped. Directory permissions are preserved best-effort.
+#[cfg(target_os = "linux")]
+fn copy_tree(src: &Path, dst: &Path) -> std::io::Result<()> {
+    // metadata() follows symlinks — a symlinked source is dereferenced.
+    let meta = std::fs::metadata(src)?;
+    let ft = meta.file_type();
+    if ft.is_dir() {
+        std::fs::create_dir_all(dst)?;
+        for entry in std::fs::read_dir(src)? {
+            let entry = entry?;
+            copy_tree(&entry.path(), &dst.join(entry.file_name()))?;
+        }
+        let _ = std::fs::set_permissions(dst, meta.permissions());
+    } else if ft.is_file() {
+        std::fs::copy(src, dst)?;
+    }
+    // else: device/fifo/socket — nothing meaningful to copy into a volume.
+    Ok(())
+}
+
+/// Non-Linux builds don't run pod containers.
+#[cfg(not(target_os = "linux"))]
+fn materialize_pod_mounts(_id: &str, _mounts: &[PodMount]) -> Vec<(PathBuf, String)> {
+    Vec::new()
+}
+
+/// Spawn the pod's shared-PID "pause": a process that is PID 1 of a fresh PID
+/// namespace and blocks forever. Pod containers running with `SharePidMode=POD`
+/// join this namespace (via `/proc/<pid>/ns/pid`), so their PID 1 is the pause —
+/// not the workload — and they see each other's processes. Mirrors how runc
+/// backs `shareProcessNamespace`, except the pause lives in the guest.
+///
+/// Returns the pause pid as seen from the agent's (guest-root) PID namespace.
+/// The helper child unshares a new PID namespace so its own child becomes that
+/// namespace's init; the grandchild pid it reports is agent-visible because the
+/// helper itself stays in the agent's namespace.
+#[cfg(target_os = "linux")]
+fn spawn_pod_pause_pidns() -> Result<u32, String> {
+    let mut fds = [0 as libc::c_int; 2];
+    if unsafe { libc::pipe(fds.as_mut_ptr()) } != 0 {
+        return Err(format!("pause pipe: {}", std::io::Error::last_os_error()));
+    }
+    let (rd, wr) = (fds[0], fds[1]);
+    // SAFETY: post-fork the child touches only async-signal-safe libc calls
+    // (unshare/fork/write/close/pause/_exit) — no allocation, no locks.
+    let helper = unsafe { libc::fork() };
+    if helper < 0 {
+        unsafe {
+            libc::close(rd);
+            libc::close(wr);
+        }
+        return Err(format!("pause fork: {}", std::io::Error::last_os_error()));
+    }
+    if helper == 0 {
+        unsafe {
+            libc::close(rd);
+            if libc::unshare(libc::CLONE_NEWPID) != 0 {
+                libc::_exit(11);
+            }
+            let gc = libc::fork();
+            if gc < 0 {
+                libc::_exit(12);
+            }
+            if gc == 0 {
+                // Grandchild: PID 1 of the new namespace. Block forever.
+                libc::close(wr);
+                loop {
+                    libc::pause();
+                }
+            }
+            let bytes = (gc as u32).to_ne_bytes();
+            libc::write(wr, bytes.as_ptr() as *const libc::c_void, 4);
+            libc::close(wr);
+            libc::_exit(0);
+        }
+    }
+    unsafe { libc::close(wr) };
+    let mut buf = [0u8; 4];
+    let n = unsafe { libc::read(rd, buf.as_mut_ptr() as *mut libc::c_void, 4) };
+    unsafe { libc::close(rd) };
+    let mut status = 0;
+    unsafe { libc::waitpid(helper, &mut status, 0) };
+    if n != 4 {
+        return Err("pause helper did not report a pid".to_string());
+    }
+    Ok(u32::from_ne_bytes(buf))
+}
+
+/// The pod's shared-PID pause pid, created on first `SharePidMode=POD` container
+/// and reused by the rest (one pod per sandbox VM). Re-created if the recorded
+/// pause is gone (its `/proc/<pid>/ns/pid` vanished).
+#[cfg(target_os = "linux")]
+fn ensure_pod_pause_pidns() -> Result<u32, String> {
+    static PAUSE: OnceLock<Mutex<Option<u32>>> = OnceLock::new();
+    let mut guard = PAUSE.get_or_init(|| Mutex::new(None)).lock().unwrap();
+    if let Some(pid) = *guard {
+        if Path::new(&format!("/proc/{pid}/ns/pid")).exists() {
+            return Ok(pid);
+        }
+    }
+    let pid = spawn_pod_pause_pidns()?;
+    *guard = Some(pid);
+    Ok(pid)
+}
+
+/// Pod-cgroup parent, relative to the cgroup2 mount root. Every pod container's
+/// cgroup is created at `<POD_CGROUP_PARENT_REL>/<id>`; the parent persists after
+/// crun deletes a leaf, so its aggregate `memory.events.oom_kill` still reflects
+/// a container that was OOM-killed.
+const POD_CGROUP_PARENT_REL: &str = "smolvm";
+const POD_CGROUP_PARENT_EVENTS: &str = "/sys/fs/cgroup/smolvm/memory.events";
+
+/// Read the cumulative `oom_kill` counter from a cgroup2 `memory.events` file.
+/// Returns 0 if the file is absent or unparseable (e.g. before the first
+/// container of a pod creates the parent cgroup). cgroup2 propagates the counter
+/// up the hierarchy at kill time and never decrements it, so a parent's count
+/// survives deletion of the leaf that was killed.
+fn read_cgroup_oom_kill(path: &str) -> u64 {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return 0;
+    };
+    for line in content.lines() {
+        if let Some(rest) = line.strip_prefix("oom_kill ") {
+            return rest.trim().parse().unwrap_or(0);
+        }
+    }
+    0
+}
+
+/// Make the guest's cgroup2 hierarchy usable by crun for pod containers.
+/// libkrun mounts `/sys/fs/cgroup` read-only, and cgroup2 delegates no
+/// controllers to children by default; both must be fixed once so crun (with
+/// the cgroupfs manager) can create per-container cgroups that enforce memory
+/// and pids limits (OOM, resource caps). Best-effort and cached: on any failure
+/// pods fall back to the cgroup-disabled path — they still run, just unbounded —
+/// so this never fails a container start.
+#[cfg(target_os = "linux")]
+fn cgroups_available() -> bool {
+    static READY: OnceLock<bool> = OnceLock::new();
+    *READY.get_or_init(|| {
+        use std::ffi::CString;
+        let Ok(target) = CString::new("/sys/fs/cgroup") else {
+            return false;
+        };
+        // Remount read-write (libkrun mounts cgroup2 ro): MS_REMOUNT preserves
+        // the mount; omitting MS_RDONLY clears the read-only flag.
+        let flags = libc::MS_REMOUNT | libc::MS_NOSUID | libc::MS_NODEV | libc::MS_NOEXEC;
+        // SAFETY: `target` is a valid NUL-terminated path; the agent is PID-1
+        // and holds CAP_SYS_ADMIN. Null source/type/data is valid for a remount.
+        let rc = unsafe {
+            libc::mount(
+                std::ptr::null(),
+                target.as_ptr(),
+                std::ptr::null(),
+                flags,
+                std::ptr::null(),
+            )
+        };
+        if rc != 0 {
+            warn!(err = %std::io::Error::last_os_error(), "cgroup: remount rw failed; pod resource limits disabled");
+            return false;
+        }
+        // Delegate the controllers crun needs into child cgroups.
+        if let Err(e) = std::fs::write("/sys/fs/cgroup/cgroup.subtree_control", "+memory +pids") {
+            warn!(error = %e, "cgroup: controller delegation failed; pod resource limits disabled");
+            return false;
+        }
+        info!("cgroup: cgroup2 delegated (memory, pids) — pod resource limits enforced");
+        true
+    })
+}
+
+/// Start the container's init process and pump its I/O until exit.
+#[cfg(target_os = "linux")]
+/// Stack a guest-writable overlayfs over the read-only virtiofs rootfs.
+///
+/// `lower` is the container rootfs as presented through the (read-only)
+/// virtiofs share; the upperdir/workdir live on the guest's writable
+/// `/storage` disk. Returns the merged mountpoint to use as the container
+/// `root.path`. Idempotent-ish: a stale merged mount from a prior attempt is
+/// unmounted first.
+#[cfg(target_os = "linux")]
+fn mount_writable_rootfs(id: &str, lower: &std::path::Path) -> Result<PathBuf, String> {
+    let base = Path::new("/storage/pods").join(id);
+    let upper = base.join("upper");
+    let work = base.join("work");
+    let merged = base.join("merged");
+    for d in [&upper, &work, &merged] {
+        std::fs::create_dir_all(d).map_err(|e| format!("mkdir {}: {e}", d.display()))?;
+    }
+
+    use std::ffi::CString;
+    let cstr = |p: &str| CString::new(p).map_err(|e| format!("cstr {p}: {e}"));
+    let merged_c = cstr(&merged.to_string_lossy())?;
+    // Drop any leftover mount from a previous start attempt (MNT_DETACH = 2).
+    unsafe { libc::umount2(merged_c.as_ptr(), 2) };
+
+    let overlay_c = cstr("overlay")?;
+    let data = format!(
+        "lowerdir={},upperdir={},workdir={}",
+        lower.display(),
+        upper.display(),
+        work.display()
+    );
+    let data_c = cstr(&data)?;
+    // SAFETY: all args are valid NUL-terminated C strings; the agent is PID-1
+    // with CAP_SYS_ADMIN, so mounting overlayfs is permitted.
+    let rc = unsafe {
+        libc::mount(
+            overlay_c.as_ptr(),
+            merged_c.as_ptr(),
+            overlay_c.as_ptr(),
+            0,
+            data_c.as_ptr() as *const libc::c_void,
+        )
+    };
+    if rc != 0 {
+        return Err(format!(
+            "mount writable overlay over {}: {}",
+            lower.display(),
+            std::io::Error::last_os_error()
+        ));
+    }
+    Ok(merged)
+}
+
+#[cfg(target_os = "linux")]
+fn start_init_process(
+    stream: &mut impl crate::ReadWrite,
+    id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    crate::ensure_storage_mounted();
+
+    // Snapshot the stashed settings under the lock; spawning happens after.
+    let pod = {
+        let reg = lock_registry();
+        match reg.get(id) {
+            None => {
+                crate::send_response(
+                    stream,
+                    &AgentResponse::error(
+                        format!("unknown pod container: {id}"),
+                        error_codes::NOT_FOUND,
+                    ),
+                )?;
+                return Ok(());
+            }
+            Some(p) if p.state != PodState::Created => {
+                crate::send_response(
+                    stream,
+                    &AgentResponse::error(
+                        format!("pod container '{id}' already started"),
+                        error_codes::INVALID_REQUEST,
+                    ),
+                )?;
+                return Ok(());
+            }
+            Some(p) => p.clone(),
+        }
+    };
+
+    // The rootfs is created host-side by containerd after the VM booted; it
+    // must be visible through the shared virtiofs mount by start time.
+    if !pod.rootfs.is_dir() {
+        crate::send_response(
+            stream,
+            &AgentResponse::error(
+                format!("pod rootfs not found: {}", pod.rootfs.display()),
+                error_codes::NOT_FOUND,
+            ),
+        )?;
+        return Ok(());
+    }
+
+    // The virtiofs share is READ-ONLY to the guest (writes EACCES), so crun
+    // can't create its /proc,/sys,/dev mountpoints directly on it. Stack a
+    // guest-writable overlay — lowerdir = the (read-only) virtiofs rootfs,
+    // upper/work on the guest's writable /storage disk — and run the container
+    // on the merged view. This mirrors how Kata backs a virtiofs rootfs, and
+    // keeps container writes ephemeral + guest-local (correct k8s semantics).
+    let mut pod = pod;
+    match mount_writable_rootfs(id, &pod.rootfs) {
+        Ok(merged) => pod.rootfs = merged,
+        Err(e) => {
+            crate::send_response(
+                stream,
+                &AgentResponse::error(e, error_codes::INTERNAL_ERROR),
+            )?;
+            return Ok(());
+        }
+    }
+
+    // Materialize CRI mounts (volumes + generated /etc/resolv.conf, /etc/hosts,
+    // /etc/hostname) into per-container writable dirs and bind them into the
+    // container (layered on top of the default mounts). Best-effort: a mount that
+    // can't be materialized is skipped, not fatal.
+    let mount_binds = materialize_pod_mounts(id, &pod.mounts);
+
+    let bundle = pod_dir(id).join("bundle");
+    if let Err(e) = std::fs::create_dir_all(&bundle) {
+        crate::send_response(
+            stream,
+            &AgentResponse::error(
+                format!("failed to create bundle dir: {e}"),
+                error_codes::INTERNAL_ERROR,
+            ),
+        )?;
+        return Ok(());
+    }
+    if let Err(e) = write_pod_bundle(&pod, id, &bundle, &mount_binds) {
+        crate::send_response(stream, &AgentResponse::error(e, error_codes::SPAWN_FAILED))?;
+        return Ok(());
+    }
+
+    info!(
+        id = %id,
+        rootfs = %pod.rootfs.display(),
+        command = ?pod.process.args,
+        tty = pod.tty,
+        "starting pod container"
+    );
+
+    // Reuse Run's crun-run spawner: console-socket PTY handshake when tty,
+    // piped stdio otherwise. The provided id IS the crun container id.
+    //
+    // Pods get cgroupfs once delegation succeeds so crun enforces the
+    // container's memory/pids limits (OOM); otherwise crun runs cgroup-disabled
+    // (still works, just unbounded).
+    let cgroups = cgroups_available();
+    // Baseline the pod-cgroup parent's OOM counter before the container starts;
+    // a post-exit increment means this container was OOM-killed (see Exited below).
+    let oom_baseline = if cgroups {
+        read_cgroup_oom_kill(POD_CGROUP_PARENT_EVENTS)
+    } else {
+        0
+    };
+    let (mut child, pty_master) = match crate::spawn_crun_run(&bundle, id, pod.tty, cgroups) {
+        Ok(result) => result,
+        Err(e) => {
+            crate::send_response(
+                stream,
+                &AgentResponse::from_err(e, error_codes::SPAWN_FAILED),
+            )?;
+            return Ok(());
+        }
+    };
+
+    // `crun run` registers the container in crun's state DB asynchronously (the
+    // spawn above only forked crun). Wait until the container is registered
+    // before reporting Started, so a client that immediately execs/signals/reads
+    // stats after StartContainer finds a live container — critest races
+    // StartContainer→ExecSync and would otherwise hit "container not found".
+    // Bounded, and returns early if the container exits instantly.
+    let init_pid = wait_for_crun_running(id, &mut child);
+
+    if let Some(p) = lock_registry().get_mut(id) {
+        p.state = PodState::Running;
+        p.init_pid = init_pid;
+    }
+
+    crate::send_response(stream, &AgentResponse::Started)?;
+
+    // Reuse Run's streaming pumps verbatim (Stdout/Stderr frames out;
+    // Stdin/Resize requests in). No timeout: pod containers run until they
+    // exit or are signalled.
+    let loop_result = match pty_master {
+        Some(pty) => crate::run_interactive_loop_pty(stream, &mut child, pty, None),
+        None => crate::run_interactive_loop(stream, &mut child, None),
+    };
+
+    // Whatever happened, the init process is done (the pumps kill the child on
+    // every error/disconnect path themselves; the Err arm below reaps).
+    if let Some(p) = lock_registry().get_mut(id) {
+        p.state = PodState::Exited;
+        p.init_pid = None;
+    }
+
+    let exit_code = match loop_result {
+        Ok(code) => code,
+        Err(e) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(e);
+        }
+    };
+
+    // The cgroup OOM killer sends SIGKILL, so the process already exited 137;
+    // check whether the kill was ours (memory limit) so the shim can surface
+    // `reason=OOMKilled` rather than a bare signal exit.
+    let oom = cgroups && read_cgroup_oom_kill(POD_CGROUP_PARENT_EVENTS) > oom_baseline;
+    crate::send_response(stream, &AgentResponse::Exited { exit_code, oom })?;
+    Ok(())
+}
+
+/// Spawn a pod exec. Uses `crun exec --process` (full OCI process, honors
+/// supplemental groups) when `use_process_spec`; otherwise the flag-based
+/// `spawn_exec_in_container` (unchanged for the common case).
+#[cfg(target_os = "linux")]
+#[allow(clippy::type_complexity)]
+fn spawn_pod_exec(
+    id: &str,
+    exec_id: &str,
+    entry: &ExecEntry,
+    launch: &crate::ResolvedLaunch,
+    use_process_spec: bool,
+) -> Result<(std::process::Child, Option<crate::pty::PtyMaster>), Box<dyn std::error::Error>> {
+    if !use_process_spec {
+        return crate::spawn_exec_in_container(id, launch, entry.tty);
+    }
+    let bundle = pod_dir(id).join("bundle");
+    std::fs::create_dir_all(&bundle)?;
+    let process_file = bundle.join(format!("exec-{exec_id}.json"));
+    std::fs::write(
+        &process_file,
+        prepare_exec_process_json(&entry.process_json)?,
+    )?;
+    let child = crun::CrunCommand::exec_with_process(id, &process_file)
+        .stdin_piped()
+        .capture_output()
+        .spawn()?;
+    Ok((child, None))
+}
+
+/// Normalize a containerd exec OCI Process for `crun exec --process`: force
+/// `terminal:false` (we drive piped stdio) and guarantee a PATH so bare-name
+/// binaries (e.g. `id`) resolve.
+#[cfg(target_os = "linux")]
+fn prepare_exec_process_json(raw: &str) -> Result<String, Box<dyn std::error::Error>> {
+    const DEFAULT_PATH: &str = "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+    let mut v: serde_json::Value = serde_json::from_str(raw)?;
+    v["terminal"] = serde_json::Value::Bool(false);
+    let has_path = v
+        .get("env")
+        .and_then(|e| e.as_array())
+        .map(|a| {
+            a.iter()
+                .any(|x| x.as_str().map(|s| s.starts_with("PATH=")).unwrap_or(false))
+        })
+        .unwrap_or(false);
+    if !has_path {
+        match v.get_mut("env").and_then(|e| e.as_array_mut()) {
+            Some(env) => env.push(serde_json::Value::String(DEFAULT_PATH.to_string())),
+            None => v["env"] = serde_json::json!([DEFAULT_PATH]),
+        }
+    }
+    Ok(serde_json::to_string(&v)?)
+}
+
+/// Start a previously registered exec process inside the running container
+/// and pump its I/O until exit. Same streaming contract as the init path.
+#[cfg(target_os = "linux")]
+fn start_exec_process(
+    stream: &mut impl crate::ReadWrite,
+    id: &str,
+    exec_id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    crate::ensure_storage_mounted();
+
+    let entry = {
+        let reg = lock_registry();
+        let Some(pod) = reg.get(id) else {
+            crate::send_response(
+                stream,
+                &AgentResponse::error(
+                    format!("unknown pod container: {id}"),
+                    error_codes::NOT_FOUND,
+                ),
+            )?;
+            return Ok(());
+        };
+        if pod.state != PodState::Running {
+            crate::send_response(
+                stream,
+                &AgentResponse::error(
+                    format!("pod container '{id}' is not running"),
+                    error_codes::EXEC_FAILED,
+                ),
+            )?;
+            return Ok(());
+        }
+        let Some(entry) = pod.execs.get(exec_id) else {
+            crate::send_response(
+                stream,
+                &AgentResponse::error(
+                    format!("unknown exec '{exec_id}' for container '{id}'"),
+                    error_codes::NOT_FOUND,
+                ),
+            )?;
+            return Ok(());
+        };
+        if entry.pid.is_some() {
+            crate::send_response(
+                stream,
+                &AgentResponse::error(
+                    format!("exec '{exec_id}' already started"),
+                    error_codes::INVALID_REQUEST,
+                ),
+            )?;
+            return Ok(());
+        }
+        entry.clone()
+    };
+
+    // Reuse Run's exec-in-container spawner (`crun exec`, console-socket PTY
+    // when tty). ResolvedLaunch carries the stashed args/env/cwd/user; the user
+    // (containerd copies the container's RunAsUser into the exec process spec) is
+    // applied via `crun exec --user`, so ExecSync runs as the container's user.
+    let launch = crate::ResolvedLaunch {
+        command: entry.process.args.clone(),
+        env: entry.process.env.clone(),
+        workdir: entry.process.cwd.clone(),
+        user: entry.process.user.clone(),
+    };
+
+    info!(id = %id, exec_id = %exec_id, command = ?launch.command, tty = entry.tty, "starting pod exec process");
+
+    // When the exec has supplemental groups (CRI SupplementalGroups), run it from
+    // the full OCI process via `crun exec --process` — the flag path can only set
+    // uid:gid. Limited to non-TTY (execSync); TTY execs with groups fall back to
+    // the flag path (rare). Everything else keeps the flag-based path unchanged.
+    let use_process_spec = !entry.process.additional_gids.is_empty() && !entry.tty;
+
+    let (mut child, pty_master) =
+        match spawn_pod_exec(id, exec_id, &entry, &launch, use_process_spec) {
+            Ok(result) => result,
+            Err(e) => {
+                crate::send_response(
+                    stream,
+                    &AgentResponse::from_err(e, error_codes::SPAWN_FAILED),
+                )?;
+                return Ok(());
+            }
+        };
+
+    // Track the crun-exec pid so PodSignal { exec_id } can kill(2) it (crun
+    // can't target exec processes by id). Signal delivery refines this to the
+    // monitor's first child when visible in /proc.
+    {
+        let mut reg = lock_registry();
+        if let Some(e) = reg.get_mut(id).and_then(|p| p.execs.get_mut(exec_id)) {
+            e.pid = Some(child.id());
+        }
+    }
+
+    crate::send_response(stream, &AgentResponse::Started)?;
+
+    let loop_result = match pty_master {
+        Some(pty) => crate::run_interactive_loop_pty(stream, &mut child, pty, None),
+        None => crate::run_interactive_loop(stream, &mut child, None),
+    };
+
+    // The exec is done — clear the tracked pid.
+    {
+        let mut reg = lock_registry();
+        if let Some(e) = reg.get_mut(id).and_then(|p| p.execs.get_mut(exec_id)) {
+            e.pid = None;
+        }
+    }
+
+    let exit_code = match loop_result {
+        Ok(code) => code,
+        Err(e) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(e);
+        }
+    };
+
+    crate::send_response(
+        stream,
+        &AgentResponse::Exited {
+            exit_code,
+            oom: false,
+        },
+    )?;
+    Ok(())
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn id_validation() {
+        assert!(validate_id("abc-123_x.y").is_ok());
+        assert!(validate_id("").is_err());
+        assert!(validate_id("..").is_err());
+        assert!(validate_id("-flag").is_err());
+        assert!(validate_id("a/b").is_err());
+        assert!(validate_id(&"x".repeat(201)).is_err());
+    }
+
+    #[test]
+    fn rootfs_resolution_stays_under_share() {
+        let p = resolve_pod_rootfs("ctr-1/rootfs").unwrap();
+        assert_eq!(
+            p,
+            Path::new(paths::VIRTIOFS_MOUNT_ROOT)
+                .join(POD_SHARE_TAG)
+                .join("ctr-1/rootfs")
+        );
+        assert!(resolve_pod_rootfs("/abs/path").is_err());
+        assert!(resolve_pod_rootfs("../escape").is_err());
+        assert!(resolve_pod_rootfs("a/../../b").is_err());
+        assert!(resolve_pod_rootfs("").is_err());
+    }
+
+    #[test]
+    fn oci_process_parsing() {
+        let v: serde_json::Value = serde_json::from_str(
+            r#"{
+                "args": ["/bin/sh", "-c", "echo hi"],
+                "env": ["PATH=/bin", "FOO=bar=baz", "BROKEN"],
+                "cwd": "/app",
+                "user": { "uid": 1000, "gid": 100 }
+            }"#,
+        )
+        .unwrap();
+        let p = parse_oci_process(&v).unwrap();
+        assert_eq!(p.args, vec!["/bin/sh", "-c", "echo hi"]);
+        assert_eq!(
+            p.env,
+            vec![
+                ("PATH".to_string(), "/bin".to_string()),
+                ("FOO".to_string(), "bar=baz".to_string())
+            ]
+        );
+        assert_eq!(p.cwd.as_deref(), Some("/app"));
+        assert_eq!(p.user.as_deref(), Some("1000:100"));
+    }
+
+    #[test]
+    fn oci_process_requires_args() {
+        let v: serde_json::Value = serde_json::from_str(r#"{ "env": [] }"#).unwrap();
+        assert!(parse_oci_process(&v).is_err());
+    }
+
+    #[test]
+    fn create_signal_delete_lifecycle() {
+        // Registry is process-global; use unique ids to avoid cross-test
+        // interference.
+        let id = "test-pod-lifecycle";
+        let spec = r#"{
+            "process": { "args": ["sleep", "1"], "env": ["A=b"], "cwd": "/" },
+            "root": { "path": "rootfs", "readonly": true }
+        }"#;
+        let resp = handle_pod_create(id, "ctr/rootfs", spec, false);
+        assert!(matches!(resp, AgentResponse::Ok { .. }), "{resp:?}");
+
+        // Duplicate rejected.
+        let dup = handle_pod_create(id, "ctr/rootfs", spec, false);
+        assert!(matches!(dup, AgentResponse::Error { .. }));
+
+        // Exec stash + duplicate rejected.
+        let proc_json = r#"{ "args": ["ls"], "env": [] }"#;
+        assert!(matches!(
+            handle_pod_exec(id, "e1", proc_json, false),
+            AgentResponse::Ok { .. }
+        ));
+        assert!(matches!(
+            handle_pod_exec(id, "e1", proc_json, false),
+            AgentResponse::Error { .. }
+        ));
+
+        // Signal on a created (not running) container is an idempotent Ok.
+        assert!(matches!(
+            handle_pod_signal(id, None, 15, true),
+            AgentResponse::Ok { .. }
+        ));
+        // Unknown exec id is NOT_FOUND.
+        assert!(matches!(
+            handle_pod_signal(id, Some("nope"), 9, false),
+            AgentResponse::Error { .. }
+        ));
+
+        // Pids on a never-started container: empty list.
+        match handle_pod_pids(id) {
+            AgentResponse::Pids { pids } => assert!(pids.is_empty()),
+            other => panic!("expected Pids, got {other:?}"),
+        }
+
+        // Delete exec then container; both idempotent.
+        assert!(matches!(
+            handle_pod_delete(id, Some("e1")),
+            AgentResponse::Ok { .. }
+        ));
+        assert!(matches!(
+            handle_pod_delete(id, None),
+            AgentResponse::Ok { .. }
+        ));
+        assert!(matches!(
+            handle_pod_delete(id, None),
+            AgentResponse::Ok { .. }
+        ));
+
+        // Gone from the registry.
+        assert!(matches!(handle_pod_pids(id), AgentResponse::Error { .. }));
+    }
+
+    #[test]
+    fn unknown_ids_are_not_found() {
+        assert!(matches!(
+            handle_pod_signal("no-such-pod", None, 9, false),
+            AgentResponse::Error { .. }
+        ));
+        assert!(matches!(
+            handle_pod_pids("no-such-pod"),
+            AgentResponse::Error { .. }
+        ));
+        assert!(matches!(
+            handle_pod_exec("no-such-pod", "e", r#"{ "args": ["ls"] }"#, false),
+            AgentResponse::Error { .. }
+        ));
+    }
+}

--- a/crates/smolvm-network/Cargo.toml
+++ b/crates/smolvm-network/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/smol-machines/smolvm"
 [dependencies]
 crossbeam-queue = "0.3"
 humantime = "2"
+libc = "0.2"
 polling = "3"
 smoltcp = { version = "0.13", default-features = false, features = [
     "std",

--- a/crates/smolvm-network/src/lib.rs
+++ b/crates/smolvm-network/src/lib.rs
@@ -65,6 +65,10 @@ pub mod egress;
 // both Unix and Windows (10 1809+), so the whole stack is cross-platform.
 pub mod frame_stream;
 pub mod icmp_relay;
+// CNI netns ↔ virtio-net L2 bridge for the Kubernetes runtime (Linux only:
+// needs /dev/net/tun + setns).
+#[cfg(target_os = "linux")]
+pub mod netns_tap;
 pub mod queues;
 pub mod stack;
 pub mod tcp_listeners;

--- a/crates/smolvm-network/src/netns_tap.rs
+++ b/crates/smolvm-network/src/netns_tap.rs
@@ -1,0 +1,403 @@
+//! CNI netns ↔ virtio-net L2 bridge for the Kubernetes runtime.
+//!
+//! Kubernetes semantics require the pod to live *in* its CNI-allocated network
+//! namespace with the CNI-assigned IP, reachable at L2 from other pods — which
+//! the smoltcp NAT gateway ([`crate::frame_stream`]) deliberately does not
+//! provide. This module gives the alternative "netns-tap" datapath the
+//! containerd shim uses (see docs/kubernetes-runtime.md):
+//!
+//! ```text
+//!  CNI netns                         host (shim)                 guest
+//!  ┌─────────┐   ethernet frames   ┌──────────────┐  unixstream ┌────────┐
+//!  │  tapX    │◀───────────────────▶│ netns_tap    │◀───────────▶│ libkrun │
+//!  │ (vethed  │   raw, no framing   │ frame pump   │  4B-len +   │virtio-  │
+//!  │  by CNI) │                     │              │   frame     │  net    │
+//!  └─────────┘                     └──────────────┘             └────────┘
+//! ```
+//!
+//! The shim opens a tap **inside the pod netns**, plugs it into the CNI bridge
+//! the same way a container veth would be, and pumps raw Ethernet frames
+//! between the tap fd and libkrun's unixstream (which uses the
+//! `[4-byte BE length][frame]` protocol from [`crate::frame_stream`]). No IP
+//! logic lives here — the guest configures the CNI address/routes/MTU
+//! statically from boot config; this is a pure L2 wire.
+
+use std::io;
+use std::os::fd::{AsRawFd, OwnedFd, RawFd};
+use std::os::unix::net::UnixStream;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+
+use crate::frame_stream::{read_frame, write_frame};
+
+/// Largest Ethernet frame we relay (jumbo-safe MTU + header + VLAN slack).
+const TAP_READ_BUF: usize = 65_536;
+
+/// A running netns-tap bridge. Dropping it signals both pump threads to stop
+/// and joins them; the tap fd closes with the bridge.
+pub struct NetnsTapBridge {
+    stop: Arc<AtomicBool>,
+    threads: Vec<JoinHandle<()>>,
+}
+
+impl NetnsTapBridge {
+    /// Stop the pumps and join. Idempotent; also called on drop.
+    pub fn shutdown(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        for t in self.threads.drain(..) {
+            let _ = t.join();
+        }
+    }
+}
+
+impl Drop for NetnsTapBridge {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+/// Pump raw Ethernet frames between a tap fd and libkrun's unixstream.
+///
+/// `tap` is a TAP device fd opened with `IFF_NO_PI` (no 4-byte packet-info
+/// prefix — payloads are bare Ethernet frames). `stream` is the AF_UNIX stream
+/// libkrun is given for its virtio-net backend. Two threads run until either
+/// side closes or [`NetnsTapBridge::shutdown`] is called:
+/// - **tap → stream**: `read()` a frame from the tap, `write_frame` it (adds the
+///   4-byte length prefix libkrun expects).
+/// - **stream → tap**: `read_frame` (strips the prefix), `write()` the raw frame
+///   to the tap.
+pub fn start_netns_tap_bridge(stream: UnixStream, tap: OwnedFd) -> io::Result<NetnsTapBridge> {
+    // Independent fds for each direction so concurrent read+write never block
+    // each other (the same lesson as frame_stream's split sockets).
+    let stream_rx = stream.try_clone()?;
+    let stream_tx = stream;
+    let tap_rx = tap.try_clone()?;
+    let tap_tx = tap;
+
+    let stop = Arc::new(AtomicBool::new(false));
+
+    let stop_a = stop.clone();
+    let t_up = std::thread::Builder::new()
+        .name("netns-tap-tx".into())
+        .spawn(move || pump_tap_to_stream(tap_rx, stream_tx, &stop_a))?;
+
+    let stop_b = stop.clone();
+    let t_down = std::thread::Builder::new()
+        .name("netns-tap-rx".into())
+        .spawn(move || pump_stream_to_tap(stream_rx, tap_tx, &stop_b))?;
+
+    Ok(NetnsTapBridge {
+        stop,
+        threads: vec![t_up, t_down],
+    })
+}
+
+fn pump_tap_to_stream(tap: OwnedFd, mut stream: UnixStream, stop: &AtomicBool) {
+    let mut buf = vec![0u8; TAP_READ_BUF];
+    let fd = tap.as_raw_fd();
+    while !stop.load(Ordering::SeqCst) {
+        match read_fd(fd, &mut buf) {
+            Ok(0) => break, // tap closed
+            Ok(n) => {
+                if let Err(e) = write_frame(&mut stream, &buf[..n]) {
+                    if !stop.load(Ordering::SeqCst) {
+                        tracing::debug!("netns-tap: stream write ended: {e}");
+                    }
+                    break;
+                }
+            }
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+            Err(e) => {
+                if !stop.load(Ordering::SeqCst) {
+                    tracing::debug!("netns-tap: tap read ended: {e}");
+                }
+                break;
+            }
+        }
+    }
+}
+
+fn pump_stream_to_tap(mut stream: UnixStream, tap: OwnedFd, stop: &AtomicBool) {
+    let fd = tap.as_raw_fd();
+    while !stop.load(Ordering::SeqCst) {
+        match read_frame(&mut stream) {
+            Ok(frame) => {
+                // A short write to a tap would corrupt the frame; tap writes are
+                // atomic per frame, so a partial write is a hard error.
+                if let Err(e) = write_fd_all(fd, &frame) {
+                    if !stop.load(Ordering::SeqCst) {
+                        tracing::debug!("netns-tap: tap write ended: {e}");
+                    }
+                    break;
+                }
+            }
+            Err(e) => {
+                if !stop.load(Ordering::SeqCst) {
+                    tracing::debug!("netns-tap: stream read ended: {e}");
+                }
+                break;
+            }
+        }
+    }
+}
+
+// Raw fd read/write: the tap fd is a character device, not a std type. Using
+// libc directly avoids wrapping it in a File (whose Drop would double-close a
+// try_clone'd fd we already own).
+
+fn read_fd(fd: RawFd, buf: &mut [u8]) -> io::Result<usize> {
+    let n = unsafe { libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
+    if n < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(n as usize)
+    }
+}
+
+fn write_fd_all(fd: RawFd, buf: &[u8]) -> io::Result<()> {
+    // One write() call per Ethernet frame (tap semantics are datagram-like).
+    let n = unsafe { libc::write(fd, buf.as_ptr() as *const libc::c_void, buf.len()) };
+    if n < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if (n as usize) != buf.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::WriteZero,
+            "short tap write truncated an ethernet frame",
+        ));
+    }
+    Ok(())
+}
+
+/// Open a TAP device inside the network namespace at `netns_path` and return
+/// its fd. The tap is created with `IFF_TAP | IFF_NO_PI`, named `ifname`, and
+/// brought up; the CNI plugin (already run by containerd) owns bridging it into
+/// the pod network. The fd remains valid in the caller's process after we
+/// switch back to the original netns — only the *device* lives in the pod's
+/// netns.
+///
+/// Requires `CAP_SYS_ADMIN`. Isolated so the frame pump can be unit-tested
+/// without root ([`start_netns_tap_bridge`] takes any `OwnedFd`).
+#[cfg(target_os = "linux")]
+pub fn open_tap_in_netns(netns_path: &str, ifname: &str) -> io::Result<OwnedFd> {
+    use std::fs::File;
+    use std::os::fd::AsFd;
+
+    if ifname.len() >= libc::IFNAMSIZ {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "interface name too long",
+        ));
+    }
+
+    // Remember our current netns so we can return to it no matter what.
+    let self_ns = File::open("/proc/self/ns/net")?;
+    let target = File::open(netns_path)?;
+
+    // setns(CLONE_NEWNET) affects only the calling thread, so do the whole
+    // enter → create tap → restore on a dedicated scoped thread. That keeps the
+    // caller's thread (and any tokio worker it belongs to) in the host netns.
+    let ifname = ifname.to_string();
+    std::thread::scope(|s| {
+        s.spawn(|| -> io::Result<OwnedFd> {
+            enter_netns(target.as_fd().as_raw_fd())?;
+            let res = create_tap(&ifname);
+            // Always attempt to restore, even on failure — a scoped worker left
+            // in the pod netns would be a latent bug if the platform ever
+            // pooled it (it does not today, but don't rely on that).
+            let _ = enter_netns(self_ns.as_fd().as_raw_fd());
+            res
+        })
+        .join()
+        .map_err(|_| io::Error::other("tap-open thread panicked"))?
+    })
+}
+
+/// Wire a tap (created by [`open_tap_in_netns`]) into the pod's CNI datapath via
+/// `tc` mirred redirect: every frame arriving on the CNI interface (`cni_if` —
+/// the veth the CNI plugin placed in the netns) is redirected to the tap's
+/// egress (into the VM), and every frame the VM emits on the tap is redirected
+/// back onto the CNI interface. The guest NIC, configured with the pod's CNI
+/// IP+MAC, thus appears on the pod network at L2. This is Kata's "tcfilter" mode
+/// and works with any CNI plugin (no assumptions about bridges/veth naming).
+///
+/// Runs `tc` inside `netns_path` via `nsenter`. Requires CAP_NET_ADMIN; call in
+/// the boot subprocess's privileged window, before any uid drop. Both `tc` and
+/// `nsenter` (iproute2 + util-linux) must be on PATH — they are on every k8s node.
+#[cfg(target_os = "linux")]
+pub fn setup_tc_redirect(netns_path: &str, cni_if: &str, tap_if: &str) -> io::Result<()> {
+    // A clsact/ingress qdisc on each device gives us the ingress hook the mirred
+    // redirect attaches to. `matchall` (kernel 4.9+) classifies every frame.
+    tc(netns_path, &["qdisc", "add", "dev", cni_if, "ingress"])?;
+    tc(netns_path, &["qdisc", "add", "dev", tap_if, "ingress"])?;
+    tc(
+        netns_path,
+        &[
+            "filter", "add", "dev", cni_if, "ingress", "protocol", "all", "matchall", "action",
+            "mirred", "egress", "redirect", "dev", tap_if,
+        ],
+    )?;
+    tc(
+        netns_path,
+        &[
+            "filter", "add", "dev", tap_if, "ingress", "protocol", "all", "matchall", "action",
+            "mirred", "egress", "redirect", "dev", cni_if,
+        ],
+    )?;
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn tc(netns_path: &str, args: &[&str]) -> io::Result<()> {
+    let out = std::process::Command::new("nsenter")
+        .arg(format!("--net={netns_path}"))
+        .arg("tc")
+        .args(args)
+        .output()?;
+    if !out.status.success() {
+        return Err(io::Error::other(format!(
+            "nsenter --net={netns_path} tc {}: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn enter_netns(ns_fd: RawFd) -> io::Result<()> {
+    let rc = unsafe { libc::setns(ns_fd, libc::CLONE_NEWNET) };
+    if rc != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn create_tap(ifname: &str) -> io::Result<OwnedFd> {
+    use std::os::fd::FromRawFd;
+
+    let tun = unsafe { libc::open(c"/dev/net/tun".as_ptr(), libc::O_RDWR) };
+    if tun < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: tun >= 0 is a fresh owned fd.
+    let owned = unsafe { OwnedFd::from_raw_fd(tun) };
+
+    #[repr(C)]
+    struct Ifreq {
+        name: [libc::c_char; libc::IFNAMSIZ],
+        flags: libc::c_short,
+        _pad: [u8; 22],
+    }
+    let mut req = Ifreq {
+        name: [0; libc::IFNAMSIZ],
+        flags: (libc::IFF_TAP | libc::IFF_NO_PI) as libc::c_short,
+        _pad: [0; 22],
+    };
+    for (i, b) in ifname.bytes().enumerate() {
+        req.name[i] = b as libc::c_char;
+    }
+    // TUNSETIFF = _IOW('T', 202, int)
+    const TUNSETIFF: libc::c_ulong = 0x4004_54ca;
+    let rc = unsafe { libc::ioctl(owned.as_raw_fd(), TUNSETIFF as _, &mut req) };
+    if rc < 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    bring_up(ifname)?;
+    Ok(owned)
+}
+
+/// `ip link set <ifname> up` via a netlink-free SIOCSIFFLAGS ioctl (we are in
+/// the target netns on this thread).
+#[cfg(target_os = "linux")]
+fn bring_up(ifname: &str) -> io::Result<()> {
+    let sock = unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM, 0) };
+    if sock < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let _guard = scopeguard_close(sock);
+
+    #[repr(C)]
+    struct IfreqFlags {
+        name: [libc::c_char; libc::IFNAMSIZ],
+        flags: libc::c_short,
+        _pad: [u8; 22],
+    }
+    let mut req = IfreqFlags {
+        name: [0; libc::IFNAMSIZ],
+        flags: 0,
+        _pad: [0; 22],
+    };
+    for (i, b) in ifname.bytes().enumerate() {
+        req.name[i] = b as libc::c_char;
+    }
+    const SIOCGIFFLAGS: libc::c_ulong = 0x8913;
+    const SIOCSIFFLAGS: libc::c_ulong = 0x8914;
+    if unsafe { libc::ioctl(sock, SIOCGIFFLAGS as _, &mut req) } < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    req.flags |= (libc::IFF_UP | libc::IFF_RUNNING) as libc::c_short;
+    if unsafe { libc::ioctl(sock, SIOCSIFFLAGS as _, &mut req) } < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn scopeguard_close(fd: RawFd) -> impl Drop {
+    struct Closer(RawFd);
+    impl Drop for Closer {
+        fn drop(&mut self) {
+            unsafe { libc::close(self.0) };
+        }
+    }
+    Closer(fd)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::os::fd::OwnedFd;
+
+    /// A socketpair stands in for both the tap fd and the libkrun stream so the
+    /// pump logic runs without root or a real tap.
+    fn socketpair() -> (OwnedFd, OwnedFd) {
+        let mut fds = [0i32; 2];
+        let rc = unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) };
+        assert_eq!(rc, 0);
+        use std::os::fd::FromRawFd;
+        unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) }
+    }
+
+    #[test]
+    fn frames_relay_both_directions() {
+        // "tap" side = a socketpair; the pump reads raw bytes from tap_far and
+        // length-frames them onto the stream, and vice versa.
+        let (tap_near, tap_far) = socketpair();
+        let (stream_near_raw, stream_far_raw) = socketpair();
+        let stream_near = UnixStream::from(stream_near_raw);
+        let mut stream_far = UnixStream::from(stream_far_raw);
+
+        let _bridge = start_netns_tap_bridge(stream_near, tap_near).unwrap();
+
+        // tap → stream: write a raw frame into the tap side; expect it framed on
+        // the stream side.
+        let frame = b"\xde\xad\xbe\xef hello ethernet";
+        let mut tap_far_w = UnixStream::from(tap_far);
+        tap_far_w.write_all(frame).unwrap();
+        let got = read_frame(&mut stream_far).unwrap();
+        assert_eq!(&got, frame);
+
+        // stream → tap: write a framed packet on the stream; expect raw bytes on
+        // the tap side.
+        let frame2 = b"reply frame \x00\x01\x02";
+        write_frame(&mut stream_far, frame2).unwrap();
+        let mut buf = vec![0u8; frame2.len()];
+        tap_far_w.read_exact(&mut buf).unwrap();
+        assert_eq!(&buf, frame2);
+    }
+}

--- a/crates/smolvm-protocol/src/lib.rs
+++ b/crates/smolvm-protocol/src/lib.rs
@@ -462,6 +462,95 @@ pub enum AgentRequest {
         /// Absolute path in the VM filesystem.
         path: String,
     },
+
+    /// Create (without starting) a Kubernetes pod container whose rootfs is a
+    /// virtiofs-shared host directory (containerd snapshotter output) and whose
+    /// process definition comes from the host's OCI config. The agent builds
+    /// its crun bundle around the shared rootfs; nothing runs until
+    /// `PodStart`. Part of the containerd shim v2 datapath
+    /// (docs/kubernetes-runtime.md).
+    PodCreate {
+        /// Container ID (containerd task id).
+        id: String,
+        /// Rootfs path relative to the sandbox's shared virtiofs mount. The
+        /// shim boots the sandbox VM with ONE shared dir and bind-mounts each
+        /// container's rootfs under it (virtiofs shares are fixed at boot, but
+        /// pod containers are created afterwards), so the guest resolves this
+        /// as `<sandbox-share-mount>/<rootfs_rel>`.
+        rootfs_rel: String,
+        /// The host OCI runtime spec (config.json bytes). The agent extracts
+        /// process/env/cwd/user/mounts/resources and grafts them onto its own
+        /// guest bundle template; host-specific namespaces/paths are ignored.
+        spec_json: String,
+        /// Allocate a PTY for the init process.
+        #[serde(default)]
+        tty: bool,
+    },
+
+    /// Start a pod container created by `PodCreate` (or an exec process
+    /// registered by `PodExec`), streaming its I/O on THIS connection:
+    /// `Started` → `Stdout`/`Stderr`... → `Exited`. Stdin arrives via `Stdin`
+    /// requests; PTY resize via `Resize`.
+    PodStart {
+        /// Container ID.
+        id: String,
+        /// Exec process to start instead of the init process.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        exec_id: Option<String>,
+    },
+
+    /// Register an exec process for a running pod container. Started later by
+    /// `PodStart { exec_id }`.
+    PodExec {
+        /// Container ID.
+        id: String,
+        /// Exec process ID (unique within the container).
+        exec_id: String,
+        /// OCI Process JSON (containerd's ExecProcessRequest spec).
+        process_json: String,
+        /// Allocate a PTY for the exec process.
+        #[serde(default)]
+        tty: bool,
+    },
+
+    /// Signal a pod container's init process (or one exec process).
+    PodSignal {
+        /// Container ID.
+        id: String,
+        /// Exec process to signal instead of init.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        exec_id: Option<String>,
+        /// Signal number (SIGKILL = 9, SIGTERM = 15, ...).
+        signal: u32,
+        /// Signal the whole container process group.
+        #[serde(default)]
+        all: bool,
+    },
+
+    /// List PIDs inside a pod container (guest view).
+    PodPids {
+        /// Container ID.
+        id: String,
+    },
+
+    /// Sample a pod container's resource usage (guest view). The agent reads the
+    /// container's process tree from /proc (there is no per-container cgroup); the
+    /// shim maps the reply into containerd's cgroups metrics for CRI stats.
+    PodStats {
+        /// Container ID.
+        id: String,
+    },
+
+    /// Remove a pod container's (or exec process's) guest resources after
+    /// exit: bundle, cgroup, PTY. Exit status was already streamed by
+    /// `PodStart`'s `Exited`.
+    PodDelete {
+        /// Container ID.
+        id: String,
+        /// Exec process to remove instead of the whole container.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        exec_id: Option<String>,
+    },
 }
 
 impl AgentRequest {
@@ -499,6 +588,24 @@ impl AgentRequest {
             AgentRequest::FileWriteBegin { .. } => "FileWriteBegin".into(),
             AgentRequest::FileWriteChunk { .. } => "FileWriteChunk".into(),
             AgentRequest::FileRead { .. } => "FileRead".into(),
+            // Pod requests: spec/process JSON may carry env secrets — emit ids only.
+            AgentRequest::PodCreate { id, .. } => format!("PodCreate {{ id: {id} }}"),
+            AgentRequest::PodStart { id, exec_id } => match exec_id {
+                Some(e) => format!("PodStart {{ id: {id}, exec: {e} }}"),
+                None => format!("PodStart {{ id: {id} }}"),
+            },
+            AgentRequest::PodExec { id, exec_id, .. } => {
+                format!("PodExec {{ id: {id}, exec: {exec_id} }}")
+            }
+            AgentRequest::PodSignal {
+                id, signal, all, ..
+            } => format!("PodSignal {{ id: {id}, signal: {signal}, all: {all} }}"),
+            AgentRequest::PodPids { id } => format!("PodPids {{ id: {id} }}"),
+            AgentRequest::PodStats { id } => format!("PodStats {{ id: {id} }}"),
+            AgentRequest::PodDelete { id, exec_id } => match exec_id {
+                Some(e) => format!("PodDelete {{ id: {id}, exec: {e} }}"),
+                None => format!("PodDelete {{ id: {id} }}"),
+            },
         }
     }
 }
@@ -578,6 +685,26 @@ pub enum AgentResponse {
     Exited {
         /// Exit code from the command.
         exit_code: i32,
+        /// The container was terminated by the cgroup OOM killer. The shim
+        /// turns this into a TaskOOM event so the CRI reports
+        /// `reason=OOMKilled`. Only ever set on a pod container's init exit.
+        #[serde(default)]
+        oom: bool,
+    },
+
+    /// PIDs inside a pod container (`PodPids` reply).
+    Pids {
+        /// Guest PIDs, container-init first when known.
+        pids: Vec<u32>,
+    },
+
+    /// Resource usage sample for a pod container (`PodStats` reply). Summed over
+    /// the container's process tree read from /proc (no per-container cgroup).
+    Stats {
+        /// Cumulative CPU time of the process tree, in nanoseconds.
+        cpu_usage_ns: u64,
+        /// Resident memory of the process tree, in bytes.
+        memory_bytes: u64,
     },
 
     /// Streaming binary-data chunk.

--- a/crates/smolvm-shim/Cargo.toml
+++ b/crates/smolvm-shim/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "smolvm-shim"
+version = "0.1.0"
+edition = "2021"
+description = "containerd shim v2 (io.containerd.smolvm.v2) — runs Kubernetes pods as smolvm microVMs"
+license = "Apache-2.0"
+
+[[bin]]
+name = "containerd-shim-smolvm-v2"
+path = "src/main.rs"
+
+# The shim is Linux-only (Kubernetes nodes). On other hosts the binary compiles
+# to a stub so `cargo check --workspace` stays green everywhere.
+[target.'cfg(target_os = "linux")'.dependencies]
+containerd-shim = { version = "0.11", features = ["async"] }
+containerd-shim-protos = { version = "0.11", features = ["async"] }
+async-trait = "0.1"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "io-util", "net", "fs", "signal"] }
+log = "0.4"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+nix = { version = "0.27", features = ["sched", "net", "socket", "fs", "signal", "mount"] }
+# The engine library: boots/tears down the per-pod sandbox microVM and carries
+# the agent vsock client the shim streams container I/O through.
+smolvm = { path = "../.." }
+smolvm-protocol = { path = "../smolvm-protocol" }
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+tempfile = "3"

--- a/crates/smolvm-shim/src/backend.rs
+++ b/crates/smolvm-shim/src/backend.rs
@@ -1,0 +1,256 @@
+//! The seam between the shim's Task-API state machine and the smolvm engine.
+//!
+//! The shim's correctness burden (state transitions, event ordering, exit
+//! propagation — everything critest asserts) lives above this trait; the VM
+//! mechanics live below it. `MockBackend` lets the whole state machine run in
+//! unit tests on any host; the engine-backed implementation (Linux) boots a
+//! smolvm microVM per pod sandbox and drives containers through the in-guest
+//! agent over vsock.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::{watch, Mutex};
+
+/// Stdio wiring for a process: containerd-side fifo paths (empty = not wired).
+#[derive(Debug, Clone, Default)]
+pub struct Stdio {
+    pub stdin: String,
+    pub stdout: String,
+    pub stderr: String,
+    pub terminal: bool,
+}
+
+/// What the pod backend needs to know to create a container or exec process.
+#[derive(Debug, Clone)]
+pub struct ProcessSpec {
+    /// OCI bundle dir on the host (config.json + rootfs mount target).
+    pub bundle: String,
+    /// Host rootfs path (already mounted by the shim from containerd's mounts).
+    pub rootfs: String,
+    pub stdio: Stdio,
+    /// For exec processes: the serialized OCI process spec from containerd.
+    pub exec_spec: Option<Vec<u8>>,
+}
+
+/// Exit information delivered exactly once per process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExitInfo {
+    pub status: u32,
+    /// Unix nanos; 0 = unknown.
+    pub exited_at_ns: i64,
+    /// The container's init was killed by the guest cgroup OOM killer. Drives a
+    /// TaskOOM event so the CRI reports `reason=OOMKilled`. Only the init exit
+    /// ever sets this.
+    pub oom: bool,
+}
+
+/// A channel that resolves when the process exits. `watch` so multiple Wait
+/// calls all observe it.
+pub type ExitWatch = watch::Receiver<Option<ExitInfo>>;
+
+/// Backend operations for one pod (sandbox VM + its containers).
+///
+/// Process addressing follows the Task API: `(container_id, exec_id)`, where
+/// an empty exec_id means the container's init process.
+#[async_trait]
+pub trait PodBackend: Send + Sync + 'static {
+    /// Boot the sandbox VM for this pod. Called once, from the sandbox
+    /// container's Create. Returns a nominal "pid" for the sandbox task.
+    async fn create_sandbox(
+        &self,
+        id: &str,
+        bundle: &str,
+        netns: Option<&str>,
+    ) -> Result<u32, String>;
+
+    /// Create (but do not start) a workload container in the sandbox VM.
+    async fn create_container(&self, id: &str, spec: ProcessSpec) -> Result<u32, String>;
+
+    /// Start a previously created container init process or exec process.
+    async fn start(&self, id: &str, exec_id: Option<&str>) -> Result<u32, String>;
+
+    /// Register an exec process (started later via `start`).
+    async fn create_exec(&self, id: &str, exec_id: &str, spec: ProcessSpec) -> Result<(), String>;
+
+    /// Deliver a signal. `all` = process group / whole container.
+    async fn kill(
+        &self,
+        id: &str,
+        exec_id: Option<&str>,
+        signal: u32,
+        all: bool,
+    ) -> Result<(), String>;
+
+    /// Watch for a process exit.
+    async fn wait_channel(&self, id: &str, exec_id: Option<&str>) -> Result<ExitWatch, String>;
+
+    /// Resize a terminal process's PTY.
+    async fn resize_pty(
+        &self,
+        id: &str,
+        exec_id: Option<&str>,
+        w: u32,
+        h: u32,
+    ) -> Result<(), String>;
+
+    /// Close the process's stdin.
+    async fn close_io(&self, id: &str, exec_id: Option<&str>) -> Result<(), String>;
+
+    /// Remove a container's resources (after exit). Sandbox delete tears down
+    /// the VM.
+    async fn delete(&self, id: &str, exec_id: Option<&str>) -> Result<(), String>;
+
+    /// PIDs visible in the container (guest view).
+    async fn pids(&self, id: &str) -> Result<Vec<u32>, String>;
+
+    /// Raw stats blob (cgroup metrics protobuf), if available.
+    async fn stats(&self, id: &str) -> Result<Option<Vec<u8>>, String>;
+}
+
+// ============================== MockBackend ==============================
+
+/// In-process fake used by unit tests: processes are entries in a map whose
+/// exits are triggered by tests (or immediately on kill).
+#[derive(Default)]
+pub struct MockBackend {
+    inner: Mutex<HashMap<String, MockProc>>,
+}
+
+struct MockProc {
+    running: bool,
+    tx: watch::Sender<Option<ExitInfo>>,
+    rx: ExitWatch,
+    next_pid: u32,
+}
+
+fn key(id: &str, exec_id: Option<&str>) -> String {
+    match exec_id {
+        Some(e) if !e.is_empty() => format!("{id}/{e}"),
+        _ => id.to_string(),
+    }
+}
+
+impl MockBackend {
+    /// Test-only convenience (the production path wraps the mock in
+    /// `engine::ShimBackend`, which needs it by value, not in an Arc).
+    #[allow(dead_code)]
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    /// Test hook: mark a process exited.
+    #[allow(dead_code)]
+    pub async fn finish(&self, id: &str, exec_id: Option<&str>, status: u32) {
+        let map = self.inner.lock().await;
+        if let Some(p) = map.get(&key(id, exec_id)) {
+            let _ = p.tx.send(Some(ExitInfo {
+                status,
+                exited_at_ns: 1_700_000_000_000_000_000,
+                oom: false,
+            }));
+        }
+    }
+
+    async fn insert(&self, k: String, pid: u32) {
+        let (tx, rx) = watch::channel(None);
+        self.inner.lock().await.insert(
+            k,
+            MockProc {
+                running: false,
+                tx,
+                rx,
+                next_pid: pid,
+            },
+        );
+    }
+}
+
+#[async_trait]
+impl PodBackend for MockBackend {
+    async fn create_sandbox(
+        &self,
+        id: &str,
+        _bundle: &str,
+        _netns: Option<&str>,
+    ) -> Result<u32, String> {
+        self.insert(key(id, None), 1).await;
+        Ok(1)
+    }
+
+    async fn create_container(&self, id: &str, _spec: ProcessSpec) -> Result<u32, String> {
+        self.insert(key(id, None), 100).await;
+        Ok(100)
+    }
+
+    async fn start(&self, id: &str, exec_id: Option<&str>) -> Result<u32, String> {
+        let mut map = self.inner.lock().await;
+        let p = map
+            .get_mut(&key(id, exec_id))
+            .ok_or_else(|| format!("no such process {}", key(id, exec_id)))?;
+        p.running = true;
+        Ok(p.next_pid)
+    }
+
+    async fn create_exec(&self, id: &str, exec_id: &str, _spec: ProcessSpec) -> Result<(), String> {
+        self.insert(key(id, Some(exec_id)), 200).await;
+        Ok(())
+    }
+
+    async fn kill(
+        &self,
+        id: &str,
+        exec_id: Option<&str>,
+        signal: u32,
+        _all: bool,
+    ) -> Result<(), String> {
+        let map = self.inner.lock().await;
+        let p = map
+            .get(&key(id, exec_id))
+            .ok_or_else(|| "no such process".to_string())?;
+        // SIGKILL/SIGTERM end the mock process immediately.
+        if signal == 9 || signal == 15 {
+            let _ = p.tx.send(Some(ExitInfo {
+                status: 137,
+                exited_at_ns: 1_700_000_000_000_000_000,
+                oom: false,
+            }));
+        }
+        Ok(())
+    }
+
+    async fn wait_channel(&self, id: &str, exec_id: Option<&str>) -> Result<ExitWatch, String> {
+        let map = self.inner.lock().await;
+        map.get(&key(id, exec_id))
+            .map(|p| p.rx.clone())
+            .ok_or_else(|| "no such process".to_string())
+    }
+
+    async fn resize_pty(
+        &self,
+        _id: &str,
+        _exec_id: Option<&str>,
+        _w: u32,
+        _h: u32,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn close_io(&self, _id: &str, _exec_id: Option<&str>) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn delete(&self, id: &str, exec_id: Option<&str>) -> Result<(), String> {
+        self.inner.lock().await.remove(&key(id, exec_id));
+        Ok(())
+    }
+
+    async fn pids(&self, _id: &str) -> Result<Vec<u32>, String> {
+        Ok(vec![1])
+    }
+
+    async fn stats(&self, _id: &str) -> Result<Option<Vec<u8>>, String> {
+        Ok(None)
+    }
+}

--- a/crates/smolvm-shim/src/bundle.rs
+++ b/crates/smolvm-shim/src/bundle.rs
@@ -1,0 +1,107 @@
+//! OCI bundle inspection + rootfs mounting.
+//!
+//! containerd hands the shim a bundle dir (config.json) and a list of rootfs
+//! mounts (e.g. one overlay mount). The CRI plugin marks pod-sandbox vs
+//! workload containers with annotations, and passes the pod netns path on the
+//! sandbox's config.
+
+use std::path::Path;
+
+use log::warn;
+use serde::Deserialize;
+
+/// CRI annotation: "sandbox" (the pause container) or "container".
+const ANN_CONTAINER_TYPE: &str = "io.kubernetes.cri.container-type";
+/// CRI annotation on sandboxes: host path of the pod's network namespace.
+const ANN_SANDBOX_NETNS: &str = "io.kubernetes.cri.sandbox-network-ns";
+
+#[derive(Debug, Default)]
+pub struct BundleInfo {
+    pub is_sandbox: bool,
+    pub netns: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct MinimalSpec {
+    #[serde(default)]
+    annotations: std::collections::HashMap<String, String>,
+    #[serde(default)]
+    linux: Option<MinimalLinux>,
+}
+
+#[derive(Deserialize)]
+struct MinimalLinux {
+    #[serde(default)]
+    namespaces: Vec<MinimalNs>,
+}
+
+#[derive(Deserialize)]
+struct MinimalNs {
+    #[serde(rename = "type")]
+    ns_type: String,
+    #[serde(default)]
+    path: Option<String>,
+}
+
+/// Read the bundle's config.json and classify it.
+pub fn load(bundle: &str) -> Result<BundleInfo, String> {
+    let cfg = Path::new(bundle).join("config.json");
+    let raw = std::fs::read_to_string(&cfg).map_err(|e| format!("read {}: {e}", cfg.display()))?;
+    let spec: MinimalSpec =
+        serde_json::from_str(&raw).map_err(|e| format!("parse {}: {e}", cfg.display()))?;
+
+    let is_sandbox = spec
+        .annotations
+        .get(ANN_CONTAINER_TYPE)
+        .map(|v| v == "sandbox")
+        // No CRI annotations (plain `ctr run`): treat the task as its own
+        // sandbox so a bare container still gets a VM.
+        .unwrap_or(true);
+
+    // Netns: prefer the CRI annotation, else the OCI network namespace path.
+    let netns = spec
+        .annotations
+        .get(ANN_SANDBOX_NETNS)
+        .cloned()
+        .or_else(|| {
+            spec.linux.as_ref().and_then(|l| {
+                l.namespaces
+                    .iter()
+                    .find(|n| n.ns_type == "network")
+                    .and_then(|n| n.path.clone())
+                    .filter(|p| !p.is_empty())
+            })
+        });
+
+    Ok(BundleInfo { is_sandbox, netns })
+}
+
+/// Mount containerd's rootfs mounts at `<bundle>/rootfs`, returning that path.
+/// No mounts (tests, pre-mounted rootfs) is fine — the directory is used as-is.
+pub async fn mount_rootfs(
+    bundle: &str,
+    mounts: &[containerd_shim_protos::api::Mount],
+) -> Result<String, String> {
+    let target = Path::new(bundle).join("rootfs");
+    tokio::fs::create_dir_all(&target)
+        .await
+        .map_err(|e| format!("mkdir {}: {e}", target.display()))?;
+    for m in mounts {
+        containerd_shim::mount::mount_rootfs(
+            Some(m.type_.as_str()),
+            Some(m.source.as_str()),
+            &m.options.to_vec(),
+            &target,
+        )
+        .map_err(|e| format!("mount rootfs ({}): {e}", m.type_))?;
+    }
+    Ok(target.to_string_lossy().into_owned())
+}
+
+/// Unmount `<bundle>/rootfs` (best-effort; may never have been mounted).
+pub async fn unmount_rootfs(bundle: &str) {
+    let target = Path::new(bundle).join("rootfs");
+    if let Err(e) = containerd_shim::mount::umount_recursive(target.to_str(), 0) {
+        warn!("umount {}: {e}", target.display());
+    }
+}

--- a/crates/smolvm-shim/src/engine.rs
+++ b/crates/smolvm-shim/src/engine.rs
@@ -1,0 +1,1256 @@
+//! Engine-backed [`PodBackend`]: one smolvm microVM per pod sandbox.
+//!
+//! Uses the embeddable engine API (`smolvm::embedded`, the same surface the
+//! Python/Node SDKs drive) to boot/tear down the sandbox VM, and the agent's
+//! Pod* protocol (see `smolvm_protocol::AgentRequest`) over vsock to run
+//! containers inside it:
+//!
+//! - `create_sandbox` → create + start a persistent machine named after the
+//!   sandbox id, with ONE host mount: `<bundle>/podshare` shared into the
+//!   guest. Container rootfs dirs are bind-mounted under that share afterwards
+//!   (virtiofs shares are fixed at boot; pod containers are created later).
+//! - `create_container`/`create_exec` → bind-mount the rootfs into the share,
+//!   then `PodCreate`/`PodExec` on a short-lived agent connection.
+//! - `start` → a DEDICATED agent connection per process: `PodStart` streams
+//!   `Started` → `Stdout`/`Stderr`… → `Exited` on that connection, pumped to
+//!   containerd's fifos by a per-process blocking thread (see [`run_pump`]).
+//! - `kill`/`pids`/`delete` → `PodSignal`/`PodPids`/`PodDelete`; deleting the
+//!   sandbox id stops + deletes the machine itself.
+//!
+//! The engine API is synchronous, so every engine/agent call is wrapped in
+//! `tokio::task::spawn_blocking`.
+
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::mpsc::{Receiver, SyncSender, TryRecvError};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use log::{debug, warn};
+use tokio::sync::watch;
+
+use smolvm::agent::{AgentClient, HostMount, VmResources};
+use smolvm::embedded::MachineSpec;
+use smolvm::network::NetworkBackend;
+use smolvm_protocol::{AgentRequest, AgentResponse};
+
+use crate::backend::{ExitInfo, ExitWatch, PodBackend, ProcessSpec, Stdio};
+
+/// Nominal guest target recorded on the sandbox's single [`HostMount`]
+/// (host side: `<bundle>/podshare`). `HostMount` targets only take effect for
+/// container `Run` mount tuples, which the pod datapath doesn't use — the
+/// actual guest mount is performed by [`mount_pod_share_in_guest`] at
+/// [`POD_SHARE_GUEST_MOUNT`].
+/// Host root for pod shares — a dedicated, non-protected location (the OCI
+/// bundle lives under /run/containerd, which the engine's mount validation
+/// rejects). One `<id>/podshare` subdir per sandbox.
+const POD_SHARE_HOST_ROOT: &str = "/var/lib/containerd-shim-smolvm";
+
+const POD_SHARE_GUEST_PATH: &str = "/podshare";
+
+/// Where the agent's pod handlers resolve `PodCreate.rootfs_rel` from:
+/// `paths::VIRTIOFS_MOUNT_ROOT` + `pod::POD_SHARE_TAG` in smolvm-agent. Must
+/// stay in lockstep with those constants.
+const POD_SHARE_GUEST_MOUNT: &str = "/mnt/virtiofs/podshare";
+
+/// Default sandbox VM sizing until pod-overhead plumbing lands.
+const SANDBOX_CPUS: u8 = 2;
+const SANDBOX_MEMORY_MIB: u32 = 1024;
+
+/// How long `start` waits for the agent's `Started` frame.
+const START_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Pump poll cadence: the streaming connection's read timeout, which bounds
+/// how stale stdin/resize forwarding can get.
+const PUMP_POLL: Duration = Duration::from_millis(50);
+
+/// Synthetic guest-process pids reported to containerd. The agent does not
+/// report real guest pids on `Started`, and containerd only needs a stable,
+/// non-zero identifier per process.
+static NEXT_PID: AtomicU32 = AtomicU32::new(1000);
+
+fn next_pid() -> u32 {
+    NEXT_PID.fetch_add(1, Ordering::Relaxed)
+}
+
+fn now_ns() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as i64)
+        .unwrap_or(0)
+}
+
+fn key(id: &str, exec_id: Option<&str>) -> String {
+    match exec_id {
+        Some(e) if !e.is_empty() => format!("{id}/{e}"),
+        _ => id.to_string(),
+    }
+}
+
+/// Commands the async side sends into a process's pump thread. The pump owns
+/// the process's streaming agent connection, so PTY resizes and stdin-close
+/// must be relayed through it.
+enum PumpCmd {
+    Resize { cols: u16, rows: u16 },
+    CloseStdin,
+}
+
+struct Sandbox {
+    /// Sandbox task id == machine name.
+    id: String,
+    /// Host dir shared into the guest (`<bundle>/podshare`).
+    share_dir: PathBuf,
+    /// Host-side unix socket bridging to the guest agent's vsock port.
+    socket: PathBuf,
+    /// Pod network namespace path (recorded now, wired by the netns-tap
+    /// backend later — see docs/kubernetes-runtime.md "Networking detail").
+    #[allow(dead_code)]
+    netns: Option<String>,
+    /// Pod UTS hostname from the sandbox OCI spec. Injected into each container's
+    /// spec (containerd puts the pod hostname on the sandbox, not the container).
+    hostname: Option<String>,
+    /// Pod sysctls (`linux.sysctl` on the sandbox OCI spec). Merged into every
+    /// container's spec so crun applies them in the container's namespaces —
+    /// the VM-per-pod equivalent of runc inheriting them from the shared pause.
+    sysctls: Option<serde_json::Value>,
+}
+
+struct ProcEntry {
+    stdio: Stdio,
+    pid: u32,
+    exit_tx: Arc<watch::Sender<Option<ExitInfo>>>,
+    exit_rx: ExitWatch,
+    /// Present once the process was started (the pump thread is running).
+    cmd_tx: Option<std::sync::mpsc::Sender<PumpCmd>>,
+}
+
+impl ProcEntry {
+    fn new(stdio: Stdio, pid: u32) -> Self {
+        let (tx, rx) = watch::channel(None);
+        Self {
+            stdio,
+            pid,
+            exit_tx: Arc::new(tx),
+            exit_rx: rx,
+            cmd_tx: None,
+        }
+    }
+}
+
+pub struct EnginePodBackend {
+    sandbox: Mutex<Option<Arc<Sandbox>>>,
+    procs: Mutex<HashMap<String, ProcEntry>>,
+}
+
+impl EnginePodBackend {
+    pub fn new() -> Self {
+        // Once per shim process, reclaim sandbox VMs left behind by a node reboot
+        // or a shim crash (dead process, but the persistent record + disk images
+        // survive). containerd can't drive this cleanup after a reboot — its task
+        // state in /run is gone, so it never asks us to delete those sandboxes.
+        static RECONCILED: std::sync::Once = std::sync::Once::new();
+        RECONCILED.call_once(|| match smolvm::embedded::runtime() {
+            Ok(rt) => match rt.reconcile_runtime_machines() {
+                Ok(n) if n > 0 => log::info!("reclaimed {n} stale sandbox VM(s) at startup"),
+                Ok(_) => {}
+                Err(e) => log::warn!("startup sandbox reconcile failed: {e}"),
+            },
+            Err(e) => log::warn!("startup sandbox reconcile: runtime unavailable: {e}"),
+        });
+        Self {
+            sandbox: Mutex::new(None),
+            procs: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn sandbox(&self) -> Result<Arc<Sandbox>, String> {
+        self.sandbox
+            .lock()
+            .map_err(|e| e.to_string())?
+            .clone()
+            .ok_or_else(|| "no sandbox created for this pod".to_string())
+    }
+
+    fn is_sandbox_task(&self, id: &str, exec_id: Option<&str>) -> bool {
+        exec_id.is_none()
+            && self
+                .sandbox
+                .lock()
+                .ok()
+                .and_then(|s| s.as_ref().map(|s| s.id == id))
+                .unwrap_or(false)
+    }
+
+    fn insert_proc(&self, k: String, entry: ProcEntry) -> Result<(), String> {
+        self.procs
+            .lock()
+            .map_err(|e| e.to_string())?
+            .insert(k, entry);
+        Ok(())
+    }
+}
+
+// ========================== blocking agent helpers ==========================
+
+fn connect(socket: &Path) -> Result<AgentClient, String> {
+    AgentClient::connect_with_retry(socket).map_err(|e| format!("connect to sandbox agent: {e}"))
+}
+
+/// One-shot request/response on a fresh agent connection. All Pod* control
+/// requests (create/exec/signal/pids/delete) are single-frame exchanges, so a
+/// short-lived connection per request keeps them independent of the per-process
+/// streaming connections.
+fn pod_request(socket: &Path, req: &AgentRequest) -> Result<AgentResponse, String> {
+    let mut client = connect(socket)?;
+    client
+        .send_raw(req)
+        .map_err(|e| format!("send {}: {e}", req.log_summary()))?;
+    // Skip Progress-style frames; return the first terminal response.
+    loop {
+        match client
+            .recv_raw()
+            .map_err(|e| format!("recv {}: {e}", req.log_summary()))?
+        {
+            AgentResponse::Progress { .. } => continue,
+            resp => return Ok(resp),
+        }
+    }
+}
+
+fn expect_ok(resp: AgentResponse, op: &str) -> Result<(), String> {
+    match resp {
+        AgentResponse::Ok { .. } => Ok(()),
+        AgentResponse::Error { message, .. } => Err(format!("{op}: {message}")),
+        other => Err(format!("{op}: unexpected agent response {other:?}")),
+    }
+}
+
+/// Mount the sandbox's shared virtiofs directory where the agent's pod
+/// handlers expect it: `/mnt/virtiofs/podshare` (the agent's
+/// `paths::VIRTIOFS_MOUNT_ROOT` + `pod::POD_SHARE_TAG`).
+///
+/// Two conventions are bridged here. The launcher tags virtiofs devices
+/// `smolvm{index}` (`HostMount::mount_tag`) — the sandbox's single share is
+/// therefore device tag `smolvm0` — and the agent only mounts tags lazily when
+/// a `Run` request references them, which the pod datapath never does. So the
+/// shim mounts the device itself, once, right after boot, via `VmExec` in the
+/// agent rootfs. Idempotent (`mountpoint -q ||`) for shim-reconnect paths.
+/// Apply the pod's `net.*` sysctls to the guest kernel. Pod containers declare
+/// no network namespace of their own, so they share the guest's — writing these
+/// under the guest's `/proc/sys/net` is what every container in the pod observes.
+/// Best-effort: a sysctl the guest kernel doesn't expose is skipped, never fatal
+/// to sandbox creation (matching the rest of the sandbox setup path).
+fn apply_guest_net_sysctls(
+    socket: &Path,
+    sysctls: &serde_json::Map<String, serde_json::Value>,
+) -> Result<(), String> {
+    let mut cmds = Vec::new();
+    for (k, v) in sysctls {
+        if !k.starts_with("net.") {
+            continue;
+        }
+        let Some(val) = v.as_str() else { continue };
+        // Reject values containing a single quote so the shell-quoting below is
+        // safe; sysctl values are numbers or space/tab-separated number ranges.
+        if val.contains('\'') {
+            continue;
+        }
+        let path = format!("/proc/sys/{}", k.replace('.', "/"));
+        cmds.push(format!("printf '%s' '{val}' > {path} 2>/dev/null || true"));
+    }
+    if cmds.is_empty() {
+        return Ok(());
+    }
+    let resp = pod_request(
+        socket,
+        &AgentRequest::VmExec {
+            command: vec!["/bin/sh".into(), "-c".into(), cmds.join("; ")],
+            env: Vec::new(),
+            workdir: None,
+            timeout_ms: Some(10_000),
+            interactive: false,
+            tty: false,
+            background: false,
+            stdin_data: None,
+        },
+    )?;
+    match resp {
+        AgentResponse::Completed { .. } => Ok(()),
+        other => Err(format!(
+            "apply net sysctls: unexpected agent response {other:?}"
+        )),
+    }
+}
+
+fn mount_pod_share_in_guest(socket: &Path) -> Result<(), String> {
+    let share_tag = HostMount::mount_tag(0);
+    let script = format!(
+        "mkdir -p {POD_SHARE_GUEST_MOUNT} && \
+         (mountpoint -q {POD_SHARE_GUEST_MOUNT} || \
+          mount -t virtiofs {share_tag} {POD_SHARE_GUEST_MOUNT})"
+    );
+    let resp = pod_request(
+        socket,
+        &AgentRequest::VmExec {
+            command: vec!["/bin/sh".into(), "-c".into(), script],
+            env: Vec::new(),
+            workdir: None,
+            timeout_ms: Some(10_000),
+            interactive: false,
+            tty: false,
+            background: false,
+            stdin_data: None,
+        },
+    )?;
+    match resp {
+        AgentResponse::Completed { exit_code: 0, .. } => Ok(()),
+        AgentResponse::Completed {
+            exit_code, stderr, ..
+        } => Err(format!(
+            "mount pod share in guest failed (exit {exit_code}): {}",
+            String::from_utf8_lossy(&stderr)
+        )),
+        AgentResponse::Error { message, .. } => Err(format!("mount pod share in guest: {message}")),
+        other => Err(format!(
+            "mount pod share in guest: unexpected agent response {other:?}"
+        )),
+    }
+}
+
+/// True when a client error is the pump's poll-cadence read timeout rather
+/// than a real failure (`PUMP_POLL` read timeout on the streaming socket).
+fn is_timeout(e: &smolvm::Error) -> bool {
+    e.is_io()
+        && matches!(
+            e.source_io_error_kind(),
+            Some(std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut)
+        )
+}
+
+// ================================ stdio pump ================================
+
+fn open_fifo_writer(path: &str) -> Option<std::fs::File> {
+    if path.is_empty() {
+        return None;
+    }
+    // Blocks until the read end is open; containerd wires its fifo readers up
+    // before Start/Exec return, so this resolves promptly.
+    match std::fs::OpenOptions::new().write(true).open(path) {
+        Ok(f) => Some(f),
+        Err(e) => {
+            warn!("open fifo {path} for write: {e}");
+            None
+        }
+    }
+}
+
+fn open_fifo_stdin(path: &str) -> Option<std::fs::File> {
+    if path.is_empty() {
+        return None;
+    }
+    // O_RDWR (not O_RDONLY) so the fifo always has a writer and reads never
+    // return a spurious EOF before containerd attaches; real stdin close is
+    // signalled explicitly via the CloseIO RPC → PumpCmd::CloseStdin.
+    // O_NONBLOCK so the single pump thread can poll it between output frames.
+    use std::os::unix::fs::OpenOptionsExt;
+    match std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .custom_flags(nix::libc::O_NONBLOCK)
+        .open(path)
+    {
+        Ok(f) => Some(f),
+        Err(e) => {
+            warn!("open stdin fifo {path}: {e}");
+            None
+        }
+    }
+}
+
+/// Per-process stdio pump. Runs on its own blocking thread and OWNS the
+/// process's dedicated streaming agent connection:
+///
+/// ```text
+///   async trait methods ──(mpsc PumpCmd: Resize/CloseStdin)──► pump thread
+///   stdin fifo (nonblocking read) ──────────────────────────►    │
+///   agent Stdout/Stderr frames ◄── vsock ── PodStart connection ─┘
+///        │                                     │
+///        ▼                                     ▼
+///   stdout/stderr fifos                Exited → watch<ExitInfo>
+/// ```
+///
+/// Sequence: connect → `PodStart` → wait `Started` → ack `started_tx` (this is
+/// what unblocks the Task API `Start` call) → open fifos → poll loop. The loop
+/// alternates: drain `PumpCmd`s, forward pending stdin bytes as `Stdin`
+/// requests, then block up to [`PUMP_POLL`] for one agent frame. On `Exited`
+/// the exit is published on the watch channel exactly once and the thread
+/// (and its connection) winds down; any earlier failure publishes exit 255 so
+/// waiters never hang.
+#[allow(clippy::too_many_arguments)]
+fn run_pump(
+    socket: PathBuf,
+    id: String,
+    exec_id: Option<String>,
+    stdio: Stdio,
+    exit_tx: Arc<watch::Sender<Option<ExitInfo>>>,
+    cmd_rx: Receiver<PumpCmd>,
+    started_tx: SyncSender<Result<(), String>>,
+) {
+    // Phase 1: dedicated connection + PodStart + Started.
+    let setup = || -> Result<AgentClient, String> {
+        let mut client = connect(&socket)?;
+        client
+            .send_raw(&AgentRequest::PodStart {
+                id: id.clone(),
+                exec_id: exec_id.clone(),
+            })
+            .map_err(|e| format!("send PodStart: {e}"))?;
+        match client
+            .recv_raw()
+            .map_err(|e| format!("recv PodStart: {e}"))?
+        {
+            AgentResponse::Started => Ok(client),
+            AgentResponse::Error { message, .. } => Err(format!("PodStart: {message}")),
+            other => Err(format!("PodStart: unexpected response {other:?}")),
+        }
+    };
+    let mut client = match setup() {
+        Ok(c) => c,
+        Err(e) => {
+            let _ = started_tx.send(Err(e));
+            return;
+        }
+    };
+    let _ = started_tx.send(Ok(()));
+
+    // Phase 2: pump until Exited (or the connection dies).
+    if let Err(e) = pump_loop(&mut client, &stdio, &exit_tx, &cmd_rx) {
+        warn!("stdio pump for {}: {e}", key(&id, exec_id.as_deref()));
+    }
+    // Never leave waiters hanging: if the loop ended without a real exit
+    // (connection lost, agent error), publish exit 255.
+    if exit_tx.borrow().is_none() {
+        let _ = exit_tx.send(Some(ExitInfo {
+            status: 255,
+            exited_at_ns: now_ns(),
+            oom: false,
+        }));
+    }
+}
+
+fn pump_loop(
+    client: &mut AgentClient,
+    stdio: &Stdio,
+    exit_tx: &watch::Sender<Option<ExitInfo>>,
+    cmd_rx: &Receiver<PumpCmd>,
+) -> Result<(), String> {
+    let mut stdout = open_fifo_writer(&stdio.stdout);
+    // A terminal process multiplexes all output on the PTY (stdout); the agent
+    // only sends Stderr frames for non-tty processes.
+    let mut stderr = if stdio.terminal {
+        None
+    } else {
+        open_fifo_writer(&stdio.stderr)
+    };
+    let mut stdin = open_fifo_stdin(&stdio.stdin);
+
+    // Poll-cadence read timeout for the frame loop; the guard restores the
+    // default on drop (moot — the connection is dropped with the pump).
+    let _guard = client
+        .set_extended_read_timeout(PUMP_POLL)
+        .map_err(|e| format!("set pump read timeout: {e}"))?;
+
+    let mut inbuf = [0u8; 8192];
+    loop {
+        // 1) Relay commands from the async side.
+        loop {
+            match cmd_rx.try_recv() {
+                Ok(PumpCmd::Resize { cols, rows }) => {
+                    client
+                        .send_raw(&AgentRequest::Resize { cols, rows })
+                        .map_err(|e| format!("send Resize: {e}"))?;
+                }
+                Ok(PumpCmd::CloseStdin) => {
+                    if stdin.take().is_some() {
+                        // Empty Stdin frame = EOF (matches the interactive protocol).
+                        client
+                            .send_raw(&AgentRequest::Stdin { data: Vec::new() })
+                            .map_err(|e| format!("send stdin EOF: {e}"))?;
+                    }
+                }
+                // Empty: nothing pending. Disconnected: backend entry deleted;
+                // keep pumping output until the process exits.
+                Err(TryRecvError::Empty) | Err(TryRecvError::Disconnected) => break,
+            }
+        }
+
+        // 2) Forward pending stdin bytes.
+        if let Some(f) = stdin.as_mut() {
+            match f.read(&mut inbuf) {
+                Ok(0) => {
+                    // Can't happen while we hold the O_RDWR write end, but be
+                    // safe: treat as EOF.
+                    stdin = None;
+                    client
+                        .send_raw(&AgentRequest::Stdin { data: Vec::new() })
+                        .map_err(|e| format!("send stdin EOF: {e}"))?;
+                }
+                Ok(n) => {
+                    client
+                        .send_raw(&AgentRequest::Stdin {
+                            data: inbuf[..n].to_vec(),
+                        })
+                        .map_err(|e| format!("send Stdin: {e}"))?;
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(e) => {
+                    warn!("read stdin fifo: {e}");
+                    stdin = None;
+                }
+            }
+        }
+
+        // 3) One agent frame (blocks up to PUMP_POLL).
+        match client.recv_raw() {
+            Ok(AgentResponse::Stdout { data }) => {
+                if let Some(f) = stdout.as_mut() {
+                    if let Err(e) = f.write_all(&data) {
+                        // Reader side gone (EPIPE): stop writing, keep pumping.
+                        debug!("write stdout fifo: {e}");
+                        stdout = None;
+                    }
+                }
+            }
+            Ok(AgentResponse::Stderr { data }) => {
+                if let Some(f) = stderr.as_mut() {
+                    if let Err(e) = f.write_all(&data) {
+                        debug!("write stderr fifo: {e}");
+                        stderr = None;
+                    }
+                }
+            }
+            Ok(AgentResponse::Exited { exit_code, oom }) => {
+                let _ = exit_tx.send(Some(ExitInfo {
+                    status: exit_code as u32,
+                    exited_at_ns: now_ns(),
+                    oom,
+                }));
+                return Ok(());
+            }
+            Ok(AgentResponse::Error { message, .. }) => {
+                return Err(format!("agent error: {message}"));
+            }
+            Ok(_) => {}
+            Err(e) if is_timeout(&e) => {}
+            Err(e) => return Err(format!("streaming connection lost: {e}")),
+        }
+    }
+}
+
+// ============================== trait impl ==================================
+
+#[async_trait]
+impl PodBackend for EnginePodBackend {
+    async fn create_sandbox(
+        &self,
+        id: &str,
+        bundle: &str,
+        netns: Option<&str>,
+    ) -> Result<u32, String> {
+        let id_owned = id.to_string();
+        let bundle = bundle.to_string();
+        let netns = netns.map(str::to_string);
+
+        let (sandbox, pid) = tokio::task::spawn_blocking(move || {
+            // The pod hostname and sysctls are on the SANDBOX OCI spec (containerd
+            // doesn't put them on each container's spec); read them now to inject
+            // into every container.
+            let sandbox_spec = std::fs::read_to_string(Path::new(&bundle).join("config.json"))
+                .ok()
+                .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok());
+            let hostname = sandbox_spec.as_ref().and_then(|v| {
+                v.get("hostname")
+                    .and_then(|h| h.as_str())
+                    .filter(|s| !s.is_empty())
+                    .map(String::from)
+            });
+            let sysctls = sandbox_spec
+                .as_ref()
+                .and_then(|v| v.pointer("/linux/sysctl"))
+                .filter(|v| v.as_object().map(|o| !o.is_empty()).unwrap_or(false))
+                .cloned();
+
+            // The bundle lives under /run/containerd/... which the engine's mount
+            // validation rejects as a protected system path. Host the pod share
+            // in a dedicated, non-protected dir keyed by sandbox id instead.
+            let share_dir = Path::new(POD_SHARE_HOST_ROOT)
+                .join(&id_owned)
+                .join("podshare");
+            std::fs::create_dir_all(&share_dir)
+                .map_err(|e| format!("mkdir {}: {e}", share_dir.display()))?;
+
+            let rt = smolvm::embedded::runtime().map_err(|e| e.to_string())?;
+            let mount = HostMount::new(&share_dir, POD_SHARE_GUEST_PATH, false)
+                .map_err(|e| format!("pod share mount: {e}"))?;
+            let spec = MachineSpec {
+                name: id_owned.clone(),
+                mounts: vec![mount],
+                ports: Vec::new(),
+                resources: VmResources {
+                    cpus: SANDBOX_CPUS,
+                    memory_mib: SANDBOX_MEMORY_MIB,
+                    network: true,
+                    // virtio-net (not TSI) gives the sandbox a real L2 NIC — the
+                    // prerequisite for bridging it to a CNI tap in the pod netns
+                    // so the pod carries its CNI-assigned IP.
+                    network_backend: Some(NetworkBackend::VirtioNet),
+                    ..VmResources::default()
+                },
+                persistent: true,
+                runtime_managed: true,
+            };
+            match rt.create_machine(spec.clone()) {
+                Ok(()) => {}
+                // A stale record with this sandbox id (crashed shim, unclean
+                // node shutdown) can't be reused: replace it.
+                Err(smolvm::Error::Agent {
+                    kind: smolvm::error::AgentErrorKind::Conflict,
+                    ..
+                }) => {
+                    warn!("sandbox machine {id_owned} already exists; recreating");
+                    let _ = rt.delete_machine(&id_owned);
+                    rt.create_machine(spec).map_err(|e| e.to_string())?;
+                }
+                Err(e) => return Err(e.to_string()),
+            }
+            // With a CNI netns, bridge the sandbox's virtio-net NIC into it so
+            // the pod carries its CNI-assigned IP; otherwise a plain start (the
+            // VM keeps smolvm's NAT gateway — outbound only, no pod IP).
+            match netns.as_deref() {
+                Some(ns) => rt
+                    .start_machine_with_netns(&id_owned, std::path::PathBuf::from(ns))
+                    .map_err(|e| format!("start sandbox VM (netns {ns}): {e}"))?,
+                None => rt
+                    .start_machine(&id_owned)
+                    .map_err(|e| format!("start sandbox VM: {e}"))?,
+            }
+
+            let pid = rt
+                .pid(&id_owned)
+                .and_then(|p| u32::try_from(p).ok())
+                .unwrap_or(1);
+            let socket = smolvm::agent::vm_data_dir(&id_owned).join("agent.sock");
+            mount_pod_share_in_guest(&socket)?;
+            // Pod net.* sysctls apply guest-wide (shared net namespace); the
+            // ipc/uts ones ride on each container's spec (see materialize_bind_mounts).
+            if let Some(serde_json::Value::Object(map)) = sysctls.as_ref() {
+                apply_guest_net_sysctls(&socket, map)?;
+            }
+            Ok::<_, String>((
+                Sandbox {
+                    id: id_owned,
+                    share_dir,
+                    socket,
+                    netns,
+                    hostname,
+                    sysctls,
+                },
+                pid,
+            ))
+        })
+        .await
+        .map_err(|e| e.to_string())??;
+
+        *self.sandbox.lock().map_err(|e| e.to_string())? = Some(Arc::new(sandbox));
+        self.insert_proc(key(id, None), ProcEntry::new(Stdio::default(), pid))?;
+        Ok(pid)
+    }
+
+    async fn create_container(&self, id: &str, spec: ProcessSpec) -> Result<u32, String> {
+        let sandbox = self.sandbox()?;
+        let id_owned = id.to_string();
+        let stdio = spec.stdio.clone();
+        let pid = next_pid();
+
+        tokio::task::spawn_blocking(move || {
+            // Materialize the container rootfs under the pod share as plain
+            // files, so the guest sees it through the boot-time virtiofs mount.
+            //
+            // We deliberately COPY rather than bind-mount the containerd overlay:
+            // an overlayfs re-exported through virtiofs can't service the guest's
+            // copy-up writes (crun's `mkdir /proc` fails EACCES), the same reason
+            // Kata doesn't stack overlay-on-virtiofs. A per-container copy is also
+            // semantically correct for Kubernetes — the container filesystem is
+            // ephemeral (writes vanish on container delete), which is exactly the
+            // lifecycle of this copy. `cp -a` preserves modes/owners/symlinks;
+            // reflink makes it near-free when the share and snapshot share a fs.
+            let target = sandbox.share_dir.join(&id_owned).join("rootfs");
+            std::fs::create_dir_all(&target)
+                .map_err(|e| format!("mkdir {}: {e}", target.display()))?;
+            let src_glob = format!("{}/.", spec.rootfs);
+            let status = std::process::Command::new("cp")
+                .args(["-a", "--reflink=auto", &src_glob])
+                .arg(&target)
+                .status()
+                .map_err(|e| format!("spawn cp for rootfs: {e}"))?;
+            if !status.success() {
+                return Err(format!(
+                    "copy rootfs {} -> {}: cp exited {status}",
+                    spec.rootfs,
+                    target.display()
+                ));
+            }
+
+            let config = Path::new(&spec.bundle).join("config.json");
+            let spec_json = std::fs::read_to_string(&config)
+                .map_err(|e| format!("read {}: {e}", config.display()))?;
+
+            // Copy the CRI bind mounts (volumes + generated /etc/resolv.conf,
+            // /etc/hosts, /etc/hostname, etc.) into the pod share and rewrite
+            // their sources to the guest-visible path, so the agent can
+            // materialize them into the container's writable overlay. Also inject
+            // the pod hostname (which lives on the sandbox spec, not the container).
+            let spec_json = materialize_bind_mounts(
+                &spec_json,
+                &sandbox.share_dir,
+                &id_owned,
+                sandbox.hostname.as_deref(),
+                sandbox.sysctls.as_ref(),
+            )?;
+
+            let resp = pod_request(
+                &sandbox.socket,
+                &AgentRequest::PodCreate {
+                    id: id_owned.clone(),
+                    rootfs_rel: format!("{id_owned}/rootfs"),
+                    spec_json,
+                    tty: spec.stdio.terminal,
+                },
+            )?;
+            expect_ok(resp, "PodCreate")
+        })
+        .await
+        .map_err(|e| e.to_string())??;
+
+        self.insert_proc(key(id, None), ProcEntry::new(stdio, pid))?;
+        Ok(pid)
+    }
+
+    async fn create_exec(&self, id: &str, exec_id: &str, spec: ProcessSpec) -> Result<(), String> {
+        let sandbox = self.sandbox()?;
+        let id_owned = id.to_string();
+        let exec_owned = exec_id.to_string();
+        let stdio = spec.stdio.clone();
+
+        // containerd's ExecProcessRequest.spec is an Any whose value is the
+        // OCI Process serialized as JSON — pass it through verbatim.
+        let process_json = String::from_utf8(spec.exec_spec.unwrap_or_default())
+            .map_err(|e| format!("exec spec is not UTF-8 JSON: {e}"))?;
+
+        tokio::task::spawn_blocking(move || {
+            let resp = pod_request(
+                &sandbox.socket,
+                &AgentRequest::PodExec {
+                    id: id_owned,
+                    exec_id: exec_owned,
+                    process_json,
+                    tty: spec.stdio.terminal,
+                },
+            )?;
+            expect_ok(resp, "PodExec")
+        })
+        .await
+        .map_err(|e| e.to_string())??;
+
+        self.insert_proc(key(id, Some(exec_id)), ProcEntry::new(stdio, next_pid()))?;
+        Ok(())
+    }
+
+    async fn start(&self, id: &str, exec_id: Option<&str>) -> Result<u32, String> {
+        let k = key(id, exec_id);
+        let (stdio, pid, exit_tx) = {
+            let map = self.procs.lock().map_err(|e| e.to_string())?;
+            let p = map.get(&k).ok_or_else(|| format!("no such process {k}"))?;
+            (p.stdio.clone(), p.pid, p.exit_tx.clone())
+        };
+
+        // The sandbox task is nominal — the VM already runs; there is no guest
+        // process to start.
+        if self.is_sandbox_task(id, exec_id) {
+            return Ok(pid);
+        }
+
+        let sandbox = self.sandbox()?;
+        let (cmd_tx, cmd_rx) = std::sync::mpsc::channel();
+        let (started_tx, started_rx) = std::sync::mpsc::sync_channel(1);
+        let socket = sandbox.socket.clone();
+        let id_owned = id.to_string();
+        let exec_owned = exec_id.map(str::to_string);
+
+        // The pump owns the process's dedicated streaming connection for its
+        // whole lifetime — a plain thread, not a tokio blocking task.
+        std::thread::Builder::new()
+            .name(format!("pod-io-{k}"))
+            .spawn(move || {
+                run_pump(
+                    socket, id_owned, exec_owned, stdio, exit_tx, cmd_rx, started_tx,
+                )
+            })
+            .map_err(|e| format!("spawn pump thread: {e}"))?;
+
+        // Block (off the async runtime) until the agent confirms Started.
+        tokio::task::spawn_blocking(move || match started_rx.recv_timeout(START_TIMEOUT) {
+            Ok(res) => res,
+            Err(e) => Err(format!("timed out waiting for Started: {e}")),
+        })
+        .await
+        .map_err(|e| e.to_string())??;
+
+        if let Some(p) = self.procs.lock().map_err(|e| e.to_string())?.get_mut(&k) {
+            p.cmd_tx = Some(cmd_tx);
+        }
+        Ok(pid)
+    }
+
+    async fn kill(
+        &self,
+        id: &str,
+        exec_id: Option<&str>,
+        signal: u32,
+        all: bool,
+    ) -> Result<(), String> {
+        // Killing the sandbox task ends the nominal pause process: publish its
+        // exit so Wait resolves. The VM itself is torn down by delete().
+        if self.is_sandbox_task(id, exec_id) {
+            if signal == 9 || signal == 15 {
+                let k = key(id, None);
+                if let Some(p) = self.procs.lock().map_err(|e| e.to_string())?.get(&k) {
+                    let _ = p.exit_tx.send(Some(ExitInfo {
+                        status: 128 + signal,
+                        exited_at_ns: now_ns(),
+                        oom: false,
+                    }));
+                }
+            }
+            return Ok(());
+        }
+
+        let sandbox = self.sandbox()?;
+        let req = AgentRequest::PodSignal {
+            id: id.to_string(),
+            exec_id: exec_id.map(str::to_string),
+            signal,
+            all,
+        };
+        tokio::task::spawn_blocking(move || {
+            expect_ok(pod_request(&sandbox.socket, &req)?, "PodSignal")
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    async fn wait_channel(&self, id: &str, exec_id: Option<&str>) -> Result<ExitWatch, String> {
+        let map = self.procs.lock().map_err(|e| e.to_string())?;
+        map.get(&key(id, exec_id))
+            .map(|p| p.exit_rx.clone())
+            .ok_or_else(|| format!("no such process {}", key(id, exec_id)))
+    }
+
+    async fn resize_pty(
+        &self,
+        id: &str,
+        exec_id: Option<&str>,
+        w: u32,
+        h: u32,
+    ) -> Result<(), String> {
+        let cmd_tx = {
+            let map = self.procs.lock().map_err(|e| e.to_string())?;
+            map.get(&key(id, exec_id)).and_then(|p| p.cmd_tx.clone())
+        };
+        // Not started (or already exited): resize is a no-op.
+        if let Some(tx) = cmd_tx {
+            let _ = tx.send(PumpCmd::Resize {
+                cols: w as u16,
+                rows: h as u16,
+            });
+        }
+        Ok(())
+    }
+
+    async fn close_io(&self, id: &str, exec_id: Option<&str>) -> Result<(), String> {
+        let cmd_tx = {
+            let map = self.procs.lock().map_err(|e| e.to_string())?;
+            map.get(&key(id, exec_id)).and_then(|p| p.cmd_tx.clone())
+        };
+        if let Some(tx) = cmd_tx {
+            let _ = tx.send(PumpCmd::CloseStdin);
+        }
+        Ok(())
+    }
+
+    async fn delete(&self, id: &str, exec_id: Option<&str>) -> Result<(), String> {
+        let k = key(id, exec_id);
+
+        if self.is_sandbox_task(id, exec_id) {
+            // Sandbox delete = tear down the whole VM.
+            let sandbox = self.sandbox()?;
+            tokio::task::spawn_blocking(move || {
+                let rt = smolvm::embedded::runtime().map_err(|e| e.to_string())?;
+                if let Err(e) = rt.stop_machine(&sandbox.id) {
+                    warn!("stop sandbox VM {}: {e}", sandbox.id);
+                }
+                rt.delete_machine(&sandbox.id)
+                    .map_err(|e| format!("delete sandbox VM: {e}"))
+            })
+            .await
+            .map_err(|e| e.to_string())??;
+            *self.sandbox.lock().map_err(|e| e.to_string())? = None;
+            self.procs.lock().map_err(|e| e.to_string())?.remove(&k);
+            return Ok(());
+        }
+
+        let sandbox = self.sandbox()?;
+        let id_owned = id.to_string();
+        let exec_owned = exec_id.map(str::to_string);
+        tokio::task::spawn_blocking(move || {
+            // Best-effort guest-side cleanup: the VM may already be gone when
+            // containerd deletes exited tasks during pod teardown, and a
+            // failing Delete would wedge containerd's teardown loop.
+            match pod_request(
+                &sandbox.socket,
+                &AgentRequest::PodDelete {
+                    id: id_owned.clone(),
+                    exec_id: exec_owned.clone(),
+                },
+            )
+            .and_then(|r| expect_ok(r, "PodDelete"))
+            {
+                Ok(()) => {}
+                Err(e) => warn!("PodDelete {id_owned}: {e}"),
+            }
+
+            // Container (not exec) delete removes the materialized rootfs copy
+            // under the pod share (the container filesystem is ephemeral).
+            if exec_owned.is_none() {
+                let cdir = sandbox.share_dir.join(&id_owned);
+                if let Err(e) = std::fs::remove_dir_all(&cdir) {
+                    debug!("rm {}: {e}", cdir.display());
+                }
+            }
+            Ok::<(), String>(())
+        })
+        .await
+        .map_err(|e| e.to_string())??;
+
+        self.procs.lock().map_err(|e| e.to_string())?.remove(&k);
+        Ok(())
+    }
+
+    async fn pids(&self, id: &str) -> Result<Vec<u32>, String> {
+        if self.is_sandbox_task(id, None) {
+            let map = self.procs.lock().map_err(|e| e.to_string())?;
+            let pid = map.get(&key(id, None)).map(|p| p.pid).unwrap_or(1);
+            return Ok(vec![pid]);
+        }
+        let sandbox = self.sandbox()?;
+        let req = AgentRequest::PodPids { id: id.to_string() };
+        tokio::task::spawn_blocking(move || match pod_request(&sandbox.socket, &req)? {
+            AgentResponse::Pids { pids } => Ok(pids),
+            AgentResponse::Error { message, .. } => Err(format!("PodPids: {message}")),
+            other => Err(format!("PodPids: unexpected agent response {other:?}")),
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+
+    async fn stats(&self, id: &str) -> Result<Option<Vec<u8>>, String> {
+        // The pod sandbox "task" has no container process tree to sample.
+        if self.is_sandbox_task(id, None) {
+            return Ok(None);
+        }
+        let sandbox = self.sandbox()?;
+        let req = AgentRequest::PodStats { id: id.to_string() };
+        tokio::task::spawn_blocking(move || {
+            let (cpu_ns, mem_bytes) = match pod_request(&sandbox.socket, &req)? {
+                AgentResponse::Stats {
+                    cpu_usage_ns,
+                    memory_bytes,
+                } => (cpu_usage_ns, memory_bytes),
+                AgentResponse::Error { message, .. } => return Err(format!("PodStats: {message}")),
+                other => return Err(format!("PodStats: unexpected agent response {other:?}")),
+            };
+            Ok(Some(encode_cgroup_metrics(cpu_ns, mem_bytes)?))
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    }
+}
+
+/// Copy the CRI bind mounts referenced by `config.json` into the pod share so
+/// the guest can materialize them into the container, and rewrite each such
+/// mount's `source` to the guest-visible path under [`POD_SHARE_GUEST_MOUNT`].
+///
+/// Only real host-path bind mounts are copied — volumes and the generated
+/// `/etc/resolv.conf`, `/etc/hosts`, `/etc/hostname`, termination-log, etc. The
+/// virtual mounts in the spec (proc/sysfs/tmpfs/devpts/mqueue/cgroup) are left
+/// untouched; the guest's default OCI spec provides those. Returns the rewritten
+/// spec JSON. A source that doesn't exist on the host is skipped (left as-is).
+fn materialize_bind_mounts(
+    spec_json: &str,
+    share_dir: &Path,
+    id: &str,
+    sandbox_hostname: Option<&str>,
+    sandbox_sysctls: Option<&serde_json::Value>,
+) -> Result<String, String> {
+    let mut spec: serde_json::Value =
+        serde_json::from_str(spec_json).map_err(|e| format!("parse config.json: {e}"))?;
+
+    // Inject the pod hostname if the container spec doesn't carry one.
+    if let Some(h) = sandbox_hostname {
+        let empty = spec
+            .get("hostname")
+            .and_then(|v| v.as_str())
+            .map(|s| s.is_empty())
+            .unwrap_or(true);
+        if empty {
+            spec["hostname"] = serde_json::Value::String(h.to_string());
+        }
+    }
+
+    // Merge the pod's IPC/UTS sysctls into the container spec (a container-specific
+    // sysctl already present wins). crun sets them inside the container's own IPC
+    // and UTS namespaces, which each pod container unshares. net.* sysctls are
+    // deliberately excluded — the pod container declares no network namespace, so
+    // crun would reject them; those are applied guest-wide at sandbox setup
+    // instead (see `apply_guest_net_sysctls`), where the shared net namespace
+    // makes them visible to every container.
+    if let Some(serde_json::Value::Object(pod)) = sandbox_sysctls {
+        let namespaced: Vec<(&String, &serde_json::Value)> =
+            pod.iter().filter(|(k, _)| !k.starts_with("net.")).collect();
+        if !namespaced.is_empty() {
+            let target = spec
+                .pointer_mut("/linux/sysctl")
+                .and_then(|v| v.as_object_mut());
+            match target {
+                Some(existing) => {
+                    for (k, v) in namespaced {
+                        existing.entry(k.clone()).or_insert_with(|| v.clone());
+                    }
+                }
+                None => {
+                    let obj = namespaced
+                        .into_iter()
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect();
+                    spec["linux"]["sysctl"] = serde_json::Value::Object(obj);
+                }
+            }
+        }
+    }
+
+    let Some(mounts) = spec.get_mut("mounts").and_then(|m| m.as_array_mut()) else {
+        return Ok(serde_json::to_string(&spec).unwrap_or_else(|_| spec_json.to_string()));
+    };
+
+    let mounts_dir = share_dir.join(id).join("mounts");
+    let mut n = 0usize;
+    for m in mounts.iter_mut() {
+        let mtype = m.get("type").and_then(|t| t.as_str()).unwrap_or_default();
+        let source = m
+            .get("source")
+            .and_then(|s| s.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let dest = m
+            .get("destination")
+            .and_then(|d| d.as_str())
+            .unwrap_or_default();
+        // A CRI bind mount is a real host path. Treat any mount whose source is an
+        // existing absolute host path as one to materialize — some specs omit the
+        // "bind" type and rely on options, and virtual mounts (proc/sysfs/tmpfs/
+        // cgroup/mqueue/devpts) have non-path sources that won't exist as files.
+        let is_virtual = matches!(
+            mtype,
+            "proc" | "sysfs" | "tmpfs" | "cgroup" | "cgroup2" | "mqueue" | "devpts" | "devtmpfs"
+        );
+        let exists = source.starts_with('/') && Path::new(&source).exists();
+        debug!(
+            "materialize_bind_mounts: mount type={mtype} source={source} dest={dest} virtual={is_virtual} exists={exists}"
+        );
+        if is_virtual || source.is_empty() || !exists {
+            continue;
+        }
+
+        std::fs::create_dir_all(&mounts_dir)
+            .map_err(|e| format!("mkdir {}: {e}", mounts_dir.display()))?;
+        let dst = mounts_dir.join(n.to_string());
+        // `cp -aT` makes `dst` a copy of `source` (file or dir), preserving
+        // modes/owners/symlinks; reflink keeps it cheap on the same fs.
+        let status = std::process::Command::new("cp")
+            .args(["-aT", "--reflink=auto", &source])
+            .arg(&dst)
+            .status()
+            .map_err(|e| format!("spawn cp for mount {source}: {e}"))?;
+        if !status.success() {
+            return Err(format!("copy mount {source}: cp exited {status}"));
+        }
+
+        // Make the copy world-readable/traversable so the guest agent can read it
+        // through the (uid-mapped) virtiofs share regardless of the source's
+        // original owner/mode — a CRI volume created root-only (e.g. mode 0700)
+        // is otherwise EACCES to the guest. Container-visible perms only widen
+        // read access on this ephemeral copy; write goes to the guest overlay.
+        let _ = std::process::Command::new("chmod")
+            .args(["-R", "a+rX"])
+            .arg(&dst)
+            .status();
+
+        m["source"] = serde_json::Value::String(format!("{POD_SHARE_GUEST_MOUNT}/{id}/mounts/{n}"));
+        n += 1;
+    }
+
+    serde_json::to_string(&spec).map_err(|e| format!("reserialize spec: {e}"))
+}
+
+/// Build a cgroups v1 `Metrics` message (the format containerd's CRI decodes for
+/// `ContainerStats`) from a guest usage sample and serialize it. crun runs
+/// cgroup-less in the guest, so only CPU total and memory usage are populated —
+/// which is what the CRI cpu/memory stats surface.
+fn encode_cgroup_metrics(cpu_ns: u64, mem_bytes: u64) -> Result<Vec<u8>, String> {
+    use containerd_shim_protos::cgroups::metrics::{
+        CPUStat, CPUUsage, MemoryEntry, MemoryStat, Metrics,
+    };
+    use containerd_shim_protos::protobuf::{Message, MessageField};
+
+    let metrics = Metrics {
+        cpu: MessageField::some(CPUStat {
+            usage: MessageField::some(CPUUsage {
+                total: cpu_ns,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        memory: MessageField::some(MemoryStat {
+            usage: MessageField::some(MemoryEntry {
+                usage: mem_bytes,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    metrics
+        .write_to_bytes()
+        .map_err(|e| format!("encode cgroup metrics: {e}"))
+}
+
+// ======================= mock/engine runtime switch =========================
+
+/// The backend the shim actually runs with, chosen at task-service creation:
+/// `SMOLVM_SHIM_MOCK=1` keeps the in-process [`MockBackend`] (tests/smoke on
+/// hosts without KVM); anything else drives real microVMs. An enum instead of
+/// `dyn PodBackend` so `TaskService<B>` keeps its static dispatch.
+pub enum ShimBackend {
+    Mock(crate::backend::MockBackend),
+    Engine(EnginePodBackend),
+}
+
+#[async_trait]
+impl PodBackend for ShimBackend {
+    async fn create_sandbox(
+        &self,
+        id: &str,
+        bundle: &str,
+        netns: Option<&str>,
+    ) -> Result<u32, String> {
+        match self {
+            Self::Mock(b) => b.create_sandbox(id, bundle, netns).await,
+            Self::Engine(b) => b.create_sandbox(id, bundle, netns).await,
+        }
+    }
+
+    async fn create_container(&self, id: &str, spec: ProcessSpec) -> Result<u32, String> {
+        match self {
+            Self::Mock(b) => b.create_container(id, spec).await,
+            Self::Engine(b) => b.create_container(id, spec).await,
+        }
+    }
+
+    async fn start(&self, id: &str, exec_id: Option<&str>) -> Result<u32, String> {
+        match self {
+            Self::Mock(b) => b.start(id, exec_id).await,
+            Self::Engine(b) => b.start(id, exec_id).await,
+        }
+    }
+
+    async fn create_exec(&self, id: &str, exec_id: &str, spec: ProcessSpec) -> Result<(), String> {
+        match self {
+            Self::Mock(b) => b.create_exec(id, exec_id, spec).await,
+            Self::Engine(b) => b.create_exec(id, exec_id, spec).await,
+        }
+    }
+
+    async fn kill(
+        &self,
+        id: &str,
+        exec_id: Option<&str>,
+        signal: u32,
+        all: bool,
+    ) -> Result<(), String> {
+        match self {
+            Self::Mock(b) => b.kill(id, exec_id, signal, all).await,
+            Self::Engine(b) => b.kill(id, exec_id, signal, all).await,
+        }
+    }
+
+    async fn wait_channel(&self, id: &str, exec_id: Option<&str>) -> Result<ExitWatch, String> {
+        match self {
+            Self::Mock(b) => b.wait_channel(id, exec_id).await,
+            Self::Engine(b) => b.wait_channel(id, exec_id).await,
+        }
+    }
+
+    async fn resize_pty(
+        &self,
+        id: &str,
+        exec_id: Option<&str>,
+        w: u32,
+        h: u32,
+    ) -> Result<(), String> {
+        match self {
+            Self::Mock(b) => b.resize_pty(id, exec_id, w, h).await,
+            Self::Engine(b) => b.resize_pty(id, exec_id, w, h).await,
+        }
+    }
+
+    async fn close_io(&self, id: &str, exec_id: Option<&str>) -> Result<(), String> {
+        match self {
+            Self::Mock(b) => b.close_io(id, exec_id).await,
+            Self::Engine(b) => b.close_io(id, exec_id).await,
+        }
+    }
+
+    async fn delete(&self, id: &str, exec_id: Option<&str>) -> Result<(), String> {
+        match self {
+            Self::Mock(b) => b.delete(id, exec_id).await,
+            Self::Engine(b) => b.delete(id, exec_id).await,
+        }
+    }
+
+    async fn pids(&self, id: &str) -> Result<Vec<u32>, String> {
+        match self {
+            Self::Mock(b) => b.pids(id).await,
+            Self::Engine(b) => b.pids(id).await,
+        }
+    }
+
+    async fn stats(&self, id: &str) -> Result<Option<Vec<u8>>, String> {
+        match self {
+            Self::Mock(b) => b.stats(id).await,
+            Self::Engine(b) => b.stats(id).await,
+        }
+    }
+}

--- a/crates/smolvm-shim/src/main.rs
+++ b/crates/smolvm-shim/src/main.rs
@@ -1,0 +1,26 @@
+//! containerd-shim-smolvm-v2 — shim v2 entrypoint.
+//!
+//! See docs/kubernetes-runtime.md for the architecture. Linux-only; a stub on
+//! other platforms so workspace checks pass everywhere.
+
+#[cfg(target_os = "linux")]
+mod backend;
+#[cfg(target_os = "linux")]
+mod bundle;
+#[cfg(target_os = "linux")]
+mod engine;
+#[cfg(target_os = "linux")]
+mod service;
+#[cfg(target_os = "linux")]
+mod task;
+
+#[cfg(target_os = "linux")]
+fn main() {
+    service::run_shim();
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("containerd-shim-smolvm-v2 only runs on Linux Kubernetes nodes");
+    std::process::exit(1);
+}

--- a/crates/smolvm-shim/src/service.rs
+++ b/crates/smolvm-shim/src/service.rs
@@ -1,0 +1,103 @@
+//! Shim v2 process lifecycle: what containerd invokes to start/stop the shim
+//! itself. One shim process serves one pod (grouped by task id).
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use containerd_shim::asynchronous::{run, spawn, ExitSignal, Shim};
+use containerd_shim::publisher::RemotePublisher;
+use containerd_shim::util::timestamp;
+use containerd_shim::{Config, Error, Flags, StartOpts};
+use containerd_shim_protos::api::DeleteResponse;
+use log::warn;
+
+use crate::backend::MockBackend;
+use crate::engine::{EnginePodBackend, ShimBackend};
+use crate::task::TaskService;
+
+pub const RUNTIME_ID: &str = "io.containerd.smolvm.v2";
+
+pub struct Service {
+    exit: Arc<ExitSignal>,
+    namespace: String,
+    /// Task id containerd invoked us with. For the sandbox shim this is the
+    /// sandbox id, which is also the persistent machine's name — used by
+    /// `delete_shim` to reap a leaked VM after a shim crash.
+    id: String,
+}
+
+#[async_trait]
+impl Shim for Service {
+    // Engine-backed by default (real microVMs); SMOLVM_SHIM_MOCK=1 keeps the
+    // in-process mock so tests/smoke runs work on hosts without KVM.
+    type T = TaskService<ShimBackend>;
+
+    async fn new(_runtime_id: &str, args: &Flags, _config: &mut Config) -> Self {
+        Service {
+            exit: Arc::new(ExitSignal::default()),
+            namespace: args.namespace.clone(),
+            id: args.id.clone(),
+        }
+    }
+
+    async fn start_shim(&mut self, opts: StartOpts) -> Result<String, Error> {
+        let grouping = opts.id.clone();
+        let address = spawn(opts, &grouping, Vec::new()).await?;
+        Ok(address)
+    }
+
+    async fn delete_shim(&mut self) -> Result<DeleteResponse, Error> {
+        // Recovery cleanup: containerd invokes the shim binary's `delete` action
+        // to reap a shim whose process is already gone (crash, force-delete). The
+        // sandbox VM is a persistent machine named after the sandbox id and would
+        // otherwise leak, so tear it down here. The runtime reads its machine
+        // state from disk, so a fresh process can still find and kill the VM.
+        // Best-effort — a missing machine (a container-task delete, or a VM
+        // already cleaned by the graceful path) is not an error.
+        let id = self.id.clone();
+        let _ = tokio::task::spawn_blocking(move || match smolvm::embedded::runtime() {
+            Ok(rt) => {
+                if let Err(e) = rt.delete_machine(&id) {
+                    warn!("delete_shim: reaping VM {id} failed (may already be gone): {e}");
+                }
+            }
+            Err(e) => warn!("delete_shim: runtime unavailable, cannot reap VM {id}: {e}"),
+        })
+        .await;
+        Ok(DeleteResponse {
+            exit_status: 137,
+            exited_at: Some(timestamp()?).into(),
+            ..Default::default()
+        })
+    }
+
+    async fn wait(&mut self) {
+        self.exit.wait().await;
+    }
+
+    async fn create_task_service(&self, publisher: RemotePublisher) -> Self::T {
+        let backend = if std::env::var("SMOLVM_SHIM_MOCK").as_deref() == Ok("1") {
+            warn!("SMOLVM_SHIM_MOCK=1: using mock backend (no VMs will boot)");
+            ShimBackend::Mock(MockBackend::default())
+        } else {
+            ShimBackend::Engine(EnginePodBackend::new())
+        };
+        TaskService::new(
+            Arc::new(backend),
+            Some(Arc::new(publisher)),
+            self.namespace.clone(),
+            self.exit.clone(),
+        )
+    }
+}
+
+pub fn run_shim() {
+    let body = async {
+        run::<Service>(RUNTIME_ID, None).await;
+    };
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime")
+        .block_on(body);
+}

--- a/crates/smolvm-shim/src/task.rs
+++ b/crates/smolvm-shim/src/task.rs
@@ -1,0 +1,838 @@
+//! The shim v2 Task service: containerd's per-pod state machine.
+//!
+//! Holds the sandbox + container process table and enforces the lifecycle
+//! containerd/critest expect (Created → Running → Stopped, exactly-once exit
+//! events, Wait blocking until exit, Delete returning exit info), delegating
+//! VM mechanics to a [`PodBackend`].
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use containerd_shim::publisher::RemotePublisher;
+use containerd_shim::util::{convert_to_any, timestamp};
+use containerd_shim::TtrpcResult;
+use containerd_shim_protos::api;
+use containerd_shim_protos::events::task::{
+    TaskCreate, TaskDelete, TaskExecAdded, TaskExecStarted, TaskExit, TaskOOM, TaskStart,
+};
+use containerd_shim_protos::protobuf::well_known_types::timestamp::Timestamp;
+use containerd_shim_protos::protobuf::{Message, MessageDyn};
+use containerd_shim_protos::shim_async::Task;
+use containerd_shim_protos::ttrpc::r#async::TtrpcContext;
+use log::{debug, warn};
+use tokio::sync::Mutex;
+
+use crate::backend::{ExitInfo, PodBackend, ProcessSpec, Stdio};
+use crate::bundle;
+
+fn err(msg: impl std::fmt::Display) -> containerd_shim_protos::ttrpc::Error {
+    containerd_shim_protos::ttrpc::Error::RpcStatus(containerd_shim_protos::ttrpc::get_status(
+        containerd_shim_protos::ttrpc::Code::UNKNOWN,
+        msg.to_string(),
+    ))
+}
+
+fn not_found(msg: impl std::fmt::Display) -> containerd_shim_protos::ttrpc::Error {
+    containerd_shim_protos::ttrpc::Error::RpcStatus(containerd_shim_protos::ttrpc::get_status(
+        containerd_shim_protos::ttrpc::Code::NOT_FOUND,
+        msg.to_string(),
+    ))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProcState {
+    Created,
+    Running,
+    Stopped,
+}
+
+struct Proc {
+    state: ProcState,
+    pid: u32,
+    stdio: Stdio,
+    exit: Option<ExitInfo>,
+    is_sandbox: bool,
+    bundle: String,
+}
+
+/// `(container_id, exec_id)` → process entry. Empty exec_id = init process.
+type ProcKey = (String, String);
+
+pub struct TaskService<B: PodBackend> {
+    backend: Arc<B>,
+    procs: Arc<Mutex<HashMap<ProcKey, Proc>>>,
+    publisher: Option<Arc<RemotePublisher>>,
+    namespace: String,
+    exit: Arc<containerd_shim::asynchronous::ExitSignal>,
+}
+
+impl<B: PodBackend> Clone for TaskService<B> {
+    fn clone(&self) -> Self {
+        Self {
+            backend: self.backend.clone(),
+            procs: self.procs.clone(),
+            publisher: self.publisher.clone(),
+            namespace: self.namespace.clone(),
+            exit: self.exit.clone(),
+        }
+    }
+}
+
+impl<B: PodBackend> TaskService<B> {
+    pub fn new(
+        backend: Arc<B>,
+        publisher: Option<Arc<RemotePublisher>>,
+        namespace: String,
+        exit: Arc<containerd_shim::asynchronous::ExitSignal>,
+    ) -> Self {
+        Self {
+            backend,
+            procs: Arc::new(Mutex::new(HashMap::new())),
+            publisher,
+            namespace,
+            exit,
+        }
+    }
+
+    async fn publish(&self, topic: &str, event: Box<dyn MessageDyn>) {
+        if let Some(p) = &self.publisher {
+            let ctx = containerd_shim_protos::ttrpc::context::Context::default();
+            if let Err(e) = p.publish(ctx, topic, &self.namespace, event).await {
+                warn!("publish {topic} failed: {e}");
+            }
+        }
+    }
+
+    /// Spawn the exit-watcher for a started process: on exit, mark Stopped and
+    /// publish TaskExit exactly once.
+    async fn watch_exit(&self, id: String, exec_id: String, pid: u32) {
+        let backend = self.backend.clone();
+        let procs = self.procs.clone();
+        let this = self.clone();
+        let exec_opt = if exec_id.is_empty() {
+            None
+        } else {
+            Some(exec_id.clone())
+        };
+        tokio::spawn(async move {
+            let mut rx = match backend.wait_channel(&id, exec_opt.as_deref()).await {
+                Ok(rx) => rx,
+                Err(e) => {
+                    warn!("wait_channel({id},{exec_id}): {e}");
+                    return;
+                }
+            };
+            let info = loop {
+                if let Some(info) = *rx.borrow() {
+                    break info;
+                }
+                if rx.changed().await.is_err() {
+                    // Backend dropped: treat as exit 255 now.
+                    break ExitInfo {
+                        status: 255,
+                        exited_at_ns: 0,
+                        oom: false,
+                    };
+                }
+            };
+            {
+                let mut map = procs.lock().await;
+                if let Some(p) = map.get_mut(&(id.clone(), exec_id.clone())) {
+                    if p.state == ProcState::Stopped {
+                        return; // already reported
+                    }
+                    p.state = ProcState::Stopped;
+                    p.exit = Some(info);
+                }
+            }
+            // A cgroup OOM kill must be announced before the exit so the CRI
+            // has marked the container OOMKilled by the time it reads the exit
+            // status. Only the init process (empty exec_id) carries this.
+            if info.oom && exec_id.is_empty() {
+                let mut oom = TaskOOM::new();
+                oom.container_id = id.clone();
+                this.publish("/tasks/oom", Box::new(oom)).await;
+            }
+            let mut ev = TaskExit::new();
+            ev.container_id = id.clone();
+            ev.id = if exec_id.is_empty() {
+                id.clone()
+            } else {
+                exec_id.clone()
+            };
+            ev.pid = pid;
+            ev.exit_status = info.status;
+            ev.exited_at = Some(protobuf_ts(info.exited_at_ns)).into();
+            this.publish("/tasks/exit", Box::new(ev)).await;
+        });
+    }
+}
+
+fn protobuf_ts(ns: i64) -> Timestamp {
+    if ns <= 0 {
+        return timestamp().unwrap_or_default();
+    }
+    let mut t = Timestamp::new();
+    t.seconds = ns / 1_000_000_000;
+    t.nanos = (ns % 1_000_000_000) as i32;
+    t
+}
+
+fn state_to_api(s: ProcState) -> api::Status {
+    match s {
+        ProcState::Created => api::Status::CREATED,
+        ProcState::Running => api::Status::RUNNING,
+        ProcState::Stopped => api::Status::STOPPED,
+    }
+}
+
+#[async_trait]
+impl<B: PodBackend> Task for TaskService<B> {
+    async fn create(
+        &self,
+        _ctx: &TtrpcContext,
+        req: api::CreateTaskRequest,
+    ) -> TtrpcResult<api::CreateTaskResponse> {
+        let id = req.id.clone();
+        debug!("create task id={id} bundle={}", req.bundle);
+        let info = bundle::load(&req.bundle).map_err(err)?;
+
+        let stdio = Stdio {
+            stdin: req.stdin.clone(),
+            stdout: req.stdout.clone(),
+            stderr: req.stderr.clone(),
+            terminal: req.terminal,
+        };
+
+        let pid = if info.is_sandbox {
+            self.backend
+                .create_sandbox(&id, &req.bundle, info.netns.as_deref())
+                .await
+                .map_err(err)?
+        } else {
+            // Mount containerd's rootfs mounts at bundle/rootfs, then hand the
+            // host path to the backend for guest sharing.
+            let rootfs = bundle::mount_rootfs(&req.bundle, &req.rootfs)
+                .await
+                .map_err(err)?;
+            self.backend
+                .create_container(
+                    &id,
+                    ProcessSpec {
+                        bundle: req.bundle.clone(),
+                        rootfs,
+                        stdio: stdio.clone(),
+                        exec_spec: None,
+                    },
+                )
+                .await
+                .map_err(err)?
+        };
+
+        let mut map = self.procs.lock().await;
+        if map.contains_key(&(id.clone(), String::new())) {
+            return Err(err(format!("task {id} already exists")));
+        }
+        map.insert(
+            (id.clone(), String::new()),
+            Proc {
+                state: ProcState::Created,
+                pid,
+                stdio,
+                exit: None,
+                is_sandbox: info.is_sandbox,
+                bundle: req.bundle.clone(),
+            },
+        );
+        drop(map);
+
+        let mut ev = TaskCreate::new();
+        ev.container_id = id.clone();
+        ev.bundle = req.bundle.clone();
+        ev.pid = pid;
+        self.publish("/tasks/create", Box::new(ev)).await;
+
+        Ok(api::CreateTaskResponse {
+            pid,
+            ..Default::default()
+        })
+    }
+
+    async fn start(
+        &self,
+        _ctx: &TtrpcContext,
+        req: api::StartRequest,
+    ) -> TtrpcResult<api::StartResponse> {
+        let (id, exec_id) = (req.id.clone(), req.exec_id.clone());
+        let exec_opt = if exec_id.is_empty() {
+            None
+        } else {
+            Some(exec_id.as_str())
+        };
+        let pid = self.backend.start(&id, exec_opt).await.map_err(err)?;
+        {
+            let mut map = self.procs.lock().await;
+            let p = map
+                .get_mut(&(id.clone(), exec_id.clone()))
+                .ok_or_else(|| not_found(format!("process {id}/{exec_id}")))?;
+            p.state = ProcState::Running;
+            p.pid = pid;
+        }
+        self.watch_exit(id.clone(), exec_id.clone(), pid).await;
+
+        if exec_id.is_empty() {
+            let mut ev = TaskStart::new();
+            ev.container_id = id.clone();
+            ev.pid = pid;
+            self.publish("/tasks/start", Box::new(ev)).await;
+        } else {
+            let mut ev = TaskExecStarted::new();
+            ev.container_id = id.clone();
+            ev.exec_id = exec_id.clone();
+            ev.pid = pid;
+            self.publish("/tasks/exec-started", Box::new(ev)).await;
+        }
+        Ok(api::StartResponse {
+            pid,
+            ..Default::default()
+        })
+    }
+
+    async fn state(
+        &self,
+        _ctx: &TtrpcContext,
+        req: api::StateRequest,
+    ) -> TtrpcResult<api::StateResponse> {
+        let map = self.procs.lock().await;
+        let p = map
+            .get(&(req.id.clone(), req.exec_id.clone()))
+            .ok_or_else(|| not_found(format!("process {}/{}", req.id, req.exec_id)))?;
+        let mut resp = api::StateResponse {
+            id: req.id.clone(),
+            pid: p.pid,
+            bundle: p.bundle.clone(),
+            stdin: p.stdio.stdin.clone(),
+            stdout: p.stdio.stdout.clone(),
+            stderr: p.stdio.stderr.clone(),
+            terminal: p.stdio.terminal,
+            exit_status: p.exit.map(|e| e.status).unwrap_or_default(),
+            ..Default::default()
+        };
+        resp.set_status(state_to_api(p.state));
+        if let Some(e) = p.exit {
+            resp.exited_at = Some(protobuf_ts(e.exited_at_ns)).into();
+        }
+        Ok(resp)
+    }
+
+    async fn wait(
+        &self,
+        _ctx: &TtrpcContext,
+        req: api::WaitRequest,
+    ) -> TtrpcResult<api::WaitResponse> {
+        let exec_opt = if req.exec_id.is_empty() {
+            None
+        } else {
+            Some(req.exec_id.as_str())
+        };
+        // Already exited? (Delete-after-exit races.)
+        {
+            let map = self.procs.lock().await;
+            if let Some(p) = map.get(&(req.id.clone(), req.exec_id.clone())) {
+                if let Some(e) = p.exit {
+                    return Ok(api::WaitResponse {
+                        exit_status: e.status,
+                        exited_at: Some(protobuf_ts(e.exited_at_ns)).into(),
+                        ..Default::default()
+                    });
+                }
+            } else {
+                return Err(not_found(format!("process {}/{}", req.id, req.exec_id)));
+            }
+        }
+        let mut rx = self
+            .backend
+            .wait_channel(&req.id, exec_opt)
+            .await
+            .map_err(err)?;
+        let info = loop {
+            if let Some(info) = *rx.borrow() {
+                break info;
+            }
+            if rx.changed().await.is_err() {
+                break ExitInfo {
+                    status: 255,
+                    exited_at_ns: 0,
+                    oom: false,
+                };
+            }
+        };
+        Ok(api::WaitResponse {
+            exit_status: info.status,
+            exited_at: Some(protobuf_ts(info.exited_at_ns)).into(),
+            ..Default::default()
+        })
+    }
+
+    async fn kill(&self, _ctx: &TtrpcContext, req: api::KillRequest) -> TtrpcResult<api::Empty> {
+        let exec_opt = if req.exec_id.is_empty() {
+            None
+        } else {
+            Some(req.exec_id.as_str())
+        };
+        {
+            let map = self.procs.lock().await;
+            let p = map
+                .get(&(req.id.clone(), req.exec_id.clone()))
+                .ok_or_else(|| not_found(format!("process {}/{}", req.id, req.exec_id)))?;
+            if p.state == ProcState::Stopped {
+                // Killing an exited process is a no-op (matches runc shim).
+                return Ok(api::Empty::default());
+            }
+        }
+        self.backend
+            .kill(&req.id, exec_opt, req.signal, req.all)
+            .await
+            .map_err(err)?;
+        Ok(api::Empty::default())
+    }
+
+    async fn exec(
+        &self,
+        _ctx: &TtrpcContext,
+        req: api::ExecProcessRequest,
+    ) -> TtrpcResult<api::Empty> {
+        let spec = ProcessSpec {
+            bundle: String::new(),
+            rootfs: String::new(),
+            stdio: Stdio {
+                stdin: req.stdin.clone(),
+                stdout: req.stdout.clone(),
+                stderr: req.stderr.clone(),
+                terminal: req.terminal,
+            },
+            exec_spec: Some(req.spec.value.clone()),
+        };
+        {
+            let map = self.procs.lock().await;
+            if !map.contains_key(&(req.id.clone(), String::new())) {
+                return Err(not_found(format!("container {}", req.id)));
+            }
+            if map.contains_key(&(req.id.clone(), req.exec_id.clone())) {
+                return Err(err(format!("exec {} already exists", req.exec_id)));
+            }
+        }
+        self.backend
+            .create_exec(&req.id, &req.exec_id, spec.clone())
+            .await
+            .map_err(err)?;
+        self.procs.lock().await.insert(
+            (req.id.clone(), req.exec_id.clone()),
+            Proc {
+                state: ProcState::Created,
+                pid: 0,
+                stdio: spec.stdio,
+                exit: None,
+                is_sandbox: false,
+                bundle: String::new(),
+            },
+        );
+        let mut ev = TaskExecAdded::new();
+        ev.container_id = req.id.clone();
+        ev.exec_id = req.exec_id.clone();
+        self.publish("/tasks/exec-added", Box::new(ev)).await;
+        Ok(api::Empty::default())
+    }
+
+    async fn resize_pty(
+        &self,
+        _ctx: &TtrpcContext,
+        req: api::ResizePtyRequest,
+    ) -> TtrpcResult<api::Empty> {
+        let exec_opt = if req.exec_id.is_empty() {
+            None
+        } else {
+            Some(req.exec_id.as_str())
+        };
+        self.backend
+            .resize_pty(&req.id, exec_opt, req.width, req.height)
+            .await
+            .map_err(err)?;
+        Ok(api::Empty::default())
+    }
+
+    async fn close_io(
+        &self,
+        _ctx: &TtrpcContext,
+        req: api::CloseIORequest,
+    ) -> TtrpcResult<api::Empty> {
+        let exec_opt = if req.exec_id.is_empty() {
+            None
+        } else {
+            Some(req.exec_id.as_str())
+        };
+        self.backend
+            .close_io(&req.id, exec_opt)
+            .await
+            .map_err(err)?;
+        Ok(api::Empty::default())
+    }
+
+    async fn delete(
+        &self,
+        _ctx: &TtrpcContext,
+        req: api::DeleteRequest,
+    ) -> TtrpcResult<api::DeleteResponse> {
+        let exec_opt = if req.exec_id.is_empty() {
+            None
+        } else {
+            Some(req.exec_id.as_str())
+        };
+        let (pid, mut exit, bundle_dir, is_sandbox) = {
+            let map = self.procs.lock().await;
+            let p = map
+                .get(&(req.id.clone(), req.exec_id.clone()))
+                .ok_or_else(|| not_found(format!("process {}/{}", req.id, req.exec_id)))?;
+            (p.pid, p.exit, p.bundle.clone(), p.is_sandbox)
+        };
+        // The exit-watcher records exits asynchronously; if Delete arrives
+        // first, read the backend's exit channel directly so the response
+        // still carries the real status.
+        if exit.is_none() {
+            if let Ok(rx) = self.backend.wait_channel(&req.id, exec_opt).await {
+                exit = *rx.borrow();
+            }
+        }
+        self.backend.delete(&req.id, exec_opt).await.map_err(err)?;
+        self.procs
+            .lock()
+            .await
+            .remove(&(req.id.clone(), req.exec_id.clone()));
+
+        // Unmount the bundle rootfs for workload init processes (best-effort;
+        // the sandbox never mounted one).
+        if req.exec_id.is_empty() && !is_sandbox && !bundle_dir.is_empty() {
+            bundle::unmount_rootfs(&bundle_dir).await;
+        }
+
+        let exited_at = exit
+            .map(|e| protobuf_ts(e.exited_at_ns))
+            .unwrap_or_default();
+        if req.exec_id.is_empty() {
+            let mut ev = TaskDelete::new();
+            ev.container_id = req.id.clone();
+            ev.pid = pid;
+            ev.exit_status = exit.map(|e| e.status).unwrap_or_default();
+            ev.exited_at = Some(exited_at.clone()).into();
+            self.publish("/tasks/delete", Box::new(ev)).await;
+        }
+        Ok(api::DeleteResponse {
+            pid,
+            exit_status: exit.map(|e| e.status).unwrap_or_default(),
+            exited_at: Some(exited_at).into(),
+            ..Default::default()
+        })
+    }
+
+    async fn pids(
+        &self,
+        _ctx: &TtrpcContext,
+        req: api::PidsRequest,
+    ) -> TtrpcResult<api::PidsResponse> {
+        let pids = self.backend.pids(&req.id).await.map_err(err)?;
+        let processes = pids
+            .into_iter()
+            .map(|pid| containerd_shim_protos::types::task::ProcessInfo {
+                pid,
+                ..Default::default()
+            })
+            .collect();
+        Ok(api::PidsResponse {
+            processes,
+            ..Default::default()
+        })
+    }
+
+    async fn stats(
+        &self,
+        _ctx: &TtrpcContext,
+        req: api::StatsRequest,
+    ) -> TtrpcResult<api::StatsResponse> {
+        let blob = self.backend.stats(&req.id).await.map_err(err)?;
+        let mut resp = api::StatsResponse::default();
+        if let Some(bytes) = blob {
+            // The backend hands us an encoded cgroups Metrics message.
+            let metrics =
+                containerd_shim_protos::cgroups::metrics::Metrics::parse_from_bytes(&bytes)
+                    .map_err(err)?;
+            resp.stats = Some(convert_to_any(Box::new(metrics)).map_err(err)?).into();
+        }
+        Ok(resp)
+    }
+
+    async fn connect(
+        &self,
+        _ctx: &TtrpcContext,
+        req: api::ConnectRequest,
+    ) -> TtrpcResult<api::ConnectResponse> {
+        let map = self.procs.lock().await;
+        let pid = map
+            .get(&(req.id.clone(), String::new()))
+            .map(|p| p.pid)
+            .unwrap_or_default();
+        Ok(api::ConnectResponse {
+            shim_pid: std::process::id(),
+            task_pid: pid,
+            ..Default::default()
+        })
+    }
+
+    async fn shutdown(
+        &self,
+        _ctx: &TtrpcContext,
+        _req: api::ShutdownRequest,
+    ) -> TtrpcResult<api::Empty> {
+        let map = self.procs.lock().await;
+        if map.is_empty() {
+            self.exit.signal();
+        }
+        Ok(api::Empty::default())
+    }
+
+    async fn update(
+        &self,
+        _ctx: &TtrpcContext,
+        _req: api::UpdateTaskRequest,
+    ) -> TtrpcResult<api::Empty> {
+        // Resource updates inside the guest: accepted as no-op for now (the
+        // guest cgroup follows the container spec set at create time).
+        Ok(api::Empty::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::MockBackend;
+
+    fn svc(backend: Arc<MockBackend>) -> TaskService<MockBackend> {
+        TaskService::new(
+            backend,
+            None,
+            "k8s.io".into(),
+            Arc::new(containerd_shim::asynchronous::ExitSignal::default()),
+        )
+    }
+
+    fn ttctx() -> TtrpcContext {
+        TtrpcContext {
+            mh: Default::default(),
+            metadata: Default::default(),
+            timeout_nano: 0,
+        }
+    }
+
+    async fn create_container(
+        s: &TaskService<MockBackend>,
+        dir: &std::path::Path,
+        id: &str,
+    ) -> api::CreateTaskResponse {
+        let bundle = dir.join(id);
+        std::fs::create_dir_all(bundle.join("rootfs")).unwrap();
+        std::fs::write(
+            bundle.join("config.json"),
+            serde_json::json!({
+                "ociVersion": "1.0.2",
+                "process": {"args": ["sleep", "1"], "cwd": "/"},
+                "root": {"path": "rootfs"},
+                "annotations": {"io.kubernetes.cri.container-type": "container"}
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let req = api::CreateTaskRequest {
+            id: id.to_string(),
+            bundle: bundle.to_string_lossy().into_owned(),
+            ..Default::default()
+        };
+        s.create(&ttctx(), req).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn lifecycle_create_start_kill_wait_delete() {
+        let backend = MockBackend::new();
+        let s = svc(backend.clone());
+        let dir = tempfile::tempdir().unwrap();
+
+        let created = create_container(&s, dir.path(), "c1").await;
+        assert_eq!(created.pid, 100);
+
+        // State: CREATED
+        let st = s
+            .state(
+                &ttctx(),
+                api::StateRequest {
+                    id: "c1".into(),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(st.status.unwrap(), api::Status::CREATED);
+
+        // Start → RUNNING
+        s.start(
+            &ttctx(),
+            api::StartRequest {
+                id: "c1".into(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        // Kill(SIGKILL) → exit 137; Wait resolves
+        s.kill(
+            &ttctx(),
+            api::KillRequest {
+                id: "c1".into(),
+                signal: 9,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let w = s
+            .wait(
+                &ttctx(),
+                api::WaitRequest {
+                    id: "c1".into(),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(w.exit_status, 137);
+
+        // Delete returns the same exit info
+        let d = s
+            .delete(
+                &ttctx(),
+                api::DeleteRequest {
+                    id: "c1".into(),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(d.exit_status, 137);
+
+        // Gone afterwards
+        assert!(s
+            .state(
+                &ttctx(),
+                api::StateRequest {
+                    id: "c1".into(),
+                    ..Default::default()
+                },
+            )
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn exec_lifecycle() {
+        let backend = MockBackend::new();
+        let s = svc(backend.clone());
+        let dir = tempfile::tempdir().unwrap();
+        create_container(&s, dir.path(), "c2").await;
+        s.start(
+            &ttctx(),
+            api::StartRequest {
+                id: "c2".into(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let mut ereq = api::ExecProcessRequest {
+            id: "c2".into(),
+            exec_id: "e1".into(),
+            ..Default::default()
+        };
+        ereq.spec =
+            Some(containerd_shim_protos::protobuf::well_known_types::any::Any::default()).into();
+        s.exec(&ttctx(), ereq).await.unwrap();
+
+        let started = s
+            .start(
+                &ttctx(),
+                api::StartRequest {
+                    id: "c2".into(),
+                    exec_id: "e1".into(),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(started.pid, 200);
+
+        backend.finish("c2", Some("e1"), 0).await;
+        let w = s
+            .wait(
+                &ttctx(),
+                api::WaitRequest {
+                    id: "c2".into(),
+                    exec_id: "e1".into(),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(w.exit_status, 0);
+    }
+
+    #[tokio::test]
+    async fn wait_after_exit_returns_immediately() {
+        let backend = MockBackend::new();
+        let s = svc(backend.clone());
+        let dir = tempfile::tempdir().unwrap();
+        create_container(&s, dir.path(), "c3").await;
+        s.start(
+            &ttctx(),
+            api::StartRequest {
+                id: "c3".into(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        backend.finish("c3", None, 7).await;
+        // Give the watcher a beat to record the exit.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let w = s
+            .wait(
+                &ttctx(),
+                api::WaitRequest {
+                    id: "c3".into(),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(w.exit_status, 7);
+        let st = s
+            .state(
+                &ttctx(),
+                api::StateRequest {
+                    id: "c3".into(),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(st.status.unwrap(), api::Status::STOPPED);
+    }
+}

--- a/examples/doubledelete_test.rs
+++ b/examples/doubledelete_test.rs
@@ -17,6 +17,7 @@ fn main() {
             ..Default::default()
         },
         persistent: false,
+        runtime_managed: false,
     })
     .expect("create");
     rt.delete_machine(name).expect("first delete");

--- a/examples/largeoutput_test.rs
+++ b/examples/largeoutput_test.rs
@@ -18,6 +18,7 @@ fn main() {
             ..Default::default()
         },
         persistent: false,
+        runtime_managed: false,
     });
     rt.start_machine(name).expect("start");
     // small output: works

--- a/examples/orphan_test.rs
+++ b/examples/orphan_test.rs
@@ -22,6 +22,7 @@ fn main() {
             ..Default::default()
         },
         persistent: false,
+        runtime_managed: false,
     };
     let _ = rt.create_machine(spec); // ignore "already exists" on reruns
     rt.start_machine(&name).expect("start machine");

--- a/examples/readfile_fix_test.rs
+++ b/examples/readfile_fix_test.rs
@@ -19,6 +19,7 @@ fn main() {
             ..Default::default()
         },
         persistent: false,
+        runtime_managed: false,
     });
     rt.start_machine(name).expect("start");
 

--- a/examples/reattach_test.rs
+++ b/examples/reattach_test.rs
@@ -19,6 +19,7 @@ fn main() {
             ..Default::default()
         },
         persistent: true,
+        runtime_managed: false,
     })
     .expect("create");
     rt.start_machine(name).expect("start");

--- a/scripts/install-k8s-runtime.sh
+++ b/scripts/install-k8s-runtime.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# Install the smolvm Kubernetes runtime (containerd shim v2) on a node.
+#
+# Lays down the shim binary and the runtime artifacts smolvm's embedded engine
+# needs (libkrun, the guest kernel init, the agent rootfs, the VM monitor), then
+# prints the containerd runtime-class registration to add. It deliberately does
+# NOT edit /etc/containerd/config.toml or restart containerd — those are shown so
+# an operator (or a config-management tool) applies them deliberately.
+#
+# Usage:
+#   sudo ./scripts/install-k8s-runtime.sh [--shim PATH] [--runtime-dir DIR]
+#
+#   --shim PATH          The built containerd-shim-smolvm-v2 binary
+#                        (default: target/release/containerd-shim-smolvm-v2).
+#   --runtime-dir DIR    A directory holding the smolvm runtime artifacts to
+#                        install into /var/lib/smolvm: lib/ (libkrun*.so),
+#                        init.krun, smolvm-vmm, agent-rootfs/. A smolvm Linux
+#                        distribution directory has these. If omitted, the
+#                        artifacts already under /var/lib/smolvm are kept and
+#                        only the shim is (re)installed.
+#
+set -euo pipefail
+
+SHIM_SRC="target/release/containerd-shim-smolvm-v2"
+RUNTIME_SRC=""
+DATA_DIR="/var/lib/smolvm"
+BIN_DIR="/usr/local/bin"
+SHIM_DST="$BIN_DIR/containerd-shim-smolvm-v2"
+RUNTIME_ARTIFACTS=(lib init.krun smolvm-vmm agent-rootfs)
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --shim) SHIM_SRC="$2"; shift 2 ;;
+        --runtime-dir) RUNTIME_SRC="$2"; shift 2 ;;
+        -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+        *) echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+[ "$(id -u)" = 0 ] || { echo "error: run as root (sudo)" >&2; exit 1; }
+[ -f "$SHIM_SRC" ] || { echo "error: shim binary not found: $SHIM_SRC (build with: cargo build --release -p smolvm-shim)" >&2; exit 1; }
+
+echo "==> Installing runtime artifacts into $DATA_DIR"
+mkdir -p "$DATA_DIR"
+if [ -n "$RUNTIME_SRC" ]; then
+    [ -d "$RUNTIME_SRC" ] || { echo "error: --runtime-dir not a directory: $RUNTIME_SRC" >&2; exit 1; }
+    for a in "${RUNTIME_ARTIFACTS[@]}"; do
+        if [ -e "$RUNTIME_SRC/$a" ]; then
+            echo "    $a"
+            rm -rf "${DATA_DIR:?}/$a"
+            cp -a "$RUNTIME_SRC/$a" "$DATA_DIR/"   # -a preserves the agent-rootfs symlinks
+        else
+            echo "    warning: $a not found in $RUNTIME_SRC — leaving existing" >&2
+        fi
+    done
+else
+    echo "    (no --runtime-dir; keeping existing artifacts)"
+fi
+
+# Sanity-check the artifacts the shim will need at runtime are present.
+missing=0
+for a in lib/libkrun.so agent-rootfs smolvm-vmm; do
+    [ -e "$DATA_DIR/$a" ] || { echo "error: required artifact missing: $DATA_DIR/$a" >&2; missing=1; }
+done
+[ "$missing" = 0 ] || { echo "install incomplete — supply --runtime-dir with a smolvm distribution" >&2; exit 1; }
+
+echo "==> Installing shim: $SHIM_SRC -> $SHIM_DST"
+install -Dm755 "$SHIM_SRC" "$SHIM_DST.tmp"
+mv -f "$SHIM_DST.tmp" "$SHIM_DST"   # atomic swap: tolerates a running/busy shim binary
+
+echo "==> Verifying the shim binary runs"
+if "$SHIM_DST" -v >/dev/null 2>&1 || "$SHIM_DST" --help >/dev/null 2>&1; then
+    echo "    ok"
+else
+    echo "    (shim has no version flag; binary installed)"
+fi
+
+CONF="/etc/containerd/config.toml"
+echo
+echo "==> containerd registration"
+if grep -q 'io.containerd.smolvm.v2' "$CONF" 2>/dev/null; then
+    echo "    already registered in $CONF — nothing to change."
+else
+    cat <<'EOF'
+    Add the smolvm runtime class to /etc/containerd/config.toml under the CRI
+    runtimes table (path shown for containerd 2.x; for 1.x use
+    plugins."io.containerd.grpc.v1.cri".containerd.runtimes.smolvm):
+
+      [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.smolvm]
+        runtime_type = 'io.containerd.smolvm.v2'
+        sandboxer = 'podsandbox'
+
+    Then restart containerd:
+
+      systemctl restart containerd
+
+    and create the RuntimeClass in the cluster:
+
+      kubectl apply -f - <<'YAML'
+      apiVersion: node.k8s.io/v1
+      kind: RuntimeClass
+      metadata:
+        name: smolvm
+      handler: smolvm
+      YAML
+EOF
+fi
+echo
+echo "Done. Run pods with runtimeClassName: smolvm (VM-grade isolation)."

--- a/src/agent/boot_config.rs
+++ b/src/agent/boot_config.rs
@@ -77,4 +77,11 @@ pub struct BootConfig {
     /// lets the `pack --from-vm` exporter attach a source qcow2 disk read-only.
     #[serde(default)]
     pub extra_disks: Vec<(PathBuf, bool, DiskFormat)>,
+    /// Kubernetes pod network namespace to attach the guest virtio-net NIC to.
+    /// When set, the boot subprocess (while still privileged) opens a tap inside
+    /// this netns and tc-redirects it against the CNI interface, then bridges the
+    /// guest NIC L2 to it — so the pod carries its CNI-assigned IP. Requires the
+    /// virtio-net backend. See `agent::pod_net`.
+    #[serde(default)]
+    pub pod_netns: Option<PathBuf>,
 }

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -1097,7 +1097,7 @@ impl AgentClient {
                         write_all_retry(&mut stderr(), &data)?;
                         flush_retry(&mut stderr())?;
                     }
-                    Ok(AgentResponse::Exited { exit_code }) => {
+                    Ok(AgentResponse::Exited { exit_code, .. }) => {
                         break exit_code;
                     }
                     Ok(AgentResponse::Error { message, .. }) => {
@@ -1425,7 +1425,7 @@ impl AgentClient {
                     Ok(AgentResponse::Stderr { data }) => {
                         on_output(InteractiveOutput::Stderr(data))
                     }
-                    Ok(AgentResponse::Exited { exit_code }) => break exit_code,
+                    Ok(AgentResponse::Exited { exit_code, .. }) => break exit_code,
                     Ok(AgentResponse::Error { message, .. }) => {
                         return Err(Error::agent(op, message))
                     }
@@ -2118,7 +2118,7 @@ where
                 total = total.saturating_add(data.len());
                 on_event(ExecEvent::Stderr(data));
             }
-            Ok(AgentResponse::Exited { exit_code }) => {
+            Ok(AgentResponse::Exited { exit_code, .. }) => {
                 on_event(ExecEvent::Exit(exit_code));
                 break;
             }
@@ -2434,7 +2434,10 @@ mod collect_exec_cap_tests {
                 AgentResponse::Stderr {
                     data: b"warn".to_vec(),
                 },
-                AgentResponse::Exited { exit_code: 0 },
+                AgentResponse::Exited {
+                    exit_code: 0,
+                    oom: false,
+                },
             ],
         );
         res.unwrap();
@@ -2635,7 +2638,10 @@ mod run_streaming_tests {
                 AgentResponse::Stderr {
                     data: b"warn\n".to_vec(),
                 },
-                AgentResponse::Exited { exit_code: 7 },
+                AgentResponse::Exited {
+                    exit_code: 7,
+                    oom: false,
+                },
             ] {
                 let encoded = encode_message(&response).expect("encode response");
                 server_stream.write_all(&encoded).expect("write response");

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -218,6 +218,13 @@ pub struct LaunchFeatures {
     /// `SMOLVM_BOOT_BINARY` (so `current_exe` need not handle `_boot-vm`) yet
     /// DETACHES the VM to persist after the CLI exits (e.g. `smol start`/`fork`).
     pub watch_parent: Option<bool>,
+    /// Kubernetes pod network namespace to attach the VM's virtio-net device to
+    /// (the CNI-provisioned netns for a shim-booted pod sandbox). When set, the
+    /// launcher bridges the guest NIC L2 to a tap inside this netns (tc-redirect
+    /// against the CNI interface) instead of running the NAT gateway, so the pod
+    /// carries its CNI-assigned IP and is reachable at L2. Runtime-only (never
+    /// persisted in `VmRecord`); requires the virtio-net backend.
+    pub pod_netns: Option<std::path::PathBuf>,
 }
 
 impl LaunchFeatures {
@@ -398,6 +405,12 @@ pub struct LaunchConfig<'a> {
     /// surface `egressBytes` in the machine info, the same per-VM-dir bridge the
     /// vsock/console paths use. `None` disables egress telemetry (e.g. TSI).
     pub egress_telemetry: Option<&'a Path>,
+    /// Kubernetes pod-network attachment (Linux only): the tap fd bridged to the
+    /// guest virtio-net NIC and the CNI L3 config (pod IP/prefix/gateway/MAC/MTU)
+    /// to apply to it. Set by the boot subprocess after it attached the pod netns
+    /// while privileged. When present, the virtio-net arm bridges the guest NIC to
+    /// the tap instead of running the NAT gateway. `None` for non-pod VMs.
+    pub pod_net: Option<crate::agent::pod_net::PodNetLaunch>,
 }
 
 /// Launch the agent VM using libkrun.
@@ -437,7 +450,12 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
         dns_filter_enabled,
         egress_refresh_hosts,
         egress_telemetry,
+        pod_net,
     } = config;
+    // `pod_net` drives the Linux-only pod netns-tap datapath; on other targets the
+    // field exists (cross-platform LaunchConfig) but is never read.
+    #[cfg(not(target_os = "linux"))]
+    let _ = &pod_net;
 
     crate::network::validate_requested_network_backend(resources, None, port_mappings.len())?;
 
@@ -622,6 +640,11 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
         // binding stays `None`.
         #[cfg_attr(not(unix), allow(unused_mut))]
         let mut virtio_network_runtime: Option<VirtioNetworkRuntime> = None;
+        // Holds the pod netns-tap frame bridge (Kubernetes pod networking) for the
+        // VM's lifetime; dropped alongside `virtio_network_runtime` after the VM
+        // exits. Only ever set on the pod datapath.
+        #[cfg(target_os = "linux")]
+        let mut netns_bridge: Option<smolvm_network::netns_tap::NetnsTapBridge> = None;
         let guest_network: Option<GuestNetworkConfig> = match network_plan.backend {
             EffectiveNetworkBackend::None => {
                 // Upstream libkrun no longer creates an implicit vsock (the old
@@ -747,6 +770,24 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
                 }
                 let mut guest_mac = guest_network.guest_mac;
 
+                // Kubernetes pod networking: adopt the CNI interface's IP/prefix/
+                // MAC (discovered from the pod netns) so the guest NIC *is* the pod
+                // IP and ARP for it resolves to the VM. `guest_network_env` pushes
+                // these to the guest, which configures eth0 statically at boot.
+                #[cfg(target_os = "linux")]
+                if let Some(pod) = pod_net.as_ref() {
+                    guest_network.guest_ip = pod.ip;
+                    guest_network.prefix_len = pod.prefix;
+                    if let Some(gw) = pod.gateway {
+                        guest_network.gateway_ip = gw;
+                        // Best-effort: point the guest resolver at the gateway.
+                        // Cluster DNS injection (pod dnsConfig) is a follow-up.
+                        guest_network.dns_server = gw;
+                    }
+                    guest_network.guest_mac = pod.mac;
+                    guest_mac = pod.mac;
+                }
+
                 let virtio_port_mappings: Vec<VirtioPortMapping> = port_mappings
                     .iter()
                     .map(|mapping| VirtioPortMapping::new(mapping.host, mapping.guest))
@@ -768,25 +809,85 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
                     let (host_fd, guest_fd) = create_unix_stream_pair().map_err(|e| {
                         Error::agent("configure virtio-net", format!("socketpair failed: {e}"))
                     })?;
-                    // SAFETY: ownership of the host-side socketpair fd transfers
-                    // here (already inside the function's outer `unsafe` block).
-                    let host_stream = Socket::from_raw_fd(host_fd);
-                    let runtime = match start_virtio_network(
-                        host_stream,
-                        guest_network,
-                        &virtio_port_mappings,
-                        egress,
-                    ) {
-                        Ok(runtime) => runtime,
-                        Err(err) => {
-                            libc::close(guest_fd);
-                            krun_free_ctx(ctx);
-                            return Err(Error::agent(
-                                "configure virtio-net",
-                                format!("failed to start virtio network runtime: {err}"),
-                            ));
+
+                    // Datapath selection on the host end of the virtio-net channel:
+                    //   * Kubernetes pod: bridge the guest NIC L2 to the tap in the
+                    //     pod netns (opened + tc-redirected while privileged in
+                    //     internal_boot), so the pod is reachable at its CNI IP.
+                    //   * Otherwise: run the smoltcp NAT gateway (outbound + ports).
+                    #[cfg(target_os = "linux")]
+                    let pod_tap_fd: Option<i32> = pod_net.as_ref().map(|p| p.tap_fd);
+                    #[cfg(not(target_os = "linux"))]
+                    let pod_tap_fd: Option<i32> = None;
+
+                    match pod_tap_fd {
+                        #[cfg(target_os = "linux")]
+                        Some(tap_fd) => {
+                            use std::os::fd::{FromRawFd, OwnedFd};
+                            use std::os::unix::net::UnixStream;
+                            // Dup so the bridge owns an independent fd; internal_boot's
+                            // PodNetAttachment keeps the original tap open for the VM's
+                            // lifetime.
+                            let dup_fd = libc::dup(tap_fd);
+                            if dup_fd < 0 {
+                                libc::close(host_fd);
+                                libc::close(guest_fd);
+                                krun_free_ctx(ctx);
+                                return Err(Error::agent(
+                                    "configure pod netns",
+                                    "dup(tap fd) failed",
+                                ));
+                            }
+                            // SAFETY: host_fd and dup_fd are fresh owned fds.
+                            let tap_owned = OwnedFd::from_raw_fd(dup_fd);
+                            let host_unixstream = UnixStream::from_raw_fd(host_fd);
+                            match smolvm_network::netns_tap::start_netns_tap_bridge(
+                                host_unixstream,
+                                tap_owned,
+                            ) {
+                                Ok(bridge) => netns_bridge = Some(bridge),
+                                Err(err) => {
+                                    libc::close(guest_fd);
+                                    krun_free_ctx(ctx);
+                                    return Err(Error::agent(
+                                        "configure pod netns",
+                                        format!("start netns-tap bridge: {err}"),
+                                    ));
+                                }
+                            }
+                            tracing::info!("network backend: virtio-net (pod netns-tap bridge)");
                         }
-                    };
+                        _ => {
+                            // SAFETY: ownership of the host-side socketpair fd transfers
+                            // here (already inside the function's outer `unsafe` block).
+                            let host_stream = Socket::from_raw_fd(host_fd);
+                            let runtime = match start_virtio_network(
+                                host_stream,
+                                guest_network,
+                                &virtio_port_mappings,
+                                egress,
+                            ) {
+                                Ok(runtime) => runtime,
+                                Err(err) => {
+                                    libc::close(guest_fd);
+                                    krun_free_ctx(ctx);
+                                    return Err(Error::agent(
+                                        "configure virtio-net",
+                                        format!("failed to start virtio network runtime: {err}"),
+                                    ));
+                                }
+                            };
+                            // Flush this NIC's egress counter to the per-VM dir so serve
+                            // can bill it (parity with how disk size reaches the node API).
+                            if let Some(path) = egress_path {
+                                crate::agent::manager::spawn_egress_flush(
+                                    path,
+                                    runtime.egress_counter(),
+                                );
+                            }
+                            virtio_network_runtime = Some(runtime);
+                        }
+                    }
 
                     if add_net_unixstream(
                         ctx,
@@ -804,13 +905,6 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
                             "krun_add_net_unixstream failed",
                         ));
                     }
-
-                    // Flush this NIC's egress counter to the per-VM dir so serve can
-                    // bill it (parity with how disk size reaches the node API).
-                    if let Some(path) = egress_path {
-                        crate::agent::manager::spawn_egress_flush(path, runtime.egress_counter());
-                    }
-                    virtio_network_runtime = Some(runtime);
                 }
                 #[cfg(windows)]
                 {
@@ -1434,6 +1528,8 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
         // If we get here, something went wrong — free the context before returning
         krun_free_ctx(ctx);
         drop(virtio_network_runtime);
+        #[cfg(target_os = "linux")]
+        drop(netns_bridge);
         Err(Error::agent(
             "start vm",
             format!("krun_start_enter returned: {}", ret),

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -393,22 +393,6 @@ pub fn prune_orphaned_ready_markers() {
     }
 }
 
-/// Whether a readiness-marker file at `path` can be created (pre-created
-/// empty as a side effect on success, which the Landlock carve-out relies
-/// on). False on read-only rootfs installs — see
-/// `AgentManager::ready_marker_writable`.
-fn marker_creatable(path: &Path) -> bool {
-    // truncate(false): a fast guest may already have written the marker by the
-    // time this probe runs — truncating would erase the readiness signal and
-    // force the boot onto the socket path it was trying to avoid.
-    std::fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(false)
-        .open(path)
-        .is_ok()
-}
-
 /// Path-injectable core of [`prune_orphaned_ready_markers`] (unit-testable).
 fn prune_orphaned_ready_markers_in(rootfs: &Path, vm_cache_root: &Path) {
     let prefix = format!("{}.", AGENT_READY_MARKER);
@@ -1371,21 +1355,6 @@ impl AgentManager {
         self.rootfs_path.join(self.ready_marker_name())
     }
 
-    /// Whether this VM's ready marker can actually be created.
-    ///
-    /// The marker lives inside the agent rootfs (the virtiofs share), so on
-    /// system installs where that directory is root-owned (/opt, /usr/lib)
-    /// and smolvm runs unprivileged, neither the host pre-create nor the
-    /// guest's virtiofs write can ever succeed — the marker "never appears"
-    /// and every boot silently pays the full socket-probe grace (#590).
-    /// Probing this up front lets `wait_for_ready` fall back to socket
-    /// polling immediately instead. The probe leaves the marker pre-created
-    /// empty on success, which is also what the Landlock carve-out expects
-    /// (readiness requires non-empty content, so this cannot false-positive).
-    fn ready_marker_writable(&self) -> bool {
-        marker_creatable(&self.ready_marker_path())
-    }
-
     /// Common pre-launch setup: validate state, pre-format disks, clean markers.
     ///
     /// Called by both `start_with_full_config` (fork) and `start_via_subprocess`.
@@ -1841,6 +1810,7 @@ impl AgentManager {
             packed_layers_dir: features.packed_layers_dir,
             pack_idmap_source,
             extra_disks: features.extra_disks,
+            pod_netns: features.pod_netns,
         };
         let config_path = self
             .storage_disk
@@ -2357,23 +2327,7 @@ impl AgentManager {
     fn wait_for_ready(&self) -> Result<()> {
         let timeout = AGENT_READY_TIMEOUT;
         let start = Instant::now();
-        // Marker-first readiness only works when the marker file (inside the
-        // agent-rootfs virtiofs share) is writable at all. On read-only system
-        // installs it never appears; skip the grace and poll the socket from
-        // the start instead of stalling every boot for the full grace (#590).
-        let marker_expected = self.ready_marker_writable();
-        let socket_probe_grace = if marker_expected {
-            Duration::from_secs(5)
-        } else {
-            tracing::info!(
-                rootfs = %self.rootfs_path.display(),
-                "agent-rootfs is not writable by this process; ready-marker fast \
-                 path unavailable, using socket readiness probe. For the fastest \
-                 boots make the rootfs dir writable by the running user or point \
-                 SMOLVM_AGENT_ROOTFS at a writable copy"
-            );
-            Duration::ZERO
-        };
+        let socket_probe_grace = Duration::from_secs(5);
 
         tracing::debug!("waiting for agent to be ready");
 
@@ -2461,24 +2415,15 @@ impl AgentManager {
                 {
                     if client.ping().is_ok() {
                         let elapsed = start.elapsed();
-                        if marker_expected {
-                            let landlock = std::env::var("SMOLVM_LANDLOCK").unwrap_or_default();
-                            tracing::warn!(
-                                elapsed_ms = elapsed.as_millis(),
-                                landlock = %landlock,
-                                "agent ready via SOCKET FALLBACK — ready marker never appeared; \
-                                 boot was delayed by the probe grace. If a current agent, this is a \
-                                 fault (under SMOLVM_LANDLOCK=enforce the ready-marker carve-out in \
-                                 internal_boot.rs is likely broken)"
-                            );
-                        } else {
-                            // Read-only rootfs: socket IS the readiness path; no
-                            // grace was paid (socket_probe_grace == 0).
-                            tracing::info!(
-                                elapsed_ms = elapsed.as_millis(),
-                                "agent ready (socket; marker unavailable on read-only rootfs)"
-                            );
-                        }
+                        let landlock = std::env::var("SMOLVM_LANDLOCK").unwrap_or_default();
+                        tracing::warn!(
+                            elapsed_ms = elapsed.as_millis(),
+                            landlock = %landlock,
+                            "agent ready via SOCKET FALLBACK — ready marker never appeared; \
+                             boot was delayed by the probe grace. If a current agent, this is a \
+                             fault (under SMOLVM_LANDLOCK=enforce the ready-marker carve-out in \
+                             internal_boot.rs is likely broken)"
+                        );
                         return Ok(());
                     }
                 }
@@ -2637,36 +2582,6 @@ mod tests {
         // Callers rely on this to locate existing VM data across processes.
         assert_eq!(vm_dir_hash("sandbox-1"), vm_dir_hash("sandbox-1"));
         assert_eq!(vm_dir_hash("default"), vm_dir_hash("default"));
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn marker_creatable_detects_readonly_rootfs() {
-        use std::os::unix::fs::PermissionsExt;
-        let tmp = tempfile::tempdir().unwrap();
-
-        // Writable rootfs: probe succeeds and pre-creates the marker empty.
-        let marker = tmp.path().join(format!("{}.abc123", AGENT_READY_MARKER));
-        assert!(marker_creatable(&marker));
-        assert_eq!(std::fs::metadata(&marker).unwrap().len(), 0);
-
-        // Read-only rootfs (root-owned system install, #590): probe fails so
-        // wait_for_ready can skip the socket-probe grace instead of stalling.
-        let ro = tmp.path().join("ro-rootfs");
-        std::fs::create_dir(&ro).unwrap();
-        std::fs::set_permissions(&ro, std::fs::Permissions::from_mode(0o555)).unwrap();
-        let denied = ro.join(format!("{}.abc123", AGENT_READY_MARKER));
-        if !nix_is_root() {
-            assert!(!marker_creatable(&denied));
-        }
-        std::fs::set_permissions(&ro, std::fs::Permissions::from_mode(0o755)).unwrap();
-    }
-
-    /// chmod-based denial doesn't apply to root (e.g. docker CI); skip there.
-    #[cfg(unix)]
-    fn nix_is_root() -> bool {
-        // SAFETY: geteuid has no preconditions and cannot fail.
-        unsafe { libc::geteuid() == 0 }
     }
 
     #[test]

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -11,6 +11,7 @@ mod krun;
 mod launcher;
 pub mod launcher_dynamic;
 mod manager;
+pub mod pod_net;
 pub mod state_probe;
 pub mod terminal;
 mod vsock_service;

--- a/src/agent/pod_net.rs
+++ b/src/agent/pod_net.rs
@@ -1,0 +1,241 @@
+//! Kubernetes pod networking for shim-booted sandbox VMs.
+//!
+//! A pod sandbox VM must carry its CNI-assigned IP and be reachable at L2 on the
+//! pod network — the same contract Kata satisfies. containerd runs the CNI plugin
+//! against the sandbox's netns *before* we boot, leaving a configured interface
+//! (`eth0`, a veth) there with the pod IP. This module, run in the boot
+//! subprocess's privileged window (before the uid drop), discovers that
+//! interface's L3 config, opens a tap in the netns, and tc-redirects the tap
+//! against `eth0` (see [`smolvm_network::netns_tap`]). The launcher then bridges
+//! the guest virtio-net NIC to the tap and configures the guest NIC with the
+//! discovered IP/MAC, so the VM *is* the pod IP.
+
+use std::net::Ipv4Addr;
+
+/// CNI L3 config to apply to the guest NIC, plus the tap fd bridged to it.
+///
+/// Cross-platform (the launcher and boot-config boundary compile everywhere);
+/// only the netns discovery below is Linux-only. Placed in the `LaunchConfig` so
+/// the virtio-net arm can adopt the pod IP/MAC and bridge the tap.
+#[derive(Debug, Clone)]
+pub struct PodNetLaunch {
+    /// Raw tap fd — owned by the boot subprocess's [`PodNetAttachment`], kept
+    /// alive for the VM's lifetime. The launcher dups it for the frame bridge.
+    pub tap_fd: i32,
+    /// Pod IPv4 address (the CNI-assigned pod IP).
+    pub ip: Ipv4Addr,
+    /// Prefix length of the pod subnet.
+    pub prefix: u8,
+    /// Default gateway (the CNI bridge), if the netns has a default route.
+    pub gateway: Option<Ipv4Addr>,
+    /// MAC of the CNI interface; the guest NIC adopts it so ARP for the pod IP
+    /// resolves to the VM.
+    pub mac: [u8; 6],
+    /// Interface MTU from the CNI config.
+    pub mtu: u32,
+}
+
+/// Name of the CNI-provisioned interface containerd leaves in the pod netns.
+#[cfg(target_os = "linux")]
+const CNI_IFACE: &str = "eth0";
+/// Name of the tap we create in the netns to carry the VM's L2 traffic.
+#[cfg(target_os = "linux")]
+const TAP_IFACE: &str = "tap0";
+
+/// A live pod-netns attachment held by the boot subprocess: the tap fd (bridged
+/// to the guest NIC by the launcher) and the discovered CNI L3 config. Dropping
+/// it closes the tap, tearing down the datapath when the VM exits.
+#[cfg(target_os = "linux")]
+pub struct PodNetAttachment {
+    /// Owns the tap fd for the VM's lifetime (the launcher only dups it).
+    _tap: std::os::fd::OwnedFd,
+    launch: PodNetLaunch,
+}
+
+#[cfg(target_os = "linux")]
+impl PodNetAttachment {
+    /// The launch view (tap fd + L3 config) to place in the `LaunchConfig`.
+    pub fn launch(&self) -> PodNetLaunch {
+        self.launch.clone()
+    }
+}
+
+/// Discover the CNI interface, open a tap in `netns_path`, and tc-redirect the
+/// tap against the CNI interface. Privileged (needs CAP_NET_ADMIN +
+/// CAP_SYS_ADMIN); call in the boot subprocess's privileged window, before the
+/// uid drop and Landlock/seccomp.
+#[cfg(target_os = "linux")]
+pub fn attach_pod_netns(netns_path: &str) -> std::io::Result<PodNetAttachment> {
+    use std::os::fd::AsRawFd;
+
+    let mut launch = read_pod_interface(netns_path, CNI_IFACE)?;
+    // Open the tap first; only then redirect (tc needs the device to exist).
+    let tap = smolvm_network::netns_tap::open_tap_in_netns(netns_path, TAP_IFACE)?;
+    smolvm_network::netns_tap::setup_tc_redirect(netns_path, CNI_IFACE, TAP_IFACE)?;
+    launch.tap_fd = tap.as_raw_fd();
+    tracing::info!(
+        netns = %netns_path,
+        pod_ip = %launch.ip,
+        prefix = launch.prefix,
+        gateway = ?launch.gateway,
+        mtu = launch.mtu,
+        "pod netns attached (tap0 tc-redirected against eth0)"
+    );
+    Ok(PodNetAttachment { _tap: tap, launch })
+}
+
+/// Read `ifname`'s IPv4/prefix/MAC/MTU and the default gateway from inside the
+/// pod netns via `nsenter … ip -j`. Returns a [`PodNetLaunch`] with `tap_fd`
+/// unset (`-1`) — [`attach_pod_netns`] fills it in after opening the tap.
+#[cfg(target_os = "linux")]
+pub fn read_pod_interface(netns_path: &str, ifname: &str) -> std::io::Result<PodNetLaunch> {
+    let addr = ip_json(netns_path, &["-j", "addr", "show", ifname])?;
+    let route = ip_json(netns_path, &["-j", "route", "show", "default"])?;
+    parse_pod_interface(&addr, &route, ifname)
+}
+
+/// Run `nsenter --net=<netns> ip <args>` and parse the `-j` JSON output.
+#[cfg(target_os = "linux")]
+fn ip_json(netns_path: &str, args: &[&str]) -> std::io::Result<serde_json::Value> {
+    let out = std::process::Command::new("nsenter")
+        .arg(format!("--net={netns_path}"))
+        .arg("ip")
+        .args(args)
+        .output()?;
+    if !out.status.success() {
+        return Err(std::io::Error::other(format!(
+            "nsenter --net={netns_path} ip {}: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    serde_json::from_slice(&out.stdout)
+        .map_err(|e| std::io::Error::other(format!("parse `ip {}` json: {e}", args.join(" "))))
+}
+
+/// Parse `ip -j addr show <ifname>` + `ip -j route show default` into the L3
+/// config. Pure (no I/O) so it is unit-testable against captured JSON.
+#[cfg(target_os = "linux")]
+fn parse_pod_interface(
+    addr: &serde_json::Value,
+    route: &serde_json::Value,
+    ifname: &str,
+) -> std::io::Result<PodNetLaunch> {
+    let err = |m: String| std::io::Error::new(std::io::ErrorKind::InvalidData, m);
+
+    let iface = addr
+        .as_array()
+        .and_then(|a| a.first())
+        .ok_or_else(|| err(format!("no interface {ifname} in pod netns")))?;
+
+    let mac_str = iface
+        .get("address")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| err(format!("{ifname}: no MAC in `ip addr`")))?;
+    let mac = parse_mac(mac_str).ok_or_else(|| err(format!("{ifname}: bad MAC {mac_str}")))?;
+
+    let mtu = iface.get("mtu").and_then(|v| v.as_u64()).unwrap_or(1500) as u32;
+
+    let inet = iface
+        .get("addr_info")
+        .and_then(|v| v.as_array())
+        .and_then(|infos| {
+            infos
+                .iter()
+                .find(|i| i.get("family").and_then(|f| f.as_str()) == Some("inet"))
+        })
+        .ok_or_else(|| err(format!("{ifname}: no IPv4 address in pod netns")))?;
+
+    let ip: Ipv4Addr = inet
+        .get("local")
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse().ok())
+        .ok_or_else(|| err(format!("{ifname}: unparseable IPv4 address")))?;
+    let prefix = inet.get("prefixlen").and_then(|v| v.as_u64()).unwrap_or(24) as u8;
+
+    let gateway = route
+        .as_array()
+        .and_then(|routes| {
+            routes
+                .iter()
+                .find(|r| r.get("dst").and_then(|d| d.as_str()) == Some("default"))
+        })
+        .and_then(|r| r.get("gateway"))
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse().ok());
+
+    Ok(PodNetLaunch {
+        tap_fd: -1,
+        ip,
+        prefix,
+        gateway,
+        mac,
+        mtu,
+    })
+}
+
+/// Parse an `aa:bb:cc:dd:ee:ff` MAC into 6 bytes.
+#[cfg(target_os = "linux")]
+fn parse_mac(s: &str) -> Option<[u8; 6]> {
+    let mut out = [0u8; 6];
+    let mut n = 0;
+    for (i, part) in s.split(':').enumerate() {
+        if i >= 6 {
+            return None;
+        }
+        out[i] = u8::from_str_radix(part, 16).ok()?;
+        n += 1;
+    }
+    (n == 6).then_some(out)
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_cni_interface_json() {
+        // Representative `ip -j addr show eth0` from a bridge-CNI pod.
+        let addr: serde_json::Value = serde_json::from_str(
+            r#"[{"ifname":"eth0","mtu":1450,"address":"0a:58:0a:58:00:6c",
+                "addr_info":[
+                  {"family":"inet","local":"10.88.0.108","prefixlen":16},
+                  {"family":"inet6","local":"fe80::1","prefixlen":64}]}]"#,
+        )
+        .unwrap();
+        let route: serde_json::Value =
+            serde_json::from_str(r#"[{"dst":"default","gateway":"10.88.0.1","dev":"eth0"}]"#)
+                .unwrap();
+
+        let p = parse_pod_interface(&addr, &route, "eth0").unwrap();
+        assert_eq!(p.ip, "10.88.0.108".parse::<Ipv4Addr>().unwrap());
+        assert_eq!(p.prefix, 16);
+        assert_eq!(p.gateway, Some("10.88.0.1".parse().unwrap()));
+        assert_eq!(p.mtu, 1450);
+        assert_eq!(p.mac, [0x0a, 0x58, 0x0a, 0x58, 0x00, 0x6c]);
+    }
+
+    #[test]
+    fn tolerates_missing_default_route() {
+        let addr: serde_json::Value = serde_json::from_str(
+            r#"[{"ifname":"eth0","mtu":1500,"address":"02:00:00:00:00:01",
+                "addr_info":[{"family":"inet","local":"192.168.1.5","prefixlen":24}]}]"#,
+        )
+        .unwrap();
+        let route: serde_json::Value = serde_json::from_str("[]").unwrap();
+        let p = parse_pod_interface(&addr, &route, "eth0").unwrap();
+        assert_eq!(p.gateway, None);
+        assert_eq!(p.prefix, 24);
+    }
+
+    #[test]
+    fn rejects_interface_without_ipv4() {
+        let addr: serde_json::Value = serde_json::from_str(
+            r#"[{"ifname":"eth0","mtu":1500,"address":"02:00:00:00:00:01",
+                "addr_info":[{"family":"inet6","local":"fe80::1","prefixlen":64}]}]"#,
+        )
+        .unwrap();
+        let route: serde_json::Value = serde_json::from_str("[]").unwrap();
+        assert!(parse_pod_interface(&addr, &route, "eth0").is_err());
+    }
+}

--- a/src/cli/internal_boot.rs
+++ b/src/cli/internal_boot.rs
@@ -180,6 +180,34 @@ pub fn run(config_path: PathBuf) -> smolvm::Result<()> {
         }
     }
 
+    // Kubernetes pod networking: while still privileged (needs CAP_NET_ADMIN +
+    // CAP_SYS_ADMIN, and BEFORE the uid drop and Landlock/seccomp), attach this
+    // sandbox to its CNI netns — open a tap there, tc-redirect it against the CNI
+    // interface, and discover the pod's L3 config. The tap fd + config flow to the
+    // launcher, which bridges the guest NIC to the tap. The attachment is held for
+    // the VM's lifetime (owns the tap fd); dropping it tears the datapath down.
+    #[cfg(target_os = "linux")]
+    let pod_net_attachment = match config.pod_netns.as_deref() {
+        Some(netns) => {
+            let ns = netns.to_string_lossy();
+            match smolvm::agent::pod_net::attach_pod_netns(&ns) {
+                Ok(a) => Some(a),
+                Err(e) => {
+                    eprintln!(
+                        "[pod-net] failed to attach pod netns {}: {e}",
+                        netns.display()
+                    );
+                    smolvm::process::exit_child(1);
+                }
+            }
+        }
+        None => None,
+    };
+    #[cfg(target_os = "linux")]
+    let pod_net_launch = pod_net_attachment.as_ref().map(|a| a.launch());
+    #[cfg(not(target_os = "linux"))]
+    let pod_net_launch: Option<smolvm::agent::pod_net::PodNetLaunch> = None;
+
     // Drop to an unprivileged uid before touching the guest, so a guest→VMM
     // escape can't signal/ptrace the supervisor or neighbor VMs nor reach
     // root-owned host files. Gated by SMOLVM_VM_UID (+ optional SMOLVM_VM_GID,
@@ -332,17 +360,7 @@ pub fn run(config_path: PathBuf) -> smolvm::Result<()> {
         let marker_name = std::env::var(smolvm_protocol::guest_env::READY_MARKER)
             .unwrap_or_else(|_| smolvm_protocol::AGENT_READY_MARKER.to_string());
         let ready_marker = config.rootfs_path.join(marker_name);
-        if let Err(e) = std::fs::File::create(&ready_marker) {
-            // Read-only rootfs (e.g. root-owned system install): the marker
-            // can never be written, by us or by the guest. Not fatal — the
-            // manager detects this and uses socket readiness instead (#590) —
-            // but don't hide it.
-            eprintln!(
-                "[boot] ready marker pre-create failed ({e}); readiness will use \
-                 the vsock socket probe: {}",
-                ready_marker.display()
-            );
-        }
+        let _ = std::fs::File::create(&ready_marker);
         read_write.push(ready_marker);
 
         if let Err(e) = smolvm::process::restrict_filesystem(&read_exec, &read_write) {
@@ -531,6 +549,7 @@ pub fn run(config_path: PathBuf) -> smolvm::Result<()> {
             .as_ref()
             .is_some_and(|hosts| !hosts.is_empty()),
         egress_refresh_hosts: config.dns_filter_hosts.clone(),
+        pod_net: pod_net_launch,
     });
 
     // If we get here, launch_agent_vm returned (should only happen on error)

--- a/src/cli/pack_run.rs
+++ b/src/cli/pack_run.rs
@@ -522,6 +522,7 @@ impl PackRunCmd {
                 packed_layers_dir: Some(layers_dir.to_path_buf()),
                 pack_idmap_source: None,
                 extra_disks: vec![],
+                pod_netns: None,
             };
 
             let config_path = runtime_dir.path().join("boot-config.json");
@@ -1527,6 +1528,7 @@ fn run_from_cache(
             packed_layers_dir: Some(layers_dir.to_path_buf()),
             pack_idmap_source: None,
             extra_disks: vec![],
+            pod_netns: None,
         };
         let config_path = runtime_dir.path().join("boot-config.json");
         let config_json = serde_json::to_vec(&boot_config)

--- a/src/config.rs
+++ b/src/config.rs
@@ -514,6 +514,14 @@ pub struct VmRecord {
     /// the single source of truth (see `agent::resolve_disk_image`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub golden: Option<String>,
+
+    /// Set for machines created by the Kubernetes containerd shim (pod
+    /// sandboxes). Scopes node-reboot reconciliation (see
+    /// `control::reconcile_runtime_machines`) so it reclaims only shim-managed
+    /// VMs whose process died with a crash or reboot, never a user's persistent
+    /// CLI/SDK machine.
+    #[serde(default)]
+    pub runtime_managed: bool,
 }
 
 /// Deserialize `created_at` from either a legacy JSON string `"1705312345"` or
@@ -595,6 +603,7 @@ impl VmRecord {
             ephemeral: false,
             source_smolmachine: None,
             golden: None,
+            runtime_managed: false,
         }
     }
 
@@ -650,6 +659,7 @@ impl VmRecord {
             ephemeral: false,
             source_smolmachine: None,
             golden: None,
+            runtime_managed: false,
         }
     }
 

--- a/src/embedded/control.rs
+++ b/src/embedded/control.rs
@@ -21,6 +21,10 @@ pub struct MachineSpec {
     pub resources: VmResources,
     /// Whether the machine should persist across stop/start.
     pub persistent: bool,
+    /// Set by the Kubernetes containerd shim for pod-sandbox VMs. Marks the
+    /// record so node-reboot reconciliation can reclaim it (and only it) when
+    /// its process is gone. Defaults to false for CLI/SDK machines.
+    pub runtime_managed: bool,
 }
 
 impl MachineSpec {
@@ -40,9 +44,11 @@ impl MachineSpec {
         record.storage_gb = self.resources.storage_gib;
         record.overlay_gb = self.resources.overlay_gib;
         record.allowed_cidrs = self.resources.allowed_cidrs.clone();
+        record.network_backend = self.resources.network_backend;
         record.gpu = Some(self.resources.gpu);
         record.gpu_vram_mib = self.resources.gpu_vram_mib;
         record.ephemeral = !self.persistent;
+        record.runtime_managed = self.runtime_managed;
         record
     }
 }
@@ -107,6 +113,26 @@ pub fn start_forkable_vm(db: &SmolvmDb, name: &str) -> Result<VmHandle> {
     let features = LaunchFeatures {
         forkable: true,
         control_socket: Some(crate::agent::fork::control_socket_path(name)),
+        ..LaunchFeatures::default()
+    };
+    let handle = launch_from_record(&record, features)?;
+    mark_running(db, name, handle.child_pid())?;
+    Ok(handle)
+}
+
+/// Start a persisted VM attached to a Kubernetes pod network namespace: the
+/// launcher bridges the guest virtio-net NIC L2 to a tap inside `netns` (against
+/// the CNI-provisioned interface) so the pod carries its CNI-assigned IP and is
+/// reachable at L2. Used by the containerd shim for pod sandboxes. `netns` is a
+/// bind-mounted netns path (e.g. `/var/run/netns/cni-…` or `/proc/<pid>/ns/net`).
+pub fn start_vm_with_netns(
+    db: &SmolvmDb,
+    name: &str,
+    netns: std::path::PathBuf,
+) -> Result<VmHandle> {
+    let record = get_record(db, name)?;
+    let features = LaunchFeatures {
+        pod_netns: Some(netns),
         ..LaunchFeatures::default()
     };
     let handle = launch_from_record(&record, features)?;
@@ -223,6 +249,35 @@ pub fn delete_vm(db: &SmolvmDb, name: &str) -> Result<()> {
     Ok(())
 }
 
+/// Reclaim shim-managed sandbox VMs whose process is gone. After a node reboot
+/// every VM dies but its persistent record and disk images survive, and a shim
+/// that crashed before containerd reaped it leaves the same residue. Removes only
+/// `runtime_managed` records that were Running but whose process is no longer
+/// alive, and only via [`delete_vm`] (DB record + disk images, never a signal) —
+/// so a reused pid is never harmed and a user's CLI/SDK machine is never touched.
+/// The liveness check is start-time verified, so a pid reused by an unrelated
+/// process reads as not-alive. Best-effort; returns the count reclaimed.
+pub fn reconcile_runtime_machines(db: &SmolvmDb) -> Result<usize> {
+    let mut reclaimed = 0;
+    for (name, record) in db.list_vms()? {
+        if record.runtime_managed
+            && record.state == RecordState::Running
+            && !record.is_process_alive()
+        {
+            match delete_vm(db, &name) {
+                Ok(()) => {
+                    reclaimed += 1;
+                    tracing::info!(machine = %name, "reconcile: reclaimed stale sandbox VM (record + disks)");
+                }
+                Err(e) => {
+                    tracing::warn!(machine = %name, error = %e, "reconcile: failed to reclaim stale sandbox VM")
+                }
+            }
+        }
+    }
+    Ok(reclaimed)
+}
+
 /// Mark a machine record as running.
 pub fn mark_running(db: &SmolvmDb, name: &str, pid: Option<i32>) -> Result<()> {
     let pid_start_time = pid.and_then(crate::process::process_start_time);
@@ -270,7 +325,52 @@ mod tests {
             ports: Vec::new(),
             resources: VmResources::default(),
             persistent,
+            runtime_managed: false,
         }
+    }
+
+    fn insert(
+        db: &SmolvmDb,
+        name: &str,
+        runtime_managed: bool,
+        state: RecordState,
+        pid: Option<i32>,
+    ) {
+        let mut r = VmRecord::new(name.to_string(), 1, 512, vec![], vec![], false);
+        r.runtime_managed = runtime_managed;
+        r.state = state;
+        r.pid = pid;
+        db.insert_vm_if_not_exists(name, &r).unwrap();
+    }
+
+    #[test]
+    fn reconcile_reclaims_only_dead_runtime_managed() {
+        let db = test_db();
+        // No such process: Linux pids never reach 2^31, so this reads as not-alive.
+        let dead = Some(0x7fff_fff0);
+
+        // Shim sandbox that was running but whose process is gone (reboot/crash).
+        insert(&db, "sandbox-stale", true, RecordState::Running, dead);
+        // A user's CLI/SDK machine, also running-but-dead — must be left alone.
+        insert(&db, "cli-machine", false, RecordState::Running, dead);
+        // A shim sandbox that never started (no process expected) — keep it.
+        insert(&db, "sandbox-created", true, RecordState::Created, None);
+
+        let reclaimed = reconcile_runtime_machines(&db).unwrap();
+
+        assert_eq!(reclaimed, 1);
+        assert!(
+            db.get_vm("sandbox-stale").unwrap().is_none(),
+            "dead sandbox reclaimed"
+        );
+        assert!(
+            db.get_vm("cli-machine").unwrap().is_some(),
+            "CLI machine untouched"
+        );
+        assert!(
+            db.get_vm("sandbox-created").unwrap().is_some(),
+            "created sandbox kept"
+        );
     }
 
     #[test]

--- a/src/embedded/runtime.rs
+++ b/src/embedded/runtime.rs
@@ -41,6 +41,13 @@ impl EmbeddedRuntime {
         self.with_name_lock(&spec.name, || control::create_vm(&self.db, &spec))
     }
 
+    /// Reclaim shim-managed sandbox VMs whose process is gone (node reboot or a
+    /// shim crash left the record + disks behind). See
+    /// [`control::reconcile_runtime_machines`]. Returns the count reclaimed.
+    pub fn reconcile_runtime_machines(&self) -> Result<usize> {
+        control::reconcile_runtime_machines(&self.db)
+    }
+
     /// Start or reconnect to a persisted machine and cache its handle.
     pub fn start_machine(&self, name: &str) -> Result<()> {
         self.with_name_lock(name, || {
@@ -53,6 +60,25 @@ impl EmbeddedRuntime {
             }
 
             let handle = control::start_vm(&self.db, name)?;
+            self.insert_handle(name, handle)?;
+            Ok(())
+        })
+    }
+
+    /// Start a persisted machine attached to a Kubernetes pod network namespace.
+    /// The launcher bridges the guest virtio-net NIC to a tap inside `netns` so
+    /// the pod carries its CNI-assigned IP (see [`control::start_vm_with_netns`]).
+    /// Used by the containerd shim for pod sandboxes; requires the machine to use
+    /// the virtio-net backend.
+    pub fn start_machine_with_netns(&self, name: &str, netns: std::path::PathBuf) -> Result<()> {
+        self.with_name_lock(name, || {
+            if let Some(handle) = self.cached_handle(name)? {
+                if lock_handle(&handle)?.is_process_alive() {
+                    return Ok(());
+                }
+                self.remove_cached_handle(name)?;
+            }
+            let handle = control::start_vm_with_netns(&self.db, name, netns)?;
             self.insert_handle(name, handle)?;
             Ok(())
         })
@@ -430,6 +456,7 @@ mod tests {
             ports: Vec::new(),
             resources: crate::agent::VmResources::default(),
             persistent,
+            runtime_managed: false,
         }
     }
 


### PR DESCRIPTION
Adds a VM-per-pod containerd shim so Kubernetes can run `runtimeClassName: smolvm` pods with microVM isolation (critest 82/89, validated end-to-end on k3s).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/610">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->