### PR TITLE
Coordinate clone boots across fork pools

### DIFF
--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -1402,7 +1402,9 @@ pub(crate) struct ForkHeldBatch {
     pub share_weights: bool,
     pub ready_timeout: std::time::Duration,
     pub retained_snapshot: Option<crate::agent::fork::RetainedForkSnapshot>,
-    pub max_parallel: usize,
+    pub boot_slots: Arc<tokio::sync::Semaphore>,
+    pub snapshot_ready:
+        Option<tokio::sync::oneshot::Sender<crate::agent::fork::RetainedForkSnapshot>>,
 }
 
 pub(crate) async fn fork_held_machines_inner(
@@ -1416,7 +1418,8 @@ pub(crate) async fn fork_held_machines_inner(
         share_weights,
         ready_timeout,
         retained_snapshot,
-        max_parallel,
+        boot_slots,
+        mut snapshot_ready,
     } = batch;
     if clones.is_empty() {
         return Ok(ForkBatchOutcome { retained_snapshot });
@@ -1475,7 +1478,6 @@ pub(crate) async fn fork_held_machines_inner(
     let snapshot_reused = prepared.snapshot_reused;
     let reusable_snapshot = prepared.retained_snapshot;
     let pending_boots = prepared.forks.len();
-    let boot_slots = Arc::new(tokio::sync::Semaphore::new(max_parallel.max(1)));
     let boots = prepared.forks.into_iter().zip(clones).map(|(prep, clone)| {
         let state = state.clone();
         let boot_slots = boot_slots.clone();
@@ -1510,6 +1512,13 @@ pub(crate) async fn fork_held_machines_inner(
     // width; completed results are still reported as soon as each is usable.
     let any_succeeded = run_bounded_futures(boots, pending_boots, |result| {
         let succeeded = result.1.is_ok();
+        if succeeded {
+            if let (Some(sender), Some(snapshot)) =
+                (snapshot_ready.take(), reusable_snapshot.clone())
+            {
+                let _ = sender.send(snapshot);
+            }
+        }
         if result_tx.send(result).is_err() {
             tracing::warn!("fork pool result receiver closed before provisioning completed");
         }
@@ -2802,6 +2811,60 @@ mod tests {
             result_rx.recv().await.expect("remaining result");
         }
         assert!(runner.await.expect("runner task"));
+    }
+
+    #[tokio::test]
+    async fn shared_boot_slots_bound_independent_batches() {
+        const WIDTH: usize = 2;
+        const PER_BATCH: usize = 4;
+
+        let boot_slots = Arc::new(tokio::sync::Semaphore::new(WIDTH));
+        let release = Arc::new(tokio::sync::Semaphore::new(0));
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let (started_tx, mut started_rx) = tokio::sync::watch::channel(0usize);
+        let build_batch = |offset| {
+            (0..PER_BATCH)
+                .map(|index| {
+                    let boot_slots = boot_slots.clone();
+                    let release = release.clone();
+                    let active = active.clone();
+                    let peak = peak.clone();
+                    let started_tx = started_tx.clone();
+                    async move {
+                        let permit = boot_slots.acquire_owned().await.expect("scheduler open");
+                        let now_active = active.fetch_add(1, Ordering::SeqCst) + 1;
+                        peak.fetch_max(now_active, Ordering::SeqCst);
+                        started_tx.send_modify(|started| *started += 1);
+                        let gate = release.acquire().await.expect("test gate open");
+                        gate.forget();
+                        active.fetch_sub(1, Ordering::SeqCst);
+                        drop(permit);
+                        offset + index
+                    }
+                })
+                .collect::<Vec<_>>()
+        };
+        let first = build_batch(0);
+        let second = build_batch(PER_BATCH);
+        drop(started_tx);
+
+        let first =
+            tokio::spawn(async move { run_bounded_futures(first, PER_BATCH, |_| true).await });
+        let second =
+            tokio::spawn(async move { run_bounded_futures(second, PER_BATCH, |_| true).await });
+
+        while *started_rx.borrow() < WIDTH {
+            started_rx.changed().await.expect("boots still pending");
+        }
+        assert_eq!(active.load(Ordering::SeqCst), WIDTH);
+        assert_eq!(peak.load(Ordering::SeqCst), WIDTH);
+
+        release.add_permits(PER_BATCH * 2);
+        assert!(first.await.expect("first batch task"));
+        assert!(second.await.expect("second batch task"));
+        assert_eq!(peak.load(Ordering::SeqCst), WIDTH);
+        assert_eq!(active.load(Ordering::SeqCst), 0);
     }
 
     #[test]

--- a/src/api/pool_controller.rs
+++ b/src/api/pool_controller.rs
@@ -31,6 +31,7 @@ pub struct ForkPoolController {
     nvml: Option<crate::api::admission::NvmlSampler>,
     host_cpu: crate::api::admission::HostCpuSampler,
     retained_snapshots: RetainedSnapshotMap,
+    boot_slots: Arc<tokio::sync::Semaphore>,
 }
 
 impl ForkPoolController {
@@ -51,6 +52,7 @@ impl ForkPoolController {
             nvml,
             host_cpu: crate::api::admission::HostCpuSampler::default(),
             retained_snapshots: Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new())),
+            boot_slots: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_POOL_BOOTS)),
         }
     }
 
@@ -226,9 +228,10 @@ impl ForkPoolController {
             if deficit > 0 && self.filling.insert(pool.name.clone()) {
                 let state = self.state.clone();
                 let retained_snapshots = self.retained_snapshots.clone();
+                let boot_slots = self.boot_slots.clone();
                 let pool_name = pool.name.clone();
                 self.fills.spawn(async move {
-                    Self::fill_pool(state, pool, retained_snapshots).await;
+                    Self::fill_pool(state, pool, retained_snapshots, boot_slots).await;
                     pool_name
                 });
             }
@@ -412,12 +415,13 @@ impl ForkPoolController {
         state: Arc<ApiState>,
         pool: ForkPoolRecord,
         retained_snapshots: RetainedSnapshotMap,
+        boot_slots: Arc<tokio::sync::Semaphore>,
     ) {
         // A golden can produce only one RAM checkpoint at a time. Keep the
         // lifecycle lock through snapshot publication so another pool sharing
         // this golden reads the proven retained checkpoint instead of issuing
         // a second FORK command after the first caller has paused the VM.
-        let _golden_guard = state.lifecycle_lock(&pool.golden).lock_owned().await;
+        let golden_guard = state.lifecycle_lock(&pool.golden).lock_owned().await;
 
         // Bound each pool's work so a large cold fill cannot starve expiry and
         // cleanup for every other pool. Reserve the bounded deficit first so all
@@ -464,6 +468,7 @@ impl ForkPoolController {
         let retained_snapshot = retained_snapshots.lock().get(&pool.golden).cloned();
         let retained_snapshot_hint = retained_snapshot.clone();
         let (result_tx, mut result_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (snapshot_ready_tx, snapshot_ready_rx) = tokio::sync::oneshot::channel();
         let provision = fork_held_machines_inner(
             state.clone(),
             ForkHeldBatch {
@@ -472,7 +477,8 @@ impl ForkPoolController {
                 share_weights: pool.share_weights,
                 ready_timeout: Duration::from_secs(pool.ready_timeout_secs),
                 retained_snapshot,
-                max_parallel: MAX_CONCURRENT_POOL_BOOTS,
+                boot_slots,
+                snapshot_ready: Some(snapshot_ready_tx),
             },
             result_tx,
         );
@@ -484,16 +490,41 @@ impl ForkPoolController {
             }
             completed
         };
-        let (provision_result, completed) = tokio::join!(provision, process_results);
+        let manage_provision = async {
+            tokio::pin!(provision);
+            let mut golden_guard = Some(golden_guard);
+            let mut published_early = false;
+            let provision_result = tokio::select! {
+                ready = snapshot_ready_rx => {
+                    if let Ok(snapshot) = ready {
+                        update_retained_snapshot(
+                            &mut retained_snapshots.lock(),
+                            &pool.golden,
+                            retained_snapshot_hint.as_ref(),
+                            Some(snapshot),
+                        );
+                        published_early = true;
+                        drop(golden_guard.take());
+                    }
+                    provision.await
+                }
+                result = &mut provision => result,
+            };
+            (provision_result, published_early)
+        };
+        let ((provision_result, published_early), completed) =
+            tokio::join!(manage_provision, process_results);
 
         match provision_result {
             Ok(outcome) => {
-                update_retained_snapshot(
-                    &mut retained_snapshots.lock(),
-                    &pool.golden,
-                    retained_snapshot_hint.as_ref(),
-                    outcome.retained_snapshot,
-                );
+                if !published_early {
+                    update_retained_snapshot(
+                        &mut retained_snapshots.lock(),
+                        &pool.golden,
+                        retained_snapshot_hint.as_ref(),
+                        outcome.retained_snapshot,
+                    );
+                }
             }
             Err(error) => {
                 tracing::warn!(pool = %pool.name, error = ?error, workers = machines.len(), "failed to prepare fork pool worker batch");


### PR DESCRIPTION
Share bounded clone boot capacity and publish proven snapshots early so pools fill concurrently without restore pressure spikes.