### PR TITLE
Fix cross-VM --mount-socket collisions when the guest path is inside a shared --volume

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -3308,6 +3308,7 @@ fn write_oci_bundle(
     storage::add_storage_fallback(&mut spec, mounts, unprivileged);
 
     ssh_agent::inject_into_container(&mut spec);
+    publish_socket::inject_into_container(&mut spec);
     rosetta::inject_into_container(&mut spec);
     forkpoint::inject_into_container(&mut spec);
     cuda::inject_into_container(&mut spec, rootfs_path);
@@ -4223,6 +4224,7 @@ fn spawn_interactive_command(
 
     // Forward SSH agent into the container if enabled at boot.
     ssh_agent::inject_into_container(&mut spec);
+    publish_socket::inject_into_container(&mut spec);
     rosetta::inject_into_container(&mut spec);
     forkpoint::inject_into_container(&mut spec);
     cuda::inject_into_container(&mut spec, rootfs_path);

--- a/crates/smolvm-agent/src/pod.rs
+++ b/crates/smolvm-agent/src/pod.rs
@@ -963,6 +963,7 @@ fn write_pod_bundle(
 
     // Same injections as Run's bundle build (write_oci_bundle).
     crate::ssh_agent::inject_into_container(&mut spec);
+    crate::publish_socket::inject_into_container(&mut spec);
     crate::rosetta::inject_into_container(&mut spec);
     crate::forkpoint::inject_into_container(&mut spec);
     crate::cuda::inject_into_container(&mut spec, &pod.rootfs);

--- a/crates/smolvm-agent/src/publish_socket.rs
+++ b/crates/smolvm-agent/src/publish_socket.rs
@@ -24,7 +24,7 @@ use smolvm_protocol::guest_env;
 use smolvm_protocol::publish_socket::{decode, PublishedSocket, SocketDirection};
 use std::io;
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
+use std::sync::RwLock;
 use std::thread;
 
 /// VM-private directory the mount-direction listeners are bound in.
@@ -36,13 +36,18 @@ use std::thread;
 const MOUNT_SOCKET_DIR: &str = "/run/smolvm/published-sockets";
 
 /// Mount-direction sockets whose listener is bound *and* published at its guest
-/// path, recorded by [`start_all`] before the agent accepts host requests.
+/// path, written by [`start_all`] before the agent accepts host requests.
 ///
 /// [`inject_into_container`] reads this rather than the env var so a bridge that
 /// failed to come up is never bind-mounted into a container: crun rejects a
 /// missing mount source, which would turn one broken socket into a VM that can't
 /// start any container.
-static PUBLISHED_MOUNTS: OnceLock<Vec<PublishedSocket>> = OnceLock::new();
+///
+/// A [`RwLock`] rather than a `OnceLock`: production writes this exactly once
+/// per boot, but the lock lets tests reset it — with `OnceLock`, a single
+/// [`start_all`] call in one test would permanently poison the "nothing
+/// published yet" invariant for every other test in the process.
+static PUBLISHED_MOUNTS: RwLock<Vec<PublishedSocket>> = RwLock::new(Vec::new());
 
 /// Start every user-published socket bridge. No-op when none are configured.
 ///
@@ -67,7 +72,9 @@ pub fn start_all() {
             },
         }
     }
-    let _ = PUBLISHED_MOUNTS.set(published);
+    *PUBLISHED_MOUNTS
+        .write()
+        .expect("published-sockets registry lock poisoned") = published;
 }
 
 #[cfg(target_os = "linux")]
@@ -112,12 +119,10 @@ fn mount_socket_path(vsock_port: u32) -> PathBuf {
 /// after the user-volume mounts makes the socket visible even when its public path
 /// is nested under a volume target.
 pub fn inject_into_container(spec: &mut crate::oci::OciSpec) {
-    inject_sockets_into_container(spec, published_mounts());
-}
-
-/// The mount-direction sockets [`start_all`] published; empty before it runs.
-fn published_mounts() -> &'static [PublishedSocket] {
-    PUBLISHED_MOUNTS.get().map_or(&[], Vec::as_slice)
+    let published = PUBLISHED_MOUNTS
+        .read()
+        .expect("published-sockets registry lock poisoned");
+    inject_sockets_into_container(spec, &published);
 }
 
 fn inject_sockets_into_container(spec: &mut crate::oci::OciSpec, sockets: &[PublishedSocket]) {
@@ -442,9 +447,15 @@ mod mount_tests {
     fn nothing_is_injected_before_the_bridges_are_published() {
         // An injected mount whose source doesn't exist fails `crun create`, so a
         // bridge that never came up must not reach the spec at all.
+        // Reset the registry explicitly: the invariant being guarded is about
+        // what the registry *contains*, not about test execution order.
+        PUBLISHED_MOUNTS
+            .write()
+            .expect("published-sockets registry lock poisoned")
+            .clear();
         let mut spec = spec();
         let baseline = spec.mounts.len();
-        inject_sockets_into_container(&mut spec, published_mounts());
+        inject_into_container(&mut spec);
         assert_eq!(spec.mounts.len(), baseline);
     }
 

--- a/crates/smolvm-agent/src/publish_socket.rs
+++ b/crates/smolvm-agent/src/publish_socket.rs
@@ -9,9 +9,13 @@
 //! - **Expose** (guest→host): the agent listens on the vsock port; for each host
 //!   connection it dials the in-guest app socket and relays. Same shape as the
 //!   Docker bridge.
-//! - **Mount** (host→guest): the agent creates a Unix listener at the guest path;
-//!   for each guest-app connection it dials the vsock port (libkrun bridges it to
-//!   the host socket) and relays. Same shape as the SSH-agent bridge.
+//! - **Mount** (host→guest): the agent listens on a VM-private Unix socket and, for
+//!   each guest-app connection, dials the vsock port (libkrun bridges it to the host
+//!   socket) and relays. Same shape as the SSH-agent bridge. The listener node is
+//!   *published* at the caller's guest path — bind-mounted there in the VM's root
+//!   namespace for bare-VM execs, and injected into every OCI spec for containers —
+//!   rather than bound there directly, which would put it inside a `--volume` share
+//!   and make co-mounting VMs fight over one node (see [`MOUNT_SOCKET_DIR`]).
 //!
 //! The relay honors independent TCP-style half-close so hijacked/streaming
 //! protocols don't lose output — the same property the Docker bridge fixed.
@@ -19,38 +23,111 @@
 use smolvm_protocol::guest_env;
 use smolvm_protocol::publish_socket::{decode, PublishedSocket, SocketDirection};
 use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use std::thread;
 
+/// VM-private directory the mount-direction listeners are bound in.
+///
+/// Never the caller-supplied guest path: that path may sit inside a `--volume`
+/// share, where the listener node lands on the *host* filesystem and every other
+/// VM mounting the same directory sees — and re-binds — it. Binding privately and
+/// republishing the node by bind mount keeps each VM's socket its own.
+const MOUNT_SOCKET_DIR: &str = "/run/smolvm/published-sockets";
+
+/// Mount-direction sockets whose listener is bound *and* published at its guest
+/// path, recorded by [`start_all`] before the agent accepts host requests.
+///
+/// [`inject_into_container`] reads this rather than the env var so a bridge that
+/// failed to come up is never bind-mounted into a container: crun rejects a
+/// missing mount source, which would turn one broken socket into a VM that can't
+/// start any container.
+static PUBLISHED_MOUNTS: OnceLock<Vec<PublishedSocket>> = OnceLock::new();
+
 /// Start every user-published socket bridge. No-op when none are configured.
+///
+/// Mount listeners are prepared here, synchronously, instead of inside their
+/// bridge thread: every OCI bundle written later bind-mounts the private socket
+/// node, so it has to exist before the agent starts accepting execs.
 pub fn start_all() {
     let encoded = match std::env::var(guest_env::PUBLISH_SOCKETS) {
         Ok(v) if !v.is_empty() => v,
         _ => return,
     };
+    let mut published = Vec::new();
     for sock in decode(&encoded) {
-        start_one(sock);
+        match sock.direction {
+            SocketDirection::Expose => spawn_bridge(sock, serve_expose),
+            SocketDirection::Mount => match prepare_mount_listener(&sock) {
+                Ok(listener) => {
+                    published.push(sock.clone());
+                    spawn_bridge(sock, move |s| serve_mount(s, listener));
+                }
+                Err(e) => log_bridge_error(&sock, &e),
+            },
+        }
     }
+    let _ = PUBLISHED_MOUNTS.set(published);
 }
 
-fn start_one(sock: PublishedSocket) {
+#[cfg(target_os = "linux")]
+type MountListener = std::os::unix::net::UnixListener;
+
+#[cfg(not(target_os = "linux"))]
+type MountListener = ();
+
+/// Run one bridge on its own thread, logging why it stopped.
+fn spawn_bridge<F>(sock: PublishedSocket, serve: F)
+where
+    F: FnOnce(&PublishedSocket) -> io::Result<()> + Send + 'static,
+{
     thread::Builder::new()
         .name(format!("publish-sock-{}", sock.vsock_port))
         .spawn(move || {
-            let result = match sock.direction {
-                SocketDirection::Expose => serve_expose(&sock),
-                SocketDirection::Mount => serve_mount(&sock),
-            };
-            if let Err(e) = result {
-                tracing::warn!(
-                    vsock_port = sock.vsock_port,
-                    guest_path = %sock.guest_path,
-                    direction = sock.direction.as_str(),
-                    error = %e,
-                    "published socket bridge stopped"
-                );
+            if let Err(e) = serve(&sock) {
+                log_bridge_error(&sock, &e);
             }
         })
         .ok();
+}
+
+fn log_bridge_error(sock: &PublishedSocket, error: &io::Error) {
+    tracing::warn!(
+        vsock_port = sock.vsock_port,
+        guest_path = %sock.guest_path,
+        direction = sock.direction.as_str(),
+        error = %error,
+        "published socket bridge stopped"
+    );
+}
+
+/// VM-private path the bridge for `vsock_port` listens on.
+fn mount_socket_path(vsock_port: u32) -> PathBuf {
+    Path::new(MOUNT_SOCKET_DIR).join(format!("{vsock_port}.sock"))
+}
+
+/// Inject each host-mounted socket into an OCI container at its public guest path.
+///
+/// The listener itself lives in the VM-private root namespace. Adding this mount
+/// after the user-volume mounts makes the socket visible even when its public path
+/// is nested under a volume target.
+pub fn inject_into_container(spec: &mut crate::oci::OciSpec) {
+    inject_sockets_into_container(spec, published_mounts());
+}
+
+/// The mount-direction sockets [`start_all`] published; empty before it runs.
+fn published_mounts() -> &'static [PublishedSocket] {
+    PUBLISHED_MOUNTS.get().map_or(&[], Vec::as_slice)
+}
+
+fn inject_sockets_into_container(spec: &mut crate::oci::OciSpec, sockets: &[PublishedSocket]) {
+    for sock in sockets {
+        spec.add_bind_mount(
+            &mount_socket_path(sock.vsock_port).to_string_lossy(),
+            &sock.guest_path,
+            false,
+        );
+    }
 }
 
 /// Expose: listen on the vsock port; per host connection, dial the in-guest app
@@ -98,26 +175,106 @@ fn serve_expose(sock: &PublishedSocket) -> io::Result<()> {
     }
 }
 
-/// Mount: create a Unix listener at the guest path; per guest-app connection,
-/// dial the vsock port (bridged by libkrun to the host socket) and relay.
-/// Mirrors the SSH-agent bridge but with a caller-supplied path/port.
+/// Bind the mount-direction listener on its private path and publish that node at
+/// the caller-supplied guest path. Returns the bound listener for [`serve_mount`].
+///
+/// All-or-nothing: on failure nothing is left behind at the private path, so
+/// [`inject_into_container`] can't hand a container a dead socket.
 #[cfg(target_os = "linux")]
-fn serve_mount(sock: &PublishedSocket) -> io::Result<()> {
+fn prepare_mount_listener(sock: &PublishedSocket) -> io::Result<MountListener> {
     use std::os::unix::fs::PermissionsExt;
     use std::os::unix::net::UnixListener;
 
-    let path = std::path::Path::new(&sock.guest_path);
-    let _ = std::fs::remove_file(path);
+    let guest_path = Path::new(&sock.guest_path);
+    if !guest_path.is_absolute() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "guest socket path must be absolute",
+        ));
+    }
+    let path = mount_socket_path(sock.vsock_port);
+    // A persistent machine's /run survives stop/start, so a previous boot's node
+    // can still be sitting here.
+    let _ = std::fs::remove_file(&path);
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let listener = UnixListener::bind(path)?;
+    let listener = UnixListener::bind(&path)?;
     // World-accessible so any uid in the guest can reach the mounted socket,
     // matching the SSH-agent bridge.
-    let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o777));
+    let published = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o777))
+        .and_then(|()| publish_at_guest_path(&path, guest_path));
+    if let Err(e) = published {
+        // Leave no stale node behind: an unpublished socket nobody listens on is
+        // worse than none — it answers connects with ECONNREFUSED.
+        let _ = std::fs::remove_file(&path);
+        return Err(e);
+    }
+    Ok(listener)
+}
+
+/// Make the private listener node reachable at the caller-supplied guest path by
+/// bind-mounting it there in the VM's root mount namespace.
+///
+/// Bare-VM execs run in that namespace and have no OCI spec to inject into;
+/// containers get the same node through [`inject_into_container`], which layers it
+/// over any `--volume` mounted at or above the guest path.
+#[cfg(target_os = "linux")]
+fn publish_at_guest_path(source: &Path, destination: &Path) -> io::Result<()> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    if let Some(parent) = destination.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    // A file bind mount needs an existing target. When the guest path sits inside a
+    // `--volume` share this placeholder is visible on the host as an empty file;
+    // each VM's own bind mount shadows it, so it stays inert.
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(destination)
+    {
+        Ok(_) => {}
+        Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {}
+        Err(e) => return Err(e),
+    }
+
+    let source = CString::new(source.as_os_str().as_bytes())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "socket source contains NUL"))?;
+    let destination = CString::new(destination.as_os_str().as_bytes()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "socket destination contains NUL",
+        )
+    })?;
+    // SAFETY: source and destination are valid C paths. A file bind mount is
+    // private to this VM's mount namespace and keeps bare-VM execs working.
+    let rc = unsafe {
+        libc::mount(
+            source.as_ptr(),
+            destination.as_ptr(),
+            std::ptr::null(),
+            libc::MS_BIND,
+            std::ptr::null(),
+        )
+    };
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+/// Mount: per guest-app connection on the published listener, dial the vsock port
+/// (bridged by libkrun to the host socket) and relay. Mirrors the SSH-agent bridge
+/// but with a caller-supplied path/port.
+#[cfg(target_os = "linux")]
+fn serve_mount(sock: &PublishedSocket, listener: MountListener) -> io::Result<()> {
     tracing::info!(
         vsock_port = sock.vsock_port,
         guest_path = %sock.guest_path,
+        private_path = %mount_socket_path(sock.vsock_port).display(),
         "mount-socket bridge listening"
     );
     for stream in listener.incoming() {
@@ -233,11 +390,88 @@ fn serve_expose(_sock: &PublishedSocket) -> io::Result<()> {
 }
 
 #[cfg(not(target_os = "linux"))]
-fn serve_mount(_sock: &PublishedSocket) -> io::Result<()> {
+fn prepare_mount_listener(_sock: &PublishedSocket) -> io::Result<MountListener> {
     Err(io::Error::new(
         io::ErrorKind::Unsupported,
         "published socket bridges are only supported on Linux guests",
     ))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn serve_mount(_sock: &PublishedSocket, _listener: MountListener) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "published socket bridges are only supported on Linux guests",
+    ))
+}
+
+#[cfg(test)]
+mod mount_tests {
+    use super::*;
+    use crate::oci::{OciSpec, ProcessIdentity};
+
+    fn spec() -> OciSpec {
+        OciSpec::new(
+            &["true".to_string()],
+            &[],
+            "/",
+            false,
+            &ProcessIdentity::root(),
+            false,
+        )
+    }
+
+    fn mount_sock(vsock_port: u32, guest_path: &str) -> PublishedSocket {
+        PublishedSocket {
+            vsock_port,
+            guest_path: guest_path.into(),
+            direction: SocketDirection::Mount,
+        }
+    }
+
+    #[test]
+    fn listeners_bind_outside_the_caller_supplied_path() {
+        // The bug this guards: binding at the guest path puts the listener node
+        // inside a `--volume` share, where every VM sharing it collides.
+        let path = mount_socket_path(6100);
+        assert!(path.starts_with(MOUNT_SOCKET_DIR));
+        assert_ne!(path, mount_socket_path(6101));
+    }
+
+    #[test]
+    fn nothing_is_injected_before_the_bridges_are_published() {
+        // An injected mount whose source doesn't exist fails `crun create`, so a
+        // bridge that never came up must not reach the spec at all.
+        let mut spec = spec();
+        let baseline = spec.mounts.len();
+        inject_sockets_into_container(&mut spec, published_mounts());
+        assert_eq!(spec.mounts.len(), baseline);
+    }
+
+    #[test]
+    fn container_injection_overlays_mount_socket_after_user_volume() {
+        let mut spec = spec();
+        spec.add_bind_mount("/mnt/virtiofs/shared", "/run/control", false);
+        let volume_index = spec.mounts.len() - 1;
+
+        inject_sockets_into_container(&mut spec, &[mount_sock(6100, "/run/control/engine.sock")]);
+
+        let socket_index = spec
+            .mounts
+            .iter()
+            .position(|mount| mount.destination == "/run/control/engine.sock")
+            .expect("mount socket injection missing");
+        let socket_mount = &spec.mounts[socket_index];
+        assert!(
+            socket_index > volume_index,
+            "socket file mount must overlay the containing user volume"
+        );
+        assert_eq!(
+            socket_mount.source,
+            mount_socket_path(6100).to_string_lossy()
+        );
+        assert_eq!(socket_mount.mount_type.as_deref(), Some("bind"));
+    }
 }
 
 #[cfg(all(test, target_os = "linux"))]

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -2743,6 +2743,7 @@ pub fn run_command(
 
         // Forward SSH agent into the container if enabled at boot.
         crate::ssh_agent::inject_into_container(&mut spec);
+        crate::publish_socket::inject_into_container(&mut spec);
         crate::forkpoint::inject_into_container(&mut spec);
         crate::cuda::inject_into_container(&mut spec, Path::new(&prepared.rootfs_path));
 
@@ -2837,6 +2838,7 @@ pub fn spawn_in_overlay(
     add_storage_fallback(&mut spec, mounts, unprivileged);
 
     crate::ssh_agent::inject_into_container(&mut spec);
+    crate::publish_socket::inject_into_container(&mut spec);
     crate::forkpoint::inject_into_container(&mut spec);
     crate::cuda::inject_into_container(&mut spec, Path::new(&prepared.rootfs_path));
     spec.add_gpu_devices_if_available();

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -173,6 +173,22 @@ fn parse_published_sockets(
             ));
         }
     }
+    // Two mount bridges at the same guest path silently shadow each other in
+    // the guest, the later bind mount wins, leaving the first bridge's host
+    // socket unreachable. Reject the config instead of paying out a dead
+    // bridge. (Expose entries only *dial* their guest path, so duplicates
+    // there are harmless.)
+    let mut mounted_paths = std::collections::HashSet::new();
+    for s in &out {
+        if s.direction == smolvm::config::SocketDirection::Mount
+            && !mounted_paths.insert(&s.guest_path)
+        {
+            return Err(smolvm::Error::config(
+                "mount-socket",
+                format!("guest path '{}' is mounted more than once", s.guest_path),
+            ));
+        }
+    }
     Ok(out)
 }
 
@@ -1988,6 +2004,16 @@ mod tests {
         // rooted at, so they can never name the socket the user meant.
         assert!(parse_published_sockets(&["app.sock".to_string()], &[]).is_err());
         assert!(parse_published_sockets(&[], &["/run/h.sock:app.sock".to_string()]).is_err());
+        // Two mount bridges at one guest path shadow each other in the guest,
+        // leaving the first host socket unreachable.
+        assert!(parse_published_sockets(
+            &[],
+            &[
+                "/run/h1.sock:/run/control/engine.sock".to_string(),
+                "/run/h2.sock:/run/control/engine.sock".to_string(),
+            ]
+        )
+        .is_err());
     }
 
     #[test]

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -163,6 +163,15 @@ fn parse_published_sockets(
                 ),
             ));
         }
+        // The guest resolves this path in its own namespace (and bind-mounts a
+        // mounted socket there), so a relative path would silently land next to
+        // whatever the resolving process happens to be rooted at.
+        if !s.guest_path.starts_with('/') {
+            return Err(smolvm::Error::config(
+                "publish-socket",
+                format!("guest path '{}' must be absolute", s.guest_path),
+            ));
+        }
     }
     Ok(out)
 }
@@ -1975,6 +1984,10 @@ mod tests {
         assert!(parse_published_sockets(&[], &["/only-host".to_string()]).is_err());
         assert!(parse_published_sockets(&[":/tmp/h.sock".to_string()], &[]).is_err());
         assert!(parse_published_sockets(&["/run/a;b.sock".to_string()], &[]).is_err());
+        // Relative guest paths resolve against whatever the guest process is
+        // rooted at, so they can never name the socket the user meant.
+        assert!(parse_published_sockets(&["app.sock".to_string()], &[]).is_err());
+        assert!(parse_published_sockets(&[], &["/run/h.sock:app.sock".to_string()]).is_err());
     }
 
     #[test]

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -1961,6 +1961,111 @@ pub fn stop_vm_default() -> smolvm::Result<()> {
 // Delete
 // ============================================================================
 
+/// Host-side paths behind which a `--mount-socket` publish may have left a
+/// placeholder for this machine: the guest agent bind-mounts its VM-private
+/// listener node at the caller's guest path, a file bind mount needs the
+/// destination to exist, and inside a `--volume` (virtiofs) share that
+/// destination lands on the host filesystem as a 0-byte regular file.
+///
+/// Only mount-direction sockets create placeholders, only for guest paths
+/// inside a declared volume (otherwise the node lives on the VM's own rootfs).
+/// When volumes nest, the deepest guest mountpoint owns the path. Volume host
+/// paths are canonicalized so differently-spelled references (`/tmp` vs
+/// `/private/tmp`) to the same share compare equal.
+fn mount_socket_placeholder_paths(record: &VmRecord) -> Vec<std::path::PathBuf> {
+    use smolvm::config::SocketDirection;
+    use std::path::{Path, PathBuf};
+
+    let mut out = Vec::new();
+    for sock in &record.published_sockets {
+        if sock.direction != SocketDirection::Mount {
+            continue;
+        }
+        let guest_path = Path::new(&sock.guest_path);
+        if !guest_path.is_absolute() {
+            continue;
+        }
+        let deepest = record
+            .mounts
+            .iter()
+            .filter(|(_, guest_target, _)| guest_path.starts_with(Path::new(guest_target)))
+            .max_by_key(|(_, guest_target, _)| guest_target.len());
+        let Some((host_source, guest_target, _)) = deepest else {
+            continue;
+        };
+        let Ok(rel) = guest_path.strip_prefix(guest_target) else {
+            continue;
+        };
+        let host_source: PathBuf =
+            std::fs::canonicalize(host_source).unwrap_or_else(|_| PathBuf::from(host_source));
+        out.push(host_source.join(rel));
+    }
+    out
+}
+
+/// Remove mount-socket placeholder files this machine left in shared `--volume`
+/// dirs (see [`mount_socket_placeholder_paths`]), except any `claimed` by
+/// another machine. Best-effort housekeeping: failures are debug-logged, never
+/// fatal to machine deletion.
+fn remove_mount_socket_placeholders_except(
+    record: &VmRecord,
+    claimed: &std::collections::HashSet<std::path::PathBuf>,
+) {
+    for placeholder in mount_socket_placeholder_paths(record) {
+        if claimed.contains(&placeholder) {
+            continue;
+        }
+        // Only ever remove provably-inert nodes: zero-byte *regular files*, not
+        // symlinks. Anything else at that path is the user's, not ours.
+        let Ok(meta) = std::fs::symlink_metadata(&placeholder) else {
+            continue; // never created, or already gone
+        };
+        if !meta.file_type().is_file() || meta.len() != 0 {
+            continue;
+        }
+        match std::fs::remove_file(&placeholder) {
+            Ok(()) => {
+                tracing::debug!(
+                    path = %placeholder.display(),
+                    "removed mount-socket placeholder from shared volume"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    path = %placeholder.display(),
+                    error = %e,
+                    "failed to remove mount-socket placeholder"
+                );
+            }
+        }
+    }
+}
+
+/// Remove machine `record`'s mount-socket placeholders from shared `--volume`
+/// dirs — but only those no other machine record claims.
+///
+/// The claim check is load-bearing, not just tidiness: over virtiofs, removing
+/// the placeholder on the host invalidates the mountpoint dentry of a *running*
+/// VM that bind-mounted over it, severing its guest path with ENOENT. A
+/// placeholder is inert once every machine declaring the same path is deleted,
+/// so cleanup converges instead of racing co-mounted machines.
+pub fn remove_mount_socket_placeholders(record: &VmRecord) {
+    let claimed: std::collections::HashSet<std::path::PathBuf> = match SmolvmConfig::load() {
+        Ok(cfg) => cfg
+            .list_vms()
+            .filter(|(name, _)| name.as_str() != record.name)
+            .flat_map(|(_, other)| mount_socket_placeholder_paths(other))
+            .collect(),
+        // Can't enumerate other machines? Remove nothing — leaving litter is the
+        // fail-safe direction; deleting under a running VM is not.
+        Err(e) => {
+            tracing::debug!(error = %e, "skipping placeholder cleanup: cannot list machines");
+            return;
+        }
+    };
+    remove_mount_socket_placeholders_except(record, &claimed);
+}
+
 /// Options for machine delete behavior.
 pub struct DeleteVmOptions {
     /// If true, stop the VM before deleting when it is running.
@@ -2105,6 +2210,12 @@ pub fn delete_vm(name: &str, force: bool, options: DeleteVmOptions) -> smolvm::R
             name,
         ));
     }
+
+    // Drop mount-socket placeholder files this machine left in shared --volume
+    // dirs. Runs after the VM is confirmed stopped (or was never running), so
+    // no live bind mount can reference the host-side node; a machine that still
+    // declares the same socket recreates its placeholder at its next boot.
+    remove_mount_socket_placeholders(&record);
 
     let data_dir = vm_data_dir(name);
     if data_dir.exists() {
@@ -3072,5 +3183,190 @@ mod init_runner_tests {
                 ("BAZ".to_string(), "from-cli".to_string()),
             ]
         );
+    }
+}
+
+#[cfg(test)]
+mod mount_socket_placeholder_tests {
+    use super::{mount_socket_placeholder_paths, remove_mount_socket_placeholders_except};
+    use smolvm::config::{PublishedSocketConfig, SocketDirection, VmRecord};
+    use std::collections::HashSet;
+
+    fn remove_placeholders(record: &VmRecord) {
+        remove_mount_socket_placeholders_except(record, &HashSet::new());
+    }
+
+    fn mount_sock(guest_path: &str) -> PublishedSocketConfig {
+        PublishedSocketConfig {
+            direction: SocketDirection::Mount,
+            guest_path: guest_path.to_string(),
+            host_path: Some("/tmp/host.sock".to_string()),
+        }
+    }
+
+    fn record_with(
+        share: &std::path::Path,
+        guest_target: &str,
+        sockets: Vec<PublishedSocketConfig>,
+    ) -> VmRecord {
+        let mut record = VmRecord::new(
+            "t".to_string(),
+            1,
+            256,
+            vec![(
+                share.to_string_lossy().into_owned(),
+                guest_target.to_string(),
+                false,
+            )],
+            vec![],
+            false,
+        );
+        record.published_sockets = sockets;
+        record
+    }
+
+    #[test]
+    fn removes_only_inert_placeholder_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let share = tmp.path().join("shared");
+        std::fs::create_dir_all(&share).unwrap();
+        let placeholder = share.join("engine.sock");
+        std::fs::write(&placeholder, b"").unwrap(); // the 0-byte node the agent leaves
+        let user_data = share.join("real.sock");
+        std::fs::write(&user_data, b"user data").unwrap();
+        let dir = share.join("dir.sock");
+        std::fs::create_dir(&dir).unwrap();
+
+        let record = record_with(
+            &share,
+            "/run/control",
+            vec![
+                mount_sock("/run/control/engine.sock"),
+                mount_sock("/run/control/real.sock"),
+                mount_sock("/run/control/dir.sock"),
+                // Expose entries only dial; they never create placeholders.
+                PublishedSocketConfig {
+                    direction: SocketDirection::Expose,
+                    guest_path: "/run/control/exposed.sock".to_string(),
+                    host_path: None,
+                },
+                // A socket whose guest path is inside no volume touches nothing.
+                mount_sock("/elsewhere/engine.sock"),
+                // Pre-fix records could hold relative paths; never follow them.
+                mount_sock("relative/engine.sock"),
+            ],
+        );
+        remove_placeholders(&record);
+
+        assert!(!placeholder.exists(), "inert 0-byte placeholder must go");
+        assert!(user_data.exists(), "user data must survive");
+        assert!(dir.is_dir(), "directories must survive");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn symlink_at_placeholder_path_is_left_alone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let share = tmp.path().join("shared");
+        std::fs::create_dir_all(&share).unwrap();
+        let target = share.join("target-empty");
+        std::fs::write(&target, b"").unwrap();
+        let link = share.join("engine.sock");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let record = record_with(
+            &share,
+            "/run/control",
+            vec![mount_sock("/run/control/engine.sock")],
+        );
+        remove_placeholders(&record);
+
+        // We only ever recognize our own placeholders — a symlink is the user's
+        // and both it and its target survive.
+        assert!(link.symlink_metadata().unwrap().file_type().is_symlink());
+        assert!(target.exists());
+    }
+
+    #[test]
+    fn deepest_volume_wins_when_mounts_nest() {
+        let tmp = tempfile::tempdir().unwrap();
+        let share = tmp.path().join("shared");
+        let deep = tmp.path().join("deep");
+        std::fs::create_dir_all(share.join("sub")).unwrap();
+        std::fs::create_dir_all(&deep).unwrap();
+        // Same guest path maps to different host files depending on which
+        // volume owns the prefix; only the deepest mount is authoritative.
+        let shallow_file = share.join("sub/engine.sock");
+        std::fs::write(&shallow_file, b"").unwrap();
+        let real = deep.join("engine.sock");
+        std::fs::write(&real, b"").unwrap();
+
+        let mut record = record_with(
+            &share,
+            "/run/control",
+            vec![mount_sock("/run/control/sub/engine.sock")],
+        );
+        record.mounts.push((
+            deep.to_string_lossy().into_owned(),
+            "/run/control/sub".to_string(),
+            false,
+        ));
+        remove_placeholders(&record);
+
+        assert!(!real.exists(), "deepest volume's placeholder must go");
+        assert!(shallow_file.exists(), "shallow mapping's file must survive");
+    }
+
+    #[test]
+    fn shared_placeholder_survives_while_another_machine_claims_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let share = tmp.path().join("shared");
+        std::fs::create_dir_all(&share).unwrap();
+        let placeholder = share.join("engine.sock");
+        std::fs::write(&placeholder, b"").unwrap();
+
+        let mut record_a = record_with(
+            &share,
+            "/run/control",
+            vec![mount_sock("/run/control/engine.sock")],
+        );
+        record_a.name = "sock-a".to_string();
+        let mut record_b = record_with(
+            &share,
+            "/run/control",
+            vec![mount_sock("/run/control/engine.sock")],
+        );
+        record_b.name = "sock-b".to_string();
+
+        // Deleting A while B still exists must NOT remove the placeholder:
+        // over virtiofs that invalidates the running B's mountpoint dentry.
+        let claimed: HashSet<_> = mount_socket_placeholder_paths(&record_b)
+            .into_iter()
+            .collect();
+        remove_mount_socket_placeholders_except(&record_a, &claimed);
+        assert!(
+            placeholder.exists(),
+            "placeholder must survive while another machine claims it"
+        );
+
+        // Once B is the last one left, its delete cleans up.
+        remove_mount_socket_placeholders_except(&record_b, &HashSet::new());
+        assert!(
+            !placeholder.exists(),
+            "last machine's delete removes the placeholder"
+        );
+    }
+
+    #[test]
+    fn missing_placeholder_is_not_an_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let share = tmp.path().join("shared");
+        std::fs::create_dir_all(&share).unwrap();
+        let record = record_with(
+            &share,
+            "/run/control",
+            vec![mount_sock("/run/control/engine.sock")],
+        );
+        remove_placeholders(&record); // nothing present: no failure
     }
 }


### PR DESCRIPTION
Fixes #864

## Problem

When multiple VMs mount the same host directory via `--volume` and declare a
`--mount-socket` whose guest path sits inside that directory, each VM's guest
agent unlinked and rebound the *same host-backed node*. Which listener the
shared pathname resolved to depended on boot order and virtiofs dentry-cache
state: the last VM to bind won, and the others got permanent `ECONNREFUSED`
(or, cache permitting, kept working by accident) — the host-side socket stayed
live the whole time.

## Fix

The guest agent now binds each mount-direction listener at a VM-private path
(`/run/smolvm/published-sockets/<vsock-port>.sock`) and *publishes* that node at
the caller's guest path:

- an `MS_BIND` file mount in the VM root namespace, so bare-VM execs resolve it;
- a bind mount appended to every OCI spec **after** the user-volume mounts, so
  containers see the socket even when the guest path is nested under a volume
  target.

Only fully-prepared sockets enter container specs: crun rejects a bind mount
whose source doesn't exist, so a bridge that failed to come up is skipped with
a warning instead of taking down every container start. Preparation failures
remove the private node, so nothing dangles as an `ECONNREFUSED` endpoint.

Relative guest paths are now rejected at the CLI and in the agent — they
previously resolved silently against whatever rooted the resolving process.

The change also tightens the edges this design touches:

- **Duplicate guest paths rejected**: two `--mount-socket` entries with the
  same guest path silently shadow each other in the guest (later bind mount
  wins), so the CLI fails the config instead of paying out a dead bridge.
- **Placeholder cleanup on delete**: publishing over a path inside a share
  needs a destination node, which lands on the host as a 0-byte file.
  `machine delete` removes it — but only when no other machine record claims
  the same host path, because over virtiofs unlinking it under a *running* VM
  invalidates that VM's mountpoint dentry. Cleanup converges: the last machine
  out removes the file. Only provably-inert nodes (zero-byte regular files at
  record-derived, canonicalized paths) are ever removed; user data,
  directories, and symlinks are left alone.
- **Agent registry is a `RwLock`, not a `OnceLock`**, so the "no injection
  before publish" test doesn't depend on test execution order — a future test
  that starts bridges would otherwise poison the invariant process-wide.

## Testing

Reproduced the issue setup live on macOS arm64 (1.7.4 base + rebuilt agent):

- two VMs, identical socket guest path + shared volume: A PONG → start B →
  **A still PONG**, B PONG (was: order/cache-dependent `ECONNREFUSED`)
- bare VMs (root-namespace bind mount path): same isolation result
- stop/start persistence: socket survives, placeholder re-created idempotently
- failed bridge (`/proc/ro/bad.sock`): WARN + skip, other sockets and execs
  unaffected, no dead mount injected
- delete ordering: deleting B while A runs keeps the placeholder (A stays
  PONG); deleting A (last claimant) removes it — shared dir empty
- relative guest path: new CLI rejects, pre-fix CLI accepted (verified both)
- duplicate mount paths: rejected with `guest path ... is mounted more than
  once`
- suites: `smolvm-agent` 122 ✓, CLI 86 ✓, clippy/fmt clean