### PR TITLE
Gate engine PRs on compiling the smol CLI and script the release cut

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,11 +329,86 @@ jobs:
           file target/aarch64-unknown-linux-musl/release/smolvm-agent
 
   # ==========================================================================
+  # Downstream compatibility: the smol CLI builds this workspace via path deps
+  # (`smolvm = { path = ".." }`) and releases in version lockstep, so an engine
+  # API change that breaks smol otherwise surfaces only at release time (as
+  # with the LaunchConfig `published_sockets` field). Compile smol's main
+  # against this PR so the break fails HERE, before merge.
+  # ==========================================================================
+  smol-compat:
+    name: smol CLI compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          lfs: false
+
+      - name: Checkout smol (main) into the monorepo
+        uses: actions/checkout@v6
+        with:
+          repository: smol-machines/smol
+          path: smol
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: smol-compat-${{ hashFiles('smol/Cargo.lock') }}
+          restore-keys: smol-compat-
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libssl-dev pkg-config
+
+      # Same linking stub the Linux job uses — smol only needs to COMPILE
+      # against this engine tree, not boot VMs.
+      - name: Create libkrun stub for linking
+        run: |
+          cat > /tmp/libkrun_stub.c << 'EOF'
+          int krun_create_ctx() { return -1; }
+          int krun_free_ctx(int ctx) { return 0; }
+          int krun_set_vm_config(int ctx, int cpus, int mem) { return -1; }
+          int krun_set_root(int ctx, const char* path) { return -1; }
+          int krun_set_workdir(int ctx, const char* path) { return -1; }
+          int krun_set_exec(int ctx, const char* path, char** argv, char** env) { return -1; }
+          int krun_start_enter(int ctx) { return -1; }
+          int krun_set_log_level(int level) { return 0; }
+          int krun_add_disk2(int ctx, const char* id, const char* path, int flags, int ro) { return -1; }
+          int krun_set_port_map(int ctx, char** map) { return -1; }
+          int krun_add_vsock_port(int ctx, int port, const char* path) { return -1; }
+          int krun_add_vsock_port2(int ctx, int port, const char* path, int flags) { return -1; }
+          int krun_disable_implicit_vsock(int ctx) { return -1; }
+          int krun_add_vsock(int ctx, int tsi_features) { return -1; }
+          int krun_set_passt_fd(int ctx, int fd) { return -1; }
+          int krun_add_virtiofs(int ctx, const char* tag, const char* path) { return -1; }
+          int krun_add_virtiofs2(int ctx, const char* tag, const char* path, int flags) { return -1; }
+          int krun_set_console_output(int ctx, const char* path) { return -1; }
+          int krun_add_virtio_console_default(int ctx) { return -1; }
+          EOF
+          gcc -shared -fPIC -o /tmp/libkrun.so /tmp/libkrun_stub.c
+          sudo cp /tmp/libkrun.so /usr/local/lib/
+          sudo ldconfig
+
+      - name: Compile smol against this engine tree
+        working-directory: smol
+        run: cargo check --bin smol
+        env:
+          LIBRARY_PATH: /usr/local/lib
+          LIBKRUN_BUNDLE: /usr/local/lib
+
+  # ==========================================================================
   # Summary job for branch protection
   # ==========================================================================
   ci-success:
     name: CI Success
-    needs: [fmt, macos, linux, windows, agent]
+    needs: [fmt, macos, linux, windows, agent, smol-compat]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -343,7 +418,8 @@ jobs:
              [[ "${{ needs.macos.result }}" != "success" ]] || \
              [[ "${{ needs.linux.result }}" != "success" ]] || \
              [[ "${{ needs.windows.result }}" != "success" ]] || \
-             [[ "${{ needs.agent.result }}" != "success" ]]; then
+             [[ "${{ needs.agent.result }}" != "success" ]] || \
+             [[ "${{ needs.smol-compat.result }}" != "success" ]]; then
             echo "One or more jobs failed"
             exit 1
           fi

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Cut a smolvm engine release: bump every workspace crate + nix to VERSION on a
+# fresh branch off origin/main, tag vVERSION, and push — which triggers the
+# Release (platform tarballs) and crates.io publish workflows.
+#
+# Why a script: version bumps live only on release branches (main stays at the
+# last baseline), so every manual cut re-derives "what version is main at?" by
+# hand — get it wrong and the bump silently misses files, or worse, the branch
+# is cut from a stale local main and reverts merged work. This automates the
+# exact sequence, always from a freshly-fetched origin/main.
+#
+# Usage: ./scripts/cut-release.sh 1.7.0
+set -euo pipefail
+
+VERSION="${1:?usage: cut-release.sh X.Y.Z}"
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "error: '$VERSION' is not X.Y.Z" >&2; exit 1; }
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+git fetch origin main --tags
+if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+  echo "error: tag v$VERSION already exists" >&2; exit 1
+fi
+
+BRANCH="release-v$VERSION"
+WT="$(mktemp -d)/smolvm-rel-$VERSION"
+git worktree add -b "$BRANCH" "$WT" origin/main
+trap 'git worktree remove "$WT" --force 2>/dev/null || true' EXIT
+cd "$WT"
+
+# The current baseline is whatever the workspace package declares on main.
+BASE="$(grep -m1 '^version = ' Cargo.toml | sed -E 's/version = "(.*)"/\1/')"
+echo ">>> bumping workspace $BASE -> $VERSION"
+
+# Bump the first-package version line in every OUR-crate manifest, plus every
+# internal dep spec in the root manifest, plus the nix flake. Third-party
+# vendored crates (different versions) are untouched by construction: only
+# exact "$BASE" strings are rewritten.
+for f in Cargo.toml crates/*/Cargo.toml; do
+  perl -i -pe "s/^version = \"\Q$BASE\E\"/version = \"$VERSION\"/" "$f"
+done
+perl -i -pe "s/version = \"\Q$BASE\E\"/version = \"$VERSION\"/g" Cargo.toml nix/smolvm.nix
+
+if grep -rn "^version = \"$BASE\"" Cargo.toml crates/*/Cargo.toml >/dev/null 2>&1; then
+  echo "error: some manifests still at $BASE after bump:" >&2
+  grep -rn "^version = \"$BASE\"" Cargo.toml crates/*/Cargo.toml >&2
+  exit 1
+fi
+
+cargo update -w
+cargo metadata --no-deps --format-version 1 >/dev/null
+
+git add -A
+git commit -m "Bump the workspace to $VERSION"
+git tag -a "v$VERSION" -m "smolvm v$VERSION"
+git push -u origin "$BRANCH"
+git push origin "v$VERSION"
+
+echo ">>> v$VERSION tagged and pushed. Watch the Release + crates workflows:"
+echo "    gh run list --repo smol-machines/smolvm --limit 4"


### PR DESCRIPTION
Two guardrails against version skew. CI gains a smol-compat job that compiles the smol CLI's main against every engine PR (using the same libkrun linking stub as the Linux job), so an engine API change that breaks smol fails before merge instead of at release time. scripts/cut-release.sh codifies the release cut — fresh branch off a freshly-fetched origin/main, baseline-derived version bump across every workspace manifest plus nix, lockfile sync, tag, push — so a cut can't silently start from a stale base or miss files.