### PR TITLE
Boot pods by pinning the shim's runtime environment and stripping host LSM labels

### DIFF
--- a/crates/smolvm-shim/src/engine.rs
+++ b/crates/smolvm-shim/src/engine.rs
@@ -750,9 +750,17 @@ impl PodBackend for EnginePodBackend {
         let stdio = spec.stdio.clone();
 
         // containerd's ExecProcessRequest.spec is an Any whose value is the
-        // OCI Process serialized as JSON — pass it through verbatim.
-        let process_json = String::from_utf8(spec.exec_spec.unwrap_or_default())
+        // OCI Process serialized as JSON — passed through as-is except for the
+        // host LSM labels, which containerd stamps on exec processes too and
+        // which crun cannot honor in the guest (see [`strip_host_lsm`]).
+        let mut process_json = String::from_utf8(spec.exec_spec.unwrap_or_default())
             .map_err(|e| format!("exec spec is not UTF-8 JSON: {e}"))?;
+        if let Ok(mut process) = serde_json::from_str::<serde_json::Value>(&process_json) {
+            strip_host_lsm(&mut process);
+            if let Ok(s) = serde_json::to_string(&process) {
+                process_json = s;
+            }
+        }
 
         tokio::task::spawn_blocking(move || {
             let resp = pod_request(
@@ -1002,6 +1010,22 @@ impl PodBackend for EnginePodBackend {
 /// virtual mounts in the spec (proc/sysfs/tmpfs/devpts/mqueue/cgroup) are left
 /// untouched; the guest's default OCI spec provides those. Returns the rewritten
 /// spec JSON. A source that doesn't exist on the host is skipped (left as-is).
+/// Strip host-kernel LSM settings from an OCI `process` object.
+///
+/// containerd stamps the NODE's AppArmor profile (`runtime/default`) into every
+/// container and exec process spec, and a SELinux label on SELinux hosts. Both
+/// name policy loaded in the host kernel. The pod's guest kernel has neither, so
+/// crun aborts the container outright — "AppArmor is not initialized correctly"
+/// — and the pod CrashLoopBackOffs with no useful signal. Nothing is weakened by
+/// dropping them: the VM boundary is the isolation, and a host LSM label has
+/// nothing to attach to on the other side of it (the same reason Kata drops it).
+fn strip_host_lsm(process: &mut serde_json::Value) {
+    if let Some(obj) = process.as_object_mut() {
+        obj.remove("apparmorProfile");
+        obj.remove("selinuxLabel");
+    }
+}
+
 fn materialize_bind_mounts(
     spec_json: &str,
     share_dir: &Path,
@@ -1011,6 +1035,11 @@ fn materialize_bind_mounts(
 ) -> Result<String, String> {
     let mut spec: serde_json::Value =
         serde_json::from_str(spec_json).map_err(|e| format!("parse config.json: {e}"))?;
+
+    // The guest kernel has no AppArmor/SELinux policy loaded; see [`strip_host_lsm`].
+    if let Some(process) = spec.get_mut("process") {
+        strip_host_lsm(process);
+    }
 
     // Inject the pod hostname if the container spec doesn't carry one.
     if let Some(h) = sandbox_hostname {
@@ -1256,5 +1285,46 @@ impl PodBackend for ShimBackend {
             Self::Mock(b) => b.stats(id).await,
             Self::Engine(b) => b.stats(id).await,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// containerd stamps the host's AppArmor profile / SELinux label into the
+    /// container spec; the guest kernel has neither, so crun would abort the
+    /// container ("AppArmor is not initialized correctly").
+    #[test]
+    fn materialize_strips_host_lsm_from_container_spec() {
+        let spec = r#"{
+            "hostname": "pod-a",
+            "process": {
+                "args": ["sh"],
+                "apparmorProfile": "runtime/default",
+                "selinuxLabel": "system_u:system_r:container_t:s0"
+            }
+        }"#;
+        let out = materialize_bind_mounts(spec, Path::new("/nonexistent"), "c1", None, None)
+            .expect("materialize");
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert!(v["process"].get("apparmorProfile").is_none());
+        assert!(v["process"].get("selinuxLabel").is_none());
+        // The rest of the process object is untouched.
+        assert_eq!(v["process"]["args"][0], "sh");
+    }
+
+    /// Exec specs get the same containerd stamp; `strip_host_lsm` is what the
+    /// exec path applies to the raw OCI Process JSON.
+    #[test]
+    fn strip_host_lsm_leaves_other_fields() {
+        let mut process: serde_json::Value = serde_json::from_str(
+            r#"{"args":["env"],"env":["A=1"],"apparmorProfile":"runtime/default"}"#,
+        )
+        .unwrap();
+        strip_host_lsm(&mut process);
+        assert!(process.get("apparmorProfile").is_none());
+        assert_eq!(process["env"][0], "A=1");
+        assert_eq!(process["args"][0], "env");
     }
 }

--- a/crates/smolvm-shim/src/main.rs
+++ b/crates/smolvm-shim/src/main.rs
@@ -14,8 +14,55 @@ mod service;
 #[cfg(target_os = "linux")]
 mod task;
 
+/// Node runtime layout laid down by `scripts/install-k8s-runtime.sh`.
+#[cfg(target_os = "linux")]
+const RUNTIME_ROOT: &str = "/var/lib/smolvm";
+
+/// Point the embedded engine at the node's runtime artifacts.
+///
+/// containerd execs the shim with a minimal environment, from the bundle dir,
+/// so nothing the engine discovers relative to `current_exe` resolves: libkrun
+/// is not next to `/usr/local/bin/containerd-shim-smolvm-v2`, and neither is
+/// the agent rootfs. Worse, the engine boots every VM as a subprocess
+/// `<boot binary> _boot-vm <config.json>` defaulting to `current_exe` — and
+/// this binary does not serve `_boot-vm`, so a pod sandbox would never boot.
+/// Resolve all three against the install layout, honoring operator overrides.
+///
+/// Called from `main` before the tokio runtime exists, so the process is still
+/// single-threaded and the `set_var`s are sound.
+#[cfg(target_os = "linux")]
+fn init_runtime_env() {
+    let root = std::env::var_os("SMOLVM_DATA_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| {
+            let root = std::path::PathBuf::from(RUNTIME_ROOT);
+            std::env::set_var("SMOLVM_DATA_DIR", &root);
+            root
+        });
+    if std::env::var_os("SMOLVM_LIB_DIR").is_none() {
+        std::env::set_var("SMOLVM_LIB_DIR", root.join("lib"));
+    }
+    // `smolvm-vmm` is the installed smolvm binary, the one that serves `_boot-vm`.
+    // Setting this also arms the boot child's parent-death watchdog, which is what
+    // we want here: the pod VM belongs to this shim and must not outlive it.
+    if std::env::var_os("SMOLVM_BOOT_BINARY").is_none() {
+        std::env::set_var("SMOLVM_BOOT_BINARY", root.join("smolvm-vmm"));
+    }
+    // The rootfs otherwise resolves next to `current_exe` (a shim in /usr/local/bin
+    // has none) or under `$HOME/.local/share/smolvm` — neither is where
+    // install-k8s-runtime.sh lays it down. The Linux tarball's wrapper script sets
+    // this same variable for the CLI; the shim has no wrapper, so set it here.
+    if std::env::var_os("SMOLVM_AGENT_ROOTFS").is_none() {
+        std::env::set_var("SMOLVM_AGENT_ROOTFS", root.join("agent-rootfs"));
+    }
+    // Root every dirs::-derived path (agent rootfs, per-VM dirs, machine db) at
+    // the data root, the same relocation `smolvm serve` performs on this node.
+    smolvm::process::apply_system_data_root(false);
+}
+
 #[cfg(target_os = "linux")]
 fn main() {
+    init_runtime_env();
     service::run_shim();
 }
 

--- a/scripts/install-k8s-runtime.sh
+++ b/scripts/install-k8s-runtime.sh
@@ -9,31 +9,41 @@
 # an operator (or a config-management tool) applies them deliberately.
 #
 # Usage:
-#   sudo ./scripts/install-k8s-runtime.sh [--shim PATH] [--runtime-dir DIR]
+#   sudo ./scripts/install-k8s-runtime.sh [--shim PATH] [--runtime-dir DIR] [--smolvm PATH]
 #
 #   --shim PATH          The built containerd-shim-smolvm-v2 binary
 #                        (default: target/release/containerd-shim-smolvm-v2).
 #   --runtime-dir DIR    A directory holding the smolvm runtime artifacts to
 #                        install into /var/lib/smolvm: lib/ (libkrun*.so),
-#                        init.krun, smolvm-vmm, agent-rootfs/. A smolvm Linux
-#                        distribution directory has these. If omitted, the
-#                        artifacts already under /var/lib/smolvm are kept and
-#                        only the shim is (re)installed.
+#                        init.krun, agent-rootfs/, and the smolvm binary
+#                        (smolvm-bin in a distribution directory). If omitted,
+#                        the artifacts already under /var/lib/smolvm are kept
+#                        and only the shim is (re)installed.
+#   --smolvm PATH        The smolvm binary to install as the VM boot helper
+#                        /var/lib/smolvm/smolvm-vmm. Defaults to smolvm-bin (or
+#                        smolvm) inside --runtime-dir, else target/release/smolvm.
+#                        The engine boots each pod VM as a subprocess
+#                        `<boot helper> _boot-vm <config.json>`; the shim binary
+#                        cannot serve that, so this helper is REQUIRED — without
+#                        it no pod sandbox boots.
 #
 set -euo pipefail
 
 SHIM_SRC="target/release/containerd-shim-smolvm-v2"
 RUNTIME_SRC=""
+SMOLVM_SRC=""
 DATA_DIR="/var/lib/smolvm"
 BIN_DIR="/usr/local/bin"
 SHIM_DST="$BIN_DIR/containerd-shim-smolvm-v2"
-RUNTIME_ARTIFACTS=(lib init.krun smolvm-vmm agent-rootfs)
+BOOT_DST="$DATA_DIR/smolvm-vmm"
+RUNTIME_ARTIFACTS=(lib init.krun agent-rootfs)
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --shim) SHIM_SRC="$2"; shift 2 ;;
         --runtime-dir) RUNTIME_SRC="$2"; shift 2 ;;
-        -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+        --smolvm) SMOLVM_SRC="$2"; shift 2 ;;
+        -h|--help) sed -n '2,38p' "$0"; exit 0 ;;
         *) echo "unknown argument: $1" >&2; exit 2 ;;
     esac
 done
@@ -58,12 +68,63 @@ else
     echo "    (no --runtime-dir; keeping existing artifacts)"
 fi
 
+# The VM boot helper. The engine spawns `<boot helper> _boot-vm <config.json>`
+# per VM (see agent::manager), pointed at $SMOLVM_BOOT_BINARY, which the shim
+# defaults to $DATA_DIR/smolvm-vmm. A distribution ships the real binary as
+# smolvm-bin (plain `smolvm` there is a wrapper script, no good as a boot exec).
+if [ -z "$SMOLVM_SRC" ] && [ -n "$RUNTIME_SRC" ]; then
+    for c in smolvm-bin smolvm; do
+        if [ -f "$RUNTIME_SRC/$c" ] && [ -x "$RUNTIME_SRC/$c" ]; then SMOLVM_SRC="$RUNTIME_SRC/$c"; break; fi
+    done
+fi
+[ -n "$SMOLVM_SRC" ] || SMOLVM_SRC="target/release/smolvm"
+if [ -f "$SMOLVM_SRC" ]; then
+    echo "==> Installing VM boot helper: $SMOLVM_SRC -> $BOOT_DST"
+    install -Dm755 "$SMOLVM_SRC" "$BOOT_DST.tmp"
+    mv -f "$BOOT_DST.tmp" "$BOOT_DST"
+elif [ ! -x "$BOOT_DST" ]; then
+    echo "error: no smolvm binary to install as the boot helper ($SMOLVM_SRC not found)" >&2
+    echo "       build it with: cargo build --release  (or pass --smolvm PATH)" >&2
+    exit 1
+else
+    echo "==> Keeping existing VM boot helper: $BOOT_DST"
+fi
+
+# Pre-formatted disk templates. Without them every VM's storage/overlay disk is
+# built with mkfs.ext4 at boot instead of a hole-preserving copy (or a qcow2
+# overlay off the template), which is markedly slower per pod. The engine looks
+# them up at $HOME/.smolvm/, and the shim roots HOME at $DATA_DIR — so they go in
+# $DATA_DIR/.smolvm. Sizing to the default virtual size here is what lets the fast
+# overlay path be used at boot (mirrors scripts/install.sh).
+if [ -n "$RUNTIME_SRC" ]; then
+    mkdir -p "$DATA_DIR/.smolvm"
+    for t in storage-template.ext4:20G overlay-template.ext4:10G; do
+        name="${t%%:*}"; size="${t##*:}"
+        if [ -f "$RUNTIME_SRC/$name" ]; then
+            echo "==> Installing disk template: $name (sized $size)"
+            cp --sparse=always "$RUNTIME_SRC/$name" "$DATA_DIR/.smolvm/$name" 2>/dev/null \
+                || cp "$RUNTIME_SRC/$name" "$DATA_DIR/.smolvm/$name"
+            truncate -s "$size" "$DATA_DIR/.smolvm/$name"
+        else
+            echo "    note: $name not in $RUNTIME_SRC — disks will be mkfs'd per VM (slower)" >&2
+        fi
+    done
+fi
+
 # Sanity-check the artifacts the shim will need at runtime are present.
 missing=0
 for a in lib/libkrun.so agent-rootfs smolvm-vmm; do
     [ -e "$DATA_DIR/$a" ] || { echo "error: required artifact missing: $DATA_DIR/$a" >&2; missing=1; }
 done
 [ "$missing" = 0 ] || { echo "install incomplete — supply --runtime-dir with a smolvm distribution" >&2; exit 1; }
+
+# The boot helper must actually serve `_boot-vm` — installing the wrong binary
+# here (the shim, a wrapper script) fails at the first pod, not at install time.
+if ! "$BOOT_DST" _boot-vm --help >/dev/null 2>&1; then
+    echo "error: $BOOT_DST does not serve '_boot-vm' — it is not a smolvm binary." >&2
+    echo "       Pod sandboxes cannot boot without it. Pass --smolvm PATH." >&2
+    exit 1
+fi
 
 echo "==> Installing shim: $SHIM_SRC -> $SHIM_DST"
 install -Dm755 "$SHIM_SRC" "$SHIM_DST.tmp"

--- a/tests/k8s_pod_e2e.sh
+++ b/tests/k8s_pod_e2e.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+#
+# End-to-end check for the Kubernetes runtime (containerd-shim-smolvm-v2).
+#
+# Run ON THE NODE, as root, after scripts/install-k8s-runtime.sh and the
+# containerd + RuntimeClass registration it prints. Two phases:
+#
+#   preflight  Host and install checks that touch nothing (KVM, containerd
+#              registration, runtime artifacts, boot helper, reflink support).
+#   pod        Creates one pod through the smolvm RuntimeClass and asserts it
+#              really is a VM (own kernel, own CPU count), that logs/exec/pod-IP
+#              work, and that teardown leaves nothing behind.
+#
+# Usage:
+#   sudo ./tests/k8s_pod_e2e.sh [--preflight-only] [--image IMG] [--keep]
+#
+#   --preflight-only  Stop after the host checks; never touches the cluster.
+#   --image IMG       Pod image (default: nginx:1.27-alpine; must serve :80).
+#   --keep            Leave the pod running (for manual poking / a demo).
+#
+set -uo pipefail
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+PASS=0; FAIL=0; WARN=0
+ok()   { echo -e "  ${GREEN}PASS${NC}  $*"; PASS=$((PASS+1)); }
+bad()  { echo -e "  ${RED}FAIL${NC}  $*"; FAIL=$((FAIL+1)); }
+warn() { echo -e "  ${YELLOW}WARN${NC}  $*"; WARN=$((WARN+1)); }
+phase(){ echo -e "\n${BLUE}==> $*${NC}"; }
+
+IMAGE="nginx:1.27-alpine"
+PREFLIGHT_ONLY=0
+KEEP=0
+DATA_DIR="/var/lib/smolvm"
+SHARE_ROOT="/var/lib/containerd-shim-smolvm"
+POD="smolvm-e2e-$$"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --preflight-only) PREFLIGHT_ONLY=1; shift ;;
+        --image) IMAGE="$2"; shift 2 ;;
+        --keep) KEEP=1; shift ;;
+        -h|--help) sed -n '2,22p' "$0"; exit 0 ;;
+        *) echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+# ============================== preflight ==============================
+
+phase "Preflight: host"
+
+[ "$(id -u)" = 0 ] && ok "running as root" || bad "not root — rerun with sudo"
+
+if [ -e /dev/kvm ]; then
+    [ -r /dev/kvm ] && [ -w /dev/kvm ] && ok "/dev/kvm present and writable" \
+        || bad "/dev/kvm exists but is not writable by this user"
+else
+    bad "/dev/kvm missing — no hardware virtualization (nested virt off?). Pods cannot boot."
+fi
+
+if command -v containerd >/dev/null 2>&1; then
+    CTD_VER="$(containerd --version 2>/dev/null | awk '{print $3}')"
+    case "$CTD_VER" in
+        v2.*) ok "containerd $CTD_VER" ;;
+        v1.*) warn "containerd $CTD_VER — the shim targets 2.x; 1.x needs the legacy CRI config path and lacks the sandbox grouping this shim relies on" ;;
+        *)    warn "containerd version not parsed: ${CTD_VER:-unknown}" ;;
+    esac
+else
+    bad "containerd not on PATH"
+fi
+
+phase "Preflight: install"
+
+SHIM="$(command -v containerd-shim-smolvm-v2 || echo /usr/local/bin/containerd-shim-smolvm-v2)"
+if [ -x "$SHIM" ]; then
+    ok "shim installed: $SHIM"
+    SHIM_ARCH="$(file -b "$SHIM" 2>/dev/null | grep -o 'x86-64\|aarch64\|ARM aarch64' | head -1)"
+    HOST_ARCH="$(uname -m)"
+    case "$HOST_ARCH:$SHIM_ARCH" in
+        x86_64:x86-64|aarch64:aarch64|aarch64:"ARM aarch64") ok "shim arch matches host ($HOST_ARCH)" ;;
+        *:"") warn "could not determine shim arch (file(1) unavailable?)" ;;
+        *) bad "shim arch '$SHIM_ARCH' does not match host $HOST_ARCH — built on the wrong machine" ;;
+    esac
+else
+    bad "shim not found at $SHIM (build: cargo build --release -p smolvm-shim, then scripts/install-k8s-runtime.sh)"
+fi
+
+for a in lib/libkrun.so agent-rootfs smolvm-vmm; do
+    [ -e "$DATA_DIR/$a" ] && ok "artifact present: $DATA_DIR/$a" \
+        || bad "artifact MISSING: $DATA_DIR/$a"
+done
+
+# The engine boots each pod VM as `<boot helper> _boot-vm <config.json>`. The
+# shim binary cannot serve that, so a wrong/absent helper means no pod ever boots.
+if [ -x "$DATA_DIR/smolvm-vmm" ]; then
+    if "$DATA_DIR/smolvm-vmm" _boot-vm --help >/dev/null 2>&1; then
+        ok "boot helper serves _boot-vm"
+    else
+        bad "$DATA_DIR/smolvm-vmm does not serve _boot-vm — not a smolvm binary. No pod will boot."
+    fi
+fi
+
+if containerd config dump 2>/dev/null | grep -q 'io.containerd.smolvm.v2'; then
+    ok "containerd registers io.containerd.smolvm.v2"
+    containerd config dump 2>/dev/null | grep -q "sandboxer = 'podsandbox'\|sandboxer = \"podsandbox\"" \
+        && ok "sandboxer = podsandbox" \
+        || warn "runtime registered without sandboxer='podsandbox' — container tasks may not reach the pod's shim"
+else
+    bad "containerd config has no io.containerd.smolvm.v2 runtime (add it and restart containerd)"
+fi
+
+phase "Preflight: filesystem (pod start cost)"
+
+mkdir -p "$SHARE_ROOT"
+SHARE_FS="$(stat -f -c %T "$SHARE_ROOT" 2>/dev/null)"
+CTD_ROOT="/var/lib/containerd"
+CTD_FS="$(stat -f -c %T "$CTD_ROOT" 2>/dev/null || echo unknown)"
+echo "      pod share:  $SHARE_ROOT ($SHARE_FS)"
+echo "      snapshots:  $CTD_ROOT ($CTD_FS)"
+
+SHARE_DEV="$(stat -c %d "$SHARE_ROOT" 2>/dev/null)"
+CTD_DEV="$(stat -c %d "$CTD_ROOT" 2>/dev/null || echo none)"
+[ "$SHARE_DEV" = "$CTD_DEV" ] && ok "pod share and snapshotter are on the same filesystem" \
+    || warn "pod share and snapshotter are on DIFFERENT filesystems — every container rootfs is a full byte copy"
+
+# Empirical, not by filesystem name: does a reflink actually succeed here?
+RT="$SHARE_ROOT/.reflink-probe"
+rm -rf "$RT"; mkdir -p "$RT"
+head -c 1048576 /dev/urandom > "$RT/src" 2>/dev/null
+if cp --reflink=always "$RT/src" "$RT/dst" 2>/dev/null; then
+    ok "reflink works on the pod share — container rootfs copies are near-free"
+else
+    warn "reflink NOT supported here (ext4?) — each container start copies the whole image. Expect slow pod starts; use XFS (reflink=1) or Btrfs."
+fi
+rm -rf "$RT"
+
+if [ "$PREFLIGHT_ONLY" = 1 ]; then
+    phase "Preflight summary"
+    echo -e "  ${GREEN}$PASS passed${NC}, ${YELLOW}$WARN warnings${NC}, ${RED}$FAIL failed${NC}"
+    [ "$FAIL" = 0 ] && exit 0 || exit 1
+fi
+
+if [ "$FAIL" != 0 ]; then
+    echo -e "\n${RED}Preflight failed — not starting a pod. Fix the above first.${NC}"
+    exit 1
+fi
+
+# ================================ pod ==================================
+
+command -v kubectl >/dev/null 2>&1 || { echo -e "${RED}kubectl not on PATH${NC}"; exit 1; }
+
+cleanup() {
+    if [ "$KEEP" = 1 ]; then
+        echo -e "\n${YELLOW}--keep: leaving pod/$POD running${NC}"
+        return
+    fi
+    kubectl delete pod "$POD" --ignore-not-found --wait=true --timeout=60s >/dev/null 2>&1
+}
+trap cleanup EXIT
+
+phase "Pod: RuntimeClass"
+if kubectl get runtimeclass smolvm >/dev/null 2>&1; then
+    ok "RuntimeClass smolvm exists"
+else
+    kubectl apply -f - >/dev/null <<'YAML' && ok "RuntimeClass smolvm created" || bad "could not create RuntimeClass"
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: smolvm
+handler: smolvm
+YAML
+fi
+
+phase "Pod: create $POD ($IMAGE)"
+kubectl apply -f - >/dev/null <<YAML || bad "kubectl apply failed"
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $POD
+spec:
+  runtimeClassName: smolvm
+  containers:
+    - name: app
+      image: $IMAGE
+      ports: [{containerPort: 80}]
+YAML
+
+START=$(date +%s)
+if kubectl wait --for=condition=Ready "pod/$POD" --timeout=180s >/dev/null 2>&1; then
+    ok "pod Ready in $(( $(date +%s) - START ))s"
+else
+    bad "pod never became Ready (180s)"
+    echo -e "\n${YELLOW}--- kubectl describe ---${NC}"
+    kubectl describe "pod/$POD" 2>&1 | tail -30
+    echo -e "\n${YELLOW}--- containerd log (last 40) ---${NC}"
+    journalctl -u containerd --no-pager -n 40 2>/dev/null | tail -40
+    echo -e "\n${RED}$PASS passed, $WARN warnings, $FAIL failed${NC}"
+    exit 1
+fi
+
+phase "Pod: is it actually a VM?"
+
+HOST_KERNEL="$(uname -r)"
+GUEST_KERNEL="$(kubectl exec "$POD" -- uname -r 2>/dev/null | tr -d '\r\n')"
+if [ -n "$GUEST_KERNEL" ] && [ "$GUEST_KERNEL" != "$HOST_KERNEL" ]; then
+    ok "guest kernel $GUEST_KERNEL != host kernel $HOST_KERNEL (real VM boundary)"
+elif [ -z "$GUEST_KERNEL" ]; then
+    bad "kubectl exec returned nothing — exec path broken"
+else
+    bad "guest kernel == host kernel ($HOST_KERNEL) — this is NOT running in a VM"
+fi
+
+CPUS="$(kubectl exec "$POD" -- sh -c 'grep -c ^processor /proc/cpuinfo' 2>/dev/null | tr -d '\r\n')"
+[ "$CPUS" = "2" ] && ok "guest sees 2 vCPUs (the sandbox VM's fixed sizing)" \
+    || warn "guest sees ${CPUS:-?} CPUs (expected 2 — the shim's hardcoded SANDBOX_CPUS)"
+
+# Match the running executable, not a command line — a pgrep pattern matches this
+# script's own argv (and any ssh wrapper carrying it) and reports false positives.
+VMPROCS="$(ls -l /proc/*/exe 2>/dev/null | grep -c 'smolvm-vmm' || true)"
+[ "${VMPROCS:-0}" -gt 0 ] && ok "$VMPROCS VM process(es) running on the node" \
+    || warn "no smolvm-vmm process found — the pod may not be VM-backed"
+
+phase "Pod: networking, logs, exec"
+
+POD_IP="$(kubectl get pod "$POD" -o jsonpath='{.status.podIP}' 2>/dev/null)"
+if [ -n "$POD_IP" ]; then
+    ok "pod has a CNI IP: $POD_IP"
+    if curl -sS --max-time 8 "http://$POD_IP" >/dev/null 2>&1; then
+        ok "node reached $POD_IP:80 (netns-tap L2 bridge works)"
+    else
+        bad "could not reach $POD_IP:80 from the node — pod networking is not wired through"
+    fi
+else
+    bad "pod has no IP — netns bridging failed (VM would only have NAT egress)"
+fi
+
+# The curl above is the request nginx should have logged.
+if [ -n "$(kubectl logs "$POD" 2>/dev/null | head -c 1)" ]; then
+    ok "kubectl logs streams container output"
+else
+    bad "kubectl logs is empty — the stdio pump is not delivering to containerd fifos"
+fi
+
+MARK="e2e-$RANDOM"
+ECHOED="$(kubectl exec "$POD" -- sh -c "echo $MARK > /tmp/probe && cat /tmp/probe" 2>/dev/null | tr -d '\r\n')"
+[ "$ECHOED" = "$MARK" ] && ok "exec round-trip (write + read in guest)" \
+    || bad "exec round-trip failed (got '${ECHOED:-<empty>}')"
+
+phase "Pod: teardown"
+if [ "$KEEP" = 1 ]; then
+    warn "--keep set; skipping teardown assertions"
+else
+    # What matters is BYTES reclaimed, not directory count: the rootfs copy is the
+    # only thing with real size, and an empty <sandbox-id>/podshare skeleton left
+    # behind costs ~4 KB. Counting dirs reports a scary leak that isn't one.
+    KB_BEFORE="$(du -sk "$SHARE_ROOT" 2>/dev/null | cut -f1)"
+    kubectl delete pod "$POD" --wait=true --timeout=90s >/dev/null 2>&1 \
+        && ok "pod deleted" || bad "pod delete timed out"
+    sleep 3
+    KB_AFTER="$(du -sk "$SHARE_ROOT" 2>/dev/null | cut -f1)"
+    if [ "${KB_AFTER:-0}" -lt 1024 ]; then
+        ok "pod share reclaimed (${KB_BEFORE}KB -> ${KB_AFTER}KB; empty skeleton dirs are harmless)"
+    else
+        warn "$((KB_AFTER/1024))MB still under $SHARE_ROOT after delete — rootfs copies are not being reclaimed"
+    fi
+    VMPROCS_AFTER="$(ls -l /proc/*/exe 2>/dev/null | grep -c 'smolvm-vmm' || true)"
+    [ "${VMPROCS_AFTER:-0}" = 0 ] && ok "no VM processes left behind" \
+        || warn "$VMPROCS_AFTER smolvm-vmm process(es) still running after pod delete — orphaned VMs hold their full RAM"
+fi
+
+phase "Summary"
+echo -e "  ${GREEN}$PASS passed${NC}, ${YELLOW}$WARN warnings${NC}, ${RED}$FAIL failed${NC}"
+[ "$FAIL" = 0 ] || exit 1


### PR DESCRIPTION
The Kubernetes runtime couldn't start a single sandbox, for two reasons.

First, the shim was re-executing itself to boot a VM, but it doesn't serve `_boot-vm` (the code already handles this for the Node SDK and for `smol`), and the shim is just a third case nobody wired up.

Second, containerd stamps a host AppArmor label into every container and exec spec, and the guest kernel has no AppArmor, so crun aborts and every pod CrashLoopBackOffs on Ubuntu and SELinux nodes. We strip the label rather than honor it, because the VM boundary is already the isolation and the profile name is meaningless outside the host that made it.

---

## Why

On `main` the k8s runtime cannot start a single sandbox. Three failures fire in sequence, each masking the next, and none of them are visible without a real node — the shim's unit tests pass throughout:

1. Every sandbox fails to start, because the engine re-execs a binary that does not serve `_boot-vm`.
2. Once sandboxes start, every container and every `kubectl exec` dies with `AppArmor is not initialized correctly` → CrashLoopBackOff. This hits **every Ubuntu or SELinux node**, which is most of them.
3. Nothing in the tree would have caught either, because there was no node-side test.

The result is that "smolvm as a Kubernetes runtime" is currently a claim with no working path behind it. That is what this PR is for.

## How

**1. Engine environment never resolved inside the shim** (`main.rs`, `install-k8s-runtime.sh`). containerd execs the shim with a minimal env, so the engine's boot binary fell back to `current_exe` — the shim itself, which doesn't serve `_boot-vm`. Same story for the agent rootfs (the Linux tarball's wrapper script normally sets `SMOLVM_AGENT_ROOTFS`; the shim has no wrapper), libkrun, and the data root. The shim now pins all four to the install layout, each overridable. The install script also installs the boot helper it was requiring but never installing (`smolvm-bin` → `smolvm-vmm`, probed for `_boot-vm` at install time) and the disk templates.

**2. Host LSM labels abort every container** (`engine.rs`). containerd stamps `runtime/default` into container *and exec* specs. The guest kernel has no AppArmor policy, so crun aborts. `strip_host_lsm()` drops `apparmorProfile`/`selinuxLabel` on both paths — the VM boundary is the isolation, and a host LSM label has nothing to attach to inside the guest. Kata drops these for the same reason. Unit-tested.

**3. `tests/k8s_pod_e2e.sh`** — node-side preflight (KVM, registration, artifacts, `_boot-vm` probe, empirical reflink check) plus a full pod lifecycle: real-VM assertions (guest kernel ≠ host kernel), CNI pod IP reachability, logs/exec round-trip, teardown reclaim.

## Alternatives considered

**Fix it in the guest kernel instead of stripping host-side** — @BinSquare asked this directly on `engine.rs:1021`, and it's the right question to ask, especially since the guest kernel *did* just gain an LSM. Recording the answer here rather than leaving it in a review thread.

Verified state of the shipped guest kernel (libkrunfw at `85728e46`, which `main` pins), on both x86_64 and aarch64:

```
CONFIG_SECURITY=y
CONFIG_SECURITY_LANDLOCK=y      # added by #847
# no CONFIG_SECURITY_APPARMOR
# no CONFIG_SECURITY_SELINUX
```

Enabling AppArmor there would not fix this. `runtime/default` is a profile containerd **generates and loads into the host kernel** — it is a name, resolved against whatever profiles that kernel has loaded. A guest kernel with AppArmor compiled in but no such profile loaded fails *differently*: "profile not found" instead of "not initialized correctly". To honor the label in-guest you would need apparmor userspace in the agent rootfs, profile generation, and boot-time loading — and even then you would still need strip logic for `localhost/<profile>` (arbitrary host-defined names that cannot be reconstructed guest-side) and for `selinuxLabel`, which the guest kernel also has no support for.

So the host-side strip is required either way. Kernel work here is **additive hardening, not a replacement**, and it's worth doing as a follow-up since it touches libkrunfw releases: AppArmor in the guest kernel, the agent loading a generated default profile, and the shim passing the label through only when the guest advertises support. Happy to open that as its own issue.

**Let crun ignore the label** — crun is correct to fail when asked to apply a profile that isn't loaded, and it isn't ours to change.

**Tell users to set `securityContext: unconfined` in every manifest** — pushes a workaround onto every pod on every node, and doesn't help `exec` specs, which containerd stamps independently of the pod spec.

## Validation

Full run on a KVM node (Ubuntu 22.04.5, containerd **2.1.4**, Kubernetes v1.33.13, flannel, XFS reflink store): **25 passed / 0 failed** —

- pod Ready in **1.7–2.0 s** (nginx:alpine, warm image)
- guest kernel 6.12.95 vs host 5.15.0-143 (real VM boundary)
- CNI pod IP assigned and reachable from the node; `kubectl logs` / `exec` work
- teardown reclaims the 49 MB rootfs copy; no orphan VM processes

Note: containerd 2.1.4 works — the `2a225162` sandbox-grouping fix is not 2.2-specific, despite the commit message.

## Validated against #876's k3s deployment

Re-tested 2026-08-09 on Ubuntu 24.04 with AppArmor **enforcing** and real `/dev/kvm`,
against the k3s deployment merged in #876.

- **On `main`:** your `deploy/kubernetes/example-pod.yaml` fails — `AppArmor is not
  initialized correctly`. k3s's containerd does stamp the profile
  (`"apparmorProfile":"cri-containerd.apparmor.d"`), so the path is live.
- **With this PR:** pod reaches Ready (`SMOLVM_K8S_E2E_OK`, guest kernel 6.12.95 vs host
  6.8.0), and your own `deploy/k3s/e2e-test.sh` reports **E2E PASS**, `kubectl exec`
  included.

**Necessary but not sufficient on current k3s stable.** k3s v1.36.3 bundles containerd
v2.3.2, and there the shim never starts at all: `Protobuf(Error(WireError(IncorrectTag(46))))`.
containerd **v2.3.0+** writes a `BootstrapParams` protobuf to the shim's stdin
unconditionally, which the `containerd-shim` 0.11 crate mis-parses as the legacy
`Any(Options)` — filed as #889 with the source trace and a proposed upstream fix. It hits
`main` and this PR identically and is not in scope here; I stubbed stdin to `/dev/null` to
get past it. **containerd ≤2.2 is unaffected**, so on those versions this PR alone
unblocks #876.

Caveats: aarch64 in a Lima VM rather than x86_64 bare metal (both bugs are
arch-independent, and the 07-17 run covered x86_64 on containerd 2.1.4);
`sandboxer=podsandbox` was set mid-debug and left in place for the green runs, so your
exact no-sandboxer config was not re-isolated afterwards.

## Size

459 lines, which is larger than I'd normally send. The three parts are separable in principle, but items 1 and 2 are each individually necessary for a pod to boot at all, so splitting would produce two PRs that can't be validated on their own and an e2e test with nothing passing to guard. Happy to split if you'd rather review them apart.

## Not addressed here (follow-ups)

- Pod requests/limits → `MachineSpec` sizing (still hardcoded 2 CPU / 1 GiB)
- CRI volumes are copied, not bind-mounted (idmapped-bind-mount sketch exists)
- `docs/kubernetes-runtime.md` is referenced from the code but doesn't exist yet
- Guest-side LSM hardening, per the alternatives section above



