### PR TITLE
Remove a pod's overlay and share tree on every teardown path

### DIFF
--- a/crates/smolvm-agent/src/pod.rs
+++ b/crates/smolvm-agent/src/pod.rs
@@ -36,6 +36,12 @@ pub const POD_SHARE_TAG: &str = "podshare";
 /// Guest directory holding per-pod-container state (crun bundle dirs).
 const POD_STATE_DIR: &str = "/storage/containers/pods";
 
+/// Guest directory holding each container's writable overlay (`upper`/`work`/
+/// `merged`) and its materialized CRI mounts (`mnt/`). A second per-container
+/// tree alongside [`POD_STATE_DIR`]; both are created on start and both are
+/// torn down by `PodDelete`.
+const POD_OVERLAY_DIR: &str = "/storage/pods";
+
 // ============================================================================
 // Registry
 // ============================================================================
@@ -312,6 +318,31 @@ fn parse_pod_mounts(spec: &serde_json::Value) -> Vec<PodMount> {
 fn pod_dir(id: &str) -> PathBuf {
     PathBuf::from(POD_STATE_DIR).join(id)
 }
+
+/// Per-container overlay directory (holds `upper`/`work`/`merged` and `mnt/`).
+fn pod_overlay_dir(id: &str) -> PathBuf {
+    PathBuf::from(POD_OVERLAY_DIR).join(id)
+}
+
+/// Detach an overlay mounted at `merged`, if one is there.
+///
+/// `MNT_DETACH` because a container that died badly can still hold references:
+/// a lazy unmount always succeeds in taking the mountpoint out of the namespace
+/// and lets the kernel release it when the last reference goes. Not being
+/// mounted is the common case and not an error, so the result is discarded.
+#[cfg(target_os = "linux")]
+fn detach_overlay(merged: &Path) {
+    use std::ffi::CString;
+    if let Ok(c) = CString::new(merged.to_string_lossy().as_bytes()) {
+        // SAFETY: `c` is a valid NUL-terminated C string that outlives the call;
+        // the agent is PID 1 with CAP_SYS_ADMIN, so umount2 is permitted.
+        unsafe { libc::umount2(c.as_ptr(), libc::MNT_DETACH) };
+    }
+}
+
+/// Guest overlays only exist on Linux; nothing to detach elsewhere.
+#[cfg(not(target_os = "linux"))]
+fn detach_overlay(_merged: &Path) {}
 
 // ============================================================================
 // PID helpers
@@ -773,18 +804,37 @@ pub fn handle_pod_delete(id: &str, exec_id: Option<&str>) -> AgentResponse {
     let _ = crun::CrunCommand::delete(id, true)
         .discard_output()
         .output();
-    // Only touch the bundle dir for ids we actually created (or whose dir
-    // exists) — pod_dir(id) is validated-id-safe but stay conservative.
+    // Only touch on-disk state for ids we actually created (or whose dirs
+    // exist) — the path helpers are validated-id-safe but stay conservative.
     if validate_id(id).is_ok() {
-        let dir = pod_dir(id);
-        if dir.exists() {
-            if let Err(e) = std::fs::remove_dir_all(&dir) {
-                warn!(id = %id, error = %e, "failed to remove pod state dir");
-            }
-        }
+        remove_container_state(&pod_dir(id), &pod_overlay_dir(id));
     }
     info!(id = %id, existed = existed, "pod container deleted");
     AgentResponse::ok(None)
+}
+
+/// Remove both per-container trees that starting a container creates: the crun
+/// bundle under [`POD_STATE_DIR`] and the writable overlay under
+/// [`POD_OVERLAY_DIR`].
+///
+/// The overlay's `merged` mount is detached BEFORE its tree is removed. The
+/// other order recurses into a live overlay and deletes *through* it — which
+/// destroys the content the lower is showing and still leaves the mount behind.
+///
+/// Best-effort throughout, like the rest of delete: failures are logged, never
+/// propagated, so leftover state cannot wedge a CRI delete.
+fn remove_container_state(bundle: &Path, overlay: &Path) {
+    if bundle.exists() {
+        if let Err(e) = std::fs::remove_dir_all(bundle) {
+            warn!(dir = %bundle.display(), error = %e, "failed to remove pod state dir");
+        }
+    }
+    detach_overlay(&overlay.join("merged"));
+    if overlay.exists() {
+        if let Err(e) = std::fs::remove_dir_all(overlay) {
+            warn!(dir = %overlay.display(), error = %e, "failed to remove pod overlay dir");
+        }
+    }
 }
 
 // ============================================================================
@@ -1057,7 +1107,7 @@ fn materialize_pod_mounts(id: &str, mounts: &[PodMount]) -> Vec<(PathBuf, String
     // The copy makes the volume writable + guest-local (correct emptyDir/configMap
     // /secret semantics; smolvm's virtiofs share is read-only so a live bind of the
     // host source couldn't be written).
-    let base = Path::new("/storage/pods").join(id).join("mnt");
+    let base = pod_overlay_dir(id).join("mnt");
     let mut binds = Vec::new();
     for (n, m) in mounts.iter().enumerate() {
         let dst = base.join(n.to_string());
@@ -1267,7 +1317,7 @@ fn cgroups_available() -> bool {
 /// unmounted first.
 #[cfg(target_os = "linux")]
 fn mount_writable_rootfs(id: &str, lower: &std::path::Path) -> Result<PathBuf, String> {
-    let base = Path::new("/storage/pods").join(id);
+    let base = pod_overlay_dir(id);
     let upper = base.join("upper");
     let work = base.join("work");
     let merged = base.join("merged");
@@ -1278,8 +1328,10 @@ fn mount_writable_rootfs(id: &str, lower: &std::path::Path) -> Result<PathBuf, S
     use std::ffi::CString;
     let cstr = |p: &str| CString::new(p).map_err(|e| format!("cstr {p}: {e}"));
     let merged_c = cstr(&merged.to_string_lossy())?;
-    // Drop any leftover mount from a previous start attempt (MNT_DETACH = 2).
-    unsafe { libc::umount2(merged_c.as_ptr(), 2) };
+    // Drop any leftover mount from a previous start attempt of THIS id. A
+    // predecessor container has a different id and is reclaimed by its own
+    // delete, not here.
+    detach_overlay(&merged);
 
     let overlay_c = cstr("overlay")?;
     let data = format!(
@@ -1785,6 +1837,45 @@ mod tests {
 
         // Gone from the registry.
         assert!(matches!(handle_pod_pids(id), AgentResponse::Error { .. }));
+    }
+
+    #[test]
+    fn deleting_a_container_removes_both_of_its_state_trees() {
+        // Starting a container creates two trees: the crun bundle and the
+        // writable overlay (upper/work/merged) with its materialized CRI
+        // mounts. Delete owns both — leaving either behind means a container
+        // that restarts under a fresh id (which every k8s restart does)
+        // accumulates one orphan per restart inside the same sandbox.
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle = tmp.path().join("containers/pods/ctr-a");
+        let overlay = tmp.path().join("pods/ctr-a");
+        std::fs::create_dir_all(bundle.join("rootfs")).unwrap();
+        for d in ["upper/etc", "work/work", "merged", "mnt/0"] {
+            std::fs::create_dir_all(overlay.join(d)).unwrap();
+        }
+        std::fs::write(overlay.join("upper/etc/hosts"), b"127.0.0.1").unwrap();
+
+        remove_container_state(&bundle, &overlay);
+
+        assert!(!bundle.exists(), "crun bundle survived delete");
+        assert!(!overlay.exists(), "writable overlay survived delete");
+
+        // Deleting twice, and deleting something that was never started, are
+        // both fine: delete is idempotent and must never fail the CRI call.
+        remove_container_state(&bundle, &overlay);
+        remove_container_state(&tmp.path().join("nope"), &tmp.path().join("nope2"));
+    }
+
+    #[test]
+    fn a_containers_two_state_trees_are_siblings_under_distinct_roots() {
+        // The overlay root is deliberately NOT under the bundle root: removing
+        // the bundle cannot reclaim the overlay by accident, which is exactly
+        // why delete has to name both.
+        let bundle = pod_dir("ctr-a");
+        let overlay = pod_overlay_dir("ctr-a");
+        assert_eq!(bundle, Path::new("/storage/containers/pods/ctr-a"));
+        assert_eq!(overlay, Path::new("/storage/pods/ctr-a"));
+        assert!(!overlay.starts_with(POD_STATE_DIR));
     }
 
     #[test]

--- a/crates/smolvm-agent/src/pod.rs
+++ b/crates/smolvm-agent/src/pod.rs
@@ -36,6 +36,12 @@ pub const POD_SHARE_TAG: &str = "podshare";
 /// Guest directory holding per-pod-container state (crun bundle dirs).
 const POD_STATE_DIR: &str = "/storage/containers/pods";
 
+/// Guest directory holding each container's writable overlay (`upper`/`work`/
+/// `merged`) and its materialized CRI mounts (`mnt/`). A second per-container
+/// tree alongside [`POD_STATE_DIR`]; both are created on start and both are
+/// torn down by `PodDelete`.
+const POD_OVERLAY_DIR: &str = "/storage/pods";
+
 // ============================================================================
 // Registry
 // ============================================================================
@@ -312,6 +318,31 @@ fn parse_pod_mounts(spec: &serde_json::Value) -> Vec<PodMount> {
 fn pod_dir(id: &str) -> PathBuf {
     PathBuf::from(POD_STATE_DIR).join(id)
 }
+
+/// Per-container overlay directory (holds `upper`/`work`/`merged` and `mnt/`).
+fn pod_overlay_dir(id: &str) -> PathBuf {
+    PathBuf::from(POD_OVERLAY_DIR).join(id)
+}
+
+/// Detach an overlay mounted at `merged`, if one is there.
+///
+/// `MNT_DETACH` because a container that died badly can still hold references:
+/// a lazy unmount always succeeds in taking the mountpoint out of the namespace
+/// and lets the kernel release it when the last reference goes. Not being
+/// mounted is the common case and not an error, so the result is discarded.
+#[cfg(target_os = "linux")]
+fn detach_overlay(merged: &Path) {
+    use std::ffi::CString;
+    if let Ok(c) = CString::new(merged.to_string_lossy().as_bytes()) {
+        // SAFETY: `c` is a valid NUL-terminated C string that outlives the call;
+        // the agent is PID 1 with CAP_SYS_ADMIN, so umount2 is permitted.
+        unsafe { libc::umount2(c.as_ptr(), libc::MNT_DETACH) };
+    }
+}
+
+/// Guest overlays only exist on Linux; nothing to detach elsewhere.
+#[cfg(not(target_os = "linux"))]
+fn detach_overlay(_merged: &Path) {}
 
 // ============================================================================
 // PID helpers
@@ -773,18 +804,37 @@ pub fn handle_pod_delete(id: &str, exec_id: Option<&str>) -> AgentResponse {
     let _ = crun::CrunCommand::delete(id, true)
         .discard_output()
         .output();
-    // Only touch the bundle dir for ids we actually created (or whose dir
-    // exists) — pod_dir(id) is validated-id-safe but stay conservative.
+    // Only touch on-disk state for ids we actually created (or whose dirs
+    // exist) — the path helpers are validated-id-safe but stay conservative.
     if validate_id(id).is_ok() {
-        let dir = pod_dir(id);
-        if dir.exists() {
-            if let Err(e) = std::fs::remove_dir_all(&dir) {
-                warn!(id = %id, error = %e, "failed to remove pod state dir");
-            }
-        }
+        remove_container_state(&pod_dir(id), &pod_overlay_dir(id));
     }
     info!(id = %id, existed = existed, "pod container deleted");
     AgentResponse::ok(None)
+}
+
+/// Remove both per-container trees that starting a container creates: the crun
+/// bundle under [`POD_STATE_DIR`] and the writable overlay under
+/// [`POD_OVERLAY_DIR`].
+///
+/// The overlay's `merged` mount is detached BEFORE its tree is removed. The
+/// other order recurses into a live overlay and deletes *through* it — which
+/// destroys the content the lower is showing and still leaves the mount behind.
+///
+/// Best-effort throughout, like the rest of delete: failures are logged, never
+/// propagated, so leftover state cannot wedge a CRI delete.
+fn remove_container_state(bundle: &Path, overlay: &Path) {
+    if bundle.exists() {
+        if let Err(e) = std::fs::remove_dir_all(bundle) {
+            warn!(dir = %bundle.display(), error = %e, "failed to remove pod state dir");
+        }
+    }
+    detach_overlay(&overlay.join("merged"));
+    if overlay.exists() {
+        if let Err(e) = std::fs::remove_dir_all(overlay) {
+            warn!(dir = %overlay.display(), error = %e, "failed to remove pod overlay dir");
+        }
+    }
 }
 
 // ============================================================================
@@ -1058,7 +1108,7 @@ fn materialize_pod_mounts(id: &str, mounts: &[PodMount]) -> Vec<(PathBuf, String
     // The copy makes the volume writable + guest-local (correct emptyDir/configMap
     // /secret semantics; smolvm's virtiofs share is read-only so a live bind of the
     // host source couldn't be written).
-    let base = Path::new("/storage/pods").join(id).join("mnt");
+    let base = pod_overlay_dir(id).join("mnt");
     let mut binds = Vec::new();
     for (n, m) in mounts.iter().enumerate() {
         let dst = base.join(n.to_string());
@@ -1268,7 +1318,7 @@ fn cgroups_available() -> bool {
 /// unmounted first.
 #[cfg(target_os = "linux")]
 fn mount_writable_rootfs(id: &str, lower: &std::path::Path) -> Result<PathBuf, String> {
-    let base = Path::new("/storage/pods").join(id);
+    let base = pod_overlay_dir(id);
     let upper = base.join("upper");
     let work = base.join("work");
     let merged = base.join("merged");
@@ -1279,8 +1329,10 @@ fn mount_writable_rootfs(id: &str, lower: &std::path::Path) -> Result<PathBuf, S
     use std::ffi::CString;
     let cstr = |p: &str| CString::new(p).map_err(|e| format!("cstr {p}: {e}"));
     let merged_c = cstr(&merged.to_string_lossy())?;
-    // Drop any leftover mount from a previous start attempt (MNT_DETACH = 2).
-    unsafe { libc::umount2(merged_c.as_ptr(), 2) };
+    // Drop any leftover mount from a previous start attempt of THIS id. A
+    // predecessor container has a different id and is reclaimed by its own
+    // delete, not here.
+    detach_overlay(&merged);
 
     let overlay_c = cstr("overlay")?;
     let data = format!(
@@ -1786,6 +1838,45 @@ mod tests {
 
         // Gone from the registry.
         assert!(matches!(handle_pod_pids(id), AgentResponse::Error { .. }));
+    }
+
+    #[test]
+    fn deleting_a_container_removes_both_of_its_state_trees() {
+        // Starting a container creates two trees: the crun bundle and the
+        // writable overlay (upper/work/merged) with its materialized CRI
+        // mounts. Delete owns both — leaving either behind means a container
+        // that restarts under a fresh id (which every k8s restart does)
+        // accumulates one orphan per restart inside the same sandbox.
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle = tmp.path().join("containers/pods/ctr-a");
+        let overlay = tmp.path().join("pods/ctr-a");
+        std::fs::create_dir_all(bundle.join("rootfs")).unwrap();
+        for d in ["upper/etc", "work/work", "merged", "mnt/0"] {
+            std::fs::create_dir_all(overlay.join(d)).unwrap();
+        }
+        std::fs::write(overlay.join("upper/etc/hosts"), b"127.0.0.1").unwrap();
+
+        remove_container_state(&bundle, &overlay);
+
+        assert!(!bundle.exists(), "crun bundle survived delete");
+        assert!(!overlay.exists(), "writable overlay survived delete");
+
+        // Deleting twice, and deleting something that was never started, are
+        // both fine: delete is idempotent and must never fail the CRI call.
+        remove_container_state(&bundle, &overlay);
+        remove_container_state(&tmp.path().join("nope"), &tmp.path().join("nope2"));
+    }
+
+    #[test]
+    fn a_containers_two_state_trees_are_siblings_under_distinct_roots() {
+        // The overlay root is deliberately NOT under the bundle root: removing
+        // the bundle cannot reclaim the overlay by accident, which is exactly
+        // why delete has to name both.
+        let bundle = pod_dir("ctr-a");
+        let overlay = pod_overlay_dir("ctr-a");
+        assert_eq!(bundle, Path::new("/storage/containers/pods/ctr-a"));
+        assert_eq!(overlay, Path::new("/storage/pods/ctr-a"));
+        assert!(!overlay.starts_with(POD_STATE_DIR));
     }
 
     #[test]

--- a/crates/smolvm-shim/src/engine.rs
+++ b/crates/smolvm-shim/src/engine.rs
@@ -49,6 +49,45 @@ use crate::backend::{ExitInfo, ExitWatch, PodBackend, ProcessSpec, Stdio};
 /// rejects). One `<id>/podshare` subdir per sandbox.
 const POD_SHARE_HOST_ROOT: &str = "/var/lib/containerd-shim-smolvm";
 
+/// Resolve a sandbox's share tree — `<root>/<sandbox-id>`, the parent of the
+/// `podshare` dir handed to the VM.
+///
+/// Returns `None` for an id that could climb out of `root`. containerd ids are
+/// hex, but this path feeds `remove_dir_all`, so it is checked rather than
+/// trusted.
+fn share_tree_in(root: &Path, id: &str) -> Option<PathBuf> {
+    if id.is_empty() || id == "." || id == ".." || id.contains('/') || id.contains('\\') {
+        return None;
+    }
+    Some(root.join(id))
+}
+
+fn remove_share_tree(root: &Path, id: &str) {
+    let Some(dir) = share_tree_in(root, id) else {
+        warn!("refusing to remove share tree for suspicious sandbox id {id:?}");
+        return;
+    };
+    match std::fs::remove_dir_all(&dir) {
+        Ok(()) => debug!("removed sandbox share tree {}", dir.display()),
+        // Already gone is the common case (a second teardown path ran first).
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => warn!("rm {}: {e}", dir.display()),
+    }
+}
+
+/// Remove the host share tree belonging to `id`.
+///
+/// The sandbox VM is reaped by sandbox id on three separate teardown paths, and
+/// this directory is keyed by that same id, so it has to go with it. Nothing
+/// else can reclaim it: a graceful delete removes the machine record first, so
+/// the startup reconcile — which only walks surviving records — can never see
+/// that the tree is orphaned.
+///
+/// Best-effort: teardown must not fail because residue could not be removed.
+pub(crate) fn remove_sandbox_share_tree(id: &str) {
+    remove_share_tree(Path::new(POD_SHARE_HOST_ROOT), id);
+}
+
 const POD_SHARE_GUEST_PATH: &str = "/podshare";
 
 /// Where the agent's pod handlers resolve `PodCreate.rootfs_rel` from:
@@ -626,6 +665,13 @@ impl PodBackend for EnginePodBackend {
                 }) => {
                     warn!("sandbox machine {id_owned} already exists; recreating");
                     let _ = rt.delete_machine(&id_owned);
+                    // The predecessor's share tree is stale too, and on this
+                    // path it still holds its container rootfs copies — the
+                    // per-container delete never ran. Replace it alongside the
+                    // record rather than letting the new sandbox inherit it.
+                    remove_sandbox_share_tree(&id_owned);
+                    std::fs::create_dir_all(&share_dir)
+                        .map_err(|e| format!("mkdir {}: {e}", share_dir.display()))?;
                     rt.create_machine(spec).map_err(|e| e.to_string())?;
                 }
                 Err(e) => return Err(e.to_string()),
@@ -906,8 +952,14 @@ impl PodBackend for EnginePodBackend {
                 if let Err(e) = rt.stop_machine(&sandbox.id) {
                     warn!("stop sandbox VM {}: {e}", sandbox.id);
                 }
-                rt.delete_machine(&sandbox.id)
-                    .map_err(|e| format!("delete sandbox VM: {e}"))
+                let deleted = rt
+                    .delete_machine(&sandbox.id)
+                    .map_err(|e| format!("delete sandbox VM: {e}"));
+                // The share tree outlives the VM it was created for unless it
+                // is removed here; do it even if the VM teardown reported an
+                // error, since the pod is going away either way.
+                remove_sandbox_share_tree(&sandbox.id);
+                deleted
             })
             .await
             .map_err(|e| e.to_string())??;
@@ -1256,5 +1308,64 @@ impl PodBackend for ShimBackend {
             Self::Mock(b) => b.stats(id).await,
             Self::Engine(b) => b.stats(id).await,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The sandbox VM is reaped by sandbox id on every teardown path; the host
+    /// share tree is keyed by that same id and has to go with it. What makes it
+    /// expensive is the crash profile: the per-container delete never ran, so
+    /// the tree still holds full `cp -a` image rootfs copies.
+    #[test]
+    fn removing_a_sandbox_share_tree_takes_its_container_rootfs_copies_with_it() {
+        let root = tempfile::tempdir().unwrap();
+        let sandbox = "a1b2c3";
+        let rootfs = root.path().join(sandbox).join("podshare/ctr-1/rootfs");
+        std::fs::create_dir_all(rootfs.join("bin")).unwrap();
+        std::fs::write(rootfs.join("bin/sh"), b"#!/bin/sh").unwrap();
+        // A second sandbox on the same node must be left strictly alone.
+        let other = root.path().join("d4e5f6").join("podshare");
+        std::fs::create_dir_all(&other).unwrap();
+
+        remove_share_tree(root.path(), sandbox);
+
+        assert!(
+            !root.path().join(sandbox).exists(),
+            "share tree survived sandbox teardown"
+        );
+        assert!(other.exists(), "teardown removed an unrelated sandbox");
+
+        // Teardown runs from more than one path, so a tree that is already gone
+        // is the normal case, not an error.
+        remove_share_tree(root.path(), sandbox);
+    }
+
+    #[test]
+    fn a_share_tree_path_cannot_climb_out_of_the_share_root() {
+        let root = Path::new(POD_SHARE_HOST_ROOT);
+        assert_eq!(
+            share_tree_in(root, "a1b2c3"),
+            Some(root.join("a1b2c3")),
+            "an ordinary containerd id must resolve"
+        );
+        for bad in ["", ".", "..", "../..", "a/b", "..\\x"] {
+            assert_eq!(share_tree_in(root, bad), None, "accepted id {bad:?}");
+        }
+    }
+
+    /// The tree removed on teardown is the PARENT of the dir handed to the VM,
+    /// so the per-sandbox `podshare` goes with it rather than being orphaned.
+    #[test]
+    fn the_share_tree_is_the_parent_of_the_dir_mounted_into_the_vm() {
+        let root = Path::new(POD_SHARE_HOST_ROOT);
+        let mounted = root.join("a1b2c3").join("podshare");
+        assert_eq!(
+            share_tree_in(root, "a1b2c3").as_deref(),
+            mounted.parent(),
+            "teardown must remove the sandbox dir, not just its podshare"
+        );
     }
 }

--- a/crates/smolvm-shim/src/engine.rs
+++ b/crates/smolvm-shim/src/engine.rs
@@ -49,6 +49,45 @@ use crate::backend::{ExitInfo, ExitWatch, PodBackend, ProcessSpec, Stdio};
 /// rejects). One `<id>/podshare` subdir per sandbox.
 const POD_SHARE_HOST_ROOT: &str = "/var/lib/containerd-shim-smolvm";
 
+/// Resolve a sandbox's share tree — `<root>/<sandbox-id>`, the parent of the
+/// `podshare` dir handed to the VM.
+///
+/// Returns `None` for an id that could climb out of `root`. containerd ids are
+/// hex, but this path feeds `remove_dir_all`, so it is checked rather than
+/// trusted.
+fn share_tree_in(root: &Path, id: &str) -> Option<PathBuf> {
+    if id.is_empty() || id == "." || id == ".." || id.contains('/') || id.contains('\\') {
+        return None;
+    }
+    Some(root.join(id))
+}
+
+fn remove_share_tree(root: &Path, id: &str) {
+    let Some(dir) = share_tree_in(root, id) else {
+        warn!("refusing to remove share tree for suspicious sandbox id {id:?}");
+        return;
+    };
+    match std::fs::remove_dir_all(&dir) {
+        Ok(()) => debug!("removed sandbox share tree {}", dir.display()),
+        // Already gone is the common case (a second teardown path ran first).
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => warn!("rm {}: {e}", dir.display()),
+    }
+}
+
+/// Remove the host share tree belonging to `id`.
+///
+/// The sandbox VM is reaped by sandbox id on three separate teardown paths, and
+/// this directory is keyed by that same id, so it has to go with it. Nothing
+/// else can reclaim it: a graceful delete removes the machine record first, so
+/// the startup reconcile — which only walks surviving records — can never see
+/// that the tree is orphaned.
+///
+/// Best-effort: teardown must not fail because residue could not be removed.
+pub(crate) fn remove_sandbox_share_tree(id: &str) {
+    remove_share_tree(Path::new(POD_SHARE_HOST_ROOT), id);
+}
+
 const POD_SHARE_GUEST_PATH: &str = "/podshare";
 
 /// Where the agent's pod handlers resolve `PodCreate.rootfs_rel` from:
@@ -690,6 +729,13 @@ impl PodBackend for EnginePodBackend {
                 }) => {
                     warn!("sandbox machine {id_owned} already exists; recreating");
                     let _ = rt.delete_machine(&id_owned);
+                    // The predecessor's share tree is stale too, and on this
+                    // path it still holds its container rootfs copies — the
+                    // per-container delete never ran. Replace it alongside the
+                    // record rather than letting the new sandbox inherit it.
+                    remove_sandbox_share_tree(&id_owned);
+                    std::fs::create_dir_all(&share_dir)
+                        .map_err(|e| format!("mkdir {}: {e}", share_dir.display()))?;
                     rt.create_machine(spec).map_err(|e| e.to_string())?;
                 }
                 Err(e) => return Err(e.to_string()),
@@ -970,8 +1016,14 @@ impl PodBackend for EnginePodBackend {
                 if let Err(e) = rt.stop_machine(&sandbox.id) {
                     warn!("stop sandbox VM {}: {e}", sandbox.id);
                 }
-                rt.delete_machine(&sandbox.id)
-                    .map_err(|e| format!("delete sandbox VM: {e}"))
+                let deleted = rt
+                    .delete_machine(&sandbox.id)
+                    .map_err(|e| format!("delete sandbox VM: {e}"));
+                // The share tree outlives the VM it was created for unless it
+                // is removed here; do it even if the VM teardown reported an
+                // error, since the pod is going away either way.
+                remove_sandbox_share_tree(&sandbox.id);
+                deleted
             })
             .await
             .map_err(|e| e.to_string())??;
@@ -1407,6 +1459,60 @@ mod tests {
                 serde_json::json!({ ANN_GPU_VRAM_MIB: "2048" })
             ))),
             GpuRequest::default()
+        );
+    }
+
+    /// The sandbox VM is reaped by sandbox id on every teardown path; the host
+    /// share tree is keyed by that same id and has to go with it. What makes it
+    /// expensive is the crash profile: the per-container delete never ran, so
+    /// the tree still holds full `cp -a` image rootfs copies.
+    #[test]
+    fn removing_a_sandbox_share_tree_takes_its_container_rootfs_copies_with_it() {
+        let root = tempfile::tempdir().unwrap();
+        let sandbox = "a1b2c3";
+        let rootfs = root.path().join(sandbox).join("podshare/ctr-1/rootfs");
+        std::fs::create_dir_all(rootfs.join("bin")).unwrap();
+        std::fs::write(rootfs.join("bin/sh"), b"#!/bin/sh").unwrap();
+        // A second sandbox on the same node must be left strictly alone.
+        let other = root.path().join("d4e5f6").join("podshare");
+        std::fs::create_dir_all(&other).unwrap();
+
+        remove_share_tree(root.path(), sandbox);
+
+        assert!(
+            !root.path().join(sandbox).exists(),
+            "share tree survived sandbox teardown"
+        );
+        assert!(other.exists(), "teardown removed an unrelated sandbox");
+
+        // Teardown runs from more than one path, so a tree that is already gone
+        // is the normal case, not an error.
+        remove_share_tree(root.path(), sandbox);
+    }
+
+    #[test]
+    fn a_share_tree_path_cannot_climb_out_of_the_share_root() {
+        let root = Path::new(POD_SHARE_HOST_ROOT);
+        assert_eq!(
+            share_tree_in(root, "a1b2c3"),
+            Some(root.join("a1b2c3")),
+            "an ordinary containerd id must resolve"
+        );
+        for bad in ["", ".", "..", "../..", "a/b", "..\\x"] {
+            assert_eq!(share_tree_in(root, bad), None, "accepted id {bad:?}");
+        }
+    }
+
+    /// The tree removed on teardown is the PARENT of the dir handed to the VM,
+    /// so the per-sandbox `podshare` goes with it rather than being orphaned.
+    #[test]
+    fn the_share_tree_is_the_parent_of_the_dir_mounted_into_the_vm() {
+        let root = Path::new(POD_SHARE_HOST_ROOT);
+        let mounted = root.join("a1b2c3").join("podshare");
+        assert_eq!(
+            share_tree_in(root, "a1b2c3").as_deref(),
+            mounted.parent(),
+            "teardown must remove the sandbox dir, not just its podshare"
         );
     }
 }

--- a/crates/smolvm-shim/src/service.rs
+++ b/crates/smolvm-shim/src/service.rs
@@ -60,14 +60,23 @@ impl Shim for Service {
         // state from disk, so a fresh process can still find and kill the VM.
         // Best-effort — a missing machine (a container-task delete, or a VM
         // already cleaned by the graceful path) is not an error.
+        //
+        // The host share tree is keyed by that same sandbox id and leaks the same
+        // way, so it goes here too. On this path it is the expensive one: the
+        // per-container delete never ran, so the tree still holds full image
+        // rootfs copies.
         let id = self.id.clone();
-        let _ = tokio::task::spawn_blocking(move || match smolvm::embedded::runtime() {
-            Ok(rt) => {
-                if let Err(e) = rt.delete_machine(&id) {
-                    warn!("delete_shim: reaping VM {id} failed (may already be gone): {e}");
+        let _ = tokio::task::spawn_blocking(move || {
+            match smolvm::embedded::runtime() {
+                Ok(rt) => {
+                    if let Err(e) = rt.delete_machine(&id) {
+                        warn!("delete_shim: reaping VM {id} failed (may already be gone): {e}");
+                    }
                 }
+                Err(e) => warn!("delete_shim: runtime unavailable, cannot reap VM {id}: {e}"),
             }
-            Err(e) => warn!("delete_shim: runtime unavailable, cannot reap VM {id}: {e}"),
+            // Independent of the runtime being reachable at all.
+            crate::engine::remove_sandbox_share_tree(&id);
         })
         .await;
         Ok(DeleteResponse {


### PR DESCRIPTION
There's leakage and pile-up of files from a pod in two places, and nothing ever cleans up either of them: one set inside the sandbox VM, and one on the node outside it. The files inside the VM sit outside the container because they have to. The mounts have to be laid down and the writable layer stacked before the container is started at all, and our cleanup only covered what the bundle owns, so the rest was never deleted. Every restart gets a fresh container ID, so each restart piles up another set; deleting the pod does reclaim the VM's disk, but nothing ever reclaims the tree left on the node. This makes delete actually clean up both, keyed on the same ID that created them.

---

Fixes the two leaks measured in #901. Two commits, one per leak, reviewable independently.

Starting a pod container creates two per-container trees in the guest, the crun bundle under `/storage/containers/pods/<id>` and the writable overlay plus materialized CRI mounts under `/storage/pods/<id>`, and `PodDelete` removed only the first, never unmounting `merged`. The `umount2` inside `mount_writable_rootfs` cannot cover the gap because it is keyed to the id it is about to mount, so it only ever clears a retry of the same container, and CRI allocates a fresh id per restart. Delete now owns both trees, detaching `merged` **before** removing the tree rather than after, the other order recurses into a live overlay and deletes through it, destroying what the lower is showing and still leaving the mount behind. Both creation sites and the stale-mount drop now go through one `pod_overlay_dir` accessor so the root cannot drift between them again.

On the host, `POD_SHARE_HOST_ROOT` appeared exactly twice in the crate, the constant and one `create_dir_all`, while three teardown paths held the sandbox id and all three reaped the VM keyed by that id and ignored the directory keyed by the same id. All three now remove it: the graceful sandbox delete, `delete_shim`'s crash recovery, and the stale-record replacement in `create_sandbox`. This is deliberately not left to the startup reconcile: the graceful path deletes the machine record first, and the reconcile only walks surviving records, so the orphan is invisible to it by construction. Reconcile stays a backstop for the crash profile, not the fix. The sandbox id is checked before it reaches `remove_dir_all` instead of trusted, and every removal is best-effort and logged, so cleanup cannot wedge a CRI delete.

**Unchanged on purpose:** a *running* container keeps its overlay, its bundle, and its host rootfs copy, verified live. `/storage/containers/pods` behaves exactly as before. Nodes already carrying residue are not swept; that needs a separate decision (noted in #901).

### Validation

Real KVM node, k3s v1.36.3+k3s1 / containerd v2.3.3 / AppArmor enforcing / kernel 6.8.0-136 / guest 6.12.95. Same helpers, same node, before and after.

| | before | after |
|---|---|---|
| crash-loop, 4 restarts × 2 containers | 9 overlay dirs, 9 stale mounts, `/storage` 41 MB | **0, 0, 72 KiB** |
| delete the crash-looping pod | 1 share tree, 4.1 MB (full rootfs stranded) | **0 trees** |
| 3 graceful create/delete cycles | +1 tree each → 4 trees | **0, 0, 0** |
| `SIGKILL` the shim, containerd recovers | tree remains, 4.1 MB, 1 rootfs copy | **removed, 0 copies** |
| end state | 5 trees, 8.2 MB | **0 trees** |

Control: a normal pod still boots as a VM (`SMOLVM_K8S_E2E_OK`, `kernel: Linux 6.12.95`), `kubectl exec` works, and while running it holds exactly 1 overlay + 1 bundle + 1 host copy; after delete, 0 trees and 0 VMs.

Gates run locally: `cargo fmt --all -- --check`; `cargo clippy --all-targets -- -D warnings`; `cargo test --lib` (542 passed); `cargo test -p smolvm-agent --bins` (124 passed); workspace clippy for `aarch64-unknown-linux-gnu` with `-Dwarnings` (clean). The two Linux-only suites were cross-built and executed on the node: agent 134 passed, shim 6 passed. Each new test was confirmed to fail with the fix neutered, `writable overlay survived delete` and `share tree survived sandbox teardown`, rather than assumed to.

⚠ Limits: arm64 only, no x86_64 run. The node is AppArmor-enforcing, so the validated shim binary was this branch merged with #849 (throwaway branch, never pushed); #849 touches no cleanup path and the agent source is identical across both. The `create_sandbox` stale-record path is covered by its unit test but was not reached live, `sv2-crash` exercises `delete_shim` instead. `deploy/k3s/e2e-test.sh` is flaky on this node independent of this change (old binaries 1/3 pass, new 2/3); it reads pod logs the instant the pod goes Ready and races the workload's own output.

---

### Rebased 2026-08-24 onto `6f905411`

Rebased after #1052, #1053 and #1054 moved the pod and shim surface this morning. **0 behind, mergeable.**

The only conflict was test adjacency in `crates/smolvm-shim/src/engine.rs`, #1054 appends `sandbox_gpu_request` tests and this branch appends share-tree teardown tests to the same `mod tests`. Both sets are kept; no production line of either change was touched.

**Both leaks re-verified on `6f905411` after that work**, so nothing here is stale: the delete path at `crates/smolvm-agent/src/pod.rs:781` still removes only `pod_dir(id)` (`POD_STATE_DIR` = `/storage/containers/pods`), while `mount_writable_rootfs` at `:1271` and the CRI mount staging at `:1061` both still build under the hardcoded `/storage/pods`. #1053's single added line in `pod.rs` is a Vulkan bind mount and does not touch teardown.

**One note on the validation above:** it was run against a shim built from this branch merged with #849. **#849 is now closed**, it could not reach green because its e2e depends on #889, which is still open. That does not affect these numbers (#849 touches no cleanup path, and the agent source was identical across both), but the exact binary that produced the table is no longer reconstructible from two open branches. The shim tests are `#[cfg(target_os = "linux")]`, so they compile out on macOS and CI is the Linux evidence for this rebase.
