### PR TITLE
Document the local archive, stdin and rootfs-directory forms of --image in the CLI help so a locally built image is discoverable without reading the README

### DIFF
--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -374,8 +374,11 @@ impl MachineCmd {
 ///   smolvm machine run --net -v ./src:/app --image node -- npm start
 #[derive(Args, Debug)]
 pub struct RunCmd {
-    /// Container image (e.g., alpine, ubuntu:22.04, ghcr.io/org/image).
-    /// Optional when a Smolfile provides the image, or for bare VM mode.
+    /// Container image: a registry reference (alpine, ubuntu:22.04,
+    /// ghcr.io/org/image), a `docker save` archive (./myapp.tar, or `-` to read
+    /// one from stdin), or an unpacked rootfs directory (./rootfs/). A bare name
+    /// is always a registry reference — pipe `docker save` to use a locally
+    /// built image. Optional when a Smolfile provides the image, or for bare VM mode.
     #[arg(short = 'I', long, value_name = "IMAGE", value_parser = parse_image)]
     pub image: Option<String>,
 
@@ -2620,7 +2623,10 @@ pub struct CreateCmd {
     #[arg(short = 'n', long, value_name = "NAME")]
     pub name: Option<String>,
 
-    /// Container image (e.g., alpine, python:3.12-alpine)
+    /// Container image: a registry reference (alpine, python:3.12-alpine), a
+    /// `docker save` archive (./myapp.tar, or `-` to read one from stdin), or an
+    /// unpacked rootfs directory (./rootfs/). A bare name is always a registry
+    /// reference — pipe `docker save` to use a locally built image.
     #[arg(short = 'I', long, value_name = "IMAGE", value_parser = parse_image)]
     pub image: Option<String>,
 


### PR DESCRIPTION
`--image` accepts four kinds of value; `--help` described one, so a locally built image was undiscoverable from the CLI.

## Why

Both `machine run` and `machine create` read *"Container image (e.g., alpine, ubuntu:22.04, ghcr.io/org/image)"* — three registry examples, nothing else. `docker save myapp | smolvm machine run --image -` and `--image ./rootfs/` work, and neither appears anywhere in the CLI.

That cost a real report. In #173 a user ran `docker build . -t smolvm-test`, tried `--image smolvm-test`, concluded local images weren't supported at all, and the issue sat open ~4 months. They *were* supported — just not by that spelling.

## How

Extends the doc comment on the two `--image` args that route through `classify()`. Rendered:

```
-I, --image <IMAGE>
        Container image: a registry reference (alpine, ubuntu:22.04,
        ghcr.io/org/image), a `docker save` archive (./myapp.tar, or `-` to read
        one from stdin), or an unpacked rootfs directory (./rootfs/). A bare name
        is always a registry reference — pipe `docker save` to use a locally
        built image. Optional when a Smolfile provides the image, or for bare VM mode
```

## Alternatives considered

**Make `--image smolvm-test` resolve from the local Docker daemon** — that's the change the reporter actually wanted, and I'm deliberately not making it. The current rule is intentional: `looks_local()` requires a path prefix or archive suffix, and `bare_name_matching_a_cwd_file_still_resolves_to_registry` pins it as a test. Querying the Docker daemon would also make smolvm depend on container tooling it currently delegates to. If it's wanted it deserves its own issue; documenting the rule is the honest fix for the discoverability bug.

**Also update `pack create --image`** — deliberately not touched. It doesn't route through `classify()`, so its registry-only wording is already accurate for what it accepts. Changing it would have documented support that isn't there.

## Validation

Built and ran the real CLI rather than reading the source back:

```
$ smolvm machine run --image ./definitely-not-real.tar -- true
Error: config operation failed: --image: cannot read archive ./definitely-not-real.tar: No such file or directory

$ smolvm machine run --image definitely-not-real.tar -- true      # no ./ prefix
Error: config operation failed: --image: cannot read archive definitely-not-real.tar: No such file or directory

$ smolvm machine run --image definitely-not-real-xyz -- true      # bare name
… proceeds past config into VM start — never classified as an archive
```

Confirms all three documented behaviors: an explicit path is an archive, a bare `*.tar` is too (via `ARCHIVE_SUFFIXES`), and a bare name is not. `pack create --help` verified unchanged.

`cargo fmt --check` clean, `cargo clippy --bin smolvm -D warnings` clean, `image_source` tests 8/8 pass.

Docs-only; no behavior change. 9 insertions, 3 deletions, one file, one commit.

Fixes #881.
