### PR TITLE
Reuse golden snapshots for faster pool refills

### DIFF
--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -180,6 +180,30 @@ pub struct PreparedFork {
     pub resume_golden_on_rollback: bool,
 }
 
+/// A checkpoint that may be reused while the exact same golden process remains
+/// paused. The PID start time prevents an old on-disk checkpoint from being
+/// applied after a golden restart or PID reuse.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct RetainedForkSnapshot {
+    /// Directory containing the libkrun checkpoint and memfd manifest.
+    pub(crate) path: PathBuf,
+    /// Host process that produced the checkpoint.
+    pub(crate) golden_pid: i32,
+    /// Kernel process start time paired with `golden_pid`.
+    pub(crate) golden_pid_start_time: u64,
+}
+
+/// Prepared batch plus the checkpoint identity that can service later refills.
+pub(crate) struct PreparedForkBatch {
+    /// Clones registered from one checkpoint.
+    pub(crate) forks: Vec<PreparedFork>,
+    /// Checkpoint bound to the current golden process, when its identity is
+    /// strong enough to reuse safely.
+    pub(crate) retained_snapshot: Option<RetainedForkSnapshot>,
+    /// Whether this call reused `retained_snapshot` instead of checkpointing.
+    pub(crate) snapshot_reused: bool,
+}
+
 /// Parameters for one clone in a single-snapshot fork operation.
 pub struct ForkSpec<'a> {
     /// New machine name.
@@ -263,6 +287,18 @@ pub fn prepare_forks(
     golden: &str,
     specs: &[ForkSpec<'_>],
 ) -> Result<Vec<PreparedFork>> {
+    Ok(prepare_forks_reusing(db, golden, specs, None)?.forks)
+}
+
+/// Prepare a batch while reusing a proven checkpoint when it still belongs to
+/// the exact paused golden process. Invalid or stale hints fall back to a fresh
+/// checkpoint; they can never cause a restore from a restarted golden.
+pub(crate) fn prepare_forks_reusing(
+    db: &SmolvmDb,
+    golden: &str,
+    specs: &[ForkSpec<'_>],
+    retained: Option<&RetainedForkSnapshot>,
+) -> Result<PreparedForkBatch> {
     if specs.is_empty() {
         return Err(Error::config("fork", "at least one clone is required"));
     }
@@ -333,48 +369,62 @@ pub fn prepare_forks(
     // Never remove a colliding random directory because a live clone may still
     // be using an older snapshot.
     let snapshot_root = gdir.join("s");
-    std::fs::create_dir_all(&snapshot_root)
-        .map_err(|e| Error::agent("create snapshot root", e.to_string()))?;
-    let snapshot_dir = (0..128)
-        .find_map(|_| {
-            let candidate = snapshot_root.join(host_random_hex(8));
-            match std::fs::create_dir(&candidate) {
-                Ok(()) => Some(Ok(candidate)),
-                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => None,
-                Err(error) => Some(Err(error)),
-            }
-        })
-        .transpose()
-        .map_err(|e| Error::agent("create snapshot dir", e.to_string()))?
-        .ok_or_else(|| Error::agent("create snapshot dir", "could not allocate a unique id"))?;
-    if let Some(result) =
-        crate::process::vm_drop_ids(&crate::agent::vm_uid_registry_dir(), &gdir, None, None)
-    {
-        let (uid, gid) =
-            result.map_err(|e| Error::agent("fork: resolve golden uid", e.to_string()))?;
-        crate::process::chown_tree(&snapshot_dir, uid, gid)
-            .map_err(|e| Error::agent("fork: chown snapshot dir", e.to_string()))?;
-    }
+    let reusable = retained.filter(|snapshot| {
+        retained_snapshot_is_reusable(&golden_rec, golden_was_paused, &snapshot_root, snapshot)
+    });
+    let (snapshot_dir, snapshot_reused) = if let Some(snapshot) = reusable {
+        tracing::info!(
+            golden,
+            path = %snapshot.path.display(),
+            clones = specs.len(),
+            "fork: reusing retained golden RAM checkpoint"
+        );
+        (snapshot.path.clone(), true)
+    } else {
+        std::fs::create_dir_all(&snapshot_root)
+            .map_err(|e| Error::agent("create snapshot root", e.to_string()))?;
+        let snapshot_dir = (0..128)
+            .find_map(|_| {
+                let candidate = snapshot_root.join(host_random_hex(8));
+                match std::fs::create_dir(&candidate) {
+                    Ok(()) => Some(Ok(candidate)),
+                    Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => None,
+                    Err(error) => Some(Err(error)),
+                }
+            })
+            .transpose()
+            .map_err(|e| Error::agent("create snapshot dir", e.to_string()))?
+            .ok_or_else(|| Error::agent("create snapshot dir", "could not allocate a unique id"))?;
+        if let Some(result) =
+            crate::process::vm_drop_ids(&crate::agent::vm_uid_registry_dir(), &gdir, None, None)
+        {
+            let (uid, gid) =
+                result.map_err(|e| Error::agent("fork: resolve golden uid", e.to_string()))?;
+            crate::process::chown_tree(&snapshot_dir, uid, gid)
+                .map_err(|e| Error::agent("fork: chown snapshot dir", e.to_string()))?;
+        }
 
-    let t_snap = std::time::Instant::now();
-    let reply = control_socket_cmd(&ctl, &format!("FORK {}", snapshot_dir.display()));
-    let reply = match reply {
-        Ok(reply) if reply.starts_with("OK") => reply,
-        Ok(reply) => {
-            let _ = std::fs::remove_dir_all(&snapshot_dir);
-            return Err(Error::agent("fork", format!("golden FORK failed: {reply}")));
-        }
-        Err(error) => {
-            let _ = std::fs::remove_dir_all(&snapshot_dir);
-            return Err(error);
-        }
+        let t_snap = std::time::Instant::now();
+        let reply = control_socket_cmd(&ctl, &format!("FORK {}", snapshot_dir.display()));
+        let reply = match reply {
+            Ok(reply) if reply.starts_with("OK") => reply,
+            Ok(reply) => {
+                let _ = std::fs::remove_dir_all(&snapshot_dir);
+                return Err(Error::agent("fork", format!("golden FORK failed: {reply}")));
+            }
+            Err(error) => {
+                let _ = std::fs::remove_dir_all(&snapshot_dir);
+                return Err(error);
+            }
+        };
+        tracing::info!(
+            elapsed_ms = t_snap.elapsed().as_millis() as u64,
+            clones = specs.len(),
+            response = %reply,
+            "fork: golden RAM checkpoint written"
+        );
+        (snapshot_dir, false)
     };
-    tracing::info!(
-        elapsed_ms = t_snap.elapsed().as_millis() as u64,
-        clones = specs.len(),
-        response = %reply,
-        "fork: golden RAM checkpoint written"
-    );
 
     let mut prepared = Vec::with_capacity(specs.len());
     for spec in specs {
@@ -396,7 +446,9 @@ pub fn prepare_forks(
                     let _ = db.remove_vm(&clone.clone_record.name);
                     let _ = std::fs::remove_dir_all(vm_data_dir(&clone.clone_record.name));
                 }
-                let _ = std::fs::remove_dir_all(&snapshot_dir);
+                if !snapshot_reused {
+                    let _ = std::fs::remove_dir_all(&snapshot_dir);
+                }
                 if golden_was_paused {
                     return Err(error);
                 }
@@ -412,7 +464,45 @@ pub fn prepare_forks(
             }
         }
     }
-    Ok(prepared)
+    let retained_snapshot =
+        golden_rec
+            .pid
+            .zip(golden_rec.pid_start_time)
+            .map(|(golden_pid, golden_pid_start_time)| RetainedForkSnapshot {
+                path: snapshot_dir,
+                golden_pid,
+                golden_pid_start_time,
+            });
+    Ok(PreparedForkBatch {
+        forks: prepared,
+        retained_snapshot,
+        snapshot_reused,
+    })
+}
+
+fn reusable_snapshot_path(snapshot_root: &Path, snapshot: &Path) -> bool {
+    snapshot.parent() == Some(snapshot_root)
+        && snapshot
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(|name| name.len() == 8 && name.bytes().all(|b| b.is_ascii_hexdigit()))
+            .unwrap_or(false)
+        && snapshot
+            .symlink_metadata()
+            .map(|metadata| metadata.file_type().is_dir())
+            .unwrap_or(false)
+}
+
+fn retained_snapshot_is_reusable(
+    golden: &VmRecord,
+    golden_was_paused: bool,
+    snapshot_root: &Path,
+    snapshot: &RetainedForkSnapshot,
+) -> bool {
+    golden_was_paused
+        && golden.pid == Some(snapshot.golden_pid)
+        && golden.pid_start_time == Some(snapshot.golden_pid_start_time)
+        && reusable_snapshot_path(snapshot_root, &snapshot.path)
 }
 
 fn prepare_clone_from_snapshot(
@@ -1021,6 +1111,61 @@ mod tests {
         assert!(fork_base_already_paused("OK paused\n"));
         assert!(!fork_base_already_paused("OK running\n"));
         assert!(!fork_base_already_paused("ERR not forkable\n"));
+    }
+
+    #[test]
+    fn retained_snapshot_requires_the_same_paused_golden_process() {
+        let temp = tempfile::tempdir().unwrap();
+        let snapshot_root = temp.path().join("s");
+        let snapshot_path = snapshot_root.join("a1b2c3d4");
+        std::fs::create_dir_all(&snapshot_path).unwrap();
+        let snapshot = RetainedForkSnapshot {
+            path: snapshot_path,
+            golden_pid: 123,
+            golden_pid_start_time: 456,
+        };
+        let mut golden = VmRecord::new("golden".into(), 2, 1024, vec![], vec![], false);
+        golden.pid = Some(123);
+        golden.pid_start_time = Some(456);
+
+        assert!(retained_snapshot_is_reusable(
+            &golden,
+            true,
+            &snapshot_root,
+            &snapshot
+        ));
+        assert!(!retained_snapshot_is_reusable(
+            &golden,
+            false,
+            &snapshot_root,
+            &snapshot
+        ));
+        golden.pid_start_time = Some(457);
+        assert!(!retained_snapshot_is_reusable(
+            &golden,
+            true,
+            &snapshot_root,
+            &snapshot
+        ));
+    }
+
+    #[test]
+    fn retained_snapshot_path_must_be_a_direct_real_checkpoint_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let snapshot_root = temp.path().join("s");
+        std::fs::create_dir_all(&snapshot_root).unwrap();
+        let valid = snapshot_root.join("0123abcd");
+        std::fs::create_dir(&valid).unwrap();
+
+        assert!(reusable_snapshot_path(&snapshot_root, &valid));
+        assert!(!reusable_snapshot_path(
+            &snapshot_root,
+            &snapshot_root.join("short")
+        ));
+        assert!(!reusable_snapshot_path(
+            &snapshot_root,
+            &temp.path().join("0123abcd")
+        ));
     }
 
     #[test]

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -1388,17 +1388,34 @@ pub(crate) async fn fork_machine_inner(
 /// through a bounded queue. Preparation is all-or-nothing; once booting begins,
 /// each result is reported as soon as it completes so successful workers can be
 /// leased while the remainder of the batch is still restoring.
+pub(crate) struct ForkBatchOutcome {
+    pub retained_snapshot: Option<crate::agent::fork::RetainedForkSnapshot>,
+}
+
+pub(crate) struct ForkHeldBatch {
+    pub golden: String,
+    pub clones: Vec<String>,
+    pub share_weights: bool,
+    pub ready_timeout: std::time::Duration,
+    pub retained_snapshot: Option<crate::agent::fork::RetainedForkSnapshot>,
+    pub max_parallel: usize,
+}
+
 pub(crate) async fn fork_held_machines_inner(
     state: Arc<ApiState>,
-    golden: String,
-    clones: Vec<String>,
-    share_weights: bool,
-    ready_timeout: std::time::Duration,
-    max_parallel: usize,
+    batch: ForkHeldBatch,
     result_tx: UnboundedSender<(String, Result<MachineInfo, ApiError>)>,
-) -> Result<(), ApiError> {
+) -> Result<ForkBatchOutcome, ApiError> {
+    let ForkHeldBatch {
+        golden,
+        clones,
+        share_weights,
+        ready_timeout,
+        retained_snapshot,
+        max_parallel,
+    } = batch;
     if clones.is_empty() {
-        return Ok(());
+        return Ok(ForkBatchOutcome { retained_snapshot });
     }
 
     let golden_for_wait = golden.clone();
@@ -1437,16 +1454,23 @@ pub(crate) async fn fork_held_machines_inner(
                     hold: true,
                 })
                 .collect();
-            crate::agent::fork::prepare_forks(&db, &golden_for_prep, &specs)
+            crate::agent::fork::prepare_forks_reusing(
+                &db,
+                &golden_for_prep,
+                &specs,
+                retained_snapshot.as_ref(),
+            )
         })
         .await
         .map_err(|e| ApiError::internal(format!("task error: {e}")))?
         .map_err(classify_fork_error)?
     };
 
-    let snapshot_dir = prepared[0].snapshot_dir.clone();
-    let resume_golden_on_rollback = prepared[0].resume_golden_on_rollback;
-    let boots = prepared.into_iter().zip(clones).map(|(prep, clone)| {
+    let snapshot_dir = prepared.forks[0].snapshot_dir.clone();
+    let resume_golden_on_rollback = prepared.forks[0].resume_golden_on_rollback;
+    let snapshot_reused = prepared.snapshot_reused;
+    let reusable_snapshot = prepared.retained_snapshot;
+    let boots = prepared.forks.into_iter().zip(clones).map(|(prep, clone)| {
         let state = state.clone();
         async move {
             let result = boot_prepared_fork_inner(
@@ -1474,7 +1498,7 @@ pub(crate) async fn fork_held_machines_inner(
     // If every restore failed, no clone depends on this checkpoint and an
     // initially-running golden can safely resume for a later retry. A partial
     // success must retain the paused golden and shared snapshot.
-    if !any_succeeded {
+    if !any_succeeded && !snapshot_reused {
         if let Err(error) = std::fs::remove_dir_all(&snapshot_dir) {
             tracing::warn!(path = %snapshot_dir.display(), %error, "failed to remove unused batch fork snapshot");
         }
@@ -1486,7 +1510,9 @@ pub(crate) async fn fork_held_machines_inner(
     }
 
     drop(guards);
-    Ok(())
+    Ok(ForkBatchOutcome {
+        retained_snapshot: any_succeeded.then_some(reusable_snapshot).flatten(),
+    })
 }
 
 async fn run_bounded_futures<F, T>(

--- a/src/api/pool_controller.rs
+++ b/src/api/pool_controller.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use tokio::sync::watch;
 
-use crate::api::handlers::machines::{delete_one, fork_held_machines_inner};
+use crate::api::handlers::machines::{delete_one, fork_held_machines_inner, ForkHeldBatch};
 use crate::api::state::ApiState;
 use crate::pool::{ForkPoolRecord, ForkPoolSlotState};
 
@@ -18,6 +18,10 @@ const MAX_PREPARED_POOL_WORKERS: usize = 32;
 // four-worker checkpoint barriers.
 const MAX_CONCURRENT_POOL_BOOTS: usize = 4;
 
+type RetainedSnapshotMap = Arc<
+    parking_lot::Mutex<std::collections::HashMap<String, crate::agent::fork::RetainedForkSnapshot>>,
+>;
+
 /// Maintains each pool's clean-worker target and reaps finished leases.
 pub struct ForkPoolController {
     state: Arc<ApiState>,
@@ -26,6 +30,7 @@ pub struct ForkPoolController {
     filling: std::collections::HashSet<String>,
     nvml: Option<crate::api::admission::NvmlSampler>,
     host_cpu: crate::api::admission::HostCpuSampler,
+    retained_snapshots: RetainedSnapshotMap,
 }
 
 impl ForkPoolController {
@@ -45,6 +50,7 @@ impl ForkPoolController {
             filling: std::collections::HashSet::new(),
             nvml,
             host_cpu: crate::api::admission::HostCpuSampler::default(),
+            retained_snapshots: Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new())),
         }
     }
 
@@ -197,6 +203,14 @@ impl ForkPoolController {
             .await
             .map_err(|e| e.to_string())?
             .map_err(|e| e.to_string())?;
+        let active_goldens = pools
+            .iter()
+            .filter(|pool| !pool.deleting)
+            .map(|pool| pool.golden.as_str())
+            .collect::<std::collections::HashSet<_>>();
+        self.retained_snapshots
+            .lock()
+            .retain(|golden, _| active_goldens.contains(golden.as_str()));
         self.update_admission(&pools, sample_admission).await?;
         for pool in pools.into_iter().filter(|pool| !pool.deleting) {
             if self.filling.contains(&pool.name) {
@@ -211,9 +225,10 @@ impl ForkPoolController {
                     .map_err(|e| e.to_string())?;
             if deficit > 0 && self.filling.insert(pool.name.clone()) {
                 let state = self.state.clone();
+                let retained_snapshots = self.retained_snapshots.clone();
                 let pool_name = pool.name.clone();
                 self.fills.spawn(async move {
-                    Self::fill_pool(state, pool).await;
+                    Self::fill_pool(state, pool, retained_snapshots).await;
                     pool_name
                 });
             }
@@ -391,7 +406,11 @@ impl ForkPoolController {
         Ok(())
     }
 
-    async fn fill_pool(state: Arc<ApiState>, pool: ForkPoolRecord) {
+    async fn fill_pool(
+        state: Arc<ApiState>,
+        pool: ForkPoolRecord,
+        retained_snapshots: RetainedSnapshotMap,
+    ) {
         // Bound each pool's work so a large cold fill cannot starve expiry and
         // cleanup for every other pool. Reserve the bounded deficit first so all
         // workers in this tick can share one golden checkpoint.
@@ -434,14 +453,19 @@ impl ForkPoolController {
             return;
         }
 
+        let retained_snapshot = retained_snapshots.lock().get(&pool.golden).cloned();
+        let retained_snapshot_hint = retained_snapshot.clone();
         let (result_tx, mut result_rx) = tokio::sync::mpsc::unbounded_channel();
         let provision = fork_held_machines_inner(
             state.clone(),
-            pool.golden.clone(),
-            machines.clone(),
-            pool.share_weights,
-            Duration::from_secs(pool.ready_timeout_secs),
-            MAX_CONCURRENT_POOL_BOOTS,
+            ForkHeldBatch {
+                golden: pool.golden.clone(),
+                clones: machines.clone(),
+                share_weights: pool.share_weights,
+                ready_timeout: Duration::from_secs(pool.ready_timeout_secs),
+                retained_snapshot,
+                max_parallel: MAX_CONCURRENT_POOL_BOOTS,
+            },
             result_tx,
         );
         let process_results = async {
@@ -454,11 +478,21 @@ impl ForkPoolController {
         };
         let (provision_result, completed) = tokio::join!(provision, process_results);
 
-        if let Err(error) = provision_result {
-            tracing::warn!(pool = %pool.name, error = ?error, workers = machines.len(), "failed to prepare fork pool worker batch");
-            for machine in machines {
-                if !completed.contains(&machine) {
-                    Self::retire_failed_provision(&state, machine, format!("{error:?}")).await;
+        match provision_result {
+            Ok(outcome) => {
+                update_retained_snapshot(
+                    &mut retained_snapshots.lock(),
+                    &pool.golden,
+                    retained_snapshot_hint.as_ref(),
+                    outcome.retained_snapshot,
+                );
+            }
+            Err(error) => {
+                tracing::warn!(pool = %pool.name, error = ?error, workers = machines.len(), "failed to prepare fork pool worker batch");
+                for machine in machines {
+                    if !completed.contains(&machine) {
+                        Self::retire_failed_provision(&state, machine, format!("{error:?}")).await;
+                    }
                 }
             }
         }
@@ -519,5 +553,53 @@ impl ForkPoolController {
             )
         })
         .await;
+    }
+}
+
+fn update_retained_snapshot(
+    snapshots: &mut std::collections::HashMap<String, crate::agent::fork::RetainedForkSnapshot>,
+    golden: &str,
+    prior_hint: Option<&crate::agent::fork::RetainedForkSnapshot>,
+    proven: Option<crate::agent::fork::RetainedForkSnapshot>,
+) {
+    if let Some(snapshot) = proven {
+        snapshots.insert(golden.to_string(), snapshot);
+    } else if snapshots.get(golden) == prior_hint {
+        snapshots.remove(golden);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn snapshot(id: &str, pid: i32) -> crate::agent::fork::RetainedForkSnapshot {
+        crate::agent::fork::RetainedForkSnapshot {
+            path: PathBuf::from(format!("/golden/s/{id}")),
+            golden_pid: pid,
+            golden_pid_start_time: pid as u64 * 10,
+        }
+    }
+
+    #[test]
+    fn successful_batch_records_the_proven_snapshot() {
+        let mut snapshots = std::collections::HashMap::new();
+        let proven = snapshot("12345678", 1);
+        update_retained_snapshot(&mut snapshots, "golden", None, Some(proven.clone()));
+        assert_eq!(snapshots.get("golden"), Some(&proven));
+    }
+
+    #[test]
+    fn failed_reuse_drops_only_the_snapshot_that_was_attempted() {
+        let prior = snapshot("12345678", 1);
+        let newer = snapshot("abcdef01", 2);
+        let mut snapshots = std::collections::HashMap::from([("golden".into(), prior.clone())]);
+        update_retained_snapshot(&mut snapshots, "golden", Some(&prior), None);
+        assert!(!snapshots.contains_key("golden"));
+
+        snapshots.insert("golden".into(), newer.clone());
+        update_retained_snapshot(&mut snapshots, "golden", Some(&prior), None);
+        assert_eq!(snapshots.get("golden"), Some(&newer));
     }
 }


### PR DESCRIPTION
Reuses a process-identity-bound golden checkpoint to reduce replacement readiness latency without changing initial pool fills.