### PR TITLE
Add best-effort CUDA auto-graph execution

### DIFF
--- a/crates/smolvm-agent/src/cuda.rs
+++ b/crates/smolvm-agent/src/cuda.rs
@@ -14,7 +14,7 @@
 //! `CAP_SYS_ADMIN`, older libkrun), so forwarding it is always safe.
 
 /// The env var the launcher sets on the agent, and that the guest shim reads.
-const ZEROCOPY_ENV: &str = "SMOLVM_CUDA_ZEROCOPY";
+const ZEROCOPY_ENV: &str = smolvm_protocol::guest_env::CUDA_ZEROCOPY;
 
 /// Whether CUDA guest-RAM zero-copy was requested for this VM.
 pub fn zerocopy_enabled() -> bool {

--- a/crates/smolvm-protocol/src/guest_env.rs
+++ b/crates/smolvm-protocol/src/guest_env.rs
@@ -23,6 +23,12 @@ pub const VALUE_ON: &str = "1";
 /// This is a boolean sentinel — the value is [`VALUE_ON`] when set.
 pub const GPU: &str = "SMOLVM_GPU";
 
+/// Env var the host sets on guest init when CUDA-over-vsock is available.
+///
+/// The guest agent uses it to stage the bundled CUDA shims into workload
+/// containers and the runtime shim uses it to enable guest-RAM zero-copy.
+pub const CUDA_ZEROCOPY: &str = "SMOLVM_CUDA_ZEROCOPY";
+
 /// Env var the host sets on guest init to signal Rosetta 2 x86_64 translation
 /// was requested (and is available on the host).
 ///

--- a/crates/smolvm-smolfile/src/lib.rs
+++ b/crates/smolvm-smolfile/src/lib.rs
@@ -23,6 +23,7 @@
 //! | `memory` | int | No | Memory in MiB (default: 256). |
 //! | `net` | bool | No | Enable outbound networking via NAT. |
 //! | `cuda` | bool | No | Enable CUDA-over-vsock (host NVIDIA GPU). |
+//! | `auto_graph` | bool | No | Best-effort framework CUDA graphs; implies `cuda`. |
 //! | `storage` | int | No | Storage disk size in GiB. |
 //! | `overlay` | int | No | Overlay disk size in GiB. |
 //! | `ports` | string[] | No | Port mappings (`"host:guest"`). Prefer `[dev] ports`. |
@@ -244,6 +245,9 @@ pub struct Smolfile {
     /// Enable CUDA-over-vsock: remote guest CUDA Driver-API calls to the
     /// host NVIDIA GPU. Linux-only; requires a host NVIDIA driver.
     pub cuda: Option<bool>,
+    /// Ask compatible CUDA frameworks to graph safe compiled regions.
+    /// Implies `cuda`; arbitrary eager CUDA calls are not captured.
+    pub auto_graph: Option<bool>,
     /// Expose the guest's Docker daemon socket to the host as a Unix socket
     /// (`DOCKER_HOST=unix://…`). Requires dockerd running inside the VM.
     pub docker_socket: Option<bool>,
@@ -561,6 +565,18 @@ protocol = "http"
 
         let sf = parse("").unwrap();
         assert_eq!(sf.cuda, None);
+    }
+
+    #[test]
+    fn parse_auto_graph_field() {
+        let sf = parse("auto_graph = true").unwrap();
+        assert_eq!(sf.auto_graph, Some(true));
+
+        let sf = parse("auto_graph = false").unwrap();
+        assert_eq!(sf.auto_graph, Some(false));
+
+        let sf = parse("").unwrap();
+        assert_eq!(sf.auto_graph, None);
     }
 
     #[test]

--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -571,6 +571,17 @@ pub fn launch_agent_vm_dynamic(
         }
     }
 
+    // The packed launcher wires CUDA directly instead of going through the
+    // shared vsock-service builder, so it must carry the same guest feature
+    // sentinel explicitly. Without it the agent never stages the bundled
+    // shims and `pack run --cuda` boots a CUDA bridge that workloads cannot use.
+    if config.cuda_socket.is_some() {
+        let cuda_env = format!("{}={}", guest_env::CUDA_ZEROCOPY, guest_env::VALUE_ON);
+        if let Ok(cstr) = CString::new(cuda_env) {
+            env_strings.push(cstr);
+        }
+    }
+
     // Enable Rosetta only when requested AND actually available on this host, so
     // a stray `--rosetta` on a non-Rosetta host degrades to a no-op rather than a
     // dangling virtiofs tag the guest would fail to mount. The guest agent reads

--- a/src/agent/vsock_service.rs
+++ b/src/agent/vsock_service.rs
@@ -11,7 +11,7 @@
 //! Adding a new vsock-backed capability is one `impl VsockService` plus one line
 //! in [`registry`] — no new control flow in the launcher.
 
-use smolvm_protocol::ports;
+use smolvm_protocol::{guest_env, ports};
 use std::path::Path;
 
 /// The optional, host-derived socket paths a service resolves itself from.
@@ -102,7 +102,7 @@ impl VsockService for CudaService {
             // only uses it when it can read `/proc/self/pagemap` (guest is root)
             // and the host published the mapping; otherwise it falls back to the
             // byte-shipping path transparently.
-            guest_env: &[("SMOLVM_CUDA_ZEROCOPY", "1")],
+            guest_env: &[(guest_env::CUDA_ZEROCOPY, guest_env::VALUE_ON)],
         })
     }
 }

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -727,7 +727,7 @@ pub async fn create_machine(
         memory_mb: Some(mem),
         network: Some(network),
         gpu: Some(req.gpu),
-        cuda: Some(req.cuda),
+        cuda: Some(req.cuda || req.auto_graph),
         storage_gb: req.storage_gb,
         overlay_gb: req.overlay_gb,
         allowed_cidrs: normalized_cidrs,
@@ -741,6 +741,10 @@ pub async fn create_machine(
     // must be configured locally via the CLI.
     crate::api::handlers::validate_request_secrets(&req.secrets)?;
     crate::api::handlers::validate_request_env(&req.env)?;
+    let mut workload_env = merge_request_env(env, &req.env);
+    if req.auto_graph {
+        crate::util::enable_cuda_auto_graph_env(&mut workload_env);
+    }
 
     // Complete registration: persists to DB + registers in ApiState
     let complete_result = guard.complete(MachineRegistration {
@@ -770,7 +774,7 @@ pub async fn create_machine(
         source_smolmachine,
         entrypoint,
         cmd,
-        env: merge_request_env(env, &req.env),
+        env: workload_env,
         workdir: req.workdir.clone().or(workdir),
         // Record secrets = packed refs from --from (validated Untrusted above)
         // merged with request refs (validated Untrusted at ~line 333); request
@@ -2409,6 +2413,7 @@ mod tests {
             network: false,
             gpu: false,
             cuda: false,
+            auto_graph: false,
             entrypoint: vec![],
             cmd: vec![],
             docker_socket: false,
@@ -2471,6 +2476,52 @@ mod tests {
         assert_eq!(req.env[0].name, "FOO");
         assert_eq!(req.env[0].value, "bar");
         assert_eq!(req.workdir.as_deref(), Some("/app"));
+    }
+
+    #[test]
+    fn create_request_auto_graph_is_opt_in() {
+        let enabled: CreateMachineRequest = serde_json::from_value(serde_json::json!({
+            "name": "api-vm",
+            "autoGraph": true
+        }))
+        .unwrap();
+        assert!(enabled.auto_graph);
+
+        let defaulted: CreateMachineRequest = serde_json::from_value(serde_json::json!({
+            "name": "api-vm"
+        }))
+        .unwrap();
+        assert!(!defaulted.auto_graph);
+    }
+
+    #[test]
+    fn auto_graph_policy_overrides_conflicting_request_env() {
+        let mut env = merge_request_env(
+            vec![(
+                crate::util::CUDA_AUTO_GRAPH_ENV.to_string(),
+                "0".to_string(),
+            )],
+            &[crate::api::types::EnvVar {
+                name: crate::util::TORCHINDUCTOR_CUDAGRAPHS_ENV.to_string(),
+                value: "0".to_string(),
+            }],
+        );
+
+        crate::util::enable_cuda_auto_graph_env(&mut env);
+
+        assert_eq!(
+            env,
+            vec![
+                (
+                    crate::util::CUDA_AUTO_GRAPH_ENV.to_string(),
+                    "1".to_string()
+                ),
+                (
+                    crate::util::TORCHINDUCTOR_CUDAGRAPHS_ENV.to_string(),
+                    "1".to_string(),
+                ),
+            ]
+        );
     }
 
     #[test]

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -505,6 +505,10 @@ pub struct CreateMachineRequest {
     /// Enable CUDA remoting (host NVIDIA GPU via the bundled shims).
     #[serde(default)]
     pub cuda: bool,
+    /// Ask compatible CUDA frameworks to graph safe compiled regions.
+    /// Implies CUDA; arbitrary eager CUDA calls are not captured.
+    #[serde(default)]
+    pub auto_graph: bool,
     /// Workload entrypoint. With `cmd`, overrides the image's (or the
     /// `.smolmachine` artifact's) own entrypoint+cmd, matching the CLI's
     /// `machine create -- <command>` precedence. Empty = use the image's.

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -531,6 +531,11 @@ pub struct RunCmd {
     #[arg(long, help_heading = "Hardware")]
     pub cuda: bool,
 
+    /// Ask compatible CUDA frameworks to graph safe compiled regions.
+    /// Implies --cuda; arbitrary eager CUDA calls are not captured.
+    #[arg(long, help_heading = "Hardware")]
+    pub auto_graph: bool,
+
     /// Expose the guest's Docker daemon socket to the host as a Unix socket
     /// (DOCKER_HOST=unix://…). Requires dockerd running in the VM.
     #[arg(long, help_heading = "Network")]
@@ -869,6 +874,10 @@ impl RunCmd {
         // flags pass through. Flags the sidecar runner can't honor are rejected
         // at parse time via `conflicts_with_all` on `from`.
         if let Some(from) = self.from {
+            let mut env = self.env;
+            if self.auto_graph {
+                smolvm::util::enable_cuda_auto_graph_env_specs(&mut env);
+            }
             return crate::cli::pack_run::PackRunCmd {
                 sidecar: Some(from),
                 command: self.command,
@@ -876,7 +885,7 @@ impl RunCmd {
                 tty: self.tty,
                 timeout: self.timeout,
                 workdir: self.workdir,
-                env: self.env,
+                env,
                 volume: self.volume,
                 port: self.port,
                 net: self.net,
@@ -888,7 +897,8 @@ impl RunCmd {
                 force_extract: false,
                 info: false,
                 debug: false,
-                cuda: false,
+                cuda: self.cuda,
+                auto_graph: self.auto_graph,
             }
             .run();
         }
@@ -942,6 +952,10 @@ impl RunCmd {
         )?;
 
         let mut params = params;
+        if self.auto_graph {
+            smolvm::util::enable_cuda_auto_graph_env_specs(&mut params.env);
+            params.cuda = true;
+        }
         params.dns_filter_hosts = match (params.dns_filter_hosts.take(), cli_dns_filter_hosts) {
             (Some(mut from_smolfile), Some(mut from_cli)) => {
                 from_smolfile.append(&mut from_cli);
@@ -1003,7 +1017,8 @@ impl RunCmd {
                     force_extract: false,
                     info: false,
                     debug: false,
-                    cuda: false,
+                    cuda: self.cuda || params.cuda,
+                    auto_graph: self.auto_graph,
                 }
                 .run();
             }
@@ -1056,7 +1071,8 @@ impl RunCmd {
                 force_extract: false,
                 info: false,
                 debug: false,
-                cuda: false,
+                cuda: self.cuda || params.cuda,
+                auto_graph: self.auto_graph,
             }
             .run();
         }
@@ -1887,6 +1903,36 @@ mod tests {
         .is_err());
     }
 
+    #[test]
+    fn run_accepts_auto_graph_flag() {
+        let cli = TestMachineCli::parse_from([
+            "machine",
+            "run",
+            "--auto-graph",
+            "--image",
+            "alpine",
+            "--",
+            "true",
+        ]);
+
+        let MachineCmd::Run(cmd) = cli.command else {
+            panic!("expected machine run command");
+        };
+        assert!(cmd.auto_graph);
+        assert!(!cmd.cuda, "auto-graph implies CUDA during parameter merge");
+    }
+
+    #[test]
+    fn create_accepts_auto_graph_flag() {
+        let cli =
+            TestMachineCli::parse_from(["machine", "create", "--name", "golden", "--auto-graph"]);
+
+        let MachineCmd::Create(cmd) = cli.command else {
+            panic!("expected machine create command");
+        };
+        assert!(cmd.auto_graph);
+    }
+
     // Documents the clap parsing behaviour: positionals before "--" land in
     // `command`, not `image`.  is_likely_image_ref() catches the unambiguous
     // cases before a VM is booted.
@@ -2385,6 +2431,11 @@ pub struct CreateCmd {
     #[arg(long)]
     pub cuda: bool,
 
+    /// Ask compatible CUDA frameworks to graph safe compiled regions.
+    /// Implies --cuda; arbitrary eager CUDA calls are not captured.
+    #[arg(long)]
+    pub auto_graph: bool,
+
     /// Expose the guest's Docker daemon socket to the host as a Unix socket
     /// (DOCKER_HOST=unix://…). Requires dockerd running in the VM.
     #[arg(long)]
@@ -2493,6 +2544,10 @@ impl CreateCmd {
             cli_allow_cidrs,
         )?;
         let mut params = params;
+        if self.auto_graph {
+            smolvm::util::enable_cuda_auto_graph_env_specs(&mut params.env);
+            params.cuda = true;
+        }
         params.dns_filter_hosts = match (params.dns_filter_hosts.take(), cli_dns_filter_hosts) {
             (Some(mut from_smolfile), Some(mut from_cli)) => {
                 from_smolfile.append(&mut from_cli);
@@ -2684,6 +2739,9 @@ impl CreateCmd {
             env: {
                 let mut env = manifest.env;
                 env.extend(self.env.iter().cloned());
+                if self.auto_graph {
+                    smolvm::util::enable_cuda_auto_graph_env_specs(&mut env);
+                }
                 env
             },
             workdir: manifest.workdir,
@@ -2699,7 +2757,7 @@ impl CreateCmd {
             health_retries: None,
             health_startup_grace_secs: None,
             ssh_agent: self.ssh_agent,
-            cuda: self.cuda,
+            cuda: self.cuda || self.auto_graph,
             docker_socket: self.docker_socket,
             dns_filter_hosts: None,
             published_sockets: parse_published_sockets(&self.expose_socket, &self.mount_socket)?,

--- a/src/cli/pack_run.rs
+++ b/src/cli/pack_run.rs
@@ -268,6 +268,11 @@ pub struct PackRunCmd {
     /// was created with CUDA, or via `SMOLVM_CUDA=1`.
     #[arg(long)]
     pub cuda: bool,
+
+    /// Ask compatible CUDA frameworks to graph safe compiled regions.
+    /// Implies --cuda; arbitrary eager CUDA calls are not captured.
+    #[arg(long)]
+    pub auto_graph: bool,
 }
 
 impl PackRunCmd {
@@ -401,7 +406,7 @@ impl PackRunCmd {
         // `--cuda` override, or `SMOLVM_CUDA=1`. When on, the parent runs a host
         // CUDA server on `cuda_sock` and the launcher bridges the guest's vsock
         // CUDA port to it (the guest's LD_PRELOADed shims connect out).
-        let cuda_enabled = manifest.cuda || self.cuda || env_flag("SMOLVM_CUDA");
+        let cuda_enabled = manifest.cuda || self.cuda || self.auto_graph || env_flag("SMOLVM_CUDA");
         let cuda_sock = runtime_dir.path().join("cuda.sock");
 
         // Compute auto-sized storage before creating the disk so both the
@@ -435,7 +440,7 @@ impl PackRunCmd {
             network_backend: self.net_backend,
             dns: None,
             gpu: manifest.gpu,
-            cuda: manifest.cuda,
+            cuda: cuda_enabled,
             storage_gib,
             overlay_gib: self.overlay,
             gpu_vram_mib: None,
@@ -962,7 +967,10 @@ fn execute_command(
     mounts: &[smolvm::data::storage::HostMount],
 ) -> smolvm::Result<i32> {
     let command = build_command(manifest, &args.command);
-    let env = build_env(manifest, &args.env)?;
+    let mut env = build_env(manifest, &args.env)?;
+    if args.auto_graph {
+        smolvm::util::enable_cuda_auto_graph_env(&mut env);
+    }
     let workdir = args.workdir.clone().or_else(|| manifest.workdir.clone());
 
     let params = ExecParams {
@@ -1352,6 +1360,7 @@ fn run_ephemeral(
                 info: false,
                 debug,
                 cuda: args.cuda,
+                auto_graph: false,
             };
             cmd.run()
         }

--- a/src/cli/smolfile.rs
+++ b/src/cli/smolfile.rs
@@ -96,6 +96,7 @@ pub fn build_create_params(
             });
         }
     };
+    let auto_graph = sf.auto_graph.unwrap_or(false);
 
     // Image: CLI > Smolfile > None
     let image = cli_image.or(sf.image);
@@ -139,6 +140,9 @@ pub fn build_create_params(
     let mut env: Vec<String> = sf.env.into_iter().map(|e| e.trim().to_string()).collect();
     env.extend(dev.env.into_iter().map(|e| e.trim().to_string()));
     env.extend(cli_env.into_iter().map(|e| e.trim().to_string()));
+    if auto_graph {
+        smolvm::util::enable_cuda_auto_graph_env_specs(&mut env);
+    }
 
     // Init: [dev].init > top-level init, then CLI extends
     let sf_init = if !dev.init.is_empty() {
@@ -281,7 +285,7 @@ pub fn build_create_params(
         health_retries,
         health_startup_grace_secs,
         ssh_agent: sf.auth.as_ref().and_then(|a| a.ssh_agent).unwrap_or(false),
-        cuda: sf.cuda.unwrap_or(false),
+        cuda: sf.cuda.unwrap_or(false) || auto_graph,
         docker_socket: sf.docker_socket.unwrap_or(false),
         gpu,
         gpu_vram_mib: sf.gpu_vram,
@@ -435,4 +439,52 @@ pub fn resolve_pack_config(
         gpu: cli_gpu || sf.gpu.unwrap_or(false),
         secret_refs: sf.secrets,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auto_graph_smolfile_enables_cuda_and_framework_policy() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("Smolfile");
+        std::fs::write(
+            &path,
+            "auto_graph = true\nenv = [\"KEEP=yes\", \"TORCHINDUCTOR_CUDAGRAPHS=0\"]\n",
+        )
+        .unwrap();
+
+        let params = build_create_params(
+            "graph-vm".to_string(),
+            None,
+            None,
+            vec![],
+            DEFAULT_MICROVM_CPU_COUNT,
+            DEFAULT_MICROVM_MEMORY_MIB,
+            vec![],
+            vec![],
+            false,
+            None,
+            None,
+            vec![],
+            vec![],
+            None,
+            Some(path),
+            None,
+            None,
+            vec![],
+        )
+        .unwrap();
+
+        assert!(params.cuda);
+        assert_eq!(
+            params.env,
+            vec![
+                "KEEP=yes".to_string(),
+                "SMOLVM_CUDA_AUTO_GRAPH=1".to_string(),
+                "TORCHINDUCTOR_CUDAGRAPHS=1".to_string(),
+            ]
+        );
+    }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,6 +8,12 @@ pub use smolvm_protocol::retry::{
     is_transient_io_error, is_transient_network_error, retry_with_backoff, RetryConfig,
 };
 
+/// Workload marker set when smolvm's best-effort CUDA graph policy is enabled.
+pub const CUDA_AUTO_GRAPH_ENV: &str = "SMOLVM_CUDA_AUTO_GRAPH";
+
+/// PyTorch Inductor switch for CUDA graphs in compatible compiled regions.
+pub const TORCHINDUCTOR_CUDAGRAPHS_ENV: &str = "TORCHINDUCTOR_CUDAGRAPHS";
+
 /// Generate a short random ID for auto-naming machines.
 ///
 /// Produces an 8-character hex string (e.g., "a1b2c3d4") from 4 bytes
@@ -99,6 +105,26 @@ pub fn parse_env_list(env_args: &[String]) -> Vec<(String, String)> {
     env_args.iter().filter_map(|e| parse_env_spec(e)).collect()
 }
 
+/// Enable best-effort CUDA graphs in a parsed workload environment.
+///
+/// Existing values are replaced so an explicit auto-graph request has one
+/// canonical result. Frameworks remain responsible for deciding which regions
+/// are safe to capture.
+pub fn enable_cuda_auto_graph_env(env: &mut Vec<(String, String)>) {
+    for name in [CUDA_AUTO_GRAPH_ENV, TORCHINDUCTOR_CUDAGRAPHS_ENV] {
+        env.retain(|(existing, _)| existing != name);
+        env.push((name.to_string(), "1".to_string()));
+    }
+}
+
+/// Enable best-effort CUDA graphs in `KEY=VALUE` workload specifications.
+pub fn enable_cuda_auto_graph_env_specs(env: &mut Vec<String>) {
+    for name in [CUDA_AUTO_GRAPH_ENV, TORCHINDUCTOR_CUDAGRAPHS_ENV] {
+        env.retain(|spec| spec.split_once('=').map_or(spec.as_str(), |(key, _)| key) != name);
+        env.push(format!("{name}=1"));
+    }
+}
+
 /// Parse a byte size like `16GiB`, `16G`, `512M`, or a plain byte count
 /// (`17179869184`). Suffixes are binary (1K = 1024); `K/M/G/T`, optionally with
 /// a trailing `i` and/or `B`, are accepted case-insensitively.
@@ -152,6 +178,46 @@ mod tests {
         // Empty key is rejected.
         assert_eq!(parse_env_spec("=bar"), None);
         assert_eq!(parse_env_spec(""), None);
+    }
+
+    #[test]
+    fn auto_graph_env_replaces_conflicting_values() {
+        let mut env = vec![
+            ("KEEP".to_string(), "yes".to_string()),
+            (TORCHINDUCTOR_CUDAGRAPHS_ENV.to_string(), "0".to_string()),
+            (CUDA_AUTO_GRAPH_ENV.to_string(), "old".to_string()),
+        ];
+
+        enable_cuda_auto_graph_env(&mut env);
+
+        assert_eq!(
+            env,
+            vec![
+                ("KEEP".to_string(), "yes".to_string()),
+                (CUDA_AUTO_GRAPH_ENV.to_string(), "1".to_string()),
+                (TORCHINDUCTOR_CUDAGRAPHS_ENV.to_string(), "1".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn auto_graph_env_specs_replaces_conflicting_values() {
+        let mut env = vec![
+            "KEEP=yes".to_string(),
+            "TORCHINDUCTOR_CUDAGRAPHS=0".to_string(),
+            "SMOLVM_CUDA_AUTO_GRAPH".to_string(),
+        ];
+
+        enable_cuda_auto_graph_env_specs(&mut env);
+
+        assert_eq!(
+            env,
+            vec![
+                "KEEP=yes".to_string(),
+                "SMOLVM_CUDA_AUTO_GRAPH=1".to_string(),
+                "TORCHINDUCTOR_CUDAGRAPHS=1".to_string(),
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Adds a transparent CUDA graph policy for compatible compiled workloads and fixes shim injection for packed CUDA execution.