### PR TITLE
chore(nix): bump flake to 1.7.7 (#913)

### DIFF
--- a/nix/smolvm.nix
+++ b/nix/smolvm.nix
@@ -17,23 +17,23 @@
   gnutar,
   coreutils,
 }: let
-  version = "1.7.0";
+  version = "1.7.7";
 
   releases = {
     x86_64-linux = {
       asset = "smolvm-${version}-linux-x86_64.tar.gz";
       root = "smolvm-${version}-linux-x86_64";
-      hash = "sha256-9OcxCXTeJNqfBN62OOqKxCNBz1b5+AYpu2yVwOkb/fI=";
+      hash = "sha256-IxdXsPy+OYYnIJlNNKFrwyAw/5Vqg+qb1xHvpogYdbI=";
     };
     aarch64-linux = {
       asset = "smolvm-${version}-linux-arm64.tar.gz";
       root = "smolvm-${version}-linux-arm64";
-      hash = "sha256-o6vcevZwXT10zgU32/TOiL0M5vVJk/e4MxDnkb/c4Ao=";
+      hash = "sha256-LxJxPSzzsDF0YPtt+UnaI8SHOn8MIPjDjxvCv4XO8vY=";
     };
     aarch64-darwin = {
       asset = "smolvm-${version}-darwin-arm64.tar.gz";
       root = "smolvm-${version}-darwin-arm64";
-      hash = "sha256-HrfTf88F//WaWDbWU9JOmbbEufcroXjnkq0liTUCGZ8=";
+      hash = "sha256-1UnK24G+OJ7uKj3bD8ujP00EMvGy1VW2ngl6I47WQ4Y=";
     };
   };
 


### PR DESCRIPTION
This PR bumps the nix pkg to 1.7.7.
fixes #913 