### PR TITLE
Detect a stale CUDA guest shim at boot instead of an opaque cuInit failure

### DIFF
--- a/crates/smolvm-cuda-guest/src/main.rs
+++ b/crates/smolvm-cuda-guest/src/main.rs
@@ -276,8 +276,20 @@ fn as_bytes(v: &[f32]) -> &[u8] {
     unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, std::mem::size_of_val(v)) }
 }
 
+/// `--proto-hash`: print the wire fingerprint and exit, before any VM-only work.
+/// Lets `scripts/build-agent-rootfs.sh` stamp the shim's hash into the rootfs
+/// without re-deriving the FNV algorithm, so the host can spot a stale rootfs at
+/// boot (see `internal_boot`) instead of a cryptic `cuInit` failure mid-workload.
+fn print_proto_hash_and_exit() {
+    if std::env::args().any(|a| a == "--proto-hash") {
+        println!("{:016x}", smolvm_cuda::PROTO_HASH);
+        std::process::exit(0);
+    }
+}
+
 #[cfg(target_os = "linux")]
 fn main() {
+    print_proto_hash_and_exit();
     if let Err(e) = run() {
         eprintln!("smolvm-cuda: ERROR: {e}");
         std::process::exit(1);
@@ -286,6 +298,7 @@ fn main() {
 
 #[cfg(not(target_os = "linux"))]
 fn main() {
+    print_proto_hash_and_exit();
     eprintln!("smolvm-cuda-run runs only inside a Linux guest microVM");
     std::process::exit(1);
 }

--- a/scripts/build-agent-rootfs.sh
+++ b/scripts/build-agent-rootfs.sh
@@ -321,6 +321,25 @@ if [[ "$NO_BUILD_AGENT" != "1" && "$(uname -s)" == "Linux" && "$(uname -m)" == "
         cp "$PROJECT_ROOT/target/release/libcuda.so" \
             "$OUTPUT_DIR/usr/local/lib/smolvm-cuda/libcuda.so.1"
         echo "Installed CUDA guest shims"
+        # Stamp the shims' wire fingerprint into the rootfs so the host can flag a
+        # stale rootfs at boot (internal_boot's warn_if_stale_cuda_shim) instead of
+        # leaving the user with an opaque cuInit failure. Read it from the guest
+        # runner (built from the same smolvm-cuda source as the shims, so the same
+        # PROTO_HASH); fall back to a quick native build of that same binary.
+        PROTO_HASH=""
+        if [[ -n "${CUDA_GUEST_BINARY:-}" && -x "${CUDA_GUEST_BINARY:-}" ]]; then
+            PROTO_HASH="$("$CUDA_GUEST_BINARY" --proto-hash 2>/dev/null || true)"
+        fi
+        if [[ -z "$PROTO_HASH" ]]; then
+            PROTO_HASH="$(cargo run --release -q -p smolvm-cuda-guest \
+                --manifest-path "$PROJECT_ROOT/Cargo.toml" -- --proto-hash 2>/dev/null || true)"
+        fi
+        if [[ -n "$PROTO_HASH" ]]; then
+            printf '%s\n' "$PROTO_HASH" > "$OUTPUT_DIR/usr/local/lib/smolvm-cuda/proto-hash"
+            echo "Stamped CUDA shim proto-hash: $PROTO_HASH"
+        else
+            echo "Could not determine CUDA proto-hash — rootfs left unstamped (boot check skips)"
+        fi
     else
         echo "CUDA guest shim build failed — rootfs ships without auto-staging"
     fi

--- a/src/cli/internal_boot.rs
+++ b/src/cli/internal_boot.rs
@@ -490,6 +490,33 @@ pub fn run(config_path: PathBuf) -> smolvm::Result<()> {
     {
         Some(std::path::PathBuf::from(p))
     } else if config.cuda {
+        // Before booting: if the CUDA guest shims baked into this rootfs were
+        // built from different wire source than this host binary, say so now with
+        // the exact fix — otherwise the skew only surfaces as an opaque cuInit
+        // failure deep inside the guest's first real CUDA call. The connect
+        // handshake still hard-rejects a mismatch; this is the early, legible heads-up.
+        fn warn_if_stale_cuda_shim(rootfs: &std::path::Path) {
+            let stamp = rootfs.join("usr/local/lib/smolvm-cuda/proto-hash");
+            let Ok(text) = std::fs::read_to_string(&stamp) else {
+                return; // pre-stamp rootfs (no marker) — handshake still guards it
+            };
+            let Ok(shim) = u64::from_str_radix(text.trim(), 16) else {
+                return; // unrecognized marker — don't second-guess it
+            };
+            if shim != smolvm::cuda_host::PROTO_HASH {
+                let msg = format!(
+                    "CUDA guest shim in the agent rootfs is STALE: rootfs wire hash {:016x} != \
+                     this host {:016x}. The guest's CUDA calls will fail at cuInit. Rebuild the \
+                     rootfs from the same source: scripts/build-agent-rootfs.sh --install",
+                    shim,
+                    smolvm::cuda_host::PROTO_HASH
+                );
+                tracing::warn!("{msg}");
+                eprintln!("[smolvm] WARNING: {msg}");
+            }
+        }
+        warn_if_stale_cuda_shim(&config.rootfs_path);
+
         let path = config
             .vsock_socket
             .parent()

--- a/src/cuda_host.rs
+++ b/src/cuda_host.rs
@@ -17,6 +17,12 @@ use std::path::Path;
 use std::sync::OnceLock;
 use std::thread;
 
+/// The host's CUDA wire fingerprint (see [`smolvm_cuda::PROTO_HASH`]). Re-exported
+/// so smolvm-side callers (e.g. the boot-time stale-rootfs check in
+/// `internal_boot`) can compare it against the shim hash stamped into the agent
+/// rootfs, without taking a direct dependency on the `smolvm-cuda` crate.
+pub use smolvm_cuda::PROTO_HASH;
+
 /// Provider for the guest-RAM regions, each `(gpa_start, host_va, len)`,
 /// installed by the launcher (via `krun_get_guest_ram`) before the VM starts.
 /// Each connection's backend queries it to enable guest-RAM zero-copy


### PR DESCRIPTION
Stamp the CUDA shims' wire fingerprint into the agent rootfs at build time and check it against the host's compiled PROTO_HASH at machine-start, so a rootfs rebuilt out of lockstep with the host warns early with the exact rebuild command instead of failing cryptically at cuInit deep inside the workload.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/630">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->