### PR TITLE
Boot registry-image machines from a host-side image store so an image is pulled and extracted once instead of inside every VM

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,17 @@ smolvm machine create --name myvm --image ./myapp.tar     # persistent, from a l
 - **`pack start` + `exec`** — daemon mode. `/workspace` persists across exec sessions and stop/start. Container overlay resets per exec (package installs don't persist — use `/workspace` for durable data).
 - **`machine create --from .smolmachine`** — creates a persistent named machine from a packed artifact. Boots from pre-extracted layers (~250ms, no image pull). Full `machine exec` persistence — package installs, file writes all survive across exec and stop/start.
 
+### Image Layer Cache
+
+A machine created from a registry image (`--image alpine`) takes its root filesystem from a host-side cache of extracted layers, so the image is pulled and unpacked once instead of inside every VM. The second machine on the same image starts without contacting the registry at all, and so does every restart of a machine already using it.
+
+The cache is transparent — there is nothing to enable and no flag to pass. Creating the device nodes overlay whiteouts require needs privileges, so it applies when smolvm runs as root on a Unix host (validated on Linux) and never on Windows; anywhere else machines pull in-guest exactly as before. It is only ever a cache: if it cannot serve a machine for any reason, that machine falls back to the in-guest pull rather than failing.
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `SMOLVM_IMAGE_CACHE_MAX_BYTES` | 20 GiB | Size ceiling for the cache. Least-recently-used images are evicted; images a machine still boots from are never evicted. |
+| `SMOLVM_MAX_LAYER_BYTES` | 8 GiB | Rejects any single layer larger than this. |
+
 ## CLI Structure
 
 All commands use named flags (no positional args except `machine create --name NAME` and `machine delete --name NAME`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3045,6 +3045,7 @@ dependencies = [
  "smolfile",
  "smolvm-cuda",
  "smolvm-network",
+ "smolvm-oci-layer",
  "smolvm-pack",
  "smolvm-protocol",
  "smolvm-registry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,10 @@ smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.7.2" }
 smolvm-cuda = { path = "crates/smolvm-cuda", version = "1.7.2" }
 smolvm-pack = { path = "crates/smolvm-pack", version = "1.7.2" }
 smolvm-registry = { path = "crates/smolvm-registry", version = "1.7.2" }
+# Shared OCI layer extraction. The host image store fills content-addressed
+# overlay lowerdirs through the SAME code the guest agent uses, with the
+# host-shared options (see `ExtractOptions::HOST_SHARED`).
+smolvm-oci-layer = { path = "crates/smolvm-oci-layer", version = "1.7.2" }
 smolfile = { path = "crates/smolvm-smolfile", version = "1.7.2" }
 thiserror = "1"
 clap = { version = "4", features = ["derive"] }

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -12,7 +12,7 @@ use crate::crun::CrunCommand;
 use crate::oci::{generate_container_id, OciSpec};
 use crate::paths::{self, STORAGE_ROOT};
 use crate::process::{WaitResult, TIMEOUT_EXIT_CODE};
-use smolvm_oci_layer::{decompress_layer_reader, extract_oci_layer};
+use smolvm_oci_layer::{decompress_layer_reader, extract_oci_layer, ExtractOptions};
 use smolvm_protocol::guest_env;
 use smolvm_protocol::{
     image_repo, normalize_image_ref, ImageInfo, OverlayInfo, RegistryAuth, StorageStatus,
@@ -1785,7 +1785,7 @@ where
             .take()
             .ok_or_else(|| StorageError::new("failed to capture crane stdout".to_string()))?;
 
-        let extract_result = extract_oci_layer(crane_stdout, &layer_dir);
+        let extract_result = extract_oci_layer(crane_stdout, &layer_dir, ExtractOptions::GUEST);
 
         let crane_status = crane
             .wait()
@@ -4036,7 +4036,8 @@ mod tests {
 
         let extract = |bytes: &[u8]| -> Vec<u8> {
             let dir = tempfile::tempdir().unwrap();
-            extract_oci_layer(bytes, dir.path()).expect("extraction should succeed");
+            extract_oci_layer(bytes, dir.path(), ExtractOptions::GUEST)
+                .expect("extraction should succeed");
             std::fs::read(dir.path().join("greeting.txt")).unwrap()
         };
 
@@ -4087,8 +4088,9 @@ mod tests {
 
         for sentinel in ["storage.ext4", "agent-rootfs.tar", "./storage.ext4"] {
             let dir = tempfile::tempdir().unwrap();
-            let err = extract_oci_layer(&build_tar(sentinel)[..], dir.path())
-                .expect_err("pack sentinel must abort extraction");
+            let err =
+                extract_oci_layer(&build_tar(sentinel)[..], dir.path(), ExtractOptions::GUEST)
+                    .expect_err("pack sentinel must abort extraction");
             assert!(
                 err.to_string().contains("smolmachine pack"),
                 "clear error for {sentinel}, got: {err}"
@@ -4101,8 +4103,12 @@ mod tests {
 
         // A NESTED file of the same name is legitimate image content.
         let dir = tempfile::tempdir().unwrap();
-        extract_oci_layer(&build_tar("var/lib/foo/storage.ext4")[..], dir.path())
-            .expect("nested same-named file extracts normally");
+        extract_oci_layer(
+            &build_tar("var/lib/foo/storage.ext4")[..],
+            dir.path(),
+            ExtractOptions::GUEST,
+        )
+        .expect("nested same-named file extracts normally");
         assert!(dir.path().join("var/lib/foo/storage.ext4").exists());
     }
 
@@ -4155,7 +4161,8 @@ mod tests {
             builder.finish().unwrap();
         }
 
-        extract_oci_layer(&buf[..], dest).expect("extraction should succeed");
+        extract_oci_layer(&buf[..], dest, ExtractOptions::GUEST)
+            .expect("extraction should succeed");
 
         // The real file extracted.
         assert_eq!(

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -335,6 +335,35 @@ pub fn init_packed_layers() -> Option<PathBuf> {
     }
 }
 
+/// Filename a layer producer drops beside `layer-order` to declare which xattr
+/// namespace its opaque-directory markers use.
+///
+/// Absent means `trusted.overlay.*` — the long-standing representation every
+/// existing `.smolmachine` uses — so older artifacts keep working untouched.
+const OPAQUE_XATTR_MARKER: &str = "opaque-xattr";
+
+/// Whether the mounted packed layers use `user.overlay.*` opaque markers, which
+/// the overlay must then be mounted with `userxattr` to honor.
+///
+/// Layers extracted on the HOST are served to us over virtiofs by a VMM that has
+/// dropped privileges, and an unprivileged reader cannot see a `trusted.*` xattr
+/// at all — so those layers use `user.*`. Getting this pairing wrong fails
+/// SILENTLY: the kernel ignores markers from the other namespace and stale lower
+/// content shows through with no error, which is why the producer declares it
+/// rather than the consumer guessing.
+pub fn packed_layers_use_userxattr() -> bool {
+    static USERXATTR: OnceLock<bool> = OnceLock::new();
+    *USERXATTR.get_or_init(|| {
+        get_packed_layers_dir()
+            .map(|d| {
+                std::fs::read_to_string(d.join(OPAQUE_XATTR_MARKER))
+                    .map(|v| v.trim() == "user")
+                    .unwrap_or(false)
+            })
+            .unwrap_or(false)
+    })
+}
+
 /// Get the packed layers directory if available.
 pub fn get_packed_layers_dir() -> Option<&'static PathBuf> {
     PACKED_LAYERS_DIR.get_or_init(init_packed_layers).as_ref()
@@ -3393,6 +3422,13 @@ fn mount_overlay_fsconfig(
     // Preserve prior semantics: index=off disables the inode-index feature.
     fsconfig_set_string(fs.as_fd(), "index", "off")
         .map_err(|e| StorageError::new(format!("fsconfig index=off failed: {e}")))?;
+    // Host-extracted layers mark opaque dirs in the `user.*` namespace, because
+    // the unprivileged virtiofs server that serves them cannot see `trusted.*`.
+    // The kernel only consults that namespace when mounted with `userxattr`.
+    if packed_layers_use_userxattr() {
+        rustix::mount::fsconfig_set_flag(fs.as_fd(), "userxattr")
+            .map_err(|e| StorageError::new(format!("fsconfig userxattr failed: {e}")))?;
+    }
 
     fsconfig_create(fs.as_fd())
         .map_err(|e| StorageError::new(format!("fsconfig create (overlay) failed: {e}")))?;

--- a/crates/smolvm-oci-layer/src/lib.rs
+++ b/crates/smolvm-oci-layer/src/lib.rs
@@ -424,13 +424,13 @@ mod tests {
         // Guest: privileged local reader, so trusted.* — and it must keep image
         // ownership, since it is root and images ship non-root-owned paths.
         assert_eq!(ExtractOptions::GUEST.opaque_xattr, OpaqueXattr::Trusted);
-        assert!(ExtractOptions::GUEST.preserve_ownership);
+        const { assert!(ExtractOptions::GUEST.preserve_ownership) };
         assert_eq!(OpaqueXattr::Trusted.name(), "trusted.overlay.opaque");
 
         // Host-shared: read by an UNPRIVILEGED virtiofs server through an
         // idmapped mount, so user.* and no ownership preservation.
         assert_eq!(ExtractOptions::HOST_SHARED.opaque_xattr, OpaqueXattr::User);
-        assert!(!ExtractOptions::HOST_SHARED.preserve_ownership);
+        const { assert!(!ExtractOptions::HOST_SHARED.preserve_ownership) };
         assert_eq!(OpaqueXattr::User.name(), "user.overlay.opaque");
     }
 

--- a/crates/smolvm-oci-layer/src/lib.rs
+++ b/crates/smolvm-oci-layer/src/lib.rs
@@ -130,15 +130,87 @@ pub fn create_overlay_whiteout(_path: &Path) -> std::io::Result<()> {
     ))
 }
 
-/// Mark `dir` opaque for overlayfs via the `trusted.overlay.opaque` xattr — the
-/// representation of OCI's `.wh..wh..opq` marker. Linux-only (see
-/// [`create_overlay_whiteout`]).
+/// Which xattr namespace opaque-directory markers are written in.
+///
+/// This is NOT a stylistic choice — it must match how the overlay that reads
+/// these layers is mounted, and a mismatch fails **silently**: the kernel simply
+/// ignores markers from the other namespace and stale lower-layer content shows
+/// through with no error. Measured both ways.
+///
+/// The deciding question is *who reads the marker*:
+///
+/// * [`OpaqueXattr::Trusted`] — the reader is root on a local filesystem (the
+///   guest agent extracting its own pulled layers). `trusted.*` requires
+///   `CAP_SYS_ADMIN` to read, which it has. This is the long-standing behavior
+///   and every existing `.smolmachine` relies on it.
+/// * [`OpaqueXattr::User`] — the reader is **unprivileged**. Host-produced layers
+///   are served to the guest over virtiofs by a VMM that has dropped to a per-VM
+///   uid, and an unprivileged process cannot even see a `trusted.*` xattr. Such
+///   layers must use `user.*`, and the overlay that consumes them must be mounted
+///   with the `userxattr` option.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpaqueXattr {
+    /// `trusted.overlay.opaque` — for layers read by a privileged local reader.
+    Trusted,
+    /// `user.overlay.opaque` — for layers read by an unprivileged reader, whose
+    /// overlay must be mounted with `userxattr`.
+    User,
+}
+
+impl OpaqueXattr {
+    /// The xattr name this flavor writes. Consumed only by the Linux
+    /// `setxattr` path; the non-Linux build keeps the enum for API parity.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    fn name(self) -> &'static str {
+        match self {
+            OpaqueXattr::Trusted => "trusted.overlay.opaque",
+            OpaqueXattr::User => "user.overlay.opaque",
+        }
+    }
+}
+
+/// How a layer should be written to disk.
+#[derive(Debug, Clone, Copy)]
+pub struct ExtractOptions {
+    /// Namespace for opaque-directory markers. See [`OpaqueXattr`].
+    pub opaque_xattr: OpaqueXattr,
+    /// Whether to restore each entry's uid/gid from the archive.
+    ///
+    /// `true` for the guest, which is root on a local filesystem and must honor
+    /// images that ship non-root-owned paths (a `node`/`postgres` user's home).
+    ///
+    /// `false` for host-side extraction, matching the pack store: the layers are
+    /// presented to the guest through an **idmapped** mount that shifts a single
+    /// uid, so preserving arbitrary owners would defeat the mapping. Leaving
+    /// ownership alone also means extraction needs no `CAP_CHOWN`.
+    pub preserve_ownership: bool,
+}
+
+impl ExtractOptions {
+    /// Layers extracted by the guest for its own use: privileged local reader,
+    /// image ownership preserved. The long-standing behavior.
+    pub const GUEST: Self = Self {
+        opaque_xattr: OpaqueXattr::Trusted,
+        preserve_ownership: true,
+    };
+
+    /// Layers extracted on the host and served to a guest over virtiofs by an
+    /// unprivileged VMM, through an idmapped mount.
+    pub const HOST_SHARED: Self = Self {
+        opaque_xattr: OpaqueXattr::User,
+        preserve_ownership: false,
+    };
+}
+
+/// Mark `dir` opaque for overlayfs — the representation of OCI's `.wh..wh..opq`
+/// marker. Linux-only (see [`create_overlay_whiteout`]). See [`OpaqueXattr`] for
+/// why the namespace matters.
 #[cfg(target_os = "linux")]
-pub fn set_overlay_opaque(dir: &Path) -> std::io::Result<()> {
+pub fn set_overlay_opaque(dir: &Path, flavor: OpaqueXattr) -> std::io::Result<()> {
     use std::os::unix::ffi::OsStrExt;
     let c_path = std::ffi::CString::new(dir.as_os_str().as_bytes())
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;
-    let name = std::ffi::CString::new("trusted.overlay.opaque").expect("static xattr name");
+    let name = std::ffi::CString::new(flavor.name()).expect("static xattr name");
     let value = b"y";
     // SAFETY: path/name are NUL-terminated; value/len describe a valid buffer.
     let rc = unsafe {
@@ -157,7 +229,7 @@ pub fn set_overlay_opaque(dir: &Path) -> std::io::Result<()> {
 }
 
 #[cfg(not(target_os = "linux"))]
-pub fn set_overlay_opaque(_dir: &Path) -> std::io::Result<()> {
+pub fn set_overlay_opaque(_dir: &Path, _flavor: OpaqueXattr) -> std::io::Result<()> {
     Err(std::io::Error::new(
         std::io::ErrorKind::Unsupported,
         "overlayfs opaque dirs are only set on Linux",
@@ -232,7 +304,11 @@ fn pack_sidecar_sentinel(path: &Path) -> Option<&'static str> {
 /// `reader` yields the raw layer blob (gzip/zstd/plain — decompressed here). The
 /// whiteout translation only takes effect on Linux; on other hosts the markers
 /// would surface as `Unsupported` errors, so this is called on the Linux node.
-pub fn extract_oci_layer<R: Read>(reader: R, dest: &Path) -> std::io::Result<()> {
+pub fn extract_oci_layer<R: Read>(
+    reader: R,
+    dest: &Path,
+    opts: ExtractOptions,
+) -> std::io::Result<()> {
     // Layers arrive gzip- or zstd-compressed (or, rarely, plain). Decompress
     // transparently so a zstd layer no longer breaks extraction.
     let reader = decompress_layer_reader(reader)?;
@@ -242,7 +318,7 @@ pub fn extract_oci_layer<R: Read>(reader: R, dest: &Path) -> std::io::Result<()>
     // Preserve the archive's uid/gid. The caller runs as root (CAP_CHOWN) so this
     // chowns each entry to the image's intended owner; without it every file is
     // owned by root, breaking images that ship non-root-owned paths.
-    archive.set_preserve_ownerships(true);
+    archive.set_preserve_ownerships(opts.preserve_ownership);
     archive.set_overwrite(true);
 
     for entry in archive.entries()? {
@@ -276,7 +352,7 @@ pub fn extract_oci_layer<R: Read>(reader: R, dest: &Path) -> std::io::Result<()>
                 LayerEntry::OpaqueDir => {
                     if let Some(parent) = full_path.parent() {
                         std::fs::create_dir_all(parent)?;
-                        set_overlay_opaque(parent)?;
+                        set_overlay_opaque(parent, opts.opaque_xattr)?;
                     }
                     continue;
                 }
@@ -337,6 +413,26 @@ pub fn extract_oci_layer<R: Read>(reader: R, dest: &Path) -> std::io::Result<()>
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The two presets encode a pairing that must hold, because getting it wrong
+    /// fails SILENTLY (the kernel ignores markers from the other namespace and
+    /// shows stale lower content, with no error). Measured on Linux 6.x:
+    /// `user.overlay.opaque` is honored only under a `userxattr` mount, and an
+    /// unprivileged reader cannot see `trusted.*` at all.
+    #[test]
+    fn presets_pair_xattr_flavor_with_the_reader() {
+        // Guest: privileged local reader, so trusted.* — and it must keep image
+        // ownership, since it is root and images ship non-root-owned paths.
+        assert_eq!(ExtractOptions::GUEST.opaque_xattr, OpaqueXattr::Trusted);
+        assert!(ExtractOptions::GUEST.preserve_ownership);
+        assert_eq!(OpaqueXattr::Trusted.name(), "trusted.overlay.opaque");
+
+        // Host-shared: read by an UNPRIVILEGED virtiofs server through an
+        // idmapped mount, so user.* and no ownership preservation.
+        assert_eq!(ExtractOptions::HOST_SHARED.opaque_xattr, OpaqueXattr::User);
+        assert!(!ExtractOptions::HOST_SHARED.preserve_ownership);
+        assert_eq!(OpaqueXattr::User.name(), "user.overlay.opaque");
+    }
 
     #[test]
     fn classify_recognizes_markers_and_normals() {

--- a/crates/smolvm-oci-layer/src/lib.rs
+++ b/crates/smolvm-oci-layer/src/lib.rs
@@ -609,12 +609,14 @@ mod tests {
         dir.set_entry_type(tar::EntryType::Directory);
         dir.set_mode(0o700);
         dir.set_size(0);
-        tar.append_data(&mut dir, "private/", std::io::empty()).unwrap();
+        tar.append_data(&mut dir, "private/", std::io::empty())
+            .unwrap();
         let mut file = tar::Header::new_gnu();
         file.set_entry_type(tar::EntryType::Regular);
         file.set_mode(0o600);
         file.set_size(3);
-        tar.append_data(&mut file, "private/secret", &b"hi\n"[..]).unwrap();
+        tar.append_data(&mut file, "private/secret", &b"hi\n"[..])
+            .unwrap();
         let archive = tar.into_inner().unwrap();
 
         extract_oci_layer(
@@ -624,8 +626,15 @@ mod tests {
         )
         .unwrap();
 
-        let got = std::fs::metadata(dest.join("private")).unwrap().permissions().mode() & 0o777;
+        let got = std::fs::metadata(dest.join("private"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
         assert_eq!(got, 0o700, "directory mode widened to {got:o}");
-        assert!(dest.join("private/secret").is_file(), "contents still extracted");
+        assert!(
+            dest.join("private/secret").is_file(),
+            "contents still extracted"
+        );
     }
 }

--- a/crates/smolvm-oci-layer/src/lib.rs
+++ b/crates/smolvm-oci-layer/src/lib.rs
@@ -321,6 +321,14 @@ pub fn extract_oci_layer<R: Read>(
     archive.set_preserve_ownerships(opts.preserve_ownership);
     archive.set_overwrite(true);
 
+    // Directory modes are restored AFTER all entries are written. The loop below
+    // force-opens each parent to 0755 so restrictive directories cannot block the
+    // extraction of their own contents; without this deferred pass those widened
+    // modes would be what the image ships with, silently turning a 0700 directory
+    // (a private PGDATA, an .ssh, a secrets dir) world-readable.
+    #[cfg(unix)]
+    let mut deferred_dir_modes: Vec<(std::path::PathBuf, u32)> = Vec::new();
+
     for entry in archive.entries()? {
         let mut entry = entry?;
         let path = entry.path()?.into_owned();
@@ -388,6 +396,13 @@ pub fn extract_oci_layer<R: Read>(
             }
         }
 
+        #[cfg(unix)]
+        if entry.header().entry_type() == tar::EntryType::Directory {
+            if let Ok(mode) = entry.header().mode() {
+                deferred_dir_modes.push((full_path.clone(), mode));
+            }
+        }
+
         if let Err(e) = entry.unpack_in(dest) {
             // Regular files and directories failing is a real error; non-regular
             // entries (symlinks, device nodes, fifos) can fail benignly — skip.
@@ -404,6 +419,19 @@ pub fn extract_oci_layer<R: Read>(
                 _ => {
                     warn!(path = %path.display(), error = %e, "skipping non-regular layer entry");
                 }
+            }
+        }
+    }
+
+    // Deepest first: a parent re-tightened before its children were written would
+    // block them, so this runs only once every entry is on disk.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        deferred_dir_modes.sort_by_key(|(path, _)| std::cmp::Reverse(path.components().count()));
+        for (path, mode) in deferred_dir_modes {
+            if path.is_dir() {
+                let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(mode));
             }
         }
     }
@@ -562,5 +590,42 @@ mod tests {
                 .collect();
             assert_eq!(names, vec!["hello".to_string()], "{label} entry list");
         }
+    }
+
+    /// A layer that ships a 0700 directory containing a file must keep 0700 after
+    /// extraction. The extractor force-opens parents to 0755 so restrictive
+    /// directories cannot block their own contents; without the deferred restore
+    /// that widening is what survives, silently exposing private directories.
+    #[cfg(unix)]
+    #[test]
+    fn restrictive_directory_modes_survive_extraction() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("out");
+        std::fs::create_dir_all(&dest).unwrap();
+
+        let mut tar = tar::Builder::new(Vec::new());
+        let mut dir = tar::Header::new_gnu();
+        dir.set_entry_type(tar::EntryType::Directory);
+        dir.set_mode(0o700);
+        dir.set_size(0);
+        tar.append_data(&mut dir, "private/", std::io::empty()).unwrap();
+        let mut file = tar::Header::new_gnu();
+        file.set_entry_type(tar::EntryType::Regular);
+        file.set_mode(0o600);
+        file.set_size(3);
+        tar.append_data(&mut file, "private/secret", &b"hi\n"[..]).unwrap();
+        let archive = tar.into_inner().unwrap();
+
+        extract_oci_layer(
+            std::io::Cursor::new(archive),
+            &dest,
+            ExtractOptions::HOST_SHARED,
+        )
+        .unwrap();
+
+        let got = std::fs::metadata(dest.join("private")).unwrap().permissions().mode() & 0o777;
+        assert_eq!(got, 0o700, "directory mode widened to {got:o}");
+        assert!(dest.join("private/secret").is_file(), "contents still extracted");
     }
 }

--- a/scripts/rebuild-agent.sh
+++ b/scripts/rebuild-agent.sh
@@ -10,7 +10,15 @@ set -ex
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
-ROOTFS_DIR="$HOME/Library/Application Support/smolvm/agent-rootfs"
+# The agent rootfs lives under the platform's data dir — macOS keeps it in
+# "Application Support", Linux under XDG's ~/.local/share. Hardcoding the macOS
+# path made this script unrunnable on Linux, where the guest agent actually ships
+# from.
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  ROOTFS_DIR="$HOME/Library/Application Support/smolvm/agent-rootfs"
+else
+  ROOTFS_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/smolvm/agent-rootfs"
+fi
 
 cd "$PROJECT_DIR"
 

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -392,6 +392,29 @@ pub async fn create_machine(
     // affect the socket path — only character sanity + a generous length
     // cap are needed.
     let name = req.name.clone().unwrap_or_else(generate_machine_name);
+
+    // Fill the host image store for a registry-image machine, here rather than at
+    // start, because this is the request that carries the caller's registry
+    // credential — the store re-authorizes every fill, and a start has no
+    // credential of its own. Once filled, the machine's back-reference lets every
+    // later start re-present the same layers with no registry round-trip.
+    //
+    // The node's own configured credentials are deliberately NOT a fallback: on a
+    // shared node they would let one caller's fill be authorized with rights it
+    // never presented. Without a token the gate runs anonymously, which reaches
+    // exactly the public images an unauthenticated in-guest pull could reach.
+    if let Some(image) = req.image.clone() {
+        let auth = match req.registry_identity_token.as_deref() {
+            Some(token) => crate::registry::PullAuth::Identity(token.to_string()),
+            None => crate::registry::PullAuth::Anonymous,
+        };
+        let machine = name.clone();
+        // Blocking pull + extract; keep it off the async worker threads.
+        let _ = tokio::task::spawn_blocking(move || {
+            crate::image_store::prepare_layers(&machine, Some(&image), Some(&auth))
+        })
+        .await;
+    }
     validate_vm_name(&name, "machine name").map_err(ApiError::BadRequest)?;
 
     // Validate mount paths
@@ -1070,6 +1093,9 @@ pub async fn start_machine(
             Some(&name_clone),
             source_smolmachine.as_deref(),
             dns_filter_hosts,
+            // The fill happened at create, where the caller's registry credential
+            // was in hand; a start only re-presents that entry.
+            None,
         )
         .map_err(|e| format!("failed to prepare packed layers: {}", e))?;
         // A fork clone shares its golden's uid. On a cold (re)start there is no
@@ -1595,6 +1621,9 @@ async fn boot_prepared_fork_inner(
             Some(&clone_b),
             record.source_smolmachine.as_deref(),
             record.dns_filter_hosts.clone(),
+            // A clone boots from its golden's snapshot; any store entry it needs
+            // is re-presented from its own back-reference.
+            None,
         )
         .map_err(|e| format!("failed to prepare packed layers: {}", e))?;
         // Boot from the golden's snapshot instead of cold-booting.

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -408,6 +408,11 @@ pub async fn create_machine(
             Some(token) => crate::registry::PullAuth::Identity(token.to_string()),
             None => crate::registry::PullAuth::Anonymous,
         };
+        // Reconcile claims against the machines that actually exist, so a
+        // discarded database cannot pin entries against the LRU forever.
+        if let Ok(vms) = state.db().list_vms() {
+            crate::image_store::sweep_refs(vms.iter().map(|(n, _)| n.as_str()));
+        }
         let machine = name.clone();
         // Blocking pull + extract; keep it off the async worker threads.
         let _ = tokio::task::spawn_blocking(move || {
@@ -2218,6 +2223,10 @@ pub(crate) async fn delete_one(
     let state_rm = state.clone();
     let name_rm = name.clone();
     tokio::task::spawn_blocking(move || -> Result<(), ApiError> {
+        // Release this machine's claim on its shared store entry, so the LRU may
+        // reclaim it once nothing boots from it. The entry itself is shared and
+        // stays. Mirrors the CLI delete path.
+        crate::image_store::forget_entry(&name_rm);
         match state_rm.remove_machine(&name_rm) {
             Ok(_) => Ok(()),
             Err(ApiError::NotFound(_)) => {

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -1138,6 +1138,22 @@ where
 // Shared Machine Helpers
 // ============================================================================
 
+/// A registry image an API-started machine may take its layers from.
+pub struct StoreImage<'a> {
+    /// The image reference the machine was created with, when the caller has it.
+    /// Absent on start paths that only re-present an already-filled entry.
+    pub reference: Option<&'a str>,
+    /// The credential the store must re-authorize this caller with.
+    ///
+    /// `None` declines a fill. The node's own configured credentials are
+    /// deliberately NOT a fallback: on a shared node they would authorize one
+    /// tenant's cache hit with another tenant's rights, which is exactly what
+    /// the per-caller gate exists to prevent. Declining costs a pull, not
+    /// correctness — and an entry this machine already booted from is still
+    /// re-presented, having passed the gate when it was filled.
+    pub auth: Option<crate::registry::PullAuth>,
+}
+
 /// Build `LaunchFeatures` for an API-driven machine start.
 ///
 /// Thin wrapper over [`crate::agent::LaunchFeatures::with_packed_layers`]
@@ -1155,6 +1171,7 @@ pub fn build_launch_features(
     machine_name: Option<&str>,
     source_smolmachine: Option<&str>,
     dns_filter_hosts: Option<Vec<String>>,
+    image: Option<StoreImage<'_>>,
 ) -> crate::Result<crate::agent::LaunchFeatures> {
     let features = crate::agent::LaunchFeatures::default();
     let mut features = match machine_name {
@@ -1164,6 +1181,25 @@ pub fn build_launch_features(
         )?,
         None => features,
     };
+    // Registry-image machines: present the host image store's shared lowerdirs,
+    // through the same `prepare_layers` the CLI uses. A `.smolmachine` machine
+    // already has its layers above and never reaches this.
+    // Attempted on every start path, including those holding no image reference:
+    // re-presenting an already-filled entry is keyed by the machine alone, and
+    // skipping it would leave a store-backed machine with no rootfs.
+    if features.packed_layers_dir.is_none() {
+        if let Some(name) = machine_name {
+            let image = image.as_ref();
+            if let Some(layers) = crate::image_store::prepare_layers(
+                name,
+                image.and_then(|i| i.reference),
+                image.and_then(|i| i.auth.as_ref()),
+            ) {
+                features.pack_idmap_source = Some(layers.idmap_source);
+                features.packed_layers_dir = Some(layers.mountpoint);
+            }
+        }
+    }
     // Carry the egress hostname allow-list into the boot config; `internal_boot`
     // starts the DNS filter for these names and learns their answers into the
     // egress allow-list (parity with the CLI `--allow-host` path).
@@ -1221,6 +1257,9 @@ pub async fn ensure_machine_running(
                 entry.manager.name(),
                 entry.source_smolmachine.as_deref(),
                 entry.resources.allowed_hosts.clone(),
+                // An autostart re-presents an already-filled entry; the in-memory
+                // entry carries no image reference or tenant credential.
+                None,
             )?
         };
         features.cuda_fork_pool_size = entry.cuda_fork_pool_size;
@@ -1637,11 +1676,11 @@ mod tests {
         // The serve-API launch path must forward the egress hostname allow-list
         // into the boot config, so `internal_boot` starts the DNS filter for it.
         let hosts = vec!["api.anthropic.com".to_string(), "pypi.org".to_string()];
-        let features = build_launch_features(None, None, Some(hosts.clone())).unwrap();
+        let features = build_launch_features(None, None, Some(hosts.clone()), None).unwrap();
         assert_eq!(features.dns_filter_hosts, Some(hosts));
 
         // No hostname policy stays None (unrestricted egress, unchanged behavior).
-        let features = build_launch_features(None, None, None).unwrap();
+        let features = build_launch_features(None, None, None, None).unwrap();
         assert_eq!(features.dns_filter_hosts, None);
     }
 

--- a/src/api/supervisor.rs
+++ b/src/api/supervisor.rs
@@ -301,6 +301,9 @@ impl Supervisor {
                 Some(&name_for_features),
                 source_smolmachine.as_deref(),
                 dns_filter_hosts,
+                // A supervisor restart re-presents an already-filled entry; it
+                // holds no credential to gate a fresh fill with.
+                None,
             )?;
             features.cuda_fork_pool_size = cuda_fork_pool_size;
             features.cuda_vram_limit_mib = cuda_vram_limit_mib;

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -1306,17 +1306,31 @@ fn start_vm_named_with_db(
     // overlay lowerdirs, so this and every other machine on that image skips both
     // the in-guest pull and the per-VM flatten.
     //
-    // Only on a machine's FIRST boot: once `init_completed` is set the layers are
-    // already established, and re-resolving would make every later start depend on
-    // the registry being reachable. `ensure_image_blocking` returns `None` on any
-    // failure — it is a cache, so a miss falls through to the in-guest pull rather
-    // than failing the machine.
-    if features.packed_layers_dir.is_none() && !record.init_completed {
+    // On EVERY boot, not just the first: packed layers are a per-boot mount, not
+    // persistent machine state (the local-archive path above re-derives its dir
+    // the same way). A machine whose layers came from the store has no in-guest
+    // image to fall back on, so presenting them only once would leave every later
+    // start with no rootfs at all.
+    //
+    // Prefer the entry this machine already booted from — it is on disk, so a warm
+    // restart needs no registry round-trip and survives an outage. Re-resolve only
+    // when that entry is gone (first boot, or evicted). `ensure_image_blocking`
+    // returns `None` on any failure: it is a cache, so a miss falls through to the
+    // in-guest pull rather than failing the machine.
+    if features.packed_layers_dir.is_none() {
         if let Some(image) = record.image.as_deref() {
-            if let Some(dir) = smolvm::image_store::ensure_image_blocking(
-                image,
-                &smolvm::registry::PullAuth::FromConfig,
-            ) {
+            // Reconcile claims against the machines that actually exist, so a
+            // discarded database cannot pin entries against the LRU forever.
+            if let Ok(vms) = db.list_vms() {
+                smolvm::image_store::sweep_refs(vms.iter().map(|(n, _)| n.as_str()));
+            }
+            let entry = smolvm::image_store::remembered_entry(name).or_else(|| {
+                smolvm::image_store::ensure_image_blocking(
+                    image,
+                    &smolvm::registry::PullAuth::FromConfig,
+                )
+            });
+            if let Some(dir) = entry {
                 // Present it exactly as the pack store does: `packed_layers_dir`
                 // is an EMPTY per-machine mountpoint and `pack_idmap_source` is
                 // the shared content. While the uid drop is active `internal_boot`
@@ -1328,6 +1342,7 @@ fn start_vm_named_with_db(
                 if let Err(e) = std::fs::create_dir_all(&mountpoint) {
                     tracing::warn!(error = %e, "image store skipped: no layers mountpoint");
                 } else {
+                    smolvm::image_store::remember_entry(name, &dir);
                     features.pack_idmap_source = Some(dir);
                     features.packed_layers_dir = Some(mountpoint);
                 }
@@ -2094,6 +2109,10 @@ pub fn delete_vm(name: &str, force: bool, options: DeleteVmOptions) -> smolvm::R
             name,
         ));
     }
+
+    // Release this machine's claim on its shared store entry, so the LRU may
+    // reclaim it once nothing boots from it. The entry itself is shared and stays.
+    smolvm::image_store::forget_entry(name);
 
     let data_dir = vm_data_dir(name);
     if data_dir.exists() {

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -1304,19 +1304,9 @@ fn start_vm_named_with_db(
     }
     // Host-side image store: pull + extract a registry image ONCE into shared
     // overlay lowerdirs, so this and every other machine on that image skips both
-    // the in-guest pull and the per-VM flatten.
-    //
-    // On EVERY boot, not just the first: packed layers are a per-boot mount, not
-    // persistent machine state (the local-archive path above re-derives its dir
-    // the same way). A machine whose layers came from the store has no in-guest
-    // image to fall back on, so presenting them only once would leave every later
-    // start with no rootfs at all.
-    //
-    // Prefer the entry this machine already booted from — it is on disk, so a warm
-    // restart needs no registry round-trip and survives an outage. Re-resolve only
-    // when that entry is gone (first boot, or evicted). `ensure_image_blocking`
-    // returns `None` on any failure: it is a cache, so a miss falls through to the
-    // in-guest pull rather than failing the machine.
+    // the in-guest pull and the per-VM flatten. `prepare_layers` is the same
+    // implementation the API start path uses; a local caller gates with the
+    // host's own configured credentials.
     if features.packed_layers_dir.is_none() {
         if let Some(image) = record.image.as_deref() {
             // Reconcile claims against the machines that actually exist, so a
@@ -1324,28 +1314,13 @@ fn start_vm_named_with_db(
             if let Ok(vms) = db.list_vms() {
                 smolvm::image_store::sweep_refs(vms.iter().map(|(n, _)| n.as_str()));
             }
-            let entry = smolvm::image_store::remembered_entry(name).or_else(|| {
-                smolvm::image_store::ensure_image_blocking(
-                    image,
-                    &smolvm::registry::PullAuth::FromConfig,
-                )
-            });
-            if let Some(dir) = entry {
-                // Present it exactly as the pack store does: `packed_layers_dir`
-                // is an EMPTY per-machine mountpoint and `pack_idmap_source` is
-                // the shared content. While the uid drop is active `internal_boot`
-                // idmap-binds the source onto that mountpoint, mapping on-disk
-                // uid 0 to the VM's uid; pointing both at the same directory would
-                // ask it to bind the store onto itself. Without the drop the
-                // manager collapses the indirection on its own.
-                let mountpoint = smolvm::agent::machine_layers_cache_dir(name);
-                if let Err(e) = std::fs::create_dir_all(&mountpoint) {
-                    tracing::warn!(error = %e, "image store skipped: no layers mountpoint");
-                } else {
-                    smolvm::image_store::remember_entry(name, &dir);
-                    features.pack_idmap_source = Some(dir);
-                    features.packed_layers_dir = Some(mountpoint);
-                }
+            if let Some(layers) = smolvm::image_store::prepare_layers(
+                name,
+                Some(image),
+                Some(&smolvm::registry::PullAuth::FromConfig),
+            ) {
+                features.pack_idmap_source = Some(layers.idmap_source);
+                features.packed_layers_dir = Some(layers.mountpoint);
             }
         }
     }

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -1325,6 +1325,11 @@ fn start_vm_named_with_db(
         }
     }
 
+    // Whether the guest's layers are already mounted via virtiofs. Captured here
+    // because `features` is moved into the launch below, and the in-guest pull
+    // further down must be skipped exactly when this is true.
+    let uses_packed_layers = features.packed_layers_dir.is_some();
+
     // First boot pulls the base image in-guest, subject to the egress filter —
     // fold the image's registry into the enforced policy so a hostname scope
     // doesn't block its own pull. Subsequent starts skip the pull, so they keep
@@ -1365,11 +1370,12 @@ fn start_vm_named_with_db(
     // starts, skip both — image manifests/layers persist on the storage disk
     // and the container overlay is remounted (not recreated).
     if !record.init_completed {
-        let uses_packed_layers = record.source_smolmachine.is_some()
-            || record
-                .image
-                .as_deref()
-                .is_some_and(smolvm::data::image_source::is_local_ref);
+        // `uses_packed_layers` comes from the launch features (captured above), not
+        // re-derived from the record: `packed_layers_dir` is the one place that
+        // knows whether layers are already mounted, and it is set from three
+        // sources (a `.smolmachine`, a local image archive, and the image store).
+        // Re-deriving here would miss any source it does not enumerate, and the
+        // machine would pull in-guest even though the layers are already there.
         let image_info = if uses_packed_layers {
             // Layers already mounted via virtiofs — no pull needed.
             None

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -1302,6 +1302,28 @@ fn start_vm_named_with_db(
             features.packed_layers_dir = Some(dir);
         }
     }
+    // Host-side image store: pull + extract a registry image ONCE into shared
+    // overlay lowerdirs, so this and every other machine on that image skips both
+    // the in-guest pull and the per-VM flatten.
+    //
+    // Only on a machine's FIRST boot: once `init_completed` is set the layers are
+    // already established, and re-resolving would make every later start depend on
+    // the registry being reachable. `ensure_image_blocking` returns `None` on any
+    // failure — it is a cache, so a miss falls through to the in-guest pull rather
+    // than failing the machine.
+    if features.packed_layers_dir.is_none() && !record.init_completed {
+        if let Some(image) = record.image.as_deref() {
+            if let Some(dir) = smolvm::image_store::ensure_image_blocking(
+                image,
+                &smolvm::registry::PullAuth::FromConfig,
+            ) {
+                // The store is root-owned and the VMM drops to a per-VM uid before
+                // serving virtiofs, so it needs the same idmap the pack store uses.
+                features.pack_idmap_source = Some(dir.clone());
+                features.packed_layers_dir = Some(dir);
+            }
+        }
+    }
 
     // First boot pulls the base image in-guest, subject to the egress filter —
     // fold the image's registry into the enforced policy so a hostname scope

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -1317,10 +1317,20 @@ fn start_vm_named_with_db(
                 image,
                 &smolvm::registry::PullAuth::FromConfig,
             ) {
-                // The store is root-owned and the VMM drops to a per-VM uid before
-                // serving virtiofs, so it needs the same idmap the pack store uses.
-                features.pack_idmap_source = Some(dir.clone());
-                features.packed_layers_dir = Some(dir);
+                // Present it exactly as the pack store does: `packed_layers_dir`
+                // is an EMPTY per-machine mountpoint and `pack_idmap_source` is
+                // the shared content. While the uid drop is active `internal_boot`
+                // idmap-binds the source onto that mountpoint, mapping on-disk
+                // uid 0 to the VM's uid; pointing both at the same directory would
+                // ask it to bind the store onto itself. Without the drop the
+                // manager collapses the indirection on its own.
+                let mountpoint = smolvm::agent::machine_layers_cache_dir(name);
+                if let Err(e) = std::fs::create_dir_all(&mountpoint) {
+                    tracing::warn!(error = %e, "image store skipped: no layers mountpoint");
+                } else {
+                    features.pack_idmap_source = Some(dir);
+                    features.packed_layers_dir = Some(mountpoint);
+                }
             }
         }
     }

--- a/src/embedded/control.rs
+++ b/src/embedded/control.rs
@@ -89,6 +89,21 @@ fn start_vm_from_record(record: &VmRecord) -> Result<VmHandle> {
 /// the plain, forkable-golden, and fork-clone start paths so they can't drift.
 fn launch_from_record(record: &VmRecord, features: LaunchFeatures) -> Result<VmHandle> {
     let mut features = features;
+    // Present the host image store's shared layers, through the same
+    // `prepare_layers` the CLI and API start paths use. An embedded host is the
+    // machine's own owner, so it gates a fill with its configured credentials —
+    // and a machine already filled elsewhere is re-presented from its
+    // back-reference, which it must be: those layers are its only rootfs.
+    if features.packed_layers_dir.is_none() {
+        if let Some(layers) = crate::image_store::prepare_layers(
+            &record.name,
+            record.image.as_deref(),
+            Some(&crate::registry::PullAuth::FromConfig),
+        ) {
+            features.pack_idmap_source = Some(layers.idmap_source);
+            features.packed_layers_dir = Some(layers.mountpoint);
+        }
+    }
     if features.cuda_fork_pool_size.is_none() {
         features.cuda_fork_pool_size = record.cuda_fork_pool_size;
     }

--- a/src/image_store.rs
+++ b/src/image_store.rs
@@ -1,46 +1,207 @@
-//! Host-side registry authorization for OCI images, shared by the local CLI and
-//! the cloud worker path so both authorize identically (issue #756).
+//! Content-addressed store of OCI image layers, extracted once on the host and
+//! mounted read-only by every machine that runs the image (issue #756).
 //!
-//! [`authorized_digest`] resolves an image reference with the CALLER's
-//! credentials and returns its manifest digest. Two properties fall out:
+//! Without it each VM pulls the image from the registry and flattens it into its
+//! own storage — work whose cost scales with the *extracted* size and is repeated
+//! per machine. The store does it once: the layers become overlayfs lowerdirs the
+//! guest mounts through the existing packed-layers path, so a repeat run skips
+//! both the pull and the flatten.
 //!
-//! * **Authorization is the registry's own decision.** Resolving the manifest
-//!   makes the registry authorize `repository:<repo>:pull` for these
-//!   credentials, so a caller who cannot pull the image is rejected here (401/
-//!   403) before anything is cached or booted on their behalf.
-//! * **The digest is a content address.** Callers key their caches on it, so an
-//!   entry tracks the image's CONTENT rather than a mutable tag: when `:latest`
-//!   moves upstream the digest changes and the stale entry is not reused.
+//! # Two properties this store is built around
 //!
-//! A caller that caches image CONTENT keyed by this digest must also bind the
-//! entry to the registry and repository that authorized it — resolution accepts
-//! the first candidate registry that answers, including one the caller controls,
-//! so a digest alone is not proof of entitlement to previously cached bytes.
+//! **Access is re-authorized per caller, every time.** [`ImageStore::ensure_image`]
+//! resolves the manifest with the caller's credentials before the cache is
+//! consulted, so the registry's own `repository:<repo>:pull` decision gates a hit
+//! exactly as it gates a miss. Entries are additionally keyed by the registry and
+//! repository they were authorized against ([`entry_key`]), so passing the gate at
+//! one registry can never unlock content filled from another.
+//!
+//! **The on-disk entry is shaped like a packed-layers directory**, because that is
+//! what the guest already consumes: digest-named layer dirs, a `layer-order`
+//! index, and the image's own config as `config.json`. Producing that shape
+//! rather than inventing a parallel one is what lets the idmapped mount, the
+//! config parsing, and the overlay stacking all work unchanged.
+//!
+//! # Why this store does not live in the pack store's directory
+//!
+//! The shared pack store is deliberately never size-capped: its entries are
+//! reference-shared by live VMs with no lease, so evicting one can pull the rug
+//! from under a running machine. This store keeps its own root, so it can be
+//! bounded without touching anything it does not own.
+
+use std::path::{Path, PathBuf};
 
 use sha2::{Digest, Sha256};
 
 use crate::registry::{registry_client, PullAuth, Reference};
 use crate::{Error, Result};
 
-/// Resolve `reference` against the candidate registries the guest would try and
-/// return its manifest digest, authorized with `auth`.
+/// A content-addressed store of extracted image layers, rooted at its own
+/// directory (never the pack store's — see the module docs).
+pub struct ImageStore {
+    root: PathBuf,
+}
+
+impl ImageStore {
+    /// Store rooted at `root`; each image lives at `root/<entry-key>/`.
+    pub fn new(root: PathBuf) -> Self {
+        Self { root }
+    }
+
+    /// The node/host image store — a sibling of the pack store, not a tenant.
+    pub fn shared() -> Self {
+        Self::new(crate::agent::vm_cache_root().join("_images"))
+    }
+
+    /// Resolve and authorize `reference`, ensure its layers are extracted, and
+    /// return the directory to present as the guest's packed layers.
+    ///
+    /// The auth gate runs on every call, before the cache is consulted, so a hit
+    /// cannot serve an image the caller is not entitled to pull.
+    pub async fn ensure_image(&self, reference: &str, auth: &PullAuth) -> Result<PathBuf> {
+        let r = resolve_authorized(reference, auth).await?;
+        let key = entry_key(&r.registry, &r.repo, &r.digest);
+        let entry = self.root.join(&key);
+
+        if is_intact(&entry) {
+            touch(&entry);
+            return Ok(entry);
+        }
+
+        std::fs::create_dir_all(&self.root)
+            .map_err(|e| Error::config("image-store", e.to_string()))?;
+        // Serialize fills of the same key across processes AND tasks. Without it
+        // two fillers share a staging dir: one wipes the other's extracted layers
+        // and then publishes an entry whose `layer-order` names dirs that are gone.
+        let _guard = FillLock::acquire(&self.root.join(format!(".lock-{key}")))?;
+        // Whoever held the lock before us may have just filled it.
+        if is_intact(&entry) {
+            touch(&entry);
+            return Ok(entry);
+        }
+
+        let manifest: smolvm_registry::OciManifest = serde_json::from_slice(&r.manifest_bytes)
+            .map_err(|e| Error::agent("image-store: parse manifest", e.to_string()))?;
+        let staging = self.root.join(format!(".staging-{key}-{}", fill_nonce()));
+        let _ = std::fs::remove_dir_all(&staging);
+        materialize_entry(&r.client, &r.repo, &manifest, &staging)
+            .await
+            .inspect_err(|_| {
+                let _ = std::fs::remove_dir_all(&staging);
+            })?;
+
+        // Atomic publish. A pre-existing directory here is debris (a crash, or a
+        // partial removal): rename would fail with ENOTEMPTY forever, so clear it
+        // and retry once rather than poisoning the key permanently.
+        match std::fs::rename(&staging, &entry) {
+            Ok(()) => {}
+            Err(_) if is_intact(&entry) => {
+                let _ = std::fs::remove_dir_all(&staging);
+            }
+            Err(_) if entry.exists() => {
+                let _ = std::fs::remove_dir_all(&entry);
+                std::fs::rename(&staging, &entry).map_err(|e| {
+                    let _ = std::fs::remove_dir_all(&staging);
+                    Error::config("image-store: publish", e.to_string())
+                })?;
+            }
+            Err(e) => {
+                let _ = std::fs::remove_dir_all(&staging);
+                return Err(Error::config("image-store: publish", e.to_string()));
+            }
+        }
+
+        sweep_staging(&self.root);
+        prune_store(&self.root, image_cache_max_bytes(), &entry);
+        Ok(entry)
+    }
+}
+
+/// The image's own config, under the name and shape the guest already parses
+/// (`config.json`, OCI `{"config": {...}}`), so entrypoint, cmd, env, working
+/// directory and user all reach the container with no host-side translation.
+const CONFIG_FILE: &str = "config.json";
+
+/// The layer-stacking index, bottom-most layer first.
+const LAYER_ORDER_FILE: &str = "layer-order";
+
+/// An entry is usable only once its `layer-order` index exists. It is written
+/// last, so its presence means every layer and the config are already in place —
+/// a crash mid-fill can never present a partial entry as a hit.
+fn is_intact(entry: &Path) -> bool {
+    entry.join(LAYER_ORDER_FILE).is_file() && entry.join(CONFIG_FILE).is_file()
+}
+
+/// Whether this process can materialize an entry.
 ///
-/// The registry authorizes `repository:<repo>:pull` for the caller's credentials
-/// during resolution; an unauthorized caller is rejected here.
-pub async fn authorized_digest(reference: &str, auth: &PullAuth) -> Result<String> {
+/// Translating an OCI whiteout into an overlayfs whiteout is a `mknod` of a
+/// character device, which needs `CAP_MKNOD`. Ownership is deliberately NOT
+/// preserved (see `ExtractOptions::HOST_SHARED`), so no `CAP_CHOWN` is required.
+/// Rather than degrade into half-applied deletions, the store declines and the
+/// caller keeps the in-guest pull.
+#[cfg(unix)]
+pub fn can_extract() -> bool {
+    // SAFETY: geteuid is always safe and cannot fail.
+    unsafe { libc::geteuid() == 0 }
+}
+
+#[cfg(not(unix))]
+pub fn can_extract() -> bool {
+    false
+}
+
+/// Fill (or reuse) the store for `reference` and return the directory to present
+/// as packed layers, from a synchronous caller.
+///
+/// Returns `None` whenever the store cannot serve this caller — it is a cache,
+/// never a hard dependency, so a registry outage, a rate limit, or a host that
+/// cannot extract must not stop a machine that could still pull in-guest.
+pub fn ensure_image_blocking(reference: &str, auth: &PullAuth) -> Option<PathBuf> {
+    if !can_extract() {
+        tracing::debug!("image store skipped: layer extraction needs CAP_MKNOD");
+        return None;
+    }
+    let rt = match tokio::runtime::Runtime::new() {
+        Ok(rt) => rt,
+        Err(e) => {
+            tracing::warn!(error = %e, "image store skipped: runtime");
+            return None;
+        }
+    };
+    match rt.block_on(ImageStore::shared().ensure_image(reference, auth)) {
+        Ok(dir) => Some(dir),
+        Err(e) => {
+            tracing::warn!(error = %e, "image store unavailable; falling back to in-guest pull");
+            None
+        }
+    }
+}
+
+/// The outcome of the auth gate.
+struct Resolved {
+    client: smolvm_registry::RegistryClient,
+    /// The registry the manifest was actually authorized against — part of the
+    /// key, so an entry is only served to a caller who passed the gate there.
+    registry: String,
+    repo: String,
+    manifest_bytes: Vec<u8>,
+    digest: String,
+}
+
+/// Resolve + authorize `reference` across the candidate registries the guest
+/// would try, returning the winning client, repo, manifest, and content digest.
+async fn resolve_authorized(reference: &str, auth: &PullAuth) -> Result<Resolved> {
     let parsed = Reference::parse(reference)
-        .map_err(|e| Error::config("image-auth", format!("bad reference: {}", e.reason)))?;
+        .map_err(|e| Error::config("image-store", format!("bad reference: {}", e.reason)))?;
     let want = parsed
         .digest
         .clone()
         .or_else(|| parsed.tag.clone())
         .unwrap_or_else(|| "latest".to_string());
-    // OCI-image credentials live under `images` (docker.io/ghcr/...), the same
-    // config the in-guest pull consults.
     let config = crate::SmolSettings::load()?.images;
 
-    // Resolve the registry the way the GUEST does — via `registry_pull_hosts`, not
-    // the configured default — so the host-side gate targets the same registry the
+    // Resolve the way the GUEST does — via `registry_pull_hosts`, not the
+    // configured default — so the host-side gate targets the same registry the
     // in-guest pull would (a bare `alpine` is Docker Hub, not the smol registry).
     let mut first_err: Option<String> = None;
     for host in &crate::registry::registry_pull_hosts(reference) {
@@ -48,29 +209,40 @@ pub async fn authorized_digest(reference: &str, auth: &PullAuth) -> Result<Strin
         let repo = repo_for(host, &parsed);
         match client.get_manifest_resolved(&repo, &want).await {
             Ok(manifest_bytes) => {
-                return Ok(format!(
-                    "sha256:{}",
-                    hex::encode(Sha256::digest(&manifest_bytes))
-                ));
+                let digest = format!("sha256:{}", hex::encode(Sha256::digest(&manifest_bytes)));
+                return Ok(Resolved {
+                    client,
+                    registry: host.clone(),
+                    repo,
+                    manifest_bytes,
+                    digest,
+                });
             }
-            // Keep the FIRST failure. `registry_pull_hosts` is a DNS allow-list,
-            // not a list of real endpoints — Docker Hub yields
-            // ["docker.io", "docker.com"] — so letting the later marketing-host
-            // failure overwrite the real 401/429 would surface a nonsense error.
+            // Keep the FIRST failure: `registry_pull_hosts` is a DNS allow-list,
+            // not a list of endpoints — Docker Hub yields ["docker.io",
+            // "docker.com"] — so a later marketing-host failure would otherwise
+            // mask the real 401/429.
             Err(e) => {
                 let _ = first_err.get_or_insert_with(|| e.to_string());
             }
         }
     }
     Err(Error::agent(
-        "image-auth",
+        "image-store: authorize",
         first_err.unwrap_or_else(|| "no candidate registry resolved the image".to_string()),
     ))
 }
 
+/// The auth gate alone: resolve `reference` with the caller's credentials and
+/// return its manifest digest. Callers key content on it, so an entry tracks the
+/// image's CONTENT rather than a mutable tag.
+pub async fn authorized_digest(reference: &str, auth: &PullAuth) -> Result<String> {
+    Ok(resolve_authorized(reference, auth).await?.digest)
+}
+
 /// The repository path for a reference against a candidate `host`. Docker Hub
 /// official images (no namespace) live under the implicit `library/` namespace,
-/// so a bare `alpine` becomes `library/alpine` — without which the pull-scope is
+/// so a bare `alpine` becomes `library/alpine` — without which the pull scope is
 /// wrong and the registry answers 401.
 fn repo_for(host: &str, r: &Reference) -> String {
     let docker_hub = matches!(
@@ -84,25 +256,426 @@ fn repo_for(host: &str, r: &Reference) -> String {
     }
 }
 
+/// A filesystem-safe directory name for a digest (`sha256:abc` → `sha256-abc`).
+fn digest_dir(digest: &str) -> String {
+    digest.replace(':', "-")
+}
+
+/// The cache key: the manifest digest bound to the registry and repository it was
+/// authorized against.
+///
+/// Keying on the digest ALONE would make the gate bypassable. Resolution accepts
+/// the first candidate registry that answers, including one the caller controls,
+/// so anyone holding a private image's manifest bytes (manifests leak far more
+/// easily than blobs — an old public tag, a CI log) could serve them from their
+/// own registry, pass the gate there, and be handed the private image's extracted
+/// layers. Dedup is preserved where it matters: every caller pulling
+/// `docker.io/library/alpine` at the same digest still shares one entry.
+fn entry_key(registry: &str, repo: &str, manifest_digest: &str) -> String {
+    let scoped = format!("{registry}/{repo}@{manifest_digest}");
+    format!("sha256-{}", hex::encode(Sha256::digest(scoped.as_bytes())))
+}
+
+/// Environment override (bytes) for the store's on-disk ceiling.
+const IMAGE_CACHE_MAX_BYTES_ENV: &str = "SMOLVM_IMAGE_CACHE_MAX_BYTES";
+
+/// Size ceiling for the store, default 20 GiB. Extracted layers are far larger
+/// than the blobs they came from, so an unbounded store fills a node's disk and
+/// every machine on it then fails to start.
+fn image_cache_max_bytes() -> u64 {
+    std::env::var(IMAGE_CACHE_MAX_BYTES_ENV)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(20 * 1024 * 1024 * 1024)
+}
+
+/// Mark an entry recently used so LRU eviction keeps hot images.
+fn touch(entry: &Path) {
+    if let Ok(f) = std::fs::File::open(entry) {
+        let _ = f.set_modified(std::time::SystemTime::now());
+    }
+}
+
+/// A unique-per-fill suffix, so a crashed fill's debris is never mistaken for an
+/// in-progress one. (Uniqueness only — the lock provides mutual exclusion.)
+fn fill_nonce() -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("{}-{}", std::process::id(), nanos)
+}
+
+/// An exclusive advisory lock held for one fill, released when the handle closes.
+struct FillLock(
+    // Never read: the handle IS the lock. The OS releases it when this file
+    // closes, so the field's only job is to live as long as the guard.
+    #[allow(dead_code)] std::fs::File,
+);
+
+impl FillLock {
+    fn acquire(path: &Path) -> Result<Self> {
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(path)
+            .map_err(|e| Error::config("image-store: lock", e.to_string()))?;
+        lock_exclusive(&file).map_err(|e| Error::config("image-store: lock", e.to_string()))?;
+        Ok(Self(file))
+    }
+}
+
+#[cfg(unix)]
+fn lock_exclusive(file: &std::fs::File) -> std::io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+    // SAFETY: `fd` is a valid open descriptor for the duration of the call.
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn lock_exclusive(file: &std::fs::File) -> std::io::Result<()> {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::{LockFileEx, LOCKFILE_EXCLUSIVE_LOCK};
+    use windows_sys::Win32::System::IO::OVERLAPPED;
+    let mut overlapped: OVERLAPPED = unsafe { std::mem::zeroed() };
+    // SAFETY: handle is valid; overlapped is a zeroed, correctly sized struct.
+    let ok = unsafe {
+        LockFileEx(
+            file.as_raw_handle() as _,
+            LOCKFILE_EXCLUSIVE_LOCK,
+            0,
+            !0,
+            !0,
+            &mut overlapped,
+        )
+    };
+    if ok == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Reap staging debris left by a crashed fill; without this every crash leaks a
+/// full extracted image that nothing reclaims. Only demonstrably stale debris is
+/// removed, so a concurrent fill in another process is never pulled out from
+/// under itself.
+fn sweep_staging(root: &Path) {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    for e in entries.flatten() {
+        let name = e.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if !name.starts_with(".staging-") {
+            continue;
+        }
+        let stale = e
+            .metadata()
+            .and_then(|m| m.modified())
+            .map(|t| {
+                t.elapsed()
+                    .map(|age| age > std::time::Duration::from_secs(3600))
+                    .unwrap_or(false)
+            })
+            .unwrap_or(false);
+        if stale {
+            let _ = std::fs::remove_dir_all(e.path());
+        }
+    }
+}
+
+/// Evict least-recently-used entries until the store fits `max_bytes`, never
+/// removing `keep` (the entry the caller is about to mount).
+///
+/// Safe here precisely because this root belongs to the store: the pack store is
+/// never-evict, since its entries are reference-shared by live VMs.
+fn prune_store(root: &Path, max_bytes: u64, keep: &Path) {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    let mut items: Vec<(std::time::SystemTime, u64, PathBuf)> = Vec::new();
+    let mut total = 0u64;
+    for e in entries.flatten() {
+        let path = e.path();
+        let name = e.file_name();
+        let name = name.to_string_lossy();
+        // Only content entries participate; locks and staging are not evictable.
+        if name.starts_with('.') || !path.is_dir() {
+            continue;
+        }
+        let size = dir_size(&path);
+        total += size;
+        let mtime = e
+            .metadata()
+            .and_then(|m| m.modified())
+            .unwrap_or(std::time::UNIX_EPOCH);
+        items.push((mtime, size, path));
+    }
+    if total <= max_bytes {
+        return;
+    }
+    items.sort_by_key(|(mtime, _, _)| *mtime);
+    for (_, size, path) in items {
+        if total <= max_bytes {
+            break;
+        }
+        if path == keep {
+            continue;
+        }
+        if std::fs::remove_dir_all(&path).is_ok() {
+            total = total.saturating_sub(size);
+        }
+    }
+}
+
+/// Bytes a file actually occupies on disk.
+///
+/// `st_blocks × 512`, not the apparent length: sparse files report a length far
+/// larger than they consume, so counting apparent size would over-count by orders
+/// of magnitude and evict far too aggressively.
+#[cfg(unix)]
+fn file_disk_usage(md: &std::fs::Metadata) -> u64 {
+    use std::os::unix::fs::MetadataExt;
+    md.blocks() * 512
+}
+
+#[cfg(not(unix))]
+fn file_disk_usage(md: &std::fs::Metadata) -> u64 {
+    md.len()
+}
+
+/// Recursive on-disk size of a directory, following no symlinks.
+fn dir_size(path: &Path) -> u64 {
+    let mut total = 0;
+    let Ok(entries) = std::fs::read_dir(path) else {
+        return 0;
+    };
+    for e in entries.flatten() {
+        let Ok(md) = e.metadata() else { continue };
+        if md.is_dir() {
+            total += dir_size(&e.path());
+        } else {
+            total += file_disk_usage(&md);
+        }
+    }
+    total
+}
+
+/// Environment override (bytes) for the largest single blob accepted.
+const MAX_LAYER_BYTES_ENV: &str = "SMOLVM_MAX_LAYER_BYTES";
+
+/// Ceiling on one blob, default 8 GiB — larger than any real base image, small
+/// enough that a runaway download cannot fill the disk before the digest check.
+fn max_layer_bytes() -> u64 {
+    std::env::var(MAX_LAYER_BYTES_ENV)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(8 * 1024 * 1024 * 1024)
+}
+
+/// Stream a blob to `dest`, hashing as it goes, and reject it unless the content
+/// hashes to `digest`. Streaming (rather than a buffered pull) removes both the
+/// body size cap and the full-blob memory buffer; verifying from the streamed
+/// bytes keeps the content-addressing guarantee.
+async fn stream_blob_verified(
+    client: &smolvm_registry::RegistryClient,
+    repo: &str,
+    digest: &str,
+    dest: &Path,
+) -> Result<()> {
+    use futures_util::StreamExt;
+    use std::io::Write;
+
+    let mut stream = client
+        .pull_blob_stream(repo, digest)
+        .await
+        .map_err(|e| Error::agent("image-store: pull blob", e.to_string()))?;
+    let file =
+        std::fs::File::create(dest).map_err(|e| Error::config("image-store", e.to_string()))?;
+    let mut writer = std::io::BufWriter::new(file);
+    let mut hasher = Sha256::new();
+    let mut written: u64 = 0;
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| Error::agent("image-store: pull blob", e.to_string()))?;
+        written += chunk.len() as u64;
+        // Bound the write so a hostile or broken registry cannot fill the disk
+        // before the digest is checked at the end.
+        if written > max_layer_bytes() {
+            let _ = std::fs::remove_file(dest);
+            return Err(Error::agent(
+                "image-store: pull blob",
+                format!("blob exceeds {} bytes", max_layer_bytes()),
+            ));
+        }
+        hasher.update(&chunk);
+        writer
+            .write_all(&chunk)
+            .map_err(|e| Error::config("image-store: write blob", e.to_string()))?;
+    }
+    writer
+        .flush()
+        .map_err(|e| Error::config("image-store: write blob", e.to_string()))?;
+
+    let got = format!("sha256:{}", hex::encode(hasher.finalize()));
+    if got != digest {
+        let _ = std::fs::remove_file(dest);
+        return Err(Error::agent(
+            "image-store: blob digest",
+            format!("content mismatch: expected {digest}, got {got}"),
+        ));
+    }
+    Ok(())
+}
+
+/// Materialize a full entry into `staging`, in the shape the guest's packed-layers
+/// path already consumes: one extracted directory per layer, the image's own
+/// config as `config.json`, and the `layer-order` index written LAST.
+///
+/// Layers extract with `ExtractOptions::HOST_SHARED`: ownership is not preserved
+/// (the guest sees these through an idmapped mount) and opaque markers use the
+/// `user.*` namespace, because the virtiofs server that will read them has
+/// dropped privileges and cannot see `trusted.*` at all.
+async fn materialize_entry(
+    client: &smolvm_registry::RegistryClient,
+    repo: &str,
+    manifest: &smolvm_registry::OciManifest,
+    staging: &Path,
+) -> Result<()> {
+    std::fs::create_dir_all(staging).map_err(|e| Error::config("image-store", e.to_string()))?;
+
+    let mut order = Vec::with_capacity(manifest.layers.len());
+    for descriptor in &manifest.layers {
+        smolvm_registry::validate_digest(&descriptor.digest)
+            .map_err(|e| Error::agent("image-store: layer digest", e.to_string()))?;
+        let blob_path = staging.join(format!("{}.blob", digest_dir(&descriptor.digest)));
+        stream_blob_verified(client, repo, &descriptor.digest, &blob_path).await?;
+
+        let dir = staging.join(digest_dir(&descriptor.digest));
+        std::fs::create_dir_all(&dir).map_err(|e| Error::config("image-store", e.to_string()))?;
+        let blob = std::fs::File::open(&blob_path)
+            .map_err(|e| Error::config("image-store: open layer", e.to_string()))?;
+        let extracted = smolvm_oci_layer::extract_oci_layer(
+            std::io::BufReader::new(blob),
+            &dir,
+            smolvm_oci_layer::ExtractOptions::HOST_SHARED,
+        )
+        .map_err(|e| Error::agent("image-store: extract layer", e.to_string()));
+        // The compressed blob is scratch — drop it either way, so a fill never
+        // leaves both representations on disk.
+        let _ = std::fs::remove_file(&blob_path);
+        extracted?;
+        order.push(digest_dir(&descriptor.digest));
+    }
+
+    // The image config, verbatim. The guest parses this exact shape already, so
+    // entrypoint/cmd/env/workdir/user reach the container with no host-side
+    // translation and nothing to drift out of sync.
+    smolvm_registry::validate_digest(&manifest.config.digest)
+        .map_err(|e| Error::agent("image-store: config digest", e.to_string()))?;
+    stream_blob_verified(
+        client,
+        repo,
+        &manifest.config.digest,
+        &staging.join(CONFIG_FILE),
+    )
+    .await?;
+
+    // Written LAST: its presence is what `is_intact` treats as "complete".
+    std::fs::write(staging.join(LAYER_ORDER_FILE), order.join("\n"))
+        .map_err(|e| Error::config("image-store", e.to_string()))?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
+    fn digest_dir_is_filesystem_safe() {
+        assert_eq!(digest_dir("sha256:abc123"), "sha256-abc123");
+    }
+
+    #[test]
     fn repo_for_maps_docker_hub_and_namespaced_refs() {
-        // Docker Hub official image (no namespace) → implicit `library/`.
         let bare = Reference::parse("alpine").unwrap();
         assert_eq!(repo_for("docker.io", &bare), "library/alpine");
-        // A namespaced ref keeps its namespace on any host.
         let ns = Reference::parse("ghcr.io/org/tool:v1").unwrap();
         assert_eq!(repo_for("ghcr.io", &ns), "org/tool");
-        // A bare name on a non-Docker-Hub host is not `library/`-prefixed.
         assert_eq!(repo_for("ghcr.io", &bare), "alpine");
     }
 
+    /// The store must never share the pack store's root: that tree is
+    /// deliberately never-evict (its entries are reference-shared by live VMs
+    /// with no lease), and this store size-caps its own root.
+    #[test]
+    fn store_root_is_not_the_pack_store_root() {
+        let store = ImageStore::shared().root;
+        assert_ne!(store, crate::agent::shared_pack_cache_root());
+        assert!(store.ends_with("_images"));
+    }
+
+    /// THE key-scoping property: the same manifest digest served from a different
+    /// registry or repo must land on a different entry, or merely holding a
+    /// private image's manifest would unlock its cached layers.
+    #[test]
+    fn entry_key_is_scoped_to_registry_and_repo() {
+        let d = "sha256:abc";
+        let real = entry_key("registry.example.com", "team/private", d);
+        assert_ne!(real, entry_key("evil.example.com", "team/private", d));
+        assert_ne!(real, entry_key("registry.example.com", "other/repo", d));
+        assert_ne!(
+            real,
+            entry_key("registry.example.com", "team/private", "sha256:def")
+        );
+        assert_eq!(real, entry_key("registry.example.com", "team/private", d));
+        assert!(!real.contains('/') && !real.contains(':'));
+    }
+
+    /// The order index is written last, so an entry missing it — or missing the
+    /// config — is never treated as a hit.
+    #[test]
+    fn intact_requires_config_and_order_index() {
+        let tmp = tempfile::tempdir().unwrap();
+        let entry = tmp.path().join("e");
+        std::fs::create_dir_all(entry.join("sha256-l1")).unwrap();
+        assert!(!is_intact(&entry));
+        std::fs::write(entry.join(CONFIG_FILE), b"{}").unwrap();
+        assert!(!is_intact(&entry), "config alone is not a complete entry");
+        std::fs::write(entry.join(LAYER_ORDER_FILE), "sha256-l1").unwrap();
+        assert!(is_intact(&entry));
+    }
+
+    /// Eviction is LRU and never drops the entry the caller is about to mount.
+    #[test]
+    fn prune_store_evicts_oldest_and_never_the_kept_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let mk = |name: &str, bytes: usize, age: u64| -> PathBuf {
+            let dir = root.join(name);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("blob"), vec![0u8; bytes]).unwrap();
+            let f = std::fs::File::open(&dir).unwrap();
+            let _ =
+                f.set_modified(std::time::SystemTime::now() - std::time::Duration::from_secs(age));
+            dir
+        };
+        let oldest = mk("a", 8192, 300);
+        let middle = mk("b", 8192, 200);
+        let newest = mk("c", 8192, 100);
+        // Cap admits two of three entries → exactly one eviction.
+        prune_store(root, 20000, &newest);
+        assert!(!oldest.exists(), "least-recently-used entry evicted");
+        assert!(middle.exists());
+        assert!(newest.exists(), "the kept entry is never evicted");
+    }
+
     /// THE security property: authorization is the registry's decision, made with
-    /// the CALLER's credentials on every call. An unauthorized caller is rejected
-    /// even though the image plainly exists and another caller can resolve it.
+    /// the caller's credentials on every call.
     #[test]
     fn resolution_requires_authorization() {
         use wiremock::matchers::{header, method, path};
@@ -113,7 +686,6 @@ mod tests {
             let server = MockServer::start().await;
             let body = br#"{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{"mediaType":"application/vnd.oci.image.config.v1+json","digest":"sha256:0000000000000000000000000000000000000000000000000000000000000000","size":0},"layers":[]}"#.to_vec();
 
-            // Authorized bearer → 200 with the manifest.
             Mock::given(method("GET"))
                 .and(path("/v2/myrepo/manifests/latest"))
                 .and(header("authorization", "Bearer good-token"))
@@ -125,7 +697,6 @@ mod tests {
                 .with_priority(1)
                 .mount(&server)
                 .await;
-            // Anyone else → 401 (no challenge header → the client does not retry).
             Mock::given(method("GET"))
                 .and(path("/v2/myrepo/manifests/latest"))
                 .respond_with(ResponseTemplate::new(401).set_body_string("unauthorized"))
@@ -136,18 +707,15 @@ mod tests {
             let host = server.uri().strip_prefix("http://").unwrap().to_string();
             let reference = format!("{host}/myrepo:latest");
 
-            // DENY: an unauthorized caller cannot resolve the image at all.
             let denied = authorized_digest(&reference, &PullAuth::Anonymous).await;
             assert!(denied.is_err(), "unauthorized caller must be rejected");
 
-            // ALLOW: the authorized caller gets the manifest's content digest.
             let digest = authorized_digest(&reference, &PullAuth::Bearer("good-token".into()))
                 .await
                 .expect("authorized caller should resolve");
             assert_eq!(
                 digest,
-                format!("sha256:{}", hex::encode(Sha256::digest(&body))),
-                "the digest is the content address of the manifest"
+                format!("sha256:{}", hex::encode(Sha256::digest(&body)))
             );
         });
     }

--- a/src/image_store.rs
+++ b/src/image_store.rs
@@ -151,6 +151,8 @@ pub fn can_extract() -> bool {
     unsafe { libc::geteuid() == 0 }
 }
 
+/// Non-Unix hosts cannot create the device nodes overlayfs whiteouts require,
+/// so the store never serves them and the caller keeps the in-guest pull.
 #[cfg(not(unix))]
 pub fn can_extract() -> bool {
     false

--- a/src/image_store.rs
+++ b/src/image_store.rs
@@ -265,6 +265,65 @@ where
     }
 }
 
+/// The shared layers to present to a machine, in the shape the packed-layers
+/// path already consumes.
+pub struct PreparedLayers {
+    /// The shared, content-addressed entry holding the extracted layers.
+    pub idmap_source: PathBuf,
+    /// The machine's own EMPTY mountpoint the source is bound onto.
+    pub mountpoint: PathBuf,
+}
+
+/// Resolve the layers `machine` should boot from, filling the store if needed.
+///
+/// The single implementation behind both the CLI and the API start paths — they
+/// differ only in the credential they gate with, never in the mechanics.
+///
+/// Call this on EVERY boot, not just the first: packed layers are a per-boot
+/// mount, not persistent machine state. A machine whose layers came from the
+/// store has no in-guest image to fall back on, so presenting them once would
+/// leave every later start with no rootfs at all.
+///
+/// Only a *fill* needs `image` and `auth`. Re-presenting the entry this machine
+/// already booted from needs neither: it is keyed by the machine, it passed the
+/// gate when it was filled, and it belongs to this machine alone. That is what
+/// lets a start path with no image reference in hand — an exec autostart, a
+/// supervisor restart — keep a store-backed machine bootable, and what lets a
+/// warm restart survive a registry outage.
+///
+/// `auth` is `None` when the caller holds no credential it may gate a fill with.
+/// That declines the fill rather than falling back to ambient host credentials,
+/// which on a shared node would authorize one tenant's cache hit with another's
+/// rights.
+///
+/// Returns `None` whenever the store cannot serve this machine. It is a cache,
+/// never a hard dependency, so every miss falls through to the in-guest pull.
+pub fn prepare_layers(
+    machine: &str,
+    image: Option<&str>,
+    auth: Option<&PullAuth>,
+) -> Option<PreparedLayers> {
+    let entry = match remembered_entry(machine) {
+        Some(entry) => entry,
+        None => ensure_image_blocking(image?, auth?)?,
+    };
+    // `mountpoint` must be an EMPTY per-machine directory and `idmap_source` the
+    // shared content. While the uid drop is active `internal_boot` idmap-binds
+    // the source onto that mountpoint, mapping on-disk uid 0 to the VM's uid;
+    // pointing both at the same directory would ask it to bind the store onto
+    // itself. Without the drop the manager collapses the indirection on its own.
+    let mountpoint = crate::agent::machine_layers_cache_dir(machine);
+    if let Err(e) = std::fs::create_dir_all(&mountpoint) {
+        tracing::warn!(error = %e, "image store skipped: no layers mountpoint");
+        return None;
+    }
+    remember_entry(machine, &entry);
+    Some(PreparedLayers {
+        idmap_source: entry,
+        mountpoint,
+    })
+}
+
 /// Entry directory names that some machine still boots from.
 fn entries_in_use(root: &Path) -> std::collections::HashSet<std::ffi::OsString> {
     let mut used = std::collections::HashSet::new();

--- a/src/image_store.rs
+++ b/src/image_store.rs
@@ -185,6 +185,104 @@ pub fn ensure_image_blocking(reference: &str, auth: &PullAuth) -> Option<PathBuf
     }
 }
 
+/// A machine's back-reference file: records which entry served it.
+///
+/// The name is dot-prefixed so `prune_store` skips it as a non-content entry,
+/// the same way it skips the fill locks.
+fn ref_path(machine: &str) -> PathBuf {
+    let safe: String = machine
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    ImageStore::shared().root.join(format!(".ref-{safe}"))
+}
+
+/// Record that `machine` boots from `entry`, so later starts can re-present the
+/// same layers without a registry round-trip, and so the LRU knows the entry is
+/// in use.
+pub fn remember_entry(machine: &str, entry: &Path) {
+    let Some(name) = entry.file_name().and_then(|n| n.to_str()) else {
+        return;
+    };
+    if let Err(e) = std::fs::write(ref_path(machine), name) {
+        tracing::debug!(error = %e, "image store: could not record machine back-reference");
+    }
+}
+
+/// The entry `machine` last booted from, if it is still present.
+///
+/// Returning it lets a warm restart re-present layers that are already on disk,
+/// so a machine survives a registry outage instead of depending on it.
+pub fn remembered_entry(machine: &str) -> Option<PathBuf> {
+    let name = std::fs::read_to_string(ref_path(machine)).ok()?;
+    let name = name.trim();
+    // Reject anything that is not a bare entry directory name: the file is
+    // host-local, but a path component here would escape the store root.
+    if name.is_empty() || name.contains('/') || name.starts_with('.') {
+        return None;
+    }
+    let dir = ImageStore::shared().root.join(name);
+    dir.is_dir().then_some(dir)
+}
+
+/// Drop `machine`'s claim on its entry, so the LRU may reclaim it.
+pub fn forget_entry(machine: &str) {
+    let _ = std::fs::remove_file(ref_path(machine));
+}
+
+/// Drop claims held by machines that no longer exist.
+///
+/// `delete_vm` releases a claim on the normal path, but a machine can also
+/// vanish without it — a restored or discarded database, a data dir removed by
+/// hand. A claim left behind pins its entry against the LRU forever, which is
+/// exactly the unbounded growth the size cap exists to prevent, so reconcile
+/// against the live machine list on start.
+pub fn sweep_refs<I, S>(live: I)
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let live: std::collections::HashSet<PathBuf> =
+        live.into_iter().map(|m| ref_path(m.as_ref())).collect();
+    let root = ImageStore::shared().root;
+    let Ok(entries) = std::fs::read_dir(&root) else {
+        return;
+    };
+    for e in entries.flatten() {
+        let path = e.path();
+        if !e.file_name().to_string_lossy().starts_with(".ref-") {
+            continue;
+        }
+        if !live.contains(&path) {
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+}
+
+/// Entry directory names that some machine still boots from.
+fn entries_in_use(root: &Path) -> std::collections::HashSet<std::ffi::OsString> {
+    let mut used = std::collections::HashSet::new();
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return used;
+    };
+    for e in entries.flatten() {
+        let name = e.file_name();
+        if !name.to_string_lossy().starts_with(".ref-") {
+            continue;
+        }
+        if let Ok(target) = std::fs::read_to_string(e.path()) {
+            used.insert(std::ffi::OsString::from(target.trim()));
+        }
+    }
+    used
+}
+
 /// The outcome of the auth gate.
 struct Resolved {
     client: smolvm_registry::RegistryClient,
@@ -406,11 +504,19 @@ fn prune_store(root: &Path, max_bytes: u64, keep: &Path) {
     let Ok(entries) = std::fs::read_dir(root) else {
         return;
     };
+    // Entries a machine still boots from are pinned. Evicting one does not just
+    // cost a re-pull: the machine's layers ARE those directories, so removing
+    // them leaves it unable to start with nothing to fall back on.
+    let in_use = entries_in_use(root);
     let mut items: Vec<(std::time::SystemTime, u64, PathBuf)> = Vec::new();
     let mut total = 0u64;
     for e in entries.flatten() {
         let path = e.path();
         let name = e.file_name();
+        if in_use.contains(&name) {
+            total += dir_size(&path);
+            continue;
+        }
         let name = name.to_string_lossy();
         // Only content entries participate; locks and staging are not evictable.
         if name.starts_with('.') || !path.is_dir() {

--- a/src/image_store.rs
+++ b/src/image_store.rs
@@ -125,6 +125,12 @@ const CONFIG_FILE: &str = "config.json";
 /// The layer-stacking index, bottom-most layer first.
 const LAYER_ORDER_FILE: &str = "layer-order";
 
+/// Declares which xattr namespace this entry's opaque-directory markers use, so
+/// the guest can mount the overlay with a matching `userxattr` setting. Read by
+/// the agent; absent means `trusted.*`, which is what every pre-existing packed
+/// artifact uses.
+const OPAQUE_XATTR_MARKER: &str = "opaque-xattr";
+
 /// An entry is usable only once its `layer-order` index exists. It is written
 /// last, so its presence means every layer and the config are already in place —
 /// a crash mid-fill can never present a partial entry as a hit.
@@ -584,6 +590,13 @@ async fn materialize_entry(
         &staging.join(CONFIG_FILE),
     )
     .await?;
+
+    // Declare the opaque-marker namespace these layers use, so the guest mounts
+    // the overlay with `userxattr` and actually honors them. The layers describe
+    // themselves rather than relying on an out-of-band signal, which keeps every
+    // existing artifact correct by absence: no marker means `trusted.*`.
+    std::fs::write(staging.join(OPAQUE_XATTR_MARKER), b"user")
+        .map_err(|e| Error::config("image-store", e.to_string()))?;
 
     // Written LAST: its presence is what `is_intact` treats as "complete".
     std::fs::write(staging.join(LAYER_ORDER_FILE), order.join("\n"))

--- a/src/pack_export.rs
+++ b/src/pack_export.rs
@@ -439,6 +439,15 @@ fn flatten_and_export(
     // overlayfs wants topmost-first in `lowerdir=`.
     let base_chain: Vec<&str> = lowers.iter().rev().map(String::as_str).collect();
     let base_chain = base_chain.join(":");
+    // NOTE on the bind-mounts in the script below: `mount(8)` caps its option
+    // string near 255 bytes, and a lowerdir chain of real layer paths blows past
+    // that — `/storage/layers/<64-hex>` alone is 80 bytes, so three layers plus
+    // the container overlay reach ~290 and the mount fails with the famously
+    // unhelpful "wrong fs type, bad option". Binding each lower to a short
+    // `/tmp/lN` first keeps the option string tiny no matter how many layers an
+    // image has. (The guest's own overlay mount sidesteps this differently, via
+    // `fsconfig` + repeated `lowerdir+`, which the shell has no access to.)
+    //
     // The producer of these layers declares its opaque-marker namespace in a file
     // beside them; the layer dirs are siblings under one parent, so derive it from
     // the first lower. Absent → `trusted.*`, i.e. every pre-existing pack.
@@ -466,9 +475,15 @@ fn flatten_and_export(
            mkdir -p /tmp/flatview\n\
            xopt=\"\"\n\
            if [ \"$(cat {marker} 2>/dev/null)\" = user ]; then xopt=\",userxattr\"; fi\n\
-           mount -t overlay overlay -o lowerdir=\"$low\"\"$xopt\" /tmp/flatview\n\
+           i=0; short=\"\"\n\
+           for l in $(echo \"$low\" | tr : \" \"); do\n\
+             mkdir -p /tmp/l$i && mount --bind \"$l\" /tmp/l$i || exit 33\n\
+             short=\"${{short:+$short:}}/tmp/l$i\"; i=$((i+1))\n\
+           done\n\
+           mount -t overlay overlay -o lowerdir=\"$short\"\"$xopt\" /tmp/flatview\n\
            tar cf /storage/flat-export.tar -C /tmp/flatview .\n\
            umount /tmp/flatview\n\
+           j=0; while [ $j -lt $i ]; do umount /tmp/l$j 2>/dev/null; j=$((j+1)); done\n\
          fi\n\
          echo FLAT_OK\n",
         n = lowers.len(),

--- a/src/pack_export.rs
+++ b/src/pack_export.rs
@@ -439,6 +439,15 @@ fn flatten_and_export(
     // overlayfs wants topmost-first in `lowerdir=`.
     let base_chain: Vec<&str> = lowers.iter().rev().map(String::as_str).collect();
     let base_chain = base_chain.join(":");
+    // The producer of these layers declares its opaque-marker namespace in a file
+    // beside them; the layer dirs are siblings under one parent, so derive it from
+    // the first lower. Absent → `trusted.*`, i.e. every pre-existing pack.
+    let marker_path = std::path::Path::new(&lowers[0])
+        .parent()
+        .map(|d| d.join("opaque-xattr"))
+        .unwrap_or_else(|| std::path::PathBuf::from("/nonexistent"))
+        .display()
+        .to_string();
 
     println!(
         "Flattening {} layer(s) + container overlay...",
@@ -455,12 +464,22 @@ fn flatten_and_export(
            tar cf /storage/flat-export.tar -C \"${{low%%:*}}\" .\n\
          else\n\
            mkdir -p /tmp/flatview\n\
-           mount -t overlay overlay -o lowerdir=\"$low\" /tmp/flatview\n\
+           xopt=\"\"\n\
+           if [ \"$(cat {marker} 2>/dev/null)\" = user ]; then xopt=\",userxattr\"; fi\n\
+           mount -t overlay overlay -o lowerdir=\"$low\"\"$xopt\" /tmp/flatview\n\
            tar cf /storage/flat-export.tar -C /tmp/flatview .\n\
            umount /tmp/flatview\n\
          fi\n\
          echo FLAT_OK\n",
         n = lowers.len(),
+        // Layers extracted on the HOST mark opaque directories in the `user.*`
+        // namespace (the unprivileged virtiofs server that serves them cannot see
+        // `trusted.*`), and the kernel only consults that namespace under
+        // `userxattr`. Without matching here the merged view would silently show
+        // content a replaced directory had removed — and this tar becomes an
+        // exported artifact, so those files would travel to a registry.
+        // No marker means `trusted.*`, which is every pre-existing pack.
+        marker = marker_path,
     );
     let (exit_code, stdout, stderr) = client.vm_exec(
         vec!["sh".to_string(), "-c".to_string(), script],


### PR DESCRIPTION
Registry-image machines boot from a host-side content-addressed image store: an image is pulled and extracted once into overlay lowerdirs, and every machine using that image mounts them read-only instead of pulling and flattening the image inside each VM.

Also fixes `pack create --from-vm` for machines with three or more layers.