### PR TITLE
Group container tasks under the sandbox shim (fixes containers on containerd 2.2+)

### DIFF
--- a/crates/smolvm-shim/src/bundle.rs
+++ b/crates/smolvm-shim/src/bundle.rs
@@ -14,6 +14,9 @@ use serde::Deserialize;
 const ANN_CONTAINER_TYPE: &str = "io.kubernetes.cri.container-type";
 /// CRI annotation on sandboxes: host path of the pod's network namespace.
 const ANN_SANDBOX_NETNS: &str = "io.kubernetes.cri.sandbox-network-ns";
+/// CRI annotation on workload containers: the id of the pod sandbox they belong
+/// to. Used to group a container's shim under its sandbox's shim.
+const ANN_SANDBOX_ID: &str = "io.kubernetes.cri.sandbox-id";
 
 #[derive(Debug, Default)]
 pub struct BundleInfo {
@@ -74,6 +77,25 @@ pub fn load(bundle: &str) -> Result<BundleInfo, String> {
         });
 
     Ok(BundleInfo { is_sandbox, netns })
+}
+
+/// If this bundle is a workload container (not the pod sandbox), return its
+/// sandbox id from the CRI `io.kubernetes.cri.sandbox-id` annotation. The shim's
+/// `start` action uses it as the grouping so the container's shim is the one
+/// that already owns the pod VM. Returns `None` for the sandbox itself, a bare
+/// `ctr run`, or an unreadable bundle (caller falls back to the task id).
+pub fn sandbox_grouping(bundle: &str) -> Option<String> {
+    let cfg = Path::new(bundle).join("config.json");
+    let spec: MinimalSpec = serde_json::from_str(&std::fs::read_to_string(cfg).ok()?).ok()?;
+    let is_sandbox = spec
+        .annotations
+        .get(ANN_CONTAINER_TYPE)
+        .map(|v| v == "sandbox")
+        .unwrap_or(true);
+    if is_sandbox {
+        return None;
+    }
+    spec.annotations.get(ANN_SANDBOX_ID).cloned()
 }
 
 /// Mount containerd's rootfs mounts at `<bundle>/rootfs`, returning that path.

--- a/crates/smolvm-shim/src/service.rs
+++ b/crates/smolvm-shim/src/service.rs
@@ -41,7 +41,13 @@ impl Shim for Service {
     }
 
     async fn start_shim(&mut self, opts: StartOpts) -> Result<String, Error> {
-        let grouping = opts.id.clone();
+        // Group a container task under its sandbox's shim (via the CRI
+        // `io.kubernetes.cri.sandbox-id` annotation) so the container reaches the
+        // shim process that owns the pod VM. Without this, containerd 2.2+ starts
+        // a fresh shim per container — which has no sandbox in its state, so the
+        // container task fails with "no sandbox created for this pod". The shim's
+        // `start` action runs with the bundle directory as its CWD.
+        let grouping = crate::bundle::sandbox_grouping(".").unwrap_or_else(|| opts.id.clone());
         let address = spawn(opts, &grouping, Vec::new()).await?;
         Ok(address)
     }


### PR DESCRIPTION
On containerd 2.2+ (e.g. k3s v1.33's containerd 2.2.5), a pod's container failed to start with "no sandbox created for this pod" (StartError, exitCode 128) even though the sandbox VM booted and was Ready — because the shim used the container's own task id as the shim grouping, so containerd started a fresh shim per container that had no sandbox in its state.

Fix: the shim's start action now reads the CRI io.kubernetes.cri.sandbox-id annotation and, for a workload container, groups it under its sandbox's shim (the process that owns the pod VM), matching how sandbox shims are expected to group tasks.

Validated end-to-end: built natively, deployed, and a pod on the smolvm RuntimeClass now boots as a microVM and runs to Running/Ready on k3s v1.33.13 / containerd 2.2.5 — logs show the VM kernel (Linux 6.12.95), kubectl exec works, and a live smolvm-vmm microVM backs the pod.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/643">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->