### PR TITLE
CUDA Path 3: opt-in weight-sharing density for fork clones

### DIFF
--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -568,18 +568,47 @@ type VmmRanges = std::sync::Mutex<HashMap<u64, u64>>;
 /// worker process reconstructs memory at the golden's EXACT VAs (M2). Reservations
 /// (va→size) it re-reserves; maps (va→(size, physical handle)) whose handle the
 /// daemon exports to an fd for the clone to IPC-import/copy at that VA.
+/// Per-chunk H2D upload record for the share-safety verdict (see
+/// `GoldenLayout::maps`). `segs` = sorted, disjoint, chunk-relative
+/// `(start, end, crc)` of every uploaded range (`crc == 0` marks a segment
+/// whose bytes weren't dispatch-visible — shm/GPA H2D — and therefore can
+/// never be verified). `verified` caches the fork-time content check.
+#[derive(Default, Clone)]
+struct ChunkCover {
+    size: u64,
+    handle: u64,
+    segs: Vec<(u64, u64, u64)>,
+    verified: Option<bool>,
+}
+
+impl ChunkCover {
+    /// Upload segments tile the chunk exactly and every segment is verifiable.
+    fn covered_exactly(&self) -> bool {
+        let mut expect = 0;
+        for &(s, e, crc) in &self.segs {
+            if s != expect || crc == 0 {
+                return false;
+            }
+            expect = e;
+        }
+        expect == self.size
+    }
+}
+
 #[derive(Default)]
 struct GoldenLayout {
     reservations: HashMap<u64, u64>,
-    /// va → (size, physical handle, h2d_covered_bytes). `h2d_covered_bytes` = how
-    /// many bytes of this VMM chunk received a host→device copy (weights streamed
-    /// in at load). A chunk is shareable ONLY if FULLY covered (covered == size):
-    /// under `expandable_segments` torch packs post-fork activations into the FREE
-    /// space of partially-filled weight chunks, so sharing a partial chunk lets an
-    /// activation write corrupt the shared physical (proven: RMS-LayerNorm writes
-    /// Y/r into a loaded chunk). A fully-covered chunk has no free space → the
-    /// allocator can't place activations there → safe to share.
-    maps: HashMap<u64, (u64, u64, u64)>,
+    /// va → per-chunk H2D coverage + share verdict. A chunk is a share
+    /// CANDIDATE only if its recorded upload segments tile it exactly; it is
+    /// share-SAFE only once the daemon verifies (at fork time) that its device
+    /// content still equals what the H2Ds uploaded, byte for byte. Coverage
+    /// alone is NOT enough: under `expandable_segments` torch frees weight
+    /// bytes and reuses them for MUTABLE tensors (proven: LoRA adapters inside
+    /// fully H2D-covered chunks — the bitsandbytes optimizer then writes the
+    /// shared physical and the update leaks into every later fork; also RMS
+    /// LayerNorm activations packed into partial chunks). A kernel write
+    /// changes content → CRC mismatch → the chunk degrades to private.
+    maps: HashMap<u64, ChunkCover>,
     /// M3a: golden module handle → module image bytes (to reload in the worker).
     modules: HashMap<u64, Vec<u8>>,
     /// M3a: golden function handle → (module handle, name) — the worker re-resolves
@@ -667,24 +696,57 @@ fn layout_handoff_register(l: &std::sync::Arc<LayoutCell>, my_token: u64) {
     reg.insert(my_token, std::sync::Arc::downgrade(l));
 }
 
-/// `(reservations: [(va,size)], maps: [(va,size,handle,loaded)])` for `token`'s
-/// golden. `loaded` marks a weight range a clone worker can share read-only.
+/// One VMM chunk in the fork handoff (see [`layout_handoff_snapshot`]).
+pub struct HandoffChunk {
+    pub va: u64,
+    pub size: u64,
+    pub handle: u64,
+    /// Upload segments tile the chunk exactly (share CANDIDATE — safe to share
+    /// only after fork-time content verification against `segs`).
+    pub candidate: bool,
+    /// Chunk-relative `(start, end, crc)` upload segments (crc from [`fnv64`]).
+    pub segs: Vec<(u64, u64, u64)>,
+    /// Cached fork-time content-verification verdict (golden frozen → stable).
+    pub verified: Option<bool>,
+}
+
+/// `(reservations: [(va,size)], chunks)` for `token`'s golden.
 #[allow(clippy::type_complexity)]
-pub fn layout_handoff_snapshot(
-    token: u64,
-) -> Option<(Vec<(u64, u64)>, Vec<(u64, u64, u64, bool)>)> {
+pub fn layout_handoff_snapshot(token: u64) -> Option<(Vec<(u64, u64)>, Vec<HandoffChunk>)> {
     let reg = LAYOUT_HANDOFF.lock().unwrap();
     let l = reg.as_ref()?.get(&token)?.upgrade()?;
     let g = l.lock().unwrap();
     let resvs = g.reservations.iter().map(|(&v, &s)| (v, s)).collect();
-    // A chunk is shareable only if FULLY covered by H2D weight bytes (no free
-    // space for the clone's post-fork activation writes).
     let maps = g
         .maps
         .iter()
-        .map(|(&v, &(s, h, covered))| (v, s, h, covered >= s))
+        .map(|(&va, c)| HandoffChunk {
+            va,
+            size: c.size,
+            handle: c.handle,
+            candidate: c.covered_exactly(),
+            segs: c.segs.clone(),
+            verified: c.verified,
+        })
         .collect();
     Some((resvs, maps))
+}
+
+/// Cache the fork-time content-verification verdict for `va` in `token`'s
+/// golden layout, so later forks of the (frozen) golden skip the D2H+CRC pass.
+pub fn layout_set_share_verdict(token: u64, va: u64, ok: bool) {
+    let reg = LAYOUT_HANDOFF.lock().unwrap();
+    let Some(l) = reg
+        .as_ref()
+        .and_then(|r| r.get(&token))
+        .and_then(|w| w.upgrade())
+    else {
+        return;
+    };
+    let mut g = l.lock().unwrap();
+    if let Some(c) = g.maps.get_mut(&va) {
+        c.verified = Some(ok);
+    }
 }
 
 /// M3a: golden handle-reconstruction snapshot for `token`'s golden —
@@ -845,20 +907,43 @@ fn xlat_event(h: u64) -> u64 {
     EVENT_TRANS.with(|m| m.borrow().get(&h).copied().unwrap_or(h))
 }
 
-/// Path 3: accumulate this H2D's byte coverage into every golden VMM chunk it
-/// overlaps. A chunk is shareable only once fully covered (see `GoldenLayout.maps`).
-/// No-op unless Path 3 is tracking a golden layout.
-fn mark_loaded_vmm(layout: &LayoutCell, dptr: u64, nbytes: u64) {
+/// Path 3: record this H2D's coverage (+ content CRC) into every golden VMM
+/// chunk it overlaps (see `GoldenLayout.maps`). No-op unless Path 3 is
+/// tracking a golden layout.
+fn mark_loaded_vmm(layout: &LayoutCell, dptr: u64, nbytes: u64, data: Option<&[u8]>) {
     let end = dptr.saturating_add(nbytes);
     let mut g = layout.lock().unwrap();
-    for (&base, v) in g.maps.iter_mut() {
-        let (size, covered) = (v.0, &mut v.2);
-        let (s, e) = (dptr.max(base), end.min(base + size));
-        if s < e {
-            // Cap at the chunk size so overlapping/re-issued H2Ds can't over-count.
-            *covered = (*covered + (e - s)).min(size);
+    for (&base, c) in g.maps.iter_mut() {
+        let (abs_s, abs_e) = (dptr.max(base), end.min(base + c.size));
+        if abs_s >= abs_e {
+            continue;
         }
+        // CRC the PER-CHUNK SLICE of the payload: one H2D spans many chunks,
+        // and each chunk must record the hash of its own bytes (crc 0 =
+        // unverifiable → never shared; used when bytes aren't dispatch-visible).
+        let crc = data.map_or(0, |d| {
+            fnv64(&d[(abs_s - dptr) as usize..(abs_e - dptr) as usize])
+        });
+        let (s, e) = (abs_s - base, abs_e - base);
+        // An overlapping re-upload invalidates the prior segment's CRC for its
+        // surviving bytes, so overlapped segments are dropped whole
+        // (conservative: lost coverage → the chunk stays private).
+        c.segs.retain(|&(a, b, _)| b <= s || a >= e);
+        c.segs.push((s, e, crc));
+        c.segs.sort_unstable();
+        c.verified = None;
     }
+}
+
+/// FNV-1a 64-bit content hash (0 remapped to 1 — segment CRC 0 means
+/// "unverifiable", reserved for uploads whose bytes dispatch can't see).
+pub fn fnv64(data: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in data {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h.max(1)
 }
 
 /// Mark the allocation containing `dptr` as loaded (H2D-written → read-only
@@ -1777,7 +1862,7 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         Request::MemcpyHtoD { dptr, stream, data } => {
             mark_loaded(&sess.alloc_table, dptr); // H2D write → weight/read-only
             if path3_enabled() {
-                mark_loaded_vmm(&sess.golden_layout, dptr, data.len() as u64);
+                mark_loaded_vmm(&sess.golden_layout, dptr, data.len() as u64, Some(&data));
             }
             b.memcpy_htod(dptr, &data, raw_stream(sess, stream)?)
                 .map(|_| Response::Ok)
@@ -2135,7 +2220,9 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         } => {
             mark_loaded(&sess.alloc_table, dptr);
             if path3_enabled() {
-                mark_loaded_vmm(&sess.golden_layout, dptr, size);
+                // Bytes not dispatch-visible on this path: coverage recorded but
+                // never verifiable, so the chunk can't be shared (crc = 0).
+                mark_loaded_vmm(&sess.golden_layout, dptr, size, None);
             }
             b.memcpy_shm_htod(dptr, offset, size, raw_stream(sess, stream)?)
                 .map(|_| Response::Ok)
@@ -2156,7 +2243,7 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             mark_loaded(&sess.alloc_table, dptr);
             if path3_enabled() {
                 let n: u64 = segments.iter().map(|&(_, len)| len).sum();
-                mark_loaded_vmm(&sess.golden_layout, dptr, n);
+                mark_loaded_vmm(&sess.golden_layout, dptr, n, None); // see ShmHtoD
             }
             b.memcpy_gpa_htod(dptr, &segments, raw_stream(sess, stream)?)
                 .map(|_| Response::Ok)
@@ -2218,11 +2305,14 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
                 // Path 3 (M2): record va→(size, physical handle) so the daemon can
                 // export this physical to an fd for a clone worker to import at `va`.
                 // coverage starts at 0 bytes; H2Ds accumulate it (see mark_loaded_vmm).
-                sess.golden_layout
-                    .lock()
-                    .unwrap()
-                    .maps
-                    .insert(va, (size, handle, 0));
+                sess.golden_layout.lock().unwrap().maps.insert(
+                    va,
+                    ChunkCover {
+                        size,
+                        handle,
+                        ..ChunkCover::default()
+                    },
+                );
                 Response::Ok
             })
         }

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -483,6 +483,14 @@ fn path3_enabled() -> bool {
     std::env::var_os("SMOLVM_CUDA_PATH3").is_some()
 }
 
+/// Path 3 density opt-in: a clone worker SHARES the golden's loaded (weight)
+/// VMM ranges read-only (IPC-import without copy) instead of privately copying
+/// them. Off by default (the proven path privately copies every range —
+/// correct + isolated but N copies of the weights).
+pub fn path3_share_weights_enabled() -> bool {
+    std::env::var_os("SMOLVM_CUDA_PATH3_SHARE_WEIGHTS").is_some()
+}
+
 /// P0 transport-viability instrumentation. Counts every dispatched CUDA RPC so we
 /// can derive calls-per-token (the number that decides whether CUDA-over-network
 /// survives WAN round-trips). `SMOLVM_CUDA_RPC_STATS=1` logs the running count with
@@ -563,7 +571,15 @@ type VmmRanges = std::sync::Mutex<HashMap<u64, u64>>;
 #[derive(Default)]
 struct GoldenLayout {
     reservations: HashMap<u64, u64>,
-    maps: HashMap<u64, (u64, u64)>,
+    /// va → (size, physical handle, h2d_covered_bytes). `h2d_covered_bytes` = how
+    /// many bytes of this VMM chunk received a host→device copy (weights streamed
+    /// in at load). A chunk is shareable ONLY if FULLY covered (covered == size):
+    /// under `expandable_segments` torch packs post-fork activations into the FREE
+    /// space of partially-filled weight chunks, so sharing a partial chunk lets an
+    /// activation write corrupt the shared physical (proven: RMS-LayerNorm writes
+    /// Y/r into a loaded chunk). A fully-covered chunk has no free space → the
+    /// allocator can't place activations there → safe to share.
+    maps: HashMap<u64, (u64, u64, u64)>,
     /// M3a: golden module handle → module image bytes (to reload in the worker).
     modules: HashMap<u64, Vec<u8>>,
     /// M3a: golden function handle → (module handle, name) — the worker re-resolves
@@ -651,14 +667,23 @@ fn layout_handoff_register(l: &std::sync::Arc<LayoutCell>, my_token: u64) {
     reg.insert(my_token, std::sync::Arc::downgrade(l));
 }
 
-/// `(reservations: [(va,size)], maps: [(va,size,handle)])` for `token`'s golden.
+/// `(reservations: [(va,size)], maps: [(va,size,handle,loaded)])` for `token`'s
+/// golden. `loaded` marks a weight range a clone worker can share read-only.
 #[allow(clippy::type_complexity)]
-pub fn layout_handoff_snapshot(token: u64) -> Option<(Vec<(u64, u64)>, Vec<(u64, u64, u64)>)> {
+pub fn layout_handoff_snapshot(
+    token: u64,
+) -> Option<(Vec<(u64, u64)>, Vec<(u64, u64, u64, bool)>)> {
     let reg = LAYOUT_HANDOFF.lock().unwrap();
     let l = reg.as_ref()?.get(&token)?.upgrade()?;
     let g = l.lock().unwrap();
     let resvs = g.reservations.iter().map(|(&v, &s)| (v, s)).collect();
-    let maps = g.maps.iter().map(|(&v, &(s, h))| (v, s, h)).collect();
+    // A chunk is shareable only if FULLY covered by H2D weight bytes (no free
+    // space for the clone's post-fork activation writes).
+    let maps = g
+        .maps
+        .iter()
+        .map(|(&v, &(s, h, covered))| (v, s, h, covered >= s))
+        .collect();
     Some((resvs, maps))
 }
 
@@ -818,6 +843,22 @@ fn xlat_stream(h: u64) -> u64 {
 }
 fn xlat_event(h: u64) -> u64 {
     EVENT_TRANS.with(|m| m.borrow().get(&h).copied().unwrap_or(h))
+}
+
+/// Path 3: accumulate this H2D's byte coverage into every golden VMM chunk it
+/// overlaps. A chunk is shareable only once fully covered (see `GoldenLayout.maps`).
+/// No-op unless Path 3 is tracking a golden layout.
+fn mark_loaded_vmm(layout: &LayoutCell, dptr: u64, nbytes: u64) {
+    let end = dptr.saturating_add(nbytes);
+    let mut g = layout.lock().unwrap();
+    for (&base, v) in g.maps.iter_mut() {
+        let (size, covered) = (v.0, &mut v.2);
+        let (s, e) = (dptr.max(base), end.min(base + size));
+        if s < e {
+            // Cap at the chunk size so overlapping/re-issued H2Ds can't over-count.
+            *covered = (*covered + (e - s)).min(size);
+        }
+    }
 }
 
 /// Mark the allocation containing `dptr` as loaded (H2D-written → read-only
@@ -1735,6 +1776,9 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         }
         Request::MemcpyHtoD { dptr, stream, data } => {
             mark_loaded(&sess.alloc_table, dptr); // H2D write → weight/read-only
+            if path3_enabled() {
+                mark_loaded_vmm(&sess.golden_layout, dptr, data.len() as u64);
+            }
             b.memcpy_htod(dptr, &data, raw_stream(sess, stream)?)
                 .map(|_| Response::Ok)
         }
@@ -2090,6 +2134,9 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             stream,
         } => {
             mark_loaded(&sess.alloc_table, dptr);
+            if path3_enabled() {
+                mark_loaded_vmm(&sess.golden_layout, dptr, size);
+            }
             b.memcpy_shm_htod(dptr, offset, size, raw_stream(sess, stream)?)
                 .map(|_| Response::Ok)
         }
@@ -2107,6 +2154,10 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             segments,
         } => {
             mark_loaded(&sess.alloc_table, dptr);
+            if path3_enabled() {
+                let n: u64 = segments.iter().map(|&(_, len)| len).sum();
+                mark_loaded_vmm(&sess.golden_layout, dptr, n);
+            }
             b.memcpy_gpa_htod(dptr, &segments, raw_stream(sess, stream)?)
                 .map(|_| Response::Ok)
         }
@@ -2166,11 +2217,12 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
                 sess.vmm_ranges.lock().unwrap().insert(va, size);
                 // Path 3 (M2): record va→(size, physical handle) so the daemon can
                 // export this physical to an fd for a clone worker to import at `va`.
+                // coverage starts at 0 bytes; H2Ds accumulate it (see mark_loaded_vmm).
                 sess.golden_layout
                     .lock()
                     .unwrap()
                     .maps
-                    .insert(va, (size, handle));
+                    .insert(va, (size, handle, 0));
                 Response::Ok
             })
         }

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -635,6 +635,24 @@ fn peek_clone_token(fd: std::os::unix::io::RawFd) -> Option<u64> {
     (token != 0).then_some(token)
 }
 
+/// Fork-time share-safety check: D2H the chunk and confirm every recorded
+/// upload segment still hashes to its H2D-time CRC. Any mismatch (or D2H
+/// failure) → not shareable.
+#[cfg(unix)]
+fn verify_chunk_content(b: &mut dyn Backend, ch: &smolvm_cuda::host::HandoffChunk) -> bool {
+    match b.memcpy_dtoh(ch.va, ch.size, 0) {
+        Ok(bytes) => ch.segs.iter().all(|&(s, e, crc)| {
+            crc != 0
+                && e as usize <= bytes.len()
+                && smolvm_cuda::host::fnv64(&bytes[s as usize..e as usize]) == crc
+        }),
+        Err(e) => {
+            tracing::warn!(e, va = ch.va, "M2-share: verify D2H failed → private");
+            false
+        }
+    }
+}
+
 /// Path 3 (M1): hand the accepted connection to a fresh worker PROCESS (its own
 /// CUDA context, hence its own UVA — so it can place memory at the golden's exact
 /// VAs). `dup2` the socket fd onto fd 3 in the child (clears CLOEXEC) and exec
@@ -668,12 +686,29 @@ fn spawn_clone_worker(conn_fd: std::os::unix::io::RawFd, token: u64) -> io::Resu
     }
     layout.push_str("|maps=");
     let mut export_fds: Vec<i32> = Vec::new();
-    for (va, size, handle, loaded) in &maps {
-        if let Ok(efd) = backend.mem_export_handle(*handle) {
+    for ch in &maps {
+        if let Ok(efd) = backend.mem_export_handle(ch.handle) {
             let idx = export_fds.len();
             export_fds.push(efd);
-            let ld = u8::from(*loaded);
-            layout.push_str(&format!("{va:x}:{size:x}:{idx}:{ld}:{handle:x},"));
+            // Share-safety: a candidate chunk is shared only if its device
+            // content still equals what the H2Ds uploaded (any kernel write —
+            // e.g. LoRA adapters placed in freed weight space — must keep the
+            // chunk private or clone writes leak through the shared physical).
+            // Verified once per frozen golden; verdict cached.
+            let safe = match (ch.candidate, ch.verified) {
+                (false, _) => false,
+                (true, Some(v)) => v,
+                (true, None) => {
+                    let v = verify_chunk_content(backend.as_mut(), ch);
+                    smolvm_cuda::host::layout_set_share_verdict(token, ch.va, v);
+                    v
+                }
+            };
+            let ld = u8::from(safe);
+            layout.push_str(&format!(
+                "{:x}:{:x}:{}:{}:{:x},",
+                ch.va, ch.size, idx, ld, ch.handle
+            ));
         }
     }
     // M3a: serialize the golden's modules (images) + functions to a temp file for

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -318,8 +318,32 @@ pub fn run_clone_worker(fd: std::os::unix::io::RawFd) -> io::Result<()> {
     }
 }
 
+/// IPC-import a golden physical from `fd`, retrying on transient failure with a
+/// ctx_synchronize between attempts. Defense-in-depth: the deterministic e=999
+/// import failure was the CLOEXEC fd handoff (fixed in spawn_clone_worker); this
+/// guards the remaining first-import-in-fresh-context warm-up window.
+#[cfg(unix)]
+fn import_with_retry(b: &mut dyn Backend, fd: i32) -> Result<u64, i32> {
+    let mut last = 0;
+    for attempt in 0..5 {
+        match b.mem_import_handle(fd) {
+            Ok(h) => {
+                if attempt > 0 {
+                    tracing::info!(fd, attempt, "M2: import succeeded on retry");
+                }
+                return Ok(h);
+            }
+            Err(e) => {
+                last = e;
+                let _ = b.ctx_synchronize();
+            }
+        }
+    }
+    Err(last)
+}
+
 /// M2: rebuild the golden's VMM layout in THIS worker's context at the golden's
-/// EXACT VAs. `layout` = `"resv=va:size,…|maps=va:size:fdidx:ghandle,…"` (hex);
+/// EXACT VAs. `layout` = `"resv=va:size,…|maps=va:size:fdidx:loaded:ghandle,…"` (hex);
 /// each map's physical was exported by the daemon to fd `4 + fdidx`. We import +
 /// map at the same VA — address-preserving, so inherited pointers and rebuilt
 /// graphs are valid verbatim. (Weights are shared here; private-mutable copy for
@@ -353,7 +377,8 @@ fn reconstruct_golden_memory(
             }
         }
     }
-    let mut count = 0;
+    let share_weights = smolvm_cuda::host::path3_share_weights_enabled();
+    let (mut count, mut shared) = (0, 0);
     for e in maps_s.split(',').filter(|s| !s.is_empty()) {
         let f: Vec<&str> = e.split(':').collect();
         if f.len() < 3 {
@@ -362,8 +387,51 @@ fn reconstruct_golden_memory(
         let (Some(va), Some(size), Ok(idx)) = (hx(f[0]), hx(f[1]), f[2].parse::<i32>()) else {
             continue;
         };
-        // 4th field: the golden's handle value for this chunk (hex).
-        let golden_h = f.get(3).and_then(|s| hx(s));
+        // 4th field (loaded) marks a fully-H2D-covered weight range; 5th is the
+        // golden's handle value for this chunk (hex).
+        let loaded = f.get(3).map(|s| *s == "1").unwrap_or(false);
+        let golden_h = f.get(4).and_then(|s| hx(s));
+
+        // DENSITY (opt-in, SMOLVM_CUDA_PATH3_SHARE_WEIGHTS): a loaded weight range is
+        // read-only during frozen-base fine-tuning (LoRA freezes the base; only the
+        // clone's PRIVATE adapters train), so SHARE the golden's physical at its VA —
+        // every clone imports the same physical, so one weight set lives in VRAM.
+        // Mapped READ-WRITE: unsloth's fix_untrained_tokens writes the embedding at
+        // trainer setup, and that write is identical across clones (same base → same
+        // fix), so sharing stays correct for this use case (verified by each clone
+        // still learning its distinct task). On ANY share failure, fall through to a
+        // private copy — never leave the VA unmapped (a hole faults the clone).
+        if share_weights && loaded {
+            let mut ok = false;
+            if let Ok(gh) = import_with_retry(b, 4 + idx) {
+                if b.mem_map(va, size, 0, gh).is_ok() {
+                    if b.mem_set_access(va, size, 0).is_ok() {
+                        ok = true;
+                    } else {
+                        let _ = b.mem_unmap(va, size); // roll back for the fallback
+                    }
+                }
+                match (ok, golden_h) {
+                    // Keep gh held and record golden→worker: the clone later
+                    // releases this chunk by the GOLDEN's handle value.
+                    (true, Some(g)) => {
+                        vmm_trans.insert(g, gh);
+                    }
+                    // Legacy layout (no handle field) or failure: the va mapping
+                    // holds its own ref, so drop ours.
+                    _ => {
+                        let _ = b.mem_release(gh);
+                    }
+                }
+            }
+            if ok {
+                shared += 1;
+                count += 1;
+                continue;
+            }
+            tracing::warn!(idx, "M2-share: share failed → private-copy fallback");
+            // fall through to the private path (va stays reserved + unmapped)
+        }
         // Private-mutable, address-preserving: map a PRIVATE physical at the golden
         // VA, then copy the golden's bytes in via a temp mapping of the imported
         // physical. Reads see the golden's data; writes hit the clone's own copy,
@@ -387,7 +455,7 @@ fn reconstruct_golden_memory(
         if let Err(e) = b.mem_set_access(va, size, 0) {
             tracing::warn!(e, va, "M2: private set_access failed");
         }
-        match b.mem_import_handle(4 + idx) {
+        match import_with_retry(b, 4 + idx) {
             Ok(gh) => {
                 if let Ok(tmp) = b.mem_address_reserve(size, 0) {
                     match b.mem_map(tmp, size, 0, gh) {
@@ -412,6 +480,9 @@ fn reconstruct_golden_memory(
             Err(e) => tracing::warn!(e, idx, "M2: import failed"),
         }
         count += 1;
+    }
+    if share_weights {
+        tracing::info!(shared, private = count - shared, "M2: shared weight ranges");
     }
     (count, vmm_trans)
 }
@@ -576,7 +647,8 @@ fn spawn_clone_worker(conn_fd: std::os::unix::io::RawFd, token: u64) -> io::Resu
         .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "no golden layout for token"))?;
     // Export each map's physical to a POSIX fd (in the golden's shared context) and
     // build the layout string the worker parses
-    // ("resv=va:size,…|maps=va:size:fdidx:ghandle,…"; ghandle = the golden's
+    // ("resv=va:size,…|maps=va:size:fdidx:loaded:ghandle,…"; loaded=1 → shareable
+    // weight; ghandle = the golden's
     // handle value, so the worker can translate the clone's inherited
     // MemRelease/MemMap handles to its own).
     let mut backend = make_backend();
@@ -596,11 +668,12 @@ fn spawn_clone_worker(conn_fd: std::os::unix::io::RawFd, token: u64) -> io::Resu
     }
     layout.push_str("|maps=");
     let mut export_fds: Vec<i32> = Vec::new();
-    for (va, size, handle) in &maps {
+    for (va, size, handle, loaded) in &maps {
         if let Ok(efd) = backend.mem_export_handle(*handle) {
             let idx = export_fds.len();
             export_fds.push(efd);
-            layout.push_str(&format!("{va:x}:{size:x}:{idx}:{handle:x},"));
+            let ld = u8::from(*loaded);
+            layout.push_str(&format!("{va:x}:{size:x}:{idx}:{ld}:{handle:x},"));
         }
     }
     // M3a: serialize the golden's modules (images) + functions to a temp file for


### PR DESCRIPTION
Share fully-H2D-covered VMM weight chunks across clone workers via SMOLVM_CUDA_PATH3_SHARE_WEIGHTS (validated: 2-clone 0.5B and 1.5B Unsloth fork-sweeps train correctly with ~16-27% VRAM saved).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/645">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->