### PR TITLE
Validate request env var names on create/exec/run

### DIFF
--- a/src/api/handlers/exec.rs
+++ b/src/api/handlers/exec.rs
@@ -68,6 +68,7 @@ pub async fn exec_command(
     // before resolution so structural/scope violations surface as 400 without
     // the resolution audit firing.
     crate::api::handlers::validate_request_secrets(&req.secrets)?;
+    crate::api::handlers::validate_request_env(&req.env)?;
     let record_env = crate::api::handlers::record_secret_refs_env(&entry)?;
     let req_env = crate::api::handlers::resolve_request_secrets(&req.secrets)?;
     let mut env = EnvVar::to_tuples(&req.env);
@@ -221,6 +222,7 @@ pub async fn exec_stream(
         .map_err(classify_ensure_running_error)?;
 
     crate::api::handlers::validate_request_secrets(&req.secrets)?;
+    crate::api::handlers::validate_request_env(&req.env)?;
     let record_env = crate::api::handlers::record_secret_refs_env(&entry)?;
     let req_env = crate::api::handlers::resolve_request_secrets(&req.secrets)?;
 
@@ -356,6 +358,7 @@ pub async fn run_command(
         .map_err(classify_ensure_running_error)?;
 
     crate::api::handlers::validate_request_secrets(&req.secrets)?;
+    crate::api::handlers::validate_request_env(&req.env)?;
     let record_env = crate::api::handlers::record_secret_refs_env(&entry)?;
     let req_env = crate::api::handlers::resolve_request_secrets(&req.secrets)?;
 

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -683,6 +683,7 @@ pub async fn create_machine(
     // the API surface is refused regardless of server binding — secrets
     // must be configured locally via the CLI.
     crate::api::handlers::validate_request_secrets(&req.secrets)?;
+    crate::api::handlers::validate_request_env(&req.env)?;
 
     // Complete registration: persists to DB + registers in ApiState
     let complete_result = guard.complete(MachineRegistration {
@@ -1591,6 +1592,7 @@ pub async fn exec_machine(
     // This avoids a second DB read per request.
     let entry = state.get_machine(&name)?;
     crate::api::handlers::validate_request_secrets(&req.secrets)?;
+    crate::api::handlers::validate_request_env(&req.env)?;
     let record_env = crate::api::handlers::record_secret_refs_env(&entry)?;
     let req_env = crate::api::handlers::resolve_request_secrets(&req.secrets)?;
 

--- a/src/api/handlers/mod.rs
+++ b/src/api/handlers/mod.rs
@@ -132,6 +132,26 @@ pub(crate) fn validate_request_secrets(
     Ok(())
 }
 
+/// Validate caller-supplied env var *names* with the same shape rule as secret
+/// keys ([`check_env_key_shape`]). Env *values* stay unrestricted, but a name is
+/// materialized into the guest environment verbatim, so one carrying `=`, a
+/// control character, or a newline could inject or corrupt a second variable in
+/// anything that parses the environment line-by-line. As with secret keys, a
+/// malformed name is not echoed back (only its byte length) since it may hold
+/// control characters. Used by the exec/run/create handlers on `req.env`.
+pub(crate) fn validate_request_env(env: &[crate::api::types::EnvVar]) -> Result<(), ApiError> {
+    for var in env {
+        check_env_key_shape(&var.name).map_err(|rule| {
+            ApiError::BadRequest(format!(
+                "env entry with {}-byte name rejected: {}",
+                var.name.len(),
+                rule
+            ))
+        })?;
+    }
+    Ok(())
+}
+
 /// Resolve request-body `req.secrets` under `Untrusted` scope. Caller
 /// must have already called [`validate_request_secrets`].
 pub(crate) fn resolve_request_secrets(
@@ -166,6 +186,25 @@ mod tests {
         SecretRef {
             from_env: Some(name.to_string()),
             from_file: None,
+        }
+    }
+
+    #[test]
+    fn validate_request_env_rejects_malformed_names() {
+        use crate::api::types::EnvVar;
+        let ev = |name: &str| EnvVar {
+            name: name.to_string(),
+            value: "v".to_string(),
+        };
+        // Well-formed names pass; values are never inspected.
+        assert!(validate_request_env(&[ev("FOO"), ev("_BAR2")]).is_ok());
+        assert!(validate_request_env(&[]).is_ok());
+        // Injection/corruption-prone names are rejected.
+        for bad in ["", "HAS=EQ", "HAS SPACE", "HAS\nNL", "1LEADINGDIGIT"] {
+            assert!(
+                validate_request_env(&[ev(bad)]).is_err(),
+                "expected {bad:?} to be rejected"
+            );
         }
     }
 


### PR DESCRIPTION
Caller-supplied env var names were passed to the guest unvalidated, so a name containing a newline or equals sign could inject or corrupt a second variable; they now go through the same shape check as secret keys and are rejected with a 400.