### PR TITLE
Add prepared trainer forkpoints

### DIFF
--- a/sdks/python/src/smolvm_rollout/__init__.py
+++ b/sdks/python/src/smolvm_rollout/__init__.py
@@ -8,6 +8,7 @@ from .device_handoff import (
     publish_device_adapter,
 )
 from .torch_handoff import TorchDeviceAdapter, import_torch_device_adapter
+from .transformers import add_transformers_forkpoint, transformers_forkpoint_callback
 from .unsloth_vllm import UnslothVllmExecutor
 
 __all__ = [
@@ -19,6 +20,8 @@ __all__ = [
     "TorchDeviceAdapter",
     "UnslothVllmExecutor",
     "adapter_sha256",
+    "add_transformers_forkpoint",
     "publish_device_adapter",
     "import_torch_device_adapter",
+    "transformers_forkpoint_callback",
 ]

--- a/sdks/python/src/smolvm_rollout/transformers.py
+++ b/sdks/python/src/smolvm_rollout/transformers.py
@@ -1,0 +1,87 @@
+"""Transformers integration for prepared smolvm forkpoints."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Sequence
+
+
+_ENV_KEY = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def _read_fork_env(path: Path) -> dict[str, str]:
+    if not path.is_file():
+        return {}
+
+    values = {}
+    for line_number, line in enumerate(path.read_text().splitlines(), 1):
+        if not line:
+            continue
+        key, separator, value = line.partition("=")
+        if not separator or _ENV_KEY.fullmatch(key) is None:
+            raise ValueError(f"invalid fork environment at {path}:{line_number}")
+        values[key] = value
+    return values
+
+
+def transformers_forkpoint_callback(
+    *,
+    command: str | Sequence[str] = "smolvm-fork-ready",
+    env_path: str | Path = "/etc/smolvm/fork-env",
+    reseed: bool = True,
+):
+    """Create a callback that forks after Transformers prepares the trainer."""
+    try:
+        from transformers import TrainerCallback, set_seed
+    except ImportError as error:
+        raise RuntimeError(
+            "transformers_forkpoint_callback requires the transformers package"
+        ) from error
+
+    argv = (command,) if isinstance(command, str) else tuple(command)
+    if not argv or any(not isinstance(value, str) or not value for value in argv):
+        raise ValueError("forkpoint command must contain non-empty strings")
+    fork_env_path = Path(env_path)
+
+    class SmolvmTrainerForkpointCallback(TrainerCallback):
+        def __init__(self):
+            self.released = False
+            self.fork_env: dict[str, str] = {}
+            self.seed: int | None = None
+
+        def on_train_begin(self, args, _state, control, **_kwargs):
+            if self.released:
+                return control
+
+            subprocess.run(argv, check=True)
+            self.released = True
+            self.fork_env = _read_fork_env(fork_env_path)
+            os.environ.update(self.fork_env)
+
+            if reseed:
+                seed_text = self.fork_env.get("SMOLVM_FORK_SEED")
+                if seed_text is None:
+                    index = self.fork_env.get("SMOLVM_FORK_INDEX")
+                    if index is not None:
+                        seed_text = str(int(getattr(args, "seed", 0) or 0) + int(index))
+                if seed_text is not None:
+                    self.seed = int(seed_text) % (2**32)
+                    set_seed(self.seed)
+                    if hasattr(args, "seed"):
+                        args.seed = self.seed
+                    if hasattr(args, "data_seed"):
+                        args.data_seed = self.seed
+
+            return control
+
+    return SmolvmTrainerForkpointCallback()
+
+
+def add_transformers_forkpoint(trainer, **options):
+    """Attach the prepared forkpoint callback to a Transformers trainer."""
+    callback = transformers_forkpoint_callback(**options)
+    trainer.add_callback(callback)
+    return callback

--- a/sdks/python/src/smolvm_rollout/transformers.py
+++ b/sdks/python/src/smolvm_rollout/transformers.py
@@ -32,8 +32,9 @@ def transformers_forkpoint_callback(
     command: str | Sequence[str] = "smolvm-fork-ready",
     env_path: str | Path = "/etc/smolvm/fork-env",
     reseed: bool = True,
+    preload_cuda_modules: bool = True,
 ):
-    """Create a callback that forks after Transformers prepares the trainer."""
+    """Fork after trainer preparation and preload clone CUDA modules by default."""
     try:
         from transformers import TrainerCallback, set_seed
     except ImportError as error:
@@ -44,6 +45,8 @@ def transformers_forkpoint_callback(
     argv = (command,) if isinstance(command, str) else tuple(command)
     if not argv or any(not isinstance(value, str) or not value for value in argv):
         raise ValueError("forkpoint command must contain non-empty strings")
+    if preload_cuda_modules and "--cuda-preload-modules" not in argv:
+        argv += ("--cuda-preload-modules",)
     fork_env_path = Path(env_path)
 
     class SmolvmTrainerForkpointCallback(TrainerCallback):

--- a/sdks/python/tests/test_transformers.py
+++ b/sdks/python/tests/test_transformers.py
@@ -1,0 +1,122 @@
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from smolvm_rollout import add_transformers_forkpoint, transformers_forkpoint_callback
+
+
+class FakeTrainerCallback:
+    pass
+
+
+class FakeTrainer:
+    def __init__(self):
+        self.callbacks = []
+
+    def add_callback(self, callback):
+        self.callbacks.append(callback)
+
+
+class TransformersForkpointTests(unittest.TestCase):
+    def transformers_module(self, seeds):
+        module = types.ModuleType("transformers")
+        module.TrainerCallback = FakeTrainerCallback
+        module.set_seed = seeds.append
+        return module
+
+    def test_callback_releases_once_imports_identity_and_reseeds(self):
+        seeds = []
+        with tempfile.TemporaryDirectory() as directory:
+            env_path = Path(directory) / "fork-env"
+            env_path.write_text(
+                "SMOLVM_FORK_INDEX=3\nSMOLVM_FORK_NAME=worker-3\nVALUE=a=b c\n"
+            )
+            args = SimpleNamespace(seed=42, data_seed=7)
+            control = object()
+            with (
+                mock.patch.dict(
+                    sys.modules,
+                    {"transformers": self.transformers_module(seeds)},
+                ),
+                mock.patch("smolvm_rollout.transformers.subprocess.run") as run,
+                mock.patch.dict(os.environ, {}, clear=True),
+            ):
+                callback = transformers_forkpoint_callback(
+                    command=("fork-ready", "--test"), env_path=env_path
+                )
+                self.assertIs(callback.on_train_begin(args, None, control), control)
+                self.assertIs(callback.on_train_begin(args, None, control), control)
+                self.assertEqual(os.environ["SMOLVM_FORK_NAME"], "worker-3")
+                self.assertEqual(os.environ["VALUE"], "a=b c")
+
+            run.assert_called_once_with(("fork-ready", "--test"), check=True)
+            self.assertTrue(callback.released)
+            self.assertEqual(callback.fork_env["SMOLVM_FORK_INDEX"], "3")
+            self.assertEqual(callback.seed, 45)
+            self.assertEqual(seeds, [45])
+            self.assertEqual(args.seed, 45)
+            self.assertEqual(args.data_seed, 45)
+
+    def test_explicit_seed_takes_precedence_over_index(self):
+        seeds = []
+        with tempfile.TemporaryDirectory() as directory:
+            env_path = Path(directory) / "fork-env"
+            env_path.write_text("SMOLVM_FORK_INDEX=3\nSMOLVM_FORK_SEED=99\n")
+            args = SimpleNamespace(seed=42, data_seed=None)
+            with (
+                mock.patch.dict(
+                    sys.modules,
+                    {"transformers": self.transformers_module(seeds)},
+                ),
+                mock.patch("smolvm_rollout.transformers.subprocess.run"),
+            ):
+                callback = transformers_forkpoint_callback(env_path=env_path)
+                callback.on_train_begin(args, None, object())
+
+            self.assertEqual(seeds, [99])
+            self.assertEqual(args.seed, 99)
+            self.assertEqual(args.data_seed, 99)
+
+    def test_invalid_environment_does_not_repeat_consumed_forkpoint(self):
+        seeds = []
+        with tempfile.TemporaryDirectory() as directory:
+            env_path = Path(directory) / "fork-env"
+            env_path.write_text("not valid\n")
+            with (
+                mock.patch.dict(
+                    sys.modules,
+                    {"transformers": self.transformers_module(seeds)},
+                ),
+                mock.patch("smolvm_rollout.transformers.subprocess.run") as run,
+            ):
+                callback = transformers_forkpoint_callback(env_path=env_path)
+                with self.assertRaisesRegex(ValueError, "invalid fork environment"):
+                    callback.on_train_begin(SimpleNamespace(seed=1), None, object())
+                callback.on_train_begin(SimpleNamespace(seed=1), None, object())
+
+            run.assert_called_once()
+            self.assertTrue(callback.released)
+
+    def test_add_helper_attaches_callback(self):
+        seeds = []
+        trainer = FakeTrainer()
+        with mock.patch.dict(
+            sys.modules,
+            {"transformers": self.transformers_module(seeds)},
+        ):
+            callback = add_transformers_forkpoint(trainer, command="fork-ready")
+        self.assertEqual(trainer.callbacks, [callback])
+
+    def test_factory_reports_missing_transformers(self):
+        with mock.patch.dict(sys.modules, {"transformers": None}):
+            with self.assertRaisesRegex(RuntimeError, "requires the transformers"):
+                transformers_forkpoint_callback()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdks/python/tests/test_transformers.py
+++ b/sdks/python/tests/test_transformers.py
@@ -54,7 +54,9 @@ class TransformersForkpointTests(unittest.TestCase):
                 self.assertEqual(os.environ["SMOLVM_FORK_NAME"], "worker-3")
                 self.assertEqual(os.environ["VALUE"], "a=b c")
 
-            run.assert_called_once_with(("fork-ready", "--test"), check=True)
+            run.assert_called_once_with(
+                ("fork-ready", "--test", "--cuda-preload-modules"), check=True
+            )
             self.assertTrue(callback.released)
             self.assertEqual(callback.fork_env["SMOLVM_FORK_INDEX"], "3")
             self.assertEqual(callback.seed, 45)
@@ -111,6 +113,27 @@ class TransformersForkpointTests(unittest.TestCase):
         ):
             callback = add_transformers_forkpoint(trainer, command="fork-ready")
         self.assertEqual(trainer.callbacks, [callback])
+
+    def test_cuda_module_preload_can_be_disabled(self):
+        seeds = []
+        with tempfile.TemporaryDirectory() as directory:
+            env_path = Path(directory) / "fork-env"
+            env_path.write_text("")
+            with (
+                mock.patch.dict(
+                    sys.modules,
+                    {"transformers": self.transformers_module(seeds)},
+                ),
+                mock.patch("smolvm_rollout.transformers.subprocess.run") as run,
+            ):
+                callback = transformers_forkpoint_callback(
+                    command="fork-ready",
+                    env_path=env_path,
+                    preload_cuda_modules=False,
+                )
+                callback.on_train_begin(SimpleNamespace(seed=1), None, object())
+
+            run.assert_called_once_with(("fork-ready",), check=True)
 
     def test_factory_reports_missing_transformers(self):
         with mock.patch.dict(sys.modules, {"transformers": None}):


### PR DESCRIPTION
Adds a Transformers callback that forks after trainer preparation, preloads clone CUDA modules, imports per-clone environment values, and reseeds each clone.