### PR TITLE
Pin the CLI program name to smolvm in help output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod cli;
 
 /// smolvm - build and run portable, self-contained virtual machines
 #[derive(Parser, Debug)]
-#[command(name = "smolvm")]
+#[command(name = "smolvm", bin_name = "smolvm")]
 #[command(
     about = "Build and run portable, self-contained virtual machines",
     after_help = "Agents: run `smolvm --help` for full documentation including CLI reference and Smolfile schema"


### PR DESCRIPTION
Previously, running `smolvm -h` would output `Usage: smolvm-bin <COMMAND>`.
This happens because clap uses the actual binary name as the program name. However, since users typically execute the program only via the `smolvm` command using `smolvm-wrapper.sh`, we correct this by explicitly specifying the `bin_name` in clap.