### PR TITLE
Publish PEFT adapters without base traversal

### DIFF
--- a/sdks/python/src/smolvm_rollout/__init__.py
+++ b/sdks/python/src/smolvm_rollout/__init__.py
@@ -7,6 +7,7 @@ from .device_handoff import (
     DeviceTensor,
     publish_device_adapter,
 )
+from .peft import peft_lora_tensors, publish_peft_adapter
 from .torch_handoff import TorchDeviceAdapter, import_torch_device_adapter
 from .transformers import add_transformers_forkpoint, transformers_forkpoint_callback
 from .unsloth_vllm import UnslothVllmExecutor
@@ -21,7 +22,9 @@ __all__ = [
     "UnslothVllmExecutor",
     "adapter_sha256",
     "add_transformers_forkpoint",
+    "peft_lora_tensors",
     "publish_device_adapter",
+    "publish_peft_adapter",
     "import_torch_device_adapter",
     "transformers_forkpoint_callback",
 ]

--- a/sdks/python/src/smolvm_rollout/peft.py
+++ b/sdks/python/src/smolvm_rollout/peft.py
@@ -1,0 +1,111 @@
+"""PEFT integration for device-resident LoRA publication."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from .device_handoff import publish_device_adapter
+
+
+def _enum_value(value: Any) -> str:
+    return str(getattr(value, "value", value)).upper()
+
+
+def _adapter_name(model: Any, requested: str | None) -> str:
+    name = requested if requested is not None else getattr(model, "active_adapter", None)
+    if not isinstance(name, str) or not name:
+        raise ValueError("a single active PEFT adapter is required")
+    return name
+
+
+def _configuration(model: Any, adapter_name: str) -> Mapping[str, Any]:
+    configurations = getattr(model, "peft_config", None)
+    if not isinstance(configurations, Mapping) or adapter_name not in configurations:
+        raise ValueError(f"PEFT adapter {adapter_name!r} is not configured")
+    configuration = configurations[adapter_name]
+    if _enum_value(getattr(configuration, "peft_type", "")) != "LORA":
+        raise ValueError("device adapter publication supports LoRA and QLoRA only")
+    if str(getattr(configuration, "bias", "none")).lower() != "none":
+        raise ValueError("device adapter publication does not support trained biases")
+    if bool(getattr(configuration, "use_dora", False)):
+        raise ValueError("device adapter publication does not support DoRA")
+    if getattr(configuration, "modules_to_save", None):
+        raise ValueError("device adapter publication does not support modules_to_save")
+    if getattr(configuration, "trainable_token_indices", None):
+        raise ValueError("device adapter publication does not support trainable tokens")
+    if getattr(model, "_tp_plan", None) is not None:
+        modules = getattr(model, "modules", None)
+        if not callable(modules):
+            raise ValueError("cannot verify whether the PEFT model is sharded")
+        if any(
+            getattr(getattr(module, "_tp_info", None), "tp_plan", None)
+            for module in modules()
+        ):
+            raise ValueError("device adapter publication requires an unsharded PEFT model")
+
+    if isinstance(configuration, Mapping):
+        values = configuration
+    else:
+        to_dict = getattr(configuration, "to_dict", None)
+        if not callable(to_dict):
+            raise TypeError("PEFT adapter configuration must expose to_dict()")
+        values = to_dict()
+    if not isinstance(values, Mapping):
+        raise TypeError("PEFT adapter configuration must serialize to a mapping")
+    return values
+
+
+def _remove_adapter_name(name: str, adapter_name: str) -> str | None:
+    marker = f".{adapter_name}"
+    if name.endswith(marker):
+        return name[: -len(marker)]
+    prefix, separator, suffix = name.rpartition(".")
+    if not separator or not prefix.endswith(marker):
+        return None
+    return f"{prefix[: -len(marker)]}.{suffix}"
+
+
+def _lora_tensors(model: Any, adapter_name: str) -> dict[str, Any]:
+    named_parameters = getattr(model, "named_parameters", None)
+    if not callable(named_parameters):
+        raise TypeError("PEFT model must expose named_parameters()")
+
+    tensors = {}
+    for parameter_name, parameter in named_parameters():
+        if "lora_" not in parameter_name:
+            continue
+        published_name = _remove_adapter_name(parameter_name, adapter_name)
+        if published_name is not None:
+            if published_name in tensors:
+                raise ValueError(f"duplicate PEFT adapter tensor {published_name!r}")
+            tensors[published_name] = parameter.detach()
+    if not tensors:
+        raise ValueError(f"PEFT adapter {adapter_name!r} has no LoRA tensors")
+    return dict(sorted(tensors.items()))
+
+
+def peft_lora_tensors(model: Any, *, adapter_name: str | None = None) -> dict[str, Any]:
+    """Return one unsharded LoRA adapter without traversing base-model state."""
+    name = _adapter_name(model, adapter_name)
+    _configuration(model, name)
+    return _lora_tensors(model, name)
+
+
+def publish_peft_adapter(
+    model: Any,
+    *,
+    adapter_name: str | None = None,
+    shim_path: str | os.PathLike[str] | None = None,
+    synchronize: Callable[[], None] | None = None,
+) -> bytes:
+    """Publish a compatible PEFT LoRA directly from its trainable parameters."""
+    name = _adapter_name(model, adapter_name)
+    configuration = _configuration(model, name)
+    return publish_device_adapter(
+        _lora_tensors(model, name),
+        configuration,
+        shim_path=shim_path,
+        synchronize=synchronize,
+    )

--- a/sdks/python/tests/test_peft.py
+++ b/sdks/python/tests/test_peft.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from smolvm_rollout import peft_lora_tensors, publish_peft_adapter
+
+
+class Parameter:
+    def __init__(self, identity):
+        self.identity = identity
+
+    def detach(self):
+        return self
+
+
+class Configuration:
+    peft_type = "LORA"
+    bias = "none"
+    use_dora = False
+    modules_to_save = None
+    trainable_token_indices = None
+
+    def to_dict(self):
+        return {"peft_type": self.peft_type, "r": 16}
+
+
+class Model:
+    active_adapter = "default"
+    _tp_plan = None
+
+    def __init__(self, configuration=None):
+        self.peft_config = {"default": configuration or Configuration()}
+        self.parameters = [
+            ("base.weight", Parameter("base")),
+            ("model.q_proj.lora_B.other.weight", Parameter("other")),
+            ("model.q_proj.lora_B.default.weight", Parameter("b")),
+            ("model.q_proj.lora_A.default.weight", Parameter("a")),
+        ]
+
+    def named_parameters(self):
+        return iter(self.parameters)
+
+    def modules(self):
+        return iter(())
+
+
+class PeftTests(unittest.TestCase):
+    def test_extracts_only_the_active_lora_without_base_state(self):
+        model = Model()
+        tensors = peft_lora_tensors(model)
+        self.assertEqual(
+            list(tensors),
+            ["model.q_proj.lora_A.weight", "model.q_proj.lora_B.weight"],
+        )
+        self.assertEqual(tensors["model.q_proj.lora_A.weight"].identity, "a")
+        self.assertEqual(tensors["model.q_proj.lora_B.weight"].identity, "b")
+
+    def test_publishes_the_extracted_tensors_and_configuration(self):
+        model = Model()
+        with mock.patch("smolvm_rollout.peft.publish_device_adapter") as publish:
+            publish.return_value = bytes(range(32))
+            token = publish_peft_adapter(
+                model,
+                shim_path="/shim.so",
+                synchronize=lambda: None,
+            )
+        self.assertEqual(token, bytes(range(32)))
+        tensors, configuration = publish.call_args.args
+        self.assertEqual(
+            list(tensors),
+            ["model.q_proj.lora_A.weight", "model.q_proj.lora_B.weight"],
+        )
+        self.assertEqual(configuration, {"peft_type": "LORA", "r": 16})
+        self.assertEqual(publish.call_args.kwargs["shim_path"], "/shim.so")
+        self.assertIsNotNone(publish.call_args.kwargs["synchronize"])
+
+    def test_explicit_adapter_name_selects_and_normalizes_that_adapter(self):
+        model = Model()
+        model.peft_config["experiment"] = Configuration()
+        model.parameters.append(
+            ("model.q_proj.lora_A.experiment.weight", Parameter("experiment"))
+        )
+        tensors = peft_lora_tensors(model, adapter_name="experiment")
+        self.assertEqual(list(tensors), ["model.q_proj.lora_A.weight"])
+        self.assertEqual(tensors["model.q_proj.lora_A.weight"].identity, "experiment")
+
+    def test_ignores_a_model_plan_without_tensor_parallel_module_state(self):
+        model = Model()
+        model._tp_plan = {"model.q_proj": "local"}
+        self.assertEqual(len(peft_lora_tensors(model)), 2)
+
+    def test_requires_one_active_adapter(self):
+        model = Model()
+        model.active_adapter = ["default"]
+        with self.assertRaisesRegex(ValueError, "single active"):
+            peft_lora_tensors(model)
+
+    def test_rejects_semantics_not_represented_by_vllm_lora(self):
+        for attribute, value, message in [
+            ("peft_type", "ADALORA", "LoRA and QLoRA"),
+            ("bias", "all", "biases"),
+            ("use_dora", True, "DoRA"),
+            ("modules_to_save", ["lm_head"], "modules_to_save"),
+            ("trainable_token_indices", [1], "trainable tokens"),
+        ]:
+            with self.subTest(attribute=attribute):
+                configuration = Configuration()
+                setattr(configuration, attribute, value)
+                with self.assertRaisesRegex(ValueError, message):
+                    peft_lora_tensors(Model(configuration))
+
+    def test_rejects_sharded_models_and_empty_adapters(self):
+        model = Model()
+        model._tp_plan = {"model.q_proj": "colwise"}
+        tp_info = type("TpInfo", (), {"tp_plan": model._tp_plan})()
+        module = type("TensorParallelModule", (), {"_tp_info": tp_info})()
+        model.modules = lambda: iter((module,))
+        with self.assertRaisesRegex(ValueError, "unsharded"):
+            peft_lora_tensors(model)
+
+        model = Model()
+        model.parameters = [("base.weight", Parameter("base"))]
+        with self.assertRaisesRegex(ValueError, "no LoRA tensors"):
+            peft_lora_tensors(model)
+
+    def test_rejects_duplicate_normalized_tensor_names(self):
+        model = Model()
+        duplicate = Parameter("duplicate")
+        model.parameters.append(
+            ("model.q_proj.lora_A.default.weight", duplicate)
+        )
+        with self.assertRaisesRegex(ValueError, "duplicate PEFT adapter tensor"):
+            peft_lora_tensors(model)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Publishes compatible PEFT LoRA adapters directly from trainable tensors while rejecting unsupported layouts.