### PR TITLE
Roll back checkpoints after clone identity failures

### DIFF
--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -609,22 +609,36 @@ pub(crate) fn prepare_forks_reusing(
     })
 }
 
-fn rollback_new_snapshot(
+/// Restore an initially-running golden after a failed clone finalization and
+/// discard the checkpoint that produced that clone. Callers must ensure no
+/// successfully booted clone depends on `snapshot_dir` before invoking this.
+pub(crate) fn rollback_retained_fork_snapshot(
     db: &SmolvmDb,
     golden: &str,
     snapshot_dir: &Path,
     persisted: bool,
-    error: Error,
-) -> Error {
+) -> Result<()> {
+    let dependent_clones = db.dependent_clones(golden)?;
+    if !dependent_clones.is_empty() {
+        return Err(Error::agent(
+            "fork rollback",
+            format!(
+                "refusing to resume golden '{golden}': {} live clone(s) still depend on its checkpoint ({})",
+                dependent_clones.len(),
+                dependent_clones.join(", ")
+            ),
+        ));
+    }
+
     let mut rollback_errors = Vec::new();
     if let Err(resume_error) = resume_golden(golden, snapshot_dir) {
-        return Error::agent(
-            "fork",
+        return Err(Error::agent(
+            "fork rollback",
             format!(
-                "{error}; golden rollback failed: {resume_error}; preserved checkpoint {} for recovery",
+                "golden rollback failed: {resume_error}; preserved checkpoint {} for recovery",
                 snapshot_dir.display()
             ),
-        );
+        ));
     }
     if persisted {
         if let Err(remove_error) = db.remove_retained_fork_snapshot(golden) {
@@ -641,15 +655,22 @@ fn rollback_new_snapshot(
         }
     }
     if rollback_errors.is_empty() {
-        error
+        Ok(())
     } else {
-        Error::agent(
-            "fork",
-            format!(
-                "{error}; rollback also failed: {}",
-                rollback_errors.join("; ")
-            ),
-        )
+        Err(Error::agent("fork rollback", rollback_errors.join("; ")))
+    }
+}
+
+fn rollback_new_snapshot(
+    db: &SmolvmDb,
+    golden: &str,
+    snapshot_dir: &Path,
+    persisted: bool,
+    error: Error,
+) -> Error {
+    match rollback_retained_fork_snapshot(db, golden, snapshot_dir, persisted) {
+        Ok(()) => error,
+        Err(rollback_error) => Error::agent("fork", format!("{error}; {rollback_error}")),
     }
 }
 
@@ -1571,6 +1592,25 @@ mod tests {
         std::fs::remove_file(temp.path().join("checkpoint.bin")).unwrap();
         std::fs::create_dir(temp.path().join("checkpoint.bin")).unwrap();
         assert!(golden_resume_command(temp.path()).is_err());
+    }
+
+    #[test]
+    fn golden_rollback_refuses_to_invalidate_a_live_clones_checkpoint() {
+        let temp = tempfile::tempdir().unwrap();
+        let db = SmolvmDb::open_at(&temp.path().join("test.db")).unwrap();
+        let golden = VmRecord::new("golden".into(), 2, 1024, vec![], vec![], false);
+        db.insert_vm("golden", &golden).unwrap();
+        let mut clone = VmRecord::new("clone".into(), 2, 1024, vec![], vec![], false);
+        clone.golden = Some("golden".into());
+        db.insert_vm("clone", &clone).unwrap();
+        let snapshot = temp.path().join("snapshot");
+        std::fs::create_dir(&snapshot).unwrap();
+
+        let error = rollback_retained_fork_snapshot(&db, "golden", &snapshot, true)
+            .expect_err("a live clone must keep its checkpoint");
+
+        assert!(error.to_string().contains("1 live clone(s)"));
+        assert!(snapshot.exists());
     }
 
     #[test]

--- a/src/api/errors.rs
+++ b/src/api/errors.rs
@@ -24,6 +24,9 @@ pub enum ApiError {
     /// specific, retryable failure (reallocate a different port and retry)
     /// instead of treating it as a generic 500/409.
     PortConflict(String),
+    /// A restored clone could not prove that its inherited machine identity was
+    /// replaced. The clone has been torn down, so callers may safely retry.
+    CloneIdentityRejuvenationFailed(String),
     /// Bad request - invalid input (400).
     BadRequest(String),
     /// Request timeout (408).
@@ -61,6 +64,11 @@ impl IntoResponse for ApiError {
             ApiError::NotFound(msg) => (StatusCode::NOT_FOUND, "NOT_FOUND", msg),
             ApiError::Conflict(msg) => (StatusCode::CONFLICT, "CONFLICT", msg),
             ApiError::PortConflict(msg) => (StatusCode::CONFLICT, "PORT_IN_USE", msg),
+            ApiError::CloneIdentityRejuvenationFailed(msg) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "CLONE_IDENTITY_REJUVENATION_FAILED",
+                msg,
+            ),
             ApiError::BadRequest(msg) => (StatusCode::BAD_REQUEST, "BAD_REQUEST", msg),
             ApiError::Timeout => (
                 StatusCode::REQUEST_TIMEOUT,
@@ -134,6 +142,10 @@ mod tests {
             (ApiError::Forbidden("x".into()), StatusCode::FORBIDDEN),
             (ApiError::NotFound("x".into()), StatusCode::NOT_FOUND),
             (ApiError::Conflict("x".into()), StatusCode::CONFLICT),
+            (
+                ApiError::CloneIdentityRejuvenationFailed("x".into()),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
             (ApiError::BadRequest("x".into()), StatusCode::BAD_REQUEST),
             (ApiError::Timeout, StatusCode::REQUEST_TIMEOUT),
             (
@@ -148,6 +160,19 @@ mod tests {
         for (error, expected) in cases {
             assert_eq!(error.into_response().status(), expected);
         }
+    }
+
+    #[tokio::test]
+    async fn clone_rejuvenation_failure_has_a_stable_public_code() {
+        let response = ApiError::CloneIdentityRejuvenationFailed("identity reset failed".into())
+            .into_response();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(body["code"], "CLONE_IDENTITY_REJUVENATION_FAILED");
+        assert_eq!(body["error"], "identity reset failed");
     }
 
     #[test]

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -1379,6 +1379,12 @@ pub(crate) async fn fork_machine_inner(
     crate::agent::fork::validate_fork_env(&fork_env)
         .map_err(|e| ApiError::BadRequest(e.to_string()))?;
 
+    if clone == golden {
+        return Err(ApiError::Conflict(format!(
+            "clone name '{clone}' is already used by the golden"
+        )));
+    }
+
     // Validate pinned ports as the create path does: fork uses these host ports
     // as-is (no remapping), so port 0 or a duplicated host port would otherwise
     // surface only as a confusing clone-boot bind failure instead of a clean 400.
@@ -1400,6 +1406,23 @@ pub(crate) async fn fork_machine_inner(
         }
     }
 
+    // A failed clone finalization may need to roll back the golden and discard
+    // the retained checkpoint that produced it. Keep that state transition in
+    // one owner-level critical section so another fork/start/stop/delete cannot
+    // observe the golden between failed-clone teardown and rollback.
+    let golden_lifecycle = state.lifecycle_lock(&golden);
+    let _golden_guard = golden_lifecycle.lock().await;
+
+    // Reject an already-registered target before taking its lifecycle lock.
+    // Besides avoiding a pointless forkpoint wait, this prevents two invalid
+    // cross-forks (X -> Y and Y -> X) from each holding one golden while waiting
+    // forever on the other machine's clone lock.
+    if state.lookup_vm(&clone).await?.is_some() {
+        return Err(ApiError::Conflict(format!(
+            "machine '{clone}' already exists"
+        )));
+    }
+
     if wait_ready {
         let golden_b = golden.clone();
         tokio::task::spawn_blocking(move || {
@@ -1411,8 +1434,8 @@ pub(crate) async fn fork_machine_inner(
     }
 
     // Serialize lifecycle on the CLONE name so a concurrent start/stop/delete of
-    // the same clone can't race the fork's register + boot. The golden is only
-    // read + frozen via its control socket, which tolerates concurrent forks.
+    // the same clone can't race the fork's register + boot. Golden is always
+    // acquired before clone, matching the fork-pool lock order.
     let lifecycle = state.lifecycle_lock(&clone);
     let _guard = lifecycle.lock().await;
 
@@ -1444,8 +1467,10 @@ pub(crate) async fn fork_machine_inner(
         .map_err(classify_fork_error)?
     };
 
-    boot_prepared_fork_inner(
-        state,
+    let snapshot_dir = prep.snapshot_dir.clone();
+    let resume_golden_on_rollback = prep.resume_golden_on_rollback;
+    let result = boot_prepared_fork_inner(
+        state.clone(),
         clone,
         prep,
         PreparedForkBoot {
@@ -1457,7 +1482,40 @@ pub(crate) async fn fork_machine_inner(
             boot_permit: None,
         },
     )
+    .await;
+
+    let Err(ApiError::CloneIdentityRejuvenationFailed(message)) = result else {
+        return result;
+    };
+    if !resume_golden_on_rollback {
+        return Err(ApiError::CloneIdentityRejuvenationFailed(message));
+    }
+
+    // `fail_closed_on_rejuvenation` has torn down the only clone prepared from
+    // this new checkpoint. It is therefore safe to restore the initially-running
+    // golden and invalidate the checkpoint before releasing its lifecycle lock.
+    let db = state.db().clone();
+    let golden_for_rollback = golden.clone();
+    let rollback = match tokio::task::spawn_blocking(move || {
+        crate::agent::fork::rollback_retained_fork_snapshot(
+            &db,
+            &golden_for_rollback,
+            &snapshot_dir,
+            true,
+        )
+    })
     .await
+    {
+        Ok(result) => result,
+        Err(error) => Err(SmolvmError::agent(
+            "fork rollback",
+            format!("task error: {error}"),
+        )),
+    };
+    match rollback {
+        Ok(()) => Err(ApiError::CloneIdentityRejuvenationFailed(message)),
+        Err(rollback_error) => Err(ApiError::Internal(format!("{message}; {rollback_error}"))),
+    }
 }
 
 /// Prepare several clean held workers from one golden checkpoint and boot them
@@ -1670,6 +1728,26 @@ struct PreparedForkBoot {
     boot_permit: Option<tokio::sync::OwnedSemaphorePermit>,
 }
 
+enum PreparedForkBootError {
+    Launch(String),
+    CloneIdentityRejuvenation(String),
+}
+
+impl From<String> for PreparedForkBootError {
+    fn from(message: String) -> Self {
+        Self::Launch(message)
+    }
+}
+
+fn classify_prepared_fork_boot_error(error: PreparedForkBootError) -> ApiError {
+    match error {
+        PreparedForkBootError::Launch(message) => classify_launch_error(message),
+        PreparedForkBootError::CloneIdentityRejuvenation(message) => {
+            ApiError::CloneIdentityRejuvenationFailed(message)
+        }
+    }
+}
+
 async fn boot_prepared_fork_inner(
     state: Arc<ApiState>,
     clone: String,
@@ -1717,7 +1795,7 @@ async fn boot_prepared_fork_inner(
             // leaves nothing half-created.
             let _ = db.remove_vm(&clone_b);
             let _ = std::fs::remove_dir_all(vm_data_dir(&clone_b));
-            return Err(format!("failed to boot clone: {}", e));
+            return Err(format!("failed to boot clone: {}", e).into());
         }
 
         let pid = manager.child_pid();
@@ -1736,7 +1814,11 @@ async fn boot_prepared_fork_inner(
             crate::agent::fork::rejuvenate_clone(&clone_b, &record),
             teardown,
         )
-        .map_err(|e| format!("clone identity rejuvenation failed: {}", e))?;
+        .map_err(|e| {
+            PreparedForkBootError::CloneIdentityRejuvenation(format!(
+                "clone identity rejuvenation failed: {e}"
+            ))
+        })?;
         // Per-fork parameters: same fail-closed contract — a clone that asked
         // for parameters but can't receive them must not be vended.
         crate::agent::fork::fail_closed_on_rejuvenation(
@@ -1769,7 +1851,7 @@ async fn boot_prepared_fork_inner(
                 });
             if let Err(error) = worker_ready {
                 teardown();
-                return Err(format!("CUDA clone worker readiness failed: {error}"));
+                return Err(format!("CUDA clone worker readiness failed: {error}").into());
             }
         }
         #[cfg(not(unix))]
@@ -1782,11 +1864,11 @@ async fn boot_prepared_fork_inner(
             .map_err(|e| format!("forkpoint release failed: {e}"))?;
         }
 
-        Ok::<_, String>((manager, pid, record))
+        Ok::<_, PreparedForkBootError>((manager, pid, record))
     })
     .await
     .map_err(|e| ApiError::internal(format!("task error: {}", e)))?
-    .map_err(classify_launch_error)?;
+    .map_err(classify_prepared_fork_boot_error)?;
 
     // Register the clone so exec/run endpoints can reach it.
     state.insert_machine(&clone, machine_entry_from_record(&clone_record, manager));
@@ -2267,13 +2349,13 @@ pub(crate) async fn delete_one(
     }
 
     // Re-check for dependent clones now that the golden's process (and its fork
-    // control socket) is down. `fork_machine` locks only the CLONE name, not the
-    // golden, so a fork could have snapshotted + registered a clone between the
-    // initial check above and here. With the golden killed no NEW fork can
-    // snapshot, so this catches that race window. Abort BEFORE removing the DB
-    // record or the data dir — the clones' copy-on-write disks are backed by this
-    // golden's disks, so removing them would be silent data loss. The golden is
-    // left stopped with its disks intact; delete the clones and retry.
+    // control socket) is down. API forks share the lifecycle lock held here, but
+    // a separate CLI/embedded process has no access to that in-process lock and
+    // could have registered a clone after the initial check. Abort BEFORE
+    // removing the DB record or data dir — the clones' copy-on-write disks are
+    // backed by this golden's disks, so removing them would be silent data loss.
+    // The golden is left stopped with its disks intact; delete the clones and
+    // retry.
     {
         let db = state.db().clone();
         let golden = name.clone();
@@ -3090,6 +3172,17 @@ mod tests {
         assert!(matches!(
             classify_launch_error(e),
             ApiError::PortConflict(_)
+        ));
+    }
+
+    #[test]
+    fn prepared_fork_boot_error_preserves_clone_rejuvenation_identity() {
+        let error = PreparedForkBootError::CloneIdentityRejuvenation(
+            "clone identity rejuvenation failed: identity reset could not be confirmed".to_string(),
+        );
+        assert!(matches!(
+            classify_prepared_fork_boot_error(error),
+            ApiError::CloneIdentityRejuvenationFailed(_)
         ));
     }
 

--- a/src/api/handlers/pools.rs
+++ b/src/api/handlers/pools.rs
@@ -1061,6 +1061,9 @@ fn lease_batch_error(error: ApiError) -> (&'static str, String) {
         ApiError::NotFound(message) => ("NOT_FOUND", message),
         ApiError::Conflict(message) => ("CONFLICT", message),
         ApiError::PortConflict(message) => ("PORT_IN_USE", message),
+        ApiError::CloneIdentityRejuvenationFailed(message) => {
+            ("CLONE_IDENTITY_REJUVENATION_FAILED", message)
+        }
         ApiError::BadRequest(message) => ("BAD_REQUEST", message),
         ApiError::Timeout => ("TIMEOUT", "request timed out".into()),
         ApiError::Unavailable(message) => ("UNAVAILABLE", message),
@@ -1277,6 +1280,11 @@ mod tests {
         let cases = [
             (ApiError::BadRequest("bad".into()), "BAD_REQUEST", "bad"),
             (ApiError::Conflict("busy".into()), "CONFLICT", "busy"),
+            (
+                ApiError::CloneIdentityRejuvenationFailed("reset failed".into()),
+                "CLONE_IDENTITY_REJUVENATION_FAILED",
+                "reset failed",
+            ),
             (
                 ApiError::Unavailable("empty".into()),
                 "UNAVAILABLE",

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -27,7 +27,7 @@ pub struct ApiState {
     /// Reserved machine names (creation in progress).
     /// This prevents race conditions during machine creation.
     reserved_names: RwLock<HashSet<String>>,
-    /// Per-machine lifecycle locks serializing start/stop/delete/restart.
+    /// Per-machine lifecycle locks serializing start/stop/delete/restart/fork.
     ///
     /// On macOS, stop/delete `hdiutil`-detach a machine's case-sensitive
     /// packed-layers volume while a concurrent start acquires+mounts+launches
@@ -39,10 +39,12 @@ pub struct ApiState {
     /// for the whole operation, so mount and detach can never interleave for one
     /// machine. Lock order is lifecycle (tokio, async) → entry (parking_lot,
     /// inside `spawn_blocking`); no entry-holding path ever takes lifecycle, so
-    /// there is no inversion. On Linux the guarded detach/mount are compile-time
-    /// no-ops, making this harmless serialization. Scope: the API server only —
-    /// the embedded (`control.rs`) and CLI (`vm_common.rs`) paths are separate
-    /// processes with no shared in-process lock.
+    /// there is no inversion. Forks that need two lifecycle locks take the
+    /// golden before the clone, matching the pool controller. On Linux the
+    /// guarded detach/mount are compile-time no-ops, making this harmless
+    /// serialization. Scope: the API server only — the embedded (`control.rs`)
+    /// and CLI (`vm_common.rs`) paths are separate processes with no shared
+    /// in-process lock.
     ///
     /// Entries are created on first use and never removed: the map is bounded by
     /// the number of distinct machine names, so a retained `Arc<Mutex<()>>` per
@@ -516,7 +518,7 @@ impl ApiState {
     /// Get the per-machine lifecycle lock for `name`, creating it on first use.
     ///
     /// Callers `.lock().await` the returned mutex at the top of
-    /// start/stop/delete/restart and hold the guard for the whole operation so
+    /// start/stop/delete/restart/fork and hold the guard for the whole operation so
     /// the macOS layers-volume mount (start) and detach (stop/delete) can never
     /// interleave for one machine. See the `lifecycle_locks` field docs for the
     /// lock-ordering and scope contract.


### PR DESCRIPTION
## Problem

The serve API tears a clone down when identity rejuvenation fails, but a single fork leaves the golden paused and retains the checkpoint that produced that failure. Every later fork then restores the same checkpoint, turning a transient guest-agent failure into correlated failures until the golden is replaced externally.

## Change

- Hold the golden lifecycle lock across one serve-API fork transaction, using the same golden-to-clone lock order as fork pools.
- When identity rejuvenation fails closed on a newly captured checkpoint, restore the initially running golden with `ROLLBACK_FORK` and remove the retained checkpoint before releasing that lock.
- Refuse rollback if any live clone depends on the checkpoint. If rollback itself fails, preserve the original rejuvenation error alongside the rollback error and do not advertise the failure as safely retryable.
- Return `CLONE_IDENTITY_REJUVENATION_FAILED` so clients can apply a bounded retry without parsing server prose.
- Reject existing clone targets before taking the clone lock, preventing invalid cross-forks from deadlocking.

This keeps checkpoint recovery with the component that owns the golden process, retained-snapshot row, snapshot directory, and fork serialization. Callers no longer need to delete and recreate the golden around queued forks.

## Validation

- `cargo check --lib -p smolvm`
- `cargo test --lib -p smolvm` (566 passed)
- `cargo clippy --lib -p smolvm -- -D warnings` on stable Rust 1.97.1
