### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,67 @@
+# Security Policy
+
+smolvm runs untrusted workloads inside per-workload microVMs, each with its own
+guest kernel. The boundary we defend is guest to host: guest code should not be
+able to affect the host beyond the resources, mounts, and network it was
+explicitly given.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a security problem.**
+
+Report privately via GitHub's
+**[Private vulnerability reporting](https://github.com/smol-machines/smolvm/security/advisories/new)**
+(repo → **Security** → **Report a vulnerability**). The report stays private
+between you and the maintainers, and we will coordinate a fix and a disclosure
+timeline with you there.
+
+Please include:
+
+- the affected component (CLI, VMM, guest agent, containerd shim, pack/image
+  handling) and the version or commit,
+- a description and, where possible, a minimal reproduction,
+- the host OS and backend (macOS Hypervisor.framework, or Linux KVM),
+- the impact you believe it has.
+
+## In scope
+
+- **Guest to host escape** — guest code reading, writing, or executing on the
+  host beyond its configured mounts, network, and devices.
+- **Boundary failures in the host-side components** — the VMM process, the boot
+  helper, the guest agent transport, or the containerd shim.
+- **Crafted input that escapes its handler** — a `.smolmachine` pack or an OCI
+  image that reaches outside its extraction root or runs code on the host.
+- **Isolation between workloads** — one VM reaching another VM's state, disks,
+  or control socket under the same user.
+- **Release integrity** — a tampered artifact that the installer's checksum
+  verification should reject and does not.
+
+## Out of scope
+
+These follow from the security model in the [README](README.md); they are
+design, not defects.
+
+- Anything reached only through a capability the user explicitly forwarded, and
+  behaving as documented: `--volume` mounts, `--ssh-agent`, `--net`, and
+  published ports all widen the workload's authority on purpose.
+- Anything that presupposes an already-compromised host, or a hostile
+  local user on the host. The invoking user account, the host OS, the
+  hypervisor backend, and libkrun are inside the trusted computing base.
+- Guest-internal behaviour with no host effect. Root in the guest is untrusted
+  by design.
+- Limitations already documented in the README security model, including
+  unsigned release archives. Improvements there are welcome as normal issues.
+- The hosted cloud service, which is operated separately from this repo.
+
+## Supported versions
+
+Only the latest published release is supported. Please reproduce against it
+before reporting.
+
+## What you can expect
+
+- We practice coordinated disclosure, and will agree a timeline with you before
+  anything is published.
+- We credit reporters in the advisory unless you ask us not to.
+- We will not pursue legal action over good-faith research that follows this
+  policy.


### PR DESCRIPTION
Someone who finds a guest-to-host escape in smolvm has no private way to tell us. Private vulnerability reporting is already switched on for this repo, but nothing in the repo says so, so the only route a reporter can see is a public issue. That publishes the bug to everyone at the moment it is reported, before there is a fix.

This adds `SECURITY.md` pointing at the private advisory form, and says what we consider a vulnerability here.

## Scope is drawn from the README, not invented

The security model section of the README already defines the boundary: guest to host, with the invoking user account, the host OS, the hypervisor backend and libkrun inside the trusted computing base. The in-scope list is that boundary (escape, host-side component failures, crafted packs and images, cross-VM reach, release integrity), and the out-of-scope list is the other side of the same sentences.

The out-of-scope half is the part that saves triage time. Forwarded capabilities behaving as documented are not vulnerabilities: `--volume`, `--ssh-agent`, `--net` and published ports all widen the workload's authority on purpose, and the README says so. Neither is anything that presupposes a hostile local user on the host, since that is outside the stated model. Without those lines every "my `--volume` mount was readable from the guest" report costs a reply.

## Consistent with the smol repo

`smol` has carried a `SECURITY.md` since it was open sourced, so this follows its structure and placement at the repo root. Two deliberate differences.

It does not commit to a response time. A policy that promises acknowledgement we might not hit is worse than one that promises nothing, and this is the line most likely to age badly. Happy to add one if you would rather match `smol` exactly.

It does not describe the hosted service. A hosted product has no "users upgrade" step, so it needs an incident and customer-notification policy rather than an advisory policy. That is a different document and is deliberately not attempted here.

## Only this repo

`smol` already has its own file. The other public repos have private vulnerability reporting switched off, so a policy pointing at that form would send reporters to a channel that does not exist yet. Worth doing per repo once the setting is on, rather than in one sweep now.

Two settings notes, since both are yours and neither is something I can check or change without admin:

- `smol/SECURITY.md` links to its private reporting form, but the setting appears to be off on that repo, so that link may not work today. Settings, then Security, then enable Private vulnerability reporting fixes it in one click.
- The same click is what the remaining public repos need before they are worth a policy file.
