### PR TITLE
Fix the deb/rpm build broken by a leftover LICENSE.txt copy

### DIFF
--- a/.github/workflows/deb-rpm-repo.yml
+++ b/.github/workflows/deb-rpm-repo.yml
@@ -61,7 +61,6 @@ jobs:
             curl -fsSL "https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/smolvm-${VER}-linux-${rel}.tar.gz" -o tarball.tgz
             rm -rf pkgroot && mkdir pkgroot
             tar -xzf tarball.tgz --strip-components=1 -C pkgroot
-            cp LICENSE.txt pkgroot/LICENSE
             cp packaging/deb/copyright pkgroot/copyright
             # Retarget the wrapper at the packaged locations (same as the PKGBUILD).
             sed -i \


### PR DESCRIPTION
Removes a dead cp of a LICENSE.txt that is no longer downloaded, which was failing the deb/rpm build step now that the package ships the DEP-5 copyright instead.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/614">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->