### PR TITLE
tiny nit: Stop reporting a skipped test suite as all-passed

### DIFF
--- a/tests/common.sh
+++ b/tests/common.sh
@@ -222,7 +222,12 @@ print_summary() {
 
     echo ""
 
-    if [[ $TESTS_FAILED -eq 0 ]]; then
+    if [[ $TESTS_FAILED -eq 0 ]] && [[ $TESTS_RUN -eq 0 ]]; then
+        # Nothing ran — usually a suite that skipped its setup (unsupported
+        # platform, missing dependency, a VM that would not boot).
+        echo -e "${YELLOW}No tests ran — suite skipped.${NC}"
+        return 0
+    elif [[ $TESTS_FAILED -eq 0 ]]; then
         echo -e "${GREEN}All tests passed!${NC}"
         return 0
     else


### PR DESCRIPTION

## Summary

Print `No tests ran — suite skipped.` instead of `All tests passed!` when a suite runs zero tests.

A suite that skips its setup (unsupported platform, missing dependency, a VM that will not boot) currently prints a green `All tests passed!`. That is how the libkrun defect in #789 stayed invisible: `tests/test_fork_base_guards.sh` reported `Tests run: 0` and still claimed success.

## Verification

`tests/test_fork_base_guards.sh` on macOS arm64.

Suite skips (bundled libkrun cannot boot a VM):

```
Tests run:    0
Tests passed: 0
Tests failed: 0

No tests ran — suite skipped.
```

Suite runs against a working libkrun — unchanged:

```
Tests run:    7
Tests passed: 7
Tests failed: 0

All tests passed!
```

`bash -n tests/common.sh` passes.
