### PR TITLE
CUDA Path 3: address-preserving per-clone-process fork isolation

### DIFF
--- a/crates/smolvm-cuda/examples/m1_route_probe.rs
+++ b/crates/smolvm-cuda/examples/m1_route_probe.rs
@@ -1,0 +1,86 @@
+//! Path 3 M1 routing probe: connect to a running cuda-daemon as an ISOLATING fork
+//! clone (`init` with resume_token=1). With SMOLVM_CUDA_PATH3=1 +
+//! SMOLVM_CUDA_FORK_ISOLATE=1 the daemon serves us in a dedicated worker PROCESS
+//! (its own CUDA context/UVA). We then run a real vecadd kernel and verify —
+//! proving the routed worker process serves the clone correctly (M1).
+//!
+//! Run: cargo run --release --example m1_route_probe -p smolvm-cuda -- <daemon.sock>
+use smolvm_cuda::client::Client;
+use std::os::unix::net::UnixStream;
+
+const VECADD_PTX: &str = r#".version 7.0
+.target sm_52
+.address_size 64
+.visible .entry vecadd(.param .u64 a, .param .u64 b, .param .u64 c, .param .u32 n)
+{ .reg .pred %p<2>; .reg .f32 %f<4>; .reg .b32 %r<6>; .reg .b64 %rd<11>;
+ ld.param.u64 %rd1,[a]; ld.param.u64 %rd2,[b]; ld.param.u64 %rd3,[c]; ld.param.u32 %r2,[n];
+ mov.u32 %r3,%ntid.x; mov.u32 %r4,%ctaid.x; mov.u32 %r5,%tid.x; mad.lo.s32 %r1,%r4,%r3,%r5;
+ setp.ge.u32 %p1,%r1,%r2; @%p1 bra $E;
+ cvta.to.global.u64 %rd4,%rd1; cvta.to.global.u64 %rd5,%rd2; cvta.to.global.u64 %rd6,%rd3;
+ mul.wide.u32 %rd7,%r1,4; add.s64 %rd8,%rd4,%rd7; add.s64 %rd9,%rd5,%rd7; add.s64 %rd10,%rd6,%rd7;
+ ld.global.f32 %f1,[%rd8]; ld.global.f32 %f2,[%rd9]; add.f32 %f3,%f1,%f2; st.global.f32 [%rd10],%f3;
+$E: ret; }
+"#;
+
+fn bytemuck(v: &[f32]) -> &[u8] {
+    // SAFETY: f32 has no invalid bit patterns; reading its bytes is sound.
+    unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, std::mem::size_of_val(v)) }
+}
+
+fn main() {
+    let sock = std::env::args()
+        .nth(1)
+        .expect("usage: m1_route_probe <daemon.sock>");
+    let stream = UnixStream::connect(&sock).expect("connect daemon");
+    let mut cu = Client::new(stream);
+    let token = cu.init(1).expect("init (isolating clone, resume_token=1)");
+    eprintln!("m1_route_probe: connected as isolating clone; server token={token}");
+    let _ctx = cu.primary_ctx_retain(0).expect("primary ctx retain");
+    let name = cu.device_get_name(0).expect("device name");
+
+    let module = cu
+        .module_load_data(VECADD_PTX.as_bytes())
+        .expect("module load");
+    let func = cu
+        .module_get_function(module, "vecadd")
+        .expect("get function");
+    let n: usize = 1 << 16;
+    let bytes = (n * 4) as u64;
+    let a: Vec<f32> = (0..n).map(|i| i as f32).collect();
+    let b: Vec<f32> = (0..n).map(|i| (3 * i) as f32).collect();
+    let da = cu.mem_alloc(bytes).expect("alloc a");
+    let db = cu.mem_alloc(bytes).expect("alloc b");
+    let dc = cu.mem_alloc(bytes).expect("alloc c");
+    cu.memcpy_htod(da, bytemuck(&a), 0).expect("h2d a");
+    cu.memcpy_htod(db, bytemuck(&b), 0).expect("h2d b");
+    let block = 256u32;
+    let grid = (n as u32).div_ceil(block);
+    cu.launch_kernel(
+        func,
+        [grid, 1, 1],
+        [block, 1, 1],
+        0,
+        0,
+        &[
+            da.to_le_bytes().to_vec(),
+            db.to_le_bytes().to_vec(),
+            dc.to_le_bytes().to_vec(),
+            (n as u32).to_le_bytes().to_vec(),
+        ],
+    )
+    .expect("launch");
+    cu.ctx_synchronize().expect("sync");
+    let out = cu.memcpy_dtoh(dc, bytes, 0).expect("d2h");
+    let c: Vec<f32> = out
+        .chunks_exact(4)
+        .map(|p| f32::from_le_bytes(p.try_into().unwrap()))
+        .collect();
+    let ok = (0..n).all(|i| (c[i] - (a[i] + b[i])).abs() < 1e-2);
+    println!(
+        "M1-ROUTE-PROBE {}: device={name} vecadd[7]={} (want {})",
+        if ok { "PASS" } else { "FAIL" },
+        c[7],
+        a[7] + b[7]
+    );
+    std::process::exit(if ok { 0 } else { 3 });
+}

--- a/crates/smolvm-cuda/examples/m2_reconstruct_probe.rs
+++ b/crates/smolvm-cuda/examples/m2_reconstruct_probe.rs
@@ -1,0 +1,85 @@
+//! Path 3 M2 validation (with isolation): golden allocates VMM memory (exportable)
+//! and writes pattern P1; a clone (routed to a worker PROCESS) reconstructs the
+//! golden's memory at the golden's EXACT VA, reads P1 (shared data), then WRITES
+//! P2. The golden then re-reads its VA and must still see P1 — proving the clone's
+//! writes hit a PRIVATE copy at the same virtual address (address-preserving
+//! isolation through the real daemon).
+//!
+//! Roles:  m2_reconstruct_probe golden <sock> <statefile>
+//!         m2_reconstruct_probe clone  <sock> <statefile>
+use smolvm_cuda::client::Client;
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+
+fn pattern(size: u64, seed: u8) -> Vec<u8> {
+    (0..size)
+        .map(|i| (i as u8).wrapping_mul(37) ^ seed)
+        .collect()
+}
+fn wait_for(p: &str) {
+    for _ in 0..600 {
+        if Path::new(p).exists() {
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
+fn main() {
+    let a: Vec<String> = std::env::args().collect();
+    let (role, sock, state) = (a[1].as_str(), a[2].as_str(), a[3].as_str());
+    let done = format!("{state}.clonedone");
+    match role {
+        "golden" => {
+            let mut cu = Client::new(UnixStream::connect(sock).expect("connect"));
+            let token = cu.init(0).expect("init golden");
+            cu.primary_ctx_retain(0).expect("ctx");
+            let gran = cu.mem_get_allocation_granularity(0, 0).expect("gran");
+            let size = gran;
+            let va = cu.mem_address_reserve(size, gran).expect("reserve");
+            let h = cu
+                .mem_create(size, 0)
+                .expect("create (exportable under PATH3)");
+            cu.mem_map(va, size, 0, h).expect("map");
+            cu.mem_set_access(va, size, 0).expect("set_access");
+            cu.memcpy_htod(va, &pattern(size, 0x5A), 0).expect("h2d P1");
+            std::fs::write(state, format!("{token} {va} {size}")).expect("write state");
+            eprintln!("golden: token={token} va={va:#x} — wrote P1, waiting for clone");
+            wait_for(&done); // clone has written P2 to the same VA in its own process
+            let after = cu.memcpy_dtoh(va, size, 0).expect("golden re-read");
+            let uncorrupted = after == pattern(size, 0x5A);
+            std::fs::write(
+                format!("{state}.goldenafter"),
+                if uncorrupted {
+                    "UNCORRUPTED"
+                } else {
+                    "CORRUPTED"
+                },
+            )
+            .ok();
+            eprintln!("golden: re-read after clone write — uncorrupted={uncorrupted}");
+            loop {
+                std::thread::sleep(std::time::Duration::from_secs(3600));
+            }
+        }
+        "clone" => {
+            let s = std::fs::read_to_string(state).expect("read state");
+            let p: Vec<u64> = s.split_whitespace().map(|x| x.parse().unwrap()).collect();
+            let (token, va, size) = (p[0], p[1], p[2]);
+            let mut cu = Client::new(UnixStream::connect(sock).expect("connect"));
+            let t = cu.init(token).expect("init clone");
+            cu.primary_ctx_retain(0).expect("ctx");
+            eprintln!("clone: resumed token={token} (server={t}); golden VA {va:#x}");
+            let read_ok = cu.memcpy_dtoh(va, size, 0).expect("d2h") == pattern(size, 0x5A);
+            cu.memcpy_htod(va, &pattern(size, 0xC3), 0)
+                .expect("clone write P2");
+            let write_ok = cu.memcpy_dtoh(va, size, 0).expect("d2h") == pattern(size, 0xC3);
+            std::fs::write(&done, "done").ok();
+            println!(
+                "M2-ISO-PROBE(clone): read_golden_data={read_ok} clone_private_write={write_ok}"
+            );
+            std::process::exit(if read_ok && write_ok { 0 } else { 4 });
+        }
+        _ => std::process::exit(2),
+    }
+}

--- a/crates/smolvm-cuda/examples/m3a_probe.rs
+++ b/crates/smolvm-cuda/examples/m3a_probe.rs
@@ -1,0 +1,135 @@
+//! Path 3 M3a validation: golden loads a module + resolves a function + allocates
+//! VMM buffers (a,b,c) and writes a,b; a clone (routed to a worker PROCESS)
+//! reconstructs memory (M2) AND reloads the module + remaps handles (M3a), then
+//! LAUNCHES the kernel using the golden's INHERITED function handle. The worker
+//! translates it to its own reloaded function → vecadd runs → c = a+b. Proves
+//! module reload + inherited-handle translation end-to-end through the daemon.
+//!
+//! Roles:  m3a_probe golden <sock> <statefile>   |   m3a_probe clone <sock> <statefile>
+use smolvm_cuda::client::Client;
+use std::os::unix::net::UnixStream;
+
+const VECADD_PTX: &str = r#".version 7.0
+.target sm_52
+.address_size 64
+.visible .entry vecadd(.param .u64 a, .param .u64 b, .param .u64 c, .param .u32 n)
+{ .reg .pred %p<2>; .reg .f32 %f<4>; .reg .b32 %r<6>; .reg .b64 %rd<11>;
+ ld.param.u64 %rd1,[a]; ld.param.u64 %rd2,[b]; ld.param.u64 %rd3,[c]; ld.param.u32 %r2,[n];
+ mov.u32 %r3,%ntid.x; mov.u32 %r4,%ctaid.x; mov.u32 %r5,%tid.x; mad.lo.s32 %r1,%r4,%r3,%r5;
+ setp.ge.u32 %p1,%r1,%r2; @%p1 bra $E;
+ cvta.to.global.u64 %rd4,%rd1; cvta.to.global.u64 %rd5,%rd2; cvta.to.global.u64 %rd6,%rd3;
+ mul.wide.u32 %rd7,%r1,4; add.s64 %rd8,%rd4,%rd7; add.s64 %rd9,%rd5,%rd7; add.s64 %rd10,%rd6,%rd7;
+ ld.global.f32 %f1,[%rd8]; ld.global.f32 %f2,[%rd9]; add.f32 %f3,%f1,%f2; st.global.f32 [%rd10],%f3;
+$E: ret; }
+"#;
+
+fn bytes(v: &[f32]) -> &[u8] {
+    unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, std::mem::size_of_val(v)) }
+}
+fn vmm_buf(cu: &mut Client<UnixStream>, size: u64, gran: u64) -> u64 {
+    let va = cu.mem_address_reserve(size, gran).expect("reserve");
+    let h = cu.mem_create(size, 0).expect("create");
+    cu.mem_map(va, size, 0, h).expect("map");
+    cu.mem_set_access(va, size, 0).expect("access");
+    va
+}
+
+const N: usize = 256;
+
+fn main() {
+    let a: Vec<String> = std::env::args().collect();
+    let (role, sock, state) = (a[1].as_str(), a[2].as_str(), a[3].as_str());
+    let done = format!("{state}.clonedone");
+    match role {
+        "golden" => {
+            let mut cu = Client::new(UnixStream::connect(sock).expect("connect"));
+            let token = cu.init(0).expect("init");
+            cu.primary_ctx_retain(0).expect("ctx");
+            let module = cu.module_load_data(VECADD_PTX.as_bytes()).expect("module");
+            let func = cu.module_get_function(module, "vecadd").expect("func");
+            let gran = cu.mem_get_allocation_granularity(0, 0).expect("gran");
+            let (va_a, va_b, va_c) = (
+                vmm_buf(&mut cu, gran, gran),
+                vmm_buf(&mut cu, gran, gran),
+                vmm_buf(&mut cu, gran, gran),
+            );
+            let av: Vec<f32> = (0..N).map(|i| i as f32).collect();
+            let bv: Vec<f32> = (0..N).map(|i| (3 * i) as f32).collect();
+            cu.memcpy_htod(va_a, bytes(&av), 0).expect("h2d a");
+            cu.memcpy_htod(va_b, bytes(&bv), 0).expect("h2d b");
+            cu.ctx_synchronize().ok(); // commit writes before the clone imports the physical
+            let check: Vec<f32> = cu
+                .memcpy_dtoh(va_a, 32, 0)
+                .unwrap()
+                .chunks_exact(4)
+                .map(|p| f32::from_le_bytes(p.try_into().unwrap()))
+                .collect();
+            eprintln!("golden: wrote a; reads back a[0..8]={check:?}");
+            std::fs::write(state, format!("{token} {va_a} {va_b} {va_c} {func}")).unwrap();
+            eprintln!("golden: token={token} func={func:#x} a/b written — staying connected");
+            for _ in 0..600 {
+                if std::path::Path::new(&done).exists() {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            loop {
+                std::thread::sleep(std::time::Duration::from_secs(3600));
+            }
+        }
+        "clone" => {
+            let s = std::fs::read_to_string(state).unwrap();
+            let p: Vec<u64> = s.split_whitespace().map(|x| x.parse().unwrap()).collect();
+            let (token, va_a, va_b, va_c, func) = (p[0], p[1], p[2], p[3], p[4]);
+            let mut cu = Client::new(UnixStream::connect(sock).expect("connect"));
+            cu.init(token).expect("init clone");
+            cu.primary_ctx_retain(0).expect("ctx");
+            // diagnostic: does the clone see the golden's a/b at their VAs?
+            let ra: Vec<f32> = cu
+                .memcpy_dtoh(va_a, 32, 0)
+                .expect("d2h a")
+                .chunks_exact(4)
+                .map(|p| f32::from_le_bytes(p.try_into().unwrap()))
+                .collect();
+            let rb: Vec<f32> = cu
+                .memcpy_dtoh(va_b, 32, 0)
+                .expect("d2h b")
+                .chunks_exact(4)
+                .map(|p| f32::from_le_bytes(p.try_into().unwrap()))
+                .collect();
+            eprintln!("clone: read golden a[0..8]={ra:?} b[0..8]={rb:?}");
+            eprintln!("clone: launching vecadd with INHERITED func={func:#x}");
+            let block = 256u32;
+            let grid = (N as u32).div_ceil(block);
+            cu.launch_kernel(
+                func, // the golden's raw handle — the worker must translate it
+                [grid, 1, 1],
+                [block, 1, 1],
+                0,
+                0,
+                &[
+                    va_a.to_le_bytes().to_vec(),
+                    va_b.to_le_bytes().to_vec(),
+                    va_c.to_le_bytes().to_vec(),
+                    (N as u32).to_le_bytes().to_vec(),
+                ],
+            )
+            .expect("launch (inherited func)");
+            cu.ctx_synchronize().expect("sync");
+            let out = cu.memcpy_dtoh(va_c, (N * 4) as u64, 0).expect("d2h");
+            let c: Vec<f32> = out
+                .chunks_exact(4)
+                .map(|p| f32::from_le_bytes(p.try_into().unwrap()))
+                .collect();
+            let ok = (0..N).all(|i| (c[i] - (4 * i) as f32).abs() < 1e-2);
+            std::fs::write(&done, "done").ok();
+            println!(
+                "M3A-PROBE {}: clone launched golden's kernel via reloaded module; c[7]={} (want 28)",
+                if ok { "PASS" } else { "FAIL" },
+                c[7]
+            );
+            std::process::exit(if ok { 0 } else { 5 });
+        }
+        _ => std::process::exit(2),
+    }
+}

--- a/crates/smolvm-cuda/examples/m3a_stream_probe.rs
+++ b/crates/smolvm-cuda/examples/m3a_stream_probe.rs
@@ -1,0 +1,130 @@
+//! Path 3 M3a (streams/events): golden creates a stream + event, loads a module,
+//! allocates VMM buffers (a,b,c), writes a,b. A clone (routed to a worker PROCESS)
+//! reconstructs memory + reloads the module AND recreates the golden's stream +
+//! event, then LAUNCHES the kernel on the golden's INHERITED stream and records +
+//! synchronizes the golden's INHERITED event. The worker translates each inherited
+//! handle to its own recreated one → vecadd runs on the clone's stream → c = a+b.
+//! Proves stream + event handle reconstruction end-to-end through the daemon.
+//!
+//! Roles:  m3a_stream_probe golden <sock> <statefile>  |  ... clone <sock> <statefile>
+use smolvm_cuda::client::Client;
+use std::os::unix::net::UnixStream;
+
+const VECADD_PTX: &str = r#".version 7.0
+.target sm_52
+.address_size 64
+.visible .entry vecadd(.param .u64 a, .param .u64 b, .param .u64 c, .param .u32 n)
+{ .reg .pred %p<2>; .reg .f32 %f<4>; .reg .b32 %r<6>; .reg .b64 %rd<11>;
+ ld.param.u64 %rd1,[a]; ld.param.u64 %rd2,[b]; ld.param.u64 %rd3,[c]; ld.param.u32 %r2,[n];
+ mov.u32 %r3,%ntid.x; mov.u32 %r4,%ctaid.x; mov.u32 %r5,%tid.x; mad.lo.s32 %r1,%r4,%r3,%r5;
+ setp.ge.u32 %p1,%r1,%r2; @%p1 bra $E;
+ cvta.to.global.u64 %rd4,%rd1; cvta.to.global.u64 %rd5,%rd2; cvta.to.global.u64 %rd6,%rd3;
+ mul.wide.u32 %rd7,%r1,4; add.s64 %rd8,%rd4,%rd7; add.s64 %rd9,%rd5,%rd7; add.s64 %rd10,%rd6,%rd7;
+ ld.global.f32 %f1,[%rd8]; ld.global.f32 %f2,[%rd9]; add.f32 %f3,%f1,%f2; st.global.f32 [%rd10],%f3;
+$E: ret; }
+"#;
+
+fn bytes(v: &[f32]) -> &[u8] {
+    unsafe { std::slice::from_raw_parts(v.as_ptr() as *const u8, std::mem::size_of_val(v)) }
+}
+fn vmm_buf(cu: &mut Client<UnixStream>, size: u64, gran: u64) -> u64 {
+    let va = cu.mem_address_reserve(size, gran).expect("reserve");
+    let h = cu.mem_create(size, 0).expect("create");
+    cu.mem_map(va, size, 0, h).expect("map");
+    cu.mem_set_access(va, size, 0).expect("access");
+    va
+}
+
+const N: usize = 256;
+
+fn main() {
+    let a: Vec<String> = std::env::args().collect();
+    let (role, sock, state) = (a[1].as_str(), a[2].as_str(), a[3].as_str());
+    let done = format!("{state}.clonedone");
+    match role {
+        "golden" => {
+            let mut cu = Client::new(UnixStream::connect(sock).expect("connect"));
+            let token = cu.init(0).expect("init");
+            cu.primary_ctx_retain(0).expect("ctx");
+            let module = cu.module_load_data(VECADD_PTX.as_bytes()).expect("module");
+            let func = cu.module_get_function(module, "vecadd").expect("func");
+            // The handles the clone will inherit and must have translated.
+            let stream = cu.stream_create(0).expect("stream");
+            let event = cu.event_create(0).expect("event");
+            let gran = cu.mem_get_allocation_granularity(0, 0).expect("gran");
+            let (va_a, va_b, va_c) = (
+                vmm_buf(&mut cu, gran, gran),
+                vmm_buf(&mut cu, gran, gran),
+                vmm_buf(&mut cu, gran, gran),
+            );
+            let av: Vec<f32> = (0..N).map(|i| i as f32).collect();
+            let bv: Vec<f32> = (0..N).map(|i| (3 * i) as f32).collect();
+            cu.memcpy_htod(va_a, bytes(&av), 0).expect("h2d a");
+            cu.memcpy_htod(va_b, bytes(&bv), 0).expect("h2d b");
+            cu.ctx_synchronize().ok(); // commit writes before the clone imports the physical
+            std::fs::write(
+                state,
+                format!("{token} {va_a} {va_b} {va_c} {func} {stream} {event}"),
+            )
+            .unwrap();
+            eprintln!(
+                "golden: token={token} func={func:#x} stream={stream:#x} event={event:#x} — staying connected"
+            );
+            for _ in 0..600 {
+                if std::path::Path::new(&done).exists() {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            loop {
+                std::thread::sleep(std::time::Duration::from_secs(3600));
+            }
+        }
+        "clone" => {
+            let s = std::fs::read_to_string(state).unwrap();
+            let p: Vec<u64> = s.split_whitespace().map(|x| x.parse().unwrap()).collect();
+            let (token, va_a, va_b, va_c, func, stream, event) =
+                (p[0], p[1], p[2], p[3], p[4], p[5], p[6]);
+            let mut cu = Client::new(UnixStream::connect(sock).expect("connect"));
+            cu.init(token).expect("init clone");
+            cu.primary_ctx_retain(0).expect("ctx");
+            eprintln!(
+                "clone: launching vecadd on INHERITED stream={stream:#x} func={func:#x} event={event:#x}"
+            );
+            let block = 256u32;
+            let grid = (N as u32).div_ceil(block);
+            cu.launch_kernel(
+                func, // the golden's raw function handle — worker must translate
+                [grid, 1, 1],
+                [block, 1, 1],
+                0,
+                stream, // the golden's raw stream handle — worker must translate
+                &[
+                    va_a.to_le_bytes().to_vec(),
+                    va_b.to_le_bytes().to_vec(),
+                    va_c.to_le_bytes().to_vec(),
+                    (N as u32).to_le_bytes().to_vec(),
+                ],
+            )
+            .expect("launch (inherited stream+func)");
+            // Record + sync the golden's INHERITED event on the inherited stream.
+            cu.event_record(event, stream).expect("event_record");
+            cu.event_synchronize(event).expect("event_synchronize");
+            cu.stream_synchronize(stream).expect("stream_synchronize");
+            let out = cu.memcpy_dtoh(va_c, (N * 4) as u64, 0).expect("d2h");
+            let c: Vec<f32> = out
+                .chunks_exact(4)
+                .map(|p| f32::from_le_bytes(p.try_into().unwrap()))
+                .collect();
+            let ok = (0..N).all(|i| (c[i] - (4 * i) as f32).abs() < 1e-2);
+            std::fs::write(&done, "done").ok();
+            println!(
+                "M3A-STREAM-PROBE {}: clone ran kernel on inherited stream + synced inherited event; c[7]={} (want 28)",
+                if ok { "PASS" } else { "FAIL" },
+                c[7]
+            );
+            std::process::exit(if ok { 0 } else { 5 });
+        }
+        _ => std::process::exit(2),
+    }
+}

--- a/crates/smolvm-cuda/examples/path3_ipc_spike.rs
+++ b/crates/smolvm-cuda/examples/path3_ipc_spike.rs
@@ -1,0 +1,81 @@
+//! Path 3 primitive spike — validates the address-preserving IPC primitives the
+//! per-clone-process isolation needs:
+//!   * `mem_create_exportable` + `mem_export_handle` → a POSIX fd for a physical,
+//!   * `mem_import_handle` → the physical back, mapped at a SECOND VA that must
+//!     alias the first (reads back bytes written through VA_a), and
+//!   * `mem_address_reserve_fixed` → reserve at an exact VA (place a clone's
+//!     memory at the golden's address).
+//! Cross-process separate-UVA behavior is proven in scratchpad/spike_vmm_ipc.py;
+//! this validates the in-tree `GpuBackend` primitives added for Path 3.
+//!
+//! Run: cargo run --release --example path3_ipc_spike -p smolvm-cuda
+
+#[cfg(feature = "gpu")]
+fn main() {
+    use smolvm_cuda::host::{Backend, GpuBackend};
+    let mut b = match GpuBackend::load() {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("path3_ipc_spike: no CUDA driver: {e}");
+            std::process::exit(2);
+        }
+    };
+    b.init().expect("cuInit");
+    let _ctx = b.primary_ctx_retain(0).expect("primary ctx retain");
+    let dev = 0;
+
+    let gran = b
+        .mem_get_allocation_granularity(dev, 0)
+        .expect("granularity");
+    assert!(gran > 0, "granularity must be > 0");
+    let size = gran; // one allocation granule
+
+    // Golden: exportable physical, mapped at VA_a, filled with a pattern.
+    let h = b
+        .mem_create_exportable(size, dev)
+        .expect("mem_create_exportable");
+    let va_a = b.mem_address_reserve(size, gran).expect("reserve a");
+    b.mem_map(va_a, size, 0, h).expect("map a");
+    b.mem_set_access(va_a, size, dev).expect("set_access a");
+    let pattern: Vec<u8> = (0..size)
+        .map(|i| (i as u8).wrapping_mul(31) ^ 0xAB)
+        .collect();
+    b.memcpy_htod(va_a, &pattern, 0).expect("h2d");
+
+    // Export the physical to a POSIX fd, then import it back to a fresh handle.
+    let fd = b.mem_export_handle(h).expect("export");
+    assert!(fd >= 0, "export gave a bad fd: {fd}");
+    let h2 = b.mem_import_handle(fd).expect("import");
+
+    // Map the imported physical at a DIFFERENT VA — it must alias the same memory.
+    let va_b = b.mem_address_reserve(size, gran).expect("reserve b");
+    b.mem_map(va_b, size, 0, h2).expect("map b");
+    b.mem_set_access(va_b, size, dev).expect("set_access b");
+    let got = b.memcpy_dtoh(va_b, size, 0).expect("d2h");
+    assert_eq!(
+        got, pattern,
+        "imported mapping does not alias the exported physical"
+    );
+
+    // Fixed-address reservation: reserve a region, free it, re-reserve at that
+    // exact VA — proves the addr hint is honored (place clone memory at golden VA).
+    let probe = b.mem_address_reserve(size, gran).expect("reserve probe");
+    b.mem_address_free(probe, size).expect("free probe");
+    let fixed = b
+        .mem_address_reserve_fixed(size, gran, probe)
+        .expect("reserve fixed");
+    assert_eq!(
+        fixed, probe,
+        "fixed-address reserve did not honor the requested VA"
+    );
+
+    println!(
+        "PATH3-IPC-SPIKE PASS: export/import aliases ({size} B); fixed-addr reserve honored @ {probe:#x}"
+    );
+}
+
+#[cfg(not(feature = "gpu"))]
+fn main() {
+    eprintln!("path3_ipc_spike requires the `gpu` feature");
+    std::process::exit(2);
+}

--- a/crates/smolvm-cuda/examples/path3_ipc_spike.rs
+++ b/crates/smolvm-cuda/examples/path3_ipc_spike.rs
@@ -1,10 +1,12 @@
 //! Path 3 primitive spike — validates the address-preserving IPC primitives the
 //! per-clone-process isolation needs:
-//!   * `mem_create_exportable` + `mem_export_handle` → a POSIX fd for a physical,
-//!   * `mem_import_handle` → the physical back, mapped at a SECOND VA that must
-//!     alias the first (reads back bytes written through VA_a), and
-//!   * `mem_address_reserve_fixed` → reserve at an exact VA (place a clone's
-//!     memory at the golden's address).
+//!
+//! - `mem_create_exportable` + `mem_export_handle` give a POSIX fd for a physical.
+//! - `mem_import_handle` maps that physical back at a SECOND VA that aliases the
+//!   first (reads back bytes written through VA_a).
+//! - `mem_address_reserve_fixed` reserves at an exact VA (place a clone's memory
+//!   at the golden's address).
+//!
 //! Cross-process separate-UVA behavior is proven in scratchpad/spike_vmm_ipc.py;
 //! this validates the in-tree `GpuBackend` primitives added for Path 3.
 //!

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -271,6 +271,19 @@ pub trait Backend: Send {
     fn mem_get_allocation_granularity(&mut self, _device: i32, _flags: u32) -> CuResult<u64> {
         Err(CUDA_ERROR_NOT_SUPPORTED)
     }
+    // Path 3 address-preserving isolation primitives. Defaults: unsupported.
+    fn mem_address_reserve_fixed(&mut self, _size: u64, _align: u64, _fixed: u64) -> CuResult<u64> {
+        Err(CUDA_ERROR_NOT_SUPPORTED)
+    }
+    fn mem_create_exportable(&mut self, _size: u64, _device: i32) -> CuResult<u64> {
+        Err(CUDA_ERROR_NOT_SUPPORTED)
+    }
+    fn mem_export_handle(&mut self, _handle: u64) -> CuResult<i32> {
+        Err(CUDA_ERROR_NOT_SUPPORTED)
+    }
+    fn mem_import_handle(&mut self, _fd: i32) -> CuResult<u64> {
+        Err(CUDA_ERROR_NOT_SUPPORTED)
+    }
 }
 
 /// Per-connection opaque→raw handle translation. Ids are dense and monotonic so

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -569,6 +569,10 @@ struct GoldenLayout {
     /// M3a: golden function handle → (module handle, name) — the worker re-resolves
     /// it in its reloaded module and remaps the inherited raw CUfunction handle.
     functions: HashMap<u64, (u64, String)>,
+    /// M3a: golden stream handle → create flags (the worker recreates + remaps).
+    streams: HashMap<u64, u32>,
+    /// M3a: golden event handle → create flags (the worker recreates + remaps).
+    events: HashMap<u64, u32>,
 }
 type LayoutCell = std::sync::Mutex<GoldenLayout>;
 static DPTR_HANDOFF: std::sync::Mutex<Option<HashMap<u64, std::sync::Weak<AllocTable>>>> =
@@ -648,6 +652,7 @@ fn layout_handoff_register(l: &std::sync::Arc<LayoutCell>, my_token: u64) {
 }
 
 /// `(reservations: [(va,size)], maps: [(va,size,handle)])` for `token`'s golden.
+#[allow(clippy::type_complexity)]
 pub fn layout_handoff_snapshot(token: u64) -> Option<(Vec<(u64, u64)>, Vec<(u64, u64, u64)>)> {
     let reg = LAYOUT_HANDOFF.lock().unwrap();
     let l = reg.as_ref()?.get(&token)?.upgrade()?;
@@ -657,13 +662,20 @@ pub fn layout_handoff_snapshot(token: u64) -> Option<(Vec<(u64, u64)>, Vec<(u64,
     Some((resvs, maps))
 }
 
-/// M3a: `(modules: [(handle, image)], functions: [(handle, module, name)])` for
-/// `token`'s golden — the module images the worker reloads + the functions it
-/// re-resolves, to remap the clone's inherited raw handles.
+/// M3a: golden handle-reconstruction snapshot for `token`'s golden —
+/// `(modules: [(handle, image)], functions: [(handle, module, name)],
+///   streams: [(handle, flags)], events: [(handle, flags)])`. The worker
+/// reloads modules / re-resolves functions / recreates streams+events, then
+/// remaps the clone's inherited raw handles to its own.
 #[allow(clippy::type_complexity)]
 pub fn module_handoff_snapshot(
     token: u64,
-) -> Option<(Vec<(u64, Vec<u8>)>, Vec<(u64, u64, String)>)> {
+) -> Option<(
+    Vec<(u64, Vec<u8>)>,
+    Vec<(u64, u64, String)>,
+    Vec<(u64, u32)>,
+    Vec<(u64, u32)>,
+)> {
     let reg = LAYOUT_HANDOFF.lock().unwrap();
     let l = reg.as_ref()?.get(&token)?.upgrade()?;
     let g = l.lock().unwrap();
@@ -673,29 +685,41 @@ pub fn module_handoff_snapshot(
         .iter()
         .map(|(&h, (m, n))| (h, *m, n.clone()))
         .collect();
-    Some((modules, funcs))
+    let streams = g.streams.iter().map(|(&h, &f)| (h, f)).collect();
+    let events = g.events.iter().map(|(&h, &f)| (h, f)).collect();
+    Some((modules, funcs, streams, events))
 }
 
 // M3a: per-worker (thread-local) translation of the golden's inherited raw
 // module/function handles → this worker's reloaded ones. Empty (identity) unless
 // a Path-3 clone worker installed it via `set_handle_trans`.
+type HandleMap = std::cell::RefCell<HashMap<u64, u64>>;
 thread_local! {
-    static FUNC_TRANS: std::cell::RefCell<HashMap<u64, u64>> = std::cell::RefCell::new(HashMap::new());
-    static MOD_TRANS: std::cell::RefCell<HashMap<u64, u64>> = std::cell::RefCell::new(HashMap::new());
+    static FUNC_TRANS: HandleMap = std::cell::RefCell::new(HashMap::new());
+    static MOD_TRANS: HandleMap = std::cell::RefCell::new(HashMap::new());
+    static STREAM_TRANS: HandleMap = std::cell::RefCell::new(HashMap::new());
+    static EVENT_TRANS: HandleMap = std::cell::RefCell::new(HashMap::new());
 }
 
-/// Install a clone worker's golden→worker handle maps (functions, modules).
-pub fn set_handle_trans(funcs: Vec<(u64, u64)>, mods: Vec<(u64, u64)>) {
-    FUNC_TRANS.with(|m| {
-        let mut m = m.borrow_mut();
-        m.clear();
-        m.extend(funcs);
-    });
-    MOD_TRANS.with(|m| {
-        let mut m = m.borrow_mut();
-        m.clear();
-        m.extend(mods);
-    });
+/// Install a clone worker's golden→worker handle maps (functions, modules,
+/// streams, events); each applied at the matching dispatch choke point.
+pub fn set_handle_trans(
+    funcs: Vec<(u64, u64)>,
+    mods: Vec<(u64, u64)>,
+    streams: Vec<(u64, u64)>,
+    events: Vec<(u64, u64)>,
+) {
+    fn put(cell: &'static std::thread::LocalKey<HandleMap>, v: Vec<(u64, u64)>) {
+        cell.with(|m| {
+            let mut m = m.borrow_mut();
+            m.clear();
+            m.extend(v);
+        });
+    }
+    put(&FUNC_TRANS, funcs);
+    put(&MOD_TRANS, mods);
+    put(&STREAM_TRANS, streams);
+    put(&EVENT_TRANS, events);
 }
 
 fn xlat_func(h: u64) -> u64 {
@@ -703,6 +727,12 @@ fn xlat_func(h: u64) -> u64 {
 }
 fn xlat_mod(h: u64) -> u64 {
     MOD_TRANS.with(|m| m.borrow().get(&h).copied().unwrap_or(h))
+}
+fn xlat_stream(h: u64) -> u64 {
+    STREAM_TRANS.with(|m| m.borrow().get(&h).copied().unwrap_or(h))
+}
+fn xlat_event(h: u64) -> u64 {
+    EVENT_TRANS.with(|m| m.borrow().get(&h).copied().unwrap_or(h))
 }
 
 /// Mark the allocation containing `dptr` as loaded (H2D-written → read-only
@@ -1333,7 +1363,11 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         if stream == 0 {
             Ok(0)
         } else {
-            Ok(sess.streams.get(&stream).copied().unwrap_or(stream))
+            // Path 3 (M3a pattern): translate a clone's inherited golden stream
+            // to its own recreated stream; identity otherwise.
+            Ok(xlat_stream(
+                sess.streams.get(&stream).copied().unwrap_or(stream),
+            ))
         }
     }
     // Modules and functions are raw host handles on the wire (like streams):
@@ -1365,7 +1399,9 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
     }
     fn raw_event(sess: &Session, event: u64) -> CuResult<u64> {
         // Same raw-on-the-wire convention as streams.
-        Ok(sess.events.get(&event).copied().unwrap_or(event))
+        Ok(xlat_event(
+            sess.events.get(&event).copied().unwrap_or(event),
+        ))
     }
     // Copy-on-write any shared weight buffer this request writes, then rewrite
     // inherited device pointers to this clone's private copies (both no-ops
@@ -1654,6 +1690,9 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         // Raw pointers are valid on every connection, like device pointers.
         Request::StreamCreate { flags } => b.stream_create(flags).map(|st| {
             sess.owned_streams.insert(st);
+            if path3_enabled() {
+                sess.golden_layout.lock().unwrap().streams.insert(st, flags);
+            }
             Response::Handle(st)
         }),
         Request::StreamBeginCapture { stream, mode } => {
@@ -1835,6 +1874,9 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         // several connections that must all understand the same handle.
         Request::EventCreate { flags } => b.event_create(flags).map(|e| {
             sess.owned_events.insert(e);
+            if path3_enabled() {
+                sess.golden_layout.lock().unwrap().events.insert(e, flags);
+            }
             Response::Handle(e)
         }),
         Request::EventDestroy { event } => {
@@ -2031,6 +2073,8 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         } => b.mem_map(va, size, offset, handle).map(|_| {
             sess.owned_vmm_maps.insert(va, size);
             sess.vmm_ranges.lock().unwrap().insert(va, size);
+            // Path 3 (M2): record va→(size, physical handle) so the daemon can
+            // export this physical to an fd for a clone worker to import at `va`.
             sess.golden_layout
                 .lock()
                 .unwrap()

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -312,6 +312,14 @@ struct Session {
     /// [`DPTR_HANDOFF`] so a fork clone in isolation mode can enumerate the
     /// parent's buffers and give itself private copies. Mirrors `owned_dptrs`.
     alloc_table: std::sync::Arc<std::sync::Mutex<HashMap<u64, (u64, bool)>>>,
+    /// This session's live VMM-mapped ranges (mapped-va → size), shared via
+    /// [`VMM_HANDOFF`] so a fork clone copies them privately. Torch's default
+    /// `expandable_segments` allocator serves the whole pool from VMM
+    /// (`cuMemCreate`/`cuMemMap`), whose memory never lands in `alloc_table` —
+    /// without this the fork misses the entire model (0 copies). Always copied,
+    /// never shared: an expandable segment mixes weights and activations, so it
+    /// can't be shared read-only like a discrete weight buffer.
+    vmm_ranges: std::sync::Arc<VmmRanges>,
     /// Fork-isolation pointer map: `(parent_base, size, private_copy_base)`.
     /// Empty unless this session is an isolating clone. Every inherited dptr the
     /// guest sends is rewritten through these ranges to the clone's own copy, so
@@ -522,6 +530,9 @@ fn graph_inplace_enabled() -> bool {
 /// inference, so clones SHARE them (M4) instead of each copying gigabytes of
 /// weights; only the un-loaded buffers (KV cache, activations) get private copies.
 type AllocTable = std::sync::Mutex<HashMap<u64, (u64, bool)>>;
+/// VMM-mapped ranges (mapped-va → size), handed off to fork clones. Parallels
+/// [`AllocTable`] but for the CUDA VMM path (see [`Session::vmm_ranges`]).
+type VmmRanges = std::sync::Mutex<HashMap<u64, u64>>;
 static DPTR_HANDOFF: std::sync::Mutex<Option<HashMap<u64, std::sync::Weak<AllocTable>>>> =
     std::sync::Mutex::new(None);
 
@@ -536,12 +547,52 @@ fn dptr_handoff_register(table: &std::sync::Arc<AllocTable>, my_token: u64) {
 /// if that lineage is gone.
 fn dptr_handoff_snapshot(token: u64) -> Option<Vec<(u64, u64, bool)>> {
     let reg = DPTR_HANDOFF.lock().unwrap();
+    if std::env::var_os("SMOLVM_CUDA_FORK_DEBUG").is_some() {
+        // Show which tokens hold how many live allocations — reveals whether the
+        // weight-bearing session's token differs from the one the clone resumes.
+        let dump: Vec<(u64, usize)> = reg
+            .as_ref()
+            .map(|m| {
+                m.iter()
+                    .map(|(&t, w)| (t, w.upgrade().map(|a| a.lock().unwrap().len()).unwrap_or(0)))
+                    .collect()
+            })
+            .unwrap_or_default();
+        eprintln!("[fork-debug] snapshot(token={token}) registry tokens->allocs = {dump:?}");
+    }
     let table = reg.as_ref()?.get(&token)?.upgrade()?;
     let snap = table
         .lock()
         .unwrap()
         .iter()
         .map(|(&d, &(s, l))| (d, s, l))
+        .collect();
+    Some(snap)
+}
+
+/// Registry of live sessions' VMM-mapped ranges, keyed by lineage token — the
+/// VMM counterpart of [`DPTR_HANDOFF`]. Torch/Unsloth `expandable_segments`
+/// memory lives here (never in `alloc_table`), so a fork clone must copy these
+/// too or it inherits the golden's raw VMM addresses untranslated.
+static VMM_HANDOFF: std::sync::Mutex<Option<HashMap<u64, std::sync::Weak<VmmRanges>>>> =
+    std::sync::Mutex::new(None);
+
+fn vmm_handoff_register(ranges: &std::sync::Arc<VmmRanges>, my_token: u64) {
+    let mut reg = VMM_HANDOFF.lock().unwrap();
+    let reg = reg.get_or_insert_with(HashMap::new);
+    reg.retain(|_, w| w.strong_count() > 0);
+    reg.insert(my_token, std::sync::Arc::downgrade(ranges));
+}
+
+/// Snapshot of `token`'s VMM-mapped `(va, size)` ranges, or `None` if gone.
+fn vmm_handoff_snapshot(token: u64) -> Option<Vec<(u64, u64)>> {
+    let reg = VMM_HANDOFF.lock().unwrap();
+    let ranges = reg.as_ref()?.get(&token)?.upgrade()?;
+    let snap = ranges
+        .lock()
+        .unwrap()
+        .iter()
+        .map(|(&v, &s)| (v, s))
         .collect();
     Some(snap)
 }
@@ -1234,6 +1285,7 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
                 let token = b.begin_session(resume_token);
                 graph_handoff_register(&sess.graph_vhandles, resume_token, token);
                 dptr_handoff_register(&sess.alloc_table, token);
+                vmm_handoff_register(&sess.vmm_ranges, token);
                 // Isolation-mode clone: defer copying the parent's buffers until
                 // the first PrimaryCtxRetain, when a context is actually current.
                 if resume_token != 0 && fork_isolate_enabled() {
@@ -1294,6 +1346,26 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
                         if let Ok(cdptr) = b.mem_alloc(size) {
                             let _ = b.memcpy_dtod(cdptr, gdptr, size);
                             sess.dptr_trans.push((gdptr, size, cdptr));
+                            sess.owned_dptrs.insert(cdptr, size);
+                            sess.alloc_table
+                                .lock()
+                                .unwrap()
+                                .insert(cdptr, (size, false));
+                            copied += 1;
+                            cbytes += size;
+                        }
+                    }
+                }
+                // VMM-mapped ranges (torch's expandable_segments pool) never
+                // enter alloc_table, so copy each privately here — ALWAYS, since
+                // an expandable segment mixes weights + activations and can't be
+                // shared read-only. Without this a clone inherits the golden's
+                // raw VMM addresses untranslated (the 0-copies bug).
+                if let Some(vmm) = vmm_handoff_snapshot(parent) {
+                    for (gva, size) in vmm {
+                        if let Ok(cdptr) = b.mem_alloc(size) {
+                            let _ = b.memcpy_dtod(cdptr, gva, size);
+                            sess.dptr_trans.push((gva, size, cdptr));
                             sess.owned_dptrs.insert(cdptr, size);
                             sess.alloc_table
                                 .lock()
@@ -1819,6 +1891,7 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             handle,
         } => b.mem_map(va, size, offset, handle).map(|_| {
             sess.owned_vmm_maps.insert(va, size);
+            sess.vmm_ranges.lock().unwrap().insert(va, size);
             Response::Ok
         }),
         Request::MemSetAccess { va, size, device } => {
@@ -1826,6 +1899,7 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         }
         Request::MemUnmap { va, size } => {
             sess.owned_vmm_maps.remove(&va);
+            sess.vmm_ranges.lock().unwrap().remove(&va);
             b.mem_unmap(va, size).map(|_| Response::Ok)
         }
         Request::MemRelease { handle } => {

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -564,6 +564,11 @@ type VmmRanges = std::sync::Mutex<HashMap<u64, u64>>;
 struct GoldenLayout {
     reservations: HashMap<u64, u64>,
     maps: HashMap<u64, (u64, u64)>,
+    /// M3a: golden module handle → module image bytes (to reload in the worker).
+    modules: HashMap<u64, Vec<u8>>,
+    /// M3a: golden function handle → (module handle, name) — the worker re-resolves
+    /// it in its reloaded module and remaps the inherited raw CUfunction handle.
+    functions: HashMap<u64, (u64, String)>,
 }
 type LayoutCell = std::sync::Mutex<GoldenLayout>;
 static DPTR_HANDOFF: std::sync::Mutex<Option<HashMap<u64, std::sync::Weak<AllocTable>>>> =
@@ -650,6 +655,54 @@ pub fn layout_handoff_snapshot(token: u64) -> Option<(Vec<(u64, u64)>, Vec<(u64,
     let resvs = g.reservations.iter().map(|(&v, &s)| (v, s)).collect();
     let maps = g.maps.iter().map(|(&v, &(s, h))| (v, s, h)).collect();
     Some((resvs, maps))
+}
+
+/// M3a: `(modules: [(handle, image)], functions: [(handle, module, name)])` for
+/// `token`'s golden — the module images the worker reloads + the functions it
+/// re-resolves, to remap the clone's inherited raw handles.
+#[allow(clippy::type_complexity)]
+pub fn module_handoff_snapshot(
+    token: u64,
+) -> Option<(Vec<(u64, Vec<u8>)>, Vec<(u64, u64, String)>)> {
+    let reg = LAYOUT_HANDOFF.lock().unwrap();
+    let l = reg.as_ref()?.get(&token)?.upgrade()?;
+    let g = l.lock().unwrap();
+    let modules = g.modules.iter().map(|(&h, i)| (h, i.clone())).collect();
+    let funcs = g
+        .functions
+        .iter()
+        .map(|(&h, (m, n))| (h, *m, n.clone()))
+        .collect();
+    Some((modules, funcs))
+}
+
+// M3a: per-worker (thread-local) translation of the golden's inherited raw
+// module/function handles → this worker's reloaded ones. Empty (identity) unless
+// a Path-3 clone worker installed it via `set_handle_trans`.
+thread_local! {
+    static FUNC_TRANS: std::cell::RefCell<HashMap<u64, u64>> = std::cell::RefCell::new(HashMap::new());
+    static MOD_TRANS: std::cell::RefCell<HashMap<u64, u64>> = std::cell::RefCell::new(HashMap::new());
+}
+
+/// Install a clone worker's golden→worker handle maps (functions, modules).
+pub fn set_handle_trans(funcs: Vec<(u64, u64)>, mods: Vec<(u64, u64)>) {
+    FUNC_TRANS.with(|m| {
+        let mut m = m.borrow_mut();
+        m.clear();
+        m.extend(funcs);
+    });
+    MOD_TRANS.with(|m| {
+        let mut m = m.borrow_mut();
+        m.clear();
+        m.extend(mods);
+    });
+}
+
+fn xlat_func(h: u64) -> u64 {
+    FUNC_TRANS.with(|m| m.borrow().get(&h).copied().unwrap_or(h))
+}
+fn xlat_mod(h: u64) -> u64 {
+    MOD_TRANS.with(|m| m.borrow().get(&h).copied().unwrap_or(h))
 }
 
 /// Mark the allocation containing `dptr` as loaded (H2D-written → read-only
@@ -1290,10 +1343,12 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
     // reconnect and keep using its parent's loaded modules). The tables only
     // translate ids minted by pre-raw guests; a raw value passes through.
     fn raw_module(sess: &Session, m: u64) -> u64 {
-        sess.modules.get(&m).copied().unwrap_or(m)
+        // Path 3 (M3a): a clone worker translates the golden's inherited raw module
+        // handle to its own reloaded module; identity otherwise.
+        xlat_mod(sess.modules.get(&m).copied().unwrap_or(m))
     }
     fn raw_fn_h(sess: &Session, f: u64) -> u64 {
-        sess.functions.get(&f).copied().unwrap_or(f)
+        xlat_func(sess.functions.get(&f).copied().unwrap_or(f))
     }
     fn raw_graph(sess: &Session, h: u64) -> u64 {
         // Virtual graph/exec handle → real; untagged values pass through.
@@ -1480,6 +1535,15 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             // survives a fork-clone reconnect). Still tracked for reclaim.
             let raw = b.module_load_data(&image)?;
             sess.owned_modules.insert(raw);
+            // M3a: keep the image so a Path-3 clone worker can reload the module in
+            // its own context and remap this inherited handle.
+            if path3_enabled() {
+                sess.golden_layout
+                    .lock()
+                    .unwrap()
+                    .modules
+                    .insert(raw, image.clone());
+            }
             Ok(Response::Handle(raw))
         }
         Request::ModuleGetFunction { module, name } => {
@@ -1487,6 +1551,13 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             // Raw CUfunction on the wire: valid across connections in the shared
             // primary context, so a forked clone keeps its parent's functions.
             let raw_fn = b.module_get_function(raw_mod, &name)?;
+            if path3_enabled() {
+                sess.golden_layout
+                    .lock()
+                    .unwrap()
+                    .functions
+                    .insert(raw_fn, (raw_mod, name.clone()));
+            }
             Ok(Response::Handle(raw_fn))
         }
         Request::ModuleUnload { module } => {

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -333,6 +333,9 @@ struct Session {
     /// never shared: an expandable segment mixes weights and activations, so it
     /// can't be shared read-only like a discrete weight buffer.
     vmm_ranges: std::sync::Arc<VmmRanges>,
+    /// Path 3: this session's VMM layout (reservations + maps→physical handle),
+    /// handed off so a clone worker reconstructs memory at the golden's VAs (M2).
+    golden_layout: std::sync::Arc<LayoutCell>,
     /// Fork-isolation pointer map: `(parent_base, size, private_copy_base)`.
     /// Empty unless this session is an isolating clone. Every inherited dptr the
     /// guest sends is rewritten through these ranges to the clone's own copy, so
@@ -473,6 +476,13 @@ fn fork_isolate_enabled() -> bool {
     std::env::var_os("SMOLVM_CUDA_FORK_ISOLATE").is_some()
 }
 
+/// Path 3 (address-preserving per-clone-process isolation) mode. When set, the
+/// golden's VMM physical is created IPC-exportable so a clone worker process can
+/// share/copy it at the golden's exact VA. Off = legacy shared-context path.
+fn path3_enabled() -> bool {
+    std::env::var_os("SMOLVM_CUDA_PATH3").is_some()
+}
+
 /// P0 transport-viability instrumentation. Counts every dispatched CUDA RPC so we
 /// can derive calls-per-token (the number that decides whether CUDA-over-network
 /// survives WAN round-trips). `SMOLVM_CUDA_RPC_STATS=1` logs the running count with
@@ -546,6 +556,16 @@ type AllocTable = std::sync::Mutex<HashMap<u64, (u64, bool)>>;
 /// VMM-mapped ranges (mapped-va → size), handed off to fork clones. Parallels
 /// [`AllocTable`] but for the CUDA VMM path (see [`Session::vmm_ranges`]).
 type VmmRanges = std::sync::Mutex<HashMap<u64, u64>>;
+/// Path 3: the golden's VMM layout, handed off (via [`LAYOUT_HANDOFF`]) so a clone
+/// worker process reconstructs memory at the golden's EXACT VAs (M2). Reservations
+/// (va→size) it re-reserves; maps (va→(size, physical handle)) whose handle the
+/// daemon exports to an fd for the clone to IPC-import/copy at that VA.
+#[derive(Default)]
+struct GoldenLayout {
+    reservations: HashMap<u64, u64>,
+    maps: HashMap<u64, (u64, u64)>,
+}
+type LayoutCell = std::sync::Mutex<GoldenLayout>;
 static DPTR_HANDOFF: std::sync::Mutex<Option<HashMap<u64, std::sync::Weak<AllocTable>>>> =
     std::sync::Mutex::new(None);
 
@@ -608,6 +628,28 @@ fn vmm_handoff_snapshot(token: u64) -> Option<Vec<(u64, u64)>> {
         .map(|(&v, &s)| (v, s))
         .collect();
     Some(snap)
+}
+
+/// Path 3 (M2): the golden's VMM layout, keyed by lineage token, so the daemon
+/// can gather it (reservations + maps→handle) when spawning a clone worker.
+static LAYOUT_HANDOFF: std::sync::Mutex<Option<HashMap<u64, std::sync::Weak<LayoutCell>>>> =
+    std::sync::Mutex::new(None);
+
+fn layout_handoff_register(l: &std::sync::Arc<LayoutCell>, my_token: u64) {
+    let mut reg = LAYOUT_HANDOFF.lock().unwrap();
+    let reg = reg.get_or_insert_with(HashMap::new);
+    reg.retain(|_, w| w.strong_count() > 0);
+    reg.insert(my_token, std::sync::Arc::downgrade(l));
+}
+
+/// `(reservations: [(va,size)], maps: [(va,size,handle)])` for `token`'s golden.
+pub fn layout_handoff_snapshot(token: u64) -> Option<(Vec<(u64, u64)>, Vec<(u64, u64, u64)>)> {
+    let reg = LAYOUT_HANDOFF.lock().unwrap();
+    let l = reg.as_ref()?.get(&token)?.upgrade()?;
+    let g = l.lock().unwrap();
+    let resvs = g.reservations.iter().map(|(&v, &s)| (v, s)).collect();
+    let maps = g.maps.iter().map(|(&v, &(s, h))| (v, s, h)).collect();
+    Some((resvs, maps))
 }
 
 /// Mark the allocation containing `dptr` as loaded (H2D-written → read-only
@@ -1299,6 +1341,7 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
                 graph_handoff_register(&sess.graph_vhandles, resume_token, token);
                 dptr_handoff_register(&sess.alloc_table, token);
                 vmm_handoff_register(&sess.vmm_ranges, token);
+                layout_handoff_register(&sess.golden_layout, token);
                 // Isolation-mode clone: defer copying the parent's buffers until
                 // the first PrimaryCtxRetain, when a context is actually current.
                 if resume_token != 0 && fork_isolate_enabled() {
@@ -1882,6 +1925,11 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         Request::MemAddressReserve { size, align } => {
             b.mem_address_reserve(size, align).map(|va| {
                 sess.owned_vmm_reservations.insert(va, size);
+                sess.golden_layout
+                    .lock()
+                    .unwrap()
+                    .reservations
+                    .insert(va, size);
                 Response::Dptr(va)
             })
         }
@@ -1892,7 +1940,14 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             if used.saturating_add(size) > limit {
                 return Err(2); // CUDA_ERROR_OUT_OF_MEMORY
             }
-            b.mem_create(size, device).map(|h| {
+            // Path 3: create the physical IPC-exportable so a clone worker process
+            // can import it and place it at the golden's exact VA (M2).
+            let created = if path3_enabled() {
+                b.mem_create_exportable(size, device)
+            } else {
+                b.mem_create(size, device)
+            };
+            created.map(|h| {
                 sess.owned_vmm_handles.insert(h, size);
                 Response::Handle(h)
             })
@@ -1905,6 +1960,11 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         } => b.mem_map(va, size, offset, handle).map(|_| {
             sess.owned_vmm_maps.insert(va, size);
             sess.vmm_ranges.lock().unwrap().insert(va, size);
+            sess.golden_layout
+                .lock()
+                .unwrap()
+                .maps
+                .insert(va, (size, handle));
             Response::Ok
         }),
         Request::MemSetAccess { va, size, device } => {
@@ -1913,6 +1973,7 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         Request::MemUnmap { va, size } => {
             sess.owned_vmm_maps.remove(&va);
             sess.vmm_ranges.lock().unwrap().remove(&va);
+            sess.golden_layout.lock().unwrap().maps.remove(&va);
             b.mem_unmap(va, size).map(|_| Response::Ok)
         }
         Request::MemRelease { handle } => {
@@ -1921,6 +1982,7 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         }
         Request::MemAddressFree { va, size } => {
             sess.owned_vmm_reservations.remove(&va);
+            sess.golden_layout.lock().unwrap().reservations.remove(&va);
             b.mem_address_free(va, size).map(|_| Response::Ok)
         }
         Request::MemGetAllocationGranularity { device, flags } => b

--- a/crates/smolvm-cuda/src/host/gpu.rs
+++ b/crates/smolvm-cuda/src/host/gpu.rs
@@ -137,6 +137,12 @@ pub struct GpuBackend {
     vmm_unmap: Option<unsafe extern "C" fn(u64, usize) -> CuResultCode>,
     vmm_release: Option<unsafe extern "C" fn(u64) -> CuResultCode>,
     vmm_address_free: Option<unsafe extern "C" fn(u64, usize) -> CuResultCode>,
+    // IPC (Path 3 address-preserving isolation): export a physical handle to a
+    // POSIX fd (golden) and import it back (clone), so a clone process shares the
+    // golden's weight physical at the golden's VA. `cuMemExportToShareableHandle`
+    // / `cuMemImportFromShareableHandle`.
+    vmm_export: Option<unsafe extern "C" fn(*mut c_int, u64, c_int, u64) -> CuResultCode>,
+    vmm_import: Option<unsafe extern "C" fn(*mut u64, *mut c_void, c_int) -> CuResultCode>,
     vmm_granularity:
         Option<unsafe extern "C" fn(*mut usize, *const VmmProp, c_uint) -> CuResultCode>,
     event_query: unsafe extern "C" fn(*mut c_void) -> CuResultCode,
@@ -430,6 +436,8 @@ impl GpuBackend {
                 vmm_unmap: sym(&lib, b"cuMemUnmap\0").ok(),
                 vmm_release: sym(&lib, b"cuMemRelease\0").ok(),
                 vmm_address_free: sym(&lib, b"cuMemAddressFree\0").ok(),
+                vmm_export: sym(&lib, b"cuMemExportToShareableHandle\0").ok(),
+                vmm_import: sym(&lib, b"cuMemImportFromShareableHandle\0").ok(),
                 vmm_granularity: sym(&lib, b"cuMemGetAllocationGranularity\0").ok(),
                 event_query: sym(&lib, b"cuEventQuery\0")?,
                 event_create: sym(&lib, b"cuEventCreate\0")?,
@@ -761,6 +769,42 @@ impl Backend for GpuBackend {
             .vmm_address_free
             .ok_or(super::CUDA_ERROR_NOT_SUPPORTED)?;
         unsafe { chk(f(va, size as usize)) }
+    }
+    // ---- Path 3 address-preserving isolation primitives ----
+    /// Reserve a VA at a FIXED address (`cuMemAddressReserve` addr hint), so a
+    /// clone process can place memory at the golden's exact virtual address.
+    fn mem_address_reserve_fixed(&mut self, size: u64, align: u64, fixed: u64) -> CuResult<u64> {
+        let f = self
+            .vmm_address_reserve
+            .ok_or(super::CUDA_ERROR_NOT_SUPPORTED)?;
+        let mut va = 0u64;
+        unsafe { chk(f(&mut va, size as usize, align as usize, fixed, 0))? };
+        Ok(va)
+    }
+    /// `cuMemCreate` with POSIX-fd handle type requested, so the physical can be
+    /// IPC-exported to a clone process.
+    fn mem_create_exportable(&mut self, size: u64, device: i32) -> CuResult<u64> {
+        let f = self.vmm_create.ok_or(super::CUDA_ERROR_NOT_SUPPORTED)?;
+        let mut prop = vmm_prop(device);
+        prop.requested_handle_types = 1; // CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+        let mut h = 0u64;
+        unsafe { chk(f(&mut h, size as usize, &prop, 0))? };
+        Ok(h)
+    }
+    /// Export a physical handle to a POSIX fd (`cuMemExportToShareableHandle`).
+    fn mem_export_handle(&mut self, handle: u64) -> CuResult<i32> {
+        let f = self.vmm_export.ok_or(super::CUDA_ERROR_NOT_SUPPORTED)?;
+        let mut fd: c_int = -1;
+        unsafe { chk(f(&mut fd, handle, 1, 0))? }; // 1 = POSIX_FILE_DESCRIPTOR
+        Ok(fd as i32)
+    }
+    /// Import a physical handle from a POSIX fd (`cuMemImportFromShareableHandle`).
+    /// The fd's int value is passed as the `osHandle` pointer, per the CUDA ABI.
+    fn mem_import_handle(&mut self, fd: i32) -> CuResult<u64> {
+        let f = self.vmm_import.ok_or(super::CUDA_ERROR_NOT_SUPPORTED)?;
+        let mut h = 0u64;
+        unsafe { chk(f(&mut h, fd as usize as *mut c_void, 1))? };
+        Ok(h)
     }
     fn mem_get_allocation_granularity(&mut self, device: i32, flags: u32) -> CuResult<u64> {
         let f = self

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -473,16 +473,34 @@ fn peek_clone_token(fd: std::os::unix::io::RawFd) -> Option<u64> {
     }
     // framing: [u32 le len][op][proto_hash u64][resume_token u64]
     let mut buf = [0u8; 21];
-    let n = unsafe {
-        libc::recv(
-            fd,
-            buf.as_mut_ptr() as *mut libc::c_void,
-            buf.len(),
-            libc::MSG_PEEK,
-        )
-    };
+    // The connection is often proxied (guest vsock → per-VM cuda_host proxy →
+    // daemon unix socket), so the 21-byte Init can arrive in pieces AFTER accept.
+    // A one-shot peek that saw a short read here would MISROUTE the isolating
+    // clone to the legacy shared-context path (which fails for expandable_segments
+    // → CUDA_ERROR_UNKNOWN, esp. at larger models). Retry the non-consuming peek
+    // until the full header is buffered (or the peer closes / we time out ~1s).
+    let mut n: isize = 0;
+    for _ in 0..200 {
+        n = unsafe {
+            libc::recv(
+                fd,
+                buf.as_mut_ptr() as *mut libc::c_void,
+                buf.len(),
+                libc::MSG_PEEK,
+            )
+        };
+        if n >= 21 || n == 0 {
+            break; // full header buffered, or peer closed
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
     if n < 21 || buf[4] != 0x01 {
-        return None; // short read or not an Init
+        tracing::warn!(
+            n,
+            op = buf[4],
+            "peek_clone_token: not routed (short read / non-Init)"
+        );
+        return None;
     }
     let token = u64::from_le_bytes(buf[13..21].try_into().unwrap());
     (token != 0).then_some(token)

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -503,10 +503,10 @@ fn spawn_clone_worker(conn_fd: std::os::unix::io::RawFd, token: u64) -> io::Resu
     let mut backend = make_backend();
     backend
         .init()
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("worker-export init: {e}")))?;
+        .map_err(|e| io::Error::other(format!("worker-export init: {e}")))?;
     backend
         .primary_ctx_retain(0)
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("ctx retain: {e}")))?;
+        .map_err(|e| io::Error::other(format!("ctx retain: {e}")))?;
     // Commit the golden's pending device work so its writes are visible in the
     // physical the clone will IPC-import (the golden runs on another thread of the
     // shared primary context).

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -238,12 +238,14 @@ pub fn run_clone_worker(fd: std::os::unix::io::RawFd) -> io::Result<()> {
     // and install the golden→worker handle translation so the clone's inherited
     // kernel launches (raw CUfunction from the golden's context) resolve correctly.
     if let Ok(modpath) = std::env::var("SMOLVM_CUDA_CLONE_MODULES") {
-        let (funcs, mods) = reconstruct_golden_modules(backend.as_mut(), &modpath);
-        let nf = funcs.len();
-        smolvm_cuda::host::set_handle_trans(funcs, mods);
+        let (funcs, mods, streams, events) = reconstruct_golden_modules(backend.as_mut(), &modpath);
+        let (nf, ns, ne) = (funcs.len(), streams.len(), events.len());
+        smolvm_cuda::host::set_handle_trans(funcs, mods, streams, events);
         let _ = std::fs::remove_file(&modpath);
         tracing::info!(
             functions = nf,
+            streams = ns,
+            events = ne,
             "cuda clone-worker: reloaded golden modules + remapped handles"
         );
     }
@@ -344,19 +346,28 @@ fn reconstruct_golden_memory(b: &mut dyn Backend, layout: &str) -> usize {
 /// binary blob the daemon wrote (path in `SMOLVM_CUDA_CLONE_MODULES`):
 /// `[u32 nmods]( [u64 handle][u32 len][image] )* [u32 nfuncs]( [u64 fn][u64 mod][u32 len][name] )*`.
 #[cfg(unix)]
+#[allow(clippy::type_complexity)]
 fn reconstruct_golden_modules(
     b: &mut dyn Backend,
     path: &str,
-) -> (Vec<(u64, u64)>, Vec<(u64, u64)>) {
-    let (mut func_trans, mut mod_trans) = (Vec::new(), Vec::new());
+) -> (
+    Vec<(u64, u64)>,
+    Vec<(u64, u64)>,
+    Vec<(u64, u64)>,
+    Vec<(u64, u64)>,
+) {
+    let mut func_trans = Vec::new();
+    let mut mod_trans = Vec::new();
+    let mut stream_trans = Vec::new();
+    let mut event_trans = Vec::new();
     let Ok(buf) = std::fs::read(path) else {
-        return (func_trans, mod_trans);
+        return (func_trans, mod_trans, stream_trans, event_trans);
     };
     let mut p = 0usize;
     macro_rules! need {
         ($n:expr) => {
             if p + $n > buf.len() {
-                return (func_trans, mod_trans);
+                return (func_trans, mod_trans, stream_trans, event_trans);
             }
         };
     }
@@ -414,14 +425,38 @@ fn reconstruct_golden_modules(
             None => tracing::warn!(gm, "M3a: function's module not reloaded"),
         }
     }
+    // Streams + events: recreate each with its golden create flags in OUR context,
+    // mapping the golden's inherited raw handle → our own (same M3a pattern).
+    let nstreams = ru32!();
+    for _ in 0..nstreams {
+        let gs = ru64!();
+        let flags = ru32!();
+        match b.stream_create(flags) {
+            Ok(ws) => stream_trans.push((gs, ws)),
+            Err(e) => tracing::warn!(e, "M3a: stream recreate failed"),
+        }
+    }
+    let nevents = ru32!();
+    for _ in 0..nevents {
+        let ge = ru64!();
+        let flags = ru32!();
+        match b.event_create(flags) {
+            Ok(we) => event_trans.push((ge, we)),
+            Err(e) => tracing::warn!(e, "M3a: event recreate failed"),
+        }
+    }
     tracing::info!(
         nmods,
         nfuncs,
+        nstreams,
+        nevents,
         mods = mod_trans.len(),
         funcs = func_trans.len(),
+        streams = stream_trans.len(),
+        events = event_trans.len(),
         "M3a: reconstruct_golden_modules"
     );
-    (func_trans, mod_trans)
+    (func_trans, mod_trans, stream_trans, event_trans)
 }
 
 /// Path 3 (M1): peek a just-accepted connection's first message; true iff it's an
@@ -492,11 +527,15 @@ fn spawn_clone_worker(conn_fd: std::os::unix::io::RawFd, token: u64) -> io::Resu
     // M3a: serialize the golden's modules (images) + functions to a temp file for
     // the worker to reload + remap. Images are MB-scale, so a file, not env.
     let mut modpath: Option<String> = None;
-    if let Some((modules, funcs)) = smolvm_cuda::host::module_handoff_snapshot(token) {
+    if let Some((modules, funcs, streams, events)) =
+        smolvm_cuda::host::module_handoff_snapshot(token)
+    {
         tracing::info!(
             modules = modules.len(),
             funcs = funcs.len(),
-            "M3a: gathered golden modules/functions"
+            streams = streams.len(),
+            events = events.len(),
+            "M3a: gathered golden modules/functions/streams/events"
         );
         let mut blob = Vec::new();
         blob.extend_from_slice(&(modules.len() as u32).to_le_bytes());
@@ -511,6 +550,17 @@ fn spawn_clone_worker(conn_fd: std::os::unix::io::RawFd, token: u64) -> io::Resu
             blob.extend_from_slice(&m.to_le_bytes());
             blob.extend_from_slice(&(n.len() as u32).to_le_bytes());
             blob.extend_from_slice(n.as_bytes());
+        }
+        // Streams + events: [u64 golden handle][u32 create flags] each.
+        blob.extend_from_slice(&(streams.len() as u32).to_le_bytes());
+        for (h, flags) in &streams {
+            blob.extend_from_slice(&h.to_le_bytes());
+            blob.extend_from_slice(&flags.to_le_bytes());
+        }
+        blob.extend_from_slice(&(events.len() as u32).to_le_bytes());
+        for (h, flags) in &events {
+            blob.extend_from_slice(&h.to_le_bytes());
+            blob.extend_from_slice(&flags.to_le_bytes());
         }
         let _ = std::fs::create_dir_all("/tmp/smolvm");
         let mp = format!("/tmp/smolvm/clone-mods-{token}-{conn_fd}.bin");

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -228,6 +228,24 @@ pub fn run_clone_worker(fd: std::os::unix::io::RawFd) -> io::Result<()> {
             maps = n,
             "cuda clone-worker: reconstructed golden memory at its VAs"
         );
+        // Barrier: VMM reconstruction must fully settle before the clone runs, or a
+        // later cuModuleLoadData surfaces a sticky async fault from the copies.
+        if let Err(e) = backend.ctx_synchronize() {
+            tracing::warn!(e, "clone-worker: sync after memory reconstruction failed");
+        }
+    }
+    // M3a: reload the golden's modules + re-resolve its functions in OUR context,
+    // and install the golden→worker handle translation so the clone's inherited
+    // kernel launches (raw CUfunction from the golden's context) resolve correctly.
+    if let Ok(modpath) = std::env::var("SMOLVM_CUDA_CLONE_MODULES") {
+        let (funcs, mods) = reconstruct_golden_modules(backend.as_mut(), &modpath);
+        let nf = funcs.len();
+        smolvm_cuda::host::set_handle_trans(funcs, mods);
+        let _ = std::fs::remove_file(&modpath);
+        tracing::info!(
+            functions = nf,
+            "cuda clone-worker: reloaded golden modules + remapped handles"
+        );
     }
     // SAFETY: the daemon handed us sole ownership of the accepted connection fd.
     let stream = unsafe { std::os::unix::net::UnixStream::from_raw_fd(fd) };
@@ -259,7 +277,9 @@ fn reconstruct_golden_memory(b: &mut dyn Backend, layout: &str) -> usize {
     for e in resv_s.split(',').filter(|s| !s.is_empty()) {
         if let Some((va, size)) = e.split_once(':') {
             if let (Some(va), Some(size)) = (hx(va), hx(size)) {
-                let _ = b.mem_address_reserve_fixed(size, 0, va);
+                if let Err(e) = b.mem_address_reserve_fixed(size, 0, va) {
+                    tracing::warn!(e, va, "M2: reserve-fixed failed");
+                }
             }
         }
     }
@@ -276,27 +296,132 @@ fn reconstruct_golden_memory(b: &mut dyn Backend, layout: &str) -> usize {
         // VA, then copy the golden's bytes in via a temp mapping of the imported
         // physical. Reads see the golden's data; writes hit the clone's own copy,
         // so a clone can't corrupt the frozen golden.
-        let Ok(priv_h) = b.mem_create(size, 0) else {
-            continue;
+        let priv_h = match b.mem_create(size, 0) {
+            Ok(h) => h,
+            Err(e) => {
+                tracing::warn!(e, "M2: private create failed");
+                continue;
+            }
         };
-        if b.mem_map(va, size, 0, priv_h).is_err() {
+        if let Err(e) = b.mem_map(va, size, 0, priv_h) {
+            tracing::warn!(e, va, "M2: private map failed");
             continue;
         }
-        let _ = b.mem_set_access(va, size, 0);
-        if let Ok(gh) = b.mem_import_handle(4 + idx) {
-            if let Ok(tmp) = b.mem_address_reserve(size, 0) {
-                if b.mem_map(tmp, size, 0, gh).is_ok() {
-                    let _ = b.mem_set_access(tmp, size, 0);
-                    let _ = b.memcpy_dtod(va, tmp, size); // golden data → private copy
-                    let _ = b.mem_unmap(tmp, size);
+        if let Err(e) = b.mem_set_access(va, size, 0) {
+            tracing::warn!(e, va, "M2: private set_access failed");
+        }
+        match b.mem_import_handle(4 + idx) {
+            Ok(gh) => {
+                if let Ok(tmp) = b.mem_address_reserve(size, 0) {
+                    match b.mem_map(tmp, size, 0, gh) {
+                        Ok(()) => {
+                            if let Err(e) = b.mem_set_access(tmp, size, 0) {
+                                tracing::warn!(e, "M2: temp set_access failed");
+                            }
+                            if let Err(e) = b.memcpy_dtod(va, tmp, size) {
+                                tracing::warn!(e, va, tmp, "M2: dtod copy failed");
+                            }
+                            // The copy must finish before we unmap the temp source,
+                            // or the in-flight copy faults on unmapped memory.
+                            let _ = b.ctx_synchronize();
+                            let _ = b.mem_unmap(tmp, size);
+                        }
+                        Err(e) => tracing::warn!(e, tmp, "M2: temp map failed"),
+                    }
+                    let _ = b.mem_address_free(tmp, size);
                 }
-                let _ = b.mem_address_free(tmp, size);
+                let _ = b.mem_release(gh);
             }
-            let _ = b.mem_release(gh);
+            Err(e) => tracing::warn!(e, idx, "M2: import failed"),
         }
         count += 1;
     }
     count
+}
+
+/// M3a: reload the golden's modules + re-resolve its functions in THIS worker's
+/// context, returning golden→worker handle maps `(functions, modules)`. Reads the
+/// binary blob the daemon wrote (path in `SMOLVM_CUDA_CLONE_MODULES`):
+/// `[u32 nmods]( [u64 handle][u32 len][image] )* [u32 nfuncs]( [u64 fn][u64 mod][u32 len][name] )*`.
+#[cfg(unix)]
+fn reconstruct_golden_modules(
+    b: &mut dyn Backend,
+    path: &str,
+) -> (Vec<(u64, u64)>, Vec<(u64, u64)>) {
+    let (mut func_trans, mut mod_trans) = (Vec::new(), Vec::new());
+    let Ok(buf) = std::fs::read(path) else {
+        return (func_trans, mod_trans);
+    };
+    let mut p = 0usize;
+    macro_rules! need {
+        ($n:expr) => {
+            if p + $n > buf.len() {
+                return (func_trans, mod_trans);
+            }
+        };
+    }
+    macro_rules! ru32 {
+        () => {{
+            need!(4);
+            let v = u32::from_le_bytes(buf[p..p + 4].try_into().unwrap());
+            p += 4;
+            v
+        }};
+    }
+    macro_rules! ru64 {
+        () => {{
+            need!(8);
+            let v = u64::from_le_bytes(buf[p..p + 8].try_into().unwrap());
+            p += 8;
+            v
+        }};
+    }
+    let mut g2w: std::collections::HashMap<u64, u64> = std::collections::HashMap::new();
+    let nmods = ru32!();
+    for _ in 0..nmods {
+        let gh = ru64!();
+        let ilen = ru32!() as usize;
+        need!(ilen);
+        let img = buf[p..p + ilen].to_vec();
+        p += ilen;
+        // Null-terminate: cuModuleLoadData treats a PTX image as a C string, so the
+        // stored bytes need a trailing NUL the raw blob may lack.
+        let mut img = img;
+        if img.last() != Some(&0) {
+            img.push(0);
+        }
+        match b.module_load_data(&img) {
+            Ok(wh) => {
+                g2w.insert(gh, wh);
+                mod_trans.push((gh, wh));
+            }
+            Err(e) => tracing::warn!(e, ilen, "M3a: module reload failed"),
+        }
+    }
+    let nfuncs = ru32!();
+    for _ in 0..nfuncs {
+        let gf = ru64!();
+        let gm = ru64!();
+        let nlen = ru32!() as usize;
+        need!(nlen);
+        let name = String::from_utf8_lossy(&buf[p..p + nlen]).into_owned();
+        p += nlen;
+        match g2w.get(&gm) {
+            Some(&wm) => match b.module_get_function(wm, &name) {
+                Ok(wf) => func_trans.push((gf, wf)),
+                Err(e) => tracing::warn!(name, e, "M3a: re-resolve function failed"),
+            },
+            None => tracing::warn!(gm, "M3a: function's module not reloaded"),
+        }
+    }
+    tracing::info!(
+        nmods,
+        nfuncs,
+        mods = mod_trans.len(),
+        funcs = func_trans.len(),
+        "M3a: reconstruct_golden_modules"
+    );
+    (func_trans, mod_trans)
 }
 
 /// Path 3 (M1): peek a just-accepted connection's first message; true iff it's an
@@ -347,6 +472,10 @@ fn spawn_clone_worker(conn_fd: std::os::unix::io::RawFd, token: u64) -> io::Resu
     backend
         .primary_ctx_retain(0)
         .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("ctx retain: {e}")))?;
+    // Commit the golden's pending device work so its writes are visible in the
+    // physical the clone will IPC-import (the golden runs on another thread of the
+    // shared primary context).
+    let _ = backend.ctx_synchronize();
     let mut layout = String::from("resv=");
     for (va, size) in &resvs {
         layout.push_str(&format!("{va:x}:{size:x},"));
@@ -360,10 +489,42 @@ fn spawn_clone_worker(conn_fd: std::os::unix::io::RawFd, token: u64) -> io::Resu
             layout.push_str(&format!("{va:x}:{size:x}:{idx},"));
         }
     }
+    // M3a: serialize the golden's modules (images) + functions to a temp file for
+    // the worker to reload + remap. Images are MB-scale, so a file, not env.
+    let mut modpath: Option<String> = None;
+    if let Some((modules, funcs)) = smolvm_cuda::host::module_handoff_snapshot(token) {
+        tracing::info!(
+            modules = modules.len(),
+            funcs = funcs.len(),
+            "M3a: gathered golden modules/functions"
+        );
+        let mut blob = Vec::new();
+        blob.extend_from_slice(&(modules.len() as u32).to_le_bytes());
+        for (h, img) in &modules {
+            blob.extend_from_slice(&h.to_le_bytes());
+            blob.extend_from_slice(&(img.len() as u32).to_le_bytes());
+            blob.extend_from_slice(img);
+        }
+        blob.extend_from_slice(&(funcs.len() as u32).to_le_bytes());
+        for (h, m, n) in &funcs {
+            blob.extend_from_slice(&h.to_le_bytes());
+            blob.extend_from_slice(&m.to_le_bytes());
+            blob.extend_from_slice(&(n.len() as u32).to_le_bytes());
+            blob.extend_from_slice(n.as_bytes());
+        }
+        let _ = std::fs::create_dir_all("/tmp/smolvm");
+        let mp = format!("/tmp/smolvm/clone-mods-{token}-{conn_fd}.bin");
+        if std::fs::write(&mp, &blob).is_ok() {
+            modpath = Some(mp);
+        }
+    }
     let exe = std::env::current_exe()?;
     let mut cmd = std::process::Command::new(exe);
     cmd.arg("_cuda-clone-worker").arg("3");
     cmd.env("SMOLVM_CUDA_CLONE_LAYOUT", layout);
+    if let Some(mp) = &modpath {
+        cmd.env("SMOLVM_CUDA_CLONE_MODULES", mp);
+    }
     // SAFETY: dup2 in the forked child (async-signal-safe); fds were inherited at
     // fork. Connection → fd 3; each exported physical → fd 4+idx.
     unsafe {

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -126,7 +126,29 @@ pub fn run(sock: &Path) -> io::Result<()> {
         match stream {
             // Count the connection open for the whole serve loop so a frozen golden
             // (idle but connected) keeps the daemon alive for its clones.
-            Ok(stream) => spawn_serve(stream, &active),
+            Ok(stream) => {
+                // Path 3 (M1): an isolating fork clone is served in its own worker
+                // PROCESS (own context/UVA) so it can hold memory at the golden's
+                // exact VAs. Only fires under SMOLVM_CUDA_PATH3; otherwise legacy.
+                #[cfg(unix)]
+                {
+                    use std::os::unix::io::AsRawFd;
+                    let fd = stream.as_raw_fd();
+                    if let Some(token) = peek_clone_token(fd) {
+                        match spawn_clone_worker(fd, token) {
+                            Ok(()) => {
+                                tracing::info!(token, "routed isolating clone to a worker process");
+                                drop(stream); // the worker owns the connection now
+                                continue;
+                            }
+                            Err(e) => {
+                                tracing::warn!(error = %e, "clone-worker spawn failed; serving in-process");
+                            }
+                        }
+                    }
+                }
+                spawn_serve(stream, &active);
+            }
             Err(e) => tracing::debug!(error = %e, "CUDA daemon accept error"),
         }
     }
@@ -181,6 +203,183 @@ fn make_backend() -> Box<dyn Backend> {
             Box::<CpuBackend>::default()
         }
     }
+}
+
+/// Path 3 (M1): serve one isolating fork-clone connection in THIS separate worker
+/// process. A per-clone process has its own CUDA primary context and thus its own
+/// UVA space, so it can place memory at the golden's exact virtual addresses
+/// (address-preserving isolation — no per-op pointer translation). The daemon
+/// spawns us with the accepted connection's fd (see the clone routing in
+/// `spawn_serve`). M2 (golden-state reconstruction) and M3 (module/graph rebuild)
+/// hook in before the serve loop; establishing the process boundary comes first.
+pub fn run_clone_worker(fd: std::os::unix::io::RawFd) -> io::Result<()> {
+    use std::os::unix::io::FromRawFd;
+    let mut backend = make_backend();
+    // Our own primary context (separate process ⇒ own UVA), so we can place memory
+    // at the golden's exact VAs.
+    let _ = backend.init();
+    let _ = backend.primary_ctx_retain(0);
+    // M2: reconstruct the golden's memory at its exact VAs from the layout the
+    // daemon passed (SMOLVM_CUDA_CLONE_LAYOUT) + the golden's physical exported to
+    // fds 4.. — BEFORE serving, so the clone's inherited pointers are valid verbatim.
+    if let Ok(layout) = std::env::var("SMOLVM_CUDA_CLONE_LAYOUT") {
+        let n = reconstruct_golden_memory(backend.as_mut(), &layout);
+        tracing::info!(
+            maps = n,
+            "cuda clone-worker: reconstructed golden memory at its VAs"
+        );
+    }
+    // SAFETY: the daemon handed us sole ownership of the accepted connection fd.
+    let stream = unsafe { std::os::unix::net::UnixStream::from_raw_fd(fd) };
+    tracing::info!(
+        fd,
+        "cuda clone-worker: serving in its own context / UVA space"
+    );
+    serve(stream, backend.as_mut())
+}
+
+/// M2: rebuild the golden's VMM layout in THIS worker's context at the golden's
+/// EXACT VAs. `layout` = `"resv=va:size,…|maps=va:size:fdidx,…"` (hex); each map's
+/// physical was exported by the daemon to fd `4 + fdidx`. We import + map at the
+/// same VA — address-preserving, so inherited pointers and rebuilt graphs are
+/// valid verbatim. (Weights are shared here; private-mutable copy for full
+/// isolation is the next refinement.)
+#[cfg(unix)]
+fn reconstruct_golden_memory(b: &mut dyn Backend, layout: &str) -> usize {
+    let (mut resv_s, mut maps_s) = ("", "");
+    for part in layout.split('|') {
+        if let Some(r) = part.strip_prefix("resv=") {
+            resv_s = r;
+        }
+        if let Some(m) = part.strip_prefix("maps=") {
+            maps_s = m;
+        }
+    }
+    let hx = |s: &str| u64::from_str_radix(s, 16).ok();
+    for e in resv_s.split(',').filter(|s| !s.is_empty()) {
+        if let Some((va, size)) = e.split_once(':') {
+            if let (Some(va), Some(size)) = (hx(va), hx(size)) {
+                let _ = b.mem_address_reserve_fixed(size, 0, va);
+            }
+        }
+    }
+    let mut count = 0;
+    for e in maps_s.split(',').filter(|s| !s.is_empty()) {
+        let f: Vec<&str> = e.split(':').collect();
+        if f.len() != 3 {
+            continue;
+        }
+        let (Some(va), Some(size), Ok(idx)) = (hx(f[0]), hx(f[1]), f[2].parse::<i32>()) else {
+            continue;
+        };
+        // Private-mutable, address-preserving: map a PRIVATE physical at the golden
+        // VA, then copy the golden's bytes in via a temp mapping of the imported
+        // physical. Reads see the golden's data; writes hit the clone's own copy,
+        // so a clone can't corrupt the frozen golden.
+        let Ok(priv_h) = b.mem_create(size, 0) else {
+            continue;
+        };
+        if b.mem_map(va, size, 0, priv_h).is_err() {
+            continue;
+        }
+        let _ = b.mem_set_access(va, size, 0);
+        if let Ok(gh) = b.mem_import_handle(4 + idx) {
+            if let Ok(tmp) = b.mem_address_reserve(size, 0) {
+                if b.mem_map(tmp, size, 0, gh).is_ok() {
+                    let _ = b.mem_set_access(tmp, size, 0);
+                    let _ = b.memcpy_dtod(va, tmp, size); // golden data → private copy
+                    let _ = b.mem_unmap(tmp, size);
+                }
+                let _ = b.mem_address_free(tmp, size);
+            }
+            let _ = b.mem_release(gh);
+        }
+        count += 1;
+    }
+    count
+}
+
+/// Path 3 (M1): peek a just-accepted connection's first message; true iff it's an
+/// isolating fork-clone Init (`op == Init`, `resume_token != 0`) that should be
+/// served in a dedicated worker process. `MSG_PEEK` leaves the bytes on the
+/// socket so the worker reads them fresh. Gated behind `SMOLVM_CUDA_PATH3` (unset
+/// = legacy shared-context path) so partial Path-3 wiring can't disturb serving.
+#[cfg(unix)]
+fn peek_clone_token(fd: std::os::unix::io::RawFd) -> Option<u64> {
+    if std::env::var_os("SMOLVM_CUDA_PATH3").is_none()
+        || std::env::var_os("SMOLVM_CUDA_FORK_ISOLATE").is_none()
+    {
+        return None;
+    }
+    // framing: [u32 le len][op][proto_hash u64][resume_token u64]
+    let mut buf = [0u8; 21];
+    let n = unsafe {
+        libc::recv(
+            fd,
+            buf.as_mut_ptr() as *mut libc::c_void,
+            buf.len(),
+            libc::MSG_PEEK,
+        )
+    };
+    if n < 21 || buf[4] != 0x01 {
+        return None; // short read or not an Init
+    }
+    let token = u64::from_le_bytes(buf[13..21].try_into().unwrap());
+    (token != 0).then_some(token)
+}
+
+/// Path 3 (M1): hand the accepted connection to a fresh worker PROCESS (its own
+/// CUDA context, hence its own UVA — so it can place memory at the golden's exact
+/// VAs). `dup2` the socket fd onto fd 3 in the child (clears CLOEXEC) and exec
+/// `smolvm _cuda-clone-worker 3`; the daemon then drops its own copy.
+#[cfg(unix)]
+fn spawn_clone_worker(conn_fd: std::os::unix::io::RawFd, token: u64) -> io::Result<()> {
+    use std::os::unix::process::CommandExt;
+    // Gather the golden's VMM layout (reservations + maps→physical handle).
+    let (resvs, maps) = smolvm_cuda::host::layout_handoff_snapshot(token)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "no golden layout for token"))?;
+    // Export each map's physical to a POSIX fd (in the golden's shared context) and
+    // build the layout string the worker parses ("resv=va:size,…|maps=va:size:fdidx,…").
+    let mut backend = make_backend();
+    backend
+        .init()
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("worker-export init: {e}")))?;
+    backend
+        .primary_ctx_retain(0)
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("ctx retain: {e}")))?;
+    let mut layout = String::from("resv=");
+    for (va, size) in &resvs {
+        layout.push_str(&format!("{va:x}:{size:x},"));
+    }
+    layout.push_str("|maps=");
+    let mut export_fds: Vec<i32> = Vec::new();
+    for (va, size, handle) in &maps {
+        if let Ok(efd) = backend.mem_export_handle(*handle) {
+            let idx = export_fds.len();
+            export_fds.push(efd);
+            layout.push_str(&format!("{va:x}:{size:x}:{idx},"));
+        }
+    }
+    let exe = std::env::current_exe()?;
+    let mut cmd = std::process::Command::new(exe);
+    cmd.arg("_cuda-clone-worker").arg("3");
+    cmd.env("SMOLVM_CUDA_CLONE_LAYOUT", layout);
+    // SAFETY: dup2 in the forked child (async-signal-safe); fds were inherited at
+    // fork. Connection → fd 3; each exported physical → fd 4+idx.
+    unsafe {
+        cmd.pre_exec(move || {
+            if libc::dup2(conn_fd, 3) < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            for (i, efd) in export_fds.iter().enumerate() {
+                if libc::dup2(*efd, 4 + i as i32) < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+            }
+            Ok(())
+        });
+    }
+    cmd.spawn().map(|_| ())
 }
 
 /// Ensure the shared daemon is running and return its socket path. Serialized by

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,14 @@ enum Commands {
         socket: std::path::PathBuf,
     },
 
+    /// Internal: serve one isolating fork-clone connection in its own process
+    /// (Path 3 per-clone worker; not for direct use)
+    #[command(name = "_cuda-clone-worker", hide = true)]
+    CudaCloneWorker {
+        /// Accepted connection fd handed over by the daemon
+        fd: i32,
+    },
+
     /// Internal: clean up an ephemeral VM after its command exits (not for direct use)
     #[command(name = "_cleanup-ephemeral", hide = true)]
     CleanupEphemeral {
@@ -89,7 +97,7 @@ fn main() {
             .nth(1)
             .as_deref()
             .and_then(|s| s.to_str()),
-        Some("_boot-vm") | Some("_cuda-daemon")
+        Some("_boot-vm") | Some("_cuda-daemon") | Some("_cuda-clone-worker")
     );
     if !internal {
         if let Some(mode) = smolvm_pack::detect_packed_mode() {
@@ -120,6 +128,15 @@ fn main() {
         Commands::CudaDaemon { .. } => Err(smolvm::Error::Io(std::io::Error::new(
             std::io::ErrorKind::Unsupported,
             "the shared CUDA daemon is unix-only",
+        ))),
+        #[cfg(unix)]
+        Commands::CudaCloneWorker { fd } => {
+            smolvm::cuda_daemon::run_clone_worker(fd).map_err(smolvm::Error::Io)
+        }
+        #[cfg(not(unix))]
+        Commands::CudaCloneWorker { .. } => Err(smolvm::Error::Io(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "the CUDA clone worker is unix-only",
         ))),
         Commands::CleanupEphemeral {
             vm_name,


### PR DESCRIPTION
Each isolating fork clone runs in its own worker process (own CUDA context/UVA) at the golden's exact VAs — IPC-importing memory and reconstructing modules/functions/streams/events — so default-config expandable_segments torch/Unsloth can fork-train isolated in parallel; validated end-to-end with two Unsloth clones training distinct tasks correctly.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/633">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->