### PR TITLE
Route smolmachine pack references through the host-side pack flow instead of the in-guest OCI puller

### DIFF
--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -1506,9 +1506,9 @@ fn pack_sidecar_sentinel(path: &Path) -> Option<&'static str> {
         .components()
         .filter(|c| !matches!(c, std::path::Component::CurDir));
     match (components.next(), components.next()) {
-        (Some(std::path::Component::Normal(name)), None) => SENTINELS
-            .into_iter()
-            .find(|s| name.to_str() == Some(s)),
+        (Some(std::path::Component::Normal(name)), None) => {
+            SENTINELS.into_iter().find(|s| name.to_str() == Some(s))
+        }
         _ => None,
     }
 }

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -1494,6 +1494,25 @@ fn decompress_layer_reader<'a>(
     }
 }
 
+/// The `.smolmachine` sidecar members that identify a smolmachine pack blob
+/// masquerading as an OCI layer: `agent-rootfs.tar` is the archive's first
+/// entry (so the guard fires before anything large is written) and
+/// `storage.ext4` is the multi-GiB disk template that would fill the guest
+/// disk. Only TOP-LEVEL entries match — a real container image nesting a
+/// same-named file (e.g. `/var/lib/foo/storage.ext4`) must not trip the guard.
+fn pack_sidecar_sentinel(path: &Path) -> Option<&'static str> {
+    const SENTINELS: [&str; 2] = ["agent-rootfs.tar", "storage.ext4"];
+    let mut components = path
+        .components()
+        .filter(|c| !matches!(c, std::path::Component::CurDir));
+    match (components.next(), components.next()) {
+        (Some(std::path::Component::Normal(name)), None) => SENTINELS
+            .into_iter()
+            .find(|s| name.to_str() == Some(s)),
+        _ => None,
+    }
+}
+
 fn extract_oci_layer<R: std::io::Read>(reader: R, dest: &Path) -> std::io::Result<()> {
     use std::os::unix::fs::PermissionsExt;
 
@@ -1514,6 +1533,22 @@ fn extract_oci_layer<R: std::io::Read>(reader: R, dest: &Path) -> std::io::Resul
     for entry in archive.entries()? {
         let mut entry = entry?;
         let path = entry.path()?.into_owned();
+
+        // A smolmachine PACK blob (mediaType application/vnd.smolmachines.*) is
+        // not an OCI filesystem layer: it is a .smolmachine sidecar carrying
+        // agent-rootfs.tar and a multi-GiB non-sparse storage.ext4 disk
+        // template. Unpacking it here fills the guest disk before failing, so
+        // detect its top-level sentinels and abort immediately with a routing
+        // hint instead.
+        if let Some(sentinel) = pack_sidecar_sentinel(&path) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "layer is a smolmachine pack (contains '{sentinel}') — pull it on the \
+                     host via the smolmachine flow, not as a container image"
+                ),
+            ));
+        }
 
         // Jail the on-disk path under the layer dir (defends against `..` and
         // absolute paths embedded in the archive).
@@ -3893,6 +3928,54 @@ mod tests {
         let zst = zstd::stream::encode_all(&tar_buf[..], 0).unwrap();
         assert_eq!(&zst[..4], &[0x28, 0xb5, 0x2f, 0xfd], "zstd magic");
         assert_eq!(extract(&zst), b"hello from a layer");
+    }
+
+    /// A smolmachine pack blob pulled as if it were a container image must
+    /// fail fast on its sentinel entries — before the pack's multi-GiB
+    /// storage.ext4 fills the guest disk — with a host-flow routing hint.
+    #[test]
+    fn extract_oci_layer_rejects_smolmachine_pack_blobs() {
+        // Owned by the current uid/gid so the nested-file case (which really
+        // extracts, preserving ownership) succeeds without root.
+        let uid = unsafe { libc::getuid() } as u64;
+        let gid = unsafe { libc::getgid() } as u64;
+        let build_tar = |name: &str| -> Vec<u8> {
+            let mut buf = Vec::new();
+            let mut builder = tar::Builder::new(&mut buf);
+            let body = b"not really a disk image";
+            let mut header = tar::Header::new_gnu();
+            header.set_path(name).unwrap();
+            header.set_size(body.len() as u64);
+            header.set_entry_type(tar::EntryType::Regular);
+            header.set_mode(0o644);
+            header.set_uid(uid);
+            header.set_gid(gid);
+            header.set_cksum();
+            builder.append(&header, &body[..]).unwrap();
+            builder.finish().unwrap();
+            drop(builder);
+            buf
+        };
+
+        for sentinel in ["storage.ext4", "agent-rootfs.tar", "./storage.ext4"] {
+            let dir = tempfile::tempdir().unwrap();
+            let err = extract_oci_layer(&build_tar(sentinel)[..], dir.path())
+                .expect_err("pack sentinel must abort extraction");
+            assert!(
+                err.to_string().contains("smolmachine pack"),
+                "clear error for {sentinel}, got: {err}"
+            );
+            assert!(
+                err.to_string().contains("host"),
+                "routing hint for {sentinel}, got: {err}"
+            );
+        }
+
+        // A NESTED file of the same name is legitimate image content.
+        let dir = tempfile::tempdir().unwrap();
+        extract_oci_layer(&build_tar("var/lib/foo/storage.ext4")[..], dir.path())
+            .expect("nested same-named file extracts normally");
+        assert!(dir.path().join("var/lib/foo/storage.ext4").exists());
     }
 
     #[cfg(target_os = "linux")]

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -346,6 +346,26 @@ pub async fn create_machine(
         req.registry_ref = None;
     }
 
+    // An `image` can also name a smolmachine pack artifact (e.g.
+    // registry.smolmachines.com/library/alpine), whose single "layer" is a
+    // full .smolmachine sidecar, not an OCI filesystem layer — the in-guest
+    // OCI puller would unpack its multi-GiB storage.ext4 into the guest disk.
+    // Probe the manifest on the host and reroute through the same from-sidecar
+    // flow as `registryRef`; a failed probe falls back to the in-guest pull.
+    if let Some(image) = req.image.clone() {
+        let sidecar = crate::data::pack_ref::resolve_pack_ref(
+            &image,
+            req.registry_identity_token.as_deref(),
+            &req.blob_peers,
+        )
+        .await
+        .map_err(|e| ApiError::internal(e.to_string()))?;
+        if let Some(sidecar) = sidecar {
+            req.from = Some(sidecar.to_string_lossy().into_owned());
+            req.image = None;
+        }
+    }
+
     // Generate name if not provided, then validate. The on-disk layout uses
     // a hash-derived directory (see `vm_data_dir`) so name length doesn't
     // affect the socket path — only character sanity + a generous length

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -882,6 +882,59 @@ impl RunCmd {
             params.secret_refs.insert(key, r);
         }
 
+        // A registry --image can name a smolmachine PACK artifact (e.g.
+        // registry.smolmachines.com/library/alpine), whose single "layer" is a
+        // full .smolmachine sidecar — not an OCI filesystem layer. The in-guest
+        // OCI puller would tar-unpack its multi-GiB storage.ext4 into the guest
+        // disk, so probe the manifest on the host and reroute through the
+        // proven pack-run path (same as `--from`); a failed probe falls back to
+        // the normal in-guest pull.
+        if let Some(img) = params.image.clone() {
+            if let Some(sidecar) = smolvm::data::pack_ref::resolve_pack_ref_blocking(&img)? {
+                if self.detach {
+                    // pack-run is ephemeral-only; a persistent machine from a
+                    // pack ref goes through create (which reroutes the same way).
+                    return Err(Error::config(
+                        "machine run",
+                        format!(
+                            "'{img}' is a smolmachine pack artifact and cannot run detached \
+                             via --image. Create a persistent machine instead:\n  \
+                             smolvm machine create --image {img} && smolvm machine start"
+                        ),
+                    ));
+                }
+                let command = if !self.command.is_empty() {
+                    self.command.clone()
+                } else {
+                    let mut c = params.entrypoint.clone();
+                    c.extend(params.cmd.clone());
+                    c
+                };
+                return crate::cli::pack_run::PackRunCmd {
+                    sidecar: Some(sidecar),
+                    command,
+                    interactive: self.interactive,
+                    tty: self.tty,
+                    timeout: self.timeout,
+                    workdir: params.workdir.clone(),
+                    env: params.env.clone(),
+                    volume: params.volume.clone(),
+                    port: params.port.clone(),
+                    net: params.net,
+                    net_backend: params.network_backend,
+                    cpus: (params.cpus != DEFAULT_MICROVM_CPU_COUNT).then_some(params.cpus),
+                    mem: (params.mem != DEFAULT_MICROVM_MEMORY_MIB).then_some(params.mem),
+                    storage: params.storage_gb,
+                    overlay: params.overlay_gb,
+                    force_extract: false,
+                    info: false,
+                    debug: false,
+                    cuda: false,
+                }
+                .run();
+            }
+        }
+
         // Init-layer cache (prototype): for an ephemeral run of an IMAGE with `init`
         // commands, bake `image + init` once into a cached `.smolmachine` and run from
         // that artifact, so init's cost (e.g. `apt install`) is paid once and reused
@@ -2217,6 +2270,19 @@ impl CreateCmd {
         // Branch for --from: create machine from .smolmachine artifact.
         if let Some(ref sidecar_path) = self.from {
             return self.run_from_smolmachine(sidecar_path);
+        }
+
+        // A registry --image can name a smolmachine PACK artifact (e.g.
+        // registry.smolmachines.com/library/alpine), whose single "layer" is a
+        // full .smolmachine sidecar — not an OCI filesystem layer the in-guest
+        // puller could unpack (its multi-GiB storage.ext4 would fill the guest
+        // disk). Probe the manifest on the host and, if so, pull the sidecar
+        // and continue exactly as `--from`; a failed probe falls back to the
+        // normal in-guest pull.
+        if let Some(img) = self.image.as_deref() {
+            if let Some(sidecar) = smolvm::data::pack_ref::resolve_pack_ref_blocking(img)? {
+                return self.run_from_smolmachine(&sidecar);
+            }
         }
 
         let (cli_allow_cidrs, net, cli_dns_filter_hosts) = resolve_egress_flags(

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -11,6 +11,8 @@ pub mod error;
 pub mod image_source;
 /// Canonical network-related data models.
 pub mod network;
+/// Detecting and host-pulling registry refs that name smolmachine packs.
+pub mod pack_ref;
 /// Canonical resource configuration data models.
 pub mod resources;
 /// Canonical storage and mount data models.

--- a/src/data/pack_ref.rs
+++ b/src/data/pack_ref.rs
@@ -73,7 +73,10 @@ fn explicit_registry_host(image: &str) -> Option<&str> {
 /// Docker Hub aliases — never serve packs, so skip the probe entirely rather
 /// than pay a cold manifest round-trip on every Hub pull.
 fn is_docker_hub(host: &str) -> bool {
-    matches!(host, "docker.io" | "index.docker.io" | "registry-1.docker.io")
+    matches!(
+        host,
+        "docker.io" | "index.docker.io" | "registry-1.docker.io"
+    )
 }
 
 /// Probe `image`'s manifest and, if it is a smolmachine pack artifact, pull

--- a/src/data/pack_ref.rs
+++ b/src/data/pack_ref.rs
@@ -1,0 +1,246 @@
+//! Routing registry references that name smolmachine PACK artifacts.
+//!
+//! A repository on the smolmachines registry (e.g. `library/alpine`, or a
+//! tenant export) is not an OCI container image: its single "layer" blob
+//! (mediaType `application/vnd.smolmachines.smolmachine.v1`) is a complete
+//! `.smolmachine` sidecar — `agent-rootfs.tar`, `layers/*.tar`, and a
+//! multi-GiB non-sparse `storage.ext4` disk template. Handing such a ref to
+//! the in-guest OCI puller tar-unpacks the sidecar generically, and the
+//! `storage.ext4` fills the guest disk before anything boots.
+//!
+//! This module probes a registry image reference's manifest on the HOST and,
+//! when the layers carry a smolmachines media type, downloads the sidecar
+//! blob so the caller can continue through the proven from-`.smolmachine`
+//! flow (`machine create --from` / the serve API `from` path) instead.
+//!
+//! The probe is deliberately fail-open: any parse/auth/network failure means
+//! "not a pack" and the caller proceeds with the normal in-guest pull, so the
+//! probe can never break docker.io/GHCR/other-registry images. Only a pull
+//! failure AFTER a positive probe is an error — falling back at that point
+//! would just reproduce the disk-fill.
+
+use crate::{Error, Result};
+use std::path::PathBuf;
+
+/// Media-type prefix that marks a manifest layer as a smolmachines artifact
+/// (`application/vnd.smolmachines.smolmachine.v1` today; treat the vendor
+/// prefix as the trigger so future versions route the same way).
+pub const PACK_MEDIA_TYPE_PREFIX: &str = "application/vnd.smolmachines.";
+
+/// Whether a (platform-resolved) OCI manifest describes a smolmachine pack:
+/// any layer whose mediaType carries the smolmachines vendor prefix.
+///
+/// Parses leniently (`serde_json::Value`) so Docker v2 / OCI manifests that
+/// don't match our strict `OciManifest` struct still classify as "not a pack"
+/// rather than erroring.
+pub fn manifest_has_pack_layer(manifest_bytes: &[u8]) -> bool {
+    let Ok(doc) = serde_json::from_slice::<serde_json::Value>(manifest_bytes) else {
+        return false;
+    };
+    doc.get("layers")
+        .and_then(|l| l.as_array())
+        .is_some_and(|layers| {
+            layers.iter().any(|layer| {
+                layer
+                    .get("mediaType")
+                    .and_then(|m| m.as_str())
+                    .is_some_and(|m| m.starts_with(PACK_MEDIA_TYPE_PREFIX))
+            })
+        })
+}
+
+/// The explicit registry host of an `--image` value, if it names one
+/// (`host.tld/...`, `host:port/...`, `localhost/...`).
+///
+/// Docker-convention bare names (`alpine`, `library/ubuntu:24.04`) return
+/// `None`: to the in-guest puller they mean Docker Hub, while
+/// [`crate::registry::Reference::parse`] defaults them to the smolmachines
+/// registry (pack-ref convention). Probing them would re-interpret
+/// `--image alpine` as `registry.smolmachines.com/library/alpine` — a pack —
+/// and silently hijack a Docker Hub pull, so only explicit hosts are probed.
+fn explicit_registry_host(image: &str) -> Option<&str> {
+    let (first, rest) = image.split_once('/')?;
+    if rest.is_empty() {
+        return None;
+    }
+    if first.contains('.') || first.contains(':') || first == "localhost" {
+        Some(first)
+    } else {
+        None
+    }
+}
+
+/// Docker Hub aliases — never serve packs, so skip the probe entirely rather
+/// than pay a cold manifest round-trip on every Hub pull.
+fn is_docker_hub(host: &str) -> bool {
+    matches!(host, "docker.io" | "index.docker.io" | "registry-1.docker.io")
+}
+
+/// Probe `image`'s manifest and, if it is a smolmachine pack artifact, pull
+/// the sidecar blob into the blob cache and return its path for the caller to
+/// route through the from-`.smolmachine` flow.
+///
+/// Returns `Ok(None)` when the ref is not a pack — including every probe
+/// failure (no explicit registry host, Docker Hub, unreadable settings,
+/// manifest fetch error) — so callers always have the in-guest pull to fall
+/// back on. A request-supplied `identity_token` (the control plane's
+/// short-lived pull token) takes precedence over persisted credentials,
+/// mirroring the serve `registryRef` path.
+pub async fn resolve_pack_ref(
+    image: &str,
+    identity_token: Option<&str>,
+    blob_peers: &[String],
+) -> Result<Option<PathBuf>> {
+    let Some(host) = explicit_registry_host(image) else {
+        return Ok(None);
+    };
+    if is_docker_hub(host) {
+        return Ok(None);
+    }
+    let Ok(parsed) = crate::registry::Reference::parse(image) else {
+        return Ok(None); // the in-guest puller surfaces its own parse error
+    };
+    let Ok(settings) = crate::settings::SmolSettings::load() else {
+        return Ok(None);
+    };
+
+    let effective_registry = settings
+        .machines
+        .get_mirror(&parsed.registry)
+        .unwrap_or(&parsed.registry);
+    if is_docker_hub(effective_registry) {
+        return Ok(None);
+    }
+
+    let base_url = if smolvm_registry::is_local_registry(effective_registry) {
+        format!("http://{}", effective_registry)
+    } else {
+        format!("https://{}", effective_registry)
+    };
+    let mut client = smolvm_registry::RegistryClient::new(base_url);
+    if let Some(token) = identity_token {
+        client = client.with_identity_token(token.to_string());
+    } else if let Some(entry) = settings.machines.registries.get(&parsed.registry) {
+        if let Some(ref token) = entry.identity_token {
+            client = client.with_identity_token(token.clone());
+        } else if let Some(auth) = settings.machines.get_credentials(&parsed.registry) {
+            if auth.username == "token" {
+                // Legacy direct-bearer convention: the password IS the bearer.
+                client = client.with_token(auth.password);
+            } else {
+                client = client.with_basic_credentials(auth.username, auth.password);
+            }
+        }
+    }
+
+    let repo = parsed.repository();
+    let reference = parsed
+        .digest
+        .as_deref()
+        .or(parsed.tag.as_deref())
+        .unwrap_or("latest");
+
+    let manifest_bytes = match client.get_manifest_resolved(&repo, reference).await {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            // Fail open: an unreachable/denying registry falls back to the
+            // in-guest pull, which reports its own (authoritative) error.
+            tracing::debug!(image = %image, error = %e, "pack probe failed; using in-guest pull");
+            return Ok(None);
+        }
+    };
+    if !manifest_has_pack_layer(&manifest_bytes) {
+        return Ok(None);
+    }
+
+    // Positive probe: this IS a pack, so the in-guest path is guaranteed to
+    // fail (disk-fill) — a pull error from here on is the real error.
+    tracing::info!(image = %image, "reference is a smolmachine pack; pulling sidecar on the host");
+    let cache = smolvm_registry::BlobCache::open_default()
+        .map_err(|e| Error::agent("open blob cache", e.to_string()))?;
+    let result = smolvm_registry::pull(&client, &repo, reference, None, &cache, blob_peers)
+        .await
+        .map_err(|e| Error::agent("pull smolmachine artifact", e.to_string()))?;
+    Ok(Some(result.path))
+}
+
+/// Blocking wrapper for the synchronous CLI paths (`machine run`/`create`).
+/// Skips spinning up a runtime for refs that can never probe (bare Docker
+/// Hub-style names).
+pub fn resolve_pack_ref_blocking(image: &str) -> Result<Option<PathBuf>> {
+    if explicit_registry_host(image).is_none() {
+        return Ok(None);
+    }
+    let rt = tokio::runtime::Runtime::new()
+        .map_err(|e| Error::agent("create tokio runtime", e.to_string()))?;
+    rt.block_on(resolve_pack_ref(image, None, &[]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pack_manifests_are_detected_by_layer_media_type() {
+        // The exact shape `smolvm pack push` produces.
+        let pack = serde_json::json!({
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "config": {
+                "mediaType": "application/vnd.smolmachines.machine.config.v1+json",
+                "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+                "size": 2
+            },
+            "layers": [{
+                "mediaType": "application/vnd.smolmachines.smolmachine.v1",
+                "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+                "size": 123
+            }]
+        });
+        assert!(manifest_has_pack_layer(&serde_json::to_vec(&pack).unwrap()));
+
+        // An ordinary container manifest (gzip layers) must not match.
+        let oci = serde_json::json!({
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "config": { "mediaType": "application/vnd.oci.image.config.v1+json", "digest": "sha256:aa", "size": 1 },
+            "layers": [
+                { "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip", "digest": "sha256:bb", "size": 1 },
+                { "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip", "digest": "sha256:cc", "size": 1 }
+            ]
+        });
+        assert!(!manifest_has_pack_layer(&serde_json::to_vec(&oci).unwrap()));
+
+        // Layerless docs (an image index) and garbage are "not a pack".
+        let index = serde_json::json!({ "schemaVersion": 2, "manifests": [] });
+        assert!(!manifest_has_pack_layer(
+            &serde_json::to_vec(&index).unwrap()
+        ));
+        assert!(!manifest_has_pack_layer(b"not json"));
+    }
+
+    #[test]
+    fn only_explicit_non_hub_hosts_are_probed() {
+        // Bare Docker-convention names mean Docker Hub to the in-guest puller —
+        // probing them against the smolmachines default would hijack the pull.
+        assert_eq!(explicit_registry_host("alpine"), None);
+        assert_eq!(explicit_registry_host("alpine:3.20"), None);
+        assert_eq!(explicit_registry_host("library/ubuntu:24.04"), None);
+
+        assert_eq!(
+            explicit_registry_host("registry.smolmachines.com/library/alpine:latest"),
+            Some("registry.smolmachines.com")
+        );
+        assert_eq!(
+            explicit_registry_host("localhost:5000/myimage:dev"),
+            Some("localhost:5000")
+        );
+        assert_eq!(explicit_registry_host("ghcr.io/o/r:v1"), Some("ghcr.io"));
+
+        // Explicit Docker Hub spellings short-circuit without a probe.
+        assert!(is_docker_hub("docker.io"));
+        assert!(is_docker_hub("index.docker.io"));
+        assert!(is_docker_hub("registry-1.docker.io"));
+        assert!(!is_docker_hub("registry.smolmachines.com"));
+    }
+}


### PR DESCRIPTION
Route image references whose manifest layers carry the smolmachine media type through the host-side pack flow (failing open to the in-guest pull on probe errors), and make the in-guest extractor fast-fail on pack sentinels instead of filling the guest disk.