### PR TITLE
Fork clones reuse the golden's extracted pack layers

### DIFF
--- a/crates/smolvm-pack/src/extract.rs
+++ b/crates/smolvm-pack/src/extract.rs
@@ -1464,6 +1464,16 @@ pub fn has_active_leases(cache_dir: &Path) -> bool {
 /// `pack prune` — prune should check `has_active_leases` first and skip
 /// active caches.
 pub fn force_detach_layers_volume(cache_dir: &Path) {
+    // A fork clone's cache dir is a symlink to its golden's — the clone doesn't
+    // own the volume or the leases behind it, so detaching through the link
+    // would rip the layers out from under the frozen golden and its siblings.
+    if cache_dir
+        .symlink_metadata()
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false)
+    {
+        return;
+    }
     #[cfg(target_os = "macos")]
     {
         let mount_point = cache_dir.join(CS_MOUNT_DIR);

--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -144,6 +144,43 @@ pub fn prepare_fork(
     std::fs::create_dir_all(&clone_dir)
         .map_err(|e| Error::agent("create clone dir", e.to_string()))?;
 
+    // A pack-backed golden (created `--from <.smolmachine>`) resolves its layers
+    // either through the shared content-addressed store (privileged installs: a
+    // pointer file beside its data dir) or from its own pre-extracted `pack`
+    // dir (rootless installs). The clone record inherits `source_smolmachine`
+    // but a fork never runs the create-time extraction, so without one of those
+    // the clone's start falls into the sidecar re-extraction fallback — seconds
+    // of host-side work per fork for read-only state the golden already has.
+    // Give the clone the golden's resolution in O(1):
+    //  - shared store: replicate the pointer file (the entry is no-evict while
+    //    referenced and start self-heals a missing one, so the copied pointer
+    //    can never point at anything the golden's own couldn't);
+    //  - per-machine layout: symlink the clone's `pack` dir to the golden's
+    //    extracted layers. The layers are read-only lowerdir content, the
+    //    golden is frozen, and its deletion is refused while clones exist, so
+    //    the target outlives every reader. `force_detach_layers_volume` no-ops
+    //    on symlinks, so a clone's stop/delete can't detach the golden's macOS
+    //    layers volume through the link.
+    let golden_layers = crate::agent::machine_layers_cache_dir(golden);
+    let golden_ptr = crate::agent::shared_pack_pointer_path(&golden_layers);
+    if golden_ptr.exists() {
+        let clone_layers = crate::agent::machine_layers_cache_dir(clone);
+        std::fs::create_dir_all(&clone_layers)
+            .map_err(|e| Error::agent("create clone pack dir", e.to_string()))?;
+        std::fs::copy(
+            &golden_ptr,
+            crate::agent::shared_pack_pointer_path(&clone_layers),
+        )
+        .map_err(|e| Error::agent("copy shared pack pointer", e.to_string()))?;
+    } else if smolvm_pack::extract::is_extracted(&golden_layers) {
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(
+            &golden_layers,
+            crate::agent::machine_layers_cache_dir(clone),
+        )
+        .map_err(|e| Error::agent("link clone pack dir", e.to_string()))?;
+    }
+
     // The golden writes its frozen snapshot (checkpoint + memfd manifest) here.
     // It lives under the GOLDEN's data dir, not the clone's: under Landlock the
     // frozen golden VMM is confined to its own data dir, so it can write here but


### PR DESCRIPTION
Machines created from a .smolmachine re-extracted the whole sidecar on every fork clone start, adding ~10s per fork. The clone now inherits the golden's layers resolution directly: shared-store installs get the pointer replicated, per-machine installs get a symlink to the golden's extracted dir, and volume detach no-ops on symlinks so a clone's stop can't detach the golden's layers volume. Pack-backed forks now match image-based fork latency (~80ms, was ~12.7s in the repro).