### PR TITLE
Harden device adapter server startup

### DIFF
--- a/sdks/python/src/smolvm_rollout/device_handoff.py
+++ b/sdks/python/src/smolvm_rollout/device_handoff.py
@@ -271,20 +271,27 @@ class DeviceAdapterServer:
         self._lock = threading.Lock()
         self._listener: socket.socket | None = None
         self._stopping = threading.Event()
+        self._ready = threading.Event()
+        self._startup_error: BaseException | None = None
 
     def serve_forever(self) -> None:
         """Bind the private socket and process requests until ``shutdown``."""
 
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        _remove_stale_socket(self.path)
-        listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        listener: socket.socket | None = None
         cleanup_error: Exception | None = None
+        socket_identity: tuple[int, int] | None = None
         try:
+            listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            _remove_stale_socket(self.path)
             listener.bind(str(self.path))
+            metadata = self.path.lstat()
+            socket_identity = (metadata.st_dev, metadata.st_ino)
             os.chmod(self.path, 0o600)
             listener.listen(16)
             listener.settimeout(0.5)
             self._listener = listener
+            self._ready.set()
             while not self._stopping.is_set():
                 try:
                     connection, _ = listener.accept()
@@ -297,13 +304,16 @@ class DeviceAdapterServer:
                 with connection:
                     connection.settimeout(self._io_timeout_secs)
                     self._serve_one(connection)
+        except BaseException as error:
+            if not self._ready.is_set():
+                self._startup_error = error
+                self._ready.set()
+            raise
         finally:
             self._listener = None
-            listener.close()
-            try:
-                self.path.unlink()
-            except FileNotFoundError:
-                pass
+            if listener is not None:
+                listener.close()
+            _remove_owned_socket(self.path, socket_identity)
             for model in tuple(self._loaded):
                 try:
                     self._unload(model)
@@ -312,6 +322,18 @@ class DeviceAdapterServer:
                         cleanup_error = error
         if cleanup_error is not None:
             raise cleanup_error
+
+    def wait_until_ready(self, timeout: float | None = None) -> None:
+        """Wait until the socket accepts connections or startup fails."""
+
+        if timeout is not None and timeout < 0:
+            raise ValueError("timeout must be non-negative")
+        if not self._ready.wait(timeout):
+            raise TimeoutError(f"device adapter server did not become ready at {self.path}")
+        if self._startup_error is not None:
+            raise RuntimeError(
+                f"device adapter server failed to start at {self.path}"
+            ) from self._startup_error
 
     def shutdown(self) -> None:
         """Stop accepting requests and unload every retained adapter mapping."""
@@ -432,6 +454,17 @@ def _remove_stale_socket(path: Path) -> None:
         raise RuntimeError(f"device adapter socket {path} is already active")
     finally:
         probe.close()
+
+
+def _remove_owned_socket(path: Path, identity: tuple[int, int] | None) -> None:
+    if identity is None:
+        return
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return
+    if (metadata.st_dev, metadata.st_ino) == identity and stat.S_ISSOCK(metadata.st_mode):
+        path.unlink()
 
 
 def _validate_peer(connection: socket.socket) -> None:

--- a/sdks/python/tests/test_device_handoff.py
+++ b/sdks/python/tests/test_device_handoff.py
@@ -51,6 +51,13 @@ class Owner:
         self.closed = True
 
 
+def start_server(server):
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    server.wait_until_ready(2)
+    return thread
+
+
 class DeviceHandoffTests(unittest.TestCase):
     def test_active_socket_is_never_unlinked(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -64,6 +71,42 @@ class DeviceHandoffTests(unittest.TestCase):
                     device_handoff._remove_stale_socket(path)
                 self.assertTrue(path.exists())
             finally:
+                listener.close()
+
+    def test_failed_server_start_does_not_unlink_an_active_socket(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "adapter.sock"
+            listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            listener.bind(str(path))
+            os.chmod(path, 0o600)
+            listener.listen(4)
+            errors = []
+            server = DeviceAdapterServer(
+                path,
+                load_adapter=lambda _model, _bundle: None,
+                unload_adapter=lambda _model, _owner: None,
+            )
+
+            def run_server():
+                try:
+                    server.serve_forever()
+                except BaseException as error:
+                    errors.append(error)
+
+            thread = threading.Thread(target=run_server, daemon=True)
+            thread.start()
+            with self.assertRaisesRegex(RuntimeError, "failed to start"):
+                server.wait_until_ready(2)
+            thread.join(timeout=2)
+            self.assertFalse(thread.is_alive())
+            self.assertTrue(errors)
+            self.assertTrue(path.exists())
+
+            probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            try:
+                probe.connect(str(path))
+            finally:
+                probe.close()
                 listener.close()
 
     def test_manifest_range_must_match_shape_and_dtype(self):
@@ -99,13 +142,7 @@ class DeviceHandoffTests(unittest.TestCase):
                 unload_adapter=lambda _model, _owner: None,
                 io_timeout_secs=0.05,
             )
-            thread = threading.Thread(target=server.serve_forever, daemon=True)
-            thread.start()
-            deadline = time.monotonic() + 2
-            while not path.exists():
-                if time.monotonic() > deadline:
-                    self.fail("device adapter server did not bind")
-                time.sleep(0.01)
+            thread = start_server(server)
             stalled = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             stalled.connect(str(path))
             stalled.sendall(b"S")
@@ -186,13 +223,7 @@ class DeviceHandoffTests(unittest.TestCase):
                 os.fstat(owner.descriptor)
 
             server = DeviceAdapterServer(path, load_adapter=load, unload_adapter=unload)
-            thread = threading.Thread(target=server.serve_forever, daemon=True)
-            thread.start()
-            deadline = time.monotonic() + 2
-            while not path.exists():
-                if time.monotonic() > deadline:
-                    self.fail("device adapter server did not bind")
-                time.sleep(0.01)
+            thread = start_server(server)
 
             self.assertEqual(request(path, 0), (b"SMVDHR01", 0, b""))
             manifest = json.dumps(
@@ -253,13 +284,7 @@ class DeviceHandoffTests(unittest.TestCase):
                     raise RuntimeError("injected unload failure")
 
             server = DeviceAdapterServer(path, load_adapter=load, unload_adapter=unload)
-            thread = threading.Thread(target=server.serve_forever, daemon=True)
-            thread.start()
-            deadline = time.monotonic() + 2
-            while not path.exists():
-                if time.monotonic() > deadline:
-                    self.fail("device adapter server did not bind")
-                time.sleep(0.01)
+            thread = start_server(server)
             manifest = json.dumps(
                 {
                     "schema": "smolvm.device-lora.v1",
@@ -312,13 +337,7 @@ class DeviceHandoffTests(unittest.TestCase):
                 unloads += 1
 
             server = DeviceAdapterServer(path, load_adapter=load, unload_adapter=unload)
-            thread = threading.Thread(target=server.serve_forever, daemon=True)
-            thread.start()
-            deadline = time.monotonic() + 2
-            while not path.exists():
-                if time.monotonic() > deadline:
-                    self.fail("device adapter server did not bind")
-                time.sleep(0.01)
+            thread = start_server(server)
             manifest = json.dumps(
                 {
                     "schema": "smolvm.device-lora.v1",


### PR DESCRIPTION
Expose an explicit readiness barrier and preserve active Unix sockets when competing server startup fails.