### PR TITLE
fix(tiny): machine create --from discards --mount-socket and --expose-socket

### DIFF
--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -2673,7 +2673,7 @@ impl CreateCmd {
             cuda: self.cuda,
             docker_socket: self.docker_socket,
             dns_filter_hosts: None,
-            published_sockets: Vec::new(),
+            published_sockets: parse_published_sockets(&self.expose_socket, &self.mount_socket)?,
             gpu: manifest.gpu,
             gpu_vram_mib: None,
             rosetta: false,


### PR DESCRIPTION
`machine create --from <artifact.smolmachine>` accepts `--mount-socket` and `--expose-socket` but silently discards both. The machine creates fine, but the socket relay is missing at boot. The failure only shows up later when something tries to connect.

The normal `--image` creation path runs the flags through `parse_published_sockets` and wires the result into `CreateVmParams`. The packed creation path in `run_from_smolmachine` was built separately and just hardcodes `published_sockets: Vec::new()`, so the parsed flags never make it into the VM record.

One line fix: call `parse_published_sockets(&self.expose_socket, &self.mount_socket)?` in `run_from_smolmachine`, same as the image path.