### PR TITLE
Route fork clones to workers by an explicit connection preamble so a golden's reconnect can never be misrouted

### DIFF
--- a/crates/smolvm-cuda/examples/m1_route_probe.rs
+++ b/crates/smolvm-cuda/examples/m1_route_probe.rs
@@ -31,7 +31,14 @@ fn main() {
     let sock = std::env::args()
         .nth(1)
         .expect("usage: m1_route_probe <daemon.sock>");
-    let stream = UnixStream::connect(&sock).expect("connect daemon");
+    let mut stream = UnixStream::connect(&sock).expect("connect daemon");
+    // Identify as a fork clone (proxy preamble): magic + clone id.
+    {
+        use std::io::Write as _;
+        let mut p = smolvm_cuda::proto::CLONE_PREAMBLE_MAGIC.to_vec();
+        p.extend_from_slice(&u64::from(std::process::id()).to_le_bytes());
+        stream.write_all(&p).expect("clone preamble");
+    }
     let mut cu = Client::new(stream);
     let token = cu.init(1).expect("init (isolating clone, resume_token=1)");
     eprintln!("m1_route_probe: connected as isolating clone; server token={token}");

--- a/crates/smolvm-cuda/examples/m2_reconstruct_probe.rs
+++ b/crates/smolvm-cuda/examples/m2_reconstruct_probe.rs
@@ -66,7 +66,15 @@ fn main() {
             let s = std::fs::read_to_string(state).expect("read state");
             let p: Vec<u64> = s.split_whitespace().map(|x| x.parse().unwrap()).collect();
             let (token, va, size) = (p[0], p[1], p[2]);
-            let mut cu = Client::new(UnixStream::connect(sock).expect("connect"));
+            let mut conn = UnixStream::connect(sock).expect("connect");
+            // Identify as a fork clone (proxy preamble): magic + clone id.
+            {
+                use std::io::Write as _;
+                let mut p = smolvm_cuda::proto::CLONE_PREAMBLE_MAGIC.to_vec();
+                p.extend_from_slice(&u64::from(std::process::id()).to_le_bytes());
+                conn.write_all(&p).expect("clone preamble");
+            }
+            let mut cu = Client::new(conn);
             let t = cu.init(token).expect("init clone");
             cu.primary_ctx_retain(0).expect("ctx");
             eprintln!("clone: resumed token={token} (server={t}); golden VA {va:#x}");

--- a/crates/smolvm-cuda/examples/m3a_probe.rs
+++ b/crates/smolvm-cuda/examples/m3a_probe.rs
@@ -81,7 +81,15 @@ fn main() {
             let s = std::fs::read_to_string(state).unwrap();
             let p: Vec<u64> = s.split_whitespace().map(|x| x.parse().unwrap()).collect();
             let (token, va_a, va_b, va_c, func) = (p[0], p[1], p[2], p[3], p[4]);
-            let mut cu = Client::new(UnixStream::connect(sock).expect("connect"));
+            let mut conn = UnixStream::connect(sock).expect("connect");
+            // Identify as a fork clone (proxy preamble): magic + clone id.
+            {
+                use std::io::Write as _;
+                let mut p = smolvm_cuda::proto::CLONE_PREAMBLE_MAGIC.to_vec();
+                p.extend_from_slice(&u64::from(std::process::id()).to_le_bytes());
+                conn.write_all(&p).expect("clone preamble");
+            }
+            let mut cu = Client::new(conn);
             cu.init(token).expect("init clone");
             cu.primary_ctx_retain(0).expect("ctx");
             // diagnostic: does the clone see the golden's a/b at their VAs?

--- a/crates/smolvm-cuda/examples/m3a_stream_probe.rs
+++ b/crates/smolvm-cuda/examples/m3a_stream_probe.rs
@@ -85,7 +85,15 @@ fn main() {
             let p: Vec<u64> = s.split_whitespace().map(|x| x.parse().unwrap()).collect();
             let (token, va_a, va_b, va_c, func, stream, event) =
                 (p[0], p[1], p[2], p[3], p[4], p[5], p[6]);
-            let mut cu = Client::new(UnixStream::connect(sock).expect("connect"));
+            let mut conn = UnixStream::connect(sock).expect("connect");
+            // Identify as a fork clone (proxy preamble): magic + clone id.
+            {
+                use std::io::Write as _;
+                let mut p = smolvm_cuda::proto::CLONE_PREAMBLE_MAGIC.to_vec();
+                p.extend_from_slice(&u64::from(std::process::id()).to_le_bytes());
+                conn.write_all(&p).expect("clone preamble");
+            }
+            let mut cu = Client::new(conn);
             cu.init(token).expect("init clone");
             cu.primary_ctx_retain(0).expect("ctx");
             eprintln!(

--- a/crates/smolvm-cuda/src/client.rs
+++ b/crates/smolvm-cuda/src/client.rs
@@ -578,7 +578,15 @@ impl<S: Read + Write> Client<S> {
                 frame.extend_from_slice(&payload);
                 self.journal.push(payload);
                 self.deferred += 1;
-                self.ring_push(&frame)?;
+                // A transport error here (e.g. a fork clone's first op hitting
+                // the dead inherited ring/doorbell) is NOT a failure of the op:
+                // it is already journaled, so the reconnect the next blocking
+                // call triggers will replay it in order. Erroring here instead
+                // made the guest wrapper fail the op spuriously (seen as a
+                // bogus CUBLAS_STATUS_NOT_INITIALIZED on the clone's first
+                // post-fork matmul). A persistent transport failure still
+                // surfaces loudly at the next blocking round-trip.
+                let _ = self.ring_push(&frame);
             } else {
                 // Oversized quiet frames go indirect, which needs the staging
                 // buffer alive until consumption — round-trip instead and
@@ -604,7 +612,10 @@ impl<S: Read + Write> Client<S> {
         self.journal.push(payload);
         self.deferred += 1;
         if self.wbuf.len() >= WBUF_FLUSH {
-            self.flush_wbuf()?;
+            // Swallow a transport error: the ops are journaled (see the ring
+            // branch above) and replay after the reconnect the next blocking
+            // call triggers.
+            let _ = self.flush_wbuf();
         }
         Ok(())
     }

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -11,7 +11,9 @@
 //! `libcuda.so.1`) and [`CpuBackend`] (emulates a known test kernel so the full
 //! protocol + transport can be exercised on a host with no NVIDIA GPU).
 
-use crate::proto::{decode_request, encode_response, read_msg, write_msg, Request, Response};
+use crate::proto::{
+    decode_request, encode_request, encode_response, read_msg, write_msg, Request, Response,
+};
 use std::collections::HashMap;
 use std::io::{Read, Write};
 
@@ -233,6 +235,12 @@ pub trait Backend: Send {
     ) -> CuResult<(i32, Vec<u8>)> {
         Err(CUDA_ERROR_NOT_FOUND)
     }
+
+    /// Alias an inherited raw library-handle value (the GOLDEN process's
+    /// pointer, e.g. what cublasLtCreate returned there) to `real`, a handle
+    /// created in THIS process — so a clone's calls on the inherited value
+    /// resolve to a live handle instead of a foreign pointer. Default: no-op.
+    fn lib_handle_alias(&mut self, _golden: u64, _real: u64) {}
 
     /// Zero-copy H2D: DMA `size` bytes from shared-region `offset` to `dptr`.
     /// Default: no shared region → caller must fall back to byte-shipping.
@@ -662,6 +670,15 @@ struct GoldenLayout {
     /// rebuilds the graph in its own context and maps both virtual handles to
     /// its rebuilt reals, so the clone's inherited `GraphLaunch` resolves.
     graphs: Vec<(u64, u64, GraphSer)>,
+    /// Top-level library handles (cuBLAS/cuBLASLt/cuDNN contexts) the golden
+    /// created, as `(lib, func, guest handle value, create args)`. Library
+    /// handles are process-local; a clone worker replays each create in ITS
+    /// process and maps the inherited value to its own handle — otherwise the
+    /// clone's first post-fork cuBLASLt call on a pre-fork handle fails
+    /// CUBLAS_STATUS_NOT_INITIALIZED (or worse, dereferences a foreign
+    /// pointer). Only context-level creates are recorded; descriptors are
+    /// transient and recreated by the workload itself.
+    lib_handles: Vec<(u8, u16, u64, Vec<u8>)>,
 }
 type LayoutCell = std::sync::Mutex<GoldenLayout>;
 static DPTR_HANDOFF: std::sync::Mutex<Option<HashMap<u64, std::sync::Weak<AllocTable>>>> =
@@ -807,6 +824,7 @@ pub fn module_handoff_snapshot(
     Vec<(u64, u32)>,
     Vec<(u64, u32)>,
     Vec<(u64, u64, GraphSer)>,
+    Vec<(u8, u16, u64, Vec<u8>)>,
 )> {
     let reg = LAYOUT_HANDOFF.lock().unwrap();
     let l = reg.as_ref()?.get(&token)?.upgrade()?;
@@ -820,7 +838,34 @@ pub fn module_handoff_snapshot(
     let streams = g.streams.iter().map(|(&h, &f)| (h, f)).collect();
     let events = g.events.iter().map(|(&h, &f)| (h, f)).collect();
     let graphs = g.graphs.clone();
-    Some((modules, funcs, streams, events, graphs))
+    let lib_handles = g.lib_handles.clone();
+    Some((modules, funcs, streams, events, graphs, lib_handles))
+}
+
+/// Replay the golden's top-level library-handle creates in THIS worker's
+/// process. cuBLAS/cuDNN creates carry the guest-minted id in their args, so
+/// the generated dispatch installs id→worker-handle itself; cuBLASLt returns a
+/// raw pointer, so the golden's value is aliased to the worker's new handle
+/// via [`Backend::lib_handle_alias`]. Returns how many creates succeeded.
+pub fn replay_lib_handles(b: &mut dyn Backend, handles: &[(u8, u16, u64, Vec<u8>)]) -> usize {
+    let empty = HashMap::new();
+    let mut n = 0;
+    for (lib, func, golden, args) in handles {
+        match b.lib_call(*lib, *func, args, &empty) {
+            Ok((0, out)) => {
+                if *lib == 4 && out.len() >= 8 {
+                    let real = u64::from_le_bytes(out[..8].try_into().unwrap());
+                    b.lib_handle_alias(*golden, real);
+                }
+                n += 1;
+            }
+            Ok((st, _)) => {
+                eprintln!("[lib-seed] create lib={lib} func={func} failed: status={st}")
+            }
+            Err(e) => eprintln!("[lib-seed] create lib={lib} func={func} failed: e={e}"),
+        }
+    }
+    n
 }
 
 // M3a: per-worker (thread-local) translation of the golden's inherited raw
@@ -1691,6 +1736,9 @@ fn optrace_summary(req: &Request) -> Option<String> {
             function, params, ..
         } => format!("Launch fn={function:#x} nparams={}", params.len()),
         Request::GraphLaunch { graph_exec, .. } => format!("GraphLaunch exec={graph_exec:#x}"),
+        Request::LibCall { lib, func, args } => {
+            format!("LibCall lib={lib} func={func} alen={}", args.len())
+        }
         Request::MemAddressReserve { size, .. } => format!("VmmReserve size={size:#x}"),
         Request::MemCreate { size, .. } => format!("VmmCreate size={size:#x}"),
         Request::MemMap {
@@ -1701,7 +1749,12 @@ fn optrace_summary(req: &Request) -> Option<String> {
         Request::MemSetAccess { va, size, .. } => format!("VmmAccess va={va:#x} size={size:#x}"),
         Request::MemUnmap { va, size } => format!("VmmUnmap va={va:#x} size={size:#x}"),
         Request::MemRelease { handle } => format!("VmmRelease h={handle:#x}"),
-        _ => return None,
+        // Catch-all: op byte only (re-encoding is debug-run-only cost), so a
+        // failing op outside the detailed set above still shows up.
+        other => format!(
+            "Op0x{:02x}",
+            encode_request(other).first().copied().unwrap_or(0)
+        ),
     })
 }
 
@@ -2404,9 +2457,41 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             )
             .map(|_| Response::Ok)
         }
-        Request::LibCall { lib, func, args } => b
-            .lib_call(lib, func, &args, &sess.streams)
-            .map(|(status, out)| Response::LibResult(status, out)),
+        Request::LibCall { lib, func, args } => {
+            let r = b.lib_call(lib, func, &args, &sess.streams);
+            // Path 3: record top-level library-context creates so a clone
+            // worker can replay them in ITS process (library handles are
+            // process-local; see GoldenLayout::lib_handles). The guest value
+            // is the minted vhandle id (cuBLAS/cuDNN pass it in args) or the
+            // returned raw pointer (cuBLASLt returns it in the output).
+            if path3_enabled() {
+                if let Ok((0, ref out)) = r {
+                    let recorded = match (lib, func) {
+                        // cublasCreate_v2 / cudnnCreate: guest-minted id leads args.
+                        (1, 0) | (2, 0) if args.len() >= 8 => {
+                            Some(u64::from_le_bytes(args[..8].try_into().unwrap()))
+                        }
+                        // cublasLtCreate: raw host pointer returned to the guest.
+                        (4, 11) if out.len() >= 8 => {
+                            Some(u64::from_le_bytes(out[..8].try_into().unwrap()))
+                        }
+                        _ => None,
+                    };
+                    if let Some(h) = recorded {
+                        if std::env::var_os("SMOLVM_CUDA_LIB_SEED_DEBUG").is_some() {
+                            eprintln!("[lib-rec] lib={lib} func={func} h={h:#x}");
+                        }
+                        sess.golden_layout.lock().unwrap().lib_handles.push((
+                            lib,
+                            func,
+                            h,
+                            args.clone(),
+                        ));
+                    }
+                }
+            }
+            r.map(|(status, out)| Response::LibResult(status, out))
+        }
         Request::MemcpyShmHtoD {
             dptr,
             offset,
@@ -2557,7 +2642,10 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         Ok(resp) => (0, resp),
         Err(code) => (code, Response::Ok),
     };
-    if let Some(line) = trace {
+    if let Some(mut line) = trace {
+        if let Response::LibResult(lst, _) = &resp {
+            line.push_str(&format!(" lib_st={lst}"));
+        }
         optrace_write(&line, status);
     }
     (status, resp)

--- a/crates/smolvm-cuda/src/host/gpu.rs
+++ b/crates/smolvm-cuda/src/host/gpu.rs
@@ -1663,6 +1663,9 @@ impl Backend for GpuBackend {
     ) -> CuResult<(i32, Vec<u8>)> {
         self.gen_lib_call(lib, func, args, streams)
     }
+    fn lib_handle_alias(&mut self, golden: u64, real: u64) {
+        self.vhandles.lock().unwrap().insert(golden, real);
+    }
 }
 
 /// cuBLAS status: 0 = `CUBLAS_STATUS_SUCCESS`, else the code as `Err`.
@@ -2141,7 +2144,12 @@ fn vh_resolve(map: &std::collections::HashMap<u64, u64>, h: u64) -> u64 {
     if h & VHANDLE_TAG != 0 {
         map.get(&h).copied().unwrap_or(0)
     } else {
-        h
+        // Untagged values are usually real host pointers and pass through —
+        // EXCEPT an inherited raw library handle in a fork-clone worker
+        // (cuBLASLt returns raw pointers to the guest), which the worker
+        // aliased to its own re-created handle at staging. Identity when
+        // absent, so the common case costs one map miss.
+        map.get(&h).copied().unwrap_or(h)
     }
 }
 

--- a/crates/smolvm-cuda/src/proto.rs
+++ b/crates/smolvm-cuda/src/proto.rs
@@ -27,6 +27,15 @@ pub const QUIET_PREFIX: u8 = 0x7F;
 /// status among quiet requests since the previous fence.
 pub const FENCE_OP: u8 = 0x7E;
 
+/// Connection preamble a FORK-CLONE VM's proxy sends before any RPC frames:
+/// these 8 magic bytes followed by an 8-byte per-clone id (le). Lets the
+/// daemon distinguish a clone's connection (route to its isolating worker
+/// process) from the GOLDEN's own reconnect carrying the same lineage token
+/// (must resume in-daemon — a worker would silently serve it a reconstructed
+/// COPY of its memory). The first 4 bytes decode as a length far beyond
+/// [`MAX_MSG`], so the preamble can never be confused with a legit frame.
+pub const CLONE_PREAMBLE_MAGIC: [u8; 8] = *b"SMVCLN\x01\x00";
+
 /// Request opcodes. Stable wire values — append only.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -17,7 +17,7 @@ use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -102,32 +102,21 @@ pub fn run(sock: &Path) -> io::Result<()> {
                             match stream {
                                 Ok(s) => {
                                     let _ = s.set_nodelay(true); // low-latency RPC
-                                    // Path 3: a REMOTE isolating fork clone (its VM
-                                    // proxies here over TCP) gets a worker process
-                                    // exactly like a local one — the golden's memory
-                                    // and the clone worker both live on THIS GPU
-                                    // host; only the RPC crosses the network.
+                                                                 // Path 3: a REMOTE isolating fork clone (its VM
+                                                                 // proxies here over TCP) gets a worker process
+                                                                 // exactly like a local one — the golden's memory
+                                                                 // and the clone worker both live on THIS GPU
+                                                                 // host; only the RPC crosses the network.
                                     #[cfg(unix)]
                                     {
                                         use std::os::unix::io::AsRawFd;
-                                        let fd = s.as_raw_fd();
-                                        if let Some(token) = peek_clone_token(fd) {
-                                            match spawn_clone_worker(fd, token) {
-                                                Ok(()) => {
-                                                    tracing::info!(
-                                                        token,
-                                                        "routed REMOTE isolating clone to a worker process"
-                                                    );
-                                                    drop(s); // the worker owns it now
-                                                    continue;
-                                                }
-                                                Err(e) => {
-                                                    // See the UDS arm: reject, fail fast.
-                                                    tracing::warn!(error = %e, token, "remote clone-worker spawn failed; rejecting the clone connection");
-                                                    drop(s);
-                                                    continue;
-                                                }
-                                            }
+                                        // Clone-marked connections (preamble from the
+                                        // remote clone VM's proxy) route to a worker or
+                                        // are rejected; a golden's reconnect (token, no
+                                        // preamble) falls through to in-daemon serving.
+                                        if route_clone_connection(s.as_raw_fd()) {
+                                            drop(s); // worker owns it / rejected
+                                            continue;
                                         }
                                     }
                                     spawn_serve(s, &active_tcp);
@@ -155,33 +144,19 @@ pub fn run(sock: &Path) -> io::Result<()> {
             // Count the connection open for the whole serve loop so a frozen golden
             // (idle but connected) keeps the daemon alive for its clones.
             Ok(stream) => {
-                // Path 3 (M1): an isolating fork clone is served in its own worker
-                // PROCESS (own context/UVA) so it can hold memory at the golden's
-                // exact VAs. Only fires under SMOLVM_CUDA_FORK_WORKERS; otherwise legacy.
+                // Path 3 (M1): an isolating fork clone (its VM's proxy sends a
+                // clone preamble) is served in its own worker PROCESS (own
+                // context/UVA) so it can hold memory at the golden's exact VAs.
+                // A GOLDEN's reconnect — same lineage token, NO preamble —
+                // falls through and resumes in-daemon: routing it to a worker
+                // would silently serve it a reconstructed COPY of its memory.
+                // Only fires under SMOLVM_CUDA_FORK_WORKERS; otherwise legacy.
                 #[cfg(unix)]
                 {
                     use std::os::unix::io::AsRawFd;
-                    let fd = stream.as_raw_fd();
-                    if let Some(token) = peek_clone_token(fd) {
-                        match spawn_clone_worker(fd, token) {
-                            Ok(()) => {
-                                tracing::info!(token, "routed isolating clone to a worker process");
-                                drop(stream); // the worker owns the connection now
-                                continue;
-                            }
-                            Err(e) => {
-                                // REJECT rather than serve in-process: this IS an
-                                // isolating clone (peek matched), and the legacy
-                                // shared path can't serve it — its inherited
-                                // pointers are garbage in a fresh context, so the
-                                // guest would wedge mid-training (seen after a
-                                // daemon restart orphaned a lineage). Closing
-                                // makes the guest fail fast instead.
-                                tracing::warn!(error = %e, token, "clone-worker spawn failed; rejecting the clone connection");
-                                drop(stream);
-                                continue;
-                            }
-                        }
+                    if route_clone_connection(stream.as_raw_fd()) {
+                        drop(stream); // worker owns it / rejected
+                        continue;
                     }
                 }
                 spawn_serve(stream, &active);
@@ -652,6 +627,121 @@ fn reconstruct_golden_modules(
     (mod_images, func_meta, stream_trans, event_trans, graphs)
 }
 
+/// Strip a fork-clone connection preamble (magic + clone id) if present,
+/// returning the clone id. The preamble is sent by a CLONE VM's proxy before
+/// any RPC frames (see `cuda_host::proxy_to_daemon`); the GOLDEN's connections
+/// never carry it. Must run on every accepted connection REGARDLESS of routing
+/// mode — an unconsumed preamble would corrupt the frame stream. Non-preamble
+/// connections are left untouched (peek only).
+#[cfg(unix)]
+fn consume_clone_preamble(fd: std::os::unix::io::RawFd) -> Option<u64> {
+    let mut buf = [0u8; 16];
+    // Same buffered-in-pieces caveat as peek_clone_token: retry the peek
+    // briefly so a slow proxy write can't make us misread the magic.
+    let mut n: isize = 0;
+    for _ in 0..200 {
+        n = unsafe {
+            libc::recv(
+                fd,
+                buf.as_mut_ptr() as *mut libc::c_void,
+                buf.len(),
+                libc::MSG_PEEK,
+            )
+        };
+        // Enough to decide: 8 bytes tells us magic-or-not; 16 is the full
+        // preamble. A legit first frame is ≥ 5 bytes, so a short non-magic
+        // prefix resolves as soon as the magic mismatches.
+        if n >= 8 && buf[..(n as usize).min(8)] != smolvm_cuda::proto::CLONE_PREAMBLE_MAGIC {
+            return None;
+        }
+        if n >= 16 || n == 0 {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    if n < 16 || buf[..8] != smolvm_cuda::proto::CLONE_PREAMBLE_MAGIC {
+        return None;
+    }
+    // Consume exactly the 16 preamble bytes, leaving the RPC stream intact.
+    // SAFETY: plain recv on a valid fd; MSG_WAITALL for the already-peeked bytes.
+    let c = unsafe {
+        libc::recv(
+            fd,
+            buf.as_mut_ptr() as *mut libc::c_void,
+            16,
+            libc::MSG_WAITALL,
+        )
+    };
+    if c != 16 {
+        return None;
+    }
+    Some(u64::from_le_bytes(buf[8..16].try_into().unwrap()))
+}
+
+/// Live clone workers keyed by (lineage token, clone id) → worker pid. A
+/// reconnect from a clone whose worker is STILL ALIVE is rejected loudly: a
+/// fresh worker would re-reconstruct from the golden and silently DISCARD the
+/// clone's accumulated GPU state (its training progress). Dead entries are
+/// replaced (worker crash → a fresh worker is the best recovery available).
+#[cfg(unix)]
+fn clone_worker_registry() -> &'static Mutex<std::collections::HashMap<(u64, u64), u32>> {
+    static REG: OnceLock<Mutex<std::collections::HashMap<(u64, u64), u32>>> = OnceLock::new();
+    REG.get_or_init(|| Mutex::new(std::collections::HashMap::new()))
+}
+
+/// Route one just-accepted connection: strip the clone preamble (always), and
+/// when it marks an isolating fork clone, spawn/refuse its worker. Returns
+/// `true` when the connection was consumed (routed or rejected); `false` means
+/// the caller serves it normally — including a GOLDEN's own reconnect, whose
+/// token-bearing Init WITHOUT the preamble must resume in-daemon (a worker
+/// would silently serve it a reconstructed COPY of its memory).
+#[cfg(unix)]
+fn route_clone_connection(fd: std::os::unix::io::RawFd) -> bool {
+    let Some(clone_id) = consume_clone_preamble(fd) else {
+        return false;
+    };
+    let Some(token) = peek_clone_token(fd) else {
+        // A clone VM's connection whose Init carries no lineage token: fresh
+        // post-fork work (new guest process), served in-daemon like any new
+        // session.
+        return false;
+    };
+    let mut reg = clone_worker_registry().lock().unwrap();
+    if let Some(&pid) = reg.get(&(token, clone_id)) {
+        // SAFETY: kill(pid, 0) — pure liveness probe, no signal delivered.
+        if unsafe { libc::kill(pid as i32, 0) } == 0 {
+            tracing::warn!(
+                token,
+                clone_id,
+                worker_pid = pid,
+                "clone reconnected while its worker is still alive; rejecting — \
+                 a fresh worker would silently reset the clone's GPU state"
+            );
+            return true; // consumed: caller drops the stream (fail fast)
+        }
+        reg.remove(&(token, clone_id));
+    }
+    match spawn_clone_worker(fd, token) {
+        Ok(pid) => {
+            reg.insert((token, clone_id), pid);
+            tracing::info!(
+                token,
+                clone_id,
+                worker_pid = pid,
+                "routed isolating clone to a worker process"
+            );
+        }
+        Err(e) => {
+            // REJECT rather than serve in-process: this IS an isolating clone
+            // (preamble matched), and the legacy shared path can't serve it —
+            // its inherited pointers are garbage in a fresh context, so the
+            // guest would wedge mid-training. Closing makes it fail fast.
+            tracing::warn!(error = %e, token, "clone-worker spawn failed; rejecting the clone connection");
+        }
+    }
+    true
+}
+
 /// Path 3 (M1): peek a just-accepted connection's first message; true iff it's an
 /// isolating fork-clone Init (`op == Init`, `resume_token != 0`) that should be
 /// served in a dedicated worker process. `MSG_PEEK` leaves the bytes on the
@@ -722,7 +812,7 @@ fn verify_chunk_content(b: &mut dyn Backend, ch: &smolvm_cuda::host::HandoffChun
 /// VAs). `dup2` the socket fd onto fd 3 in the child (clears CLOEXEC) and exec
 /// `smolvm _cuda-clone-worker 3`; the daemon then drops its own copy.
 #[cfg(unix)]
-fn spawn_clone_worker(conn_fd: std::os::unix::io::RawFd, token: u64) -> io::Result<()> {
+fn spawn_clone_worker(conn_fd: std::os::unix::io::RawFd, token: u64) -> io::Result<u32> {
     use std::os::unix::process::CommandExt;
     // Gather the golden's VMM layout (reservations + maps→physical handle).
     let (resvs, maps) = smolvm_cuda::host::layout_handoff_snapshot(token)
@@ -896,7 +986,7 @@ fn spawn_clone_worker(conn_fd: std::os::unix::io::RawFd, token: u64) -> io::Resu
             Ok(())
         });
     }
-    let spawned = cmd.spawn().map(|_| ());
+    let spawned = cmd.spawn().map(|child| child.id());
     // The child (if any) forked with its own copies; drop ours either way so
     // the golden's physicals can actually be released at teardown.
     for efd in parent_fds {

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -256,16 +256,22 @@ pub fn run_clone_worker(fd: std::os::unix::io::RawFd) -> io::Result<()> {
     // + recreate streams/events, then install the translation so the clone's
     // inherited kernel launches resolve (each module reloads on first use).
     if let Ok(modpath) = std::env::var("SMOLVM_CUDA_CLONE_MODULES") {
-        let (mod_images, func_meta, streams, events, graphs) =
+        let (mod_images, func_meta, streams, events, graphs, lib_handles) =
             reconstruct_golden_modules(backend.as_mut(), &modpath);
-        let (nm, nf, ns, ne, ng) = (
+        let (nm, nf, ns, ne, ng, nlh) = (
             mod_images.len(),
             func_meta.len(),
             streams.len(),
             events.len(),
             graphs.len(),
+            lib_handles.len(),
         );
         smolvm_cuda::host::set_handle_trans(mod_images, func_meta, streams, events);
+        // Re-create the golden's top-level cuBLAS/cuBLASLt/cuDNN handles in
+        // THIS process and map the clone's inherited values to them — library
+        // handles are process-local, so a pre-fork handle would otherwise fail
+        // the clone's first post-fork library call.
+        let nseeded = smolvm_cuda::host::replay_lib_handles(backend.as_mut(), &lib_handles);
         // M3b: rebuild the golden's captured CUDA graphs in THIS context, now
         // that modules can lazily reload and memory is reconstructed (kernel-arg
         // pointers reference the golden VAs, valid here). Maps the clone's
@@ -279,6 +285,8 @@ pub fn run_clone_worker(fd: std::os::unix::io::RawFd) -> io::Result<()> {
             events = ne,
             graphs = ng,
             graphs_rebuilt = nrebuilt,
+            lib_handles = nlh,
+            lib_handles_seeded = nseeded,
             "cuda clone-worker: staged modules for lazy reload + remapped handles"
         );
     }
@@ -496,20 +504,36 @@ fn reconstruct_golden_modules(
     Vec<(u64, u64)>,
     Vec<(u64, u64)>,
     Vec<(u64, u64, smolvm_cuda::host::GraphSer)>,
+    Vec<(u8, u16, u64, Vec<u8>)>,
 ) {
     let mut mod_images = Vec::new();
     let mut func_meta = Vec::new();
     let mut stream_trans = Vec::new();
     let mut event_trans = Vec::new();
     let mut graphs: Vec<(u64, u64, smolvm_cuda::host::GraphSer)> = Vec::new();
+    let mut lib_handles: Vec<(u8, u16, u64, Vec<u8>)> = Vec::new();
     let Ok(buf) = std::fs::read(path) else {
-        return (mod_images, func_meta, stream_trans, event_trans, graphs);
+        return (
+            mod_images,
+            func_meta,
+            stream_trans,
+            event_trans,
+            graphs,
+            lib_handles,
+        );
     };
     let mut p = 0usize;
     macro_rules! need {
         ($n:expr) => {
             if p + $n > buf.len() {
-                return (mod_images, func_meta, stream_trans, event_trans, graphs);
+                return (
+                    mod_images,
+                    func_meta,
+                    stream_trans,
+                    event_trans,
+                    graphs,
+                    lib_handles,
+                );
             }
         };
     }
@@ -614,6 +638,24 @@ fn reconstruct_golden_modules(
             ));
         }
     }
+    // Library-handle creates to replay in this worker (absent in older blobs).
+    if p < buf.len() {
+        let nlh = ru32!();
+        for _ in 0..nlh {
+            need!(1);
+            let lib = buf[p];
+            p += 1;
+            need!(2);
+            let func = u16::from_le_bytes(buf[p..p + 2].try_into().unwrap());
+            p += 2;
+            let h = ru64!();
+            let alen = ru32!() as usize;
+            need!(alen);
+            let args = buf[p..p + alen].to_vec();
+            p += alen;
+            lib_handles.push((lib, func, h, args));
+        }
+    }
     tracing::info!(
         nmods,
         nfuncs,
@@ -622,9 +664,17 @@ fn reconstruct_golden_modules(
         ngraphs = graphs.len(),
         streams = stream_trans.len(),
         events = event_trans.len(),
+        lib_handles = lib_handles.len(),
         "M3a: staged golden modules/functions for lazy reload + recreated streams/events"
     );
-    (mod_images, func_meta, stream_trans, event_trans, graphs)
+    (
+        mod_images,
+        func_meta,
+        stream_trans,
+        event_trans,
+        graphs,
+        lib_handles,
+    )
 }
 
 /// Strip a fork-clone connection preamble (magic + clone id) if present,
@@ -868,7 +918,7 @@ fn spawn_clone_worker(conn_fd: std::os::unix::io::RawFd, token: u64) -> io::Resu
     // M3a: serialize the golden's modules (images) + functions to a temp file for
     // the worker to reload + remap. Images are MB-scale, so a file, not env.
     let mut modpath: Option<String> = None;
-    if let Some((modules, funcs, streams, events, graphs)) =
+    if let Some((modules, funcs, streams, events, graphs, lib_handles)) =
         smolvm_cuda::host::module_handoff_snapshot(token)
     {
         tracing::info!(
@@ -877,6 +927,7 @@ fn spawn_clone_worker(conn_fd: std::os::unix::io::RawFd, token: u64) -> io::Resu
             streams = streams.len(),
             events = events.len(),
             graphs = graphs.len(),
+            lib_handles = lib_handles.len(),
             "M3a: gathered golden modules/functions/streams/events"
         );
         let mut blob = Vec::new();
@@ -930,6 +981,16 @@ fn spawn_clone_worker(conn_fd: std::os::unix::io::RawFd, token: u64) -> io::Resu
                 blob.extend_from_slice(&f.to_le_bytes());
                 blob.extend_from_slice(&t.to_le_bytes());
             }
+        }
+        // Library-handle creates for the worker to replay:
+        //   [u32 n]([u8 lib][u16 func][u64 handle][u32 len][args])*
+        blob.extend_from_slice(&(lib_handles.len() as u32).to_le_bytes());
+        for (lib, func, h, args) in &lib_handles {
+            blob.push(*lib);
+            blob.extend_from_slice(&func.to_le_bytes());
+            blob.extend_from_slice(&h.to_le_bytes());
+            blob.extend_from_slice(&(args.len() as u32).to_le_bytes());
+            blob.extend_from_slice(args);
         }
         let _ = std::fs::create_dir_all("/tmp/smolvm");
         // Unique per SPAWN, not per (token, conn_fd): fd numbers are reused as

--- a/src/cuda_host.rs
+++ b/src/cuda_host.rs
@@ -131,17 +131,56 @@ pub fn start(socket_path: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
+/// This VM's clone identity for the daemon-connection preamble, computed once.
+/// `Some` iff this VMM process was launched from a fork snapshot (the boot
+/// subprocess carries `SMOLVM_SNAPSHOT_DIR` per-process; the golden's process
+/// never has it). The id is stable for this VM's lifetime and distinct across
+/// sibling clones (per-process randomness ⊕ pid), so the daemon can key one
+/// worker per clone and tell a clone's reconnect apart from a fresh clone.
+fn fork_clone_id() -> Option<u64> {
+    static ID: OnceLock<Option<u64>> = OnceLock::new();
+    *ID.get_or_init(|| {
+        std::env::var_os("SMOLVM_SNAPSHOT_DIR")?;
+        let mut b = [0u8; 8];
+        if std::fs::File::open("/dev/urandom")
+            .and_then(|mut f| std::io::Read::read_exact(&mut f, &mut b))
+            .is_err()
+        {
+            b = (std::process::id() as u64)
+                .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+                .to_le_bytes();
+        }
+        Some(u64::from_le_bytes(b) ^ u64::from(std::process::id()))
+    })
+}
+
 /// Relay one guest connection to the shared CUDA daemon at `addr` (a byte pump
 /// in both directions — the RPC is end-to-end between the guest shim and the
 /// daemon, so smolvm only forwards frames). This is the minimal form of the
 /// shared-host-daemon architecture: every VM's traffic lands in one process, so
 /// they share a single GPU context and device memory.
+///
+/// A FORK-CLONE VM's proxy prepends the clone preamble (magic + clone id) so
+/// the daemon routes this connection to the clone's isolating worker — and, by
+/// its absence, serves the GOLDEN's own reconnect in-daemon instead of handing
+/// it a worker's reconstructed COPY of its memory.
 fn proxy_to_daemon(guest: crate::platform::uds::UdsStream, addr: &str) -> std::io::Result<()> {
+    fn preamble() -> Option<[u8; 16]> {
+        let id = fork_clone_id()?;
+        let mut p = [0u8; 16];
+        p[..8].copy_from_slice(&smolvm_cuda::proto::CLONE_PREAMBLE_MAGIC);
+        p[8..].copy_from_slice(&id.to_le_bytes());
+        Some(p)
+    }
     // A path (managed daemon) → unix socket; otherwise host:port → TCP.
     if addr.starts_with('/') {
         #[cfg(unix)]
         {
-            let daemon = std::os::unix::net::UnixStream::connect(addr)?;
+            use std::io::Write as _;
+            let mut daemon = std::os::unix::net::UnixStream::connect(addr)?;
+            if let Some(p) = preamble() {
+                daemon.write_all(&p)?;
+            }
             let sd = daemon.try_clone()?;
             return pump(guest, daemon.try_clone()?, daemon, move || {
                 let _ = sd.shutdown(std::net::Shutdown::Both);
@@ -156,8 +195,12 @@ fn proxy_to_daemon(guest: crate::platform::uds::UdsStream, addr: &str) -> std::i
             ));
         }
     }
-    let daemon = std::net::TcpStream::connect(addr)?;
+    let mut daemon = std::net::TcpStream::connect(addr)?;
     let _ = daemon.set_nodelay(true);
+    if let Some(p) = preamble() {
+        use std::io::Write as _;
+        daemon.write_all(&p)?;
+    }
     let sd = daemon.try_clone()?;
     pump(guest, daemon.try_clone()?, daemon, move || {
         let _ = sd.shutdown(std::net::Shutdown::Both);


### PR DESCRIPTION
Clone VM proxies mark their daemon connections with a preamble so a golden's reconnect is never handed a worker's reconstructed copy of its memory (one live worker per clone, loud rejection instead of silent state reset); clone workers now re-create the golden's cuBLAS/cuBLASLt/cuDNN context handles so pre-fork library handles keep working after the fork; and a fire-and-forget op whose transport enqueue fails is left to the replay journal instead of failing the caller spuriously. Known boundary: torch.compile(reduce-overhead) cudagraph-trees state does not survive a fork — clones fail loud with a CUDA error on replay; use mode="default" or eager in forked workloads (fully supported).