### PR TITLE
Harden the registry pull path against SSRF: reject repository traversal and private pull hosts

### DIFF
--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -2114,6 +2114,40 @@ pub async fn export_machine(
     }))
 }
 
+/// True if `host` is a loopback, link-local, or private-range address — an
+/// SSRF-prone pull destination on a fleet node (its own `127.0.0.1` services, the
+/// cloud metadata endpoint at `169.254.169.254`, or a neighbour on the private
+/// network). Hostnames that are not IP literals return false (a DNS-rebind to a
+/// private address is a residual not covered here).
+fn is_ssrf_prone_registry_host(host: &str) -> bool {
+    // localhost / 127.0.0.0/8 / ::1 / 0.0.0.0 — reuse the registry classifier.
+    if smolvm_registry::is_local_registry(host) {
+        return true;
+    }
+    // Extract the bare host (strip IPv6 brackets and any :port), then classify it
+    // only if it parses as an IP literal.
+    let bare = if let Some(rest) = host.strip_prefix('[') {
+        rest.split(']').next().unwrap_or(rest)
+    } else if host.matches(':').count() == 1 {
+        host.split(':').next().unwrap_or(host)
+    } else {
+        host
+    };
+    match bare.parse::<std::net::IpAddr>() {
+        Ok(std::net::IpAddr::V4(v4)) => {
+            v4.is_private() || v4.is_loopback() || v4.is_link_local() || v4.is_unspecified()
+        }
+        Ok(std::net::IpAddr::V6(v6)) => {
+            let first = v6.segments()[0];
+            v6.is_loopback()
+                || v6.is_unspecified()
+                || (first & 0xffc0) == 0xfe80 // link-local fe80::/10
+                || (first & 0xfe00) == 0xfc00 // unique-local fc00::/7
+        }
+        Err(_) => false,
+    }
+}
+
 async fn pull_from_registry(
     registry_ref: &str,
     identity_token: Option<&str>,
@@ -2152,6 +2186,18 @@ pub(crate) async fn pull_smolmachine(
         "docker.io" => "registry-1.docker.io",
         h => h,
     };
+
+    // A control-plane tenant pull (identity_token present) must never target a
+    // loopback/link-local/private-range host: on a fleet node that is an SSRF
+    // pivot into node-local services, not a real registry. Local dev (no token)
+    // is unaffected, and legitimate tenant pulls resolve public registries.
+    if identity_token.is_some() && is_ssrf_prone_registry_host(api_host) {
+        return Err(ApiError::BadRequest(format!(
+            "registry host '{}' is a private/loopback address and is not permitted for tenant image pulls",
+            api_host
+        )));
+    }
+
     let base_url = if smolvm_registry::is_local_registry(api_host) {
         format!("http://{}", api_host)
     } else {
@@ -2239,6 +2285,39 @@ mod tests {
     use super::*;
     use crate::db::SmolvmDb;
     use tempfile::TempDir;
+
+    #[test]
+    fn ssrf_prone_registry_host_flags_loopback_linklocal_and_private() {
+        for host in [
+            "127.0.0.1:8081",
+            "localhost:5000",
+            "0.0.0.0",
+            "169.254.169.254", // cloud metadata
+            "10.0.0.5",
+            "172.16.4.4",
+            "192.168.1.10",
+            "[::1]:5000",
+            "[fe80::1]",
+            "[fc00::1]:443",
+        ] {
+            assert!(
+                is_ssrf_prone_registry_host(host),
+                "{host} should be flagged"
+            );
+        }
+        for host in [
+            "registry-1.docker.io",
+            "registry.smolmachines.com",
+            "ghcr.io",
+            "8.8.8.8",
+            "203.0.113.7:5000",
+        ] {
+            assert!(
+                !is_ssrf_prone_registry_host(host),
+                "{host} should NOT be flagged"
+            );
+        }
+    }
 
     #[test]
     fn export_stub_path_is_not_the_sidecar_name() {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -422,6 +422,23 @@ impl Reference {
             }
         }
 
+        // Reject any repository component that could break out of the `/v2/<repo>/`
+        // prefix when interpolated into a registry URL: a `.`/`..` traversal segment
+        // or anything outside the OCI repository charset (notably `%`, which can
+        // smuggle an encoded slash). Without this, `..` in a component turns
+        // `/v2/<repo>/manifests/...` into a request to an unrelated path on the host.
+        for component in namespace
+            .iter()
+            .flat_map(|ns| ns.split('/'))
+            .chain(std::iter::once(name.as_str()))
+        {
+            if !is_valid_repo_component(component) {
+                return Err(err(
+                    "invalid repository component (path traversal or disallowed characters)",
+                ));
+            }
+        }
+
         Ok(Reference {
             registry,
             namespace,
@@ -438,6 +455,18 @@ impl Reference {
             None => self.name.clone(),
         }
     }
+}
+
+/// A single `/`-delimited repository path component is safe to interpolate into a
+/// `/v2/<repo>/...` registry URL: non-empty, not a `.`/`..` traversal segment, and
+/// limited to the OCI repository charset `[A-Za-z0-9._-]` (so no `%`, `/`, or other
+/// URL metacharacters that could smuggle an encoded slash or escape the prefix).
+fn is_valid_repo_component(c: &str) -> bool {
+    !c.is_empty()
+        && c != "."
+        && c != ".."
+        && c.bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'.' || b == b'_' || b == b'-')
 }
 
 impl std::fmt::Display for Reference {
@@ -950,6 +979,40 @@ mirror = "ghcr-mirror.example.com"
             "unexpected reason: {}",
             err.reason
         );
+    }
+
+    #[test]
+    fn test_reference_rejects_repository_path_traversal() {
+        // A `..` component would turn `/v2/<repo>/...` into a request to an
+        // unrelated path on the registry host — reject it (and `.`, and any
+        // component carrying URL metacharacters like `%`).
+        for bad in [
+            "127.0.0.1:8081/../api/v1/machines:latest",
+            "registry.example.com/org/../secret:latest",
+            "registry.example.com/org/%2e%2e:latest",
+            "registry.example.com/org/a%2fb:latest",
+            "registry.example.com/./machine:latest",
+        ] {
+            let err = Reference::parse(bad).unwrap_err();
+            assert!(
+                err.reason.contains("invalid repository component"),
+                "expected rejection for {bad}, got: {}",
+                err.reason
+            );
+        }
+    }
+
+    #[test]
+    fn test_reference_accepts_normal_repositories() {
+        // The guard must not reject legitimate OCI repository paths.
+        for ok in [
+            "python-dev:latest",
+            "binsquare/custom:v1",
+            "ghcr.io/org/team/machine:latest",
+            "registry.example.com/a.b_c-d/img:latest",
+        ] {
+            assert!(Reference::parse(ok).is_ok(), "should accept {ok}");
+        }
     }
 
     // ── set_credentials / set_token / save ──────────────────────────────────


### PR DESCRIPTION
Two independent, defense-in-depth guards on the node's registry-pull path. Either one alone breaks an SSRF chain where a tenant-controlled image reference turns the node's in-process pull client into a request against node-local services.

**1. Repository path-traversal (`src/registry.rs`, `Reference::parse`).** A repository component of `..` (or one carrying URL metacharacters like `%`, which can smuggle an encoded slash) would turn `/v2/<repo>/manifests/...` into a request to an unrelated path on the host. `parse` now rejects any component that is `.`/`..` or falls outside the OCI repository charset `[A-Za-z0-9._-]`.

**2. Private/loopback pull hosts (`src/api/handlers/machines.rs`, `pull_smolmachine`).** A control-plane *tenant* pull (identity token present) must never target a loopback, link-local, or private-range host — on a fleet node that is an SSRF pivot into `127.0.0.1` services, the `169.254.169.254` metadata endpoint, or a private-network neighbour, not a real registry. Such pulls are now rejected with a 400. Local dev (no token) is unaffected, and legitimate tenant pulls resolve public registries.

Tests cover traversal rejection + normal-repository acceptance, and the host classifier across loopback/link-local/private/IPv6 vs public hosts.

Note: hostnames that are not IP literals are not classified in guard 2 (a DNS-rebind to a private address is a residual); guard 1 and the loopback-router restriction remain the primary defenses.