### PR TITLE
Normalize the agent rootfs's owner-only Alpine paths at build time so pack create works for a non-root user on a packaged install

### DIFF
--- a/scripts/build-agent-rootfs.sh
+++ b/scripts/build-agent-rootfs.sh
@@ -180,6 +180,76 @@ repair_executable_modes() {
     done
 }
 
+normalize_owner_only_modes() {
+    local rootfs_dir="$1"
+
+    # The stock Alpine minirootfs ships four paths only their owner can read.
+    # A mode-preserving install — packaging/arch/PKGBUILD and packaging/nfpm.yaml
+    # both copy the tree as-is — lands them root-owned under a system prefix such
+    # as /usr/lib/smolvm/agent-rootfs, where the user running smolvm cannot read
+    # them. `pack create` tars the whole rootfs and cannot skip anything, so it
+    # hard-fails with "Permission denied" (collect_agent_rootfs,
+    # crates/smolvm-pack/src/assets.rs). That also breaks plain `machine run`
+    # whenever an init layer is baked via `pack create --from-vm` — a Smolfile
+    # with [dev] init steps, or any --oci-cache run.
+    #
+    # Booting is unaffected either way: the guest never opens these files, and
+    # since the vsock readiness doorbell the host no longer writes into this
+    # directory to signal ready.
+    #
+    # Widening them discloses nothing. This tree is a build artifact published on
+    # a public release page and byte-identical for every user: `shadow` carries no
+    # hashes (root:*, every other account !), /etc/crontabs/root is the stock
+    # run-parts schedule, /root is empty, and lib/apk/db/lock is zero bytes.
+    # Ownership and write bits are left alone.
+    echo "Normalizing owner-only permissions..."
+    local owner_only_dirs=(
+        # The tree root itself: created by this script under the builder's umask,
+        # so a restrictive umask would otherwise produce a rootfs nobody but the
+        # owner can even traverse into.
+        "$rootfs_dir"
+        "$rootfs_dir/root"
+    )
+    local owner_only_files=(
+        "$rootfs_dir/etc/shadow"
+        "$rootfs_dir/etc/crontabs/root"
+        "$rootfs_dir/lib/apk/db/lock"
+    )
+    for path in "${owner_only_dirs[@]}"; do
+        if [[ -d "$path" ]]; then
+            chmod 0755 "$path"
+        fi
+    done
+    for path in "${owner_only_files[@]}"; do
+        if [[ -f "$path" ]]; then
+            chmod 0644 "$path"
+        fi
+    done
+
+    # Then verify the whole tree, and fail the build on anything still owner-only.
+    #
+    # Deliberately not a blanket `chmod -R a+rX`: this script also runs against
+    # user-supplied trees, and SMOLVM_AGENT_ROOTFS can boot one. The rootfs is
+    # shared into every VM, so a recursive widen would quietly expose a custom
+    # tree's 0600 registry token or signing key to every workload. Naming the
+    # known paths and hard-failing on the rest means a later Alpine bump that adds
+    # a fifth one stops the build here — instead of shipping a rootfs that cannot
+    # be packed, or widening something nobody looked at.
+    local owner_only
+    owner_only="$(find "$rootfs_dir" \
+        \( -type f ! -perm -o=r \) -o \( -type d ! -perm -o=rx \) 2>/dev/null || true)"
+    if [[ -n "$owner_only" ]]; then
+        echo "Error: agent rootfs has paths unreadable to a non-owner:" >&2
+        echo "$owner_only" | sed "s#^${rootfs_dir}#  #" >&2
+        echo "" >&2
+        echo "A mode-preserving install makes these unreadable to the user running" >&2
+        echo "smolvm, and 'pack create' fails on them. Either widen them by name in" >&2
+        echo "normalize_owner_only_modes() once you have confirmed they hold nothing" >&2
+        echo "secret, or keep them out of the rootfs." >&2
+        exit 1
+    fi
+}
+
 if [[ "$(uname -s)" == "Linux" ]]; then
     # On Linux, apk.static is preferred — it handles cross-arch correctly
     install_packages_apk_static
@@ -378,6 +448,9 @@ if [[ -n "$CUDART_SHIM_SRC" && -f "$CUDART_SHIM_SRC" \
 else
     echo "Skipping CUDA guest shims (no prebuilt paths, cross-arch, or no cargo) — auto-staging disabled in this rootfs"
 fi
+
+# Last, so it covers every file the steps above installed — not just the Alpine base.
+normalize_owner_only_modes "$OUTPUT_DIR"
 
 echo ""
 echo "Agent rootfs created at: $OUTPUT_DIR"

--- a/tests/test_agent_rootfs_modes.sh
+++ b/tests/test_agent_rootfs_modes.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+#
+# Agent Rootfs Permission Tests
+#
+# Part of the smolvm test suite. Run with: ./tests/test_agent_rootfs_modes.sh
+#
+# Covers normalize_owner_only_modes() in scripts/build-agent-rootfs.sh, which
+# widens the stock Alpine paths that only their owner can read. A mode-preserving
+# install lands those root-owned under a system prefix, where `pack create` — it
+# tars the whole rootfs and cannot skip anything — fails for the user running
+# smolvm. The rootfs build only runs in the release workflow, so without this the
+# behavior is unexercised until a tarball is already cut.
+#
+# Pure fixture test: no smolvm binary, no VM, no network. It therefore carries
+# its own runner rather than sourcing common.sh, whose helpers assume an
+# initialized smolvm and a machine lifecycle to clean up.
+#
+
+set -uo pipefail
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+TESTS_RUN=0; TESTS_PASSED=0; TESTS_FAILED=0; FAILED_TESTS=()
+
+run_test() {
+    local test_name="$1" test_func="$2" output
+    TESTS_RUN=$((TESTS_RUN + 1))
+    echo -e "${YELLOW}[TEST]${NC} $test_name"
+    if output=$($test_func 2>&1); then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "${GREEN}[PASS]${NC} $test_name"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        FAILED_TESTS+=("$test_name")
+        echo -e "${RED}[FAIL]${NC} $test_name"
+        [[ -n "$output" ]] && echo "$output" | sed 's/^/    /'
+    fi
+}
+
+print_summary() {
+    echo ""
+    echo "=========================================="
+    echo "  $1 Summary"
+    echo "=========================================="
+    echo ""
+    echo "Tests run:    $TESTS_RUN"
+    echo -e "Tests passed: ${GREEN}$TESTS_PASSED${NC}"
+    echo -e "Tests failed: ${RED}$TESTS_FAILED${NC}"
+    if [[ $TESTS_FAILED -gt 0 ]]; then
+        echo ""
+        echo -e "${RED}Failed tests:${NC}"
+        printf "  ${RED}✗${NC} %s\n" "${FAILED_TESTS[@]}"
+        return 1
+    fi
+    return 0
+}
+
+BUILD_SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/scripts/build-agent-rootfs.sh"
+
+# Source just the function under test; the build script's top level would go off
+# and download Alpine.
+eval "$(awk '/^normalize_owner_only_modes\(\) \{/,/^\}/' "$BUILD_SCRIPT")"
+
+echo ""
+echo "=========================================="
+echo "  Agent Rootfs Permission Tests"
+echo "=========================================="
+echo ""
+
+# Mode of a path, portable across GNU and BSD stat.
+mode_of() {
+    stat -c '%a' "$1" 2>/dev/null || stat -f '%OLp' "$1"
+}
+
+# The owner-only layout the stock Alpine minirootfs ships.
+make_rootfs_fixture() {
+    local root="$1"
+    mkdir -p "$root/etc/crontabs" "$root/lib/apk/db" "$root/root" "$root/bin"
+    : > "$root/etc/shadow"
+    : > "$root/etc/crontabs/root"
+    : > "$root/lib/apk/db/lock"
+    : > "$root/bin/busybox"
+    chmod 0640 "$root/etc/shadow"
+    chmod 0600 "$root/etc/crontabs/root"
+    chmod 0600 "$root/lib/apk/db/lock"
+    chmod 0700 "$root/root"
+    chmod 0755 "$root/bin/busybox"
+    ln -sf /usr/local/bin/smolvm-agent "$root/bin/init"
+}
+
+test_stock_alpine_paths_are_widened() {
+    local root
+    root=$(mktemp -d)
+    make_rootfs_fixture "$root"
+
+    normalize_owner_only_modes "$root" >/dev/null || {
+        echo "normalize_owner_only_modes failed on a stock layout"
+        rm -rf "$root"
+        return 1
+    }
+
+    local rc=0
+    local path
+    for path in etc/shadow etc/crontabs/root lib/apk/db/lock; do
+        if [[ "$(mode_of "$root/$path")" != "644" ]]; then
+            echo "$path is $(mode_of "$root/$path"), want 644"
+            rc=1
+        fi
+    done
+    for path in . root; do
+        if [[ "$(mode_of "$root/$path")" != "755" ]]; then
+            echo "$path is $(mode_of "$root/$path"), want 755"
+            rc=1
+        fi
+    done
+
+    rm -rf "$root"
+    return $rc
+}
+
+# The rootfs is shared into every VM and this script also runs against
+# user-supplied trees, so an unrecognized owner-only path must stop the build
+# rather than be widened silently.
+test_unexpected_owner_only_path_fails_loudly() {
+    local root
+    root=$(mktemp -d)
+    make_rootfs_fixture "$root"
+    mkdir -p "$root/etc/smolvm"
+    : > "$root/etc/smolvm/registry-token"
+    chmod 0600 "$root/etc/smolvm/registry-token"
+
+    local output rc=0
+    if output=$(normalize_owner_only_modes "$root" 2>&1); then
+        echo "expected a non-zero exit for an unrecognized owner-only file"
+        rc=1
+    fi
+    if ! grep -q "registry-token" <<<"$output"; then
+        echo "error output does not name the offending path:"
+        echo "$output"
+        rc=1
+    fi
+    if [[ "$(mode_of "$root/etc/smolvm/registry-token")" != "600" ]]; then
+        echo "the unrecognized file was widened to $(mode_of "$root/etc/smolvm/registry-token")"
+        rc=1
+    fi
+
+    rm -rf "$root"
+    return $rc
+}
+
+test_unexpected_owner_only_directory_fails_loudly() {
+    local root
+    root=$(mktemp -d)
+    make_rootfs_fixture "$root"
+    mkdir -p "$root/opt/private"
+    chmod 0700 "$root/opt/private"
+
+    # Called in a subshell: the function exits rather than returning, so that a
+    # failure stops the build script it normally runs from.
+    local rc=0
+    if (normalize_owner_only_modes "$root" >/dev/null 2>&1); then
+        echo "expected a non-zero exit for an unrecognized owner-only directory"
+        rc=1
+    fi
+
+    rm -rf "$root"
+    return $rc
+}
+
+# --no-build-agent and cross-arch builds can legitimately omit some of these.
+test_missing_optional_paths_are_tolerated() {
+    local root
+    root=$(mktemp -d)
+    mkdir -p "$root/bin"
+    : > "$root/bin/busybox"
+    chmod 0755 "$root/bin/busybox"
+
+    local rc=0
+    normalize_owner_only_modes "$root" >/dev/null 2>&1 || {
+        echo "a rootfs without the Alpine owner-only paths should pass"
+        rc=1
+    }
+
+    rm -rf "$root"
+    return $rc
+}
+
+# A symlink's own mode is not meaningful and cannot be chmod'd portably; the
+# check must look through to file/directory types only.
+test_symlinks_do_not_trip_the_check() {
+    local root
+    root=$(mktemp -d)
+    make_rootfs_fixture "$root"
+    ln -sf /nonexistent-target "$root/bin/dangling"
+
+    local rc=0
+    normalize_owner_only_modes "$root" >/dev/null 2>&1 || {
+        echo "a dangling symlink should not fail the check"
+        rc=1
+    }
+
+    rm -rf "$root"
+    return $rc
+}
+
+run_test "Stock Alpine owner-only paths are widened" test_stock_alpine_paths_are_widened
+run_test "Unexpected owner-only file fails loudly" test_unexpected_owner_only_path_fails_loudly
+run_test "Unexpected owner-only directory fails loudly" test_unexpected_owner_only_directory_fails_loudly
+run_test "Missing optional paths are tolerated" test_missing_optional_paths_are_tolerated
+run_test "Symlinks do not trip the check" test_symlinks_do_not_trip_the_check
+
+print_summary "Agent Rootfs Permission Tests"


### PR DESCRIPTION
Normalizes the four owner-only paths the stock Alpine minirootfs ships, at rootfs build time, so `pack create` works for a non-root user on a system-wide install.

## Why

`/root` (0700), `/etc/shadow` (0640), `/etc/crontabs/root` (0600) and `lib/apk/db/lock` (0600) come straight from the Alpine minirootfs. `packaging/arch/PKGBUILD` and `packaging/nfpm.yaml` both copy the tree mode-preservingly, so a system-wide install lands them root-owned under `/usr/lib/smolvm/agent-rootfs` — unreadable to the user running smolvm.

`collect_agent_rootfs` tars the whole rootfs and cannot skip anything, so `pack create` hard-fails with `Permission denied`. Plain `machine run` breaks too wherever an init layer is baked via `pack create --from-vm`: a Smolfile with `[dev] init` steps, or any `--oci-cache` run.

Booting was never affected — the guest never opens these files, and since the vsock readiness doorbell (#811) the host no longer writes into this directory either. Only the pack path, which can't skip anything, hits it.

## How

`normalize_owner_only_modes()`, called last so it covers every file the build installs rather than just the Alpine base. It widens the four by name, plus the tree root itself — that one is created under the builder's umask, so a restrictive umask would otherwise produce a rootfs nobody but the owner can traverse into (not in the issue's list; the fixtures caught it).

It then verifies the whole tree and fails the build on anything still owner-only.

Nothing is disclosed by the widening. This tree is a public release artifact, byte-identical for every user: `shadow` carries no hashes (`root:*`, every other account `!`), `/etc/crontabs/root` is the stock run-parts schedule, `/root` is empty, the apk lock is zero bytes. Ownership and write bits are unchanged.

## Alternatives considered

**A blanket `chmod -R a+rX`** — rejected. This script also runs against user-supplied trees, `SMOLVM_AGENT_ROOTFS` can boot one, and the rootfs is shared into every VM, so a recursive widen would quietly expose a custom tree's 0600 registry token or signing key to every workload. Naming the known paths and hard-failing on the rest means a later Alpine bump that adds a fifth one stops the build here, instead of shipping a rootfs that can't be packed or widening something nobody examined.

**Shipping `agent-rootfs.tar` and reusing `ensure_extracted_rootfs`** (the issue's option A) — heavier: `default_rootfs_path` checks `SMOLVM_AGENT_ROOTFS` before the tar variable and `scripts/smolvm-wrapper.sh` only handles the directory case, so the wrapper changes too; it costs a ~30 MB extracted copy per user; and it makes the rootfs writable by the invoking user where the packaged layout currently isn't. Worth discussing on its own merits, but not needed to unbreak this.

Neither option helps the 1.7.x tarballs already shipped — packagers still want the interim `chmod` in the issue for those.

## Validation

**Fixtures — `./tests/test_agent_rootfs_modes.sh`, 5/5 pass.** No smolvm binary, no VM, no network. Covers both halves: the stock layout is widened, and an unrecognized owner-only path fails the build *while being left at its original mode*. Also covers missing optional paths (`--no-build-agent`, cross-arch) and dangling symlinks.

The rootfs build only runs in `release.yml`, not per-PR CI — hence a fixture suite rather than leaning on the build to exercise this.

**Real uid boundary, Alpine guest under smolvm.** Fixture rootfs root-owned at stock modes, tarred as uid 1000 the way `collect_agent_rootfs` walks it:

```
=== BEFORE ===
tar: can't open 'etc/shadow': Permission denied
tar: can't open 'etc/crontabs/root': Permission denied
tar: root: Permission denied
tar: can't open 'lib/apk/db/lock': Permission denied
rc=1

=== AFTER (same tar, same user) ===
rc=0
etc/  etc/crontabs/  etc/crontabs/root  etc/shadow
lib/  lib/apk/  lib/apk/db/  lib/apk/db/lock  root/
```

Fixes #865.

---

Unrelated, found while writing the suite and filed separately as #873: `tests/common.sh` increments its counters with `((x++))` under `set -euo pipefail`, which exits 1 on the first increment of a zero-initialized counter. Suites are shielded by the `run_test … || true` idiom (`set -e` is suspended inside an `||` list), so only a suite written without it is affected — `tests/test_pack_registry.sh` today. This suite carries its own runner for that reason; happy to switch to the shared helpers once #873 lands.
