### PR TITLE
Bump libkrun to reap leaked macOS guest-RAM files and validate guest directory-entry names

### DIFF
--- a/lib/libkrun.dylib
+++ b/lib/libkrun.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5a9857af1c3b76732e0ff1820dfad8d7c325a24df0351811bc6d0734d4ac9772
-size 6202528
+oid sha256:1114beddf44f10605af389cfb450dd2357bc98d92c4f6cf13dafec073721af43
+size 6200288

--- a/lib/libkrun.provenance
+++ b/lib/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=cbd00771f11a3d3ce011df992e915d20e50f9e0b
+libkrun=512a3b65cdf03ad92b3f0eb62045d826dd63d7fc
 libkrunfw=1ba61ba8e0ed6670182020d0be417e84548b0723


### PR DESCRIPTION
Advances the libkrun submodule and rebuilds the signed macOS dylib so orphaned forkable guest-RAM files are reaped by pid liveness on the next start, and guest directory-entry names that are not a single path component are rejected.