### PR TITLE
Report honest completion status from cuEventQuery instead of always complete

### DIFF
--- a/crates/smolvm-cuda-shim/src/lib.rs
+++ b/crates/smolvm-cuda-shim/src/lib.rs
@@ -3124,8 +3124,14 @@ pub extern "C" fn cuEventSynchronize(event: *mut c_void) -> c_int {
 }
 
 #[no_mangle]
-pub extern "C" fn cuEventQuery(_event: *mut c_void) -> c_int {
-    CUDA_SUCCESS
+pub extern "C" fn cuEventQuery(event: *mut c_void) -> c_int {
+    // Honest completion status (0 or 600-NotReady), same as cuStreamQuery above:
+    // a caller polling an event to decide when a buffer is safe to reuse must not
+    // be told "complete" while the work is still in flight on a side stream.
+    match with_state(|s| s.client.event_query(event as u64)) {
+        Ok(code) => code,
+        Err(e) => e,
+    }
 }
 
 #[no_mangle]


### PR DESCRIPTION
Fixes #932.

`cuEventQuery` in the driver shim returned `CUDA_SUCCESS` unconditionally and never bound its event handle, so a caller polling an event to decide when a buffer is safe to reuse was told "done" while the work was still in flight on a side stream. This forwards to `client.event_query` and returns the real code (0, or 600-NotReady), which is the rule change: the shim now reports what the daemon says instead of a fixed answer.

The shape is copied from `cuStreamQuery` 48 lines above, which was already made honest for exactly this reason ("Honest completion status (0 or 600-NotReady) now that work runs on real side streams"), and the runtime shim's `cudaEventQuery` documents the consequence of getting it wrong, since always answering "complete" caused premature reuse (ILLEGAL_ADDRESS) once work really ran on side streams. Both wire ends already existed and were simply unused by this shim (`smolvm-cuda/src/client.rs` `event_query`, `host.rs` `Request::EventQuery`), so nothing new is added on either end.

Scope is deliberately one call site: no other shim function is touched, the cudart shim is untouched, and there is no reformatting. The exposed population is code on the CUDA **driver** API, including anything resolving the symbol via `cuGetProcAddress`. PyTorch links against cudart and that shim is already correct, so this is not a PyTorch fix.

⚠ **No test, and I would rather say why than stay silent.** `cuEventQuery` is a thin FFI pass-through whose only branch is `with_state` succeeding or failing, and `with_state` needs a live client connected to the daemon, so a real regression test needs a GPU and a running daemon, which CI does not have. The crate's existing unit tests are all pure-logic (fatbin parsing, ABI layout, ELF pointers) and there is no harness for the RPC path; `cuStreamQuery`'s equivalent fix shipped the same way. I did not want to add a mock that would only assert the match arms I just wrote.

**Validation:** `cargo check --lib --bins -p smolvm-cuda-shim` clean (the 3 dead-code warnings are pre-existing constants, unchanged by this diff), `cargo test --lib -p smolvm-cuda-shim` 8 passed / 0 failed, `cargo fmt --check` clean. Behaviour itself is **not** hardware-verified: the correctness argument is the sibling shim's documented regression, not a run.

