### PR TITLE
Rebuild the macOS libkrun so guests reach userspace instead of exiting at boot

### DIFF
--- a/lib/libkrun.dylib
+++ b/lib/libkrun.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:011751b39c0bf02d4dd2a6b0be4d6ab71c885fb3bb3af626c6edd1ad83115f76
-size 5970400
+oid sha256:156d54a50e4cbeac111b6fdbc59e0ce0141a211f00168711ef3a43d132bee027
+size 6234592


### PR DESCRIPTION
The bundled dylib was built such that every guest exited immediately with "boot process exited (code 0) before the agent was ready", which no check caught because its exports, provenance and freshness were all correct; rebuilding from the same pinned submodule restores booting on both networking backends.