### PR TITLE
Bump libkrun to DEFLATE_ON_OOM so idle balloon reclaim can't OOM-kill machines with pinned RAM

### DIFF
--- a/lib/libkrun.dylib
+++ b/lib/libkrun.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5a9857af1c3b76732e0ff1820dfad8d7c325a24df0351811bc6d0734d4ac9772
-size 6202528
+oid sha256:6968db075bed68abe2a66b75b77b24a9f23565b5ac1e05eba0479443265e96b8
+size 6196096

--- a/lib/libkrun.provenance
+++ b/lib/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=cbd00771f11a3d3ce011df992e915d20e50f9e0b
+libkrun=ab0d393d52eeb82448b0f72b7a132a1a507fa18d
 libkrunfw=37f73dadb7e64610642d7041c163b8dbf0e9a1ef

--- a/lib/linux-aarch64/libkrun.provenance
+++ b/lib/linux-aarch64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=cbd00771f11a3d3ce011df992e915d20e50f9e0b
+libkrun=ab0d393d52eeb82448b0f72b7a132a1a507fa18d
 libkrunfw=37f73dadb7e64610642d7041c163b8dbf0e9a1ef

--- a/lib/linux-aarch64/libkrun.so
+++ b/lib/linux-aarch64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0d80c302f8c5b6ce0020ab57d1556a6746000afc23a57693b72cf235e4f54cc1
-size 6947240
+oid sha256:e99e45e2bbbf5f22ae7b38488717cd836dedcc1009ee2d0c43c87efc381f5f29
+size 6947176

--- a/lib/linux-aarch64/libkrun.so.2.0.0
+++ b/lib/linux-aarch64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0d80c302f8c5b6ce0020ab57d1556a6746000afc23a57693b72cf235e4f54cc1
-size 6947240
+oid sha256:e99e45e2bbbf5f22ae7b38488717cd836dedcc1009ee2d0c43c87efc381f5f29
+size 6947176

--- a/lib/linux-x86_64/libkrun.provenance
+++ b/lib/linux-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=cbd00771f11a3d3ce011df992e915d20e50f9e0b
+libkrun=ab0d393d52eeb82448b0f72b7a132a1a507fa18d
 libkrunfw=37f73dadb7e64610642d7041c163b8dbf0e9a1ef

--- a/lib/linux-x86_64/libkrun.so
+++ b/lib/linux-x86_64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c639b178d074485f8dc51d86743c2b7fbaead4cdcfb79ecc39f4b4a677e0c296
+oid sha256:8646322363b3d2689f042926ad322a5f9b906c5da5bf423cd8e63b0ca2b524e3
 size 8084704

--- a/lib/linux-x86_64/libkrun.so.2.0.0
+++ b/lib/linux-x86_64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c639b178d074485f8dc51d86743c2b7fbaead4cdcfb79ecc39f4b4a677e0c296
+oid sha256:8646322363b3d2689f042926ad322a5f9b906c5da5bf423cd8e63b0ca2b524e3
 size 8084704


### PR DESCRIPTION
Bump libkrun to advertise VIRTIO_BALLOON_F_DEFLATE_ON_OOM so idle balloon reclaim cannot OOM-kill machines holding pinned RAM, rebuilding the vendored libs for Linux x86_64/aarch64 and macOS arm64 (Windows krun.dll rebuild still pending).