### PR TITLE
Resolve host.smolvm.internal to the gateway address

### DIFF
--- a/crates/smolvm-network/src/dns.rs
+++ b/crates/smolvm-network/src/dns.rs
@@ -143,8 +143,6 @@ fn parse_answer_ip_records(packet: &[u8]) -> Option<Vec<(IpAddr, u32)>> {
     Some(ips)
 }
 
-/// Build a DNS response carrying just an error `rcode` (e.g. NXDOMAIN), echoing
-/// the query id and question. Mirrors libkrun's `build_error_response`.
 /// A NOERROR answer for the gateway's own name ([`GATEWAY_HOSTNAME`]): an A
 /// query gets the gateway address, any other qtype an empty answer section
 /// (AAAA in particular — v6-first resolvers then settle on the A record).
@@ -169,6 +167,8 @@ pub fn gateway_response(query: &[u8], gateway: Ipv4Addr) -> Vec<u8> {
     response
 }
 
+/// Build a DNS response carrying just an error `rcode` (e.g. NXDOMAIN), echoing
+/// the query id and question. Mirrors libkrun's `build_error_response`.
 pub fn error_response(query: &[u8], rcode: u16) -> Vec<u8> {
     let id: &[u8] = if query.len() >= DNS_ID_LEN {
         &query[..DNS_ID_LEN]

--- a/crates/smolvm-network/src/dns.rs
+++ b/crates/smolvm-network/src/dns.rs
@@ -40,6 +40,16 @@ const DNS_POINTER_OFFSET_MASK: u8 = 0x3f;
 const DNS_MAX_COMPRESSION_JUMPS: usize = 16;
 const DNS_MAX_LABEL_LEN: usize = 63;
 
+/// The gateway's own name: the guest's stand-in for "the host" (a guest flow
+/// to the gateway address is relayed to host loopback), answered
+/// authoritatively by the gateway so guests need not hardcode its address.
+/// Mirrors Docker's `host.docker.internal`.
+pub const GATEWAY_HOSTNAME: &str = "host.smolvm.internal";
+
+/// TTL for the gateway's self-answer. Short so a stack restart with a
+/// different gateway address is picked up quickly.
+const GATEWAY_TTL_SECS: u32 = 60;
+
 /// Lowercase + strip a trailing dot. `None` for an empty name.
 pub fn normalize_hostname(hostname: &str) -> Option<String> {
     let hostname = hostname.trim_end_matches('.').to_ascii_lowercase();
@@ -135,6 +145,30 @@ fn parse_answer_ip_records(packet: &[u8]) -> Option<Vec<(IpAddr, u32)>> {
 
 /// Build a DNS response carrying just an error `rcode` (e.g. NXDOMAIN), echoing
 /// the query id and question. Mirrors libkrun's `build_error_response`.
+/// A NOERROR answer for the gateway's own name ([`GATEWAY_HOSTNAME`]): an A
+/// query gets the gateway address, any other qtype an empty answer section
+/// (AAAA in particular — v6-first resolvers then settle on the A record).
+pub fn gateway_response(query: &[u8], gateway: Ipv4Addr) -> Vec<u8> {
+    let mut response = error_response(query, 0);
+    let Some(end) = question_section_end(query) else {
+        return response;
+    };
+    if read_u16(query, end - DNS_QUESTION_FIXED_LEN) != Some(DNS_TYPE_A) {
+        return response;
+    }
+    response[DNS_ANCOUNT_OFFSET..DNS_ANCOUNT_OFFSET + DNS_U16_LEN]
+        .copy_from_slice(&1u16.to_be_bytes());
+    // One answer record: a compression pointer to the question name, then
+    // A/IN, TTL, and the 4-byte address.
+    response.extend_from_slice(&[DNS_POINTER_TAG, DNS_HEADER_LEN as u8]);
+    response.extend_from_slice(&DNS_TYPE_A.to_be_bytes());
+    response.extend_from_slice(&DNS_CLASS_IN.to_be_bytes());
+    response.extend_from_slice(&GATEWAY_TTL_SECS.to_be_bytes());
+    response.extend_from_slice(&(DNS_A_RDATA_LEN as u16).to_be_bytes());
+    response.extend_from_slice(&gateway.octets());
+    response
+}
+
 pub fn error_response(query: &[u8], rcode: u16) -> Vec<u8> {
     let id: &[u8] = if query.len() >= DNS_ID_LEN {
         &query[..DNS_ID_LEN]
@@ -285,6 +319,36 @@ mod tests {
     #[test]
     fn empty_allow_list_blocks_all() {
         assert!(!hostname_allowed("example.com", &[]));
+    }
+
+    #[test]
+    fn gateway_response_answers_a_with_the_gateway_address() {
+        let gw = Ipv4Addr::new(100, 96, 0, 1);
+        let response = gateway_response(&query_for(GATEWAY_HOSTNAME), gw);
+        assert_eq!(response[..2], [0x12, 0x34]); // id echoed
+        assert_eq!(
+            read_u16(&response, DNS_FLAGS_OFFSET).unwrap() & DNS_RCODE_MASK,
+            0
+        );
+        let records = answer_ip_records(&response);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].0, IpAddr::V4(gw));
+        assert_eq!(records[0].1, GATEWAY_TTL_SECS);
+    }
+
+    #[test]
+    fn gateway_response_gives_aaaa_an_empty_noerror() {
+        let mut query = query_for(GATEWAY_HOSTNAME);
+        let qtype_offset = query.len() - DNS_QUESTION_FIXED_LEN;
+        query[qtype_offset..qtype_offset + DNS_U16_LEN]
+            .copy_from_slice(&DNS_TYPE_AAAA.to_be_bytes());
+        let response = gateway_response(&query, Ipv4Addr::new(100, 96, 0, 1));
+        assert_eq!(
+            read_u16(&response, DNS_FLAGS_OFFSET).unwrap() & DNS_RCODE_MASK,
+            0
+        );
+        assert_eq!(read_u16(&response, DNS_ANCOUNT_OFFSET).unwrap(), 0);
+        assert!(answer_ip_records(&response).is_empty());
     }
 
     #[test]

--- a/crates/smolvm-network/src/stack.rs
+++ b/crates/smolvm-network/src/stack.rs
@@ -347,6 +347,7 @@ fn run_network_stack(
             &mut sockets,
             &egress,
             config.upstream_dns,
+            config.gateway_ipv4,
             &mut dns_gateway,
             &dns_channels.to_relay,
         );
@@ -356,6 +357,7 @@ fn run_network_stack(
             &mut sockets,
             &egress,
             config.upstream_dns,
+            config.gateway_ipv4,
             &mut dns_gateway,
             &dns_channels.to_relay,
         );
@@ -771,7 +773,17 @@ enum DnsDecision {
 /// inactive everything is forwarded (no learning); otherwise only allow-listed
 /// names are forwarded and learned, others get NXDOMAIN and unparseable ones
 /// SERVFAIL. Identical policy to the old `filtered_dns_response`.
-fn classify_dns_query(query: &[u8], egress: &EgressPolicy) -> DnsDecision {
+///
+/// The gateway's own name is answered before the filter runs: it names
+/// gateway-internal plumbing, not egress, so it must resolve even under a
+/// strict allow-host policy.
+fn classify_dns_query(query: &[u8], egress: &EgressPolicy, gateway_ipv4: Ipv4Addr) -> DnsDecision {
+    if dns::question_name(query)
+        .and_then(|n| dns::normalize_hostname(&n))
+        .is_some_and(|n| n == dns::GATEWAY_HOSTNAME)
+    {
+        return DnsDecision::Immediate(dns::gateway_response(query, gateway_ipv4));
+    }
     if !egress.dns_filter_active() {
         return DnsDecision::Forward { learn: false };
     }
@@ -799,6 +811,7 @@ fn dispatch_dns_udp(
     sockets: &mut SocketSet<'_>,
     egress: &EgressPolicy,
     upstream_dns: Ipv4Addr,
+    gateway_ipv4: Ipv4Addr,
     gateway: &mut DnsGateway,
     to_relay: &SyncSender<DnsQuery>,
 ) -> bool {
@@ -811,7 +824,7 @@ fn dispatch_dns_udp(
             Ok((q, m)) => (q.to_vec(), m.endpoint, m.local_address),
             Err(_) => break,
         };
-        match classify_dns_query(&query, egress) {
+        match classify_dns_query(&query, egress, gateway_ipv4) {
             DnsDecision::Immediate(response) => {
                 let response_meta = UdpMetadata {
                     endpoint,
@@ -974,6 +987,7 @@ fn process_dns_tcp(
     sockets: &mut SocketSet<'_>,
     egress: &EgressPolicy,
     upstream_dns: Ipv4Addr,
+    gateway_ipv4: Ipv4Addr,
     gateway: &mut DnsGateway,
     to_relay: &SyncSender<DnsQuery>,
 ) -> bool {
@@ -1038,7 +1052,7 @@ fn process_dns_tcp(
                     query.len(),
                     upstream_dns
                 );
-                match classify_dns_query(&query, egress) {
+                match classify_dns_query(&query, egress, gateway_ipv4) {
                     DnsDecision::Immediate(response) => {
                         frame_dns_tcp_response(conn, &response);
                         conn.done = true;

--- a/crates/smolvm-network/src/stack.rs
+++ b/crates/smolvm-network/src/stack.rs
@@ -199,6 +199,10 @@ fn run_network_stack(
     let mut device = VirtioNetworkDevice::new(queues.clone(), config.mtu);
     let mut interface = create_interface(&mut device, &config);
     let mut sockets = SocketSet::new(vec![]);
+    let dns_routing = DnsRouting {
+        upstream: config.upstream_dns,
+        gateway: config.gateway_ipv4,
+    };
     let dns_socket_handle = add_dns_socket(&mut sockets);
     let dns_tcp_handles = add_dns_tcp_sockets(&mut sockets);
     let mut dns_tcp_conns: Vec<DnsTcpConn> = (0..dns_tcp_handles.len())
@@ -346,8 +350,7 @@ fn run_network_stack(
             dns_socket_handle,
             &mut sockets,
             &egress,
-            config.upstream_dns,
-            config.gateway_ipv4,
+            dns_routing,
             &mut dns_gateway,
             &dns_channels.to_relay,
         );
@@ -356,8 +359,7 @@ fn run_network_stack(
             &mut dns_tcp_conns,
             &mut sockets,
             &egress,
-            config.upstream_dns,
-            config.gateway_ipv4,
+            dns_routing,
             &mut dns_gateway,
             &dns_channels.to_relay,
         );
@@ -758,6 +760,14 @@ impl DnsGateway {
     }
 }
 
+/// Where guest DNS answers come from: the upstream resolver queries are
+/// forwarded to, and the gateway address answered for the gateway's own name.
+#[derive(Clone, Copy)]
+struct DnsRouting {
+    upstream: Ipv4Addr,
+    gateway: Ipv4Addr,
+}
+
 /// The decision for a single guest DNS query, made on the poll thread using the
 /// egress allow-host policy (no host I/O). Mirrors the previous inline filter.
 enum DnsDecision {
@@ -810,8 +820,7 @@ fn dispatch_dns_udp(
     dns_socket_handle: SocketHandle,
     sockets: &mut SocketSet<'_>,
     egress: &EgressPolicy,
-    upstream_dns: Ipv4Addr,
-    gateway_ipv4: Ipv4Addr,
+    routing: DnsRouting,
     gateway: &mut DnsGateway,
     to_relay: &SyncSender<DnsQuery>,
 ) -> bool {
@@ -824,7 +833,7 @@ fn dispatch_dns_udp(
             Ok((q, m)) => (q.to_vec(), m.endpoint, m.local_address),
             Err(_) => break,
         };
-        match classify_dns_query(&query, egress, gateway_ipv4) {
+        match classify_dns_query(&query, egress, routing.gateway) {
             DnsDecision::Immediate(response) => {
                 let response_meta = UdpMetadata {
                     endpoint,
@@ -850,7 +859,7 @@ fn dispatch_dns_udp(
                 match to_relay.try_send(DnsQuery {
                     id,
                     transport: DnsTransport::Udp,
-                    upstream: upstream_dns,
+                    upstream: routing.upstream,
                     query,
                 }) {
                     Ok(()) => queued = true,
@@ -986,8 +995,7 @@ fn process_dns_tcp(
     conns: &mut [DnsTcpConn],
     sockets: &mut SocketSet<'_>,
     egress: &EgressPolicy,
-    upstream_dns: Ipv4Addr,
-    gateway_ipv4: Ipv4Addr,
+    routing: DnsRouting,
     gateway: &mut DnsGateway,
     to_relay: &SyncSender<DnsQuery>,
 ) -> bool {
@@ -1050,9 +1058,9 @@ fn process_dns_tcp(
                 virtio_net_log!(
                     "virtio-net: DNS/TCP query query_len={} upstream_dns={}",
                     query.len(),
-                    upstream_dns
+                    routing.upstream
                 );
-                match classify_dns_query(&query, egress, gateway_ipv4) {
+                match classify_dns_query(&query, egress, routing.gateway) {
                     DnsDecision::Immediate(response) => {
                         frame_dns_tcp_response(conn, &response);
                         conn.done = true;
@@ -1065,7 +1073,7 @@ fn process_dns_tcp(
                         match to_relay.try_send(DnsQuery {
                             id,
                             transport: DnsTransport::Tcp,
-                            upstream: upstream_dns,
+                            upstream: routing.upstream,
                             query,
                         }) {
                             Ok(()) => {


### PR DESCRIPTION
The virtio-net gateway already relays guest flows addressed to its own IP onto host loopback, so it now answers DNS for host.smolvm.internal with that address (before the allow-host filter, since the name is gateway-internal), giving guests a stable name for the host like Docker's host.docker.internal.