### PR TITLE
Fix silently dropped CUDA work after a fork-clone reconnect, and rebuild captured graphs in clone workers

### DIFF
--- a/crates/smolvm-cuda/src/client.rs
+++ b/crates/smolvm-cuda/src/client.rs
@@ -676,7 +676,8 @@ impl<S: Read + Write> Client<S> {
         self.flush_wbuf()?;
         write_msg(&mut self.stream, payload)?;
         rtt_tax();
-        let p = read_msg(&mut self.stream)?.ok_or(CudaRpcError::Protocol("host closed mid-call"))?;
+        let p =
+            read_msg(&mut self.stream)?.ok_or(CudaRpcError::Protocol("host closed mid-call"))?;
         self.journal.clear(); // response received → all prior consumed
         Ok(p)
     }

--- a/crates/smolvm-cuda/src/client.rs
+++ b/crates/smolvm-cuda/src/client.rs
@@ -193,6 +193,15 @@ pub struct Client<S> {
     /// a launch storm's thousand syscalls into a handful; flushed before any
     /// read (a response can only exist for a request the host has seen).
     wbuf: Vec<u8>,
+    /// Replay journal: every quiet request "sent" since the last response we
+    /// received (encoded payloads, send order). A VM-fork clone inherits a
+    /// transport that swallows writes without erroring — ring records land in
+    /// cloned pages no host reads, vsock writes buffer into a dead socket — so
+    /// quiet ops issued before the first blocking call are silently lost. The
+    /// host serves strictly in order, so ANY received response proves every
+    /// prior request was consumed (journal clears); on reconnect the journal
+    /// replays the unproven suffix. Bounded by MAX_DEFERRED (drain fences).
+    journal: Vec<Vec<u8>>,
 }
 
 /// Outstanding-response cap. Responses are ~8 bytes, so even the smallest
@@ -213,6 +222,7 @@ impl<S: Read + Write> Client<S> {
             sticky: 0,
             defer_enabled: std::env::var("SMOLVM_CUDA_ASYNC").as_deref() != Ok("0"),
             wbuf: Vec::new(),
+            journal: Vec::new(),
         }
     }
 
@@ -407,7 +417,11 @@ impl<S: Read + Write> Client<S> {
     fn ring_roundtrip(&mut self, frame: &[u8]) -> Result<Vec<u8>> {
         self.ring_push(frame)?;
         rtt_tax();
-        self.ring_pop_response()
+        let resp = self.ring_pop_response()?;
+        // In-order serving: this response proves every earlier request was
+        // consumed by the host — the replay journal can forget them.
+        self.journal.clear();
+        Ok(resp)
     }
 
     /// Send everything buffered by deferred calls.
@@ -429,30 +443,37 @@ impl<S: Read + Write> Client<S> {
         self.defer_enabled = on;
     }
 
-    /// Take this client's pending deferred pipeline (framed-but-unsent quiet
-    /// requests + their count + sticky status), clearing it. On a VM-fork clone
-    /// whose connection died mid-flush, these requests never reached the host —
-    /// so they must move to the reconnected client and re-flush there, or the
-    /// buffered work (e.g. torch's queued cuBLAS matmuls before a `.item()`)
-    /// would be silently dropped and the next read returns stale data.
-    pub fn take_pending(&mut self) -> (Vec<u8>, usize, i32) {
-        let sticky = self.sticky;
-        self.sticky = 0;
-        let deferred = self.deferred;
+    /// Take this client's replay journal — every quiet request not yet proven
+    /// consumed by a host response — plus the sticky status, clearing both. On
+    /// a VM-fork clone the inherited transport swallows writes without erroring
+    /// (ring records land in cloned pages no host reads; vsock writes buffer
+    /// into a dead socket), so these requests may never have reached the host:
+    /// they must replay on the reconnected client or the work (e.g. torch's
+    /// queued launches before a `.item()`) is silently dropped and later reads
+    /// return stale data. Fork points are quiescent (the golden synchronizes
+    /// before gating), so an empty journal is the common case and replay of a
+    /// host-side-executed op cannot arise there.
+    pub fn take_journal(&mut self) -> (Vec<Vec<u8>>, i32) {
+        let sticky = std::mem::take(&mut self.sticky);
         self.deferred = 0;
-        (std::mem::take(&mut self.wbuf), deferred, sticky)
+        self.wbuf.clear(); // superseded: the journal holds sent AND unsent
+        (std::mem::take(&mut self.journal), sticky)
     }
 
-    /// Adopt a pending deferred pipeline taken from a prior (dead) client. The
-    /// requests reference handles that stay valid in the shared primary context
-    /// (and are restored by the Init handoff), so re-flushing them on this fresh
-    /// connection replays exactly the not-yet-executed work.
-    pub fn restore_pending(&mut self, wbuf: Vec<u8>, deferred: usize, sticky: i32) {
-        self.wbuf = wbuf;
-        self.deferred = deferred;
+    /// Replay a journal taken from a prior (dead) client, in order, on this
+    /// fresh connection (after `init` — and ring setup, if any — so the ops
+    /// re-enter the new pipeline exactly like first-time sends and are
+    /// re-journaled for a possible second reconnect). The requests reference
+    /// handles that stay valid across the reconnect (shared primary context /
+    /// Init handoff / clone-worker translation tables).
+    pub fn replay_journal(&mut self, ops: Vec<Vec<u8>>, sticky: i32) -> Result<()> {
         if self.sticky == 0 {
             self.sticky = sticky;
         }
+        for payload in ops {
+            self.enqueue_quiet(payload)?;
+        }
+        Ok(())
     }
 
     /// Settle all fire-and-forget work with a single fence round-trip: quiet
@@ -491,6 +512,7 @@ impl<S: Read + Write> Client<S> {
         rtt_tax();
         let payload =
             read_msg(&mut self.stream)?.ok_or(CudaRpcError::Protocol("host closed mid-fence"))?;
+        self.journal.clear(); // fence response → all prior consumed
         if payload.len() >= 4 {
             let status = i32::from_le_bytes(payload[..4].try_into().unwrap());
             if status != 0 && self.sticky == 0 {
@@ -535,24 +557,33 @@ impl<S: Read + Write> Client<S> {
             }
             return Ok(());
         }
+        self.enqueue_quiet(encode_request(req))
+    }
+
+    /// Enqueue one quiet (fire-and-forget) request payload on the active
+    /// transport, journaling it for replay-on-reconnect. The journal append
+    /// comes FIRST so a payload whose transport write fails is still replayed
+    /// after the reconnect that failure triggers.
+    fn enqueue_quiet(&mut self, payload: Vec<u8>) -> Result<()> {
+        if self.deferred >= MAX_DEFERRED {
+            self.drain()?;
+        }
+        if self.sticky != 0 {
+            return Err(CudaRpcError::Cuda(std::mem::take(&mut self.sticky)));
+        }
         if self.ring.is_some() {
-            if self.deferred >= MAX_DEFERRED {
-                self.drain()?;
-            }
-            if self.sticky != 0 {
-                return Err(CudaRpcError::Cuda(std::mem::take(&mut self.sticky)));
-            }
-            let payload = encode_request(req);
             if payload.len() < crate::ring::INLINE_MAX {
                 let mut frame = Vec::with_capacity(payload.len() + 1);
                 frame.push(crate::proto::QUIET_PREFIX);
                 frame.extend_from_slice(&payload);
-                self.ring_push(&frame)?;
+                self.journal.push(payload);
                 self.deferred += 1;
+                self.ring_push(&frame)?;
             } else {
                 // Oversized quiet frames go indirect, which needs the staging
                 // buffer alive until consumption — round-trip instead and
-                // fold a failure into the sticky slot.
+                // fold a failure into the sticky slot. (Synchronous: no
+                // journal entry needed, the response itself proves delivery.)
                 let resp = self.ring_roundtrip(&payload)?;
                 if resp.len() >= 4 {
                     let st = i32::from_le_bytes(resp[..4].try_into().unwrap());
@@ -563,20 +594,14 @@ impl<S: Read + Write> Client<S> {
             }
             return Ok(());
         }
-        if self.deferred >= MAX_DEFERRED {
-            self.drain()?;
-        }
-        if self.sticky != 0 {
-            return Err(CudaRpcError::Cuda(std::mem::take(&mut self.sticky)));
-        }
         // Frame into the batch buffer as a QUIET request (no response) — one
         // write syscall per sync point (or per WBUF_FLUSH bytes), and one
         // fence reply per drain instead of one reply per request.
-        let payload = encode_request(req);
         self.wbuf
             .extend_from_slice(&((payload.len() + 1) as u32).to_le_bytes());
         self.wbuf.push(crate::proto::QUIET_PREFIX);
         self.wbuf.extend_from_slice(&payload);
+        self.journal.push(payload);
         self.deferred += 1;
         if self.wbuf.len() >= WBUF_FLUSH {
             self.flush_wbuf()?;
@@ -610,7 +635,10 @@ impl<S: Read + Write> Client<S> {
             self.flush_wbuf()?;
             write_msg(&mut self.stream, &encode_request(req))?;
             rtt_tax();
-            read_msg(&mut self.stream)?.ok_or(CudaRpcError::Protocol("host closed mid-call"))?
+            let p = read_msg(&mut self.stream)?
+                .ok_or(CudaRpcError::Protocol("host closed mid-call"))?;
+            self.journal.clear(); // response received → all prior consumed
+            p
         };
         let (status, resp) = decode_response(op, &payload)?;
         if status != 0 {
@@ -624,30 +652,6 @@ impl<S: Read + Write> Client<S> {
     /// mode (`SMOLVM_CUDA_ASYNC=0`) the request round-trips instead and a
     /// failure status is collected as this connection's sticky error.
     pub fn raw_quiet(&mut self, payload: &[u8]) -> Result<()> {
-        if self.ring.is_some() && self.defer_enabled {
-            if self.deferred >= MAX_DEFERRED {
-                self.drain()?;
-            }
-            if self.sticky != 0 {
-                return Err(CudaRpcError::Cuda(std::mem::take(&mut self.sticky)));
-            }
-            if payload.len() < crate::ring::INLINE_MAX {
-                let mut frame = Vec::with_capacity(payload.len() + 1);
-                frame.push(crate::proto::QUIET_PREFIX);
-                frame.extend_from_slice(payload);
-                self.ring_push(&frame)?;
-                self.deferred += 1;
-            } else {
-                let resp = self.ring_roundtrip(payload)?;
-                if resp.len() >= 4 {
-                    let st = i32::from_le_bytes(resp[..4].try_into().unwrap());
-                    if st != 0 && self.sticky == 0 {
-                        self.sticky = st;
-                    }
-                }
-            }
-            return Ok(());
-        }
         if !self.defer_enabled {
             let resp = self.raw_call(payload)?;
             if resp.len() >= 4 {
@@ -658,21 +662,7 @@ impl<S: Read + Write> Client<S> {
             }
             return Ok(());
         }
-        if self.deferred >= MAX_DEFERRED {
-            self.drain()?;
-        }
-        if self.sticky != 0 {
-            return Err(CudaRpcError::Cuda(std::mem::take(&mut self.sticky)));
-        }
-        self.wbuf
-            .extend_from_slice(&((payload.len() + 1) as u32).to_le_bytes());
-        self.wbuf.push(crate::proto::QUIET_PREFIX);
-        self.wbuf.extend_from_slice(payload);
-        self.deferred += 1;
-        if self.wbuf.len() >= WBUF_FLUSH {
-            self.flush_wbuf()?;
-        }
-        Ok(())
+        self.enqueue_quiet(payload.to_vec())
     }
 
     /// Serve a bridged peer: one pre-encoded synchronous round-trip. Returns
@@ -686,7 +676,9 @@ impl<S: Read + Write> Client<S> {
         self.flush_wbuf()?;
         write_msg(&mut self.stream, payload)?;
         rtt_tax();
-        read_msg(&mut self.stream)?.ok_or(CudaRpcError::Protocol("host closed mid-call"))
+        let p = read_msg(&mut self.stream)?.ok_or(CudaRpcError::Protocol("host closed mid-call"))?;
+        self.journal.clear(); // response received → all prior consumed
+        Ok(p)
     }
 
     /// Run the connect handshake, adopting `resume_token`'s (frozen) session
@@ -944,8 +936,14 @@ impl<S: Read + Write> Client<S> {
     }
 
     pub fn ctx_synchronize(&mut self) -> Result<()> {
+        // Settle fire-and-forget work first: a quiet op's failure lives in the
+        // HOST's sticky slot and only a fence reports it — and synchronize is
+        // exactly CUDA's contract point for surfacing asynchronous errors.
+        // Without this, a failed quiet launch (e.g. an inherited CUDA graph a
+        // fork clone couldn't rebuild) returns success + stale data.
+        self.drain()?;
         self.call(&Request::CtxSynchronize, Op::CtxSynchronize)?;
-        // Surface any asynchronous failure collected while draining, the way
+        // Surface any asynchronous failure collected by the drain, the way
         // cudaDeviceSynchronize reports errors from earlier async work.
         match self.take_sticky() {
             0 => Ok(()),
@@ -1070,11 +1068,15 @@ impl<S: Read + Write> Client<S> {
     }
 
     pub fn stream_synchronize(&mut self, stream: u64) -> Result<()> {
+        self.drain()?; // see ctx_synchronize: fences surface quiet failures
         self.call(
             &Request::StreamSynchronize { stream },
             Op::StreamSynchronize,
-        )
-        .map(|_| ())
+        )?;
+        match self.take_sticky() {
+            0 => Ok(()),
+            code => Err(CudaRpcError::Cuda(code)),
+        }
     }
 
     /// Raw `cuStreamQuery` code: 0 complete, 600 not ready.

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -26,6 +26,28 @@ const VHANDLE_TAG: u64 = 1 << 63;
 pub const CUDA_ERROR_NOT_FOUND: i32 = 500;
 pub const CUDA_ERROR_NOT_SUPPORTED: i32 = 801;
 
+/// M3b: one KERNEL node of a captured CUDA graph, in a portable form. `func` is
+/// the golden's `CUfunction` (re-resolved in the worker); `params` are the raw
+/// bytes of each kernel argument in declaration order (address-preserving fork
+/// keeps device pointers valid verbatim, so they are copied, not translated).
+#[derive(Clone)]
+pub struct GraphKernelNode {
+    pub func: u64,
+    pub grid: [u32; 3],
+    pub block: [u32; 3],
+    pub shared_mem: u32,
+    pub params: Vec<Vec<u8>>,
+}
+
+/// M3b: a captured CUDA graph reduced to kernel nodes + dependency edges, so a
+/// clone worker can rebuild it in its own context. `edges` are `(from, to)`
+/// indices into `nodes` (from runs before to).
+#[derive(Clone, Default)]
+pub struct GraphSer {
+    pub nodes: Vec<GraphKernelNode>,
+    pub edges: Vec<(u32, u32)>,
+}
+
 /// A CUDA Driver-API implementation. Handles returned here are the backend's
 /// own raw values (e.g. real `CUmodule` pointers); [`serve`] hides them behind
 /// opaque ids before they reach the guest.
@@ -120,6 +142,26 @@ pub trait Backend: Send {
     fn graph_destroy(&mut self, graph: u64) -> CuResult<()>;
     /// Number of nodes in a captured graph (PyTorch warns on empty graphs).
     fn graph_get_node_count(&mut self, graph: u64) -> CuResult<u64>;
+    /// M3b: introspect a captured graph into a portable, rebuildable form so a
+    /// Path-3 clone worker can reconstruct it in its OWN context (the golden's
+    /// CUgraph/CUgraphExec are context-scoped and invalid there). Returns `None`
+    /// if the graph contains any non-KERNEL node (unsupported — the caller then
+    /// keeps the golden's exec, which fails loud rather than mis-executing).
+    /// Address-preserving fork means kernel-arg bytes are captured verbatim;
+    /// only each node's `func` is golden-scoped and re-resolved in the worker.
+    fn graph_introspect(&mut self, _graph: u64) -> CuResult<Option<GraphSer>> {
+        Ok(None)
+    }
+    /// M3b: rebuild `ser` as a NEW CUDA graph in THIS context, mapping every
+    /// node's golden `func` handle through `funcs` (golden CUfunction → this
+    /// context's reloaded function). Returns the new `cudaGraph_t`.
+    fn graph_rebuild(
+        &mut self,
+        _ser: &GraphSer,
+        _funcs: &HashMap<u64, u64>,
+    ) -> CuResult<u64> {
+        Err(CUDA_ERROR_NOT_SUPPORTED)
+    }
     /// Stream-ordered memset (capture-safe; the sync form would invalidate an
     /// active capture).
     fn memset_d8_async(&mut self, dptr: u64, value: u8, bytes: u64, stream: u64) -> CuResult<()>;
@@ -618,6 +660,12 @@ struct GoldenLayout {
     streams: HashMap<u64, u32>,
     /// M3a: golden event handle → create flags (the worker recreates + remaps).
     events: HashMap<u64, u32>,
+    /// M3b: captured CUDA graphs to rebuild in a clone worker. Each entry is
+    /// `(guest virtual graph handle, guest virtual exec handle, portable graph)`,
+    /// recorded at the golden's `GraphInstantiate` under Path 3. The worker
+    /// rebuilds the graph in its own context and maps both virtual handles to
+    /// its rebuilt reals, so the clone's inherited `GraphLaunch` resolves.
+    graphs: Vec<(u64, u64, GraphSer)>,
 }
 type LayoutCell = std::sync::Mutex<GoldenLayout>;
 static DPTR_HANDOFF: std::sync::Mutex<Option<HashMap<u64, std::sync::Weak<AllocTable>>>> =
@@ -762,6 +810,7 @@ pub fn module_handoff_snapshot(
     Vec<(u64, u64, String)>,
     Vec<(u64, u32)>,
     Vec<(u64, u32)>,
+    Vec<(u64, u64, GraphSer)>,
 )> {
     let reg = LAYOUT_HANDOFF.lock().unwrap();
     let l = reg.as_ref()?.get(&token)?.upgrade()?;
@@ -774,7 +823,8 @@ pub fn module_handoff_snapshot(
         .collect();
     let streams = g.streams.iter().map(|(&h, &f)| (h, f)).collect();
     let events = g.events.iter().map(|(&h, &f)| (h, f)).collect();
-    Some((modules, funcs, streams, events))
+    let graphs = g.graphs.clone();
+    Some((modules, funcs, streams, events, graphs))
 }
 
 // M3a: per-worker (thread-local) translation of the golden's inherited raw
@@ -801,12 +851,67 @@ thread_local! {
     // the worker's context SEGFAULTS the driver (SEGV_MAPERR inside cuMemRelease).
     static VMM_TRANS: std::cell::RefCell<Option<HashMap<u64, u64>>> =
         const { std::cell::RefCell::new(None) };
+    // M3b: guest virtual graph/exec handle → THIS worker's rebuilt graph/exec.
+    // A clone forked at a graph-capture point inherits the guest's virtual
+    // handles; the golden's reals are context-scoped, so `raw_graph` remaps them
+    // to the worker's rebuilt reals here.
+    static GRAPH_TRANS: HandleMap = std::cell::RefCell::new(HashMap::new());
 }
 
 /// Install a clone worker's golden→worker VMM physical-handle map (M2). Until
 /// installed, MemMap/MemRelease pass handles through raw (daemon/golden path).
 pub fn set_vmm_trans(map: HashMap<u64, u64>) {
     VMM_TRANS.with(|m| *m.borrow_mut() = Some(map));
+}
+
+/// M3b: rebuild the golden's captured graphs in THIS worker's context and map
+/// each `(graph_vh, exec_vh)` to the rebuilt reals, so the clone's inherited
+/// `GraphLaunch` resolves. Kernel-node graphs only; a rebuild/instantiate
+/// failure is logged and skipped (that graph's launch then fails loud). Returns
+/// the number rebuilt. Call AFTER `set_handle_trans` (needs module reload) and
+/// AFTER memory reconstruction (kernel-arg pointers reference golden VAs).
+pub fn rebuild_clone_graphs(b: &mut dyn Backend, graphs: Vec<(u64, u64, GraphSer)>) -> usize {
+    let mut n = 0;
+    for (graph_vh, exec_vh, ser) in graphs {
+        // Resolve each golden CUfunction to this worker's reloaded function.
+        let mut funcs: HashMap<u64, u64> = HashMap::new();
+        for node in &ser.nodes {
+            if let std::collections::hash_map::Entry::Vacant(e) = funcs.entry(node.func) {
+                let w = xlat_func(b, node.func);
+                e.insert(w);
+            }
+        }
+        // A func that resolved to 0 (reload failed) or back to its golden handle
+        // (not in FUNC_META — e.g. cuBLAS kernels bound via the CUDA-12 library
+        // API, which we don't track) is a FOREIGN-context handle. Passing it to
+        // cuGraphAddKernelNode makes the driver dereference it -> SIGSEGV, which
+        // crash-loops the worker. Skip the whole graph instead: the clone's
+        // GraphLaunch then fails loud rather than taking down the process.
+        let unresolved = funcs.iter().filter(|(g, w)| **w == 0 || *g == *w).count();
+        if unresolved > 0 {
+            eprintln!(
+                "[graph-rebuild] skipping graph vh={graph_vh:#x}: {unresolved}/{} kernel funcs \
+                 unresolved (not in FUNC_META); leaving inherited exec in place",
+                funcs.len()
+            );
+            continue;
+        }
+        match b.graph_rebuild(&ser, &funcs) {
+            Ok(wgraph) => match b.graph_instantiate(wgraph) {
+                Ok(wexec) => {
+                    GRAPH_TRANS.with(|m| {
+                        let mut m = m.borrow_mut();
+                        m.insert(graph_vh, wgraph);
+                        m.insert(exec_vh, wexec);
+                    });
+                    n += 1;
+                }
+                Err(e) => eprintln!("[graph-rebuild] instantiate failed: e={e}"),
+            },
+            Err(e) => eprintln!("[graph-rebuild] rebuild failed: e={e}"),
+        }
+    }
+    n
 }
 
 /// Install a clone worker's golden→worker handle reconstruction. Modules are
@@ -1545,6 +1650,72 @@ fn vram_limit() -> u64 {
         .unwrap_or(u64::MAX)
 }
 
+/// Debug op trace (`SMOLVM_CUDA_OPTRACE=<path>`): appends one line per traced
+/// memory/launch op with pid + post-translation params + status, so a fork
+/// investigation can see exactly which PROCESS executed which op on which
+/// address. Off (None) unless the env var is set.
+fn optrace_summary(req: &Request) -> Option<String> {
+    static PATH: std::sync::OnceLock<Option<std::path::PathBuf>> = std::sync::OnceLock::new();
+    PATH.get_or_init(|| std::env::var_os("SMOLVM_CUDA_OPTRACE").map(Into::into))
+        .as_ref()?;
+    Some(match req {
+        Request::MemAlloc { bytes } => format!("MemAlloc bytes={bytes:#x}"),
+        Request::MemFree { dptr } => format!("MemFree dptr={dptr:#x}"),
+        Request::MemcpyHtoD { dptr, data, .. } => {
+            format!("HtoD dptr={dptr:#x} len={:#x}", data.len())
+        }
+        Request::MemcpyDtoH { dptr, bytes, .. } => format!("DtoH dptr={dptr:#x} len={bytes:#x}"),
+        Request::MemcpyShmHtoD { dptr, size, .. } => {
+            format!("ShmHtoD dptr={dptr:#x} len={size:#x}")
+        }
+        Request::MemcpyShmDtoH { dptr, size, .. } => {
+            format!("ShmDtoH dptr={dptr:#x} len={size:#x}")
+        }
+        Request::MemcpyGpaHtoD { dptr, segments, .. } => {
+            let len: u64 = segments.iter().map(|(_, l)| l).sum();
+            format!("GpaHtoD dptr={dptr:#x} len={len:#x}")
+        }
+        Request::MemcpyGpaDtoH { dptr, segments, .. } => {
+            let len: u64 = segments.iter().map(|(_, l)| l).sum();
+            format!("GpaDtoH dptr={dptr:#x} len={len:#x}")
+        }
+        Request::MemcpyDtoD { dst, src, bytes } => {
+            format!("DtoD dst={dst:#x} src={src:#x} len={bytes:#x}")
+        }
+        Request::MemcpyDtoDAsync {
+            dst, src, bytes, ..
+        } => format!("DtoDAsync dst={dst:#x} src={src:#x} len={bytes:#x}"),
+        Request::MemsetD8 { dptr, value, bytes } => {
+            format!("MemsetD8 dptr={dptr:#x} v={value} len={bytes:#x}")
+        }
+        Request::MemsetD8Async {
+            dptr, value, bytes, ..
+        } => format!("MemsetD8Async dptr={dptr:#x} v={value} len={bytes:#x}"),
+        Request::LaunchKernel {
+            function, params, ..
+        } => format!("Launch fn={function:#x} nparams={}", params.len()),
+        Request::GraphLaunch { graph_exec, .. } => format!("GraphLaunch exec={graph_exec:#x}"),
+        Request::MemAddressReserve { size, .. } => format!("VmmReserve size={size:#x}"),
+        Request::MemCreate { size, .. } => format!("VmmCreate size={size:#x}"),
+        Request::MemMap { va, size, handle, .. } => {
+            format!("VmmMap va={va:#x} size={size:#x} h={handle:#x}")
+        }
+        Request::MemSetAccess { va, size, .. } => format!("VmmAccess va={va:#x} size={size:#x}"),
+        Request::MemUnmap { va, size } => format!("VmmUnmap va={va:#x} size={size:#x}"),
+        Request::MemRelease { handle } => format!("VmmRelease h={handle:#x}"),
+        _ => return None,
+    })
+}
+
+fn optrace_write(line: &str, status: i32) {
+    if let Some(p) = std::env::var_os("SMOLVM_CUDA_OPTRACE") {
+        use std::io::Write as _;
+        if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(p) {
+            let _ = writeln!(f, "pid={} {line} st={status}", std::process::id());
+        }
+    }
+}
+
 fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Response) {
     // P0 transport-viability: count every RPC; optionally inject per-call latency
     // to model network RTT, and periodically log the count vs wall-clock so
@@ -1597,16 +1768,23 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
     }
     fn raw_graph(sess: &Session, h: u64) -> u64 {
         // Virtual graph/exec handle → real; untagged values pass through.
-        if h & VHANDLE_TAG != 0 {
-            sess.graph_vhandles
-                .lock()
-                .unwrap()
-                .get(&h)
-                .copied()
-                .unwrap_or(0)
-        } else {
-            h
+        if h & VHANDLE_TAG == 0 {
+            return h;
         }
+        // M3b (Path 3): a clone worker rebuilds inherited graphs in ITS OWN
+        // context; GRAPH_TRANS holds those worker-local reals. It must win over
+        // the session map, which — via the handoff registry — still carries the
+        // GOLDEN's real handles for the same virtual handle (a foreign-context
+        // exec that silently no-ops or faults if launched here).
+        if let Some(r) = GRAPH_TRANS.with(|m| m.borrow().get(&h).copied()) {
+            return r;
+        }
+        sess.graph_vhandles
+            .lock()
+            .unwrap()
+            .get(&h)
+            .copied()
+            .unwrap_or(0)
     }
     fn raw_event(sess: &Session, event: u64) -> CuResult<u64> {
         // Same raw-on-the-wire convention as streams.
@@ -1619,6 +1797,7 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
     // unless this is an isolating clone).
     cow_written(sess, b, &req);
     let req = translate_dptrs(&sess.dptr_trans, req);
+    let trace = optrace_summary(&req);
     let r: CuResult<Response> = (|| match req {
         Request::Init {
             proto_hash,
@@ -1936,6 +2115,20 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             exec_template_register(e, real_graph); // for Path 2 clone re-instantiation
             if fork_isolate_enabled() {
                 template_graph_mark(real_graph); // keep it alive for clones
+            }
+            // M3b (Path 3): record the graph in portable form so a clone worker
+            // can rebuild it in its own context (the golden's CUgraph/exec are
+            // context-scoped). Only kernel-node graphs serialize; anything else
+            // returns None and simply isn't recorded (the clone then fails loud
+            // on launch rather than mis-executing an unsupported graph).
+            if path3_enabled() {
+                if let Ok(Some(ser)) = b.graph_introspect(real_graph) {
+                    sess.golden_layout
+                        .lock()
+                        .unwrap()
+                        .graphs
+                        .push((graph, exec_vh, ser));
+                }
             }
             if exec_vh & VHANDLE_TAG != 0 {
                 sess.graph_vhandles.lock().unwrap().insert(exec_vh, e);
@@ -2358,10 +2551,14 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             .mem_get_allocation_granularity(device, flags)
             .map(Response::Bytes),
     })();
-    match r {
+    let (status, resp) = match r {
         Ok(resp) => (0, resp),
         Err(code) => (code, Response::Ok),
+    };
+    if let Some(line) = trace {
+        optrace_write(&line, status);
     }
+    (status, resp)
 }
 
 // ===========================================================================

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -155,11 +155,7 @@ pub trait Backend: Send {
     /// M3b: rebuild `ser` as a NEW CUDA graph in THIS context, mapping every
     /// node's golden `func` handle through `funcs` (golden CUfunction → this
     /// context's reloaded function). Returns the new `cudaGraph_t`.
-    fn graph_rebuild(
-        &mut self,
-        _ser: &GraphSer,
-        _funcs: &HashMap<u64, u64>,
-    ) -> CuResult<u64> {
+    fn graph_rebuild(&mut self, _ser: &GraphSer, _funcs: &HashMap<u64, u64>) -> CuResult<u64> {
         Err(CUDA_ERROR_NOT_SUPPORTED)
     }
     /// Stream-ordered memset (capture-safe; the sync form would invalidate an
@@ -1697,7 +1693,9 @@ fn optrace_summary(req: &Request) -> Option<String> {
         Request::GraphLaunch { graph_exec, .. } => format!("GraphLaunch exec={graph_exec:#x}"),
         Request::MemAddressReserve { size, .. } => format!("VmmReserve size={size:#x}"),
         Request::MemCreate { size, .. } => format!("VmmCreate size={size:#x}"),
-        Request::MemMap { va, size, handle, .. } => {
+        Request::MemMap {
+            va, size, handle, ..
+        } => {
             format!("VmmMap va={va:#x} size={size:#x} h={handle:#x}")
         }
         Request::MemSetAccess { va, size, .. } => format!("VmmAccess va={va:#x} size={size:#x}"),
@@ -1710,7 +1708,11 @@ fn optrace_summary(req: &Request) -> Option<String> {
 fn optrace_write(line: &str, status: i32) {
     if let Some(p) = std::env::var_os("SMOLVM_CUDA_OPTRACE") {
         use std::io::Write as _;
-        if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(p) {
+        if let Ok(mut f) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(p)
+        {
             let _ = writeln!(f, "pid={} {line} st={status}", std::process::id());
         }
     }

--- a/crates/smolvm-cuda/src/host/gpu.rs
+++ b/crates/smolvm-cuda/src/host/gpu.rs
@@ -98,6 +98,24 @@ pub struct GpuBackend {
     graph_destroy: unsafe extern "C" fn(*mut c_void) -> CuResultCode,
     graph_get_nodes:
         unsafe extern "C" fn(*mut c_void, *mut *mut c_void, *mut usize) -> CuResultCode,
+    // M3b: graph rebuild in a fresh context (Path 3) — create + add kernel nodes
+    // + wire dependencies, then instantiate.
+    graph_create: unsafe extern "C" fn(*mut *mut c_void, c_uint) -> CuResultCode,
+    graph_add_kernel_node: unsafe extern "C" fn(
+        *mut *mut c_void,       // out node
+        *mut c_void,            // graph
+        *const *mut c_void,     // deps
+        usize,                  // numDeps
+        *const KernelNodeParams,
+    ) -> CuResultCode,
+    graph_node_get_dependencies:
+        unsafe extern "C" fn(*mut c_void, *mut *mut c_void, *mut usize) -> CuResultCode,
+    graph_add_dependencies: unsafe extern "C" fn(
+        *mut c_void,        // graph
+        *const *mut c_void, // from[]
+        *const *mut c_void, // to[]
+        usize,              // count
+    ) -> CuResultCode,
     // Graph-node introspection + exec node-param setters — used to patch a fork
     // clone's inherited cudagraph so its baked-in device pointers hit the clone's
     // private copies (Path 2 of the fork-isolation design).
@@ -413,6 +431,10 @@ impl GpuBackend {
                 graph_exec_destroy: sym(&lib, b"cuGraphExecDestroy\0")?,
                 graph_destroy: sym(&lib, b"cuGraphDestroy\0")?,
                 graph_get_nodes: sym(&lib, b"cuGraphGetNodes\0")?,
+                graph_create: sym(&lib, b"cuGraphCreate\0")?,
+                graph_add_kernel_node: sym(&lib, b"cuGraphAddKernelNode_v2\0")?,
+                graph_node_get_dependencies: sym(&lib, b"cuGraphNodeGetDependencies\0")?,
+                graph_add_dependencies: sym(&lib, b"cuGraphAddDependencies\0")?,
                 graph_node_get_type: sym(&lib, b"cuGraphNodeGetType\0")?,
                 graph_kernel_node_get_params: sym(&lib, b"cuGraphKernelNodeGetParams_v2\0")?,
                 graph_exec_kernel_node_set_params: sym(
@@ -1262,6 +1284,176 @@ impl Backend for GpuBackend {
             ))?
         };
         Ok(n as u64)
+    }
+    fn graph_introspect(&mut self, graph: u64) -> CuResult<Option<super::GraphSer>> {
+        // Enumerate the golden graph's nodes.
+        let mut count: usize = 0;
+        unsafe {
+            chk((self.graph_get_nodes)(
+                graph as *mut c_void,
+                std::ptr::null_mut(),
+                &mut count,
+            ))?
+        };
+        if count == 0 {
+            // A working captured graph that reports zero nodes is OPAQUE, not
+            // empty — torch.compile(reduce-overhead)'s cudagraph trees hide
+            // their kernels from cuGraphGetNodes. Rebuilding it would produce a
+            // genuinely empty graph whose replay silently returns wrong data
+            // (stale/zero outputs); skipping keeps the inherited exec, which
+            // fails loud in the clone instead.
+            return Ok(None);
+        }
+        let mut nodes: Vec<*mut c_void> = vec![std::ptr::null_mut(); count];
+        unsafe {
+            chk((self.graph_get_nodes)(
+                graph as *mut c_void,
+                nodes.as_mut_ptr(),
+                &mut count,
+            ))?
+        };
+        // Node pointer -> index, for turning dependency edges into indices.
+        let idx: std::collections::HashMap<usize, u32> = nodes
+            .iter()
+            .take(count)
+            .enumerate()
+            .map(|(i, &n)| (n as usize, i as u32))
+            .collect();
+        let mut out = super::GraphSer::default();
+        for &node in nodes.iter().take(count) {
+            let mut ty: c_int = -1;
+            unsafe { chk((self.graph_node_get_type)(node, &mut ty))? };
+            if ty != 0 {
+                // Non-KERNEL node (memcpy/memset/child-graph/event/...). Rebuild
+                // isn't implemented for these yet; bail so the caller keeps the
+                // golden's exec (which fails loud) rather than a wrong graph.
+                return Ok(None);
+            }
+            let mut kp: KernelNodeParams = unsafe { std::mem::zeroed() };
+            unsafe { chk((self.graph_kernel_node_get_params)(node, &mut kp))? };
+            if kp.kernel_params.is_null() {
+                // Args packed via `extra` — opaque, can't serialize. Bail.
+                return Ok(None);
+            }
+            let sizes = self.func_get_param_info(kp.func as u64)?;
+            let mut params: Vec<Vec<u8>> = Vec::with_capacity(sizes.len());
+            for (i, &sz) in sizes.iter().enumerate() {
+                let sz = sz as usize;
+                let argptr = unsafe { *kp.kernel_params.add(i) } as *const u8;
+                if argptr.is_null() || sz == 0 {
+                    params.push(Vec::new());
+                    continue;
+                }
+                let mut v = vec![0u8; sz];
+                unsafe { std::ptr::copy_nonoverlapping(argptr, v.as_mut_ptr(), sz) };
+                params.push(v);
+            }
+            out.nodes.push(super::GraphKernelNode {
+                func: kp.func as u64,
+                grid: [kp.grid_x, kp.grid_y, kp.grid_z],
+                block: [kp.block_x, kp.block_y, kp.block_z],
+                shared_mem: kp.shared_mem_bytes,
+                params,
+            });
+        }
+        // Dependency edges: for each node, its predecessors -> (pred, node).
+        for (&node, to) in nodes.iter().take(count).zip(0u32..) {
+            let mut dn: usize = 0;
+            unsafe {
+                chk((self.graph_node_get_dependencies)(
+                    node,
+                    std::ptr::null_mut(),
+                    &mut dn,
+                ))?
+            };
+            if dn == 0 {
+                continue;
+            }
+            let mut deps: Vec<*mut c_void> = vec![std::ptr::null_mut(); dn];
+            unsafe {
+                chk((self.graph_node_get_dependencies)(
+                    node,
+                    deps.as_mut_ptr(),
+                    &mut dn,
+                ))?
+            };
+            for &d in deps.iter().take(dn) {
+                if let Some(&from) = idx.get(&(d as usize)) {
+                    out.edges.push((from, to));
+                }
+            }
+        }
+        Ok(Some(out))
+    }
+    fn graph_rebuild(
+        &mut self,
+        ser: &super::GraphSer,
+        funcs: &std::collections::HashMap<u64, u64>,
+    ) -> CuResult<u64> {
+        let mut graph: *mut c_void = std::ptr::null_mut();
+        unsafe { chk((self.graph_create)(&mut graph, 0))? };
+        let mut new_nodes: Vec<*mut c_void> = Vec::with_capacity(ser.nodes.len());
+        for n in &ser.nodes {
+            // Keep each arg's bytes alive for the add call; kernel_params points
+            // at them. Addresses are preserved across the fork, so the bytes
+            // (which may embed device pointers) are used verbatim.
+            let bufs = n.params.clone();
+            let mut argp: Vec<*mut c_void> = bufs
+                .iter()
+                .map(|b| {
+                    if b.is_empty() {
+                        std::ptr::null_mut()
+                    } else {
+                        b.as_ptr() as *mut c_void
+                    }
+                })
+                .collect();
+            let func = funcs.get(&n.func).copied().unwrap_or(n.func);
+            let kp = KernelNodeParams {
+                func: func as *mut c_void,
+                grid_x: n.grid[0],
+                grid_y: n.grid[1],
+                grid_z: n.grid[2],
+                block_x: n.block[0],
+                block_y: n.block[1],
+                block_z: n.block[2],
+                shared_mem_bytes: n.shared_mem,
+                kernel_params: if argp.is_empty() {
+                    std::ptr::null_mut()
+                } else {
+                    argp.as_mut_ptr()
+                },
+                extra: std::ptr::null_mut(),
+                kern: std::ptr::null_mut(),
+                ctx: std::ptr::null_mut(),
+            };
+            let mut node: *mut c_void = std::ptr::null_mut();
+            unsafe {
+                chk((self.graph_add_kernel_node)(
+                    &mut node,
+                    graph,
+                    std::ptr::null(),
+                    0,
+                    &kp,
+                ))?
+            };
+            new_nodes.push(node);
+        }
+        if !ser.edges.is_empty() {
+            let from: Vec<*mut c_void> =
+                ser.edges.iter().map(|&(f, _)| new_nodes[f as usize]).collect();
+            let to: Vec<*mut c_void> =
+                ser.edges.iter().map(|&(_, t)| new_nodes[t as usize]).collect();
+            unsafe {
+                chk((self.graph_add_dependencies)(
+                    graph,
+                    from.as_ptr(),
+                    to.as_ptr(),
+                    from.len(),
+                ))?
+            };
+        }
+        Ok(graph as u64)
     }
     fn memset_d8_async(&mut self, dptr: u64, value: u8, bytes: u64, stream: u64) -> CuResult<()> {
         unsafe {

--- a/crates/smolvm-cuda/src/host/gpu.rs
+++ b/crates/smolvm-cuda/src/host/gpu.rs
@@ -102,10 +102,10 @@ pub struct GpuBackend {
     // + wire dependencies, then instantiate.
     graph_create: unsafe extern "C" fn(*mut *mut c_void, c_uint) -> CuResultCode,
     graph_add_kernel_node: unsafe extern "C" fn(
-        *mut *mut c_void,       // out node
-        *mut c_void,            // graph
-        *const *mut c_void,     // deps
-        usize,                  // numDeps
+        *mut *mut c_void,   // out node
+        *mut c_void,        // graph
+        *const *mut c_void, // deps
+        usize,              // numDeps
         *const KernelNodeParams,
     ) -> CuResultCode,
     graph_node_get_dependencies:
@@ -1440,10 +1440,16 @@ impl Backend for GpuBackend {
             new_nodes.push(node);
         }
         if !ser.edges.is_empty() {
-            let from: Vec<*mut c_void> =
-                ser.edges.iter().map(|&(f, _)| new_nodes[f as usize]).collect();
-            let to: Vec<*mut c_void> =
-                ser.edges.iter().map(|&(_, t)| new_nodes[t as usize]).collect();
+            let from: Vec<*mut c_void> = ser
+                .edges
+                .iter()
+                .map(|&(f, _)| new_nodes[f as usize])
+                .collect();
+            let to: Vec<*mut c_void> = ser
+                .edges
+                .iter()
+                .map(|&(_, t)| new_nodes[t as usize])
+                .collect();
             unsafe {
                 chk((self.graph_add_dependencies)(
                     graph,

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -536,12 +536,21 @@ fn with_client<T>(
                         st.conn_token
                     );
                 }
-                // Carry the not-yet-sent deferred pipeline across the reconnect
-                // so buffered quiet ops (e.g. torch's queued matmuls) replay on
-                // the fresh connection instead of being dropped.
-                let (wbuf, deferred, sticky) = st.client.take_pending();
+                // Carry every quiet op not yet PROVEN consumed (no host response
+                // received since it was sent) across the reconnect. A fork
+                // clone's inherited transport swallows writes without erroring —
+                // ring records go into cloned pages no host reads — so ops
+                // "sent" pre-reconnect (e.g. torch's queued launches before the
+                // first sync) would otherwise be silently lost, leaving reads
+                // stale and compute wrong.
+                let (journal, sticky) = st.client.take_journal();
                 let (mut client, token, fd) = bring_up_client(st.conn_token)?;
-                client.restore_pending(wbuf, deferred, sticky);
+                if let Err(e) = client.replay_journal(journal, sticky) {
+                    if std::env::var_os("SHIM_TRACE").is_some() {
+                        eprintln!("[shim] journal replay failed: {e:?}");
+                    }
+                    return Err(map_err(e));
+                }
                 st.client = client;
                 st.conn_token = token;
                 st.conn_pid = pid;

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -632,7 +632,11 @@ fn reconstruct_golden_modules(
                 let t = ru32!();
                 edges.push((f, t));
             }
-            graphs.push((graph_vh, exec_vh, smolvm_cuda::host::GraphSer { nodes, edges }));
+            graphs.push((
+                graph_vh,
+                exec_vh,
+                smolvm_cuda::host::GraphSer { nodes, edges },
+            ));
         }
     }
     tracing::info!(

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -281,21 +281,29 @@ pub fn run_clone_worker(fd: std::os::unix::io::RawFd) -> io::Result<()> {
     // + recreate streams/events, then install the translation so the clone's
     // inherited kernel launches resolve (each module reloads on first use).
     if let Ok(modpath) = std::env::var("SMOLVM_CUDA_CLONE_MODULES") {
-        let (mod_images, func_meta, streams, events) =
+        let (mod_images, func_meta, streams, events, graphs) =
             reconstruct_golden_modules(backend.as_mut(), &modpath);
-        let (nm, nf, ns, ne) = (
+        let (nm, nf, ns, ne, ng) = (
             mod_images.len(),
             func_meta.len(),
             streams.len(),
             events.len(),
+            graphs.len(),
         );
         smolvm_cuda::host::set_handle_trans(mod_images, func_meta, streams, events);
+        // M3b: rebuild the golden's captured CUDA graphs in THIS context, now
+        // that modules can lazily reload and memory is reconstructed (kernel-arg
+        // pointers reference the golden VAs, valid here). Maps the clone's
+        // inherited graph/exec handles to the worker's rebuilt reals.
+        let nrebuilt = smolvm_cuda::host::rebuild_clone_graphs(backend.as_mut(), graphs);
         let _ = std::fs::remove_file(&modpath);
         tracing::info!(
             modules = nm,
             functions = nf,
             streams = ns,
             events = ne,
+            graphs = ng,
+            graphs_rebuilt = nrebuilt,
             "cuda clone-worker: staged modules for lazy reload + remapped handles"
         );
     }
@@ -512,19 +520,21 @@ fn reconstruct_golden_modules(
     Vec<(u64, u64, String)>,
     Vec<(u64, u64)>,
     Vec<(u64, u64)>,
+    Vec<(u64, u64, smolvm_cuda::host::GraphSer)>,
 ) {
     let mut mod_images = Vec::new();
     let mut func_meta = Vec::new();
     let mut stream_trans = Vec::new();
     let mut event_trans = Vec::new();
+    let mut graphs: Vec<(u64, u64, smolvm_cuda::host::GraphSer)> = Vec::new();
     let Ok(buf) = std::fs::read(path) else {
-        return (mod_images, func_meta, stream_trans, event_trans);
+        return (mod_images, func_meta, stream_trans, event_trans, graphs);
     };
     let mut p = 0usize;
     macro_rules! need {
         ($n:expr) => {
             if p + $n > buf.len() {
-                return (mod_images, func_meta, stream_trans, event_trans);
+                return (mod_images, func_meta, stream_trans, event_trans, graphs);
             }
         };
     }
@@ -584,16 +594,58 @@ fn reconstruct_golden_modules(
             Err(e) => tracing::warn!(e, "M3a: event recreate failed"),
         }
     }
+    // M3b: parse captured graphs (rebuilt later, after set_handle_trans). Absent
+    // in older blobs → the `p < buf.len()` guard leaves `graphs` empty.
+    if p < buf.len() {
+        let ngraphs = ru32!();
+        for _ in 0..ngraphs {
+            let graph_vh = ru64!();
+            let exec_vh = ru64!();
+            let nnodes = ru32!();
+            let mut nodes = Vec::with_capacity(nnodes as usize);
+            for _ in 0..nnodes {
+                let func = ru64!();
+                let mut d = [0u32; 7];
+                for v in d.iter_mut() {
+                    *v = ru32!();
+                }
+                let nparams = ru32!();
+                let mut params = Vec::with_capacity(nparams as usize);
+                for _ in 0..nparams {
+                    let plen = ru32!() as usize;
+                    need!(plen);
+                    params.push(buf[p..p + plen].to_vec());
+                    p += plen;
+                }
+                nodes.push(smolvm_cuda::host::GraphKernelNode {
+                    func,
+                    grid: [d[0], d[1], d[2]],
+                    block: [d[3], d[4], d[5]],
+                    shared_mem: d[6],
+                    params,
+                });
+            }
+            let nedges = ru32!();
+            let mut edges = Vec::with_capacity(nedges as usize);
+            for _ in 0..nedges {
+                let f = ru32!();
+                let t = ru32!();
+                edges.push((f, t));
+            }
+            graphs.push((graph_vh, exec_vh, smolvm_cuda::host::GraphSer { nodes, edges }));
+        }
+    }
     tracing::info!(
         nmods,
         nfuncs,
         nstreams,
         nevents,
+        ngraphs = graphs.len(),
         streams = stream_trans.len(),
         events = event_trans.len(),
         "M3a: staged golden modules/functions for lazy reload + recreated streams/events"
     );
-    (mod_images, func_meta, stream_trans, event_trans)
+    (mod_images, func_meta, stream_trans, event_trans, graphs)
 }
 
 /// Path 3 (M1): peek a just-accepted connection's first message; true iff it's an
@@ -722,7 +774,7 @@ fn spawn_clone_worker(conn_fd: std::os::unix::io::RawFd, token: u64) -> io::Resu
     // M3a: serialize the golden's modules (images) + functions to a temp file for
     // the worker to reload + remap. Images are MB-scale, so a file, not env.
     let mut modpath: Option<String> = None;
-    if let Some((modules, funcs, streams, events)) =
+    if let Some((modules, funcs, streams, events, graphs)) =
         smolvm_cuda::host::module_handoff_snapshot(token)
     {
         tracing::info!(
@@ -730,6 +782,7 @@ fn spawn_clone_worker(conn_fd: std::os::unix::io::RawFd, token: u64) -> io::Resu
             funcs = funcs.len(),
             streams = streams.len(),
             events = events.len(),
+            graphs = graphs.len(),
             "M3a: gathered golden modules/functions/streams/events"
         );
         let mut blob = Vec::new();
@@ -756,6 +809,33 @@ fn spawn_clone_worker(conn_fd: std::os::unix::io::RawFd, token: u64) -> io::Resu
         for (h, flags) in &events {
             blob.extend_from_slice(&h.to_le_bytes());
             blob.extend_from_slice(&flags.to_le_bytes());
+        }
+        // M3b: captured graphs. Per graph: [u64 graph_vh][u64 exec_vh]
+        //   [u32 nnodes]([u64 func][u32*3 grid][u32*3 block][u32 shmem]
+        //                [u32 nparams]([u32 len][bytes])* )*
+        //   [u32 nedges]([u32 from][u32 to])*
+        blob.extend_from_slice(&(graphs.len() as u32).to_le_bytes());
+        for (graph_vh, exec_vh, g) in &graphs {
+            blob.extend_from_slice(&graph_vh.to_le_bytes());
+            blob.extend_from_slice(&exec_vh.to_le_bytes());
+            blob.extend_from_slice(&(g.nodes.len() as u32).to_le_bytes());
+            for nd in &g.nodes {
+                blob.extend_from_slice(&nd.func.to_le_bytes());
+                for x in nd.grid.iter().chain(nd.block.iter()) {
+                    blob.extend_from_slice(&x.to_le_bytes());
+                }
+                blob.extend_from_slice(&nd.shared_mem.to_le_bytes());
+                blob.extend_from_slice(&(nd.params.len() as u32).to_le_bytes());
+                for p in &nd.params {
+                    blob.extend_from_slice(&(p.len() as u32).to_le_bytes());
+                    blob.extend_from_slice(p);
+                }
+            }
+            blob.extend_from_slice(&(g.edges.len() as u32).to_le_bytes());
+            for &(f, t) in &g.edges {
+                blob.extend_from_slice(&f.to_le_bytes());
+                blob.extend_from_slice(&t.to_le_bytes());
+            }
         }
         let _ = std::fs::create_dir_all("/tmp/smolvm");
         // Unique per SPAWN, not per (token, conn_fd): fd numbers are reused as


### PR DESCRIPTION
Fork clones lost fire-and-forget CUDA ops issued before their first blocking call (silently wrong compute); the client now journals and replays them on reconnect, synchronize surfaces async failures, and clone workers rebuild the golden's captured CUDA graphs in their own context so graph replay survives the fork (unrebuildable graphs fail loud instead of silently wrong).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/smol-machines/smolvm/pull/659">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->