### PR TITLE
Flatten from-vm packs to a single layer and share the pack export, workload launch, and machine-create env handling in the lib

### DIFF
--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -530,15 +530,12 @@ fn create_packed_image_info(image: &str, packed_dir: &Path) -> Result<ImageInfo>
         .map(|name| format!("sha256:{}", name))
         .collect();
 
-    // Calculate approximate size
-    let mut total_size = 0u64;
-    for layer_digest in &layer_dirs {
-        let short_id = layer_digest.strip_prefix("sha256:").unwrap_or(layer_digest);
-        let layer_path = packed_dir.join(short_id);
-        if let Ok(size) = dir_size(&layer_path) {
-            total_size += size;
-        }
-    }
+    // Size is informational only — never walk the layer trees for it. The
+    // packed dir is virtiofs-backed, and stat-ing a multi-GB extracted layer
+    // (hundreds of thousands of files) costs a FUSE round-trip per entry:
+    // minutes on the first Run, which blows the client's 120s read timeout and
+    // surfaces as EAGAIN before the container ever assembles.
+    let total_size = 0u64;
 
     // Determine architecture from environment or default
     #[cfg(target_arch = "aarch64")]

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -692,8 +692,8 @@ pub async fn create_machine(
         source_smolmachine,
         entrypoint,
         cmd,
-        env,
-        workdir,
+        env: merge_request_env(env, &req.env),
+        workdir: req.workdir.clone().or(workdir),
         // Record secrets = packed refs from --from (validated Untrusted above)
         // merged with request refs (validated Untrusted at ~line 333); request
         // refs win on key collision. Both sources are store-only, so RecordReplay
@@ -1872,6 +1872,20 @@ fn resolve_create_resources(
     )
 }
 
+/// Manifest env is the baseline; request env layers on top and wins on name
+/// collision, so a control plane can override a packed default.
+fn merge_request_env(
+    manifest_env: Vec<(String, String)>,
+    request_env: &[crate::api::types::EnvVar],
+) -> Vec<(String, String)> {
+    let mut merged = manifest_env;
+    for (name, value) in crate::api::types::EnvVar::to_tuples(request_env) {
+        merged.retain(|(existing, _)| existing != &name);
+        merged.push((name, value));
+    }
+    merged
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2041,7 +2055,53 @@ mod tests {
             registry_identity_token: None,
             blob_peers: vec![],
             secrets: Default::default(),
+            env: vec![],
+            workdir: None,
         }
+    }
+
+    #[test]
+    fn request_env_layers_over_manifest_env_and_wins_collisions() {
+        let manifest_env = vec![
+            ("KEEP".to_string(), "manifest".to_string()),
+            ("OVERRIDE".to_string(), "manifest".to_string()),
+        ];
+        let request_env = vec![
+            crate::api::types::EnvVar {
+                name: "OVERRIDE".to_string(),
+                value: "request".to_string(),
+            },
+            crate::api::types::EnvVar {
+                name: "NEW".to_string(),
+                value: "request".to_string(),
+            },
+        ];
+
+        let merged = merge_request_env(manifest_env, &request_env);
+
+        assert_eq!(
+            merged,
+            vec![
+                ("KEEP".to_string(), "manifest".to_string()),
+                ("OVERRIDE".to_string(), "request".to_string()),
+                ("NEW".to_string(), "request".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn create_request_accepts_env_and_workdir() {
+        let req: CreateMachineRequest = serde_json::from_value(serde_json::json!({
+            "name": "api-vm",
+            "env": [{"name": "FOO", "value": "bar"}],
+            "workdir": "/app"
+        }))
+        .unwrap();
+
+        assert_eq!(req.env.len(), 1);
+        assert_eq!(req.env[0].name, "FOO");
+        assert_eq!(req.env[0].value, "bar");
+        assert_eq!(req.workdir.as_deref(), Some("/app"));
     }
 
     #[test]

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -517,6 +517,15 @@ pub struct CreateMachineRequest {
     #[serde(default)]
     #[schema(value_type = Object)]
     pub secrets: RequestSecretRefs,
+    /// Environment variables for the machine's workload (init commands and the
+    /// entrypoint). For `from`/`registry_ref` machines these layer on top of
+    /// the artifact manifest's env; a request variable wins on name collision.
+    #[serde(default)]
+    pub env: Vec<EnvVar>,
+    /// Working directory for the machine's workload. Overrides the artifact
+    /// manifest's workdir when set.
+    #[serde(default)]
+    pub workdir: Option<String>,
 }
 
 /// Request to execute a command in a machine.

--- a/src/cli/pack.rs
+++ b/src/cli/pack.rs
@@ -23,7 +23,7 @@ use smolvm_pack::format::PackManifest;
 use smolvm_pack::packer::Packer;
 use smolvm_pack::signing::sign_with_hypervisor_entitlements;
 use smolvm_protocol::AgentResponse;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use tracing::{debug, info, warn};
 
 /// Package and run self-contained VM executables.
@@ -1510,7 +1510,6 @@ fn fmt_bytes(bytes: u64) -> String {
         format!("{} MB", bytes / (1024 * 1024))
     }
 }
-
 
 /// A simple terminal spinner that prints a rotating character every 200ms.
 /// Stops automatically on drop (error paths) or via explicit `stop()`.

--- a/src/cli/pack.rs
+++ b/src/cli/pack.rs
@@ -8,10 +8,8 @@
 //! - Configuration manifest
 
 use clap::{Args, Subcommand};
-use smolvm::agent::{resolve_disk_image, AgentClient, AgentManager, VmResources};
-use smolvm::data::disk::DiskFormat;
+use smolvm::agent::{AgentClient, AgentManager, VmResources};
 use smolvm::data::resources::DEFAULT_MICROVM_CPU_COUNT;
-use smolvm::storage::{OVERLAY_DISK_FILENAME, STORAGE_DISK_FILENAME};
 
 /// Default memory for packed VMs. Same as machine create — memory is elastic
 /// via virtio balloon, so the host only commits what the guest actually uses.
@@ -21,7 +19,7 @@ use smolvm::config::{RecordState, SmolvmConfig};
 use smolvm::platform::{Arch, Os, Platform, VmExecutor};
 use smolvm::Error;
 use smolvm_pack::assets::AssetCollector;
-use smolvm_pack::format::{PackManifest, PackMode};
+use smolvm_pack::format::PackManifest;
 use smolvm_pack::packer::Packer;
 use smolvm_pack::signing::sign_with_hypervisor_entitlements;
 use smolvm_protocol::AgentResponse;
@@ -518,28 +516,9 @@ impl PackCreateCmd {
             ));
         }
 
-        // 2. Locate the VM's disks. Default-size machines on Linux get qcow2 CoW
-        // overlays (overlay.qcow2 / storage.qcow2), not `.raw`, so resolve whichever
-        // format exists rather than hardcoding `.raw`. The overlay template is only
-        // consumed by VM-mode (bare) restores — container restores ignore it — so it
-        // is required only for non-image VMs.
-        let vm_dir = smolvm::agent::vm_data_dir(&vm_name);
-        let (overlay_disk, overlay_fmt) = resolve_disk_image(&vm_dir, OVERLAY_DISK_FILENAME);
-        let is_image_based = vm.image.is_some();
-        let is_artifact_sourced_container = is_image_based && vm.source_smolmachine.is_some();
-        if !is_image_based && !overlay_disk.exists() {
-            return Err(Error::agent(
-                "pack from VM",
-                format!(
-                    "overlay disk not found at {}. The VM may not have been started yet.",
-                    overlay_disk.display()
-                ),
-            ));
-        }
-
         println!("Packing VM '{}' snapshot...", vm_name);
 
-        // 3. Create temporary staging directory
+        // 2. Create temporary staging directory
         let temp_dir = tempfile::Builder::new()
             .prefix("pack-staging-")
             .tempdir_in(self.staging_root()?)
@@ -549,81 +528,24 @@ impl PackCreateCmd {
         let mut collector = AssetCollector::new(staging_dir.clone())
             .map_err(|e| Error::agent("collect assets", e.to_string()))?;
 
-        // 4. For image-based VMs, preserve imported artifact layers by default
-        // and append the current container overlay. The explicit rebase path keeps
-        // the historical behavior of rebuilding lower layers from vm.image.
-        if is_artifact_sourced_container && !self.rebase_from_image {
-            let source_smolmachine = vm.source_smolmachine.clone().unwrap();
-            let source_path = Path::new(&source_smolmachine);
-            let source_manifest = if source_path.exists() {
-                Some(
-                    smolvm_pack::packer::read_manifest_from_sidecar(source_path)
-                        .map_err(|e| Error::agent("read .smolmachine", e.to_string()))?,
-                )
-            } else {
-                None
-            };
+        // 3. Collect the machine's state via the shared export (single source
+        // of truth for bare / image / artifact-sourced dispatch and the
+        // single-layer flatten).
+        self.collect_base_assets(&mut collector)?;
+        let export_opts = smolvm::pack_export::FromVmExportOptions {
+            proxy: self.proxy_opts.proxy().map(str::to_string),
+            no_proxy: self.proxy_opts.no_proxy().map(str::to_string),
+            rebase_from_image: self.rebase_from_image,
+        };
+        let assets = smolvm::pack_export::collect_from_vm_assets(
+            &mut collector,
+            &vm_name,
+            vm,
+            temp_dir.path(),
+            &export_opts,
+        )?;
 
-            self.collect_base_assets(&mut collector)?;
-            let imported_layers =
-                match self.imported_layers_from_cache(&vm_name, source_manifest.as_ref())? {
-                    Some(layers) => layers,
-                    None => self.imported_layers_from_source_sidecar(
-                        &vm_name,
-                        &source_smolmachine,
-                        temp_dir.path(),
-                    )?,
-                };
-            self.add_imported_layers(&mut collector, imported_layers)?;
-            self.export_container_overlay_from_vm(&mut collector, &vm_name, &vm_dir)?;
-        } else if is_image_based {
-            let image = vm.image.clone().unwrap();
-            // A locally-sourced image (`--image -` / `--image file.tar` / a rootfs
-            // dir) is flattened on boot and has no registry manifest, so the
-            // layer-export path below — which pulls that manifest to enumerate base
-            // layers — cannot source it. Fail with a clear, actionable message
-            // instead of a confusing registry "UNAUTHORIZED" on `local:<hash>`.
-            if smolvm::data::image_source::is_local_ref(&image) {
-                return Err(Error::agent(
-                    "pack from VM",
-                    format!(
-                        "VM '{vm_name}' was created from a local image ({image}). \
-                         `pack create --from-vm` can only snapshot VMs created from a \
-                         REGISTRY image — local archives and rootfs directories are \
-                         flattened on boot and have no registry manifest to re-pull. \
-                         Recreate the machine from a registry reference to pack it."
-                    ),
-                ));
-            }
-
-            self.collect_base_assets(&mut collector)?;
-            self.export_registry_image_layers_from_vm(&mut collector, &vm_name, &vm_dir, &image)?;
-        } else {
-            // Bare VM: just collect base assets, no layers needed.
-            self.collect_base_assets(&mut collector)?;
-        }
-
-        // Add the overlay template (the VM's rootfs state). VM-mode restores boot
-        // from it; container restores ignore it entirely (every import path gates
-        // `overlay_template` on `PackMode::Vm`), so skip it for image-based VMs
-        // rather than flatten a qcow2 for nothing. A default-size overlay is a qcow2
-        // CoW image, which must be flattened to a raw before it can be a template.
-        if !is_image_based {
-            let overlay_for_pack = match overlay_fmt {
-                DiskFormat::Raw => overlay_disk.clone(),
-                DiskFormat::Qcow2 => {
-                    let flat = temp_dir.path().join("overlay-flat.raw");
-                    self.flatten_qcow2_to_raw(&overlay_disk, &flat)?;
-                    flat
-                }
-            };
-            println!("Copying overlay disk ({})...", overlay_for_pack.display());
-            collector
-                .add_overlay_template(&overlay_for_pack)
-                .map_err(|e| Error::agent("collect overlay", e.to_string()))?;
-        }
-
-        // 5. Resolve Smolfile overrides if provided
+        // 4. Resolve Smolfile overrides if provided
         //    Precedence: CLI > [artifact] > Smolfile top-level > VmRecord > default
         let pack_config = crate::cli::smolfile::resolve_pack_config(
             None, // no image for --from-vm
@@ -635,7 +557,7 @@ impl PackCreateCmd {
             self.smolfile.clone(),
         )?;
 
-        // 6. Build manifest
+        // 5. Build manifest: shared VM-derived baseline, then local overrides.
         let platform = format!("linux/{}", Arch::current().oci_arch());
         let host_platform = Platform::current().host_oci_platform().to_string();
         let mut manifest = PackManifest::new(
@@ -644,33 +566,15 @@ impl PackCreateCmd {
             platform,
             host_platform,
         );
-        if is_image_based {
-            manifest.mode = PackMode::Container;
-            manifest.image = vm.image.clone().unwrap_or_default();
-        } else {
-            manifest.mode = PackMode::Vm;
-        }
+        smolvm::pack_export::seed_manifest_from_vm(&mut manifest, vm, &assets);
         manifest.cpus = pack_config.cpus;
         manifest.mem = pack_config.mem;
         // Smolfile > source VM record > default
-        manifest.network = pack_config.net.unwrap_or(vm.network);
+        if let Some(net) = pack_config.net {
+            manifest.network = net;
+        }
         // CLI --gpu > Smolfile gpu > source VM record gpu > false
-        manifest.gpu = pack_config.gpu || vm.gpu.unwrap_or(false);
-        // Preserve the source VM's CUDA-over-vsock flag so the packed run starts
-        // a host CUDA server and bridges the guest's CUDA client to it.
-        manifest.cuda = vm.cuda;
-
-        // Entrypoint baseline: VmRecord > /bin/sh default
-        manifest.entrypoint = if !vm.entrypoint.is_empty() {
-            vm.entrypoint.clone()
-        } else {
-            vec!["/bin/sh".to_string()]
-        };
-        manifest.cmd = vm.cmd.clone();
-
-        // Start with VmRecord env/workdir as baseline
-        manifest.env = vm.env.iter().map(|(k, v)| format!("{}={}", k, v)).collect();
-        manifest.workdir = vm.workdir.clone();
+        manifest.gpu = pack_config.gpu || manifest.gpu;
 
         // Layer Smolfile env on top of VmRecord env
         if !pack_config.env.is_empty() {
@@ -684,10 +588,9 @@ impl PackCreateCmd {
             }
         }
 
-        // Baseline secret refs from the source VM record, then layer the
+        // Seeded baseline secret refs come from the source VM record; layer the
         // Smolfile [secrets] on top (Smolfile wins on key collisions). Refs
         // only — plaintext is resolved on the run host, never packed.
-        manifest.secret_refs = vm.secret_refs.clone();
         manifest.secret_refs.extend(pack_config.secret_refs.clone());
 
         // Smolfile workdir overrides VmRecord workdir
@@ -708,500 +611,6 @@ impl PackCreateCmd {
         self.finalize_pack(manifest, collector, staging_dir)
     }
 
-    fn export_registry_image_layers_from_vm(
-        &self,
-        collector: &mut AssetCollector,
-        vm_name: &str,
-        vm_dir: &Path,
-        image: &str,
-    ) -> smolvm::Result<()> {
-        let (storage_disk, storage_fmt) = resolve_disk_image(vm_dir, STORAGE_DISK_FILENAME);
-        let pack_vm_name = format!(
-            "pack-fromvm-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_nanos()
-        );
-        let vm_data = smolvm::agent::vm_data_dir(&pack_vm_name);
-
-        println!("Starting agent VM to export layers...");
-        let manager = AgentManager::for_vm(&pack_vm_name)?;
-        let features = smolvm::agent::LaunchFeatures {
-            extra_disks: vec![(storage_disk.clone(), false, storage_fmt)],
-            ..Default::default()
-        };
-        manager.start_with_full_config(
-            Vec::new(),
-            Vec::new(),
-            VmResources {
-                cpus: 4,
-                memory_mib: 8192,
-                network: true,
-                network_backend: None,
-                dns: None,
-                gpu: false,
-                cuda: false,
-                gpu_vram_mib: None,
-                rosetta: false,
-                storage_gib: None,
-                overlay_gib: None,
-                allowed_cidrs: None,
-            },
-            features,
-        )?;
-
-        let export_result: smolvm::Result<()> = (|| {
-            let mut client = manager.connect()?;
-            let (exit_code, _, stderr) = client.vm_exec(
-                vec![
-                    "sh".to_string(),
-                    "-c".to_string(),
-                    "mkdir -p /mnt/source-storage && mount /dev/vdc /mnt/source-storage"
-                        .to_string(),
-                ],
-                vec![],
-                None,
-                None,
-                None,
-            )?;
-            if exit_code != 0 {
-                return Err(Error::agent(
-                    "mount source storage in temp VM",
-                    format!(
-                        "mount failed (exit {}): {}",
-                        exit_code,
-                        String::from_utf8_lossy(&stderr)
-                    ),
-                ));
-            }
-
-            let image_info = crate::cli::pull_with_progress(
-                &mut client,
-                image,
-                None,
-                self.proxy_opts.proxy(),
-                self.proxy_opts.no_proxy(),
-            )?;
-
-            println!("Exporting {} layers...", image_info.layer_count);
-            for (i, layer_digest) in image_info.layers.iter().enumerate() {
-                let prefix = format!(
-                    "  Layer {}/{}: {}",
-                    i + 1,
-                    image_info.layer_count,
-                    &layer_digest[..std::cmp::min(19, layer_digest.len())]
-                );
-                print!("{}...", prefix);
-                let _ = std::io::Write::flush(&mut std::io::stdout());
-                let layer_file = collector.layer_staging_path(layer_digest);
-                self.export_layer_to_file(
-                    &mut client,
-                    &image_info.digest,
-                    i,
-                    &layer_file,
-                    &prefix,
-                )?;
-                collector
-                    .register_layer(layer_digest)
-                    .map_err(|e| Error::agent("collect layers", e.to_string()))?;
-            }
-
-            self.export_container_overlay_from_mounted_storage(collector, &mut client, vm_name)?;
-
-            Ok(())
-        })();
-
-        if let Err(e) = manager.stop() {
-            warn!(error = %e, "failed to stop pack temp VM");
-        }
-        let _ = std::fs::remove_dir_all(&vm_data);
-        export_result
-    }
-
-    fn export_container_overlay_from_mounted_storage(
-        &self,
-        collector: &mut AssetCollector,
-        client: &mut AgentClient,
-        vm_name: &str,
-    ) -> smolvm::Result<()> {
-        let overlay_dir = format!("/mnt/source-storage/overlays/persistent-{}/upper", vm_name);
-        println!("Exporting container overlay...");
-        let (exit_code, _, stderr) = client.vm_exec(
-            vec![
-                "sh".to_string(),
-                "-c".to_string(),
-                format!(
-                    "if [ -d '{}' ] && [ \"$(ls -A '{}')\" ]; then \
-                     tar cf /tmp/overlay-export.tar -C '{}' . 2>/dev/null; \
-                     echo OVERLAY_OK; \
-                     else echo OVERLAY_EMPTY; fi",
-                    overlay_dir, overlay_dir, overlay_dir
-                ),
-            ],
-            vec![],
-            None,
-            None,
-            None,
-        )?;
-
-        if exit_code == 0 {
-            // Stream the overlay tar to disk instead of buffering it: a real
-            // image's overlay (e.g. a baked-in ML venv) easily exceeds the
-            // in-memory transfer cap. Raise SMOLVM_FILE_TRANSFER_MAX_BYTES for
-            // overlays past the default streaming cap.
-            // Stage the temp download in the layers dir (same filesystem as the
-            // final digest-named file, so the rename below stays atomic).
-            let tmp_file = collector
-                .layer_staging_path(&format!("sha256:{}", "0".repeat(64)))
-                .with_file_name("overlay-export.tmp");
-            let total = client
-                .read_file_to_path("/tmp/overlay-export.tar", &tmp_file, |_| {})
-                .map_err(|e| Error::agent("export overlay layer", e.to_string()))?;
-            if total > 0 {
-                let mut hasher = Sha256::new();
-                {
-                    use std::io::Read;
-                    let mut f = std::fs::File::open(&tmp_file)
-                        .map_err(|e| Error::agent("read overlay layer", e.to_string()))?;
-                    let mut buf = vec![0u8; 4 * 1024 * 1024];
-                    loop {
-                        let n = f
-                            .read(&mut buf)
-                            .map_err(|e| Error::agent("hash overlay layer", e.to_string()))?;
-                        if n == 0 {
-                            break;
-                        }
-                        hasher.update(&buf[..n]);
-                    }
-                }
-                let overlay_digest = format!("sha256:{}", hex::encode(hasher.finalize()));
-                let overlay_layer_file = collector.layer_staging_path(&overlay_digest);
-                std::fs::rename(&tmp_file, &overlay_layer_file)
-                    .map_err(|e| Error::agent("write overlay layer", e.to_string()))?;
-                collector
-                    .register_layer(&overlay_digest)
-                    .map_err(|e| Error::agent("register overlay layer", e.to_string()))?;
-                println!("  Overlay layer: {} bytes", total);
-            } else {
-                let _ = std::fs::remove_file(&tmp_file);
-            }
-        } else {
-            tracing::debug!(stderr = %String::from_utf8_lossy(&stderr), "overlay export: no container changes found");
-        }
-
-        Ok(())
-    }
-
-    fn export_container_overlay_from_vm(
-        &self,
-        collector: &mut AssetCollector,
-        vm_name: &str,
-        vm_dir: &Path,
-    ) -> smolvm::Result<()> {
-        let (storage_disk, storage_fmt) = resolve_disk_image(vm_dir, STORAGE_DISK_FILENAME);
-        let pack_vm_name = format!(
-            "pack-fromvm-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_nanos()
-        );
-        let vm_data = smolvm::agent::vm_data_dir(&pack_vm_name);
-
-        println!("Starting agent VM to export container overlay...");
-        let manager = AgentManager::for_vm(&pack_vm_name)?;
-        let features = smolvm::agent::LaunchFeatures {
-            extra_disks: vec![(storage_disk.clone(), false, storage_fmt)],
-            // Under per-VM uid isolation the source VM's dir is 0700/its-own-uid;
-            // this helper's whole job is reading that VM's storage disk, so run
-            // it as the source's uid (a fresh sibling uid can't open the disk and
-            // the boot dies configuring virtio-blk).
-            uid_share_dir: Some(vm_dir.to_path_buf()),
-            ..Default::default()
-        };
-        manager.start_with_full_config(
-            Vec::new(),
-            Vec::new(),
-            VmResources {
-                cpus: 4,
-                memory_mib: 8192,
-                network: true,
-                network_backend: None,
-                dns: None,
-                gpu: false,
-                cuda: false,
-                gpu_vram_mib: None,
-                rosetta: false,
-                storage_gib: None,
-                overlay_gib: None,
-                allowed_cidrs: None,
-            },
-            features,
-        )?;
-
-        let export_result: smolvm::Result<()> = (|| {
-            let mut client = manager.connect()?;
-            let (exit_code, _, stderr) = client.vm_exec(
-                vec![
-                    "sh".to_string(),
-                    "-c".to_string(),
-                    "mkdir -p /mnt/source-storage && mount /dev/vdc /mnt/source-storage"
-                        .to_string(),
-                ],
-                vec![],
-                None,
-                None,
-                None,
-            )?;
-            if exit_code != 0 {
-                return Err(Error::agent(
-                    "mount source storage in temp VM",
-                    format!(
-                        "mount failed (exit {}): {}",
-                        exit_code,
-                        String::from_utf8_lossy(&stderr)
-                    ),
-                ));
-            }
-
-            self.export_container_overlay_from_mounted_storage(collector, &mut client, vm_name)?;
-
-            Ok(())
-        })();
-
-        if let Err(e) = manager.stop() {
-            warn!(error = %e, "failed to stop pack temp VM");
-        }
-        let _ = std::fs::remove_dir_all(&vm_data);
-        export_result
-    }
-
-    fn imported_layers_from_cache(
-        &self,
-        vm_name: &str,
-        source_manifest: Option<&PackManifest>,
-    ) -> smolvm::Result<Option<Vec<(String, PathBuf)>>> {
-        let cache_dir = smolvm::agent::machine_layers_cache_dir(vm_name);
-        let pack_content_dir =
-            smolvm::agent::read_shared_pack_pointer(&cache_dir).unwrap_or(cache_dir);
-        let layers_dir = pack_content_dir.join("layers");
-
-        if let Some(manifest) = source_manifest {
-            let mut layers = Vec::new();
-            for layer in &manifest.assets.layers {
-                let path = smolvm_pack::extract::resolve_cache_asset_path(
-                    &pack_content_dir,
-                    &layer.path,
-                    "source layer",
-                )
-                .map_err(|e| Error::agent("resolve source layer", e.to_string()))?;
-                if !path.exists() {
-                    return Ok(None);
-                }
-                layers.push((layer.digest.clone(), path));
-            }
-            return Ok(Some(layers));
-        }
-
-        let order_path = layers_dir.join("layer-order");
-        if let Ok(contents) = std::fs::read_to_string(&order_path) {
-            let mut layers = Vec::new();
-            for id in contents.lines().map(str::trim).filter(|id| !id.is_empty()) {
-                let path = layers_dir.join(format!("{id}.tar"));
-                if !path.exists() {
-                    return Ok(None);
-                }
-                layers.push((format!("sha256:{id}"), path));
-            }
-            return Ok(Some(layers));
-        }
-
-        let mut tar_layers = Vec::new();
-        if let Ok(entries) = std::fs::read_dir(&layers_dir) {
-            for entry in entries {
-                let entry = entry.map_err(|e| Error::agent("read source layers", e.to_string()))?;
-                let path = entry.path();
-                if path.extension().and_then(|s| s.to_str()) == Some("tar") {
-                    tar_layers.push(path);
-                }
-            }
-        }
-        if tar_layers.len() == 1 {
-            let path = tar_layers.pop().unwrap();
-            if let Some(id) = path.file_stem().and_then(|s| s.to_str()) {
-                return Ok(Some(vec![(format!("sha256:{id}"), path)]));
-            }
-        }
-
-        Ok(None)
-    }
-
-    fn imported_layers_from_source_sidecar(
-        &self,
-        vm_name: &str,
-        source_smolmachine: &str,
-        temp_dir: &Path,
-    ) -> smolvm::Result<Vec<(String, PathBuf)>> {
-        let source_path = Path::new(source_smolmachine);
-        let fail = || {
-            Error::agent(
-                "pack from VM",
-                format!(
-                    "VM '{vm_name}' was created from a .smolmachine artifact, but its imported layer closure could not be read from cache or source artifact: {source_smolmachine}"
-                ),
-            )
-        };
-        if !source_path.exists() {
-            return Err(fail());
-        }
-
-        let source_manifest =
-            smolvm_pack::packer::read_manifest_from_sidecar(source_path).map_err(|_| fail())?;
-        let footer =
-            smolvm_pack::packer::read_footer_from_sidecar(source_path).map_err(|_| fail())?;
-        let source_cache_dir = temp_dir.join("source-pack");
-        std::fs::create_dir_all(&source_cache_dir).map_err(|_| fail())?;
-        smolvm_pack::extract::extract_sidecar(source_path, &source_cache_dir, &footer, true, false)
-            .map_err(|_| fail())?;
-
-        let mut layers = Vec::new();
-        for layer in &source_manifest.assets.layers {
-            let path = smolvm_pack::extract::resolve_cache_asset_path(
-                &source_cache_dir,
-                &layer.path,
-                "source layer",
-            )
-            .map_err(|_| fail())?;
-            if !path.exists() {
-                return Err(fail());
-            }
-            layers.push((layer.digest.clone(), path));
-        }
-        Ok(layers)
-    }
-
-    fn add_imported_layers(
-        &self,
-        collector: &mut AssetCollector,
-        layers: Vec<(String, PathBuf)>,
-    ) -> smolvm::Result<()> {
-        for (_, path) in &layers {
-            if !path.exists() {
-                return Err(Error::agent(
-                    "collect source layers",
-                    format!("source layer not found: {}", path.display()),
-                ));
-            }
-        }
-
-        for (digest, path) in layers {
-            collector
-                .add_layer_from_file(&digest, &path)
-                .map_err(|e| Error::agent("collect source layers", e.to_string()))?;
-        }
-        Ok(())
-    }
-
-    /// Flatten a qcow2 CoW overlay into a standalone raw disk image.
-    ///
-    /// Default-size machines use a qcow2 overlay backed by the install's default
-    /// template, but a pack's overlay template must be a flat raw. There is no
-    /// host-side qcow2 reader (smolvm deliberately takes no qemu-img dependency),
-    /// so the conversion runs inside a throwaway agent VM: the source qcow2 is
-    /// attached read-only (libkrun resolves its backing chain) as `/dev/vdc`
-    /// alongside a fresh raw output as `/dev/vdd`, and the guest `dd`s one into the
-    /// other. `add_overlay_template` then strips trailing zeros so a mostly-empty
-    /// overlay still packs small, and extraction re-sparsifies it on import.
-    fn flatten_qcow2_to_raw(&self, qcow2_path: &Path, dest_raw: &Path) -> smolvm::Result<()> {
-        let virtual_size = read_qcow2_virtual_size(qcow2_path)?;
-        {
-            let f = std::fs::File::create(dest_raw)
-                .map_err(|e| Error::agent("create flatten target", e.to_string()))?;
-            f.set_len(virtual_size)
-                .map_err(|e| Error::agent("size flatten target", e.to_string()))?;
-        }
-
-        let flatten_vm_name = format!(
-            "pack-flatten-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_nanos()
-        );
-        let vm_data = smolvm::agent::vm_data_dir(&flatten_vm_name);
-        println!("Flattening qcow2 overlay to raw...");
-        let manager = AgentManager::for_vm(&flatten_vm_name)?;
-        let features = smolvm::agent::LaunchFeatures {
-            // vdc = source qcow2 (read-only), vdd = fresh raw output.
-            extra_disks: vec![
-                (qcow2_path.to_path_buf(), true, DiskFormat::Qcow2),
-                (dest_raw.to_path_buf(), false, DiskFormat::Raw),
-            ],
-            ..Default::default()
-        };
-        manager.start_with_full_config(
-            Vec::new(),
-            Vec::new(),
-            VmResources {
-                cpus: 2,
-                memory_mib: 2048,
-                network: false,
-                network_backend: None,
-                dns: None,
-                gpu: false,
-                cuda: false,
-                gpu_vram_mib: None,
-                rosetta: false,
-                storage_gib: None,
-                overlay_gib: None,
-                allowed_cidrs: None,
-            },
-            features,
-        )?;
-
-        let result: smolvm::Result<()> = (|| {
-            let mut client = manager.connect()?;
-            let (exit_code, _, stderr) = client.vm_exec(
-                vec![
-                    "sh".to_string(),
-                    "-c".to_string(),
-                    // busybox dd lacks GNU `conv=sparse`, so do a plain full copy
-                    // and `sync`. The output is dense on the temp disk, but
-                    // `add_overlay_template` strips trailing zeros so the pack stays
-                    // small; the imported overlay is re-sparsified on extraction.
-                    "dd if=/dev/vdc of=/dev/vdd bs=1M && sync".to_string(),
-                ],
-                vec![],
-                None,
-                None,
-                None,
-            )?;
-            if exit_code != 0 {
-                return Err(Error::agent(
-                    "flatten qcow2 overlay",
-                    format!(
-                        "dd failed (exit {}): {}",
-                        exit_code,
-                        String::from_utf8_lossy(&stderr)
-                    ),
-                ));
-            }
-            Ok(())
-        })();
-
-        if let Err(e) = manager.stop() {
-            warn!(error = %e, "failed to stop pack flatten VM");
-        }
-        let _ = std::fs::remove_dir_all(&vm_data);
-        result
-    }
-
-    /// Collect base assets shared by both image and VM packing modes:
-    /// runtime libraries, agent rootfs, and a pre-formatted storage template.
     fn collect_base_assets(&self, collector: &mut AssetCollector) -> smolvm::Result<()> {
         println!("Collecting runtime libraries...");
         let lib_dir = self.find_lib_dir()?;
@@ -2102,28 +1511,6 @@ fn fmt_bytes(bytes: u64) -> String {
     }
 }
 
-/// Read a qcow2 image's virtual (guest-visible) size from its header — the
-/// big-endian `u64` at byte offset 24, per the qcow2 spec. Lets the flatten path
-/// size its raw output correctly without a qcow2 library.
-fn read_qcow2_virtual_size(path: &Path) -> smolvm::Result<u64> {
-    use std::io::{Read, Seek, SeekFrom};
-    let mut f = std::fs::File::open(path).map_err(|e| Error::agent("open qcow2", e.to_string()))?;
-    let mut magic = [0u8; 4];
-    f.read_exact(&mut magic)
-        .map_err(|e| Error::agent("read qcow2 magic", e.to_string()))?;
-    if &magic != b"QFI\xfb" {
-        return Err(Error::agent(
-            "read qcow2",
-            format!("{} is not a qcow2 image (bad magic)", path.display()),
-        ));
-    }
-    f.seek(SeekFrom::Start(24))
-        .map_err(|e| Error::agent("seek qcow2 size", e.to_string()))?;
-    let mut buf = [0u8; 8];
-    f.read_exact(&mut buf)
-        .map_err(|e| Error::agent("read qcow2 size", e.to_string()))?;
-    Ok(u64::from_be_bytes(buf))
-}
 
 /// A simple terminal spinner that prints a rotating character every 200ms.
 /// Stops automatically on drop (error paths) or via explicit `stop()`.

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -1074,9 +1074,12 @@ pub fn start_vm_named(
         // inherited as-is.
         let _ = img;
         if !from_snapshot {
-            if let Err(e) =
-                smolvm::workload::launch_image_workload(&mut client, name, &record, exec_env.clone())
-            {
+            if let Err(e) = smolvm::workload::launch_image_workload(
+                &mut client,
+                name,
+                &record,
+                exec_env.clone(),
+            ) {
                 if let Err(stop_err) = manager.stop() {
                     tracing::warn!(error = %stop_err, "failed to stop machine after CMD launch failure");
                 }

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -1072,22 +1072,15 @@ pub fn start_vm_named(
         // container and hang every later `machine exec`, so skip the (re)launch
         // entirely when restoring from a snapshot — the forked container is
         // inherited as-is.
-        let mut cmd = record.entrypoint.clone();
-        cmd.extend(record.cmd.clone());
+        let _ = img;
         if !from_snapshot {
-            let mount_bindings =
-                crate::cli::parsers::record_mounts_to_runconfig_bindings(&record.mounts);
-            let bg_config = smolvm::agent::RunConfig::new(img, cmd)
-                .with_env(exec_env.clone())
-                .with_workdir(record.workdir.clone())
-                .with_user(record.user.clone())
-                .with_mounts(mount_bindings)
-                .with_persistent_overlay(Some(name.to_string()));
-            if let Err(e) = client.run_container_detached(bg_config) {
+            if let Err(e) =
+                smolvm::workload::launch_image_workload(&mut client, name, &record, exec_env.clone())
+            {
                 if let Err(stop_err) = manager.stop() {
                     tracing::warn!(error = %stop_err, "failed to stop machine after CMD launch failure");
                 }
-                return Err(smolvm::Error::agent("start background CMD", format!("{e}")));
+                return Err(e);
             }
         } else {
             tracing::info!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,8 @@ pub mod dns_filter_listener;
 pub mod embedded;
 pub mod log_rotation;
 pub mod network;
+/// Shared from-VM pack export used by every `pack create --from-vm` front-end.
+pub mod pack_export;
 pub mod platform;
 pub mod process;
 pub mod registry;
@@ -90,6 +92,8 @@ pub mod storage;
 pub mod systemd_scope;
 pub mod util;
 pub mod vm;
+/// Shared machine-workload launch used by every machine-start front-end.
+pub mod workload;
 
 /// Compatibility re-exports for smolvm error types.
 ///

--- a/src/pack_export.rs
+++ b/src/pack_export.rs
@@ -318,7 +318,10 @@ fn export_flattened_from_artifact_sourced(
     // Stage each virtiofs layer dir onto the helper's local disk. A tar pipe
     // preserves overlayfs whiteout devices and opaque-dir xattrs, which a
     // later overlay mount needs intact.
-    println!("Staging {} imported layer(s) for flatten...", layer_ids.len());
+    println!(
+        "Staging {} imported layer(s) for flatten...",
+        layer_ids.len()
+    );
     let mut lowers = Vec::new();
     for (i, id) in layer_ids.iter().enumerate() {
         let src = format!("/packed_layers/{}", id);
@@ -403,7 +406,10 @@ fn flatten_and_export(
     let base_chain: Vec<&str> = lowers.iter().rev().map(String::as_str).collect();
     let base_chain = base_chain.join(":");
 
-    println!("Flattening {} layer(s) + container overlay...", lowers.len());
+    println!(
+        "Flattening {} layer(s) + container overlay...",
+        lowers.len()
+    );
     let script = format!(
         "set -e\n\
          low='{base_chain}'\n\
@@ -582,8 +588,7 @@ fn flatten_qcow2_to_raw(qcow2_path: &Path, dest_raw: &Path) -> crate::Result<()>
 /// Read a qcow2 header's virtual size (big-endian u64 at offset 24).
 fn read_qcow2_virtual_size(path: &Path) -> crate::Result<u64> {
     use std::io::Read;
-    let mut f =
-        std::fs::File::open(path).map_err(|e| Error::agent("open qcow2", e.to_string()))?;
+    let mut f = std::fs::File::open(path).map_err(|e| Error::agent("open qcow2", e.to_string()))?;
     let mut header = [0u8; 32];
     f.read_exact(&mut header)
         .map_err(|e| Error::agent("read qcow2 header", e.to_string()))?;

--- a/src/pack_export.rs
+++ b/src/pack_export.rs
@@ -1,0 +1,597 @@
+//! Shared from-VM pack export: turn a stopped machine into `.smolmachine`
+//! assets.
+//!
+//! This is the single implementation behind every CLI's `pack create
+//! --from-vm` (and the cloud export path). It lives in the lib — not a CLI —
+//! so front-ends cannot fork-and-drift the export semantics: the bare-VM /
+//! image-machine / artifact-sourced dispatch, the manifest seeding, and the
+//! layer flattening below are all decided here.
+//!
+//! Image-based exports produce ONE flattened layer. Multi-layer packs cannot
+//! overlay-mount virtiofs-backed lowers at import time, so the guest falls
+//! back to physically merging every layer file-by-file through virtiofs —
+//! pathologically slow for file-heavy layers (a node_modules-scale overlay
+//! reads as a boot hang). The from-image pack path already pre-merges for
+//! exactly this reason; flattening here gives from-VM exports the same
+//! import-time behavior: a single lowerdir that mounts instantly.
+
+use crate::agent::{
+    machine_layers_cache_dir, read_shared_pack_pointer, resolve_disk_image, vm_data_dir,
+    AgentClient, AgentManager, LaunchFeatures, VmResources,
+};
+use crate::config::VmRecord;
+use crate::data::disk::DiskFormat;
+use crate::storage::{OVERLAY_DISK_FILENAME, STORAGE_DISK_FILENAME};
+use crate::Error;
+use sha2::{Digest, Sha256};
+use smolvm_pack::assets::AssetCollector;
+use smolvm_pack::format::{PackManifest, PackMode};
+use std::path::{Path, PathBuf};
+use tracing::warn;
+
+/// Options for a from-VM export.
+#[derive(Debug, Default, Clone)]
+pub struct FromVmExportOptions {
+    /// HTTP(S) proxy for the in-VM registry pull (registry-image machines).
+    pub proxy: Option<String>,
+    /// NO_PROXY for the in-VM registry pull.
+    pub no_proxy: Option<String>,
+    /// For artifact-sourced machines: rebuild base layers from `vm.image`
+    /// (re-pull from the registry) instead of preserving imported layers.
+    pub rebase_from_image: bool,
+}
+
+/// What the export decided about the machine, for the caller's manifest.
+#[derive(Debug, Clone)]
+pub struct FromVmAssets {
+    /// `Container` for image-based machines, `Vm` for bare machines.
+    pub mode: PackMode,
+    /// The machine's image reference (image-based machines only).
+    pub image: Option<String>,
+}
+
+/// Collect a stopped machine's pack assets into `collector` and report the
+/// pack mode. The caller has already: loaded the record, verified the machine
+/// is stopped, and collected its base assets (runtime libs, agent rootfs,
+/// templates). `staging_dir` hosts temporary extractions and must live until
+/// the pack is finalized.
+pub fn collect_from_vm_assets(
+    collector: &mut AssetCollector,
+    vm_name: &str,
+    vm: &VmRecord,
+    staging_dir: &Path,
+    opts: &FromVmExportOptions,
+) -> crate::Result<FromVmAssets> {
+    let vm_dir = vm_data_dir(vm_name);
+    let (overlay_disk, overlay_fmt) = resolve_disk_image(&vm_dir, OVERLAY_DISK_FILENAME);
+    let is_image_based = vm.image.is_some();
+    let is_artifact_sourced = is_image_based && vm.source_smolmachine.is_some();
+
+    if !is_image_based && !overlay_disk.exists() {
+        return Err(Error::agent(
+            "pack from VM",
+            format!(
+                "overlay disk not found at {}. The VM may not have been started yet.",
+                overlay_disk.display()
+            ),
+        ));
+    }
+
+    if is_artifact_sourced && !opts.rebase_from_image {
+        export_flattened_from_artifact_sourced(collector, vm_name, &vm_dir, staging_dir)?;
+    } else if is_image_based {
+        let image = vm.image.clone().unwrap();
+        // A locally-sourced image (`--image -` / `--image file.tar` / a rootfs
+        // dir) is flattened on boot and has no registry manifest, so the
+        // in-VM re-pull below cannot source it. Fail with a clear, actionable
+        // message instead of a confusing registry "UNAUTHORIZED" on
+        // `local:<hash>`.
+        if crate::data::image_source::is_local_ref(&image) {
+            return Err(Error::agent(
+                "pack from VM",
+                format!(
+                    "VM '{vm_name}' was created from a local image ({image}). \
+                     `pack create --from-vm` can only snapshot VMs created from a \
+                     REGISTRY image — local archives and rootfs directories are \
+                     flattened on boot and have no registry manifest to re-pull. \
+                     Recreate the machine from a registry reference to pack it."
+                ),
+            ));
+        }
+        export_flattened_from_registry_image(collector, vm_name, &vm_dir, &image, opts)?;
+    } else {
+        // Bare VM: its state is the rootfs overlay disk. VM-mode restores boot
+        // from the template; a default-size overlay is a qcow2 CoW image and
+        // must be flattened to a raw before it can be a template.
+        let overlay_for_pack = match overlay_fmt {
+            DiskFormat::Raw => overlay_disk.clone(),
+            DiskFormat::Qcow2 => {
+                let flat = staging_dir.join("overlay-flat.raw");
+                flatten_qcow2_to_raw(&overlay_disk, &flat)?;
+                flat
+            }
+        };
+        println!("Copying overlay disk ({})...", overlay_for_pack.display());
+        collector
+            .add_overlay_template(&overlay_for_pack)
+            .map_err(|e| Error::agent("collect overlay", e.to_string()))?;
+    }
+
+    Ok(FromVmAssets {
+        mode: if is_image_based {
+            PackMode::Container
+        } else {
+            PackMode::Vm
+        },
+        image: vm.image.clone(),
+    })
+}
+
+/// Seed a pack manifest with the source machine's runtime identity. CLI /
+/// Smolfile overrides layer on top of this baseline at the call site.
+pub fn seed_manifest_from_vm(manifest: &mut PackManifest, vm: &VmRecord, assets: &FromVmAssets) {
+    manifest.mode = assets.mode.clone();
+    if let Some(ref image) = assets.image {
+        manifest.image = image.clone();
+    }
+    manifest.network = vm.network;
+    manifest.gpu = vm.gpu.unwrap_or(false);
+    manifest.cuda = vm.cuda;
+    manifest.entrypoint = if !vm.entrypoint.is_empty() {
+        vm.entrypoint.clone()
+    } else {
+        vec!["/bin/sh".to_string()]
+    };
+    manifest.cmd = vm.cmd.clone();
+    manifest.env = vm.env.iter().map(|(k, v)| format!("{}={}", k, v)).collect();
+    manifest.workdir = vm.workdir.clone();
+    manifest.secret_refs = vm.secret_refs.clone();
+}
+
+/// A helper VM used to read the source machine's disks and flatten layers.
+/// Stops the VM and removes its scratch data dir on drop.
+struct ExportVm {
+    manager: AgentManager,
+    data_dir: PathBuf,
+}
+
+impl ExportVm {
+    /// Boot a scratch agent VM with the source machine's storage disk attached
+    /// read-only as `/dev/vdc`, plus (optionally) a host layer dir shared as
+    /// `/packed_layers`.
+    fn start(
+        vm_name: &str,
+        source_vm_dir: &Path,
+        packed_layers_dir: Option<PathBuf>,
+        network: bool,
+    ) -> crate::Result<Self> {
+        let (storage_disk, storage_fmt) = resolve_disk_image(source_vm_dir, STORAGE_DISK_FILENAME);
+        let scratch_name = format!(
+            "pack-fromvm-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        );
+        let data_dir = vm_data_dir(&scratch_name);
+
+        println!("Starting agent VM to export machine state...");
+        let manager = AgentManager::for_vm(&scratch_name)?;
+        let features = LaunchFeatures {
+            extra_disks: vec![(storage_disk, false, storage_fmt)],
+            packed_layers_dir,
+            // Under per-VM uid isolation the source VM's dir is 0700/its-own-uid;
+            // this helper's whole job is reading that VM's disks, so run it as
+            // the source's uid (a fresh sibling uid can't open the disk and the
+            // boot dies configuring virtio-blk).
+            uid_share_dir: Some(source_vm_dir.to_path_buf()),
+            ..Default::default()
+        };
+        manager.start_with_full_config(
+            Vec::new(),
+            Vec::new(),
+            VmResources {
+                cpus: 4,
+                memory_mib: 8192,
+                network,
+                network_backend: None,
+                dns: None,
+                gpu: false,
+                cuda: false,
+                gpu_vram_mib: None,
+                rosetta: false,
+                storage_gib: None,
+                overlay_gib: None,
+                allowed_cidrs: None,
+            },
+            features,
+        )?;
+        let _ = vm_name;
+        Ok(Self { manager, data_dir })
+    }
+
+    fn connect(&self) -> crate::Result<AgentClient> {
+        self.manager.connect()
+    }
+
+    /// Mount the source machine's storage disk at `/mnt/source-storage`.
+    fn mount_source_storage(&self, client: &mut AgentClient) -> crate::Result<()> {
+        let (exit_code, _, stderr) = client.vm_exec(
+            vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                "mkdir -p /mnt/source-storage && mount /dev/vdc /mnt/source-storage".to_string(),
+            ],
+            vec![],
+            None,
+            None,
+            None,
+        )?;
+        if exit_code != 0 {
+            return Err(Error::agent(
+                "mount source storage in temp VM",
+                format!(
+                    "mount failed (exit {}): {}",
+                    exit_code,
+                    String::from_utf8_lossy(&stderr)
+                ),
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Drop for ExportVm {
+    fn drop(&mut self) {
+        if let Err(e) = self.manager.stop() {
+            warn!(error = %e, "failed to stop pack temp VM");
+        }
+        let _ = std::fs::remove_dir_all(&self.data_dir);
+    }
+}
+
+/// Registry-image machine: pull the base image inside the helper VM (layers
+/// extract to its local disk), then flatten base layers + the machine's
+/// persistent container overlay into a single exported layer.
+fn export_flattened_from_registry_image(
+    collector: &mut AssetCollector,
+    vm_name: &str,
+    vm_dir: &Path,
+    image: &str,
+    opts: &FromVmExportOptions,
+) -> crate::Result<()> {
+    let export_vm = ExportVm::start(vm_name, vm_dir, None, true)?;
+    let mut client = export_vm.connect()?;
+    export_vm.mount_source_storage(&mut client)?;
+
+    eprintln!("Pulling {} in export VM...", image);
+    let image_info = client.pull_with_registry_config_and_progress(
+        image,
+        None,
+        opts.proxy.as_deref(),
+        opts.no_proxy.as_deref(),
+        |_, _, _| {},
+    )?;
+
+    // Lower dirs on the helper's own disk, bottom -> top as pulled.
+    let lowers: Vec<String> = image_info
+        .layers
+        .iter()
+        .map(|d| {
+            let id = d.strip_prefix("sha256:").unwrap_or(d);
+            format!("/storage/layers/{}", id)
+        })
+        .collect();
+
+    flatten_and_export(collector, &mut client, vm_name, &lowers)
+}
+
+/// Artifact-sourced machine: its extracted layer dirs live in the host-side
+/// machine layers cache; share them into the helper VM, stage them onto its
+/// local disk (overlayfs cannot use virtiofs-backed lowers), and flatten with
+/// the current container overlay.
+fn export_flattened_from_artifact_sourced(
+    collector: &mut AssetCollector,
+    vm_name: &str,
+    vm_dir: &Path,
+    _staging_dir: &Path,
+) -> crate::Result<()> {
+    let cache_dir = machine_layers_cache_dir(vm_name);
+    let pack_content_dir = read_shared_pack_pointer(&cache_dir).unwrap_or(cache_dir);
+    let layer_ids = ordered_cached_layer_ids(&pack_content_dir).ok_or_else(|| {
+        Error::agent(
+            "pack from VM",
+            format!(
+                "VM '{vm_name}' was created from a .smolmachine artifact, but its \
+                 imported layer cache is missing ({}). Start the machine once to \
+                 re-extract it, then re-run the export.",
+                pack_content_dir.display()
+            ),
+        )
+    })?;
+
+    let export_vm = ExportVm::start(vm_name, vm_dir, Some(pack_content_dir.clone()), false)?;
+    let mut client = export_vm.connect()?;
+    export_vm.mount_source_storage(&mut client)?;
+
+    // Stage each virtiofs layer dir onto the helper's local disk. A tar pipe
+    // preserves overlayfs whiteout devices and opaque-dir xattrs, which a
+    // later overlay mount needs intact.
+    println!("Staging {} imported layer(s) for flatten...", layer_ids.len());
+    let mut lowers = Vec::new();
+    for (i, id) in layer_ids.iter().enumerate() {
+        let src = format!("/packed_layers/{}", id);
+        let dst = format!("/storage/stage/{}", i);
+        let (exit_code, _, stderr) = client.vm_exec(
+            vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                format!(
+                    "mkdir -p '{dst}' && (cd '{src}' && tar cf - .) | (cd '{dst}' && tar xf -)"
+                ),
+            ],
+            vec![],
+            None,
+            None,
+            None,
+        )?;
+        if exit_code != 0 {
+            return Err(Error::agent(
+                "stage imported layer",
+                format!(
+                    "layer {} stage failed (exit {}): {}",
+                    id,
+                    exit_code,
+                    String::from_utf8_lossy(&stderr)
+                ),
+            ));
+        }
+        lowers.push(dst);
+    }
+
+    flatten_and_export(collector, &mut client, vm_name, &lowers)
+}
+
+/// The extracted layer dirs of an imported pack, bottom -> top, as short ids.
+/// `None` when the cache (or its ordering) is gone.
+fn ordered_cached_layer_ids(pack_content_dir: &Path) -> Option<Vec<String>> {
+    let layers_dir = pack_content_dir.join("layers");
+    let order_path = layers_dir.join("layer-order");
+    let ids: Vec<String> = if let Ok(contents) = std::fs::read_to_string(&order_path) {
+        contents
+            .lines()
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+            .map(str::to_string)
+            .collect()
+    } else {
+        // No order file: only unambiguous for a single extracted layer dir.
+        let mut dirs: Vec<String> = std::fs::read_dir(&layers_dir)
+            .ok()?
+            .flatten()
+            .filter(|e| e.path().is_dir())
+            .filter_map(|e| e.file_name().to_str().map(str::to_string))
+            .collect();
+        if dirs.len() != 1 {
+            return None;
+        }
+        vec![dirs.pop().unwrap()]
+    };
+    if ids.is_empty() || !ids.iter().all(|id| layers_dir.join(id).is_dir()) {
+        return None;
+    }
+    Some(ids.iter().map(|id| format!("layers/{}", id)).collect())
+}
+
+/// Overlay-mount `lowers` (bottom -> top, helper-local paths) with the source
+/// machine's persistent container overlay on top, tar the merged view, and
+/// register the stream as the pack's single layer. The overlay mount applies
+/// whiteouts/opaque markers exactly as the runtime would, so the flattened
+/// tree is byte-equivalent to what the machine's container saw.
+fn flatten_and_export(
+    collector: &mut AssetCollector,
+    client: &mut AgentClient,
+    vm_name: &str,
+    lowers: &[String],
+) -> crate::Result<()> {
+    if lowers.is_empty() {
+        return Err(Error::agent("flatten layers", "no layers to flatten"));
+    }
+    let upper = format!("/mnt/source-storage/overlays/persistent-{}/upper", vm_name);
+    // overlayfs wants topmost-first in `lowerdir=`.
+    let base_chain: Vec<&str> = lowers.iter().rev().map(String::as_str).collect();
+    let base_chain = base_chain.join(":");
+
+    println!("Flattening {} layer(s) + container overlay...", lowers.len());
+    let script = format!(
+        "set -e\n\
+         low='{base_chain}'\n\
+         n={n}\n\
+         if [ -d '{upper}' ] && [ -n \"$(ls -A '{upper}' 2>/dev/null)\" ]; then\n\
+           low=\"{upper}:$low\"; n=$((n+1))\n\
+         fi\n\
+         if [ \"$n\" -eq 1 ]; then\n\
+           tar cf /storage/flat-export.tar -C \"${{low%%:*}}\" .\n\
+         else\n\
+           mkdir -p /tmp/flatview\n\
+           mount -t overlay overlay -o lowerdir=\"$low\" /tmp/flatview\n\
+           tar cf /storage/flat-export.tar -C /tmp/flatview .\n\
+           umount /tmp/flatview\n\
+         fi\n\
+         echo FLAT_OK\n",
+        n = lowers.len(),
+    );
+    let (exit_code, stdout, stderr) = client.vm_exec(
+        vec!["sh".to_string(), "-c".to_string(), script],
+        vec![],
+        None,
+        None,
+        None,
+    )?;
+    let stdout_str = String::from_utf8_lossy(&stdout);
+    if exit_code != 0 || !stdout_str.contains("FLAT_OK") {
+        return Err(Error::agent(
+            "flatten layers",
+            format!(
+                "flatten failed (exit {}): {}",
+                exit_code,
+                String::from_utf8_lossy(&stderr)
+            ),
+        ));
+    }
+
+    // Stream the flattened tar to disk (never buffered whole in memory), then
+    // content-address it. Stage in the layers dir so the final rename is
+    // atomic on the same filesystem.
+    let tmp_file = collector
+        .layer_staging_path(&format!("sha256:{}", "0".repeat(64)))
+        .with_file_name("flat-export.tmp");
+    let total = client
+        .read_file_to_path("/storage/flat-export.tar", &tmp_file, |_| {})
+        .map_err(|e| Error::agent("export flattened layer", e.to_string()))?;
+    if total == 0 {
+        let _ = std::fs::remove_file(&tmp_file);
+        return Err(Error::agent(
+            "export flattened layer",
+            "flattened layer tar is empty",
+        ));
+    }
+
+    let mut hasher = Sha256::new();
+    {
+        use std::io::Read;
+        let mut f = std::fs::File::open(&tmp_file)
+            .map_err(|e| Error::agent("read flattened layer", e.to_string()))?;
+        let mut buf = vec![0u8; 4 * 1024 * 1024];
+        loop {
+            let n = f
+                .read(&mut buf)
+                .map_err(|e| Error::agent("hash flattened layer", e.to_string()))?;
+            if n == 0 {
+                break;
+            }
+            hasher.update(&buf[..n]);
+        }
+    }
+    let digest = format!("sha256:{}", hex::encode(hasher.finalize()));
+    let layer_file = collector.layer_staging_path(&digest);
+    std::fs::rename(&tmp_file, &layer_file)
+        .map_err(|e| Error::agent("write flattened layer", e.to_string()))?;
+    collector
+        .register_layer(&digest)
+        .map_err(|e| Error::agent("register flattened layer", e.to_string()))?;
+    println!("  Flattened layer: {} bytes", total);
+    Ok(())
+}
+
+/// Flatten a qcow2 CoW overlay into a standalone raw disk image (bare VMs).
+///
+/// There is no host-side qcow2 reader (smolvm deliberately takes no qemu-img
+/// dependency), so the conversion runs inside a throwaway agent VM: the source
+/// qcow2 is attached read-only (libkrun resolves its backing chain) as
+/// `/dev/vdc` alongside a fresh raw output as `/dev/vdd`, and the guest `dd`s
+/// one into the other.
+fn flatten_qcow2_to_raw(qcow2_path: &Path, dest_raw: &Path) -> crate::Result<()> {
+    let virtual_size = read_qcow2_virtual_size(qcow2_path)?;
+    let dest = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(dest_raw)
+        .map_err(|e| Error::agent("create flat overlay", e.to_string()))?;
+    dest.set_len(virtual_size)
+        .map_err(|e| Error::agent("size flat overlay", e.to_string()))?;
+    drop(dest);
+
+    let scratch_name = format!(
+        "pack-flatten-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    );
+    let data_dir = vm_data_dir(&scratch_name);
+    println!("Flattening qcow2 overlay to raw...");
+    let manager = AgentManager::for_vm(&scratch_name)?;
+    let features = LaunchFeatures {
+        extra_disks: vec![
+            (qcow2_path.to_path_buf(), true, DiskFormat::Qcow2),
+            (dest_raw.to_path_buf(), false, DiskFormat::Raw),
+        ],
+        ..Default::default()
+    };
+    manager.start_with_full_config(
+        Vec::new(),
+        Vec::new(),
+        VmResources {
+            cpus: 2,
+            memory_mib: 2048,
+            network: false,
+            network_backend: None,
+            dns: None,
+            gpu: false,
+            cuda: false,
+            gpu_vram_mib: None,
+            rosetta: false,
+            storage_gib: None,
+            overlay_gib: None,
+            allowed_cidrs: None,
+        },
+        features,
+    )?;
+
+    let result: crate::Result<()> = (|| {
+        let mut client = manager.connect()?;
+        let (exit_code, _, stderr) = client.vm_exec(
+            vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                // busybox dd lacks GNU `conv=sparse`, so do a plain full copy
+                // and `sync`. The output is dense on the temp disk, but
+                // `add_overlay_template` strips trailing zeros so the pack stays
+                // small; the imported overlay is re-sparsified on extraction.
+                "dd if=/dev/vdc of=/dev/vdd bs=1M && sync".to_string(),
+            ],
+            vec![],
+            None,
+            None,
+            None,
+        )?;
+        if exit_code != 0 {
+            return Err(Error::agent(
+                "flatten overlay qcow2",
+                format!(
+                    "dd failed (exit {}): {}",
+                    exit_code,
+                    String::from_utf8_lossy(&stderr)
+                ),
+            ));
+        }
+        Ok(())
+    })();
+
+    if let Err(e) = manager.stop() {
+        warn!(error = %e, "failed to stop flatten temp VM");
+    }
+    let _ = std::fs::remove_dir_all(&data_dir);
+    result
+}
+
+/// Read a qcow2 header's virtual size (big-endian u64 at offset 24).
+fn read_qcow2_virtual_size(path: &Path) -> crate::Result<u64> {
+    use std::io::Read;
+    let mut f =
+        std::fs::File::open(path).map_err(|e| Error::agent("open qcow2", e.to_string()))?;
+    let mut header = [0u8; 32];
+    f.read_exact(&mut header)
+        .map_err(|e| Error::agent("read qcow2 header", e.to_string()))?;
+    if &header[0..4] != b"QFI\xfb" {
+        return Err(Error::agent(
+            "read qcow2 header",
+            format!("{} is not a qcow2 image", path.display()),
+        ));
+    }
+    Ok(u64::from_be_bytes(header[24..32].try_into().unwrap()))
+}

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -1,0 +1,56 @@
+//! Shared machine-workload launch: run an image machine's persistent
+//! container (its ENTRYPOINT+CMD) after the VM boots.
+//!
+//! Every front-end that starts machines (the engine CLI, the HTTP API, the
+//! smol CLI) must launch the workload the same way — a front-end that skips
+//! it boots a bare agent VM whose published ports forward to nothing. Keeping
+//! the launch here, in the lib, is what stops front-ends from drifting apart.
+
+use crate::agent::{AgentClient, RunConfig};
+use crate::config::VmRecord;
+use crate::data::storage::HostMount;
+
+/// Convert a `VmRecord` mount list (`(host_source, guest_target, read_only)`
+/// triples) to the agent's virtiofs binding format. The host source is
+/// dropped — the agent only needs the guest-facing target and the positional
+/// `smolvm{i}` tag.
+pub fn record_mounts_to_bindings(mounts: &[(String, String, bool)]) -> Vec<(String, String, bool)> {
+    mounts
+        .iter()
+        .enumerate()
+        .map(|(i, (_host, target, ro))| (HostMount::mount_tag(i), target.clone(), *ro))
+        .collect()
+}
+
+/// Launch an image machine's workload container in the background.
+///
+/// `exec_env` is the record env with secrets already resolved — resolution is
+/// a host-side concern the caller owns. An empty entrypoint+cmd makes the
+/// agent resolve the image's own ENTRYPOINT+CMD, so service-style images
+/// start as their authors intended. The persistent overlay is keyed by the
+/// machine name so filesystem state survives restarts.
+///
+/// Returns `Ok(false)` (no launch) for machines without an image; callers
+/// handle bare-VM entrypoints themselves.
+pub fn launch_image_workload(
+    client: &mut AgentClient,
+    machine_name: &str,
+    record: &VmRecord,
+    exec_env: Vec<(String, String)>,
+) -> crate::Result<bool> {
+    let Some(ref image) = record.image else {
+        return Ok(false);
+    };
+    let mut command = record.entrypoint.clone();
+    command.extend(record.cmd.clone());
+    let config = RunConfig::new(image, command)
+        .with_env(exec_env)
+        .with_workdir(record.workdir.clone())
+        .with_user(record.user.clone())
+        .with_mounts(record_mounts_to_bindings(&record.mounts))
+        .with_persistent_overlay(Some(machine_name.to_string()));
+    client
+        .run_container_detached(config)
+        .map(|_| true)
+        .map_err(|e| crate::Error::agent("start background CMD", format!("{e}")))
+}


### PR DESCRIPTION
Multi-layer from-vm packs cannot overlay-mount virtiofs-backed lowers at import, so the guest physically merges layers file-by-file through virtiofs — pathologically slow for file-heavy overlays. The from-vm export now overlay-mounts base layers plus the container upperdir inside the helper VM and exports one flattened layer, matching the from-image pre-merge.

The from-vm export and the image-workload launch move into public lib modules (pack_export, workload) so front-end CLIs share one implementation instead of drifting copies, and CreateMachineRequest gains env/workdir fields that merge over the artifact manifest (request wins), fixing API-created machines silently dropping caller env.