### PR TITLE
Bump libkrun for the mount-socket concurrent-hang fix

### DIFF
--- a/lib/libkrun.dylib
+++ b/lib/libkrun.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cf31756c8b2b79ee1f009af7ac91cd024ebfc4115e5b27b451a57ea3f9cbe5f3
-size 6218304
+oid sha256:8dfe651404dd408061d29da59f1dc63eec0d459802acc93415ac526138cc8034
+size 6158144

--- a/lib/libkrun.provenance
+++ b/lib/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=ede6f7986a2cd8a05776bb1b93880bb024c6567c
+libkrun=3ca804246b584d8024f95fd3e8ca48daa3e38800
 libkrunfw=85728e46fd394bfad050efe84e00467fa45e58a7

--- a/lib/linux-aarch64/libkrun.provenance
+++ b/lib/linux-aarch64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=ede6f7986a2cd8a05776bb1b93880bb024c6567c
+libkrun=3ca804246b584d8024f95fd3e8ca48daa3e38800
 libkrunfw=85728e46fd394bfad050efe84e00467fa45e58a7

--- a/lib/linux-aarch64/libkrun.so
+++ b/lib/linux-aarch64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1c203a7521b3eb8c84e988f521bf97fb501359d6ee270434a4f1ac62e601ea7a
-size 6963328
+oid sha256:97485d9a4282c1285af2d6f0500a5eda63019dc49e169b12af8b05c6e5f8d22c
+size 6960552

--- a/lib/linux-aarch64/libkrun.so.2.0.0
+++ b/lib/linux-aarch64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1c203a7521b3eb8c84e988f521bf97fb501359d6ee270434a4f1ac62e601ea7a
-size 6963328
+oid sha256:97485d9a4282c1285af2d6f0500a5eda63019dc49e169b12af8b05c6e5f8d22c
+size 6960552

--- a/lib/linux-x86_64/libkrun.provenance
+++ b/lib/linux-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=ede6f7986a2cd8a05776bb1b93880bb024c6567c
+libkrun=3ca804246b584d8024f95fd3e8ca48daa3e38800
 libkrunfw=85728e46fd394bfad050efe84e00467fa45e58a7

--- a/lib/linux-x86_64/libkrun.so
+++ b/lib/linux-x86_64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9c4e82ab81d7334a9965d7b91f529dade0db72c3db3703bbe2f7e4753f0eb527
-size 8141240
+oid sha256:bfae377ae84bb2f2aba917c478b16077e356e1ec21ab1cf25749094c2a4e5a96
+size 8129104

--- a/lib/linux-x86_64/libkrun.so.2.0.0
+++ b/lib/linux-x86_64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9c4e82ab81d7334a9965d7b91f529dade0db72c3db3703bbe2f7e4753f0eb527
-size 8141240
+oid sha256:bfae377ae84bb2f2aba917c478b16077e356e1ec21ab1cf25749094c2a4e5a96
+size 8129104

--- a/lib/windows-x86_64/krun.dll
+++ b/lib/windows-x86_64/krun.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5d5c1e8a5f073bb7627b18a191a486e36027aaf112f0666dceb3eca84efffcb1
-size 10791902
+oid sha256:1102a1b9e18a8b1b22e4928c4da28356e904da65dfb447a74673254184385b10
+size 10373971

--- a/lib/windows-x86_64/libkrun.provenance
+++ b/lib/windows-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=ede6f7986a2cd8a05776bb1b93880bb024c6567c
+libkrun=3ca804246b584d8024f95fd3e8ca48daa3e38800
 libkrunfw=85728e46fd394bfad050efe84e00467fa45e58a7


### PR DESCRIPTION
Picks up smol-machines/libkrun#52 so concurrent guest connections through `--mount-socket` no longer hang, and rebuilds the bundled libkrun for all four platforms.