### PR TITLE
CUDA Path 3 follow-ups: fork crash fixes, zero-config forkable machines, remote (TCP) clone workers

### DIFF
--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -777,7 +777,10 @@ fn xlat_mod(b: &mut dyn Backend, golden: u64) -> u64 {
         }
         Err(e) => {
             eprintln!("[M3a-lazy] module reload failed: e={e}");
-            golden
+            // NULL, not the golden handle: the driver rejects a NULL module with
+            // a clean error, but DEREFERENCES a foreign-context handle (SIGSEGV
+            // in cuModuleGetFunction — seen when a sticky fault poisoned reloads).
+            0
         }
     }
 }
@@ -792,6 +795,9 @@ fn xlat_func(b: &mut dyn Backend, golden: u64) -> u64 {
         return golden;
     };
     let wm = xlat_mod(b, gm);
+    if wm == 0 {
+        return 0; // module reload failed; a NULL function errors cleanly
+    }
     match b.module_get_function(wm, &name) {
         Ok(w) => {
             FUNC_TRANS.with(|m| {
@@ -801,7 +807,9 @@ fn xlat_func(b: &mut dyn Backend, golden: u64) -> u64 {
         }
         Err(e) => {
             eprintln!("[M3a-lazy] function re-resolve failed: name={name} e={e}");
-            golden
+            // NULL, not the golden handle (see xlat_mod): fail with a clean
+            // driver error rather than a foreign-handle dereference.
+            0
         }
     }
 }

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -568,18 +568,47 @@ type VmmRanges = std::sync::Mutex<HashMap<u64, u64>>;
 /// worker process reconstructs memory at the golden's EXACT VAs (M2). Reservations
 /// (va→size) it re-reserves; maps (va→(size, physical handle)) whose handle the
 /// daemon exports to an fd for the clone to IPC-import/copy at that VA.
+/// Per-chunk H2D upload record for the share-safety verdict (see
+/// `GoldenLayout::maps`). `segs` = sorted, disjoint, chunk-relative
+/// `(start, end, crc)` of every uploaded range (`crc == 0` marks a segment
+/// whose bytes weren't dispatch-visible — shm/GPA H2D — and therefore can
+/// never be verified). `verified` caches the fork-time content check.
+#[derive(Default, Clone)]
+struct ChunkCover {
+    size: u64,
+    handle: u64,
+    segs: Vec<(u64, u64, u64)>,
+    verified: Option<bool>,
+}
+
+impl ChunkCover {
+    /// Upload segments tile the chunk exactly and every segment is verifiable.
+    fn covered_exactly(&self) -> bool {
+        let mut expect = 0;
+        for &(s, e, crc) in &self.segs {
+            if s != expect || crc == 0 {
+                return false;
+            }
+            expect = e;
+        }
+        expect == self.size
+    }
+}
+
 #[derive(Default)]
 struct GoldenLayout {
     reservations: HashMap<u64, u64>,
-    /// va → (size, physical handle, h2d_covered_bytes). `h2d_covered_bytes` = how
-    /// many bytes of this VMM chunk received a host→device copy (weights streamed
-    /// in at load). A chunk is shareable ONLY if FULLY covered (covered == size):
-    /// under `expandable_segments` torch packs post-fork activations into the FREE
-    /// space of partially-filled weight chunks, so sharing a partial chunk lets an
-    /// activation write corrupt the shared physical (proven: RMS-LayerNorm writes
-    /// Y/r into a loaded chunk). A fully-covered chunk has no free space → the
-    /// allocator can't place activations there → safe to share.
-    maps: HashMap<u64, (u64, u64, u64)>,
+    /// va → per-chunk H2D coverage + share verdict. A chunk is a share
+    /// CANDIDATE only if its recorded upload segments tile it exactly; it is
+    /// share-SAFE only once the daemon verifies (at fork time) that its device
+    /// content still equals what the H2Ds uploaded, byte for byte. Coverage
+    /// alone is NOT enough: under `expandable_segments` torch frees weight
+    /// bytes and reuses them for MUTABLE tensors (proven: LoRA adapters inside
+    /// fully H2D-covered chunks — the bitsandbytes optimizer then writes the
+    /// shared physical and the update leaks into every later fork; also RMS
+    /// LayerNorm activations packed into partial chunks). A kernel write
+    /// changes content → CRC mismatch → the chunk degrades to private.
+    maps: HashMap<u64, ChunkCover>,
     /// M3a: golden module handle → module image bytes (to reload in the worker).
     modules: HashMap<u64, Vec<u8>>,
     /// M3a: golden function handle → (module handle, name) — the worker re-resolves
@@ -667,24 +696,57 @@ fn layout_handoff_register(l: &std::sync::Arc<LayoutCell>, my_token: u64) {
     reg.insert(my_token, std::sync::Arc::downgrade(l));
 }
 
-/// `(reservations: [(va,size)], maps: [(va,size,handle,loaded)])` for `token`'s
-/// golden. `loaded` marks a weight range a clone worker can share read-only.
+/// One VMM chunk in the fork handoff (see [`layout_handoff_snapshot`]).
+pub struct HandoffChunk {
+    pub va: u64,
+    pub size: u64,
+    pub handle: u64,
+    /// Upload segments tile the chunk exactly (share CANDIDATE — safe to share
+    /// only after fork-time content verification against `segs`).
+    pub candidate: bool,
+    /// Chunk-relative `(start, end, crc)` upload segments (crc from [`fnv64`]).
+    pub segs: Vec<(u64, u64, u64)>,
+    /// Cached fork-time content-verification verdict (golden frozen → stable).
+    pub verified: Option<bool>,
+}
+
+/// `(reservations: [(va,size)], chunks)` for `token`'s golden.
 #[allow(clippy::type_complexity)]
-pub fn layout_handoff_snapshot(
-    token: u64,
-) -> Option<(Vec<(u64, u64)>, Vec<(u64, u64, u64, bool)>)> {
+pub fn layout_handoff_snapshot(token: u64) -> Option<(Vec<(u64, u64)>, Vec<HandoffChunk>)> {
     let reg = LAYOUT_HANDOFF.lock().unwrap();
     let l = reg.as_ref()?.get(&token)?.upgrade()?;
     let g = l.lock().unwrap();
     let resvs = g.reservations.iter().map(|(&v, &s)| (v, s)).collect();
-    // A chunk is shareable only if FULLY covered by H2D weight bytes (no free
-    // space for the clone's post-fork activation writes).
     let maps = g
         .maps
         .iter()
-        .map(|(&v, &(s, h, covered))| (v, s, h, covered >= s))
+        .map(|(&va, c)| HandoffChunk {
+            va,
+            size: c.size,
+            handle: c.handle,
+            candidate: c.covered_exactly(),
+            segs: c.segs.clone(),
+            verified: c.verified,
+        })
         .collect();
     Some((resvs, maps))
+}
+
+/// Cache the fork-time content-verification verdict for `va` in `token`'s
+/// golden layout, so later forks of the (frozen) golden skip the D2H+CRC pass.
+pub fn layout_set_share_verdict(token: u64, va: u64, ok: bool) {
+    let reg = LAYOUT_HANDOFF.lock().unwrap();
+    let Some(l) = reg
+        .as_ref()
+        .and_then(|r| r.get(&token))
+        .and_then(|w| w.upgrade())
+    else {
+        return;
+    };
+    let mut g = l.lock().unwrap();
+    if let Some(c) = g.maps.get_mut(&va) {
+        c.verified = Some(ok);
+    }
 }
 
 /// M3a: golden handle-reconstruction snapshot for `token`'s golden —
@@ -845,20 +907,43 @@ fn xlat_event(h: u64) -> u64 {
     EVENT_TRANS.with(|m| m.borrow().get(&h).copied().unwrap_or(h))
 }
 
-/// Path 3: accumulate this H2D's byte coverage into every golden VMM chunk it
-/// overlaps. A chunk is shareable only once fully covered (see `GoldenLayout.maps`).
-/// No-op unless Path 3 is tracking a golden layout.
-fn mark_loaded_vmm(layout: &LayoutCell, dptr: u64, nbytes: u64) {
+/// Path 3: record this H2D's coverage (+ content CRC) into every golden VMM
+/// chunk it overlaps (see `GoldenLayout.maps`). No-op unless Path 3 is
+/// tracking a golden layout.
+fn mark_loaded_vmm(layout: &LayoutCell, dptr: u64, nbytes: u64, data: Option<&[u8]>) {
     let end = dptr.saturating_add(nbytes);
     let mut g = layout.lock().unwrap();
-    for (&base, v) in g.maps.iter_mut() {
-        let (size, covered) = (v.0, &mut v.2);
-        let (s, e) = (dptr.max(base), end.min(base + size));
-        if s < e {
-            // Cap at the chunk size so overlapping/re-issued H2Ds can't over-count.
-            *covered = (*covered + (e - s)).min(size);
+    for (&base, c) in g.maps.iter_mut() {
+        let (abs_s, abs_e) = (dptr.max(base), end.min(base + c.size));
+        if abs_s >= abs_e {
+            continue;
         }
+        // CRC the PER-CHUNK SLICE of the payload: one H2D spans many chunks,
+        // and each chunk must record the hash of its own bytes (crc 0 =
+        // unverifiable → never shared; used when bytes aren't dispatch-visible).
+        let crc = data.map_or(0, |d| {
+            fnv64(&d[(abs_s - dptr) as usize..(abs_e - dptr) as usize])
+        });
+        let (s, e) = (abs_s - base, abs_e - base);
+        // An overlapping re-upload invalidates the prior segment's CRC for its
+        // surviving bytes, so overlapped segments are dropped whole
+        // (conservative: lost coverage → the chunk stays private).
+        c.segs.retain(|&(a, b, _)| b <= s || a >= e);
+        c.segs.push((s, e, crc));
+        c.segs.sort_unstable();
+        c.verified = None;
     }
+}
+
+/// FNV-1a 64-bit content hash (0 remapped to 1 — segment CRC 0 means
+/// "unverifiable", reserved for uploads whose bytes dispatch can't see).
+pub fn fnv64(data: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in data {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h.max(1)
 }
 
 /// Mark the allocation containing `dptr` as loaded (H2D-written → read-only
@@ -1777,7 +1862,7 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         Request::MemcpyHtoD { dptr, stream, data } => {
             mark_loaded(&sess.alloc_table, dptr); // H2D write → weight/read-only
             if path3_enabled() {
-                mark_loaded_vmm(&sess.golden_layout, dptr, data.len() as u64);
+                mark_loaded_vmm(&sess.golden_layout, dptr, data.len() as u64, Some(&data));
             }
             b.memcpy_htod(dptr, &data, raw_stream(sess, stream)?)
                 .map(|_| Response::Ok)
@@ -2135,7 +2220,9 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         } => {
             mark_loaded(&sess.alloc_table, dptr);
             if path3_enabled() {
-                mark_loaded_vmm(&sess.golden_layout, dptr, size);
+                // Bytes not dispatch-visible on this path: coverage recorded but
+                // never verifiable, so the chunk can't be shared (crc = 0).
+                mark_loaded_vmm(&sess.golden_layout, dptr, size, None);
             }
             b.memcpy_shm_htod(dptr, offset, size, raw_stream(sess, stream)?)
                 .map(|_| Response::Ok)
@@ -2156,7 +2243,7 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             mark_loaded(&sess.alloc_table, dptr);
             if path3_enabled() {
                 let n: u64 = segments.iter().map(|&(_, len)| len).sum();
-                mark_loaded_vmm(&sess.golden_layout, dptr, n);
+                mark_loaded_vmm(&sess.golden_layout, dptr, n, None); // see ShmHtoD
             }
             b.memcpy_gpa_htod(dptr, &segments, raw_stream(sess, stream)?)
                 .map(|_| Response::Ok)
@@ -2218,11 +2305,14 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
                 // Path 3 (M2): record va→(size, physical handle) so the daemon can
                 // export this physical to an fd for a clone worker to import at `va`.
                 // coverage starts at 0 bytes; H2Ds accumulate it (see mark_loaded_vmm).
-                sess.golden_layout
-                    .lock()
-                    .unwrap()
-                    .maps
-                    .insert(va, (size, handle, 0));
+                sess.golden_layout.lock().unwrap().maps.insert(
+                    va,
+                    ChunkCover {
+                        size,
+                        handle,
+                        ..ChunkCover::default()
+                    },
+                );
                 Response::Ok
             })
         }

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -691,42 +691,107 @@ pub fn module_handoff_snapshot(
 }
 
 // M3a: per-worker (thread-local) translation of the golden's inherited raw
-// module/function handles → this worker's reloaded ones. Empty (identity) unless
-// a Path-3 clone worker installed it via `set_handle_trans`.
+// module/function handles → this worker's reloaded ones. LAZY: a real model has
+// ~400 modules; reloading them ALL synchronously before serving stalls the clone
+// worker ~2s, and the clone's connection breaks during that silent window. So we
+// hold the source images/metadata here and reload each module (and re-resolve
+// each function) on FIRST USE at the raw_module/raw_fn_h choke points. Empty
+// (identity) unless a Path-3 clone worker installed it via `set_handle_trans`.
 type HandleMap = std::cell::RefCell<HashMap<u64, u64>>;
+type ImageMap = std::cell::RefCell<HashMap<u64, Vec<u8>>>;
+type MetaMap = std::cell::RefCell<HashMap<u64, (u64, String)>>;
 thread_local! {
     static FUNC_TRANS: HandleMap = std::cell::RefCell::new(HashMap::new());
     static MOD_TRANS: HandleMap = std::cell::RefCell::new(HashMap::new());
     static STREAM_TRANS: HandleMap = std::cell::RefCell::new(HashMap::new());
     static EVENT_TRANS: HandleMap = std::cell::RefCell::new(HashMap::new());
+    // Lazy sources: golden module handle → image; golden fn handle → (module, name).
+    static MOD_IMAGES: ImageMap = std::cell::RefCell::new(HashMap::new());
+    static FUNC_META: MetaMap = std::cell::RefCell::new(HashMap::new());
 }
 
-/// Install a clone worker's golden→worker handle maps (functions, modules,
-/// streams, events); each applied at the matching dispatch choke point.
+/// Install a clone worker's golden→worker handle reconstruction. Modules are
+/// reloaded / functions re-resolved LAZILY from `mod_images` / `func_meta` at
+/// first use; streams/events are already-recreated golden→worker maps (eager,
+/// few). Clears any prior worker's caches.
 pub fn set_handle_trans(
-    funcs: Vec<(u64, u64)>,
-    mods: Vec<(u64, u64)>,
+    mod_images: Vec<(u64, Vec<u8>)>,
+    func_meta: Vec<(u64, u64, String)>,
     streams: Vec<(u64, u64)>,
     events: Vec<(u64, u64)>,
 ) {
-    fn put(cell: &'static std::thread::LocalKey<HandleMap>, v: Vec<(u64, u64)>) {
+    fn put_h(cell: &'static std::thread::LocalKey<HandleMap>, v: Vec<(u64, u64)>) {
         cell.with(|m| {
             let mut m = m.borrow_mut();
             m.clear();
             m.extend(v);
         });
     }
-    put(&FUNC_TRANS, funcs);
-    put(&MOD_TRANS, mods);
-    put(&STREAM_TRANS, streams);
-    put(&EVENT_TRANS, events);
+    MOD_TRANS.with(|m| m.borrow_mut().clear());
+    FUNC_TRANS.with(|m| m.borrow_mut().clear());
+    MOD_IMAGES.with(|m| {
+        let mut m = m.borrow_mut();
+        m.clear();
+        m.extend(mod_images);
+    });
+    FUNC_META.with(|m| {
+        let mut m = m.borrow_mut();
+        m.clear();
+        m.extend(func_meta.into_iter().map(|(f, gm, n)| (f, (gm, n))));
+    });
+    put_h(&STREAM_TRANS, streams);
+    put_h(&EVENT_TRANS, events);
 }
 
-fn xlat_func(h: u64) -> u64 {
-    FUNC_TRANS.with(|m| m.borrow().get(&h).copied().unwrap_or(h))
+/// Lazily reload the golden module `golden` in THIS worker's context (once),
+/// caching golden→worker. Identity for a non-clone / unknown handle.
+fn xlat_mod(b: &mut dyn Backend, golden: u64) -> u64 {
+    if let Some(w) = MOD_TRANS.with(|m| m.borrow().get(&golden).copied()) {
+        return w;
+    }
+    let Some(mut image) = MOD_IMAGES.with(|m| m.borrow().get(&golden).cloned()) else {
+        return golden;
+    };
+    // cuModuleLoadData treats a PTX image as a C string; ensure a trailing NUL.
+    if image.last() != Some(&0) {
+        image.push(0);
+    }
+    match b.module_load_data(&image) {
+        Ok(w) => {
+            MOD_TRANS.with(|m| {
+                m.borrow_mut().insert(golden, w);
+            });
+            w
+        }
+        Err(e) => {
+            eprintln!("[M3a-lazy] module reload failed: e={e}");
+            golden
+        }
+    }
 }
-fn xlat_mod(h: u64) -> u64 {
-    MOD_TRANS.with(|m| m.borrow().get(&h).copied().unwrap_or(h))
+
+/// Lazily re-resolve the golden function `golden` (loading its module first if
+/// needed), caching golden→worker. Identity for a non-clone / unknown handle.
+fn xlat_func(b: &mut dyn Backend, golden: u64) -> u64 {
+    if let Some(w) = FUNC_TRANS.with(|m| m.borrow().get(&golden).copied()) {
+        return w;
+    }
+    let Some((gm, name)) = FUNC_META.with(|m| m.borrow().get(&golden).cloned()) else {
+        return golden;
+    };
+    let wm = xlat_mod(b, gm);
+    match b.module_get_function(wm, &name) {
+        Ok(w) => {
+            FUNC_TRANS.with(|m| {
+                m.borrow_mut().insert(golden, w);
+            });
+            w
+        }
+        Err(e) => {
+            eprintln!("[M3a-lazy] function re-resolve failed: name={name} e={e}");
+            golden
+        }
+    }
 }
 fn xlat_stream(h: u64) -> u64 {
     STREAM_TRANS.with(|m| m.borrow().get(&h).copied().unwrap_or(h))
@@ -1376,13 +1441,13 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
     // connection stays valid on another (this is what lets a forked VM clone
     // reconnect and keep using its parent's loaded modules). The tables only
     // translate ids minted by pre-raw guests; a raw value passes through.
-    fn raw_module(sess: &Session, m: u64) -> u64 {
-        // Path 3 (M3a): a clone worker translates the golden's inherited raw module
-        // handle to its own reloaded module; identity otherwise.
-        xlat_mod(sess.modules.get(&m).copied().unwrap_or(m))
+    fn raw_module(sess: &Session, b: &mut dyn Backend, m: u64) -> u64 {
+        // Path 3 (M3a): a clone worker lazily reloads + translates the golden's
+        // inherited raw module handle to its own; identity otherwise.
+        xlat_mod(b, sess.modules.get(&m).copied().unwrap_or(m))
     }
-    fn raw_fn_h(sess: &Session, f: u64) -> u64 {
-        xlat_func(sess.functions.get(&f).copied().unwrap_or(f))
+    fn raw_fn_h(sess: &Session, b: &mut dyn Backend, f: u64) -> u64 {
+        xlat_func(b, sess.functions.get(&f).copied().unwrap_or(f))
     }
     fn raw_graph(sess: &Session, h: u64) -> u64 {
         // Virtual graph/exec handle → real; untagged values pass through.
@@ -1583,7 +1648,7 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             Ok(Response::Handle(raw))
         }
         Request::ModuleGetFunction { module, name } => {
-            let raw_mod = raw_module(sess, module);
+            let raw_mod = raw_module(sess, b, module);
             // Raw CUfunction on the wire: valid across connections in the shared
             // primary context, so a forked clone keeps its parent's functions.
             let raw_fn = b.module_get_function(raw_mod, &name)?;
@@ -1597,14 +1662,14 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             Ok(Response::Handle(raw_fn))
         }
         Request::ModuleUnload { module } => {
-            let raw_mod = raw_module(sess, module);
+            let raw_mod = raw_module(sess, b, module);
             b.module_unload(raw_mod)?;
             sess.owned_modules.remove(&raw_mod);
             sess.modules.remove(&module);
             Ok(Response::Ok)
         }
         Request::FuncGetParamInfo { function } => {
-            let raw_fn = raw_fn_h(sess, function);
+            let raw_fn = raw_fn_h(sess, b, function);
             let sizes = b.func_get_param_info(raw_fn)?;
             let mut out = Vec::with_capacity(sizes.len() * 4);
             for s in sizes {
@@ -1617,12 +1682,12 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             attrib,
             value,
         } => {
-            let raw_fn = raw_fn_h(sess, function);
+            let raw_fn = raw_fn_h(sess, b, function);
             b.func_set_attribute(raw_fn, attrib, value)
                 .map(|_| Response::Ok)
         }
         Request::FuncGetAttribute { function, attrib } => {
-            let raw_fn = raw_fn_h(sess, function);
+            let raw_fn = raw_fn_h(sess, b, function);
             b.func_get_attribute(raw_fn, attrib).map(Response::Count)
         }
         Request::MemAlloc { bytes } => {
@@ -1675,7 +1740,7 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             stream,
             params,
         } => {
-            let raw_fn = raw_fn_h(sess, function);
+            let raw_fn = raw_fn_h(sess, b, function);
             let raw_str = raw_stream(sess, stream)?;
             b.launch_kernel(raw_fn, grid, block, shared_bytes, raw_str, &params)
                 .map(|_| Response::Ok)

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -483,6 +483,14 @@ fn path3_enabled() -> bool {
     std::env::var_os("SMOLVM_CUDA_PATH3").is_some()
 }
 
+/// Path 3 density opt-in: a clone worker SHARES the golden's loaded (weight)
+/// VMM ranges read-only (IPC-import without copy) instead of privately copying
+/// them. Off by default (the proven path privately copies every range —
+/// correct + isolated but N copies of the weights).
+pub fn path3_share_weights_enabled() -> bool {
+    std::env::var_os("SMOLVM_CUDA_PATH3_SHARE_WEIGHTS").is_some()
+}
+
 /// P0 transport-viability instrumentation. Counts every dispatched CUDA RPC so we
 /// can derive calls-per-token (the number that decides whether CUDA-over-network
 /// survives WAN round-trips). `SMOLVM_CUDA_RPC_STATS=1` logs the running count with
@@ -563,7 +571,15 @@ type VmmRanges = std::sync::Mutex<HashMap<u64, u64>>;
 #[derive(Default)]
 struct GoldenLayout {
     reservations: HashMap<u64, u64>,
-    maps: HashMap<u64, (u64, u64)>,
+    /// va → (size, physical handle, h2d_covered_bytes). `h2d_covered_bytes` = how
+    /// many bytes of this VMM chunk received a host→device copy (weights streamed
+    /// in at load). A chunk is shareable ONLY if FULLY covered (covered == size):
+    /// under `expandable_segments` torch packs post-fork activations into the FREE
+    /// space of partially-filled weight chunks, so sharing a partial chunk lets an
+    /// activation write corrupt the shared physical (proven: RMS-LayerNorm writes
+    /// Y/r into a loaded chunk). A fully-covered chunk has no free space → the
+    /// allocator can't place activations there → safe to share.
+    maps: HashMap<u64, (u64, u64, u64)>,
     /// M3a: golden module handle → module image bytes (to reload in the worker).
     modules: HashMap<u64, Vec<u8>>,
     /// M3a: golden function handle → (module handle, name) — the worker re-resolves
@@ -651,14 +667,23 @@ fn layout_handoff_register(l: &std::sync::Arc<LayoutCell>, my_token: u64) {
     reg.insert(my_token, std::sync::Arc::downgrade(l));
 }
 
-/// `(reservations: [(va,size)], maps: [(va,size,handle)])` for `token`'s golden.
+/// `(reservations: [(va,size)], maps: [(va,size,handle,loaded)])` for `token`'s
+/// golden. `loaded` marks a weight range a clone worker can share read-only.
 #[allow(clippy::type_complexity)]
-pub fn layout_handoff_snapshot(token: u64) -> Option<(Vec<(u64, u64)>, Vec<(u64, u64, u64)>)> {
+pub fn layout_handoff_snapshot(
+    token: u64,
+) -> Option<(Vec<(u64, u64)>, Vec<(u64, u64, u64, bool)>)> {
     let reg = LAYOUT_HANDOFF.lock().unwrap();
     let l = reg.as_ref()?.get(&token)?.upgrade()?;
     let g = l.lock().unwrap();
     let resvs = g.reservations.iter().map(|(&v, &s)| (v, s)).collect();
-    let maps = g.maps.iter().map(|(&v, &(s, h))| (v, s, h)).collect();
+    // A chunk is shareable only if FULLY covered by H2D weight bytes (no free
+    // space for the clone's post-fork activation writes).
+    let maps = g
+        .maps
+        .iter()
+        .map(|(&v, &(s, h, covered))| (v, s, h, covered >= s))
+        .collect();
     Some((resvs, maps))
 }
 
@@ -818,6 +843,22 @@ fn xlat_stream(h: u64) -> u64 {
 }
 fn xlat_event(h: u64) -> u64 {
     EVENT_TRANS.with(|m| m.borrow().get(&h).copied().unwrap_or(h))
+}
+
+/// Path 3: accumulate this H2D's byte coverage into every golden VMM chunk it
+/// overlaps. A chunk is shareable only once fully covered (see `GoldenLayout.maps`).
+/// No-op unless Path 3 is tracking a golden layout.
+fn mark_loaded_vmm(layout: &LayoutCell, dptr: u64, nbytes: u64) {
+    let end = dptr.saturating_add(nbytes);
+    let mut g = layout.lock().unwrap();
+    for (&base, v) in g.maps.iter_mut() {
+        let (size, covered) = (v.0, &mut v.2);
+        let (s, e) = (dptr.max(base), end.min(base + size));
+        if s < e {
+            // Cap at the chunk size so overlapping/re-issued H2Ds can't over-count.
+            *covered = (*covered + (e - s)).min(size);
+        }
+    }
 }
 
 /// Mark the allocation containing `dptr` as loaded (H2D-written → read-only
@@ -1735,6 +1776,9 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         }
         Request::MemcpyHtoD { dptr, stream, data } => {
             mark_loaded(&sess.alloc_table, dptr); // H2D write → weight/read-only
+            if path3_enabled() {
+                mark_loaded_vmm(&sess.golden_layout, dptr, data.len() as u64);
+            }
             b.memcpy_htod(dptr, &data, raw_stream(sess, stream)?)
                 .map(|_| Response::Ok)
         }
@@ -2090,6 +2134,9 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             stream,
         } => {
             mark_loaded(&sess.alloc_table, dptr);
+            if path3_enabled() {
+                mark_loaded_vmm(&sess.golden_layout, dptr, size);
+            }
             b.memcpy_shm_htod(dptr, offset, size, raw_stream(sess, stream)?)
                 .map(|_| Response::Ok)
         }
@@ -2107,6 +2154,10 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             segments,
         } => {
             mark_loaded(&sess.alloc_table, dptr);
+            if path3_enabled() {
+                let n: u64 = segments.iter().map(|&(_, len)| len).sum();
+                mark_loaded_vmm(&sess.golden_layout, dptr, n);
+            }
             b.memcpy_gpa_htod(dptr, &segments, raw_stream(sess, stream)?)
                 .map(|_| Response::Ok)
         }
@@ -2166,11 +2217,12 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
                 sess.vmm_ranges.lock().unwrap().insert(va, size);
                 // Path 3 (M2): record va→(size, physical handle) so the daemon can
                 // export this physical to an fd for a clone worker to import at `va`.
+                // coverage starts at 0 bytes; H2Ds accumulate it (see mark_loaded_vmm).
                 sess.golden_layout
                     .lock()
                     .unwrap()
                     .maps
-                    .insert(va, (size, handle));
+                    .insert(va, (size, handle, 0));
                 Response::Ok
             })
         }

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -708,6 +708,18 @@ thread_local! {
     // Lazy sources: golden module handle → image; golden fn handle → (module, name).
     static MOD_IMAGES: ImageMap = std::cell::RefCell::new(HashMap::new());
     static FUNC_META: MetaMap = std::cell::RefCell::new(HashMap::new());
+    // M2: golden VMM physical handle → THIS worker's handle backing the same VA.
+    // `None` = not a clone worker (raw passthrough). The clone frees inherited
+    // chunks by their GOLDEN handle values; passing one raw into cuMemRelease in
+    // the worker's context SEGFAULTS the driver (SEGV_MAPERR inside cuMemRelease).
+    static VMM_TRANS: std::cell::RefCell<Option<HashMap<u64, u64>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// Install a clone worker's golden→worker VMM physical-handle map (M2). Until
+/// installed, MemMap/MemRelease pass handles through raw (daemon/golden path).
+pub fn set_vmm_trans(map: HashMap<u64, u64>) {
+    VMM_TRANS.with(|m| *m.borrow_mut() = Some(map));
 }
 
 /// Install a clone worker's golden→worker handle reconstruction. Modules are
@@ -2135,18 +2147,25 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             size,
             offset,
             handle,
-        } => b.mem_map(va, size, offset, handle).map(|_| {
-            sess.owned_vmm_maps.insert(va, size);
-            sess.vmm_ranges.lock().unwrap().insert(va, size);
-            // Path 3 (M2): record va→(size, physical handle) so the daemon can
-            // export this physical to an fd for a clone worker to import at `va`.
-            sess.golden_layout
-                .lock()
-                .unwrap()
-                .maps
-                .insert(va, (size, handle));
-            Response::Ok
-        }),
+        } => {
+            // Path 3 worker: an inherited golden handle must map via the worker's
+            // own physical (raw golden values are invalid in this context).
+            let handle = VMM_TRANS
+                .with(|m| m.borrow().as_ref().and_then(|t| t.get(&handle).copied()))
+                .unwrap_or(handle);
+            b.mem_map(va, size, offset, handle).map(|_| {
+                sess.owned_vmm_maps.insert(va, size);
+                sess.vmm_ranges.lock().unwrap().insert(va, size);
+                // Path 3 (M2): record va→(size, physical handle) so the daemon can
+                // export this physical to an fd for a clone worker to import at `va`.
+                sess.golden_layout
+                    .lock()
+                    .unwrap()
+                    .maps
+                    .insert(va, (size, handle));
+                Response::Ok
+            })
+        }
         Request::MemSetAccess { va, size, device } => {
             b.mem_set_access(va, size, device).map(|_| Response::Ok)
         }
@@ -2157,8 +2176,28 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             b.mem_unmap(va, size).map(|_| Response::Ok)
         }
         Request::MemRelease { handle } => {
-            sess.owned_vmm_handles.remove(&handle);
-            b.mem_release(handle).map(|_| Response::Ok)
+            let created_here = sess.owned_vmm_handles.remove(&handle).is_some();
+            // Path 3 worker: translate an inherited golden handle to the worker
+            // handle backing that chunk (consumed: releasing twice is a no-op).
+            // A handle neither translated nor created in this process is a stale
+            // golden value we can't resolve — dropped, NOT passed to the driver
+            // (cuMemRelease on a foreign-context handle segfaults, not errors).
+            let resolved = VMM_TRANS.with(|m| match m.borrow_mut().as_mut() {
+                Some(t) => match t.remove(&handle) {
+                    Some(w) => Some(Some(w)),
+                    None if created_here => Some(Some(handle)),
+                    None => Some(None),
+                },
+                None => None,
+            });
+            match resolved {
+                Some(Some(h)) => b.mem_release(h).map(|_| Response::Ok),
+                Some(None) => {
+                    eprintln!("[M2] MemRelease: unknown inherited handle {handle:#x} → no-op");
+                    Ok(Response::Ok)
+                }
+                None => b.mem_release(handle).map(|_| Response::Ok),
+            }
         }
         Request::MemAddressFree { va, size } => {
             sess.owned_vmm_reservations.remove(&va);

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -1675,6 +1675,20 @@ impl AgentManager {
             if !shared_set && (features.forkable || features.snapshot_dir.is_some()) {
                 v.push(("SMOLVM_CUDA_SHARED", "1".to_string()));
             }
+            // Auto-enable Path 3 isolating forks for a fork base / clone, same
+            // pattern as SHARED above: a CUDA golden's clones need the daemon in
+            // address-preserving per-clone-worker mode or default-config torch
+            // (expandable_segments) forks into a broken clone. Explicit operator
+            // settings win. The daemon reads these at ITS spawn (inherited from
+            // this VM's boot process via ensure_running), so a daemon already
+            // running in another mode keeps that mode until restarted.
+            for flag in ["SMOLVM_CUDA_PATH3", "SMOLVM_CUDA_FORK_ISOLATE"] {
+                if std::env::var_os(flag).is_none()
+                    && (features.forkable || features.snapshot_dir.is_some())
+                {
+                    v.push((flag, "1".to_string()));
+                }
+            }
             v
         };
         self.inner.lock().is_clone = features.snapshot_dir.is_some();

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -635,6 +635,24 @@ fn peek_clone_token(fd: std::os::unix::io::RawFd) -> Option<u64> {
     (token != 0).then_some(token)
 }
 
+/// Fork-time share-safety check: D2H the chunk and confirm every recorded
+/// upload segment still hashes to its H2D-time CRC. Any mismatch (or D2H
+/// failure) → not shareable.
+#[cfg(unix)]
+fn verify_chunk_content(b: &mut dyn Backend, ch: &smolvm_cuda::host::HandoffChunk) -> bool {
+    match b.memcpy_dtoh(ch.va, ch.size, 0) {
+        Ok(bytes) => ch.segs.iter().all(|&(s, e, crc)| {
+            crc != 0
+                && e as usize <= bytes.len()
+                && smolvm_cuda::host::fnv64(&bytes[s as usize..e as usize]) == crc
+        }),
+        Err(e) => {
+            tracing::warn!(e, va = ch.va, "M2-share: verify D2H failed → private");
+            false
+        }
+    }
+}
+
 /// Path 3 (M1): hand the accepted connection to a fresh worker PROCESS (its own
 /// CUDA context, hence its own UVA — so it can place memory at the golden's exact
 /// VAs). `dup2` the socket fd onto fd 3 in the child (clears CLOEXEC) and exec
@@ -668,12 +686,29 @@ fn spawn_clone_worker(conn_fd: std::os::unix::io::RawFd, token: u64) -> io::Resu
     }
     layout.push_str("|maps=");
     let mut export_fds: Vec<i32> = Vec::new();
-    for (va, size, handle, loaded) in &maps {
-        if let Ok(efd) = backend.mem_export_handle(*handle) {
+    for ch in &maps {
+        if let Ok(efd) = backend.mem_export_handle(ch.handle) {
             let idx = export_fds.len();
             export_fds.push(efd);
-            let ld = u8::from(*loaded);
-            layout.push_str(&format!("{va:x}:{size:x}:{idx}:{ld}:{handle:x},"));
+            // Share-safety: a candidate chunk is shared only if its device
+            // content still equals what the H2Ds uploaded (any kernel write —
+            // e.g. LoRA adapters placed in freed weight space — must keep the
+            // chunk private or clone writes leak through the shared physical).
+            // Verified once per frozen golden; verdict cached.
+            let safe = match (ch.candidate, ch.verified) {
+                (false, _) => false,
+                (true, Some(v)) => v,
+                (true, None) => {
+                    let v = verify_chunk_content(backend.as_mut(), ch);
+                    smolvm_cuda::host::layout_set_share_verdict(token, ch.va, v);
+                    v
+                }
+            };
+            let ld = u8::from(safe);
+            layout.push_str(&format!(
+                "{:x}:{:x}:{}:{}:{:x},",
+                ch.va, ch.size, idx, ld, ch.handle
+            ));
         }
     }
     // M3a: serialize the golden's modules (images) + functions to a temp file for

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -605,6 +605,20 @@ fn spawn_clone_worker(conn_fd: std::os::unix::io::RawFd, token: u64) -> io::Resu
                     return Err(std::io::Error::last_os_error());
                 }
             }
+            // The export fds from cuMemExportToShareableHandle are O_CLOEXEC. dup2 to
+            // a DIFFERENT fd clears CLOEXEC, but dup2(fd, fd) — when an export fd
+            // already sits at its destination (commonly the first, fd 4) — is a
+            // no-op that does NOT clear it, so that fd would be closed on exec and
+            // the worker's import fails e=999 (a region left uninitialized → a later
+            // read of a weight there faults). Clear CLOEXEC on every handed-off fd.
+            if libc::fcntl(3, libc::F_SETFD, 0) < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            for i in 0..export_fds.len() as i32 {
+                if libc::fcntl(4 + i, libc::F_SETFD, 0) < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+            }
             Ok(())
         });
     }

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -234,19 +234,22 @@ pub fn run_clone_worker(fd: std::os::unix::io::RawFd) -> io::Result<()> {
             tracing::warn!(e, "clone-worker: sync after memory reconstruction failed");
         }
     }
-    // M3a: reload the golden's modules + re-resolve its functions in OUR context,
-    // and install the golden→worker handle translation so the clone's inherited
-    // kernel launches (raw CUfunction from the golden's context) resolve correctly.
+    // M3a: STAGE the golden's modules/functions for LAZY reload in OUR context
+    // (reloading all up front stalls serving ~2s and breaks the clone connection)
+    // + recreate streams/events, then install the translation so the clone's
+    // inherited kernel launches resolve (each module reloads on first use).
     if let Ok(modpath) = std::env::var("SMOLVM_CUDA_CLONE_MODULES") {
-        let (funcs, mods, streams, events) = reconstruct_golden_modules(backend.as_mut(), &modpath);
-        let (nf, ns, ne) = (funcs.len(), streams.len(), events.len());
-        smolvm_cuda::host::set_handle_trans(funcs, mods, streams, events);
+        let (mod_images, func_meta, streams, events) =
+            reconstruct_golden_modules(backend.as_mut(), &modpath);
+        let (nm, nf, ns, ne) = (mod_images.len(), func_meta.len(), streams.len(), events.len());
+        smolvm_cuda::host::set_handle_trans(mod_images, func_meta, streams, events);
         let _ = std::fs::remove_file(&modpath);
         tracing::info!(
+            modules = nm,
             functions = nf,
             streams = ns,
             events = ne,
-            "cuda clone-worker: reloaded golden modules + remapped handles"
+            "cuda clone-worker: staged modules for lazy reload + remapped handles"
         );
     }
     // SAFETY: the daemon handed us sole ownership of the accepted connection fd.
@@ -341,33 +344,36 @@ fn reconstruct_golden_memory(b: &mut dyn Backend, layout: &str) -> usize {
     count
 }
 
-/// M3a: reload the golden's modules + re-resolve its functions in THIS worker's
-/// context, returning golden→worker handle maps `(functions, modules)`. Reads the
-/// binary blob the daemon wrote (path in `SMOLVM_CUDA_CLONE_MODULES`):
-/// `[u32 nmods]( [u64 handle][u32 len][image] )* [u32 nfuncs]( [u64 fn][u64 mod][u32 len][name] )*`.
+/// M3a: parse the golden's module IMAGES + function METADATA (for LAZY reload in
+/// THIS worker at first use — reloading ~400 modules up front stalls the clone
+/// ~2s and breaks its connection) and RECREATE its streams/events now (few,
+/// cheap). Returns `(mod_images, func_meta, streams, events)`. Reads the blob the
+/// daemon wrote (path in `SMOLVM_CUDA_CLONE_MODULES`):
+/// `[u32 nmods]([u64 h][u32 len][image])* [u32 nfuncs]([u64 fn][u64 mod][u32 len][name])*
+///  [u32 nstreams]([u64 h][u32 flags])* [u32 nevents]([u64 h][u32 flags])*`.
 #[cfg(unix)]
 #[allow(clippy::type_complexity)]
 fn reconstruct_golden_modules(
     b: &mut dyn Backend,
     path: &str,
 ) -> (
-    Vec<(u64, u64)>,
-    Vec<(u64, u64)>,
+    Vec<(u64, Vec<u8>)>,
+    Vec<(u64, u64, String)>,
     Vec<(u64, u64)>,
     Vec<(u64, u64)>,
 ) {
-    let mut func_trans = Vec::new();
-    let mut mod_trans = Vec::new();
+    let mut mod_images = Vec::new();
+    let mut func_meta = Vec::new();
     let mut stream_trans = Vec::new();
     let mut event_trans = Vec::new();
     let Ok(buf) = std::fs::read(path) else {
-        return (func_trans, mod_trans, stream_trans, event_trans);
+        return (mod_images, func_meta, stream_trans, event_trans);
     };
     let mut p = 0usize;
     macro_rules! need {
         ($n:expr) => {
             if p + $n > buf.len() {
-                return (func_trans, mod_trans, stream_trans, event_trans);
+                return (mod_images, func_meta, stream_trans, event_trans);
             }
         };
     }
@@ -387,28 +393,16 @@ fn reconstruct_golden_modules(
             v
         }};
     }
-    let mut g2w: std::collections::HashMap<u64, u64> = std::collections::HashMap::new();
+    // Modules: just STAGE the images (reloaded lazily on first use in the worker).
     let nmods = ru32!();
     for _ in 0..nmods {
         let gh = ru64!();
         let ilen = ru32!() as usize;
         need!(ilen);
-        let img = buf[p..p + ilen].to_vec();
+        mod_images.push((gh, buf[p..p + ilen].to_vec()));
         p += ilen;
-        // Null-terminate: cuModuleLoadData treats a PTX image as a C string, so the
-        // stored bytes need a trailing NUL the raw blob may lack.
-        let mut img = img;
-        if img.last() != Some(&0) {
-            img.push(0);
-        }
-        match b.module_load_data(&img) {
-            Ok(wh) => {
-                g2w.insert(gh, wh);
-                mod_trans.push((gh, wh));
-            }
-            Err(e) => tracing::warn!(e, ilen, "M3a: module reload failed"),
-        }
     }
+    // Functions: stage golden fn → (golden module, name); resolved lazily.
     let nfuncs = ru32!();
     for _ in 0..nfuncs {
         let gf = ru64!();
@@ -417,13 +411,7 @@ fn reconstruct_golden_modules(
         need!(nlen);
         let name = String::from_utf8_lossy(&buf[p..p + nlen]).into_owned();
         p += nlen;
-        match g2w.get(&gm) {
-            Some(&wm) => match b.module_get_function(wm, &name) {
-                Ok(wf) => func_trans.push((gf, wf)),
-                Err(e) => tracing::warn!(name, e, "M3a: re-resolve function failed"),
-            },
-            None => tracing::warn!(gm, "M3a: function's module not reloaded"),
-        }
+        func_meta.push((gf, gm, name));
     }
     // Streams + events: recreate each with its golden create flags in OUR context,
     // mapping the golden's inherited raw handle → our own (same M3a pattern).
@@ -450,13 +438,11 @@ fn reconstruct_golden_modules(
         nfuncs,
         nstreams,
         nevents,
-        mods = mod_trans.len(),
-        funcs = func_trans.len(),
         streams = stream_trans.len(),
         events = event_trans.len(),
-        "M3a: reconstruct_golden_modules"
+        "M3a: staged golden modules/functions for lazy reload + recreated streams/events"
     );
-    (func_trans, mod_trans, stream_trans, event_trans)
+    (mod_images, func_meta, stream_trans, event_trans)
 }
 
 /// Path 3 (M1): peek a just-accepted connection's first message; true iff it's an

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -102,6 +102,31 @@ pub fn run(sock: &Path) -> io::Result<()> {
                             match stream {
                                 Ok(s) => {
                                     let _ = s.set_nodelay(true); // low-latency RPC
+                                    // Path 3: a REMOTE isolating fork clone (its VM
+                                    // proxies here over TCP) gets a worker process
+                                    // exactly like a local one — the golden's memory
+                                    // and the clone worker both live on THIS GPU
+                                    // host; only the RPC crosses the network.
+                                    #[cfg(unix)]
+                                    {
+                                        use std::os::unix::io::AsRawFd;
+                                        let fd = s.as_raw_fd();
+                                        if let Some(token) = peek_clone_token(fd) {
+                                            match spawn_clone_worker(fd, token) {
+                                                Ok(()) => {
+                                                    tracing::info!(
+                                                        token,
+                                                        "routed REMOTE isolating clone to a worker process"
+                                                    );
+                                                    drop(s); // the worker owns it now
+                                                    continue;
+                                                }
+                                                Err(e) => {
+                                                    tracing::warn!(error = %e, "remote clone-worker spawn failed; serving in-process");
+                                                }
+                                            }
+                                        }
+                                    }
                                     spawn_serve(s, &active_tcp);
                                 }
                                 Err(e) => {
@@ -262,13 +287,35 @@ pub fn run_clone_worker(fd: std::os::unix::io::RawFd) -> io::Result<()> {
             "cuda clone-worker: staged modules for lazy reload + remapped handles"
         );
     }
-    // SAFETY: the daemon handed us sole ownership of the accepted connection fd.
-    let stream = unsafe { std::os::unix::net::UnixStream::from_raw_fd(fd) };
+    // The handed-off connection may be a local UDS (VM on this host) or a TCP
+    // socket (remote client driving this GPU host) — wrap by actual domain.
+    let mut domain: libc::c_int = 0;
+    let mut len = std::mem::size_of::<libc::c_int>() as libc::socklen_t;
+    // SAFETY: plain getsockopt on a valid fd with a correctly-sized out buffer.
+    unsafe {
+        libc::getsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_DOMAIN,
+            &mut domain as *mut _ as *mut libc::c_void,
+            &mut len,
+        );
+    }
     tracing::info!(
         fd,
+        tcp = domain != libc::AF_UNIX,
         "cuda clone-worker: serving in its own context / UVA space"
     );
-    serve(stream, backend.as_mut())
+    if domain == libc::AF_UNIX {
+        // SAFETY: the daemon handed us sole ownership of the accepted fd.
+        let stream = unsafe { std::os::unix::net::UnixStream::from_raw_fd(fd) };
+        serve(stream, backend.as_mut())
+    } else {
+        // SAFETY: as above; a TCP connection from the daemon's network listener.
+        let stream = unsafe { std::net::TcpStream::from_raw_fd(fd) };
+        let _ = stream.set_nodelay(true);
+        serve(stream, backend.as_mut())
+    }
 }
 
 /// M2: rebuild the golden's VMM layout in THIS worker's context at the golden's

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -289,18 +289,14 @@ pub fn run_clone_worker(fd: std::os::unix::io::RawFd) -> io::Result<()> {
     }
     // The handed-off connection may be a local UDS (VM on this host) or a TCP
     // socket (remote client driving this GPU host) — wrap by actual domain.
-    let mut domain: libc::c_int = 0;
-    let mut len = std::mem::size_of::<libc::c_int>() as libc::socklen_t;
-    // SAFETY: plain getsockopt on a valid fd with a correctly-sized out buffer.
+    // (getsockname is portable unix; SO_DOMAIN would be Linux-only.)
+    let mut addr: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
+    let mut len = std::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
+    // SAFETY: plain getsockname on a valid fd with a correctly-sized out buffer.
     unsafe {
-        libc::getsockopt(
-            fd,
-            libc::SOL_SOCKET,
-            libc::SO_DOMAIN,
-            &mut domain as *mut _ as *mut libc::c_void,
-            &mut len,
-        );
+        libc::getsockname(fd, &mut addr as *mut _ as *mut libc::sockaddr, &mut len);
     }
+    let domain = libc::c_int::from(addr.ss_family);
     tracing::info!(
         fd,
         tcp = domain != libc::AF_UNIX,

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -223,11 +223,16 @@ pub fn run_clone_worker(fd: std::os::unix::io::RawFd) -> io::Result<()> {
     // daemon passed (SMOLVM_CUDA_CLONE_LAYOUT) + the golden's physical exported to
     // fds 4.. — BEFORE serving, so the clone's inherited pointers are valid verbatim.
     if let Ok(layout) = std::env::var("SMOLVM_CUDA_CLONE_LAYOUT") {
-        let n = reconstruct_golden_memory(backend.as_mut(), &layout);
+        let (n, vmm_trans) = reconstruct_golden_memory(backend.as_mut(), &layout);
         tracing::info!(
             maps = n,
+            vmm_handles = vmm_trans.len(),
             "cuda clone-worker: reconstructed golden memory at its VAs"
         );
+        // The clone unmaps/releases inherited chunks by their GOLDEN handle
+        // values (torch expandable_segments trims segments under pressure);
+        // untranslated, cuMemRelease segfaults on the foreign-context handle.
+        smolvm_cuda::host::set_vmm_trans(vmm_trans);
         // Barrier: VMM reconstruction must fully settle before the clone runs, or a
         // later cuModuleLoadData surfaces a sticky async fault from the copies.
         if let Err(e) = backend.ctx_synchronize() {
@@ -262,13 +267,21 @@ pub fn run_clone_worker(fd: std::os::unix::io::RawFd) -> io::Result<()> {
 }
 
 /// M2: rebuild the golden's VMM layout in THIS worker's context at the golden's
-/// EXACT VAs. `layout` = `"resv=va:size,…|maps=va:size:fdidx,…"` (hex); each map's
-/// physical was exported by the daemon to fd `4 + fdidx`. We import + map at the
-/// same VA — address-preserving, so inherited pointers and rebuilt graphs are
-/// valid verbatim. (Weights are shared here; private-mutable copy for full
-/// isolation is the next refinement.)
+/// EXACT VAs. `layout` = `"resv=va:size,…|maps=va:size:fdidx:ghandle,…"` (hex);
+/// each map's physical was exported by the daemon to fd `4 + fdidx`. We import +
+/// map at the same VA — address-preserving, so inherited pointers and rebuilt
+/// graphs are valid verbatim. (Weights are shared here; private-mutable copy for
+/// full isolation is the next refinement.)
+///
+/// Also returns the golden-handle → worker-handle map (from `ghandle`): the
+/// clone's torch later unmaps/releases inherited chunks by their GOLDEN handle
+/// values, and cuMemRelease on a foreign-context handle SEGFAULTS the worker.
 #[cfg(unix)]
-fn reconstruct_golden_memory(b: &mut dyn Backend, layout: &str) -> usize {
+fn reconstruct_golden_memory(
+    b: &mut dyn Backend,
+    layout: &str,
+) -> (usize, std::collections::HashMap<u64, u64>) {
+    let mut vmm_trans = std::collections::HashMap::new();
     let (mut resv_s, mut maps_s) = ("", "");
     for part in layout.split('|') {
         if let Some(r) = part.strip_prefix("resv=") {
@@ -291,12 +304,14 @@ fn reconstruct_golden_memory(b: &mut dyn Backend, layout: &str) -> usize {
     let mut count = 0;
     for e in maps_s.split(',').filter(|s| !s.is_empty()) {
         let f: Vec<&str> = e.split(':').collect();
-        if f.len() != 3 {
+        if f.len() < 3 {
             continue;
         }
         let (Some(va), Some(size), Ok(idx)) = (hx(f[0]), hx(f[1]), f[2].parse::<i32>()) else {
             continue;
         };
+        // 4th field: the golden's handle value for this chunk (hex).
+        let golden_h = f.get(3).and_then(|s| hx(s));
         // Private-mutable, address-preserving: map a PRIVATE physical at the golden
         // VA, then copy the golden's bytes in via a temp mapping of the imported
         // physical. Reads see the golden's data; writes hit the clone's own copy,
@@ -311,6 +326,11 @@ fn reconstruct_golden_memory(b: &mut dyn Backend, layout: &str) -> usize {
         if let Err(e) = b.mem_map(va, size, 0, priv_h) {
             tracing::warn!(e, va, "M2: private map failed");
             continue;
+        }
+        // priv_h stays held (never released here): the clone releases this chunk
+        // post-fork by the GOLDEN's handle value, translated to priv_h.
+        if let Some(g) = golden_h {
+            vmm_trans.insert(g, priv_h);
         }
         if let Err(e) = b.mem_set_access(va, size, 0) {
             tracing::warn!(e, va, "M2: private set_access failed");
@@ -341,7 +361,7 @@ fn reconstruct_golden_memory(b: &mut dyn Backend, layout: &str) -> usize {
         }
         count += 1;
     }
-    count
+    (count, vmm_trans)
 }
 
 /// M3a: parse the golden's module IMAGES + function METADATA (for LAZY reload in
@@ -503,7 +523,10 @@ fn spawn_clone_worker(conn_fd: std::os::unix::io::RawFd, token: u64) -> io::Resu
     let (resvs, maps) = smolvm_cuda::host::layout_handoff_snapshot(token)
         .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "no golden layout for token"))?;
     // Export each map's physical to a POSIX fd (in the golden's shared context) and
-    // build the layout string the worker parses ("resv=va:size,…|maps=va:size:fdidx,…").
+    // build the layout string the worker parses
+    // ("resv=va:size,…|maps=va:size:fdidx:ghandle,…"; ghandle = the golden's
+    // handle value, so the worker can translate the clone's inherited
+    // MemRelease/MemMap handles to its own).
     let mut backend = make_backend();
     backend
         .init()
@@ -525,7 +548,7 @@ fn spawn_clone_worker(conn_fd: std::os::unix::io::RawFd, token: u64) -> io::Resu
         if let Ok(efd) = backend.mem_export_handle(*handle) {
             let idx = export_fds.len();
             export_fds.push(efd);
-            layout.push_str(&format!("{va:x}:{size:x}:{idx},"));
+            layout.push_str(&format!("{va:x}:{size:x}:{idx}:{handle:x},"));
         }
     }
     // M3a: serialize the golden's modules (images) + functions to a temp file for

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -318,8 +318,32 @@ pub fn run_clone_worker(fd: std::os::unix::io::RawFd) -> io::Result<()> {
     }
 }
 
+/// IPC-import a golden physical from `fd`, retrying on transient failure with a
+/// ctx_synchronize between attempts. Defense-in-depth: the deterministic e=999
+/// import failure was the CLOEXEC fd handoff (fixed in spawn_clone_worker); this
+/// guards the remaining first-import-in-fresh-context warm-up window.
+#[cfg(unix)]
+fn import_with_retry(b: &mut dyn Backend, fd: i32) -> Result<u64, i32> {
+    let mut last = 0;
+    for attempt in 0..5 {
+        match b.mem_import_handle(fd) {
+            Ok(h) => {
+                if attempt > 0 {
+                    tracing::info!(fd, attempt, "M2: import succeeded on retry");
+                }
+                return Ok(h);
+            }
+            Err(e) => {
+                last = e;
+                let _ = b.ctx_synchronize();
+            }
+        }
+    }
+    Err(last)
+}
+
 /// M2: rebuild the golden's VMM layout in THIS worker's context at the golden's
-/// EXACT VAs. `layout` = `"resv=va:size,…|maps=va:size:fdidx:ghandle,…"` (hex);
+/// EXACT VAs. `layout` = `"resv=va:size,…|maps=va:size:fdidx:loaded:ghandle,…"` (hex);
 /// each map's physical was exported by the daemon to fd `4 + fdidx`. We import +
 /// map at the same VA — address-preserving, so inherited pointers and rebuilt
 /// graphs are valid verbatim. (Weights are shared here; private-mutable copy for
@@ -353,7 +377,8 @@ fn reconstruct_golden_memory(
             }
         }
     }
-    let mut count = 0;
+    let share_weights = smolvm_cuda::host::path3_share_weights_enabled();
+    let (mut count, mut shared) = (0, 0);
     for e in maps_s.split(',').filter(|s| !s.is_empty()) {
         let f: Vec<&str> = e.split(':').collect();
         if f.len() < 3 {
@@ -362,8 +387,51 @@ fn reconstruct_golden_memory(
         let (Some(va), Some(size), Ok(idx)) = (hx(f[0]), hx(f[1]), f[2].parse::<i32>()) else {
             continue;
         };
-        // 4th field: the golden's handle value for this chunk (hex).
-        let golden_h = f.get(3).and_then(|s| hx(s));
+        // 4th field (loaded) marks a fully-H2D-covered weight range; 5th is the
+        // golden's handle value for this chunk (hex).
+        let loaded = f.get(3).map(|s| *s == "1").unwrap_or(false);
+        let golden_h = f.get(4).and_then(|s| hx(s));
+
+        // DENSITY (opt-in, SMOLVM_CUDA_PATH3_SHARE_WEIGHTS): a loaded weight range is
+        // read-only during frozen-base fine-tuning (LoRA freezes the base; only the
+        // clone's PRIVATE adapters train), so SHARE the golden's physical at its VA —
+        // every clone imports the same physical, so one weight set lives in VRAM.
+        // Mapped READ-WRITE: unsloth's fix_untrained_tokens writes the embedding at
+        // trainer setup, and that write is identical across clones (same base → same
+        // fix), so sharing stays correct for this use case (verified by each clone
+        // still learning its distinct task). On ANY share failure, fall through to a
+        // private copy — never leave the VA unmapped (a hole faults the clone).
+        if share_weights && loaded {
+            let mut ok = false;
+            if let Ok(gh) = import_with_retry(b, 4 + idx) {
+                if b.mem_map(va, size, 0, gh).is_ok() {
+                    if b.mem_set_access(va, size, 0).is_ok() {
+                        ok = true;
+                    } else {
+                        let _ = b.mem_unmap(va, size); // roll back for the fallback
+                    }
+                }
+                match (ok, golden_h) {
+                    // Keep gh held and record golden→worker: the clone later
+                    // releases this chunk by the GOLDEN's handle value.
+                    (true, Some(g)) => {
+                        vmm_trans.insert(g, gh);
+                    }
+                    // Legacy layout (no handle field) or failure: the va mapping
+                    // holds its own ref, so drop ours.
+                    _ => {
+                        let _ = b.mem_release(gh);
+                    }
+                }
+            }
+            if ok {
+                shared += 1;
+                count += 1;
+                continue;
+            }
+            tracing::warn!(idx, "M2-share: share failed → private-copy fallback");
+            // fall through to the private path (va stays reserved + unmapped)
+        }
         // Private-mutable, address-preserving: map a PRIVATE physical at the golden
         // VA, then copy the golden's bytes in via a temp mapping of the imported
         // physical. Reads see the golden's data; writes hit the clone's own copy,
@@ -387,7 +455,7 @@ fn reconstruct_golden_memory(
         if let Err(e) = b.mem_set_access(va, size, 0) {
             tracing::warn!(e, va, "M2: private set_access failed");
         }
-        match b.mem_import_handle(4 + idx) {
+        match import_with_retry(b, 4 + idx) {
             Ok(gh) => {
                 if let Ok(tmp) = b.mem_address_reserve(size, 0) {
                     match b.mem_map(tmp, size, 0, gh) {
@@ -412,6 +480,9 @@ fn reconstruct_golden_memory(
             Err(e) => tracing::warn!(e, idx, "M2: import failed"),
         }
         count += 1;
+    }
+    if share_weights {
+        tracing::info!(shared, private = count - shared, "M2: shared weight ranges");
     }
     (count, vmm_trans)
 }
@@ -576,7 +647,8 @@ fn spawn_clone_worker(conn_fd: std::os::unix::io::RawFd, token: u64) -> io::Resu
         .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "no golden layout for token"))?;
     // Export each map's physical to a POSIX fd (in the golden's shared context) and
     // build the layout string the worker parses
-    // ("resv=va:size,…|maps=va:size:fdidx:ghandle,…"; ghandle = the golden's
+    // ("resv=va:size,…|maps=va:size:fdidx:loaded:ghandle,…"; loaded=1 → shareable
+    // weight; ghandle = the golden's
     // handle value, so the worker can translate the clone's inherited
     // MemRelease/MemMap handles to its own).
     let mut backend = make_backend();
@@ -596,11 +668,12 @@ fn spawn_clone_worker(conn_fd: std::os::unix::io::RawFd, token: u64) -> io::Resu
     }
     layout.push_str("|maps=");
     let mut export_fds: Vec<i32> = Vec::new();
-    for (va, size, handle) in &maps {
+    for (va, size, handle, loaded) in &maps {
         if let Ok(efd) = backend.mem_export_handle(*handle) {
             let idx = export_fds.len();
             export_fds.push(efd);
-            layout.push_str(&format!("{va:x}:{size:x}:{idx}:{handle:x},"));
+            let ld = u8::from(*loaded);
+            layout.push_str(&format!("{va:x}:{size:x}:{idx}:{ld}:{handle:x},"));
         }
     }
     // M3a: serialize the golden's modules (images) + functions to a temp file for

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -246,7 +246,12 @@ pub fn run_clone_worker(fd: std::os::unix::io::RawFd) -> io::Result<()> {
     if let Ok(modpath) = std::env::var("SMOLVM_CUDA_CLONE_MODULES") {
         let (mod_images, func_meta, streams, events) =
             reconstruct_golden_modules(backend.as_mut(), &modpath);
-        let (nm, nf, ns, ne) = (mod_images.len(), func_meta.len(), streams.len(), events.len());
+        let (nm, nf, ns, ne) = (
+            mod_images.len(),
+            func_meta.len(),
+            streams.len(),
+            events.len(),
+        );
         smolvm_cuda::host::set_handle_trans(mod_images, func_meta, streams, events);
         let _ = std::fs::remove_file(&modpath);
         tracing::info!(
@@ -590,7 +595,14 @@ fn spawn_clone_worker(conn_fd: std::os::unix::io::RawFd, token: u64) -> io::Resu
             blob.extend_from_slice(&flags.to_le_bytes());
         }
         let _ = std::fs::create_dir_all("/tmp/smolvm");
-        let mp = format!("/tmp/smolvm/clone-mods-{token}-{conn_fd}.bin");
+        // Unique per SPAWN, not per (token, conn_fd): fd numbers are reused as
+        // soon as the daemon closes a spawned worker's copy, so two clones forked
+        // near-simultaneously collide on the same path — and each worker deletes
+        // its blob after staging, leaving the second worker 0 modules (its kernel
+        // launches then use raw golden handles → SIGSEGV in cuLaunchKernel).
+        static SPAWN_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let seq = SPAWN_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let mp = format!("/tmp/smolvm/clone-mods-{token}-{seq}.bin");
         if std::fs::write(&mp, &blob).is_ok() {
             modpath = Some(mp);
         }


### PR DESCRIPTION
Seven fixes proven on real Unsloth fork-sweeps: CLOEXEC fd handoff, lazy module reload (+ crash-safe NULL fallback), golden VMM-handle translation, unique module-blob paths, auto-enabled isolating forks for --forkable CUDA machines, and Path 3 routing for TCP clients so remote hosts can fork against a network GPU.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/648">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->