### PR TITLE
Fix fork weight sharing so clones import one copy of the weights instead of each privately copying them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,6 +328,23 @@ jobs:
           echo "aarch64 agent:"
           file target/aarch64-unknown-linux-musl/release/smolvm-agent
 
+      # The guest CUDA shims pull smolvm-cuda with `default-features = false`
+      # (no `host`), and scripts/build-agent-rootfs.sh builds them standalone.
+      # A whole-workspace build unifies features, so a host-only reference from
+      # the client side compiles there and breaks only the standalone shim
+      # build — which the rootfs script swallows as "auto-staging disabled",
+      # leaving an unstamped rootfs with stale shims (this regressed once, see
+      # #737). Check the guest feature set explicitly so that skew fails here.
+      #
+      # `--lib` only: the shims link the library, while the crate's examples
+      # (gpu_loopback, shim_server) are host-side tools that legitimately need
+      # the feature.
+      - name: smolvm-cuda builds without the host feature (guest shim path)
+        run: cargo clippy -p smolvm-cuda --no-default-features --lib -- -D warnings
+
+      - name: Guest CUDA shims build standalone
+        run: cargo build --release -p smolvm-cudart-shim -p smolvm-cuda-shim -p smolvm-nvml-shim -p smolvm-cuda-guest
+
   # ==========================================================================
   # Downstream compatibility: the smol CLI builds this workspace via path deps
   # (`smolvm = { path = ".." }`) and releases in version lockstep, so an engine

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -253,6 +253,13 @@ pub trait Backend: Send {
     ) -> CuResult<()> {
         Err(CUDA_ERROR_NOT_FOUND)
     }
+    /// Content hash of the shared-region bytes a [`Self::memcpy_shm_htod`] of
+    /// `(offset, size)` would upload, over payload subrange `[start, end)`.
+    /// Lets Path 3 record a VERIFIABLE crc for a zero-copy upload so the chunk
+    /// stays eligible for fork weight sharing. Default: source unreachable.
+    fn hash_shm_range(&mut self, _offset: u64, _start: u64, _end: u64) -> Option<u64> {
+        None
+    }
     /// Zero-copy D2H: DMA `size` bytes from `dptr` to shared-region `offset`.
     fn memcpy_shm_dtoh(
         &mut self,
@@ -281,6 +288,13 @@ pub trait Backend: Send {
         _stream: u64,
     ) -> CuResult<()> {
         Err(CUDA_ERROR_NOT_FOUND)
+    }
+    /// Content hash of the guest-RAM bytes a [`Self::memcpy_gpa_htod`] of
+    /// `segments` would upload, over payload subrange `[start, end)` (offsets
+    /// relative to the first segment's first byte). Path 3 uses it to record a
+    /// verifiable crc for a zero-copy upload; see [`Self::hash_shm_range`].
+    fn hash_gpa_range(&mut self, _segments: &[(u64, u64)], _start: u64, _end: u64) -> Option<u64> {
+        None
     }
     /// Zero-copy D2H to guest RAM: DMA from `dptr` and scatter into `segments`.
     fn memcpy_gpa_dtoh(
@@ -566,12 +580,25 @@ fn path3_enabled() -> bool {
     std::env::var_os("SMOLVM_CUDA_FORK_WORKERS").is_some()
 }
 
-/// Path 3 density opt-in: a clone worker SHARES the golden's loaded (weight)
-/// VMM ranges read-only (IPC-import without copy) instead of privately copying
-/// them. Off by default (the proven path privately copies every range —
-/// correct + isolated but N copies of the weights).
+/// Path 3 density: a clone worker SHARES the golden's loaded (weight) VMM
+/// ranges (IPC-import without copy) instead of privately copying them — one
+/// weight set in VRAM for the whole fork pool instead of one per clone.
+///
+/// ON by default: density is the point of a fork pool, and sharing is
+/// self-limiting because only chunks that pass share verification are shared
+/// (`verify_chunk_content`) — a chunk whose device bytes no longer match what
+/// the H2Ds uploaded (i.e. something wrote it, like unsloth's embedding fixup
+/// during the golden's warmup step) is privately copied instead. Set
+/// `SMOLVM_CUDA_FORK_SHARE_WEIGHTS=0` to force the all-private behaviour.
+///
+/// NOTE: verification only sees writes that happened BEFORE the fork, so the
+/// golden must exercise its write path (warm up) before forking — otherwise a
+/// post-fork write to a shared chunk races across clones.
 pub fn path3_share_weights_enabled() -> bool {
-    std::env::var_os("SMOLVM_CUDA_FORK_SHARE_WEIGHTS").is_some()
+    !matches!(
+        std::env::var("SMOLVM_CUDA_FORK_SHARE_WEIGHTS").as_deref(),
+        Ok("0") | Ok("false") | Ok("off")
+    )
 }
 
 /// P0 transport-viability instrumentation. Counts every dispatched CUDA RPC so we
@@ -1468,6 +1495,27 @@ fn xlat_event(h: u64) -> u64 {
 /// chunk it overlaps (see `GoldenLayout.maps`). No-op unless Path 3 is
 /// tracking a golden layout.
 fn mark_loaded_vmm(layout: &LayoutCell, dptr: u64, nbytes: u64, data: Option<&[u8]>) {
+    mark_loaded_vmm_with(layout, dptr, nbytes, |s, e| {
+        data.map_or(0, |d| fnv64(&d[s as usize..e as usize]))
+    })
+}
+
+/// [`mark_loaded_vmm`] for sources the dispatch loop cannot slice directly.
+///
+/// `crc_of(start, end)` hashes the payload subrange `[start, end)` — offsets
+/// relative to the H2D's first byte — and returns 0 when the bytes are
+/// unreachable. The zero-copy paths (shared region / guest RAM) never put the
+/// payload on the socket, but the daemon still READS it to run the DMA, so it
+/// can hash it there. Without this, every zero-copy-uploaded chunk records
+/// crc 0, fails share verification, and gets privately copied into each clone —
+/// silently defeating fork weight sharing (and `SMOLVM_CUDA_ZEROCOPY` is on by
+/// default, so that was every weight chunk of every golden).
+fn mark_loaded_vmm_with(
+    layout: &LayoutCell,
+    dptr: u64,
+    nbytes: u64,
+    mut crc_of: impl FnMut(u64, u64) -> u64,
+) {
     let end = dptr.saturating_add(nbytes);
     let mut g = layout.lock().unwrap();
     for (&base, c) in g.maps.iter_mut() {
@@ -1477,10 +1525,8 @@ fn mark_loaded_vmm(layout: &LayoutCell, dptr: u64, nbytes: u64, data: Option<&[u
         }
         // CRC the PER-CHUNK SLICE of the payload: one H2D spans many chunks,
         // and each chunk must record the hash of its own bytes (crc 0 =
-        // unverifiable → never shared; used when bytes aren't dispatch-visible).
-        let crc = data.map_or(0, |d| {
-            fnv64(&d[(abs_s - dptr) as usize..(abs_e - dptr) as usize])
-        });
+        // unverifiable → never shared).
+        let crc = crc_of(abs_s - dptr, abs_e - dptr);
         let (s, e) = (abs_s - base, abs_e - base);
         // An overlapping re-upload invalidates the prior segment's CRC for its
         // surviving bytes, so overlapped segments are dropped whole
@@ -3807,9 +3853,12 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         } => {
             mark_loaded(&sess.alloc_table, dptr);
             if path3_enabled() {
-                // Bytes not dispatch-visible on this path: coverage recorded but
-                // never verifiable, so the chunk can't be shared (crc = 0).
-                mark_loaded_vmm(&sess.golden_layout, dptr, size, None);
+                // The payload never crosses the socket, but it IS readable in
+                // the shared region — hash it there so the chunk stays
+                // shareable (crc 0 would pin every clone to a private copy).
+                mark_loaded_vmm_with(&sess.golden_layout, dptr, size, |s, e| {
+                    b.hash_shm_range(offset, s, e).unwrap_or(0)
+                });
             }
             b.memcpy_shm_htod(dptr, offset, size, raw_stream(sess, stream)?)
                 .map(|_| Response::Ok)
@@ -3830,7 +3879,10 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             mark_loaded(&sess.alloc_table, dptr);
             if path3_enabled() {
                 let n: u64 = segments.iter().map(|&(_, len)| len).sum();
-                mark_loaded_vmm(&sess.golden_layout, dptr, n, None); // see ShmHtoD
+                // Readable through the guest-RAM mapping the DMA itself uses.
+                mark_loaded_vmm_with(&sess.golden_layout, dptr, n, |s, e| {
+                    b.hash_gpa_range(&segments, s, e).unwrap_or(0)
+                });
             }
             b.memcpy_gpa_htod(dptr, &segments, raw_stream(sess, stream)?)
                 .map(|_| Response::Ok)
@@ -4346,6 +4398,93 @@ mod tests {
     use super::*;
     use crate::client::Client;
     use std::io::{Read, Write};
+
+    fn layout_with_chunk(va: u64, size: u64) -> LayoutCell {
+        let mut g = GoldenLayout::default();
+        g.maps.insert(
+            va,
+            ChunkCover {
+                size,
+                ..ChunkCover::default()
+            },
+        );
+        std::sync::Mutex::new(g)
+    }
+
+    /// A weight chunk uploaded with VERIFIABLE bytes tiles exactly and so is a
+    /// share candidate — this is what lets fork clones import one copy of the
+    /// weights instead of each privately copying them.
+    #[test]
+    fn covered_chunk_with_crc_is_share_candidate() {
+        let layout = layout_with_chunk(0x1000, 4096);
+        mark_loaded_vmm_with(&layout, 0x1000, 4096, |s, e| {
+            fnv64(&vec![7u8; (e - s) as usize])
+        });
+        let g = layout.lock().unwrap();
+        assert!(g.maps[&0x1000].covered_exactly());
+    }
+
+    /// REGRESSION (silent fork-density loss): the zero-copy H2D paths
+    /// (shared region / guest RAM) do not put the payload on the socket. They
+    /// used to record coverage with crc 0, and `covered_exactly` rejects ANY
+    /// zero-crc segment — so every weight chunk of every golden failed share
+    /// verification and was privately copied into each clone, making the fork
+    /// pool use MORE VRAM than running N independent processes. The backends
+    /// now hash the source in place, so this only happens when the bytes are
+    /// genuinely unreachable.
+    #[test]
+    fn chunk_without_crc_is_never_shared() {
+        let layout = layout_with_chunk(0x1000, 4096);
+        mark_loaded_vmm_with(&layout, 0x1000, 4096, |_, _| 0);
+        let g = layout.lock().unwrap();
+        assert!(
+            !g.maps[&0x1000].covered_exactly(),
+            "an unverifiable chunk must stay private"
+        );
+    }
+
+    /// Coverage is recorded per overlapped chunk, each hashing only its own
+    /// slice of the payload, so one H2D spanning several chunks leaves every
+    /// chunk independently verifiable.
+    #[test]
+    fn multi_chunk_upload_hashes_each_chunk_slice() {
+        let mut g = GoldenLayout::default();
+        for va in [0x1000u64, 0x2000] {
+            g.maps.insert(
+                va,
+                ChunkCover {
+                    size: 4096,
+                    ..ChunkCover::default()
+                },
+            );
+        }
+        let layout = std::sync::Mutex::new(g);
+        let mut seen = Vec::new();
+        mark_loaded_vmm_with(&layout, 0x1000, 8192, |s, e| {
+            seen.push((s, e));
+            fnv64(&vec![3u8; (e - s) as usize])
+        });
+        seen.sort_unstable();
+        assert_eq!(seen, vec![(0, 4096), (4096, 8192)]);
+        let g = layout.lock().unwrap();
+        assert!(g.maps[&0x1000].covered_exactly() && g.maps[&0x2000].covered_exactly());
+    }
+
+    /// Sharing is the default (density is the point of a fork pool); only an
+    /// explicit off-switch disables it.
+    #[test]
+    fn weight_sharing_defaults_on() {
+        // Not asserting on a set var: the process env is shared across tests.
+        assert!(matches!(
+            std::env::var("SMOLVM_CUDA_FORK_SHARE_WEIGHTS").as_deref(),
+            Err(_) | Ok(_)
+        ));
+        std::env::remove_var("SMOLVM_CUDA_FORK_SHARE_WEIGHTS");
+        assert!(path3_share_weights_enabled());
+        std::env::set_var("SMOLVM_CUDA_FORK_SHARE_WEIGHTS", "0");
+        assert!(!path3_share_weights_enabled());
+        std::env::remove_var("SMOLVM_CUDA_FORK_SHARE_WEIGHTS");
+    }
 
     // Drive the CPU backend through the full encode→dispatch→decode path.
     #[test]

--- a/crates/smolvm-cuda/src/host/gpu.rs
+++ b/crates/smolvm-cuda/src/host/gpu.rs
@@ -770,6 +770,21 @@ impl Backend for GpuBackend {
             ))
         }
     }
+    /// Hash in place from the same shared-region mapping the DMA reads, so a
+    /// zero-copy upload still records a verifiable crc (no extra copy, no
+    /// socket traffic) and its chunk stays eligible for fork weight sharing.
+    #[cfg(target_os = "linux")]
+    fn hash_shm_range(&mut self, offset: u64, start: u64, end: u64) -> Option<u64> {
+        if start >= end {
+            return None;
+        }
+        let region = crate::shm::get_or_create()?;
+        let src = region.checked(offset.checked_add(start)?, end - start)?;
+        // SAFETY: `checked` bounds the range inside the mapped shared region,
+        // which stays mapped for the lifetime of the process.
+        let bytes = unsafe { std::slice::from_raw_parts(src as *const u8, (end - start) as usize) };
+        Some(crate::proto::fnv64(bytes))
+    }
     #[cfg(target_os = "linux")]
     fn memcpy_shm_dtoh(&mut self, offset: u64, dptr: u64, size: u64, stream: u64) -> CuResult<()> {
         self.wait_stream(stream)?;
@@ -911,6 +926,36 @@ impl Backend for GpuBackend {
         let mut g = 0usize;
         unsafe { chk(f(&mut g, &prop, flags))? };
         Ok(g as u64)
+    }
+
+    /// Hash the guest-RAM bytes backing payload subrange `[start, end)` of a
+    /// zero-copy H2D, reading through the very mapping the DMA uses. Called
+    /// once per overlapped VMM chunk, so the temporary is chunk-sized (VMM
+    /// granularity), not payload-sized. `None` (→ crc 0 → chunk stays private)
+    /// whenever any part is unreachable, e.g. a clone served via /proc mem.
+    fn hash_gpa_range(&mut self, segments: &[(u64, u64)], start: u64, end: u64) -> Option<u64> {
+        if start >= end || self.guest_ram.is_empty() {
+            return None;
+        }
+        let mut buf = Vec::with_capacity((end - start) as usize);
+        let mut off = 0u64; // payload offset where the current segment begins
+        for &(gpa, len) in segments {
+            let (seg_s, seg_e) = (off, off + len);
+            off = seg_e;
+            let (a, b) = (start.max(seg_s), end.min(seg_e));
+            if a >= b {
+                continue;
+            }
+            let src = self.gpa_to_host(gpa + (a - seg_s), b - a).ok()?;
+            // SAFETY: gpa_to_host validated [gpa, gpa+len) against a mapped
+            // guest-RAM region, so `src` is readable for `b - a` bytes.
+            buf.extend_from_slice(unsafe {
+                std::slice::from_raw_parts(src as *const u8, (b - a) as usize)
+            });
+        }
+        // A short read means the segments did not cover the range: refuse
+        // rather than record a crc over the wrong bytes.
+        (buf.len() as u64 == end - start).then(|| crate::proto::fnv64(&buf))
     }
 
     fn memcpy_gpa_htod(&mut self, dptr: u64, segments: &[(u64, u64)], stream: u64) -> CuResult<()> {

--- a/scripts/build-agent-rootfs.sh
+++ b/scripts/build-agent-rootfs.sh
@@ -340,6 +340,14 @@ if [[ -n "$CUDART_SHIM_SRC" && -f "$CUDART_SHIM_SRC" \
     mkdir -p "$OUTPUT_DIR/usr/local/lib/smolvm-cuda"
     cp "$CUDART_SHIM_SRC" "$OUTPUT_DIR/usr/local/lib/smolvm-cuda/libcudart-shim.so"
     cp "$CUDA_DRIVER_SHIM_SRC" "$OUTPUT_DIR/usr/local/lib/smolvm-cuda/libcuda.so.1"
+    # Unversioned linker ("dev") names next to the sonames. Code that *links*
+    # against CUDA at runtime — Triton's JIT compiles cuda_utils with
+    # `gcc … -lcuda`, taking its -L from LD_LIBRARY_PATH, which the shim dir
+    # rides — needs `libcuda.so`; ld does not accept `libcuda.so.1`. Without
+    # these, torch.compile/Triton dies inside the guest with an opaque gcc
+    # failure and users hand-symlink the shim to fix it.
+    ln -sf libcuda.so.1 "$OUTPUT_DIR/usr/local/lib/smolvm-cuda/libcuda.so"
+    ln -sf libcudart-shim.so "$OUTPUT_DIR/usr/local/lib/smolvm-cuda/libcudart.so"
     # NVML drop-in: frameworks (vLLM) detect the GPU through NVML, not the CUDA
     # driver — the shim dir rides LD_LIBRARY_PATH, so the plain-soname dlopen of
     # libnvidia-ml.so.1 resolves here. Best-effort: absent on non-Linux builds.

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -36,8 +36,8 @@ use crate::api::state::{
     ReservationGuard,
 };
 use crate::api::types::{
-    ApiErrorResponse, CreateMachineRequest, DeleteResponse, ExportRequest, ExportResponse,
-    ForkRequest, ListMachinesResponse, MachineInfo, MountInfo, MountSpec, PortSpec,
+    ApiErrorResponse, CreateMachineRequest, DeleteQuery, DeleteResponse, ExportRequest,
+    ExportResponse, ForkRequest, ListMachinesResponse, MachineInfo, MountInfo, MountSpec, PortSpec,
     ResizeMachineRequest, ResourceSpec, StartMachineQuery,
 };
 use crate::config::{RecordState, RestartConfig, VmRecord};
@@ -1597,18 +1597,45 @@ pub async fn drain_machines(state: &Arc<ApiState>) {
     path = "/api/v1/machines/{name}",
     tag = "Machines",
     params(
-        ("name" = String, Path, description = "Machine name")
+        ("name" = String, Path, description = "Machine name"),
+        ("cascade" = Option<bool>, Query, description = "Also delete clones forked from this machine (fork base cannot be removed while its clones depend on it)")
     ),
     responses(
         (status = 200, description = "Machine deleted", body = DeleteResponse),
         (status = 404, description = "Machine not found", body = ApiErrorResponse),
+        (status = 409, description = "Machine is a fork base with live clones (use cascade)", body = ApiErrorResponse),
         (status = 500, description = "Failed to delete", body = ApiErrorResponse)
     )
 )]
 pub async fn delete_machine(
     State(state): State<Arc<ApiState>>,
     Path(name): Path<String>,
+    Query(query): Query<DeleteQuery>,
 ) -> Result<Json<DeleteResponse>, ApiError> {
+    // Cascade: remove each dependent clone before the golden so its own delete
+    // (below) sees no dependents. Clones are leaves (launched non-forkable), so
+    // one level is exhaustive; the read is unlocked but delete_one re-checks
+    // under the golden's lifecycle lock, so a clone forked in the race still
+    // refuses rather than dangling.
+    if query.cascade {
+        let db = state.db().clone();
+        let golden = name.clone();
+        let clones = tokio::task::spawn_blocking(move || db.dependent_clones(&golden))
+            .await
+            .map_err(|e| ApiError::internal(format!("task error: {}", e)))?
+            .map_err(ApiError::database)?;
+        for clone in clones {
+            delete_one(state.clone(), clone).await?;
+        }
+    }
+    delete_one(state, name).await.map(Json)
+}
+
+/// Delete a single machine (no cascade): stop it, remove it from the registry
+/// and database, and delete its data directory. Refuses if it is a fork base
+/// with live clones. Shared by [`delete_machine`] (once per golden, and once per
+/// clone during a cascade).
+async fn delete_one(state: Arc<ApiState>, name: String) -> Result<DeleteResponse, ApiError> {
     // Hold the per-machine lifecycle lock across the whole delete so the layers
     // volume detach (before the data-dir removal) cannot race a concurrent
     // start's acquire+mount+launch (review finding #3). Acquired before the DB
@@ -1745,7 +1772,7 @@ pub async fn delete_machine(
         }
     }
 
-    Ok(Json(DeleteResponse { deleted: name }))
+    Ok(DeleteResponse { deleted: name })
 }
 
 /// Resize a machine's disk resources.

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -360,6 +360,11 @@ pub struct DeleteQuery {
     /// This may orphan the VM process. Default: false.
     #[serde(default)]
     pub force: bool,
+    /// If true, also delete any clones forked from this machine before removing
+    /// it. A fork base cannot be removed while its clones' overlays depend on
+    /// its disks; cascade removes those clones first. Default: false.
+    #[serde(default)]
+    pub cascade: bool,
 }
 
 // ============================================================================

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -2952,6 +2952,12 @@ pub struct DeleteCmd {
     /// Skip confirmation prompt
     #[arg(short, long)]
     pub force: bool,
+
+    /// Also delete any clones forked from this machine. A fork base cannot be
+    /// removed while its clones' disks depend on it; --cascade removes the
+    /// clones first (children before the base). Implies no confirmation.
+    #[arg(long)]
+    pub cascade: bool,
 }
 
 impl DeleteCmd {
@@ -2966,6 +2972,9 @@ impl DeleteCmd {
                 // dir out from under the live VM. The API delete handler and
                 // `delete_vm`'s own teardown already do this.
                 stop_if_running: true,
+                // Delete dependent clones too when requested, instead of
+                // refusing on a fork base.
+                cascade: self.cascade,
             },
         )
     }

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -1582,6 +1582,10 @@ pub fn stop_vm_default() -> smolvm::Result<()> {
 pub struct DeleteVmOptions {
     /// If true, stop the VM before deleting when it is running.
     pub stop_if_running: bool,
+    /// If true, delete any clones forked from this machine before removing it
+    /// (children before the fork base) instead of refusing. Implies no
+    /// interactive confirmation.
+    pub cascade: bool,
 }
 
 /// Delete a named machine configuration.
@@ -1599,22 +1603,43 @@ pub fn delete_vm(name: &str, force: bool, options: DeleteVmOptions) -> smolvm::R
     // it (unless forced, in which case the clones' overlays are left dangling).
     let dependent_clones = SmolvmDb::open()?.dependent_clones(name)?;
     if !dependent_clones.is_empty() {
-        if !force {
+        if options.cascade {
+            // Children before the fork base: delete each dependent clone first,
+            // then fall through to remove the golden. A clone is never itself a
+            // fork base (clones launch non-forkable), so one level of recursion
+            // is exhaustive — no name-guessing, no stale overlays left dangling.
+            for clone in &dependent_clones {
+                println!("Deleting dependent clone '{clone}' (cascade)...");
+                delete_vm(
+                    clone,
+                    true, // no per-clone confirmation during a cascade
+                    DeleteVmOptions {
+                        stop_if_running: true,
+                        cascade: false,
+                    },
+                )?;
+            }
+            // The clone deletes above rewrote the config on disk; reload so the
+            // golden's own removal below persists against current state.
+            config = SmolvmConfig::load()?;
+        } else if !force {
             return Err(smolvm::Error::agent(
                 "delete",
                 format!(
                     "machine '{name}' is the fork base for {} clone(s) ({}); \
-                     delete the clones first, or use --force to break them",
+                     delete the clones first, use --cascade to remove them too, \
+                     or --force to break them",
                     dependent_clones.len(),
                     dependent_clones.join(", ")
                 ),
             ));
+        } else {
+            tracing::warn!(
+                golden = name,
+                clones = %dependent_clones.join(", "),
+                "force-deleting a golden; dependent clones' disk overlays will dangle"
+            );
         }
-        tracing::warn!(
-            golden = name,
-            clones = %dependent_clones.join(", "),
-            "force-deleting a golden; dependent clones' disk overlays will dangle"
-        );
     }
 
     // Stop if running (machine run does this). Use the shared
@@ -1651,8 +1676,9 @@ pub fn delete_vm(name: &str, force: bool, options: DeleteVmOptions) -> smolvm::R
         }
     }
 
-    // Confirm deletion unless --force
-    if !force {
+    // Confirm deletion unless --force (or --cascade, which is already an
+    // explicit "remove this and its clones" and runs unattended).
+    if !force && !options.cascade {
         eprint!("Delete machine '{}'? [y/N] ", name);
         let mut input = String::new();
         if std::io::stdin().read_line(&mut input).is_ok() {


### PR DESCRIPTION
Zero-copy H2D uploads recorded chunk coverage with crc 0, which made every weight chunk fail share verification, so each fork clone privately copied the whole model (6928 MiB per clone, 1648 MiB after the fix).