### PR TITLE
Dial the expose-socket app inside the workload container's mount namespace

### DIFF
--- a/crates/smolvm-agent/Cargo.toml
+++ b/crates/smolvm-agent/Cargo.toml
@@ -43,7 +43,10 @@ zstd = "0.13"
 
 # Linux-specific dependencies for vsock
 [target.'cfg(target_os = "linux")'.dependencies]
-nix = { version = "0.27", features = ["socket", "fs"] }
+# "uio" carries sendmsg/recvmsg and the SCM_RIGHTS control-message types, which
+# the ns-file `connect` op uses to hand a descriptor back out of the container's
+# mount namespace. "socket" alone does not enable them.
+nix = { version = "0.27", features = ["socket", "fs", "uio"] }
 # The new mount API (fsopen/fsconfig/fsmount/move_mount) for overlay mounts — lets
 # us append each lower layer via `lowerdir+` instead of shelling out to `mount(8)`,
 # whose `-o lowerdir=` value is capped at ~255 bytes. Already in the workspace lock.

--- a/crates/smolvm-agent/src/nsfile.rs
+++ b/crates/smolvm-agent/src/nsfile.rs
@@ -89,6 +89,7 @@ pub fn run_helper() -> i32 {
     let result = match op {
         "read" => helper_read(&path),
         "write" => helper_write(&path, mode, uid, gid),
+        "connect" => helper_connect(&path),
         _ => Err("unknown op".to_string()),
     };
     match result {
@@ -208,6 +209,43 @@ fn helper_write(
     out.write_all(b"OK\n").map_err(|e| e.to_string())?;
     out.flush().map_err(|e| e.to_string())?;
     Ok(())
+}
+
+/// Dial a Unix socket inside the container and hand the connected descriptor
+/// back to the parent over stdin, which the parent made a socketpair.
+///
+/// Only the *connect* needs the container's namespace: once the socket is
+/// established the path is spent, so the parent relays over an ordinary
+/// `UnixStream` with no namespace involvement. That is why a descriptor is
+/// passed rather than the helper proxying bytes — no extra hop in the data path,
+/// and no second process alive for the life of the connection.
+#[cfg(target_os = "linux")]
+fn helper_connect(path: &str) -> Result<(), String> {
+    use std::io::IoSlice;
+    use std::os::unix::io::AsRawFd;
+    use std::os::unix::net::UnixStream;
+
+    let app = UnixStream::connect(path).map_err(|e| format!("connect {path}: {e}"))?;
+
+    // One byte of payload: SCM_RIGHTS needs a non-empty iovec to travel, and it
+    // doubles as the parent's "the fd is coming" signal.
+    let fds = [app.as_raw_fd()];
+    let cmsg = [nix::sys::socket::ControlMessage::ScmRights(&fds)];
+    let iov = [IoSlice::new(b"K")];
+    nix::sys::socket::sendmsg::<()>(
+        std::io::stdin().as_raw_fd(),
+        &iov,
+        &cmsg,
+        nix::sys::socket::MsgFlags::empty(),
+        None,
+    )
+    .map_err(|e| format!("send fd for {path}: {e}"))?;
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn helper_connect(_path: &str) -> Result<(), String> {
+    Err("mount namespaces are Linux-only".to_string())
 }
 
 // ===========================================================================
@@ -378,6 +416,93 @@ fn write_via_helper<R: std::io::Read>(
         .to_string())
 }
 
+/// Connect to a Unix socket at `path` inside the workload container.
+///
+/// `None` means "no single running workload" — the caller keeps whatever it does
+/// in the agent's own namespace. Used by the `--expose-socket` bridge, whose app
+/// socket lives in the container's mount namespace on an `--image` machine (a
+/// private tmpfs `/run`, or the container rootfs) and therefore does not resolve
+/// for the agent at all.
+#[cfg(target_os = "linux")]
+pub fn connect_in_container(path: &str) -> Option<Result<std::os::unix::net::UnixStream, String>> {
+    let pid = workload_container_pid()?;
+    Some(connect_via_helper(pid, path))
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn connect_in_container(_path: &str) -> Option<Result<std::os::unix::net::UnixStream, String>> {
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn connect_via_helper(pid: u32, path: &str) -> Result<std::os::unix::net::UnixStream, String> {
+    use std::io::IoSliceMut;
+    use std::os::unix::io::{AsRawFd, FromRawFd, OwnedFd};
+    use std::os::unix::net::UnixStream;
+
+    // The helper returns the descriptor over SCM_RIGHTS, which needs a socket
+    // rather than a pipe — so its stdin is one end of a socketpair instead of
+    // the pipe `read`/`write` use.
+    let (ours, theirs) =
+        UnixStream::pair().map_err(|e| format!("socketpair for ns-file connect: {e}"))?;
+    let child = Command::new(AGENT_BINARY)
+        .args([HELPER_ARG, "connect", &pid.to_string(), path])
+        .stdin(Stdio::from(OwnedFd::from(theirs)))
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| format!("spawn ns-file helper: {e}"))?;
+
+    let mut byte = [0u8; 1];
+    let mut iov = [IoSliceMut::new(&mut byte)];
+    let mut cmsg_buf = nix::cmsg_space!(std::os::unix::io::RawFd);
+    let received = nix::sys::socket::recvmsg::<()>(
+        ours.as_raw_fd(),
+        &mut iov,
+        Some(&mut cmsg_buf),
+        nix::sys::socket::MsgFlags::empty(),
+    );
+
+    let mut app_fd = None;
+    if let Ok(msg) = received {
+        for cmsg in msg.cmsgs() {
+            if let nix::sys::socket::ControlMessageOwned::ScmRights(fds) = cmsg {
+                // SAFETY: SCM_RIGHTS installed these descriptors in this process,
+                // which owns them from here. Exactly one is expected; close any
+                // extra rather than leak it.
+                for (i, fd) in fds.iter().enumerate() {
+                    let owned = unsafe { OwnedFd::from_raw_fd(*fd) };
+                    if i == 0 {
+                        app_fd = Some(owned);
+                    }
+                }
+            }
+        }
+    }
+
+    // The helper is short-lived either way; reap it before reporting.
+    let output = child.wait_with_output();
+    match app_fd {
+        Some(fd) => Ok(UnixStream::from(fd)),
+        None => {
+            let reply = output
+                .as_ref()
+                .map(|o| String::from_utf8_lossy(&o.stdout).trim_end().to_string())
+                .unwrap_or_default();
+            Err(reply
+                .strip_prefix("ERR ")
+                .unwrap_or_else(|| {
+                    if reply.is_empty() {
+                        "ns-file helper sent no descriptor"
+                    } else {
+                        &reply
+                    }
+                })
+                .to_string())
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -395,5 +520,38 @@ mod tests {
         for bad in ["", "ERR boom", "OKAY", "ERR "] {
             assert_ne!(bad.trim_end(), "OK", "{bad:?} must not look like success");
         }
+    }
+
+    #[test]
+    fn connect_reports_an_error_when_no_descriptor_arrives() {
+        // The connect op signals success by SENDING A DESCRIPTOR, not by a reply
+        // string, so "nothing came back" is the failure the parent must name
+        // rather than treat as an empty-but-fine result. Mirrors the fallback in
+        // `connect_via_helper` when `app_fd` is None and stdout was empty.
+        let reply = "";
+        let msg = reply
+            .strip_prefix("ERR ")
+            .unwrap_or(if reply.is_empty() {
+                "ns-file helper sent no descriptor"
+            } else {
+                reply
+            })
+            .to_string();
+        assert!(
+            !msg.is_empty(),
+            "a missing descriptor must produce a reason"
+        );
+        assert!(msg.contains("no descriptor"));
+    }
+
+    #[test]
+    fn connect_surfaces_the_helper_error_text() {
+        // A failed in-container dial reports through stdout like the other ops.
+        let reply = "ERR connect /run/control/app.sock: No such file or directory";
+        let msg = reply.strip_prefix("ERR ").unwrap_or(reply);
+        assert_eq!(
+            msg,
+            "connect /run/control/app.sock: No such file or directory"
+        );
     }
 }

--- a/crates/smolvm-agent/src/publish_socket.rs
+++ b/crates/smolvm-agent/src/publish_socket.rs
@@ -139,8 +139,6 @@ fn inject_sockets_into_container(spec: &mut crate::oci::OciSpec, sockets: &[Publ
 /// socket and relay. Mirrors the Docker bridge but with a caller-supplied path.
 #[cfg(target_os = "linux")]
 fn serve_expose(sock: &PublishedSocket) -> io::Result<()> {
-    use std::os::unix::net::UnixStream;
-
     let listener = crate::vsock::VsockListener::bind(sock.vsock_port)?;
     tracing::info!(
         vsock_port = sock.vsock_port,
@@ -161,7 +159,7 @@ fn serve_expose(sock: &PublishedSocket) -> io::Result<()> {
         let guest_path = sock.guest_path.clone();
         thread::Builder::new()
             .name("expose-sock-fwd".into())
-            .spawn(move || match UnixStream::connect(&guest_path) {
+            .spawn(move || match dial_app(&guest_path) {
                 Ok(app) => {
                     if let Err(e) = relay(host_conn, app) {
                         tracing::debug!(error = %e, "expose-socket relay ended");
@@ -177,6 +175,45 @@ fn serve_expose(sock: &PublishedSocket) -> io::Result<()> {
                 ),
             })
             .ok();
+    }
+}
+
+/// Dial the app's socket, in the agent's namespace first and the workload
+/// container's second.
+///
+/// The agent runs in the VM root mount namespace; on an `--image` machine the
+/// workload runs under crun with its own, including a private tmpfs `/run`. A
+/// socket the app binds at `/run/control/app.sock` therefore does not exist for
+/// the agent, and the bridge accepted the host connection and then had nothing
+/// to relay to — the host client hung until it timed out.
+///
+/// Root namespace is tried FIRST so the cases that already work keep their exact
+/// behavior and cost: a bare VM, and a socket bound inside a `--volume` share,
+/// which is bind-mounted identically in both namespaces. The container is a
+/// fallback, and only when there is exactly one running workload to be
+/// unambiguous about — with none or several, this is just the old behavior.
+#[cfg(target_os = "linux")]
+fn dial_app(guest_path: &str) -> io::Result<std::os::unix::net::UnixStream> {
+    use std::os::unix::net::UnixStream;
+
+    let agent_ns_err = match UnixStream::connect(guest_path) {
+        Ok(app) => return Ok(app),
+        Err(e) => e,
+    };
+    match crate::nsfile::connect_in_container(guest_path) {
+        Some(Ok(app)) => {
+            tracing::debug!(
+                guest_path = %guest_path,
+                "expose-socket: dialed the app socket in the workload container's namespace"
+            );
+            Ok(app)
+        }
+        // Report the container attempt: with a workload running, that is the
+        // namespace the path was meant for, so its error is the informative one.
+        Some(Err(e)) => Err(io::Error::other(e)),
+        // No single running workload — nothing was tried beyond the root
+        // namespace, so that error is the whole story.
+        None => Err(agent_ns_err),
     }
 }
 


### PR DESCRIPTION
Dials the `--expose-socket` app socket inside the workload container's mount namespace, so an `--image` machine delivers instead of leaving the host client hung.

> **Validated end-to-end on Linux** — see [the results comment](#issuecomment) for the full before/after matrix. Stock 1.7.4 delivers zero bytes on the container case; patched returns the payload. The bare-VM and `--volume` cases are unchanged by the patch, which is what the root-namespace-first ordering guarantees.

## Why

The agent runs in the VM's root mount namespace. On an `--image` machine the workload runs under crun with its own — including a private tmpfs `/run` and the container rootfs. A socket the app binds at `/run/control/app.sock` doesn't resolve for the agent at all, so `serve_expose` accepted the host connection and then had nothing to relay to.

That's the reported symptom exactly: the connect to `HOST_PATH` succeeds (accept backlog), `recv` times out with zero bytes, and `/proc/net/unix` inside the guest shows the listener plainly alive. Path resolution, not listener liveness.

## How

A `connect` op on the existing ns-file helper, reusing the `setns` machinery already there for the files API — a single-threaded re-exec of the agent binary, dispatched before the async runtime starts because `setns(CLONE_NEWMNT)` is refused for a multithreaded caller. No new marker and no new dispatch in `main`: the helper already takes an `<op>`.

Only the *connect* needs the container's namespace. Once the socket is established the path is spent, so the helper hands the connected descriptor back over `SCM_RIGHTS` and the parent relays over an ordinary `UnixStream`. No extra hop in the data path and no second process alive for the life of the connection. The helper's stdin is one end of a socketpair rather than the pipe `read`/`write` use, because control messages need a socket.

`dial_app` tries the **root namespace first**, so the two cases that already work keep their exact behavior and cost — a bare VM, and a socket bound inside a `--volume` share, which is bind-mounted identically in both namespaces. The container is a fallback, and only when `workload_container_pid` finds exactly one running workload; with none or several it declines to guess, which is pre-existing behavior and leaves this the old code path.

`nix` gains the `uio` feature — `sendmsg`/`recvmsg` and the `SCM_RIGHTS` control-message types live behind it, and `socket` alone doesn't enable them.

## Alternatives considered

**Proxy the bytes through the helper** instead of passing the descriptor — simpler to write, but puts a second process and two extra copies in the data path for the life of every connection, on a bridge whose entire job is relaying.

**Resolve the container's rootfs from outside and join paths** (`<overlay>/merged/<path>`) — this is the approach `nsfile`'s module docs already reject, and for a reason that applies here too: a planted symlink inside the container could redirect the dial outside it. Resolving inside the namespace makes containment the kernel's job.

**Try the container namespace first** — would have made the fallback the common path and put a re-exec on every connection for the bare-VM and volume cases that work today. Root-first keeps those byte-identical.

## Validation

**Done:**
- `cargo check -p smolvm-agent --target aarch64-unknown-linux-musl` — clean (the guest target)
- `cargo check -p smolvm-agent` on macOS — clean (the non-Linux cfg path still compiles)
- `cargo clippy … -D warnings` on the musl target — no findings in `nsfile.rs` or `publish_socket.rs`. Two pre-existing `libc::time_t` deprecations in `main.rs:195` and `timesync.rs:82` are unrelated and also present on unmodified `main`.
- `cargo test -p smolvm-agent --bins nsfile` — 4/4 pass. Thin by necessity: they cover the helper-dispatch marker and the connect error paths. `nix` is a Linux-only dependency here, so the `SCM_RIGHTS` round-trip can't be exercised on macOS at all.

**Done on Linux** (Lambda A10, Ubuntu 22.04 x86_64, KVM; smolvm 1.7.4 release install with only the guest agent swapped, built `x86_64-unknown-linux-musl` / `release-small` from `7dd13bb`):

| Case | Stock 1.7.4 | Patched |
|---|---|---|
| `--image`, socket under container-private `/run` | **zero bytes** ❌ | `GUEST-CTR:ping` ✅ |
| Bare VM, root namespace | `GUEST-BARE:ping` ✅ | `GUEST-BARE:ping` ✅ |
| `--image`, socket in a `--volume` share | `GUEST-VOL:ping` ✅ | `GUEST-VOL:ping` ✅ |

One deviation from the report: the failing case surfaces as an immediate empty read rather than a 5s timeout. Same defect, different observable — noted in the results comment so nobody waits for a hang that doesn't come.

Fixes #866.
