### PR TITLE
Expand tilde in source path

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ allow_hosts = ["api.stripe.com", "db.example.com"]
 
 [dev]
 init = ["pip install -r requirements.txt"]
-volumes = ["./src:/app"]
+volumes = ["~/src:/app"]
 
 [auth]
 ssh_agent = true

--- a/src/data/storage.rs
+++ b/src/data/storage.rs
@@ -84,7 +84,7 @@ impl HostMount {
         read_only: bool,
     ) -> Result<Self> {
         let mut mount = Self {
-            source: source.into(),
+            source: Self::expand_path(source),
             target: target.into(),
             read_only,
         };
@@ -113,6 +113,32 @@ impl HostMount {
         })?;
         Self::validate(&mount)?;
         Ok(mount)
+    }
+
+    /// Expand a path containing a tilde into a full path
+    ///
+    /// '~', '~/foo' are valid paths but not '~foo'
+    fn expand_path(source: impl Into<PathBuf>) -> PathBuf {
+        let source_path = source.into();
+        let Some(after_tilde) = source_path.to_str().and_then(|s| s.strip_prefix('~')) else {
+            return source_path;
+        };
+
+        if !after_tilde.is_empty() && !after_tilde.starts_with('/') {
+            // '~somepath should not be expanded
+            return source_path;
+        }
+
+        dirs::home_dir()
+            .map(|home| {
+                if after_tilde.is_empty() {
+                    home
+                } else {
+                    // drop leading /
+                    home.join(&after_tilde[1..])
+                }
+            })
+            .unwrap_or(source_path)
     }
 
     /// Parse a mount specification (`host_path:guest_path[:ro|:rw]`).


### PR DESCRIPTION
Allow to specify
```
volumes = ["~/music:/app/music"]
```
Tested on Linux only

**Context:**

The comment in [`local-llm.smolfile`](https://github.com/smol-machines/smolvm/blob/b31b405b72d434ad0c7242082c54498adffda408/examples/local-llm/local-llm.smolfile#L73) suggest that you can use the tilde to refer to home

```
# Mount your local model directory into /models inside the VM.
# Set the host path to wherever you store .gguf files, for example:
#
#   volumes = ["~/.cache/smolvm/models:/models"]
```
however, it’s a simple `PathBuf`, it is not resolving shell values.

We can either
- not support tilde and update the comment
- resolve tilde only in src (this PR)
- resolve tilde and shell variables (with `expandshell::full`)
- other?

Note that if we only want to resolve one tilde, it’s maybe not worth adding a new dependency. This is a minimal PR to first see if you are interrested. Let me know the direction you want to take and I can update my PR (or feel free to push in my branch directly).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/657">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->