### PR TITLE
Assert a real VM boundary in the k3s e2e, and stop clobbering operator config

### DIFF
--- a/deploy/k3s/e2e-test.sh
+++ b/deploy/k3s/e2e-test.sh
@@ -31,7 +31,18 @@ echo "==> logs show the workload ran inside a VM kernel"
 LOGS=$($K logs "$POD")
 echo "$LOGS" | sed 's/^/    /'
 echo "$LOGS" | grep -q SMOLVM_K8S_E2E_OK || fail "expected marker not in logs"
-echo "$LOGS" | grep -qi "kernel:" || fail "no kernel line in logs"
+
+# The assertion that can actually fail. A microVM boots its own kernel, so the
+# guest's `uname -sr` differs from the node's; under runc the container shares
+# the host kernel and the two strings are identical. Grepping for the "kernel:"
+# prefix only matched the echo in example-pod.yaml, which any runtime prints.
+GUEST_KERNEL=$(printf '%s\n' "$LOGS" | sed -n 's/^kernel: //p' | head -1)
+[ -n "$GUEST_KERNEL" ] || fail "no kernel line in logs"
+HOST_KERNEL=$(uname -sr)
+echo "    guest kernel: $GUEST_KERNEL"
+echo "    host kernel:  $HOST_KERNEL"
+[ "$GUEST_KERNEL" != "$HOST_KERNEL" ] \
+    || fail "guest kernel '$GUEST_KERNEL' is the node's own — the workload is not in a microVM"
 
 echo "==> exec into the running microVM"
 UID_OUT=$($K exec "$POD" -- id 2>/dev/null) || fail "kubectl exec failed"

--- a/deploy/k3s/uninstall-smolvm-k3s.sh
+++ b/deploy/k3s/uninstall-smolvm-k3s.sh
@@ -29,14 +29,13 @@ fi
 
 echo "==> removing the smolvm runtime block from the containerd template"
 if [ -f "$TMPL" ]; then
-  # Restore the newest pre-smolvm backup when the installer made one (it only
-  # does so when a template already existed), otherwise strip just our block so
-  # any operator config in the file survives.
-  BACKUP=$(ls -1t "$TMPL".pre-smolvm.* 2>/dev/null | head -1 || true)
-  if [ -n "$BACKUP" ]; then
-    echo "    restoring $BACKUP"
-    mv "$BACKUP" "$TMPL"
-  else
+  # Always strip just our block, never restore the install-time backup over the
+  # live file. The installer states the rule this follows: config.toml.tmpl is
+  # where operators put registry mirrors and private-registry auth, "so it is NOT
+  # ours to overwrite", and "a lost mirror config breaks image pulls cluster-wide
+  # and the cause is hard to trace". Restoring a snapshot taken at install time
+  # discards everything the operator added since, which can be months of edits.
+  if grep -q 'runtimes\.smolvm\]' "$TMPL"; then
     # Drop the smolvm table header and its runtime_type line.
     sed -i '/runtimes\.smolvm\]/,+1d' "$TMPL"
     # A template that is now nothing but the base include is what k3s generates
@@ -44,6 +43,16 @@ if [ -f "$TMPL" ]; then
     if [ "$(grep -cvE '^[[:space:]]*($|\{\{ template "base" \. \}\})' "$TMPL")" = 0 ]; then
       rm -f "$TMPL"
       echo "    template held only the base include — removed"
+    fi
+  else
+    # Our block is absent, so there is nothing to strip. This is the one case the
+    # backup is for: a template edited between our header and its runtime_type
+    # line, which sed cannot match. Leave both files alone and say so, rather
+    # than overwriting the operator's file on a guess.
+    echo "    no smolvm runtime block found in $TMPL — leaving it untouched"
+    BACKUP=$(ls -1t "$TMPL".pre-smolvm.* 2>/dev/null | head -1 || true)
+    if [ -n "$BACKUP" ]; then
+      echo "    if it was hand-edited, the install-time copy is at $BACKUP"
     fi
   fi
 fi

--- a/deploy/k3s/uninstall-smolvm-k3s.sh
+++ b/deploy/k3s/uninstall-smolvm-k3s.sh
@@ -29,14 +29,10 @@ fi
 
 echo "==> removing the smolvm runtime block from the containerd template"
 if [ -f "$TMPL" ]; then
-  # Restore the newest pre-smolvm backup when the installer made one (it only
-  # does so when a template already existed), otherwise strip just our block so
-  # any operator config in the file survives.
-  BACKUP=$(ls -1t "$TMPL".pre-smolvm.* 2>/dev/null | head -1 || true)
-  if [ -n "$BACKUP" ]; then
-    echo "    restoring $BACKUP"
-    mv "$BACKUP" "$TMPL"
-  else
+  # Strip only our block; never restore the install-time backup over the live
+  # file. Operators keep registry mirrors and private-registry auth in
+  # config.toml.tmpl, so a restore discards every edit made since install.
+  if grep -q 'runtimes\.smolvm\]' "$TMPL"; then
     # Drop the smolvm table header and its runtime_type line.
     sed -i '/runtimes\.smolvm\]/,+1d' "$TMPL"
     # A template that is now nothing but the base include is what k3s generates
@@ -44,6 +40,15 @@ if [ -f "$TMPL" ]; then
     if [ "$(grep -cvE '^[[:space:]]*($|\{\{ template "base" \. \}\})' "$TMPL")" = 0 ]; then
       rm -f "$TMPL"
       echo "    template held only the base include — removed"
+    fi
+  else
+    # Nothing of ours to strip. The backup exists for this case: a template
+    # edited between our header and its runtime_type line, which sed cannot
+    # match. Leave both files alone rather than overwrite on a guess.
+    echo "    no smolvm runtime block found in $TMPL — leaving it untouched"
+    BACKUP=$(ls -1t "$TMPL".pre-smolvm.* 2>/dev/null | head -1 || true)
+    if [ -n "$BACKUP" ]; then
+      echo "    if it was hand-edited, the install-time copy is at $BACKUP"
     fi
   fi
 fi


### PR DESCRIPTION
Two scripts under `deploy/k3s` check something other than what they claim. The e2e test passes whether the pod booted a microVM or ran under runc, and the uninstaller restores an install-time snapshot over `config.toml.tmpl`, discarding whatever the operator added after install.

## The e2e cannot fail for the reason it advertises

`deploy/README.md:29` sells `e2e-test.sh` as "prove it end-to-end", and it is the only end-to-end gate the k8s runtime has. Its three assertions:

* `grep -q SMOLVM_K8S_E2E_OK` (`e2e-test.sh:33`) matches a literal the pod echoes at `example-pod.yaml:25`.
* `grep -qi "kernel:"` (`:34`) matches the *prefix* of `echo "kernel: $(uname -sr)"` at `example-pod.yaml:26`, so it matches the echo and never the value.
* `[ "$RC" = smolvm ]` (`:27-28`) reads back `.spec.runtimeClassName`, the field the script applied at `:21`.

None can tell a microVM from runc. This adds one that can: a microVM boots its own kernel, so the guest's `uname -sr` must differ from the node's, while under runc the container shares the host kernel and the strings are identical. The existing assertions stay.

## The uninstaller overwrites the file its own installer protects

`install-smolvm-k3s.sh:67-70` states the rule:

> `config.toml.tmpl` is where operators put registry mirrors, private-registry auth and other runtimes, so it is NOT ours to overwrite. If one already exists and is not ours, append to a copy of it and keep a timestamped backup; a lost mirror config breaks image pulls cluster-wide and the cause is hard to trace.

`uninstall-smolvm-k3s.sh` prefers that backup over its own surgical strip: `mv "$BACKUP" "$TMPL"`. Install at T0 snapshots, the operator adds a mirror at T1, uninstall at T2 restores T0, and the mirror is gone. The `mv` consumes the backup too, so nothing is left to recover from. This always strips our two lines instead, leaving the backup for the one case `sed` cannot handle: a template hand-edited between our header and its `runtime_type` line.

Blast radius is narrow: the installer writes a backup only when a template already existed and did not already contain our block, so a fresh node and a re-run both already took the safe path.

If the restore was deliberate rather than an oversight, say so and I will drop that half.

## Why these are one PR

Same directory, same defect class, under 40 lines of shell. Splitting them gives two PRs against the same directory with no independent review value. A third finding here, the seven references to a `docs/kubernetes-runtime.md` that has never existed, is deliberately **not** included: five of the seven are in `crates/`, and whether that doc should exist is a call for you rather than a behaviour fix.

## Alternatives considered

For the uninstaller, the other option was keeping the restore and documenting it. Rejected because it contradicts the installer's own comment, and by that comment's own assessment the failure is cluster-wide and hard to trace.

## Validation

I cannot run the k8s e2e here, as it needs a k3s node with KVM. Two things I did run:

* The new comparison against the real log shape, using values from a smolvm k3s pod booted on an A10 node on 2026-08-12: guest `Linux 6.12.95`, node `Linux 6.8.0-1046-nvidia`. It passes on those and fails on the same log with the node's own kernel substituted, which is the runc case. It would have passed on the run we did do.
* The uninstaller change against a fixture reproducing the T0/T1/T2 timeline. Old logic loses the post-install mirror; new logic keeps it and still removes the smolvm block.

`bash -n` clean on both scripts. No Rust is touched; `cargo fmt --all -- --check` and `cargo test --lib` (562 passed, 0 failed) are green on this branch.
