### PR TITLE
Add automatic CUDA admission and fused rollouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3032,6 +3032,7 @@ dependencies = [
  "parking_lot",
  "pkg-config",
  "regex",
+ "reqwest",
  "rusqlite",
  "rustls",
  "rustls-pemfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ tokio-util = { version = "0.7", features = ["io"] }
 parking_lot = "0.12"
 async-stream = "0.3"
 futures-util = "0.3"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "json"] }
 
 # OpenAPI documentation
 utoipa = { version = "5", features = ["axum_extras"] }

--- a/sdks/README.md
+++ b/sdks/README.md
@@ -1,15 +1,17 @@
-# SmolVM Embedded SDKs
+# SmolVM SDKs
 
 ## Overview
 
-This directory holds language bindings that embed `smolvm` directly into the
-host process instead of talking to the API server.
+This directory holds language bindings for smolvm's embedded runtime and stable
+service APIs.
 
 Layout convention:
 
 - `sdks/scripts/` contains shared helpers used by all embedded SDKs.
 - `sdks/node/` contains the Node.js embedded SDK and its internal platform
   packages.
+- `sdks/python/` contains the dependency-free fused rollout API client used by
+  training frameworks.
 - Future embedded SDKs should live in sibling directories such as `sdks/go/`, and `sdks/c/`.
 
 Bundled native library rule:

--- a/sdks/python/.gitignore
+++ b/sdks/python/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -1,0 +1,33 @@
+# smolvm rollout client
+
+`smolvm-rollout` is the framework-neutral generation boundary for fused policy
+rollouts. A trainer publishes each immutable LoRA version and submits text or
+token-ID prompts; smolvm verifies and routes the version while one local vLLM
+engine continuously batches compatible policies. Unsupported workflows can use
+the executor's advertised `fallbackPool` with the ordinary fork-lease API.
+
+The vLLM server must bind to loopback, enable LoRA and runtime adapter updates,
+and reserve at least one spare CPU LoRA slot so a new policy version can load
+before the previous version retires. smolvm never exposes vLLM's unrestricted
+adapter-path endpoint to remote callers.
+
+```python
+from smolvm_rollout import RolloutClient
+
+client = RolloutClient("http://127.0.0.1:8080/api/v1", "qwen")
+client.ensure_vllm_executor(
+    endpoint="http://127.0.0.1:8000",
+    adapter_root="/var/lib/smolvm/adapters",
+    fallback_pool="isolated-rollouts",
+)
+client.publish_policy("experiment-a", "step-40", "/var/lib/smolvm/adapters/a-40")
+result = client.generate(
+    idempotency_key="experiment-a-step-40-batch-7",
+    policy="experiment-a",
+    prompts=[[1, 2, 3]],
+    max_tokens=64,
+    temperature=0.9,
+    seed=7,
+    logprobs=1,
+)
+```

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "smolvm-rollout"
+version = "0.1.0"
+description = "Framework-neutral client for smolvm fused rollout executors"
+requires-python = ">=3.10"
+license = { text = "Apache-2.0" }
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/sdks/python/src/smolvm_rollout/__init__.py
+++ b/sdks/python/src/smolvm_rollout/__init__.py
@@ -1,0 +1,5 @@
+"""Framework-neutral client for smolvm fused rollout executors."""
+
+from .client import RolloutClient, RolloutError, adapter_sha256
+
+__all__ = ["RolloutClient", "RolloutError", "adapter_sha256"]

--- a/sdks/python/src/smolvm_rollout/client.py
+++ b/sdks/python/src/smolvm_rollout/client.py
@@ -1,0 +1,280 @@
+"""Small dependency-free client usable from TRL, Unsloth, or custom RL loops."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import ssl
+import struct
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+
+class RolloutError(RuntimeError):
+    """A structured error returned by smolvm's rollout API."""
+
+    def __init__(self, status: int, code: str, message: str):
+        super().__init__(f"{code}: {message}")
+        self.status = status
+        self.code = code
+        self.message = message
+
+
+def adapter_sha256(directory: str | os.PathLike[str]) -> str:
+    """Return the deterministic directory digest required by policy publication."""
+
+    root = Path(directory).resolve(strict=True)
+    if not root.is_dir():
+        raise ValueError("adapter path must be a directory")
+    files: list[Path] = []
+    for current, directories, names in os.walk(root, followlinks=False):
+        current_path = Path(current)
+        for name in directories:
+            if (current_path / name).is_symlink():
+                raise ValueError("adapter directories cannot contain symlinks")
+        for name in names:
+            path = current_path / name
+            if path.is_symlink() or not path.is_file():
+                raise ValueError("adapter directories may contain only regular files")
+            files.append(path)
+    if not files:
+        raise ValueError("adapter directory contains no files")
+
+    digest = hashlib.sha256()
+    for path in sorted(files, key=lambda item: item.relative_to(root).as_posix()):
+        name = path.relative_to(root).as_posix().encode("utf-8")
+        size = path.stat().st_size
+        digest.update(struct.pack("<Q", len(name)))
+        digest.update(name)
+        digest.update(struct.pack("<Q", size))
+        with path.open("rb") as stream:
+            while chunk := stream.read(1024 * 1024):
+                digest.update(chunk)
+    return digest.hexdigest()
+
+
+class RolloutClient:
+    """Synchronous rollout client designed for framework generation boundaries."""
+
+    def __init__(
+        self,
+        api_url: str,
+        executor: str,
+        *,
+        timeout: float = 300.0,
+        ssl_context: ssl.SSLContext | None = None,
+    ) -> None:
+        self.api_url = api_url.rstrip("/")
+        self.executor = executor
+        self.timeout = timeout
+        self.ssl_context = ssl_context
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        body: dict[str, Any] | None = None,
+    ) -> Any:
+        data = None if body is None else json.dumps(body, separators=(",", ":")).encode()
+        request = urllib.request.Request(
+            f"{self.api_url}{path}",
+            data=data,
+            method=method,
+            headers={"content-type": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(
+                request, timeout=self.timeout, context=self.ssl_context
+            ) as response:
+                payload = response.read()
+                return None if not payload else json.loads(payload)
+        except urllib.error.HTTPError as error:
+            raw = error.read()
+            try:
+                payload = json.loads(raw)
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                payload = {"code": "HTTP_ERROR", "error": raw.decode(errors="replace")}
+            raise RolloutError(
+                error.code,
+                str(payload.get("code", "HTTP_ERROR")),
+                str(payload.get("error", error.reason)),
+            ) from error
+        except urllib.error.URLError as error:
+            raise RolloutError(0, "UNAVAILABLE", str(error.reason)) from error
+
+    def ensure_vllm_executor(
+        self,
+        *,
+        endpoint: str,
+        adapter_root: str | os.PathLike[str],
+        fallback_pool: str | None = None,
+        max_concurrent_requests: int = 32,
+        max_queue_depth: int = 256,
+        request_timeout_secs: int = 300,
+    ) -> dict[str, Any]:
+        """Declaratively create the executor or verify an identical registration."""
+
+        desired: dict[str, Any] = {
+            "name": self.executor,
+            "backend": "vllm",
+            "endpoint": endpoint,
+            "adapterRoot": str(Path(adapter_root).resolve()),
+            "maxConcurrentRequests": max_concurrent_requests,
+            "maxQueueDepth": max_queue_depth,
+            "requestTimeoutSecs": request_timeout_secs,
+        }
+        if fallback_pool is not None:
+            desired["fallbackPool"] = fallback_pool
+        try:
+            return self._request("POST", "/rollout-executors", desired)
+        except RolloutError as error:
+            if error.status != 409:
+                raise
+        current = self.info()
+        comparable = {
+            "backend": current["backend"],
+            "endpoint": current["endpoint"],
+            "adapterRoot": current["adapterRoot"],
+            "fallbackPool": current.get("fallbackPool"),
+            "maxConcurrentRequests": current["maxConcurrentRequests"],
+            "maxQueueDepth": current["maxQueueDepth"],
+        }
+        expected = {
+            "backend": "vllm",
+            "endpoint": endpoint,
+            "adapterRoot": desired["adapterRoot"],
+            "fallbackPool": fallback_pool,
+            "maxConcurrentRequests": max_concurrent_requests,
+            "maxQueueDepth": max_queue_depth,
+        }
+        if comparable != expected:
+            raise RolloutError(
+                409,
+                "CONFLICT",
+                f"executor {self.executor!r} exists with different configuration",
+            )
+        return current
+
+    def info(self) -> dict[str, Any]:
+        """Return capabilities, queue state, fallback, and published policies."""
+
+        return self._request("GET", f"/rollout-executors/{self.executor}")
+
+    def publish_policy(
+        self,
+        policy: str,
+        version: str,
+        adapter_directory: str | os.PathLike[str],
+        *,
+        retain_previous: bool = False,
+    ) -> dict[str, Any]:
+        """Content-verify and atomically publish one immutable LoRA version."""
+
+        info = self.info()
+        root = Path(info["adapterRoot"]).resolve(strict=True)
+        adapter = Path(adapter_directory).resolve(strict=True)
+        try:
+            relative = adapter.relative_to(root)
+        except ValueError as error:
+            raise ValueError("adapter must be beneath the executor adapter root") from error
+        return self._request(
+            "POST",
+            f"/rollout-executors/{self.executor}/policies",
+            {
+                "policy": policy,
+                "version": version,
+                "adapterPath": relative.as_posix(),
+                "adapterSha256": adapter_sha256(adapter),
+                "retainPrevious": retain_previous,
+            },
+        )
+
+    def retire_policy(self, policy: str, version: str) -> None:
+        """Stop routing and unload a policy version after its requests drain."""
+
+        self._request(
+            "DELETE",
+            f"/rollout-executors/{self.executor}/policies/{policy}/{version}",
+        )
+
+    @staticmethod
+    def _prompts(prompts: Sequence[str] | Sequence[Sequence[int]]) -> list[dict[str, Any]]:
+        if not prompts:
+            raise ValueError("at least one prompt is required")
+        if isinstance(prompts[0], str):
+            if not all(isinstance(prompt, str) for prompt in prompts):
+                raise ValueError("one request cannot mix text and token prompts")
+            return [{"text": prompt} for prompt in prompts]
+        if not all(not isinstance(prompt, str) for prompt in prompts):
+            raise ValueError("one request cannot mix text and token prompts")
+        return [{"tokenIds": list(prompt)} for prompt in prompts]
+
+    def job(
+        self,
+        *,
+        idempotency_key: str,
+        policy: str,
+        prompts: Sequence[str] | Sequence[Sequence[int]],
+        max_tokens: int,
+        version: str | None = None,
+        n: int = 1,
+        deadline_ms: int | None = None,
+        **sampling: Any,
+    ) -> dict[str, Any]:
+        """Build a generation job for `generate` or a cross-policy cohort."""
+
+        parameters = {"n": n, "maxTokens": max_tokens}
+        wire_names = {
+            "temperature": "temperature",
+            "top_p": "topP",
+            "top_k": "topK",
+            "min_p": "minP",
+            "repetition_penalty": "repetitionPenalty",
+            "seed": "seed",
+            "logprobs": "logprobs",
+            "prompt_logprobs": "promptLogprobs",
+        }
+        unknown = set(sampling) - set(wire_names)
+        if unknown:
+            raise TypeError(f"unknown sampling parameters: {sorted(unknown)}")
+        parameters.update(
+            {wire_names[name]: value for name, value in sampling.items() if value is not None}
+        )
+        job: dict[str, Any] = {
+            "idempotencyKey": idempotency_key,
+            "policy": policy,
+            "prompts": self._prompts(prompts),
+            "sampling": parameters,
+        }
+        if version is not None:
+            job["version"] = version
+        if deadline_ms is not None:
+            job["deadlineMs"] = deadline_ms
+        return job
+
+    def generate(self, **job: Any) -> dict[str, Any]:
+        """Generate through one policy, returning exact token IDs and logprobs."""
+
+        return self._request(
+            "POST",
+            f"/rollout-executors/{self.executor}/generate",
+            self.job(**job),
+        )
+
+    def generate_batch(self, jobs: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Submit independent policy jobs together so vLLM can fuse the cohort."""
+
+        response = self._request(
+            "POST",
+            f"/rollout-executors/{self.executor}/batches",
+            {"jobs": list(jobs)},
+        )
+        return response["jobs"]
+
+    def close(self) -> None:
+        """Drain and delete the executor registration."""
+
+        self._request("DELETE", f"/rollout-executors/{self.executor}")

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -1,0 +1,25 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from smolvm_rollout import adapter_sha256
+
+
+class AdapterDigestTests(unittest.TestCase):
+    def test_digest_is_stable_and_content_sensitive(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "adapter_config.json").write_bytes(b"{}")
+            (root / "adapter_model.safetensors").write_bytes(b"weights")
+            first = adapter_sha256(root)
+            self.assertEqual(
+                first,
+                "26d1c7593b9650cb489a9a1fe2fad9def32c75ec2685cf8261c3c0fa3b73e315",
+            )
+            self.assertEqual(first, adapter_sha256(root))
+            (root / "adapter_model.safetensors").write_bytes(b"changed")
+            self.assertNotEqual(first, adapter_sha256(root))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/api/admission.rs
+++ b/src/api/admission.rs
@@ -446,6 +446,7 @@ impl AdmissionRegistry {
 /// Samples aggregate host CPU busy time from `/proc/stat`.
 #[derive(Default)]
 pub struct HostCpuSampler {
+    #[cfg(target_os = "linux")]
     previous: Option<(u64, u64)>,
 }
 
@@ -609,6 +610,7 @@ impl Drop for NvmlSampler {
 }
 
 #[cfg(not(target_os = "linux"))]
+/// Reports unavailable NVML telemetry on unsupported hosts.
 pub struct NvmlSampler;
 
 #[cfg(not(target_os = "linux"))]

--- a/src/api/admission.rs
+++ b/src/api/admission.rs
@@ -1,0 +1,807 @@
+//! Lease-aware admission for CUDA fork pools.
+//!
+//! The controller deliberately gates durable lease claims, not CUDA daemon
+//! connections.  A claimed worker must always be allowed to finish activation;
+//! moving the gate below that boundary can deadlock the daemon accept loop and
+//! leaves the lease state ambiguous after a restart.
+
+use std::collections::{HashMap, HashSet};
+use std::time::{Duration, Instant};
+
+use parking_lot::Mutex;
+
+use crate::pool::ForkPoolRecord;
+
+const OBSERVATION_WINDOW: Duration = Duration::from_secs(8);
+const MIN_STABLE_SAMPLES: u32 = 5;
+const PRESSURE_TTL: Duration = Duration::from_secs(30);
+const REPROBE_INTERVAL: Duration = Duration::from_secs(15 * 60);
+const MIN_VRAM_RESERVE_MIB: u64 = 8 * 1024;
+const VRAM_RESERVE_PERCENT: u64 = 10;
+const CPU_SATURATION_PERCENT: f64 = 90.0;
+const MARGINAL_GAIN_PERCENT: f64 = 2.0;
+
+/// One node-wide GPU sample. Multi-GPU nodes are represented as aggregate
+/// memory and memory-weighted utilization so the policy stays conservative
+/// without assuming a pool-to-device mapping the current runtime does not have.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct GpuSample {
+    /// Memory-weighted mean streaming-multiprocessor utilization.
+    pub utilization_percent: f64,
+    /// Aggregate used device memory in MiB.
+    pub used_memory_mib: u64,
+    /// Aggregate device-memory capacity in MiB.
+    pub total_memory_mib: u64,
+}
+
+impl GpuSample {
+    fn free_memory_mib(self) -> u64 {
+        self.total_memory_mib.saturating_sub(self.used_memory_mib)
+    }
+
+    fn reserve_mib(self) -> u64 {
+        MIN_VRAM_RESERVE_MIB.max(self.total_memory_mib.saturating_mul(VRAM_RESERVE_PERCENT) / 100)
+    }
+}
+
+/// Public, read-only controller state returned with pool status.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AdmissionSnapshot {
+    /// Maximum active or activating leases currently admitted.
+    pub effective_limit: u32,
+    /// Explanation of the most recent controller decision.
+    pub reason: String,
+    /// Whether the controller is comparing a candidate resident level.
+    pub calibrating: bool,
+    /// Latest aggregate GPU utilization, when NVML is healthy.
+    pub gpu_utilization_percent: Option<f64>,
+    /// Latest aggregate used GPU memory in MiB.
+    pub gpu_memory_used_mib: Option<u64>,
+    /// Latest aggregate GPU memory capacity in MiB.
+    pub gpu_memory_total_mib: Option<u64>,
+    /// Latest host CPU busy percentage.
+    pub host_cpu_percent: Option<f64>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Score {
+    gpu_utilization_percent: f64,
+    completion_rate: Option<f64>,
+}
+
+impl Score {
+    fn improvement_over(self, baseline: Self) -> f64 {
+        let (current, previous) = match (self.completion_rate, baseline.completion_rate) {
+            (Some(current), Some(previous)) if previous > 0.0 => (current, previous),
+            _ if baseline.gpu_utilization_percent > 0.0 => (
+                self.gpu_utilization_percent,
+                baseline.gpu_utilization_percent,
+            ),
+            _ => return f64::INFINITY,
+        };
+        ((current - previous) / previous) * 100.0
+    }
+}
+
+#[derive(Debug)]
+struct PoolAdmissionState {
+    ceiling: u32,
+    effective_limit: u32,
+    best_limit: u32,
+    best_score: Option<Score>,
+    testing_from: Option<(u32, Score)>,
+    last_lower: Option<(u32, Score)>,
+    settled: bool,
+    last_probe: Instant,
+    last_blocked: Option<Instant>,
+    observed_active: u32,
+    window_started: Instant,
+    window_samples: u32,
+    gpu_utilization_sum: f64,
+    host_cpu_sum: f64,
+    completed_at_start: u64,
+    latest_gpu: Option<GpuSample>,
+    latest_host_cpu_percent: Option<f64>,
+    telemetry_failed_open: bool,
+    reason: String,
+}
+
+impl PoolAdmissionState {
+    fn initial_limit(ceiling: u32) -> u32 {
+        // Calibrate in at most three multiplicative steps without embedding a
+        // GPU- or workload-specific resident count. Small pools stay unmodified.
+        if ceiling <= 2 {
+            ceiling
+        } else {
+            ceiling.div_ceil(3).max(1)
+        }
+    }
+
+    fn new(ceiling: u32, now: Instant, completed_total: u64) -> Self {
+        let effective_limit = Self::initial_limit(ceiling);
+        Self {
+            ceiling,
+            effective_limit,
+            best_limit: effective_limit,
+            best_score: None,
+            testing_from: None,
+            last_lower: None,
+            settled: effective_limit == ceiling,
+            last_probe: now,
+            last_blocked: None,
+            observed_active: 0,
+            window_started: now,
+            window_samples: 0,
+            gpu_utilization_sum: 0.0,
+            host_cpu_sum: 0.0,
+            completed_at_start: completed_total,
+            latest_gpu: None,
+            latest_host_cpu_percent: None,
+            telemetry_failed_open: false,
+            reason: "waiting for GPU telemetry".into(),
+        }
+    }
+
+    fn reset_window(&mut self, now: Instant, active: u32, completed_total: u64) {
+        self.observed_active = active;
+        self.window_started = now;
+        self.window_samples = 0;
+        self.gpu_utilization_sum = 0.0;
+        self.host_cpu_sum = 0.0;
+        self.completed_at_start = completed_total;
+    }
+
+    fn has_pressure(&self, now: Instant) -> bool {
+        self.last_blocked
+            .is_some_and(|blocked| now.saturating_duration_since(blocked) <= PRESSURE_TTL)
+    }
+
+    fn update_ceiling(&mut self, ceiling: u32, now: Instant, completed_total: u64) {
+        if self.ceiling == ceiling {
+            return;
+        }
+        self.ceiling = ceiling;
+        self.effective_limit = self.effective_limit.min(ceiling).max(1);
+        self.best_limit = self.best_limit.min(ceiling).max(1);
+        self.testing_from = None;
+        self.last_lower = None;
+        self.settled = self.effective_limit == ceiling;
+        self.best_score = None;
+        self.last_probe = now;
+        self.reset_window(now, 0, completed_total);
+        self.reason = "pool ceiling changed; restarting calibration".into();
+    }
+
+    fn observe(
+        &mut self,
+        now: Instant,
+        active: u32,
+        completed_total: u64,
+        gpu: Option<GpuSample>,
+        host_cpu_percent: Option<f64>,
+    ) {
+        let telemetry_recovered = self.telemetry_failed_open && gpu.is_some();
+        self.latest_gpu = gpu;
+        self.latest_host_cpu_percent = host_cpu_percent;
+
+        let Some(gpu) = gpu else {
+            // Fail open: telemetry loss must never strand work behind a stale
+            // learned cap. A fixed maxActive still applies as the ceiling.
+            self.effective_limit = self.ceiling;
+            self.best_limit = self.ceiling;
+            self.best_score = None;
+            self.testing_from = None;
+            self.last_lower = None;
+            self.settled = true;
+            self.telemetry_failed_open = true;
+            self.reason = "GPU telemetry unavailable; using full residency".into();
+            self.reset_window(now, active, completed_total);
+            return;
+        };
+
+        if telemetry_recovered {
+            self.effective_limit = Self::initial_limit(self.ceiling);
+            self.best_limit = self.effective_limit;
+            self.best_score = None;
+            self.testing_from = None;
+            self.last_lower = None;
+            self.settled = self.effective_limit == self.ceiling;
+            self.last_probe = now;
+            self.telemetry_failed_open = false;
+            self.reason = "GPU telemetry recovered; restarting calibration".into();
+            self.reset_window(now, active, completed_total);
+            return;
+        }
+
+        if active != self.observed_active {
+            self.reset_window(now, active, completed_total);
+        }
+        self.window_samples = self.window_samples.saturating_add(1);
+        self.gpu_utilization_sum += gpu.utilization_percent;
+        self.host_cpu_sum += host_cpu_percent.unwrap_or(0.0);
+
+        let elapsed = now.saturating_duration_since(self.window_started);
+        if active > self.effective_limit {
+            self.reason = format!(
+                "waiting for active leases to drain from {active} to {}",
+                self.effective_limit
+            );
+            return;
+        }
+        let at_requested_residency = active == self.effective_limit;
+        if !at_requested_residency
+            || self.window_samples < MIN_STABLE_SAMPLES
+            || elapsed < OBSERVATION_WINDOW
+        {
+            self.reason = format!(
+                "observing stable residency at {active}/{}",
+                self.effective_limit
+            );
+            return;
+        }
+
+        let mean_gpu = self.gpu_utilization_sum / f64::from(self.window_samples);
+        let mean_cpu = self.host_cpu_sum / f64::from(self.window_samples);
+        let completed = completed_total.saturating_sub(self.completed_at_start);
+        let completion_rate = (completed > 0 && elapsed.as_secs_f64() > 0.0)
+            .then(|| completed as f64 / elapsed.as_secs_f64());
+        let score = Score {
+            gpu_utilization_percent: mean_gpu,
+            completion_rate,
+        };
+        let memory_safe = gpu.free_memory_mib() >= gpu.reserve_mib();
+        let cpu_safe = mean_cpu < CPU_SATURATION_PERCENT;
+
+        if let Some((prior_limit, prior_score)) = self.testing_from.take() {
+            let improvement = score.improvement_over(prior_score);
+            if improvement < MARGINAL_GAIN_PERCENT || !memory_safe || !cpu_safe {
+                self.effective_limit = prior_limit;
+                self.best_limit = prior_limit;
+                self.best_score = Some(prior_score);
+                self.settled = true;
+                self.last_probe = now;
+                self.reason = if !memory_safe {
+                    format!(
+                        "returned to {prior_limit}: preserving {} MiB GPU reserve",
+                        gpu.reserve_mib()
+                    )
+                } else if !cpu_safe {
+                    format!("returned to {prior_limit}: host CPU saturated at {mean_cpu:.1}%")
+                } else {
+                    format!(
+                        "returned to {prior_limit}: marginal gain {improvement:.1}% is below {MARGINAL_GAIN_PERCENT:.1}%"
+                    )
+                };
+                self.reset_window(now, active, completed_total);
+                return;
+            }
+            self.last_lower = Some((prior_limit, prior_score));
+        }
+
+        self.best_limit = self.effective_limit;
+        self.best_score = Some(score);
+
+        if self.settled
+            && now.saturating_duration_since(self.last_probe) >= REPROBE_INTERVAL
+            && self.has_pressure(now)
+            && self.effective_limit < self.ceiling
+        {
+            self.settled = false;
+        }
+
+        if self.settled && (!memory_safe || !cpu_safe) {
+            if let Some((lower_limit, lower_score)) = self.last_lower.take() {
+                self.effective_limit = lower_limit;
+                self.best_limit = lower_limit;
+                self.best_score = Some(lower_score);
+                self.last_probe = now;
+                self.reason = if !memory_safe {
+                    format!(
+                        "returned to {lower_limit}: preserving {} MiB GPU reserve",
+                        gpu.reserve_mib()
+                    )
+                } else {
+                    format!("returned to {lower_limit}: host CPU saturated at {mean_cpu:.1}%")
+                };
+                self.reset_window(now, active, completed_total);
+                return;
+            }
+        }
+
+        if !self.settled && self.has_pressure(now) && memory_safe && cpu_safe {
+            let next = self.effective_limit.saturating_mul(2).min(self.ceiling);
+            if next > self.effective_limit {
+                self.testing_from = Some((self.effective_limit, score));
+                self.effective_limit = next;
+                self.reason = format!("probing resident limit {next}");
+                self.reset_window(now, active, completed_total);
+                return;
+            }
+        }
+
+        self.settled = true;
+        self.last_probe = now;
+        self.reason = if !memory_safe {
+            format!(
+                "holding at {} to preserve {} MiB GPU reserve",
+                self.effective_limit,
+                gpu.reserve_mib()
+            )
+        } else if !cpu_safe {
+            format!(
+                "holding at {} because host CPU is {:.1}% busy",
+                self.effective_limit, mean_cpu
+            )
+        } else {
+            format!("settled at resident limit {}", self.effective_limit)
+        };
+        self.reset_window(now, active, completed_total);
+    }
+
+    fn snapshot(&self) -> AdmissionSnapshot {
+        AdmissionSnapshot {
+            effective_limit: self.effective_limit,
+            reason: self.reason.clone(),
+            calibrating: !self.settled,
+            gpu_utilization_percent: self.latest_gpu.map(|sample| sample.utilization_percent),
+            gpu_memory_used_mib: self.latest_gpu.map(|sample| sample.used_memory_mib),
+            gpu_memory_total_mib: self.latest_gpu.map(|sample| sample.total_memory_mib),
+            host_cpu_percent: self.latest_host_cpu_percent,
+        }
+    }
+}
+
+/// Thread-safe bridge between the HTTP admission path and the background
+/// telemetry loop.
+#[derive(Default)]
+pub struct AdmissionRegistry {
+    pools: Mutex<HashMap<String, PoolAdmissionState>>,
+}
+
+impl AdmissionRegistry {
+    fn ceiling(pool: &ForkPoolRecord) -> u32 {
+        pool.max_active
+            .unwrap_or(pool.desired_ready)
+            .min(pool.desired_ready)
+            .max(1)
+    }
+
+    /// Record that a caller had work but could not claim another resident slot.
+    pub fn note_blocked(&self, pool_name: &str) {
+        if let Some(state) = self.pools.lock().get_mut(pool_name) {
+            state.last_blocked = Some(Instant::now());
+        }
+    }
+
+    /// Current dynamic claim limit. `None` means the pool uses its existing
+    /// static `maxActive`/ready-slot behavior.
+    pub fn limit(&self, pool: &ForkPoolRecord) -> Option<u32> {
+        if !pool.auto_admission {
+            return None;
+        }
+        self.pools
+            .lock()
+            .get(&pool.name)
+            .map(|state| state.effective_limit)
+    }
+
+    /// Return the latest published telemetry and decision for an automatic pool.
+    pub fn snapshot(&self, pool: &ForkPoolRecord) -> Option<AdmissionSnapshot> {
+        if !pool.auto_admission {
+            return None;
+        }
+        self.pools
+            .lock()
+            .get(&pool.name)
+            .map(PoolAdmissionState::snapshot)
+    }
+
+    /// Feed one controller-tick observation into a pool's calibration state.
+    pub fn observe(
+        &self,
+        pool: &ForkPoolRecord,
+        active: u32,
+        completed_total: u64,
+        gpu: Option<GpuSample>,
+        host_cpu_percent: Option<f64>,
+    ) {
+        if !pool.auto_admission {
+            self.pools.lock().remove(&pool.name);
+            return;
+        }
+        self.observe_at(
+            pool,
+            active,
+            completed_total,
+            gpu,
+            host_cpu_percent,
+            Instant::now(),
+        );
+    }
+
+    fn observe_at(
+        &self,
+        pool: &ForkPoolRecord,
+        active: u32,
+        completed_total: u64,
+        gpu: Option<GpuSample>,
+        host_cpu_percent: Option<f64>,
+        now: Instant,
+    ) {
+        let ceiling = Self::ceiling(pool);
+        let mut pools = self.pools.lock();
+        let state = pools
+            .entry(pool.name.clone())
+            .or_insert_with(|| PoolAdmissionState::new(ceiling, now, completed_total));
+        state.update_ceiling(ceiling, now, completed_total);
+        state.observe(now, active, completed_total, gpu, host_cpu_percent);
+    }
+
+    /// Forget runtime state for pools that no longer exist.
+    pub fn retain_pools(&self, names: &HashSet<String>) {
+        self.pools.lock().retain(|name, _| names.contains(name));
+    }
+}
+
+/// Samples aggregate host CPU busy time from `/proc/stat`.
+#[derive(Default)]
+pub struct HostCpuSampler {
+    previous: Option<(u64, u64)>,
+}
+
+impl HostCpuSampler {
+    /// Sample host CPU busy percentage since the previous call.
+    pub fn sample(&mut self) -> Option<f64> {
+        #[cfg(target_os = "linux")]
+        {
+            let data = std::fs::read_to_string("/proc/stat").ok()?;
+            let line = data.lines().next()?;
+            let mut fields = line.split_whitespace();
+            if fields.next()? != "cpu" {
+                return None;
+            }
+            let values: Vec<u64> = fields.filter_map(|field| field.parse().ok()).collect();
+            if values.len() < 4 {
+                return None;
+            }
+            let total = values.iter().copied().sum::<u64>();
+            let idle = values[3].saturating_add(values.get(4).copied().unwrap_or(0));
+            let result = self.previous.and_then(|(old_total, old_idle)| {
+                let delta_total = total.saturating_sub(old_total);
+                let delta_idle = idle.saturating_sub(old_idle);
+                (delta_total > 0).then(|| {
+                    100.0 * (delta_total.saturating_sub(delta_idle)) as f64 / delta_total as f64
+                })
+            });
+            self.previous = Some((total, idle));
+            result
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            None
+        }
+    }
+}
+
+/// Small dynamically-loaded NVML surface. The host NVIDIA driver already ships
+/// this library; keeping it optional preserves CPU-only and non-Linux builds.
+#[cfg(target_os = "linux")]
+pub struct NvmlSampler {
+    _library: libloading::Library,
+    shutdown: unsafe extern "C" fn() -> i32,
+    device_count: unsafe extern "C" fn(*mut u32) -> i32,
+    device_handle: unsafe extern "C" fn(u32, *mut *mut std::ffi::c_void) -> i32,
+    memory_info: unsafe extern "C" fn(*mut std::ffi::c_void, *mut NvmlMemory) -> i32,
+    utilization: unsafe extern "C" fn(*mut std::ffi::c_void, *mut NvmlUtilization) -> i32,
+}
+
+#[cfg(target_os = "linux")]
+#[repr(C)]
+#[derive(Default)]
+struct NvmlMemory {
+    total: u64,
+    free: u64,
+    used: u64,
+}
+
+#[cfg(target_os = "linux")]
+#[repr(C)]
+#[derive(Default)]
+struct NvmlUtilization {
+    gpu: u32,
+    memory: u32,
+}
+
+#[cfg(target_os = "linux")]
+impl NvmlSampler {
+    /// Load and initialize the host driver's NVML library.
+    pub fn new() -> Result<Self, String> {
+        type Init = unsafe extern "C" fn() -> i32;
+        type Shutdown = unsafe extern "C" fn() -> i32;
+        type DeviceCount = unsafe extern "C" fn(*mut u32) -> i32;
+        type DeviceHandle = unsafe extern "C" fn(u32, *mut *mut std::ffi::c_void) -> i32;
+        type MemoryInfo = unsafe extern "C" fn(*mut std::ffi::c_void, *mut NvmlMemory) -> i32;
+        type Utilization = unsafe extern "C" fn(*mut std::ffi::c_void, *mut NvmlUtilization) -> i32;
+
+        // SAFETY: the copied function pointers remain valid because the Library
+        // is retained in the returned sampler until after `shutdown` runs.
+        unsafe {
+            let library = libloading::Library::new("libnvidia-ml.so.1")
+                .map_err(|error| format!("load libnvidia-ml.so.1: {error}"))?;
+            let init = *library
+                .get::<Init>(b"nvmlInit_v2\0")
+                .map_err(|error| format!("resolve nvmlInit_v2: {error}"))?;
+            let shutdown = *library
+                .get::<Shutdown>(b"nvmlShutdown\0")
+                .map_err(|error| format!("resolve nvmlShutdown: {error}"))?;
+            let device_count = *library
+                .get::<DeviceCount>(b"nvmlDeviceGetCount_v2\0")
+                .map_err(|error| format!("resolve nvmlDeviceGetCount_v2: {error}"))?;
+            let device_handle = *library
+                .get::<DeviceHandle>(b"nvmlDeviceGetHandleByIndex_v2\0")
+                .map_err(|error| format!("resolve nvmlDeviceGetHandleByIndex_v2: {error}"))?;
+            let memory_info = *library
+                .get::<MemoryInfo>(b"nvmlDeviceGetMemoryInfo\0")
+                .map_err(|error| format!("resolve nvmlDeviceGetMemoryInfo: {error}"))?;
+            let utilization = *library
+                .get::<Utilization>(b"nvmlDeviceGetUtilizationRates\0")
+                .map_err(|error| format!("resolve nvmlDeviceGetUtilizationRates: {error}"))?;
+            let status = init();
+            if status != 0 {
+                return Err(format!("nvmlInit_v2 returned {status}"));
+            }
+            Ok(Self {
+                _library: library,
+                shutdown,
+                device_count,
+                device_handle,
+                memory_info,
+                utilization,
+            })
+        }
+    }
+
+    /// Sample aggregate memory and utilization across visible NVIDIA devices.
+    pub fn sample(&mut self) -> Option<GpuSample> {
+        // SAFETY: NVML owns device handles; all output pointers target valid,
+        // initialized storage with the ABI layouts documented by NVML.
+        unsafe {
+            let mut count = 0;
+            if (self.device_count)(&mut count) != 0 || count == 0 {
+                return None;
+            }
+            let mut total_bytes = 0_u64;
+            let mut used_bytes = 0_u64;
+            let mut weighted_utilization = 0_f64;
+            for index in 0..count {
+                let mut device = std::ptr::null_mut();
+                if (self.device_handle)(index, &mut device) != 0 || device.is_null() {
+                    return None;
+                }
+                let mut memory = NvmlMemory::default();
+                let mut utilization = NvmlUtilization::default();
+                if (self.memory_info)(device, &mut memory) != 0
+                    || (self.utilization)(device, &mut utilization) != 0
+                {
+                    return None;
+                }
+                total_bytes = total_bytes.saturating_add(memory.total);
+                used_bytes = used_bytes.saturating_add(memory.used);
+                weighted_utilization += f64::from(utilization.gpu) * memory.total as f64;
+            }
+            Some(GpuSample {
+                utilization_percent: weighted_utilization / total_bytes.max(1) as f64,
+                used_memory_mib: used_bytes / (1024 * 1024),
+                total_memory_mib: total_bytes / (1024 * 1024),
+            })
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for NvmlSampler {
+    fn drop(&mut self) {
+        // SAFETY: paired with the successful nvmlInit_v2 call in `new`.
+        unsafe {
+            (self.shutdown)();
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub struct NvmlSampler;
+
+#[cfg(not(target_os = "linux"))]
+impl NvmlSampler {
+    /// Report that NVML telemetry is unsupported on this host.
+    pub fn new() -> Result<Self, String> {
+        Err("NVML admission telemetry is only available on Linux".into())
+    }
+
+    /// Return no GPU sample on unsupported hosts.
+    pub fn sample(&mut self) -> Option<GpuSample> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pool(size: u32) -> ForkPoolRecord {
+        ForkPoolRecord {
+            name: "rollouts".into(),
+            golden: "golden".into(),
+            desired_ready: size,
+            max_active: None,
+            auto_admission: true,
+            share_weights: true,
+            ready_timeout_secs: 240,
+            lease_ttl_secs: 300,
+            created_at: 1,
+            deleting: false,
+        }
+    }
+
+    fn gpu(utilization: f64, used: u64) -> Option<GpuSample> {
+        Some(GpuSample {
+            utilization_percent: utilization,
+            used_memory_mib: used,
+            total_memory_mib: 80 * 1024,
+        })
+    }
+
+    fn stable_window(
+        registry: &AdmissionRegistry,
+        pool: &ForkPoolRecord,
+        start: Instant,
+        observation: (u32, u64, f64, u64, f64),
+    ) {
+        let (active, completed, utilization, used, cpu) = observation;
+        for second in 0..=8 {
+            registry.observe_at(
+                pool,
+                active,
+                completed,
+                gpu(utilization, used),
+                Some(cpu),
+                start + Duration::from_secs(second),
+            );
+        }
+    }
+
+    #[test]
+    fn calibrates_to_the_measured_pareto_point_without_card_specific_limit() {
+        let registry = AdmissionRegistry::default();
+        let pool = pool(12);
+        let start = Instant::now();
+        registry.observe_at(&pool, 0, 0, gpu(0.0, 10_000), Some(10.0), start);
+        registry.note_blocked("rollouts");
+
+        stable_window(&registry, &pool, start, (4, 0, 56.6, 30_828, 62.0));
+        assert_eq!(registry.limit(&pool), Some(8));
+
+        stable_window(
+            &registry,
+            &pool,
+            start + Duration::from_secs(9),
+            (8, 0, 90.2, 51_138, 62.0),
+        );
+        assert_eq!(registry.limit(&pool), Some(12));
+
+        stable_window(
+            &registry,
+            &pool,
+            start + Duration::from_secs(18),
+            (12, 0, 88.0, 71_445, 62.0),
+        );
+        assert_eq!(registry.limit(&pool), Some(8));
+        assert!(!registry.snapshot(&pool).unwrap().calibrating);
+    }
+
+    #[test]
+    fn telemetry_failure_falls_back_to_full_residency() {
+        let registry = AdmissionRegistry::default();
+        let pool = pool(12);
+        registry.observe_at(&pool, 0, 0, None, None, Instant::now());
+        let snapshot = registry.snapshot(&pool).unwrap();
+        assert_eq!(snapshot.effective_limit, 12);
+        assert!(snapshot.reason.contains("telemetry unavailable"));
+    }
+
+    #[test]
+    fn telemetry_recovery_restarts_calibration_after_existing_leases_drain() {
+        let registry = AdmissionRegistry::default();
+        let pool = pool(12);
+        let start = Instant::now();
+        registry.observe_at(&pool, 12, 0, None, None, start);
+        assert_eq!(registry.limit(&pool), Some(12));
+
+        registry.observe_at(
+            &pool,
+            12,
+            0,
+            gpu(90.0, 70_000),
+            Some(50.0),
+            start + Duration::from_secs(1),
+        );
+        assert_eq!(registry.limit(&pool), Some(4));
+        assert!(registry
+            .snapshot(&pool)
+            .unwrap()
+            .reason
+            .contains("restarting calibration"));
+
+        registry.observe_at(
+            &pool,
+            12,
+            0,
+            gpu(90.0, 70_000),
+            Some(50.0),
+            start + Duration::from_secs(2),
+        );
+        assert!(registry.snapshot(&pool).unwrap().reason.contains("drain"));
+        assert_eq!(registry.limit(&pool), Some(4));
+    }
+
+    #[test]
+    fn cpu_saturation_rejects_a_larger_candidate() {
+        let registry = AdmissionRegistry::default();
+        let pool = pool(12);
+        let start = Instant::now();
+        registry.observe_at(&pool, 0, 0, gpu(0.0, 10_000), Some(10.0), start);
+        registry.note_blocked("rollouts");
+        stable_window(&registry, &pool, start, (4, 0, 50.0, 30_000, 50.0));
+        assert_eq!(registry.limit(&pool), Some(8));
+        stable_window(
+            &registry,
+            &pool,
+            start + Duration::from_secs(9),
+            (8, 0, 90.0, 50_000, 96.0),
+        );
+        assert_eq!(registry.limit(&pool), Some(4));
+    }
+
+    #[test]
+    fn late_cpu_saturation_rolls_back_the_last_accepted_candidate() {
+        let registry = AdmissionRegistry::default();
+        let pool = pool(12);
+        let start = Instant::now();
+        registry.observe_at(&pool, 0, 0, gpu(0.0, 10_000), Some(10.0), start);
+        registry.note_blocked("rollouts");
+        stable_window(&registry, &pool, start, (4, 0, 50.0, 30_000, 50.0));
+        stable_window(
+            &registry,
+            &pool,
+            start + Duration::from_secs(9),
+            (8, 0, 75.0, 50_000, 70.0),
+        );
+        assert_eq!(registry.limit(&pool), Some(12));
+        stable_window(
+            &registry,
+            &pool,
+            start + Duration::from_secs(18),
+            (12, 0, 95.0, 70_000, 80.0),
+        );
+        assert_eq!(registry.limit(&pool), Some(12));
+        stable_window(
+            &registry,
+            &pool,
+            start + Duration::from_secs(27),
+            (12, 0, 95.0, 71_000, 95.0),
+        );
+        assert_eq!(registry.limit(&pool), Some(8));
+        let snapshot = registry.snapshot(&pool).unwrap();
+        assert!(snapshot.reason.contains("drain"), "{}", snapshot.reason);
+    }
+
+    #[test]
+    fn a_static_pool_never_receives_a_dynamic_limit() {
+        let registry = AdmissionRegistry::default();
+        let mut pool = pool(12);
+        pool.auto_admission = false;
+        registry.observe(&pool, 0, 0, gpu(0.0, 0), Some(0.0));
+        assert_eq!(registry.limit(&pool), None);
+        assert_eq!(registry.snapshot(&pool), None);
+    }
+}

--- a/src/api/handlers/mod.rs
+++ b/src/api/handlers/mod.rs
@@ -9,6 +9,7 @@ pub mod node;
 pub mod p2p;
 pub mod pools;
 pub mod prewarm;
+pub mod rollouts;
 pub mod volumes;
 
 use crate::api::error::ApiError;

--- a/src/api/handlers/pools.rs
+++ b/src/api/handlers/pools.rs
@@ -205,6 +205,7 @@ async fn activate_claimed_lease(
 }
 
 async fn pool_info(state: &ApiState, pool: ForkPoolRecord) -> Result<ForkPoolInfo, ApiError> {
+    let admission = state.admission().snapshot(&pool);
     let db = state.db().clone();
     let pool_name = pool.name.clone();
     let slots = tokio::task::spawn_blocking(move || db.list_fork_pool_slots(&pool_name))
@@ -230,6 +231,20 @@ async fn pool_info(state: &ApiState, pool: ForkPoolRecord) -> Result<ForkPoolInf
         golden: pool.golden,
         desired_ready: pool.desired_ready,
         max_active: pool.max_active,
+        auto_admission: pool.auto_admission,
+        effective_active_limit: admission.as_ref().map(|state| state.effective_limit),
+        admission_reason: admission.as_ref().map(|state| state.reason.clone()),
+        admission_calibrating: admission.as_ref().map(|state| state.calibrating),
+        gpu_utilization_percent: admission
+            .as_ref()
+            .and_then(|state| state.gpu_utilization_percent),
+        gpu_memory_used_mib: admission
+            .as_ref()
+            .and_then(|state| state.gpu_memory_used_mib),
+        gpu_memory_total_mib: admission
+            .as_ref()
+            .and_then(|state| state.gpu_memory_total_mib),
+        host_cpu_percent: admission.as_ref().and_then(|state| state.host_cpu_percent),
         share_weights: pool.share_weights,
         lease_ttl_secs: pool.lease_ttl_secs,
         provisioning,
@@ -278,6 +293,12 @@ pub async fn create_pool(
     if matches!(req.max_active, Some(0)) {
         return Err(ApiError::BadRequest(
             "maxActive must be greater than zero when set".into(),
+        ));
+    }
+    let auto_admission = req.auto_admission.unwrap_or(req.share_weights);
+    if auto_admission && !req.share_weights {
+        return Err(ApiError::BadRequest(
+            "autoAdmission requires shareWeights so residency controls CUDA workers".into(),
         ));
     }
     let ready_timeout_secs = req.ready_timeout_secs.unwrap_or(DEFAULT_READY_TIMEOUT_SECS);
@@ -331,6 +352,7 @@ pub async fn create_pool(
         golden: req.golden,
         desired_ready: req.desired_ready,
         max_active: req.max_active,
+        auto_admission,
         share_weights: req.share_weights,
         ready_timeout_secs,
         lease_ttl_secs,
@@ -534,6 +556,7 @@ pub async fn acquire_lease(
     let assignment_for_claim = assignment.clone();
     let payload_for_claim = payload_sha256.clone();
     let require_private_workspace = !files.is_empty();
+    let admission_limit = state.admission().limit(&pool);
     let claim = tokio::task::spawn_blocking(move || {
         db.claim_fork_pool_slot(ForkPoolSlotClaim {
             pool_name: &pool_for_claim,
@@ -542,6 +565,7 @@ pub async fn acquire_lease(
             assignment: &assignment_for_claim,
             payload_sha256: payload_for_claim.as_deref(),
             require_private_workspace,
+            admission_limit,
             ttl_secs: ttl,
             now,
         })
@@ -568,8 +592,11 @@ pub async fn acquire_lease(
             )))
         }
         ClaimForkPoolSlot::AtCapacity => {
+            state.admission().note_blocked(&pool_name);
+            let limit = admission_limit.or(pool.max_active);
             return Err(ApiError::Conflict(format!(
-                "fork pool '{pool_name}' reached maxActive"
+                "fork pool '{pool_name}' reached active lease limit{}",
+                limit.map(|value| format!(" ({value})")).unwrap_or_default()
             )))
         }
         ClaimForkPoolSlot::PoolNotFound => {

--- a/src/api/handlers/rollouts.rs
+++ b/src/api/handlers/rollouts.rs
@@ -1,0 +1,243 @@
+//! Framework-aware fused rollout executor endpoints.
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use futures_util::future::join_all;
+use std::sync::Arc;
+
+use crate::api::error::ApiError;
+use crate::api::rollout::{
+    CreateRolloutExecutorRequest, PublishRolloutPolicyRequest, RolloutBatchItemResponse,
+    RolloutBatchRequest, RolloutBatchResponse, RolloutExecutorInfo, RolloutGenerateRequest,
+    RolloutGenerateResponse, RolloutPolicyInfo,
+};
+use crate::api::state::ApiState;
+
+const MAX_BATCH_JOBS: usize = 256;
+
+/// Register a healthy local fused rollout backend.
+#[utoipa::path(
+    post,
+    path = "/api/v1/rollout-executors",
+    request_body = CreateRolloutExecutorRequest,
+    responses(
+        (status = 201, description = "Executor registered", body = RolloutExecutorInfo),
+        (status = 400, description = "Invalid executor configuration"),
+        (status = 409, description = "Executor already exists"),
+        (status = 503, description = "Backend unavailable")
+    ),
+    tag = "Rollouts"
+)]
+pub async fn create_executor(
+    State(state): State<Arc<ApiState>>,
+    Json(request): Json<CreateRolloutExecutorRequest>,
+) -> Result<(StatusCode, Json<RolloutExecutorInfo>), ApiError> {
+    if let Some(pool) = &request.fallback_pool {
+        let db = state.db().clone();
+        let pool = pool.clone();
+        let exists = tokio::task::spawn_blocking(move || db.get_fork_pool(&pool))
+            .await
+            .map_err(ApiError::from)?
+            .map_err(ApiError::database)?
+            .is_some();
+        if !exists {
+            return Err(ApiError::BadRequest(format!(
+                "fallback pool '{}' does not exist",
+                request.fallback_pool.as_deref().unwrap_or_default()
+            )));
+        }
+    }
+    let info = state
+        .rollout()
+        .create(request)
+        .await
+        .map_err(ApiError::from)?;
+    Ok((StatusCode::CREATED, Json(info)))
+}
+
+/// List local fused rollout executors.
+#[utoipa::path(
+    get,
+    path = "/api/v1/rollout-executors",
+    responses((status = 200, description = "Executors", body = Vec<RolloutExecutorInfo>)),
+    tag = "Rollouts"
+)]
+pub async fn list_executors(State(state): State<Arc<ApiState>>) -> Json<Vec<RolloutExecutorInfo>> {
+    Json(state.rollout().list().await)
+}
+
+/// Inspect one local fused rollout executor.
+#[utoipa::path(
+    get,
+    path = "/api/v1/rollout-executors/{name}",
+    params(("name" = String, Path, description = "Executor name")),
+    responses(
+        (status = 200, description = "Executor state", body = RolloutExecutorInfo),
+        (status = 404, description = "Executor not found")
+    ),
+    tag = "Rollouts"
+)]
+pub async fn get_executor(
+    State(state): State<Arc<ApiState>>,
+    Path(name): Path<String>,
+) -> Result<Json<RolloutExecutorInfo>, ApiError> {
+    let executor = state.rollout().get(&name).await.map_err(ApiError::from)?;
+    Ok(Json(executor.info().await))
+}
+
+/// Delete an executor after draining requests and unloading its adapters.
+#[utoipa::path(
+    delete,
+    path = "/api/v1/rollout-executors/{name}",
+    params(("name" = String, Path, description = "Executor name")),
+    responses(
+        (status = 204, description = "Executor deleted"),
+        (status = 404, description = "Executor not found"),
+        (status = 503, description = "Adapter unload failed")
+    ),
+    tag = "Rollouts"
+)]
+pub async fn delete_executor(
+    State(state): State<Arc<ApiState>>,
+    Path(name): Path<String>,
+) -> Result<StatusCode, ApiError> {
+    state
+        .rollout()
+        .delete(&name)
+        .await
+        .map_err(ApiError::from)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// Verify, load, and atomically publish one policy adapter version.
+#[utoipa::path(
+    post,
+    path = "/api/v1/rollout-executors/{name}/policies",
+    params(("name" = String, Path, description = "Executor name")),
+    request_body = PublishRolloutPolicyRequest,
+    responses(
+        (status = 201, description = "Policy published", body = RolloutPolicyInfo),
+        (status = 400, description = "Invalid adapter or digest"),
+        (status = 404, description = "Executor not found"),
+        (status = 409, description = "Version conflict"),
+        (status = 503, description = "Backend unavailable")
+    ),
+    tag = "Rollouts"
+)]
+pub async fn publish_policy(
+    State(state): State<Arc<ApiState>>,
+    Path(name): Path<String>,
+    Json(request): Json<PublishRolloutPolicyRequest>,
+) -> Result<(StatusCode, Json<RolloutPolicyInfo>), ApiError> {
+    let executor = state.rollout().get(&name).await.map_err(ApiError::from)?;
+    let policy = executor
+        .publish_policy(request)
+        .await
+        .map_err(ApiError::from)?;
+    Ok((StatusCode::CREATED, Json(policy)))
+}
+
+/// Stop routing one policy version and unload it after active requests drain.
+#[utoipa::path(
+    delete,
+    path = "/api/v1/rollout-executors/{name}/policies/{policy}/{version}",
+    params(
+        ("name" = String, Path, description = "Executor name"),
+        ("policy" = String, Path, description = "Policy name"),
+        ("version" = String, Path, description = "Policy version")
+    ),
+    responses(
+        (status = 204, description = "Policy retired"),
+        (status = 404, description = "Executor or policy not found"),
+        (status = 503, description = "Backend unavailable")
+    ),
+    tag = "Rollouts"
+)]
+pub async fn retire_policy(
+    State(state): State<Arc<ApiState>>,
+    Path((name, policy, version)): Path<(String, String, String)>,
+) -> Result<StatusCode, ApiError> {
+    let executor = state.rollout().get(&name).await.map_err(ApiError::from)?;
+    executor
+        .retire_policy(&policy, &version)
+        .await
+        .map_err(ApiError::from)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// Generate rollouts through one explicitly versioned policy adapter.
+#[utoipa::path(
+    post,
+    path = "/api/v1/rollout-executors/{name}/generate",
+    params(("name" = String, Path, description = "Executor name")),
+    request_body = RolloutGenerateRequest,
+    responses(
+        (status = 200, description = "Generated rollouts", body = RolloutGenerateResponse),
+        (status = 400, description = "Invalid generation request"),
+        (status = 404, description = "Executor or policy not found"),
+        (status = 409, description = "Idempotency conflict"),
+        (status = 503, description = "Queue full or backend unavailable")
+    ),
+    tag = "Rollouts"
+)]
+pub async fn generate(
+    State(state): State<Arc<ApiState>>,
+    Path(name): Path<String>,
+    Json(request): Json<RolloutGenerateRequest>,
+) -> Result<Json<RolloutGenerateResponse>, ApiError> {
+    let executor = state.rollout().get(&name).await.map_err(ApiError::from)?;
+    let response = executor.generate(request).await.map_err(ApiError::from)?;
+    Ok(Json(response))
+}
+
+/// Submit a bounded cohort concurrently so the backend can fuse policies in one batch.
+#[utoipa::path(
+    post,
+    path = "/api/v1/rollout-executors/{name}/batches",
+    params(("name" = String, Path, description = "Executor name")),
+    request_body = RolloutBatchRequest,
+    responses(
+        (status = 200, description = "Ordered per-job results", body = RolloutBatchResponse),
+        (status = 400, description = "Invalid or oversized cohort"),
+        (status = 404, description = "Executor not found")
+    ),
+    tag = "Rollouts"
+)]
+pub async fn generate_batch(
+    State(state): State<Arc<ApiState>>,
+    Path(name): Path<String>,
+    Json(request): Json<RolloutBatchRequest>,
+) -> Result<Json<RolloutBatchResponse>, ApiError> {
+    if request.jobs.is_empty() || request.jobs.len() > MAX_BATCH_JOBS {
+        return Err(ApiError::BadRequest(format!(
+            "jobs must contain between 1 and {MAX_BATCH_JOBS} items"
+        )));
+    }
+    let executor = state.rollout().get(&name).await.map_err(ApiError::from)?;
+    let futures = request.jobs.into_iter().map(|job| {
+        let executor = executor.clone();
+        async move {
+            let key = job.idempotency_key.clone();
+            match executor.generate(job).await {
+                Ok(response) => RolloutBatchItemResponse {
+                    idempotency_key: key,
+                    response: Some(response),
+                    error_code: None,
+                    error: None,
+                },
+                Err(error) => RolloutBatchItemResponse {
+                    idempotency_key: key,
+                    response: None,
+                    error_code: Some(error.code().into()),
+                    error: Some(error.message().into()),
+                },
+            }
+        }
+    });
+    Ok(Json(RolloutBatchResponse {
+        jobs: join_all(futures).await,
+    }))
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -18,6 +18,7 @@
 //!   -d '{"name": "test"}'
 //! ```
 
+pub mod admission;
 #[path = "errors.rs"]
 pub mod error;
 pub mod handlers;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -23,6 +23,7 @@ pub mod admission;
 pub mod error;
 pub mod handlers;
 pub mod pool_controller;
+pub mod rollout;
 pub mod state;
 pub mod supervisor;
 pub mod types;
@@ -62,6 +63,7 @@ use state::ApiState;
         (name = "Node", description = "Node capacity introspection"),
         (name = "Machines", description = "Machine lifecycle management"),
         (name = "Pools", description = "Automatic held-fork worker pools"),
+        (name = "Rollouts", description = "Framework-aware fused multi-policy rollout executors"),
         (name = "Execution", description = "Command execution in machines"),
         (name = "Logs", description = "Log streaming"),
         (name = "Images", description = "OCI image management"),
@@ -104,6 +106,15 @@ use state::ApiState;
         handlers::pools::get_lease,
         handlers::pools::heartbeat_lease,
         handlers::pools::complete_lease,
+        // Fused rollouts
+        handlers::rollouts::create_executor,
+        handlers::rollouts::list_executors,
+        handlers::rollouts::get_executor,
+        handlers::rollouts::delete_executor,
+        handlers::rollouts::publish_policy,
+        handlers::rollouts::retire_policy,
+        handlers::rollouts::generate,
+        handlers::rollouts::generate_batch,
     ),
     components(schemas(
         // Request types
@@ -128,6 +139,12 @@ use state::ApiState;
         types::AcquireForkLeaseRequest,
         types::ForkLeasePayloadFile,
         types::ResizeForkPoolRequest,
+        rollout::CreateRolloutExecutorRequest,
+        rollout::PublishRolloutPolicyRequest,
+        rollout::RolloutPrompt,
+        rollout::RolloutSamplingParams,
+        rollout::RolloutGenerateRequest,
+        rollout::RolloutBatchRequest,
         // Response types
         types::HealthResponse,
         types::CapacityResponse,
@@ -146,6 +163,13 @@ use state::ApiState;
         types::ForkPoolInfo,
         types::ListForkPoolsResponse,
         types::ForkLeaseInfo,
+        rollout::RolloutExecutorInfo,
+        rollout::RolloutPolicyInfo,
+        rollout::RolloutCompletion,
+        rollout::RolloutUsage,
+        rollout::RolloutGenerateResponse,
+        rollout::RolloutBatchItemResponse,
+        rollout::RolloutBatchResponse,
     ))
 )]
 pub struct ApiDoc;
@@ -160,6 +184,8 @@ const API_REQUEST_TIMEOUT_SECS: u64 = 300;
 /// uploads before the handler runs; the control plane permits 100 MiB, so match
 /// it here. The agent streams the write and enforces the true ceiling.
 const MAX_FILE_UPLOAD_BYTES: usize = 100 * 1024 * 1024;
+/// Bounded but large enough for cohorts of pre-tokenized RL prompts.
+const MAX_ROLLOUT_REQUEST_BYTES: usize = 20 * 1024 * 1024;
 
 /// Validate that an API command payload is not empty.
 pub fn validate_command(cmd: &[String]) -> Result<(), ApiError> {
@@ -290,10 +316,27 @@ pub fn create_router(state: Arc<ApiState>, cors_origins: Vec<String>) -> Router 
         .route("/", post(handlers::volumes::provision_volume))
         .route("/{id}", delete(handlers::volumes::deprovision_volume));
 
+    // Fused rollout handlers own their deadlines so cancelled clients abort the
+    // backend HTTP request instead of inheriting the generic lifecycle timeout.
+    let rollout_routes = Router::new()
+        .route("/", post(handlers::rollouts::create_executor))
+        .route("/", get(handlers::rollouts::list_executors))
+        .route("/{name}", get(handlers::rollouts::get_executor))
+        .route("/{name}", delete(handlers::rollouts::delete_executor))
+        .route("/{name}/policies", post(handlers::rollouts::publish_policy))
+        .route(
+            "/{name}/policies/{policy}/{version}",
+            delete(handlers::rollouts::retire_policy),
+        )
+        .route("/{name}/generate", post(handlers::rollouts::generate))
+        .route("/{name}/batches", post(handlers::rollouts::generate_batch))
+        .layer(DefaultBodyLimit::max(MAX_ROLLOUT_REQUEST_BYTES));
+
     // API v1 routes
     let api_v1 = Router::new()
         .nest("/machines", machine_routes)
         .nest("/pools", pool_routes)
+        .nest("/rollout-executors", rollout_routes)
         .nest("/volumes", volume_routes);
 
     let cors = build_cors(cors_origins);
@@ -494,12 +537,22 @@ fn machine_id_from_path(path: &str) -> Option<&str> {
 
 fn normalize_metrics_path(path: &str) -> String {
     let parts: Vec<&str> = path.split('/').collect();
-    if parts.len() >= 4 && parts[1] == "api" && parts[3] == "machines" {
+    if parts.len() >= 4
+        && parts[1] == "api"
+        && matches!(parts[3], "machines" | "pools" | "rollout-executors")
+    {
         if let Some(id_pos) = parts.get(4) {
             if !id_pos.is_empty() {
                 let mut normalized = parts[..4].to_vec();
                 normalized.push(":id");
                 normalized.extend_from_slice(&parts[5..]);
+                if parts[3] == "rollout-executors"
+                    && normalized.get(5) == Some(&"policies")
+                    && normalized.len() >= 8
+                {
+                    normalized[6] = ":policy";
+                    normalized[7] = ":version";
+                }
                 return normalized.join("/");
             }
         }
@@ -546,7 +599,7 @@ async fn trace_id_middleware(mut req: Request, next: Next) -> Response {
 
 #[cfg(test)]
 mod tests {
-    use super::{machine_id_from_path, validate_command};
+    use super::{machine_id_from_path, normalize_metrics_path, validate_command};
 
     #[test]
     fn machine_id_is_extracted_from_machine_routes() {
@@ -569,6 +622,22 @@ mod tests {
         assert_eq!(machine_id_from_path("/health"), None);
         assert_eq!(machine_id_from_path("/api/v1/machines"), None);
         assert_eq!(machine_id_from_path("/api/v1/machines/"), None);
+    }
+
+    #[test]
+    fn metrics_paths_hide_rollout_and_pool_identifiers() {
+        assert_eq!(
+            normalize_metrics_path("/api/v1/pools/team-a/leases"),
+            "/api/v1/pools/:id/leases"
+        );
+        assert_eq!(
+            normalize_metrics_path("/api/v1/rollout-executors/qwen/policies/experiment-1/step-400"),
+            "/api/v1/rollout-executors/:id/policies/:policy/:version"
+        );
+        assert_eq!(
+            normalize_metrics_path("/api/v1/rollout-executors/qwen/generate"),
+            "/api/v1/rollout-executors/:id/generate"
+        );
     }
 
     #[test]

--- a/src/api/pool_controller.rs
+++ b/src/api/pool_controller.rs
@@ -18,16 +18,27 @@ pub struct ForkPoolController {
     shutdown_rx: watch::Receiver<bool>,
     fills: tokio::task::JoinSet<String>,
     filling: std::collections::HashSet<String>,
+    nvml: Option<crate::api::admission::NvmlSampler>,
+    host_cpu: crate::api::admission::HostCpuSampler,
 }
 
 impl ForkPoolController {
     /// Create a controller sharing the API's durable state and shutdown signal.
     pub fn new(state: Arc<ApiState>, shutdown_rx: watch::Receiver<bool>) -> Self {
+        let nvml = match crate::api::admission::NvmlSampler::new() {
+            Ok(nvml) => Some(nvml),
+            Err(error) => {
+                tracing::info!(%error, "NVML unavailable; automatic admission will use full residency");
+                None
+            }
+        };
         Self {
             state,
             shutdown_rx,
             fills: tokio::task::JoinSet::new(),
             filling: std::collections::HashSet::new(),
+            nvml,
+            host_cpu: crate::api::admission::HostCpuSampler::default(),
         }
     }
 
@@ -162,6 +173,7 @@ impl ForkPoolController {
             .await
             .map_err(|e| e.to_string())?
             .map_err(|e| e.to_string())?;
+        self.update_admission(&pools).await?;
         for pool in pools.into_iter().filter(|pool| !pool.deleting) {
             if self.filling.contains(&pool.name) {
                 continue;
@@ -180,6 +192,42 @@ impl ForkPoolController {
                     Self::fill_pool(state, pool).await;
                     pool_name
                 });
+            }
+        }
+        Ok(())
+    }
+
+    async fn update_admission(&mut self, pools: &[ForkPoolRecord]) -> Result<(), String> {
+        let gpu = self.nvml.as_mut().and_then(|nvml| nvml.sample());
+        let host_cpu = self.host_cpu.sample();
+        let names = pools
+            .iter()
+            .map(|pool| pool.name.clone())
+            .collect::<std::collections::HashSet<_>>();
+        self.state.admission().retain_pools(&names);
+
+        for pool in pools.iter().filter(|pool| !pool.deleting) {
+            if !pool.auto_admission {
+                self.state.admission().observe(pool, 0, 0, gpu, host_cpu);
+                continue;
+            }
+            let db = self.state.db().clone();
+            let pool_name = pool.name.clone();
+            let (active, completed) =
+                tokio::task::spawn_blocking(move || db.fork_pool_admission_counts(&pool_name))
+                    .await
+                    .map_err(|error| error.to_string())?
+                    .map_err(|error| error.to_string())?;
+            self.state
+                .admission()
+                .observe(pool, active, completed, gpu, host_cpu);
+            if let Some(snapshot) = self.state.admission().snapshot(pool) {
+                metrics::gauge!("smolvm_pool_admission_limit", "pool" => pool.name.clone())
+                    .set(f64::from(snapshot.effective_limit));
+                if let Some(utilization) = snapshot.gpu_utilization_percent {
+                    metrics::gauge!("smolvm_pool_gpu_utilization_percent", "pool" => pool.name.clone())
+                        .set(utilization);
+                }
             }
         }
         Ok(())

--- a/src/api/rollout.rs
+++ b/src/api/rollout.rs
@@ -1,0 +1,1750 @@
+//! Framework-neutral control plane for fused multi-policy rollout engines.
+//!
+//! smolvm does not attempt to infer framework semantics from CUDA calls. A
+//! supported framework publishes immutable policy adapters here and submits
+//! generation requests through one engine. The first backend is vLLM's
+//! OpenAI-compatible completion API; isolated fork pools remain the advertised
+//! fallback for requests a fused backend cannot represent.
+
+use futures_util::StreamExt;
+use reqwest::{redirect::Policy, Client};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::path::{Component, Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::{Mutex, Notify, OnceCell, RwLock, Semaphore};
+use utoipa::ToSchema;
+
+const DEFAULT_MAX_CONCURRENT: u32 = 32;
+const MAX_CONCURRENT: u32 = 1024;
+const DEFAULT_MAX_QUEUE_DEPTH: u32 = 256;
+const MAX_QUEUE_DEPTH: u32 = 16_384;
+const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 300;
+const MAX_REQUEST_TIMEOUT_SECS: u64 = 60 * 60;
+const MAX_NAME_BYTES: usize = 128;
+const MAX_IDEMPOTENCY_KEY_BYTES: usize = 256;
+const MAX_POLICY_VERSIONS: usize = 4096;
+const MAX_PROMPTS: usize = 4096;
+const MAX_PROMPT_TOKENS: usize = 1_048_576;
+const MAX_PROMPT_TEXT_BYTES: usize = 16 * 1024 * 1024;
+const MAX_COMPLETION_TOKENS: u32 = 65_536;
+const MAX_BACKEND_BODY_BYTES: usize = 64 * 1024 * 1024;
+const MAX_ADAPTER_FILES: usize = 4096;
+const MAX_ADAPTER_BYTES: u64 = 32 * 1024 * 1024 * 1024;
+const IDEMPOTENCY_TTL: Duration = Duration::from_secs(10 * 60);
+const MAX_IDEMPOTENCY_ENTRIES: usize = 8192;
+
+/// Request to register one local fused rollout engine.
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateRolloutExecutorRequest {
+    /// Stable executor name.
+    pub name: String,
+    /// Backend kind. Only `vllm` is currently supported.
+    pub backend: String,
+    /// Loopback HTTP endpoint of the backend, for example `http://127.0.0.1:8000`.
+    pub endpoint: String,
+    /// Host directory beneath which adapter paths must resolve.
+    pub adapter_root: String,
+    /// Optional ordinary fork pool used by framework adapters as a compatibility fallback.
+    #[serde(default)]
+    pub fallback_pool: Option<String>,
+    /// Maximum backend requests in flight.
+    #[serde(default)]
+    pub max_concurrent_requests: Option<u32>,
+    /// Maximum requests waiting behind active work.
+    #[serde(default)]
+    pub max_queue_depth: Option<u32>,
+    /// Whole-request deadline used when a caller supplies no shorter deadline.
+    #[serde(default)]
+    pub request_timeout_secs: Option<u64>,
+}
+
+/// Runtime state and capabilities for one fused rollout engine.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RolloutExecutorInfo {
+    /// Stable executor name.
+    pub name: String,
+    /// Backend kind.
+    pub backend: String,
+    /// Local backend endpoint.
+    pub endpoint: String,
+    /// Confined adapter root.
+    pub adapter_root: String,
+    /// Optional isolated-worker fallback pool.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fallback_pool: Option<String>,
+    /// Maximum concurrent backend requests.
+    pub max_concurrent_requests: u32,
+    /// Maximum queued requests.
+    pub max_queue_depth: u32,
+    /// Requests currently executing.
+    pub active_requests: u32,
+    /// Requests currently waiting for an execution permit.
+    pub queued_requests: u32,
+    /// Published policy versions currently routable.
+    pub policies: Vec<RolloutPolicyInfo>,
+    /// Backend capabilities understood by the stable API.
+    pub capabilities: Vec<String>,
+}
+
+/// Request to publish one immutable LoRA policy version.
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PublishRolloutPolicyRequest {
+    /// Logical policy or experiment identifier.
+    pub policy: String,
+    /// Immutable version identifier, normally the optimizer step or content digest.
+    pub version: String,
+    /// Relative directory beneath the executor's configured adapter root.
+    pub adapter_path: String,
+    /// Expected deterministic SHA-256 of the adapter directory contents.
+    pub adapter_sha256: String,
+    /// Keep the previous current version routable instead of retiring it.
+    #[serde(default)]
+    pub retain_previous: bool,
+}
+
+/// Published policy metadata.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RolloutPolicyInfo {
+    /// Logical policy identifier.
+    pub policy: String,
+    /// Immutable version identifier.
+    pub version: String,
+    /// Verified adapter SHA-256.
+    pub adapter_sha256: String,
+    /// Opaque backend model name assigned by smolvm.
+    pub backend_model: String,
+    /// Whether this is the default version for the policy.
+    pub current: bool,
+    /// Requests using this version right now.
+    pub active_requests: u32,
+}
+
+/// One text or pre-tokenized prompt.
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RolloutPrompt {
+    /// Text prompt. Exactly one of `text` and `tokenIds` must be set.
+    #[serde(default)]
+    pub text: Option<String>,
+    /// Tokenized prompt. Exactly one of `text` and `tokenIds` must be set.
+    #[serde(default)]
+    pub token_ids: Option<Vec<u32>>,
+}
+
+/// Sampling parameters shared by every prompt in one request.
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RolloutSamplingParams {
+    /// Completions per prompt.
+    #[serde(default = "default_one")]
+    pub n: u32,
+    /// Maximum generated tokens per completion.
+    pub max_tokens: u32,
+    /// Sampling temperature.
+    #[serde(default)]
+    pub temperature: Option<f64>,
+    /// Nucleus sampling probability.
+    #[serde(default)]
+    pub top_p: Option<f64>,
+    /// Top-k sampling cutoff.
+    #[serde(default)]
+    pub top_k: Option<i64>,
+    /// Minimum-token probability cutoff.
+    #[serde(default)]
+    pub min_p: Option<f64>,
+    /// Repetition penalty.
+    #[serde(default)]
+    pub repetition_penalty: Option<f64>,
+    /// Deterministic seed.
+    #[serde(default)]
+    pub seed: Option<i64>,
+    /// Number of per-token alternatives to return.
+    #[serde(default)]
+    pub logprobs: Option<u32>,
+    /// Return prompt-token log probabilities.
+    #[serde(default)]
+    pub prompt_logprobs: Option<u32>,
+}
+
+fn default_one() -> u32 {
+    1
+}
+
+/// One idempotent fused generation request.
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RolloutGenerateRequest {
+    /// Retry key unique within the executor.
+    pub idempotency_key: String,
+    /// Logical policy identifier.
+    pub policy: String,
+    /// Explicit immutable version, or the current version when omitted.
+    #[serde(default)]
+    pub version: Option<String>,
+    /// Text or tokenized prompts. A request cannot mix the two representations.
+    pub prompts: Vec<RolloutPrompt>,
+    /// Generation parameters.
+    pub sampling: RolloutSamplingParams,
+    /// Optional shorter whole-request deadline.
+    #[serde(default)]
+    pub deadline_ms: Option<u64>,
+}
+
+/// A cohort of independent policy requests submitted together for backend fusion.
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RolloutBatchRequest {
+    /// Independent generation jobs. Results retain this order.
+    pub jobs: Vec<RolloutGenerateRequest>,
+}
+
+/// One completion returned by the backend.
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RolloutCompletion {
+    /// Backend choice index.
+    pub index: u32,
+    /// Decoded completion text.
+    pub text: String,
+    /// Exact generated token IDs when supplied by the backend.
+    #[serde(default, alias = "token_ids", skip_serializing_if = "Option::is_none")]
+    pub token_ids: Option<Vec<u32>>,
+    /// Exact prompt token IDs when supplied by the backend.
+    #[serde(
+        default,
+        alias = "prompt_token_ids",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub prompt_token_ids: Option<Vec<u32>>,
+    /// Backend log-probability payload.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<Object>)]
+    pub logprobs: Option<serde_json::Value>,
+    /// Backend finish reason.
+    #[serde(
+        default,
+        alias = "finish_reason",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub finish_reason: Option<String>,
+    /// Token or string that stopped generation.
+    #[serde(
+        default,
+        alias = "stop_reason",
+        skip_serializing_if = "Option::is_none"
+    )]
+    #[schema(value_type = Option<Object>)]
+    pub stop_reason: Option<serde_json::Value>,
+}
+
+/// Token accounting returned by a rollout backend.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RolloutUsage {
+    /// Prompt tokens consumed.
+    #[serde(default, alias = "prompt_tokens")]
+    pub prompt_tokens: u64,
+    /// Completion tokens produced.
+    #[serde(default, alias = "completion_tokens")]
+    pub completion_tokens: u64,
+    /// Total tokens processed.
+    #[serde(default, alias = "total_tokens")]
+    pub total_tokens: u64,
+}
+
+/// Stable fused generation response.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RolloutGenerateResponse {
+    /// Executor that handled the request.
+    pub executor: String,
+    /// Routed logical policy.
+    pub policy: String,
+    /// Routed immutable version.
+    pub version: String,
+    /// Backend request identifier.
+    pub backend_request_id: String,
+    /// Generated choices.
+    pub choices: Vec<RolloutCompletion>,
+    /// Backend token usage.
+    pub usage: RolloutUsage,
+    /// True when an idempotent retry reused an earlier result.
+    pub cached: bool,
+}
+
+/// One ordered item in a cohort response.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RolloutBatchItemResponse {
+    /// Retry key from the submitted job.
+    pub idempotency_key: String,
+    /// Successful result.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response: Option<RolloutGenerateResponse>,
+    /// Stable error category for a failed item.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_code: Option<String>,
+    /// Human-readable failure.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Ordered results for one submitted cohort.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RolloutBatchResponse {
+    /// Per-job results in submission order.
+    pub jobs: Vec<RolloutBatchItemResponse>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum RolloutError {
+    BadRequest(String),
+    NotFound(String),
+    Conflict(String),
+    Unavailable(String),
+    Timeout(String),
+    Backend(String),
+}
+
+impl RolloutError {
+    pub(crate) fn code(&self) -> &'static str {
+        match self {
+            Self::BadRequest(_) => "BAD_REQUEST",
+            Self::NotFound(_) => "NOT_FOUND",
+            Self::Conflict(_) => "CONFLICT",
+            Self::Unavailable(_) => "UNAVAILABLE",
+            Self::Timeout(_) => "TIMEOUT",
+            Self::Backend(_) => "BACKEND_ERROR",
+        }
+    }
+
+    pub(crate) fn message(&self) -> &str {
+        match self {
+            Self::BadRequest(v)
+            | Self::NotFound(v)
+            | Self::Conflict(v)
+            | Self::Unavailable(v)
+            | Self::Timeout(v)
+            | Self::Backend(v) => v,
+        }
+    }
+}
+
+impl From<RolloutError> for crate::api::error::ApiError {
+    fn from(value: RolloutError) -> Self {
+        match value {
+            RolloutError::BadRequest(v) => Self::BadRequest(v),
+            RolloutError::NotFound(v) => Self::NotFound(v),
+            RolloutError::Conflict(v) => Self::Conflict(v),
+            RolloutError::Unavailable(v) => Self::Unavailable(v),
+            RolloutError::Timeout(_) => Self::Timeout,
+            RolloutError::Backend(v) => Self::Unavailable(v),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct CachedError {
+    value: RolloutError,
+}
+
+struct IdempotencyEntry {
+    digest: [u8; 32],
+    created: Instant,
+    result: OnceCell<Result<Arc<RolloutGenerateResponse>, CachedError>>,
+}
+
+struct PolicyEntry {
+    policy: String,
+    version: String,
+    adapter_sha256: String,
+    backend_model: String,
+    active: AtomicUsize,
+    drained: Notify,
+}
+
+struct PolicyGuard {
+    policy: Arc<PolicyEntry>,
+}
+
+impl Drop for PolicyGuard {
+    fn drop(&mut self) {
+        if self.policy.active.fetch_sub(1, Ordering::AcqRel) == 1 {
+            self.policy.drained.notify_waiters();
+        }
+    }
+}
+
+struct ExecutorConfig {
+    name: String,
+    endpoint: String,
+    adapter_root: PathBuf,
+    fallback_pool: Option<String>,
+    max_concurrent: u32,
+    max_queue_depth: u32,
+    request_timeout: Duration,
+}
+
+struct PolicyState {
+    versions: HashMap<(String, String), Arc<PolicyEntry>>,
+    current: HashMap<String, String>,
+}
+
+pub(crate) struct RolloutExecutor {
+    config: ExecutorConfig,
+    http: Client,
+    permits: Semaphore,
+    queued: AtomicU32,
+    active: AtomicU32,
+    accepting: AtomicBool,
+    policy_state: RwLock<PolicyState>,
+    publish_lock: Mutex<()>,
+    idempotency: Mutex<HashMap<String, Arc<IdempotencyEntry>>>,
+}
+
+/// In-memory executor registry. The framework client re-registers declaratively
+/// after a node restart, while immutable policy state remains in its adapter root.
+#[derive(Default)]
+pub struct RolloutRegistry {
+    executors: RwLock<HashMap<String, Arc<RolloutExecutor>>>,
+}
+
+impl RolloutRegistry {
+    /// Register an executor after validating its local trust boundary and health.
+    pub(crate) async fn create(
+        &self,
+        request: CreateRolloutExecutorRequest,
+    ) -> Result<RolloutExecutorInfo, RolloutError> {
+        let executor = Arc::new(RolloutExecutor::new(request)?);
+        executor.health().await?;
+        let mut executors = self.executors.write().await;
+        if executors.contains_key(&executor.config.name) {
+            return Err(RolloutError::Conflict(format!(
+                "rollout executor '{}' already exists",
+                executor.config.name
+            )));
+        }
+        let info = executor.info().await;
+        executors.insert(executor.config.name.clone(), executor);
+        Ok(info)
+    }
+
+    /// List registered executors.
+    pub async fn list(&self) -> Vec<RolloutExecutorInfo> {
+        let values: Vec<_> = self.executors.read().await.values().cloned().collect();
+        let mut infos = Vec::with_capacity(values.len());
+        for executor in values {
+            infos.push(executor.info().await);
+        }
+        infos.sort_by(|a, b| a.name.cmp(&b.name));
+        infos
+    }
+
+    /// Resolve one registered executor.
+    pub(crate) async fn get(&self, name: &str) -> Result<Arc<RolloutExecutor>, RolloutError> {
+        self.executors
+            .read()
+            .await
+            .get(name)
+            .cloned()
+            .ok_or_else(|| RolloutError::NotFound(format!("rollout executor '{name}' not found")))
+    }
+
+    /// Remove an executor and retire its loaded adapters.
+    pub(crate) async fn delete(&self, name: &str) -> Result<(), RolloutError> {
+        let executor = self.executors.write().await.remove(name).ok_or_else(|| {
+            RolloutError::NotFound(format!("rollout executor '{name}' not found"))
+        })?;
+        executor.accepting.store(false, Ordering::Release);
+        executor.shutdown().await
+    }
+}
+
+impl RolloutExecutor {
+    fn new(request: CreateRolloutExecutorRequest) -> Result<Self, RolloutError> {
+        validate_name("executor", &request.name)?;
+        if request.backend != "vllm" {
+            return Err(RolloutError::BadRequest(format!(
+                "unsupported rollout backend '{}'; expected 'vllm'",
+                request.backend
+            )));
+        }
+        let endpoint = validate_loopback_endpoint(&request.endpoint)?;
+        let root = Path::new(&request.adapter_root);
+        if !root.is_absolute() {
+            return Err(RolloutError::BadRequest(
+                "adapterRoot must be an absolute directory".into(),
+            ));
+        }
+        let adapter_root = root.canonicalize().map_err(|error| {
+            RolloutError::BadRequest(format!("canonicalize adapterRoot: {error}"))
+        })?;
+        if !adapter_root.is_dir() {
+            return Err(RolloutError::BadRequest(
+                "adapterRoot must resolve to a directory".into(),
+            ));
+        }
+        let max_concurrent = request
+            .max_concurrent_requests
+            .unwrap_or(DEFAULT_MAX_CONCURRENT);
+        if !(1..=MAX_CONCURRENT).contains(&max_concurrent) {
+            return Err(RolloutError::BadRequest(format!(
+                "maxConcurrentRequests must be between 1 and {MAX_CONCURRENT}"
+            )));
+        }
+        let max_queue_depth = request.max_queue_depth.unwrap_or(DEFAULT_MAX_QUEUE_DEPTH);
+        if max_queue_depth > MAX_QUEUE_DEPTH {
+            return Err(RolloutError::BadRequest(format!(
+                "maxQueueDepth must be at most {MAX_QUEUE_DEPTH}"
+            )));
+        }
+        let timeout_secs = request
+            .request_timeout_secs
+            .unwrap_or(DEFAULT_REQUEST_TIMEOUT_SECS);
+        if !(1..=MAX_REQUEST_TIMEOUT_SECS).contains(&timeout_secs) {
+            return Err(RolloutError::BadRequest(format!(
+                "requestTimeoutSecs must be between 1 and {MAX_REQUEST_TIMEOUT_SECS}"
+            )));
+        }
+        if let Some(pool) = &request.fallback_pool {
+            validate_name("fallback pool", pool)?;
+        }
+        let http = Client::builder()
+            .no_proxy()
+            .redirect(Policy::none())
+            .connect_timeout(Duration::from_secs(5))
+            .build()
+            .map_err(|error| RolloutError::Backend(format!("build rollout client: {error}")))?;
+        Ok(Self {
+            config: ExecutorConfig {
+                name: request.name,
+                endpoint,
+                adapter_root,
+                fallback_pool: request.fallback_pool,
+                max_concurrent,
+                max_queue_depth,
+                request_timeout: Duration::from_secs(timeout_secs),
+            },
+            http,
+            permits: Semaphore::new(max_concurrent as usize),
+            queued: AtomicU32::new(0),
+            active: AtomicU32::new(0),
+            accepting: AtomicBool::new(true),
+            policy_state: RwLock::new(PolicyState {
+                versions: HashMap::new(),
+                current: HashMap::new(),
+            }),
+            publish_lock: Mutex::new(()),
+            idempotency: Mutex::new(HashMap::new()),
+        })
+    }
+
+    async fn health(&self) -> Result<(), RolloutError> {
+        let response = tokio::time::timeout(
+            Duration::from_secs(10),
+            self.http
+                .get(format!("{}/health", self.config.endpoint))
+                .send(),
+        )
+        .await
+        .map_err(|_| RolloutError::Timeout("rollout backend health check timed out".into()))?
+        .map_err(|error| {
+            RolloutError::Unavailable(format!("rollout backend health check failed: {error}"))
+        })?;
+        if !response.status().is_success() {
+            return Err(RolloutError::Unavailable(format!(
+                "rollout backend health check returned {}",
+                response.status()
+            )));
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn info(&self) -> RolloutExecutorInfo {
+        let state = self.policy_state.read().await;
+        let mut policies: Vec<_> = state
+            .versions
+            .values()
+            .map(|entry| RolloutPolicyInfo {
+                policy: entry.policy.clone(),
+                version: entry.version.clone(),
+                adapter_sha256: entry.adapter_sha256.clone(),
+                backend_model: entry.backend_model.clone(),
+                current: state.current.get(&entry.policy) == Some(&entry.version),
+                active_requests: entry.active.load(Ordering::Acquire) as u32,
+            })
+            .collect();
+        policies.sort_by(|a, b| (&a.policy, &a.version).cmp(&(&b.policy, &b.version)));
+        RolloutExecutorInfo {
+            name: self.config.name.clone(),
+            backend: "vllm".into(),
+            endpoint: self.config.endpoint.clone(),
+            adapter_root: self.config.adapter_root.display().to_string(),
+            fallback_pool: self.config.fallback_pool.clone(),
+            max_concurrent_requests: self.config.max_concurrent,
+            max_queue_depth: self.config.max_queue_depth,
+            active_requests: self.active.load(Ordering::Acquire),
+            queued_requests: self.queued.load(Ordering::Acquire),
+            policies,
+            capabilities: vec![
+                "multi_lora".into(),
+                "text_prompts".into(),
+                "token_id_prompts".into(),
+                "token_id_outputs".into(),
+                "logprobs".into(),
+                "continuous_batching".into(),
+            ],
+        }
+    }
+
+    pub(crate) async fn publish_policy(
+        self: &Arc<Self>,
+        request: PublishRolloutPolicyRequest,
+    ) -> Result<RolloutPolicyInfo, RolloutError> {
+        validate_name("policy", &request.policy)?;
+        validate_name("version", &request.version)?;
+        validate_sha256(&request.adapter_sha256)?;
+        let _publish = self.publish_lock.lock().await;
+        {
+            let state = self.policy_state.read().await;
+            if let Some(existing) = state
+                .versions
+                .get(&(request.policy.clone(), request.version.clone()))
+            {
+                if existing.adapter_sha256 != request.adapter_sha256 {
+                    return Err(RolloutError::Conflict(format!(
+                        "policy '{}:{}' already exists with a different digest",
+                        request.policy, request.version
+                    )));
+                }
+                return Ok(RolloutPolicyInfo {
+                    policy: existing.policy.clone(),
+                    version: existing.version.clone(),
+                    adapter_sha256: existing.adapter_sha256.clone(),
+                    backend_model: existing.backend_model.clone(),
+                    current: state.current.get(&existing.policy) == Some(&existing.version),
+                    active_requests: existing.active.load(Ordering::Acquire) as u32,
+                });
+            }
+            if state.versions.len() >= MAX_POLICY_VERSIONS {
+                return Err(RolloutError::Unavailable(format!(
+                    "executor reached its {MAX_POLICY_VERSIONS}-policy-version limit"
+                )));
+            }
+        }
+        let adapter_path = resolve_adapter_path(&self.config.adapter_root, &request.adapter_path)?;
+        let expected = request.adapter_sha256.clone();
+        let hash_path = adapter_path.clone();
+        let actual = tokio::task::spawn_blocking(move || hash_adapter_dir(&hash_path))
+            .await
+            .map_err(|error| {
+                RolloutError::Backend(format!("adapter hash task failed: {error}"))
+            })??;
+        if actual != expected {
+            return Err(RolloutError::BadRequest(format!(
+                "adapter digest mismatch: expected {expected}, computed {actual}"
+            )));
+        }
+        let backend_model = backend_model_name(
+            &self.config.name,
+            &request.policy,
+            &request.version,
+            &request.adapter_sha256,
+        );
+        self.load_adapter(&backend_model, &adapter_path).await?;
+        let entry = Arc::new(PolicyEntry {
+            policy: request.policy.clone(),
+            version: request.version.clone(),
+            adapter_sha256: request.adapter_sha256,
+            backend_model: backend_model.clone(),
+            active: AtomicUsize::new(0),
+            drained: Notify::new(),
+        });
+        let previous = {
+            let mut state = self.policy_state.write().await;
+            let previous_version = state
+                .current
+                .insert(request.policy.clone(), request.version.clone());
+            state.versions.insert(
+                (request.policy.clone(), request.version.clone()),
+                entry.clone(),
+            );
+            if request.retain_previous {
+                None
+            } else {
+                previous_version.and_then(|version| {
+                    if version == request.version {
+                        None
+                    } else {
+                        state.versions.remove(&(request.policy.clone(), version))
+                    }
+                })
+            }
+        };
+        if let Some(previous) = previous {
+            let executor = self.clone();
+            tokio::spawn(async move {
+                if let Err(error) = executor.retire_entry(previous).await {
+                    tracing::warn!(
+                        executor = %executor.config.name,
+                        error = %error.message(),
+                        "failed to retire previous rollout policy version"
+                    );
+                }
+            });
+        }
+        metrics::counter!("smolvm_rollout_policy_publications_total", "executor" => self.config.name.clone()).increment(1);
+        Ok(RolloutPolicyInfo {
+            policy: entry.policy.clone(),
+            version: entry.version.clone(),
+            adapter_sha256: entry.adapter_sha256.clone(),
+            backend_model,
+            current: true,
+            active_requests: 0,
+        })
+    }
+
+    pub(crate) async fn retire_policy(
+        &self,
+        policy: &str,
+        version: &str,
+    ) -> Result<(), RolloutError> {
+        validate_name("policy", policy)?;
+        validate_name("version", version)?;
+        let entry = {
+            let mut state = self.policy_state.write().await;
+            let key = (policy.to_string(), version.to_string());
+            let entry = state.versions.remove(&key).ok_or_else(|| {
+                RolloutError::NotFound(format!("policy '{policy}:{version}' not found"))
+            })?;
+            if state.current.get(policy) == Some(&version.to_string()) {
+                state.current.remove(policy);
+            }
+            entry
+        };
+        self.retire_entry(entry).await
+    }
+
+    async fn retire_entry(&self, entry: Arc<PolicyEntry>) -> Result<(), RolloutError> {
+        loop {
+            let notified = entry.drained.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+            if entry.active.load(Ordering::Acquire) == 0 {
+                break;
+            }
+            notified.await;
+        }
+        self.unload_adapter(&entry.backend_model).await
+    }
+
+    async fn shutdown(&self) -> Result<(), RolloutError> {
+        let entries = {
+            let mut state = self.policy_state.write().await;
+            state.current.clear();
+            state
+                .versions
+                .drain()
+                .map(|(_, value)| value)
+                .collect::<Vec<_>>()
+        };
+        let mut first = None;
+        for entry in entries {
+            if let Err(error) = self.retire_entry(entry).await {
+                first.get_or_insert(error);
+            }
+        }
+        first.map_or(Ok(()), Err)
+    }
+
+    async fn load_adapter(&self, model: &str, path: &Path) -> Result<(), RolloutError> {
+        let response = self
+            .http
+            .post(format!("{}/v1/load_lora_adapter", self.config.endpoint))
+            .json(&serde_json::json!({
+                "lora_name": model,
+                "lora_path": path,
+            }))
+            .timeout(self.config.request_timeout)
+            .send()
+            .await
+            .map_err(|error| backend_send_error("load adapter", error))?;
+        let status = response.status();
+        let bytes = read_body_capped(response, 1024 * 1024).await?;
+        if status.is_success() || self.backend_has_model(model).await? {
+            Ok(())
+        } else {
+            Err(RolloutError::Backend(format!(
+                "rollout backend load adapter returned {status}: {}",
+                body_excerpt(&bytes)
+            )))
+        }
+    }
+
+    async fn unload_adapter(&self, model: &str) -> Result<(), RolloutError> {
+        let response = self
+            .http
+            .post(format!("{}/v1/unload_lora_adapter", self.config.endpoint))
+            .json(&serde_json::json!({"lora_name": model}))
+            .timeout(self.config.request_timeout)
+            .send()
+            .await
+            .map_err(|error| backend_send_error("unload adapter", error))?;
+        let status = response.status();
+        let bytes = read_body_capped(response, 1024 * 1024).await?;
+        if status.is_success() || !self.backend_has_model(model).await? {
+            Ok(())
+        } else {
+            Err(RolloutError::Backend(format!(
+                "rollout backend unload adapter returned {status}: {}",
+                body_excerpt(&bytes)
+            )))
+        }
+    }
+
+    async fn backend_has_model(&self, model: &str) -> Result<bool, RolloutError> {
+        let response = self
+            .http
+            .get(format!("{}/v1/models", self.config.endpoint))
+            .timeout(Duration::from_secs(10))
+            .send()
+            .await
+            .map_err(|error| backend_send_error("list models", error))?;
+        let status = response.status();
+        let bytes = read_body_capped(response, 4 * 1024 * 1024).await?;
+        if !status.is_success() {
+            return Err(RolloutError::Backend(format!(
+                "rollout backend list models returned {status}: {}",
+                body_excerpt(&bytes)
+            )));
+        }
+        #[derive(Deserialize)]
+        struct Models {
+            data: Vec<Model>,
+        }
+        #[derive(Deserialize)]
+        struct Model {
+            id: String,
+        }
+        let models: Models = serde_json::from_slice(&bytes).map_err(|error| {
+            RolloutError::Backend(format!("decode rollout backend models: {error}"))
+        })?;
+        Ok(models.data.iter().any(|candidate| candidate.id == model))
+    }
+
+    pub(crate) async fn generate(
+        self: &Arc<Self>,
+        request: RolloutGenerateRequest,
+    ) -> Result<RolloutGenerateResponse, RolloutError> {
+        validate_generate_request(&request)?;
+        if !self.accepting.load(Ordering::Acquire) {
+            return Err(RolloutError::Unavailable(format!(
+                "rollout executor '{}' is draining",
+                self.config.name
+            )));
+        }
+        let digest: [u8; 32] = Sha256::digest(
+            serde_json::to_vec(&request)
+                .map_err(|error| RolloutError::BadRequest(error.to_string()))?,
+        )
+        .into();
+        let (entry, created) = {
+            let mut cache = self.idempotency.lock().await;
+            let now = Instant::now();
+            if cache.len() >= MAX_IDEMPOTENCY_ENTRIES {
+                cache.retain(|_, item| now.duration_since(item.created) < IDEMPOTENCY_TTL);
+                if cache.len() >= MAX_IDEMPOTENCY_ENTRIES {
+                    let completed_oldest = cache
+                        .iter()
+                        .filter(|(_, item)| item.result.get().is_some())
+                        .min_by_key(|(_, item)| item.created)
+                        .map(|(key, _)| key.clone());
+                    if let Some(key) = completed_oldest {
+                        cache.remove(&key);
+                    }
+                }
+                if cache.len() >= MAX_IDEMPOTENCY_ENTRIES {
+                    return Err(RolloutError::Unavailable(
+                        "rollout idempotency cache is temporarily full".into(),
+                    ));
+                }
+            }
+            if let Some(existing) = cache.get(&request.idempotency_key) {
+                if existing.digest != digest {
+                    return Err(RolloutError::Conflict(format!(
+                        "idempotency key '{}' was reused with a different request",
+                        request.idempotency_key
+                    )));
+                }
+                (existing.clone(), false)
+            } else {
+                let entry = Arc::new(IdempotencyEntry {
+                    digest,
+                    created: now,
+                    result: OnceCell::new(),
+                });
+                cache.insert(request.idempotency_key.clone(), entry.clone());
+                (entry, true)
+            }
+        };
+        let executor = self.clone();
+        let request_for_run = request.clone();
+        let result = entry
+            .result
+            .get_or_init(|| async move {
+                executor
+                    .execute_generate(request_for_run)
+                    .await
+                    .map(Arc::new)
+                    .map_err(|value| CachedError { value })
+            })
+            .await;
+        match result {
+            Ok(response) => {
+                let mut response = response.as_ref().clone();
+                response.cached = !created;
+                Ok(response)
+            }
+            Err(error) => {
+                let mut cache = self.idempotency.lock().await;
+                if cache
+                    .get(&request.idempotency_key)
+                    .is_some_and(|current| Arc::ptr_eq(current, &entry))
+                {
+                    cache.remove(&request.idempotency_key);
+                }
+                Err(error.value.clone())
+            }
+        }
+    }
+
+    async fn execute_generate(
+        self: &Arc<Self>,
+        request: RolloutGenerateRequest,
+    ) -> Result<RolloutGenerateResponse, RolloutError> {
+        let deadline = request
+            .deadline_ms
+            .map(Duration::from_millis)
+            .unwrap_or(self.config.request_timeout)
+            .min(self.config.request_timeout);
+        tokio::time::timeout(deadline, self.execute_generate_inner(request))
+            .await
+            .map_err(|_| RolloutError::Timeout("rollout request deadline exceeded".into()))?
+    }
+
+    async fn execute_generate_inner(
+        self: &Arc<Self>,
+        request: RolloutGenerateRequest,
+    ) -> Result<RolloutGenerateResponse, RolloutError> {
+        let policy = self
+            .acquire_policy(&request.policy, request.version.as_deref())
+            .await?;
+        let _policy_guard = PolicyGuard {
+            policy: policy.clone(),
+        };
+        let _permit = self.acquire_queue_permit().await?;
+        let body = completion_body(&request, &policy.backend_model)?;
+        let started = Instant::now();
+        let response = self
+            .http
+            .post(format!("{}/v1/completions", self.config.endpoint))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|error| backend_send_error("generate", error))?;
+        let status = response.status();
+        let bytes = read_body_capped(response, MAX_BACKEND_BODY_BYTES).await?;
+        if !status.is_success() {
+            return Err(RolloutError::Backend(format!(
+                "rollout backend generate returned {status}: {}",
+                body_excerpt(&bytes)
+            )));
+        }
+        let backend: BackendCompletionResponse =
+            serde_json::from_slice(&bytes).map_err(|error| {
+                RolloutError::Backend(format!("decode rollout backend response: {error}"))
+            })?;
+        let response = RolloutGenerateResponse {
+            executor: self.config.name.clone(),
+            policy: policy.policy.clone(),
+            version: policy.version.clone(),
+            backend_request_id: backend.id,
+            choices: backend.choices,
+            usage: backend.usage,
+            cached: false,
+        };
+        let elapsed = started.elapsed().as_secs_f64();
+        metrics::counter!("smolvm_rollout_requests_total", "executor" => self.config.name.clone(), "status" => "ok").increment(1);
+        metrics::histogram!("smolvm_rollout_request_seconds", "executor" => self.config.name.clone()).record(elapsed);
+        metrics::counter!("smolvm_rollout_tokens_total", "executor" => self.config.name.clone())
+            .increment(response.usage.completion_tokens);
+        Ok(response)
+    }
+
+    async fn acquire_policy(
+        &self,
+        policy: &str,
+        version: Option<&str>,
+    ) -> Result<Arc<PolicyEntry>, RolloutError> {
+        let state = self.policy_state.read().await;
+        let version = match version {
+            Some(value) => value.to_string(),
+            None => state.current.get(policy).cloned().ok_or_else(|| {
+                RolloutError::NotFound(format!("policy '{policy}' has no current version"))
+            })?,
+        };
+        let entry = state
+            .versions
+            .get(&(policy.to_string(), version.clone()))
+            .cloned()
+            .ok_or_else(|| {
+                RolloutError::NotFound(format!("policy '{policy}:{version}' not found"))
+            })?;
+        entry.active.fetch_add(1, Ordering::AcqRel);
+        Ok(entry)
+    }
+
+    async fn acquire_queue_permit(&self) -> Result<ActivePermit<'_>, RolloutError> {
+        if let Ok(permit) = self.permits.try_acquire() {
+            self.active.fetch_add(1, Ordering::AcqRel);
+            return Ok(ActivePermit {
+                _permit: permit,
+                active: &self.active,
+            });
+        }
+        self.queued
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |queued| {
+                (queued < self.config.max_queue_depth).then_some(queued + 1)
+            })
+            .map_err(|_| {
+                RolloutError::Unavailable(format!(
+                    "rollout executor '{}' queue is full",
+                    self.config.name
+                ))
+            })?;
+        let mut queued = QueuedGuard {
+            queued: &self.queued,
+            armed: true,
+        };
+        let permit = self
+            .permits
+            .acquire()
+            .await
+            .map_err(|_| RolloutError::Unavailable("rollout executor is closed".into()))?;
+        queued.disarm();
+        self.active.fetch_add(1, Ordering::AcqRel);
+        Ok(ActivePermit {
+            _permit: permit,
+            active: &self.active,
+        })
+    }
+}
+
+struct QueuedGuard<'a> {
+    queued: &'a AtomicU32,
+    armed: bool,
+}
+
+impl QueuedGuard<'_> {
+    fn disarm(&mut self) {
+        if self.armed {
+            self.queued.fetch_sub(1, Ordering::AcqRel);
+            self.armed = false;
+        }
+    }
+}
+
+impl Drop for QueuedGuard<'_> {
+    fn drop(&mut self) {
+        self.disarm();
+    }
+}
+
+struct ActivePermit<'a> {
+    _permit: tokio::sync::SemaphorePermit<'a>,
+    active: &'a AtomicU32,
+}
+
+impl Drop for ActivePermit<'_> {
+    fn drop(&mut self) {
+        self.active.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+#[derive(Deserialize)]
+struct BackendCompletionResponse {
+    id: String,
+    choices: Vec<RolloutCompletion>,
+    #[serde(default)]
+    usage: RolloutUsage,
+}
+
+fn validate_name(kind: &str, value: &str) -> Result<(), RolloutError> {
+    let valid = !value.is_empty()
+        && value.len() <= MAX_NAME_BYTES
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'));
+    if !valid {
+        return Err(RolloutError::BadRequest(format!(
+            "{kind} must be 1-{MAX_NAME_BYTES} ASCII letters, digits, '.', '_' or '-'"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_sha256(value: &str) -> Result<(), RolloutError> {
+    if value.len() != 64 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(RolloutError::BadRequest(
+            "adapterSha256 must be exactly 64 hexadecimal characters".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_loopback_endpoint(value: &str) -> Result<String, RolloutError> {
+    let address = value.strip_prefix("http://").ok_or_else(|| {
+        RolloutError::BadRequest("endpoint must use http:// with a loopback IP literal".into())
+    })?;
+    if address.contains('/')
+        || address.contains('?')
+        || address.contains('#')
+        || address.contains('@')
+    {
+        return Err(RolloutError::BadRequest(
+            "endpoint must contain only a loopback socket address".into(),
+        ));
+    }
+    let socket: SocketAddr = address.parse().map_err(|_| {
+        RolloutError::BadRequest("endpoint must contain a loopback IP literal and port".into())
+    })?;
+    if !socket.ip().is_loopback() || socket.port() == 0 {
+        return Err(RolloutError::BadRequest(
+            "endpoint must target a nonzero loopback port".into(),
+        ));
+    }
+    Ok(format!("http://{socket}"))
+}
+
+fn resolve_adapter_path(root: &Path, relative: &str) -> Result<PathBuf, RolloutError> {
+    let relative = Path::new(relative);
+    if relative.as_os_str().is_empty()
+        || relative.is_absolute()
+        || relative
+            .components()
+            .any(|part| !matches!(part, Component::Normal(_)))
+    {
+        return Err(RolloutError::BadRequest(
+            "adapterPath must be a safe relative directory".into(),
+        ));
+    }
+    let path = root
+        .join(relative)
+        .canonicalize()
+        .map_err(|error| RolloutError::BadRequest(format!("canonicalize adapterPath: {error}")))?;
+    if !path.is_dir() || !path.starts_with(root) {
+        return Err(RolloutError::BadRequest(
+            "adapterPath must resolve to a directory beneath adapterRoot".into(),
+        ));
+    }
+    Ok(path)
+}
+
+/// Deterministically hash relative names, lengths, and bytes of regular files.
+pub(crate) fn hash_adapter_dir(path: &Path) -> Result<String, RolloutError> {
+    fn walk(root: &Path, current: &Path, files: &mut Vec<PathBuf>) -> Result<(), RolloutError> {
+        for item in std::fs::read_dir(current)
+            .map_err(|error| RolloutError::BadRequest(format!("read adapter directory: {error}")))?
+        {
+            let item = item.map_err(|error| {
+                RolloutError::BadRequest(format!("read adapter directory entry: {error}"))
+            })?;
+            let file_type = item.file_type().map_err(|error| {
+                RolloutError::BadRequest(format!("read adapter file type: {error}"))
+            })?;
+            if file_type.is_symlink() {
+                return Err(RolloutError::BadRequest(format!(
+                    "adapter directory contains symlink '{}'",
+                    item.path().display()
+                )));
+            }
+            if file_type.is_dir() {
+                walk(root, &item.path(), files)?;
+            } else if file_type.is_file() {
+                let _ = item.path().strip_prefix(root).map_err(|_| {
+                    RolloutError::BadRequest("adapter file escaped adapter root".into())
+                })?;
+                files.push(item.path());
+                if files.len() > MAX_ADAPTER_FILES {
+                    return Err(RolloutError::BadRequest(format!(
+                        "adapter contains more than {MAX_ADAPTER_FILES} files"
+                    )));
+                }
+            } else {
+                return Err(RolloutError::BadRequest(
+                    "adapter directory contains a non-regular file".into(),
+                ));
+            }
+        }
+        Ok(())
+    }
+    let mut files = Vec::new();
+    walk(path, path, &mut files)?;
+    if files.is_empty() {
+        return Err(RolloutError::BadRequest(
+            "adapter directory contains no files".into(),
+        ));
+    }
+    files.sort_by(|left, right| {
+        left.strip_prefix(path)
+            .unwrap_or(left)
+            .cmp(right.strip_prefix(path).unwrap_or(right))
+    });
+    let mut total = 0u64;
+    let mut digest = Sha256::new();
+    for file in files {
+        let relative = file.strip_prefix(path).map_err(|_| {
+            RolloutError::BadRequest("adapter file escaped adapter directory".into())
+        })?;
+        let name = relative.to_string_lossy();
+        let metadata = std::fs::metadata(&file)
+            .map_err(|error| RolloutError::BadRequest(format!("stat adapter file: {error}")))?;
+        total = total
+            .checked_add(metadata.len())
+            .ok_or_else(|| RolloutError::BadRequest("adapter byte count overflowed".into()))?;
+        if total > MAX_ADAPTER_BYTES {
+            return Err(RolloutError::BadRequest(format!(
+                "adapter exceeds {MAX_ADAPTER_BYTES} bytes"
+            )));
+        }
+        digest.update((name.len() as u64).to_le_bytes());
+        digest.update(name.as_bytes());
+        digest.update(metadata.len().to_le_bytes());
+        let mut input = std::fs::File::open(&file)
+            .map_err(|error| RolloutError::BadRequest(format!("open adapter file: {error}")))?;
+        std::io::copy(&mut input, &mut DigestWriter(&mut digest))
+            .map_err(|error| RolloutError::BadRequest(format!("hash adapter file: {error}")))?;
+    }
+    Ok(hex::encode(digest.finalize()))
+}
+
+struct DigestWriter<'a, D: Digest>(&'a mut D);
+
+impl<D: Digest> std::io::Write for DigestWriter<'_, D> {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        self.0.update(buffer);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn backend_model_name(executor: &str, policy: &str, version: &str, digest: &str) -> String {
+    let hash = Sha256::digest(format!("{executor}\0{policy}\0{version}\0{digest}"));
+    format!("smolvm-{}", &hex::encode(hash)[..32])
+}
+
+fn validate_generate_request(request: &RolloutGenerateRequest) -> Result<(), RolloutError> {
+    if request.idempotency_key.is_empty()
+        || request.idempotency_key.len() > MAX_IDEMPOTENCY_KEY_BYTES
+        || request.idempotency_key.chars().any(char::is_control)
+    {
+        return Err(RolloutError::BadRequest(format!(
+            "idempotencyKey must be 1-{MAX_IDEMPOTENCY_KEY_BYTES} bytes without control characters"
+        )));
+    }
+    validate_name("policy", &request.policy)?;
+    if let Some(version) = &request.version {
+        validate_name("version", version)?;
+    }
+    if request.prompts.is_empty() || request.prompts.len() > MAX_PROMPTS {
+        return Err(RolloutError::BadRequest(format!(
+            "prompts must contain between 1 and {MAX_PROMPTS} items"
+        )));
+    }
+    let mut text_bytes = 0usize;
+    let mut token_count = 0usize;
+    let mut kind = None;
+    for prompt in &request.prompts {
+        let prompt_kind = match (&prompt.text, &prompt.token_ids) {
+            (Some(text), None) if !text.is_empty() => {
+                text_bytes = text_bytes.saturating_add(text.len());
+                0
+            }
+            (None, Some(tokens)) if !tokens.is_empty() => {
+                token_count = token_count.saturating_add(tokens.len());
+                1
+            }
+            _ => {
+                return Err(RolloutError::BadRequest(
+                    "each prompt must set exactly one non-empty text or tokenIds value".into(),
+                ))
+            }
+        };
+        if kind
+            .replace(prompt_kind)
+            .is_some_and(|value| value != prompt_kind)
+        {
+            return Err(RolloutError::BadRequest(
+                "one generation request cannot mix text and tokenIds prompts".into(),
+            ));
+        }
+    }
+    if text_bytes > MAX_PROMPT_TEXT_BYTES || token_count > MAX_PROMPT_TOKENS {
+        return Err(RolloutError::BadRequest(
+            "prompt payload exceeds the executor safety limit".into(),
+        ));
+    }
+    let sampling = &request.sampling;
+    if sampling.n == 0 || sampling.n > 256 {
+        return Err(RolloutError::BadRequest(
+            "sampling.n must be between 1 and 256".into(),
+        ));
+    }
+    if sampling.max_tokens == 0 || sampling.max_tokens > MAX_COMPLETION_TOKENS {
+        return Err(RolloutError::BadRequest(format!(
+            "sampling.maxTokens must be between 1 and {MAX_COMPLETION_TOKENS}"
+        )));
+    }
+    if sampling
+        .temperature
+        .is_some_and(|value| !value.is_finite() || value < 0.0)
+        || sampling
+            .top_p
+            .is_some_and(|value| !value.is_finite() || !(0.0..=1.0).contains(&value))
+        || sampling
+            .min_p
+            .is_some_and(|value| !value.is_finite() || !(0.0..=1.0).contains(&value))
+        || sampling
+            .repetition_penalty
+            .is_some_and(|value| !value.is_finite() || value <= 0.0)
+    {
+        return Err(RolloutError::BadRequest(
+            "sampling parameters are outside their finite valid ranges".into(),
+        ));
+    }
+    if request.deadline_ms == Some(0) {
+        return Err(RolloutError::BadRequest(
+            "deadlineMs must be greater than zero".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn completion_body(
+    request: &RolloutGenerateRequest,
+    backend_model: &str,
+) -> Result<serde_json::Value, RolloutError> {
+    let prompt = if request.prompts[0].text.is_some() {
+        serde_json::to_value(
+            request
+                .prompts
+                .iter()
+                .map(|prompt| prompt.text.as_deref().unwrap_or_default())
+                .collect::<Vec<_>>(),
+        )
+    } else {
+        serde_json::to_value(
+            request
+                .prompts
+                .iter()
+                .map(|prompt| prompt.token_ids.as_deref().unwrap_or_default())
+                .collect::<Vec<_>>(),
+        )
+    }
+    .map_err(|error| RolloutError::BadRequest(error.to_string()))?;
+    let sampling = &request.sampling;
+    let mut body = serde_json::json!({
+        "model": backend_model,
+        "prompt": prompt,
+        "n": sampling.n,
+        "max_tokens": sampling.max_tokens,
+        "stream": false,
+        "return_token_ids": true,
+    });
+    let object = body.as_object_mut().expect("completion body is an object");
+    macro_rules! optional {
+        ($field:ident, $wire:literal) => {
+            if let Some(value) = sampling.$field {
+                object.insert($wire.into(), serde_json::json!(value));
+            }
+        };
+    }
+    optional!(temperature, "temperature");
+    optional!(top_p, "top_p");
+    optional!(top_k, "top_k");
+    optional!(min_p, "min_p");
+    optional!(repetition_penalty, "repetition_penalty");
+    optional!(seed, "seed");
+    optional!(logprobs, "logprobs");
+    optional!(prompt_logprobs, "prompt_logprobs");
+    Ok(body)
+}
+
+fn backend_send_error(operation: &str, error: reqwest::Error) -> RolloutError {
+    if error.is_timeout() {
+        RolloutError::Timeout(format!("rollout backend {operation} timed out"))
+    } else {
+        RolloutError::Unavailable(format!("rollout backend {operation} failed: {error}"))
+    }
+}
+
+async fn read_body_capped(
+    response: reqwest::Response,
+    cap: usize,
+) -> Result<Vec<u8>, RolloutError> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > cap as u64)
+    {
+        return Err(RolloutError::Backend(format!(
+            "rollout backend response exceeds {cap} bytes"
+        )));
+    }
+    let mut body = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|error| {
+            RolloutError::Unavailable(format!("read rollout backend response: {error}"))
+        })?;
+        if body.len().saturating_add(chunk.len()) > cap {
+            return Err(RolloutError::Backend(format!(
+                "rollout backend response exceeds {cap} bytes"
+            )));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
+fn body_excerpt(body: &[u8]) -> String {
+    const LIMIT: usize = 1024;
+    String::from_utf8_lossy(&body[..body.len().min(LIMIT)]).into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        extract::State,
+        http::StatusCode,
+        routing::{get, post},
+        Json, Router,
+    };
+    use std::io::Write as _;
+
+    #[derive(Default)]
+    struct MockBackend {
+        loads: Mutex<Vec<serde_json::Value>>,
+        unloads: Mutex<Vec<serde_json::Value>>,
+        generations: AtomicUsize,
+    }
+
+    async fn start_mock_backend() -> (SocketAddr, Arc<MockBackend>, tokio::task::JoinHandle<()>) {
+        async fn health() -> StatusCode {
+            StatusCode::OK
+        }
+        async fn load(
+            State(state): State<Arc<MockBackend>>,
+            Json(body): Json<serde_json::Value>,
+        ) -> StatusCode {
+            state.loads.lock().await.push(body);
+            StatusCode::OK
+        }
+        async fn unload(
+            State(state): State<Arc<MockBackend>>,
+            Json(body): Json<serde_json::Value>,
+        ) -> StatusCode {
+            state.unloads.lock().await.push(body);
+            StatusCode::OK
+        }
+        async fn completion(
+            State(state): State<Arc<MockBackend>>,
+            Json(body): Json<serde_json::Value>,
+        ) -> Json<serde_json::Value> {
+            state.generations.fetch_add(1, Ordering::AcqRel);
+            assert_eq!(body["return_token_ids"], true);
+            Json(serde_json::json!({
+                "id": "cmpl-1",
+                "choices": [{
+                    "index": 0,
+                    "text": "ok",
+                    "token_ids": [7, 8],
+                    "prompt_token_ids": [1, 2],
+                    "finish_reason": "length",
+                    "stop_reason": null,
+                    "logprobs": {"token_logprobs": [-0.1, -0.2]}
+                }],
+                "usage": {
+                    "prompt_tokens": 2,
+                    "completion_tokens": 2,
+                    "total_tokens": 4
+                }
+            }))
+        }
+
+        async fn models(State(state): State<Arc<MockBackend>>) -> Json<serde_json::Value> {
+            let models = state
+                .loads
+                .lock()
+                .await
+                .iter()
+                .filter_map(|body| body["lora_name"].as_str())
+                .map(|name| serde_json::json!({"id": name}))
+                .collect::<Vec<_>>();
+            Json(serde_json::json!({"data": models}))
+        }
+
+        let state = Arc::new(MockBackend::default());
+        let app = Router::new()
+            .route("/health", get(health))
+            .route("/v1/load_lora_adapter", post(load))
+            .route("/v1/unload_lora_adapter", post(unload))
+            .route("/v1/completions", post(completion))
+            .route("/v1/models", get(models))
+            .with_state(state.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (address, state, handle)
+    }
+
+    fn sample_generate(key: &str) -> RolloutGenerateRequest {
+        RolloutGenerateRequest {
+            idempotency_key: key.into(),
+            policy: "policy".into(),
+            version: None,
+            prompts: vec![RolloutPrompt {
+                text: None,
+                token_ids: Some(vec![1, 2]),
+            }],
+            sampling: RolloutSamplingParams {
+                n: 1,
+                max_tokens: 2,
+                temperature: Some(0.0),
+                top_p: None,
+                top_k: None,
+                min_p: None,
+                repetition_penalty: None,
+                seed: Some(9),
+                logprobs: Some(1),
+                prompt_logprobs: None,
+            },
+            deadline_ms: Some(5_000),
+        }
+    }
+
+    #[tokio::test]
+    async fn publish_generate_retry_and_retire_are_end_to_end_safe() {
+        let (address, backend, server) = start_mock_backend().await;
+        let root = tempfile::tempdir().unwrap();
+        let adapter = root.path().join("adapter-v1");
+        std::fs::create_dir(&adapter).unwrap();
+        std::fs::write(adapter.join("adapter_config.json"), b"{}").unwrap();
+        std::fs::write(adapter.join("adapter_model.safetensors"), b"weights").unwrap();
+        let digest = hash_adapter_dir(&adapter).unwrap();
+
+        let registry = RolloutRegistry::default();
+        let created = registry
+            .create(CreateRolloutExecutorRequest {
+                name: "fused".into(),
+                backend: "vllm".into(),
+                endpoint: format!("http://{address}"),
+                adapter_root: root.path().display().to_string(),
+                fallback_pool: None,
+                max_concurrent_requests: Some(2),
+                max_queue_depth: Some(2),
+                request_timeout_secs: Some(5),
+            })
+            .await
+            .unwrap();
+        assert_eq!(created.name, "fused");
+        let executor = registry.get("fused").await.unwrap();
+        let published = executor
+            .publish_policy(PublishRolloutPolicyRequest {
+                policy: "policy".into(),
+                version: "step-1".into(),
+                adapter_path: "adapter-v1".into(),
+                adapter_sha256: digest,
+                retain_previous: false,
+            })
+            .await
+            .unwrap();
+        assert!(published.current);
+        assert_eq!(backend.loads.lock().await.len(), 1);
+
+        let first = executor
+            .generate(sample_generate("request-1"))
+            .await
+            .unwrap();
+        assert!(!first.cached);
+        assert_eq!(first.version, "step-1");
+        assert_eq!(first.choices[0].token_ids, Some(vec![7, 8]));
+        assert_eq!(first.usage.completion_tokens, 2);
+        let retry = executor
+            .generate(sample_generate("request-1"))
+            .await
+            .unwrap();
+        assert!(retry.cached);
+        assert_eq!(backend.generations.load(Ordering::Acquire), 1);
+
+        let mut conflicting = sample_generate("request-1");
+        conflicting.sampling.seed = Some(10);
+        assert!(matches!(
+            executor.generate(conflicting).await,
+            Err(RolloutError::Conflict(_))
+        ));
+
+        executor.retire_policy("policy", "step-1").await.unwrap();
+        assert_eq!(backend.unloads.lock().await.len(), 1);
+        registry.delete("fused").await.unwrap();
+        server.abort();
+    }
+
+    #[test]
+    fn endpoints_are_confined_to_ip_literal_loopback() {
+        assert_eq!(
+            validate_loopback_endpoint("http://127.0.0.1:8000").unwrap(),
+            "http://127.0.0.1:8000"
+        );
+        assert!(validate_loopback_endpoint("https://127.0.0.1:8000").is_err());
+        assert!(validate_loopback_endpoint("http://localhost:8000").is_err());
+        assert!(validate_loopback_endpoint("http://10.0.0.1:8000").is_err());
+        assert!(validate_loopback_endpoint("http://127.0.0.1:8000/path").is_err());
+    }
+
+    #[test]
+    fn adapter_digest_is_deterministic_and_rejects_symlinks() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("nested")).unwrap();
+        std::fs::File::create(root.path().join("adapter_config.json"))
+            .unwrap()
+            .write_all(b"config")
+            .unwrap();
+        std::fs::File::create(root.path().join("nested/adapter.bin"))
+            .unwrap()
+            .write_all(b"weights")
+            .unwrap();
+        let first = hash_adapter_dir(root.path()).unwrap();
+        let second = hash_adapter_dir(root.path()).unwrap();
+        assert_eq!(first, second);
+        assert_eq!(first.len(), 64);
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink("adapter_config.json", root.path().join("link")).unwrap();
+            assert!(hash_adapter_dir(root.path()).is_err());
+        }
+    }
+
+    #[test]
+    fn adapter_digest_matches_the_python_sdk_contract() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("adapter_config.json"), b"{}").unwrap();
+        std::fs::write(root.path().join("adapter_model.safetensors"), b"weights").unwrap();
+        assert_eq!(
+            hash_adapter_dir(root.path()).unwrap(),
+            "26d1c7593b9650cb489a9a1fe2fad9def32c75ec2685cf8261c3c0fa3b73e315"
+        );
+    }
+
+    #[tokio::test]
+    async fn zero_queue_depth_still_allows_immediate_capacity() {
+        let root = tempfile::tempdir().unwrap();
+        let executor = RolloutExecutor::new(CreateRolloutExecutorRequest {
+            name: "bounded".into(),
+            backend: "vllm".into(),
+            endpoint: "http://127.0.0.1:1".into(),
+            adapter_root: root.path().display().to_string(),
+            fallback_pool: None,
+            max_concurrent_requests: Some(1),
+            max_queue_depth: Some(0),
+            request_timeout_secs: Some(1),
+        })
+        .unwrap();
+        let first = executor.acquire_queue_permit().await.unwrap();
+        assert!(matches!(
+            executor.acquire_queue_permit().await,
+            Err(RolloutError::Unavailable(_))
+        ));
+        drop(first);
+        assert!(executor.acquire_queue_permit().await.is_ok());
+    }
+
+    #[test]
+    fn prompt_validation_rejects_mixed_representations() {
+        let request = RolloutGenerateRequest {
+            idempotency_key: "key".into(),
+            policy: "policy".into(),
+            version: None,
+            prompts: vec![
+                RolloutPrompt {
+                    text: Some("hello".into()),
+                    token_ids: None,
+                },
+                RolloutPrompt {
+                    text: None,
+                    token_ids: Some(vec![1, 2]),
+                },
+            ],
+            sampling: RolloutSamplingParams {
+                n: 1,
+                max_tokens: 16,
+                temperature: None,
+                top_p: None,
+                top_k: None,
+                min_p: None,
+                repetition_penalty: None,
+                seed: None,
+                logprobs: None,
+                prompt_logprobs: None,
+            },
+            deadline_ms: None,
+        };
+        assert!(validate_generate_request(&request).is_err());
+    }
+
+    #[test]
+    fn completion_body_uses_vllm_token_id_contract() {
+        let request = RolloutGenerateRequest {
+            idempotency_key: "key".into(),
+            policy: "policy".into(),
+            version: Some("7".into()),
+            prompts: vec![RolloutPrompt {
+                text: None,
+                token_ids: Some(vec![1, 2, 3]),
+            }],
+            sampling: RolloutSamplingParams {
+                n: 2,
+                max_tokens: 8,
+                temperature: Some(0.9),
+                top_p: Some(0.95),
+                top_k: None,
+                min_p: None,
+                repetition_penalty: None,
+                seed: Some(42),
+                logprobs: Some(1),
+                prompt_logprobs: None,
+            },
+            deadline_ms: None,
+        };
+        let body = completion_body(&request, "adapter").unwrap();
+        assert_eq!(body["prompt"], serde_json::json!([[1, 2, 3]]));
+        assert_eq!(body["return_token_ids"], true);
+        assert_eq!(body["model"], "adapter");
+        assert_eq!(body["seed"], 42);
+    }
+}

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -70,6 +70,8 @@ pub struct ApiState {
     /// Runtime-only CUDA pool admission state. Durable pool configuration lives
     /// in SQLite; learned telemetry is intentionally rebuilt after a restart.
     admission: crate::api::admission::AdmissionRegistry,
+    /// Runtime registry for framework-aware fused rollout executors.
+    rollout: crate::api::rollout::RolloutRegistry,
 }
 
 /// Internal machine entry with manager and configuration.
@@ -234,6 +236,7 @@ impl ApiState {
             started_at: std::time::Instant::now(),
             runtime_heartbeat_ms: std::sync::atomic::AtomicU64::new(0),
             admission: crate::api::admission::AdmissionRegistry::default(),
+            rollout: crate::api::rollout::RolloutRegistry::default(),
         })
     }
 
@@ -250,6 +253,7 @@ impl ApiState {
             started_at: std::time::Instant::now(),
             runtime_heartbeat_ms: std::sync::atomic::AtomicU64::new(0),
             admission: crate::api::admission::AdmissionRegistry::default(),
+            rollout: crate::api::rollout::RolloutRegistry::default(),
         }
     }
 
@@ -257,6 +261,11 @@ impl ApiState {
     /// the atomic lease claim path.
     pub fn admission(&self) -> &crate::api::admission::AdmissionRegistry {
         &self.admission
+    }
+
+    /// Framework-aware fused rollout executors registered on this node.
+    pub fn rollout(&self) -> &crate::api::rollout::RolloutRegistry {
+        &self.rollout
     }
 
     /// How long the main runtime may go without a supervisor heartbeat before

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -67,6 +67,9 @@ pub struct ApiState {
     /// node as unschedulable (HTTP 503) the moment the main runtime stops
     /// making progress, turning a silent wedge into a fast, honest drain signal.
     runtime_heartbeat_ms: std::sync::atomic::AtomicU64,
+    /// Runtime-only CUDA pool admission state. Durable pool configuration lives
+    /// in SQLite; learned telemetry is intentionally rebuilt after a restart.
+    admission: crate::api::admission::AdmissionRegistry,
 }
 
 /// Internal machine entry with manager and configuration.
@@ -230,6 +233,7 @@ impl ApiState {
             cpu_samples: parking_lot::Mutex::new(HashMap::new()),
             started_at: std::time::Instant::now(),
             runtime_heartbeat_ms: std::sync::atomic::AtomicU64::new(0),
+            admission: crate::api::admission::AdmissionRegistry::default(),
         })
     }
 
@@ -245,7 +249,14 @@ impl ApiState {
             cpu_samples: parking_lot::Mutex::new(HashMap::new()),
             started_at: std::time::Instant::now(),
             runtime_heartbeat_ms: std::sync::atomic::AtomicU64::new(0),
+            admission: crate::api::admission::AdmissionRegistry::default(),
         }
+    }
+
+    /// Shared lease-aware admission registry used by the pool controller and
+    /// the atomic lease claim path.
+    pub fn admission(&self) -> &crate::api::admission::AdmissionRegistry {
+        &self.admission
     }
 
     /// How long the main runtime may go without a supervisor heartbeat before

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -876,6 +876,10 @@ pub struct CreateForkPoolRequest {
     /// Optional maximum number of simultaneously active leases.
     #[serde(default)]
     pub max_active: Option<u32>,
+    /// Automatically calibrate resident CUDA leases. Defaults on for shared
+    /// CUDA pools when omitted; set false for full residency.
+    #[serde(default)]
+    pub auto_admission: Option<bool>,
     /// Share immutable CUDA allocations with the golden and sibling workers.
     #[serde(default)]
     pub share_weights: bool,
@@ -916,6 +920,29 @@ pub struct ForkPoolInfo {
     /// Optional simultaneous active-lease limit.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_active: Option<u32>,
+    /// Whether lease residency is calibrated automatically.
+    pub auto_admission: bool,
+    /// Current dynamic resident limit when automatic admission is enabled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effective_active_limit: Option<u32>,
+    /// Human-readable reason for the current automatic limit.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub admission_reason: Option<String>,
+    /// True while the controller is comparing resident levels.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub admission_calibrating: Option<bool>,
+    /// Latest node-wide GPU utilization used by admission.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gpu_utilization_percent: Option<f64>,
+    /// Latest aggregate GPU memory use in MiB.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gpu_memory_used_mib: Option<u64>,
+    /// Latest aggregate GPU memory capacity in MiB.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gpu_memory_total_mib: Option<u64>,
+    /// Latest host CPU busy percentage used by admission.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub host_cpu_percent: Option<f64>,
     /// Whether immutable CUDA allocations are shared.
     pub share_weights: bool,
     /// Default lease heartbeat duration.

--- a/src/db.rs
+++ b/src/db.rs
@@ -45,6 +45,8 @@ pub struct ForkPoolSlotClaim<'a> {
     pub payload_sha256: Option<&'a str>,
     /// Reject workers whose `/workspace` is backed by an external mount.
     pub require_private_workspace: bool,
+    /// Runtime-calibrated active-lease ceiling, applied with the durable limit.
+    pub admission_limit: Option<u32>,
     /// Lease lifetime renewed by each heartbeat.
     pub ttl_secs: u64,
     /// Timestamp used for every record in this transaction.
@@ -835,6 +837,30 @@ impl SmolvmDb {
         })
     }
 
+    /// Return the active/activating lease count and cumulative successful
+    /// completions used by the runtime-only admission controller.
+    pub fn fork_pool_admission_counts(&self, pool_name: &str) -> Result<(u32, u64)> {
+        self.with_read_conn(|conn| {
+            let active = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM fork_leases
+                     WHERE pool_name = ?1 AND state IN ('activating', 'active')",
+                    params![pool_name],
+                    |row| row.get(0),
+                )
+                .db_err("count active fork leases for admission")?;
+            let completed = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM fork_leases
+                     WHERE pool_name = ?1 AND state = 'completed'",
+                    params![pool_name],
+                    |row| row.get(0),
+                )
+                .db_err("count completed fork leases for admission")?;
+            Ok((active, completed))
+        })
+    }
+
     /// Reserve a provisioning slot only while the pool still has a ready deficit.
     ///
     /// The deficit check and insert share a transaction, so repeated controller
@@ -1004,6 +1030,7 @@ impl SmolvmDb {
             assignment,
             payload_sha256,
             require_private_workspace,
+            admission_limit,
             ttl_secs,
             now,
         } = claim;
@@ -1042,7 +1069,12 @@ impl SmolvmDb {
                 tx.commit().db_err("commit deleting fork pool claim")?;
                 return Ok(ClaimForkPoolSlot::PoolDeleting);
             }
-            if let Some(max_active) = pool.max_active {
+            let max_active = match (pool.max_active, admission_limit) {
+                (Some(configured), Some(adaptive)) => Some(configured.min(adaptive)),
+                (Some(configured), None) => Some(configured),
+                (None, adaptive) => adaptive,
+            };
+            if let Some(max_active) = max_active {
                 let active: u32 = tx
                     .query_row(
                         "SELECT COUNT(*) FROM fork_leases
@@ -2010,6 +2042,7 @@ mod tests {
             golden: "golden".into(),
             desired_ready,
             max_active: None,
+            auto_admission: false,
             share_weights: true,
             ready_timeout_secs: 30,
             lease_ttl_secs: 60,
@@ -2087,6 +2120,7 @@ mod tests {
                 assignment: &assignment,
                 payload_sha256: Some(payload_sha256),
                 require_private_workspace: true,
+                admission_limit: None,
                 ttl_secs: 60,
                 now: 200,
             })
@@ -2112,6 +2146,7 @@ mod tests {
                 assignment: &assignment,
                 payload_sha256: Some(payload_sha256),
                 require_private_workspace: true,
+                admission_limit: None,
                 ttl_secs: 60,
                 now: 201,
             })
@@ -2130,6 +2165,7 @@ mod tests {
                 assignment: &assignment,
                 payload_sha256: None,
                 require_private_workspace: false,
+                admission_limit: None,
                 ttl_secs: 60,
                 now: 201,
             })
@@ -2157,6 +2193,7 @@ mod tests {
                 assignment: &[],
                 payload_sha256: Some("payload-digest"),
                 require_private_workspace: true,
+                admission_limit: None,
                 ttl_secs: 60,
                 now: 200,
             })
@@ -2176,6 +2213,7 @@ mod tests {
                 assignment: &[],
                 payload_sha256: None,
                 require_private_workspace: false,
+                admission_limit: None,
                 ttl_secs: 60,
                 now: 201,
             })
@@ -2221,6 +2259,7 @@ mod tests {
                         assignment: &[("EPISODE".into(), "42".into())],
                         payload_sha256: None,
                         require_private_workspace: false,
+                        admission_limit: None,
                         ttl_secs: 60,
                         now: 200,
                     })
@@ -2274,6 +2313,7 @@ mod tests {
             assignment: &[],
             payload_sha256: None,
             require_private_workspace: false,
+            admission_limit: None,
             ttl_secs: 60,
             now: 200,
         })
@@ -2288,6 +2328,7 @@ mod tests {
                 assignment: &[],
                 payload_sha256: None,
                 require_private_workspace: false,
+                admission_limit: None,
                 ttl_secs: 60,
                 now: 202,
             })
@@ -2311,12 +2352,57 @@ mod tests {
                 assignment: &[],
                 payload_sha256: None,
                 require_private_workspace: false,
+                admission_limit: None,
                 ttl_secs: 60,
                 now: 203,
             })
                 .unwrap(),
             ClaimForkPoolSlot::Existing(lease) if lease.id == "lease-1"
         ));
+    }
+
+    #[test]
+    fn adaptive_limit_is_atomic_and_never_loosens_static_limit() {
+        let (_dir, db) = temp_db();
+        let mut pool = test_pool("rollouts", 3);
+        pool.max_active = Some(2);
+        db.insert_fork_pool_if_not_exists(&pool).unwrap();
+        for machine in ["slot-1", "slot-2", "slot-3"] {
+            insert_ready_pool_slot(&db, "rollouts", machine);
+        }
+
+        let claim = |lease_id: &str, request: &str, admission_limit| {
+            db.claim_fork_pool_slot(ForkPoolSlotClaim {
+                pool_name: "rollouts",
+                lease_id,
+                idempotency_key: request,
+                assignment: &[],
+                payload_sha256: None,
+                require_private_workspace: false,
+                admission_limit,
+                ttl_secs: 60,
+                now: 200,
+            })
+            .unwrap()
+        };
+
+        assert!(matches!(
+            claim("lease-1", "request-1", Some(1)),
+            ClaimForkPoolSlot::Claimed(_)
+        ));
+        assert_eq!(
+            claim("lease-2", "request-2", Some(1)),
+            ClaimForkPoolSlot::AtCapacity
+        );
+        assert!(matches!(
+            claim("lease-2", "request-2", Some(3)),
+            ClaimForkPoolSlot::Claimed(_)
+        ));
+        assert_eq!(
+            claim("lease-3", "request-3", Some(3)),
+            ClaimForkPoolSlot::AtCapacity,
+            "dynamic admission may not exceed maxActive"
+        );
     }
 
     #[test]
@@ -2339,6 +2425,7 @@ mod tests {
                     assignment: &[],
                     payload_sha256: None,
                     require_private_workspace: false,
+                    admission_limit: None,
                     ttl_secs: 10,
                     now: 200,
                 })
@@ -2399,6 +2486,7 @@ mod tests {
             assignment: &[],
             payload_sha256: None,
             require_private_workspace: false,
+            admission_limit: None,
             ttl_secs: 60,
             now: 200,
         })
@@ -2434,6 +2522,7 @@ mod tests {
             assignment: &[],
             payload_sha256: None,
             require_private_workspace: false,
+            admission_limit: None,
             ttl_secs: 60,
             now: 200,
         })

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -13,6 +13,10 @@ pub struct ForkPoolRecord {
     pub desired_ready: u32,
     /// Optional limit on simultaneously active leases.
     pub max_active: Option<u32>,
+    /// Dynamically calibrate the active-lease limit from host/GPU telemetry.
+    /// Absent on records written before automatic admission was introduced.
+    #[serde(default)]
+    pub auto_admission: bool,
     /// Share the golden's immutable CUDA allocations with each worker.
     pub share_weights: bool,
     /// Maximum time to wait for the golden's workload forkpoint.
@@ -177,5 +181,24 @@ mod tests {
         )
         .unwrap();
         assert_eq!(lease.payload_sha256, None);
+    }
+
+    #[test]
+    fn legacy_pool_without_auto_admission_stays_full_residency() {
+        let pool: ForkPoolRecord = serde_json::from_str(
+            r#"{
+                "name":"rollouts",
+                "golden":"golden",
+                "desired_ready":8,
+                "max_active":null,
+                "share_weights":true,
+                "ready_timeout_secs":240,
+                "lease_ttl_secs":300,
+                "created_at":1,
+                "deleting":false
+            }"#,
+        )
+        .unwrap();
+        assert!(!pool.auto_admission);
     }
 }


### PR DESCRIPTION
Automatically calibrates active shared-CUDA pool leases from GPU and host telemetry while preserving explicit capacity limits.

Adds safe, versioned multi-LoRA rollout executors with ordinary isolated pools retained as the compatibility fallback.

Validated with strict linting, workspace tests, live H100 admission scaling from 4 to 12 active jobs, policy replacement and restart recovery, and no measurable hot-path proxy overhead.