### PR TITLE
Bump the workspace to 1.7.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2985,7 +2985,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smolfile"
-version = "1.7.4"
+version = "1.7.5"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -3011,7 +3011,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.7.4"
+version = "1.7.5"
 dependencies = [
  "async-stream",
  "axum",
@@ -3070,7 +3070,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-agent"
-version = "1.7.4"
+version = "1.7.5"
 dependencies = [
  "flate2",
  "lazy_static",
@@ -3092,7 +3092,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda"
-version = "1.7.4"
+version = "1.7.5"
 dependencies = [
  "libc",
  "libloading",
@@ -3100,11 +3100,11 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda-codegen"
-version = "1.7.4"
+version = "1.7.5"
 
 [[package]]
 name = "smolvm-cuda-guest"
-version = "1.7.4"
+version = "1.7.5"
 dependencies = [
  "smolvm-cuda",
  "vsock",
@@ -3112,7 +3112,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda-shim"
-version = "1.7.4"
+version = "1.7.5"
 dependencies = [
  "libc",
  "smolvm-cuda",
@@ -3121,7 +3121,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cudart-shim"
-version = "1.7.4"
+version = "1.7.5"
 dependencies = [
  "libc",
  "smolvm-cuda",
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-network"
-version = "1.7.4"
+version = "1.7.5"
 dependencies = [
  "crossbeam-queue",
  "humantime",
@@ -3143,14 +3143,14 @@ dependencies = [
 
 [[package]]
 name = "smolvm-nvml-shim"
-version = "1.7.4"
+version = "1.7.5"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "smolvm-oci-layer"
-version = "1.7.4"
+version = "1.7.5"
 dependencies = [
  "flate2",
  "libc",
@@ -3163,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-pack"
-version = "1.7.4"
+version = "1.7.5"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -3182,7 +3182,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.7.4"
+version = "1.7.5"
 dependencies = [
  "base64",
  "serde",
@@ -3192,7 +3192,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.7.4"
+version = "1.7.5"
 dependencies = [
  "bytes",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ resolver = "2"
 
 [package]
 name = "smolvm"
-version = "1.7.4"
+version = "1.7.5"
 edition = "2021"
 description = "OCI-native microVM runtime"
 license = "Apache-2.0"
@@ -37,12 +37,12 @@ name = "smolvm"
 path = "src/main.rs"
 
 [dependencies]
-smolvm-network = { path = "crates/smolvm-network", version = "1.7.4" }
-smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.7.4" }
-smolvm-cuda = { path = "crates/smolvm-cuda", version = "1.7.4" }
-smolvm-pack = { path = "crates/smolvm-pack", version = "1.7.4" }
-smolvm-registry = { path = "crates/smolvm-registry", version = "1.7.4" }
-smolfile = { path = "crates/smolvm-smolfile", version = "1.7.4" }
+smolvm-network = { path = "crates/smolvm-network", version = "1.7.5" }
+smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.7.5" }
+smolvm-cuda = { path = "crates/smolvm-cuda", version = "1.7.5" }
+smolvm-pack = { path = "crates/smolvm-pack", version = "1.7.5" }
+smolvm-registry = { path = "crates/smolvm-registry", version = "1.7.5" }
+smolfile = { path = "crates/smolvm-smolfile", version = "1.7.5" }
 thiserror = "1"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
@@ -127,7 +127,7 @@ windows-sys = { version = "0.60", features = [
 
 [dev-dependencies]
 tempfile = "3"
-smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.7.4" }
+smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.7.5" }
 regex = "1"
 tower = { version = "0.5", features = ["util"] }
 wiremock = "0.6"

--- a/crates/smolvm-agent/Cargo.toml
+++ b/crates/smolvm-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-agent"
-version = "1.7.4"
+version = "1.7.5"
 edition = "2021"
 description = "Guest agent for smolvm VMs (handles OCI operations and command execution)"
 license = "Apache-2.0"

--- a/crates/smolvm-cuda-codegen/Cargo.toml
+++ b/crates/smolvm-cuda-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda-codegen"
-version = "1.7.4"
+version = "1.7.5"
 edition = "2021"
 description = "Generates forward-to-host-lib marshaling (guest stubs + host dispatch) from a function spec"
 license = "Apache-2.0"

--- a/crates/smolvm-cuda-guest/Cargo.toml
+++ b/crates/smolvm-cuda-guest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda-guest"
-version = "1.7.4"
+version = "1.7.5"
 edition = "2021"
 description = "Guest-side CUDA-over-vsock runner for smolvm microVMs (Linux)"
 license = "Apache-2.0"

--- a/crates/smolvm-cuda-shim/Cargo.toml
+++ b/crates/smolvm-cuda-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda-shim"
-version = "1.7.4"
+version = "1.7.5"
 edition = "2021"
 description = "Guest-side libcuda.so.1 drop-in: CUDA Driver API over smolvm's vsock RPC"
 license = "Apache-2.0"

--- a/crates/smolvm-cuda/Cargo.toml
+++ b/crates/smolvm-cuda/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda"
-version = "1.7.4"
+version = "1.7.5"
 edition = "2021"
 description = "CUDA Driver-API remoting over vsock for smolvm guests"
 license = "Apache-2.0"

--- a/crates/smolvm-cudart-shim/Cargo.toml
+++ b/crates/smolvm-cudart-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cudart-shim"
-version = "1.7.4"
+version = "1.7.5"
 edition = "2021"
 description = "Guest-side libcudart.so drop-in: CUDA Runtime API lowered to smolvm's Driver-API vsock RPC"
 license = "Apache-2.0"

--- a/crates/smolvm-network/Cargo.toml
+++ b/crates/smolvm-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-network"
-version = "1.7.4"
+version = "1.7.5"
 edition = "2021"
 description = "Host-side virtio-net runtime for smolvm"
 license = "Apache-2.0"

--- a/crates/smolvm-nvml-shim/Cargo.toml
+++ b/crates/smolvm-nvml-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-nvml-shim"
-version = "1.7.4"
+version = "1.7.5"
 edition = "2021"
 description = "Guest-side libnvidia-ml.so.1 drop-in: answers the NVML queries CUDA frameworks (vLLM) use for device detection, backed by the remoted CUDA driver"
 license = "Apache-2.0"

--- a/crates/smolvm-oci-layer/Cargo.toml
+++ b/crates/smolvm-oci-layer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-oci-layer"
-version = "1.7.4"
+version = "1.7.5"
 edition = "2021"
 description = "Pure-Rust OCI image-layer extraction: decompress a layer blob and unpack it into an overlayfs lowerdir, translating OCI whiteouts"
 license = "Apache-2.0"

--- a/crates/smolvm-pack/Cargo.toml
+++ b/crates/smolvm-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-pack"
-version = "1.7.4"
+version = "1.7.5"
 edition = "2021"
 description = "Single-binary packaging for smolvm"
 license = "Apache-2.0"

--- a/crates/smolvm-protocol/Cargo.toml
+++ b/crates/smolvm-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-protocol"
-version = "1.7.4"
+version = "1.7.5"
 edition = "2021"
 description = "Protocol types for smolvm host-guest communication"
 license = "Apache-2.0"

--- a/crates/smolvm-registry/Cargo.toml
+++ b/crates/smolvm-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-registry"
-version = "1.7.4"
+version = "1.7.5"
 edition = "2021"
 description = "OCI Distribution client for smolmachines registry"
 license = "Apache-2.0"

--- a/crates/smolvm-smolfile/Cargo.toml
+++ b/crates/smolvm-smolfile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolfile"
-version = "1.7.4"
+version = "1.7.5"
 edition = "2021"
 description = "Smolfile specification and parser for smolvm microVM workloads"
 license = "Apache-2.0"


### PR DESCRIPTION
Main's manifests still declared 1.7.4 because the bump was never merged back after that release, so a source checkout reported a version two releases behind what users install.