### PR TITLE
Rebuild the macOS libkrun.dylib with a static ELF guest init so a source checkout can boot VMs

### DIFF
--- a/lib/libkrun.dylib
+++ b/lib/libkrun.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b99047ebe37ead26cac1f9f5bc79108cb36cc9809d0ddb49648fe337b503f8e6
-size 6176528
+oid sha256:cf31756c8b2b79ee1f009af7ac91cd024ebfc4115e5b27b451a57ea3f9cbe5f3
+size 6218304


### PR DESCRIPTION
Fixes #789.

The committed macOS `lib/libkrun.dylib` embedded a **Mach-O** arm64 binary as the guest's `/init.krun`, so PID 1 could not be exec'd and every VM started from a source checkout panicked with `Requested init /init.krun failed (error -8)` (ENOEXEC). VM integration suites (e.g. `tests/test_fork_base_guards.sh`) then reported `Tests run: 0` and falsely printed "All tests passed."

Root cause: `libkrun/src/init_blob/build.rs` cross-compiles the guest init to `aarch64-unknown-linux-musl`, but when the build host lacks that Rust target it silently falls back to a host (macOS) build. The previously-committed dylib was built on a host without the musl target.

This rebuilds `lib/libkrun.dylib` from the pinned libkrun submodule (`ede6f798`, unchanged) on a host **with** the musl target present, so the embedded init is a statically-linked Linux aarch64 ELF. Provenance is unchanged (still `ede6f798`); only the macOS `lib/` binary changes.

Verified locally: a VM now boots from this dylib (`init.krun` runs as PID 1) and the full `tests/test_fork_base_guards.sh` suite runs for real (7/7).

Follow-up (separate PR): cherry-pick upstream libkrun `b0429184` ("init: enforce static linking") so this fallback fails the build loudly instead of silently shipping a broken init.