### PR TITLE
Coordinate forked rollout cohorts automatically

### DIFF
--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -46,6 +46,12 @@ result = client.generate(
 )
 ```
 
+When the fork assignment includes a batch ID and size, the client automatically
+coordinates matching `generate` calls for up to 250 ms so the rollout engine can
+batch policies before admitting stragglers. Use
+`RolloutClient(auto_fork_cohort=False)` for intentionally divergent workers, or
+set `auto_fork_cohort_max_wait_ms` to tune the bounded wait.
+
 For colocated CUDA trainers, `publish_device_adapter` replaces the checkpoint
 write with an immutable device allocation. Register a mode-0600 sidecar socket,
 then publish the returned one-use token:

--- a/sdks/python/src/smolvm_rollout/client.py
+++ b/sdks/python/src/smolvm_rollout/client.py
@@ -59,7 +59,7 @@ def _read_fork_env(path: Path) -> dict[str, str]:
     return values
 
 
-def _lease_configuration(path: Path) -> tuple[str, str, str, str]:
+def _lease_configuration(path: Path) -> tuple[str, str, str, str, dict[str, str]]:
     values = _read_fork_env(path)
     for key in _ROLLOUT_LEASE_KEYS:
         if key in os.environ:
@@ -86,6 +86,7 @@ def _lease_configuration(path: Path) -> tuple[str, str, str, str]:
         executor,
         values[_ROLLOUT_TOKEN_ENV],
         values[_ROLLOUT_POLICY_ENV],
+        values,
     )
 
 
@@ -144,10 +145,15 @@ class RolloutClient:
         auto_fork_cohort_max_wait_ms: int | None = 250,
     ) -> None:
         lease_policy = None
+        fork_assignment: dict[str, str] = {}
         if api_url is None and executor is None:
-            api_url, executor, discovered_token, lease_policy = _lease_configuration(
-                Path(fork_env_path)
-            )
+            (
+                api_url,
+                executor,
+                discovered_token,
+                lease_policy,
+                fork_assignment,
+            ) = _lease_configuration(Path(fork_env_path))
             if bearer_token is not None and bearer_token != discovered_token:
                 raise ValueError("bearer_token conflicts with the smolvm lease credential")
             bearer_token = discovered_token
@@ -171,6 +177,7 @@ class RolloutClient:
         self.ssl_context = ssl_context
         self.auto_fork_cohort = auto_fork_cohort
         self.auto_fork_cohort_max_wait_ms = auto_fork_cohort_max_wait_ms
+        self._fork_assignment = fork_assignment
         self._fork_cohort_lock = threading.Lock()
         self._fork_cohort_round = 0
         self._fork_cohorts: OrderedDict[
@@ -182,8 +189,13 @@ class RolloutClient:
     ) -> tuple[str, int, int | None] | None:
         if not self.auto_fork_cohort:
             return None
-        batch_id = os.environ.get("SMOLVM_FORK_BATCH_ID")
-        batch_size_text = os.environ.get("SMOLVM_FORK_BATCH_SIZE")
+        batch_id = os.environ.get(
+            "SMOLVM_FORK_BATCH_ID", self._fork_assignment.get("SMOLVM_FORK_BATCH_ID")
+        )
+        batch_size_text = os.environ.get(
+            "SMOLVM_FORK_BATCH_SIZE",
+            self._fork_assignment.get("SMOLVM_FORK_BATCH_SIZE"),
+        )
         if batch_id is None and batch_size_text is None:
             return None
         if not batch_id or batch_size_text is None:
@@ -199,7 +211,9 @@ class RolloutClient:
         group_index = 0
         group_size = batch_size
         if batch_size > 256:
-            fork_index_text = os.environ.get("SMOLVM_FORK_INDEX")
+            fork_index_text = os.environ.get(
+                "SMOLVM_FORK_INDEX", self._fork_assignment.get("SMOLVM_FORK_INDEX")
+            )
             try:
                 fork_index = int(fork_index_text or "")
             except ValueError as error:

--- a/sdks/python/src/smolvm_rollout/client.py
+++ b/sdks/python/src/smolvm_rollout/client.py
@@ -7,8 +7,10 @@ import json
 import os
 import ssl
 import struct
+import threading
 import urllib.error
 import urllib.request
+from collections import OrderedDict
 from pathlib import Path
 from typing import Any, Iterable, Sequence
 
@@ -121,7 +123,11 @@ def adapter_sha256(directory: str | os.PathLike[str]) -> str:
 
 
 class RolloutClient:
-    """Synchronous rollout client designed for framework generation boundaries."""
+    """Synchronous rollout client designed for framework generation boundaries.
+
+    Direct smolvm batch forks automatically form one rollout cohort per call.
+    Set ``auto_fork_cohort=False`` when batch members intentionally diverge.
+    """
 
     def __init__(
         self,
@@ -132,6 +138,7 @@ class RolloutClient:
         fork_env_path: str | os.PathLike[str] = _FORK_ENV_PATH,
         timeout: float = 300.0,
         ssl_context: ssl.SSLContext | None = None,
+        auto_fork_cohort: bool = True,
     ) -> None:
         lease_policy = None
         if api_url is None and executor is None:
@@ -143,12 +150,68 @@ class RolloutClient:
             bearer_token = discovered_token
         elif api_url is None or executor is None:
             raise TypeError("api_url and executor must be provided together")
+        if not isinstance(auto_fork_cohort, bool):
+            raise ValueError("auto_fork_cohort must be a boolean")
         self.api_url = api_url.rstrip("/")
         self.executor = executor
         self.bearer_token = bearer_token
         self.lease_policy = lease_policy
         self.timeout = timeout
         self.ssl_context = ssl_context
+        self.auto_fork_cohort = auto_fork_cohort
+        self._fork_cohort_lock = threading.Lock()
+        self._fork_cohort_round = 0
+        self._fork_cohorts: OrderedDict[str, tuple[str, int]] = OrderedDict()
+
+    def _automatic_fork_cohort(
+        self, idempotency_key: str
+    ) -> tuple[str, int] | None:
+        if not self.auto_fork_cohort:
+            return None
+        batch_id = os.environ.get("SMOLVM_FORK_BATCH_ID")
+        batch_size_text = os.environ.get("SMOLVM_FORK_BATCH_SIZE")
+        if batch_id is None and batch_size_text is None:
+            return None
+        if not batch_id or batch_size_text is None:
+            raise ValueError(
+                "SMOLVM_FORK_BATCH_ID and SMOLVM_FORK_BATCH_SIZE must be set together"
+            )
+        try:
+            batch_size = int(batch_size_text)
+        except ValueError as error:
+            raise ValueError("SMOLVM_FORK_BATCH_SIZE must be an integer") from error
+        if not 2 <= batch_size <= 1024:
+            raise ValueError("SMOLVM_FORK_BATCH_SIZE must be between 2 and 1024")
+        group_index = 0
+        group_size = batch_size
+        if batch_size > 256:
+            fork_index_text = os.environ.get("SMOLVM_FORK_INDEX")
+            try:
+                fork_index = int(fork_index_text or "")
+            except ValueError as error:
+                raise ValueError(
+                    "SMOLVM_FORK_INDEX is required for batches larger than 256"
+                ) from error
+            if not 0 <= fork_index < batch_size:
+                raise ValueError("SMOLVM_FORK_INDEX is outside the fork batch")
+            group_index = fork_index // 256
+            group_size = min(256, batch_size - group_index * 256)
+
+        with self._fork_cohort_lock:
+            cached = self._fork_cohorts.get(idempotency_key)
+            if cached is not None:
+                self._fork_cohorts.move_to_end(idempotency_key)
+                return cached
+            round_index = self._fork_cohort_round
+            self._fork_cohort_round += 1
+            digest = hashlib.sha256(
+                f"{batch_id}\0{self.executor}\0{group_index}\0{round_index}".encode()
+            ).hexdigest()
+            cohort = (f"fork-{digest[:32]}", group_size)
+            self._fork_cohorts[idempotency_key] = cohort
+            if len(self._fork_cohorts) > 1024:
+                self._fork_cohorts.popitem(last=False)
+            return cohort
 
     def _request(
         self,
@@ -393,6 +456,11 @@ class RolloutClient:
 
     def generate(self, **job: Any) -> dict[str, Any]:
         """Generate through one policy, returning exact token IDs and logprobs."""
+
+        if "cohort_id" not in job and "cohort_size" not in job:
+            cohort = self._automatic_fork_cohort(job.get("idempotency_key", ""))
+            if cohort is not None:
+                job["cohort_id"], job["cohort_size"] = cohort
 
         return self._request(
             "POST",

--- a/sdks/python/src/smolvm_rollout/client.py
+++ b/sdks/python/src/smolvm_rollout/client.py
@@ -126,7 +126,9 @@ class RolloutClient:
     """Synchronous rollout client designed for framework generation boundaries.
 
     Direct smolvm batch forks automatically form one rollout cohort per call.
-    Set ``auto_fork_cohort=False`` when batch members intentionally diverge.
+    Automatic cohorts release the members that arrive within a bounded window
+    so one straggler cannot stall the rest of the batch. Set
+    ``auto_fork_cohort=False`` when batch members intentionally diverge.
     """
 
     def __init__(
@@ -139,6 +141,7 @@ class RolloutClient:
         timeout: float = 300.0,
         ssl_context: ssl.SSLContext | None = None,
         auto_fork_cohort: bool = True,
+        auto_fork_cohort_max_wait_ms: int | None = 250,
     ) -> None:
         lease_policy = None
         if api_url is None and executor is None:
@@ -152,6 +155,14 @@ class RolloutClient:
             raise TypeError("api_url and executor must be provided together")
         if not isinstance(auto_fork_cohort, bool):
             raise ValueError("auto_fork_cohort must be a boolean")
+        if auto_fork_cohort_max_wait_ms is not None and (
+            not isinstance(auto_fork_cohort_max_wait_ms, int)
+            or isinstance(auto_fork_cohort_max_wait_ms, bool)
+            or not 1 <= auto_fork_cohort_max_wait_ms <= 60_000
+        ):
+            raise ValueError(
+                "auto_fork_cohort_max_wait_ms must be between 1 and 60000"
+            )
         self.api_url = api_url.rstrip("/")
         self.executor = executor
         self.bearer_token = bearer_token
@@ -159,13 +170,16 @@ class RolloutClient:
         self.timeout = timeout
         self.ssl_context = ssl_context
         self.auto_fork_cohort = auto_fork_cohort
+        self.auto_fork_cohort_max_wait_ms = auto_fork_cohort_max_wait_ms
         self._fork_cohort_lock = threading.Lock()
         self._fork_cohort_round = 0
-        self._fork_cohorts: OrderedDict[str, tuple[str, int]] = OrderedDict()
+        self._fork_cohorts: OrderedDict[
+            str, tuple[str, int, int | None]
+        ] = OrderedDict()
 
     def _automatic_fork_cohort(
         self, idempotency_key: str
-    ) -> tuple[str, int] | None:
+    ) -> tuple[str, int, int | None] | None:
         if not self.auto_fork_cohort:
             return None
         batch_id = os.environ.get("SMOLVM_FORK_BATCH_ID")
@@ -207,7 +221,11 @@ class RolloutClient:
             digest = hashlib.sha256(
                 f"{batch_id}\0{self.executor}\0{group_index}\0{round_index}".encode()
             ).hexdigest()
-            cohort = (f"fork-{digest[:32]}", group_size)
+            cohort = (
+                f"fork-{digest[:32]}",
+                group_size,
+                self.auto_fork_cohort_max_wait_ms,
+            )
             self._fork_cohorts[idempotency_key] = cohort
             if len(self._fork_cohorts) > 1024:
                 self._fork_cohorts.popitem(last=False)
@@ -411,6 +429,7 @@ class RolloutClient:
         deadline_ms: int | None = None,
         cohort_id: str | None = None,
         cohort_size: int | None = None,
+        cohort_max_wait_ms: int | None = None,
         **sampling: Any,
     ) -> dict[str, Any]:
         """Build a generation job for `generate` or a cross-policy cohort."""
@@ -444,6 +463,8 @@ class RolloutClient:
             job["deadlineMs"] = deadline_ms
         if (cohort_id is None) != (cohort_size is None):
             raise ValueError("cohort_id and cohort_size must be set together")
+        if cohort_id is None and cohort_max_wait_ms is not None:
+            raise ValueError("cohort_max_wait_ms requires a cohort")
         if cohort_id is not None:
             if not cohort_id:
                 raise ValueError("cohort_id cannot be empty")
@@ -451,16 +472,28 @@ class RolloutClient:
                 raise ValueError("cohort_size must be an integer")
             if not 1 <= cohort_size <= 256:
                 raise ValueError("cohort_size must be between 1 and 256")
+            if cohort_max_wait_ms is not None and (
+                not isinstance(cohort_max_wait_ms, int)
+                or isinstance(cohort_max_wait_ms, bool)
+                or not 1 <= cohort_max_wait_ms <= 60_000
+            ):
+                raise ValueError("cohort_max_wait_ms must be between 1 and 60000")
             job["cohort"] = {"id": cohort_id, "size": cohort_size}
+            if cohort_max_wait_ms is not None:
+                job["cohort"]["maxWaitMs"] = cohort_max_wait_ms
         return job
 
     def generate(self, **job: Any) -> dict[str, Any]:
         """Generate through one policy, returning exact token IDs and logprobs."""
 
-        if "cohort_id" not in job and "cohort_size" not in job:
+        if not {"cohort_id", "cohort_size", "cohort_max_wait_ms"}.intersection(job):
             cohort = self._automatic_fork_cohort(job.get("idempotency_key", ""))
             if cohort is not None:
-                job["cohort_id"], job["cohort_size"] = cohort
+                (
+                    job["cohort_id"],
+                    job["cohort_size"],
+                    job["cohort_max_wait_ms"],
+                ) = cohort
 
         return self._request(
             "POST",

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -1,7 +1,9 @@
+import os
 import tempfile
 import unittest
 from unittest import mock
 from pathlib import Path
+from unittest.mock import patch
 
 from smolvm_rollout import RolloutClient, RolloutError, adapter_sha256
 
@@ -23,8 +25,8 @@ class AdapterDigestTests(unittest.TestCase):
 
 
 class RecordingClient(RolloutClient):
-    def __init__(self):
-        super().__init__("http://127.0.0.1:1/api/v1", "fused")
+    def __init__(self, **options):
+        super().__init__("http://127.0.0.1:1/api/v1", "fused", **options)
         self.recorded = None
 
     def _request(self, method, path, body=None):
@@ -168,6 +170,130 @@ class CohortTests(unittest.TestCase):
             client.job(**common, cohort_id="training-step-1")
         with self.assertRaisesRegex(ValueError, "between 1 and 256"):
             client.job(**common, cohort_id="training-step-1", cohort_size=0)
+
+    def test_explicit_cohort_overrides_fork_metadata(self):
+        with patch.dict(
+            os.environ,
+            {
+                "SMOLVM_FORK_BATCH_ID": "batch-1",
+                "SMOLVM_FORK_BATCH_SIZE": "2",
+            },
+            clear=False,
+        ):
+            client = RecordingClient()
+            client.generate(
+                idempotency_key="request-1",
+                policy="policy-1",
+                prompts=["hello"],
+                max_tokens=8,
+                cohort_id="controller-round-1",
+                cohort_size=4,
+            )
+        self.assertEqual(
+            client.recorded[2]["cohort"],
+            {"id": "controller-round-1", "size": 4},
+        )
+
+    def test_generate_automatically_groups_direct_batch_forks(self):
+        environment = {
+            "SMOLVM_FORK_BATCH_ID": "batch-1",
+            "SMOLVM_FORK_BATCH_SIZE": "2",
+        }
+        with patch.dict(os.environ, environment, clear=False):
+            first = RecordingClient()
+            second = RecordingClient()
+            first.generate(
+                idempotency_key="learner-0-step-0",
+                policy="policy-0",
+                prompts=["hello"],
+                max_tokens=8,
+            )
+            second.generate(
+                idempotency_key="learner-1-step-0",
+                policy="policy-1",
+                prompts=["hello"],
+                max_tokens=8,
+            )
+            first_cohort = first.recorded[2]["cohort"]
+            self.assertEqual(first_cohort, second.recorded[2]["cohort"])
+            self.assertEqual(first_cohort["size"], 2)
+
+            first.generate(
+                idempotency_key="learner-0-step-1",
+                policy="policy-0",
+                prompts=["hello"],
+                max_tokens=8,
+            )
+            second.generate(
+                idempotency_key="learner-1-step-1",
+                policy="policy-1",
+                prompts=["hello"],
+                max_tokens=8,
+            )
+            self.assertEqual(first.recorded[2]["cohort"], second.recorded[2]["cohort"])
+            self.assertNotEqual(first_cohort, first.recorded[2]["cohort"])
+
+    def test_automatic_fork_cohort_is_retry_stable_and_optional(self):
+        environment = {
+            "SMOLVM_FORK_BATCH_ID": "batch-1",
+            "SMOLVM_FORK_BATCH_SIZE": "2",
+        }
+        request = {
+            "idempotency_key": "learner-0-step-0",
+            "policy": "policy-0",
+            "prompts": ["hello"],
+            "max_tokens": 8,
+        }
+        with patch.dict(os.environ, environment, clear=False):
+            client = RecordingClient()
+            client.generate(**request)
+            first = client.recorded[2]["cohort"]
+            client.generate(**request)
+            self.assertEqual(first, client.recorded[2]["cohort"])
+
+            disabled = RecordingClient(auto_fork_cohort=False)
+            disabled.generate(**request)
+            self.assertNotIn("cohort", disabled.recorded[2])
+
+    def test_automatic_fork_cohort_rejects_incomplete_metadata(self):
+        with patch.dict(
+            os.environ,
+            {"SMOLVM_FORK_BATCH_ID": "batch-1"},
+            clear=True,
+        ):
+            with self.assertRaisesRegex(ValueError, "must be set together"):
+                RecordingClient().generate(
+                    idempotency_key="request-1",
+                    policy="policy-1",
+                    prompts=["hello"],
+                    max_tokens=8,
+                )
+
+    def test_automatic_fork_cohort_partitions_large_batches(self):
+        common = {
+            "SMOLVM_FORK_BATCH_ID": "batch-1",
+            "SMOLVM_FORK_BATCH_SIZE": "300",
+        }
+        clients = []
+        for index in (0, 255, 256, 299):
+            with patch.dict(
+                os.environ,
+                {**common, "SMOLVM_FORK_INDEX": str(index)},
+                clear=True,
+            ):
+                client = RecordingClient()
+                client.generate(
+                    idempotency_key=f"request-{index}",
+                    policy=f"policy-{index}",
+                    prompts=["hello"],
+                    max_tokens=8,
+                )
+                clients.append(client.recorded[2]["cohort"])
+        self.assertEqual(clients[0], clients[1])
+        self.assertEqual(clients[0]["size"], 256)
+        self.assertEqual(clients[2], clients[3])
+        self.assertEqual(clients[2]["size"], 44)
+        self.assertNotEqual(clients[0], clients[2])
 
 
 if __name__ == "__main__":

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -170,6 +170,31 @@ class CohortTests(unittest.TestCase):
             client.job(**common, cohort_id="training-step-1")
         with self.assertRaisesRegex(ValueError, "between 1 and 256"):
             client.job(**common, cohort_id="training-step-1", cohort_size=0)
+        with self.assertRaisesRegex(ValueError, "requires a cohort"):
+            client.job(**common, cohort_max_wait_ms=250)
+        with self.assertRaisesRegex(ValueError, "between 1 and 60000"):
+            client.job(
+                **common,
+                cohort_id="training-step-1",
+                cohort_size=2,
+                cohort_max_wait_ms=0,
+            )
+
+    def test_generate_encodes_bounded_distributed_cohort(self):
+        client = RecordingClient()
+        client.generate(
+            idempotency_key="request-1",
+            policy="policy-1",
+            prompts=["hello"],
+            max_tokens=8,
+            cohort_id="training-step-1",
+            cohort_size=4,
+            cohort_max_wait_ms=250,
+        )
+        self.assertEqual(
+            client.recorded[2]["cohort"],
+            {"id": "training-step-1", "size": 4, "maxWaitMs": 250},
+        )
 
     def test_explicit_cohort_overrides_fork_metadata(self):
         with patch.dict(
@@ -217,6 +242,7 @@ class CohortTests(unittest.TestCase):
             first_cohort = first.recorded[2]["cohort"]
             self.assertEqual(first_cohort, second.recorded[2]["cohort"])
             self.assertEqual(first_cohort["size"], 2)
+            self.assertEqual(first_cohort["maxWaitMs"], 250)
 
             first.generate(
                 idempotency_key="learner-0-step-1",
@@ -254,6 +280,10 @@ class CohortTests(unittest.TestCase):
             disabled = RecordingClient(auto_fork_cohort=False)
             disabled.generate(**request)
             self.assertNotIn("cohort", disabled.recorded[2])
+
+            exact = RecordingClient(auto_fork_cohort_max_wait_ms=None)
+            exact.generate(**request)
+            self.assertNotIn("maxWaitMs", exact.recorded[2]["cohort"])
 
     def test_automatic_fork_cohort_rejects_incomplete_metadata(self):
         with patch.dict(

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -1,3 +1,4 @@
+import json
 import os
 import tempfile
 import unittest
@@ -42,7 +43,9 @@ class LeaseDiscoveryTests(unittest.TestCase):
                 "SMOLVM_ROLLOUT_URL=http://100.96.0.1:10081/api/v1/rollout-executors/fused\n"
                 "SMOLVM_ROLLOUT_TOKEN=lease-id.secret\n"
                 "SMOLVM_ROLLOUT_EXECUTOR=fused\n"
-                "SMOLVM_ROLLOUT_POLICY=experiment-a\n",
+                "SMOLVM_ROLLOUT_POLICY=experiment-a\n"
+                "SMOLVM_FORK_BATCH_ID=batch-a\n"
+                "SMOLVM_FORK_BATCH_SIZE=2\n",
                 encoding="utf-8",
             )
             with mock.patch.dict("os.environ", {}, clear=True):
@@ -65,6 +68,9 @@ class LeaseDiscoveryTests(unittest.TestCase):
                 self.assertEqual(
                     request.get_header("Authorization"), "Bearer lease-id.secret"
                 )
+                cohort = json.loads(request.data)["cohort"]
+                self.assertRegex(cohort.pop("id"), r"^fork-[0-9a-f]{32}$")
+                self.assertEqual(cohort, {"size": 2, "maxWaitMs": 250})
 
     def test_environment_overrides_assignment_after_clone_release(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/src/api/rollout.rs
+++ b/src/api/rollout.rs
@@ -42,6 +42,8 @@ const MAX_ADAPTER_BYTES: u64 = 32 * 1024 * 1024 * 1024;
 const IDEMPOTENCY_TTL: Duration = Duration::from_secs(10 * 60);
 const MAX_IDEMPOTENCY_ENTRIES: usize = 8192;
 const MAX_COHORT_SIZE: u32 = 256;
+const MAX_COHORT_WAIT_MS: u64 = 60_000;
+const PARTIAL_COHORT_RETENTION: Duration = Duration::from_secs(10 * 60);
 
 /// Request to register one local fused rollout engine.
 #[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
@@ -242,8 +244,11 @@ pub struct RolloutGenerateRequest {
 pub struct RolloutCohort {
     /// Unique identifier for one logical rollout round.
     pub id: String,
-    /// Exact number of independent jobs required before any member executes.
+    /// Target number of independent jobs in this rollout round.
     pub size: u32,
+    /// Optional bounded wait before the members already present are admitted.
+    #[serde(default)]
+    pub max_wait_ms: Option<u64>,
 }
 
 /// A cohort of independent policy requests submitted together for backend fusion.
@@ -453,6 +458,7 @@ const COHORT_FAILED: usize = 2;
 struct CohortEntry {
     id: String,
     expected: u32,
+    max_wait_ms: Option<u64>,
     members: SyncMutex<HashSet<String>>,
     state: AtomicUsize,
     changed: Notify,
@@ -476,6 +482,7 @@ impl CohortAdmission {
                 Arc::new(CohortEntry {
                     id: cohort.id.clone(),
                     expected: cohort.size,
+                    max_wait_ms: cohort.max_wait_ms,
                     members: SyncMutex::new(HashSet::new()),
                     state: AtomicUsize::new(COHORT_WAITING),
                     changed: Notify::new(),
@@ -488,6 +495,12 @@ impl CohortAdmission {
                 cohort.id, entry.expected, cohort.size
             )));
         }
+        if entry.max_wait_ms != cohort.max_wait_ms {
+            return Err(RolloutError::Conflict(format!(
+                "rollout cohort '{}' has a different maxWaitMs",
+                cohort.id
+            )));
+        }
         let ready = {
             let mut members = entry.members.lock();
             if !members.insert(member.to_string()) {
@@ -498,7 +511,7 @@ impl CohortAdmission {
             }
             members.len() == entry.expected as usize
         };
-        if ready
+        let released_exactly = ready
             && entry
                 .state
                 .compare_exchange(
@@ -507,9 +520,11 @@ impl CohortAdmission {
                     Ordering::AcqRel,
                     Ordering::Acquire,
                 )
-                .is_ok()
-        {
+                .is_ok();
+        if ready {
             entries.remove(&cohort.id);
+        }
+        if released_exactly {
             entry.changed.notify_waiters();
             metrics::counter!("smolvm_rollout_cohorts_total", "status" => "ready").increment(1);
             metrics::histogram!("smolvm_rollout_cohort_size").record(cohort.size as f64);
@@ -553,6 +568,10 @@ struct CohortTicket {
 
 impl CohortTicket {
     async fn wait(mut self) -> Result<(), RolloutError> {
+        let deadline = self
+            .entry
+            .max_wait_ms
+            .map(|wait_ms| tokio::time::Instant::now() + Duration::from_millis(wait_ms));
         loop {
             let changed = self.entry.changed.notified();
             match self.entry.state.load(Ordering::Acquire) {
@@ -567,9 +586,52 @@ impl CohortTicket {
                         self.entry.id
                     )));
                 }
-                _ => changed.await,
+                _ => {
+                    if let Some(deadline) = deadline {
+                        if tokio::time::timeout_at(deadline, changed).await.is_err() {
+                            self.release_partial();
+                        }
+                    } else {
+                        changed.await;
+                    }
+                }
             }
         }
+    }
+
+    fn release_partial(&self) {
+        if self
+            .entry
+            .state
+            .compare_exchange(
+                COHORT_WAITING,
+                COHORT_READY,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_err()
+        {
+            return;
+        }
+
+        let admitted = self.entry.members.lock().len();
+        self.entry.changed.notify_waiters();
+        metrics::counter!("smolvm_rollout_cohorts_total", "status" => "partial").increment(1);
+        metrics::histogram!("smolvm_rollout_cohort_size").record(self.entry.expected as f64);
+        metrics::histogram!("smolvm_rollout_cohort_admitted_size").record(admitted as f64);
+
+        let admission = self.admission.clone();
+        let entry = self.entry.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(PARTIAL_COHORT_RETENTION).await;
+            let mut entries = admission.entries.lock();
+            if entries
+                .get(&entry.id)
+                .is_some_and(|current| Arc::ptr_eq(current, &entry))
+            {
+                entries.remove(&entry.id);
+            }
+        });
     }
 }
 
@@ -1899,6 +1961,14 @@ fn validate_generate_request(request: &RolloutGenerateRequest) -> Result<(), Rol
                 "cohort.size must be between 1 and {MAX_COHORT_SIZE}"
             )));
         }
+        if cohort
+            .max_wait_ms
+            .is_some_and(|wait_ms| !(1..=MAX_COHORT_WAIT_MS).contains(&wait_ms))
+        {
+            return Err(RolloutError::BadRequest(format!(
+                "cohort.maxWaitMs must be between 1 and {MAX_COHORT_WAIT_MS}"
+            )));
+        }
     }
     Ok(())
 }
@@ -2133,6 +2203,7 @@ mod tests {
         let cohort = RolloutCohort {
             id: "round-1".into(),
             size: 2,
+            max_wait_ms: None,
         };
         let first = admission.join(&cohort, "request-1").unwrap();
         let first = tokio::spawn(first.wait());
@@ -2154,11 +2225,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn distributed_cohort_releases_arrived_members_after_bounded_wait() {
+        let admission = Arc::new(CohortAdmission::default());
+        let cohort = RolloutCohort {
+            id: "round-partial".into(),
+            size: 2,
+            max_wait_ms: Some(10),
+        };
+
+        tokio::time::timeout(
+            Duration::from_millis(100),
+            admission.join(&cohort, "request-1").unwrap().wait(),
+        )
+        .await
+        .expect("the bounded cohort must release its arrived member")
+        .unwrap();
+        assert_eq!(admission.entries.lock().len(), 1);
+
+        tokio::time::timeout(
+            Duration::from_millis(50),
+            admission.join(&cohort, "request-2").unwrap().wait(),
+        )
+        .await
+        .expect("a late cohort member must be admitted immediately")
+        .unwrap();
+        assert!(admission.entries.lock().is_empty());
+    }
+
+    #[tokio::test]
     async fn distributed_cohort_fails_all_members_when_one_leaves() {
         let admission = Arc::new(CohortAdmission::default());
         let cohort = RolloutCohort {
             id: "round-2".into(),
             size: 3,
+            max_wait_ms: None,
         };
         let first = admission.join(&cohort, "request-1").unwrap();
         let first = tokio::spawn(first.wait());
@@ -2181,6 +2281,7 @@ mod tests {
         let cohort = RolloutCohort {
             id: "round-shutdown".into(),
             size: 2,
+            max_wait_ms: None,
         };
         let waiting = admission.join(&cohort, "request-1").unwrap();
         let waiting = tokio::spawn(waiting.wait());
@@ -2203,14 +2304,25 @@ mod tests {
         let first = RolloutCohort {
             id: "round-3".into(),
             size: 2,
+            max_wait_ms: None,
         };
         let inconsistent = RolloutCohort {
             id: first.id.clone(),
             size: 3,
+            max_wait_ms: None,
+        };
+        let inconsistent_wait = RolloutCohort {
+            id: first.id.clone(),
+            size: first.size,
+            max_wait_ms: Some(10),
         };
         let _ticket = admission.join(&first, "request-1").unwrap();
         assert!(matches!(
             admission.join(&inconsistent, "request-2"),
+            Err(RolloutError::Conflict(_))
+        ));
+        assert!(matches!(
+            admission.join(&inconsistent_wait, "request-2"),
             Err(RolloutError::Conflict(_))
         ));
     }
@@ -2261,6 +2373,7 @@ mod tests {
         first.cohort = Some(RolloutCohort {
             id: "training-step-1".into(),
             size: 2,
+            max_wait_ms: None,
         });
         let first_executor = executor.clone();
         let first = tokio::spawn(async move { first_executor.generate(first).await });
@@ -2271,6 +2384,7 @@ mod tests {
         second.cohort = Some(RolloutCohort {
             id: "training-step-1".into(),
             size: 2,
+            max_wait_ms: None,
         });
         let (first, second) = tokio::join!(first, executor.generate(second));
         first.unwrap().unwrap();
@@ -2288,6 +2402,7 @@ mod tests {
         abandoned.cohort = Some(RolloutCohort {
             id: "retry-round".into(),
             size: 2,
+            max_wait_ms: None,
         });
         assert!(matches!(
             executor.generate(abandoned.clone()).await,
@@ -2597,6 +2712,20 @@ mod tests {
             deadline_ms: None,
             cohort: None,
         };
+        assert!(validate_generate_request(&request).is_err());
+    }
+
+    #[test]
+    fn cohort_validation_rejects_invalid_bounded_wait() {
+        let mut request = sample_generate("invalid-cohort-wait");
+        request.cohort = Some(RolloutCohort {
+            id: "round-invalid".into(),
+            size: 2,
+            max_wait_ms: Some(0),
+        });
+        assert!(validate_generate_request(&request).is_err());
+
+        request.cohort.as_mut().unwrap().max_wait_ms = Some(MAX_COHORT_WAIT_MS + 1);
         assert!(validate_generate_request(&request).is_err());
     }
 

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -365,7 +365,8 @@ const TENSOR_RESPONSE_MAGIC: [u8; 4] = *b"TBR1";
 const MAX_TENSOR_BUNDLE_METADATA: usize = (2 << 20) + 64;
 const MAX_PENDING_TENSOR_BUNDLES: usize = 64;
 const MAX_PENDING_TENSOR_BYTES: u64 = 32 << 30;
-const TENSOR_BUNDLE_TTL: Duration = Duration::from_secs(60);
+const DEFAULT_TENSOR_BUNDLE_TTL: Duration = Duration::from_secs(5 * 60);
+const MAX_TENSOR_BUNDLE_TTL_SECS: u64 = 60 * 60;
 static TENSOR_BUNDLE_SERVICE_READY: AtomicBool = AtomicBool::new(false);
 #[cfg(unix)]
 const MAX_MODULE_HANDOFF_BLOB_BYTES: u64 = 32 << 30;
@@ -385,6 +386,26 @@ fn pending_tensor_bundles(
     static BUNDLES: OnceLock<Mutex<std::collections::HashMap<Vec<u8>, PendingTensorBundle>>> =
         OnceLock::new();
     BUNDLES.get_or_init(|| Mutex::new(std::collections::HashMap::new()))
+}
+
+fn tensor_bundle_ttl_from(value: Option<&str>) -> Duration {
+    value
+        .map(str::trim)
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|seconds| (1..=MAX_TENSOR_BUNDLE_TTL_SECS).contains(seconds))
+        .map(Duration::from_secs)
+        .unwrap_or(DEFAULT_TENSOR_BUNDLE_TTL)
+}
+
+fn tensor_bundle_ttl() -> Duration {
+    static TTL: OnceLock<Duration> = OnceLock::new();
+    *TTL.get_or_init(|| {
+        tensor_bundle_ttl_from(
+            std::env::var("SMOLVM_CUDA_TENSOR_BUNDLE_TTL_SECS")
+                .ok()
+                .as_deref(),
+        )
+    })
 }
 
 fn tensor_bundle_socket_path(cuda_socket: &Path) -> PathBuf {
@@ -407,7 +428,7 @@ fn prune_tensor_bundles(
     bundles: &mut std::collections::HashMap<Vec<u8>, PendingTensorBundle>,
     now: Instant,
 ) {
-    bundles.retain(|_, bundle| now.duration_since(bundle.created) < TENSOR_BUNDLE_TTL);
+    bundles.retain(|_, bundle| now.duration_since(bundle.created) < tensor_bundle_ttl());
 }
 
 fn pending_tensor_bytes(bundles: &std::collections::HashMap<Vec<u8>, PendingTensorBundle>) -> u64 {
@@ -6041,8 +6062,9 @@ mod mps_tests {
         reconstruct_golden_modules, recv_fd, redeem_tensor_bundle_from_stream, seal_host_snapshot,
         select_golden_owner, send_fd, send_tensor_bundle_to_parent, serve_tensor_bundle_consumer,
         spawn_clone_attach_listener_with_timeout, spawn_tensor_bundle_receiver,
-        unique_live_clone_worker, validate_tensor_bundle_metadata, write_module_handoff,
-        CloneWorkerSpawnFds, CloneWorkerStatus, TENSOR_CONSUME_MAGIC,
+        tensor_bundle_ttl_from, unique_live_clone_worker, validate_tensor_bundle_metadata,
+        write_module_handoff, CloneWorkerSpawnFds, CloneWorkerStatus, DEFAULT_TENSOR_BUNDLE_TTL,
+        TENSOR_CONSUME_MAGIC,
     };
     use std::collections::HashMap;
     use std::io::{self, Write};
@@ -6458,6 +6480,24 @@ mod mps_tests {
         assert_eq!(
             clone_worker_idle_timeout_from(Some("invalid")).as_secs(),
             300
+        );
+    }
+
+    #[test]
+    fn tensor_bundle_lifetime_covers_delayed_cohort_consumers() {
+        assert_eq!(tensor_bundle_ttl_from(None), Duration::from_secs(300));
+        assert_eq!(
+            tensor_bundle_ttl_from(Some(" 600 ")),
+            Duration::from_secs(600)
+        );
+        assert_eq!(tensor_bundle_ttl_from(Some("0")), DEFAULT_TENSOR_BUNDLE_TTL);
+        assert_eq!(
+            tensor_bundle_ttl_from(Some("3601")),
+            DEFAULT_TENSOR_BUNDLE_TTL
+        );
+        assert_eq!(
+            tensor_bundle_ttl_from(Some("invalid")),
+            DEFAULT_TENSOR_BUNDLE_TTL
         );
     }
 


### PR DESCRIPTION
Derives bounded rollout cohorts from fork assignments so aligned workers batch policy publication without blocking on stragglers.