### PR TITLE
Route a fork clone's execs to its inherited overlay and heal the restored stale mount

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -3660,7 +3660,20 @@ pub fn resolve_main_container(persistent_overlay_id: Option<&str>) -> Option<Str
     }
 
     if is_container_running(&cid) {
-        return Some(cid);
+        // A restored fork clone's keep-alive container is alive (its process
+        // came back with the golden's RAM) but runs from the golden's
+        // pre-fork overlay mount, whose virtiofs lowerdirs are stale in the
+        // clone — joining it fails every exec with ESTALE. Only hand the
+        // container out if its overlay still answers lookups; otherwise
+        // recycle it so the caller re-establishes container + overlay fresh
+        // (the remount keeps the CoW-inherited upper layer).
+        if storage::persistent_overlay_mount_is_healthy(&workload_id) {
+            return Some(cid);
+        }
+        info!(container_id = %cid, "main container's overlay mount is stale (restored fork state); recycling");
+        let _ = std::fs::remove_file(&id_path);
+        let _ = crun::CrunCommand::delete(&cid, true).output();
+        return None;
     }
 
     // Stale: container died. Clean up the ID file and crun state.

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -2410,16 +2410,41 @@ impl OverlaySetup {
 
     /// Reuse an existing persistent overlay or create a new one.
     ///
-    /// If the overlay is already mounted, returns it immediately.
+    /// If the overlay is already mounted AND healthy, returns it immediately.
+    /// A mounted-but-stale overlay (a fork clone's RAM image carries the
+    /// golden's overlay mount, whose virtiofs lowerdirs died with the pre-fork
+    /// virtiofsd session — every fresh lookup through it is ESTALE) is torn
+    /// down and remounted from its intact upper layer, so the clone keeps the
+    /// golden's exec-written state instead of erroring on every exec.
     /// If the overlay directory exists but is not mounted (e.g. after VM restart),
     /// remounts it preserving the upper layer (which contains previous changes).
     /// If the overlay does not exist at all, creates it fresh.
     fn execute_or_remount(self, lowerdirs: Vec<String>) -> Result<OverlayInfo> {
-        // Already mounted — just reuse it
+        // Already mounted — reuse it only if it actually answers lookups.
         if self.merged_path.exists() && is_mountpoint(&self.merged_path) {
-            info!(workload_id = %self.workload_id, "reusing existing persistent overlay");
-            self.create_bundle()?;
-            return Ok(self.into_overlay_info());
+            if mounted_overlay_is_healthy(&self.merged_path) {
+                info!(workload_id = %self.workload_id, "reusing existing persistent overlay");
+                self.create_bundle()?;
+                return Ok(self.into_overlay_info());
+            }
+            // Stale restored mount (fork clone). The restored keep-alive
+            // container (if any) still runs from it — kill it so the next
+            // exec establishes a fresh one on the healed overlay, then detach
+            // the dead mount and fall through to the remount path below,
+            // which reuses the (CoW-inherited) upper layer.
+            warn!(
+                workload_id = %self.workload_id,
+                "persistent overlay mount is stale (restored fork state); remounting from its upper layer"
+            );
+            let id_path = paths::main_container_id_path(&self.workload_id);
+            if let Ok(cid) = std::fs::read_to_string(&id_path) {
+                let cid = cid.trim();
+                if !cid.is_empty() {
+                    let _ = CrunCommand::delete(cid, true).output();
+                }
+            }
+            let _ = std::fs::remove_file(&id_path);
+            detach_mount(&self.merged_path);
         }
 
         // Upper layer exists from a previous session — remount preserving it
@@ -3057,6 +3082,67 @@ fn setup_volume_mounts(_rootfs: &str, _mounts: &[(String, String, bool)]) -> Res
 /// Check if a path is a mountpoint (delegates to paths::is_mount_point).
 fn is_mountpoint(path: &Path) -> bool {
     paths::is_mount_point(path)
+}
+
+/// Whether a persistent overlay's mounted state (if any) answers lookups.
+/// True when the overlay isn't mounted at all — "nothing stale to heal".
+/// Used by `resolve_main_container` to refuse handing out a restored
+/// keep-alive container whose rootfs mount is dead.
+pub fn persistent_overlay_mount_is_healthy(workload_id: &str) -> bool {
+    let Ok(root) = overlay_root_for_workload(workload_id) else {
+        return true;
+    };
+    let merged = root.join("merged");
+    !(merged.exists() && is_mountpoint(&merged)) || mounted_overlay_is_healthy(&merged)
+}
+
+/// Whether an already-mounted persistent overlay actually answers lookups.
+///
+/// A fork clone's restored RAM image carries the golden's overlay mount, but
+/// the mount's virtiofs lowerdirs reference the pre-fork virtiofsd session —
+/// in the clone every *fresh* lookup through it fails with ESTALE, while
+/// page-cached entries may still read fine. So the probe is a lookup that
+/// cannot be served from cache: a name never looked up before. A healthy
+/// mount answers NotFound; a stale one surfaces the lowerdir error.
+fn mounted_overlay_is_healthy(merged: &Path) -> bool {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let probe = merged.join(format!(".smolvm-stale-probe-{nonce}"));
+    match std::fs::metadata(&probe) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
+        Err(e) => {
+            warn!(path = %merged.display(), error = %e, "mounted overlay failed the lookup probe");
+            false
+        }
+        Ok(_) => true,
+    }
+}
+
+/// Lazily detach a dead mount (`umount2(MNT_DETACH)`): the tree is unhooked
+/// immediately while any restored process still holding it keeps its
+/// references until it exits. Best-effort — a failure here just means the
+/// subsequent fresh mount shadows the stale one.
+fn detach_mount(path: &Path) {
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        if let Ok(c) = std::ffi::CString::new(path.as_os_str().as_bytes()) {
+            let rc = unsafe { libc::umount2(c.as_ptr(), libc::MNT_DETACH) };
+            if rc != 0 {
+                warn!(
+                    path = %path.display(),
+                    errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0),
+                    "could not detach stale overlay mount"
+                );
+            }
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = path;
+    }
 }
 
 /// Run a command using crun OCI runtime (one-shot execution).

--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -317,30 +317,26 @@ fn clone_fork_disks(gdir: &Path, clone_dir: &Path) -> Result<()> {
 /// `vm_exec` errors or exits non-zero transiently.
 const REJUVENATE_ATTEMPTS: usize = 3;
 
-/// Build the shell script that re-mints a clone's on-disk identity and adopts
-/// the golden's persistent exec overlay. Kept as a pure function of
-/// `(clone, golden, seed)` so the security-critical contents (fresh
+/// Build the shell script that re-mints a clone's on-disk identity. Kept as a
+/// pure function of `(clone, seed)` so the security-critical contents (fresh
 /// machine-id, regenerated SSH host keys) are unit-tested without a live VM.
 ///
-/// `clone` and `golden` are validated machine names (alphanumeric + dashes)
-/// and `seed` is hex, so single-quoting them is injection-safe.
+/// `clone` is a validated machine name (alphanumeric + dashes) and `seed` is
+/// hex, so single-quoting both is injection-safe.
 ///
-/// OVERLAY ADOPTION: the CoW disk clone carries the golden's persistent exec
-/// overlay byte-for-byte, but it sits at `/storage/overlays/persistent-<golden>`
-/// while the clone's execs resolve `/storage/overlays/persistent-<clone>` — so
-/// without a re-key the clone would mount a fresh empty upper next to the
-/// inherited one and appear to start blank. Renaming it (same ext4, atomic)
-/// makes the clone's first exec find and remount the golden's upper, i.e. the
-/// clone inherits everything the golden wrote via exec. Guarded: no-op when the
-/// golden never ran an exec (no source dir) or the clone already has its own
-/// overlay (never clobber real state).
+/// NOTE: this deliberately does NOT touch `/storage/overlays`. The clone's
+/// inherited exec overlay stays under the GOLDEN's id and the restored guest
+/// may still hold it mounted (or have a restored workload container running
+/// from it) — renaming it on disk poisons that live overlayfs mount (ESTALE
+/// in every subsequent container exec). Hosts alias the overlay lookup
+/// instead (`crate::workload::persistent_overlay_owner`).
 ///
 /// The script is fail-hard on the *unambiguously per-machine* identity material
 /// (`set -e`): if a clone cannot get its own machine-id or SSH host keys, the
 /// fork must fail rather than vend a clone that impersonates the golden. Steps
 /// that are legitimately absent on minimal/library images (no sshd, no dbus,
 /// no cloud-init) are guarded so they no-op instead of failing.
-fn build_rejuvenation_script(clone: &str, golden: &str, seed: &str) -> String {
+fn build_rejuvenation_script(clone: &str, seed: &str) -> String {
     format!(
         "set -e; \
          hostname '{c}' 2>/dev/null || true; \
@@ -354,13 +350,9 @@ fn build_rejuvenation_script(clone: &str, golden: &str, seed: &str) -> String {
              ssh-keygen -A >/dev/null 2>&1; \
          fi; \
          rm -rf /var/lib/cloud/instance /var/lib/cloud/instances/* /var/lib/cloud/data/instance-id 2>/dev/null || true; \
-         if [ -d '/storage/overlays/persistent-{g}' ] && [ ! -e '/storage/overlays/persistent-{c}' ]; then \
-             mv '/storage/overlays/persistent-{g}' '/storage/overlays/persistent-{c}'; \
-         fi; \
          printf '%s' '{s}' > /dev/urandom 2>/dev/null || true; \
          true",
         c = clone,
-        g = golden,
         s = seed,
     )
 }
@@ -372,11 +364,7 @@ fn build_rejuvenation_script(clone: &str, golden: &str, seed: &str) -> String {
 /// cross-tenant impersonation / MITM hole (identical SSH host keys) and a
 /// duplicate-identity bug. This runs over the freshly-booted clone's agent to
 /// give it a fresh hostname, machine-id, SSH host keys, and to stir the kernel
-/// RNG with fresh host entropy so the random streams diverge. It also re-keys
-/// the golden's persistent exec overlay to the clone's name so the clone's
-/// execs see the filesystem state the golden built up (see
-/// [`build_rejuvenation_script`]) — the disks are already CoW-inherited; this
-/// makes the inherited overlay *findable* under the clone's own id.
+/// RNG with fresh host entropy so the random streams diverge.
 ///
 /// FAIL-CLOSED: this returns `Err` if the reset could not be *confirmed* (agent
 /// unreachable, or the re-mint script exited non-zero) after
@@ -394,10 +382,10 @@ fn build_rejuvenation_script(clone: &str, golden: &str, seed: &str) -> String {
 /// disk rejuvenation. Likewise this stirs but does not *credit* entropy
 /// (no `RNDADDENTROPY`/VMGENID yet) and does not re-address the network
 /// (MAC/IP; safe under the default TSI backend) — both are follow-ups.
-pub fn rejuvenate_clone(clone: &str, golden: &str) -> Result<()> {
+pub fn rejuvenate_clone(clone: &str) -> Result<()> {
     let sock = vm_data_dir(clone).join("agent.sock");
     let seed = host_random_hex(64);
-    let script = build_rejuvenation_script(clone, golden, &seed);
+    let script = build_rejuvenation_script(clone, &seed);
 
     let mut last_err = String::from("unknown error");
     for attempt in 1..=REJUVENATE_ATTEMPTS {
@@ -496,7 +484,7 @@ mod tests {
     // above all the SSH host keys.
     #[test]
     fn rejuvenation_script_regenerates_per_machine_secrets() {
-        let script = build_rejuvenation_script("clone-a", "golden-a", "deadbeef");
+        let script = build_rejuvenation_script("clone-a", "deadbeef");
 
         // SSH host keys: delete the golden's, then regenerate fresh ones.
         assert!(
@@ -520,25 +508,17 @@ mod tests {
         assert!(script.contains("command -v ssh-keygen"));
     }
 
-    // The CoW disk clone carries the golden's persistent exec overlay, but the
-    // clone's execs look it up under the clone's own name — the script must
-    // re-key it so the clone actually inherits the golden's filesystem state,
-    // and must never clobber an overlay the clone already owns.
+    // The rejuvenation script must NOT touch the inherited exec overlay: the
+    // restored guest may still hold it mounted, and renaming a live
+    // overlayfs's backing directories breaks every subsequent container exec
+    // (ESTALE). Overlay adoption is a host-side lookup alias instead.
     #[test]
-    fn rejuvenation_script_adopts_goldens_persistent_overlay() {
-        let script = build_rejuvenation_script("clone-a", "golden-a", "deadbeef");
-
-        // Renames the golden's overlay dir to the clone's id.
+    fn rejuvenation_script_leaves_the_inherited_overlay_alone() {
+        let script = build_rejuvenation_script("clone-a", "deadbeef");
         assert!(
-            script.contains(
-                "mv '/storage/overlays/persistent-golden-a' '/storage/overlays/persistent-clone-a'"
-            ),
-            "script must re-key the inherited overlay to the clone: {script}"
+            !script.contains("/storage/overlays"),
+            "script must not rename/touch overlay dirs: {script}"
         );
-        // Guarded on both sides: source must exist (golden may never have
-        // exec'd) and destination must not (never overwrite the clone's own).
-        assert!(script.contains("[ -d '/storage/overlays/persistent-golden-a' ]"));
-        assert!(script.contains("[ ! -e '/storage/overlays/persistent-clone-a' ]"));
     }
 
     // Fix 2 (fail-closed): an Err rejuvenation must tear the clone down and

--- a/src/api/handlers/exec.rs
+++ b/src/api/handlers/exec.rs
@@ -81,7 +81,9 @@ pub async fn exec_command(
     if req.background {
         let command = req.command.clone();
         let workdir = req.workdir.clone();
-        let machine_image = state.lookup_vm(&id).await?.and_then(|r| r.image);
+        let machine_rec = state.lookup_vm(&id).await?;
+        let machine_golden = machine_rec.as_ref().and_then(|r| r.golden.clone());
+        let machine_image = machine_rec.and_then(|r| r.image);
         let pid = if let Some(image) = machine_image {
             let mounts_config = {
                 let e = entry.lock();
@@ -91,7 +93,10 @@ pub async fn exec_command(
                     .map(|(i, m)| (HostMount::mount_tag(i), m.target.clone(), m.readonly))
                     .collect::<Vec<_>>()
             };
-            let overlay_id = id.clone();
+            // A fork clone's inherited overlay lives under the golden's id
+            // (see `persistent_overlay_owner`).
+            let overlay_id =
+                crate::workload::persistent_overlay_owner(&id, machine_golden.as_deref());
             with_machine_client_traced(&entry, tid, move |c| {
                 if c.query(&image)?.is_none() {
                     c.pull_with_registry_config(&image)?;
@@ -132,7 +137,9 @@ pub async fn exec_command(
     // sessions. Without this, exec runs in the bare agent VM (no `python3`,
     // etc.) — the image is never entered. Plain machines exec in the VM
     // directly via `vm_exec`.
-    let machine_image = state.lookup_vm(&id).await?.and_then(|r| r.image);
+    let machine_rec = state.lookup_vm(&id).await?;
+    let machine_golden = machine_rec.as_ref().and_then(|r| r.golden.clone());
+    let machine_image = machine_rec.and_then(|r| r.image);
 
     let start = std::time::Instant::now();
     let (exit_code, stdout, stderr) = if let Some(image) = machine_image {
@@ -144,7 +151,8 @@ pub async fn exec_command(
                 .map(|(i, m)| (HostMount::mount_tag(i), m.target.clone(), m.readonly))
                 .collect::<Vec<_>>()
         };
-        let overlay_id = id.clone();
+        // A fork clone's inherited overlay lives under the golden's id.
+        let overlay_id = crate::workload::persistent_overlay_owner(&id, machine_golden.as_deref());
         let stdin_data = stdin_data.clone();
         with_machine_client_traced(&entry, tid, move |c| {
             // Pull only if the image isn't already present — avoids a registry
@@ -227,7 +235,9 @@ pub async fn exec_stream(
     // overlay keyed by machine name); plain machines stream from the VM
     // directly. Without this, streaming exec on an image machine produces no
     // output (the agent-base streaming path doesn't enter the container).
-    let machine_image = state.lookup_vm(&id).await?.and_then(|r| r.image);
+    let machine_rec = state.lookup_vm(&id).await?;
+    let machine_golden = machine_rec.as_ref().and_then(|r| r.golden.clone());
+    let machine_image = machine_rec.and_then(|r| r.image);
 
     // Run streaming exec via the machine client (vsock is synchronous)
     let start = std::time::Instant::now();
@@ -240,7 +250,8 @@ pub async fn exec_stream(
                 .map(|(i, m)| (HostMount::mount_tag(i), m.target.clone(), m.readonly))
                 .collect::<Vec<_>>()
         };
-        let overlay_id = id.clone();
+        // A fork clone's inherited overlay lives under the golden's id.
+        let overlay_id = crate::workload::persistent_overlay_owner(&id, machine_golden.as_deref());
         with_machine_client_traced(&entry, tid, move |c| {
             if c.query(&image)?.is_none() {
                 c.pull_with_registry_config(&image)?;

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -965,7 +965,7 @@ pub async fn start_machine(
                 .map(|(i, m)| (HostMount::mount_tag(i), m.target.clone(), m.readonly))
                 .collect::<Vec<_>>()
         };
-        let overlay_id = name.clone();
+        let overlay_id = crate::workload::persistent_overlay_owner(&name, record.golden.as_deref());
         // Pull the image FIRST, as a FATAL step. A pull failure — the image /
         // tag doesn't exist, is private without access, or the machine has no
         // network to reach the registry — is a permanent, user-fixable
@@ -1114,7 +1114,6 @@ pub async fn fork_machine(
     // processes are already running in the restored RAM, so unlike a cold start
     // there is no image workload to launch), then rejuvenate its identity.
     let clone_b = clone.clone();
-    let golden_c = golden.clone();
     let db = state.db().clone();
     let (manager, pid, clone_record) = tokio::task::spawn_blocking(move || {
         let record = prep.clone_record;
@@ -1150,7 +1149,7 @@ pub async fn fork_machine(
         // confirmed, tear the booted clone down and fail the fork rather than
         // vend a clone that impersonates the golden.
         crate::agent::fork::fail_closed_on_rejuvenation(
-            crate::agent::fork::rejuvenate_clone(&clone_b, &golden_c),
+            crate::agent::fork::rejuvenate_clone(&clone_b),
             || {
                 manager.kill();
                 manager.cleanup_data_dir();

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -751,7 +751,7 @@ pub fn fork_vm(
         // FAIL-CLOSED: if the reset can't be confirmed, stop the booted clone and
         // roll it back rather than leave it live with the golden's secrets.
         smolvm::agent::fork::fail_closed_on_rejuvenation(
-            smolvm::agent::fork::rejuvenate_clone(clone, golden),
+            smolvm::agent::fork::rejuvenate_clone(clone),
             || {
                 if let Ok(manager) = AgentManager::for_vm(clone) {
                     manager.kill();

--- a/src/embedded/control.rs
+++ b/src/embedded/control.rs
@@ -169,7 +169,7 @@ pub fn fork_vm(
             // and roll it back rather than leave it live with the golden's
             // per-machine secrets.
             crate::agent::fork::fail_closed_on_rejuvenation(
-                crate::agent::fork::rejuvenate_clone(clone, golden),
+                crate::agent::fork::rejuvenate_clone(clone),
                 || {
                     let _ = handle.stop();
                     let _ = db.remove_vm(clone);

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -22,13 +22,27 @@ pub fn record_mounts_to_bindings(mounts: &[(String, String, bool)]) -> Vec<(Stri
         .collect()
 }
 
+/// The id under which a machine's persistent exec overlay lives on its
+/// `/storage` disk. Normally the machine's own name; for a fork clone it is
+/// the GOLDEN's name: a fork CoW-clones the golden's disks, so the inherited
+/// overlay — everything the golden wrote via exec — sits at
+/// `/storage/overlays/persistent-<golden>` inside the clone's own disk, and
+/// the restored guest may still hold that overlay *mounted* (or a restored
+/// workload container running from it). Aliasing the lookup, instead of
+/// renaming the directory on disk, keeps that live mount valid while making
+/// the clone's execs land in the inherited state.
+pub fn persistent_overlay_owner(name: &str, golden: Option<&str>) -> String {
+    golden.unwrap_or(name).to_string()
+}
+
 /// Launch an image machine's workload container in the background.
 ///
 /// `exec_env` is the record env with secrets already resolved — resolution is
 /// a host-side concern the caller owns. An empty entrypoint+cmd makes the
 /// agent resolve the image's own ENTRYPOINT+CMD, so service-style images
-/// start as their authors intended. The persistent overlay is keyed by the
-/// machine name so filesystem state survives restarts.
+/// start as their authors intended. The persistent overlay is keyed by
+/// [`persistent_overlay_owner`] (the machine name, or the golden's for a fork
+/// clone) so filesystem state survives restarts and forks.
 ///
 /// Returns `Ok(false)` (no launch) for machines without an image; callers
 /// handle bare-VM entrypoints themselves.
@@ -48,9 +62,29 @@ pub fn launch_image_workload(
         .with_workdir(record.workdir.clone())
         .with_user(record.user.clone())
         .with_mounts(record_mounts_to_bindings(&record.mounts))
-        .with_persistent_overlay(Some(machine_name.to_string()));
+        .with_persistent_overlay(Some(persistent_overlay_owner(
+            machine_name,
+            record.golden.as_deref(),
+        )));
     client
         .run_container_detached(config)
         .map(|_| true)
         .map_err(|e| crate::Error::agent("start background CMD", format!("{e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A plain machine's overlay is keyed by its own name; a fork clone's by
+    // its golden's name, so clone execs land in the CoW-inherited overlay
+    // (and its still-live restored mount) instead of a fresh empty one.
+    #[test]
+    fn overlay_owner_aliases_fork_clones_to_their_golden() {
+        assert_eq!(persistent_overlay_owner("m1", None), "m1");
+        assert_eq!(
+            persistent_overlay_owner("clone-a", Some("golden-a")),
+            "golden-a"
+        );
+    }
 }


### PR DESCRIPTION
A fork CoW-clones the golden's disks, so everything the golden wrote via exec is already inside the clone's disk under the golden's overlay id — but clone execs looked the overlay up under the clone's own id and mounted a fresh empty upper, so clones appeared to start blank. The previous approach renamed the overlay directory inside the clone, which broke worse: the restored RAM image still holds that overlay mounted (with a keep-alive container running from it), and renaming a live overlayfs's backing directories poisons it.

This replaces the rename with a lookup alias plus a self-heal:
- hosts resolve a clone's persistent overlay id to its golden's (`persistent_overlay_owner`), so execs and workload launches land in the inherited overlay;
- the agent no longer touches `/storage/overlays` during identity rejuvenation;
- `resolve_main_container` refuses to hand out a restored keep-alive container whose overlay mount no longer answers lookups (the restored mount's virtiofs lowerdirs die with the pre-fork virtiofsd session — every fresh lookup is ESTALE) and recycles it instead;
- `execute_or_remount` probes an already-mounted overlay with an uncacheable lookup before reuse, and on staleness detaches the dead mount and remounts from the intact upper layer — preserving the inherited state.

Verified live: a clone's first exec reads files the golden wrote before the fork, clone writes stay private, repeated forks of the same frozen golden all inherit, and plain-machine persistence across execs and stop/start is unchanged.