### PR TITLE
Increment the test harness counters with arithmetic expansion so a suite that does not use the `|| true` idiom survives its first passing test

### DIFF
--- a/tests/common.sh
+++ b/tests/common.sh
@@ -112,14 +112,19 @@ log_test() {
     echo -e "${YELLOW}[TEST]${NC} $1"
 }
 
+# Counters use arithmetic EXPANSION, not the `((...))` arithmetic command.
+# `((x++))` yields the value of the expression as its exit status, and
+# post-increment evaluates to the OLD value — so the first increment of a
+# zero-initialized counter exits 1 and `set -e` (line 8) kills the suite. That
+# aborted every suite at its first passing test.
 log_pass() {
     echo -e "${GREEN}[PASS]${NC} $1"
-    ((TESTS_PASSED++))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
 }
 
 log_fail() {
     echo -e "${RED}[FAIL]${NC} $1"
-    ((TESTS_FAILED++))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
 }
 
 log_skip() {
@@ -168,7 +173,7 @@ run_test() {
         return 0
     fi
 
-    ((TESTS_RUN++))
+    TESTS_RUN=$((TESTS_RUN + 1))
     log_test "$test_name"
 
     local output_file
@@ -349,7 +354,7 @@ run_with_timeout() {
     local count=0
     while kill -0 "$pid" 2>/dev/null; do
         sleep 1
-        ((count++))
+        count=$((count + 1))
         if [[ $count -ge $timeout_secs ]]; then
             echo "[TIMEOUT] Command timed out after ${timeout_secs}s: $*" >&2
             # Kill the process and all its children

--- a/tests/test_harness.sh
+++ b/tests/test_harness.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+#
+# Test Harness Tests
+#
+# Part of the smolvm test suite. Run with: ./tests/test_harness.sh
+#
+# Covers common.sh itself. Its counters are incremented under `set -euo pipefail`,
+# where the `((x++))` arithmetic command exits 1 on the first increment of a
+# zero-initialized counter (post-increment yields the OLD value as the status).
+# That aborted every suite at its first passing test, which read as the feature
+# under test failing rather than as a harness fault.
+#
+# Probe suites run as subprocesses so these assertions hold regardless of what
+# the harness does in-process; this file therefore carries its own small runner
+# rather than sourcing common.sh.
+#
+# Pure harness test: no smolvm binary, no VM, no network.
+#
+
+set -uo pipefail
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+TESTS_RUN=0; TESTS_PASSED=0; TESTS_FAILED=0; FAILED_TESTS=()
+
+run_test() {
+    local test_name="$1" test_func="$2" output
+    TESTS_RUN=$((TESTS_RUN + 1))
+    echo -e "${YELLOW}[TEST]${NC} $test_name"
+    if output=$($test_func 2>&1); then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "${GREEN}[PASS]${NC} $test_name"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        FAILED_TESTS+=("$test_name")
+        echo -e "${RED}[FAIL]${NC} $test_name"
+        [[ -n "$output" ]] && echo "$output" | sed 's/^/    /'
+    fi
+}
+
+# Write a probe suite that sources common.sh, and run it as a subprocess.
+# Prints its output; returns its exit status.
+run_probe() {
+    local body="$1"
+    local probe
+    probe="$(mktemp "${TMPDIR:-/tmp}/smolvm-probe-XXXXXX.sh")"
+    {
+        echo "source \"$TESTS_DIR/common.sh\""
+        echo "$body"
+    } > "$probe"
+    # Strip ANSI colors: print_summary wraps its counts in escapes, so a literal
+    # "Tests passed: 2" would never match.
+    bash "$probe" 2>&1 | sed $'s/\033\\[[0-9;]*m//g'
+    local rc=${PIPESTATUS[0]}
+    rm -f "$probe"
+    return $rc
+}
+
+# Deliberately WITHOUT `|| true`: this is the case the counter fix enables. Before
+# it, the suite died inside log_pass on the first pass, so only one test ran.
+test_all_passing_tests_run() {
+    local output rc=0
+    output=$(run_probe '
+t_ok() { return 0; }
+run_test "first" t_ok
+run_test "second" t_ok
+run_test "third" t_ok
+print_summary "Probe"
+') || rc=$?
+
+    if [[ $rc -ne 0 ]]; then
+        echo "probe exited $rc, want 0"
+        echo "$output"
+        return 1
+    fi
+    if ! grep -q "Tests run:    3" <<<"$output"; then
+        echo "expected all 3 tests to run; got:"
+        echo "$output"
+        return 1
+    fi
+    return 0
+}
+
+# A failing test makes run_test return 1 by design, so suites carry it past that
+# with `|| true` — the idiom 338 of the 345 call sites in tests/ already use.
+test_failing_test_is_counted_without_aborting() {
+    local output rc=0
+    output=$(run_probe '
+t_ok() { return 0; }
+t_bad() { return 1; }
+run_test "passes" t_ok || true
+run_test "fails" t_bad || true
+run_test "also passes" t_ok || true
+print_summary "Probe"
+') || rc=$?
+
+    # A suite with a failure must still exit non-zero...
+    if [[ $rc -eq 0 ]]; then
+        echo "probe exited 0, want non-zero for a suite containing a failure"
+        return 1
+    fi
+    # ...but every test must have run, and the counts must be right.
+    local expect
+    for expect in "Tests run:    3" "Tests passed: 2" "Tests failed: 1"; do
+        if ! grep -q "$expect" <<<"$output"; then
+            echo "missing '$expect' in summary:"
+            echo "$output"
+            return 1
+        fi
+    done
+    return 0
+}
+
+# run_with_timeout polls in a loop whose counter also starts at zero.
+test_run_with_timeout_survives_its_poll_counter() {
+    local output rc=0
+    output=$(run_probe '
+run_with_timeout 10 sleep 2
+echo "REACHED_AFTER_TIMEOUT_HELPER"
+') || rc=$?
+
+    if [[ $rc -ne 0 ]]; then
+        echo "probe exited $rc, want 0"
+        echo "$output"
+        return 1
+    fi
+    if ! grep -q "REACHED_AFTER_TIMEOUT_HELPER" <<<"$output"; then
+        echo "run_with_timeout aborted the shell before returning:"
+        echo "$output"
+        return 1
+    fi
+    return 0
+}
+
+# A suite that skips its setup reports "no tests ran" rather than failing.
+test_empty_suite_is_not_a_failure() {
+    local output rc=0
+    output=$(run_probe 'print_summary "Probe"') || rc=$?
+
+    if [[ $rc -ne 0 ]]; then
+        echo "an empty suite should exit 0, got $rc"
+        echo "$output"
+        return 1
+    fi
+    return 0
+}
+
+echo ""
+echo "=========================================="
+echo "  Test Harness Tests"
+echo "=========================================="
+echo ""
+
+run_test "All passing tests run" test_all_passing_tests_run
+run_test "Failing test is counted without aborting" test_failing_test_is_counted_without_aborting
+run_test "run_with_timeout survives its poll counter" test_run_with_timeout_survives_its_poll_counter
+run_test "Empty suite is not a failure" test_empty_suite_is_not_a_failure
+
+echo ""
+echo "=========================================="
+echo "  Test Harness Tests Summary"
+echo "=========================================="
+echo ""
+echo "Tests run:    $TESTS_RUN"
+echo -e "Tests passed: ${GREEN}$TESTS_PASSED${NC}"
+echo -e "Tests failed: ${RED}$TESTS_FAILED${NC}"
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    echo ""
+    echo -e "${RED}Failed tests:${NC}"
+    printf "  ${RED}✗${NC} %s\n" "${FAILED_TESTS[@]}"
+    exit 1
+fi
+echo ""
+echo -e "${GREEN}All tests passed!${NC}"


### PR DESCRIPTION
Switches the test harness counters to arithmetic expansion, so a suite that doesn't use the `run_test … || true` idiom no longer dies at its first passing test.

## Why

`tests/common.sh` sets `set -euo pipefail` and increments its counters with `((x++))`. The arithmetic command yields the value of the expression as its exit status, and post-increment evaluates to the *old* value — 0 on the first increment of a zero-initialized counter. `set -e` then kills the suite inside `log_pass`, immediately after the `[PASS]` line.

338 of the 345 `run_test` call sites in `tests/` are written `run_test "name" fn || true`, and `set -e` is suspended for the entire duration of a command in an `||` list, including inside the functions it calls. That idiom is what keeps the suite directory working.

The exception is **`tests/test_pack_registry.sh:271-277`**, which omits it and so stops after its first passing test, reporting 1 of 7. A new suite written the obvious way hits the same wall, and the failure looks like the feature under test rather than the harness.

## How

Three counters become `X=$((X + 1))`, whose exit status doesn't depend on the value. Correctness no longer rests on an undocumented calling convention.

`run_with_timeout`'s poll counter gets the same treatment for consistency — same shape, but I could **not** get it to abort (`run_with_timeout 10 sleep 3` completes and exits 0 against the unmodified file), so that one is latent rather than live. Flagging that rather than claiming a fix I can't demonstrate.

The `|| true` at existing call sites is deliberately left alone: it's harmless, and it still carries a suite past a genuinely *failing* test, which is what it's actually for. This PR doesn't change `run_test`'s contract.

## Alternatives considered

**`((x++)) || true`** — the patch already applied piecemeal at `common.sh:315` and `393-406`. It works, but it keeps the hazard in the file and reads as incidental noise. The assignment form states the intent and can't regress.

**Documenting the `|| true` requirement instead** — leaves a footgun whose failure mode is actively misleading: a green-looking `[PASS]` followed by silent truncation.

**Fixing `tests/test_pack_registry.sh` to use the idiom** — treats the symptom in one suite and leaves the next author to rediscover it.

Same `((x++))` shape also exists at `tests/test_scale.sh:52,60,70` (`start_fails`, `running`, `exec_pass`, all zero-initialized). Not touched here — different suite, and I haven't confirmed those abort in practice. Happy to take them in a follow-up.

## Validation

`./tests/test_harness.sh` — **4/4 pass** with the fix, **1/4 fails without it** (verified by stashing the `common.sh` change and re-running). No smolvm binary, no VM, no network.

Probe suites run as subprocesses and the assertions read their output, so they hold regardless of what the harness does in-process. Coverage:

- a suite written **without** `|| true` runs all three of its tests — the case the fix enables, and the one that fails against unmodified `common.sh`
- a failing test is still counted and still reported by `print_summary` (pins the contract the fix must not change)
- `run_with_timeout` returns without aborting its caller
- an empty suite is still "no tests ran", not a failure

Fixes #873.
