### PR TITLE
Replay function attributes on clone-worker kernels, and print backtraces on fatal signals

### DIFF
--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -854,7 +854,7 @@ pub fn module_handoff_snapshot(
     token: u64,
 ) -> Option<(
     Vec<(u64, Vec<u8>)>,
-    Vec<(u64, u64, String, Vec<(i32, i32)>)>,
+    Vec<FuncMeta>,
     Vec<(u64, u32)>,
     Vec<(u64, u32)>,
     Vec<(u64, u64, GraphSer)>,
@@ -1018,9 +1018,13 @@ pub fn rebuild_clone_graphs(b: &mut dyn Backend, graphs: Vec<(u64, u64, GraphSer
 /// reloaded / functions re-resolved LAZILY from `mod_images` / `func_meta` at
 /// first use; streams/events are already-recreated golden→worker maps (eager,
 /// few). Clears any prior worker's caches.
+/// One staged golden function: `(golden handle, golden module, name, attribute
+/// replays)` — see [`module_handoff_snapshot`].
+pub type FuncMeta = (u64, u64, String, Vec<(i32, i32)>);
+
 pub fn set_handle_trans(
     mod_images: Vec<(u64, Vec<u8>)>,
-    func_meta: Vec<(u64, u64, String, Vec<(i32, i32)>)>,
+    func_meta: Vec<FuncMeta>,
     streams: Vec<(u64, u64)>,
     events: Vec<(u64, u64)>,
 ) {

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -672,6 +672,12 @@ struct GoldenLayout {
     /// M3a: golden function handle → (module handle, name) — the worker re-resolves
     /// it in its reloaded module and remaps the inherited raw CUfunction handle.
     functions: HashMap<u64, (u64, String)>,
+    /// Function attributes the golden set (`cuFuncSetAttribute`) — chiefly
+    /// FlashAttention's MaxDynamicSharedMemorySize opt-in, applied once at
+    /// library import. Per-context state: a worker's re-resolved function
+    /// reverts to the 48KB default and every large-smem launch fails with
+    /// "invalid argument" until these are replayed.
+    func_attrs: HashMap<u64, Vec<(i32, i32)>>,
     /// M3a: golden stream handle → create flags (the worker recreates + remaps).
     streams: HashMap<u64, u32>,
     /// M3a: golden event handle → create flags (the worker recreates + remaps).
@@ -848,7 +854,7 @@ pub fn module_handoff_snapshot(
     token: u64,
 ) -> Option<(
     Vec<(u64, Vec<u8>)>,
-    Vec<(u64, u64, String)>,
+    Vec<(u64, u64, String, Vec<(i32, i32)>)>,
     Vec<(u64, u32)>,
     Vec<(u64, u32)>,
     Vec<(u64, u64, GraphSer)>,
@@ -861,7 +867,14 @@ pub fn module_handoff_snapshot(
     let funcs = g
         .functions
         .iter()
-        .map(|(&h, (m, n))| (h, *m, n.clone()))
+        .map(|(&h, (m, n))| {
+            (
+                h,
+                *m,
+                n.clone(),
+                g.func_attrs.get(&h).cloned().unwrap_or_default(),
+            )
+        })
         .collect();
     let streams = g.streams.iter().map(|(&h, &f)| (h, f)).collect();
     let events = g.events.iter().map(|(&h, &f)| (h, f)).collect();
@@ -905,7 +918,7 @@ pub fn replay_lib_handles(b: &mut dyn Backend, handles: &[(u8, u16, u64, Vec<u8>
 // (identity) unless a Path-3 clone worker installed it via `set_handle_trans`.
 type HandleMap = std::cell::RefCell<HashMap<u64, u64>>;
 type ImageMap = std::cell::RefCell<HashMap<u64, Vec<u8>>>;
-type MetaMap = std::cell::RefCell<HashMap<u64, (u64, String)>>;
+type MetaMap = std::cell::RefCell<HashMap<u64, (u64, String, Vec<(i32, i32)>)>>;
 thread_local! {
     static FUNC_TRANS: HandleMap = std::cell::RefCell::new(HashMap::new());
     static MOD_TRANS: HandleMap = std::cell::RefCell::new(HashMap::new());
@@ -1007,7 +1020,7 @@ pub fn rebuild_clone_graphs(b: &mut dyn Backend, graphs: Vec<(u64, u64, GraphSer
 /// few). Clears any prior worker's caches.
 pub fn set_handle_trans(
     mod_images: Vec<(u64, Vec<u8>)>,
-    func_meta: Vec<(u64, u64, String)>,
+    func_meta: Vec<(u64, u64, String, Vec<(i32, i32)>)>,
     streams: Vec<(u64, u64)>,
     events: Vec<(u64, u64)>,
 ) {
@@ -1028,7 +1041,7 @@ pub fn set_handle_trans(
     FUNC_META.with(|m| {
         let mut m = m.borrow_mut();
         m.clear();
-        m.extend(func_meta.into_iter().map(|(f, gm, n)| (f, (gm, n))));
+        m.extend(func_meta.into_iter().map(|(f, gm, n, a)| (f, (gm, n, a))));
     });
     put_h(&STREAM_TRANS, streams);
     put_h(&EVENT_TRANS, events);
@@ -1088,7 +1101,7 @@ fn xlat_func(b: &mut dyn Backend, golden: u64) -> u64 {
     if let Some(w) = FUNC_TRANS.with(|m| m.borrow().get(&golden).copied()) {
         return w;
     }
-    let Some((gm, name)) = FUNC_META.with(|m| m.borrow().get(&golden).cloned()) else {
+    let Some((gm, name, attrs)) = FUNC_META.with(|m| m.borrow().get(&golden).cloned()) else {
         return golden;
     };
     let wm = xlat_mod(b, gm);
@@ -1097,6 +1110,14 @@ fn xlat_func(b: &mut dyn Backend, golden: u64) -> u64 {
     }
     match b.module_get_function(wm, &name) {
         Ok(w) => {
+            // Re-apply the golden's per-function attributes in THIS context —
+            // without FlashAttention's MaxDynamicSharedMemorySize opt-in, its
+            // decode kernels launch with >48KB smem and fail "invalid argument".
+            for &(a, v) in &attrs {
+                if let Err(e) = b.func_set_attribute(w, a, v) {
+                    eprintln!("[M3a-lazy] func attr replay failed: name={name} attr={a} e={e}");
+                }
+            }
             FUNC_TRANS.with(|m| {
                 m.borrow_mut().insert(golden, w);
             });
@@ -2166,6 +2187,15 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             value,
         } => {
             let raw_fn = raw_fn_h(sess, b, function);
+            if path3_enabled() {
+                sess.golden_layout
+                    .lock()
+                    .unwrap()
+                    .func_attrs
+                    .entry(raw_fn)
+                    .or_default()
+                    .push((attrib, value));
+            }
             b.func_set_attribute(raw_fn, attrib, value)
                 .map(|_| Response::Ok)
         }

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -101,10 +101,7 @@ pub(crate) fn install_crash_handler(role: &'static str) {
         // SAFETY: installing a handler that only formats + re-raises.
         unsafe {
             let mut sa: libc::sigaction = std::mem::zeroed();
-            #[allow(clippy::fn_to_numeric_cast_any)] // sigaction's ABI wants the raw address
-            {
-                sa.sa_sigaction = on_fatal as usize;
-            }
+            sa.sa_sigaction = on_fatal as *const () as usize;
             sa.sa_flags = libc::SA_ONSTACK;
             libc::sigaction(sig, &sa, std::ptr::null_mut());
         }

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -77,7 +77,40 @@ fn spawn_idle_watchdog(active: Arc<AtomicUsize>, timeout: Duration) {
 /// thread against a fresh backend — all in this process, so they share one GPU
 /// context. Returns only on listener failure; otherwise exits via the idle
 /// watchdog (or runs until the host shuts down when the timeout is disabled).
+/// Fatal-signal backtrace: the daemon and its clone workers host large unsafe
+/// surfaces (the CUDA driver itself, raw-pointer translation, IPC mappings). A
+/// SIGSEGV/SIGABRT/SIGBUS here previously died SILENTLY — a daemon segfault
+/// under concurrent 7B vLLM engines left a 933-byte log and no evidence. The
+/// handler writes the signal and a native backtrace to stderr (async-signal-
+/// unsafe in principle, but we are crashing anyway — best-effort output beats
+/// none) and then re-raises with the default action so wait() sees the truth.
+#[cfg(unix)]
+pub(crate) fn install_crash_handler(role: &'static str) {
+    static ROLE: std::sync::OnceLock<&'static str> = std::sync::OnceLock::new();
+    let _ = ROLE.set(role);
+    unsafe extern "C" fn on_fatal(sig: libc::c_int) {
+        let role = ROLE.get().copied().unwrap_or("cuda-proc");
+        eprintln!("[{role}] FATAL signal {sig}; backtrace:");
+        eprintln!("{}", std::backtrace::Backtrace::force_capture());
+        unsafe {
+            libc::signal(sig, libc::SIG_DFL);
+            libc::raise(sig);
+        }
+    }
+    for sig in [libc::SIGSEGV, libc::SIGABRT, libc::SIGBUS, libc::SIGILL] {
+        // SAFETY: installing a handler that only formats + re-raises.
+        unsafe {
+            let mut sa: libc::sigaction = std::mem::zeroed();
+            sa.sa_sigaction = on_fatal as usize;
+            sa.sa_flags = libc::SA_ONSTACK;
+            libc::sigaction(sig, &sa, std::ptr::null_mut());
+        }
+    }
+}
+
 pub fn run(sock: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    install_crash_handler("cuda-daemon");
     if let Some(parent) = sock.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
@@ -226,6 +259,7 @@ fn make_backend() -> Box<dyn Backend> {
 /// hook in before the serve loop; establishing the process boundary comes first.
 pub fn run_clone_worker(fd: std::os::unix::io::RawFd) -> io::Result<()> {
     use std::os::unix::io::FromRawFd;
+    install_crash_handler("cuda-clone-worker");
     let mut backend = make_backend();
     // Our own primary context (separate process ⇒ own UVA), so we can place memory
     // at the golden's exact VAs.

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -101,13 +101,17 @@ pub(crate) fn install_crash_handler(role: &'static str) {
         // SAFETY: installing a handler that only formats + re-raises.
         unsafe {
             let mut sa: libc::sigaction = std::mem::zeroed();
-            sa.sa_sigaction = on_fatal as usize;
+            #[allow(clippy::fn_to_numeric_cast_any)] // sigaction's ABI wants the raw address
+            {
+                sa.sa_sigaction = on_fatal as usize;
+            }
             sa.sa_flags = libc::SA_ONSTACK;
             libc::sigaction(sig, &sa, std::ptr::null_mut());
         }
     }
 }
 
+/// Serve the shared CUDA daemon on `sock` (spawned as `smolvm _cuda-daemon`).
 pub fn run(sock: &Path) -> io::Result<()> {
     #[cfg(unix)]
     install_crash_handler("cuda-daemon");
@@ -627,7 +631,7 @@ fn reconstruct_golden_modules(
     path: &str,
 ) -> (
     Vec<(u64, Vec<u8>)>,
-    Vec<(u64, u64, String, Vec<(i32, i32)>)>,
+    Vec<smolvm_cuda::host::FuncMeta>,
     Vec<(u64, u64)>,
     Vec<(u64, u64)>,
     Vec<(u64, u64, smolvm_cuda::host::GraphSer)>,

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -593,7 +593,7 @@ fn reconstruct_golden_modules(
     path: &str,
 ) -> (
     Vec<(u64, Vec<u8>)>,
-    Vec<(u64, u64, String)>,
+    Vec<(u64, u64, String, Vec<(i32, i32)>)>,
     Vec<(u64, u64)>,
     Vec<(u64, u64)>,
     Vec<(u64, u64, smolvm_cuda::host::GraphSer)>,
@@ -664,7 +664,14 @@ fn reconstruct_golden_modules(
         need!(nlen);
         let name = String::from_utf8_lossy(&buf[p..p + nlen]).into_owned();
         p += nlen;
-        func_meta.push((gf, gm, name));
+        let nattrs = ru32!();
+        let mut attrs = Vec::with_capacity(nattrs as usize);
+        for _ in 0..nattrs {
+            let a = ru32!() as i32;
+            let v = ru32!() as i32;
+            attrs.push((a, v));
+        }
+        func_meta.push((gf, gm, name, attrs));
     }
     // Streams + events: recreate each with its golden create flags in OUR context,
     // mapping the golden's inherited raw handle → our own (same M3a pattern).
@@ -1177,11 +1184,18 @@ fn spawn_clone_worker(
             blob.extend_from_slice(img);
         }
         blob.extend_from_slice(&(funcs.len() as u32).to_le_bytes());
-        for (h, m, n) in &funcs {
+        for (h, m, n, attrs) in &funcs {
             blob.extend_from_slice(&h.to_le_bytes());
             blob.extend_from_slice(&m.to_le_bytes());
             blob.extend_from_slice(&(n.len() as u32).to_le_bytes());
             blob.extend_from_slice(n.as_bytes());
+            // Per-function attribute replays ([i32 attr][i32 value] each) —
+            // e.g. FlashAttention's MaxDynamicSharedMemorySize opt-in.
+            blob.extend_from_slice(&(attrs.len() as u32).to_le_bytes());
+            for &(a, v) in attrs {
+                blob.extend_from_slice(&a.to_le_bytes());
+                blob.extend_from_slice(&v.to_le_bytes());
+            }
         }
         // Streams + events: [u64 golden handle][u32 create flags] each.
         blob.extend_from_slice(&(streams.len() as u32).to_le_bytes());


### PR DESCRIPTION
Re-lands the two commits orphaned by the #675 squash: the FlashAttention cuFuncSetAttribute replay (the root-cause fix for sm90 clone deaths and vLLM fork serving — H100-verified) and fatal-signal backtraces for the daemon and workers.