### PR TITLE
Bump the guest kernel to the build with the netfilter options Kubernetes services need

### DIFF
--- a/lib/libkrun.provenance
+++ b/lib/libkrun.provenance
@@ -3,4 +3,4 @@
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
 libkrun=c283ed7556d0af534903f4b7972f190239858f15
-libkrunfw=85728e46fd394bfad050efe84e00467fa45e58a7
+libkrunfw=502d3258211b0fbadcd95d6ade08a4fc799c4db0

--- a/lib/libkrunfw.5.dylib
+++ b/lib/libkrunfw.5.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d68be1f48af1a2c9408b8c576635b1cf699f5b173323ce93be4ccca19ce70fd1
-size 13512480
+oid sha256:42c33c75c83b9cd6a4291498636880dc8c98e335f8b91f78694eaf0a781ad14c
+size 13446800

--- a/lib/linux-aarch64/libkrun.provenance
+++ b/lib/linux-aarch64/libkrun.provenance
@@ -3,4 +3,4 @@
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
 libkrun=c283ed7556d0af534903f4b7972f190239858f15
-libkrunfw=85728e46fd394bfad050efe84e00467fa45e58a7
+libkrunfw=502d3258211b0fbadcd95d6ade08a4fc799c4db0

--- a/lib/linux-aarch64/libkrunfw.so.5.5.0
+++ b/lib/linux-aarch64/libkrunfw.so.5.5.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:178a2ea8aeafd82d991d05f0aafac046638df8b226cc10f5b57fcf9800ffce73
-size 13436520
+oid sha256:6d138fcf66d11f2e7e740a75f5aace24d9c1eeb7816e02a49c621ff2850b25ae
+size 13567592

--- a/lib/linux-x86_64/libkrun.provenance
+++ b/lib/linux-x86_64/libkrun.provenance
@@ -3,4 +3,4 @@
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
 libkrun=c283ed7556d0af534903f4b7972f190239858f15
-libkrunfw=85728e46fd394bfad050efe84e00467fa45e58a7
+libkrunfw=502d3258211b0fbadcd95d6ade08a4fc799c4db0

--- a/lib/linux-x86_64/libkrunfw.so.5.5.0
+++ b/lib/linux-x86_64/libkrunfw.so.5.5.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:910b38bf3e8c5cb2a8e9c6e2042f35b8d46f0469211c50d11ef0924db01a7194
+oid sha256:710f87f6698cbe5619de07455237cb6582f173288c2dd313cd9e28b8ac8d8f0f
 size 17041080

--- a/lib/windows-x86_64/libkrun.provenance
+++ b/lib/windows-x86_64/libkrun.provenance
@@ -3,4 +3,4 @@
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
 libkrun=c283ed7556d0af534903f4b7972f190239858f15
-libkrunfw=85728e46fd394bfad050efe84e00467fa45e58a7
+libkrunfw=502d3258211b0fbadcd95d6ade08a4fc799c4db0

--- a/lib/windows-x86_64/libkrunfw.dll
+++ b/lib/windows-x86_64/libkrunfw.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2e3bc3587ba60bb8a933285294d3466eaf42f51399e6cfd5bc26bce396f84140
-size 19350964
+oid sha256:fa78f22626b5a0f922032465e2d4af897bc09981ec58b7a3e085b89cde832df0
+size 21509556


### PR DESCRIPTION
The guest kernel was missing the netfilter and VXLAN options kube-proxy and flannel rely on, so a Kubernetes cluster in a machine came up with no working Services: kube-proxy could not write its rules, flannel could not create its VXLAN device, and CoreDNS never became ready. This bumps the bundled kernel to the build that enables them and rebuilds the libkrunfw binaries for all four platforms. Verified with a real k3s cluster on macOS arm64 and Linux x86_64: CoreDNS reaches 1/1, ClusterIP routing and cluster DNS work, and the rule-sync failures drop to zero.