### PR TITLE
Recover fork clones whose worker died, and give clone reconnects a real handshake window

### DIFF
--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -459,8 +459,11 @@ fn bring_up_client(resume_token: u64) -> Result<(Client<Stream>, u64, i32), c_in
     if trace {
         eprintln!("[shim] bring_up: connected fd={fd}");
     }
+    // A fork clone's reconnect handshake waits for its worker's full golden
+    // reconstruction (chunk imports + copies + module staging) — give it real
+    // headroom; a fresh session's handshake stays tight.
     #[cfg(unix)]
-    set_recv_timeout(fd, 10);
+    set_recv_timeout(fd, if resume_token != 0 { 45 } else { 10 });
     let mut client = Client::new(stream);
     let token = client.init(resume_token).map_err(|e| {
         if trace {

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -852,8 +852,35 @@ fn route_clone_connection(fd: std::os::unix::io::RawFd) -> bool {
     };
     let mut reg = clone_worker_registry().lock().unwrap();
     if let Some(&pid) = reg.get(&(token, clone_id)) {
+        // Reap first: an exited worker stays a ZOMBIE (the daemon is its parent
+        // and nothing waits on it), and kill(pid, 0) reports zombies as alive —
+        // without this, one worker death makes every reconnect of that clone
+        // rejected forever (observed as a 54/s reconnect storm on H100).
+        // Reaping also surfaces HOW it died, which nothing logged before.
+        let mut status: libc::c_int = 0;
+        // SAFETY: WNOHANG waitpid on our own child; no blocking, no signals.
+        let r = unsafe { libc::waitpid(pid as i32, &mut status, libc::WNOHANG) };
+        if r == pid as i32 {
+            let (code, sig) = (
+                libc::WEXITSTATUS(status),
+                if libc::WIFSIGNALED(status) {
+                    libc::WTERMSIG(status)
+                } else {
+                    0
+                },
+            );
+            tracing::warn!(
+                token,
+                clone_id,
+                worker_pid = pid,
+                exit_code = code,
+                signal = sig,
+                "clone worker had exited; reaped — spawning a fresh worker for the reconnect"
+            );
+            reg.remove(&(token, clone_id));
+        }
         // SAFETY: kill(pid, 0) — pure liveness probe, no signal delivered.
-        if unsafe { libc::kill(pid as i32, 0) } == 0 {
+        else if unsafe { libc::kill(pid as i32, 0) } == 0 {
             tracing::warn!(
                 token,
                 clone_id,


### PR DESCRIPTION
A dead clone worker became an unreapable zombie that the liveness check saw as alive, turning any worker death into an endless reconnect-reject storm (the 7B H100 failure mode); reconnects now reap, log the death cause, and get a fresh worker.