### PR TITLE
Clean up deb/rpm packaging lintian and rpmlint findings

### DIFF
--- a/.github/workflows/deb-rpm-repo.yml
+++ b/.github/workflows/deb-rpm-repo.yml
@@ -56,19 +56,23 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p out
-          curl -fsSL "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/refs/tags/${TAG}/LICENSE" -o LICENSE.txt
           build() {  # $1 = release-tarball arch label, $2 = nfpm arch
             local rel="$1" nar="$2"
             curl -fsSL "https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/smolvm-${VER}-linux-${rel}.tar.gz" -o tarball.tgz
             rm -rf pkgroot && mkdir pkgroot
             tar -xzf tarball.tgz --strip-components=1 -C pkgroot
             cp LICENSE.txt pkgroot/LICENSE
+            cp packaging/deb/copyright pkgroot/copyright
             # Retarget the wrapper at the packaged locations (same as the PKGBUILD).
             sed -i \
               -e 's|^SMOLVM_BIN=.*|SMOLVM_BIN=/usr/lib/smolvm/smolvm-bin|' \
               -e 's|^SMOLVM_LIB=.*|SMOLVM_LIB=/usr/lib/smolvm/lib|' \
               -e 's|^SMOLVM_BUNDLED_ROOTFS=.*|SMOLVM_BUNDLED_ROOTFS=/usr/lib/smolvm/agent-rootfs|' \
               pkgroot/smolvm
+            # Shared libraries don't need the execute bit; 0644 keeps lintian/rpmlint
+            # happy (shared-library-is-executable). Only touch the bundled libs, not
+            # the guest rootfs payload.
+            find pkgroot/lib -type f -name '*.so*' -exec chmod 0644 {} +
             export NFPM_ARCH="$nar" NFPM_VERSION="$VER"
             nfpm package -f packaging/nfpm.yaml -p deb -t out/
             nfpm package -f packaging/nfpm.yaml -p rpm -t out/

--- a/packaging/deb/copyright
+++ b/packaging/deb/copyright
@@ -1,0 +1,12 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: smolvm
+Upstream-Contact: smol-machines <hebinsquared@gmail.com>
+Source: https://github.com/smol-machines/smolvm
+
+Files: *
+Copyright: 2023-2026 smol-machines
+License: Apache-2.0
+
+License: Apache-2.0
+ On Debian systems, the complete text of the Apache License version 2.0
+ can be found in "/usr/share/common-licenses/Apache-2.0".

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -22,20 +22,40 @@ release: "1"
 section: utils
 priority: optional
 maintainer: smol-machines <hebinsquared@gmail.com>
+# First line is the deb synopsis / rpm Summary (no trailing period); the rest is
+# the extended description.
 description: |
-  Build & run portable, lightweight, self-contained virtual machines.
-  Official smol-machines build — bundles the smol-machines libkrun fork.
+  Build and run portable, lightweight, self-contained virtual machines
+  smolvm runs each workload in its own microVM on libkrun, with sub-second boot
+  and OCI-native images. This is the official smol-machines build and bundles
+  the smol-machines libkrun fork.
 vendor: smol-machines
 homepage: https://github.com/smol-machines/smolvm
 license: Apache-2.0
 
 # crun (OCI runtime), jq and e2fsprogs (mkfs.ext4, used to format storage on the
 # first pack since we don't ship the prebuilt template) are the runtime deps most
-# likely to be missing; the rest (util-linux, gzip, tar, libcap) are base.
+# likely to be missing; the rest (util-linux, gzip, tar, libcap) are base. The
+# per-format overrides add the C library (deb: libc6, rpm: glibc) — nfpm does not
+# run the distro's automatic ELF dependency generator, so we declare it.
 depends:
   - crun
   - jq
   - e2fsprogs
+
+overrides:
+  deb:
+    depends:
+      - crun
+      - jq
+      - e2fsprogs
+      - libc6
+  rpm:
+    depends:
+      - crun
+      - jq
+      - e2fsprogs
+      - glibc
 
 contents:
   - src: ./pkgroot/smolvm
@@ -50,8 +70,11 @@ contents:
   - src: ./pkgroot/agent-rootfs
     dst: /usr/lib/smolvm/agent-rootfs
     type: tree
-  - src: ./pkgroot/LICENSE
-    dst: /usr/share/doc/smolvm/LICENSE
+  # DEP-5 machine-readable copyright at the Debian path (satisfies lintian's
+  # no-copyright-file; references common-licenses for Apache-2.0 rather than
+  # embedding the text). Generated into pkgroot by the CI workflow.
+  - src: ./pkgroot/copyright
+    dst: /usr/share/doc/smolvm/copyright
     file_info: { mode: 0644 }
   - src: ./pkgroot/README.txt
     dst: /usr/share/doc/smolvm/README.txt


### PR DESCRIPTION
Sets shared libraries non-executable, declares the C library dependency (libc6/glibc), ships a DEP-5 copyright file, and tightens the package description so the deb/rpm pass lintian and rpmlint cleanly apart from the intentionally-unstripped bundled libkrun.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/613">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->