### PR TITLE
chore: re-vendor libkrun at f55362a for the TSI remote-half-close fix

### DIFF
--- a/lib/libkrun.dylib
+++ b/lib/libkrun.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7d909151d6a00f7e3f81f25dfc8da121d86a39e9f61e21da8eb5c462f9fc7a5c
-size 6152000
+oid sha256:2c566ece1d0ea168b4b2df62392ad56ff1e51f30cccfd3fdb82f7454a1f3cc6b
+size 6152544

--- a/lib/libkrun.provenance
+++ b/lib/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=6f757b39fd303423f1d861b22356ae143558a300
+libkrun=f55362a2b8e402a71163c667041827299751f87b
 libkrunfw=37f73dadb7e64610642d7041c163b8dbf0e9a1ef

--- a/lib/linux-aarch64/libkrun.provenance
+++ b/lib/linux-aarch64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=6f757b39fd303423f1d861b22356ae143558a300
+libkrun=f55362a2b8e402a71163c667041827299751f87b
 libkrunfw=37f73dadb7e64610642d7041c163b8dbf0e9a1ef

--- a/lib/linux-aarch64/libkrun.so
+++ b/lib/linux-aarch64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e34592631146eee4a190d1f3a350dd7a68fb842ceea8db792003ef35d632bf92
-size 6981416
+oid sha256:469d3b83a9844d12fe33eb5999401e7e7e1e4693a42c5ec7a178af7a647fcdb0
+size 6983640

--- a/lib/linux-aarch64/libkrun.so.2.0.0
+++ b/lib/linux-aarch64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e34592631146eee4a190d1f3a350dd7a68fb842ceea8db792003ef35d632bf92
-size 6981416
+oid sha256:469d3b83a9844d12fe33eb5999401e7e7e1e4693a42c5ec7a178af7a647fcdb0
+size 6983640

--- a/lib/linux-x86_64/libkrun.provenance
+++ b/lib/linux-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=6f757b39fd303423f1d861b22356ae143558a300
+libkrun=f55362a2b8e402a71163c667041827299751f87b
 libkrunfw=37f73dadb7e64610642d7041c163b8dbf0e9a1ef

--- a/lib/linux-x86_64/libkrun.so
+++ b/lib/linux-x86_64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:83d6661e2cf28abe01fe6f1caceb42c6cd53ae255faeeb41a0de34ad63bf1e7c
-size 7846672
+oid sha256:786c9617cc28275db5ce95c19a1746d115de41dfc73e4ef9d06da3c015ec34f2
+size 7959224

--- a/lib/linux-x86_64/libkrun.so.2.0.0
+++ b/lib/linux-x86_64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:83d6661e2cf28abe01fe6f1caceb42c6cd53ae255faeeb41a0de34ad63bf1e7c
-size 7846672
+oid sha256:786c9617cc28275db5ce95c19a1746d115de41dfc73e4ef9d06da3c015ec34f2
+size 7959224

--- a/lib/windows-x86_64/krun.dll
+++ b/lib/windows-x86_64/krun.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dcb0261dcdcfaf9f4a0b9df0b8a29e2b9ce90818ce89223dce4cdb991b5e4ecb
-size 10383640
+oid sha256:6254be2c94bde52be9e4e8120beffa71aee609cec009f49b9db5d4bfac2dbde5
+size 10384390

--- a/lib/windows-x86_64/libkrun.provenance
+++ b/lib/windows-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=6f757b39fd303423f1d861b22356ae143558a300
+libkrun=f55362a2b8e402a71163c667041827299751f87b
 libkrunfw=37f73dadb7e64610642d7041c163b8dbf0e9a1ef


### PR DESCRIPTION
Bumps the libkrun submodule to f55362a and rebuilds the bundled libs for all four platforms, carrying the TSI outbound half-close fix into smolvm.