### PR TITLE
Fix the CUDA guest crate builds so they compile without the host feature and on macOS

### DIFF
--- a/crates/smolvm-cuda/src/client.rs
+++ b/crates/smolvm-cuda/src/client.rs
@@ -855,7 +855,7 @@ impl<S: Read + Write> Client<S> {
         // also populates the server cache.
         if image.len() >= 64 {
             let mut blob = Vec::with_capacity(32);
-            blob.extend_from_slice(&crate::host::fnv64(image).to_le_bytes());
+            blob.extend_from_slice(&crate::proto::fnv64(image).to_le_bytes());
             blob.extend_from_slice(&(image.len() as u64).to_le_bytes());
             blob.extend_from_slice(&image[..8]);
             blob.extend_from_slice(&image[image.len() - 8..]);

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -12,7 +12,7 @@
 //! protocol + transport can be exercised on a host with no NVIDIA GPU).
 
 use crate::proto::{
-    decode_request, encode_request, encode_response, read_msg, write_msg, Request, Response,
+    decode_request, encode_request, encode_response, fnv64, read_msg, write_msg, Request, Response,
 };
 use std::collections::HashMap;
 use std::io::{Read, Write};
@@ -1545,15 +1545,6 @@ fn module_cache_put(image: &[u8]) {
 
 fn module_cache_get(key: &ModuleCacheKey) -> Option<std::sync::Arc<Vec<u8>>> {
     module_cache().lock().unwrap().get(key).cloned()
-}
-
-pub fn fnv64(data: &[u8]) -> u64 {
-    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
-    for &b in data {
-        h ^= b as u64;
-        h = h.wrapping_mul(0x0000_0100_0000_01b3);
-    }
-    h.max(1)
 }
 
 /// Mark the allocation containing `dptr` as loaded (H2D-written → read-only

--- a/crates/smolvm-cuda/src/proto.rs
+++ b/crates/smolvm-cuda/src/proto.rs
@@ -1617,6 +1617,19 @@ pub fn decode_response(op: Op, payload: &[u8]) -> io::Result<(i32, Response)> {
     Ok((status, body))
 }
 
+/// FNV-1a 64-bit hash of `data`, floored to a minimum of 1 so `0` stays free as
+/// a "no hash" sentinel. Used for the module/upload wire cache on both sides of
+/// the RPC (host verifies, guest primes), so it lives here in the shared,
+/// always-compiled protocol module rather than the host-only backend.
+pub fn fnv64(data: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in data {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h.max(1)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/smolvm-cudart-shim/Cargo.toml
+++ b/crates/smolvm-cudart-shim/Cargo.toml
@@ -11,7 +11,10 @@ crate-type = ["cdylib"]
 
 [dependencies]
 smolvm-cuda = { path = "../smolvm-cuda", default-features = false }
+# libc is POSIX-portable here (clock_gettime/mmap/recv/…), so keep it un-gated so
+# the crate also type-checks on a macOS dev host; the guest .so still only ships
+# on Linux. Matches smolvm-cuda-shim.
+libc = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 vsock = "0.5"
-libc = "0.2"

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -1853,7 +1853,7 @@ fn verify_chunk_content(b: &mut dyn Backend, ch: &smolvm_cuda::host::HandoffChun
         Ok(bytes) => ch.segs.iter().all(|&(s, e, crc)| {
             crc != 0
                 && e as usize <= bytes.len()
-                && smolvm_cuda::host::fnv64(&bytes[s as usize..e as usize]) == crc
+                && smolvm_cuda::proto::fnv64(&bytes[s as usize..e as usize]) == crc
         }),
         Err(e) => {
             tracing::warn!(e, va = ch.va, "M2-share: verify D2H failed → private");


### PR DESCRIPTION
The guest CUDA shims build smolvm-cuda without the host feature, but a guest client path called fnv64 from the host-only module, and the cudart shim gated libc to Linux while using it unconditionally, so the guest .so failed to compile off Linux and off the host feature; this moves fnv64 into the shared proto module and un-gates libc so every CUDA crate builds cleanly.