### PR TITLE
Persist CUDA pool refill checkpoints

### DIFF
--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -183,7 +183,7 @@ pub struct PreparedFork {
 /// A checkpoint that may be reused while the exact same golden process remains
 /// paused. The PID start time prevents an old on-disk checkpoint from being
 /// applied after a golden restart or PID reuse.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub(crate) struct RetainedForkSnapshot {
     /// Directory containing the libkrun checkpoint and memfd manifest.
     pub(crate) path: PathBuf,
@@ -287,7 +287,7 @@ pub fn prepare_forks(
     golden: &str,
     specs: &[ForkSpec<'_>],
 ) -> Result<Vec<PreparedFork>> {
-    Ok(prepare_forks_reusing(db, golden, specs, None)?.forks)
+    Ok(prepare_forks_reusing(db, golden, specs, None, false)?.forks)
 }
 
 /// Prepare a batch while reusing a proven checkpoint when it still belongs to
@@ -298,6 +298,7 @@ pub(crate) fn prepare_forks_reusing(
     golden: &str,
     specs: &[ForkSpec<'_>],
     retained: Option<&RetainedForkSnapshot>,
+    persist_snapshot: bool,
 ) -> Result<PreparedForkBatch> {
     if specs.is_empty() {
         return Err(Error::config("fork", "at least one clone is required"));
@@ -432,6 +433,41 @@ pub(crate) fn prepare_forks_reusing(
         (snapshot_dir, false)
     };
 
+    let retained_snapshot =
+        golden_rec
+            .pid
+            .zip(golden_rec.pid_start_time)
+            .map(|(golden_pid, golden_pid_start_time)| RetainedForkSnapshot {
+                path: snapshot_dir.clone(),
+                golden_pid,
+                golden_pid_start_time,
+            });
+    if persist_snapshot && !snapshot_reused {
+        let persisted = retained_snapshot
+            .as_ref()
+            .ok_or_else(|| {
+                Error::agent(
+                    "fork",
+                    format!("golden '{golden}' process identity is unavailable"),
+                )
+            })
+            .and_then(|snapshot| {
+                db.set_fork_pool_snapshot(golden, snapshot)
+                    .map_err(|error| {
+                        Error::agent("persist fork pool checkpoint", error.to_string())
+                    })
+            });
+        if let Err(error) = persisted {
+            return Err(rollback_new_snapshot(
+                db,
+                golden,
+                &snapshot_dir,
+                false,
+                error,
+            ));
+        }
+    }
+
     let mut prepared = Vec::with_capacity(specs.len());
     for spec in specs {
         match prepare_clone_from_snapshot(
@@ -452,38 +488,48 @@ pub(crate) fn prepare_forks_reusing(
                     let _ = db.remove_vm(&clone.clone_record.name);
                     let _ = std::fs::remove_dir_all(vm_data_dir(&clone.clone_record.name));
                 }
-                if !snapshot_reused {
-                    let _ = std::fs::remove_dir_all(&snapshot_dir);
-                }
-                if golden_was_paused {
+                if snapshot_reused || golden_was_paused {
                     return Err(error);
                 }
-                return match resume_golden(golden) {
-                    Ok(()) => Err(error),
-                    Err(resume_error) => Err(Error::agent(
-                        "fork",
-                        format!(
-                            "clone preparation failed: {error}; golden rollback also failed: {resume_error}"
-                        ),
-                    )),
-                };
+                return Err(rollback_new_snapshot(
+                    db,
+                    golden,
+                    &snapshot_dir,
+                    persist_snapshot,
+                    error,
+                ));
             }
         }
     }
-    let retained_snapshot =
-        golden_rec
-            .pid
-            .zip(golden_rec.pid_start_time)
-            .map(|(golden_pid, golden_pid_start_time)| RetainedForkSnapshot {
-                path: snapshot_dir,
-                golden_pid,
-                golden_pid_start_time,
-            });
     Ok(PreparedForkBatch {
         forks: prepared,
         retained_snapshot,
         snapshot_reused,
     })
+}
+
+fn rollback_new_snapshot(
+    db: &SmolvmDb,
+    golden: &str,
+    snapshot_dir: &Path,
+    persisted: bool,
+    error: Error,
+) -> Error {
+    if let Err(resume_error) = resume_golden(golden) {
+        return Error::agent(
+            "fork",
+            format!("{error}; golden rollback also failed: {resume_error}"),
+        );
+    }
+    if persisted {
+        if let Err(remove_error) = db.remove_fork_pool_snapshot(golden) {
+            tracing::warn!(%golden, %remove_error, "failed to remove rolled-back fork pool checkpoint");
+        }
+    }
+    if let Err(remove_error) = std::fs::remove_dir_all(snapshot_dir) {
+        tracing::warn!(path = %snapshot_dir.display(), %remove_error, "failed to remove rolled-back fork snapshot");
+    }
+    error
 }
 
 fn reusable_snapshot_path(snapshot_root: &Path, snapshot: &Path) -> bool {

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -1463,6 +1463,7 @@ pub(crate) async fn fork_held_machines_inner(
                 &golden_for_prep,
                 &specs,
                 retained_snapshot.as_ref(),
+                true,
             )
         })
         .await
@@ -1473,7 +1474,7 @@ pub(crate) async fn fork_held_machines_inner(
     let snapshot_dir = prepared.forks[0].snapshot_dir.clone();
     let resume_golden_on_rollback = prepared.forks[0].resume_golden_on_rollback;
     let snapshot_reused = prepared.snapshot_reused;
-    let reusable_snapshot = prepared.retained_snapshot;
+    let reusable_snapshot = prepared.retained_snapshot.clone();
     let pending_boots = prepared.forks.len();
     let boot_slots = Arc::new(tokio::sync::Semaphore::new(max_parallel.max(1)));
     let boots = prepared.forks.into_iter().zip(clones).map(|(prep, clone)| {
@@ -1520,13 +1521,20 @@ pub(crate) async fn fork_held_machines_inner(
     // If every restore failed, no clone depends on this checkpoint and an
     // initially-running golden can safely resume for a later retry. A partial
     // success must retain the paused golden and shared snapshot.
+    let mut rollback_completed = true;
     if !any_succeeded && !snapshot_reused {
-        if let Err(error) = std::fs::remove_dir_all(&snapshot_dir) {
-            tracing::warn!(path = %snapshot_dir.display(), %error, "failed to remove unused batch fork snapshot");
-        }
         if resume_golden_on_rollback {
             if let Err(error) = crate::agent::fork::resume_golden(&golden) {
                 tracing::warn!(%golden, %error, "failed to resume golden after batch restore failure");
+                rollback_completed = false;
+            }
+        }
+        if rollback_completed {
+            if let Err(error) = state.db().remove_fork_pool_snapshot(&golden) {
+                tracing::warn!(%golden, %error, "failed to remove rolled-back fork pool checkpoint");
+            }
+            if let Err(error) = std::fs::remove_dir_all(&snapshot_dir) {
+                tracing::warn!(path = %snapshot_dir.display(), %error, "failed to remove unused batch fork snapshot");
             }
         }
     }
@@ -1536,6 +1544,7 @@ pub(crate) async fn fork_held_machines_inner(
         retained_snapshot: retained_snapshot_after_boots(
             snapshot_reused,
             any_succeeded,
+            rollback_completed,
             reusable_snapshot,
         ),
     })
@@ -1544,12 +1553,13 @@ pub(crate) async fn fork_held_machines_inner(
 fn retained_snapshot_after_boots(
     snapshot_reused: bool,
     any_succeeded: bool,
+    rollback_completed: bool,
     reusable_snapshot: Option<crate::agent::fork::RetainedForkSnapshot>,
 ) -> Option<crate::agent::fork::RetainedForkSnapshot> {
     // A failed boot does not invalidate a checkpoint that preparation just
     // verified against the paused golden. Keep it so a transient KVM or guest
     // readiness failure cannot strand that golden without a refill path.
-    (snapshot_reused || any_succeeded)
+    (snapshot_reused || any_succeeded || !rollback_completed)
         .then_some(reusable_snapshot)
         .flatten()
 }
@@ -2700,7 +2710,7 @@ mod tests {
     fn failed_reused_checkpoint_remains_available_for_retry() {
         let snapshot = retained_snapshot();
         assert_eq!(
-            retained_snapshot_after_boots(true, false, Some(snapshot.clone())),
+            retained_snapshot_after_boots(true, false, true, Some(snapshot.clone())),
             Some(snapshot)
         );
     }
@@ -2708,7 +2718,7 @@ mod tests {
     #[test]
     fn failed_new_checkpoint_is_not_retained() {
         assert_eq!(
-            retained_snapshot_after_boots(false, false, Some(retained_snapshot())),
+            retained_snapshot_after_boots(false, false, true, Some(retained_snapshot())),
             None
         );
     }
@@ -2717,7 +2727,16 @@ mod tests {
     fn successful_new_checkpoint_is_retained() {
         let snapshot = retained_snapshot();
         assert_eq!(
-            retained_snapshot_after_boots(false, true, Some(snapshot.clone())),
+            retained_snapshot_after_boots(false, true, true, Some(snapshot.clone())),
+            Some(snapshot)
+        );
+    }
+
+    #[test]
+    fn failed_new_checkpoint_remains_available_when_rollback_fails() {
+        let snapshot = retained_snapshot();
+        assert_eq!(
+            retained_snapshot_after_boots(false, false, false, Some(snapshot.clone())),
             Some(snapshot)
         );
     }

--- a/src/api/pool_controller.rs
+++ b/src/api/pool_controller.rs
@@ -43,6 +43,21 @@ impl ForkPoolController {
                 None
             }
         };
+        let retained_snapshots = match state.db().list_fork_pool_snapshots() {
+            Ok(snapshots) => {
+                if !snapshots.is_empty() {
+                    tracing::info!(
+                        count = snapshots.len(),
+                        "restored retained fork pool checkpoints"
+                    );
+                }
+                snapshots.into_iter().collect()
+            }
+            Err(error) => {
+                tracing::warn!(%error, "failed to restore retained fork pool checkpoints");
+                std::collections::HashMap::new()
+            }
+        };
         Self {
             state,
             shutdown_rx,
@@ -50,7 +65,7 @@ impl ForkPoolController {
             filling: std::collections::HashSet::new(),
             nvml,
             host_cpu: crate::api::admission::HostCpuSampler::default(),
-            retained_snapshots: Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new())),
+            retained_snapshots: Arc::new(parking_lot::Mutex::new(retained_snapshots)),
         }
     }
 
@@ -208,9 +223,33 @@ impl ForkPoolController {
             .filter(|pool| !pool.deleting)
             .map(|pool| pool.golden.as_str())
             .collect::<std::collections::HashSet<_>>();
-        self.retained_snapshots
-            .lock()
-            .retain(|golden, _| active_goldens.contains(golden.as_str()));
+        let stale_snapshots = {
+            let mut snapshots = self.retained_snapshots.lock();
+            let stale = snapshots
+                .keys()
+                .filter(|golden| !active_goldens.contains(golden.as_str()))
+                .cloned()
+                .collect::<Vec<_>>();
+            snapshots.retain(|golden, _| active_goldens.contains(golden.as_str()));
+            stale
+        };
+        if !stale_snapshots.is_empty() {
+            let db = self.state.db().clone();
+            match tokio::task::spawn_blocking(move || {
+                for golden in stale_snapshots {
+                    if let Err(error) = db.remove_fork_pool_snapshot(&golden) {
+                        tracing::warn!(%golden, %error, "failed to remove inactive fork pool checkpoint");
+                    }
+                }
+            })
+            .await
+            {
+                Ok(()) => {}
+                Err(error) => {
+                    tracing::warn!(%error, "inactive fork pool checkpoint cleanup task failed");
+                }
+            }
+        }
         self.update_admission(&pools, sample_admission).await?;
         for pool in pools.into_iter().filter(|pool| !pool.deleting) {
             if self.filling.contains(&pool.name) {

--- a/src/db.rs
+++ b/src/db.rs
@@ -270,6 +270,10 @@ impl SmolvmDb {
                  name TEXT PRIMARY KEY NOT NULL,
                  data BLOB NOT NULL
              );
+             CREATE TABLE IF NOT EXISTS fork_pool_snapshots (
+                 golden TEXT PRIMARY KEY NOT NULL,
+                 data BLOB NOT NULL
+             );
              CREATE TABLE IF NOT EXISTS fork_pool_slots (
                  machine_name TEXT PRIMARY KEY NOT NULL,
                  pool_name TEXT NOT NULL,
@@ -695,6 +699,61 @@ impl SmolvmDb {
                 pools.push(serde_json::from_slice(&bytes).db_err("deserialize fork pool")?);
             }
             Ok(pools)
+        })
+    }
+
+    /// Durably publish the RAM checkpoint that can refill pools for one golden.
+    pub(crate) fn set_fork_pool_snapshot(
+        &self,
+        golden: &str,
+        snapshot: &crate::agent::fork::RetainedForkSnapshot,
+    ) -> Result<()> {
+        let data = serde_json::to_vec(snapshot).db_err("serialize fork pool snapshot")?;
+        self.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO fork_pool_snapshots (golden, data) VALUES (?1, ?2)
+                 ON CONFLICT(golden) DO UPDATE SET data = excluded.data",
+                params![golden, data],
+            )
+            .db_err(format!("set fork pool snapshot for '{golden}'"))?;
+            Ok(())
+        })
+    }
+
+    /// Load every retained pool checkpoint after a controller restart.
+    pub(crate) fn list_fork_pool_snapshots(
+        &self,
+    ) -> Result<Vec<(String, crate::agent::fork::RetainedForkSnapshot)>> {
+        self.with_read_conn(|conn| {
+            let mut stmt = conn
+                .prepare_cached("SELECT golden, data FROM fork_pool_snapshots ORDER BY golden")
+                .db_err("prepare list fork pool snapshots")?;
+            let rows = stmt
+                .query_map([], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, Vec<u8>>(1)?))
+                })
+                .db_err("query fork pool snapshots")?;
+            let mut snapshots = Vec::new();
+            for row in rows {
+                let (golden, data) = row.db_err("read fork pool snapshot row")?;
+                let snapshot = serde_json::from_slice(&data)
+                    .db_err(format!("deserialize fork pool snapshot for '{golden}'"))?;
+                snapshots.push((golden, snapshot));
+            }
+            Ok(snapshots)
+        })
+    }
+
+    /// Forget a checkpoint only after its golden is resumed or no pool can use it.
+    pub(crate) fn remove_fork_pool_snapshot(&self, golden: &str) -> Result<bool> {
+        self.with_conn(|conn| {
+            let changed = conn
+                .execute(
+                    "DELETE FROM fork_pool_snapshots WHERE golden = ?1",
+                    params![golden],
+                )
+                .db_err(format!("remove fork pool snapshot for '{golden}'"))?;
+            Ok(changed == 1)
         })
     }
 
@@ -2015,6 +2074,27 @@ mod tests {
         assert_eq!(value, "test_value");
 
         assert!(db.get_config("nonexistent").unwrap().is_none());
+    }
+
+    #[test]
+    fn fork_pool_snapshot_survives_database_reopen_and_can_be_removed() {
+        let (dir, db) = temp_db();
+        let snapshot = crate::agent::fork::RetainedForkSnapshot {
+            path: PathBuf::from("/golden/s/12345678"),
+            golden_pid: 123,
+            golden_pid_start_time: 456,
+        };
+        db.set_fork_pool_snapshot("golden", &snapshot).unwrap();
+        drop(db);
+
+        let reopened = SmolvmDb::open_at(&dir.path().join("test.db")).unwrap();
+        assert_eq!(
+            reopened.list_fork_pool_snapshots().unwrap(),
+            vec![("golden".to_string(), snapshot)]
+        );
+        assert!(reopened.remove_fork_pool_snapshot("golden").unwrap());
+        assert!(reopened.list_fork_pool_snapshots().unwrap().is_empty());
+        assert!(!reopened.remove_fork_pool_snapshot("golden").unwrap());
     }
 
     #[test]


### PR DESCRIPTION
Restore verified retained checkpoints after controller restarts so CUDA pools continue refilling without recreating or stranding their golden.