### PR TITLE
Make VM boot failures diagnosable instead of opaque

### DIFF
--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -1027,6 +1027,10 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
         // Redirect console output to a file if specified, via the upstream
         // virtio-console API (krun_set_console_output was removed).
         if let Some(log_path) = console_log {
+            // Truncate first so the log reflects only this boot — libkrun appends,
+            // and reused per-machine dirs otherwise show a prior boot's console for
+            // a failed boot. See launcher_dynamic::truncate_console_log.
+            super::launcher_dynamic::truncate_console_log(log_path);
             if krun.console_output_to_file(ctx, log_path) < 0 {
                 // Expected on Windows (fd-based console redirection is a no-op
                 // there); don't let a benign WARN mask the real boot failure the
@@ -1436,7 +1440,7 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
         drop(virtio_network_runtime);
         Err(Error::agent(
             "start vm",
-            format!("krun_start_enter returned: {}", ret),
+            super::launcher_dynamic::describe_krun_start_error(ret),
         ))
     }
 }

--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -496,6 +496,15 @@ pub fn launch_agent_vm_dynamic(
         }
     }
 
+    // Truncate the console log so it reflects only THIS boot. libkrun's
+    // virtio-console opens the file in append mode, so a per-machine dir that is
+    // reused across boots (e.g. the deterministic ephemeral `run` dir) otherwise
+    // accumulates every past boot's console. A boot that fails then shows a prior
+    // run's *successful* console, making a real boot failure look like a healthy
+    // boot that mysteriously shut down — actively misleading whoever debugs it.
+    // Best-effort: if truncation fails we still boot (worst case, stale history).
+    truncate_console_log(&config.console_log);
+
     // Redirect console output to a log file so libkrun doesn't put the
     // inherited terminal into raw mode (which would break terminal echo
     // if the child is killed before exit observers can restore it). Uses the
@@ -680,12 +689,51 @@ pub fn launch_agent_vm_dynamic(
     // SAFETY: ctx is a valid context from krun_create_ctx
     unsafe { (krun.free_ctx)(ctx) };
     drop(virtio_network_runtime);
-    Err(format!("krun_start_enter returned: {}", ret))
+    Err(describe_krun_start_error(ret))
 }
 
 /// Create a CString from a static string that is known not to contain NUL bytes.
 fn cstr(s: &str) -> CString {
     CString::new(s).expect("string literal must not contain NUL bytes")
+}
+
+/// Turn a `krun_start_enter` failure code into an actionable message.
+///
+/// libkrun returns a negative errno; the bare number ("krun_start_enter
+/// returned: -22") is opaque and, when it bubbles up through the readiness
+/// monitor as "boot process exited before the agent was ready", tells the user
+/// nothing about what to fix. Decode the common codes and name the usual cause.
+pub(crate) fn describe_krun_start_error(ret: i32) -> String {
+    let errno = -ret;
+    let hint = match errno {
+        22 => "EINVAL — libkrun rejected the VM configuration; usually a disk/overlay \
+               that could not be opened (still held by another VM that has not fully \
+               exited, or a corrupt/foreign-owned image) or an unsupported device option",
+        5 => "EIO — a backing disk or overlay could not be read/created",
+        13 => "EACCES — permission denied opening a VM resource (disk, socket, or rootfs)",
+        16 => "EBUSY — a VM resource is already in use by another process",
+        12 => "ENOMEM — out of memory starting the VM",
+        1 => "EPERM — the hypervisor rejected the operation (KVM/HVF/WHP access)",
+        19 => "ENODEV — the hypervisor device is unavailable (is KVM/HVF/WHP enabled?)",
+        _ => "the VM failed to start at the hypervisor layer",
+    };
+    format!("krun_start_enter returned: {ret} ({hint})")
+}
+
+/// Truncate the guest console log to empty so it holds only the current boot.
+///
+/// libkrun's virtio-console appends, and per-machine dirs are reused across
+/// boots, so without this the console grows unbounded and — worse — a failed
+/// boot inherits the previous boot's output, so the log shows a successful boot
+/// that does not correspond to the crashed run. Only truncates a file that
+/// already exists (never creates a spurious log where console capture is a no-op,
+/// e.g. Windows); a failure here is non-fatal.
+pub(crate) fn truncate_console_log(path: &Path) {
+    if path.exists() {
+        if let Err(e) = std::fs::OpenOptions::new().write(true).truncate(true).open(path) {
+            tracing::debug!(path = %path.display(), error = %e, "could not truncate console log");
+        }
+    }
 }
 
 /// Convert a Path to a CString.
@@ -721,5 +769,45 @@ fn raise_fd_limits() {
             limit.rlim_cur = limit.rlim_max;
             libc::setrlimit(libc::RLIMIT_NOFILE, &limit);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn describe_krun_start_error_decodes_common_codes() {
+        // The exact string the readiness monitor greps for must survive so
+        // boot_failure_reason still surfaces it as "the error".
+        let einval = describe_krun_start_error(-22);
+        assert!(einval.contains("krun_start_enter returned: -22"));
+        assert!(einval.contains("EINVAL"));
+        assert!(describe_krun_start_error(-13).contains("EACCES"));
+        // Unknown codes still render the raw number with a generic explanation.
+        let unknown = describe_krun_start_error(-999);
+        assert!(unknown.contains("-999"));
+        assert!(unknown.contains("hypervisor"));
+    }
+
+    #[test]
+    fn truncate_console_log_clears_prior_boot_output() {
+        let dir = std::env::temp_dir().join(format!("smolvm-console-trunc-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let log = dir.join("agent-console.log");
+        // A prior boot's console is present.
+        std::fs::write(&log, b"PRIOR BOOT: agent init complete\n").unwrap();
+        assert!(std::fs::metadata(&log).unwrap().len() > 0);
+
+        truncate_console_log(&log);
+
+        // The next boot starts from an empty file — no stale success lines.
+        assert_eq!(std::fs::metadata(&log).unwrap().len(), 0);
+        // A missing log is left untouched (no spurious file where capture is a no-op).
+        let missing = dir.join("nope.log");
+        truncate_console_log(&missing);
+        assert!(!missing.exists());
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -706,9 +706,11 @@ fn cstr(s: &str) -> CString {
 pub(crate) fn describe_krun_start_error(ret: i32) -> String {
     let errno = -ret;
     let hint = match errno {
-        22 => "EINVAL — libkrun rejected the VM configuration; usually a disk/overlay \
+        22 => {
+            "EINVAL — libkrun rejected the VM configuration; usually a disk/overlay \
                that could not be opened (still held by another VM that has not fully \
-               exited, or a corrupt/foreign-owned image) or an unsupported device option",
+               exited, or a corrupt/foreign-owned image) or an unsupported device option"
+        }
         5 => "EIO — a backing disk or overlay could not be read/created",
         13 => "EACCES — permission denied opening a VM resource (disk, socket, or rootfs)",
         16 => "EBUSY — a VM resource is already in use by another process",
@@ -730,7 +732,11 @@ pub(crate) fn describe_krun_start_error(ret: i32) -> String {
 /// e.g. Windows); a failure here is non-fatal.
 pub(crate) fn truncate_console_log(path: &Path) {
     if path.exists() {
-        if let Err(e) = std::fs::OpenOptions::new().write(true).truncate(true).open(path) {
+        if let Err(e) = std::fs::OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(path)
+        {
             tracing::debug!(path = %path.display(), error = %e, "could not truncate console log");
         }
     }


### PR DESCRIPTION
Decode the libkrun start-enter error code into an actionable message and reset the guest console log at each boot so a failed boot no longer shows a prior run's output.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/627">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->