### PR TITLE
Wire image workloads through embedded forks

### DIFF
--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -912,10 +912,13 @@ fn build_rejuvenation_script(clone: &str, seed: &str) -> String {
          fi; \
          rm -rf /var/lib/cloud/instance /var/lib/cloud/instances/* /var/lib/cloud/data/instance-id 2>/dev/null || true; \
          printf '%s' '{s}' > /dev/urandom 2>/dev/null || true; \
+         umask 077; \
+         mkdir -p '{state_dir}'; \
          printf '%s\n' smolvm-forkpoint-restored-v1 > '{restored}'; \
          true",
         c = clone,
         s = seed,
+        state_dir = smolvm_protocol::forkpoint::STATE_DIR,
         restored = smolvm_protocol::forkpoint::RESTORED_PATH,
     )
 }
@@ -1818,6 +1821,10 @@ mod tests {
         // The clone name and RNG seed are threaded through.
         assert!(script.contains("clone-a"));
         assert!(script.contains("deadbeef"));
+        assert!(script.contains(&format!(
+            "mkdir -p '{}'",
+            smolvm_protocol::forkpoint::STATE_DIR
+        )));
         assert!(script.contains(smolvm_protocol::forkpoint::RESTORED_PATH));
         // Guarded so it fails hard on core identity but no-ops when sshd/dbus
         // are absent (minimal library images).

--- a/src/embedded/control.rs
+++ b/src/embedded/control.rs
@@ -61,9 +61,22 @@ impl MachineSpec {
 
 /// Create a DB record for a new SDK machine.
 pub fn create_vm(db: &SmolvmDb, spec: &MachineSpec) -> Result<()> {
+    create_vm_with_workload(db, spec, Vec::new(), None)
+}
+
+/// Create a DB record with the image workload configuration supplied by an
+/// SDK, without expanding the stable `MachineSpec` struct.
+pub(crate) fn create_vm_with_workload(
+    db: &SmolvmDb,
+    spec: &MachineSpec,
+    env: Vec<(String, String)>,
+    workdir: Option<String>,
+) -> Result<()> {
     validate_vm_name(&spec.name, "name")
         .map_err(|reason| Error::config("validate machine name", reason))?;
-    let record = spec.to_record();
+    let mut record = spec.to_record();
+    record.env = env;
+    record.workdir = workdir;
     if db.insert_vm_if_not_exists(&spec.name, &record)? {
         Ok(())
     } else {
@@ -79,21 +92,29 @@ pub fn get_record(db: &SmolvmDb, name: &str) -> Result<VmRecord> {
     db.get_vm(name)?.ok_or_else(|| Error::vm_not_found(name))
 }
 
-/// Start a persisted VM and update its DB state.
-pub fn start_vm(db: &SmolvmDb, name: &str) -> Result<VmHandle> {
+/// Start or reconnect to a persisted VM and report whether this call actually
+/// booted/restarted it. Callers use the status to launch image workloads exactly
+/// once: a reused VM already has its workload, while a restarted VM does not.
+pub(crate) fn start_vm(db: &SmolvmDb, name: &str) -> Result<StartedVm> {
     let record = get_record(db, name)?;
-    let handle = start_vm_from_record(&record)?;
-    mark_running(db, name, handle.child_pid())?;
-    Ok(handle)
+    let started = start_vm_from_record(&record)?;
+    mark_running(db, name, started.handle.child_pid())?;
+    Ok(started)
 }
 
-fn start_vm_from_record(record: &VmRecord) -> Result<VmHandle> {
+fn start_vm_from_record(record: &VmRecord) -> Result<StartedVm> {
     launch_from_record(record, LaunchFeatures::default())
+}
+
+/// Result of an embedded launch attempt.
+pub(crate) struct StartedVm {
+    pub(crate) handle: VmHandle,
+    pub(crate) freshly_started: bool,
 }
 
 /// Boot `record` with the given launch features and return a handle. Shared by
 /// the plain, forkable-golden, and fork-clone start paths so they can't drift.
-fn launch_from_record(record: &VmRecord, features: LaunchFeatures) -> Result<VmHandle> {
+fn launch_from_record(record: &VmRecord, features: LaunchFeatures) -> Result<StartedVm> {
     let mut features = features;
     if record.forkable_on_start() {
         features.forkable = true;
@@ -116,7 +137,7 @@ fn launch_from_record(record: &VmRecord, features: LaunchFeatures) -> Result<VmH
         AgentManager::for_vm_with_sizes(&record.name, record.storage_gb, record.overlay_gb)
             .map_err(|e| Error::agent("create agent manager", e.to_string()))?;
 
-    manager
+    let freshly_started = manager
         .ensure_running_with_full_config(
             record.host_mounts(),
             record.port_mappings(),
@@ -125,22 +146,26 @@ fn launch_from_record(record: &VmRecord, features: LaunchFeatures) -> Result<VmH
         )
         .map_err(|e| Error::agent("start machine", e.to_string()))?;
 
-    Ok(VmHandle::new(manager, None))
+    Ok(StartedVm {
+        handle: VmHandle::new(manager, None),
+        freshly_started,
+    })
 }
 
 /// Start a persisted VM as a FORKABLE fork base: its guest RAM is backed by a
 /// memfd (copy-on-write cloneable) and a control socket is exposed so the machine
 /// can later be forked with [`fork_vm`]. Same mechanics as the CLI's
 /// `machine start --forkable`, surfaced for the embedded SDK.
-pub fn start_forkable_vm(db: &SmolvmDb, name: &str) -> Result<VmHandle> {
+/// Start or reconnect to a forkable VM and retain the actual launch status.
+pub(crate) fn start_forkable_vm(db: &SmolvmDb, name: &str) -> Result<StartedVm> {
     let record = get_record(db, name)?;
     let features = LaunchFeatures {
         forkable: true,
         ..LaunchFeatures::default()
     };
-    let handle = launch_from_record(&record, features)?;
-    mark_running(db, name, handle.child_pid())?;
-    Ok(handle)
+    let started = launch_from_record(&record, features)?;
+    mark_running(db, name, started.handle.child_pid())?;
+    Ok(started)
 }
 
 /// Start a persisted VM attached to a Kubernetes pod network namespace: the
@@ -158,9 +183,9 @@ pub fn start_vm_with_netns(
         pod_netns: Some(netns),
         ..LaunchFeatures::default()
     };
-    let handle = launch_from_record(&record, features)?;
-    mark_running(db, name, handle.child_pid())?;
-    Ok(handle)
+    let started = launch_from_record(&record, features)?;
+    mark_running(db, name, started.handle.child_pid())?;
+    Ok(started.handle)
 }
 
 /// Fork a running, forkable `golden` into a new `clone` via copy-on-write guest
@@ -175,6 +200,18 @@ pub fn fork_vm(
     golden: &str,
     clone: &str,
     pinned_ports: &[(u16, u16)],
+) -> Result<VmHandle> {
+    fork_vm_with_options(db, golden, clone, pinned_ports, false, None)
+}
+
+/// Fork a machine with launch options needed by non-embedded front-ends.
+pub(crate) fn fork_vm_with_options(
+    db: &SmolvmDb,
+    golden: &str,
+    clone: &str,
+    pinned_ports: &[(u16, u16)],
+    share_weights: bool,
+    watch_parent: Option<bool>,
 ) -> Result<VmHandle> {
     // Freeze + snapshot the golden, register the clone (CoW disks + DB record).
     // `clone_forkable = false`: a clone can't itself be re-forked (nested fork).
@@ -191,11 +228,14 @@ pub fn fork_vm(
     // Boot the clone from the golden's in-memory snapshot instead of cold-booting.
     let features = LaunchFeatures {
         snapshot_dir: Some(prep.snapshot_dir.clone()),
+        cuda_share_weights: share_weights,
         cuda_preload_modules: prep.clone_record.cuda_preload_modules,
+        watch_parent,
         ..LaunchFeatures::default()
     };
     match launch_from_record(&prep.clone_record, features) {
-        Ok(mut handle) => {
+        Ok(started) => {
+            let mut handle = started.handle;
             // Fresh on-disk identity (hostname, machine-id, SSH host keys, RNG).
             // FAIL-CLOSED: if the reset can't be confirmed, stop the booted clone
             // and roll it back rather than leave it live with the golden's
@@ -433,6 +473,24 @@ mod tests {
         assert!(!plain.vm_resources().gpu);
         assert!(!plain.cuda);
         assert!(!plain.vm_resources().cuda);
+    }
+
+    #[test]
+    fn record_carries_image_workload_configuration() {
+        let mut spec = test_spec("workload", true);
+        spec.image = Some("example/service:latest".into());
+        let db = test_db();
+        create_vm_with_workload(
+            &db,
+            &spec,
+            vec![("SESSION".into(), "golden".into())],
+            Some("/workspace".into()),
+        )
+        .unwrap();
+        let record = get_record(&db, "workload").unwrap();
+        assert_eq!(record.image.as_deref(), Some("example/service:latest"));
+        assert_eq!(record.env, vec![("SESSION".into(), "golden".into())]);
+        assert_eq!(record.workdir.as_deref(), Some("/workspace"));
     }
 
     #[test]

--- a/src/embedded/handle.rs
+++ b/src/embedded/handle.rs
@@ -3,6 +3,7 @@
 use std::time::Duration;
 
 use crate::agent::{AgentClient, AgentManager, ExecEvent, RunConfig};
+use crate::config::VmRecord;
 use crate::Result;
 use smolvm_protocol::ImageInfo;
 
@@ -103,6 +104,18 @@ impl VmHandle {
         self.client_mut()?.list_images()
     }
 
+    /// Pull and launch an image machine's persistent workload before the SDK
+    /// reports create/start complete.
+    pub fn launch_image_workload(&mut self, name: &str, record: &VmRecord) -> Result<()> {
+        let Some(image) = record.image.as_deref() else {
+            return Ok(());
+        };
+        let client = self.client_mut()?;
+        client.pull_with_registry_config(image)?;
+        crate::workload::launch_image_workload(client, name, record, record.env.clone())?;
+        Ok(())
+    }
+
     /// Write a file into the VM.
     pub fn write_file(&mut self, path: &str, data: &[u8], mode: Option<u32>) -> Result<()> {
         self.client_mut()?.write_file(path, data, mode)
@@ -145,5 +158,10 @@ impl VmHandle {
     pub fn stop(&mut self) -> Result<()> {
         self.client = None;
         self.manager.stop()
+    }
+
+    /// Let a CLI-started VM outlive the process that launched it.
+    pub fn detach(self) {
+        self.manager.detach();
     }
 }

--- a/src/embedded/runtime.rs
+++ b/src/embedded/runtime.rs
@@ -41,6 +41,19 @@ impl EmbeddedRuntime {
         self.with_name_lock(&spec.name, || control::create_vm(&self.db, &spec))
     }
 
+    /// Create a persisted image machine with its launch-time environment and
+    /// working directory.
+    pub fn create_machine_with_workload(
+        &self,
+        spec: MachineSpec,
+        env: Vec<(String, String)>,
+        workdir: Option<String>,
+    ) -> Result<()> {
+        self.with_name_lock(&spec.name, || {
+            control::create_vm_with_workload(&self.db, &spec, env, workdir)
+        })
+    }
+
     /// Reclaim shim-managed sandbox VMs whose process is gone (node reboot or a
     /// shim crash left the record + disks behind). See
     /// [`control::reconcile_runtime_machines`]. Returns the count reclaimed.
@@ -59,7 +72,15 @@ impl EmbeddedRuntime {
                 self.remove_cached_handle(name)?;
             }
 
-            let handle = control::start_vm(&self.db, name)?;
+            let started = control::start_vm(&self.db, name)?;
+            let mut handle = started.handle;
+            if started.freshly_started {
+                if let Err(error) = self.launch_image_workload(name, &mut handle) {
+                    let _ = handle.stop();
+                    let _ = control::mark_stopped(&self.db, name);
+                    return Err(error);
+                }
+            }
             self.insert_handle(name, handle)?;
             Ok(())
         })
@@ -98,7 +119,15 @@ impl EmbeddedRuntime {
                 self.remove_cached_handle(name)?;
             }
 
-            let handle = control::start_forkable_vm(&self.db, name)?;
+            let started = control::start_forkable_vm(&self.db, name)?;
+            let mut handle = started.handle;
+            if started.freshly_started {
+                if let Err(error) = self.launch_image_workload(name, &mut handle) {
+                    let _ = handle.stop();
+                    let _ = control::mark_stopped(&self.db, name);
+                    return Err(error);
+                }
+            }
             self.insert_handle(name, handle)?;
             Ok(())
         })
@@ -113,6 +142,30 @@ impl EmbeddedRuntime {
         self.with_name_lock(clone, || {
             let handle = control::fork_vm(&self.db, golden, clone, ports)?;
             self.insert_handle(clone, handle)?;
+            Ok(())
+        })
+    }
+
+    /// Fork a machine for a detached CLI operation. Unlike the SDK path, the
+    /// clone intentionally outlives this process; all preparation, retained
+    /// snapshot reuse, and fail-closed identity rejuvenation remain shared.
+    pub fn fork_machine_detached(
+        &self,
+        golden: &str,
+        clone: &str,
+        ports: &[(u16, u16)],
+        share_weights: bool,
+    ) -> Result<()> {
+        self.with_name_lock(clone, || {
+            let handle = control::fork_vm_with_options(
+                &self.db,
+                golden,
+                clone,
+                ports,
+                share_weights,
+                Some(false),
+            )?;
+            handle.detach();
             Ok(())
         })
     }
@@ -176,7 +229,7 @@ impl EmbeddedRuntime {
         workdir: Option<String>,
         timeout: Option<Duration>,
     ) -> Result<(i32, Vec<u8>, Vec<u8>)> {
-        let image = self.image_of(name);
+        let (image, overlay_owner) = self.image_and_overlay_owner(name)?;
         let handle = self.started_handle(name)?;
         let mut handle = lock_handle(&handle)?;
         match image {
@@ -190,7 +243,7 @@ impl EmbeddedRuntime {
                     .with_env(env)
                     .with_workdir(workdir)
                     .with_timeout(timeout)
-                    .with_persistent_overlay(Some(name.to_string()));
+                    .with_persistent_overlay(Some(overlay_owner));
                 handle.run_config(config)
             }
             // Bare VM: exec directly against the guest.
@@ -235,23 +288,83 @@ impl EmbeddedRuntime {
         data: Vec<u8>,
         mode: Option<u32>,
     ) -> Result<()> {
+        let (image, overlay_owner) = self.image_and_overlay_owner(name)?;
         let handle = self.started_handle(name)?;
         let mut handle = lock_handle(&handle)?;
+        Self::activate_image_overlay(&mut handle, image, overlay_owner)?;
         handle.write_file(path, &data, mode)
     }
 
     /// Read a file from the machine.
     pub fn read_file(&self, name: &str, path: &str) -> Result<Vec<u8>> {
+        let (image, overlay_owner) = self.image_and_overlay_owner(name)?;
         let handle = self.started_handle(name)?;
         let mut handle = lock_handle(&handle)?;
+        Self::activate_image_overlay(&mut handle, image, overlay_owner)?;
         handle.read_file(path)
+    }
+
+    /// Make an image machine's persistent container rootfs the active target
+    /// for the file RPCs that follow. Preparing the overlay alone only mounts
+    /// it; a no-op container run also switches the agent's active file root.
+    fn activate_image_overlay(
+        handle: &mut VmHandle,
+        image: Option<String>,
+        overlay_owner: String,
+    ) -> Result<()> {
+        let Some(image) = image else {
+            return Ok(());
+        };
+        let (code, _, stderr) = handle.run_config(
+            RunConfig::new(image, vec!["/bin/true".to_string()])
+                .with_persistent_overlay(Some(overlay_owner)),
+        )?;
+        if code == 0 {
+            Ok(())
+        } else {
+            Err(Error::agent(
+                "activate image overlay",
+                format!(
+                    "container probe exited {code}: {}",
+                    String::from_utf8_lossy(&stderr).trim()
+                ),
+            ))
+        }
+    }
+
+    /// Return the host port currently forwarding to `guest_port`.
+    ///
+    /// Forks with unpinned ports receive fresh host ports, so SDK callers must
+    /// read the clone's persisted mapping instead of assuming the golden's.
+    pub fn host_port(&self, name: &str, guest_port: u16) -> Result<Option<u16>> {
+        Ok(control::get_record(&self.db, name)?
+            .ports
+            .into_iter()
+            .find_map(|(host, guest)| (guest == guest_port).then_some(host)))
+    }
+
+    /// Return all published guest ports for readiness checks.
+    pub fn guest_ports(&self, name: &str) -> Result<Vec<u16>> {
+        Ok(control::get_record(&self.db, name)?
+            .ports
+            .into_iter()
+            .map(|(_, guest)| guest)
+            .collect())
+    }
+
+    fn launch_image_workload(&self, name: &str, handle: &mut VmHandle) -> Result<()> {
+        let record = control::get_record(&self.db, name)?;
+        handle.launch_image_workload(name, &record)
     }
 
     /// The machine's image, if it is an image (container-workload) machine.
     /// Streamed execs on such a machine must run inside its persistent container
     /// overlay so their writes survive — matching non-streaming exec.
-    fn image_of(&self, name: &str) -> Option<String> {
-        self.db.get_vm(name).ok().flatten().and_then(|r| r.image)
+    fn image_and_overlay_owner(&self, name: &str) -> Result<(Option<String>, String)> {
+        let record = control::get_record(&self.db, name)?;
+        let overlay_owner =
+            crate::workload::persistent_overlay_owner(name, record.golden.as_deref());
+        Ok((record.image, overlay_owner))
     }
 
     /// Execute a command and collect streaming output events.
@@ -280,7 +393,7 @@ impl EmbeddedRuntime {
         timeout: Option<Duration>,
         on_event: F,
     ) -> Result<()> {
-        let image = self.image_of(name);
+        let (image, overlay_owner) = self.image_and_overlay_owner(name)?;
         let handle = self.started_handle(name)?;
         let mut handle = lock_handle(&handle)?;
         match image {
@@ -292,7 +405,7 @@ impl EmbeddedRuntime {
                     .with_env(env)
                     .with_workdir(workdir)
                     .with_timeout(timeout)
-                    .with_persistent_overlay(Some(name.to_string()));
+                    .with_persistent_overlay(Some(overlay_owner));
                 handle.run_streaming_with(config, on_event)
             }
             // Bare VM: stream directly against the guest.
@@ -533,6 +646,62 @@ mod tests {
         assert_eq!(runtime.state("runtime-state"), "stopped");
         assert!(!runtime.is_running("runtime-state"));
         assert_eq!(runtime.pid("runtime-state"), None);
+    }
+
+    #[test]
+    fn image_overlay_owner_uses_machine_name_for_regular_machines() {
+        let runtime = EmbeddedRuntime::with_db(test_db());
+        let mut spec = test_spec("runtime-image", true);
+        spec.image = Some("example/image:latest".to_string());
+        runtime.create_machine(spec).unwrap();
+
+        assert_eq!(
+            runtime.image_and_overlay_owner("runtime-image").unwrap(),
+            (
+                Some("example/image:latest".to_string()),
+                "runtime-image".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn image_overlay_owner_uses_golden_name_for_clones() {
+        let runtime = EmbeddedRuntime::with_db(test_db());
+        let mut record = test_spec("runtime-clone", true).to_record();
+        record.image = Some("example/image:latest".to_string());
+        record.golden = Some("runtime-golden".to_string());
+        runtime.db.insert_vm("runtime-clone", &record).unwrap();
+
+        assert_eq!(
+            runtime.image_and_overlay_owner("runtime-clone").unwrap(),
+            (
+                Some("example/image:latest".to_string()),
+                "runtime-golden".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn image_overlay_owner_fails_closed_for_missing_records() {
+        let runtime = EmbeddedRuntime::with_db(test_db());
+        assert!(matches!(
+            runtime.image_and_overlay_owner("missing"),
+            Err(crate::Error::VmNotFound { .. })
+        ));
+    }
+
+    #[test]
+    fn host_port_reads_the_persisted_mapping() {
+        let runtime = EmbeddedRuntime::with_db(test_db());
+        let mut spec = test_spec("runtime-ports", true);
+        spec.ports = vec![crate::data::network::PortMapping::new(49152, 3000)];
+        runtime.create_machine(spec).unwrap();
+
+        assert_eq!(
+            runtime.host_port("runtime-ports", 3000).unwrap(),
+            Some(49152)
+        );
+        assert_eq!(runtime.host_port("runtime-ports", 9222).unwrap(), None);
     }
 
     #[test]


### PR DESCRIPTION
Launches persistent image workloads and preserves inherited overlays, ports, files, and clone identity across embedded clients.