### PR TITLE
Pass the stub name to pack create -o in the README snapshot recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ like — by hand, or from a Smolfile — then pack the stopped machine into a
 ```bash
 smolvm machine shell --name myvm          # install and configure interactively
 smolvm machine stop  --name myvm
-smolvm pack create --from-vm myvm -o myvm.smolmachine
+smolvm pack create --from-vm myvm -o myvm
 smolvm pack push --file myvm.smolmachine ghcr.io/you/myvm:v1
 ```
 


### PR DESCRIPTION
The README's "snapshot a machine into a reusable image" recipe can't be followed as written — the third of its four commands is rejected by smolvm itself. `pack create -o` takes the stub name, not the sidecar name, so anyone following the recipe loses a minute to an error the docs caused.

`pack create --output` names the executable stub and derives the `.smolmachine` sidecar from it (`sidecar_path_for`), so `-o myvm.smolmachine` would land the sidecar at `myvm.smolmachine.smolmachine`. `PackCreateCmd::run` rejects a `.smolmachine` extension up front and names the right form in the error, so this fails loudly rather than mispacking anything — the cost is a headline workflow that doesn't run, not a broken pack.

The fourth line is deliberately unchanged: with `-o myvm` the sidecar is written as `myvm.smolmachine`, exactly what `pack push --file myvm.smolmachine` expects. The other five `pack create` examples in the repo already use the stub form, and the `pack pull -o ./my-app.smolmachine` examples are correct as they stand — `pack pull` writes the sidecar directly and has no such guard.
