### PR TITLE
fix(machine): preserve local secret refs for --from

### DIFF
--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -208,6 +208,27 @@ fn parse_cli_secret_refs(
     Ok(out)
 }
 
+fn smolmachine_secret_refs(
+    manifest_refs: std::collections::BTreeMap<String, smolvm::secrets::SecretRef>,
+    secret_env: &[String],
+    secret_file: &[String],
+) -> smolvm::Result<std::collections::BTreeMap<String, smolvm::secrets::SecretRef>> {
+    for (key, r) in &manifest_refs {
+        smolvm::secrets::validate_ref(r, smolvm::secrets::ResolutionScope::Untrusted).map_err(
+            |e| {
+                smolvm::Error::config(
+                    "create from .smolmachine",
+                    format!("secret '{}': {} (packs may not carry secret refs)", key, e),
+                )
+            },
+        )?;
+    }
+
+    let mut refs = manifest_refs;
+    refs.extend(parse_cli_secret_refs(secret_env, secret_file)?);
+    Ok(refs)
+}
+
 /// Spawn a detached `smolvm _cleanup-ephemeral` helper process so the parent
 /// CLI can exit immediately after flushing output.
 ///
@@ -2012,6 +2033,36 @@ mod tests {
         );
     }
 
+    #[test]
+    fn smolmachine_secret_refs_adds_local_cli_refs() {
+        let refs = smolmachine_secret_refs(
+            std::collections::BTreeMap::new(),
+            &["GUEST_TOKEN=HOST_TOKEN".to_string()],
+            &["GUEST_KEY=/abs/key".to_string()],
+        )
+        .unwrap();
+
+        assert_eq!(refs["GUEST_TOKEN"].from_env.as_deref(), Some("HOST_TOKEN"));
+        assert_eq!(
+            refs["GUEST_KEY"]
+                .from_file
+                .as_ref()
+                .map(|p| p.to_string_lossy().into_owned()),
+            Some("/abs/key".to_string())
+        );
+    }
+
+    #[test]
+    fn smolmachine_secret_refs_rejects_artifact_refs() {
+        let manifest_refs = std::collections::BTreeMap::from([(
+            "GUEST_TOKEN".to_string(),
+            smolvm::secrets::env_ref("PACK_HOST_TOKEN"),
+        )]);
+
+        let err = smolmachine_secret_refs(manifest_refs, &[], &[]).unwrap_err();
+        assert!(err.to_string().contains("packs may not carry secret refs"));
+    }
+
     #[derive(Parser, Debug)]
     #[command(name = "machine")]
     struct TestMachineCli {
@@ -2990,24 +3041,13 @@ impl CreateCmd {
             manifest.mem
         };
 
-        // A .smolmachine is an untrusted, portable artifact: validate its secret
-        // refs under the Untrusted scope, which rejects every source kind. A
-        // packed `from_env`/`from_file` ref would otherwise read THIS host's
-        // env/files at exec time — reject at create rather than carry an exfil
-        // primitive. Configure secrets locally via the CLI instead.
-        for (key, r) in &manifest.secret_refs {
-            smolvm::secrets::validate_ref(r, smolvm::secrets::ResolutionScope::Untrusted).map_err(
-                |e| {
-                    smolvm::Error::config(
-                        "create from .smolmachine",
-                        format!("secret '{}': {} (packs may not carry secret refs)", key, e),
-                    )
-                },
-            )?;
-        }
+        // A .smolmachine is an untrusted, portable artifact: reject refs carried
+        // by the pack, then add refs explicitly configured on this host.
+        let secret_refs =
+            smolmachine_secret_refs(manifest.secret_refs, &self.secret_env, &self.secret_file)?;
 
         let params = vm_common::CreateVmParams {
-            secret_refs: manifest.secret_refs,
+            secret_refs,
             name,
             // A VM-mode pack is a VM, not a container: its synthetic `vm://<name>`
             // label would make exec/start/re-pack treat it as a pullable image


### PR DESCRIPTION
## Purpose

People creating a persistent machine from a `.smolmachine` artifact should be able to configure secret sources on the local host. Accepting `--secret-env` or `--secret-file` and then dropping those references leaves the created machine unable to receive the requested secrets.

## End State

- `machine create --from` validates and persists caller-provided `--secret-env` and `--secret-file` references.
- Secret references embedded in a `.smolmachine` artifact remain rejected as untrusted.
- Secret values are resolved only when the machine runs; plaintext values are not stored in the artifact or machine record.

## Current State

The artifact-specific create path validates references carried by the artifact, but never adds the locally supplied CLI references to `CreateVmParams`. The CLI accepts the flags, yet the resulting machine record has no secret references.

## Constraints

- References carried inside an artifact must remain untrusted and rejected.
- Locally supplied references must pass the existing trusted-local validation, including absolute paths for file sources and duplicate-name rejection.
- Plaintext secret values must not be resolved or persisted during machine creation.
- Behavior outside `machine create --from` must remain unchanged.
- This change does not depend on #892 and can be reviewed or merged independently.

## Judgment Guidance

Keep the artifact and local caller at distinct trust levels. Validate the artifact first, then add only the references explicitly supplied on the current host.

## Risk Tolerance

- The change is confined to the artifact-based create path and focused secret-reference tests.
- Fail closed for artifact-carried references because accepting one could read an unexpected environment variable or file from the host that later runs the machine.

## Escalation Conditions

- If artifacts should be allowed to describe secret sources, define a separate portable and non-host-specific format before relaxing this boundary.
- If secret resolution moves from runtime to create time, re-evaluate what the machine record is allowed to contain.

## Verification Steps

1. Run `cargo test --bin smolvm cli::machine::tests`; all 20 focused machine tests pass.
2. Run `cargo test --bin smolvm`; all 83 binary unit tests pass.
3. Run `cargo fmt --check`; formatting passes.

## Revalidation

- Recheck when `run_from_smolmachine`, `CreateVmParams`, or secret resolution scopes change.
- Remove the helper if artifact creation is later unified with the ordinary create path.
