### PR TITLE
Enforce the resolved egress policy when a machine run is served from the image cache

### DIFF
--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -70,6 +70,11 @@ pub struct PackedLaunchConfig<'a> {
     /// `cuda_host` server loaded the real driver. Mirrors the non-packed
     /// launcher's `cuda_socket`.
     pub cuda_socket: Option<&'a Path>,
+    /// Hostnames the egress policy permits resolving and connecting to
+    /// (`--allow-host`), mirroring the main launcher's `egress_refresh_hosts`.
+    /// Owned because the launch runs in a forked child that outlives the
+    /// caller's borrows.
+    pub dns_filter_hosts: Option<Vec<String>>,
 }
 
 /// The `krun_add_disk2` image-format code for a disk file: `1` (qcow2) when it
@@ -105,7 +110,7 @@ pub fn launch_agent_vm_dynamic(
 ) -> Result<(), String> {
     crate::network::validate_requested_network_backend(
         &config.resources,
-        None,
+        config.dns_filter_hosts.as_deref(),
         config.port_mappings.len(),
     )
     .map_err(|e| e.to_string())?;
@@ -266,38 +271,65 @@ pub fn launch_agent_vm_dynamic(
                 free_ctx_on_err!("krun_set_port_map failed");
             }
 
-            if let Some(ref cidrs) = config.resources.allowed_cidrs {
-                if !cidrs.is_empty() {
-                    let set_egress = krun.set_egress_policy.ok_or_else(|| {
-                        "libkrun does not support egress policy (krun_set_egress_policy not found). \
-                         Update libkrun or remove --allow-cidr flags."
-                            .to_string()
-                    })?;
+            // Egress policy: static CIDRs plus DNS allow-host filtering enforced
+            // inside libkrun, mirroring the main launcher's TSI arm. When
+            // allow-hosts are set, guest UDP:53 queries are forwarded only to the
+            // trusted resolver and A/AAAA answers for allowed hosts become
+            // temporarily allowed IPs.
+            let egress_hosts = config.dns_filter_hosts.clone().unwrap_or_default();
+            let has_cidrs = config
+                .resources
+                .allowed_cidrs
+                .as_ref()
+                .is_some_and(|cidrs| !cidrs.is_empty());
+            if has_cidrs || !egress_hosts.is_empty() {
+                let set_egress = krun.set_egress_policy.ok_or_else(|| {
+                    "libkrun does not support egress policy (krun_set_egress_policy not found). \
+                     Update libkrun or remove --allow-cidr/--allow-host flags."
+                        .to_string()
+                })?;
 
-                    let mut all_cidrs = cidrs.clone();
-                    crate::data::network::ensure_dns_in_cidrs(&mut all_cidrs);
+                let mut all_cidrs = config.resources.allowed_cidrs.clone().unwrap_or_default();
+                crate::data::network::ensure_dns_in_cidrs(&mut all_cidrs);
 
-                    let cidr_cstrings: Vec<CString> = match all_cidrs
-                        .iter()
-                        .map(|c| CString::new(c.as_str()))
-                        .collect::<std::result::Result<Vec<_>, _>>()
-                    {
-                        Ok(v) => v,
-                        Err(_) => free_ctx_on_err!("allow-CIDR contains an interior NUL byte"),
-                    };
-                    let mut cidr_ptrs: Vec<*const libc::c_char> =
-                        cidr_cstrings.iter().map(|s| s.as_ptr()).collect();
-                    cidr_ptrs.push(std::ptr::null());
+                let cidr_cstrings: Vec<CString> = match all_cidrs
+                    .iter()
+                    .map(|c| CString::new(c.as_str()))
+                    .collect::<std::result::Result<Vec<_>, _>>()
+                {
+                    Ok(v) => v,
+                    Err(_) => free_ctx_on_err!("allow-CIDR contains an interior NUL byte"),
+                };
+                let mut cidr_ptrs: Vec<*const libc::c_char> =
+                    cidr_cstrings.iter().map(|s| s.as_ptr()).collect();
+                cidr_ptrs.push(std::ptr::null());
 
-                    // The dynamic path enforces CIDR-only egress; DNS allow-host
-                    // filtering (hosts + resolver args) is wired in the main
-                    // launcher path.
-                    if unsafe {
-                        (set_egress)(ctx, cidr_ptrs.as_ptr(), std::ptr::null(), std::ptr::null())
-                    } < 0
-                    {
-                        free_ctx_on_err!("krun_set_egress_policy failed");
-                    }
+                let host_cstrings: Vec<CString> = match egress_hosts
+                    .iter()
+                    .map(|h| CString::new(h.as_str()))
+                    .collect::<std::result::Result<Vec<_>, _>>()
+                {
+                    Ok(v) => v,
+                    Err(_) => free_ctx_on_err!("allow-host contains an interior NUL byte"),
+                };
+                let mut host_ptrs: Vec<*const libc::c_char> =
+                    host_cstrings.iter().map(|s| s.as_ptr()).collect();
+                host_ptrs.push(std::ptr::null());
+
+                let resolver_cstring =
+                    CString::new(crate::data::network::default_dns_addr().to_string())
+                        .expect("resolver IP has no null bytes");
+                let resolver_ptrs: Vec<*const libc::c_char> =
+                    vec![resolver_cstring.as_ptr(), std::ptr::null()];
+
+                let (host_arg, resolver_arg) = if egress_hosts.is_empty() {
+                    (std::ptr::null(), std::ptr::null())
+                } else {
+                    (host_ptrs.as_ptr(), resolver_ptrs.as_ptr())
+                };
+
+                if unsafe { (set_egress)(ctx, cidr_ptrs.as_ptr(), host_arg, resolver_arg) } < 0 {
+                    free_ctx_on_err!("krun_set_egress_policy failed");
                 }
             }
 
@@ -328,8 +360,9 @@ pub fn launch_agent_vm_dynamic(
                 .map(|(host, guest)| VirtioPortMapping::new(*host, *guest))
                 .collect();
             // Denial sink beside the vsock socket, mirroring the static launcher.
-            let mut egress = smolvm_network::EgressPolicy::from_allowed_cidrs(
+            let mut egress = smolvm_network::EgressPolicy::new(
                 config.resources.allowed_cidrs.as_deref(),
+                config.dns_filter_hosts.as_deref(),
             );
             if let Some(dir) = config.vsock_socket.parent() {
                 egress = egress.with_denial_log(dir.join(smolvm_network::EGRESS_DENIALS_LOG));

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -1029,6 +1029,9 @@ impl RunCmd {
                 debug: false,
                 cuda: self.cuda,
                 auto_graph: self.auto_graph,
+                // `--from` rejects the egress flags at parse time
+                // (`conflicts_with_all`), so there is no policy to carry.
+                egress: None,
             }
             .run();
         }
@@ -1153,6 +1156,14 @@ impl RunCmd {
                     debug: false,
                     cuda: self.cuda || params.cuda,
                     auto_graph: self.auto_graph,
+                    // A user-supplied artifact's manifest keeps deciding the
+                    // network default (no override), but any allow-list / DNS
+                    // filter from the flags or Smolfile must still be enforced.
+                    egress: Some(crate::cli::pack_run::ResolvedEgressPolicy {
+                        network_override: None,
+                        allowed_cidrs: params.allowed_cidrs.clone(),
+                        dns_filter_hosts: params.dns_filter_hosts.clone(),
+                    }),
                 }
                 .run();
             }
@@ -1254,6 +1265,16 @@ impl RunCmd {
                 debug: false,
                 cuda: self.cuda || params.cuda,
                 auto_graph: self.auto_graph,
+                // The workload's network policy, resolved above from the flags
+                // and Smolfile. The override is absolute: the baked artifact's
+                // manifest records the BAKE VM's networking (enabled, for the
+                // pull), so without it a cache hit would run the workload with
+                // unrestricted egress no matter what the caller asked for.
+                egress: Some(crate::cli::pack_run::ResolvedEgressPolicy {
+                    network_override: Some(params.net),
+                    allowed_cidrs: params.allowed_cidrs.clone(),
+                    dns_filter_hosts: params.dns_filter_hosts.clone(),
+                }),
             }
             .run();
         }

--- a/src/cli/pack_run.rs
+++ b/src/cli/pack_run.rs
@@ -273,6 +273,48 @@ pub struct PackRunCmd {
     /// Implies --cuda; arbitrary eager CUDA calls are not captured.
     #[arg(long)]
     pub auto_graph: bool,
+
+    /// Egress policy already resolved by `machine run` when it serves a run
+    /// through this command instead of the direct boot path. Not a CLI flag:
+    /// direct `pack run` invocations carry no policy and keep the
+    /// manifest-driven behavior.
+    #[clap(skip)]
+    pub egress: Option<ResolvedEgressPolicy>,
+}
+
+/// Network policy resolved from `--allow-cidr`/`--allow-host`/
+/// `--outbound-localhost-only` and the Smolfile before a run is handed to the
+/// pack-run boot path. Without this the hand-off would silently drop the
+/// policy and boot the workload with unrestricted egress.
+#[derive(Debug, Clone, Default)]
+pub struct ResolvedEgressPolicy {
+    /// Overrides the manifest-driven network default entirely when set. A baked
+    /// cache artifact's manifest records the BAKE VM's networking (enabled, to
+    /// pull the image), not the workload's requested posture, so serving from
+    /// the cache must not let it re-enable outbound access. `None` keeps the
+    /// manifest fallback — a user-supplied `.smolmachine`'s manifest is the
+    /// packaged intent.
+    pub network_override: Option<bool>,
+    /// Outbound CIDR allow-list, with `--allow-host` names already resolved.
+    pub allowed_cidrs: Option<Vec<String>>,
+    /// Hostnames the guest DNS filter permits resolving.
+    pub dns_filter_hosts: Option<Vec<String>>,
+}
+
+/// Outbound-network decision for a pack-run boot: a resolved policy's override
+/// is absolute (matching the direct `machine run` path, where ports and the
+/// artifact manifest never re-enable networking); otherwise the manifest and
+/// flags decide as before.
+fn effective_network(
+    egress: Option<&ResolvedEgressPolicy>,
+    net_flag: bool,
+    manifest_network: bool,
+    has_ports: bool,
+) -> bool {
+    match egress.and_then(|policy| policy.network_override) {
+        Some(network) => network,
+        None => net_flag || manifest_network || has_ports,
+    }
 }
 
 impl PackRunCmd {
@@ -436,7 +478,12 @@ impl PackRunCmd {
         let resources = VmResources {
             cpus: self.cpus.unwrap_or(manifest.cpus),
             memory_mib: self.mem.unwrap_or(manifest.mem),
-            network: self.net || manifest.network || !self.port.is_empty(),
+            network: effective_network(
+                self.egress.as_ref(),
+                self.net,
+                manifest.network,
+                !self.port.is_empty(),
+            ),
             network_backend: self.net_backend,
             dns: None,
             network_name: None,
@@ -446,9 +493,18 @@ impl PackRunCmd {
             overlay_gib: self.overlay,
             gpu_vram_mib: None,
             rosetta: false,
-            allowed_cidrs: None,
+            allowed_cidrs: self
+                .egress
+                .as_ref()
+                .and_then(|policy| policy.allowed_cidrs.clone()),
         };
-        validate_requested_network_backend(&resources, None, self.port.len())?;
+        validate_requested_network_backend(
+            &resources,
+            self.egress
+                .as_ref()
+                .and_then(|policy| policy.dns_filter_hosts.as_deref()),
+            self.port.len(),
+        )?;
 
         // Build packed mounts for the launcher
         let packed_mounts = mounts_to_packed(&mounts);
@@ -479,6 +535,10 @@ impl PackRunCmd {
         let child_pid = {
             let vsock_path_clone = vsock_path.clone();
             let cuda_sock_clone = cuda_sock.clone();
+            let dns_filter_hosts = self
+                .egress
+                .as_ref()
+                .and_then(|policy| policy.dns_filter_hosts.clone());
             smolvm::process::fork_session_leader(move || {
                 // Child process: load libkrun via dlopen and launch VM
                 let krun = match unsafe { KrunFunctions::load(&lib_dir) } {
@@ -505,6 +565,7 @@ impl PackRunCmd {
                     } else {
                         None
                     },
+                    dns_filter_hosts,
                 };
 
                 // Detach from parent's terminal so libkrun doesn't
@@ -554,7 +615,10 @@ impl PackRunCmd {
                 cuda: false,
                 expose_docker: false,
                 published_sockets: Vec::new(),
-                dns_filter_hosts: None,
+                dns_filter_hosts: self
+                    .egress
+                    .as_ref()
+                    .and_then(|policy| policy.dns_filter_hosts.clone()),
                 packed_layers_dir: Some(layers_dir.to_path_buf()),
                 pack_idmap_source: None,
                 extra_disks: vec![],
@@ -1357,6 +1421,7 @@ fn run_ephemeral(
                 mem: args.mem,
                 storage: args.storage,
                 overlay: args.overlay,
+                egress: None,
                 force_extract,
                 info: false,
                 debug,
@@ -1526,6 +1591,9 @@ fn run_from_cache(
             // CUDA-over-vsock for the persistent/daemon packed paths is not
             // wired yet; the `run` path starts the host server.
             cuda_socket: None,
+            // Packed binaries carry no egress flags; policy comes only from a
+            // `machine run` hand-off.
+            dns_filter_hosts: None,
         };
 
         // Detach from parent's terminal so libkrun doesn't
@@ -1953,6 +2021,9 @@ fn daemon_start(
             // CUDA-over-vsock for the persistent/daemon packed paths is not
             // wired yet; the `run` path starts the host server.
             cuda_socket: None,
+            // Packed binaries carry no egress flags; policy comes only from a
+            // `machine run` hand-off.
+            dns_filter_hosts: None,
         };
 
         // Detach from parent's terminal before launching the VM.
@@ -2155,4 +2226,49 @@ fn daemon_status(checksum: u32) -> smolvm::Result<()> {
 
     println!("Status: running (PID: {}, agent not responding)", pid);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolved_policy_decides_network_instead_of_the_baked_manifest() {
+        // The baked artifact's manifest records the bake VM's networking
+        // (enabled, for the pull); the workload asked for none. The override
+        // must win, and ports must not re-enable it either.
+        let closed = ResolvedEgressPolicy {
+            network_override: Some(false),
+            allowed_cidrs: None,
+            dns_filter_hosts: None,
+        };
+        assert!(!effective_network(Some(&closed), false, true, true));
+
+        let open = ResolvedEgressPolicy {
+            network_override: Some(true),
+            ..Default::default()
+        };
+        assert!(effective_network(Some(&open), false, false, false));
+    }
+
+    #[test]
+    fn policy_without_override_keeps_the_manifest_default() {
+        // A user-supplied `.smolmachine` carries its packaged intent: the
+        // allow-list rides along but the manifest still decides the default.
+        let policy = ResolvedEgressPolicy {
+            network_override: None,
+            allowed_cidrs: Some(vec!["140.82.112.0/20".to_string()]),
+            dns_filter_hosts: Some(vec!["github.com".to_string()]),
+        };
+        assert!(effective_network(Some(&policy), false, true, false));
+        assert!(!effective_network(Some(&policy), false, false, false));
+    }
+
+    #[test]
+    fn no_policy_preserves_the_flag_manifest_port_default() {
+        assert!(!effective_network(None, false, false, false));
+        assert!(effective_network(None, true, false, false));
+        assert!(effective_network(None, false, true, false));
+        assert!(effective_network(None, false, false, true));
+    }
 }


### PR DESCRIPTION
A run served from the bake cache (--oci-cache or init steps) hands off to the pack-run boot path, which dropped the resolved --allow-cidr/--allow-host policy and booted the workload with the bake artifact's open networking, so cache hits ran with unrestricted egress no matter what the caller asked for; the hand-off now carries the resolved policy into the pack boot on every platform's launch path, validated live on macOS with the cached-run allow-host, default-deny, explicit --net, and plain pack-run cases matching the direct path exactly.