### PR TITLE
Record egress denials and surface them per machine through the CLI and serve API

### DIFF
--- a/crates/smolvm-network/src/egress.rs
+++ b/crates/smolvm-network/src/egress.rs
@@ -205,6 +205,10 @@ pub struct EgressPolicy {
     inner: Option<Arc<AllowList>>,
     /// Hard-floor scope, resolved once from the deployment context at creation.
     floor: FloorMode,
+    /// Audit sink for denials. When set, every denied connect/sendto/resolve is
+    /// appended here in addition to the runtime's stderr line, so the record
+    /// can't be evicted by ordinary connection chatter in the boot log.
+    denial_log: Option<Arc<std::path::PathBuf>>,
 }
 
 impl EgressPolicy {
@@ -213,6 +217,7 @@ impl EgressPolicy {
         Self {
             inner: None,
             floor: floor_mode(),
+            denial_log: None,
         }
     }
 
@@ -248,10 +253,51 @@ impl EgressPolicy {
                 learned: Mutex::new(HashMap::new()),
             })),
             floor: floor_mode(),
+            denial_log: None,
         }
     }
 
     /// Convenience for the CIDR-only case.
+    /// Attach the audit sink denials are appended to. The launcher points this
+    /// at the machine's data dir so the host can read denials back.
+    pub fn with_denial_log(mut self, path: std::path::PathBuf) -> Self {
+        self.denial_log = Some(Arc::new(path));
+        self
+    }
+
+    /// Record one denial: a stderr line for anyone tailing the boot log, and —
+    /// when a sink is attached — an appended line in the dedicated audit file,
+    /// which connection chatter can never evict. Keep the marker text stable:
+    /// the host's `read_egress_denials` parses `egress policy denied <op> <dest>`.
+    ///
+    /// The sink rotates once past 8 MiB (`.1` suffix) so a workload hammering a
+    /// denied destination at packet rate can't fill the host disk.
+    pub fn record_denial(&self, operation: &str, dest: &dyn std::fmt::Display) {
+        crate::virtio_net_log!("egress policy denied {} {}", operation, dest);
+        let Some(path) = self.denial_log.as_deref() else {
+            return;
+        };
+        const ROTATE_BYTES: u64 = 8 * 1024 * 1024;
+        if std::fs::metadata(path).is_ok_and(|m| m.len() > ROTATE_BYTES) {
+            let _ = std::fs::rename(path, path.with_extension("log.1"));
+        }
+        use std::io::Write;
+        if let Ok(mut file) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+        {
+            let _ = writeln!(
+                file,
+                "{}",
+                crate::format_network_log_line(
+                    std::time::SystemTime::now(),
+                    &format!("egress policy denied {operation} {dest}"),
+                )
+            );
+        }
+    }
+
     pub fn from_allowed_cidrs(allowed: Option<&[String]>) -> Self {
         Self::new(allowed, None)
     }

--- a/crates/smolvm-network/src/lib.rs
+++ b/crates/smolvm-network/src/lib.rs
@@ -187,7 +187,11 @@ impl GuestNetworkConfig {
     }
 }
 
-fn format_network_log_line(timestamp: SystemTime, message: &str) -> String {
+/// Filename of the per-VM egress denial audit log, created beside the vsock
+/// socket by the launcher and read back by the host's `read_egress_denials`.
+pub const EGRESS_DENIALS_LOG: &str = "egress-denials.log";
+
+pub(crate) fn format_network_log_line(timestamp: SystemTime, message: &str) -> String {
     format!(
         "[{}]: {}",
         humantime::format_rfc3339_seconds(timestamp),

--- a/crates/smolvm-network/src/stack.rs
+++ b/crates/smolvm-network/src/stack.rs
@@ -304,7 +304,7 @@ fn run_network_stack(
                     // the machine's egress audit trail (`read_egress_denials`).
                     let relay_allowed = udp_relay::should_relay_udp(destination, &egress);
                     if !relay_allowed && destination.port() != 53 {
-                        virtio_net_log!("egress policy denied sendto {}", destination);
+                        egress.record_denial("sendto", &destination);
                     }
                     if relay_allowed && udp_sockets.ensure_socket(destination, &mut sockets) {
                         if matches!(
@@ -783,7 +783,7 @@ fn classify_dns_query(query: &[u8], egress: &EgressPolicy) -> DnsDecision {
                 name
             );
             // Standardized marker for the egress audit trail (`read_egress_denials`).
-            virtio_net_log!("egress policy denied resolve {}", name);
+            egress.record_denial("resolve", &name);
             DnsDecision::Immediate(dns::error_response(query, dns::DNS_RCODE_NXDOMAIN))
         }
         None => DnsDecision::Immediate(dns::error_response(query, dns::DNS_RCODE_SERVFAIL)),

--- a/crates/smolvm-network/src/stack.rs
+++ b/crates/smolvm-network/src/stack.rs
@@ -299,10 +299,14 @@ fn run_network_stack(
                 }
                 FrameAction::UdpFlow { destination } => {
                     // Same egress policy as TCP; a denied destination's datagram
-                    // is silently dropped (a guest sees a normal UDP black hole).
-                    if udp_relay::should_relay_udp(destination, &egress)
-                        && udp_sockets.ensure_socket(destination, &mut sockets)
-                    {
+                    // is silently dropped (a guest sees a normal UDP black hole),
+                    // but the denial is recorded in the boot log — these lines are
+                    // the machine's egress audit trail (`read_egress_denials`).
+                    let relay_allowed = udp_relay::should_relay_udp(destination, &egress);
+                    if !relay_allowed && destination.port() != 53 {
+                        virtio_net_log!("egress policy denied sendto {}", destination);
+                    }
+                    if relay_allowed && udp_sockets.ensure_socket(destination, &mut sockets) {
                         if matches!(
                             interface.poll_ingress_single(now, &mut device, &mut sockets),
                             PollIngressSingleResult::None
@@ -778,6 +782,8 @@ fn classify_dns_query(query: &[u8], egress: &EgressPolicy) -> DnsDecision {
                 "virtio-net: blocking DNS query by allow-host policy name={}",
                 name
             );
+            // Standardized marker for the egress audit trail (`read_egress_denials`).
+            virtio_net_log!("egress policy denied resolve {}", name);
             DnsDecision::Immediate(dns::error_response(query, dns::DNS_RCODE_NXDOMAIN))
         }
         None => DnsDecision::Immediate(dns::error_response(query, dns::DNS_RCODE_SERVFAIL)),

--- a/crates/smolvm-network/src/tcp_relay.rs
+++ b/crates/smolvm-network/src/tcp_relay.rs
@@ -287,6 +287,10 @@ impl TcpRelayTable {
                 %destination,
                 "virtio-net: blocking outbound connection by egress policy"
             );
+            // Recorded unconditionally in the boot log: these lines are the
+            // machine's egress audit trail, parsed by the host's
+            // `read_egress_denials` (keep the marker text stable).
+            virtio_net_log!("egress policy denied connect to {}", destination);
             return false;
         }
 

--- a/crates/smolvm-network/src/tcp_relay.rs
+++ b/crates/smolvm-network/src/tcp_relay.rs
@@ -287,10 +287,10 @@ impl TcpRelayTable {
                 %destination,
                 "virtio-net: blocking outbound connection by egress policy"
             );
-            // Recorded unconditionally in the boot log: these lines are the
-            // machine's egress audit trail, parsed by the host's
-            // `read_egress_denials` (keep the marker text stable).
-            virtio_net_log!("egress policy denied connect to {}", destination);
+            // Recorded in the machine's egress audit trail (dedicated file +
+            // stderr) — parsed by the host's `read_egress_denials`.
+            self.egress
+                .record_denial("connect", &format_args!("to {destination}"));
             return false;
         }
 

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -1056,10 +1056,19 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
                     .iter()
                     .map(|mapping| VirtioPortMapping::new(mapping.host, mapping.guest))
                     .collect();
-                let egress = smolvm_network::EgressPolicy::new(
+                // The denial sink lives beside the vsock socket — the same
+                // per-VM dir the host resolves via `vm_data_dir`, where
+                // `read_egress_denials` looks for it.
+                let denial_log = vsock_socket
+                    .parent()
+                    .map(|dir| dir.join(smolvm_network::EGRESS_DENIALS_LOG));
+                let mut egress = smolvm_network::EgressPolicy::new(
                     resources.allowed_cidrs.as_deref(),
                     egress_refresh_hosts.as_deref(),
                 );
+                if let Some(path) = denial_log {
+                    egress = egress.with_denial_log(path);
+                }
                 let egress_path = egress_telemetry.map(|p| p.to_path_buf());
 
                 // The host and guest ends of the virtio-net channel are an AF_UNIX

--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -327,9 +327,13 @@ pub fn launch_agent_vm_dynamic(
                 .iter()
                 .map(|(host, guest)| VirtioPortMapping::new(*host, *guest))
                 .collect();
-            let egress = smolvm_network::EgressPolicy::from_allowed_cidrs(
+            // Denial sink beside the vsock socket, mirroring the static launcher.
+            let mut egress = smolvm_network::EgressPolicy::from_allowed_cidrs(
                 config.resources.allowed_cidrs.as_deref(),
             );
+            if let Some(dir) = config.vsock_socket.parent() {
+                egress = egress.with_denial_log(dir.join(smolvm_network::EGRESS_DENIALS_LOG));
+            }
 
             // The host/guest ends of the virtio-net channel are an AF_UNIX
             // stream: a socketpair fd on Unix, a per-VM path listener libkrun

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -360,14 +360,14 @@ pub fn egress_telemetry_file(name: &str) -> PathBuf {
     vm_data_dir(name).join("egress")
 }
 
-/// Per-VM boot-subprocess stderr log: `<vm_data_dir>/agent-startup-error.log`.
-/// The subprocess re-points its own stderr here at startup (append mode, so
-/// prior boots survive), and the virtio-net runtime's unconditional log lines
-/// land in it — including the `egress policy denied` lines that are a confined
-/// machine's only record of blocked traffic. Resolved from the name on both
-/// sides of the process boundary, like [`egress_telemetry_file`].
-pub fn boot_stderr_log_file(name: &str) -> PathBuf {
-    vm_data_dir(name).join("agent-startup-error.log")
+/// Per-VM egress denial audit log: `<vm_data_dir>/egress-denials.log`. The
+/// virtio-net runtime appends one line per denied connect/sendto/resolve
+/// (append mode, so prior boots survive; rotated once past 8 MiB). Dedicated
+/// so ordinary connection chatter in the boot log can never evict an audit
+/// event. Resolved from the name on both sides of the process boundary, like
+/// [`egress_telemetry_file`].
+pub fn egress_denials_log_file(name: &str) -> PathBuf {
+    vm_data_dir(name).join(smolvm_network::EGRESS_DENIALS_LOG)
 }
 
 /// One egress denial observed by the VMM: the policy refused a guest's
@@ -383,10 +383,9 @@ pub struct EgressDenial {
     pub dest: String,
 }
 
-/// How much of the VMM log tail to scan for denial lines. A denial line is
-/// ~100 bytes, so this window holds a few thousand events — far more than a
-/// caller pages through — while bounding the read on a long-lived machine
-/// whose log has grown.
+/// How much of the denial log tail to scan. The file holds only denial lines
+/// (~100 bytes each), so this window is a few thousand events — far more than
+/// a caller pages through — while bounding the read.
 const EGRESS_DENIAL_SCAN_BYTES: u64 = 256 * 1024;
 
 /// Read the egress denials recorded for `name`, oldest first, capped at
@@ -394,7 +393,7 @@ const EGRESS_DENIAL_SCAN_BYTES: u64 = 256 * 1024;
 /// booted, or built before the log existed) — absence of the file is
 /// "no denials observed", not an error.
 pub fn read_egress_denials(name: &str, limit: usize) -> Vec<EgressDenial> {
-    let path = boot_stderr_log_file(name);
+    let path = egress_denials_log_file(name);
     let Ok(mut file) = std::fs::File::open(&path) else {
         return Vec::new();
     };
@@ -3175,7 +3174,7 @@ mod tests {
         // Write the log exactly where vmm_log_file() resolves for a
         // pid-namespaced throwaway name, and remove that dir afterwards.
         let name = format!("egress-test-{}", std::process::id());
-        let log = boot_stderr_log_file(&name);
+        let log = egress_denials_log_file(&name);
         std::fs::create_dir_all(log.parent().expect("parent")).expect("mkdir");
         let mut contents = String::new();
         for i in 0..10 {

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -360,6 +360,98 @@ pub fn egress_telemetry_file(name: &str) -> PathBuf {
     vm_data_dir(name).join("egress")
 }
 
+/// Per-VM boot-subprocess stderr log: `<vm_data_dir>/agent-startup-error.log`.
+/// The subprocess re-points its own stderr here at startup (append mode, so
+/// prior boots survive), and the virtio-net runtime's unconditional log lines
+/// land in it — including the `egress policy denied` lines that are a confined
+/// machine's only record of blocked traffic. Resolved from the name on both
+/// sides of the process boundary, like [`egress_telemetry_file`].
+pub fn boot_stderr_log_file(name: &str) -> PathBuf {
+    vm_data_dir(name).join("agent-startup-error.log")
+}
+
+/// One egress denial observed by the VMM: the policy refused a guest's
+/// connect or sendto toward `dest`.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct EgressDenial {
+    /// Denial time as logged by the VMM (RFC 3339, microsecond precision), or
+    /// empty when the line carried no parseable timestamp.
+    pub timestamp: String,
+    /// The refused operation: `connect` (TCP) or `sendto` (UDP).
+    pub operation: String,
+    /// The destination the guest tried to reach, as `ip:port`.
+    pub dest: String,
+}
+
+/// How much of the VMM log tail to scan for denial lines. A denial line is
+/// ~100 bytes, so this window holds a few thousand events — far more than a
+/// caller pages through — while bounding the read on a long-lived machine
+/// whose log has grown.
+const EGRESS_DENIAL_SCAN_BYTES: u64 = 256 * 1024;
+
+/// Read the egress denials recorded for `name`, oldest first, capped at
+/// `limit`. Returns an empty list when the machine has no VMM log (never
+/// booted, or built before the log existed) — absence of the file is
+/// "no denials observed", not an error.
+pub fn read_egress_denials(name: &str, limit: usize) -> Vec<EgressDenial> {
+    let path = boot_stderr_log_file(name);
+    let Ok(mut file) = std::fs::File::open(&path) else {
+        return Vec::new();
+    };
+    use std::io::{Read, Seek, SeekFrom};
+    let len = file.metadata().map(|m| m.len()).unwrap_or(0);
+    if len > EGRESS_DENIAL_SCAN_BYTES {
+        let _ = file.seek(SeekFrom::End(-(EGRESS_DENIAL_SCAN_BYTES as i64)));
+    }
+    let mut tail = String::new();
+    if file.read_to_string(&mut tail).is_err() {
+        return Vec::new();
+    }
+    let mut events: Vec<EgressDenial> = tail.lines().filter_map(parse_egress_denial_line).collect();
+    if events.len() > limit {
+        events.drain(..events.len() - limit);
+    }
+    events
+}
+
+/// Parse one boot-log line into a denial event, or `None` for any other line.
+///
+/// The virtio-net runtime emits three shapes (see `smolvm-network`'s tcp/udp
+/// relays and DNS filter), prefixed `[<ts>]: `:
+///   `egress policy denied connect to <ip:port>`
+///   `egress policy denied sendto <ip:port>`
+///   `egress policy denied resolve <hostname>`
+/// Matching is anchored on the `egress policy denied ` marker rather than the
+/// prefix, so surrounding format drift can't silently discard events; libkrun's
+/// TSI muxer logs the same marker, so those parse too if they ever appear.
+fn parse_egress_denial_line(line: &str) -> Option<EgressDenial> {
+    const MARKER: &str = "egress policy denied ";
+    let after = &line[line.find(MARKER)? + MARKER.len()..];
+    let (operation, rest) = after.split_once(' ')?;
+    if operation != "connect" && operation != "sendto" && operation != "resolve" {
+        return None;
+    }
+    let dest = rest.strip_prefix("to ").unwrap_or(rest).trim();
+    if dest.is_empty() {
+        return None;
+    }
+    // virtio-net lines look like `[2026-08-13T02:31:05Z]: ...`; env_logger's
+    // (libkrun) like `[2026-08-13T02:31:05.123456Z WARN ...] ...`. Both start
+    // with a bracketed timestamp token.
+    let timestamp = line
+        .strip_prefix('[')
+        .and_then(|r| r.split_whitespace().next())
+        .unwrap_or("")
+        .trim_end_matches(':')
+        .trim_end_matches(']')
+        .to_string();
+    Some(EgressDenial {
+        timestamp,
+        operation: operation.to_string(),
+        dest: dest.to_string(),
+    })
+}
+
 /// How often the VM subprocess flushes its egress counter to disk. The control
 /// plane's egress rollup runs on a multi-minute cadence, so a value this small
 /// keeps the file comfortably fresh while writing only a few bytes.
@@ -3025,6 +3117,79 @@ mod tests {
     fn restored_cuda_clones_fail_faster_than_other_boots() {
         assert_eq!(agent_ready_timeout(true), Duration::from_secs(10));
         assert_eq!(agent_ready_timeout(false), Duration::from_secs(30));
+    }
+
+    /// The three denial shapes the virtio-net runtime emits parse into
+    /// structured events — and libkrun's muxer format parses too — while
+    /// everything else in a boot log is ignored.
+    #[test]
+    fn egress_denial_lines_parse_and_noise_is_ignored() {
+        let connect = parse_egress_denial_line(
+            "[2026-08-14T03:13:08Z]: egress policy denied connect to 8.8.8.8:443",
+        )
+        .expect("connect line parses");
+        assert_eq!(connect.timestamp, "2026-08-14T03:13:08Z");
+        assert_eq!(connect.operation, "connect");
+        assert_eq!(connect.dest, "8.8.8.8:443");
+
+        let sendto = parse_egress_denial_line(
+            "[2026-08-14T03:13:09Z]: egress policy denied sendto 9.9.9.9:123",
+        )
+        .expect("sendto line parses");
+        assert_eq!(sendto.operation, "sendto");
+        assert_eq!(sendto.dest, "9.9.9.9:123");
+
+        let resolve = parse_egress_denial_line(
+            "[2026-08-14T03:13:10Z]: egress policy denied resolve evil.example.com",
+        )
+        .expect("resolve line parses");
+        assert_eq!(resolve.operation, "resolve");
+        assert_eq!(resolve.dest, "evil.example.com");
+
+        // libkrun's TSI muxer format (env_logger) parses as well.
+        let muxer = parse_egress_denial_line(
+            "[2026-08-13T02:31:05.123456Z WARN  devices::virtio::vsock::muxer] \
+             egress policy denied connect to 93.184.215.14:443",
+        )
+        .expect("muxer line parses");
+        assert_eq!(muxer.timestamp, "2026-08-13T02:31:05.123456Z");
+        assert_eq!(muxer.dest, "93.184.215.14:443");
+
+        for noise in [
+            "[2026-08-14T03:13:08Z]: virtio-net: guest TCP SYN source=x destination=y",
+            "[2026-08-13T02:31:07Z INFO  libkrun] egress policy configured with 2 CIDR rule(s)",
+            "plain unrelated stderr line",
+            "[ts WARN x] egress policy denied", // no operation/dest
+        ] {
+            assert!(
+                parse_egress_denial_line(noise).is_none(),
+                "must ignore: {noise}"
+            );
+        }
+    }
+
+    /// `read_egress_denials` reads the newest events from the log tail and
+    /// honors the caller's cap, keeping the most recent entries.
+    #[test]
+    fn read_egress_denials_caps_to_newest() {
+        // Write the log exactly where vmm_log_file() resolves for a
+        // pid-namespaced throwaway name, and remove that dir afterwards.
+        let name = format!("egress-test-{}", std::process::id());
+        let log = boot_stderr_log_file(&name);
+        std::fs::create_dir_all(log.parent().expect("parent")).expect("mkdir");
+        let mut contents = String::new();
+        for i in 0..10 {
+            contents.push_str(&format!(
+                "[2026-08-13T02:31:{i:02}Z]: egress policy denied connect to 10.0.0.{i}:443\n"
+            ));
+        }
+        std::fs::write(&log, contents).expect("write log");
+
+        let events = read_egress_denials(&name, 3);
+        std::fs::remove_dir_all(vm_data_dir(&name)).ok();
+        assert_eq!(events.len(), 3, "capped to limit");
+        assert_eq!(events[0].dest, "10.0.0.7:443", "oldest of the kept tail");
+        assert_eq!(events[2].dest, "10.0.0.9:443", "newest kept last");
     }
 
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -32,9 +32,10 @@ pub use launcher::{
 pub(crate) use manager::{cleanup_dead_vm_runtime, cleanup_dead_vm_runtime_in_db};
 pub use manager::{
     disk_used_mb, docker_config_dir, docker_config_mount, ensure_vm_dir, machine_layers_cache_dir,
-    prune_orphaned_ready_markers, read_egress_telemetry, read_shared_pack_pointer,
-    resolve_disk_image, shared_pack_cache_root, shared_pack_pointer_path, vm_cache_root,
-    vm_data_dir, vm_dir_hash, vm_uid_registry_dir, AgentManager, AgentState, SHARED_PACK_POINTER,
+    prune_orphaned_ready_markers, read_egress_denials, read_egress_telemetry,
+    read_shared_pack_pointer, resolve_disk_image, shared_pack_cache_root, shared_pack_pointer_path,
+    vm_cache_root, vm_data_dir, vm_dir_hash, vm_uid_registry_dir, AgentManager, AgentState,
+    EgressDenial, SHARED_PACK_POINTER,
 };
 
 /// Agent VM name.

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -39,9 +39,10 @@ use crate::api::state::{
     ReservationGuard,
 };
 use crate::api::types::{
-    ApiErrorResponse, CreateMachineRequest, DeleteQuery, DeleteResponse, ExportRequest,
-    ExportResponse, ForkReleaseRequest, ForkRequest, ListMachinesResponse, MachineInfo, MountInfo,
-    MountSpec, PortSpec, ResizeMachineRequest, ResourceSpec, StartMachineQuery,
+    ApiErrorResponse, CreateMachineRequest, DeleteQuery, DeleteResponse, EgressEventsResponse,
+    ExportRequest, ExportResponse, ForkReleaseRequest, ForkRequest, ListMachinesResponse,
+    MachineInfo, MountInfo, MountSpec, PortSpec, ResizeMachineRequest, ResourceSpec,
+    StartMachineQuery,
 };
 use crate::config::{RecordState, RestartConfig, VmRecord};
 use crate::data::disk::{Overlay, Storage};
@@ -874,6 +875,47 @@ pub async fn get_machine(
         .ok_or_else(|| ApiError::NotFound(format!("machine '{}' not found", name)))?;
 
     Ok(Json(record_to_info(&name, &record)))
+}
+
+/// Query string for `GET /machines/{name}/egress-events`.
+#[derive(Debug, serde::Deserialize, utoipa::IntoParams)]
+pub struct EgressEventsQuery {
+    /// Maximum number of events to return (newest kept). Default 200.
+    pub limit: Option<usize>,
+}
+
+/// List the machine's egress denials — outbound connects and sendtos its
+/// egress policy refused. Empty for a machine with no policy, no denials, or
+/// one that has never booted.
+#[utoipa::path(
+    get,
+    path = "/api/v1/machines/{name}/egress-events",
+    tag = "Machines",
+    params(
+        ("name" = String, Path, description = "Machine name"),
+        EgressEventsQuery
+    ),
+    responses(
+        (status = 200, description = "Egress denial events", body = EgressEventsResponse),
+        (status = 404, description = "Machine not found", body = ApiErrorResponse)
+    )
+)]
+pub async fn get_machine_egress_events(
+    State(state): State<Arc<ApiState>>,
+    Path(name): Path<String>,
+    axum::extract::Query(query): axum::extract::Query<EgressEventsQuery>,
+) -> Result<Json<EgressEventsResponse>, ApiError> {
+    state
+        .lookup_vm(&name)
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("machine '{}' not found", name)))?;
+
+    let limit = query.limit.unwrap_or(200);
+    let events = crate::agent::read_egress_denials(&name, limit)
+        .into_iter()
+        .map(Into::into)
+        .collect();
+    Ok(Json(EgressEventsResponse { events }))
 }
 
 /// Classify a VM launch/boot failure. A published host-port bind conflict — the

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -92,6 +92,7 @@ use state::ApiState;
         handlers::machines::create_machine,
         handlers::machines::list_machines,
         handlers::machines::get_machine,
+        handlers::machines::get_machine_egress_events,
         handlers::machines::start_machine,
         handlers::machines::fork_machine,
         handlers::machines::release_held_fork,
@@ -158,6 +159,8 @@ use state::ApiState;
         types::HealthResponse,
         types::CapacityResponse,
         types::MachineInfo,
+        types::EgressDenialInfo,
+        types::EgressEventsResponse,
         types::MountInfo,
         types::ListMachinesResponse,
         types::ExecResponse,
@@ -256,6 +259,10 @@ pub fn create_router(state: Arc<ApiState>, cors_origins: Vec<String>) -> Router 
         .route("/", post(handlers::machines::create_machine))
         .route("/", get(handlers::machines::list_machines))
         .route("/{id}", get(handlers::machines::get_machine))
+        .route(
+            "/{id}/egress-events",
+            get(handlers::machines::get_machine_egress_events),
+        )
         .route("/{id}/start", post(handlers::machines::start_machine))
         .route("/{id}/fork", post(handlers::machines::fork_machine))
         .route(

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -696,6 +696,41 @@ pub struct MachineInfo {
     pub created_at: u64,
 }
 
+/// One egress denial: the machine's egress policy refused an outbound
+/// connect or sendto. These are the machine's only record of blocked
+/// traffic, read from the VMM's log.
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct EgressDenialInfo {
+    /// Denial time (RFC 3339, microsecond precision), or empty when the
+    /// log line carried no parseable timestamp.
+    #[schema(example = "2026-08-13T02:31:05.123456Z")]
+    pub timestamp: String,
+    /// The refused operation: `connect` (TCP) or `sendto` (UDP).
+    #[schema(example = "connect")]
+    pub operation: String,
+    /// The destination the guest tried to reach.
+    #[schema(example = "93.184.215.14:443")]
+    pub dest: String,
+}
+
+impl From<crate::agent::EgressDenial> for EgressDenialInfo {
+    fn from(d: crate::agent::EgressDenial) -> Self {
+        Self {
+            timestamp: d.timestamp,
+            operation: d.operation,
+            dest: d.dest,
+        }
+    }
+}
+
+/// Egress denial events response.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct EgressEventsResponse {
+    /// Denials oldest-first, capped by the `limit` query parameter.
+    pub events: Vec<EgressDenialInfo>,
+}
+
 /// List machines response.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct ListMachinesResponse {

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -323,6 +323,9 @@ pub enum MachineCmd {
     /// Show machine status
     Status(StatusCmd),
 
+    /// Show egress denials — outbound connections the machine's egress policy refused
+    EgressEvents(EgressEventsCmd),
+
     /// List all machines
     #[command(visible_alias = "list")]
     Ls(LsCmd),
@@ -387,6 +390,7 @@ impl MachineCmd {
             MachineCmd::Stop(cmd) => cmd.run(),
             MachineCmd::Delete(cmd) => cmd.run(),
             MachineCmd::Status(cmd) => cmd.run(),
+            MachineCmd::EgressEvents(cmd) => cmd.run(),
             MachineCmd::Ls(cmd) => cmd.run(),
             MachineCmd::Resize(cmd) => cmd.run(),
             MachineCmd::Update(cmd) => cmd.run(),
@@ -3785,6 +3789,53 @@ impl StatusCmd {
             return vm_common::status_vm_json(&self.name);
         }
         vm_common::status_vm(&self.name, |_| {})
+    }
+}
+
+// ============================================================================
+// EgressEvents Command
+// ============================================================================
+
+/// Show the machine's egress denials.
+///
+/// Lists outbound connects and sendtos the egress policy refused — the record
+/// of what a confined workload tried and failed to reach. Empty for machines
+/// without an egress policy, or with no denials.
+#[derive(Args, Debug)]
+pub struct EgressEventsCmd {
+    /// Machine to inspect (default: "default")
+    #[arg(short = 'n', long, value_name = "NAME")]
+    pub name: Option<String>,
+
+    /// Maximum number of events to show (newest kept)
+    #[arg(long, default_value_t = 200)]
+    pub limit: usize,
+
+    /// Output in JSON format
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl EgressEventsCmd {
+    pub fn run(self) -> smolvm::Result<()> {
+        let name = self.name.as_deref().unwrap_or("default");
+        let events = smolvm::agent::read_egress_denials(name, self.limit);
+        if self.json {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&events).unwrap_or_default()
+            );
+            return Ok(());
+        }
+        if events.is_empty() {
+            println!("No egress denials recorded for '{name}'.");
+            return Ok(());
+        }
+        println!("{:<30} {:<9} DESTINATION", "TIMESTAMP", "OP");
+        for e in &events {
+            println!("{:<30} {:<9} {}", e.timestamp, e.operation, e.dest);
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
A machine with an egress policy silently dropped whatever its workload tried and failed to reach, leaving no record for whoever set the policy; the virtio-net relays and the DNS filter now append each denied connect, sendto and resolve to a dedicated per-machine audit file that ordinary connection chatter cannot evict, and a new machine egress-events CLI command and GET /api/v1/machines/{name}/egress-events endpoint read them back as structured events.