### PR TITLE
Make CUDA clone recovery transactional

### DIFF
--- a/crates/smolvm-agent/src/crun.rs
+++ b/crates/smolvm-agent/src/crun.rs
@@ -596,6 +596,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_os = "linux")]
     fn workload_cleanup_kills_background_descendants() {
         let mut shell = std::process::Command::new("/bin/sh")
             .args(["-c", "sleep 60 & wait"])

--- a/crates/smolvm-agent/src/crun.rs
+++ b/crates/smolvm-agent/src/crun.rs
@@ -3,8 +3,9 @@
 //! This module provides a consistent interface for invoking crun commands
 //! with the correct configuration (cgroup-manager, etc.).
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::paths;
 
@@ -41,6 +42,107 @@ pub struct CrunCommand {
     /// the very end in `spawn`/`output`/`status` so options added later (e.g.
     /// `--console-socket` via `console_socket()`) still land before them.
     pending_positionals: Vec<String>,
+}
+
+/// Unique pid file for one foreground `crun exec` invocation.
+///
+/// The PID of the `crun` client is not the PID of the workload in the
+/// container. Keeping the pid file alive until the wait completes lets timeout
+/// and disconnect cleanup signal the workload itself, then removes the runtime
+/// artifact on every return path.
+pub struct ExecPidFile {
+    path: PathBuf,
+}
+
+impl ExecPidFile {
+    pub fn new() -> std::io::Result<Self> {
+        static NEXT: AtomicU64 = AtomicU64::new(1);
+
+        std::fs::create_dir_all(paths::CONTAINERS_RUN_DIR)?;
+        let sequence = NEXT.fetch_add(1, Ordering::Relaxed);
+        let path = Path::new(paths::CONTAINERS_RUN_DIR)
+            .join(format!("exec-{}-{sequence}.pid", std::process::id()));
+        Ok(Self { path })
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Signal the actual container workload recorded by crun. Returns false
+    /// when crun did not create a valid pid file, in which case killing the
+    /// foreground crun child remains the caller's fallback.
+    pub fn kill_workload(&self) -> bool {
+        let Some(pid) = read_pid_file(&self.path) else {
+            return false;
+        };
+        // PID 1 is never a valid foreground exec target and must not be
+        // signalled if a corrupt pid file is encountered.
+        if pid <= 1 {
+            return false;
+        }
+        kill_process_tree(pid)
+    }
+}
+
+impl Drop for ExecPidFile {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+fn read_pid_file(path: &Path) -> Option<libc::pid_t> {
+    std::fs::read_to_string(path)
+        .ok()?
+        .trim()
+        .parse::<libc::pid_t>()
+        .ok()
+}
+
+/// Stop a foreground exec process, discover its descendants while it can no
+/// longer create more, then kill the entire tree. Killing only the pid crun
+/// records leaks background children such as `sh -c 'worker & wait'`, which can
+/// keep GPU memory, ports, and files live after the client has timed out.
+fn kill_process_tree(root: libc::pid_t) -> bool {
+    // SAFETY: `root` came from crun's pid file and was validated above.
+    if unsafe { libc::kill(root, libc::SIGSTOP) } != 0 {
+        return false;
+    }
+
+    let mut descendants = Vec::new();
+    let mut pending = vec![root];
+    let mut seen = std::collections::HashSet::from([root]);
+    while let Some(pid) = pending.pop() {
+        for child in process_children(pid) {
+            if !seen.insert(child) {
+                continue;
+            }
+            // Stop each child before walking its own children. Once every
+            // discovered process is stopped, the tree is stable.
+            unsafe {
+                libc::kill(child, libc::SIGSTOP);
+            }
+            descendants.push(child);
+            pending.push(child);
+        }
+    }
+
+    // Children first avoids leaving work running after its parent disappears.
+    for pid in descendants.into_iter().rev() {
+        unsafe {
+            libc::kill(pid, libc::SIGKILL);
+        }
+    }
+    unsafe { libc::kill(root, libc::SIGKILL) == 0 }
+}
+
+fn process_children(pid: libc::pid_t) -> Vec<libc::pid_t> {
+    std::fs::read_to_string(format!("/proc/{pid}/task/{pid}/children"))
+        .unwrap_or_default()
+        .split_whitespace()
+        .filter_map(|child| child.parse().ok())
+        .filter(|child| *child > 1)
+        .collect()
 }
 
 impl CrunCommand {
@@ -207,6 +309,13 @@ impl CrunCommand {
         self
     }
 
+    /// Ask crun to record the PID of the process launched inside the
+    /// container. This is valid for foreground and detached `exec` commands.
+    pub fn pid_file(mut self, path: &Path) -> Self {
+        self.cmd.arg("--pid-file").arg(path);
+        self
+    }
+
     /// Start a container: `crun start <id>`
     pub fn start(container_id: &str) -> Self {
         let mut c = Self::new();
@@ -252,7 +361,7 @@ impl CrunCommand {
     /// Execute a command DETACHED inside a running container:
     /// `crun exec --detach <id> <cmd…>`. crun starts the process in the
     /// container's namespaces and returns immediately; the process keeps
-    /// running as a child of the container's PID 1 (the keep-alive `tail -f`)
+    /// running as a child of the container's PID 1 (smolvm's child reaper)
     /// for the machine's lifetime — this is how a background exec (a dev
     /// server, an agent) survives across foreground execs, sharing the
     /// container view every other exec sees. Stdio is detached (no pipes to
@@ -473,5 +582,54 @@ mod tests {
         let result = ensure_path_in_env(&env);
         assert_eq!(result.len(), 2);
         assert!(result.iter().any(|(k, _)| k == "PATH"));
+    }
+
+    #[test]
+    fn read_pid_file_rejects_invalid_content() {
+        let path =
+            std::env::temp_dir().join(format!("smolvm-crun-pid-test-{}", std::process::id()));
+        std::fs::write(&path, "not-a-pid\n").unwrap();
+        assert_eq!(read_pid_file(&path), None);
+        std::fs::write(&path, "4242\n").unwrap();
+        assert_eq!(read_pid_file(&path), Some(4242));
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn workload_cleanup_kills_background_descendants() {
+        let mut shell = std::process::Command::new("/bin/sh")
+            .args(["-c", "sleep 60 & wait"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let root = shell.id() as libc::pid_t;
+        let mut children = Vec::new();
+        for _ in 0..50 {
+            children = process_children(root);
+            if !children.is_empty() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert!(
+            !children.is_empty(),
+            "shell did not start its background child"
+        );
+        assert!(kill_process_tree(root));
+        shell.wait().unwrap();
+        for child in children {
+            for _ in 0..50 {
+                if !Path::new(&format!("/proc/{child}")).exists() {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            assert!(
+                !Path::new(&format!("/proc/{child}")).exists(),
+                "background child {child} survived cleanup"
+            );
+        }
     }
 }

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -200,6 +200,9 @@ fn maybe_set_clock_from_host() {
 }
 
 fn main() {
+    if process::container_init_requested() {
+        std::process::exit(process::run_container_init());
+    }
     if forkpoint::worker_ready_helper_requested() {
         std::process::exit(forkpoint::run_worker_ready_helper());
     }
@@ -1909,6 +1912,22 @@ fn handle_connection(stream: &mut impl ReadWrite) -> Result<(), Box<dyn std::err
 
         debug!(method = %request.log_summary(), "received request");
 
+        // A fork clone resumes this already-initialized agent with fresh
+        // virtiofs devices. Repair hidden/stale boot mounts before replying to
+        // even a Ping, so fork readiness cannot race the inherited workload's
+        // first access to a dead golden mount (notably /opt/smolvm-ring).
+        if let Err(error) = storage::repair_boot_volume_mounts() {
+            warn!(%error, "failed to restore boot volume mounts");
+            send_response(
+                stream,
+                &AgentResponse::error(
+                    format!("restore boot volume mounts: {error}"),
+                    error_codes::INTERNAL_ERROR,
+                ),
+            )?;
+            continue;
+        }
+
         // Check if this is an interactive run request
         if let AgentRequest::Run {
             interactive: true, ..
@@ -3270,6 +3289,7 @@ fn write_oci_bundle(
     mounts: &[(String, String, bool)],
     tty: bool,
     unprivileged: bool,
+    container_init: bool,
 ) -> Result<String, Box<dyn std::error::Error>> {
     use std::path::Path;
 
@@ -3298,6 +3318,13 @@ fn write_oci_bundle(
     // storage::run_command(). Mirror that path's GPU wiring so `-i`/`-t`
     // shells see /dev/dri when the VM was started with --gpu.
     spec.add_gpu_devices_if_available();
+
+    if container_init {
+        const INIT_SOURCE: &str = "/usr/local/bin/smolvm-agent";
+        const INIT_DESTINATION: &str = "/run/smolvm/init";
+        storage::ensure_file_mount_target_under_root(rootfs_path, INIT_DESTINATION)?;
+        spec.add_bind_mount(INIT_SOURCE, INIT_DESTINATION, true);
+    }
 
     for (tag, container_path, read_only) in mounts {
         let virtiofs_mount = Path::new(paths::VIRTIOFS_MOUNT_ROOT).join(tag);
@@ -3480,6 +3507,7 @@ fn handle_run_detached(
         &mounts,
         false,
         unprivileged,
+        false,
     ) {
         Ok(id) => id,
         Err(e) => {
@@ -3855,6 +3883,10 @@ pub fn resolve_main_container(persistent_overlay_id: Option<&str>) -> Option<Str
         return None;
     }
 
+    if let Some(pid) = crun_container_pid(&cid) {
+        stabilize_new_container(pid);
+    }
+
     if is_container_running(&cid) {
         // A restored fork clone's keep-alive container is alive (its process
         // came back with the golden's RAM) but runs from the golden's
@@ -3877,6 +3909,42 @@ pub fn resolve_main_container(persistent_overlay_id: Option<&str>) -> Option<Str
     let _ = std::fs::remove_file(&id_path);
     let _ = crun::CrunCommand::delete(&cid, true).output();
     None
+}
+
+/// Close the short `crun start` race where a container reports running, its
+/// main command exits immediately afterwards, and an exec reaches crun before
+/// stale-state cleanup. Mature containers pay no delay; only a process in its
+/// first 100 ms is allowed to settle before the second validated state check.
+#[cfg(target_os = "linux")]
+fn stabilize_new_container(pid: u32) {
+    let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) else {
+        return;
+    };
+    let Some((_, remainder)) = stat.rsplit_once(')') else {
+        return;
+    };
+    let Some(start_ticks) = remainder
+        .split_whitespace()
+        .nth(19)
+        .and_then(|value| value.parse::<u64>().ok())
+    else {
+        return;
+    };
+    let Some(uptime) = std::fs::read_to_string("/proc/uptime")
+        .ok()
+        .and_then(|value| value.split_whitespace().next()?.parse::<f64>().ok())
+    else {
+        return;
+    };
+    let ticks_per_second = unsafe { libc::sysconf(libc::_SC_CLK_TCK) };
+    if ticks_per_second <= 0 {
+        return;
+    }
+    let age = uptime - start_ticks as f64 / ticks_per_second as f64;
+    const SETTLE_SECONDS: f64 = 0.1;
+    if (0.0..SETTLE_SECONDS).contains(&age) {
+        std::thread::sleep(std::time::Duration::from_secs_f64(SETTLE_SECONDS - age));
+    }
 }
 
 /// Non-Linux stub.
@@ -3907,9 +3975,9 @@ static CONSOLE_SOCKET_WORKS: std::sync::atomic::AtomicBool =
 /// resize message is silently applied to the wrong terminal. See GH
 /// #156.
 /// Establish the long-lived "main" container for a persistent overlay and return
-/// its id. PID 1 is a keep-alive (`tail -f /dev/null`, present on both busybox and
-/// coreutils) that never exits, so processes a later `crun exec` backgrounds
-/// inside it survive across exec calls for the machine's lifetime. Env / workdir /
+/// its id. PID 1 is smolvm's image-independent keepalive and child reaper, so
+/// processes a later `crun exec` backgrounds inside it survive across exec calls
+/// for the machine's lifetime without accumulating orphan zombies. Env / workdir /
 /// user are inherited from the image so exec'd commands see the right environment.
 /// Uses the same two-step `crun create` + `crun start` as [`handle_run_detached`]
 /// (`crun run --detach` hangs in the smolvm VM environment).
@@ -3924,11 +3992,7 @@ fn ensure_main_container(
     use std::path::Path;
 
     let keepalive = ResolvedLaunch {
-        command: vec![
-            "tail".to_string(),
-            "-f".to_string(),
-            "/dev/null".to_string(),
-        ],
+        command: vec!["/run/smolvm/init".to_string(), "container-init".to_string()],
         env: base_launch.env.clone(),
         workdir: base_launch.workdir.clone(),
         user: base_launch.user.clone(),
@@ -3950,6 +4014,7 @@ fn ensure_main_container(
         mounts,
         false,
         unprivileged,
+        true,
     )?;
 
     let create = crun::CrunCommand::create(&bundle_path, &container_id).output()?;
@@ -4018,7 +4083,7 @@ fn spawn_interactive_command(
     }
 
     // On a persistent machine with no main container yet, establish a long-lived
-    // keep-alive container (PID 1 = `tail -f /dev/null`) and exec the command INTO
+    // keep-alive container (PID 1 = smolvm's child reaper) and exec the command INTO
     // it, rather than running the command AS the container. Without this, PID 1 is
     // the command itself, so the container — and anything the command backgrounds
     // (a `dockerd`, a dev server, a k3d cluster) — is torn down the moment the
@@ -4048,8 +4113,15 @@ fn spawn_interactive_command(
     // Build the OCI bundle (config.json) and get a fresh container ID. When
     // tty=true the spec sets terminal:true and a starting consoleSize, and the
     // PTY master is obtained from crun via --console-socket below.
-    let container_id =
-        write_oci_bundle(rootfs_path, &bundle_path, launch, mounts, tty, unprivileged)?;
+    let container_id = write_oci_bundle(
+        rootfs_path,
+        &bundle_path,
+        launch,
+        mounts,
+        tty,
+        unprivileged,
+        false,
+    )?;
 
     // Persist the container ID so subsequent execs join this container.
     // Written before spawn: if spawn fails the ID is stale, but
@@ -5219,7 +5291,7 @@ fn run_in_keepalive_container(
     )?;
 
     // Reuse the running keep-alive container, or establish one now so this and
-    // every later exec join the same container (PID 1 = `tail -f /dev/null`).
+    // every later exec join the same container (PID 1 = smolvm's child reaper).
     // Also carry the container's rootfs so the user can be resolved against its
     // /etc/passwd below.
     let (cid, rootfs) = match resolve_main_container(Some(overlay_id)) {
@@ -5250,6 +5322,7 @@ fn run_in_keepalive_container(
     // previously used blocking `.output()` / `wait_with_output()`, which
     // silently ignored `timeout_ms` — an `exec --timeout N` against an image
     // machine ran to completion regardless (found by QA 2026-07-19).
+    let exec_pid_file = crun::ExecPidFile::new()?;
     let mut builder = crun::CrunCommand::exec(
         &cid,
         &launch.env,
@@ -5258,6 +5331,7 @@ fn run_in_keepalive_container(
         false,
     )
     .user(launch.user.as_deref())
+    .pid_file(exec_pid_file.path())
     .capture_output();
     builder = if stdin_data.is_some() {
         builder.stdin_piped()
@@ -5273,13 +5347,12 @@ fn run_in_keepalive_container(
     // Kill only the exec'd process on timeout/disconnect — NOT the keep-alive
     // container, which hosts the shared namespace for every exec (a timed-out
     // `exec -- sleep 10` must not destroy the machine's workload).
-    let exec_pid = child.id();
     let result = crate::process::wait_with_timeout_cleanup_and_liveness(
         &mut child,
         timeout_ms,
         client_fd,
-        || unsafe {
-            libc::kill(exec_pid as libc::pid_t, libc::SIGKILL);
+        || {
+            exec_pid_file.kill_workload();
         },
     )?;
 
@@ -5329,6 +5402,14 @@ fn handle_run(
     unprivileged: bool,
 ) -> AgentResponse {
     info!(image = %image, command = ?command, mounts = ?mounts, timeout_ms = ?timeout_ms, persistent = persistent_overlay_id.is_some(), stdin = stdin_data.is_some(), "running command");
+
+    // Host-injected boot mounts (including the implicit CUDA ring) must be
+    // present in ordinary non-interactive containers too. Interactive and
+    // detached paths already merge them; omitting them here creates a fresh
+    // post-fork overlay with a plain /opt/smolvm-ring directory, so mapped
+    // host allocations fall back or can hit the clone's stale golden mount.
+    let mounts = storage::merged_with_boot_mounts(mounts);
+    let mounts = &mounts[..];
 
     // SSH agent forwarding: make SSH_AUTH_SOCK part of the command env so it
     // survives the keep-alive `crun exec` path (#542), which runs commands with

--- a/crates/smolvm-agent/src/process.rs
+++ b/crates/smolvm-agent/src/process.rs
@@ -7,6 +7,59 @@ use std::io::Read;
 use std::process::Child;
 use std::time::{Duration, Instant};
 
+const CONTAINER_INIT_ARG: &str = "container-init";
+
+/// Whether this agent invocation is the image-independent init process used by
+/// a persistent workload container.
+pub fn container_init_requested() -> bool {
+    std::env::args_os().nth(1).as_deref() == Some(std::ffi::OsStr::new(CONTAINER_INIT_ARG))
+}
+
+/// Run a minimal PID-1 reaper for a persistent workload container.
+///
+/// Foreground execs can create background descendants. When timeout cleanup
+/// kills that process tree, the descendants are reparented to container PID 1.
+/// A passive keepalive such as `tail -f /dev/null` never waits for them and
+/// therefore leaks zombies across execs. Block the relevant signals and use
+/// `sigwait`, which closes the usual reap-before-sleep race without requiring
+/// an async signal handler.
+#[cfg(target_os = "linux")]
+pub fn run_container_init() -> i32 {
+    let mut signals = unsafe { std::mem::zeroed::<libc::sigset_t>() };
+    unsafe {
+        libc::sigemptyset(&mut signals);
+        libc::sigaddset(&mut signals, libc::SIGCHLD);
+        libc::sigaddset(&mut signals, libc::SIGTERM);
+        libc::sigaddset(&mut signals, libc::SIGINT);
+    }
+    if unsafe { libc::pthread_sigmask(libc::SIG_BLOCK, &signals, std::ptr::null_mut()) } != 0 {
+        return 1;
+    }
+
+    loop {
+        loop {
+            let mut status = 0;
+            let pid = unsafe { libc::waitpid(-1, &mut status, libc::WNOHANG) };
+            if pid <= 0 {
+                break;
+            }
+        }
+
+        let mut signal = 0;
+        if unsafe { libc::sigwait(&signals, &mut signal) } != 0 {
+            return 1;
+        }
+        if signal == libc::SIGTERM || signal == libc::SIGINT {
+            return 0;
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn run_container_init() -> i32 {
+    1
+}
+
 /// Exit code used when a command is killed due to timeout.
 pub const TIMEOUT_EXIT_CODE: i32 = 124;
 
@@ -141,7 +194,7 @@ pub fn wait_with_timeout_cleanup_and_liveness<F>(
     child: &mut Child,
     timeout_ms: Option<u64>,
     client_fd: Option<std::os::unix::io::RawFd>,
-    on_timeout: F,
+    on_abort: F,
 ) -> std::io::Result<WaitResult>
 where
     F: FnOnce(),
@@ -264,6 +317,7 @@ where
             Ok(None) => {
                 if let Some(fd) = client_fd {
                     if is_peer_closed(fd) {
+                        on_abort();
                         let _ = child.kill();
                         let _ = child.wait();
                         drain_channels(&stdout_rx, &stderr_rx, &mut stdout_buf, &mut stderr_buf);
@@ -278,7 +332,7 @@ where
 
                 if let Some(deadline) = deadline {
                     if Instant::now() >= deadline {
-                        on_timeout();
+                        on_abort();
                         let _ = child.kill();
                         let _ = child.wait();
                         drain_channels(&stdout_rx, &stderr_rx, &mut stdout_buf, &mut stderr_buf);

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -257,6 +257,68 @@ fn ensure_mount_target_under_root(rootfs: &Path, container_path: &str) -> Result
     Ok(final_canon)
 }
 
+/// Create a regular-file mountpoint without following a final symlink outside
+/// the container root. OCI runtimes require a file destination when the bind
+/// source is a file.
+pub(crate) fn ensure_file_mount_target_under_root(
+    rootfs: &Path,
+    container_path: &str,
+) -> Result<PathBuf> {
+    let relative = validate_container_destination_path(container_path)?;
+    let file_name = relative
+        .file_name()
+        .ok_or_else(|| StorageError::ValidationFailed {
+            context: "mount destination".to_string(),
+            reason: "file mount destination has no filename".to_string(),
+        })?;
+    let parent = relative
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .ok_or_else(|| StorageError::ValidationFailed {
+            context: "mount destination".to_string(),
+            reason: "file mount destination must have a parent directory".to_string(),
+        })?;
+    let parent_destination = format!("/{}", parent.display());
+    let parent_path = ensure_mount_target_under_root(rootfs, &parent_destination)?;
+    let target = parent_path.join(file_name);
+
+    match std::fs::symlink_metadata(&target) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            std::fs::remove_file(&target).map_err(|error| StorageError::ReadFile {
+                path: target.display().to_string(),
+                cause: format!("failed to replace symlink at file mount target: {error}"),
+            })?;
+            std::fs::File::create(&target).map_err(|error| StorageError::ReadFile {
+                path: target.display().to_string(),
+                cause: format!("failed to create file mount target: {error}"),
+            })?;
+        }
+        Ok(metadata) if metadata.is_file() => {}
+        Ok(_) => {
+            return Err(StorageError::ValidationFailed {
+                context: "mount destination".to_string(),
+                reason: format!(
+                    "file mount destination is not a regular file: {}",
+                    target.display()
+                ),
+            });
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            std::fs::File::create(&target).map_err(|error| StorageError::ReadFile {
+                path: target.display().to_string(),
+                cause: format!("failed to create file mount target: {error}"),
+            })?;
+        }
+        Err(error) => {
+            return Err(StorageError::ReadFile {
+                path: target.display().to_string(),
+                cause: error.to_string(),
+            });
+        }
+    }
+    Ok(target)
+}
+
 /// Global state for packed layers support.
 /// Set at startup if SMOLVM_PACKED_LAYERS env var is present.
 static PACKED_LAYERS_DIR: OnceLock<Option<PathBuf>> = OnceLock::new();
@@ -399,6 +461,49 @@ pub fn init_volume_mounts() -> &'static [(String, String, bool)] {
 
         mounts
     })
+}
+
+/// Re-establish boot-time virtiofs mounts after a fork restore.
+///
+/// A clone resumes the golden agent after its one-time boot initialization,
+/// while libkrun attaches fresh virtiofs devices to the clone VMM. The restored
+/// mount can remain under the golden's old overlay tree, but a newly selected
+/// clone overlay hides its bind target. Accessing that stale mount can block in
+/// the dead golden virtiofs session indefinitely. Check only mount metadata
+/// (never the stale filesystem), detach a stale staging mount if present, and
+/// bind the clone's fresh device before acknowledging its first host request.
+#[cfg(target_os = "linux")]
+pub fn repair_boot_volume_mounts() -> Result<()> {
+    let missing = init_volume_mounts()
+        .iter()
+        .filter(|(_, target, _)| !is_mountpoint(Path::new(target)))
+        .cloned()
+        .collect::<Vec<_>>();
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    for mount in &missing {
+        let (tag, target, _) = mount;
+        let staging = Path::new(paths::VIRTIOFS_MOUNT_ROOT).join(tag);
+        if is_mountpoint(&staging) {
+            detach_mount(&staging);
+        }
+        setup_volume_mounts("/", std::slice::from_ref(mount))?;
+        if !is_mountpoint(Path::new(target)) {
+            return Err(StorageError::new(format!(
+                "boot volume mount '{}' was not restored at '{}'",
+                tag, target
+            )));
+        }
+        info!(tag = %tag, target = %target, "restored boot volume mount after clone resume");
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn repair_boot_volume_mounts() -> Result<()> {
+    Ok(())
 }
 
 /// Add the /storage/workspace → /workspace fallback bind mount to an OCI spec,
@@ -3157,7 +3262,10 @@ fn run_exec_in_container(
 ) -> Result<RunResult> {
     info!(container_id = %container_id, command = ?command, "joining container via crun exec");
 
+    let exec_pid_file = crate::crun::ExecPidFile::new()
+        .map_err(|e| StorageError::new(format!("create crun exec pid file failed: {}", e)))?;
     let mut child = CrunCommand::exec(container_id, env, command, workdir, false)
+        .pid_file(exec_pid_file.path())
         .stdin_null()
         .capture_output()
         .spawn()
@@ -3166,13 +3274,12 @@ fn run_exec_in_container(
     // On timeout/disconnect, kill only the exec'd process — NOT the main
     // container. The main container hosts the shared namespace for all execs;
     // a timed-out `exec -- sleep 10` must not destroy the workload.
-    let exec_pid = child.id();
     let result = crate::process::wait_with_timeout_cleanup_and_liveness(
         &mut child,
         timeout_ms,
         client_fd,
-        || unsafe {
-            libc::kill(exec_pid as libc::pid_t, libc::SIGKILL);
+        || {
+            exec_pid_file.kill_workload();
         },
     )?;
 
@@ -4494,6 +4601,36 @@ mod tests {
             workspace_link.is_dir(),
             "/workspace should now be a directory"
         );
+    }
+
+    #[test]
+    fn file_mount_target_creates_parent_and_regular_file() {
+        let root = tempfile::tempdir().unwrap();
+        let rootfs = root.path().join("rootfs");
+        std::fs::create_dir_all(&rootfs).unwrap();
+
+        let target = ensure_file_mount_target_under_root(&rootfs, "/run/smolvm/init").unwrap();
+        assert!(target.is_file());
+        assert!(target.starts_with(rootfs.canonicalize().unwrap()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn file_mount_target_replaces_final_symlink_without_touching_target() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::NamedTempFile::new().unwrap();
+        let rootfs = root.path().join("rootfs");
+        let destination_parent = rootfs.join("run/smolvm");
+        std::fs::create_dir_all(&destination_parent).unwrap();
+        let destination = destination_parent.join("init");
+        symlink(outside.path(), &destination).unwrap();
+
+        let target = ensure_file_mount_target_under_root(&rootfs, "/run/smolvm/init").unwrap();
+        assert!(target.is_file());
+        assert!(!target.is_symlink());
+        assert!(outside.path().is_file());
     }
 
     #[test]

--- a/crates/smolvm-cuda-shim/src/driver_stubs.rs
+++ b/crates/smolvm-cuda-shim/src/driver_stubs.rs
@@ -5,2551 +5,2410 @@
 //! the basic init/compute path — those are the hand-written forwarders).
 #![allow(non_snake_case)]
 use std::os::raw::c_int;
+
+fn unsupported(name: &str) -> c_int {
+    if std::env::var_os("SMOLVM_CUDA_SHIM_TRACE").is_some() {
+        eprintln!("[shim] unsupported driver call: {name}");
+    }
+    801
+}
 #[no_mangle]
 pub extern "C" fn cuArray3DCreate() -> c_int {
-    801
+    unsupported(stringify!(cuArray3DCreate))
 }
 #[no_mangle]
 pub extern "C" fn cuArray3DCreate_v2() -> c_int {
-    801
+    unsupported(stringify!(cuArray3DCreate_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuArray3DGetDescriptor() -> c_int {
-    801
+    unsupported(stringify!(cuArray3DGetDescriptor))
 }
 #[no_mangle]
 pub extern "C" fn cuArray3DGetDescriptor_v2() -> c_int {
-    801
+    unsupported(stringify!(cuArray3DGetDescriptor_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuArrayCreate() -> c_int {
-    801
+    unsupported(stringify!(cuArrayCreate))
 }
 #[no_mangle]
 pub extern "C" fn cuArrayCreate_v2() -> c_int {
-    801
+    unsupported(stringify!(cuArrayCreate_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuArrayDestroy() -> c_int {
-    801
+    unsupported(stringify!(cuArrayDestroy))
 }
 #[no_mangle]
 pub extern "C" fn cuArrayGetDescriptor() -> c_int {
-    801
+    unsupported(stringify!(cuArrayGetDescriptor))
 }
 #[no_mangle]
 pub extern "C" fn cuArrayGetDescriptor_v2() -> c_int {
-    801
+    unsupported(stringify!(cuArrayGetDescriptor_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuArrayGetMemoryRequirements() -> c_int {
-    801
+    unsupported(stringify!(cuArrayGetMemoryRequirements))
 }
 #[no_mangle]
 pub extern "C" fn cuArrayGetPlane() -> c_int {
-    801
+    unsupported(stringify!(cuArrayGetPlane))
 }
 #[no_mangle]
 pub extern "C" fn cuArrayGetSparseProperties() -> c_int {
-    801
+    unsupported(stringify!(cuArrayGetSparseProperties))
 }
 #[no_mangle]
 pub extern "C" fn cuCheckpointProcessCheckpoint() -> c_int {
-    801
+    unsupported(stringify!(cuCheckpointProcessCheckpoint))
 }
 #[no_mangle]
 pub extern "C" fn cuCheckpointProcessGetRestoreThreadId() -> c_int {
-    801
+    unsupported(stringify!(cuCheckpointProcessGetRestoreThreadId))
 }
 #[no_mangle]
 pub extern "C" fn cuCheckpointProcessGetState() -> c_int {
-    801
+    unsupported(stringify!(cuCheckpointProcessGetState))
 }
 #[no_mangle]
 pub extern "C" fn cuCheckpointProcessLock() -> c_int {
-    801
+    unsupported(stringify!(cuCheckpointProcessLock))
 }
 #[no_mangle]
 pub extern "C" fn cuCheckpointProcessRestore() -> c_int {
-    801
+    unsupported(stringify!(cuCheckpointProcessRestore))
 }
 #[no_mangle]
 pub extern "C" fn cuCheckpointProcessUnlock() -> c_int {
-    801
+    unsupported(stringify!(cuCheckpointProcessUnlock))
 }
 #[no_mangle]
 pub extern "C" fn cuCoredumpDeregisterCompleteCallback() -> c_int {
-    801
+    unsupported(stringify!(cuCoredumpDeregisterCompleteCallback))
 }
 #[no_mangle]
 pub extern "C" fn cuCoredumpDeregisterStartCallback() -> c_int {
-    801
+    unsupported(stringify!(cuCoredumpDeregisterStartCallback))
 }
 #[no_mangle]
 pub extern "C" fn cuCoredumpGetAttribute() -> c_int {
-    801
+    unsupported(stringify!(cuCoredumpGetAttribute))
 }
 #[no_mangle]
 pub extern "C" fn cuCoredumpGetAttributeGlobal() -> c_int {
-    801
+    unsupported(stringify!(cuCoredumpGetAttributeGlobal))
 }
 #[no_mangle]
 pub extern "C" fn cuCoredumpRegisterCompleteCallback() -> c_int {
-    801
+    unsupported(stringify!(cuCoredumpRegisterCompleteCallback))
 }
 #[no_mangle]
 pub extern "C" fn cuCoredumpRegisterStartCallback() -> c_int {
-    801
+    unsupported(stringify!(cuCoredumpRegisterStartCallback))
 }
 #[no_mangle]
 pub extern "C" fn cuCoredumpSetAttribute() -> c_int {
-    801
+    unsupported(stringify!(cuCoredumpSetAttribute))
 }
 #[no_mangle]
 pub extern "C" fn cuCoredumpSetAttributeGlobal() -> c_int {
-    801
+    unsupported(stringify!(cuCoredumpSetAttributeGlobal))
 }
 #[no_mangle]
 pub extern "C" fn cuCtxAttach() -> c_int {
-    801
+    unsupported(stringify!(cuCtxAttach))
 }
 #[no_mangle]
 pub extern "C" fn cuCtxCreate() -> c_int {
-    801
+    unsupported(stringify!(cuCtxCreate))
 }
 #[no_mangle]
 pub extern "C" fn cuCtxCreate_v3() -> c_int {
-    801
+    unsupported(stringify!(cuCtxCreate_v3))
 }
 #[no_mangle]
 pub extern "C" fn cuCtxCreate_v4() -> c_int {
-    801
+    unsupported(stringify!(cuCtxCreate_v4))
 }
 #[no_mangle]
 pub extern "C" fn cuCtxDestroy() -> c_int {
-    801
+    unsupported(stringify!(cuCtxDestroy))
 }
 #[no_mangle]
 pub extern "C" fn cuCtxDetach() -> c_int {
-    801
+    unsupported(stringify!(cuCtxDetach))
 }
 #[no_mangle]
 pub extern "C" fn cuCtxDisablePeerAccess() -> c_int {
-    801
+    unsupported(stringify!(cuCtxDisablePeerAccess))
 }
 #[no_mangle]
 pub extern "C" fn cuCtxEnablePeerAccess() -> c_int {
-    801
+    unsupported(stringify!(cuCtxEnablePeerAccess))
 }
 #[no_mangle]
 pub extern "C" fn cuCtxFromGreenCtx() -> c_int {
-    801
+    unsupported(stringify!(cuCtxFromGreenCtx))
 }
 #[no_mangle]
 pub extern "C" fn cuCtxGetApiVersion() -> c_int {
-    801
+    unsupported(stringify!(cuCtxGetApiVersion))
 }
 #[no_mangle]
 pub extern "C" fn cuCtxGetCacheConfig() -> c_int {
-    801
+    unsupported(stringify!(cuCtxGetCacheConfig))
 }
 #[no_mangle]
 pub extern "C" fn cuCtxGetDevice_v2() -> c_int {
-    801
+    unsupported(stringify!(cuCtxGetDevice_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuCtxGetDevResource() -> c_int {
-    801
+    unsupported(stringify!(cuCtxGetDevResource))
 }
 #[no_mangle]
 pub extern "C" fn cuCtxGetExecAffinity() -> c_int {
-    801
+    unsupported(stringify!(cuCtxGetExecAffinity))
 }
 #[no_mangle]
 pub extern "C" fn cuCtxGetFlags() -> c_int {
-    801
+    unsupported(stringify!(cuCtxGetFlags))
 }
 #[no_mangle]
 pub extern "C" fn cuCtxGetId() -> c_int {
-    801
+    unsupported(stringify!(cuCtxGetId))
 }
 #[no_mangle]
 pub extern "C" fn cuCtxGetSharedMemConfig() -> c_int {
-    801
+    unsupported(stringify!(cuCtxGetSharedMemConfig))
 }
 #[no_mangle]
 pub extern "C" fn cuCtxGetStreamPriorityRange() -> c_int {
-    801
+    unsupported(stringify!(cuCtxGetStreamPriorityRange))
 }
 #[no_mangle]
 pub extern "C" fn cuCtxPopCurrent() -> c_int {
-    801
+    unsupported(stringify!(cuCtxPopCurrent))
 }
 #[no_mangle]
 pub extern "C" fn cuCtxPushCurrent() -> c_int {
-    801
+    unsupported(stringify!(cuCtxPushCurrent))
 }
 #[no_mangle]
 pub extern "C" fn cuCtxRecordEvent() -> c_int {
-    801
+    unsupported(stringify!(cuCtxRecordEvent))
 }
 #[no_mangle]
 pub extern "C" fn cuCtxResetPersistingL2Cache() -> c_int {
-    801
+    unsupported(stringify!(cuCtxResetPersistingL2Cache))
 }
 #[no_mangle]
 pub extern "C" fn cuCtxSetCacheConfig() -> c_int {
-    801
+    unsupported(stringify!(cuCtxSetCacheConfig))
 }
 #[no_mangle]
 pub extern "C" fn cuCtxSetFlags() -> c_int {
-    801
+    unsupported(stringify!(cuCtxSetFlags))
 }
 #[no_mangle]
 pub extern "C" fn cuCtxSetSharedMemConfig() -> c_int {
-    801
+    unsupported(stringify!(cuCtxSetSharedMemConfig))
 }
 #[no_mangle]
 pub extern "C" fn cuCtxSynchronize_v2() -> c_int {
-    801
+    unsupported(stringify!(cuCtxSynchronize_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuCtxWaitEvent() -> c_int {
-    801
+    unsupported(stringify!(cuCtxWaitEvent))
 }
 #[no_mangle]
 pub extern "C" fn cuDestroyExternalMemory() -> c_int {
-    801
+    unsupported(stringify!(cuDestroyExternalMemory))
 }
 #[no_mangle]
 pub extern "C" fn cuDestroyExternalSemaphore() -> c_int {
-    801
+    unsupported(stringify!(cuDestroyExternalSemaphore))
 }
 #[no_mangle]
 pub extern "C" fn cuDeviceCanAccessPeer() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuDeviceGetByPCIBusId() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuDeviceGetDefaultMemPool() -> c_int {
-    801
+    unsupported(stringify!(cuDeviceCanAccessPeer))
 }
 #[no_mangle]
 pub extern "C" fn cuDeviceGetDevResource() -> c_int {
-    801
+    unsupported(stringify!(cuDeviceGetDevResource))
 }
 #[no_mangle]
 pub extern "C" fn cuDeviceGetExecAffinitySupport() -> c_int {
-    801
+    unsupported(stringify!(cuDeviceGetExecAffinitySupport))
 }
 #[no_mangle]
 pub extern "C" fn cuDeviceGetGraphMemAttribute() -> c_int {
-    801
+    unsupported(stringify!(cuDeviceGetGraphMemAttribute))
 }
 #[no_mangle]
 pub extern "C" fn cuDeviceGetHostAtomicCapabilities() -> c_int {
-    801
+    unsupported(stringify!(cuDeviceGetHostAtomicCapabilities))
 }
 #[no_mangle]
 pub extern "C" fn cuDeviceGetLuid() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuDeviceGetMemPool() -> c_int {
-    801
+    unsupported(stringify!(cuDeviceGetLuid))
 }
 #[no_mangle]
 pub extern "C" fn cuDeviceGetNvSciSyncAttributes() -> c_int {
-    801
+    unsupported(stringify!(cuDeviceGetNvSciSyncAttributes))
 }
 #[no_mangle]
 pub extern "C" fn cuDeviceGetP2PAtomicCapabilities() -> c_int {
-    801
+    unsupported(stringify!(cuDeviceGetP2PAtomicCapabilities))
 }
 #[no_mangle]
 pub extern "C" fn cuDeviceGetP2PAttribute() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuDeviceGetPCIBusId() -> c_int {
-    801
+    unsupported(stringify!(cuDeviceGetP2PAttribute))
 }
 #[no_mangle]
 pub extern "C" fn cuDeviceGetProperties() -> c_int {
-    801
+    unsupported(stringify!(cuDeviceGetProperties))
 }
 #[no_mangle]
 pub extern "C" fn cuDeviceGetTexture1DLinearMaxWidth() -> c_int {
-    801
+    unsupported(stringify!(cuDeviceGetTexture1DLinearMaxWidth))
 }
 #[no_mangle]
 pub extern "C" fn cuDeviceGraphMemTrim() -> c_int {
-    801
+    unsupported(stringify!(cuDeviceGraphMemTrim))
 }
 #[no_mangle]
 pub extern "C" fn cuDevicePrimaryCtxReset() -> c_int {
-    801
+    unsupported(stringify!(cuDevicePrimaryCtxReset))
 }
 #[no_mangle]
 pub extern "C" fn cuDevicePrimaryCtxReset_v2() -> c_int {
-    801
+    unsupported(stringify!(cuDevicePrimaryCtxReset_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuDevicePrimaryCtxSetFlags() -> c_int {
-    801
+    unsupported(stringify!(cuDevicePrimaryCtxSetFlags))
 }
 #[no_mangle]
 pub extern "C" fn cuDeviceRegisterAsyncNotification() -> c_int {
-    801
+    unsupported(stringify!(cuDeviceRegisterAsyncNotification))
 }
 #[no_mangle]
 pub extern "C" fn cuDeviceSetGraphMemAttribute() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuDeviceSetMemPool() -> c_int {
-    801
+    unsupported(stringify!(cuDeviceSetGraphMemAttribute))
 }
 #[no_mangle]
 pub extern "C" fn cuDeviceTotalMem() -> c_int {
-    801
+    unsupported(stringify!(cuDeviceTotalMem))
 }
 #[no_mangle]
 pub extern "C" fn cuDeviceUnregisterAsyncNotification() -> c_int {
-    801
+    unsupported(stringify!(cuDeviceUnregisterAsyncNotification))
 }
 #[no_mangle]
 pub extern "C" fn cuDevResourceGenerateDesc() -> c_int {
-    801
+    unsupported(stringify!(cuDevResourceGenerateDesc))
 }
 #[no_mangle]
 pub extern "C" fn cuDevSmResourceSplit() -> c_int {
-    801
+    unsupported(stringify!(cuDevSmResourceSplit))
 }
 #[no_mangle]
 pub extern "C" fn cuDevSmResourceSplitByCount() -> c_int {
-    801
+    unsupported(stringify!(cuDevSmResourceSplitByCount))
 }
 #[no_mangle]
 pub extern "C" fn cuDriverGetGpuCodeIsaVersion() -> c_int {
-    801
+    unsupported(stringify!(cuDriverGetGpuCodeIsaVersion))
 }
 #[no_mangle]
 pub extern "C" fn cuEGLApiInit() -> c_int {
-    801
+    unsupported(stringify!(cuEGLApiInit))
 }
 #[no_mangle]
 pub extern "C" fn cuEGLStreamConsumerAcquireFrame() -> c_int {
-    801
+    unsupported(stringify!(cuEGLStreamConsumerAcquireFrame))
 }
 #[no_mangle]
 pub extern "C" fn cuEGLStreamConsumerConnect() -> c_int {
-    801
+    unsupported(stringify!(cuEGLStreamConsumerConnect))
 }
 #[no_mangle]
 pub extern "C" fn cuEGLStreamConsumerConnectWithFlags() -> c_int {
-    801
+    unsupported(stringify!(cuEGLStreamConsumerConnectWithFlags))
 }
 #[no_mangle]
 pub extern "C" fn cuEGLStreamConsumerDisconnect() -> c_int {
-    801
+    unsupported(stringify!(cuEGLStreamConsumerDisconnect))
 }
 #[no_mangle]
 pub extern "C" fn cuEGLStreamConsumerReleaseFrame() -> c_int {
-    801
+    unsupported(stringify!(cuEGLStreamConsumerReleaseFrame))
 }
 #[no_mangle]
 pub extern "C" fn cuEGLStreamProducerConnect() -> c_int {
-    801
+    unsupported(stringify!(cuEGLStreamProducerConnect))
 }
 #[no_mangle]
 pub extern "C" fn cuEGLStreamProducerDisconnect() -> c_int {
-    801
+    unsupported(stringify!(cuEGLStreamProducerDisconnect))
 }
 #[no_mangle]
 pub extern "C" fn cuEGLStreamProducerPresentFrame() -> c_int {
-    801
+    unsupported(stringify!(cuEGLStreamProducerPresentFrame))
 }
 #[no_mangle]
 pub extern "C" fn cuEGLStreamProducerReturnFrame() -> c_int {
-    801
+    unsupported(stringify!(cuEGLStreamProducerReturnFrame))
 }
 #[no_mangle]
 pub extern "C" fn cuEventDestroy() -> c_int {
-    801
+    unsupported(stringify!(cuEventDestroy))
 }
 #[no_mangle]
 pub extern "C" fn cuEventElapsedTime_v2() -> c_int {
-    801
+    unsupported(stringify!(cuEventElapsedTime_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuEventRecord_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuEventRecord_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuEventRecordWithFlags() -> c_int {
-    801
+    unsupported(stringify!(cuEventRecordWithFlags))
 }
 #[no_mangle]
 pub extern "C" fn cuEventRecordWithFlags_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuEventRecordWithFlags_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuExternalMemoryGetMappedBuffer() -> c_int {
-    801
+    unsupported(stringify!(cuExternalMemoryGetMappedBuffer))
 }
 #[no_mangle]
 pub extern "C" fn cuExternalMemoryGetMappedMipmappedArray() -> c_int {
-    801
+    unsupported(stringify!(cuExternalMemoryGetMappedMipmappedArray))
 }
 #[no_mangle]
 pub extern "C" fn cuFlushGPUDirectRDMAWrites() -> c_int {
-    801
+    unsupported(stringify!(cuFlushGPUDirectRDMAWrites))
 }
 #[no_mangle]
 pub extern "C" fn cuFuncGetModule() -> c_int {
-    801
+    unsupported(stringify!(cuFuncGetModule))
 }
 #[no_mangle]
 pub extern "C" fn cuFuncGetName() -> c_int {
-    801
+    unsupported(stringify!(cuFuncGetName))
 }
 #[no_mangle]
 pub extern "C" fn cuFuncGetParamCount() -> c_int {
-    801
+    unsupported(stringify!(cuFuncGetParamCount))
 }
 #[no_mangle]
 pub extern "C" fn cuFuncGetParamInfo() -> c_int {
-    801
+    unsupported(stringify!(cuFuncGetParamInfo))
 }
 #[no_mangle]
 pub extern "C" fn cuFuncIsLoaded() -> c_int {
-    801
+    unsupported(stringify!(cuFuncIsLoaded))
 }
 #[no_mangle]
 pub extern "C" fn cuFuncLoad() -> c_int {
-    801
+    unsupported(stringify!(cuFuncLoad))
 }
 #[no_mangle]
 pub extern "C" fn cuFuncSetBlockShape() -> c_int {
-    801
+    unsupported(stringify!(cuFuncSetBlockShape))
 }
 #[no_mangle]
 pub extern "C" fn cuFuncSetSharedMemConfig() -> c_int {
-    801
+    unsupported(stringify!(cuFuncSetSharedMemConfig))
 }
 #[no_mangle]
 pub extern "C" fn cuFuncSetSharedSize() -> c_int {
-    801
+    unsupported(stringify!(cuFuncSetSharedSize))
 }
 #[no_mangle]
 pub extern "C" fn cuGLCtxCreate() -> c_int {
-    801
+    unsupported(stringify!(cuGLCtxCreate))
 }
 #[no_mangle]
 pub extern "C" fn cuGLCtxCreate_v2() -> c_int {
-    801
+    unsupported(stringify!(cuGLCtxCreate_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuGLGetDevices() -> c_int {
-    801
+    unsupported(stringify!(cuGLGetDevices))
 }
 #[no_mangle]
 pub extern "C" fn cuGLGetDevices_v2() -> c_int {
-    801
+    unsupported(stringify!(cuGLGetDevices_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuGLInit() -> c_int {
-    801
+    unsupported(stringify!(cuGLInit))
 }
 #[no_mangle]
 pub extern "C" fn cuGLMapBufferObject() -> c_int {
-    801
+    unsupported(stringify!(cuGLMapBufferObject))
 }
 #[no_mangle]
 pub extern "C" fn cuGLMapBufferObjectAsync() -> c_int {
-    801
+    unsupported(stringify!(cuGLMapBufferObjectAsync))
 }
 #[no_mangle]
 pub extern "C" fn cuGLMapBufferObjectAsync_v2() -> c_int {
-    801
+    unsupported(stringify!(cuGLMapBufferObjectAsync_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuGLMapBufferObjectAsync_v2_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuGLMapBufferObjectAsync_v2_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuGLMapBufferObject_v2() -> c_int {
-    801
+    unsupported(stringify!(cuGLMapBufferObject_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuGLMapBufferObject_v2_ptds() -> c_int {
-    801
+    unsupported(stringify!(cuGLMapBufferObject_v2_ptds))
 }
 #[no_mangle]
 pub extern "C" fn cuGLRegisterBufferObject() -> c_int {
-    801
+    unsupported(stringify!(cuGLRegisterBufferObject))
 }
 #[no_mangle]
 pub extern "C" fn cuGLSetBufferObjectMapFlags() -> c_int {
-    801
+    unsupported(stringify!(cuGLSetBufferObjectMapFlags))
 }
 #[no_mangle]
 pub extern "C" fn cuGLUnmapBufferObject() -> c_int {
-    801
+    unsupported(stringify!(cuGLUnmapBufferObject))
 }
 #[no_mangle]
 pub extern "C" fn cuGLUnmapBufferObjectAsync() -> c_int {
-    801
+    unsupported(stringify!(cuGLUnmapBufferObjectAsync))
 }
 #[no_mangle]
 pub extern "C" fn cuGLUnregisterBufferObject() -> c_int {
-    801
+    unsupported(stringify!(cuGLUnregisterBufferObject))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphAddBatchMemOpNode() -> c_int {
-    801
+    unsupported(stringify!(cuGraphAddBatchMemOpNode))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphAddChildGraphNode() -> c_int {
-    801
+    unsupported(stringify!(cuGraphAddChildGraphNode))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphAddDependencies() -> c_int {
-    801
+    unsupported(stringify!(cuGraphAddDependencies))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphAddDependencies_v2() -> c_int {
-    801
+    unsupported(stringify!(cuGraphAddDependencies_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphAddEmptyNode() -> c_int {
-    801
+    unsupported(stringify!(cuGraphAddEmptyNode))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphAddEventRecordNode() -> c_int {
-    801
+    unsupported(stringify!(cuGraphAddEventRecordNode))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphAddEventWaitNode() -> c_int {
-    801
+    unsupported(stringify!(cuGraphAddEventWaitNode))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphAddExternalSemaphoresSignalNode() -> c_int {
-    801
+    unsupported(stringify!(cuGraphAddExternalSemaphoresSignalNode))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphAddExternalSemaphoresWaitNode() -> c_int {
-    801
+    unsupported(stringify!(cuGraphAddExternalSemaphoresWaitNode))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphAddHostNode() -> c_int {
-    801
+    unsupported(stringify!(cuGraphAddHostNode))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphAddKernelNode() -> c_int {
-    801
+    unsupported(stringify!(cuGraphAddKernelNode))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphAddKernelNode_v2() -> c_int {
-    801
+    unsupported(stringify!(cuGraphAddKernelNode_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphAddMemAllocNode() -> c_int {
-    801
+    unsupported(stringify!(cuGraphAddMemAllocNode))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphAddMemcpyNode() -> c_int {
-    801
+    unsupported(stringify!(cuGraphAddMemcpyNode))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphAddMemFreeNode() -> c_int {
-    801
+    unsupported(stringify!(cuGraphAddMemFreeNode))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphAddMemsetNode() -> c_int {
-    801
+    unsupported(stringify!(cuGraphAddMemsetNode))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphAddNode() -> c_int {
-    801
+    unsupported(stringify!(cuGraphAddNode))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphAddNode_v2() -> c_int {
-    801
+    unsupported(stringify!(cuGraphAddNode_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphBatchMemOpNodeGetParams() -> c_int {
-    801
+    unsupported(stringify!(cuGraphBatchMemOpNodeGetParams))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphBatchMemOpNodeSetParams() -> c_int {
-    801
+    unsupported(stringify!(cuGraphBatchMemOpNodeSetParams))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphChildGraphNodeGetGraph() -> c_int {
-    801
+    unsupported(stringify!(cuGraphChildGraphNodeGetGraph))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphClone() -> c_int {
-    801
+    unsupported(stringify!(cuGraphClone))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphConditionalHandleCreate() -> c_int {
-    801
+    unsupported(stringify!(cuGraphConditionalHandleCreate))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphCreate() -> c_int {
-    801
+    unsupported(stringify!(cuGraphCreate))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphDebugDotPrint() -> c_int {
-    801
+    unsupported(stringify!(cuGraphDebugDotPrint))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphDestroy() -> c_int {
-    801
+    unsupported(stringify!(cuGraphDestroy))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphDestroyNode() -> c_int {
-    801
+    unsupported(stringify!(cuGraphDestroyNode))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphEventRecordNodeGetEvent() -> c_int {
-    801
+    unsupported(stringify!(cuGraphEventRecordNodeGetEvent))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphEventRecordNodeSetEvent() -> c_int {
-    801
+    unsupported(stringify!(cuGraphEventRecordNodeSetEvent))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphEventWaitNodeGetEvent() -> c_int {
-    801
+    unsupported(stringify!(cuGraphEventWaitNodeGetEvent))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphEventWaitNodeSetEvent() -> c_int {
-    801
+    unsupported(stringify!(cuGraphEventWaitNodeSetEvent))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphExecBatchMemOpNodeSetParams() -> c_int {
-    801
+    unsupported(stringify!(cuGraphExecBatchMemOpNodeSetParams))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphExecChildGraphNodeSetParams() -> c_int {
-    801
+    unsupported(stringify!(cuGraphExecChildGraphNodeSetParams))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphExecDestroy() -> c_int {
-    801
+    unsupported(stringify!(cuGraphExecDestroy))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphExecEventRecordNodeSetEvent() -> c_int {
-    801
+    unsupported(stringify!(cuGraphExecEventRecordNodeSetEvent))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphExecEventWaitNodeSetEvent() -> c_int {
-    801
+    unsupported(stringify!(cuGraphExecEventWaitNodeSetEvent))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphExecExternalSemaphoresSignalNodeSetParams() -> c_int {
-    801
+    unsupported(stringify!(cuGraphExecExternalSemaphoresSignalNodeSetParams))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphExecExternalSemaphoresWaitNodeSetParams() -> c_int {
-    801
+    unsupported(stringify!(cuGraphExecExternalSemaphoresWaitNodeSetParams))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphExecGetFlags() -> c_int {
-    801
+    unsupported(stringify!(cuGraphExecGetFlags))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphExecGetId() -> c_int {
-    801
+    unsupported(stringify!(cuGraphExecGetId))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphExecHostNodeSetParams() -> c_int {
-    801
+    unsupported(stringify!(cuGraphExecHostNodeSetParams))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphExecKernelNodeSetParams() -> c_int {
-    801
+    unsupported(stringify!(cuGraphExecKernelNodeSetParams))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphExecKernelNodeSetParams_v2() -> c_int {
-    801
+    unsupported(stringify!(cuGraphExecKernelNodeSetParams_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphExecMemcpyNodeSetParams() -> c_int {
-    801
+    unsupported(stringify!(cuGraphExecMemcpyNodeSetParams))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphExecMemsetNodeSetParams() -> c_int {
-    801
+    unsupported(stringify!(cuGraphExecMemsetNodeSetParams))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphExecNodeSetParams() -> c_int {
-    801
+    unsupported(stringify!(cuGraphExecNodeSetParams))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphExecUpdate() -> c_int {
-    801
+    unsupported(stringify!(cuGraphExecUpdate))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphExecUpdate_v2() -> c_int {
-    801
+    unsupported(stringify!(cuGraphExecUpdate_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphExternalSemaphoresSignalNodeGetParams() -> c_int {
-    801
+    unsupported(stringify!(cuGraphExternalSemaphoresSignalNodeGetParams))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphExternalSemaphoresSignalNodeSetParams() -> c_int {
-    801
+    unsupported(stringify!(cuGraphExternalSemaphoresSignalNodeSetParams))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphExternalSemaphoresWaitNodeGetParams() -> c_int {
-    801
+    unsupported(stringify!(cuGraphExternalSemaphoresWaitNodeGetParams))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphExternalSemaphoresWaitNodeSetParams() -> c_int {
-    801
+    unsupported(stringify!(cuGraphExternalSemaphoresWaitNodeSetParams))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphGetEdges() -> c_int {
-    801
+    unsupported(stringify!(cuGraphGetEdges))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphGetEdges_v2() -> c_int {
-    801
+    unsupported(stringify!(cuGraphGetEdges_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphGetId() -> c_int {
-    801
+    unsupported(stringify!(cuGraphGetId))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphGetNodes() -> c_int {
-    801
+    unsupported(stringify!(cuGraphGetNodes))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphGetRootNodes() -> c_int {
-    801
+    unsupported(stringify!(cuGraphGetRootNodes))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphHostNodeGetParams() -> c_int {
-    801
+    unsupported(stringify!(cuGraphHostNodeGetParams))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphHostNodeSetParams() -> c_int {
-    801
+    unsupported(stringify!(cuGraphHostNodeSetParams))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphicsEGLRegisterImage() -> c_int {
-    801
+    unsupported(stringify!(cuGraphicsEGLRegisterImage))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphicsGLRegisterBuffer() -> c_int {
-    801
+    unsupported(stringify!(cuGraphicsGLRegisterBuffer))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphicsGLRegisterImage() -> c_int {
-    801
+    unsupported(stringify!(cuGraphicsGLRegisterImage))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphicsMapResources() -> c_int {
-    801
+    unsupported(stringify!(cuGraphicsMapResources))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphicsMapResources_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuGraphicsMapResources_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphicsResourceGetMappedEglFrame() -> c_int {
-    801
+    unsupported(stringify!(cuGraphicsResourceGetMappedEglFrame))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphicsResourceGetMappedMipmappedArray() -> c_int {
-    801
+    unsupported(stringify!(cuGraphicsResourceGetMappedMipmappedArray))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphicsResourceGetMappedPointer() -> c_int {
-    801
+    unsupported(stringify!(cuGraphicsResourceGetMappedPointer))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphicsResourceGetMappedPointer_v2() -> c_int {
-    801
+    unsupported(stringify!(cuGraphicsResourceGetMappedPointer_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphicsResourceSetMapFlags() -> c_int {
-    801
+    unsupported(stringify!(cuGraphicsResourceSetMapFlags))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphicsResourceSetMapFlags_v2() -> c_int {
-    801
+    unsupported(stringify!(cuGraphicsResourceSetMapFlags_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphicsSubResourceGetMappedArray() -> c_int {
-    801
+    unsupported(stringify!(cuGraphicsSubResourceGetMappedArray))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphicsUnmapResources() -> c_int {
-    801
+    unsupported(stringify!(cuGraphicsUnmapResources))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphicsUnmapResources_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuGraphicsUnmapResources_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphicsUnregisterResource() -> c_int {
-    801
+    unsupported(stringify!(cuGraphicsUnregisterResource))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphicsVDPAURegisterOutputSurface() -> c_int {
-    801
+    unsupported(stringify!(cuGraphicsVDPAURegisterOutputSurface))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphicsVDPAURegisterVideoSurface() -> c_int {
-    801
+    unsupported(stringify!(cuGraphicsVDPAURegisterVideoSurface))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphInstantiate() -> c_int {
-    801
+    unsupported(stringify!(cuGraphInstantiate))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphInstantiate_v2() -> c_int {
-    801
+    unsupported(stringify!(cuGraphInstantiate_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphInstantiateWithFlags() -> c_int {
-    801
+    unsupported(stringify!(cuGraphInstantiateWithFlags))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphInstantiateWithParams() -> c_int {
-    801
+    unsupported(stringify!(cuGraphInstantiateWithParams))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphInstantiateWithParams_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuGraphInstantiateWithParams_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphKernelNodeCopyAttributes() -> c_int {
-    801
+    unsupported(stringify!(cuGraphKernelNodeCopyAttributes))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphKernelNodeGetAttribute() -> c_int {
-    801
+    unsupported(stringify!(cuGraphKernelNodeGetAttribute))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphKernelNodeGetParams() -> c_int {
-    801
+    unsupported(stringify!(cuGraphKernelNodeGetParams))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphKernelNodeGetParams_v2() -> c_int {
-    801
+    unsupported(stringify!(cuGraphKernelNodeGetParams_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphKernelNodeSetAttribute() -> c_int {
-    801
+    unsupported(stringify!(cuGraphKernelNodeSetAttribute))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphKernelNodeSetParams() -> c_int {
-    801
+    unsupported(stringify!(cuGraphKernelNodeSetParams))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphKernelNodeSetParams_v2() -> c_int {
-    801
+    unsupported(stringify!(cuGraphKernelNodeSetParams_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphLaunch() -> c_int {
-    801
+    unsupported(stringify!(cuGraphLaunch))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphLaunch_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuGraphLaunch_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphMemAllocNodeGetParams() -> c_int {
-    801
+    unsupported(stringify!(cuGraphMemAllocNodeGetParams))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphMemcpyNodeGetParams() -> c_int {
-    801
+    unsupported(stringify!(cuGraphMemcpyNodeGetParams))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphMemcpyNodeSetParams() -> c_int {
-    801
+    unsupported(stringify!(cuGraphMemcpyNodeSetParams))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphMemFreeNodeGetParams() -> c_int {
-    801
+    unsupported(stringify!(cuGraphMemFreeNodeGetParams))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphMemsetNodeGetParams() -> c_int {
-    801
+    unsupported(stringify!(cuGraphMemsetNodeGetParams))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphMemsetNodeSetParams() -> c_int {
-    801
+    unsupported(stringify!(cuGraphMemsetNodeSetParams))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphNodeFindInClone() -> c_int {
-    801
+    unsupported(stringify!(cuGraphNodeFindInClone))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphNodeGetContainingGraph() -> c_int {
-    801
+    unsupported(stringify!(cuGraphNodeGetContainingGraph))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphNodeGetDependencies() -> c_int {
-    801
+    unsupported(stringify!(cuGraphNodeGetDependencies))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphNodeGetDependencies_v2() -> c_int {
-    801
+    unsupported(stringify!(cuGraphNodeGetDependencies_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphNodeGetDependentNodes() -> c_int {
-    801
+    unsupported(stringify!(cuGraphNodeGetDependentNodes))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphNodeGetDependentNodes_v2() -> c_int {
-    801
+    unsupported(stringify!(cuGraphNodeGetDependentNodes_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphNodeGetEnabled() -> c_int {
-    801
+    unsupported(stringify!(cuGraphNodeGetEnabled))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphNodeGetLocalId() -> c_int {
-    801
+    unsupported(stringify!(cuGraphNodeGetLocalId))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphNodeGetParams() -> c_int {
-    801
+    unsupported(stringify!(cuGraphNodeGetParams))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphNodeGetToolsId() -> c_int {
-    801
+    unsupported(stringify!(cuGraphNodeGetToolsId))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphNodeGetType() -> c_int {
-    801
+    unsupported(stringify!(cuGraphNodeGetType))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphNodeSetEnabled() -> c_int {
-    801
+    unsupported(stringify!(cuGraphNodeSetEnabled))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphNodeSetParams() -> c_int {
-    801
+    unsupported(stringify!(cuGraphNodeSetParams))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphReleaseUserObject() -> c_int {
-    801
+    unsupported(stringify!(cuGraphReleaseUserObject))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphRemoveDependencies() -> c_int {
-    801
+    unsupported(stringify!(cuGraphRemoveDependencies))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphRemoveDependencies_v2() -> c_int {
-    801
+    unsupported(stringify!(cuGraphRemoveDependencies_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphRetainUserObject() -> c_int {
-    801
+    unsupported(stringify!(cuGraphRetainUserObject))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphUpload() -> c_int {
-    801
+    unsupported(stringify!(cuGraphUpload))
 }
 #[no_mangle]
 pub extern "C" fn cuGraphUpload_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuGraphUpload_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuGreenCtxCreate() -> c_int {
-    801
+    unsupported(stringify!(cuGreenCtxCreate))
 }
 #[no_mangle]
 pub extern "C" fn cuGreenCtxDestroy() -> c_int {
-    801
+    unsupported(stringify!(cuGreenCtxDestroy))
 }
 #[no_mangle]
 pub extern "C" fn cuGreenCtxGetDevResource() -> c_int {
-    801
+    unsupported(stringify!(cuGreenCtxGetDevResource))
 }
 #[no_mangle]
 pub extern "C" fn cuGreenCtxGetId() -> c_int {
-    801
+    unsupported(stringify!(cuGreenCtxGetId))
 }
 #[no_mangle]
 pub extern "C" fn cuGreenCtxRecordEvent() -> c_int {
-    801
+    unsupported(stringify!(cuGreenCtxRecordEvent))
 }
 #[no_mangle]
 pub extern "C" fn cuGreenCtxStreamCreate() -> c_int {
-    801
+    unsupported(stringify!(cuGreenCtxStreamCreate))
 }
 #[no_mangle]
 pub extern "C" fn cuGreenCtxWaitEvent() -> c_int {
-    801
+    unsupported(stringify!(cuGreenCtxWaitEvent))
 }
 #[no_mangle]
 pub extern "C" fn cuImportExternalMemory() -> c_int {
-    801
+    unsupported(stringify!(cuImportExternalMemory))
 }
 #[no_mangle]
 pub extern "C" fn cuImportExternalSemaphore() -> c_int {
-    801
+    unsupported(stringify!(cuImportExternalSemaphore))
 }
 #[no_mangle]
 pub extern "C" fn cuIpcCloseMemHandle() -> c_int {
-    801
+    unsupported(stringify!(cuIpcCloseMemHandle))
 }
 #[no_mangle]
 pub extern "C" fn cuIpcGetEventHandle() -> c_int {
-    801
+    unsupported(stringify!(cuIpcGetEventHandle))
 }
 #[no_mangle]
 pub extern "C" fn cuIpcGetMemHandle() -> c_int {
-    801
+    unsupported(stringify!(cuIpcGetMemHandle))
 }
 #[no_mangle]
 pub extern "C" fn cuIpcOpenEventHandle() -> c_int {
-    801
+    unsupported(stringify!(cuIpcOpenEventHandle))
 }
 #[no_mangle]
 pub extern "C" fn cuIpcOpenMemHandle() -> c_int {
-    801
+    unsupported(stringify!(cuIpcOpenMemHandle))
 }
 #[no_mangle]
 pub extern "C" fn cuIpcOpenMemHandle_v2() -> c_int {
-    801
+    unsupported(stringify!(cuIpcOpenMemHandle_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuKernelGetAttribute() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuKernelGetFunction() -> c_int {
-    801
+    unsupported(stringify!(cuKernelGetAttribute))
 }
 #[no_mangle]
 pub extern "C" fn cuKernelGetLibrary() -> c_int {
-    801
+    unsupported(stringify!(cuKernelGetLibrary))
 }
 #[no_mangle]
 pub extern "C" fn cuKernelGetName() -> c_int {
-    801
+    unsupported(stringify!(cuKernelGetName))
 }
 #[no_mangle]
 pub extern "C" fn cuKernelGetParamCount() -> c_int {
-    801
+    unsupported(stringify!(cuKernelGetParamCount))
 }
 #[no_mangle]
 pub extern "C" fn cuKernelGetParamInfo() -> c_int {
-    801
+    unsupported(stringify!(cuKernelGetParamInfo))
 }
 #[no_mangle]
 pub extern "C" fn cuKernelSetAttribute() -> c_int {
-    801
+    unsupported(stringify!(cuKernelSetAttribute))
 }
 #[no_mangle]
 pub extern "C" fn cuKernelSetCacheConfig() -> c_int {
-    801
+    unsupported(stringify!(cuKernelSetCacheConfig))
 }
 #[no_mangle]
 pub extern "C" fn cuLaunch() -> c_int {
-    801
+    unsupported(stringify!(cuLaunch))
 }
 #[no_mangle]
 pub extern "C" fn cuLaunchCooperativeKernelMultiDevice() -> c_int {
-    801
+    unsupported(stringify!(cuLaunchCooperativeKernelMultiDevice))
 }
 #[no_mangle]
 pub extern "C" fn cuLaunchCooperativeKernel_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuLaunchCooperativeKernel_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuLaunchGrid() -> c_int {
-    801
+    unsupported(stringify!(cuLaunchGrid))
 }
 #[no_mangle]
 pub extern "C" fn cuLaunchGridAsync() -> c_int {
-    801
+    unsupported(stringify!(cuLaunchGridAsync))
 }
 #[no_mangle]
 pub extern "C" fn cuLaunchHostFunc() -> c_int {
-    801
+    unsupported(stringify!(cuLaunchHostFunc))
 }
 #[no_mangle]
 pub extern "C" fn cuLaunchHostFunc_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuLaunchHostFunc_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuLaunchHostFunc_v2() -> c_int {
-    801
+    unsupported(stringify!(cuLaunchHostFunc_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuLaunchHostFunc_v2_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuLaunchHostFunc_v2_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuLaunchKernel_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuLaunchKernel_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuLibraryEnumerateKernels() -> c_int {
-    801
+    unsupported(stringify!(cuLibraryEnumerateKernels))
 }
 #[no_mangle]
 pub extern "C" fn cuLibraryGetGlobal() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuLibraryGetKernel() -> c_int {
-    801
+    unsupported(stringify!(cuLibraryGetGlobal))
 }
 #[no_mangle]
 pub extern "C" fn cuLibraryGetKernelCount() -> c_int {
-    801
+    unsupported(stringify!(cuLibraryGetKernelCount))
 }
 #[no_mangle]
 pub extern "C" fn cuLibraryGetManaged() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuLibraryGetModule() -> c_int {
-    801
+    unsupported(stringify!(cuLibraryGetManaged))
 }
 #[no_mangle]
 pub extern "C" fn cuLibraryGetUnifiedFunction() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuLibraryLoadData() -> c_int {
-    801
+    unsupported(stringify!(cuLibraryGetUnifiedFunction))
 }
 #[no_mangle]
 pub extern "C" fn cuLibraryLoadFromFile() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuLibraryUnload() -> c_int {
-    801
+    unsupported(stringify!(cuLibraryLoadFromFile))
 }
 #[no_mangle]
 pub extern "C" fn cuLinkAddData() -> c_int {
-    801
+    unsupported(stringify!(cuLinkAddData))
 }
 #[no_mangle]
 pub extern "C" fn cuLinkAddFile() -> c_int {
-    801
+    unsupported(stringify!(cuLinkAddFile))
 }
 #[no_mangle]
 pub extern "C" fn cuLinkAddFile_v2() -> c_int {
-    801
+    unsupported(stringify!(cuLinkAddFile_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuLinkCreate() -> c_int {
-    801
+    unsupported(stringify!(cuLinkCreate))
 }
 #[no_mangle]
 pub extern "C" fn cuLinkDestroy() -> c_int {
-    801
+    unsupported(stringify!(cuLinkDestroy))
 }
 #[no_mangle]
 pub extern "C" fn cuLogicalEndpointAddDevice() -> c_int {
-    801
+    unsupported(stringify!(cuLogicalEndpointAddDevice))
 }
 #[no_mangle]
 pub extern "C" fn cuLogicalEndpointBindAddr() -> c_int {
-    801
+    unsupported(stringify!(cuLogicalEndpointBindAddr))
 }
 #[no_mangle]
 pub extern "C" fn cuLogicalEndpointBindMem() -> c_int {
-    801
+    unsupported(stringify!(cuLogicalEndpointBindMem))
 }
 #[no_mangle]
 pub extern "C" fn cuLogicalEndpointCreate() -> c_int {
-    801
+    unsupported(stringify!(cuLogicalEndpointCreate))
 }
 #[no_mangle]
 pub extern "C" fn cuLogicalEndpointDestroy() -> c_int {
-    801
+    unsupported(stringify!(cuLogicalEndpointDestroy))
 }
 #[no_mangle]
 pub extern "C" fn cuLogicalEndpointExport() -> c_int {
-    801
+    unsupported(stringify!(cuLogicalEndpointExport))
 }
 #[no_mangle]
 pub extern "C" fn cuLogicalEndpointGetLimits() -> c_int {
-    801
+    unsupported(stringify!(cuLogicalEndpointGetLimits))
 }
 #[no_mangle]
 pub extern "C" fn cuLogicalEndpointIdRelease() -> c_int {
-    801
+    unsupported(stringify!(cuLogicalEndpointIdRelease))
 }
 #[no_mangle]
 pub extern "C" fn cuLogicalEndpointIdReserve() -> c_int {
-    801
+    unsupported(stringify!(cuLogicalEndpointIdReserve))
 }
 #[no_mangle]
 pub extern "C" fn cuLogicalEndpointImport() -> c_int {
-    801
+    unsupported(stringify!(cuLogicalEndpointImport))
 }
 #[no_mangle]
 pub extern "C" fn cuLogicalEndpointQuery() -> c_int {
-    801
+    unsupported(stringify!(cuLogicalEndpointQuery))
 }
 #[no_mangle]
 pub extern "C" fn cuLogicalEndpointUnbind() -> c_int {
-    801
+    unsupported(stringify!(cuLogicalEndpointUnbind))
 }
 #[no_mangle]
 pub extern "C" fn cuLogsCurrent() -> c_int {
-    801
+    unsupported(stringify!(cuLogsCurrent))
 }
 #[no_mangle]
 pub extern "C" fn cuLogsDumpToFile() -> c_int {
-    801
+    unsupported(stringify!(cuLogsDumpToFile))
 }
 #[no_mangle]
 pub extern "C" fn cuLogsDumpToMemory() -> c_int {
-    801
+    unsupported(stringify!(cuLogsDumpToMemory))
 }
 #[no_mangle]
 pub extern "C" fn cuLogsRegisterCallback() -> c_int {
-    801
+    unsupported(stringify!(cuLogsRegisterCallback))
 }
 #[no_mangle]
 pub extern "C" fn cuLogsUnregisterCallback() -> c_int {
-    801
+    unsupported(stringify!(cuLogsUnregisterCallback))
 }
 #[no_mangle]
 pub extern "C" fn cuMemAdvise() -> c_int {
-    801
+    unsupported(stringify!(cuMemAdvise))
 }
 #[no_mangle]
 pub extern "C" fn cuMemAdvise_v2() -> c_int {
-    801
+    unsupported(stringify!(cuMemAdvise_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuMemAlloc() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuMemAllocAsync() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuMemAllocAsync_ptsz() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuMemAllocFromPoolAsync() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuMemAllocFromPoolAsync_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuMemAlloc))
 }
 #[no_mangle]
 pub extern "C" fn cuMemAllocHost() -> c_int {
-    801
+    unsupported(stringify!(cuMemAllocHost))
 }
 #[no_mangle]
 pub extern "C" fn cuMemAllocHost_v2() -> c_int {
-    801
+    unsupported(stringify!(cuMemAllocHost_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuMemAllocManaged() -> c_int {
-    801
+    unsupported(stringify!(cuMemAllocManaged))
 }
 #[no_mangle]
 pub extern "C" fn cuMemAllocPitch() -> c_int {
-    801
+    unsupported(stringify!(cuMemAllocPitch))
 }
 #[no_mangle]
 pub extern "C" fn cuMemAllocPitch_v2() -> c_int {
-    801
+    unsupported(stringify!(cuMemAllocPitch_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuMemBatchDecompressAsync() -> c_int {
-    801
+    unsupported(stringify!(cuMemBatchDecompressAsync))
 }
 #[no_mangle]
 pub extern "C" fn cuMemBatchDecompressAsync_ptsz() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuMemcpy() -> c_int {
-    801
+    unsupported(stringify!(cuMemBatchDecompressAsync_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpy2D() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpy2D))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpy2DAsync() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpy2DAsync))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpy2DAsync_v2() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpy2DAsync_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpy2DAsync_v2_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpy2DAsync_v2_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpy2DUnaligned() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpy2DUnaligned))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpy2DUnaligned_v2() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpy2DUnaligned_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpy2DUnaligned_v2_ptds() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpy2DUnaligned_v2_ptds))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpy2D_v2() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpy2D_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpy2D_v2_ptds() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpy2D_v2_ptds))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpy3D() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpy3D))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpy3DAsync() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpy3DAsync))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpy3DAsync_v2() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpy3DAsync_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpy3DAsync_v2_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpy3DAsync_v2_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpy3DBatchAsync() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpy3DBatchAsync))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpy3DBatchAsync_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpy3DBatchAsync_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpy3DBatchAsync_v2() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpy3DBatchAsync_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpy3DBatchAsync_v2_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpy3DBatchAsync_v2_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpy3DPeer() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpy3DPeer))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpy3DPeerAsync() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpy3DPeerAsync))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpy3DPeerAsync_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpy3DPeerAsync_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpy3DPeer_ptds() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpy3DPeer_ptds))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpy3D_v2() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpy3D_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpy3D_v2_ptds() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpy3D_v2_ptds))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpy3DWithAttributesAsync() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpy3DWithAttributesAsync))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpy3DWithAttributesAsync_ptsz() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuMemcpyAsync() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuMemcpyAsync_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpy3DWithAttributesAsync_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyAtoA() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyAtoA))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyAtoA_v2() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyAtoA_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyAtoA_v2_ptds() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyAtoA_v2_ptds))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyAtoD() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyAtoD))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyAtoD_v2() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyAtoD_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyAtoD_v2_ptds() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyAtoD_v2_ptds))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyAtoH() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyAtoH))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyAtoHAsync() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyAtoHAsync))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyAtoHAsync_v2() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyAtoHAsync_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyAtoHAsync_v2_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyAtoHAsync_v2_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyAtoH_v2() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyAtoH_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyAtoH_v2_ptds() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyAtoH_v2_ptds))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyBatchAsync() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyBatchAsync))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyBatchAsync_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyBatchAsync_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyBatchAsync_v2() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyBatchAsync_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyBatchAsync_v2_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyBatchAsync_v2_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyDtoA() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyDtoA))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyDtoA_v2() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyDtoA_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyDtoA_v2_ptds() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyDtoA_v2_ptds))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyDtoD() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyDtoD))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyDtoDAsync() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyDtoDAsync))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyDtoDAsync_v2_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyDtoDAsync_v2_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyDtoD_v2_ptds() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyDtoD_v2_ptds))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyDtoH() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyDtoH))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyDtoHAsync() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyDtoHAsync))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyDtoHAsync_v2_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyDtoHAsync_v2_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyDtoH_v2_ptds() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyDtoH_v2_ptds))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyHtoA() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyHtoA))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyHtoAAsync() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyHtoAAsync))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyHtoAAsync_v2() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyHtoAAsync_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyHtoAAsync_v2_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyHtoAAsync_v2_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyHtoA_v2() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyHtoA_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyHtoA_v2_ptds() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyHtoA_v2_ptds))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyHtoD() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyHtoD))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyHtoDAsync() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyHtoDAsync))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyHtoDAsync_v2_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyHtoDAsync_v2_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyHtoD_v2_ptds() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyHtoD_v2_ptds))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyPeer() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyPeer))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyPeerAsync() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyPeerAsync))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyPeerAsync_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyPeerAsync_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyPeer_ptds() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyPeer_ptds))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpy_ptds() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpy_ptds))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyWithAttributesAsync() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyWithAttributesAsync))
 }
 #[no_mangle]
 pub extern "C" fn cuMemcpyWithAttributesAsync_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuMemcpyWithAttributesAsync_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuMemDiscardAndPrefetchBatchAsync() -> c_int {
-    801
+    unsupported(stringify!(cuMemDiscardAndPrefetchBatchAsync))
 }
 #[no_mangle]
 pub extern "C" fn cuMemDiscardAndPrefetchBatchAsync_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuMemDiscardAndPrefetchBatchAsync_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuMemDiscardBatchAsync() -> c_int {
-    801
+    unsupported(stringify!(cuMemDiscardBatchAsync))
 }
 #[no_mangle]
 pub extern "C" fn cuMemDiscardBatchAsync_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuMemDiscardBatchAsync_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuMemExportToShareableHandle() -> c_int {
-    801
+    unsupported(stringify!(cuMemExportToShareableHandle))
 }
 #[no_mangle]
 pub extern "C" fn cuMemFree() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuMemFreeAsync() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuMemFreeAsync_ptsz() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuMemFreeHost() -> c_int {
-    801
+    unsupported(stringify!(cuMemFree))
 }
 #[no_mangle]
 pub extern "C" fn cuMemGetAccess() -> c_int {
-    801
+    unsupported(stringify!(cuMemGetAccess))
 }
 #[no_mangle]
 pub extern "C" fn cuMemGetAddressRange() -> c_int {
-    801
+    unsupported(stringify!(cuMemGetAddressRange))
 }
 #[no_mangle]
 pub extern "C" fn cuMemGetAddressRange_v2() -> c_int {
-    801
+    unsupported(stringify!(cuMemGetAddressRange_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuMemGetAllocationPropertiesFromHandle() -> c_int {
-    801
+    unsupported(stringify!(cuMemGetAllocationPropertiesFromHandle))
 }
 #[no_mangle]
 pub extern "C" fn cuMemGetAttribute() -> c_int {
-    801
+    unsupported(stringify!(cuMemGetAttribute))
 }
 #[no_mangle]
 pub extern "C" fn cuMemGetAttribute_v2() -> c_int {
-    801
+    unsupported(stringify!(cuMemGetAttribute_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuMemGetDefaultMemPool() -> c_int {
-    801
+    unsupported(stringify!(cuMemGetDefaultMemPool))
 }
 #[no_mangle]
 pub extern "C" fn cuMemGetHandleForAddressRange() -> c_int {
-    801
+    unsupported(stringify!(cuMemGetHandleForAddressRange))
 }
 #[no_mangle]
 pub extern "C" fn cuMemGetInfo() -> c_int {
-    801
+    unsupported(stringify!(cuMemGetInfo))
 }
 #[no_mangle]
 pub extern "C" fn cuMemGetMemPool() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuMemHostAlloc() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuMemHostGetDevicePointer() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuMemHostGetDevicePointer_v2() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuMemHostGetFlags() -> c_int {
-    801
+    unsupported(stringify!(cuMemGetMemPool))
 }
 #[no_mangle]
 pub extern "C" fn cuMemHostRegister() -> c_int {
-    801
+    unsupported(stringify!(cuMemHostRegister))
 }
 #[no_mangle]
 pub extern "C" fn cuMemHostRegister_v2() -> c_int {
-    801
+    unsupported(stringify!(cuMemHostRegister_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuMemHostUnregister() -> c_int {
-    801
+    unsupported(stringify!(cuMemHostUnregister))
 }
 #[no_mangle]
 pub extern "C" fn cuMemImportFromShareableHandle() -> c_int {
-    801
+    unsupported(stringify!(cuMemImportFromShareableHandle))
 }
 #[no_mangle]
 pub extern "C" fn cuMemMapArrayAsync() -> c_int {
-    801
+    unsupported(stringify!(cuMemMapArrayAsync))
 }
 #[no_mangle]
 pub extern "C" fn cuMemMapArrayAsync_ptsz() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuMemPoolCreate() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuMemPoolDestroy() -> c_int {
-    801
+    unsupported(stringify!(cuMemMapArrayAsync_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuMemPoolExportPointer() -> c_int {
-    801
+    unsupported(stringify!(cuMemPoolExportPointer))
 }
 #[no_mangle]
 pub extern "C" fn cuMemPoolExportToShareableHandle() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuMemPoolGetAccess() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuMemPoolGetAttribute() -> c_int {
-    801
+    unsupported(stringify!(cuMemPoolExportToShareableHandle))
 }
 #[no_mangle]
 pub extern "C" fn cuMemPoolImportFromShareableHandle() -> c_int {
-    801
+    unsupported(stringify!(cuMemPoolImportFromShareableHandle))
 }
 #[no_mangle]
 pub extern "C" fn cuMemPoolImportPointer() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuMemPoolSetAccess() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuMemPoolSetAttribute() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuMemPoolTrimTo() -> c_int {
-    801
+    unsupported(stringify!(cuMemPoolImportPointer))
 }
 #[no_mangle]
 pub extern "C" fn cuMemPrefetchAsync() -> c_int {
-    801
+    unsupported(stringify!(cuMemPrefetchAsync))
 }
 #[no_mangle]
 pub extern "C" fn cuMemPrefetchAsync_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuMemPrefetchAsync_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuMemPrefetchAsync_v2() -> c_int {
-    801
+    unsupported(stringify!(cuMemPrefetchAsync_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuMemPrefetchAsync_v2_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuMemPrefetchAsync_v2_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuMemPrefetchBatchAsync() -> c_int {
-    801
+    unsupported(stringify!(cuMemPrefetchBatchAsync))
 }
 #[no_mangle]
 pub extern "C" fn cuMemPrefetchBatchAsync_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuMemPrefetchBatchAsync_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuMemRangeGetAttribute() -> c_int {
-    801
+    unsupported(stringify!(cuMemRangeGetAttribute))
 }
 #[no_mangle]
 pub extern "C" fn cuMemRangeGetAttributes() -> c_int {
-    801
+    unsupported(stringify!(cuMemRangeGetAttributes))
 }
 #[no_mangle]
 pub extern "C" fn cuMemRetainAllocationHandle() -> c_int {
-    801
+    unsupported(stringify!(cuMemRetainAllocationHandle))
 }
 #[no_mangle]
 pub extern "C" fn cuMemsetD16() -> c_int {
-    801
+    unsupported(stringify!(cuMemsetD16))
 }
 #[no_mangle]
 pub extern "C" fn cuMemsetD16Async() -> c_int {
-    801
+    unsupported(stringify!(cuMemsetD16Async))
 }
 #[no_mangle]
 pub extern "C" fn cuMemsetD16Async_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuMemsetD16Async_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuMemsetD16_v2() -> c_int {
-    801
+    unsupported(stringify!(cuMemsetD16_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuMemsetD16_v2_ptds() -> c_int {
-    801
+    unsupported(stringify!(cuMemsetD16_v2_ptds))
 }
 #[no_mangle]
 pub extern "C" fn cuMemsetD2D16() -> c_int {
-    801
+    unsupported(stringify!(cuMemsetD2D16))
 }
 #[no_mangle]
 pub extern "C" fn cuMemsetD2D16Async() -> c_int {
-    801
+    unsupported(stringify!(cuMemsetD2D16Async))
 }
 #[no_mangle]
 pub extern "C" fn cuMemsetD2D16Async_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuMemsetD2D16Async_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuMemsetD2D16_v2() -> c_int {
-    801
+    unsupported(stringify!(cuMemsetD2D16_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuMemsetD2D16_v2_ptds() -> c_int {
-    801
+    unsupported(stringify!(cuMemsetD2D16_v2_ptds))
 }
 #[no_mangle]
 pub extern "C" fn cuMemsetD2D32() -> c_int {
-    801
+    unsupported(stringify!(cuMemsetD2D32))
 }
 #[no_mangle]
 pub extern "C" fn cuMemsetD2D32Async() -> c_int {
-    801
+    unsupported(stringify!(cuMemsetD2D32Async))
 }
 #[no_mangle]
 pub extern "C" fn cuMemsetD2D32Async_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuMemsetD2D32Async_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuMemsetD2D32_v2() -> c_int {
-    801
+    unsupported(stringify!(cuMemsetD2D32_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuMemsetD2D32_v2_ptds() -> c_int {
-    801
+    unsupported(stringify!(cuMemsetD2D32_v2_ptds))
 }
 #[no_mangle]
 pub extern "C" fn cuMemsetD2D8() -> c_int {
-    801
+    unsupported(stringify!(cuMemsetD2D8))
 }
 #[no_mangle]
 pub extern "C" fn cuMemsetD2D8Async() -> c_int {
-    801
+    unsupported(stringify!(cuMemsetD2D8Async))
 }
 #[no_mangle]
 pub extern "C" fn cuMemsetD2D8Async_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuMemsetD2D8Async_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuMemsetD2D8_v2() -> c_int {
-    801
+    unsupported(stringify!(cuMemsetD2D8_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuMemsetD2D8_v2_ptds() -> c_int {
-    801
+    unsupported(stringify!(cuMemsetD2D8_v2_ptds))
 }
 #[no_mangle]
 pub extern "C" fn cuMemsetD32() -> c_int {
-    801
+    unsupported(stringify!(cuMemsetD32))
 }
 #[no_mangle]
 pub extern "C" fn cuMemsetD32Async() -> c_int {
-    801
+    unsupported(stringify!(cuMemsetD32Async))
 }
 #[no_mangle]
 pub extern "C" fn cuMemsetD32Async_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuMemsetD32Async_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuMemsetD32_v2() -> c_int {
-    801
+    unsupported(stringify!(cuMemsetD32_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuMemsetD32_v2_ptds() -> c_int {
-    801
+    unsupported(stringify!(cuMemsetD32_v2_ptds))
 }
 #[no_mangle]
 pub extern "C" fn cuMemsetD8() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuMemsetD8Async() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuMemsetD8Async_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuMemsetD8))
 }
 #[no_mangle]
 pub extern "C" fn cuMemsetD8_v2_ptds() -> c_int {
-    801
+    unsupported(stringify!(cuMemsetD8_v2_ptds))
 }
 #[no_mangle]
 pub extern "C" fn cuMemSetMemPool() -> c_int {
-    801
+    unsupported(stringify!(cuMemSetMemPool))
 }
 #[no_mangle]
 pub extern "C" fn cuMipmappedArrayCreate() -> c_int {
-    801
+    unsupported(stringify!(cuMipmappedArrayCreate))
 }
 #[no_mangle]
 pub extern "C" fn cuMipmappedArrayDestroy() -> c_int {
-    801
+    unsupported(stringify!(cuMipmappedArrayDestroy))
 }
 #[no_mangle]
 pub extern "C" fn cuMipmappedArrayGetLevel() -> c_int {
-    801
+    unsupported(stringify!(cuMipmappedArrayGetLevel))
 }
 #[no_mangle]
 pub extern "C" fn cuMipmappedArrayGetMemoryRequirements() -> c_int {
-    801
+    unsupported(stringify!(cuMipmappedArrayGetMemoryRequirements))
 }
 #[no_mangle]
 pub extern "C" fn cuMipmappedArrayGetSparseProperties() -> c_int {
-    801
+    unsupported(stringify!(cuMipmappedArrayGetSparseProperties))
 }
 #[no_mangle]
 pub extern "C" fn cuModuleEnumerateFunctions() -> c_int {
-    801
+    unsupported(stringify!(cuModuleEnumerateFunctions))
 }
 #[no_mangle]
 pub extern "C" fn cuModuleGetFunctionCount() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuModuleGetGlobal() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuModuleGetGlobal_v2() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuModuleGetLoadingMode() -> c_int {
-    801
+    unsupported(stringify!(cuModuleGetFunctionCount))
 }
 #[no_mangle]
 pub extern "C" fn cuModuleGetSurfRef() -> c_int {
-    801
+    unsupported(stringify!(cuModuleGetSurfRef))
 }
 #[no_mangle]
 pub extern "C" fn cuModuleGetTexRef() -> c_int {
-    801
+    unsupported(stringify!(cuModuleGetTexRef))
 }
 #[no_mangle]
 pub extern "C" fn cuMulticastAddDevice() -> c_int {
-    801
+    unsupported(stringify!(cuMulticastAddDevice))
 }
 #[no_mangle]
 pub extern "C" fn cuMulticastBindAddr() -> c_int {
-    801
+    unsupported(stringify!(cuMulticastBindAddr))
 }
 #[no_mangle]
 pub extern "C" fn cuMulticastBindAddr_v2() -> c_int {
-    801
+    unsupported(stringify!(cuMulticastBindAddr_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuMulticastBindMem() -> c_int {
-    801
+    unsupported(stringify!(cuMulticastBindMem))
 }
 #[no_mangle]
 pub extern "C" fn cuMulticastBindMem_v2() -> c_int {
-    801
+    unsupported(stringify!(cuMulticastBindMem_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuMulticastCreate() -> c_int {
-    801
+    unsupported(stringify!(cuMulticastCreate))
 }
 #[no_mangle]
 pub extern "C" fn cuMulticastGetGranularity() -> c_int {
-    801
+    unsupported(stringify!(cuMulticastGetGranularity))
 }
 #[no_mangle]
 pub extern "C" fn cuMulticastUnbind() -> c_int {
-    801
+    unsupported(stringify!(cuMulticastUnbind))
 }
 #[no_mangle]
 pub extern "C" fn cuOccupancyAvailableDynamicSMemPerBlock() -> c_int {
-    801
+    unsupported(stringify!(cuOccupancyAvailableDynamicSMemPerBlock))
 }
 #[no_mangle]
 pub extern "C" fn cuOccupancyMaxPotentialBlockSize() -> c_int {
-    801
+    unsupported(stringify!(cuOccupancyMaxPotentialBlockSize))
 }
 #[no_mangle]
 pub extern "C" fn cuOccupancyMaxPotentialBlockSizeWithFlags() -> c_int {
-    801
+    unsupported(stringify!(cuOccupancyMaxPotentialBlockSizeWithFlags))
 }
 #[no_mangle]
 pub extern "C" fn cuOccupancyMaxPotentialClusterSize() -> c_int {
-    801
+    unsupported(stringify!(cuOccupancyMaxPotentialClusterSize))
 }
 #[no_mangle]
 pub extern "C" fn cuParamSetf() -> c_int {
-    801
+    unsupported(stringify!(cuParamSetf))
 }
 #[no_mangle]
 pub extern "C" fn cuParamSeti() -> c_int {
-    801
+    unsupported(stringify!(cuParamSeti))
 }
 #[no_mangle]
 pub extern "C" fn cuParamSetSize() -> c_int {
-    801
+    unsupported(stringify!(cuParamSetSize))
 }
 #[no_mangle]
 pub extern "C" fn cuParamSetTexRef() -> c_int {
-    801
+    unsupported(stringify!(cuParamSetTexRef))
 }
 #[no_mangle]
 pub extern "C" fn cuParamSetv() -> c_int {
-    801
+    unsupported(stringify!(cuParamSetv))
 }
 #[no_mangle]
 pub extern "C" fn cuPointerSetAttribute() -> c_int {
-    801
+    unsupported(stringify!(cuPointerSetAttribute))
 }
 #[no_mangle]
 pub extern "C" fn cuProfilerInitialize() -> c_int {
-    801
+    unsupported(stringify!(cuProfilerInitialize))
 }
 #[no_mangle]
 pub extern "C" fn cuProfilerStart() -> c_int {
-    801
+    unsupported(stringify!(cuProfilerStart))
 }
 #[no_mangle]
 pub extern "C" fn cuProfilerStop() -> c_int {
-    801
+    unsupported(stringify!(cuProfilerStop))
 }
 #[no_mangle]
 pub extern "C" fn cuSignalExternalSemaphoresAsync() -> c_int {
-    801
+    unsupported(stringify!(cuSignalExternalSemaphoresAsync))
 }
 #[no_mangle]
 pub extern "C" fn cuSignalExternalSemaphoresAsync_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuSignalExternalSemaphoresAsync_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamAddCallback() -> c_int {
-    801
+    unsupported(stringify!(cuStreamAddCallback))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamAddCallback_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamAddCallback_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamAttachMemAsync() -> c_int {
-    801
+    unsupported(stringify!(cuStreamAttachMemAsync))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamAttachMemAsync_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamAttachMemAsync_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamBatchMemOp() -> c_int {
-    801
+    unsupported(stringify!(cuStreamBatchMemOp))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamBatchMemOp_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamBatchMemOp_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamBatchMemOp_v2() -> c_int {
-    801
+    unsupported(stringify!(cuStreamBatchMemOp_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamBatchMemOp_v2_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamBatchMemOp_v2_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamBeginCapture() -> c_int {
-    801
+    unsupported(stringify!(cuStreamBeginCapture))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamBeginCapture_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamBeginCapture_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamBeginCaptureToCig() -> c_int {
-    801
+    unsupported(stringify!(cuStreamBeginCaptureToCig))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamBeginCaptureToCig_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamBeginCaptureToCig_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamBeginCaptureToGraph() -> c_int {
-    801
+    unsupported(stringify!(cuStreamBeginCaptureToGraph))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamBeginCaptureToGraph_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamBeginCaptureToGraph_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamBeginCapture_v2() -> c_int {
-    801
+    unsupported(stringify!(cuStreamBeginCapture_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamBeginCapture_v2_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamBeginCapture_v2_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamBeginRecaptureToGraph() -> c_int {
-    801
+    unsupported(stringify!(cuStreamBeginRecaptureToGraph))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamBeginRecaptureToGraph_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamBeginRecaptureToGraph_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamCopyAttributes() -> c_int {
-    801
+    unsupported(stringify!(cuStreamCopyAttributes))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamCopyAttributes_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamCopyAttributes_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamDestroy() -> c_int {
-    801
+    unsupported(stringify!(cuStreamDestroy))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamEndCapture() -> c_int {
-    801
+    unsupported(stringify!(cuStreamEndCapture))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamEndCapture_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamEndCapture_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamEndCaptureToCig() -> c_int {
-    801
+    unsupported(stringify!(cuStreamEndCaptureToCig))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamEndCaptureToCig_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamEndCaptureToCig_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamGetAttribute() -> c_int {
-    801
+    unsupported(stringify!(cuStreamGetAttribute))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamGetAttribute_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamGetAttribute_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamGetCaptureInfo() -> c_int {
-    801
+    unsupported(stringify!(cuStreamGetCaptureInfo))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamGetCaptureInfo_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamGetCaptureInfo_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamGetCaptureInfo_v2() -> c_int {
-    801
+    unsupported(stringify!(cuStreamGetCaptureInfo_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamGetCaptureInfo_v2_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamGetCaptureInfo_v2_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamGetCaptureInfo_v3() -> c_int {
-    801
+    unsupported(stringify!(cuStreamGetCaptureInfo_v3))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamGetCaptureInfo_v3_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamGetCaptureInfo_v3_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamGetCtx() -> c_int {
-    801
+    unsupported(stringify!(cuStreamGetCtx))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamGetCtx_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamGetCtx_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamGetCtx_v2() -> c_int {
-    801
+    unsupported(stringify!(cuStreamGetCtx_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamGetCtx_v2_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamGetCtx_v2_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamGetDevice() -> c_int {
-    801
+    unsupported(stringify!(cuStreamGetDevice))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamGetDevice_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamGetDevice_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamGetDevResource() -> c_int {
-    801
+    unsupported(stringify!(cuStreamGetDevResource))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamGetDevResource_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamGetDevResource_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamGetFlags() -> c_int {
-    801
+    unsupported(stringify!(cuStreamGetFlags))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamGetFlags_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamGetFlags_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamGetGreenCtx() -> c_int {
-    801
+    unsupported(stringify!(cuStreamGetGreenCtx))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamGetId() -> c_int {
-    801
+    unsupported(stringify!(cuStreamGetId))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamGetId_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamGetId_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamGetPriority() -> c_int {
-    801
+    unsupported(stringify!(cuStreamGetPriority))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamGetPriority_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamGetPriority_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamIsCapturing() -> c_int {
-    801
+    unsupported(stringify!(cuStreamIsCapturing))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamIsCapturing_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamIsCapturing_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamQuery_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamQuery_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamSetAttribute() -> c_int {
-    801
+    unsupported(stringify!(cuStreamSetAttribute))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamSetAttribute_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamSetAttribute_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamSynchronize_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamSynchronize_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamUpdateCaptureDependencies() -> c_int {
-    801
+    unsupported(stringify!(cuStreamUpdateCaptureDependencies))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamUpdateCaptureDependencies_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamUpdateCaptureDependencies_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamUpdateCaptureDependencies_v2() -> c_int {
-    801
+    unsupported(stringify!(cuStreamUpdateCaptureDependencies_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamUpdateCaptureDependencies_v2_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamUpdateCaptureDependencies_v2_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamWaitEvent_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamWaitEvent_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamWaitValue32() -> c_int {
-    801
+    unsupported(stringify!(cuStreamWaitValue32))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamWaitValue32_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamWaitValue32_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamWaitValue32_v2() -> c_int {
-    801
+    unsupported(stringify!(cuStreamWaitValue32_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamWaitValue32_v2_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamWaitValue32_v2_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamWaitValue64() -> c_int {
-    801
+    unsupported(stringify!(cuStreamWaitValue64))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamWaitValue64_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamWaitValue64_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamWaitValue64_v2() -> c_int {
-    801
+    unsupported(stringify!(cuStreamWaitValue64_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamWaitValue64_v2_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamWaitValue64_v2_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamWriteValue32() -> c_int {
-    801
+    unsupported(stringify!(cuStreamWriteValue32))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamWriteValue32_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamWriteValue32_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamWriteValue32_v2() -> c_int {
-    801
+    unsupported(stringify!(cuStreamWriteValue32_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamWriteValue32_v2_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamWriteValue32_v2_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamWriteValue64() -> c_int {
-    801
+    unsupported(stringify!(cuStreamWriteValue64))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamWriteValue64_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamWriteValue64_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamWriteValue64_v2() -> c_int {
-    801
+    unsupported(stringify!(cuStreamWriteValue64_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuStreamWriteValue64_v2_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuStreamWriteValue64_v2_ptsz))
 }
 #[no_mangle]
 pub extern "C" fn cuSubgridCreate() -> c_int {
-    801
+    unsupported(stringify!(cuSubgridCreate))
 }
 #[no_mangle]
 pub extern "C" fn cuSubgridWorkerGridCreate() -> c_int {
-    801
+    unsupported(stringify!(cuSubgridWorkerGridCreate))
 }
 #[no_mangle]
 pub extern "C" fn cuSubgridWorksetCreate() -> c_int {
-    801
+    unsupported(stringify!(cuSubgridWorksetCreate))
 }
 #[no_mangle]
 pub extern "C" fn cuSurfObjectCreate() -> c_int {
-    801
+    unsupported(stringify!(cuSurfObjectCreate))
 }
 #[no_mangle]
 pub extern "C" fn cuSurfObjectDestroy() -> c_int {
-    801
+    unsupported(stringify!(cuSurfObjectDestroy))
 }
 #[no_mangle]
 pub extern "C" fn cuSurfObjectGetResourceDesc() -> c_int {
-    801
+    unsupported(stringify!(cuSurfObjectGetResourceDesc))
 }
 #[no_mangle]
 pub extern "C" fn cuSurfRefGetArray() -> c_int {
-    801
+    unsupported(stringify!(cuSurfRefGetArray))
 }
 #[no_mangle]
 pub extern "C" fn cuSurfRefSetArray() -> c_int {
-    801
+    unsupported(stringify!(cuSurfRefSetArray))
 }
 #[no_mangle]
 pub extern "C" fn cuTensorMapEncodeIm2col() -> c_int {
-    801
+    unsupported(stringify!(cuTensorMapEncodeIm2col))
 }
 #[no_mangle]
 pub extern "C" fn cuTensorMapEncodeIm2colWide() -> c_int {
-    801
+    unsupported(stringify!(cuTensorMapEncodeIm2colWide))
 }
 #[no_mangle]
 pub extern "C" fn cuTensorMapReplaceAddress() -> c_int {
-    801
+    unsupported(stringify!(cuTensorMapReplaceAddress))
 }
 #[no_mangle]
 pub extern "C" fn cuTexObjectCreate() -> c_int {
-    801
+    unsupported(stringify!(cuTexObjectCreate))
 }
 #[no_mangle]
 pub extern "C" fn cuTexObjectDestroy() -> c_int {
-    801
+    unsupported(stringify!(cuTexObjectDestroy))
 }
 #[no_mangle]
 pub extern "C" fn cuTexObjectGetResourceDesc() -> c_int {
-    801
+    unsupported(stringify!(cuTexObjectGetResourceDesc))
 }
 #[no_mangle]
 pub extern "C" fn cuTexObjectGetResourceViewDesc() -> c_int {
-    801
+    unsupported(stringify!(cuTexObjectGetResourceViewDesc))
 }
 #[no_mangle]
 pub extern "C" fn cuTexObjectGetTextureDesc() -> c_int {
-    801
+    unsupported(stringify!(cuTexObjectGetTextureDesc))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefCreate() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefCreate))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefDestroy() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefDestroy))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefGetAddress() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefGetAddress))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefGetAddressMode() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefGetAddressMode))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefGetAddress_v2() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefGetAddress_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefGetArray() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefGetArray))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefGetBorderColor() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefGetBorderColor))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefGetFilterMode() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefGetFilterMode))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefGetFlags() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefGetFlags))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefGetFormat() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefGetFormat))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefGetMaxAnisotropy() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefGetMaxAnisotropy))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefGetMipmapFilterMode() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefGetMipmapFilterMode))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefGetMipmapLevelBias() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefGetMipmapLevelBias))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefGetMipmapLevelClamp() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefGetMipmapLevelClamp))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefGetMipmappedArray() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefGetMipmappedArray))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefSetAddress() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefSetAddress))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefSetAddress2D() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefSetAddress2D))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefSetAddress2D_v2() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefSetAddress2D_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefSetAddress2D_v3() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefSetAddress2D_v3))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefSetAddressMode() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefSetAddressMode))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefSetAddress_v2() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefSetAddress_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefSetArray() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefSetArray))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefSetBorderColor() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefSetBorderColor))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefSetFilterMode() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefSetFilterMode))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefSetFlags() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefSetFlags))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefSetFormat() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefSetFormat))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefSetMaxAnisotropy() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefSetMaxAnisotropy))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefSetMipmapFilterMode() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefSetMipmapFilterMode))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefSetMipmapLevelBias() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefSetMipmapLevelBias))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefSetMipmapLevelClamp() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefSetMipmapLevelClamp))
 }
 #[no_mangle]
 pub extern "C" fn cuTexRefSetMipmappedArray() -> c_int {
-    801
-}
-#[no_mangle]
-pub extern "C" fn cuThreadExchangeStreamCaptureMode() -> c_int {
-    801
+    unsupported(stringify!(cuTexRefSetMipmappedArray))
 }
 #[no_mangle]
 pub extern "C" fn cuUserObjectCreate() -> c_int {
-    801
+    unsupported(stringify!(cuUserObjectCreate))
 }
 #[no_mangle]
 pub extern "C" fn cuUserObjectRelease() -> c_int {
-    801
+    unsupported(stringify!(cuUserObjectRelease))
 }
 #[no_mangle]
 pub extern "C" fn cuUserObjectRetain() -> c_int {
-    801
+    unsupported(stringify!(cuUserObjectRetain))
 }
 #[no_mangle]
 pub extern "C" fn cuVDPAUCtxCreate() -> c_int {
-    801
+    unsupported(stringify!(cuVDPAUCtxCreate))
 }
 #[no_mangle]
 pub extern "C" fn cuVDPAUCtxCreate_v2() -> c_int {
-    801
+    unsupported(stringify!(cuVDPAUCtxCreate_v2))
 }
 #[no_mangle]
 pub extern "C" fn cuVDPAUGetDevice() -> c_int {
-    801
+    unsupported(stringify!(cuVDPAUGetDevice))
 }
 #[no_mangle]
 pub extern "C" fn cuWaitExternalSemaphoresAsync() -> c_int {
-    801
+    unsupported(stringify!(cuWaitExternalSemaphoresAsync))
 }
 #[no_mangle]
 pub extern "C" fn cuWaitExternalSemaphoresAsync_ptsz() -> c_int {
-    801
+    unsupported(stringify!(cuWaitExternalSemaphoresAsync_ptsz))
 }

--- a/crates/smolvm-cuda-shim/src/integrity.rs
+++ b/crates/smolvm-cuda-shim/src/integrity.rs
@@ -1,0 +1,200 @@
+//! CUDA runtime integrity response used by the private cudart export table.
+//!
+//! The byte-mixing algorithm and table layout are compatible with the public
+//! ZLUDA implementation (Apache-2.0/MIT). Inputs remain local to the guest
+//! process because the hash intentionally includes its table/function
+//! addresses, process id, and thread id.
+
+#[repr(C)]
+struct Pass3Input {
+    driver_version: u32,
+    version: u32,
+    current_process: u32,
+    current_thread: u32,
+    cudart_table: usize,
+    integrity_check_table: usize,
+    function_address: usize,
+    unix_seconds: u64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub(crate) struct DeviceHashInfo {
+    pub(crate) uuid: [u8; 16],
+    pub(crate) pci_domain: i32,
+    pub(crate) pci_bus: i32,
+    pub(crate) pci_device: i32,
+}
+
+pub(crate) struct Inputs<'a> {
+    pub(crate) version: u32,
+    pub(crate) unix_seconds: u64,
+    pub(crate) driver_version: u32,
+    pub(crate) process: u32,
+    pub(crate) thread: u32,
+    pub(crate) integrity_check_table: usize,
+    pub(crate) cudart_table: usize,
+    pub(crate) function_address: usize,
+    pub(crate) devices: &'a [DeviceHashInfo],
+}
+
+pub(crate) fn compute(inputs: Inputs<'_>) -> [u64; 2] {
+    match inputs.version % 10 {
+        0 => return [0x3341_181c_03cb_675c, 0x8ed3_83aa_1f4c_d1e8],
+        1 => return [0x1841_181c_03cb_675c, 0x8ed3_83aa_1f4c_d1e8],
+        _ => {}
+    }
+
+    const PASS1: [u8; 16] = [
+        0x14, 0x6a, 0xdd, 0xae, 0x53, 0xa9, 0xa7, 0x52, 0xaa, 0x08, 0x41, 0x36, 0x0b, 0xf5, 0x5a,
+        0x9f,
+    ];
+    let mut accumulator = [0u8; 66];
+    hash_pass(&mut accumulator, &PASS1, 0x36);
+    hash_pass(
+        &mut accumulator,
+        &Pass3Input {
+            driver_version: inputs.driver_version,
+            version: inputs.version,
+            current_process: inputs.process,
+            current_thread: inputs.thread,
+            cudart_table: inputs.cudart_table,
+            integrity_check_table: inputs.integrity_check_table,
+            function_address: inputs.function_address,
+            unix_seconds: inputs.unix_seconds,
+        },
+        0,
+    );
+    for device in inputs.devices {
+        hash_pass(&mut accumulator, device, 0);
+    }
+    let first = finish(&mut accumulator);
+    accumulator[..16].fill(0);
+    accumulator[48..].fill(0);
+    hash_pass(&mut accumulator, &PASS1, 0x5c);
+    hash_pass(&mut accumulator, &first, 0);
+    finish(&mut accumulator)
+}
+
+fn hash_pass<T>(accumulator: &mut [u8; 66], input: &T, xor_mask: u8) {
+    let bytes = unsafe {
+        std::slice::from_raw_parts(
+            std::ptr::from_ref(input).cast::<u8>(),
+            std::mem::size_of_val(input),
+        )
+    };
+    for byte in bytes {
+        mix(accumulator, byte ^ xor_mask);
+    }
+}
+
+fn finish(accumulator: &mut [u8; 66]) -> [u64; 2] {
+    let padding = 16u8.wrapping_sub(accumulator[64]);
+    for _ in 0..padding {
+        mix(accumulator, padding);
+    }
+    for index in 48..64 {
+        mix(accumulator, accumulator[index]);
+    }
+    [
+        u64::from_ne_bytes(accumulator[..8].try_into().expect("eight bytes")),
+        u64::from_ne_bytes(accumulator[8..16].try_into().expect("eight bytes")),
+    ]
+}
+
+fn mix(state: &mut [u8; 66], byte: u8) {
+    const TABLE: [u8; 256] = [
+        0x29, 0x2e, 0x43, 0xc9, 0xa2, 0xd8, 0x7c, 0x01, 0x3d, 0x36, 0x54, 0xa1, 0xec, 0xf0, 0x06,
+        0x13, 0x62, 0xa7, 0x05, 0xf3, 0xc0, 0xc7, 0x73, 0x8c, 0x98, 0x93, 0x2b, 0xd9, 0xbc, 0x4c,
+        0x82, 0xca, 0x1e, 0x9b, 0x57, 0x3c, 0xfd, 0xd4, 0xe0, 0x16, 0x67, 0x42, 0x6f, 0x18, 0x8a,
+        0x17, 0xe5, 0x12, 0xbe, 0x4e, 0xc4, 0xd6, 0xda, 0x9e, 0xde, 0x49, 0xa0, 0xfb, 0xf5, 0x8e,
+        0xbb, 0x2f, 0xee, 0x7a, 0xa9, 0x68, 0x79, 0x91, 0x15, 0xb2, 0x07, 0x3f, 0x94, 0xc2, 0x10,
+        0x89, 0x0b, 0x22, 0x5f, 0x21, 0x80, 0x7f, 0x5d, 0x9a, 0x5a, 0x90, 0x32, 0x27, 0x35, 0x3e,
+        0xcc, 0xe7, 0xbf, 0xf7, 0x97, 0x03, 0xff, 0x19, 0x30, 0xb3, 0x48, 0xa5, 0xb5, 0xd1, 0xd7,
+        0x5e, 0x92, 0x2a, 0xac, 0x56, 0xaa, 0xc6, 0x4f, 0xb8, 0x38, 0xd2, 0x96, 0xa4, 0x7d, 0xb6,
+        0x76, 0xfc, 0x6b, 0xe2, 0x9c, 0x74, 0x04, 0xf1, 0x45, 0x9d, 0x70, 0x59, 0x64, 0x71, 0x87,
+        0x20, 0x86, 0x5b, 0xcf, 0x65, 0xe6, 0x2d, 0xa8, 0x02, 0x1b, 0x60, 0x25, 0xad, 0xae, 0xb0,
+        0xb9, 0xf6, 0x1c, 0x46, 0x61, 0x69, 0x34, 0x40, 0x7e, 0x0f, 0x55, 0x47, 0xa3, 0x23, 0xdd,
+        0x51, 0xaf, 0x3a, 0xc3, 0x5c, 0xf9, 0xce, 0xba, 0xc5, 0xea, 0x26, 0x2c, 0x53, 0x0d, 0x6e,
+        0x85, 0x28, 0x84, 0x09, 0xd3, 0xdf, 0xcd, 0xf4, 0x41, 0x81, 0x4d, 0x52, 0x6a, 0xdc, 0x37,
+        0xc8, 0x6c, 0xc1, 0xab, 0xfa, 0x24, 0xe1, 0x7b, 0x08, 0x0c, 0xbd, 0xb1, 0x4a, 0x78, 0x88,
+        0x95, 0x8b, 0xe3, 0x63, 0xe8, 0x6d, 0xe9, 0xcb, 0xd5, 0xfe, 0x3b, 0x00, 0x1d, 0x39, 0xf2,
+        0xef, 0xb7, 0x0e, 0x66, 0x58, 0xd0, 0xe4, 0xa6, 0x77, 0x72, 0xf8, 0xeb, 0x75, 0x4b, 0x0a,
+        0x31, 0x44, 0x50, 0xb4, 0x8f, 0xed, 0x1f, 0x1a, 0xdb, 0x99, 0x8d, 0x33, 0x9f, 0x11, 0x83,
+        0x14,
+    ];
+    let cursor = state[64] as usize;
+    state[cursor + 16] = byte;
+    let next = (state[64] + 1) & 0xf;
+    state[cursor + 32] = state[cursor] ^ byte;
+    let substituted = TABLE[(byte ^ state[65]) as usize];
+    let mixed = substituted ^ state[cursor + 48];
+    state[cursor + 48] = mixed;
+    state[65] = mixed;
+    state[64] = next;
+    if next != 0 {
+        return;
+    }
+
+    let mut value = 0x29u8;
+    for round in 0..0x12u8 {
+        value ^= state[0];
+        state[0] = value;
+        for slot in state.iter_mut().take(48).skip(1) {
+            value = *slot ^ TABLE[value as usize];
+            *slot = value;
+        }
+        value = value.wrapping_add(round);
+        if round != 0x11 {
+            value = TABLE[value as usize];
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixed_versions_match_runtime_constants() {
+        let input = |version| Inputs {
+            version,
+            unix_seconds: 0,
+            driver_version: 0,
+            process: 0,
+            thread: 0,
+            integrity_check_table: 0,
+            cudart_table: 0,
+            function_address: 0,
+            devices: &[],
+        };
+        assert_eq!(
+            compute(input(12080)),
+            [0x3341_181c_03cb_675c, 0x8ed3_83aa_1f4c_d1e8]
+        );
+        assert_eq!(
+            compute(input(12081)),
+            [0x1841_181c_03cb_675c, 0x8ed3_83aa_1f4c_d1e8]
+        );
+    }
+
+    #[test]
+    fn pass2_matches_known_vector() {
+        const PASS1: [u8; 16] = [
+            0x14, 0x6a, 0xdd, 0xae, 0x53, 0xa9, 0xa7, 0x52, 0xaa, 0x08, 0x41, 0x36, 0x0b, 0xf5,
+            0x5a, 0x9f,
+        ];
+        let mut state = [0u8; 66];
+        hash_pass(&mut state, &PASS1, 0x36);
+        assert_eq!(
+            state,
+            [
+                0x8b, 0x21, 0x9a, 0x49, 0xe8, 0x6d, 0x1a, 0xee, 0xf2, 0x37, 0xf9, 0xb5, 0x4a, 0x8c,
+                0x3c, 0x75, 0xc7, 0x1e, 0xee, 0x21, 0xcf, 0x29, 0x8a, 0xe5, 0x13, 0x83, 0xf4, 0xec,
+                0x33, 0x04, 0xe2, 0xfd, 0xb0, 0x2f, 0x09, 0x01, 0x4f, 0xf7, 0x68, 0x6d, 0x69, 0x46,
+                0x43, 0x7e, 0xb6, 0x2b, 0x21, 0xed, 0x57, 0xa1, 0x10, 0x86, 0x0e, 0x60, 0x44, 0x1e,
+                0x70, 0x5f, 0x67, 0xd1, 0xeb, 0x67, 0xa1, 0x3d, 0x00, 0x3d,
+            ]
+        );
+    }
+}

--- a/crates/smolvm-cuda-shim/src/lib.rs
+++ b/crates/smolvm-cuda-shim/src/lib.rs
@@ -32,8 +32,9 @@
 
 use smolvm_cuda::client::{Client, CudaRpcError};
 mod driver_stubs;
+mod integrity;
 use std::collections::HashMap;
-use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
+use std::ffi::{c_char, c_int, c_uint, c_void, CStr, CString};
 use std::io::{Read, Write};
 use std::sync::Mutex;
 
@@ -41,12 +42,39 @@ use std::sync::Mutex;
 
 const CUDA_SUCCESS: c_int = 0;
 const CUDA_ERROR_INVALID_VALUE: c_int = 1;
+const CUDA_ERROR_OUT_OF_MEMORY: c_int = 2;
 const CUDA_ERROR_NOT_INITIALIZED: c_int = 3;
 const CUDA_ERROR_NO_DEVICE: c_int = 100;
+const CUDA_ERROR_INVALID_IMAGE: c_int = 200;
 const CUDA_ERROR_INVALID_CONTEXT: c_int = 201;
 const CUDA_ERROR_NOT_FOUND: c_int = 500;
 const CUDA_ERROR_NOT_SUPPORTED: c_int = 801;
 const CUDA_ERROR_UNKNOWN: c_int = 999;
+
+#[repr(C)]
+pub struct CUmemLocation {
+    type_: c_int,
+    id: c_int,
+}
+
+/// CUDA keeps this ABI at 88 bytes; newer toolkits consume fields that were
+/// reserved in older versions without changing the public layout.
+#[repr(C)]
+pub struct CUmemPoolProps {
+    alloc_type: c_int,
+    handle_types: c_uint,
+    location: CUmemLocation,
+    win32_security_attributes: *mut c_void,
+    max_size: usize,
+    usage: u16,
+    reserved: [u8; 54],
+}
+
+#[repr(C)]
+pub struct CUmemAccessDesc {
+    location: CUmemLocation,
+    flags: c_int,
+}
 
 /// The CUDA version this shim reports for its own API surface.
 /// CUDA version the driver shim ADVERTISES. Must not overpromise: a real cu12
@@ -410,21 +438,434 @@ pub extern "C" fn cuInit(_flags: c_uint) -> c_int {
     ret(ensure_connected(&mut guard))
 }
 
-/// Undocumented internal driver interface tables, keyed by a 16-byte UUID.
-/// NVIDIA's CUDA runtime (`libcudart`) requires several of these to complete
-/// its context bootstrap; their layout and function ABIs are private and not
-/// part of the public Driver API this shim implements. Returning "not
-/// supported" (and logging the UUID under trace) makes the boundary explicit:
-/// a pure `libcuda` shim cannot host NVIDIA's runtime — that needs remoting at
-/// the `libcudart` level instead. See docs/cuda-support-plan.md (Phase 4).
-#[no_mangle]
-pub extern "C" fn cuGetExportTable(_table: *mut *const c_void, uuid: *const c_void) -> c_int {
-    if std::env::var_os("SMOLVM_CUDA_SHIM_TRACE").is_some() && !uuid.is_null() {
-        let b = unsafe { std::slice::from_raw_parts(uuid as *const u8, 16) };
-        let hex: String = b.iter().map(|x| format!("{x:02x}")).collect();
-        eprintln!("[shim] cuGetExportTable uuid={hex} -> NOT_SUPPORTED");
+/// CUDA's statically linked runtime uses this process-local table to retain the
+/// primary context and register embedded fatbins. Dynamic `libcudart` is
+/// normally replaced by smolvm's runtime shim, but libraries that embed cudart
+/// (collective runtimes are a common example) cannot be interposed that way.
+/// Keep the private table deliberately small and implement its operations in
+/// terms of the public driver entry points already forwarded by this shim.
+const CUDART_INTERFACE_UUID: [u8; 16] = [
+    0x6b, 0xd5, 0xfb, 0x6c, 0x5b, 0xf4, 0xe7, 0x4a, 0x89, 0x87, 0xd9, 0x39, 0x12, 0xfd, 0x9d, 0xf9,
+];
+
+// This probe UUID asks whether the driver can bypass normal cudart bootstrap.
+// Success skips the CUDART_INTERFACE path, so an implementation that does not
+// provide the bypass table must report NOT_FOUND rather than NOT_SUPPORTED.
+const CUDART_SKIP_INIT_UUID: [u8; 16] = [
+    0xf8, 0xcf, 0xf9, 0x51, 0x21, 0x46, 0x8b, 0x4e, 0xb9, 0xe2, 0xfb, 0x46, 0x9e, 0x7c, 0x0d, 0xd9,
+];
+
+const TOOLS_RUNTIME_CALLBACK_HOOKS_UUID: [u8; 16] = [
+    0xa0, 0x94, 0x79, 0x8c, 0x2e, 0x74, 0x2e, 0x74, 0x93, 0xf2, 0x08, 0x00, 0x20, 0x0c, 0x0a, 0x66,
+];
+
+const TOOLS_TLS_UUID: [u8; 16] = [
+    0x42, 0xd8, 0x5a, 0x81, 0x23, 0xf6, 0xcb, 0x47, 0x82, 0x98, 0xf6, 0xe7, 0x8a, 0x3a, 0xec, 0xdc,
+];
+
+const CONTEXT_LOCAL_STORAGE_UUID: [u8; 16] = [
+    0xc6, 0x93, 0x33, 0x6e, 0x11, 0x21, 0xdf, 0x11, 0xa8, 0xc3, 0x68, 0xf3, 0x55, 0xd8, 0x95, 0x93,
+];
+
+const CONTEXT_CHECKS_UUID: [u8; 16] = [
+    0x26, 0x3e, 0x88, 0x60, 0x7c, 0xd2, 0x61, 0x43, 0x92, 0xf6, 0xbb, 0xd5, 0x00, 0x6d, 0xfa, 0x7e,
+];
+
+const INTEGRITY_CHECK_UUID: [u8; 16] = [
+    0xd4, 0x08, 0x20, 0x55, 0xbd, 0xe6, 0x70, 0x4b, 0x8d, 0x34, 0xba, 0x12, 0x3c, 0x66, 0xe1, 0xf2,
+];
+
+#[repr(C)]
+struct FatbincWrapper {
+    magic: c_uint,
+    _version: c_uint,
+    data: *const c_void,
+    _filename_or_fatbins: *const c_void,
+}
+
+fn trace_private_call(name: &str, status: c_int) -> c_int {
+    if std::env::var_os("SMOLVM_CUDA_SHIM_TRACE").is_some() {
+        eprintln!("[shim] private driver call: {name} -> {status}");
     }
-    CUDA_ERROR_NOT_SUPPORTED
+    status
+}
+
+extern "C" fn cudart_get_module_from_cubin(
+    module: *mut *mut c_void,
+    wrapper: *const FatbincWrapper,
+) -> c_int {
+    if module.is_null() || wrapper.is_null() {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    let wrapper = unsafe { &*wrapper };
+    if wrapper.magic != 0x4662_43b1 || wrapper.data.is_null() {
+        return 200; // CUDA_ERROR_INVALID_IMAGE
+    }
+    trace_private_call(
+        "CUDART_INTERFACE.get_module_from_cubin",
+        cuModuleLoadData(module, wrapper.data),
+    )
+}
+
+extern "C" fn cudart_primary_context(pctx: *mut *mut c_void, device: c_int) -> c_int {
+    trace_private_call(
+        "CUDART_INTERFACE.primary_context",
+        cuDevicePrimaryCtxRetain(pctx, device),
+    )
+}
+
+extern "C" fn cudart_get_module_from_cubin_ext1(
+    module: *mut *mut c_void,
+    wrapper: *const FatbincWrapper,
+    _arg3: *mut c_void,
+    _arg4: *mut c_void,
+    _arg5: c_uint,
+) -> c_int {
+    cudart_get_module_from_cubin(module, wrapper)
+}
+
+extern "C" fn cudart_interface_fn7(_arg: usize) {}
+
+extern "C" fn cudart_get_module_from_cubin_ext2(
+    fatbin_header: *const c_void,
+    module: *mut *mut c_void,
+    _arg3: *mut c_void,
+    _arg4: *mut c_void,
+    _arg5: c_uint,
+) -> c_int {
+    if module.is_null() || fatbin_header.is_null() {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    trace_private_call(
+        "CUDART_INTERFACE.get_module_from_cubin_ext2",
+        cuModuleLoadData(module, fatbin_header),
+    )
+}
+
+extern "C" fn cudart_load_compilers() -> c_int {
+    trace_private_call("CUDART_INTERFACE.load_compilers", CUDA_SUCCESS)
+}
+
+fn cudart_interface_table() -> &'static [usize; 13] {
+    static TABLE: std::sync::OnceLock<[usize; 13]> = std::sync::OnceLock::new();
+    TABLE.get_or_init(|| {
+        [
+            13 * std::mem::size_of::<usize>(),
+            cudart_get_module_from_cubin as *const () as usize,
+            cudart_primary_context as *const () as usize,
+            0,
+            0,
+            0,
+            cudart_get_module_from_cubin_ext1 as *const () as usize,
+            cudart_interface_fn7 as *const () as usize,
+            cudart_get_module_from_cubin_ext2 as *const () as usize,
+            0,
+            0,
+            0,
+            cudart_load_compilers as *const () as usize,
+        ]
+    })
+}
+
+fn tools_buffer<const N: usize>(slot: &'static std::sync::OnceLock<usize>) -> *mut c_void {
+    *slot.get_or_init(|| Box::into_raw(Box::new([0u8; N])) as usize) as *mut c_void
+}
+
+extern "C" fn tools_get_buffer1(ptr: *mut *mut c_void, size: *mut usize) {
+    static BUFFER: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    if !ptr.is_null() {
+        unsafe { *ptr = tools_buffer::<1024>(&BUFFER) };
+    }
+    if !size.is_null() {
+        unsafe { *size = 1024 };
+    }
+}
+
+extern "C" fn tools_get_buffer2(ptr: *mut *mut c_void, size: *mut usize) {
+    static BUFFER: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    if !ptr.is_null() {
+        unsafe { *ptr = tools_buffer::<14>(&BUFFER) };
+    }
+    if !size.is_null() {
+        unsafe { *size = 14 };
+    }
+}
+
+fn tools_runtime_callback_hooks_table() -> &'static [usize; 7] {
+    static TABLE: std::sync::OnceLock<[usize; 7]> = std::sync::OnceLock::new();
+    TABLE.get_or_init(|| {
+        [
+            7 * std::mem::size_of::<usize>(),
+            tools_runtime_callback_event as *const () as usize,
+            tools_get_buffer1 as *const () as usize,
+            0,
+            tools_runtime_callback_span as *const () as usize,
+            0,
+            tools_get_buffer2 as *const () as usize,
+        ]
+    })
+}
+
+// The static runtime brackets driver lookups with these private tooling hooks.
+// No profiler is registered in the guest, so preserving the callbacks as
+// no-ops is the correct behavior. They must still be callable: CUDA 12.8 uses
+// them on the ordinary "optional symbol not found" path.
+extern "C" fn tools_runtime_callback_event(_event: c_uint, _data: *mut c_void) {}
+
+extern "C" fn tools_runtime_callback_span(_context: *mut c_void, _data: *mut c_void) {}
+
+extern "C" fn tools_tls_callback(_record: *mut c_void) {}
+
+fn tools_tls_table() -> &'static [usize; 4] {
+    static TABLE: std::sync::OnceLock<[usize; 4]> = std::sync::OnceLock::new();
+    TABLE.get_or_init(|| {
+        [
+            4 * std::mem::size_of::<usize>(),
+            0,
+            tools_tls_callback as *const () as usize,
+            0,
+        ]
+    })
+}
+
+fn context_local_storage() -> &'static Mutex<HashMap<(usize, usize), usize>> {
+    static STORAGE: std::sync::OnceLock<Mutex<HashMap<(usize, usize), usize>>> =
+        std::sync::OnceLock::new();
+    STORAGE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn context_handle(context: *mut c_void) -> Result<usize, c_int> {
+    if !context.is_null() {
+        return Ok(context as usize);
+    }
+    let mut current = std::ptr::null_mut();
+    let result = cuCtxGetCurrent(&mut current);
+    if result != CUDA_SUCCESS {
+        return Err(result);
+    }
+    if current.is_null() {
+        Err(CUDA_ERROR_INVALID_CONTEXT)
+    } else {
+        Ok(current as usize)
+    }
+}
+
+extern "C" fn context_local_storage_put(
+    context: *mut c_void,
+    key: *mut c_void,
+    value: *mut c_void,
+    _destructor: *mut c_void,
+) -> c_int {
+    let context = match context_handle(context) {
+        Ok(context) => context,
+        Err(error) => return error,
+    };
+    match context_local_storage().lock() {
+        Ok(mut storage) => {
+            storage.insert((context, key as usize), value as usize);
+            CUDA_SUCCESS
+        }
+        Err(_) => CUDA_ERROR_UNKNOWN,
+    }
+}
+
+extern "C" fn context_local_storage_delete(context: *mut c_void, key: *mut c_void) -> c_int {
+    let context = match context_handle(context) {
+        Ok(context) => context,
+        Err(error) => return error,
+    };
+    match context_local_storage().lock() {
+        Ok(mut storage) => {
+            storage.remove(&(context, key as usize));
+            CUDA_SUCCESS
+        }
+        Err(_) => CUDA_ERROR_UNKNOWN,
+    }
+}
+
+extern "C" fn context_local_storage_get(
+    value: *mut *mut c_void,
+    context: *mut c_void,
+    key: *mut c_void,
+) -> c_int {
+    if value.is_null() {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    let context = match context_handle(context) {
+        Ok(context) => context,
+        Err(error) => return error,
+    };
+    match context_local_storage().lock() {
+        Ok(storage) => match storage.get(&(context, key as usize)) {
+            Some(&stored) => {
+                unsafe { *value = stored as *mut c_void };
+                CUDA_SUCCESS
+            }
+            None => {
+                unsafe { *value = std::ptr::null_mut() };
+                CUDA_ERROR_NOT_FOUND
+            }
+        },
+        Err(_) => CUDA_ERROR_UNKNOWN,
+    }
+}
+
+fn context_local_storage_table() -> &'static [usize; 4] {
+    static TABLE: std::sync::OnceLock<[usize; 4]> = std::sync::OnceLock::new();
+    TABLE.get_or_init(|| {
+        [
+            context_local_storage_put as *const () as usize,
+            context_local_storage_delete as *const () as usize,
+            context_local_storage_get as *const () as usize,
+            0,
+        ]
+    })
+}
+
+extern "C" fn context_check(
+    _context: *mut c_void,
+    result: *mut c_uint,
+    _detail: *mut *const c_void,
+) -> c_int {
+    if !result.is_null() {
+        unsafe { *result = 0 };
+    }
+    CUDA_SUCCESS
+}
+
+extern "C" fn context_check_flags() -> c_uint {
+    0
+}
+
+fn context_checks_table() -> &'static [usize; 4] {
+    static TABLE: std::sync::OnceLock<[usize; 4]> = std::sync::OnceLock::new();
+    TABLE.get_or_init(|| {
+        [
+            4 * std::mem::size_of::<usize>(),
+            0,
+            context_check as *const () as usize,
+            context_check_flags as *const () as usize,
+        ]
+    })
+}
+
+extern "C" fn integrity_check(version: c_uint, unix_seconds: u64, result: *mut [u64; 2]) -> c_int {
+    if result.is_null() {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    let mut count = 0;
+    let status = cuDeviceGetCount(&mut count);
+    if status != CUDA_SUCCESS {
+        return status;
+    }
+    let mut devices = Vec::with_capacity(count.max(0) as usize);
+    for device in 0..count {
+        let mut uuid = [0u8; 16];
+        let status = cuDeviceGetUuid(uuid.as_mut_ptr(), device);
+        if status != CUDA_SUCCESS {
+            return status;
+        }
+        let attribute = |id| {
+            let mut value = 0;
+            let status = cuDeviceGetAttribute(&mut value, id, device);
+            if status == CUDA_SUCCESS {
+                Ok(value)
+            } else {
+                Err(status)
+            }
+        };
+        let pci_domain = match attribute(50) {
+            Ok(value) => value,
+            Err(status) => return status,
+        };
+        let pci_bus = match attribute(33) {
+            Ok(value) => value,
+            Err(status) => return status,
+        };
+        let pci_device = match attribute(34) {
+            Ok(value) => value,
+            Err(status) => return status,
+        };
+        devices.push(integrity::DeviceHashInfo {
+            uuid,
+            pci_domain,
+            pci_bus,
+            pci_device,
+        });
+    }
+    #[cfg(unix)]
+    let thread = unsafe { libc::pthread_self() as usize as u32 };
+    #[cfg(windows)]
+    let thread = unsafe {
+        unsafe extern "system" {
+            fn GetCurrentThreadId() -> u32;
+        }
+        GetCurrentThreadId()
+    };
+    let response = integrity::compute(integrity::Inputs {
+        version,
+        unix_seconds,
+        driver_version: shim_cuda_version() as u32,
+        process: std::process::id(),
+        thread,
+        integrity_check_table: integrity_check_table().as_ptr() as usize,
+        cudart_table: cudart_interface_table().as_ptr() as usize,
+        function_address: integrity_check as *const () as usize,
+        devices: &devices,
+    });
+    unsafe { *result = response };
+    CUDA_SUCCESS
+}
+
+fn integrity_check_table() -> &'static [usize; 3] {
+    static TABLE: std::sync::OnceLock<[usize; 3]> = std::sync::OnceLock::new();
+    TABLE.get_or_init(|| {
+        [
+            3 * std::mem::size_of::<usize>(),
+            integrity_check as *const () as usize,
+            0,
+        ]
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn cuGetExportTable(table: *mut *const c_void, uuid: *const c_void) -> c_int {
+    if table.is_null() || uuid.is_null() {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    let b = unsafe { std::slice::from_raw_parts(uuid as *const u8, 16) };
+    let (result, label) = if b == CUDART_INTERFACE_UUID {
+        unsafe { *table = cudart_interface_table().as_ptr().cast() };
+        (CUDA_SUCCESS, "CUDART_INTERFACE")
+    } else if b == TOOLS_RUNTIME_CALLBACK_HOOKS_UUID {
+        unsafe { *table = tools_runtime_callback_hooks_table().as_ptr().cast() };
+        (CUDA_SUCCESS, "TOOLS_RUNTIME_CALLBACK_HOOKS")
+    } else if b == TOOLS_TLS_UUID {
+        unsafe { *table = tools_tls_table().as_ptr().cast() };
+        (CUDA_SUCCESS, "TOOLS_TLS")
+    } else if b == CONTEXT_LOCAL_STORAGE_UUID {
+        unsafe { *table = context_local_storage_table().as_ptr().cast() };
+        (CUDA_SUCCESS, "CONTEXT_LOCAL_STORAGE")
+    } else if b == CONTEXT_CHECKS_UUID {
+        unsafe { *table = context_checks_table().as_ptr().cast() };
+        (CUDA_SUCCESS, "CONTEXT_CHECKS")
+    } else if b == INTEGRITY_CHECK_UUID {
+        unsafe { *table = integrity_check_table().as_ptr().cast() };
+        (CUDA_SUCCESS, "INTEGRITY_CHECK")
+    } else {
+        unsafe { *table = std::ptr::null() };
+        let label = if b == CUDART_SKIP_INIT_UUID {
+            "SKIP_INIT_NOT_FOUND"
+        } else {
+            "NOT_FOUND"
+        };
+        (CUDA_ERROR_NOT_FOUND, label)
+    };
+    if std::env::var_os("SMOLVM_CUDA_SHIM_TRACE").is_some() {
+        let hex: String = b.iter().map(|x| format!("{x:02x}")).collect();
+        eprintln!("[shim] cuGetExportTable uuid={hex} -> {label}");
+    }
+    result
 }
 
 #[no_mangle]
@@ -536,6 +977,42 @@ pub extern "C" fn cuDeviceGetUuid(uuid: *mut u8, device: c_int) -> c_int {
 #[no_mangle]
 pub extern "C" fn cuDeviceGetUuid_v2(uuid: *mut u8, device: c_int) -> c_int {
     cuDeviceGetUuid(uuid, device)
+}
+
+#[no_mangle]
+pub extern "C" fn cuDeviceGetPCIBusId(pci_bus_id: *mut c_char, len: c_int, device: c_int) -> c_int {
+    if pci_bus_id.is_null() || len <= 0 {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    match with_state(|state| state.client.device_get_pci_bus_id(device)) {
+        Ok(value) => {
+            let bytes = value.as_bytes();
+            if bytes.len() >= len as usize {
+                return CUDA_ERROR_INVALID_VALUE;
+            }
+            unsafe {
+                std::ptr::copy_nonoverlapping(bytes.as_ptr(), pci_bus_id.cast::<u8>(), bytes.len());
+                *pci_bus_id.add(bytes.len()) = 0;
+            }
+            CUDA_SUCCESS
+        }
+        Err(status) => status,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn cuDeviceGetByPCIBusId(device: *mut c_int, pci_bus_id: *const c_char) -> c_int {
+    if device.is_null() || pci_bus_id.is_null() {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    let value = match unsafe { CStr::from_ptr(pci_bus_id) }.to_str() {
+        Ok(value) => value,
+        Err(_) => return CUDA_ERROR_INVALID_VALUE,
+    };
+    ret(
+        with_state(|state| state.client.device_get_by_pci_bus_id(value))
+            .and_then(|ordinal| unsafe { out(device, ordinal) }),
+    )
 }
 
 // ---- contexts -------------------------------------------------------------------
@@ -815,6 +1292,94 @@ unsafe fn module_image_len(image: *const c_void) -> Result<usize, c_int> {
         + 1)
 }
 
+/// Resolve the private fatbin wrapper that statically linked libcudart passes
+/// to the CUDA Library API into the actual module image behind it.
+///
+/// CUDA 12's static runtime uses `cuLibraryLoadData` with
+/// `__fatBinC_Wrapper_t`, rather than passing its embedded fatbin directly.
+/// Forwarding the wrapper bytes as PTX truncates them at the first zero byte
+/// (six bytes for a version-1 wrapper) and the host driver reports
+/// `CUDA_ERROR_INVALID_IMAGE`. Version 1 has one image pointer and is the form
+/// emitted by the NCCL 2.27.5 binaries. Version 2 describes a list of images,
+/// which cannot be represented by the shim's single module handle yet.
+unsafe fn canonical_module_image(image: *const c_void) -> Result<*const c_void, c_int> {
+    if image.is_null() {
+        return Err(CUDA_ERROR_INVALID_VALUE);
+    }
+    let magic = unsafe { (image as *const u32).read_unaligned() };
+    if magic != 0x4662_43b1 {
+        return Ok(image);
+    }
+    let wrapper = unsafe { &*(image as *const FatbincWrapper) };
+    match wrapper._version {
+        1 if !wrapper.data.is_null() => Ok(wrapper.data),
+        1 => Err(CUDA_ERROR_INVALID_VALUE),
+        _ => Err(CUDA_ERROR_NOT_SUPPORTED),
+    }
+}
+
+#[cfg(test)]
+mod module_image_tests {
+    use super::*;
+
+    #[test]
+    fn unwraps_version_one_fatbin_wrapper() {
+        let image = [0x50_u8, 0xed, 0x55, 0xba];
+        let wrapper = FatbincWrapper {
+            magic: 0x4662_43b1,
+            _version: 1,
+            data: image.as_ptr().cast(),
+            _filename_or_fatbins: std::ptr::null(),
+        };
+
+        let resolved =
+            unsafe { canonical_module_image((&wrapper as *const FatbincWrapper).cast()) };
+        assert_eq!(resolved, Ok(image.as_ptr().cast()));
+    }
+
+    #[test]
+    fn leaves_direct_module_images_unchanged() {
+        let image = [0x7f_u8, b'E', b'L', b'F'];
+        let ptr = image.as_ptr().cast();
+        assert_eq!(unsafe { canonical_module_image(ptr) }, Ok(ptr));
+    }
+
+    #[test]
+    fn rejects_multi_image_fatbin_wrapper() {
+        let wrapper = FatbincWrapper {
+            magic: 0x4662_43b1,
+            _version: 2,
+            data: std::ptr::null(),
+            _filename_or_fatbins: std::ptr::null(),
+        };
+
+        assert_eq!(
+            unsafe { canonical_module_image((&wrapper as *const FatbincWrapper).cast()) },
+            Err(CUDA_ERROR_NOT_SUPPORTED)
+        );
+    }
+
+    #[test]
+    fn parses_version_two_fatbin_list() {
+        let first = [0x50_u8, 0xed, 0x55, 0xba];
+        let second = [0x50_u8, 0xed, 0x55, 0xba];
+        let list = [
+            first.as_ptr().cast::<c_void>(),
+            second.as_ptr().cast::<c_void>(),
+            std::ptr::null(),
+        ];
+        let wrapper = FatbincWrapper {
+            magic: 0x4662_43b1,
+            _version: 2,
+            data: std::ptr::null(),
+            _filename_or_fatbins: list.as_ptr().cast(),
+        };
+
+        let images = unsafe { version_two_fatbins(&wrapper) }.unwrap();
+        assert_eq!(images, list[..2]);
+    }
+}
+
 // ---- VMM (torch expandable-segments allocator) --------------------------------
 // Prop/desc structs are read at fixed offsets: CUmemAllocationProp.location.id
 // sits at byte 12, CUmemAccessDesc.location.id at byte 4.
@@ -1001,6 +1566,10 @@ pub extern "C" fn cuMemGetAllocationGranularity(
 
 #[no_mangle]
 pub extern "C" fn cuModuleLoadData(module: *mut *mut c_void, image: *const c_void) -> c_int {
+    let image = match unsafe { canonical_module_image(image) } {
+        Ok(image) => image,
+        Err(code) => return code,
+    };
     let len = match unsafe { module_image_len(image) } {
         Ok(l) => l,
         Err(code) => return code,
@@ -1048,23 +1617,754 @@ pub extern "C" fn cuModuleLoad(module: *mut *mut c_void, fname: *const c_char) -
     }
 }
 
+/// Smolvm resolves and loads a module's full image before returning its handle,
+/// so its observable loading mode is eager even when the guest requested lazy
+/// kernel loading.
+#[no_mangle]
+pub extern "C" fn cuModuleGetLoadingMode(mode: *mut c_int) -> c_int {
+    ret(unsafe { out(mode, 1) }) // CU_MODULE_EAGER_LOADING
+}
+
+const CUDA_LIBRARY_BEGIN: u16 = 3;
+const CUDA_LIBRARY_ADD_IMAGE: u16 = 4;
+const CUDA_LIBRARY_COMPLETE: u16 = 5;
+const CUDA_LIBRARY_UNLOAD: u16 = 6;
+const CUDA_LIBRARY_GET_KERNEL: u16 = 7;
+const CUDA_KERNEL_GET_FUNCTION: u16 = 8;
+const CUDA_LIBRARY_GET_MODULE: u16 = 9;
+const CUDA_LIBRARY_CANCEL: u16 = 10;
+const CUDA_MODULE_GET_GLOBAL: u16 = 11;
+const CUDA_HOST_REGISTER_GPA: u16 = 12;
+const CUDA_HOST_UNREGISTER_GPA: u16 = 13;
+
+fn native_libraries() -> &'static Mutex<std::collections::HashSet<usize>> {
+    static HANDLES: std::sync::OnceLock<Mutex<std::collections::HashSet<usize>>> =
+        std::sync::OnceLock::new();
+    HANDLES.get_or_init(|| Mutex::new(std::collections::HashSet::new()))
+}
+
+fn native_kernels() -> &'static Mutex<std::collections::HashSet<usize>> {
+    static HANDLES: std::sync::OnceLock<Mutex<std::collections::HashSet<usize>>> =
+        std::sync::OnceLock::new();
+    HANDLES.get_or_init(|| Mutex::new(std::collections::HashSet::new()))
+}
+
+fn native_functions() -> &'static Mutex<std::collections::HashSet<usize>> {
+    static HANDLES: std::sync::OnceLock<Mutex<std::collections::HashSet<usize>>> =
+        std::sync::OnceLock::new();
+    HANDLES.get_or_init(|| Mutex::new(std::collections::HashSet::new()))
+}
+
+/// Static libcudart occasionally applies attributes to optional CUDA host
+/// stubs that were not resolved for the active architecture.  In a native
+/// process the runtime consumes those addresses locally; forwarding one to a
+/// different process makes the host driver dereference a foreign code pointer.
+/// A genuine CUfunction returned by this shim is recorded in
+/// [`native_functions`], while `dladdr` identifies an unresolved pointer into a
+/// guest ELF image without parsing `/proc` or depending on address ranges.
+#[cfg(unix)]
+fn is_guest_elf_pointer(pointer: *mut c_void) -> bool {
+    let mut info: libc::Dl_info = unsafe { std::mem::zeroed() };
+    unsafe { libc::dladdr(pointer.cast_const(), &mut info) != 0 && !info.dli_fname.is_null() }
+}
+
+#[cfg(not(unix))]
+fn is_guest_elf_pointer(_pointer: *mut c_void) -> bool {
+    false
+}
+
+fn is_unresolved_guest_host_stub(function: *mut c_void) -> bool {
+    !function.is_null()
+        && !native_functions()
+            .lock()
+            .unwrap()
+            .contains(&(function as usize))
+        && is_guest_elf_pointer(function)
+}
+
+#[cfg(all(test, unix))]
+mod guest_elf_pointer_tests {
+    use super::*;
+
+    #[test]
+    fn distinguishes_loaded_code_from_an_unmapped_handle() {
+        assert!(is_guest_elf_pointer(cuInit as *const () as *mut c_void));
+        assert!(!is_guest_elf_pointer(std::ptr::dangling_mut::<c_void>()));
+    }
+}
+
+fn cuda_driver_lib_call(func: u16, args: Vec<u8>) -> Result<Vec<u8>, c_int> {
+    match with_state(|s| s.client.lib_call(6, func, args)) {
+        Ok((CUDA_SUCCESS, out)) => Ok(out),
+        Ok((status, _)) => Err(status),
+        Err(status) => Err(status),
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod mapped_host_memory {
+    use super::*;
+    use std::os::unix::fs::FileExt;
+
+    const PAGE: usize = 4096;
+    const HUGE_PAGE: usize = 2 * 1024 * 1024;
+    const MAX_ALLOCATION: usize = 256 * 1024 * 1024;
+
+    struct Allocation {
+        base: usize,
+        len: usize,
+        device_pointer: u64,
+        flags: c_uint,
+    }
+
+    static ALLOCATIONS: Mutex<Vec<Allocation>> = Mutex::new(Vec::new());
+
+    fn allocation_len(bytes: usize) -> Option<usize> {
+        bytes
+            .checked_add(HUGE_PAGE - 1)
+            .map(|n| n & !(HUGE_PAGE - 1))
+    }
+
+    fn contiguous_gpa(base: usize, pages: usize) -> Option<u64> {
+        let file = std::fs::File::open("/proc/self/pagemap").ok()?;
+        let mut entries = vec![0u8; pages.checked_mul(8)?];
+        file.read_exact_at(&mut entries, (base / PAGE) as u64 * 8)
+            .ok()?;
+        let mut first = None;
+        for (index, entry) in entries.chunks_exact(8).enumerate() {
+            let entry = u64::from_le_bytes(entry.try_into().unwrap());
+            if entry & (1 << 63) == 0 {
+                return None;
+            }
+            let pfn = entry & ((1u64 << 55) - 1);
+            if pfn == 0 {
+                return None;
+            }
+            let gpa = pfn.checked_mul(PAGE as u64)?;
+            match first {
+                None => first = Some(gpa),
+                Some(start) if gpa == start + index as u64 * PAGE as u64 => {}
+                Some(_) => return None,
+            }
+        }
+        first
+    }
+
+    fn page_len(bytes: usize) -> Option<usize> {
+        bytes.checked_add(PAGE - 1).map(|n| n & !(PAGE - 1))
+    }
+
+    fn file_allocation(bytes: usize, flags: c_uint) -> Option<Result<Allocation, c_int>> {
+        use std::os::unix::fs::OpenOptionsExt;
+        use std::os::unix::io::AsRawFd;
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        static NEXT: AtomicU64 = AtomicU64::new(1);
+        let len = page_len(bytes)?;
+        let name = format!(
+            "hostmem-{}-{}.bin",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        );
+        let path = std::path::Path::new("/opt/smolvm-ring").join(&name);
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&path)
+            .ok()?;
+        if file.set_len(len as u64).is_err() {
+            let _ = std::fs::remove_file(&path);
+            return None;
+        }
+        let pointer = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                len,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_SHARED,
+                file.as_raw_fd(),
+                0,
+            )
+        };
+        if pointer == libc::MAP_FAILED {
+            let _ = std::fs::remove_file(&path);
+            return None;
+        }
+        let mut args = Vec::with_capacity(8 + name.len());
+        args.extend_from_slice(&(len as u64).to_le_bytes());
+        args.extend_from_slice(name.as_bytes());
+        let result = cuda_driver_lib_call(14, args).and_then(|bytes| returned_handle(&bytes));
+        // The host has opened and mapped the file before acknowledging the
+        // registration, so the directory entry is no longer needed.
+        let _ = std::fs::remove_file(&path);
+        match result {
+            Ok(device_pointer) => Some(Ok(Allocation {
+                base: pointer as usize,
+                len,
+                device_pointer: device_pointer as u64,
+                flags,
+            })),
+            Err(status) => {
+                unsafe { libc::munmap(pointer, len) };
+                // A runtime without a tmpfs ring or the new host registration
+                // path falls back to the physically-contiguous compatibility
+                // allocation below.
+                if matches!(
+                    status,
+                    CUDA_ERROR_INVALID_VALUE | CUDA_ERROR_OUT_OF_MEMORY | 801
+                ) {
+                    None
+                } else {
+                    Some(Err(status))
+                }
+            }
+        }
+    }
+
+    unsafe fn aligned_mapping(len: usize) -> Option<*mut u8> {
+        let reserve = len.checked_add(HUGE_PAGE)?;
+        let raw = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                reserve,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                -1,
+                0,
+            )
+        };
+        if raw == libc::MAP_FAILED {
+            return None;
+        }
+        let raw = raw as usize;
+        let aligned = raw.checked_add(HUGE_PAGE - 1)? & !(HUGE_PAGE - 1);
+        let prefix = aligned - raw;
+        let suffix = reserve - prefix - len;
+        if prefix != 0 {
+            unsafe { libc::munmap(raw as *mut c_void, prefix) };
+        }
+        if suffix != 0 {
+            unsafe { libc::munmap((aligned + len) as *mut c_void, suffix) };
+        }
+        let pointer = aligned as *mut u8;
+        unsafe {
+            libc::madvise(pointer.cast(), len, libc::MADV_HUGEPAGE);
+            std::ptr::write_bytes(pointer, 0, len);
+            // Linux 6.1+: synchronously collapse each aligned 2 MiB range.
+            // Best-effort on older kernels; the physical-contiguity check
+            // below remains authoritative.
+            libc::madvise(pointer.cast(), len, 25); // MADV_COLLAPSE
+        }
+        if unsafe { libc::mlock(pointer.cast(), len) } != 0 {
+            unsafe { libc::munmap(pointer.cast(), len) };
+            return None;
+        }
+        Some(pointer)
+    }
+
+    pub fn allocate(out: *mut *mut c_void, bytes: usize, flags: c_uint) -> c_int {
+        if out.is_null() || bytes == 0 || bytes > MAX_ALLOCATION {
+            return CUDA_ERROR_INVALID_VALUE;
+        }
+        if let Some(result) = file_allocation(bytes, flags) {
+            return match result {
+                Ok(allocation) => {
+                    let pointer = allocation.base as *mut c_void;
+                    ALLOCATIONS.lock().unwrap().push(allocation);
+                    unsafe { *out = pointer };
+                    CUDA_SUCCESS
+                }
+                Err(status) => status,
+            };
+        }
+        let Some(len) = allocation_len(bytes) else {
+            return CUDA_ERROR_INVALID_VALUE;
+        };
+        for _ in 0..8 {
+            let Some(pointer) = (unsafe { aligned_mapping(len) }) else {
+                continue;
+            };
+            let Some(gpa) = contiguous_gpa(pointer as usize, len / PAGE) else {
+                unsafe { libc::munmap(pointer.cast(), len) };
+                continue;
+            };
+            let mut args = Vec::with_capacity(16);
+            args.extend_from_slice(&gpa.to_le_bytes());
+            args.extend_from_slice(&(len as u64).to_le_bytes());
+            let device_pointer = match cuda_driver_lib_call(CUDA_HOST_REGISTER_GPA, args)
+                .and_then(|bytes| returned_handle(&bytes))
+            {
+                Ok(pointer) => pointer as u64,
+                Err(status) => {
+                    unsafe { libc::munmap(pointer.cast(), len) };
+                    return status;
+                }
+            };
+            ALLOCATIONS.lock().unwrap().push(Allocation {
+                base: pointer as usize,
+                len,
+                device_pointer,
+                flags,
+            });
+            unsafe { *out = pointer.cast() };
+            return CUDA_SUCCESS;
+        }
+        CUDA_ERROR_OUT_OF_MEMORY
+    }
+
+    pub fn device_pointer(out: *mut u64, pointer: *mut c_void) -> c_int {
+        if out.is_null() || pointer.is_null() {
+            return CUDA_ERROR_INVALID_VALUE;
+        }
+        let pointer = pointer as usize;
+        match ALLOCATIONS.lock().unwrap().iter().find(|allocation| {
+            pointer >= allocation.base && pointer < allocation.base + allocation.len
+        }) {
+            Some(allocation) => {
+                unsafe { *out = allocation.device_pointer + (pointer - allocation.base) as u64 };
+                CUDA_SUCCESS
+            }
+            None => CUDA_ERROR_INVALID_VALUE,
+        }
+    }
+
+    pub fn flags(out: *mut c_uint, pointer: *mut c_void) -> c_int {
+        if out.is_null() || pointer.is_null() {
+            return CUDA_ERROR_INVALID_VALUE;
+        }
+        let pointer = pointer as usize;
+        match ALLOCATIONS.lock().unwrap().iter().find(|allocation| {
+            pointer >= allocation.base && pointer < allocation.base + allocation.len
+        }) {
+            Some(allocation) => {
+                unsafe { *out = allocation.flags };
+                CUDA_SUCCESS
+            }
+            None => CUDA_ERROR_INVALID_VALUE,
+        }
+    }
+
+    pub fn free(pointer: *mut c_void) -> c_int {
+        if pointer.is_null() {
+            return CUDA_SUCCESS;
+        }
+        let allocation = {
+            let mut allocations = ALLOCATIONS.lock().unwrap();
+            let Some(index) = allocations
+                .iter()
+                .position(|allocation| allocation.base == pointer as usize)
+            else {
+                return CUDA_ERROR_INVALID_VALUE;
+            };
+            allocations.swap_remove(index)
+        };
+        let mut args = Vec::with_capacity(16);
+        args.extend_from_slice(&allocation.device_pointer.to_le_bytes());
+        args.extend_from_slice(&(allocation.len as u64).to_le_bytes());
+        let status = match cuda_driver_lib_call(CUDA_HOST_UNREGISTER_GPA, args) {
+            Ok(_) => CUDA_SUCCESS,
+            Err(status) => status,
+        };
+        unsafe { libc::munmap(pointer, allocation.len) };
+        status
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::{allocation_len, page_len, HUGE_PAGE, PAGE};
+
+        #[test]
+        fn host_allocations_retain_full_hugepage_backing() {
+            assert_eq!(allocation_len(1), Some(HUGE_PAGE));
+            assert_eq!(allocation_len(HUGE_PAGE), Some(HUGE_PAGE));
+            assert_eq!(allocation_len(HUGE_PAGE + 1), Some(HUGE_PAGE * 2));
+            assert_eq!(allocation_len(usize::MAX), None);
+        }
+
+        #[test]
+        fn file_allocations_are_page_rounded() {
+            assert_eq!(page_len(1), Some(PAGE));
+            assert_eq!(page_len(PAGE), Some(PAGE));
+            assert_eq!(page_len(PAGE + 1), Some(PAGE * 2));
+            assert_eq!(page_len(usize::MAX), None);
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod mapped_host_memory {
+    use super::*;
+
+    pub fn allocate(_: *mut *mut c_void, _: usize, _: c_uint) -> c_int {
+        CUDA_ERROR_NOT_SUPPORTED
+    }
+    pub fn device_pointer(_: *mut u64, _: *mut c_void) -> c_int {
+        CUDA_ERROR_NOT_SUPPORTED
+    }
+    pub fn flags(_: *mut c_uint, _: *mut c_void) -> c_int {
+        CUDA_ERROR_NOT_SUPPORTED
+    }
+    pub fn free(_: *mut c_void) -> c_int {
+        CUDA_ERROR_NOT_SUPPORTED
+    }
+}
+
+fn returned_handle(bytes: &[u8]) -> Result<usize, c_int> {
+    if bytes.len() != 8 {
+        return Err(CUDA_ERROR_UNKNOWN);
+    }
+    Ok(u64::from_le_bytes(bytes.try_into().unwrap()) as usize)
+}
+
+unsafe fn image_bytes<'a>(image: *const c_void) -> Result<&'a [u8], c_int> {
+    let len = unsafe { module_image_len(image) }?;
+    Ok(unsafe { std::slice::from_raw_parts(image.cast::<u8>(), len) })
+}
+
+unsafe fn version_two_fatbins(wrapper: &FatbincWrapper) -> Result<Vec<*const c_void>, c_int> {
+    if wrapper._filename_or_fatbins.is_null() {
+        return Err(CUDA_ERROR_INVALID_VALUE);
+    }
+    let list = wrapper._filename_or_fatbins as *const *const c_void;
+    let mut images = Vec::new();
+    // Generated wrappers are short; the cap turns a missing terminator into a
+    // clean error instead of walking arbitrary guest memory forever.
+    for index in 0..4096 {
+        let image = unsafe { list.add(index).read() };
+        if image.is_null() {
+            return if images.is_empty() {
+                Err(CUDA_ERROR_INVALID_IMAGE)
+            } else {
+                Ok(images)
+            };
+        }
+        images.push(image);
+    }
+    Err(CUDA_ERROR_INVALID_IMAGE)
+}
+
+/// CUDA's library API is a newer handle vocabulary over the same loaded-code
+/// object used by the module API. Static libcudart also passes private v1/v2
+/// fatbin wrappers here. Stream their pointed-to images to the daemon, which
+/// reconstructs the wrapper and invokes the host driver's real Library API;
+/// eagerly loading every image as an independent module both violates lazy
+/// architecture selection and can exhaust/crash the driver on large NCCL
+/// libraries.
+#[no_mangle]
+pub extern "C" fn cuLibraryLoadData(
+    library: *mut *mut c_void,
+    code: *const c_void,
+    _jit_options: *mut c_int,
+    _jit_option_values: *mut *mut c_void,
+    _num_jit_options: c_uint,
+    _library_options: *mut c_int,
+    _library_option_values: *mut *mut c_void,
+    _num_library_options: c_uint,
+) -> c_int {
+    let trace = std::env::var_os("SMOLVM_CUDA_SHIM_TRACE").is_some();
+    if library.is_null() || code.is_null() {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    let magic = unsafe { (code as *const u32).read_unaligned() };
+    let wrapper_version =
+        (magic == 0x4662_43b1).then(|| unsafe { (code as *const u32).add(1).read_unaligned() });
+    let (kind, images) = match wrapper_version {
+        Some(1) => {
+            let wrapper = unsafe { &*(code as *const FatbincWrapper) };
+            if wrapper.data.is_null() {
+                return CUDA_ERROR_INVALID_VALUE;
+            }
+            (1_u32, vec![wrapper.data])
+        }
+        Some(2) => {
+            let wrapper = unsafe { &*(code as *const FatbincWrapper) };
+            if wrapper.data.is_null() {
+                return CUDA_ERROR_INVALID_VALUE;
+            }
+            match unsafe { version_two_fatbins(wrapper) } {
+                Ok(prelinked) => {
+                    // v2 keeps the primary fatbin in `data`; the pointer list
+                    // contains additional prelinked fatbins. Preserve that
+                    // distinction so the host driver selects kernels from the
+                    // primary image rather than treating the first dependency
+                    // as the library itself.
+                    let mut images = Vec::with_capacity(prelinked.len() + 1);
+                    images.push(wrapper.data);
+                    images.extend(prelinked);
+                    (2_u32, images)
+                }
+                Err(status) => return status,
+            }
+        }
+        _ => (0_u32, vec![code]),
+    };
+    if trace {
+        eprintln!(
+            "[shim] cuLibraryLoadData kind={kind} images={} code={code:p}",
+            images.len()
+        );
+    }
+
+    let build = match cuda_driver_lib_call(CUDA_LIBRARY_BEGIN, kind.to_le_bytes().to_vec())
+        .and_then(|bytes| returned_handle(&bytes))
+    {
+        Ok(build) => build,
+        Err(status) => return status,
+    };
+    let cancel = || {
+        let _ = cuda_driver_lib_call(CUDA_LIBRARY_CANCEL, (build as u64).to_le_bytes().to_vec());
+    };
+    for (index, image) in images.into_iter().enumerate() {
+        if trace {
+            eprintln!("[shim] cuLibraryLoadData image={index} ptr={image:p} sizing");
+        }
+        let bytes = match unsafe { image_bytes(image) } {
+            Ok(bytes) => bytes,
+            Err(status) => {
+                cancel();
+                return status;
+            }
+        };
+        if trace {
+            eprintln!(
+                "[shim] cuLibraryLoadData image={index} len={:#x} streaming",
+                bytes.len()
+            );
+        }
+        let mut args = Vec::with_capacity(8 + bytes.len());
+        args.extend_from_slice(&(build as u64).to_le_bytes());
+        args.extend_from_slice(bytes);
+        if let Err(status) = cuda_driver_lib_call(CUDA_LIBRARY_ADD_IMAGE, args) {
+            cancel();
+            return status;
+        }
+    }
+    let handle =
+        match cuda_driver_lib_call(CUDA_LIBRARY_COMPLETE, (build as u64).to_le_bytes().to_vec())
+            .and_then(|bytes| returned_handle(&bytes))
+        {
+            Ok(handle) => handle,
+            Err(status) => {
+                cancel();
+                return status;
+            }
+        };
+    if trace {
+        eprintln!("[shim] cuLibraryLoadData complete handle={handle:#x}");
+    }
+    native_libraries().lock().unwrap().insert(handle);
+    ret(unsafe { out(library, handle as *mut c_void) })
+}
+
+#[no_mangle]
+pub extern "C" fn cuLibraryUnload(library: *mut c_void) -> c_int {
+    let trace = std::env::var_os("SMOLVM_CUDA_SHIM_TRACE").is_some();
+    if native_libraries()
+        .lock()
+        .unwrap()
+        .remove(&(library as usize))
+    {
+        let status = match cuda_driver_lib_call(
+            CUDA_LIBRARY_UNLOAD,
+            (library as u64).to_le_bytes().to_vec(),
+        ) {
+            Ok(_) => CUDA_SUCCESS,
+            Err(status) => status,
+        };
+        if trace {
+            eprintln!("[shim] cuLibraryUnload library={library:p} status={status}");
+        }
+        return status;
+    }
+    cuModuleUnload(library)
+}
+
+#[no_mangle]
+pub extern "C" fn cuLibraryGetKernel(
+    kernel: *mut *mut c_void,
+    library: *mut c_void,
+    name: *const c_char,
+) -> c_int {
+    let trace = std::env::var_os("SMOLVM_CUDA_SHIM_TRACE").is_some();
+    if native_libraries()
+        .lock()
+        .unwrap()
+        .contains(&(library as usize))
+    {
+        if kernel.is_null() || name.is_null() {
+            return CUDA_ERROR_INVALID_VALUE;
+        }
+        let name = unsafe { CStr::from_ptr(name) }.to_bytes();
+        let mut args = Vec::with_capacity(8 + name.len());
+        args.extend_from_slice(&(library as u64).to_le_bytes());
+        args.extend_from_slice(name);
+        let status = match cuda_driver_lib_call(CUDA_LIBRARY_GET_KERNEL, args)
+            .and_then(|bytes| returned_handle(&bytes))
+        {
+            Ok(handle) => {
+                native_kernels().lock().unwrap().insert(handle);
+                if trace {
+                    eprintln!(
+                        "[shim] cuLibraryGetKernel library={library:p} name={} kernel={handle:#x}",
+                        String::from_utf8_lossy(name)
+                    );
+                }
+                ret(unsafe { out(kernel, handle as *mut c_void) })
+            }
+            Err(status) => {
+                if trace {
+                    eprintln!(
+                        "[shim] cuLibraryGetKernel library={library:p} name={} status={status}",
+                        String::from_utf8_lossy(name)
+                    );
+                }
+                status
+            }
+        };
+        return status;
+    }
+    cuModuleGetFunction(kernel, library, name)
+}
+
+#[no_mangle]
+pub extern "C" fn cuLibraryGetModule(module: *mut *mut c_void, library: *mut c_void) -> c_int {
+    let trace = std::env::var_os("SMOLVM_CUDA_SHIM_TRACE").is_some();
+    if native_libraries()
+        .lock()
+        .unwrap()
+        .contains(&(library as usize))
+    {
+        let status = match cuda_driver_lib_call(
+            CUDA_LIBRARY_GET_MODULE,
+            (library as u64).to_le_bytes().to_vec(),
+        )
+        .and_then(|bytes| returned_handle(&bytes))
+        {
+            Ok(handle) => {
+                if trace {
+                    eprintln!("[shim] cuLibraryGetModule library={library:p} module={handle:#x}");
+                }
+                ret(unsafe { out(module, handle as *mut c_void) })
+            }
+            Err(status) => status,
+        };
+        return status;
+    }
+    ret(unsafe { out(module, library) })
+}
+
+#[no_mangle]
+pub extern "C" fn cuKernelGetFunction(function: *mut *mut c_void, kernel: *mut c_void) -> c_int {
+    let trace = std::env::var_os("SMOLVM_CUDA_SHIM_TRACE").is_some();
+    if native_kernels()
+        .lock()
+        .unwrap()
+        .contains(&(kernel as usize))
+    {
+        let status = match cuda_driver_lib_call(
+            CUDA_KERNEL_GET_FUNCTION,
+            (kernel as u64).to_le_bytes().to_vec(),
+        )
+        .and_then(|bytes| returned_handle(&bytes))
+        {
+            Ok(handle) => {
+                native_functions().lock().unwrap().insert(handle);
+                if trace {
+                    eprintln!("[shim] cuKernelGetFunction kernel={kernel:p} function={handle:#x}");
+                }
+                ret(unsafe { out(function, handle as *mut c_void) })
+            }
+            Err(status) => status,
+        };
+        return status;
+    }
+    ret(unsafe { out(function, kernel) })
+}
+
 #[no_mangle]
 pub extern "C" fn cuModuleGetFunction(
     func: *mut *mut c_void,
     module: *mut c_void,
     name: *const c_char,
 ) -> c_int {
-    if name.is_null() {
+    let trace = std::env::var_os("SMOLVM_CUDA_SHIM_TRACE").is_some();
+    if func.is_null() || name.is_null() {
         return CUDA_ERROR_INVALID_VALUE;
+    }
+    // CUDA's statically linked runtime registers code through the Library API
+    // but later resolves registered kernels through the legacy Module API.
+    // CUlibrary and CUmodule are distinct host-driver handle types, so bridge
+    // that compatibility lookup through CUkernel before returning CUfunction.
+    let is_library = native_libraries()
+        .lock()
+        .map(|libraries| libraries.contains(&(module as usize)))
+        .unwrap_or(false);
+    if is_library {
+        let mut kernel = std::ptr::null_mut();
+        let status = cuLibraryGetKernel(&mut kernel, module, name);
+        if status != CUDA_SUCCESS {
+            return status;
+        }
+        return cuKernelGetFunction(func, kernel);
     }
     let fn_name = match unsafe { CStr::from_ptr(name) }.to_str() {
         Ok(n) => n.to_string(),
         Err(_) => return CUDA_ERROR_INVALID_VALUE,
     };
-    match with_state(|s| s.client.module_get_function(module as u64, &fn_name)) {
-        Ok(h) => ret(unsafe { out(func, h as *mut c_void) }),
+    let status = match with_state(|s| s.client.module_get_function(module as u64, &fn_name)) {
+        Ok(h) => {
+            native_functions().lock().unwrap().insert(h as usize);
+            ret(unsafe { out(func, h as *mut c_void) })
+        }
         Err(code) => code,
+    };
+    if trace {
+        eprintln!("[shim] cuModuleGetFunction module={module:p} name={fn_name} status={status}");
     }
+    status
+}
+
+#[no_mangle]
+pub extern "C" fn cuModuleGetGlobal(
+    dptr: *mut u64,
+    bytes: *mut usize,
+    module: *mut c_void,
+    name: *const c_char,
+) -> c_int {
+    if dptr.is_null() || name.is_null() {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    let name = unsafe { CStr::from_ptr(name) }.to_bytes();
+    let mut args = Vec::with_capacity(8 + name.len());
+    args.extend_from_slice(&(module as u64).to_le_bytes());
+    args.extend_from_slice(name);
+    match cuda_driver_lib_call(CUDA_MODULE_GET_GLOBAL, args) {
+        Ok(result) if result.len() == 16 => {
+            let pointer = u64::from_le_bytes(result[..8].try_into().unwrap());
+            let size = u64::from_le_bytes(result[8..].try_into().unwrap());
+            unsafe {
+                *dptr = pointer;
+                if !bytes.is_null() {
+                    *bytes = size as usize;
+                }
+            }
+            CUDA_SUCCESS
+        }
+        Ok(_) => CUDA_ERROR_UNKNOWN,
+        Err(status) => status,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn cuModuleGetGlobal_v2(
+    dptr: *mut u64,
+    bytes: *mut usize,
+    module: *mut c_void,
+    name: *const c_char,
+) -> c_int {
+    cuModuleGetGlobal(dptr, bytes, module, name)
 }
 
 #[no_mangle]
@@ -1073,6 +2373,39 @@ pub extern "C" fn cuModuleUnload(module: *mut c_void) -> c_int {
 }
 
 // ---- memory ---------------------------------------------------------------------
+
+#[no_mangle]
+pub extern "C" fn cuMemHostAlloc(pointer: *mut *mut c_void, bytes: usize, flags: c_uint) -> c_int {
+    mapped_host_memory::allocate(pointer, bytes, flags)
+}
+
+#[no_mangle]
+pub extern "C" fn cuMemHostGetDevicePointer_v2(
+    device_pointer: *mut u64,
+    host_pointer: *mut c_void,
+    _flags: c_uint,
+) -> c_int {
+    mapped_host_memory::device_pointer(device_pointer, host_pointer)
+}
+
+#[no_mangle]
+pub extern "C" fn cuMemHostGetDevicePointer(
+    device_pointer: *mut u64,
+    host_pointer: *mut c_void,
+    flags: c_uint,
+) -> c_int {
+    cuMemHostGetDevicePointer_v2(device_pointer, host_pointer, flags)
+}
+
+#[no_mangle]
+pub extern "C" fn cuMemHostGetFlags(flags: *mut c_uint, host_pointer: *mut c_void) -> c_int {
+    mapped_host_memory::flags(flags, host_pointer)
+}
+
+#[no_mangle]
+pub extern "C" fn cuMemFreeHost(host_pointer: *mut c_void) -> c_int {
+    mapped_host_memory::free(host_pointer)
+}
 
 #[no_mangle]
 pub extern "C" fn cuMemAlloc_v2(dptr: *mut u64, bytes: usize) -> c_int {
@@ -1085,6 +2418,227 @@ pub extern "C" fn cuMemAlloc_v2(dptr: *mut u64, bytes: usize) -> c_int {
 #[no_mangle]
 pub extern "C" fn cuMemFree_v2(dptr: u64) -> c_int {
     ret(with_state(|s| s.client.mem_free(dptr)))
+}
+
+#[no_mangle]
+pub extern "C" fn cuMemPoolCreate(pool: *mut *mut c_void, props: *const CUmemPoolProps) -> c_int {
+    if pool.is_null() || props.is_null() {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    let props = unsafe { &*props };
+    match with_state(|s| {
+        s.client.mem_pool_create(
+            props.alloc_type,
+            props.handle_types,
+            props.location.type_,
+            props.location.id,
+            props.max_size as u64,
+            props.usage,
+        )
+    }) {
+        Ok(handle) => ret(unsafe { out(pool, handle as *mut c_void) }),
+        Err(code) => code,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn cuMemPoolDestroy(pool: *mut c_void) -> c_int {
+    if pool.is_null() {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    ret(with_state(|s| s.client.mem_pool_destroy(pool as u64)))
+}
+
+fn mem_pool_attr_is_int(attr: c_int) -> bool {
+    matches!(attr, 1..=3)
+}
+
+#[no_mangle]
+pub extern "C" fn cuMemPoolSetAttribute(
+    pool: *mut c_void,
+    attr: c_int,
+    value: *mut c_void,
+) -> c_int {
+    if pool.is_null() || value.is_null() {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    let value = unsafe {
+        if mem_pool_attr_is_int(attr) {
+            *(value as *const c_int) as u32 as u64
+        } else {
+            *(value as *const u64)
+        }
+    };
+    ret(with_state(|s| {
+        s.client.mem_pool_set_attribute(pool as u64, attr, value)
+    }))
+}
+
+#[no_mangle]
+pub extern "C" fn cuMemPoolGetAttribute(
+    pool: *mut c_void,
+    attr: c_int,
+    value: *mut c_void,
+) -> c_int {
+    if pool.is_null() || value.is_null() {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    match with_state(|s| s.client.mem_pool_get_attribute(pool as u64, attr)) {
+        Ok(v) => {
+            unsafe {
+                if mem_pool_attr_is_int(attr) {
+                    *(value as *mut c_int) = v as c_int;
+                } else {
+                    *(value as *mut u64) = v;
+                }
+            }
+            CUDA_SUCCESS
+        }
+        Err(code) => code,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn cuMemPoolSetAccess(
+    pool: *mut c_void,
+    map: *const CUmemAccessDesc,
+    count: usize,
+) -> c_int {
+    if pool.is_null() || (map.is_null() && count != 0) {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    let descriptors = if count == 0 {
+        Vec::new()
+    } else {
+        unsafe { std::slice::from_raw_parts(map, count) }
+            .iter()
+            .map(|d| (d.location.type_, d.location.id, d.flags as u32 as u64))
+            .collect()
+    };
+    ret(with_state(|s| {
+        s.client.mem_pool_set_access(pool as u64, descriptors)
+    }))
+}
+
+#[no_mangle]
+pub extern "C" fn cuMemPoolGetAccess(
+    flags: *mut c_int,
+    pool: *mut c_void,
+    location: *const CUmemLocation,
+) -> c_int {
+    if flags.is_null() || pool.is_null() || location.is_null() {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    let location = unsafe { &*location };
+    match with_state(|s| {
+        s.client
+            .mem_pool_get_access(pool as u64, location.type_, location.id)
+    }) {
+        Ok(v) => ret(unsafe { out(flags, v as c_int) }),
+        Err(code) => code,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn cuMemPoolTrimTo(pool: *mut c_void, min_bytes: usize) -> c_int {
+    if pool.is_null() {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    ret(with_state(|s| {
+        s.client.mem_pool_trim_to(pool as u64, min_bytes as u64)
+    }))
+}
+
+#[no_mangle]
+pub extern "C" fn cuMemAllocFromPoolAsync(
+    dptr: *mut u64,
+    bytes: usize,
+    pool: *mut c_void,
+    stream: *mut c_void,
+) -> c_int {
+    if dptr.is_null() || pool.is_null() {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    match with_state(|s| {
+        s.client
+            .mem_alloc_from_pool_async(bytes as u64, pool as u64, stream as u64)
+    }) {
+        Ok(v) => ret(unsafe { out(dptr, v) }),
+        Err(code) => code,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn cuMemAllocFromPoolAsync_ptsz(
+    dptr: *mut u64,
+    bytes: usize,
+    pool: *mut c_void,
+    stream: *mut c_void,
+) -> c_int {
+    cuMemAllocFromPoolAsync(dptr, bytes, pool, stream)
+}
+
+#[no_mangle]
+pub extern "C" fn cuMemAllocAsync(dptr: *mut u64, bytes: usize, stream: *mut c_void) -> c_int {
+    if dptr.is_null() {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    match with_state(|s| s.client.mem_alloc_async(bytes as u64, stream as u64)) {
+        Ok(v) => ret(unsafe { out(dptr, v) }),
+        Err(code) => code,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn cuMemAllocAsync_ptsz(dptr: *mut u64, bytes: usize, stream: *mut c_void) -> c_int {
+    cuMemAllocAsync(dptr, bytes, stream)
+}
+
+#[no_mangle]
+pub extern "C" fn cuMemFreeAsync(dptr: u64, stream: *mut c_void) -> c_int {
+    ret(with_state(|s| s.client.mem_free_async(dptr, stream as u64)))
+}
+
+#[no_mangle]
+pub extern "C" fn cuMemFreeAsync_ptsz(dptr: u64, stream: *mut c_void) -> c_int {
+    cuMemFreeAsync(dptr, stream)
+}
+
+fn device_mem_pool(device: c_int, default: bool, pool: *mut *mut c_void) -> c_int {
+    if pool.is_null() {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    let result = with_state(|s| {
+        if default {
+            s.client.device_get_default_mem_pool(device)
+        } else {
+            s.client.device_get_mem_pool(device)
+        }
+    });
+    match result {
+        Ok(handle) => ret(unsafe { out(pool, handle as *mut c_void) }),
+        Err(code) => code,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn cuDeviceGetDefaultMemPool(pool: *mut *mut c_void, device: c_int) -> c_int {
+    device_mem_pool(device, true, pool)
+}
+
+#[no_mangle]
+pub extern "C" fn cuDeviceGetMemPool(pool: *mut *mut c_void, device: c_int) -> c_int {
+    device_mem_pool(device, false, pool)
+}
+
+#[no_mangle]
+pub extern "C" fn cuDeviceSetMemPool(device: c_int, pool: *mut c_void) -> c_int {
+    if pool.is_null() {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    ret(with_state(|s| {
+        s.client.device_set_mem_pool(device, pool as u64)
+    }))
 }
 
 #[no_mangle]
@@ -1118,9 +2672,90 @@ pub extern "C" fn cuMemcpyDtoD_v2(dst: u64, src: u64, bytes: usize) -> c_int {
     ret(with_state(|s| s.client.memcpy_dtod(dst, src, bytes as u64)))
 }
 
+fn pointer_is_device(pointer: u64) -> Result<bool, c_int> {
+    let out = cuda_driver_lib_call(2, pointer.to_le_bytes().to_vec())?;
+    Ok(out.first().copied() == Some(2))
+}
+
+fn memcpy_unified(dst: u64, src: u64, bytes: usize, stream: u64) -> c_int {
+    if bytes == 0 {
+        return CUDA_SUCCESS;
+    }
+    if dst == 0 || src == 0 {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    let dst_device = match pointer_is_device(dst) {
+        Ok(value) => value,
+        Err(code) => return code,
+    };
+    let src_device = match pointer_is_device(src) {
+        Ok(value) => value,
+        Err(code) => return code,
+    };
+    match (dst_device, src_device) {
+        (true, true) => ret(with_state(|s| {
+            s.client.memcpy_dtod_async(dst, src, bytes as u64, stream)
+        })),
+        (true, false) => {
+            let data = unsafe { std::slice::from_raw_parts(src as *const u8, bytes) };
+            ret(with_state(|s| s.client.memcpy_htod(dst, data, stream)))
+        }
+        (false, true) => match with_state(|s| s.client.memcpy_dtoh(src, bytes as u64, stream)) {
+            Ok(data) if data.len() == bytes => {
+                unsafe { std::ptr::copy_nonoverlapping(data.as_ptr(), dst as *mut u8, bytes) };
+                CUDA_SUCCESS
+            }
+            Ok(_) => CUDA_ERROR_UNKNOWN,
+            Err(code) => code,
+        },
+        (false, false) => {
+            unsafe { std::ptr::copy(src as *const u8, dst as *mut u8, bytes) };
+            CUDA_SUCCESS
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn cuMemcpy(dst: u64, src: u64, bytes: usize) -> c_int {
+    memcpy_unified(dst, src, bytes, 0)
+}
+
+#[no_mangle]
+pub extern "C" fn cuMemcpyAsync(dst: u64, src: u64, bytes: usize, stream: *mut c_void) -> c_int {
+    memcpy_unified(dst, src, bytes, stream as u64)
+}
+
+#[no_mangle]
+pub extern "C" fn cuMemcpyAsync_ptsz(
+    dst: u64,
+    src: u64,
+    bytes: usize,
+    stream: *mut c_void,
+) -> c_int {
+    cuMemcpyAsync(dst, src, bytes, stream)
+}
+
 #[no_mangle]
 pub extern "C" fn cuMemsetD8_v2(dptr: u64, value: u8, n: usize) -> c_int {
     ret(with_state(|s| s.client.memset_d8(dptr, value, n as u64)))
+}
+
+#[no_mangle]
+pub extern "C" fn cuMemsetD8Async(dptr: u64, value: u8, n: usize, stream: *mut c_void) -> c_int {
+    ret(with_state(|s| {
+        s.client
+            .memset_d8_async(dptr, value, n as u64, stream as u64)
+    }))
+}
+
+#[no_mangle]
+pub extern "C" fn cuMemsetD8Async_ptsz(
+    dptr: u64,
+    value: u8,
+    n: usize,
+    stream: *mut c_void,
+) -> c_int {
+    cuMemsetD8Async(dptr, value, n, stream)
 }
 
 #[no_mangle]
@@ -1205,6 +2840,19 @@ pub extern "C" fn cuLaunchKernelEx(
     }
     // SAFETY: caller passes a valid CUlaunchConfig.
     let c = unsafe { &*(config as *const CuLaunchConfig) };
+    if std::env::var_os("SMOLVM_CUDA_SHIM_TRACE").is_some() {
+        eprintln!(
+            "[shim] cuLaunchKernelEx grid={}x{}x{} block={}x{}x{} shared={} attrs={}",
+            c.grid_x,
+            c.grid_y,
+            c.grid_z,
+            c.block_x,
+            c.block_y,
+            c.block_z,
+            c.shared_bytes,
+            c.num_attrs
+        );
+    }
     cuLaunchKernel(
         func,
         c.grid_x,
@@ -1382,6 +3030,18 @@ pub extern "C" fn cuLaunchKernel(
 // ---- streams / events ----------------------------------------------------------------
 
 #[no_mangle]
+pub extern "C" fn cuThreadExchangeStreamCaptureMode(mode: *mut c_int) -> c_int {
+    if mode.is_null() {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    let requested = unsafe { *mode };
+    match with_state(|s| s.client.thread_exchange_capture_mode(requested)) {
+        Ok(previous) => ret(unsafe { out(mode, previous) }),
+        Err(status) => status,
+    }
+}
+
+#[no_mangle]
 pub extern "C" fn cuStreamCreate(stream: *mut *mut c_void, flags: c_uint) -> c_int {
     match with_state(|s| s.client.stream_create(flags)) {
         Ok(h) => ret(unsafe { out(stream, h as *mut c_void) }),
@@ -1547,19 +3207,48 @@ fn proc_table(name: &str) -> Option<*mut c_void> {
         "cuModuleLoadDataEx" => cuModuleLoadDataEx,
         "cuModuleLoadFatBinary" => cuModuleLoadFatBinary,
         "cuModuleGetFunction" => cuModuleGetFunction,
+        "cuModuleGetGlobal" => cuModuleGetGlobal_v2,
         "cuModuleUnload" => cuModuleUnload,
+        "cuModuleGetLoadingMode" => cuModuleGetLoadingMode,
+        "cuLibraryLoadData" => cuLibraryLoadData,
+        "cuLibraryUnload" => cuLibraryUnload,
+        "cuLibraryGetKernel" => cuLibraryGetKernel,
+        "cuLibraryGetModule" => cuLibraryGetModule,
+        "cuKernelGetFunction" => cuKernelGetFunction,
         "cuMemAlloc" => cuMemAlloc_v2,
         "cuMemFree" => cuMemFree_v2,
+        "cuMemPoolCreate" => cuMemPoolCreate,
+        "cuMemPoolDestroy" => cuMemPoolDestroy,
+        "cuMemPoolSetAttribute" => cuMemPoolSetAttribute,
+        "cuMemPoolGetAttribute" => cuMemPoolGetAttribute,
+        "cuMemPoolSetAccess" => cuMemPoolSetAccess,
+        "cuMemPoolGetAccess" => cuMemPoolGetAccess,
+        "cuMemPoolTrimTo" => cuMemPoolTrimTo,
+        "cuMemAllocFromPoolAsync" => cuMemAllocFromPoolAsync,
+        "cuMemAllocAsync" => cuMemAllocAsync,
+        "cuMemFreeAsync" => cuMemFreeAsync,
+        "cuDeviceGetDefaultMemPool" => cuDeviceGetDefaultMemPool,
+        "cuDeviceGetMemPool" => cuDeviceGetMemPool,
+        "cuDeviceSetMemPool" => cuDeviceSetMemPool,
+        "cuMemHostAlloc" => cuMemHostAlloc,
+        "cuMemHostGetDevicePointer" => cuMemHostGetDevicePointer_v2,
+        "cuMemHostGetFlags" => cuMemHostGetFlags,
+        "cuMemFreeHost" => cuMemFreeHost,
         "cuMemcpyHtoD" => cuMemcpyHtoD_v2,
+        "cuMemcpy" => cuMemcpy,
+        "cuMemcpyAsync" => cuMemcpyAsync,
         "cuMemcpyDtoH" => cuMemcpyDtoH_v2,
         "cuMemcpyDtoD" => cuMemcpyDtoD_v2,
         "cuMemcpyHtoDAsync" => cuMemcpyHtoDAsync_v2,
         "cuMemcpyDtoHAsync" => cuMemcpyDtoHAsync_v2,
         "cuMemcpyDtoDAsync" => cuMemcpyDtoDAsync_v2,
         "cuMemsetD8" => cuMemsetD8_v2,
+        "cuMemsetD8Async" => cuMemsetD8Async,
         "cuMemGetInfo" => cuMemGetInfo_v2,
         "cuLaunchKernel" => cuLaunchKernel,
+        "cuLaunchKernelEx" => cuLaunchKernelEx,
         "cuTensorMapEncodeTiled" => cuTensorMapEncodeTiled,
+        "cuThreadExchangeStreamCaptureMode" => cuThreadExchangeStreamCaptureMode,
         "cuStreamCreate" => cuStreamCreate,
         "cuStreamCreateWithPriority" => cuStreamCreateWithPriority,
         "cuStreamDestroy" => cuStreamDestroy_v2,
@@ -1600,7 +3289,26 @@ fn resolve_proc(name: &str, cuda_version: c_int) -> Option<*mut c_void> {
             cuGetProcAddress as *mut c_void
         });
     }
-    proc_table(base)
+    let resolved = proc_table(base);
+    if resolved.is_some() || cuda_version > shim_cuda_version() {
+        return resolved;
+    }
+    // Static libcudart builds eagerly resolve the complete Driver API surface
+    // for the advertised compatibility version before performing even a
+    // cudaFree(NULL). The generated exports preserve that ABI contract: APIs
+    // outside smolvm's forwarded subset resolve and return NOT_SUPPORTED if an
+    // application actually invokes them, instead of making the whole runtime
+    // look like an older/incompatible driver during bootstrap.
+    for candidate in [name, base] {
+        let Ok(candidate) = CString::new(candidate) else {
+            continue;
+        };
+        let address = unsafe { libc::dlsym(libc::RTLD_DEFAULT, candidate.as_ptr()) };
+        if !address.is_null() {
+            return Some(address);
+        }
+    }
+    None
 }
 
 #[no_mangle]
@@ -1675,28 +3383,44 @@ pub extern "C" fn cuGetProcAddress(
 // None are called during basic CUDA init; JIT-link (cuLink*), cooperative
 // launch, and Hopper TMA (cuTensorMapEncodeTiled) are unused on sm_86 forwarding.
 const CU_ERROR_NOT_SUPPORTED: c_int = 801;
+
+fn unsupported_driver_call(name: &str) -> c_int {
+    if std::env::var_os("SMOLVM_CUDA_SHIM_TRACE").is_some() {
+        eprintln!("[shim] unsupported driver call: {name}");
+    }
+    CU_ERROR_NOT_SUPPORTED
+}
+
 #[no_mangle]
 pub extern "C" fn cuLinkCreate_v2() -> c_int {
-    CU_ERROR_NOT_SUPPORTED
+    unsupported_driver_call("cuLinkCreate_v2")
 }
 #[no_mangle]
 pub extern "C" fn cuLinkAddData_v2() -> c_int {
-    CU_ERROR_NOT_SUPPORTED
+    unsupported_driver_call("cuLinkAddData_v2")
 }
 #[no_mangle]
 pub extern "C" fn cuLinkComplete() -> c_int {
-    CU_ERROR_NOT_SUPPORTED
+    unsupported_driver_call("cuLinkComplete")
 }
-// These write out-params that callers (PyTorch's launch config) divide by, so a
-// bare NOT_SUPPORTED stub (leaving the out uninitialized) causes a divide-by-zero
-// crash. Return plausible values instead.
 #[no_mangle]
-pub extern "C" fn cuFuncGetAttribute(pi: *mut c_int, attrib: c_int, _func: *mut c_void) -> c_int {
-    // CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK=0 → 1024; else 0.
-    if !pi.is_null() {
-        unsafe { *pi = if attrib == 0 { 1024 } else { 0 } };
+pub extern "C" fn cuFuncGetAttribute(pi: *mut c_int, attrib: c_int, func: *mut c_void) -> c_int {
+    if pi.is_null() || func.is_null() {
+        return CUDA_ERROR_INVALID_VALUE;
     }
-    CUDA_SUCCESS
+    if is_unresolved_guest_host_stub(func) {
+        if std::env::var_os("SMOLVM_CUDA_SHIM_TRACE").is_some() {
+            eprintln!(
+                "[shim] cuFuncGetAttribute consumed unresolved guest host stub={func:p} \
+                 attrib={attrib}"
+            );
+        }
+        return ret(unsafe { out(pi, 0) });
+    }
+    match with_state(|state| state.client.func_get_attribute(func as u64, attrib)) {
+        Ok(value) => ret(unsafe { out(pi, value) }),
+        Err(status) => status,
+    }
 }
 // Triton/vLLM kernels needing >48 KiB shared memory must raise
 // CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES here before launching, or the
@@ -1704,13 +3428,31 @@ pub extern "C" fn cuFuncGetAttribute(pi: *mut c_int, attrib: c_int, _func: *mut 
 // is raised; Triton checks the return to decide whether the kernel can run.
 #[no_mangle]
 pub extern "C" fn cuFuncSetAttribute(func: *mut c_void, attrib: c_int, value: c_int) -> c_int {
-    ret(with_state(|s| {
+    if func.is_null() {
+        return CUDA_ERROR_INVALID_VALUE;
+    }
+    if is_unresolved_guest_host_stub(func) {
+        if std::env::var_os("SMOLVM_CUDA_SHIM_TRACE").is_some() {
+            eprintln!(
+                "[shim] cuFuncSetAttribute ignored unresolved guest host stub={func:p} \
+                 attrib={attrib} value={value}"
+            );
+        }
+        return CUDA_SUCCESS;
+    }
+    let status = ret(with_state(|s| {
         s.client.func_set_attribute(func as u64, attrib, value)
-    }))
+    }));
+    if std::env::var_os("SMOLVM_CUDA_SHIM_TRACE").is_some() {
+        eprintln!(
+            "[shim] cuFuncSetAttribute function={func:p} attrib={attrib} value={value} status={status}"
+        );
+    }
+    status
 }
 #[no_mangle]
 pub extern "C" fn cuLaunchCooperativeKernel() -> c_int {
-    CU_ERROR_NOT_SUPPORTED
+    unsupported_driver_call("cuLaunchCooperativeKernel")
 }
 #[no_mangle]
 pub extern "C" fn cuOccupancyMaxActiveBlocksPerMultiprocessor(
@@ -1817,4 +3559,16 @@ pub extern "C" fn cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(
         unsafe { *num_blocks = (2048 / bs).clamp(1, 32) }
     }
     CUDA_SUCCESS
+}
+
+#[cfg(test)]
+mod mem_pool_abi_tests {
+    use super::{CUmemAccessDesc, CUmemLocation, CUmemPoolProps};
+
+    #[test]
+    fn cuda_memory_pool_struct_layout_matches_cuda_h() {
+        assert_eq!(std::mem::size_of::<CUmemLocation>(), 8);
+        assert_eq!(std::mem::size_of::<CUmemAccessDesc>(), 12);
+        assert_eq!(std::mem::size_of::<CUmemPoolProps>(), 88);
+    }
 }

--- a/crates/smolvm-cuda/src/client.rs
+++ b/crates/smolvm-cuda/src/client.rs
@@ -181,14 +181,18 @@ pub struct ClientRing {
     _file_mapping: Option<ClientRingMapping>,
 }
 
+#[cfg(unix)]
 struct ClientRingMapping {
     base: usize,
     len: usize,
 }
 
+#[cfg(not(unix))]
+struct ClientRingMapping;
+
+#[cfg(unix)]
 impl Drop for ClientRingMapping {
     fn drop(&mut self) {
-        #[cfg(unix)]
         // SAFETY: base/len are the exact successful mmap result transferred to
         // ClientRing after the host accepts the file-ring upgrade.
         unsafe {
@@ -316,6 +320,7 @@ impl<S: Read + Write> Client<S> {
     /// `fname` (inside the guest's dax ring mount) MAP_SHARED and hands the
     /// page pointers here; the host mmaps the same file through the dir its
     /// proxy advertised. Layout: req pages, then resp, then bounce.
+    #[cfg(unix)]
     pub fn ring_setup_file(
         &mut self,
         page_size: usize,

--- a/crates/smolvm-cuda/src/client.rs
+++ b/crates/smolvm-cuda/src/client.rs
@@ -176,6 +176,25 @@ pub struct ClientRing {
     /// never simultaneously, the queue is strictly request-then-response).
     bounce: Vec<*mut u8>,
     page_size: usize,
+    /// Owns the mmap behind file-backed rings. Ordinary GPA-backed rings use
+    /// guest allocations owned elsewhere and leave this empty.
+    _file_mapping: Option<ClientRingMapping>,
+}
+
+struct ClientRingMapping {
+    base: usize,
+    len: usize,
+}
+
+impl Drop for ClientRingMapping {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        // SAFETY: base/len are the exact successful mmap result transferred to
+        // ClientRing after the host accepts the file-ring upgrade.
+        unsafe {
+            libc::munmap(self.base as *mut libc::c_void, self.len);
+        }
+    }
 }
 
 // SAFETY: raw pointers reference process-owned pinned pages; the shim holds
@@ -288,6 +307,7 @@ impl<S: Read + Write> Client<S> {
             resp: unsafe { crate::ring::Ring::from_pages(resp.0, page_size) },
             bounce: bounce.0,
             page_size,
+            _file_mapping: None,
         });
         Ok(())
     }
@@ -300,6 +320,7 @@ impl<S: Read + Write> Client<S> {
         &mut self,
         page_size: usize,
         fname: &str,
+        mapping: (*mut u8, usize),
         req: Vec<*mut u8>,
         resp: Vec<*mut u8>,
         bounce: Vec<*mut u8>,
@@ -314,13 +335,17 @@ impl<S: Read + Write> Client<S> {
             },
             Op::RingSetupFile,
         )?;
-        // SAFETY: the file mapping is owned by the shim and stays mapped for
-        // the process lifetime (never munmap'd).
+        // SAFETY: the accepted file mapping remains live until this ClientRing
+        // is replaced or dropped, at which point its owner munmaps it.
         self.ring = Some(ClientRing {
             req: unsafe { crate::ring::Ring::from_pages(req, page_size) },
             resp: unsafe { crate::ring::Ring::from_pages(resp, page_size) },
             bounce,
             page_size,
+            _file_mapping: Some(ClientRingMapping {
+                base: mapping.0 as usize,
+                len: mapping.1,
+            }),
         });
         Ok(())
     }
@@ -700,6 +725,8 @@ impl<S: Read + Write> Client<S> {
             | Op::DriverGetVersion
             | Op::DeviceGetAttribute
             | Op::DeviceGetUuid
+            | Op::DeviceGetPciBusId
+            | Op::DeviceGetByPciBusId
             | Op::ModuleGetFunction
             | Op::FuncGetParamInfo
             | Op::FuncGetAttribute
@@ -829,6 +856,28 @@ impl<S: Read + Write> Client<S> {
         }
     }
 
+    pub fn device_get_pci_bus_id(&mut self, device: i32) -> Result<String> {
+        match self.call(
+            &Request::DeviceGetPciBusId { device },
+            Op::DeviceGetPciBusId,
+        )? {
+            Response::Name(value) => Ok(value),
+            _ => Err(CudaRpcError::Protocol("expected Name")),
+        }
+    }
+
+    pub fn device_get_by_pci_bus_id(&mut self, pci_bus_id: &str) -> Result<i32> {
+        match self.call(
+            &Request::DeviceGetByPciBusId {
+                pci_bus_id: pci_bus_id.to_string(),
+            },
+            Op::DeviceGetByPciBusId,
+        )? {
+            Response::Count(device) => Ok(device),
+            _ => Err(CudaRpcError::Protocol("expected Count")),
+        }
+    }
+
     pub fn device_total_mem(&mut self, device: i32) -> Result<u64> {
         match self.call(&Request::DeviceTotalMem { device }, Op::DeviceTotalMem)? {
             Response::Bytes(v) => Ok(v),
@@ -916,6 +965,144 @@ impl<S: Read + Write> Client<S> {
     pub fn mem_free(&mut self, dptr: u64) -> Result<()> {
         // Deferred: status-only, and callers ignore free failures anyway.
         self.call_deferred(&Request::MemFree { dptr }, Op::MemFree)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn mem_pool_create(
+        &mut self,
+        alloc_type: i32,
+        handle_types: u32,
+        location_type: i32,
+        location_id: i32,
+        max_size: u64,
+        usage: u16,
+    ) -> Result<u64> {
+        match self.call(
+            &Request::MemPoolCreate {
+                alloc_type,
+                handle_types,
+                location_type,
+                location_id,
+                max_size,
+                usage,
+            },
+            Op::MemPoolCreate,
+        )? {
+            Response::Handle(pool) => Ok(pool),
+            _ => Err(CudaRpcError::Protocol("expected Handle")),
+        }
+    }
+
+    pub fn mem_pool_destroy(&mut self, pool: u64) -> Result<()> {
+        self.call(&Request::MemPoolDestroy { pool }, Op::MemPoolDestroy)
+            .map(|_| ())
+    }
+
+    pub fn mem_pool_set_attribute(&mut self, pool: u64, attr: i32, value: u64) -> Result<()> {
+        self.call(
+            &Request::MemPoolSetAttribute { pool, attr, value },
+            Op::MemPoolSetAttribute,
+        )
+        .map(|_| ())
+    }
+
+    pub fn mem_pool_get_attribute(&mut self, pool: u64, attr: i32) -> Result<u64> {
+        match self.call(
+            &Request::MemPoolGetAttribute { pool, attr },
+            Op::MemPoolGetAttribute,
+        )? {
+            Response::Bytes(value) => Ok(value),
+            _ => Err(CudaRpcError::Protocol("expected Bytes")),
+        }
+    }
+
+    pub fn mem_pool_set_access(
+        &mut self,
+        pool: u64,
+        descriptors: Vec<(i32, i32, u64)>,
+    ) -> Result<()> {
+        self.call(
+            &Request::MemPoolSetAccess { pool, descriptors },
+            Op::MemPoolSetAccess,
+        )
+        .map(|_| ())
+    }
+
+    pub fn mem_pool_get_access(
+        &mut self,
+        pool: u64,
+        location_type: i32,
+        location_id: i32,
+    ) -> Result<u64> {
+        match self.call(
+            &Request::MemPoolGetAccess {
+                pool,
+                location_type,
+                location_id,
+            },
+            Op::MemPoolGetAccess,
+        )? {
+            Response::Bytes(flags) => Ok(flags),
+            _ => Err(CudaRpcError::Protocol("expected Bytes")),
+        }
+    }
+
+    pub fn mem_pool_trim_to(&mut self, pool: u64, min_bytes: u64) -> Result<()> {
+        self.call(
+            &Request::MemPoolTrimTo { pool, min_bytes },
+            Op::MemPoolTrimTo,
+        )
+        .map(|_| ())
+    }
+
+    pub fn mem_alloc_from_pool_async(&mut self, bytes: u64, pool: u64, stream: u64) -> Result<u64> {
+        match self.call(
+            &Request::MemAllocFromPoolAsync {
+                bytes,
+                pool,
+                stream,
+            },
+            Op::MemAllocFromPoolAsync,
+        )? {
+            Response::Dptr(dptr) => Ok(dptr),
+            _ => Err(CudaRpcError::Protocol("expected Dptr")),
+        }
+    }
+
+    pub fn mem_alloc_async(&mut self, bytes: u64, stream: u64) -> Result<u64> {
+        match self.call(&Request::MemAllocAsync { bytes, stream }, Op::MemAllocAsync)? {
+            Response::Dptr(dptr) => Ok(dptr),
+            _ => Err(CudaRpcError::Protocol("expected Dptr")),
+        }
+    }
+
+    pub fn mem_free_async(&mut self, dptr: u64, stream: u64) -> Result<()> {
+        self.call_deferred(&Request::MemFreeAsync { dptr, stream }, Op::MemFreeAsync)
+    }
+
+    pub fn device_get_default_mem_pool(&mut self, device: i32) -> Result<u64> {
+        match self.call(
+            &Request::DeviceGetDefaultMemPool { device },
+            Op::DeviceGetDefaultMemPool,
+        )? {
+            Response::Handle(pool) => Ok(pool),
+            _ => Err(CudaRpcError::Protocol("expected Handle")),
+        }
+    }
+
+    pub fn device_get_mem_pool(&mut self, device: i32) -> Result<u64> {
+        match self.call(&Request::DeviceGetMemPool { device }, Op::DeviceGetMemPool)? {
+            Response::Handle(pool) => Ok(pool),
+            _ => Err(CudaRpcError::Protocol("expected Handle")),
+        }
+    }
+
+    pub fn device_set_mem_pool(&mut self, device: i32, pool: u64) -> Result<()> {
+        self.call(
+            &Request::DeviceSetMemPool { device, pool },
+            Op::DeviceSetMemPool,
+        )
+        .map(|_| ())
     }
 
     pub fn memcpy_htod(&mut self, dptr: u64, data: &[u8], stream: u64) -> Result<()> {

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -26,6 +26,8 @@ pub type CuResult<T> = Result<T, i32>;
 
 /// `CUDA_ERROR_INVALID_HANDLE`.
 pub const CUDA_ERROR_INVALID_HANDLE: i32 = 400;
+/// `CUDA_ERROR_INVALID_VALUE`.
+pub const CUDA_ERROR_INVALID_VALUE: i32 = 1;
 /// Bit-63 marks a guest-minted virtual handle (see `raw_graph`, cublas vh).
 const VHANDLE_TAG: u64 = 1 << 63;
 /// `CUDA_ERROR_NOT_FOUND`.
@@ -118,6 +120,8 @@ pub trait Backend: Send {
     fn driver_get_version(&mut self) -> CuResult<i32>;
     fn device_get_attribute(&mut self, attrib: i32, device: i32) -> CuResult<i32>;
     fn device_get_uuid(&mut self, device: i32) -> CuResult<[u8; 16]>;
+    fn device_get_pci_bus_id(&mut self, device: i32) -> CuResult<String>;
+    fn device_get_by_pci_bus_id(&mut self, pci_bus_id: &str) -> CuResult<i32>;
     fn ctx_create(&mut self, device: i32) -> CuResult<u64>;
     fn ctx_destroy(&mut self, ctx: u64) -> CuResult<()>;
     fn primary_ctx_retain(&mut self, device: i32) -> CuResult<u64>;
@@ -138,6 +142,32 @@ pub trait Backend: Send {
     }
     fn mem_alloc(&mut self, bytes: u64) -> CuResult<u64>;
     fn mem_free(&mut self, dptr: u64) -> CuResult<()>;
+    fn mem_pool_create(
+        &mut self,
+        alloc_type: i32,
+        handle_types: u32,
+        location_type: i32,
+        location_id: i32,
+        max_size: u64,
+        usage: u16,
+    ) -> CuResult<u64>;
+    fn mem_pool_destroy(&mut self, pool: u64) -> CuResult<()>;
+    fn mem_pool_set_attribute(&mut self, pool: u64, attr: i32, value: u64) -> CuResult<()>;
+    fn mem_pool_get_attribute(&mut self, pool: u64, attr: i32) -> CuResult<u64>;
+    fn mem_pool_set_access(&mut self, pool: u64, descriptors: &[(i32, i32, u64)]) -> CuResult<()>;
+    fn mem_pool_get_access(
+        &mut self,
+        pool: u64,
+        location_type: i32,
+        location_id: i32,
+    ) -> CuResult<u64>;
+    fn mem_pool_trim_to(&mut self, pool: u64, min_bytes: u64) -> CuResult<()>;
+    fn mem_alloc_from_pool_async(&mut self, bytes: u64, pool: u64, stream: u64) -> CuResult<u64>;
+    fn mem_alloc_async(&mut self, bytes: u64, stream: u64) -> CuResult<u64>;
+    fn mem_free_async(&mut self, dptr: u64, stream: u64) -> CuResult<()>;
+    fn device_get_default_mem_pool(&mut self, device: i32) -> CuResult<u64>;
+    fn device_get_mem_pool(&mut self, device: i32) -> CuResult<u64>;
+    fn device_set_mem_pool(&mut self, device: i32, pool: u64) -> CuResult<()>;
     /// Copy with stream ordering: prior work on `stream` (0 = legacy default)
     /// must complete first. Torch's pool streams are created non-blocking, so
     /// a NULL-stream copy does NOT order against them — dropping `stream`
@@ -528,6 +558,8 @@ struct Session {
     contexts: HashMap<u64, u64>,
     streams: HashMap<u64, u64>,
     events: HashMap<u64, u64>,
+    mem_pools: HashMap<u64, u64>,
+    owned_mem_pools: std::collections::HashSet<u64>,
     cublas_handles: HashMap<u64, u64>,
     /// Guest-minted virtual graph/exec handles → real (bit-63 tagged). Lets
     /// EndCapture / GraphInstantiate be fire-and-forget: the guest invents the
@@ -611,6 +643,9 @@ struct Session {
 fn reclaim_session(sess: &mut Session, b: &mut dyn Backend) {
     for (d, _size) in std::mem::take(&mut sess.owned_dptrs) {
         let _ = b.mem_free(d);
+    }
+    for pool in std::mem::take(&mut sess.owned_mem_pools) {
+        let _ = b.mem_pool_destroy(pool);
     }
     // VMM teardown order: unmap, release physical, free reservations.
     for (va, size) in std::mem::take(&mut sess.owned_vmm_maps) {
@@ -2141,6 +2176,34 @@ fn ring_dir_get() -> Option<String> {
     RING_DIR.with(|r| r.borrow().clone())
 }
 
+#[cfg(unix)]
+pub(crate) fn open_ring_file(fname: &[u8], minimum_len: usize) -> Result<std::fs::File, i32> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let Some(dir) = ring_dir_get() else {
+        return Err(CUDA_ERROR_NOT_SUPPORTED);
+    };
+    let name = std::str::from_utf8(fname).map_err(|_| CUDA_ERROR_INVALID_VALUE)?;
+    if name.is_empty() || name.contains('/') || name.contains("..") {
+        return Err(CUDA_ERROR_INVALID_VALUE);
+    }
+    let path = std::path::Path::new(&dir).join(name);
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        // A guest controls this private directory. Never follow a final
+        // symlink into an unrelated host path, even if the name passed the
+        // traversal check above.
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(path)
+        .map_err(|_| CUDA_ERROR_INVALID_VALUE)?;
+    let metadata = file.metadata().map_err(|_| CUDA_ERROR_INVALID_VALUE)?;
+    if !metadata.file_type().is_file() || metadata.len() < minimum_len as u64 {
+        return Err(CUDA_ERROR_INVALID_VALUE);
+    }
+    Ok(file)
+}
+
 fn xlat_stream(h: u64) -> u64 {
     // Thread-local first (P3b replay overrides are deliberately per-thread),
     // then the process-global map for channels served on unseeded threads.
@@ -2621,6 +2684,10 @@ fn translate_dptrs(trans: &[(u64, u64, u64)], req: Request) -> Request {
         Request::MemFree { dptr } => Request::MemFree {
             dptr: xlat(trans, dptr),
         },
+        Request::MemFreeAsync { dptr, stream } => Request::MemFreeAsync {
+            dptr: xlat(trans, dptr),
+            stream,
+        },
         Request::LaunchKernel {
             function,
             grid,
@@ -2929,6 +2996,24 @@ struct HostRings {
     /// Bounce pages (host VAs) for responses too large for an inline record.
     bounce: Vec<*mut u8>,
     page_size: usize,
+    /// Owns an mmap created for file-backed rings. GPA-backed rings point into
+    /// guest RAM and therefore carry no mapping here.
+    _file_mapping: Option<RingFileMapping>,
+}
+
+struct RingFileMapping {
+    base: *mut libc::c_void,
+    len: usize,
+}
+
+impl Drop for RingFileMapping {
+    fn drop(&mut self) {
+        // SAFETY: base/len are the exact successful mmap result retained by
+        // HostRings, and this owner is constructed only once for that mapping.
+        unsafe {
+            libc::munmap(self.base, self.len);
+        }
+    }
 }
 
 impl HostRings {
@@ -2965,6 +3050,7 @@ impl HostRings {
             resp: unsafe { crate::ring::Ring::from_pages(resp, ps) },
             bounce,
             page_size: ps,
+            _file_mapping: None,
         })
     }
 
@@ -2990,27 +3076,8 @@ impl HostRings {
         {
             return Err(1);
         }
-        let Some(dir) = ring_dir_get() else {
-            return Err(801); // no advert on this connection -> not supported
-        };
-        let name = std::str::from_utf8(fname).map_err(|_| 1)?;
-        // Bare names only: the guest must not traverse out of the ring dir.
-        if name.is_empty() || name.contains('/') || name.contains("..") {
-            return Err(1);
-        }
         let total = (req_n + resp_n + bounce_n) as usize * ps;
-        let path = std::path::Path::new(&dir).join(name);
-        let f = std::fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(&path)
-            .map_err(|_| 1)?;
-        if f.metadata()
-            .map(|m| (m.len() as usize) < total)
-            .unwrap_or(true)
-        {
-            return Err(1);
-        }
+        let f = open_ring_file(fname, total)?;
         // SAFETY: mapping a regular file we just validated, MAP_SHARED so the
         // guest's dax view and ours are the same physical pages.
         let base = unsafe {
@@ -3034,15 +3101,16 @@ impl HostRings {
         let req = pages(0, req_n as usize);
         let resp = pages(req_n as usize, resp_n as usize);
         let bounce = pages((req_n + resp_n) as usize, bounce_n as usize);
-        // The mapping (and an O_RDWR fd via the mmap ref) lives for the
-        // connection; the file itself can be unlinked by either side later.
-        // SAFETY: pages are backed by the shared file mapping for the
-        // connection's lifetime (never munmap'd until process exit).
+        // Keep one owner so the mapping is released as soon as the connection
+        // exits. Without this, every short-lived clone leaked one mapping and
+        // its tmpfs pages in the long-lived shared CUDA daemon.
+        // SAFETY: pages remain backed by this owner for the connection lifetime.
         Ok(HostRings {
             req: unsafe { crate::ring::Ring::from_pages(req, ps) },
             resp: unsafe { crate::ring::Ring::from_pages(resp, ps) },
             bounce,
             page_size: ps,
+            _file_mapping: Some(RingFileMapping { base, len: total }),
         })
     }
 
@@ -3981,6 +4049,20 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
         Request::DeviceGetUuid { device } => b
             .device_get_uuid(dev(sess, device))
             .map(|u| Response::Data(u.to_vec())),
+        Request::DeviceGetPciBusId { device } => b
+            .device_get_pci_bus_id(dev(sess, device))
+            .map(Response::Name),
+        Request::DeviceGetByPciBusId { pci_bus_id } => {
+            let physical = b.device_get_by_pci_bus_id(&pci_bus_id)?;
+            if sess.device_pinned {
+                if physical != sess.device_base {
+                    return Err(101); // CUDA_ERROR_INVALID_DEVICE
+                }
+                Ok(Response::Count(0))
+            } else {
+                Ok(Response::Count(physical))
+            }
+        }
         Request::CtxCreate { device } => {
             let raw = b.ctx_create(dev(sess, device))?;
             let id = sess.mint();
@@ -4311,6 +4393,139 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
             } else {
                 b.mem_free(dptr).map(|_| Response::Ok)
             }
+        }
+        Request::MemPoolCreate {
+            alloc_type,
+            handle_types,
+            location_type,
+            location_id,
+            max_size,
+            usage,
+        } => {
+            let location_id = if location_type == 1 {
+                dev(sess, location_id)
+            } else {
+                location_id
+            };
+            let pool = b.mem_pool_create(
+                alloc_type,
+                handle_types,
+                location_type,
+                location_id,
+                max_size,
+                usage,
+            )?;
+            let id = sess.mint();
+            sess.mem_pools.insert(id, pool);
+            sess.owned_mem_pools.insert(pool);
+            Ok(Response::Handle(id))
+        }
+        Request::MemPoolDestroy { pool } => {
+            let raw_pool = raw(&sess.mem_pools, pool)?;
+            b.mem_pool_destroy(raw_pool)?;
+            sess.mem_pools.remove(&pool);
+            sess.owned_mem_pools.remove(&raw_pool);
+            Ok(Response::Ok)
+        }
+        Request::MemPoolSetAttribute { pool, attr, value } => {
+            let raw_pool = raw(&sess.mem_pools, pool)?;
+            b.mem_pool_set_attribute(raw_pool, attr, value)
+                .map(|_| Response::Ok)
+        }
+        Request::MemPoolGetAttribute { pool, attr } => {
+            let raw_pool = raw(&sess.mem_pools, pool)?;
+            b.mem_pool_get_attribute(raw_pool, attr)
+                .map(Response::Bytes)
+        }
+        Request::MemPoolSetAccess {
+            pool,
+            mut descriptors,
+        } => {
+            let raw_pool = raw(&sess.mem_pools, pool)?;
+            for (location_type, location_id, _) in &mut descriptors {
+                if *location_type == 1 {
+                    *location_id = dev(sess, *location_id);
+                }
+            }
+            b.mem_pool_set_access(raw_pool, &descriptors)
+                .map(|_| Response::Ok)
+        }
+        Request::MemPoolGetAccess {
+            pool,
+            location_type,
+            location_id,
+        } => {
+            let raw_pool = raw(&sess.mem_pools, pool)?;
+            let location_id = if location_type == 1 {
+                dev(sess, location_id)
+            } else {
+                location_id
+            };
+            b.mem_pool_get_access(raw_pool, location_type, location_id)
+                .map(Response::Bytes)
+        }
+        Request::MemPoolTrimTo { pool, min_bytes } => {
+            let raw_pool = raw(&sess.mem_pools, pool)?;
+            b.mem_pool_trim_to(raw_pool, min_bytes)
+                .map(|_| Response::Ok)
+        }
+        Request::MemAllocFromPoolAsync {
+            bytes,
+            pool,
+            stream,
+        } => {
+            let limit = allocation_vram_limit(sess, b)?;
+            let used: u64 = sess.owned_dptrs.values().sum::<u64>()
+                + sess.owned_vmm_handles.values().sum::<u64>();
+            if used.saturating_add(bytes) > limit {
+                return Err(2);
+            }
+            let raw_pool = raw(&sess.mem_pools, pool)?;
+            let dptr = b.mem_alloc_from_pool_async(bytes, raw_pool, raw_stream(sess, stream)?)?;
+            sess.owned_dptrs.insert(dptr, bytes);
+            sess.alloc_table
+                .lock()
+                .unwrap()
+                .insert(dptr, (bytes, false));
+            Ok(Response::Dptr(dptr))
+        }
+        Request::MemAllocAsync { bytes, stream } => {
+            let limit = allocation_vram_limit(sess, b)?;
+            let used: u64 = sess.owned_dptrs.values().sum::<u64>()
+                + sess.owned_vmm_handles.values().sum::<u64>();
+            if used.saturating_add(bytes) > limit {
+                return Err(2);
+            }
+            let dptr = b.mem_alloc_async(bytes, raw_stream(sess, stream)?)?;
+            sess.owned_dptrs.insert(dptr, bytes);
+            sess.alloc_table
+                .lock()
+                .unwrap()
+                .insert(dptr, (bytes, false));
+            Ok(Response::Dptr(dptr))
+        }
+        Request::MemFreeAsync { dptr, stream } => {
+            b.mem_free_async(dptr, raw_stream(sess, stream)?)?;
+            sess.owned_dptrs.remove(&dptr);
+            sess.alloc_table.lock().unwrap().remove(&dptr);
+            Ok(Response::Ok)
+        }
+        Request::DeviceGetDefaultMemPool { device } => {
+            let pool = b.device_get_default_mem_pool(dev(sess, device))?;
+            let id = sess.mint();
+            sess.mem_pools.insert(id, pool);
+            Ok(Response::Handle(id))
+        }
+        Request::DeviceGetMemPool { device } => {
+            let pool = b.device_get_mem_pool(dev(sess, device))?;
+            let id = sess.mint();
+            sess.mem_pools.insert(id, pool);
+            Ok(Response::Handle(id))
+        }
+        Request::DeviceSetMemPool { device, pool } => {
+            let raw_pool = raw(&sess.mem_pools, pool)?;
+            b.device_set_mem_pool(dev(sess, device), raw_pool)
+                .map(|_| Response::Ok)
         }
         Request::MemcpyHtoD { dptr, stream, data } => {
             mark_loaded(&sess.alloc_table, dptr); // H2D write → weight/read-only
@@ -5217,6 +5432,12 @@ impl Backend for CpuBackend {
     fn device_get_uuid(&mut self, _device: i32) -> CuResult<[u8; 16]> {
         Ok(*b"smolvm-cpu-emul\0")
     }
+    fn device_get_pci_bus_id(&mut self, _device: i32) -> CuResult<String> {
+        Ok("0000:00:00.0".to_string())
+    }
+    fn device_get_by_pci_bus_id(&mut self, pci_bus_id: &str) -> CuResult<i32> {
+        (pci_bus_id == "0000:00:00.0").then_some(0).ok_or(101)
+    }
     fn ctx_create(&mut self, _device: i32) -> CuResult<u64> {
         Ok(self.handle())
     }
@@ -5266,6 +5487,62 @@ impl Backend for CpuBackend {
             .remove(&dptr)
             .map(|_| ())
             .ok_or(CUDA_ERROR_INVALID_HANDLE)
+    }
+    fn mem_pool_create(
+        &mut self,
+        _alloc_type: i32,
+        _handle_types: u32,
+        _location_type: i32,
+        _location_id: i32,
+        _max_size: u64,
+        _usage: u16,
+    ) -> CuResult<u64> {
+        Ok(self.handle())
+    }
+    fn mem_pool_destroy(&mut self, _pool: u64) -> CuResult<()> {
+        Ok(())
+    }
+    fn mem_pool_set_attribute(&mut self, _pool: u64, _attr: i32, _value: u64) -> CuResult<()> {
+        Ok(())
+    }
+    fn mem_pool_get_attribute(&mut self, _pool: u64, _attr: i32) -> CuResult<u64> {
+        Ok(0)
+    }
+    fn mem_pool_set_access(
+        &mut self,
+        _pool: u64,
+        _descriptors: &[(i32, i32, u64)],
+    ) -> CuResult<()> {
+        Ok(())
+    }
+    fn mem_pool_get_access(
+        &mut self,
+        _pool: u64,
+        _location_type: i32,
+        _location_id: i32,
+    ) -> CuResult<u64> {
+        Ok(3)
+    }
+    fn mem_pool_trim_to(&mut self, _pool: u64, _min_bytes: u64) -> CuResult<()> {
+        Ok(())
+    }
+    fn mem_alloc_from_pool_async(&mut self, bytes: u64, _pool: u64, _stream: u64) -> CuResult<u64> {
+        self.mem_alloc(bytes)
+    }
+    fn mem_alloc_async(&mut self, bytes: u64, _stream: u64) -> CuResult<u64> {
+        self.mem_alloc(bytes)
+    }
+    fn mem_free_async(&mut self, dptr: u64, _stream: u64) -> CuResult<()> {
+        self.mem_free(dptr)
+    }
+    fn device_get_default_mem_pool(&mut self, _device: i32) -> CuResult<u64> {
+        Ok(1)
+    }
+    fn device_get_mem_pool(&mut self, _device: i32) -> CuResult<u64> {
+        Ok(1)
+    }
+    fn device_set_mem_pool(&mut self, _device: i32, _pool: u64) -> CuResult<()> {
+        Ok(())
     }
     fn memcpy_htod(&mut self, dptr: u64, data: &[u8], _stream: u64) -> CuResult<()> {
         let buf = self.mem.get_mut(&dptr).ok_or(CUDA_ERROR_INVALID_HANDLE)?;
@@ -5478,6 +5755,72 @@ mod tests {
     use super::*;
     use crate::client::Client;
     use std::io::{Read, Write};
+
+    #[cfg(unix)]
+    #[test]
+    fn ring_files_reject_traversal_and_final_symlinks() {
+        use std::os::unix::fs::symlink;
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        static SEQUENCE: AtomicU64 = AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "smolvm-ring-test-{}-{}",
+            std::process::id(),
+            SEQUENCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir(&dir).unwrap();
+        std::fs::write(dir.join("ring.bin"), [0_u8; 64]).unwrap();
+        symlink(dir.join("ring.bin"), dir.join("link.bin")).unwrap();
+        ring_dir_set(Some(dir.to_string_lossy().into_owned()));
+        assert!(open_ring_file(b"ring.bin", 64).is_ok());
+        assert!(open_ring_file(b"link.bin", 64).is_err());
+        assert!(open_ring_file(b"../ring.bin", 64).is_err());
+        ring_dir_set(None);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn file_ring_mapping_is_unmapped_when_connection_rings_drop() {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        const PAGE: usize = 4096;
+        static SEQUENCE: AtomicU64 = AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "smolvm-ring-unmap-test-{}-{}",
+            std::process::id(),
+            SEQUENCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir(&dir).unwrap();
+        let path = dir.join("ring.bin");
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&path)
+            .unwrap();
+        file.set_len((3 * PAGE) as u64).unwrap();
+        ring_dir_set(Some(dir.to_string_lossy().into_owned()));
+        let rings = HostRings::map_file(PAGE as u32, 1, 1, 1, b"ring.bin").unwrap();
+        ring_dir_set(None);
+
+        let mapping = rings._file_mapping.as_ref().unwrap();
+        let base = mapping.base;
+        let mut residency = 0_u8;
+        // SAFETY: base identifies the live page-aligned mapping owned by rings.
+        assert_eq!(unsafe { libc::mincore(base, PAGE, &mut residency) }, 0);
+        drop(rings);
+        // SAFETY: mincore only queries the address range; it does not dereference
+        // it. The call must now reject the unmapped range with ENOMEM.
+        assert_eq!(unsafe { libc::mincore(base, PAGE, &mut residency) }, -1);
+        assert_eq!(
+            std::io::Error::last_os_error().raw_os_error(),
+            Some(libc::ENOMEM)
+        );
+        std::fs::remove_dir_all(dir).unwrap();
+    }
 
     #[cfg(target_os = "linux")]
     #[test]
@@ -5989,6 +6332,8 @@ mod tests {
         let mut cli = Client::new(client_side);
         cli.init(0).unwrap();
         assert_eq!(cli.device_get_count().unwrap(), 1);
+        assert_eq!(cli.device_get_pci_bus_id(0).unwrap(), "0000:00:00.0");
+        assert_eq!(cli.device_get_by_pci_bus_id("0000:00:00.0").unwrap(), 0);
         let module = cli.module_load_data(b"<ptx>").unwrap();
         let func = cli.module_get_function(module, "vecadd").unwrap();
         let n = 8usize;
@@ -6023,6 +6368,15 @@ mod tests {
             .collect();
         let expect: Vec<f32> = (0..n).map(|i| (3 * i) as f32).collect();
         assert_eq!(c, expect);
+        let pool = cli.mem_pool_create(1, 0, 1, 0, 0, 0).unwrap();
+        cli.mem_pool_set_attribute(pool, 4, 1 << 20).unwrap();
+        assert_eq!(cli.mem_pool_get_attribute(pool, 4).unwrap(), 0);
+        cli.mem_pool_set_access(pool, vec![(1, 0, 3)]).unwrap();
+        assert_eq!(cli.mem_pool_get_access(pool, 1, 0).unwrap(), 3);
+        let pooled = cli.mem_alloc_from_pool_async(4096, pool, 0).unwrap();
+        cli.mem_free_async(pooled, 0).unwrap();
+        cli.ctx_synchronize().unwrap();
+        cli.mem_pool_destroy(pool).unwrap();
         drop(cli); // closes client_side → server sees EOF
         server.join().unwrap();
     }

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -3001,11 +3001,16 @@ struct HostRings {
     _file_mapping: Option<RingFileMapping>,
 }
 
+#[cfg(unix)]
 struct RingFileMapping {
     base: *mut libc::c_void,
     len: usize,
 }
 
+#[cfg(not(unix))]
+struct RingFileMapping;
+
+#[cfg(unix)]
 impl Drop for RingFileMapping {
     fn drop(&mut self) {
         // SAFETY: base/len are the exact successful mmap result retained by
@@ -5806,19 +5811,21 @@ mod tests {
         let rings = HostRings::map_file(PAGE as u32, 1, 1, 1, b"ring.bin").unwrap();
         ring_dir_set(None);
 
-        let mapping = rings._file_mapping.as_ref().unwrap();
-        let base = mapping.base;
-        let mut residency = 0_u8;
-        // SAFETY: base identifies the live page-aligned mapping owned by rings.
-        assert_eq!(unsafe { libc::mincore(base, PAGE, &mut residency) }, 0);
+        let canonical = path.canonicalize().unwrap();
+        let mapping_is_listed = || {
+            std::fs::read_to_string("/proc/self/maps")
+                .unwrap()
+                .lines()
+                .filter_map(|line| line.split_whitespace().last())
+                .any(|mapped| mapped == canonical.to_string_lossy())
+        };
+        assert!(rings._file_mapping.is_some());
+        assert!(mapping_is_listed());
         drop(rings);
-        // SAFETY: mincore only queries the address range; it does not dereference
-        // it. The call must now reject the unmapped range with ENOMEM.
-        assert_eq!(unsafe { libc::mincore(base, PAGE, &mut residency) }, -1);
-        assert_eq!(
-            std::io::Error::last_os_error().raw_os_error(),
-            Some(libc::ENOMEM)
-        );
+        // Do not query the stale address with mincore: another parallel test
+        // can immediately reuse that VA and make the mapping appear live. The
+        // unique backing path proves this owner's mapping itself was removed.
+        assert!(!mapping_is_listed());
         std::fs::remove_dir_all(dir).unwrap();
     }
 

--- a/crates/smolvm-cuda/src/host/gpu.rs
+++ b/crates/smolvm-cuda/src/host/gpu.rs
@@ -22,6 +22,70 @@ const CUDA_LIB: &str = "libcuda.dylib"; // not expected to exist; macOS has no C
 
 type CuResultCode = c_int;
 
+const CUDA_ERROR_INVALID_VALUE: c_int = 1;
+const CUDA_ERROR_INVALID_HANDLE: c_int = 400;
+const CUDA_ERROR_NOT_SUPPORTED: c_int = 801;
+
+/// CUfunction handles are process-local driver objects.  A remoted guest can
+/// accidentally send one of its own code pointers (static libcudart does this
+/// for unavailable fallback kernels), and NVIDIA's driver dereferences rather
+/// than validates some such values.  Record every function minted in this
+/// daemon process so untrusted wire handles fail as INVALID_HANDLE instead of
+/// taking down the shared CUDA daemon.
+fn live_cuda_functions() -> &'static std::sync::Mutex<std::collections::HashSet<u64>> {
+    static FUNCTIONS: std::sync::OnceLock<std::sync::Mutex<std::collections::HashSet<u64>>> =
+        std::sync::OnceLock::new();
+    FUNCTIONS.get_or_init(|| std::sync::Mutex::new(std::collections::HashSet::new()))
+}
+
+fn register_cuda_function(function: u64) {
+    if function != 0 {
+        live_cuda_functions().lock().unwrap().insert(function);
+    }
+}
+
+fn validate_cuda_function(function: u64) -> CuResult<()> {
+    live_cuda_functions()
+        .lock()
+        .unwrap()
+        .contains(&function)
+        .then_some(())
+        .ok_or(CUDA_ERROR_INVALID_HANDLE)
+}
+
+#[repr(C)]
+struct FatbincWrapper {
+    magic: c_uint,
+    version: c_uint,
+    data: *const c_void,
+    filename_or_fatbins: *const c_void,
+}
+
+#[repr(C)]
+struct CuMemLocation {
+    type_: c_int,
+    id: c_int,
+}
+
+/// CUDA 13 `CUmemPoolProps_v1`. Pointer and reserved fields are always local
+/// zeroes; the guest transports only the stable scalar fields.
+#[repr(C)]
+struct CuMemPoolProps {
+    alloc_type: c_int,
+    handle_types: c_uint,
+    location: CuMemLocation,
+    win32_security_attributes: *mut c_void,
+    max_size: usize,
+    usage: u16,
+    reserved: [u8; 54],
+}
+
+#[repr(C)]
+struct CuMemAccessDesc {
+    location: CuMemLocation,
+    flags: c_int,
+}
+
 /// Hand-declared driver entry points. Stored as `'static` fn pointers; `_lib`
 /// keeps the library mapped for as long as the backend lives.
 pub struct GpuBackend {
@@ -33,6 +97,8 @@ pub struct GpuBackend {
     driver_get_version: unsafe extern "C" fn(*mut c_int) -> CuResultCode,
     device_get_attribute: unsafe extern "C" fn(*mut c_int, c_int, c_int) -> CuResultCode,
     device_get_uuid: unsafe extern "C" fn(*mut u8, c_int) -> CuResultCode,
+    device_get_pci_bus_id: unsafe extern "C" fn(*mut c_char, c_int, c_int) -> CuResultCode,
+    device_get_by_pci_bus_id: unsafe extern "C" fn(*mut c_int, *const c_char) -> CuResultCode,
     ctx_create: unsafe extern "C" fn(*mut *mut c_void, c_uint, c_int) -> CuResultCode,
     ctx_destroy: unsafe extern "C" fn(*mut c_void) -> CuResultCode,
     ctx_set_current: unsafe extern "C" fn(*mut c_void) -> CuResultCode,
@@ -45,6 +111,27 @@ pub struct GpuBackend {
     module_get_global:
         unsafe extern "C" fn(*mut u64, *mut usize, *mut c_void, *const c_char) -> CuResultCode,
     module_unload: unsafe extern "C" fn(*mut c_void) -> CuResultCode,
+    library_load_data: Option<
+        unsafe extern "C" fn(
+            *mut *mut c_void,
+            *const c_void,
+            *mut c_int,
+            *mut *mut c_void,
+            c_uint,
+            *mut c_int,
+            *mut *mut c_void,
+            c_uint,
+        ) -> CuResultCode,
+    >,
+    library_unload: Option<unsafe extern "C" fn(*mut c_void) -> CuResultCode>,
+    library_get_kernel:
+        Option<unsafe extern "C" fn(*mut *mut c_void, *mut c_void, *const c_char) -> CuResultCode>,
+    library_get_module: Option<unsafe extern "C" fn(*mut *mut c_void, *mut c_void) -> CuResultCode>,
+    kernel_get_function:
+        Option<unsafe extern "C" fn(*mut *mut c_void, *mut c_void) -> CuResultCode>,
+    cuda_library_builds: std::collections::HashMap<u64, (u32, Vec<Vec<u8>>)>,
+    next_cuda_library_build: u64,
+    live_cuda_libraries: std::collections::HashSet<u64>,
     /// `cuFuncGetParamInfo` — CUDA 12.4+. `None` on older drivers, where
     /// [`Backend::func_get_param_info`] reports `CUDA_ERROR_NOT_SUPPORTED`.
     func_get_param_info:
@@ -53,6 +140,22 @@ pub struct GpuBackend {
     func_get_attribute: unsafe extern "C" fn(*mut c_int, c_int, *mut c_void) -> CuResultCode,
     mem_alloc: unsafe extern "C" fn(*mut u64, usize) -> CuResultCode,
     mem_free: unsafe extern "C" fn(u64) -> CuResultCode,
+    mem_pool_create: unsafe extern "C" fn(*mut *mut c_void, *const CuMemPoolProps) -> CuResultCode,
+    mem_pool_destroy: unsafe extern "C" fn(*mut c_void) -> CuResultCode,
+    mem_pool_set_attribute: unsafe extern "C" fn(*mut c_void, c_int, *mut c_void) -> CuResultCode,
+    mem_pool_get_attribute: unsafe extern "C" fn(*mut c_void, c_int, *mut c_void) -> CuResultCode,
+    mem_pool_set_access:
+        unsafe extern "C" fn(*mut c_void, *const CuMemAccessDesc, usize) -> CuResultCode,
+    mem_pool_get_access:
+        unsafe extern "C" fn(*mut c_int, *mut c_void, *const CuMemLocation) -> CuResultCode,
+    mem_pool_trim_to: unsafe extern "C" fn(*mut c_void, usize) -> CuResultCode,
+    mem_alloc_from_pool_async:
+        unsafe extern "C" fn(*mut u64, usize, *mut c_void, *mut c_void) -> CuResultCode,
+    mem_alloc_async: unsafe extern "C" fn(*mut u64, usize, *mut c_void) -> CuResultCode,
+    mem_free_async: unsafe extern "C" fn(u64, *mut c_void) -> CuResultCode,
+    device_get_default_mem_pool: unsafe extern "C" fn(*mut *mut c_void, c_int) -> CuResultCode,
+    device_get_mem_pool: unsafe extern "C" fn(*mut *mut c_void, c_int) -> CuResultCode,
+    device_set_mem_pool: unsafe extern "C" fn(c_int, *mut c_void) -> CuResultCode,
     memcpy_htod: unsafe extern "C" fn(u64, *const c_void, usize) -> CuResultCode,
     memcpy_dtoh: unsafe extern "C" fn(*mut c_void, u64, usize) -> CuResultCode,
     memcpy_dtod: unsafe extern "C" fn(u64, u64, usize) -> CuResultCode,
@@ -219,6 +322,9 @@ pub struct GpuBackend {
     /// `cuMemHostRegister` (to unregister on drop). Excludes ranges another
     /// connection already owns. Empty until the first zero-copy transfer.
     registered: Vec<(u64, u64)>,
+    /// Tmpfs file mappings registered for guest `cuMemHostAlloc`. Each mapping
+    /// is also present in `registered`; keep it alive until CUDA unregisters it.
+    mapped_host_files: Vec<(u64, u64)>,
     /// Whether lazy guest-RAM pinning has been attempted (once per backend).
     guest_ram_pin_tried: bool,
     /// Reusable pinned host staging buffer `(addr, capacity)` for the gather /
@@ -233,6 +339,21 @@ pub struct GpuBackend {
 /// — past here the per-DMA launch overhead of thousands of tiny copies costs
 /// more than a single host-side gather plus one big transfer.
 const ZC_DIRECT_MAX_SEGMENTS: usize = 16;
+fn containing_registered_range(
+    registered: &[(u64, u64)],
+    address: u64,
+    len: u64,
+) -> Option<(usize, u64, u64)> {
+    let end = address.checked_add(len)?;
+    registered
+        .iter()
+        .copied()
+        .enumerate()
+        .find(|&(_, (base, size))| {
+            base <= address && base.checked_add(size).is_some_and(|limit| end <= limit)
+        })
+        .map(|(index, (base, size))| (index, base, size))
+}
 
 /// Code-generated forward-to-host-lib dispatch (see `smolvm-cuda-codegen`).
 /// Each `include!`d module exposes a `GenLib` with `load()` + `dispatch()`.
@@ -401,6 +522,8 @@ impl GpuBackend {
                 driver_get_version: sym(&lib, b"cuDriverGetVersion\0")?,
                 device_get_attribute: sym(&lib, b"cuDeviceGetAttribute\0")?,
                 device_get_uuid: sym2(&lib, b"cuDeviceGetUuid_v2\0", b"cuDeviceGetUuid\0")?,
+                device_get_pci_bus_id: sym(&lib, b"cuDeviceGetPCIBusId\0")?,
+                device_get_by_pci_bus_id: sym(&lib, b"cuDeviceGetByPCIBusId\0")?,
                 ctx_create: sym(&lib, b"cuCtxCreate_v2\0")?,
                 ctx_destroy: sym(&lib, b"cuCtxDestroy_v2\0")?,
                 ctx_set_current: sym(&lib, b"cuCtxSetCurrent\0")?,
@@ -415,11 +538,32 @@ impl GpuBackend {
                 module_get_function: sym(&lib, b"cuModuleGetFunction\0")?,
                 module_get_global: sym2(&lib, b"cuModuleGetGlobal_v2\0", b"cuModuleGetGlobal\0")?,
                 module_unload: sym(&lib, b"cuModuleUnload\0")?,
+                library_load_data: sym(&lib, b"cuLibraryLoadData\0").ok(),
+                library_unload: sym(&lib, b"cuLibraryUnload\0").ok(),
+                library_get_kernel: sym(&lib, b"cuLibraryGetKernel\0").ok(),
+                library_get_module: sym(&lib, b"cuLibraryGetModule\0").ok(),
+                kernel_get_function: sym(&lib, b"cuKernelGetFunction\0").ok(),
+                cuda_library_builds: std::collections::HashMap::new(),
+                next_cuda_library_build: 1,
+                live_cuda_libraries: std::collections::HashSet::new(),
                 func_get_param_info: sym(&lib, b"cuFuncGetParamInfo\0").ok(),
                 func_set_attribute: sym(&lib, b"cuFuncSetAttribute\0")?,
                 func_get_attribute: sym(&lib, b"cuFuncGetAttribute\0")?,
                 mem_alloc: sym(&lib, b"cuMemAlloc_v2\0")?,
                 mem_free: sym(&lib, b"cuMemFree_v2\0")?,
+                mem_pool_create: sym(&lib, b"cuMemPoolCreate\0")?,
+                mem_pool_destroy: sym(&lib, b"cuMemPoolDestroy\0")?,
+                mem_pool_set_attribute: sym(&lib, b"cuMemPoolSetAttribute\0")?,
+                mem_pool_get_attribute: sym(&lib, b"cuMemPoolGetAttribute\0")?,
+                mem_pool_set_access: sym(&lib, b"cuMemPoolSetAccess\0")?,
+                mem_pool_get_access: sym(&lib, b"cuMemPoolGetAccess\0")?,
+                mem_pool_trim_to: sym(&lib, b"cuMemPoolTrimTo\0")?,
+                mem_alloc_from_pool_async: sym(&lib, b"cuMemAllocFromPoolAsync\0")?,
+                mem_alloc_async: sym(&lib, b"cuMemAllocAsync\0")?,
+                mem_free_async: sym(&lib, b"cuMemFreeAsync\0")?,
+                device_get_default_mem_pool: sym(&lib, b"cuDeviceGetDefaultMemPool\0")?,
+                device_get_mem_pool: sym(&lib, b"cuDeviceGetMemPool\0")?,
+                device_set_mem_pool: sym(&lib, b"cuDeviceSetMemPool\0")?,
                 memcpy_htod: sym(&lib, b"cuMemcpyHtoD_v2\0")?,
                 memcpy_dtoh: sym(&lib, b"cuMemcpyDtoH_v2\0")?,
                 memcpy_dtod: sym(&lib, b"cuMemcpyDtoD_v2\0")?,
@@ -517,12 +661,357 @@ impl GpuBackend {
                 #[cfg(unix)]
                 proc_mem_regions: Vec::new(),
                 registered: Vec::new(),
+                mapped_host_files: Vec::new(),
                 guest_ram_pin_tried: false,
                 staging: (0, 0),
                 _lib: lib,
             };
             Ok(b)
         }
+    }
+
+    /// Driver Library API bridge used by generic library id 6, functions
+    /// 3..=11. Images arrive incrementally so a large static-runtime wrapper
+    /// (NCCL has hundreds of fatbins) never exceeds the 256 MiB wire frame.
+    fn cuda_driver_library_call(
+        &mut self,
+        func: u16,
+        args: &[u8],
+    ) -> Option<CuResult<(i32, Vec<u8>)>> {
+        // One primary image plus up to 4096 v2 prelinked dependencies.
+        const MAX_IMAGES: usize = 4097;
+        const MAX_LIBRARY_BYTES: usize = 2 * 1024 * 1024 * 1024;
+
+        let read_handle = |bytes: &[u8]| -> Result<u64, c_int> {
+            bytes
+                .get(..8)
+                .and_then(|b| b.try_into().ok())
+                .map(u64::from_le_bytes)
+                .ok_or(CUDA_ERROR_INVALID_VALUE)
+        };
+        let response = |status: c_int, handle: *mut c_void| {
+            Ok((
+                status,
+                if status == 0 {
+                    (handle as u64).to_le_bytes().to_vec()
+                } else {
+                    Vec::new()
+                },
+            ))
+        };
+
+        Some(match func {
+            3 => {
+                let kind = args
+                    .get(..4)
+                    .and_then(|b| b.try_into().ok())
+                    .map(u32::from_le_bytes)
+                    .filter(|kind| *kind <= 2)
+                    .ok_or(CUDA_ERROR_INVALID_VALUE);
+                match kind {
+                    Ok(kind) => {
+                        let build = self.next_cuda_library_build.max(1);
+                        self.next_cuda_library_build = build.wrapping_add(1).max(1);
+                        self.cuda_library_builds.insert(build, (kind, Vec::new()));
+                        response(0, build as *mut c_void)
+                    }
+                    Err(status) => response(status, std::ptr::null_mut()),
+                }
+            }
+            4 => match read_handle(args) {
+                Ok(build) => match self.cuda_library_builds.get_mut(&build) {
+                    Some((_, images)) => {
+                        let total = images
+                            .iter()
+                            .try_fold(0usize, |n, image| n.checked_add(image.len()))
+                            .and_then(|n| n.checked_add(args.len().saturating_sub(8)));
+                        if images.len() >= MAX_IMAGES
+                            || total.is_none_or(|n| n > MAX_LIBRARY_BYTES)
+                            || args.len() <= 8
+                        {
+                            response(CUDA_ERROR_INVALID_VALUE, std::ptr::null_mut())
+                        } else {
+                            images.push(args[8..].to_vec());
+                            response(0, std::ptr::null_mut())
+                        }
+                    }
+                    None => response(CUDA_ERROR_INVALID_VALUE, std::ptr::null_mut()),
+                },
+                Err(status) => response(status, std::ptr::null_mut()),
+            },
+            5 => match read_handle(args) {
+                Ok(build) => match self.cuda_library_builds.remove(&build) {
+                    Some((kind, images)) if !images.is_empty() => {
+                        let Some(load) = self.library_load_data else {
+                            return Some(response(CUDA_ERROR_NOT_SUPPORTED, std::ptr::null_mut()));
+                        };
+                        if (kind < 2 && images.len() != 1) || (kind == 2 && images.len() < 2) {
+                            response(CUDA_ERROR_INVALID_VALUE, std::ptr::null_mut())
+                        } else {
+                            let pointers: Vec<*const c_void> = images
+                                .iter()
+                                .skip(if kind == 2 { 1 } else { 0 })
+                                .map(|image| image.as_ptr().cast())
+                                .chain(std::iter::once(std::ptr::null()))
+                                .collect();
+                            let wrapper = FatbincWrapper {
+                                magic: 0x4662_43b1,
+                                version: kind,
+                                data: images[0].as_ptr().cast(),
+                                filename_or_fatbins: if kind == 2 {
+                                    pointers.as_ptr().cast()
+                                } else {
+                                    std::ptr::null()
+                                },
+                            };
+                            let code = if kind == 0 {
+                                images[0].as_ptr().cast()
+                            } else {
+                                (&wrapper as *const FatbincWrapper).cast()
+                            };
+                            let mut library = std::ptr::null_mut();
+                            let status = unsafe {
+                                load(
+                                    &mut library,
+                                    code,
+                                    std::ptr::null_mut(),
+                                    std::ptr::null_mut(),
+                                    0,
+                                    std::ptr::null_mut(),
+                                    std::ptr::null_mut(),
+                                    0,
+                                )
+                            };
+                            if status == 0 {
+                                self.live_cuda_libraries.insert(library as u64);
+                            }
+                            response(status, library)
+                        }
+                    }
+                    _ => response(CUDA_ERROR_INVALID_VALUE, std::ptr::null_mut()),
+                },
+                Err(status) => response(status, std::ptr::null_mut()),
+            },
+            6 => match (read_handle(args), self.library_unload) {
+                (Ok(library), Some(unload)) => {
+                    let status = unsafe { unload(library as *mut c_void) };
+                    if status == 0 {
+                        self.live_cuda_libraries.remove(&library);
+                    }
+                    response(status, std::ptr::null_mut())
+                }
+                (Err(status), _) => response(status, std::ptr::null_mut()),
+                (_, None) => response(CUDA_ERROR_NOT_SUPPORTED, std::ptr::null_mut()),
+            },
+            7 => match (read_handle(args), self.library_get_kernel) {
+                (Ok(library), Some(get_kernel)) if args.len() > 8 => {
+                    match CString::new(&args[8..]) {
+                        Ok(name) => {
+                            let mut kernel = std::ptr::null_mut();
+                            let status = unsafe {
+                                get_kernel(&mut kernel, library as *mut c_void, name.as_ptr())
+                            };
+                            response(status, kernel)
+                        }
+                        Err(_) => response(CUDA_ERROR_INVALID_VALUE, std::ptr::null_mut()),
+                    }
+                }
+                (Err(status), _) => response(status, std::ptr::null_mut()),
+                (_, None) => response(CUDA_ERROR_NOT_SUPPORTED, std::ptr::null_mut()),
+                _ => response(CUDA_ERROR_INVALID_VALUE, std::ptr::null_mut()),
+            },
+            8 => match (read_handle(args), self.kernel_get_function) {
+                (Ok(kernel), Some(get_function)) => {
+                    let mut function = std::ptr::null_mut();
+                    let status = unsafe { get_function(&mut function, kernel as *mut c_void) };
+                    if status == 0 {
+                        register_cuda_function(function as u64);
+                    }
+                    response(status, function)
+                }
+                (Err(status), _) => response(status, std::ptr::null_mut()),
+                (_, None) => response(CUDA_ERROR_NOT_SUPPORTED, std::ptr::null_mut()),
+            },
+            9 => match (read_handle(args), self.library_get_module) {
+                (Ok(library), Some(get_module)) => {
+                    let mut module = std::ptr::null_mut();
+                    let status = unsafe { get_module(&mut module, library as *mut c_void) };
+                    response(status, module)
+                }
+                (Err(status), _) => response(status, std::ptr::null_mut()),
+                (_, None) => response(CUDA_ERROR_NOT_SUPPORTED, std::ptr::null_mut()),
+            },
+            10 => match read_handle(args) {
+                Ok(build) => response(
+                    if self.cuda_library_builds.remove(&build).is_some() {
+                        0
+                    } else {
+                        CUDA_ERROR_INVALID_VALUE
+                    },
+                    std::ptr::null_mut(),
+                ),
+                Err(status) => response(status, std::ptr::null_mut()),
+            },
+            11 => match read_handle(args) {
+                Ok(module) if args.len() > 8 => match CString::new(&args[8..]) {
+                    Ok(name) => {
+                        let mut pointer = 0u64;
+                        let mut bytes = 0usize;
+                        let status = unsafe {
+                            (self.module_get_global)(
+                                &mut pointer,
+                                &mut bytes,
+                                module as *mut c_void,
+                                name.as_ptr(),
+                            )
+                        };
+                        Ok((
+                            status,
+                            if status == 0 {
+                                [pointer.to_le_bytes(), (bytes as u64).to_le_bytes()].concat()
+                            } else {
+                                Vec::new()
+                            },
+                        ))
+                    }
+                    Err(_) => response(CUDA_ERROR_INVALID_VALUE, std::ptr::null_mut()),
+                },
+                Ok(_) => response(CUDA_ERROR_INVALID_VALUE, std::ptr::null_mut()),
+                Err(status) => response(status, std::ptr::null_mut()),
+            },
+            12 => {
+                let parsed = args
+                    .get(..16)
+                    .and_then(|bytes| {
+                        Some((
+                            u64::from_le_bytes(bytes[..8].try_into().ok()?),
+                            u64::from_le_bytes(bytes[8..].try_into().ok()?),
+                        ))
+                    })
+                    .filter(|(_, len)| *len != 0);
+                match (parsed, self.mem_host_register) {
+                    (Some((gpa, len)), Some(register)) => {
+                        let Some(hva) = self.gpa_to_hva(gpa, len) else {
+                            return Some(response(CUDA_ERROR_NOT_SUPPORTED, std::ptr::null_mut()));
+                        };
+                        let mut unified = 0;
+                        let attribute_status =
+                            unsafe { (self.device_get_attribute)(&mut unified, 41, 0) };
+                        if attribute_status != 0 || unified == 0 {
+                            return Some(response(CUDA_ERROR_NOT_SUPPORTED, std::ptr::null_mut()));
+                        }
+                        if containing_registered_range(&self.registered, hva, len).is_some() {
+                            return Some(response(0, hva as *mut c_void));
+                        }
+                        let status = unsafe { register(hva as *mut c_void, len as usize, 2) };
+                        if status == 0 {
+                            self.registered.push((hva, len));
+                        }
+                        response(status, hva as *mut c_void)
+                    }
+                    _ => response(CUDA_ERROR_NOT_SUPPORTED, std::ptr::null_mut()),
+                }
+            }
+            13 => {
+                let parsed = args.get(..16).and_then(|bytes| {
+                    Some((
+                        u64::from_le_bytes(bytes[..8].try_into().ok()?),
+                        u64::from_le_bytes(bytes[8..].try_into().ok()?),
+                    ))
+                });
+                match parsed {
+                    Some((hva, len)) => {
+                        let owned =
+                            self.registered
+                                .iter()
+                                .position(|&(registered, registered_len)| {
+                                    registered == hva && registered_len == len
+                                });
+                        match (owned, self.mem_host_unregister) {
+                            (Some(index), Some(unregister)) => {
+                                let status = unsafe { unregister(hva as *mut c_void) };
+                                if status == 0 {
+                                    self.registered.swap_remove(index);
+                                    self.unmap_mapped_host_file(hva, len);
+                                }
+                                response(status, std::ptr::null_mut())
+                            }
+                            // A containing whole-RAM pin owns this allocation;
+                            // keep it until the backend's normal teardown.
+                            _ if containing_registered_range(&self.registered, hva, len)
+                                .is_some() =>
+                            {
+                                response(0, std::ptr::null_mut())
+                            }
+                            _ => response(CUDA_ERROR_INVALID_VALUE, std::ptr::null_mut()),
+                        }
+                    }
+                    None => response(CUDA_ERROR_INVALID_VALUE, std::ptr::null_mut()),
+                }
+            }
+            #[cfg(unix)]
+            14 => {
+                use std::os::unix::io::AsRawFd;
+                const TMPFS_MAGIC: libc::c_long = 0x0102_1994;
+                const MAX_HOST_ALLOCATION: u64 = 256 * 1024 * 1024;
+
+                let parsed = args.get(..8).and_then(|bytes| {
+                    let len = u64::from_le_bytes(bytes.try_into().ok()?);
+                    (len > 0 && len <= MAX_HOST_ALLOCATION && args.len() > 8)
+                        .then_some((len, &args[8..]))
+                });
+                match (parsed, self.mem_host_register) {
+                    (Some((len, name)), Some(register)) => {
+                        let Ok(len_usize) = usize::try_from(len) else {
+                            return Some(response(CUDA_ERROR_INVALID_VALUE, std::ptr::null_mut()));
+                        };
+                        let file = match super::open_ring_file(name, len_usize) {
+                            Ok(file) => file,
+                            Err(status) => {
+                                return Some(response(status, std::ptr::null_mut()));
+                            }
+                        };
+                        let mut stat: libc::statfs = unsafe { std::mem::zeroed() };
+                        if unsafe { libc::fstatfs(file.as_raw_fd(), &mut stat) } != 0
+                            || stat.f_type != TMPFS_MAGIC
+                        {
+                            return Some(response(CUDA_ERROR_NOT_SUPPORTED, std::ptr::null_mut()));
+                        }
+                        let mapping = unsafe {
+                            libc::mmap(
+                                std::ptr::null_mut(),
+                                len_usize,
+                                libc::PROT_READ | libc::PROT_WRITE,
+                                libc::MAP_SHARED,
+                                file.as_raw_fd(),
+                                0,
+                            )
+                        };
+                        if mapping == libc::MAP_FAILED {
+                            return Some(response(2, std::ptr::null_mut()));
+                        }
+                        let hva = mapping as u64;
+                        let mut unified = 0;
+                        let attribute_status =
+                            unsafe { (self.device_get_attribute)(&mut unified, 41, 0) };
+                        if attribute_status != 0 || unified == 0 {
+                            unsafe { libc::munmap(mapping, len_usize) };
+                            return Some(response(CUDA_ERROR_NOT_SUPPORTED, std::ptr::null_mut()));
+                        }
+                        let status = unsafe { register(mapping, len_usize, 2) };
+                        if status == 0 {
+                            self.registered.push((hva, len));
+                            self.mapped_host_files.push((hva, len));
+                        } else {
+                            unsafe { libc::munmap(mapping, len_usize) };
+                        }
+                        response(status, mapping)
+                    }
+                    _ => response(CUDA_ERROR_NOT_SUPPORTED, std::ptr::null_mut()),
+                }
+            }
+            _ => return None,
+        })
     }
 }
 
@@ -620,6 +1109,30 @@ impl Backend for GpuBackend {
         unsafe { chk((self.device_get_uuid)(uuid.as_mut_ptr(), device))? };
         Ok(uuid)
     }
+    fn device_get_pci_bus_id(&mut self, device: i32) -> CuResult<String> {
+        let mut value = [0i8; 32];
+        unsafe {
+            chk((self.device_get_pci_bus_id)(
+                value.as_mut_ptr(),
+                value.len() as c_int,
+                device,
+            ))?
+        };
+        Ok(unsafe { CStr::from_ptr(value.as_ptr()) }
+            .to_string_lossy()
+            .into_owned())
+    }
+    fn device_get_by_pci_bus_id(&mut self, pci_bus_id: &str) -> CuResult<i32> {
+        let pci_bus_id = CString::new(pci_bus_id).map_err(|_| CUDA_ERROR_INVALID_VALUE)?;
+        let mut device = 0;
+        unsafe {
+            chk((self.device_get_by_pci_bus_id)(
+                &mut device,
+                pci_bus_id.as_ptr(),
+            ))?
+        };
+        Ok(device)
+    }
     fn ctx_create(&mut self, device: i32) -> CuResult<u64> {
         let mut ctx: *mut c_void = std::ptr::null_mut();
         unsafe { chk((self.ctx_create)(&mut ctx, 0, device))? };
@@ -670,6 +1183,7 @@ impl Backend for GpuBackend {
                 cname.as_ptr(),
             ))?
         };
+        register_cuda_function(func as u64);
         Ok(func as u64)
     }
     fn module_get_global(&mut self, module: u64, name: &str) -> CuResult<(u64, u64)> {
@@ -693,6 +1207,7 @@ impl Backend for GpuBackend {
         // CUDA 12.4+. Walk parameter indices until INVALID_VALUE marks the end.
         const CUDA_ERROR_INVALID_VALUE: i32 = 1;
         const CUDA_ERROR_NOT_SUPPORTED: i32 = 801;
+        validate_cuda_function(function)?;
         let f = self.func_get_param_info.ok_or(CUDA_ERROR_NOT_SUPPORTED)?;
         let mut sizes = Vec::new();
         for i in 0.. {
@@ -707,6 +1222,7 @@ impl Backend for GpuBackend {
         Ok(sizes)
     }
     fn func_set_attribute(&mut self, function: u64, attrib: i32, value: i32) -> CuResult<()> {
+        validate_cuda_function(function)?;
         unsafe {
             chk((self.func_set_attribute)(
                 function as *mut c_void,
@@ -716,6 +1232,7 @@ impl Backend for GpuBackend {
         }
     }
     fn func_get_attribute(&mut self, function: u64, attrib: i32) -> CuResult<i32> {
+        validate_cuda_function(function)?;
         let mut v = 0;
         unsafe {
             chk((self.func_get_attribute)(
@@ -733,6 +1250,138 @@ impl Backend for GpuBackend {
     }
     fn mem_free(&mut self, dptr: u64) -> CuResult<()> {
         unsafe { chk((self.mem_free)(dptr)) }
+    }
+    fn mem_pool_create(
+        &mut self,
+        alloc_type: i32,
+        handle_types: u32,
+        location_type: i32,
+        location_id: i32,
+        max_size: u64,
+        usage: u16,
+    ) -> CuResult<u64> {
+        let props = CuMemPoolProps {
+            alloc_type,
+            handle_types,
+            location: CuMemLocation {
+                type_: location_type,
+                id: location_id,
+            },
+            win32_security_attributes: std::ptr::null_mut(),
+            max_size: usize::try_from(max_size).map_err(|_| CUDA_ERROR_INVALID_VALUE)?,
+            usage,
+            reserved: [0; 54],
+        };
+        let mut pool = std::ptr::null_mut();
+        unsafe { chk((self.mem_pool_create)(&mut pool, &props))? };
+        Ok(pool as u64)
+    }
+    fn mem_pool_destroy(&mut self, pool: u64) -> CuResult<()> {
+        unsafe { chk((self.mem_pool_destroy)(pool as *mut c_void)) }
+    }
+    fn mem_pool_set_attribute(&mut self, pool: u64, attr: i32, value: u64) -> CuResult<()> {
+        let mut value = value;
+        unsafe {
+            chk((self.mem_pool_set_attribute)(
+                pool as *mut c_void,
+                attr,
+                (&mut value as *mut u64).cast(),
+            ))
+        }
+    }
+    fn mem_pool_get_attribute(&mut self, pool: u64, attr: i32) -> CuResult<u64> {
+        let mut value = 0u64;
+        unsafe {
+            chk((self.mem_pool_get_attribute)(
+                pool as *mut c_void,
+                attr,
+                (&mut value as *mut u64).cast(),
+            ))?
+        };
+        Ok(value)
+    }
+    fn mem_pool_set_access(&mut self, pool: u64, descriptors: &[(i32, i32, u64)]) -> CuResult<()> {
+        let descriptors = descriptors
+            .iter()
+            .map(|&(type_, id, flags)| {
+                Ok(CuMemAccessDesc {
+                    location: CuMemLocation { type_, id },
+                    flags: i32::try_from(flags).map_err(|_| CUDA_ERROR_INVALID_VALUE)?,
+                })
+            })
+            .collect::<CuResult<Vec<_>>>()?;
+        unsafe {
+            chk((self.mem_pool_set_access)(
+                pool as *mut c_void,
+                descriptors.as_ptr(),
+                descriptors.len(),
+            ))
+        }
+    }
+    fn mem_pool_get_access(
+        &mut self,
+        pool: u64,
+        location_type: i32,
+        location_id: i32,
+    ) -> CuResult<u64> {
+        let location = CuMemLocation {
+            type_: location_type,
+            id: location_id,
+        };
+        let mut flags = 0i32;
+        unsafe {
+            chk((self.mem_pool_get_access)(
+                &mut flags,
+                pool as *mut c_void,
+                &location,
+            ))?
+        };
+        Ok(flags as u32 as u64)
+    }
+    fn mem_pool_trim_to(&mut self, pool: u64, min_bytes: u64) -> CuResult<()> {
+        let min_bytes = usize::try_from(min_bytes).map_err(|_| CUDA_ERROR_INVALID_VALUE)?;
+        unsafe { chk((self.mem_pool_trim_to)(pool as *mut c_void, min_bytes)) }
+    }
+    fn mem_alloc_from_pool_async(&mut self, bytes: u64, pool: u64, stream: u64) -> CuResult<u64> {
+        let mut dptr = 0;
+        let bytes = usize::try_from(bytes).map_err(|_| CUDA_ERROR_INVALID_VALUE)?;
+        unsafe {
+            chk((self.mem_alloc_from_pool_async)(
+                &mut dptr,
+                bytes,
+                pool as *mut c_void,
+                stream as *mut c_void,
+            ))?
+        };
+        Ok(dptr)
+    }
+    fn mem_alloc_async(&mut self, bytes: u64, stream: u64) -> CuResult<u64> {
+        let mut dptr = 0;
+        let bytes = usize::try_from(bytes).map_err(|_| CUDA_ERROR_INVALID_VALUE)?;
+        unsafe {
+            chk((self.mem_alloc_async)(
+                &mut dptr,
+                bytes,
+                stream as *mut c_void,
+            ))?
+        };
+        Ok(dptr)
+    }
+    fn mem_free_async(&mut self, dptr: u64, stream: u64) -> CuResult<()> {
+        unsafe { chk((self.mem_free_async)(dptr, stream as *mut c_void)) }
+    }
+    fn device_get_default_mem_pool(&mut self, device: i32) -> CuResult<u64> {
+        let mut pool = std::ptr::null_mut();
+        unsafe { chk((self.device_get_default_mem_pool)(&mut pool, device))? };
+        Ok(pool as u64)
+    }
+    fn device_get_mem_pool(&mut self, device: i32) -> CuResult<u64> {
+        let mut pool = std::ptr::null_mut();
+        unsafe { chk((self.device_get_mem_pool)(&mut pool, device))? };
+        Ok(pool as u64)
+    }
+    fn device_set_mem_pool(&mut self, device: i32, pool: u64) -> CuResult<()> {
+        unsafe { chk((self.device_set_mem_pool)(device, pool as *mut c_void)) }
     }
     fn memcpy_htod(&mut self, dptr: u64, data: &[u8], stream: u64) -> CuResult<()> {
         self.wait_stream(stream)?;
@@ -1104,6 +1753,7 @@ impl Backend for GpuBackend {
         stream: u64,
         params: &[Vec<u8>],
     ) -> CuResult<()> {
+        validate_cuda_function(function)?;
         // The Driver API wants `void* kernelParams[]`, each pointing at one
         // argument's value. Point at each param blob in place (CUDA only reads).
         let mut ptrs: Vec<*mut c_void> = params.iter().map(|p| p.as_ptr() as *mut c_void).collect();
@@ -1808,6 +2458,11 @@ impl Backend for GpuBackend {
         args: &[u8],
         streams: &std::collections::HashMap<u64, u64>,
     ) -> CuResult<(i32, Vec<u8>)> {
+        if lib == 6 {
+            if let Some(result) = self.cuda_driver_library_call(func, args) {
+                return result;
+            }
+        }
         self.gen_lib_call(lib, func, args, streams)
     }
     fn lib_handle_alias(&mut self, golden: u64, real: u64) {
@@ -2798,6 +3453,15 @@ impl CudnnBn {
 
 impl Drop for GpuBackend {
     fn drop(&mut self) {
+        if let Some(unload) = self.library_unload {
+            for library in self.live_cuda_libraries.drain() {
+                // SAFETY: these handles were returned by cuLibraryLoadData in
+                // this backend and have not been unloaded successfully yet.
+                unsafe {
+                    unload(library as *mut c_void);
+                }
+            }
+        }
         // Release any guest-RAM pins this backend took so the next connection can
         // re-register them. Safe to call at drop: the context is still alive.
         if let Some(unreg) = self.mem_host_unregister {
@@ -2807,6 +3471,14 @@ impl Drop for GpuBackend {
                     unreg(hva as *mut c_void);
                 }
             }
+        }
+        for (address, len) in self.mapped_host_files.drain(..) {
+            #[cfg(unix)]
+            if let (Ok(address), Ok(len)) = (usize::try_from(address), usize::try_from(len)) {
+                unsafe { libc::munmap(address as *mut c_void, len) };
+            }
+            #[cfg(not(unix))]
+            let _ = (address, len);
         }
         let (addr, _) = self.staging;
         if addr != 0 {
@@ -2932,6 +3604,23 @@ fn vmm_prop(device: i32) -> VmmProp {
 }
 
 impl GpuBackend {
+    #[cfg(unix)]
+    fn unmap_mapped_host_file(&mut self, address: u64, len: u64) {
+        if let Some(index) = self
+            .mapped_host_files
+            .iter()
+            .position(|&(candidate, candidate_len)| candidate == address && candidate_len == len)
+        {
+            self.mapped_host_files.swap_remove(index);
+            if let (Ok(address), Ok(len)) = (usize::try_from(address), usize::try_from(len)) {
+                unsafe { libc::munmap(address as *mut c_void, len) };
+            }
+        }
+    }
+
+    #[cfg(not(unix))]
+    fn unmap_mapped_host_file(&mut self, _address: u64, _len: u64) {}
+
     /// CLONE transport: move `total` bytes between the GPU (`dptr`) and the
     /// clone's LIVE guest RAM via /proc/<pid>/mem + pinned staging. `to_guest`:
     /// D2H (GPU -> pwrite guest); else H2D (pread guest -> GPU).
@@ -3032,7 +3721,7 @@ impl GpuBackend {
         };
         for &(_, hva, len) in &self.guest_ram {
             // SAFETY: [hva, hva+len) is a live host mapping of guest RAM.
-            let rc = unsafe { reg(hva as *mut c_void, len as usize, 0) };
+            let rc = unsafe { reg(hva as *mut c_void, len as usize, 2) };
             match rc {
                 0 => {
                     self.registered.push((hva, len));
@@ -3313,6 +4002,30 @@ fn zc_trace_segments(dir: &str, segments: &[(u64, u64)]) {
             "[zc-host] {dir} gpa memcpy: {total} bytes in {} segment(s)",
             segments.len()
         ));
+    }
+}
+
+#[cfg(test)]
+mod registered_range_tests {
+    use super::containing_registered_range;
+
+    #[test]
+    fn finds_the_registration_containing_a_subrange() {
+        let ranges = [(0x1000, 0x1000), (0x4000, 0x2000)];
+        assert_eq!(
+            containing_registered_range(&ranges, 0x4800, 0x400),
+            Some((1, 0x4000, 0x2000))
+        );
+        assert_eq!(containing_registered_range(&ranges, 0x3000, 1), None);
+        assert_eq!(containing_registered_range(&ranges, 0x5f00, 0x200), None);
+    }
+
+    #[test]
+    fn rejects_overflowing_ranges() {
+        assert_eq!(
+            containing_registered_range(&[(0, u64::MAX)], u64::MAX, 2),
+            None
+        );
     }
 }
 

--- a/crates/smolvm-cuda/src/host/gpu.rs
+++ b/crates/smolvm-cuda/src/host/gpu.rs
@@ -949,7 +949,7 @@ impl GpuBackend {
                     None => response(CUDA_ERROR_INVALID_VALUE, std::ptr::null_mut()),
                 }
             }
-            #[cfg(unix)]
+            #[cfg(target_os = "linux")]
             14 => {
                 use std::os::unix::io::AsRawFd;
                 const TMPFS_MAGIC: libc::c_long = 0x0102_1994;
@@ -1110,7 +1110,7 @@ impl Backend for GpuBackend {
         Ok(uuid)
     }
     fn device_get_pci_bus_id(&mut self, device: i32) -> CuResult<String> {
-        let mut value = [0i8; 32];
+        let mut value: [c_char; 32] = [0; 32];
         unsafe {
             chk((self.device_get_pci_bus_id)(
                 value.as_mut_ptr(),

--- a/crates/smolvm-cuda/src/proto.rs
+++ b/crates/smolvm-cuda/src/proto.rs
@@ -49,6 +49,8 @@ pub enum Op {
     DriverGetVersion = 0x05,
     DeviceGetAttribute = 0x06,
     DeviceGetUuid = 0x07,
+    DeviceGetPciBusId = 0x08,
+    DeviceGetByPciBusId = 0x09,
     CtxCreate = 0x10,
     CtxDestroy = 0x11,
     PrimaryCtxRetain = 0x12,
@@ -67,7 +69,20 @@ pub enum Op {
     MemcpyDtoD = 0x34,
     MemsetD8 = 0x35,
     MemGetInfo = 0x36,
+    MemPoolCreate = 0x37,
+    MemPoolDestroy = 0x38,
+    MemPoolSetAttribute = 0x39,
+    MemPoolGetAttribute = 0x3A,
+    MemPoolSetAccess = 0x3B,
+    MemPoolGetAccess = 0x3C,
+    MemPoolTrimTo = 0x3D,
+    MemAllocFromPoolAsync = 0x3E,
+    MemAllocAsync = 0x3F,
     LaunchKernel = 0x40,
+    MemFreeAsync = 0x41,
+    DeviceGetDefaultMemPool = 0x42,
+    DeviceGetMemPool = 0x43,
+    DeviceSetMemPool = 0x44,
     CtxSynchronize = 0x50,
     StreamCreate = 0x60,
     StreamDestroy = 0x61,
@@ -160,6 +175,8 @@ impl Op {
             0x05 => Op::DriverGetVersion,
             0x06 => Op::DeviceGetAttribute,
             0x07 => Op::DeviceGetUuid,
+            0x08 => Op::DeviceGetPciBusId,
+            0x09 => Op::DeviceGetByPciBusId,
             0x10 => Op::CtxCreate,
             0x11 => Op::CtxDestroy,
             0x12 => Op::PrimaryCtxRetain,
@@ -178,7 +195,20 @@ impl Op {
             0x34 => Op::MemcpyDtoD,
             0x35 => Op::MemsetD8,
             0x36 => Op::MemGetInfo,
+            0x37 => Op::MemPoolCreate,
+            0x38 => Op::MemPoolDestroy,
+            0x39 => Op::MemPoolSetAttribute,
+            0x3A => Op::MemPoolGetAttribute,
+            0x3B => Op::MemPoolSetAccess,
+            0x3C => Op::MemPoolGetAccess,
+            0x3D => Op::MemPoolTrimTo,
+            0x3E => Op::MemAllocFromPoolAsync,
+            0x3F => Op::MemAllocAsync,
             0x40 => Op::LaunchKernel,
+            0x41 => Op::MemFreeAsync,
+            0x42 => Op::DeviceGetDefaultMemPool,
+            0x43 => Op::DeviceGetMemPool,
+            0x44 => Op::DeviceSetMemPool,
             0x50 => Op::CtxSynchronize,
             0xC0 => Op::StreamBeginCapture,
             0xC1 => Op::StreamEndCapture,
@@ -258,6 +288,12 @@ pub enum Request {
     },
     DeviceGetUuid {
         device: i32,
+    },
+    DeviceGetPciBusId {
+        device: i32,
+    },
+    DeviceGetByPciBusId {
+        pci_bus_id: String,
     },
     CtxCreate {
         device: i32,
@@ -339,6 +375,66 @@ pub enum Request {
         bytes: u64,
     },
     MemGetInfo,
+    /// Create a stream-ordered allocation pool. Pointer-bearing/reserved fields
+    /// from `CUmemPoolProps` are deliberately not transported.
+    MemPoolCreate {
+        alloc_type: i32,
+        handle_types: u32,
+        location_type: i32,
+        location_id: i32,
+        max_size: u64,
+        usage: u16,
+    },
+    MemPoolDestroy {
+        pool: u64,
+    },
+    /// Attribute values are normalized to 8 bytes; int-valued attributes use
+    /// the low four bytes and uint64-valued attributes use all eight.
+    MemPoolSetAttribute {
+        pool: u64,
+        attr: i32,
+        value: u64,
+    },
+    MemPoolGetAttribute {
+        pool: u64,
+        attr: i32,
+    },
+    MemPoolSetAccess {
+        pool: u64,
+        descriptors: Vec<(i32, i32, u64)>,
+    },
+    MemPoolGetAccess {
+        pool: u64,
+        location_type: i32,
+        location_id: i32,
+    },
+    MemPoolTrimTo {
+        pool: u64,
+        min_bytes: u64,
+    },
+    MemAllocFromPoolAsync {
+        bytes: u64,
+        pool: u64,
+        stream: u64,
+    },
+    MemAllocAsync {
+        bytes: u64,
+        stream: u64,
+    },
+    MemFreeAsync {
+        dptr: u64,
+        stream: u64,
+    },
+    DeviceGetDefaultMemPool {
+        device: i32,
+    },
+    DeviceGetMemPool {
+        device: i32,
+    },
+    DeviceSetMemPool {
+        device: i32,
+        pool: u64,
+    },
     /// Launch `function` with the given geometry. `params` is one byte-blob per
     /// kernel argument, in order — the host rebuilds the `void*[]` the Driver
     /// API expects by pointing at local copies of each blob. `stream` is an
@@ -642,6 +738,9 @@ fn w_i32(b: &mut Vec<u8>, v: i32) {
 fn w_u32(b: &mut Vec<u8>, v: u32) {
     b.extend_from_slice(&v.to_le_bytes());
 }
+fn w_u16(b: &mut Vec<u8>, v: u16) {
+    b.extend_from_slice(&v.to_le_bytes());
+}
 fn w_u64(b: &mut Vec<u8>, v: u64) {
     b.extend_from_slice(&v.to_le_bytes());
 }
@@ -678,6 +777,9 @@ impl<'a> Cur<'a> {
     }
     fn i32(&mut self) -> io::Result<i32> {
         Ok(i32::from_le_bytes(self.take(4)?.try_into().unwrap()))
+    }
+    fn u16(&mut self) -> io::Result<u16> {
+        Ok(u16::from_le_bytes(self.take(2)?.try_into().unwrap()))
     }
     pub(crate) fn u32(&mut self) -> io::Result<u32> {
         Ok(u32::from_le_bytes(self.take(4)?.try_into().unwrap()))
@@ -794,6 +896,14 @@ pub fn encode_request(req: &Request) -> Vec<u8> {
             w_u8(&mut b, Op::DeviceGetUuid as u8);
             w_i32(&mut b, *device);
         }
+        Request::DeviceGetPciBusId { device } => {
+            w_u8(&mut b, Op::DeviceGetPciBusId as u8);
+            w_i32(&mut b, *device);
+        }
+        Request::DeviceGetByPciBusId { pci_bus_id } => {
+            w_u8(&mut b, Op::DeviceGetByPciBusId as u8);
+            w_str(&mut b, pci_bus_id);
+        }
         Request::CtxCreate { device } => {
             w_u8(&mut b, Op::CtxCreate as u8);
             w_i32(&mut b, *device);
@@ -854,6 +964,95 @@ pub fn encode_request(req: &Request) -> Vec<u8> {
         Request::MemFree { dptr } => {
             w_u8(&mut b, Op::MemFree as u8);
             w_u64(&mut b, *dptr);
+        }
+        Request::MemPoolCreate {
+            alloc_type,
+            handle_types,
+            location_type,
+            location_id,
+            max_size,
+            usage,
+        } => {
+            w_u8(&mut b, Op::MemPoolCreate as u8);
+            w_i32(&mut b, *alloc_type);
+            w_u32(&mut b, *handle_types);
+            w_i32(&mut b, *location_type);
+            w_i32(&mut b, *location_id);
+            w_u64(&mut b, *max_size);
+            w_u16(&mut b, *usage);
+        }
+        Request::MemPoolDestroy { pool } => {
+            w_u8(&mut b, Op::MemPoolDestroy as u8);
+            w_u64(&mut b, *pool);
+        }
+        Request::MemPoolSetAttribute { pool, attr, value } => {
+            w_u8(&mut b, Op::MemPoolSetAttribute as u8);
+            w_u64(&mut b, *pool);
+            w_i32(&mut b, *attr);
+            w_u64(&mut b, *value);
+        }
+        Request::MemPoolGetAttribute { pool, attr } => {
+            w_u8(&mut b, Op::MemPoolGetAttribute as u8);
+            w_u64(&mut b, *pool);
+            w_i32(&mut b, *attr);
+        }
+        Request::MemPoolSetAccess { pool, descriptors } => {
+            w_u8(&mut b, Op::MemPoolSetAccess as u8);
+            w_u64(&mut b, *pool);
+            w_u32(&mut b, descriptors.len() as u32);
+            for &(location_type, location_id, flags) in descriptors {
+                w_i32(&mut b, location_type);
+                w_i32(&mut b, location_id);
+                w_u64(&mut b, flags);
+            }
+        }
+        Request::MemPoolGetAccess {
+            pool,
+            location_type,
+            location_id,
+        } => {
+            w_u8(&mut b, Op::MemPoolGetAccess as u8);
+            w_u64(&mut b, *pool);
+            w_i32(&mut b, *location_type);
+            w_i32(&mut b, *location_id);
+        }
+        Request::MemPoolTrimTo { pool, min_bytes } => {
+            w_u8(&mut b, Op::MemPoolTrimTo as u8);
+            w_u64(&mut b, *pool);
+            w_u64(&mut b, *min_bytes);
+        }
+        Request::MemAllocFromPoolAsync {
+            bytes,
+            pool,
+            stream,
+        } => {
+            w_u8(&mut b, Op::MemAllocFromPoolAsync as u8);
+            w_u64(&mut b, *bytes);
+            w_u64(&mut b, *pool);
+            w_u64(&mut b, *stream);
+        }
+        Request::MemAllocAsync { bytes, stream } => {
+            w_u8(&mut b, Op::MemAllocAsync as u8);
+            w_u64(&mut b, *bytes);
+            w_u64(&mut b, *stream);
+        }
+        Request::MemFreeAsync { dptr, stream } => {
+            w_u8(&mut b, Op::MemFreeAsync as u8);
+            w_u64(&mut b, *dptr);
+            w_u64(&mut b, *stream);
+        }
+        Request::DeviceGetDefaultMemPool { device } => {
+            w_u8(&mut b, Op::DeviceGetDefaultMemPool as u8);
+            w_i32(&mut b, *device);
+        }
+        Request::DeviceGetMemPool { device } => {
+            w_u8(&mut b, Op::DeviceGetMemPool as u8);
+            w_i32(&mut b, *device);
+        }
+        Request::DeviceSetMemPool { device, pool } => {
+            w_u8(&mut b, Op::DeviceSetMemPool as u8);
+            w_i32(&mut b, *device);
+            w_u64(&mut b, *pool);
         }
         Request::MemcpyHtoD { dptr, stream, data } => {
             w_u8(&mut b, Op::MemcpyHtoD as u8);
@@ -1289,6 +1488,10 @@ pub fn decode_request(payload: &[u8]) -> io::Result<Request> {
             device: c.i32()?,
         },
         Op::DeviceGetUuid => Request::DeviceGetUuid { device: c.i32()? },
+        Op::DeviceGetPciBusId => Request::DeviceGetPciBusId { device: c.i32()? },
+        Op::DeviceGetByPciBusId => Request::DeviceGetByPciBusId {
+            pci_bus_id: c.string()?,
+        },
         Op::CtxCreate => Request::CtxCreate { device: c.i32()? },
         Op::CtxDestroy => Request::CtxDestroy { ctx: c.u64()? },
         Op::PrimaryCtxRetain => Request::PrimaryCtxRetain { device: c.i32()? },
@@ -1315,6 +1518,64 @@ pub fn decode_request(payload: &[u8]) -> io::Result<Request> {
         },
         Op::MemAlloc => Request::MemAlloc { bytes: c.u64()? },
         Op::MemFree => Request::MemFree { dptr: c.u64()? },
+        Op::MemPoolCreate => Request::MemPoolCreate {
+            alloc_type: c.i32()?,
+            handle_types: c.u32()?,
+            location_type: c.i32()?,
+            location_id: c.i32()?,
+            max_size: c.u64()?,
+            usage: c.u16()?,
+        },
+        Op::MemPoolDestroy => Request::MemPoolDestroy { pool: c.u64()? },
+        Op::MemPoolSetAttribute => Request::MemPoolSetAttribute {
+            pool: c.u64()?,
+            attr: c.i32()?,
+            value: c.u64()?,
+        },
+        Op::MemPoolGetAttribute => Request::MemPoolGetAttribute {
+            pool: c.u64()?,
+            attr: c.i32()?,
+        },
+        Op::MemPoolSetAccess => {
+            let pool = c.u64()?;
+            let count = c.u32()? as usize;
+            if count > 1024 {
+                return Err(bad());
+            }
+            let mut descriptors = Vec::with_capacity(count);
+            for _ in 0..count {
+                descriptors.push((c.i32()?, c.i32()?, c.u64()?));
+            }
+            Request::MemPoolSetAccess { pool, descriptors }
+        }
+        Op::MemPoolGetAccess => Request::MemPoolGetAccess {
+            pool: c.u64()?,
+            location_type: c.i32()?,
+            location_id: c.i32()?,
+        },
+        Op::MemPoolTrimTo => Request::MemPoolTrimTo {
+            pool: c.u64()?,
+            min_bytes: c.u64()?,
+        },
+        Op::MemAllocFromPoolAsync => Request::MemAllocFromPoolAsync {
+            bytes: c.u64()?,
+            pool: c.u64()?,
+            stream: c.u64()?,
+        },
+        Op::MemAllocAsync => Request::MemAllocAsync {
+            bytes: c.u64()?,
+            stream: c.u64()?,
+        },
+        Op::MemFreeAsync => Request::MemFreeAsync {
+            dptr: c.u64()?,
+            stream: c.u64()?,
+        },
+        Op::DeviceGetDefaultMemPool => Request::DeviceGetDefaultMemPool { device: c.i32()? },
+        Op::DeviceGetMemPool => Request::DeviceGetMemPool { device: c.i32()? },
+        Op::DeviceSetMemPool => Request::DeviceSetMemPool {
+            device: c.i32()?,
+            pool: c.u64()?,
+        },
         Op::MemcpyHtoD => Request::MemcpyHtoD {
             dptr: c.u64()?,
             stream: c.u64()?,
@@ -1606,23 +1867,29 @@ pub fn decode_response(op: Op, payload: &[u8]) -> io::Result<(i32, Response)> {
     }
     let body = match op {
         Op::DeviceGetCount
+        | Op::DeviceGetByPciBusId
         | Op::DriverGetVersion
         | Op::DeviceGetAttribute
         | Op::ThreadExchangeCaptureMode
         | Op::StreamQuery
         | Op::EventQuery
         | Op::FuncGetAttribute => Response::Count(c.i32()?),
-        Op::DeviceGetName => Response::Name(c.string()?),
+        Op::DeviceGetName | Op::DeviceGetPciBusId => Response::Name(c.string()?),
         Op::DeviceTotalMem => Response::Bytes(c.u64()?),
         // Init hands back this session's lineage token (for fork-clone handoff).
         Op::Init => Response::Handle(c.u64()?),
-        Op::CtxCreate | Op::PrimaryCtxRetain => Response::Handle(c.u64()?),
+        Op::CtxCreate
+        | Op::PrimaryCtxRetain
+        | Op::MemPoolCreate
+        | Op::DeviceGetDefaultMemPool
+        | Op::DeviceGetMemPool => Response::Handle(c.u64()?),
         Op::ModuleLoadData | Op::ModuleGetFunction => Response::Handle(c.u64()?),
         Op::StreamCreate | Op::EventCreate => Response::Handle(c.u64()?),
         Op::StreamEndCapture | Op::GraphInstantiate => Response::Handle(c.u64()?),
         Op::GraphGetNodes => Response::Bytes(c.u64()?),
         Op::StreamCaptureInfo => Response::Pair(c.u64()?, c.u64()?),
-        Op::MemAlloc => Response::Dptr(c.u64()?),
+        Op::MemAlloc | Op::MemAllocFromPoolAsync | Op::MemAllocAsync => Response::Dptr(c.u64()?),
+        Op::MemPoolGetAttribute | Op::MemPoolGetAccess => Response::Bytes(c.u64()?),
         Op::MemcpyDtoH
         | Op::DeviceGetUuid
         | Op::FuncGetParamInfo
@@ -1647,6 +1914,12 @@ pub fn decode_response(op: Op, payload: &[u8]) -> io::Result<(i32, Response)> {
         | Op::ModuleUnload
         | Op::FuncSetAttribute
         | Op::MemFree
+        | Op::MemPoolDestroy
+        | Op::MemPoolSetAttribute
+        | Op::MemPoolSetAccess
+        | Op::MemPoolTrimTo
+        | Op::MemFreeAsync
+        | Op::DeviceSetMemPool
         | Op::MemcpyHtoD
         | Op::MemcpyDtoD
         | Op::MemsetD8
@@ -1724,6 +1997,33 @@ mod tests {
         });
         roundtrip(Request::MemAlloc { bytes: 4096 });
         roundtrip(Request::MemFree { dptr: 0x7f00_0000 });
+        roundtrip(Request::MemPoolCreate {
+            alloc_type: 1,
+            handle_types: 0,
+            location_type: 1,
+            location_id: 0,
+            max_size: 1 << 30,
+            usage: 3,
+        });
+        roundtrip(Request::MemPoolSetAttribute {
+            pool: 17,
+            attr: 4,
+            value: 1 << 20,
+        });
+        roundtrip(Request::MemPoolSetAccess {
+            pool: 17,
+            descriptors: vec![(1, 0, 3), (1, 1, 1)],
+        });
+        roundtrip(Request::MemAllocFromPoolAsync {
+            bytes: 8192,
+            pool: 17,
+            stream: 23,
+        });
+        roundtrip(Request::MemFreeAsync {
+            dptr: 0x7f00_1000,
+            stream: 23,
+        });
+        roundtrip(Request::DeviceGetDefaultMemPool { device: 0 });
         roundtrip(Request::MemcpyHtoD {
             dptr: 0x7f00_0000,
             stream: 0x7001,
@@ -1800,6 +2100,10 @@ mod tests {
             device: 0,
         });
         roundtrip(Request::DeviceGetUuid { device: 0 });
+        roundtrip(Request::DeviceGetPciBusId { device: 0 });
+        roundtrip(Request::DeviceGetByPciBusId {
+            pci_bus_id: "0000:65:00.0".to_string(),
+        });
         roundtrip(Request::PrimaryCtxRetain { device: 0 });
         roundtrip(Request::PrimaryCtxRelease { device: 0 });
         roundtrip(Request::ModuleUnload { module: 7 });

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -666,11 +666,15 @@ fn ring_try_setup_file(client: &mut Client<Stream>) {
     match client.ring_setup_file(
         PAGE,
         &fname,
+        (base.cast(), total),
         pages(0, REQ_N),
         pages(REQ_N, RESP_N),
         pages(REQ_N + RESP_N, BOUNCE_N),
     ) {
         Ok(()) => {
+            // Both sides have mapped the inode now; keeping a directory entry
+            // would accumulate one visible tmpfs file per process/reconnect.
+            let _ = std::fs::remove_file(&path);
             if trace {
                 eprintln!("[ring-file] file-backed rings active ({fname})");
             }

--- a/lib/libkrun.dylib
+++ b/lib/libkrun.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:134b507e1c9b71b940ca3e788b4ce22c56fef8259597439b53f8fd769de7b945
+oid sha256:011751b39c0bf02d4dd2a6b0be4d6ab71c885fb3bb3af626c6edd1ad83115f76
 size 5970400

--- a/lib/libkrun.dylib
+++ b/lib/libkrun.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8dfe651404dd408061d29da59f1dc63eec0d459802acc93415ac526138cc8034
-size 6158144
+oid sha256:134b507e1c9b71b940ca3e788b4ce22c56fef8259597439b53f8fd769de7b945
+size 5970400

--- a/lib/libkrun.provenance
+++ b/lib/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=93b5b320120cbb1552cdeffc501890e254ed6833
+libkrun=c283ed7556d0af534903f4b7972f190239858f15
 libkrunfw=85728e46fd394bfad050efe84e00467fa45e58a7

--- a/lib/libkrun.provenance
+++ b/lib/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=3ca804246b584d8024f95fd3e8ca48daa3e38800
+libkrun=93b5b320120cbb1552cdeffc501890e254ed6833
 libkrunfw=85728e46fd394bfad050efe84e00467fa45e58a7

--- a/lib/linux-aarch64/libkrun.provenance
+++ b/lib/linux-aarch64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=93b5b320120cbb1552cdeffc501890e254ed6833
+libkrun=c283ed7556d0af534903f4b7972f190239858f15
 libkrunfw=85728e46fd394bfad050efe84e00467fa45e58a7

--- a/lib/linux-aarch64/libkrun.provenance
+++ b/lib/linux-aarch64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=3ca804246b584d8024f95fd3e8ca48daa3e38800
+libkrun=93b5b320120cbb1552cdeffc501890e254ed6833
 libkrunfw=85728e46fd394bfad050efe84e00467fa45e58a7

--- a/lib/linux-aarch64/libkrun.so
+++ b/lib/linux-aarch64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:80f6bed84686ee5679698f45ed3e9fb27a1f4c346c735290ceb04babdea250a3
+oid sha256:82b27a425f75a9e073c375bd4a773c5006a3f2d9d3285a696f9df6fa6599f489
 size 6972936

--- a/lib/linux-aarch64/libkrun.so
+++ b/lib/linux-aarch64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:97485d9a4282c1285af2d6f0500a5eda63019dc49e169b12af8b05c6e5f8d22c
-size 6960552
+oid sha256:80f6bed84686ee5679698f45ed3e9fb27a1f4c346c735290ceb04babdea250a3
+size 6972936

--- a/lib/linux-aarch64/libkrun.so
+++ b/lib/linux-aarch64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:82b27a425f75a9e073c375bd4a773c5006a3f2d9d3285a696f9df6fa6599f489
+oid sha256:89dcb85997add84ac1310b3cfbb9dcd748faf7b7b817a180d3b808f87173ab30
 size 6972936

--- a/lib/linux-aarch64/libkrun.so.2.0.0
+++ b/lib/linux-aarch64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:80f6bed84686ee5679698f45ed3e9fb27a1f4c346c735290ceb04babdea250a3
+oid sha256:82b27a425f75a9e073c375bd4a773c5006a3f2d9d3285a696f9df6fa6599f489
 size 6972936

--- a/lib/linux-aarch64/libkrun.so.2.0.0
+++ b/lib/linux-aarch64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:97485d9a4282c1285af2d6f0500a5eda63019dc49e169b12af8b05c6e5f8d22c
-size 6960552
+oid sha256:80f6bed84686ee5679698f45ed3e9fb27a1f4c346c735290ceb04babdea250a3
+size 6972936

--- a/lib/linux-aarch64/libkrun.so.2.0.0
+++ b/lib/linux-aarch64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:82b27a425f75a9e073c375bd4a773c5006a3f2d9d3285a696f9df6fa6599f489
+oid sha256:89dcb85997add84ac1310b3cfbb9dcd748faf7b7b817a180d3b808f87173ab30
 size 6972936

--- a/lib/linux-x86_64/libkrun.provenance
+++ b/lib/linux-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=93b5b320120cbb1552cdeffc501890e254ed6833
+libkrun=c283ed7556d0af534903f4b7972f190239858f15
 libkrunfw=85728e46fd394bfad050efe84e00467fa45e58a7

--- a/lib/linux-x86_64/libkrun.provenance
+++ b/lib/linux-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=3ca804246b584d8024f95fd3e8ca48daa3e38800
+libkrun=93b5b320120cbb1552cdeffc501890e254ed6833
 libkrunfw=85728e46fd394bfad050efe84e00467fa45e58a7

--- a/lib/linux-x86_64/libkrun.so
+++ b/lib/linux-x86_64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:216ea9877b5e5e6c091419d05b35f7e7fa73f8aedd52ab505977f28ac712a3ae
+oid sha256:0f78d6a62ef0deff76a93ae0a7872f93f876a8f2706708ce602b35705898997d
 size 8138576

--- a/lib/linux-x86_64/libkrun.so
+++ b/lib/linux-x86_64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bfae377ae84bb2f2aba917c478b16077e356e1ec21ab1cf25749094c2a4e5a96
-size 8129104
+oid sha256:7277100eccb0023b16c1ba6e174ba24cb29aa5ab7d28234803826bc7073c4050
+size 8137744

--- a/lib/linux-x86_64/libkrun.so
+++ b/lib/linux-x86_64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7277100eccb0023b16c1ba6e174ba24cb29aa5ab7d28234803826bc7073c4050
-size 8137744
+oid sha256:216ea9877b5e5e6c091419d05b35f7e7fa73f8aedd52ab505977f28ac712a3ae
+size 8138576

--- a/lib/linux-x86_64/libkrun.so.2.0.0
+++ b/lib/linux-x86_64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:216ea9877b5e5e6c091419d05b35f7e7fa73f8aedd52ab505977f28ac712a3ae
+oid sha256:0f78d6a62ef0deff76a93ae0a7872f93f876a8f2706708ce602b35705898997d
 size 8138576

--- a/lib/linux-x86_64/libkrun.so.2.0.0
+++ b/lib/linux-x86_64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bfae377ae84bb2f2aba917c478b16077e356e1ec21ab1cf25749094c2a4e5a96
-size 8129104
+oid sha256:7277100eccb0023b16c1ba6e174ba24cb29aa5ab7d28234803826bc7073c4050
+size 8137744

--- a/lib/linux-x86_64/libkrun.so.2.0.0
+++ b/lib/linux-x86_64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7277100eccb0023b16c1ba6e174ba24cb29aa5ab7d28234803826bc7073c4050
-size 8137744
+oid sha256:216ea9877b5e5e6c091419d05b35f7e7fa73f8aedd52ab505977f28ac712a3ae
+size 8138576

--- a/lib/windows-x86_64/krun.dll
+++ b/lib/windows-x86_64/krun.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1102a1b9e18a8b1b22e4928c4da28356e904da65dfb447a74673254184385b10
-size 10373971
+oid sha256:b44291fdafe35d6e397ded5a87c0729bf6b0f8f0b7c8b400a4cfe9f015d1d24e
+size 10803222

--- a/lib/windows-x86_64/krun.dll
+++ b/lib/windows-x86_64/krun.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b44291fdafe35d6e397ded5a87c0729bf6b0f8f0b7c8b400a4cfe9f015d1d24e
-size 10803222
+oid sha256:8bac1ca9c5fc8b40453032c18e60415df150963226f707e8c23640c22ec359e3
+size 10804276

--- a/lib/windows-x86_64/libkrun.provenance
+++ b/lib/windows-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=93b5b320120cbb1552cdeffc501890e254ed6833
+libkrun=c283ed7556d0af534903f4b7972f190239858f15
 libkrunfw=85728e46fd394bfad050efe84e00467fa45e58a7

--- a/lib/windows-x86_64/libkrun.provenance
+++ b/lib/windows-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=3ca804246b584d8024f95fd3e8ca48daa3e38800
+libkrun=93b5b320120cbb1552cdeffc501890e254ed6833
 libkrunfw=85728e46fd394bfad050efe84e00467fa45e58a7

--- a/scripts/build-libkrun-linux.sh
+++ b/scripts/build-libkrun-linux.sh
@@ -50,7 +50,7 @@ if [[ "${SKIP_DEPS:-0}" != "1" ]] && command -v apt-get >/dev/null 2>&1; then
     # kernel build (libkrunfw)        + libkrun (rust/bindgen) + git-lfs/runtime
     sudo apt-get install -y -q \
         build-essential flex bison libelf-dev libssl-dev bc cpio rsync kmod \
-        python3 python3-pyelftools pkg-config clang llvm libclang-dev curl git git-lfs \
+        python3 python3-pyelftools pkg-config clang llvm libclang-dev curl git git-lfs patchelf \
         $([[ "$GPU" == "1" ]] && echo "libvirglrenderer-dev libepoxy-dev libdrm-dev libgbm-dev" || true)
     if ! command -v cargo >/dev/null 2>&1; then
         echo "--- installing rust toolchain ---"
@@ -162,6 +162,23 @@ KRUN_FNAME="$(basename "$KRUN_SO")"; KRUN_VER="${KRUN_FNAME#libkrun.so.}"; KRUN_
 cp -f "$KRUN_SO" "$LIBDIR/$KRUN_FNAME"
 cp -f "$KRUN_SO" "$LIBDIR/libkrun.so"
 ln -sf "libkrun.so" "$LIBDIR/libkrun.so.${KRUN_MAJOR}"
+
+# The GPU feature links libkrun against virglrenderer, but CUDA-only and CPU-only
+# hosts must still be able to load the same bundled VMM without installing the
+# Vulkan stack. smolvm loads libkrun lazily and preloads virglrenderer only when
+# it is available, so remove the eager ELF dependency from every real copy in
+# the committed bundle. Fail the build instead of emitting an artifact that only
+# boots on the builder image.
+if [[ "$GPU" == "1" ]]; then
+    command -v patchelf >/dev/null 2>&1 \
+        || { echo "ERROR: GPU=1 requires patchelf to keep virglrenderer optional" >&2; exit 1; }
+    for lk in "$LIBDIR"/libkrun.so*; do
+        [[ -f "$lk" && ! -L "$lk" ]] || continue
+        if patchelf --print-needed "$lk" | grep -qx 'libvirglrenderer.so.1'; then
+            patchelf --remove-needed libvirglrenderer.so.1 "$lk"
+        fi
+    done
+fi
 
 # Record which submodule commits these libs came from, so CI can detect a stale
 # bundle (scripts/check-libkrun-provenance.sh). When libkrunfw was reused rather

--- a/scripts/check-libkrun-provenance.sh
+++ b/scripts/check-libkrun-provenance.sh
@@ -45,6 +45,18 @@ for dir in "${LIB_DIRS[@]}"; do
     echo "FAIL  $dir: libkrunfw built from $got_fw but submodule is pinned at $want_fw"
     dir_ok=0; fail=1
   fi
+
+  # A GPU-enabled Linux libkrun normally records virglrenderer as DT_NEEDED.
+  # The runtime deliberately makes Vulkan optional, so committed artifacts must
+  # have that eager dependency removed; otherwise even CPU-only/CUDA-only VMs
+  # fail before boot on hosts without virglrenderer installed.
+  if [[ "$dir" == lib/linux-* ]]; then
+    libkrun="$dir/libkrun.so"
+    if readelf -d "$libkrun" 2>/dev/null | grep -q 'libvirglrenderer\.so\.1'; then
+      echo "FAIL  $dir: libkrun has a hard libvirglrenderer dependency"
+      dir_ok=0; fail=1
+    fi
+  fi
   [[ "$dir_ok" == "1" ]] && echo "OK    $dir (libkrun=$got_krun)"
 done
 

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -1304,10 +1304,11 @@ impl AgentClient {
         F: FnMut(ExecEvent),
     {
         let timeout_ms = config.timeout.map(|t| t.as_millis() as u64);
-
-        self.stream
-            .set_read_timeout(None)
-            .map_err(|e| Error::agent("set read timeout", e.to_string()))?;
+        // Keep a host-side deadline whenever the caller requested one. The
+        // guest normally enforces the command timeout, but a wedged restored
+        // VM cannot send its terminal event and must not leave the CLI blocked
+        // forever on an otherwise-open vsock connection.
+        let _timeout_guard = self.set_exec_timeout(config.timeout)?;
 
         self.send(&AgentRequest::Run {
             image: config.image,
@@ -1935,10 +1936,7 @@ impl AgentClient {
         F: FnMut(ExecEvent),
     {
         let timeout_ms = timeout.map(|t| t.as_millis() as u64);
-
-        self.stream
-            .set_read_timeout(None)
-            .map_err(|e| Error::agent("set read timeout", e.to_string()))?;
+        let _timeout_guard = self.set_exec_timeout(timeout)?;
 
         self.send(&AgentRequest::VmExec {
             command,

--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -174,11 +174,34 @@ pub fn release_forkpoint(clone: &str) -> Result<()> {
     }
 }
 
-/// Resume a golden after every clone prepared from its snapshot has been torn
-/// down. This is used only for failed transactional batch forks; a successful
-/// fork keeps the golden frozen as the copy-on-write base.
-pub fn resume_golden(golden: &str) -> Result<()> {
-    let reply = control_socket_cmd(&control_socket_path(golden), "RESUME")?;
+/// Roll back a golden after every clone prepared from its snapshot has been
+/// torn down. A completed fork checkpoint must be reapplied before resuming;
+/// if capture failed before producing one, an ordinary resume is sufficient.
+fn golden_resume_command(snapshot_dir: &Path) -> Result<String> {
+    let checkpoint = snapshot_dir.join("checkpoint.bin");
+    match std::fs::symlink_metadata(&checkpoint) {
+        Ok(metadata) if metadata.file_type().is_file() => {
+            Ok(format!("ROLLBACK_FORK {}", snapshot_dir.display()))
+        }
+        Ok(_) => Err(Error::agent(
+            "resume golden",
+            format!(
+                "refusing non-regular rollback checkpoint {}",
+                checkpoint.display()
+            ),
+        )),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok("RESUME".to_string()),
+        Err(error) => Err(Error::agent(
+            "resume golden",
+            format!("inspect rollback checkpoint: {error}"),
+        )),
+    }
+}
+
+/// Resume a failed fork's golden, restoring its completed checkpoint when one exists.
+pub fn resume_golden(golden: &str, snapshot_dir: &Path) -> Result<()> {
+    let command = golden_resume_command(snapshot_dir)?;
+    let reply = control_socket_cmd(&control_socket_path(golden), &command)?;
     if reply.starts_with("OK") {
         Ok(())
     } else {
@@ -187,6 +210,38 @@ pub fn resume_golden(golden: &str) -> Result<()> {
             format!("golden '{golden}' RESUME failed: {reply}"),
         ))
     }
+}
+
+/// Remove every retained RAM checkpoint for a golden whose VMM is confirmed
+/// dead and which has no dependent clones. A checkpoint is tied to the exact
+/// golden PID/memfd identity and can never be valid after that process exits.
+pub(crate) fn discard_retained_snapshots(db: &SmolvmDb, golden: &str) -> Result<()> {
+    let snapshot_root = vm_data_dir(golden).join("s");
+    match std::fs::symlink_metadata(&snapshot_root) {
+        Ok(metadata) if metadata.file_type().is_dir() => {
+            std::fs::remove_dir_all(&snapshot_root).map_err(|error| {
+                Error::agent("remove retained fork snapshots", error.to_string())
+            })?;
+        }
+        Ok(_) => {
+            return Err(Error::agent(
+                "remove retained fork snapshots",
+                format!(
+                    "refusing to remove non-directory {}",
+                    snapshot_root.display()
+                ),
+            ));
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(Error::agent(
+                "inspect retained fork snapshots",
+                error.to_string(),
+            ));
+        }
+    }
+    db.remove_retained_fork_snapshot(golden)?;
+    Ok(())
 }
 
 /// The result of preparing a fork: the golden is frozen + snapshotted and the
@@ -452,12 +507,22 @@ pub(crate) fn prepare_forks_reusing(
         let reply = match reply {
             Ok(reply) if reply.starts_with("OK") => reply,
             Ok(reply) => {
-                let _ = std::fs::remove_dir_all(&snapshot_dir);
-                return Err(Error::agent("fork", format!("golden FORK failed: {reply}")));
+                return Err(rollback_new_snapshot(
+                    db,
+                    golden,
+                    &snapshot_dir,
+                    false,
+                    Error::agent("fork", format!("golden FORK failed: {reply}")),
+                ));
             }
             Err(error) => {
-                let _ = std::fs::remove_dir_all(&snapshot_dir);
-                return Err(error);
+                return Err(rollback_new_snapshot(
+                    db,
+                    golden,
+                    &snapshot_dir,
+                    false,
+                    error,
+                ));
             }
         };
         tracing::info!(
@@ -551,21 +616,35 @@ fn rollback_new_snapshot(
     persisted: bool,
     error: Error,
 ) -> Error {
-    if let Err(resume_error) = resume_golden(golden) {
-        return Error::agent(
-            "fork",
-            format!("{error}; golden rollback also failed: {resume_error}"),
-        );
+    let mut rollback_errors = Vec::new();
+    if let Err(resume_error) = resume_golden(golden, snapshot_dir) {
+        rollback_errors.push(format!("golden resume failed: {resume_error}"));
     }
     if persisted {
         if let Err(remove_error) = db.remove_retained_fork_snapshot(golden) {
             tracing::warn!(%golden, %remove_error, "failed to remove rolled-back retained fork checkpoint");
+            rollback_errors.push(format!(
+                "retained-checkpoint cleanup failed: {remove_error}"
+            ));
         }
     }
     if let Err(remove_error) = std::fs::remove_dir_all(snapshot_dir) {
         tracing::warn!(path = %snapshot_dir.display(), %remove_error, "failed to remove rolled-back fork snapshot");
+        if remove_error.kind() != std::io::ErrorKind::NotFound {
+            rollback_errors.push(format!("snapshot cleanup failed: {remove_error}"));
+        }
     }
-    error
+    if rollback_errors.is_empty() {
+        error
+    } else {
+        Error::agent(
+            "fork",
+            format!(
+                "{error}; rollback also failed: {}",
+                rollback_errors.join("; ")
+            ),
+        )
+    }
 }
 
 fn reusable_snapshot_path(snapshot_root: &Path, snapshot: &Path) -> bool {
@@ -587,8 +666,19 @@ fn retained_snapshot_is_reusable(
     snapshot_root: &Path,
     snapshot: &RetainedForkSnapshot,
 ) -> bool {
-    golden_was_paused
-        && golden.pid == Some(snapshot.golden_pid)
+    golden_was_paused && retained_snapshot_matches_golden(golden, snapshot_root, snapshot)
+}
+
+/// Return whether a retained checkpoint belongs to the exact live golden
+/// process recorded in the registry and still occupies an owned snapshot path.
+/// State probing uses this to recognize a deliberately paused fork base even
+/// between pool fills, when it temporarily has no dependent clone rows.
+pub(crate) fn retained_snapshot_matches_golden(
+    golden: &VmRecord,
+    snapshot_root: &Path,
+    snapshot: &RetainedForkSnapshot,
+) -> bool {
+    golden.pid == Some(snapshot.golden_pid)
         && golden.pid_start_time == Some(snapshot.golden_pid_start_time)
         && reusable_snapshot_path(snapshot_root, &snapshot.path)
 }
@@ -1382,6 +1472,22 @@ mod tests {
     }
 
     #[test]
+    fn golden_rollback_reapplies_a_completed_checkpoint_only() {
+        let temp = tempfile::tempdir().unwrap();
+        assert_eq!(golden_resume_command(temp.path()).unwrap(), "RESUME");
+
+        std::fs::write(temp.path().join("checkpoint.bin"), b"checkpoint").unwrap();
+        assert_eq!(
+            golden_resume_command(temp.path()).unwrap(),
+            format!("ROLLBACK_FORK {}", temp.path().display())
+        );
+
+        std::fs::remove_file(temp.path().join("checkpoint.bin")).unwrap();
+        std::fs::create_dir(temp.path().join("checkpoint.bin")).unwrap();
+        assert!(golden_resume_command(temp.path()).is_err());
+    }
+
+    #[test]
     fn forkpoint_profile_parses_optional_cuda_preload_hint() {
         assert_eq!(
             parse_forkpoint_profile(b"smolvm-forkpoint-v1\n"),
@@ -1415,6 +1521,11 @@ mod tests {
             &snapshot_root,
             &snapshot
         ));
+        assert!(retained_snapshot_matches_golden(
+            &golden,
+            &snapshot_root,
+            &snapshot
+        ));
         assert!(!retained_snapshot_is_reusable(
             &golden,
             false,
@@ -1422,6 +1533,11 @@ mod tests {
             &snapshot
         ));
         golden.pid_start_time = Some(457);
+        assert!(!retained_snapshot_matches_golden(
+            &golden,
+            &snapshot_root,
+            &snapshot
+        ));
         assert!(!retained_snapshot_is_reusable(
             &golden,
             true,

--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -618,7 +618,13 @@ fn rollback_new_snapshot(
 ) -> Error {
     let mut rollback_errors = Vec::new();
     if let Err(resume_error) = resume_golden(golden, snapshot_dir) {
-        rollback_errors.push(format!("golden resume failed: {resume_error}"));
+        return Error::agent(
+            "fork",
+            format!(
+                "{error}; golden rollback failed: {resume_error}; preserved checkpoint {} for recovery",
+                snapshot_dir.display()
+            ),
+        );
     }
     if persisted {
         if let Err(remove_error) = db.remove_retained_fork_snapshot(golden) {

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -48,6 +48,96 @@ const EGRESS_CIDR_CAP: usize = 512;
 /// disabling the root DAX region for benchmarking.
 const ENV_SMOLVM_ROOTFS_DAX: &str = "SMOLVM_ROOTFS_DAX";
 
+/// Stable tmpfs directory used by one VM's CUDA file-ring transport.
+///
+/// The path is derived from the full per-VM runtime directory rather than its
+/// basename. This avoids collisions when two independent smolvm homes contain
+/// a machine with the same name. A stable path lets the lifecycle manager
+/// reclaim it after a signal-terminated VMM, where Rust destructors do not run.
+#[cfg(target_os = "linux")]
+pub(crate) fn cuda_ring_tmpfs_path(vm_runtime_dir: &Path) -> PathBuf {
+    use sha2::{Digest, Sha256};
+    use std::os::unix::ffi::OsStrExt;
+
+    let digest = Sha256::digest(vm_runtime_dir.as_os_str().as_bytes());
+    PathBuf::from("/dev/shm").join(format!("smolvm-cuda-ring-{}", hex::encode(&digest[..8])))
+}
+
+/// Remove an exact directory only when it is a real directory owned by this
+/// process's uid. Refusing symlinks and foreign-owned paths prevents lifecycle
+/// cleanup from following an attacker-controlled replacement in shared tmpfs.
+#[cfg(target_os = "linux")]
+fn remove_owned_directory(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::MetadataExt;
+
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    if !metadata.file_type().is_dir() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("refusing to remove non-directory {}", path.display()),
+        ));
+    }
+    // SAFETY: geteuid has no preconditions and cannot fail.
+    let effective_uid = unsafe { libc::geteuid() };
+    if metadata.uid() != effective_uid {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "refusing to remove {} owned by uid {} (effective uid {})",
+                path.display(),
+                metadata.uid(),
+                effective_uid
+            ),
+        ));
+    }
+    std::fs::remove_dir_all(path)
+}
+
+/// Reclaim a VM's deterministic CUDA tmpfs directory after its VMM is dead.
+#[cfg(target_os = "linux")]
+pub(crate) fn cleanup_cuda_ring_dir(vm_runtime_dir: &Path) -> std::io::Result<()> {
+    remove_owned_directory(&cuda_ring_tmpfs_path(vm_runtime_dir))?;
+    remove_owned_directory(&vm_runtime_dir.join("cuda-ring"))
+}
+
+#[cfg(target_os = "linux")]
+struct CudaRingDirGuard {
+    path: PathBuf,
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for CudaRingDirGuard {
+    fn drop(&mut self) {
+        if let Err(error) = remove_owned_directory(&self.path) {
+            tracing::warn!(
+                %error,
+                path = %self.path.display(),
+                "failed to clean CUDA tmpfs ring directory"
+            );
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn create_cuda_ring_dir(vm_runtime_dir: &Path) -> std::io::Result<CudaRingDirGuard> {
+    let path = cuda_ring_tmpfs_path(vm_runtime_dir);
+    create_owned_directory(&path)?;
+    Ok(CudaRingDirGuard { path })
+}
+
+#[cfg(target_os = "linux")]
+fn create_owned_directory(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::DirBuilderExt;
+
+    remove_owned_directory(path)?;
+    let mut builder = std::fs::DirBuilder::new();
+    builder.mode(0o700).create(path)
+}
+
 /// Root virtiofs DAX window (512 MB), matching the default the removed
 /// `krun_set_root` configured. DAX gives the host a coherent shared mapping of
 /// the root fs so the guest agent's ready-marker write is visible to the host
@@ -538,11 +628,18 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
 
     // CUDA machines get an implicit dax RING mount: a per-machine host dir the
     // guest shim and the CUDA daemon both mmap for the file-backed clone-ring
-    // transport (see cuda_host::ring_dir_advert / RingSetupFile). The dir sits
-    // next to the per-VM cuda socket; the guest sees it at /opt/smolvm-ring.
+    // transport and mapped host allocations. On Linux, tmpfs backing is
+    // required for NVIDIA cuMemHostRegister; an ordinary disk file is rejected
+    // by the driver. Linux uses a deterministic, per-machine tmpfs directory so
+    // AgentManager can reclaim it even when the VMM is terminated by a signal
+    // and this process's destructors do not run. Other platforms retain a
+    // per-VM directory used by file rings. The guest sees either at
+    // /opt/smolvm-ring.
     // Opt out with SMOLVM_CUDA_FILE_RING=0.
     let mut mounts_vec: Vec<crate::data::storage::HostMount> = mounts.to_vec();
-    if let Some(cs) = cuda_socket {
+    #[cfg(target_os = "linux")]
+    let mut _cuda_ring_guard: Option<CudaRingDirGuard> = None;
+    if cuda_socket.is_some() {
         // Device-slot budget: libkrun EINVALs the VM config once the virtio
         // device count crosses its table size (measured: 4 user mounts + the
         // ring device fails; either alone boots). Skip the ring mount rather
@@ -553,8 +650,40 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
                 "skipping CUDA ring mount: virtio device budget exhausted (clone rings unavailable; socket transport)"
             );
         } else if std::env::var("SMOLVM_CUDA_FILE_RING").as_deref() != Ok("0") {
-            if let Some(dir) = cs.parent().map(|d| d.join("cuda-ring")) {
-                if std::fs::create_dir_all(&dir).is_ok() {
+            let vm_runtime_dir = vsock_socket.parent().unwrap_or_else(|| Path::new("."));
+            let fallback_ring_dir = vm_runtime_dir.join("cuda-ring");
+            let mut ring_dir: Option<PathBuf> = None;
+            #[cfg(target_os = "linux")]
+            match create_cuda_ring_dir(vm_runtime_dir) {
+                Ok(guard) => {
+                    ring_dir = Some(guard.path.clone());
+                    _cuda_ring_guard = Some(guard);
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        %error,
+                        "CUDA tmpfs ring unavailable; mapped host allocations will use the contiguous-memory fallback"
+                    );
+                    match create_owned_directory(&fallback_ring_dir) {
+                        Ok(()) => ring_dir = Some(fallback_ring_dir.clone()),
+                        Err(error) => tracing::warn!(
+                            %error,
+                            path = %fallback_ring_dir.display(),
+                            "CUDA fallback ring directory unavailable; using socket transport"
+                        ),
+                    }
+                }
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                ring_dir = Some(fallback_ring_dir);
+            }
+            if let Some(dir) = ring_dir {
+                #[cfg(target_os = "linux")]
+                let directory_ready = true;
+                #[cfg(not(target_os = "linux"))]
+                let directory_ready = std::fs::create_dir_all(&dir).is_ok();
+                if directory_ready {
                     // SAFETY-free env set: single-threaded launch path, before
                     // the proxy threads spawn (they read these lazily anyway).
                     unsafe {
@@ -2081,6 +2210,43 @@ fn spawn_idle_reclaim(ctl: PathBuf, memory_mib: u32, idle_minutes: u64) {
 mod tests {
     use super::*;
     use std::fs;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn cuda_ring_tmpfs_path_is_stable_and_scoped_to_full_runtime_path() {
+        let first = cuda_ring_tmpfs_path(Path::new("/tmp/home-a/vms/deadbeef"));
+        assert_eq!(
+            first,
+            cuda_ring_tmpfs_path(Path::new("/tmp/home-a/vms/deadbeef"))
+        );
+        assert_ne!(
+            first,
+            cuda_ring_tmpfs_path(Path::new("/tmp/home-b/vms/deadbeef"))
+        );
+        assert_eq!(first.parent(), Some(Path::new("/dev/shm")));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn owned_directory_cleanup_removes_directory_but_refuses_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let owned = tmp.path().join("owned");
+        fs::create_dir(&owned).unwrap();
+        fs::write(owned.join("state"), b"test").unwrap();
+        remove_owned_directory(&owned).unwrap();
+        assert!(!owned.exists());
+
+        let target = tmp.path().join("target");
+        fs::create_dir(&target).unwrap();
+        let link = tmp.path().join("link");
+        symlink(&target, &link).unwrap();
+        let error = remove_owned_directory(&link).unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(target.is_dir());
+        assert!(link.symlink_metadata().is_ok());
+    }
 
     fn scoped(hosts: &[&str]) -> LaunchFeatures {
         LaunchFeatures {

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -652,12 +652,12 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
         } else if std::env::var("SMOLVM_CUDA_FILE_RING").as_deref() != Ok("0") {
             let vm_runtime_dir = vsock_socket.parent().unwrap_or_else(|| Path::new("."));
             let fallback_ring_dir = vm_runtime_dir.join("cuda-ring");
-            let mut ring_dir: Option<PathBuf> = None;
             #[cfg(target_os = "linux")]
-            match create_cuda_ring_dir(vm_runtime_dir) {
+            let ring_dir = match create_cuda_ring_dir(vm_runtime_dir) {
                 Ok(guard) => {
-                    ring_dir = Some(guard.path.clone());
+                    let path = guard.path.clone();
                     _cuda_ring_guard = Some(guard);
+                    Some(path)
                 }
                 Err(error) => {
                     tracing::warn!(
@@ -665,19 +665,20 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
                         "CUDA tmpfs ring unavailable; mapped host allocations will use the contiguous-memory fallback"
                     );
                     match create_owned_directory(&fallback_ring_dir) {
-                        Ok(()) => ring_dir = Some(fallback_ring_dir.clone()),
-                        Err(error) => tracing::warn!(
-                            %error,
-                            path = %fallback_ring_dir.display(),
-                            "CUDA fallback ring directory unavailable; using socket transport"
-                        ),
+                        Ok(()) => Some(fallback_ring_dir.clone()),
+                        Err(error) => {
+                            tracing::warn!(
+                                %error,
+                                path = %fallback_ring_dir.display(),
+                                "CUDA fallback ring directory unavailable; using socket transport"
+                            );
+                            None
+                        }
                     }
                 }
-            }
+            };
             #[cfg(not(target_os = "linux"))]
-            {
-                ring_dir = Some(fallback_ring_dir);
-            }
+            let ring_dir = Some(fallback_ring_dir);
             if let Some(dir) = ring_dir {
                 #[cfg(target_os = "linux")]
                 let directory_ready = true;

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -225,6 +225,30 @@ pub fn vm_data_dir(name: &str) -> PathBuf {
     vm_cache_root().join(vm_dir_hash(name))
 }
 
+/// Reclaim CUDA transport state after a named VM process is confirmed dead.
+///
+/// Some teardown paths terminate a VMM directly because its guest agent is
+/// unreachable and therefore never construct an [`AgentManager`] that can run
+/// normal lifecycle cleanup. Keeping this name-based entry point next to
+/// [`vm_data_dir`] makes those recovery paths clean the same exact directories.
+pub(crate) fn cleanup_dead_vm_runtime(name: &str) -> Result<()> {
+    let db = crate::db::SmolvmDb::open()?;
+    cleanup_dead_vm_runtime_in_db(name, &db)
+}
+
+pub(crate) fn cleanup_dead_vm_runtime_in_db(name: &str, db: &crate::db::SmolvmDb) -> Result<()> {
+    #[cfg(target_os = "linux")]
+    launcher::cleanup_cuda_ring_dir(&vm_data_dir(name))
+        .map_err(|error| Error::agent("clean CUDA ring directory", error.to_string()))?;
+    #[cfg(not(target_os = "linux"))]
+    let _ = name;
+
+    if db.dependent_clones(name)?.is_empty() {
+        crate::agent::fork::discard_retained_snapshots(db, name)?;
+    }
+    Ok(())
+}
+
 /// Node-shared, content-addressed pack store: `<vm_cache_root>/_shared`. Each
 /// build-constant pack is extracted here once per node under `<checksum>/`
 /// (root-owned, read-only) and presented to every machine via a per-VM idmapped
@@ -2407,6 +2431,32 @@ impl AgentManager {
         }
     }
 
+    /// Remove the per-VM CUDA tmpfs transport directory after the VMM is known
+    /// to be dead. VMMs are normally terminated by signal, so launcher-local
+    /// destructors cannot provide authoritative cleanup.
+    fn cleanup_cuda_ring_dir(&self) {
+        #[cfg(target_os = "linux")]
+        if let Some(runtime_dir) = self.vsock_socket.parent() {
+            if let Err(error) = launcher::cleanup_cuda_ring_dir(runtime_dir) {
+                tracing::warn!(
+                    %error,
+                    path = %runtime_dir.display(),
+                    "failed to clean CUDA tmpfs ring directory"
+                );
+            }
+        }
+    }
+
+    fn cleanup_dead_vm_runtime(&self) {
+        if let Some(name) = self.name.as_deref() {
+            if let Err(error) = cleanup_dead_vm_runtime(name) {
+                tracing::warn!(%name, %error, "failed to clean dead VM runtime state");
+            }
+        } else {
+            self.cleanup_cuda_ring_dir();
+        }
+    }
+
     /// Kill the VM process immediately with SIGKILL. No graceful shutdown.
     ///
     /// Used for ephemeral `machine run` where the command has already finished
@@ -2461,7 +2511,7 @@ impl AgentManager {
             },
         };
 
-        if let Some(pid) = killed_pid {
+        let confirmed_dead = if let Some(pid) = killed_pid {
             // Brief wait for the kernel to reap (SIGKILL is near-instant).
             // try_wait reaps zombie children; is_alive catches non-children
             // that have been reparented to init/launchd.
@@ -2471,14 +2521,23 @@ impl AgentManager {
                 }
                 std::thread::sleep(std::time::Duration::from_millis(5));
             }
+            !process::is_alive(pid)
+        } else {
+            // If an unverified live pid-file remains, do not remove resources
+            // out from under a process that we deliberately refused to signal.
+            !self.pid_file.exists()
+        };
+        if confirmed_dead {
+            self.cleanup_marker_files();
+            self.cleanup_dead_vm_runtime();
         }
-        self.cleanup_marker_files();
     }
 
     /// Remove the VM's entire data directory (storage, overlay, socket, logs).
     ///
     /// Only safe for ephemeral VMs after the process is confirmed dead.
     pub fn cleanup_data_dir(&self) {
+        self.cleanup_cuda_ring_dir();
         if let Some(ref name) = self.name {
             let dir = vm_data_dir(name);
             // Release this VM's per-VM uid (if any) back to the allocator before
@@ -2518,6 +2577,7 @@ impl AgentManager {
                 }
                 self.cleanup_marker_files();
             }
+            self.cleanup_dead_vm_runtime();
             return Ok(());
         }
 
@@ -2584,6 +2644,7 @@ impl AgentManager {
         }
 
         self.cleanup_marker_files();
+        self.cleanup_dead_vm_runtime();
         metrics::gauge!("smolvm_machines_running").decrement(1.0);
 
         Ok(())

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -29,6 +29,7 @@ pub use launcher::{
     create_disk_overlays, find_lib_dir, launch_agent_vm, DiskOverlaySpec, LaunchConfig,
     LaunchFeatures, VmDisks,
 };
+pub(crate) use manager::{cleanup_dead_vm_runtime, cleanup_dead_vm_runtime_in_db};
 pub use manager::{
     disk_used_mb, docker_config_dir, docker_config_mount, ensure_vm_dir, machine_layers_cache_dir,
     prune_orphaned_ready_markers, read_egress_telemetry, read_shared_pack_pointer,

--- a/src/agent/state_probe.rs
+++ b/src/agent/state_probe.rs
@@ -46,13 +46,15 @@ pub fn resolve_state(name: &str, record: &VmRecord) -> RecordState {
     let pid_alive = record.is_process_alive();
 
     if pid_alive {
-        // A fork base with live clones was snapshot-frozen by `machine
-        // fork`: its guest is paused and never answers a vsock ping.
+        // A fork base with live clones or a retained checkpoint was
+        // snapshot-frozen by `machine fork`: its guest is paused and never
+        // answers a vsock ping. A retained checkpoint remains authoritative
+        // between pool fills, when there may be zero dependent clone rows.
         // Report it as Frozen *without* probing — this distinguishes it
         // from a genuine zombie (so the reaper and supervisor leave it
         // alone) and avoids a multi-second ping timeout on a VM we know
         // won't respond (the `machine status`/`ls` hang).
-        if has_live_clones(name) {
+        if has_frozen_fork_state(name, record) {
             return RecordState::Frozen;
         }
         // PID alive: confirm the agent responds. If it doesn't, the
@@ -77,13 +79,16 @@ pub fn resolve_state(name: &str, record: &VmRecord) -> RecordState {
 }
 
 /// Cheap (no vsock probe) check for a snapshot-frozen fork base: its
-/// record says `Running`, its VMM PID is alive, and it has dependent
-/// clones. Such a VM's guest agent is paused and must not be connected to
-/// or probed — doing so blocks for the full vsock timeout. Callers report
-/// it as [`RecordState::Frozen`] directly. Shares the same condition
-/// `resolve_state` uses, so the two never disagree.
+/// record says `Running`, its VMM PID is alive, and it has dependent clones
+/// or a retained checkpoint bound to that exact process. Such a VM's guest
+/// agent is paused and must not be connected to or probed — doing so blocks
+/// for the full vsock timeout. Callers report it as [`RecordState::Frozen`]
+/// directly. Shares the same condition `resolve_state` uses, so the two never
+/// disagree.
 pub fn is_frozen_fork_base(name: &str, record: &VmRecord) -> bool {
-    record.state == RecordState::Running && record.is_process_alive() && has_live_clones(name)
+    record.state == RecordState::Running
+        && record.is_process_alive()
+        && has_frozen_fork_state(name, record)
 }
 
 /// True if `name` is a fork base — at least one VM record's disk overlays
@@ -92,10 +97,27 @@ pub fn is_frozen_fork_base(name: &str, record: &VmRecord) -> bool {
 /// auto-restarted; it has to outlive its clones. Best-effort: a DB error
 /// resolves to `false` (treat as not-a-fork-base) so a transient failure
 /// can't wedge state resolution.
-fn has_live_clones(name: &str) -> bool {
-    SmolvmDb::open()
-        .and_then(|db| db.dependent_clones(name))
+fn has_frozen_fork_state(name: &str, record: &VmRecord) -> bool {
+    let Ok(db) = SmolvmDb::open() else {
+        return false;
+    };
+    if db
+        .dependent_clones(name)
         .map(|clones| !clones.is_empty())
+        .unwrap_or(false)
+    {
+        return true;
+    }
+    db.retained_fork_snapshot(name)
+        .ok()
+        .flatten()
+        .map(|snapshot| {
+            crate::agent::fork::retained_snapshot_matches_golden(
+                record,
+                &crate::agent::vm_data_dir(name).join("s"),
+                &snapshot,
+            )
+        })
         .unwrap_or(false)
 }
 
@@ -133,6 +155,14 @@ fn recover_unreachable_machine_in_db(record: &VmRecord, db: &SmolvmDb) -> crate:
                 crate::process::VM_SIGKILL_TIMEOUT,
             )?;
         }
+    }
+
+    if let Err(error) = crate::agent::cleanup_dead_vm_runtime_in_db(&record.name, db) {
+        tracing::warn!(
+            machine = %record.name,
+            %error,
+            "failed to clean runtime after unreachable VM teardown"
+        );
     }
 
     // Write via SmolvmDb (not SmolvmConfig) to avoid pulling the full

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -263,6 +263,9 @@ fn shutdown_machine_process(
                 .map(|mut c| c.ping().is_ok())
                 .unwrap_or(false);
             if !reachable {
+                if let Err(error) = crate::agent::cleanup_dead_vm_runtime(name) {
+                    tracing::warn!(%name, %error, "failed to clean runtime after VM teardown");
+                }
                 return true;
             }
             std::thread::sleep(std::time::Duration::from_millis(300));
@@ -274,6 +277,9 @@ fn shutdown_machine_process(
         return false;
     }
 
+    if let Err(error) = crate::agent::cleanup_dead_vm_runtime(name) {
+        tracing::warn!(%name, %error, "failed to clean runtime after VM teardown");
+    }
     true
 }
 
@@ -991,6 +997,28 @@ pub async fn start_machine(
         return Ok(Json(record_to_info(&name, &record)));
     }
 
+    if resolved == RecordState::Frozen {
+        let db = state.db().clone();
+        let golden = name.clone();
+        let clones = tokio::task::spawn_blocking(move || db.dependent_clones(&golden))
+            .await
+            .map_err(|e| ApiError::internal(format!("task error: {e}")))?
+            .map_err(ApiError::database)?;
+        let reason = if clones.is_empty() {
+            "it retains a reusable fork checkpoint; stop it before restarting, or fork it again"
+                .to_string()
+        } else {
+            format!(
+                "it is the fork base for {} live clone(s) ({}); delete the clones first",
+                clones.len(),
+                clones.join(", ")
+            )
+        };
+        return Err(ApiError::Conflict(format!(
+            "machine '{name}' is frozen because {reason}"
+        )));
+    }
+
     if resolved == RecordState::Unreachable {
         // Zombie: verified-kill the VMM and clear the DB record
         // before falling through to a clean fresh start. Any stale
@@ -1533,7 +1561,7 @@ pub(crate) async fn fork_held_machines_inner(
     let mut rollback_completed = true;
     if !any_succeeded && !snapshot_reused {
         if resume_golden_on_rollback {
-            if let Err(error) = crate::agent::fork::resume_golden(&golden) {
+            if let Err(error) = crate::agent::fork::resume_golden(&golden, &snapshot_dir) {
                 tracing::warn!(%golden, %error, "failed to resume golden after batch restore failure");
                 rollback_completed = false;
             }

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -1105,12 +1105,12 @@ fn rollback_failed_fork(
     resume_golden: bool,
     error: smolvm::Error,
 ) -> smolvm::Result<()> {
-    let cleanup_error = std::fs::remove_dir_all(snapshot_dir).err();
     let resume_error = if resume_golden {
-        smolvm::agent::fork::resume_golden(golden).err()
+        smolvm::agent::fork::resume_golden(golden, snapshot_dir).err()
     } else {
         None
     };
+    let cleanup_error = std::fs::remove_dir_all(snapshot_dir).err();
     match (cleanup_error, resume_error) {
         (None, None) => Err(error),
         (cleanup, resume) => Err(smolvm::Error::agent(
@@ -1210,19 +1210,20 @@ fn start_vm_named_with_db(
             cli_recover_if_unreachable(name)?;
         }
         RecordState::Frozen => {
-            // Snapshot-frozen fork base: relaunching it writable would
-            // corrupt the clones whose disks CoW-back onto it. Refuse —
-            // delete the clones first to reuse the name.
             let clones = db.dependent_clones(name).unwrap_or_default();
-            return Err(Error::agent(
-                "start",
+            let reason = if clones.is_empty() {
+                "it retains a reusable fork checkpoint; stop it before restarting, or fork it again"
+                    .to_string()
+            } else {
                 format!(
-                    "'{name}' is the fork base for {} live clone(s) ({}); their disks are \
-                     copy-on-write overlays backed by its disks, so it cannot be re-launched \
-                     while they exist — delete the clones first",
+                    "it is the fork base for {} live clone(s) ({}); their disks are copy-on-write overlays backed by its disks, so it cannot be re-launched while they exist — delete the clones first",
                     clones.len(),
                     clones.join(", ")
-                ),
+                )
+            };
+            return Err(Error::agent(
+                "start",
+                format!("'{name}' is frozen because {reason}"),
             ));
         }
         RecordState::Stopped | RecordState::Created | RecordState::Failed => {
@@ -1814,19 +1815,24 @@ pub fn stop_vm_named(name: &str) -> smolvm::Result<()> {
             // fall through to the normal stop path
         }
         RecordState::Frozen => {
-            // Snapshot-frozen fork base: it must outlive its clones (their
-            // disks CoW-back onto its disks). Refuse instead of tearing it
-            // down — mirrors `delete`'s guard.
             let clones = SmolvmDb::open()?.dependent_clones(name).unwrap_or_default();
-            return Err(smolvm::Error::agent(
-                "stop",
-                format!(
-                    "machine '{name}' is the fork base for {} live clone(s) ({}); \
-                     stop or delete the clones first",
-                    clones.len(),
-                    clones.join(", ")
-                ),
-            ));
+            if !clones.is_empty() {
+                // A snapshot-frozen fork base must outlive its clones: their
+                // disks CoW-back onto its disks and their RAM maps its memfd.
+                return Err(smolvm::Error::agent(
+                    "stop",
+                    format!(
+                        "machine '{name}' is the fork base for {} live clone(s) ({}); \
+                         stop or delete the clones first",
+                        clones.len(),
+                        clones.join(", ")
+                    ),
+                ));
+            }
+            // A retained checkpoint deliberately keeps the golden frozen
+            // between fills even when no clones exist. It is now safe to kill
+            // the paused VMM; AgentManager::stop removes the exact retained
+            // checkpoint only after confirming process death.
         }
         other => {
             // Not running. If a prior start mounted the layers volume but the

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -1105,21 +1105,23 @@ fn rollback_failed_fork(
     resume_golden: bool,
     error: smolvm::Error,
 ) -> smolvm::Result<()> {
-    let resume_error = if resume_golden {
-        smolvm::agent::fork::resume_golden(golden, snapshot_dir).err()
-    } else {
-        None
-    };
+    if resume_golden {
+        if let Err(resume_error) = smolvm::agent::fork::resume_golden(golden, snapshot_dir) {
+            return Err(smolvm::Error::agent(
+                "fork rollback",
+                format!(
+                    "{error}; golden rollback failed: {resume_error}; preserved checkpoint {} for recovery",
+                    snapshot_dir.display()
+                ),
+            ));
+        }
+    }
     let cleanup_error = std::fs::remove_dir_all(snapshot_dir).err();
-    match (cleanup_error, resume_error) {
-        (None, None) => Err(error),
-        (cleanup, resume) => Err(smolvm::Error::agent(
+    match cleanup_error {
+        None => Err(error),
+        Some(cleanup) => Err(smolvm::Error::agent(
             "fork rollback",
-            format!(
-                "{error}; snapshot cleanup: {}; golden resume: {}",
-                cleanup.map_or_else(|| "ok".to_string(), |e| e.to_string()),
-                resume.map_or_else(|| "ok".to_string(), |e| e.to_string()),
-            ),
+            format!("{error}; golden rollback succeeded but snapshot cleanup failed: {cleanup}"),
         )),
     }
 }

--- a/src/cuda_host.rs
+++ b/src/cuda_host.rs
@@ -184,6 +184,9 @@ pub fn start_with_clone_mode(socket_path: &Path, is_fork_clone: bool) -> std::io
                                     }
                                     return;
                                 }
+                                smolvm_cuda::host::ring_dir_set(
+                                    std::env::var("SMOLVM_CUDA_RING_HOST_DIR").ok(),
+                                );
                                 let mut backend = make_backend();
                                 if let Err(e) =
                                     serve_with_options(stream, backend.as_mut(), options)


### PR DESCRIPTION
Adds bounded mapped CUDA transport, complete fork rollback, and matched cross-platform runtimes that keep Vulkan optional; depends on smol-machines/libkrun#53.