### PR TITLE
CUDA-over-vsock: fork warm GPU VMs and run vLLM through the remoting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2414,6 +2414,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "smolvm-nvml-shim"
+version = "1.5.2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "smolvm-pack"
 version = "1.5.2"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2387,6 +2387,7 @@ dependencies = [
 name = "smolvm-cuda-shim"
 version = "1.5.2"
 dependencies = [
+ "libc",
  "smolvm-cuda",
  "vsock",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/smolvm-cuda-shim",
     "crates/smolvm-cuda-codegen",
     "crates/smolvm-cudart-shim",
+    "crates/smolvm-nvml-shim",
     "crates/smolvm-network",
     "crates/smolvm-pack",
     "crates/smolvm-protocol",

--- a/crates/smolvm-cuda-guest/src/main.rs
+++ b/crates/smolvm-cuda-guest/src/main.rs
@@ -43,7 +43,22 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         .map_err(|e| format!("connect vsock {HOST_CID}:{CUDA_PORT}: {e}"))?;
     let mut cu = Client::new(stream);
 
-    cu.init()?;
+    // Cross-VM device-memory sharing probe (validates the shared-daemon model):
+    //  writer — retain the primary context, allocate a buffer, write a known
+    //           pattern, print its device pointer, then hold the connection open.
+    //  reader — retain the same primary context (shared daemon → same GPU
+    //           context) and read the writer's pointer back.
+    match std::env::var("SMOLVM_CUDA_TEST").as_deref() {
+        Ok("writer") => return run_writer(&mut cu),
+        Ok("reader") => return run_reader(&mut cu),
+        Ok("loop") => {
+            drop(cu);
+            return run_loop();
+        }
+        _ => {}
+    }
+
+    cu.init(0)?;
     let count = cu.device_get_count()?;
     if count < 1 {
         return Err("no CUDA devices reported by host".into());
@@ -101,6 +116,153 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         c[n - 1]
     );
     println!("SMOLVM-CUDA-OK");
+    Ok(())
+}
+
+/// The shared pattern the writer stores and the reader verifies.
+#[cfg(target_os = "linux")]
+const PROBE_PATTERN: [f32; 4] = [3.14, 2.71, 1.41, 1.61];
+
+#[cfg(target_os = "linux")]
+type VClient = smolvm_cuda::client::Client<vsock::VsockStream>;
+
+/// Open a fresh vsock connection to the CUDA host, run the handshake resuming
+/// `resume_token` (0 first time), and retain the primary context. A short
+/// socket timeout makes a severed connection surface as an error instead of
+/// hanging — the signal a fork clone uses to reconnect (its pid is unchanged
+/// across the VM snapshot, so pid-based detection can't fire).
+#[cfg(target_os = "linux")]
+fn connect_cuda(resume_token: u64) -> Result<(VClient, u64), Box<dyn std::error::Error>> {
+    use vsock::VsockStream;
+    let stream = VsockStream::connect_with_cid_port(HOST_CID, CUDA_PORT)?;
+    stream.set_read_timeout(Some(std::time::Duration::from_secs(2)))?;
+    stream.set_write_timeout(Some(std::time::Duration::from_secs(2)))?;
+    let mut cu = VClient::new(stream);
+    let token = cu.init(resume_token)?;
+    cu.primary_ctx_retain(0)?;
+    Ok((cu, token))
+}
+
+/// Long-lived probe for the VM-fork path: allocate a buffer with a known
+/// pattern, then loop reading it back. On a transport error (the clone's
+/// inherited connection is dead after the fork), reconnect — resuming the
+/// parent session's token — and keep reading. Because every VM shares the
+/// daemon's one GPU context, the reconnected clone reads the SAME device
+/// pointer the parent allocated. Ticks are appended to `SMOLVM_CUDA_OUT` with a
+/// per-boot tag so the host can see the golden vs. the clone.
+#[cfg(target_os = "linux")]
+fn run_loop() -> Result<(), Box<dyn std::error::Error>> {
+    use std::io::Write;
+    let out = std::env::var("SMOLVM_CUDA_OUT").unwrap_or_else(|_| "/dev/stderr".into());
+    let tag = std::fs::read_to_string("/etc/machine-id")
+        .unwrap_or_default()
+        .trim()
+        .chars()
+        .take(8)
+        .collect::<String>();
+    let mut append = |line: String| {
+        if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&out) {
+            let _ = writeln!(f, "{line}");
+        }
+    };
+
+    let (mut cu, mut token) = connect_cuda(0)?;
+    let dptr = cu.mem_alloc(16)?;
+    cu.memcpy_htod(dptr, as_bytes(&PROBE_PATTERN), 0)?;
+    cu.ctx_synchronize()?;
+    append(format!("BOOT tag={tag} dptr=0x{dptr:x} token={token}"));
+
+    for tick in 0.. {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0);
+        match cu.memcpy_dtoh(dptr, 16, 0) {
+            Ok(bytes) => {
+                let v: Vec<f32> = bytes
+                    .chunks_exact(4)
+                    .map(|p| f32::from_le_bytes(p.try_into().unwrap()))
+                    .collect();
+                let ok = v
+                    .iter()
+                    .zip(PROBE_PATTERN.iter())
+                    .all(|(g, e)| (g - e).abs() < 1e-3);
+                append(format!("TICK tag={tag} n={tick} t={now} ok={ok} v={v:?}"));
+            }
+            Err(e) => {
+                append(format!("SEVERED tag={tag} n={tick} t={now} err={e}"));
+                match connect_cuda(token) {
+                    Ok((c, t)) => {
+                        cu = c;
+                        token = t;
+                        let t2 = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .map(|d| d.as_millis())
+                            .unwrap_or(0);
+                        append(format!("RECONNECT tag={tag} n={tick} t={t2} token={token}"));
+                    }
+                    Err(e2) => append(format!("RECONNECT-FAIL tag={tag} n={tick} err={e2}")),
+                }
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(500));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn run_writer(
+    cu: &mut smolvm_cuda::client::Client<vsock::VsockStream>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    cu.init(0)?;
+    cu.primary_ctx_retain(0)?;
+    let dptr = cu.mem_alloc(16)?;
+    cu.memcpy_htod(dptr, as_bytes(&PROBE_PATTERN), 0)?;
+    cu.ctx_synchronize()?;
+    // The device pointer is a raw GPU address, valid in the daemon's shared
+    // context for any other VM's connection.
+    println!("DPTR=0x{dptr:x}");
+    println!("WRITER-READY");
+    // stdout is block-buffered when piped through the VM console; flush so the
+    // orchestrator sees the pointer before we block holding the connection.
+    std::io::Write::flush(&mut std::io::stdout())?;
+    // Robust side channel: also publish the pointer to a writable mount so the
+    // host can read it without depending on live console relay.
+    if let Ok(path) = std::env::var("SMOLVM_CUDA_OUT") {
+        std::fs::write(&path, format!("0x{dptr:x}\n"))?;
+    }
+    // Hold the connection (and thus the primary-context retain + allocation)
+    // while a second VM reads it.
+    std::thread::sleep(std::time::Duration::from_secs(180));
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn run_reader(
+    cu: &mut smolvm_cuda::client::Client<vsock::VsockStream>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    cu.init(0)?;
+    cu.primary_ctx_retain(0)?;
+    let ptr_env = std::env::var("SMOLVM_CUDA_PTR")?;
+    let dptr = u64::from_str_radix(ptr_env.trim().trim_start_matches("0x"), 16)?;
+    let out = cu.memcpy_dtoh(dptr, 16, 0)?;
+    let got: Vec<f32> = out
+        .chunks_exact(4)
+        .map(|p| f32::from_le_bytes(p.try_into().unwrap()))
+        .collect();
+    let ok = got
+        .iter()
+        .zip(PROBE_PATTERN.iter())
+        .all(|(g, e)| (g - e).abs() < 1e-3);
+    println!("READER read {got:?} from 0x{dptr:x} (expect {PROBE_PATTERN:?})");
+    println!(
+        "{}",
+        if ok {
+            "CROSS-VM-SHARED-OK"
+        } else {
+            "CROSS-VM-SHARED-FAIL"
+        }
+    );
     Ok(())
 }
 

--- a/crates/smolvm-cuda-guest/src/main.rs
+++ b/crates/smolvm-cuda-guest/src/main.rs
@@ -161,7 +161,11 @@ fn run_loop() -> Result<(), Box<dyn std::error::Error>> {
         .take(8)
         .collect::<String>();
     let mut append = |line: String| {
-        if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&out) {
+        if let Ok(mut f) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&out)
+        {
             let _ = writeln!(f, "{line}");
         }
     };

--- a/crates/smolvm-cuda-shim/Cargo.toml
+++ b/crates/smolvm-cuda-shim/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 smolvm-cuda = { path = "../smolvm-cuda", default-features = false }
+libc = "0.2"
 
 # vsock is the production transport (guest → host CID 2). Off Linux the crate
 # still compiles (tcp/unix transports only) so the workspace builds everywhere.

--- a/crates/smolvm-cuda-shim/src/lib.rs
+++ b/crates/smolvm-cuda-shim/src/lib.rs
@@ -575,12 +575,20 @@ pub extern "C" fn cuCtxGetCurrent(pctx: *mut *mut c_void) -> c_int {
     if let Err(e) = ensure_connected(&mut g) {
         return e;
     }
-    let cur = g
-        .as_ref()
-        .expect("connected")
+    let s = g.as_ref().expect("connected");
+    // Report the explicitly-pushed context if there is one; otherwise fall back
+    // to a retained primary context. Real `cudaSetDevice`/runtime init leaves the
+    // device's primary context current, so torch/cuBLAS expect a non-null current
+    // context here. Returning 0 makes torch lazily retain+bind the primary on
+    // first cuBLAS use — harmless in eager (a warning that self-heals) but FATAL
+    // during CUDA-graph capture, where context ops aren't allowed and cuBLAS then
+    // fails `CUBLAS_STATUS_NOT_INITIALIZED`. Surfacing the primary avoids the lazy
+    // bind entirely, which is what lets a graph-capturing engine (vLLM) work.
+    let cur = s
         .ctx_stack
         .last()
         .copied()
+        .or_else(|| s.primary_ctx.values().next().copied())
         .unwrap_or(0);
     ret(unsafe { out(pctx, cur as *mut c_void) })
 }

--- a/crates/smolvm-cuda-shim/src/lib.rs
+++ b/crates/smolvm-cuda-shim/src/lib.rs
@@ -169,7 +169,7 @@ fn ensure_connected(guard: &mut Option<ShimState>) -> Result<(), c_int> {
             c
         }
     };
-    if let Err(e) = client.init() {
+    if let Err(e) = client.init(0) {
         return Err(match e {
             CudaRpcError::Cuda(code) => code as c_int,
             _ => CUDA_ERROR_NO_DEVICE,

--- a/crates/smolvm-cuda-shim/src/lib.rs
+++ b/crates/smolvm-cuda-shim/src/lib.rs
@@ -100,6 +100,49 @@ impl Write for Stream {
     }
 }
 
+#[cfg(unix)]
+impl Stream {
+    /// Raw socket fd for the liveness peek; -1 when bridged (no own socket).
+    fn raw_fd(&self) -> std::os::unix::io::RawFd {
+        use std::os::unix::io::AsRawFd;
+        match self {
+            #[cfg(target_os = "linux")]
+            Stream::Vsock(s) => s.as_raw_fd(),
+            Stream::Tcp(s) => s.as_raw_fd(),
+            Stream::Unix(s) => s.as_raw_fd(),
+            Stream::Bridged => -1,
+        }
+    }
+}
+
+/// Non-blocking, non-consuming liveness peek on the host connection. A VM-fork
+/// clone (same pid, so a pid check can't fire) inherits a socket whose host peer
+/// is gone; the guest kernel resets it and the peek sees EOF, telling us to
+/// reconnect. `true` = usable (data pending or none yet), `false` = closed/error.
+#[cfg(unix)]
+fn conn_alive(fd: std::os::unix::io::RawFd) -> bool {
+    if fd < 0 {
+        return true; // bridged: liveness is the runtime shim's concern
+    }
+    let mut b = [0u8; 1];
+    let n = unsafe {
+        libc::recv(
+            fd,
+            b.as_mut_ptr() as *mut libc::c_void,
+            1,
+            libc::MSG_PEEK | libc::MSG_DONTWAIT,
+        )
+    };
+    if n > 0 {
+        true
+    } else if n == 0 {
+        false
+    } else {
+        let e = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+        e == libc::EAGAIN || e == libc::EWOULDBLOCK
+    }
+}
+
 fn connect() -> Result<Stream, c_int> {
     let spec = std::env::var("SMOLVM_CUDA_RPC").unwrap_or_default();
     if let Some(addr) = spec.strip_prefix("tcp:") {
@@ -140,6 +183,12 @@ struct ShimState {
     primary_ctx: HashMap<i32, u64>,
     /// Process-global "current context" stack (bottom = cuCtxSetCurrent slot).
     ctx_stack: Vec<u64>,
+    /// Fork-reconnect bookkeeping for a standalone (non-bridged) connection:
+    /// pid that opened it, its socket fd (liveness peek), and the host-assigned
+    /// lineage token to resume. Bridged connections leave these inert (fd -1).
+    conn_pid: i32,
+    conn_fd: i32,
+    conn_token: u64,
 }
 
 static STATE: Mutex<Option<ShimState>> = Mutex::new(None);
@@ -151,7 +200,34 @@ static STATE: Mutex<Option<ShimState>> = Mutex::new(None);
 /// initialized CUDA through the runtime API never called *our* `cuInit`. Lazily
 /// connecting on first use makes any driver entry point self-initializing.
 fn ensure_connected(guard: &mut Option<ShimState>) -> Result<(), c_int> {
-    if guard.is_some() {
+    if let Some(st) = guard.as_mut() {
+        // A standalone connection can be severed under us by a VM-fork clone
+        // (pid is preserved across the snapshot, so the peek is what catches
+        // it). Bridged connections ride the runtime shim, which reconnects
+        // itself. Rebuild in place, resuming the lineage token; the registries
+        // (param sizes, primary-context + stack — all raw handles valid in the
+        // shared primary context) survive.
+        let bridged = BRIDGED.load(std::sync::atomic::Ordering::Relaxed);
+        let pid = std::process::id() as i32;
+        #[cfg(unix)]
+        let severed = !bridged && !conn_alive(st.conn_fd);
+        #[cfg(not(unix))]
+        let severed = false;
+        if !bridged && (st.conn_pid != pid || severed) {
+            let (mut client, token, fd) = connect_standalone(st.conn_token)?;
+            // Restore a current context on the fresh host session. The host binds
+            // the primary context on retain (its `cuCtxSetCurrent` is local), so
+            // without this a driver-API alloc/launch on the reconnected session
+            // faults with INVALID_CONTEXT. The app's own handle stays valid in
+            // the shared daemon context; we only need the host thread bound.
+            if !st.primary_ctx.is_empty() {
+                let _ = client.primary_ctx_retain(0);
+            }
+            st.client = client;
+            st.conn_token = token;
+            st.conn_fd = fd;
+            st.conn_pid = pid;
+        }
         return Ok(());
     }
     // Preferred: ride the runtime shim's connection (both shims loaded, one
@@ -161,28 +237,48 @@ fn ensure_connected(guard: &mut Option<ShimState>) -> Result<(), c_int> {
     // queues would let the host execute work out of order (recorded misorder
     // in a CUDA graph replays wrong), so run every op sync and fence the
     // runtime connection before each one (see fence_runtime).
-    let mut client = match resolve_bridge() {
-        Some(bridge) => Client::new_bridged(Stream::Bridged, bridge),
-        None => {
-            let mut c = Client::new(connect()?);
-            c.set_defer_enabled(false);
-            c
+    let (client, token, fd) = match resolve_bridge() {
+        Some(bridge) => {
+            let mut client = Client::new_bridged(Stream::Bridged, bridge);
+            let token = client.init(0).map_err(init_err)?;
+            (client, token, -1)
         }
+        None => connect_standalone(0)?,
     };
-    if let Err(e) = client.init(0) {
-        return Err(match e {
-            CudaRpcError::Cuda(code) => code as c_int,
-            _ => CUDA_ERROR_NO_DEVICE,
-        });
-    }
     BRIDGED.store(client.is_bridged(), std::sync::atomic::Ordering::Relaxed);
     *guard = Some(ShimState {
         client,
         param_sizes: HashMap::new(),
         primary_ctx: HashMap::new(),
         ctx_stack: Vec::new(),
+        conn_pid: std::process::id() as i32,
+        conn_fd: fd,
+        conn_token: token,
     });
     Ok(())
+}
+
+/// Open a standalone (non-bridged) connection to the host, run the handshake
+/// resuming `resume_token`, and return the client, its assigned token, and its
+/// socket fd. Deferral is off — a standalone driver connection must stay
+/// program-ordered against the runtime shim's separate connection.
+fn connect_standalone(resume_token: u64) -> Result<(Client<Stream>, u64, i32), c_int> {
+    let stream = connect()?;
+    #[cfg(unix)]
+    let fd = stream.raw_fd();
+    #[cfg(not(unix))]
+    let fd = -1;
+    let mut client = Client::new(stream);
+    client.set_defer_enabled(false);
+    let token = client.init(resume_token).map_err(init_err)?;
+    Ok((client, token, fd))
+}
+
+fn init_err(e: CudaRpcError) -> c_int {
+    match e {
+        CudaRpcError::Cuda(code) => code as c_int,
+        _ => CUDA_ERROR_NO_DEVICE,
+    }
 }
 
 /// Set once at connect: this shim's client rides the runtime shim's

--- a/crates/smolvm-cuda/examples/gpu_loopback.rs
+++ b/crates/smolvm-cuda/examples/gpu_loopback.rs
@@ -50,7 +50,7 @@ fn main() {
     });
 
     let mut cu = Client::new(TcpStream::connect(addr).expect("connect"));
-    cu.init().expect("cuInit");
+    cu.init(0).expect("cuInit");
     let count = cu.device_get_count().expect("device count");
     let name = cu.device_get_name(0).expect("device name");
     let vram = cu.device_total_mem(0).expect("total mem");

--- a/crates/smolvm-cuda/src/client.rs
+++ b/crates/smolvm-cuda/src/client.rs
@@ -429,6 +429,32 @@ impl<S: Read + Write> Client<S> {
         self.defer_enabled = on;
     }
 
+    /// Take this client's pending deferred pipeline (framed-but-unsent quiet
+    /// requests + their count + sticky status), clearing it. On a VM-fork clone
+    /// whose connection died mid-flush, these requests never reached the host —
+    /// so they must move to the reconnected client and re-flush there, or the
+    /// buffered work (e.g. torch's queued cuBLAS matmuls before a `.item()`)
+    /// would be silently dropped and the next read returns stale data.
+    pub fn take_pending(&mut self) -> (Vec<u8>, usize, i32) {
+        let sticky = self.sticky;
+        self.sticky = 0;
+        let deferred = self.deferred;
+        self.deferred = 0;
+        (std::mem::take(&mut self.wbuf), deferred, sticky)
+    }
+
+    /// Adopt a pending deferred pipeline taken from a prior (dead) client. The
+    /// requests reference handles that stay valid in the shared primary context
+    /// (and are restored by the Init handoff), so re-flushing them on this fresh
+    /// connection replays exactly the not-yet-executed work.
+    pub fn restore_pending(&mut self, wbuf: Vec<u8>, deferred: usize, sticky: i32) {
+        self.wbuf = wbuf;
+        self.deferred = deferred;
+        if self.sticky == 0 {
+            self.sticky = sticky;
+        }
+    }
+
     /// Settle all fire-and-forget work with a single fence round-trip: quiet
     /// requests produce no per-op responses (each response read costs a guest
     /// wake-up on vsock), so one fence reply carries the first failure among

--- a/crates/smolvm-cuda/src/client.rs
+++ b/crates/smolvm-cuda/src/client.rs
@@ -663,14 +663,21 @@ impl<S: Read + Write> Client<S> {
         read_msg(&mut self.stream)?.ok_or(CudaRpcError::Protocol("host closed mid-call"))
     }
 
-    pub fn init(&mut self) -> Result<()> {
-        self.call(
+    /// Run the connect handshake, adopting `resume_token`'s (frozen) session
+    /// handle map if non-zero. Returns this session's own lineage token, to be
+    /// replayed as `resume_token` when a fork clone reconnects.
+    pub fn init(&mut self, resume_token: u64) -> Result<u64> {
+        match self.call(
             &Request::Init {
                 proto_hash: crate::PROTO_HASH,
+                resume_token,
             },
             Op::Init,
-        )
-        .map(|_| ())
+        )? {
+            Response::Handle(token) => Ok(token),
+            // Older host that replies Ok carries no token; treat as no handoff.
+            _ => Ok(0),
+        }
     }
 
     pub fn device_get_count(&mut self) -> Result<i32> {

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -275,8 +275,14 @@ struct Session {
     cublas_handles: HashMap<u64, u64>,
     /// Guest-minted virtual graph/exec handles → real (bit-63 tagged). Lets
     /// EndCapture / GraphInstantiate be fire-and-forget: the guest invents the
-    /// handle, the host maps it when it materializes the real one.
-    graph_vhandles: HashMap<u64, u64>,
+    /// handle, the host maps it when it materializes the real one. Shared via
+    /// [`GRAPH_HANDOFF`] so a fork clone inherits a snapshot of its parent's
+    /// captured graphs (the reals are context-scoped, valid across connections).
+    graph_vhandles: std::sync::Arc<std::sync::Mutex<HashMap<u64, u64>>>,
+    /// Real graph/exec handles THIS session created (not inherited). Only these
+    /// are destroyed on reclaim — mirrors `owned_modules`, so a clone dropping
+    /// never frees a graph its (still-live) parent handed it.
+    owned_graph_reals: std::collections::HashSet<u64>,
     /// Live resources this connection created, reclaimed when it ends —
     /// a guest that dies mid-run must not leak GPU memory (device
     /// allocations are the multi-GB hazard; modules/streams/events are
@@ -318,15 +324,14 @@ fn reclaim_session(sess: &mut Session, b: &mut dyn Backend) {
     for e in std::mem::take(&mut sess.owned_events) {
         let _ = b.event_destroy(e);
     }
-    for (vh, real) in std::mem::take(&mut sess.graph_vhandles) {
-        // Exec handles (used by GraphLaunch) vs graphs — try exec destroy
-        // first, then graph destroy; the wrong one errors harmlessly.
-        let _ = if vh != 0 {
-            b.graph_exec_destroy(real)
-                .or_else(|_| b.graph_destroy(real))
-        } else {
-            Ok(())
-        };
+    for real in std::mem::take(&mut sess.owned_graph_reals) {
+        // Only reals this session created — never a graph inherited from a
+        // still-live parent (those stay in the shared map, owned by the parent).
+        // Exec vs graph is unknown here; try exec destroy first, then graph
+        // destroy — the wrong one errors harmlessly.
+        let _ = b
+            .graph_exec_destroy(real)
+            .or_else(|_| b.graph_destroy(real));
     }
     for _ in 0..std::mem::take(&mut sess.primary_retains) {
         let _ = b.primary_ctx_release(0);
@@ -338,6 +343,36 @@ impl Session {
         self.next_id += 1;
         self.next_id
     }
+}
+
+/// Registry of live sessions' `graph_vhandles` maps, keyed by the lineage token
+/// [`Backend::begin_session`] returns. `Weak` refs so a session's entry
+/// evaporates when its connection closes. Parallels the cuBLAS `HANDOFF` in
+/// `host::gpu`, but lives here because graph vhandles are session state (the
+/// generic dispatch owns them, not the concrete GPU backend). A fork clone
+/// resuming a parent token adopts a snapshot of the parent's captured graphs.
+type GraphVhMap = std::sync::Mutex<HashMap<u64, u64>>;
+static GRAPH_HANDOFF: std::sync::Mutex<Option<HashMap<u64, std::sync::Weak<GraphVhMap>>>> =
+    std::sync::Mutex::new(None);
+
+/// Copy `resume_token`'s captured-graph map into `dst`, then register `dst`
+/// under `my_token` (the same token the backend minted for cuBLAS handoff, so
+/// both handle families share one lineage). The reals are context-scoped host
+/// handles valid in the shared primary context, so copying vh→real is enough.
+fn graph_handoff_register(
+    dst: &std::sync::Arc<GraphVhMap>,
+    resume_token: u64,
+    my_token: u64,
+) {
+    let mut reg = GRAPH_HANDOFF.lock().unwrap();
+    let reg = reg.get_or_insert_with(HashMap::new);
+    if resume_token != 0 {
+        if let Some(parent) = reg.get(&resume_token).and_then(|w| w.upgrade()) {
+            *dst.lock().unwrap() = parent.lock().unwrap().clone();
+        }
+    }
+    reg.retain(|_, w| w.strong_count() > 0);
+    reg.insert(my_token, std::sync::Arc::downgrade(dst));
 }
 
 /// Serve one CUDA-RPC connection to completion (until the peer closes). Each
@@ -715,7 +750,12 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
     fn raw_graph(sess: &Session, h: u64) -> u64 {
         // Virtual graph/exec handle → real; untagged values pass through.
         if h & VHANDLE_TAG != 0 {
-            sess.graph_vhandles.get(&h).copied().unwrap_or(0)
+            sess.graph_vhandles
+                .lock()
+                .unwrap()
+                .get(&h)
+                .copied()
+                .unwrap_or(0)
         } else {
             h
         }
@@ -741,8 +781,11 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
                 Err(CUDA_ERROR_NOT_SUPPORTED)
             } else {
                 // Adopt the parent's handle map if resuming, and hand back this
-                // session's token so a later fork-clone can resume from us.
+                // session's token so a later fork-clone can resume from us. The
+                // backend hands off its cuBLAS/cuDNN descriptors; mirror that for
+                // the session-level captured-graph map under the same token.
                 let token = b.begin_session(resume_token);
+                graph_handoff_register(&sess.graph_vhandles, resume_token, token);
                 b.init().map(|_| Response::Handle(token))
             }
         }
@@ -895,7 +938,8 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             let raw = raw_stream(sess, stream)?;
             let g = b.stream_end_capture(raw)?;
             if graph_vh & VHANDLE_TAG != 0 {
-                sess.graph_vhandles.insert(graph_vh, g);
+                sess.graph_vhandles.lock().unwrap().insert(graph_vh, g);
+                sess.owned_graph_reals.insert(g);
             }
             Ok(Response::Handle(g))
         }
@@ -908,7 +952,8 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             let real_graph = raw_graph(sess, graph);
             let e = b.graph_instantiate(real_graph)?;
             if exec_vh & VHANDLE_TAG != 0 {
-                sess.graph_vhandles.insert(exec_vh, e);
+                sess.graph_vhandles.lock().unwrap().insert(exec_vh, e);
+                sess.owned_graph_reals.insert(e);
             }
             Ok(Response::Handle(e))
         }
@@ -919,13 +964,23 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         }
         Request::GraphExecDestroy { graph_exec } => {
             let real = raw_graph(sess, graph_exec);
-            sess.graph_vhandles.remove(&graph_exec);
-            b.graph_exec_destroy(real).map(|_| Response::Ok)
+            sess.graph_vhandles.lock().unwrap().remove(&graph_exec);
+            // Only free if we created it; an inherited exec belongs to the
+            // still-live parent (or a sibling clone) and must not be freed here.
+            if sess.owned_graph_reals.remove(&real) {
+                b.graph_exec_destroy(real).map(|_| Response::Ok)
+            } else {
+                Ok(Response::Ok)
+            }
         }
         Request::GraphDestroy { graph } => {
             let real = raw_graph(sess, graph);
-            sess.graph_vhandles.remove(&graph);
-            b.graph_destroy(real).map(|_| Response::Ok)
+            sess.graph_vhandles.lock().unwrap().remove(&graph);
+            if sess.owned_graph_reals.remove(&real) {
+                b.graph_destroy(real).map(|_| Response::Ok)
+            } else {
+                Ok(Response::Ok)
+            }
         }
         Request::GraphGetNodes { graph } => b.graph_get_node_count(graph).map(Response::Bytes),
         Request::MemsetD8Async {
@@ -1943,6 +1998,39 @@ mod tests {
             ),
             other => panic!("expected param data, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn graph_handoff_copies_parent_captures_to_clone() {
+        use std::sync::{Arc, Mutex};
+        // High, distinctive tokens so this test can't collide with any token
+        // minted through `dispatch` (CpuBackend hands out 0) in the shared
+        // GRAPH_HANDOFF registry.
+        let vh = VHANDLE_TAG | 0x0000_0000_0000_0007;
+        let real_exec = 0xDEAD_BEEF_u64;
+
+        // Parent captured a graph (vh → real) and registered under its token.
+        let parent: Arc<GraphVhMap> = Arc::new(Mutex::new(HashMap::new()));
+        parent.lock().unwrap().insert(vh, real_exec);
+        graph_handoff_register(&parent, 0, 0xA1A1_0000_0000_0001);
+
+        // Clone resumes the parent's token: it must inherit the vh → real entry
+        // so a GraphLaunch of the guest's (unchanged) virtual handle resolves.
+        let clone: Arc<GraphVhMap> = Arc::new(Mutex::new(HashMap::new()));
+        graph_handoff_register(&clone, 0xA1A1_0000_0000_0001, 0xA1A1_0000_0000_0002);
+        assert_eq!(
+            clone.lock().unwrap().get(&vh).copied(),
+            Some(real_exec),
+            "clone must inherit the parent's captured-graph handle"
+        );
+
+        // Resuming a token whose session is gone yields an empty map, not a fault.
+        let orphan: Arc<GraphVhMap> = Arc::new(Mutex::new(HashMap::new()));
+        graph_handoff_register(&orphan, 0xDEAD_0000_0000_9999, 0xA1A1_0000_0000_0003);
+        assert!(
+            orphan.lock().unwrap().is_empty(),
+            "a dead lineage token hands off nothing"
+        );
     }
     // The connect handshake rejects a client whose wire fingerprint differs
     // (stale shim/server), so protocol skew fails loudly instead of decoding

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -692,6 +692,18 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             Ok(sess.streams.get(&stream).copied().unwrap_or(stream))
         }
     }
+    // Modules and functions are raw host handles on the wire (like streams):
+    // the real CUmodule/CUfunction is context-scoped and every connection
+    // retains the same device primary context, so a handle minted on one
+    // connection stays valid on another (this is what lets a forked VM clone
+    // reconnect and keep using its parent's loaded modules). The tables only
+    // translate ids minted by pre-raw guests; a raw value passes through.
+    fn raw_module(sess: &Session, m: u64) -> u64 {
+        sess.modules.get(&m).copied().unwrap_or(m)
+    }
+    fn raw_fn_h(sess: &Session, f: u64) -> u64 {
+        sess.functions.get(&f).copied().unwrap_or(f)
+    }
     fn raw_graph(sess: &Session, h: u64) -> u64 {
         // Virtual graph/exec handle → real; untagged values pass through.
         if h & VHANDLE_TAG != 0 {
@@ -754,28 +766,28 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             b.primary_ctx_release(device).map(|_| Response::Ok)
         }
         Request::ModuleLoadData { image } => {
+            // Return the raw CUmodule as the wire handle (context-scoped, so it
+            // survives a fork-clone reconnect). Still tracked for reclaim.
             let raw = b.module_load_data(&image)?;
             sess.owned_modules.insert(raw);
-            let id = sess.mint();
-            sess.modules.insert(id, raw);
-            Ok(Response::Handle(id))
+            Ok(Response::Handle(raw))
         }
         Request::ModuleGetFunction { module, name } => {
-            let raw_mod = raw(&sess.modules, module)?;
+            let raw_mod = raw_module(sess, module);
+            // Raw CUfunction on the wire: valid across connections in the shared
+            // primary context, so a forked clone keeps its parent's functions.
             let raw_fn = b.module_get_function(raw_mod, &name)?;
-            let id = sess.mint();
-            sess.functions.insert(id, raw_fn);
-            Ok(Response::Handle(id))
+            Ok(Response::Handle(raw_fn))
         }
         Request::ModuleUnload { module } => {
-            let raw_mod = raw(&sess.modules, module)?;
+            let raw_mod = raw_module(sess, module);
             b.module_unload(raw_mod)?;
             sess.owned_modules.remove(&raw_mod);
             sess.modules.remove(&module);
             Ok(Response::Ok)
         }
         Request::FuncGetParamInfo { function } => {
-            let raw_fn = raw(&sess.functions, function)?;
+            let raw_fn = raw_fn_h(sess, function);
             let sizes = b.func_get_param_info(raw_fn)?;
             let mut out = Vec::with_capacity(sizes.len() * 4);
             for s in sizes {
@@ -788,12 +800,12 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             attrib,
             value,
         } => {
-            let raw_fn = raw(&sess.functions, function)?;
+            let raw_fn = raw_fn_h(sess, function);
             b.func_set_attribute(raw_fn, attrib, value)
                 .map(|_| Response::Ok)
         }
         Request::FuncGetAttribute { function, attrib } => {
-            let raw_fn = raw(&sess.functions, function)?;
+            let raw_fn = raw_fn_h(sess, function);
             b.func_get_attribute(raw_fn, attrib).map(Response::Count)
         }
         Request::MemAlloc { bytes } => {
@@ -841,7 +853,7 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             stream,
             params,
         } => {
-            let raw_fn = raw(&sess.functions, function)?;
+            let raw_fn = raw_fn_h(sess, function);
             let raw_str = raw_stream(sess, stream)?;
             b.launch_kernel(raw_fn, grid, block, shared_bytes, raw_str, &params)
                 .map(|_| Response::Ok)
@@ -1862,6 +1874,61 @@ mod tests {
         let (st, _) = dispatch(&mut sess, &mut b, Request::MemAlloc { bytes: mb / 4 });
         assert_eq!(st, 0);
         std::env::remove_var("SMOLVM_CUDA_VRAM_LIMIT_MB");
+    }
+    // Modules and functions are raw host handles on the wire, so a handle minted
+    // on one connection resolves on another (both retain the same primary
+    // context). This is what lets a forked VM clone reconnect on a fresh session
+    // and keep launching the parent's kernels instead of getting INVALID_HANDLE.
+    #[test]
+    fn function_handle_survives_across_sessions() {
+        let mut backend = CpuBackend::default();
+        // Session A loads a module and resolves a function.
+        let mut sess_a = Session::default();
+        let (st, r) = dispatch(
+            &mut sess_a,
+            &mut backend,
+            Request::ModuleLoadData { image: vec![0u8; 8] },
+        );
+        assert_eq!(st, 0);
+        let module = match r {
+            Response::Handle(h) => h,
+            _ => unreachable!("module load returns a handle"),
+        };
+        let (st, r) = dispatch(
+            &mut sess_a,
+            &mut backend,
+            Request::ModuleGetFunction { module, name: "vecadd".into() },
+        );
+        assert_eq!(st, 0);
+        let function = match r {
+            Response::Handle(h) => h,
+            _ => unreachable!("get-function returns a handle"),
+        };
+        // Session B is a brand-new session (the clone's fresh connection). It
+        // never loaded the module, yet resolving A's function must succeed —
+        // pre-raw-handle code returned INVALID_HANDLE here.
+        let mut sess_b = Session::default();
+        assert!(
+            sess_b.functions.is_empty(),
+            "clone session starts with no local function ids"
+        );
+        let (st, r) = dispatch(
+            &mut sess_b,
+            &mut backend,
+            Request::FuncGetParamInfo { function },
+        );
+        assert_eq!(st, 0, "function from another session must resolve, not fault");
+        match r {
+            Response::Data(d) => assert_eq!(
+                d,
+                [8u32, 8, 8, 4]
+                    .iter()
+                    .flat_map(|s| s.to_le_bytes())
+                    .collect::<Vec<u8>>(),
+                "resolved the right function's param layout"
+            ),
+            other => panic!("expected param data, got {other:?}"),
+        }
     }
     // The connect handshake rejects a client whose wire fingerprint differs
     // (stale shim/server), so protocol skew fails loudly instead of decoding

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -31,6 +31,14 @@ pub const CUDA_ERROR_NOT_SUPPORTED: i32 = 801;
 /// opaque ids before they reach the guest.
 pub trait Backend: Send {
     fn init(&mut self) -> CuResult<()>;
+    /// Begin a session on this connection and return its lineage token (0 if
+    /// the backend has no handoff support). `resume_token` is 0 for a fresh
+    /// session, or a token from a prior `begin_session` whose (frozen) library
+    /// handle map this connection should adopt — the mechanism a forked VM
+    /// clone uses to keep its parent's cuBLAS/cuDNN descriptors valid.
+    fn begin_session(&mut self, _resume_token: u64) -> u64 {
+        0
+    }
     fn device_get_count(&mut self) -> CuResult<i32>;
     fn device_get_name(&mut self, device: i32) -> CuResult<String>;
     fn device_total_mem(&mut self, device: i32) -> CuResult<u64>;
@@ -717,7 +725,10 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         Ok(sess.events.get(&event).copied().unwrap_or(event))
     }
     let r: CuResult<Response> = (|| match req {
-        Request::Init { proto_hash } => {
+        Request::Init {
+            proto_hash,
+            resume_token,
+        } => {
             if proto_hash != crate::PROTO_HASH {
                 eprintln!(
                     "[smolvm-cuda] PROTOCOL MISMATCH: client wire hash {:016x} != server {:016x} \
@@ -729,7 +740,10 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
                 // CUDA_ERROR_NOT_SUPPORTED — surfaced at cuInit, loud and early.
                 Err(CUDA_ERROR_NOT_SUPPORTED)
             } else {
-                b.init().map(|_| Response::Ok)
+                // Adopt the parent's handle map if resuming, and hand back this
+                // session's token so a later fork-clone can resume from us.
+                let token = b.begin_session(resume_token);
+                b.init().map(|_| Response::Handle(token))
             }
         }
         Request::DeviceGetCount => b.device_get_count().map(Response::Count),
@@ -1703,7 +1717,7 @@ mod tests {
         });
 
         let mut cli = Client::new(client_side);
-        cli.init().unwrap();
+        cli.init(0).unwrap();
         assert_eq!(cli.device_get_count().unwrap(), 1);
         let module = cli.module_load_data(b"<ptx>").unwrap();
         let func = cli.module_get_function(module, "vecadd").unwrap();
@@ -1814,7 +1828,7 @@ mod tests {
         });
 
         let mut cli = Client::new(client_side);
-        cli.init().unwrap();
+        cli.init(0).unwrap();
         let vas = |r: std::ops::Range<usize>| -> Vec<*mut u8> {
             r.map(|i| (hva + i * PAGE) as *mut u8).collect()
         };
@@ -1942,6 +1956,7 @@ mod tests {
             &mut b,
             Request::Init {
                 proto_hash: crate::PROTO_HASH,
+                resume_token: 0,
             },
         );
         assert_eq!(st, 0, "matching proto hash must connect");
@@ -1950,6 +1965,7 @@ mod tests {
             &mut b,
             Request::Init {
                 proto_hash: crate::PROTO_HASH ^ 0x1,
+                resume_token: 0,
             },
         );
         assert_eq!(

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -359,11 +359,7 @@ static GRAPH_HANDOFF: std::sync::Mutex<Option<HashMap<u64, std::sync::Weak<Graph
 /// under `my_token` (the same token the backend minted for cuBLAS handoff, so
 /// both handle families share one lineage). The reals are context-scoped host
 /// handles valid in the shared primary context, so copying vh→real is enough.
-fn graph_handoff_register(
-    dst: &std::sync::Arc<GraphVhMap>,
-    resume_token: u64,
-    my_token: u64,
-) {
+fn graph_handoff_register(dst: &std::sync::Arc<GraphVhMap>, resume_token: u64, my_token: u64) {
     let mut reg = GRAPH_HANDOFF.lock().unwrap();
     let reg = reg.get_or_insert_with(HashMap::new);
     if resume_token != 0 {
@@ -1956,7 +1952,9 @@ mod tests {
         let (st, r) = dispatch(
             &mut sess_a,
             &mut backend,
-            Request::ModuleLoadData { image: vec![0u8; 8] },
+            Request::ModuleLoadData {
+                image: vec![0u8; 8],
+            },
         );
         assert_eq!(st, 0);
         let module = match r {
@@ -1966,7 +1964,10 @@ mod tests {
         let (st, r) = dispatch(
             &mut sess_a,
             &mut backend,
-            Request::ModuleGetFunction { module, name: "vecadd".into() },
+            Request::ModuleGetFunction {
+                module,
+                name: "vecadd".into(),
+            },
         );
         assert_eq!(st, 0);
         let function = match r {
@@ -1986,7 +1987,10 @@ mod tests {
             &mut backend,
             Request::FuncGetParamInfo { function },
         );
-        assert_eq!(st, 0, "function from another session must resolve, not fault");
+        assert_eq!(
+            st, 0,
+            "function from another session must resolve, not fault"
+        );
         match r {
             Response::Data(d) => assert_eq!(
                 d,

--- a/crates/smolvm-cuda/src/host/gpu.rs
+++ b/crates/smolvm-cuda/src/host/gpu.rs
@@ -141,7 +141,13 @@ pub struct GpuBackend {
     /// pointer. Lets the guest fire-and-forget descriptor creation: it invents
     /// the id, the host materializes and maps it, and every later reference is
     /// translated here. Real pointers (bit 63 clear) pass through untouched.
-    vhandles: std::collections::HashMap<u64, u64>,
+    ///
+    /// Behind `Arc<Mutex>` so a fork clone's reconnecting session can adopt a
+    /// snapshot of its (frozen) parent's map — the descriptors are real host
+    /// pointers valid in the shared primary context, so copying the id→pointer
+    /// pairs is enough. Lock cost is negligible: every access already sits
+    /// behind a guest round-trip.
+    vhandles: std::sync::Arc<std::sync::Mutex<std::collections::HashMap<u64, u64>>>,
     /// Host mappings of guest RAM, each `(gpa_start, host_va, len)`, for
     /// zero-copy `memcpy_gpa_*` (via `krun_get_guest_ram`). Empty outside a
     /// microVM / on older libkrun. Guest RAM is usually split into a low and a
@@ -401,7 +407,9 @@ impl GpuBackend {
                 cublas_gen: None,
                 cudnn_gen: None,
                 cudnn_backend: None,
-                vhandles: std::collections::HashMap::new(),
+                vhandles: std::sync::Arc::new(std::sync::Mutex::new(
+                    std::collections::HashMap::new(),
+                )),
                 cublaslt: None,
                 cudnn_bn: None,
                 guest_ram: Vec::new(),
@@ -424,9 +432,47 @@ fn chk(code: CuResultCode) -> CuResult<()> {
     }
 }
 
+/// Registry of live sessions' `vhandles` maps, keyed by lineage token. Holds
+/// `Weak` refs so a session's entry evaporates when its connection closes; a
+/// fork clone resuming a dead token just starts with an empty map. Lets a
+/// clone's fresh connection adopt a snapshot of its (frozen) parent's handle
+/// map — see [`GpuBackend::begin_session`].
+type VhMap = std::sync::Mutex<std::collections::HashMap<u64, u64>>;
+static HANDOFF: std::sync::Mutex<
+    Option<std::collections::HashMap<u64, std::sync::Weak<VhMap>>>,
+> = std::sync::Mutex::new(None);
+
+fn next_lineage_token() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static NEXT: AtomicU64 = AtomicU64::new(1);
+    NEXT.fetch_add(1, Ordering::Relaxed)
+}
+
+/// Adopt `resume_token`'s (frozen) descriptor map into `dst`, then register
+/// `dst` under a fresh token and return it. The parent's entries are real host
+/// pointers valid in the shared primary context, so copying id→pointer pairs is
+/// enough for a fork clone to keep using them. Closed sessions' entries (dead
+/// `Weak`s) are pruned on the way through.
+fn handoff_register(dst: &std::sync::Arc<VhMap>, resume_token: u64) -> u64 {
+    let mut reg = HANDOFF.lock().unwrap();
+    let reg = reg.get_or_insert_with(std::collections::HashMap::new);
+    if resume_token != 0 {
+        if let Some(parent) = reg.get(&resume_token).and_then(|w| w.upgrade()) {
+            *dst.lock().unwrap() = parent.lock().unwrap().clone();
+        }
+    }
+    let token = next_lineage_token();
+    reg.retain(|_, w| w.strong_count() > 0);
+    reg.insert(token, std::sync::Arc::downgrade(dst));
+    token
+}
+
 impl Backend for GpuBackend {
     fn init(&mut self) -> CuResult<()> {
         unsafe { chk((self.init)(0)) }
+    }
+    fn begin_session(&mut self, resume_token: u64) -> u64 {
+        handoff_register(&self.vhandles, resume_token)
     }
     fn device_get_count(&mut self) -> CuResult<i32> {
         let mut n = 0;
@@ -2195,12 +2241,12 @@ impl GpuBackend {
                         }
                     }
                 }
-                Ok(self.cublas_gen.as_ref().unwrap().dispatch(
-                    func,
-                    args,
-                    &mut self.vhandles,
-                    streams,
-                ))
+                let mut vh = self.vhandles.lock().unwrap();
+                Ok(self
+                    .cublas_gen
+                    .as_ref()
+                    .unwrap()
+                    .dispatch(func, args, &mut vh, streams))
             }
             LIB_CUDNN => {
                 if self.cudnn_gen.is_none() {
@@ -2212,12 +2258,12 @@ impl GpuBackend {
                         }
                     }
                 }
-                Ok(self.cudnn_gen.as_ref().unwrap().dispatch(
-                    func,
-                    args,
-                    &mut self.vhandles,
-                    streams,
-                ))
+                let mut vh = self.vhandles.lock().unwrap();
+                Ok(self
+                    .cudnn_gen
+                    .as_ref()
+                    .unwrap()
+                    .dispatch(func, args, &mut vh, streams))
             }
             LIB_CUDNN_BACKEND => {
                 if self.cudnn_backend.is_none() {
@@ -2229,11 +2275,12 @@ impl GpuBackend {
                         }
                     }
                 }
+                let mut vh = self.vhandles.lock().unwrap();
                 Ok(self
                     .cudnn_backend
                     .as_ref()
                     .unwrap()
-                    .dispatch(func, args, &mut self.vhandles))
+                    .dispatch(func, args, &mut vh))
             }
             LIB_CUBLASLT => {
                 if self.cublaslt.is_none() {
@@ -2245,12 +2292,12 @@ impl GpuBackend {
                         }
                     }
                 }
-                Ok(self.cublaslt.as_ref().unwrap().dispatch(
-                    func,
-                    args,
-                    &mut self.vhandles,
-                    streams,
-                ))
+                let mut vh = self.vhandles.lock().unwrap();
+                Ok(self
+                    .cublaslt
+                    .as_ref()
+                    .unwrap()
+                    .dispatch(func, args, &mut vh, streams))
             }
             LIB_CUDNN_BN => {
                 if self.cudnn_bn.is_none() {
@@ -2262,11 +2309,12 @@ impl GpuBackend {
                         }
                     }
                 }
+                let vh = self.vhandles.lock().unwrap();
                 Ok(self
                     .cudnn_bn
                     .as_ref()
                     .unwrap()
-                    .dispatch(func, args, &self.vhandles))
+                    .dispatch(func, args, &vh))
             }
             _ => Err(super::CUDA_ERROR_NOT_FOUND),
         }
@@ -2310,5 +2358,63 @@ fn zc_trace_segments(dir: &str, segments: &[(u64, u64)]) {
             "[zc-host] {dir} gpa memcpy: {total} bytes in {} segment(s)",
             segments.len()
         ));
+    }
+}
+
+#[cfg(test)]
+mod handoff_tests {
+    use super::handoff_register;
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    fn map(pairs: &[(u64, u64)]) -> Arc<Mutex<HashMap<u64, u64>>> {
+        Arc::new(Mutex::new(pairs.iter().copied().collect()))
+    }
+
+    // A fork clone (fresh, empty handle map) resuming its parent's token adopts
+    // the parent's live descriptor map — the mechanism that keeps a clone's
+    // cuBLAS/cuDNN handles valid after it reconnects.
+    #[test]
+    fn clone_adopts_parent_handle_map() {
+        // Parent registers (fresh), then creates a descriptor after the fact —
+        // the clone must see it because the registry holds the live map.
+        let parent = map(&[]);
+        let ptoken = handoff_register(&parent, 0);
+        assert_ne!(ptoken, 0, "a session gets a non-zero lineage token");
+        parent.lock().unwrap().insert(1 << 63, 0xdead_beef);
+
+        let clone = map(&[]);
+        let ctoken = handoff_register(&clone, ptoken);
+        assert_ne!(ctoken, ptoken, "the clone gets its own token");
+        assert_eq!(
+            clone.lock().unwrap().get(&(1 << 63)).copied(),
+            Some(0xdead_beef),
+            "clone adopted the parent's descriptor"
+        );
+
+        // The clone's own later descriptors do not leak back into the parent.
+        clone.lock().unwrap().insert((1 << 63) | 2, 0x1234);
+        assert!(
+            !parent.lock().unwrap().contains_key(&((1 << 63) | 2)),
+            "clone and parent maps are independent copies"
+        );
+    }
+
+    // Resuming a token whose session has closed (its map dropped) is not an
+    // error — the clone simply starts empty instead of faulting.
+    #[test]
+    fn resuming_a_dead_token_is_harmless() {
+        let dead_token = {
+            let gone = map(&[(1 << 63, 7)]);
+            handoff_register(&gone, 0)
+            // `gone` drops here; the registry's Weak can no longer upgrade.
+        };
+        let clone = map(&[]);
+        let t = handoff_register(&clone, dead_token);
+        assert_ne!(t, 0);
+        assert!(
+            clone.lock().unwrap().is_empty(),
+            "no parent to adopt → empty map, no panic"
+        );
     }
 }

--- a/crates/smolvm-cuda/src/host/gpu.rs
+++ b/crates/smolvm-cuda/src/host/gpu.rs
@@ -438,9 +438,8 @@ fn chk(code: CuResultCode) -> CuResult<()> {
 /// clone's fresh connection adopt a snapshot of its (frozen) parent's handle
 /// map — see [`GpuBackend::begin_session`].
 type VhMap = std::sync::Mutex<std::collections::HashMap<u64, u64>>;
-static HANDOFF: std::sync::Mutex<
-    Option<std::collections::HashMap<u64, std::sync::Weak<VhMap>>>,
-> = std::sync::Mutex::new(None);
+static HANDOFF: std::sync::Mutex<Option<std::collections::HashMap<u64, std::sync::Weak<VhMap>>>> =
+    std::sync::Mutex::new(None);
 
 fn next_lineage_token() -> u64 {
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -2310,11 +2309,7 @@ impl GpuBackend {
                     }
                 }
                 let vh = self.vhandles.lock().unwrap();
-                Ok(self
-                    .cudnn_bn
-                    .as_ref()
-                    .unwrap()
-                    .dispatch(func, args, &vh))
+                Ok(self.cudnn_bn.as_ref().unwrap().dispatch(func, args, &vh))
             }
             _ => Err(super::CUDA_ERROR_NOT_FOUND),
         }

--- a/crates/smolvm-cuda/src/proto.rs
+++ b/crates/smolvm-cuda/src/proto.rs
@@ -1153,9 +1153,16 @@ pub fn decode_request(payload: &[u8]) -> io::Result<Request> {
     let mut c = Cur::new(payload);
     let op = Op::from_u8(c.u8()?).ok_or_else(bad)?;
     Ok(match op {
+        // Decode Init leniently so a *shorter* Init from an older shim still
+        // yields a Request rather than a decode error. A stale shim would
+        // otherwise have its whole connection dropped as a "malformed message",
+        // hiding the real cause; decoding here lets the proto_hash check reject
+        // it *loudly* ("PROTOCOL MISMATCH … rebuild and restage both"). Missing
+        // fields default to 0 — proto_hash is never 0 in practice, so an Init too
+        // short to even carry a hash still mismatches and is rejected.
         Op::Init => Request::Init {
-            proto_hash: c.u64()?,
-            resume_token: c.u64()?,
+            proto_hash: c.u64().unwrap_or(0),
+            resume_token: c.u64().unwrap_or(0),
         },
         Op::DeviceGetCount => Request::DeviceGetCount,
         Op::DeviceGetName => Request::DeviceGetName { device: c.i32()? },
@@ -1573,6 +1580,49 @@ mod tests {
             ],
         });
         roundtrip(Request::CtxSynchronize);
+    }
+
+    // A stale shim sends a shorter Init (older wire format). It must still
+    // *decode* — with missing fields defaulting to 0 — so the host's proto_hash
+    // check can reject it loudly, rather than the frame failing to decode and
+    // the connection being silently dropped as "malformed" (which hid the real
+    // version-skew cause during the torch bring-up debugging).
+    #[test]
+    fn short_init_decodes_for_loud_rejection() {
+        // Full-length Init (current format).
+        let full = decode_request(&encode_request(&Request::Init {
+            proto_hash: 0xabcd,
+            resume_token: 7,
+        }))
+        .expect("full Init decodes");
+        assert_eq!(
+            full,
+            Request::Init {
+                proto_hash: 0xabcd,
+                resume_token: 7
+            }
+        );
+
+        // Older shim: op + proto_hash only (no resume_token) → resume_token = 0.
+        let mut short = vec![Op::Init as u8];
+        short.extend_from_slice(&0xabcdu64.to_le_bytes());
+        assert_eq!(
+            decode_request(&short).expect("short Init still decodes"),
+            Request::Init {
+                proto_hash: 0xabcd,
+                resume_token: 0
+            }
+        );
+
+        // Pre-handshake shim: just the op byte → proto_hash = 0 (never a real
+        // hash, so it will mismatch and be rejected loudly).
+        assert_eq!(
+            decode_request(&[Op::Init as u8]).expect("bare Init still decodes"),
+            Request::Init {
+                proto_hash: 0,
+                resume_token: 0
+            }
+        );
     }
 
     #[test]

--- a/crates/smolvm-cuda/src/proto.rs
+++ b/crates/smolvm-cuda/src/proto.rs
@@ -205,8 +205,13 @@ impl Op {
 pub enum Request {
     /// Connect handshake. `proto_hash` is the client's wire fingerprint
     /// (`crate::PROTO_HASH`); the host rejects a mismatch (stale binary).
+    /// `resume_token` is 0 for a fresh session, or a token returned by a prior
+    /// `Init` to adopt that (frozen) session's library handle map — this is how
+    /// a forked VM clone reconnects and keeps using its parent's cuBLAS/cuDNN
+    /// descriptors. The response's `Handle` carries this session's own token.
     Init {
         proto_hash: u64,
+        resume_token: u64,
     },
     DeviceGetCount,
     DeviceGetName {
@@ -688,9 +693,13 @@ pub fn read_msg<R: Read>(r: &mut R) -> io::Result<Option<Vec<u8>>> {
 pub fn encode_request(req: &Request) -> Vec<u8> {
     let mut b = Vec::new();
     match req {
-        Request::Init { proto_hash } => {
+        Request::Init {
+            proto_hash,
+            resume_token,
+        } => {
             w_u8(&mut b, Op::Init as u8);
             w_u64(&mut b, *proto_hash);
+            w_u64(&mut b, *resume_token);
         }
         Request::DeviceGetCount => w_u8(&mut b, Op::DeviceGetCount as u8),
         Request::DeviceGetName { device } => {
@@ -1146,6 +1155,7 @@ pub fn decode_request(payload: &[u8]) -> io::Result<Request> {
     Ok(match op {
         Op::Init => Request::Init {
             proto_hash: c.u64()?,
+            resume_token: c.u64()?,
         },
         Op::DeviceGetCount => Request::DeviceGetCount,
         Op::DeviceGetName => Request::DeviceGetName { device: c.i32()? },
@@ -1449,6 +1459,8 @@ pub fn decode_response(op: Op, payload: &[u8]) -> io::Result<(i32, Response)> {
         | Op::FuncGetAttribute => Response::Count(c.i32()?),
         Op::DeviceGetName => Response::Name(c.string()?),
         Op::DeviceTotalMem => Response::Bytes(c.u64()?),
+        // Init hands back this session's lineage token (for fork-clone handoff).
+        Op::Init => Response::Handle(c.u64()?),
         Op::CtxCreate | Op::PrimaryCtxRetain => Response::Handle(c.u64()?),
         Op::ModuleLoadData | Op::ModuleGetFunction => Response::Handle(c.u64()?),
         Op::StreamCreate | Op::EventCreate => Response::Handle(c.u64()?),
@@ -1522,6 +1534,7 @@ mod tests {
     fn request_roundtrips() {
         roundtrip(Request::Init {
             proto_hash: 0xdeadbeef,
+            resume_token: 0x1234,
         });
         roundtrip(Request::DeviceGetCount);
         roundtrip(Request::DeviceGetName { device: 3 });

--- a/crates/smolvm-cuda/src/proto.rs
+++ b/crates/smolvm-cuda/src/proto.rs
@@ -1484,8 +1484,7 @@ pub fn decode_response(op: Op, payload: &[u8]) -> io::Result<(i32, Response)> {
         Op::CublasCreate => Response::Handle(c.u64()?),
         Op::LibCall => Response::LibResult(c.i32()?, c.bytes()?),
         Op::EventElapsedTime => Response::Millis(f32::from_bits(c.u32()?)),
-        Op::Init
-        | Op::StreamBeginCapture
+        Op::StreamBeginCapture
         | Op::GraphLaunch
         | Op::GraphExecDestroy
         | Op::GraphDestroy

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -428,15 +428,34 @@ fn bring_up_client(resume_token: u64) -> Result<(Client<Stream>, u64, i32), c_in
     let fd = stream.raw_fd();
     #[cfg(not(unix))]
     let fd = -1;
+    let trace = std::env::var_os("SHIM_TRACE").is_some();
+    if trace {
+        eprintln!("[shim] bring_up: connected fd={fd}");
+    }
     let mut client = Client::new(stream);
-    let token = client
-        .init(resume_token)
-        .map_err(|_| CUDA_ERROR_INITIALIZATION)?;
-    let _ = client
-        .primary_ctx_retain(0)
-        .map_err(|_| CUDA_ERROR_INITIALIZATION)?;
+    let token = client.init(resume_token).map_err(|e| {
+        if trace {
+            eprintln!("[shim] bring_up: init FAILED {e:?}");
+        }
+        CUDA_ERROR_INITIALIZATION
+    })?;
+    if trace {
+        eprintln!("[shim] bring_up: init ok token={token}");
+    }
+    client.primary_ctx_retain(0).map_err(|e| {
+        if trace {
+            eprintln!("[shim] bring_up: primary_ctx_retain FAILED {e:?}");
+        }
+        CUDA_ERROR_INITIALIZATION
+    })?;
+    if trace {
+        eprintln!("[shim] bring_up: primary_ctx_retain ok");
+    }
     if try_ring {
         ring_try_setup(&mut client); // best-effort; socket mode on failure
+    }
+    if trace {
+        eprintln!("[shim] bring_up: complete");
     }
     Ok((client, token, fd))
 }

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -508,7 +508,12 @@ fn with_client<T>(
                         st.conn_token
                     );
                 }
-                let (client, token, fd) = bring_up_client(st.conn_token)?;
+                // Carry the not-yet-sent deferred pipeline across the reconnect
+                // so buffered quiet ops (e.g. torch's queued matmuls) replay on
+                // the fresh connection instead of being dropped.
+                let (wbuf, deferred, sticky) = st.client.take_pending();
+                let (mut client, token, fd) = bring_up_client(st.conn_token)?;
+                client.restore_pending(wbuf, deferred, sticky);
                 st.client = client;
                 st.conn_token = token;
                 st.conn_pid = pid;

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -162,6 +162,13 @@ struct ShimState {
     /// `cudaStreamGetCaptureInfo` — PyTorch's allocator calls them constantly)
     /// answer locally instead of round-tripping.
     capture: Option<(u64, u64)>,
+    /// PID that opened `client`. If the process forks (or a snapshotted VM is
+    /// restored as a clone), the inherited socket fd + ring mapping belong to
+    /// the parent and are dead here; a mismatch triggers a transparent
+    /// reconnect. The registries above survive because every connection retains
+    /// the same device primary context, so their raw module / function / device
+    /// handles stay valid across the new connection.
+    conn_pid: i32,
 }
 
 static STATE: Mutex<Option<ShimState>> = Mutex::new(None);
@@ -353,34 +360,56 @@ fn ring_try_setup(client: &mut Client<Stream>) {
     }
 }
 
+/// Open a fresh transport, run the init handshake, retain device 0's primary
+/// context, and (best-effort) set up the shared-memory rings. Used for the
+/// first connection and to re-establish one after a fork/clone.
+fn bring_up_client() -> Result<Client<Stream>, c_int> {
+    let stream = connect()?;
+    #[cfg(target_os = "linux")]
+    let try_ring = matches!(stream, Stream::Vsock(_))
+        && std::env::var("SMOLVM_CUDA_RING").as_deref() != Ok("0");
+    #[cfg(not(target_os = "linux"))]
+    let try_ring = false;
+    let mut client = Client::new(stream);
+    client.init().map_err(|_| CUDA_ERROR_INITIALIZATION)?;
+    let _ = client
+        .primary_ctx_retain(0)
+        .map_err(|_| CUDA_ERROR_INITIALIZATION)?;
+    if try_ring {
+        ring_try_setup(&mut client); // best-effort; socket mode on failure
+    }
+    Ok(client)
+}
+
 fn with_client<T>(
     f: impl FnOnce(&mut Client<Stream>) -> Result<T, CudaRpcError>,
 ) -> Result<T, c_int> {
     let mut guard = STATE.lock().map_err(|_| CUDA_ERROR_UNKNOWN)?;
-    if guard.is_none() {
-        let stream = connect()?;
-        #[cfg(target_os = "linux")]
-        let try_ring = matches!(stream, Stream::Vsock(_))
-            && std::env::var("SMOLVM_CUDA_RING").as_deref() != Ok("0");
-        #[cfg(not(target_os = "linux"))]
-        let try_ring = false;
-        let mut client = Client::new(stream);
-        client.init().map_err(|_| CUDA_ERROR_INITIALIZATION)?;
-        let _ = client
-            .primary_ctx_retain(0)
-            .map_err(|_| CUDA_ERROR_INITIALIZATION)?;
-        if try_ring {
-            ring_try_setup(&mut client); // best-effort; socket mode on failure
+    let pid = unsafe { libc::getpid() };
+    match guard.as_mut() {
+        None => {
+            let client = bring_up_client()?;
+            *guard = Some(ShimState {
+                client,
+                initialized: true,
+                modules: HashMap::new(),
+                funcs: HashMap::new(),
+                host_allocs: HashMap::new(),
+                dev_allocs: std::collections::BTreeMap::new(),
+                capture: None,
+                conn_pid: pid,
+            });
         }
-        *guard = Some(ShimState {
-            client,
-            initialized: true,
-            modules: HashMap::new(),
-            funcs: HashMap::new(),
-            host_allocs: HashMap::new(),
-            dev_allocs: std::collections::BTreeMap::new(),
-            capture: None,
-        });
+        // We forked (in-guest process fork, or a snapshotted VM restored as a
+        // clone): the inherited connection is dead. Re-establish it in place,
+        // keeping the registries — their handles are still valid because the
+        // reconnected session retains the same device primary context.
+        Some(st) if st.conn_pid != pid => {
+            st.client = bring_up_client()?;
+            st.conn_pid = pid;
+            st.capture = None; // any in-flight capture belonged to the parent
+        }
+        Some(_) => {}
     }
     let st = guard.as_mut().ok_or(CUDA_ERROR_INITIALIZATION)?;
     debug_assert!(st.initialized);

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -219,6 +219,11 @@ struct ShimState {
     /// clone (same pid, so the pid check can't fire) inherits a dead socket;
     /// the peek catches it and triggers a reconnect. -1 = no fd / skip.
     conn_fd: i32,
+    /// Set when an op just hit a transport error: the peek can miss a freshly
+    /// severed connection (the kernel hasn't processed the reset yet on the
+    /// first post-fork call), so `with_client_retrying` forces an unconditional
+    /// reconnect on its retry instead of trusting the peek.
+    force_reconnect: bool,
 }
 
 static STATE: Mutex<Option<ShimState>> = Mutex::new(None);
@@ -479,6 +484,7 @@ fn with_client<T>(
                 conn_pid: pid,
                 conn_token: token,
                 conn_fd: fd,
+                force_reconnect: false,
             });
         }
         // We forked and the inherited connection is dead — either an in-guest
@@ -494,10 +500,11 @@ fn with_client<T>(
             let severed = st.conn_fd >= 0 && !conn_alive(st.conn_fd);
             #[cfg(not(unix))]
             let severed = false;
-            if forked || severed {
+            let forced = st.force_reconnect;
+            if forked || severed || forced {
                 if std::env::var_os("SHIM_TRACE").is_some() {
                     eprintln!(
-                        "[shim] reconnect (forked={forked} severed={severed}) resume_token={}",
+                        "[shim] reconnect (forked={forked} severed={severed} forced={forced}) resume_token={}",
                         st.conn_token
                     );
                 }
@@ -506,6 +513,7 @@ fn with_client<T>(
                 st.conn_token = token;
                 st.conn_pid = pid;
                 st.conn_fd = fd;
+                st.force_reconnect = false;
                 st.capture = None; // any in-flight capture belonged to the parent
             }
         }
@@ -515,6 +523,27 @@ fn with_client<T>(
     // SAFETY-free: split the borrow so `f` gets the client while we keep the lock.
     let client = &mut st.client;
     f(client).map_err(map_err)
+}
+
+/// Like [`with_client`], but transparently retries once on a transport error.
+/// After a VM-fork the clone's inherited connection is dead, but the pre-call
+/// liveness peek can miss it on the very first call (the kernel hasn't surfaced
+/// the reset yet) — so that call fails with a transport error (`999`). This
+/// forces a reconnect and reruns `f`, which then reads from the reconnected
+/// (shared-context) session. Only for idempotent ops (reads, syncs, queries):
+/// `f` runs twice, so it must have no side effects on the first, failed attempt
+/// — which holds here because a transport failure means the op never reached the
+/// host. Takes `Fn` (not `FnOnce`) precisely so it can run twice.
+fn with_client_retrying<T>(
+    f: impl Fn(&mut Client<Stream>) -> Result<T, CudaRpcError>,
+) -> Result<T, c_int> {
+    match with_client(&f) {
+        Err(CUDA_ERROR_UNKNOWN) => {
+            mark_force_reconnect();
+            with_client(&f)
+        }
+        other => other,
+    }
 }
 
 /// Run `f` with the full state (client + registries) under the lock.
@@ -538,7 +567,7 @@ unsafe fn out<T>(p: *mut T, v: T) -> c_int {
 
 #[no_mangle]
 pub extern "C" fn cudaGetDeviceCount(count: *mut c_int) -> c_int {
-    set_last(match with_client(|c| c.device_get_count()) {
+    set_last(match with_client_retrying(|c| c.device_get_count()) {
         Ok(n) => unsafe { out(count, n) },
         Err(e) => {
             // A CUDA program treats "0 devices" as recoverable; surface the count.
@@ -565,7 +594,7 @@ pub extern "C" fn cudaGetDevice(device: *mut c_int) -> c_int {
 
 #[no_mangle]
 pub extern "C" fn cudaDeviceSynchronize() -> c_int {
-    set_last(match with_client(|c| c.ctx_synchronize()) {
+    set_last(match with_client_retrying(|c| c.ctx_synchronize()) {
         Ok(()) => CUDA_SUCCESS,
         Err(e) => e,
     })
@@ -986,11 +1015,29 @@ fn resolve_kind(s: &ShimState, dst: *const c_void, src: *const c_void, kind: c_i
 
 fn do_memcpy(dst: *mut c_void, src: *const c_void, n: usize, kind: c_int, stream: u64) -> c_int {
     let dbg = std::env::var_os("SMOLVM_CUDA_TRACE_MEMCPY").is_some();
-    let r = do_memcpy_inner(dst, src, n, kind, stream);
+    let mut r = do_memcpy_inner(dst, src, n, kind, stream);
+    // A transport error means the copy never reached the host (e.g. a VM-fork
+    // clone's inherited connection is dead and the pre-call peek missed it on
+    // this first call). Force a reconnect and retry once — the copy is safe to
+    // repeat because it didn't run.
+    if r == CUDA_ERROR_UNKNOWN {
+        mark_force_reconnect();
+        r = do_memcpy_inner(dst, src, n, kind, stream);
+    }
     if dbg && r != CUDA_SUCCESS {
         eprintln!("[memcpy-err] kind={kind} n={n} -> {r}");
     }
     r
+}
+
+/// Force the next `with_client` to rebuild the connection (used after a
+/// transport error whose op is safe to retry).
+fn mark_force_reconnect() {
+    if let Ok(mut guard) = STATE.lock() {
+        if let Some(st) = guard.as_mut() {
+            st.force_reconnect = true;
+        }
+    }
 }
 
 fn do_memcpy_inner(
@@ -1175,7 +1222,7 @@ pub extern "C" fn cudaStreamDestroy(stream: *mut c_void) -> c_int {
 
 #[no_mangle]
 pub extern "C" fn cudaStreamSynchronize(stream: *mut c_void) -> c_int {
-    set_last(match with_client(|c| c.stream_synchronize(stream as u64)) {
+    set_last(match with_client_retrying(|c| c.stream_synchronize(stream as u64)) {
         Ok(()) => CUDA_SUCCESS,
         Err(e) => e,
     })
@@ -1191,7 +1238,7 @@ pub extern "C" fn cudaLaunchHostFunc(
     func: Option<unsafe extern "C" fn(*mut c_void)>,
     user_data: *mut c_void,
 ) -> c_int {
-    let rc = with_client(|c| c.stream_synchronize(stream as u64));
+    let rc = with_client_retrying(|c| c.stream_synchronize(stream as u64));
     if let Err(e) = rc {
         return set_last(e);
     }
@@ -1288,7 +1335,7 @@ pub extern "C" fn cudaDeviceGetAttribute(value: *mut c_int, attr: c_int, device:
 
 #[no_mangle]
 pub extern "C" fn cudaMemGetInfo(free: *mut usize, total: *mut usize) -> c_int {
-    set_last(match with_client(|c| c.mem_get_info()) {
+    set_last(match with_client_retrying(|c| c.mem_get_info()) {
         Ok((f, t)) => unsafe {
             let _ = out(free, f as usize);
             out(total, t as usize)
@@ -1685,7 +1732,7 @@ pub extern "C" fn cudaEventQuery(event: *mut c_void) -> c_int {
     // blocks are safe to reuse. Always answering "complete" caused premature
     // reuse (ILLEGAL_ADDRESS) once work really ran on side streams. NotReady
     // (600) latches into last-error exactly like real cudart; torch clears it.
-    set_last(match with_client(|c| c.event_query(event as u64)) {
+    set_last(match with_client_retrying(|c| c.event_query(event as u64)) {
         Ok(code) => code,
         Err(e) => e,
     })
@@ -1736,7 +1783,7 @@ pub extern "C" fn cudaStreamWaitEvent(
 #[no_mangle]
 pub extern "C" fn cudaStreamQuery(stream: *mut c_void) -> c_int {
     // Honest completion status (0 or 600-NotReady), same as cudaEventQuery.
-    set_last(match with_client(|c| c.stream_query(stream as u64)) {
+    set_last(match with_client_retrying(|c| c.stream_query(stream as u64)) {
         Ok(code) => code,
         Err(e) => e,
     })
@@ -1964,7 +2011,7 @@ pub extern "C" fn cudaStreamAddCallback(
     // The callback must run after all prior work on `stream`. Under the
     // deferred pipeline that work may not have executed host-side yet, so
     // synchronize first — invoking it immediately let it observe stale results.
-    if let Err(e) = with_client(|c| c.stream_synchronize(stream as u64)) {
+    if let Err(e) = with_client_retrying(|c| c.stream_synchronize(stream as u64)) {
         return set_last(e);
     }
     if let Some(cb) = callback {

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -169,6 +169,11 @@ struct ShimState {
     /// the same device primary context, so their raw module / function / device
     /// handles stay valid across the new connection.
     conn_pid: i32,
+    /// Lineage token the host assigned this session. Inherited by a fork clone
+    /// (it lives in this CoW guest memory), so on reconnect the clone replays it
+    /// as the resume token and the host seeds the clone's fresh connection with
+    /// the parent's cuBLAS/cuDNN handle map. 0 = host has no handoff support.
+    conn_token: u64,
 }
 
 static STATE: Mutex<Option<ShimState>> = Mutex::new(None);
@@ -360,10 +365,12 @@ fn ring_try_setup(client: &mut Client<Stream>) {
     }
 }
 
-/// Open a fresh transport, run the init handshake, retain device 0's primary
-/// context, and (best-effort) set up the shared-memory rings. Used for the
-/// first connection and to re-establish one after a fork/clone.
-fn bring_up_client() -> Result<Client<Stream>, c_int> {
+/// Open a fresh transport, run the init handshake (adopting `resume_token`'s
+/// session handle map if non-zero), retain device 0's primary context, and
+/// (best-effort) set up the shared-memory rings. Used for the first connection
+/// and to re-establish one after a fork/clone. Returns the client and the
+/// lineage token the host assigned this session.
+fn bring_up_client(resume_token: u64) -> Result<(Client<Stream>, u64), c_int> {
     let stream = connect()?;
     #[cfg(target_os = "linux")]
     let try_ring = matches!(stream, Stream::Vsock(_))
@@ -371,14 +378,16 @@ fn bring_up_client() -> Result<Client<Stream>, c_int> {
     #[cfg(not(target_os = "linux"))]
     let try_ring = false;
     let mut client = Client::new(stream);
-    client.init().map_err(|_| CUDA_ERROR_INITIALIZATION)?;
+    let token = client
+        .init(resume_token)
+        .map_err(|_| CUDA_ERROR_INITIALIZATION)?;
     let _ = client
         .primary_ctx_retain(0)
         .map_err(|_| CUDA_ERROR_INITIALIZATION)?;
     if try_ring {
         ring_try_setup(&mut client); // best-effort; socket mode on failure
     }
-    Ok(client)
+    Ok((client, token))
 }
 
 fn with_client<T>(
@@ -388,7 +397,7 @@ fn with_client<T>(
     let pid = unsafe { libc::getpid() };
     match guard.as_mut() {
         None => {
-            let client = bring_up_client()?;
+            let (client, token) = bring_up_client(0)?;
             *guard = Some(ShimState {
                 client,
                 initialized: true,
@@ -398,14 +407,25 @@ fn with_client<T>(
                 dev_allocs: std::collections::BTreeMap::new(),
                 capture: None,
                 conn_pid: pid,
+                conn_token: token,
             });
         }
         // We forked (in-guest process fork, or a snapshotted VM restored as a
         // clone): the inherited connection is dead. Re-establish it in place,
-        // keeping the registries — their handles are still valid because the
-        // reconnected session retains the same device primary context.
+        // resuming from the parent's lineage token so the host seeds this
+        // connection with the parent's library handle map. The registries here
+        // stay valid because the reconnected session retains the same device
+        // primary context.
         Some(st) if st.conn_pid != pid => {
-            st.client = bring_up_client()?;
+            if std::env::var_os("SHIM_TRACE").is_some() {
+                eprintln!(
+                    "[shim] fork detected pid {}->{}, reconnect resume_token={}",
+                    st.conn_pid, pid, st.conn_token
+                );
+            }
+            let (client, token) = bring_up_client(st.conn_token)?;
+            st.client = client;
+            st.conn_token = token;
             st.conn_pid = pid;
             st.capture = None; // any in-flight capture belonged to the parent
         }

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -1227,10 +1227,12 @@ pub extern "C" fn cudaStreamDestroy(stream: *mut c_void) -> c_int {
 
 #[no_mangle]
 pub extern "C" fn cudaStreamSynchronize(stream: *mut c_void) -> c_int {
-    set_last(match with_client_retrying(|c| c.stream_synchronize(stream as u64)) {
-        Ok(()) => CUDA_SUCCESS,
-        Err(e) => e,
-    })
+    set_last(
+        match with_client_retrying(|c| c.stream_synchronize(stream as u64)) {
+            Ok(()) => CUDA_SUCCESS,
+            Err(e) => e,
+        },
+    )
 }
 
 /// `cudaLaunchHostFunc` — a host callback that must run AFTER all prior work on
@@ -1737,10 +1739,12 @@ pub extern "C" fn cudaEventQuery(event: *mut c_void) -> c_int {
     // blocks are safe to reuse. Always answering "complete" caused premature
     // reuse (ILLEGAL_ADDRESS) once work really ran on side streams. NotReady
     // (600) latches into last-error exactly like real cudart; torch clears it.
-    set_last(match with_client_retrying(|c| c.event_query(event as u64)) {
-        Ok(code) => code,
-        Err(e) => e,
-    })
+    set_last(
+        match with_client_retrying(|c| c.event_query(event as u64)) {
+            Ok(code) => code,
+            Err(e) => e,
+        },
+    )
 }
 #[no_mangle]
 pub extern "C" fn cudaEventElapsedTime(
@@ -1788,10 +1792,12 @@ pub extern "C" fn cudaStreamWaitEvent(
 #[no_mangle]
 pub extern "C" fn cudaStreamQuery(stream: *mut c_void) -> c_int {
     // Honest completion status (0 or 600-NotReady), same as cudaEventQuery.
-    set_last(match with_client_retrying(|c| c.stream_query(stream as u64)) {
-        Ok(code) => code,
-        Err(e) => e,
-    })
+    set_last(
+        match with_client_retrying(|c| c.stream_query(stream as u64)) {
+            Ok(code) => code,
+            Err(e) => e,
+        },
+    )
 }
 // ---- CUDA graphs -------------------------------------------------------------
 // Capture happens on the HOST driver: Begin/End forward, and every launch /

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -106,6 +106,47 @@ impl Write for Stream {
     }
 }
 
+#[cfg(unix)]
+impl Stream {
+    fn raw_fd(&self) -> std::os::unix::io::RawFd {
+        use std::os::unix::io::AsRawFd;
+        match self {
+            #[cfg(target_os = "linux")]
+            Stream::Vsock(s) => s.as_raw_fd(),
+            Stream::Tcp(s) => s.as_raw_fd(),
+            Stream::Unix(s) => s.as_raw_fd(),
+        }
+    }
+}
+
+/// Best-effort liveness of the host connection via a non-blocking, non-consuming
+/// `MSG_PEEK`. A VM-fork clone inherits a socket whose host peer is gone; the
+/// guest kernel resets it, so the peek sees EOF/ECONNRESET and we know to
+/// reconnect. Returns `true` when the connection is usable (data pending, or
+/// simply no data yet), `false` on a clean close or fatal socket error. Peeking
+/// is safe in shared-memory-ring mode too: pending doorbell bytes read as
+/// "alive" and stay queued for the real read.
+#[cfg(unix)]
+fn conn_alive(fd: std::os::unix::io::RawFd) -> bool {
+    let mut b = [0u8; 1];
+    let n = unsafe {
+        libc::recv(
+            fd,
+            b.as_mut_ptr() as *mut libc::c_void,
+            1,
+            libc::MSG_PEEK | libc::MSG_DONTWAIT,
+        )
+    };
+    if n > 0 {
+        true
+    } else if n == 0 {
+        false // orderly shutdown by the peer
+    } else {
+        let e = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+        e == libc::EAGAIN || e == libc::EWOULDBLOCK
+    }
+}
+
 fn connect() -> Result<Stream, c_int> {
     let spec = std::env::var("SMOLVM_CUDA_RPC").unwrap_or_default();
     if let Some(addr) = spec.strip_prefix("tcp:") {
@@ -174,6 +215,10 @@ struct ShimState {
     /// as the resume token and the host seeds the clone's fresh connection with
     /// the parent's cuBLAS/cuDNN handle map. 0 = host has no handoff support.
     conn_token: u64,
+    /// Raw fd of `client`'s socket, for the pre-call liveness peek. A VM-fork
+    /// clone (same pid, so the pid check can't fire) inherits a dead socket;
+    /// the peek catches it and triggers a reconnect. -1 = no fd / skip.
+    conn_fd: i32,
 }
 
 static STATE: Mutex<Option<ShimState>> = Mutex::new(None);
@@ -370,13 +415,19 @@ fn ring_try_setup(client: &mut Client<Stream>) {
 /// (best-effort) set up the shared-memory rings. Used for the first connection
 /// and to re-establish one after a fork/clone. Returns the client and the
 /// lineage token the host assigned this session.
-fn bring_up_client(resume_token: u64) -> Result<(Client<Stream>, u64), c_int> {
+fn bring_up_client(resume_token: u64) -> Result<(Client<Stream>, u64, i32), c_int> {
     let stream = connect()?;
     #[cfg(target_os = "linux")]
     let try_ring = matches!(stream, Stream::Vsock(_))
         && std::env::var("SMOLVM_CUDA_RING").as_deref() != Ok("0");
     #[cfg(not(target_os = "linux"))]
     let try_ring = false;
+    // Capture the socket fd for the liveness check before `Client` takes the
+    // stream. Rings keep this same socket (for doorbells), so it stays valid.
+    #[cfg(unix)]
+    let fd = stream.raw_fd();
+    #[cfg(not(unix))]
+    let fd = -1;
     let mut client = Client::new(stream);
     let token = client
         .init(resume_token)
@@ -387,7 +438,7 @@ fn bring_up_client(resume_token: u64) -> Result<(Client<Stream>, u64), c_int> {
     if try_ring {
         ring_try_setup(&mut client); // best-effort; socket mode on failure
     }
-    Ok((client, token))
+    Ok((client, token, fd))
 }
 
 fn with_client<T>(
@@ -397,7 +448,7 @@ fn with_client<T>(
     let pid = unsafe { libc::getpid() };
     match guard.as_mut() {
         None => {
-            let (client, token) = bring_up_client(0)?;
+            let (client, token, fd) = bring_up_client(0)?;
             *guard = Some(ShimState {
                 client,
                 initialized: true,
@@ -408,28 +459,37 @@ fn with_client<T>(
                 capture: None,
                 conn_pid: pid,
                 conn_token: token,
+                conn_fd: fd,
             });
         }
-        // We forked (in-guest process fork, or a snapshotted VM restored as a
-        // clone): the inherited connection is dead. Re-establish it in place,
-        // resuming from the parent's lineage token so the host seeds this
-        // connection with the parent's library handle map. The registries here
-        // stay valid because the reconnected session retains the same device
+        // We forked and the inherited connection is dead — either an in-guest
+        // process fork (pid changes) or a snapshotted VM restored as a clone
+        // (pid is preserved, so the socket peek is what catches it). Either way
+        // re-establish in place, resuming the parent's lineage token so the host
+        // seeds this connection with the parent's library handle map. The
+        // registries stay valid: the reconnected session retains the same device
         // primary context.
-        Some(st) if st.conn_pid != pid => {
-            if std::env::var_os("SHIM_TRACE").is_some() {
-                eprintln!(
-                    "[shim] fork detected pid {}->{}, reconnect resume_token={}",
-                    st.conn_pid, pid, st.conn_token
-                );
+        Some(st) => {
+            let forked = st.conn_pid != pid;
+            #[cfg(unix)]
+            let severed = st.conn_fd >= 0 && !conn_alive(st.conn_fd);
+            #[cfg(not(unix))]
+            let severed = false;
+            if forked || severed {
+                if std::env::var_os("SHIM_TRACE").is_some() {
+                    eprintln!(
+                        "[shim] reconnect (forked={forked} severed={severed}) resume_token={}",
+                        st.conn_token
+                    );
+                }
+                let (client, token, fd) = bring_up_client(st.conn_token)?;
+                st.client = client;
+                st.conn_token = token;
+                st.conn_pid = pid;
+                st.conn_fd = fd;
+                st.capture = None; // any in-flight capture belonged to the parent
             }
-            let (client, token) = bring_up_client(st.conn_token)?;
-            st.client = client;
-            st.conn_token = token;
-            st.conn_pid = pid;
-            st.capture = None; // any in-flight capture belonged to the parent
         }
-        Some(_) => {}
     }
     let st = guard.as_mut().ok_or(CUDA_ERROR_INITIALIZATION)?;
     debug_assert!(st.initialized);

--- a/crates/smolvm-nvml-shim/Cargo.toml
+++ b/crates/smolvm-nvml-shim/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "smolvm-nvml-shim"
+version = "1.5.2"
+edition = "2021"
+description = "Guest-side libnvidia-ml.so.1 drop-in: answers the NVML queries CUDA frameworks (vLLM) use for device detection, backed by the remoted CUDA driver"
+license = "Apache-2.0"
+
+[lib]
+name = "nvidia_ml"
+crate-type = ["cdylib"]
+
+[dependencies]
+libc = "0.2"

--- a/crates/smolvm-nvml-shim/src/lib.rs
+++ b/crates/smolvm-nvml-shim/src/lib.rs
@@ -1,0 +1,295 @@
+//! Guest-side `libnvidia-ml.so.1` drop-in.
+//!
+//! CUDA frameworks — vLLM in particular — detect the GPU and read its memory,
+//! compute capability, name and UUID through **NVML**, not the CUDA driver or
+//! runtime. smolvm remotes the CUDA driver + runtime but not NVML, so without
+//! this shim such frameworks see "no CUDA platform" and refuse to run.
+//!
+//! This implements the small NVML surface they touch and answers it from the
+//! remoted CUDA driver: our `libcuda.so.1` is already loaded in the process, so
+//! its `cuDeviceGet*`/`cuMemGetInfo` are resolvable at runtime via
+//! `dlsym(RTLD_DEFAULT, …)`. Everything degrades to a static fallback when the
+//! driver isn't reachable, so the library is safe to load unconditionally.
+//!
+//! Drop it in where the loader looks for `libnvidia-ml.so.1`.
+
+use std::os::raw::{c_char, c_int, c_uint, c_ulonglong};
+
+// ---- nvmlReturn_t ------------------------------------------------------------
+const NVML_SUCCESS: c_int = 0;
+const NVML_ERROR_INVALID_ARGUMENT: c_int = 2;
+
+// ---- CUdevice attribute ids (driver API) ------------------------------------
+const CU_ATTR_CC_MAJOR: c_int = 75;
+const CU_ATTR_CC_MINOR: c_int = 76;
+
+// ---- CUDA driver resolution (from the already-loaded libcuda.so.1) -----------
+
+/// Resolve a NUL-terminated CUDA Driver symbol from any library loaded in the
+/// process (our LD_PRELOADed `libcuda.so.1`). `None` if CUDA isn't present.
+unsafe fn cu_sym(name: &[u8]) -> Option<*mut std::ffi::c_void> {
+    let p = libc::dlsym(libc::RTLD_DEFAULT, name.as_ptr() as *const c_char);
+    if p.is_null() {
+        None
+    } else {
+        Some(p)
+    }
+}
+
+fn cu_init() {
+    unsafe {
+        if let Some(f) = cu_sym(b"cuInit\0") {
+            let f: extern "C" fn(c_uint) -> c_int = std::mem::transmute(f);
+            let _ = f(0);
+        }
+    }
+}
+
+/// The driver's CUdevice for ordinal `ord` (an int handle, usually == ord).
+unsafe fn cu_device(ord: c_int) -> Option<c_int> {
+    let f = cu_sym(b"cuDeviceGet\0")?;
+    let f: extern "C" fn(*mut c_int, c_int) -> c_int = std::mem::transmute(f);
+    let mut dev: c_int = 0;
+    (f(&mut dev, ord) == 0).then_some(dev)
+}
+
+/// Number of visible CUDA devices, or 1 if the driver can't be asked (we only
+/// ever expose the single remoted GPU anyway).
+fn cu_device_count() -> u32 {
+    unsafe {
+        if let Some(f) = cu_sym(b"cuDeviceGetCount\0") {
+            let f: extern "C" fn(*mut c_int) -> c_int = std::mem::transmute(f);
+            let mut n: c_int = 0;
+            if f(&mut n) == 0 && n > 0 {
+                return n as u32;
+            }
+        }
+    }
+    1
+}
+
+fn cu_device_name(ord: c_int) -> Option<String> {
+    unsafe {
+        let dev = cu_device(ord)?;
+        let f = cu_sym(b"cuDeviceGetName\0")?;
+        let f: extern "C" fn(*mut c_char, c_int, c_int) -> c_int = std::mem::transmute(f);
+        let mut buf = [0i8; 256];
+        (f(buf.as_mut_ptr(), buf.len() as c_int, dev) == 0).then(|| {
+            let cstr = std::ffi::CStr::from_ptr(buf.as_ptr());
+            cstr.to_string_lossy().into_owned()
+        })
+    }
+}
+
+fn cu_total_mem(ord: c_int) -> Option<u64> {
+    unsafe {
+        let dev = cu_device(ord)?;
+        // cuDeviceTotalMem_v2 takes no context (device query only).
+        let f = cu_sym(b"cuDeviceTotalMem_v2\0").or_else(|| cu_sym(b"cuDeviceTotalMem\0"))?;
+        let f: extern "C" fn(*mut usize, c_int) -> c_int = std::mem::transmute(f);
+        let mut bytes: usize = 0;
+        (f(&mut bytes, dev) == 0 && bytes > 0).then_some(bytes as u64)
+    }
+}
+
+/// (free, total) from the current context if one exists; `None` otherwise.
+fn cu_mem_get_info() -> Option<(u64, u64)> {
+    unsafe {
+        let f = cu_sym(b"cuMemGetInfo_v2\0").or_else(|| cu_sym(b"cuMemGetInfo\0"))?;
+        let f: extern "C" fn(*mut usize, *mut usize) -> c_int = std::mem::transmute(f);
+        let (mut free, mut total): (usize, usize) = (0, 0);
+        (f(&mut free, &mut total) == 0 && total > 0).then_some((free as u64, total as u64))
+    }
+}
+
+fn cu_compute_capability(ord: c_int) -> Option<(c_int, c_int)> {
+    unsafe {
+        let dev = cu_device(ord)?;
+        let f = cu_sym(b"cuDeviceGetAttribute\0")?;
+        let f: extern "C" fn(*mut c_int, c_int, c_int) -> c_int = std::mem::transmute(f);
+        let (mut maj, mut min): (c_int, c_int) = (0, 0);
+        let ok = f(&mut maj, CU_ATTR_CC_MAJOR, dev) == 0
+            && f(&mut min, CU_ATTR_CC_MINOR, dev) == 0
+            && maj > 0;
+        ok.then_some((maj, min))
+    }
+}
+
+// ---- helpers ----------------------------------------------------------------
+
+/// Encode an ordinal as a non-null opaque `nvmlDevice_t` (ordinal + 1) and back.
+fn handle_of(ord: u32) -> *mut std::ffi::c_void {
+    (ord as usize + 1) as *mut std::ffi::c_void
+}
+fn ord_of(handle: *mut std::ffi::c_void) -> c_int {
+    (handle as usize).wrapping_sub(1) as c_int
+}
+
+/// Copy `s` into the caller's C buffer, NUL-terminated and length-bounded.
+unsafe fn write_cstr(dst: *mut c_char, len: c_uint, s: &str) {
+    if dst.is_null() || len == 0 {
+        return;
+    }
+    let cap = len as usize - 1;
+    let bytes = s.as_bytes();
+    let n = bytes.len().min(cap);
+    std::ptr::copy_nonoverlapping(bytes.as_ptr() as *const c_char, dst, n);
+    *dst.add(n) = 0;
+}
+
+// ---- nvmlMemory_t ------------------------------------------------------------
+#[repr(C)]
+pub struct NvmlMemory {
+    pub total: c_ulonglong,
+    pub free: c_ulonglong,
+    pub used: c_ulonglong,
+}
+
+// ---- NVML API ----------------------------------------------------------------
+// Return NVML_SUCCESS broadly: these are queried during device discovery, and a
+// framework that gets an error concludes "no GPU". Multiple symbol versions are
+// exported because pynvml resolves whichever the header it was built against
+// names (`_v2`, plain, etc.).
+
+#[no_mangle]
+pub extern "C" fn nvmlInit_v2() -> c_int {
+    cu_init();
+    NVML_SUCCESS
+}
+#[no_mangle]
+pub extern "C" fn nvmlInit() -> c_int {
+    cu_init();
+    NVML_SUCCESS
+}
+#[no_mangle]
+pub extern "C" fn nvmlInitWithFlags(_flags: c_uint) -> c_int {
+    cu_init();
+    NVML_SUCCESS
+}
+#[no_mangle]
+pub extern "C" fn nvmlShutdown() -> c_int {
+    NVML_SUCCESS
+}
+
+#[no_mangle]
+pub extern "C" fn nvmlDeviceGetCount_v2(count: *mut c_uint) -> c_int {
+    if count.is_null() {
+        return NVML_ERROR_INVALID_ARGUMENT;
+    }
+    unsafe { *count = cu_device_count() }
+    NVML_SUCCESS
+}
+#[no_mangle]
+pub extern "C" fn nvmlDeviceGetCount(count: *mut c_uint) -> c_int {
+    nvmlDeviceGetCount_v2(count)
+}
+
+#[no_mangle]
+pub extern "C" fn nvmlDeviceGetHandleByIndex_v2(
+    index: c_uint,
+    device: *mut *mut std::ffi::c_void,
+) -> c_int {
+    if device.is_null() || index >= cu_device_count() {
+        return NVML_ERROR_INVALID_ARGUMENT;
+    }
+    unsafe { *device = handle_of(index) }
+    NVML_SUCCESS
+}
+#[no_mangle]
+pub extern "C" fn nvmlDeviceGetHandleByIndex(
+    index: c_uint,
+    device: *mut *mut std::ffi::c_void,
+) -> c_int {
+    nvmlDeviceGetHandleByIndex_v2(index, device)
+}
+
+#[no_mangle]
+pub extern "C" fn nvmlDeviceGetName(
+    device: *mut std::ffi::c_void,
+    name: *mut c_char,
+    length: c_uint,
+) -> c_int {
+    let s = cu_device_name(ord_of(device)).unwrap_or_else(|| "NVIDIA GPU".to_string());
+    unsafe { write_cstr(name, length, &s) }
+    NVML_SUCCESS
+}
+
+#[no_mangle]
+pub extern "C" fn nvmlDeviceGetMemoryInfo(
+    device: *mut std::ffi::c_void,
+    memory: *mut NvmlMemory,
+) -> c_int {
+    if memory.is_null() {
+        return NVML_ERROR_INVALID_ARGUMENT;
+    }
+    let ord = ord_of(device);
+    // Prefer live (free,total) from the current context; else total from the
+    // device query with a conservative free estimate.
+    let (free, total) = cu_mem_get_info().unwrap_or_else(|| {
+        let total = cu_total_mem(ord).unwrap_or(8 * 1024 * 1024 * 1024);
+        (total, total)
+    });
+    unsafe {
+        (*memory).total = total;
+        (*memory).free = free;
+        (*memory).used = total.saturating_sub(free);
+    }
+    NVML_SUCCESS
+}
+// v2 memory struct adds reserved fields after {total,free,used}; the first three
+// match, so the same writer is ABI-safe for callers that pass the larger struct.
+#[no_mangle]
+pub extern "C" fn nvmlDeviceGetMemoryInfo_v2(
+    device: *mut std::ffi::c_void,
+    memory: *mut NvmlMemory,
+) -> c_int {
+    nvmlDeviceGetMemoryInfo(device, memory)
+}
+
+#[no_mangle]
+pub extern "C" fn nvmlDeviceGetCudaComputeCapability(
+    device: *mut std::ffi::c_void,
+    major: *mut c_int,
+    minor: *mut c_int,
+) -> c_int {
+    if major.is_null() || minor.is_null() {
+        return NVML_ERROR_INVALID_ARGUMENT;
+    }
+    let (maj, min) = cu_compute_capability(ord_of(device)).unwrap_or((8, 0));
+    unsafe {
+        *major = maj;
+        *minor = min;
+    }
+    NVML_SUCCESS
+}
+
+#[no_mangle]
+pub extern "C" fn nvmlDeviceGetUUID(
+    _device: *mut std::ffi::c_void,
+    uuid: *mut c_char,
+    length: c_uint,
+) -> c_int {
+    // A stable, well-formed GPU UUID. Frameworks key caches/logs on it but don't
+    // require it to match real hardware for a single-GPU remoted device.
+    unsafe { write_cstr(uuid, length, "GPU-00000000-0000-0000-0000-000000000000") }
+    NVML_SUCCESS
+}
+
+#[no_mangle]
+pub extern "C" fn nvmlDeviceGetP2PStatus(
+    _device1: *mut std::ffi::c_void,
+    _device2: *mut std::ffi::c_void,
+    _p2p_index: c_int,
+    p2p_status: *mut c_int,
+) -> c_int {
+    if p2p_status.is_null() {
+        return NVML_ERROR_INVALID_ARGUMENT;
+    }
+    unsafe { *p2p_status = 0 } // NVML_P2P_STATUS_OK
+    NVML_SUCCESS
+}
+
+#[no_mangle]
+pub extern "C" fn nvmlErrorString(_result: c_int) -> *const c_char {
+    b"Success\0".as_ptr() as *const c_char
+}

--- a/crates/smolvm-nvml-shim/src/lib.rs
+++ b/crates/smolvm-nvml-shim/src/lib.rs
@@ -13,6 +13,11 @@
 //!
 //! Drop it in where the loader looks for `libnvidia-ml.so.1`.
 
+// These are C ABI entry points: the caller owns the pointers and the contract is
+// the NVML one, so marking each `unsafe` would only obscure the ABI. Matches the
+// other `smolvm-*-shim` crates.
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
+
 use std::os::raw::{c_char, c_int, c_uint, c_ulonglong};
 
 // ---- nvmlReturn_t ------------------------------------------------------------
@@ -27,8 +32,13 @@ const CU_ATTR_CC_MINOR: c_int = 76;
 
 /// Resolve a NUL-terminated CUDA Driver symbol from any library loaded in the
 /// process (our LD_PRELOADed `libcuda.so.1`). `None` if CUDA isn't present.
-unsafe fn cu_sym(name: &[u8]) -> Option<*mut std::ffi::c_void> {
-    let p = libc::dlsym(libc::RTLD_DEFAULT, name.as_ptr() as *const c_char);
+///
+/// The shim is only ever loaded by a Linux guest, but the workspace is
+/// cross-compiled, so the non-Unix build resolves nothing and every NVML query
+/// then falls back to its static answer.
+#[cfg(unix)]
+unsafe fn cu_sym(name: &std::ffi::CStr) -> Option<*mut std::ffi::c_void> {
+    let p = libc::dlsym(libc::RTLD_DEFAULT, name.as_ptr());
     if p.is_null() {
         None
     } else {
@@ -36,9 +46,14 @@ unsafe fn cu_sym(name: &[u8]) -> Option<*mut std::ffi::c_void> {
     }
 }
 
+#[cfg(not(unix))]
+unsafe fn cu_sym(_name: &std::ffi::CStr) -> Option<*mut std::ffi::c_void> {
+    None
+}
+
 fn cu_init() {
     unsafe {
-        if let Some(f) = cu_sym(b"cuInit\0") {
+        if let Some(f) = cu_sym(c"cuInit") {
             let f: extern "C" fn(c_uint) -> c_int = std::mem::transmute(f);
             let _ = f(0);
         }
@@ -47,7 +62,7 @@ fn cu_init() {
 
 /// The driver's CUdevice for ordinal `ord` (an int handle, usually == ord).
 unsafe fn cu_device(ord: c_int) -> Option<c_int> {
-    let f = cu_sym(b"cuDeviceGet\0")?;
+    let f = cu_sym(c"cuDeviceGet")?;
     let f: extern "C" fn(*mut c_int, c_int) -> c_int = std::mem::transmute(f);
     let mut dev: c_int = 0;
     (f(&mut dev, ord) == 0).then_some(dev)
@@ -57,7 +72,7 @@ unsafe fn cu_device(ord: c_int) -> Option<c_int> {
 /// ever expose the single remoted GPU anyway).
 fn cu_device_count() -> u32 {
     unsafe {
-        if let Some(f) = cu_sym(b"cuDeviceGetCount\0") {
+        if let Some(f) = cu_sym(c"cuDeviceGetCount") {
             let f: extern "C" fn(*mut c_int) -> c_int = std::mem::transmute(f);
             let mut n: c_int = 0;
             if f(&mut n) == 0 && n > 0 {
@@ -71,7 +86,7 @@ fn cu_device_count() -> u32 {
 fn cu_device_name(ord: c_int) -> Option<String> {
     unsafe {
         let dev = cu_device(ord)?;
-        let f = cu_sym(b"cuDeviceGetName\0")?;
+        let f = cu_sym(c"cuDeviceGetName")?;
         let f: extern "C" fn(*mut c_char, c_int, c_int) -> c_int = std::mem::transmute(f);
         let mut buf = [0i8; 256];
         (f(buf.as_mut_ptr(), buf.len() as c_int, dev) == 0).then(|| {
@@ -85,7 +100,7 @@ fn cu_total_mem(ord: c_int) -> Option<u64> {
     unsafe {
         let dev = cu_device(ord)?;
         // cuDeviceTotalMem_v2 takes no context (device query only).
-        let f = cu_sym(b"cuDeviceTotalMem_v2\0").or_else(|| cu_sym(b"cuDeviceTotalMem\0"))?;
+        let f = cu_sym(c"cuDeviceTotalMem_v2").or_else(|| cu_sym(c"cuDeviceTotalMem"))?;
         let f: extern "C" fn(*mut usize, c_int) -> c_int = std::mem::transmute(f);
         let mut bytes: usize = 0;
         (f(&mut bytes, dev) == 0 && bytes > 0).then_some(bytes as u64)
@@ -95,7 +110,7 @@ fn cu_total_mem(ord: c_int) -> Option<u64> {
 /// (free, total) from the current context if one exists; `None` otherwise.
 fn cu_mem_get_info() -> Option<(u64, u64)> {
     unsafe {
-        let f = cu_sym(b"cuMemGetInfo_v2\0").or_else(|| cu_sym(b"cuMemGetInfo\0"))?;
+        let f = cu_sym(c"cuMemGetInfo_v2").or_else(|| cu_sym(c"cuMemGetInfo"))?;
         let f: extern "C" fn(*mut usize, *mut usize) -> c_int = std::mem::transmute(f);
         let (mut free, mut total): (usize, usize) = (0, 0);
         (f(&mut free, &mut total) == 0 && total > 0).then_some((free as u64, total as u64))
@@ -105,7 +120,7 @@ fn cu_mem_get_info() -> Option<(u64, u64)> {
 fn cu_compute_capability(ord: c_int) -> Option<(c_int, c_int)> {
     unsafe {
         let dev = cu_device(ord)?;
-        let f = cu_sym(b"cuDeviceGetAttribute\0")?;
+        let f = cu_sym(c"cuDeviceGetAttribute")?;
         let f: extern "C" fn(*mut c_int, c_int, c_int) -> c_int = std::mem::transmute(f);
         let (mut maj, mut min): (c_int, c_int) = (0, 0);
         let ok = f(&mut maj, CU_ATTR_CC_MAJOR, dev) == 0
@@ -291,5 +306,5 @@ pub extern "C" fn nvmlDeviceGetP2PStatus(
 
 #[no_mangle]
 pub extern "C" fn nvmlErrorString(_result: c_int) -> *const c_char {
-    b"Success\0".as_ptr() as *const c_char
+    c"Success".as_ptr()
 }

--- a/crates/smolvm-pack/src/extract.rs
+++ b/crates/smolvm-pack/src/extract.rs
@@ -744,6 +744,26 @@ fn dir_disk_usage(path: &Path) -> u64 {
 /// automatically after a new (cache-miss) extraction, and keeps the newest
 /// entries (including the one just written) by evicting oldest-first.
 pub fn evict_cache_to_size(cache_root: &Path, max_bytes: u64) -> u64 {
+    evict_cache_to_size_protecting(cache_root, max_bytes, None)
+}
+
+/// Like [`evict_cache_to_size`], but never evicts `protect` (canonicalized),
+/// even if that leaves the cache over the cap.
+///
+/// The eviction after a fresh extraction runs *before* the caller acquires a
+/// layers lease, so the just-written directory has no lease yet. When a single
+/// extraction is larger than the cap (a torch/CUDA pack is ~13 GiB vs the 5 GiB
+/// default), oldest-first eviction would otherwise delete the very directory
+/// about to be booted — the VM then mounts nonexistent virtio-fs shares and the
+/// vcpu panics with `BadActivate`. Passing the current `cache_dir` as `protect`
+/// prevents that; the cache is simply allowed over-cap until the run releases it
+/// (same policy already applied to leased dirs).
+pub fn evict_cache_to_size_protecting(
+    cache_root: &Path,
+    max_bytes: u64,
+    protect: Option<&Path>,
+) -> u64 {
+    let protect_canon = protect.and_then(|p| fs::canonicalize(p).ok());
     let mut entries: Vec<(PathBuf, std::time::SystemTime, u64)> = Vec::new();
     let read_dir = match fs::read_dir(cache_root) {
         Ok(rd) => rd,
@@ -778,6 +798,12 @@ pub fn evict_cache_to_size(cache_root: &Path, max_bytes: u64) -> u64 {
         }
         if has_active_leases(&path) {
             continue; // never evict a running pack/VM
+        }
+        if protect_canon
+            .as_deref()
+            .is_some_and(|pc| fs::canonicalize(&path).ok().as_deref() == Some(pc))
+        {
+            continue; // never evict the extraction we just wrote / are about to boot
         }
         force_detach_layers_volume(&path);
         if fs::remove_dir_all(&path).is_ok() {
@@ -879,7 +905,13 @@ pub fn extract_sidecar(
     // wrote) and never evicts a running pack.
     if result.is_ok() {
         if let Some(root) = cache_dir.parent() {
-            let freed = evict_cache_to_size(root, pack_cache_max_bytes());
+            // Protect the directory we just extracted: the caller has not yet
+            // acquired its layers lease, so without this the eviction can delete
+            // the assets this very run is about to boot (→ virtio-fs ENOENT →
+            // vcpu BadActivate). A torch pack (~13 GiB) alone exceeds the 5 GiB
+            // default cap, which is exactly when oldest-first eviction reaches it.
+            let freed =
+                evict_cache_to_size_protecting(root, pack_cache_max_bytes(), Some(cache_dir));
             if freed > 0 && debug {
                 eprintln!("debug: pack cache evicted {freed} bytes to stay under cap");
             }
@@ -3152,6 +3184,43 @@ mod tests {
         assert!(freed > 0, "expected some bytes freed");
         assert!(!old.exists(), "oldest extraction should be evicted");
         assert!(mid.exists() && new.exists(), "newer extractions kept");
+    }
+
+    #[test]
+    fn test_evict_cache_protects_current_extraction() {
+        use std::ffi::CString;
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let mk = |name: &str, mtime_secs: i64| {
+            let d = root.join(name);
+            fs::create_dir_all(&d).unwrap();
+            fs::write(d.join("data"), vec![0u8; 4 * 1024 * 1024]).unwrap(); // ~4 MiB real
+            let c = CString::new(d.to_string_lossy().as_bytes()).unwrap();
+            let tv = libc::timeval {
+                tv_sec: mtime_secs,
+                tv_usec: 0,
+            };
+            let times = [tv, tv];
+            unsafe {
+                libc::utimes(c.as_ptr(), times.as_ptr());
+            }
+            d
+        };
+        // The dir we just wrote is the NEWEST but still larger than the cap on
+        // its own — the exact torch-pack shape (one ~13 GiB extraction vs a 5 GiB
+        // cap). Without protection, oldest-first eviction would reach it and
+        // delete the very assets about to boot.
+        let old = mk("aaaa", 1_000_000);
+        let current = mk("cccc", 3_000_000);
+
+        // Cap smaller than `current` alone: everything is "over cap".
+        let freed = evict_cache_to_size_protecting(root, 1024 * 1024, Some(&current));
+        assert!(freed > 0, "the old entry should still be evicted");
+        assert!(!old.exists(), "oldest unprotected extraction evicted");
+        assert!(
+            current.exists() && current.join("data").exists(),
+            "the protected (just-extracted) dir must survive even over cap"
+        );
     }
 
     // Lease tracking is a macOS case-sensitive-volume concept; on Linux

--- a/crates/smolvm-pack/src/format.rs
+++ b/crates/smolvm-pack/src/format.rs
@@ -375,6 +375,13 @@ pub struct PackManifest {
     #[serde(default)]
     pub gpu: bool,
 
+    /// Enable CUDA-over-vsock: the runtime starts a host CUDA server and bridges
+    /// the guest's CUDA client to it. Preserved from the source VM's `cuda` flag
+    /// when packing `--from-vm`. `#[serde(default)]` keeps older sidecars (which
+    /// lack the field) loadable.
+    #[serde(default)]
+    pub cuda: bool,
+
     /// Host platform this .smolmachine runs on (e.g., "darwin/arm64").
     /// Distinct from `platform` which is the guest architecture (always linux).
     /// Used for registry Image Index resolution.
@@ -469,6 +476,7 @@ impl PackManifest {
             image_size: 0,
             network: false,
             gpu: false,
+            cuda: false,
             host_platform,
             created: rfc3339_now(),
             smolvm_version: env!("CARGO_PKG_VERSION").to_string(),

--- a/crates/smolvm-protocol/src/lib.rs
+++ b/crates/smolvm-protocol/src/lib.rs
@@ -103,9 +103,16 @@ pub const FILE_WRITE_CHUNK_SIZE: usize = FILE_WRITE_SINGLE_SHOT_MAX;
 /// dropped. This protects the host process from OOM if the guest
 /// (compromised or merely buggy) streams unbounded data.
 ///
-/// 4 GiB matches the order-of-magnitude of the default overlay disk
-/// and the `gpu_vram_mib` cap. Callers that need to move larger
-/// blobs should stage via a virtiofs mount instead of `cp`.
+/// 4 GiB matches the order-of-magnitude of the default overlay disk and the
+/// `gpu_vram_mib` cap. It is the compiled-in default. The host-side transfer
+/// paths (read/export, including `pack create --from-vm`) raise it at runtime
+/// via `SMOLVM_FILE_TRANSFER_MAX_BYTES` (see
+/// `agent::client::file_transfer_max_total`) so a VM snapshot whose overlay
+/// carries a large dependency tree (e.g. a torch + CUDA-wheels environment is
+/// ~5 GiB) can be packed without lowering the DoS bound for everyone else. The
+/// guest agent's write-path check runs inside the VM and cannot see that host
+/// env var, so it always enforces this const. Callers that need to move larger
+/// blobs routinely should stage via a virtiofs mount instead of `cp`.
 pub const FILE_TRANSFER_MAX_TOTAL: u64 = 4 * 1024 * 1024 * 1024;
 
 /// Filename of the virtiofs-visible marker the agent creates when it is

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -1782,17 +1782,18 @@ impl AgentClient {
         })?;
 
         let mut total = 0u64;
+        let cap = file_transfer_max_total();
         loop {
             match self.recv_raw()? {
                 AgentResponse::DataChunk { data, done } => {
                     let next_total = total.saturating_add(data.len() as u64);
-                    if next_total > FILE_TRANSFER_MAX_TOTAL {
+                    if next_total > cap {
                         let _ = std::fs::remove_file(local_path);
                         return Err(Error::agent(
                             "read file",
                             format!(
                                 "guest streamed {} bytes, exceeding the {} byte cap",
-                                next_total, FILE_TRANSFER_MAX_TOTAL
+                                next_total, cap
                             ),
                         ));
                     }
@@ -2162,12 +2163,25 @@ where
 ///   with kilobytes instead of gigabytes).
 ///
 /// Both delegate to [`consume_streamed_read_inner`].
+/// The file-transfer size cap, in bytes. Defaults to the protocol's
+/// [`FILE_TRANSFER_MAX_TOTAL`] (4 GiB) and can be raised at runtime with
+/// `SMOLVM_FILE_TRANSFER_MAX_BYTES` (accepts a plain byte count or a suffixed
+/// size like `16GiB`). This lets an operator pack a VM snapshot whose overlay
+/// carries a large dependency tree (e.g. a ~5 GiB torch + CUDA-wheels env)
+/// without lowering the default DoS bound for everyone else.
+pub fn file_transfer_max_total() -> u64 {
+    std::env::var("SMOLVM_FILE_TRANSFER_MAX_BYTES")
+        .ok()
+        .and_then(|s| crate::util::parse_size_bytes(s.trim()).ok())
+        .unwrap_or(FILE_TRANSFER_MAX_TOTAL)
+}
+
 fn consume_streamed_read_with_progress<F, P>(next_response: F, on_progress: P) -> Result<Vec<u8>>
 where
     F: FnMut() -> Result<AgentResponse>,
     P: FnMut(u64),
 {
-    consume_streamed_read_inner(next_response, FILE_TRANSFER_MAX_TOTAL, on_progress)
+    consume_streamed_read_inner(next_response, file_transfer_max_total(), on_progress)
 }
 
 #[cfg(test)]

--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -133,8 +133,13 @@ pub fn launch_agent_vm_dynamic(
     // SAFETY: Each FFI call below is individually wrapped in unsafe.
     // All CString/pointer construction is safe Rust outside the unsafe blocks.
 
-    // Set log level
-    let log_level = if config.debug { 3 } else { 0 };
+    // Set log level (0 = off, 1 = error, 2 = warn, 3 = info, 4 = debug).
+    // Honor SMOLVM_KRUN_LOG_LEVEL like the non-packed launcher so a packed VM's
+    // boot can be traced; otherwise fall back to info under --debug.
+    let log_level = std::env::var(crate::data::consts::ENV_SMOLVM_KRUN_LOG_LEVEL)
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+        .unwrap_or(if config.debug { 3 } else { 0 });
     // SAFETY: set_log_level is a valid function pointer loaded from libkrun
     unsafe { (krun.set_log_level)(log_level) };
 

--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -65,6 +65,11 @@ pub struct PackedLaunchConfig<'a> {
     /// Path to redirect VM console output (prevents libkrun from putting
     /// the inherited terminal into raw mode).
     pub console_log: PathBuf,
+    /// Host CUDA-over-vsock server socket. When set, the guest's CUDA client
+    /// (vsock port [`ports::CUDA`]) is bridged to this AF_UNIX path, where a
+    /// `cuda_host` server loaded the real driver. Mirrors the non-packed
+    /// launcher's `cuda_socket`.
+    pub cuda_socket: Option<&'a Path>,
 }
 
 /// The `krun_add_disk2` image-format code for a disk file: `1` (qcow2) when it
@@ -470,6 +475,25 @@ pub fn launch_agent_vm_dynamic(
     if unsafe { (krun.add_vsock_port2)(ctx, ports::AGENT_CONTROL, socket_path.as_ptr(), true) } < 0
     {
         free_ctx_on_err!("krun_add_vsock_port2 failed");
+    }
+
+    // Bridge the guest CUDA client (vsock port `ports::CUDA`) to the host CUDA
+    // server socket. `listen=false`: the guest connects out and libkrun forwards
+    // to the AF_UNIX path where `cuda_host::start` is serving. Mirrors the
+    // non-packed launcher; keeps this launcher policy-free (the caller owns the
+    // server lifecycle).
+    if let Some(cuda_sock) = config.cuda_socket {
+        let cuda_sock_c = try_or_free_ctx!(
+            path_to_cstring(cuda_sock),
+            "cuda socket path contains null byte"
+        );
+        // SAFETY: ctx is valid, cuda_sock_c is a valid C string.
+        if unsafe { (krun.add_vsock_port2)(ctx, ports::CUDA, cuda_sock_c.as_ptr(), false) } < 0 {
+            free_ctx_on_err!("krun_add_vsock_port2 (CUDA) failed");
+        }
+        if config.debug {
+            eprintln!("debug: CUDA-over-vsock bridged to {}", cuda_sock.display());
+        }
     }
 
     // Redirect console output to a log file so libkrun doesn't put the

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -1686,6 +1686,11 @@ impl AgentManager {
             if let Some(ref snap) = features.snapshot_dir {
                 v.push(("SMOLVM_SNAPSHOT_DIR", snap.to_string_lossy().into_owned()));
             }
+            // Shared CUDA daemon: forward so this VM's embedded host proxies to
+            // the one daemon (shared GPU context across VMs / fork clones).
+            if let Ok(daemon) = std::env::var("SMOLVM_CUDA_DAEMON") {
+                v.push(("SMOLVM_CUDA_DAEMON", daemon));
+            }
             v
         };
         self.inner.lock().is_clone = features.snapshot_dir.is_some();

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -1686,14 +1686,25 @@ impl AgentManager {
             if let Some(ref snap) = features.snapshot_dir {
                 v.push(("SMOLVM_SNAPSHOT_DIR", snap.to_string_lossy().into_owned()));
             }
-            // Shared CUDA daemon: forward so this VM's embedded host proxies to
-            // the one daemon (shared GPU context across VMs / fork clones).
+            // Shared CUDA daemon: forward an explicit operator setting as-is.
             // SHARED=1 => smolvm spawns/manages the daemon; DAEMON=X => external.
+            let mut shared_set = false;
             if let Ok(shared) = std::env::var("SMOLVM_CUDA_SHARED") {
                 v.push(("SMOLVM_CUDA_SHARED", shared));
+                shared_set = true;
             }
             if let Ok(daemon) = std::env::var("SMOLVM_CUDA_DAEMON") {
                 v.push(("SMOLVM_CUDA_DAEMON", daemon));
+                shared_set = true;
+            }
+            // Auto-enable the shared daemon for a fork base or a fork clone even
+            // when the operator didn't ask: a clone can only reuse its golden's
+            // GPU context through the one shared daemon, so a per-VM host (its own
+            // process, its own context) would fork into a broken clone. No-op for
+            // non-CUDA machines — the daemon is only ever spawned from the CUDA
+            // host path, which runs only when the machine has `cuda`.
+            if !shared_set && (features.forkable || features.snapshot_dir.is_some()) {
+                v.push(("SMOLVM_CUDA_SHARED", "1".to_string()));
             }
             v
         };

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -1688,6 +1688,10 @@ impl AgentManager {
             }
             // Shared CUDA daemon: forward so this VM's embedded host proxies to
             // the one daemon (shared GPU context across VMs / fork clones).
+            // SHARED=1 => smolvm spawns/manages the daemon; DAEMON=X => external.
+            if let Ok(shared) = std::env::var("SMOLVM_CUDA_SHARED") {
+                v.push(("SMOLVM_CUDA_SHARED", shared));
+            }
             if let Ok(daemon) = std::env::var("SMOLVM_CUDA_DAEMON") {
                 v.push(("SMOLVM_CUDA_DAEMON", daemon));
             }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -19,7 +19,8 @@ pub use crate::data::network::PortMapping;
 pub use crate::data::resources::VmResources;
 pub use crate::data::storage::HostMount;
 pub use client::{
-    AgentClient, ExecEvent, InteractiveInput, InteractiveOutput, PullOptions, RunConfig,
+    file_transfer_max_total, AgentClient, ExecEvent, InteractiveInput, InteractiveOutput,
+    PullOptions, RunConfig,
 };
 pub use fsnotify_watch::FsNotifyWatcher;
 pub use krun::KrunFunctions;

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -809,6 +809,7 @@ impl RunCmd {
                 force_extract: false,
                 info: false,
                 debug: false,
+                cuda: false,
             }
             .run();
         }
@@ -923,6 +924,7 @@ impl RunCmd {
                 force_extract: false,
                 info: false,
                 debug: false,
+                cuda: false,
             }
             .run();
         }

--- a/src/cli/pack.rs
+++ b/src/cli/pack.rs
@@ -1475,7 +1475,7 @@ impl PackCreateCmd {
         dest: &std::path::Path,
         progress_prefix: &str,
     ) -> smolvm::Result<()> {
-        use smolvm_protocol::{AgentRequest, FILE_TRANSFER_MAX_TOTAL};
+        use smolvm_protocol::AgentRequest;
         use std::io::Write;
         use std::time::{Duration, Instant};
 
@@ -1499,6 +1499,7 @@ impl PackCreateCmd {
         let start = Instant::now();
         let mut total_bytes = 0u64;
         let mut last_progress = Instant::now();
+        let cap = smolvm::agent::file_transfer_max_total();
         loop {
             if start.elapsed() > LAYER_EXPORT_TIMEOUT {
                 return Err(Error::agent(
@@ -1519,13 +1520,13 @@ impl PackCreateCmd {
                         // paths do (client.rs): a compromised or buggy guest must not
                         // be able to exhaust the host disk with an endless chunk stream.
                         let next_total = total_bytes.saturating_add(data.len() as u64);
-                        if next_total > FILE_TRANSFER_MAX_TOTAL {
+                        if next_total > cap {
                             let _ = std::fs::remove_file(dest);
                             return Err(Error::agent(
                                 "export layer",
                                 format!(
                                     "guest streamed {} bytes, exceeding the {} byte cap",
-                                    next_total, FILE_TRANSFER_MAX_TOTAL
+                                    next_total, cap
                                 ),
                             ));
                         }

--- a/src/cli/pack.rs
+++ b/src/cli/pack.rs
@@ -655,6 +655,9 @@ impl PackCreateCmd {
         manifest.network = pack_config.net.unwrap_or(vm.network);
         // CLI --gpu > Smolfile gpu > source VM record gpu > false
         manifest.gpu = pack_config.gpu || vm.gpu.unwrap_or(false);
+        // Preserve the source VM's CUDA-over-vsock flag so the packed run starts
+        // a host CUDA server and bridges the guest's CUDA client to it.
+        manifest.cuda = vm.cuda;
 
         // Entrypoint baseline: VmRecord > /bin/sh default
         manifest.entrypoint = if !vm.entrypoint.is_empty() {

--- a/src/cli/pack_run.rs
+++ b/src/cli/pack_run.rs
@@ -30,8 +30,48 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-/// Timeout waiting for the agent to become ready.
-const AGENT_READY_TIMEOUT: Duration = Duration::from_secs(30);
+/// Default timeout waiting for the agent to become ready.
+///
+/// A packed VM assembles its container rootfs *inside the guest* on first boot
+/// (extract OCI layers to /storage, then overlayfs copy-up), so a machine that
+/// carries a large dependency tree — e.g. a ~6 GiB torch + CUDA-wheels overlay —
+/// can legitimately take longer than this to reach its vsock accept loop. Raise
+/// it for such machines with `SMOLVM_AGENT_READY_TIMEOUT_SECS`.
+const AGENT_READY_TIMEOUT_DEFAULT_SECS: u64 = 30;
+
+/// Resolve the agent-ready timeout, honoring `SMOLVM_AGENT_READY_TIMEOUT_SECS`.
+fn agent_ready_timeout() -> Duration {
+    let secs = std::env::var("SMOLVM_AGENT_READY_TIMEOUT_SECS")
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .filter(|&s| s > 0)
+        .unwrap_or(AGENT_READY_TIMEOUT_DEFAULT_SECS);
+    Duration::from_secs(secs)
+}
+
+/// Detach the forked VM child from the terminal. When
+/// `SMOLVM_PACKED_KRUN_STDERR_LOG` names a path, the child's stderr (libkrun's
+/// own log, level from `SMOLVM_KRUN_LOG_LEVEL`) is captured there instead of
+/// discarded — the only way to see a libkrun-level boot failure in a packed run,
+/// since the guest's virtio-console goes to a separate file.
+#[cfg(unix)]
+fn detach_vm_child_stdio() {
+    match std::env::var("SMOLVM_PACKED_KRUN_STDERR_LOG").ok() {
+        Some(p) if !p.trim().is_empty() => {
+            if smolvm::process::detach_stdio_to_stderr_file(std::path::Path::new(p.trim()))
+                .is_err()
+            {
+                smolvm::process::detach_stdio();
+            }
+        }
+        _ => smolvm::process::detach_stdio(),
+    }
+}
+
+#[cfg(not(unix))]
+fn detach_vm_child_stdio() {
+    smolvm::process::detach_stdio();
+}
 
 /// Resolve the lib directory containing libkrun/libkrunfw.
 ///
@@ -39,6 +79,22 @@ const AGENT_READY_TIMEOUT: Duration = Duration::from_secs(30);
 /// Single-file mode: libs extracted from Mach-O section to cache_dir/lib/.
 /// `smolvm pack run`: uses the host-installed libs.
 fn resolve_lib_dir(cache_dir: &Path, debug: bool) -> smolvm::Result<PathBuf> {
+    // Explicit override (matches the non-packed launcher). Lets a dev run a
+    // packed sidecar with a freshly-built smolvm binary pointed at a known-good
+    // libkrun, instead of the libs embedded in the original stub.
+    if let Ok(dir) = std::env::var(smolvm::data::consts::ENV_SMOLVM_LIB_DIR) {
+        let dir = dir.trim();
+        if !dir.is_empty() {
+            let p = PathBuf::from(dir);
+            if p.exists() {
+                if debug {
+                    eprintln!("debug: using libs from SMOLVM_LIB_DIR: {}", p.display());
+                }
+                return Ok(p);
+            }
+        }
+    }
+
     // Two-file mode: libs embedded in stub binary (SMOLLIBS footer)
     if let Ok(exe_path) = std::env::current_exe() {
         if let Ok(Some(lib_dir)) = extract::extract_libs_from_binary(&exe_path, debug) {
@@ -389,7 +445,7 @@ impl PackRunCmd {
 
                 // Detach from parent's terminal so libkrun doesn't
                 // steal keystrokes or corrupt terminal state.
-                smolvm::process::detach_stdio();
+                detach_vm_child_stdio();
 
                 if let Err(e) = launch_agent_vm_dynamic(&krun, &config) {
                     let msg = format!("launch_agent_vm_dynamic failed: {}\n", e);
@@ -682,14 +738,15 @@ fn wait_for_agent(vsock_path: &Path, debug: bool) -> smolvm::Result<AgentClient>
 
     let start = Instant::now();
     let poll_interval = Duration::from_millis(100);
+    let timeout = agent_ready_timeout();
 
     loop {
-        if start.elapsed() > AGENT_READY_TIMEOUT {
+        if start.elapsed() > timeout {
             return Err(Error::agent(
                 "wait for agent",
                 format!(
                     "agent did not become ready within {} seconds",
-                    AGENT_READY_TIMEOUT.as_secs()
+                    timeout.as_secs()
                 ),
             ));
         }
@@ -1370,7 +1427,7 @@ fn run_from_cache(
 
         // Detach from parent's terminal so libkrun doesn't
         // steal keystrokes or corrupt terminal state.
-        smolvm::process::detach_stdio();
+        detach_vm_child_stdio();
 
         if let Err(e) = launch_agent_vm_dynamic(&krun, &config) {
             let msg = format!("launch_agent_vm_dynamic failed: {}\n", e);
@@ -1790,7 +1847,7 @@ fn daemon_start(
         // Detach from parent's terminal before launching the VM.
         // Without this, libkrun's threads inherit stdin and steal
         // keystrokes from the user's shell.
-        smolvm::process::detach_stdio();
+        detach_vm_child_stdio();
 
         if let Err(e) = launch_agent_vm_dynamic(&krun, &config) {
             let msg = format!("launch_agent_vm_dynamic failed: {}\n", e);

--- a/src/cli/pack_run.rs
+++ b/src/cli/pack_run.rs
@@ -69,8 +69,7 @@ fn agent_ready_timeout() -> Duration {
 fn detach_vm_child_stdio() {
     match std::env::var("SMOLVM_PACKED_KRUN_STDERR_LOG").ok() {
         Some(p) if !p.trim().is_empty() => {
-            if smolvm::process::detach_stdio_to_stderr_file(std::path::Path::new(p.trim()))
-                .is_err()
+            if smolvm::process::detach_stdio_to_stderr_file(std::path::Path::new(p.trim())).is_err()
             {
                 smolvm::process::detach_stdio();
             }
@@ -492,7 +491,8 @@ impl PackRunCmd {
             // These bindings are consumed by the Unix fork closure above; on
             // Windows the BootConfig carries the same data, so silence the
             // unused-variable warnings rather than reshape the surrounding code.
-            let _ = (&packed_mounts, &port_mappings);
+            // `cuda_enabled`/`cuda_sock` drive the unix-only shared-daemon path.
+            let _ = (&packed_mounts, &port_mappings, cuda_enabled, &cuda_sock);
 
             // The overlay file is always created on disk before this point
             // (`setup_vm_overlay`); fall back to the well-known runtime path when

--- a/src/cli/pack_run.rs
+++ b/src/cli/pack_run.rs
@@ -39,6 +39,17 @@ use std::time::Duration;
 /// it for such machines with `SMOLVM_AGENT_READY_TIMEOUT_SECS`.
 const AGENT_READY_TIMEOUT_DEFAULT_SECS: u64 = 30;
 
+/// Truthy env-var flag (`1`, `true`, `yes`, case-insensitive).
+fn env_flag(name: &str) -> bool {
+    std::env::var(name)
+        .ok()
+        .map(|v| {
+            let v = v.trim().to_ascii_lowercase();
+            v == "1" || v == "true" || v == "yes"
+        })
+        .unwrap_or(false)
+}
+
 /// Resolve the agent-ready timeout, honoring `SMOLVM_AGENT_READY_TIMEOUT_SECS`.
 fn agent_ready_timeout() -> Duration {
     let secs = std::env::var("SMOLVM_AGENT_READY_TIMEOUT_SECS")
@@ -252,6 +263,12 @@ pub struct PackRunCmd {
     /// Enable debug output
     #[arg(long)]
     pub debug: bool,
+
+    /// Enable CUDA-over-vsock: run a host CUDA server and bridge the guest's
+    /// CUDA client to it. Also enabled automatically when the packed machine
+    /// was created with CUDA, or via `SMOLVM_CUDA=1`.
+    #[arg(long)]
+    pub cuda: bool,
 }
 
 impl PackRunCmd {
@@ -353,6 +370,13 @@ impl PackRunCmd {
         let storage_path = runtime_dir.path().join("storage.ext4");
         let vsock_path = runtime_dir.path().join("agent.sock");
 
+        // CUDA-over-vsock: enabled by the packed machine's manifest flag, the
+        // `--cuda` override, or `SMOLVM_CUDA=1`. When on, the parent runs a host
+        // CUDA server on `cuda_sock` and the launcher bridges the guest's vsock
+        // CUDA port to it (the guest's LD_PRELOADed shims connect out).
+        let cuda_enabled = manifest.cuda || self.cuda || env_flag("SMOLVM_CUDA");
+        let cuda_sock = runtime_dir.path().join("cuda.sock");
+
         // Compute auto-sized storage before creating the disk so both the
         // disk file and VmResources use the same value.
         let storage_gib = storage_gib_for_manifest(self.storage, &manifest);
@@ -420,6 +444,7 @@ impl PackRunCmd {
         #[cfg(unix)]
         let child_pid = {
             let vsock_path_clone = vsock_path.clone();
+            let cuda_sock_clone = cuda_sock.clone();
             smolvm::process::fork_session_leader(move || {
                 // Child process: load libkrun via dlopen and launch VM
                 let krun = match unsafe { KrunFunctions::load(&lib_dir) } {
@@ -441,6 +466,11 @@ impl PackRunCmd {
                     overlay_path: overlay_runtime_path.as_deref(),
                     debug: self.debug,
                     console_log: console_log_path,
+                    cuda_socket: if cuda_enabled {
+                        Some(cuda_sock_clone.as_path())
+                    } else {
+                        None
+                    },
                 };
 
                 // Detach from parent's terminal so libkrun doesn't
@@ -575,6 +605,26 @@ impl PackRunCmd {
 
         if self.debug {
             eprintln!("debug: forked VM process with PID {}", child_pid);
+        }
+
+        // Start the host CUDA server in the parent (which owns the run's
+        // lifetime). The guest's LD_PRELOADed shims connect out to vsock port
+        // `ports::CUDA`, which the launcher (in the child) bridges to this
+        // AF_UNIX socket. Started after the fork so the child never inherits any
+        // CUDA-driver state, and before `wait_for_agent` so the socket is
+        // serving well before the guest workload dials in.
+        #[cfg(unix)]
+        if cuda_enabled {
+            match smolvm::cuda_host::start(&cuda_sock) {
+                Ok(()) => {
+                    if self.debug {
+                        eprintln!("debug: CUDA host serving {}", cuda_sock.display());
+                    }
+                }
+                Err(e) => {
+                    eprintln!("warning: failed to start CUDA host server: {e} — CUDA disabled");
+                }
+            }
         }
 
         // Guard ensures the VM child is terminated and runtime dir is
@@ -1079,6 +1129,11 @@ struct PackedRunArgs {
     /// Overlay disk size in GiB
     #[arg(long, value_name = "GiB")]
     overlay: Option<u64>,
+
+    /// Enable CUDA-over-vsock (also implied by the packed machine's manifest or
+    /// `SMOLVM_CUDA=1`).
+    #[arg(long)]
+    cuda: bool,
 }
 
 /// Arguments for the `start` subcommand (persistent daemon).
@@ -1264,6 +1319,7 @@ fn run_ephemeral(
                 force_extract,
                 info: false,
                 debug,
+                cuda: args.cuda,
             };
             cmd.run()
         }
@@ -1423,6 +1479,9 @@ fn run_from_cache(
             overlay_path: overlay_runtime_path.as_deref(),
             debug,
             console_log: console_log_path,
+            // CUDA-over-vsock for the persistent/daemon packed paths is not
+            // wired yet; the `run` path starts the host server.
+            cuda_socket: None,
         };
 
         // Detach from parent's terminal so libkrun doesn't
@@ -1842,6 +1901,9 @@ fn daemon_start(
             overlay_path: overlay_daemon_path.as_deref(),
             debug,
             console_log: console_log_path,
+            // CUDA-over-vsock for the persistent/daemon packed paths is not
+            // wired yet; the `run` path starts the host server.
+            cuda_socket: None,
         };
 
         // Detach from parent's terminal before launching the VM.

--- a/src/cli/parsers.rs
+++ b/src/cli/parsers.rs
@@ -27,40 +27,10 @@ pub fn parse_gpu_vram_mib(s: &str) -> Result<u32, String> {
     Ok(v)
 }
 
-/// Parse a byte size like `16GiB`, `16G`, `512M`, or a plain byte count
-/// (`17179869184`). Suffixes are binary (1K = 1024); `K/M/G/T`, optionally with
-/// a trailing `i` and/or `B`, are accepted case-insensitively. Used for
-/// `--max-image-size`.
-pub fn parse_size_bytes(s: &str) -> Result<u64, String> {
-    let t = s.trim();
-    if t.is_empty() {
-        return Err("size must not be empty".to_string());
-    }
-    let split = t
-        .find(|c: char| !c.is_ascii_digit() && c != '.')
-        .unwrap_or(t.len());
-    let (num, unit) = t.split_at(split);
-    let value: f64 = num
-        .parse()
-        .map_err(|_| format!("'{s}' is not a valid size (expected a number, optional K/M/G/T)"))?;
-    let mult: u64 = match unit.trim().to_ascii_lowercase().as_str() {
-        "" | "b" => 1,
-        "k" | "ki" | "kib" | "kb" => 1 << 10,
-        "m" | "mi" | "mib" | "mb" => 1 << 20,
-        "g" | "gi" | "gib" | "gb" => 1 << 30,
-        "t" | "ti" | "tib" | "tb" => 1u64 << 40,
-        other => {
-            return Err(format!(
-                "invalid size unit '{other}' in '{s}' (use K, M, G, or T)"
-            ))
-        }
-    };
-    let bytes = (value * mult as f64) as u64;
-    if bytes == 0 {
-        return Err(format!("size '{s}' must be greater than zero"));
-    }
-    Ok(bytes)
-}
+// Byte-size parsing lives in the library so both the CLI (`--max-image-size`)
+// and the host runtime (`agent::client::file_transfer_max_total`) share one
+// implementation.
+pub use smolvm::util::parse_size_bytes;
 
 /// Parse and validate an image reference. Rejects empty/whitespace-only
 /// values at CLI parse time so `--image ""` errors immediately instead of

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -16,8 +16,10 @@ use std::io;
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 /// Control-socket path for the shared daemon, under the smolvm data dir (so the
 /// daemon and every boot subprocess agree on one location).
@@ -33,9 +35,48 @@ fn is_alive(sock: &Path) -> bool {
     UnixStream::connect(sock).is_ok()
 }
 
+/// How long the daemon may sit with ZERO open connections before it exits and
+/// releases the GPU context. `None` (env set to `0`) disables the timeout.
+///
+/// Counting *open connections* (not activity) is what makes this fork-safe: a
+/// frozen golden keeps its proxied connection open, so it counts as active and
+/// never trips the timeout even while paused. The daemon only exits once every
+/// VM — golden and clones — has disconnected.
+fn idle_timeout() -> Option<Duration> {
+    let secs = std::env::var("SMOLVM_CUDA_DAEMON_IDLE_SECS")
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .unwrap_or(300);
+    (secs > 0).then(|| Duration::from_secs(secs))
+}
+
+/// Exit the process once `active` has been 0 for `timeout`. Polls slowly (the
+/// timeout is coarse) and resets the idle clock whenever a connection is live.
+fn spawn_idle_watchdog(active: Arc<AtomicUsize>, timeout: Duration) {
+    thread::Builder::new()
+        .name("cuda-daemon-idle".into())
+        .spawn(move || {
+            let mut idle_since = Instant::now();
+            loop {
+                thread::sleep(Duration::from_secs(5));
+                if active.load(Ordering::SeqCst) > 0 {
+                    idle_since = Instant::now();
+                } else if idle_since.elapsed() >= timeout {
+                    tracing::info!(
+                        timeout_secs = timeout.as_secs(),
+                        "shared CUDA daemon idle with no connections — exiting"
+                    );
+                    std::process::exit(0);
+                }
+            }
+        })
+        .ok();
+}
+
 /// Run the daemon body: bind `sock` and serve every connection in its own
 /// thread against a fresh backend — all in this process, so they share one GPU
-/// context. Never returns under normal operation.
+/// context. Returns only on listener failure; otherwise exits via the idle
+/// watchdog (or runs until the host shuts down when the timeout is disabled).
 pub fn run(sock: &Path) -> io::Result<()> {
     if let Some(parent) = sock.parent() {
         let _ = std::fs::create_dir_all(parent);
@@ -43,12 +84,21 @@ pub fn run(sock: &Path) -> io::Result<()> {
     let _ = std::fs::remove_file(sock); // caller serialized us; clear any stale node
     let listener = UdsListener::bind(sock)?;
     tracing::info!(socket = %sock.display(), "shared CUDA daemon listening");
+    let active = Arc::new(AtomicUsize::new(0));
+    if let Some(timeout) = idle_timeout() {
+        spawn_idle_watchdog(active.clone(), timeout);
+    }
     for stream in listener.incoming() {
         match stream {
             Ok(stream) => {
+                // Count the connection open for the whole serve loop so a frozen
+                // golden (idle but connected) keeps the daemon alive for its
+                // clones. The RAII guard balances the count even if spawn fails.
+                let guard = ConnGuard::new(&active);
                 thread::Builder::new()
                     .name("cuda-daemon-conn".into())
                     .spawn(move || {
+                        let _guard = guard;
                         let mut backend = make_backend();
                         if let Err(e) = serve(stream, backend.as_mut()) {
                             tracing::debug!(error = %e, "CUDA daemon connection ended");
@@ -60,6 +110,23 @@ pub fn run(sock: &Path) -> io::Result<()> {
         }
     }
     Ok(())
+}
+
+/// Keeps the daemon's open-connection count accurate: +1 on construction, -1 on
+/// drop (whether the serve thread finished or never started).
+struct ConnGuard(Arc<AtomicUsize>);
+
+impl ConnGuard {
+    fn new(active: &Arc<AtomicUsize>) -> Self {
+        active.fetch_add(1, Ordering::SeqCst);
+        ConnGuard(active.clone())
+    }
+}
+
+impl Drop for ConnGuard {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::SeqCst);
+    }
 }
 
 fn make_backend() -> Box<dyn Backend> {

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -1,0 +1,138 @@
+//! smolvm-managed shared CUDA daemon.
+//!
+//! One process holding a single GPU context, serving every CUDA VM's proxied
+//! connection (see [`crate::cuda_host`]'s proxy path). Because all connections
+//! live in this one process, they share the device primary context — which is
+//! what lets a forked VM clone reconnect and reuse its golden's device memory.
+//!
+//! Lifecycle is lazy and self-managing: the first CUDA VM that needs the daemon
+//! calls [`ensure_running`], which spawns `smolvm _cuda-daemon <socket>` if the
+//! socket isn't already live. The daemon then persists across VMs (it is not
+//! tied to any single VM's boot subprocess) until the host shuts down.
+
+use crate::platform::uds::UdsListener;
+use smolvm_cuda::host::{serve, Backend, CpuBackend, GpuBackend};
+use std::io;
+use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::Duration;
+
+/// Control-socket path for the shared daemon, under the smolvm data dir (so the
+/// daemon and every boot subprocess agree on one location).
+pub fn socket_path() -> PathBuf {
+    let root = std::env::var_os("SMOLVM_DATA_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| std::env::temp_dir().join("smolvm"));
+    root.join("cuda-daemon.sock")
+}
+
+/// True if a daemon is already listening on `sock` (a probe connect succeeds).
+fn is_alive(sock: &Path) -> bool {
+    UnixStream::connect(sock).is_ok()
+}
+
+/// Run the daemon body: bind `sock` and serve every connection in its own
+/// thread against a fresh backend — all in this process, so they share one GPU
+/// context. Never returns under normal operation.
+pub fn run(sock: &Path) -> io::Result<()> {
+    if let Some(parent) = sock.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::remove_file(sock); // caller serialized us; clear any stale node
+    let listener = UdsListener::bind(sock)?;
+    tracing::info!(socket = %sock.display(), "shared CUDA daemon listening");
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                thread::Builder::new()
+                    .name("cuda-daemon-conn".into())
+                    .spawn(move || {
+                        let mut backend = make_backend();
+                        if let Err(e) = serve(stream, backend.as_mut()) {
+                            tracing::debug!(error = %e, "CUDA daemon connection ended");
+                        }
+                    })
+                    .ok();
+            }
+            Err(e) => tracing::debug!(error = %e, "CUDA daemon accept error"),
+        }
+    }
+    Ok(())
+}
+
+fn make_backend() -> Box<dyn Backend> {
+    match GpuBackend::load() {
+        Ok(gpu) => {
+            tracing::info!("cuda-daemon: GPU driver backend ready");
+            Box::new(gpu)
+        }
+        Err(e) => {
+            tracing::info!("cuda-daemon: no GPU driver ({e}) — CPU emulation backend");
+            Box::<CpuBackend>::default()
+        }
+    }
+}
+
+/// Ensure the shared daemon is running and return its socket path. Serialized by
+/// an exclusive lock on `<socket>.lock` so concurrent CUDA VMs can't spawn two
+/// daemons (a second would bind-fail and exit, but the lock avoids the churn and
+/// the stale-socket-removal race).
+pub fn ensure_running() -> io::Result<PathBuf> {
+    let sock = socket_path();
+    if let Some(parent) = sock.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _guard = FileLock::acquire(&sock.with_extension("lock"))?;
+    if is_alive(&sock) {
+        return Ok(sock);
+    }
+    let _ = std::fs::remove_file(&sock); // stale node from a dead daemon
+    use std::os::unix::process::CommandExt;
+    let exe = std::env::current_exe()?;
+    Command::new(exe)
+        .args(["_cuda-daemon", &sock.to_string_lossy()])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        // Own process group so the daemon outlives the VM that first spawned it.
+        .process_group(0)
+        .spawn()?;
+    for _ in 0..200 {
+        if is_alive(&sock) {
+            return Ok(sock);
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+    Err(io::Error::new(
+        io::ErrorKind::TimedOut,
+        "shared CUDA daemon did not come up",
+    ))
+}
+
+/// Minimal RAII `flock(LOCK_EX)` guard on a lock file.
+struct FileLock(std::fs::File);
+
+impl FileLock {
+    fn acquire(path: &Path) -> io::Result<Self> {
+        use std::os::unix::io::AsRawFd;
+        let f = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(path)?;
+        let rc = unsafe { libc::flock(f.as_raw_fd(), libc::LOCK_EX) };
+        if rc != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(FileLock(f))
+    }
+}
+
+impl Drop for FileLock {
+    fn drop(&mut self) {
+        use std::os::unix::io::AsRawFd;
+        unsafe { libc::flock(self.0.as_raw_fd(), libc::LOCK_UN) };
+    }
+}

--- a/src/cuda_host.rs
+++ b/src/cuda_host.rs
@@ -47,12 +47,28 @@ pub fn start(socket_path: &Path) -> std::io::Result<()> {
         .name("cuda-host".into())
         .spawn(move || {
             tracing::info!(path = path_display, "CUDA host server listening");
+            // Shared-daemon mode: when SMOLVM_CUDA_DAEMON=<host:port> is set, relay
+            // every guest connection to one external CUDA daemon instead of
+            // serving it in-process. All VMs then share that daemon's single GPU
+            // context — the prerequisite for a forked clone to reuse a golden
+            // VM's device memory (which lives in the daemon, not per-VM).
+            let daemon = std::env::var("SMOLVM_CUDA_DAEMON").ok();
+            if let Some(ref addr) = daemon {
+                tracing::info!(daemon = %addr, "cuda-host: shared-daemon proxy mode");
+            }
             for stream in listener.incoming() {
                 match stream {
                     Ok(stream) => {
+                        let daemon = daemon.clone();
                         thread::Builder::new()
                             .name("cuda-host-conn".into())
                             .spawn(move || {
+                                if let Some(addr) = daemon {
+                                    if let Err(e) = proxy_to_daemon(stream, &addr) {
+                                        tracing::debug!(error = %e, "CUDA daemon proxy ended");
+                                    }
+                                    return;
+                                }
                                 let mut backend = make_backend();
                                 if let Err(e) = serve(stream, backend.as_mut()) {
                                     tracing::debug!(error = %e, "CUDA host connection ended");
@@ -67,6 +83,26 @@ pub fn start(socket_path: &Path) -> std::io::Result<()> {
             }
         })?;
 
+    Ok(())
+}
+
+/// Relay one guest connection to the shared CUDA daemon at `addr` (a byte pump
+/// in both directions — the RPC is end-to-end between the guest shim and the
+/// daemon, so smolvm only forwards frames). This is the minimal form of the
+/// shared-host-daemon architecture: every VM's traffic lands in one process, so
+/// they share a single GPU context and device memory.
+fn proxy_to_daemon(guest: crate::platform::uds::UdsStream, addr: &str) -> std::io::Result<()> {
+    let daemon = std::net::TcpStream::connect(addr)?;
+    let _ = daemon.set_nodelay(true);
+    let mut guest_rd = guest.try_clone()?;
+    let mut daemon_wr = daemon.try_clone()?;
+    let up = thread::spawn(move || {
+        let _ = std::io::copy(&mut guest_rd, &mut daemon_wr);
+    });
+    let mut daemon_rd = daemon;
+    let mut guest_wr = guest;
+    let _ = std::io::copy(&mut daemon_rd, &mut guest_wr);
+    let _ = up.join();
     Ok(())
 }
 

--- a/src/cuda_host.rs
+++ b/src/cuda_host.rs
@@ -47,12 +47,27 @@ pub fn start(socket_path: &Path) -> std::io::Result<()> {
         .name("cuda-host".into())
         .spawn(move || {
             tracing::info!(path = path_display, "CUDA host server listening");
-            // Shared-daemon mode: when SMOLVM_CUDA_DAEMON=<host:port> is set, relay
-            // every guest connection to one external CUDA daemon instead of
-            // serving it in-process. All VMs then share that daemon's single GPU
-            // context — the prerequisite for a forked clone to reuse a golden
-            // VM's device memory (which lives in the daemon, not per-VM).
-            let daemon = std::env::var("SMOLVM_CUDA_DAEMON").ok();
+            // Shared-daemon mode: relay every guest connection to one CUDA daemon
+            // instead of serving it in-process, so all VMs share that daemon's
+            // single GPU context — the prerequisite for a forked clone to reuse a
+            // golden VM's device memory (which lives in the daemon, not per-VM).
+            //   SMOLVM_CUDA_SHARED=1  — smolvm spawns + manages the daemon.
+            //   SMOLVM_CUDA_DAEMON=X  — relay to an external daemon at address X
+            //                           (a host:port or a unix-socket path); also
+            //                           overrides the managed one.
+            let daemon = match std::env::var("SMOLVM_CUDA_DAEMON").ok() {
+                Some(addr) => Some(addr),
+                None if std::env::var("SMOLVM_CUDA_SHARED").as_deref() == Ok("1") => {
+                    match crate::cuda_daemon::ensure_running() {
+                        Ok(sock) => Some(sock.to_string_lossy().into_owned()),
+                        Err(e) => {
+                            tracing::warn!(error = %e, "cuda-host: managed daemon unavailable, serving in-process");
+                            None
+                        }
+                    }
+                }
+                None => None,
+            };
             if let Some(ref addr) = daemon {
                 tracing::info!(daemon = %addr, "cuda-host: shared-daemon proxy mode");
             }
@@ -92,15 +107,31 @@ pub fn start(socket_path: &Path) -> std::io::Result<()> {
 /// shared-host-daemon architecture: every VM's traffic lands in one process, so
 /// they share a single GPU context and device memory.
 fn proxy_to_daemon(guest: crate::platform::uds::UdsStream, addr: &str) -> std::io::Result<()> {
-    let daemon = std::net::TcpStream::connect(addr)?;
-    let _ = daemon.set_nodelay(true);
+    // A path (managed daemon) → unix socket; otherwise host:port → TCP.
+    if addr.starts_with('/') {
+        let daemon = std::os::unix::net::UnixStream::connect(addr)?;
+        pump(guest, daemon.try_clone()?, daemon)
+    } else {
+        let daemon = std::net::TcpStream::connect(addr)?;
+        let _ = daemon.set_nodelay(true);
+        pump(guest, daemon.try_clone()?, daemon)
+    }
+}
+
+/// Byte-pump the guest connection and a daemon connection in both directions.
+fn pump<D>(
+    guest: crate::platform::uds::UdsStream,
+    mut daemon_wr: D,
+    mut daemon_rd: D,
+) -> std::io::Result<()>
+where
+    D: std::io::Read + std::io::Write + Send + 'static,
+{
     let mut guest_rd = guest.try_clone()?;
-    let mut daemon_wr = daemon.try_clone()?;
+    let mut guest_wr = guest;
     let up = thread::spawn(move || {
         let _ = std::io::copy(&mut guest_rd, &mut daemon_wr);
     });
-    let mut daemon_rd = daemon;
-    let mut guest_wr = guest;
     let _ = std::io::copy(&mut daemon_rd, &mut guest_wr);
     let _ = up.join();
     Ok(())

--- a/src/cuda_host.rs
+++ b/src/cuda_host.rs
@@ -57,6 +57,9 @@ pub fn start(socket_path: &Path) -> std::io::Result<()> {
             //                           overrides the managed one.
             let daemon = match std::env::var("SMOLVM_CUDA_DAEMON").ok() {
                 Some(addr) => Some(addr),
+                // The smolvm-managed daemon is unix-only (see `cuda_daemon`); on
+                // other platforms SMOLVM_CUDA_SHARED just serves in-process.
+                #[cfg(unix)]
                 None if std::env::var("SMOLVM_CUDA_SHARED").as_deref() == Ok("1") => {
                     match crate::cuda_daemon::ensure_running() {
                         Ok(sock) => Some(sock.to_string_lossy().into_owned()),
@@ -109,13 +112,23 @@ pub fn start(socket_path: &Path) -> std::io::Result<()> {
 fn proxy_to_daemon(guest: crate::platform::uds::UdsStream, addr: &str) -> std::io::Result<()> {
     // A path (managed daemon) → unix socket; otherwise host:port → TCP.
     if addr.starts_with('/') {
-        let daemon = std::os::unix::net::UnixStream::connect(addr)?;
-        pump(guest, daemon.try_clone()?, daemon)
-    } else {
-        let daemon = std::net::TcpStream::connect(addr)?;
-        let _ = daemon.set_nodelay(true);
-        pump(guest, daemon.try_clone()?, daemon)
+        #[cfg(unix)]
+        {
+            let daemon = std::os::unix::net::UnixStream::connect(addr)?;
+            return pump(guest, daemon.try_clone()?, daemon);
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = guest;
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "unix-socket CUDA daemon unsupported on this platform; use SMOLVM_CUDA_DAEMON=host:port",
+            ));
+        }
     }
+    let daemon = std::net::TcpStream::connect(addr)?;
+    let _ = daemon.set_nodelay(true);
+    pump(guest, daemon.try_clone()?, daemon)
 }
 
 /// Byte-pump the guest connection and a daemon connection in both directions.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,10 @@
 pub mod agent;
 pub mod api;
 pub mod config;
+// The shared CUDA daemon manages unix-domain sockets, flock, and detached
+// process groups — all POSIX. GPU acceleration is unavailable on Windows anyway,
+// so the module (and its callers in cuda_host) are unix-only.
+#[cfg(unix)]
 pub mod cuda_daemon;
 pub mod cuda_host;
 /// Canonical shared data models and constants used across adapters.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@
 pub mod agent;
 pub mod api;
 pub mod config;
+pub mod cuda_daemon;
 pub mod cuda_host;
 /// Canonical shared data models and constants used across adapters.
 pub mod data;

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,13 @@ enum Commands {
         config: std::path::PathBuf,
     },
 
+    /// Internal: run the shared CUDA daemon (not for direct use)
+    #[command(name = "_cuda-daemon", hide = true)]
+    CudaDaemon {
+        /// Control-socket path to bind
+        socket: std::path::PathBuf,
+    },
+
     /// Internal: clean up an ephemeral VM after its command exits (not for direct use)
     #[command(name = "_cleanup-ephemeral", hide = true)]
     CleanupEphemeral {
@@ -75,9 +82,13 @@ fn main() {
     // still carries the packed footer/sidecar, so without this guard it would
     // re-trigger packed-mode detection and rehydrate again instead of booting
     // the VM from the config it was handed.
-    let is_boot_vm =
-        std::env::args_os().nth(1).as_deref() == Some(std::ffi::OsStr::new("_boot-vm"));
-    if !is_boot_vm {
+    // Internal re-invocations (`_boot-vm`, `_cuda-daemon`) run the same packed
+    // executable but must do their job, not re-trigger packed rehydration.
+    let internal = matches!(
+        std::env::args_os().nth(1).as_deref().and_then(|s| s.to_str()),
+        Some("_boot-vm") | Some("_cuda-daemon")
+    );
+    if !internal {
         if let Some(mode) = smolvm_pack::detect_packed_mode() {
             cli::pack_run::run_as_packed_binary(mode);
         }
@@ -98,6 +109,9 @@ fn main() {
         Commands::Pack(cmd) => cmd.run(),
         Commands::Config(cmd) => cmd.run(),
         Commands::BootVm { config } => cli::internal_boot::run(config),
+        Commands::CudaDaemon { socket } => {
+            smolvm::cuda_daemon::run(&socket).map_err(smolvm::Error::Io)
+        }
         Commands::CleanupEphemeral {
             vm_name,
             pid,

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,10 @@ fn main() {
     // Internal re-invocations (`_boot-vm`, `_cuda-daemon`) run the same packed
     // executable but must do their job, not re-trigger packed rehydration.
     let internal = matches!(
-        std::env::args_os().nth(1).as_deref().and_then(|s| s.to_str()),
+        std::env::args_os()
+            .nth(1)
+            .as_deref()
+            .and_then(|s| s.to_str()),
         Some("_boot-vm") | Some("_cuda-daemon")
     );
     if !internal {
@@ -109,9 +112,15 @@ fn main() {
         Commands::Pack(cmd) => cmd.run(),
         Commands::Config(cmd) => cmd.run(),
         Commands::BootVm { config } => cli::internal_boot::run(config),
+        #[cfg(unix)]
         Commands::CudaDaemon { socket } => {
             smolvm::cuda_daemon::run(&socket).map_err(smolvm::Error::Io)
         }
+        #[cfg(not(unix))]
+        Commands::CudaDaemon { .. } => Err(smolvm::Error::Io(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "the shared CUDA daemon is unix-only",
+        ))),
         Commands::CleanupEphemeral {
             vm_name,
             pid,

--- a/src/util.rs
+++ b/src/util.rs
@@ -99,6 +99,40 @@ pub fn parse_env_list(env_args: &[String]) -> Vec<(String, String)> {
     env_args.iter().filter_map(|e| parse_env_spec(e)).collect()
 }
 
+/// Parse a byte size like `16GiB`, `16G`, `512M`, or a plain byte count
+/// (`17179869184`). Suffixes are binary (1K = 1024); `K/M/G/T`, optionally with
+/// a trailing `i` and/or `B`, are accepted case-insensitively.
+pub fn parse_size_bytes(s: &str) -> Result<u64, String> {
+    let t = s.trim();
+    if t.is_empty() {
+        return Err("size must not be empty".to_string());
+    }
+    let split = t
+        .find(|c: char| !c.is_ascii_digit() && c != '.')
+        .unwrap_or(t.len());
+    let (num, unit) = t.split_at(split);
+    let value: f64 = num
+        .parse()
+        .map_err(|_| format!("'{s}' is not a valid size (expected a number, optional K/M/G/T)"))?;
+    let mult: u64 = match unit.trim().to_ascii_lowercase().as_str() {
+        "" | "b" => 1,
+        "k" | "ki" | "kib" | "kb" => 1 << 10,
+        "m" | "mi" | "mib" | "mb" => 1 << 20,
+        "g" | "gi" | "gib" | "gb" => 1 << 30,
+        "t" | "ti" | "tib" | "tb" => 1u64 << 40,
+        other => {
+            return Err(format!(
+                "invalid size unit '{other}' in '{s}' (use K, M, G, or T)"
+            ))
+        }
+    };
+    let bytes = (value * mult as f64) as u64;
+    if bytes == 0 {
+        return Err(format!("size '{s}' must be greater than zero"));
+    }
+    Ok(bytes)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Raw context-scoped handles + cuBLAS/CUDA-graph handoff + transport-severance reconnect let a warm CUDA VM fork into clones that reuse the golden's GPU state; adds a shared CUDA daemon (idle-timeout + auto-enable for forkable machines), packed .smolmachine CUDA support, and driver-shim + libnvidia-ml NVML shim fixes so unmodified vLLM (torch.compile + cudagraphs) runs and fork-resumes through the remoting.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/616">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->