### PR TITLE
Rename the CUDA fork env vars to describe behavior

### DIFF
--- a/crates/smolvm-cuda/examples/m1_route_probe.rs
+++ b/crates/smolvm-cuda/examples/m1_route_probe.rs
@@ -1,5 +1,5 @@
 //! Path 3 M1 routing probe: connect to a running cuda-daemon as an ISOLATING fork
-//! clone (`init` with resume_token=1). With SMOLVM_CUDA_PATH3=1 +
+//! clone (`init` with resume_token=1). With SMOLVM_CUDA_FORK_WORKERS=1 +
 //! SMOLVM_CUDA_FORK_ISOLATE=1 the daemon serves us in a dedicated worker PROCESS
 //! (its own CUDA context/UVA). We then run a real vecadd kernel and verify —
 //! proving the routed worker process serves the clone correctly (M1).

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -480,7 +480,7 @@ fn fork_isolate_enabled() -> bool {
 /// golden's VMM physical is created IPC-exportable so a clone worker process can
 /// share/copy it at the golden's exact VA. Off = legacy shared-context path.
 fn path3_enabled() -> bool {
-    std::env::var_os("SMOLVM_CUDA_PATH3").is_some()
+    std::env::var_os("SMOLVM_CUDA_FORK_WORKERS").is_some()
 }
 
 /// Path 3 density opt-in: a clone worker SHARES the golden's loaded (weight)
@@ -488,7 +488,7 @@ fn path3_enabled() -> bool {
 /// them. Off by default (the proven path privately copies every range —
 /// correct + isolated but N copies of the weights).
 pub fn path3_share_weights_enabled() -> bool {
-    std::env::var_os("SMOLVM_CUDA_PATH3_SHARE_WEIGHTS").is_some()
+    std::env::var_os("SMOLVM_CUDA_FORK_SHARE_WEIGHTS").is_some()
 }
 
 /// P0 transport-viability instrumentation. Counts every dispatched CUDA RPC so we

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -1682,7 +1682,7 @@ impl AgentManager {
             // settings win. The daemon reads these at ITS spawn (inherited from
             // this VM's boot process via ensure_running), so a daemon already
             // running in another mode keeps that mode until restarted.
-            for flag in ["SMOLVM_CUDA_PATH3", "SMOLVM_CUDA_FORK_ISOLATE"] {
+            for flag in ["SMOLVM_CUDA_FORK_WORKERS", "SMOLVM_CUDA_FORK_ISOLATE"] {
                 if std::env::var_os(flag).is_none()
                     && (features.forkable || features.snapshot_dir.is_some())
                 {

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -154,7 +154,7 @@ pub fn run(sock: &Path) -> io::Result<()> {
             Ok(stream) => {
                 // Path 3 (M1): an isolating fork clone is served in its own worker
                 // PROCESS (own context/UVA) so it can hold memory at the golden's
-                // exact VAs. Only fires under SMOLVM_CUDA_PATH3; otherwise legacy.
+                // exact VAs. Only fires under SMOLVM_CUDA_FORK_WORKERS; otherwise legacy.
                 #[cfg(unix)]
                 {
                     use std::os::unix::io::AsRawFd;
@@ -388,7 +388,7 @@ fn reconstruct_golden_memory(
         let loaded = f.get(3).map(|s| *s == "1").unwrap_or(false);
         let golden_h = f.get(4).and_then(|s| hx(s));
 
-        // DENSITY (opt-in, SMOLVM_CUDA_PATH3_SHARE_WEIGHTS): a loaded weight range is
+        // DENSITY (opt-in, SMOLVM_CUDA_FORK_SHARE_WEIGHTS): a loaded weight range is
         // read-only during frozen-base fine-tuning (LoRA freezes the base; only the
         // clone's PRIVATE adapters train), so SHARE the golden's physical at its VA —
         // every clone imports the same physical, so one weight set lives in VRAM.
@@ -587,11 +587,11 @@ fn reconstruct_golden_modules(
 /// Path 3 (M1): peek a just-accepted connection's first message; true iff it's an
 /// isolating fork-clone Init (`op == Init`, `resume_token != 0`) that should be
 /// served in a dedicated worker process. `MSG_PEEK` leaves the bytes on the
-/// socket so the worker reads them fresh. Gated behind `SMOLVM_CUDA_PATH3` (unset
+/// socket so the worker reads them fresh. Gated behind `SMOLVM_CUDA_FORK_WORKERS` (unset
 /// = legacy shared-context path) so partial Path-3 wiring can't disturb serving.
 #[cfg(unix)]
 fn peek_clone_token(fd: std::os::unix::io::RawFd) -> Option<u64> {
-    if std::env::var_os("SMOLVM_CUDA_PATH3").is_none()
+    if std::env::var_os("SMOLVM_CUDA_FORK_WORKERS").is_none()
         || std::env::var_os("SMOLVM_CUDA_FORK_ISOLATE").is_none()
     {
         return None;


### PR DESCRIPTION
SMOLVM_CUDA_PATH3 -> SMOLVM_CUDA_FORK_WORKERS and SMOLVM_CUDA_PATH3_SHARE_WEIGHTS -> SMOLVM_CUDA_FORK_SHARE_WEIGHTS while the flags are new and nothing depends on them (validated end-to-end with a 2-clone fork-sweep).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/653">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->