### PR TITLE
tiny fix: machine create --from discards --mount-socket and --expose-socket

### DIFF
--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -2673,7 +2673,7 @@ impl CreateCmd {
             cuda: self.cuda,
             docker_socket: self.docker_socket,
             dns_filter_hosts: None,
-            published_sockets: Vec::new(),
+            published_sockets: parse_published_sockets(&self.expose_socket, &self.mount_socket)?,
             gpu: manifest.gpu,
             gpu_vram_mib: None,
             rosetta: false,


### PR DESCRIPTION
`machine create --from artifact.smolmachine` accepts `--mount-socket` and `--expose-socket` but silently discards both. The machine creates fine, but the  socket relay is missing at boot. The failure only shows up later when something tries to connect. The parsed flags just never make it through.