### PR TITLE
Harden CUDA admission calibration

### DIFF
--- a/src/api/admission.rs
+++ b/src/api/admission.rs
@@ -22,6 +22,7 @@ const MIN_VRAM_RESERVE_MIB: u64 = 8 * 1024;
 const VRAM_RESERVE_PERCENT: u64 = 10;
 const CPU_SATURATION_PERCENT: f64 = 90.0;
 const MARGINAL_GAIN_PERCENT: f64 = 2.0;
+const MIN_GPU_ACTIVITY_PERCENT: f64 = 10.0;
 
 /// Telemetry for one host CUDA device.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -128,6 +129,8 @@ struct PoolAdmissionState {
     window_samples: u32,
     gpu_utilization_sum: f64,
     host_cpu_sum: f64,
+    window_peak_gpu_memory_mib: u64,
+    idle_gpu_memory_mib: Option<u64>,
     completed_at_start: u64,
     latest_gpu: Option<GpuSample>,
     latest_host_cpu_percent: Option<f64>,
@@ -163,6 +166,8 @@ impl PoolAdmissionState {
             window_samples: 0,
             gpu_utilization_sum: 0.0,
             host_cpu_sum: 0.0,
+            window_peak_gpu_memory_mib: 0,
+            idle_gpu_memory_mib: None,
             completed_at_start: completed_total,
             latest_gpu: None,
             latest_host_cpu_percent: None,
@@ -177,6 +182,7 @@ impl PoolAdmissionState {
         self.window_samples = 0;
         self.gpu_utilization_sum = 0.0;
         self.host_cpu_sum = 0.0;
+        self.window_peak_gpu_memory_mib = 0;
         self.completed_at_start = completed_total;
     }
 
@@ -196,6 +202,7 @@ impl PoolAdmissionState {
         self.last_lower = None;
         self.settled = self.effective_limit == ceiling;
         self.best_score = None;
+        self.idle_gpu_memory_mib = None;
         self.last_probe = now;
         self.reset_window(now, 0, completed_total);
         self.reason = "pool ceiling changed; restarting calibration".into();
@@ -223,6 +230,7 @@ impl PoolAdmissionState {
             self.last_lower = None;
             self.settled = true;
             self.telemetry_failed_open = true;
+            self.idle_gpu_memory_mib = None;
             self.reason = "GPU telemetry unavailable; using full residency".into();
             self.reset_window(now, active, completed_total);
             return;
@@ -237,6 +245,7 @@ impl PoolAdmissionState {
             self.settled = self.effective_limit == self.ceiling;
             self.last_probe = now;
             self.telemetry_failed_open = false;
+            self.idle_gpu_memory_mib = None;
             self.reason = "GPU telemetry recovered; restarting calibration".into();
             self.reset_window(now, active, completed_total);
             return;
@@ -245,9 +254,16 @@ impl PoolAdmissionState {
         if active != self.observed_active {
             self.reset_window(now, active, completed_total);
         }
+        if active == 0 {
+            self.idle_gpu_memory_mib = Some(
+                self.idle_gpu_memory_mib
+                    .map_or(gpu.used_memory_mib, |idle| idle.min(gpu.used_memory_mib)),
+            );
+        }
         self.window_samples = self.window_samples.saturating_add(1);
         self.gpu_utilization_sum += gpu.utilization_percent;
         self.host_cpu_sum += host_cpu_percent.unwrap_or(0.0);
+        self.window_peak_gpu_memory_mib = self.window_peak_gpu_memory_mib.max(gpu.used_memory_mib);
 
         let elapsed = now.saturating_duration_since(self.window_started);
         if active > self.effective_limit {
@@ -278,7 +294,10 @@ impl PoolAdmissionState {
             gpu_utilization_percent: mean_gpu,
             completion_rate,
         };
-        let memory_safe = gpu.memory_safe();
+        let observed_free_mib = gpu
+            .total_memory_mib
+            .saturating_sub(self.window_peak_gpu_memory_mib);
+        let memory_safe = gpu.memory_safe() && observed_free_mib >= gpu.reserve_mib;
         let cpu_safe = mean_cpu < CPU_SATURATION_PERCENT;
 
         if let Some((prior_limit, prior_score)) = self.testing_from.take() {
@@ -292,7 +311,7 @@ impl PoolAdmissionState {
                 self.reason = if !memory_safe {
                     format!(
                         "returned to {prior_limit}: limiting GPU has {} MiB free; preserving {} MiB reserve",
-                        gpu.free_memory_mib,
+                        observed_free_mib,
                         gpu.reserve_mib
                     )
                 } else if !cpu_safe {
@@ -328,7 +347,7 @@ impl PoolAdmissionState {
                 self.reason = if !memory_safe {
                     format!(
                         "returned to {lower_limit}: limiting GPU has {} MiB free; preserving {} MiB reserve",
-                        gpu.free_memory_mib,
+                        observed_free_mib,
                         gpu.reserve_mib
                     )
                 } else {
@@ -340,8 +359,29 @@ impl PoolAdmissionState {
         }
 
         if !self.settled && self.has_pressure(now) && memory_safe && cpu_safe {
+            if completion_rate.is_none() && mean_gpu < MIN_GPU_ACTIVITY_PERCENT {
+                self.reason = format!(
+                    "waiting for CUDA activity or a completion before probing beyond {}",
+                    self.effective_limit
+                );
+                self.reset_window(now, active, completed_total);
+                return;
+            }
             let next = self.effective_limit.saturating_mul(2).min(self.ceiling);
             if next > self.effective_limit {
+                let projected_free_mib = self
+                    .projected_free_memory_mib(gpu, active, next)
+                    .unwrap_or(observed_free_mib);
+                if projected_free_mib < gpu.reserve_mib {
+                    self.settled = true;
+                    self.last_probe = now;
+                    self.reason = format!(
+                        "holding at {}: projected limit {next} leaves {projected_free_mib} MiB free; preserving {} MiB reserve",
+                        self.effective_limit, gpu.reserve_mib
+                    );
+                    self.reset_window(now, active, completed_total);
+                    return;
+                }
                 self.testing_from = Some((self.effective_limit, score));
                 self.effective_limit = next;
                 self.reason = format!("probing resident limit {next}");
@@ -355,7 +395,7 @@ impl PoolAdmissionState {
         self.reason = if !memory_safe {
             format!(
                 "holding at {}: limiting GPU has {} MiB free; preserving {} MiB reserve",
-                self.effective_limit, gpu.free_memory_mib, gpu.reserve_mib
+                self.effective_limit, observed_free_mib, gpu.reserve_mib
             )
         } else if !cpu_safe {
             format!(
@@ -366,6 +406,35 @@ impl PoolAdmissionState {
             format!("settled at resident limit {}", self.effective_limit)
         };
         self.reset_window(now, active, completed_total);
+    }
+
+    fn projected_free_memory_mib(
+        &self,
+        gpu: GpuSample,
+        active: u32,
+        candidate: u32,
+    ) -> Option<u64> {
+        if active == 0 || candidate <= active {
+            return None;
+        }
+        let peak = self.window_peak_gpu_memory_mib.max(gpu.used_memory_mib);
+        // If no usable idle sample survived a restart, treating all current
+        // memory as active-job memory is deliberately conservative until the
+        // device next reaches zero active leases. An idle sample at or above
+        // the active peak is stale (for example, an unrelated process exited)
+        // and must not collapse the projected worker footprint to zero.
+        let active_memory = self
+            .idle_gpu_memory_mib
+            .filter(|idle| *idle < peak)
+            .map_or(peak, |idle| peak - idle);
+        let additional_workers = u64::from(candidate - active);
+        let projected_additional = active_memory
+            .saturating_mul(additional_workers)
+            .div_ceil(u64::from(active));
+        Some(
+            gpu.total_memory_mib
+                .saturating_sub(peak.saturating_add(projected_additional)),
+        )
     }
 
     fn snapshot(&self) -> AdmissionSnapshot {
@@ -1341,6 +1410,125 @@ mod tests {
         );
         assert_eq!(pool_limit(&registry, &pool), Some(8));
         assert!(!registry.snapshot(&pool).unwrap().calibrating);
+    }
+
+    #[test]
+    fn cold_cuda_startup_matures_before_projecting_the_next_limit() {
+        let registry = AdmissionRegistry::default();
+        let pool = pool(24);
+        let start = Instant::now();
+        registry.observe_at(&pool, 0, 0, gpu(0.0, 39_719), Some(10.0), start);
+        registry.note_blocked("rollouts");
+
+        // CUDA workloads can spend their first window creating framework and
+        // optimizer state on the CPU. The partial allocation visible in that
+        // window is not a safe basis for doubling residency.
+        stable_window(&registry, &pool, start, (8, 0, 0.0, 50_438, 53.0));
+        assert_eq!(pool_limit(&registry, &pool), Some(8));
+        let waiting = registry.snapshot(&pool).unwrap();
+        assert!(waiting.calibrating);
+        assert!(waiting.reason.contains("waiting for CUDA activity"));
+
+        // Once CUDA is active, the mature eight-worker footprint projects a
+        // 16-worker candidate below the device reserve, so calibration settles
+        // without releasing the unsafe wave.
+        stable_window(
+            &registry,
+            &pool,
+            start + Duration::from_secs(8),
+            (8, 0, 90.0, 58_119, 65.0),
+        );
+        assert_eq!(pool_limit(&registry, &pool), Some(8));
+        let settled = registry.snapshot(&pool).unwrap();
+        assert!(!settled.calibrating);
+        assert!(
+            settled.reason.contains("projected limit 16"),
+            "{}",
+            settled.reason
+        );
+        assert!(settled.reason.contains("preserving 8192 MiB reserve"));
+    }
+
+    #[test]
+    fn calibration_without_an_idle_sample_projects_conservatively() {
+        let registry = AdmissionRegistry::default();
+        let pool = pool(12);
+        let start = Instant::now();
+        registry.ensure_pools(&[(pool.clone(), 4, 0)]);
+        registry.note_blocked("rollouts");
+
+        stable_window(&registry, &pool, start, (4, 0, 60.0, 45_000, 50.0));
+        assert_eq!(pool_limit(&registry, &pool), Some(4));
+        let snapshot = registry.snapshot(&pool).unwrap();
+        assert!(!snapshot.calibrating);
+        assert!(snapshot.reason.contains("projected limit 8"));
+    }
+
+    #[test]
+    fn stale_idle_baseline_projects_conservatively() {
+        let registry = AdmissionRegistry::default();
+        let pool = pool(12);
+        let start = Instant::now();
+        registry.observe_at(&pool, 0, 0, gpu(0.0, 50_000), Some(10.0), start);
+        registry.note_blocked("rollouts");
+
+        // GPU usage can fall below the recorded idle baseline when an
+        // unrelated process exits. Do not interpret that stale baseline as a
+        // zero-byte worker footprint and release another residency wave.
+        stable_window(&registry, &pool, start, (4, 0, 60.0, 45_000, 50.0));
+        assert_eq!(pool_limit(&registry, &pool), Some(4));
+        let snapshot = registry.snapshot(&pool).unwrap();
+        assert!(!snapshot.calibrating);
+        assert!(snapshot.reason.contains("projected limit 8"));
+    }
+
+    #[test]
+    fn a_completed_cpu_heavy_job_is_a_mature_calibration_signal() {
+        let registry = AdmissionRegistry::default();
+        let pool = pool(12);
+        let start = Instant::now();
+        registry.observe_at(&pool, 0, 0, gpu(0.0, 10_000), Some(10.0), start);
+        registry.note_blocked("rollouts");
+
+        for second in 0..=8 {
+            registry.observe_at(
+                &pool,
+                4,
+                u64::from(second == 8),
+                gpu(0.0, 20_000),
+                Some(50.0),
+                start + Duration::from_secs(second),
+            );
+        }
+        assert_eq!(pool_limit(&registry, &pool), Some(8));
+    }
+
+    #[test]
+    fn memory_safety_uses_the_observation_window_peak() {
+        let registry = AdmissionRegistry::default();
+        let pool = pool(12);
+        let start = Instant::now();
+        registry.observe_at(&pool, 0, 0, gpu(0.0, 10_000), Some(10.0), start);
+        registry.note_blocked("rollouts");
+
+        for second in 0..=8 {
+            let used = if second == 4 { 75 * 1024 } else { 30_000 };
+            registry.observe_at(
+                &pool,
+                4,
+                0,
+                gpu(50.0, used),
+                Some(50.0),
+                start + Duration::from_secs(second),
+            );
+        }
+
+        assert_eq!(pool_limit(&registry, &pool), Some(4));
+        let reason = registry.snapshot(&pool).unwrap().reason;
+        assert!(
+            reason.contains("limiting GPU has 5120 MiB free"),
+            "{reason}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Wait for mature CUDA activity and preserve projected VRAM headroom before expanding automatic pool residency.