### PR TITLE
Grow an existing storage/overlay disk to the requested size instead of booting the stale one

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -242,10 +242,21 @@ impl<K: DiskType> VmDisk<K> {
         let size_bytes = size_gb * BYTES_PER_GIB;
 
         if path.exists() {
-            let metadata = std::fs::metadata(path)?;
+            // An existing disk keeps whatever size it was created at, so a
+            // machine whose data dir outlived a delete would boot the previous,
+            // smaller disk while its record reports the requested size. Grow it
+            // to the request instead (sparse, so it costs nothing); the guest's
+            // resize2fs expands the filesystem into the new space at boot. A
+            // disk that is already larger is left alone — callers that open with
+            // the default size must not shrink a machine's storage.
+            let mut on_disk = std::fs::metadata(path)?.len();
+            if on_disk < size_bytes {
+                expand_disk::<K>(path, size_gb)?;
+                on_disk = std::fs::metadata(path)?.len();
+            }
             Ok(Self {
                 path: path.to_path_buf(),
-                size_bytes: metadata.len(),
+                size_bytes: on_disk,
                 format: DiskFormat::Raw,
                 _kind: PhantomData,
             })
@@ -712,6 +723,35 @@ mod tests {
         assert_eq!(disk.size_gib(), 2);
         let metadata = std::fs::metadata(&disk_path).unwrap();
         assert_eq!(metadata.len(), 2 * BYTES_PER_GIB);
+
+        let _ = std::fs::remove_file(&disk_path);
+        let _ = std::fs::remove_dir(&temp_dir);
+    }
+
+    #[test]
+    fn open_or_create_at_grows_an_existing_smaller_disk() {
+        let temp_dir = std::env::temp_dir().join("smolvm_test_open_grows");
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let disk_path = temp_dir.join("grow_test.raw");
+        let _ = std::fs::remove_file(&disk_path);
+
+        // A disk left behind at the old size (a data dir that outlived a
+        // delete) must present the newly requested size, not the stale one.
+        disk_utils::create_sparse_disk::<Storage>(&disk_path, BYTES_PER_GIB).unwrap();
+        let disk = StorageDisk::open_or_create_at(&disk_path, 2).unwrap();
+        assert_eq!(disk.size_gib(), 2);
+        assert_eq!(
+            std::fs::metadata(&disk_path).unwrap().len(),
+            2 * BYTES_PER_GIB
+        );
+
+        // Opening with a smaller size never shrinks an existing disk.
+        let disk = StorageDisk::open_or_create_at(&disk_path, 1).unwrap();
+        assert_eq!(disk.size_gib(), 2);
+        assert_eq!(
+            std::fs::metadata(&disk_path).unwrap().len(),
+            2 * BYTES_PER_GIB
+        );
 
         let _ = std::fs::remove_file(&disk_path);
         let _ = std::fs::remove_dir(&temp_dir);


### PR DESCRIPTION
## Summary

A machine's data dir is keyed by a hash of its name, so a dir that outlives a delete (failed create, interrupted teardown) is reused by the next machine of the same name. `open_or_create_at` returned such a disk at its on-disk length and never resized it, so `machine ls` reported the requested size while the disk — and the guest device — stayed at the previous, smaller one. Large flattens then failed with a guest ENOSPC that surfaces host-side as `Resource temporarily unavailable (os error 35)`.

Fixes #949. (#921 fixed the fresh-create case in 1.8.0; this is the reuse case, still present on v1.8.2.)

## Change

In `open_or_create_at`, grow an existing disk to the request using the existing `expand_disk` primitive — sparse, so it costs nothing — and let the guest's `resize2fs` expand the filesystem at boot:

```rust
let mut on_disk = std::fs::metadata(path)?.len();
if on_disk < size_bytes {
    expand_disk::<K>(path, size_gb)?;
    on_disk = std::fs::metadata(path)?.len();
}
```

A disk that is already larger is left alone, so callers that open with the default size (`for_vm`, `open_or_create`) never shrink a machine's storage. Fixing it here rather than in the boot path covers every caller — create, boot, `pack_run`, and the serve API — with one check.

## Verification

- `cargo test --release -p smolvm --lib storage::` — 28 passed, including a new test that a 1 GiB disk opened at 2 GiB presents 2 GiB and that reopening at 1 GiB does not shrink it. The pre-existing `expand_disk` tests (basic, reject-shrink, idempotent, typed-expand) are unchanged and still pass.
- Live A/B on macOS 15 / Apple Silicon against the v1.8.2 release binary, same machine data dir:
  - record `storage_gb: 40`, disk `21474836480` (20 GiB) after a pristine `machine start` — the bug
  - after `machine start` with this build: disk `42949672960` (40 GiB), and in-guest `df` reports `/dev/vda 39.4G … /storage`
- Same A/B on the `machine create --from <pack>` path, which sizes its disk at create time (`AgentManager::for_vm_with_sizes` → `open_or_overlay_at`): over a reused data dir, `--storage 80` left the stale `21474836480` on v1.8.2 (record reported 80) and it stayed stale after `start`; with this change the disk is `85899345920` (80 GiB) already at create, before any extraction or staged-layer unpack runs. A fresh `--from --storage 80` is 80 GiB on both builds.
- `cargo fmt --check` clean.
