### PR TITLE
CUDA image machines: run the create workload, and fail fast when no GPU host answers

### DIFF
--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -420,6 +420,28 @@ fn ring_try_setup(client: &mut Client<Stream>) {
 /// (best-effort) set up the shared-memory rings. Used for the first connection
 /// and to re-establish one after a fork/clone. Returns the client and the
 /// lineage token the host assigned this session.
+/// Bound a socket's blocking reads (0 = restore fully blocking). Used only
+/// around bring-up: a connection that is ACCEPTED but never answered (e.g. the
+/// CUDA host service isn't actually up behind the port) must fail cuInit in
+/// seconds, not hang the first torch import forever.
+#[cfg(unix)]
+fn set_recv_timeout(fd: i32, secs: i64) {
+    let tv = libc::timeval {
+        tv_sec: secs,
+        tv_usec: 0,
+    };
+    // SAFETY: plain setsockopt on our own connected socket fd.
+    unsafe {
+        libc::setsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_RCVTIMEO,
+            &tv as *const _ as *const libc::c_void,
+            std::mem::size_of::<libc::timeval>() as libc::socklen_t,
+        );
+    }
+}
+
 fn bring_up_client(resume_token: u64) -> Result<(Client<Stream>, u64, i32), c_int> {
     let stream = connect()?;
     #[cfg(target_os = "linux")]
@@ -437,6 +459,8 @@ fn bring_up_client(resume_token: u64) -> Result<(Client<Stream>, u64, i32), c_in
     if trace {
         eprintln!("[shim] bring_up: connected fd={fd}");
     }
+    #[cfg(unix)]
+    set_recv_timeout(fd, 10);
     let mut client = Client::new(stream);
     let token = client.init(resume_token).map_err(|e| {
         if trace {
@@ -459,6 +483,10 @@ fn bring_up_client(resume_token: u64) -> Result<(Client<Stream>, u64, i32), c_in
     if try_ring {
         ring_try_setup(&mut client); // best-effort; socket mode on failure
     }
+    // Bring-up answered: restore fully blocking reads (steady-state ops may
+    // legitimately wait longer than the handshake bound).
+    #[cfg(unix)]
+    set_recv_timeout(fd, 0);
     if trace {
         eprintln!("[shim] bring_up: complete");
     }

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -2497,8 +2497,19 @@ impl CreateCmd {
             } else {
                 Some(manifest.image)
             },
-            entrypoint: manifest.entrypoint,
-            cmd: manifest.cmd,
+            // CLI trailing args override the artifact's baked (entrypoint, cmd),
+            // matching the --image create path's precedence — without this a
+            // `machine create --from art -- <workload>` silently never runs it.
+            entrypoint: if self.command.is_empty() {
+                manifest.entrypoint
+            } else {
+                Vec::new()
+            },
+            cmd: if self.command.is_empty() {
+                manifest.cmd
+            } else {
+                self.command.clone()
+            },
             cpus,
             mem,
             volume: self.volume.clone(),


### PR DESCRIPTION
Two fixes surfaced building a self-contained CUDA image: machine create --from <artifact> now runs the workload command it was given (was silently dropped), and the CUDA shim bounds its bring-up read so cuInit errors in ~10s when nothing is listening instead of hanging the first call forever.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/655">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->