### PR TITLE
CUDA fork: fail fast when a clone's worker dies or its lineage is gone

### DIFF
--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -122,7 +122,10 @@ pub fn run(sock: &Path) -> io::Result<()> {
                                                     continue;
                                                 }
                                                 Err(e) => {
-                                                    tracing::warn!(error = %e, "remote clone-worker spawn failed; serving in-process");
+                                                    // See the UDS arm: reject, fail fast.
+                                                    tracing::warn!(error = %e, token, "remote clone-worker spawn failed; rejecting the clone connection");
+                                                    drop(s);
+                                                    continue;
                                                 }
                                             }
                                         }
@@ -167,7 +170,16 @@ pub fn run(sock: &Path) -> io::Result<()> {
                                 continue;
                             }
                             Err(e) => {
-                                tracing::warn!(error = %e, "clone-worker spawn failed; serving in-process");
+                                // REJECT rather than serve in-process: this IS an
+                                // isolating clone (peek matched), and the legacy
+                                // shared path can't serve it — its inherited
+                                // pointers are garbage in a fresh context, so the
+                                // guest would wedge mid-training (seen after a
+                                // daemon restart orphaned a lineage). Closing
+                                // makes the guest fail fast instead.
+                                tracing::warn!(error = %e, token, "clone-worker spawn failed; rejecting the clone connection");
+                                drop(stream);
+                                continue;
                             }
                         }
                     }

--- a/src/cuda_host.rs
+++ b/src/cuda_host.rs
@@ -142,7 +142,10 @@ fn proxy_to_daemon(guest: crate::platform::uds::UdsStream, addr: &str) -> std::i
         #[cfg(unix)]
         {
             let daemon = std::os::unix::net::UnixStream::connect(addr)?;
-            return pump(guest, daemon.try_clone()?, daemon);
+            let sd = daemon.try_clone()?;
+            return pump(guest, daemon.try_clone()?, daemon, move || {
+                let _ = sd.shutdown(std::net::Shutdown::Both);
+            });
         }
         #[cfg(not(unix))]
         {
@@ -155,7 +158,10 @@ fn proxy_to_daemon(guest: crate::platform::uds::UdsStream, addr: &str) -> std::i
     }
     let daemon = std::net::TcpStream::connect(addr)?;
     let _ = daemon.set_nodelay(true);
-    pump(guest, daemon.try_clone()?, daemon)
+    let sd = daemon.try_clone()?;
+    pump(guest, daemon.try_clone()?, daemon, move || {
+        let _ = sd.shutdown(std::net::Shutdown::Both);
+    })
 }
 
 /// Byte-pump the guest connection and a daemon connection in both directions.
@@ -163,16 +169,25 @@ fn pump<D>(
     guest: crate::platform::uds::UdsStream,
     mut daemon_wr: D,
     mut daemon_rd: D,
+    daemon_shutdown: impl FnOnce() + Send + 'static,
 ) -> std::io::Result<()>
 where
     D: std::io::Read + std::io::Write + Send + 'static,
 {
     let mut guest_rd = guest.try_clone()?;
+    let guest_sd = guest_rd.try_clone()?;
     let mut guest_wr = guest;
     let up = thread::spawn(move || {
         let _ = std::io::copy(&mut guest_rd, &mut daemon_wr);
+        // Guest side ended: unblock the daemon→guest copy below so the proxy
+        // thread exits instead of leaking, blocked on a silent daemon.
+        daemon_shutdown();
     });
     let _ = std::io::copy(&mut daemon_rd, &mut guest_wr);
+    // Daemon side ended — e.g. this connection's clone worker died. Shut the
+    // guest socket down so the guest's blocked read fails LOUDLY (the clone
+    // would otherwise hang forever mid-training) and the up-thread unblocks.
+    let _ = guest_sd.shutdown(std::net::Shutdown::Both);
     let _ = up.join();
     Ok(())
 }


### PR DESCRIPTION
Battle-test findings: a SIGKILLed clone worker left the guest hung mid-training (proxy byte-pump never propagated the half-close), and a fork against a restarted daemon wedged on the shared serving path — both now surface as immediate errors in the guest.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/652">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->