### PR TITLE
Fixing some generic findings from six QA

### DIFF
--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -956,8 +956,15 @@ impl AgentManager {
             }
         };
 
-        // Try to ping the agent
-        if let Ok(mut client) = super::AgentClient::connect(&self.vsock_socket) {
+        // Try to ping the agent. Probe-timeout connect (3 s), not the default
+        // client (30 s read timeout): this client only carries the liveness
+        // ping and is dropped after. Against a frozen fork-base golden the
+        // unix socket accepts (libkrun holds the listener) but the paused
+        // guest never replies, so the default timeout stalled every caller —
+        // most visibly `serve start`, which pings each persisted machine
+        // during its reconnect scan and sat silent for 30 s per frozen golden
+        // before binding its port.
+        if let Ok(mut client) = super::AgentClient::connect_for_state_probe(&self.vsock_socket) {
             if client.ping().is_ok() {
                 // Update internal state to reflect running
                 let mut inner = self.inner.lock();
@@ -2560,17 +2567,31 @@ impl Drop for AgentManager {
 /// Windows the guest console isn't captured, so the log is often just that).
 fn boot_failure_reason(exit_code: Option<i32>, startup_log: Option<&str>) -> String {
     let real_error = startup_log.and_then(|log| {
-        log.lines().rev().find_map(|line| {
-            let lower = line.to_ascii_lowercase();
-            if lower.contains("error")
-                || lower.contains("panic")
-                || lower.contains("krun_start_enter returned")
-            {
-                Some(line.trim().to_string())
-            } else {
-                None
-            }
-        })
+        log.lines()
+            .rev()
+            .find_map(|line| {
+                let lower = line.to_ascii_lowercase();
+                if lower.contains("error")
+                    || lower.contains("panic")
+                    || lower.contains("krun_start_enter returned")
+                {
+                    Some(line.trim().to_string())
+                } else {
+                    None
+                }
+            })
+            // Everything in the startup-error log is error content — e.g.
+            // "agent operation failed: load libkrun: symbol not found: …"
+            // carries neither "error" nor "panic", and dropping it leaves the
+            // user with only the generic exit-code note. Fall back to the last
+            // non-empty line so the actionable message always surfaces.
+            .or_else(|| {
+                log.lines()
+                    .rev()
+                    .map(str::trim)
+                    .find(|l| !l.is_empty())
+                    .map(str::to_string)
+            })
     });
 
     let code_note = match exit_code {
@@ -2626,6 +2647,18 @@ mod tests {
         let r = boot_failure_reason(Some(1), Some(log));
         assert!(r.contains("kernel not found"), "{r}");
         assert!(!r.starts_with("WARN"), "{r}");
+    }
+
+    #[test]
+    fn boot_failure_surfaces_log_without_error_keyword() {
+        // Real field failures ("agent operation failed: load libkrun: symbol
+        // not found: krun_add_disk2", "find libraries: libkrun/libkrunfw not
+        // found… set SMOLVM_LIB_DIR") contain neither "error" nor "panic";
+        // the last non-empty log line must surface anyway.
+        let log = "agent operation failed: load libkrun: symbol not found: krun_add_disk2\n";
+        let r = boot_failure_reason(Some(1), Some(log));
+        assert!(r.contains("krun_add_disk2"), "{r}");
+        assert!(r.contains("code 1"), "{r}");
     }
 
     #[test]

--- a/src/api/handlers/volumes.rs
+++ b/src/api/handlers/volumes.rs
@@ -98,9 +98,31 @@ pub async fn provision_volume(
 
 /// `DELETE /api/v1/volumes/{id}` — tear down the backing storage. Idempotent:
 /// deleting an already-absent volume succeeds.
-pub async fn deprovision_volume(Path(id): Path<String>) -> Result<StatusCode, ApiError> {
+pub async fn deprovision_volume(
+    axum::extract::State(state): axum::extract::State<std::sync::Arc<crate::api::state::ApiState>>,
+    Path(id): Path<String>,
+) -> Result<StatusCode, ApiError> {
     safe_volume_id(&id)?;
     let path = volumes_base().join(&id);
+    // Volumes are single-attach with the control plane driving detach-then-
+    // deprovision ordering — but the node must not yank a virtiofs backing dir
+    // out from under a live VM if that ordering breaks (the machine's mounts
+    // go dark and its execs start failing). Refuse while any running machine
+    // still lists this volume's path as a mount source.
+    let path_str = path.to_string_lossy();
+    if let Ok(vms) = state.db().list_vms() {
+        for (name, record) in vms {
+            let attached = record
+                .mounts
+                .iter()
+                .any(|(source, _, _)| source == path_str.as_ref());
+            if attached && record.is_process_alive() {
+                return Err(ApiError::Conflict(format!(
+                    "volume '{id}' is mounted by running machine '{name}'; stop or detach it first"
+                )));
+            }
+        }
+    }
     match std::fs::remove_dir_all(&path) {
         Ok(()) => {}
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {} // already gone

--- a/src/cli/pack.rs
+++ b/src/cli/pack.rs
@@ -186,6 +186,26 @@ impl PackCreateCmd {
     }
 
     pub fn run(self) -> smolvm::Result<()> {
+        // `--output foo.smolmachine` names the EXECUTABLE stub, so the sidecar
+        // lands at `foo.smolmachine.smolmachine` — a footgun every time (QA
+        // BUG-139). The extension belongs to the sidecar, which is derived
+        // from the stub name automatically.
+        if self
+            .output
+            .extension()
+            .is_some_and(|e| e.eq_ignore_ascii_case("smolmachine"))
+        {
+            let stem = self.output.with_extension("");
+            return Err(smolvm::Error::config(
+                "pack create",
+                format!(
+                    "--output names the executable stub, not the .smolmachine sidecar \
+                     (which is created automatically as '<output>.smolmachine'). Use \
+                     --output {} instead.",
+                    stem.display()
+                ),
+            ));
+        }
         if let Some(vm_name) = self.from_vm.clone() {
             if self.oci_platform.is_some() {
                 warn!("--oci-platform is ignored with --from-vm (VM snapshot is arch-fixed)");

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,24 @@ fn main() {
         if let Some(mode) = smolvm_pack::detect_packed_mode() {
             cli::pack_run::run_as_packed_binary(mode);
         }
+        // A packed stub separated from its `.smolmachine` sidecar is
+        // byte-identical to the plain CLI, so detection can't hard-fail —
+        // but silently becoming a different program strands users (QA
+        // BUG-167). A non-`smolvm` executable name is the tell: say what
+        // happened before falling through to the normal CLI.
+        let exe_name = std::env::current_exe()
+            .ok()
+            .and_then(|p| p.file_stem().map(|s| s.to_string_lossy().into_owned()));
+        if let Some(name) = exe_name {
+            if name != "smolvm" {
+                eprintln!(
+                    "note: no packed assets found for '{name}' (looked for a \
+                     '{name}.smolmachine' sidecar next to the executable); \
+                     running as the plain smolvm CLI. If this is a packed \
+                     binary, keep its .smolmachine file alongside it."
+                );
+            }
+        }
     }
 
     let cli = Cli::parse();

--- a/src/pack_export.rs
+++ b/src/pack_export.rs
@@ -62,6 +62,22 @@ pub fn collect_from_vm_assets(
     staging_dir: &Path,
     opts: &FromVmExportOptions,
 ) -> crate::Result<FromVmAssets> {
+    // A fork clone's disks are CoW qcow2 overlays that only the fork/resume
+    // machinery can assemble — the export helper cold-boots them and libkrun
+    // rejects the stack with an opaque -22 EINVAL (same class as clone
+    // auto-standby wake). Refuse with the real story until overlay-chain boot
+    // is supported.
+    if let Some(ref golden) = vm.golden {
+        return Err(Error::agent(
+            "pack from VM",
+            format!(
+                "machine '{vm_name}' is a fork clone of '{golden}'; its copy-on-write \
+                 disks cannot be exported directly. Export the golden instead, or \
+                 recreate the state in a non-clone machine and export that."
+            ),
+        ));
+    }
+
     let vm_dir = vm_data_dir(vm_name);
     let (overlay_disk, overlay_fmt) = resolve_disk_image(&vm_dir, OVERLAY_DISK_FILENAME);
     let is_image_based = vm.image.is_some();


### PR DESCRIPTION
Refuses exporting fork clones and deprovisioning attached volumes, rejects `--output *.smolmachine`, prints a diagnostic when a stub's sidecar is missing, surfaces agent-startup-error.log in boot failures, and uses the 3s probe client so a frozen golden can't stall serve startup 30s per machine.