### PR TITLE
Load device-resident LoRA policies through managed executors

### DIFF
--- a/crates/smolvm-cuda/src/client.rs
+++ b/crates/smolvm-cuda/src/client.rs
@@ -1517,6 +1517,23 @@ impl<S: Read + Write> Client<S> {
         }
     }
 
+    /// Publish selected device ranges into an immutable device-resident bundle.
+    /// The returned token is meaningful only to smolvm's local managed rollout
+    /// consumer; callers never receive a CUDA allocation handle or raw fd.
+    pub fn publish_tensor_bundle(
+        &mut self,
+        manifest: Vec<u8>,
+        tensors: Vec<(u64, u64)>,
+    ) -> Result<Vec<u8>> {
+        match self.call(
+            &Request::PublishTensorBundle { manifest, tensors },
+            Op::PublishTensorBundle,
+        )? {
+            Response::Data(token) => Ok(token),
+            _ => Err(CudaRpcError::Protocol("expected Data")),
+        }
+    }
+
     /// Zero-copy H2D via the shared region (data already written at `offset`).
     pub fn memcpy_shm_htod(
         &mut self,

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -32,8 +32,11 @@ const VHANDLE_TAG: u64 = 1 << 63;
 pub const CUDA_ERROR_NOT_FOUND: i32 = 500;
 pub const CUDA_ERROR_NOT_SUPPORTED: i32 = 801;
 
+#[cfg(unix)]
 const MAX_PUBLISHED_TENSORS: usize = 65_536;
+#[cfg(unix)]
 const MAX_PUBLISHED_MANIFEST: usize = 1 << 20;
+#[cfg(unix)]
 const MAX_PUBLISHED_BYTES: u64 = 16 << 30;
 
 /// One range inside a packed device-resident tensor bundle. Offsets are chosen

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -16,6 +16,10 @@ use crate::proto::{
 };
 use std::collections::{hash_map::Entry, HashMap};
 use std::io::{Read, Write};
+#[cfg(unix)]
+use std::os::fd::OwnedFd;
+#[cfg(unix)]
+use std::sync::{Arc, Mutex};
 
 /// `Ok(value)` or `Err(CUresult)` — a non-zero CUDA error code.
 pub type CuResult<T> = Result<T, i32>;
@@ -27,6 +31,48 @@ const VHANDLE_TAG: u64 = 1 << 63;
 /// `CUDA_ERROR_NOT_FOUND`.
 pub const CUDA_ERROR_NOT_FOUND: i32 = 500;
 pub const CUDA_ERROR_NOT_SUPPORTED: i32 = 801;
+
+const MAX_PUBLISHED_TENSORS: usize = 65_536;
+const MAX_PUBLISHED_MANIFEST: usize = 1 << 20;
+const MAX_PUBLISHED_BYTES: u64 = 16 << 30;
+
+/// One range inside a packed device-resident tensor bundle. Offsets are chosen
+/// by the host from the explicit source ranges; the caller's manifest cannot
+/// redirect a consumer to memory outside this allocation.
+#[cfg(unix)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PublishedTensorRange {
+    pub offset: u64,
+    pub size: u64,
+}
+
+/// An immutable allocation staged for a local managed consumer. `allocation`
+/// owns the CUDA-export fd; dropping an unconsumed bundle releases that driver
+/// reference automatically.
+#[cfg(unix)]
+#[derive(Debug)]
+pub struct DeviceTensorBundle {
+    pub allocation: OwnedFd,
+    pub allocation_size: u64,
+    pub manifest: Vec<u8>,
+    pub tensors: Vec<PublishedTensorRange>,
+}
+
+#[cfg(unix)]
+pub type TensorBundlePublisher =
+    dyn Fn(DeviceTensorBundle) -> CuResult<Vec<u8>> + Send + Sync + 'static;
+
+/// Process-local publication hook installed only by an isolated clone worker.
+/// The shared daemon intentionally leaves this unset: a request can therefore
+/// never use a shared CUDA context to name another session's allocation.
+#[cfg(unix)]
+static TENSOR_BUNDLE_PUBLISHER: Mutex<Option<Arc<TensorBundlePublisher>>> = Mutex::new(None);
+
+/// Install or clear the clone worker's tensor-bundle sink.
+#[cfg(unix)]
+pub fn set_tensor_bundle_publisher(publisher: Option<Arc<TensorBundlePublisher>>) {
+    *TENSOR_BUNDLE_PUBLISHER.lock().unwrap() = publisher;
+}
 
 /// M3b: one KERNEL node of a captured CUDA graph, in a portable form. `func` is
 /// the golden's `CUfunction` (re-resolved in the worker); `params` are the raw
@@ -356,6 +402,101 @@ pub trait Backend: Send {
     fn mem_import_handle(&mut self, _fd: i32) -> CuResult<u64> {
         Err(CUDA_ERROR_NOT_SUPPORTED)
     }
+}
+
+#[cfg(unix)]
+fn tensor_publish_stage<T>(stage: &str, result: CuResult<T>) -> CuResult<T> {
+    if let Err(error) = &result {
+        eprintln!("[cuda-tensor-publish] {stage} failed code={error}");
+    }
+    result
+}
+
+#[cfg(unix)]
+fn publish_tensor_bundle(
+    b: &mut dyn Backend,
+    device: i32,
+    manifest: Vec<u8>,
+    tensors: Vec<(u64, u64)>,
+) -> CuResult<Vec<u8>> {
+    use std::os::fd::FromRawFd;
+
+    if manifest.len() > MAX_PUBLISHED_MANIFEST
+        || tensors.is_empty()
+        || tensors.len() > MAX_PUBLISHED_TENSORS
+        || tensors.iter().any(|&(dptr, size)| dptr == 0 || size == 0)
+    {
+        return Err(CUDA_ERROR_INVALID_HANDLE);
+    }
+    let publisher = TENSOR_BUNDLE_PUBLISHER
+        .lock()
+        .unwrap()
+        .clone()
+        .ok_or(CUDA_ERROR_NOT_SUPPORTED)?;
+    let payload_size = tensors.iter().try_fold(0u64, |total, &(_, size)| {
+        total.checked_add(size).ok_or(CUDA_ERROR_INVALID_HANDLE)
+    })?;
+    if payload_size > MAX_PUBLISHED_BYTES {
+        return Err(CUDA_ERROR_INVALID_HANDLE);
+    }
+    let granularity = tensor_publish_stage(
+        "allocation granularity",
+        b.mem_get_allocation_granularity(device, 0),
+    )?
+    .max(1 << 16);
+    let allocation_size = payload_size
+        .checked_add(granularity - 1)
+        .ok_or(CUDA_ERROR_INVALID_HANDLE)?
+        / granularity
+        * granularity;
+    let handle = tensor_publish_stage(
+        "exportable allocation",
+        b.mem_create_exportable(allocation_size, device),
+    )?;
+    let va = match b.mem_address_reserve(allocation_size, 0) {
+        Ok(va) => va,
+        Err(error) => {
+            eprintln!("[cuda-tensor-publish] address reservation failed code={error}");
+            let _ = b.mem_release(handle);
+            return Err(error);
+        }
+    };
+    let mut mapped = false;
+    let staged: CuResult<DeviceTensorBundle> = (|| {
+        tensor_publish_stage("allocation map", b.mem_map(va, allocation_size, 0, handle))?;
+        mapped = true;
+        tensor_publish_stage(
+            "allocation access",
+            b.mem_set_access(va, allocation_size, device),
+        )?;
+        let mut offset = 0u64;
+        let mut ranges = Vec::with_capacity(tensors.len());
+        for (dptr, size) in tensors {
+            tensor_publish_stage("device copy", b.memcpy_dtod(va + offset, dptr, size))?;
+            ranges.push(PublishedTensorRange { offset, size });
+            offset += size;
+        }
+        // The export must not become visible before work on framework-owned
+        // streams has settled and every D2D copy into the immutable allocation
+        // is complete.
+        tensor_publish_stage("copy synchronization", b.ctx_synchronize())?;
+        let fd = tensor_publish_stage("allocation export", b.mem_export_handle(handle))?;
+        // SAFETY: a successful backend export transfers one newly owned POSIX
+        // descriptor; OwnedFd closes it on every callback/error path.
+        let allocation = unsafe { OwnedFd::from_raw_fd(fd) };
+        Ok(DeviceTensorBundle {
+            allocation,
+            allocation_size,
+            manifest,
+            tensors: ranges,
+        })
+    })();
+    if mapped {
+        let _ = b.mem_unmap(va, allocation_size);
+    }
+    let _ = b.mem_address_free(va, allocation_size);
+    let _ = b.mem_release(handle);
+    tensor_publish_stage("parent publication channel", publisher(staged?))
 }
 
 /// Per-connection opaque→raw handle translation. Ids are dense and monotonic so
@@ -2189,6 +2330,15 @@ fn translate_dptrs(trans: &[(u64, u64, u64)], req: Request) -> Request {
             c: xlat(trans, c),
             ldc,
         },
+        Request::PublishTensorBundle {
+            manifest,
+            mut tensors,
+        } => {
+            for (dptr, _) in &mut tensors {
+                *dptr = xlat(trans, *dptr);
+            }
+            Request::PublishTensorBundle { manifest, tensors }
+        }
         // LibCall (cuBLAS/cuDNN) device-pointer args are translated TYPED in the
         // generated dispatch via `gpu::dptr_resolve` (a byte-scan of the packed,
         // mixed-width arg buffer would mis-align and corrupt scalars), driven by
@@ -4586,6 +4736,17 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         Request::MemGetAllocationGranularity { device, flags } => b
             .mem_get_allocation_granularity(dev(sess, device), flags)
             .map(Response::Bytes),
+        Request::PublishTensorBundle { manifest, tensors } => {
+            #[cfg(unix)]
+            {
+                publish_tensor_bundle(b, sess.device_base, manifest, tensors).map(Response::Data)
+            }
+            #[cfg(not(unix))]
+            {
+                let _ = (manifest, tensors);
+                Err(CUDA_ERROR_NOT_SUPPORTED)
+            }
+        }
     })();
     let (status, resp) = match r {
         Ok(resp) => (0, resp),

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -1235,7 +1235,7 @@ pub fn prewarm_clone_worker(b: &mut dyn Backend) {
         return;
     }
     let t0 = std::time::Instant::now();
-    let mods: Vec<u64> = MOD_IMAGES.with(|m| m.borrow().keys().copied().collect());
+    let mods = staged_module_handles();
     let nmods = mods.len();
     for g in mods {
         let _ = xlat_mod(b, g);
@@ -1515,23 +1515,12 @@ pub fn set_handle_trans(
     }
     MOD_TRANS.with(|m| m.borrow_mut().clear());
     FUNC_TRANS.with(|m| m.borrow_mut().clear());
-    MOD_IMAGES.with(|m| {
-        let mut m = m.borrow_mut();
-        m.clear();
-        m.extend(mod_images.iter().cloned());
-    });
-    FUNC_META.with(|m| {
-        let mut m = m.borrow_mut();
-        m.clear();
-        m.extend(
-            func_meta
-                .iter()
-                .cloned()
-                .map(|(f, gm, n, a)| (f, (gm, n, a))),
-        );
-    });
-    // Process-global copies too, so a channel served on a thread that was
-    // never seeded still lazy-resolves instead of leaking golden handles.
+    // Lazy source state is immutable for the worker lifetime and can be tens
+    // of megabytes. Keep one process-global copy instead of duplicating every
+    // module image and function record into this thread as well; all serving
+    // threads already fall back to these maps before resolving a handle.
+    MOD_IMAGES.with(|m| m.borrow_mut().clear());
+    FUNC_META.with(|m| m.borrow_mut().clear());
     *MOD_IMAGES_GLOBAL.lock().unwrap() = Some(mod_images.into_iter().collect());
     *FUNC_META_GLOBAL.lock().unwrap() = Some(
         func_meta
@@ -1543,6 +1532,19 @@ pub fn set_handle_trans(
     *EVENT_TRANS_GLOBAL.lock().unwrap() = Some(events.iter().copied().collect());
     put_h(&STREAM_TRANS, streams);
     put_h(&EVENT_TRANS, events);
+}
+
+fn staged_module_handles() -> Vec<u64> {
+    let local: Vec<u64> = MOD_IMAGES.with(|m| m.borrow().keys().copied().collect());
+    if !local.is_empty() {
+        return local;
+    }
+    MOD_IMAGES_GLOBAL
+        .lock()
+        .unwrap()
+        .as_ref()
+        .map(|images| images.keys().copied().collect())
+        .unwrap_or_default()
 }
 
 /// Lazily reload the golden module `golden` in THIS worker's context (once),
@@ -3594,7 +3596,7 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
                 // the lazy paths to retry; later sessions adopt from the
                 // registry.
                 if prereplay_enabled() {
-                    let mods: Vec<u64> = MOD_IMAGES.with(|m| m.borrow().keys().copied().collect());
+                    let mods = staged_module_handles();
                     if !mods.is_empty() {
                         let t0 = std::time::Instant::now();
                         let mut loaded = 0u32;
@@ -5637,6 +5639,37 @@ mod tests {
             ),
             other => panic!("expected param data, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn clone_handle_sources_are_available_to_unseeded_threads() {
+        let golden_module = 0x6f00_0000_0000_0001;
+        let golden_function = 0x6f00_0000_0000_0002;
+        let golden_stream = 0x6f00_0000_0000_0003;
+        let worker_stream = 0x6f00_0000_0000_0004;
+        let golden_event = 0x6f00_0000_0000_0005;
+        let worker_event = 0x6f00_0000_0000_0006;
+        set_handle_trans(
+            vec![(golden_module, vec![1, 2, 3, 4])],
+            vec![(golden_function, golden_module, "vecadd".into(), Vec::new())],
+            vec![(golden_stream, worker_stream)],
+            vec![(golden_event, worker_event)],
+        );
+
+        std::thread::spawn(move || {
+            assert!(MOD_IMAGES.with(|images| images.borrow().is_empty()));
+            assert!(FUNC_META.with(|functions| functions.borrow().is_empty()));
+            assert!(staged_module_handles().contains(&golden_module));
+            assert_eq!(xlat_stream(golden_stream), worker_stream);
+            assert_eq!(xlat_event(golden_event), worker_event);
+
+            let mut backend = CpuBackend::default();
+            let worker_function = xlat_func(&mut backend, golden_function);
+            assert_ne!(worker_function, 0);
+            assert_ne!(worker_function, golden_function);
+        })
+        .join()
+        .unwrap();
     }
 
     #[test]

--- a/crates/smolvm-cuda/src/proto.rs
+++ b/crates/smolvm-cuda/src/proto.rs
@@ -141,6 +141,12 @@ pub enum Op {
     /// Pin this session to a host GPU: guest device 0 maps to host device N
     /// and the guest sees exactly one device (CUDA_VISIBLE_DEVICES-style).
     SetDeviceBase = 0xE9,
+    /// Publish selected device-memory ranges as one immutable, device-resident
+    /// tensor bundle. This is a smolvm control-plane primitive rather than a
+    /// CUDA IPC emulation: the host copies only the explicitly named ranges
+    /// into a dedicated exportable allocation and returns an opaque one-use
+    /// token for a managed local consumer.
+    PublishTensorBundle = 0xEA,
 }
 
 impl Op {
@@ -211,6 +217,7 @@ impl Op {
             0xE1 => Op::MemCreate,
             0xE8 => Op::MemCreateVh,
             0xE9 => Op::SetDeviceBase,
+            0xEA => Op::PublishTensorBundle,
             0xE2 => Op::MemMap,
             0xE3 => Op::MemSetAccess,
             0xE4 => Op::MemUnmap,
@@ -590,6 +597,13 @@ pub enum Request {
         device: i32,
         flags: u32,
     },
+    /// Publish device ranges plus caller-defined tensor metadata. `manifest`
+    /// describes names/dtypes/shapes; the host owns layout offsets and never
+    /// trusts the manifest to select additional memory.
+    PublishTensorBundle {
+        manifest: Vec<u8>,
+        tensors: Vec<(u64, u64)>,
+    },
 }
 
 /// A decoded successful response body (the `status == 0` payload).
@@ -666,7 +680,14 @@ impl<'a> Cur<'a> {
         Ok(u64::from_le_bytes(self.take(8)?.try_into().unwrap()))
     }
     fn bytes(&mut self) -> io::Result<Vec<u8>> {
-        let n = self.u64()? as usize;
+        let n = usize::try_from(self.u64()?).map_err(|_| bad())?;
+        Ok(self.take(n)?.to_vec())
+    }
+    fn bytes_bounded(&mut self, maximum: usize) -> io::Result<Vec<u8>> {
+        let n = usize::try_from(self.u64()?).map_err(|_| bad())?;
+        if n > maximum {
+            return Err(bad());
+        }
         Ok(self.take(n)?.to_vec())
     }
     fn string(&mut self) -> io::Result<String> {
@@ -1212,6 +1233,15 @@ pub fn encode_request(req: &Request) -> Vec<u8> {
             w_i32(&mut b, *device);
             w_u32(&mut b, *flags);
         }
+        Request::PublishTensorBundle { manifest, tensors } => {
+            w_u8(&mut b, Op::PublishTensorBundle as u8);
+            w_bytes(&mut b, manifest);
+            w_u32(&mut b, tensors.len() as u32);
+            for (dptr, size) in tensors {
+                w_u64(&mut b, *dptr);
+                w_u64(&mut b, *size);
+            }
+        }
     }
     b
 }
@@ -1497,6 +1527,21 @@ pub fn decode_request(payload: &[u8]) -> io::Result<Request> {
             device: c.i32()?,
             flags: c.u32()?,
         },
+        Op::PublishTensorBundle => {
+            let manifest = c.bytes_bounded(1 << 20)?;
+            let count = c.u32()? as usize;
+            if count > 65_536 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "tensor bundle contains too many ranges",
+                ));
+            }
+            let mut tensors = Vec::with_capacity(count);
+            for _ in 0..count {
+                tensors.push((c.u64()?, c.u64()?));
+            }
+            Request::PublishTensorBundle { manifest, tensors }
+        }
     })
 }
 
@@ -1563,7 +1608,9 @@ pub fn decode_response(op: Op, payload: &[u8]) -> io::Result<(i32, Response)> {
         Op::GraphGetNodes => Response::Bytes(c.u64()?),
         Op::StreamCaptureInfo => Response::Pair(c.u64()?, c.u64()?),
         Op::MemAlloc => Response::Dptr(c.u64()?),
-        Op::MemcpyDtoH | Op::DeviceGetUuid | Op::FuncGetParamInfo => Response::Data(c.bytes()?),
+        Op::MemcpyDtoH | Op::DeviceGetUuid | Op::FuncGetParamInfo | Op::PublishTensorBundle => {
+            Response::Data(c.bytes()?)
+        }
         Op::MemGetInfo => Response::Pair(c.u64()?, c.u64()?),
         // nvcomp calls carry their own nvcompStatus in the body (transport
         // status stays 0): TempSize -> (status, temp_bytes); Decompress -> status.
@@ -1775,6 +1822,10 @@ mod tests {
         });
         roundtrip(Request::EventQuery { event: 4 });
         roundtrip(Request::ThreadExchangeCaptureMode { mode: 2 });
+        roundtrip(Request::PublishTensorBundle {
+            manifest: br#"{"name":"adapter"}"#.to_vec(),
+            tensors: vec![(0x1000, 64), (0x2200, 128)],
+        });
     }
 
     #[test]
@@ -1792,6 +1843,10 @@ mod tests {
             (Op::StreamCreate, Response::Handle(21)),
             (Op::EventCreate, Response::Handle(22)),
             (Op::EventElapsedTime, Response::Millis(1.25)),
+            (
+                Op::PublishTensorBundle,
+                Response::Data(b"one-use-token".to_vec()),
+            ),
             (Op::ModuleUnload, Response::Ok),
             (Op::MemsetD8, Response::Ok),
         ] {
@@ -1800,6 +1855,17 @@ mod tests {
             assert_eq!(status, 0);
             assert_eq!(dec, resp);
         }
+    }
+
+    #[test]
+    fn tensor_publication_rejects_an_oversized_manifest_before_copying_it() {
+        let mut encoded = vec![Op::PublishTensorBundle as u8];
+        encoded.extend_from_slice(&((1 << 20) as u64 + 1).to_le_bytes());
+        encoded.resize(encoded.len() + (1 << 20) + 1, 0);
+        encoded.extend_from_slice(&1u32.to_le_bytes());
+        encoded.extend_from_slice(&0x1000u64.to_le_bytes());
+        encoded.extend_from_slice(&64u64.to_le_bytes());
+        assert!(decode_request(&encoded).is_err());
     }
 
     #[test]

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -46,6 +46,7 @@ const CUDA_ERROR_INITIALIZATION: c_int = 3;
 const CUDA_ERROR_INVALID_DEVICE_POINTER: c_int = 17;
 const CUDA_ERROR_INVALID_RESOURCE_HANDLE: c_int = 400;
 const CUDA_ERROR_NO_DEVICE: c_int = 100;
+const CUDA_ERROR_NOT_SUPPORTED: c_int = 801;
 const CUDA_ERROR_UNKNOWN: c_int = 999;
 
 // cudaMemcpyKind
@@ -260,6 +261,7 @@ fn map_err(e: CudaRpcError) -> c_int {
             2 => CUDA_ERROR_MEMORY_ALLOCATION,
             200 | 218 => CUDA_ERROR_INVALID_VALUE, // invalid image / PTX
             400 => CUDA_ERROR_INVALID_RESOURCE_HANDLE,
+            801 => CUDA_ERROR_NOT_SUPPORTED,
             other => {
                 if std::env::var_os("SMOLVM_CUDA_SHIM_TRACE").is_some() {
                     eprintln!("[map-err] unmapped driver code {other}");
@@ -311,6 +313,106 @@ pub extern "C" fn smolvm_cudart_fence() {
             let _ = st.client.drain();
         }
     }
+}
+
+fn tensor_publish_sync(client: &mut Client<Stream>) -> Result<(), CudaRpcError> {
+    client.drain()?;
+    let request = smolvm_cuda::proto::encode_request(&smolvm_cuda::proto::Request::CtxSynchronize);
+    let response = client.raw_call(&request)?;
+    if response.len() < 4 {
+        return Err(CudaRpcError::Protocol("short forced synchronize response"));
+    }
+    let status = i32::from_le_bytes(response[..4].try_into().unwrap());
+    if status != 0 {
+        return Err(CudaRpcError::Cuda(status));
+    }
+    match client.take_sticky() {
+        0 => Ok(()),
+        status => Err(CudaRpcError::Cuda(status)),
+    }
+}
+
+/// Publish selected CUDA tensors to smolvm's managed rollout consumer without
+/// serializing a checkpoint through guest RAM or disk. This is intentionally a
+/// smolvm-specific ABI rather than an implementation of generic CUDA IPC.
+///
+/// On success, `token_len` receives the opaque token length and `token` receives
+/// those bytes. `token_capacity` must be at least 64 bytes; smaller buffers are
+/// rejected before any allocation is published.
+#[no_mangle]
+pub extern "C" fn smolvm_cuda_publish_tensor_bundle(
+    manifest: *const u8,
+    manifest_len: usize,
+    dptrs: *const u64,
+    sizes: *const u64,
+    count: usize,
+    token: *mut u8,
+    token_capacity: usize,
+    token_len: *mut usize,
+) -> c_int {
+    if manifest_len > 1 << 20
+        || count == 0
+        || count > 65_536
+        || (manifest_len != 0 && manifest.is_null())
+        || dptrs.is_null()
+        || sizes.is_null()
+        || token.is_null()
+        || token_capacity < 64
+        || token_len.is_null()
+    {
+        return set_last(CUDA_ERROR_INVALID_VALUE);
+    }
+    // SAFETY: the caller promises readable arrays of `count` u64s and a
+    // readable manifest of `manifest_len` bytes for the duration of this call.
+    let manifest = if manifest_len == 0 {
+        Vec::new()
+    } else {
+        unsafe { std::slice::from_raw_parts(manifest, manifest_len) }.to_vec()
+    };
+    let dptrs = unsafe { std::slice::from_raw_parts(dptrs, count) };
+    let sizes = unsafe { std::slice::from_raw_parts(sizes, count) };
+    if dptrs
+        .iter()
+        .zip(sizes)
+        .any(|(&dptr, &size)| dptr == 0 || size == 0)
+    {
+        return set_last(CUDA_ERROR_INVALID_VALUE);
+    }
+    // Quiesce framework-owned streams before the host copies their tensors.
+    // This idempotent preflight is also the clone-boundary reconnect barrier:
+    // the first post-restore call can race the inherited socket reset, so use
+    // the transport-safe retry path before the deliberately at-most-once
+    // publication request.
+    let trace = std::env::var_os("SMOLVM_CUDA_SHIM_TRACE").is_some();
+    if trace {
+        eprintln!("[tensor-publish] reconnect/sync preflight");
+    }
+    if let Err(error) = with_client_retrying(tensor_publish_sync) {
+        return set_last(error);
+    }
+    if trace {
+        eprintln!("[tensor-publish] preflight complete; sending publication");
+    }
+    let tensors = dptrs.iter().copied().zip(sizes.iter().copied()).collect();
+    // Publication is not retried implicitly: once the host has accepted a
+    // bundle, a lost reply may leave a short-lived orphan that its TTL reaps;
+    // replaying here would publish duplicate driver references.
+    let published = with_client(|client| client.publish_tensor_bundle(manifest, tensors));
+    let published = match published {
+        Ok(published) => published,
+        Err(error) => return set_last(error),
+    };
+    if trace {
+        eprintln!("[tensor-publish] publication accepted");
+    }
+    // SAFETY: token_len was validated non-null above.
+    unsafe { token_len.write(published.len()) };
+    if published.len() > token_capacity {
+        return set_last(CUDA_ERROR_INVALID_VALUE);
+    }
+    // SAFETY: the caller supplied at least `token_capacity` writable bytes.
+    unsafe { std::ptr::copy_nonoverlapping(published.as_ptr(), token, published.len()) };
+    CUDA_SUCCESS
 }
 
 // ---- driver-shim bridge -------------------------------------------------------

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -31,3 +31,27 @@ result = client.generate(
     logprobs=1,
 )
 ```
+
+For colocated CUDA trainers, `publish_device_adapter` replaces the checkpoint
+write with an immutable device allocation. Register a mode-0600 sidecar socket,
+then publish the returned one-use token:
+
+```python
+from peft import get_peft_model_state_dict
+from smolvm_rollout import publish_device_adapter
+
+state = get_peft_model_state_dict(model)
+token = publish_device_adapter(state, model.peft_config[model.active_adapter].to_dict())
+client.publish_device_policy("experiment-a", "step-41", token)
+```
+
+PyTorch synchronization is automatic. Other CUDA frameworks pass their own
+stream barrier with `synchronize=` before smolvm packs the immutable allocation.
+Publish at an optimizer-step boundary while the framework has stopped mutating
+the selected adapter tensors.
+
+The rollout process runs `DeviceAdapterServer` with framework load/unload
+callbacks. `import_torch_device_adapter` provides named PyTorch views over the
+received CUDA allocation; the server retains them until smolvm drains active
+requests and the unload callback succeeds. Filesystem publication remains the
+fallback when a framework has no device-adapter callback.

--- a/sdks/python/src/smolvm_rollout/__init__.py
+++ b/sdks/python/src/smolvm_rollout/__init__.py
@@ -1,5 +1,22 @@
 """Framework-neutral client for smolvm fused rollout executors."""
 
 from .client import RolloutClient, RolloutError, adapter_sha256
+from .device_handoff import (
+    DeviceAdapterBundle,
+    DeviceAdapterServer,
+    DeviceTensor,
+    publish_device_adapter,
+)
+from .torch_handoff import TorchDeviceAdapter, import_torch_device_adapter
 
-__all__ = ["RolloutClient", "RolloutError", "adapter_sha256"]
+__all__ = [
+    "DeviceAdapterBundle",
+    "DeviceAdapterServer",
+    "DeviceTensor",
+    "RolloutClient",
+    "RolloutError",
+    "TorchDeviceAdapter",
+    "adapter_sha256",
+    "publish_device_adapter",
+    "import_torch_device_adapter",
+]

--- a/sdks/python/src/smolvm_rollout/client.py
+++ b/sdks/python/src/smolvm_rollout/client.py
@@ -110,6 +110,7 @@ class RolloutClient:
         *,
         endpoint: str,
         adapter_root: str | os.PathLike[str],
+        device_adapter_socket: str | os.PathLike[str] | None = None,
         fallback_pool: str | None = None,
         max_concurrent_requests: int = 32,
         max_queue_depth: int = 256,
@@ -128,6 +129,8 @@ class RolloutClient:
         }
         if fallback_pool is not None:
             desired["fallbackPool"] = fallback_pool
+        if device_adapter_socket is not None:
+            desired["deviceAdapterSocket"] = str(Path(device_adapter_socket).resolve())
         try:
             return self._request("POST", "/rollout-executors", desired)
         except RolloutError as error:
@@ -138,6 +141,7 @@ class RolloutClient:
             "backend": current["backend"],
             "endpoint": current["endpoint"],
             "adapterRoot": current["adapterRoot"],
+            "deviceAdapterSocket": current.get("deviceAdapterSocket"),
             "fallbackPool": current.get("fallbackPool"),
             "maxConcurrentRequests": current["maxConcurrentRequests"],
             "maxQueueDepth": current["maxQueueDepth"],
@@ -146,6 +150,7 @@ class RolloutClient:
             "backend": "vllm",
             "endpoint": endpoint,
             "adapterRoot": desired["adapterRoot"],
+            "deviceAdapterSocket": desired.get("deviceAdapterSocket"),
             "fallbackPool": fallback_pool,
             "maxConcurrentRequests": max_concurrent_requests,
             "maxQueueDepth": max_queue_depth,
@@ -191,6 +196,44 @@ class RolloutClient:
                 "retainPrevious": retain_previous,
             },
         )
+
+    def publish_device_policy(
+        self,
+        policy: str,
+        version: str,
+        tensor_bundle_token: bytes | str,
+        *,
+        retain_previous: bool = False,
+    ) -> dict[str, Any]:
+        """Atomically publish a one-use device-resident LoRA allocation."""
+
+        token = (
+            tensor_bundle_token.hex()
+            if isinstance(tensor_bundle_token, bytes)
+            else tensor_bundle_token
+        )
+        if len(token) != 64:
+            raise ValueError("tensor bundle token must contain exactly 32 bytes")
+        try:
+            bytes.fromhex(token)
+        except ValueError as error:
+            raise ValueError("tensor bundle token must be hexadecimal") from error
+        path = f"/rollout-executors/{self.executor}/device-policies"
+        body = {
+            "policy": policy,
+            "version": version,
+            "tensorBundleToken": token,
+            "retainPrevious": retain_previous,
+        }
+        try:
+            return self._request("POST", path, body)
+        except RolloutError as error:
+            if error.status != 0:
+                raise
+            # The token is one-use, but the controller remembers its digest.
+            # Reusing the same token is therefore safe when a lost response
+            # leaves it ambiguous whether the first request was accepted.
+            return self._request("POST", path, body)
 
     def retire_policy(self, policy: str, version: str) -> None:
         """Stop routing and unload a policy version after its requests drain."""

--- a/sdks/python/src/smolvm_rollout/device_handoff.py
+++ b/sdks/python/src/smolvm_rollout/device_handoff.py
@@ -1,0 +1,536 @@
+"""Framework-neutral receiver for smolvm device-resident policy adapters."""
+
+from __future__ import annotations
+
+import array
+import ctypes
+import functools
+import json
+import os
+import socket
+import stat
+import struct
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from collections.abc import Iterable, Mapping
+from typing import Any, Callable
+
+
+_REQUEST_MAGIC = b"SMVDLH01"
+_RESPONSE_MAGIC = b"SMVDHR01"
+_HEADER = struct.Struct("<8sB3xIIQ4x")
+_RESPONSE = struct.Struct("<8siI")
+_OP_HEALTH = 0
+_OP_LOAD = 1
+_OP_UNLOAD = 2
+_MAX_MODEL_BYTES = 512
+_MAX_METADATA_BYTES = (2 << 20) + 64
+_MAX_RESPONSE_BYTES = 1 << 20
+_DEFAULT_IO_TIMEOUT_SECS = 30.0
+_DEFAULT_SHIM = "/opt/smolvm-cuda/libcudart-shim.so"
+_DTYPES = {
+    "bool",
+    "int8",
+    "uint8",
+    "int16",
+    "int32",
+    "int64",
+    "float8_e4m3fn",
+    "float8_e5m2",
+    "float16",
+    "bfloat16",
+    "float32",
+    "float64",
+}
+_DTYPE_SIZES = {
+    "bool": 1,
+    "int8": 1,
+    "uint8": 1,
+    "float8_e4m3fn": 1,
+    "float8_e5m2": 1,
+    "int16": 2,
+    "float16": 2,
+    "bfloat16": 2,
+    "int32": 4,
+    "float32": 4,
+    "int64": 8,
+    "float64": 8,
+}
+
+
+@dataclass(frozen=True)
+class DeviceTensor:
+    """One named contiguous tensor range inside an imported allocation."""
+
+    name: str
+    shape: tuple[int, ...]
+    dtype: str
+    offset: int
+    size: int
+
+
+class DeviceAdapterBundle:
+    """Descriptor and validated manifest delivered to a framework loader."""
+
+    def __init__(
+        self,
+        descriptor: int,
+        allocation_size: int,
+        manifest: dict[str, Any],
+        tensors: tuple[DeviceTensor, ...],
+    ) -> None:
+        self.descriptor = descriptor
+        self.allocation_size = allocation_size
+        self.manifest = manifest
+        self.tensors = tensors
+
+    def _close(self) -> None:
+        if self.descriptor >= 0:
+            os.close(self.descriptor)
+            self.descriptor = -1
+
+
+@dataclass
+class _LoadedAdapter:
+    bundle: DeviceAdapterBundle
+    owner: Any
+    framework_unloaded: bool = False
+
+
+LoadAdapter = Callable[[str, DeviceAdapterBundle], Any]
+UnloadAdapter = Callable[[str, Any], None]
+
+
+@functools.lru_cache(maxsize=4)
+def _publisher(path: str):
+    # Keep the GIL while the host copies the selected ranges so another Python
+    # training thread cannot enqueue an optimizer update halfway through the
+    # snapshot boundary.
+    library = ctypes.PyDLL(path)
+    publish = library.smolvm_cuda_publish_tensor_bundle
+    publish.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_uint64),
+        ctypes.POINTER(ctypes.c_uint64),
+        ctypes.c_size_t,
+        ctypes.c_void_p,
+        ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_size_t),
+    ]
+    publish.restype = ctypes.c_int
+    return publish
+
+
+def publish_device_adapter(
+    tensors: Mapping[str, Any] | Iterable[tuple[str, Any]],
+    adapter_config: Mapping[str, Any],
+    *,
+    shim_path: str | os.PathLike[str] | None = None,
+    synchronize: Callable[[], None] | None = None,
+) -> bytes:
+    """Stage named CUDA tensors and return a one-use 256-bit publication token.
+
+    Tensor objects use the small PyTorch-compatible surface ``detach()``,
+    ``is_cuda``, ``is_contiguous()``, ``data_ptr()``, ``shape``, ``dtype``,
+    ``numel()``, and ``element_size()``. PyTorch tensors synchronize through
+    PyTorch's existing CUDA connection. Other frameworks must provide a
+    ``synchronize`` callback so their queued work cannot be overtaken by the
+    publication connection.
+    """
+
+    entries = list(tensors.items() if isinstance(tensors, Mapping) else tensors)
+    if not entries:
+        raise ValueError("at least one device adapter tensor is required")
+    if len(entries) > 65_536:
+        raise ValueError("device adapter contains too many tensors")
+    if not isinstance(adapter_config, Mapping):
+        raise TypeError("adapter_config must be a mapping")
+    configuration = json.loads(
+        json.dumps(
+            dict(adapter_config),
+            default=lambda value: (
+                sorted(value)
+                if isinstance(value, (set, frozenset))
+                else getattr(value, "value", str(value))
+            ),
+        )
+    )
+    names: set[str] = set()
+    retained = []
+    manifest_tensors = []
+    pointers = []
+    sizes = []
+    device = None
+    for name, tensor in entries:
+        if not isinstance(name, str) or not name or len(name.encode()) > 1024 or "\0" in name:
+            raise ValueError("device adapter tensor names must be unique, non-empty, and bounded")
+        if name in names:
+            raise ValueError(f"duplicate device adapter tensor name {name!r}")
+        names.add(name)
+        value = tensor.detach()
+        if not bool(value.is_cuda):
+            raise ValueError(f"device adapter tensor {name!r} is not on CUDA")
+        if not value.is_contiguous():
+            value = value.contiguous()
+        tensor_device = getattr(value.device, "index", None)
+        if not isinstance(tensor_device, int) or tensor_device < 0:
+            raise ValueError(f"device adapter tensor {name!r} has no CUDA device index")
+        if device is None:
+            device = tensor_device
+        elif tensor_device != device:
+            raise ValueError("one device adapter publication cannot span CUDA devices")
+        pointer = int(value.data_ptr())
+        size = int(value.numel()) * int(value.element_size())
+        if pointer <= 0 or size <= 0:
+            raise ValueError(f"device adapter tensor {name!r} is empty")
+        dtype = str(value.dtype).removeprefix("torch.")
+        if dtype not in _DTYPES:
+            raise ValueError(f"device adapter tensor {name!r} has unsupported dtype {dtype!r}")
+        shape = [int(dimension) for dimension in value.shape]
+        if len(shape) > 16 or any(dimension <= 0 for dimension in shape):
+            raise ValueError(f"device adapter tensor {name!r} has an invalid shape")
+        retained.append(value)
+        pointers.append(pointer)
+        sizes.append(size)
+        manifest_tensors.append({"name": name, "shape": shape, "dtype": dtype})
+    manifest = json.dumps(
+        {
+            "schema": "smolvm.device-lora.v1",
+            "adapterConfig": configuration,
+            "tensors": manifest_tensors,
+        },
+        separators=(",", ":"),
+    ).encode()
+    if len(manifest) > 1 << 20:
+        raise ValueError("device adapter manifest exceeds 1 MiB")
+    if synchronize is not None:
+        synchronize()
+    else:
+        try:
+            import torch
+        except ImportError as error:
+            raise ValueError(
+                "non-PyTorch device publication requires a synchronize callback"
+            ) from error
+        if not all(isinstance(value, torch.Tensor) for value in retained):
+            raise ValueError(
+                "non-PyTorch device publication requires a synchronize callback"
+            )
+        torch.cuda.synchronize(device)
+    path = str(shim_path or os.environ.get("SMOLVM_CUDART_SHIM", _DEFAULT_SHIM))
+    publish = _publisher(path)
+    pointer_array = (ctypes.c_uint64 * len(pointers))(*pointers)
+    size_array = (ctypes.c_uint64 * len(sizes))(*sizes)
+    token = ctypes.create_string_buffer(64)
+    token_len = ctypes.c_size_t()
+    status = publish(
+        manifest,
+        len(manifest),
+        pointer_array,
+        size_array,
+        len(pointers),
+        token,
+        len(token),
+        ctypes.byref(token_len),
+    )
+    if status:
+        raise RuntimeError(f"device adapter publication failed with CUDA status {status}")
+    if token_len.value != 32:
+        raise RuntimeError("smolvm returned an invalid device adapter token")
+    return token.raw[: token_len.value]
+
+
+class DeviceAdapterServer:
+    """Own device mappings from load acknowledgement through unload acknowledgement.
+
+    ``load_adapter`` imports the descriptor, installs the policy in its framework,
+    and returns an owner object that keeps the mapping alive. ``unload_adapter``
+    removes the policy. If the owner exposes ``close()``, it is called only after
+    framework unload succeeds.
+    """
+
+    def __init__(
+        self,
+        path: str | os.PathLike[str],
+        *,
+        load_adapter: LoadAdapter,
+        unload_adapter: UnloadAdapter,
+        io_timeout_secs: float = _DEFAULT_IO_TIMEOUT_SECS,
+    ) -> None:
+        self.path = Path(path)
+        if not self.path.is_absolute():
+            raise ValueError("device adapter socket path must be absolute")
+        if io_timeout_secs <= 0:
+            raise ValueError("io_timeout_secs must be positive")
+        self._io_timeout_secs = io_timeout_secs
+        self._load_adapter = load_adapter
+        self._unload_adapter = unload_adapter
+        self._loaded: dict[str, _LoadedAdapter] = {}
+        self._lock = threading.Lock()
+        self._listener: socket.socket | None = None
+        self._stopping = threading.Event()
+
+    def serve_forever(self) -> None:
+        """Bind the private socket and process requests until ``shutdown``."""
+
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        _remove_stale_socket(self.path)
+        listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        cleanup_error: Exception | None = None
+        try:
+            listener.bind(str(self.path))
+            os.chmod(self.path, 0o600)
+            listener.listen(16)
+            listener.settimeout(0.5)
+            self._listener = listener
+            while not self._stopping.is_set():
+                try:
+                    connection, _ = listener.accept()
+                except TimeoutError:
+                    continue
+                except OSError:
+                    if self._stopping.is_set():
+                        break
+                    raise
+                with connection:
+                    connection.settimeout(self._io_timeout_secs)
+                    self._serve_one(connection)
+        finally:
+            self._listener = None
+            listener.close()
+            try:
+                self.path.unlink()
+            except FileNotFoundError:
+                pass
+            for model in tuple(self._loaded):
+                try:
+                    self._unload(model)
+                except Exception as error:
+                    if cleanup_error is None:
+                        cleanup_error = error
+        if cleanup_error is not None:
+            raise cleanup_error
+
+    def shutdown(self) -> None:
+        """Stop accepting requests and unload every retained adapter mapping."""
+
+        self._stopping.set()
+        listener = self._listener
+        if listener is not None:
+            try:
+                listener.close()
+            except OSError:
+                pass
+
+    def _serve_one(self, connection: socket.socket) -> None:
+        descriptor = -1
+        try:
+            _validate_peer(connection)
+            receive_flags = getattr(socket, "MSG_CMSG_CLOEXEC", 0)
+            header, ancillary, flags, _ = connection.recvmsg(
+                _HEADER.size,
+                socket.CMSG_SPACE(array.array("i").itemsize),
+                receive_flags,
+            )
+            if not header:
+                return
+            if len(header) < _HEADER.size:
+                header += _receive_exact(connection, _HEADER.size - len(header))
+            magic, operation, model_len, metadata_len, allocation_size = _HEADER.unpack(
+                header
+            )
+            if magic != _REQUEST_MAGIC:
+                raise ValueError("invalid device handoff request")
+            if model_len > _MAX_MODEL_BYTES or metadata_len > _MAX_METADATA_BYTES:
+                raise ValueError("device handoff request exceeds its size limit")
+            descriptors = array.array("i")
+            for level, kind, data in ancillary:
+                if level == socket.SOL_SOCKET and kind == socket.SCM_RIGHTS:
+                    usable = len(data) - len(data) % descriptors.itemsize
+                    descriptors.frombytes(data[:usable])
+            if flags & socket.MSG_CTRUNC or len(descriptors) > 1:
+                for received in descriptors:
+                    os.close(received)
+                raise ValueError("device handoff supplied multiple descriptors")
+            if descriptors:
+                descriptor = descriptors[0]
+                os.set_inheritable(descriptor, False)
+            model = _receive_exact(connection, model_len).decode("utf-8")
+            metadata = _receive_exact(connection, metadata_len)
+            if operation == _OP_HEALTH:
+                if model or metadata or descriptor >= 0 or allocation_size:
+                    raise ValueError("invalid device handoff health request")
+            elif operation == _OP_LOAD:
+                if not model or descriptor < 0 or not metadata or allocation_size <= 0:
+                    raise ValueError("incomplete device adapter load request")
+                bundle = _decode_bundle(descriptor, allocation_size, metadata)
+                descriptor = -1
+                self._load(model, bundle)
+            elif operation == _OP_UNLOAD:
+                if not model or metadata or descriptor >= 0 or allocation_size:
+                    raise ValueError("invalid device adapter unload request")
+                self._unload(model)
+            else:
+                raise ValueError("unsupported device handoff operation")
+            _send_response(connection, 0, b"")
+        except Exception as error:  # The error is returned to the local controller.
+            if descriptor >= 0:
+                os.close(descriptor)
+            message = str(error).encode("utf-8", errors="replace")[:_MAX_RESPONSE_BYTES]
+            _send_response(connection, 1, message)
+
+    def _load(self, model: str, bundle: DeviceAdapterBundle) -> None:
+        with self._lock:
+            if model in self._loaded:
+                bundle._close()
+                raise ValueError(f"device adapter {model!r} is already loaded")
+            try:
+                owner = self._load_adapter(model, bundle)
+            except Exception:
+                bundle._close()
+                raise
+            self._loaded[model] = _LoadedAdapter(bundle=bundle, owner=owner)
+
+    def _unload(self, model: str) -> None:
+        with self._lock:
+            loaded = self._loaded.get(model)
+            if loaded is None:
+                return
+            if not loaded.framework_unloaded:
+                self._unload_adapter(model, loaded.owner)
+                loaded.framework_unloaded = True
+            close = getattr(loaded.owner, "close", None)
+            if callable(close):
+                close()
+            loaded.bundle._close()
+            del self._loaded[model]
+
+
+def _remove_stale_socket(path: Path) -> None:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return
+    if not stat.S_ISSOCK(metadata.st_mode):
+        raise RuntimeError(f"refusing to replace non-socket path {path}")
+    if metadata.st_uid != os.geteuid():
+        raise RuntimeError(f"refusing to replace socket {path} owned by another user")
+    probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    probe.settimeout(0.2)
+    try:
+        probe.connect(str(path))
+    except (ConnectionRefusedError, FileNotFoundError):
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+    except OSError as error:
+        raise RuntimeError(f"cannot verify existing device adapter socket {path}: {error}") from error
+    else:
+        raise RuntimeError(f"device adapter socket {path} is already active")
+    finally:
+        probe.close()
+
+
+def _validate_peer(connection: socket.socket) -> None:
+    peer_option = getattr(socket, "SO_PEERCRED", None)
+    if peer_option is None:
+        return
+    credentials = connection.getsockopt(socket.SOL_SOCKET, peer_option, struct.calcsize("3i"))
+    _pid, uid, _gid = struct.unpack("3i", credentials)
+    if uid != os.geteuid():
+        raise PermissionError("device handoff peer has a different user identity")
+
+
+def _receive_exact(connection: socket.socket, size: int) -> bytes:
+    chunks = bytearray()
+    while len(chunks) < size:
+        chunk = connection.recv(size - len(chunks))
+        if not chunk:
+            raise EOFError("device handoff request ended early")
+        chunks.extend(chunk)
+    return bytes(chunks)
+
+
+def _send_response(connection: socket.socket, status: int, message: bytes) -> None:
+    try:
+        connection.sendall(_RESPONSE.pack(_RESPONSE_MAGIC, status, len(message)) + message)
+    except OSError:
+        pass
+
+
+def _decode_bundle(
+    descriptor: int, allocation_size: int, metadata: bytes
+) -> DeviceAdapterBundle:
+    if len(metadata) < 8:
+        raise ValueError("device adapter metadata is truncated")
+    manifest_len, count = struct.unpack_from("<II", metadata)
+    expected = 8 + manifest_len + count * 16
+    if count == 0 or expected != len(metadata):
+        raise ValueError("device adapter metadata is inconsistent")
+    manifest = json.loads(metadata[8 : 8 + manifest_len])
+    if not isinstance(manifest, dict) or set(manifest) != {
+        "schema",
+        "adapterConfig",
+        "tensors",
+    }:
+        raise ValueError("invalid device adapter manifest")
+    if manifest["schema"] != "smolvm.device-lora.v1":
+        raise ValueError("unsupported device adapter manifest schema")
+    if not isinstance(manifest["adapterConfig"], dict):
+        raise ValueError("device adapter config must be an object")
+    manifest_tensors = manifest["tensors"]
+    if not isinstance(manifest_tensors, list) or len(manifest_tensors) != count:
+        raise ValueError("device adapter manifest tensor count mismatch")
+    tensors = []
+    names = set()
+    prior_end = 0
+    ranges = memoryview(metadata)[8 + manifest_len :]
+    for index, tensor in enumerate(manifest_tensors):
+        if not isinstance(tensor, dict) or set(tensor) != {"name", "shape", "dtype"}:
+            raise ValueError("invalid device adapter tensor manifest")
+        name = tensor["name"]
+        shape = tensor["shape"]
+        dtype = tensor["dtype"]
+        if (
+            not isinstance(name, str)
+            or not name
+            or len(name.encode()) > 1024
+            or "\0" in name
+            or name in names
+        ):
+            raise ValueError("device adapter tensor names must be unique and bounded")
+        if (
+            not isinstance(shape, list)
+            or len(shape) > 16
+            or any(not isinstance(value, int) or isinstance(value, bool) or value <= 0 for value in shape)
+        ):
+            raise ValueError("invalid device adapter tensor shape")
+        if dtype not in _DTYPE_SIZES:
+            raise ValueError("unsupported device adapter tensor dtype")
+        expected_size = _DTYPE_SIZES[dtype]
+        for dimension in shape:
+            expected_size *= dimension
+            if expected_size > allocation_size:
+                raise ValueError("device adapter tensor size exceeds its allocation")
+        offset, size = struct.unpack_from("<QQ", ranges, index * 16)
+        if (
+            offset != prior_end
+            or size != expected_size
+            or offset + size > allocation_size
+        ):
+            raise ValueError("device adapter tensor range is invalid")
+        names.add(name)
+        tensors.append(
+            DeviceTensor(
+                name=name,
+                shape=tuple(shape),
+                dtype=dtype,
+                offset=offset,
+                size=size,
+            )
+        )
+        prior_end = offset + size
+    return DeviceAdapterBundle(descriptor, allocation_size, manifest, tuple(tensors))

--- a/sdks/python/src/smolvm_rollout/torch_handoff.py
+++ b/sdks/python/src/smolvm_rollout/torch_handoff.py
@@ -1,0 +1,206 @@
+"""Optional CUDA-VMM importer that exposes a device adapter as PyTorch tensors."""
+
+from __future__ import annotations
+
+import ctypes
+import gc
+from typing import Any
+
+from .device_handoff import DeviceAdapterBundle
+
+
+_CUDA_ARRAY_TYPES = {
+    "bool": ("|b1", None),
+    "int8": ("|i1", None),
+    "uint8": ("|u1", None),
+    "int16": ("<i2", None),
+    "int32": ("<i4", None),
+    "int64": ("<i8", None),
+    "float16": ("<f2", None),
+    "bfloat16": ("<u2", "bfloat16"),
+    "float32": ("<f4", None),
+    "float64": ("<f8", None),
+    "float8_e4m3fn": ("|u1", "float8_e4m3fn"),
+    "float8_e5m2": ("|u1", "float8_e5m2"),
+}
+
+
+class _CudaArray:
+    def __init__(self, pointer: int, shape: tuple[int, ...], typestr: str) -> None:
+        self.__cuda_array_interface__ = {
+            "shape": shape,
+            "strides": None,
+            "typestr": typestr,
+            "data": (pointer, False),
+            "version": 3,
+        }
+
+
+class _CUmemLocation(ctypes.Structure):
+    _fields_ = [("type", ctypes.c_int), ("id", ctypes.c_int)]
+
+
+class _CUmemAccessDesc(ctypes.Structure):
+    _fields_ = [("location", _CUmemLocation), ("flags", ctypes.c_uint64)]
+
+
+class _CudaDriver:
+    def __init__(self, device: int) -> None:
+        self.library = ctypes.CDLL("libcuda.so.1")
+        self.device = device
+        self._bind()
+        self.check(self.library.cuInit(0), "cuInit")
+
+    def _bind(self) -> None:
+        self.library.cuInit.argtypes = [ctypes.c_uint]
+        self.library.cuMemImportFromShareableHandle.argtypes = [
+            ctypes.POINTER(ctypes.c_uint64),
+            ctypes.c_void_p,
+            ctypes.c_int,
+        ]
+        self.library.cuMemAddressReserve.argtypes = [
+            ctypes.POINTER(ctypes.c_uint64),
+            ctypes.c_size_t,
+            ctypes.c_size_t,
+            ctypes.c_uint64,
+            ctypes.c_uint64,
+        ]
+        self.library.cuMemMap.argtypes = [
+            ctypes.c_uint64,
+            ctypes.c_size_t,
+            ctypes.c_size_t,
+            ctypes.c_uint64,
+            ctypes.c_uint64,
+        ]
+        self.library.cuMemSetAccess.argtypes = [
+            ctypes.c_uint64,
+            ctypes.c_size_t,
+            ctypes.POINTER(_CUmemAccessDesc),
+            ctypes.c_size_t,
+        ]
+        self.library.cuMemUnmap.argtypes = [ctypes.c_uint64, ctypes.c_size_t]
+        self.library.cuMemAddressFree.argtypes = [ctypes.c_uint64, ctypes.c_size_t]
+        self.library.cuMemRelease.argtypes = [ctypes.c_uint64]
+
+    @staticmethod
+    def check(status: int, operation: str) -> None:
+        if status:
+            raise RuntimeError(f"{operation} failed with CUDA status {status}")
+
+    def import_allocation(self, descriptor: int, size: int) -> tuple[int, int]:
+        handle = ctypes.c_uint64()
+        self.check(
+            self.library.cuMemImportFromShareableHandle(
+                ctypes.byref(handle), ctypes.c_void_p(descriptor), 1
+            ),
+            "cuMemImportFromShareableHandle",
+        )
+        pointer = ctypes.c_uint64()
+        try:
+            self.check(
+                self.library.cuMemAddressReserve(
+                    ctypes.byref(pointer), size, 0, 0, 0
+                ),
+                "cuMemAddressReserve",
+            )
+            mapped = False
+            try:
+                self.check(
+                    self.library.cuMemMap(pointer.value, size, 0, handle.value, 0),
+                    "cuMemMap",
+                )
+                mapped = True
+                access = _CUmemAccessDesc(
+                    location=_CUmemLocation(type=1, id=self.device), flags=1
+                )
+                self.check(
+                    self.library.cuMemSetAccess(
+                        pointer.value, size, ctypes.byref(access), 1
+                    ),
+                    "cuMemSetAccess",
+                )
+            except Exception:
+                if mapped:
+                    self.library.cuMemUnmap(pointer.value, size)
+                self.library.cuMemAddressFree(pointer.value, size)
+                raise
+        except Exception:
+            self.library.cuMemRelease(handle.value)
+            raise
+        return handle.value, pointer.value
+
+    def unmap(self, pointer: int, size: int) -> None:
+        self.check(self.library.cuMemUnmap(pointer, size), "cuMemUnmap")
+
+    def free_address(self, pointer: int, size: int) -> None:
+        self.check(self.library.cuMemAddressFree(pointer, size), "cuMemAddressFree")
+
+    def release_handle(self, handle: int) -> None:
+        self.check(self.library.cuMemRelease(handle), "cuMemRelease")
+
+
+class TorchDeviceAdapter:
+    """Imported mapping, tensor views, and configuration for one LoRA version."""
+
+    def __init__(self, bundle: DeviceAdapterBundle) -> None:
+        import torch
+
+        self.adapter_config: dict[str, Any] = bundle.manifest["adapterConfig"]
+        self._driver = _CudaDriver(torch.cuda.current_device())
+        self._size = bundle.allocation_size
+        self._handle, self._pointer = self._driver.import_allocation(
+            bundle.descriptor, self._size
+        )
+        self._mapped = True
+        self._arrays = []
+        self.tensors = {}
+        try:
+            for tensor in bundle.tensors:
+                typestr, view_dtype = _CUDA_ARRAY_TYPES[tensor.dtype]
+                array = _CudaArray(self._pointer + tensor.offset, tensor.shape, typestr)
+                value = torch.as_tensor(array, device=f"cuda:{self._driver.device}")
+                if view_dtype is not None:
+                    value = value.view(getattr(torch, view_dtype))
+                if value.data_ptr() != self._pointer + tensor.offset:
+                    raise RuntimeError(
+                        f"PyTorch copied imported tensor {tensor.name!r} instead of viewing it"
+                    )
+                if value.numel() * value.element_size() != tensor.size:
+                    raise ValueError(
+                        f"imported tensor {tensor.name!r} does not match its range"
+                    )
+                self._arrays.append(array)
+                self.tensors[tensor.name] = value
+        except Exception:
+            self.close()
+            raise
+
+    def close(self) -> None:
+        """Release views and the imported mapping after framework unload."""
+
+        if not getattr(self, "_handle", 0):
+            return
+        import torch
+
+        with torch.cuda.device(self._driver.device):
+            torch.cuda.synchronize(self._driver.device)
+            self.tensors.clear()
+            self._arrays.clear()
+            gc.collect()
+            if self._mapped:
+                self._driver.unmap(self._pointer, self._size)
+                self._mapped = False
+            if self._pointer:
+                pointer = self._pointer
+                self._driver.free_address(pointer, self._size)
+                self._pointer = 0
+            if self._handle:
+                handle = self._handle
+                self._driver.release_handle(handle)
+                self._handle = 0
+
+
+def import_torch_device_adapter(bundle: DeviceAdapterBundle) -> TorchDeviceAdapter:
+    """Import a smolvm allocation and return named PyTorch tensor views."""
+
+    return TorchDeviceAdapter(bundle)

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -2,7 +2,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from smolvm_rollout import adapter_sha256
+from smolvm_rollout import RolloutClient, RolloutError, adapter_sha256
 
 
 class AdapterDigestTests(unittest.TestCase):
@@ -19,6 +19,50 @@ class AdapterDigestTests(unittest.TestCase):
             self.assertEqual(first, adapter_sha256(root))
             (root / "adapter_model.safetensors").write_bytes(b"changed")
             self.assertNotEqual(first, adapter_sha256(root))
+
+
+class RecordingClient(RolloutClient):
+    def __init__(self):
+        super().__init__("http://127.0.0.1:1/api/v1", "fused")
+        self.recorded = None
+
+    def _request(self, method, path, body=None):
+        self.recorded = (method, path, body)
+        return {"ok": True}
+
+
+class DevicePublicationTests(unittest.TestCase):
+    def test_device_token_is_encoded_without_exposing_a_descriptor(self):
+        client = RecordingClient()
+        response = client.publish_device_policy(
+            "policy", "step-1", bytes(range(32))
+        )
+        self.assertEqual(response, {"ok": True})
+        method, path, body = client.recorded
+        self.assertEqual(method, "POST")
+        self.assertEqual(path, "/rollout-executors/fused/device-policies")
+        self.assertEqual(body["tensorBundleToken"], bytes(range(32)).hex())
+        self.assertNotIn("adapterSha256", body)
+
+    def test_device_publication_retries_one_ambiguous_transport_failure(self):
+        class FlakyClient(RecordingClient):
+            def __init__(self):
+                super().__init__()
+                self.attempts = []
+
+            def _request(self, method, path, body=None):
+                self.attempts.append((method, path, body))
+                if len(self.attempts) == 1:
+                    raise RolloutError(0, "UNAVAILABLE", "lost response")
+                return {"ok": True}
+
+        client = FlakyClient()
+        self.assertEqual(
+            client.publish_device_policy("policy", "step-1", bytes(range(32))),
+            {"ok": True},
+        )
+        self.assertEqual(len(client.attempts), 2)
+        self.assertEqual(client.attempts[0], client.attempts[1])
 
 
 if __name__ == "__main__":

--- a/sdks/python/tests/test_device_handoff.py
+++ b/sdks/python/tests/test_device_handoff.py
@@ -1,0 +1,354 @@
+import array
+import json
+import os
+import socket
+import struct
+import tempfile
+import threading
+import time
+import unittest
+from unittest import mock
+from pathlib import Path
+
+from smolvm_rollout import DeviceAdapterServer, publish_device_adapter
+from smolvm_rollout import device_handoff
+
+
+REQUEST = struct.Struct("<8sB3xIIQ4x")
+RESPONSE = struct.Struct("<8siI")
+
+
+def request(path, operation, model="", metadata=b"", descriptor=None, size=0):
+    connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    connection.connect(str(path))
+    header = REQUEST.pack(
+        b"SMVDLH01", operation, len(model.encode()), len(metadata), size
+    )
+    if descriptor is None:
+        connection.sendall(header)
+    else:
+        connection.sendmsg(
+            [header],
+            [(socket.SOL_SOCKET, socket.SCM_RIGHTS, array.array("i", [descriptor]))],
+        )
+    connection.sendall(model.encode() + metadata)
+    response = connection.recv(RESPONSE.size)
+    magic, status, message_len = RESPONSE.unpack(response)
+    message = b""
+    while len(message) < message_len:
+        message += connection.recv(message_len - len(message))
+    connection.close()
+    return magic, status, message
+
+
+class Owner:
+    def __init__(self, descriptor):
+        self.descriptor = descriptor
+        self.closed = False
+
+    def close(self):
+        os.fstat(self.descriptor)
+        self.closed = True
+
+
+class DeviceHandoffTests(unittest.TestCase):
+    def test_active_socket_is_never_unlinked(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "adapter.sock"
+            listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            listener.bind(str(path))
+            os.chmod(path, 0o600)
+            listener.listen(1)
+            try:
+                with self.assertRaisesRegex(RuntimeError, "already active"):
+                    device_handoff._remove_stale_socket(path)
+                self.assertTrue(path.exists())
+            finally:
+                listener.close()
+
+    def test_manifest_range_must_match_shape_and_dtype(self):
+        manifest = json.dumps(
+            {
+                "schema": "smolvm.device-lora.v1",
+                "adapterConfig": {},
+                "tensors": [
+                    {
+                        "name": "q_proj.lora_A.weight",
+                        "shape": [2, 4],
+                        "dtype": "float16",
+                    }
+                ],
+            },
+            separators=(",", ":"),
+        ).encode()
+        metadata = (
+            struct.pack("<II", len(manifest), 1)
+            + manifest
+            + struct.pack("<QQ", 0, 8)
+        )
+        with tempfile.TemporaryFile() as allocation:
+            with self.assertRaisesRegex(ValueError, "range is invalid"):
+                device_handoff._decode_bundle(allocation.fileno(), 64, metadata)
+
+    def test_partial_client_is_timed_out_without_blocking_health(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "adapter.sock"
+            server = DeviceAdapterServer(
+                path,
+                load_adapter=lambda _model, _bundle: None,
+                unload_adapter=lambda _model, _owner: None,
+                io_timeout_secs=0.05,
+            )
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            deadline = time.monotonic() + 2
+            while not path.exists():
+                if time.monotonic() > deadline:
+                    self.fail("device adapter server did not bind")
+                time.sleep(0.01)
+            stalled = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            stalled.connect(str(path))
+            stalled.sendall(b"S")
+            time.sleep(0.1)
+            stalled.close()
+            self.assertEqual(request(path, 0), (b"SMVDHR01", 0, b""))
+            server.shutdown()
+            thread.join(timeout=2)
+            self.assertFalse(thread.is_alive())
+
+    def test_framework_tensors_form_a_versioned_publication_manifest(self):
+        class Device:
+            index = 0
+
+        class Tensor:
+            is_cuda = True
+            is_contiguous_value = True
+            device = Device()
+            dtype = "torch.bfloat16"
+            shape = (2, 4)
+
+            def detach(self):
+                return self
+
+            def is_contiguous(self):
+                return self.is_contiguous_value
+
+            def data_ptr(self):
+                return 0x12340000
+
+            def numel(self):
+                return 8
+
+            def element_size(self):
+                return 2
+
+        captured = {}
+        events = []
+
+        def publish(manifest, manifest_len, pointers, sizes, count, token, capacity, token_len):
+            events.append("publish")
+            captured["manifest"] = json.loads(manifest[:manifest_len])
+            captured["pointers"] = [pointers[index] for index in range(count)]
+            captured["sizes"] = [sizes[index] for index in range(count)]
+            value = bytes(range(32))
+            import ctypes
+
+            ctypes.memmove(token, value, len(value))
+            ctypes.cast(token_len, ctypes.POINTER(ctypes.c_size_t))[0] = len(value)
+            return 0
+
+        with mock.patch.object(device_handoff, "_publisher", return_value=publish):
+            token = publish_device_adapter(
+                {"q_proj.lora_A.weight": Tensor()},
+                {"r": 16, "lora_alpha": 16},
+                synchronize=lambda: events.append("synchronize"),
+            )
+        self.assertEqual(token, bytes(range(32)))
+        self.assertEqual(captured["manifest"]["schema"], "smolvm.device-lora.v1")
+        self.assertEqual(captured["manifest"]["tensors"][0]["dtype"], "bfloat16")
+        self.assertEqual(captured["pointers"], [0x12340000])
+        self.assertEqual(captured["sizes"], [16])
+        self.assertEqual(events, ["synchronize", "publish"])
+
+    def test_descriptor_is_retained_until_successful_unload(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "adapter.sock"
+            loaded = {}
+
+            def load(model, bundle):
+                os.fstat(bundle.descriptor)
+                owner = Owner(bundle.descriptor)
+                loaded[model] = owner
+                return owner
+
+            def unload(model, owner):
+                self.assertIs(loaded[model], owner)
+                os.fstat(owner.descriptor)
+
+            server = DeviceAdapterServer(path, load_adapter=load, unload_adapter=unload)
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            deadline = time.monotonic() + 2
+            while not path.exists():
+                if time.monotonic() > deadline:
+                    self.fail("device adapter server did not bind")
+                time.sleep(0.01)
+
+            self.assertEqual(request(path, 0), (b"SMVDHR01", 0, b""))
+            manifest = json.dumps(
+                {
+                    "schema": "smolvm.device-lora.v1",
+                    "adapterConfig": {},
+                    "tensors": [
+                        {"name": "q_proj.lora_A.weight", "shape": [2, 4], "dtype": "float16"}
+                    ],
+                },
+                separators=(",", ":"),
+            ).encode()
+            metadata = (
+                struct.pack("<II", len(manifest), 1)
+                + manifest
+                + struct.pack("<QQ", 0, 16)
+            )
+            with tempfile.TemporaryFile() as allocation:
+                self.assertEqual(
+                    request(
+                        path,
+                        1,
+                        "fused-policy-step",
+                        metadata,
+                        allocation.fileno(),
+                        64,
+                    ),
+                    (b"SMVDHR01", 0, b""),
+                )
+            owner = loaded["fused-policy-step"]
+            os.fstat(owner.descriptor)
+            self.assertFalse(owner.closed)
+            self.assertEqual(
+                request(path, 2, "fused-policy-step"),
+                (b"SMVDHR01", 0, b""),
+            )
+            self.assertTrue(owner.closed)
+            with self.assertRaises(OSError):
+                os.fstat(owner.descriptor)
+
+            server.shutdown()
+            thread.join(timeout=2)
+            self.assertFalse(thread.is_alive())
+
+    def test_failed_unload_keeps_the_mapping_for_a_safe_retry(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "adapter.sock"
+            attempts = 0
+
+            def load(_model, bundle):
+                return Owner(bundle.descriptor)
+
+            def unload(_model, owner):
+                nonlocal attempts
+                attempts += 1
+                os.fstat(owner.descriptor)
+                if attempts == 1:
+                    raise RuntimeError("injected unload failure")
+
+            server = DeviceAdapterServer(path, load_adapter=load, unload_adapter=unload)
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            deadline = time.monotonic() + 2
+            while not path.exists():
+                if time.monotonic() > deadline:
+                    self.fail("device adapter server did not bind")
+                time.sleep(0.01)
+            manifest = json.dumps(
+                {
+                    "schema": "smolvm.device-lora.v1",
+                    "adapterConfig": {},
+                    "tensors": [
+                        {"name": "q_proj.lora_A.weight", "shape": [2, 4], "dtype": "float16"}
+                    ],
+                },
+                separators=(",", ":"),
+            ).encode()
+            metadata = struct.pack("<II", len(manifest), 1) + manifest + struct.pack(
+                "<QQ", 0, 16
+            )
+            with tempfile.TemporaryFile() as allocation:
+                self.assertEqual(
+                    request(path, 1, "retry", metadata, allocation.fileno(), 64)[1],
+                    0,
+                )
+            owner = server._loaded["retry"].owner
+            self.assertNotEqual(request(path, 2, "retry")[1], 0)
+            os.fstat(owner.descriptor)
+            self.assertFalse(owner.closed)
+            self.assertEqual(request(path, 2, "retry")[1], 0)
+            self.assertTrue(owner.closed)
+            self.assertNotIn("retry", server._loaded)
+            server.shutdown()
+            thread.join(timeout=2)
+
+    def test_owner_close_retry_does_not_unload_framework_twice(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "adapter.sock"
+            unloads = 0
+
+            class FlakyOwner(Owner):
+                def __init__(self, descriptor):
+                    super().__init__(descriptor)
+                    self.close_attempts = 0
+
+                def close(self):
+                    self.close_attempts += 1
+                    if self.close_attempts == 1:
+                        raise RuntimeError("injected mapping release failure")
+                    super().close()
+
+            def load(_model, bundle):
+                return FlakyOwner(bundle.descriptor)
+
+            def unload(_model, _owner):
+                nonlocal unloads
+                unloads += 1
+
+            server = DeviceAdapterServer(path, load_adapter=load, unload_adapter=unload)
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            deadline = time.monotonic() + 2
+            while not path.exists():
+                if time.monotonic() > deadline:
+                    self.fail("device adapter server did not bind")
+                time.sleep(0.01)
+            manifest = json.dumps(
+                {
+                    "schema": "smolvm.device-lora.v1",
+                    "adapterConfig": {},
+                    "tensors": [
+                        {
+                            "name": "q_proj.lora_A.weight",
+                            "shape": [2, 4],
+                            "dtype": "float16",
+                        }
+                    ],
+                },
+                separators=(",", ":"),
+            ).encode()
+            metadata = (
+                struct.pack("<II", len(manifest), 1)
+                + manifest
+                + struct.pack("<QQ", 0, 16)
+            )
+            with tempfile.TemporaryFile() as allocation:
+                self.assertEqual(
+                    request(path, 1, "close-retry", metadata, allocation.fileno(), 64)[1],
+                    0,
+                )
+            self.assertNotEqual(request(path, 2, "close-retry")[1], 0)
+            self.assertEqual(request(path, 2, "close-retry")[1], 0)
+            self.assertEqual(unloads, 1)
+            server.shutdown()
+            thread.join(timeout=2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/api/device_handoff.rs
+++ b/src/api/device_handoff.rs
@@ -1,0 +1,541 @@
+//! Private descriptor transport between smolvm and a managed rollout sidecar.
+//!
+//! The public rollout API never exposes CUDA allocation descriptors. It
+//! redeems a one-use clone publication itself, then transfers the descriptor
+//! to the executor's registered Unix socket. The sidecar acknowledges load and
+//! unload so the executor can keep the corresponding policy lifetime tracked.
+
+use crate::api::rollout::RolloutError;
+use crate::cuda_daemon::RedeemedTensorBundle;
+use serde::Deserialize;
+use std::collections::HashSet;
+use std::io::{self, Read, Write};
+use std::os::fd::{AsRawFd, RawFd};
+use std::os::unix::fs::{FileTypeExt, MetadataExt};
+use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+const REQUEST_MAGIC: [u8; 8] = *b"SMVDLH01";
+const RESPONSE_MAGIC: [u8; 8] = *b"SMVDHR01";
+const HEADER_BYTES: usize = 32;
+const RESPONSE_HEADER_BYTES: usize = 16;
+const OP_HEALTH: u8 = 0;
+const OP_LOAD: u8 = 1;
+const OP_UNLOAD: u8 = 2;
+const MAX_MODEL_BYTES: usize = 512;
+const MAX_METADATA_BYTES: usize = (2 << 20) + 64;
+const MAX_RESPONSE_BYTES: usize = 1 << 20;
+const MANIFEST_SCHEMA: &str = "smolvm.device-lora.v1";
+const MAX_TENSOR_NAME_BYTES: usize = 1024;
+const MAX_TENSOR_RANK: usize = 16;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct DeviceAdapterManifest {
+    schema: String,
+    adapter_config: serde_json::Value,
+    tensors: Vec<DeviceAdapterTensor>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct DeviceAdapterTensor {
+    name: String,
+    shape: Vec<u64>,
+    dtype: String,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct DeviceHandoffClient {
+    path: PathBuf,
+    timeout: Duration,
+}
+
+impl DeviceHandoffClient {
+    pub(crate) fn new(path: &Path, timeout: Duration) -> Result<Self, RolloutError> {
+        if !path.is_absolute() {
+            return Err(RolloutError::BadRequest(
+                "deviceAdapterSocket must be an absolute Unix-socket path".into(),
+            ));
+        }
+        let path = path.canonicalize().map_err(|error| {
+            RolloutError::BadRequest(format!("canonicalize deviceAdapterSocket: {error}"))
+        })?;
+        validate_socket_node(&path)?;
+        Ok(Self { path, timeout })
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub(crate) async fn health(&self) -> Result<(), RolloutError> {
+        let path = self.path.clone();
+        let timeout = self.timeout.min(Duration::from_secs(10));
+        tokio::task::spawn_blocking(move || transact(&path, timeout, OP_HEALTH, "", None))
+            .await
+            .map_err(|error| {
+                RolloutError::Backend(format!("device handoff task failed: {error}"))
+            })??;
+        Ok(())
+    }
+
+    pub(crate) async fn load(
+        &self,
+        model: &str,
+        bundle: RedeemedTensorBundle,
+    ) -> Result<(), RolloutError> {
+        validate_bundle_metadata(&bundle.metadata, bundle.allocation_size)?;
+        validate_model_name(model)?;
+        let path = self.path.clone();
+        let timeout = self.timeout;
+        let model = model.to_string();
+        tokio::task::spawn_blocking(move || {
+            transact(&path, timeout, OP_LOAD, &model, Some(bundle))
+        })
+        .await
+        .map_err(|error| RolloutError::Backend(format!("device handoff task failed: {error}")))??;
+        Ok(())
+    }
+
+    pub(crate) async fn unload(&self, model: &str) -> Result<(), RolloutError> {
+        validate_model_name(model)?;
+        let path = self.path.clone();
+        let timeout = self.timeout;
+        let model = model.to_string();
+        tokio::task::spawn_blocking(move || transact(&path, timeout, OP_UNLOAD, &model, None))
+            .await
+            .map_err(|error| {
+                RolloutError::Backend(format!("device handoff task failed: {error}"))
+            })??;
+        Ok(())
+    }
+}
+
+fn validate_socket_node(path: &Path) -> Result<(), RolloutError> {
+    let metadata = path.metadata().map_err(|error| {
+        RolloutError::BadRequest(format!("inspect deviceAdapterSocket: {error}"))
+    })?;
+    if !metadata.file_type().is_socket() {
+        return Err(RolloutError::BadRequest(
+            "deviceAdapterSocket must resolve to a Unix socket".into(),
+        ));
+    }
+    if metadata.uid() != unsafe { libc::geteuid() } {
+        return Err(RolloutError::BadRequest(
+            "deviceAdapterSocket must be owned by the smolvm user".into(),
+        ));
+    }
+    if metadata.mode() & 0o077 != 0 {
+        return Err(RolloutError::BadRequest(
+            "deviceAdapterSocket must not grant group or other permissions".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_model_name(model: &str) -> Result<(), RolloutError> {
+    if model.is_empty() || model.len() > MAX_MODEL_BYTES || model.as_bytes().contains(&0) {
+        return Err(RolloutError::BadRequest(
+            "invalid device adapter model name".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn tensor_dtype_size(dtype: &str) -> Option<u64> {
+    match dtype {
+        "bool" | "int8" | "uint8" | "float8_e4m3fn" | "float8_e5m2" => Some(1),
+        "int16" | "float16" | "bfloat16" => Some(2),
+        "int32" | "float32" => Some(4),
+        "int64" | "float64" => Some(8),
+        _ => None,
+    }
+}
+
+fn validate_bundle_metadata(metadata: &[u8], allocation_size: u64) -> Result<(), RolloutError> {
+    if metadata.len() < 8 || metadata.len() > MAX_METADATA_BYTES {
+        return Err(RolloutError::BadRequest(
+            "invalid device adapter metadata length".into(),
+        ));
+    }
+    let manifest_len = u32::from_le_bytes(metadata[0..4].try_into().unwrap()) as usize;
+    let tensor_count = u32::from_le_bytes(metadata[4..8].try_into().unwrap()) as usize;
+    let ranges_offset = 8usize.checked_add(manifest_len).ok_or_else(|| {
+        RolloutError::BadRequest("device adapter metadata length overflow".into())
+    })?;
+    let expected = ranges_offset
+        .checked_add(tensor_count.checked_mul(16).ok_or_else(|| {
+            RolloutError::BadRequest("device adapter tensor count overflow".into())
+        })?)
+        .ok_or_else(|| RolloutError::BadRequest("device adapter metadata overflow".into()))?;
+    if tensor_count == 0 || expected != metadata.len() {
+        return Err(RolloutError::BadRequest(
+            "inconsistent device adapter metadata".into(),
+        ));
+    }
+    let manifest: DeviceAdapterManifest = serde_json::from_slice(&metadata[8..ranges_offset])
+        .map_err(|error| {
+            RolloutError::BadRequest(format!("decode device adapter manifest: {error}"))
+        })?;
+    if manifest.schema != MANIFEST_SCHEMA {
+        return Err(RolloutError::BadRequest(format!(
+            "unsupported device adapter schema '{}'",
+            manifest.schema
+        )));
+    }
+    if !manifest.adapter_config.is_object() {
+        return Err(RolloutError::BadRequest(
+            "device adapter config must be a JSON object".into(),
+        ));
+    }
+    if manifest.tensors.len() != tensor_count {
+        return Err(RolloutError::BadRequest(
+            "device adapter manifest tensor count mismatch".into(),
+        ));
+    }
+    let mut names = HashSet::with_capacity(tensor_count);
+    let mut prior_end = 0u64;
+    for (tensor, range) in manifest
+        .tensors
+        .iter()
+        .zip(metadata[ranges_offset..].chunks_exact(16))
+    {
+        if tensor.name.is_empty()
+            || tensor.name.len() > MAX_TENSOR_NAME_BYTES
+            || tensor.name.as_bytes().contains(&0)
+            || !names.insert(&tensor.name)
+        {
+            return Err(RolloutError::BadRequest(
+                "device adapter tensor names must be unique, non-empty, and bounded".into(),
+            ));
+        }
+        if tensor.shape.len() > MAX_TENSOR_RANK || tensor.shape.contains(&0) {
+            return Err(RolloutError::BadRequest(
+                "invalid device adapter tensor shape".into(),
+            ));
+        }
+        let element_size = tensor_dtype_size(&tensor.dtype).ok_or_else(|| {
+            RolloutError::BadRequest(format!(
+                "unsupported device adapter dtype '{}'",
+                tensor.dtype
+            ))
+        })?;
+        let expected_size = tensor
+            .shape
+            .iter()
+            .try_fold(element_size, |size, dimension| size.checked_mul(*dimension))
+            .ok_or_else(|| {
+                RolloutError::BadRequest("device adapter tensor size overflow".into())
+            })?;
+        let offset = u64::from_le_bytes(range[0..8].try_into().unwrap());
+        let size = u64::from_le_bytes(range[8..16].try_into().unwrap());
+        let end = offset.checked_add(size).ok_or_else(|| {
+            RolloutError::BadRequest("device adapter tensor range overflow".into())
+        })?;
+        if offset != prior_end || size != expected_size || end > allocation_size {
+            return Err(RolloutError::BadRequest(
+                "device adapter tensor shape does not match its exported range".into(),
+            ));
+        }
+        prior_end = end;
+    }
+    Ok(())
+}
+
+fn transact(
+    path: &Path,
+    timeout: Duration,
+    operation: u8,
+    model: &str,
+    bundle: Option<RedeemedTensorBundle>,
+) -> Result<(), RolloutError> {
+    validate_socket_node(path)?;
+    let mut stream = UnixStream::connect(path).map_err(|error| {
+        RolloutError::Unavailable(format!("connect device adapter sidecar: {error}"))
+    })?;
+    stream.set_read_timeout(Some(timeout)).map_err(sidecar_io)?;
+    stream
+        .set_write_timeout(Some(timeout))
+        .map_err(sidecar_io)?;
+    validate_peer(&stream)?;
+
+    let metadata_len = bundle.as_ref().map_or(0, |value| value.metadata.len());
+    let allocation_size = bundle.as_ref().map_or(0, |value| value.allocation_size);
+    let mut header = [0u8; HEADER_BYTES];
+    header[..8].copy_from_slice(&REQUEST_MAGIC);
+    header[8] = operation;
+    header[12..16].copy_from_slice(&(model.len() as u32).to_le_bytes());
+    header[16..20].copy_from_slice(&(metadata_len as u32).to_le_bytes());
+    header[20..28].copy_from_slice(&allocation_size.to_le_bytes());
+    if let Some(bundle) = bundle.as_ref() {
+        send_header_with_fd(&mut stream, &header, bundle.allocation.as_raw_fd())?;
+    } else {
+        stream.write_all(&header).map_err(sidecar_io)?;
+    }
+    stream.write_all(model.as_bytes()).map_err(sidecar_io)?;
+    if let Some(bundle) = bundle.as_ref() {
+        stream.write_all(&bundle.metadata).map_err(sidecar_io)?;
+    }
+
+    let mut response = [0u8; RESPONSE_HEADER_BYTES];
+    stream.read_exact(&mut response).map_err(sidecar_io)?;
+    if response[..8] != RESPONSE_MAGIC {
+        return Err(RolloutError::Backend(
+            "invalid device adapter sidecar response".into(),
+        ));
+    }
+    let status = i32::from_le_bytes(response[8..12].try_into().unwrap());
+    let message_len = u32::from_le_bytes(response[12..16].try_into().unwrap()) as usize;
+    if message_len > MAX_RESPONSE_BYTES {
+        return Err(RolloutError::Backend(
+            "device adapter sidecar response is too large".into(),
+        ));
+    }
+    let mut message = vec![0u8; message_len];
+    stream.read_exact(&mut message).map_err(sidecar_io)?;
+    if status != 0 {
+        return Err(RolloutError::Backend(format!(
+            "device adapter sidecar rejected request ({status}): {}",
+            String::from_utf8_lossy(&message)
+        )));
+    }
+    Ok(())
+}
+
+fn sidecar_io(error: io::Error) -> RolloutError {
+    if matches!(
+        error.kind(),
+        io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
+    ) {
+        RolloutError::Timeout("device adapter sidecar request timed out".into())
+    } else {
+        RolloutError::Unavailable(format!("device adapter sidecar I/O failed: {error}"))
+    }
+}
+
+fn send_header_with_fd(
+    stream: &mut UnixStream,
+    header: &[u8; HEADER_BYTES],
+    fd: RawFd,
+) -> Result<(), RolloutError> {
+    let mut iov = libc::iovec {
+        iov_base: header.as_ptr() as *mut libc::c_void,
+        iov_len: header.len(),
+    };
+    let sent = unsafe {
+        let mut control = [0u8; 32];
+        let mut message: libc::msghdr = std::mem::zeroed();
+        message.msg_iov = &mut iov;
+        message.msg_iovlen = 1;
+        message.msg_control = control.as_mut_ptr().cast();
+        message.msg_controllen = libc::CMSG_SPACE(4) as _;
+        let cmsg = libc::CMSG_FIRSTHDR(&message);
+        (*cmsg).cmsg_level = libc::SOL_SOCKET;
+        (*cmsg).cmsg_type = libc::SCM_RIGHTS;
+        (*cmsg).cmsg_len = libc::CMSG_LEN(4) as _;
+        std::ptr::copy_nonoverlapping((&fd as *const RawFd).cast::<u8>(), libc::CMSG_DATA(cmsg), 4);
+        libc::sendmsg(stream.as_raw_fd(), &message, libc::MSG_NOSIGNAL)
+    };
+    if sent < 0 {
+        return Err(sidecar_io(io::Error::last_os_error()));
+    }
+    let sent = sent as usize;
+    if sent < header.len() {
+        stream.write_all(&header[sent..]).map_err(sidecar_io)?;
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn validate_peer(stream: &UnixStream) -> Result<(), RolloutError> {
+    let mut credentials: libc::ucred = unsafe { std::mem::zeroed() };
+    let mut length = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+    let rc = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_PEERCRED,
+            (&mut credentials as *mut libc::ucred).cast(),
+            &mut length,
+        )
+    };
+    if rc != 0 {
+        return Err(sidecar_io(io::Error::last_os_error()));
+    }
+    if credentials.uid != unsafe { libc::geteuid() } {
+        return Err(RolloutError::Unavailable(
+            "device adapter sidecar peer has a different user identity".into(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn validate_peer(_stream: &UnixStream) -> Result<(), RolloutError> {
+    Err(RolloutError::Unavailable(
+        "device-resident rollout handoff requires Linux".into(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::fd::{FromRawFd, OwnedFd};
+    use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::net::UnixListener;
+
+    fn metadata(manifest: serde_json::Value, ranges: &[(u64, u64)]) -> Vec<u8> {
+        let manifest = serde_json::to_vec(&manifest).unwrap();
+        let mut metadata = Vec::new();
+        metadata.extend_from_slice(&(manifest.len() as u32).to_le_bytes());
+        metadata.extend_from_slice(&(ranges.len() as u32).to_le_bytes());
+        metadata.extend_from_slice(&manifest);
+        for (offset, size) in ranges {
+            metadata.extend_from_slice(&offset.to_le_bytes());
+            metadata.extend_from_slice(&size.to_le_bytes());
+        }
+        metadata
+    }
+
+    fn receive_request(
+        mut stream: UnixStream,
+    ) -> (u8, String, Vec<u8>, Option<OwnedFd>, UnixStream) {
+        let mut header = [0u8; HEADER_BYTES];
+        let mut iov = libc::iovec {
+            iov_base: header.as_mut_ptr().cast(),
+            iov_len: header.len(),
+        };
+        let (received, fd) = unsafe {
+            let mut control = [0u8; 32];
+            let mut message: libc::msghdr = std::mem::zeroed();
+            message.msg_iov = &mut iov;
+            message.msg_iovlen = 1;
+            message.msg_control = control.as_mut_ptr().cast();
+            message.msg_controllen = libc::CMSG_SPACE(4) as _;
+            let received = libc::recvmsg(stream.as_raw_fd(), &mut message, 0);
+            assert!(received > 0);
+            let cmsg = libc::CMSG_FIRSTHDR(&message);
+            if cmsg.is_null() {
+                (received as usize, None)
+            } else {
+                assert_eq!((*cmsg).cmsg_level, libc::SOL_SOCKET);
+                assert_eq!((*cmsg).cmsg_type, libc::SCM_RIGHTS);
+                let mut fd = -1;
+                std::ptr::copy_nonoverlapping(
+                    libc::CMSG_DATA(cmsg),
+                    (&mut fd as *mut RawFd).cast(),
+                    4,
+                );
+                (received as usize, Some(OwnedFd::from_raw_fd(fd)))
+            }
+        };
+        if received < header.len() {
+            stream.read_exact(&mut header[received..]).unwrap();
+        }
+        assert_eq!(header[..8], REQUEST_MAGIC);
+        let operation = header[8];
+        let model_len = u32::from_le_bytes(header[12..16].try_into().unwrap()) as usize;
+        let metadata_len = u32::from_le_bytes(header[16..20].try_into().unwrap()) as usize;
+        let mut model = vec![0u8; model_len];
+        stream.read_exact(&mut model).unwrap();
+        let mut metadata = vec![0u8; metadata_len];
+        stream.read_exact(&mut metadata).unwrap();
+        (
+            operation,
+            String::from_utf8(model).unwrap(),
+            metadata,
+            fd,
+            stream,
+        )
+    }
+
+    fn acknowledge(mut stream: UnixStream) {
+        let mut response = [0u8; RESPONSE_HEADER_BYTES];
+        response[..8].copy_from_slice(&RESPONSE_MAGIC);
+        stream.write_all(&response).unwrap();
+    }
+
+    #[test]
+    fn manifest_shape_and_exported_ranges_must_agree() {
+        let manifest = serde_json::json!({
+            "schema": MANIFEST_SCHEMA,
+            "adapterConfig": {},
+            "tensors": [
+                {"name": "q_proj.lora_A.weight", "shape": [2, 4], "dtype": "float16"},
+                {"name": "q_proj.lora_B.weight", "shape": [4, 2], "dtype": "float16"}
+            ]
+        });
+        let valid = metadata(manifest.clone(), &[(0, 16), (16, 16)]);
+        validate_bundle_metadata(&valid, 64).unwrap();
+
+        let wrong_size = metadata(manifest.clone(), &[(0, 8), (8, 16)]);
+        assert!(validate_bundle_metadata(&wrong_size, 64).is_err());
+        let duplicate = serde_json::json!({
+            "schema": MANIFEST_SCHEMA,
+            "adapterConfig": {},
+            "tensors": [
+                {"name": "same", "shape": [2, 4], "dtype": "float16"},
+                {"name": "same", "shape": [4, 2], "dtype": "float16"}
+            ]
+        });
+        assert!(validate_bundle_metadata(&metadata(duplicate, &[(0, 16), (16, 16)]), 64).is_err());
+    }
+
+    #[tokio::test]
+    async fn descriptor_owner_survives_load_until_unload_acknowledgement() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("device-adapter.sock");
+        let listener = UnixListener::bind(&path).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        let server = std::thread::spawn(move || {
+            let (health, _) = listener.accept().unwrap();
+            let (operation, model, metadata, fd, health) = receive_request(health);
+            assert_eq!(operation, OP_HEALTH);
+            assert!(model.is_empty());
+            assert!(metadata.is_empty());
+            assert!(fd.is_none());
+            acknowledge(health);
+
+            let (load, _) = listener.accept().unwrap();
+            let (operation, model, metadata, retained, load) = receive_request(load);
+            assert_eq!(operation, OP_LOAD);
+            assert_eq!(model, "executor-policy-step");
+            assert!(!metadata.is_empty());
+            let retained = retained.unwrap();
+            let mut stat: libc::stat = unsafe { std::mem::zeroed() };
+            assert_eq!(unsafe { libc::fstat(retained.as_raw_fd(), &mut stat) }, 0);
+            acknowledge(load);
+
+            let (unload, _) = listener.accept().unwrap();
+            let (operation, model, metadata, fd, unload) = receive_request(unload);
+            assert_eq!(operation, OP_UNLOAD);
+            assert_eq!(model, "executor-policy-step");
+            assert!(metadata.is_empty());
+            assert!(fd.is_none());
+            assert_eq!(unsafe { libc::fstat(retained.as_raw_fd(), &mut stat) }, 0);
+            drop(retained);
+            acknowledge(unload);
+        });
+
+        let client = DeviceHandoffClient::new(&path, Duration::from_secs(2)).unwrap();
+        client.health().await.unwrap();
+        let manifest = serde_json::json!({
+            "schema": MANIFEST_SCHEMA,
+            "adapterConfig": {},
+            "tensors": [
+                {"name": "q_proj.lora_A.weight", "shape": [2, 4], "dtype": "float16"}
+            ]
+        });
+        let allocation: OwnedFd = tempfile::tempfile().unwrap().into();
+        let bundle = RedeemedTensorBundle {
+            allocation,
+            allocation_size: 64,
+            metadata: metadata(manifest, &[(0, 16)]),
+        };
+        client.load("executor-policy-step", bundle).await.unwrap();
+        client.unload("executor-policy-step").await.unwrap();
+        server.join().unwrap();
+    }
+}

--- a/src/api/handlers/rollouts.rs
+++ b/src/api/handlers/rollouts.rs
@@ -10,9 +10,9 @@ use std::sync::Arc;
 
 use crate::api::error::ApiError;
 use crate::api::rollout::{
-    CreateRolloutExecutorRequest, PublishRolloutPolicyRequest, RolloutBatchItemResponse,
-    RolloutBatchRequest, RolloutBatchResponse, RolloutExecutorInfo, RolloutGenerateRequest,
-    RolloutGenerateResponse, RolloutPolicyInfo,
+    CreateRolloutExecutorRequest, PublishDeviceRolloutPolicyRequest, PublishRolloutPolicyRequest,
+    RolloutBatchItemResponse, RolloutBatchRequest, RolloutBatchResponse, RolloutExecutorInfo,
+    RolloutGenerateRequest, RolloutGenerateResponse, RolloutPolicyInfo,
 };
 use crate::api::state::ApiState;
 
@@ -138,6 +138,44 @@ pub async fn publish_policy(
         .await
         .map_err(ApiError::from)?;
     Ok((StatusCode::CREATED, Json(policy)))
+}
+
+/// Validate, redeem, and atomically publish a device-resident policy version.
+#[utoipa::path(
+    post,
+    path = "/api/v1/rollout-executors/{name}/device-policies",
+    params(("name" = String, Path, description = "Executor name")),
+    request_body = PublishDeviceRolloutPolicyRequest,
+    responses(
+        (status = 201, description = "Device policy published", body = RolloutPolicyInfo),
+        (status = 400, description = "Invalid token or tensor manifest"),
+        (status = 404, description = "Executor not found"),
+        (status = 409, description = "Version conflict"),
+        (status = 503, description = "Device sidecar unavailable")
+    ),
+    tag = "Rollouts"
+)]
+pub async fn publish_device_policy(
+    State(state): State<Arc<ApiState>>,
+    Path(name): Path<String>,
+    Json(request): Json<PublishDeviceRolloutPolicyRequest>,
+) -> Result<(StatusCode, Json<RolloutPolicyInfo>), ApiError> {
+    #[cfg(unix)]
+    {
+        let executor = state.rollout().get(&name).await.map_err(ApiError::from)?;
+        let policy = executor
+            .publish_device_policy(request)
+            .await
+            .map_err(ApiError::from)?;
+        Ok((StatusCode::CREATED, Json(policy)))
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (state, name, request);
+        Err(ApiError::BadRequest(
+            "device-resident rollout handoff requires a Unix host".into(),
+        ))
+    }
 }
 
 /// Stop routing one policy version and unload it after active requests drain.

--- a/src/api/handlers/rollouts.rs
+++ b/src/api/handlers/rollouts.rs
@@ -160,7 +160,7 @@ pub async fn publish_device_policy(
     Path(name): Path<String>,
     Json(request): Json<PublishDeviceRolloutPolicyRequest>,
 ) -> Result<(StatusCode, Json<RolloutPolicyInfo>), ApiError> {
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     {
         let executor = state.rollout().get(&name).await.map_err(ApiError::from)?;
         let policy = executor
@@ -169,11 +169,11 @@ pub async fn publish_device_policy(
             .map_err(ApiError::from)?;
         Ok((StatusCode::CREATED, Json(policy)))
     }
-    #[cfg(not(unix))]
+    #[cfg(not(target_os = "linux"))]
     {
         let _ = (state, name, request);
         Err(ApiError::BadRequest(
-            "device-resident rollout handoff requires a Unix host".into(),
+            "device-resident rollout handoff requires Linux".into(),
         ))
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -19,7 +19,7 @@
 //! ```
 
 pub mod admission;
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 pub(crate) mod device_handoff;
 #[path = "errors.rs"]
 pub mod error;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -19,6 +19,8 @@
 //! ```
 
 pub mod admission;
+#[cfg(unix)]
+pub(crate) mod device_handoff;
 #[path = "errors.rs"]
 pub mod error;
 pub mod handlers;
@@ -112,6 +114,7 @@ use state::ApiState;
         handlers::rollouts::get_executor,
         handlers::rollouts::delete_executor,
         handlers::rollouts::publish_policy,
+        handlers::rollouts::publish_device_policy,
         handlers::rollouts::retire_policy,
         handlers::rollouts::generate,
         handlers::rollouts::generate_batch,
@@ -141,6 +144,7 @@ use state::ApiState;
         types::ResizeForkPoolRequest,
         rollout::CreateRolloutExecutorRequest,
         rollout::PublishRolloutPolicyRequest,
+        rollout::PublishDeviceRolloutPolicyRequest,
         rollout::RolloutPrompt,
         rollout::RolloutSamplingParams,
         rollout::RolloutGenerateRequest,
@@ -324,6 +328,10 @@ pub fn create_router(state: Arc<ApiState>, cors_origins: Vec<String>) -> Router 
         .route("/{name}", get(handlers::rollouts::get_executor))
         .route("/{name}", delete(handlers::rollouts::delete_executor))
         .route("/{name}/policies", post(handlers::rollouts::publish_policy))
+        .route(
+            "/{name}/device-policies",
+            post(handlers::rollouts::publish_device_policy),
+        )
         .route(
             "/{name}/policies/{policy}/{version}",
             delete(handlers::rollouts::retire_policy),

--- a/src/api/rollout.rs
+++ b/src/api/rollout.rs
@@ -19,6 +19,9 @@ use std::time::{Duration, Instant};
 use tokio::sync::{Mutex, Notify, OnceCell, RwLock, Semaphore};
 use utoipa::ToSchema;
 
+#[cfg(unix)]
+use crate::api::device_handoff::DeviceHandoffClient;
+
 const DEFAULT_MAX_CONCURRENT: u32 = 32;
 const MAX_CONCURRENT: u32 = 1024;
 const DEFAULT_MAX_QUEUE_DEPTH: u32 = 256;
@@ -50,6 +53,9 @@ pub struct CreateRolloutExecutorRequest {
     pub endpoint: String,
     /// Host directory beneath which adapter paths must resolve.
     pub adapter_root: String,
+    /// Optional private Unix socket for device-resident LoRA handoff without host staging.
+    #[serde(default)]
+    pub device_adapter_socket: Option<String>,
     /// Optional ordinary fork pool used by framework adapters as a compatibility fallback.
     #[serde(default)]
     pub fallback_pool: Option<String>,
@@ -76,6 +82,9 @@ pub struct RolloutExecutorInfo {
     pub endpoint: String,
     /// Confined adapter root.
     pub adapter_root: String,
+    /// Private device-adapter sidecar socket, when enabled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub device_adapter_socket: Option<String>,
     /// Optional isolated-worker fallback pool.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fallback_pool: Option<String>,
@@ -114,6 +123,21 @@ pub struct PublishRolloutPolicyRequest {
     pub retain_previous: bool,
 }
 
+/// Request to publish one immutable LoRA policy directly from clone GPU memory.
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PublishDeviceRolloutPolicyRequest {
+    /// Logical policy or experiment identifier.
+    pub policy: String,
+    /// Immutable version identifier, normally the optimizer step.
+    pub version: String,
+    /// Hex-encoded one-use token returned by the clone's CUDA publisher.
+    pub tensor_bundle_token: String,
+    /// Keep the previous current version routable instead of retiring it.
+    #[serde(default)]
+    pub retain_previous: bool,
+}
+
 /// Published policy metadata.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
@@ -122,10 +146,12 @@ pub struct RolloutPolicyInfo {
     pub policy: String,
     /// Immutable version identifier.
     pub version: String,
-    /// Verified adapter SHA-256.
+    /// Verified file-adapter digest or controller-derived device-publication digest.
     pub adapter_sha256: String,
     /// Opaque backend model name assigned by smolvm.
     pub backend_model: String,
+    /// Policy transport: `filesystem` or `device`.
+    pub source: String,
     /// Whether this is the default version for the policy.
     pub current: bool,
     /// Requests using this version right now.
@@ -375,10 +401,27 @@ struct PolicyEntry {
     version: String,
     adapter_sha256: String,
     backend_model: String,
+    source: AdapterSource,
+    device_token_fingerprint: Option<[u8; 32]>,
     active: AtomicUsize,
     retiring: AtomicBool,
     drained: Notify,
     retirement: Mutex<()>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum AdapterSource {
+    Filesystem,
+    Device,
+}
+
+impl AdapterSource {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Filesystem => "filesystem",
+            Self::Device => "device",
+        }
+    }
 }
 
 struct PolicyGuard {
@@ -397,6 +440,8 @@ struct ExecutorConfig {
     name: String,
     endpoint: String,
     adapter_root: PathBuf,
+    #[cfg(unix)]
+    device_handoff: Option<DeviceHandoffClient>,
     fallback_pool: Option<String>,
     max_concurrent: u32,
     max_queue_depth: u32,
@@ -547,11 +592,27 @@ impl RolloutExecutor {
             .connect_timeout(Duration::from_secs(5))
             .build()
             .map_err(|error| RolloutError::Backend(format!("build rollout client: {error}")))?;
+        #[cfg(unix)]
+        let device_handoff = request
+            .device_adapter_socket
+            .as_deref()
+            .map(|path| {
+                DeviceHandoffClient::new(Path::new(path), Duration::from_secs(timeout_secs))
+            })
+            .transpose()?;
+        #[cfg(not(unix))]
+        if request.device_adapter_socket.is_some() {
+            return Err(RolloutError::BadRequest(
+                "device-resident rollout handoff requires a Unix host".into(),
+            ));
+        }
         Ok(Self {
             config: ExecutorConfig {
                 name: request.name,
                 endpoint,
                 adapter_root,
+                #[cfg(unix)]
+                device_handoff,
                 fallback_pool: request.fallback_pool,
                 max_concurrent,
                 max_queue_depth,
@@ -589,6 +650,10 @@ impl RolloutExecutor {
                 response.status()
             )));
         }
+        #[cfg(unix)]
+        if let Some(handoff) = &self.config.device_handoff {
+            handoff.health().await?;
+        }
         Ok(())
     }
 
@@ -602,17 +667,43 @@ impl RolloutExecutor {
                 version: entry.version.clone(),
                 adapter_sha256: entry.adapter_sha256.clone(),
                 backend_model: entry.backend_model.clone(),
+                source: entry.source.as_str().into(),
                 current: state.current.get(&entry.policy) == Some(&entry.version),
                 active_requests: entry.active.load(Ordering::Acquire) as u32,
                 retiring: entry.retiring.load(Ordering::Acquire),
             })
             .collect();
         policies.sort_by(|a, b| (&a.policy, &a.version).cmp(&(&b.policy, &b.version)));
+        let mut capabilities = vec![
+            "multi_lora".into(),
+            "text_prompts".into(),
+            "token_id_prompts".into(),
+            "token_id_outputs".into(),
+            "logprobs".into(),
+            "continuous_batching".into(),
+        ];
+        #[cfg(unix)]
+        if self.config.device_handoff.is_some() {
+            capabilities.push("device_lora_handoff".into());
+        }
         RolloutExecutorInfo {
             name: self.config.name.clone(),
             backend: "vllm".into(),
             endpoint: self.config.endpoint.clone(),
             adapter_root: self.config.adapter_root.display().to_string(),
+            device_adapter_socket: {
+                #[cfg(unix)]
+                {
+                    self.config
+                        .device_handoff
+                        .as_ref()
+                        .map(|client| client.path().display().to_string())
+                }
+                #[cfg(not(unix))]
+                {
+                    None
+                }
+            },
             fallback_pool: self.config.fallback_pool.clone(),
             max_concurrent_requests: self.config.max_concurrent,
             max_queue_depth: self.config.max_queue_depth,
@@ -621,14 +712,7 @@ impl RolloutExecutor {
             queued_requests: self.queued.load(Ordering::Acquire),
             accepting: self.accepting.load(Ordering::Acquire),
             policies,
-            capabilities: vec![
-                "multi_lora".into(),
-                "text_prompts".into(),
-                "token_id_prompts".into(),
-                "token_id_outputs".into(),
-                "logprobs".into(),
-                "continuous_batching".into(),
-            ],
+            capabilities,
         }
     }
 
@@ -652,7 +736,9 @@ impl RolloutExecutor {
                 .versions
                 .get(&(request.policy.clone(), request.version.clone()))
             {
-                if existing.adapter_sha256 != request.adapter_sha256 {
+                if existing.source != AdapterSource::Filesystem
+                    || existing.adapter_sha256 != request.adapter_sha256
+                {
                     return Err(RolloutError::Conflict(format!(
                         "policy '{}:{}' already exists with a different digest",
                         request.policy, request.version
@@ -669,6 +755,7 @@ impl RolloutExecutor {
                     version: existing.version.clone(),
                     adapter_sha256: existing.adapter_sha256.clone(),
                     backend_model: existing.backend_model.clone(),
+                    source: existing.source.as_str().into(),
                     current: state.current.get(&existing.policy) == Some(&existing.version),
                     active_requests: existing.active.load(Ordering::Acquire) as u32,
                     retiring: false,
@@ -705,6 +792,8 @@ impl RolloutExecutor {
             version: request.version.clone(),
             adapter_sha256: request.adapter_sha256,
             backend_model: backend_model.clone(),
+            source: AdapterSource::Filesystem,
+            device_token_fingerprint: None,
             active: AtomicUsize::new(0),
             retiring: AtomicBool::new(false),
             drained: Notify::new(),
@@ -747,12 +836,185 @@ impl RolloutExecutor {
                 }
             });
         }
-        metrics::counter!("smolvm_rollout_policy_publications_total", "executor" => self.config.name.clone()).increment(1);
+        metrics::counter!("smolvm_rollout_policy_publications_total", "executor" => self.config.name.clone(), "source" => "filesystem").increment(1);
         Ok(RolloutPolicyInfo {
             policy: entry.policy.clone(),
             version: entry.version.clone(),
             adapter_sha256: entry.adapter_sha256.clone(),
             backend_model,
+            source: AdapterSource::Filesystem.as_str().into(),
+            current: true,
+            active_requests: 0,
+            retiring: false,
+        })
+    }
+
+    #[cfg(unix)]
+    pub(crate) async fn publish_device_policy(
+        self: &Arc<Self>,
+        request: PublishDeviceRolloutPolicyRequest,
+    ) -> Result<RolloutPolicyInfo, RolloutError> {
+        validate_name("policy", &request.policy)?;
+        validate_name("version", &request.version)?;
+        let token = hex::decode(&request.tensor_bundle_token).map_err(|_| {
+            RolloutError::BadRequest("tensorBundleToken must be hexadecimal".into())
+        })?;
+        if token.len() != 32 {
+            return Err(RolloutError::BadRequest(
+                "tensorBundleToken must contain exactly 32 bytes".into(),
+            ));
+        }
+        let token_fingerprint: [u8; 32] = Sha256::digest(&token).into();
+        let _publish = self.publish_lock.lock().await;
+        if !self.accepting.load(Ordering::Acquire) {
+            return Err(RolloutError::Unavailable(format!(
+                "rollout executor '{}' is draining",
+                self.config.name
+            )));
+        }
+        {
+            let state = self.policy_state.read().await;
+            if let Some(existing) = state
+                .versions
+                .get(&(request.policy.clone(), request.version.clone()))
+            {
+                if existing.source != AdapterSource::Device
+                    || existing.device_token_fingerprint != Some(token_fingerprint)
+                {
+                    return Err(RolloutError::Conflict(format!(
+                        "policy '{}:{}' already exists with a different device publication",
+                        request.policy, request.version
+                    )));
+                }
+                if existing.retiring.load(Ordering::Acquire) {
+                    return Err(RolloutError::Unavailable(format!(
+                        "policy '{}:{}' is retiring",
+                        request.policy, request.version
+                    )));
+                }
+                return Ok(RolloutPolicyInfo {
+                    policy: existing.policy.clone(),
+                    version: existing.version.clone(),
+                    adapter_sha256: existing.adapter_sha256.clone(),
+                    backend_model: existing.backend_model.clone(),
+                    source: existing.source.as_str().into(),
+                    current: state.current.get(&existing.policy) == Some(&existing.version),
+                    active_requests: existing.active.load(Ordering::Acquire) as u32,
+                    retiring: false,
+                });
+            }
+            if state.versions.len() >= MAX_POLICY_VERSIONS {
+                return Err(RolloutError::Unavailable(format!(
+                    "executor reached its {MAX_POLICY_VERSIONS}-policy-version limit"
+                )));
+            }
+        }
+        let handoff = self.config.device_handoff.as_ref().ok_or_else(|| {
+            RolloutError::BadRequest(format!(
+                "rollout executor '{}' has no deviceAdapterSocket",
+                self.config.name
+            ))
+        })?;
+        let redeem_token = token.clone();
+        let bundle = tokio::task::spawn_blocking(move || {
+            crate::cuda_daemon::redeem_tensor_bundle(&redeem_token)
+        })
+        .await
+        .map_err(|error| RolloutError::Backend(format!("tensor redemption task failed: {error}")))?
+        .map_err(|error| {
+            RolloutError::Unavailable(format!("redeem device tensor bundle: {error}"))
+        })?;
+        let mut digest = Sha256::new();
+        digest.update(b"smolvm-device-publication-v1\0");
+        digest.update(&token);
+        digest.update(&bundle.metadata);
+        let publication_sha256 = hex::encode(digest.finalize());
+        let backend_model = backend_model_name(
+            &self.config.name,
+            &request.policy,
+            &request.version,
+            &publication_sha256,
+        );
+        if let Err(error) = handoff.load(&backend_model, bundle).await {
+            if let Err(cleanup) = handoff.unload(&backend_model).await {
+                let handoff = handoff.clone();
+                let executor = self.config.name.clone();
+                let cleanup_model = backend_model.clone();
+                tokio::spawn(async move {
+                    let mut last = cleanup;
+                    for attempt in 1..=3 {
+                        tokio::time::sleep(Duration::from_secs(attempt)).await;
+                        match handoff.unload(&cleanup_model).await {
+                            Ok(()) => return,
+                            Err(error) => last = error,
+                        }
+                    }
+                    tracing::warn!(
+                        %executor,
+                        model = %cleanup_model,
+                        error = %last.message(),
+                        "failed to clean up an uncertain device-adapter load"
+                    );
+                });
+            }
+            return Err(error);
+        }
+        let entry = Arc::new(PolicyEntry {
+            policy: request.policy.clone(),
+            version: request.version.clone(),
+            adapter_sha256: publication_sha256,
+            backend_model: backend_model.clone(),
+            source: AdapterSource::Device,
+            device_token_fingerprint: Some(token_fingerprint),
+            active: AtomicUsize::new(0),
+            retiring: AtomicBool::new(false),
+            drained: Notify::new(),
+            retirement: Mutex::new(()),
+        });
+        let previous = {
+            let mut state = self.policy_state.write().await;
+            let previous_version = state
+                .current
+                .insert(request.policy.clone(), request.version.clone());
+            state.versions.insert(
+                (request.policy.clone(), request.version.clone()),
+                entry.clone(),
+            );
+            if request.retain_previous {
+                None
+            } else {
+                previous_version.and_then(|version| {
+                    if version == request.version {
+                        None
+                    } else {
+                        state
+                            .versions
+                            .get(&(request.policy.clone(), version))
+                            .cloned()
+                            .inspect(|entry| entry.retiring.store(true, Ordering::Release))
+                    }
+                })
+            }
+        };
+        if let Some(previous) = previous {
+            let executor = self.clone();
+            tokio::spawn(async move {
+                if let Err(error) = executor.retire_tracked_entry(previous).await {
+                    tracing::warn!(
+                        executor = %executor.config.name,
+                        error = %error.message(),
+                        "failed to retire previous rollout policy version"
+                    );
+                }
+            });
+        }
+        metrics::counter!("smolvm_rollout_policy_publications_total", "executor" => self.config.name.clone(), "source" => "device").increment(1);
+        Ok(RolloutPolicyInfo {
+            policy: entry.policy.clone(),
+            version: entry.version.clone(),
+            adapter_sha256: entry.adapter_sha256.clone(),
+            backend_model,
+            source: AdapterSource::Device.as_str().into(),
             current: true,
             active_requests: 0,
             retiring: false,
@@ -807,7 +1069,26 @@ impl RolloutExecutor {
             }
             notified.await;
         }
-        self.unload_adapter(&entry.backend_model).await?;
+        match entry.source {
+            AdapterSource::Filesystem => self.unload_adapter(&entry.backend_model).await?,
+            AdapterSource::Device => {
+                #[cfg(unix)]
+                self.config
+                    .device_handoff
+                    .as_ref()
+                    .ok_or_else(|| {
+                        RolloutError::Unavailable(
+                            "device adapter sidecar is no longer configured".into(),
+                        )
+                    })?
+                    .unload(&entry.backend_model)
+                    .await?;
+                #[cfg(not(unix))]
+                return Err(RolloutError::Unavailable(
+                    "device-resident rollout handoff requires a Unix host".into(),
+                ));
+            }
+        }
         let mut state = self.policy_state.write().await;
         let key = (entry.policy.clone(), entry.version.clone());
         if state
@@ -1664,6 +1945,7 @@ mod tests {
                 backend: "vllm".into(),
                 endpoint: format!("http://{address}"),
                 adapter_root: root.path().display().to_string(),
+                device_adapter_socket: None,
                 fallback_pool: None,
                 max_concurrent_requests: Some(2),
                 max_queue_depth: Some(2),
@@ -1702,6 +1984,7 @@ mod tests {
                 backend: "vllm".into(),
                 endpoint: format!("http://{address}"),
                 adapter_root: root.path().display().to_string(),
+                device_adapter_socket: None,
                 fallback_pool: None,
                 max_concurrent_requests: Some(2),
                 max_queue_depth: Some(2),
@@ -1829,6 +2112,7 @@ mod tests {
                 backend: "vllm".into(),
                 endpoint: format!("http://{address}"),
                 adapter_root: root.path().display().to_string(),
+                device_adapter_socket: None,
                 fallback_pool: None,
                 max_concurrent_requests: Some(2),
                 max_queue_depth: Some(2),
@@ -1927,6 +2211,7 @@ mod tests {
             backend: "vllm".into(),
             endpoint: "http://127.0.0.1:1".into(),
             adapter_root: root.path().display().to_string(),
+            device_adapter_socket: None,
             fallback_pool: None,
             max_concurrent_requests: Some(1),
             max_queue_depth: Some(0),

--- a/src/api/rollout.rs
+++ b/src/api/rollout.rs
@@ -19,7 +19,7 @@ use std::time::{Duration, Instant};
 use tokio::sync::{Mutex, Notify, OnceCell, RwLock, Semaphore};
 use utoipa::ToSchema;
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 use crate::api::device_handoff::DeviceHandoffClient;
 
 const DEFAULT_MAX_CONCURRENT: u32 = 32;
@@ -402,6 +402,7 @@ struct PolicyEntry {
     adapter_sha256: String,
     backend_model: String,
     source: AdapterSource,
+    #[cfg(target_os = "linux")]
     device_token_fingerprint: Option<[u8; 32]>,
     active: AtomicUsize,
     retiring: AtomicBool,
@@ -412,6 +413,7 @@ struct PolicyEntry {
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum AdapterSource {
     Filesystem,
+    #[cfg(target_os = "linux")]
     Device,
 }
 
@@ -419,6 +421,7 @@ impl AdapterSource {
     fn as_str(self) -> &'static str {
         match self {
             Self::Filesystem => "filesystem",
+            #[cfg(target_os = "linux")]
             Self::Device => "device",
         }
     }
@@ -440,7 +443,7 @@ struct ExecutorConfig {
     name: String,
     endpoint: String,
     adapter_root: PathBuf,
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     device_handoff: Option<DeviceHandoffClient>,
     fallback_pool: Option<String>,
     max_concurrent: u32,
@@ -592,7 +595,7 @@ impl RolloutExecutor {
             .connect_timeout(Duration::from_secs(5))
             .build()
             .map_err(|error| RolloutError::Backend(format!("build rollout client: {error}")))?;
-        #[cfg(unix)]
+        #[cfg(target_os = "linux")]
         let device_handoff = request
             .device_adapter_socket
             .as_deref()
@@ -600,10 +603,10 @@ impl RolloutExecutor {
                 DeviceHandoffClient::new(Path::new(path), Duration::from_secs(timeout_secs))
             })
             .transpose()?;
-        #[cfg(not(unix))]
+        #[cfg(not(target_os = "linux"))]
         if request.device_adapter_socket.is_some() {
             return Err(RolloutError::BadRequest(
-                "device-resident rollout handoff requires a Unix host".into(),
+                "device-resident rollout handoff requires Linux".into(),
             ));
         }
         Ok(Self {
@@ -611,7 +614,7 @@ impl RolloutExecutor {
                 name: request.name,
                 endpoint,
                 adapter_root,
-                #[cfg(unix)]
+                #[cfg(target_os = "linux")]
                 device_handoff,
                 fallback_pool: request.fallback_pool,
                 max_concurrent,
@@ -650,7 +653,7 @@ impl RolloutExecutor {
                 response.status()
             )));
         }
-        #[cfg(unix)]
+        #[cfg(target_os = "linux")]
         if let Some(handoff) = &self.config.device_handoff {
             handoff.health().await?;
         }
@@ -674,32 +677,41 @@ impl RolloutExecutor {
             })
             .collect();
         policies.sort_by(|a, b| (&a.policy, &a.version).cmp(&(&b.policy, &b.version)));
-        let mut capabilities = vec![
+        let device_handoff_enabled = {
+            #[cfg(target_os = "linux")]
+            {
+                self.config.device_handoff.is_some()
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                false
+            }
+        };
+        let capabilities = vec![
             "multi_lora".into(),
             "text_prompts".into(),
             "token_id_prompts".into(),
             "token_id_outputs".into(),
             "logprobs".into(),
             "continuous_batching".into(),
-        ];
-        #[cfg(unix)]
-        if self.config.device_handoff.is_some() {
-            capabilities.push("device_lora_handoff".into());
-        }
+        ]
+        .into_iter()
+        .chain(device_handoff_enabled.then(|| "device_lora_handoff".into()))
+        .collect();
         RolloutExecutorInfo {
             name: self.config.name.clone(),
             backend: "vllm".into(),
             endpoint: self.config.endpoint.clone(),
             adapter_root: self.config.adapter_root.display().to_string(),
             device_adapter_socket: {
-                #[cfg(unix)]
+                #[cfg(target_os = "linux")]
                 {
                     self.config
                         .device_handoff
                         .as_ref()
                         .map(|client| client.path().display().to_string())
                 }
-                #[cfg(not(unix))]
+                #[cfg(not(target_os = "linux"))]
                 {
                     None
                 }
@@ -793,6 +805,7 @@ impl RolloutExecutor {
             adapter_sha256: request.adapter_sha256,
             backend_model: backend_model.clone(),
             source: AdapterSource::Filesystem,
+            #[cfg(target_os = "linux")]
             device_token_fingerprint: None,
             active: AtomicUsize::new(0),
             retiring: AtomicBool::new(false),
@@ -849,7 +862,7 @@ impl RolloutExecutor {
         })
     }
 
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     pub(crate) async fn publish_device_policy(
         self: &Arc<Self>,
         request: PublishDeviceRolloutPolicyRequest,
@@ -1071,8 +1084,8 @@ impl RolloutExecutor {
         }
         match entry.source {
             AdapterSource::Filesystem => self.unload_adapter(&entry.backend_model).await?,
+            #[cfg(target_os = "linux")]
             AdapterSource::Device => {
-                #[cfg(unix)]
                 self.config
                     .device_handoff
                     .as_ref()
@@ -1083,10 +1096,6 @@ impl RolloutExecutor {
                     })?
                     .unload(&entry.backend_model)
                     .await?;
-                #[cfg(not(unix))]
-                return Err(RolloutError::Unavailable(
-                    "device-resident rollout handoff requires a Unix host".into(),
-                ));
             }
         }
         let mut state = self.policy_state.write().await;

--- a/src/cli/internal_boot.rs
+++ b/src/cli/internal_boot.rs
@@ -564,7 +564,10 @@ pub fn run(config_path: PathBuf) -> smolvm::Result<()> {
             .parent()
             .unwrap_or_else(|| std::path::Path::new("/tmp"))
             .join("cuda.sock");
-        match smolvm::cuda_host::start(&path, std::env::var_os("SMOLVM_SNAPSHOT_DIR").is_some()) {
+        match smolvm::cuda_host::start_with_clone_mode(
+            &path,
+            std::env::var_os("SMOLVM_SNAPSHOT_DIR").is_some(),
+        ) {
             Ok(()) => {
                 tracing::info!(path = %path.display(), "CUDA host server started");
                 Some(path)

--- a/src/cli/internal_boot.rs
+++ b/src/cli/internal_boot.rs
@@ -564,7 +564,7 @@ pub fn run(config_path: PathBuf) -> smolvm::Result<()> {
             .parent()
             .unwrap_or_else(|| std::path::Path::new("/tmp"))
             .join("cuda.sock");
-        match smolvm::cuda_host::start(&path) {
+        match smolvm::cuda_host::start(&path, std::env::var_os("SMOLVM_SNAPSHOT_DIR").is_some()) {
             Ok(()) => {
                 tracing::info!(path = %path.display(), "CUDA host server started");
                 Some(path)

--- a/src/cli/pack_run.rs
+++ b/src/cli/pack_run.rs
@@ -652,7 +652,7 @@ impl PackRunCmd {
         // serving well before the guest workload dials in.
         #[cfg(unix)]
         if cuda_enabled {
-            match smolvm::cuda_host::start(&cuda_sock, false) {
+            match smolvm::cuda_host::start(&cuda_sock) {
                 Ok(()) => {
                     if self.debug {
                         eprintln!("debug: CUDA host serving {}", cuda_sock.display());

--- a/src/cli/pack_run.rs
+++ b/src/cli/pack_run.rs
@@ -652,7 +652,7 @@ impl PackRunCmd {
         // serving well before the guest workload dials in.
         #[cfg(unix)]
         if cuda_enabled {
-            match smolvm::cuda_host::start(&cuda_sock) {
+            match smolvm::cuda_host::start(&cuda_sock, false) {
                 Ok(()) => {
                     if self.debug {
                         eprintln!("debug: CUDA host serving {}", cuda_sock.display());

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -65,6 +65,7 @@ fn tensor_bundle_socket_path(cuda_socket: &Path) -> PathBuf {
 /// The descriptor is owned by the caller. Dropping it releases only this
 /// process's reference; a descriptor already transferred with `SCM_RIGHTS`
 /// remains valid in the receiving process.
+#[cfg(any(target_os = "linux", test))]
 pub(crate) struct RedeemedTensorBundle {
     pub(crate) allocation: OwnedFd,
     pub(crate) allocation_size: u64,
@@ -384,6 +385,7 @@ fn serve_tensor_bundle_consumer(mut stream: UnixStream) -> io::Result<()> {
     send_tensor_bundle_to_consumer(&mut stream, &bundle)
 }
 
+#[cfg(any(target_os = "linux", test))]
 fn redeem_tensor_bundle_from_stream(
     mut stream: UnixStream,
     token: &[u8],
@@ -430,6 +432,7 @@ fn redeem_tensor_bundle_from_stream(
 /// Redeem a clone worker's random one-use publication token into an owned GPU
 /// allocation. This is intentionally crate-private: only smolvm's managed
 /// rollout executor may cross the daemon's bearer-token boundary.
+#[cfg(any(target_os = "linux", test))]
 pub(crate) fn redeem_tensor_bundle(token: &[u8]) -> io::Result<RedeemedTensorBundle> {
     let stream = UnixStream::connect(tensor_bundle_socket_path(&socket_path()))?;
     redeem_tensor_bundle_from_stream(stream, token)

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -13,10 +13,12 @@
 use crate::platform::uds::UdsListener;
 use smolvm_cuda::host::{serve, serve_with_options, Backend, CpuBackend, GpuBackend, ServeOptions};
 use std::io;
-use std::os::unix::net::UnixStream;
+use std::io::{Read, Write};
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -28,6 +30,448 @@ pub fn socket_path() -> PathBuf {
         .map(PathBuf::from)
         .unwrap_or_else(|| std::env::temp_dir().join("smolvm"));
     root.join("cuda-daemon.sock")
+}
+
+const TENSOR_PUBLISH_MAGIC: [u8; 4] = *b"TBP1";
+const TENSOR_CONSUME_MAGIC: [u8; 4] = *b"TBC1";
+const TENSOR_RESPONSE_MAGIC: [u8; 4] = *b"TBR1";
+const MAX_TENSOR_BUNDLE_METADATA: usize = (2 << 20) + 64;
+const MAX_PENDING_TENSOR_BUNDLES: usize = 64;
+const MAX_PENDING_TENSOR_BYTES: u64 = 32 << 30;
+const TENSOR_BUNDLE_TTL: Duration = Duration::from_secs(60);
+static TENSOR_BUNDLE_SERVICE_READY: AtomicBool = AtomicBool::new(false);
+
+#[derive(Debug)]
+struct PendingTensorBundle {
+    allocation: OwnedFd,
+    allocation_size: u64,
+    metadata: Vec<u8>,
+    created: Instant,
+}
+
+fn pending_tensor_bundles(
+) -> &'static Mutex<std::collections::HashMap<Vec<u8>, PendingTensorBundle>> {
+    static BUNDLES: OnceLock<Mutex<std::collections::HashMap<Vec<u8>, PendingTensorBundle>>> =
+        OnceLock::new();
+    BUNDLES.get_or_init(|| Mutex::new(std::collections::HashMap::new()))
+}
+
+fn tensor_bundle_socket_path(cuda_socket: &Path) -> PathBuf {
+    PathBuf::from(format!("{}.tensors", cuda_socket.display()))
+}
+
+/// One immutable device allocation redeemed from a clone worker publication.
+///
+/// The descriptor is owned by the caller. Dropping it releases only this
+/// process's reference; a descriptor already transferred with `SCM_RIGHTS`
+/// remains valid in the receiving process.
+pub(crate) struct RedeemedTensorBundle {
+    pub(crate) allocation: OwnedFd,
+    pub(crate) allocation_size: u64,
+    pub(crate) metadata: Vec<u8>,
+}
+
+fn prune_tensor_bundles(
+    bundles: &mut std::collections::HashMap<Vec<u8>, PendingTensorBundle>,
+    now: Instant,
+) {
+    bundles.retain(|_, bundle| now.duration_since(bundle.created) < TENSOR_BUNDLE_TTL);
+}
+
+fn pending_tensor_bytes(bundles: &std::collections::HashMap<Vec<u8>, PendingTensorBundle>) -> u64 {
+    bundles.values().map(|bundle| bundle.allocation_size).sum()
+}
+
+fn fresh_tensor_token() -> io::Result<Vec<u8>> {
+    let mut token = vec![0u8; 32];
+    std::fs::File::open("/dev/urandom")?.read_exact(&mut token)?;
+    Ok(token)
+}
+
+fn encode_tensor_bundle_metadata(bundle: &smolvm_cuda::host::DeviceTensorBundle) -> Vec<u8> {
+    let mut metadata = Vec::with_capacity(8 + bundle.manifest.len() + bundle.tensors.len() * 16);
+    metadata.extend_from_slice(&(bundle.manifest.len() as u32).to_le_bytes());
+    metadata.extend_from_slice(&(bundle.tensors.len() as u32).to_le_bytes());
+    metadata.extend_from_slice(&bundle.manifest);
+    for tensor in &bundle.tensors {
+        metadata.extend_from_slice(&tensor.offset.to_le_bytes());
+        metadata.extend_from_slice(&tensor.size.to_le_bytes());
+    }
+    metadata
+}
+
+fn validate_tensor_bundle_metadata(metadata: &[u8], allocation_size: u64) -> io::Result<()> {
+    if metadata.len() < 8 || metadata.len() > MAX_TENSOR_BUNDLE_METADATA {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid tensor-bundle metadata length",
+        ));
+    }
+    let manifest_len = u32::from_le_bytes(metadata[0..4].try_into().unwrap()) as usize;
+    let count = u32::from_le_bytes(metadata[4..8].try_into().unwrap()) as usize;
+    let expected = 8usize
+        .checked_add(manifest_len)
+        .and_then(|size| size.checked_add(count.checked_mul(16)?))
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "metadata overflow"))?;
+    if expected != metadata.len() || manifest_len > 1 << 20 || count == 0 || count > 65_536 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "inconsistent tensor-bundle metadata",
+        ));
+    }
+    let mut prior_end = 0u64;
+    for tensor in metadata[8 + manifest_len..].chunks_exact(16) {
+        let offset = u64::from_le_bytes(tensor[0..8].try_into().unwrap());
+        let size = u64::from_le_bytes(tensor[8..16].try_into().unwrap());
+        let end = offset
+            .checked_add(size)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "tensor range overflow"))?;
+        if size == 0 || offset != prior_end || end > allocation_size {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "tensor range falls outside its allocation",
+            ));
+        }
+        prior_end = end;
+    }
+    Ok(())
+}
+
+fn send_fd_header(stream: &UnixStream, fd: i32, header: &[u8; 16]) -> io::Result<()> {
+    let mut iov = libc::iovec {
+        iov_base: header.as_ptr() as *mut libc::c_void,
+        iov_len: header.len(),
+    };
+    // SAFETY: standard sendmsg with one immutable header and one owned fd. The
+    // receiving process gets its own descriptor reference through SCM_RIGHTS.
+    unsafe {
+        let mut cmsgbuf = [0u8; 32];
+        let mut msg: libc::msghdr = std::mem::zeroed();
+        msg.msg_iov = &mut iov;
+        msg.msg_iovlen = 1;
+        msg.msg_control = cmsgbuf.as_mut_ptr().cast();
+        msg.msg_controllen = libc::CMSG_SPACE(4) as _;
+        let cmsg = libc::CMSG_FIRSTHDR(&msg);
+        (*cmsg).cmsg_level = libc::SOL_SOCKET;
+        (*cmsg).cmsg_type = libc::SCM_RIGHTS;
+        (*cmsg).cmsg_len = libc::CMSG_LEN(4) as _;
+        std::ptr::copy_nonoverlapping((&fd as *const i32).cast::<u8>(), libc::CMSG_DATA(cmsg), 4);
+        let sent = libc::sendmsg(stream.as_raw_fd(), &msg, libc::MSG_NOSIGNAL);
+        if sent < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        if sent as usize != header.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                "short tensor-bundle control header",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn recv_fd_header(stream: &mut UnixStream) -> io::Result<Option<(OwnedFd, [u8; 16])>> {
+    let mut header = [0u8; 16];
+    let mut iov = libc::iovec {
+        iov_base: header.as_mut_ptr().cast(),
+        iov_len: header.len(),
+    };
+    // SAFETY: recvmsg writes within the fixed header/control buffers. A valid
+    // SCM_RIGHTS message transfers ownership of exactly one descriptor.
+    let (received, fd) = unsafe {
+        let mut cmsgbuf = [0u8; 32];
+        let mut msg: libc::msghdr = std::mem::zeroed();
+        msg.msg_iov = &mut iov;
+        msg.msg_iovlen = 1;
+        msg.msg_control = cmsgbuf.as_mut_ptr().cast();
+        msg.msg_controllen = libc::CMSG_SPACE(4) as _;
+        #[cfg(target_os = "linux")]
+        let flags = libc::MSG_CMSG_CLOEXEC;
+        #[cfg(not(target_os = "linux"))]
+        let flags = 0;
+        let received = libc::recvmsg(stream.as_raw_fd(), &mut msg, flags);
+        if received < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        if received == 0 {
+            return Ok(None);
+        }
+        let cmsg = libc::CMSG_FIRSTHDR(&msg);
+        if cmsg.is_null()
+            || msg.msg_flags & libc::MSG_CTRUNC != 0
+            || (*cmsg).cmsg_level != libc::SOL_SOCKET
+            || (*cmsg).cmsg_type != libc::SCM_RIGHTS
+            || (*cmsg).cmsg_len != libc::CMSG_LEN(4) as usize
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "tensor-bundle message did not contain one fd",
+            ));
+        }
+        let mut fd = -1;
+        std::ptr::copy_nonoverlapping(libc::CMSG_DATA(cmsg), (&mut fd as *mut i32).cast(), 4);
+        (received as usize, fd)
+    };
+    if received < header.len() {
+        stream.read_exact(&mut header[received..])?;
+    }
+    // SAFETY: SCM_RIGHTS returned a new descriptor owned by this process.
+    Ok(Some((unsafe { OwnedFd::from_raw_fd(fd) }, header)))
+}
+
+fn send_tensor_bundle_to_parent(
+    stream: &mut UnixStream,
+    bundle: smolvm_cuda::host::DeviceTensorBundle,
+) -> smolvm_cuda::host::CuResult<Vec<u8>> {
+    let channel_error = |stage: &'static str, error: io::Error| {
+        tracing::warn!(%error, stage, "tensor-bundle publication channel failed");
+        999
+    };
+    let metadata = encode_tensor_bundle_metadata(&bundle);
+    let mut header = [0u8; 16];
+    header[..4].copy_from_slice(&TENSOR_PUBLISH_MAGIC);
+    header[4..8].copy_from_slice(&(metadata.len() as u32).to_le_bytes());
+    header[8..16].copy_from_slice(&bundle.allocation_size.to_le_bytes());
+    send_fd_header(stream, bundle.allocation.as_raw_fd(), &header)
+        .map_err(|error| channel_error("descriptor", error))?;
+    stream
+        .write_all(&metadata)
+        .map_err(|error| channel_error("metadata", error))?;
+    let mut ack = [0u8; 8];
+    stream
+        .read_exact(&mut ack)
+        .map_err(|error| channel_error("acknowledgement", error))?;
+    let status = i32::from_le_bytes(ack[..4].try_into().unwrap());
+    let token_len = u32::from_le_bytes(ack[4..].try_into().unwrap()) as usize;
+    if status != 0 {
+        return Err(status);
+    }
+    if token_len == 0 || token_len > 256 {
+        return Err(999);
+    }
+    let mut token = vec![0u8; token_len];
+    stream
+        .read_exact(&mut token)
+        .map_err(|error| channel_error("token", error))?;
+    Ok(token)
+}
+
+fn tensor_bundle_receiver(mut stream: UnixStream, worker_pid: u32) {
+    loop {
+        let received = match recv_fd_header(&mut stream) {
+            Ok(Some(received)) => received,
+            Ok(None) => break,
+            Err(error) => {
+                tracing::warn!(%error, worker_pid, "tensor-bundle worker channel ended");
+                break;
+            }
+        };
+        let (allocation, header) = received;
+        let mut status = 0i32;
+        let mut token = Vec::new();
+        let mut close_after_ack = false;
+        let metadata_len = u32::from_le_bytes(header[4..8].try_into().unwrap()) as usize;
+        let allocation_size = u64::from_le_bytes(header[8..16].try_into().unwrap());
+        let mut metadata = vec![0u8; metadata_len.min(MAX_TENSOR_BUNDLE_METADATA)];
+        if header[..4] != TENSOR_PUBLISH_MAGIC
+            || metadata_len == 0
+            || metadata_len > MAX_TENSOR_BUNDLE_METADATA
+            || allocation_size == 0
+        {
+            status = 1;
+            close_after_ack = true;
+        } else if stream.read_exact(&mut metadata).is_err() {
+            status = 999;
+            close_after_ack = true;
+        } else if validate_tensor_bundle_metadata(&metadata, allocation_size).is_err() {
+            status = 1;
+        } else {
+            let mut bundles = pending_tensor_bundles().lock().unwrap();
+            prune_tensor_bundles(&mut bundles, Instant::now());
+            let capacity_available = bundles.len() < MAX_PENDING_TENSOR_BUNDLES
+                && pending_tensor_bytes(&bundles)
+                    .checked_add(allocation_size)
+                    .is_some_and(|total| total <= MAX_PENDING_TENSOR_BYTES);
+            if !capacity_available {
+                status = 2;
+            } else {
+                for _ in 0..4 {
+                    match fresh_tensor_token() {
+                        Ok(candidate) if !bundles.contains_key(&candidate) => {
+                            token = candidate;
+                            break;
+                        }
+                        Ok(_) => continue,
+                        Err(_) => break,
+                    }
+                }
+                if token.is_empty() {
+                    status = 999;
+                } else {
+                    bundles.insert(
+                        token.clone(),
+                        PendingTensorBundle {
+                            allocation,
+                            allocation_size,
+                            metadata,
+                            created: Instant::now(),
+                        },
+                    );
+                }
+            }
+        }
+        let mut ack = [0u8; 8];
+        ack[..4].copy_from_slice(&status.to_le_bytes());
+        ack[4..].copy_from_slice(&(token.len() as u32).to_le_bytes());
+        if stream.write_all(&ack).is_err()
+            || (!token.is_empty() && stream.write_all(&token).is_err())
+            || close_after_ack
+        {
+            if !token.is_empty() {
+                pending_tensor_bundles().lock().unwrap().remove(&token);
+            }
+            break;
+        }
+    }
+}
+
+fn spawn_tensor_bundle_receiver(stream: UnixStream, worker_pid: u32) -> io::Result<()> {
+    thread::Builder::new()
+        .name(format!("cuda-tensor-publisher-{worker_pid}"))
+        .spawn(move || tensor_bundle_receiver(stream, worker_pid))?;
+    Ok(())
+}
+
+fn send_tensor_bundle_to_consumer(
+    stream: &mut UnixStream,
+    bundle: &PendingTensorBundle,
+) -> io::Result<()> {
+    let mut header = [0u8; 16];
+    header[..4].copy_from_slice(&TENSOR_RESPONSE_MAGIC);
+    header[4..8].copy_from_slice(&(bundle.metadata.len() as u32).to_le_bytes());
+    header[8..16].copy_from_slice(&bundle.allocation_size.to_le_bytes());
+    send_fd_header(stream, bundle.allocation.as_raw_fd(), &header)?;
+    stream.write_all(&bundle.metadata)
+}
+
+fn serve_tensor_bundle_consumer(mut stream: UnixStream) -> io::Result<()> {
+    let mut header = [0u8; 6];
+    stream.read_exact(&mut header)?;
+    if header[..4] != TENSOR_CONSUME_MAGIC {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid tensor-bundle consume request",
+        ));
+    }
+    let token_len = u16::from_le_bytes(header[4..6].try_into().unwrap()) as usize;
+    if token_len == 0 || token_len > 256 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid tensor-bundle token length",
+        ));
+    }
+    let mut token = vec![0u8; token_len];
+    stream.read_exact(&mut token)?;
+    let bundle = {
+        let mut bundles = pending_tensor_bundles().lock().unwrap();
+        prune_tensor_bundles(&mut bundles, Instant::now());
+        bundles.remove(&token)
+    }
+    .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "tensor bundle expired"))?;
+    // Once SCM_RIGHTS starts, the receiver may own a descriptor even when a
+    // later metadata write fails. Never restore the token and risk two
+    // consumers observing one supposedly one-use publication.
+    send_tensor_bundle_to_consumer(&mut stream, &bundle)
+}
+
+fn redeem_tensor_bundle_from_stream(
+    mut stream: UnixStream,
+    token: &[u8],
+) -> io::Result<RedeemedTensorBundle> {
+    if token.is_empty() || token.len() > 256 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "invalid tensor-bundle token length",
+        ));
+    }
+    stream.write_all(&TENSOR_CONSUME_MAGIC)?;
+    stream.write_all(&(token.len() as u16).to_le_bytes())?;
+    stream.write_all(token)?;
+    let (allocation, header) = recv_fd_header(&mut stream)?.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "tensor-bundle service closed without a response",
+        )
+    })?;
+    if header[..4] != TENSOR_RESPONSE_MAGIC {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid tensor-bundle response",
+        ));
+    }
+    let metadata_len = u32::from_le_bytes(header[4..8].try_into().unwrap()) as usize;
+    let allocation_size = u64::from_le_bytes(header[8..16].try_into().unwrap());
+    if metadata_len == 0 || metadata_len > MAX_TENSOR_BUNDLE_METADATA || allocation_size == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid tensor-bundle response dimensions",
+        ));
+    }
+    let mut metadata = vec![0u8; metadata_len];
+    stream.read_exact(&mut metadata)?;
+    validate_tensor_bundle_metadata(&metadata, allocation_size)?;
+    Ok(RedeemedTensorBundle {
+        allocation,
+        allocation_size,
+        metadata,
+    })
+}
+
+/// Redeem a clone worker's random one-use publication token into an owned GPU
+/// allocation. This is intentionally crate-private: only smolvm's managed
+/// rollout executor may cross the daemon's bearer-token boundary.
+pub(crate) fn redeem_tensor_bundle(token: &[u8]) -> io::Result<RedeemedTensorBundle> {
+    let stream = UnixStream::connect(tensor_bundle_socket_path(&socket_path()))?;
+    redeem_tensor_bundle_from_stream(stream, token)
+}
+
+fn spawn_tensor_bundle_service(cuda_socket: &Path) -> io::Result<PathBuf> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let path = tensor_bundle_socket_path(cuda_socket);
+    let _ = std::fs::remove_file(&path);
+    let listener = UnixListener::bind(&path)?;
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))?;
+    let service_path = path.clone();
+    thread::Builder::new()
+        .name("cuda-tensor-consumer".into())
+        .spawn(move || {
+            for connection in listener.incoming() {
+                match connection {
+                    Ok(stream) => {
+                        let _ = thread::Builder::new()
+                            .name("cuda-tensor-consume".into())
+                            .spawn(move || {
+                                if let Err(error) = serve_tensor_bundle_consumer(stream) {
+                                    tracing::debug!(%error, "tensor-bundle consume failed");
+                                }
+                            });
+                    }
+                    Err(error) => {
+                        tracing::debug!(%error, "tensor-bundle listener ended");
+                        break;
+                    }
+                }
+            }
+        })?;
+    thread::Builder::new()
+        .name("cuda-tensor-reaper".into())
+        .spawn(|| loop {
+            thread::sleep(Duration::from_secs(5));
+            let mut bundles = pending_tensor_bundles().lock().unwrap();
+            prune_tensor_bundles(&mut bundles, Instant::now());
+        })?;
+    Ok(service_path)
 }
 
 /// Pure policy helper for the managed MPS default.
@@ -622,6 +1066,16 @@ pub fn run(sock: &Path) -> io::Result<()> {
     #[cfg(unix)]
     install_shutdown_handler(sock);
     let listener = UdsListener::bind(sock)?;
+    match spawn_tensor_bundle_service(sock) {
+        Ok(path) => {
+            TENSOR_BUNDLE_SERVICE_READY.store(true, Ordering::Release);
+            tracing::info!(socket = %path.display(), "device-resident tensor service listening");
+        }
+        Err(error) => tracing::warn!(
+            %error,
+            "device-resident tensor publication disabled; CUDA serving remains available"
+        ),
+    }
     // Must precede listener threads and the first GpuBackend::load. Clone
     // workers inherit the endpoint from this daemon. Starting only after the
     // socket is exclusively bound avoids briefly starting MPS in a losing
@@ -1150,6 +1604,20 @@ pub fn run_clone_worker(fd: std::os::unix::io::RawFd) -> io::Result<()> {
     // Our own primary context (separate process ⇒ own UVA), so we can place memory
     // at the golden's exact VAs.
     let _ = backend.init();
+    if let Some(fd) = std::env::var("SMOLVM_CUDA_CLONE_PUBLISH_CTRL")
+        .ok()
+        .and_then(|value| value.parse::<i32>().ok())
+    {
+        // SAFETY: spawn_clone_worker transfers sole ownership of this inherited
+        // descriptor to the worker and clears CLOEXEC before exec.
+        let stream = unsafe { UnixStream::from_raw_fd(fd) };
+        let stream = Arc::new(Mutex::new(stream));
+        let publisher: Arc<smolvm_cuda::host::TensorBundlePublisher> = Arc::new(move |bundle| {
+            let mut stream = stream.lock().map_err(|_| 999)?;
+            send_tensor_bundle_to_parent(&mut stream, bundle)
+        });
+        smolvm_cuda::host::set_tensor_bundle_publisher(Some(publisher));
+    }
     // Reconstruct on the GOLDEN's GPU: the exported physical lives there.
     let clone_dev: i32 = std::env::var("SMOLVM_CUDA_CLONE_DEVICE")
         .ok()
@@ -4060,8 +4528,25 @@ fn spawn_clone_worker(
         }
         return Err(error);
     }
+    let publish_enabled = TENSOR_BUNDLE_SERVICE_READY.load(Ordering::Acquire);
+    let mut publish_sp = [-1i32; 2];
+    if publish_enabled
+        && unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, publish_sp.as_mut_ptr()) }
+            != 0
+    {
+        let error = io::Error::last_os_error();
+        unsafe {
+            libc::close(sp[0]);
+            libc::close(sp[1]);
+        }
+        for fd in export_fds {
+            unsafe { libc::close(fd) };
+        }
+        return Err(error);
+    }
     let ctrl_slot = 4 + export_fds.len() as i32;
-    let source_minimum = ctrl_slot + 1;
+    let publish_slot = ctrl_slot + 1;
+    let source_minimum = publish_slot + i32::from(publish_enabled);
     // Lift the control source and every exported-memory source above the whole
     // dup2 destination range. Hundreds of VMM chunks can extend beyond any
     // fixed descriptor floor.
@@ -4072,17 +4557,46 @@ fn spawn_clone_worker(
         let error = io::Error::last_os_error();
         // SAFETY: closing the parent end we created above.
         unsafe { libc::close(sp[0]) };
+        if publish_enabled {
+            unsafe {
+                libc::close(publish_sp[0]);
+                libc::close(publish_sp[1]);
+            }
+        }
         for fd in export_fds {
             unsafe { libc::close(fd) };
         }
         return Err(error);
     }
+    let publish_child = if publish_enabled {
+        let fd = unsafe { libc::fcntl(publish_sp[1], libc::F_DUPFD_CLOEXEC, source_minimum) };
+        unsafe { libc::close(publish_sp[1]) };
+        if fd < 0 {
+            let error = io::Error::last_os_error();
+            unsafe {
+                libc::close(sp[0]);
+                libc::close(ctrl_child);
+                libc::close(publish_sp[0]);
+            }
+            for fd in export_fds {
+                unsafe { libc::close(fd) };
+            }
+            return Err(error);
+        }
+        fd
+    } else {
+        -1
+    };
     let export_fds = match lift_owned_fds(export_fds, source_minimum) {
         Ok(fds) => fds,
         Err(error) => {
             unsafe {
                 libc::close(sp[0]);
                 libc::close(ctrl_child);
+                if publish_enabled {
+                    libc::close(publish_sp[0]);
+                    libc::close(publish_child);
+                }
             }
             return Err(error);
         }
@@ -4092,6 +4606,9 @@ fn spawn_clone_worker(
     cmd.env("SMOLVM_CUDA_CLONE_LAYOUT", layout);
     cmd.env("SMOLVM_CUDA_CLONE_DEVICE", golden_dev.to_string());
     cmd.env("SMOLVM_CUDA_CLONE_CTRL", ctrl_slot.to_string());
+    if publish_enabled {
+        cmd.env("SMOLVM_CUDA_CLONE_PUBLISH_CTRL", publish_slot.to_string());
+    }
     if let Some(limit) = options.vram_limit_bytes {
         cmd.env("SMOLVM_CUDA_VRAM_LIMIT_BYTES", limit.to_string());
     }
@@ -4156,6 +4673,14 @@ fn spawn_clone_worker(
             if libc::fcntl(ctrl_slot, libc::F_SETFD, 0) < 0 {
                 return Err(std::io::Error::last_os_error());
             }
+            if publish_enabled {
+                if libc::dup2(publish_child, publish_slot) < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                if libc::fcntl(publish_slot, libc::F_SETFD, 0) < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+            }
             Ok(())
         });
     }
@@ -4168,11 +4693,33 @@ fn spawn_clone_worker(
     }
     // SAFETY: the child inherited its own copy of the control child-end.
     unsafe { libc::close(ctrl_child) };
+    if publish_enabled {
+        // SAFETY: as above for the dedicated publication child-end.
+        unsafe { libc::close(publish_child) };
+    }
     match spawned {
-        Ok(pid) => Ok((pid, sp[0])),
+        Ok(pid) => {
+            if publish_enabled {
+                // SAFETY: the parent owns this socketpair end after spawn.
+                let stream = unsafe { UnixStream::from_raw_fd(publish_sp[0]) };
+                if let Err(error) = spawn_tensor_bundle_receiver(stream, pid) {
+                    unsafe {
+                        libc::close(sp[0]);
+                        libc::kill(pid as libc::pid_t, libc::SIGTERM);
+                    }
+                    return Err(error);
+                }
+            }
+            Ok((pid, sp[0]))
+        }
         Err(e) => {
             // SAFETY: no worker took ownership; close the parent control end.
-            unsafe { libc::close(sp[0]) };
+            unsafe {
+                libc::close(sp[0]);
+                if publish_enabled {
+                    libc::close(publish_sp[0]);
+                }
+            }
             Err(e)
         }
     }
@@ -4261,11 +4808,13 @@ mod mps_tests {
         encode_attach_procmem, fork_snapshot_enabled, golden_eviction_enabled, host_snapshot_fits,
         host_snapshot_reconstructable, lift_owned_fds, live_host_snapshot_count, mps_enabled,
         ordinary_regions_are_reserved, range_is_reserved, read_host_snapshot, recv_fd,
-        seal_host_snapshot, select_golden_owner, send_fd, spawn_clone_attach_listener_with_timeout,
-        unique_live_clone_worker,
+        redeem_tensor_bundle_from_stream, seal_host_snapshot, select_golden_owner, send_fd,
+        send_tensor_bundle_to_parent, serve_tensor_bundle_consumer,
+        spawn_clone_attach_listener_with_timeout, spawn_tensor_bundle_receiver,
+        unique_live_clone_worker, validate_tensor_bundle_metadata, TENSOR_CONSUME_MAGIC,
     };
     use std::collections::HashMap;
-    use std::io;
+    use std::io::{self, Write};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
@@ -4543,6 +5092,98 @@ mod mps_tests {
             libc::close(sockets[0]);
             libc::close(sockets[1]);
         }
+    }
+
+    #[test]
+    fn tensor_bundle_metadata_rejects_ranges_outside_the_export() {
+        let mut metadata = Vec::new();
+        metadata.extend_from_slice(&2u32.to_le_bytes());
+        metadata.extend_from_slice(&2u32.to_le_bytes());
+        metadata.extend_from_slice(b"{}");
+        metadata.extend_from_slice(&0u64.to_le_bytes());
+        metadata.extend_from_slice(&64u64.to_le_bytes());
+        metadata.extend_from_slice(&64u64.to_le_bytes());
+        metadata.extend_from_slice(&32u64.to_le_bytes());
+        validate_tensor_bundle_metadata(&metadata, 128).unwrap();
+
+        metadata[26..34].copy_from_slice(&96u64.to_le_bytes());
+        assert!(validate_tensor_bundle_metadata(&metadata, 128).is_err());
+    }
+
+    #[test]
+    fn tensor_bundle_token_transfers_one_fd_once() {
+        use smolvm_cuda::host::{DeviceTensorBundle, PublishedTensorRange};
+        use std::os::fd::OwnedFd;
+
+        let (mut worker, parent) = std::os::unix::net::UnixStream::pair().unwrap();
+        spawn_tensor_bundle_receiver(parent, std::process::id()).unwrap();
+        let allocation: OwnedFd = tempfile::tempfile().unwrap().into();
+        let token = send_tensor_bundle_to_parent(
+            &mut worker,
+            DeviceTensorBundle {
+                allocation,
+                allocation_size: 4096,
+                manifest: br#"{"name":"adapter"}"#.to_vec(),
+                tensors: vec![
+                    PublishedTensorRange {
+                        offset: 0,
+                        size: 64,
+                    },
+                    PublishedTensorRange {
+                        offset: 64,
+                        size: 32,
+                    },
+                ],
+            },
+        )
+        .unwrap();
+        assert_eq!(token.len(), 32);
+
+        let (client, server) = std::os::unix::net::UnixStream::pair().unwrap();
+        let served = std::thread::spawn(move || serve_tensor_bundle_consumer(server));
+        let redeemed = redeem_tensor_bundle_from_stream(client, &token).unwrap();
+        assert_eq!(redeemed.allocation_size, 4096);
+        validate_tensor_bundle_metadata(&redeemed.metadata, redeemed.allocation_size).unwrap();
+        drop(redeemed);
+        served.join().unwrap().unwrap();
+
+        let (mut retry, retry_server) = std::os::unix::net::UnixStream::pair().unwrap();
+        retry.write_all(&TENSOR_CONSUME_MAGIC).unwrap();
+        retry
+            .write_all(&(token.len() as u16).to_le_bytes())
+            .unwrap();
+        retry.write_all(&token).unwrap();
+        assert!(serve_tensor_bundle_consumer(retry_server).is_err());
+    }
+
+    #[test]
+    fn published_tensor_bundle_outlives_its_clone_worker_channel() {
+        use smolvm_cuda::host::{DeviceTensorBundle, PublishedTensorRange};
+        use std::os::fd::OwnedFd;
+
+        let (mut worker, parent) = std::os::unix::net::UnixStream::pair().unwrap();
+        spawn_tensor_bundle_receiver(parent, u32::MAX).unwrap();
+        let allocation: OwnedFd = tempfile::tempfile().unwrap().into();
+        let token = send_tensor_bundle_to_parent(
+            &mut worker,
+            DeviceTensorBundle {
+                allocation,
+                allocation_size: 4096,
+                manifest: br#"{"name":"adapter"}"#.to_vec(),
+                tensors: vec![PublishedTensorRange {
+                    offset: 0,
+                    size: 64,
+                }],
+            },
+        )
+        .unwrap();
+        drop(worker);
+
+        let (client, server) = std::os::unix::net::UnixStream::pair().unwrap();
+        let served = std::thread::spawn(move || serve_tensor_bundle_consumer(server));
+        let redeemed = redeem_tensor_bundle_from_stream(client, &token).unwrap();
+        assert_eq!(redeemed.allocation_size, 4096);
+        served.join().unwrap().unwrap();
     }
 
     #[test]

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -201,7 +201,7 @@ fn recv_fd_header(stream: &mut UnixStream) -> io::Result<Option<(OwnedFd, [u8; 1
             || msg.msg_flags & libc::MSG_CTRUNC != 0
             || (*cmsg).cmsg_level != libc::SOL_SOCKET
             || (*cmsg).cmsg_type != libc::SCM_RIGHTS
-            || (*cmsg).cmsg_len != libc::CMSG_LEN(4) as usize
+            || (*cmsg).cmsg_len as usize != libc::CMSG_LEN(4) as usize
         {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -65,7 +65,7 @@ fn tensor_bundle_socket_path(cuda_socket: &Path) -> PathBuf {
 /// The descriptor is owned by the caller. Dropping it releases only this
 /// process's reference; a descriptor already transferred with `SCM_RIGHTS`
 /// remains valid in the receiving process.
-#[cfg(any(target_os = "linux", test))]
+#[cfg(target_os = "linux")]
 pub(crate) struct RedeemedTensorBundle {
     pub(crate) allocation: OwnedFd,
     pub(crate) allocation_size: u64,
@@ -385,7 +385,7 @@ fn serve_tensor_bundle_consumer(mut stream: UnixStream) -> io::Result<()> {
     send_tensor_bundle_to_consumer(&mut stream, &bundle)
 }
 
-#[cfg(any(target_os = "linux", test))]
+#[cfg(target_os = "linux")]
 fn redeem_tensor_bundle_from_stream(
     mut stream: UnixStream,
     token: &[u8],
@@ -432,7 +432,7 @@ fn redeem_tensor_bundle_from_stream(
 /// Redeem a clone worker's random one-use publication token into an owned GPU
 /// allocation. This is intentionally crate-private: only smolvm's managed
 /// rollout executor may cross the daemon's bearer-token boundary.
-#[cfg(any(target_os = "linux", test))]
+#[cfg(target_os = "linux")]
 pub(crate) fn redeem_tensor_bundle(token: &[u8]) -> io::Result<RedeemedTensorBundle> {
     let stream = UnixStream::connect(tensor_bundle_socket_path(&socket_path()))?;
     redeem_tensor_bundle_from_stream(stream, token)

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -1126,13 +1126,12 @@ fn make_backend() -> Box<dyn Backend> {
     }
 }
 
-/// Staged golden handle state retained for late-attached channels:
-/// (module images, function metadata, streams, events).
-type SeedHandles = (
-    Vec<(u64, Vec<u8>)>,
-    Vec<smolvm_cuda::host::FuncMeta>,
-    Vec<(u64, u64)>,
-    Vec<(u64, u64)>,
+/// Per-thread state that cannot use the clone worker's process-global fallback.
+/// Module/function images and stream/event maps are installed process-wide by
+/// `set_handle_trans`, so copying them into every attached channel is wasteful.
+type CloneChannelSeed = (
+    Option<std::collections::HashMap<u64, u64>>,
+    Vec<(u64, u64, u64)>,
 );
 
 /// Path 3 (M1): serve one isolating fork-clone connection in THIS separate worker
@@ -1198,11 +1197,9 @@ pub fn run_clone_worker(fd: std::os::unix::io::RawFd) -> io::Result<()> {
         }
     }
     // Seed state for late-attached guest channels (see the attach listener
-    // below): each attached channel serves on its own thread, and every
-    // translation table is thread-local — new threads must be seeded with
-    // clones of what the main serving thread installed.
+    // below). VMM handle translation is thread-local; module/function and
+    // stream/event translation have process-global fallbacks.
     let mut seed_vmm: Option<std::collections::HashMap<u64, u64>> = None;
-    let mut seed_handles: Option<SeedHandles> = None;
     // M2: reconstruct the golden's memory at its exact VAs from the layout the
     // daemon passed (SMOLVM_CUDA_CLONE_LAYOUT) + the golden's physical exported to
     // fds 4.. — BEFORE serving, so the clone's inherited pointers are valid verbatim.
@@ -1240,14 +1237,9 @@ pub fn run_clone_worker(fd: std::os::unix::io::RawFd) -> io::Result<()> {
             graphs.len(),
             lib_handles.len(),
         );
-        // Retained for attached-channel threads (module images are the bulk —
-        // tens of MB per worker; the price of correct late channels).
-        seed_handles = Some((
-            mod_images.clone(),
-            func_meta.clone(),
-            streams.clone(),
-            events.clone(),
-        ));
+        // This installs immutable process-global fallbacks as well as the main
+        // thread's fast-path maps. Attached channels use those fallbacks rather
+        // than deep-copying every module image and function record.
         smolvm_cuda::host::set_handle_trans(mod_images, func_meta, streams, events);
         // Re-create the golden's top-level cuBLAS/cuBLASLt/cuDNN handles in
         // THIS process and map the clone's inherited values to them — library
@@ -1287,7 +1279,7 @@ pub fn run_clone_worker(fd: std::os::unix::io::RawFd) -> io::Result<()> {
         .and_then(|v| v.parse::<std::os::unix::io::RawFd>().ok())
     {
         let seed_alloc = smolvm_cuda::host::worker_alloc_trans_snapshot();
-        let seed = std::sync::Arc::new((seed_vmm, seed_handles, seed_alloc));
+        let seed = std::sync::Arc::new((seed_vmm, seed_alloc));
         Some(spawn_clone_attach_listener(
             ctrl,
             clone_dev,
@@ -1344,11 +1336,7 @@ pub fn run_clone_worker(fd: std::os::unix::io::RawFd) -> io::Result<()> {
 fn spawn_clone_attach_listener(
     ctrl: std::os::unix::io::RawFd,
     clone_dev: i32,
-    seed: Arc<(
-        Option<std::collections::HashMap<u64, u64>>,
-        Option<SeedHandles>,
-        Vec<(u64, u64, u64)>,
-    )>,
+    seed: Arc<CloneChannelSeed>,
     active_channels: Arc<AtomicUsize>,
     clone_vm_pid: Option<u32>,
 ) -> io::Result<std::thread::JoinHandle<()>> {
@@ -1395,11 +1383,7 @@ fn clone_worker_idle_expired(
 fn spawn_clone_attach_listener_with_timeout(
     ctrl: std::os::unix::io::RawFd,
     clone_dev: i32,
-    seed: Arc<(
-        Option<std::collections::HashMap<u64, u64>>,
-        Option<SeedHandles>,
-        Vec<(u64, u64, u64)>,
-    )>,
+    seed: Arc<CloneChannelSeed>,
     active_channels: Arc<AtomicUsize>,
     clone_vm_pid: Option<u32>,
     idle_timeout: Duration,
@@ -1488,19 +1472,14 @@ fn clone_worker_idle_timeout_from(value: Option<&str>) -> Duration {
 }
 
 /// Serve one late-attached guest channel inside the clone worker. Own backend
-/// handle, same primary context (same UVA space), thread-local translation
-/// tables seeded from the main serving thread's snapshot so golden handles and
-/// translated allocations resolve identically on this channel.
+/// handle, same primary context (same UVA space), and only the thread-local
+/// translations that lack process-global fallbacks.
 #[cfg(unix)]
 #[allow(clippy::type_complexity)]
 fn serve_attached_channel(
     fd: std::os::unix::io::RawFd,
     dev: i32,
-    seed: &(
-        Option<std::collections::HashMap<u64, u64>>,
-        Option<SeedHandles>,
-        Vec<(u64, u64, u64)>,
-    ),
+    seed: &CloneChannelSeed,
     attached_procmem: Option<ProcMemAdvert>,
 ) {
     use std::os::unix::io::FromRawFd;
@@ -1516,12 +1495,9 @@ fn serve_attached_channel(
     // File-ring transport: attached channels serve on their own threads, and
     // the ring dir is per-worker (thread-local install per serve thread).
     smolvm_cuda::host::ring_dir_set(std::env::var("SMOLVM_CUDA_CLONE_RING_DIR").ok());
-    let (vmm, handles, alloc) = seed;
+    let (vmm, alloc) = seed;
     if let Some(v) = vmm {
         smolvm_cuda::host::set_vmm_trans(v.clone());
-    }
-    if let Some((m, f, s, e)) = handles {
-        smolvm_cuda::host::set_handle_trans(m.clone(), f.clone(), s.clone(), e.clone());
     }
     if !alloc.is_empty() {
         smolvm_cuda::host::set_worker_alloc_trans(alloc.clone());
@@ -4508,7 +4484,7 @@ mod mps_tests {
         let listener = spawn_clone_attach_listener_with_timeout(
             sockets[1],
             0,
-            Arc::new((None, None, Vec::new())),
+            Arc::new((None, Vec::new())),
             active.clone(),
             None,
             Duration::ZERO,

--- a/src/cuda_host.rs
+++ b/src/cuda_host.rs
@@ -42,12 +42,13 @@ pub fn set_guest_ram_provider(f: GuestRamProvider) {
 ///
 /// The caller passes the same path to `LaunchConfig::cuda_socket`. Returns once
 /// the listener is bound; serving continues until the process exits.
-pub fn start(socket_path: &Path) -> std::io::Result<()> {
+pub fn start(socket_path: &Path, is_fork_clone: bool) -> std::io::Result<()> {
     // Clean up any stale socket from a previous run.
     let _ = std::fs::remove_file(socket_path);
 
     let listener = UdsListener::bind(socket_path)?;
     let path_display = socket_path.display().to_string();
+    let clone_identity = clone_proxy_identity(is_fork_clone);
 
     // One-time, launch-time preflight: if this host can't load the CUDA driver,
     // every guest connection falls back to a CPU-emulation backend that only
@@ -109,7 +110,7 @@ pub fn start(socket_path: &Path) -> std::io::Result<()> {
             // CUDA call. The connection is held open as the worker's idle
             // primary channel; real guest channels attach to the live worker.
             if std::env::var("SMOLVM_CUDA_WARM_DIAL").as_deref() != Ok("0") {
-              if let (Some(addr), Some(p)) = (daemon.clone(), clone_preamble(true)) {
+              if let (Some(addr), Some(p)) = (daemon.clone(), clone_preamble(clone_identity, true)) {
                 thread::Builder::new()
                     .name("cuda-clone-warm".into())
                     .spawn(move || {
@@ -163,11 +164,14 @@ pub fn start(socket_path: &Path) -> std::io::Result<()> {
                     Ok(stream) => {
                         let daemon = daemon.clone();
                         let options = serve_options;
+                        let clone_identity = clone_identity;
                         thread::Builder::new()
                             .name("cuda-host-conn".into())
                             .spawn(move || {
                                 if let Some(addr) = daemon {
-                                    if let Err(e) = proxy_to_daemon(stream, &addr) {
+                                    if let Err(e) =
+                                        proxy_to_daemon(stream, &addr, clone_identity)
+                                    {
                                         tracing::debug!(error = %e, "CUDA daemon proxy ended");
                                     }
                                     return;
@@ -191,26 +195,31 @@ pub fn start(socket_path: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-/// This VM's clone identity for the daemon-connection preamble, computed once.
-/// `Some` iff this VMM process was launched from a fork snapshot (the boot
-/// subprocess carries `SMOLVM_SNAPSHOT_DIR` per-process; the golden's process
-/// never has it). The id is stable for this VM's lifetime and distinct across
-/// sibling clones (per-process randomness ⊕ pid), so the daemon can key one
-/// worker per clone and tell a clone's reconnect apart from a fresh clone.
-fn fork_clone_id() -> Option<u64> {
-    static ID: OnceLock<Option<u64>> = OnceLock::new();
-    *ID.get_or_init(|| {
-        std::env::var_os("SMOLVM_SNAPSHOT_DIR")?;
-        let mut b = [0u8; 8];
-        if std::fs::File::open("/dev/urandom")
-            .and_then(|mut f| std::io::Read::read_exact(&mut f, &mut b))
-            .is_err()
-        {
-            b = (std::process::id() as u64)
-                .wrapping_mul(0x9E37_79B9_7F4A_7C15)
-                .to_le_bytes();
-        }
-        Some(u64::from_le_bytes(b) ^ u64::from(std::process::id()))
+/// Stable identity captured at the VM boot boundary and carried by every CUDA
+/// proxy thread. A typed launch role avoids re-reading mutable process state in
+/// late reconnect threads and accidentally serving a clone as a golden.
+#[derive(Clone, Copy)]
+struct CloneProxyIdentity {
+    id: u64,
+    share_weights: bool,
+}
+
+fn clone_proxy_identity(is_fork_clone: bool) -> Option<CloneProxyIdentity> {
+    if !is_fork_clone {
+        return None;
+    }
+    let mut bytes = [0u8; 8];
+    if std::fs::File::open("/dev/urandom")
+        .and_then(|mut file| std::io::Read::read_exact(&mut file, &mut bytes))
+        .is_err()
+    {
+        bytes = (std::process::id() as u64)
+            .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+            .to_le_bytes();
+    }
+    Some(CloneProxyIdentity {
+        id: u64::from_le_bytes(bytes) ^ u64::from(std::process::id()),
+        share_weights: std::env::var_os("SMOLVM_CUDA_CLONE_SHARE").is_some(),
     })
 }
 
@@ -223,18 +232,24 @@ fn fork_clone_id() -> Option<u64> {
 /// The 17-byte clone-connection preamble (magic + clone id + flags), `None`
 /// on non-clone VMs. Flag bit 0: forked with `--share-weights`; bit 1: warm
 /// dial (spawn the worker eagerly, no Init follows on this connection).
-fn clone_preamble(warm: bool) -> Option<[u8; 17]> {
-    let id = fork_clone_id()?;
+fn clone_preamble(identity: Option<CloneProxyIdentity>, warm: bool) -> Option<[u8; 17]> {
+    let identity = identity?;
     let mut p = [0u8; 17];
     p[..8].copy_from_slice(&smolvm_cuda::proto::CLONE_PREAMBLE_MAGIC);
-    p[8..16].copy_from_slice(&id.to_le_bytes());
+    p[8..16].copy_from_slice(&identity.id.to_le_bytes());
     // bit 0: this fork was requested with --share-weights (the launcher put
     // SMOLVM_CUDA_CLONE_SHARE in this clone VMM's env).
-    if std::env::var_os("SMOLVM_CUDA_CLONE_SHARE").is_some() {
+    if identity.share_weights {
         p[16] |= 1;
     }
     if warm {
         p[16] |= 2;
+    }
+    if std::env::var_os("SMOLVM_CUDA_PROXY_TRACE").is_some() {
+        eprintln!(
+            "[cuda-proxy] clone preamble id={} flags={}",
+            identity.id, p[16]
+        );
     }
     Some(p)
 }
@@ -287,8 +302,12 @@ fn clone_lifetime_advert() -> [u8; 20] {
 /// the daemon routes this connection to the clone's isolating worker — and, by
 /// its absence, serves the GOLDEN's own reconnect in-daemon instead of handing
 /// it a worker's reconstructed COPY of its memory.
-fn proxy_to_daemon(guest: crate::platform::uds::UdsStream, addr: &str) -> std::io::Result<()> {
-    let preamble = || clone_preamble(false);
+fn proxy_to_daemon(
+    guest: crate::platform::uds::UdsStream,
+    addr: &str,
+    clone_identity: Option<CloneProxyIdentity>,
+) -> std::io::Result<()> {
+    let preamble = || clone_preamble(clone_identity, false);
     /// Guest-RAM advertisement for a SHARED daemon: when this VM's RAM is
     /// memfd-backed (forkable machines), tell the daemon how to map the same
     /// pages via `/proc/<pid>/fd/<memfd>` — magic + pid + fd + count +
@@ -520,5 +539,30 @@ fn make_backend() -> Box<dyn Backend> {
             tracing::info!("cuda-host: no GPU driver ({e}) — CPU emulation backend");
             Box::new(CpuBackend::default())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clone_preamble_uses_the_captured_boot_identity() {
+        assert!(clone_preamble(None, false).is_none());
+
+        let identity = CloneProxyIdentity {
+            id: 0x1122_3344_5566_7788,
+            share_weights: true,
+        };
+        let regular = clone_preamble(Some(identity), false).unwrap();
+        assert_eq!(&regular[..8], &smolvm_cuda::proto::CLONE_PREAMBLE_MAGIC);
+        assert_eq!(
+            u64::from_le_bytes(regular[8..16].try_into().unwrap()),
+            identity.id
+        );
+        assert_eq!(regular[16], 1);
+
+        let warm = clone_preamble(Some(identity), true).unwrap();
+        assert_eq!(warm[16], 3);
     }
 }

--- a/src/cuda_host.rs
+++ b/src/cuda_host.rs
@@ -42,7 +42,15 @@ pub fn set_guest_ram_provider(f: GuestRamProvider) {
 ///
 /// The caller passes the same path to `LaunchConfig::cuda_socket`. Returns once
 /// the listener is bound; serving continues until the process exits.
-pub fn start(socket_path: &Path, is_fork_clone: bool) -> std::io::Result<()> {
+pub fn start(socket_path: &Path) -> std::io::Result<()> {
+    start_with_clone_mode(socket_path, false)
+}
+
+/// Start the CUDA host server and identify whether it serves a restored clone.
+///
+/// Restored clones use their stable proxy identity to attach new CUDA channels
+/// to the daemon-side worker that owns their reconstructed device state.
+pub fn start_with_clone_mode(socket_path: &Path, is_fork_clone: bool) -> std::io::Result<()> {
     // Clean up any stale socket from a previous run.
     let _ = std::fs::remove_file(socket_path);
 


### PR DESCRIPTION
Publishes clone LoRA tensors directly into managed rollout executors without host or filesystem staging.