### PR TITLE
Rebuild the linux libkrun.so with a glibc 2.35 floor and bump to 1.6.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,11 @@ jobs:
           sudo apt-get install -y binutils binutils-mingw-w64-x86-64 llvm
       - name: Bundled libkrun exports every symbol smolvm requires
         run: ./scripts/check-krun-exports.sh
+      # A libkrun built on a newer distro (glibc > 2.35) loads there but fails on
+      # ubuntu-22.04 / Debian 12 with "GLIBC_x.y not found" before the VM boots
+      # (issue #636). Gate every push so a wrong-host lib can't ship again.
+      - name: Bundled libkrun keeps a glibc floor <= 2.35
+        run: ./scripts/check-libkrun-glibc-floor.sh
 
   audit:
     name: Cargo Audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2985,7 +2985,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smolfile"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -3011,7 +3011,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "async-stream",
  "axum",
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-agent"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "flate2",
  "lazy_static",
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "libc",
  "libloading",
@@ -3095,11 +3095,11 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda-codegen"
-version = "1.6.0"
+version = "1.6.1"
 
 [[package]]
 name = "smolvm-cuda-guest"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "smolvm-cuda",
  "vsock",
@@ -3107,7 +3107,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda-shim"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "libc",
  "smolvm-cuda",
@@ -3116,7 +3116,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cudart-shim"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "libc",
  "smolvm-cuda",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-network"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "crossbeam-queue",
  "humantime",
@@ -3138,14 +3138,14 @@ dependencies = [
 
 [[package]]
 name = "smolvm-nvml-shim"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "smolvm-pack"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "base64",
  "serde",
@@ -3174,7 +3174,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "bytes",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2985,7 +2985,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smolfile"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -3011,7 +3011,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "async-stream",
  "axum",
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-agent"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "flate2",
  "lazy_static",
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "libc",
  "libloading",
@@ -3095,11 +3095,11 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda-codegen"
-version = "1.6.1"
+version = "1.6.2"
 
 [[package]]
 name = "smolvm-cuda-guest"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "smolvm-cuda",
  "vsock",
@@ -3107,7 +3107,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda-shim"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "libc",
  "smolvm-cuda",
@@ -3116,7 +3116,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cudart-shim"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "libc",
  "smolvm-cuda",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-network"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "crossbeam-queue",
  "humantime",
@@ -3138,14 +3138,14 @@ dependencies = [
 
 [[package]]
 name = "smolvm-nvml-shim"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "smolvm-pack"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "base64",
  "serde",
@@ -3174,7 +3174,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "bytes",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 
 [package]
 name = "smolvm"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "OCI-native microVM runtime"
 license = "Apache-2.0"
@@ -36,12 +36,12 @@ name = "smolvm"
 path = "src/main.rs"
 
 [dependencies]
-smolvm-network = { path = "crates/smolvm-network", version = "1.6.0" }
-smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.6.0" }
-smolvm-cuda = { path = "crates/smolvm-cuda", version = "1.6.0" }
-smolvm-pack = { path = "crates/smolvm-pack", version = "1.6.0" }
-smolvm-registry = { path = "crates/smolvm-registry", version = "1.6.0" }
-smolfile = { path = "crates/smolvm-smolfile", version = "1.6.0" }
+smolvm-network = { path = "crates/smolvm-network", version = "1.6.1" }
+smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.6.1" }
+smolvm-cuda = { path = "crates/smolvm-cuda", version = "1.6.1" }
+smolvm-pack = { path = "crates/smolvm-pack", version = "1.6.1" }
+smolvm-registry = { path = "crates/smolvm-registry", version = "1.6.1" }
+smolfile = { path = "crates/smolvm-smolfile", version = "1.6.1" }
 thiserror = "1"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
@@ -124,7 +124,7 @@ windows-sys = { version = "0.60", features = [
 
 [dev-dependencies]
 tempfile = "3"
-smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.6.0" }
+smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.6.1" }
 regex = "1"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 
 [package]
 name = "smolvm"
-version = "1.6.1"
+version = "1.6.2"
 edition = "2021"
 description = "OCI-native microVM runtime"
 license = "Apache-2.0"
@@ -36,12 +36,12 @@ name = "smolvm"
 path = "src/main.rs"
 
 [dependencies]
-smolvm-network = { path = "crates/smolvm-network", version = "1.6.1" }
-smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.6.1" }
-smolvm-cuda = { path = "crates/smolvm-cuda", version = "1.6.1" }
-smolvm-pack = { path = "crates/smolvm-pack", version = "1.6.1" }
-smolvm-registry = { path = "crates/smolvm-registry", version = "1.6.1" }
-smolfile = { path = "crates/smolvm-smolfile", version = "1.6.1" }
+smolvm-network = { path = "crates/smolvm-network", version = "1.6.2" }
+smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.6.2" }
+smolvm-cuda = { path = "crates/smolvm-cuda", version = "1.6.2" }
+smolvm-pack = { path = "crates/smolvm-pack", version = "1.6.2" }
+smolvm-registry = { path = "crates/smolvm-registry", version = "1.6.2" }
+smolfile = { path = "crates/smolvm-smolfile", version = "1.6.2" }
 thiserror = "1"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
@@ -124,7 +124,7 @@ windows-sys = { version = "0.60", features = [
 
 [dev-dependencies]
 tempfile = "3"
-smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.6.1" }
+smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.6.2" }
 regex = "1"
 
 [build-dependencies]

--- a/crates/smolvm-agent/Cargo.toml
+++ b/crates/smolvm-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-agent"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "Guest agent for smolvm VMs (handles OCI operations and command execution)"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ name = "smolvm-agent"
 path = "src/main.rs"
 
 [dependencies]
-smolvm-protocol = { path = "../smolvm-protocol", version = "1.6.0" }
+smolvm-protocol = { path = "../smolvm-protocol", version = "1.6.1" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/crates/smolvm-agent/Cargo.toml
+++ b/crates/smolvm-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-agent"
-version = "1.6.1"
+version = "1.6.2"
 edition = "2021"
 description = "Guest agent for smolvm VMs (handles OCI operations and command execution)"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ name = "smolvm-agent"
 path = "src/main.rs"
 
 [dependencies]
-smolvm-protocol = { path = "../smolvm-protocol", version = "1.6.1" }
+smolvm-protocol = { path = "../smolvm-protocol", version = "1.6.2" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/crates/smolvm-cuda-codegen/Cargo.toml
+++ b/crates/smolvm-cuda-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda-codegen"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "Generates forward-to-host-lib marshaling (guest stubs + host dispatch) from a function spec"
 license = "Apache-2.0"

--- a/crates/smolvm-cuda-codegen/Cargo.toml
+++ b/crates/smolvm-cuda-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda-codegen"
-version = "1.6.1"
+version = "1.6.2"
 edition = "2021"
 description = "Generates forward-to-host-lib marshaling (guest stubs + host dispatch) from a function spec"
 license = "Apache-2.0"

--- a/crates/smolvm-cuda-guest/Cargo.toml
+++ b/crates/smolvm-cuda-guest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda-guest"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "Guest-side CUDA-over-vsock runner for smolvm microVMs (Linux)"
 license = "Apache-2.0"

--- a/crates/smolvm-cuda-guest/Cargo.toml
+++ b/crates/smolvm-cuda-guest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda-guest"
-version = "1.6.1"
+version = "1.6.2"
 edition = "2021"
 description = "Guest-side CUDA-over-vsock runner for smolvm microVMs (Linux)"
 license = "Apache-2.0"

--- a/crates/smolvm-cuda-shim/Cargo.toml
+++ b/crates/smolvm-cuda-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda-shim"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "Guest-side libcuda.so.1 drop-in: CUDA Driver API over smolvm's vsock RPC"
 license = "Apache-2.0"

--- a/crates/smolvm-cuda-shim/Cargo.toml
+++ b/crates/smolvm-cuda-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda-shim"
-version = "1.6.1"
+version = "1.6.2"
 edition = "2021"
 description = "Guest-side libcuda.so.1 drop-in: CUDA Driver API over smolvm's vsock RPC"
 license = "Apache-2.0"

--- a/crates/smolvm-cuda/Cargo.toml
+++ b/crates/smolvm-cuda/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "CUDA Driver-API remoting over vsock for smolvm guests"
 license = "Apache-2.0"

--- a/crates/smolvm-cuda/Cargo.toml
+++ b/crates/smolvm-cuda/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda"
-version = "1.6.1"
+version = "1.6.2"
 edition = "2021"
 description = "CUDA Driver-API remoting over vsock for smolvm guests"
 license = "Apache-2.0"

--- a/crates/smolvm-cudart-shim/Cargo.toml
+++ b/crates/smolvm-cudart-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cudart-shim"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "Guest-side libcudart.so drop-in: CUDA Runtime API lowered to smolvm's Driver-API vsock RPC"
 license = "Apache-2.0"

--- a/crates/smolvm-cudart-shim/Cargo.toml
+++ b/crates/smolvm-cudart-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cudart-shim"
-version = "1.6.1"
+version = "1.6.2"
 edition = "2021"
 description = "Guest-side libcudart.so drop-in: CUDA Runtime API lowered to smolvm's Driver-API vsock RPC"
 license = "Apache-2.0"

--- a/crates/smolvm-network/Cargo.toml
+++ b/crates/smolvm-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-network"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "Host-side virtio-net runtime for smolvm"
 license = "Apache-2.0"

--- a/crates/smolvm-network/Cargo.toml
+++ b/crates/smolvm-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-network"
-version = "1.6.1"
+version = "1.6.2"
 edition = "2021"
 description = "Host-side virtio-net runtime for smolvm"
 license = "Apache-2.0"

--- a/crates/smolvm-nvml-shim/Cargo.toml
+++ b/crates/smolvm-nvml-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-nvml-shim"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "Guest-side libnvidia-ml.so.1 drop-in: answers the NVML queries CUDA frameworks (vLLM) use for device detection, backed by the remoted CUDA driver"
 license = "Apache-2.0"

--- a/crates/smolvm-nvml-shim/Cargo.toml
+++ b/crates/smolvm-nvml-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-nvml-shim"
-version = "1.6.1"
+version = "1.6.2"
 edition = "2021"
 description = "Guest-side libnvidia-ml.so.1 drop-in: answers the NVML queries CUDA frameworks (vLLM) use for device detection, backed by the remoted CUDA driver"
 license = "Apache-2.0"

--- a/crates/smolvm-pack/Cargo.toml
+++ b/crates/smolvm-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-pack"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "Single-binary packaging for smolvm"
 license = "Apache-2.0"
@@ -10,7 +10,7 @@ repository = "https://github.com/smol-machines/smolvm"
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-smolvm-protocol = { path = "../smolvm-protocol", version = "1.6.0" }
+smolvm-protocol = { path = "../smolvm-protocol", version = "1.6.1" }
 tar = "0.4"
 zstd = "0.13"
 crc32fast = "1.4"

--- a/crates/smolvm-pack/Cargo.toml
+++ b/crates/smolvm-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-pack"
-version = "1.6.1"
+version = "1.6.2"
 edition = "2021"
 description = "Single-binary packaging for smolvm"
 license = "Apache-2.0"
@@ -10,7 +10,7 @@ repository = "https://github.com/smol-machines/smolvm"
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-smolvm-protocol = { path = "../smolvm-protocol", version = "1.6.1" }
+smolvm-protocol = { path = "../smolvm-protocol", version = "1.6.2" }
 tar = "0.4"
 zstd = "0.13"
 crc32fast = "1.4"

--- a/crates/smolvm-protocol/Cargo.toml
+++ b/crates/smolvm-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-protocol"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "Protocol types for smolvm host-guest communication"
 license = "Apache-2.0"

--- a/crates/smolvm-protocol/Cargo.toml
+++ b/crates/smolvm-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-protocol"
-version = "1.6.1"
+version = "1.6.2"
 edition = "2021"
 description = "Protocol types for smolvm host-guest communication"
 license = "Apache-2.0"

--- a/crates/smolvm-registry/Cargo.toml
+++ b/crates/smolvm-registry/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "smolvm-registry"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "OCI Distribution client for smolmachines registry"
 license = "Apache-2.0"
 repository = "https://github.com/smol-machines/smolvm"
 
 [dependencies]
-smolvm-pack = { path = "../smolvm-pack", version = "1.6.0" }
+smolvm-pack = { path = "../smolvm-pack", version = "1.6.1" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "json"] }
 sha2 = "0.10"
 bytes = "1"

--- a/crates/smolvm-registry/Cargo.toml
+++ b/crates/smolvm-registry/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "smolvm-registry"
-version = "1.6.1"
+version = "1.6.2"
 edition = "2021"
 description = "OCI Distribution client for smolmachines registry"
 license = "Apache-2.0"
 repository = "https://github.com/smol-machines/smolvm"
 
 [dependencies]
-smolvm-pack = { path = "../smolvm-pack", version = "1.6.1" }
+smolvm-pack = { path = "../smolvm-pack", version = "1.6.2" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "json"] }
 sha2 = "0.10"
 bytes = "1"

--- a/crates/smolvm-smolfile/Cargo.toml
+++ b/crates/smolvm-smolfile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolfile"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 description = "Smolfile specification and parser for smolvm microVM workloads"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ keywords = ["smolvm", "microvm", "configuration"]
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 thiserror = "1"
-smolvm-protocol = { path = "../smolvm-protocol", version = "1.6.0" }
+smolvm-protocol = { path = "../smolvm-protocol", version = "1.6.1" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/smolvm-smolfile/Cargo.toml
+++ b/crates/smolvm-smolfile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolfile"
-version = "1.6.1"
+version = "1.6.2"
 edition = "2021"
 description = "Smolfile specification and parser for smolvm microVM workloads"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ keywords = ["smolvm", "microvm", "configuration"]
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 thiserror = "1"
-smolvm-protocol = { path = "../smolvm-protocol", version = "1.6.1" }
+smolvm-protocol = { path = "../smolvm-protocol", version = "1.6.2" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/lib/linux-aarch64/libkrun.so
+++ b/lib/linux-aarch64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:469d3b83a9844d12fe33eb5999401e7e7e1e4693a42c5ec7a178af7a647fcdb0
-size 6983640
+oid sha256:2a60967b99d5cc8c8fcfabbccfd8e319a966169966ce02ffbc34c880a952b82b
+size 6731696

--- a/lib/linux-aarch64/libkrun.so.2.0.0
+++ b/lib/linux-aarch64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:469d3b83a9844d12fe33eb5999401e7e7e1e4693a42c5ec7a178af7a647fcdb0
-size 6983640
+oid sha256:2a60967b99d5cc8c8fcfabbccfd8e319a966169966ce02ffbc34c880a952b82b
+size 6731696

--- a/lib/linux-x86_64/libkrun.so
+++ b/lib/linux-x86_64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:786c9617cc28275db5ce95c19a1746d115de41dfc73e4ef9d06da3c015ec34f2
-size 7959224
+oid sha256:da60bd23ffb84d86969e78a9a781c0885b944495f18505a07ed9c20412cb8432
+size 7855688

--- a/lib/linux-x86_64/libkrun.so.2.0.0
+++ b/lib/linux-x86_64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:786c9617cc28275db5ce95c19a1746d115de41dfc73e4ef9d06da3c015ec34f2
-size 7959224
+oid sha256:da60bd23ffb84d86969e78a9a781c0885b944495f18505a07ed9c20412cb8432
+size 7855688

--- a/nix/smolvm.nix
+++ b/nix/smolvm.nix
@@ -17,7 +17,7 @@
   gnutar,
   coreutils,
 }: let
-  version = "1.6.1";
+  version = "1.6.2";
 
   releases = {
     x86_64-linux = {

--- a/nix/smolvm.nix
+++ b/nix/smolvm.nix
@@ -17,7 +17,7 @@
   gnutar,
   coreutils,
 }: let
-  version = "1.6.0";
+  version = "1.6.1";
 
   releases = {
     x86_64-linux = {

--- a/scripts/check-libkrun-glibc-floor.sh
+++ b/scripts/check-libkrun-glibc-floor.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Assert the bundled linux libkrun.so libraries keep a glibc symbol floor <= 2.35
+# — the release runtime floor (the dist binaries build on ubuntu-22.04). A libkrun
+# built on a newer distro (e.g. Ubuntu 24.04 / glibc 2.39) loads fine there but
+# fails on 22.04 / Debian 12 hosts with "GLIBC_2.39 not found" before the VM can
+# boot (issue #636). objdump -T reads the ELF version-needed records; the check is
+# arch-independent (an x86_64 objdump reads the arm64 .so fine).
+#
+# If this fails, rebuild the libs on ubuntu-22.04 via the build-libkrun workflow
+# and commit the refreshed lib/linux-<arch>/libkrun.so.
+set -euo pipefail
+
+FLOOR="2.35"
+status=0
+
+for so in lib/linux-x86_64/libkrun.so lib/linux-arm64/libkrun.so; do
+  if [ ! -f "$so" ]; then
+    echo "::error::$so is missing (LFS not pulled?)"
+    status=1
+    continue
+  fi
+  maxv=$(objdump -T "$so" | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sed 's/GLIBC_//' | sort -V | tail -1)
+  echo "max GLIBC required by $so: ${maxv:-none}"
+  if [ -n "$maxv" ] && [ "$(printf '%s\n%s\n' "$maxv" "$FLOOR" | sort -V | tail -1)" != "$FLOOR" ]; then
+    echo "::error::$so requires glibc $maxv (> $FLOOR) — rebuild on ubuntu-22.04 via build-libkrun.yml"
+    status=1
+  fi
+done
+
+if [ "$status" = 0 ]; then
+  echo "OK: all bundled linux libkrun.so glibc floors are <= $FLOOR"
+fi
+exit "$status"


### PR DESCRIPTION
The v1.6.0/v1.6.1 linux libkrun.so was built on a glibc 2.39 host, so machine run failed on Ubuntu 22.04 / Debian 12 (glibc 2.35); this ships a libkrun rebuilt on ubuntu-22.04 (floor 2.34, both arches) and adds a CI gate that fails if the bundled libkrun floor exceeds 2.35. Opened to run full CI before tagging v1.6.2.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/642">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->