### PR TITLE
Validate resources in the create-machine API so invalid cpu/memory is rejected at create

### DIFF
--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -509,6 +509,18 @@ pub async fn create_machine(
     // machines. Memory is ballooned, so a generous default does not imply
     // immediate host commitment.
     let (cpus, mem) = resolve_create_resources(&req, manifest_cpus, manifest_mem);
+    // Reject invalid resources up front (as the CLI does at create time), so the
+    // API returns a clear 400 here instead of persisting an unbootable machine
+    // that only fails with a deferred 500 when it is later started.
+    crate::data::resources::VmResources {
+        cpus,
+        memory_mib: mem,
+        storage_gib: req.storage_gb,
+        overlay_gib: req.overlay_gb,
+        ..Default::default()
+    }
+    .validate()
+    .map_err(|e| ApiError::BadRequest(e.to_string()))?;
     let network = req.network || manifest_net;
 
     // Reserve the name atomically (prevents concurrent creation)


### PR DESCRIPTION
The HTTP create endpoint skipped the resource validation the CLI runs, so a cpus=0 or under-64-MiB request was accepted and only failed with a deferred 500 at start; it now runs the same validate() and returns 400.