### PR TITLE
Make a provisioned local volume writable by the per-VM uid that mounts it

### DIFF
--- a/src/api/handlers/volumes.rs
+++ b/src/api/handlers/volumes.rs
@@ -70,6 +70,22 @@ pub async fn provision_volume(
         "local" => {
             let path = volumes_base().join(&req.id);
             std::fs::create_dir_all(&path).map_err(ApiError::internal)?;
+            // The node service runs as root, so the dir is created root:root 0755.
+            // But a machine mounts it via virtiofs under per-VM uid isolation
+            // (#456): the guest's uid 0 is a dropped host uid (e.g. 2000025), and
+            // the virtiofs daemon writing on the guest's behalf runs as THAT uid —
+            // which has no write access to a root-owned 0755 dir, so every write
+            // into the mounted volume fails with EACCES (the volume is read-only in
+            // practice). Make the volume root world-writable so whichever per-VM
+            // uid mounts it can write; the dir is only ever virtiofs-exposed to the
+            // single VM that has it attached (volumes are single-attach), and the
+            // per-VM uid boundary — not these bits — is the isolation guarantee.
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o777))
+                    .map_err(ApiError::internal)?;
+            }
             let node_path = path.to_string_lossy().to_string();
             tracing::info!(volume_id = %req.id, node_path = %node_path, size_gb = req.size_gb, "provisioned local volume");
             Ok(Json(ProvisionVolumeResponse { node_path }))


### PR DESCRIPTION
A machine that mounts a volume could not write into it: every write failed with EACCES, making volumes read-only in practice (verified end-to-end on cloud — the mount is virtiofs rw but `touch /data/x` → Permission denied).

Root cause: the node service provisions the volume dir with `create_dir_all` as root, so it is root:root 0755. But a machine mounts it via virtiofs under per-VM uid isolation (#456), where the guest's uid 0 is a dropped host uid and the virtiofs daemon writing on the guest's behalf runs as that uid — which has no write access to a root-owned 0755 dir. Make the volume root world-writable so whichever per-VM uid mounts it can write; the dir is only ever virtiofs-exposed to the single VM that has it attached (volumes are single-attach), and the per-VM uid boundary — not these bits — is the isolation guarantee.

Follow-up (not this PR): cross-machine writes to files ALREADY created by a different machine's uid still need an idmapped volume mount (like the shared pack store) so guest-root maps to a stable owner regardless of the per-VM allocation; this PR fixes the common single-machine persistent-write case. Verified e2e that the bug reproduces; the fix is a minimal permission correction validated by CI + a node roll.