### PR TITLE
docs(agents): adopt Pragmatic Rust Guidelines with Smol overrides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,25 @@ A tool to build and run portable, self-contained virtual machines locally. <200m
 
 Windows caveats (run, persistent machines, volumes, port-forwarding, pack create/run, and interactive TTY all work): networking is TSI-only (TCP/UDP + inbound `-p`, no virtio-net); no GPU acceleration; no fork/snapshot. `pack create` needs `storage-template.ext4` / `overlay-template.ext4` beside `smolvm.exe` (Windows has no host `mkfs.ext4`). Set `SMOLVM_LIB_DIR` (folder holding `krun.dll` + `libkrunfw.dll`) and `SMOLVM_AGENT_ROOTFS` when running from a non-standard layout.
 
+## Rust quality (agents)
+
+Use Microsoft's [Pragmatic Rust Guidelines](https://microsoft.github.io/rust-guidelines/) as a quality reference. The [condensed agent pack](https://microsoft.github.io/rust-guidelines/agents/all.txt) is available for deep Rust API, FFI, or unsafe refactors; attaching it is optional, not required for every task.
+
+Prioritize, in order:
+
+1. Library UX: smolvm is library-first; keep the CLI a thin surface.
+2. FFI quality in `napi` and `pyo3` bindings.
+3. Unsafe code and correctness.
+4. Hot-path performance.
+5. Avoid AI anti-patterns: one implementation path, no meta-design docs in user-facing docs, and no tautological tests.
+
+Smol overrides:
+
+- Subtract: do not add crates or APIs solely for ceremony.
+- Keep one way to do a thing; prefer small shared validators over fat dependencies.
+- Humans own design; agents implement it.
+- Treat guideline must/should rules as spirit over letter—do not block work by citing rule IDs for theater.
+
 ## Quick Reference
 
 ```bash


### PR DESCRIPTION
## Summary
- Add a thin Rust-quality overlay to `AGENTS.md` that links Microsoft’s Pragmatic Rust Guidelines and its condensed agent pack.
- Prioritize library UX, FFI bindings, correctness, performance, and targeted AI anti-pattern avoidance while documenting Smol’s subtractive, human-led design defaults.

## Why
This gives coding agents practical hygiene for library and FFI work without displacing smolvm’s existing product and CLI guidance.

## Deliberately not included
- No full copy of the guidelines or condensed pack in the repository.
- No CI or Clippy-policy overhaul.
- No mandatory CONTRIBUTING checklist.

## Test plan
- [x] Reviewed the rendered Markdown diff.
- [x] Confirmed the change is documentation-only and AGENTS.md remains product/CLI-first.
