### PR TITLE
Add labels to the embedded MachineSpec so SDK callers reach CLI parity

### DIFF
--- a/crates/smolvm-shim/src/engine.rs
+++ b/crates/smolvm-shim/src/engine.rs
@@ -614,6 +614,7 @@ impl PodBackend for EnginePodBackend {
                 },
                 persistent: true,
                 runtime_managed: true,
+                labels: Default::default(),
             };
             match rt.create_machine(spec.clone()) {
                 Ok(()) => {}

--- a/examples/doubledelete_test.rs
+++ b/examples/doubledelete_test.rs
@@ -19,6 +19,7 @@ fn main() {
         image: None,
         persistent: false,
         runtime_managed: false,
+        labels: Default::default(),
     })
     .expect("create");
     rt.delete_machine(name).expect("first delete");

--- a/examples/largeoutput_test.rs
+++ b/examples/largeoutput_test.rs
@@ -20,6 +20,7 @@ fn main() {
         image: None,
         persistent: false,
         runtime_managed: false,
+        labels: Default::default(),
     });
     rt.start_machine(name).expect("start");
     // small output: works

--- a/examples/orphan_test.rs
+++ b/examples/orphan_test.rs
@@ -24,6 +24,7 @@ fn main() {
         image: None,
         persistent: false,
         runtime_managed: false,
+        labels: Default::default(),
     };
     let _ = rt.create_machine(spec); // ignore "already exists" on reruns
     rt.start_machine(&name).expect("start machine");

--- a/examples/readfile_fix_test.rs
+++ b/examples/readfile_fix_test.rs
@@ -21,6 +21,7 @@ fn main() {
         image: None,
         persistent: false,
         runtime_managed: false,
+        labels: Default::default(),
     });
     rt.start_machine(name).expect("start");
 

--- a/examples/reattach_test.rs
+++ b/examples/reattach_test.rs
@@ -21,6 +21,7 @@ fn main() {
         image: None,
         persistent: true,
         runtime_managed: false,
+        labels: Default::default(),
     })
     .expect("create");
     rt.start_machine(name).expect("start");

--- a/src/embedded/control.rs
+++ b/src/embedded/control.rs
@@ -2,6 +2,7 @@
 
 use crate::agent::{AgentClient, AgentManager, HostMount, LaunchFeatures, VmResources};
 use crate::config::{RecordState, VmRecord};
+use std::collections::BTreeMap;
 use crate::data::network::PortMapping;
 use crate::data::validate_vm_name;
 use crate::db::SmolvmDb;
@@ -9,7 +10,11 @@ use crate::embedded::handle::VmHandle;
 use crate::{Error, Result};
 
 /// Runtime configuration supplied by an embedded SDK constructor.
-#[derive(Debug, Clone)]
+/// `Default` is derived so a new field does not break every construction site —
+/// callers can spread `..MachineSpec::default()`. The shim and the examples
+/// previously listed every field, which made each addition a breaking change to
+/// code that only compiles on Linux (and so failed after review, not during it).
+#[derive(Debug, Clone, Default)]
 pub struct MachineSpec {
     /// Unique machine name.
     pub name: String,
@@ -25,6 +30,15 @@ pub struct MachineSpec {
     pub image: Option<String>,
     /// Whether the machine should persist across stop/start.
     pub persistent: bool,
+    /// Caller metadata, mirroring the CLI's `--label` and surfaced by
+    /// `machine ls --json`. smolvm never interprets these.
+    ///
+    /// An embedder managing many machines has only the name to go on otherwise,
+    /// and a name cannot be read back reliably (the table view truncates it), so
+    /// without labels a process that dies cannot recognise its own machines
+    /// afterwards. That is the difference between reclaiming a leaked VM and
+    /// leaving it running.
+    pub labels: BTreeMap<String, String>,
     /// Set by the Kubernetes containerd shim for pod-sandbox VMs. Marks the
     /// record so node-reboot reconciliation can reclaim it (and only it) when
     /// its process is gone. Defaults to false for CLI/SDK machines.
@@ -53,6 +67,7 @@ impl MachineSpec {
         record.gpu_vram_mib = self.resources.gpu_vram_mib;
         record.cuda = self.resources.cuda;
         record.image = self.image.clone();
+        record.labels = self.labels.clone();
         record.ephemeral = !self.persistent;
         record.runtime_managed = self.runtime_managed;
         record

--- a/src/embedded/control.rs
+++ b/src/embedded/control.rs
@@ -2,12 +2,12 @@
 
 use crate::agent::{AgentClient, AgentManager, HostMount, LaunchFeatures, VmResources};
 use crate::config::{RecordState, VmRecord};
-use std::collections::BTreeMap;
 use crate::data::network::PortMapping;
 use crate::data::validate_vm_name;
 use crate::db::SmolvmDb;
 use crate::embedded::handle::VmHandle;
 use crate::{Error, Result};
+use std::collections::BTreeMap;
 
 /// Runtime configuration supplied by an embedded SDK constructor.
 /// `Default` is derived so a new field does not break every construction site —
@@ -413,7 +413,8 @@ mod tests {
             resources: VmResources::default(),
             image: None,
             persistent,
-            runtime_managed: false,
+            // Spread the rest so a new spec field does not break the fixtures.
+            ..MachineSpec::default()
         }
     }
 

--- a/src/embedded/runtime.rs
+++ b/src/embedded/runtime.rs
@@ -587,7 +587,8 @@ mod tests {
             resources: crate::agent::VmResources::default(),
             image: None,
             persistent,
-            runtime_managed: false,
+            // Spread the rest so a new spec field does not break the fixtures.
+            ..MachineSpec::default()
         }
     }
 


### PR DESCRIPTION
`machine create --label` had no embedded equivalent, so an SDK-driven process could not recognise its own machines after a restart the way a CLI-driven one can; MachineSpec now carries labels and derives Default, so the next field addition is not a breaking change to every construction site.