### PR TITLE
Signal guest boot-readiness with an event-driven vsock doorbell as the primary ready signal, keeping the marker file and control-channel ping as fallbacks

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -486,8 +486,41 @@ fn main() {
 /// Writes a marker file to the virtiofs rootfs. The host polls for this file.
 /// The virtiofs FUSE write is visible on the host filesystem within ~1ms
 /// (hv_gic_set_spi interrupt injection is 0–15µs; no event_manager involvement).
+/// Ring the readiness doorbell: connect to the host (CID 2) on the `AGENT_READY`
+/// vsock port. The host's `accept()` fires the instant this connects, giving an
+/// event-driven readiness signal that — unlike the marker — needs no writable
+/// filesystem, so it works even when the rootfs share is root-owned (packaged
+/// installs). Best-effort: a failure just falls back to the marker/ping.
+#[cfg(target_os = "linux")]
+fn ready_doorbell() {
+    unsafe {
+        let fd = libc::socket(libc::AF_VSOCK, libc::SOCK_STREAM, 0);
+        if fd < 0 {
+            return;
+        }
+        let mut addr: libc::sockaddr_vm = std::mem::zeroed();
+        addr.svm_family = libc::AF_VSOCK as libc::sa_family_t;
+        addr.svm_cid = libc::VMADDR_CID_HOST;
+        addr.svm_port = smolvm_protocol::ports::AGENT_READY;
+        let _ = libc::connect(
+            fd,
+            &addr as *const libc::sockaddr_vm as *const libc::sockaddr,
+            std::mem::size_of::<libc::sockaddr_vm>() as libc::socklen_t,
+        );
+        libc::close(fd);
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn ready_doorbell() {}
+
 fn signal_ready_to_host() {
     use std::path::Path;
+
+    // Ring the event-driven doorbell first (a single connect), then write the file
+    // marker — both go out microseconds apart, and the host takes whichever it
+    // sees first.
+    ready_doorbell();
 
     let content = uptime_ms().to_string();
 

--- a/crates/smolvm-protocol/src/lib.rs
+++ b/crates/smolvm-protocol/src/lib.rs
@@ -152,6 +152,14 @@ pub mod ports {
     /// (`DOCKER_HOST=unix://…`). Inbound (host connects in), like the agent
     /// control channel — unlike the outbound SSH/DNS/CUDA bridges.
     pub const DOCKER: u32 = 6003;
+    /// Readiness doorbell: the guest connects OUT to this host port the instant it
+    /// finishes init, and the host's `accept()` fires — an event-driven readiness
+    /// signal that needs no writable filesystem, DAX window, or extra virtio
+    /// device. Outbound (guest connects in), like the SSH/DNS/CUDA bridges. The
+    /// primary readiness signal; the ready-marker file and the control-channel
+    /// ping remain as fallbacks. A fork clone resumes past the ring, so it never
+    /// dials this — clones detect readiness by pinging the restored agent.
+    pub const AGENT_READY: u32 = 6004;
     /// CUDA-over-vsock (experimental): guest CUDA client forwards Driver-API
     /// calls to a host CUDA server that runs them on the host NVIDIA GPU.
     pub const CUDA: u32 = 7000;

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -1208,6 +1208,21 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
             ));
         }
 
+        // Readiness doorbell (listen=false → the guest connects OUT and the host
+        // accepts). A vsock PORT on the existing vsock device, not a new device, so
+        // it costs nothing against the virtio device budget. Best-effort: if it
+        // can't be added the boot still readies via the marker/ping fallbacks.
+        {
+            let ready_path = vsock_socket.with_extension("ready");
+            if let Ok(ready_c) = path_to_cstring(&ready_path) {
+                if krun_add_vsock_port2(ctx, ports::AGENT_READY, ready_c.as_ptr(), false) < 0 {
+                    tracing::warn!(
+                        "readiness-doorbell vsock port failed to add; using marker/ping"
+                    );
+                }
+            }
+        }
+
         // Guest↔host vsock services (SSH agent, DNS filter, CUDA, …). The set
         // and its wiring live in `vsock_service`; here we just register the
         // port for each one enabled for this launch. Adding a capability needs

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -427,6 +427,21 @@ fn ready_marker_unwritable(_marker: &Path) -> bool {
     false
 }
 
+/// Bind a non-blocking AF_UNIX listener for the readiness doorbell. libkrun
+/// connects to this socket (the `AGENT_READY` port is `listen=false`) the instant
+/// the guest dials it at end-of-init, so `accept()` returning is the readiness
+/// signal. socket2's `Domain::UNIX` works on unix AND Windows (Win10+), unlike
+/// std's unix-only `UnixListener`, so this builds on every host. Returns None on
+/// any error — readiness then falls back to the marker/ping.
+fn bind_ready_listener(path: &Path) -> Option<socket2::Socket> {
+    let _ = std::fs::remove_file(path);
+    let sock = socket2::Socket::new(socket2::Domain::UNIX, socket2::Type::STREAM, None).ok()?;
+    sock.bind(&socket2::SockAddr::unix(path).ok()?).ok()?;
+    sock.listen(16).ok()?;
+    sock.set_nonblocking(true).ok()?;
+    Some(sock)
+}
+
 /// Path-injectable core of [`prune_orphaned_ready_markers`] (unit-testable).
 fn prune_orphaned_ready_markers_in(rootfs: &Path, vm_cache_root: &Path) {
     let prefix = format!("{}.", AGENT_READY_MARKER);
@@ -2514,6 +2529,13 @@ impl AgentManager {
         }
 
         let ready_marker = self.ready_marker_path();
+        // PRIMARY readiness signal: the doorbell. libkrun connects to this socket
+        // the instant the guest dials AGENT_READY at end-of-init, so `accept()`
+        // returning IS readiness — event-driven, and needing no writable marker
+        // location it works even where the marker can't be written (root-owned
+        // packaged installs). The marker (fast-path file) and the control-channel
+        // ping remain below as fallbacks; readiness is whichever fires first.
+        let ready_doorbell = bind_ready_listener(&self.vsock_socket.with_extension("ready"));
         // Socket probing cadence. The marker is a 1ms stat; a connect+ping is
         // heavier, so pace it — 20ms is what the fork-clone path above already
         // uses, and it costs at most ~20ms of the ~320ms boot.
@@ -2539,7 +2561,19 @@ impl AgentManager {
                 }
             }
 
-            // Ready when the marker is present AND non-empty. The guest writes
+            // Primary: the readiness doorbell. Non-blocking accept polled at the
+            // loop cadence; a connection means the guest reached end-of-init.
+            if let Some(listener) = &ready_doorbell {
+                if listener.accept().is_ok() {
+                    tracing::debug!(
+                        elapsed_ms = start.elapsed().as_millis(),
+                        "agent ready (doorbell)"
+                    );
+                    return Ok(());
+                }
+            }
+
+            // Fallback: ready when the marker is present AND non-empty. The guest writes
             // its uptime (always non-empty) into it. Under SMOLVM_LANDLOCK the
             // confined VMM pre-creates this file empty so Landlock can grant
             // write on just this one file (see internal_boot.rs) — so existence


### PR DESCRIPTION
The guest now rings a readiness doorbell — a connect to the host on a new listen=false vsock port (AGENT_READY) — the instant it finishes init, and the host detects readiness when its accept() returns. This is event-driven rather than polled, needs no writable filesystem, no DAX window, and no extra virtio device (it is a port on the existing vsock device), so unlike the ready-marker file it works even when the agent-rootfs share is root-owned (packaged installs), where the marker can never be written. The doorbell is the primary signal; the marker file and the control-channel ping remain as fallbacks, so readiness is whichever fires first. Fork clones warm-resume past the ring and so never dial it — they keep detecting readiness by pinging the restored agent, leaving the fork path untouched. The host listener uses socket2 (AF_UNIX works on macOS, Linux, and Windows), and cold-boot readiness latency was measured to match or beat the marker on Hypervisor.framework, KVM, and WHP.