### PR TITLE
Stop the guest resolver returning AAAA records when the host has no route to the IPv6 internet

### DIFF
--- a/crates/smolvm-agent/src/network/linux.rs
+++ b/crates/smolvm-agent/src/network/linux.rs
@@ -302,6 +302,8 @@ fn add_default_route_v6(gateway: Ipv6Addr) -> Result<(), String> {
         .map_err(|err| format!("failed to add default IPv6 route via {}: {}", gateway, err))
 }
 
+use super::resolv_conf_options;
+
 /// Replace `/etc/resolv.conf` with the gateway-side resolver.
 ///
 /// Outcome:
@@ -312,7 +314,7 @@ fn add_default_route_v6(gateway: Ipv6Addr) -> Result<(), String> {
 /// DNS configuration in a minimal Linux guest is usually conveyed through
 /// `/etc/resolv.conf`, and that is enough for the MVP.
 fn write_resolv_conf(dns_server: Ipv4Addr) -> Result<(), String> {
-    let contents = format!("nameserver {}\n", dns_server);
+    let contents = format!("nameserver {}\n{}", dns_server, resolv_conf_options());
     let direct_err = match std::fs::write("/etc/resolv.conf", &contents) {
         Ok(()) => return Ok(()),
         Err(err) => err,

--- a/crates/smolvm-agent/src/network/mod.rs
+++ b/crates/smolvm-agent/src/network/mod.rs
@@ -208,6 +208,41 @@ fn parse_mac(value: &str) -> Result<[u8; 6], String> {
     Ok(mac)
 }
 
+/// The resolv.conf line that stops the resolver asking for AAAA records.
+///
+/// `options no-aaaa` (glibc 2.36+) makes `getaddrinfo` skip the AAAA query
+/// outright. Older glibc ignores the unknown option rather than erroring, and
+/// musl ignores it too, so writing it is safe everywhere and effective where it
+/// matters. It is not a substitute for giving hosts real IPv6 egress.
+const NO_AAAA_OPTION: &str = "options no-aaaa";
+
+/// The resolv.conf suffix for this boot: the no-AAAA option where the host said
+/// it has no IPv6 egress, otherwise nothing.
+///
+/// A guest reaches the outside world through a host socket, so it can only use
+/// an IPv6 address where the *host* has an IPv6 route. Where the host is
+/// IPv4-only, a AAAA answer is a trap: the connect fails, and clients diverge
+/// sharply in how they cope. Anything doing Happy Eyeballs (node's `fetch`,
+/// curl, most browsers) races both families and never notices; anything that
+/// commits to the first answer stalls until its own timeout and reports a
+/// connectivity error for a name that resolves perfectly well over IPv4 — which
+/// is exactly how this was found, as a coding agent that hung for 30s per
+/// attempt while every hand-written probe from the same shell passed.
+///
+/// Only the host can see whether that route exists, so it decides and sets
+/// [`guest_env::NO_AAAA`]; suppressing unconditionally would take working IPv6
+/// away from guests on hosts that have it. Both resolv.conf writers use this —
+/// the virtio-net one in `linux.rs` and the overlay one in `storage.rs` that
+/// covers TSI — so the backend a guest happens to get never decides whether its
+/// resolver hands it addresses it cannot connect to.
+pub fn resolv_conf_options() -> String {
+    if std::env::var(guest_env::NO_AAAA).as_deref() == Ok("1") {
+        format!("{NO_AAAA_OPTION}\n")
+    } else {
+        String::new()
+    }
+}
+
 #[cfg(target_os = "linux")]
 mod linux;
 

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -2524,8 +2524,14 @@ impl OverlaySetup {
 }
 
 fn overlay_resolv_conf_contents() -> String {
+    // Whichever resolver the guest ends up with, it reaches the network through
+    // a host socket, so it must not be handed AAAA answers the host cannot
+    // route. See `network::resolv_conf_options`.
+    let with_options =
+        |nameservers: &str| format!("{nameservers}{}", crate::network::resolv_conf_options());
+
     if std::env::var(guest_env::DNS_FILTER).as_deref() == Ok("1") {
-        return "nameserver 127.0.0.1\n".to_string();
+        return with_options("nameserver 127.0.0.1\n");
     }
 
     // A nameserver supplied by the host (SMOLVM_NETWORK_DNS) wins for either
@@ -2534,11 +2540,11 @@ fn overlay_resolv_conf_contents() -> String {
     // public resolvers when the host didn't specify one.
     if let Ok(dns_server) = std::env::var(guest_env::DNS) {
         if !dns_server.is_empty() {
-            return format!("nameserver {}\n", dns_server);
+            return with_options(&format!("nameserver {}\n", dns_server));
         }
     }
 
-    "nameserver 8.8.8.8\nnameserver 1.1.1.1\n".to_string()
+    with_options("nameserver 8.8.8.8\nnameserver 1.1.1.1\n")
 }
 
 /// Prepare an overlay filesystem for a workload.
@@ -4484,6 +4490,7 @@ mod tests {
     fn overlay_resolv_conf_uses_localhost_when_dns_filter_enabled() {
         let _guard = env_lock().lock().unwrap();
         std::env::set_var(guest_env::DNS_FILTER, "1");
+        std::env::remove_var(guest_env::NO_AAAA);
         std::env::remove_var(guest_env::BACKEND);
         std::env::remove_var(guest_env::DNS);
 
@@ -4496,6 +4503,7 @@ mod tests {
     fn overlay_resolv_conf_uses_virtio_dns_server() {
         let _guard = env_lock().lock().unwrap();
         std::env::remove_var(guest_env::DNS_FILTER);
+        std::env::remove_var(guest_env::NO_AAAA);
         std::env::set_var(guest_env::BACKEND, guest_env::BACKEND_VIRTIO_NET);
         std::env::set_var(guest_env::DNS, "100.96.0.1");
 
@@ -4511,6 +4519,7 @@ mod tests {
         // must honor the custom resolver (--dns) rather than the public default.
         let _guard = env_lock().lock().unwrap();
         std::env::remove_var(guest_env::DNS_FILTER);
+        std::env::remove_var(guest_env::NO_AAAA);
         std::env::remove_var(guest_env::BACKEND);
         std::env::set_var(guest_env::DNS, "100.100.100.100");
 
@@ -4526,6 +4535,7 @@ mod tests {
     fn overlay_resolv_conf_defaults_to_public_resolvers() {
         let _guard = env_lock().lock().unwrap();
         std::env::remove_var(guest_env::DNS_FILTER);
+        std::env::remove_var(guest_env::NO_AAAA);
         std::env::remove_var(guest_env::BACKEND);
         std::env::remove_var(guest_env::DNS);
 
@@ -4533,6 +4543,44 @@ mod tests {
             overlay_resolv_conf_contents(),
             "nameserver 8.8.8.8\nnameserver 1.1.1.1\n"
         );
+    }
+
+    /// The host says it has no IPv6 route, so the guest must stop asking for
+    /// AAAA records. This is the TSI shape a cloud machine boots with, and the
+    /// one that made coding agents hang on IPv4-only workers.
+    #[test]
+    fn overlay_resolv_conf_suppresses_aaaa_when_host_lacks_ipv6() {
+        let _guard = env_lock().lock().unwrap();
+        std::env::remove_var(guest_env::DNS_FILTER);
+        std::env::remove_var(guest_env::BACKEND);
+        std::env::set_var(guest_env::DNS, "100.100.100.100");
+        std::env::set_var(guest_env::NO_AAAA, "1");
+
+        assert_eq!(
+            overlay_resolv_conf_contents(),
+            "nameserver 100.100.100.100\noptions no-aaaa\n"
+        );
+
+        std::env::remove_var(guest_env::NO_AAAA);
+        std::env::remove_var(guest_env::DNS);
+    }
+
+    /// A host with IPv6 egress keeps it: suppression must not be the default,
+    /// or guests lose working IPv6 everywhere to fix the hosts that lack it.
+    #[test]
+    fn overlay_resolv_conf_keeps_aaaa_when_host_has_ipv6() {
+        let _guard = env_lock().lock().unwrap();
+        std::env::remove_var(guest_env::DNS_FILTER);
+        std::env::remove_var(guest_env::BACKEND);
+        std::env::remove_var(guest_env::NO_AAAA);
+        std::env::set_var(guest_env::DNS, "100.100.100.100");
+
+        assert_eq!(
+            overlay_resolv_conf_contents(),
+            "nameserver 100.100.100.100\n"
+        );
+
+        std::env::remove_var(guest_env::DNS);
     }
 
     #[test]

--- a/crates/smolvm-protocol/src/guest_env.rs
+++ b/crates/smolvm-protocol/src/guest_env.rs
@@ -93,6 +93,19 @@ pub const GATEWAY6: &str = "SMOLVM_NETWORK_GATEWAY6";
 pub const PREFIX_LEN6: &str = "SMOLVM_NETWORK_PREFIX_LEN6";
 /// Guest-visible DNS server IPv4 address.
 pub const DNS: &str = "SMOLVM_NETWORK_DNS";
+/// Set to `1` when the host has no route to the IPv6 internet, telling the
+/// agent to write `options no-aaaa` into the guest's resolv.conf.
+///
+/// The guest reaches the network through a host socket, so whether an AAAA
+/// answer is usable is a fact about the *host*, which the guest cannot observe.
+/// The host decides and says so here. Absent → the guest resolves normally and
+/// keeps working IPv6, so this suppression appears only where it is needed.
+///
+/// It applies at overlay creation, not per boot: an image machine's resolv.conf
+/// is written into the overlay upper layer once and reused on every later start.
+/// So a host that gains IPv6 egress frees new machines, while ones created
+/// before it keep the option until their overlay is rebuilt.
+pub const NO_AAAA: &str = "SMOLVM_NETWORK_NO_AAAA";
 /// Enables the guest-side DNS filtering proxy.
 pub const DNS_FILTER: &str = "SMOLVM_DNS_FILTER";
 /// Enables the guest-side Docker socket bridge: the agent listens on the

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -90,6 +90,9 @@ pub(crate) fn guest_network_env(
     let mut push = |key: &str, val: String| {
         env.push(std::ffi::CString::new(format!("{key}={val}")).expect("env var contains NUL"));
     };
+    if !host_has_ipv6_egress() {
+        push(guest_env::NO_AAAA, "1".to_string());
+    }
     if let Some(n) = guest_network {
         push(
             guest_env::BACKEND,
@@ -107,6 +110,32 @@ pub(crate) fn guest_network_env(
         push(guest_env::DNS, dns.to_string());
     }
     env
+}
+
+/// Does this host have a route to the IPv6 internet?
+///
+/// A guest's egress leaves through a host socket, so a AAAA answer is only
+/// usable where the host itself can reach IPv6. Where it cannot, the guest's
+/// resolver must stop returning AAAA records — glibc orders them first, so a
+/// client that takes the first result connects to an unroutable address and
+/// stalls until its own timeout, reporting a connectivity failure for a name
+/// that resolves perfectly well over IPv4.
+///
+/// `connect` on a UDP socket sends no packets; it only performs a route lookup.
+/// So this asks the kernel "is there a route?" without touching the network, and
+/// answers in microseconds. The address is a well-known public resolver used
+/// purely as a routing target — nothing is sent to it.
+///
+/// Cached: this is a property of the host, and the boot path is latency-critical.
+/// A host that gains or loses IPv6 needs the daemon restarted to be noticed,
+/// which is the right trade for keeping this off the per-boot path.
+fn host_has_ipv6_egress() -> bool {
+    static CACHE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *CACHE.get_or_init(|| {
+        std::net::UdpSocket::bind("[::]:0")
+            .and_then(|sock| sock.connect("[2001:4860:4860::8888]:53"))
+            .is_ok()
+    })
 }
 
 fn format_mac(mac: [u8; 6]) -> String {


### PR DESCRIPTION
A guest's egress leaves through a host socket, so where the host has no IPv6 route an AAAA answer is unusable and clients that commit to it stall until their own timeout, so the host now probes for an IPv6 route and tells the agent to write `options no-aaaa` only in that case, leaving guests on IPv6-capable hosts untouched.