### PR TITLE
Fix the pacman repo build so it packages both architectures

### DIFF
--- a/.github/workflows/pacman-repo.yml
+++ b/.github/workflows/pacman-repo.yml
@@ -36,6 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: archlinux:base-devel
+      # fakeroot's SysV IPC breaks under GitHub's default container seccomp
+      # profile ("libfakeroot: payload not recognized" during makepkg package());
+      # unconfined seccomp lets faked's msgsnd/msgrcv through.
+      options: --security-opt seccomp=unconfined
     env:
       GH_TOKEN: ${{ github.token }}
     steps:

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -41,6 +41,23 @@ sha256sums_aarch64=(
     'f3e339635359b29cb60407e5d7deac3d4199870d8af2034c37c74f0f1c5530e8'
 )
 
+# makepkg extracts with bsdtar (libarchive), which desyncs on the fully-sparse
+# storage-template.ext4 in the arm64 tarball and silently drops every later
+# member — including the smolvm wrapper — so package()'s `sed ... smolvm` fails.
+# GNU tar handles the sparse member correctly, so skip makepkg's auto-extract
+# and unpack the arch tarball ourselves in prepare().
+noextract=(
+    "$pkgname-$pkgver-linux-x86_64.tar.gz"
+    "$pkgname-$pkgver-linux-arm64.tar.gz"
+)
+
+prepare() {
+    case "$CARCH" in
+        x86_64)  tar -xf "$pkgname-$pkgver-linux-x86_64.tar.gz" ;;
+        aarch64) tar -xf "$pkgname-$pkgver-linux-arm64.tar.gz" ;;
+    esac
+}
+
 package() {
     case "$CARCH" in
         x86_64)  _dir="$pkgname-$pkgver-linux-x86_64" ;;


### PR DESCRIPTION
Run the Arch build with unconfined seccomp so fakeroot works in the container, and extract the release tarballs with GNU tar so the sparse storage template unpacks fully.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/626">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->