### PR TITLE
Give every pack-export read the same ceiling instead of two that disagree

### DIFF
--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -2132,6 +2132,26 @@ impl AgentClient {
         &mut self,
         guest_path: &str,
         local_path: &std::path::Path,
+        on_progress: F,
+    ) -> Result<u64> {
+        self.read_file_to_path_capped(
+            guest_path,
+            local_path,
+            file_transfer_max_total(),
+            on_progress,
+        )
+    }
+
+    /// [`Self::read_file_to_path`] with an explicit byte ceiling.
+    ///
+    /// The pack paths read back a layer smolvm itself asked the guest to
+    /// produce, so they pass [`pack_export_max_total`] instead of the general
+    /// guest-driven transfer bound.
+    pub fn read_file_to_path_capped<F: FnMut(u64)>(
+        &mut self,
+        guest_path: &str,
+        local_path: &std::path::Path,
+        cap: u64,
         mut on_progress: F,
     ) -> Result<u64> {
         use std::io::Write;
@@ -2150,7 +2170,6 @@ impl AgentClient {
         })?;
 
         let mut total = 0u64;
-        let cap = file_transfer_max_total();
         loop {
             match self.recv_raw()? {
                 AgentResponse::DataChunk { data, done } => {
@@ -2541,6 +2560,25 @@ pub fn file_transfer_max_total() -> u64 {
         .unwrap_or(FILE_TRANSFER_MAX_TOTAL)
 }
 
+/// Default ceiling for pack-export reads (64 GiB).
+const PACK_EXPORT_MAX_TOTAL: u64 = 64 << 30;
+
+/// The size cap for pack-export reads, in bytes. Defaults to 64 GiB and honors
+/// the same `SMOLVM_FILE_TRANSFER_MAX_BYTES` override as
+/// [`file_transfer_max_total`].
+///
+/// Pack export reads back a layer smolvm itself asked the guest to write, and a
+/// provisioned machine's flattened rootfs is routinely tens of GiB, so the
+/// general transfer bound — sized for `machine cp` against a guest that chooses
+/// its own payload — is the wrong ceiling here. Every pack read shares this one
+/// so the routes of a single export cannot disagree.
+pub fn pack_export_max_total() -> u64 {
+    std::env::var("SMOLVM_FILE_TRANSFER_MAX_BYTES")
+        .ok()
+        .and_then(|s| crate::util::parse_size_bytes(s.trim()).ok())
+        .unwrap_or(PACK_EXPORT_MAX_TOTAL)
+}
+
 fn consume_streamed_read_with_progress<F, P>(next_response: F, on_progress: P) -> Result<Vec<u8>>
 where
     F: FnMut() -> Result<AgentResponse>,
@@ -2639,6 +2677,15 @@ mod read_cap_tests {
     fn read_cap_terminator_returns_full_buffer() {
         let out = drive(vec![chunk(100, false), chunk(50, true)]).unwrap();
         assert_eq!(out.len(), 150);
+    }
+
+    // Pack export reads back a layer smolvm asked the guest to produce, not a
+    // guest-chosen payload, so its ceiling must never be the more restrictive
+    // of the two. Holds with or without the shared override, since both caps
+    // read it.
+    #[test]
+    fn pack_export_cap_is_never_below_the_transfer_cap() {
+        assert!(pack_export_max_total() >= file_transfer_max_total());
     }
 
     #[test]

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -20,8 +20,8 @@ pub use crate::data::network::PortMapping;
 pub use crate::data::resources::VmResources;
 pub use crate::data::storage::HostMount;
 pub use client::{
-    file_transfer_max_total, AgentClient, ExecEvent, InteractiveInput, InteractiveOutput,
-    PullOptions, RunConfig,
+    file_transfer_max_total, pack_export_max_total, AgentClient, ExecEvent, InteractiveInput,
+    InteractiveOutput, PullOptions, RunConfig,
 };
 pub use fsnotify_watch::FsNotifyWatcher;
 pub use krun::KrunFunctions;

--- a/src/cli/pack.rs
+++ b/src/cli/pack.rs
@@ -452,7 +452,12 @@ impl PackCreateCmd {
             let merged_file = collector.layer_staging_path(&merged_digest);
 
             let total_bytes = client
-                .read_file_to_path("/tmp/merged-layers.tar", &merged_file, |_| {})
+                .read_file_to_path_capped(
+                    "/tmp/merged-layers.tar",
+                    &merged_file,
+                    smolvm::agent::pack_export_max_total(),
+                    |_| {},
+                )
                 .map_err(|e| Error::agent("export merged layer", e.to_string()))?;
             println!(" {} MB done", total_bytes / (1024 * 1024));
 
@@ -969,13 +974,9 @@ impl PackCreateCmd {
         let mut total_bytes = 0u64;
         let mut last_progress = Instant::now();
         // Pack export legitimately streams multi-GiB layers (a provisioned
-        // VM's rootfs with baked venvs / model caches), so the general 4 GiB
-        // file-transfer cap is too small here: honor an explicit override,
-        // otherwise allow 64 GiB before calling the stream runaway.
-        let cap = std::env::var("SMOLVM_FILE_TRANSFER_MAX_BYTES")
-            .ok()
-            .and_then(|s| smolvm::util::parse_size_bytes(s.trim()).ok())
-            .unwrap_or(64 << 30);
+        // VM's rootfs with baked venvs / model caches), so it carries the
+        // pack ceiling rather than the general file-transfer cap.
+        let cap = smolvm::agent::pack_export_max_total();
         loop {
             if start.elapsed() > LAYER_EXPORT_TIMEOUT {
                 return Err(Error::agent(

--- a/src/pack_export.rs
+++ b/src/pack_export.rs
@@ -513,7 +513,12 @@ fn flatten_and_export(
         .layer_staging_path(&format!("sha256:{}", "0".repeat(64)))
         .with_file_name("flat-export.tmp");
     let total = client
-        .read_file_to_path("/storage/flat-export.tar", &tmp_file, |_| {})
+        .read_file_to_path_capped(
+            "/storage/flat-export.tar",
+            &tmp_file,
+            crate::agent::pack_export_max_total(),
+            |_| {},
+        )
         .map_err(|e| Error::agent("export flattened layer", e.to_string()))?;
     if total == 0 {
         let _ = std::fs::remove_file(&tmp_file);


### PR DESCRIPTION
## Summary

`pack create --from-vm` reads the flattened layer back through `read_file_to_path`, which is bounded by `file_transfer_max_total()` — the protocol's 4 GiB guest-transfer cap. So packing any machine whose flattened rootfs exceeds 4 GiB fails:

```
Error: agent operation failed: read file: guest streamed 4311744512 bytes,
exceeding the 4294967296 byte cap
```

The sibling route in the *same* operation — the per-layer export in `src/cli/pack.rs`, given a 64 GiB ceiling by #508 — already allowed 16× more. One export, two ceilings, and an operator had to know to set `SMOLVM_FILE_TRANSFER_MAX_BYTES` to pack an ordinary provisioned machine.

Fixes #952.

## Change

Name the pack ceiling once, mirroring the existing `file_transfer_max_total()` (same env override, larger default):

```rust
/// Default ceiling for pack-export reads (64 GiB).
const PACK_EXPORT_MAX_TOTAL: u64 = 64 << 30;

pub fn pack_export_max_total() -> u64 { … }
```

- `read_file_to_path` gains a `read_file_to_path_capped` sibling that takes the ceiling explicitly; the original delegates to it with `file_transfer_max_total()`, so existing callers are unchanged.
- All three pack reads now use `pack_export_max_total()`: the from-vm flatten export (`pack_export.rs`), the merged-layer export (`cli/pack.rs`), and the per-layer export — whose inlined env-var-plus-64-GiB block is replaced by the shared function, removing the duplicate definition.
- The 4 GiB default stays exactly where it belongs: `machine cp` and any other read whose payload the *guest* chooses. Pack export reads back a layer smolvm itself asked the guest to produce, which is a different trust story.

## Verification

- `cargo test --release -p smolvm --lib read_cap_tests` — 8 passed, including a new invariant in the module that already covers this arithmetic: the pack ceiling is never below the general transfer cap (true with or without the shared override, since both read it).
- Live on macOS 15 / Apple Silicon, built from this branch, **with `SMOLVM_FILE_TRANSFER_MAX_BYTES` unset**: `pack create --from-vm` of a registry-image machine completes end to end (`Flattened layer: 8942080 bytes`, 15.4 MB artifact) — no regression on the small path, and no env var needed.
- Not exercised locally: a >4 GiB layer actually tripping the old cap needs ~15 GB of transient disk, which I could not spend on this host. The failing call site is confirmed by inspection at `v1.8.2` (`pack_export.rs:516` → `read_file_to_path`), and the cap check is deterministic arithmetic (`next_total > cap`), so the path is certain; the observed failure is the field report in #952 (smolvm 1.7.7, ~30 GB flattened base).
- `cargo fmt --check` clean.
