### PR TITLE
Pre-materialize CUDA modules for clone startup

### DIFF
--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -915,6 +915,16 @@ struct GoldenLayout {
     /// worker). Shared with the process-wide content cache and handoff snapshots
     /// so preparing a clone never deep-copies multi-gigabyte module state.
     modules: HashMap<u64, std::sync::Arc<[u8]>>,
+    /// Linux keeps a second, append-only representation of module images in an
+    /// unlinked regular file while the golden loads. Clone handoffs can then
+    /// serialize only handle metadata and map these already-materialized bytes
+    /// instead of rewriting every image at first fork.
+    #[cfg(target_os = "linux")]
+    module_image_store: Option<ModuleImageStore>,
+    /// A store write failure permanently selects the existing owned-image
+    /// fallback for this layout; repeatedly retrying could mix partial stores.
+    #[cfg(target_os = "linux")]
+    module_image_store_failed: bool,
     /// M3a: golden function handle → (module handle, name) — the worker re-resolves
     /// it in its reloaded module and remaps the inherited raw CUfunction handle.
     functions: HashMap<u64, (u64, String)>,
@@ -954,6 +964,13 @@ struct GoldenLayout {
     lib_handles: Vec<(u8, u16, u64, Vec<u8>)>,
     /// Host GPU the golden is pinned to — clones must reconstruct on it.
     device_base: i32,
+}
+
+#[cfg(target_os = "linux")]
+struct ModuleImageStore {
+    writable: std::fs::File,
+    bytes: u64,
+    ranges: HashMap<u64, (u64, u64)>,
 }
 type LayoutCell = std::sync::Mutex<GoldenLayout>;
 static DPTR_HANDOFF: std::sync::Mutex<Option<HashMap<u64, std::sync::Weak<AllocTable>>>> =
@@ -1278,6 +1295,60 @@ pub fn module_handoff_snapshot(
     let graphs = g.graphs.clone();
     let lib_handles = g.lib_handles.clone();
     Some((modules, funcs, streams, events, graphs, lib_handles))
+}
+
+/// Read-only snapshot of the append-only Linux module-image store.
+///
+/// The returned ranges cover every module in the same process layout or the
+/// function returns `None`, allowing the daemon to retain its existing
+/// self-contained handoff fallback after any store failure.
+#[cfg(target_os = "linux")]
+pub struct ModuleImageStoreSnapshot {
+    pub file: std::fs::File,
+    pub ranges: HashMap<u64, (u64, u64)>,
+    pub bytes: u64,
+}
+
+#[cfg(target_os = "linux")]
+pub fn module_image_store_snapshot(
+    token: u64,
+) -> std::io::Result<Option<ModuleImageStoreSnapshot>> {
+    use std::os::fd::AsRawFd;
+
+    let Some(layout) = layout_handoff_lookup(token) else {
+        return Ok(None);
+    };
+    let golden = layout.lock().unwrap();
+    let Some(store) = golden.module_image_store.as_ref() else {
+        return Ok(None);
+    };
+    if golden.modules.len() != store.ranges.len()
+        || golden
+            .modules
+            .keys()
+            .any(|handle| !store.ranges.contains_key(handle))
+        || store.ranges.values().any(|(offset, length)| {
+            offset
+                .checked_add(*length)
+                .is_none_or(|end| end > store.bytes)
+        })
+    {
+        return Ok(None);
+    }
+    let path = format!("/proc/self/fd/{}", store.writable.as_raw_fd());
+    let file = std::fs::OpenOptions::new().read(true).open(path)?;
+    let metadata = file.metadata()?;
+    if !metadata.file_type().is_file() || metadata.len() < store.bytes {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "CUDA module image store is truncated or not a regular file",
+        ));
+    }
+    Ok(Some(ModuleImageStoreSnapshot {
+        file,
+        ranges: store.ranges.clone(),
+        bytes: store.bytes,
+    }))
 }
 
 /// Current version of the module/handle state serialized for clone workers.
@@ -2211,6 +2282,76 @@ fn module_cache_put(image: std::sync::Arc<[u8]>) {
 
 fn module_cache_get(key: &ModuleCacheKey) -> Option<std::sync::Arc<[u8]>> {
     module_cache().lock().unwrap().get(key).cloned()
+}
+
+#[cfg(target_os = "linux")]
+fn create_module_image_store() -> std::io::Result<ModuleImageStore> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    static NEXT_STORE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let directory = std::env::temp_dir().join("smolvm");
+    std::fs::create_dir_all(&directory)?;
+    for _ in 0..16 {
+        let sequence = NEXT_STORE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let path = directory.join(format!(
+            "cuda-module-images-{}-{sequence:016x}",
+            std::process::id()
+        ));
+        match std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&path)
+        {
+            Ok(file) => {
+                if let Err(error) = std::fs::remove_file(&path) {
+                    drop(file);
+                    let _ = std::fs::remove_file(path);
+                    return Err(error);
+                }
+                return Ok(ModuleImageStore {
+                    writable: file,
+                    bytes: 0,
+                    ranges: HashMap::new(),
+                });
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error),
+        }
+    }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::AlreadyExists,
+        "could not allocate a unique CUDA module image store",
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn retain_module_image(layout: &mut GoldenLayout, handle: u64, image: &[u8]) {
+    if layout.module_image_store_failed {
+        return;
+    }
+    if layout.module_image_store.is_none() {
+        match create_module_image_store() {
+            Ok(store) => layout.module_image_store = Some(store),
+            Err(error) => {
+                layout.module_image_store_failed = true;
+                eprintln!("[cuda-module-store] disabled after create failure: {error}");
+                return;
+            }
+        }
+    }
+    let store = layout.module_image_store.as_mut().unwrap();
+    let offset = store.bytes;
+    let length = image.len() as u64;
+    if let Err(error) = store.writable.write_all(image) {
+        layout.module_image_store = None;
+        layout.module_image_store_failed = true;
+        eprintln!("[cuda-module-store] disabled after append failure: {error}");
+        return;
+    }
+    store.ranges.insert(handle, (offset, length));
+    store.bytes = store.bytes.saturating_add(length);
 }
 
 /// Mark the allocation containing `dptr` as loaded (H2D-written → read-only
@@ -4068,6 +4209,8 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             // its own context and remap this inherited handle.
             if path3_enabled() {
                 let mut layout = sess.golden_layout.lock().unwrap();
+                #[cfg(target_os = "linux")]
+                retain_module_image(&mut layout, raw, &image);
                 layout.modules.insert(raw, image);
                 layout.handoff_revision = layout.handoff_revision.wrapping_add(1);
             }
@@ -4662,6 +4805,8 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
                     sess.owned_modules.insert(raw);
                     if path3_enabled() {
                         let mut layout = sess.golden_layout.lock().unwrap();
+                        #[cfg(target_os = "linux")]
+                        retain_module_image(&mut layout, raw, &image);
                         layout.modules.insert(raw, image.clone());
                         layout.handoff_revision = layout.handoff_revision.wrapping_add(1);
                     }
@@ -5349,6 +5494,43 @@ mod tests {
         drop(file);
         assert_eq!(range.as_slice(), b"3456");
         assert!(range.slice(4, 1).is_none());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn module_image_store_snapshot_covers_every_retained_module() {
+        use std::os::unix::fs::FileExt as _;
+
+        let layout: Arc<LayoutCell> = Arc::new(Mutex::new(GoldenLayout::default()));
+        let first: Arc<[u8]> = b"first-module-image".as_slice().into();
+        let second: Arc<[u8]> = b"second-module-image".as_slice().into();
+        {
+            let mut golden = layout.lock().unwrap();
+            retain_module_image(&mut golden, 0x10, &first);
+            retain_module_image(&mut golden, 0x20, &second);
+            golden.modules.insert(0x10, first.clone());
+            golden.modules.insert(0x20, second.clone());
+        }
+        let token = 0xA6A6_0000_0000_0001;
+        layout_handoff_register(&layout, token);
+
+        let snapshot = module_image_store_snapshot(token).unwrap().unwrap();
+        assert_eq!(snapshot.bytes, (first.len() + second.len()) as u64);
+        let mut actual = vec![0; snapshot.bytes as usize];
+        snapshot.file.read_exact_at(&mut actual, 0).unwrap();
+        assert_eq!(actual, [first.as_ref(), second.as_ref()].concat());
+        assert_eq!(snapshot.ranges.get(&0x10), Some(&(0, first.len() as u64)));
+        assert_eq!(
+            snapshot.ranges.get(&0x20),
+            Some(&(first.len() as u64, second.len() as u64))
+        );
+
+        layout
+            .lock()
+            .unwrap()
+            .modules
+            .insert(0x30, b"not-in-store".as_slice().into());
+        assert!(module_image_store_snapshot(token).unwrap().is_none());
     }
 
     #[test]

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -42,6 +42,8 @@ const TENSOR_BUNDLE_TTL: Duration = Duration::from_secs(60);
 static TENSOR_BUNDLE_SERVICE_READY: AtomicBool = AtomicBool::new(false);
 #[cfg(unix)]
 const MAX_MODULE_HANDOFF_BLOB_BYTES: u64 = 32 << 30;
+#[cfg(unix)]
+const EXTERNAL_MODULE_IMAGES_MAGIC: [u8; 4] = *b"MHI2";
 
 #[derive(Debug)]
 struct PendingTensorBundle {
@@ -1720,6 +1722,27 @@ pub fn run_clone_worker(fd: std::os::unix::io::RawFd) -> io::Result<()> {
         };
     #[cfg(not(target_os = "linux"))]
     let inherited_module_blob: Option<smolvm_cuda::host::ModuleHandoffBytes> = None;
+    #[cfg(target_os = "linux")]
+    let inherited_module_images =
+        if let Some(value) = std::env::var_os("SMOLVM_CUDA_CLONE_MODULE_IMAGES_FD") {
+            let value = value.into_string().map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "CUDA module image-store fd is not valid UTF-8",
+                )
+            })?;
+            let image_fd = value.parse::<std::os::fd::RawFd>().map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "CUDA module image-store fd is invalid",
+                )
+            })?;
+            Some(map_module_blob_fd(image_fd)?)
+        } else {
+            None
+        };
+    #[cfg(not(target_os = "linux"))]
+    let inherited_module_images: Option<smolvm_cuda::host::ModuleHandoffBytes> = None;
     let module_blob = if inherited_module_blob.is_some() {
         inherited_module_blob
     } else if let Ok(modpath) = std::env::var("SMOLVM_CUDA_CLONE_MODULES") {
@@ -1731,7 +1754,11 @@ pub fn run_clone_worker(fd: std::os::unix::io::RawFd) -> io::Result<()> {
     };
     if let Some(module_blob) = module_blob {
         let (mod_images, func_meta, streams, events, graphs, lib_handles) =
-            reconstruct_golden_modules(backend.as_mut(), &module_blob);
+            reconstruct_golden_modules(
+                backend.as_mut(),
+                &module_blob,
+                inherited_module_images.as_ref(),
+            )?;
         let (nm, nf, ns, ne, ng, nlh) = (
             mod_images.len(),
             func_meta.len(),
@@ -2998,14 +3025,15 @@ fn map_module_blob_fd(fd: std::os::fd::RawFd) -> io::Result<smolvm_cuda::host::M
 fn reconstruct_golden_modules(
     b: &mut dyn Backend,
     source: &smolvm_cuda::host::ModuleHandoffBytes,
-) -> (
+    external_module_images: Option<&smolvm_cuda::host::ModuleHandoffBytes>,
+) -> io::Result<(
     Vec<(u64, smolvm_cuda::host::ModuleHandoffBytes)>,
     Vec<smolvm_cuda::host::FuncMeta>,
     Vec<(u64, u64)>,
     Vec<(u64, u64)>,
     Vec<(u64, u64, smolvm_cuda::host::GraphSer)>,
     Vec<(u8, u16, u64, Vec<u8>)>,
-) {
+)> {
     let buf = source.as_slice();
     let mut mod_images = Vec::new();
     let mut func_meta = Vec::new();
@@ -3016,15 +3044,11 @@ fn reconstruct_golden_modules(
     let mut p = 0usize;
     macro_rules! need {
         ($n:expr) => {
-            if p + $n > buf.len() {
-                return (
-                    mod_images,
-                    func_meta,
-                    stream_trans,
-                    event_trans,
-                    graphs,
-                    lib_handles,
-                );
+            if p.checked_add($n).is_none_or(|end| end > buf.len()) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "CUDA module handoff is truncated",
+                ));
             }
         };
     }
@@ -3044,15 +3068,44 @@ fn reconstruct_golden_modules(
             v
         }};
     }
+    let uses_external_images = buf.starts_with(&EXTERNAL_MODULE_IMAGES_MAGIC);
+    if uses_external_images {
+        p += EXTERNAL_MODULE_IMAGES_MAGIC.len();
+        if external_module_images.is_none() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "CUDA module handoff requires a missing external image store",
+            ));
+        }
+    }
     // Modules: just STAGE the images (reloaded lazily on first use in the worker).
     let nmods = ru32!();
     for _ in 0..nmods {
         let gh = ru64!();
-        let ilen = ru32!() as usize;
-        need!(ilen);
-        // `need!` proved this range is within the immutable source.
-        mod_images.push((gh, source.slice(p, ilen).unwrap()));
-        p += ilen;
+        if uses_external_images {
+            let offset = usize::try_from(ru64!()).map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "CUDA module image offset does not fit in address space",
+                )
+            })?;
+            let length = ru32!() as usize;
+            let image = external_module_images
+                .and_then(|images| images.slice(offset, length))
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "CUDA module image range exceeds its external store",
+                    )
+                })?;
+            mod_images.push((gh, image));
+        } else {
+            let ilen = ru32!() as usize;
+            need!(ilen);
+            // `need!` proved this range is within the immutable source.
+            mod_images.push((gh, source.slice(p, ilen).unwrap()));
+            p += ilen;
+        }
     }
     // Functions: stage golden fn → (golden module, name); resolved lazily.
     let nfuncs = ru32!();
@@ -3189,14 +3242,14 @@ fn reconstruct_golden_modules(
         lib_handles = lib_handles.len(),
         "M3a: staged golden modules/functions for lazy reload + recreated streams/events"
     );
-    (
+    Ok((
         mod_images,
         func_meta,
         stream_trans,
         event_trans,
         graphs,
         lib_handles,
-    )
+    ))
 }
 
 /// Strip a fork-clone connection preamble (magic + clone id) if present,
@@ -4204,6 +4257,15 @@ struct CachedModuleBlob {
     file: std::fs::File,
     bytes: u64,
     revision: u64,
+    image_file: Option<std::fs::File>,
+    image_bytes: u64,
+}
+
+#[cfg(target_os = "linux")]
+impl CachedModuleBlob {
+    fn total_bytes(&self) -> u64 {
+        self.bytes.saturating_add(self.image_bytes)
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -4326,14 +4388,14 @@ fn prune_module_blob_cache(cache: &mut std::collections::HashMap<u64, Arc<Cached
     let before = cache.len();
     let before_bytes = cache
         .values()
-        .fold(0u64, |total, blob| total.saturating_add(blob.bytes));
+        .fold(0u64, |total, blob| total.saturating_add(blob.total_bytes()));
     cache.retain(|token, blob| {
         smolvm_cuda::host::module_handoff_revision(*token) == Some(blob.revision)
     });
     if cache.len() != before {
         let retained_bytes = cache
             .values()
-            .fold(0u64, |total, blob| total.saturating_add(blob.bytes));
+            .fold(0u64, |total, blob| total.saturating_add(blob.total_bytes()));
         tracing::info!(
             entries = before - cache.len(),
             bytes = before_bytes.saturating_sub(retained_bytes),
@@ -4367,7 +4429,7 @@ fn prepare_module_blob(
     std::fs::create_dir_all(&directory)?;
     let mut writable = tempfile::tempfile_in(&directory)?;
     writable.write_all(bytes)?;
-    finish_module_blob(token, revision, writable, bytes.len() as u64)
+    finish_module_blob(token, revision, writable, bytes.len() as u64, None)
 }
 
 #[cfg(target_os = "linux")]
@@ -4376,6 +4438,7 @@ fn prepare_streamed_module_blob(
     revision: u64,
     snapshot: &CapturedModuleHandoff,
     oplogs: &CapturedGraphOplogs,
+    module_images: Option<smolvm_cuda::host::ModuleImageStoreSnapshot>,
 ) -> io::Result<Arc<CachedModuleBlob>> {
     if let Some(blob) = cached_module_blob(token) {
         return Ok(blob);
@@ -4385,11 +4448,11 @@ fn prepare_streamed_module_blob(
     let mut writable = tempfile::tempfile_in(&directory)?;
     let bytes = {
         let mut output = std::io::BufWriter::with_capacity(1 << 20, &mut writable);
-        let bytes = write_module_handoff(&mut output, snapshot, oplogs)?;
+        let bytes = write_module_handoff(&mut output, snapshot, oplogs, module_images.as_ref())?;
         output.flush()?;
         bytes
     };
-    finish_module_blob(token, revision, writable, bytes)
+    finish_module_blob(token, revision, writable, bytes, module_images)
 }
 
 #[cfg(target_os = "linux")]
@@ -4398,6 +4461,7 @@ fn finish_module_blob(
     revision: u64,
     writable: std::fs::File,
     bytes: u64,
+    module_images: Option<smolvm_cuda::host::ModuleImageStoreSnapshot>,
 ) -> io::Result<Arc<CachedModuleBlob>> {
     let read_path = format!("/proc/self/fd/{}", writable.as_raw_fd());
     let file = std::fs::OpenOptions::new().read(true).open(read_path)?;
@@ -4405,6 +4469,8 @@ fn finish_module_blob(
         file,
         bytes,
         revision,
+        image_bytes: module_images.as_ref().map_or(0, |store| store.bytes),
+        image_file: module_images.map(|store| store.file),
     });
     drop(writable);
 
@@ -4418,19 +4484,20 @@ fn finish_module_blob(
     }) {
         return Ok(existing);
     }
-    let cached_bytes = cache
-        .values()
-        .fold(0u64, |total, entry| total.saturating_add(entry.bytes));
+    let cached_bytes = cache.values().fold(0u64, |total, entry| {
+        total.saturating_add(entry.total_bytes())
+    });
     let revision_current = smolvm_cuda::host::module_handoff_revision(token) == Some(revision);
     if revision_current
         && cache.len() < MAX_CACHED_MODULE_BLOBS
-        && cached_bytes.saturating_add(blob.bytes) <= MAX_MODULE_HANDOFF_BLOB_BYTES
+        && cached_bytes.saturating_add(blob.total_bytes()) <= MAX_MODULE_HANDOFF_BLOB_BYTES
     {
         cache.insert(token, blob.clone());
     } else if revision_current {
         tracing::warn!(
             token,
-            bytes = blob.bytes,
+            metadata_bytes = blob.bytes,
+            image_bytes = blob.image_bytes,
             cached_bytes,
             "CUDA module handoff cache is full; retaining this source for one worker"
         );
@@ -4443,7 +4510,8 @@ fn module_blob_for_token(token: u64) -> io::Result<Option<Arc<CachedModuleBlob>>
     if let Some(blob) = cached_module_blob(token) {
         tracing::info!(
             token,
-            bytes = blob.bytes,
+            metadata_bytes = blob.bytes,
+            image_bytes = blob.image_bytes,
             "reusing serialized CUDA module handoff"
         );
         return Ok(Some(blob));
@@ -4456,7 +4524,8 @@ fn module_blob_for_token(token: u64) -> io::Result<Option<Arc<CachedModuleBlob>>
     if let Some(blob) = cached_module_blob(token) {
         tracing::info!(
             token,
-            bytes = blob.bytes,
+            metadata_bytes = blob.bytes,
+            image_bytes = blob.image_bytes,
             "reusing serialized CUDA module handoff after concurrent build"
         );
         return Ok(Some(blob));
@@ -4465,12 +4534,18 @@ fn module_blob_for_token(token: u64) -> io::Result<Option<Arc<CachedModuleBlob>>
         let Some((revision, snapshot, oplogs)) = capture_module_handoff(token)? else {
             return Ok(None);
         };
-        let blob = prepare_streamed_module_blob(token, revision, &snapshot, &oplogs)?;
+        let module_images = smolvm_cuda::host::module_image_store_snapshot(token)?;
+        if smolvm_cuda::host::module_handoff_revision(token) != Some(revision) {
+            continue;
+        }
+        let blob =
+            prepare_streamed_module_blob(token, revision, &snapshot, &oplogs, module_images)?;
         if smolvm_cuda::host::module_handoff_revision(token) == Some(revision) {
             tracing::info!(
                 token,
                 revision,
-                bytes = blob.bytes,
+                metadata_bytes = blob.bytes,
+                image_bytes = blob.image_bytes,
                 "prepared reusable CUDA module handoff"
             );
             return Ok(Some(blob));
@@ -4678,6 +4753,7 @@ fn write_module_handoff(
     mut output: impl Write,
     snapshot: &CapturedModuleHandoff,
     oplogs: &CapturedGraphOplogs,
+    #[cfg(target_os = "linux")] module_images: Option<&smolvm_cuda::host::ModuleImageStoreSnapshot>,
 ) -> io::Result<u64> {
     let (modules, funcs, streams, events, graphs, lib_handles) = snapshot;
     let mut written = 0_u64;
@@ -4694,9 +4770,35 @@ fn write_module_handoff(
         }};
     }
 
+    #[cfg(target_os = "linux")]
+    if module_images.is_some() {
+        put!(&EXTERNAL_MODULE_IMAGES_MAGIC);
+    }
     put!(&module_handoff_len(modules.len())?);
     for (handle, image) in modules {
         put!(&handle.to_le_bytes());
+        #[cfg(target_os = "linux")]
+        if let Some(store) = module_images {
+            let &(offset, length) = store.ranges.get(handle).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "CUDA module image is missing from its append-only store",
+                )
+            })?;
+            if length != image.len() as u64
+                || offset
+                    .checked_add(length)
+                    .is_none_or(|end| end > store.bytes)
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "CUDA module image store range does not match its captured image",
+                ));
+            }
+            put!(&offset.to_le_bytes());
+            put!(&module_handoff_len(image.len())?);
+            continue;
+        }
         put!(&module_handoff_len(image.len())?);
         put!(image);
     }
@@ -4832,6 +4934,7 @@ struct CloneWorkerSpawnFds<'a> {
     control: (i32, i32),
     publish: Option<(i32, i32)>,
     module: Option<(i32, i32)>,
+    module_images: Option<(i32, i32)>,
 }
 
 /// Launch a clone worker without copying the CUDA daemon's large address space.
@@ -4858,6 +4961,9 @@ fn posix_spawn_clone_worker(
         actions.dup2(source, slot)?;
     }
     if let Some((source, slot)) = fds.module {
+        actions.dup2(source, slot)?;
+    }
+    if let Some((source, slot)) = fds.module_images {
         actions.dup2(source, slot)?;
     }
 
@@ -5318,7 +5424,13 @@ fn spawn_clone_worker(
     #[cfg(target_os = "linux")]
     let module_slot = publish_slot + i32::from(publish_enabled);
     #[cfg(target_os = "linux")]
-    let source_minimum = module_slot + i32::from(module_blob.is_some());
+    let module_images_slot = module_slot + i32::from(module_blob.is_some());
+    #[cfg(target_os = "linux")]
+    let has_module_images = module_blob
+        .as_ref()
+        .is_some_and(|blob| blob.image_file.is_some());
+    #[cfg(target_os = "linux")]
+    let source_minimum = module_images_slot + i32::from(has_module_images);
     #[cfg(not(target_os = "linux"))]
     let source_minimum = publish_slot + i32::from(publish_enabled);
     #[cfg(target_os = "linux")]
@@ -5333,6 +5445,34 @@ fn spawn_clone_worker(
                 if publish_enabled {
                     libc::close(publish_sp[0]);
                     libc::close(publish_sp[1]);
+                }
+            }
+            for fd in export_fds {
+                unsafe { libc::close(fd) };
+            }
+            return Err(error);
+        }
+        fd
+    } else {
+        -1
+    };
+    #[cfg(target_os = "linux")]
+    let module_images_child = if let Some(file) = module_blob
+        .as_ref()
+        .and_then(|blob| blob.image_file.as_ref())
+    {
+        let fd = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_DUPFD_CLOEXEC, source_minimum) };
+        if fd < 0 {
+            let error = io::Error::last_os_error();
+            unsafe {
+                libc::close(sp[0]);
+                libc::close(sp[1]);
+                if publish_enabled {
+                    libc::close(publish_sp[0]);
+                    libc::close(publish_sp[1]);
+                }
+                if module_child >= 0 {
+                    libc::close(module_child);
                 }
             }
             for fd in export_fds {
@@ -5364,6 +5504,10 @@ fn spawn_clone_worker(
         if module_child >= 0 {
             unsafe { libc::close(module_child) };
         }
+        #[cfg(target_os = "linux")]
+        if module_images_child >= 0 {
+            unsafe { libc::close(module_images_child) };
+        }
         for fd in export_fds {
             unsafe { libc::close(fd) };
         }
@@ -5382,6 +5526,10 @@ fn spawn_clone_worker(
             #[cfg(target_os = "linux")]
             if module_child >= 0 {
                 unsafe { libc::close(module_child) };
+            }
+            #[cfg(target_os = "linux")]
+            if module_images_child >= 0 {
+                unsafe { libc::close(module_images_child) };
             }
             for fd in export_fds {
                 unsafe { libc::close(fd) };
@@ -5405,6 +5553,10 @@ fn spawn_clone_worker(
                 #[cfg(target_os = "linux")]
                 if module_child >= 0 {
                     libc::close(module_child);
+                }
+                #[cfg(target_os = "linux")]
+                if module_images_child >= 0 {
+                    libc::close(module_images_child);
                 }
             }
             return Err(error);
@@ -5475,6 +5627,13 @@ fn spawn_clone_worker(
             std::ffi::OsString::from(module_slot.to_string()),
         ));
     }
+    #[cfg(target_os = "linux")]
+    if has_module_images {
+        worker_env.push((
+            std::ffi::OsString::from("SMOLVM_CUDA_CLONE_MODULE_IMAGES_FD"),
+            std::ffi::OsString::from(module_images_slot.to_string()),
+        ));
+    }
     #[cfg(not(target_os = "linux"))]
     if let Some(mp) = &modpath {
         worker_env.push((
@@ -5492,6 +5651,11 @@ fn spawn_clone_worker(
     let module_action = (module_child >= 0).then_some((module_child, module_slot));
     #[cfg(not(target_os = "linux"))]
     let module_action = None;
+    #[cfg(target_os = "linux")]
+    let module_images_action =
+        (module_images_child >= 0).then_some((module_images_child, module_images_slot));
+    #[cfg(not(target_os = "linux"))]
+    let module_images_action = None;
     let spawned = posix_spawn_clone_worker(
         &exe,
         &worker_env,
@@ -5501,6 +5665,7 @@ fn spawn_clone_worker(
             control: (ctrl_child, ctrl_slot),
             publish: publish_enabled.then_some((publish_child, publish_slot)),
             module: module_action,
+            module_images: module_images_action,
         },
     );
     // The child (if any) forked with its own copies; drop ours either way so
@@ -5519,6 +5684,11 @@ fn spawn_clone_worker(
     if module_child >= 0 {
         // SAFETY: the child inherited its own copy at module_slot.
         unsafe { libc::close(module_child) };
+    }
+    #[cfg(target_os = "linux")]
+    if module_images_child >= 0 {
+        // SAFETY: the child inherited its own copy at module_images_slot.
+        unsafe { libc::close(module_images_child) };
     }
     match spawned {
         Ok(pid) => {
@@ -5691,6 +5861,7 @@ mod mps_tests {
                 control: (control[1], 4),
                 publish: None,
                 module: None,
+                module_images: None,
             },
         )
         .unwrap();
@@ -5794,7 +5965,7 @@ mod mps_tests {
         let source = map_module_blob_fd(file.into_raw_fd()).unwrap();
         let mut backend = smolvm_cuda::host::CpuBackend::default();
         let (images, functions, streams, events, graphs, handles) =
-            reconstruct_golden_modules(&mut backend, &source);
+            reconstruct_golden_modules(&mut backend, &source, None).unwrap();
         drop(source);
 
         assert_eq!(images.len(), 1);
@@ -5805,6 +5976,85 @@ mod mps_tests {
         assert!(events.is_empty());
         assert!(graphs.is_empty());
         assert!(handles.is_empty());
+    }
+
+    #[test]
+    fn external_module_image_store_keeps_handoff_metadata_small() {
+        use std::io::Write as _;
+        use std::os::fd::IntoRawFd as _;
+
+        let image: Arc<[u8]> = b"external-module-image".as_slice().into();
+        let snapshot = (
+            vec![(0x1234, image.clone())],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        let mut image_file = tempfile::tempfile().unwrap();
+        image_file.write_all(&image).unwrap();
+        let image_store = smolvm_cuda::host::ModuleImageStoreSnapshot {
+            file: image_file.try_clone().unwrap(),
+            ranges: std::collections::HashMap::from([(0x1234, (0, image.len() as u64))]),
+            bytes: image.len() as u64,
+        };
+        let mut metadata = Vec::new();
+        write_module_handoff(&mut metadata, &snapshot, &Vec::new(), Some(&image_store)).unwrap();
+        assert!(metadata.starts_with(&super::EXTERNAL_MODULE_IMAGES_MAGIC));
+        assert!(!metadata
+            .windows(image.len())
+            .any(|window| window == image.as_ref()));
+
+        let mut metadata_file = tempfile::tempfile().unwrap();
+        metadata_file.write_all(&metadata).unwrap();
+        let metadata_source = map_module_blob_fd(metadata_file.into_raw_fd()).unwrap();
+        let image_source = map_module_blob_fd(image_file.into_raw_fd()).unwrap();
+        let mut backend = smolvm_cuda::host::CpuBackend::default();
+        assert_eq!(
+            reconstruct_golden_modules(&mut backend, &metadata_source, None)
+                .err()
+                .unwrap()
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+        let mut invalid_range = metadata.clone();
+        invalid_range[16..24].copy_from_slice(&1_u64.to_le_bytes());
+        let invalid_range = smolvm_cuda::host::ModuleHandoffBytes::from_owned(invalid_range);
+        assert_eq!(
+            reconstruct_golden_modules(&mut backend, &invalid_range, Some(&image_source))
+                .err()
+                .unwrap()
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+        let (images, functions, streams, events, graphs, handles) =
+            reconstruct_golden_modules(&mut backend, &metadata_source, Some(&image_source))
+                .unwrap();
+        drop(metadata_source);
+        drop(image_source);
+
+        assert_eq!(images.len(), 1);
+        assert_eq!(images[0].0, 0x1234);
+        assert_eq!(images[0].1.as_slice(), image.as_ref());
+        assert!(functions.is_empty());
+        assert!(streams.is_empty());
+        assert!(events.is_empty());
+        assert!(graphs.is_empty());
+        assert!(handles.is_empty());
+    }
+
+    #[test]
+    fn truncated_module_handoff_fails_closed() {
+        let source = smolvm_cuda::host::ModuleHandoffBytes::from_owned(vec![1, 0, 0]);
+        let mut backend = smolvm_cuda::host::CpuBackend::default();
+        assert_eq!(
+            reconstruct_golden_modules(&mut backend, &source, None)
+                .err()
+                .unwrap()
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
     }
 
     #[test]
@@ -5843,7 +6093,7 @@ mod mps_tests {
         let oplogs = vec![(0x50, 0x51, vec![vec![7, 6, 5]])];
 
         let mut actual = Vec::new();
-        let written = write_module_handoff(&mut actual, &snapshot, &oplogs).unwrap();
+        let written = write_module_handoff(&mut actual, &snapshot, &oplogs, None).unwrap();
 
         fn u16_field(output: &mut Vec<u8>, value: u16) {
             output.extend_from_slice(&value.to_le_bytes());
@@ -5910,7 +6160,7 @@ mod mps_tests {
         assert_eq!(actual, expected);
 
         let token = u64::MAX - 92;
-        let blob = prepare_streamed_module_blob(token, 0, &snapshot, &oplogs).unwrap();
+        let blob = prepare_streamed_module_blob(token, 0, &snapshot, &oplogs, None).unwrap();
         assert_eq!(blob.bytes, expected.len() as u64);
         assert_eq!(blob.file.metadata().unwrap().len(), expected.len() as u64);
         let mapped = unsafe {


### PR DESCRIPTION
Pre-materializes immutable CUDA module images so clone workers map them instead of rewriting gigabytes during startup.