### PR TITLE
Prepare CUDA fork handoffs in parallel

### DIFF
--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -33,6 +33,11 @@ const AGENT_STOP_TIMEOUT: Duration = Duration::from_secs(2);
 /// Timeout when waiting for agent to stop.
 const WAIT_FOR_STOP_TIMEOUT: Duration = Duration::from_secs(10);
 
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+fn should_retry_kvm_enomem(cpus: u8, fork_clone: bool) -> bool {
+    cpus == 1 || fork_clone
+}
+
 /// Running VM configuration persisted to disk so new CLI invocations
 /// can restore the actual config of a detached VM.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -1744,19 +1749,25 @@ impl AgentManager {
             if let Some(limit_mib) = features.cuda_vram_limit_mib {
                 v.push(("SMOLVM_CUDA_VRAM_LIMIT_MB", limit_mib.to_string()));
             }
-            // Some KVM kernels return a spurious ENOMEM when a one-vCPU VM
-            // enters KVM too soon after vCPU creation. Delay that first entry
-            // and retain bounded retries without delaying normal guest exits.
+            let fork_clone = features.snapshot_dir.is_some();
+            let cuda_clone = fork_clone && (features.cuda || resources_for_config.cuda);
+            // Some KVM kernels return a spurious ENOMEM while concurrent fork
+            // clones enter KVM. Keep the first-entry delay specific to one-vCPU
+            // guests, but enable the bounded retry path for every fork clone;
+            // retries add no delay unless KVM actually returns ENOMEM.
             #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
             if resources_for_config.cpus == 1 {
                 v.push(("KRUN_FIRST_RUN_DELAY", "1".to_string()));
+            }
+            #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+            if should_retry_kvm_enomem(resources_for_config.cpus, fork_clone) {
                 v.push(("KRUN_ENOMEM_RETRY", "1".to_string()));
             }
             // A CUDA fork clone must stay ptrace-readable by the same-uid daemon
             // /worker: the proc-mem live-RAM transport preads /proc/<pid>/mem for
             // D2H/H2D, so the clone must NOT harden to dumpable=0. Same same-uid
             // exposure the forkable golden already accepts (single-tenant).
-            if features.snapshot_dir.is_some() && (features.cuda || resources_for_config.cuda) {
+            if cuda_clone {
                 v.push(("SMOLVM_CUDA_CLONE_PTRACEABLE", "1".to_string()));
             }
             // Shared CUDA daemon: forward an explicit operator setting as-is.
@@ -2758,6 +2769,14 @@ fn boot_failure_reason(exit_code: Option<i32>, startup_log: Option<&str>) -> Str
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    #[test]
+    fn kvm_enomem_retries_cover_multi_vcpu_fork_clones() {
+        assert!(should_retry_kvm_enomem(1, false));
+        assert!(should_retry_kvm_enomem(3, true));
+        assert!(!should_retry_kvm_enomem(3, false));
+    }
 
     // The distro-package case: the rootfs directory is not writable by the user
     // running smolvm, so the guest's marker write can never succeed. Detecting

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -4793,6 +4793,25 @@ fn spawn_clone_worker(
         golden_eviction_enabled(eviction_mode.as_deref(), options.fork_pool_size),
         sharing_active,
     );
+    #[cfg(target_os = "linux")]
+    let module_blob_build = if cached_module_blob(token).is_none() {
+        // Capturing module metadata briefly shares the frozen layout lock, but
+        // writing the immutable images is independent of the device-to-host
+        // memory snapshot below. Overlap both first-worker costs; later workers
+        // continue to use the two single-flight caches.
+        match std::thread::Builder::new()
+            .name("cuda-module-handoff".into())
+            .spawn(move || module_blob_for_token(token))
+        {
+            Ok(build) => Some(build),
+            Err(error) => {
+                tracing::warn!(%error, token, "could not parallelize CUDA module handoff");
+                None
+            }
+        }
+    } else {
+        None
+    };
     let (golden_dev, layout, export_fds) = if let Some(cached) = cached_host_snapshot(token) {
         tracing::info!(
             token,
@@ -5075,7 +5094,20 @@ fn spawn_clone_worker(
     // inherit a read-only descriptor for an unnamed file; other Unix hosts keep
     // the legacy unique-path handoff.
     #[cfg(target_os = "linux")]
-    let module_blob = match module_blob_for_token(token) {
+    let module_blob_result = match module_blob_build {
+        Some(build) => match build.join() {
+            Ok(result) => result,
+            Err(_) => {
+                for &fd in &export_fds {
+                    unsafe { libc::close(fd) };
+                }
+                return Err(io::Error::other("CUDA module handoff builder panicked"));
+            }
+        },
+        None => module_blob_for_token(token),
+    };
+    #[cfg(target_os = "linux")]
+    let module_blob = match module_blob_result {
         Ok(blob) => blob,
         Err(error) => {
             for &fd in &export_fds {


### PR DESCRIPTION
Builds the first CUDA module handoff concurrently with the host snapshot while preserving cached and non-Linux paths.