### PR TITLE
Add the k3s deployment for the smolvm Kubernetes runtime, without clobbering existing containerd config

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,48 @@
+# Deploying smolvm as a Kubernetes runtime
+
+smolvm is a **containerd shim v2** CRI runtime (`io.containerd.smolvm.v2`): every
+pod sandbox boots as its own microVM (the Kata/Firecracker model), so workloads
+get hardware-level isolation instead of a shared kernel.
+
+## Conformance status
+
+`critest` (cri-tools v1.31.1) on the reference node: **82 Passed / 7 Failed /
+24 Skipped** of 113 — at or above the runc baseline (79 passed) on the same host.
+
+The 7 remaining failures are the boundary of *any* VM-based runtime and fail for
+Kata / Firecracker / gVisor too:
+
+| failing test(s) | why a microVM can't pass it |
+| --- | --- |
+| `portforward` ×2 | containerd's portforward dials `127.0.0.1` in the pod netns; the workload listens inside the VM at the pod IP. Needs a sandbox-controller portforward path (planned). |
+| `HostNetwork`, `HostIpc` | a microVM has its own kernel — it cannot share the host's network / IPC namespace. |
+| mount propagation `rprivate` / `rshared` / `rslave` | bidirectional mount propagation across the VM boundary is not possible with a separate guest kernel. |
+
+These are intentional isolation trade-offs, not defects.
+
+## Quick start (k3s)
+
+```sh
+# 1. install the runtime into k3s (idempotent, version-robust)
+sudo deploy/k3s/install-smolvm-k3s.sh
+
+# 2. prove it end-to-end (deploy a pod as a microVM, check logs + exec)
+sudo deploy/k3s/e2e-test.sh
+```
+
+`install-smolvm-k3s.sh` wires the shim into k3s's embedded containerd by reading
+k3s's *generated* config to find the exact CRI plugin path, exports the shim's
+runtime env to k3s, drops the shim onto containerd's PATH, writes a
+`config.toml.tmpl`, registers the `smolvm` RuntimeClass, and labels nodes.
+
+## Manifests
+
+- [`kubernetes/runtimeclass.yaml`](kubernetes/runtimeclass.yaml) — the `smolvm` RuntimeClass.
+- [`kubernetes/example-pod.yaml`](kubernetes/example-pod.yaml) — a smoke pod (`runtimeClassName: smolvm`).
+
+## Prerequisites
+
+The smolvm runtime payload must be installed on each node under
+`$SMOLVM_DATA_DIR` (default `/var/lib/smolvm`): the musl `agent-rootfs`, the
+`smolvm-vmm` boot helper, `lib/` (libkrun), and the `containerd-shim-smolvm-v2`
+binary on `PATH`. A Linux host with KVM (`/dev/kvm`) is required.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -23,14 +23,26 @@ These are intentional isolation trade-offs, not defects.
 ## Quick start (k3s)
 
 ```sh
-# 1. install the runtime into k3s (idempotent, version-robust)
+# 1. install the runtime into k3s (re-runnable, version-robust)
 sudo deploy/k3s/install-smolvm-k3s.sh
 
 # 2. prove it end-to-end (deploy a pod as a microVM, check logs + exec)
 sudo deploy/k3s/e2e-test.sh
+
+# to unwire it again (leaves the payload in place)
+sudo deploy/k3s/uninstall-smolvm-k3s.sh
 ```
 
-`install-smolvm-k3s.sh` wires the shim into k3s's embedded containerd by reading
+**Re-run the installer after a k3s upgrade.** k3s keeps its bundled binaries in a
+content-addressed directory that `data/current` repoints to on every upgrade, so
+a shim symlinked into it is orphaned. The installer also pins the shim's
+directory on k3s's `PATH`, which is upgrade-durable, but re-running is the
+reliable fix if pods stop scheduling after an upgrade.
+
+`install-smolvm-k3s.sh` is safe to re-run: it backs up and appends to an existing
+`config.toml.tmpl` rather than overwriting it (that file is where registry
+mirrors and private-registry auth live), and leaves k3s's enable/disable state
+alone. It wires the shim into k3s's embedded containerd by reading
 k3s's *generated* config to find the exact CRI plugin path, exports the shim's
 runtime env to k3s, drops the shim onto containerd's PATH, writes a
 `config.toml.tmpl`, registers the `smolvm` RuntimeClass, and labels nodes.

--- a/deploy/k3s/e2e-test.sh
+++ b/deploy/k3s/e2e-test.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# End-to-end validation: a Pod scheduled onto the smolvm runtime boots as a
+# microVM, runs, streams logs, and accepts exec — through the real k3s/k8s API.
+# Run AFTER install-smolvm-k3s.sh.
+#
+#   sudo ./e2e-test.sh
+#
+# Exits non-zero (and prints why) on any failure, so it can gate CI / a demo.
+set -euo pipefail
+HERE=$(cd "$(dirname "$0")" && pwd)
+K="k3s kubectl"
+POD=smolvm-hello
+
+fail() { echo "E2E FAIL: $*" >&2; $K describe pod "$POD" 2>/dev/null | tail -20 >&2 || true; exit 1; }
+
+echo "==> RuntimeClass 'smolvm' registered?"
+$K get runtimeclass smolvm >/dev/null 2>&1 || fail "RuntimeClass smolvm missing (run install-smolvm-k3s.sh)"
+
+echo "==> deploying the smolvm pod"
+$K delete pod "$POD" --ignore-not-found --wait=true >/dev/null 2>&1 || true
+$K apply -f "$HERE/../kubernetes/example-pod.yaml" >/dev/null
+
+echo "==> waiting for Ready (microVM boot)"
+$K wait --for=condition=Ready "pod/$POD" --timeout=150s || fail "pod never became Ready"
+
+echo "==> the pod really runs on the smolvm runtime handler"
+RC=$($K get "pod/$POD" -o jsonpath='{.spec.runtimeClassName}')
+[ "$RC" = smolvm ] || fail "pod runtimeClassName is '$RC', expected smolvm"
+
+echo "==> logs show the workload ran inside a VM kernel"
+LOGS=$($K logs "$POD")
+echo "$LOGS" | sed 's/^/    /'
+echo "$LOGS" | grep -q SMOLVM_K8S_E2E_OK || fail "expected marker not in logs"
+echo "$LOGS" | grep -qi "kernel:" || fail "no kernel line in logs"
+
+echo "==> exec into the running microVM"
+UID_OUT=$($K exec "$POD" -- id 2>/dev/null) || fail "kubectl exec failed"
+echo "    exec id -> $UID_OUT"
+echo "$UID_OUT" | grep -q "uid=" || fail "exec did not return a valid id"
+
+echo "==> tearing the pod (microVM) down"
+$K delete pod "$POD" --wait=true >/dev/null
+
+echo
+echo "E2E PASS: smolvm pod booted as a microVM, ran, logged, exec'd, and tore down cleanly via k3s."

--- a/deploy/k3s/install-smolvm-k3s.sh
+++ b/deploy/k3s/install-smolvm-k3s.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Install smolvm as a k3s container runtime (RuntimeClass "smolvm").
+#
+# Wires the smolvm containerd shim v2 into k3s's embedded containerd so pods with
+# `runtimeClassName: smolvm` boot as per-workload microVMs. Version-robust: it
+# reads k3s's *generated* containerd config to find the exact CRI plugin path
+# (containerd 1.x and 2.x differ) instead of hardcoding it.
+#
+# Prereqs: k3s installed, and the smolvm runtime payload present under
+# $SMOLVM_DATA_DIR (agent-rootfs, smolvm-vmm boot helper, lib/, and the shim
+# binary on PATH). See docs/kubernetes-runtime.md for building the payload.
+#
+#   sudo ./install-smolvm-k3s.sh
+#   sudo k3s kubectl apply -f ../kubernetes/example-pod.yaml   # e2e smoke test
+set -euo pipefail
+
+SMOLVM_DATA_DIR=${SMOLVM_DATA_DIR:-/var/lib/smolvm}
+SHIM=${SHIM:-/usr/local/bin/containerd-shim-smolvm-v2}
+K3S_CTD_DIR=/var/lib/rancher/k3s/agent/etc/containerd
+HERE=$(cd "$(dirname "$0")" && pwd)
+
+[ "$(id -u)" = 0 ] || { echo "run as root (sudo)"; exit 1; }
+command -v k3s >/dev/null || { echo "k3s not found on PATH"; exit 1; }
+
+echo "==> verifying smolvm runtime payload"
+for f in "$SHIM" "$SMOLVM_DATA_DIR/agent-rootfs" "$SMOLVM_DATA_DIR/smolvm-vmm" "$SMOLVM_DATA_DIR/lib"; do
+  [ -e "$f" ] || { echo "  MISSING: $f — install the smolvm runtime payload first"; exit 1; }
+done
+
+echo "==> exporting the shim's env to k3s (the shim inherits k3s -> containerd env)"
+mkdir -p /etc/systemd/system/k3s.service.d
+cat > /etc/systemd/system/k3s.service.d/smolvm.conf <<EOF
+[Service]
+Environment=SMOLVM_DATA_DIR=$SMOLVM_DATA_DIR
+Environment=SMOLVM_AGENT_ROOTFS=$SMOLVM_DATA_DIR/agent-rootfs
+Environment=SMOLVM_BOOT_BINARY=$SMOLVM_DATA_DIR/smolvm-vmm
+Environment=SMOLVM_LIB_DIR=$SMOLVM_DATA_DIR/lib
+EOF
+systemctl daemon-reload
+
+echo "==> ensuring k3s is up and has generated its base containerd config"
+systemctl enable --now k3s
+for _ in $(seq 1 60); do [ -f "$K3S_CTD_DIR/config.toml" ] && break; sleep 2; done
+CFG="$K3S_CTD_DIR/config.toml"
+[ -f "$CFG" ] || { echo "  k3s did not generate $CFG"; exit 1; }
+
+echo "==> detecting the CRI runtimes plugin path k3s uses"
+# e.g. [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc]  (ctd 2.x)
+#  or  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]     (ctd 1.x)
+RUNC_HDR=$(grep -E '\.containerd\.runtimes\.runc\]\s*$' "$CFG" | head -1)
+[ -n "$RUNC_HDR" ] || { echo "  couldn't find the runc runtimes block in $CFG"; exit 1; }
+SMOLVM_HDR=${RUNC_HDR/.runtimes.runc]/.runtimes.smolvm]}
+echo "    runc:   $RUNC_HDR"
+echo "    smolvm: $SMOLVM_HDR"
+
+echo "==> writing k3s containerd template (base + smolvm runtime, no [options])"
+# NB: we deliberately omit the runc-style [...options] sub-table — those options
+# (BinaryName/SystemdCgroup) crash our shim; the smolvm shim takes none.
+cat > "$K3S_CTD_DIR/config.toml.tmpl" <<EOF
+{{ template "base" . }}
+
+$SMOLVM_HDR
+  runtime_type = "io.containerd.smolvm.v2"
+EOF
+
+echo "==> putting the shim on k3s containerd's PATH"
+if [ -d /var/lib/rancher/k3s/data/current/bin ]; then
+  ln -sf "$SHIM" /var/lib/rancher/k3s/data/current/bin/containerd-shim-smolvm-v2
+fi
+
+echo "==> restarting k3s to apply the template"
+systemctl restart k3s
+for _ in $(seq 1 60); do k3s kubectl get --raw='/readyz' >/dev/null 2>&1 && break; sleep 2; done
+
+echo "==> labelling nodes + applying the smolvm RuntimeClass"
+k3s kubectl label node --all smolvm-runtime=true --overwrite
+k3s kubectl apply -f "$HERE/../kubernetes/runtimeclass.yaml"
+
+cat <<EOF
+
+smolvm is installed as a k3s runtime.
+  Smoke test:  sudo k3s kubectl apply -f $HERE/../kubernetes/example-pod.yaml
+               sudo k3s kubectl wait --for=condition=Ready pod/smolvm-hello --timeout=120s
+               sudo k3s kubectl logs smolvm-hello   # expect SMOLVM_K8S_E2E_OK + a VM kernel
+EOF

--- a/deploy/k3s/install-smolvm-k3s.sh
+++ b/deploy/k3s/install-smolvm-k3s.sh
@@ -35,11 +35,18 @@ Environment=SMOLVM_DATA_DIR=$SMOLVM_DATA_DIR
 Environment=SMOLVM_AGENT_ROOTFS=$SMOLVM_DATA_DIR/agent-rootfs
 Environment=SMOLVM_BOOT_BINARY=$SMOLVM_DATA_DIR/smolvm-vmm
 Environment=SMOLVM_LIB_DIR=$SMOLVM_DATA_DIR/lib
+# containerd resolves the shim binary off PATH. Pinning it here (rather than
+# only symlinking into k3s's data dir) is what makes the install survive a k3s
+# upgrade: that data dir is content-addressed and repoints on every upgrade,
+# orphaning anything we linked into it.
+Environment=PATH=$(dirname "$SHIM"):/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 EOF
 systemctl daemon-reload
 
 echo "==> ensuring k3s is up and has generated its base containerd config"
-systemctl enable --now k3s
+# Start k3s if it is down, but leave its enable/disable state as the operator
+# set it — installing a runtime should not silently make k3s boot-persistent.
+systemctl is-active --quiet k3s || systemctl start k3s
 for _ in $(seq 1 60); do [ -f "$K3S_CTD_DIR/config.toml" ] && break; sleep 2; done
 CFG="$K3S_CTD_DIR/config.toml"
 [ -f "$CFG" ] || { echo "  k3s did not generate $CFG"; exit 1; }
@@ -47,7 +54,7 @@ CFG="$K3S_CTD_DIR/config.toml"
 echo "==> detecting the CRI runtimes plugin path k3s uses"
 # e.g. [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc]  (ctd 2.x)
 #  or  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]     (ctd 1.x)
-RUNC_HDR=$(grep -E '\.containerd\.runtimes\.runc\]\s*$' "$CFG" | head -1)
+RUNC_HDR=$(grep -E '\.containerd\.runtimes\.runc\][[:space:]]*$' "$CFG" | head -1)
 [ -n "$RUNC_HDR" ] || { echo "  couldn't find the runc runtimes block in $CFG"; exit 1; }
 SMOLVM_HDR=${RUNC_HDR/.runtimes.runc]/.runtimes.smolvm]}
 echo "    runc:   $RUNC_HDR"
@@ -56,21 +63,45 @@ echo "    smolvm: $SMOLVM_HDR"
 echo "==> writing k3s containerd template (base + smolvm runtime, no [options])"
 # NB: we deliberately omit the runc-style [...options] sub-table — those options
 # (BinaryName/SystemdCgroup) crash our shim; the smolvm shim takes none.
-cat > "$K3S_CTD_DIR/config.toml.tmpl" <<EOF
-{{ template "base" . }}
+#
+# config.toml.tmpl is where operators put registry mirrors, private-registry
+# auth and other runtimes, so it is NOT ours to overwrite. If one already exists
+# and is not ours, append to a copy of it and keep a timestamped backup; a lost
+# mirror config breaks image pulls cluster-wide and the cause is hard to trace.
+TMPL="$K3S_CTD_DIR/config.toml.tmpl"
+SMOLVM_BLOCK="$SMOLVM_HDR
+  runtime_type = \"io.containerd.smolvm.v2\""
 
-$SMOLVM_HDR
-  runtime_type = "io.containerd.smolvm.v2"
-EOF
+if [ ! -f "$TMPL" ]; then
+  printf '{{ template "base" . }}\n\n%s\n' "$SMOLVM_BLOCK" > "$TMPL"
+elif grep -qF 'runtimes.smolvm]' "$TMPL"; then
+  echo "    smolvm runtime already present in $TMPL — leaving it alone"
+else
+  BACKUP="$TMPL.pre-smolvm.$(date +%Y%m%d%H%M%S)"
+  cp -a "$TMPL" "$BACKUP"
+  echo "    existing template found — backed up to $BACKUP and appending"
+  printf '\n%s\n' "$SMOLVM_BLOCK" >> "$TMPL"
+fi
 
 echo "==> putting the shim on k3s containerd's PATH"
-if [ -d /var/lib/rancher/k3s/data/current/bin ]; then
-  ln -sf "$SHIM" /var/lib/rancher/k3s/data/current/bin/containerd-shim-smolvm-v2
+# PATH in the drop-in above is the durable mechanism. This symlink is a belt-and
+# -braces extra for k3s builds that ignore the inherited PATH — and it is NOT
+# durable: /var/lib/rancher/k3s/data/current is content-addressed and repoints on
+# every k3s upgrade, orphaning the link. Re-run this installer after upgrading.
+K3S_BIN=/var/lib/rancher/k3s/data/current/bin
+if [ -d "$K3S_BIN" ]; then
+  ln -sf "$SHIM" "$K3S_BIN/containerd-shim-smolvm-v2"
+else
+  echo "    note: $K3S_BIN not present; relying on the PATH set above" >&2
 fi
 
 echo "==> restarting k3s to apply the template"
 systemctl restart k3s
 for _ in $(seq 1 60); do k3s kubectl get --raw='/readyz' >/dev/null 2>&1 && break; sleep 2; done
+k3s kubectl get --raw='/readyz' >/dev/null 2>&1 || {
+  echo "  k3s did not become ready within 120s after restart; check: journalctl -u k3s -n50"
+  exit 1
+}
 
 echo "==> labelling nodes + applying the smolvm RuntimeClass"
 k3s kubectl label node --all smolvm-runtime=true --overwrite

--- a/deploy/k3s/uninstall-smolvm-k3s.sh
+++ b/deploy/k3s/uninstall-smolvm-k3s.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Remove smolvm as a k3s container runtime — the inverse of
+# install-smolvm-k3s.sh.
+#
+# The installer touches five places (systemd drop-in, containerd template, a shim
+# symlink, node labels, the RuntimeClass). Undoing that by hand is easy to get
+# wrong, and the two pieces most likely to be forgotten — the drop-in and the
+# template — are exactly the ones that break a later k3s reconfigure.
+#
+#   sudo ./uninstall-smolvm-k3s.sh
+#
+# Leaves the runtime payload under $SMOLVM_DATA_DIR and the shim binary alone;
+# this only unwires them from k3s.
+set -euo pipefail
+
+K3S_CTD_DIR=/var/lib/rancher/k3s/agent/etc/containerd
+TMPL="$K3S_CTD_DIR/config.toml.tmpl"
+DROPIN=/etc/systemd/system/k3s.service.d/smolvm.conf
+
+[ "$(id -u)" = 0 ] || { echo "run as root (sudo)"; exit 1; }
+
+echo "==> removing the RuntimeClass and node labels"
+if command -v k3s >/dev/null && k3s kubectl get --raw='/readyz' >/dev/null 2>&1; then
+  k3s kubectl delete runtimeclass smolvm --ignore-not-found >/dev/null || true
+  k3s kubectl label node --all smolvm-runtime- >/dev/null 2>&1 || true
+else
+  echo "    k3s not reachable — skipping cluster objects"
+fi
+
+echo "==> removing the smolvm runtime block from the containerd template"
+if [ -f "$TMPL" ]; then
+  # Restore the newest pre-smolvm backup when the installer made one (it only
+  # does so when a template already existed), otherwise strip just our block so
+  # any operator config in the file survives.
+  BACKUP=$(ls -1t "$TMPL".pre-smolvm.* 2>/dev/null | head -1 || true)
+  if [ -n "$BACKUP" ]; then
+    echo "    restoring $BACKUP"
+    mv "$BACKUP" "$TMPL"
+  else
+    # Drop the smolvm table header and its runtime_type line.
+    sed -i '/runtimes\.smolvm\]/,+1d' "$TMPL"
+    # A template that is now nothing but the base include is what k3s generates
+    # by default, so remove it rather than leave a no-op file behind.
+    if [ "$(grep -cvE '^[[:space:]]*($|\{\{ template "base" \. \}\})' "$TMPL")" = 0 ]; then
+      rm -f "$TMPL"
+      echo "    template held only the base include — removed"
+    fi
+  fi
+fi
+
+echo "==> removing the shim symlink and systemd drop-in"
+rm -f /var/lib/rancher/k3s/data/current/bin/containerd-shim-smolvm-v2
+rm -f "$DROPIN"
+rmdir /etc/systemd/system/k3s.service.d 2>/dev/null || true
+systemctl daemon-reload
+
+echo "==> restarting k3s to drop the runtime"
+if systemctl is-active --quiet k3s; then
+  systemctl restart k3s
+  for _ in $(seq 1 60); do k3s kubectl get --raw='/readyz' >/dev/null 2>&1 && break; sleep 2; done
+fi
+
+echo
+echo "smolvm unwired from k3s. The payload under /var/lib/smolvm and the shim binary were left in place."

--- a/deploy/kubernetes/example-pod.yaml
+++ b/deploy/kubernetes/example-pod.yaml
@@ -1,0 +1,36 @@
+# Minimal end-to-end smoke pod: runs inside a smolvm microVM via the RuntimeClass.
+#
+#   kubectl apply -f example-pod.yaml
+#   kubectl wait --for=condition=Ready pod/smolvm-hello --timeout=120s
+#   kubectl logs smolvm-hello        # -> SMOLVM_K8S_E2E_OK + `uname -a` from the guest
+#   kubectl exec smolvm-hello -- id  # exec into the microVM
+#
+# The `uname` line proves it's a real VM kernel (not the host); the pod is a
+# throwaway per-workload microVM torn down on delete.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: smolvm-hello
+  labels:
+    app: smolvm-hello
+spec:
+  runtimeClassName: smolvm
+  restartPolicy: Never
+  containers:
+    - name: hello
+      image: busybox:1.36
+      command: ["sh", "-c"]
+      args:
+        - |
+          echo "SMOLVM_K8S_E2E_OK"
+          echo "kernel: $(uname -sr)"
+          echo "whoami: $(id)"
+          # keep the pod alive so `kubectl exec` works during the e2e
+          sleep 3600
+      resources:
+        requests:
+          cpu: "250m"
+          memory: "128Mi"
+        limits:
+          cpu: "1"
+          memory: "512Mi"

--- a/deploy/kubernetes/runtimeclass.yaml
+++ b/deploy/kubernetes/runtimeclass.yaml
@@ -1,0 +1,23 @@
+# RuntimeClass that routes pods to the smolvm containerd shim v2, so each pod
+# sandbox boots as a real per-workload microVM (the Kata/Firecracker model).
+#
+#   kubectl apply -f runtimeclass.yaml
+#   # then set `runtimeClassName: smolvm` on any Pod (see example-pod.yaml)
+#
+# `handler` must match the containerd runtime name (config `...runtimes.smolvm`,
+# runtime_type = io.containerd.smolvm.v2). The overhead reflects the per-pod VM
+# footprint so the scheduler accounts for it.
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: smolvm
+handler: smolvm
+overhead:
+  podFixed:
+    cpu: "250m"
+    memory: "160Mi"
+# Restrict to nodes that actually have the smolvm runtime installed (label them
+# `smolvm-runtime=true`). Drop this block on a single-node/all-nodes install.
+scheduling:
+  nodeSelector:
+    smolvm-runtime: "true"


### PR DESCRIPTION
Supersedes #637 by rebasing it onto current main and fixing two install hazards: the installer overwrote config.toml.tmpl (where registry mirrors and private-registry auth live) and symlinked the shim into k3s's content-addressed data dir, which repoints on every upgrade and orphans it — verified broken on a real node.