### PR TITLE
Harden privileged CUDA clone startup

### DIFF
--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -38,6 +38,20 @@ fn should_retry_kvm_enomem(cpus: u8, fork_clone: bool) -> bool {
     cpus == 1 || fork_clone
 }
 
+#[cfg(unix)]
+fn needs_managed_cuda_daemon(
+    cuda: bool,
+    fork_context: bool,
+    shared_setting: Option<&str>,
+    external_daemon: bool,
+) -> bool {
+    cuda && !external_daemon
+        && match shared_setting {
+            Some(value) => value == "1",
+            None => fork_context,
+        }
+}
+
 /// Running VM configuration persisted to disk so new CLI invocations
 /// can restore the actual config of a detached VM.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -1681,6 +1695,35 @@ impl AgentManager {
 
         let t_launch = Instant::now();
 
+        // A privileged node drops each VMM to a distinct uid. Start the shared
+        // CUDA daemon while this manager still has access to the node data dir;
+        // the isolated VMM then only needs permission to connect to its socket.
+        // Forkable CUDA cannot safely fall back in-process because restored
+        // clones must reconnect to the golden's daemon-owned device state.
+        #[cfg(unix)]
+        {
+            let shared_setting = std::env::var("SMOLVM_CUDA_SHARED").ok();
+            let external_daemon = std::env::var_os("SMOLVM_CUDA_DAEMON").is_some();
+            let fork_context = features.forkable || features.snapshot_dir.is_some();
+            if needs_managed_cuda_daemon(
+                features.cuda || resources.cuda,
+                fork_context,
+                shared_setting.as_deref(),
+                external_daemon,
+            ) {
+                let daemon_executable = match std::env::var_os("SMOLVM_BOOT_BINARY") {
+                    Some(path) => PathBuf::from(path),
+                    None => std::env::current_exe()
+                        .map_err(|error| Error::agent("find smolvm binary", error.to_string()))?,
+                };
+                crate::cuda_daemon::ensure_running_with_executable(
+                    &daemon_executable,
+                    fork_context,
+                )
+                .map_err(|error| Error::agent("start shared CUDA daemon", error.to_string()))?;
+            }
+        }
+
         let cpu_policy = std::env::var("SMOLVM_CUDA_FORK_CPU_POLICY")
             .ok()
             .map(|value| value.trim().to_ascii_lowercase())
@@ -1809,9 +1852,10 @@ impl AgentManager {
             // pattern as SHARED above: a CUDA golden's clones need the daemon in
             // address-preserving per-clone-worker mode or default-config torch
             // (expandable_segments) forks into a broken clone. Explicit operator
-            // settings win. The daemon reads these at ITS spawn (inherited from
-            // this VM's boot process via ensure_running), so a daemon already
-            // running in another mode keeps that mode until restarted.
+            // settings win. Both the privileged manager prestart above and the
+            // VM boot fallback propagate these defaults to a newly spawned
+            // daemon; a daemon already running in another mode keeps that mode
+            // until restarted.
             for flag in ["SMOLVM_CUDA_FORK_WORKERS", "SMOLVM_CUDA_FORK_ISOLATE"] {
                 if std::env::var_os(flag).is_none()
                     && (features.forkable || features.snapshot_dir.is_some())
@@ -2134,18 +2178,19 @@ impl AgentManager {
         // SMOLVM_VM_USE_SCOPE at startup and did NOT set SMOLVM_CGROUP_ROOT, so the
         // boot subprocess skipped self-placement and the VM is still in serve's
         // cgroup for this microsecond window — the adopt moves it out. Caps mirror
-        // process::place_in_cgroup (CGROUP_MEM_OVERHEAD_MIB=768, CGROUP_PIDS_MAX
+        // process::place_in_cgroup (VMM_MEM_OVERHEAD_MIB=768, CGROUP_PIDS_MAX
         // =1024) as scope properties. Best-effort: on failure the VM keeps running
         // (just not restart-safe), same as an uncapped cgroup join.
         #[cfg(target_os = "linux")]
         if std::env::var_os("SMOLVM_VM_USE_SCOPE").is_some() {
             if let Some(name) = self.name() {
                 let caps = crate::systemd_scope::ScopeCaps {
-                    memory_max_bytes: Some(
-                        (resources_for_config.memory_mib as u64 + 768) * 1024 * 1024,
-                    ),
+                    memory_max_bytes: Some(crate::process::vmm_memory_limit_bytes(
+                        resources_for_config.memory_mib,
+                        config.cuda,
+                    )),
                     cpu_quota_usec_per_sec: Some(
-                        (resources_for_config.cpus.max(1) as u64) * 1_000_000,
+                        u64::from(resources_for_config.cpus.max(1)) * 1_000_000,
                     ),
                     tasks_max: Some(1024),
                 };
@@ -2847,6 +2892,16 @@ mod tests {
         assert!(should_retry_kvm_enomem(1, false));
         assert!(should_retry_kvm_enomem(3, true));
         assert!(!should_retry_kvm_enomem(3, false));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn managed_cuda_daemon_is_mandatory_for_automatic_forking() {
+        assert!(needs_managed_cuda_daemon(true, true, None, false));
+        assert!(needs_managed_cuda_daemon(true, false, Some("1"), false));
+        assert!(!needs_managed_cuda_daemon(false, true, None, false));
+        assert!(!needs_managed_cuda_daemon(true, true, Some("0"), false));
+        assert!(!needs_managed_cuda_daemon(true, true, None, true));
     }
 
     // The distro-package case: the rootfs directory is not writable by the user

--- a/src/cli/internal_boot.rs
+++ b/src/cli/internal_boot.rs
@@ -145,6 +145,7 @@ pub fn run(config_path: PathBuf) -> smolvm::Result<()> {
             std::path::Path::new(&cgroup_root),
             config.resources.cpus,
             config.resources.memory_mib,
+            config.cuda,
         );
     }
 

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -35,6 +35,76 @@ pub fn socket_path() -> PathBuf {
     root.join("cuda-daemon.sock")
 }
 
+#[cfg(target_os = "linux")]
+fn daemon_socket_access(
+    effective_uid: u32,
+    kvm_gid: Option<libc::gid_t>,
+) -> io::Result<(u32, Option<libc::gid_t>)> {
+    if effective_uid != 0 {
+        return Ok((0o600, None));
+    }
+    let gid = kvm_gid.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "privileged shared CUDA daemon requires a kvm group for isolated VMM access",
+        )
+    })?;
+    Ok((0o660, Some(gid)))
+}
+
+#[cfg(target_os = "linux")]
+fn current_daemon_socket_access() -> io::Result<(u32, Option<libc::gid_t>)> {
+    daemon_socket_access(unsafe { libc::geteuid() }, crate::process::kvm_group_gid())
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn current_daemon_socket_access() -> io::Result<(u32, Option<libc::gid_t>)> {
+    Ok((0o600, None))
+}
+
+#[cfg(unix)]
+fn configure_daemon_socket_access(
+    sock: &Path,
+    mode: u32,
+    group: Option<libc::gid_t>,
+) -> io::Result<()> {
+    use std::os::unix::ffi::OsStrExt as _;
+    use std::os::unix::fs::PermissionsExt as _;
+
+    if let Some(gid) = group {
+        let path = std::ffi::CString::new(sock.as_os_str().as_bytes()).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "CUDA daemon socket contains NUL",
+            )
+        })?;
+        if unsafe { libc::chown(path.as_ptr(), u32::MAX, gid) } != 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+    std::fs::set_permissions(sock, std::fs::Permissions::from_mode(mode))
+}
+
+#[cfg(unix)]
+fn bind_daemon_listener(sock: &Path) -> io::Result<UdsListener> {
+    let (mode, group) = current_daemon_socket_access()?;
+    // AF_UNIX socket nodes start at 0777 minus umask. Restrict the node during
+    // bind/listen itself so an unrelated process cannot queue a connection in
+    // the interval before the final ownership update.
+    let socket_umask = libc::mode_t::try_from(0o777_u32 & !mode).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "invalid CUDA daemon socket mode",
+        )
+    })?;
+    let old_umask = unsafe { libc::umask(socket_umask) };
+    let listener = UdsListener::bind(sock);
+    unsafe { libc::umask(old_umask) };
+    let listener = listener?;
+    configure_daemon_socket_access(sock, mode, group)?;
+    Ok(listener)
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum CloneWorkerStatus {
     Ready,
@@ -1228,7 +1298,13 @@ pub fn run(sock: &Path) -> io::Result<()> {
     let _ = std::fs::remove_file(sock);
     #[cfg(unix)]
     install_shutdown_handler(sock);
+    #[cfg(unix)]
+    let listener = bind_daemon_listener(sock)?;
+    #[cfg(not(unix))]
     let listener = UdsListener::bind(sock)?;
+    // Per-VM uid isolation deliberately gives every VMM a distinct uid while
+    // retaining only the shared kvm supplementary group. Grant that group
+    // access to the daemon boundary without exposing it to unrelated host users.
     match spawn_tensor_bundle_service(sock) {
         Ok(path) => {
             TENSOR_BUNDLE_SERVICE_READY.store(true, Ordering::Release);
@@ -5725,7 +5801,29 @@ fn spawn_clone_worker(
 /// daemons (a second would bind-fail and exit, but the lock avoids the churn and
 /// the stale-socket-removal race).
 pub fn ensure_running() -> io::Result<PathBuf> {
+    let executable = std::env::current_exe()?;
+    ensure_running_with_executable(&executable, false)
+}
+
+/// Ensure the shared daemon is running by launching `executable` when a new
+/// daemon is required.
+///
+/// Embedders use this entry point because their current executable is the host
+/// runtime (for example Node or Python), while `SMOLVM_BOOT_BINARY` names the
+/// bundled helper that implements the `_cuda-daemon` subcommand.
+pub(crate) fn ensure_running_with_executable(
+    executable: &Path,
+    automatic_fork_workers: bool,
+) -> io::Result<PathBuf> {
     let sock = socket_path();
+    // A privileged node launches the daemon before dropping each VMM to its
+    // dedicated uid. Those VMMs may connect to the live socket but must not
+    // need write access to the shared data directory merely to create/open the
+    // spawn lock. Check the read-only fast path first; the lock still
+    // serializes every absent/stale-daemon spawn below.
+    if is_alive(&sock) {
+        return Ok(sock);
+    }
     if let Some(parent) = sock.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
@@ -5735,7 +5833,6 @@ pub fn ensure_running() -> io::Result<PathBuf> {
     }
     let _ = std::fs::remove_file(&sock); // stale node from a dead daemon
     use std::os::unix::process::CommandExt;
-    let exe = std::env::current_exe()?;
     // Dev diagnostic: SMOLVM_CUDA_DAEMON_STDERR=<path> captures the daemon's
     // stderr (fork-isolation traces, backend selection) instead of dropping it.
     let stderr = match std::env::var_os("SMOLVM_CUDA_DAEMON_STDERR") {
@@ -5747,15 +5844,23 @@ pub fn ensure_running() -> io::Result<PathBuf> {
             .unwrap_or_else(|_| Stdio::null()),
         None => Stdio::null(),
     };
-    Command::new(exe)
+    let mut command = Command::new(executable);
+    command
         .args(["_cuda-daemon", &sock.to_string_lossy()])
         .env("CUDA_DEVICE_ORDER", CUDA_DEVICE_ORDER)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(stderr)
         // Own process group so the daemon outlives the VM that first spawned it.
-        .process_group(0)
-        .spawn()?;
+        .process_group(0);
+    if automatic_fork_workers {
+        for flag in ["SMOLVM_CUDA_FORK_WORKERS", "SMOLVM_CUDA_FORK_ISOLATE"] {
+            if std::env::var_os(flag).is_none() {
+                command.env(flag, "1");
+            }
+        }
+    }
+    command.spawn()?;
     for _ in 0..200 {
         if is_alive(&sock) {
             return Ok(sock);
@@ -5800,10 +5905,10 @@ mod mps_tests {
         clone_layout_reservation_envelopes, clone_worker_idle_expired,
         clone_worker_idle_timeout_from, clone_worker_share_env, clone_worker_spawn_pace,
         clone_worker_vm_is_alive, consume_procmem_preamble, create_host_snapshot_memfd,
-        create_private_mps_paths, daemon_has_live_cuda_clients, decode_attach_procmem,
-        decode_clone_worker_status, disabled_worker_route, encode_attach_procmem,
-        encode_clone_worker_status, fork_snapshot_enabled, golden_eviction_enabled,
-        host_snapshot_fits, host_snapshot_reconstructable, lift_owned_fds,
+        create_private_mps_paths, daemon_has_live_cuda_clients, daemon_socket_access,
+        decode_attach_procmem, decode_clone_worker_status, disabled_worker_route,
+        encode_attach_procmem, encode_clone_worker_status, fork_snapshot_enabled,
+        golden_eviction_enabled, host_snapshot_fits, host_snapshot_reconstructable, lift_owned_fds,
         live_host_snapshot_count, map_module_blob_fd, mps_enabled, ordinary_regions_are_reserved,
         posix_spawn_clone_worker, prepare_module_blob, prepare_streamed_module_blob,
         range_is_reserved, read_host_snapshot, reconstruct_golden_modules, recv_fd,
@@ -5818,6 +5923,16 @@ mod mps_tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
+
+    #[test]
+    fn daemon_socket_is_private_or_limited_to_the_vmm_group() {
+        assert_eq!(daemon_socket_access(1000, None).unwrap(), (0o600, None));
+        assert_eq!(
+            daemon_socket_access(0, Some(123)).unwrap(),
+            (0o660, Some(123))
+        );
+        assert!(daemon_socket_access(0, None).is_err());
+    }
 
     #[test]
     fn high_fanout_clone_workers_keep_a_bounded_spawn_interval() {

--- a/src/process.rs
+++ b/src/process.rs
@@ -401,11 +401,10 @@ const CGROUP_CPU_PERIOD_US: u64 = 100_000;
 #[cfg(target_os = "linux")]
 const CGROUP_PIDS_MAX: u32 = 1024;
 
-/// Extra MiB granted on top of guest RAM for VMM/virtio/gpu overhead when sizing
+/// Fixed MiB granted beyond guest RAM and any CUDA host mapping when sizing
 /// `memory.max`. This is defense-in-depth atop the guest RAM bound already
 /// enforced by `krun_set_vm_config`, not the primary memory control.
-#[cfg(target_os = "linux")]
-const CGROUP_MEM_OVERHEAD_MIB: u64 = 768;
+const VMM_MEM_OVERHEAD_MIB: u64 = 768;
 
 /// Resolve this process's cgroup v2 directory from `/proc/self/cgroup`.
 ///
@@ -468,14 +467,14 @@ pub fn setup_cgroup_delegation_root() -> Option<std::path::PathBuf> {
 /// Caps applied (best-effort, each independently):
 /// - `cpu.max` = `vcpus * 100ms / 100ms` → bounds CPU to ~`vcpus` cores.
 /// - `pids.max` = [`CGROUP_PIDS_MAX`] → caps host tasks (fork-bomb containment).
-/// - `memory.max` = guest RAM + [`CGROUP_MEM_OVERHEAD_MIB`] → defense-in-depth.
+/// - `memory.max` = guest RAM, CUDA mapping allowance, and fixed overhead.
 ///
 /// `root` must be a delegated root with `cpu`/`memory`/`pids` enabled in its
 /// `subtree_control` (see [`setup_cgroup_delegation_root`]); otherwise the limit
 /// files won't exist and the caps silently degrade while the process still runs.
 /// Never blocks boot.
 #[cfg(target_os = "linux")]
-pub fn place_in_cgroup(root: &std::path::Path, vcpus: u8, memory_mib: u32) {
+pub fn place_in_cgroup(root: &std::path::Path, vcpus: u8, memory_mib: u32, cuda: bool) {
     let pid = unsafe { libc::getpid() };
     let vm = root.join(format!("vm-{pid}"));
     if let Err(e) = std::fs::create_dir(&vm) {
@@ -487,15 +486,15 @@ pub fn place_in_cgroup(root: &std::path::Path, vcpus: u8, memory_mib: u32) {
     }
 
     // Set limits on the leaf *before* joining it.
-    let quota_us = (vcpus.max(1) as u64) * CGROUP_CPU_PERIOD_US;
+    let quota_us = u64::from(vcpus.max(1)) * CGROUP_CPU_PERIOD_US;
     let _ = write_cgroup(
         &vm,
         "cpu.max",
         &format!("{quota_us} {CGROUP_CPU_PERIOD_US}"),
     );
     let _ = write_cgroup(&vm, "pids.max", &CGROUP_PIDS_MAX.to_string());
-    let mem_bytes = (memory_mib as u64 + CGROUP_MEM_OVERHEAD_MIB) * 1024 * 1024;
-    let _ = write_cgroup(&vm, "memory.max", &mem_bytes.to_string());
+    let memory_limit_bytes = vmm_memory_limit_bytes(memory_mib, cuda);
+    let _ = write_cgroup(&vm, "memory.max", &memory_limit_bytes.to_string());
 
     // Join the leaf last; from here the caps above govern this process tree.
     if let Err(e) = write_cgroup(&vm, "cgroup.procs", &pid.to_string()) {
@@ -504,9 +503,24 @@ pub fn place_in_cgroup(root: &std::path::Path, vcpus: u8, memory_mib: u32) {
         return;
     }
     tracing::info!(
-        vcpus, memory_mib, cgroup = %vm.display(),
+        vcpus, memory_mib, cuda, memory_limit_bytes, cgroup = %vm.display(),
         "placed VMM subprocess in per-VM cgroup with cpu/pids/memory caps"
     );
+}
+
+/// Bound host memory for a VMM while leaving room beyond its configured guest
+/// RAM. CUDA device mappings and forkable memfd-backed guest pages can both be
+/// charged to the VMM cgroup, so CUDA needs room for one additional guest-sized
+/// mapping plus the fixed process overhead. CPU-only VMs retain the tighter
+/// historical guest-plus-overhead cap.
+pub fn vmm_memory_limit_bytes(guest_memory_mib: u32, cuda: bool) -> u64 {
+    let guest = u64::from(guest_memory_mib);
+    let limit_mib = if cuda {
+        guest.saturating_mul(2).saturating_add(VMM_MEM_OVERHEAD_MIB)
+    } else {
+        guest.saturating_add(VMM_MEM_OVERHEAD_MIB)
+    };
+    limit_mib.saturating_mul(1024 * 1024)
 }
 
 /// Bound each CUDA fork-pool VM to its configured CPU count or an even share
@@ -804,7 +818,7 @@ pub fn restrict_filesystem(
 /// Look up the `kvm` group's gid, so it can be kept as a supplementary group
 /// across the privilege drop (the VMM needs `/dev/kvm`).
 #[cfg(target_os = "linux")]
-fn kvm_group_gid() -> Option<libc::gid_t> {
+pub(crate) fn kvm_group_gid() -> Option<libc::gid_t> {
     let grp = unsafe { libc::getgrnam(c"kvm".as_ptr()) };
     if grp.is_null() {
         None
@@ -2579,7 +2593,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn cuda_fork_pool_vcpus_avoids_host_oversubscription() {
+    fn cuda_fork_pool_vcpus_preserve_reliable_guest_topology() {
         assert_eq!(cuda_fork_pool_vcpus(4, 24, 26), 2);
         assert_eq!(cuda_fork_pool_vcpus(4, 8, 26), 3);
         assert_eq!(cuda_fork_pool_vcpus(2, 8, 26), 2);
@@ -2592,6 +2606,45 @@ mod tests {
         assert_eq!(cuda_fork_pool_vcpus(1, 32, 8), 1);
         assert_eq!(cuda_fork_pool_vcpus(0, 1, 0), 1);
         assert_eq!(cuda_fork_pool_vcpus(4, 0, 26), 4);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn cgroup_uses_guest_cpu_and_cuda_memory_limits() {
+        let root = tempfile::tempdir().expect("temp cgroup root");
+        let pid = unsafe { libc::getpid() };
+        let vm = root.path().join(format!("vm-{pid}"));
+        std::fs::create_dir(&vm).expect("create fake VM cgroup");
+        for file in ["cpu.max", "pids.max", "memory.max", "cgroup.procs"] {
+            std::fs::write(vm.join(file), []).expect("create fake cgroup control");
+        }
+
+        place_in_cgroup(root.path(), 2, 1024, true);
+
+        assert_eq!(
+            std::fs::read_to_string(vm.join("cpu.max")).expect("read boot CPU quota"),
+            "200000 100000"
+        );
+        assert_eq!(
+            std::fs::read_to_string(vm.join("cgroup.procs")).expect("read fake membership"),
+            pid.to_string()
+        );
+        assert_eq!(
+            std::fs::read_to_string(vm.join("memory.max")).expect("read memory limit"),
+            ((2 * 1024_u64 + VMM_MEM_OVERHEAD_MIB) * 1024 * 1024).to_string()
+        );
+    }
+
+    #[test]
+    fn cuda_vmm_memory_limit_allows_device_and_memfd_mappings() {
+        assert_eq!(
+            vmm_memory_limit_bytes(8192, true),
+            (2 * 8192_u64 + VMM_MEM_OVERHEAD_MIB) * 1024 * 1024
+        );
+        assert_eq!(
+            vmm_memory_limit_bytes(8192, false),
+            (8192_u64 + VMM_MEM_OVERHEAD_MIB) * 1024 * 1024
+        );
     }
 
     #[test]


### PR DESCRIPTION
Starts the shared CUDA daemon before VMM privilege isolation and applies CUDA-safe process resource limits.