### PR TITLE
Run the pack-from-vm helper as the source VM's isolated uid so it can read the source disks

### DIFF
--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -159,7 +159,7 @@ pub fn prepare_fork(
     // command below, so hand this dir to that uid. No-op unless privileged; if the
     // drop is active the golden's uid lookup must succeed (fail closed).
     if let Some(result) =
-        crate::process::vm_drop_ids(&crate::agent::vm_uid_registry_dir(), &gdir, None)
+        crate::process::vm_drop_ids(&crate::agent::vm_uid_registry_dir(), &gdir, None, None)
     {
         let (uid, gid) =
             result.map_err(|e| Error::agent("fork: resolve golden uid", e.to_string()))?;

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -229,6 +229,13 @@ pub struct LaunchFeatures {
     /// carries its CNI-assigned IP and is reachable at L2. Runtime-only (never
     /// persisted in `VmRecord`); requires the virtio-net backend.
     pub pod_netns: Option<std::path::PathBuf>,
+    /// Under per-VM uid isolation, run this VM as the uid already owned by the
+    /// VM at this data dir instead of allocating a fresh one. Set by the
+    /// pack-from-vm helper, whose whole job is reading the source VM's 0700
+    /// disks (attached via `extra_disks`) — a fresh sibling uid cannot open
+    /// them, so the helper boot would fail configuring virtio-blk. Same trust
+    /// domain, same uid, mirroring how a fork clone shares its golden's uid.
+    pub uid_share_dir: Option<std::path::PathBuf>,
 }
 
 impl LaunchFeatures {

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -1721,9 +1721,12 @@ impl AgentManager {
         // otherwise the VMM stays root and reads the shared copy directly.
         let mut uid_drop_active = false;
         if let Some(d) = data_dir.as_deref() {
-            if let Some(result) =
-                crate::process::vm_drop_ids(&registry, d, features.snapshot_dir.as_deref())
-            {
+            if let Some(result) = crate::process::vm_drop_ids(
+                &registry,
+                d,
+                features.snapshot_dir.as_deref(),
+                features.uid_share_dir.as_deref(),
+            ) {
                 // The drop is active — allocation MUST succeed or we refuse to boot
                 // (fail closed; never silently run the VMM over-privileged).
                 let (uid, gid) = result.map_err(|e| {

--- a/src/cli/pack.rs
+++ b/src/cli/pack.rs
@@ -915,6 +915,11 @@ impl PackCreateCmd {
         let manager = AgentManager::for_vm(&pack_vm_name)?;
         let features = smolvm::agent::LaunchFeatures {
             extra_disks: vec![(storage_disk.clone(), false, storage_fmt)],
+            // Under per-VM uid isolation the source VM's dir is 0700/its-own-uid;
+            // this helper's whole job is reading that VM's storage disk, so run
+            // it as the source's uid (a fresh sibling uid can't open the disk and
+            // the boot dies configuring virtio-blk).
+            uid_share_dir: Some(vm_dir.to_path_buf()),
             ..Default::default()
         };
         manager.start_with_full_config(

--- a/src/process.rs
+++ b/src/process.rs
@@ -1046,18 +1046,27 @@ pub fn free_vm_uid(_registry_dir: &std::path::Path, _key_dir: &std::path::Path) 
 /// A fork clone (`snapshot_dir` set, laid out as
 /// `<golden_dir>/fork-snapshots/<clone>`) resolves to the GOLDEN's uid so it can
 /// map the golden's memfd. gid mirrors uid (a per-VM group).
+///
+/// `share_uid_with` (when set) overrides the key resolution entirely: the VM
+/// resolves to THAT data dir's uid instead of claiming its own. Used by the
+/// pack-from-vm helper, which must read the source VM's 0700 disks — same trust
+/// domain, same uid (mirroring how a fork clone shares its golden's uid). The
+/// borrower never writes its own `.vm-uid`, so deleting it can't free the
+/// owner's uid.
 #[cfg(target_os = "linux")]
 pub fn vm_drop_ids(
     registry_dir: &std::path::Path,
     data_dir: &std::path::Path,
     snapshot_dir: Option<&std::path::Path>,
+    share_uid_with: Option<&std::path::Path>,
 ) -> Option<std::io::Result<(u32, u32)>> {
     if !vm_uid_drop_active() {
         return None;
     }
-    let key_dir = match snapshot_dir {
-        Some(snap) => snap.parent().and_then(|p| p.parent()).unwrap_or(data_dir),
-        None => data_dir,
+    let key_dir = match (share_uid_with, snapshot_dir) {
+        (Some(owner), _) => owner,
+        (None, Some(snap)) => snap.parent().and_then(|p| p.parent()).unwrap_or(data_dir),
+        (None, None) => data_dir,
     };
     let Some(vm_key) = key_dir.file_name().and_then(|n| n.to_str()) else {
         return Some(Err(std::io::Error::new(
@@ -1074,6 +1083,7 @@ pub fn vm_drop_ids(
     _registry_dir: &std::path::Path,
     _data_dir: &std::path::Path,
     _snapshot_dir: Option<&std::path::Path>,
+    _share_uid_with: Option<&std::path::Path>,
 ) -> Option<std::io::Result<(u32, u32)>> {
     None
 }


### PR DESCRIPTION
Under per-VM uid isolation, pack --from-vm boots a helper VM with the source machine's storage disk attached, but the helper was allocated a fresh sibling uid while the source's data dir is 0700 owned by the source's uid — the helper couldn't open the disk and died configuring virtio-blk, breaking every export of a stopped machine. Resolve the helper to the source VM's uid via a new uid-share override on vm_drop_ids, mirroring how a fork clone shares its golden's uid; the helper never writes its own uid cache, so deleting it can't free the source's uid.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/658">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->