### PR TITLE
Run the three VM-less shell suites in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,19 @@ jobs:
       - name: Check secrets guardrails
         run: ./scripts/check-secrets-guards.sh
 
+  shell-tests:
+    name: Shell tests (VM-less)
+    runs-on: ubuntu-latest
+    # Only the three suites that declare they need no smolvm binary, VM, KVM or
+    # network. Everything else under tests/ drives real machines and stays out of
+    # CI for the reasons the macOS and Linux jobs already document. These need no
+    # build and no LFS, so they get their own job rather than slowing a job that
+    # does: nothing here waits on a toolchain, and a failure names itself.
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run the shell suites that need no VM
+        run: ./tests/run_tests.sh rootfs-modes harness wrapper
+
   libkrun-provenance:
     name: libkrun freshness
     runs-on: ubuntu-latest

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -32,6 +32,12 @@
 #   pack-quick      test_pack.sh --quick
 #   gpu             test_gpu.sh  (requires GPU hardware)
 #
+# VM-less suites (opt-in only; no smolvm binary, VM, KVM or network needed, so
+# unlike every group above these are safe to run anywhere, including in CI):
+#   rootfs-modes    test_agent_rootfs_modes.sh
+#   harness         test_harness.sh
+#   wrapper         test_wrapper.sh
+#
 # Non-pass/fail:
 #   bench           bench_vm_startup.sh (prints timing, always exits 0)
 #
@@ -72,6 +78,9 @@ get_suite() {
         pack-quick)  echo "$SCRIPT_DIR/test_pack.sh --quick" ;;
         gpu)         echo "$SCRIPT_DIR/test_gpu.sh" ;;
         scale)       echo "$SCRIPT_DIR/test_scale.sh" ;;
+        rootfs-modes) echo "$SCRIPT_DIR/test_agent_rootfs_modes.sh" ;;
+        harness)     echo "$SCRIPT_DIR/test_harness.sh" ;;
+        wrapper)     echo "$SCRIPT_DIR/test_wrapper.sh" ;;
         *)           return 1 ;;
     esac
 }
@@ -156,6 +165,7 @@ else
             echo "Unknown group: $group"
             echo "Feature suites: bare db network volumes ports storage resources reliability run image local-image fork-base packed"
             echo "Extended suites: cli api virtio-net smolfile pack pack-quick gpu scale"
+            echo "VM-less suites: rootfs-modes harness wrapper"
             echo "Other: bench"
             exit 1
         }


### PR DESCRIPTION
We have 31 shell suites under `tests/` and CI runs none of them. Most of that is right (they need a real VM) but three of them do not, and one of those is the only thing anywhere that tests `normalize_owner_only_modes()`. That function only runs during a release build, so if it breaks we will find out after cutting a tarball instead of on the PR. This runs those three and nothing else.

---

**The three suites declare it themselves:** `test_agent_rootfs_modes.sh` ("Pure fixture test: no smolvm binary, no VM, no network"), `test_harness.sh` ("Pure harness test: no smolvm binary, no VM, no network"), `test_wrapper.sh` ("do not require a built smolvm binary, libkrun, KVM, or an agent rootfs"). Together they are 13 tests in about 4 seconds.

**The other 28 stay excluded, deliberately.** They drive real machines and need Hypervisor.framework or KVM, and the macOS and Linux jobs already say so in comments. Nothing here changes that, and this is not a step toward running them; the boundary is exactly "the suites that declare they need no VM."

**`run_tests.sh` had no group mapping for any of the three**, so they could only be invoked by direct path. They are added as their own opt-in category, so the no-argument default set stays VM-bound and unchanged.

**Own job rather than a step in an existing one:** it needs no toolchain, no build artifacts and no LFS, so it starts immediately, adds nothing to the critical path of a job that does, and names itself when it fails. It sits with the other quick checks and, like `Secrets invariants`, `libkrun freshness` and `Cargo Audit`, is not wired into the `CI Success` aggregate.

**Validation:** on macOS 14 (arm64), against this branch, `./tests/run_tests.sh rootfs-modes harness wrapper` exits 0: `rootfs-modes` 5 tests, `harness` 4, `wrapper` 4, 13 total, about 4 s wall. ⚠ Those numbers are from macOS only; `test_agent_rootfs_modes.sh` manipulates file modes, so the Linux CI run in this PR is the first evidence it behaves the same there. If it does not, that is worth knowing on its own rather than papering over with an OS filter.

