### PR TITLE
Map CUDA module handoffs across clone workers

### DIFF
--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -1468,8 +1468,157 @@ pub fn replay_lib_handles(b: &mut dyn Backend, handles: &[(u8, u16, u64, Vec<u8>
 // each function) on FIRST USE at the raw_module/raw_fn_h choke points. Empty
 // (identity) unless a Path-3 clone worker installed it via `set_handle_trans`.
 type HandleMap = std::cell::RefCell<HashMap<u64, u64>>;
-type ImageMap = std::cell::RefCell<HashMap<u64, Vec<u8>>>;
+type ImageMap = std::cell::RefCell<HashMap<u64, ModuleHandoffBytes>>;
 type MetaMap = std::cell::RefCell<HashMap<u64, (u64, String, Vec<(i32, i32)>)>>;
+
+/// Immutable bytes backing a clone worker's CUDA module handoff.
+///
+/// Owned inputs use one reference-counted allocation. Linux clone workers map
+/// the daemon's read-only handoff descriptor instead, and each module is a
+/// cheap range into that mapping. Keeping the mapping alive here is required:
+/// modules are deliberately loaded lazily, after worker startup.
+#[derive(Clone)]
+pub struct ModuleHandoffBytes {
+    storage: std::sync::Arc<ModuleHandoffStorage>,
+    start: usize,
+    len: usize,
+}
+
+enum ModuleHandoffStorage {
+    Owned(Box<[u8]>),
+    #[cfg(target_os = "linux")]
+    Mapped(ReadOnlyModuleMapping),
+}
+
+#[cfg(target_os = "linux")]
+struct ReadOnlyModuleMapping {
+    ptr: std::ptr::NonNull<u8>,
+    len: usize,
+}
+
+// SAFETY: the mapping is immutable (`PROT_READ`) and remains valid until the
+// last Arc-backed ModuleHandoffBytes is dropped. Sharing read-only slices across
+// worker serving threads cannot introduce aliasing writes.
+#[cfg(target_os = "linux")]
+unsafe impl Send for ReadOnlyModuleMapping {}
+// SAFETY: see the Send justification above; no API exposes a mutable pointer.
+#[cfg(target_os = "linux")]
+unsafe impl Sync for ReadOnlyModuleMapping {}
+
+#[cfg(target_os = "linux")]
+impl Drop for ReadOnlyModuleMapping {
+    fn drop(&mut self) {
+        // SAFETY: `ptr` and `len` are exactly the successful mmap result and
+        // are unmapped once, when the final Arc owner is released.
+        unsafe {
+            libc::munmap(self.ptr.as_ptr().cast(), self.len);
+        }
+    }
+}
+
+impl ModuleHandoffBytes {
+    pub fn from_owned(bytes: Vec<u8>) -> Self {
+        let bytes = bytes.into_boxed_slice();
+        let len = bytes.len();
+        Self {
+            storage: std::sync::Arc::new(ModuleHandoffStorage::Owned(bytes)),
+            start: 0,
+            len,
+        }
+    }
+
+    /// Map an immutable regular file read-only. The file descriptor may be
+    /// closed after this returns; the mapping owns the kernel reference.
+    ///
+    /// # Safety
+    ///
+    /// The file must not be truncated or modified for the lifetime of this
+    /// value or any slices cloned from it.
+    #[cfg(target_os = "linux")]
+    pub unsafe fn map_read_only(file: &std::fs::File, len: usize) -> std::io::Result<Self> {
+        use std::os::fd::AsRawFd;
+
+        let metadata = file.metadata()?;
+        if !metadata.file_type().is_file()
+            || len == 0
+            || len > isize::MAX as usize
+            || metadata.len() < len as u64
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "CUDA module handoff mapping has invalid size",
+            ));
+        }
+        // SAFETY: the descriptor is a validated regular file at least `len`
+        // bytes long. The mapping is read-only/private and checked for failure.
+        let ptr = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                len,
+                libc::PROT_READ,
+                libc::MAP_PRIVATE,
+                file.as_raw_fd(),
+                0,
+            )
+        };
+        if ptr == libc::MAP_FAILED {
+            return Err(std::io::Error::last_os_error());
+        }
+        let Some(ptr) = std::ptr::NonNull::new(ptr.cast::<u8>()) else {
+            // SAFETY: mmap reported success, so release its exact result before
+            // rejecting an address that cannot back a NonNull slice.
+            unsafe { libc::munmap(ptr, len) };
+            return Err(std::io::Error::other(
+                "CUDA module handoff mmap returned null",
+            ));
+        };
+        Ok(Self {
+            storage: std::sync::Arc::new(ModuleHandoffStorage::Mapped(ReadOnlyModuleMapping {
+                ptr,
+                len,
+            })),
+            start: 0,
+            len,
+        })
+    }
+
+    /// Return a cheap, bounds-checked view into the same immutable storage.
+    pub fn slice(&self, start: usize, len: usize) -> Option<Self> {
+        let end = start.checked_add(len)?;
+        if end > self.len {
+            return None;
+        }
+        Some(Self {
+            storage: self.storage.clone(),
+            start: self.start.checked_add(start)?,
+            len,
+        })
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        #[cfg(target_os = "linux")]
+        let all: &[u8] = match self.storage.as_ref() {
+            ModuleHandoffStorage::Owned(bytes) => bytes,
+            ModuleHandoffStorage::Mapped(mapping) => {
+                // SAFETY: the mapping remains live through `self.storage`, is
+                // immutable, and its length was validated before construction.
+                unsafe { std::slice::from_raw_parts(mapping.ptr.as_ptr(), mapping.len) }
+            }
+        };
+        #[cfg(not(target_os = "linux"))]
+        let all: &[u8] = {
+            let ModuleHandoffStorage::Owned(bytes) = self.storage.as_ref();
+            bytes
+        };
+        &all[self.start..self.start + self.len]
+    }
+}
+
+impl AsRef<[u8]> for ModuleHandoffBytes {
+    fn as_ref(&self) -> &[u8] {
+        self.as_slice()
+    }
+}
 thread_local! {
     static FUNC_TRANS: HandleMap = std::cell::RefCell::new(HashMap::new());
     static MOD_TRANS: HandleMap = std::cell::RefCell::new(HashMap::new());
@@ -1667,6 +1816,25 @@ pub fn set_handle_trans(
     streams: Vec<(u64, u64)>,
     events: Vec<(u64, u64)>,
 ) {
+    set_shared_handle_trans(
+        mod_images
+            .into_iter()
+            .map(|(handle, image)| (handle, ModuleHandoffBytes::from_owned(image)))
+            .collect(),
+        func_meta,
+        streams,
+        events,
+    );
+}
+
+/// Install handle reconstruction without copying module images. Each image may
+/// be a range of one shared read-only handoff mapping.
+pub fn set_shared_handle_trans(
+    mod_images: Vec<(u64, ModuleHandoffBytes)>,
+    func_meta: Vec<FuncMeta>,
+    streams: Vec<(u64, u64)>,
+    events: Vec<(u64, u64)>,
+) {
     fn put_h(cell: &'static std::thread::LocalKey<HandleMap>, v: Vec<(u64, u64)>) {
         cell.with(|m| {
             let mut m = m.borrow_mut();
@@ -1741,20 +1909,30 @@ fn xlat_mod(b: &mut dyn Backend, golden: u64) -> u64 {
                 .as_ref()
                 .and_then(|m| m.get(&golden).cloned())
         });
-    let Some(mut image) = image else {
+    let Some(image) = image else {
         return golden;
     };
     // Binary images (ELF cubin / fatbin) must reload BYTE-IDENTICAL to what the
     // golden loaded — appending anything diverges from the proven-loadable bytes
     // (sm90 fatbins failed 209 with a spurious trailing byte). Only PTX, which
     // cuModuleLoadData reads as a C string, needs a trailing NUL.
-    let is_elf = image.starts_with(&[0x7f, b'E', b'L', b'F']);
-    let is_fatbin = image.len() >= 4
-        && u32::from_le_bytes([image[0], image[1], image[2], image[3]]) == 0xba55ed50;
-    if !is_elf && !is_fatbin && image.last() != Some(&0) {
-        image.push(0);
-    }
-    match b.module_load_data(&image) {
+    let bytes = image.as_slice();
+    let is_elf = bytes.starts_with(&[0x7f, b'E', b'L', b'F']);
+    let is_fatbin = bytes.len() >= 4
+        && u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) == 0xba55ed50;
+    let nul_terminated;
+    let load_bytes = if !is_elf && !is_fatbin && bytes.last() != Some(&0) {
+        nul_terminated = {
+            let mut copy = Vec::with_capacity(bytes.len() + 1);
+            copy.extend_from_slice(bytes);
+            copy.push(0);
+            copy
+        };
+        nul_terminated.as_slice()
+    } else {
+        bytes
+    };
+    match b.module_load_data(load_bytes) {
         Ok(w) => {
             MOD_TRANS.with(|m| {
                 m.borrow_mut().insert(golden, w);
@@ -1772,15 +1950,19 @@ fn xlat_mod(b: &mut dyn Backend, golden: u64) -> u64 {
                 std::sync::atomic::AtomicU64::new(0);
             let n = RELOAD_FAILS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             if n < 8 {
-                let head: Vec<String> = image.iter().take(12).map(|b| format!("{b:02x}")).collect();
+                let head: Vec<String> = load_bytes
+                    .iter()
+                    .take(12)
+                    .map(|b| format!("{b:02x}"))
+                    .collect();
                 eprintln!(
                     "[M3a-lazy] module reload failed: e={e} len={} elf={is_elf} fatbin={is_fatbin} head={}",
-                    image.len(),
+                    load_bytes.len(),
                     head.join("")
                 );
                 if std::env::var_os("SMOLVM_CUDA_DUMP_FAILMOD").is_some() {
                     let p = format!("/tmp/smolvm/failmod-{golden:x}.bin");
-                    let _ = std::fs::write(&p, &image);
+                    let _ = std::fs::write(&p, load_bytes);
                     // Context health right after the failed load: a poisoned
                     // (sticky-fault) context errors on sync/alloc too; a healthy
                     // one pins the failure on cuModuleLoadData itself.
@@ -3265,7 +3447,7 @@ fn worker_module_take(raw: u64) -> bool {
 /// passed RAW GOLDEN HANDLES to the driver — launch-time "invalid argument"
 /// at best, a SIGSEGV inside `cuModuleGetFunction` (foreign-handle deref) at
 /// worst: the intermittent per-clone worker crash loop.
-static MOD_IMAGES_GLOBAL: std::sync::Mutex<Option<HashMap<u64, Vec<u8>>>> =
+static MOD_IMAGES_GLOBAL: std::sync::Mutex<Option<HashMap<u64, ModuleHandoffBytes>>> =
     std::sync::Mutex::new(None);
 #[allow(clippy::type_complexity)]
 static FUNC_META_GLOBAL: std::sync::Mutex<Option<HashMap<u64, (u64, String, Vec<(i32, i32)>)>>> =
@@ -5129,6 +5311,31 @@ mod tests {
     use super::*;
     use crate::client::Client;
     use std::io::{Read, Write};
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn mapped_module_ranges_keep_the_read_only_mapping_alive() {
+        use std::io::Write as _;
+        use std::os::fd::FromRawFd as _;
+
+        let name = std::ffi::CString::new("smolvm-module-mapping-test").unwrap();
+        let fd = unsafe { libc::memfd_create(name.as_ptr(), libc::MFD_CLOEXEC) };
+        assert!(fd >= 0);
+        let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
+        file.write_all(b"0123456789").unwrap();
+        let range = {
+            // SAFETY: the test never changes the memfd after mapping it.
+            let mapping = unsafe { ModuleHandoffBytes::map_read_only(&file, 10) }.unwrap();
+            assert!(matches!(
+                mapping.storage.as_ref(),
+                ModuleHandoffStorage::Mapped(_)
+            ));
+            mapping.slice(3, 4).unwrap()
+        };
+        drop(file);
+        assert_eq!(range.as_slice(), b"3456");
+        assert!(range.slice(4, 1).is_none());
+    }
 
     #[test]
     fn replayed_vmm_access_preserves_only_shared_intersections() {

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -1714,18 +1714,18 @@ pub fn run_clone_worker(fd: std::os::unix::io::RawFd) -> io::Result<()> {
                     "CUDA module handoff fd is invalid",
                 )
             })?;
-            Some(read_module_blob_fd(module_fd)?)
+            Some(map_module_blob_fd(module_fd)?)
         } else {
             None
         };
     #[cfg(not(target_os = "linux"))]
-    let inherited_module_blob: Option<Vec<u8>> = None;
+    let inherited_module_blob: Option<smolvm_cuda::host::ModuleHandoffBytes> = None;
     let module_blob = if inherited_module_blob.is_some() {
         inherited_module_blob
     } else if let Ok(modpath) = std::env::var("SMOLVM_CUDA_CLONE_MODULES") {
         let result = std::fs::read(&modpath);
         let _ = std::fs::remove_file(&modpath);
-        Some(result?)
+        Some(smolvm_cuda::host::ModuleHandoffBytes::from_owned(result?))
     } else {
         None
     };
@@ -1743,7 +1743,7 @@ pub fn run_clone_worker(fd: std::os::unix::io::RawFd) -> io::Result<()> {
         // This installs immutable process-global fallbacks as well as the main
         // thread's fast-path maps. Attached channels use those fallbacks rather
         // than deep-copying every module image and function record.
-        smolvm_cuda::host::set_handle_trans(mod_images, func_meta, streams, events);
+        smolvm_cuda::host::set_shared_handle_trans(mod_images, func_meta, streams, events);
         // Re-create the golden's top-level cuBLAS/cuBLASLt/cuDNN handles in
         // THIS process and map the clone's inherited values to them — library
         // handles are process-local, so a pre-fork handle would otherwise fail
@@ -2745,17 +2745,16 @@ fn reconstruct_golden_memory(
 }
 
 #[cfg(target_os = "linux")]
-fn read_module_blob_fd(fd: std::os::fd::RawFd) -> io::Result<Vec<u8>> {
-    use std::os::unix::fs::FileExt;
-
+fn map_module_blob_fd(fd: std::os::fd::RawFd) -> io::Result<smolvm_cuda::host::ModuleHandoffBytes> {
     // Take an independent owned descriptor before closing the inherited slot.
-    // Reads use pread so workers forked from the same cached source never share
-    // or race an open-file offset.
+    // Every worker maps the same immutable file pages, so staging does not
+    // allocate and copy the entire handoff into private anonymous memory.
     let owned = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 0) };
-    if owned < 0 {
-        return Err(io::Error::last_os_error());
-    }
+    let duplicate_error = io::Error::last_os_error();
     unsafe { libc::close(fd) };
+    if owned < 0 {
+        return Err(duplicate_error);
+    }
     let file = unsafe { std::fs::File::from_raw_fd(owned) };
     let metadata = file.metadata()?;
     let bytes = metadata.len();
@@ -2771,25 +2770,10 @@ fn read_module_blob_fd(fd: std::os::fd::RawFd) -> io::Result<Vec<u8>> {
             "CUDA module handoff source does not fit in address space",
         )
     })?;
-    let mut blob = Vec::new();
-    blob.try_reserve_exact(bytes)
-        .map_err(|error| io::Error::other(format!("CUDA module handoff allocation: {error}")))?;
-    blob.resize(bytes, 0);
-    let mut offset = 0usize;
-    while offset < blob.len() {
-        match file.read_at(&mut blob[offset..], offset as u64) {
-            Ok(0) => {
-                return Err(io::Error::new(
-                    io::ErrorKind::UnexpectedEof,
-                    "CUDA module handoff source was truncated",
-                ))
-            }
-            Ok(read) => offset += read,
-            Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
-            Err(error) => return Err(error),
-        }
-    }
-    Ok(blob)
+    // SAFETY: `file` is a read-only reopen of the daemon-owned unnamed handoff
+    // inode. Its only writable descriptor was dropped before caching, so the
+    // inode cannot be changed or truncated while workers map it.
+    unsafe { smolvm_cuda::host::ModuleHandoffBytes::map_read_only(&file, bytes) }
 }
 
 /// M3a: parse the golden's module IMAGES + function METADATA (for LAZY reload in
@@ -2803,15 +2787,16 @@ fn read_module_blob_fd(fd: std::os::fd::RawFd) -> io::Result<Vec<u8>> {
 #[allow(clippy::type_complexity)]
 fn reconstruct_golden_modules(
     b: &mut dyn Backend,
-    buf: &[u8],
+    source: &smolvm_cuda::host::ModuleHandoffBytes,
 ) -> (
-    Vec<(u64, Vec<u8>)>,
+    Vec<(u64, smolvm_cuda::host::ModuleHandoffBytes)>,
     Vec<smolvm_cuda::host::FuncMeta>,
     Vec<(u64, u64)>,
     Vec<(u64, u64)>,
     Vec<(u64, u64, smolvm_cuda::host::GraphSer)>,
     Vec<(u8, u16, u64, Vec<u8>)>,
 ) {
+    let buf = source.as_slice();
     let mut mod_images = Vec::new();
     let mut func_meta = Vec::new();
     let mut stream_trans = Vec::new();
@@ -2855,7 +2840,8 @@ fn reconstruct_golden_modules(
         let gh = ru64!();
         let ilen = ru32!() as usize;
         need!(ilen);
-        mod_images.push((gh, buf[p..p + ilen].to_vec()));
+        // `need!` proved this range is within the immutable source.
+        mod_images.push((gh, source.slice(p, ilen).unwrap()));
         p += ilen;
     }
     // Functions: stage golden fn → (golden module, name); resolved lazily.
@@ -5160,10 +5146,11 @@ mod mps_tests {
         consume_procmem_preamble, create_host_snapshot_memfd, create_private_mps_paths,
         daemon_has_live_cuda_clients, decode_attach_procmem, disabled_worker_route,
         encode_attach_procmem, fork_snapshot_enabled, golden_eviction_enabled, host_snapshot_fits,
-        host_snapshot_reconstructable, lift_owned_fds, live_host_snapshot_count, mps_enabled,
-        ordinary_regions_are_reserved, prepare_module_blob, range_is_reserved, read_host_snapshot,
-        read_module_blob_fd, recv_fd, redeem_tensor_bundle_from_stream, seal_host_snapshot,
-        select_golden_owner, send_fd, send_tensor_bundle_to_parent, serve_tensor_bundle_consumer,
+        host_snapshot_reconstructable, lift_owned_fds, live_host_snapshot_count,
+        map_module_blob_fd, mps_enabled, ordinary_regions_are_reserved, prepare_module_blob,
+        range_is_reserved, read_host_snapshot, reconstruct_golden_modules, recv_fd,
+        redeem_tensor_bundle_from_stream, seal_host_snapshot, select_golden_owner, send_fd,
+        send_tensor_bundle_to_parent, serve_tensor_bundle_consumer,
         spawn_clone_attach_listener_with_timeout, spawn_tensor_bundle_receiver,
         unique_live_clone_worker, validate_tensor_bundle_metadata, TENSOR_CONSUME_MAGIC,
     };
@@ -5196,7 +5183,7 @@ mod mps_tests {
     }
 
     #[test]
-    fn module_blob_fd_reads_are_offset_independent() {
+    fn module_blob_fd_mappings_are_offset_independent() {
         use std::io::{Seek as _, Write as _};
         use std::os::fd::AsRawFd as _;
 
@@ -5208,9 +5195,68 @@ mod mps_tests {
         let second = unsafe { libc::dup(file.as_raw_fd()) };
         assert!(first >= 0 && second >= 0);
 
-        assert_eq!(read_module_blob_fd(first).unwrap(), expected);
-        assert_eq!(read_module_blob_fd(second).unwrap(), expected);
+        let first = map_module_blob_fd(first).unwrap();
+        let second = map_module_blob_fd(second).unwrap();
+        assert_eq!(first.as_slice(), expected);
+        assert_eq!(second.as_slice(), expected);
         assert_eq!(file.stream_position().unwrap(), expected.len() as u64);
+    }
+
+    #[test]
+    fn module_blob_mapping_rejects_empty_and_non_file_sources() {
+        use std::os::fd::IntoRawFd as _;
+
+        let empty = tempfile::tempfile().unwrap();
+        assert_eq!(
+            map_module_blob_fd(empty.into_raw_fd())
+                .err()
+                .unwrap()
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+
+        let directory = tempfile::tempdir().unwrap();
+        let directory = std::fs::File::open(directory.path()).unwrap();
+        assert_eq!(
+            map_module_blob_fd(directory.into_raw_fd())
+                .err()
+                .unwrap()
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+
+    #[test]
+    fn parsed_module_images_keep_the_mapped_blob_alive() {
+        use std::io::Write as _;
+        use std::os::fd::IntoRawFd as _;
+
+        let image = b"mapped-cubin";
+        let mut blob = Vec::new();
+        blob.extend_from_slice(&1_u32.to_le_bytes());
+        blob.extend_from_slice(&0x1234_u64.to_le_bytes());
+        blob.extend_from_slice(&(image.len() as u32).to_le_bytes());
+        blob.extend_from_slice(image);
+        blob.extend_from_slice(&0_u32.to_le_bytes()); // functions
+        blob.extend_from_slice(&0_u32.to_le_bytes()); // streams
+        blob.extend_from_slice(&0_u32.to_le_bytes()); // events
+
+        let mut file = tempfile::tempfile().unwrap();
+        file.write_all(&blob).unwrap();
+        let source = map_module_blob_fd(file.into_raw_fd()).unwrap();
+        let mut backend = smolvm_cuda::host::CpuBackend::default();
+        let (images, functions, streams, events, graphs, handles) =
+            reconstruct_golden_modules(&mut backend, &source);
+        drop(source);
+
+        assert_eq!(images.len(), 1);
+        assert_eq!(images[0].0, 0x1234);
+        assert_eq!(images[0].1.as_slice(), image);
+        assert!(functions.is_empty());
+        assert!(streams.is_empty());
+        assert!(events.is_empty());
+        assert!(graphs.is_empty());
+        assert!(handles.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Maps one immutable module handoff across clone workers to reduce pool startup time and private host memory.