### PR TITLE
Let a golden be forked more than once by retaining its RAM checkpoint

### DIFF
--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -310,12 +310,20 @@ pub fn prepare_held_fork(
 /// Freeze a golden once and prepare every requested clone from the same RAM
 /// snapshot. Preparation is transactional: if any clone fails, all clone
 /// records and disks created by this call are removed.
+///
+/// A successful fork leaves the golden paused forever as the copy-on-write base,
+/// so the checkpoint it just took is retained and reused by every later fork of
+/// that same golden process. Without the retain a golden could be forked exactly
+/// once and every call after it failed with "already paused".
 pub fn prepare_forks(
     db: &SmolvmDb,
     golden: &str,
     specs: &[ForkSpec<'_>],
 ) -> Result<Vec<PreparedFork>> {
-    Ok(prepare_forks_reusing(db, golden, specs, None, false)?.forks)
+    let retained = db
+        .retained_fork_snapshot(golden)
+        .map_err(|error| Error::agent("read retained fork checkpoint", error.to_string()))?;
+    Ok(prepare_forks_reusing(db, golden, specs, retained.as_ref(), true)?.forks)
 }
 
 /// Prepare a batch while reusing a proven checkpoint when it still belongs to
@@ -480,9 +488,9 @@ pub(crate) fn prepare_forks_reusing(
                 )
             })
             .and_then(|snapshot| {
-                db.set_fork_pool_snapshot(golden, snapshot)
+                db.set_retained_fork_snapshot(golden, snapshot)
                     .map_err(|error| {
-                        Error::agent("persist fork pool checkpoint", error.to_string())
+                        Error::agent("persist retained fork checkpoint", error.to_string())
                     })
             });
         if let Err(error) = persisted {
@@ -550,8 +558,8 @@ fn rollback_new_snapshot(
         );
     }
     if persisted {
-        if let Err(remove_error) = db.remove_fork_pool_snapshot(golden) {
-            tracing::warn!(%golden, %remove_error, "failed to remove rolled-back fork pool checkpoint");
+        if let Err(remove_error) = db.remove_retained_fork_snapshot(golden) {
+            tracing::warn!(%golden, %remove_error, "failed to remove rolled-back retained fork checkpoint");
         }
     }
     if let Err(remove_error) = std::fs::remove_dir_all(snapshot_dir) {

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -1539,7 +1539,7 @@ pub(crate) async fn fork_held_machines_inner(
             }
         }
         if rollback_completed {
-            if let Err(error) = state.db().remove_fork_pool_snapshot(&golden) {
+            if let Err(error) = state.db().remove_retained_fork_snapshot(&golden) {
                 tracing::warn!(%golden, %error, "failed to remove rolled-back fork pool checkpoint");
             }
             if let Err(error) = std::fs::remove_dir_all(&snapshot_dir) {

--- a/src/api/pool_controller.rs
+++ b/src/api/pool_controller.rs
@@ -44,7 +44,7 @@ impl ForkPoolController {
                 None
             }
         };
-        let retained_snapshots = match state.db().list_fork_pool_snapshots() {
+        let retained_snapshots = match state.db().list_retained_fork_snapshots() {
             Ok(snapshots) => {
                 if !snapshots.is_empty() {
                     tracing::info!(
@@ -239,7 +239,7 @@ impl ForkPoolController {
             let db = self.state.db().clone();
             match tokio::task::spawn_blocking(move || {
                 for golden in stale_snapshots {
-                    if let Err(error) = db.remove_fork_pool_snapshot(&golden) {
+                    if let Err(error) = db.remove_retained_fork_snapshot(&golden) {
                         tracing::warn!(%golden, %error, "failed to remove inactive fork pool checkpoint");
                     }
                 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -562,6 +562,14 @@ impl SmolvmDb {
                         .db_err(format!("deserialize vm record '{}'", name))?;
                     tx.execute("DELETE FROM vms WHERE name = ?1", params![name])
                         .db_err(format!("remove vm '{}'", name))?;
+                    // A retained checkpoint only means anything while its golden
+                    // process is alive, so it dies with the record rather than
+                    // waiting for a sweep that only the pool controller runs.
+                    tx.execute(
+                        "DELETE FROM fork_pool_snapshots WHERE golden = ?1",
+                        params![name],
+                    )
+                    .db_err(format!("remove retained fork snapshot for '{}'", name))?;
                     Some(r)
                 }
                 None => None,
@@ -706,57 +714,84 @@ impl SmolvmDb {
         })
     }
 
-    /// Durably publish the RAM checkpoint that can refill pools for one golden.
-    pub(crate) fn set_fork_pool_snapshot(
+    /// Durably publish the RAM checkpoint every later fork of this golden reuses.
+    ///
+    /// The `fork_pool_snapshots` table predates plain forks using this and keeps
+    /// its name so no migration is needed; it is not pool-specific.
+    pub(crate) fn set_retained_fork_snapshot(
         &self,
         golden: &str,
         snapshot: &crate::agent::fork::RetainedForkSnapshot,
     ) -> Result<()> {
-        let data = serde_json::to_vec(snapshot).db_err("serialize fork pool snapshot")?;
+        let data = serde_json::to_vec(snapshot).db_err("serialize retained fork snapshot")?;
         self.with_conn(|conn| {
             conn.execute(
                 "INSERT INTO fork_pool_snapshots (golden, data) VALUES (?1, ?2)
                  ON CONFLICT(golden) DO UPDATE SET data = excluded.data",
                 params![golden, data],
             )
-            .db_err(format!("set fork pool snapshot for '{golden}'"))?;
+            .db_err(format!("set retained fork snapshot for '{golden}'"))?;
             Ok(())
         })
     }
 
-    /// Load every retained pool checkpoint after a controller restart.
-    pub(crate) fn list_fork_pool_snapshots(
+    /// Read one golden's retained checkpoint, if it still has one.
+    pub(crate) fn retained_fork_snapshot(
+        &self,
+        golden: &str,
+    ) -> Result<Option<crate::agent::fork::RetainedForkSnapshot>> {
+        self.with_read_conn(|conn| {
+            let data: Option<Vec<u8>> = conn
+                .query_row(
+                    "SELECT data FROM fork_pool_snapshots WHERE golden = ?1",
+                    params![golden],
+                    |row| row.get(0),
+                )
+                .optional()
+                .db_err(format!("get retained fork snapshot for '{golden}'"))?;
+            match data {
+                Some(bytes) => Ok(Some(
+                    serde_json::from_slice(&bytes)
+                        .db_err(format!("deserialize retained fork snapshot for '{golden}'"))?,
+                )),
+                None => Ok(None),
+            }
+        })
+    }
+
+    /// Load every retained checkpoint after a controller restart.
+    pub(crate) fn list_retained_fork_snapshots(
         &self,
     ) -> Result<Vec<(String, crate::agent::fork::RetainedForkSnapshot)>> {
         self.with_read_conn(|conn| {
             let mut stmt = conn
                 .prepare_cached("SELECT golden, data FROM fork_pool_snapshots ORDER BY golden")
-                .db_err("prepare list fork pool snapshots")?;
+                .db_err("prepare list retained fork snapshots")?;
             let rows = stmt
                 .query_map([], |row| {
                     Ok((row.get::<_, String>(0)?, row.get::<_, Vec<u8>>(1)?))
                 })
-                .db_err("query fork pool snapshots")?;
+                .db_err("query retained fork snapshots")?;
             let mut snapshots = Vec::new();
             for row in rows {
-                let (golden, data) = row.db_err("read fork pool snapshot row")?;
+                let (golden, data) = row.db_err("read retained fork snapshot row")?;
                 let snapshot = serde_json::from_slice(&data)
-                    .db_err(format!("deserialize fork pool snapshot for '{golden}'"))?;
+                    .db_err(format!("deserialize retained fork snapshot for '{golden}'"))?;
                 snapshots.push((golden, snapshot));
             }
             Ok(snapshots)
         })
     }
 
-    /// Forget a checkpoint only after its golden is resumed or no pool can use it.
-    pub(crate) fn remove_fork_pool_snapshot(&self, golden: &str) -> Result<bool> {
+    /// Forget a checkpoint only after its golden is resumed or no clone can use it.
+    pub(crate) fn remove_retained_fork_snapshot(&self, golden: &str) -> Result<bool> {
         self.with_conn(|conn| {
             let changed = conn
                 .execute(
                     "DELETE FROM fork_pool_snapshots WHERE golden = ?1",
                     params![golden],
                 )
-                .db_err(format!("remove fork pool snapshot for '{golden}'"))?;
+                .db_err(format!("remove retained fork snapshot for '{golden}'"))?;
             Ok(changed == 1)
         })
     }
@@ -2150,17 +2185,47 @@ mod tests {
             golden_pid: 123,
             golden_pid_start_time: 456,
         };
-        db.set_fork_pool_snapshot("golden", &snapshot).unwrap();
+        db.set_retained_fork_snapshot("golden", &snapshot).unwrap();
         drop(db);
 
         let reopened = SmolvmDb::open_at(&dir.path().join("test.db")).unwrap();
         assert_eq!(
-            reopened.list_fork_pool_snapshots().unwrap(),
-            vec![("golden".to_string(), snapshot)]
+            reopened.list_retained_fork_snapshots().unwrap(),
+            vec![("golden".to_string(), snapshot.clone())]
         );
-        assert!(reopened.remove_fork_pool_snapshot("golden").unwrap());
-        assert!(reopened.list_fork_pool_snapshots().unwrap().is_empty());
-        assert!(!reopened.remove_fork_pool_snapshot("golden").unwrap());
+        assert_eq!(
+            reopened.retained_fork_snapshot("golden").unwrap().as_ref(),
+            Some(&snapshot)
+        );
+        assert!(reopened.retained_fork_snapshot("other").unwrap().is_none());
+        assert!(reopened.remove_retained_fork_snapshot("golden").unwrap());
+        assert!(reopened.list_retained_fork_snapshots().unwrap().is_empty());
+        assert!(!reopened.remove_retained_fork_snapshot("golden").unwrap());
+    }
+
+    /// A retained checkpoint restores RAM from one specific golden process, so it
+    /// must not outlive that golden's record — otherwise a later machine reusing
+    /// the name would inherit a checkpoint that belongs to a dead VM.
+    #[test]
+    fn removing_a_golden_also_drops_its_retained_fork_snapshot() {
+        let (_dir, db) = temp_db();
+        db.insert_vm(
+            "golden",
+            &VmRecord::new("golden".to_string(), 1, 256, vec![], vec![], true),
+        )
+        .unwrap();
+        db.set_retained_fork_snapshot(
+            "golden",
+            &crate::agent::fork::RetainedForkSnapshot {
+                path: PathBuf::from("/golden/s/12345678"),
+                golden_pid: 123,
+                golden_pid_start_time: 456,
+            },
+        )
+        .unwrap();
+
+        assert!(db.remove_vm("golden").unwrap().is_some());
+        assert!(db.retained_fork_snapshot("golden").unwrap().is_none());
     }
 
     #[test]


### PR DESCRIPTION
A successful fork leaves the golden paused as the copy-on-write base, but only the pool path retained the checkpoint it took, so every later fork of the same golden failed with "already paused".