### PR TITLE
Add a node endpoint that pre-loads a .smolmachine artifact into the local blob cache

### DIFF
--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -2060,6 +2060,25 @@ async fn pull_from_registry(
     identity_token: Option<&str>,
     blob_peers: &[String],
 ) -> Result<String, ApiError> {
+    let result = pull_smolmachine(registry_ref, identity_token, blob_peers).await?;
+    tracing::info!(path = %result.path.display(), cached = result.cached, "pull complete");
+    Ok(result.path.to_string_lossy().into_owned())
+}
+
+/// Resolve `registry_ref` and pull its `.smolmachine` layer into this node's
+/// blob cache, returning the full [`smolvm_registry::PullResult`].
+///
+/// Split out of [`pull_from_registry`] so the pre-warm endpoint
+/// ([`crate::api::handlers::prewarm`]) reaches the registry through byte-for-byte
+/// the same reference parsing, mirror lookup, credential precedence, cache, and
+/// peer fallback that a real create uses. A warm path that resolved references
+/// even slightly differently would cache a blob under one key and leave the
+/// create looking for another — a silent no-op that still looks like a success.
+pub(crate) async fn pull_smolmachine(
+    registry_ref: &str,
+    identity_token: Option<&str>,
+    blob_peers: &[String],
+) -> Result<smolvm_registry::PullResult, ApiError> {
     let parsed = crate::registry::Reference::parse(registry_ref)
         .map_err(|e| ApiError::BadRequest(format!("invalid registry reference: {}", e)))?;
 
@@ -2119,9 +2138,7 @@ async fn pull_from_registry(
             _ => ApiError::internal(format!("registry pull failed: {}", e)),
         })?;
 
-    tracing::info!(path = %result.path.display(), cached = result.cached, "pull complete");
-
-    Ok(result.path.to_string_lossy().into_owned())
+    Ok(result)
 }
 
 fn registry_reference_tag_or_digest(parsed: &crate::registry::Reference) -> &str {

--- a/src/api/handlers/mod.rs
+++ b/src/api/handlers/mod.rs
@@ -7,6 +7,7 @@ pub mod images;
 pub mod machines;
 pub mod node;
 pub mod p2p;
+pub mod prewarm;
 pub mod volumes;
 
 use crate::api::error::ApiError;

--- a/src/api/handlers/prewarm.rs
+++ b/src/api/handlers/prewarm.rs
@@ -1,0 +1,90 @@
+//! Control-initiated artifact pre-warming.
+//!
+//! `POST /artifacts/warm` pulls a `.smolmachine` layer blob into this node's
+//! local cache *ahead of* any machine that needs it, so the create path finds a
+//! warm cache instead of racing a cold multi-hundred-MB download.
+//!
+//! ## Why this exists
+//!
+//! The shared registry is reached over a link with a fixed bandwidth ceiling
+//! that every concurrent pull in the fleet divides between them. A tenant who
+//! pushes a fresh artifact and immediately fans out N machines makes N nodes
+//! pull the same bytes at the same moment, so each one gets roughly 1/N of the
+//! ceiling and the pull stretches from seconds into tens of seconds — long
+//! enough to lose a client-side readiness race. Fetching once per node at push
+//! time, when nothing is waiting on it, moves that transfer off the critical
+//! path entirely and lets the create hit a local cache instead.
+//!
+//! ## Security
+//!
+//! Like `/drain` and `/p2p/blob/{digest}`, this route is mTLS-gated by the serve
+//! listener by construction: only a client whose cert chains to the fleet
+//! node-CA can reach it. The caller supplies the short-lived, tenant-scoped
+//! registry token, so this node can fetch exactly the artifact it was told to
+//! and nothing else — pre-warming grants no access the create path wouldn't
+//! already have.
+
+use axum::Json;
+
+use crate::api::error::ApiError;
+use crate::api::types::{WarmArtifactRequest, WarmArtifactResponse};
+
+/// Pull `req.reference` into this node's blob cache.
+///
+/// Idempotent: a reference whose layer is already cached returns immediately
+/// with `already_cached: true` and touches no network, so the control plane can
+/// re-warm freely (on a retry, a node restart, or a repeated push) without
+/// paying for the transfer twice.
+pub async fn warm_artifact(
+    Json(req): Json<WarmArtifactRequest>,
+) -> Result<Json<WarmArtifactResponse>, ApiError> {
+    if req.reference.trim().is_empty() {
+        return Err(ApiError::BadRequest("reference must not be empty".into()));
+    }
+
+    tracing::info!(reference = %req.reference, "pre-warming .smolmachine artifact");
+
+    let result = super::machines::pull_smolmachine(
+        &req.reference,
+        req.identity_token.as_deref(),
+        &req.blob_peers,
+    )
+    .await?;
+
+    tracing::info!(
+        reference = %req.reference,
+        digest = %result.digest,
+        size_bytes = result.size,
+        already_cached = result.cached,
+        "artifact pre-warm complete"
+    );
+
+    Ok(Json(WarmArtifactResponse {
+        digest: result.digest,
+        size_bytes: result.size,
+        already_cached: result.cached,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An empty reference is rejected at the boundary rather than handed to the
+    /// reference parser. Pre-warm is fire-and-forget from the control plane's
+    /// side, so a request that could never name an artifact should fail loudly
+    /// here instead of turning into a confusing parse error deeper in the pull.
+    #[tokio::test]
+    async fn empty_reference_is_rejected() {
+        for blank in ["", "   "] {
+            let err = warm_artifact(Json(WarmArtifactRequest {
+                reference: blank.to_string(),
+                identity_token: None,
+                blob_peers: Vec::new(),
+            }))
+            .await
+            .expect_err("a blank reference must not reach the pull path");
+            assert!(matches!(err, ApiError::BadRequest(_)));
+        }
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -174,6 +174,14 @@ pub fn create_router(state: Arc<ApiState>, cors_origins: Vec<String>) -> Router 
     // blobs can be large.
     let p2p_route = Router::new().route("/p2p/blob/{digest}", get(handlers::p2p::serve_blob));
 
+    // Control-initiated artifact pre-warm: pull a `.smolmachine` layer into this
+    // node's blob cache before any machine needs it, so a create finds it warm
+    // instead of racing a cold multi-hundred-MB download against a client's
+    // readiness timeout. mTLS-gated by the listener like `/drain` and `/p2p`
+    // above. No request timeout: the transfer is as large as a blob pull, and
+    // it runs off the critical path where slowness costs nothing.
+    let warm_route = Router::new().route("/artifacts/warm", post(handlers::prewarm::warm_artifact));
+
     // Long-lived streaming routes (no request timeout): SSE logs and the
     // interactive PTY WebSocket both outlive the 5-minute API timeout.
     let logs_route = Router::new()
@@ -291,6 +299,7 @@ pub fn create_router(state: Arc<ApiState>, cors_origins: Vec<String>) -> Router 
         .merge(capacity_route)
         .merge(drain_route)
         .merge(p2p_route)
+        .merge(warm_route)
         .merge(metrics_route)
         .nest("/api/v1", api_v1)
         .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -241,6 +241,40 @@ pub struct ExportResponse {
     pub manifest: String,
 }
 
+/// Request to pull a `.smolmachine` artifact into this node's blob cache ahead
+/// of any machine that needs it. See [`crate::api::handlers::prewarm`].
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct WarmArtifactRequest {
+    /// Full registry reference of the artifact to cache.
+    #[schema(example = "registry.example.com/tenants/t/app:latest")]
+    pub reference: String,
+    /// Short-lived, scoped registry token authorizing the pull. Omitted for a
+    /// reference this node already holds a persisted credential for.
+    #[serde(default)]
+    pub identity_token: Option<String>,
+    /// Sibling nodes to try before the registry, same as the create path. Warming
+    /// the second and later nodes from a peer keeps the fan-out off the registry
+    /// link entirely.
+    #[serde(default)]
+    pub blob_peers: Vec<String>,
+}
+
+/// Result of pre-warming an artifact into the node's blob cache.
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct WarmArtifactResponse {
+    /// Digest of the cached layer blob.
+    #[schema(example = "sha256:abc123")]
+    pub digest: String,
+    /// Size of the cached layer blob in bytes.
+    #[schema(example = 104857600)]
+    pub size_bytes: u64,
+    /// True when the blob was already cached and no transfer was needed — the
+    /// signal that a repeat warm cost nothing.
+    pub already_cached: bool,
+}
+
 /// Request to run a command in an image.
 #[derive(Debug, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
A create that needs an uncached `.smolmachine` downloads the whole layer before the machine can boot. When several nodes need the same freshly-pushed artifact at once they all download it simultaneously and divide whatever bandwidth the registry link has, so the transfer stretches from seconds into tens of seconds — on the critical path, with a client waiting.

`POST /artifacts/warm` pulls a reference into the node blob cache ahead of time, so the create finds it already there. It reuses the create path's own pull via a lifted `pull_smolmachine` helper, so reference parsing, mirror lookup, credential precedence, cache, and peer fallback are byte-for-byte identical — a warm path that resolved references differently would cache under one key while the create looked for another, a silent no-op that still reported success.

Idempotent: an already-cached layer returns `alreadyCached: true` without touching the network. mTLS-gated by the listener like `/drain` and `/p2p/blob/{digest}`, and the caller supplies the scoped token, so warming grants no access the create path did not already have.