### PR TITLE
Never LRU-evict the reference-shared pack store

### DIFF
--- a/crates/smolvm-pack/src/extract.rs
+++ b/crates/smolvm-pack/src/extract.rs
@@ -847,6 +847,30 @@ pub fn extract_sidecar(
     force: bool,
     debug: bool,
 ) -> std::io::Result<()> {
+    // Private per-machine caches are LRU-capped after extraction; the shared
+    // store opts out (see `extract_sidecar_capped`).
+    extract_sidecar_capped(sidecar_path, cache_dir, footer, force, debug, true)
+}
+
+/// Core of [`extract_sidecar`]. `cap_cache` runs the LRU size-cap on
+/// `cache_dir.parent()` after a successful extraction.
+///
+/// It MUST be `false` for the node-shared store (`_shared`): those entries are
+/// reference-shared across many VMs via `.pack-shared` pointers and hold NO
+/// per-VM lease, so capping the shared root would LRU-evict a pack still mounted
+/// by live pool VMs — their `/packed_layers` then reads empty and the guest
+/// fails with "no layer directories found in /packed_layers" (exit 255 on
+/// connect/exec). Only the private per-machine cache (`smolvm-pack/<checksum>`),
+/// whose running entries DO hold leases, is safe to cap. See
+/// `extract_sidecar_shared`, which passes `false`.
+fn extract_sidecar_capped(
+    sidecar_path: &Path,
+    cache_dir: &Path,
+    footer: &PackFooter,
+    force: bool,
+    debug: bool,
+    cap_cache: bool,
+) -> std::io::Result<()> {
     if !sidecar_path.exists() {
         return Err(std::io::Error::new(
             std::io::ErrorKind::NotFound,
@@ -903,7 +927,7 @@ pub fn extract_sidecar(
     // handles cache hits), cap the cache so old, unused extractions don't grow
     // without bound. LRU + lease-aware: keeps the newest (incl. what we just
     // wrote) and never evicts a running pack.
-    if result.is_ok() {
+    if result.is_ok() && cap_cache {
         if let Some(root) = cache_dir.parent() {
             // Protect the directory we just extracted: the caller has not yet
             // acquired its layers lease, so without this the eviction can delete
@@ -966,7 +990,11 @@ pub fn extract_sidecar_shared(
     debug: bool,
 ) -> std::io::Result<PathBuf> {
     let shared_dir = shared_pack_dir(shared_root, footer.checksum);
-    extract_sidecar(sidecar_path, &shared_dir, footer, false, debug)?;
+    // cap_cache=false: NEVER LRU-evict the shared store. Its entries are
+    // reference-shared across every VM via `.pack-shared` pointers and take no
+    // per-VM lease, so an oldest-first size-cap here would delete a pack still
+    // mounted by live pool VMs. See `extract_sidecar_capped`.
+    extract_sidecar_capped(sidecar_path, &shared_dir, footer, false, debug, false)?;
     // Lock down the store so a dropped per-VM uid can't read the shared copy
     // directly (it must go through its idmapped mount). Best-effort: traversal
     // by root (the VMM before it drops privileges) is unaffected by 0700.

--- a/crates/smolvm-pack/tests/shared_extract.rs
+++ b/crates/smolvm-pack/tests/shared_extract.rs
@@ -184,7 +184,10 @@ fn build_real_sidecar_marked(dir: &Path, marker: &[u8]) -> std::path::PathBuf {
 
     let mut collector = AssetCollector::new(dir.join("staging")).unwrap();
     collector
-        .add_layer("sha256:aaa111aaa111bbb222", &layer_tar("etc/base.conf", marker))
+        .add_layer(
+            "sha256:aaa111aaa111bbb222",
+            &layer_tar("etc/base.conf", marker),
+        )
         .unwrap();
 
     let manifest = PackManifest::new(

--- a/crates/smolvm-pack/tests/shared_extract.rs
+++ b/crates/smolvm-pack/tests/shared_extract.rs
@@ -174,3 +174,76 @@ fn kill_switch_disables_the_shared_store() {
     );
     std::env::remove_var("SMOLVM_DISABLE_SHARED_EXTRACT");
 }
+
+/// Like [`build_real_sidecar`] but mixes `marker` into the layer so the pack's
+/// content checksum differs — lets us create two distinct shared entries.
+fn build_real_sidecar_marked(dir: &Path, marker: &[u8]) -> std::path::PathBuf {
+    fs::create_dir_all(dir).unwrap();
+    let stub_path = dir.join("stub");
+    fs::write(&stub_path, b"#!/bin/sh\necho stub").unwrap();
+
+    let mut collector = AssetCollector::new(dir.join("staging")).unwrap();
+    collector
+        .add_layer("sha256:aaa111aaa111bbb222", &layer_tar("etc/base.conf", marker))
+        .unwrap();
+
+    let manifest = PackManifest::new(
+        "test:latest".to_string(),
+        "sha256:test".to_string(),
+        "linux/x86_64".to_string(),
+        "linux/x86_64".to_string(),
+    );
+    let output = dir.join("packed");
+    Packer::new(manifest)
+        .with_stub(&stub_path)
+        .with_assets(collector)
+        .pack(&output)
+        .unwrap();
+    sidecar_path_for(&output)
+}
+
+#[test]
+fn shared_store_is_not_lru_evicted_by_a_later_pack() {
+    // Regression for the packed-layers store eviction: creating a second,
+    // different-checksum pack must NOT LRU-evict the first shared entry. A pool VM
+    // references a shared entry only through its `.pack-shared` pointer and holds
+    // NO lease, so evicting it empties that VM's `/packed_layers` and every
+    // connect/exec into it dies "no layer directories found" (exit 255).
+    let tmp = tempfile::tempdir().unwrap();
+    let shared_root = tmp.path().join("_shared");
+
+    // Cap of 1 byte: were the shared store size-capped (the bug), writing the
+    // second entry would evict the first. The fix routes shared extraction with
+    // cap_cache=false, so the cap never applies to `_shared`. (Own test fn so the
+    // env mutation cannot race the other tests on cargo's parallel threads.)
+    std::env::set_var("SMOLVM_PACK_CACHE_MAX_BYTES", "1");
+
+    let sa = build_real_sidecar_marked(&tmp.path().join("a"), b"alpha-layer");
+    let fa = read_footer_from_sidecar(&sa).unwrap();
+    let da = extract_sidecar_shared(&sa, &shared_root, &fa, false).unwrap();
+
+    let sb = build_real_sidecar_marked(&tmp.path().join("b"), b"beta-layer-longer-bytes");
+    let fb = read_footer_from_sidecar(&sb).unwrap();
+    let db = extract_sidecar_shared(&sb, &shared_root, &fb, false).unwrap();
+
+    std::env::remove_var("SMOLVM_PACK_CACHE_MAX_BYTES");
+
+    assert_ne!(
+        fa.checksum, fb.checksum,
+        "test needs two distinct-checksum packs"
+    );
+    assert!(
+        da.is_dir(),
+        "first shared entry must SURVIVE a later extraction (not be LRU-evicted)"
+    );
+    assert!(db.is_dir(), "second shared entry must exist");
+    // Both entries keep their extracted layer dirs (not just an empty shell).
+    for d in [&da, &db] {
+        let n = fs::read_dir(d.join("layers"))
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_dir())
+            .count();
+        assert!(n > 0, "{} must keep its layer dirs", d.display());
+    }
+}

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -238,6 +238,17 @@ pub struct LaunchFeatures {
     pub uid_share_dir: Option<std::path::PathBuf>,
 }
 
+/// Whether a shared-pack-store `layers/` dir actually holds image layers — i.e.
+/// contains at least one subdirectory (a digest layer dir). A shared entry whose
+/// dir survives but whose `layers/` is missing or holds no layer dirs would boot
+/// an empty `/packed_layers` and make the guest fail "no layer directories
+/// found"; this drives the self-heal re-extract in `with_packed_layers`.
+fn shared_layers_populated(layers: &Path) -> bool {
+    std::fs::read_dir(layers)
+        .map(|rd| rd.flatten().any(|e| e.path().is_dir()))
+        .unwrap_or(false)
+}
+
 impl LaunchFeatures {
     /// Fold an image's own registry into the enforced DNS egress filter so a
     /// scoped machine's in-guest base-image pull isn't blocked by its own
@@ -325,6 +336,40 @@ impl LaunchFeatures {
         // container `/` and running the agent rootfs instead of the real image.
         if let Some(shared) = super::read_shared_pack_pointer(layers_cache_dir) {
             let layers = shared.join("layers");
+            // Self-heal: the shared entry's dir survived but its `layers/` holds
+            // no layer subdirs (a partial extraction, or an older binary that
+            // size-evicted the shared store's contents out from under this VM).
+            // Booting over that mounts an empty `/packed_layers` and the guest
+            // fails "no layer directories found in /packed_layers" (exit 255 on
+            // connect/exec). Re-extract the pack into the shared store from the
+            // sidecar first — idempotent + flock-serialized (a healthy entry is a
+            // cheap no-op via the `.smolvm-extracted` marker). Best-effort: if the
+            // sidecar is gone we proceed and surface the original error rather than
+            // masking it.
+            if !shared_layers_populated(&layers) {
+                let sidecar = Path::new(sidecar_path);
+                if sidecar.exists() {
+                    if let Ok(footer) = smolvm_pack::packer::read_footer_from_sidecar(sidecar) {
+                        if let Err(e) = smolvm_pack::extract::extract_sidecar_shared(
+                            sidecar,
+                            &super::shared_pack_cache_root(),
+                            &footer,
+                            false,
+                        ) {
+                            tracing::warn!(
+                                error = %e,
+                                shared = %shared.display(),
+                                "shared pack re-extract (self-heal) failed"
+                            );
+                        } else {
+                            tracing::info!(
+                                shared = %shared.display(),
+                                "re-extracted evicted shared pack before launch"
+                            );
+                        }
+                    }
+                }
+            }
             self.packed_layers_dir = Some(layers_cache_dir.to_path_buf());
             self.pack_idmap_source = Some(if layers.is_dir() { layers } else { shared });
             return Ok(self);


### PR DESCRIPTION
The per-machine pack-cache LRU size cap was running on the node-shared content-addressed store (`_shared`) after every extraction, so creating a new-checksum pack could evict a shared entry that live warm-pool VMs still reference through their `.pack-shared` pointer (those take no lease). Their `/packed_layers` then mounts empty and every connect/exec fails "no layer directories found". This routes shared extraction so the cap never applies to the shared store, and self-heals at launch by re-extracting a shared entry whose layers went missing. Adds a regression test.