### PR TITLE
Set TERM for interactive exec sessions so a guest shell's line editor can redraw correctly

### DIFF
--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -409,6 +409,26 @@ fn expect_data<T: serde::de::DeserializeOwned>(resp: AgentResponse, op: &str) ->
     }
 }
 
+/// Give a PTY session a `TERM` unless the caller already set one.
+///
+/// A shell's line editor needs `TERM` to look up the terminal's cursor-movement
+/// capabilities. Without it the edit still happens — the buffer is correct — but
+/// the redraw is not: the screen never catches up, so backspace looks like it
+/// advances the cursor and deletes nothing. zsh's ZLE is strict here; bash's
+/// readline has built-in fallbacks and hides the problem.
+///
+/// The host's own `TERM` is deliberately NOT forwarded. An exotic value
+/// (`alacritty`, `foot`, …) often has no terminfo entry inside a slim container
+/// image, which fails exactly the same way — so a value every image ships with
+/// is the safer default. It also matches the `TERM` the launcher and OCI paths
+/// already set. Callers wanting something else pass `TERM` in `env` explicitly.
+fn with_term_default(mut env: Vec<(String, String)>, tty: bool) -> Vec<(String, String)> {
+    if tty && !env.iter().any(|(key, _)| key == "TERM") {
+        env.push(("TERM".to_string(), "xterm-256color".to_string()));
+    }
+    env
+}
+
 /// Expect an `Ok` response, ignoring any data.
 fn expect_ok(resp: AgentResponse, op: &str) -> Result<()> {
     match resp {
@@ -1169,6 +1189,7 @@ impl AgentClient {
         tty: bool,
     ) -> Result<i32> {
         let timeout_ms = timeout.map(|t| t.as_millis() as u64);
+        let env = with_term_default(env, tty);
         self.interactive_session(
             AgentRequest::VmExec {
                 command,
@@ -1300,11 +1321,12 @@ impl AgentClient {
     pub fn run_interactive(&mut self, config: RunConfig) -> Result<i32> {
         let timeout_ms = config.timeout.map(|t| t.as_millis() as u64);
         let tty = config.tty;
+        let env = with_term_default(config.env, tty);
         self.interactive_session(
             AgentRequest::Run {
                 image: config.image,
                 command: config.command,
-                env: config.env,
+                env,
                 workdir: config.workdir,
                 user: config.user,
                 mounts: config.mounts,
@@ -1521,6 +1543,7 @@ impl AgentClient {
     where
         F: FnMut(InteractiveOutput),
     {
+        let env = with_term_default(env, tty);
         self.interactive_session_io(
             AgentRequest::VmExec {
                 command,
@@ -1550,11 +1573,12 @@ impl AgentClient {
         F: FnMut(InteractiveOutput),
     {
         let tty = config.tty;
+        let env = with_term_default(config.env, tty);
         self.interactive_session_io(
             AgentRequest::Run {
                 image: config.image,
                 command: config.command,
-                env: config.env,
+                env,
                 workdir: config.workdir,
                 user: config.user,
                 mounts: config.mounts,
@@ -2854,5 +2878,43 @@ mod stalled_body_tests {
         );
 
         server.join().expect("server thread joined");
+    }
+}
+
+#[cfg(test)]
+mod term_default_tests {
+    use super::with_term_default;
+
+    fn term_of(env: &[(String, String)]) -> Option<&str> {
+        env.iter()
+            .find(|(k, _)| k == "TERM")
+            .map(|(_, v)| v.as_str())
+    }
+
+    #[test]
+    fn pty_session_gets_a_term() {
+        // Without this the guest shell's line editor cannot redraw, and backspace
+        // appears to advance the cursor instead of deleting.
+        let env = with_term_default(vec![], true);
+        assert_eq!(term_of(&env), Some("xterm-256color"));
+    }
+
+    #[test]
+    fn caller_supplied_term_is_kept() {
+        let env = with_term_default(
+            vec![("TERM".to_string(), "screen-256color".to_string())],
+            true,
+        );
+        assert_eq!(term_of(&env), Some("screen-256color"));
+        assert_eq!(env.len(), 1, "must not append a second TERM");
+    }
+
+    #[test]
+    fn non_tty_exec_is_untouched() {
+        // A piped exec has no terminal to describe; adding TERM there would make
+        // programs emit escape sequences into what is usually captured output.
+        let env = with_term_default(vec![("A".to_string(), "b".to_string())], false);
+        assert_eq!(term_of(&env), None);
+        assert_eq!(env.len(), 1);
     }
 }


### PR DESCRIPTION
An interactive exec sent no TERM to the guest, so a shell's line editor could not emit cursor movement: edits applied to the buffer but the screen never caught up, making backspace look like it advanced the cursor without deleting. Interactive sessions now default TERM to xterm-256color unless the caller supplies one.