### PR TITLE
feat: expose the docker-socket bridge in the machines HTTP API

### DIFF
--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -1992,6 +1992,7 @@ mod tests {
             ports: vec![],
             network: false,
             gpu: false,
+            docker_socket: false,
             storage_gb: None,
             overlay_gb: None,
             allowed_cidrs: None,

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -667,6 +667,7 @@ pub async fn create_machine(
             None => RestartConfig::default(),
         },
         network,
+        docker_socket: req.docker_socket,
         image,
         source_smolmachine,
         entrypoint,

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -108,6 +108,8 @@ pub struct MachineRegistration {
     pub restart: RestartConfig,
     /// Whether outbound network access is enabled.
     pub network: bool,
+    /// Whether to expose the guest Docker daemon socket to the host.
+    pub docker_socket: bool,
     /// OCI image reference (e.g., "alpine:latest").
     pub image: Option<String>,
     /// Path to .smolmachine sidecar this machine was created from.
@@ -818,6 +820,7 @@ impl ApiState {
         record.allowed_cidrs = reg.resources.allowed_cidrs.clone();
         record.dns_filter_hosts = reg.resources.allowed_hosts.clone();
         record.network_backend = reg.resources.network_backend;
+        record.docker_socket = reg.docker_socket;
         record.image = reg.image;
         record.source_smolmachine = reg.source_smolmachine.clone();
         record.entrypoint = reg.entrypoint;

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -459,6 +459,11 @@ pub struct CreateMachineRequest {
     /// Enable GPU acceleration (Vulkan via virtio-gpu).
     #[serde(default)]
     pub gpu: bool,
+    /// Expose the guest's Docker daemon socket to the host as a Unix socket in
+    /// the VM data dir, so a host client can drive it with `DOCKER_HOST=unix://…`.
+    /// Off by default.
+    #[serde(default)]
+    pub docker_socket: bool,
     /// Storage disk size in GiB (default: 20).
     #[serde(default)]
     pub storage_gb: Option<u64>,


### PR DESCRIPTION
Adds `docker_socket` (`dockerSocket` in OpenAPI) to `CreateMachineRequest` and threads it onto the persisted `VmRecord`, so the cloud control plane and SDKs can enable the guest-Docker-socket bridge that was previously CLI/Smolfile-only.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/631">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->