### PR TITLE
Keep an explicitly stopped machine stopped under restart policies

### DIFF
--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -1359,6 +1359,11 @@ pub async fn drain_machines(state: &Arc<ApiState>) {
                     r.state = RecordState::Stopped;
                     r.pid = None;
                     r.pid_start_time = None;
+                    // A drain is a deliberate decommission: mark the machine
+                    // user-stopped so the restart supervisor does not resurrect it
+                    // in the window before the host is terminated (or if drain is
+                    // used standalone). An explicit start elsewhere clears this.
+                    r.restart.user_stopped = true;
                 })
                 .await;
             tracing::info!(machine = %name, stopped, "drain: machine stopped");

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -989,6 +989,11 @@ pub async fn start_machine(
             r.state = RecordState::Running;
             r.pid = pid;
             r.pid_start_time = pid_start_time;
+            // An explicit start re-enables supervision: clear the user-stopped
+            // flag and reset the retry budget so a machine that previously
+            // exhausted max_retries can be restarted and supervised again.
+            r.restart.user_stopped = false;
+            r.restart.restart_count = 0;
         })
         .await?
         .ok_or_else(|| {
@@ -1275,6 +1280,9 @@ pub async fn stop_machine(
             r.state = RecordState::Stopped;
             r.pid = None;
             r.pid_start_time = None;
+            // Record the explicit stop so the restart supervisor does not
+            // resurrect this machine (any policy) until an explicit start.
+            r.restart.user_stopped = true;
         })
         .await?
         .ok_or_else(|| {

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -1193,6 +1193,11 @@ pub async fn ensure_running_and_persist(
     if let Err(e) = state.update_machine_state(name, RecordState::Running, pid) {
         tracing::warn!(machine = %name, error = %e, "failed to persist Running state after implicit start");
     }
+    // An implicit start (exec/file/image waking a stopped machine) re-enables
+    // supervision like the explicit start handler: clear the user-stopped flag so
+    // the restart supervisor will keep this machine up again. (Retry-budget reset
+    // stays on the explicit `start` path.) Idempotent for an already-running machine.
+    state.mark_user_stopped(name, false);
 
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -142,6 +142,14 @@ impl RestartConfig {
     /// Determine whether the machine should be restarted based on the policy,
     /// exit code, and current restart count.
     pub fn should_restart(&self, exit_code: Option<i32>) -> bool {
+        // An explicit user stop suppresses auto-restart for every policy until an
+        // explicit start clears the flag — a machine the operator stopped must
+        // stay stopped (matching `docker stop` on a restart-policy container),
+        // not be resurrected by the supervisor. Only `unless-stopped` consulted
+        // this flag before, so `always`/`on-failure` machines were un-stoppable.
+        if self.user_stopped {
+            return false;
+        }
         // Check max retries limit (0 = unlimited)
         if self.max_retries > 0 && self.restart_count >= self.max_retries {
             return false;
@@ -150,7 +158,7 @@ impl RestartConfig {
             RestartPolicy::Never => false,
             RestartPolicy::Always => true,
             RestartPolicy::OnFailure => exit_code != Some(0),
-            RestartPolicy::UnlessStopped => !self.user_stopped,
+            RestartPolicy::UnlessStopped => true,
         }
     }
 
@@ -963,6 +971,26 @@ mod tests {
                 None,
                 false,
                 "unless-stopped user stopped",
+            ),
+            // An explicit user stop suppresses restart for every policy, not just
+            // unless-stopped — otherwise always/on-failure machines can't be stopped.
+            (
+                RestartPolicy::Always,
+                0,
+                0,
+                true,
+                None,
+                false,
+                "always but user stopped",
+            ),
+            (
+                RestartPolicy::OnFailure,
+                0,
+                0,
+                true,
+                Some(1),
+                false,
+                "on-failure non-zero but user stopped",
             ),
         ];
 


### PR DESCRIPTION
Stopping a machine with an always or unless-stopped restart policy left it eligible for the supervisor to resurrect because the stop path never recorded the user's intent, so this marks a stopped machine user-stopped (and clears it plus the retry count on an explicit start) and has the supervisor honor that for every policy.