### PR TITLE
Map shared weight chunks read-only so a stray post-fork base write cannot corrupt sibling clones

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,105 @@
+# Fork-pool benchmark harness
+
+Measures the same post-training workload two ways on one GPU, so claims about
+smolvm's fork pool can be checked rather than believed:
+
+- **native** — N learner processes on bare metal, each loading its own base model
+- **fork** — one smolvm golden VM loads the base once, then N `--share-weights`
+  clones, CUDA remoted to the host daemon
+
+Both arms run the *same* workload file with the same
+`STEPS/BATCH/MAXSEQ/MODEL`, and are measured the same way: wall clock from t0 to
+the last learner finishing, 1 Hz `nvidia-smi` peak sampling, and per-learner
+tok/s taken from the workload's own JSONL. Every run writes
+`results/<run-id>.json` including an environment manifest (smolvm version +
+binary md5, rootfs proto-hash, shim md5, driver, torch, GPU, host cores).
+
+## Prerequisites
+
+The harness does not build or install anything. You need, on the GPU host:
+
+| Requirement | Default | Override |
+|---|---|---|
+| smolvm binary | `~/smolvm/smolvm` | `SMOLVM=` |
+| libkrun dir | `~/smolvm/lib/linux-x86_64` | `SMOLVM_LIB_DIR=` |
+| Python venv with torch + unsloth + trl | `~/ptwork/bin/python` | `PY_VENV=` |
+| Machine image (`.smolmachine`) with that venv baked in | `~/qlora-baked.smolmachine` | `PACK=` |
+| Model in the HF cache (`~/hf`) | `unsloth/Qwen2.5-7B-bnb-4bit` | `MODEL=` |
+| NVIDIA GPU + driver | — | — |
+
+**The agent rootfs must carry CUDA guest shims built from the same tree as the
+smolvm binary.** If they disagree you get
+`PROTOCOL MISMATCH: client wire hash … != server …` and the golden never loads.
+Stage them together:
+
+```sh
+T=<repo>/target/release
+R=~/.local/share/smolvm/agent-rootfs/usr/local/lib/smolvm-cuda
+cp $T/libcudart.so $R/libcudart-shim.so
+cp $T/libcuda.so   $R/libcuda.so.1
+cp $T/libnvidia_ml.so $R/libnvidia-ml.so.1
+ln -sf libcuda.so.1 $R/libcuda.so          # Triton's JIT links -lcuda
+ln -sf libcudart-shim.so $R/libcudart.so
+$T/smolvm-cuda-run --proto-hash > $R/proto-hash
+```
+
+## Running
+
+```sh
+./bench.sh --arm native --n 4 --steps 20 --cpus 4
+./bench.sh --arm fork   --n 4 --steps 20 --cpus 4 --share on
+./summarize.py                    # median + spread per (arm, N, batch), and the ratio
+```
+
+Flags that exist because leaving them out produces misleading numbers:
+
+- `--cpus K` — pin **each** native learner to its own K-core set, matching the
+  per-VM vCPU count in the fork arm. Without this, native silently gets the
+  whole host (26 cores here) while each clone VM gets 4. `--cpus 0` = unpinned.
+- `--share on|off|default` — sets `SMOLVM_CUDA_FORK_SHARE_WEIGHTS` **and checks
+  the daemon honoured it**, printing `!! CONTROL FAILED` if a copy-mode arm
+  actually shared. An earlier control silently ran the wrong configuration; this
+  is the guard against repeating that.
+- `--reps R` — repeat; `summarize.py` reports median and min–max. Single runs are
+  not evidence: the golden load is bimodal (~15s vs ~156s) and one N=16 run in
+  three produced `nan` learners.
+- `--cold` — drop the page cache first (default warms both arms identically).
+- `--batch` / `--maxseq` — kernel size. The default (2 × 256) is launch-latency
+  bound, which flatters neither arm honestly.
+
+`matrix.sh` (scaling + kernel-size sweep) and `highn.sh` (native vs fork at high
+N) drive `bench.sh` sequentially — the GPU must be exclusive or every number is
+noise. `bench.sh` refuses to start if the GPU already holds >500 MiB.
+
+## Reading the output
+
+```
+wall=253.79s done=4/4 agg_tok_s=546 peak_gpu=14550MiB golden_load=165.59s
+```
+
+- `done` — learners that reported `event: done`. **Less than N usually means OOM**;
+  `summarize.py` flags those rows, since a partial aggregate looks like a real
+  datapoint otherwise.
+- `peak_gpu` — whole-device peak, so it includes the golden's own context in the
+  fork arm. For a per-process split use `probe_mem.sh` during a run.
+- `golden_load` — fork arm only; paid once per pool, not per learner.
+
+Analysis helpers: `nan_census.py` (nan count per run across `results/`),
+`parse_losses.py <run-dir>` (per-learner losses for one run).
+
+## Caveats a reader should know
+
+1. **Throughput and density are separate questions.** Weight sharing changes
+   VRAM, not FLOPs — measured +6% aggregate at N=4, i.e. noise.
+2. **CPU becomes the limit before VRAM does.** At 4 vCPU per clone on a 26-core
+   host, aggregate throughput peaks near N=8 and falls at N=16. High-N results
+   measure a memory ceiling, not useful throughput.
+3. **`nan` learners appear intermittently at N=16** (1 run in 3; never at N≤8).
+   Not yet attributed — a copy-mode control at N=16 is impossible because it
+   needs ~118 GiB on an 80 GiB card.
+4. **A ~750 MiB CUDA context can leak after a fork run.** The preflight check
+   catches it and aborts rather than measuring on a dirty GPU; kill stray
+   `_cuda-daemon` / `_cuda-clone-worker` processes between runs.
+5. The workload (`workload_dpo.py`) writes its trainer output under `$OUTBASE`;
+   it is a copy of the DPO fork workload with that path made configurable so the
+   same file runs both in-VM (as root) and on the host.

--- a/bench/RESULTS.md
+++ b/bench/RESULTS.md
@@ -1,0 +1,28 @@
+# Measured results
+
+All rows produced by `bench.sh` on one exclusive GPU. Regenerate with
+`./summarize.py`; raw per-run JSON (including a full environment manifest)
+is in `results/`.
+
+Host: NVIDIA H100 80GB HBM3 · driver 570.148.08 · torch 2.7.0+cu126 · 26 cores / 237 GB
+
+| arm | N | steps | batch×seq | done | agg tok/s | peak GPU MiB | golden load s | shared ranges |
+|---|---|---|---|---|---|---|---|---|
+| fork | 4 | 20 | 2x256 | 4/4 | 546 | 14550 | 165.59 | - |
+| fork | 8 | 10 | 2x256 | 8/8 | 432 | 21500 | 163.73 | - |
+| fork | 8 | 10 | 2x256 | 8/8 | 432 | 21480 | 169.23 | - |
+| fork | 8 | 10 | 2x256 | 8/8 | 436 | 21480 | 166.66 | - |
+| fork | 8 | 20 | 2x256 | 8/8 | 736 | 63082 | 156.34 | - |
+| fork | 16 | 10 | 2x256 | 16/16 (2 nan) | 465 | 35400 | 166.47 | - |
+| fork | 16 | 10 | 2x256 | 16/16 | 452 | 35340 | 167.02 | - |
+| fork | 16 | 10 | 2x256 | 16/16 | 487 | 35340 | 164.39 | - |
+| native | 8 | 20 | 2x256 | 8/8 | 1462 | 59080 | - | - |
+| native | 12 | 20 | 2x256 | 7/12 | 1145 | 81057 | - | - |
+| native | 16 | 10 | 2x256 | 2/16 | 467 | 81087 | - | - |
+
+## Headline
+
+- Weight sharing was inert before the fix: the daemon logged `shared=0 private=420` even when explicitly enabled, because zero-copy H2D uploads recorded chunk coverage with crc 0 and share verification rejects any zero-crc segment.
+- After the fix: `shared=260 private=160`, per-clone VRAM 6928 -> 1648 MiB, and N=4 final losses bit-identical to all-private mode.
+- Native's ceiling on an 80 GiB card is ~11 learners (N=12 -> 7/12, N=16 -> 2/16). Fork with sharing ran 16/16 in 35.4 GiB.
+- Throughput is unchanged by the fix (+6% at N=4) and fork remains ~2x slower per learner than native; this is a density change, not a speed change.

--- a/bench/bench.sh
+++ b/bench/bench.sh
@@ -1,0 +1,255 @@
+#!/bin/bash
+# Reproducible A/B: the SAME post-training workload run two ways on one GPU.
+#
+#   native — N learner processes on bare metal, each loading its own base
+#   fork   — one smolvm golden VM loads the base once, then N --share-weights
+#            clones, CUDA remoted to the host daemon
+#
+# Both arms run the identical workload file (workload_dpo.py) with identical
+# STEPS/BATCH/MAXSEQ/MODEL/seed, and are measured identically (wall clock from
+# t0 to last learner done, 1 Hz nvidia-smi peak sampling, per-learner tok/s from
+# the workload's own JSONL). Results append to results/<run-id>.json.
+#
+# FAIRNESS KNOBS (the confounds that made the first ad-hoc comparison invalid):
+#   --cpus K   pin EACH native learner to its own K-core set, matching the
+#              per-VM vCPU count in the fork arm. Default 4 = fork parity.
+#              Use --cpus 0 to leave native unpinned (whole host).
+#   --cold     drop the page cache before the run (default: warm, i.e. the
+#              model file is pre-read so neither arm pays first-touch disk I/O)
+#   --reps R   repeat R times; summarize.py reports the median and the spread
+#              (the golden load is known to be bimodal ~15s vs ~156s)
+#
+# Usage: ./bench.sh --arm native|fork --n 4 [--steps 20] [--reps 3] [--cpus 4]
+#        [--cold] [--share on|off|default] [--batch 2] [--maxseq 256]
+set -u
+
+ARM=""; N=4; STEPS=20; REPS=1; CPUS=4; COLD=0; BATCH=2; MAXSEQ=256; TIMEOUT=600; SHARE=default
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --arm) ARM="$2"; shift 2 ;;
+        --n) N="$2"; shift 2 ;;
+        --steps) STEPS="$2"; shift 2 ;;
+        --reps) REPS="$2"; shift 2 ;;
+        --cpus) CPUS="$2"; shift 2 ;;
+        --cold) COLD=1; shift ;;
+        --batch) BATCH="$2"; shift 2 ;;
+        --maxseq) MAXSEQ="$2"; shift 2 ;;
+        --timeout) TIMEOUT="$2"; shift 2 ;;
+        # on|off|default — sets SMOLVM_CUDA_FORK_SHARE_WEIGHTS for the run and
+        # VERIFIES the daemon actually honoured it (see check_share_mode).
+        --share) SHARE="$2"; shift 2 ;;
+        *) echo "unknown arg: $1"; exit 2 ;;
+    esac
+done
+[[ "$ARM" == "native" || "$ARM" == "fork" ]] || { echo "need --arm native|fork"; exit 2; }
+
+BENCH_DIR="$(cd "$(dirname "$0")" && pwd)"
+RESULTS="$BENCH_DIR/results"; mkdir -p "$RESULTS"
+WORKLOAD="$BENCH_DIR/workload_dpo.py"
+MODEL="${MODEL:-unsloth/Qwen2.5-7B-bnb-4bit}"
+PY_VENV="${PY_VENV:-$HOME/ptwork/bin/python}"
+S="${SMOLVM:-$HOME/smolvm/smolvm}"
+export SMOLVM_LIB_DIR="${SMOLVM_LIB_DIR:-$HOME/smolvm/lib/linux-x86_64}"
+SOCK=/tmp/smolvm/cuda-daemon.sock
+PACK="${PACK:-$HOME/qlora-baked.smolmachine}"
+# expandable_segments:True makes torch allocate via CUDA VMM, which bypasses
+# the daemon alloc-table that marks weight ranges "loaded" -> fork weight
+# sharing degrades to private copies. Override to test the sharing path.
+ALLOC_CONF="${ALLOC_CONF:-expandable_segments:True}"
+
+# ---------------------------------------------------------------- preconditions
+# A leaked context or a live clone from a previous run silently changes both
+# load time and peak memory, so refuse to measure until the box is clean.
+preflight() {
+    local used
+    used=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits)
+    if [[ "$used" -gt 500 ]]; then
+        echo "PREFLIGHT FAIL: GPU already using ${used} MiB (leaked context?). Aborting."
+        nvidia-smi --query-compute-apps=pid,used_memory --format=csv | head
+        exit 1
+    fi
+    pkill -f "smolvm _cuda-daemo[n]" 2>/dev/null
+    pkill -f "_cuda-clone-worke[r]" 2>/dev/null
+    # --cascade removes a golden together with its clones (no name guessing).
+    $S machine rm --name bench-g --cascade >/dev/null 2>&1
+    for m in $($S machine list 2>/dev/null | awk '/^bench-/{print $1}'); do
+        $S machine rm --name "$m" --force >/dev/null 2>&1
+    done
+    rm -f "$SOCK"
+    if [[ "$COLD" == "1" ]]; then
+        sync; echo 3 | sudo tee /proc/sys/vm/drop_caches >/dev/null 2>&1 || echo "  (cache drop needs sudo; continuing warm)"
+    else
+        # Warm both arms identically: page in the model weights once.
+        find "$HOME/hf" -name "*.safetensors" -exec cat {} + > /dev/null 2>&1
+    fi
+}
+
+# Environment manifest: everything that could move a number between runs.
+manifest() {
+    python3 - "$@" <<'PY'
+import json, subprocess, sys, os
+def sh(c):
+    try: return subprocess.check_output(c, shell=True, text=True, stderr=subprocess.DEVNULL).strip()
+    except Exception: return None
+print(json.dumps({
+  "smolvm_version": sh(f"{sys.argv[1]} --version"),
+  "smolvm_binary_md5": sh(f"md5sum {sys.argv[1]} | cut -d' ' -f1"),
+  "proto_hash_rootfs": sh("cat ~/.local/share/smolvm/agent-rootfs/usr/local/lib/smolvm-cuda/proto-hash"),
+  "shim_md5": sh("md5sum ~/.local/share/smolvm/agent-rootfs/usr/local/lib/smolvm-cuda/libcudart-shim.so | cut -d' ' -f1"),
+  "driver": sh("nvidia-smi --query-gpu=driver_version --format=csv,noheader"),
+  "gpu": sh("nvidia-smi --query-gpu=name --format=csv,noheader"),
+  "torch": sh(f"{sys.argv[2]} -c 'import torch;print(torch.__version__)'"),
+  "host_cores": os.cpu_count(),
+  "host_mem_gb": round(os.sysconf('SC_PAGE_SIZE')*os.sysconf('SC_PHYS_PAGES')/1e9),
+}))
+PY
+}
+
+# 1 Hz peak sampler; writes the max MiB seen to $1 when told to stop via $2.
+sample_gpu() {
+    local out="$1" stopflag="$2" maxv=0 v
+    while [[ ! -f "$stopflag" ]]; do
+        v=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits 2>/dev/null)
+        [[ "$v" -gt "$maxv" ]] 2>/dev/null && maxv=$v
+        sleep 1
+    done
+    echo "$maxv" > "$out"
+}
+
+# ---------------------------------------------------------------------- arms
+run_native() {
+    local CO="$1"
+    export HF_HOME=$HOME/hf HF_HUB_OFFLINE=1 COORD=$CO ARM=native FORK=0 OUTBASE=$CO
+    export STEPS=$STEPS MODEL=$MODEL BATCH=$BATCH MAXSEQ=$MAXSEQ
+    export PYTORCH_CUDA_ALLOC_CONF="$ALLOC_CONF" TORCHINDUCTOR_COMPILE_THREADS=1
+    # Collect the learner PIDs and wait on THOSE only: a bare `wait` would also
+    # block on the GPU sampler running in this same shell, which by design does
+    # not exit until after this function returns (deadlock).
+    local pids=()
+    for i in $(seq 0 $((N-1))); do
+        if [[ "$CPUS" -gt 0 ]]; then
+            # Give each learner its own K-core set, mirroring one VM's vCPUs.
+            local nproc_n cores
+            nproc_n=$(nproc)
+            cores=$(python3 -c "print(','.join(str(($i*$CPUS+k) % $nproc_n) for k in range($CPUS)))")
+            LEARNER_ID=$i taskset -c "$cores" "$PY_VENV" "$CO/dpo_train.py" > "$CO/o$i.log" 2>"$CO/e$i.log" &
+        else
+            LEARNER_ID=$i "$PY_VENV" "$CO/dpo_train.py" > "$CO/o$i.log" 2>"$CO/e$i.log" &
+        fi
+        pids+=($!)
+    done
+    wait "${pids[@]}"
+}
+
+run_fork() {
+    local CO="$1"
+    # Set the mode explicitly rather than relying on ambient env: an arm that
+    # silently runs the wrong configuration is worse than no arm at all (this
+    # bit me — a "copy mode" control that actually shared, because the variable
+    # never reached the daemon). check_share_mode below proves what ran.
+    case "$SHARE" in
+        on)  export SMOLVM_CUDA_FORK_SHARE_WEIGHTS=1 ;;
+        off) export SMOLVM_CUDA_FORK_SHARE_WEIGHTS=0 ;;
+        default) unset SMOLVM_CUDA_FORK_SHARE_WEIGHTS ;;
+        *) echo "bad --share: $SHARE (want on|off|default)"; exit 2 ;;
+    esac
+    env SMOLVM_CUDA_FORK_WORKERS=1 SMOLVM_CUDA_FORK_ISOLATE=1 SMOLVM_CUDA_DAEMON_IDLE_SECS=0 \
+        RUST_LOG=warn,smolvm::cuda_daemon=info "$S" _cuda-daemon "$SOCK" > "$CO/daemon.log" 2>&1 &
+    for i in $(seq 1 100); do [[ -S "$SOCK" ]] && break; sleep 0.1; done
+    # No manual CUDA env: smolvm injects SMOLVM_CUDA_ZEROCOPY and stages the
+    # guest shims (libcuda.so.1 + the unversioned dev names) itself.
+    # Optional guest-side prelude (e.g. `unset SMOLVM_CUDA_ZEROCOPY;`) so a run
+    # can disable the zero-copy upload path, whose crc=0 coverage makes every
+    # weight chunk unshareable.
+    local GUEST="${BENCH_GUEST_EXTRA:-} export HF_HOME=/opt/hfcache HF_HUB_OFFLINE=0 COORD=/opt/coord ARM=fork FORK=1 \
+STEPS=$STEPS NSLOTS=$N MODEL=$MODEL OUTBASE=/root BATCH=$BATCH MAXSEQ=$MAXSEQ \
+PYTORCH_CUDA_ALLOC_CONF=$ALLOC_CONF TORCHINDUCTOR_COMPILE_THREADS=1; \
+/home/ubuntu/ptwork/bin/python /opt/coord/dpo_train.py 2>>/opt/coord/g.err"
+    $S machine create --name bench-g --cuda --net -v "$CO:/opt/coord:rw" \
+        --from "$PACK" --storage 30 --overlay 20 -- sh -c "$GUEST" >/dev/null 2>&1
+    env SMOLVM_CUDA_SHARED=1 $S machine start --forkable --name bench-g >/dev/null 2>&1
+    local tgold
+    for i in $(seq 1 300); do [[ -f "$CO/golden_ready" ]] && break; sleep 1; done
+    [[ -f "$CO/golden_ready" ]] || { echo "GOLDEN-LOAD-FAILED"; return 1; }
+    tgold=$(date +%s.%N); echo "$tgold" > "$CO/.t_golden"
+    for c in $(seq 0 $((N-1))); do
+        $S machine fork --golden bench-g --name bench-c$c --share-weights >/dev/null 2>&1
+    done
+    echo "$(date +%s.%N)" > "$CO/.t_forked"
+    touch "$CO/go"
+    local deadline=$(( $(date +%s) + TIMEOUT ))
+    while [[ "$(grep -l '"event": "done"' "$CO"/learner_*.jsonl 2>/dev/null | wc -l)" -lt "$N" ]]; do
+        [[ $(date +%s) -ge $deadline ]] && { echo "  TIMEOUT after ${TIMEOUT}s (learners still unfinished)"; break; }
+        sleep 2
+    done
+    check_share_mode "$CO"
+    $S machine rm --name bench-g --cascade >/dev/null 2>&1
+    pkill -f "smolvm _cuda-daemo[n]" 2>/dev/null; pkill -f "_cuda-clone-worke[r]" 2>/dev/null
+}
+
+# The daemon logs "M2: shared weight ranges shared=<n> private=<m>" per clone.
+# Confirm it agrees with --share, so a result can never be attributed to a mode
+# that did not actually run.
+check_share_mode() {
+    local CO="$1" line shared
+    line=$(grep -o "shared=[0-9]* private=[0-9]*" "$CO/daemon.log" 2>/dev/null | tail -1)
+    shared=$(echo "$line" | sed -E "s/shared=([0-9]*).*/\1/")
+    echo "  share-mode requested=$SHARE  daemon reported: ${line:-<none>}"
+    if [[ "$SHARE" == "off" && "${shared:-0}" -gt 0 ]]; then
+        echo "  !! CONTROL FAILED: asked for copy mode but the daemon shared $shared ranges"
+    elif [[ "$SHARE" == "on" && "${shared:-0}" -eq 0 ]]; then
+        echo "  !! SHARING DID NOT ENGAGE: asked to share but the daemon shared 0 ranges"
+    fi
+}
+
+# ---------------------------------------------------------------------- driver
+MF=$(manifest "$S" "$PY_VENV")
+for rep in $(seq 1 "$REPS"); do
+    RUNID="${ARM}_n${N}_s${STEPS}_c${CPUS}_$(date +%Y%m%d-%H%M%S)_r${rep}"
+    CO="$HOME/bench_run/$RUNID"; rm -rf "$CO"; mkdir -p "$CO"; cp "$WORKLOAD" "$CO/dpo_train.py"
+    echo "=== $RUNID (arm=$ARM n=$N steps=$STEPS cpus=$CPUS cold=$COLD) ==="
+    preflight
+    STOP="$CO/.stop"; PEAK="$CO/.peak"; rm -f "$STOP"
+    sample_gpu "$PEAK" "$STOP" &
+    SAMPLER=$!
+    T0=$(date +%s.%N)
+    if [[ "$ARM" == "native" ]]; then run_native "$CO"; else run_fork "$CO"; fi
+    T1=$(date +%s.%N)
+    touch "$STOP"; wait $SAMPLER 2>/dev/null
+    WALL=$(echo "$T1 - $T0" | bc)
+    GOLD=""; [[ -f "$CO/.t_golden" ]] && GOLD=$(echo "$(cat "$CO/.t_golden") - $T0" | bc)
+    FORKED=""; [[ -f "$CO/.t_forked" ]] && FORKED=$(echo "$(cat "$CO/.t_forked") - $(cat "$CO/.t_golden")" | bc)
+    SHARE_RECORD="$SHARE" SHARED_RANGES="$(grep -o 'shared=[0-9]*' "$CO/daemon.log" 2>/dev/null | tail -1 | cut -d= -f2)" BATCH_RECORD="$BATCH" MAXSEQ_RECORD="$MAXSEQ" ALLOC_CONF_RECORD="$ALLOC_CONF" SW_RECORD="${SMOLVM_CUDA_FORK_SHARE_WEIGHTS:-unset}" python3 - "$CO" "$RESULTS/$RUNID.json" "$ARM" "$N" "$STEPS" "$CPUS" "$COLD" "$WALL" "${GOLD:-null}" "${FORKED:-null}" "$(cat "$PEAK" 2>/dev/null || echo 0)" "$MF" <<'PY'
+import sys, json, glob
+co, out, arm, n, steps, cpus, cold, wall, gold, forked, peak, mf = sys.argv[1:13]
+learners = []
+for f in sorted(glob.glob(f"{co}/learner_*.jsonl")):
+    d = {}
+    for line in open(f):
+        e = json.loads(line); d[e["event"]] = e
+    if "done" in d:
+        z = d["done"]
+        learners.append({k: z.get(k) for k in ("lid","tok_s","train_s","step_ms","loss0","lossN","peak_gb")})
+rec = {
+  "arm": arm, "n": int(n), "steps": int(steps), "cpus_per_learner": int(cpus),
+  "cold_cache": bool(int(cold)),
+  "alloc_conf": __import__("os").environ.get("ALLOC_CONF_RECORD", ""),
+  "batch": int(__import__("os").environ.get("BATCH_RECORD", "0")),
+  "maxseq": int(__import__("os").environ.get("MAXSEQ_RECORD", "0")),
+  "share_weights_env": __import__("os").environ.get("SW_RECORD", ""),
+  "share_mode": __import__("os").environ.get("SHARE_RECORD", ""),
+  "shared_ranges": __import__("os").environ.get("SHARED_RANGES", ""),
+  "wall_s": round(float(wall), 2),
+  "golden_load_s": None if gold == "null" else round(float(gold), 2),
+  "fork_s": None if forked == "null" else round(float(forked), 2),
+  "peak_gpu_mib": int(peak),
+  "learners_done": len(learners), "learners_expected": int(n),
+  "agg_tok_s": sum(l["tok_s"] for l in learners if l["tok_s"]),
+  "learners": learners,
+  "env": json.loads(mf),
+}
+json.dump(rec, open(out, "w"), indent=2)
+print(f"  wall={rec['wall_s']}s done={rec['learners_done']}/{n} agg_tok_s={rec['agg_tok_s']} peak_gpu={rec['peak_gpu_mib']}MiB" + (f" golden_load={rec['golden_load_s']}s" if rec["golden_load_s"] else ""))
+print(f"  -> {out}")
+PY
+done

--- a/bench/highn.sh
+++ b/bench/highn.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# HIGH-N PAYOFF: the regime the fork pool exists for.
+#
+# Native holds one full model per learner (~7.4 GiB), so an 80 GiB card runs
+# out at ~11 (measured: N=12 finished only 7/12, peaking at 81 GiB). With
+# weight sharing repaired, a clone's marginal cost is ~1.6 GiB, so the same
+# card should hold far more learners than native can.
+#
+# Runs native first (fails fast) then fork, strictly sequentially. Steps are
+# short because this measures MEMORY CEILING and completion, not throughput.
+set -u
+cd "$(dirname "$0")"
+LOG=~/highn_progress.log; : > "$LOG"
+N=${N:-16}
+STEPS=${STEPS:-10}
+
+run() {
+    echo "" | tee -a "$LOG"
+    echo "########## $* ##########" | tee -a "$LOG"
+    ./bench.sh "$@" 2>&1 | tee -a "$LOG" || echo "  (cell failed — recorded)" | tee -a "$LOG"
+    for i in $(seq 1 40); do
+        u=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits)
+        [[ "$u" -lt 500 ]] && break
+        sleep 3
+    done
+    pkill -f "smolvm _cuda-daemo[n]" 2>/dev/null
+    pkill -f "_cuda-clone-worke[r]" 2>/dev/null
+    sleep 3
+}
+
+echo "===== HIGH-N: native vs fork at N=$N =====" | tee -a "$LOG"
+run --arm native --n "$N" --steps "$STEPS" --cpus 4 --timeout 1500
+run --arm fork   --n "$N" --steps "$STEPS" --cpus 4 --timeout 1500
+
+echo "" | tee -a "$LOG"
+echo "HIGHN_DONE" | tee -a "$LOG"

--- a/bench/matrix.sh
+++ b/bench/matrix.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# The two experiments that decide whether the fork architecture earns its cost.
+#
+# A. SCALE: raise N until VRAM binds. Native holds N copies (~7 GiB each), fork
+#    holds N+1 (golden + one per clone), so native should survive to a higher N.
+#    This is the regime the architecture is *for* — if weight sharing worked,
+#    fork would keep going where native OOMs.
+#
+# B. KERNEL SIZE: raise batch/seq so each CUDA call does more work. If the fork
+#    gap shrinks, the remoting cost is per-call launch latency (amortizable, so
+#    the design is viable for realistic training shapes). If it stays flat, the
+#    remoting cost is proportional and no shape escapes it.
+#
+# Runs strictly sequentially: the GPU must be exclusive or every number is junk.
+set -u
+cd "$(dirname "$0")"
+LOG=~/matrix_progress.log; : > "$LOG"
+
+run() {
+    echo "" | tee -a "$LOG"
+    echo "########## $* ##########" | tee -a "$LOG"
+    # Never abort the matrix on one failed cell: an OOM IS the result we want.
+    ./bench.sh "$@" 2>&1 | tee -a "$LOG" || echo "  (cell failed — recorded)" | tee -a "$LOG"
+    # Let the GPU fully drain before the next cell's preflight check.
+    for i in $(seq 1 30); do
+        u=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits)
+        [[ "$u" -lt 500 ]] && break
+        sleep 2
+    done
+    pkill -f "smolvm _cuda-daemo[n]" 2>/dev/null
+    pkill -f "_cuda-clone-worke[r]" 2>/dev/null
+    sleep 3
+}
+
+echo "===== EXPERIMENT A: scale N until memory binds =====" | tee -a "$LOG"
+run --arm native --n 8  --steps 20 --cpus 4 --timeout 600
+run --arm fork   --n 8  --steps 20 --cpus 4 --timeout 600
+run --arm native --n 12 --steps 20 --cpus 4 --timeout 600
+run --arm fork   --n 12 --steps 20 --cpus 4 --timeout 600
+
+echo "" | tee -a "$LOG"
+echo "===== EXPERIMENT B: bigger kernels (batch 8 x seq 1024) =====" | tee -a "$LOG"
+run --arm native --n 2 --steps 20 --cpus 4 --batch 8 --maxseq 1024 --timeout 600
+run --arm fork   --n 2 --steps 20 --cpus 4 --batch 8 --maxseq 1024 --timeout 600
+
+echo "" | tee -a "$LOG"
+echo "MATRIX_DONE" | tee -a "$LOG"

--- a/bench/nan_census.py
+++ b/bench/nan_census.py
@@ -1,0 +1,13 @@
+import json, glob, os
+rows = []
+for f in sorted(glob.glob("/home/ubuntu/bench/results/*.json")):
+    r = json.load(open(f))
+    ls = [str(l.get("lossN")).lower() for l in r.get("learners", [])]
+    nan = sum(1 for x in ls if x == "nan")
+    rows.append((os.path.basename(f)[:28], r["arm"], r["n"], r["steps"],
+                 r["learners_done"], nan, r["peak_gpu_mib"]))
+print("%-28s %-7s %3s %5s %6s %5s %9s" % ("run", "arm", "N", "steps", "done", "nan", "peakGPU"))
+print("-" * 72)
+for run, arm, n, s, done, nan, peak in rows:
+    flag = "  <-- NAN" if nan else ""
+    print("%-28s %-7s %3d %5d %6s %5d %9d%s" % (run, arm, n, s, "%d/%d" % (done, n), nan, peak, flag))

--- a/bench/parse_losses.py
+++ b/bench/parse_losses.py
@@ -1,0 +1,15 @@
+import json, glob, sys, os
+d = sys.argv[1]
+n = nan = 0
+out = []
+for f in sorted(glob.glob(os.path.join(d, "learner_*.jsonl"))):
+    rec = {}
+    for line in open(f):
+        e = json.loads(line); rec[e["event"]] = e
+    if "done" in rec:
+        z = rec["done"]; n += 1
+        bad = str(z["lossN"]).lower() == "nan"
+        nan += bad
+        out.append("  learner %2s: %s -> %s%s" % (z["lid"], z["loss0"], z["lossN"], "   <-- NAN" if bad else ""))
+print("\n".join(out))
+print("  => done=%d  nan=%d" % (n, nan))

--- a/bench/probe_mem.sh
+++ b/bench/probe_mem.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Per-process GPU memory during a fork run. With CUDA remoted, the golden's
+# context and each clone worker are separate HOST processes, so this shows
+# directly whether the frozen base is shared or re-materialized per clone.
+OUT=$HOME/procmem.log; : > "$OUT"
+for i in $(seq 1 240); do
+  [ -f "$HOME/.probe_stop" ] && break
+  ts=$(date +%s)
+  nvidia-smi --query-compute-apps=pid,used_memory --format=csv,noheader,nounits 2>/dev/null > /tmp/.apps
+  while read -r line; do
+    pid=$(echo "$line" | cut -d, -f1 | tr -d ' ')
+    mem=$(echo "$line" | cut -d, -f2 | tr -d ' ')
+    cmd=$(ps -p "$pid" -o args= 2>/dev/null | cut -c1-55)
+    echo "$ts pid=$pid mem=${mem}MiB cmd=$cmd" >> "$OUT"
+  done < /tmp/.apps
+  echo "$ts TOTAL=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits)MiB" >> "$OUT"
+  sleep 5
+done

--- a/bench/results/fork_n16_s10_c4_20260724-220036_r1.json
+++ b/bench/results/fork_n16_s10_c4_20260724-220036_r1.json
@@ -1,0 +1,175 @@
+{
+  "arm": "fork",
+  "n": 16,
+  "steps": 10,
+  "cpus_per_learner": 4,
+  "cold_cache": false,
+  "alloc_conf": "expandable_segments:True",
+  "batch": 2,
+  "maxseq": 256,
+  "share_weights_env": "unset",
+  "wall_s": 377.28,
+  "golden_load_s": 166.47,
+  "fork_s": 9.42,
+  "peak_gpu_mib": 35400,
+  "learners_done": 16,
+  "learners_expected": 16,
+  "agg_tok_s": 465,
+  "learners": [
+    {
+      "lid": "0",
+      "tok_s": 28,
+      "train_s": 180.77,
+      "step_ms": 18077,
+      "loss0": 0.6931,
+      "lossN": 0.6649,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "1",
+      "tok_s": 28,
+      "train_s": 180.85,
+      "step_ms": 18085,
+      "loss0": 0.6931,
+      "lossN": 0.632,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "10",
+      "tok_s": 31,
+      "train_s": 163.25,
+      "step_ms": 16325,
+      "loss0": 0.6931,
+      "lossN": 0.648,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "11",
+      "tok_s": 28,
+      "train_s": 180.4,
+      "step_ms": 18040,
+      "loss0": 0.6931,
+      "lossN": 0.6397,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "12",
+      "tok_s": 34,
+      "train_s": 150.25,
+      "step_ms": 15025,
+      "loss0": 0.6931,
+      "lossN": 0.6383,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "13",
+      "tok_s": 29,
+      "train_s": 178.21,
+      "step_ms": 17821,
+      "loss0": 0.6931,
+      "lossN": 0.6363,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "14",
+      "tok_s": 28,
+      "train_s": 180.44,
+      "step_ms": 18044,
+      "loss0": 0.6931,
+      "lossN": 0.6406,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "15",
+      "tok_s": 29,
+      "train_s": 178.48,
+      "step_ms": 17848,
+      "loss0": 0.6931,
+      "lossN": 0.6277,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "2",
+      "tok_s": 28,
+      "train_s": 181.44,
+      "step_ms": 18144,
+      "loss0": 0.6931,
+      "lossN": 0.6318,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "3",
+      "tok_s": 28,
+      "train_s": 180.84,
+      "step_ms": 18084,
+      "loss0": NaN,
+      "lossN": NaN,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "4",
+      "tok_s": 32,
+      "train_s": 160.21,
+      "step_ms": 16021,
+      "loss0": NaN,
+      "lossN": NaN,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "5",
+      "tok_s": 28,
+      "train_s": 180.44,
+      "step_ms": 18044,
+      "loss0": 0.6931,
+      "lossN": 0.6821,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "6",
+      "tok_s": 28,
+      "train_s": 180.5,
+      "step_ms": 18050,
+      "loss0": 0.6931,
+      "lossN": 0.637,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "7",
+      "tok_s": 28,
+      "train_s": 180.18,
+      "step_ms": 18018,
+      "loss0": 0.6931,
+      "lossN": 0.6375,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "8",
+      "tok_s": 30,
+      "train_s": 171.65,
+      "step_ms": 17165,
+      "loss0": 0.6931,
+      "lossN": 0.6355,
+      "peak_gb": 6.4
+    },
+    {
+      "lid": "9",
+      "tok_s": 28,
+      "train_s": 180.42,
+      "step_ms": 18042,
+      "loss0": 0.6931,
+      "lossN": 0.6315,
+      "peak_gb": 6.41
+    }
+  ],
+  "env": {
+    "smolvm_version": "smolvm 1.6.13",
+    "smolvm_binary_md5": "60924e45452fad0b386bed5bfa5c54ba",
+    "proto_hash_rootfs": "c5631758382d21af",
+    "shim_md5": "46a6603f881b42931779b12b50805052",
+    "driver": "570.148.08",
+    "gpu": "NVIDIA H100 80GB HBM3",
+    "torch": "2.7.0+cu126",
+    "host_cores": 26,
+    "host_mem_gb": 237
+  }
+}

--- a/bench/results/fork_n16_s10_c4_20260724-222133_r1.json
+++ b/bench/results/fork_n16_s10_c4_20260724-222133_r1.json
@@ -1,0 +1,175 @@
+{
+  "arm": "fork",
+  "n": 16,
+  "steps": 10,
+  "cpus_per_learner": 4,
+  "cold_cache": false,
+  "alloc_conf": "expandable_segments:True",
+  "batch": 2,
+  "maxseq": 256,
+  "share_weights_env": "unset",
+  "wall_s": 380.01,
+  "golden_load_s": 167.02,
+  "fork_s": 9.13,
+  "peak_gpu_mib": 35340,
+  "learners_done": 16,
+  "learners_expected": 16,
+  "agg_tok_s": 452,
+  "learners": [
+    {
+      "lid": "0",
+      "tok_s": 28,
+      "train_s": 182.23,
+      "step_ms": 18223,
+      "loss0": 0.6931,
+      "lossN": 0.6936,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "1",
+      "tok_s": 28,
+      "train_s": 183.33,
+      "step_ms": 18333,
+      "loss0": 0.6931,
+      "lossN": 0.632,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "10",
+      "tok_s": 28,
+      "train_s": 183.07,
+      "step_ms": 18307,
+      "loss0": 0.6931,
+      "lossN": 0.648,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "11",
+      "tok_s": 28,
+      "train_s": 183.69,
+      "step_ms": 18369,
+      "loss0": 0.6931,
+      "lossN": 0.6578,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "12",
+      "tok_s": 28,
+      "train_s": 182.89,
+      "step_ms": 18289,
+      "loss0": 0.6931,
+      "lossN": 0.6383,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "13",
+      "tok_s": 29,
+      "train_s": 176.45,
+      "step_ms": 17645,
+      "loss0": 0.6931,
+      "lossN": 0.6363,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "14",
+      "tok_s": 28,
+      "train_s": 182.21,
+      "step_ms": 18221,
+      "loss0": 0.6931,
+      "lossN": 0.6406,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "15",
+      "tok_s": 28,
+      "train_s": 182.81,
+      "step_ms": 18281,
+      "loss0": 0.6931,
+      "lossN": 0.6277,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "2",
+      "tok_s": 28,
+      "train_s": 183.43,
+      "step_ms": 18343,
+      "loss0": 0.6931,
+      "lossN": 0.6318,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "3",
+      "tok_s": 28,
+      "train_s": 182.19,
+      "step_ms": 18219,
+      "loss0": 0.6931,
+      "lossN": 0.6234,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "4",
+      "tok_s": 28,
+      "train_s": 182.37,
+      "step_ms": 18237,
+      "loss0": 0.6931,
+      "lossN": 0.6452,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "5",
+      "tok_s": 31,
+      "train_s": 162.63,
+      "step_ms": 16263,
+      "loss0": 0.6931,
+      "lossN": 0.6243,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "6",
+      "tok_s": 28,
+      "train_s": 183.18,
+      "step_ms": 18318,
+      "loss0": 0.6931,
+      "lossN": 0.637,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "7",
+      "tok_s": 28,
+      "train_s": 181.35,
+      "step_ms": 18135,
+      "loss0": 0.6931,
+      "lossN": 0.6375,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "8",
+      "tok_s": 28,
+      "train_s": 183.4,
+      "step_ms": 18340,
+      "loss0": 0.6931,
+      "lossN": 0.6384,
+      "peak_gb": 6.4
+    },
+    {
+      "lid": "9",
+      "tok_s": 28,
+      "train_s": 182.42,
+      "step_ms": 18242,
+      "loss0": 0.6931,
+      "lossN": 0.6315,
+      "peak_gb": 6.41
+    }
+  ],
+  "env": {
+    "smolvm_version": "smolvm 1.6.13",
+    "smolvm_binary_md5": "60924e45452fad0b386bed5bfa5c54ba",
+    "proto_hash_rootfs": "c5631758382d21af",
+    "shim_md5": "46a6603f881b42931779b12b50805052",
+    "driver": "570.148.08",
+    "gpu": "NVIDIA H100 80GB HBM3",
+    "torch": "2.7.0+cu126",
+    "host_cores": 26,
+    "host_mem_gb": 237
+  }
+}

--- a/bench/results/fork_n16_s10_c4_20260724-222839_r1.json
+++ b/bench/results/fork_n16_s10_c4_20260724-222839_r1.json
@@ -1,0 +1,175 @@
+{
+  "arm": "fork",
+  "n": 16,
+  "steps": 10,
+  "cpus_per_learner": 4,
+  "cold_cache": false,
+  "alloc_conf": "expandable_segments:True",
+  "batch": 2,
+  "maxseq": 256,
+  "share_weights_env": "unset",
+  "wall_s": 364.52,
+  "golden_load_s": 164.39,
+  "fork_s": 9.0,
+  "peak_gpu_mib": 35340,
+  "learners_done": 16,
+  "learners_expected": 16,
+  "agg_tok_s": 487,
+  "learners": [
+    {
+      "lid": "0",
+      "tok_s": 32,
+      "train_s": 161.0,
+      "step_ms": 16100,
+      "loss0": 0.6931,
+      "lossN": 0.6813,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "1",
+      "tok_s": 30,
+      "train_s": 169.02,
+      "step_ms": 16902,
+      "loss0": 0.6931,
+      "lossN": 0.6656,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "10",
+      "tok_s": 30,
+      "train_s": 171.43,
+      "step_ms": 17143,
+      "loss0": 0.6931,
+      "lossN": 0.648,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "11",
+      "tok_s": 30,
+      "train_s": 168.68,
+      "step_ms": 16868,
+      "loss0": 0.6931,
+      "lossN": 0.6397,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "12",
+      "tok_s": 30,
+      "train_s": 171.38,
+      "step_ms": 17138,
+      "loss0": 0.6931,
+      "lossN": 0.6383,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "13",
+      "tok_s": 30,
+      "train_s": 170.1,
+      "step_ms": 17010,
+      "loss0": 0.6931,
+      "lossN": 0.6849,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "14",
+      "tok_s": 30,
+      "train_s": 168.37,
+      "step_ms": 16837,
+      "loss0": 0.6931,
+      "lossN": 0.6406,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "15",
+      "tok_s": 33,
+      "train_s": 156.46,
+      "step_ms": 15646,
+      "loss0": 0.6931,
+      "lossN": 0.6968,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "2",
+      "tok_s": 31,
+      "train_s": 164.94,
+      "step_ms": 16494,
+      "loss0": 0.6931,
+      "lossN": 0.6401,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "3",
+      "tok_s": 31,
+      "train_s": 164.77,
+      "step_ms": 16477,
+      "loss0": 0.6931,
+      "lossN": 0.6234,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "4",
+      "tok_s": 30,
+      "train_s": 170.27,
+      "step_ms": 17027,
+      "loss0": 0.6931,
+      "lossN": 0.6452,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "5",
+      "tok_s": 30,
+      "train_s": 171.6,
+      "step_ms": 17160,
+      "loss0": 0.6931,
+      "lossN": 0.6243,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "6",
+      "tok_s": 30,
+      "train_s": 170.28,
+      "step_ms": 17028,
+      "loss0": 0.6931,
+      "lossN": 0.6235,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "7",
+      "tok_s": 30,
+      "train_s": 168.76,
+      "step_ms": 16876,
+      "loss0": 0.6931,
+      "lossN": 0.6375,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "8",
+      "tok_s": 30,
+      "train_s": 170.23,
+      "step_ms": 17023,
+      "loss0": 0.6931,
+      "lossN": 0.6384,
+      "peak_gb": 6.4
+    },
+    {
+      "lid": "9",
+      "tok_s": 30,
+      "train_s": 168.61,
+      "step_ms": 16861,
+      "loss0": 0.6931,
+      "lossN": 0.5834,
+      "peak_gb": 6.41
+    }
+  ],
+  "env": {
+    "smolvm_version": "smolvm 1.6.13",
+    "smolvm_binary_md5": "60924e45452fad0b386bed5bfa5c54ba",
+    "proto_hash_rootfs": "c5631758382d21af",
+    "shim_md5": "46a6603f881b42931779b12b50805052",
+    "driver": "570.148.08",
+    "gpu": "NVIDIA H100 80GB HBM3",
+    "torch": "2.7.0+cu126",
+    "host_cores": 26,
+    "host_mem_gb": 237
+  }
+}

--- a/bench/results/fork_n4_s20_c4_20260724-213340_r1.json
+++ b/bench/results/fork_n4_s20_c4_20260724-213340_r1.json
@@ -1,0 +1,67 @@
+{
+  "arm": "fork",
+  "n": 4,
+  "steps": 20,
+  "cpus_per_learner": 4,
+  "cold_cache": false,
+  "alloc_conf": "expandable_segments:True",
+  "batch": 2,
+  "maxseq": 256,
+  "share_weights_env": "unset",
+  "wall_s": 253.79,
+  "golden_load_s": 165.59,
+  "fork_s": 2.52,
+  "peak_gpu_mib": 14550,
+  "learners_done": 4,
+  "learners_expected": 4,
+  "agg_tok_s": 546,
+  "learners": [
+    {
+      "lid": "0",
+      "tok_s": 137,
+      "train_s": 74.67,
+      "step_ms": 3734,
+      "loss0": 0.688,
+      "lossN": 0.4483,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "1",
+      "tok_s": 137,
+      "train_s": 74.59,
+      "step_ms": 3730,
+      "loss0": 0.6877,
+      "lossN": 0.4081,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "2",
+      "tok_s": 135,
+      "train_s": 75.97,
+      "step_ms": 3799,
+      "loss0": 0.688,
+      "lossN": 0.4809,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "3",
+      "tok_s": 137,
+      "train_s": 74.51,
+      "step_ms": 3725,
+      "loss0": 0.6885,
+      "lossN": 0.4153,
+      "peak_gb": 6.41
+    }
+  ],
+  "env": {
+    "smolvm_version": "smolvm 1.6.13",
+    "smolvm_binary_md5": "60924e45452fad0b386bed5bfa5c54ba",
+    "proto_hash_rootfs": "c5631758382d21af",
+    "shim_md5": "46a6603f881b42931779b12b50805052",
+    "driver": "570.148.08",
+    "gpu": "NVIDIA H100 80GB HBM3",
+    "torch": "2.7.0+cu126",
+    "host_cores": 26,
+    "host_mem_gb": 237
+  }
+}

--- a/bench/results/fork_n8_s10_c4_20260724-220758_r1.json
+++ b/bench/results/fork_n8_s10_c4_20260724-220758_r1.json
@@ -1,0 +1,103 @@
+{
+  "arm": "fork",
+  "n": 8,
+  "steps": 10,
+  "cpus_per_learner": 4,
+  "cold_cache": false,
+  "alloc_conf": "expandable_segments:True",
+  "batch": 2,
+  "maxseq": 256,
+  "share_weights_env": "unset",
+  "wall_s": 279.36,
+  "golden_load_s": 163.73,
+  "fork_s": 4.53,
+  "peak_gpu_mib": 21500,
+  "learners_done": 8,
+  "learners_expected": 8,
+  "agg_tok_s": 432,
+  "learners": [
+    {
+      "lid": "0",
+      "tok_s": 54,
+      "train_s": 94.22,
+      "step_ms": 9422,
+      "loss0": 0.6931,
+      "lossN": 0.6376,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "1",
+      "tok_s": 53,
+      "train_s": 96.95,
+      "step_ms": 9695,
+      "loss0": 0.6931,
+      "lossN": 0.632,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "2",
+      "tok_s": 53,
+      "train_s": 95.82,
+      "step_ms": 9582,
+      "loss0": 0.6931,
+      "lossN": 0.6318,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "3",
+      "tok_s": 54,
+      "train_s": 94.11,
+      "step_ms": 9411,
+      "loss0": 0.6931,
+      "lossN": 0.6234,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "4",
+      "tok_s": 54,
+      "train_s": 94.57,
+      "step_ms": 9457,
+      "loss0": 0.6931,
+      "lossN": 0.6452,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "5",
+      "tok_s": 53,
+      "train_s": 97.49,
+      "step_ms": 9749,
+      "loss0": 0.6931,
+      "lossN": 0.6243,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "6",
+      "tok_s": 57,
+      "train_s": 90.43,
+      "step_ms": 9043,
+      "loss0": 0.6931,
+      "lossN": 0.637,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "7",
+      "tok_s": 54,
+      "train_s": 95.21,
+      "step_ms": 9521,
+      "loss0": 0.6931,
+      "lossN": 0.6375,
+      "peak_gb": 6.41
+    }
+  ],
+  "env": {
+    "smolvm_version": "smolvm 1.6.13",
+    "smolvm_binary_md5": "60924e45452fad0b386bed5bfa5c54ba",
+    "proto_hash_rootfs": "c5631758382d21af",
+    "shim_md5": "46a6603f881b42931779b12b50805052",
+    "driver": "570.148.08",
+    "gpu": "NVIDIA H100 80GB HBM3",
+    "torch": "2.7.0+cu126",
+    "host_cores": 26,
+    "host_mem_gb": 237
+  }
+}

--- a/bench/results/fork_n8_s10_c4_20260724-221245_r1.json
+++ b/bench/results/fork_n8_s10_c4_20260724-221245_r1.json
@@ -1,0 +1,103 @@
+{
+  "arm": "fork",
+  "n": 8,
+  "steps": 10,
+  "cpus_per_learner": 4,
+  "cold_cache": false,
+  "alloc_conf": "expandable_segments:True",
+  "batch": 2,
+  "maxseq": 256,
+  "share_weights_env": "0",
+  "wall_s": 286.76,
+  "golden_load_s": 169.23,
+  "fork_s": 4.39,
+  "peak_gpu_mib": 21480,
+  "learners_done": 8,
+  "learners_expected": 8,
+  "agg_tok_s": 432,
+  "learners": [
+    {
+      "lid": "0",
+      "tok_s": 54,
+      "train_s": 95.19,
+      "step_ms": 9519,
+      "loss0": 0.6931,
+      "lossN": 0.645,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "1",
+      "tok_s": 54,
+      "train_s": 94.71,
+      "step_ms": 9471,
+      "loss0": 0.6931,
+      "lossN": 0.632,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "2",
+      "tok_s": 54,
+      "train_s": 95.32,
+      "step_ms": 9532,
+      "loss0": 0.6931,
+      "lossN": 0.6318,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "3",
+      "tok_s": 54,
+      "train_s": 94.25,
+      "step_ms": 9425,
+      "loss0": 0.6931,
+      "lossN": 0.6234,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "4",
+      "tok_s": 54,
+      "train_s": 95.55,
+      "step_ms": 9555,
+      "loss0": 0.6931,
+      "lossN": 0.6452,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "5",
+      "tok_s": 57,
+      "train_s": 90.57,
+      "step_ms": 9057,
+      "loss0": 0.6931,
+      "lossN": 0.6243,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "6",
+      "tok_s": 52,
+      "train_s": 98.2,
+      "step_ms": 9820,
+      "loss0": 0.6931,
+      "lossN": 0.637,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "7",
+      "tok_s": 53,
+      "train_s": 96.05,
+      "step_ms": 9605,
+      "loss0": 0.6931,
+      "lossN": 0.6375,
+      "peak_gb": 6.41
+    }
+  ],
+  "env": {
+    "smolvm_version": "smolvm 1.6.13",
+    "smolvm_binary_md5": "60924e45452fad0b386bed5bfa5c54ba",
+    "proto_hash_rootfs": "c5631758382d21af",
+    "shim_md5": "46a6603f881b42931779b12b50805052",
+    "driver": "570.148.08",
+    "gpu": "NVIDIA H100 80GB HBM3",
+    "torch": "2.7.0+cu126",
+    "host_cores": 26,
+    "host_mem_gb": 237
+  }
+}

--- a/bench/results/fork_n8_s10_c4_20260724-224056_r1.json
+++ b/bench/results/fork_n8_s10_c4_20260724-224056_r1.json
@@ -1,0 +1,103 @@
+{
+  "arm": "fork",
+  "n": 8,
+  "steps": 10,
+  "cpus_per_learner": 4,
+  "cold_cache": false,
+  "alloc_conf": "expandable_segments:True",
+  "batch": 2,
+  "maxseq": 256,
+  "share_weights_env": "1",
+  "wall_s": 280.11,
+  "golden_load_s": 166.66,
+  "fork_s": 4.42,
+  "peak_gpu_mib": 21480,
+  "learners_done": 8,
+  "learners_expected": 8,
+  "agg_tok_s": 436,
+  "learners": [
+    {
+      "lid": "0",
+      "tok_s": 55,
+      "train_s": 92.59,
+      "step_ms": 9259,
+      "loss0": 0.6931,
+      "lossN": 0.645,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "1",
+      "tok_s": 55,
+      "train_s": 93.5,
+      "step_ms": 9350,
+      "loss0": 0.6931,
+      "lossN": 0.632,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "2",
+      "tok_s": 54,
+      "train_s": 95.58,
+      "step_ms": 9558,
+      "loss0": 0.6931,
+      "lossN": 0.6318,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "3",
+      "tok_s": 53,
+      "train_s": 95.82,
+      "step_ms": 9582,
+      "loss0": 0.6931,
+      "lossN": 0.6234,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "4",
+      "tok_s": 54,
+      "train_s": 95.09,
+      "step_ms": 9509,
+      "loss0": 0.6931,
+      "lossN": 0.6461,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "5",
+      "tok_s": 55,
+      "train_s": 92.47,
+      "step_ms": 9247,
+      "loss0": 0.6931,
+      "lossN": 0.6234,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "6",
+      "tok_s": 55,
+      "train_s": 92.52,
+      "step_ms": 9252,
+      "loss0": 0.6931,
+      "lossN": 0.637,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "7",
+      "tok_s": 55,
+      "train_s": 93.73,
+      "step_ms": 9373,
+      "loss0": 0.6931,
+      "lossN": 0.6375,
+      "peak_gb": 6.41
+    }
+  ],
+  "env": {
+    "smolvm_version": "smolvm 1.6.13",
+    "smolvm_binary_md5": "60924e45452fad0b386bed5bfa5c54ba",
+    "proto_hash_rootfs": "c5631758382d21af",
+    "shim_md5": "46a6603f881b42931779b12b50805052",
+    "driver": "570.148.08",
+    "gpu": "NVIDIA H100 80GB HBM3",
+    "torch": "2.7.0+cu126",
+    "host_cores": 26,
+    "host_mem_gb": 237
+  }
+}

--- a/bench/results/fork_n8_s20_c4_20260724-210314_r1.json
+++ b/bench/results/fork_n8_s20_c4_20260724-210314_r1.json
@@ -1,0 +1,103 @@
+{
+  "arm": "fork",
+  "n": 8,
+  "steps": 20,
+  "cpus_per_learner": 4,
+  "cold_cache": false,
+  "alloc_conf": "expandable_segments:True",
+  "batch": 2,
+  "maxseq": 256,
+  "share_weights_env": "unset",
+  "wall_s": 521.17,
+  "golden_load_s": 156.34,
+  "fork_s": 221.4,
+  "peak_gpu_mib": 63082,
+  "learners_done": 8,
+  "learners_expected": 8,
+  "agg_tok_s": 736,
+  "learners": [
+    {
+      "lid": "0",
+      "tok_s": 92,
+      "train_s": 111.52,
+      "step_ms": 5576,
+      "loss0": 0.688,
+      "lossN": 0.4483,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "1",
+      "tok_s": 95,
+      "train_s": 107.73,
+      "step_ms": 5387,
+      "loss0": 0.6877,
+      "lossN": 0.4081,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "2",
+      "tok_s": 92,
+      "train_s": 111.52,
+      "step_ms": 5576,
+      "loss0": 0.688,
+      "lossN": 0.4809,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "3",
+      "tok_s": 96,
+      "train_s": 106.72,
+      "step_ms": 5336,
+      "loss0": 0.6885,
+      "lossN": 0.4153,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "4",
+      "tok_s": 92,
+      "train_s": 111.36,
+      "step_ms": 5568,
+      "loss0": 0.6891,
+      "lossN": 0.4552,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "5",
+      "tok_s": 90,
+      "train_s": 113.62,
+      "step_ms": 5681,
+      "loss0": 0.6861,
+      "lossN": 0.3857,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "6",
+      "tok_s": 90,
+      "train_s": 113.37,
+      "step_ms": 5668,
+      "loss0": 0.6878,
+      "lossN": 0.4008,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "7",
+      "tok_s": 89,
+      "train_s": 114.81,
+      "step_ms": 5740,
+      "loss0": 0.6866,
+      "lossN": 0.43,
+      "peak_gb": 6.41
+    }
+  ],
+  "env": {
+    "smolvm_version": "smolvm 1.6.13",
+    "smolvm_binary_md5": "ee08f6bc0870e951afd497373fe87be8",
+    "proto_hash_rootfs": "afe482be004b7c1f",
+    "shim_md5": "392e1f5e9843abfefad5c8252510edc0",
+    "driver": "570.148.08",
+    "gpu": "NVIDIA H100 80GB HBM3",
+    "torch": "2.7.0+cu126",
+    "host_cores": 26,
+    "host_mem_gb": 237
+  }
+}

--- a/bench/results/native_n12_s20_c4_20260724-211204_r1.json
+++ b/bench/results/native_n12_s20_c4_20260724-211204_r1.json
@@ -1,0 +1,94 @@
+{
+  "arm": "native",
+  "n": 12,
+  "steps": 20,
+  "cpus_per_learner": 4,
+  "cold_cache": false,
+  "alloc_conf": "expandable_segments:True",
+  "batch": 2,
+  "maxseq": 256,
+  "share_weights_env": "unset",
+  "wall_s": 86.14,
+  "golden_load_s": null,
+  "fork_s": null,
+  "peak_gpu_mib": 81057,
+  "learners_done": 7,
+  "learners_expected": 12,
+  "agg_tok_s": 1145,
+  "learners": [
+    {
+      "lid": "0",
+      "tok_s": 159,
+      "train_s": 64.43,
+      "step_ms": 3222,
+      "loss0": 0.688,
+      "lossN": 0.4483,
+      "peak_gb": 7.07
+    },
+    {
+      "lid": "11",
+      "tok_s": 158,
+      "train_s": 64.95,
+      "step_ms": 3247,
+      "loss0": 0.6867,
+      "lossN": 0.4188,
+      "peak_gb": 7.07
+    },
+    {
+      "lid": "2",
+      "tok_s": 158,
+      "train_s": 64.71,
+      "step_ms": 3235,
+      "loss0": 0.688,
+      "lossN": 0.4809,
+      "peak_gb": 7.07
+    },
+    {
+      "lid": "4",
+      "tok_s": 163,
+      "train_s": 62.72,
+      "step_ms": 3136,
+      "loss0": 0.6891,
+      "lossN": 0.4552,
+      "peak_gb": 7.07
+    },
+    {
+      "lid": "5",
+      "tok_s": 185,
+      "train_s": 55.27,
+      "step_ms": 2763,
+      "loss0": 0.6861,
+      "lossN": 0.3857,
+      "peak_gb": 7.07
+    },
+    {
+      "lid": "6",
+      "tok_s": 164,
+      "train_s": 62.29,
+      "step_ms": 3115,
+      "loss0": 0.6878,
+      "lossN": 0.4008,
+      "peak_gb": 7.07
+    },
+    {
+      "lid": "9",
+      "tok_s": 158,
+      "train_s": 64.88,
+      "step_ms": 3244,
+      "loss0": 0.6877,
+      "lossN": 0.4369,
+      "peak_gb": 6.41
+    }
+  ],
+  "env": {
+    "smolvm_version": "smolvm 1.6.13",
+    "smolvm_binary_md5": "ee08f6bc0870e951afd497373fe87be8",
+    "proto_hash_rootfs": "afe482be004b7c1f",
+    "shim_md5": "392e1f5e9843abfefad5c8252510edc0",
+    "driver": "570.148.08",
+    "gpu": "NVIDIA H100 80GB HBM3",
+    "torch": "2.7.0+cu126",
+    "host_cores": 26,
+    "host_mem_gb": 237
+  }
+}

--- a/bench/results/native_n16_s10_c4_20260724-215946_r1.json
+++ b/bench/results/native_n16_s10_c4_20260724-215946_r1.json
@@ -1,0 +1,49 @@
+{
+  "arm": "native",
+  "n": 16,
+  "steps": 10,
+  "cpus_per_learner": 4,
+  "cold_cache": false,
+  "alloc_conf": "expandable_segments:True",
+  "batch": 2,
+  "maxseq": 256,
+  "share_weights_env": "unset",
+  "wall_s": 43.74,
+  "golden_load_s": null,
+  "fork_s": null,
+  "peak_gpu_mib": 81087,
+  "learners_done": 2,
+  "learners_expected": 16,
+  "agg_tok_s": 467,
+  "learners": [
+    {
+      "lid": "14",
+      "tok_s": 235,
+      "train_s": 21.75,
+      "step_ms": 2175,
+      "loss0": 0.6931,
+      "lossN": 0.6406,
+      "peak_gb": 6.41
+    },
+    {
+      "lid": "6",
+      "tok_s": 232,
+      "train_s": 22.03,
+      "step_ms": 2203,
+      "loss0": 0.6931,
+      "lossN": 0.637,
+      "peak_gb": 6.41
+    }
+  ],
+  "env": {
+    "smolvm_version": "smolvm 1.6.13",
+    "smolvm_binary_md5": "60924e45452fad0b386bed5bfa5c54ba",
+    "proto_hash_rootfs": "c5631758382d21af",
+    "shim_md5": "46a6603f881b42931779b12b50805052",
+    "driver": "570.148.08",
+    "gpu": "NVIDIA H100 80GB HBM3",
+    "torch": "2.7.0+cu126",
+    "host_cores": 26,
+    "host_mem_gb": 237
+  }
+}

--- a/bench/results/native_n8_s20_c4_20260724-210151_r1.json
+++ b/bench/results/native_n8_s20_c4_20260724-210151_r1.json
@@ -1,0 +1,103 @@
+{
+  "arm": "native",
+  "n": 8,
+  "steps": 20,
+  "cpus_per_learner": 4,
+  "cold_cache": false,
+  "alloc_conf": "expandable_segments:True",
+  "batch": 2,
+  "maxseq": 256,
+  "share_weights_env": "unset",
+  "wall_s": 77.12,
+  "golden_load_s": null,
+  "fork_s": null,
+  "peak_gpu_mib": 59080,
+  "learners_done": 8,
+  "learners_expected": 8,
+  "agg_tok_s": 1462,
+  "learners": [
+    {
+      "lid": "0",
+      "tok_s": 176,
+      "train_s": 58.2,
+      "step_ms": 2910,
+      "loss0": 0.688,
+      "lossN": 0.4483,
+      "peak_gb": 7.07
+    },
+    {
+      "lid": "1",
+      "tok_s": 178,
+      "train_s": 57.53,
+      "step_ms": 2877,
+      "loss0": 0.6877,
+      "lossN": 0.4081,
+      "peak_gb": 7.07
+    },
+    {
+      "lid": "2",
+      "tok_s": 187,
+      "train_s": 54.76,
+      "step_ms": 2738,
+      "loss0": 0.688,
+      "lossN": 0.4809,
+      "peak_gb": 7.07
+    },
+    {
+      "lid": "3",
+      "tok_s": 188,
+      "train_s": 54.37,
+      "step_ms": 2719,
+      "loss0": 0.6885,
+      "lossN": 0.4153,
+      "peak_gb": 7.07
+    },
+    {
+      "lid": "4",
+      "tok_s": 191,
+      "train_s": 53.49,
+      "step_ms": 2674,
+      "loss0": 0.6891,
+      "lossN": 0.4552,
+      "peak_gb": 7.07
+    },
+    {
+      "lid": "5",
+      "tok_s": 188,
+      "train_s": 54.55,
+      "step_ms": 2728,
+      "loss0": 0.6861,
+      "lossN": 0.3857,
+      "peak_gb": 7.07
+    },
+    {
+      "lid": "6",
+      "tok_s": 178,
+      "train_s": 57.53,
+      "step_ms": 2877,
+      "loss0": 0.6878,
+      "lossN": 0.4008,
+      "peak_gb": 7.07
+    },
+    {
+      "lid": "7",
+      "tok_s": 176,
+      "train_s": 58.15,
+      "step_ms": 2907,
+      "loss0": 0.6866,
+      "lossN": 0.43,
+      "peak_gb": 7.07
+    }
+  ],
+  "env": {
+    "smolvm_version": "smolvm 1.6.13",
+    "smolvm_binary_md5": "ee08f6bc0870e951afd497373fe87be8",
+    "proto_hash_rootfs": "afe482be004b7c1f",
+    "shim_md5": "392e1f5e9843abfefad5c8252510edc0",
+    "driver": "570.148.08",
+    "gpu": "NVIDIA H100 80GB HBM3",
+    "torch": "2.7.0+cu126",
+    "host_cores": 26,
+    "host_mem_gb": 237
+  }
+}

--- a/bench/summarize.py
+++ b/bench/summarize.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Summarize bench.sh results: median per (arm, n, cpus) + the native/fork ratio.
+
+Reports the median across repetitions and the min-max spread, because the two
+numbers that decide this comparison are both known to be unstable: the golden
+load is bimodal (~15s vs ~156s) and per-learner throughput moves with GPU
+contention. A single run of either arm is not evidence.
+
+Usage: ./summarize.py [results_dir]
+"""
+import json
+import glob
+import os
+import statistics
+import sys
+
+
+def med(xs):
+    xs = [x for x in xs if x is not None]
+    return statistics.median(xs) if xs else None
+
+
+def fmt(v, unit="", nd=0):
+    if v is None:
+        return "-"
+    return f"{v:.{nd}f}{unit}"
+
+
+def main():
+    d = sys.argv[1] if len(sys.argv) > 1 else os.path.join(os.path.dirname(__file__), "results")
+    runs = [json.load(open(f)) for f in sorted(glob.glob(os.path.join(d, "*.json")))]
+    if not runs:
+        print(f"no results in {d}")
+        return
+
+    groups = {}
+    for r in runs:
+        groups.setdefault((r["arm"], r["n"], r["cpus_per_learner"],
+                           r.get("batch", 0), r.get("maxseq", 0)), []).append(r)
+
+    print(f"{'arm':<7} {'N':>3} {'bxseq':>9} {'reps':>4} {'wall_s':>8} {'agg_tok/s':>10} "
+          f"{'peak_GPU':>9} {'golden_s':>9} {'done':>7}")
+    print("-" * 78)
+    rows = {}
+    for (arm, n, cpus, batch, maxseq), rs in sorted(groups.items()):
+        wall = med([r["wall_s"] for r in rs])
+        agg = med([r["agg_tok_s"] for r in rs])
+        peak = med([r["peak_gpu_mib"] for r in rs])
+        gold = med([r["golden_load_s"] for r in rs])
+        done = f"{sum(r['learners_done'] for r in rs)}/{sum(r['learners_expected'] for r in rs)}"
+        rows[(arm, n, cpus, batch, maxseq)] = (wall, agg, peak)
+        shape = f"{batch}x{maxseq}" if batch else "-"
+        # A cell where learners did not all finish is usually an OOM; flag it
+        # rather than letting a partial aggregate look like a real datapoint.
+        incomplete = "" if all(r["learners_done"] == r["learners_expected"] for r in rs) else "  <-- INCOMPLETE (OOM?)"
+        print(f"{arm:<7} {n:>3} {shape:>9} {len(rs):>4} {fmt(wall,'',1):>8} {fmt(agg):>10} "
+              f"{fmt(peak,'MiB'):>9} {fmt(gold,'',1):>9} {done:>7}{incomplete}")
+        if len(rs) > 1:
+            w = [r["wall_s"] for r in rs]
+            g = [r["golden_load_s"] for r in rs if r["golden_load_s"] is not None]
+            spread = f"           spread: wall {min(w):.1f}-{max(w):.1f}s"
+            if g:
+                spread += f", golden {min(g):.1f}-{max(g):.1f}s"
+            print(spread)
+
+    print()
+    for (arm, n, cpus, batch, maxseq), (wall, agg, peak) in sorted(rows.items()):
+        if arm != "fork":
+            continue
+        base = rows.get(("native", n, cpus, batch, maxseq))
+        if not base:
+            continue
+        bw, ba, bp = base
+        print(f"N={n}, {cpus} cpu/learner, batch {batch}x{maxseq} — fork vs native:")
+        if bw and wall:
+            print(f"  wall:      {wall:.1f}s vs {bw:.1f}s   ({wall/bw:.2f}x {'slower' if wall > bw else 'faster'})")
+        if ba and agg:
+            print(f"  agg tok/s: {agg:.0f} vs {ba:.0f}   ({ba/agg:.2f}x {'slower' if agg < ba else 'faster'})")
+        if bp and peak:
+            print(f"  peak GPU:  {peak:.0f} vs {bp:.0f} MiB   ({peak/bp:.2f}x)")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/workload_dpo.py
+++ b/bench/workload_dpo.py
@@ -1,0 +1,119 @@
+import faulthandler; faulthandler.enable()
+import os, time, json, random, glob
+os.environ.setdefault("HF_HUB_OFFLINE", "0")
+os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+STEPS = int(os.environ.get("STEPS", "20"))
+MAXSEQ = int(os.environ.get("MAXSEQ", "256"))
+BATCH = int(os.environ.get("BATCH", "2"))
+COORD = os.environ.get("COORD", "/coord")
+MODEL = os.environ.get("MODEL", "unsloth/Qwen2.5-0.5B-Instruct-bnb-4bit")
+ARM = os.environ.get("ARM", "?")
+FORK = os.environ.get("FORK", "0") == "1"
+LID = os.environ.get("LEARNER_ID", "0")
+BETA = float(os.environ.get("DPO_BETA", "0.1"))
+
+def emit(lid, **kw):
+    kw.update(lid=str(lid), arm=ARM, method="dpo", t=round(time.time(), 3))
+    with open(f"{COORD}/learner_{lid}.jsonl", "a") as f:
+        f.write(json.dumps(kw) + "\n")
+
+# Resolve the model to its local snapshot so loading never hits the hub.
+_snaps = sorted(glob.glob(os.path.join(
+    os.environ.get("HF_HOME", os.path.expanduser("~/hf")), "hub",
+    "models--" + MODEL.replace("/", "--"), "snapshots", "*")))
+if _snaps:
+    MODEL = _snaps[-1]
+    os.environ["HF_HUB_OFFLINE"] = "1"
+
+from unsloth import FastLanguageModel
+import torch
+t0 = time.time()
+model, tok = FastLanguageModel.from_pretrained(
+    MODEL, max_seq_length=MAXSEQ, load_in_4bit=True, dtype=None)
+model = FastLanguageModel.get_peft_model(
+    model, r=16, lora_alpha=16,
+    target_modules=["q_proj", "k_proj", "v_proj", "o_proj",
+                    "gate_proj", "up_proj", "down_proj"],
+    use_gradient_checkpointing="unsloth", random_state=0)
+if tok.pad_token is None:
+    tok.pad_token = tok.eos_token
+torch.cuda.synchronize()
+load_ms = (time.time() - t0) * 1000
+
+from datasets import Dataset
+from trl import DPOTrainer, DPOConfig
+
+
+def make_prefs(seed, n):
+    """Synthetic arithmetic preference pairs: 'chosen' is the correct answer,
+    'rejected' is a plausible-but-wrong one. A real DPO signal (prefer correct)
+    with a distinct per-learner shard via the seed."""
+    r = random.Random(seed)
+    rows = []
+    for _ in range(n):
+        a, b = r.randint(1, 20), r.randint(1, 20)
+        prompt = f"### Q: what is {a}+{b}?\n### A:"
+        chosen = f" {a + b}"
+        rejected = f" {a + b + r.choice([-2, -1, 1, 2, 3])}"
+        rows.append({"prompt": prompt, "chosen": chosen, "rejected": rejected})
+    return Dataset.from_list(rows)
+
+
+def run_dpo(lid, steps):
+    seed = (int(lid) if str(lid).isdigit() else 0) + 100
+    ds = make_prefs(seed, max(64, BATCH * steps))
+    cfg = DPOConfig(
+        per_device_train_batch_size=BATCH, max_steps=steps, learning_rate=5e-5,
+        logging_steps=max(1, steps // 4), optim="adamw_8bit", seed=42,
+        output_dir=os.environ.get("OUTBASE", "/root") + f"/dpo{lid}", report_to=[], beta=BETA,
+        max_length=MAXSEQ, max_prompt_length=MAXSEQ // 2,
+        remove_unused_columns=False, warmup_steps=1,
+    )
+    FastLanguageModel.for_training(model)
+    # ref_model=None: with a PEFT/LoRA policy, DPO uses the adapter-disabled
+    # base as the implicit frozen reference — no second model copy. This is the
+    # smolvm --share-weights fit: the frozen base (=reference) is shared, each
+    # fork trains only its own LoRA policy.
+    tr = DPOTrainer(model=model, ref_model=None, args=cfg,
+                    train_dataset=ds, processing_class=tok)
+    tr.train()
+    losses = [h["loss"] for h in tr.state.log_history if "loss" in h]
+    return losses
+
+
+# FORK mode: golden loads once, warms the DPO path, waits at a barrier; the host
+# forks N share-weights clones; each resumes here and claims a distinct id.
+if FORK:
+    if os.environ.get("GOLDEN_WARMUP", "1") == "1":
+        # One DPO step in the golden exercises the training write-path so the
+        # daemon marks touched chunks private (see qlora_train GOLDEN_WARMUP).
+        run_dpo("warm", 1)
+        torch.cuda.synchronize()
+    with open(f"{COORD}/golden_ready", "w") as f:
+        f.write(str(round(load_ms)))
+    while not os.path.exists(f"{COORD}/go"):
+        time.sleep(0.2)
+    claimed = None
+    for k in range(int(os.environ.get("NSLOTS", "64"))):
+        try:
+            fd = os.open(f"{COORD}/claim_{k}", os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            os.close(fd)
+            claimed = k
+            break
+        except FileExistsError:
+            continue
+    LID = str(claimed)
+LID = str(LID)
+
+emit(LID, event="ready", load_ms=round(load_ms))
+t = time.time()
+losses = run_dpo(LID, STEPS)
+dur = time.time() - t
+toks = STEPS * BATCH * MAXSEQ
+emit(LID, event="done", train_s=round(dur, 2), tok_s=round(toks / dur),
+     step_ms=round(dur / STEPS * 1000), loss0=round(losses[0], 4),
+     lossN=round(losses[-1], 4),
+     peak_gb=round(torch.cuda.max_memory_allocated() / 1e9, 2))
+print(f"DPO LEARNER {LID} [{ARM}] DONE load={load_ms:.0f}ms "
+      f"loss {losses[0]:.3f}->{losses[-1]:.3f} tok/s={toks/dur:.0f} "
+      f"peak={torch.cuda.max_memory_allocated()/1e9:.1f}GB", flush=True)

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -1042,21 +1042,25 @@ fn reconstruct_golden_memory(
             let mut ok = false;
             if let Ok(gh) = import_with_retry(b, 4 + idx) {
                 if b.mem_map(va, size, 0, gh).is_ok() {
-                    // Sharing the golden's frozen base READ-WRITE across clones
-                    // is only correct when the base is never written post-fork.
-                    // Unsloth writes the embedding via a KERNEL (undetectable by
-                    // the COW path, which only catches explicit mem ops), so at
-                    // N>=3 concurrent clones those writes race on the shared
-                    // physical and corrupt every sibling (loss=nan). Copy-mode
-                    // (the DEFAULT, no --share-weights) is correct at all N.
-                    // SMOLVM_CUDA_SHARE_RO=1 maps read-only so a base write
-                    // faults loudly instead of corrupting silently (diagnostic;
-                    // currently SIGSEGVs on base-writing workloads — the proper
-                    // fix is to private-copy only the written ranges).
-                    let set = if std::env::var("SMOLVM_CUDA_SHARE_RO").as_deref() == Ok("1") {
-                        b.mem_set_access_ro(va, size, device)
-                    } else {
+                    // READ-ONLY by default. A shared chunk is one the golden's
+                    // H2Ds wrote and nothing has touched since (verified at fork
+                    // time), so a clone has no business writing it. Mapping it
+                    // read-write means a post-fork base write — unsloth's
+                    // embedding fixup is a KERNEL write, invisible to the COW
+                    // path, which only sees explicit mem ops — silently races
+                    // across every clone sharing that physical (loss=nan).
+                    // Read-only makes that fail-stop instead: the write faults,
+                    // and since each clone worker owns its context the blast
+                    // radius is that one clone, with the shared bytes intact for
+                    // its siblings. A warmed golden never trips it (its writes
+                    // happen pre-fork, so verification already marked those
+                    // chunks private): measured 8/8 clean, 0 faults, same
+                    // 260-shared/160-private split as read-write.
+                    // SMOLVM_CUDA_SHARE_RO=0 restores read-write sharing.
+                    let set = if std::env::var("SMOLVM_CUDA_SHARE_RO").as_deref() == Ok("0") {
                         b.mem_set_access(va, size, device)
+                    } else {
+                        b.mem_set_access_ro(va, size, device)
                     };
                     if set.is_ok() {
                         ok = true;


### PR DESCRIPTION
Weight sharing is on by default since #741, but shared chunks were mapped read-write, so a kernel writing the base after the fork silently raced across every clone sharing that physical; read-only turns that into a fault contained to the offending clone, and a warmed golden never trips it (measured 8/8 clean, 0 faults, same 260-shared/160-private split and same VRAM as read-write).