### PR TITLE
Enable ring transport and CUDA-graph capture for in-VM serving

### DIFF
--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -2773,6 +2773,32 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
                 }
                 return Ok(Response::LibResult(0, Vec::new()));
             }
+            // lib 6 / func 2: classify a pointer — reply [2] iff the session
+            // knows it as device memory (cudaMalloc table, VMM ranges, clone
+            // translations/shared ranges). The guest cudart shim can't see
+            // driver-VMM allocations (torch expandable_segments), so its
+            // cudaPointerGetAttributes mis-reported them as unregistered and
+            // vLLM's CUDA-graph capture (`weak_ref_tensor`) refused them.
+            if lib == 6 && func == 2 && args.len() >= 8 {
+                let p = u64::from_le_bytes(args[0..8].try_into().unwrap());
+                let in_alloc = sess
+                    .alloc_table
+                    .lock()
+                    .unwrap()
+                    .iter()
+                    .any(|(&b0, &(sz, _))| p >= b0 && p < b0 + sz);
+                let dev = in_alloc
+                    || sess.owned_dptrs.iter().any(|(&b0, &sz)| p >= b0 && p < b0 + sz)
+                    || sess
+                        .vmm_ranges
+                        .lock()
+                        .unwrap()
+                        .iter()
+                        .any(|(&b0, &sz)| p >= b0 && p < b0 + sz)
+                    || sess.dptr_trans.iter().any(|&(b0, sz, _)| p >= b0 && p < b0 + sz)
+                    || sess.shared_ranges.iter().any(|&(b0, sz)| p >= b0 && p < b0 + sz);
+                return Ok(Response::LibResult(0, vec![if dev { 2 } else { 0 }]));
+            }
             let r = b.lib_call(lib, func, &args, &sess.streams);
             // Path 3: record top-level library-context creates so a clone
             // worker can replay them in ITS process (library handles are

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -2788,15 +2788,24 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
                     .iter()
                     .any(|(&b0, &(sz, _))| p >= b0 && p < b0 + sz);
                 let dev = in_alloc
-                    || sess.owned_dptrs.iter().any(|(&b0, &sz)| p >= b0 && p < b0 + sz)
+                    || sess
+                        .owned_dptrs
+                        .iter()
+                        .any(|(&b0, &sz)| p >= b0 && p < b0 + sz)
                     || sess
                         .vmm_ranges
                         .lock()
                         .unwrap()
                         .iter()
                         .any(|(&b0, &sz)| p >= b0 && p < b0 + sz)
-                    || sess.dptr_trans.iter().any(|&(b0, sz, _)| p >= b0 && p < b0 + sz)
-                    || sess.shared_ranges.iter().any(|&(b0, sz)| p >= b0 && p < b0 + sz);
+                    || sess
+                        .dptr_trans
+                        .iter()
+                        .any(|&(b0, sz, _)| p >= b0 && p < b0 + sz)
+                    || sess
+                        .shared_ranges
+                        .iter()
+                        .any(|&(b0, sz)| p >= b0 && p < b0 + sz);
                 return Ok(Response::LibResult(0, vec![if dev { 2 } else { 0 }]));
             }
             let r = b.lib_call(lib, func, &args, &sess.streams);

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -2184,7 +2184,18 @@ pub extern "C" fn cudaPointerGetAttributes(attr: *mut c_void, ptr: *const c_void
     // unregistered, and PyTorch's `is_pinned()` relies on that: reporting Host
     // for arbitrary pointers made `pin_memory()` a silent no-op, so pinned
     // transfers never reached the zero-copy path.
-    let is_dev = with_state(|s| Ok(dev_contains(&s.dev_allocs, ptr as u64))).unwrap_or(false);
+    let is_dev = with_state(|s| Ok(dev_contains(&s.dev_allocs, ptr as u64))).unwrap_or(false)
+        // Driver-VMM allocations (torch expandable_segments) never enter this
+        // shim's tables — ask the server, which knows every session range
+        // (LibCall 6/2 → [2] iff device). Without this, CUDA-graph capture
+        // (vLLM `weak_ref_tensor`) saw device tensors as "unregistered host".
+        || with_state(|s| {
+            Ok(s.client
+                .lib_call(6, 2, (ptr as u64).to_le_bytes().to_vec())
+                .map(|(st, out)| st == 0 && out.first() == Some(&2))
+                .unwrap_or(false))
+        })
+        .unwrap_or(false);
     let is_pinned_host = !is_dev
         && (guestmem::is_pinned(ptr as usize)
             || shm_offset(ptr).is_some()

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -153,7 +153,7 @@ pub fn run(sock: &Path) -> io::Result<()> {
                                             continue;
                                         }
                                     }
-                                    spawn_serve(s, &active_tcp);
+                                    spawn_serve(s, &active_tcp, None);
                                 }
                                 Err(e) => {
                                     tracing::debug!(error = %e, "CUDA daemon TCP accept error")
@@ -186,14 +186,18 @@ pub fn run(sock: &Path) -> io::Result<()> {
                 // would silently serve it a reconstructed COPY of its memory.
                 // Only fires under SMOLVM_CUDA_FORK_WORKERS; otherwise legacy.
                 #[cfg(unix)]
-                {
+                let guest_ram = {
                     use std::os::unix::io::AsRawFd;
+                    let ram = consume_ram_preamble(stream.as_raw_fd());
                     if route_clone_connection(stream.as_raw_fd()) {
                         drop(stream); // worker owns it / rejected
                         continue;
                     }
-                }
-                spawn_serve(stream, &active);
+                    ram
+                };
+                #[cfg(not(unix))]
+                let guest_ram = None;
+                spawn_serve(stream, &active, guest_ram);
             }
             Err(e) => tracing::debug!(error = %e, "CUDA daemon accept error"),
         }
@@ -204,7 +208,10 @@ pub fn run(sock: &Path) -> io::Result<()> {
 /// Serve one accepted connection on its own thread with a fresh backend, counting
 /// it against `active` for the idle watchdog. Generic over the stream type so the
 /// local UDS listener and the optional TCP listener share one path.
-fn spawn_serve<S>(stream: S, active: &Arc<AtomicUsize>)
+/// `guest_ram`: daemon-local mappings of the VM's guest RAM (from the RAM
+/// preamble) — installing them enables the ring transport + zero-copy GPA
+/// memcpys for this connection.
+fn spawn_serve<S>(stream: S, active: &Arc<AtomicUsize>, guest_ram: Option<Vec<(u64, u64, u64)>>)
 where
     S: std::io::Read + std::io::Write + Send + 'static,
 {
@@ -214,11 +221,117 @@ where
         .spawn(move || {
             let _guard = guard;
             let mut backend = make_backend();
+            if let Some(regions) = guest_ram {
+                tracing::info!(count = regions.len(), "guest-RAM mapped: zero-copy + rings enabled");
+                backend.set_guest_ram(regions);
+            }
             if let Err(e) = serve(stream, backend.as_mut()) {
                 tracing::debug!(error = %e, "CUDA daemon connection ended");
             }
         })
         .ok();
+}
+
+/// Consume a guest-RAM advertisement preamble if present (peek-based; absent on
+/// old proxies and non-memfd VMs). Maps the advertised regions of
+/// `/proc/<pid>/fd/<memfd>` MAP_SHARED into THIS process and returns them as
+/// `(gpa, daemon_va, len)` for `Backend::set_guest_ram`. Mappings are leaked
+/// (VM-lifetime; bounded by connections-with-adverts). Same-uid access only —
+/// exactly the trust boundary the daemon already has with its VMs.
+#[cfg(unix)]
+fn consume_ram_preamble(fd: std::os::unix::io::RawFd) -> Option<Vec<(u64, u64, u64)>> {
+    let mut hdr = [0u8; 20];
+    // SAFETY: MSG_PEEK of the fixed header on a valid fd; loops like
+    // peek_clone_token because proxied bytes can arrive in pieces.
+    let mut n: isize = 0;
+    for _ in 0..200 {
+        n = unsafe {
+            libc::recv(
+                fd,
+                hdr.as_mut_ptr() as *mut libc::c_void,
+                hdr.len(),
+                libc::MSG_PEEK,
+            )
+        };
+        if n >= 8 && &hdr[..8] != b"SMVGRAM2" {
+            return None; // not ours; leave the bytes untouched
+        }
+        if n >= 20 || n == 0 {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    if n < 20 || &hdr[..8] != b"SMVGRAM2" {
+        return None;
+    }
+    let pid = u32::from_le_bytes(hdr[8..12].try_into().unwrap());
+    let count = u32::from_le_bytes(hdr[12..16].try_into().unwrap()) as usize;
+    if count == 0 || count > 64 {
+        return None;
+    }
+    let total = 20 + count * 28;
+    let mut buf = vec![0u8; total];
+    let mut got = 0usize;
+    while got < total {
+        // SAFETY: plain recv consuming the preamble we just validated.
+        let r = unsafe {
+            libc::recv(
+                fd,
+                buf[got..].as_mut_ptr() as *mut libc::c_void,
+                total - got,
+                0,
+            )
+        };
+        if r <= 0 {
+            return None;
+        }
+        got += r as usize;
+    }
+    // One memfd PER REGION (libkrun's layout): open each via /proc and map
+    // MAP_SHARED at the advertised offset.
+    let mut files: std::collections::HashMap<u32, std::fs::File> = std::collections::HashMap::new();
+    let mut regions = Vec::with_capacity(count);
+    for i in 0..count {
+        let o = 20 + i * 28;
+        let gpa = u64::from_le_bytes(buf[o..o + 8].try_into().unwrap());
+        let fd_no = u32::from_le_bytes(buf[o + 8..o + 12].try_into().unwrap());
+        let off = u64::from_le_bytes(buf[o + 12..o + 20].try_into().unwrap());
+        let len = u64::from_le_bytes(buf[o + 20..o + 28].try_into().unwrap());
+        if len == 0 || off % 4096 != 0 {
+            return None;
+        }
+        use std::os::unix::io::AsRawFd as _;
+        let file = match files.entry(fd_no) {
+            std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
+            std::collections::hash_map::Entry::Vacant(v) => {
+                let f = std::fs::OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .open(format!("/proc/{pid}/fd/{fd_no}"))
+                    .ok()?;
+                v.insert(f)
+            }
+        };
+        // SAFETY: MAP_SHARED of the VM's guest-RAM memfd at the advertised
+        // offset; failure aborts the whole advert. Mappings are leaked
+        // (VM-lifetime; bounded by connections that advertise).
+        let va = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                len as usize,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_SHARED,
+                file.as_raw_fd(),
+                off as i64,
+            )
+        };
+        if va == libc::MAP_FAILED {
+            tracing::warn!(pid, fd_no, off, len, "guest-RAM mmap failed; sockets only");
+            return None;
+        }
+        regions.push((gpa, va as u64, len));
+    }
+    Some(regions)
 }
 
 /// Keeps the daemon's open-connection count accurate: +1 on construction, -1 on

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -222,7 +222,10 @@ where
             let _guard = guard;
             let mut backend = make_backend();
             if let Some(regions) = guest_ram {
-                tracing::info!(count = regions.len(), "guest-RAM mapped: zero-copy + rings enabled");
+                tracing::info!(
+                    count = regions.len(),
+                    "guest-RAM mapped: zero-copy + rings enabled"
+                );
                 backend.set_guest_ram(regions);
             }
             if let Err(e) = serve(stream, backend.as_mut()) {

--- a/src/cuda_host.rs
+++ b/src/cuda_host.rs
@@ -265,7 +265,8 @@ fn proxy_to_daemon(guest: crate::platform::uds::UdsStream, addr: &str) -> std::i
         }
         Some(p)
     }
-    #[cfg(not(target_os = "linux"))]    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(target_os = "linux"))]
     fn guest_ram_advert() -> Option<Vec<u8>> {
         None
     }

--- a/src/cuda_host.rs
+++ b/src/cuda_host.rs
@@ -266,7 +266,7 @@ fn proxy_to_daemon(guest: crate::platform::uds::UdsStream, addr: &str) -> std::i
         Some(p)
     }
     #[cfg(not(target_os = "linux"))]
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(all(unix, not(target_os = "linux")))]
     fn guest_ram_advert() -> Option<Vec<u8>> {
         None
     }

--- a/src/cuda_host.rs
+++ b/src/cuda_host.rs
@@ -177,12 +177,107 @@ fn proxy_to_daemon(guest: crate::platform::uds::UdsStream, addr: &str) -> std::i
         }
         Some(p)
     }
+    /// Guest-RAM advertisement for a SHARED daemon: when this VM's RAM is
+    /// memfd-backed (forkable machines), tell the daemon how to map the same
+    /// pages via `/proc/<pid>/fd/<memfd>` — magic + pid + fd + count +
+    /// (gpa, memfd offset, len)×count. With guest RAM visible, the daemon can
+    /// establish the shared-memory ring transport and zero-copy GPA memcpys
+    /// instead of per-call socket framing. `None` (silently) when RAM isn't
+    /// memfd-backed or the layout can't be resolved — sockets still work.
+    #[cfg(target_os = "linux")]
+    fn guest_ram_advert() -> Option<Vec<u8>> {
+        if std::env::var_os("SMOLVM_CUDA_NO_RAM_ADVERT").is_some() {
+            return None;
+        }
+        let regions = GUEST_RAM.get().and_then(|f| f())?; // (gpa, host_va, len)
+        if regions.is_empty() {
+            return None;
+        }
+        // memfd-backed mappings of this process: match each guest region's
+        // host VA into a maps entry, then express it as a file offset.
+        let maps = std::fs::read_to_string("/proc/self/maps").ok()?;
+        let mut memfd_maps: Vec<(u64, u64, u64, u64)> = Vec::new(); // start,end,file_off,inode
+        for l in maps.lines() {
+            if !l.contains("memfd:") {
+                continue;
+            }
+            let mut f = l.split_whitespace();
+            let range = f.next()?;
+            let perms = f.next()?;
+            // MAP_SHARED only: a fork CLONE maps the golden's memfd
+            // MAP_PRIVATE (COW) — its live pages have diverged from the file,
+            // so advertising the memfd would hand the daemon STALE golden
+            // bytes. Private mappings are excluded; clones stay socket-mode.
+            if perms.as_bytes().get(3) != Some(&b's') {
+                continue;
+            }
+            let off = u64::from_str_radix(f.next()?, 16).ok()?;
+            let _dev = f.next()?;
+            let inode: u64 = f.next()?.parse().ok()?;
+            let (s, e) = range.split_once('-')?;
+            memfd_maps.push((
+                u64::from_str_radix(s, 16).ok()?,
+                u64::from_str_radix(e, 16).ok()?,
+                off,
+                inode,
+            ));
+        }
+        if memfd_maps.is_empty() {
+            return None;
+        }
+        // libkrun backs guest RAM with ONE MEMFD PER REGION — build an
+        // inode→fd table and express each region as (gpa, fd, offset, len).
+        let mut inode_to_fd: std::collections::HashMap<u64, u32> = std::collections::HashMap::new();
+        for e in std::fs::read_dir("/proc/self/fd").ok()? {
+            let e = e.ok()?;
+            let is_memfd = std::fs::read_link(e.path())
+                .ok()
+                .and_then(|l| l.to_str().map(|s| s.contains("memfd:")))
+                .unwrap_or(false);
+            if !is_memfd {
+                continue;
+            }
+            if let Ok(md) = std::fs::metadata(e.path()) {
+                use std::os::unix::fs::MetadataExt as _;
+                if let Some(n) = e.file_name().to_str().and_then(|s| s.parse().ok()) {
+                    inode_to_fd.entry(md.ino()).or_insert(n);
+                }
+            }
+        }
+        let mut quads: Vec<(u64, u32, u64, u64)> = Vec::new();
+        for &(gpa, hva, len) in &regions {
+            let m = memfd_maps
+                .iter()
+                .find(|&&(s, e, _, _)| hva >= s && hva + len <= e)?;
+            let fd_no = *inode_to_fd.get(&m.3)?;
+            quads.push((gpa, fd_no, m.2 + (hva - m.0), len));
+        }
+        let mut p = Vec::with_capacity(20 + quads.len() * 28);
+        p.extend_from_slice(b"SMVGRAM2");
+        p.extend_from_slice(&(std::process::id()).to_le_bytes());
+        p.extend_from_slice(&(quads.len() as u32).to_le_bytes());
+        p.extend_from_slice(&[0u8; 4]); // reserved
+        for (gpa, fd_no, off, len) in quads {
+            p.extend_from_slice(&gpa.to_le_bytes());
+            p.extend_from_slice(&fd_no.to_le_bytes());
+            p.extend_from_slice(&off.to_le_bytes());
+            p.extend_from_slice(&len.to_le_bytes());
+        }
+        Some(p)
+    }
+    #[cfg(not(target_os = "linux"))]    #[cfg(not(target_os = "linux"))]
+    fn guest_ram_advert() -> Option<Vec<u8>> {
+        None
+    }
     // A path (managed daemon) → unix socket; otherwise host:port → TCP.
     if addr.starts_with('/') {
         #[cfg(unix)]
         {
             use std::io::Write as _;
             let mut daemon = std::os::unix::net::UnixStream::connect(addr)?;
+            if let Some(a) = guest_ram_advert() {
+                daemon.write_all(&a)?;
+            }
             if let Some(p) = preamble() {
                 daemon.write_all(&p)?;
             }


### PR DESCRIPTION
The per-VM proxy advertises memfd-backed guest RAM so the shared daemon maps it and rings plus zero-copy GPA transfers engage (batch-1 p50 318 ms to 87 ms locally), and pointer classification consults the server so vLLM CUDA-graph capture works in-VM (94 ms with graphs).