### PR TITLE
Resolve guest file and socket operations in the namespace the workload actually runs in

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -2773,16 +2773,19 @@ fn handle_file_write(
     uid: Option<u32>,
     gid: Option<u32>,
 ) -> AgentResponse {
-    if let Some(result) = nsfile::write_to_container(path, data, mode, uid, gid) {
-        return match result {
+    match nsfile::GuestNs::for_workload() {
+        nsfile::GuestNs::Container(ns) => match ns.write(path, data, mode, uid, gid) {
             Ok(()) => AgentResponse::Ok { data: None },
             Err(e) => AgentResponse::error(
                 format!("failed to write {} in the workload container: {}", path, e),
                 error_codes::FILE_IO_FAILED,
             ),
-        };
+        },
+        // Seeding the VM's own namespace, which `install_file_atomic` maps into
+        // the machine's overlay. Correct with no workload running, and a
+        // deliberate branch rather than a fallthrough.
+        nsfile::GuestNs::Root(_) => install_file_atomic(path, data, mode, uid, gid),
     }
-    install_file_atomic(path, data, mode, uid, gid)
 }
 
 /// State for an in-progress streaming file upload on one connection.
@@ -2913,15 +2916,15 @@ impl WriteSession {
         // streaming twin). The staged bytes are piped, never re-buffered.
         match std::fs::File::open(&self.tmp_path) {
             Ok(mut staged) => {
-                if let Some(result) = nsfile::write_reader_to_container(
-                    &self.target.to_string_lossy(),
-                    &mut staged,
-                    self.mode,
-                    self.uid,
-                    self.gid,
-                ) {
+                if let nsfile::GuestNs::Container(ns) = nsfile::GuestNs::for_workload() {
                     // Session Drop still cleans the staging file.
-                    return match result {
+                    return match ns.write_reader(
+                        &self.target.to_string_lossy(),
+                        &mut staged,
+                        self.mode,
+                        self.uid,
+                        self.gid,
+                    ) {
                         Ok(()) => {
                             info!(
                                 path = %self.target.display(),
@@ -3140,8 +3143,8 @@ fn handle_streaming_file_read(
     // layer, so a file the container itself created came back 404 (BUG-240).
     // Both directions must move together: fixing only writes would break the
     // upload-then-download round trip, which is self-consistent today.
-    if let Some(opened) = nsfile::open_in_container(path) {
-        match opened {
+    if let nsfile::GuestNs::Container(ns) = nsfile::GuestNs::for_workload() {
+        match ns.open(path) {
             Ok(mut cf) => {
                 info!(path = %path, size = cf.size, "streaming file read (container)");
                 return send_data_chunks(

--- a/crates/smolvm-agent/src/nsfile.rs
+++ b/crates/smolvm-agent/src/nsfile.rs
@@ -89,6 +89,7 @@ pub fn run_helper() -> i32 {
     let result = match op {
         "read" => helper_read(&path),
         "write" => helper_write(&path, mode, uid, gid),
+        "connect" => helper_connect(&path),
         _ => Err("unknown op".to_string()),
     };
     match result {
@@ -128,8 +129,8 @@ fn enter_mount_namespace(pid: u32) -> Result<(), String> {
 
 /// Non-Linux stub. `setns`/`CLONE_NEWNS` are Linux-only, and the agent's unit
 /// tests build on macOS. Unreachable in practice: the agent runs in a Linux
-/// guest, and [`workload_container_pid`] already yields `None` elsewhere, so no
-/// caller ever spawns the helper off Linux.
+/// guest, and off Linux no workload container is ever resolved (`for_workload`
+/// yields [`GuestNs::Root`]), so no caller ever spawns the helper off Linux.
 #[cfg(not(target_os = "linux"))]
 fn enter_mount_namespace(_pid: u32) -> Result<(), String> {
     Err("mount namespaces are Linux-only".to_string())
@@ -210,44 +211,193 @@ fn helper_write(
     Ok(())
 }
 
+/// Dial `path` inside the container and hand the connected socket back.
+///
+/// A file operation can move bytes through a pipe, but a proxy needs the socket
+/// ITSELF: the parent relays traffic for the life of the connection, so what has
+/// to cross the process boundary is the descriptor, not its contents. `SCM_RIGHTS`
+/// over the inherited stdin socket is the only way to pass one.
+#[cfg(target_os = "linux")]
+fn helper_connect(path: &str) -> Result<(), String> {
+    use std::os::unix::io::AsRawFd as _;
+    let app = std::os::unix::net::UnixStream::connect(path)
+        .map_err(|e| format!("connect {path}: {e}"))?;
+    // stdin is the parent's socketpair end (set by `ContainerNs::connect`).
+    send_fd(libc::STDIN_FILENO, app.as_raw_fd())?;
+    let mut out = std::io::stdout().lock();
+    out.write_all(b"OK\n").map_err(|e| e.to_string())?;
+    out.flush().map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn helper_connect(_path: &str) -> Result<(), String> {
+    Err("mount namespaces are Linux-only".to_string())
+}
+
+/// Send `fd` over `sock` as an SCM_RIGHTS control message.
+///
+/// One byte of payload accompanies it because a control message needs at least
+/// one byte of data to be delivered.
+#[cfg(target_os = "linux")]
+fn send_fd(sock: libc::c_int, fd: libc::c_int) -> Result<(), String> {
+    let mut byte = [0u8; 1];
+    let mut iov = libc::iovec {
+        iov_base: byte.as_mut_ptr().cast(),
+        iov_len: 1,
+    };
+    let mut cmsg = [0u8; 32]; // >= CMSG_SPACE(sizeof(int))
+    let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+    msg.msg_iov = &mut iov;
+    msg.msg_iovlen = 1;
+    msg.msg_control = cmsg.as_mut_ptr().cast();
+    msg.msg_controllen = cmsg.len() as _;
+    // SAFETY: `msg` points at live local storage sized per CMSG_SPACE, and the
+    // header is filled exactly as sendmsg requires before the payload is copied.
+    unsafe {
+        let hdr = libc::CMSG_FIRSTHDR(&msg);
+        (*hdr).cmsg_level = libc::SOL_SOCKET;
+        (*hdr).cmsg_type = libc::SCM_RIGHTS;
+        (*hdr).cmsg_len = libc::CMSG_LEN(std::mem::size_of::<libc::c_int>() as u32) as _;
+        std::ptr::copy_nonoverlapping(&fd, libc::CMSG_DATA(hdr).cast::<libc::c_int>(), 1);
+        msg.msg_controllen = (*hdr).cmsg_len;
+        if libc::sendmsg(sock, &msg, 0) < 0 {
+            return Err(format!("sendmsg: {}", std::io::Error::last_os_error()));
+        }
+    }
+    Ok(())
+}
+
 // ===========================================================================
 // Parent side
 // ===========================================================================
 
-/// The init PID of this machine's running workload container, if there is
-/// exactly one.
+/// Why guest I/O is happening in the VM's own namespace rather than a
+/// container's.
 ///
-/// Discovered from the overlay tree because a file request carries no workload
-/// id. Ambiguity is not guessed at: with several live workloads (a pod) the
-/// caller falls back to the VM-namespace path rather than pick one.
-#[cfg(target_os = "linux")]
-pub fn workload_container_pid() -> Option<u32> {
-    let entries = std::fs::read_dir(crate::paths::OVERLAYS_DIR).ok()?;
-    let mut found: Option<u32> = None;
-    for entry in entries.flatten() {
-        let id_file = entry.path().join("main_container_id");
-        let Ok(cid) = std::fs::read_to_string(&id_file) else {
-            continue;
-        };
-        let cid = cid.trim();
-        if cid.is_empty() {
-            continue;
-        }
-        let Some(pid) = crate::crun_container_pid(cid) else {
-            continue;
-        };
-        if found.is_some() {
-            tracing::debug!("several live workload containers; file ops stay in the VM namespace");
-            return None;
-        }
-        found = Some(pid);
-    }
-    found
+/// Carried rather than discarded: the container path declining to run is
+/// invisible from the outside — an upload still reports success, a socket dial
+/// still returns — so without a reason a silent no-op is indistinguishable from
+/// a working container. Diagnosing one such case took hours of reading bytes off
+/// a live guest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub enum RootReason {
+    /// Nothing is running: no container to enter.
+    NoWorkload,
+    /// Several unrelated workloads (a pod). Picking one would write into an
+    /// arbitrary container's filesystem, so we decline instead of guessing.
+    Ambiguous(usize),
 }
 
+impl std::fmt::Display for RootReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoWorkload => write!(f, "no running workload container"),
+            Self::Ambiguous(n) => write!(f, "{n} running workload containers; cannot choose"),
+        }
+    }
+}
+
+/// A running workload container's mount namespace.
+///
+/// Holding this type IS the proof a container was found, so the operations below
+/// exist only here — a caller cannot reach for them and silently get the VM's
+/// namespace instead.
+#[derive(Debug, Clone, Copy)]
+pub struct ContainerNs {
+    pid: u32,
+}
+
+/// Where a guest path or socket should be resolved.
+///
+/// Both arms are legitimate. The VM namespace is *correct* when no workload is
+/// running: overlayfs reads `upper` at mount time, so seeding it before the
+/// container starts is how a rootfs is pre-populated. What must never happen is
+/// choosing it by accident.
+#[derive(Debug, Clone)]
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub enum GuestNs {
+    Root(RootReason),
+    Container(ContainerNs),
+}
+
+impl GuestNs {
+    /// Resolve where this machine's workload lives, logging the reason whenever
+    /// the answer is the VM's own namespace.
+    pub fn for_workload() -> Self {
+        match workload_container() {
+            Ok(pid) => Self::Container(ContainerNs { pid }),
+            Err(reason) => {
+                tracing::debug!(reason = %reason, "guest I/O staying in the VM namespace");
+                Self::Root(reason)
+            }
+        }
+    }
+}
+
+/// The init PID of the container this machine's guest I/O belongs in.
+///
+/// Prefers the machine's recorded main container. When that is not running —
+/// the normal state of an exec-driven machine, whose main container exits
+/// between commands while each `exec` runs its own — it falls back to the single
+/// container crun actually has running. Reading the overlay tree alone missed
+/// those entirely, so the container path never engaged on such a machine and
+/// every file operation silently took the VM-namespace route.
+#[cfg(target_os = "linux")]
+fn workload_container() -> Result<u32, RootReason> {
+    let mains = live_main_containers();
+    match mains.len() {
+        1 => return Ok(mains[0]),
+        0 => {}
+        n => return Err(RootReason::Ambiguous(n)),
+    }
+    // No recorded main container is alive. Anything crun is running now shares
+    // this machine's filesystem, so entering it resolves paths the same way.
+    let running = live_containers();
+    match running.len() {
+        1 => Ok(running[0]),
+        0 => Err(RootReason::NoWorkload),
+        n => Err(RootReason::Ambiguous(n)),
+    }
+}
+
+/// Off Linux there are no containers at all, which is what `NoWorkload` says.
+/// Present so the agent's unit tests build on a developer machine.
 #[cfg(not(target_os = "linux"))]
-pub fn workload_container_pid() -> Option<u32> {
-    None
+fn workload_container() -> Result<u32, RootReason> {
+    Err(RootReason::NoWorkload)
+}
+
+/// PIDs of the running containers each overlay records as its main one.
+#[cfg(target_os = "linux")]
+fn live_main_containers() -> Vec<u32> {
+    let Ok(entries) = std::fs::read_dir(crate::paths::OVERLAYS_DIR) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .filter_map(|e| std::fs::read_to_string(e.path().join("main_container_id")).ok())
+        .filter_map(|cid| crate::crun_container_pid(cid.trim()))
+        .collect()
+}
+
+/// PIDs of every container crun currently has running.
+///
+/// The crun state directory is the truth about what exists right now; the
+/// overlay tree only records the container a machine was STARTED with. Entries
+/// for exited containers resolve to `None` (their recorded pid no longer
+/// matches), so they filter themselves out.
+#[cfg(target_os = "linux")]
+fn live_containers() -> Vec<u32> {
+    let Ok(entries) = std::fs::read_dir(crate::paths::CRUN_ROOT_DIR) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .filter_map(|e| e.file_name().into_string().ok())
+        .filter_map(|cid| crate::crun_container_pid(&cid))
+        .collect()
 }
 
 /// A file opened inside the container, streaming over the helper's pipe.
@@ -264,74 +414,141 @@ pub struct ContainerFile {
     pub reader: std::io::Take<std::io::BufReader<std::process::ChildStdout>>,
 }
 
-/// Open `path` inside the container for reading. `None` means "no single
-/// running workload" — the caller keeps the VM-namespace behavior.
-pub fn open_in_container(path: &str) -> Option<Result<ContainerFile, String>> {
-    let pid = workload_container_pid()?;
-    Some(open_via_helper(pid, path))
-}
-
-fn open_via_helper(pid: u32, path: &str) -> Result<ContainerFile, String> {
-    let mut child = Command::new(AGENT_BINARY)
-        .args([HELPER_ARG, "read", &pid.to_string(), path])
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .map_err(|e| format!("spawn ns-file helper: {e}"))?;
-    let stdout = child.stdout.take().expect("piped");
-    let mut reader = std::io::BufReader::new(stdout);
-    let mut header = String::new();
-    reader
-        .read_line(&mut header)
-        .map_err(|e| format!("ns-file helper: {e}"))?;
-    let header = header.trim_end();
-    if let Some(msg) = header.strip_prefix("ERR ") {
-        return Err(msg.to_string());
+// Reachable only on Linux: `workload_container` yields a `ContainerNs` only
+// there, so a developer build on macOS sees these as unused by construction.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+impl ContainerNs {
+    /// Open `path` inside the container for reading.
+    pub fn open(&self, path: &str) -> Result<ContainerFile, String> {
+        let mut child = Command::new(AGENT_BINARY)
+            .args([HELPER_ARG, "read", &self.pid.to_string(), path])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|e| format!("spawn ns-file helper: {e}"))?;
+        let stdout = child.stdout.take().expect("piped");
+        let mut reader = std::io::BufReader::new(stdout);
+        let mut header = String::new();
+        reader
+            .read_line(&mut header)
+            .map_err(|e| format!("ns-file helper: {e}"))?;
+        let header = header.trim_end();
+        if let Some(msg) = header.strip_prefix("ERR ") {
+            return Err(msg.to_string());
+        }
+        let size: u64 = header
+            .strip_prefix("OK ")
+            .and_then(|s| s.parse().ok())
+            .ok_or_else(|| format!("ns-file helper: bad header {header:?}"))?;
+        Ok(ContainerFile {
+            _child: child,
+            size,
+            reader: reader.take(size),
+        })
     }
-    let size: u64 = header
-        .strip_prefix("OK ")
-        .and_then(|s| s.parse().ok())
-        .ok_or_else(|| format!("ns-file helper: bad header {header:?}"))?;
-    Ok(ContainerFile {
-        _child: child,
-        size,
-        reader: reader.take(size),
-    })
+
+    /// Write `data` to `path` inside the container, atomically, applying `mode`
+    /// and `uid`/`gid` ownership so a non-root workload can read its own upload.
+    pub fn write(
+        &self,
+        path: &str,
+        data: &[u8],
+        mode: Option<u32>,
+        uid: Option<u32>,
+        gid: Option<u32>,
+    ) -> Result<(), String> {
+        write_via_helper(
+            self.pid,
+            path,
+            &mut std::io::Cursor::new(data),
+            mode,
+            uid,
+            gid,
+        )
+    }
+
+    /// Stream `reader` into `path` inside the container without buffering the
+    /// whole payload — the streaming-upload counterpart to [`write`].
+    pub fn write_reader<R: std::io::Read>(
+        &self,
+        path: &str,
+        reader: &mut R,
+        mode: Option<u32>,
+        uid: Option<u32>,
+        gid: Option<u32>,
+    ) -> Result<(), String> {
+        write_via_helper(self.pid, path, reader, mode, uid, gid)
+    }
+
+    /// Dial `path` inside the container and return the connected socket.
+    ///
+    /// The descriptor is received over a socketpair given to the helper as its
+    /// stdin, so the caller relays traffic on a socket that was opened with the
+    /// container's view of the filesystem.
+    #[cfg(target_os = "linux")]
+    pub fn connect(&self, path: &str) -> Result<std::os::unix::net::UnixStream, String> {
+        use std::os::unix::io::{AsRawFd as _, FromRawFd as _, IntoRawFd as _};
+        let (ours, theirs) =
+            std::os::unix::net::UnixStream::pair().map_err(|e| format!("socketpair: {e}"))?;
+        let child = Command::new(AGENT_BINARY)
+            .args([HELPER_ARG, "connect", &self.pid.to_string(), path])
+            // SAFETY: `theirs` is an owned socket handed to the child as fd 0.
+            .stdin(unsafe { Stdio::from_raw_fd(theirs.into_raw_fd()) })
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|e| format!("spawn ns-file helper: {e}"))?;
+        let out = child
+            .wait_with_output()
+            .map_err(|e| format!("ns-file helper: {e}"))?;
+        // Check the reply BEFORE reading a descriptor: on failure there is none,
+        // and the error text says why the dial failed inside the container.
+        parse_ok_reply(&String::from_utf8_lossy(&out.stdout))?;
+        let fd = recv_fd(ours.as_raw_fd())?;
+        // SAFETY: `fd` was just received via SCM_RIGHTS and is owned by us.
+        Ok(unsafe { std::os::unix::net::UnixStream::from_raw_fd(fd) })
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub fn connect(&self, _path: &str) -> Result<std::os::unix::net::UnixStream, String> {
+        Err("mount namespaces are Linux-only".to_string())
+    }
 }
 
-/// Write `data` to `path` inside the container. `Ok(None)` means "no single
-/// running workload" — the caller keeps the VM-namespace behavior.
-pub fn write_to_container(
-    path: &str,
-    data: &[u8],
-    mode: Option<u32>,
-    uid: Option<u32>,
-    gid: Option<u32>,
-) -> Option<Result<(), String>> {
-    let pid = workload_container_pid()?;
-    Some(write_via_helper(
-        pid,
-        path,
-        &mut std::io::Cursor::new(data),
-        mode,
-        uid,
-        gid,
-    ))
-}
-
-/// Stream an already-staged file into the workload container's namespace.
-/// Used by the streaming upload's finalize so large files land where the
-/// workload reads, exactly like the single-shot path. `None` = no running
-/// workload; the caller keeps its agent-namespace placement.
-pub fn write_reader_to_container<R: std::io::Read>(
-    path: &str,
-    reader: &mut R,
-    mode: Option<u32>,
-    uid: Option<u32>,
-    gid: Option<u32>,
-) -> Option<Result<(), String>> {
-    let pid = workload_container_pid()?;
-    Some(write_via_helper(pid, path, reader, mode, uid, gid))
+/// Receive a descriptor sent with [`send_fd`].
+#[cfg(target_os = "linux")]
+fn recv_fd(sock: libc::c_int) -> Result<libc::c_int, String> {
+    let mut byte = [0u8; 1];
+    let mut iov = libc::iovec {
+        iov_base: byte.as_mut_ptr().cast(),
+        iov_len: 1,
+    };
+    let mut cmsg = [0u8; 32];
+    let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+    msg.msg_iov = &mut iov;
+    msg.msg_iovlen = 1;
+    msg.msg_control = cmsg.as_mut_ptr().cast();
+    msg.msg_controllen = cmsg.len() as _;
+    // SAFETY: `msg` describes live local storage; the header is inspected only
+    // after recvmsg reports success, and only for an SCM_RIGHTS payload.
+    unsafe {
+        if libc::recvmsg(sock, &mut msg, 0) < 0 {
+            return Err(format!("recvmsg: {}", std::io::Error::last_os_error()));
+        }
+        let hdr = libc::CMSG_FIRSTHDR(&msg);
+        if hdr.is_null()
+            || (*hdr).cmsg_level != libc::SOL_SOCKET
+            || (*hdr).cmsg_type != libc::SCM_RIGHTS
+        {
+            return Err("helper sent no descriptor".to_string());
+        }
+        let mut fd: libc::c_int = -1;
+        std::ptr::copy_nonoverlapping(libc::CMSG_DATA(hdr).cast::<libc::c_int>(), &mut fd, 1);
+        if fd < 0 {
+            return Err("helper sent an invalid descriptor".to_string());
+        }
+        Ok(fd)
+    }
 }
 
 fn write_via_helper<R: std::io::Read>(
@@ -367,15 +584,19 @@ fn write_via_helper<R: std::io::Read>(
     let out = child
         .wait_with_output()
         .map_err(|e| format!("ns-file helper: {e}"))?;
-    let reply = String::from_utf8_lossy(&out.stdout);
-    let reply = reply.trim_end();
-    if reply == "OK" {
-        return Ok(());
+    parse_ok_reply(&String::from_utf8_lossy(&out.stdout))
+}
+
+/// Strict reply parsing: anything that is not exactly `OK` is a failure, so a
+/// truncated or unexpected reply is never read as success.
+fn parse_ok_reply(reply: &str) -> Result<(), String> {
+    match reply.trim_end() {
+        "OK" => Ok(()),
+        other => Err(other
+            .strip_prefix("ERR ")
+            .unwrap_or("ns-file helper failed")
+            .to_string()),
     }
-    Err(reply
-        .strip_prefix("ERR ")
-        .unwrap_or("ns-file helper failed")
-        .to_string())
 }
 
 #[cfg(test)]
@@ -395,5 +616,51 @@ mod tests {
         for bad in ["", "ERR boom", "OKAY", "ERR "] {
             assert_ne!(bad.trim_end(), "OK", "{bad:?} must not look like success");
         }
+    }
+}
+
+#[cfg(test)]
+mod guest_ns_tests {
+    use super::{parse_ok_reply, RootReason};
+
+    #[test]
+    fn a_fallback_to_the_vm_namespace_always_carries_a_reason() {
+        // The container path declining to run is invisible from outside: an
+        // upload still reports success and a dial still returns. Without a
+        // reason, a silent no-op is indistinguishable from a working container —
+        // which is what made one such case take hours to find.
+        for r in [RootReason::NoWorkload, RootReason::Ambiguous(3)] {
+            assert!(!r.to_string().is_empty(), "{r:?} must explain itself");
+        }
+        assert!(RootReason::Ambiguous(3).to_string().contains('3'));
+    }
+
+    #[test]
+    fn only_an_exact_ok_is_success() {
+        // A truncated or unexpected reply must never read as success: the write
+        // path reports 200 on Ok, so a loose parse silently loses a file.
+        assert!(parse_ok_reply("OK\n").is_ok());
+        assert!(parse_ok_reply("OK").is_ok());
+        for bad in ["", "OKAY", "ERR boom", "ERR ", "ok"] {
+            assert!(parse_ok_reply(bad).is_err(), "{bad:?} must not be success");
+        }
+    }
+
+    #[test]
+    fn a_helper_error_reaches_the_caller_verbatim() {
+        // The reason a dial or write failed INSIDE the container is the only
+        // diagnostic the operator gets; swallowing it leaves an unexplained 500.
+        assert_eq!(
+            parse_ok_reply("ERR connect /run/app.sock: No such file or directory").unwrap_err(),
+            "connect /run/app.sock: No such file or directory"
+        );
+    }
+
+    #[test]
+    fn an_unrecognised_reply_is_not_reported_as_an_empty_error() {
+        assert_eq!(
+            parse_ok_reply("garbage").unwrap_err(),
+            "ns-file helper failed"
+        );
     }
 }

--- a/crates/smolvm-agent/src/publish_socket.rs
+++ b/crates/smolvm-agent/src/publish_socket.rs
@@ -139,8 +139,6 @@ fn inject_sockets_into_container(spec: &mut crate::oci::OciSpec, sockets: &[Publ
 /// socket and relay. Mirrors the Docker bridge but with a caller-supplied path.
 #[cfg(target_os = "linux")]
 fn serve_expose(sock: &PublishedSocket) -> io::Result<()> {
-    use std::os::unix::net::UnixStream;
-
     let listener = crate::vsock::VsockListener::bind(sock.vsock_port)?;
     tracing::info!(
         vsock_port = sock.vsock_port,
@@ -161,7 +159,7 @@ fn serve_expose(sock: &PublishedSocket) -> io::Result<()> {
         let guest_path = sock.guest_path.clone();
         thread::Builder::new()
             .name("expose-sock-fwd".into())
-            .spawn(move || match UnixStream::connect(&guest_path) {
+            .spawn(move || match dial_app(&guest_path) {
                 Ok(app) => {
                     if let Err(e) = relay(host_conn, app) {
                         tracing::debug!(error = %e, "expose-socket relay ended");
@@ -606,5 +604,33 @@ mod tests {
         server_thread.join().unwrap();
         relay_thread.join().unwrap();
         assert_eq!(&resp, b"pong");
+    }
+}
+
+/// Dial the guest app's socket where the workload can actually see it.
+///
+/// On an `--image` machine the app runs under crun with its own mount
+/// namespace, so the socket it binds does not exist in the agent's namespace at
+/// all — a direct connect finds nothing and the host client hangs waiting for a
+/// server that is listening a namespace away. With no container running the
+/// agent's own namespace IS the workload's, and the direct connect is right.
+// Same gate as the bridge that calls it.
+#[cfg(target_os = "linux")]
+fn dial_app(guest_path: &str) -> io::Result<std::os::unix::net::UnixStream> {
+    match crate::nsfile::GuestNs::for_workload() {
+        crate::nsfile::GuestNs::Container(ns) => ns
+            .connect(guest_path)
+            .map_err(|e| io::Error::new(io::ErrorKind::NotConnected, e)),
+        // Carry WHY we are dialing here into the error. A bare "not reachable"
+        // cannot distinguish "the app is not listening" from "the app is
+        // listening in a container we declined to enter", which is the whole
+        // failure this path exists to fix.
+        crate::nsfile::GuestNs::Root(reason) => std::os::unix::net::UnixStream::connect(guest_path)
+            .map_err(|e| {
+                io::Error::new(
+                    e.kind(),
+                    format!("{e} (dialed in the VM namespace: {reason})"),
+                )
+            }),
     }
 }


### PR DESCRIPTION
Guest I/O now resolves through one namespace value, so an image machine's socket is reachable, a container is found even when only exec containers are running, and choosing the VM namespace always records why.