### PR TITLE
Preserve container file ownership in packed machines

### DIFF
--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -588,6 +588,164 @@ fn should_expose_storage(mounts: &[(String, String, bool)], unprivileged: bool) 
 /// back to a name sort.
 const LAYER_ORDER_FILE: &str = "layer-order";
 
+/// Subdir on the storage disk holding layers this VM unpacked for itself.
+const GUEST_LAYERS_DIR: &str = "packed-layers";
+/// Marker written once every staged tar has been unpacked, holding the staged
+/// set's signature so a restart reuses the work and a changed pack redoes it.
+const GUEST_LAYERS_MARKER: &str = ".extracted";
+
+/// The layer tars a host staged for us rather than unpacking itself, if any.
+///
+/// A `.tar` whose sibling directory already exists was unpacked by the host, so
+/// it is not ours to redo.
+fn staged_layer_tars(packed_dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut tars = Vec::new();
+    let entries = std::fs::read_dir(packed_dir)
+        .map_err(|e| StorageError::read_error(packed_dir.display().to_string(), e))?;
+    for entry in entries {
+        let path = entry?.path();
+        if path.extension().is_some_and(|e| e == "tar") && !path.with_extension("").is_dir() {
+            tars.push(path);
+        }
+    }
+    tars.sort();
+    Ok(tars)
+}
+
+/// Unpack host-staged layer tars onto the storage disk and return that
+/// directory, or `None` when the host already unpacked them.
+///
+/// A host only unpacks a pack's layers itself when it can reproduce the
+/// archived uid/gid, which in practice means running as root on Unix.
+/// Everywhere else — macOS, Windows, a rootless Linux daemon — `chown` is
+/// simply unavailable, and unpacking there silently re-owns every file to
+/// whoever ran the command: an image's postgres files (uid 999) arrive owned by
+/// the host user, and the service cannot read the data directory it owns.
+///
+/// Those hosts stage the raw tars instead and we unpack them here, where the
+/// agent is root no matter what the host OS is. That is the same reason the
+/// ordinary registry-pull path (`crane` + `tar`, in-guest) has always got
+/// ownership right on every platform; this brings packs onto it.
+///
+/// Returning `None` for an already-unpacked dir leaves that path untouched, so
+/// artifacts made by earlier versions keep working and a root Linux host keeps
+/// sharing one extracted copy across every VM built on the pack.
+fn ensure_packed_layers_extracted_with_progress<F>(
+    packed_dir: &Path,
+    mut progress: F,
+) -> Result<Option<PathBuf>>
+where
+    F: FnMut(&str, u64),
+{
+    let tars = staged_layer_tars(packed_dir)?;
+    if tars.is_empty() {
+        return Ok(None);
+    }
+
+    let key = packed_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("packed");
+    let out = Path::new(STORAGE_ROOT).join(GUEST_LAYERS_DIR).join(key);
+    let marker = out.join(GUEST_LAYERS_MARKER);
+    let signature = staged_tars_signature(&tars)?;
+    if std::fs::read_to_string(&marker).ok().as_deref() == Some(signature.as_str()) {
+        return Ok(Some(out));
+    }
+
+    // First boot on this disk, or the pack changed under a reused one.
+    let _ = std::fs::remove_dir_all(&out);
+    std::fs::create_dir_all(&out)?;
+    for tar in &tars {
+        let stem = tar.file_stem().and_then(|s| s.to_str()).ok_or_else(|| {
+            StorageError::new(format!("unreadable layer name: {}", tar.display()))
+        })?;
+        let dir = out.join(stem);
+        std::fs::create_dir_all(&dir)?;
+        info!(layer = %stem, "unpacking staged layer");
+        progress("unpacking image layers", 0);
+        extract_layer_tar(tar, &dir)?;
+    }
+
+    // Carry the stacking order across; without it the guest would fall back to
+    // sorting layer dirs by digest, which is not OCI order.
+    let order = packed_dir.join(LAYER_ORDER_FILE);
+    if order.is_file() {
+        let _ = std::fs::copy(&order, out.join(LAYER_ORDER_FILE));
+    }
+
+    // Marker last, so an interrupted unpack is redone rather than trusted.
+    std::fs::write(&marker, signature)?;
+    Ok(Some(out))
+}
+
+/// Identify the staged set by each tar's name, size and mtime — enough to catch
+/// a machine re-created from a different pack on a reused storage disk, without
+/// reading hundreds of megabytes to hash them.
+fn staged_tars_signature(tars: &[PathBuf]) -> Result<String> {
+    let mut parts = Vec::with_capacity(tars.len());
+    for tar in tars {
+        let meta = std::fs::metadata(tar)
+            .map_err(|e| StorageError::read_error(tar.display().to_string(), e))?;
+        let mtime = meta
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let name = tar.file_name().unwrap_or_default().to_string_lossy();
+        parts.push(format!("{name}:{}:{mtime}", meta.len()));
+    }
+    Ok(parts.join(","))
+}
+
+/// Unpack one layer tar into `dir`, preserving ownership.
+///
+/// `tar` restores the archived uid/gid when it runs as root, which the agent
+/// always does — that is the whole point of unpacking here rather than on the
+/// host.
+fn extract_layer_tar(tar: &Path, dir: &Path) -> Result<()> {
+    let out = Command::new("tar")
+        .arg("-x")
+        .arg("-f")
+        .arg(tar)
+        .arg("-C")
+        .arg(dir)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| StorageError::new(format!("failed to run tar: {e}")))?;
+    if !out.status.success() {
+        return Err(StorageError::new(format!(
+            "failed to unpack layer {}: {}",
+            tar.display(),
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    Ok(())
+}
+
+/// The directory whose subdirs are this pack's layers, materialising them first
+/// if the host staged tars for us or handed us a saved-image archive.
+fn effective_packed_dir(packed_dir: &Path) -> Result<PathBuf> {
+    effective_packed_dir_with_progress(packed_dir, |_, _| {})
+}
+
+fn effective_packed_dir_with_progress<F>(packed_dir: &Path, mut progress: F) -> Result<PathBuf>
+where
+    F: FnMut(&str, u64),
+{
+    if let Some(flattened) = ensure_archive_flattened_with_progress(packed_dir, &mut progress)? {
+        return Ok(flattened);
+    }
+    if let Some(extracted) =
+        ensure_packed_layers_extracted_with_progress(packed_dir, &mut progress)?
+    {
+        return Ok(extracted);
+    }
+    Ok(packed_dir.to_path_buf())
+}
+
 /// Packed layer directory names in OCI order, **bottom-most layer first**.
 ///
 /// Honors [`LAYER_ORDER_FILE`] when present and self-consistent; otherwise falls
@@ -704,10 +862,6 @@ const ARCHIVE_EXTRACTED_MARKER: &str = ".extracted";
 /// still matches, so a machine re-created from a different image on a reused
 /// disk re-flattens instead of booting the old rootfs. The marker is written
 /// last, so the image-info and overlay paths share one flatten within a start.
-fn ensure_archive_flattened(packed_dir: &Path) -> Result<Option<PathBuf>> {
-    ensure_archive_flattened_with_progress(packed_dir, |_, _| {})
-}
-
 fn ensure_archive_flattened_with_progress<F>(
     packed_dir: &Path,
     mut progress: F,
@@ -1692,12 +1846,9 @@ where
     // If packed layers are available, return synthetic image info
     if let Some(packed_dir) = get_packed_layers_dir() {
         info!(image = %image, "using packed layers, skipping network pull");
-        // A local image archive is flattened into a rootfs first; an ordinary
-        // packed-layers dir is used as-is.
-        if let Some(flattened) = ensure_archive_flattened(packed_dir)? {
-            return create_packed_image_info(image, &flattened);
-        }
-        return create_packed_image_info(image, packed_dir);
+        // A saved-image archive is flattened, host-staged tars are unpacked
+        // here, and an already-unpacked dir is used as-is.
+        return create_packed_image_info(image, &effective_packed_dir(packed_dir)?);
     }
 
     // Determine OCI platform - default to current architecture
@@ -2002,9 +2153,8 @@ pub fn query_image(image: &str) -> Result<Option<ImageInfo>> {
     // synthesize image info without a registry manifest, mirroring the pull
     // path. A local image archive is flattened into a rootfs first.
     if let Some(packed_dir) = get_packed_layers_dir() {
-        let flattened = ensure_archive_flattened(packed_dir)?;
-        let effective = flattened.as_deref().unwrap_or(packed_dir);
-        return Ok(Some(create_packed_image_info(image, effective)?));
+        let effective = effective_packed_dir(packed_dir)?;
+        return Ok(Some(create_packed_image_info(image, &effective)?));
     }
 
     let root = Path::new(STORAGE_ROOT);
@@ -2551,11 +2701,11 @@ pub fn prepare_overlay(image: &str, workload_id: &str) -> Result<OverlayInfo> {
     // Check if we have packed layers available
     if let Some(packed_dir) = get_packed_layers_dir() {
         info!(image = %image, packed_dir = %packed_dir.display(), "using packed layers");
-        // A local image archive is flattened into a rootfs (a single packed
-        // layer) first; an ordinary packed-layers dir is used as-is.
-        let flattened = ensure_archive_flattened(packed_dir)?;
-        let effective = flattened.as_deref().unwrap_or(packed_dir);
-        return prepare_overlay_from_packed(image, workload_id, effective);
+        // A saved-image archive is flattened into a rootfs (a single packed
+        // layer), host-staged tars are unpacked here, and an already-unpacked
+        // dir is used as-is.
+        let effective = effective_packed_dir(packed_dir)?;
+        return prepare_overlay_from_packed(image, workload_id, &effective);
     }
 
     // Ensure image exists
@@ -3007,9 +3157,8 @@ where
     // archive is flattened into a rootfs first; a packed-layers dir is used
     // as-is.
     let lowerdirs = if let Some(packed_dir) = get_packed_layers_dir() {
-        let flattened = ensure_archive_flattened_with_progress(packed_dir, &mut progress)?;
-        let effective = flattened.as_deref().unwrap_or(packed_dir);
-        get_packed_lowerdirs(effective)?
+        let effective = effective_packed_dir_with_progress(packed_dir, &mut progress)?;
+        get_packed_lowerdirs(&effective)?
     } else {
         get_image_lowerdirs(image)?
     };

--- a/crates/smolvm-pack/src/assets.rs
+++ b/crates/smolvm-pack/src/assets.rs
@@ -415,6 +415,15 @@ impl AssetCollector {
         Ok(())
     }
 
+    /// Total bytes of the layer tars registered so far.
+    ///
+    /// From-vm packs record this as the manifest's `image_size` so the run-time
+    /// storage auto-sizer accounts for the layers — essential when the guest
+    /// unpacks staged tars onto the storage disk itself.
+    pub fn staged_layer_bytes(&self) -> u64 {
+        self.inventory.layers.iter().map(|l| l.size).sum()
+    }
+
     /// Get the staging path where a layer file should be written.
     ///
     /// Call this before streaming the layer to get the destination path,

--- a/crates/smolvm-pack/src/extract.rs
+++ b/crates/smolvm-pack/src/extract.rs
@@ -102,6 +102,68 @@ fn set_mode(path: &Path, mode: u32) {
     }
 }
 
+/// Restore a tar entry's numeric owner on `path`, ignoring errors. No-op on
+/// non-Unix targets and whenever the process cannot change ownership.
+///
+/// Container images address their service accounts by numeric id — postgres is
+/// uid 999, nginx 101, mysql 999 — and the guest sees the unpacked tree through
+/// virtiofs with those host ids intact. Dropping them makes every file root's,
+/// so the service cannot read the data directory it owns: PostgreSQL refuses to
+/// start on a root-owned PGDATA, which is how this surfaced. The tar headers
+/// carry the right ids; only the extraction discarded them.
+///
+/// `lchown`, not `chown`, so a symlink entry is not dereferenced and its target
+/// re-owned instead.
+///
+/// Only attempted as root. An unprivileged extraction — the normal case on
+/// macOS, where the VM's uid mapping makes the host owner irrelevant anyway —
+/// can only ever chown to itself, so EPERM there is expected rather than a
+/// failure worth reporting. Callers still mask setuid/setgid out of the mode,
+/// so a hostile header cannot pair a chosen owner with an escalating bit.
+#[inline]
+fn set_owner(path: &Path, uid: u64, gid: u64) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        if unsafe { libc::geteuid() } != 0 {
+            return;
+        }
+        if let Ok(c_path) = std::ffi::CString::new(path.as_os_str().as_bytes()) {
+            unsafe {
+                libc::lchown(c_path.as_ptr(), uid as libc::uid_t, gid as libc::gid_t);
+            }
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (path, uid, gid);
+    }
+}
+
+/// Whether unpacking a pack's layers on this host reproduces the uid/gid the
+/// archive recorded.
+///
+/// Only root on a Unix host can: `chown` to another id requires the privilege,
+/// and Windows has no POSIX owner to restore at all. Unpacking anywhere else
+/// silently re-owns every file to whoever ran the command — a container image's
+/// postgres files (uid 999) land owned by the host user, and the service then
+/// cannot read the data directory it owns.
+///
+/// When this is false the layers are staged as tars instead and unpacked inside
+/// the guest, where the agent is always root. Host-side unpacking stays the
+/// default where it is faithful, because one extracted copy is shared by every
+/// VM built on the pack; the in-guest copy lives on a single machine's disk.
+fn host_unpack_preserves_ownership() -> bool {
+    #[cfg(unix)]
+    {
+        unsafe { libc::geteuid() == 0 }
+    }
+    #[cfg(not(unix))]
+    {
+        false
+    }
+}
+
 /// Files larger than this threshold are extracted with a sparse write
 /// (ftruncate skeleton + pwrite only non-zero 64 KiB chunks) rather than a
 /// dense sequential write.  Chosen to match typical overlay disk sizes while
@@ -523,6 +585,12 @@ fn safe_unpack_with_limits<R: Read>(
         let is_regular =
             entry_type == tar::EntryType::Regular || entry_type == tar::EntryType::GNUSparse;
 
+        // Read the owner off the header before the entry is consumed: the
+        // sparse path streams `entry` to exhaustion, after which the header is
+        // still available but reading it here keeps both branches symmetric.
+        let uid = entry.header().uid().unwrap_or(0);
+        let gid = entry.header().gid().unwrap_or(0);
+
         // For large regular files use a sparse write: ftruncate creates the
         // hole skeleton, then we only pwrite non-zero 64 KiB chunks.  This
         // prevents 10 GiB overlay disks from materialising as dense files on
@@ -536,6 +604,7 @@ fn safe_unpack_with_limits<R: Read>(
                     format!("failed to unpack '{}': {}", entry_path.display(), e),
                 ));
             }
+            set_owner(&full_path, uid, gid);
         } else {
             if let Err(e) = entry.unpack_in(dest) {
                 // On macOS, certain entries fail to unpack due to platform
@@ -557,6 +626,11 @@ fn safe_unpack_with_limits<R: Read>(
             if entry_type == tar::EntryType::Directory && full_path.is_dir() {
                 set_mode(&full_path, 0o755);
             }
+
+            // Ownership after the mode is in place: chown clears setuid/setgid,
+            // and the deferred directory pass below only restores modes, never
+            // owners, so doing it here is the single point that applies.
+            set_owner(&full_path, uid, gid);
         }
     }
 
@@ -1227,7 +1301,25 @@ fn post_process_extraction(
     // APFS sparse disk image on macOS. The image is persisted in the cache and
     // re-mounted on subsequent runs.
     let layers_dir = cache_dir.join("layers");
-    if layers_dir.exists() {
+    if layers_dir.exists() && !host_unpack_preserves_ownership() {
+        // This host cannot reproduce the archived uid/gid (see
+        // `host_unpack_preserves_ownership`), so leave the tars staged and let
+        // the guest agent unpack them, where it is root on every host OS.
+        // Only the stacking order has to be recorded here, against the tars.
+        if debug {
+            eprintln!("debug: staging OCI layers for in-guest extraction...");
+        }
+        if !layer_order.is_empty() {
+            let lines: Vec<&str> = layer_order
+                .iter()
+                .filter(|id| layers_dir.join(format!("{id}.tar")).is_file())
+                .map(String::as_str)
+                .collect();
+            if !lines.is_empty() {
+                fs::write(layers_dir.join(LAYER_ORDER_FILE), lines.join("\n"))?;
+            }
+        }
+    } else if layers_dir.exists() {
         if debug {
             eprintln!("debug: extracting OCI layers...");
         }
@@ -1368,8 +1460,15 @@ impl Drop for LayersVolumeLease {
 pub fn acquire_layers_lease(cache_dir: &Path, debug: bool) -> std::io::Result<LayersVolumeLease> {
     #[cfg(target_os = "macos")]
     {
+        // The case-sensitive volume only ever holds HOST-extracted layers.
+        // When the host stages tars for in-guest extraction instead (see
+        // `host_unpack_preserves_ownership`), the tars live in
+        // `cache_dir/layers` and the volume was never created — returning it
+        // here would hand the guest an empty directory. An existing sparse
+        // image still wins, so packs extracted by an earlier version (or by a
+        // root run) keep mounting the volume they were extracted into.
         let image_path = cache_dir.join(CS_IMAGE_NAME);
-        if image_path.exists() || has_layer_tars(cache_dir) {
+        if image_path.exists() || (host_unpack_preserves_ownership() && has_layer_tars(cache_dir)) {
             // Case-sensitive volume is required on macOS to preserve Linux
             // paths faithfully. Fail if it can't be acquired rather than
             // silently falling back to case-insensitive extraction.
@@ -1404,8 +1503,11 @@ pub fn acquire_daemon_lease(
 ) -> std::io::Result<PathBuf> {
     #[cfg(target_os = "macos")]
     {
+        // Same gate as `acquire_layers_lease`: staged tars are shared to the
+        // guest from `cache_dir/layers` directly, so the case-sensitive volume
+        // is only in play when the host extracted into it.
         let image_path = cache_dir.join(CS_IMAGE_NAME);
-        if image_path.exists() || has_layer_tars(cache_dir) {
+        if image_path.exists() || (host_unpack_preserves_ownership() && has_layer_tars(cache_dir)) {
             let leases_dir = cache_dir.join(LEASES_DIR);
             fs::create_dir_all(&leases_dir)?;
             let lock = lock_leases(cache_dir)?;
@@ -2264,6 +2366,80 @@ mod tests {
         assert_eq!(fs::read(&outside).unwrap(), b"untouched");
     }
 
+    /// Container images address their service accounts numerically — postgres
+    /// is uid 999 — so an extraction that drops the ids hands the service a
+    /// data directory it cannot read, and PostgreSQL refuses to start on it.
+    /// As root the ids must survive; unprivileged, extraction must still
+    /// succeed rather than failing on the EPERM it cannot avoid.
+    #[cfg(unix)]
+    #[test]
+    fn unpacking_preserves_the_headers_numeric_owner() {
+        use std::os::unix::fs::MetadataExt;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let dest = temp_dir.path().join("out");
+        fs::create_dir_all(&dest).unwrap();
+
+        let mut builder = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_size(4);
+        header.set_mode(0o600);
+        header.set_uid(999);
+        header.set_gid(999);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "pgdata", &b"data"[..])
+            .unwrap();
+        let tar_bytes = builder.into_inner().unwrap();
+
+        let mut archive = tar::Archive::new(tar_bytes.as_slice());
+        safe_unpack(&mut archive, &dest).expect("extraction succeeds at either privilege level");
+
+        let meta = fs::metadata(dest.join("pgdata")).unwrap();
+        let euid = unsafe { libc::geteuid() };
+        if euid == 0 {
+            assert_eq!(meta.uid(), 999, "the header's uid must survive extraction");
+            assert_eq!(meta.gid(), 999, "the header's gid must survive extraction");
+        } else {
+            assert_eq!(
+                meta.uid(),
+                euid,
+                "unprivileged extraction leaves the caller as owner, without erroring"
+            );
+        }
+    }
+
+    /// `lchown`, not `chown`: re-owning a symlink entry must not reach through
+    /// the link and re-own whatever it points at.
+    #[cfg(unix)]
+    #[test]
+    fn re_owning_a_symlink_leaves_its_target_untouched() {
+        use std::os::unix::fs::{symlink, MetadataExt};
+
+        if unsafe { libc::geteuid() } != 0 {
+            return; // chown is a no-op unprivileged, so there is nothing to assert
+        }
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let target = temp_dir.path().join("target");
+        let link = temp_dir.path().join("link");
+        fs::write(&target, b"x").unwrap();
+        symlink(&target, &link).unwrap();
+
+        set_owner(&link, 999, 999);
+
+        assert_eq!(
+            fs::metadata(&target).unwrap().uid(),
+            0,
+            "the link's target must keep its own owner"
+        );
+        assert_eq!(
+            fs::symlink_metadata(&link).unwrap().uid(),
+            999,
+            "the link itself is re-owned"
+        );
+    }
+
     /// Build a tar archive carrying a single symlink entry whose link target
     /// is `link_target`, plus (optionally) a trailing regular-file entry.
     fn make_symlink_tar(name: &str, link_target: &str) -> Vec<u8> {
@@ -2993,33 +3169,60 @@ mod tests {
         );
     }
 
+    /// Staged tars (in-guest extraction mode) must be shared from the plain
+    /// `layers` dir — a case-sensitive volume was never created for them, so
+    /// mounting one would hand the guest an empty directory.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn staged_tars_do_not_mount_a_volume() {
+        if host_unpack_preserves_ownership() {
+            return; // as root the host extracts into the volume; covered below
+        }
+        let temp_dir = tempfile::tempdir().unwrap();
+        let cache_dir = temp_dir.path().join("cache");
+        fs::create_dir_all(cache_dir.join("layers")).unwrap();
+        fs::write(cache_dir.join("layers/dummy.tar"), b"").unwrap();
+
+        let lease = acquire_layers_lease(&cache_dir, false).unwrap();
+        assert_eq!(
+            lease.path,
+            cache_dir.join("layers"),
+            "staged tars are shared to the guest as-is"
+        );
+        assert!(!is_mount_point(&lease.path));
+    }
+
     #[test]
     #[cfg(target_os = "macos")]
     fn test_layers_lease_creates_and_cleans_volume() {
-        // Verify that acquire_layers_lease creates a case-sensitive sparse
-        // image, mounts it, and detaches on lease drop.
-        // Skips gracefully if hdiutil is unavailable (CI, sandboxed envs).
+        // Verify the case-sensitive volume lifecycle: created and mounted on
+        // acquire, detached on lease drop, and — once the sparse image exists
+        // (a pack extracted by root or an earlier version) — chosen again by
+        // the public accessor. Skips gracefully if hdiutil is unavailable
+        // (CI, sandboxed envs).
         let temp_dir = tempfile::tempdir().unwrap();
         let cache_dir = temp_dir.path().join("cache");
         // Create a dummy tar so has_layer_tars() returns true.
         fs::create_dir_all(cache_dir.join("layers")).unwrap();
         fs::write(cache_dir.join("layers/dummy.tar"), b"").unwrap();
 
-        let lease = match acquire_layers_lease(&cache_dir, false) {
+        // Drive the volume machinery directly (the public accessor only takes
+        // this path for root extraction or a pre-existing image).
+        let lease = match acquire_lease(&cache_dir, false) {
             Ok(l) => l,
             Err(e) => {
                 eprintln!("SKIP: hdiutil unavailable: {}", e);
                 return;
             }
         };
-        assert!(lease.path.exists());
-        assert!(is_mount_point(&lease.path));
+        assert!(lease.exists());
+        assert!(is_mount_point(&lease));
 
         // Both "lower" and "Lower" should coexist on the case-sensitive volume.
-        fs::write(lease.path.join("lower"), "file").unwrap();
-        fs::create_dir_all(lease.path.join("Lower")).unwrap();
-        assert!(lease.path.join("lower").exists());
-        assert!(lease.path.join("Lower").is_dir());
+        fs::write(lease.join("lower"), "file").unwrap();
+        fs::create_dir_all(lease.join("Lower")).unwrap();
+        assert!(lease.join("lower").exists());
+        assert!(lease.join("Lower").is_dir());
 
         // Lease file should exist while lease is held.
         let lease_file = cache_dir
@@ -3027,13 +3230,19 @@ mod tests {
             .join(format!("{}", std::process::id()));
         assert!(lease_file.exists());
 
-        // Drop lease — should detach volume (last lease).
-        let mount_point = lease.path.clone();
-        drop(lease);
+        // Release — should detach volume (last lease).
+        release_lease(&cache_dir);
         assert!(
-            !is_mount_point(&mount_point),
+            !is_mount_point(&lease),
             "volume should be detached after last lease drop"
         );
+
+        // The sparse image persists; the public accessor must now pick the
+        // volume back up even though extraction mode would stage tars.
+        let compat = acquire_layers_lease(&cache_dir, false).unwrap();
+        assert!(is_mount_point(&compat.path), "existing image is honored");
+        assert!(compat.path.join("lower").exists());
+        drop(compat);
     }
 
     #[test]

--- a/src/pack_export.rs
+++ b/src/pack_export.rs
@@ -59,6 +59,13 @@ pub struct FromVmAssets {
     /// that path already copied the source manifest's env into the record, so the
     /// machine's own env is the complete set.
     pub image_env: Vec<String>,
+    /// Total bytes of the layer tars collected for this pack.
+    ///
+    /// Recorded as the manifest's `image_size` so the run-time storage
+    /// auto-sizer reserves room for them; without it a from-vm pack falls back
+    /// to the minimal default disk, which cannot hold the layers when the
+    /// guest has to unpack staged tars onto it.
+    pub layer_bytes: u64,
 }
 
 /// Collect a stopped machine's pack assets into `collector` and report the
@@ -158,6 +165,7 @@ pub fn collect_from_vm_assets(
         },
         image: vm.image.clone(),
         image_env,
+        layer_bytes: collector.staged_layer_bytes(),
     })
 }
 
@@ -165,6 +173,10 @@ pub fn collect_from_vm_assets(
 /// Smolfile overrides layer on top of this baseline at the call site.
 pub fn seed_manifest_from_vm(manifest: &mut PackManifest, vm: &VmRecord, assets: &FromVmAssets) {
     manifest.mode = assets.mode.clone();
+    // Without this the run-time storage auto-sizer sees a legacy manifest and
+    // creates the minimal default disk — too small to hold the layers when the
+    // guest unpacks staged tars onto it.
+    manifest.image_size = assets.layer_bytes;
     if let Some(ref image) = assets.image {
         manifest.image = image.clone();
     }


### PR DESCRIPTION
Packed machines lost file ownership at extraction — every file arrived owned by whoever ran the pack, so images with a non-root service account (postgres, mysql, nginx) could not start from an artifact; the host now restores the archived uid/gid when extracting as root and otherwise stages the layer tars for the guest agent to unpack as root, which makes ownership correct on Linux, macOS, and Windows alike.