### PR TITLE
Add lease-scoped guest rollout access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3020,6 +3020,7 @@ dependencies = [
  "clap",
  "dirs",
  "futures-util",
+ "getrandom 0.3.4",
  "hex",
  "humantime",
  "ipnet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ socket2 = "0.6"
 dirs = "5"
 sha2 = "0.10"
 hex = "0.4"
+getrandom = "0.3"
 # Host filesystem watcher (FSEvents on macOS, inotify on Linux) that drives
 # host→guest fsnotify propagation for -v mounts. See src/agent/fsnotify_watch.rs.
 notify = "6"

--- a/crates/smolvm-network/src/lib.rs
+++ b/crates/smolvm-network/src/lib.rs
@@ -152,6 +152,17 @@ pub struct GuestNetworkConfig {
     /// caller passes `--dns <ip>` so a VM on a network that blocks the default
     /// resolver can still resolve names.
     pub upstream_dns: Ipv4Addr,
+    /// Optional dedicated host service reachable only through the gateway IP.
+    pub host_service: Option<GatewayHostService>,
+}
+
+/// Exact guest gateway port mapped to one smolvm-owned host loopback port.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GatewayHostService {
+    /// Port the guest addresses on its gateway IP.
+    pub guest_port: u16,
+    /// Loopback port the host listener actually owns.
+    pub host_port: u16,
 }
 
 impl GuestNetworkConfig {
@@ -171,6 +182,7 @@ impl GuestNetworkConfig {
                 IpAddr::V4(ip) => ip,
                 IpAddr::V6(_) => Ipv4Addr::new(1, 1, 1, 1),
             },
+            host_service: None,
         }
     }
 }
@@ -301,6 +313,7 @@ pub fn start_virtio_network(
             guest_ipv6: guest_network.guest_ip6,
             prefix_len6: guest_network.prefix_len6,
             upstream_dns: guest_network.upstream_dns,
+            host_service: guest_network.host_service,
             mtu: 1500,
         },
         tcp_listeners.as_ref().map(|_| tcp_receiver),

--- a/crates/smolvm-network/src/stack.rs
+++ b/crates/smolvm-network/src/stack.rs
@@ -125,6 +125,8 @@ pub struct VirtioPollConfig {
     pub prefix_len6: u8,
     /// Upstream resolver the gateway forwards guest DNS queries to.
     pub upstream_dns: Ipv4Addr,
+    /// Dedicated loopback service reachable only at the guest-visible gateway.
+    pub host_service: Option<crate::GatewayHostService>,
     /// IP-level MTU.
     pub mtu: usize,
 }
@@ -211,7 +213,12 @@ fn run_network_stack(
         IpAddr::V6(link_local_from_mac(config.gateway_mac)),
     ];
     let relay_wake = Arc::new(queues.relay_wake.clone());
-    let mut relays = TcpRelayTable::new(None, egress.clone(), gateway_addrs.to_vec());
+    let mut relays = TcpRelayTable::new(
+        None,
+        egress.clone(),
+        gateway_addrs.to_vec(),
+        config.host_service,
+    );
     let mut udp_sockets = udp_relay::UdpSocketTable::new();
     let udp_channels = {
         let shutdown_queues = queues.clone();

--- a/crates/smolvm-network/src/tcp_relay.rs
+++ b/crates/smolvm-network/src/tcp_relay.rs
@@ -69,6 +69,9 @@ pub struct TcpRelayTable {
     /// so the host-side relay connects to loopback instead of the gateway's own
     /// (non-routable) userspace address. See `host_connect_addr`.
     gateway_ips: Vec<IpAddr>,
+    /// One authenticated smolvm-owned loopback service allowed through the
+    /// otherwise-denied gateway address.
+    host_service: Option<crate::GatewayHostService>,
 }
 
 /// Newly established guest connection ready for a host relay thread.
@@ -193,6 +196,7 @@ impl TcpRelayTable {
         max_connections: Option<usize>,
         egress: EgressPolicy,
         gateway_ips: Vec<IpAddr>,
+        host_service: Option<crate::GatewayHostService>,
     ) -> Self {
         Self {
             connections: HashMap::new(),
@@ -202,7 +206,16 @@ impl TcpRelayTable {
             max_connections: max_connections.unwrap_or(MAX_CONNECTIONS),
             egress,
             gateway_ips,
+            host_service,
         }
+    }
+
+    fn destination_allowed(&self, destination: SocketAddr) -> bool {
+        self.egress.allows(destination.ip())
+            || (self
+                .host_service
+                .is_some_and(|service| service.guest_port == destination.port())
+                && self.gateway_ips.contains(&destination.ip()))
     }
 
     /// The host-side address the relay should dial for a guest flow.
@@ -225,7 +238,11 @@ impl TcpRelayTable {
             } else {
                 IpAddr::V6(Ipv6Addr::LOCALHOST)
             };
-            return SocketAddr::new(loopback, destination.port());
+            let port = self
+                .host_service
+                .filter(|service| service.guest_port == destination.port())
+                .map_or(destination.port(), |service| service.host_port);
+            return SocketAddr::new(loopback, port);
         }
         destination
     }
@@ -265,7 +282,7 @@ impl TcpRelayTable {
         // Egress policy: drop the guest SYN before any socket is created when the
         // destination isn't allowed, so the guest just sees the connection fail.
         // Inbound published-port flows take a separate path and are unaffected.
-        if !self.egress.allows(destination.ip()) {
+        if !self.destination_allowed(destination) {
             tracing::debug!(
                 %destination,
                 "virtio-net: blocking outbound connection by egress policy"
@@ -866,7 +883,7 @@ mod tests {
     fn gateway_ip_destination_dials_the_host_over_loopback() {
         let gw4: IpAddr = "100.96.0.1".parse().unwrap();
         let gw6: IpAddr = "fd00::1".parse().unwrap();
-        let table = TcpRelayTable::new(None, EgressPolicy::unrestricted(), vec![gw4, gw6]);
+        let table = TcpRelayTable::new(None, EgressPolicy::unrestricted(), vec![gw4, gw6], None);
 
         // A guest reaching "the host" via its gateway IP must dial loopback, not
         // the gateway's own (non-routable) userspace address — the bug that made
@@ -886,6 +903,29 @@ mod tests {
         assert_eq!(
             table.host_connect_addr(SocketAddr::new(lan, 3306)),
             SocketAddr::new(lan, 3306),
+        );
+    }
+
+    #[test]
+    fn dedicated_gateway_service_does_not_weaken_other_egress() {
+        let gateway: IpAddr = "100.96.0.1".parse().unwrap();
+        let external: IpAddr = "8.8.8.8".parse().unwrap();
+        let table = TcpRelayTable::new(
+            None,
+            EgressPolicy::from_allowed_cidrs(Some(&[])),
+            vec![gateway],
+            Some(crate::GatewayHostService {
+                guest_port: 10_081,
+                host_port: 40_081,
+            }),
+        );
+
+        assert!(table.destination_allowed(SocketAddr::new(gateway, 10_081)));
+        assert!(!table.destination_allowed(SocketAddr::new(gateway, 22)));
+        assert!(!table.destination_allowed(SocketAddr::new(external, 10_081)));
+        assert_eq!(
+            table.host_connect_addr(SocketAddr::new(gateway, 10_081)),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 40_081)
         );
     }
 }

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -32,6 +32,20 @@ result = client.generate(
 )
 ```
 
+Inside a worker acquired with `rolloutAccess`, no endpoint or credential wiring
+is needed. `RolloutClient()` reads the clone-local assignment installed at
+`/etc/smolvm/fork-env` and authenticates every request with its lease scope:
+
+```python
+client = RolloutClient()
+result = client.generate(
+    idempotency_key="experiment-a-step-40-batch-7",
+    policy=client.lease_policy,
+    prompts=[[1, 2, 3]],
+    max_tokens=64,
+)
+```
+
 For colocated CUDA trainers, `publish_device_adapter` replaces the checkpoint
 write with an immutable device allocation. Register a mode-0600 sidecar socket,
 then publish the returned one-use token:

--- a/sdks/python/src/smolvm_rollout/client.py
+++ b/sdks/python/src/smolvm_rollout/client.py
@@ -13,6 +13,19 @@ from pathlib import Path
 from typing import Any, Iterable, Sequence
 
 
+_FORK_ENV_PATH = Path("/etc/smolvm/fork-env")
+_ROLLOUT_URL_ENV = "SMOLVM_ROLLOUT_URL"
+_ROLLOUT_TOKEN_ENV = "SMOLVM_ROLLOUT_TOKEN"
+_ROLLOUT_EXECUTOR_ENV = "SMOLVM_ROLLOUT_EXECUTOR"
+_ROLLOUT_POLICY_ENV = "SMOLVM_ROLLOUT_POLICY"
+_ROLLOUT_LEASE_KEYS = (
+    _ROLLOUT_URL_ENV,
+    _ROLLOUT_TOKEN_ENV,
+    _ROLLOUT_EXECUTOR_ENV,
+    _ROLLOUT_POLICY_ENV,
+)
+
+
 class RolloutError(RuntimeError):
     """A structured error returned by smolvm's rollout API."""
 
@@ -21,6 +34,57 @@ class RolloutError(RuntimeError):
         self.status = status
         self.code = code
         self.message = message
+
+
+def _read_fork_env(path: Path) -> dict[str, str]:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        return {}
+    except OSError as error:
+        raise RuntimeError(f"cannot read smolvm fork assignment {path}: {error}") from error
+
+    values: dict[str, str] = {}
+    for number, line in enumerate(lines, start=1):
+        if not line or line.startswith("#"):
+            continue
+        key, separator, value = line.partition("=")
+        if not separator or not key:
+            raise RuntimeError(f"invalid smolvm fork assignment at {path}:{number}")
+        if key in values:
+            raise RuntimeError(f"duplicate {key} in smolvm fork assignment {path}")
+        values[key] = value
+    return values
+
+
+def _lease_configuration(path: Path) -> tuple[str, str, str, str]:
+    values = _read_fork_env(path)
+    for key in _ROLLOUT_LEASE_KEYS:
+        if key in os.environ:
+            values[key] = os.environ[key]
+    missing = [key for key in _ROLLOUT_LEASE_KEYS if not values.get(key)]
+    if missing:
+        raise RuntimeError(
+            "smolvm rollout lease configuration is unavailable: missing "
+            + ", ".join(missing)
+        )
+
+    url = values[_ROLLOUT_URL_ENV].rstrip("/")
+    executor = values[_ROLLOUT_EXECUTOR_ENV]
+    suffix = f"/rollout-executors/{executor}"
+    if not url.endswith(suffix):
+        raise RuntimeError(
+            f"{_ROLLOUT_URL_ENV} does not match {_ROLLOUT_EXECUTOR_ENV}"
+        )
+    api_url = url[: -len(suffix)]
+    if not api_url.startswith(("http://", "https://")):
+        raise RuntimeError(f"{_ROLLOUT_URL_ENV} must be an HTTP URL")
+    return (
+        api_url,
+        executor,
+        values[_ROLLOUT_TOKEN_ENV],
+        values[_ROLLOUT_POLICY_ENV],
+    )
 
 
 def adapter_sha256(directory: str | os.PathLike[str]) -> str:
@@ -61,14 +125,28 @@ class RolloutClient:
 
     def __init__(
         self,
-        api_url: str,
-        executor: str,
+        api_url: str | None = None,
+        executor: str | None = None,
         *,
+        bearer_token: str | None = None,
+        fork_env_path: str | os.PathLike[str] = _FORK_ENV_PATH,
         timeout: float = 300.0,
         ssl_context: ssl.SSLContext | None = None,
     ) -> None:
+        lease_policy = None
+        if api_url is None and executor is None:
+            api_url, executor, discovered_token, lease_policy = _lease_configuration(
+                Path(fork_env_path)
+            )
+            if bearer_token is not None and bearer_token != discovered_token:
+                raise ValueError("bearer_token conflicts with the smolvm lease credential")
+            bearer_token = discovered_token
+        elif api_url is None or executor is None:
+            raise TypeError("api_url and executor must be provided together")
         self.api_url = api_url.rstrip("/")
         self.executor = executor
+        self.bearer_token = bearer_token
+        self.lease_policy = lease_policy
         self.timeout = timeout
         self.ssl_context = ssl_context
 
@@ -79,11 +157,14 @@ class RolloutClient:
         body: dict[str, Any] | None = None,
     ) -> Any:
         data = None if body is None else json.dumps(body, separators=(",", ":")).encode()
+        headers = {"content-type": "application/json"}
+        if self.bearer_token is not None:
+            headers["authorization"] = f"Bearer {self.bearer_token}"
         request = urllib.request.Request(
             f"{self.api_url}{path}",
             data=data,
             method=method,
-            headers={"content-type": "application/json"},
+            headers=headers,
         )
         try:
             with urllib.request.urlopen(

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -1,5 +1,6 @@
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 from smolvm_rollout import RolloutClient, RolloutError, adapter_sha256
@@ -29,6 +30,80 @@ class RecordingClient(RolloutClient):
     def _request(self, method, path, body=None):
         self.recorded = (method, path, body)
         return {"ok": True}
+
+
+class LeaseDiscoveryTests(unittest.TestCase):
+    def test_no_argument_client_reads_clone_assignment_and_authenticates(self):
+        with tempfile.TemporaryDirectory() as directory:
+            assignment = Path(directory) / "fork-env"
+            assignment.write_text(
+                "SMOLVM_ROLLOUT_URL=http://100.96.0.1:10081/api/v1/rollout-executors/fused\n"
+                "SMOLVM_ROLLOUT_TOKEN=lease-id.secret\n"
+                "SMOLVM_ROLLOUT_EXECUTOR=fused\n"
+                "SMOLVM_ROLLOUT_POLICY=experiment-a\n",
+                encoding="utf-8",
+            )
+            with mock.patch.dict("os.environ", {}, clear=True):
+                client = RolloutClient(fork_env_path=assignment)
+            self.assertEqual(client.api_url, "http://100.96.0.1:10081/api/v1")
+            self.assertEqual(client.executor, "fused")
+            self.assertEqual(client.bearer_token, "lease-id.secret")
+            self.assertEqual(client.lease_policy, "experiment-a")
+
+            with mock.patch("urllib.request.urlopen") as urlopen:
+                response = urlopen.return_value.__enter__.return_value
+                response.read.return_value = b"{}"
+                client.generate(
+                    idempotency_key="request",
+                    policy="experiment-a",
+                    prompts=["hello"],
+                    max_tokens=1,
+                )
+                request = urlopen.call_args.args[0]
+                self.assertEqual(
+                    request.get_header("Authorization"), "Bearer lease-id.secret"
+                )
+
+    def test_environment_overrides_assignment_after_clone_release(self):
+        with tempfile.TemporaryDirectory() as directory:
+            assignment = Path(directory) / "fork-env"
+            assignment.write_text(
+                "SMOLVM_ROLLOUT_URL=http://100.96.0.1:10081/api/v1/rollout-executors/file\n"
+                "SMOLVM_ROLLOUT_TOKEN=file-token\n"
+                "SMOLVM_ROLLOUT_EXECUTOR=file\n"
+                "SMOLVM_ROLLOUT_POLICY=file-policy\n",
+                encoding="utf-8",
+            )
+            environment = {
+                "SMOLVM_ROLLOUT_URL": "http://127.0.0.1:1/api/v1/rollout-executors/env",
+                "SMOLVM_ROLLOUT_TOKEN": "env-token",
+                "SMOLVM_ROLLOUT_EXECUTOR": "env",
+                "SMOLVM_ROLLOUT_POLICY": "env-policy",
+            }
+            with mock.patch.dict("os.environ", environment, clear=True):
+                client = RolloutClient(fork_env_path=assignment)
+            self.assertEqual(client.executor, "env")
+            self.assertEqual(client.bearer_token, "env-token")
+            self.assertEqual(client.lease_policy, "env-policy")
+
+    def test_incomplete_or_inconsistent_assignment_fails_closed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            assignment = Path(directory) / "fork-env"
+            assignment.write_text("SMOLVM_ROLLOUT_TOKEN=secret\n", encoding="utf-8")
+            with mock.patch.dict("os.environ", {}, clear=True):
+                with self.assertRaisesRegex(RuntimeError, "missing"):
+                    RolloutClient(fork_env_path=assignment)
+
+            assignment.write_text(
+                "SMOLVM_ROLLOUT_URL=http://host/api/v1/rollout-executors/other\n"
+                "SMOLVM_ROLLOUT_TOKEN=secret\n"
+                "SMOLVM_ROLLOUT_EXECUTOR=fused\n"
+                "SMOLVM_ROLLOUT_POLICY=policy\n",
+                encoding="utf-8",
+            )
+            with mock.patch.dict("os.environ", {}, clear=True):
+                with self.assertRaisesRegex(RuntimeError, "does not match"):
+                    RolloutClient(fork_env_path=assignment)
 
 
 class DevicePublicationTests(unittest.TestCase):

--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -1223,7 +1223,7 @@ fn build_activation_script(
            rm -f \"$receipt_tmp\"; \
            [ \"$(cat '{receipt}' 2>/dev/null)\" = '{activation_token}' ] || exit 42; \
          else rm -f \"$receipt_tmp\"; fi; \
-         {ensure_env_parent}; \
+         {ensure_env_parent}; umask 077; \
          env_tmp='{env_path}.{activation_token}.'$$; \
          release_tmp='{release}.{activation_token}.'$$; \
          trap 'rm -f \"$env_tmp\" \"$release_tmp\"' EXIT; \
@@ -1465,6 +1465,14 @@ mod tests {
             String::from_utf8_lossy(&first.stderr)
         );
         assert_eq!(std::fs::read_to_string(&env_path).unwrap(), "LR=1e-4\n");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(&env_path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
         assert_eq!(
             std::fs::read_to_string(&receipt).unwrap(),
             format!("{token}\n")

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -892,6 +892,8 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
                 }
 
                 let mut guest_network = GuestNetworkConfig::default();
+                guest_network.host_service = crate::network::launch::guest_host_service()
+                    .map_err(|reason| Error::config("configure guest rollout ingress", reason))?;
                 // A custom resolver (--dns) becomes the gateway's upstream: the
                 // guest still points at the gateway (100.96.0.1), which forwards
                 // queries to this address instead of the default.

--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -319,7 +319,8 @@ pub fn launch_agent_vm_dynamic(
                 free_ctx_on_err!("krun_add_vsock failed");
             }
 
-            let guest_network = GuestNetworkConfig::default();
+            let mut guest_network = GuestNetworkConfig::default();
+            guest_network.host_service = crate::network::launch::guest_host_service()?;
             let mut guest_mac = guest_network.guest_mac;
             let port_mappings: Vec<VirtioPortMapping> = config
                 .port_mappings

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -2061,6 +2061,14 @@ impl AgentManager {
             .map(std::path::PathBuf::from)
             .unwrap_or_else(|| exe.clone());
         let mut cmd = std::process::Command::new(&boot_exe);
+        if let Some(service) = crate::network::launch::guest_host_service()
+            .map_err(|reason| Error::config("configure guest rollout ingress", reason))?
+        {
+            cmd.env(
+                crate::api::guest_rollout::GUEST_HOST_SERVICE_ENV,
+                format!("{}:{}", service.guest_port, service.host_port),
+            );
+        }
         // libkrun dlopen()s libkrunfw by bare soname at krun_start_enter time and
         // carries no rpath, so the dynamic linker must be told where to look
         // BEFORE the child launches — the loader caches its search path at

--- a/src/api/errors.rs
+++ b/src/api/errors.rs
@@ -11,6 +11,10 @@ use std::fmt::Display;
 /// API error type with HTTP status code mapping.
 #[derive(Debug)]
 pub enum ApiError {
+    /// Missing or invalid authentication credentials (401).
+    Unauthorized(String),
+    /// Authenticated caller is not allowed to access this resource (403).
+    Forbidden(String),
     /// Resource not found (404).
     NotFound(String),
     /// Conflict - resource already exists or invalid state (409).
@@ -52,6 +56,8 @@ struct ErrorResponse {
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
         let (status, code, message) = match self {
+            ApiError::Unauthorized(msg) => (StatusCode::UNAUTHORIZED, "UNAUTHORIZED", msg),
+            ApiError::Forbidden(msg) => (StatusCode::FORBIDDEN, "FORBIDDEN", msg),
             ApiError::NotFound(msg) => (StatusCode::NOT_FOUND, "NOT_FOUND", msg),
             ApiError::Conflict(msg) => (StatusCode::CONFLICT, "CONFLICT", msg),
             ApiError::PortConflict(msg) => (StatusCode::CONFLICT, "PORT_IN_USE", msg),
@@ -124,6 +130,8 @@ mod tests {
     #[test]
     fn test_api_error_status_codes() {
         let cases = [
+            (ApiError::Unauthorized("x".into()), StatusCode::UNAUTHORIZED),
+            (ApiError::Forbidden("x".into()), StatusCode::FORBIDDEN),
             (ApiError::NotFound("x".into()), StatusCode::NOT_FOUND),
             (ApiError::Conflict("x".into()), StatusCode::CONFLICT),
             (ApiError::BadRequest("x".into()), StatusCode::BAD_REQUEST),

--- a/src/api/guest_rollout.rs
+++ b/src/api/guest_rollout.rs
@@ -1,0 +1,443 @@
+//! Lease-authenticated guest ingress for fused rollout workers.
+
+use axum::{
+    extract::{DefaultBodyLimit, Extension, Path, Request, State},
+    http::{header::AUTHORIZATION, StatusCode},
+    middleware::{self, Next},
+    response::Response,
+    routing::{delete, post},
+    Json, Router,
+};
+use std::sync::Arc;
+use tower_http::trace::TraceLayer;
+
+use crate::api::error::ApiError;
+use crate::api::handlers;
+use crate::api::rollout::{
+    PublishDeviceRolloutPolicyRequest, RolloutBatchRequest, RolloutBatchResponse,
+    RolloutGenerateRequest, RolloutGenerateResponse, RolloutPolicyInfo,
+};
+use crate::api::state::ApiState;
+use crate::pool::{ForkLeaseRecord, ForkLeaseState};
+
+/// Dedicated loopback port reachable only through a VM's virtio gateway.
+pub const GUEST_ROLLOUT_PORT: u16 = 10_081;
+/// Operator override for the rollout listener's host loopback port.
+pub const GUEST_ROLLOUT_HOST_PORT_ENV: &str = "SMOLVM_GUEST_ROLLOUT_HOST_PORT";
+/// Host-only gateway mapping inherited by VMM subprocesses.
+pub const GUEST_HOST_SERVICE_ENV: &str = "SMOLVM_GUEST_HOST_SERVICE";
+/// Bearer credential injected into the claimed worker.
+pub const ROLLOUT_TOKEN_ENV: &str = "SMOLVM_ROLLOUT_TOKEN";
+/// Lease-scoped executor URL injected into the claimed worker.
+pub const ROLLOUT_URL_ENV: &str = "SMOLVM_ROLLOUT_URL";
+/// Executor scope retained in the durable lease assignment.
+pub const ROLLOUT_EXECUTOR_ENV: &str = "SMOLVM_ROLLOUT_EXECUTOR";
+/// Policy scope retained in the durable lease assignment.
+pub const ROLLOUT_POLICY_ENV: &str = "SMOLVM_ROLLOUT_POLICY";
+
+const MAX_ROLLOUT_REQUEST_BYTES: usize = 20 * 1024 * 1024;
+const TOKEN_SECRET_BYTES: usize = 32;
+const MAX_CONCURRENT_AUTH_LOOKUPS: usize = 64;
+const AUTH_LOOKUP_QUEUE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+
+#[derive(Clone)]
+struct RolloutAuthState {
+    api: Arc<ApiState>,
+    lookup_permits: Arc<tokio::sync::Semaphore>,
+}
+
+#[derive(Clone)]
+struct RolloutLeaseScope {
+    executor: String,
+    policy: String,
+}
+
+impl RolloutLeaseScope {
+    fn require_executor(&self, executor: &str) -> Result<(), ApiError> {
+        if self.executor == executor {
+            Ok(())
+        } else {
+            Err(ApiError::Forbidden(
+                "lease credential is not authorized for this rollout executor".into(),
+            ))
+        }
+    }
+
+    fn require_policy(&self, policy: &str) -> Result<(), ApiError> {
+        if self.policy == policy {
+            Ok(())
+        } else {
+            Err(ApiError::Forbidden(
+                "lease credential is not authorized for this rollout policy".into(),
+            ))
+        }
+    }
+}
+
+/// Issue a high-entropy bearer whose prefix makes its durable lease lookup O(1).
+pub(crate) fn issue_lease_credential(lease_id: &str) -> Result<String, getrandom::Error> {
+    let mut secret = [0_u8; TOKEN_SECRET_BYTES];
+    getrandom::fill(&mut secret)?;
+    Ok(format!("{lease_id}.{}", hex::encode(secret)))
+}
+
+/// URL presented to a guest after its rollout scope has been validated.
+pub(crate) fn lease_rollout_url(executor: &str) -> String {
+    format!("http://100.96.0.1:{GUEST_ROLLOUT_PORT}/api/v1/rollout-executors/{executor}")
+}
+
+fn assignment_value<'a>(lease: &'a ForkLeaseRecord, key: &str) -> Option<&'a str> {
+    let mut values = lease
+        .assignment
+        .iter()
+        .filter_map(|(candidate, value)| (candidate == key).then_some(value.as_str()));
+    let value = values.next()?;
+    values.next().is_none().then_some(value)
+}
+
+fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    let mut difference = 0_u8;
+    for (&left, &right) in left.iter().zip(right) {
+        difference |= left ^ right;
+    }
+    difference == 0
+}
+
+fn lease_scope(lease: &ForkLeaseRecord, presented: &str, now: u64) -> Option<RolloutLeaseScope> {
+    if !matches!(
+        lease.state,
+        ForkLeaseState::Activating | ForkLeaseState::Active
+    ) || lease.expires_at <= now
+    {
+        return None;
+    }
+    let expected = assignment_value(lease, ROLLOUT_TOKEN_ENV)?;
+    if !constant_time_eq(expected.as_bytes(), presented.as_bytes()) {
+        return None;
+    }
+    Some(RolloutLeaseScope {
+        executor: assignment_value(lease, ROLLOUT_EXECUTOR_ENV)?.to_string(),
+        policy: assignment_value(lease, ROLLOUT_POLICY_ENV)?.to_string(),
+    })
+}
+
+fn credential_lease_id(credential: &str) -> Option<&str> {
+    let (lease_id, secret) = credential.split_once('.')?;
+    let valid_lease = lease_id.starts_with("lease-")
+        && lease_id.len() <= 128
+        && lease_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-');
+    let valid_secret = secret.len() == TOKEN_SECRET_BYTES * 2
+        && secret.bytes().all(|byte| byte.is_ascii_hexdigit());
+    (valid_lease && valid_secret).then_some(lease_id)
+}
+
+fn bearer_credential(request: &Request) -> Option<&str> {
+    let value = request.headers().get(AUTHORIZATION)?.to_str().ok()?;
+    let (scheme, credential) = value.split_once(' ')?;
+    (scheme.eq_ignore_ascii_case("bearer") && !credential.is_empty()).then_some(credential)
+}
+
+async fn authenticate_lease(
+    State(auth): State<RolloutAuthState>,
+    mut request: Request,
+    next: Next,
+) -> Result<Response, ApiError> {
+    let credential = bearer_credential(&request).ok_or_else(|| {
+        ApiError::Unauthorized("a valid rollout lease bearer credential is required".into())
+    })?;
+    let lease_id = credential_lease_id(credential).ok_or_else(|| {
+        ApiError::Unauthorized("a valid rollout lease bearer credential is required".into())
+    })?;
+    let lookup = lease_id.to_string();
+    let presented = credential.to_string();
+    let _lookup_permit =
+        tokio::time::timeout(AUTH_LOOKUP_QUEUE_TIMEOUT, auth.lookup_permits.acquire())
+            .await
+            .map_err(|_| {
+                ApiError::Unavailable("rollout authentication is busy; retry shortly".into())
+            })?
+            .map_err(|_| ApiError::internal("rollout authentication is shutting down"))?;
+    let db = auth.api.db().clone();
+    let lease = tokio::task::spawn_blocking(move || db.get_fork_lease_by_id(&lookup))
+        .await
+        .map_err(|error| ApiError::internal(format!("rollout lease lookup task failed: {error}")))?
+        .map_err(ApiError::database)?
+        .ok_or_else(|| {
+            ApiError::Unauthorized("a valid rollout lease bearer credential is required".into())
+        })?;
+    let scope =
+        lease_scope(&lease, &presented, crate::util::current_timestamp()).ok_or_else(|| {
+            ApiError::Unauthorized("a valid rollout lease bearer credential is required".into())
+        })?;
+    drop(_lookup_permit);
+    request.extensions_mut().insert(scope);
+    Ok(next.run(request).await)
+}
+
+async fn publish_device_policy(
+    Extension(scope): Extension<RolloutLeaseScope>,
+    State(state): State<Arc<ApiState>>,
+    Path(name): Path<String>,
+    Json(request): Json<PublishDeviceRolloutPolicyRequest>,
+) -> Result<(StatusCode, Json<RolloutPolicyInfo>), ApiError> {
+    scope.require_executor(&name)?;
+    scope.require_policy(&request.policy)?;
+    handlers::rollouts::publish_device_policy(State(state), Path(name), Json(request)).await
+}
+
+async fn retire_policy(
+    Extension(scope): Extension<RolloutLeaseScope>,
+    State(state): State<Arc<ApiState>>,
+    Path((name, policy, version)): Path<(String, String, String)>,
+) -> Result<StatusCode, ApiError> {
+    scope.require_executor(&name)?;
+    scope.require_policy(&policy)?;
+    handlers::rollouts::retire_policy(State(state), Path((name, policy, version))).await
+}
+
+async fn generate(
+    Extension(scope): Extension<RolloutLeaseScope>,
+    State(state): State<Arc<ApiState>>,
+    Path(name): Path<String>,
+    Json(request): Json<RolloutGenerateRequest>,
+) -> Result<Json<RolloutGenerateResponse>, ApiError> {
+    scope.require_executor(&name)?;
+    scope.require_policy(&request.policy)?;
+    handlers::rollouts::generate(State(state), Path(name), Json(request)).await
+}
+
+async fn generate_batch(
+    Extension(scope): Extension<RolloutLeaseScope>,
+    State(state): State<Arc<ApiState>>,
+    Path(name): Path<String>,
+    Json(request): Json<RolloutBatchRequest>,
+) -> Result<Json<RolloutBatchResponse>, ApiError> {
+    scope.require_executor(&name)?;
+    for job in &request.jobs {
+        scope.require_policy(&job.policy)?;
+    }
+    handlers::rollouts::generate_batch(State(state), Path(name), Json(request)).await
+}
+
+/// Build the dedicated guest-only router; no machine or executor-management routes exist here.
+pub fn create_router(state: Arc<ApiState>) -> Router {
+    let auth = RolloutAuthState {
+        api: state.clone(),
+        lookup_permits: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_AUTH_LOOKUPS)),
+    };
+    let protected = Router::new()
+        .route("/{name}/device-policies", post(publish_device_policy))
+        .route("/{name}/policies/{policy}/{version}", delete(retire_policy))
+        .route("/{name}/generate", post(generate))
+        .route("/{name}/batches", post(generate_batch))
+        .layer(DefaultBodyLimit::max(MAX_ROLLOUT_REQUEST_BYTES))
+        .layer(middleware::from_fn_with_state(auth, authenticate_lease));
+    Router::new()
+        .nest("/api/v1/rollout-executors", protected)
+        .layer(TraceLayer::new_for_http())
+        .with_state(state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request as HttpRequest;
+    use tower::ServiceExt;
+
+    fn lease(state: ForkLeaseState, expires_at: u64, token: &str) -> ForkLeaseRecord {
+        ForkLeaseRecord {
+            id: "lease-0123456789abcdef".into(),
+            pool_name: "pool".into(),
+            machine_name: "worker".into(),
+            idempotency_key: "request".into(),
+            state,
+            assignment: vec![
+                (ROLLOUT_TOKEN_ENV.into(), token.into()),
+                (ROLLOUT_EXECUTOR_ENV.into(), "executor".into()),
+                (ROLLOUT_POLICY_ENV.into(), "policy".into()),
+            ],
+            payload_sha256: None,
+            created_at: 1,
+            updated_at: 1,
+            expires_at,
+            ttl_secs: 60,
+            last_error: None,
+        }
+    }
+
+    #[test]
+    fn credential_is_random_and_parseable() {
+        let first = issue_lease_credential("lease-0123456789abcdef").unwrap();
+        let second = issue_lease_credential("lease-0123456789abcdef").unwrap();
+        assert_ne!(first, second);
+        assert_eq!(credential_lease_id(&first), Some("lease-0123456789abcdef"));
+        assert_eq!(first.len(), "lease-0123456789abcdef.".len() + 64);
+    }
+
+    #[test]
+    fn scope_requires_live_lease_and_exact_token() {
+        let token = format!("lease-0123456789abcdef.{}", "a".repeat(64));
+        let activating = lease(ForkLeaseState::Activating, 20, &token);
+        let active = lease(ForkLeaseState::Active, 20, &token);
+        assert_eq!(
+            lease_scope(&activating, &token, 10).unwrap().policy,
+            "policy"
+        );
+        assert_eq!(
+            lease_scope(&active, &token, 10).unwrap().executor,
+            "executor"
+        );
+        assert!(lease_scope(&active, "wrong", 10).is_none());
+        assert!(lease_scope(&active, &token, 20).is_none());
+        assert!(lease_scope(&lease(ForkLeaseState::Completed, 20, &token), &token, 10).is_none());
+
+        let mut ambiguous = active;
+        ambiguous
+            .assignment
+            .push((ROLLOUT_TOKEN_ENV.into(), token.clone()));
+        assert!(lease_scope(&ambiguous, &token, 10).is_none());
+    }
+
+    #[tokio::test]
+    async fn guest_router_exposes_no_control_plane_routes_and_requires_auth() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db = crate::db::SmolvmDb::open_at(&dir.path().join("state.db")).unwrap();
+        let router = create_router(Arc::new(ApiState::with_db(db.clone())));
+        let control = HttpRequest::builder()
+            .method("GET")
+            .uri("/api/v1/machines")
+            .body(Body::empty())
+            .unwrap();
+        assert_eq!(
+            router.clone().oneshot(control).await.unwrap().status(),
+            StatusCode::NOT_FOUND
+        );
+        let rollout = HttpRequest::builder()
+            .method("POST")
+            .uri("/api/v1/rollout-executors/executor/generate")
+            .header("content-type", "application/json")
+            .body(Body::from("{}"))
+            .unwrap();
+        assert_eq!(
+            router.oneshot(rollout).await.unwrap().status(),
+            StatusCode::UNAUTHORIZED
+        );
+    }
+
+    #[tokio::test]
+    async fn live_lease_authenticates_and_scope_blocks_other_executors() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db = crate::db::SmolvmDb::open_at(&dir.path().join("state.db")).unwrap();
+        let now = crate::util::current_timestamp();
+        db.insert_fork_pool_if_not_exists(&crate::pool::ForkPoolRecord {
+            name: "pool".into(),
+            golden: "golden".into(),
+            desired_ready: 1,
+            max_active: None,
+            auto_admission: false,
+            cuda_device_ordinal: None,
+            share_weights: false,
+            ready_timeout_secs: 30,
+            lease_ttl_secs: 60,
+            created_at: now,
+            deleting: false,
+        })
+        .unwrap();
+        let mut vm = crate::config::VmRecord::new("worker".into(), 2, 1024, vec![], vec![], false);
+        vm.golden = Some("golden".into());
+        vm.forkpoint_held = true;
+        db.insert_vm("worker", &vm).unwrap();
+        assert!(db.reserve_fork_pool_slot("pool", "worker", now).unwrap());
+        assert!(db.mark_fork_pool_slot_ready("worker", now).unwrap());
+        let token = format!("lease-0123456789abcdef.{}", "a".repeat(64));
+        let assignment = vec![
+            (ROLLOUT_TOKEN_ENV.into(), token.clone()),
+            (ROLLOUT_EXECUTOR_ENV.into(), "executor".into()),
+            (ROLLOUT_POLICY_ENV.into(), "policy".into()),
+        ];
+        let claimed = db
+            .claim_fork_pool_slot(crate::db::ForkPoolSlotClaim {
+                pool_name: "pool",
+                lease_id: "lease-0123456789abcdef",
+                idempotency_key: "request",
+                assignment: &assignment,
+                payload_sha256: None,
+                require_private_workspace: false,
+                admission_limit: None,
+                ttl_secs: 60,
+                now,
+            })
+            .unwrap();
+        assert!(matches!(
+            claimed,
+            crate::pool::ClaimForkPoolSlot::Claimed(_)
+        ));
+        db.mark_fork_lease_active("lease-0123456789abcdef", now)
+            .unwrap();
+        let router = create_router(Arc::new(ApiState::with_db(db.clone())));
+        let body = r#"{"idempotencyKey":"request","policy":"policy","prompts":[{"text":"hi"}],"sampling":{"maxTokens":1}}"#;
+
+        let correct = HttpRequest::builder()
+            .method("POST")
+            .uri("/api/v1/rollout-executors/executor/generate")
+            .header("content-type", "application/json")
+            .header("authorization", format!("Bearer {token}"))
+            .body(Body::from(body))
+            .unwrap();
+        assert_eq!(
+            router.clone().oneshot(correct).await.unwrap().status(),
+            StatusCode::NOT_FOUND,
+            "valid scoped auth must reach the handler"
+        );
+
+        let wrong_executor = HttpRequest::builder()
+            .method("POST")
+            .uri("/api/v1/rollout-executors/other/generate")
+            .header("content-type", "application/json")
+            .header("authorization", format!("Bearer {token}"))
+            .body(Body::from(body))
+            .unwrap();
+        assert_eq!(
+            router
+                .clone()
+                .oneshot(wrong_executor)
+                .await
+                .unwrap()
+                .status(),
+            StatusCode::FORBIDDEN
+        );
+
+        let wrong_policy_body = r#"{"idempotencyKey":"request-2","policy":"other","prompts":[{"text":"hi"}],"sampling":{"maxTokens":1}}"#;
+        let wrong_policy = HttpRequest::builder()
+            .method("POST")
+            .uri("/api/v1/rollout-executors/executor/generate")
+            .header("content-type", "application/json")
+            .header("authorization", format!("Bearer {token}"))
+            .body(Body::from(wrong_policy_body))
+            .unwrap();
+        assert_eq!(
+            router.clone().oneshot(wrong_policy).await.unwrap().status(),
+            StatusCode::FORBIDDEN
+        );
+
+        db.complete_fork_lease("pool", "lease-0123456789abcdef", now + 1)
+            .unwrap();
+        let revoked = HttpRequest::builder()
+            .method("POST")
+            .uri("/api/v1/rollout-executors/executor/generate")
+            .header("content-type", "application/json")
+            .header("authorization", format!("Bearer {token}"))
+            .body(Body::from(body))
+            .unwrap();
+        assert_eq!(
+            router.oneshot(revoked).await.unwrap().status(),
+            StatusCode::UNAUTHORIZED
+        );
+    }
+}

--- a/src/api/handlers/pools.rs
+++ b/src/api/handlers/pools.rs
@@ -38,6 +38,15 @@ const MAX_WORKER_READY_TIMEOUT_SECS: u64 = crate::pool::FORK_LEASE_ACTIVATION_GR
 const DEFAULT_WORKER_READY_TIMEOUT_SECS: u64 = MAX_WORKER_READY_TIMEOUT_SECS;
 const WORKER_READY_TIMEOUT_ENV: &str = "SMOLVM_WORKER_READY_TIMEOUT_SECS";
 
+const RESERVED_LEASE_ENV: &[&str] = &[
+    smolvm_protocol::forkpoint::WORKER_READY_TOKEN_ENV,
+    WORKER_READY_TIMEOUT_ENV,
+    crate::api::guest_rollout::ROLLOUT_TOKEN_ENV,
+    crate::api::guest_rollout::ROLLOUT_URL_ENV,
+    crate::api::guest_rollout::ROLLOUT_EXECUTOR_ENV,
+    crate::api::guest_rollout::ROLLOUT_POLICY_ENV,
+];
+
 #[derive(Clone)]
 struct StagedLeaseFile {
     path: String,
@@ -99,6 +108,80 @@ fn add_worker_ready_assignment(
     ));
     assignment.push((WORKER_READY_TIMEOUT_ENV.into(), timeout_secs.to_string()));
     Ok(token)
+}
+
+fn add_rollout_access_assignment(
+    assignment: &mut Vec<(String, String)>,
+    lease_id: &str,
+    access: &crate::api::types::RolloutLeaseAccess,
+) -> Result<(), ApiError> {
+    crate::api::rollout::validate_name("rollout executor", &access.executor)
+        .map_err(ApiError::from)?;
+    crate::api::rollout::validate_name("rollout policy", &access.policy).map_err(ApiError::from)?;
+    let credential = crate::api::guest_rollout::issue_lease_credential(lease_id)
+        .map_err(|error| ApiError::internal(format!("issue rollout lease credential: {error}")))?;
+    assignment.extend([
+        (
+            crate::api::guest_rollout::ROLLOUT_TOKEN_ENV.into(),
+            credential,
+        ),
+        (
+            crate::api::guest_rollout::ROLLOUT_URL_ENV.into(),
+            crate::api::guest_rollout::lease_rollout_url(&access.executor),
+        ),
+        (
+            crate::api::guest_rollout::ROLLOUT_EXECUTOR_ENV.into(),
+            access.executor.clone(),
+        ),
+        (
+            crate::api::guest_rollout::ROLLOUT_POLICY_ENV.into(),
+            access.policy.clone(),
+        ),
+    ]);
+    Ok(())
+}
+
+fn validate_rollout_access_target(
+    golden: &crate::config::VmRecord,
+    guest_host_service: Option<smolvm_network::GatewayHostService>,
+) -> Result<(), ApiError> {
+    if !guest_host_service
+        .is_some_and(|service| service.guest_port == crate::api::guest_rollout::GUEST_ROLLOUT_PORT)
+    {
+        return Err(ApiError::Conflict(
+            "rolloutAccess is unavailable because guest rollout ingress is not enabled on this node"
+                .into(),
+        ));
+    }
+    if !golden.network {
+        return Err(ApiError::Conflict(
+            "rolloutAccess requires a pool golden with networking enabled".into(),
+        ));
+    }
+    if golden.network_backend == Some(crate::network::NetworkBackend::Tsi) {
+        return Err(ApiError::Conflict(
+            "rolloutAccess requires the virtio-net backend; recreate the pool golden without an explicit TSI backend"
+                .into(),
+        ));
+    }
+    if golden.runtime_managed {
+        return Err(ApiError::Conflict(
+            "rolloutAccess is not supported for Kubernetes pod-network machines".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn idempotent_assignment_matches(
+    existing: &[(String, String)],
+    requested: &[(String, String)],
+) -> bool {
+    existing
+        .iter()
+        .filter(|(key, _)| key != crate::api::guest_rollout::ROLLOUT_TOKEN_ENV)
+        .eq(requested
+            .iter()
+            .filter(|(key, _)| key != crate::api::guest_rollout::ROLLOUT_TOKEN_ENV))
 }
 
 fn validate_lease_payload(
@@ -698,20 +781,28 @@ pub async fn acquire_lease(
             "idempotencyKey must contain 1-{MAX_IDEMPOTENCY_KEY_BYTES} non-control bytes"
         )));
     }
+    let lease_id = format!(
+        "lease-{}{}",
+        crate::util::generate_short_id(),
+        crate::util::generate_short_id()
+    );
     let worker_ready_timeout =
         validate_worker_ready_request(req.await_worker_ready, req.worker_ready_timeout_secs)?;
     let mut assignment = crate::util::parse_env_list(&req.env);
     crate::agent::fork::validate_fork_env(&assignment)
         .map_err(|e| ApiError::BadRequest(e.to_string()))?;
-    for reserved in [
-        smolvm_protocol::forkpoint::WORKER_READY_TOKEN_ENV,
-        WORKER_READY_TIMEOUT_ENV,
-    ] {
+    for reserved in RESERVED_LEASE_ENV {
         if assignment.iter().any(|(key, _)| key == reserved) {
             return Err(ApiError::BadRequest(format!(
-                "{reserved} is reserved for smolvm worker readiness"
+                "{reserved} is reserved for smolvm lease activation"
             )));
         }
+    }
+    if let Some(access) = &req.rollout_access {
+        crate::api::rollout::validate_name("rollout executor", &access.executor)
+            .map_err(ApiError::from)?;
+        crate::api::rollout::validate_name("rollout policy", &access.policy)
+            .map_err(ApiError::from)?;
     }
     let worker_ready = worker_ready_timeout.map(|timeout| {
         add_worker_ready_assignment(&mut assignment, &pool_name, &req.idempotency_key, timeout)
@@ -729,6 +820,22 @@ pub async fn acquire_lease(
         .map_err(|e| ApiError::internal(format!("pool lookup task failed: {e}")))?
         .map_err(ApiError::database)?
         .ok_or_else(|| ApiError::NotFound(format!("fork pool '{pool_name}' not found")))?;
+    if let Some(access) = &req.rollout_access {
+        let golden = state.lookup_vm(&pool.golden).await?.ok_or_else(|| {
+            ApiError::Conflict(format!("pool golden '{}' no longer exists", pool.golden))
+        })?;
+        let guest_host_service =
+            crate::network::launch::guest_host_service().map_err(|reason| {
+                ApiError::internal(format!("read guest rollout ingress: {reason}"))
+            })?;
+        validate_rollout_access_target(&golden, guest_host_service)?;
+        state
+            .rollout()
+            .get(&access.executor)
+            .await
+            .map_err(ApiError::from)?;
+        add_rollout_access_assignment(&mut assignment, &lease_id, access)?;
+    }
     if pool.admission_device_ordinal().is_some()
         && assignment
             .iter()
@@ -740,11 +847,6 @@ pub async fn acquire_lease(
         ));
     }
     let ttl = validate_ttl(req.ttl_secs.unwrap_or(pool.lease_ttl_secs))?;
-    let lease_id = format!(
-        "lease-{}{}",
-        crate::util::generate_short_id(),
-        crate::util::generate_short_id()
-    );
     let now = crate::util::current_timestamp();
     let db = state.db().clone();
     let pool_for_claim = pool_name.clone();
@@ -771,7 +873,7 @@ pub async fn acquire_lease(
     .map_err(ApiError::database)?;
     let lease = match claim {
         ClaimForkPoolSlot::Existing(lease) => {
-            if lease.assignment != assignment
+            if !idempotent_assignment_matches(&lease.assignment, &assignment)
                 || lease.payload_sha256 != payload_sha256
                 || lease.ttl_secs != ttl
             {
@@ -1149,6 +1251,7 @@ mod tests {
         assert!(request.files.is_empty());
         assert!(!request.await_worker_ready);
         assert_eq!(request.worker_ready_timeout_secs, None);
+        assert_eq!(request.rollout_access, None);
     }
 
     #[test]
@@ -1211,5 +1314,92 @@ mod tests {
             add_worker_ready_assignment(&mut reserved, "pool", "request", 1).unwrap_err()
         )
         .contains("reserved"));
+    }
+
+    #[test]
+    fn rollout_assignment_is_scoped_and_idempotency_ignores_only_its_secret() {
+        let access = crate::api::types::RolloutLeaseAccess {
+            executor: "executor-a".into(),
+            policy: "policy-3".into(),
+        };
+        let mut first = vec![("LEARNER".into(), "3".into())];
+        let mut retry = first.clone();
+        add_rollout_access_assignment(&mut first, "lease-1111111111111111", &access).unwrap();
+        add_rollout_access_assignment(&mut retry, "lease-2222222222222222", &access).unwrap();
+        assert!(idempotent_assignment_matches(&first, &retry));
+        assert_ne!(
+            first
+                .iter()
+                .find(|(key, _)| key == crate::api::guest_rollout::ROLLOUT_TOKEN_ENV),
+            retry
+                .iter()
+                .find(|(key, _)| key == crate::api::guest_rollout::ROLLOUT_TOKEN_ENV)
+        );
+        assert!(first.contains(&(
+            crate::api::guest_rollout::ROLLOUT_URL_ENV.into(),
+            crate::api::guest_rollout::lease_rollout_url("executor-a")
+        )));
+
+        retry
+            .iter_mut()
+            .find(|(key, _)| key == crate::api::guest_rollout::ROLLOUT_POLICY_ENV)
+            .unwrap()
+            .1 = "another-policy".into();
+        assert!(!idempotent_assignment_matches(&first, &retry));
+    }
+
+    #[test]
+    fn rollout_access_requires_reachable_non_pod_virtio_networking() {
+        let mut golden =
+            crate::config::VmRecord::new("golden".into(), 2, 1024, vec![], vec![], false);
+        assert!(matches!(
+            validate_rollout_access_target(
+                &golden,
+                Some(smolvm_network::GatewayHostService {
+                    guest_port: crate::api::guest_rollout::GUEST_ROLLOUT_PORT,
+                    host_port: 40_081,
+                })
+            ),
+            Err(ApiError::Conflict(_))
+        ));
+
+        golden.network = true;
+        assert!(validate_rollout_access_target(
+            &golden,
+            Some(smolvm_network::GatewayHostService {
+                guest_port: crate::api::guest_rollout::GUEST_ROLLOUT_PORT,
+                host_port: 40_081,
+            })
+        )
+        .is_ok());
+        assert!(matches!(
+            validate_rollout_access_target(&golden, None),
+            Err(ApiError::Conflict(_))
+        ));
+
+        golden.network_backend = Some(crate::network::NetworkBackend::Tsi);
+        assert!(matches!(
+            validate_rollout_access_target(
+                &golden,
+                Some(smolvm_network::GatewayHostService {
+                    guest_port: crate::api::guest_rollout::GUEST_ROLLOUT_PORT,
+                    host_port: 40_081,
+                })
+            ),
+            Err(ApiError::Conflict(_))
+        ));
+
+        golden.network_backend = Some(crate::network::NetworkBackend::VirtioNet);
+        golden.runtime_managed = true;
+        assert!(matches!(
+            validate_rollout_access_target(
+                &golden,
+                Some(smolvm_network::GatewayHostService {
+                    guest_port: crate::api::guest_rollout::GUEST_ROLLOUT_PORT,
+                    host_port: 40_081,
+                })
+            ),
+            Err(ApiError::Conflict(_))
+        ));
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -23,6 +23,7 @@ pub mod admission;
 pub(crate) mod device_handoff;
 #[path = "errors.rs"]
 pub mod error;
+pub mod guest_rollout;
 pub mod handlers;
 pub mod pool_controller;
 pub mod rollout;
@@ -140,6 +141,7 @@ use state::ApiState;
         types::CreateForkPoolRequest,
         types::DeleteForkPoolQuery,
         types::AcquireForkLeaseRequest,
+        types::RolloutLeaseAccess,
         types::ForkLeasePayloadFile,
         types::ResizeForkPoolRequest,
         rollout::CreateRolloutExecutorRequest,

--- a/src/api/rollout.rs
+++ b/src/api/rollout.rs
@@ -1461,7 +1461,7 @@ struct BackendCompletionResponse {
     usage: RolloutUsage,
 }
 
-fn validate_name(kind: &str, value: &str) -> Result<(), RolloutError> {
+pub(crate) fn validate_name(kind: &str, value: &str) -> Result<(), RolloutError> {
     let valid = !value.is_empty()
         && value.len() <= MAX_NAME_BYTES
         && value

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -999,6 +999,19 @@ pub struct AcquireForkLeaseRequest {
     /// Optional readiness timeout in seconds; defaults to 240 when enabled.
     #[serde(default)]
     pub worker_ready_timeout_secs: Option<u64>,
+    /// Optional fused-rollout access granted only to this lease's executor and policy.
+    #[serde(default)]
+    pub rollout_access: Option<RolloutLeaseAccess>,
+}
+
+/// Least-privilege fused-rollout scope injected into one pool worker.
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RolloutLeaseAccess {
+    /// Existing rollout executor this worker may call.
+    pub executor: String,
+    /// Logical policy this worker may publish, generate, and retire.
+    pub policy: String,
 }
 
 /// One file staged into a held worker before lease activation.

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -195,6 +195,37 @@ impl ServeStartCmd {
             tracing::info!("egress floor set to strict (multi-tenant serve default)");
         }
 
+        // VMM subprocesses may route exactly one gateway port to the
+        // lease-authenticated rollout listener started below. This is internal
+        // node configuration, never a guest-supplied egress exception.
+        let guest_rollout_host_port =
+            std::env::var(smolvm::api::guest_rollout::GUEST_ROLLOUT_HOST_PORT_ENV)
+                .ok()
+                .map(|value| {
+                    value
+                        .parse::<u16>()
+                        .ok()
+                        .filter(|port| *port != 0)
+                        .ok_or_else(|| {
+                            smolvm::error::Error::config(
+                                "configure guest rollout ingress",
+                                format!(
+                                    "{} must be an integer between 1 and 65535",
+                                    smolvm::api::guest_rollout::GUEST_ROLLOUT_HOST_PORT_ENV
+                                ),
+                            )
+                        })
+                })
+                .transpose()?
+                .unwrap_or(smolvm::api::guest_rollout::GUEST_ROLLOUT_PORT);
+        smolvm::network::launch::configure_guest_host_service(
+            smolvm::api::guest_rollout::GUEST_ROLLOUT_PORT,
+            guest_rollout_host_port,
+        )
+        .map_err(|reason| {
+            smolvm::error::Error::config("configure guest rollout ingress", reason)
+        })?;
+
         // Per-VM uid isolation preflight. When serve is privileged each VMM drops
         // to its own unprivileged uid (process::vm_drop_ids), containing a
         // guest→VMM escape to one VM. That only works if the data root is
@@ -278,6 +309,41 @@ impl ServeStartCmd {
         // Create shutdown channel for supervisor
         let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
+        // A dedicated loopback listener carries only lease-authenticated rollout
+        // operations. The virtio gateway maps its internal host-service port to
+        // this socket while the normal strict egress floor remains unchanged.
+        let guest_rollout_host_port = smolvm::network::launch::guest_host_service()
+            .map_err(|reason| smolvm::error::Error::config("read guest rollout ingress", reason))?
+            .ok_or_else(|| {
+                smolvm::error::Error::config(
+                    "read guest rollout ingress",
+                    "guest host service is not configured",
+                )
+            })?
+            .host_port;
+        let guest_rollout_addr = SocketAddr::from(([127, 0, 0, 1], guest_rollout_host_port));
+        let guest_rollout_listener = tokio::net::TcpListener::bind(guest_rollout_addr)
+            .await
+            .map_err(|error| {
+                smolvm::error::Error::config(
+                    "bind guest rollout ingress",
+                    format!("{guest_rollout_addr}: {error}"),
+                )
+            })?;
+        let guest_rollout_app = smolvm::api::guest_rollout::create_router(state.clone());
+        let guest_rollout_shutdown = shutdown_rx.clone();
+        let guest_rollout_failure = shutdown_tx.clone();
+        let guest_rollout_handle = tokio::spawn(async move {
+            tracing::info!(address = %guest_rollout_addr, "starting lease-authenticated guest rollout ingress");
+            let result = axum::serve(guest_rollout_listener, guest_rollout_app)
+                .with_graceful_shutdown(wait_for_shutdown(guest_rollout_shutdown))
+                .await;
+            if result.is_err() {
+                let _ = guest_rollout_failure.send(true);
+            }
+            result
+        });
+
         // Spawn supervisor task
         let supervisor_state = state.clone();
         let supervisor_shutdown = shutdown_rx.clone();
@@ -315,17 +381,30 @@ impl ServeStartCmd {
         })?;
 
         // Listen server on TCP or Unix socket
-        match listen_target {
-            ListenTarget::Tcp(addr) => self.serve_tcp(addr, app, local_app, tls).await?,
+        let server_result = match listen_target {
+            ListenTarget::Tcp(addr) => {
+                self.serve_tcp(addr, app, local_app, tls, shutdown_rx.clone())
+                    .await
+            }
             #[cfg(unix)]
-            ListenTarget::Unix(path) => self.serve_unix(path, app).await?,
-        }
+            ListenTarget::Unix(path) => self.serve_unix(path, app, shutdown_rx.clone()).await,
+        };
 
         // The HTTP server has stopped accepting (graceful shutdown on SIGTERM).
         // Stop reconcilers before detaching or draining machine managers. In
         // particular, a pool fill must not register a newly booted worker after
         // `detach_all` has already walked the registry.
         let _ = shutdown_tx.send(true);
+        let guest_rollout_result = guest_rollout_handle.await.map_err(|error| {
+            smolvm::error::Error::config("guest rollout ingress task", error.to_string())
+        })?;
+        if let Err(error) = guest_rollout_result {
+            tracing::error!(%error, "guest rollout ingress stopped unexpectedly");
+            if server_result.is_ok() {
+                return Err(smolvm::error::Error::Io(error));
+            }
+        }
+        server_result?;
         let mut pool_controller_handle = pool_controller_handle;
         match tokio::time::timeout(
             std::time::Duration::from_secs(5),
@@ -376,9 +455,10 @@ impl ServeStartCmd {
         app: Router,
         local_app: Router,
         tls: Option<std::sync::Arc<rustls::ServerConfig>>,
+        internal_shutdown: tokio::sync::watch::Receiver<bool>,
     ) -> Result<()> {
         if let Some(tls_config) = tls {
-            return Self::serve_tcp_tls(addr, app, local_app, tls_config).await;
+            return Self::serve_tcp_tls(addr, app, local_app, tls_config, internal_shutdown).await;
         }
 
         let listener = tokio::net::TcpListener::bind(addr)
@@ -389,7 +469,7 @@ impl ServeStartCmd {
         println!("smolvm API server listening on http://{}", addr);
 
         axum::serve(listener, app)
-            .with_graceful_shutdown(shutdown_signal())
+            .with_graceful_shutdown(shutdown_signal_or_internal(internal_shutdown))
             .await
             .map_err(smolvm::error::Error::Io)
     }
@@ -408,6 +488,7 @@ impl ServeStartCmd {
         app: Router,
         local_app: Router,
         tls_config: std::sync::Arc<rustls::ServerConfig>,
+        internal_shutdown: tokio::sync::watch::Receiver<bool>,
     ) -> Result<()> {
         // Loopback plain-HTTP door for the local node-agent.
         if let Some(local_addr) = super::serve_tls::local_plain_addr(addr) {
@@ -438,6 +519,7 @@ impl ServeStartCmd {
                 "smolvm local API (loopback, plain) on http://{}",
                 local_addr
             );
+            let local_shutdown = internal_shutdown.clone();
             std::thread::Builder::new()
                 .name("smolvm-loopback-api".to_string())
                 .spawn(move || {
@@ -461,7 +543,7 @@ impl ServeStartCmd {
                             }
                         };
                         let _ = axum::serve(listener, local_app)
-                            .with_graceful_shutdown(shutdown_signal())
+                            .with_graceful_shutdown(shutdown_signal_or_internal(local_shutdown))
                             .await;
                     });
                 })
@@ -474,7 +556,7 @@ impl ServeStartCmd {
         // Trip graceful shutdown on the same signal the plain path observes.
         let shutdown_handle = handle.clone();
         tokio::spawn(async move {
-            shutdown_signal().await;
+            shutdown_signal_or_internal(internal_shutdown).await;
             shutdown_handle.graceful_shutdown(Some(std::time::Duration::from_secs(5)));
         });
 
@@ -489,7 +571,12 @@ impl ServeStartCmd {
     }
 
     #[cfg(unix)]
-    async fn serve_unix(&self, path: PathBuf, app: Router) -> Result<()> {
+    async fn serve_unix(
+        &self,
+        path: PathBuf,
+        app: Router,
+        internal_shutdown: tokio::sync::watch::Receiver<bool>,
+    ) -> Result<()> {
         let socket_guard = UnixSocketGuard::bind(&path)?;
         let listener =
             tokio::net::UnixListener::bind(&socket_guard.path).map_err(smolvm::error::Error::Io)?;
@@ -501,7 +588,7 @@ impl ServeStartCmd {
         );
 
         axum::serve(listener, app)
-            .with_graceful_shutdown(shutdown_signal())
+            .with_graceful_shutdown(shutdown_signal_or_internal(internal_shutdown))
             .await
             .map_err(smolvm::error::Error::Io)
     }
@@ -636,6 +723,21 @@ async fn shutdown_signal() {
 
     tracing::info!("shutdown signal received");
     eprintln!("\nShutting down server (VMs continue running)...");
+}
+
+async fn wait_for_shutdown(mut shutdown: tokio::sync::watch::Receiver<bool>) {
+    while !*shutdown.borrow() {
+        if shutdown.changed().await.is_err() {
+            break;
+        }
+    }
+}
+
+async fn shutdown_signal_or_internal(shutdown: tokio::sync::watch::Receiver<bool>) {
+    tokio::select! {
+        () = shutdown_signal() => {},
+        () = wait_for_shutdown(shutdown) => {},
+    }
 }
 
 #[cfg(test)]

--- a/src/db.rs
+++ b/src/db.rs
@@ -1374,6 +1374,22 @@ impl SmolvmDb {
         })
     }
 
+    /// Read one lease by its globally unique opaque ID.
+    pub fn get_fork_lease_by_id(&self, lease_id: &str) -> Result<Option<ForkLeaseRecord>> {
+        self.with_read_conn(|conn| {
+            let data: Option<Vec<u8>> = conn
+                .query_row(
+                    "SELECT data FROM fork_leases WHERE id = ?1",
+                    params![lease_id],
+                    |row| row.get(0),
+                )
+                .optional()
+                .db_err(format!("get fork lease '{lease_id}'"))?;
+            data.map(|bytes| serde_json::from_slice(&bytes).db_err("deserialize fork lease"))
+                .transpose()
+        })
+    }
+
     /// Mark a claimed worker active after its guest release succeeds.
     pub fn mark_fork_lease_active(
         &self,

--- a/src/network/launch.rs
+++ b/src/network/launch.rs
@@ -1,5 +1,60 @@
 use crate::data::resources::VmResources;
 use crate::network::backend::NetworkBackend;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+static GUEST_HOST_SERVICE: AtomicU32 = AtomicU32::new(0);
+
+/// Enable one smolvm-owned gateway service for VMs launched by this server.
+pub fn configure_guest_host_service(
+    guest_port: u16,
+    host_port: u16,
+) -> std::result::Result<(), String> {
+    if guest_port == 0 || host_port == 0 {
+        return Err("guest host service ports must be between 1 and 65535".into());
+    }
+    let mapping = (u32::from(guest_port) << 16) | u32::from(host_port);
+    match GUEST_HOST_SERVICE.compare_exchange(0, mapping, Ordering::AcqRel, Ordering::Acquire) {
+        Ok(_) => Ok(()),
+        Err(current) if current == mapping => Ok(()),
+        Err(_) => Err("guest host service is already configured differently".into()),
+    }
+}
+
+fn guest_host_service_configured() -> bool {
+    GUEST_HOST_SERVICE.load(Ordering::Acquire) != 0
+        || std::env::var_os(crate::api::guest_rollout::GUEST_HOST_SERVICE_ENV).is_some()
+}
+
+/// Resolve the internal, smolvm-owned gateway service enabled by `serve`.
+pub fn guest_host_service(
+) -> std::result::Result<Option<smolvm_network::GatewayHostService>, String> {
+    let configured = GUEST_HOST_SERVICE.load(Ordering::Acquire);
+    if configured != 0 {
+        return Ok(Some(smolvm_network::GatewayHostService {
+            guest_port: (configured >> 16) as u16,
+            host_port: configured as u16,
+        }));
+    }
+    let Some(value) = std::env::var_os(crate::api::guest_rollout::GUEST_HOST_SERVICE_ENV) else {
+        return Ok(None);
+    };
+    let value = value
+        .to_str()
+        .ok_or_else(|| "guest host service mapping is not valid UTF-8".to_string())?;
+    let (guest_port, host_port) = value
+        .split_once(':')
+        .ok_or_else(|| "guest host service mapping must be GUEST_PORT:HOST_PORT".to_string())?;
+    let parse_port = |port: &str| {
+        port.parse::<u16>()
+            .ok()
+            .filter(|port| *port != 0)
+            .ok_or_else(|| "guest host service ports must be between 1 and 65535".to_string())
+    };
+    Ok(Some(smolvm_network::GatewayHostService {
+        guest_port: parse_port(guest_port)?,
+        host_port: parse_port(host_port)?,
+    }))
+}
 
 /// Effective backend selected for a launch.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -42,6 +97,7 @@ pub fn plan_launch_network(
         .as_ref()
         .is_some_and(|cidrs| !cidrs.is_empty());
     let has_dns_filter = dns_filter_hosts.is_some_and(|hosts| !hosts.is_empty());
+    let has_host_service = guest_host_service_configured();
     let wants_network = resources.network || has_ports || has_cidr_policy || has_dns_filter;
 
     if !wants_network {
@@ -69,7 +125,7 @@ pub fn plan_launch_network(
     // so a policy forces virtio-net unless the caller explicitly picked a backend.
     let fleet_mode = std::env::var_os("SMOLVM_PUBLISH_ADDR").is_some();
     let backend = resources.network_backend.unwrap_or(
-        if has_ports || fleet_mode || has_cidr_policy || has_dns_filter {
+        if has_ports || fleet_mode || has_cidr_policy || has_dns_filter || has_host_service {
             NetworkBackend::VirtioNet
         } else {
             NetworkBackend::Tsi
@@ -105,17 +161,18 @@ pub fn validate_requested_network_backend(
         .as_ref()
         .is_some_and(|c| !c.is_empty())
         || dns_filter_hosts.is_some_and(|h| !h.is_empty());
+    let has_host_service = guest_host_service_configured();
 
     // Mirror plan_launch_network's default: unset backend + (ports OR egress
     // policy) ⇒ virtio-net. So only an EXPLICIT `--net-backend tsi` alongside
     // ports/egress is a misconfig.
-    let backend = resources
-        .network_backend
-        .unwrap_or(if port_count > 0 || has_egress_policy {
+    let backend = resources.network_backend.unwrap_or(
+        if port_count > 0 || has_egress_policy || has_host_service {
             NetworkBackend::VirtioNet
         } else {
             NetworkBackend::Tsi
-        });
+        },
+    );
 
     // Published ports require the inbound path that only virtio-net has. With
     // the default above this only fires when the caller EXPLICITLY forced TSI.


### PR DESCRIPTION
Allow forked workers to call only their assigned fused rollout executor and policy through an authenticated strict-egress gateway.