### PR TITLE
Add fused Unsloth rollout executor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,19 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
+  python-rollout-sdk:
+    name: Python rollout SDK
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+      - name: Run rollout SDK tests
+        env:
+          PYTHONPATH: sdks/python/src
+        run: python -W error::ResourceWarning -m unittest discover -s sdks/python/tests -v
+
   secrets-guards:
     name: Secrets invariants
     runs-on: ubuntu-latest

--- a/sdks/python/src/smolvm_rollout/__init__.py
+++ b/sdks/python/src/smolvm_rollout/__init__.py
@@ -8,6 +8,7 @@ from .device_handoff import (
     publish_device_adapter,
 )
 from .torch_handoff import TorchDeviceAdapter, import_torch_device_adapter
+from .transformers import add_transformers_forkpoint, transformers_forkpoint_callback
 from .unsloth_vllm import UnslothVllmExecutor
 
 __all__ = [
@@ -19,6 +20,8 @@ __all__ = [
     "TorchDeviceAdapter",
     "UnslothVllmExecutor",
     "adapter_sha256",
+    "add_transformers_forkpoint",
     "publish_device_adapter",
     "import_torch_device_adapter",
+    "transformers_forkpoint_callback",
 ]

--- a/sdks/python/src/smolvm_rollout/__init__.py
+++ b/sdks/python/src/smolvm_rollout/__init__.py
@@ -8,6 +8,7 @@ from .device_handoff import (
     publish_device_adapter,
 )
 from .torch_handoff import TorchDeviceAdapter, import_torch_device_adapter
+from .unsloth_vllm import UnslothVllmExecutor
 
 __all__ = [
     "DeviceAdapterBundle",
@@ -16,6 +17,7 @@ __all__ = [
     "RolloutClient",
     "RolloutError",
     "TorchDeviceAdapter",
+    "UnslothVllmExecutor",
     "adapter_sha256",
     "publish_device_adapter",
     "import_torch_device_adapter",

--- a/sdks/python/src/smolvm_rollout/client.py
+++ b/sdks/python/src/smolvm_rollout/client.py
@@ -346,6 +346,8 @@ class RolloutClient:
         version: str | None = None,
         n: int = 1,
         deadline_ms: int | None = None,
+        cohort_id: str | None = None,
+        cohort_size: int | None = None,
         **sampling: Any,
     ) -> dict[str, Any]:
         """Build a generation job for `generate` or a cross-policy cohort."""
@@ -377,6 +379,16 @@ class RolloutClient:
             job["version"] = version
         if deadline_ms is not None:
             job["deadlineMs"] = deadline_ms
+        if (cohort_id is None) != (cohort_size is None):
+            raise ValueError("cohort_id and cohort_size must be set together")
+        if cohort_id is not None:
+            if not cohort_id:
+                raise ValueError("cohort_id cannot be empty")
+            if not isinstance(cohort_size, int) or isinstance(cohort_size, bool):
+                raise ValueError("cohort_size must be an integer")
+            if not 1 <= cohort_size <= 256:
+                raise ValueError("cohort_size must be between 1 and 256")
+            job["cohort"] = {"id": cohort_id, "size": cohort_size}
         return job
 
     def generate(self, **job: Any) -> dict[str, Any]:

--- a/sdks/python/src/smolvm_rollout/device_handoff.py
+++ b/sdks/python/src/smolvm_rollout/device_handoff.py
@@ -274,6 +274,12 @@ class DeviceAdapterServer:
         self._ready = threading.Event()
         self._startup_error: BaseException | None = None
 
+    @property
+    def ready(self) -> bool:
+        """Return whether the private socket has completed bind and listen."""
+
+        return self._listener is not None
+
     def serve_forever(self) -> None:
         """Bind the private socket and process requests until ``shutdown``."""
 
@@ -314,12 +320,10 @@ class DeviceAdapterServer:
             if listener is not None:
                 listener.close()
             _remove_owned_socket(self.path, socket_identity)
-            for model in tuple(self._loaded):
-                try:
-                    self._unload(model)
-                except Exception as error:
-                    if cleanup_error is None:
-                        cleanup_error = error
+            try:
+                self.drain()
+            except Exception as error:
+                cleanup_error = error
         if cleanup_error is not None:
             raise cleanup_error
 
@@ -341,10 +345,31 @@ class DeviceAdapterServer:
         self._stopping.set()
         listener = self._listener
         if listener is not None:
+            wake = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            wake.settimeout(0.1)
+            try:
+                wake.connect(str(self.path))
+            except OSError:
+                pass
+            finally:
+                wake.close()
             try:
                 listener.close()
             except OSError:
                 pass
+
+    def drain(self) -> None:
+        """Unload every retained mapping, preserving failures for a safe retry."""
+
+        first_error: Exception | None = None
+        for model in tuple(self._loaded):
+            try:
+                self._unload(model)
+            except Exception as error:
+                if first_error is None:
+                    first_error = error
+        if first_error is not None:
+            raise first_error
 
     def _serve_one(self, connection: socket.socket) -> None:
         descriptor = -1

--- a/sdks/python/src/smolvm_rollout/transformers.py
+++ b/sdks/python/src/smolvm_rollout/transformers.py
@@ -1,0 +1,90 @@
+"""Transformers integration for prepared smolvm forkpoints."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Sequence
+
+
+_ENV_KEY = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def _read_fork_env(path: Path) -> dict[str, str]:
+    if not path.is_file():
+        return {}
+
+    values = {}
+    for line_number, line in enumerate(path.read_text().splitlines(), 1):
+        if not line:
+            continue
+        key, separator, value = line.partition("=")
+        if not separator or _ENV_KEY.fullmatch(key) is None:
+            raise ValueError(f"invalid fork environment at {path}:{line_number}")
+        values[key] = value
+    return values
+
+
+def transformers_forkpoint_callback(
+    *,
+    command: str | Sequence[str] = "smolvm-fork-ready",
+    env_path: str | Path = "/etc/smolvm/fork-env",
+    reseed: bool = True,
+    preload_cuda_modules: bool = True,
+):
+    """Fork after trainer preparation and preload clone CUDA modules by default."""
+    try:
+        from transformers import TrainerCallback, set_seed
+    except ImportError as error:
+        raise RuntimeError(
+            "transformers_forkpoint_callback requires the transformers package"
+        ) from error
+
+    argv = (command,) if isinstance(command, str) else tuple(command)
+    if not argv or any(not isinstance(value, str) or not value for value in argv):
+        raise ValueError("forkpoint command must contain non-empty strings")
+    if preload_cuda_modules and "--cuda-preload-modules" not in argv:
+        argv += ("--cuda-preload-modules",)
+    fork_env_path = Path(env_path)
+
+    class SmolvmTrainerForkpointCallback(TrainerCallback):
+        def __init__(self):
+            self.released = False
+            self.fork_env: dict[str, str] = {}
+            self.seed: int | None = None
+
+        def on_train_begin(self, args, _state, control, **_kwargs):
+            if self.released:
+                return control
+
+            subprocess.run(argv, check=True)
+            self.released = True
+            self.fork_env = _read_fork_env(fork_env_path)
+            os.environ.update(self.fork_env)
+
+            if reseed:
+                seed_text = self.fork_env.get("SMOLVM_FORK_SEED")
+                if seed_text is None:
+                    index = self.fork_env.get("SMOLVM_FORK_INDEX")
+                    if index is not None:
+                        seed_text = str(int(getattr(args, "seed", 0) or 0) + int(index))
+                if seed_text is not None:
+                    self.seed = int(seed_text) % (2**32)
+                    set_seed(self.seed)
+                    if hasattr(args, "seed"):
+                        args.seed = self.seed
+                    if hasattr(args, "data_seed"):
+                        args.data_seed = self.seed
+
+            return control
+
+    return SmolvmTrainerForkpointCallback()
+
+
+def add_transformers_forkpoint(trainer, **options):
+    """Attach the prepared forkpoint callback to a Transformers trainer."""
+    callback = transformers_forkpoint_callback(**options)
+    trainer.add_callback(callback)
+    return callback

--- a/sdks/python/src/smolvm_rollout/unsloth_vllm.py
+++ b/sdks/python/src/smolvm_rollout/unsloth_vllm.py
@@ -854,19 +854,26 @@ class UnslothVllmExecutor:
                     begin = len(prompts)
                     prompts.extend(body["prompt"])
                     requests.extend([record.request] * len(body["prompt"]))
-                    parameters = self._sampling_factory(
-                        n=body.get("n", 1),
-                        max_tokens=body["max_tokens"],
-                        temperature=body.get("temperature", 1.0),
-                        top_p=body.get("top_p", 1.0),
-                        top_k=body.get("top_k", -1),
-                        min_p=body.get("min_p", 0.0),
-                        repetition_penalty=body.get("repetition_penalty", 1.0),
-                        seed=body.get("seed"),
-                        logprobs=body.get("logprobs"),
-                        prompt_logprobs=body.get("prompt_logprobs"),
-                    )
-                    sampling.extend([parameters] * len(body["prompt"]))
+                    seed = body.get("seed")
+                    for prompt_index in range(len(body["prompt"])):
+                        sampling.append(
+                            self._sampling_factory(
+                                n=body.get("n", 1),
+                                max_tokens=body["max_tokens"],
+                                temperature=body.get("temperature", 1.0),
+                                top_p=body.get("top_p", 1.0),
+                                top_k=body.get("top_k", -1),
+                                min_p=body.get("min_p", 0.0),
+                                repetition_penalty=body.get(
+                                    "repetition_penalty", 1.0
+                                ),
+                                seed=(
+                                    None if seed is None else seed + prompt_index
+                                ),
+                                logprobs=body.get("logprobs"),
+                                prompt_logprobs=body.get("prompt_logprobs"),
+                            )
+                        )
                     slices.append((call, begin, len(prompts)))
                 outputs = self.model.fast_generate(
                     prompts,

--- a/sdks/python/src/smolvm_rollout/unsloth_vllm.py
+++ b/sdks/python/src/smolvm_rollout/unsloth_vllm.py
@@ -169,7 +169,7 @@ class UnslothVllmExecutor:
         host: str = "127.0.0.1",
         port: int = 8000,
         model_lock: Any | None = None,
-        batch_window_ms: float = 2.0,
+        batch_window_ms: float = 5.0,
         max_batch_requests: int = 64,
         max_batch_prompts: int = 4096,
         max_queue_depth: int = 256,

--- a/sdks/python/src/smolvm_rollout/unsloth_vllm.py
+++ b/sdks/python/src/smolvm_rollout/unsloth_vllm.py
@@ -1,0 +1,957 @@
+"""Managed, continuously batched rollout endpoint for an embedded Unsloth vLLM."""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import math
+import socket
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Callable
+
+from .device_handoff import DeviceAdapterBundle, DeviceAdapterServer
+from .torch_handoff import import_torch_device_adapter
+
+
+_MAX_BODY_BYTES = 64 * 1024 * 1024
+_MAX_PROMPTS_PER_REQUEST = 4096
+_MAX_PROMPT_TEXT_BYTES = 16 * 1024 * 1024
+_MAX_PROMPT_TOKENS = 1_048_576
+_MAX_COMPLETION_TOKENS = 65_536
+_ADAPTER_ID_BASE = 1_000_000_000
+
+
+class _HttpError(Exception):
+    def __init__(self, status: int, message: str) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+class _InstallRollbackFailure(RuntimeError):
+    pass
+
+
+@dataclass
+class _AdapterRecord:
+    request: Any
+    source: str
+
+
+@dataclass
+class _DeviceOwner:
+    imported: Any
+    request: Any
+
+    def close(self) -> None:
+        self.imported.close()
+
+
+class _PendingCall:
+    def __init__(self, body: dict[str, Any], prompt_kind: str) -> None:
+        self.body = body
+        self.prompt_kind = prompt_kind
+        self.done = threading.Event()
+        self.response: dict[str, Any] | None = None
+        self.error: Exception | None = None
+        self.cancelled = False
+
+
+class _RolloutHttpServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(self, address: tuple[str, int], executor: "UnslothVllmExecutor") -> None:
+        self.executor = executor
+        self.request_queue_size = min(max(16, executor.max_queue_depth), 4096)
+        if ":" in address[0]:
+            self.address_family = socket.AF_INET6
+        super().__init__(address, _RolloutHandler)
+
+
+class _RolloutHandler(BaseHTTPRequestHandler):
+    server: _RolloutHttpServer
+
+    def setup(self) -> None:
+        super().setup()
+        self.connection.settimeout(min(self.server.executor.request_timeout, 30.0))
+
+    def log_message(self, _format: str, *_args: Any) -> None:
+        return
+
+    def _json(self, status: int, payload: Any) -> None:
+        body = json.dumps(payload, separators=(",", ":")).encode()
+        self.send_response(status)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _body(self) -> dict[str, Any]:
+        try:
+            length = int(self.headers.get("content-length", "0"))
+        except ValueError as error:
+            raise _HttpError(400, "invalid content-length") from error
+        if length <= 0 or length > _MAX_BODY_BYTES:
+            raise _HttpError(400, "request body is empty or exceeds its size limit")
+        try:
+            body = json.loads(self.rfile.read(length))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise _HttpError(400, "request body must be JSON") from error
+        if not isinstance(body, dict):
+            raise _HttpError(400, "request body must be an object")
+        return body
+
+    def do_GET(self) -> None:
+        if self.path == "/health":
+            try:
+                self.server.executor._health()
+                self._json(200, {"status": "ok"})
+            except _HttpError as error:
+                self._json(error.status, {"error": str(error)})
+            return
+        if not self.server.executor._begin_request():
+            self._json(503, {"error": "rollout executor is not accepting work"})
+            return
+        try:
+            if self.path == "/v1/models":
+                self._json(
+                    200,
+                    {"data": [{"id": name} for name in self.server.executor.models()]},
+                )
+            else:
+                self._json(404, {"error": "not found"})
+        finally:
+            self.server.executor._end_request()
+
+    def do_POST(self) -> None:
+        if not self.server.executor._begin_request():
+            self._json(503, {"error": "rollout executor is not accepting work"})
+            return
+        try:
+            body = self._body()
+            if self.path == "/v1/completions":
+                self._json(200, self.server.executor._generate(body))
+            elif self.path == "/v1/load_lora_adapter":
+                self.server.executor._load_filesystem(body)
+                self._json(200, {"status": "ok"})
+            elif self.path == "/v1/unload_lora_adapter":
+                self.server.executor._unload_filesystem(body)
+                self._json(200, {"status": "ok"})
+            else:
+                self._json(404, {"error": "not found"})
+        except _HttpError as error:
+            self._json(error.status, {"error": str(error)})
+        except Exception as error:
+            self._json(500, {"error": str(error)})
+        finally:
+            self.server.executor._end_request()
+
+
+class UnslothVllmExecutor:
+    """Serve one embedded Unsloth vLLM as a versioned multi-policy backend.
+
+    The HTTP endpoint is loopback-only and implements the subset of the vLLM
+    OpenAI/runtime-LoRA API consumed by smolvm. Concurrent completion requests
+    are coalesced into one ``fast_generate`` call with per-prompt LoRA and
+    sampling parameters. Device-resident adapters are inserted directly into
+    the embedded engine and retained until smolvm acknowledges unload.
+    """
+
+    def __init__(
+        self,
+        model: Any,
+        device_socket: str | Path,
+        *,
+        host: str = "127.0.0.1",
+        port: int = 8000,
+        model_lock: Any | None = None,
+        batch_window_ms: float = 2.0,
+        max_batch_requests: int = 64,
+        max_batch_prompts: int = 4096,
+        max_queue_depth: int = 256,
+        request_timeout_secs: float = 300.0,
+        _import_adapter: Callable[[DeviceAdapterBundle], Any] | None = None,
+        _request_factory: Callable[[str, int, dict[str, Any], dict[str, Any]], Any]
+        | None = None,
+        _sampling_factory: Callable[..., Any] | None = None,
+        _synchronize: Callable[[], None] | None = None,
+    ) -> None:
+        try:
+            address = ipaddress.ip_address(host)
+        except ValueError as error:
+            raise ValueError("rollout host must be a numeric loopback address") from error
+        if not address.is_loopback:
+            raise ValueError("rollout host must be loopback")
+        if (
+            not isinstance(port, int)
+            or isinstance(port, bool)
+            or not 0 <= port <= 65535
+        ):
+            raise ValueError("rollout port must be between 0 and 65535")
+        if (
+            not isinstance(batch_window_ms, (int, float))
+            or isinstance(batch_window_ms, bool)
+            or not math.isfinite(batch_window_ms)
+            or not 0 <= batch_window_ms <= 1000
+        ):
+            raise ValueError("batch_window_ms must be between 0 and 1000")
+        for name, value in (
+            ("max_batch_requests", max_batch_requests),
+            ("max_batch_prompts", max_batch_prompts),
+            ("max_queue_depth", max_queue_depth),
+        ):
+            if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+                raise ValueError(f"{name} must be positive")
+        if (
+            not isinstance(request_timeout_secs, (int, float))
+            or isinstance(request_timeout_secs, bool)
+            or not math.isfinite(request_timeout_secs)
+            or request_timeout_secs <= 0
+        ):
+            raise ValueError("request_timeout_secs must be positive")
+        engine = getattr(getattr(model, "vllm_engine", None), "llm_engine", None)
+        if engine is None or not callable(getattr(engine, "add_lora", None)):
+            raise ValueError("model must expose an embedded Unsloth vLLM engine")
+        if not callable(getattr(engine, "remove_lora", None)):
+            raise ValueError("embedded Unsloth vLLM engine cannot remove LoRAs")
+        if not callable(getattr(model, "fast_generate", None)):
+            raise ValueError("model must expose Unsloth fast_generate")
+        if model_lock is not None:
+            acquire = getattr(model_lock, "acquire", None)
+            release = getattr(model_lock, "release", None)
+            if not callable(acquire) or not callable(release):
+                raise ValueError("model_lock must be a reentrant lock")
+            with model_lock:
+                if not acquire(blocking=False):
+                    raise ValueError("model_lock must be reentrant")
+                release()
+
+        self.model = model
+        self.device_socket = Path(device_socket)
+        if not self.device_socket.is_absolute():
+            raise ValueError("device_socket must be an absolute path")
+        self.host = host
+        self._endpoint_host = f"[{host}]" if address.version == 6 else host
+        self.port = port
+        self.batch_window = batch_window_ms / 1000.0
+        self.max_batch_requests = max_batch_requests
+        self.max_batch_prompts = max_batch_prompts
+        self.max_queue_depth = max_queue_depth
+        self.request_timeout = request_timeout_secs
+        self._engine = engine
+        self._import_adapter = _import_adapter or import_torch_device_adapter
+        self._request_factory = _request_factory or self._default_request
+        self._sampling_factory = _sampling_factory or self._default_sampling
+        self._synchronize = _synchronize or self._default_synchronize
+        self._model_lock = model_lock if model_lock is not None else threading.RLock()
+        self._adapters_lock = threading.Lock()
+        self._adapters: dict[str, _AdapterRecord] = {}
+        self._next_adapter_id = _ADAPTER_ID_BASE
+        self._queue: deque[_PendingCall] = deque()
+        self._condition = threading.Condition()
+        self._request_condition = threading.Condition()
+        self._active_requests = 0
+        self._stopping = threading.Event()
+        self._state_lock = threading.Lock()
+        self._started = False
+        self._http: _RolloutHttpServer | None = None
+        self._http_thread: threading.Thread | None = None
+        self._batch_thread: threading.Thread | None = None
+        self._device: DeviceAdapterServer | None = None
+        self._device_thread: threading.Thread | None = None
+        self._thread_error: Exception | None = None
+        self._device_cleanup_error: Exception | None = None
+
+    @property
+    def endpoint(self) -> str:
+        http = self._http
+        port = http.server_address[1] if http is not None else self.port
+        return f"http://{self._endpoint_host}:{port}"
+
+    def __enter__(self) -> "UnslothVllmExecutor":
+        return self.start()
+
+    def __exit__(self, *_args: Any) -> None:
+        self.shutdown()
+
+    def start(self) -> "UnslothVllmExecutor":
+        """Bind both private endpoints and start background serving threads."""
+
+        with self._state_lock:
+            if self._started:
+                return self
+            if any(
+                value is not None
+                for value in (
+                    self._http,
+                    self._http_thread,
+                    self._batch_thread,
+                    self._device,
+                    self._device_thread,
+                )
+            ):
+                raise RuntimeError(
+                    "rollout executor cleanup is incomplete; call shutdown again"
+                )
+            self._stopping.clear()
+            self._thread_error = None
+            self._device_cleanup_error = None
+            try:
+                self._http = _RolloutHttpServer((self.host, self.port), self)
+                self._device = DeviceAdapterServer(
+                    self.device_socket,
+                    load_adapter=self._load_device,
+                    unload_adapter=self._unload_device,
+                    io_timeout_secs=self.request_timeout,
+                )
+                self._device_thread = threading.Thread(
+                    target=self._run_device,
+                    name="smolvm-device-adapters",
+                    daemon=True,
+                )
+                self._batch_thread = threading.Thread(
+                    target=self._run_batch,
+                    name="smolvm-rollout-batcher",
+                    daemon=True,
+                )
+                self._http_thread = threading.Thread(
+                    target=self._run_http,
+                    name="smolvm-rollout-http",
+                    daemon=True,
+                )
+                self._device_thread.start()
+                deadline = time.monotonic() + min(self.request_timeout, 30.0)
+                while not self._device.ready:
+                    if self._thread_error is not None:
+                        raise self._thread_error
+                    if time.monotonic() >= deadline:
+                        raise TimeoutError("device adapter server did not become ready")
+                    time.sleep(0.01)
+                if self._thread_error is not None:
+                    raise self._thread_error
+                self._batch_thread.start()
+                self._http_thread.start()
+                self._started = True
+            except Exception:
+                self._shutdown_locked()
+                raise
+        return self
+
+    def serve_forever(self) -> None:
+        """Start the executor and block until ``shutdown`` is called."""
+
+        self.start()
+        thread = self._http_thread
+        if thread is not None:
+            thread.join()
+        if self._thread_error is not None:
+            raise self._thread_error
+
+    def shutdown(self) -> None:
+        """Reject queued work, stop listeners, and unload retained adapters."""
+
+        with self._state_lock:
+            self._shutdown_locked()
+
+    def _shutdown_locked(self) -> None:
+        self._stopping.set()
+        with self._condition:
+            while self._queue:
+                call = self._queue.popleft()
+                call.error = RuntimeError("rollout executor is shutting down")
+                call.done.set()
+            self._condition.notify_all()
+        http = self._http
+        http_thread = self._http_thread
+        if http is not None and http_thread is not None and http_thread.is_alive():
+            http.shutdown()
+        deadline = time.monotonic() + min(self.request_timeout, 30.0)
+        with self._request_condition:
+            while self._active_requests:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                self._request_condition.wait(remaining)
+            active_requests = self._active_requests
+        cleanup_error = self._thread_error
+        can_unload = active_requests == 0
+        if not can_unload:
+            cleanup_error = cleanup_error or RuntimeError(
+                f"{active_requests} rollout requests did not drain"
+            )
+        device = self._device
+        if device is not None and can_unload:
+            device.shutdown()
+        current = threading.current_thread()
+        for thread in (self._http_thread, self._batch_thread, self._device_thread):
+            if thread is self._device_thread and not can_unload:
+                continue
+            if (
+                thread is not None
+                and thread is not current
+                and thread.ident is not None
+            ):
+                thread.join(timeout=max(0.0, deadline - time.monotonic()))
+        live_threads = []
+        for thread in (self._http_thread, self._batch_thread, self._device_thread):
+            if thread is self._device_thread and not can_unload:
+                continue
+            if thread is not None and thread is not current and thread.is_alive():
+                live_threads.append(thread)
+                cleanup_error = cleanup_error or RuntimeError(
+                    f"rollout thread {thread.name!r} did not stop"
+                )
+        can_cleanup = can_unload and not live_threads
+        cleanup_failed = False
+        if can_cleanup and device is not None:
+            try:
+                device.drain()
+                self._device_cleanup_error = None
+            except Exception as error:
+                cleanup_failed = True
+                self._device_cleanup_error = error
+                cleanup_error = cleanup_error or error
+        if can_cleanup:
+            for name in self._filesystem_models():
+                try:
+                    self._remove(name, "filesystem")
+                except Exception as error:
+                    cleanup_failed = True
+                    cleanup_error = cleanup_error or error
+        can_cleanup = can_cleanup and not cleanup_failed
+        if http is not None:
+            http.server_close()
+        self._started = False
+        if can_cleanup:
+            self._http = None
+            self._http_thread = None
+            self._batch_thread = None
+            self._device = None
+            self._device_thread = None
+            self._thread_error = None
+            self._device_cleanup_error = None
+        if cleanup_error is not None:
+            raise cleanup_error
+
+    def _begin_request(self) -> bool:
+        with self._request_condition:
+            if self._stopping.is_set() or not self._started:
+                return False
+            self._active_requests += 1
+            return True
+
+    def _end_request(self) -> None:
+        with self._request_condition:
+            self._active_requests -= 1
+            if self._active_requests == 0:
+                self._request_condition.notify_all()
+
+    def _health(self) -> None:
+        error = self._thread_error
+        if error is not None:
+            raise _HttpError(503, f"rollout executor failed: {error}")
+        if self._stopping.is_set() or not self._started:
+            raise _HttpError(503, "rollout executor is not accepting work")
+
+    def models(self) -> tuple[str, ...]:
+        with self._adapters_lock:
+            return tuple(sorted(self._adapters))
+
+    def _run_device(self) -> None:
+        try:
+            assert self._device is not None
+            self._device.serve_forever()
+        except Exception as error:
+            if not self._stopping.is_set():
+                self._record_failure(error)
+            else:
+                self._device_cleanup_error = error
+
+    def _run_batch(self) -> None:
+        try:
+            self._batch_loop()
+        except Exception as error:
+            if not self._stopping.is_set():
+                self._record_failure(error)
+
+    def _run_http(self) -> None:
+        try:
+            assert self._http is not None
+            self._http.serve_forever()
+        except Exception as error:
+            if not self._stopping.is_set():
+                self._record_failure(error)
+
+    def _record_failure(self, error: Exception) -> None:
+        if self._thread_error is None:
+            self._thread_error = error
+        self._stopping.set()
+        with self._condition:
+            while self._queue:
+                call = self._queue.popleft()
+                call.error = error
+                call.done.set()
+            self._condition.notify_all()
+        http = self._http
+        http_thread = self._http_thread
+        if (
+            http is not None
+            and http_thread is not None
+            and http_thread is not threading.current_thread()
+            and http_thread.is_alive()
+        ):
+            http.shutdown()
+
+    def _allocate_id(self) -> int:
+        with self._model_lock:
+            list_loras = getattr(self._engine, "list_loras", None)
+            used = set(list_loras()) if callable(list_loras) else set()
+            with self._adapters_lock:
+                value = self._next_adapter_id
+                while value in used:
+                    value += 1
+                self._next_adapter_id = value + 1
+                return value
+
+    @staticmethod
+    def _default_request(
+        name: str,
+        adapter_id: int,
+        tensors: dict[str, Any],
+        config: dict[str, Any],
+    ) -> Any:
+        try:
+            from vllm.lora.request import LoRARequest
+
+            request = LoRARequest(
+                name,
+                adapter_id,
+                lora_tensors=tensors,
+                lora_config=config,
+            )
+        except (ImportError, TypeError) as error:
+            raise RuntimeError(
+                "Unsloth's tensor-aware vLLM LoRA integration is unavailable"
+            ) from error
+        if getattr(request, "lora_tensors", None) is None:
+            raise RuntimeError("vLLM LoRARequest discarded device tensors")
+        return request
+
+    @staticmethod
+    def _default_sampling(**values: Any) -> Any:
+        from vllm import SamplingParams
+
+        return SamplingParams(**values)
+
+    @staticmethod
+    def _default_synchronize() -> None:
+        import torch
+
+        torch.cuda.synchronize()
+
+    def _insert(self, name: str, request: Any, source: str) -> None:
+        with self._model_lock:
+            with self._adapters_lock:
+                if name in self._adapters:
+                    raise _HttpError(409, f"adapter {name!r} is already loaded")
+            added = False
+            try:
+                if not self._engine.add_lora(request):
+                    raise RuntimeError("embedded vLLM rejected the LoRA adapter")
+                added = True
+                self._synchronize()
+                with self._adapters_lock:
+                    self._adapters[name] = _AdapterRecord(
+                        request=request, source=source
+                    )
+            except Exception as install_error:
+                if added:
+                    try:
+                        self._engine.remove_lora(request.lora_int_id)
+                        self._synchronize()
+                    except Exception as rollback_error:
+                        with self._adapters_lock:
+                            self._adapters[name] = _AdapterRecord(
+                                request=request, source=source
+                            )
+                        raise _InstallRollbackFailure(
+                            "embedded vLLM adapter installation failed and could not "
+                            f"be rolled back: {install_error}"
+                        ) from rollback_error
+                raise
+
+    def _load_device(self, name: str, bundle: DeviceAdapterBundle) -> _DeviceOwner:
+        if self._stopping.is_set():
+            raise RuntimeError("rollout executor is shutting down")
+        self._validate_adapter_name(name)
+        imported = self._import_adapter(bundle)
+        try:
+            request = self._request_factory(
+                name,
+                self._allocate_id(),
+                imported.tensors,
+                imported.adapter_config,
+            )
+            self._insert(name, request, "device")
+            return _DeviceOwner(imported=imported, request=request)
+        except _InstallRollbackFailure as error:
+            # The engine may still reference the imported allocation. Return an
+            # owner so DeviceAdapterServer retains it and can honor the cleanup
+            # unload that smolvm sends after the failed publication boundary.
+            owner = _DeviceOwner(imported=imported, request=request)
+            self._record_failure(error)
+            return owner
+        except Exception:
+            imported.close()
+            raise
+
+    def _remove(self, name: str, source: str) -> None:
+        with self._model_lock:
+            with self._adapters_lock:
+                record = self._adapters.get(name)
+            if record is None:
+                return
+            if record.source != source:
+                raise _HttpError(
+                    409, f"adapter {name!r} was loaded from {record.source}"
+                )
+            self._engine.remove_lora(record.request.lora_int_id)
+            self._synchronize()
+            with self._adapters_lock:
+                current = self._adapters.get(name)
+                if current is record:
+                    del self._adapters[name]
+
+    def _filesystem_models(self) -> tuple[str, ...]:
+        with self._adapters_lock:
+            return tuple(
+                name
+                for name, record in self._adapters.items()
+                if record.source == "filesystem"
+            )
+
+    def _unload_device(self, name: str, _owner: _DeviceOwner) -> None:
+        self._remove(name, "device")
+
+    def _load_filesystem(self, body: dict[str, Any]) -> None:
+        name = body.get("lora_name")
+        path = body.get("lora_path")
+        self._validate_adapter_name(name)
+        if not isinstance(path, str) or not path:
+            raise _HttpError(400, "lora_path must be non-empty")
+        loader = getattr(self.model, "load_lora", None)
+        if not callable(loader):
+            raise _HttpError(501, "embedded Unsloth model cannot load filesystem LoRAs")
+        with self._model_lock:
+            with self._adapters_lock:
+                if name in self._adapters:
+                    raise _HttpError(409, f"adapter {name!r} is already loaded")
+            request = loader(
+                path, load_tensors=False, lora_request_id=self._allocate_id()
+            )
+            self._insert(name, request, "filesystem")
+
+    def _unload_filesystem(self, body: dict[str, Any]) -> None:
+        name = body.get("lora_name")
+        self._validate_adapter_name(name)
+        self._remove(name, "filesystem")
+
+    @staticmethod
+    def _validate_adapter_name(name: Any) -> None:
+        if (
+            not isinstance(name, str)
+            or not name
+            or len(name.encode()) > 512
+            or "\0" in name
+        ):
+            raise _HttpError(400, "lora_name must be non-empty and at most 512 bytes")
+
+    def _validate_generate(self, body: dict[str, Any]) -> str:
+        model = body.get("model")
+        if (
+            not isinstance(model, str)
+            or not model
+            or len(model.encode()) > 512
+            or "\0" in model
+        ):
+            raise _HttpError(400, "model must be non-empty")
+        with self._adapters_lock:
+            if model not in self._adapters:
+                raise _HttpError(404, f"model {model!r} is not loaded")
+        prompts = body.get("prompt")
+        if not isinstance(prompts, list) or not prompts:
+            raise _HttpError(400, "prompt must be a non-empty list")
+        if len(prompts) > _MAX_PROMPTS_PER_REQUEST:
+            raise _HttpError(400, "request contains too many prompts")
+        if len(prompts) > self.max_batch_prompts:
+            raise _HttpError(400, "request exceeds the configured batch prompt limit")
+        if all(isinstance(value, str) for value in prompts):
+            if any(not value for value in prompts):
+                raise _HttpError(400, "text prompts must be non-empty")
+            if sum(len(value.encode()) for value in prompts) > _MAX_PROMPT_TEXT_BYTES:
+                raise _HttpError(400, "prompt text exceeds its size limit")
+            prompt_kind = "text"
+        elif all(
+            isinstance(value, list)
+            and value
+            and all(
+                isinstance(token, int)
+                and not isinstance(token, bool)
+                and 0 <= token <= 0xFFFFFFFF
+                for token in value
+            )
+            for value in prompts
+        ):
+            if sum(len(value) for value in prompts) > _MAX_PROMPT_TOKENS:
+                raise _HttpError(400, "prompt tokens exceed their size limit")
+            prompt_kind = "tokens"
+        else:
+            raise _HttpError(400, "prompts must be uniformly text or token IDs")
+        n = body.get("n", 1)
+        max_tokens = body.get("max_tokens")
+        if not isinstance(n, int) or isinstance(n, bool) or not 1 <= n <= 256:
+            raise _HttpError(400, "n must be between 1 and 256")
+        if (
+            not isinstance(max_tokens, int)
+            or isinstance(max_tokens, bool)
+            or not 1 <= max_tokens <= _MAX_COMPLETION_TOKENS
+        ):
+            raise _HttpError(400, "max_tokens is invalid")
+        if body.get("stream", False) is not False:
+            raise _HttpError(400, "streaming completions are not supported")
+        self._validate_sampling(body)
+        return prompt_kind
+
+    @staticmethod
+    def _validate_sampling(body: dict[str, Any]) -> None:
+        def number(name: str, default: float) -> float:
+            value = body.get(name, default)
+            if (
+                not isinstance(value, (int, float))
+                or isinstance(value, bool)
+                or not math.isfinite(value)
+            ):
+                raise _HttpError(400, f"{name} must be finite")
+            return float(value)
+
+        temperature = number("temperature", 1.0)
+        top_p = number("top_p", 1.0)
+        min_p = number("min_p", 0.0)
+        repetition_penalty = number("repetition_penalty", 1.0)
+        if temperature < 0:
+            raise _HttpError(400, "temperature cannot be negative")
+        if not 0 <= top_p <= 1:
+            raise _HttpError(400, "top_p must be between 0 and 1")
+        if not 0 <= min_p <= 1:
+            raise _HttpError(400, "min_p must be between 0 and 1")
+        if repetition_penalty <= 0:
+            raise _HttpError(400, "repetition_penalty must be positive")
+        top_k = body.get("top_k", -1)
+        if (
+            not isinstance(top_k, int)
+            or isinstance(top_k, bool)
+            or top_k == 0
+            or top_k < -1
+        ):
+            raise _HttpError(400, "top_k must be -1 or a positive integer")
+        for name in ("seed", "logprobs", "prompt_logprobs"):
+            value = body.get(name)
+            if value is not None and (
+                not isinstance(value, int) or isinstance(value, bool) or value < 0
+            ):
+                raise _HttpError(400, f"{name} must be a non-negative integer")
+
+    def _generate(self, body: dict[str, Any]) -> dict[str, Any]:
+        prompt_kind = self._validate_generate(body)
+        call = _PendingCall(body, prompt_kind)
+        with self._condition:
+            if self._stopping.is_set():
+                raise _HttpError(503, "rollout executor is shutting down")
+            if len(self._queue) >= self.max_queue_depth:
+                raise _HttpError(503, "rollout executor queue is full")
+            self._queue.append(call)
+            self._condition.notify()
+        if not call.done.wait(self.request_timeout):
+            with self._condition:
+                call.cancelled = True
+                try:
+                    self._queue.remove(call)
+                except ValueError:
+                    pass
+            raise _HttpError(504, "rollout generation timed out")
+        if call.error is not None:
+            if isinstance(call.error, _HttpError):
+                raise call.error
+            raise RuntimeError(str(call.error)) from call.error
+        assert call.response is not None
+        return call.response
+
+    def _batch_loop(self) -> None:
+        while not self._stopping.is_set():
+            with self._condition:
+                while not self._queue and not self._stopping.is_set():
+                    self._condition.wait(0.5)
+                if self._stopping.is_set():
+                    return
+                deadline = time.monotonic() + self.batch_window
+                while time.monotonic() < deadline and not self._stopping.is_set():
+                    self._condition.wait(max(0.0, deadline - time.monotonic()))
+                if self._stopping.is_set():
+                    return
+                first = next((call for call in self._queue if not call.cancelled), None)
+                if first is None:
+                    self._queue.clear()
+                    continue
+                selected: list[_PendingCall] = []
+                prompts = 0
+                remaining: deque[_PendingCall] = deque()
+                while self._queue:
+                    call = self._queue.popleft()
+                    count = len(call.body["prompt"])
+                    if (
+                        call.cancelled
+                        or call.prompt_kind != first.prompt_kind
+                        or len(selected) >= self.max_batch_requests
+                        or prompts + count > self.max_batch_prompts
+                    ):
+                        if not call.cancelled:
+                            remaining.append(call)
+                        continue
+                    selected.append(call)
+                    prompts += count
+                self._queue.extendleft(reversed(remaining))
+                if self._queue:
+                    self._condition.notify()
+            if selected:
+                self._execute_batch(selected)
+
+    def _execute_batch(self, calls: list[_PendingCall]) -> None:
+        calls = [call for call in calls if not call.cancelled]
+        if not calls:
+            return
+        prompts: list[Any] = []
+        requests: list[Any] = []
+        sampling: list[Any] = []
+        slices: list[tuple[_PendingCall, int, int]] = []
+        try:
+            with self._model_lock:
+                with self._adapters_lock:
+                    records = {
+                        call.body["model"]: self._adapters.get(call.body["model"])
+                        for call in calls
+                    }
+                for call in calls:
+                    body = call.body
+                    record = records[body["model"]]
+                    if record is None:
+                        raise _HttpError(
+                            404, f"model {body['model']!r} is not loaded"
+                        )
+                    begin = len(prompts)
+                    prompts.extend(body["prompt"])
+                    requests.extend([record.request] * len(body["prompt"]))
+                    parameters = self._sampling_factory(
+                        n=body.get("n", 1),
+                        max_tokens=body["max_tokens"],
+                        temperature=body.get("temperature", 1.0),
+                        top_p=body.get("top_p", 1.0),
+                        top_k=body.get("top_k", -1),
+                        min_p=body.get("min_p", 0.0),
+                        repetition_penalty=body.get("repetition_penalty", 1.0),
+                        seed=body.get("seed"),
+                        logprobs=body.get("logprobs"),
+                        prompt_logprobs=body.get("prompt_logprobs"),
+                    )
+                    sampling.extend([parameters] * len(body["prompt"]))
+                    slices.append((call, begin, len(prompts)))
+                outputs = self.model.fast_generate(
+                    prompts,
+                    sampling_params=sampling,
+                    lora_request=requests,
+                    use_tqdm=False,
+                )
+                self._synchronize()
+            if len(outputs) != len(prompts):
+                raise RuntimeError("embedded vLLM returned the wrong number of outputs")
+            for call, begin, end in slices:
+                call.response = self._completion_response(outputs[begin:end])
+        except Exception as error:
+            for call in calls:
+                call.error = error
+        finally:
+            for call in calls:
+                call.done.set()
+
+    @staticmethod
+    def _completion_response(outputs: list[Any]) -> dict[str, Any]:
+        choices = []
+        completion_tokens = 0
+        prompt_tokens = 0
+        index = 0
+        for output in outputs:
+            prompt_ids = [int(token) for token in output.prompt_token_ids]
+            prompt_tokens += len(prompt_ids)
+            for completion in output.outputs:
+                token_ids = [int(token) for token in completion.token_ids]
+                completion_tokens += len(token_ids)
+                finish_reason = getattr(completion, "finish_reason", None)
+                choices.append(
+                    {
+                        "index": index,
+                        "text": str(completion.text),
+                        "token_ids": token_ids,
+                        "prompt_token_ids": prompt_ids,
+                        "logprobs": _json_value(
+                            getattr(completion, "logprobs", None)
+                        ),
+                        "finish_reason": (
+                            None if finish_reason is None else str(finish_reason)
+                        ),
+                        "stop_reason": _json_value(
+                            getattr(completion, "stop_reason", None)
+                        ),
+                    }
+                )
+                index += 1
+        return {
+            "id": f"smolvm-{time.time_ns()}",
+            "choices": choices,
+            "usage": {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": prompt_tokens + completion_tokens,
+            },
+        }
+
+
+def _json_value(value: Any, depth: int = 0) -> Any:
+    """Convert vLLM result objects into strict, bounded JSON-compatible values."""
+
+    if depth > 16:
+        raise ValueError("vLLM response nesting exceeds its safety limit")
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, dict):
+        return {
+            str(key): _json_value(item, depth + 1) for key, item in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item, depth + 1) for item in value]
+    fields = {}
+    for name in ("logprob", "rank", "decoded_token"):
+        if hasattr(value, name):
+            fields[name] = _json_value(getattr(value, name), depth + 1)
+    if fields:
+        return fields
+    item = getattr(value, "item", None)
+    if callable(item):
+        converted = item()
+        if converted is not value:
+            return _json_value(converted, depth + 1)
+    return str(value)

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -140,5 +140,35 @@ class DevicePublicationTests(unittest.TestCase):
         self.assertEqual(client.attempts[0], client.attempts[1])
 
 
+class CohortTests(unittest.TestCase):
+    def test_generate_encodes_distributed_cohort(self):
+        client = RecordingClient()
+        client.generate(
+            idempotency_key="request-1",
+            policy="policy-1",
+            prompts=["hello"],
+            max_tokens=8,
+            cohort_id="training-step-1",
+            cohort_size=4,
+        )
+        method, path, body = client.recorded
+        self.assertEqual(method, "POST")
+        self.assertEqual(path, "/rollout-executors/fused/generate")
+        self.assertEqual(body["cohort"], {"id": "training-step-1", "size": 4})
+
+    def test_generate_requires_complete_valid_cohort(self):
+        client = RecordingClient()
+        common = {
+            "idempotency_key": "request-1",
+            "policy": "policy-1",
+            "prompts": ["hello"],
+            "max_tokens": 8,
+        }
+        with self.assertRaisesRegex(ValueError, "must be set together"):
+            client.job(**common, cohort_id="training-step-1")
+        with self.assertRaisesRegex(ValueError, "between 1 and 256"):
+            client.job(**common, cohort_id="training-step-1", cohort_size=0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/sdks/python/tests/test_transformers.py
+++ b/sdks/python/tests/test_transformers.py
@@ -1,0 +1,145 @@
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from smolvm_rollout import add_transformers_forkpoint, transformers_forkpoint_callback
+
+
+class FakeTrainerCallback:
+    pass
+
+
+class FakeTrainer:
+    def __init__(self):
+        self.callbacks = []
+
+    def add_callback(self, callback):
+        self.callbacks.append(callback)
+
+
+class TransformersForkpointTests(unittest.TestCase):
+    def transformers_module(self, seeds):
+        module = types.ModuleType("transformers")
+        module.TrainerCallback = FakeTrainerCallback
+        module.set_seed = seeds.append
+        return module
+
+    def test_callback_releases_once_imports_identity_and_reseeds(self):
+        seeds = []
+        with tempfile.TemporaryDirectory() as directory:
+            env_path = Path(directory) / "fork-env"
+            env_path.write_text(
+                "SMOLVM_FORK_INDEX=3\nSMOLVM_FORK_NAME=worker-3\nVALUE=a=b c\n"
+            )
+            args = SimpleNamespace(seed=42, data_seed=7)
+            control = object()
+            with (
+                mock.patch.dict(
+                    sys.modules,
+                    {"transformers": self.transformers_module(seeds)},
+                ),
+                mock.patch("smolvm_rollout.transformers.subprocess.run") as run,
+                mock.patch.dict(os.environ, {}, clear=True),
+            ):
+                callback = transformers_forkpoint_callback(
+                    command=("fork-ready", "--test"), env_path=env_path
+                )
+                self.assertIs(callback.on_train_begin(args, None, control), control)
+                self.assertIs(callback.on_train_begin(args, None, control), control)
+                self.assertEqual(os.environ["SMOLVM_FORK_NAME"], "worker-3")
+                self.assertEqual(os.environ["VALUE"], "a=b c")
+
+            run.assert_called_once_with(
+                ("fork-ready", "--test", "--cuda-preload-modules"), check=True
+            )
+            self.assertTrue(callback.released)
+            self.assertEqual(callback.fork_env["SMOLVM_FORK_INDEX"], "3")
+            self.assertEqual(callback.seed, 45)
+            self.assertEqual(seeds, [45])
+            self.assertEqual(args.seed, 45)
+            self.assertEqual(args.data_seed, 45)
+
+    def test_explicit_seed_takes_precedence_over_index(self):
+        seeds = []
+        with tempfile.TemporaryDirectory() as directory:
+            env_path = Path(directory) / "fork-env"
+            env_path.write_text("SMOLVM_FORK_INDEX=3\nSMOLVM_FORK_SEED=99\n")
+            args = SimpleNamespace(seed=42, data_seed=None)
+            with (
+                mock.patch.dict(
+                    sys.modules,
+                    {"transformers": self.transformers_module(seeds)},
+                ),
+                mock.patch("smolvm_rollout.transformers.subprocess.run"),
+            ):
+                callback = transformers_forkpoint_callback(env_path=env_path)
+                callback.on_train_begin(args, None, object())
+
+            self.assertEqual(seeds, [99])
+            self.assertEqual(args.seed, 99)
+            self.assertEqual(args.data_seed, 99)
+
+    def test_invalid_environment_does_not_repeat_consumed_forkpoint(self):
+        seeds = []
+        with tempfile.TemporaryDirectory() as directory:
+            env_path = Path(directory) / "fork-env"
+            env_path.write_text("not valid\n")
+            with (
+                mock.patch.dict(
+                    sys.modules,
+                    {"transformers": self.transformers_module(seeds)},
+                ),
+                mock.patch("smolvm_rollout.transformers.subprocess.run") as run,
+            ):
+                callback = transformers_forkpoint_callback(env_path=env_path)
+                with self.assertRaisesRegex(ValueError, "invalid fork environment"):
+                    callback.on_train_begin(SimpleNamespace(seed=1), None, object())
+                callback.on_train_begin(SimpleNamespace(seed=1), None, object())
+
+            run.assert_called_once()
+            self.assertTrue(callback.released)
+
+    def test_add_helper_attaches_callback(self):
+        seeds = []
+        trainer = FakeTrainer()
+        with mock.patch.dict(
+            sys.modules,
+            {"transformers": self.transformers_module(seeds)},
+        ):
+            callback = add_transformers_forkpoint(trainer, command="fork-ready")
+        self.assertEqual(trainer.callbacks, [callback])
+
+    def test_cuda_module_preload_can_be_disabled(self):
+        seeds = []
+        with tempfile.TemporaryDirectory() as directory:
+            env_path = Path(directory) / "fork-env"
+            env_path.write_text("")
+            with (
+                mock.patch.dict(
+                    sys.modules,
+                    {"transformers": self.transformers_module(seeds)},
+                ),
+                mock.patch("smolvm_rollout.transformers.subprocess.run") as run,
+            ):
+                callback = transformers_forkpoint_callback(
+                    command="fork-ready",
+                    env_path=env_path,
+                    preload_cuda_modules=False,
+                )
+                callback.on_train_begin(SimpleNamespace(seed=1), None, object())
+
+            run.assert_called_once_with(("fork-ready",), check=True)
+
+    def test_factory_reports_missing_transformers(self):
+        with mock.patch.dict(sys.modules, {"transformers": None}):
+            with self.assertRaisesRegex(RuntimeError, "requires the transformers"):
+                transformers_forkpoint_callback()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdks/python/tests/test_unsloth_vllm.py
+++ b/sdks/python/tests/test_unsloth_vllm.py
@@ -1,0 +1,516 @@
+import json
+import tempfile
+import threading
+import time
+import unittest
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+
+from smolvm_rollout import UnslothVllmExecutor
+
+
+@dataclass
+class FakeRequest:
+    lora_name: str
+    lora_int_id: int
+    lora_tensors: object | None = None
+    lora_config: object | None = None
+
+
+class FakeEngine:
+    def __init__(self):
+        self.adapters = {}
+        self.added = []
+        self.removed = []
+
+    def add_lora(self, request):
+        self.added.append(request)
+        self.adapters[request.lora_int_id] = request
+        return True
+
+    def remove_lora(self, adapter_id):
+        self.removed.append(adapter_id)
+        return self.adapters.pop(adapter_id, None) is not None
+
+    def list_loras(self):
+        return set(self.adapters)
+
+
+class FakeLogprob:
+    def __init__(self, value, rank, token):
+        self.logprob = value
+        self.rank = rank
+        self.decoded_token = token
+
+
+class FakeCompletion:
+    def __init__(self, request, prompt):
+        self.text = f"{request.lora_name}:{prompt}"
+        self.token_ids = [request.lora_int_id, 17]
+        self.logprobs = [{request.lora_int_id: FakeLogprob(-0.25, 1, "x")}]
+        self.finish_reason = "length"
+        self.stop_reason = None
+
+
+class FakeOutput:
+    def __init__(self, request, prompt):
+        self.prompt_token_ids = (
+            prompt if isinstance(prompt, list) else [ord(value) for value in prompt]
+        )
+        self.outputs = [FakeCompletion(request, prompt)]
+
+
+class FakeModel:
+    def __init__(self):
+        self.engine = FakeEngine()
+        self.vllm_engine = SimpleNamespace(llm_engine=self.engine)
+        self.loads = []
+        self.generate_calls = []
+
+    def load_lora(self, path, *, load_tensors, lora_request_id):
+        self.loads.append((path, load_tensors, lora_request_id))
+        return FakeRequest(Path(path).name, lora_request_id)
+
+    def fast_generate(
+        self, prompts, *, sampling_params, lora_request, use_tqdm
+    ):
+        self.generate_calls.append(
+            (list(prompts), list(sampling_params), list(lora_request), use_tqdm)
+        )
+        return [
+            FakeOutput(request, prompt)
+            for request, prompt in zip(lora_request, prompts)
+        ]
+
+
+class FakeImported:
+    def __init__(self):
+        self.tensors = {"lora": object()}
+        self.adapter_config = {"r": 16}
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+def request_factory(name, adapter_id, tensors, config):
+    return FakeRequest(name, adapter_id, tensors, config)
+
+
+def executor(model, socket_path, **options):
+    configuration = {
+        "port": 0,
+        "batch_window_ms": 50,
+        "request_timeout_secs": 2,
+        "_request_factory": request_factory,
+        "_sampling_factory": lambda **values: values,
+        "_synchronize": lambda: None,
+    }
+    configuration.update(options)
+    return UnslothVllmExecutor(model, socket_path, **configuration)
+
+
+def json_request(endpoint, path, body=None):
+    payload = None if body is None else json.dumps(body).encode()
+    request = urllib.request.Request(
+        f"{endpoint}{path}",
+        data=payload,
+        method="GET" if body is None else "POST",
+        headers={"content-type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=2) as response:
+            return response.status, json.loads(response.read())
+    except urllib.error.HTTPError as error:
+        try:
+            return error.code, json.loads(error.read())
+        finally:
+            error.close()
+
+
+class UnslothVllmExecutorTests(unittest.TestCase):
+    def test_rejects_non_loopback_listener(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(ValueError, "loopback"):
+                executor(
+                    FakeModel(),
+                    Path(directory) / "device.sock",
+                    host="0.0.0.0",
+                )
+
+    def test_shared_model_lock_must_be_reentrant(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(ValueError, "reentrant"):
+                executor(
+                    FakeModel(),
+                    Path(directory) / "device.sock",
+                    model_lock=threading.Lock(),
+                )
+            service = executor(
+                FakeModel(),
+                Path(directory) / "device.sock",
+                model_lock=threading.RLock(),
+            )
+            self.assertIsNotNone(service)
+
+    def test_partial_start_failure_does_not_deadlock(self):
+        with tempfile.TemporaryDirectory() as directory:
+            socket_path = Path(directory) / "device.sock"
+            socket_path.write_text("not a socket")
+            service = executor(FakeModel(), socket_path)
+            errors = []
+
+            thread = threading.Thread(
+                target=lambda: self._capture_start_error(service, errors), daemon=True
+            )
+            thread.start()
+            thread.join(timeout=2)
+            self.assertFalse(thread.is_alive())
+            self.assertEqual(len(errors), 1)
+            self.assertIn("non-socket", str(errors[0]))
+
+    @staticmethod
+    def _capture_start_error(service, errors):
+        try:
+            service.start()
+        except Exception as error:
+            errors.append(error)
+
+    def test_filesystem_load_is_unique_and_drained_on_shutdown(self):
+        model = FakeModel()
+        with tempfile.TemporaryDirectory() as directory:
+            service = executor(model, Path(directory) / "device.sock")
+            service.start()
+            try:
+                body = {"lora_name": "policy-a", "lora_path": "/adapters/a"}
+                self.assertEqual(
+                    json_request(service.endpoint, "/v1/load_lora_adapter", body)[0],
+                    200,
+                )
+                status, response = json_request(
+                    service.endpoint, "/v1/load_lora_adapter", body
+                )
+                self.assertEqual(status, 409)
+                self.assertIn("already loaded", response["error"])
+                self.assertEqual(len(model.loads), 1)
+                status, response = json_request(service.endpoint, "/v1/models")
+                self.assertEqual(status, 200)
+                self.assertEqual(response["data"], [{"id": "policy-a"}])
+            finally:
+                service.shutdown()
+            self.assertEqual(model.engine.adapters, {})
+            self.assertEqual(
+                model.engine.removed, [model.engine.added[0].lora_int_id]
+            )
+
+    def test_device_load_inserts_without_dummy_generation(self):
+        model = FakeModel()
+        imported = FakeImported()
+        with tempfile.TemporaryDirectory() as directory:
+            service = executor(
+                model,
+                Path(directory) / "device.sock",
+                _import_adapter=lambda _bundle: imported,
+            )
+            owner = service._load_device("policy-device", object())
+            self.assertEqual(service.models(), ("policy-device",))
+            self.assertEqual(len(model.engine.added), 1)
+            self.assertEqual(model.generate_calls, [])
+            service._unload_device("policy-device", owner)
+            owner.close()
+            self.assertTrue(imported.closed)
+            self.assertEqual(
+                model.engine.removed, [model.engine.added[0].lora_int_id]
+            )
+
+    def test_adapter_ids_skip_existing_engine_allocations(self):
+        model = FakeModel()
+        model.engine.adapters[1_000_000_000] = FakeRequest("external", 1_000_000_000)
+        imported = FakeImported()
+        with tempfile.TemporaryDirectory() as directory:
+            service = executor(
+                model,
+                Path(directory) / "device.sock",
+                _import_adapter=lambda _bundle: imported,
+            )
+            owner = service._load_device("policy-device", object())
+            self.assertEqual(owner.request.lora_int_id, 1_000_000_001)
+            service._unload_device("policy-device", owner)
+            owner.close()
+
+    def test_failed_install_rollback_retains_device_mapping_for_unload(self):
+        model = FakeModel()
+        imported = FakeImported()
+        synchronizations = 0
+        fail_remove = True
+
+        def synchronize():
+            nonlocal synchronizations
+            synchronizations += 1
+            if synchronizations == 1:
+                raise RuntimeError("injected synchronize failure")
+
+        original_remove = model.engine.remove_lora
+
+        def remove(adapter_id):
+            if fail_remove:
+                raise RuntimeError("injected rollback failure")
+            return original_remove(adapter_id)
+
+        model.engine.remove_lora = remove
+        with tempfile.TemporaryDirectory() as directory:
+            service = UnslothVllmExecutor(
+                model,
+                Path(directory) / "device.sock",
+                port=0,
+                _import_adapter=lambda _bundle: imported,
+                _request_factory=request_factory,
+                _sampling_factory=lambda **values: values,
+                _synchronize=synchronize,
+            )
+            owner = service._load_device("uncertain", object())
+            self.assertTrue(service._stopping.is_set())
+            self.assertFalse(imported.closed)
+            self.assertEqual(service.models(), ("uncertain",))
+            fail_remove = False
+            service._unload_device("uncertain", owner)
+            owner.close()
+            self.assertTrue(imported.closed)
+            self.assertEqual(service.models(), ())
+
+    def test_concurrent_policies_are_coalesced_and_json_safe(self):
+        model = FakeModel()
+        with tempfile.TemporaryDirectory() as directory:
+            service = executor(
+                model,
+                Path(directory) / "device.sock",
+                batch_window_ms=200,
+            )
+            service._insert("policy-a", FakeRequest("policy-a", 11), "filesystem")
+            service._insert("policy-b", FakeRequest("policy-b", 12), "filesystem")
+            with service:
+                barrier = threading.Barrier(3)
+                results = []
+                errors = []
+
+                def generate(policy, prompt):
+                    try:
+                        barrier.wait(timeout=2)
+                        results.append(
+                            json_request(
+                                service.endpoint,
+                                "/v1/completions",
+                                {
+                                    "model": policy,
+                                    "prompt": [prompt],
+                                    "n": 1,
+                                    "max_tokens": 2,
+                                    "logprobs": 1,
+                                },
+                            )
+                        )
+                    except Exception as error:
+                        errors.append(error)
+
+                threads = [
+                    threading.Thread(target=generate, args=("policy-a", "one")),
+                    threading.Thread(target=generate, args=("policy-b", "two")),
+                ]
+                for thread in threads:
+                    thread.start()
+                barrier.wait(timeout=2)
+                for thread in threads:
+                    thread.join(timeout=2)
+                    self.assertFalse(thread.is_alive())
+
+                self.assertEqual(errors, [])
+                self.assertEqual([status for status, _ in results], [200, 200])
+                self.assertEqual(len(model.generate_calls), 1)
+                prompts, sampling, requests, use_tqdm = model.generate_calls[0]
+                self.assertEqual(set(prompts), {"one", "two"})
+                self.assertEqual(
+                    {request.lora_name for request in requests},
+                    {"policy-a", "policy-b"},
+                )
+                self.assertEqual(len(sampling), 2)
+                self.assertFalse(use_tqdm)
+                for _, response in results:
+                    logprob = response["choices"][0]["logprobs"][0]
+                    value = next(iter(logprob.values()))
+                    self.assertEqual(value["logprob"], -0.25)
+                    self.assertEqual(value["rank"], 1)
+
+    def test_request_larger_than_batch_limit_fails_without_queuing(self):
+        model = FakeModel()
+        with tempfile.TemporaryDirectory() as directory:
+            service = executor(
+                model,
+                Path(directory) / "device.sock",
+                max_batch_prompts=1,
+            )
+            service._insert("policy-a", FakeRequest("policy-a", 1), "filesystem")
+            with service:
+                status, response = json_request(
+                    service.endpoint,
+                    "/v1/completions",
+                    {
+                        "model": "policy-a",
+                        "prompt": ["one", "two"],
+                        "n": 1,
+                        "max_tokens": 2,
+                    },
+                )
+                self.assertEqual(status, 400)
+                self.assertIn("batch prompt limit", response["error"])
+                self.assertEqual(model.generate_calls, [])
+
+    def test_sampling_and_streaming_are_validated_before_queueing(self):
+        model = FakeModel()
+        with tempfile.TemporaryDirectory() as directory:
+            service = executor(model, Path(directory) / "device.sock")
+            service._insert("policy-a", FakeRequest("policy-a", 1), "filesystem")
+            with service:
+                base = {
+                    "model": "policy-a",
+                    "prompt": [[1, 2]],
+                    "n": 1,
+                    "max_tokens": 2,
+                }
+                for field, value in (
+                    ("stream", True),
+                    ("temperature", float("nan")),
+                    ("top_p", 2),
+                    ("top_k", 0),
+                    ("seed", -1),
+                ):
+                    status, _ = json_request(
+                        service.endpoint,
+                        "/v1/completions",
+                        {**base, field: value},
+                    )
+                    self.assertEqual(status, 400, field)
+                self.assertEqual(model.generate_calls, [])
+
+    def test_shutdown_drains_an_inflight_generation_before_unload(self):
+        class BlockingModel(FakeModel):
+            def __init__(self):
+                super().__init__()
+                self.entered = threading.Event()
+                self.release = threading.Event()
+
+            def fast_generate(self, *args, **kwargs):
+                self.entered.set()
+                if not self.release.wait(2):
+                    raise RuntimeError("test generation was not released")
+                return super().fast_generate(*args, **kwargs)
+
+        model = BlockingModel()
+        with tempfile.TemporaryDirectory() as directory:
+            service = executor(model, Path(directory) / "device.sock")
+            service._insert("policy-a", FakeRequest("policy-a", 1), "filesystem")
+            service.start()
+            responses = []
+            request_thread = threading.Thread(
+                target=lambda: responses.append(
+                    json_request(
+                        service.endpoint,
+                        "/v1/completions",
+                        {
+                            "model": "policy-a",
+                            "prompt": ["one"],
+                            "n": 1,
+                            "max_tokens": 2,
+                        },
+                    )
+                )
+            )
+            request_thread.start()
+            self.assertTrue(model.entered.wait(2))
+            shutdown_errors = []
+            shutdown_thread = threading.Thread(
+                target=lambda: self._capture_shutdown_error(
+                    service, shutdown_errors
+                )
+            )
+            shutdown_thread.start()
+            time.sleep(0.05)
+            self.assertTrue(shutdown_thread.is_alive())
+            self.assertEqual(model.engine.removed, [])
+            model.release.set()
+            request_thread.join(timeout=2)
+            shutdown_thread.join(timeout=2)
+            self.assertFalse(request_thread.is_alive())
+            self.assertFalse(shutdown_thread.is_alive())
+            self.assertEqual(shutdown_errors, [])
+            self.assertEqual(responses[0][0], 200)
+            self.assertEqual(model.engine.removed, [1])
+
+    def test_timed_out_shutdown_retains_state_for_cleanup_retry(self):
+        class StalledModel(FakeModel):
+            def __init__(self):
+                super().__init__()
+                self.entered = threading.Event()
+                self.release = threading.Event()
+
+            def fast_generate(self, *args, **kwargs):
+                self.entered.set()
+                self.release.wait(2)
+                return super().fast_generate(*args, **kwargs)
+
+        model = StalledModel()
+        with tempfile.TemporaryDirectory() as directory:
+            service = executor(
+                model,
+                Path(directory) / "device.sock",
+                request_timeout_secs=0.1,
+            )
+            service._insert("policy-a", FakeRequest("policy-a", 1), "filesystem")
+            service.start()
+            response = []
+            request_thread = threading.Thread(
+                target=lambda: response.append(
+                    json_request(
+                        service.endpoint,
+                        "/v1/completions",
+                        {
+                            "model": "policy-a",
+                            "prompt": ["one"],
+                            "n": 1,
+                            "max_tokens": 2,
+                        },
+                    )
+                )
+            )
+            request_thread.start()
+            self.assertTrue(model.entered.wait(2))
+            request_thread.join(timeout=2)
+            self.assertEqual(response[0][0], 504)
+            with self.assertRaisesRegex(RuntimeError, "did not stop"):
+                service.shutdown()
+            self.assertEqual(service.models(), ("policy-a",))
+            self.assertEqual(model.engine.removed, [])
+            with self.assertRaisesRegex(RuntimeError, "cleanup is incomplete"):
+                service.start()
+            model.release.set()
+            deadline = time.monotonic() + 2
+            while service._batch_thread is not None and service._batch_thread.is_alive():
+                if time.monotonic() >= deadline:
+                    self.fail("batch thread did not finish after release")
+                time.sleep(0.01)
+            service.shutdown()
+            self.assertEqual(service.models(), ())
+            self.assertEqual(model.engine.removed, [1])
+
+    @staticmethod
+    def _capture_shutdown_error(service, errors):
+        try:
+            service.shutdown()
+        except Exception as error:
+            errors.append(error)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdks/python/tests/test_unsloth_vllm.py
+++ b/sdks/python/tests/test_unsloth_vllm.py
@@ -355,6 +355,29 @@ class UnslothVllmExecutorTests(unittest.TestCase):
                     self.assertEqual(value["logprob"], -0.25)
                     self.assertEqual(value["rank"], 1)
 
+    def test_repeated_prompts_receive_distinct_deterministic_seeds(self):
+        model = FakeModel()
+        with tempfile.TemporaryDirectory() as directory:
+            service = executor(model, Path(directory) / "device.sock")
+            service._insert("policy-a", FakeRequest("policy-a", 11), "filesystem")
+            with service:
+                status, _response = json_request(
+                    service.endpoint,
+                    "/v1/completions",
+                    {
+                        "model": "policy-a",
+                        "prompt": ["same", "same", "same"],
+                        "n": 1,
+                        "max_tokens": 2,
+                        "seed": 41,
+                    },
+                )
+                self.assertEqual(status, 200)
+                self.assertEqual(
+                    [values["seed"] for values in model.generate_calls[0][1]],
+                    [41, 42, 43],
+                )
+
     def test_request_larger_than_batch_limit_fails_without_queuing(self):
         model = FakeModel()
         with tempfile.TemporaryDirectory() as directory:

--- a/sdks/python/tests/test_unsloth_vllm.py
+++ b/sdks/python/tests/test_unsloth_vllm.py
@@ -132,6 +132,18 @@ def json_request(endpoint, path, body=None):
 
 
 class UnslothVllmExecutorTests(unittest.TestCase):
+    def test_default_batch_window_is_five_milliseconds(self):
+        with tempfile.TemporaryDirectory() as directory:
+            service = UnslothVllmExecutor(
+                FakeModel(),
+                Path(directory) / "device.sock",
+                port=0,
+                _request_factory=request_factory,
+                _sampling_factory=lambda **values: values,
+                _synchronize=lambda: None,
+            )
+            self.assertEqual(service.batch_window, 0.005)
+
     def test_rejects_non_loopback_listener(self):
         with tempfile.TemporaryDirectory() as directory:
             with self.assertRaisesRegex(ValueError, "loopback"):

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -149,6 +149,7 @@ use state::ApiState;
         rollout::PublishDeviceRolloutPolicyRequest,
         rollout::RolloutPrompt,
         rollout::RolloutSamplingParams,
+        rollout::RolloutCohort,
         rollout::RolloutGenerateRequest,
         rollout::RolloutBatchRequest,
         // Response types

--- a/src/api/rollout.rs
+++ b/src/api/rollout.rs
@@ -7,10 +7,11 @@
 //! fallback for requests a fused backend cannot represent.
 
 use futures_util::StreamExt;
+use parking_lot::Mutex as SyncMutex;
 use reqwest::{redirect::Policy, Client};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
@@ -40,6 +41,7 @@ const MAX_ADAPTER_FILES: usize = 4096;
 const MAX_ADAPTER_BYTES: u64 = 32 * 1024 * 1024 * 1024;
 const IDEMPOTENCY_TTL: Duration = Duration::from_secs(10 * 60);
 const MAX_IDEMPOTENCY_ENTRIES: usize = 8192;
+const MAX_COHORT_SIZE: u32 = 256;
 
 /// Request to register one local fused rollout engine.
 #[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
@@ -229,6 +231,19 @@ pub struct RolloutGenerateRequest {
     /// Optional shorter whole-request deadline.
     #[serde(default)]
     pub deadline_ms: Option<u64>,
+    /// Optional distributed admission cohort for independently submitted jobs.
+    #[serde(default)]
+    pub cohort: Option<RolloutCohort>,
+}
+
+/// A distributed batch boundary shared by independent rollout workers.
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RolloutCohort {
+    /// Unique identifier for one logical rollout round.
+    pub id: String,
+    /// Exact number of independent jobs required before any member executes.
+    pub size: u32,
 }
 
 /// A cohort of independent policy requests submitted together for backend fusion.
@@ -431,6 +446,162 @@ struct PolicyGuard {
     policy: Arc<PolicyEntry>,
 }
 
+const COHORT_WAITING: usize = 0;
+const COHORT_READY: usize = 1;
+const COHORT_FAILED: usize = 2;
+
+struct CohortEntry {
+    id: String,
+    expected: u32,
+    members: SyncMutex<HashSet<String>>,
+    state: AtomicUsize,
+    changed: Notify,
+}
+
+#[derive(Default)]
+struct CohortAdmission {
+    entries: SyncMutex<HashMap<String, Arc<CohortEntry>>>,
+}
+
+impl CohortAdmission {
+    fn join(
+        self: &Arc<Self>,
+        cohort: &RolloutCohort,
+        member: &str,
+    ) -> Result<CohortTicket, RolloutError> {
+        let mut entries = self.entries.lock();
+        let entry = entries
+            .entry(cohort.id.clone())
+            .or_insert_with(|| {
+                Arc::new(CohortEntry {
+                    id: cohort.id.clone(),
+                    expected: cohort.size,
+                    members: SyncMutex::new(HashSet::new()),
+                    state: AtomicUsize::new(COHORT_WAITING),
+                    changed: Notify::new(),
+                })
+            })
+            .clone();
+        if entry.expected != cohort.size {
+            return Err(RolloutError::Conflict(format!(
+                "rollout cohort '{}' expected {} jobs, not {}",
+                cohort.id, entry.expected, cohort.size
+            )));
+        }
+        let ready = {
+            let mut members = entry.members.lock();
+            if !members.insert(member.to_string()) {
+                return Err(RolloutError::Conflict(format!(
+                    "rollout cohort '{}' already contains member '{}'",
+                    cohort.id, member
+                )));
+            }
+            members.len() == entry.expected as usize
+        };
+        if ready
+            && entry
+                .state
+                .compare_exchange(
+                    COHORT_WAITING,
+                    COHORT_READY,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_ok()
+        {
+            entries.remove(&cohort.id);
+            entry.changed.notify_waiters();
+            metrics::counter!("smolvm_rollout_cohorts_total", "status" => "ready").increment(1);
+            metrics::histogram!("smolvm_rollout_cohort_size").record(cohort.size as f64);
+        }
+        Ok(CohortTicket {
+            admission: self.clone(),
+            entry,
+            completed: false,
+        })
+    }
+
+    fn cancel_all(&self) {
+        let entries = {
+            let mut current = self.entries.lock();
+            std::mem::take(&mut *current)
+        };
+        for entry in entries.into_values() {
+            if entry
+                .state
+                .compare_exchange(
+                    COHORT_WAITING,
+                    COHORT_FAILED,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_ok()
+            {
+                entry.changed.notify_waiters();
+                metrics::counter!("smolvm_rollout_cohorts_total", "status" => "cancelled")
+                    .increment(1);
+            }
+        }
+    }
+}
+
+struct CohortTicket {
+    admission: Arc<CohortAdmission>,
+    entry: Arc<CohortEntry>,
+    completed: bool,
+}
+
+impl CohortTicket {
+    async fn wait(mut self) -> Result<(), RolloutError> {
+        loop {
+            let changed = self.entry.changed.notified();
+            match self.entry.state.load(Ordering::Acquire) {
+                COHORT_READY => {
+                    self.completed = true;
+                    return Ok(());
+                }
+                COHORT_FAILED => {
+                    self.completed = true;
+                    return Err(RolloutError::Unavailable(format!(
+                        "rollout cohort '{}' lost a member before admission",
+                        self.entry.id
+                    )));
+                }
+                _ => changed.await,
+            }
+        }
+    }
+}
+
+impl Drop for CohortTicket {
+    fn drop(&mut self) {
+        if self.completed
+            || self
+                .entry
+                .state
+                .compare_exchange(
+                    COHORT_WAITING,
+                    COHORT_FAILED,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_err()
+        {
+            return;
+        }
+        let mut entries = self.admission.entries.lock();
+        if entries
+            .get(&self.entry.id)
+            .is_some_and(|current| Arc::ptr_eq(current, &self.entry))
+        {
+            entries.remove(&self.entry.id);
+        }
+        drop(entries);
+        self.entry.changed.notify_waiters();
+        metrics::counter!("smolvm_rollout_cohorts_total", "status" => "failed").increment(1);
+    }
+}
+
 impl Drop for PolicyGuard {
     fn drop(&mut self) {
         if self.policy.active.fetch_sub(1, Ordering::AcqRel) == 1 {
@@ -465,6 +636,7 @@ pub(crate) struct RolloutExecutor {
     accepting: AtomicBool,
     policy_state: RwLock<PolicyState>,
     publish_lock: Mutex<()>,
+    cohort_admission: Arc<CohortAdmission>,
     idempotency: Mutex<HashMap<String, Arc<IdempotencyEntry>>>,
 }
 
@@ -528,6 +700,7 @@ impl RolloutRegistry {
                 RolloutError::NotFound(format!("rollout executor '{name}' not found"))
             })?;
         executor.accepting.store(false, Ordering::Release);
+        executor.cohort_admission.cancel_all();
         executor.shutdown().await?;
         let mut executors = self.executors.write().await;
         if executors
@@ -631,6 +804,7 @@ impl RolloutExecutor {
                 current: HashMap::new(),
             }),
             publish_lock: Mutex::new(()),
+            cohort_admission: Arc::new(CohortAdmission::default()),
             idempotency: Mutex::new(HashMap::new()),
         })
     }
@@ -1319,6 +1493,12 @@ impl RolloutExecutor {
         let _policy_guard = PolicyGuard {
             policy: policy.clone(),
         };
+        if let Some(cohort) = &request.cohort {
+            self.cohort_admission
+                .join(cohort, &request.idempotency_key)?
+                .wait()
+                .await?;
+        }
         let _permit = self.acquire_queue_permit().await?;
         let body = completion_body(&request, &policy.backend_model)?;
         let started = Instant::now();
@@ -1712,6 +1892,14 @@ fn validate_generate_request(request: &RolloutGenerateRequest) -> Result<(), Rol
             "deadlineMs must be greater than zero".into(),
         ));
     }
+    if let Some(cohort) = &request.cohort {
+        validate_name("cohort.id", &cohort.id)?;
+        if !(1..=MAX_COHORT_SIZE).contains(&cohort.size) {
+            return Err(RolloutError::BadRequest(format!(
+                "cohort.size must be between 1 and {MAX_COHORT_SIZE}"
+            )));
+        }
+    }
     Ok(())
 }
 
@@ -1935,7 +2123,96 @@ mod tests {
                 prompt_logprobs: None,
             },
             deadline_ms: Some(5_000),
+            cohort: None,
         }
+    }
+
+    #[tokio::test]
+    async fn distributed_cohort_releases_only_at_exact_membership() {
+        let admission = Arc::new(CohortAdmission::default());
+        let cohort = RolloutCohort {
+            id: "round-1".into(),
+            size: 2,
+        };
+        let first = admission.join(&cohort, "request-1").unwrap();
+        let first = tokio::spawn(first.wait());
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        assert!(!first.is_finished());
+
+        admission
+            .join(&cohort, "request-2")
+            .unwrap()
+            .wait()
+            .await
+            .unwrap();
+        tokio::time::timeout(Duration::from_millis(50), first)
+            .await
+            .expect("a complete cohort must release every member")
+            .unwrap()
+            .unwrap();
+        assert!(admission.entries.lock().is_empty());
+    }
+
+    #[tokio::test]
+    async fn distributed_cohort_fails_all_members_when_one_leaves() {
+        let admission = Arc::new(CohortAdmission::default());
+        let cohort = RolloutCohort {
+            id: "round-2".into(),
+            size: 3,
+        };
+        let first = admission.join(&cohort, "request-1").unwrap();
+        let first = tokio::spawn(first.wait());
+        let second = admission.join(&cohort, "request-2").unwrap();
+        drop(second);
+
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_millis(50), first)
+                .await
+                .expect("a failed member must wake the cohort")
+                .unwrap(),
+            Err(RolloutError::Unavailable(_))
+        ));
+        assert!(admission.entries.lock().is_empty());
+    }
+
+    #[tokio::test]
+    async fn distributed_cohort_shutdown_wakes_waiters() {
+        let admission = Arc::new(CohortAdmission::default());
+        let cohort = RolloutCohort {
+            id: "round-shutdown".into(),
+            size: 2,
+        };
+        let waiting = admission.join(&cohort, "request-1").unwrap();
+        let waiting = tokio::spawn(waiting.wait());
+
+        admission.cancel_all();
+
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_millis(50), waiting)
+                .await
+                .expect("executor shutdown must wake cohort members")
+                .unwrap(),
+            Err(RolloutError::Unavailable(_))
+        ));
+        assert!(admission.entries.lock().is_empty());
+    }
+
+    #[test]
+    fn distributed_cohort_rejects_inconsistent_membership() {
+        let admission = Arc::new(CohortAdmission::default());
+        let first = RolloutCohort {
+            id: "round-3".into(),
+            size: 2,
+        };
+        let inconsistent = RolloutCohort {
+            id: first.id.clone(),
+            size: 3,
+        };
+        let _ticket = admission.join(&first, "request-1").unwrap();
+        assert!(matches!(
+            admission.join(&inconsistent, "request-2"),
+            Err(RolloutError::Conflict(_))
+        ));
     }
 
     async fn create_published_executor(
@@ -1974,6 +2251,59 @@ mod tests {
             .await
             .unwrap();
         (registry, executor, root)
+    }
+
+    #[tokio::test]
+    async fn executor_holds_distributed_cohort_before_backend_generation() {
+        let (address, backend, server) = start_mock_backend().await;
+        let (_registry, executor, _root) = create_published_executor(address).await;
+        let mut first = sample_generate("cohort-request-1");
+        first.cohort = Some(RolloutCohort {
+            id: "training-step-1".into(),
+            size: 2,
+        });
+        let first_executor = executor.clone();
+        let first = tokio::spawn(async move { first_executor.generate(first).await });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert_eq!(backend.generations.load(Ordering::Acquire), 0);
+
+        let mut second = sample_generate("cohort-request-2");
+        second.cohort = Some(RolloutCohort {
+            id: "training-step-1".into(),
+            size: 2,
+        });
+        let (first, second) = tokio::join!(first, executor.generate(second));
+        first.unwrap().unwrap();
+        second.unwrap();
+        assert_eq!(backend.generations.load(Ordering::Acquire), 2);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn timed_out_cohort_can_retry_without_stale_membership() {
+        let (address, backend, server) = start_mock_backend().await;
+        let (_registry, executor, _root) = create_published_executor(address).await;
+        let mut abandoned = sample_generate("retry-request-1");
+        abandoned.deadline_ms = Some(20);
+        abandoned.cohort = Some(RolloutCohort {
+            id: "retry-round".into(),
+            size: 2,
+        });
+        assert!(matches!(
+            executor.generate(abandoned.clone()).await,
+            Err(RolloutError::Timeout(_))
+        ));
+        assert!(executor.cohort_admission.entries.lock().is_empty());
+        assert_eq!(backend.generations.load(Ordering::Acquire), 0);
+
+        abandoned.deadline_ms = Some(5_000);
+        let mut peer = sample_generate("retry-request-2");
+        peer.cohort = abandoned.cohort.clone();
+        let (first, second) = tokio::join!(executor.generate(abandoned), executor.generate(peer));
+        first.unwrap();
+        second.unwrap();
+        assert_eq!(backend.generations.load(Ordering::Acquire), 2);
+        server.abort();
     }
 
     #[tokio::test]
@@ -2265,6 +2595,7 @@ mod tests {
                 prompt_logprobs: None,
             },
             deadline_ms: None,
+            cohort: None,
         };
         assert!(validate_generate_request(&request).is_err());
     }
@@ -2292,6 +2623,7 @@ mod tests {
                 prompt_logprobs: None,
             },
             deadline_ms: None,
+            cohort: None,
         };
         let body = completion_body(&request, "adapter").unwrap();
         assert_eq!(body["prompt"], serde_json::json!([[1, 2, 3]]));


### PR DESCRIPTION
Adds a lifecycle-safe embedded Unsloth/vLLM executor that directly loads device-resident LoRAs and continuously batches multi-policy rollouts.