### PR TITLE
Fail a from-vm pack of a never-started machine with a clear error and stop leaking scratch dirs on failed helper boots

### DIFF
--- a/src/pack_export.rs
+++ b/src/pack_export.rs
@@ -166,6 +166,20 @@ impl ExportVm {
         network: bool,
     ) -> crate::Result<Self> {
         let (storage_disk, storage_fmt) = resolve_disk_image(source_vm_dir, STORAGE_DISK_FILENAME);
+        // A machine that has never been started has no disks yet — attaching
+        // the nonexistent image would boot the helper into a cryptic libkrun
+        // EINVAL. Fail with the actionable story instead.
+        if !storage_disk.exists() {
+            return Err(Error::agent(
+                "pack from VM",
+                format!(
+                    "machine '{vm_name}' has no storage disk yet ({}) — it has \
+                     never been started. Start it once so its state exists, or \
+                     pack the image directly with `pack create -I <image>`.",
+                    storage_disk.display()
+                ),
+            ));
+        }
         let scratch_name = format!(
             "pack-fromvm-{}-{}",
             std::process::id(),
@@ -188,7 +202,7 @@ impl ExportVm {
             uid_share_dir: Some(source_vm_dir.to_path_buf()),
             ..Default::default()
         };
-        manager.start_with_full_config(
+        if let Err(e) = manager.start_with_full_config(
             Vec::new(),
             Vec::new(),
             VmResources {
@@ -206,8 +220,12 @@ impl ExportVm {
                 allowed_cidrs: None,
             },
             features,
-        )?;
-        let _ = vm_name;
+        ) {
+            // The Drop cleanup only arms once Self exists — a failed boot must
+            // clean its own scratch dir or every failed export leaks one.
+            let _ = std::fs::remove_dir_all(&data_dir);
+            return Err(e);
+        }
         Ok(Self { manager, data_dir })
     }
 


### PR DESCRIPTION
Packing a machine that was never started attached its nonexistent storage disk to the export helper, which died in libkrun with a cryptic EINVAL; it now fails up front with an actionable message. A helper that fails to boot also cleaned up nothing because the scratch-dir cleanup only arms after a successful start — each failed export leaked a VM data dir.