### PR TITLE
ci: widen Linux clippy/tests and guard the CUDA guest build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,11 +107,29 @@ jobs:
         env:
           LIBRARY_PATH: ${{ github.workspace }}/lib
 
+      # Root-package scope on purpose. smolvm-agent and the CUDA shims only ever
+      # ship for Linux; compiling them for macOS reports their Linux-gated items
+      # as dead code, which is noise rather than signal. The Linux job lints the
+      # whole workspace.
       - name: Clippy
         run: cargo clippy --all-targets -- -D warnings
         env:
           LIBRARY_PATH: ${{ github.workspace }}/lib
 
+      # Regression guard for #737. The CUDA guest crates depend on smolvm-cuda
+      # with default-features = false, so building them alone resolves it with
+      # the host feature off — the configuration the guest actually ships. The
+      # release job only ever builds these for Linux, so a host-feature or
+      # non-Linux-unix regression here is otherwise invisible until release.
+      - name: Check CUDA guest crates (no host feature)
+        run: cargo check -p smolvm-cuda-shim -p smolvm-cudart-shim -p smolvm-cuda-guest
+        env:
+          LIBRARY_PATH: ${{ github.workspace }}/lib
+
+      # Also root-package scope for now: smolvm-network's ICMP relay test builds
+      # echo requests with a zero ident/checksum for the kernel to fill in, which
+      # is Linux ping-socket behaviour, so it times out on macOS. The Linux job
+      # runs the full workspace suite; widen this once that is sorted.
       - name: Run unit tests
         run: cargo test --lib
         env:
@@ -216,13 +234,16 @@ jobs:
         env:
           LIBRARY_PATH: /usr/local/lib
 
+      # --workspace: Linux is where the guest crates (smolvm-agent, the CUDA
+      # shims) actually build and ship, so their lints are meaningful here.
+      # The macOS job stays at root-package scope — see the comment there.
       - name: Clippy
-        run: cargo clippy --all-targets --target ${{ matrix.target }} -- -D warnings
+        run: cargo clippy --workspace --all-targets --target ${{ matrix.target }} -- -D warnings
         env:
           LIBRARY_PATH: /usr/local/lib
 
       - name: Run unit tests
-        run: cargo test --lib --target ${{ matrix.target }}
+        run: cargo test --workspace --lib --target ${{ matrix.target }}
         env:
           LIBRARY_PATH: /usr/local/lib
           LD_LIBRARY_PATH: /usr/local/lib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
-# Supersede a PR's older in-flight run when it is pushed to again. Pushes to a
-# branch (i.e. main) are never cancelled. Without this, a run that wedges holds
-# runners until the 6h job timeout even after the fix has been pushed.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 jobs:
   # ==========================================================================
   # Quick checks (no platform-specific deps needed)
@@ -135,8 +128,8 @@ jobs:
 
       # Also root-package scope for now: smolvm-network's ICMP relay test builds
       # echo requests with a zero ident/checksum for the kernel to fill in, which
-      # is Linux ping-socket behaviour, so it times out on macOS. The Linux job
-      # runs the full workspace suite; widen this once that is sorted.
+      # is Linux ping-socket behaviour, so it times out on macOS. Linux runs the
+      # reliable member-crate suites listed below.
       - name: Run unit tests
         run: cargo test --lib
         env:
@@ -249,10 +242,12 @@ jobs:
         env:
           LIBRARY_PATH: /usr/local/lib
 
-      # Crates listed explicitly rather than --workspace: smolvm-network's suite
-      # hangs on the runner (it is the only one doing real socket I/O in tests,
-      # and its ICMP relay test is already known to be platform-sensitive).
-      # Everything else is covered; re-add smolvm-network once that is diagnosed.
+      # Every library crate with host-runnable unit tests is listed explicitly
+      # except smolvm-network: its real-socket suite hangs on the Linux runner,
+      # and its ICMP relay test is already known to be platform-sensitive.
+      # The agent and K8s shim suites run in the dedicated steps below. The CUDA
+      # guest/shim and codegen crates have no unit tests; Clippy and the
+      # standalone guest build checks above still compile them.
       - name: Run unit tests
         run: >
           cargo test --lib --target ${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,13 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+# Supersede a PR's older in-flight run when it is pushed to again. Pushes to a
+# branch (i.e. main) are never cancelled. Without this, a run that wedges holds
+# runners until the 6h job timeout even after the fix has been pushed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # ==========================================================================
   # Quick checks (no platform-specific deps needed)
@@ -242,8 +249,15 @@ jobs:
         env:
           LIBRARY_PATH: /usr/local/lib
 
+      # Crates listed explicitly rather than --workspace: smolvm-network's suite
+      # hangs on the runner (it is the only one doing real socket I/O in tests,
+      # and its ICMP relay test is already known to be platform-sensitive).
+      # Everything else is covered; re-add smolvm-network once that is diagnosed.
       - name: Run unit tests
-        run: cargo test --workspace --lib --target ${{ matrix.target }}
+        run: >
+          cargo test --lib --target ${{ matrix.target }}
+          -p smolvm -p smolvm-pack -p smolvm-registry
+          -p smolvm-protocol -p smolfile -p smolvm-cuda
         env:
           LIBRARY_PATH: /usr/local/lib
           LD_LIBRARY_PATH: /usr/local/lib

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -497,7 +497,7 @@ fn signal_ready_to_host() {
     let paths = [format!("/oldroot/{}", marker), format!("/{}", marker)];
 
     for path in &paths {
-        if Path::new(path).parent().map_or(false, |p| p.exists()) {
+        if Path::new(path).parent().is_some_and(|p| p.exists()) {
             // Write + fsync so the host sees the marker immediately. A plain
             // write() can sit in the guest's virtiofs writeback cache for
             // seconds before the host fs backend observes it, leaving the host's
@@ -5118,6 +5118,9 @@ fn run_in_keepalive_container(
     })
 }
 
+// Mirrors `storage::run_command`'s workload parameter list one-for-one; both
+// want folding into a shared spec struct rather than trimming here.
+#[allow(clippy::too_many_arguments)]
 fn handle_run(
     image: &str,
     command: &[String],
@@ -6326,9 +6329,9 @@ mod tests {
 
         let got = std::fs::read(&target).unwrap();
         let mut expected = Vec::with_capacity(total);
-        expected.extend(std::iter::repeat(b'A').take(400));
-        expected.extend(std::iter::repeat(b'B').take(400));
-        expected.extend(std::iter::repeat(b'C').take(224));
+        expected.extend(std::iter::repeat_n(b'A', 400));
+        expected.extend(std::iter::repeat_n(b'B', 400));
+        expected.extend(std::iter::repeat_n(b'C', 224));
         assert_eq!(got, expected);
         assert!(staging_files_in(tmp.path()).is_empty());
     }

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -4992,7 +4992,6 @@ fn cap_exec_response(resp: AgentResponse) -> AgentResponse {
     resp
 }
 
-#[allow(clippy::too_many_arguments)]
 /// Run a non-interactive command inside the machine's long-lived keep-alive
 /// container (establishing it on first use), capturing its output. Joining the
 /// keep-alive container — rather than spawning a fresh one per exec — is what

--- a/crates/smolvm-agent/src/process.rs
+++ b/crates/smolvm-agent/src/process.rs
@@ -243,8 +243,8 @@ where
                 let join_deadline = Instant::now() + READER_JOIN_TIMEOUT;
                 while Instant::now() < join_deadline {
                     drain_channels(&stdout_rx, &stderr_rx, &mut stdout_buf, &mut stderr_buf);
-                    let stdout_done = stdout_handle.as_ref().map_or(true, |h| h.is_finished());
-                    let stderr_done = stderr_handle.as_ref().map_or(true, |h| h.is_finished());
+                    let stdout_done = stdout_handle.as_ref().is_none_or(|h| h.is_finished());
+                    let stderr_done = stderr_handle.as_ref().is_none_or(|h| h.is_finished());
                     if stdout_done && stderr_done {
                         break;
                     }

--- a/crates/smolvm-agent/src/pty.rs
+++ b/crates/smolvm-agent/src/pty.rs
@@ -260,10 +260,8 @@ pub fn slave_pre_exec(slave_fd: RawFd) -> impl FnMut() -> io::Result<()> {
 
         // Dup slave fd onto stdin/stdout/stderr.
         for &target in &[0, 1, 2] {
-            if slave_fd != target {
-                if unsafe { libc::dup2(slave_fd, target) } < 0 {
-                    return Err(io::Error::last_os_error());
-                }
+            if slave_fd != target && unsafe { libc::dup2(slave_fd, target) } < 0 {
+                return Err(io::Error::last_os_error());
             }
         }
 

--- a/crates/smolvm-agent/src/ssh_agent.rs
+++ b/crates/smolvm-agent/src/ssh_agent.rs
@@ -80,128 +80,6 @@ fn inject_into_env_if(env: &mut Vec<(String, String)>, enabled: bool) {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::oci::{OciSpec, ProcessIdentity};
-
-    // Regression guard for #542: non-interactive exec + run go through the
-    // keep-alive container's `crun exec`, whose process env is built fresh (not
-    // inherited from the container), so SSH_AUTH_SOCK must be injected into that
-    // env explicitly — the container-spec injection alone doesn't reach it.
-    #[test]
-    fn inject_into_env_adds_ssh_auth_sock_only_when_enabled() {
-        // Enabled → injected.
-        let mut env = vec![("PATH".to_string(), "/usr/bin".to_string())];
-        inject_into_env_if(&mut env, true);
-        assert!(
-            env.iter()
-                .any(|(k, v)| k == "SSH_AUTH_SOCK" && v == GUEST_SSH_AUTH_SOCK),
-            "SSH_AUTH_SOCK must be injected into the exec/run env when forwarding is enabled"
-        );
-
-        // Disabled → no-op.
-        let mut env = vec![("PATH".to_string(), "/usr/bin".to_string())];
-        inject_into_env_if(&mut env, false);
-        assert!(!env.iter().any(|(k, _)| k == "SSH_AUTH_SOCK"));
-
-        // Never overrides a user-supplied value.
-        let mut env = vec![("SSH_AUTH_SOCK".to_string(), "/custom.sock".to_string())];
-        inject_into_env_if(&mut env, true);
-        assert_eq!(env.iter().filter(|(k, _)| k == "SSH_AUTH_SOCK").count(), 1);
-        assert_eq!(env[0].1, "/custom.sock");
-    }
-
-    #[test]
-    fn inject_is_noop_when_disabled() {
-        let mut spec = OciSpec::new(
-            &["true".to_string()],
-            &[],
-            "/",
-            false,
-            &ProcessIdentity::root(),
-            false,
-        );
-        let mounts_before = spec.mounts.len();
-        let envs_before = spec.process.env.len();
-
-        inject_into_container_if(&mut spec, false);
-
-        assert_eq!(spec.mounts.len(), mounts_before);
-        assert_eq!(spec.process.env.len(), envs_before);
-        assert!(!spec
-            .process
-            .env
-            .iter()
-            .any(|e| e.starts_with("SSH_AUTH_SOCK=")));
-    }
-
-    #[test]
-    fn inject_adds_env_and_mount_when_enabled() {
-        let mut spec = OciSpec::new(
-            &["true".to_string()],
-            &[],
-            "/",
-            false,
-            &ProcessIdentity::root(),
-            false,
-        );
-
-        inject_into_container_if(&mut spec, true);
-
-        // Env must point at the guest-side bridge socket.
-        assert!(spec
-            .process
-            .env
-            .iter()
-            .any(|e| e == &format!("SSH_AUTH_SOCK={}", GUEST_SSH_AUTH_SOCK)));
-
-        // Mount must bind the socket at the same path inside the container.
-        let mount = spec
-            .mounts
-            .iter()
-            .find(|m| m.destination == GUEST_SSH_AUTH_SOCK)
-            .expect("bind mount for SSH agent socket not found");
-        assert_eq!(mount.source, GUEST_SSH_AUTH_SOCK);
-        assert_eq!(mount.mount_type.as_deref(), Some("bind"));
-        // rw: the SSH agent protocol is bidirectional.
-        assert!(!mount.options.iter().any(|o| o == "ro"));
-        assert!(mount.options.iter().any(|o| o == "bind"));
-    }
-
-    #[test]
-    fn inject_replaces_existing_ssh_auth_sock() {
-        // Simulates an image whose config already exports a stale
-        // SSH_AUTH_SOCK: we must replace it, not duplicate it — two entries
-        // for the same key leaves the effective value shell-dependent.
-        let mut spec = OciSpec::new(
-            &["true".to_string()],
-            &[],
-            "/",
-            false,
-            &ProcessIdentity::root(),
-            false,
-        );
-        spec.process
-            .env
-            .push("SSH_AUTH_SOCK=/stale/path".to_string());
-
-        inject_into_container_if(&mut spec, true);
-
-        let matches: Vec<_> = spec
-            .process
-            .env
-            .iter()
-            .filter(|e| e.starts_with("SSH_AUTH_SOCK="))
-            .collect();
-        assert_eq!(matches.len(), 1, "duplicate SSH_AUTH_SOCK entries");
-        assert_eq!(
-            matches[0],
-            &format!("SSH_AUTH_SOCK={}", GUEST_SSH_AUTH_SOCK)
-        );
-    }
-}
-
 fn run_bridge() -> io::Result<()> {
     let sock_path = std::path::Path::new(GUEST_SSH_AUTH_SOCK);
 
@@ -417,5 +295,127 @@ fn vsock_connect(port: u32) -> io::Result<VsockStream> {
         }
 
         Ok(VsockStream { fd })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::oci::{OciSpec, ProcessIdentity};
+
+    // Regression guard for #542: non-interactive exec + run go through the
+    // keep-alive container's `crun exec`, whose process env is built fresh (not
+    // inherited from the container), so SSH_AUTH_SOCK must be injected into that
+    // env explicitly — the container-spec injection alone doesn't reach it.
+    #[test]
+    fn inject_into_env_adds_ssh_auth_sock_only_when_enabled() {
+        // Enabled → injected.
+        let mut env = vec![("PATH".to_string(), "/usr/bin".to_string())];
+        inject_into_env_if(&mut env, true);
+        assert!(
+            env.iter()
+                .any(|(k, v)| k == "SSH_AUTH_SOCK" && v == GUEST_SSH_AUTH_SOCK),
+            "SSH_AUTH_SOCK must be injected into the exec/run env when forwarding is enabled"
+        );
+
+        // Disabled → no-op.
+        let mut env = vec![("PATH".to_string(), "/usr/bin".to_string())];
+        inject_into_env_if(&mut env, false);
+        assert!(!env.iter().any(|(k, _)| k == "SSH_AUTH_SOCK"));
+
+        // Never overrides a user-supplied value.
+        let mut env = vec![("SSH_AUTH_SOCK".to_string(), "/custom.sock".to_string())];
+        inject_into_env_if(&mut env, true);
+        assert_eq!(env.iter().filter(|(k, _)| k == "SSH_AUTH_SOCK").count(), 1);
+        assert_eq!(env[0].1, "/custom.sock");
+    }
+
+    #[test]
+    fn inject_is_noop_when_disabled() {
+        let mut spec = OciSpec::new(
+            &["true".to_string()],
+            &[],
+            "/",
+            false,
+            &ProcessIdentity::root(),
+            false,
+        );
+        let mounts_before = spec.mounts.len();
+        let envs_before = spec.process.env.len();
+
+        inject_into_container_if(&mut spec, false);
+
+        assert_eq!(spec.mounts.len(), mounts_before);
+        assert_eq!(spec.process.env.len(), envs_before);
+        assert!(!spec
+            .process
+            .env
+            .iter()
+            .any(|e| e.starts_with("SSH_AUTH_SOCK=")));
+    }
+
+    #[test]
+    fn inject_adds_env_and_mount_when_enabled() {
+        let mut spec = OciSpec::new(
+            &["true".to_string()],
+            &[],
+            "/",
+            false,
+            &ProcessIdentity::root(),
+            false,
+        );
+
+        inject_into_container_if(&mut spec, true);
+
+        // Env must point at the guest-side bridge socket.
+        assert!(spec
+            .process
+            .env
+            .iter()
+            .any(|e| e == &format!("SSH_AUTH_SOCK={}", GUEST_SSH_AUTH_SOCK)));
+
+        // Mount must bind the socket at the same path inside the container.
+        let mount = spec
+            .mounts
+            .iter()
+            .find(|m| m.destination == GUEST_SSH_AUTH_SOCK)
+            .expect("bind mount for SSH agent socket not found");
+        assert_eq!(mount.source, GUEST_SSH_AUTH_SOCK);
+        assert_eq!(mount.mount_type.as_deref(), Some("bind"));
+        // rw: the SSH agent protocol is bidirectional.
+        assert!(!mount.options.iter().any(|o| o == "ro"));
+        assert!(mount.options.iter().any(|o| o == "bind"));
+    }
+
+    #[test]
+    fn inject_replaces_existing_ssh_auth_sock() {
+        // Simulates an image whose config already exports a stale
+        // SSH_AUTH_SOCK: we must replace it, not duplicate it — two entries
+        // for the same key leaves the effective value shell-dependent.
+        let mut spec = OciSpec::new(
+            &["true".to_string()],
+            &[],
+            "/",
+            false,
+            &ProcessIdentity::root(),
+            false,
+        );
+        spec.process
+            .env
+            .push("SSH_AUTH_SOCK=/stale/path".to_string());
+
+        inject_into_container_if(&mut spec, true);
+
+        let matches: Vec<_> = spec
+            .process
+            .env
+            .iter()
+            .filter(|e| e.starts_with("SSH_AUTH_SOCK="))
+            .collect();
+        assert_eq!(matches.len(), 1, "duplicate SSH_AUTH_SOCK entries");
+        assert_eq!(
+            matches[0],
+            &format!("SSH_AUTH_SOCK={}", GUEST_SSH_AUTH_SOCK)
+        );
     }
 }

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -2737,6 +2737,9 @@ fn prepare_rootfs_for_ephemeral_run(image: &str) -> Result<PreparedOverlayRootfs
 /// When `persistent_overlay_id` is `Some`, the overlay persists across runs
 /// (filesystem changes accumulate). When `None`, an ephemeral overlay is
 /// created and destroyed after the run.
+// The workload parameter list, mirrored by `main::handle_run`; both want
+// folding into a shared spec struct rather than trimming here.
+#[allow(clippy::too_many_arguments)]
 pub fn run_command(
     image: &str,
     command: &[String],
@@ -2843,6 +2846,8 @@ pub fn run_command(
 /// Requires a persistent overlay ID — ephemeral overlays would leak their
 /// upper/work/merged directories because nothing is waiting to clean them
 /// up after the container exits.
+// Same workload parameter list as `run_command`, minus the wait-related args.
+#[allow(clippy::too_many_arguments)]
 pub fn spawn_in_overlay(
     image: &str,
     command: &[String],

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -3873,7 +3873,7 @@ fn get_disk_usage(path: &Path) -> Result<(u64, u64)> {
             let free = stat.f_bfree * stat.f_frsize;
             let used = total - free;
 
-            Ok((total as u64, used as u64))
+            Ok((total, used))
         }
     }
 

--- a/crates/smolvm-cuda-guest/src/main.rs
+++ b/crates/smolvm-cuda-guest/src/main.rs
@@ -120,7 +120,12 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 /// The shared pattern the writer stores and the reader verifies.
+///
+/// Arbitrary recognizable floats, not mathematical constants — the point is
+/// that a wrong read is obvious in the log, so `approx_constant` is a false
+/// positive on the leading value here.
 #[cfg(target_os = "linux")]
+#[allow(clippy::approx_constant)]
 const PROBE_PATTERN: [f32; 4] = [3.14, 2.71, 1.41, 1.61];
 
 #[cfg(target_os = "linux")]
@@ -160,7 +165,7 @@ fn run_loop() -> Result<(), Box<dyn std::error::Error>> {
         .chars()
         .take(8)
         .collect::<String>();
-    let mut append = |line: String| {
+    let append = |line: String| {
         if let Ok(mut f) = std::fs::OpenOptions::new()
             .create(true)
             .append(true)

--- a/crates/smolvm-cuda-shim/src/lib.rs
+++ b/crates/smolvm-cuda-shim/src/lib.rs
@@ -462,7 +462,10 @@ pub extern "C" fn cuDeviceGetName(name: *mut c_char, len: c_int, device: c_int) 
             let bytes = n.as_bytes();
             let copy = bytes.len().min(len as usize - 1);
             unsafe {
-                std::ptr::copy_nonoverlapping(bytes.as_ptr(), name as *mut u8, copy);
+                // `.cast()` rather than `as *mut u8`: c_char is u8 on aarch64
+                // Linux, where the `as` form is a no-op cast clippy rejects,
+                // but i8 on x86_64 and macOS, where the conversion is real.
+                std::ptr::copy_nonoverlapping(bytes.as_ptr(), name.cast::<u8>(), copy);
                 *name.add(copy) = 0;
             }
             CUDA_SUCCESS

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -2746,7 +2746,9 @@ pub extern "C" fn cudaDeviceGetPCIBusId(buf: *mut c_char, len: c_int, _device: c
     let id = b"0000:01:00.0\0";
     if !buf.is_null() && len > 0 {
         let n = (len as usize - 1).min(id.len() - 1);
-        unsafe { std::ptr::copy_nonoverlapping(id.as_ptr() as *const c_char, buf, n) };
+        // `.cast()`: c_char is u8 on aarch64 Linux (making `as` a no-op cast
+        // clippy rejects) but i8 elsewhere.
+        unsafe { std::ptr::copy_nonoverlapping(id.as_ptr().cast::<c_char>(), buf, n) };
         unsafe { *buf.add(n) = 0 };
     }
     set_last(CUDA_SUCCESS)

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -936,7 +936,11 @@ pub extern "C" fn cudaMallocHost(ptr: *mut *mut c_void, size: usize) -> c_int {
 // offset (see do_memcpy). Falls back to plain host memory when the region is
 // absent or exhausted.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::AtomicU64;
+// Every use of the bare `Ordering` name in this file sits on a Linux-only
+// path, so importing it unconditionally warns on a macOS dev host.
+#[cfg(target_os = "linux")]
+use std::sync::atomic::Ordering;
 
 static SHM_NEXT: AtomicU64 = AtomicU64::new(0);
 

--- a/crates/smolvm-nvml-shim/src/lib.rs
+++ b/crates/smolvm-nvml-shim/src/lib.rs
@@ -100,7 +100,8 @@ fn cu_device_name(ord: c_int) -> Option<String> {
         let dev = cu_device(ord)?;
         let f = cu_sym(c"cuDeviceGetName")?;
         let f: extern "C" fn(*mut c_char, c_int, c_int) -> c_int = std::mem::transmute(f);
-        let mut buf = [0i8; 256];
+        // c_char, not i8: they differ on aarch64 Linux, where c_char is u8.
+        let mut buf: [c_char; 256] = [0; 256];
         (f(buf.as_mut_ptr(), buf.len() as c_int, dev) == 0).then(|| {
             let cstr = std::ffi::CStr::from_ptr(buf.as_ptr());
             cstr.to_string_lossy().into_owned()

--- a/crates/smolvm-nvml-shim/src/lib.rs
+++ b/crates/smolvm-nvml-shim/src/lib.rs
@@ -160,7 +160,9 @@ unsafe fn write_cstr(dst: *mut c_char, len: c_uint, s: &str) {
     let cap = len as usize - 1;
     let bytes = s.as_bytes();
     let n = bytes.len().min(cap);
-    std::ptr::copy_nonoverlapping(bytes.as_ptr() as *const c_char, dst, n);
+    // `.cast()`: c_char is u8 on aarch64 Linux (making `as` a no-op cast clippy
+    // rejects) but i8 elsewhere.
+    std::ptr::copy_nonoverlapping(bytes.as_ptr().cast::<c_char>(), dst, n);
     *dst.add(n) = 0;
 }
 

--- a/crates/smolvm-pack/src/packer.rs
+++ b/crates/smolvm-pack/src/packer.rs
@@ -856,9 +856,11 @@ mod tests {
         let staging = temp_dir.path().join("staging");
         let mut collector = AssetCollector::new(staging).unwrap();
 
-        // Add a fake layer (digest must be at least 12 chars after sha256:)
+        // Add a fake layer. The digest must be at least 12 characters after
+        // `sha256:` and valid hex — it is used as a filesystem path, so
+        // `add_layer` rejects anything else (see 680ba8d9).
         collector
-            .add_layer("sha256:embedded123456", b"embedded layer content")
+            .add_layer("sha256:abcdef123456", b"embedded layer content")
             .unwrap();
 
         // Create manifest
@@ -879,7 +881,7 @@ mod tests {
         // Verify we can read the manifest with layer info
         let manifest = read_manifest(&output_path).unwrap();
         assert_eq!(manifest.assets.layers.len(), 1);
-        assert_eq!(manifest.assets.layers[0].digest, "sha256:embedded123456");
+        assert_eq!(manifest.assets.layers[0].digest, "sha256:abcdef123456");
 
         // Verify footer indicates embedded mode
         let footer = read_footer(&output_path).unwrap();
@@ -890,7 +892,7 @@ mod tests {
         let extract_dir = temp_dir.path().join("extracted");
         extract_assets(&output_path, &extract_dir).unwrap();
 
-        let layer_file = extract_dir.join("layers/embedded1234.tar"); // First 12 chars
+        let layer_file = extract_dir.join("layers/abcdef123456.tar"); // First 12 chars
         assert!(layer_file.exists());
         assert_eq!(
             fs::read_to_string(&layer_file).unwrap(),

--- a/crates/smolvm-pack/src/signing.rs
+++ b/crates/smolvm-pack/src/signing.rs
@@ -141,13 +141,14 @@ pub struct SignatureInfo {
     pub raw_output: String,
 }
 
-#[cfg(test)]
+// Every test here drives `codesign`, so the whole module is macOS-only —
+// otherwise its imports are unused on other platforms.
+#[cfg(all(test, target_os = "macos"))]
 mod tests {
     use super::*;
     use std::io::Write;
 
     #[test]
-    #[cfg(target_os = "macos")]
     fn test_sign_binary() {
         let temp_dir = tempfile::tempdir().unwrap();
         let binary_path = temp_dir.path().join("test_binary");
@@ -189,7 +190,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_os = "macos")]
     fn test_entitlements_format() {
         // Verify the entitlements XML is valid
         assert!(HYPERVISOR_ENTITLEMENTS.contains("com.apple.security.hypervisor"));

--- a/crates/smolvm-protocol/src/lib.rs
+++ b/crates/smolvm-protocol/src/lib.rs
@@ -92,6 +92,13 @@ pub const FILE_WRITE_SINGLE_SHOT_MAX: usize = 1024 * 1024;
 /// asymmetric case and needs a smaller chunk.
 pub const FILE_WRITE_CHUNK_SIZE: usize = FILE_WRITE_SINGLE_SHOT_MAX;
 
+// The single-shot threshold must be <= the chunk size. They can be equal (a
+// 1 MiB file is a single shot; a 1 MiB + 1 byte file streams as two chunks),
+// but SINGLE_SHOT > CHUNK would be incoherent — a file slightly over the shot
+// threshold would have to stream as a single oversized chunk. Enforced at
+// compile time so a bad edit fails the build rather than a test.
+const _: () = assert!(FILE_WRITE_SINGLE_SHOT_MAX <= FILE_WRITE_CHUNK_SIZE);
+
 /// Hard ceiling on a single file transfer in either direction.
 ///
 /// On the write path: enforced at `FileWriteBegin` by the agent —
@@ -1373,13 +1380,6 @@ mod tests {
             total,
             MAX_FRAME_SIZE
         );
-
-        // Single-shot threshold must be <= chunk size. They can be
-        // equal (a 1 MiB file is a single shot; a 1 MiB + 1 byte
-        // file streams as two chunks); but SINGLE_SHOT > CHUNK would
-        // be incoherent — a file slightly over the shot threshold
-        // would need to stream as... a single oversized chunk.
-        assert!(FILE_WRITE_SINGLE_SHOT_MAX <= FILE_WRITE_CHUNK_SIZE);
     }
 
     #[test]


### PR DESCRIPTION
> #760 is on `main`. This branch rebases cleanly on top of that squash; it does not re-land the dead-helper removal.

`cargo clippy --all-targets` and `cargo test --lib` from the workspace root select **only the root `smolvm` package**. Member crates went unlinted, and their unit tests never ran in CI. That blind spot is how #737's breakage (CUDA guest crates failing without the host feature / on macOS) reached a tagged release.

### What changes

**Linux Clippy** → `cargo clippy --workspace`. Linux is where `smolvm-agent` and the CUDA shims build and ship.

**macOS Clippy** → stays root-package scope on purpose. Compiling guest crates for macOS reports their `cfg(target_os = "linux")` items as dead code.

**Linux tests** → named crates, not `--workspace`:
- `smolvm`, `smolvm-pack`, `smolvm-registry`, `smolvm-protocol`, `smolfile`, `smolvm-cuda`
- plus existing `smolvm-agent --bins` and `smolvm-shim` steps

**`smolvm-network` is excluded from the Linux test list.** Its real-socket suite hangs the runner (>1h vs ~4 min). It is still linted by `--workspace` Clippy. Re-add once diagnosed.

**CUDA guest configuration check** (macOS) → `cargo check -p smolvm-cuda-shim -p smolvm-cudart-shim -p smolvm-cuda-guest` so the guest `default-features = false` path is covered.

### What turning the lights on found

| Where | Issue |
|---|---|
| `smolvm-nvml-shim` | Did not compile on aarch64 (`[i8; 256]` vs `c_char`) |
| CUDA shims | `ptr as *mut u8` on `c_char` — switched to `.cast()` |
| `smolvm-pack` | Broken digest fixture + macOS-only signing test module gate |
| agent / cuda-guest / protocol | Clippy fixes exposed by the wider scope |

### Merge order

1. #760 (done)
2. This PR

### Verification

All jobs green on the previous tip; this push only rebases onto post-#760 `main`, drops the duplicate #760 commit, removes an unrelated concurrency policy, and corrects the coverage wording.