### PR TITLE
macOS: name the missing hypervisor entitlement when a boot fails with -22

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Known Limitations
 
 * Network is opt-in (`--net` on `machine create`). TCP/UDP only, no ICMP.
 * Volume mounts: directories only (no single files). Mounting at `/workspace` (`-v /host/dir:/workspace`) takes priority over the default storage-disk workspace — your host directory is used instead.
-* macOS: binary must be signed with Hypervisor.framework entitlements.
+* macOS: binary must be signed with Hypervisor.framework entitlements (`com.apple.security.hypervisor`). The shipped release is; a re-signed or freshly built binary silently loses it and every VM start then fails with `krun_start_enter returned: -22 (EINVAL)`. Re-sign it (ad-hoc is fine): `codesign --force --sign - --entitlements hv.entitlements <smolvm-bin>` where `hv.entitlements` is a plist containing `<key>com.apple.security.hypervisor</key><true/>`.
 * `--ssh-agent` requires an SSH agent running on the host (`SSH_AUTH_SOCK` must be set).
 * GPU acceleration requires libkrun built with `GPU=1` and virglrenderer + a Vulkan driver on the host (see [GPU Acceleration](#gpu-acceleration) below).
 * Windows: `--net` works the same as on other platforms (virtio-net with inbound port-forwarding; TSI for outbound-only VMs), as do `machine exec` / interactive sessions and `machine stats`. Not yet available on Windows: GPU acceleration and `machine fork` / snapshot. Pack *create* needs `storage-template.ext4` / `overlay-template.ext4` next to `smolvm.exe` (Windows has no host `mkfs.ext4`).

--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -756,7 +756,72 @@ pub(crate) fn describe_krun_start_error(ret: i32) -> String {
     #[cfg(not(target_os = "linux"))]
     let kvm_error: Option<String> = None;
 
+    // Same idea on macOS: `hv_vm_create` returns HV_UNSUPPORTED without the
+    // com.apple.security.hypervisor entitlement, and libkrun reports that in
+    // the same errno class as a disk that could not be opened — so the generic
+    // hint sends the user after disks when the real fix is re-signing. A
+    // re-signed (`codesign --force --sign -` with no `--entitlements`) or
+    // freshly built binary silently loses the entitlement.
+    #[cfg(target_os = "macos")]
+    if matches!(-ret, 1 | 13 | 19 | 22) && !has_hypervisor_entitlement() {
+        return format!(
+            "krun_start_enter returned: {ret} (this binary is not signed with the \
+             com.apple.security.hypervisor entitlement required by \
+             Hypervisor.framework — re-sign it: codesign --force --sign - \
+             --entitlements hv.entitlements <path-to-binary>)"
+        );
+    }
+
     describe_start_error_with_probe(ret, kvm_error.as_deref())
+}
+
+/// Whether the running binary carries the macOS hypervisor entitlement.
+///
+/// Probed with `codesign`, the same tool `smolvm_pack::signing` uses to add the
+/// entitlement when packing. An unreadable signature counts as missing (an
+/// unsigned binary is not entitled); a missing `codesign` counts as present, so
+/// a tooling gap never rewrites an unrelated boot failure.
+#[cfg(target_os = "macos")]
+fn has_hypervisor_entitlement() -> bool {
+    let Ok(exe) = std::env::current_exe() else {
+        return true;
+    };
+    // The packed run/start paths install a global `waitpid(-1)` SIGCHLD reaper
+    // before forking (`process::install_sigchld_handler`), which can reap
+    // `codesign` before `output()` waits and yield ECHILD — the same race
+    // `smolvm_pack::signing` documents. Probe under the default disposition.
+    let previous = unsafe { libc::signal(libc::SIGCHLD, libc::SIG_DFL) };
+    let probed = std::process::Command::new("codesign")
+        .args(["-d", "--entitlements", "-"])
+        .arg(&exe)
+        .output();
+    unsafe { libc::signal(libc::SIGCHLD, previous) };
+
+    let Ok(out) = probed else {
+        return true;
+    };
+    out.status.success() && entitlement_enabled(&String::from_utf8_lossy(&out.stdout))
+}
+
+/// Whether a `codesign -d --entitlements -` dump grants the hypervisor
+/// entitlement.
+///
+/// codesign names the key even when a signature sets it to `false`, so the
+/// value decides. It prints either `[Key] … [Value] [Bool] true` lines or an
+/// XML plist, so require a `true` between the key and the next entitlement.
+#[cfg(target_os = "macos")]
+fn entitlement_enabled(entitlements: &str) -> bool {
+    let Some((_, rest)) = entitlements.split_once("com.apple.security.hypervisor") else {
+        return false;
+    };
+    let mut value = rest;
+    if let Some(end) = value.find("[Key]") {
+        value = &value[..end];
+    }
+    if let Some(end) = value.find("<key>") {
+        value = &value[..end];
+    }
+    value.contains("true")
 }
 
 /// Pure core of [`describe_krun_start_error`], with the KVM probe result
@@ -881,6 +946,46 @@ mod tests {
         let eio = describe_start_error_with_probe(-5, Some("should be ignored"));
         assert!(eio.contains("EIO"));
         assert!(!eio.contains("privilege drop"));
+    }
+
+    // cargo's test binaries are ad-hoc signed without entitlements, so a
+    // hypervisor-access errno must name the missing entitlement instead of the
+    // generic disk/overlay guess — while keeping the grep contract intact.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn describe_krun_start_error_names_missing_hypervisor_entitlement() {
+        let msg = describe_krun_start_error(-22);
+        assert!(msg.contains("krun_start_enter returned: -22"), "{msg}");
+        assert!(msg.contains("com.apple.security.hypervisor"), "{msg}");
+        assert!(msg.contains("codesign"), "{msg}");
+    }
+
+    // codesign names the entitlement key even when a signature sets it to
+    // false, so the value — not the key's presence — decides.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn entitlement_is_granted_only_when_value_is_true() {
+        assert!(entitlement_enabled(
+            "[Key] com.apple.security.hypervisor\n[Value]\n[Bool] true"
+        ));
+        assert!(!entitlement_enabled(
+            "[Key] com.apple.security.hypervisor\n[Value]\n[Bool] false"
+        ));
+        assert!(entitlement_enabled(
+            "<key>com.apple.security.hypervisor</key><true/>"
+        ));
+        assert!(!entitlement_enabled(
+            "<key>com.apple.security.hypervisor</key><false/>"
+        ));
+        // A later entitlement's `true` must not leak into the decision.
+        assert!(!entitlement_enabled(
+            "<key>com.apple.security.hypervisor</key><false/>\
+             <key>com.apple.security.cs.allow-jit</key><true/>"
+        ));
+        // A dump without the key at all is not granted.
+        assert!(!entitlement_enabled(
+            "<key>com.apple.security.cs.allow-jit</key><true/>"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A re-signed binary (`codesign --force --sign -` without `--entitlements`) or a freshly built binary copied over the install silently loses `com.apple.security.hypervisor`. `hv_vm_create` then returns `HV_UNSUPPORTED`, which libkrun reports in the same errno class as a disk that could not be opened — so the boot fails with:

```
krun_start_enter returned: -22 (EINVAL — libkrun rejected the VM configuration;
usually a disk/overlay that could not be opened …)
```

The hint sends the user after disks and overlays when the fix is re-signing.

## Change

`describe_krun_start_error` already re-probes `/dev/kvm` on Linux for this errno class, so the post-drop permission cause replaces the generic guess. This adds the macOS counterpart: on `EPERM`/`EACCES`/`ENODEV`/`EINVAL`, probe the running binary's signature and, when the entitlement is absent, name it with the re-sign command instead of the disk/overlay guess. The grep contract (`krun_start_enter returned: <ret>`) is preserved, so `boot_failure_reason` still surfaces it.

- `has_hypervisor_entitlement()` probes with `codesign` — the same tool `smolvm_pack::signing` uses to add the entitlement at pack time. An unreadable signature counts as missing (an unsigned binary is not entitled); a missing `codesign` counts as present, so a tooling gap never rewrites an unrelated boot failure.
- The probe takes the default SIGCHLD disposition while it runs — the packed `run`/`start` paths install a global `waitpid(-1)` reaper (`process::install_sigchld_handler`) that would otherwise reap `codesign` and yield `ECHILD` — and it requires the entitlement's value to be `true`, since `codesign` names the key even for a signature that sets it to `false`.
- No behavior change: nothing new runs on a successful boot and no boot is refused — only the failure message changes.
- README "Known Limitations": documents the requirement and the re-sign command.

## Verification

- `cargo test --release -p smolvm --lib launcher_dynamic` — 5 passed: the new message case, a pure `entitlement_enabled` test (`true`/`false` across both codesign output forms, later-key leakage, key absent), and the pre-existing KVM-probe/decoding tests unchanged.
- Live on macOS 15 / Apple Silicon, against v1.8.2:
  - unsigned build → `krun_start_enter returned: -22 (this binary is not signed with the com.apple.security.hypervisor entitlement required by Hypervisor.framework — re-sign it: codesign --force --sign - --entitlements hv.entitlements <path-to-binary>)`
  - same binary signed with the entitlement → boots normally
  - binary signed with the entitlement set to `false` → still reports the entitlement, not the disk hint
- `cargo fmt --check` clean; `cargo build --release -p smolvm` passes.

Closes #947
