### PR TITLE
Preserve CUDA in embedded runtimes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,9 +196,20 @@ jobs:
         run: |
           for f in \
             usr/local/lib/smolvm-cuda/libcudart-shim.so \
+            usr/local/lib/smolvm-cuda/libcudart.so.13 \
+            usr/local/lib/smolvm-cuda/libcublas.so.13 \
+            usr/local/lib/smolvm-cuda/libcublasLt.so.13 \
+            usr/local/lib/smolvm-cuda/libcudart.so.12 \
+            usr/local/lib/smolvm-cuda/libcublas.so.12 \
+            usr/local/lib/smolvm-cuda/libcublasLt.so.12 \
+            usr/local/lib/smolvm-cuda/libcudnn.so.9 \
+            usr/local/lib/smolvm-cuda/libcudart.so.11.0 \
+            usr/local/lib/smolvm-cuda/libcublas.so.11 \
+            usr/local/lib/smolvm-cuda/libcublasLt.so.11 \
+            usr/local/lib/smolvm-cuda/libcudnn.so.8 \
             usr/local/lib/smolvm-cuda/libcuda.so.1 \
             usr/local/bin/smolvm-cuda-run; do
-            if [[ ! -f "target/agent-rootfs/$f" ]]; then
+            if [[ ! -e "target/agent-rootfs/$f" ]]; then
               echo "::error::missing $f in agent-rootfs (CUDA auto-staging would be disabled)"
               exit 1
             fi

--- a/scripts/build-agent-rootfs.sh
+++ b/scripts/build-agent-rootfs.sh
@@ -362,6 +362,17 @@ if [[ -n "$CUDART_SHIM_SRC" && -f "$CUDART_SHIM_SRC" \
     # failure and users hand-symlink the shim to fix it.
     ln -sf libcuda.so.1 "$OUTPUT_DIR/usr/local/lib/smolvm-cuda/libcuda.so"
     ln -sf libcudart-shim.so "$OUTPUT_DIR/usr/local/lib/smolvm-cuda/libcudart.so"
+    # Dynamic CUDA applications carry versioned DT_NEEDED entries. PyTorch's
+    # wheel-local copies are covered by per-file bind mounts, but an ordinary
+    # nvcc binary expects the matching soname to exist directly on
+    # LD_LIBRARY_PATH. Route every runtime/library ABI the shim advertises to
+    # the same implementation so those binaries start without manual links.
+    for soname in \
+        libcudart.so.13 libcublas.so.13 libcublasLt.so.13 \
+        libcudart.so.12 libcublas.so.12 libcublasLt.so.12 libcudnn.so.9 \
+        libcudart.so.11.0 libcublas.so.11 libcublasLt.so.11 libcudnn.so.8; do
+        ln -sf libcudart-shim.so "$OUTPUT_DIR/usr/local/lib/smolvm-cuda/$soname"
+    done
     # NVML drop-in: frameworks (vLLM) detect the GPU through NVML, not the CUDA
     # driver — the shim dir rides LD_LIBRARY_PATH, so the plain-soname dlopen of
     # libnvidia-ml.so.1 resolves here. Best-effort: absent on non-Linux builds.

--- a/src/embedded/control.rs
+++ b/src/embedded/control.rs
@@ -51,6 +51,7 @@ impl MachineSpec {
         record.network_backend = self.resources.network_backend;
         record.gpu = Some(self.resources.gpu);
         record.gpu_vram_mib = self.resources.gpu_vram_mib;
+        record.cuda = self.resources.cuda;
         record.image = self.image.clone();
         record.ephemeral = !self.persistent;
         record.runtime_managed = self.runtime_managed;
@@ -410,20 +411,25 @@ mod tests {
 
     #[test]
     fn record_carries_gpu_resources() {
-        // GPU must survive MachineSpec -> VmRecord (the `_boot-vm` config),
-        // otherwise the SDK's `resources.gpu` is silently dropped before launch.
+        // Vulkan and CUDA must survive MachineSpec -> VmRecord (the `_boot-vm`
+        // config), otherwise SDK and Kubernetes requests are silently dropped.
         let mut spec = test_spec("gpu", false);
         spec.resources.gpu = true;
         spec.resources.gpu_vram_mib = Some(512);
+        spec.resources.cuda = true;
         let record = spec.to_record();
         assert_eq!(record.gpu, Some(true));
         assert_eq!(record.gpu_vram_mib, Some(512));
         assert!(record.vm_resources().gpu);
+        assert!(record.cuda);
+        assert!(record.vm_resources().cuda);
 
         // Default (no GPU) records leave gpu off.
         let plain = test_spec("plain", false).to_record();
         assert_eq!(plain.gpu, Some(false));
         assert!(!plain.vm_resources().gpu);
+        assert!(!plain.cuda);
+        assert!(!plain.vm_resources().cuda);
     }
 
     #[test]


### PR DESCRIPTION
Preserves CUDA requests in embedded machine records and bundles the versioned shim sonames required by ordinary CUDA binaries.