### PR TITLE
Fix from-vm packs dropping layers past the third and the image's environment

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -2141,6 +2141,10 @@ fn handle_request(
 
         AgentRequest::StorageStatus => handle_storage_status(),
 
+        AgentRequest::FlattenLayers { lowerdirs, output } => {
+            handle_flatten_layers(&lowerdirs, &output)
+        }
+
         AgentRequest::NetworkTest { url } => {
             info!(url = %url, "testing network connectivity directly from agent");
 
@@ -5603,6 +5607,15 @@ fn handle_cleanup_overlay(workload_id: &str) -> AgentResponse {
     match storage::cleanup_overlay(workload_id) {
         Ok(_) => AgentResponse::ok(None),
         Err(e) => AgentResponse::from_err(e, error_codes::CLEANUP_FAILED),
+    }
+}
+
+/// Handle a request to merge layer directories into one tar archive.
+fn handle_flatten_layers(lowerdirs: &[String], output: &str) -> AgentResponse {
+    info!(layer_count = lowerdirs.len(), output = %output, "flattening layers");
+    match storage::flatten_layers_to_tar(lowerdirs, std::path::Path::new(output)) {
+        Ok(_) => AgentResponse::ok(None),
+        Err(e) => AgentResponse::from_err(e, error_codes::MOUNT_FAILED),
     }
 }
 

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -3545,6 +3545,154 @@ fn mount_overlay_fsconfig(
     ))
 }
 
+/// Merge `lowerdirs` (bottom -> top) into `output` as a single tar archive.
+///
+/// Backs [`AgentRequest::FlattenLayers`](smolvm_protocol::AgentRequest::FlattenLayers).
+/// The merge is a read-only overlay mount so that whiteouts and opaque markers
+/// resolve exactly as they do for a running container — a file copy would ship
+/// deleted paths back into the flattened layer.
+///
+/// Entries that are missing or empty are dropped: callers append a container
+/// overlay's upper dir without knowing whether the machine ever wrote to it, and
+/// overlayfs rejects a lowerdir that does not exist. A single surviving directory
+/// is tarred directly, since overlayfs requires two lower layers when there is no
+/// upperdir.
+pub fn flatten_layers_to_tar(lowerdirs: &[String], output: &Path) -> Result<()> {
+    let present = mountable_lowerdirs(lowerdirs);
+
+    let source = match present.len() {
+        0 => {
+            return Err(StorageError::new(
+                "no layers to flatten: every directory was missing or empty".to_string(),
+            ))
+        }
+        // One layer needs no merge, and overlayfs would refuse it anyway.
+        1 => PathBuf::from(&present[0]),
+        _ => {
+            let merged = Path::new(STORAGE_ROOT).join("flatten-merged");
+            let _ = std::fs::remove_dir_all(&merged);
+            std::fs::create_dir_all(&merged)?;
+            mount_overlay_lowers_only(&present, &merged)?;
+            merged
+        }
+    };
+
+    let tar_result = tar_directory(&source, output);
+
+    if source != Path::new(&present[0]) {
+        // Best-effort: a failed unmount must not mask a tar error.
+        let _ = std::process::Command::new("umount").arg(&source).status();
+        let _ = std::fs::remove_dir_all(&source);
+    }
+
+    tar_result
+}
+
+/// Keep the entries of `lowerdirs` that overlayfs can actually stack.
+///
+/// overlayfs fails the whole mount on a lowerdir that does not exist, and an
+/// empty directory contributes nothing to the merge, so dropping both lets a
+/// caller pass a container overlay's upper dir unconditionally.
+fn mountable_lowerdirs(lowerdirs: &[String]) -> Vec<String> {
+    lowerdirs
+        .iter()
+        .filter(|dir| {
+            let path = Path::new(dir);
+            path.is_dir()
+                && std::fs::read_dir(path)
+                    .map(|mut entries| entries.next().is_some())
+                    .unwrap_or(false)
+        })
+        .cloned()
+        .collect()
+}
+
+/// Tar `dir`'s contents (not the directory itself) into `output`.
+fn tar_directory(dir: &Path, output: &Path) -> Result<()> {
+    let status = std::process::Command::new("tar")
+        .arg("cf")
+        .arg(output)
+        .arg("-C")
+        .arg(dir)
+        .arg(".")
+        .status()
+        .map_err(|e| StorageError::new(format!("spawning tar failed: {e}")))?;
+    if !status.success() {
+        return Err(StorageError::new(format!(
+            "tar of {} failed: {status}",
+            dir.display()
+        )));
+    }
+    Ok(())
+}
+
+/// Mount a read-only overlay of `lowerdirs` (bottom -> top) at `merged_path`.
+///
+/// Same `fsconfig` path as [`mount_overlay_fsconfig`] but with no upperdir or
+/// workdir, which is what makes the mount read-only. Appending each layer with
+/// its own `lowerdir+` is the whole point: a single `lowerdir=` string caps out
+/// at ~255 bytes through `mount(8)`, which is only about three layer paths.
+#[cfg(target_os = "linux")]
+fn mount_overlay_lowers_only(lowerdirs: &[String], merged_path: &Path) -> Result<()> {
+    use rustix::fd::AsFd;
+    use rustix::mount::{
+        fsconfig_create, fsconfig_set_string, fsmount, fsopen, move_mount, FsMountFlags,
+        FsOpenFlags, MountAttrFlags, MoveMountFlags,
+    };
+
+    info!(
+        layer_count = lowerdirs.len(),
+        merged_path = %merged_path.display(),
+        "mounting read-only overlay for flatten"
+    );
+
+    let fs = fsopen("overlay", FsOpenFlags::FSOPEN_CLOEXEC)
+        .map_err(|e| StorageError::new(format!("fsopen(overlay) failed: {e}")))?;
+
+    // overlayfs stacks lowerdir+ bottom-up, matching our bottom -> top order.
+    for lower in lowerdirs {
+        fsconfig_set_string(fs.as_fd(), "lowerdir+", lower.as_str()).map_err(|e| {
+            StorageError::new(format!(
+                "fsconfig lowerdir+={lower} failed (kernel may lack lowerdir+ (<6.7)): {e}"
+            ))
+        })?;
+    }
+
+    fsconfig_create(fs.as_fd())
+        .map_err(|e| StorageError::new(format!("fsconfig create (overlay) failed: {e}")))?;
+
+    let mnt = fsmount(
+        fs.as_fd(),
+        FsMountFlags::FSMOUNT_CLOEXEC,
+        MountAttrFlags::empty(),
+    )
+    .map_err(|e| StorageError::new(format!("fsmount(overlay) failed: {e}")))?;
+
+    move_mount(
+        mnt.as_fd(),
+        "",
+        rustix::fs::CWD,
+        merged_path,
+        MoveMountFlags::MOVE_MOUNT_F_EMPTY_PATH,
+    )
+    .map_err(|e| {
+        StorageError::new(format!(
+            "move_mount to {} failed: {e}",
+            merged_path.display()
+        ))
+    })?;
+
+    Ok(())
+}
+
+/// Non-Linux stub: overlayfs is Linux-only.
+#[cfg(not(target_os = "linux"))]
+fn mount_overlay_lowers_only(_lowerdirs: &[String], _merged_path: &Path) -> Result<()> {
+    Err(StorageError::new(
+        "overlay mount is only supported on Linux".to_string(),
+    ))
+}
+
 /// Mount overlay by merging layers into a single directory (most compatible).
 ///
 /// This approach physically copies all layers into a single merged directory,
@@ -4013,6 +4161,51 @@ mod tests {
     fn env_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    /// A machine that has never written to its container overlay still has the
+    /// caller append that upper dir, and overlayfs fails the whole mount on a
+    /// lowerdir that is not there — so it has to be dropped, not passed through.
+    #[test]
+    fn flatten_drops_lowerdirs_that_are_missing_or_empty() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let populated = tmp.path().join("layer");
+        std::fs::create_dir_all(&populated).expect("create layer");
+        std::fs::write(populated.join("file"), b"x").expect("write file");
+        let empty = tmp.path().join("empty-upper");
+        std::fs::create_dir_all(&empty).expect("create empty");
+        let missing = tmp.path().join("never-created");
+
+        let kept = mountable_lowerdirs(&[
+            populated.to_string_lossy().into_owned(),
+            empty.to_string_lossy().into_owned(),
+            missing.to_string_lossy().into_owned(),
+        ]);
+
+        assert_eq!(
+            kept,
+            vec![populated.to_string_lossy().into_owned()],
+            "only the populated directory is mountable"
+        );
+    }
+
+    /// Order is the whole contract: overlayfs stacks `lowerdir+` bottom-up, and
+    /// a reversed stack would resolve whiteouts against the wrong layer and
+    /// resurrect files the image deleted.
+    #[test]
+    fn flatten_preserves_bottom_to_top_order() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dirs: Vec<String> = ["base", "middle", "top"]
+            .iter()
+            .map(|name| {
+                let dir = tmp.path().join(name);
+                std::fs::create_dir_all(&dir).expect("create dir");
+                std::fs::write(dir.join("f"), name.as_bytes()).expect("write");
+                dir.to_string_lossy().into_owned()
+            })
+            .collect();
+
+        assert_eq!(mountable_lowerdirs(&dirs), dirs);
     }
 
     #[test]

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -3545,14 +3545,20 @@ fn mount_overlay_fsconfig(
     ))
 }
 
-/// Merge `lowerdirs` (bottom -> top) into `output` as a single tar archive.
+/// Merge `lowerdirs` into `output` as a single tar archive.
 ///
 /// Backs [`AgentRequest::FlattenLayers`](smolvm_protocol::AgentRequest::FlattenLayers).
 /// The merge is a read-only overlay mount so that whiteouts and opaque markers
 /// resolve exactly as they do for a running container — a file copy would ship
 /// deleted paths back into the flattened layer.
 ///
-/// Entries that are missing or empty are dropped: callers append a container
+/// `lowerdirs` is **topmost first**, the same order the runtime container mount
+/// uses, because that is the order `lowerdir+` stacks them in. Passing an image's
+/// layers bottom-up instead silently inverts precedence: the base layer wins
+/// every conflicting path, so a merged `/etc/passwd` loses the users later layers
+/// added and the machine's own writes rank lowest of all.
+///
+/// Entries that are missing or empty are dropped: callers pass a container
 /// overlay's upper dir without knowing whether the machine ever wrote to it, and
 /// overlayfs rejects a lowerdir that does not exist. A single surviving directory
 /// is tarred directly, since overlayfs requires two lower layers when there is no
@@ -3626,7 +3632,7 @@ fn tar_directory(dir: &Path, output: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Mount a read-only overlay of `lowerdirs` (bottom -> top) at `merged_path`.
+/// Mount a read-only overlay of `lowerdirs` (topmost first) at `merged_path`.
 ///
 /// Same `fsconfig` path as [`mount_overlay_fsconfig`] but with no upperdir or
 /// workdir, which is what makes the mount read-only. Appending each layer with
@@ -3649,7 +3655,8 @@ fn mount_overlay_lowers_only(lowerdirs: &[String], merged_path: &Path) -> Result
     let fs = fsopen("overlay", FsOpenFlags::FSOPEN_CLOEXEC)
         .map_err(|e| StorageError::new(format!("fsopen(overlay) failed: {e}")))?;
 
-    // overlayfs stacks lowerdir+ bottom-up, matching our bottom -> top order.
+    // Each `lowerdir+` ranks below the one before it, so the caller's
+    // topmost-first order is passed straight through.
     for lower in lowerdirs {
         fsconfig_set_string(fs.as_fd(), "lowerdir+", lower.as_str()).map_err(|e| {
             StorageError::new(format!(
@@ -4189,13 +4196,15 @@ mod tests {
         );
     }
 
-    /// Order is the whole contract: overlayfs stacks `lowerdir+` bottom-up, and
-    /// a reversed stack would resolve whiteouts against the wrong layer and
-    /// resurrect files the image deleted.
+    /// Order is the whole contract — `lowerdir+` ranks each layer below the one
+    /// before it, so the caller's topmost-first list must survive filtering
+    /// unreordered. Passing it bottom-up instead inverts precedence silently:
+    /// the base layer wins every conflicting path and the machine's own writes
+    /// rank lowest, which reads as an image that lost its later layers.
     #[test]
-    fn flatten_preserves_bottom_to_top_order() {
+    fn flatten_preserves_topmost_first_order() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let dirs: Vec<String> = ["base", "middle", "top"]
+        let dirs: Vec<String> = ["upper", "top-layer", "base"]
             .iter()
             .map(|name| {
                 let dir = tmp.path().join(name);
@@ -4206,6 +4215,30 @@ mod tests {
             .collect();
 
         assert_eq!(mountable_lowerdirs(&dirs), dirs);
+    }
+
+    /// Dropping an empty entry must not disturb the rank of the ones that stay:
+    /// a machine that never wrote anything still has its (empty) overlay passed
+    /// first, and removing it has to leave the image layers in their own order.
+    #[test]
+    fn flatten_keeps_rank_when_an_entry_is_dropped() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut make = |name: &str, populated: bool| {
+            let dir = tmp.path().join(name);
+            std::fs::create_dir_all(&dir).expect("create dir");
+            if populated {
+                std::fs::write(dir.join("f"), name.as_bytes()).expect("write");
+            }
+            dir.to_string_lossy().into_owned()
+        };
+        let empty_upper = make("empty-upper", false);
+        let top = make("top-layer", true);
+        let base = make("base", true);
+
+        assert_eq!(
+            mountable_lowerdirs(&[empty_upper, top.clone(), base.clone()]),
+            vec![top, base]
+        );
     }
 
     #[test]

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -4223,7 +4223,7 @@ mod tests {
     #[test]
     fn flatten_keeps_rank_when_an_entry_is_dropped() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let mut make = |name: &str, populated: bool| {
+        let make = |name: &str, populated: bool| {
             let dir = tmp.path().join(name);
             std::fs::create_dir_all(&dir).expect("create dir");
             if populated {

--- a/crates/smolvm-protocol/src/lib.rs
+++ b/crates/smolvm-protocol/src/lib.rs
@@ -322,6 +322,26 @@ pub enum AgentRequest {
         layer_index: usize,
     },
 
+    /// Merge a stack of directories into a single tar archive.
+    ///
+    /// `pack create --from-vm` ships the machine's image layers plus whatever the
+    /// container has written since as ONE flattened layer. The merge has to apply
+    /// whiteouts and opaque markers exactly as the runtime would, so it is done
+    /// with a read-only overlay mount rather than a file copy.
+    ///
+    /// The agent owns this rather than the host driving `mount(8)` over `VmExec`,
+    /// because `mount(8)` rejects a `lowerdir=` value beyond ~255 bytes — about
+    /// three OCI layer paths — while the agent can append each layer separately
+    /// through the same `fsconfig` path the runtime container mount uses.
+    FlattenLayers {
+        /// Directories to merge, bottom -> top. Entries that are missing or empty
+        /// are dropped, so a caller may include a container overlay's upper dir
+        /// without first checking whether the machine ever wrote to it.
+        lowerdirs: Vec<String>,
+        /// Guest path to write the tar archive to.
+        output: String,
+    },
+
     /// Execute a command directly in the VM (not in a container).
     ///
     /// This runs the command in the agent's Alpine rootfs without any
@@ -607,6 +627,9 @@ impl AgentRequest {
             AgentRequest::NetworkTest { .. } => "NetworkTest".into(),
             AgentRequest::Shutdown => "Shutdown".into(),
             AgentRequest::ExportLayer { .. } => "ExportLayer".into(),
+            AgentRequest::FlattenLayers { lowerdirs, .. } => {
+                format!("FlattenLayers {{ count: {} }}", lowerdirs.len())
+            }
             AgentRequest::VmExec { .. } => "VmExec".into(),
             AgentRequest::Run { image, .. } => format!("Run {{ image: {image} }}"),
             AgentRequest::Stdin { .. } => "Stdin".into(),

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -915,6 +915,18 @@ impl AgentClient {
         expect_ok(resp, "format storage")
     }
 
+    /// Merge `lowerdirs` (bottom -> top) into a single tar at `output` in the guest.
+    ///
+    /// Missing or empty entries are dropped guest-side, so callers can append a
+    /// container overlay's upper dir without probing it first.
+    pub fn flatten_layers(&mut self, lowerdirs: &[String], output: &str) -> Result<()> {
+        let resp = self.request(&AgentRequest::FlattenLayers {
+            lowerdirs: lowerdirs.to_vec(),
+            output: output.to_string(),
+        })?;
+        expect_ok(resp, "flatten layers")
+    }
+
     /// Get storage status.
     pub fn storage_status(&mut self) -> Result<StorageStatus> {
         let resp = self.request(&AgentRequest::StorageStatus)?;

--- a/src/pack_export.rs
+++ b/src/pack_export.rs
@@ -435,51 +435,20 @@ fn flatten_and_export(
     if lowers.is_empty() {
         return Err(Error::agent("flatten layers", "no layers to flatten"));
     }
+    // The machine's container overlay goes on top of the image layers. The agent
+    // drops it if the machine never wrote to it, so it needs no probe from here.
     let upper = format!("/mnt/source-storage/overlays/persistent-{}/upper", vm_name);
-    // overlayfs wants topmost-first in `lowerdir=`.
-    let base_chain: Vec<&str> = lowers.iter().rev().map(String::as_str).collect();
-    let base_chain = base_chain.join(":");
+    let mut stack: Vec<String> = lowers.to_vec();
+    stack.push(upper);
 
     println!(
         "Flattening {} layer(s) + container overlay...",
         lowers.len()
     );
-    let script = format!(
-        "set -e\n\
-         low='{base_chain}'\n\
-         n={n}\n\
-         if [ -d '{upper}' ] && [ -n \"$(ls -A '{upper}' 2>/dev/null)\" ]; then\n\
-           low=\"{upper}:$low\"; n=$((n+1))\n\
-         fi\n\
-         if [ \"$n\" -eq 1 ]; then\n\
-           tar cf /storage/flat-export.tar -C \"${{low%%:*}}\" .\n\
-         else\n\
-           mkdir -p /tmp/flatview\n\
-           mount -t overlay overlay -o lowerdir=\"$low\" /tmp/flatview\n\
-           tar cf /storage/flat-export.tar -C /tmp/flatview .\n\
-           umount /tmp/flatview\n\
-         fi\n\
-         echo FLAT_OK\n",
-        n = lowers.len(),
-    );
-    let (exit_code, stdout, stderr) = client.vm_exec(
-        vec!["sh".to_string(), "-c".to_string(), script],
-        vec![],
-        None,
-        None,
-        None,
-    )?;
-    let stdout_str = String::from_utf8_lossy(&stdout);
-    if exit_code != 0 || !stdout_str.contains("FLAT_OK") {
-        return Err(Error::agent(
-            "flatten layers",
-            format!(
-                "flatten failed (exit {}): {}",
-                exit_code,
-                String::from_utf8_lossy(&stderr)
-            ),
-        ));
-    }
+    // Driven agent-side rather than through `mount(8)` over VmExec: `mount(8)`
+    // rejects a `lowerdir=` value past ~255 bytes, which any image with four or
+    // more layers exceeds.
+    client.flatten_layers(&stack, "/storage/flat-export.tar")?;
 
     // Stream the flattened tar to disk (never buffered whole in memory), then
     // content-address it. Stage in the layers dir so the final rename is

--- a/src/pack_export.rs
+++ b/src/pack_export.rs
@@ -475,11 +475,15 @@ fn flatten_and_export(
     if lowers.is_empty() {
         return Err(Error::agent("flatten layers", "no layers to flatten"));
     }
-    // The machine's container overlay goes on top of the image layers. The agent
-    // drops it if the machine never wrote to it, so it needs no probe from here.
+    // Topmost first, which is the order the agent stacks them in: the machine's
+    // own writes outrank every image layer, then the image layers from top down.
+    // `lowers` arrives bottom-up as the image lists them, so it has to be
+    // reversed — leaving it as-is makes the base layer win every conflict.
+    // The agent drops the overlay if the machine never wrote to it, so it needs
+    // no probe from here.
     let upper = format!("/mnt/source-storage/overlays/persistent-{}/upper", vm_name);
-    let mut stack: Vec<String> = lowers.to_vec();
-    stack.push(upper);
+    let mut stack: Vec<String> = vec![upper];
+    stack.extend(lowers.iter().rev().cloned());
 
     println!(
         "Flattening {} layer(s) + container overlay...",

--- a/src/pack_export.rs
+++ b/src/pack_export.rs
@@ -48,6 +48,17 @@ pub struct FromVmAssets {
     pub mode: PackMode,
     /// The machine's image reference (image-based machines only).
     pub image: Option<String>,
+    /// The image's OCI `ENV`, as `KEY=VALUE`.
+    ///
+    /// A running machine gets these because the agent reads the image config at
+    /// exec time, but flattening the layers leaves the pack with no image config
+    /// to read — so they have to travel in the manifest instead, or the packed
+    /// machine loses the image's `PATH` and every other declared variable.
+    ///
+    /// Empty for a bare machine, and for a machine created from a `.smolmachine`:
+    /// that path already copied the source manifest's env into the record, so the
+    /// machine's own env is the complete set.
+    pub image_env: Vec<String>,
 }
 
 /// Collect a stopped machine's pack assets into `collector` and report the
@@ -93,6 +104,11 @@ pub fn collect_from_vm_assets(
         ));
     }
 
+    // Only the registry path can report the image's declared env: an artifact
+    // machine already carries the source manifest's env in its own record, and a
+    // bare machine has no image at all.
+    let mut image_env: Vec<String> = Vec::new();
+
     if is_artifact_sourced && !opts.rebase_from_image {
         export_flattened_from_artifact_sourced(collector, vm_name, &vm_dir, staging_dir)?;
     } else if is_image_based {
@@ -114,7 +130,8 @@ pub fn collect_from_vm_assets(
                 ),
             ));
         }
-        export_flattened_from_registry_image(collector, vm_name, &vm_dir, &image, opts)?;
+        image_env =
+            export_flattened_from_registry_image(collector, vm_name, &vm_dir, &image, opts)?;
     } else {
         // Bare VM: its state is the rootfs overlay disk. VM-mode restores boot
         // from the template; a default-size overlay is a qcow2 CoW image and
@@ -140,6 +157,7 @@ pub fn collect_from_vm_assets(
             PackMode::Vm
         },
         image: vm.image.clone(),
+        image_env,
     })
 }
 
@@ -159,9 +177,30 @@ pub fn seed_manifest_from_vm(manifest: &mut PackManifest, vm: &VmRecord, assets:
         vec!["/bin/sh".to_string()]
     };
     manifest.cmd = vm.cmd.clone();
-    manifest.env = vm.env.iter().map(|(k, v)| format!("{}={}", k, v)).collect();
+    manifest.env = merge_env(&assets.image_env, &vm.env);
     manifest.workdir = vm.workdir.clone();
     manifest.secret_refs = vm.secret_refs.clone();
+}
+
+/// Layer a machine's own env over the image's declared env, as `KEY=VALUE`.
+///
+/// This is the order a running machine resolves: the agent applies the image
+/// config first, then whatever the machine was created with. Packing has to
+/// reproduce it, because flattening the layers leaves no image config for the
+/// packed machine to read — the image's `PATH` in particular only survives if it
+/// travels in the manifest.
+fn merge_env(image_env: &[String], vm_env: &[(String, String)]) -> Vec<String> {
+    let mut merged = image_env.to_vec();
+    for (key, value) in vm_env {
+        merged.retain(|entry| {
+            entry
+                .split_once('=')
+                .map(|(existing, _)| existing != key)
+                .unwrap_or(true)
+        });
+        merged.push(format!("{key}={value}"));
+    }
+    merged
 }
 
 /// A helper VM used to read the source machine's disks and flatten layers.
@@ -294,7 +333,7 @@ fn export_flattened_from_registry_image(
     vm_dir: &Path,
     image: &str,
     opts: &FromVmExportOptions,
-) -> crate::Result<()> {
+) -> crate::Result<Vec<String>> {
     let export_vm = ExportVm::start(vm_name, vm_dir, None, true)?;
     let mut client = export_vm.connect()?;
     export_vm.mount_source_storage(&mut client)?;
@@ -318,7 +357,8 @@ fn export_flattened_from_registry_image(
         })
         .collect();
 
-    flatten_and_export(collector, &mut client, vm_name, &lowers)
+    flatten_and_export(collector, &mut client, vm_name, &lowers)?;
+    Ok(image_info.env)
 }
 
 /// Artifact-sourced machine: its extracted layer dirs live in the host-side
@@ -602,4 +642,55 @@ fn read_qcow2_virtual_size(path: &Path) -> crate::Result<u64> {
         ));
     }
     Ok(u64::from_be_bytes(header[24..32].try_into().unwrap()))
+}
+
+#[cfg(test)]
+mod env_merge_tests {
+    use super::merge_env;
+
+    /// The image's `PATH` is what makes its binaries resolve, so a machine that
+    /// set no env of its own must still carry the image's.
+    #[test]
+    fn image_env_survives_when_the_machine_adds_none() {
+        let image = vec![
+            "PATH=/usr/local/bin:/usr/bin:/usr/lib/postgresql/16/bin".to_string(),
+            "PG_VERSION=16.14".to_string(),
+        ];
+        assert_eq!(merge_env(&image, &[]), image);
+    }
+
+    /// A machine created with `-e` overrides the image rather than appending a
+    /// second entry for the same key, which would leave the winner to whichever
+    /// end of the vector the consumer happens to read last.
+    #[test]
+    fn machine_env_replaces_the_image_entry_for_the_same_key() {
+        let image = vec!["PATH=/usr/bin".to_string(), "LANG=C".to_string()];
+        let vm = vec![
+            ("PATH".to_string(), "/opt/bin".to_string()),
+            ("EXTRA".to_string(), "1".to_string()),
+        ];
+
+        let merged = merge_env(&image, &vm);
+
+        assert_eq!(
+            merged,
+            vec![
+                "LANG=C".to_string(),
+                "PATH=/opt/bin".to_string(),
+                "EXTRA=1".to_string()
+            ]
+        );
+        assert_eq!(
+            merged.iter().filter(|e| e.starts_with("PATH=")).count(),
+            1,
+            "exactly one PATH entry"
+        );
+    }
+
+    /// A bare machine has no image, so the machine's env is the whole set.
+    #[test]
+    fn machine_env_stands_alone_without_an_image() {
+        let vm = vec![("FOO".to_string(), "bar".to_string())];
+        assert_eq!(merge_env(&[], &vm), vec!["FOO=bar".to_string()]);
+    }
 }

--- a/tests/test_pack.sh
+++ b/tests/test_pack.sh
@@ -934,6 +934,84 @@ test_from_vm_imported_layers_preserved_on_repack() {
     cleanup_from_vm_imported_layers_preserved
 }
 
+# Regression: pack a machine whose image has MORE THAN THREE layers, and keep
+# the image's declared environment.
+#
+# Both failures below were invisible to the other --from-vm tests because those
+# use alpine, a single-layer image with no declared env:
+#
+#   1. The layer merge shelled out to `mount -o lowerdir=...`, and mount(8)
+#      rejects an option value past ~255 bytes — about three OCI layer paths.
+#      A single layer never mounts an overlay at all, so alpine sailed through
+#      while every real image failed with a bad superblock error.
+#   2. The manifest recorded only the env the machine was created with, so the
+#      image's own env was dropped. Flattening leaves no image config for the
+#      packed machine to read, so anything the image put on PATH stopped
+#      resolving.
+#
+# python:3.12-slim is the smallest handy image that has both properties: four
+# layers, and a declared PYTHON_VERSION/LANG that the default env cannot supply.
+test_from_vm_multi_layer_and_image_env() {
+    local vm_name="from-vm-multilayer-$$"
+    local pack_output="$TEST_DIR/from-vm-multilayer"
+
+    cleanup_multi_layer() {
+        $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
+        rm -f "$pack_output" "$pack_output.smolmachine"
+    }
+    cleanup_multi_layer
+
+    echo "  Step 1: Create a machine from a multi-layer image and write a marker..."
+    $SMOLVM machine create --name "$vm_name" --image python:3.12-slim --net 2>&1 || {
+        echo "FAIL: machine create failed"; cleanup_multi_layer; return 1
+    }
+    $SMOLVM machine start --name "$vm_name" 2>&1 || {
+        echo "FAIL: machine start failed"; cleanup_multi_layer; return 1
+    }
+    $SMOLVM machine exec --name "$vm_name" -- sh -c 'echo baked > /root/multilayer-marker' 2>&1 || {
+        echo "FAIL: could not write marker"; cleanup_multi_layer; return 1
+    }
+    $SMOLVM machine stop --name "$vm_name" 2>&1 || {
+        echo "FAIL: machine stop failed"; cleanup_multi_layer; return 1
+    }
+
+    echo "  Step 2: Pack it (this is what failed once an image had four layers)..."
+    $SMOLVM pack create --from-vm "$vm_name" -o "$pack_output" 2>&1 || {
+        echo "FAIL: pack --from-vm failed on a multi-layer image"
+        cleanup_multi_layer; return 1
+    }
+    [[ -f "$pack_output.smolmachine" ]] || {
+        echo "FAIL: no .smolmachine sidecar produced"; cleanup_multi_layer; return 1
+    }
+
+    echo "  Step 3: The packed machine keeps its baked file and the image env..."
+    local result
+    result=$(run_with_timeout 90 "$pack_output" run -- sh -c \
+        'cat /root/multilayer-marker; echo "PYVER=$PYTHON_VERSION"; echo "LANG=$LANG"; python3 --version' 2>&1)
+
+    [[ "$result" == *"baked"* ]] || {
+        echo "FAIL: baked marker missing from packed machine (got: $result)"
+        cleanup_multi_layer; return 1
+    }
+    # Empty PYVER= means the image's env never reached the manifest.
+    [[ "$result" == *"PYVER=3.12"* ]] || {
+        echo "FAIL: image env PYTHON_VERSION missing from packed machine (got: $result)"
+        cleanup_multi_layer; return 1
+    }
+    [[ "$result" == *"LANG=C.UTF-8"* ]] || {
+        echo "FAIL: image env LANG missing from packed machine (got: $result)"
+        cleanup_multi_layer; return 1
+    }
+    # Resolved through the image's PATH rather than an absolute path.
+    [[ "$result" == *"Python 3.12"* ]] || {
+        echo "FAIL: python3 did not resolve on PATH in packed machine (got: $result)"
+        cleanup_multi_layer; return 1
+    }
+
+    cleanup_multi_layer
+}
+
 # Regression: --rebase-from-image intentionally rebuilds lower image layers and
 # drops imported artifact layers, while keeping the current writable overlay.
 test_from_vm_rebase_from_image_drops_imported_layers() {
@@ -1581,6 +1659,7 @@ if [[ "$QUICK_MODE" != "true" ]]; then
     run_test "from-vm-image: container overlay captured" test_from_vm_image_overlay || true
     run_test "from-vm-image: imported layers preserved on repack" test_from_vm_imported_layers_preserved_on_repack || true
     run_test "from-vm-image: rebase flag drops imported layers" test_from_vm_rebase_from_image_drops_imported_layers || true
+    run_test "from-vm-image: multi-layer image packs and keeps image env" test_from_vm_multi_layer_and_image_env || true
 
     echo ""
     echo "Running Debian Pack Roundtrip Tests..."


### PR DESCRIPTION
Packing a stopped machine merged its image layers by shelling out to mount(8), which rejects a lowerdir value longer than about 255 bytes — roughly three OCI layer paths — so packing any machine built from an image with four or more layers failed with a bad superblock error, and only single-layer images such as alpine got through; the merge now runs in the agent through the same fsconfig path the runtime container mount already uses, appending each layer separately so no option-length limit applies. The packed manifest also recorded only the environment the machine was created with, dropping the image's own, so a packed machine lost the image's PATH and could no longer resolve the binaries the image installed — it now takes the image environment as the baseline and layers the machine's on top, the same order a running machine resolves them in and the same order the from-image pack path already used. Verified by packing a 14-layer postgres machine and booting the artifact: its image contents, its baked filesystem changes, its PATH and its declared variables all survive, and a machine-level override still wins.