### PR TITLE
Bump the workspace to 1.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2985,7 +2985,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smolfile"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -3011,7 +3011,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "async-stream",
  "axum",
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-agent"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "flate2",
  "lazy_static",
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "libc",
  "libloading",
@@ -3095,11 +3095,11 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda-codegen"
-version = "1.6.0"
+version = "1.6.1"
 
 [[package]]
 name = "smolvm-cuda-guest"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "smolvm-cuda",
  "vsock",
@@ -3107,7 +3107,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda-shim"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "libc",
  "smolvm-cuda",
@@ -3116,7 +3116,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cudart-shim"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "libc",
  "smolvm-cuda",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-network"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "crossbeam-queue",
  "humantime",
@@ -3138,14 +3138,14 @@ dependencies = [
 
 [[package]]
 name = "smolvm-nvml-shim"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "smolvm-pack"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "base64",
  "serde",
@@ -3174,7 +3174,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "bytes",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 
 [package]
 name = "smolvm"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "OCI-native microVM runtime"
 license = "Apache-2.0"
@@ -36,12 +36,12 @@ name = "smolvm"
 path = "src/main.rs"
 
 [dependencies]
-smolvm-network = { path = "crates/smolvm-network", version = "1.6.0" }
-smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.6.0" }
-smolvm-cuda = { path = "crates/smolvm-cuda", version = "1.6.0" }
-smolvm-pack = { path = "crates/smolvm-pack", version = "1.6.0" }
-smolvm-registry = { path = "crates/smolvm-registry", version = "1.6.0" }
-smolfile = { path = "crates/smolvm-smolfile", version = "1.6.0" }
+smolvm-network = { path = "crates/smolvm-network", version = "1.6.1" }
+smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.6.1" }
+smolvm-cuda = { path = "crates/smolvm-cuda", version = "1.6.1" }
+smolvm-pack = { path = "crates/smolvm-pack", version = "1.6.1" }
+smolvm-registry = { path = "crates/smolvm-registry", version = "1.6.1" }
+smolfile = { path = "crates/smolvm-smolfile", version = "1.6.1" }
 thiserror = "1"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
@@ -124,7 +124,7 @@ windows-sys = { version = "0.60", features = [
 
 [dev-dependencies]
 tempfile = "3"
-smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.6.0" }
+smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.6.1" }
 regex = "1"
 
 [build-dependencies]

--- a/crates/smolvm-agent/Cargo.toml
+++ b/crates/smolvm-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-agent"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "Guest agent for smolvm VMs (handles OCI operations and command execution)"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ name = "smolvm-agent"
 path = "src/main.rs"
 
 [dependencies]
-smolvm-protocol = { path = "../smolvm-protocol", version = "1.6.0" }
+smolvm-protocol = { path = "../smolvm-protocol", version = "1.6.1" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/crates/smolvm-cuda-codegen/Cargo.toml
+++ b/crates/smolvm-cuda-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda-codegen"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "Generates forward-to-host-lib marshaling (guest stubs + host dispatch) from a function spec"
 license = "Apache-2.0"

--- a/crates/smolvm-cuda-guest/Cargo.toml
+++ b/crates/smolvm-cuda-guest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda-guest"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "Guest-side CUDA-over-vsock runner for smolvm microVMs (Linux)"
 license = "Apache-2.0"

--- a/crates/smolvm-cuda-shim/Cargo.toml
+++ b/crates/smolvm-cuda-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda-shim"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "Guest-side libcuda.so.1 drop-in: CUDA Driver API over smolvm's vsock RPC"
 license = "Apache-2.0"

--- a/crates/smolvm-cuda/Cargo.toml
+++ b/crates/smolvm-cuda/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "CUDA Driver-API remoting over vsock for smolvm guests"
 license = "Apache-2.0"

--- a/crates/smolvm-cudart-shim/Cargo.toml
+++ b/crates/smolvm-cudart-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cudart-shim"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "Guest-side libcudart.so drop-in: CUDA Runtime API lowered to smolvm's Driver-API vsock RPC"
 license = "Apache-2.0"

--- a/crates/smolvm-network/Cargo.toml
+++ b/crates/smolvm-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-network"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "Host-side virtio-net runtime for smolvm"
 license = "Apache-2.0"

--- a/crates/smolvm-nvml-shim/Cargo.toml
+++ b/crates/smolvm-nvml-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-nvml-shim"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "Guest-side libnvidia-ml.so.1 drop-in: answers the NVML queries CUDA frameworks (vLLM) use for device detection, backed by the remoted CUDA driver"
 license = "Apache-2.0"

--- a/crates/smolvm-pack/Cargo.toml
+++ b/crates/smolvm-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-pack"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "Single-binary packaging for smolvm"
 license = "Apache-2.0"
@@ -10,7 +10,7 @@ repository = "https://github.com/smol-machines/smolvm"
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-smolvm-protocol = { path = "../smolvm-protocol", version = "1.6.0" }
+smolvm-protocol = { path = "../smolvm-protocol", version = "1.6.1" }
 tar = "0.4"
 zstd = "0.13"
 crc32fast = "1.4"

--- a/crates/smolvm-protocol/Cargo.toml
+++ b/crates/smolvm-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-protocol"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "Protocol types for smolvm host-guest communication"
 license = "Apache-2.0"

--- a/crates/smolvm-registry/Cargo.toml
+++ b/crates/smolvm-registry/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "smolvm-registry"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "OCI Distribution client for smolmachines registry"
 license = "Apache-2.0"
 repository = "https://github.com/smol-machines/smolvm"
 
 [dependencies]
-smolvm-pack = { path = "../smolvm-pack", version = "1.6.0" }
+smolvm-pack = { path = "../smolvm-pack", version = "1.6.1" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "json"] }
 sha2 = "0.10"
 bytes = "1"

--- a/crates/smolvm-smolfile/Cargo.toml
+++ b/crates/smolvm-smolfile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolfile"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "Smolfile specification and parser for smolvm microVM workloads"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ keywords = ["smolvm", "microvm", "configuration"]
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 thiserror = "1"
-smolvm-protocol = { path = "../smolvm-protocol", version = "1.6.0" }
+smolvm-protocol = { path = "../smolvm-protocol", version = "1.6.1" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/nix/smolvm.nix
+++ b/nix/smolvm.nix
@@ -17,23 +17,23 @@
   gnutar,
   coreutils,
 }: let
-  version = "1.6.0";
+  version = "1.6.1";
 
   releases = {
     x86_64-linux = {
       asset = "smolvm-${version}-linux-x86_64.tar.gz";
       root = "smolvm-${version}-linux-x86_64";
-      hash = "sha256-bwOEVQNTo8k6tecaKR7Ww4Oe9iAa3HTNWITG1DWrrYs=";
+      hash = "sha256-JaLEPFlI0wnvFWlaubQKtzc7p6b0vmAVn5RPXni7jWY=";
     };
     aarch64-linux = {
       asset = "smolvm-${version}-linux-arm64.tar.gz";
       root = "smolvm-${version}-linux-arm64";
-      hash = "sha256-BHI9L0xkMU2J8KkQqByr6wdd4c6h/kXeBu2fsblESgM=";
+      hash = "sha256-zx3i1SGL/2u49hfLswFe5cYyyoRh4K6jUX0TqXEYY/Y=";
     };
     aarch64-darwin = {
       asset = "smolvm-${version}-darwin-arm64.tar.gz";
       root = "smolvm-${version}-darwin-arm64";
-      hash = "sha256-hWIDur296f8VaGnSzh28kvqnwq4S6tguFq0uDCztc2E=";
+      hash = "sha256-T6/oznmhfsv446JxaEOx5T2kXuOyYoa6ClOG96wB58Y=";
     };
   };
 


### PR DESCRIPTION
Aligns main with the released v1.6.1 (version strings across the workspace crates and the Nix flake, with the flake's per-arch SRI hashes updated to the 1.6.1 release tarballs).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/641">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->