### PR TITLE
CUDA 13 guest surface

### DIFF
--- a/crates/smolvm-agent/src/cuda.rs
+++ b/crates/smolvm-agent/src/cuda.rs
@@ -39,6 +39,9 @@ const DRIVER_SHIM: &str = "libcuda.so.1";
 /// interpose is to place the shim at these exact paths (a read-only bind mount
 /// over each file). CUDA 12 and 11 wheel layouts.
 const RPATH_PINNED_SONAMES: &[&str] = &[
+    "libcudart.so.13",
+    "libcublas.so.13",
+    "libcublasLt.so.13",
     "libcudart.so.12",
     "libcublas.so.12",
     "libcublasLt.so.12",

--- a/crates/smolvm-cuda-shim/src/lib.rs
+++ b/crates/smolvm-cuda-shim/src/lib.rs
@@ -49,7 +49,7 @@ const CUDA_ERROR_NOT_SUPPORTED: c_int = 801;
 const CUDA_ERROR_UNKNOWN: c_int = 999;
 
 /// The CUDA version this shim reports for its own API surface.
-const SHIM_CUDA_VERSION: c_int = 12040;
+const SHIM_CUDA_VERSION: c_int = 13020;
 
 // ---- transport ---------------------------------------------------------------
 

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -677,7 +677,7 @@ pub extern "C" fn cudaDriverGetVersion(version: *mut c_int) -> c_int {
 
 #[no_mangle]
 pub extern "C" fn cudaRuntimeGetVersion(version: *mut c_int) -> c_int {
-    set_last(unsafe { out(version, 12040) })
+    set_last(unsafe { out(version, 13000) })
 }
 
 // ---- memory -----------------------------------------------------------------
@@ -2316,6 +2316,125 @@ pub extern "C" fn cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(
     // Coarse estimate: 2048 threads/SM cap divided by the block size, ≥1.
     let bs = block_size.max(1);
     set_last(unsafe { out(num_blocks, (2048 / bs).clamp(1, 32)) })
+}
+
+// ---- CUDA 13 surface --------------------------------------------------------
+// CUDA 13 renamed several `_v2` entry points back to their base names and cu13
+// wheels (torch 2.11+cu130) bind these from libcudart.so.13 / libcublas*.so.13.
+
+#[no_mangle]
+pub extern "C" fn cudaStreamGetCaptureInfo(
+    stream: *mut c_void,
+    status: *mut c_int,
+    id: *mut u64,
+    graph: *mut *mut c_void,
+    deps: *mut *mut *const c_void,
+    num_deps: *mut usize,
+) -> c_int {
+    cudaStreamGetCaptureInfo_v2(stream, status, id, graph, deps, num_deps)
+}
+
+#[no_mangle]
+pub extern "C" fn cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+    num_blocks: *mut c_int,
+    func: *const c_void,
+    block_size: c_int,
+    dynamic_smem: usize,
+) -> c_int {
+    cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(
+        num_blocks,
+        func,
+        block_size,
+        dynamic_smem,
+        0,
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn cublasLtGetVersion() -> usize {
+    130000
+}
+
+/// Driver entry-point lookup (cudart 13): resolve `symbol` from the staged
+/// driver shim (`libcuda.so.1`) so callers get the same interposed surface as
+/// direct linking. Missing symbols report `SymbolNotFound` via `driver_status`
+/// with a success return, per the cudart contract.
+#[no_mangle]
+pub extern "C" fn cudaGetDriverEntryPointByVersion(
+    symbol: *const c_char,
+    func_ptr: *mut *mut c_void,
+    _cuda_version: c_uint,
+    _flags: u64,
+    driver_status: *mut c_int,
+) -> c_int {
+    extern "C" {
+        fn dlopen(filename: *const c_char, flags: c_int) -> *mut c_void;
+        fn dlsym(handle: *mut c_void, symbol: *const c_char) -> *mut c_void;
+    }
+    const RTLD_NOW: c_int = 2;
+    const RTLD_GLOBAL: c_int = 0x100;
+    const ENTRY_POINT_SUCCESS: c_int = 0;
+    const ENTRY_POINT_SYMBOL_NOT_FOUND: c_int = 1;
+    if symbol.is_null() || func_ptr.is_null() {
+        return set_last(CUDA_ERROR_INVALID_VALUE);
+    }
+    let found = unsafe {
+        let lib = dlopen(c"libcuda.so.1".as_ptr(), RTLD_NOW | RTLD_GLOBAL);
+        if lib.is_null() {
+            std::ptr::null_mut()
+        } else {
+            dlsym(lib, symbol)
+        }
+    };
+    unsafe {
+        *func_ptr = found;
+        if !driver_status.is_null() {
+            *driver_status = if found.is_null() {
+                ENTRY_POINT_SYMBOL_NOT_FOUND
+            } else {
+                ENTRY_POINT_SUCCESS
+            };
+        }
+    }
+    set_last(CUDA_SUCCESS)
+}
+
+#[no_mangle]
+pub extern "C" fn cudaGetSymbolAddress(
+    _dev_ptr: *mut *mut c_void,
+    _symbol: *const c_void,
+) -> c_int {
+    // Device-global symbol lookup is not remoted; callers treat this as
+    // "symbol unavailable" (cudaErrorInvalidSymbol).
+    set_last(13)
+}
+
+#[no_mangle]
+pub extern "C" fn cudaMemcpyToSymbol(
+    _symbol: *const c_void,
+    _src: *const c_void,
+    _count: usize,
+    _offset: usize,
+    _kind: c_int,
+) -> c_int {
+    set_last(13)
+}
+
+#[no_mangle]
+pub extern "C" fn cudaGraphNodeGetDependencies(
+    _node: *mut c_void,
+    deps: *mut *mut c_void,
+    num_deps: *mut usize,
+) -> c_int {
+    unsafe {
+        if !num_deps.is_null() {
+            if !deps.is_null() && *num_deps > 0 {
+                // No dependency introspection over the wire; report none.
+            }
+            *num_deps = 0;
+        }
+    }
+    set_last(CUDA_SUCCESS)
 }
 #[no_mangle]
 pub extern "C" fn cudaHostRegister(_ptr: *mut c_void, _size: usize, _flags: c_uint) -> c_int {

--- a/crates/smolvm-nvml-shim/src/lib.rs
+++ b/crates/smolvm-nvml-shim/src/lib.rs
@@ -304,6 +304,103 @@ pub extern "C" fn nvmlDeviceGetP2PStatus(
     NVML_SUCCESS
 }
 
+// ---- torch c10 DriverAPI surface --------------------------------------------
+// torch's expandable-segments support (c10/cuda/driver_api.cpp) dlopens NVML
+// and eagerly asserts its whole symbol table; a single missing name aborts
+// engine startup (vLLM: "Can't find nvmlDeviceGetHandleByPciBusId_v2").
+// NvLink/fabric queries honestly report NOT_SUPPORTED — the remoted view is a
+// single GPU with no NvLink topology.
+
+const NVML_ERROR_NOT_SUPPORTED: c_int = 3;
+
+#[no_mangle]
+pub extern "C" fn nvmlDeviceGetHandleByPciBusId_v2(
+    _pci_bus_id: *const c_char,
+    device: *mut *mut std::ffi::c_void,
+) -> c_int {
+    // The guest sees exactly one device; every bus id resolves to it.
+    if device.is_null() {
+        return NVML_ERROR_INVALID_ARGUMENT;
+    }
+    unsafe { *device = handle_of(0) }
+    NVML_SUCCESS
+}
+
+#[no_mangle]
+pub extern "C" fn nvmlDeviceGetHandleByPciBusId(
+    pci_bus_id: *const c_char,
+    device: *mut *mut std::ffi::c_void,
+) -> c_int {
+    nvmlDeviceGetHandleByPciBusId_v2(pci_bus_id, device)
+}
+
+#[no_mangle]
+pub extern "C" fn nvmlDeviceGetNvLinkRemoteDeviceType(
+    _device: *mut std::ffi::c_void,
+    _link: c_uint,
+    _dev_type: *mut c_int,
+) -> c_int {
+    NVML_ERROR_NOT_SUPPORTED
+}
+
+#[no_mangle]
+pub extern "C" fn nvmlDeviceGetNvLinkRemotePciInfo_v2(
+    _device: *mut std::ffi::c_void,
+    _link: c_uint,
+    _pci: *mut std::ffi::c_void,
+) -> c_int {
+    NVML_ERROR_NOT_SUPPORTED
+}
+
+#[no_mangle]
+pub extern "C" fn nvmlDeviceGetComputeRunningProcesses(
+    _device: *mut std::ffi::c_void,
+    info_count: *mut c_uint,
+    _infos: *mut std::ffi::c_void,
+) -> c_int {
+    // No process visibility across the remoting boundary; report none.
+    if info_count.is_null() {
+        return NVML_ERROR_INVALID_ARGUMENT;
+    }
+    unsafe { *info_count = 0 }
+    NVML_SUCCESS
+}
+
+#[no_mangle]
+pub extern "C" fn nvmlSystemGetCudaDriverVersion_v2(version: *mut c_int) -> c_int {
+    if version.is_null() {
+        return NVML_ERROR_INVALID_ARGUMENT;
+    }
+    let mut v: c_int = 0;
+    let ok = unsafe {
+        match cu_sym(c"cuDriverGetVersion") {
+            Some(f) => {
+                let f: extern "C" fn(*mut c_int) -> c_int = std::mem::transmute(f);
+                f(&mut v) == 0 && v > 0
+            }
+            None => false,
+        }
+    };
+    if !ok {
+        v = 13020;
+    }
+    unsafe { *version = v }
+    NVML_SUCCESS
+}
+
+#[no_mangle]
+pub extern "C" fn nvmlSystemGetCudaDriverVersion(version: *mut c_int) -> c_int {
+    nvmlSystemGetCudaDriverVersion_v2(version)
+}
+
+#[no_mangle]
+pub extern "C" fn nvmlDeviceGetGpuFabricInfoV(
+    _device: *mut std::ffi::c_void,
+    _info: *mut std::ffi::c_void,
+) -> c_int {
+    NVML_ERROR_NOT_SUPPORTED
+}
+
 #[no_mangle]
 pub extern "C" fn nvmlErrorString(_result: c_int) -> *const c_char {
     c"Success".as_ptr()

--- a/scripts/build-agent-rootfs.sh
+++ b/scripts/build-agent-rootfs.sh
@@ -324,10 +324,11 @@ if { [[ -z "$CUDART_SHIM_SRC" ]] || [[ -z "$CUDA_DRIVER_SHIM_SRC" ]]; } \
     && [[ "$NO_BUILD_AGENT" != "1" && "$(uname -s)" == "Linux" && "$(uname -m)" == "$ALPINE_ARCH" ]] \
     && command -v cargo &> /dev/null; then
     echo "Building CUDA guest shims (native gnu target)..."
-    if cargo build --release -p smolvm-cudart-shim -p smolvm-cuda-shim \
+    if cargo build --release -p smolvm-cudart-shim -p smolvm-cuda-shim -p smolvm-nvml-shim \
         --manifest-path "$PROJECT_ROOT/Cargo.toml"; then
         CUDART_SHIM_SRC="${CUDART_SHIM_SRC:-$PROJECT_ROOT/target/release/libcudart.so}"
         CUDA_DRIVER_SHIM_SRC="${CUDA_DRIVER_SHIM_SRC:-$PROJECT_ROOT/target/release/libcuda.so}"
+        NVML_SHIM_SRC="${NVML_SHIM_SRC:-$PROJECT_ROOT/target/release/libnvidia_ml.so}"
     else
         echo "CUDA guest shim build failed — rootfs ships without auto-staging"
     fi
@@ -339,6 +340,12 @@ if [[ -n "$CUDART_SHIM_SRC" && -f "$CUDART_SHIM_SRC" \
     mkdir -p "$OUTPUT_DIR/usr/local/lib/smolvm-cuda"
     cp "$CUDART_SHIM_SRC" "$OUTPUT_DIR/usr/local/lib/smolvm-cuda/libcudart-shim.so"
     cp "$CUDA_DRIVER_SHIM_SRC" "$OUTPUT_DIR/usr/local/lib/smolvm-cuda/libcuda.so.1"
+    # NVML drop-in: frameworks (vLLM) detect the GPU through NVML, not the CUDA
+    # driver — the shim dir rides LD_LIBRARY_PATH, so the plain-soname dlopen of
+    # libnvidia-ml.so.1 resolves here. Best-effort: absent on non-Linux builds.
+    if [[ -n "${NVML_SHIM_SRC:-}" && -f "$NVML_SHIM_SRC" ]]; then
+        cp "$NVML_SHIM_SRC" "$OUTPUT_DIR/usr/local/lib/smolvm-cuda/libnvidia-ml.so.1"
+    fi
     echo "Installed CUDA guest shims"
     # Stamp the shims' wire fingerprint into the rootfs so the host can flag a
     # stale rootfs at boot (internal_boot's warn_if_stale_cuda_shim) instead of


### PR DESCRIPTION
…u130 symbol gaps

torch 2.11+cu130 images (e.g. current vllm/vllm-openai) fail on --cuda machines four ways:

1. The cu13 wheel sonames (libcudart.so.13, libcublas.so.13, libcublasLt.so.13) are not in RPATH_PINNED_SONAMES, so the real pip cudart-13 loads instead of the shim and probes the driver shim pre-init.
2. The pre-init driver version constant (12040) makes cudart-13 refuse the driver ('driver too old'). Bumped to 13020; deriving it from the connected host instead is left as a follow-up.
3. The NVML drop-in (smolvm-nvml-shim) is never staged, so vLLM's platform probe finds no NVML and dies with 'Failed to infer device type' before any CUDA call. build-agent-rootfs.sh now builds it and installs it as libnvidia-ml.so.1 in the shim dir (plain-soname dlopen resolves via the dir's LD_LIBRARY_PATH ride).
4. Seven entry points torch cu130 binds are absent: cudaStreamGetCaptureInfo and cudaOccupancyMaxActiveBlocksPerMultiprocessor (cu13 renamed the _v2 variants back to base names - aliased), cublasLtGetVersion (constant), cudaGetDriverEntryPointByVersion (dlsym passthrough to the staged driver shim, SymbolNotFound via driver_status per contract), cudaGetSymbolAddress / cudaMemcpyToSymbol (honest cudaErrorInvalidSymbol - device-global lookup is not remoted), cudaGraphNodeGetDependencies (reports zero deps).

cudaRuntimeGetVersion now reports 13000; reporting per staged soname via dladdr is a cleaner follow-up.

Validated on 8xH200 (driver 595.71/CUDA 13.2) with the guest VMs on a separate KVM host remoting over SMOLVM_CUDA_DAEMON tcp: torch cu130 matmul, full vLLM (Qwen2.5-VL-3B) OpenAI server, machine fork with --share-weights.