### PR TITLE
Make fork-pool lease activation retry-safe

### DIFF
--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -984,48 +984,131 @@ pub fn activate_held_fork(
     } else {
         "mkdir -p /etc/smolvm".to_string()
     };
-    let script = format!(
-        "set -e; \
-         if [ -f '{release}' ]; then exit 42; fi; \
-         if [ ! -f '{ready}' ]; then exit 43; fi; \
-         {ensure_env_parent}; \
-         umask 077; cat > '{env_path}.tmp'; mv '{env_path}.tmp' '{env_path}'; \
-         printf '%s\\n' smolvm-forkpoint-release-v1 > '{release}.tmp'; \
-         mv '{release}.tmp' '{release}'",
-        ready = smolvm_protocol::forkpoint::READY_PATH,
-        release = smolvm_protocol::forkpoint::RELEASE_PATH,
+    // The token makes this operation safe to repeat after an ambiguous socket
+    // timeout. A release can wake a CUDA-heavy workload before the guest agent's
+    // reply reaches the host; without an idempotency receipt, retrying could vend
+    // the same clean slot twice while failing immediately could discard a slot
+    // that was actually released successfully.
+    let activation_token = format!(
+        "{}{}",
+        crate::util::generate_short_id(),
+        crate::util::generate_short_id()
+    );
+    let receipt = format!("{}/activation", smolvm_protocol::forkpoint::STATE_DIR);
+    let script = build_activation_script(
+        smolvm_protocol::forkpoint::READY_PATH,
+        smolvm_protocol::forkpoint::RELEASE_PATH,
+        &receipt,
+        &ensure_env_parent,
+        &env_path,
+        &activation_token,
     );
     let socket = vm_data_dir(clone).join("agent.sock");
-    let mut client = AgentClient::connect_with_retry(&socket)
-        .map_err(|e| Error::agent("activate held fork", format!("agent connect: {e}")))?;
-    match client.vm_exec(
-        vec!["/bin/sh".into(), "-c".into(), script],
-        vec![],
-        None,
-        Some(Duration::from_secs(10)),
-        Some(content),
-    ) {
-        Ok((0, _, _)) => Ok(merged),
-        Ok((42, _, _)) => Err(Error::agent(
-            "activate held fork",
-            format!("clone '{clone}' was already released"),
-        )),
-        Ok((43, _, _)) => Err(Error::agent(
-            "activate held fork",
-            format!("clone '{clone}' is not parked at a forkpoint"),
-        )),
-        Ok((code, _, stderr)) => Err(Error::agent(
-            "activate held fork",
-            format!(
-                "clone '{clone}' activation exited {code}: {}",
-                String::from_utf8_lossy(&stderr).trim()
-            ),
-        )),
-        Err(e) => Err(Error::agent(
-            "activate held fork",
-            format!("clone '{clone}': {e}"),
-        )),
+    for attempt in 1..=2 {
+        let mut client = match AgentClient::connect_with_retry(&socket) {
+            Ok(client) => client,
+            Err(error) if attempt == 1 => {
+                tracing::warn!(
+                    clone,
+                    %error,
+                    "held-fork activation connect was ambiguous; retrying idempotently"
+                );
+                std::thread::sleep(Duration::from_millis(100));
+                continue;
+            }
+            Err(error) => {
+                return Err(Error::agent(
+                    "activate held fork",
+                    format!("agent connect: {error}"),
+                ));
+            }
+        };
+        match client.vm_exec(
+            vec!["/bin/sh".into(), "-c".into(), script.clone()],
+            vec![],
+            None,
+            Some(Duration::from_secs(10)),
+            Some(content.clone()),
+        ) {
+            Ok((0, _, _)) => return Ok(merged),
+            Ok((42, _, _)) => {
+                return Err(Error::agent(
+                    "activate held fork",
+                    format!("clone '{clone}' was already released"),
+                ));
+            }
+            Ok((43, _, _)) => {
+                return Err(Error::agent(
+                    "activate held fork",
+                    format!("clone '{clone}' is not parked at a forkpoint"),
+                ));
+            }
+            Ok((code, _, stderr)) if attempt == 1 => {
+                tracing::warn!(
+                    clone,
+                    code,
+                    stderr = %String::from_utf8_lossy(&stderr).trim(),
+                    "held-fork activation attempt failed; retrying idempotently"
+                );
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Ok((code, _, stderr)) => {
+                return Err(Error::agent(
+                    "activate held fork",
+                    format!(
+                        "clone '{clone}' activation exited {code}: {}",
+                        String::from_utf8_lossy(&stderr).trim()
+                    ),
+                ));
+            }
+            Err(error) if attempt == 1 => {
+                tracing::warn!(
+                    clone,
+                    %error,
+                    "held-fork activation reply was ambiguous; retrying idempotently"
+                );
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Err(error) => {
+                return Err(Error::agent(
+                    "activate held fork",
+                    format!("clone '{clone}': {error}"),
+                ));
+            }
+        }
     }
+    unreachable!("held-fork activation loop always returns")
+}
+
+fn build_activation_script(
+    ready: &str,
+    release: &str,
+    receipt: &str,
+    ensure_env_parent: &str,
+    env_path: &str,
+    activation_token: &str,
+) -> String {
+    format!(
+        "set -e; \
+         if [ -f '{release}' ]; then \
+           [ \"$(cat '{receipt}' 2>/dev/null)\" = '{activation_token}' ] && exit 0; \
+           exit 42; \
+         fi; \
+         if [ ! -f '{ready}' ]; then exit 43; fi; \
+         receipt_tmp='{receipt}.{activation_token}.'$$; \
+         printf '%s\\n' '{activation_token}' > \"$receipt_tmp\"; \
+         if ! ln \"$receipt_tmp\" '{receipt}' 2>/dev/null; then \
+           rm -f \"$receipt_tmp\"; \
+           [ \"$(cat '{receipt}' 2>/dev/null)\" = '{activation_token}' ] || exit 42; \
+         else rm -f \"$receipt_tmp\"; fi; \
+         {ensure_env_parent}; \
+         env_tmp='{env_path}.{activation_token}.'$$; \
+         release_tmp='{release}.{activation_token}.'$$; \
+         trap 'rm -f \"$env_tmp\" \"$release_tmp\"' EXIT; \
+         cat > \"$env_tmp\"; mv \"$env_tmp\" '{env_path}'; \
+         printf '%s\\n' smolvm-forkpoint-release-v1 > \"$release_tmp\"; \
+         mv \"$release_tmp\" '{release}'"
+    )
 }
 
 /// Fail-closed fork finalizer. A clone whose identity could not be rejuvenated
@@ -1202,6 +1285,119 @@ mod tests {
                 ("DATASET".to_string(), "math".to_string()),
             ]
         );
+    }
+
+    #[cfg(unix)]
+    fn run_activation_script(script: &str, stdin: &str) -> std::process::Output {
+        use std::io::Write;
+        use std::process::{Command, Stdio};
+
+        let mut child = Command::new("/bin/sh")
+            .args(["-c", script])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn activation script");
+        child
+            .stdin
+            .take()
+            .expect("activation stdin")
+            .write_all(stdin.as_bytes())
+            .expect("write activation input");
+        child
+            .wait_with_output()
+            .expect("wait for activation script")
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn held_fork_activation_is_idempotent_after_an_ambiguous_reply() {
+        let temp = tempfile::tempdir().unwrap();
+        let state = temp.path().join("state");
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir_all(&state).unwrap();
+        std::fs::write(state.join("ready"), b"ready\n").unwrap();
+        let ready = state.join("ready");
+        let release = state.join("release");
+        let receipt = state.join("activation");
+        let env_path = workspace.join("fork-env");
+        let ensure_parent = format!("mkdir -p '{}'", workspace.display());
+        let token = "0123456789abcdef";
+        let script = build_activation_script(
+            ready.to_str().unwrap(),
+            release.to_str().unwrap(),
+            receipt.to_str().unwrap(),
+            &ensure_parent,
+            env_path.to_str().unwrap(),
+            token,
+        );
+
+        let first = run_activation_script(&script, "LR=1e-4\n");
+        assert!(
+            first.status.success(),
+            "{}",
+            String::from_utf8_lossy(&first.stderr)
+        );
+        assert_eq!(std::fs::read_to_string(&env_path).unwrap(), "LR=1e-4\n");
+        assert_eq!(
+            std::fs::read_to_string(&receipt).unwrap(),
+            format!("{token}\n")
+        );
+        assert!(release.is_file());
+
+        // A lost reply may cause the host to send the same activation again.
+        // The receipt proves ownership and makes that retry a successful no-op.
+        let retry = run_activation_script(&script, "LR=changed\n");
+        assert!(retry.status.success());
+        assert_eq!(std::fs::read_to_string(&env_path).unwrap(), "LR=1e-4\n");
+
+        let other = build_activation_script(
+            ready.to_str().unwrap(),
+            release.to_str().unwrap(),
+            receipt.to_str().unwrap(),
+            &ensure_parent,
+            env_path.to_str().unwrap(),
+            "fedcba9876543210",
+        );
+        assert_eq!(
+            run_activation_script(&other, "LR=other\n").status.code(),
+            Some(42)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn held_fork_activation_retry_finishes_a_partial_commit() {
+        let temp = tempfile::tempdir().unwrap();
+        let state = temp.path().join("state");
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir_all(&state).unwrap();
+        std::fs::write(state.join("ready"), b"ready\n").unwrap();
+        let ready = state.join("ready");
+        let release = state.join("release");
+        let receipt = state.join("activation");
+        let env_path = workspace.join("fork-env");
+        let ensure_parent = format!("mkdir -p '{}'", workspace.display());
+        let token = "0123456789abcdef";
+        std::fs::write(&receipt, format!("{token}\n")).unwrap();
+        let script = build_activation_script(
+            ready.to_str().unwrap(),
+            release.to_str().unwrap(),
+            receipt.to_str().unwrap(),
+            &ensure_parent,
+            env_path.to_str().unwrap(),
+            token,
+        );
+
+        let retry = run_activation_script(&script, "LR=3e-4\n");
+        assert!(
+            retry.status.success(),
+            "{}",
+            String::from_utf8_lossy(&retry.stderr)
+        );
+        assert_eq!(std::fs::read_to_string(&env_path).unwrap(), "LR=3e-4\n");
+        assert!(release.is_file());
     }
 
     #[test]

--- a/src/api/handlers/pools.rs
+++ b/src/api/handlers/pools.rs
@@ -6,7 +6,7 @@ use axum::{
 };
 use base64::Engine as _;
 use sha2::{Digest, Sha256};
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use crate::api::error::ApiError;
 use crate::api::state::ApiState;
@@ -31,6 +31,7 @@ const MAX_LEASE_PAYLOAD_FILES: usize = 32;
 const MAX_LEASE_PAYLOAD_BYTES: usize = 1024 * 1024;
 const MAX_LEASE_PAYLOAD_PATH_BYTES: usize = 512;
 const DEFAULT_LEASE_PAYLOAD_MODE: u32 = 0o644;
+const LEASE_PAYLOAD_STAGE_ATTEMPTS: usize = 2;
 
 #[derive(Clone)]
 struct StagedLeaseFile {
@@ -129,6 +130,53 @@ fn lease_info(lease: ForkLeaseRecord) -> ForkLeaseInfo {
     }
 }
 
+fn retry_transient_lease_stage(
+    mut operation: impl FnMut() -> crate::Result<()>,
+) -> crate::Result<()> {
+    for attempt in 1..=LEASE_PAYLOAD_STAGE_ATTEMPTS {
+        match operation() {
+            Ok(()) => return Ok(()),
+            Err(error)
+                if attempt < LEASE_PAYLOAD_STAGE_ATTEMPTS
+                    && crate::util::is_transient_network_error(&error.to_string()) =>
+            {
+                tracing::warn!(
+                    attempt,
+                    max_attempts = LEASE_PAYLOAD_STAGE_ATTEMPTS,
+                    %error,
+                    "lease payload staging reply was ambiguous; retrying atomically"
+                );
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    unreachable!("lease payload staging retry loop always returns")
+}
+
+fn stage_lease_payload(machine: &str, files: &[StagedLeaseFile]) -> crate::Result<()> {
+    if files.is_empty() {
+        return Ok(());
+    }
+    let socket = crate::agent::vm_data_dir(machine).join("agent.sock");
+    retry_transient_lease_stage(|| {
+        // Reconnect for every attempt. FileWrite installs with an atomic rename,
+        // so repeating the same validated bytes after a lost acknowledgment is
+        // safe even when the first request committed inside the guest.
+        let mut client = crate::agent::AgentClient::connect_with_retry(&socket)
+            .map_err(|e| crate::Error::agent("stage lease payload", e.to_string()))?;
+        for file in files {
+            let path = format!("/workspace/{}", file.path);
+            client
+                .write_file(&path, &file.data, Some(file.mode))
+                .map_err(|e| {
+                    crate::Error::agent("stage lease payload", format!("write '{path}': {e}"))
+                })?;
+        }
+        Ok(())
+    })
+}
+
 async fn activate_claimed_lease(
     state: Arc<ApiState>,
     lease: ForkLeaseRecord,
@@ -155,19 +203,7 @@ async fn activate_claimed_lease(
     };
     let machine = lease.machine_name.clone();
     let activation = tokio::task::spawn_blocking(move || {
-        if !files.is_empty() {
-            let socket = crate::agent::vm_data_dir(&machine).join("agent.sock");
-            let mut client = crate::agent::AgentClient::connect_with_retry(&socket)
-                .map_err(|e| crate::Error::agent("stage lease payload", e.to_string()))?;
-            for file in files {
-                let path = format!("/workspace/{}", file.path);
-                client
-                    .write_file(&path, &file.data, Some(file.mode))
-                    .map_err(|e| {
-                        crate::Error::agent("stage lease payload", format!("write '{path}': {e}"))
-                    })?;
-            }
-        }
+        stage_lease_payload(&machine, &files)?;
         crate::agent::fork::activate_held_fork(&machine, &record, &assignment)
     })
     .await
@@ -827,6 +863,36 @@ mod tests {
             ApiError::BadRequest(message) => message,
             other => panic!("expected bad request, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn lease_payload_stage_retries_an_ambiguous_agent_reply() {
+        let mut attempts = 0;
+        retry_transient_lease_stage(|| {
+            attempts += 1;
+            if attempts == 1 {
+                Err(crate::Error::agent(
+                    "write file",
+                    "Resource temporarily unavailable (os error 11)",
+                ))
+            } else {
+                Ok(())
+            }
+        })
+        .unwrap();
+        assert_eq!(attempts, 2);
+    }
+
+    #[test]
+    fn lease_payload_stage_does_not_retry_a_guest_rejection() {
+        let mut attempts = 0;
+        let error = retry_transient_lease_stage(|| {
+            attempts += 1;
+            Err(crate::Error::agent("write file", "permission denied"))
+        })
+        .unwrap_err();
+        assert_eq!(attempts, 1);
+        assert!(error.to_string().contains("permission denied"));
     }
 
     #[test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -1275,7 +1275,7 @@ impl SmolvmDb {
                 payload_sha256: payload_sha256.map(str::to_owned),
                 created_at: now,
                 updated_at: now,
-                expires_at: now.saturating_add(ttl_secs),
+                expires_at: now.saturating_add(crate::pool::FORK_LEASE_ACTIVATION_GRACE_SECS),
                 ttl_secs,
                 last_error: None,
             };
@@ -1392,6 +1392,12 @@ impl SmolvmDb {
             }
             lease.state = next;
             lease.updated_at = now;
+            if expected == ForkLeaseState::Activating && next == ForkLeaseState::Active {
+                // The configured TTL is runtime ownership time. Payload staging
+                // and guest release can be delayed by host contention, so start
+                // its countdown only after activation commits.
+                lease.expires_at = now.saturating_add(lease.ttl_secs);
+            }
             lease.last_error = error.clone();
             let updated = serde_json::to_vec(&lease).db_err("serialize fork lease")?;
             tx.execute(
@@ -2707,6 +2713,39 @@ mod tests {
         assert_eq!(expired[0].state, ForkLeaseState::Expired);
         let retiring = db.list_retiring_fork_pool_slots().unwrap();
         assert_eq!(retiring.len(), 2);
+    }
+
+    #[test]
+    fn fork_lease_ttl_starts_after_activation_completes() {
+        let (_dir, db) = temp_db();
+        db.insert_fork_pool_if_not_exists(&test_pool("rollouts", 1))
+            .unwrap();
+        insert_ready_pool_slot(&db, "rollouts", "slot-delayed");
+        let claimed = db
+            .claim_fork_pool_slot(ForkPoolSlotClaim {
+                pool_name: "rollouts",
+                lease_id: "lease-delayed",
+                idempotency_key: "req-delayed",
+                assignment: &[],
+                payload_sha256: None,
+                require_private_workspace: false,
+                admission_limit: None,
+                ttl_secs: 30,
+                now: 200,
+            })
+            .unwrap();
+        let ClaimForkPoolSlot::Claimed(claimed) = claimed else {
+            panic!("expected claimed lease");
+        };
+        assert_eq!(claimed.expires_at, 500);
+
+        let active = db
+            .mark_fork_lease_active("lease-delayed", 231)
+            .unwrap()
+            .unwrap();
+        assert_eq!(active.expires_at, 261);
+        assert!(db.expire_fork_leases(260).unwrap().is_empty());
+        assert_eq!(db.expire_fork_leases(261).unwrap().len(), 1);
     }
 
     #[test]

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -2,6 +2,10 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Maximum time a durably claimed worker may remain in the activation handoff.
+/// The user-facing lease TTL starts only after this phase commits.
+pub(crate) const FORK_LEASE_ACTIVATION_GRACE_SECS: u64 = 5 * 60;
+
 /// Configuration and lifecycle state for one automatic fork pool.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ForkPoolRecord {


### PR DESCRIPTION
Retries atomic payload staging and idempotent release handoffs while starting lease TTLs only after activation completes.