### PR TITLE
Spawn VM boot subprocesses via /proc/self/exe on Linux so a binary replaced under a running serve cannot make every subsequent boot fail

### DIFF
--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -1848,7 +1848,7 @@ impl AgentManager {
             ) {
                 let daemon_executable = match std::env::var_os("SMOLVM_BOOT_BINARY") {
                     Some(path) => PathBuf::from(path),
-                    None => std::env::current_exe()
+                    None => crate::process::self_exe_for_spawn()
                         .map_err(|error| Error::agent("find smolvm binary", error.to_string()))?,
                 };
                 crate::cuda_daemon::ensure_running_with_executable(
@@ -2183,7 +2183,7 @@ impl AgentManager {
         );
 
         // Spawn fresh subprocess (posix_spawn on macOS — safe for multi-threaded parents)
-        let exe = std::env::current_exe()
+        let exe = crate::process::self_exe_for_spawn()
             .map_err(|e| Error::agent("find smolvm binary", e.to_string()))?;
         let spawn_start = Instant::now();
         // Embedders (e.g. the Node SDK, where current_exe is `node`) can point the

--- a/src/cli/pack_run.rs
+++ b/src/cli/pack_run.rs
@@ -566,7 +566,7 @@ impl PackRunCmd {
             std::fs::write(&config_path, &config_json)
                 .map_err(|e| Error::agent("write boot config", e.to_string()))?;
 
-            let exe = std::env::current_exe()
+            let exe = smolvm::process::self_exe_for_spawn()
                 .map_err(|e| Error::agent("find smolvm binary", e.to_string()))?;
             let mut cmd = std::process::Command::new(&exe);
             cmd.args(["_boot-vm", &config_path.to_string_lossy()])
@@ -1576,7 +1576,7 @@ fn run_from_cache(
             .map_err(|e| Error::agent("serialize boot config", e.to_string()))?;
         std::fs::write(&config_path, &config_json)
             .map_err(|e| Error::agent("write boot config", e.to_string()))?;
-        let exe = std::env::current_exe()
+        let exe = smolvm::process::self_exe_for_spawn()
             .map_err(|e| Error::agent("find smolvm binary", e.to_string()))?;
         let mut cmd = std::process::Command::new(&exe);
         cmd.args(["_boot-vm", &config_path.to_string_lossy()])

--- a/src/process.rs
+++ b/src/process.rs
@@ -1410,6 +1410,28 @@ pub fn setup_pack_idmap_mount(
     result
 }
 
+/// Path to spawn another copy of the currently running executable.
+///
+/// On Linux this returns `/proc/self/exe`, which the kernel resolves at exec
+/// time to the running binary's inode — even after the file at the binary's
+/// on-disk path has been replaced or unlinked. A long-lived `serve` whose
+/// binary is swapped by an install/upgrade would otherwise see
+/// `current_exe()` = "…/smolvm-bin (deleted)" and fail every subsequent VM
+/// boot with ENOENT; spawning through `/proc/self/exe` also guarantees the
+/// boot subprocess runs the same code version as the process that spawned it,
+/// never a half-written replacement. Elsewhere the textual path is the only
+/// option.
+pub fn self_exe_for_spawn() -> std::io::Result<std::path::PathBuf> {
+    #[cfg(target_os = "linux")]
+    {
+        let proc_self = std::path::Path::new("/proc/self/exe");
+        if proc_self.exists() {
+            return Ok(proc_self.to_path_buf());
+        }
+    }
+    std::env::current_exe()
+}
+
 /// PIDs of detached VM boot subprocesses to reap. Registered by
 /// [`register_vm_child`] right after spawn (the boot subprocess is intentionally
 /// detached — own process group, never `wait()`ed — so it becomes a zombie on


### PR DESCRIPTION
A worker whose smolvm-bin is swapped on disk while serve is running keeps a deleted-inode exe, and spawning the textual current_exe path then fails every machine start with "spawn boot subprocess: No such file or directory" until a restart; resolving the spawn through /proc/self/exe boots the running binary's own inode regardless of what later replaced the file, validated live A/B on Linux where the stock binary reproduces the error and the patched one keeps booting after the same swap.