### PR TITLE
fix(ci): serve the pacman repo from GitHub Pages and auto-publish it on release

### DIFF
--- a/.github/workflows/pacman-repo.yml
+++ b/.github/workflows/pacman-repo.yml
@@ -3,6 +3,15 @@ name: Publish pacman repo
 # Builds Arch packages from the release binaries and publishes them to
 # rolling releases (pacman-repo-x86_64 / pacman-repo-aarch64) that serve
 # as pacman repository endpoints. See docs/install/arch.md.
+#
+# Triggers:
+#  - workflow_call: invoked by release.yml right after it creates the GitHub
+#    Release. This is the real automation path — the `release: published` event
+#    does NOT fire here on its own, because that release is created with the
+#    default GITHUB_TOKEN and GitHub does not start workflows from token-created
+#    releases (same reason release.yml pings the Homebrew tap explicitly).
+#  - workflow_dispatch: manual re-run / backfill for a given tag.
+#  - release: kept as a safety net for releases published by a human/PAT.
 on:
   release:
     types: [published]
@@ -11,6 +20,12 @@ on:
       tag:
         description: 'Release tag to package (e.g. v1.5.0)'
         required: true
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Release tag to package (e.g. v1.5.0)'
+        required: true
+        type: string
 
 permissions:
   contents: write

--- a/.github/workflows/pacman-repo.yml
+++ b/.github/workflows/pacman-repo.yml
@@ -1,8 +1,9 @@
 name: Publish pacman repo
 
-# Builds Arch packages from the release binaries and publishes them to
-# rolling releases (pacman-repo-x86_64 / pacman-repo-aarch64) that serve
-# as pacman repository endpoints. See docs/install/arch.md.
+# Builds Arch packages from the release binaries and publishes them to the
+# GitHub Pages `pacman-repo` branch, served at
+# https://smol-machines.github.io/smolvm/pacman/$arch — a single stable
+# repository endpoint (no per-arch release entries). See docs/install-arch.md.
 #
 # Triggers:
 #  - workflow_call: invoked by release.yml right after it creates the GitHub
@@ -46,7 +47,7 @@ jobs:
           echo "pkgver=${TAG#v}" >> "$GITHUB_OUTPUT"
 
       - name: Install tooling
-        run: pacman -Syu --noconfirm pacman-contrib github-cli git
+        run: pacman -Syu --noconfirm pacman-contrib git
 
       - uses: actions/checkout@v4
 
@@ -66,29 +67,35 @@ jobs:
           sudo -u builder env CARCH=aarch64 makepkg -df --noconfirm --ignorearch
           ls -l *.pkg.tar.zst
 
-      - name: Publish to rolling pacman repo releases
+      - name: Publish to the GitHub Pages pacman repo (branch pacman-repo)
         run: |
-          git config --global --add safe.directory "$PWD"
           cd /home/builder/build
+          git config --global user.name  'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git config --global --add safe.directory '*'
+          # Pages serves the pacman-repo branch at https://<owner>.github.io/<repo>/
+          # (Deploy from a branch); the pacman endpoint is pacman/$arch/. Pushing
+          # to the branch triggers the Pages build.
+          auth="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git clone --depth 1 --branch pacman-repo "$auth" pages
           for arch in x86_64 aarch64; do
-            roll="pacman-repo-$arch"
-            mkdir -p "repo-$arch" && cd "repo-$arch"
-            cp ../smolvm-*-"$arch".pkg.tar.zst .
-            # fetch existing db (first run: absent)
-            gh release download "$roll" -R "$GITHUB_REPOSITORY" \
-              -p 'smol-machines.db.tar.gz' -p 'smol-machines.files.tar.gz' 2>/dev/null || true
-            repo-add smol-machines.db.tar.gz smolvm-*-"$arch".pkg.tar.zst
-            # rolling release exists? create once
-            gh release view "$roll" -R "$GITHUB_REPOSITORY" >/dev/null 2>&1 || \
-              gh release create "$roll" -R "$GITHUB_REPOSITORY" --prerelease \
-                --title "pacman repo ($arch)" \
-                --notes "Rolling pacman repository endpoint for $arch. Do not delete. See docs/install/arch.md."
-            # upload package + db (db symlink targets must be uploaded as real files)
-            cp --remove-destination "$(readlink -f smol-machines.db)" smol-machines.db
-            cp --remove-destination "$(readlink -f smol-machines.files)" smol-machines.files
-            gh release upload "$roll" -R "$GITHUB_REPOSITORY" --clobber \
-              smolvm-*-"$arch".pkg.tar.zst \
-              smol-machines.db.tar.gz smol-machines.files.tar.gz \
-              smol-machines.db smol-machines.files
-            cd ..
+            dir="pages/pacman/$arch"
+            mkdir -p "$dir"
+            # Rolling repo: keep only the current version's package so the branch
+            # stays small. repo-add then builds a fresh single-entry db.
+            rm -f "$dir"/smolvm-*.pkg.tar.zst "$dir"/smol-machines.db* "$dir"/smol-machines.files*
+            cp smolvm-*-"$arch".pkg.tar.zst "$dir/"
+            (
+              cd "$dir"
+              repo-add smol-machines.db.tar.gz smolvm-*-"$arch".pkg.tar.zst
+              # GitHub Pages does not serve broken symlinks — materialize the
+              # convenience `.db`/`.files` names as real copies of their targets.
+              cp --remove-destination "$(readlink -f smol-machines.db)" smol-machines.db
+              cp --remove-destination "$(readlink -f smol-machines.files)" smol-machines.files
+            )
           done
+          cd pages
+          git add -A
+          git commit -m "pacman: publish ${{ steps.tag.outputs.tag }}" \
+            || { echo "no package changes to publish"; exit 0; }
+          git push origin pacman-repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -444,3 +444,17 @@ jobs:
             -f event_type=smolvm-release \
             -f "client_payload[version]=$version"
           echo "Dispatched smolvm-release ($version) to the Homebrew tap."
+
+  # Build + publish the Arch/pacman packages for this release. Invoked directly
+  # (not via the `release: published` event) because that event never fires for a
+  # release created with the default GITHUB_TOKEN — the same GitHub restriction
+  # the Homebrew step above works around. Runs after the release exists so the
+  # PKGBUILD can download its release binaries.
+  publish-pacman:
+    name: Publish pacman repo
+    needs: release
+    permissions:
+      contents: write
+    uses: ./.github/workflows/pacman-repo.yml
+    with:
+      tag: ${{ github.ref_name }}

--- a/docs/install-arch.md
+++ b/docs/install-arch.md
@@ -17,7 +17,7 @@ Add the repository to `/etc/pacman.conf`:
 ```ini
 [smol-machines]
 SigLevel = Optional TrustAll
-Server = https://github.com/smol-machines/smolvm/releases/download/pacman-repo-$arch
+Server = https://smol-machines.github.io/smolvm/pacman/$arch
 ```
 
 Then install:
@@ -30,9 +30,10 @@ Upgrades arrive with your normal `pacman -Syu`.
 
 ## Notes
 
-- The repository is served from rolling GitHub releases
-  (`pacman-repo-x86_64`, `pacman-repo-aarch64`); packages are built by CI
-  from the signed release artifacts (`.github/workflows/pacman-repo.yml`).
+- The repository is served from GitHub Pages (the `pacman-repo` branch);
+  packages are built by CI from the release artifacts and published on every
+  release (`.github/workflows/pacman-repo.yml`). It is a rolling repo — the
+  latest release only (older versions remain on the GitHub Releases page).
 - Package signing (GPG) is planned; until then integrity is provided by
   sha256-pinned sources built in CI and served over HTTPS.
 - The package bundles the smol-machines `libkrun`/`libkrunfw` fork under


### PR DESCRIPTION
Move the Arch/pacman repo to a single stable GitHub Pages endpoint (https://smol-machines.github.io/smolvm/pacman/$arch, served from the pacman-repo branch) instead of two per-arch releases, and invoke it from release.yml so packages actually publish on release — the release:published event never fired because the release is created with the default GITHUB_TOKEN. Validated: both arches serve a valid db + package for v1.5.2.