### PR TITLE
CUDA fork: release a torn-down golden's VRAM (close leaked export fds)

### DIFF
--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -765,6 +765,12 @@ fn spawn_clone_worker(conn_fd: std::os::unix::io::RawFd, token: u64) -> io::Resu
     if let Some(mp) = &modpath {
         cmd.env("SMOLVM_CUDA_CLONE_MODULES", mp);
     }
+    // Parent copies of the exported-physical fds, to close once the child has
+    // forked (it inherits its own set). Every open export fd holds a DRIVER
+    // REFERENCE on the golden's physical allocation — leaking them in the
+    // daemon pins the golden's VRAM long after the golden is torn down and its
+    // session reclaimed (found: two dead goldens left ~3.2 GB resident).
+    let parent_fds = export_fds.clone();
     // SAFETY: dup2 in the forked child (async-signal-safe); fds were inherited at
     // fork. Connection → fd 3; each exported physical → fd 4+idx.
     unsafe {
@@ -794,7 +800,14 @@ fn spawn_clone_worker(conn_fd: std::os::unix::io::RawFd, token: u64) -> io::Resu
             Ok(())
         });
     }
-    cmd.spawn().map(|_| ())
+    let spawned = cmd.spawn().map(|_| ());
+    // The child (if any) forked with its own copies; drop ours either way so
+    // the golden's physicals can actually be released at teardown.
+    for efd in parent_fds {
+        // SAFETY: fds we created via mem_export_handle and no longer use.
+        unsafe { libc::close(efd) };
+    }
+    spawned
 }
 
 /// Ensure the shared daemon is running and return its socket path. Serialized by


### PR DESCRIPTION
Each clone-worker spawn leaked the daemon's copies of the cuMemExportToShareableHandle fds, and every open export fd pins the golden's physical allocation — two torn-down goldens left ~3.2 GB resident; with the fix a multi-golden pool returns to baseline (611 MiB vs 609) after full teardown.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/650">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->