### PR TITLE
Confirm VM exit before deleting storage

### DIFF
--- a/src/agent/state_probe.rs
+++ b/src/agent/state_probe.rs
@@ -121,7 +121,10 @@ fn recover_unreachable_machine_in_db(record: &VmRecord, db: &SmolvmDb) -> crate:
             if !crate::process::is_our_process_strict(pid, record.pid_start_time) {
                 return Err(crate::Error::agent(
                     "recover unreachable machine",
-                    format!("refusing to stop unverified process {pid}"),
+                    format!(
+                        "refusing to stop unverified process {pid}; if {pid} is \
+                         this VM's process, run: kill -9 {pid}, then retry"
+                    ),
                 ));
             }
             crate::process::stop_vm_process(
@@ -149,16 +152,18 @@ fn recover_unreachable_machine_in_db(record: &VmRecord, db: &SmolvmDb) -> crate:
 /// CLI/API boundary can share the helper without coupling to
 /// `SmolvmConfig`.
 ///
-/// Returns `true` when recovery actually ran, so callers can print
+/// Returns `Ok(true)` when recovery actually ran, so callers can print
 /// a user-facing notice (start/stop/delete all want to mention the
 /// teardown happened — the alternative is a silent kill, which is
 /// surprising when the operator didn't know a zombie existed).
-pub fn recover_if_unreachable(name: &str) -> bool {
-    let Ok(db) = SmolvmDb::open() else {
-        return false;
-    };
+/// Returns `Ok(false)` when the machine is not Unreachable and nothing
+/// happened. Returns `Err` when the zombie could not be confirmed dead
+/// (unverified PID, or still alive after SIGTERM+SIGKILL); callers must
+/// not proceed as if the machine were stopped in that case.
+pub fn recover_if_unreachable(name: &str) -> crate::Result<bool> {
+    let db = SmolvmDb::open()?;
     let Ok(Some(record)) = db.get_vm(name) else {
-        return false;
+        return Ok(false);
     };
     // Only a genuine zombie resolves to `Unreachable`. A frozen fork base
     // resolves to `Frozen` (see `resolve_state`) and is left alone here —
@@ -166,9 +171,10 @@ pub fn recover_if_unreachable(name: &str) -> bool {
     // A force-delete that genuinely wants to break the chain calls
     // `recover_unreachable_machine` directly, bypassing this path.
     if resolve_state(name, &record) != RecordState::Unreachable {
-        return false;
+        return Ok(false);
     }
-    recover_unreachable_machine(&record).is_ok()
+    recover_unreachable_machine_in_db(&record, &db)?;
+    Ok(true)
 }
 
 /// Return true if a short-timeout vsock ping to the agent for this
@@ -303,6 +309,7 @@ mod tests {
         let error = recover_unreachable_machine_in_db(&r, &db).unwrap_err();
 
         assert!(error.to_string().contains("unverified process"));
+        assert!(error.to_string().contains("kill -9"));
         let persisted = db.get_vm(&r.name).unwrap().unwrap();
         assert_eq!(persisted.state, RecordState::Unreachable);
         assert_eq!(persisted.pid, r.pid);

--- a/src/agent/state_probe.rs
+++ b/src/agent/state_probe.rs
@@ -103,47 +103,43 @@ fn has_live_clones(name: &str) -> bool {
 /// the record's PID/state so the caller can proceed to a clean
 /// fresh start — or simply leave the VM Stopped.
 ///
-/// Kills via verified SIGTERM (PID + start-time match, so a recycled
-/// PID is never harmed), waits up to 2 s for the process to exit,
-/// then escalates to verified SIGKILL.
-///
-/// Infallible by design: if the kill or DB write fails, downstream
-/// code will surface a clear error (libkrun "address already in
-/// use" on restart, or the next `list` will re-probe and converge
-/// on Stopped since the PID ends up dead either way). The caller
-/// doesn't need to branch on success.
+/// Refuses to signal a live PID unless its start time matches the record,
+/// then uses the shared VM shutdown path to wait for confirmed process death.
+/// The record is cleared only after that confirmation.
 ///
 /// This is the shared teardown used by both the CLI (`machine start
 /// | stop | delete --stop`) and the HTTP API (`POST /machines/X/start`)
 /// so all surfaces recover from the Unreachable state the same way.
-pub fn recover_unreachable_machine(record: &VmRecord) {
-    use std::time::{Duration, Instant};
+pub fn recover_unreachable_machine(record: &VmRecord) -> crate::Result<()> {
+    let db = SmolvmDb::open()?;
+    recover_unreachable_machine_in_db(record, &db)
+}
 
+fn recover_unreachable_machine_in_db(record: &VmRecord, db: &SmolvmDb) -> crate::Result<()> {
     if let Some(pid) = record.pid {
-        if crate::process::terminate_verified(pid, record.pid_start_time) {
-            let deadline = Instant::now() + Duration::from_secs(2);
-            while Instant::now() < deadline {
-                if !crate::process::is_alive(pid) {
-                    break;
-                }
-                std::thread::sleep(Duration::from_millis(100));
+        if crate::process::is_alive(pid) {
+            if !crate::process::is_our_process_strict(pid, record.pid_start_time) {
+                return Err(crate::Error::agent(
+                    "recover unreachable machine",
+                    format!("refusing to stop unverified process {pid}"),
+                ));
             }
-            if crate::process::is_alive(pid) {
-                crate::process::kill_verified(pid, record.pid_start_time);
-            }
+            crate::process::stop_vm_process(
+                pid,
+                crate::process::VM_SIGTERM_TIMEOUT,
+                crate::process::VM_SIGKILL_TIMEOUT,
+            )?;
         }
     }
 
-    // Best-effort DB clear. We write via SmolvmDb (not SmolvmConfig)
-    // to avoid pulling the full in-memory config load; the db update
-    // is targeted to the one record.
-    if let Ok(db) = SmolvmDb::open() {
-        let _ = db.update_vm(&record.name, |r| {
-            r.state = RecordState::Stopped;
-            r.pid = None;
-            r.pid_start_time = None;
-        });
-    }
+    // Write via SmolvmDb (not SmolvmConfig) to avoid pulling the full
+    // in-memory config load; the update is targeted to the one record.
+    db.update_vm(&record.name, |r| {
+        r.state = RecordState::Stopped;
+        r.pid = None;
+        r.pid_start_time = None;
+    })?;
+    Ok(())
 }
 
 /// If the named VM resolves to `Unreachable`, recover it (kill the
@@ -172,8 +168,7 @@ pub fn recover_if_unreachable(name: &str) -> bool {
     if resolve_state(name, &record) != RecordState::Unreachable {
         return false;
     }
-    recover_unreachable_machine(&record);
-    true
+    recover_unreachable_machine(&record).is_ok()
 }
 
 /// Return true if a short-timeout vsock ping to the agent for this
@@ -295,5 +290,22 @@ mod tests {
         // "does-not-exist" so this also covers has_live_clones == false.)
         let r = record(RecordState::Stopped, Some(99999));
         assert!(!is_frozen_fork_base("does-not-exist", &r));
+    }
+
+    #[test]
+    fn failed_recovery_preserves_process_state() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db = SmolvmDb::open_at(&dir.path().join("test.db")).unwrap();
+        let mut r = record(RecordState::Unreachable, Some(std::process::id() as i32));
+        r.pid_start_time = None;
+        db.insert_vm(&r.name, &r).unwrap();
+
+        let error = recover_unreachable_machine_in_db(&r, &db).unwrap_err();
+
+        assert!(error.to_string().contains("unverified process"));
+        let persisted = db.get_vm(&r.name).unwrap().unwrap();
+        assert_eq!(persisted.state, RecordState::Unreachable);
+        assert_eq!(persisted.pid, r.pid);
+        assert_eq!(persisted.pid_start_time, r.pid_start_time);
     }
 }

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -990,13 +990,20 @@ pub async fn start_machine(
         // Zombie: verified-kill the VMM and clear the DB record
         // before falling through to a clean fresh start. Any stale
         // in-memory registry entry gets overwritten by the
-        // `insert_machine` call later in this handler.
+        // `insert_machine` call later in this handler. If the zombie
+        // cannot be confirmed dead, refuse the start instead of
+        // booting on top of it.
         let name_recover = name.clone();
         tokio::task::spawn_blocking(move || {
-            crate::agent::state_probe::recover_if_unreachable(&name_recover);
+            crate::agent::state_probe::recover_if_unreachable(&name_recover)
         })
         .await
-        .map_err(|e| ApiError::internal(format!("task error: {}", e)))?;
+        .map_err(|e| ApiError::internal(format!("task error: {}", e)))?
+        .map_err(|e| {
+            ApiError::internal(format!(
+                "machine '{name}' is unreachable and zombie cleanup failed: {e}"
+            ))
+        })?;
     }
 
     if let Some(pool_size) = query.fork_pool_size {

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -127,7 +127,9 @@ pub fn ensure_running_and_connect(
 /// prints a one-line notice when recovery actually runs. The shared
 /// helper is silent (the HTTP API doesn't have a stdout to write
 /// to); CLI callers want the operator to see the zombie teardown.
-fn cli_recover_if_unreachable(name: &str) {
+/// A failed recovery propagates: the caller must not report the
+/// machine as stopped, detach its volumes, or start over the zombie.
+fn cli_recover_if_unreachable(name: &str) -> smolvm::Result<()> {
     // Peek at the record before recovery so we can show the PID in
     // the notice. Losing the PID after recovery is fine — the DB
     // gets cleared — but we want the operator to know *which*
@@ -137,7 +139,7 @@ fn cli_recover_if_unreachable(name: &str) {
         .and_then(|db| db.get_vm(name).ok().flatten())
         .and_then(|r| r.pid);
 
-    if smolvm::agent::state_probe::recover_if_unreachable(name) {
+    if smolvm::agent::state_probe::recover_if_unreachable(name)? {
         println!(
             "Machine '{}' is unreachable (PID {} alive but agent unresponsive); \
              cleaning up.",
@@ -145,6 +147,7 @@ fn cli_recover_if_unreachable(name: &str) {
             pid_for_notice.unwrap_or(0)
         );
     }
+    Ok(())
 }
 
 /// If the VM record says `Running` and the libkrun PID is alive but
@@ -1054,7 +1057,9 @@ fn start_vm_named_with_db(
         RecordState::Unreachable => {
             // Zombie VMM: kill it, clear the record, fall through to
             // a clean fresh start.
-            cli_recover_if_unreachable(name);
+            // If the zombie cannot be confirmed dead, fail instead of
+            // starting on top of it (socket/pid-file conflicts).
+            cli_recover_if_unreachable(name)?;
         }
         RecordState::Frozen => {
             // Snapshot-frozen fork base: relaunching it writable would
@@ -1536,7 +1541,9 @@ pub fn start_vm_default(proxy: Option<&str>, no_proxy: Option<&str>) -> smolvm::
     // try_connect_existing failed — could be "really stopped" or
     // "zombie VMM with dead agent". Recover the zombie case before
     // starting fresh; no-op otherwise.
-    cli_recover_if_unreachable("default");
+    // A failed recovery must abort the start: booting over a live
+    // zombie would collide on its sockets and pid files.
+    cli_recover_if_unreachable("default")?;
 
     eprintln!("Starting machine 'default'...");
     manager.ensure_running()?;
@@ -1639,7 +1646,10 @@ pub fn stop_vm_named(name: &str) -> smolvm::Result<()> {
     let resolved = smolvm::agent::state_probe::resolve_state(name, &record);
     match resolved {
         RecordState::Unreachable => {
-            cli_recover_if_unreachable(name);
+            // Only past this point is the zombie confirmed dead. On
+            // failure we return the error without claiming the machine
+            // stopped and without detaching its volumes.
+            cli_recover_if_unreachable(name)?;
             // Process is gone — detach the layers volume so a non-running
             // machine never holds a mount (invariant: mounted iff running).
             // macOS hdiutil detach; a no-op on Linux.

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -1818,9 +1818,26 @@ pub struct DeleteVmOptions {
     pub cascade: bool,
 }
 
+fn remove_vm_data_and_record(
+    db: &SmolvmDb,
+    name: &str,
+    data_dir: &std::path::Path,
+) -> smolvm::Result<()> {
+    if data_dir.exists() {
+        std::fs::remove_dir_all(data_dir).map_err(|e| {
+            smolvm::Error::storage(
+                "delete machine data",
+                format!("{}: {e}", data_dir.display()),
+            )
+        })?;
+    }
+    db.remove_vm(name)?;
+    Ok(())
+}
+
 /// Delete a named machine configuration.
 pub fn delete_vm(name: &str, force: bool, options: DeleteVmOptions) -> smolvm::Result<()> {
-    let mut config = SmolvmConfig::load()?;
+    let config = SmolvmConfig::load()?;
 
     // Check if exists
     let record = config
@@ -1849,9 +1866,6 @@ pub fn delete_vm(name: &str, force: bool, options: DeleteVmOptions) -> smolvm::R
                     },
                 )?;
             }
-            // The clone deletes above rewrote the config on disk; reload so the
-            // golden's own removal below persists against current state.
-            config = SmolvmConfig::load()?;
         } else if !force {
             return Err(smolvm::Error::agent(
                 "delete",
@@ -1879,11 +1893,14 @@ pub fn delete_vm(name: &str, force: bool, options: DeleteVmOptions) -> smolvm::R
     if options.stop_if_running {
         match smolvm::agent::state_probe::resolve_state(name, &record) {
             RecordState::Running => {
-                if let Ok(manager) = AgentManager::for_vm(name) {
-                    println!("Stopping machine '{}'...", name);
-                    if let Err(e) = manager.stop() {
-                        tracing::warn!(error = %e, "failed to stop machine");
-                    }
+                let manager = AgentManager::for_vm(name)?;
+                println!("Stopping machine '{}'...", name);
+                manager.stop()?;
+                if record.pid.is_some_and(smolvm::process::is_alive) {
+                    return Err(smolvm::Error::agent(
+                        "delete machine",
+                        format!("machine '{name}' process is still alive after stop"),
+                    ));
                 }
             }
             RecordState::Unreachable => {
@@ -1892,7 +1909,7 @@ pub fn delete_vm(name: &str, force: bool, options: DeleteVmOptions) -> smolvm::R
                 // was given. The guarded `cli_recover_if_unreachable` would
                 // skip a frozen fork base, orphaning its VMM after we remove
                 // the record below.
-                smolvm::agent::state_probe::recover_unreachable_machine(&record);
+                smolvm::agent::state_probe::recover_unreachable_machine(&record)?;
             }
             RecordState::Frozen => {
                 // A frozen fork base only reaches here under --force (the
@@ -1900,7 +1917,7 @@ pub fn delete_vm(name: &str, force: bool, options: DeleteVmOptions) -> smolvm::R
                 // Reap its paused VMM so it isn't orphaned once the record
                 // is removed; the clones' overlays are left dangling, as
                 // the force-delete warning already states.
-                smolvm::agent::state_probe::recover_unreachable_machine(&record);
+                smolvm::agent::state_probe::recover_unreachable_machine(&record)?;
             }
             _ => {}
         }
@@ -1923,9 +1940,6 @@ pub fn delete_vm(name: &str, force: bool, options: DeleteVmOptions) -> smolvm::R
         }
     }
 
-    // Remove from config (persists immediately to database)
-    config.remove_vm(name);
-
     // If the machine was created from a .smolmachine, detach its case-sensitive
     // layers volume (macOS hdiutil mount; no-op on Linux) before removing the
     // data dir below — otherwise the `rm -rf` fails with "Resource busy". The
@@ -1945,10 +1959,11 @@ pub fn delete_vm(name: &str, force: bool, options: DeleteVmOptions) -> smolvm::R
         // Release this VM's per-VM uid (if any) before the dir holding its
         // `.vm-uid` record is removed. See process::free_vm_uid.
         smolvm::process::free_vm_uid(&smolvm::agent::vm_uid_registry_dir(), &data_dir);
-        if let Err(e) = std::fs::remove_dir_all(&data_dir) {
-            tracing::warn!(error = %e, "Failed to remove VM data directory: {}", data_dir.display());
-        }
     }
+
+    // Keep the record until process death and storage removal are both confirmed,
+    // so a failed delete remains visible and can be retried safely.
+    remove_vm_data_and_record(&SmolvmDb::open()?, name, &data_dir)?;
 
     // The VM's readiness marker lives in the *shared* agent rootfs, not its data
     // dir, so the removal above doesn't take it. Sweep it (and any other markers
@@ -2482,6 +2497,20 @@ mod init_runner_tests {
             "cap limits how many are reaped per call"
         );
         assert!(orphaned_ephemeral_names(&vms, alive, 0).is_empty());
+    }
+
+    #[test]
+    fn failed_data_removal_preserves_machine_record() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db = SmolvmDb::open_at(&dir.path().join("test.db")).unwrap();
+        let name = "delete-failure";
+        let record = VmRecord::new(name.to_string(), 1, 256, vec![], vec![], false);
+        db.insert_vm(name, &record).unwrap();
+
+        let data_path = dir.path().join("not-a-directory");
+        std::fs::write(&data_path, b"occupied").unwrap();
+        assert!(remove_vm_data_and_record(&db, name, &data_path).is_err());
+        assert!(db.get_vm(name).unwrap().is_some());
     }
 
     fn sample_image_info(env: Vec<&str>, workdir: Option<&str>, user: Option<&str>) -> ImageInfo {

--- a/tests/test_fork_base_guards.sh
+++ b/tests/test_fork_base_guards.sh
@@ -108,7 +108,17 @@ test_original_clone_alive() {
 
 # delete --force breaks the chain and reaps the golden's VMM (no orphan).
 test_force_delete_reaps_golden() {
+    local pid
+    pid=$("$SMOLVM" machine status --name "$GOLD" --json 2>/dev/null |
+        sed -nE 's/.*"pid":[[:space:]]*([0-9]+).*/\1/p' | head -1)
+    [[ -n "$pid" ]] || {
+        echo "FAIL: golden PID missing before force delete"; return 1; }
+
     "$SMOLVM" machine delete --name "$GOLD" -f >/dev/null 2>&1 || return 1
+    if kill -0 "$pid" 2>/dev/null; then
+        echo "FAIL: golden process $pid still alive after force delete"
+        return 1
+    fi
     # Golden record is gone.
     "$SMOLVM" machine ls --json 2>/dev/null | grep -q "\"name\":\"$GOLD\"" && {
         echo "FAIL: golden record still present after force delete"; return 1; }


### PR DESCRIPTION
## Summary

- propagate manager construction and VM stop failures from `machine delete`
- keep unreachable/frozen PID state until verified process termination succeeds
- remove VM storage before removing its database record
- assert that force-deleting a fork base reaps its exact `_boot-vm` PID

This keeps `--force` limited to confirmation/dependency behavior; it no longer permits deletion to continue after inconclusive teardown.

Closes #787.

## Verification

- `cargo test --bin smolvm` — 76 passed
- `cargo fmt --all -- --check`
- `tests/test_fork_base_guards.sh` — **7/7 passed** on macOS arm64 (real VMs, fork + frozen golden + `delete --force`)

The fork suite exercises the changed path directly: force-deleting a frozen golden goes through `RecordState::Frozen` -> `recover_unreachable_machine`, and the strengthened test now captures the golden's `_boot-vm` PID before `delete -f` and asserts that exact PID is dead before accepting the record's removal.

The suite was run with `SMOLVM_ORCHESTRATED=1` to skip its broad `pkill` preflight, and with the library path pinned to a known-good libkrun. The repo's bundled `lib/libkrun.dylib` cannot boot a VM on macOS: its embedded guest init payload is a Mach-O arm64 binary rather than a Linux aarch64 ELF, so the guest kernel panics with `Requested init /init.krun failed (error -8)` (ENOEXEC). That is a pre-existing packaging defect unrelated to this change, and it is invisible to CI because hosted runners cannot run VM integration tests.
