### PR TITLE
Register the machine /resize route

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -193,6 +193,7 @@ pub fn create_router(state: Arc<ApiState>, cors_origins: Vec<String>) -> Router 
         .route("/{id}/start", post(handlers::machines::start_machine))
         .route("/{id}/fork", post(handlers::machines::fork_machine))
         .route("/{id}/stop", post(handlers::machines::stop_machine))
+        .route("/{id}/resize", post(handlers::machines::resize_machine))
         .route("/{id}/export", post(handlers::machines::export_machine))
         .route("/{id}", delete(handlers::machines::delete_machine))
         // Exec routes


### PR DESCRIPTION
resize_machine is implemented, unit-tested, and in the OpenAPI spec, but its route was never added to the axum router, so POST /api/v1/machines/{id}/resize returned 404 for every HTTP/SDK caller (the CLI resize works via a separate in-process path); the route is now registered and resize works end-to-end.