### PR TITLE
Require the libkrun symbols whose absence hard-fails at machine start, and describe the real network backend default

### DIFF
--- a/scripts/check-krun-exports.sh
+++ b/scripts/check-krun-exports.sh
@@ -10,21 +10,43 @@
 # `blk`/disk API) sails through green and breaks only on a user's machine.
 # This check is that missing dlopen, done statically at build time.
 #
-# Optional symbols (load_optional_sym!) are intentionally NOT required.
+# Most optional symbols (load_optional_sym!) are genuinely optional and NOT
+# required. Some are not: they are resolved optionally because the struct field
+# is an `Option`, but every code path that uses them turns `None` into a hard
+# error rather than falling back. Checking only the load_sym! set is what let a
+# libkrun built without `NET=1` ship green and then fail at machine start with
+# "libkrun does not expose krun_add_net_unixstream" — a dlopen-time contract the
+# dlopen never got to enforce, because the symbol resolves lazily to None.
+# Those are tagged `// required-export` in krun.rs, next to the line that loads
+# them, so the list cannot drift from the code the way a copy here would.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 KRUN_RS="$ROOT/src/agent/krun.rs"
 
-# Source of truth: the identifiers passed to load_sym!(...) (required), not the
-# string literals passed to load_optional_sym!(...) (optional).
-mapfile -t REQUIRED < <(grep -oE 'load_sym!\(krun_[a-z0-9_]+\)' "$KRUN_RS" \
-  | sed -E 's/.*\((krun_[a-z0-9_]+)\)/\1/' | sort -u)
+# Source of truth: identifiers passed to load_sym!(...), plus the string
+# literals of load_optional_sym!(...) lines tagged `// required-export`.
+mapfile -t REQUIRED < <({
+  grep -oE 'load_sym!\(krun_[a-z0-9_]+\)' "$KRUN_RS" \
+    | sed -E 's/.*\((krun_[a-z0-9_]+)\)/\1/'
+  grep -E 'load_optional_sym!\("krun_[a-z0-9_]+"\).*// required-export' "$KRUN_RS" \
+    | grep -oE 'krun_[a-z0-9_]+'
+} | sort -u)
 if [ "${#REQUIRED[@]}" -eq 0 ]; then
   echo "ERROR: parsed 0 required symbols from $KRUN_RS — check the load_sym! pattern"
   exit 1
 fi
-echo "smolvm requires ${#REQUIRED[@]} krun symbols (load_sym!):"
+# A tag that stops matching (renamed macro, reworded comment) would silently
+# shrink the required set back to the load_sym! list, which is the exact failure
+# this check exists to prevent. Assert the tagged ones are actually in it.
+for tagged in $(grep -E '// required-export' "$KRUN_RS" | grep -oE 'krun_[a-z0-9_]+'); do
+  printf '%s\n' "${REQUIRED[@]}" | grep -qxF "$tagged" || {
+    echo "ERROR: '$tagged' is tagged // required-export in $KRUN_RS but was not parsed"
+    echo "into the required set — the load_optional_sym! pattern in this script has drifted."
+    exit 1
+  }
+done
+echo "smolvm requires ${#REQUIRED[@]} krun symbols (load_sym! + required-export):"
 printf '  %s\n' "${REQUIRED[@]}"
 echo
 

--- a/src/agent/krun.rs
+++ b/src/agent/krun.rs
@@ -143,18 +143,26 @@ impl KrunFunctions {
         let add_disk2 = load_sym!(krun_add_disk2);
         let add_vsock_port2 = load_sym!(krun_add_vsock_port2);
         let add_virtiofs = load_sym!(krun_add_virtiofs);
-        let add_virtiofs3 = load_optional_sym!("krun_add_virtiofs3");
+        let add_virtiofs3 = load_optional_sym!("krun_add_virtiofs3"); // required-export
         let start_enter = load_sym!(krun_start_enter);
         let add_vsock = load_sym!(krun_add_vsock);
         let add_virtio_console_default = load_sym!(krun_add_virtio_console_default);
-        let set_egress_policy = load_optional_sym!("krun_set_egress_policy");
-        let add_net_unixstream = load_optional_sym!("krun_add_net_unixstream");
+
+        // Symbols below are resolved optionally because the struct holds them as
+        // `Option`, but the code paths that use them have no fallback: they turn a
+        // missing symbol into a hard error. A lib built without the matching
+        // feature therefore loads fine and fails later, at machine start, on that
+        // platform only. `// required-export` marks those so
+        // scripts/check-krun-exports.sh refuses to ship such a lib — the export
+        // check is the dlopen that CI never performs.
+        let set_egress_policy = load_optional_sym!("krun_set_egress_policy"); // required-export
+        let add_net_unixstream = load_optional_sym!("krun_add_net_unixstream"); // required-export
         let get_egress_handle = load_optional_sym!("krun_get_egress_handle");
         let set_gpu_options2 = load_optional_sym!("krun_set_gpu_options2");
         let get_guest_ram = load_optional_sym!("krun_get_guest_ram");
         let set_control_socket = load_optional_sym!("krun_set_control_socket");
         let set_snapshot = load_optional_sym!("krun_set_snapshot");
-        let create_disk_overlay = load_optional_sym!("krun_create_disk_overlay");
+        let create_disk_overlay = load_optional_sym!("krun_create_disk_overlay"); // required-export
 
         Ok(Self {
             _handle: handle,

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -113,8 +113,16 @@ pub struct ResourceSpec {
     /// them by name. Combine with `allowed_cidrs` to also permit fixed ranges.
     #[serde(default)]
     pub allowed_hosts: Option<Vec<String>>,
-    /// Network backend: `tsi` (default, outbound-only) or `virtio-net`
-    /// (required for published `ports`). Omit for the default (TSI).
+    /// Network backend: `tsi` (outbound-only) or `virtio-net` (required for
+    /// published `ports`).
+    ///
+    /// Omit to let the server choose. The default is conditional, not always
+    /// `tsi`: a networked machine gets `virtio-net` whenever it publishes
+    /// ports, sets an egress policy (`allowed_cidrs`/`allowed_hosts`), or runs
+    /// under a server that enables the internal guest gateway — which the API
+    /// server does for every machine, so machines created through this API
+    /// default to `virtio-net`. Only an outbound-only machine with no policy
+    /// falls to `tsi`. Set this explicitly to pin a backend either way.
     #[serde(default)]
     pub network_backend: Option<crate::network::NetworkBackend>,
 }
@@ -535,8 +543,10 @@ pub struct CreateMachineRequest {
     /// names are learned into the egress allow-list.
     #[serde(default)]
     pub allowed_hosts: Option<Vec<String>>,
-    /// Network backend: `tsi` (default, outbound-only) or `virtio-net`.
-    /// Published `ports` require `virtio-net` (TSI has no inbound path).
+    /// Network backend: `tsi` (outbound-only) or `virtio-net`. Published
+    /// `ports` require `virtio-net` (TSI has no inbound path). Omitted means
+    /// the server chooses; see `CreateMachineRequest::network_backend` — the
+    /// choice is conditional and is `virtio-net` for API-created machines.
     #[serde(default)]
     pub network_backend: Option<crate::network::NetworkBackend>,
     /// Restart policy configuration.
@@ -613,8 +623,11 @@ pub struct MachineInfo {
     pub ports: Vec<PortSpec>,
     /// Whether outbound network access is enabled.
     pub network: bool,
-    /// Network backend the machine runs (`tsi` or `virtio-net`). Omitted when
-    /// unset (the default TSI). Echoes back what `create` accepted.
+    /// Network backend the machine runs (`tsi` or `virtio-net`). Echoes back
+    /// what `create` accepted, so it is omitted when the caller did not pin one
+    /// — the backend the machine actually runs is then the conditional default
+    /// described on `CreateMachineRequest::network_backend`, not necessarily
+    /// `tsi`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub network_backend: Option<crate::network::NetworkBackend>,
     /// Allowed egress CIDRs. Omitted when unrestricted; an empty list denies all.

--- a/tests/network_backend_default.rs
+++ b/tests/network_backend_default.rs
@@ -1,0 +1,50 @@
+//! The backend default flips to virtio-net once the internal guest gateway is
+//! enabled — which `serve` does for every server, so every networked machine
+//! created through the API runs virtio-net rather than TSI.
+//!
+//! This lived only in a comment, and the divergence it caused was invisible:
+//! the schema documented TSI, the server ran virtio-net, and a libkrun built
+//! without the net feature turned that gap into "machine cannot start" for the
+//! most ordinary request shape there is. Pin the flip so the documented default
+//! and the real one cannot drift apart again silently.
+//!
+//! Its own test binary on purpose: the gateway registration is a process-global
+//! set-once atomic, so a test that enables it would leak into every other test
+//! sharing the process and make their defaults depend on execution order.
+
+use smolvm::agent::VmResources;
+use smolvm::network::launch::{
+    configure_guest_host_service, plan_launch_network, EffectiveNetworkBackend,
+};
+
+#[test]
+fn guest_host_service_flips_the_default_to_virtio_net() {
+    let mut resources = VmResources::default();
+    resources.network = true;
+
+    // No ports, no egress policy, no gateway: the light outbound-only default.
+    assert_eq!(
+        plan_launch_network(&resources, None, 0).backend,
+        EffectiveNetworkBackend::Tsi,
+        "an outbound-only machine should take the lighter TSI path before the \
+         guest gateway is configured"
+    );
+
+    configure_guest_host_service(1, 1).expect("configure guest host service");
+
+    // Same request, same machine shape — the server-side gateway alone decides.
+    assert_eq!(
+        plan_launch_network(&resources, None, 0).backend,
+        EffectiveNetworkBackend::VirtioNet,
+        "once the guest gateway is configured every networked machine must run \
+         virtio-net, which is what `serve` does for all API-created machines"
+    );
+
+    // An explicit request still wins over the conditional default.
+    resources.network_backend = Some(smolvm::network::NetworkBackend::Tsi);
+    assert_eq!(
+        plan_launch_network(&resources, None, 0).backend,
+        EffectiveNetworkBackend::Tsi,
+        "an explicitly pinned backend must not be overridden by the default"
+    );
+}

--- a/tests/network_backend_default.rs
+++ b/tests/network_backend_default.rs
@@ -19,8 +19,10 @@ use smolvm::network::launch::{
 
 #[test]
 fn guest_host_service_flips_the_default_to_virtio_net() {
-    let mut resources = VmResources::default();
-    resources.network = true;
+    let mut resources = VmResources {
+        network: true,
+        ..Default::default()
+    };
 
     // No ports, no egress policy, no gateway: the light outbound-only default.
     assert_eq!(


### PR DESCRIPTION
The export check only enforced the eagerly-loaded symbols, so a libkrun built without networking passed CI and then failed at machine start, and the schema documented `tsi` as the backend default while a networked machine actually runs virtio-net whenever ports, an egress policy, or the internal guest gateway is present.