### PR TITLE
Add one-shot held fork slots for hot pool reuse

### DIFF
--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -59,6 +59,21 @@ pub fn control_socket_cmd(sock: &Path, cmd: &str) -> Result<String> {
 /// marker and blocks. Keeping the wait in the VM namespace avoids coupling the
 /// host to container logs, PIDs, or workload-specific files.
 pub fn wait_for_forkpoint(golden: &str, timeout: Duration) -> Result<()> {
+    // A successful first fork leaves the golden paused permanently as the CoW
+    // base. Pool replenishment must not try to run a new agent exec inside that
+    // paused VM: its vCPUs cannot answer, even though the already-proven
+    // forkpoint remains the exact snapshot source. The control plane is still
+    // live in the VMM, so recognize that state before touching the guest.
+    let control = control_socket_path(golden);
+    if control.exists() {
+        if let Ok(status) = control_socket_cmd(&control, "STATUS") {
+            if fork_base_already_paused(&status) {
+                tracing::debug!(golden, %status, "fork base is already paused; reusing its forkpoint");
+                return Ok(());
+            }
+        }
+    }
+
     let socket = vm_data_dir(golden).join("agent.sock");
     let mut client = AgentClient::connect_with_retry(&socket)
         .map_err(|e| Error::agent("wait for forkpoint", format!("agent connect: {e}")))?;
@@ -90,6 +105,10 @@ pub fn wait_for_forkpoint(golden: &str, timeout: Duration) -> Result<()> {
             ),
         )),
     }
+}
+
+fn fork_base_already_paused(status: &str) -> bool {
+    status.trim() == "OK paused"
 }
 
 /// Release the workload restored in `clone` after its identity and per-fork
@@ -155,6 +174,10 @@ pub struct PreparedFork {
     /// caller to log. Empty when the golden has no forwards. When ports were
     /// pinned, `golden_host == clone_host`.
     pub port_remaps: Vec<(u16, u16, u16)>,
+    /// Whether a caller must resume the golden if clone boot/finalization fails.
+    /// False for pool refill from an already-paused golden: resuming that base
+    /// would invalidate every existing clone and retained CUDA snapshot.
+    pub resume_golden_on_rollback: bool,
 }
 
 /// Parameters for one clone in a single-snapshot fork operation.
@@ -169,6 +192,9 @@ pub struct ForkSpec<'a> {
     pub fork_env: &'a [(String, String)],
     /// Per-clone secret references resolved by later execs.
     pub fork_secrets: &'a BTreeMap<String, crate::secrets::SecretRef>,
+    /// Keep the restored workload parked at its inherited forkpoint until a
+    /// later assignment explicitly releases it.
+    pub hold: bool,
 }
 
 /// Freeze a running, forkable `golden`, snapshot it, register `clone` in the DB
@@ -198,6 +224,32 @@ pub fn prepare_fork(
             clone_forkable,
             fork_env,
             fork_secrets,
+            hold: false,
+        }],
+    )?;
+    Ok(prepared.remove(0))
+}
+
+/// Prepare one clean clone that remains parked at the inherited forkpoint.
+/// Held slots are deliberately non-forkable and one-shot.
+pub fn prepare_held_fork(
+    db: &SmolvmDb,
+    golden: &str,
+    clone: &str,
+    pinned_ports: &[(u16, u16)],
+    fork_env: &[(String, String)],
+    fork_secrets: &BTreeMap<String, crate::secrets::SecretRef>,
+) -> Result<PreparedFork> {
+    let mut prepared = prepare_forks(
+        db,
+        golden,
+        &[ForkSpec {
+            clone,
+            pinned_ports,
+            clone_forkable: false,
+            fork_env,
+            fork_secrets,
+            hold: true,
         }],
     )?;
     Ok(prepared.remove(0))
@@ -270,6 +322,7 @@ pub fn prepare_forks(
             format!("golden '{golden}' is not ready to fork: {status}"),
         ));
     }
+    let golden_was_paused = fork_base_already_paused(&status);
 
     let gdir = vm_data_dir(golden);
     // Keep this path short and independent of clone names. libkrun and its
@@ -334,13 +387,19 @@ pub fn prepare_forks(
             spec,
             &mut reserved_ports,
         ) {
-            Ok(clone) => prepared.push(clone),
+            Ok(mut clone) => {
+                clone.resume_golden_on_rollback = !golden_was_paused;
+                prepared.push(clone);
+            }
             Err(error) => {
                 for clone in &prepared {
                     let _ = db.remove_vm(&clone.clone_record.name);
                     let _ = std::fs::remove_dir_all(vm_data_dir(&clone.clone_record.name));
                 }
                 let _ = std::fs::remove_dir_all(&snapshot_dir);
+                if golden_was_paused {
+                    return Err(error);
+                }
                 return match resume_golden(golden) {
                     Ok(()) => Err(error),
                     Err(resume_error) => Err(Error::agent(
@@ -432,6 +491,8 @@ fn prepare_clone_from_snapshot(
             clone_rec.ports = remapped;
         }
         clone_rec.golden = Some(golden.to_string());
+        clone_rec.forkpoint_held = spec.hold;
+        clone_rec.fork_env = spec.fork_env.to_vec();
         db.insert_vm(clone, &clone_rec)?;
 
         let t_disk = std::time::Instant::now();
@@ -445,6 +506,7 @@ fn prepare_clone_from_snapshot(
             snapshot_dir: snapshot_dir.to_path_buf(),
             clone_record: clone_rec,
             port_remaps,
+            resume_golden_on_rollback: true,
         })
     })();
 
@@ -704,6 +766,38 @@ pub fn render_fork_env(env: &[(String, String)]) -> String {
     out
 }
 
+/// Merge assignment-time parameters into a held slot's initial fork
+/// parameters. Later values replace same-named earlier values while preserving
+/// stable ordering for every untouched entry.
+pub fn merge_fork_env(
+    initial: &[(String, String)],
+    assignment: &[(String, String)],
+) -> Vec<(String, String)> {
+    let mut merged = initial.to_vec();
+    for (key, value) in assignment {
+        merged.retain(|(existing, _)| existing != key);
+        merged.push((key.clone(), value.clone()));
+    }
+    merged
+}
+
+/// Persist the state transition after a held slot has been released
+/// successfully. Kept in one shared helper so the CLI and HTTP API cannot
+/// disagree about the one-shot flag or assignment environment.
+pub fn record_fork_activation(
+    record: &mut VmRecord,
+    assignment: &[(String, String)],
+    merged: Vec<(String, String)>,
+) {
+    let assignment_keys: HashSet<&str> = assignment.iter().map(|(key, _)| key.as_str()).collect();
+    record.forkpoint_held = false;
+    record.fork_env = merged;
+    record
+        .env
+        .retain(|(key, _)| !assignment_keys.contains(key.as_str()));
+    record.env.extend(assignment.iter().cloned());
+}
+
 /// Deliver per-fork parameters into a freshly-booted clone at
 /// [`FORK_ENV_GUEST_PATH`], via a VM-namespace write THROUGH the workload
 /// container's overlayfs `merged` mount. Deliberately not a container exec:
@@ -758,6 +852,83 @@ pub fn write_fork_env(clone: &str, record: &VmRecord, env: &[(String, String)]) 
             ),
         )),
         Err(e) => Err(Error::agent("fork env", format!("vm exec: {e}"))),
+    }
+}
+
+/// Assign and release one clean, already-booted fork-pool slot.
+///
+/// The guest performs the state check, fork-env replacement, and release-marker
+/// publication in one agent exec. A slot can therefore be released only once;
+/// a completed training worker is never reset or reused with dirty optimizer,
+/// RNG, allocator, or dataset state. Callers replenish the pool by deleting the
+/// consumed clone and forking a fresh held slot from its still-frozen golden.
+///
+/// Returns the complete merged fork parameter set that the caller should
+/// persist after success.
+pub fn activate_held_fork(
+    clone: &str,
+    record: &VmRecord,
+    assignment: &[(String, String)],
+) -> Result<Vec<(String, String)>> {
+    validate_fork_env(assignment)?;
+    let merged = merge_fork_env(&record.fork_env, assignment);
+    let content = render_fork_env(&merged);
+    let owner = crate::workload::persistent_overlay_owner(clone, record.golden.as_deref());
+    let merged_root = format!("/storage/overlays/persistent-{owner}/merged");
+    let env_path = if record.image.is_some() {
+        format!("{merged_root}{FORK_ENV_GUEST_PATH}")
+    } else {
+        FORK_ENV_GUEST_PATH.to_string()
+    };
+    let ensure_env_parent = if record.image.is_some() {
+        format!(
+            "if [ ! -d '{merged_root}' ]; then echo 'missing {merged_root}' >&2; exit 41; fi; \
+             mkdir -p '{merged_root}/etc/smolvm'"
+        )
+    } else {
+        "mkdir -p /etc/smolvm".to_string()
+    };
+    let script = format!(
+        "set -e; \
+         if [ -f '{release}' ]; then exit 42; fi; \
+         if [ ! -f '{ready}' ]; then exit 43; fi; \
+         {ensure_env_parent}; \
+         umask 077; cat > '{env_path}.tmp'; mv '{env_path}.tmp' '{env_path}'; \
+         printf '%s\\n' smolvm-forkpoint-release-v1 > '{release}.tmp'; \
+         mv '{release}.tmp' '{release}'",
+        ready = smolvm_protocol::forkpoint::READY_PATH,
+        release = smolvm_protocol::forkpoint::RELEASE_PATH,
+    );
+    let socket = vm_data_dir(clone).join("agent.sock");
+    let mut client = AgentClient::connect_with_retry(&socket)
+        .map_err(|e| Error::agent("activate held fork", format!("agent connect: {e}")))?;
+    match client.vm_exec(
+        vec!["/bin/sh".into(), "-c".into(), script],
+        vec![],
+        None,
+        Some(Duration::from_secs(10)),
+        Some(content),
+    ) {
+        Ok((0, _, _)) => Ok(merged),
+        Ok((42, _, _)) => Err(Error::agent(
+            "activate held fork",
+            format!("clone '{clone}' was already released"),
+        )),
+        Ok((43, _, _)) => Err(Error::agent(
+            "activate held fork",
+            format!("clone '{clone}' is not parked at a forkpoint"),
+        )),
+        Ok((code, _, stderr)) => Err(Error::agent(
+            "activate held fork",
+            format!(
+                "clone '{clone}' activation exited {code}: {}",
+                String::from_utf8_lossy(&stderr).trim()
+            ),
+        )),
+        Err(e) => Err(Error::agent(
+            "activate held fork",
+            format!("clone '{clone}': {e}"),
+        )),
     }
 }
 
@@ -846,6 +1017,13 @@ mod tests {
     }
 
     #[test]
+    fn paused_golden_reuses_the_proven_forkpoint_for_refill() {
+        assert!(fork_base_already_paused("OK paused\n"));
+        assert!(!fork_base_already_paused("OK running\n"));
+        assert!(!fork_base_already_paused("ERR not forkable\n"));
+    }
+
+    #[test]
     fn fork_env_renders_one_pair_per_line() {
         let env = vec![
             ("LR".to_string(), "3e-4".to_string()),
@@ -853,6 +1031,50 @@ mod tests {
         ];
         assert_eq!(render_fork_env(&env), "LR=3e-4\nNOTE=a=b c\n");
         assert_eq!(render_fork_env(&[]), "");
+    }
+
+    #[test]
+    fn assignment_env_overrides_only_matching_pool_values() {
+        let initial = vec![
+            ("SMOLVM_FORK_INDEX".to_string(), "2".to_string()),
+            ("LR".to_string(), "1e-4".to_string()),
+        ];
+        let assignment = vec![
+            ("LR".to_string(), "3e-4".to_string()),
+            ("DATASET".to_string(), "math".to_string()),
+        ];
+        assert_eq!(
+            merge_fork_env(&initial, &assignment),
+            vec![
+                ("SMOLVM_FORK_INDEX".to_string(), "2".to_string()),
+                ("LR".to_string(), "3e-4".to_string()),
+                ("DATASET".to_string(), "math".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn successful_activation_is_persisted_as_one_shot() {
+        let mut record = VmRecord::new("slot-0".to_string(), 2, 1024, vec![], vec![], false);
+        record.forkpoint_held = true;
+        record.env = vec![
+            ("BASE".to_string(), "keep".to_string()),
+            ("LR".to_string(), "1e-4".to_string()),
+        ];
+        let assignment = vec![("LR".to_string(), "3e-4".to_string())];
+        let merged = vec![("LR".to_string(), "3e-4".to_string())];
+
+        record_fork_activation(&mut record, &assignment, merged.clone());
+
+        assert!(!record.forkpoint_held);
+        assert_eq!(record.fork_env, merged);
+        assert_eq!(
+            record.env,
+            vec![
+                ("BASE".to_string(), "keep".to_string()),
+                ("LR".to_string(), "3e-4".to_string()),
+            ]
+        );
     }
 
     // Fix 1: the re-mint script must regenerate the per-machine on-disk secrets

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -37,8 +37,8 @@ use crate::api::state::{
 };
 use crate::api::types::{
     ApiErrorResponse, CreateMachineRequest, DeleteQuery, DeleteResponse, ExportRequest,
-    ExportResponse, ForkRequest, ListMachinesResponse, MachineInfo, MountInfo, MountSpec, PortSpec,
-    ResizeMachineRequest, ResourceSpec, StartMachineQuery,
+    ExportResponse, ForkReleaseRequest, ForkRequest, ListMachinesResponse, MachineInfo, MountInfo,
+    MountSpec, PortSpec, ResizeMachineRequest, ResourceSpec, StartMachineQuery,
 };
 use crate::config::{RecordState, RestartConfig, VmRecord};
 use crate::data::disk::{Overlay, Storage};
@@ -107,6 +107,7 @@ fn record_to_info(name: &str, record: &VmRecord) -> MachineInfo {
         overlay_gb: Some(record.overlay_gb.unwrap_or(DEFAULT_OVERLAY_SIZE_GIB)),
         cuda_fork_pool_size: record.cuda_fork_pool_size,
         cuda_vram_limit_mib: record.cuda_vram_limit_mib,
+        forkpoint_held: record.forkpoint_held,
         // Cumulative egress, read from the per-VM telemetry file the subprocess
         // flushes. Surfaced here so the control plane reads it from the machine
         // list exactly like disk size — no bespoke endpoint.
@@ -174,6 +175,7 @@ fn machine_entry_from_record(record: &VmRecord, manager: AgentManager) -> Machin
         source_smolmachine: record.source_smolmachine.clone(),
         cuda_fork_pool_size: record.cuda_fork_pool_size,
         cuda_vram_limit_mib: record.cuda_vram_limit_mib,
+        forkpoint_held: record.forkpoint_held,
     }
 }
 
@@ -1274,12 +1276,17 @@ pub async fn fork_machine(
     let clone = req.name.clone();
     let pinned_ports: Vec<(u16, u16)> = req.ports.iter().map(|p| (p.host, p.guest)).collect();
     let req_share_weights = req.share_weights;
+    let req_hold = req.hold;
+    let wait_ready = req.wait_ready || req_hold;
+    let ready_timeout = std::time::Duration::from_secs(req.ready_timeout_secs.unwrap_or(240));
     let fork_env = crate::util::parse_env_list(&req.env);
     // Per-fork secrets become the clone's persisted secret_refs (resolved fresh
     // on each exec, never at rest) — validate them at TrustedLocal like the
     // Smolfile-declared refs they join.
     crate::api::handlers::validate_fork_secrets(&req.secrets)?;
     let fork_secrets = req.secrets.clone();
+    crate::agent::fork::validate_fork_env(&fork_env)
+        .map_err(|e| ApiError::BadRequest(e.to_string()))?;
 
     // Validate pinned ports as the create path does: fork uses these host ports
     // as-is (no remapping), so port 0 or a duplicated host port would otherwise
@@ -1302,6 +1309,16 @@ pub async fn fork_machine(
         }
     }
 
+    if wait_ready {
+        let golden_b = golden.clone();
+        tokio::task::spawn_blocking(move || {
+            crate::agent::fork::wait_for_forkpoint(&golden_b, ready_timeout)
+        })
+        .await
+        .map_err(|e| ApiError::internal(format!("task error: {e}")))?
+        .map_err(classify_fork_error)?;
+    }
+
     // Serialize lifecycle on the CLONE name so a concurrent start/stop/delete of
     // the same clone can't race the fork's register + boot. The golden is only
     // read + frozen via its control socket, which tolerates concurrent forks.
@@ -1320,9 +1337,16 @@ pub async fn fork_machine(
         let env = fork_env.clone();
         let secrets = fork_secrets.clone();
         tokio::task::spawn_blocking(move || {
-            crate::agent::fork::prepare_fork(
-                &db, &golden_b, &clone_b, &ports, /* clone_forkable */ false, &env, &secrets,
-            )
+            if req_hold {
+                crate::agent::fork::prepare_held_fork(
+                    &db, &golden_b, &clone_b, &ports, &env, &secrets,
+                )
+            } else {
+                crate::agent::fork::prepare_fork(
+                    &db, &golden_b, &clone_b, &ports, /* clone_forkable */ false, &env,
+                    &secrets,
+                )
+            }
         })
         .await
         .map_err(|e| ApiError::internal(format!("task error: {}", e)))?
@@ -1386,6 +1410,13 @@ pub async fn fork_machine(
             teardown,
         )
         .map_err(|e| format!("fork env delivery failed: {}", e))?;
+        if wait_ready && !req_hold {
+            crate::agent::fork::fail_closed_on_rejuvenation(
+                crate::agent::fork::release_forkpoint(&clone_b),
+                teardown,
+            )
+            .map_err(|e| format!("forkpoint release failed: {e}"))?;
+        }
 
         let pid = manager.child_pid();
         Ok::<_, String>((manager, pid, record))
@@ -1417,6 +1448,90 @@ pub async fn fork_machine(
     info.state = "running".to_string();
     info.pid = pid;
     Ok(Json(info))
+}
+
+/// Assign job parameters and release one held fork-pool slot.
+#[utoipa::path(
+    post,
+    path = "/api/v1/machines/{name}/fork-release",
+    tag = "Machines",
+    params(("name" = String, Path, description = "Held clone name")),
+    request_body = ForkReleaseRequest,
+    responses(
+        (status = 200, description = "Held clone assigned and released", body = MachineInfo),
+        (status = 404, description = "Clone not found", body = ApiErrorResponse),
+        (status = 409, description = "Machine is not a held fork slot", body = ApiErrorResponse),
+        (status = 500, description = "Activation failed", body = ApiErrorResponse)
+    )
+)]
+pub async fn release_held_fork(
+    State(state): State<Arc<ApiState>>,
+    Path(clone): Path<String>,
+    Json(req): Json<ForkReleaseRequest>,
+) -> Result<Json<MachineInfo>, ApiError> {
+    let lifecycle = state.lifecycle_lock(&clone);
+    let _guard = lifecycle.lock().await;
+    let record = state
+        .lookup_vm(&clone)
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("machine '{clone}' not found")))?;
+    if record.golden.is_none() || !record.forkpoint_held {
+        return Err(ApiError::Conflict(format!(
+            "machine '{clone}' is not a held fork-pool slot"
+        )));
+    }
+
+    let assignment = crate::util::parse_env_list(&req.env);
+    crate::agent::fork::validate_fork_env(&assignment)
+        .map_err(|e| ApiError::BadRequest(e.to_string()))?;
+    let merged = crate::agent::fork::merge_fork_env(&record.fork_env, &assignment);
+    // Claim in durable state before publishing the guest release marker. A
+    // crash can strand one slot, but can never leave a running workload marked
+    // assignable and run it twice. Replenishment from the golden is the safe
+    // recovery for any ambiguous activation failure.
+    let assignment_for_record = assignment.clone();
+    let merged_for_record = merged.clone();
+    let claimed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let claimed_in_update = claimed.clone();
+    let updated = state
+        .update_vm(&clone, move |entry| {
+            if entry.forkpoint_held {
+                crate::agent::fork::record_fork_activation(
+                    entry,
+                    &assignment_for_record,
+                    merged_for_record,
+                );
+                claimed_in_update.store(true, std::sync::atomic::Ordering::Release);
+            }
+        })
+        .await?
+        .ok_or_else(|| {
+            ApiError::NotFound(format!("clone '{clone}' disappeared before activation"))
+        })?;
+    if !claimed.load(std::sync::atomic::Ordering::Acquire) {
+        return Err(ApiError::Conflict(format!(
+            "held fork-pool slot '{clone}' was already claimed"
+        )));
+    }
+    if let Ok(entry) = state.get_machine(&clone) {
+        entry.lock().forkpoint_held = false;
+    }
+
+    let clone_b = clone.clone();
+    let record_b = record.clone();
+    let assignment_b = assignment.clone();
+    let activated = tokio::task::spawn_blocking(move || {
+        crate::agent::fork::activate_held_fork(&clone_b, &record_b, &assignment_b)
+    })
+    .await
+    .map_err(|e| ApiError::internal(format!("task error: {e}")))?
+    .map_err(|error| {
+        ApiError::Internal(format!(
+            "slot '{clone}' was claimed and will not be reused after activation failed: {error}"
+        ))
+    })?;
+    debug_assert_eq!(activated, merged);
+    Ok(Json(record_to_info(&clone, &updated)))
 }
 
 /// Stop a machine.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -86,6 +86,7 @@ use state::ApiState;
         handlers::machines::get_machine,
         handlers::machines::start_machine,
         handlers::machines::fork_machine,
+        handlers::machines::release_held_fork,
         handlers::machines::stop_machine,
         handlers::machines::delete_machine,
         handlers::machines::resize_machine,
@@ -106,6 +107,7 @@ use state::ApiState;
         types::LogsQuery,
         types::ResizeMachineRequest,
         types::ForkRequest,
+        types::ForkReleaseRequest,
         types::ExportRequest,
         types::StartMachineQuery,
         // Response types
@@ -198,6 +200,10 @@ pub fn create_router(state: Arc<ApiState>, cors_origins: Vec<String>) -> Router 
         .route("/{id}", get(handlers::machines::get_machine))
         .route("/{id}/start", post(handlers::machines::start_machine))
         .route("/{id}/fork", post(handlers::machines::fork_machine))
+        .route(
+            "/{id}/fork-release",
+            post(handlers::machines::release_held_fork),
+        )
         .route("/{id}/stop", post(handlers::machines::stop_machine))
         .route("/{id}/resize", post(handlers::machines::resize_machine))
         .route("/{id}/export", post(handlers::machines::export_machine))

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -97,6 +97,8 @@ pub struct MachineEntry {
     pub cuda_fork_pool_size: Option<u32>,
     /// Explicit logical CUDA memory limit restored on implicit starts.
     pub cuda_vram_limit_mib: Option<u64>,
+    /// Whether a fork clone is still parked as a clean assignable slot.
+    pub forkpoint_held: bool,
 }
 
 /// Parameters for registering a new machine.
@@ -392,6 +394,7 @@ impl ApiState {
                             source_smolmachine: record.source_smolmachine.clone(),
                             cuda_fork_pool_size: record.cuda_fork_pool_size,
                             cuda_vram_limit_mib: record.cuda_vram_limit_mib,
+                            forkpoint_held: record.forkpoint_held,
                         })),
                     );
                     loaded.push(name.clone());
@@ -867,6 +870,7 @@ impl ApiState {
                         source_smolmachine: reg.source_smolmachine,
                         cuda_fork_pool_size: None,
                         cuda_vram_limit_mib: None,
+                        forkpoint_held: false,
                     })),
                 );
                 Ok(())
@@ -1505,6 +1509,7 @@ pub fn machine_entry_to_info(name: String, entry: &MachineEntry) -> MachineInfo 
         overlay_gb: entry.resources.overlay_gb,
         cuda_fork_pool_size: entry.cuda_fork_pool_size,
         cuda_vram_limit_mib: entry.cuda_vram_limit_mib,
+        forkpoint_held: entry.forkpoint_held,
         egress_bytes,
         cpu_seconds,
         cpu_millis,
@@ -1628,6 +1633,7 @@ mod tests {
                 source_smolmachine: None,
                 cuda_fork_pool_size: None,
                 cuda_vram_limit_mib: None,
+                forkpoint_held: false,
             },
         );
 
@@ -1693,6 +1699,7 @@ mod tests {
                 source_smolmachine: None,
                 cuda_fork_pool_size: None,
                 cuda_vram_limit_mib: None,
+                forkpoint_held: false,
             },
         );
 

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -637,6 +637,9 @@ pub struct MachineInfo {
     /// Explicit logical CUDA memory limit per golden/clone session, in MiB.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cuda_vram_limit_mib: Option<u64>,
+    /// True while this clone is an already-booted clean slot parked at the
+    /// workload forkpoint and available for one assignment.
+    pub forkpoint_held: bool,
     /// Cumulative guest-outbound (egress) bytes since boot, for billing. Present
     /// only for virtio-net machines that have reported a value; omitted for TSI
     /// or machines that haven't flushed yet. Surfaced the same way `storage_gb`
@@ -814,8 +817,21 @@ pub struct ForkRequest {
     /// the base stays frozen (LoRA/QLoRA fine-tuning, inference).
     #[serde(default)]
     pub share_weights: bool,
+    /// Wait for the workload's standard forkpoint before snapshotting, then
+    /// release the clone only after identity and fork parameters are installed.
+    #[serde(default)]
+    pub wait_ready: bool,
+    /// Keep the clone parked at the inherited forkpoint as an already-booted
+    /// pool slot. Implies `waitReady`; release it exactly once through the
+    /// fork-release endpoint after assigning job-specific parameters.
+    #[serde(default)]
+    pub hold: bool,
+    /// Maximum seconds to wait for the golden workload's forkpoint. Defaults
+    /// to 240 when `waitReady` or `hold` is enabled.
+    #[serde(default)]
+    pub ready_timeout_secs: Option<u64>,
     /// Per-fork parameters as KEY=VALUE strings. Delivered to the clone at
-    /// `/run/smolvm/fork-env` (dotenv format) for the already-running workload
+    /// `/etc/smolvm/fork-env` (dotenv format) for the already-running workload
     /// to read, and merged into the clone's env for later exec sessions.
     #[serde(default)]
     pub env: Vec<String>,
@@ -828,6 +844,16 @@ pub struct ForkRequest {
     #[serde(default)]
     #[schema(value_type = Object)]
     pub secrets: RequestSecretRefs,
+}
+
+/// Assignment for one already-booted held fork slot.
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ForkReleaseRequest {
+    /// Job-specific KEY=VALUE parameters. A value replaces a same-named value
+    /// installed while provisioning the slot.
+    #[serde(default)]
+    pub env: Vec<String>,
 }
 
 #[cfg(test)]
@@ -893,5 +919,16 @@ mod registry_auth_tests {
         .into();
         assert_eq!(a.username, "oauth2accesstoken");
         assert_eq!(a.password, "p:with:colons");
+    }
+
+    #[test]
+    fn legacy_fork_request_preserves_uncoordinated_behavior() {
+        let request: ForkRequest = serde_json::from_value(serde_json::json!({
+            "name": "clone-1"
+        }))
+        .unwrap();
+        assert!(!request.wait_ready);
+        assert!(!request.hold);
+        assert_eq!(request.ready_timeout_secs, None);
     }
 }

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -267,6 +267,9 @@ pub enum MachineCmd {
     /// Fork a running forkable machine into a new clone (CoW memory + disks)
     Fork(ForkCmd),
 
+    /// Assign parameters and release one held fork-pool slot
+    ForkRelease(ForkReleaseCmd),
+
     /// Stop a running machine
     Stop(StopCmd),
 
@@ -337,6 +340,7 @@ impl MachineCmd {
             MachineCmd::Create(cmd) => cmd.run(),
             MachineCmd::Start(cmd) => cmd.run(),
             MachineCmd::Fork(cmd) => cmd.run(),
+            MachineCmd::ForkRelease(cmd) => cmd.run(),
             MachineCmd::Stop(cmd) => cmd.run(),
             MachineCmd::Delete(cmd) => cmd.run(),
             MachineCmd::Status(cmd) => cmd.run(),
@@ -1937,10 +1941,36 @@ mod tests {
         assert!(!batch.wait_ready);
         assert_eq!(batch.ready_timeout, Duration::from_secs(120));
         assert_eq!(
-            forkpoint_timeout(batch.count.get(), batch.wait_ready, batch.ready_timeout),
+            forkpoint_timeout(
+                batch.count.get(),
+                batch.wait_ready,
+                batch.hold,
+                batch.ready_timeout,
+            ),
             Some(Duration::from_secs(120))
         );
-        assert_eq!(forkpoint_timeout(1, false, Duration::from_secs(120)), None);
+        assert_eq!(
+            forkpoint_timeout(1, false, false, Duration::from_secs(120)),
+            None
+        );
+        assert_eq!(
+            forkpoint_timeout(1, false, true, Duration::from_secs(120)),
+            Some(Duration::from_secs(120))
+        );
+
+        let release = TestMachineCli::parse_from([
+            "machine",
+            "fork-release",
+            "--name",
+            "worker-0",
+            "--env",
+            "LR=3e-4",
+        ]);
+        let MachineCmd::ForkRelease(release) = release.command else {
+            panic!("expected fork-release command");
+        };
+        assert_eq!(release.name, "worker-0");
+        assert_eq!(release.env, vec!["LR=3e-4"]);
     }
 
     #[test]
@@ -3019,9 +3049,17 @@ pub struct ForkCmd {
     pub parallel: std::num::NonZeroU32,
 
     /// Wait for `smolvm-fork-ready` in a single-clone fork. Batch forks always
-    /// wait and release clones only after identity and fork env are installed.
+    /// wait; unless held, they release clones only after identity and fork env
+    /// are installed.
     #[arg(long)]
     pub wait_ready: bool,
+
+    /// Keep each clone parked at the inherited forkpoint as an already-booted
+    /// pool slot. Assign and release a slot later with `machine fork-release`.
+    /// A consumed slot is disposable; delete and replenish it from the golden
+    /// rather than reusing mutated training state.
+    #[arg(long)]
+    pub hold: bool,
 
     /// Maximum time to wait for the golden workload's forkpoint.
     #[arg(
@@ -3087,11 +3125,17 @@ impl ForkCmd {
         // they merge into the clone's secret_refs and resolve fresh per exec.
         let fork_secrets = parse_cli_secret_refs(&self.secret_env, &self.secret_file)?;
         let count = self.count.get();
-        let wait_ready = forkpoint_timeout(count, self.wait_ready, self.ready_timeout);
+        let wait_ready = forkpoint_timeout(count, self.wait_ready, self.hold, self.ready_timeout);
         if count > 1024 {
             return Err(smolvm::Error::config(
                 "fork",
                 "--count cannot exceed 1024 clones per batch",
+            ));
+        }
+        if self.hold && self.forkable {
+            return Err(smolvm::Error::config(
+                "fork",
+                "--hold cannot be combined with --forkable; pool slots are disposable leaves",
             ));
         }
 
@@ -3123,6 +3167,7 @@ impl ForkCmd {
                     fork_env: &fork_env,
                     fork_secrets: &fork_secrets,
                     wait_ready,
+                    hold: self.hold,
                 },
             );
         }
@@ -3166,7 +3211,28 @@ impl ForkCmd {
             &fork_secrets,
             wait_ready,
             self.parallel.get() as usize,
+            self.hold,
         )
+    }
+}
+
+/// Assign job-specific parameters and release one held fork-pool slot.
+#[derive(Args, Debug)]
+pub struct ForkReleaseCmd {
+    /// Held clone to assign and release.
+    #[arg(short = 'n', long = "name", value_name = "NAME")]
+    pub name: String,
+
+    /// Assignment parameter (repeatable, KEY=VALUE). Values override matching
+    /// parameters installed when the slot was provisioned.
+    #[arg(short = 'e', long = "env", value_name = "KEY=VALUE")]
+    pub env: Vec<String>,
+}
+
+impl ForkReleaseCmd {
+    pub fn run(self) -> smolvm::Result<()> {
+        let env = smolvm::util::parse_env_list(&self.env);
+        vm_common::release_held_fork(&self.name, &env)
     }
 }
 
@@ -3193,9 +3259,10 @@ fn render_indexed_fork_env(
 fn forkpoint_timeout(
     count: u32,
     explicitly_requested: bool,
+    hold: bool,
     timeout: Duration,
 ) -> Option<Duration> {
-    (count > 1 || explicitly_requested).then_some(timeout)
+    (count > 1 || explicitly_requested || hold).then_some(timeout)
 }
 
 // ============================================================================

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -721,6 +721,7 @@ pub struct ForkVmOptions<'a> {
     pub fork_env: &'a [(String, String)],
     pub fork_secrets: &'a BTreeMap<String, SecretRef>,
     pub wait_ready: Option<std::time::Duration>,
+    pub hold: bool,
 }
 
 pub fn fork_vm(golden: &str, clone: &str, options: ForkVmOptions<'_>) -> smolvm::Result<()> {
@@ -735,15 +736,26 @@ pub fn fork_vm(golden: &str, clone: &str, options: ForkVmOptions<'_>) -> smolvm:
     // The launch-agnostic mechanics live in the lib (`agent::fork`) so the CLI
     // and the serve API share one implementation.
     eprintln!("Freezing golden '{golden}' as fork base...");
-    let prep = smolvm::agent::fork::prepare_fork(
-        &db,
-        golden,
-        clone,
-        options.pinned_ports,
-        options.clone_forkable,
-        options.fork_env,
-        options.fork_secrets,
-    )?;
+    let prep = if options.hold {
+        smolvm::agent::fork::prepare_held_fork(
+            &db,
+            golden,
+            clone,
+            options.pinned_ports,
+            options.fork_env,
+            options.fork_secrets,
+        )?
+    } else {
+        smolvm::agent::fork::prepare_fork(
+            &db,
+            golden,
+            clone,
+            options.pinned_ports,
+            options.clone_forkable,
+            options.fork_env,
+            options.fork_secrets,
+        )?
+    };
     for (golden_host, guest, clone_host) in &prep.port_remaps {
         if options.pinned_ports.is_empty() {
             eprintln!(
@@ -755,23 +767,31 @@ pub fn fork_vm(golden: &str, clone: &str, options: ForkVmOptions<'_>) -> smolvm:
     }
 
     let snapshot_dir = prep.snapshot_dir.clone();
+    let resume_golden = prep.resume_golden_on_rollback;
     if let Err(error) =
         boot_prepared_fork(&db, clone, prep, options.share_weights, options.fork_env)
     {
-        return rollback_failed_fork(golden, &snapshot_dir, error);
+        return rollback_failed_fork(golden, &snapshot_dir, resume_golden, error);
     }
-    if options.wait_ready.is_some() {
+    if options.wait_ready.is_some() && !options.hold {
         if let Err(error) = smolvm::agent::fork::fail_closed_on_rejuvenation(
             smolvm::agent::fork::release_forkpoint(clone),
             || teardown_fork_clone(&db, clone),
         ) {
-            return rollback_failed_fork(golden, &snapshot_dir, error);
+            return rollback_failed_fork(golden, &snapshot_dir, resume_golden, error);
         }
     }
-    eprintln!(
-        "Forked '{golden}' -> '{clone}'. Golden stays frozen as the fork base \
-         (do not start it again while clones exist)."
-    );
+    if options.hold {
+        eprintln!(
+            "Forked '{golden}' -> held slot '{clone}'. Release it with \
+             `smolvm machine fork-release --name {clone}`."
+        );
+    } else {
+        eprintln!(
+            "Forked '{golden}' -> '{clone}'. Golden stays frozen as the fork base \
+             (do not start it again while clones exist)."
+        );
+    }
     Ok(())
 }
 
@@ -785,6 +805,7 @@ pub fn fork_vm_batch(
     fork_secrets: &BTreeMap<String, SecretRef>,
     wait_ready: Option<std::time::Duration>,
     parallel: usize,
+    hold: bool,
 ) -> smolvm::Result<()> {
     let db = SmolvmDb::open()?;
     if let Some(timeout) = wait_ready {
@@ -800,6 +821,7 @@ pub fn fork_vm_batch(
             clone_forkable: false,
             fork_env: env,
             fork_secrets,
+            hold,
         })
         .collect();
     eprintln!(
@@ -808,6 +830,7 @@ pub fn fork_vm_batch(
     );
     let prepared = smolvm::agent::fork::prepare_forks(&db, golden, &specs)?;
     let snapshot_dir = prepared[0].snapshot_dir.clone();
+    let resume_golden = prepared[0].resume_golden_on_rollback;
     let all_names: Vec<String> = clones.iter().map(|(name, _)| name.clone()).collect();
     let jobs: Vec<_> = prepared
         .into_iter()
@@ -884,7 +907,7 @@ pub fn fork_vm_batch(
         }
     }
 
-    if first_error.is_none() && wait_ready.is_some() {
+    if first_error.is_none() && wait_ready.is_some() && !hold {
         for name in &all_names {
             if let Err(error) = smolvm::agent::fork::release_forkpoint(name) {
                 first_error = Some(smolvm::Error::agent(
@@ -900,12 +923,74 @@ pub fn fork_vm_batch(
         for name in &all_names {
             teardown_fork_clone(&db, name);
         }
-        return rollback_failed_fork(golden, &snapshot_dir, error);
+        return rollback_failed_fork(golden, &snapshot_dir, resume_golden, error);
     }
 
+    if hold {
+        eprintln!(
+            "Provisioned {} held slots from '{golden}' with one snapshot.",
+            all_names.len()
+        );
+    } else {
+        eprintln!(
+            "Forked {} clones from '{golden}' with one snapshot.",
+            all_names.len()
+        );
+    }
+    Ok(())
+}
+
+/// Assign and release one held clone. This is intentionally one-way: after the
+/// workload begins, the clone is dirty and must be replaced from its golden
+/// before it can serve another independent job.
+pub fn release_held_fork(clone: &str, assignment: &[(String, String)]) -> smolvm::Result<()> {
+    let db = SmolvmDb::open()?;
+    let record = db
+        .get_vm(clone)?
+        .ok_or_else(|| smolvm::Error::vm_not_found(clone))?;
+    if record.golden.is_none() {
+        return Err(smolvm::Error::agent(
+            "release held fork",
+            format!("machine '{clone}' is not a fork clone"),
+        ));
+    }
+    if !record.forkpoint_held {
+        return Err(smolvm::Error::agent(
+            "release held fork",
+            format!("clone '{clone}' is not a held pool slot"),
+        ));
+    }
+
+    smolvm::agent::fork::validate_fork_env(assignment)?;
+    let merged = smolvm::agent::fork::merge_fork_env(&record.fork_env, assignment);
+    let claimed = std::cell::Cell::new(false);
+    db.update_vm(clone, |updated| {
+        if updated.forkpoint_held {
+            smolvm::agent::fork::record_fork_activation(updated, assignment, merged.clone());
+            claimed.set(true);
+        }
+    })?
+    .ok_or_else(|| smolvm::Error::vm_not_found(clone))?;
+    if !claimed.get() {
+        return Err(smolvm::Error::agent(
+            "release held fork",
+            format!("clone '{clone}' was already claimed"),
+        ));
+    }
+    let activated = smolvm::agent::fork::activate_held_fork(clone, &record, assignment).map_err(
+        |error| {
+            smolvm::Error::agent(
+                "release held fork",
+                format!(
+                    "slot '{clone}' was claimed and will not be reused after activation failed: {error}"
+                ),
+            )
+        },
+    )?;
+    debug_assert_eq!(activated, merged);
     eprintln!(
-        "Forked {} clones from '{golden}' with one snapshot.",
-        all_names.len()
+        "Released held slot '{clone}'. Replace it from '{}' after the workload completes.",
+        record.golden.as_deref().unwrap_or("its golden")
     );
     Ok(())
 }
@@ -956,10 +1041,15 @@ fn teardown_fork_clone(db: &SmolvmDb, clone: &str) {
 fn rollback_failed_fork(
     golden: &str,
     snapshot_dir: &std::path::Path,
+    resume_golden: bool,
     error: smolvm::Error,
 ) -> smolvm::Result<()> {
     let cleanup_error = std::fs::remove_dir_all(snapshot_dir).err();
-    let resume_error = smolvm::agent::fork::resume_golden(golden).err();
+    let resume_error = if resume_golden {
+        smolvm::agent::fork::resume_golden(golden).err()
+    } else {
+        None
+    };
     match (cleanup_error, resume_error) {
         (None, None) => Err(error),
         (cleanup, resume) => Err(smolvm::Error::agent(
@@ -2054,6 +2144,7 @@ fn machine_status_json(name: &str, record: &VmRecord) -> serde_json::Value {
         "ephemeral": record.ephemeral,
         "gpu": record.gpu.unwrap_or(false),
         "gpu_vram_mib": record.gpu_vram_mib,
+        "forkpoint_held": record.forkpoint_held,
         "restart_policy": record.restart.policy.to_string(),
         "restart_max_retries": record.restart.max_retries,
         "restart_count": record.restart.restart_count,
@@ -2166,6 +2257,9 @@ pub fn list_vms(verbose: bool, json: bool) -> smolvm::Result<()> {
                         Some(vram) => println!("  GPU: enabled ({} MiB VRAM)", vram),
                         None => println!("  GPU: enabled"),
                     }
+                }
+                if record.forkpoint_held {
+                    println!("  Fork slot: held");
                 }
                 for cmd in &record.init {
                     println!("  Init: {}", cmd);

--- a/src/config.rs
+++ b/src/config.rs
@@ -554,6 +554,21 @@ pub struct VmRecord {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub golden: Option<String>,
 
+    /// Whether a fork clone is still parked at the inherited workload
+    /// forkpoint. Held clones are clean, already-booted pool slots: a caller
+    /// installs the job-specific fork parameters and releases each slot once.
+    /// A released training clone is disposable and must never be marked held
+    /// again because its optimizer, RNG, and dataset state may have changed.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub forkpoint_held: bool,
+
+    /// Parameters delivered through `/etc/smolvm/fork-env` for this clone.
+    /// Kept separately from the machine's ordinary environment so a held slot
+    /// can merge assignment-time values without copying unrelated golden env
+    /// entries into the workload-facing parameter file.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub fork_env: Vec<(String, String)>,
+
     /// Set for machines created by the Kubernetes containerd shim (pod
     /// sandboxes). Scopes node-reboot reconciliation (see
     /// `control::reconcile_runtime_machines`) so it reclaims only shim-managed
@@ -645,6 +660,8 @@ impl VmRecord {
             ephemeral: false,
             source_smolmachine: None,
             golden: None,
+            forkpoint_held: false,
+            fork_env: Vec::new(),
             runtime_managed: false,
         }
     }
@@ -704,6 +721,8 @@ impl VmRecord {
             ephemeral: false,
             source_smolmachine: None,
             golden: None,
+            forkpoint_held: false,
+            fork_env: Vec::new(),
             runtime_managed: false,
         }
     }
@@ -1178,6 +1197,27 @@ mod tests {
         let legacy: VmRecord = serde_json::from_value(legacy_value).unwrap();
         assert_eq!(legacy.cuda_fork_pool_size, None);
         assert_eq!(legacy.cuda_vram_limit_mib, None);
+    }
+
+    #[test]
+    fn held_fork_state_roundtrips_and_legacy_records_default_released() {
+        let mut record = VmRecord::new("slot-0".to_string(), 2, 1024, vec![], vec![], false);
+        record.golden = Some("golden".to_string());
+        record.forkpoint_held = true;
+        record.fork_env = vec![("SMOLVM_FORK_INDEX".to_string(), "0".to_string())];
+
+        let encoded = serde_json::to_value(&record).unwrap();
+        let decoded: VmRecord = serde_json::from_value(encoded.clone()).unwrap();
+        assert!(decoded.forkpoint_held);
+        assert_eq!(decoded.fork_env, record.fork_env);
+
+        let mut legacy_value = encoded;
+        let legacy_object = legacy_value.as_object_mut().unwrap();
+        legacy_object.remove("forkpoint_held");
+        legacy_object.remove("fork_env");
+        let legacy: VmRecord = serde_json::from_value(legacy_value).unwrap();
+        assert!(!legacy.forkpoint_held);
+        assert!(legacy.fork_env.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Adds held batch forks and atomic CLI/API release so schedulers can vend clean prebooted slots and replenish them from a frozen golden.

Validated with workspace tests, CLI/API lifecycle tests, and two consecutive QLoRA waves on an RTX 3070.