### PR TITLE
Preserve CUDA fork-pool state and VMM isolation

### DIFF
--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -1336,6 +1336,78 @@ pub fn set_vmm_trans(map: HashMap<u64, u64>) {
     VMM_TRANS.with(|m| *m.borrow_mut() = Some(map));
 }
 
+/// Address ranges whose reconstructed physical allocation is shared with the
+/// frozen golden. Clone resume can replay the golden allocator's original
+/// `cuMemSetAccess(...READWRITE)` calls after reconstruction; those replays
+/// must not silently undo the read-only mapping installed by the worker.
+static WORKER_SHARED_VMM_RANGES: std::sync::Mutex<Vec<(u64, u64)>> =
+    std::sync::Mutex::new(Vec::new());
+
+pub fn set_worker_shared_vmm_ranges(ranges: Vec<(u64, u64)>) {
+    *WORKER_SHARED_VMM_RANGES.lock().unwrap() = ranges;
+}
+
+fn vmm_access_partitions(va: u64, size: u64, shared: &[(u64, u64)]) -> Vec<(u64, u64, bool)> {
+    let Some(end) = va.checked_add(size) else {
+        return vec![(va, size, false)];
+    };
+    let mut intersections: Vec<(u64, u64)> = shared
+        .iter()
+        .filter_map(|&(base, len)| {
+            let shared_end = base.checked_add(len)?;
+            let start = va.max(base);
+            let stop = end.min(shared_end);
+            (start < stop).then_some((start, stop))
+        })
+        .collect();
+    intersections.sort_unstable();
+    let mut merged: Vec<(u64, u64)> = Vec::new();
+    for (start, stop) in intersections {
+        if let Some(last) = merged.last_mut().filter(|last| start <= last.1) {
+            last.1 = last.1.max(stop);
+        } else {
+            merged.push((start, stop));
+        }
+    }
+    let mut result = Vec::new();
+    let mut cursor = va;
+    for (start, stop) in merged {
+        if cursor < start {
+            result.push((cursor, start - cursor, false));
+        }
+        result.push((start, stop - start, true));
+        cursor = stop;
+    }
+    if cursor < end {
+        result.push((cursor, end - cursor, false));
+    }
+    result
+}
+
+fn forget_worker_shared_vmm_range(va: u64, size: u64) {
+    let Some(end) = va.checked_add(size) else {
+        return;
+    };
+    let mut ranges = WORKER_SHARED_VMM_RANGES.lock().unwrap();
+    let mut retained = Vec::with_capacity(ranges.len() + 1);
+    for &(base, len) in ranges.iter() {
+        let Some(shared_end) = base.checked_add(len) else {
+            continue;
+        };
+        if shared_end <= va || base >= end {
+            retained.push((base, len));
+            continue;
+        }
+        if base < va {
+            retained.push((base, va - base));
+        }
+        if shared_end > end {
+            retained.push((end, shared_end - end));
+        }
+    }
+    *ranges = retained;
+}
+
 /// Worker-mode: private copies of the golden's non-VMM (`cudaMalloc`)
 /// allocations, made during reconstruction — `(golden_dptr, size, copy)`.
 /// Process-global and NON-draining: every serving thread's isolate session
@@ -1841,6 +1913,89 @@ fn cow_written(sess: &mut Session, b: &mut dyn Backend, req: &Request) {
             cow_one(sess, b, *dst)
         }
         _ => {}
+    }
+}
+
+/// Address-preserving COW for shared VMM chunks in a clone worker. An
+/// expandable-segment chunk can be reused for mutable training data after the
+/// snapshot, so its first explicit write must replace the shared mapping with
+/// private physical memory at the same virtual address.
+fn cow_worker_vmm_range(
+    sess: &Session,
+    b: &mut dyn Backend,
+    dptr: u64,
+    bytes: u64,
+) -> CuResult<()> {
+    if bytes == 0 {
+        return Ok(());
+    }
+    let write_end = dptr.saturating_add(bytes);
+    let mut ranges = WORKER_SHARED_VMM_RANGES.lock().unwrap();
+    let device = if sess.device_pinned {
+        sess.device_base
+    } else {
+        0
+    };
+    while let Some(index) = ranges.iter().position(|&(base, size)| {
+        let end = base.saturating_add(size);
+        dptr < end && base < write_end
+    }) {
+        let (base, size) = ranges[index];
+        let private = b.mem_create(size, device)?;
+        let snapshot = match b.memcpy_dtoh(base, size, 0) {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                let _ = b.mem_release(private);
+                return Err(error);
+            }
+        };
+        if let Err(error) = b.ctx_synchronize() {
+            let _ = b.mem_release(private);
+            return Err(error);
+        }
+        if let Err(error) = b.mem_unmap(base, size) {
+            let _ = b.mem_release(private);
+            return Err(error);
+        }
+        if let Err(error) = b.mem_map(base, size, 0, private) {
+            let _ = b.mem_release(private);
+            return Err(error);
+        }
+        if let Err(error) = b.mem_set_access(base, size, device) {
+            let _ = b.mem_release(private);
+            return Err(error);
+        }
+        // The mapping retains the allocation. The old imported handle remains
+        // in VMM_TRANS so the guest can release its inherited handle normally.
+        let _ = b.mem_release(private);
+        b.memcpy_htod(base, &snapshot, 0)?;
+        b.ctx_synchronize()?;
+        ranges.swap_remove(index);
+    }
+    Ok(())
+}
+
+fn cow_worker_vmm_written(sess: &Session, b: &mut dyn Backend, req: &Request) -> CuResult<()> {
+    let written = match req {
+        Request::MemcpyHtoD { dptr, data, .. } => Some((*dptr, data.len() as u64)),
+        Request::MemsetD8 { dptr, bytes, .. } | Request::MemsetD8Async { dptr, bytes, .. } => {
+            Some((*dptr, *bytes))
+        }
+        Request::MemcpyShmHtoD { dptr, size, .. } => Some((*dptr, *size)),
+        Request::MemcpyGpaHtoD { dptr, segments, .. } => {
+            let bytes = segments
+                .iter()
+                .fold(0_u64, |total, (_, len)| total.saturating_add(*len));
+            Some((*dptr, bytes))
+        }
+        Request::MemcpyDtoD { dst, bytes, .. } | Request::MemcpyDtoDAsync { dst, bytes, .. } => {
+            Some((*dst, *bytes))
+        }
+        _ => None,
+    };
+    match written {
+        Some((dptr, bytes)) => cow_worker_vmm_range(sess, b, dptr, bytes),
+        None => Ok(()),
     }
 }
 
@@ -3225,6 +3380,9 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
     // Copy-on-write any shared weight buffer this request writes, then rewrite
     // inherited device pointers to this clone's private copies (both no-ops
     // unless this is an isolating clone).
+    if let Err(code) = cow_worker_vmm_written(sess, b, &req) {
+        return (code, Response::Ok);
+    }
     cow_written(sess, b, &req);
     let req = translate_dptrs(&sess.dptr_trans, req);
     let trace = optrace_summary(&req);
@@ -4360,14 +4518,26 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
                 Response::Ok
             })
         }
-        Request::MemSetAccess { va, size, device } => b
-            .mem_set_access(va, size, dev(sess, device))
-            .map(|_| Response::Ok),
+        Request::MemSetAccess { va, size, device } => {
+            let partitions =
+                vmm_access_partitions(va, size, &WORKER_SHARED_VMM_RANGES.lock().unwrap());
+            for (part_va, part_size, read_only) in partitions {
+                if read_only {
+                    b.mem_set_access_ro(part_va, part_size, dev(sess, device))?;
+                } else {
+                    b.mem_set_access(part_va, part_size, dev(sess, device))?;
+                }
+            }
+            Ok(Response::Ok)
+        }
         Request::MemUnmap { va, size } => {
             sess.owned_vmm_maps.remove(&va);
             sess.vmm_ranges.lock().unwrap().remove(&va);
             sess.golden_layout.lock().unwrap().maps.remove(&va);
-            b.mem_unmap(va, size).map(|_| Response::Ok)
+            b.mem_unmap(va, size).map(|_| {
+                forget_worker_shared_vmm_range(va, size);
+                Response::Ok
+            })
         }
         Request::MemRelease { handle } => {
             // Burst create: resolve (and retire) the session's virtual handle.
@@ -4777,6 +4947,24 @@ mod tests {
     use super::*;
     use crate::client::Client;
     use std::io::{Read, Write};
+
+    #[test]
+    fn replayed_vmm_access_preserves_only_shared_intersections() {
+        assert_eq!(
+            vmm_access_partitions(0x1000, 0x5000, &[(0x2000, 0x1000), (0x4000, 0x1000)]),
+            vec![
+                (0x1000, 0x1000, false),
+                (0x2000, 0x1000, true),
+                (0x3000, 0x1000, false),
+                (0x4000, 0x1000, true),
+                (0x5000, 0x1000, false),
+            ]
+        );
+        assert_eq!(
+            vmm_access_partitions(0x2000, 0x2000, &[(0x1000, 0x4000)]),
+            vec![(0x2000, 0x2000, true)]
+        );
+    }
 
     #[test]
     fn golden_capacity_can_load_the_shared_model_at_high_fanout() {

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -1873,6 +1873,7 @@ fn reconstruct_golden_memory(
     }
     let share_weights = smolvm_cuda::host::path3_share_weights_enabled();
     let (mut count, mut shared) = (0, 0);
+    let mut shared_ranges = Vec::new();
     for e in maps_s.split(',').filter(|s| !s.is_empty()) {
         let f: Vec<&str> = e.split(':').collect();
         if f.len() < 3 {
@@ -1887,40 +1888,19 @@ fn reconstruct_golden_memory(
         let golden_h = f.get(4).and_then(|s| hx(s));
         let host_offset = f.get(5).and_then(|s| hx(s));
 
-        // DENSITY (opt-in, SMOLVM_CUDA_FORK_SHARE_WEIGHTS): a loaded weight range is
-        // read-only during frozen-base fine-tuning (LoRA freezes the base; only the
-        // clone's PRIVATE adapters train), so SHARE the golden's physical at its VA —
-        // every clone imports the same physical, so one weight set lives in VRAM.
-        // Mapped READ-WRITE: unsloth's fix_untrained_tokens writes the embedding at
-        // trainer setup, and that write is identical across clones (same base → same
-        // fix), so sharing stays correct for this use case (verified by each clone
-        // still learning its distinct task). On ANY share failure, fall through to a
-        // private copy — never leave the VA unmapped (a hole faults the clone).
+        // A fully loaded range is frozen at the snapshot boundary, so every
+        // clone can import the same physical memory at the golden VA. Shared
+        // mappings remain read-only until an explicit post-fork write replaces
+        // the affected VMM chunk with a private, address-preserving copy.
         if share_weights && loaded {
             let mut ok = false;
             if let Ok(gh) = import_with_retry(b, 4 + idx) {
                 match map_import_with_retry(b, va, size, 0, gh) {
                     Ok(()) => {
-                        // READ-ONLY by default. A shared chunk is one the golden's
-                        // H2Ds wrote and nothing has touched since (verified at fork
-                        // time), so a clone has no business writing it. Mapping it
-                        // read-write means a post-fork base write — unsloth's
-                        // embedding fixup is a KERNEL write, invisible to the COW
-                        // path, which only sees explicit mem ops — silently races
-                        // across every clone sharing that physical (loss=nan).
-                        // Read-only makes that fail-stop instead: the write faults,
-                        // and since each clone worker owns its context the blast
-                        // radius is that one clone, with the shared bytes intact for
-                        // its siblings. A warmed golden never trips it (its writes
-                        // happen pre-fork, so verification already marked those
-                        // chunks private): measured 8/8 clean, 0 faults, same
-                        // 260-shared/160-private split as read-write.
-                        // SMOLVM_CUDA_SHARE_RO=0 restores read-write sharing.
-                        let set = if std::env::var("SMOLVM_CUDA_SHARE_RO").as_deref() == Ok("0") {
-                            b.mem_set_access(va, size, device)
-                        } else {
-                            b.mem_set_access_ro(va, size, device)
-                        };
+                        // Kernel writes cannot be intercepted for COW, so keep
+                        // shared physical memory read-only and fail locally instead
+                        // of allowing one clone to corrupt its siblings.
+                        let set = b.mem_set_access_ro(va, size, device);
                         if set.is_ok() {
                             ok = true;
                         } else {
@@ -1949,6 +1929,7 @@ fn reconstruct_golden_memory(
                 }
             }
             if ok {
+                shared_ranges.push((va, size));
                 shared += 1;
                 count += 1;
                 continue;
@@ -2044,6 +2025,7 @@ fn reconstruct_golden_memory(
     // Emit the verdict in both modes. Private-copy controls need positive
     // evidence (`shared=0`) rather than inferring policy from a missing line.
     tracing::info!(shared, private = count - shared, "M2: shared weight ranges");
+    smolvm_cuda::host::set_worker_shared_vmm_ranges(shared_ranges);
     // Non-VMM golden allocations (`cudaMalloc` — a plain-torch golden keeps ALL
     // its tensors here): copy each from the daemon's staged export into a fresh
     // private buffer and record a POINTER TRANSLATION, exactly like the
@@ -3506,6 +3488,34 @@ impl Drop for CachedHostSnapshot {
     }
 }
 
+/// Move owned descriptor sources above every `dup2` destination used by a
+/// clone worker. Otherwise an early `dup2` can overwrite a later source and
+/// make the worker import the wrong GPU allocation.
+#[cfg(unix)]
+fn lift_owned_fds(fds: Vec<std::os::unix::io::RawFd>, minimum: i32) -> io::Result<Vec<i32>> {
+    let mut lifted = Vec::with_capacity(fds.len());
+    for &fd in &fds {
+        // CLOEXEC is intentional on the temporary source. `dup2` creates the
+        // final destination and the child explicitly clears CLOEXEC there.
+        let duplicate = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, minimum) };
+        if duplicate < 0 {
+            let error = io::Error::last_os_error();
+            for duplicate in lifted {
+                unsafe { libc::close(duplicate) };
+            }
+            for fd in fds {
+                unsafe { libc::close(fd) };
+            }
+            return Err(error);
+        }
+        lifted.push(duplicate);
+    }
+    for fd in fds {
+        unsafe { libc::close(fd) };
+    }
+    Ok(lifted)
+}
+
 #[cfg(unix)]
 fn host_snapshot_cache() -> &'static Mutex<std::collections::HashMap<u64, Arc<CachedHostSnapshot>>>
 {
@@ -3638,6 +3648,7 @@ fn spawn_clone_worker(
     options: ServeOptions,
 ) -> io::Result<(u32, std::os::unix::io::RawFd)> {
     use std::os::unix::process::CommandExt;
+    let exe = std::env::current_exe()?;
     let eviction_mode = std::env::var("SMOLVM_CUDA_GOLDEN_EVICT").ok();
     let snapshot_requested =
         golden_eviction_enabled(eviction_mode.as_deref(), options.fork_pool_size);
@@ -4017,21 +4028,39 @@ fn spawn_clone_worker(
     // variable-length proc-mem advert. A byte stream could split/coalesce the
     // metadata and associate the next channel's live-RAM map with the wrong fd.
     if unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_SEQPACKET, 0, sp.as_mut_ptr()) } != 0 {
-        return Err(io::Error::last_os_error());
+        let error = io::Error::last_os_error();
+        for fd in export_fds {
+            unsafe { libc::close(fd) };
+        }
+        return Err(error);
     }
-    // Lift the child end above the dup2 target range (3..4+nexports) so the
-    // fd shuffle in pre_exec can't clobber it before it's dup2'd into place.
-    // SAFETY: F_DUPFD to >=64 on an fd we own; original closed right after.
-    let ctrl_child = unsafe { libc::fcntl(sp[1], libc::F_DUPFD, 64) };
+    let ctrl_slot = 4 + export_fds.len() as i32;
+    let source_minimum = ctrl_slot + 1;
+    // Lift the control source and every exported-memory source above the whole
+    // dup2 destination range. Hundreds of VMM chunks can extend beyond any
+    // fixed descriptor floor.
+    let ctrl_child = unsafe { libc::fcntl(sp[1], libc::F_DUPFD_CLOEXEC, source_minimum) };
     // SAFETY: closing our original child-end copy.
     unsafe { libc::close(sp[1]) };
     if ctrl_child < 0 {
+        let error = io::Error::last_os_error();
         // SAFETY: closing the parent end we created above.
         unsafe { libc::close(sp[0]) };
-        return Err(io::Error::last_os_error());
+        for fd in export_fds {
+            unsafe { libc::close(fd) };
+        }
+        return Err(error);
     }
-    let ctrl_slot = 4 + export_fds.len() as i32;
-    let exe = std::env::current_exe()?;
+    let export_fds = match lift_owned_fds(export_fds, source_minimum) {
+        Ok(fds) => fds,
+        Err(error) => {
+            unsafe {
+                libc::close(sp[0]);
+                libc::close(ctrl_child);
+            }
+            return Err(error);
+        }
+    };
     let mut cmd = std::process::Command::new(exe);
     cmd.arg("_cuda-clone-worker").arg("3");
     cmd.env("SMOLVM_CUDA_CLONE_LAYOUT", layout);
@@ -4204,7 +4233,7 @@ mod mps_tests {
         consume_procmem_preamble, create_host_snapshot_memfd, create_private_mps_paths,
         daemon_has_live_cuda_clients, decode_attach_procmem, disabled_worker_route,
         encode_attach_procmem, golden_eviction_enabled, host_snapshot_fits,
-        host_snapshot_reconstructable, mps_enabled, ordinary_regions_are_reserved,
+        host_snapshot_reconstructable, lift_owned_fds, mps_enabled, ordinary_regions_are_reserved,
         range_is_reserved, read_host_snapshot, recv_fd, seal_host_snapshot, select_golden_owner,
         send_fd, spawn_clone_attach_listener_with_timeout, unique_live_clone_worker,
     };
@@ -4213,6 +4242,28 @@ mod mps_tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
+
+    #[test]
+    fn worker_fd_sources_are_lifted_above_every_dup_destination() {
+        use std::io::{Read as _, Seek as _, SeekFrom, Write as _};
+        use std::os::fd::{FromRawFd as _, IntoRawFd as _};
+
+        let mut sources = Vec::new();
+        for value in [11_u8, 22, 33] {
+            let mut file = tempfile::tempfile().unwrap();
+            file.write_all(&[value]).unwrap();
+            sources.push(file.into_raw_fd());
+        }
+        let lifted = lift_owned_fds(sources, 512).unwrap();
+        assert!(lifted.iter().all(|&fd| fd >= 512));
+        for (fd, value) in lifted.into_iter().zip([11_u8, 22, 33]) {
+            let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
+            file.seek(SeekFrom::Start(0)).unwrap();
+            let mut got = [0_u8; 1];
+            file.read_exact(&mut got).unwrap();
+            assert_eq!(got, [value]);
+        }
+    }
 
     #[test]
     fn capacity_policy_preamble_roundtrips() {

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -2785,6 +2785,14 @@ fn metadata_layout_waiters(
 
 #[cfg(unix)]
 fn retain_metadata_layout_for_clone(token: u64, clone_id: u64, vm_pid: u32) -> bool {
+    // A frozen memory-bearing layout is also held strongly by the metadata
+    // cache after golden eviction, but its ordinary-allocation handoff has
+    // already moved into host_snapshot_cache. Do not reclassify that layout as
+    // a metadata-only helper: completing the resulting waiter set would drop
+    // the module/function/handle metadata needed by later pool replacements.
+    if cached_host_snapshot(token).is_some() {
+        return false;
+    }
     let mut waiters = metadata_layout_waiters().lock().unwrap();
     if !smolvm_cuda::host::cache_metadata_only_layout(token) {
         return false;
@@ -4292,6 +4300,29 @@ mod mps_tests {
         assert!(!host_snapshot_reconstructable(0, 0));
         assert!(host_snapshot_reconstructable(1, 0));
         assert!(host_snapshot_reconstructable(0, 1));
+    }
+
+    #[test]
+    fn frozen_memory_layout_is_not_reclassified_as_metadata_only() {
+        let token = u64::MAX - 41;
+        super::host_snapshot_cache().lock().unwrap().insert(
+            token,
+            Arc::new(super::CachedHostSnapshot {
+                layout: String::new(),
+                device: 0,
+                fds: Vec::new(),
+                host_bytes: 1,
+                golden_pid: std::sync::atomic::AtomicU32::new(0),
+            }),
+        );
+
+        assert!(!super::retain_metadata_layout_for_clone(token, 7, 11));
+        assert!(!super::metadata_layout_waiters()
+            .lock()
+            .unwrap()
+            .contains_key(&token));
+
+        super::host_snapshot_cache().lock().unwrap().remove(&token);
     }
 
     #[test]

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -57,6 +57,10 @@ fn golden_eviction_enabled(mode: Option<&str>, fork_pool_size: Option<u32>) -> b
     }
 }
 
+fn fork_snapshot_enabled(golden_eviction: bool, share_weights: bool) -> bool {
+    golden_eviction || share_weights
+}
+
 #[cfg(target_os = "linux")]
 fn host_snapshot_fits(required: u64, meminfo: &str) -> bool {
     let available_kib = meminfo.lines().find_map(|line| {
@@ -415,6 +419,12 @@ fn spawn_child_reaper() {
                     break;
                 }
             }
+            // Snapshot cleanup must not depend on the optional idle watchdog.
+            // Long-lived daemons use IDLE_SECS=0, but their completed fork
+            // lineages must still release retained descriptors and metadata.
+            prune_dead_metadata_layout_waiters();
+            let _ = live_clone_worker_count();
+            let _ = live_host_snapshot_count();
             thread::sleep(Duration::from_secs(2));
         })
         .ok();
@@ -3545,6 +3555,31 @@ fn bind_host_snapshot_owner(token: u64, pid: u32) {
 }
 
 #[cfg(unix)]
+fn bind_host_snapshot_to_golden(token: u64) -> Option<u32> {
+    let (matching, registered) = {
+        let registry = golden_connection_registry().lock().unwrap();
+        let matching = registry
+            .iter()
+            .filter_map(|(&pid, entries)| {
+                entries
+                    .iter()
+                    .any(|entry| {
+                        entry.token == token
+                            || smolvm_cuda::host::layout_handoff_same_process(entry.token, token)
+                    })
+                    .then_some(pid)
+            })
+            .collect();
+        (matching, registry.keys().copied().collect::<Vec<_>>())
+    };
+    let known_owner = golden_token_owners().lock().unwrap().get(&token).copied();
+    let owner = select_golden_owner(matching, known_owner, &registered)?;
+    golden_token_owners().lock().unwrap().insert(token, owner);
+    bind_host_snapshot_owner(token, owner);
+    Some(owner)
+}
+
+#[cfg(unix)]
 fn live_host_snapshot_count() -> usize {
     let snapshots: Vec<(u64, Arc<CachedHostSnapshot>)> = host_snapshot_cache()
         .lock()
@@ -3650,11 +3685,13 @@ fn spawn_clone_worker(
     use std::os::unix::process::CommandExt;
     let exe = std::env::current_exe()?;
     let eviction_mode = std::env::var("SMOLVM_CUDA_GOLDEN_EVICT").ok();
-    let snapshot_requested =
-        golden_eviction_enabled(eviction_mode.as_deref(), options.fork_pool_size);
     let configured_sharing = std::env::var("SMOLVM_CUDA_FORK_SHARE_WEIGHTS").ok();
     let sharing_active =
         share_weights && !matches!(configured_sharing.as_deref(), Some("0" | "false" | "off"));
+    let snapshot_requested = fork_snapshot_enabled(
+        golden_eviction_enabled(eviction_mode.as_deref(), options.fork_pool_size),
+        sharing_active,
+    );
     let (golden_dev, layout, export_fds) = if let Some(cached) = cached_host_snapshot(token) {
         tracing::info!(
             token,
@@ -3887,12 +3924,25 @@ fn spawn_clone_worker(
         }
         if snapshot_complete {
             match retain_host_snapshot(token, &layout, golden_dev, &export_fds, snapshot_offset) {
-                Ok(()) => tracing::info!(
-                    token,
-                    fds = export_fds.len(),
-                    host_bytes = snapshot_offset,
-                    "retained golden host snapshot for pool replenishment"
-                ),
+                Ok(()) => {
+                    let owner = bind_host_snapshot_to_golden(token);
+                    if owner.is_some() {
+                        tracing::info!(
+                            token,
+                            ?owner,
+                            fds = export_fds.len(),
+                            host_bytes = snapshot_offset,
+                            "retained golden host snapshot for clone reuse"
+                        );
+                    } else {
+                        host_snapshot_cache().lock().unwrap().remove(&token);
+                        smolvm_cuda::host::release_metadata_only_layout(token);
+                        tracing::warn!(
+                            token,
+                            "golden snapshot owner is ambiguous; disabling snapshot reuse"
+                        );
+                    }
+                }
                 Err(error) => {
                     tracing::warn!(
                         %error,
@@ -4232,10 +4282,11 @@ mod mps_tests {
         clone_worker_idle_timeout_from, clone_worker_share_env, clone_worker_vm_is_alive,
         consume_procmem_preamble, create_host_snapshot_memfd, create_private_mps_paths,
         daemon_has_live_cuda_clients, decode_attach_procmem, disabled_worker_route,
-        encode_attach_procmem, golden_eviction_enabled, host_snapshot_fits,
-        host_snapshot_reconstructable, lift_owned_fds, mps_enabled, ordinary_regions_are_reserved,
-        range_is_reserved, read_host_snapshot, recv_fd, seal_host_snapshot, select_golden_owner,
-        send_fd, spawn_clone_attach_listener_with_timeout, unique_live_clone_worker,
+        encode_attach_procmem, fork_snapshot_enabled, golden_eviction_enabled, host_snapshot_fits,
+        host_snapshot_reconstructable, lift_owned_fds, live_host_snapshot_count, mps_enabled,
+        ordinary_regions_are_reserved, range_is_reserved, read_host_snapshot, recv_fd,
+        seal_host_snapshot, select_golden_owner, send_fd, spawn_clone_attach_listener_with_timeout,
+        unique_live_clone_worker,
     };
     use std::collections::HashMap;
     use std::io;
@@ -4328,6 +4379,13 @@ mod mps_tests {
     }
 
     #[test]
+    fn shared_forks_retain_one_reusable_snapshot_without_requiring_a_pool() {
+        assert!(fork_snapshot_enabled(false, true));
+        assert!(fork_snapshot_enabled(true, false));
+        assert!(!fork_snapshot_enabled(false, false));
+    }
+
+    #[test]
     fn golden_eviction_requires_one_unambiguous_vm_owner() {
         assert_eq!(select_golden_owner(vec![7], None, &[7, 8]), Some(7));
         assert_eq!(select_golden_owner(Vec::new(), Some(8), &[7, 8]), Some(8));
@@ -4374,6 +4432,30 @@ mod mps_tests {
             .contains_key(&token));
 
         super::host_snapshot_cache().lock().unwrap().remove(&token);
+    }
+
+    #[test]
+    fn dead_golden_snapshot_is_released_without_the_idle_watchdog() {
+        let token = u64::MAX - 42;
+        let mut child = std::process::Command::new("true").spawn().unwrap();
+        let pid = child.id();
+        child.wait().unwrap();
+        super::host_snapshot_cache().lock().unwrap().insert(
+            token,
+            Arc::new(super::CachedHostSnapshot {
+                layout: String::new(),
+                device: 0,
+                fds: Vec::new(),
+                host_bytes: 1,
+                golden_pid: std::sync::atomic::AtomicU32::new(pid),
+            }),
+        );
+
+        assert_eq!(live_host_snapshot_count(), 0);
+        assert!(!super::host_snapshot_cache()
+            .lock()
+            .unwrap()
+            .contains_key(&token));
     }
 
     #[test]


### PR DESCRIPTION
Preserves CUDA fork metadata, makes shared VMM writes clone-private, prevents descriptor collisions, and safely reuses one snapshot across declared and ad hoc clone pools.