### PR TITLE
Ship smolvm as a Nix flake package, auto-bumped on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -471,3 +471,16 @@ jobs:
     uses: ./.github/workflows/deb-rpm-repo.yml
     with:
       tag: ${{ github.ref_name }}
+
+  # Bump the Nix flake (nix/smolvm.nix) to this release and open a PR. Same
+  # reasoning as the steps above (the `release: published` event never fires for
+  # a GITHUB_TOKEN release), so it is invoked directly after the release exists.
+  update-nix-flake:
+    name: Update Nix flake
+    needs: release
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: ./.github/workflows/update-nix-flake.yml
+    with:
+      tag: ${{ github.ref_name }}

--- a/.github/workflows/update-nix-flake.yml
+++ b/.github/workflows/update-nix-flake.yml
@@ -1,0 +1,62 @@
+name: Update Nix flake
+
+# Bumps nix/smolvm.nix (version + per-arch SRI hashes) to a release and opens a
+# PR. Invoked by release.yml (workflow_call) after the release exists, because
+# the `release: published` event never fires for a GITHUB_TOKEN release — the
+# same restriction the pacman / deb-rpm / Homebrew steps work around. Opens a PR
+# rather than pushing to main so the flake bump gets a normal review.
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to pin (e.g. v1.5.2)'
+        required: true
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Release tag to pin (e.g. v1.5.2)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Bump nix/smolvm.nix
+        id: bump
+        run: |
+          set -euo pipefail
+          TAG='${{ github.event.release.tag_name || inputs.tag }}'
+          VER="${TAG#v}"
+          python3 packaging/nix/bump.py "$VER" nix/smolvm.nix
+          echo "ver=$VER" >> "$GITHUB_OUTPUT"
+          if git diff --quiet nix/smolvm.nix; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open bump PR
+        if: steps.bump.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          ver='${{ steps.bump.outputs.ver }}'
+          branch="nix-bump-${ver}"
+          git config user.name  'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git checkout -b "$branch"
+          git add nix/smolvm.nix
+          git commit -m "chore(nix): bump flake to ${ver}"
+          git push -f origin "$branch"
+          gh pr create --base main --head "$branch" \
+            --title "chore(nix): bump flake to ${ver}" \
+            --body "Automated bump of nix/smolvm.nix to ${ver} (version + per-arch SRI hashes)." \
+            || gh pr edit "$branch" --title "chore(nix): bump flake to ${ver}"

--- a/docs/install-nix.md
+++ b/docs/install-nix.md
@@ -1,0 +1,51 @@
+# Installing smolvm with Nix
+
+smolvm is packaged as a **Nix flake**. It repackages the official release
+binaries (bundling the smol-machines libkrun fork) and patches them for the Nix
+store, with the runtime tools (`crun`, `mkfs.ext4`, `jq`, …) wired onto the
+wrapper's `PATH` — so it works on NixOS out of the box.
+
+Supported systems: `x86_64-linux`, `aarch64-linux`, `aarch64-darwin`.
+
+## Run it once
+
+```sh
+nix run github:smol-machines/smolvm -- --help
+```
+
+## Install into a profile
+
+```sh
+nix profile install github:smol-machines/smolvm
+```
+
+Upgrades: `nix profile upgrade smolvm` (the flake tracks the latest release).
+
+## NixOS / Home Manager
+
+The flake exposes an overlay, so you can add smolvm to your configuration:
+
+```nix
+{
+  inputs.smolvm.url = "github:smol-machines/smolvm";
+
+  # in your system/home configuration:
+  nixpkgs.overlays = [ inputs.smolvm.overlays.default ];
+  environment.systemPackages = [ pkgs.smolvm ];   # or home.packages
+}
+```
+
+Running microVMs needs `/dev/kvm` on Linux; on NixOS enable it with
+`virtualisation.kvmgt.enable = true;` (Intel) or ensure the `kvm` module is
+loaded and your user is in the `kvm` group.
+
+## Notes
+
+- It is a **binary repackage** (`sourceProvenance = binaryNativeCode`): the same
+  release tarball served on the GitHub Releases page, patchelf'd for Nix. The
+  bundled libkrun/libkrunfw fork lives under the package's `libexec`, so it does
+  not collide with a system `libkrun`.
+- The pinned version and hashes in `nix/smolvm.nix` are bumped automatically on
+  every release by `.github/workflows/update-nix-flake.yml` (which opens a PR).
+- A submission to the upstream **nixpkgs** collection is planned so
+  `nix profile install nixpkgs#smolvm` works without referencing this flake.

--- a/nix/smolvm.nix
+++ b/nix/smolvm.nix
@@ -6,25 +6,34 @@
   patchelf,
   gcc-unwrapped,
   bzip2,
+  # Runtime tools smolvm shells out to on the host. The binary looks for these
+  # on PATH (and hardcodes FHS paths like /sbin/mkfs.ext4 that do not exist on
+  # NixOS), so the wrapper must put them there.
+  crun,
+  jq,
+  e2fsprogs,
+  util-linux,
+  gzip,
+  gnutar,
+  coreutils,
 }: let
-  version = "1.4.7";
+  version = "1.5.2";
 
   releases = {
     x86_64-linux = {
       asset = "smolvm-${version}-linux-x86_64.tar.gz";
       root = "smolvm-${version}-linux-x86_64";
-      hash = "sha256-KmdN7GDx+u4PB3RqWGDnSXgtC+4JoGnTn2HFUADLTfc=";
+      hash = "sha256-eZ2/o6zXdAR6SItNpN8uP5ovG1LpCqq9mT9Y4uJ73jQ=";
     };
     aarch64-linux = {
       asset = "smolvm-${version}-linux-arm64.tar.gz";
       root = "smolvm-${version}-linux-arm64";
-      hash = "sha256-SFwSbfO9K7stwcq60IwMQ7ceKvDpBYkHcFJnnUtxL80=";
+      hash = "sha256-HyLzUReV8K7N7PHk5vjztmi8duIIyjcg8PJZskn32ic=";
     };
     aarch64-darwin = {
       asset = "smolvm-${version}-darwin-arm64.tar.gz";
       root = "smolvm-${version}-darwin-arm64";
-      hash = "sha256-pJkgLg9uCnNZUz/MEtnbpof3YkcLLfWGLt5UL02PQjo=";
-
+      hash = "sha256-0sL56qrNNXuoKOcWYhaJs7Fnm4CCRjuGe8iRook1i6c=";
     };
   };
 
@@ -34,6 +43,21 @@
     gcc-unwrapped.lib
     bzip2
   ];
+
+  # crun/e2fsprogs/util-linux are Linux-only; the container runtime and mkfs.ext4
+  # only matter there. On darwin smolvm uses the host's own facilities.
+  runtimeDeps =
+    [
+      jq
+      gzip
+      gnutar
+      coreutils
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      crun
+      e2fsprogs
+      util-linux
+    ];
 in
   stdenv.mkDerivation {
     pname = "smolvm";
@@ -80,7 +104,8 @@ in
       ''
       + ''
         makeWrapper $out/libexec/smolvm/smolvm $out/bin/smolvm \
-          --set-default SMOLVM_AGENT_ROOTFS $out/libexec/smolvm/agent-rootfs
+          --set-default SMOLVM_AGENT_ROOTFS $out/libexec/smolvm/agent-rootfs \
+          --prefix PATH : ${lib.makeBinPath runtimeDeps}
 
         runHook postInstall
       '';

--- a/packaging/nix/bump.py
+++ b/packaging/nix/bump.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Bump nix/smolvm.nix to a release: rewrites the version and the per-arch
+SRI hashes by downloading each release tarball. Run by the CI workflow
+.github/workflows/update-nix-flake.yml on every release.
+
+Usage: bump.py <version-without-v> <path-to-smolvm.nix>
+"""
+import base64
+import hashlib
+import re
+import sys
+import urllib.request
+
+REPO = "smol-machines/smolvm"
+# nix system -> release tarball arch label
+ASSETS = {
+    "x86_64-linux": "linux-x86_64",
+    "aarch64-linux": "linux-arm64",
+    "aarch64-darwin": "darwin-arm64",
+}
+
+
+def sri(url: str) -> str:
+    with urllib.request.urlopen(url) as r:
+        data = r.read()
+    return "sha256-" + base64.b64encode(hashlib.sha256(data).digest()).decode()
+
+
+def main() -> int:
+    version, path = sys.argv[1], sys.argv[2]
+    text = open(path).read()
+    text = re.sub(r'version = "[^"]*";', f'version = "{version}";', text, count=1)
+    for system, label in ASSETS.items():
+        url = f"https://github.com/{REPO}/releases/download/v{version}/smolvm-{version}-{label}.tar.gz"
+        h = sri(url)
+        # Replace the hash line inside this system's attribute block only. Use a
+        # non-greedy .*? (DOTALL) — the asset strings contain "}" via ${version},
+        # so a [^}] class would stop short.
+        pattern = r"(" + re.escape(system) + r" = \{.*?hash = \")[^\"]*(\";)"
+        text, n = re.subn(pattern, lambda m: m.group(1) + h + m.group(2), text, flags=re.S)
+        if n != 1:
+            print(f"error: expected exactly one hash for {system}, replaced {n}", file=sys.stderr)
+            return 1
+        print(f"{system}: {h}")
+    open(path, "w").write(text)
+    print(f"bumped nix/smolvm.nix to {version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Updates the flake package to 1.5.2 and wires the runtime tools (crun, mkfs.ext4, jq, …) onto the wrapper PATH so it runs on NixOS, adds a Nix install doc, and adds a release job that opens a PR bumping nix/smolvm.nix on every release so it can't go stale again.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/615">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->