### PR TITLE
Stage lease payloads before worker release

### DIFF
--- a/src/api/handlers/pools.rs
+++ b/src/api/handlers/pools.rs
@@ -4,6 +4,8 @@ use axum::{
     extract::{Path, Query, State},
     Json,
 };
+use base64::Engine as _;
+use sha2::{Digest, Sha256};
 use std::sync::Arc;
 
 use crate::api::error::ApiError;
@@ -13,6 +15,7 @@ use crate::api::types::{
     DeleteResponse, ForkLeaseInfo, ForkPoolInfo, ListForkPoolsResponse, ResizeForkPoolRequest,
 };
 use crate::data::validate_vm_name;
+use crate::db::ForkPoolSlotClaim;
 use crate::pool::{
     ClaimForkPoolSlot, ForkLeaseRecord, ForkLeaseState, ForkPoolRecord, ForkPoolSlotState,
 };
@@ -24,6 +27,95 @@ const MAX_POOL_READY: u32 = 256;
 const MIN_LEASE_TTL_SECS: u64 = 30;
 const MAX_LEASE_TTL_SECS: u64 = 24 * 60 * 60;
 const MAX_IDEMPOTENCY_KEY_BYTES: usize = 256;
+const MAX_LEASE_PAYLOAD_FILES: usize = 32;
+const MAX_LEASE_PAYLOAD_BYTES: usize = 1024 * 1024;
+const MAX_LEASE_PAYLOAD_PATH_BYTES: usize = 512;
+const DEFAULT_LEASE_PAYLOAD_MODE: u32 = 0o644;
+
+#[derive(Clone)]
+struct StagedLeaseFile {
+    path: String,
+    data: Vec<u8>,
+    mode: u32,
+}
+
+fn validate_lease_payload(
+    files: &[crate::api::types::ForkLeasePayloadFile],
+) -> Result<(Vec<StagedLeaseFile>, Option<String>), ApiError> {
+    if files.len() > MAX_LEASE_PAYLOAD_FILES {
+        return Err(ApiError::BadRequest(format!(
+            "lease payload may contain at most {MAX_LEASE_PAYLOAD_FILES} files"
+        )));
+    }
+
+    let mut staged = Vec::with_capacity(files.len());
+    let mut paths = std::collections::HashSet::with_capacity(files.len());
+    let mut total = 0usize;
+    for file in files {
+        let path = file.path.as_str();
+        let valid_path = !path.is_empty()
+            && path.len() <= MAX_LEASE_PAYLOAD_PATH_BYTES
+            && !path.starts_with('/')
+            && !path.contains('\\')
+            && !path.chars().any(char::is_control)
+            && path
+                .split('/')
+                .all(|component| !component.is_empty() && component != "." && component != "..");
+        if !valid_path {
+            return Err(ApiError::BadRequest(format!(
+                "lease payload path '{path}' must be a safe relative path under /workspace"
+            )));
+        }
+        if !paths.insert(path.to_string()) {
+            return Err(ApiError::BadRequest(format!(
+                "lease payload path '{path}' is duplicated"
+            )));
+        }
+        let mode = file.mode.unwrap_or(DEFAULT_LEASE_PAYLOAD_MODE);
+        if mode & !0o777 != 0 {
+            return Err(ApiError::BadRequest(format!(
+                "lease payload mode for '{path}' must contain only Unix permission bits"
+            )));
+        }
+        let data = base64::engine::general_purpose::STANDARD
+            .decode(&file.data_base64)
+            .map_err(|_| {
+                ApiError::BadRequest(format!(
+                    "lease payload dataBase64 for '{path}' is not valid standard base64"
+                ))
+            })?;
+        total = total
+            .checked_add(data.len())
+            .ok_or_else(|| ApiError::BadRequest("lease payload decoded size overflowed".into()))?;
+        if total > MAX_LEASE_PAYLOAD_BYTES {
+            return Err(ApiError::BadRequest(format!(
+                "lease payload decoded contents must total at most {MAX_LEASE_PAYLOAD_BYTES} bytes"
+            )));
+        }
+        staged.push(StagedLeaseFile {
+            path: path.to_string(),
+            data,
+            mode,
+        });
+    }
+    if staged.is_empty() {
+        return Ok((staged, None));
+    }
+
+    // File order is not semantically meaningful because the workload remains
+    // parked until every write succeeds. Canonicalize it so idempotent retries
+    // may send the same file set in any order.
+    staged.sort_by(|left, right| left.path.cmp(&right.path));
+    let mut digest = Sha256::new();
+    for file in &staged {
+        digest.update((file.path.len() as u64).to_le_bytes());
+        digest.update(file.path.as_bytes());
+        digest.update(file.mode.to_le_bytes());
+        digest.update((file.data.len() as u64).to_le_bytes());
+        digest.update(&file.data);
+    }
+    Ok((staged, Some(hex::encode(digest.finalize()))))
+}
 
 fn lease_info(lease: ForkLeaseRecord) -> ForkLeaseInfo {
     ForkLeaseInfo {
@@ -41,6 +133,7 @@ async fn activate_claimed_lease(
     state: Arc<ApiState>,
     lease: ForkLeaseRecord,
     assignment: Vec<(String, String)>,
+    files: Vec<StagedLeaseFile>,
 ) -> Result<ForkLeaseRecord, String> {
     let record = match state.lookup_vm(&lease.machine_name).await {
         Ok(Some(record)) => record,
@@ -61,6 +154,19 @@ async fn activate_claimed_lease(
     };
     let machine = lease.machine_name.clone();
     let activation = tokio::task::spawn_blocking(move || {
+        if !files.is_empty() {
+            let socket = crate::agent::vm_data_dir(&machine).join("agent.sock");
+            let mut client = crate::agent::AgentClient::connect_with_retry(&socket)
+                .map_err(|e| crate::Error::agent("stage lease payload", e.to_string()))?;
+            for file in files {
+                let path = format!("/workspace/{}", file.path);
+                client
+                    .write_file(&path, &file.data, Some(file.mode))
+                    .map_err(|e| {
+                        crate::Error::agent("stage lease payload", format!("write '{path}': {e}"))
+                    })?;
+            }
+        }
         crate::agent::fork::activate_held_fork(&machine, &record, &assignment)
     })
     .await
@@ -385,9 +491,9 @@ pub async fn delete_pool(
     request_body = AcquireForkLeaseRequest,
     responses(
         (status = 200, description = "Worker lease", body = ForkLeaseInfo),
-        (status = 400, description = "Invalid assignment", body = ApiErrorResponse),
+        (status = 400, description = "Invalid assignment or payload", body = ApiErrorResponse),
         (status = 404, description = "Pool not found", body = ApiErrorResponse),
-        (status = 409, description = "Pool at active-lease capacity", body = ApiErrorResponse),
+        (status = 409, description = "Lease request conflicts with pool state", body = ApiErrorResponse),
         (status = 503, description = "No clean worker ready yet", body = ApiErrorResponse)
     )
 )]
@@ -407,6 +513,7 @@ pub async fn acquire_lease(
     let assignment = crate::util::parse_env_list(&req.env);
     crate::agent::fork::validate_fork_env(&assignment)
         .map_err(|e| ApiError::BadRequest(e.to_string()))?;
+    let (files, payload_sha256) = validate_lease_payload(&req.files)?;
     let db = state.db().clone();
     let lookup = pool_name.clone();
     let pool = tokio::task::spawn_blocking(move || db.get_fork_pool(&lookup))
@@ -425,24 +532,32 @@ pub async fn acquire_lease(
     let pool_for_claim = pool_name.clone();
     let key = req.idempotency_key.clone();
     let assignment_for_claim = assignment.clone();
+    let payload_for_claim = payload_sha256.clone();
+    let require_private_workspace = !files.is_empty();
     let claim = tokio::task::spawn_blocking(move || {
-        db.claim_fork_pool_slot(
-            &pool_for_claim,
-            &lease_id,
-            &key,
-            &assignment_for_claim,
-            ttl,
+        db.claim_fork_pool_slot(ForkPoolSlotClaim {
+            pool_name: &pool_for_claim,
+            lease_id: &lease_id,
+            idempotency_key: &key,
+            assignment: &assignment_for_claim,
+            payload_sha256: payload_for_claim.as_deref(),
+            require_private_workspace,
+            ttl_secs: ttl,
             now,
-        )
+        })
     })
     .await
     .map_err(|e| ApiError::internal(format!("pool claim task failed: {e}")))?
     .map_err(ApiError::database)?;
     let lease = match claim {
         ClaimForkPoolSlot::Existing(lease) => {
-            if lease.assignment != assignment || lease.ttl_secs != ttl {
+            if lease.assignment != assignment
+                || lease.payload_sha256 != payload_sha256
+                || lease.ttl_secs != ttl
+            {
                 return Err(ApiError::Conflict(
-                    "idempotencyKey was already used with a different assignment or TTL".into(),
+                    "idempotencyKey was already used with a different assignment, payload, or TTL"
+                        .into(),
                 ));
             }
             return Ok(Json(lease_info(lease)));
@@ -467,6 +582,12 @@ pub async fn acquire_lease(
                 "fork pool '{pool_name}' is deleting"
             )))
         }
+        ClaimForkPoolSlot::WorkspaceExternallyMounted => {
+            return Err(ApiError::Conflict(
+                "lease payload staging requires smolvm's private /workspace; this pool's worker mounts external storage inside /workspace"
+                    .into(),
+            ))
+        }
         ClaimForkPoolSlot::Claimed(lease) => lease,
     };
 
@@ -479,10 +600,15 @@ pub async fn acquire_lease(
     // Run activation in its own task. Dropping an HTTP request future does not
     // cancel this task, so a client disconnect after the durable claim cannot
     // strand a successfully released guest forever in `activating` state.
-    let active = tokio::spawn(activate_claimed_lease(state.clone(), lease, assignment))
-        .await
-        .map_err(|e| ApiError::internal(format!("pool activation task failed: {e}")))?
-        .map_err(ApiError::Internal)?;
+    let active = tokio::spawn(activate_claimed_lease(
+        state.clone(),
+        lease,
+        assignment,
+        files,
+    ))
+    .await
+    .map_err(|e| ApiError::internal(format!("pool activation task failed: {e}")))?
+    .map_err(ApiError::Internal)?;
     Ok(Json(lease_info(active)))
 }
 
@@ -619,4 +745,141 @@ pub async fn complete_lease(
         )));
     }
     Ok(Json(lease_info(lease)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::types::ForkLeasePayloadFile;
+
+    fn payload(path: &str, data: &[u8], mode: Option<u32>) -> ForkLeasePayloadFile {
+        ForkLeasePayloadFile {
+            path: path.into(),
+            data_base64: base64::engine::general_purpose::STANDARD.encode(data),
+            mode,
+        }
+    }
+
+    fn bad_request(error: ApiError) -> String {
+        match error {
+            ApiError::BadRequest(message) => message,
+            other => panic!("expected bad request, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lease_payload_is_canonical_and_order_independent() {
+        let first = vec![
+            payload("jobs/z.json", b"z", Some(0o600)),
+            payload("jobs/a.json", b"a", None),
+        ];
+        let second = vec![first[1].clone(), first[0].clone()];
+        let (staged_first, digest_first) = validate_lease_payload(&first).unwrap();
+        let (staged_second, digest_second) = validate_lease_payload(&second).unwrap();
+
+        assert_eq!(digest_first, digest_second);
+        assert_eq!(staged_first[0].path, "jobs/a.json");
+        assert_eq!(staged_first[0].mode, 0o644);
+        assert_eq!(staged_second[1].path, "jobs/z.json");
+    }
+
+    #[test]
+    fn lease_payload_rejects_unsafe_or_ambiguous_paths() {
+        for path in [
+            "",
+            "/absolute",
+            "../escape",
+            "jobs/../escape",
+            "jobs/./file",
+            "jobs//file",
+            "jobs\\file",
+            "jobs/file/",
+        ] {
+            let error = validate_lease_payload(&[payload(path, b"x", None)])
+                .err()
+                .expect("unsafe path should fail");
+            assert!(bad_request(error).contains("safe relative path"), "{path}");
+        }
+
+        let duplicate = vec![
+            payload("job.json", b"a", None),
+            payload("job.json", b"b", None),
+        ];
+        assert!(bad_request(
+            validate_lease_payload(&duplicate)
+                .err()
+                .expect("duplicate path should fail")
+        )
+        .contains("duplicated"));
+    }
+
+    #[test]
+    fn lease_payload_enforces_encoding_mode_and_size_limits() {
+        let invalid_base64 = ForkLeasePayloadFile {
+            path: "job.json".into(),
+            data_base64: "***".into(),
+            mode: None,
+        };
+        assert!(bad_request(
+            validate_lease_payload(&[invalid_base64])
+                .err()
+                .expect("invalid base64 should fail")
+        )
+        .contains("not valid standard base64"));
+
+        let invalid_mode = payload("job.sh", b"x", Some(0o1000));
+        assert!(bad_request(
+            validate_lease_payload(&[invalid_mode])
+                .err()
+                .expect("invalid mode should fail")
+        )
+        .contains("permission bits"));
+
+        let oversized = payload("large.bin", &vec![0u8; MAX_LEASE_PAYLOAD_BYTES + 1], None);
+        assert!(bad_request(
+            validate_lease_payload(&[oversized])
+                .err()
+                .expect("oversized payload should fail")
+        )
+        .contains("must total at most"));
+
+        let too_many: Vec<_> = (0..=MAX_LEASE_PAYLOAD_FILES)
+            .map(|index| payload(&format!("{index}.json"), b"x", None))
+            .collect();
+        assert!(bad_request(
+            validate_lease_payload(&too_many)
+                .err()
+                .expect("too many files should fail")
+        )
+        .contains("at most"));
+
+        let long_path = "a".repeat(MAX_LEASE_PAYLOAD_PATH_BYTES + 1);
+        assert!(bad_request(
+            validate_lease_payload(&[payload(&long_path, b"x", None)])
+                .err()
+                .expect("long path should fail")
+        )
+        .contains("safe relative path"));
+    }
+
+    #[test]
+    fn lease_payload_debug_redacts_contents() {
+        let file = ForkLeasePayloadFile {
+            path: "job.json".into(),
+            data_base64: "customer-secret".into(),
+            mode: None,
+        };
+        let shown = format!("{file:?}");
+        assert!(shown.contains("<redacted>"));
+        assert!(!shown.contains("customer-secret"));
+    }
+
+    #[test]
+    fn legacy_lease_request_defaults_to_no_payload() {
+        let request: AcquireForkLeaseRequest = serde_json::from_str(
+            r#"{"idempotencyKey":"request-a","env":["EPISODE=42"],"ttlSecs":60}"#,
+        )
+        .unwrap();
+        assert!(request.files.is_empty());
+    }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -125,6 +125,7 @@ use state::ApiState;
         types::CreateForkPoolRequest,
         types::DeleteForkPoolQuery,
         types::AcquireForkLeaseRequest,
+        types::ForkLeasePayloadFile,
         types::ResizeForkPoolRequest,
         // Response types
         types::HealthResponse,

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -953,9 +953,39 @@ pub struct AcquireForkLeaseRequest {
     /// Job-specific KEY=VALUE parameters installed before the workload runs.
     #[serde(default)]
     pub env: Vec<String>,
+    /// Small files written atomically under `/workspace` before the workload is
+    /// released. The entire worker is discarded if any file cannot be staged.
+    #[serde(default)]
+    pub files: Vec<ForkLeasePayloadFile>,
     /// Optional lease duration override for this worker.
     #[serde(default)]
     pub ttl_secs: Option<u64>,
+}
+
+/// One file staged into a held worker before lease activation.
+#[derive(Clone, Deserialize, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ForkLeasePayloadFile {
+    /// Relative path below `/workspace`, such as `jobs/episode.json`.
+    #[schema(example = "jobs/episode.json")]
+    pub path: String,
+    /// Standard base64-encoded file contents.
+    #[schema(example = "eyJlcGlzb2RlIjo0Mn0K")]
+    pub data_base64: String,
+    /// Optional Unix permission bits in decimal; defaults to 420 (`0644`).
+    #[serde(default)]
+    #[schema(example = 420)]
+    pub mode: Option<u32>,
+}
+
+impl std::fmt::Debug for ForkLeasePayloadFile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ForkLeasePayloadFile")
+            .field("path", &self.path)
+            .field("data_base64", &"<redacted>")
+            .field("mode", &self.mode)
+            .finish()
+    }
 }
 
 /// Public state of one one-shot fork worker lease.

--- a/src/db.rs
+++ b/src/db.rs
@@ -31,6 +31,40 @@ const BUSY_TIMEOUT: Duration = Duration::from_secs(15);
 /// crashed creator does not reserve a name forever.
 const CREATE_RESERVATION_TTL_SECS: u64 = 60 * 60;
 
+/// Inputs committed together when one ready fork-pool worker is claimed.
+pub struct ForkPoolSlotClaim<'a> {
+    /// Pool that owns the ready worker.
+    pub pool_name: &'a str,
+    /// New opaque lease identifier.
+    pub lease_id: &'a str,
+    /// Caller-provided retry key, unique within the pool.
+    pub idempotency_key: &'a str,
+    /// Environment installed before the held workload is released.
+    pub assignment: &'a [(String, String)],
+    /// Canonical digest of any files staged before release.
+    pub payload_sha256: Option<&'a str>,
+    /// Reject workers whose `/workspace` is backed by an external mount.
+    pub require_private_workspace: bool,
+    /// Lease lifetime renewed by each heartbeat.
+    pub ttl_secs: u64,
+    /// Timestamp used for every record in this transaction.
+    pub now: u64,
+}
+
+fn targets_workspace_tree(target: &str) -> bool {
+    let mut components = Vec::new();
+    for component in target.split('/') {
+        match component {
+            "" | "." => {}
+            ".." => {
+                components.pop();
+            }
+            value => components.push(value),
+        }
+    }
+    components.first() == Some(&"workspace")
+}
+
 /// Max SQLite connections held open by the pool. WAL allows these to read
 /// concurrently (writes still serialize at the SQLite layer, gated by
 /// `busy_timeout`), so a slow write can no longer block reads — the prior
@@ -962,15 +996,17 @@ impl SmolvmDb {
     /// The VM's `forkpoint_held` bit is cleared in the same transaction as the
     /// slot claim. A crash after commit can waste this worker, but can never
     /// make a released workload appear ready for a second caller.
-    pub fn claim_fork_pool_slot(
-        &self,
-        pool_name: &str,
-        lease_id: &str,
-        idempotency_key: &str,
-        assignment: &[(String, String)],
-        ttl_secs: u64,
-        now: u64,
-    ) -> Result<ClaimForkPoolSlot> {
+    pub fn claim_fork_pool_slot(&self, claim: ForkPoolSlotClaim<'_>) -> Result<ClaimForkPoolSlot> {
+        let ForkPoolSlotClaim {
+            pool_name,
+            lease_id,
+            idempotency_key,
+            assignment,
+            payload_sha256,
+            require_private_workspace,
+            ttl_secs,
+            now,
+        } = claim;
         self.with_conn(|conn| {
             let tx = conn.transaction().db_err("begin fork pool claim")?;
             if let Some(bytes) = tx
@@ -1085,6 +1121,16 @@ impl SmolvmDb {
             };
             let mut vm: VmRecord =
                 serde_json::from_slice(&vm_data).db_err("deserialize pool worker")?;
+            if require_private_workspace
+                && vm
+                    .mounts
+                    .iter()
+                    .any(|(_, target, _)| targets_workspace_tree(target))
+            {
+                tx.commit()
+                    .db_err("commit external-workspace fork claim rejection")?;
+                return Ok(ClaimForkPoolSlot::WorkspaceExternallyMounted);
+            }
             let merged = crate::agent::fork::merge_fork_env(&vm.fork_env, assignment);
             crate::agent::fork::record_fork_activation(&mut vm, assignment, merged);
             let vm_updated = serde_json::to_vec(&vm).db_err("serialize claimed pool worker")?;
@@ -1113,6 +1159,7 @@ impl SmolvmDb {
                 idempotency_key: idempotency_key.to_string(),
                 state: ForkLeaseState::Activating,
                 assignment: assignment.to_vec(),
+                payload_sha256: payload_sha256.map(str::to_owned),
                 created_at: now,
                 updated_at: now,
                 expires_at: now.saturating_add(ttl_secs),
@@ -2030,15 +2077,26 @@ mod tests {
             .unwrap();
         insert_ready_pool_slot(&db, "rollouts", "slot-1");
         let assignment = vec![("EPISODE".into(), "42".into())];
+        let payload_sha256 = "payload-digest";
 
         let first = db
-            .claim_fork_pool_slot("rollouts", "lease-a", "request-a", &assignment, 60, 200)
+            .claim_fork_pool_slot(ForkPoolSlotClaim {
+                pool_name: "rollouts",
+                lease_id: "lease-a",
+                idempotency_key: "request-a",
+                assignment: &assignment,
+                payload_sha256: Some(payload_sha256),
+                require_private_workspace: true,
+                ttl_secs: 60,
+                now: 200,
+            })
             .unwrap();
         let lease = match first {
             ClaimForkPoolSlot::Claimed(lease) => lease,
             other => panic!("unexpected claim result: {other:?}"),
         };
         assert_eq!(lease.machine_name, "slot-1");
+        assert_eq!(lease.payload_sha256.as_deref(), Some(payload_sha256));
         let vm = db.get_vm("slot-1").unwrap().unwrap();
         assert!(!vm.forkpoint_held);
         assert!(vm
@@ -2047,23 +2105,99 @@ mod tests {
             .any(|(key, value)| key == "EPISODE" && value == "42"));
 
         let retry = db
-            .claim_fork_pool_slot(
-                "rollouts",
-                "unused-new-id",
-                "request-a",
-                &assignment,
-                60,
-                201,
-            )
+            .claim_fork_pool_slot(ForkPoolSlotClaim {
+                pool_name: "rollouts",
+                lease_id: "unused-new-id",
+                idempotency_key: "request-a",
+                assignment: &assignment,
+                payload_sha256: Some(payload_sha256),
+                require_private_workspace: true,
+                ttl_secs: 60,
+                now: 201,
+            })
             .unwrap();
         assert!(matches!(
             retry,
-            ClaimForkPoolSlot::Existing(ref existing) if existing.id == "lease-a"
+            ClaimForkPoolSlot::Existing(ref existing)
+                if existing.id == "lease-a"
+                    && existing.payload_sha256.as_deref() == Some(payload_sha256)
         ));
         let second_request = db
-            .claim_fork_pool_slot("rollouts", "lease-b", "request-b", &assignment, 60, 201)
+            .claim_fork_pool_slot(ForkPoolSlotClaim {
+                pool_name: "rollouts",
+                lease_id: "lease-b",
+                idempotency_key: "request-b",
+                assignment: &assignment,
+                payload_sha256: None,
+                require_private_workspace: false,
+                ttl_secs: 60,
+                now: 201,
+            })
             .unwrap();
         assert_eq!(second_request, ClaimForkPoolSlot::NoReadySlot);
+    }
+
+    #[test]
+    fn payload_claim_rejects_external_workspace_without_consuming_slot() {
+        let (_dir, db) = temp_db();
+        db.insert_fork_pool_if_not_exists(&test_pool("rollouts", 1))
+            .unwrap();
+        insert_ready_pool_slot(&db, "rollouts", "slot-1");
+        db.update_vm("slot-1", |vm| {
+            vm.mounts
+                .push(("/host/jobs".into(), "/workspace/jobs".into(), false));
+        })
+        .unwrap();
+
+        let rejected = db
+            .claim_fork_pool_slot(ForkPoolSlotClaim {
+                pool_name: "rollouts",
+                lease_id: "lease-a",
+                idempotency_key: "request-a",
+                assignment: &[],
+                payload_sha256: Some("payload-digest"),
+                require_private_workspace: true,
+                ttl_secs: 60,
+                now: 200,
+            })
+            .unwrap();
+        assert_eq!(rejected, ClaimForkPoolSlot::WorkspaceExternallyMounted);
+        assert_eq!(
+            db.get_fork_pool_slot("slot-1").unwrap().unwrap().state,
+            ForkPoolSlotState::Ready
+        );
+        assert!(db.get_vm("slot-1").unwrap().unwrap().forkpoint_held);
+
+        let env_only = db
+            .claim_fork_pool_slot(ForkPoolSlotClaim {
+                pool_name: "rollouts",
+                lease_id: "lease-b",
+                idempotency_key: "request-b",
+                assignment: &[],
+                payload_sha256: None,
+                require_private_workspace: false,
+                ttl_secs: 60,
+                now: 201,
+            })
+            .unwrap();
+        assert!(matches!(env_only, ClaimForkPoolSlot::Claimed(_)));
+    }
+
+    #[test]
+    fn workspace_mount_targets_are_normalized_component_wise() {
+        for target in [
+            "/workspace",
+            "/workspace/",
+            "/workspace/jobs",
+            "/workspace/./jobs",
+            "/tmp/../workspace/jobs",
+            "workspace/jobs",
+        ] {
+            assert!(targets_workspace_tree(target), "{target}");
+        }
+        for target in ["/data", "/workspace2", "/tmp/workspace", "/workspace/.."] {
+            assert!(!targets_workspace_tree(target), "{target}");
+        }
     }
 
     #[test]
@@ -2080,14 +2214,16 @@ mod tests {
                 let barrier = barrier.clone();
                 std::thread::spawn(move || {
                     barrier.wait();
-                    db.claim_fork_pool_slot(
-                        "rollouts",
+                    db.claim_fork_pool_slot(ForkPoolSlotClaim {
+                        pool_name: "rollouts",
                         lease_id,
-                        "same-request",
-                        &[("EPISODE".into(), "42".into())],
-                        60,
-                        200,
-                    )
+                        idempotency_key: "same-request",
+                        assignment: &[("EPISODE".into(), "42".into())],
+                        payload_sha256: None,
+                        require_private_workspace: false,
+                        ttl_secs: 60,
+                        now: 200,
+                    })
                     .unwrap()
                 })
             })
@@ -2131,13 +2267,31 @@ mod tests {
         db.insert_fork_pool_if_not_exists(&pool).unwrap();
         insert_ready_pool_slot(&db, "rollouts", "slot-1");
         insert_ready_pool_slot(&db, "rollouts", "slot-2");
-        db.claim_fork_pool_slot("rollouts", "lease-1", "request-1", &[], 60, 200)
-            .unwrap();
+        db.claim_fork_pool_slot(ForkPoolSlotClaim {
+            pool_name: "rollouts",
+            lease_id: "lease-1",
+            idempotency_key: "request-1",
+            assignment: &[],
+            payload_sha256: None,
+            require_private_workspace: false,
+            ttl_secs: 60,
+            now: 200,
+        })
+        .unwrap();
         db.mark_fork_lease_active("lease-1", 201).unwrap();
 
         assert_eq!(
-            db.claim_fork_pool_slot("rollouts", "lease-2", "request-2", &[], 60, 202)
-                .unwrap(),
+            db.claim_fork_pool_slot(ForkPoolSlotClaim {
+                pool_name: "rollouts",
+                lease_id: "lease-2",
+                idempotency_key: "request-2",
+                assignment: &[],
+                payload_sha256: None,
+                require_private_workspace: false,
+                ttl_secs: 60,
+                now: 202,
+            })
+            .unwrap(),
             ClaimForkPoolSlot::AtCapacity
         );
         assert_eq!(
@@ -2150,7 +2304,16 @@ mod tests {
             "capacity rejection must not consume a clean worker"
         );
         assert!(matches!(
-            db.claim_fork_pool_slot("rollouts", "ignored", "request-1", &[], 60, 203)
+            db.claim_fork_pool_slot(ForkPoolSlotClaim {
+                pool_name: "rollouts",
+                lease_id: "ignored",
+                idempotency_key: "request-1",
+                assignment: &[],
+                payload_sha256: None,
+                require_private_workspace: false,
+                ttl_secs: 60,
+                now: 203,
+            })
                 .unwrap(),
             ClaimForkPoolSlot::Existing(lease) if lease.id == "lease-1"
         ));
@@ -2169,7 +2332,16 @@ mod tests {
             ("slot-expire", "lease-expire", "req-expire"),
         ] {
             let claimed = db
-                .claim_fork_pool_slot("rollouts", lease, request, &[], 10, 200)
+                .claim_fork_pool_slot(ForkPoolSlotClaim {
+                    pool_name: "rollouts",
+                    lease_id: lease,
+                    idempotency_key: request,
+                    assignment: &[],
+                    payload_sha256: None,
+                    require_private_workspace: false,
+                    ttl_secs: 10,
+                    now: 200,
+                })
                 .unwrap();
             assert!(
                 matches!(claimed, ClaimForkPoolSlot::Claimed(ref l) if l.machine_name == machine)
@@ -2220,8 +2392,17 @@ mod tests {
         db.insert_fork_pool_if_not_exists(&test_pool("rollouts", 1))
             .unwrap();
         insert_ready_pool_slot(&db, "rollouts", "slot-1");
-        db.claim_fork_pool_slot("rollouts", "lease-1", "request-1", &[], 60, 200)
-            .unwrap();
+        db.claim_fork_pool_slot(ForkPoolSlotClaim {
+            pool_name: "rollouts",
+            lease_id: "lease-1",
+            idempotency_key: "request-1",
+            assignment: &[],
+            payload_sha256: None,
+            require_private_workspace: false,
+            ttl_secs: 60,
+            now: 200,
+        })
+        .unwrap();
         db.mark_fork_lease_active("lease-1", 201).unwrap();
 
         assert_eq!(
@@ -2246,8 +2427,17 @@ mod tests {
         db.insert_fork_pool_if_not_exists(&test_pool("rollouts", 1))
             .unwrap();
         insert_ready_pool_slot(&db, "rollouts", "slot-1");
-        db.claim_fork_pool_slot("rollouts", "lease-1", "request-1", &[], 60, 200)
-            .unwrap();
+        db.claim_fork_pool_slot(ForkPoolSlotClaim {
+            pool_name: "rollouts",
+            lease_id: "lease-1",
+            idempotency_key: "request-1",
+            assignment: &[],
+            payload_sha256: None,
+            require_private_workspace: false,
+            ttl_secs: 60,
+            now: 200,
+        })
+        .unwrap();
         db.mark_fork_lease_active("lease-1", 201).unwrap();
 
         let failed = db

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -120,6 +120,9 @@ pub struct ForkLeaseRecord {
     pub state: ForkLeaseState,
     /// Canonical assignment environment written before guest release.
     pub assignment: Vec<(String, String)>,
+    /// Digest of the canonical pre-release file payload, for retry validation.
+    #[serde(default)]
+    pub payload_sha256: Option<String>,
     /// Unix timestamp when the claim was created.
     pub created_at: u64,
     /// Unix timestamp of the last state transition or heartbeat.
@@ -147,4 +150,32 @@ pub enum ClaimForkPoolSlot {
     PoolNotFound,
     /// Pool deletion began before the claim committed.
     PoolDeleting,
+    /// Payload staging cannot safely target an externally mounted workspace.
+    WorkspaceExternallyMounted,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_lease_without_payload_digest_still_deserializes() {
+        let lease: ForkLeaseRecord = serde_json::from_str(
+            r#"{
+                "id":"lease-1",
+                "pool_name":"pool",
+                "machine_name":"worker",
+                "idempotency_key":"request",
+                "state":"active",
+                "assignment":[],
+                "created_at":1,
+                "updated_at":1,
+                "expires_at":61,
+                "ttl_secs":60,
+                "last_error":null
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(lease.payload_sha256, None);
+    }
 }


### PR DESCRIPTION
Atomically stages bounded per-lease files before releasing held fork workers.