### PR TITLE
Don't leak the internal log path when a machine has no logs yet

### DIFF
--- a/src/api/handlers/exec.rs
+++ b/src/api/handlers/exec.rs
@@ -658,9 +658,13 @@ pub async fn stream_logs(
         .map_err(ApiError::internal)?;
 
     if !exists {
+        // The machine is registered (get_machine succeeded above) but has no
+        // console log yet — it was created and never started, or hasn't produced
+        // output. Report that plainly instead of leaking the internal host log
+        // path, and give the same not-started-shaped hint as the DB-miss branch
+        // (which a created machine skips, since it's in the running map).
         return Err(ApiError::NotFound(format!(
-            "log file not found: {}",
-            log_path.display()
+            "machine '{id}' has no logs yet — it may not have been started"
         )));
     }
 


### PR DESCRIPTION
Fetching logs for a created-but-never-started machine returned 'log file not found: <internal host path>' because such a machine is in the running map and skips the not-started branch; it now returns a clean not-started message without exposing the on-disk VM path.