### PR TITLE
Rebase the egress port-gating and host-loopback work onto main with a corrected DNS round-trip test

### DIFF
--- a/crates/smolvm-network/src/dns.rs
+++ b/crates/smolvm-network/src/dns.rs
@@ -168,6 +168,56 @@ pub fn error_response(query: &[u8], rcode: u16) -> Vec<u8> {
     response
 }
 
+/// Synthesize a DNS response for `query` with the given `ips` (A/AAAA, `ttl` s).
+/// SERVFAIL if the question is unparseable; QTYPE filtering — only matching record
+/// types are answered.
+pub fn build_ip_response(query: &[u8], ips: &[IpAddr], ttl: u32) -> Vec<u8> {
+    let Some(question_end) = question_section_end(query) else {
+        return error_response(query, DNS_RCODE_SERVFAIL);
+    };
+    let qtype = read_u16(query, question_end - 4).unwrap_or(0);
+    let ips: Vec<IpAddr> = ips
+        .iter()
+        .copied()
+        .filter(|ip| {
+            matches!(
+                (qtype, ip),
+                (DNS_TYPE_A, IpAddr::V4(_)) | (DNS_TYPE_AAAA, IpAddr::V6(_))
+            )
+        })
+        .collect();
+    let flags = DNS_FLAG_RESPONSE
+        | (read_u16(query, DNS_FLAGS_OFFSET).unwrap_or(0) & DNS_FLAG_RECURSION_DESIRED)
+        | DNS_FLAG_RECURSION_AVAILABLE;
+    let ancount = u16::try_from(ips.len()).unwrap_or(0);
+
+    let mut response =
+        Vec::with_capacity(question_end + ips.len() * (DNS_RR_FIXED_LEN + DNS_AAAA_RDATA_LEN));
+    response.extend_from_slice(&query[..DNS_ID_LEN]);
+    response.extend_from_slice(&flags.to_be_bytes());
+    response.extend_from_slice(&DNS_ONE_QUESTION.to_be_bytes()); // qdcount
+    response.extend_from_slice(&ancount.to_be_bytes());
+    response.extend_from_slice(&0u16.to_be_bytes()); // nscount
+    response.extend_from_slice(&0u16.to_be_bytes()); // arcount
+    response.extend_from_slice(&query[DNS_HEADER_LEN..question_end]); // echo question
+
+    // Name pointer to the question name at the fixed header offset.
+    let name_pointer = [DNS_POINTER_TAG, DNS_HEADER_LEN as u8];
+    for ip in &ips {
+        response.extend_from_slice(&name_pointer);
+        let (rtype, rdata) = match ip {
+            IpAddr::V4(v4) => (DNS_TYPE_A, v4.octets().to_vec()),
+            IpAddr::V6(v6) => (DNS_TYPE_AAAA, v6.octets().to_vec()),
+        };
+        response.extend_from_slice(&rtype.to_be_bytes());
+        response.extend_from_slice(&DNS_CLASS_IN.to_be_bytes());
+        response.extend_from_slice(&ttl.to_be_bytes());
+        response.extend_from_slice(&(rdata.len() as u16).to_be_bytes());
+        response.extend_from_slice(&rdata);
+    }
+    response
+}
+
 fn question_section_end(packet: &[u8]) -> Option<usize> {
     if packet.len() < DNS_HEADER_LEN || read_u16(packet, DNS_QDCOUNT_OFFSET)? != DNS_ONE_QUESTION {
         return None;
@@ -308,6 +358,10 @@ mod tests {
             records,
             vec![(IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)), 300)]
         );
+        // A response echoes its question, so the name is recoverable from the
+        // answer alone — which is how the gateway learns records under a name
+        // without carrying the query string alongside the pending request.
+        assert_eq!(question_name(&r).as_deref(), Some("example.com"));
     }
 
     #[test]
@@ -370,6 +424,31 @@ mod tests {
         assert_eq!(flags & DNS_FLAG_RESPONSE, DNS_FLAG_RESPONSE);
         assert_eq!(flags & DNS_RCODE_MASK, DNS_RCODE_NXDOMAIN);
         assert_eq!(&resp[..2], &q[..2]); // echoed id
+    }
+
+    #[test]
+    fn build_ip_response_round_trips_through_parser() {
+        let query = query_for("api.internal");
+        let ips = vec![
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5)),
+            IpAddr::V6("2606:4700::1".parse().unwrap()),
+        ];
+        let response = build_ip_response(&query, &ips, 60);
+        assert_eq!(&response[..2], &query[..2]); // echoed id
+        let flags = read_u16(&response, DNS_FLAGS_OFFSET).unwrap();
+        assert_eq!(flags & DNS_FLAG_RESPONSE, DNS_FLAG_RESPONSE);
+        // Our own parser must extract exactly the synthesized records.
+        assert_eq!(
+            answer_ip_records(&response),
+            vec![(ips[0], 60), (ips[1], 60)]
+        );
+    }
+
+    #[test]
+    fn build_ip_response_servfails_on_bad_query() {
+        let response = build_ip_response(&[0, 1, 2], &[IpAddr::V4(Ipv4Addr::LOCALHOST)], 60);
+        let flags = read_u16(&response, DNS_FLAGS_OFFSET).unwrap();
+        assert_eq!(flags & DNS_RCODE_MASK, DNS_RCODE_SERVFAIL);
     }
 
     #[test]

--- a/crates/smolvm-network/src/dns.rs
+++ b/crates/smolvm-network/src/dns.rs
@@ -300,6 +300,14 @@ mod tests {
     use super::*;
 
     /// A query for `name` with one question (A/IN).
+    fn query_for_type(name: &str, qtype: u16) -> Vec<u8> {
+        let mut q = query_for(name);
+        // Overwrite the trailing QTYPE (the last four bytes are QTYPE+QCLASS).
+        let qtype_at = q.len() - 4;
+        q[qtype_at..qtype_at + 2].copy_from_slice(&qtype.to_be_bytes());
+        q
+    }
+
     fn query_for(name: &str) -> Vec<u8> {
         let mut q = vec![
             0x12, 0x34, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -428,20 +436,23 @@ mod tests {
 
     #[test]
     fn build_ip_response_round_trips_through_parser() {
-        let query = query_for("api.internal");
         let ips = vec![
             IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5)),
             IpAddr::V6("2606:4700::1".parse().unwrap()),
         ];
-        let response = build_ip_response(&query, &ips, 60);
-        assert_eq!(&response[..2], &query[..2]); // echoed id
-        let flags = read_u16(&response, DNS_FLAGS_OFFSET).unwrap();
-        assert_eq!(flags & DNS_FLAG_RESPONSE, DNS_FLAG_RESPONSE);
-        // Our own parser must extract exactly the synthesized records.
-        assert_eq!(
-            answer_ip_records(&response),
-            vec![(ips[0], 60), (ips[1], 60)]
-        );
+
+        // Answers are filtered to the question's type: an A query must not carry
+        // the AAAA record, or a resolver that asked for A sees an answer it did
+        // not request (and a guest with no v6 route follows it).
+        for (qtype, expected) in [(DNS_TYPE_A, ips[0]), (DNS_TYPE_AAAA, ips[1])] {
+            let query = query_for_type("api.internal", qtype);
+            let response = build_ip_response(&query, &ips, 60);
+            assert_eq!(&response[..2], &query[..2]); // echoed id
+            let flags = read_u16(&response, DNS_FLAGS_OFFSET).unwrap();
+            assert_eq!(flags & DNS_FLAG_RESPONSE, DNS_FLAG_RESPONSE);
+            // Our own parser must extract exactly the synthesized record.
+            assert_eq!(answer_ip_records(&response), vec![(expected, 60)]);
+        }
     }
 
     #[test]

--- a/crates/smolvm-network/src/egress.rs
+++ b/crates/smolvm-network/src/egress.rs
@@ -237,6 +237,8 @@ fn is_reserved_v4(v4: Ipv4Addr) -> bool {
         || v4.is_private()    // 10/8, 172.16/12, 192.168/16 — host/control internal subnet
         || v4.is_unspecified()
         || v4.is_broadcast()
+        // 224.0.0.0/4 — host LAN segment the floor exists to block
+        || v4.is_multicast()
         // 100.64.0.0/10 (CGNAT) — the gateway's own guest/gateway addresses live here.
         || matches!(v4.octets(), [100, b, ..] if (64..=127).contains(&b))
 }
@@ -252,6 +254,7 @@ fn is_floored(ip: IpAddr, mode: FloorMode) -> bool {
             IpAddr::V6(v6) => {
                 v6.is_loopback()
                     || v6.is_unspecified()
+                    || v6.is_multicast() // ff00::/8, incl. ff02::1 — see is_reserved_v4
                     || (v6.segments()[0] & 0xffc0) == 0xfe80 // fe80::/10 link-local
                     || (v6.segments()[0] & 0xfe00) == 0xfc00 // fc00::/7 unique-local
                     || v6.to_ipv4_mapped().is_some_and(is_reserved_v4)
@@ -513,6 +516,12 @@ impl EgressPolicy {
         let now = Instant::now();
         learned.retain(|_, expires_at| *expires_at > now);
         for (ip, ttl) in records {
+            // Learned addresses are attacker-controlled — floor them too.
+            // Also exclude HOST_SENTINEL so a static `to: host` record can
+            // publish it without letting every allowed name reach the host loopback.
+            if is_floored(*ip, self.floor) || *ip == HOST_SENTINEL {
+                continue;
+            }
             let ttl = u64::from(*ttl).clamp(MIN_LEARNED_TTL, MAX_LEARNED_TTL);
             let expires_at = now + Duration::from_secs(ttl);
             for grant in &grants {
@@ -924,6 +933,37 @@ mod tests {
             ..Default::default()
         });
         assert!(by_cidr.allows(v4(10, 0, 0, 5), Some(8080)));
+    }
+
+    #[test]
+    fn a_dns_answer_cannot_publish_the_host_sentinel() {
+        // A DNS answer for an allowed name must not earn a grant on the sentinel
+        // — that would give every allowed name access to the host loopback.
+        let p = statics(
+            Some(&["db.local:5432", "api.test"]),
+            &[("db.local", StaticTarget::Host)],
+        );
+        p.learn_named("api.test", &[(HOST_SENTINEL, 300)]);
+        assert!(!p.allows(HOST_SENTINEL, Some(22)));
+        assert!(!p.allows(HOST_SENTINEL, None));
+        // The record's own grant is untouched.
+        assert!(p.allows(HOST_SENTINEL, Some(5432)));
+    }
+
+    #[test]
+    fn the_floor_covers_multicast() {
+        // Floor-only (no allow-list) must block multicast from the host LAN.
+        let p = EgressPolicy::new(EgressConfig {
+            floor: Some(FloorMode::Strict),
+            ..Default::default()
+        });
+        for addr in ["224.0.0.1", "239.255.255.250", "224.0.0.251", "ff02::1"] {
+            let ip: IpAddr = addr.parse().unwrap();
+            assert!(!p.allows(ip, Some(1900)), "reached {addr}");
+        }
+        // …including the IPv4-mapped spelling, which `Ipv6Addr::is_multicast`
+        // answers `false` for on its own.
+        assert!(!p.allows("::ffff:239.255.255.250".parse().unwrap(), Some(1900)));
     }
 
     #[test]

--- a/crates/smolvm-network/src/egress.rs
+++ b/crates/smolvm-network/src/egress.rs
@@ -14,9 +14,13 @@
 //!
 //! Disallowed destinations are dropped before any host socket is created. DNS
 //! forwarding (gateway-internal) is never gated by this filter.
+//!
+//! Additionally: [`EgressConfig::static_names`] resolves names locally;
+//! [`StaticTarget::Host`] forwards to the host loopback via [`HOST_SENTINEL`];
+//! and any allow-list entry may carry `:port` for per-port rules.
 
 use std::collections::HashMap;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -85,12 +89,71 @@ impl Cidr {
     }
 }
 
+/// The one address published for a static record naming a host-local target.
+/// RFC 5737 TEST-NET-1: never a real destination, and not caught by any
+/// `FloorMode`, so the mapping works in every floor mode. NOT link-local, which
+/// is floored everywhere but `Off` and would be ARPed for rather than routed here.
+const HOST_SENTINEL: IpAddr = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
+
+/// The address [`HOST_SENTINEL`] is translated to before connecting.
+pub const HOST_LOOPBACK: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+
+/// What a static record answers with.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StaticTarget {
+    /// A literal address, handed to the guest as-is.
+    Ip(IpAddr),
+    /// The host itself. Published as [`HOST_SENTINEL`] and translated to
+    /// [`HOST_LOOPBACK`] on connect — a guest handed `127.0.0.1` would reach its
+    /// own loopback, never the gateway. Say this rather than naming a loopback
+    /// address, so wanting host access is a declaration and not an inference.
+    Host,
+}
+
+/// Split a trailing `:port` off an allow-list entry. Uses `host:port` /
+/// `[v6]:port` convention: bare host+colon is a v6 literal or CIDR. `None` =
+/// malformed port (caller drops the entry).
+fn split_port(entry: &str) -> Option<(&str, Option<u16>)> {
+    let port = |p: &str| p.parse::<u16>().ok().filter(|p| *p != 0);
+    if let Some(rest) = entry.strip_prefix('[') {
+        let (addr, tail) = rest.split_once(']')?;
+        return match tail.strip_prefix(':') {
+            Some(p) => Some((addr, Some(port(p)?))),
+            None if tail.is_empty() => Some((addr, None)),
+            None => None,
+        };
+    }
+    match entry.rsplit_once(':') {
+        Some((host, p)) if !host.contains(':') => Some((host, Some(port(p)?))),
+        _ => Some((entry, None)),
+    }
+}
+
 struct AllowList {
-    cidrs: Vec<Cidr>,
-    /// Normalized allow-host names. `None` = no DNS hostname filtering.
-    allowed_hosts: Option<Vec<String>>,
-    /// IPs learned from allowed DNS answers → expiry instant.
-    learned: Mutex<HashMap<IpAddr, Instant>>,
+    /// Allowed CIDRs, each with the port it narrows to (`None` = any port).
+    cidrs: Vec<(Cidr, Option<u16>)>,
+    /// Normalized allow-host names with their port grants. `None` = no DNS
+    /// hostname filtering.
+    allowed_hosts: Option<Vec<(String, Option<u16>)>>,
+    /// `(IP, port grant)` learned from allowed DNS answers → expiry instant. Keyed
+    /// by the pair so one IP learned from two names keeps both grants.
+    learned: Mutex<HashMap<(IpAddr, Option<u16>), Instant>>,
+}
+
+impl AllowList {
+    /// Port grants for `hostname`; empty = none match. The opposite sense to
+    /// [`EgressPolicy::hostname_allowed`]: unset means queries pass but earn no
+    /// address grant (otherwise resolving any name would defeat `allowed_cidrs`).
+    fn name_grants(&self, hostname: &str) -> Vec<Option<u16>> {
+        let Some(hosts) = &self.allowed_hosts else {
+            return Vec::new();
+        };
+        hosts
+            .iter()
+            .filter(|(name, _)| dns::hostname_allowed(hostname, std::slice::from_ref(name)))
+            .map(|(_, grant)| *grant)
+            .collect()
+    }
 }
 
 /// How much of the platform hard-floor applies, chosen once per policy from the
@@ -98,7 +161,7 @@ struct AllowList {
 /// LAN from a local VM is legitimate and expected, so the broad internal-subnet
 /// floor is reserved for the multi-tenant context where it's actually needed.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-enum FloorMode {
+pub enum FloorMode {
     /// Trusted single-tenant/local override (`SMOLVM_EGRESS_ALLOW_PRIVATE=1`):
     /// floor nothing — the guest reaches exactly what the host can.
     Off,
@@ -205,30 +268,91 @@ pub struct EgressPolicy {
     inner: Option<Arc<AllowList>>,
     /// Hard-floor scope, resolved once from the deployment context at creation.
     floor: FloorMode,
+    /// Names the policy resolves itself → the IPs published to the guest.
+    static_names: Arc<HashMap<String, Vec<IpAddr>>>,
+    /// Whether one of them published [`HOST_SENTINEL`]. Without this the relays
+    /// would translate the sentinel for a guest that merely invented the address,
+    /// handing over the host's loopback past the hard floor.
+    host_sentinel_live: bool,
+}
+
+/// Everything a policy is built from. `Default` = unrestricted with no static
+/// names, i.e. allow everything except the platform hard-floor.
+#[derive(Clone, Debug, Default)]
+pub struct EgressConfig {
+    /// Allowed CIDRs/IPs, each with an optional `:port` (`1.1.1.1:443`,
+    /// `[::1]:443`). Either list being `Some` puts the allow-list in force.
+    pub allowed_cidrs: Option<Vec<String>>,
+    /// Allowed DNS names, each with an optional `:port` (`api.test:443`).
+    /// Subdomains match. `None` = no name filtering; `Some(vec![])` allows none.
+    pub allowed_hosts: Option<Vec<String>>,
+    /// Names the gateway answers itself: hostname → what to answer with. Ports
+    /// play no part here — put `name:port` in `allowed_hosts` to narrow access.
+    pub static_names: Vec<(String, Vec<StaticTarget>)>,
+    /// Hard-floor scope. `None` (the default) infers it from the environment;
+    /// set it to pin the floor without depending on env vars.
+    pub floor: Option<FloorMode>,
+}
+
+impl EgressConfig {
+    /// The plain `allowed_cidrs` + `--allow-host` shape, with no static names.
+    pub fn from_allow_lists(cidrs: Option<Vec<String>>, hosts: Option<Vec<String>>) -> Self {
+        Self {
+            allowed_cidrs: cidrs,
+            allowed_hosts: hosts,
+            ..Self::default()
+        }
+    }
 }
 
 impl EgressPolicy {
     /// No allow-list — every destination is allowed EXCEPT the platform hard-floor.
     pub fn unrestricted() -> Self {
-        Self {
-            inner: None,
-            floor: floor_mode(),
-        }
+        Self::new(EgressConfig::default())
     }
 
-    /// Build from `VmResources::allowed_cidrs` and the `--allow-host` list.
-    /// Both `None` → unrestricted. Otherwise a policy is in force: only the
-    /// listed CIDRs and IPs learned from allowed DNS answers may be reached
-    /// (an empty CIDR list with no hosts denies everything).
-    pub fn new(allowed_cidrs: Option<&[String]>, allowed_hosts: Option<&[String]>) -> Self {
+    /// Build the policy described by `config`. Both allow-lists `None` →
+    /// unrestricted. Otherwise a policy is in force: only the listed CIDRs and
+    /// IPs learned from allowed DNS answers may be reached (an empty CIDR list
+    /// with no hosts denies everything).
+    pub fn new(config: EgressConfig) -> Self {
+        let EgressConfig {
+            allowed_cidrs,
+            allowed_hosts,
+            static_names,
+            floor,
+        } = config;
+        let floor = floor.unwrap_or_else(floor_mode);
+        let publish = |t: &StaticTarget| match t {
+            StaticTarget::Ip(ip) => *ip,
+            StaticTarget::Host => HOST_SENTINEL,
+        };
+        let host_sentinel_live = static_names
+            .iter()
+            .any(|(_, t)| t.contains(&StaticTarget::Host));
+        let static_names: HashMap<String, Vec<IpAddr>> = static_names
+            .iter()
+            .filter_map(|(n, ts)| {
+                Some((
+                    dns::normalize_hostname(n)?,
+                    ts.iter().map(publish).collect(),
+                ))
+            })
+            .collect();
+        let static_names = Arc::new(static_names);
         if allowed_cidrs.is_none() && allowed_hosts.is_none() {
-            return Self::unrestricted();
+            return Self {
+                inner: None,
+                floor,
+                static_names,
+                host_sentinel_live,
+            };
         }
-        let cidrs = allowed_cidrs
-            .unwrap_or(&[])
+        let mut cidrs: Vec<(Cidr, Option<u16>)> = allowed_cidrs
+            .unwrap_or_default()
             .iter()
             .filter_map(|spec| {
-                let parsed = Cidr::parse(spec);
+                let parsed = split_port(spec.trim()).and_then(|(s, p)| Some((Cidr::parse(s)?, p)));
                 if parsed.is_none() {
                     tracing::warn!(cidr = %spec, "ignoring unparseable egress CIDR");
                 }
@@ -238,22 +362,63 @@ impl EgressPolicy {
         let allowed_hosts = allowed_hosts.map(|hosts| {
             hosts
                 .iter()
-                .filter_map(|h| dns::normalize_hostname(h))
-                .collect()
+                .filter_map(|h| {
+                    let (name, port) = split_port(h.trim())?;
+                    Some((dns::normalize_hostname(name)?, port))
+                })
+                .collect::<Vec<_>>()
         });
+        // A statically answered IP is reached by address, never by name: the
+        // grant on that name becomes an address rule here. Without an allow-host
+        // list the record itself authorizes (`Host` sentinel otherwise unreachable
+        // — nobody puts it in `allowed_cidrs`). Upstream answers earn nothing
+        // (`name_grants`): operator authorization is different from a resolver's.
+        for (name, ips) in static_names.iter() {
+            let grants: Vec<Option<u16>> = match &allowed_hosts {
+                None => vec![None],
+                Some(hosts) => hosts
+                    .iter()
+                    .filter(|(rule, _)| dns::hostname_allowed(name, std::slice::from_ref(rule)))
+                    .map(|(_, port)| *port)
+                    .collect(),
+            };
+            for grant in grants {
+                cidrs.extend(
+                    ips.iter()
+                        .filter_map(|i| Some((Cidr::parse(&i.to_string())?, grant))),
+                );
+            }
+        }
         Self {
             inner: Some(Arc::new(AllowList {
                 cidrs,
                 allowed_hosts,
                 learned: Mutex::new(HashMap::new()),
             })),
-            floor: floor_mode(),
+            floor,
+            static_names,
+            host_sentinel_live,
         }
     }
 
-    /// Convenience for the CIDR-only case.
-    pub fn from_allowed_cidrs(allowed: Option<&[String]>) -> Self {
-        Self::new(allowed, None)
+    /// Whether the policy answers any name itself. The gateway then intercepts
+    /// DNS/TCP too, so those answers win over whatever resolver the guest picked.
+    pub fn has_static_dns(&self) -> bool {
+        !self.static_names.is_empty()
+    }
+
+    /// The IPs to answer a statically mapped `name` with, if one is configured.
+    pub fn static_answer(&self, name: &str) -> Option<Vec<IpAddr>> {
+        self.static_names
+            .get(&dns::normalize_hostname(name)?)
+            .cloned()
+    }
+
+    /// The address [`HOST_SENTINEL`] really stands for, once a static record has
+    /// published it. Relays call this before connect; `None` = `ip` is already the
+    /// real destination. The port is untouched — only the address is swapped.
+    pub fn host_forward(&self, ip: IpAddr) -> Option<IpAddr> {
+        (ip == HOST_SENTINEL && self.host_sentinel_live).then_some(HOST_LOOPBACK)
     }
 
     /// Whether any policy is in force (false = allow-all).
@@ -261,11 +426,14 @@ impl EgressPolicy {
         self.inner.is_some()
     }
 
-    /// Whether the gateway should DNS-filter queries (an allow-host list is set).
+    /// Whether the gateway should DNS-filter queries (an allow-host list is set,
+    /// or the policy answers some name itself).
     pub fn dns_filter_active(&self) -> bool {
-        self.inner
-            .as_ref()
-            .is_some_and(|list| list.allowed_hosts.is_some())
+        self.has_static_dns()
+            || self
+                .inner
+                .as_ref()
+                .is_some_and(|l| l.allowed_hosts.is_some())
     }
 
     /// Whether a DNS query for `hostname` should be forwarded upstream. With no
@@ -275,53 +443,70 @@ impl EgressPolicy {
             None => true,
             Some(list) => match &list.allowed_hosts {
                 None => true,
-                Some(hosts) => dns::hostname_allowed(hostname, hosts),
+                Some(_) => !list.name_grants(hostname).is_empty(),
             },
         }
     }
 
-    /// Whether an outbound connection to `ip` (v4 or v6) is permitted.
-    pub fn allows(&self, ip: IpAddr) -> bool {
+    /// Whether an outbound connection to `ip` (v4 or v6) is permitted. `port` is
+    /// `None` for a portless flow (ICMP echo), which only an any-port grant covers.
+    pub fn allows(&self, ip: IpAddr, port: Option<u16>) -> bool {
         // Platform hard-floor: deny per the resolved FloorMode (metadata-only
         // locally, full floor under fleet mode) regardless of the allow-list.
         if is_floored(ip, self.floor) {
             return false;
         }
+        // The floor judges the sentinel, not its translation: a static record IS
+        // the operator authorizing that target. Which is why an unclaimed sentinel
+        // must die here — otherwise a guest that simply dials the address is handed
+        // the host's loopback past the floor.
+        if ip == HOST_SENTINEL && !self.host_sentinel_live {
+            return false;
+        }
+        // A grant of `None` covers every port, including a portless flow.
+        let covers = |grant: Option<u16>| grant.is_none() || port == grant;
         match &self.inner {
             None => true,
             Some(list) => {
-                if list.cidrs.iter().any(|cidr| cidr.contains(ip)) {
+                if list.cidrs.iter().any(|(c, g)| c.contains(ip) && covers(*g)) {
                     return true;
                 }
                 list.learned
                     .lock()
                     .map(|learned| {
-                        learned
-                            .get(&ip)
-                            .is_some_and(|expires_at| *expires_at > Instant::now())
+                        let now = Instant::now();
+                        [None, port]
+                            .iter()
+                            .any(|g| learned.get(&(ip, *g)).is_some_and(|at| *at > now))
                     })
                     .unwrap_or(false)
             }
         }
     }
 
-    /// Convenience for IPv4 call sites.
-    pub fn allows_v4(&self, ip: Ipv4Addr) -> bool {
-        self.allows(IpAddr::V4(ip))
-    }
-
-    /// Convenience for IPv6 call sites.
-    pub fn allows_v6(&self, ip: Ipv6Addr) -> bool {
-        self.allows(IpAddr::V6(ip))
-    }
-
     /// Learn the A/AAAA records of an allowed DNS answer as temporarily-allowed
     /// IPs. TTLs are clamped to [60s, 3600s]; expired entries are pruned. No-op
     /// when unrestricted.
-    pub fn learn_ip_records(&self, records: &[(IpAddr, u32)]) {
+    ///
+    /// The grant is keyed by name — `api.test:443` narrows the addresses
+    /// `api.test` resolves to — so the name is read from the answer's question,
+    /// not the query. Safe: the echoed name only selects among existing grants.
+    pub fn learn_ip_records(&self, answer: &[u8]) {
+        let Some(hostname) = dns::question_name(answer) else {
+            return;
+        };
+        self.learn_named(&hostname, &dns::answer_ip_records(answer));
+    }
+
+    /// [`Self::learn_ip_records`] with the answer already parsed.
+    fn learn_named(&self, hostname: &str, records: &[(IpAddr, u32)]) {
         let Some(list) = &self.inner else {
             return;
         };
+        let grants = list.name_grants(hostname);
+        if grants.is_empty() {
+            return;
+        }
         let Ok(mut learned) = list.learned.lock() else {
             return;
         };
@@ -330,10 +515,12 @@ impl EgressPolicy {
         for (ip, ttl) in records {
             let ttl = u64::from(*ttl).clamp(MIN_LEARNED_TTL, MAX_LEARNED_TTL);
             let expires_at = now + Duration::from_secs(ttl);
-            learned
-                .entry(*ip)
-                .and_modify(|existing| *existing = (*existing).max(expires_at))
-                .or_insert(expires_at);
+            for grant in &grants {
+                learned
+                    .entry((*ip, *grant))
+                    .and_modify(|existing| *existing = (*existing).max(expires_at))
+                    .or_insert(expires_at);
+            }
         }
     }
 }
@@ -341,6 +528,15 @@ impl EgressPolicy {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::Ipv6Addr;
+
+    /// Restricted-policy fixture: a CIDR allow-list, an allow-host list, or both.
+    fn policy(cidrs: &[&str], hosts: Option<&[&str]>) -> EgressPolicy {
+        EgressPolicy::new(EgressConfig::from_allow_lists(
+            Some(cidrs.iter().map(|s| s.to_string()).collect()),
+            hosts.map(|hosts| hosts.iter().map(|s| s.to_string()).collect()),
+        ))
+    }
 
     #[test]
     fn floor_override_parsing() {
@@ -365,28 +561,28 @@ mod tests {
     fn unrestricted_allows_everything() {
         let policy = EgressPolicy::unrestricted();
         assert!(!policy.is_restricted());
-        assert!(policy.allows_v4(Ipv4Addr::new(8, 8, 8, 8)));
-        assert!(policy.allows_v6("2001:4860:4860::8888".parse().unwrap()));
+        assert!(policy.allows(v4(8, 8, 8, 8), None));
+        assert!(policy.allows(v6("2001:4860:4860::8888"), None));
         assert!(policy.hostname_allowed("anything.test"));
         assert!(!policy.dns_filter_active());
     }
 
     #[test]
     fn empty_allowlist_denies_all() {
-        let policy = EgressPolicy::from_allowed_cidrs(Some(&[]));
+        let policy = policy(&[], None);
         assert!(policy.is_restricted());
-        assert!(!policy.allows_v4(Ipv4Addr::new(1, 1, 1, 1)));
-        assert!(!policy.allows_v6("2606:4700::1111".parse().unwrap()));
+        assert!(!policy.allows(v4(1, 1, 1, 1), None));
+        assert!(!policy.allows(v6("2606:4700::1111"), None));
     }
 
     #[test]
     fn cidr_membership_v4() {
         // Public CIDRs only — private ranges are denied by the hard-floor below.
-        let policy = EgressPolicy::new(Some(&["8.8.8.0/24".into(), "1.1.1.1".into()]), None);
-        assert!(policy.allows_v4(Ipv4Addr::new(8, 8, 8, 7)));
-        assert!(policy.allows_v4(Ipv4Addr::new(1, 1, 1, 1)));
-        assert!(!policy.allows_v4(Ipv4Addr::new(1, 1, 1, 2)));
-        assert!(!policy.allows_v4(Ipv4Addr::new(9, 0, 0, 1)));
+        let policy = policy(&["8.8.8.0/24", "1.1.1.1"], None);
+        assert!(policy.allows(v4(8, 8, 8, 7), None));
+        assert!(policy.allows(v4(1, 1, 1, 1), None));
+        assert!(!policy.allows(v4(1, 1, 1, 2), None));
+        assert!(!policy.allows(v4(9, 0, 0, 1), None));
     }
 
     #[test]
@@ -395,57 +591,56 @@ mod tests {
         // is denied; the host's LAN, loopback, and CGNAT stay reachable — so a
         // local VM behaves predictably.
         let p = EgressPolicy::unrestricted();
-        assert!(!p.allows_v4(Ipv4Addr::new(169, 254, 169, 254))); // metadata: denied
-        assert!(p.allows_v4(Ipv4Addr::new(10, 0, 0, 4))); // LAN: reachable
-        assert!(p.allows_v4(Ipv4Addr::new(127, 0, 0, 1))); // loopback: reachable
-        assert!(p.allows_v4(Ipv4Addr::new(192, 168, 1, 1)));
-        assert!(p.allows_v4(Ipv4Addr::new(172, 16, 0, 1)));
-        assert!(p.allows_v4(Ipv4Addr::new(100, 96, 0, 1))); // CGNAT: reachable
-        assert!(p.allows_v4(Ipv4Addr::new(1, 1, 1, 1))); // public: reachable
+        assert!(!p.allows(v4(169, 254, 169, 254), None)); // metadata: denied
+        assert!(p.allows(v4(10, 0, 0, 4), None)); // LAN: reachable
+        assert!(p.allows(v4(127, 0, 0, 1), None)); // loopback: reachable
+        assert!(p.allows(v4(192, 168, 1, 1), None));
+        assert!(p.allows(v4(172, 16, 0, 1), None));
+        assert!(p.allows(v4(100, 96, 0, 1), None)); // CGNAT: reachable
+        assert!(p.allows(v4(1, 1, 1, 1), None)); // public: reachable
     }
 
     #[test]
     fn metadata_floor_overrides_allowlist_and_learned_ips() {
         // The metadata range can't be re-opened by allow-listing it...
-        let p = EgressPolicy::new(Some(&["169.254.0.0/16".into()]), None);
-        assert!(!p.allows_v4(Ipv4Addr::new(169, 254, 169, 254)));
+        let p = policy(&["169.254.0.0/16"], None);
+        assert!(!p.allows(v4(169, 254, 169, 254), None));
         // ...nor via DNS-rebinding: a learned metadata IP stays denied.
-        let p2 = EgressPolicy::new(None, Some(&["evil.test".into()]));
+        let p2 = policy(&[], Some(&["evil.test"]));
         let meta = IpAddr::V4(Ipv4Addr::new(169, 254, 169, 254));
-        p2.learn_ip_records(&[(meta, 300)]);
-        assert!(!p2.allows(meta));
+        p2.learn_named("evil.test", &[(meta, 300)]);
+        assert!(!p2.allows(meta, None));
         // But a LAN IP in the allow-list IS reachable locally.
-        let p3 = EgressPolicy::new(Some(&["10.0.0.0/8".into()]), None);
-        assert!(p3.allows_v4(Ipv4Addr::new(10, 0, 0, 4)));
+        let p3 = policy(&["10.0.0.0/8"], None);
+        assert!(p3.allows(v4(10, 0, 0, 4), None));
     }
 
     #[test]
     fn metadata_floor_blocks_mapped_and_v6_link_local() {
         let p = EgressPolicy::unrestricted(); // MetadataOnly default
                                               // mapped metadata + v6 link-local are denied...
-        assert!(!p.allows_v6("::ffff:169.254.169.254".parse().unwrap()));
-        assert!(!p.allows_v6("fe80::1".parse().unwrap()));
+        assert!(!p.allows(v6("::ffff:169.254.169.254"), None));
+        assert!(!p.allows(v6("fe80::1"), None));
         // ...but v6 ULA (the LAN equivalent) and global unicast are reachable.
-        assert!(p.allows_v6("fc00::1".parse().unwrap()));
-        assert!(p.allows_v6("2606:4700::1111".parse().unwrap()));
+        assert!(p.allows(v6("fc00::1"), None));
+        assert!(p.allows(v6("2606:4700::1111"), None));
     }
 
     #[test]
     fn cidr_membership_v6() {
-        let policy =
-            EgressPolicy::new(Some(&["2606:4700::/32".into(), "2001:db8::1".into()]), None);
-        assert!(policy.allows_v6("2606:4700::1111".parse().unwrap()));
-        assert!(policy.allows_v6("2606:4700:ffff::1".parse().unwrap()));
-        assert!(policy.allows_v6("2001:db8::1".parse().unwrap()));
-        assert!(!policy.allows_v6("2001:db8::2".parse().unwrap()));
-        assert!(!policy.allows_v6("2607::1".parse().unwrap()));
+        let policy = policy(&["2606:4700::/32", "2001:db8::1"], None);
+        assert!(policy.allows(v6("2606:4700::1111"), None));
+        assert!(policy.allows(v6("2606:4700:ffff::1"), None));
+        assert!(policy.allows(v6("2001:db8::1"), None));
+        assert!(!policy.allows(v6("2001:db8::2"), None));
+        assert!(!policy.allows(v6("2607::1"), None));
         // A v6 CIDR never matches a v4 address and vice versa.
-        assert!(!policy.allows_v4(Ipv4Addr::new(1, 1, 1, 1)));
+        assert!(!policy.allows(v4(1, 1, 1, 1), None));
     }
 
     #[test]
     fn allow_host_gates_dns_and_learns_ips() {
-        let policy = EgressPolicy::new(None, Some(&["example.com".into()]));
+        let policy = policy(&[], Some(&["example.com"]));
         assert!(policy.dns_filter_active());
         assert!(policy.hostname_allowed("example.com"));
         assert!(policy.hostname_allowed("www.example.com"));
@@ -456,27 +651,91 @@ mod tests {
             .parse::<Ipv6Addr>()
             .unwrap()
             .into();
-        assert!(!policy.allows(v4));
-        assert!(!policy.allows(v6));
-        policy.learn_ip_records(&[(v4, 300), (v6, 600)]);
-        assert!(policy.allows(v4));
-        assert!(policy.allows(v6));
+        assert!(!policy.allows(v4, None));
+        assert!(!policy.allows(v6, None));
+        policy.learn_named("example.com", &[(v4, 300), (v6, 600)]);
+        assert!(policy.allows(v4, None));
+        assert!(policy.allows(v6, None));
     }
 
     #[test]
     fn learned_ip_respects_min_ttl() {
         // A tiny TTL is clamped up to MIN_LEARNED_TTL, so the entry is live now.
-        let policy = EgressPolicy::new(None, Some(&["example.com".into()]));
+        let policy = policy(&[], Some(&["example.com"]));
         let ip = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
-        policy.learn_ip_records(&[(ip, 1)]);
-        assert!(policy.allows(ip));
+        policy.learn_named("example.com", &[(ip, 1)]);
+        assert!(policy.allows(ip, None));
+    }
+
+    #[test]
+    fn split_port_follows_the_socketaddr_convention() {
+        // Bare address forms carry no port; the colons in a v6 literal or CIDR are
+        // not separators.
+        assert_eq!(split_port("10.0.0.0/8"), Some(("10.0.0.0/8", None)));
+        assert_eq!(split_port("::1"), Some(("::1", None)));
+        assert_eq!(split_port("fc00::/7"), Some(("fc00::/7", None)));
+        assert_eq!(split_port("api.test"), Some(("api.test", None)));
+        // Ports, including the bracketed v6 form.
+        assert_eq!(split_port("1.1.1.1:443"), Some(("1.1.1.1", Some(443))));
+        assert_eq!(split_port("[::1]:443"), Some(("::1", Some(443))));
+        assert_eq!(split_port("[fc00::/7]:443"), Some(("fc00::/7", Some(443))));
+        assert_eq!(split_port("api.test:443"), Some(("api.test", Some(443))));
+        // A present-but-unusable port drops the entry rather than widening it.
+        assert!(split_port("1.1.1.1:").is_none());
+        assert!(split_port("1.1.1.1:0").is_none());
+        assert!(split_port("api.test:99999").is_none());
     }
 
     #[test]
     fn unparseable_cidr_is_skipped_not_panicked() {
-        let policy = EgressPolicy::new(Some(&["nonsense".into(), "1.1.1.1".into()]), None);
-        assert!(policy.allows_v4(Ipv4Addr::new(1, 1, 1, 1)));
-        assert!(!policy.allows_v4(Ipv4Addr::new(2, 2, 2, 2)));
+        let policy = policy(&["nonsense", "10.0.0.0/33", "1.1.1.1"], None);
+        assert!(policy.allows(v4(1, 1, 1, 1), None));
+        assert!(!policy.allows(v4(2, 2, 2, 2), None));
+        // A bad CIDR stays a bad CIDR: it never turns into a name rule, so DNS
+        // filtering is not switched on behind the operator's back.
+        assert!(!policy.dns_filter_active());
+    }
+
+    #[test]
+    fn cidr_list_alone_leaves_dns_unfiltered() {
+        // An address-only policy gates connections but not resolution, so a guest
+        // still resolves names it will simply not be allowed to reach.
+        let p = policy(&["8.8.8.0/24"], None);
+        assert!(!p.dns_filter_active());
+        assert!(p.hostname_allowed("anything.test"));
+        assert!(p.allows(v4(8, 8, 8, 8), None));
+        assert!(!p.allows(v4(1, 1, 1, 1), None));
+    }
+
+    #[test]
+    fn port_suffix_narrows_cidrs_and_learned_ips_alike() {
+        let p = policy(&["8.8.8.0/24:53"], Some(&["api.test:443"]));
+        // CIDR entry: only its port.
+        assert!(p.allows(v4(8, 8, 8, 8), Some(53)));
+        assert!(!p.allows(v4(8, 8, 8, 8), Some(80)));
+        assert!(!p.allows(v4(8, 8, 8, 8), None)); // portless ICMP: no
+
+        // Name entry: the port rides onto whatever the name resolves to.
+        let resolved = v4(93, 184, 216, 34);
+        p.learn_named("api.test", &[(resolved, 300)]);
+        assert!(p.allows(resolved, Some(443)));
+        assert!(!p.allows(resolved, Some(80)));
+
+        // A name with no rule learns nothing at all.
+        let other = v4(5, 5, 5, 5);
+        p.learn_named("evil.test", &[(other, 300)]);
+        assert!(!p.allows(other, Some(443)));
+    }
+
+    #[test]
+    fn two_names_on_one_ip_keep_both_port_grants() {
+        let p = policy(&[], Some(&["a.test:80", "b.test:443"]));
+        let shared = v4(9, 9, 9, 9);
+        p.learn_named("a.test", &[(shared, 300)]);
+        p.learn_named("b.test", &[(shared, 300)]);
+        assert!(p.allows(shared, Some(80)));
+        assert!(p.allows(shared, Some(443)));
+        assert!(!p.allows(shared, Some(22)));
     }
 
     #[test]
@@ -489,6 +748,25 @@ mod tests {
 
     fn v4(a: u8, b: u8, c: u8, d: u8) -> IpAddr {
         IpAddr::V4(Ipv4Addr::new(a, b, c, d))
+    }
+
+    fn v6(addr: &str) -> IpAddr {
+        IpAddr::V6(addr.parse::<Ipv6Addr>().expect("test IPv6 literal"))
+    }
+
+    #[test]
+    fn config_floor_pins_the_scope_without_env() {
+        // A pinned floor makes the policy independent of ambient env vars.
+        let strict = EgressPolicy::new(EgressConfig {
+            floor: Some(FloorMode::Strict),
+            ..Default::default()
+        });
+        assert!(!strict.allows(v4(10, 0, 0, 4), None)); // Strict floors RFC1918
+        let off = EgressPolicy::new(EgressConfig {
+            floor: Some(FloorMode::Off),
+            ..Default::default()
+        });
+        assert!(off.allows(v4(169, 254, 169, 254), None)); // Off floors nothing
     }
 
     #[test]
@@ -562,5 +840,148 @@ mod tests {
             "2606:4700::1111".parse().unwrap(),
             FloorMode::Strict
         ));
+    }
+
+    /// Static-record fixture: names answered by the policy, gated by allow-hosts.
+    fn statics(hosts: Option<&[&str]>, names: &[(&str, StaticTarget)]) -> EgressPolicy {
+        EgressPolicy::new(EgressConfig {
+            allowed_hosts: hosts.map(|h| h.iter().map(|s| s.to_string()).collect()),
+            static_names: names
+                .iter()
+                .map(|(n, t)| (n.to_string(), vec![*t]))
+                .collect(),
+            floor: Some(FloorMode::MetadataOnly),
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn static_records_answer_names_and_translate_host_local_ones() {
+        let p = statics(
+            Some(&["api.internal", "db.local:5432"]),
+            &[
+                ("api.internal", StaticTarget::Ip(v4(10, 0, 0, 5))),
+                ("db.local", StaticTarget::Host),
+            ],
+        );
+        assert!(p.dns_filter_active());
+
+        // A routable record is published as-is, looked up on the normalized name.
+        let api = p.static_answer("API.Internal.").expect("normalized lookup");
+        assert_eq!(api, vec![v4(10, 0, 0, 5)]);
+        assert_eq!(p.host_forward(v4(10, 0, 0, 5)), None);
+        assert!(p.static_answer("other.internal").is_none());
+
+        // A host-local record is published as the sentinel and translated back.
+        assert_eq!(p.static_answer("db.local"), Some(vec![HOST_SENTINEL]));
+        assert_eq!(p.host_forward(HOST_SENTINEL), Some(HOST_LOOPBACK));
+
+        // The allow-host entry grants the record's address with no CIDR entry
+        // covering it — the one thing naming a record does that listing an
+        // address cannot, and why `allowed_cidrs` stays addresses-only.
+        assert!(p.allows(v4(10, 0, 0, 5), Some(8080)));
+        assert!(!p.allows(v4(10, 0, 0, 6), Some(8080)));
+        // ...and the port on the other entry still binds its own record.
+        assert!(p.allows(HOST_SENTINEL, Some(5432)));
+        assert!(!p.allows(HOST_SENTINEL, Some(22)));
+    }
+
+    #[test]
+    fn allow_hosts_gate_static_records_by_name() {
+        // The whole point of the split: the port is written against the *name* in
+        // the allow-list, and binds the address that name was answered with.
+        let p = statics(
+            Some(&["db.local:5432"]),
+            &[("db.local", StaticTarget::Host)],
+        );
+        assert!(p.allows(HOST_SENTINEL, Some(5432)));
+        assert!(!p.allows(HOST_SENTINEL, Some(22))); // exposing Postgres must not expose SSH
+        assert!(!p.allows(HOST_SENTINEL, None)); // portless ICMP: no
+
+        // No port on the rule = every port on what it resolves to.
+        let open = statics(Some(&["open.local"]), &[("open.local", StaticTarget::Host)]);
+        assert!(open.allows(HOST_SENTINEL, Some(22)));
+        assert!(open.allows(HOST_SENTINEL, None));
+
+        // Answered by DNS, but no allow-host rule names it: resolvable, unreachable.
+        let unlisted = statics(Some(&["other.local"]), &[("db.local", StaticTarget::Host)]);
+        assert_eq!(
+            unlisted.static_answer("db.local"),
+            Some(vec![HOST_SENTINEL])
+        );
+        assert_eq!(unlisted.host_forward(HOST_SENTINEL), Some(HOST_LOOPBACK));
+        assert!(!unlisted.allows(HOST_SENTINEL, Some(5432)));
+        assert!(!unlisted.allows(HOST_SENTINEL, Some(22)));
+
+        // A record's address is still just an address: a CIDR rule covering it
+        // grants it, with no allow-host entry naming it at all.
+        let by_cidr = EgressPolicy::new(EgressConfig {
+            allowed_cidrs: Some(vec!["10.0.0.0/8".into()]),
+            static_names: vec![(
+                "api.internal".into(),
+                vec![StaticTarget::Ip(v4(10, 0, 0, 5))],
+            )],
+            ..Default::default()
+        });
+        assert!(by_cidr.allows(v4(10, 0, 0, 5), Some(8080)));
+    }
+
+    #[test]
+    fn unclaimed_sentinel_never_reaches_the_host() {
+        // No static record publishes it, so it translates to nothing and is denied
+        // — including under a Strict floor, where translating would otherwise hand
+        // a guest the host's loopback past the floor.
+        let p = EgressPolicy::unrestricted();
+        assert_eq!(p.host_forward(HOST_SENTINEL), None);
+        assert!(!p.allows(HOST_SENTINEL, Some(22)));
+        assert!(!p.allows(HOST_SENTINEL, None));
+        // Everything else is still wide open in this mode.
+        assert!(p.allows(v4(1, 1, 1, 1), Some(22)));
+
+        // Published but unrestricted: reachable on any port, which matches this
+        // mode already permitting the host's loopback directly.
+        let live = statics(None, &[("db.local", StaticTarget::Host)]);
+        assert!(!live.is_restricted());
+        assert!(live.allows(HOST_SENTINEL, Some(5432)));
+        assert!(live.allows(HOST_SENTINEL, Some(22)));
+    }
+
+    #[test]
+    fn host_record_needs_no_name_filter_but_a_resolver_earns_nothing() {
+        // No allow-host list = names are not filtered, so the record itself is the
+        // authorization; otherwise a Host record would be silently unreachable.
+        let p = EgressPolicy::new(EgressConfig {
+            allowed_cidrs: Some(vec!["1.1.1.1".into()]),
+            allowed_hosts: None,
+            static_names: vec![("db.local".into(), vec![StaticTarget::Host])],
+            floor: Some(FloorMode::MetadataOnly),
+        });
+        assert!(p.allows(HOST_SENTINEL, Some(5432)));
+        assert!(p.allows(HOST_SENTINEL, Some(22)));
+
+        // An upstream answer still earns nothing: those addresses come from the
+        // resolver, so `allowed_cidrs` keeps gating them.
+        p.learn_named("evil.test", &[(v4(9, 9, 9, 9), 300)]);
+        assert!(!p.allows(v4(9, 9, 9, 9), Some(443)));
+        assert!(p.allows(v4(1, 1, 1, 1), Some(443)));
+
+        // A name filter that omits the record puts it back out of reach.
+        let filtered = statics(Some(&["other.local"]), &[("db.local", StaticTarget::Host)]);
+        assert!(!filtered.allows(HOST_SENTINEL, Some(5432)));
+    }
+
+    #[test]
+    fn floor_beats_a_static_record_pointing_at_it() {
+        // A record onto the metadata range is answered but never reachable: the
+        // hard floor sits under the allow-list, not beside it.
+        let p = statics(
+            Some(&["meta.test"]),
+            &[("meta.test", StaticTarget::Ip(v4(169, 254, 169, 254)))],
+        );
+        assert_eq!(
+            p.static_answer("meta.test"),
+            Some(vec![v4(169, 254, 169, 254)])
+        );
+        assert!(!p.allows(v4(169, 254, 169, 254), Some(80)));
     }
 }

--- a/crates/smolvm-network/src/egress.rs
+++ b/crates/smolvm-network/src/egress.rs
@@ -113,7 +113,11 @@ pub enum StaticTarget {
 /// Split a trailing `:port` off an allow-list entry. Uses `host:port` /
 /// `[v6]:port` convention: bare host+colon is a v6 literal or CIDR. `None` =
 /// malformed port (caller drops the entry).
-fn split_port(entry: &str) -> Option<(&str, Option<u16>)> {
+///
+/// Public so the CLI validates `--allow-host` with the exact parser that later
+/// enforces it — a second implementation could disagree about where the port
+/// ends and silently widen an allow-list.
+pub fn split_port(entry: &str) -> Option<(&str, Option<u16>)> {
     let port = |p: &str| p.parse::<u16>().ok().filter(|p| *p != 0);
     if let Some(rest) = entry.strip_prefix('[') {
         let (addr, tail) = rest.split_once(']')?;

--- a/crates/smolvm-network/src/icmp_relay.rs
+++ b/crates/smolvm-network/src/icmp_relay.rs
@@ -408,10 +408,10 @@ fn parse_echo_reply(destination: IpAddr, bytes: &[u8]) -> Option<(u16, Vec<u8>)>
     Some((seq, bytes[8..].to_vec()))
 }
 
-/// Whether the gateway should relay a guest echo to this destination. Echo
-/// obeys the same egress policy as TCP/UDP (static CIDRs + DNS-learned IPs).
+/// Whether the gateway should relay a guest echo (portless, so any-port policy).
 pub fn should_relay_icmp(destination: IpAddr, egress: &EgressPolicy) -> bool {
-    egress.allows(destination)
+    // ICMP echo carries no port, so only any-port allow rules cover it.
+    egress.allows(destination, None)
 }
 
 /// Decode a guest IPv4 ICMP echo *request* captured off the raw socket (a full

--- a/crates/smolvm-network/src/lib.rs
+++ b/crates/smolvm-network/src/lib.rs
@@ -75,7 +75,7 @@ pub mod tcp_listeners;
 pub mod tcp_relay;
 pub mod udp_relay;
 
-pub use egress::EgressPolicy;
+pub use egress::{EgressConfig, EgressPolicy, FloorMode, StaticTarget};
 
 use socket2::Socket;
 use std::fmt;

--- a/crates/smolvm-network/src/lib.rs
+++ b/crates/smolvm-network/src/lib.rs
@@ -75,7 +75,7 @@ pub mod tcp_listeners;
 pub mod tcp_relay;
 pub mod udp_relay;
 
-pub use egress::{EgressConfig, EgressPolicy, FloorMode, StaticTarget};
+pub use egress::{split_port, EgressConfig, EgressPolicy, FloorMode, StaticTarget};
 
 use socket2::Socket;
 use std::fmt;

--- a/crates/smolvm-network/src/stack.rs
+++ b/crates/smolvm-network/src/stack.rs
@@ -212,6 +212,8 @@ fn run_network_stack(
         IpAddr::V6(config.gateway_ipv6),
         IpAddr::V6(link_local_from_mac(config.gateway_mac)),
     ];
+    // Static remaps need every TCP/53 SYN intercepted so the guest's own resolver doesn't win.
+    let intercept_dns_tcp = egress.has_static_dns();
     let relay_wake = Arc::new(queues.relay_wake.clone());
     let mut relays = TcpRelayTable::new(
         None,
@@ -225,6 +227,7 @@ fn run_network_stack(
         udp_relay::start_udp_relay(
             relay_wake.clone(),
             Arc::new(move || shutdown_queues.is_shutting_down()),
+            egress.clone(),
         )
     };
     let icmp_channels = {
@@ -269,7 +272,7 @@ fn run_network_stack(
             // - TCP SYN: pre-create a matching smoltcp socket + relay entry
             // - DNS UDP: allow through for gateway-side forwarding
             // - other UDP: pre-create the destination-keyed relay socket
-            match classify_guest_frame(frame, &gateway_addrs) {
+            match classify_guest_frame(frame, &gateway_addrs, intercept_dns_tcp) {
                 FrameAction::TcpSyn {
                     source,
                     destination,
@@ -763,11 +766,22 @@ enum DnsDecision {
     Forward { learn: bool },
 }
 
-/// Classify a query under the allow-host policy. When the DNS filter is
-/// inactive everything is forwarded (no learning); otherwise only allow-listed
-/// names are forwarded and learned, others get NXDOMAIN and unparseable ones
-/// SERVFAIL. Identical policy to the old `filtered_dns_response`.
+/// TTL on synthesized static answers (60s).
+const STATIC_DNS_TTL: u32 = 60;
+
+/// Returns a synthesized answer for a name the policy maps itself, or `None` to
+/// fall through to the normal allow-host path.
+fn static_dns_response(query: &[u8], egress: &EgressPolicy) -> Option<Vec<u8>> {
+    let ips = egress.static_answer(&dns::question_name(query)?)?;
+    Some(dns::build_ip_response(query, &ips, STATIC_DNS_TTL))
+}
+
+/// Classify a query: static names answered from the policy; otherwise standard
+/// allow-host filtering (forward if allowed, NXDOMAIN/SERVFAIL if not).
 fn classify_dns_query(query: &[u8], egress: &EgressPolicy) -> DnsDecision {
+    if let Some(response) = static_dns_response(query, egress) {
+        return DnsDecision::Immediate(response);
+    }
     if !egress.dns_filter_active() {
         return DnsDecision::Forward { learn: false };
     }
@@ -868,7 +882,7 @@ fn deliver_dns_responses(
         if let Some(pending) = gateway.pending_udp.remove(&response.id) {
             if let Some(answer) = response.answer {
                 if pending.learn {
-                    egress.learn_ip_records(&dns::answer_ip_records(&answer));
+                    egress.learn_ip_records(&answer);
                 }
                 let socket = sockets.get_mut::<UdpSocket>(dns_socket_handle);
                 let response_meta = UdpMetadata {
@@ -888,7 +902,7 @@ fn deliver_dns_responses(
                     conn.awaiting = None;
                     if let Some(answer) = response.answer {
                         if pending.learn {
-                            egress.learn_ip_records(&dns::answer_ip_records(&answer));
+                            egress.learn_ip_records(&answer);
                         }
                         frame_dns_tcp_response(conn, &answer);
                     }
@@ -1112,7 +1126,11 @@ fn smoltcp_now(clock: StdInstant) -> Instant {
     Instant::from_millis(elapsed.as_millis() as i64)
 }
 
-fn classify_guest_frame(frame: &[u8], gateway_addrs: &[IpAddr]) -> FrameAction {
+fn classify_guest_frame(
+    frame: &[u8],
+    gateway_addrs: &[IpAddr],
+    intercept_dns_tcp: bool,
+) -> FrameAction {
     let ethernet = match EthernetFrame::new_checked(frame) {
         Ok(frame) => frame,
         Err(_) => return FrameAction::Passthrough,
@@ -1158,11 +1176,11 @@ fn classify_guest_frame(frame: &[u8], gateway_addrs: &[IpAddr]) -> FrameAction {
             };
 
             if tcp.syn() && !tcp.ack() {
-                // DNS-over-TCP to the gateway itself is intercepted by the local
-                // listening sockets (process_dns_tcp), not relayed. TCP/53 to an
-                // external resolver (an allow-listed IP) is left to the egress
-                // relay so the policy still applies.
-                if tcp.dst_port() == DNS_SOCKET_PORT && gateway_addrs.contains(&dst_ip) {
+                // Intercept DNS/TCP to gateway (always) or to external resolvers
+                // when static remaps are configured.
+                if tcp.dst_port() == DNS_SOCKET_PORT
+                    && (intercept_dns_tcp || gateway_addrs.contains(&dst_ip))
+                {
                     FrameAction::Passthrough
                 } else {
                     FrameAction::TcpSyn {
@@ -1199,7 +1217,7 @@ fn classify_guest_frame(frame: &[u8], gateway_addrs: &[IpAddr]) -> FrameAction {
 /// behind the `fuzzing` feature so it never ships in a normal build.
 #[cfg(feature = "fuzzing")]
 pub fn fuzz_classify_guest_frame(frame: &[u8]) {
-    let _ = classify_guest_frame(frame, &[]);
+    let _ = classify_guest_frame(frame, &[], false);
 }
 
 #[cfg(test)]
@@ -1232,7 +1250,7 @@ mod tests {
         let gw = IpAddr::V4(Ipv4Addr::new(100, 96, 0, 1));
         // TCP/53 to the gateway -> handled by the local DNS listeners (Passthrough).
         assert_eq!(
-            classify_guest_frame(&tcp_syn_frame([100, 96, 0, 1], 53), &[gw]),
+            classify_guest_frame(&tcp_syn_frame([100, 96, 0, 1], 53), &[gw], false),
             FrameAction::Passthrough
         );
     }
@@ -1243,9 +1261,20 @@ mod tests {
         // TCP/53 to an external (allow-listed) resolver must go through the egress
         // relay, NOT be swallowed by the gateway DNS listeners.
         assert!(matches!(
-            classify_guest_frame(&tcp_syn_frame([1, 1, 1, 1], 53), &[gw]),
+            classify_guest_frame(&tcp_syn_frame([1, 1, 1, 1], 53), &[gw], false),
             FrameAction::TcpSyn { .. }
         ));
+    }
+
+    #[test]
+    fn dns_tcp_to_external_resolver_intercepted_when_remaps_exist() {
+        let gw = IpAddr::V4(Ipv4Addr::new(100, 96, 0, 1));
+        // With static remaps configured the guest's own resolver must not win, so
+        // every TCP/53 SYN lands on the gateway DNS listeners instead.
+        assert_eq!(
+            classify_guest_frame(&tcp_syn_frame([1, 1, 1, 1], 53), &[gw], true),
+            FrameAction::Passthrough
+        );
     }
 
     #[test]
@@ -1253,7 +1282,12 @@ mod tests {
         let gw = IpAddr::V4(Ipv4Addr::new(100, 96, 0, 1));
         // Only port 53 is intercepted; other gateway ports relay as usual.
         assert!(matches!(
-            classify_guest_frame(&tcp_syn_frame([100, 96, 0, 1], 443), &[gw]),
+            classify_guest_frame(&tcp_syn_frame([100, 96, 0, 1], 443), &[gw], false),
+            FrameAction::TcpSyn { .. }
+        ));
+        // ...even with the DNS/TCP intercept armed.
+        assert!(matches!(
+            classify_guest_frame(&tcp_syn_frame([1, 1, 1, 1], 443), &[gw], true),
             FrameAction::TcpSyn { .. }
         ));
     }

--- a/crates/smolvm-network/src/tcp_relay.rs
+++ b/crates/smolvm-network/src/tcp_relay.rs
@@ -852,6 +852,7 @@ fn flush_proxy_data(socket: &mut tcp::Socket<'_>, connection: &mut TrackedConnec
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::egress::EgressConfig;
 
     fn test_connection(to_proxy: SyncSender<Vec<u8>>) -> TrackedConnection {
         let (_from_proxy_tx, from_proxy) = mpsc::sync_channel(CHANNEL_CAPACITY);
@@ -920,7 +921,7 @@ mod tests {
         let external: IpAddr = "8.8.8.8".parse().unwrap();
         let table = TcpRelayTable::new(
             None,
-            EgressPolicy::from_allowed_cidrs(Some(&[])),
+            EgressPolicy::new(EgressConfig::from_allow_lists(Some(Vec::new()), None)),
             vec![gateway],
             Some(crate::GatewayHostService {
                 guest_port: 10_081,

--- a/crates/smolvm-network/src/tcp_relay.rs
+++ b/crates/smolvm-network/src/tcp_relay.rs
@@ -211,7 +211,8 @@ impl TcpRelayTable {
     }
 
     fn destination_allowed(&self, destination: SocketAddr) -> bool {
-        self.egress.allows(destination.ip())
+        self.egress
+            .allows(destination.ip(), Some(destination.port()))
             || (self
                 .host_service
                 .is_some_and(|service| service.guest_port == destination.port())
@@ -290,6 +291,13 @@ impl TcpRelayTable {
             return false;
         }
 
+        // Sentinel → host loopback; guest-facing smoltcp socket keeps the sentinel.
+        let connect_to = self
+            .egress
+            .host_forward(destination.ip())
+            .map(|ip| SocketAddr::new(ip, destination.port()))
+            .unwrap_or(destination);
+
         let rx_buffer = tcp::SocketBuffer::new(vec![0u8; TCP_RX_BUFFER_BYTES]);
         let tx_buffer = tcp::SocketBuffer::new(vec![0u8; TCP_TX_BUFFER_BYTES]);
         let mut socket = tcp::Socket::new(rx_buffer, tx_buffer);
@@ -319,7 +327,7 @@ impl TcpRelayTable {
                 pending_proxy_endpoints: Some(PendingProxyEndpoints {
                     from_smoltcp: to_proxy_rx,
                     to_smoltcp: from_proxy_tx,
-                    relay_target: RelayTarget::Connect(self.host_connect_addr(destination)),
+                    relay_target: RelayTarget::Connect(self.host_connect_addr(connect_to)),
                 }),
                 relay_spawned: false,
                 buffered_guest_data: None,

--- a/crates/smolvm-network/src/udp_relay.rs
+++ b/crates/smolvm-network/src/udp_relay.rs
@@ -91,6 +91,7 @@ pub struct UdpRelayChannels {
 pub fn start_udp_relay(
     reply_wake: Arc<WakePipe>,
     shutdown: Arc<dyn Fn() -> bool + Send + Sync>,
+    egress: EgressPolicy,
 ) -> UdpRelayChannels {
     let (to_relay_tx, to_relay_rx) = mpsc::sync_channel(CHANNEL_CAPACITY);
     let (from_relay_tx, from_relay_rx) = mpsc::sync_channel(CHANNEL_CAPACITY);
@@ -106,6 +107,7 @@ pub fn start_udp_relay(
                 thread_wake,
                 reply_wake,
                 shutdown,
+                egress,
             );
         });
 
@@ -130,6 +132,7 @@ fn run_udp_relay(
     wake: WakePipe,
     reply_wake: Arc<WakePipe>,
     shutdown: Arc<dyn Fn() -> bool + Send + Sync>,
+    egress: EgressPolicy,
 ) {
     let mut flows: HashMap<(SocketAddr, SocketAddr), UdpFlow> = HashMap::new();
     let mut recv_buf = vec![0u8; MAX_DATAGRAM_BYTES];
@@ -153,7 +156,12 @@ fn run_udp_relay(
                             );
                             continue;
                         }
-                        match create_flow_socket(datagram.destination) {
+                        // Sentinel → host loopback rewrite; flow key keeps the sentinel.
+                        let peer = egress
+                            .host_forward(datagram.destination.ip())
+                            .map(|ip| SocketAddr::new(ip, datagram.destination.port()))
+                            .unwrap_or(datagram.destination);
+                        match create_flow_socket(peer) {
                             Ok(socket) => {
                                 flows.insert(
                                     key,
@@ -427,9 +435,10 @@ impl Default for UdpSocketTable {
 
 /// Whether the gateway should relay a guest UDP datagram to this destination.
 /// DNS (:53) is excluded — it has its own intercept-and-filter path. Egress
-/// policy applies exactly as for TCP (static CIDRs + DNS-learned IPs).
+/// policy applies exactly as for TCP (static CIDRs + DNS-learned IPs). Host-
+/// service sentinels are rewritten to the host loopback by the relay thread.
 pub fn should_relay_udp(destination: SocketAddr, egress: &EgressPolicy) -> bool {
-    destination.port() != 53 && egress.allows(destination.ip())
+    destination.port() != 53 && egress.allows(destination.ip(), Some(destination.port()))
 }
 
 fn endpoint_to_socket_addr(endpoint: smoltcp::wire::IpEndpoint) -> SocketAddr {
@@ -481,6 +490,7 @@ mod tests {
         let channels = start_udp_relay(
             reply_wake.clone(),
             Arc::new(move || stop_flag.load(Ordering::Relaxed)),
+            EgressPolicy::unrestricted(),
         );
 
         let guest: SocketAddr = "100.96.0.2:40000".parse().unwrap();
@@ -517,6 +527,61 @@ mod tests {
     }
 
     #[test]
+    fn host_service_sentinel_reaches_the_host_over_udp() {
+        // A real host UDP server, exposed to the guest as a sentinel address on
+        // its own port: the datagram must arrive, and the reply must come back
+        // addressed from the sentinel the guest used, not from the loopback.
+        let server = HostUdpSocket::bind("127.0.0.1:0").unwrap();
+        let host_port = server.local_addr().unwrap().port();
+        let egress = EgressPolicy::new(crate::egress::EgressConfig {
+            allowed_hosts: Some(vec![format!("db.local:{host_port}")]),
+            static_names: vec![("db.local".into(), vec![crate::egress::StaticTarget::Host])],
+            ..Default::default()
+        });
+        let sentinel = SocketAddr::new(egress.static_answer("db.local").unwrap()[0], host_port);
+        assert!(should_relay_udp(sentinel, &egress));
+
+        let reply_wake = Arc::new(WakePipe::new());
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_flag = stop.clone();
+        let channels = start_udp_relay(
+            reply_wake.clone(),
+            Arc::new(move || stop_flag.load(Ordering::Relaxed)),
+            egress,
+        );
+
+        let guest: SocketAddr = "100.96.0.2:40001".parse().unwrap();
+        channels
+            .to_relay
+            .send(UdpDatagram {
+                guest,
+                destination: sentinel,
+                payload: b"ping".to_vec(),
+            })
+            .unwrap();
+        channels.relay_thread_wake.wake();
+
+        let mut buf = [0u8; 16];
+        server
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        let (len, peer) = server.recv_from(&mut buf).unwrap();
+        assert_eq!(&buf[..len], b"ping");
+        server.send_to(b"pong", peer).unwrap();
+
+        let reply = channels
+            .from_relay
+            .recv_timeout(Duration::from_secs(2))
+            .unwrap();
+        assert_eq!(reply.guest, guest);
+        assert_eq!(reply.destination, sentinel); // sourced from the sentinel
+        assert_eq!(reply.payload, b"pong");
+
+        stop.store(true, Ordering::Relaxed);
+        channels.relay_thread_wake.wake();
+    }
+
+    #[test]
     fn should_relay_respects_dns_carveout_and_policy() {
         let open = EgressPolicy::unrestricted();
         assert!(should_relay_udp("1.2.3.4:123".parse().unwrap(), &open));
@@ -524,7 +589,10 @@ mod tests {
 
         // Public CIDR — a private allow-list entry would be overridden by the
         // egress hard-floor (see egress.rs tests).
-        let restricted = EgressPolicy::from_allowed_cidrs(Some(&["8.8.8.0/24".into()]));
+        let restricted = EgressPolicy::new(crate::egress::EgressConfig::from_allow_lists(
+            Some(vec!["8.8.8.0/24".into()]),
+            None,
+        ));
         assert!(should_relay_udp(
             "8.8.8.3:123".parse().unwrap(),
             &restricted

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -1057,8 +1057,10 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
                     .map(|mapping| VirtioPortMapping::new(mapping.host, mapping.guest))
                     .collect();
                 let egress = smolvm_network::EgressPolicy::new(
-                    resources.allowed_cidrs.as_deref(),
-                    egress_refresh_hosts.as_deref(),
+                    smolvm_network::EgressConfig::from_allow_lists(
+                        resources.allowed_cidrs.clone(),
+                        egress_refresh_hosts.clone(),
+                    ),
                 );
                 let egress_path = egress_telemetry.map(|p| p.to_path_buf());
 

--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -327,12 +327,11 @@ pub fn launch_agent_vm_dynamic(
                 .iter()
                 .map(|(host, guest)| VirtioPortMapping::new(*host, *guest))
                 .collect();
-            let egress = smolvm_network::EgressPolicy::new(
-                smolvm_network::EgressConfig::from_allow_lists(
+            let egress =
+                smolvm_network::EgressPolicy::new(smolvm_network::EgressConfig::from_allow_lists(
                     config.resources.allowed_cidrs.clone(),
                     None,
-                ),
-            );
+                ));
 
             // The host/guest ends of the virtio-net channel are an AF_UNIX
             // stream: a socketpair fd on Unix, a per-VM path listener libkrun

--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -327,8 +327,11 @@ pub fn launch_agent_vm_dynamic(
                 .iter()
                 .map(|(host, guest)| VirtioPortMapping::new(*host, *guest))
                 .collect();
-            let egress = smolvm_network::EgressPolicy::from_allowed_cidrs(
-                config.resources.allowed_cidrs.as_deref(),
+            let egress = smolvm_network::EgressPolicy::new(
+                smolvm_network::EgressConfig::from_allow_lists(
+                    config.resources.allowed_cidrs.clone(),
+                    None,
+                ),
             );
 
             // The host/guest ends of the virtio-net channel are an AF_UNIX

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -60,7 +60,26 @@ fn resolve_egress_flags(
     allow_host: Vec<String>,
     outbound_localhost_only: bool,
     net: bool,
+    explicit_backend: Option<NetworkBackend>,
 ) -> smolvm::Result<(Vec<String>, bool, Option<Vec<String>>)> {
+    // A port grant is only honoured by the host-side stack. An egress policy
+    // already forces virtio-net, so the sole way to ask for something we cannot
+    // deliver is to pick TSI explicitly — refuse instead of silently granting
+    // every port, which is the failure mode that matters for an allow-list.
+    if explicit_backend == Some(NetworkBackend::Tsi) {
+        for entry in allow_cidr.iter().chain(allow_host.iter()) {
+            if crate::cli::parsers::has_port_suffix(entry) {
+                return Err(smolvm::Error::config(
+                    "--allow-host",
+                    format!(
+                        "port suffix in '{entry}' cannot be enforced by the tsi backend; \
+                         drop the port or use --net-backend virtio-net"
+                    ),
+                ));
+            }
+        }
+    }
+
     // Resolve hostnames to CIDRs — fail hard on resolution errors
     for host in &allow_host {
         let cidrs = crate::cli::parsers::resolve_host_to_cidrs(host)
@@ -1074,6 +1093,7 @@ impl RunCmd {
             self.allow_host,
             self.outbound_localhost_only,
             self.net,
+            self.net_backend,
         )?;
 
         let params = crate::cli::smolfile::build_create_params(
@@ -2995,6 +3015,7 @@ impl CreateCmd {
             self.allow_host,
             self.outbound_localhost_only,
             self.net,
+            self.net_backend,
         )?;
 
         let name = self
@@ -3186,6 +3207,7 @@ impl CreateCmd {
             self.allow_host.clone(),
             self.outbound_localhost_only,
             self.net,
+            self.net_backend,
         )?;
         let (network, allowed_cidrs, dns_filter_hosts) = smolmachine_egress_fields(
             manifest.network,

--- a/src/cli/parsers.rs
+++ b/src/cli/parsers.rs
@@ -99,7 +99,7 @@ pub fn record_mounts_to_runconfig_bindings(
 }
 
 // Network helpers delegated to the library.
-pub use smolvm::smolfile::{parse_cidr, resolve_host_to_cidrs};
+pub use smolvm::smolfile::{has_port_suffix, parse_cidr, resolve_host_to_cidrs};
 
 #[cfg(test)]
 mod tests {

--- a/src/smolfile.rs
+++ b/src/smolfile.rs
@@ -33,27 +33,27 @@ pub fn load(path: &Path) -> crate::Result<Smolfile> {
 /// Hostnames are resolved via the host DNS at VM start time and each result
 /// address is formatted with the correct prefix length.
 ///
-/// Rejects `host:port` syntax — port filtering is not supported by the TSI
-/// egress policy (all ports to a resolved IP are implicitly allowed).
+/// A trailing `:port` (or `[v6]:port`) narrows the grant to that port and is
+/// carried through onto every resolved CIDR, so the egress policy gates on it.
+/// Only the virtio-net stack enforces ports; callers that have explicitly
+/// selected TSI must reject a port suffix rather than silently granting every
+/// port — see `port_suffix_unsupported_on_tsi`.
 pub fn resolve_host_to_cidrs(host: &str) -> Result<Vec<String>, String> {
     use ipnet::IpNet;
     use std::net::{IpAddr, ToSocketAddrs};
 
-    // Try parsing as a bare IP first — must come before the ':' check so that
-    // IPv6 addresses like "::1" or "2001:db8::1" (which contain ':') are
-    // handled correctly rather than being rejected as host:port syntax.
+    // Try parsing as a bare IP first — must come before the port split so that
+    // IPv6 addresses like "::1" or "2001:db8::1" (which contain ':') are read as
+    // addresses rather than host:port.
     if let Ok(ip) = host.parse::<IpAddr>() {
         return Ok(vec![IpNet::from(ip).to_string()]);
     }
 
-    // Reject host:port syntax (e.g. "example.com:443").
-    if host.contains(':') {
-        return Err(format!(
-            "invalid hostname '{}': port suffixes are not supported. \
-             Use the hostname only (all ports are allowed to resolved IPs).",
-            host
-        ));
-    }
+    // Split with the policy's own parser, so what the CLI accepts and what the
+    // egress layer later enforces cannot drift apart.
+    let (host, port) = smolvm_network::split_port(host)
+        .ok_or_else(|| format!("invalid hostname '{host}': malformed port suffix"))?;
+    let suffix = port.map(|p| format!(":{p}")).unwrap_or_default();
 
     // Resolve hostname with a timeout to avoid hanging on slow/unreachable DNS.
     let host_owned = host.to_string();
@@ -76,7 +76,20 @@ pub fn resolve_host_to_cidrs(host: &str) -> Result<Vec<String>, String> {
         return Err(format!("'{}' resolved to no addresses", host));
     }
 
-    Ok(addrs)
+    // Carry the port grant onto every resolved CIDR so the policy narrows each
+    // one; without this the static entries would allow every port to those IPs
+    // and quietly defeat the gate the user asked for.
+    Ok(addrs.into_iter().map(|c| format!("{c}{suffix}")).collect())
+}
+
+/// Whether an allow-list entry carries a port suffix. TSI cannot enforce ports,
+/// so a caller that has explicitly selected it must refuse rather than grant
+/// every port.
+pub fn has_port_suffix(entry: &str) -> bool {
+    if entry.parse::<std::net::IpAddr>().is_ok() {
+        return false;
+    }
+    smolvm_network::split_port(entry).is_some_and(|(_, port)| port.is_some())
 }
 
 /// Parse and validate a CIDR specification (e.g., `"10.0.0.0/8"`, `"1.1.1.1"`).
@@ -123,13 +136,33 @@ mod tests {
     }
 
     #[test]
-    fn resolve_host_rejects_port_suffix() {
-        let err = resolve_host_to_cidrs("example.com:443").unwrap_err();
-        assert!(err.contains("port suffixes are not supported"), "{}", err);
+    fn resolve_host_carries_the_port_onto_every_cidr() {
+        // IP literals so the test never depends on DNS. The port must land on
+        // the CIDR, or the static allow entry would grant every port and defeat
+        // the gate the user asked for.
+        assert_eq!(
+            resolve_host_to_cidrs("1.2.3.4:443").unwrap(),
+            vec!["1.2.3.4/32:443".to_string()]
+        );
+        assert_eq!(
+            resolve_host_to_cidrs("[::1]:80").unwrap(),
+            vec!["::1/128:80".to_string()]
+        );
+        // No suffix → unchanged, every port allowed to the resolved IPs.
+        assert_eq!(
+            resolve_host_to_cidrs("1.2.3.4").unwrap(),
+            vec!["1.2.3.4/32".to_string()]
+        );
+    }
 
-        // Bracketed IPv6 with port must also be rejected.
-        let err = resolve_host_to_cidrs("[::1]:80").unwrap_err();
-        assert!(err.contains("port suffixes are not supported"), "{}", err);
+    #[test]
+    fn port_suffix_detection_ignores_bare_addresses() {
+        assert!(has_port_suffix("example.com:443"));
+        assert!(has_port_suffix("[::1]:80"));
+        assert!(!has_port_suffix("example.com"));
+        // A bare v6 literal is full of colons but carries no port.
+        assert!(!has_port_suffix("2001:db8::1"));
+        assert!(!has_port_suffix("10.0.0.0/8"));
     }
 
     #[test]


### PR DESCRIPTION
Rebases the smolvm-network egress additions (port-gated allow-list rules, static DNS names, host-loopback forwarding) onto current main, resolving the tcp_relay conflict by composing the two host remaps (the opt-in host sentinel and the gateway-IP loopback mapping), and fixes the DNS round-trip test to assert per-query-type answers so an A query yields the A record and an AAAA query yields the AAAA record.