### PR TITLE
Add per-fork secrets to the fork API so each clone gets its own secrets, resolved fresh per exec

### DIFF
--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -82,6 +82,7 @@ pub fn prepare_fork(
     pinned_ports: &[(u16, u16)],
     clone_forkable: bool,
     fork_env: &[(String, String)],
+    fork_secrets: &std::collections::BTreeMap<String, crate::secrets::SecretRef>,
 ) -> Result<PreparedFork> {
     validate_vm_name(clone, "clone name").map_err(|e| Error::config("clone name", e))?;
     validate_fork_env(fork_env)?;
@@ -226,6 +227,15 @@ pub fn prepare_fork(
             .env
             .retain(|(k, _)| !fork_env.iter().any(|(fk, _)| fk == k));
         clone_rec.env.extend(fork_env.iter().cloned());
+    }
+    // Per-fork secrets: merge the refs into the clone's persisted `secret_refs`
+    // (overriding same-named refs inherited from the golden), so every `exec`
+    // in the clone resolves them fresh — the fork-safe path where plaintext
+    // never lands in the overlay/artifact or a guest file, and each clone's
+    // secrets are its own, invisible to the golden and sibling clones. Unlike
+    // `fork_env`, these are NOT written to the `fork-env` guest file.
+    for (k, r) in fork_secrets {
+        clone_rec.secret_refs.insert(k.clone(), r.clone());
     }
     let mut port_remaps = Vec::new();
     if !pinned_ports.is_empty() {

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -1203,6 +1203,11 @@ pub async fn fork_machine(
     let pinned_ports: Vec<(u16, u16)> = req.ports.iter().map(|p| (p.host, p.guest)).collect();
     let req_share_weights = req.share_weights;
     let fork_env = crate::util::parse_env_list(&req.env);
+    // Per-fork secrets become the clone's persisted secret_refs (resolved fresh
+    // on each exec, never at rest) — validate them at TrustedLocal like the
+    // Smolfile-declared refs they join.
+    crate::api::handlers::validate_fork_secrets(&req.secrets)?;
+    let fork_secrets = req.secrets.clone();
 
     // Validate pinned ports as the create path does: fork uses these host ports
     // as-is (no remapping), so port 0 or a duplicated host port would otherwise
@@ -1241,9 +1246,10 @@ pub async fn fork_machine(
         let clone_b = clone.clone();
         let ports = pinned_ports.clone();
         let env = fork_env.clone();
+        let secrets = fork_secrets.clone();
         tokio::task::spawn_blocking(move || {
             crate::agent::fork::prepare_fork(
-                &db, &golden_b, &clone_b, &ports, /* clone_forkable */ false, &env,
+                &db, &golden_b, &clone_b, &ports, /* clone_forkable */ false, &env, &secrets,
             )
         })
         .await

--- a/src/api/handlers/mod.rs
+++ b/src/api/handlers/mod.rs
@@ -257,9 +257,15 @@ mod tests {
         refs.insert("GUEST_TOKEN".to_string(), env_ref("HOST_TOKEN"));
         refs.insert(
             "GUEST_KEY".to_string(),
-            SecretRef { from_env: None, from_file: Some("/abs/key".into()) },
+            SecretRef {
+                from_env: None,
+                from_file: Some("/abs/key".into()),
+            },
         );
-        assert!(validate_fork_secrets(&refs).is_ok(), "host refs must be allowed for fork");
+        assert!(
+            validate_fork_secrets(&refs).is_ok(),
+            "host refs must be allowed for fork"
+        );
 
         // Empty is fine (the common case).
         assert!(validate_fork_secrets(&BTreeMap::new()).is_ok());
@@ -267,15 +273,24 @@ mod tests {
         // A malformed key is still rejected at ingress.
         let mut bad = BTreeMap::new();
         bad.insert("HAS=EQ".to_string(), env_ref("HOST"));
-        assert!(matches!(validate_fork_secrets(&bad), Err(ApiError::BadRequest(_))));
+        assert!(matches!(
+            validate_fork_secrets(&bad),
+            Err(ApiError::BadRequest(_))
+        ));
 
         // A relative file path is rejected (validate_ref TrustedLocal).
         let mut rel = BTreeMap::new();
         rel.insert(
             "K".to_string(),
-            SecretRef { from_env: None, from_file: Some("relative/path".into()) },
+            SecretRef {
+                from_env: None,
+                from_file: Some("relative/path".into()),
+            },
         );
-        assert!(matches!(validate_fork_secrets(&rel), Err(ApiError::BadRequest(_))));
+        assert!(matches!(
+            validate_fork_secrets(&rel),
+            Err(ApiError::BadRequest(_))
+        ));
     }
 
     #[test]

--- a/src/api/handlers/mod.rs
+++ b/src/api/handlers/mod.rs
@@ -132,6 +132,37 @@ pub(crate) fn validate_request_secrets(
     Ok(())
 }
 
+/// Validate per-fork `secrets` refs. Unlike [`validate_request_secrets`]
+/// (`Untrusted`), fork secrets are operator-declared and become the clone's
+/// *persisted* `secret_refs` — the same trust as a Smolfile's `[secrets]` — so
+/// they resolve under `TrustedLocal` (host env / absolute file allowed). The
+/// key-shape and count caps are identical. NOTE: the cloud control plane must
+/// not forward tenant-controlled refs to a shared node's fork endpoint (that
+/// would resolve against the node's env/files); cloud delivery is a later phase.
+pub(crate) fn validate_fork_secrets(
+    refs: &std::collections::BTreeMap<String, smolvm_protocol::SecretRef>,
+) -> Result<(), ApiError> {
+    if refs.len() > MAX_REQ_SECRETS_PER_REQUEST {
+        return Err(ApiError::BadRequest(format!(
+            "fork `secrets` map has {} entries; maximum is {}",
+            refs.len(),
+            MAX_REQ_SECRETS_PER_REQUEST
+        )));
+    }
+    for (name, r) in refs {
+        check_env_key_shape(name).map_err(|rule| {
+            ApiError::BadRequest(format!(
+                "fork secrets entry with {}-byte key rejected: {}",
+                name.len(),
+                rule
+            ))
+        })?;
+        crate::secrets::validate_ref(r, crate::secrets::ResolutionScope::TrustedLocal)
+            .map_err(|e| ApiError::BadRequest(format!("fork secret '{}': {}", name, e)))?;
+    }
+    Ok(())
+}
+
 /// Validate caller-supplied env var *names* with the same shape rule as secret
 /// keys ([`check_env_key_shape`]). Env *values* stay unrestricted, but a name is
 /// materialized into the guest environment verbatim, so one carrying `=`, a
@@ -215,6 +246,36 @@ mod tests {
         // only request that passes secret validation is one with none.
         let refs = BTreeMap::new();
         assert!(validate_request_secrets(&refs).is_ok());
+    }
+
+    #[test]
+    fn validate_fork_secrets_accepts_host_refs_but_rejects_bad_shape() {
+        // Fork secrets are operator-declared (TrustedLocal), so unlike the
+        // untrusted request path they MAY resolve from host env/absolute files —
+        // they become the clone's persisted secret_refs.
+        let mut refs = BTreeMap::new();
+        refs.insert("GUEST_TOKEN".to_string(), env_ref("HOST_TOKEN"));
+        refs.insert(
+            "GUEST_KEY".to_string(),
+            SecretRef { from_env: None, from_file: Some("/abs/key".into()) },
+        );
+        assert!(validate_fork_secrets(&refs).is_ok(), "host refs must be allowed for fork");
+
+        // Empty is fine (the common case).
+        assert!(validate_fork_secrets(&BTreeMap::new()).is_ok());
+
+        // A malformed key is still rejected at ingress.
+        let mut bad = BTreeMap::new();
+        bad.insert("HAS=EQ".to_string(), env_ref("HOST"));
+        assert!(matches!(validate_fork_secrets(&bad), Err(ApiError::BadRequest(_))));
+
+        // A relative file path is rejected (validate_ref TrustedLocal).
+        let mut rel = BTreeMap::new();
+        rel.insert(
+            "K".to_string(),
+            SecretRef { from_env: None, from_file: Some("relative/path".into()) },
+        );
+        assert!(matches!(validate_fork_secrets(&rel), Err(ApiError::BadRequest(_))));
     }
 
     #[test]

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -708,4 +708,13 @@ pub struct ForkRequest {
     /// to read, and merged into the clone's env for later exec sessions.
     #[serde(default)]
     pub env: Vec<String>,
+    /// Per-fork secrets as `SecretRef`s (host env var / absolute file). Merged
+    /// into the clone's persisted `secret_refs`, overriding same-named refs
+    /// inherited from the golden — so each clone gets its OWN secrets, resolved
+    /// fresh on every `exec`, never written to the overlay/artifact or a guest
+    /// file, and isolated from the golden and sibling clones. This is the
+    /// fork-safe path: unlike `env`, the plaintext never lands at rest.
+    #[serde(default)]
+    #[schema(value_type = Object)]
+    pub secrets: RequestSecretRefs,
 }

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -2850,12 +2850,29 @@ pub struct ForkCmd {
     /// are — no shared-mount claim files needed.
     #[arg(short = 'e', long = "env", value_name = "KEY=VALUE")]
     pub env: Vec<String>,
+
+    /// Inject a per-fork secret from a host env var (GUEST_VAR=HOST_VAR),
+    /// resolved fresh on every `exec` in the clone. Unlike `--env`, the value is
+    /// never written to the clone's record, the overlay/pack, or the fork-env
+    /// guest file — and each clone's secrets are its own, invisible to the
+    /// golden and sibling clones.
+    #[arg(long = "secret-env", value_name = "GUEST_VAR=HOST_VAR", help_heading = "Security")]
+    pub secret_env: Vec<String>,
+
+    /// Inject a per-fork secret from a host file (GUEST_VAR=/abs/path), resolved
+    /// fresh on every `exec` in the clone. Never persisted to the record,
+    /// overlay/pack, or fork-env guest file. See `--secret-env`.
+    #[arg(long = "secret-file", value_name = "GUEST_VAR=PATH", help_heading = "Security")]
+    pub secret_file: Vec<String>,
 }
 
 impl ForkCmd {
     pub fn run(self) -> smolvm::Result<()> {
         let ports: Vec<(u16, u16)> = self.port.iter().map(|p| (p.host, p.guest)).collect();
         let fork_env = smolvm::util::parse_env_list(&self.env);
+        // Parse per-fork secret refs (TrustedLocal — host env/absolute file);
+        // they merge into the clone's secret_refs and resolve fresh per exec.
+        let fork_secrets = parse_cli_secret_refs(&self.secret_env, &self.secret_file)?;
         vm_common::fork_vm(
             &self.golden,
             &self.clone,
@@ -2863,6 +2880,7 @@ impl ForkCmd {
             &ports,
             self.share_weights,
             &fork_env,
+            &fork_secrets,
         )
     }
 }

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -2856,13 +2856,21 @@ pub struct ForkCmd {
     /// never written to the clone's record, the overlay/pack, or the fork-env
     /// guest file — and each clone's secrets are its own, invisible to the
     /// golden and sibling clones.
-    #[arg(long = "secret-env", value_name = "GUEST_VAR=HOST_VAR", help_heading = "Security")]
+    #[arg(
+        long = "secret-env",
+        value_name = "GUEST_VAR=HOST_VAR",
+        help_heading = "Security"
+    )]
     pub secret_env: Vec<String>,
 
     /// Inject a per-fork secret from a host file (GUEST_VAR=/abs/path), resolved
     /// fresh on every `exec` in the clone. Never persisted to the record,
     /// overlay/pack, or fork-env guest file. See `--secret-env`.
-    #[arg(long = "secret-file", value_name = "GUEST_VAR=PATH", help_heading = "Security")]
+    #[arg(
+        long = "secret-file",
+        value_name = "GUEST_VAR=PATH",
+        help_heading = "Security"
+    )]
     pub secret_file: Vec<String>,
 }
 

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -714,6 +714,7 @@ pub fn fork_vm(
     pinned_ports: &[(u16, u16)],
     share_weights: bool,
     fork_env: &[(String, String)],
+    fork_secrets: &BTreeMap<String, SecretRef>,
 ) -> smolvm::Result<()> {
     let db = SmolvmDb::open()?;
 
@@ -728,6 +729,7 @@ pub fn fork_vm(
         pinned_ports,
         clone_forkable,
         fork_env,
+        fork_secrets,
     )?;
     for (golden_host, guest, clone_host) in &prep.port_remaps {
         if pinned_ports.is_empty() {

--- a/src/embedded/control.rs
+++ b/src/embedded/control.rs
@@ -163,7 +163,15 @@ pub fn fork_vm(
 ) -> Result<VmHandle> {
     // Freeze + snapshot the golden, register the clone (CoW disks + DB record).
     // `clone_forkable = false`: a clone can't itself be re-forked (nested fork).
-    let prep = crate::agent::fork::prepare_fork(db, golden, clone, pinned_ports, false, &[])?;
+    let prep = crate::agent::fork::prepare_fork(
+        db,
+        golden,
+        clone,
+        pinned_ports,
+        false,
+        &[],
+        &std::collections::BTreeMap::new(),
+    )?;
 
     // Boot the clone from the golden's in-memory snapshot instead of cold-booting.
     let features = LaunchFeatures {


### PR DESCRIPTION
Adds a `secrets` map of `SecretRef`s to the fork request (API and `machine fork --secret-env/--secret-file`), merged into the clone's persisted `secret_refs` so every exec in the clone resolves them fresh — never written to the overlay, artifact, or the fork-env guest file, and isolated from the golden and sibling clones.