### PR TITLE
Restore net-enabled libkrun on macOS and document the real networkBackend default (fixes #884)

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -140,6 +140,17 @@ script = [
 '''
 set -e
 ARCH=$(uname -m)
+# krun-init (the guest's PID-1 bootstrap embedded in libkrun) must be a STATIC
+# linux binary. Without the musl target, libkrun's build only WARNS and links
+# it dynamically — the resulting lib configures VMs fine but every guest exits
+# on boot ("boot process exited (code 0) before the agent was ready").
+RUST_ARCH="$ARCH"; [ "$RUST_ARCH" = "arm64" ] && RUST_ARCH=aarch64
+if ! rustup target list --installed 2>/dev/null | grep -q "${RUST_ARCH}-unknown-linux-musl"; then
+  echo "error: rust target ${RUST_ARCH}-unknown-linux-musl is not installed;"
+  echo "krun-init would be dynamically linked and no guest would boot."
+  echo "Fix: rustup target add ${RUST_ARCH}-unknown-linux-musl"
+  exit 1
+fi
 make -C libkrun BLK=1 NET=1 GPU=1
 if [ "$(uname -s)" = "Darwin" ]; then
   # macOS: the dylib lives in lib/ (alongside libkrunfw.5.dylib).

--- a/scripts/check-krun-exports.sh
+++ b/scripts/check-krun-exports.sh
@@ -24,7 +24,24 @@ if [ "${#REQUIRED[@]}" -eq 0 ]; then
   echo "ERROR: parsed 0 required symbols from $KRUN_RS — check the load_sym! pattern"
   exit 1
 fi
-echo "smolvm requires ${#REQUIRED[@]} krun symbols (load_sym!):"
+
+# Some load_optional_sym! symbols are optional only at dlsym time: a DEFAULT-
+# shaped launch hard-errors without them (issue #884 — a 1.7.5 dylib built
+# without NET=1 shipped green, then every serve/API machine failed with
+# "libkrun does not expose krun_add_net_unixstream"). Require those too, so a
+# lib rebuilt with the wrong feature set can't sail through CI again.
+REQUIRED_DEFAULT_PATH=(
+  krun_add_net_unixstream  # virtio-net attach — the DEFAULT backend under
+                           # serve/ports/egress-policy/fleet; launcher.rs and
+                           # launcher_dynamic.rs error without it (needs NET=1)
+  krun_set_egress_policy   # --allow-cidr/--allow-host egress enforcement;
+                           # launcher hard-errors when a policy is configured
+  krun_create_disk_overlay # copy-on-write disk overlays for fork/clone;
+                           # create_disk_overlays() hard-errors without it
+)
+REQUIRED+=("${REQUIRED_DEFAULT_PATH[@]}")
+
+echo "smolvm requires ${#REQUIRED[@]} krun symbols (load_sym! + default-path):"
 printf '  %s\n' "${REQUIRED[@]}"
 echo
 

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -113,8 +113,14 @@ pub struct ResourceSpec {
     /// them by name. Combine with `allowed_cidrs` to also permit fixed ranges.
     #[serde(default)]
     pub allowed_hosts: Option<Vec<String>>,
-    /// Network backend: `tsi` (default, outbound-only) or `virtio-net`
-    /// (required for published `ports`). Omit for the default (TSI).
+    /// Network backend: `tsi` (outbound-only) or `virtio-net`.
+    ///
+    /// When omitted the backend is chosen from context: machines managed by
+    /// `smolvm serve` (every API machine), machines with published `ports`,
+    /// an egress policy (`allowedCidrs`/`allowedHosts`) or fleet mode default
+    /// to `virtio-net`; only outbound-only machines launched outside `serve`
+    /// (plain CLI) default to `tsi`. Set `tsi` explicitly to force the
+    /// lighter outbound-only backend (rejected alongside published `ports`).
     #[serde(default)]
     pub network_backend: Option<crate::network::NetworkBackend>,
 }
@@ -535,8 +541,15 @@ pub struct CreateMachineRequest {
     /// names are learned into the egress allow-list.
     #[serde(default)]
     pub allowed_hosts: Option<Vec<String>>,
-    /// Network backend: `tsi` (default, outbound-only) or `virtio-net`.
-    /// Published `ports` require `virtio-net` (TSI has no inbound path).
+    /// Network backend: `tsi` (outbound-only) or `virtio-net`.
+    ///
+    /// When omitted, machines created through the API default to `virtio-net`:
+    /// the server configures a guest host-service (the rollout ingress), and
+    /// published `ports`, egress policies and fleet mode need virtio-net too.
+    /// (`tsi` is the default only for outbound-only machines launched outside
+    /// `smolvm serve`.) Set `tsi` explicitly for the lighter outbound-only
+    /// backend; published `ports` require `virtio-net` (TSI has no inbound
+    /// path), so that combination is rejected.
     #[serde(default)]
     pub network_backend: Option<crate::network::NetworkBackend>,
     /// Restart policy configuration.
@@ -613,8 +626,10 @@ pub struct MachineInfo {
     pub ports: Vec<PortSpec>,
     /// Whether outbound network access is enabled.
     pub network: bool,
-    /// Network backend the machine runs (`tsi` or `virtio-net`). Omitted when
-    /// unset (the default TSI). Echoes back what `create` accepted.
+    /// Network backend the machine runs (`tsi` or `virtio-net`). Echoes back
+    /// what `create` accepted; omitted when `create` left it unset (the
+    /// launch then picks the contextual default — `virtio-net` under
+    /// `smolvm serve`, with ports, or with an egress policy; `tsi` otherwise).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub network_backend: Option<crate::network::NetworkBackend>,
     /// Allowed egress CIDRs. Omitted when unrestricted; an empty list denies all.

--- a/src/network/launch.rs
+++ b/src/network/launch.rs
@@ -123,6 +123,12 @@ pub fn plan_launch_network(
     // enforce it (verified: a non-allowed IP stays reachable under TSI). Falling
     // to TSI here would make the egress flags a silent no-op — a security hole —
     // so a policy forces virtio-net unless the caller explicitly picked a backend.
+    //
+    // A configured guest host-service (the rollout ingress `serve` always sets
+    // up) likewise forces virtio-net: the guest reaches it through the virtio
+    // gateway's port mapping, which TSI doesn't provide. Net effect: EVERY
+    // networked machine under `serve` defaults to virtio-net — keep the API
+    // schema docs on `networkBackend` (src/api/types.rs) in sync with this.
     let fleet_mode = std::env::var_os("SMOLVM_PUBLISH_ADDR").is_some();
     let backend = resources.network_backend.unwrap_or(
         if has_ports || fleet_mode || has_cidr_policy || has_dns_filter || has_host_service {

--- a/tests/network_backend_default.rs
+++ b/tests/network_backend_default.rs
@@ -1,0 +1,45 @@
+//! The backend default is contextual (issue #884): a machine with networking
+//! and no explicit `networkBackend` gets TSI on a bare CLI launch, but
+//! virtio-net once the guest host-service is configured — which `serve` does
+//! unconditionally, so every networked API machine defaults to virtio-net.
+//! This pins the behavior the API schema documents (src/api/types.rs).
+//!
+//! Lives in its own integration-test binary because the host-service signal is
+//! process-global (a one-shot static + `SMOLVM_GUEST_HOST_SERVICE`); mutating
+//! it inside the unit-test binary would poison the launch.rs default tests.
+
+use smolvm::data::resources::VmResources;
+use smolvm::network::launch::{
+    plan_launch_network, validate_requested_network_backend, EffectiveNetworkBackend,
+};
+
+const HOST_SERVICE_ENV: &str = "SMOLVM_GUEST_HOST_SERVICE";
+
+#[test]
+fn host_service_flips_the_default_backend_to_virtio_net() {
+    // Single test function: the env var is process-wide, and cargo runs tests
+    // in the same binary concurrently — sequential phases avoid the race.
+    std::env::remove_var(HOST_SERVICE_ENV);
+
+    let resources = VmResources {
+        network: true,
+        ..Default::default()
+    };
+
+    // Outside serve (no host-service): outbound-only default stays TSI.
+    let plan = plan_launch_network(&resources, None, 0);
+    assert_eq!(plan.backend, EffectiveNetworkBackend::Tsi);
+
+    // With the host-service configured (what `serve` always does via
+    // configure_guest_host_service; the env var is the inherited form the
+    // spawned `_boot-vm` sees): the default becomes virtio-net.
+    std::env::set_var(HOST_SERVICE_ENV, "4500:4500");
+    let plan = plan_launch_network(&resources, None, 0);
+    assert_eq!(plan.backend, EffectiveNetworkBackend::VirtioNet);
+
+    // And validation accepts the defaulted shape (no ports, no policy).
+    validate_requested_network_backend(&resources, None, 0)
+        .expect("default-shaped networked machine under serve must validate");
+
+    std::env::remove_var(HOST_SERVICE_ENV);
+}


### PR DESCRIPTION
## Problem

Issue #884: on 1.7.5 / darwin-arm64, a machine created through the API without `networkBackend` failed to start with "libkrun does not expose krun_add_net_unixstream". Two combined causes:

1. The `830c856` rebuild of the bundled libs was made without `NET=1`, so the macOS dylib and Windows DLL lost the `krun_add_net_*` exports (1.7.4 had them; `2fce46c` fixed the identical lapse once before). The broken binaries themselves are fixed on main by `bca7975`/`a50815b`, which this PR is rebased on. CI never caught it because `check-krun-exports.sh` only enforces `load_sym!` symbols, while `krun_add_net_unixstream` is loaded via `load_optional_sym!` yet hard-required whenever virtio-net is selected.
2. Since `cc9befc`, `serve` unconditionally configures the guest rollout host-service and `plan_launch_network` then defaults every networked machine to virtio-net, while the OpenAPI schema still claimed `tsi` was the default. So every default-shaped API machine walks into the missing symbol.

## Changes

- **scripts:** `check-krun-exports.sh` now also requires symbols that default code paths hard-fail without: `krun_add_net_unixstream`, `krun_set_egress_policy`, `krun_create_disk_overlay`. All are exported by the correctly built libs on every platform (verified against the current bundles, including `krun.dll`), so a wrong-feature rebuild can no longer ship green.
- **build:** `build-libkrun` refuses to run when the `<arch>-unknown-linux-musl` rust target is missing. Without it, libkrun's build only warns and embeds a dynamically linked `krun-init`; the resulting lib passes every export and provenance check, configures VMs normally, and then every guest exits at boot with "boot process exited (code 0) before the agent was ready" and an empty console. This failure mode has now bitten two independent rebuilds (my first attempt for this PR, and apparently the one `bca7975` replaced), so the recipe fails fast instead of degrading silently. (Static linking also needs `lld` on macOS hosts: `brew install lld`.)
- **api:** keep the (deliberate) virtio-net-under-serve behavior and align the schema docs on `CreateMachineRequest`/`ResourceSpec`/`MachineInfo` with the real conditional default, plus a comment in `plan_launch_network` and an integration test pinning the host-service default flip (own test binary, since the signal is process-global).

## Follow-up suggestion

Extend `build-libkrun.yml` with a macOS job (and a mingw cross job for `krun.dll`, next to the existing `libkrunfw.dll` one) so CI is the only producer of the bundled blobs and by-hand rebuilds with wrong flags become impossible.

## Verification

- `check-krun-exports.sh` passes against all four bundled libs on current main with no exceptions; `check-libkrun-provenance.sh`, the `network::launch` unit tests and the new integration test all pass.
- The fix path itself was verified end to end on darwin-arm64 while diagnosing: with a net-enabled dylib, a default-shaped API machine (`POST /machines` with `network: true`, no `networkBackend`) reaches `running` under virtio-net, and an `--allow-host` machine enforces its egress allow-list.


(NOTE: the fix has been AI assisted and the above PR text too, but am I a human. I fixed this to scratch my own itch, since I'm using smolvm in another project and I needed this fixed)