### PR TITLE
Rebuild the linux libkrun.so with a glibc 2.35 floor and gate it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,11 @@ jobs:
           sudo apt-get install -y binutils binutils-mingw-w64-x86-64 llvm
       - name: Bundled libkrun exports every symbol smolvm requires
         run: ./scripts/check-krun-exports.sh
+      # A libkrun built on a newer distro (glibc > 2.35) loads there but fails on
+      # ubuntu-22.04 / Debian 12 with "GLIBC_x.y not found" before the VM boots
+      # (issue #636). Gate every push so a wrong-host lib can't ship again.
+      - name: Bundled libkrun keeps a glibc floor <= 2.35
+        run: ./scripts/check-libkrun-glibc-floor.sh
 
   audit:
     name: Cargo Audit

--- a/lib/linux-aarch64/libkrun.so
+++ b/lib/linux-aarch64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:469d3b83a9844d12fe33eb5999401e7e7e1e4693a42c5ec7a178af7a647fcdb0
-size 6983640
+oid sha256:2a60967b99d5cc8c8fcfabbccfd8e319a966169966ce02ffbc34c880a952b82b
+size 6731696

--- a/lib/linux-aarch64/libkrun.so.2.0.0
+++ b/lib/linux-aarch64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:469d3b83a9844d12fe33eb5999401e7e7e1e4693a42c5ec7a178af7a647fcdb0
-size 6983640
+oid sha256:2a60967b99d5cc8c8fcfabbccfd8e319a966169966ce02ffbc34c880a952b82b
+size 6731696

--- a/lib/linux-x86_64/libkrun.so
+++ b/lib/linux-x86_64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:786c9617cc28275db5ce95c19a1746d115de41dfc73e4ef9d06da3c015ec34f2
-size 7959224
+oid sha256:da60bd23ffb84d86969e78a9a781c0885b944495f18505a07ed9c20412cb8432
+size 7855688

--- a/lib/linux-x86_64/libkrun.so.2.0.0
+++ b/lib/linux-x86_64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:786c9617cc28275db5ce95c19a1746d115de41dfc73e4ef9d06da3c015ec34f2
-size 7959224
+oid sha256:da60bd23ffb84d86969e78a9a781c0885b944495f18505a07ed9c20412cb8432
+size 7855688

--- a/scripts/check-libkrun-glibc-floor.sh
+++ b/scripts/check-libkrun-glibc-floor.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Assert the bundled linux libkrun.so libraries keep a glibc symbol floor <= 2.35
+# — the release runtime floor (the dist binaries build on ubuntu-22.04). A libkrun
+# built on a newer distro (e.g. Ubuntu 24.04 / glibc 2.39) loads fine there but
+# fails on 22.04 / Debian 12 hosts with "GLIBC_2.39 not found" before the VM can
+# boot (issue #636). objdump -T reads the ELF version-needed records; the check is
+# arch-independent (an x86_64 objdump reads the arm64 .so fine).
+#
+# If this fails, rebuild the libs on ubuntu-22.04 via the build-libkrun workflow
+# and commit the refreshed lib/linux-<arch>/libkrun.so.
+set -euo pipefail
+
+FLOOR="2.35"
+status=0
+
+for so in lib/linux-x86_64/libkrun.so lib/linux-arm64/libkrun.so; do
+  if [ ! -f "$so" ]; then
+    echo "::error::$so is missing (LFS not pulled?)"
+    status=1
+    continue
+  fi
+  maxv=$(objdump -T "$so" | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sed 's/GLIBC_//' | sort -V | tail -1)
+  echo "max GLIBC required by $so: ${maxv:-none}"
+  if [ -n "$maxv" ] && [ "$(printf '%s\n%s\n' "$maxv" "$FLOOR" | sort -V | tail -1)" != "$FLOOR" ]; then
+    echo "::error::$so requires glibc $maxv (> $FLOOR) — rebuild on ubuntu-22.04 via build-libkrun.yml"
+    status=1
+  fi
+done
+
+if [ "$status" = 0 ]; then
+  echo "OK: all bundled linux libkrun.so glibc floors are <= $FLOOR"
+fi
+exit "$status"

--- a/scripts/check-libkrun-glibc-floor.sh
+++ b/scripts/check-libkrun-glibc-floor.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 FLOOR="2.35"
 status=0
 
-for so in lib/linux-x86_64/libkrun.so lib/linux-arm64/libkrun.so; do
+for so in lib/linux-x86_64/libkrun.so lib/linux-aarch64/libkrun.so; do
   if [ ! -f "$so" ]; then
     echo "::error::$so is missing (LFS not pulled?)"
     status=1


### PR DESCRIPTION
The bundled linux libkrun.so was built on a glibc 2.39 host, so machine run failed on Ubuntu 22.04 / Debian 12 (glibc 2.35) before the VM booted; this ships a libkrun rebuilt on ubuntu-22.04 (floor 2.34, both arches) and adds a CI check that fails when the bundled libkrun floor exceeds 2.35.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/644">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->