### PR TITLE
Reject duplicate guest mount targets on the HTTP create path

### DIFF
--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -374,9 +374,15 @@ pub async fn create_machine(
     validate_vm_name(&name, "machine name").map_err(ApiError::BadRequest)?;
 
     // Validate mount paths
-    for mount_spec in &req.mounts {
-        HostMount::try_from(mount_spec).map_err(|e| ApiError::BadRequest(e.to_string()))?;
-    }
+    let host_mounts: Vec<HostMount> = req
+        .mounts
+        .iter()
+        .map(|m| HostMount::try_from(m).map_err(|e| ApiError::BadRequest(e.to_string())))
+        .collect::<Result<_, _>>()?;
+    // Reject duplicate guest targets, matching the CLI (HostMount::parse) so an
+    // ambiguous same-target mount is a clean 400 rather than a silent shadow.
+    HostMount::ensure_unique_targets(&host_mounts)
+        .map_err(|e| ApiError::BadRequest(e.to_string()))?;
 
     // If --from is set, read manifest and extract sidecar
     let (

--- a/src/data/storage.rs
+++ b/src/data/storage.rs
@@ -145,12 +145,17 @@ impl HostMount {
             .iter()
             .map(|spec| Self::_parse(spec))
             .collect::<Result<_>>()?;
+        Self::ensure_unique_targets(&mounts)?;
+        Ok(mounts)
+    }
 
-        // Reject duplicate guest targets. Silently letting a later `-v`
-        // shadow an earlier one (second-wins) hides a likely user mistake
-        // and makes the effective mount ambiguous.
+    /// Reject duplicate guest targets. Silently letting a later mount shadow an
+    /// earlier one at the same guest path (second-wins) hides a likely mistake
+    /// and makes the effective mount ambiguous. Enforced on both the CLI (`-v`)
+    /// and the HTTP create paths so they behave identically.
+    pub fn ensure_unique_targets(mounts: &[Self]) -> Result<()> {
         let mut seen = std::collections::HashSet::new();
-        for m in &mounts {
+        for m in mounts {
             if !seen.insert(&m.target) {
                 return Err(Error::mount(
                     "validate mounts",
@@ -161,8 +166,7 @@ impl HostMount {
                 ));
             }
         }
-
-        Ok(mounts)
+        Ok(())
     }
 
     fn validate(mount: &Self) -> Result<()> {
@@ -250,6 +254,31 @@ mod tests {
         );
         // Distinct targets are fine.
         assert!(HostMount::parse(&[format!("{a}:/app"), format!("{b}:/data")]).is_ok());
+    }
+
+    #[test]
+    fn ensure_unique_targets_guards_the_http_path() {
+        // The HTTP create handler builds HostMounts via TryFrom (which does not
+        // dedup) and relies on this helper for the same duplicate-target guard
+        // the CLI gets through parse(). Exercise it directly on that collection.
+        let base = std::env::temp_dir();
+        let a = base.join("smolvm_dup_http_a");
+        let b = base.join("smolvm_dup_http_b");
+        std::fs::create_dir_all(&a).unwrap();
+        std::fs::create_dir_all(&b).unwrap();
+        let dup = vec![
+            HostMount::new(&a, "/data", true).unwrap(),
+            HostMount::new(&b, "/data", true).unwrap(),
+        ];
+        assert!(HostMount::ensure_unique_targets(&dup)
+            .unwrap_err()
+            .to_string()
+            .contains("duplicate mount target"));
+        let ok = vec![
+            HostMount::new(&a, "/data", true).unwrap(),
+            HostMount::new(&b, "/logs", true).unwrap(),
+        ];
+        assert!(HostMount::ensure_unique_targets(&ok).is_ok());
     }
 
     fn parse_one(spec: &str) -> HostMount {


### PR DESCRIPTION
The HTTP create path accepted two mounts at the same guest target where the CLI rejects them, so this dedups guest targets there too for a clean 400 instead of an ambiguous silent shadow.