### PR TITLE
Fix CUDA fork compatibility for vLLM workloads

### DIFF
--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -2477,6 +2477,16 @@ fn vram_limit() -> u64 {
         .unwrap_or(u64::MAX)
 }
 
+fn session_vram_used(sess: &Session) -> u64 {
+    sess.owned_dptrs.values().sum::<u64>() + sess.owned_vmm_handles.values().sum::<u64>()
+}
+
+fn virtual_memory_info(sess: &Session, free: u64, total: u64) -> (u64, u64) {
+    let total = total.min(vram_limit());
+    let free = free.min(total.saturating_sub(session_vram_used(sess)));
+    (free, total)
+}
+
 /// Debug op trace (`SMOLVM_CUDA_OPTRACE=<path>`): appends one line per traced
 /// memory/launch op with pid + post-translation params + status, so a fork
 /// investigation can see exactly which PROCESS executed which op on which
@@ -3040,9 +3050,9 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         Request::DeviceGetName { device } => {
             b.device_get_name(dev(sess, device)).map(Response::Name)
         }
-        Request::DeviceTotalMem { device } => {
-            b.device_total_mem(dev(sess, device)).map(Response::Bytes)
-        }
+        Request::DeviceTotalMem { device } => b
+            .device_total_mem(dev(sess, device))
+            .map(|total| Response::Bytes(total.min(vram_limit()))),
         Request::DriverGetVersion => b.driver_get_version().map(Response::Count),
         Request::DeviceGetAttribute { attrib, device } => b
             .device_get_attribute(attrib, dev(sess, device))
@@ -3386,7 +3396,10 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         Request::MemsetD8 { dptr, value, bytes } => {
             b.memset_d8(dptr, value, bytes).map(|_| Response::Ok)
         }
-        Request::MemGetInfo => b.mem_get_info().map(|(f, t)| Response::Pair(f, t)),
+        Request::MemGetInfo => b
+            .mem_get_info()
+            .map(|(free, total)| virtual_memory_info(sess, free, total))
+            .map(|(free, total)| Response::Pair(free, total)),
         Request::LaunchKernel {
             function,
             grid,
@@ -4983,12 +4996,21 @@ mod tests {
         let mut sess = Session::default();
         let mut b = CpuBackend::default();
         let mb = 1024 * 1024;
+        let (st, total) = dispatch(&mut sess, &mut b, Request::DeviceTotalMem { device: 0 });
+        assert_eq!(st, 0);
+        assert!(matches!(total, Response::Bytes(n) if n == mb));
+        let (st, info) = dispatch(&mut sess, &mut b, Request::MemGetInfo);
+        assert_eq!(st, 0);
+        assert!(matches!(info, Response::Pair(free, total) if free == mb && total == mb));
         let (st, r) = dispatch(&mut sess, &mut b, Request::MemAlloc { bytes: mb / 2 });
         assert_eq!(st, 0);
         let d1 = match r {
             Response::Dptr(d) => d,
             _ => unreachable!(),
         };
+        let (st, info) = dispatch(&mut sess, &mut b, Request::MemGetInfo);
+        assert_eq!(st, 0);
+        assert!(matches!(info, Response::Pair(free, total) if free == mb / 2 && total == mb));
         // Second half-MB fits exactly; a byte more must fail with OOM(2).
         let (st, _) = dispatch(&mut sess, &mut b, Request::MemAlloc { bytes: mb / 2 });
         assert_eq!(st, 0);

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -1044,23 +1044,51 @@ pub fn graph_oplogs_snapshot(token: u64) -> GraphOplogs {
     }
 }
 
-/// P3b worker: install inherited capture-replay logs for this clone. Drained
-/// into the serving session at clone resume; replayed lazily at first launch.
+/// P3b worker: install inherited capture-replay logs for this clone. Kept
+/// process-global and immutable so every late-attached CUDA channel can lazily
+/// rebuild a graph the first channel has not used yet.
 pub fn set_worker_graph_oplogs(v: GraphOplogs) {
-    WORKER_GRAPH_OPLOGS.with(|r| *r.borrow_mut() = v);
+    *WORKER_GRAPH_OPLOGS.lock().unwrap() = Some(std::sync::Arc::new(v));
 }
 
-thread_local! {
-    static WORKER_GRAPH_OPLOGS: std::cell::RefCell<GraphOplogs> =
-        const { std::cell::RefCell::new(Vec::new()) };
-}
+static WORKER_GRAPH_OPLOGS: std::sync::Mutex<Option<std::sync::Arc<GraphOplogs>>> =
+    std::sync::Mutex::new(None);
 
-fn take_worker_graph_oplogs() -> GraphOplogs {
-    WORKER_GRAPH_OPLOGS.with(|r| std::mem::take(&mut *r.borrow_mut()))
+fn worker_graph_oplog(exec_vh: u64) -> Option<Vec<Vec<u8>>> {
+    WORKER_GRAPH_OPLOGS
+        .lock()
+        .unwrap()
+        .as_ref()
+        .and_then(|logs| {
+            logs.iter()
+                .find(|(_, exec, _)| *exec == exec_vh)
+                .map(|(_, _, ops)| ops.clone())
+        })
 }
 
 fn worker_graph_oplogs_peek() -> GraphOplogs {
-    WORKER_GRAPH_OPLOGS.with(|r| r.borrow().clone())
+    WORKER_GRAPH_OPLOGS
+        .lock()
+        .unwrap()
+        .as_ref()
+        .map(|logs| logs.as_ref().clone())
+        .unwrap_or_default()
+}
+
+fn worker_graph_oplogs_len() -> usize {
+    WORKER_GRAPH_OPLOGS
+        .lock()
+        .unwrap()
+        .as_ref()
+        .map_or(0, |logs| logs.len())
+}
+
+fn prereplay_setting(value: Option<&str>) -> bool {
+    matches!(value.map(str::trim), Some("1" | "true" | "on" | "yes"))
+}
+
+fn prereplay_enabled() -> bool {
+    prereplay_setting(std::env::var("SMOLVM_CUDA_PREREPLAY").ok().as_deref())
 }
 
 /// P3b: pre-warm a clone worker at SPAWN, before any guest channel attaches —
@@ -1069,9 +1097,11 @@ fn worker_graph_oplogs_peek() -> GraphOplogs {
 /// results at resume instead of paying reload/re-capture on the guest's first
 /// CUDA call. Must run on the worker main thread AFTER module staging and
 /// lib-handle replay (their thread-locals seed the scratch session).
-/// Opt out: SMOLVM_CUDA_PREREPLAY=0.
+/// Opt in: SMOLVM_CUDA_PREREPLAY=1. Replaying every captured shape can execute
+/// stale/unneeded buffers and poison the context; lazy first-launch replay is
+/// the safe default.
 pub fn prewarm_clone_worker(b: &mut dyn Backend) {
-    if std::env::var("SMOLVM_CUDA_PREREPLAY").as_deref() == Ok("0") {
+    if !prereplay_enabled() {
         return;
     }
     let t0 = std::time::Instant::now();
@@ -2682,6 +2712,8 @@ fn adopt_replayed_exec(sess: &mut Session, exec_vh: u64, exec: u64) {
     sess.owned_graph_reals.insert(exec);
 }
 
+static REPLAY_CAPTURE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// P3b: rebuild an inherited graph by RE-CAPTURING its recorded op sequence in
 /// this clone's context. Begins capture on the clone's remapped copy of the
 /// golden's capture stream, re-dispatches each recorded op (so `dispatch`'s
@@ -3105,20 +3137,16 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
                 }
                 sort_trans(&mut sess.dptr_trans); // xlat binary-searches by base
                 gpu::set_lib_trans(&sess.dptr_trans); // forwarded-lib pointer map
-                                                      // P3b: adopt inherited capture-replay logs, keyed by exec_vh —
-                                                      // replayed lazily at the clone's first GraphLaunch.
-                for (graph_vh, exec_vh, ops) in take_worker_graph_oplogs() {
-                    eprintln!(
-                        "[p3b] clone adopted oplog: graph {graph_vh:#x} exec {exec_vh:#x} ({} ops)",
-                        ops.len()
-                    );
-                    sess.clone_graph_oplogs.insert(exec_vh, ops);
-                }
+                                                      // P3b logs remain process-global so late-attached channels can
+                                                      // fetch unseen graphs on demand instead of inheriting an empty
+                                                      // thread-local after the first channel drains it.
+                let inherited_graphs = worker_graph_oplogs_len();
                 eprintln!(
                     "[cuda-fork-isolate] clone resumed token {parent}: {copied} private copies \
-                     ({cbytes} B), {shared} shared read-only ({sbytes} B)"
+                     ({cbytes} B), {shared} shared read-only ({sbytes} B), \
+                     {inherited_graphs} inherited graph logs"
                 );
-                // P3b PRE-WARM (opt out: SMOLVM_CUDA_PREREPLAY=0). Two stages,
+                // P3b PRE-WARM (explicit opt in: SMOLVM_CUDA_PREREPLAY=1). Two stages,
                 // both moving one-time clone costs off the first-request path:
                 // (1) eagerly reload every staged golden module — first-touch
                 // kernel launches (prefill, eager ops) stop paying per-module
@@ -3126,7 +3154,7 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
                 // rather than lazily at first launch. Failures are left for
                 // the lazy paths to retry; later sessions adopt from the
                 // registry.
-                if std::env::var("SMOLVM_CUDA_PREREPLAY").as_deref() != Ok("0") {
+                if prereplay_enabled() {
                     let mods: Vec<u64> = MOD_IMAGES.with(|m| m.borrow().keys().copied().collect());
                     if !mods.is_empty() {
                         let t0 = std::time::Instant::now();
@@ -3142,9 +3170,12 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
                         );
                     }
                 }
-                if !sess.clone_graph_oplogs.is_empty()
-                    && std::env::var("SMOLVM_CUDA_PREREPLAY").as_deref() != Ok("0")
-                {
+                if prereplay_enabled() {
+                    for (_, exec_vh, ops) in worker_graph_oplogs_peek() {
+                        sess.clone_graph_oplogs.entry(exec_vh).or_insert(ops);
+                    }
+                }
+                if !sess.clone_graph_oplogs.is_empty() && prereplay_enabled() {
                     let t0 = std::time::Instant::now();
                     let execs: Vec<u64> = sess.clone_graph_oplogs.keys().copied().collect();
                     let (mut fresh, mut adopted, mut deferred) = (0u32, 0u32, 0u32);
@@ -3476,21 +3507,43 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
                 && !sess
                     .owned_graph_reals
                     .contains(&raw_graph(sess, graph_exec))
-                && sess.clone_graph_oplogs.contains_key(&graph_exec)
             {
-                match replay_capture_graph(sess, b, graph_exec) {
-                    Ok(exec) => {
-                        replayed_exec_put(graph_exec, exec);
-                        adopt_replayed_exec(sess, graph_exec, exec);
-                        let raw = raw_stream(sess, stream)?;
-                        return b.graph_launch(exec, raw).map(|_| Response::Ok);
+                // Only one channel may capture an inherited exec at a time.
+                // Re-check the process registry after acquiring the lock: a
+                // sibling channel may have completed this graph while we
+                // waited. Fetch only this graph's immutable global log, so a
+                // late channel does not duplicate every inherited shape log.
+                let _capture_guard = REPLAY_CAPTURE_LOCK.lock().unwrap();
+                if let Some(exec) = replayed_exec_get(graph_exec) {
+                    adopt_replayed_exec(sess, graph_exec, exec);
+                    let raw = raw_stream(sess, stream)?;
+                    return b.graph_launch(exec, raw).map(|_| Response::Ok);
+                }
+                if !sess.clone_graph_oplogs.contains_key(&graph_exec) {
+                    if let Some(ops) = worker_graph_oplog(graph_exec) {
+                        sess.clone_graph_oplogs.insert(graph_exec, ops);
                     }
-                    Err(e) => {
-                        eprintln!(
-                            "[p3b] capture-replay failed for exec {graph_exec:#x}: e={e}; \
+                }
+                if !sess.clone_graph_oplogs.contains_key(&graph_exec) {
+                    let real = raw_graph(sess, graph_exec);
+                    if real == 0 {
+                        return Err(CUDA_ERROR_INVALID_HANDLE);
+                    }
+                } else {
+                    match replay_capture_graph(sess, b, graph_exec) {
+                        Ok(exec) => {
+                            replayed_exec_put(graph_exec, exec);
+                            adopt_replayed_exec(sess, graph_exec, exec);
+                            let raw = raw_stream(sess, stream)?;
+                            return b.graph_launch(exec, raw).map(|_| Response::Ok);
+                        }
+                        Err(e) => {
+                            eprintln!(
+                                "[p3b] capture-replay failed for exec {graph_exec:#x}: e={e}; \
                                    falling back to node rebuild"
-                        );
-                        // fall through to the node-rebuild / patch paths below
+                            );
+                            // fall through to the node-rebuild / patch paths below
+                        }
                     }
                 }
             }
@@ -4461,6 +4514,23 @@ mod tests {
             !g.maps[&0x1000].covered_exactly(),
             "an unverifiable chunk must stay private"
         );
+    }
+
+    #[test]
+    fn eager_graph_prereplay_requires_explicit_opt_in() {
+        assert!(!prereplay_setting(None));
+        assert!(!prereplay_setting(Some("0")));
+        assert!(!prereplay_setting(Some("false")));
+        assert!(prereplay_setting(Some("1")));
+        assert!(prereplay_setting(Some(" on ")));
+    }
+
+    #[test]
+    fn inherited_graph_logs_are_visible_to_late_channels() {
+        let exec = 0x8000_0000_0000_f123;
+        set_worker_graph_oplogs(vec![(7, exec, vec![vec![1, 2, 3]])]);
+        assert_eq!(worker_graph_oplog(exec), Some(vec![vec![1, 2, 3]]));
+        assert_eq!(worker_graph_oplogs_len(), 1);
     }
 
     /// Coverage is recorded per overlapped chunk, each hashing only its own

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -1044,7 +1044,7 @@ pub fn graph_oplogs_snapshot(token: u64) -> GraphOplogs {
     }
 }
 
-/// P3b worker: install inherited capture-replay logs for this clone. Kept
+/// Install inherited capture-replay logs for this clone. The logs remain
 /// process-global and immutable so every late-attached CUDA channel can lazily
 /// rebuild a graph the first channel has not used yet.
 pub fn set_worker_graph_oplogs(v: GraphOplogs) {
@@ -3160,19 +3160,20 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
                     copied += 1;
                     cbytes += size;
                 }
-                sort_trans(&mut sess.dptr_trans); // xlat binary-searches by base
-                gpu::set_lib_trans(&sess.dptr_trans); // forwarded-lib pointer map
-                                                      // P3b logs remain process-global so late-attached channels can
-                                                      // fetch unseen graphs on demand instead of inheriting an empty
-                                                      // thread-local after the first channel drains it.
+                // Pointer translation uses a binary search over allocation bases.
+                sort_trans(&mut sess.dptr_trans);
+                // Forwarded CUDA libraries use the same pointer map.
+                gpu::set_lib_trans(&sess.dptr_trans);
+                // Capture-replay logs remain process-global so late-attached channels can
+                // fetch unseen graphs on demand instead of inheriting an empty thread-local.
                 let inherited_graphs = worker_graph_oplogs_len();
                 eprintln!(
                     "[cuda-fork-isolate] clone resumed token {parent}: {copied} private copies \
                      ({cbytes} B), {shared} shared read-only ({sbytes} B), \
                      {inherited_graphs} inherited graph logs"
                 );
-                // P3b PRE-WARM (explicit opt in: SMOLVM_CUDA_PREREPLAY=1). Two stages,
-                // both moving one-time clone costs off the first-request path:
+                // Pre-warming is explicitly enabled with SMOLVM_CUDA_PREREPLAY=1. Two stages
+                // move one-time clone costs off the first-request path:
                 // (1) eagerly reload every staged golden module — first-touch
                 // kernel launches (prefill, eager ops) stop paying per-module
                 // reload stalls; (2) re-capture every inherited graph now

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -1922,6 +1922,27 @@ pub fn serve<S: Read + Write>(stream: S, backend: &mut dyn Backend) -> std::io::
     r
 }
 
+/// Execute one fire-and-forget request unless an earlier request in the same
+/// deferred batch already failed. Continuing after a failed handle create can
+/// feed its never-created virtual handle into a dependent driver call before
+/// the next fence reports the sticky error; libcuda may dereference such an
+/// opaque handle instead of returning a second clean error.
+fn dispatch_quiet(
+    sess: &mut Session,
+    backend: &mut dyn Backend,
+    req: Request,
+    quiet_sticky: &mut i32,
+) -> (i32, Response) {
+    if *quiet_sticky != 0 {
+        return (*quiet_sticky, Response::Ok);
+    }
+    let result = dispatch(sess, backend, req);
+    if result.0 != 0 {
+        *quiet_sticky = result.0;
+    }
+    result
+}
+
 fn serve_inner<S: Read + Write>(
     mut stream: S,
     backend: &mut dyn Backend,
@@ -1946,12 +1967,9 @@ fn serve_inner<S: Read + Write>(
                         libcall_tag(&payload[1..])
                     );
                 }
-                let (status, _) = dispatch(sess, backend, req);
+                let (status, _) = dispatch_quiet(sess, backend, req, &mut quiet_sticky);
                 if status != 0 && std::env::var_os("SMOLVM_CUDA_HOST_OPLOG").is_some() {
                     eprintln!("[op~!] status={status}");
-                }
-                if status != 0 && quiet_sticky == 0 {
-                    quiet_sticky = status;
                 }
             }
             // Fence: report (and clear) the sticky quiet failure.
@@ -2388,7 +2406,7 @@ fn serve_rings<S: Read + Write>(
                     prof.decode += t_dec.elapsed().as_micros();
                 }
                 let t_exec = std::time::Instant::now();
-                let (status, _) = dispatch(sess, backend, req);
+                let (status, _) = dispatch_quiet(sess, backend, req, &mut quiet_sticky);
                 if prof.on {
                     prof.exec += t_exec.elapsed().as_micros();
                     prof.ops += 1;
@@ -2397,9 +2415,6 @@ fn serve_rings<S: Read + Write>(
                 if status != 0 {
                     if oplog {
                         eprintln!("[op~!] status={status}");
-                    }
-                    if quiet_sticky == 0 {
-                        quiet_sticky = status;
                     }
                 }
             }
@@ -4034,13 +4049,22 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             // raw real. Recorded as the chunk's ghandle so a clone's inherited
             // ops (which carry this value) translate in the worker.
             let ghandle = handle;
-            // Burst create: resolve the session's minted virtual handle.
-            let handle = sess.vmm_vhandles.get(&handle).copied().unwrap_or(handle);
-            // Path 3 worker: an inherited golden handle must map via the worker's
-            // own physical (raw golden values are invalid in this context).
-            let handle = VMM_TRANS
-                .with(|m| m.borrow().as_ref().and_then(|t| t.get(&handle).copied()))
-                .unwrap_or(handle);
+            // Burst create: resolve the session's minted virtual handle. In a
+            // clone worker, an inherited golden handle instead resolves through
+            // the reconstructed worker map. A tagged handle found in neither
+            // table was never created (commonly because the preceding deferred
+            // MemCreateVh returned OOM); never pass it into libcuda.
+            let handle = if let Some(real) = sess.vmm_vhandles.get(&handle).copied() {
+                real
+            } else if let Some(real) =
+                VMM_TRANS.with(|m| m.borrow().as_ref().and_then(|t| t.get(&handle).copied()))
+            {
+                real
+            } else if handle & VHANDLE_TAG != 0 {
+                return Err(CUDA_ERROR_INVALID_HANDLE);
+            } else {
+                handle
+            };
             b.mem_map(va, size, offset, handle).map(|_| {
                 sess.owned_vmm_maps.insert(va, size);
                 sess.vmm_ranges.lock().unwrap().insert(va, size);
@@ -4070,7 +4094,9 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         }
         Request::MemRelease { handle } => {
             // Burst create: resolve (and retire) the session's virtual handle.
-            let handle = sess.vmm_vhandles.remove(&handle).unwrap_or(handle);
+            let guest_handle = handle;
+            let session_handle = sess.vmm_vhandles.remove(&handle);
+            let handle = session_handle.unwrap_or(handle);
             let created_here = sess.owned_vmm_handles.remove(&handle).is_some();
             // Path 3 worker: translate an inherited golden handle to the worker
             // handle backing that chunk (consumed: releasing twice is a no-op).
@@ -4090,6 +4116,9 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
                 Some(None) => {
                     eprintln!("[M2] MemRelease: unknown inherited handle {handle:#x} → no-op");
                     Ok(Response::Ok)
+                }
+                None if session_handle.is_none() && guest_handle & VHANDLE_TAG != 0 => {
+                    Err(CUDA_ERROR_INVALID_HANDLE)
                 }
                 None => b.mem_release(handle).map(|_| Response::Ok),
             }
@@ -4531,6 +4560,47 @@ mod tests {
         set_worker_graph_oplogs(vec![(7, exec, vec![vec![1, 2, 3]])]);
         assert_eq!(worker_graph_oplog(exec), Some(vec![vec![1, 2, 3]]));
         assert_eq!(worker_graph_oplogs_len(), 1);
+    }
+
+    #[test]
+    fn deferred_failure_skips_dependent_ops_until_fence() {
+        let mut sess = Session::default();
+        let mut backend = CpuBackend::default();
+        let mut sticky = 0;
+        let unknown = VHANDLE_TAG | 0x53;
+
+        let (status, _) = dispatch_quiet(
+            &mut sess,
+            &mut backend,
+            Request::MemMap {
+                va: 0x20_0000,
+                size: 0x20_0000,
+                offset: 0,
+                handle: unknown,
+            },
+            &mut sticky,
+        );
+        assert_eq!(status, CUDA_ERROR_INVALID_HANDLE);
+        assert_eq!(sticky, CUDA_ERROR_INVALID_HANDLE);
+
+        let (status, _) = dispatch_quiet(
+            &mut sess,
+            &mut backend,
+            Request::MemAlloc { bytes: 16 },
+            &mut sticky,
+        );
+        assert_eq!(status, CUDA_ERROR_INVALID_HANDLE);
+        assert!(sess.owned_dptrs.is_empty());
+
+        sticky = 0;
+        let (status, _) = dispatch_quiet(
+            &mut sess,
+            &mut backend,
+            Request::MemAlloc { bytes: 16 },
+            &mut sticky,
+        );
+        assert_eq!(status, 0);
+        assert_eq!(sess.owned_dptrs.len(), 1);
     }
 
     /// Coverage is recorded per overlapped chunk, each hashing only its own

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -14,7 +14,7 @@
 use crate::proto::{
     decode_request, encode_request, encode_response, fnv64, read_msg, write_msg, Request, Response,
 };
-use std::collections::HashMap;
+use std::collections::{hash_map::Entry, HashMap};
 use std::io::{Read, Write};
 
 /// `Ok(value)` or `Err(CUresult)` — a non-zero CUDA error code.
@@ -2412,10 +2412,8 @@ fn serve_rings<S: Read + Write>(
                     prof.ops += 1;
                     prof.dump_maybe();
                 }
-                if status != 0 {
-                    if oplog {
-                        eprintln!("[op~!] status={status}");
-                    }
+                if status != 0 && oplog {
+                    eprintln!("[op~!] status={status}");
                 }
             }
             Some(&crate::proto::FENCE_OP) if frame.len() == 1 => {
@@ -3548,9 +3546,9 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
                     let raw = raw_stream(sess, stream)?;
                     return b.graph_launch(exec, raw).map(|_| Response::Ok);
                 }
-                if !sess.clone_graph_oplogs.contains_key(&graph_exec) {
+                if let Entry::Vacant(entry) = sess.clone_graph_oplogs.entry(graph_exec) {
                     if let Some(ops) = worker_graph_oplog(graph_exec) {
-                        sess.clone_graph_oplogs.insert(graph_exec, ops);
+                        entry.insert(ops);
                     }
                 }
                 if !sess.clone_graph_oplogs.contains_key(&graph_exec) {

--- a/crates/smolvm-nvml-shim/src/lib.rs
+++ b/crates/smolvm-nvml-shim/src/lib.rs
@@ -38,7 +38,19 @@ const CU_ATTR_CC_MINOR: c_int = 76;
 /// then falls back to its static answer.
 #[cfg(unix)]
 unsafe fn cu_sym(name: &std::ffi::CStr) -> Option<*mut std::ffi::c_void> {
-    let p = libc::dlsym(libc::RTLD_DEFAULT, name.as_ptr());
+    let mut p = libc::dlsym(libc::RTLD_DEFAULT, name.as_ptr());
+    if p.is_null() {
+        // CUDA is commonly loaded with RTLD_LOCAL (including by torch), which
+        // keeps its symbols out of RTLD_DEFAULT. Open the staged driver shim
+        // explicitly so NVML queries still reflect the remoted hardware.
+        static DRIVER: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+        let handle = *DRIVER.get_or_init(|| {
+            libc::dlopen(c"libcuda.so.1".as_ptr(), libc::RTLD_NOW | libc::RTLD_GLOBAL) as usize
+        }) as *mut std::ffi::c_void;
+        if !handle.is_null() {
+            p = libc::dlsym(handle, name.as_ptr());
+        }
+    }
     if p.is_null() {
         None
     } else {

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -998,6 +998,21 @@ pub fn run_clone_worker(fd: std::os::unix::io::RawFd) -> io::Result<()> {
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(0);
+    // Reserve the golden's address ranges before retaining this worker's CUDA
+    // context, so context initialization cannot occupy them. Some drivers
+    // require non-zero address hints to use a coarser boundary than the
+    // allocation granularity, so probe aligned envelopes from small to large.
+    let clone_layout = std::env::var("SMOLVM_CUDA_CLONE_LAYOUT").ok();
+    let mut pre_reserved = Vec::new();
+    if let Some(layout) = clone_layout.as_deref() {
+        let (ranges, granularity) = reserve_clone_layout_exact(backend.as_mut(), layout, clone_dev);
+        pre_reserved = ranges;
+        tracing::info!(
+            exact = pre_reserved.len(),
+            granularity,
+            "clone-worker: reserved golden address ranges before context creation"
+        );
+    }
     let _ = backend.primary_ctx_retain(clone_dev);
     // Clone transport: consume the proc-mem advert (SMVGPVM1) the clone proxy
     // sent right after its clone preamble, so D2H/H2D reach the clone's LIVE
@@ -1026,8 +1041,9 @@ pub fn run_clone_worker(fd: std::os::unix::io::RawFd) -> io::Result<()> {
     // M2: reconstruct the golden's memory at its exact VAs from the layout the
     // daemon passed (SMOLVM_CUDA_CLONE_LAYOUT) + the golden's physical exported to
     // fds 4.. — BEFORE serving, so the clone's inherited pointers are valid verbatim.
-    if let Ok(layout) = std::env::var("SMOLVM_CUDA_CLONE_LAYOUT") {
-        let (n, vmm_trans) = reconstruct_golden_memory(backend.as_mut(), &layout, clone_dev);
+    if let Some(layout) = clone_layout.as_deref() {
+        let (n, vmm_trans) =
+            reconstruct_golden_memory(backend.as_mut(), layout, clone_dev, &pre_reserved);
         tracing::info!(
             maps = n,
             vmm_handles = vmm_trans.len(),
@@ -1235,6 +1251,119 @@ fn import_with_retry(b: &mut dyn Backend, fd: i32) -> Result<u64, i32> {
     Err(last)
 }
 
+#[cfg(unix)]
+fn clone_layout_reservations(layout: &str) -> Vec<(u64, u64)> {
+    let hx = |s: &str| u64::from_str_radix(s, 16).ok();
+    let mut ranges = Vec::new();
+    for part in layout.split('|') {
+        if let Some(entries) = part.strip_prefix("resv=") {
+            ranges.extend(entries.split(',').filter_map(|entry| {
+                let (va, size) = entry.split_once(':')?;
+                Some((hx(va)?, hx(size)?))
+            }));
+        }
+        if let Some(entries) = part.strip_prefix("aregions=") {
+            ranges.extend(entries.split(',').filter_map(|entry| {
+                let mut fields = entry.split(':');
+                Some((hx(fields.next()?)?, hx(fields.next()?)?))
+            }));
+        }
+    }
+    ranges.sort_unstable();
+    ranges.dedup();
+    ranges
+}
+
+#[cfg(unix)]
+fn clone_layout_reservation_envelopes(layout: &str, granularity: u64) -> Vec<(u64, u64)> {
+    let mask = granularity - 1;
+    let mut spans: Vec<(u64, u64)> = clone_layout_reservations(layout)
+        .into_iter()
+        .map(|(va, size)| {
+            let base = va & !mask;
+            let end = va.saturating_add(size).saturating_add(mask) & !mask;
+            (base, end)
+        })
+        .collect();
+    spans.sort_unstable();
+    let mut merged: Vec<(u64, u64)> = Vec::new();
+    for (base, end) in spans {
+        match merged.last_mut() {
+            Some((_, prior_end)) if base <= *prior_end => *prior_end = (*prior_end).max(end),
+            _ => merged.push((base, end)),
+        }
+    }
+    merged
+        .into_iter()
+        .map(|(base, end)| (base, end - base))
+        .collect()
+}
+
+#[cfg(unix)]
+fn range_is_reserved(ranges: &[(u64, u64)], va: u64, size: u64) -> bool {
+    ranges
+        .iter()
+        .any(|&(base, span)| va >= base && va.saturating_add(size) <= base.saturating_add(span))
+}
+
+#[cfg(unix)]
+fn reserve_clone_address_exact(b: &mut dyn Backend, va: u64, size: u64, align: u64) -> bool {
+    match b.mem_address_reserve_fixed(size, align, va) {
+        Ok(actual) if actual == va => true,
+        Ok(actual) => {
+            let _ = b.mem_address_free(actual, size);
+            tracing::warn!(
+                requested = va,
+                actual,
+                size,
+                "clone-worker: CUDA moved an exact-address reservation"
+            );
+            false
+        }
+        Err(e) => {
+            tracing::warn!(e, va, size, "clone-worker: exact-address reserve failed");
+            false
+        }
+    }
+}
+
+#[cfg(unix)]
+fn reserve_clone_layout_exact(
+    b: &mut dyn Backend,
+    layout: &str,
+    device: i32,
+) -> (Vec<(u64, u64)>, u64) {
+    const MIN_GRANULARITY: u64 = 1 << 16;
+    const MAX_HINT_GRANULARITY: u64 = 1 << 30;
+
+    let mut granularity = b
+        .mem_get_allocation_granularity(device, 0)
+        .unwrap_or(1 << 21)
+        .max(MIN_GRANULARITY)
+        .next_power_of_two();
+    while granularity <= MAX_HINT_GRANULARITY {
+        let envelopes = clone_layout_reservation_envelopes(layout, granularity);
+        let mut reserved = Vec::with_capacity(envelopes.len());
+        let mut complete = true;
+        for &(va, size) in &envelopes {
+            if reserve_clone_address_exact(b, va, size, granularity) {
+                reserved.push((va, size));
+            } else {
+                complete = false;
+                break;
+            }
+        }
+        if complete {
+            return (reserved, granularity);
+        }
+        for (va, size) in reserved {
+            let _ = b.mem_address_free(va, size);
+        }
+        granularity = granularity.saturating_mul(2);
+    }
+    (Vec::new(), granularity)
+}
+
 /// M2: rebuild the golden's VMM layout in THIS worker's context at the golden's
 /// EXACT VAs. `layout` = `"resv=va:size,…|maps=va:size:fdidx:loaded:ghandle,…"` (hex);
 /// each map's physical was exported by the daemon to fd `4 + fdidx`. We import +
@@ -1250,6 +1379,7 @@ fn reconstruct_golden_memory(
     b: &mut dyn Backend,
     layout: &str,
     device: i32,
+    pre_reserved: &[(u64, u64)],
 ) -> (usize, std::collections::HashMap<u64, u64>) {
     let mut vmm_trans = std::collections::HashMap::new();
     let (mut resv_s, mut maps_s, mut aregions_s, mut allocs_s) = ("", "", "", "");
@@ -1275,8 +1405,10 @@ fn reconstruct_golden_memory(
     for e in resv_s.split(',').filter(|s| !s.is_empty()) {
         if let Some((va, size)) = e.split_once(':') {
             if let (Some(va), Some(size)) = (hx(va), hx(size)) {
-                if let Err(e) = b.mem_address_reserve_fixed(size, 0, va) {
-                    tracing::warn!(e, va, "M2: reserve-fixed failed");
+                if !range_is_reserved(pre_reserved, va, size)
+                    && !reserve_clone_address_exact(b, va, size, 0)
+                {
+                    tracing::warn!(va, size, "M2: reservation unavailable at golden VA");
                 }
             }
         }
@@ -1447,8 +1579,10 @@ fn reconstruct_golden_memory(
         // poisons the context: e=700 on every later op — found via QA-1l,
         // first-ever cuBLAS init inside a clone).
         for &(b0, sz, _) in &regions {
-            if let Err(e) = b.mem_address_reserve_fixed(sz, 0, b0) {
-                tracing::warn!(e, va = b0, size = sz, "M2-alloc: VA guard reserve failed");
+            if !range_is_reserved(pre_reserved, b0, sz)
+                && !reserve_clone_address_exact(b, b0, sz, 0)
+            {
+                tracing::warn!(va = b0, size = sz, "M2-alloc: VA guard reserve failed");
             }
         }
         let total: u64 = regions.iter().map(|r| r.1).sum();
@@ -2760,9 +2894,9 @@ impl Drop for FileLock {
 #[cfg(all(test, target_os = "linux"))]
 mod mps_tests {
     use super::{
-        clone_worker_share_env, create_private_mps_paths, decode_attach_procmem,
-        disabled_worker_route, encode_attach_procmem, mps_enabled, recv_fd, send_fd,
-        unique_live_clone_worker,
+        clone_layout_reservation_envelopes, clone_worker_share_env, create_private_mps_paths,
+        decode_attach_procmem, disabled_worker_route, encode_attach_procmem, mps_enabled,
+        range_is_reserved, recv_fd, send_fd, unique_live_clone_worker,
     };
     use std::collections::HashMap;
     use std::io;
@@ -2848,6 +2982,24 @@ mod mps_tests {
         assert_eq!(disabled_worker_route(3, false, true), Some(true));
         assert_eq!(disabled_worker_route(3, true, false), Some(true));
         assert_eq!(disabled_worker_route(3, true, true), None);
+    }
+
+    #[test]
+    fn clone_address_envelopes_align_merge_and_cover_original_ranges() {
+        let layout = concat!(
+            "resv=312400000:200000,314000000:1400000,|maps=|",
+            "aregions=7a5ed2400000:200000:0,7a5ed2600000:200000:200000,"
+        );
+        let ranges = clone_layout_reservation_envelopes(layout, 0x2000000);
+
+        assert_eq!(
+            ranges,
+            vec![(0x312000000, 0x4000000), (0x7a5ed2000000, 0x2000000)]
+        );
+        assert!(range_is_reserved(&ranges, 0x312400000, 0x200000));
+        assert!(range_is_reserved(&ranges, 0x314000000, 0x1400000));
+        assert!(range_is_reserved(&ranges, 0x7a5ed2600000, 0x200000));
+        assert!(!range_is_reserved(&ranges, 0x316000000, 0x200000));
     }
 
     #[test]

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -1816,6 +1816,13 @@ fn clone_worker_share_env(requested: bool, configured: Option<&str>) -> Option<&
     }
 }
 
+/// Decide whether a clone-marked connection should bypass worker routing when
+/// worker mode is disabled. Real channels fall through to ordinary serving;
+/// warm dials carry no Init and must be consumed instead of parking forever.
+fn disabled_worker_route(flags: u8, workers: bool, isolate: bool) -> Option<bool> {
+    (!workers || !isolate).then_some(flags & 2 != 0)
+}
+
 /// Route one just-accepted connection: strip the clone preamble (always), and
 /// when it marks an isolating fork clone, spawn/refuse its worker. Returns
 /// `true` when the connection was consumed (routed or rejected); `false` means
@@ -1831,6 +1838,20 @@ fn route_clone_connection(
     let Some((clone_id, flags)) = consume_clone_preamble(fd) else {
         return false;
     };
+    // The preamble must always be stripped, but a warm-dial connection must
+    // not bypass the worker-mode gate below. Previously the warm branch spawned
+    // a Path-3 worker unconditionally, so `SMOLVM_CUDA_FORK_WORKERS` unset still
+    // mixed worker contexts into the legacy single-context path.
+    if let Some(consumed) = disabled_worker_route(
+        flags,
+        std::env::var_os("SMOLVM_CUDA_FORK_WORKERS").is_some(),
+        std::env::var_os("SMOLVM_CUDA_FORK_ISOLATE").is_some(),
+    ) {
+        // Real clone connections still fall through to the shared-context
+        // server. A warm dial has no Init payload, so consume it instead of
+        // parking an otherwise permanent server thread on an idle socket.
+        return consumed;
+    }
     let share_weights = flags & 1 != 0;
     // Warm dial (flag bit 1): the clone VM's proxy dials at STARTUP so worker
     // spawn (CUDA init + memory reconstruction + module/graph pre-warm) runs
@@ -2740,7 +2761,8 @@ impl Drop for FileLock {
 mod mps_tests {
     use super::{
         clone_worker_share_env, create_private_mps_paths, decode_attach_procmem,
-        encode_attach_procmem, mps_enabled, recv_fd, send_fd, unique_live_clone_worker,
+        disabled_worker_route, encode_attach_procmem, mps_enabled, recv_fd, send_fd,
+        unique_live_clone_worker,
     };
     use std::collections::HashMap;
     use std::io;
@@ -2818,6 +2840,14 @@ mod mps_tests {
         assert_eq!(clone_worker_share_env(true, Some("false")), Some("0"));
         assert_eq!(clone_worker_share_env(true, Some("off")), Some("0"));
         assert_eq!(clone_worker_share_env(false, None), None);
+    }
+
+    #[test]
+    fn disabled_worker_mode_consumes_only_warm_dials() {
+        assert_eq!(disabled_worker_route(1, false, true), Some(false));
+        assert_eq!(disabled_worker_route(3, false, true), Some(true));
+        assert_eq!(disabled_worker_route(3, true, false), Some(true));
+        assert_eq!(disabled_worker_route(3, true, true), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fix CUDA worker routing, inherited address reservation, lazy graph replay, and deferred-batch error handling for forked workloads.
- Resolve locally loaded CUDA libraries for NVML and report configured CUDA allocation limits to guests.

## Validation

- `cargo test -p smolvm-cuda --lib`
- `cargo check`
- `cargo fmt --check`
- Validated concurrent forked training on an H100.