### PR TITLE
Refuse to resize a fork base that has live clones

### DIFF
--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -1600,6 +1600,29 @@ pub async fn resize_machine(
         }
     }
 
+    // A fork base's disks are the copy-on-write backing for its clones' disks, so
+    // growing them corrupts the clones. The state check above is not enough: a
+    // golden whose VMM has died (e.g. after a host reboot) resolves to Stopped
+    // while its clones still depend on it, so `actual_state` would pass. Refuse
+    // explicitly, mirroring delete/stop and the CLI resize guard.
+    {
+        let db = state.db().clone();
+        let golden = name.clone();
+        let clones = tokio::task::spawn_blocking(move || db.dependent_clones(&golden))
+            .await
+            .map_err(|e| ApiError::internal(format!("task error: {}", e)))?
+            .map_err(ApiError::database)?;
+        if !clones.is_empty() {
+            return Err(ApiError::Conflict(format!(
+                "machine '{}' is the fork base of {} live clone(s) ({}); their disks are backed \
+                 by its disks — delete the clones first",
+                name,
+                clones.len(),
+                clones.join(", ")
+            )));
+        }
+    }
+
     let current_storage_gb = record.storage_gb.unwrap_or(DEFAULT_STORAGE_SIZE_GIB);
     let current_overlay_gb = record.overlay_gb.unwrap_or(DEFAULT_OVERLAY_SIZE_GIB);
 

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -1931,6 +1931,24 @@ pub fn expand_disks(
     use smolvm::data::disk::{Overlay, Storage};
     use smolvm::storage::{expand_disk, DEFAULT_OVERLAY_SIZE_GIB, DEFAULT_STORAGE_SIZE_GIB};
 
+    // A fork base's disks are the copy-on-write backing for its clones' disks, so
+    // growing them corrupts the clones' overlays. Refuse if any clone still
+    // depends on this machine. Guarded independently of run state: a golden whose
+    // VMM has died (e.g. after a host reboot) resolves to Stopped, not Frozen, so
+    // a state check alone would let the resize through.
+    let clones = SmolvmDb::open()?.dependent_clones(name).unwrap_or_default();
+    if !clones.is_empty() {
+        return Err(smolvm::Error::config(
+            "resize",
+            format!(
+                "machine '{name}' is the fork base for {} live clone(s) ({}); their disks are \
+                 copy-on-write overlays backed by its disks — delete the clones first",
+                clones.len(),
+                clones.join(", ")
+            ),
+        ));
+    }
+
     let current_storage_gb = record.storage_gb.unwrap_or(DEFAULT_STORAGE_SIZE_GIB);
     let current_overlay_gb = record.overlay_gb.unwrap_or(DEFAULT_OVERLAY_SIZE_GIB);
 


### PR DESCRIPTION
Resizing a golden grows the disk files its clones' copy-on-write overlays are backed by, corrupting them, and the stopped-state check alone misses a golden whose VMM died with clones still registered, so this adds an explicit dependent-clones guard to both the API resize handler and the CLI disk-expansion path.