### PR TITLE
ci: gate committed libkrun glibc floor <= 2.35 (#636)

### DIFF
--- a/.github/workflows/build-libkrun.yml
+++ b/.github/workflows/build-libkrun.yml
@@ -58,17 +58,11 @@ jobs:
             SKIP_LIBKRUNFW=1 GPU=1 ./scripts/build-libkrun-linux.sh
           fi
 
+      # Same gate CI runs on the committed libs (scripts/check-libkrun-glibc.sh),
+      # scoped to the arch just built. One source of truth for the floor check.
       - name: Assert glibc floor <= 2.35
-        run: |
-          so="lib/linux-${{ matrix.arch }}/libkrun.so"
-          maxv=$(objdump -T "$so" | grep -oE 'GLIBC_[0-9]+\.[0-9]+' \
-            | sed 's/GLIBC_//' | sort -V | tail -1)
-          echo "max GLIBC required by $so: ${maxv:-none}"
-          if [ -n "$maxv" ] && [ "$(printf '%s\n2.35\n' "$maxv" | sort -V | tail -1)" != "2.35" ]; then
-            echo "::error::$so requires glibc $maxv (> 2.35) — floor not lowered"
-            exit 1
-          fi
-          echo "OK: glibc floor is <= 2.35"
+        run: SMOLVM_GLIBC_FLOOR_LIBS="lib/linux-${{ matrix.arch }}/libkrun.so" \
+          ./scripts/check-libkrun-glibc.sh
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-libkrun.yml
+++ b/.github/workflows/build-libkrun.yml
@@ -61,8 +61,9 @@ jobs:
       # Same gate CI runs on the committed libs (scripts/check-libkrun-glibc.sh),
       # scoped to the arch just built. One source of truth for the floor check.
       - name: Assert glibc floor <= 2.35
-        run: SMOLVM_GLIBC_FLOOR_LIBS="lib/linux-${{ matrix.arch }}/libkrun.so" \
-          ./scripts/check-libkrun-glibc.sh
+        env:
+          SMOLVM_GLIBC_FLOOR_LIBS: lib/linux-${{ matrix.arch }}/libkrun.so
+        run: ./scripts/check-libkrun-glibc.sh
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,10 @@ jobs:
           lfs: true
       - name: Bundled libkrun matches the pinned submodule
         run: ./scripts/check-libkrun-provenance.sh
+      # Gate the committed Linux libkrun glibc floor (<= 2.35). The release ships
+      # these libs as-is, so this is the floor users get (issue #636).
+      - name: Bundled libkrun glibc floor <= 2.35
+        run: ./scripts/check-libkrun-glibc.sh
       # nm (ELF), llvm-nm (Mach-O dylib), mingw objdump (PE dll exports).
       - name: Install symbol-reading tools
         run: |

--- a/lib/linux-aarch64/libkrun.so
+++ b/lib/linux-aarch64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:469d3b83a9844d12fe33eb5999401e7e7e1e4693a42c5ec7a178af7a647fcdb0
-size 6983640
+oid sha256:2a60967b99d5cc8c8fcfabbccfd8e319a966169966ce02ffbc34c880a952b82b
+size 6731696

--- a/lib/linux-aarch64/libkrun.so.2.0.0
+++ b/lib/linux-aarch64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:469d3b83a9844d12fe33eb5999401e7e7e1e4693a42c5ec7a178af7a647fcdb0
-size 6983640
+oid sha256:2a60967b99d5cc8c8fcfabbccfd8e319a966169966ce02ffbc34c880a952b82b
+size 6731696

--- a/lib/linux-x86_64/libkrun.so
+++ b/lib/linux-x86_64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:786c9617cc28275db5ce95c19a1746d115de41dfc73e4ef9d06da3c015ec34f2
-size 7959224
+oid sha256:e89fea9f5cbbf38f51bcde17c216617c4c4c8e92246c77ec2acb801537f792f8
+size 8076336

--- a/lib/linux-x86_64/libkrun.so.2.0.0
+++ b/lib/linux-x86_64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:786c9617cc28275db5ce95c19a1746d115de41dfc73e4ef9d06da3c015ec34f2
-size 7959224
+oid sha256:e89fea9f5cbbf38f51bcde17c216617c4c4c8e92246c77ec2acb801537f792f8
+size 8076336

--- a/scripts/check-libkrun-glibc.sh
+++ b/scripts/check-libkrun-glibc.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Assert every committed Linux libkrun.so has a glibc symbol floor <= MAX
+# (default 2.35). A libkrun built on a newer distro (e.g. Ubuntu 24.04 / glibc
+# 2.39) loads fine there but dies on 22.04 / Debian 12 / RHEL 9 with
+# "GLIBC_2.39 not found", bricking `machine run` before the agent is ready.
+#
+# The release ships the committed lib/linux-<arch>/libkrun.so as-is (no rebuild),
+# so the floor of what's in git IS the floor users get. build-libkrun.yml asserts
+# this on the rebuild path; this script gates the committed binary in CI so a
+# high-floor lib can never be merged/tagged (regression that shipped in v1.6.0,
+# issue #636).
+#
+# Arch-independent: GLIBC_x.y version strings live in .dynstr, so grepping the
+# ELF works for both x86_64 and aarch64 on one runner — no cross-arch objdump.
+#
+#   PASS  → every committed Linux libkrun.so floor <= MAX
+#   FAIL  → a lib exceeds MAX (rebuild on 22.04) or LFS wasn't pulled
+set -euo pipefail
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+MAX="${SMOLVM_GLIBC_FLOOR_MAX:-2.35}"
+# Default: every committed Linux libkrun. Override (space-separated) to scope to a
+# single arch, e.g. from build-libkrun.yml which rebuilds one arch per matrix job.
+read -r -a LIBS <<<"${SMOLVM_GLIBC_FLOOR_LIBS:-lib/linux-x86_64/libkrun.so lib/linux-aarch64/libkrun.so}"
+
+fail=0
+for so in "${LIBS[@]}"; do
+  if [[ ! -f "$so" ]]; then
+    echo "FAIL  $so: missing (git lfs not pulled?)"
+    fail=1
+    continue
+  fi
+  # LFS pointer instead of the real binary → no GLIBC strings; catch it.
+  if head -c 64 "$so" | grep -q 'git-lfs'; then
+    echo "FAIL  $so: LFS pointer, not the binary — run 'git lfs pull'"
+    fail=1
+    continue
+  fi
+  maxv="$(grep -aoE 'GLIBC_[0-9]+\.[0-9]+' "$so" | sed 's/GLIBC_//' | sort -V | tail -1)"
+  if [[ -n "$maxv" && "$(printf '%s\n%s\n' "$maxv" "$MAX" | sort -V | tail -1)" != "$MAX" ]]; then
+    echo "FAIL  $so: requires glibc $maxv (> $MAX)"
+    fail=1
+  else
+    echo "OK    $so (max GLIBC ${maxv:-none} <= $MAX)"
+  fi
+done
+
+if [[ "$fail" != "0" ]]; then
+  cat >&2 <<EOF
+
+Committed libkrun exceeds the glibc floor ($MAX). Rebuild on a matching-floor host:
+  x86_64:  ./scripts/build-libkrun-linux.sh          # on ubuntu-22.04
+  aarch64: ./scripts/build-libkrun-linux.sh          # on ubuntu-22.04-arm
+  (or dispatch .github/workflows/build-libkrun.yml, which builds both on 22.04)
+then commit the updated lib/linux-<arch>/ (binary + libkrun.provenance).
+EOF
+  exit 1
+fi
+echo "All committed libkrun binaries meet the glibc floor (<= $MAX)."


### PR DESCRIPTION
Fixes #636.

## Root cause

The Linux release ships the committed `lib/linux-<arch>/libkrun.so` as-is — `build-dist` never rebuilds libkrun. The `ubuntu-22.04` runner only lowers the floor of the freshly compiled `smolvm` CLI; the prebuilt libkrun is pulled from LFS untouched. So the **committed** binary's glibc floor is the floor users get.

`build-libkrun.yml` asserts the floor, but it's `workflow_dispatch`-only and validates a *freshly built* lib — nothing gated the committed one on PR/release. v1.6.0's committed libs were built on 24.04 (glibc 2.39); both arches floored at **2.39** and failed to boot on 22.04/Debian 12/RHEL 9:

```
version `GLIBC_2.39' not found (required by .../lib/libkrun.so)
```

`provenance` (submodule commit) and `krun-exports` (symbols) both pass on those libs, so neither catches it.

## Change

1. **Gate** — `scripts/check-libkrun-glibc.sh`: assert every committed Linux `libkrun.so` floors `<= 2.35` (override `SMOLVM_GLIBC_FLOOR_MAX` / `SMOLVM_GLIBC_FLOOR_LIBS`). Greps `.dynstr` version strings, so one x86 runner covers both arches — no cross-arch objdump. Also flags un-pulled LFS pointers. Wired into the `libkrun-provenance` CI job (blocks merge + release via `release → needs: ci`); `build-libkrun.yml` now calls the same script (one source of truth).
2. **Fix** — rebuilt both Linux libkrun via `build-libkrun.yml` on `ubuntu-22.04` / `ubuntu-22.04-arm` (`SKIP_LIBKRUNFW=1`, `GPU=1`). Floor is now **2.34**; same pinned submodules, so provenance is unchanged.

## Test

`libkrun freshness` (the gate) is green on this branch with the rebuilt libs.

```
$ ./scripts/check-libkrun-glibc.sh
OK    lib/linux-x86_64/libkrun.so (max GLIBC 2.34 <= 2.35)
OK    lib/linux-aarch64/libkrun.so (max GLIBC 2.34 <= 2.35)
```

Verified on Ubuntu 22.04 + A10: stock v1.6.0 CLI + agent-rootfs with a 2.34 libkrun reaches `torch.cuda.is_available() == True` (the 2.39 lib failed to boot). Cut a v1.6.1 with these libs to unbreak 22.04 users.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/639">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->