### PR TITLE
Publish official .deb and .rpm repos alongside the pacman repo

### DIFF
--- a/.github/workflows/deb-rpm-repo.yml
+++ b/.github/workflows/deb-rpm-repo.yml
@@ -1,0 +1,107 @@
+name: Publish deb/rpm repos
+
+# Builds the smolvm .deb + .rpm packages from the release tarballs (nfpm) and
+# publishes flat apt + dnf repositories to the GitHub Pages `pacman-repo` branch,
+# served at https://smol-machines.github.io/smolvm/{apt,yum} — alongside the
+# pacman repo. See docs/install-debian.md and docs/install-fedora.md.
+#
+# Invoked by release.yml (workflow_call) after the pacman repo is published, so
+# the sequential pushes to the Pages branch never race. workflow_dispatch is for
+# manual re-runs / backfill. Unsigned to match the pacman repo (HTTPS + CI-built).
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to package (e.g. v1.5.0)'
+        required: true
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Release tag to package (e.g. v1.5.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Resolve tag
+        id: tag
+        run: |
+          TAG='${{ github.event.release.tag_name || inputs.tag }}'
+          echo "tag=$TAG"        >> "$GITHUB_OUTPUT"
+          echo "ver=${TAG#v}"    >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+
+      - name: Install tooling (nfpm, dpkg-dev, createrepo_c)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends dpkg-dev createrepo-c jq curl ca-certificates
+          url=$(curl -fsSL https://api.github.com/repos/goreleaser/nfpm/releases/latest \
+                | jq -r '.assets[] | select(.name|test("_amd64\\.deb$")) | .browser_download_url')
+          curl -fsSL "$url" -o /tmp/nfpm.deb
+          sudo dpkg -i /tmp/nfpm.deb
+          nfpm --version
+
+      - name: Build .deb + .rpm (x86_64 + arm64)
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          VER: ${{ steps.tag.outputs.ver }}
+        run: |
+          set -euo pipefail
+          mkdir -p out
+          curl -fsSL "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/refs/tags/${TAG}/LICENSE" -o LICENSE.txt
+          build() {  # $1 = release-tarball arch label, $2 = nfpm arch
+            local rel="$1" nar="$2"
+            curl -fsSL "https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/smolvm-${VER}-linux-${rel}.tar.gz" -o tarball.tgz
+            rm -rf pkgroot && mkdir pkgroot
+            tar -xzf tarball.tgz --strip-components=1 -C pkgroot
+            cp LICENSE.txt pkgroot/LICENSE
+            # Retarget the wrapper at the packaged locations (same as the PKGBUILD).
+            sed -i \
+              -e 's|^SMOLVM_BIN=.*|SMOLVM_BIN=/usr/lib/smolvm/smolvm-bin|' \
+              -e 's|^SMOLVM_LIB=.*|SMOLVM_LIB=/usr/lib/smolvm/lib|' \
+              -e 's|^SMOLVM_BUNDLED_ROOTFS=.*|SMOLVM_BUNDLED_ROOTFS=/usr/lib/smolvm/agent-rootfs|' \
+              pkgroot/smolvm
+            export NFPM_ARCH="$nar" NFPM_VERSION="$VER"
+            nfpm package -f packaging/nfpm.yaml -p deb -t out/
+            nfpm package -f packaging/nfpm.yaml -p rpm -t out/
+          }
+          build x86_64 amd64
+          build arm64  arm64
+          ls -l out/
+
+      - name: Assemble + publish apt/ and yum/ on the Pages branch
+        run: |
+          set -euo pipefail
+          git config --global user.name  'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git config --global --add safe.directory '*'
+          auth="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git clone --depth 1 --branch pacman-repo "$auth" pages
+
+          # apt: flat repo (installed with [trusted=yes]). Both arches in one
+          # Packages index; apt selects the matching architecture. Rolling repo
+          # (latest only): drop the previous packages/index but keep index.html.
+          mkdir -p pages/apt
+          rm -f pages/apt/*.deb pages/apt/Packages pages/apt/Packages.gz
+          cp out/*.deb pages/apt/
+          ( cd pages/apt && dpkg-scanpackages --multiversion . > Packages && gzip -9 -kf Packages )
+
+          # yum/dnf: createrepo over both arches in one dir; dnf filters by arch.
+          mkdir -p pages/yum
+          rm -f pages/yum/*.rpm && rm -rf pages/yum/repodata
+          cp out/*.rpm pages/yum/
+          createrepo_c pages/yum
+
+          cd pages
+          git add -A
+          git commit -m "deb/rpm: publish ${{ steps.tag.outputs.tag }}" \
+            || { echo "no package changes to publish"; exit 0; }
+          git push origin pacman-repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -458,3 +458,16 @@ jobs:
     uses: ./.github/workflows/pacman-repo.yml
     with:
       tag: ${{ github.ref_name }}
+
+  # Build + publish the .deb / .rpm repos. Same reasoning as publish-pacman
+  # (the `release: published` event never fires for a GITHUB_TOKEN release).
+  # Runs after publish-pacman so the sequential pushes to the shared Pages
+  # branch (pacman-repo) never race.
+  publish-deb-rpm:
+    name: Publish deb/rpm repos
+    needs: publish-pacman
+    permissions:
+      contents: write
+    uses: ./.github/workflows/deb-rpm-repo.yml
+    with:
+      tag: ${{ github.ref_name }}

--- a/docs/install-debian.md
+++ b/docs/install-debian.md
@@ -1,0 +1,32 @@
+# Installing smolvm on Debian / Ubuntu
+
+smolvm ships an **official apt repository** maintained by the smol-machines
+team. It serves prebuilt `.deb` packages for `amd64` and `arm64`, updated
+automatically with every release.
+
+## Setup
+
+```sh
+echo 'deb [trusted=yes] https://smol-machines.github.io/smolvm/apt ./' \
+  | sudo tee /etc/apt/sources.list.d/smolvm.list
+sudo apt-get update
+sudo apt-get install smolvm
+```
+
+Upgrades arrive with your normal `apt-get update && apt-get upgrade`.
+
+## Notes
+
+- It is a **flat, unsigned repository** (installed with `[trusted=yes]`), which
+  matches the pacman repo's posture — integrity comes from packages built by CI
+  from the release artifacts and served over HTTPS. Package signing (GPG) is
+  planned; until then keep the `[trusted=yes]` flag.
+- Served from GitHub Pages (the `pacman-repo` branch); packages are built by CI
+  and published on every release (`.github/workflows/deb-rpm-repo.yml`). It is a
+  rolling repo — the latest release only (older versions remain on the GitHub
+  Releases page).
+- The package installs the wrapper at `/usr/bin/smolvm` and bundles the
+  smol-machines `libkrun`/`libkrunfw` fork under `/usr/lib/smolvm` — it does not
+  conflict with any system `libkrun`.
+- Requires `crun` and `jq` (pulled in automatically). `crun` is available in
+  Debian 12+ and Ubuntu 22.04+.

--- a/docs/install-fedora.md
+++ b/docs/install-fedora.md
@@ -1,0 +1,35 @@
+# Installing smolvm on Fedora / RHEL
+
+smolvm ships an **official dnf/yum repository** maintained by the smol-machines
+team. It serves prebuilt `.rpm` packages for `x86_64` and `aarch64`, updated
+automatically with every release.
+
+## Setup
+
+```sh
+sudo tee /etc/yum.repos.d/smolvm.repo >/dev/null <<'EOF'
+[smolvm]
+name=smolvm
+baseurl=https://smol-machines.github.io/smolvm/yum
+enabled=1
+gpgcheck=0
+EOF
+sudo dnf install smolvm
+```
+
+Upgrades arrive with your normal `dnf upgrade`.
+
+## Notes
+
+- The repository is **unsigned** (`gpgcheck=0`), which matches the pacman repo's
+  posture — integrity comes from packages built by CI from the release artifacts
+  and served over HTTPS. Package signing (GPG) is planned; until then keep
+  `gpgcheck=0`.
+- Served from GitHub Pages (the `pacman-repo` branch); packages are built by CI
+  and published on every release (`.github/workflows/deb-rpm-repo.yml`). It is a
+  rolling repo — the latest release only (older versions remain on the GitHub
+  Releases page).
+- The package installs the wrapper at `/usr/bin/smolvm` and bundles the
+  smol-machines `libkrun`/`libkrunfw` fork under `/usr/lib/smolvm` — it does not
+  conflict with any system `libkrun`.
+- Requires `crun` and `jq` (pulled in automatically).

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -1,0 +1,58 @@
+# nfpm config for the official smolvm .deb / .rpm packages.
+# https://nfpm.goreleaser.com — one config produces both formats.
+#
+# Repackages the upstream release tarball (which bundles the smol-machines
+# libkrun fork) into the same layout as packaging/arch/PKGBUILD:
+#   /usr/bin/smolvm                          (wrapper, retargeted by CI)
+#   /usr/lib/smolvm/{smolvm-bin,lib,agent-rootfs}
+#
+# Unlike the PKGBUILD, we deliberately do NOT ship storage-template.ext4 /
+# overlay-template.ext4: those are 20G/10G *sparse* files that neither the deb
+# nor the rpm archiver preserves as sparse — the rpm packager OOMs reading the
+# full logical size, and a .deb/.rpm would expand them to 30G of real zeros on
+# the user's disk at install time. They are only a first-pack optimization; when
+# absent, smolvm formats storage with mkfs.ext4 (hence the e2fsprogs dep).
+#
+# CI extracts the tarball to ./pkgroot, seds the wrapper, and sets
+# NFPM_ARCH (amd64|arm64) + NFPM_VERSION before invoking nfpm.
+name: smolvm
+arch: ${NFPM_ARCH}
+version: ${NFPM_VERSION}
+release: "1"
+section: utils
+priority: optional
+maintainer: smol-machines <hebinsquared@gmail.com>
+description: |
+  Build & run portable, lightweight, self-contained virtual machines.
+  Official smol-machines build — bundles the smol-machines libkrun fork.
+vendor: smol-machines
+homepage: https://github.com/smol-machines/smolvm
+license: Apache-2.0
+
+# crun (OCI runtime), jq and e2fsprogs (mkfs.ext4, used to format storage on the
+# first pack since we don't ship the prebuilt template) are the runtime deps most
+# likely to be missing; the rest (util-linux, gzip, tar, libcap) are base.
+depends:
+  - crun
+  - jq
+  - e2fsprogs
+
+contents:
+  - src: ./pkgroot/smolvm
+    dst: /usr/bin/smolvm
+    file_info: { mode: 0755 }
+  - src: ./pkgroot/smolvm-bin
+    dst: /usr/lib/smolvm/smolvm-bin
+    file_info: { mode: 0755 }
+  - src: ./pkgroot/lib
+    dst: /usr/lib/smolvm/lib
+    type: tree
+  - src: ./pkgroot/agent-rootfs
+    dst: /usr/lib/smolvm/agent-rootfs
+    type: tree
+  - src: ./pkgroot/LICENSE
+    dst: /usr/share/doc/smolvm/LICENSE
+    file_info: { mode: 0644 }
+  - src: ./pkgroot/README.txt
+    dst: /usr/share/doc/smolvm/README.txt
+    file_info: { mode: 0644 }


### PR DESCRIPTION
Adds nfpm-built .deb/.rpm packages and flat apt + dnf repositories served from the same GitHub Pages site as the pacman repo, wired into the release workflow after the pacman publish so the two never race.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/612">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->