### PR TITLE
feat: add --publish-socket for exposing a guest TCP port as a host unix socket

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,6 +261,33 @@ cpus/mem:   CLI flag > Smolfile > defaults (4 CPU, 8192 MiB)
 - `-p HOST:GUEST` forwards a host port to the VM (TCP)
 - Smolfile: use `[network] allow_hosts` and `[network] allow_cidrs`
 
+### Socket Bridges (`machine create`)
+
+Bridge Unix sockets and TCP ports between host and guest over vsock, without
+opening any host TCP listener (all three are repeatable):
+
+- `--expose-socket GUEST_PATH[:HOST_PATH]` — a Unix socket the guest listens on
+  becomes reachable at HOST_PATH (default `<vm-dir>/<basename>`), e.g. an
+  in-guest Docker daemon via `DOCKER_HOST=unix://...`
+- `--mount-socket HOST_PATH:GUEST_PATH` — a Unix socket a host service listens
+  on becomes reachable inside the guest at GUEST_PATH
+- `--publish-socket HOST_PATH:GUEST_PORT` — a TCP port the guest listens on
+  becomes reachable as a host Unix socket at HOST_PATH: `-p` without the host
+  TCP listener. The bridge dials IPv4 loopback, so the workload must listen on
+  `127.0.0.1` or `0.0.0.0`; a listener bound only to `::1` is unreachable.
+
+The host socket file is created with the invoking user's umask and is not
+chmod'd (same as `--expose-socket`), so who can connect is governed by the
+file and its directory permissions — put HOST_PATH in a directory you own.
+
+```bash
+mkdir -p ~/.myapp
+smolvm machine create --name api --publish-socket ~/.myapp/api.sock:8080
+smolvm machine start --name api
+smolvm machine exec --name api -- ./serve --port 8080 &
+curl --unix-socket ~/.myapp/api.sock http://localhost/health
+```
+
 ### Proxy Support
 
 Pass proxy settings into VMs with `-e` when behind a corporate proxy or VPN:

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -417,7 +417,7 @@ fn main() {
     }
 
     // Start any user-published Unix-socket bridges (`--expose-socket` /
-    // `--mount-socket`). No-op when none are configured.
+    // `--mount-socket` / `--publish-socket`). No-op when none are configured.
     publish_socket::start_all();
 
     // Mount the Rosetta 2 runtime and register the binfmt_misc handler if the

--- a/crates/smolvm-agent/src/publish_socket.rs
+++ b/crates/smolvm-agent/src/publish_socket.rs
@@ -1,5 +1,5 @@
 //! Guest-side generalized Unix-socket bridges (`--expose-socket` /
-//! `--mount-socket`).
+//! `--mount-socket` / `--publish-socket`).
 //!
 //! Generalizes the fixed Docker (expose) and SSH-agent (mount) bridges into a
 //! user-specified set. On startup the agent reads
@@ -12,6 +12,9 @@
 //! - **Mount** (host→guest): the agent creates a Unix listener at the guest path;
 //!   for each guest-app connection it dials the vsock port (libkrun bridges it to
 //!   the host socket) and relays. Same shape as the SSH-agent bridge.
+//! - **Publish** (guest→host): like `Expose`, but for each host connection the
+//!   agent dials a TCP port on the guest loopback instead of a Unix socket path,
+//!   so a guest TCP service is reachable through a host socket file.
 //!
 //! The relay honors independent TCP-style half-close so hijacked/streaming
 //! protocols don't lose output — the same property the Docker bridge fixed.
@@ -39,6 +42,7 @@ fn start_one(sock: PublishedSocket) {
             let result = match sock.direction {
                 SocketDirection::Expose => serve_expose(&sock),
                 SocketDirection::Mount => serve_mount(&sock),
+                SocketDirection::Publish => serve_publish(&sock),
             };
             if let Err(e) = result {
                 tracing::warn!(
@@ -94,6 +98,69 @@ fn serve_expose(sock: &PublishedSocket) -> io::Result<()> {
                     "expose-socket: in-guest app socket not reachable"
                 ),
             })
+            .ok();
+    }
+}
+
+/// How long a publish bridge waits for the guest TCP dial. A loopback connect
+/// either succeeds or is refused immediately; the timeout only bounds the case
+/// where the port is firewalled to silently drop, which would otherwise pin the
+/// forwarder thread until the kernel gives up.
+#[cfg(target_os = "linux")]
+const PUBLISH_DIAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// Publish: listen on the vsock port; per host connection, dial the guest TCP
+/// port on loopback and relay. `serve_expose` with a TCP target — the workload
+/// must listen on the guest loopback or on all interfaces.
+#[cfg(target_os = "linux")]
+fn serve_publish(sock: &PublishedSocket) -> io::Result<()> {
+    use std::net::{SocketAddr, TcpStream};
+
+    // Validated by the host and by `decode`; a missing port here is a bug, and
+    // a terminal one for this bridge.
+    let guest_port = sock.guest_port().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("invalid publish target '{}'", sock.guest_path),
+        )
+    })?;
+    let guest_addr = SocketAddr::from(([127, 0, 0, 1], guest_port));
+    let listener = crate::vsock::VsockListener::bind(sock.vsock_port)?;
+    tracing::info!(
+        vsock_port = sock.vsock_port,
+        guest_port,
+        "publish-socket bridge listening"
+    );
+    loop {
+        let host_conn = match listener.accept() {
+            Ok(conn) => conn,
+            Err(e) => {
+                // A bad listener fd is terminal; per-connection errors are not.
+                if e.kind() == io::ErrorKind::InvalidInput {
+                    return Err(e);
+                }
+                continue;
+            }
+        };
+        thread::Builder::new()
+            .name("publish-sock-fwd".into())
+            .spawn(
+                move || match TcpStream::connect_timeout(&guest_addr, PUBLISH_DIAL_TIMEOUT) {
+                    Ok(app) => {
+                        if let Err(e) = relay(host_conn, app) {
+                            tracing::debug!(error = %e, "publish-socket relay ended");
+                        }
+                    }
+                    // No listener on the guest port yet (or ever): drop the
+                    // connection. The host client sees a connection reset, same as
+                    // the expose bridge — no start-order coupling.
+                    Err(e) => tracing::debug!(
+                        guest_port,
+                        error = %e,
+                        "publish-socket: guest TCP port not reachable"
+                    ),
+                },
+            )
             .ok();
     }
 }
@@ -240,6 +307,14 @@ fn serve_mount(_sock: &PublishedSocket) -> io::Result<()> {
     ))
 }
 
+#[cfg(not(target_os = "linux"))]
+fn serve_publish(_sock: &PublishedSocket) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "published socket bridges are only supported on Linux guests",
+    ))
+}
+
 #[cfg(all(test, target_os = "linux"))]
 mod tests {
     use super::relay;
@@ -332,6 +407,51 @@ mod tests {
             server_saw, expected,
             "client input after a server half-close must not be dropped"
         );
+    }
+
+    /// The publish-socket shape: one relay leg is a real TCP stream. The client
+    /// (host side, Unix) half-closes after its request; the FIN must cross the
+    /// TCP leg so the guest server sees EOF, and the server's streamed response
+    /// must still be delivered — then the reverse close drains cleanly.
+    #[test]
+    fn relay_bridges_unix_to_tcp_with_half_close() {
+        use std::net::{TcpListener, TcpStream};
+
+        // client <-> a  ==relay==  tcp_client <-> tcp_server
+        let (mut client, a) = UnixStream::pair().unwrap();
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let tcp_client = TcpStream::connect(addr).unwrap();
+        let (mut tcp_server, _) = listener.accept().unwrap();
+
+        let relay_thread = thread::spawn(move || {
+            let _ = relay(a, tcp_client);
+        });
+
+        let payload = vec![b'T'; 256 * 1024];
+        let expected = payload.clone();
+        let server_thread = thread::spawn(move || {
+            let mut request = Vec::new();
+            tcp_server.read_to_end(&mut request).unwrap(); // sees the mirrored FIN
+            tcp_server.write_all(&payload).unwrap();
+            request
+        });
+
+        client.write_all(b"GET / HTTP/1.1\r\n\r\n").unwrap();
+        client.shutdown(Shutdown::Write).unwrap();
+
+        let mut got = Vec::new();
+        client.read_to_end(&mut got).unwrap();
+
+        let request = server_thread.join().unwrap();
+        relay_thread.join().unwrap();
+        assert_eq!(request, b"GET / HTTP/1.1\r\n\r\n");
+        assert_eq!(
+            got.len(),
+            expected.len(),
+            "streamed TCP output after a client half-close must not be dropped"
+        );
+        assert_eq!(got, expected);
     }
 
     /// Ordinary bidirectional echo — a plain request/response with no early

--- a/crates/smolvm-protocol/src/lib.rs
+++ b/crates/smolvm-protocol/src/lib.rs
@@ -149,7 +149,7 @@ pub mod ports {
     pub const CUDA: u32 = 7000;
 
     /// Base vsock port for user-published Unix-socket bridges
-    /// (`--expose-socket` / `--mount-socket`). Each published socket is assigned
+    /// (`--expose-socket` / `--mount-socket` / `--publish-socket`). Each published socket is assigned
     /// `PUBLISH_SOCKET_BASE + index`. Kept clear of the fixed ports above (and of
     /// CUDA at 7000) so a reasonable number of sockets never collides.
     pub const PUBLISH_SOCKET_BASE: u32 = 6100;

--- a/crates/smolvm-protocol/src/publish_socket.rs
+++ b/crates/smolvm-protocol/src/publish_socket.rs
@@ -4,7 +4,8 @@
 //! into a dynamic, user-specified set. The host allocates a vsock port per
 //! published socket and encodes the guest-relevant fields into the
 //! [`crate::guest_env::PUBLISH_SOCKETS`] env var; the guest agent decodes it and
-//! starts one relay per entry.
+//! starts one relay per entry. The guest-side target is a Unix socket path
+//! (`expose`/`mount`) or a TCP port on the guest loopback (`publish`).
 
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -20,6 +21,10 @@ pub enum SocketDirection {
     /// the guest at the guest path. Guest clients connect in — the SSH-agent
     /// pattern.
     Mount,
+    /// A guest process listens on a TCP port; smolvm exposes it on the host as a
+    /// Unix socket. Host clients connect in — `Expose`, but with a guest TCP
+    /// target instead of a guest socket path (the socket-flavored `-p`).
+    Publish,
 }
 
 impl SocketDirection {
@@ -28,17 +33,18 @@ impl SocketDirection {
         match self {
             SocketDirection::Expose => "expose",
             SocketDirection::Mount => "mount",
+            SocketDirection::Publish => "publish",
         }
     }
 
     /// The libkrun `krun_add_vsock_port2` `listen` flag for this direction.
     ///
-    /// `Expose`: the guest serves on the vsock port and the host connects in, so
-    /// libkrun *listens* on the host-side socket (`true`). `Mount`: the guest
-    /// connects out to the vsock port and libkrun dials the host socket, so
-    /// libkrun does not listen (`false`).
+    /// `Expose`/`Publish`: the guest serves on the vsock port and the host
+    /// connects in, so libkrun *listens* on the host-side socket (`true`).
+    /// `Mount`: the guest connects out to the vsock port and libkrun dials the
+    /// host socket, so libkrun does not listen (`false`).
     pub fn host_listens(&self) -> bool {
-        matches!(self, SocketDirection::Expose)
+        matches!(self, SocketDirection::Expose | SocketDirection::Publish)
     }
 }
 
@@ -48,15 +54,16 @@ impl FromStr for SocketDirection {
         match s.to_ascii_lowercase().as_str() {
             "expose" => Ok(SocketDirection::Expose),
             "mount" => Ok(SocketDirection::Mount),
+            "publish" => Ok(SocketDirection::Publish),
             other => Err(format!(
-                "invalid socket direction '{other}' (expected 'expose' or 'mount')"
+                "invalid socket direction '{other}' (expected 'expose', 'mount' or 'publish')"
             )),
         }
     }
 }
 
 /// One published socket, as the guest agent needs to know it: which vsock port
-/// carries it, which guest-side path to serve or create, and the direction.
+/// carries it, which guest-side target to serve or create, and the direction.
 ///
 /// The host-side path is intentionally absent — libkrun owns the host end, so
 /// the guest never needs it.
@@ -64,11 +71,24 @@ impl FromStr for SocketDirection {
 pub struct PublishedSocket {
     /// vsock port assigned to this bridge by the host launcher.
     pub vsock_port: u32,
-    /// Guest-side socket path: the existing app socket to proxy to (`Expose`),
-    /// or the path to create a listener at (`Mount`).
+    /// Guest-side target: the existing app socket to proxy to (`Expose`), the
+    /// path to create a listener at (`Mount`), or the guest TCP port in digits
+    /// (`Publish`) — see [`Self::guest_port`].
     pub guest_path: String,
     /// Bridge direction.
     pub direction: SocketDirection,
+}
+
+impl PublishedSocket {
+    /// The guest TCP port of a `Publish` bridge, parsed from [`Self::guest_path`].
+    /// `None` for path-target bridges or an unparseable port (the host-side
+    /// validator and [`decode`] reject those before a bridge ever starts).
+    pub fn guest_port(&self) -> Option<u16> {
+        match self.direction {
+            SocketDirection::Publish => self.guest_path.parse::<u16>().ok().filter(|p| *p != 0),
+            SocketDirection::Expose | SocketDirection::Mount => None,
+        }
+    }
 }
 
 /// Encode a list of published sockets for the guest env var, as
@@ -98,11 +118,17 @@ pub fn decode(encoded: &str) -> Vec<PublishedSocket> {
             if guest_path.is_empty() {
                 return None;
             }
-            Some(PublishedSocket {
+            let sock = PublishedSocket {
                 vsock_port,
                 guest_path,
                 direction,
-            })
+            };
+            // A publish target must be a valid TCP port; skip it like any other
+            // malformed entry instead of starting a bridge that can never dial.
+            if direction == SocketDirection::Publish && sock.guest_port().is_none() {
+                return None;
+            }
+            Some(sock)
         })
         .collect()
 }
@@ -121,9 +147,14 @@ mod tests {
             "MOUNT".parse::<SocketDirection>().unwrap(),
             SocketDirection::Mount
         );
+        assert_eq!(
+            "publish".parse::<SocketDirection>().unwrap(),
+            SocketDirection::Publish
+        );
         assert!("bogus".parse::<SocketDirection>().is_err());
         assert!(SocketDirection::Expose.host_listens());
         assert!(!SocketDirection::Mount.host_listens());
+        assert!(SocketDirection::Publish.host_listens());
     }
 
     #[test]
@@ -139,11 +170,16 @@ mod tests {
                 guest_path: "/tmp/host.sock".into(),
                 direction: SocketDirection::Mount,
             },
+            PublishedSocket {
+                vsock_port: 6102,
+                guest_path: "8080".into(),
+                direction: SocketDirection::Publish,
+            },
         ];
         let encoded = encode(&socks);
         assert_eq!(
             encoded,
-            "6100|expose|/var/run/app.sock;6101|mount|/tmp/host.sock"
+            "6100|expose|/var/run/app.sock;6101|mount|/tmp/host.sock;6102|publish|8080"
         );
         assert_eq!(decode(&encoded), socks);
     }
@@ -156,5 +192,36 @@ mod tests {
         let out = decode(mixed);
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].guest_path, "/ok.sock");
+    }
+
+    #[test]
+    fn guest_port_parses_publish_targets_only() {
+        let publish = |target: &str| PublishedSocket {
+            vsock_port: 6100,
+            guest_path: target.into(),
+            direction: SocketDirection::Publish,
+        };
+        assert_eq!(publish("8080").guest_port(), Some(8080));
+        assert_eq!(publish("0").guest_port(), None);
+        assert_eq!(publish("65536").guest_port(), None);
+        assert_eq!(publish("/var/run/app.sock").guest_port(), None);
+        let expose = PublishedSocket {
+            vsock_port: 6100,
+            guest_path: "8080".into(),
+            direction: SocketDirection::Expose,
+        };
+        assert_eq!(expose.guest_port(), None);
+    }
+
+    #[test]
+    fn decode_skips_publish_entries_without_a_valid_port() {
+        // A path, an out-of-range port, and port 0 are all skipped; the valid
+        // publish entry survives.
+        let mixed =
+            "6100|publish|/not-a-port.sock;6101|publish|65536;6102|publish|0;6103|publish|8080";
+        let out = decode(mixed);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].vsock_port, 6103);
+        assert_eq!(out[0].guest_port(), Some(8080));
     }
 }

--- a/src/agent/boot_config.rs
+++ b/src/agent/boot_config.rs
@@ -55,7 +55,7 @@ pub struct BootConfig {
     /// VM data dir; the guest agent proxies it to `/var/run/docker.sock`.
     #[serde(default)]
     pub expose_docker: bool,
-    /// User-published Unix-socket bridges (`--expose-socket` / `--mount-socket`),
+    /// User-published Unix-socket bridges (`--expose-socket` / `--mount-socket` / `--publish-socket`),
     /// carried into the boot subprocess and applied by the launcher.
     #[serde(default)]
     pub published_sockets: Vec<crate::config::PublishedSocketConfig>,

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -189,7 +189,7 @@ pub struct LaunchFeatures {
     /// Hostnames for DNS filtering. When set, the host starts a DNS filter
     /// listener and the guest agent proxies DNS queries through it.
     pub dns_filter_hosts: Option<Vec<String>>,
-    /// User-published Unix-socket bridges (`--expose-socket` / `--mount-socket`).
+    /// User-published Unix-socket bridges (`--expose-socket` / `--mount-socket` / `--publish-socket`).
     /// The launcher assigns each a vsock port, wires libkrun, and tells the guest
     /// agent to start the matching relay.
     pub published_sockets: Vec<crate::config::PublishedSocketConfig>,
@@ -1128,9 +1128,9 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
             }
         }
 
-        // User-published Unix-socket bridges (`--expose-socket`/`--mount-socket`).
+        // User-published Unix-socket bridges (`--expose-socket`/`--mount-socket`/`--publish-socket`).
         // Each is assigned a dynamic vsock port; libkrun bridges it to a host-side
-        // Unix socket (listening for `expose`, dialing for `mount`), and the guest
+        // Unix socket (listening for `expose`/`publish`, dialing for `mount`), and the guest
         // agent starts the matching relay from the `SMOLVM_PUBLISH_SOCKETS` env.
         // The per-VM dir (the vsock socket's parent) is where an `expose` socket's
         // host end is created when the user didn't pin a host path.
@@ -1161,8 +1161,9 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
                         }
                     }
                 };
-                // For an expose socket libkrun *creates* the host listener, so
-                // clear any stale file first (mirrors the Docker bridge).
+                // For an expose or publish socket libkrun *creates* the host
+                // listener, so clear any stale file first (mirrors the Docker
+                // bridge).
                 if spec.direction.host_listens() {
                     let _ = std::fs::remove_file(&host_path);
                 }

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -93,14 +93,18 @@ fn resolve_egress_flags(
 /// absolute `from_file` paths. A key that appears more than once — across or
 /// within the two flags — is a hard error, since silently keeping the last
 /// occurrence would mask a typo.
-/// Parse `--expose-socket`/`--mount-socket` specs into published-socket configs.
+/// Parse `--expose-socket`/`--mount-socket`/`--publish-socket` specs into
+/// published-socket configs.
 ///
 /// - `--expose-socket GUEST_PATH[:HOST_PATH]`: expose a guest-listening socket to
 ///   the host. `HOST_PATH` optional (defaults to `<vm-dir>/<basename>`).
 /// - `--mount-socket HOST_PATH:GUEST_PATH`: mount a host socket into the guest.
+/// - `--publish-socket HOST_PATH:GUEST_PORT`: expose a guest-listening TCP port
+///   to the host as a Unix socket.
 fn parse_published_sockets(
     expose: &[String],
     mount: &[String],
+    publish: &[String],
 ) -> smolvm::Result<Vec<smolvm::config::PublishedSocketConfig>> {
     use smolvm::config::{PublishedSocketConfig, SocketDirection};
 
@@ -141,11 +145,41 @@ fn parse_published_sockets(
             host_path: Some(host_path.to_string()),
         });
     }
+    for spec in publish {
+        // Split on the LAST colon: host paths may contain ':', the port cannot.
+        let (host_path, guest_port) = spec.rsplit_once(':').ok_or_else(|| {
+            smolvm::Error::config(
+                "publish-socket",
+                format!("expected HOST_PATH:GUEST_PORT, got '{spec}'"),
+            )
+        })?;
+        if host_path.is_empty() {
+            return Err(smolvm::Error::config(
+                "publish-socket",
+                format!("HOST_PATH is required in '{spec}'"),
+            ));
+        }
+        let port = guest_port
+            .parse::<u16>()
+            .ok()
+            .filter(|p| *p != 0)
+            .ok_or_else(|| {
+                smolvm::Error::config(
+                    "publish-socket",
+                    format!("invalid guest TCP port '{guest_port}' in '{spec}' (expected 1-65535)"),
+                )
+            })?;
+        out.push(PublishedSocketConfig {
+            direction: SocketDirection::Publish,
+            guest_path: port.to_string(),
+            host_path: Some(host_path.to_string()),
+        });
+    }
     if out.len() > smolvm_protocol::ports::PUBLISH_SOCKET_MAX {
         return Err(smolvm::Error::config(
             "publish-socket",
             format!(
-                "too many published sockets ({}); max is {}",
+                "too many socket bridges across --expose-socket/--mount-socket/--publish-socket ({}); max is {}",
                 out.len(),
                 smolvm_protocol::ports::PUBLISH_SOCKET_MAX
             ),
@@ -1768,6 +1802,7 @@ mod tests {
                 "/run/svc.sock:/tmp/pinned.sock".to_string(),
             ],
             &["/run/host.sock:/run/guest.sock".to_string()],
+            &[],
         )
         .unwrap();
         assert_eq!(out.len(), 3);
@@ -1782,9 +1817,40 @@ mod tests {
 
     #[test]
     fn parse_published_sockets_rejects_bad_specs() {
-        assert!(parse_published_sockets(&[], &["/only-host".to_string()]).is_err());
-        assert!(parse_published_sockets(&[":/tmp/h.sock".to_string()], &[]).is_err());
-        assert!(parse_published_sockets(&["/run/a;b.sock".to_string()], &[]).is_err());
+        assert!(parse_published_sockets(&[], &["/only-host".to_string()], &[]).is_err());
+        assert!(parse_published_sockets(&[":/tmp/h.sock".to_string()], &[], &[]).is_err());
+        assert!(parse_published_sockets(&["/run/a;b.sock".to_string()], &[], &[]).is_err());
+    }
+
+    #[test]
+    fn parse_published_sockets_publish_specs() {
+        use smolvm::config::SocketDirection;
+        let out = parse_published_sockets(
+            &[],
+            &[],
+            &[
+                "/tmp/app.sock:8080".to_string(),
+                // Host paths may contain ':'; only the last colon separates the port.
+                "/tmp/odd:name.sock:9090".to_string(),
+            ],
+        )
+        .unwrap();
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].direction, SocketDirection::Publish);
+        assert_eq!(out[0].guest_path, "8080");
+        assert_eq!(out[0].host_path.as_deref(), Some("/tmp/app.sock"));
+        assert_eq!(out[1].guest_path, "9090");
+        assert_eq!(out[1].host_path.as_deref(), Some("/tmp/odd:name.sock"));
+    }
+
+    #[test]
+    fn parse_published_sockets_rejects_bad_publish_specs() {
+        // no colon, empty host path, non-numeric port, port 0, port > 65535
+        assert!(parse_published_sockets(&[], &[], &["8080".to_string()]).is_err());
+        assert!(parse_published_sockets(&[], &[], &[":8080".to_string()]).is_err());
+        assert!(parse_published_sockets(&[], &[], &["/tmp/a.sock:http".to_string()]).is_err());
+        assert!(parse_published_sockets(&[], &[], &["/tmp/a.sock:0".to_string()]).is_err());
+        assert!(parse_published_sockets(&[], &[], &["/tmp/a.sock:65536".to_string()]).is_err());
     }
 
     #[test]
@@ -2317,6 +2383,12 @@ pub struct CreateCmd {
     #[arg(long = "mount-socket", value_name = "HOST_PATH:GUEST_PATH")]
     pub mount_socket: Vec<String>,
 
+    /// Expose a TCP port the guest listens on to the host as a Unix socket
+    /// (repeatable) — `-p` without a host TCP listener. The workload must listen
+    /// on the guest loopback or all interfaces. Format: HOST_PATH:GUEST_PORT.
+    #[arg(long = "publish-socket", value_name = "HOST_PATH:GUEST_PORT")]
+    pub publish_socket: Vec<String>,
+
     /// Run command on every VM start (can be used multiple times)
     #[arg(long = "init", value_name = "COMMAND")]
     pub init: Vec<String>,
@@ -2453,8 +2525,11 @@ impl CreateCmd {
             (Some(from_smolfile), None) => Some(from_smolfile),
             (None, some) => some,
         };
-        params.published_sockets =
-            parse_published_sockets(&self.expose_socket, &self.mount_socket)?;
+        params.published_sockets = parse_published_sockets(
+            &self.expose_socket,
+            &self.mount_socket,
+            &self.publish_socket,
+        )?;
         // CLI `--secret-env`/`--secret-file` refs merge over any Smolfile
         // `[secrets]` of the same name (CLI wins). Only refs are persisted.
         for (key, r) in parse_cli_secret_refs(&self.secret_env, &self.secret_file)? {

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -455,7 +455,7 @@ pub struct CreateVmParams {
     pub rosetta: bool,
     /// Hostnames for DNS filtering (from --allow-host / [network].allow_hosts).
     pub dns_filter_hosts: Option<Vec<String>>,
-    /// User-published Unix-socket bridges (`--expose-socket` / `--mount-socket`).
+    /// User-published Unix-socket bridges (`--expose-socket` / `--mount-socket` / `--publish-socket`).
     pub published_sockets: Vec<smolvm::config::PublishedSocketConfig>,
     /// Absolute path to .smolmachine sidecar (for machines created with --from).
     pub source_smolmachine: Option<String>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,18 +17,21 @@ pub use smolvm_protocol::publish_socket::SocketDirection;
 use std::collections::HashMap;
 
 /// A user-published host↔guest Unix-socket bridge (`--expose-socket` /
-/// `--mount-socket`), persisted on the VM record. The vsock port is assigned at
-/// launch (not stored); only the paths and direction are durable.
+/// `--mount-socket` / `--publish-socket`), persisted on the VM record. The
+/// vsock port is assigned at launch (not stored); only the guest target, host
+/// path and direction are durable.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PublishedSocketConfig {
-    /// Bridge direction (`expose` = guest→host, `mount` = host→guest).
+    /// Bridge direction (`expose`/`publish` = guest→host, `mount` = host→guest).
     pub direction: SocketDirection,
-    /// Guest-side socket path: the existing app socket to expose, or the path a
-    /// mounted host socket is created at inside the guest.
+    /// Guest-side target: the existing app socket to expose, the path a mounted
+    /// host socket is created at inside the guest, or — for `publish` — the
+    /// guest TCP port in digits (validated by the CLI before it gets here).
     pub guest_path: String,
     /// Host-side socket path. For `expose`, where the host-side socket is
     /// created (`None` → default to `<per-VM dir>/<basename of guest_path>`).
-    /// For `mount`, the existing host socket to bridge in (required).
+    /// For `mount` (the existing host socket to bridge in) and `publish` (where
+    /// the published socket is created), required.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub host_path: Option<String>,
 }
@@ -390,7 +393,7 @@ pub struct VmRecord {
     #[serde(default)]
     pub ports: Vec<(u16, u16)>,
 
-    /// User-published Unix-socket bridges (`--expose-socket` / `--mount-socket`).
+    /// User-published Unix-socket bridges (`--expose-socket` / `--mount-socket` / `--publish-socket`).
     #[serde(default)]
     pub published_sockets: Vec<PublishedSocketConfig>,
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -23,7 +23,7 @@ SMOLVM_SKIP_SLOW=1 ./tests/run_tests.sh   # skip tests with long sleeps (~5 min)
 | `db` | `test_db.sh` | 6 | DB state persistence, VM state transitions |
 | `network` | `test_network.sh` | 17 | Network disable, DNS, egress, DNS filter, Smolfile allow_hosts |
 | `volumes` | `test_volumes.sh` | 6 | virtiofs mounts, /workspace priority |
-| `ports` | `test_ports.sh` | 2 | Port mapping, cross-VM conflict detection |
+| `ports` | `test_ports.sh` | 4 | Port mapping, cross-VM conflict detection, publish-socket bridges |
 | `storage` | `test_storage.sh` | 12 | Overlay, image list, prune, storage resize |
 | `resources` | `test_resources.sh` | 8 | CLI validation — no VMs required |
 | `reliability` | `test_reliability.sh` | 5 | Concurrency, state probe, ls-does-not-kill-vm |

--- a/tests/test_ports.sh
+++ b/tests/test_ports.sh
@@ -84,7 +84,116 @@ test_port_conflict_across_vms() {
 }
 
 
+test_publish_socket_http() {
+    local vm_name="test-vm-pubsock"
+    local sock_path="/tmp/smolvm-pubsock-$$.sock"
+
+    $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
+
+    # A stale file at the host path must be replaced at start, like the other
+    # host-listening bridges.
+    echo "stale" > "$sock_path"
+
+    # Publish guest TCP 18080 as a host unix socket — no -p, so the VM process
+    # must not open any host TCP listener.
+    $SMOLVM machine create --name "$vm_name" --publish-socket "$sock_path:18080" 2>&1 || {
+        rm -f "$sock_path"
+        return 1
+    }
+    $SMOLVM machine start --name "$vm_name" 2>&1 || {
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
+        rm -f "$sock_path"
+        return 1
+    }
+
+    # The stale file was replaced by a socket.
+    local sock_ok=0
+    [[ -S "$sock_path" ]] && sock_ok=1
+
+    # Serve several requests on guest TCP 18080 (nc handles one connection per
+    # iteration; the loop lets consecutive host requests through).
+    $SMOLVM machine exec --name "$vm_name" -- \
+        sh -c 'i=0; while [ $i -lt 5 ]; do echo -e "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok" | nc -l -p 18080 -w 5; i=$((i+1)); done' &
+    local server_pid=$!
+    sleep 1
+
+    # Round-trip through the published socket, twice — the socket file must
+    # keep serving across connections.
+    local output_a output_b
+    output_a=$(curl -s --max-time 5 --unix-socket "$sock_path" http://localhost/ 2>&1)
+    local rc_a=$?
+    output_b=$(curl -s --max-time 5 --unix-socket "$sock_path" http://localhost/ 2>&1)
+    local rc_b=$?
+
+    # No host TCP listener may appear on the published guest port (that is the
+    # point of publishing a socket instead of -p). Assert on the port, not the
+    # process name: `ss -p` needs privileges and the VMM process name can vary,
+    # either of which would make a name-based check pass vacuously.
+    local tcp_listeners
+    tcp_listeners=$(ss -ltn 2>/dev/null | awk '{print $4}' | grep -c ':18080$' || true)
+
+    kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+
+    $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
+    ensure_data_dir_deleted "$vm_name"
+    rm -f "$sock_path"
+
+    [[ $sock_ok -eq 1 ]] \
+        && [[ $rc_a -eq 0 ]] && [[ "$output_a" == *"ok"* ]] \
+        && [[ $rc_b -eq 0 ]] && [[ "$output_b" == *"ok"* ]] \
+        && [[ "$tcp_listeners" -eq 0 ]]
+}
+
+test_publish_socket_no_listener() {
+    local vm_name="test-vm-pubsock-nl"
+    local sock_path="/tmp/smolvm-pubsock-nl-$$.sock"
+
+    $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
+
+    $SMOLVM machine create --name "$vm_name" --publish-socket "$sock_path:19090" 2>&1 || {
+        rm -f "$sock_path"
+        return 1
+    }
+    $SMOLVM machine start --name "$vm_name" 2>&1 || {
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
+        rm -f "$sock_path"
+        return 1
+    }
+
+    # No listener on the guest port: the connection must fail fast (reset/empty
+    # reply), not hang — the same no-start-order-coupling contract as expose.
+    local rc_missing=0
+    curl -s --max-time 5 --unix-socket "$sock_path" http://localhost/ >/dev/null 2>&1 || rc_missing=$?
+
+    # Once a listener appears, the same published socket serves without a
+    # restart.
+    $SMOLVM machine exec --name "$vm_name" -- \
+        sh -c 'echo -e "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok" | nc -l -p 19090 -w 5' &
+    local server_pid=$!
+    sleep 1
+
+    local output
+    output=$(curl -s --max-time 5 --unix-socket "$sock_path" http://localhost/ 2>&1)
+    local rc_after=$?
+
+    kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+
+    $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
+    ensure_data_dir_deleted "$vm_name"
+    rm -f "$sock_path"
+
+    [[ $rc_missing -ne 0 ]] && [[ $rc_after -eq 0 ]] && [[ "$output" == *"ok"* ]]
+}
+
 run_test "Port: mapping host to guest HTTP" test_machine_port_mapping_http || true
 run_test "Port: cross-VM conflict detected" test_port_conflict_across_vms || true
+run_test "Port: publish socket HTTP round-trip, no host TCP listener" test_publish_socket_http || true
+run_test "Port: publish socket without guest listener fails fast, recovers" test_publish_socket_no_listener || true
 
 print_summary "Port Tests"


### PR DESCRIPTION
## What

`--publish-socket HOST_PATH:GUEST_PORT` on `machine create` makes a TCP port the
guest listens on reachable on the host as a Unix socket file — `-p` without the
host TCP listener. It completes the socket-bridge triple from #656: expose
(guest unix socket → host), mount (host unix socket → guest), publish (guest
TCP port → host unix socket).

```bash
smolvm machine create --name api --publish-socket /tmp/api.sock:8080
smolvm machine start --name api
smolvm machine exec --name api -- ./serve --port 8080 &
curl --unix-socket /tmp/api.sock http://localhost/health
```

## Why

Tools that embed smolvm as an engine want the *only* host-side reachability of
a guest service to be a socket file the caller owns (the colima
`DOCKER_HOST=unix://` shape): no port collisions, no loopback exposure to other
local processes, file-permission access control for free. Guest workloads
overwhelmingly listen on TCP, so the unix↔unix bridges from #656 don't reach
them without a shim inside the guest.

## How

Publish rides the #656 machinery end to end. A new `SocketDirection::Publish`
is host-side identical to `Expose` — dynamic vsock port, libkrun listens on the
host socket, stale file replaced at start, same 64-entry cap — and the guest
agent's `serve_publish` mirrors `serve_expose`, except each host connection
dials the guest port on loopback over TCP with a short connect timeout, so a
dial the guest firewall silently drops cannot pin the forwarder thread (a
refused connection still fails immediately). The shared relay is generic over the
stream type, so independent half-close carries across the TCP leg unchanged (a
FIN maps to `shutdown(SHUT_WR)`); a port with no listener behaves like an
expose target whose socket is missing — the connection is dropped and the host
client sees a reset, no start-order coupling. The launcher pipeline and
`BootConfig` carry no functional changes — doc comments updated only, no new
fields — so the `cfg(not(unix))` initializers from the #656 follow-up are
unaffected. The wire encoding extends naturally to `port|publish|8080` with
parse-time and decode-time validation.

CLI grammar is host-first, matching `-p HOST:GUEST` and `--mount-socket`; the
spec splits on the last colon so host paths containing `:` keep working.

The AGENTS.md section added here also documents the two existing #656 flags
(`--expose-socket` / `--mount-socket`), which were previously undocumented —
included so all three bridges are described in one place.

## Tests

- protocol: publish round-trips the wire encoding; malformed publish targets
  (path, port 0, >65535) are skipped like other malformed entries
- agent: relay over a real unix↔TCP pair delivers a 256 KiB tail after a
  client half-close (plus the existing three relay tests)
- CLI: valid/invalid spec parsing, including a host path containing `:`
- integration (`tests/test_ports.sh`): HTTP round-trip through the published
  socket with an `ss` check that no process holds a host TCP listener on the
  published port; stale socket file replaced at start; no-listener fails fast
  and recovers once a listener appears
- E2E on Linux/KVM: curl round-trip through the published socket against a
  real guest HTTP server, 20 concurrent requests, half-close probes in both
  directions with byte-count asserts, `ss` proof that no process listens on
  the published ports, no-listener fail-fast plus recovery, and stop/start
  lifecycle — 13/13 passing
- E2E on macOS/Hypervisor.framework (Apple Silicon): same 13-assert suite, 13/13 passing (no-`ss` platform adaptations noted in the transcript)

Format/clippy/unit gates green on Linux; Windows cross-compile checked.

## Possible follow-up

Three pieces of shared #656 semantics are deliberately left out of this PR
and would make a natural follow-up hardening PR, since each touches the
existing expose/mount behavior too: an explicit `,mode=` option (or tighter
default) for the host socket file, which today is created with the invoking
user's umask and not chmod'd, leaving access control to the host path's
directory permissions; surfacing a host-socket bind failure
(`krun_add_vsock_port2` returning an error) as a hard launch error instead of
a warn-and-disable; and rejecting duplicate host paths across bridge
definitions, where today the last bind quietly wins.

