### PR TITLE
Bump libkrunfw to the DRM-enabled build so --gpu exposes /dev/dri

### DIFF
--- a/lib/libkrun.provenance
+++ b/lib/libkrun.provenance
@@ -3,4 +3,4 @@
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
 libkrun=cbd00771f11a3d3ce011df992e915d20e50f9e0b
-libkrunfw=37f73dadb7e64610642d7041c163b8dbf0e9a1ef
+libkrunfw=1ba61ba8e0ed6670182020d0be417e84548b0723

--- a/lib/libkrunfw.5.dylib
+++ b/lib/libkrunfw.5.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3ddcca79131bdbbd3f1d4dc2832459d990c303252260ff1329c0321d0e955935
-size 13118480
+oid sha256:d0719cb2d4d00ecfdf43bfa6acd0dec9daa2935ba39f75ff751995e3f7767259
+size 13243040

--- a/lib/linux-aarch64/libkrun.provenance
+++ b/lib/linux-aarch64/libkrun.provenance
@@ -3,4 +3,4 @@
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
 libkrun=cbd00771f11a3d3ce011df992e915d20e50f9e0b
-libkrunfw=37f73dadb7e64610642d7041c163b8dbf0e9a1ef
+libkrunfw=1ba61ba8e0ed6670182020d0be417e84548b0723

--- a/lib/linux-aarch64/libkrun.so
+++ b/lib/linux-aarch64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0d80c302f8c5b6ce0020ab57d1556a6746000afc23a57693b72cf235e4f54cc1
-size 6947240
+oid sha256:5d77f7a7cc7e052091a65ce89a29e2f09379bc8b9c36683d792a2f2aa847534c
+size 6940536

--- a/lib/linux-aarch64/libkrun.so.2.0.0
+++ b/lib/linux-aarch64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0d80c302f8c5b6ce0020ab57d1556a6746000afc23a57693b72cf235e4f54cc1
-size 6947240
+oid sha256:5d77f7a7cc7e052091a65ce89a29e2f09379bc8b9c36683d792a2f2aa847534c
+size 6940536

--- a/lib/linux-aarch64/libkrunfw.so.5.5.0
+++ b/lib/linux-aarch64/libkrunfw.so.5.5.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7da48d831e85c9908d713dd24f860a1324f4554a63804c3cc7e8a90dcf3dcfe3
+oid sha256:fedcc8b04d52e2cdee4b1ec8eb0718d9b7d435f19d5ab51b180e3cf1cb653cee
 size 13239912

--- a/lib/linux-x86_64/libkrun.provenance
+++ b/lib/linux-x86_64/libkrun.provenance
@@ -3,4 +3,4 @@
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
 libkrun=cbd00771f11a3d3ce011df992e915d20e50f9e0b
-libkrunfw=37f73dadb7e64610642d7041c163b8dbf0e9a1ef
+libkrunfw=1ba61ba8e0ed6670182020d0be417e84548b0723

--- a/lib/linux-x86_64/libkrun.so
+++ b/lib/linux-x86_64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c639b178d074485f8dc51d86743c2b7fbaead4cdcfb79ecc39f4b4a677e0c296
-size 8084704
+oid sha256:8f7c2d146236fc3889888b5e31d29bb6cdccbf12daea5772dc115ad416b80c87
+size 8082272

--- a/lib/linux-x86_64/libkrun.so.2.0.0
+++ b/lib/linux-x86_64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c639b178d074485f8dc51d86743c2b7fbaead4cdcfb79ecc39f4b4a677e0c296
-size 8084704
+oid sha256:8f7c2d146236fc3889888b5e31d29bb6cdccbf12daea5772dc115ad416b80c87
+size 8082272

--- a/lib/linux-x86_64/libkrunfw.so.5.5.0
+++ b/lib/linux-x86_64/libkrunfw.so.5.5.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7a50055fa114459642ae45e4492f81a5ced2e4cbc5226eb715cb34c637c6b8e5
-size 14878392
+oid sha256:234f7ae27d94d026ae231ab78c0d846253f82d0047cd10e18a3c6e434ede27f4
+size 16975544

--- a/lib/windows-x86_64/libkrun.provenance
+++ b/lib/windows-x86_64/libkrun.provenance
@@ -3,4 +3,4 @@
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
 libkrun=cbd00771f11a3d3ce011df992e915d20e50f9e0b
-libkrunfw=37f73dadb7e64610642d7041c163b8dbf0e9a1ef
+libkrunfw=1ba61ba8e0ed6670182020d0be417e84548b0723

--- a/lib/windows-x86_64/libkrunfw.dll
+++ b/lib/windows-x86_64/libkrunfw.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d07efdc977572b50797c5cc9656d2d3ba9db06f54568a59bea402d5c9d58bdb6
+oid sha256:0a060f2a889f596fc2514b291429f6490eb0d9be2279f7e4425a6f856c933d58
 size 19338676


### PR DESCRIPTION
The bundled guest kernel was built with CONFIG_DRM off, so a --gpu machine came up with a virtio-GPU device but no driver and no /dev/dri; this pins libkrunfw at the rebuilt firmware that re-enables virtio-GPU DRM and ships the matching binaries for linux-x86_64, linux-aarch64, and windows-x86_64, leaving the macOS dylib in lib/ to be rebuilt on a Mac (cargo make build-libkrun) before this can merge. Closes #729.