### PR TITLE
Resolve a named config.User to a numeric uid for crun exec (#632)

### DIFF
--- a/crates/smolvm-agent/src/crun.rs
+++ b/crates/smolvm-agent/src/crun.rs
@@ -191,11 +191,15 @@ impl CrunCommand {
         c
     }
 
-    /// Run the exec/run as `--user UID[:GID]` (or a username crun resolves against
-    /// the container's /etc/passwd). No-op when `user` is None. Used so `crun exec`
-    /// honours the container's configured user (CRI RunAsUser/RunAsUserName) —
-    /// without it, exec defaults to uid 0. Inserted before the deferred positional
-    /// arguments.
+    /// Run the exec/run as `--user UID[:GID]`. No-op when `user` is None. Used so
+    /// `crun exec` honours the container's configured user (image `config.User` /
+    /// CRI RunAsUser) — without it, exec defaults to uid 0.
+    ///
+    /// NOTE: crun's `--user` CLI flag accepts only a NUMERIC uid[:gid]; a username
+    /// is rejected with "invalid USERSPEC specified" (unlike the OCI runtime
+    /// spec's `process.user`, which `crun run` resolves). Callers must pass an
+    /// already-resolved numeric spec — see `oci::resolve_exec_user_spec` (#632).
+    /// Inserted before the deferred positional arguments.
     pub fn user(mut self, user: Option<&str>) -> Self {
         if let Some(u) = user.filter(|s| !s.is_empty()) {
             self.cmd.arg("--user").arg(u);

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -3785,6 +3785,19 @@ fn spawn_interactive_command(
         return Err("empty command".into());
     }
 
+    // The keep-alive join below runs the command via `crun exec --user`, which
+    // requires a NUMERIC uid[:gid] — a username (image `config.User` / request
+    // user) is rejected with "invalid USERSPEC specified". Resolve it against the
+    // container rootfs /etc/passwd, consistent with the `crun run` path (#632).
+    // (Harmless for the fresh-container path, which re-resolves via config.json.)
+    let launch_owned = ResolvedLaunch {
+        command: launch.command.clone(),
+        env: launch.env.clone(),
+        workdir: launch.workdir.clone(),
+        user: oci::resolve_exec_user_spec(Path::new(rootfs), launch.user.as_deref())?,
+    };
+    let launch = &launch_owned;
+
     // If a main workload container is running for this overlay, join it.
     if let Some(cid) = resolve_main_container(persistent_overlay_id) {
         return spawn_exec_in_container(&cid, launch, tty);
@@ -4840,7 +4853,7 @@ fn run_in_keepalive_container(
 ) -> Result<AgentResponse, Box<dyn std::error::Error>> {
     use std::io::Write as _;
 
-    let launch = ResolvedLaunch::resolve(
+    let mut launch = ResolvedLaunch::resolve(
         image,
         command.to_vec(),
         env.to_vec(),
@@ -4850,20 +4863,30 @@ fn run_in_keepalive_container(
 
     // Reuse the running keep-alive container, or establish one now so this and
     // every later exec join the same container (PID 1 = `tail -f /dev/null`).
-    let cid = match resolve_main_container(Some(overlay_id)) {
-        Some(c) => c,
+    // Also carry the container's rootfs so the user can be resolved against its
+    // /etc/passwd below.
+    let (cid, rootfs) = match resolve_main_container(Some(overlay_id)) {
+        Some(c) => (c, storage::persistent_overlay_rootfs(overlay_id)),
         None => {
             let prepared = storage::prepare_for_run_persistent(image, overlay_id)?;
             storage::setup_mounts(&prepared.rootfs_path, mounts)?;
-            ensure_main_container(
+            let cid = ensure_main_container(
                 &prepared.rootfs_path,
                 overlay_id,
                 mounts,
                 unprivileged,
                 &launch,
-            )?
+            )?;
+            (cid, std::path::PathBuf::from(&prepared.rootfs_path))
         }
     };
+
+    // The workload runs via `crun exec --user`, which requires a NUMERIC uid[:gid]
+    // — a username (the image's `config.User`, e.g. `nobody`/`node`, or the
+    // request user) is rejected with "invalid USERSPEC specified". Resolve it
+    // against the container's /etc/passwd, matching the `crun run` path (#632).
+    launch.user = oci::resolve_exec_user_spec(&rootfs, launch.user.as_deref())
+        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
 
     let output = if let Some(data) = stdin_data {
         let mut child = crun::CrunCommand::exec(

--- a/crates/smolvm-agent/src/oci.rs
+++ b/crates/smolvm-agent/src/oci.rs
@@ -176,6 +176,29 @@ pub fn resolve_process_identity(
     })
 }
 
+/// Resolve an OCI/CRI user spec — which may be a **username** (an image's
+/// `config.User`, e.g. `node`/`nobody`/`root`, or a CRI `RunAsUserName`) — to the
+/// numeric `"uid:gid"` form that `crun exec --user` requires. Unlike the OCI
+/// runtime spec's `process.user` (which `crun run` reads and resolves), crun's
+/// `--user` CLI flag only accepts numeric ids and rejects a name with
+/// `invalid USERSPEC specified` (issue #632).
+///
+/// Returns `Ok(None)` for an empty/absent spec so the exec keeps the container
+/// default. Names are resolved against the rootfs `/etc/passwd` via
+/// [`resolve_process_identity`], so this stays consistent with the `crun run`
+/// path's resolution (same uid/gid, home, groups).
+pub fn resolve_exec_user_spec(
+    rootfs: &Path,
+    user_spec: Option<&str>,
+) -> Result<Option<String>, String> {
+    let normalized = user_spec.map(str::trim).filter(|s| !s.is_empty());
+    if normalized.is_none() {
+        return Ok(None);
+    }
+    let identity = resolve_process_identity(rootfs, user_spec)?;
+    Ok(Some(format!("{}:{}", identity.user.uid, identity.user.gid)))
+}
+
 fn parse_user_spec(spec: &str) -> Result<(&str, Option<&str>), String> {
     match spec.split_once(':') {
         Some((user, group)) => {
@@ -1363,6 +1386,43 @@ mod tests {
         assert_eq!(identity.user.gid, 2345);
         assert!(identity.user.additional_gids.is_empty());
         assert!(identity.home.is_none());
+    }
+
+    #[test]
+    fn test_resolve_exec_user_spec_resolves_name_to_numeric() {
+        // crun exec --user needs numeric ids; a name (image config.User) must be
+        // resolved against the rootfs passwd — the crux of issue #632.
+        let rootfs = tempdir().unwrap();
+        let etc = rootfs.path().join("etc");
+        std::fs::create_dir_all(&etc).unwrap();
+        std::fs::write(
+            etc.join("passwd"),
+            "root:x:0:0:root:/root:/bin/sh\nnobody:x:65534:65534::/:/sbin/nologin\n",
+        )
+        .unwrap();
+        std::fs::write(etc.join("group"), "root:x:0:\nnobody:x:65534:\n").unwrap();
+
+        // A username resolves to its uid:gid.
+        assert_eq!(
+            resolve_exec_user_spec(rootfs.path(), Some("nobody")).unwrap(),
+            Some("65534:65534".to_string())
+        );
+        // `root` is also a name — it must resolve to 0:0, not be rejected.
+        assert_eq!(
+            resolve_exec_user_spec(rootfs.path(), Some("root")).unwrap(),
+            Some("0:0".to_string())
+        );
+        // Numeric specs pass through unchanged.
+        assert_eq!(
+            resolve_exec_user_spec(rootfs.path(), Some("65534")).unwrap(),
+            Some("65534:65534".to_string())
+        );
+        // No user / blank → None (exec keeps the container default).
+        assert_eq!(resolve_exec_user_spec(rootfs.path(), None).unwrap(), None);
+        assert_eq!(
+            resolve_exec_user_spec(rootfs.path(), Some("  ")).unwrap(),
+            None
+        );
     }
 
     #[test]

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -99,6 +99,17 @@ fn overlay_root_for_workload(workload_id: &str) -> Result<PathBuf> {
     Ok(Path::new(STORAGE_ROOT).join(OVERLAYS_DIR).join(workload_id))
 }
 
+/// Merged rootfs directory of a persistent overlay, derived without preparing
+/// it. Lets the keep-alive `crun exec` path read the running container's
+/// `/etc/passwd` (to resolve a username to a numeric uid, #632) when joining an
+/// already-running container, where no fresh `prepare_for_run_persistent` ran.
+pub fn persistent_overlay_rootfs(overlay_id: &str) -> PathBuf {
+    Path::new(STORAGE_ROOT)
+        .join(OVERLAYS_DIR)
+        .join(format!("persistent-{}", overlay_id))
+        .join("merged")
+}
+
 fn validate_container_destination_path(container_path: &str) -> Result<PathBuf> {
     if !container_path.starts_with('/') {
         return Err(StorageError::ValidationFailed {


### PR DESCRIPTION
Fixes #632.

An image whose config.User is a username (USER node/nobody/root) fails to boot with "invalid USERSPEC specified" because the workload runs via crun exec --user, whose CLI flag only accepts a numeric uid[:gid] — unlike the OCI process.user that crun run resolves. This resolves the name to a numeric uid:gid against the container's /etc/passwd (reusing resolve_process_identity) before the exec, so named-USER images boot and run as the correct uid.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/634">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->