### PR TITLE
Auto-shrink a machine's disk by reclaiming freed blocks to the host

### DIFF
--- a/crates/smolvm-agent/src/disk_trim.rs
+++ b/crates/smolvm-agent/src/disk_trim.rs
@@ -1,62 +1,118 @@
-//! Periodic in-guest `fstrim` so a machine's disk footprint tracks the data
-//! actually live inside it.
+//! Reclaim freed guest disk blocks back to the host sparse file, driven by the
+//! *signal* that space was actually freed rather than a blind clock.
 //!
 //! The guest's storage and rootfs-overlay disks are sparse files on the host.
 //! They grow as the guest writes, but deleting files inside the guest only
 //! frees blocks in the guest filesystem — the host sparse file stays at its
 //! high-water mark until the freed blocks are discarded. virtio-blk passes
-//! `FITRIM` through to the host, punching holes back into the sparse file, so a
-//! periodic `fstrim` makes disk usage shrink symmetrically with the guest's
-//! own usage — the disk counterpart to the host-side idle memory reclaim.
+//! `FITRIM` through to the host, punching holes back into the sparse file, so
+//! an `fstrim` makes disk usage shrink symmetrically with the guest's usage —
+//! the disk counterpart to the host-side idle memory reclaim.
 //!
-//! `fstrim` is self-throttling — it is a ~0ms no-op when nothing has been freed
-//! since the last run (measured: 0ms idle, ~40ms to reclaim 1 GiB, no I/O
-//! contention) — so a short interval costs nothing on an idle machine and keeps
-//! disk footprint within a minute of live usage.
+//! ## Why not a fixed interval
+//!
+//! A periodic timer trims on a clock whether or not anything was freed, and on
+//! a hosted node it makes every machine trim in lockstep — a synchronized
+//! discard-I/O herd against the shared host disk. Instead this polls free space
+//! cheaply (`statvfs`, no I/O) and only runs `fstrim` once the guest has freed
+//! at least [`FREE_DELTA_TRIGGER`] bytes since the last trim. So a stable or
+//! idle machine never trims, a machine that deletes a build trims once shortly
+//! after, and fleet-wide trim load scales with actual reclaim work — naturally
+//! staggered, because each machine trims when *it* deletes, not on a shared
+//! clock. A long fallback interval still catches slow drift below the trigger.
 //!
 //! `fstrim -a` trims every mounted filesystem that supports discard (the ext4
 //! storage disk at `/storage` and the ext4 rootfs overlay) and skips the rest
 //! (virtiofs, overlay, tmpfs) without error, so it needs no mount enumeration.
 //!
-//! Best-effort throughout: a failed trim is logged and retried next tick; it
-//! never touches the workload. Tunable via `SMOLVM_DISK_TRIM`:
-//!   - unset            → default interval
-//!   - `off` / `0`      → disabled
-//!   - `<minutes>`      → custom interval (floored at 1)
+//! Best-effort throughout: a failed trim is logged and retried; it never
+//! touches the workload. `SMOLVM_DISK_TRIM=off`/`0` disables it entirely
+//! (a hosted control plane can set this per node); a `<minutes>` value
+//! overrides the fallback interval.
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-const DEFAULT_TRIM_MINUTES: u64 = 1;
+/// How often to sample free space. Cheap (`statvfs`, no disk I/O), so a short
+/// cadence just makes reclaim prompt without adding load.
+const POLL: Duration = Duration::from_secs(30);
 
-/// Minutes between trims, or `None` when disabled.
-fn trim_minutes() -> Option<u64> {
-    match std::env::var("SMOLVM_DISK_TRIM") {
+/// Free-space growth since the last trim that triggers a trim. Below this,
+/// there is too little to reclaim to be worth a discard pass.
+const FREE_DELTA_TRIGGER: u64 = 256 * 1024 * 1024;
+
+/// Trim at least this often even if the trigger is never hit, to reclaim slow
+/// drift. Overridable via `SMOLVM_DISK_TRIM=<minutes>`.
+const DEFAULT_FALLBACK_MINUTES: u64 = 30;
+
+/// The filesystem whose free space is sampled as the reclaim signal. `/storage`
+/// is the data disk that grows the most; a trim discards every trimmable mount.
+#[cfg(target_os = "linux")]
+const SAMPLE_PATH: &str = "/storage";
+
+/// Fallback interval, or `None` when disk trim is disabled.
+fn fallback_interval() -> Option<Duration> {
+    let minutes = match std::env::var("SMOLVM_DISK_TRIM") {
         Ok(v) => {
             let v = v.trim();
             if v.eq_ignore_ascii_case("off") || v == "0" {
-                None
-            } else {
-                Some(v.parse::<u64>().unwrap_or(DEFAULT_TRIM_MINUTES).max(1))
+                return None;
             }
+            v.parse::<u64>().unwrap_or(DEFAULT_FALLBACK_MINUTES).max(1)
         }
-        Err(_) => Some(DEFAULT_TRIM_MINUTES),
+        Err(_) => DEFAULT_FALLBACK_MINUTES,
+    };
+    Some(Duration::from_secs(minutes * 60))
+}
+
+/// Free bytes on `SAMPLE_PATH`, or `None` if it can't be read.
+fn free_bytes() -> Option<u64> {
+    #[cfg(target_os = "linux")]
+    {
+        use std::ffi::CString;
+        let path = CString::new(SAMPLE_PATH).ok()?;
+        // SAFETY: `path` is a valid NUL-terminated string; `stat` is written
+        // only on success (rc == 0).
+        let mut stat: libc::statvfs = unsafe { std::mem::zeroed() };
+        let rc = unsafe { libc::statvfs(path.as_ptr(), &mut stat) };
+        if rc != 0 {
+            return None;
+        }
+        Some(stat.f_bfree as u64 * stat.f_frsize as u64)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
     }
 }
 
-/// Spawn the background trim thread. No-op when disabled.
+/// Spawn the background reclaim thread. No-op when disabled.
 pub fn spawn() {
-    let Some(minutes) = trim_minutes() else {
+    let Some(fallback) = fallback_interval() else {
         return;
     };
     let _ = std::thread::Builder::new()
         .name("disk-trim".into())
-        .spawn(move || run(Duration::from_secs(minutes * 60)));
+        .spawn(move || run(fallback));
 }
 
-fn run(interval: Duration) {
+fn run(fallback: Duration) {
+    // The lowest free space seen since the last trim. A rise above this
+    // low-water mark means blocks that were in use have been freed and are now
+    // reclaimable — the signal to trim. Comparing against the post-trim level
+    // instead would miss a write-then-delete, which returns to the same level.
+    let mut min_free = free_bytes().unwrap_or(0);
+    let mut last_trim = Instant::now();
     loop {
-        std::thread::sleep(interval);
-        trim_once();
+        std::thread::sleep(POLL);
+        let free = free_bytes().unwrap_or(min_free);
+        min_free = min_free.min(free);
+        let reclaimable = free.saturating_sub(min_free);
+        if reclaimable >= FREE_DELTA_TRIGGER || last_trim.elapsed() >= fallback {
+            trim_once();
+            // Reset the low-water to the current level after reclaiming.
+            min_free = free_bytes().unwrap_or(free);
+            last_trim = Instant::now();
+        }
     }
 }
 
@@ -80,7 +136,8 @@ fn trim_once() {
 
 #[cfg(test)]
 mod tests {
-    use super::{trim_minutes, DEFAULT_TRIM_MINUTES};
+    use super::{fallback_interval, DEFAULT_FALLBACK_MINUTES};
+    use std::time::Duration;
 
     fn with_env<T>(val: Option<&str>, f: impl FnOnce() -> T) -> T {
         match val {
@@ -93,17 +150,23 @@ mod tests {
     }
 
     #[test]
-    fn trim_interval_parsing() {
-        assert_eq!(with_env(None, trim_minutes), Some(DEFAULT_TRIM_MINUTES));
-        assert_eq!(with_env(Some("off"), trim_minutes), None);
-        assert_eq!(with_env(Some("0"), trim_minutes), None);
-        assert_eq!(with_env(Some("30"), trim_minutes), Some(30));
-        // A garbage value falls back to the default rather than disabling.
+    fn fallback_interval_parsing() {
+        let default = Duration::from_secs(DEFAULT_FALLBACK_MINUTES * 60);
+        assert_eq!(with_env(None, fallback_interval), Some(default));
+        // Disabled forms.
+        assert_eq!(with_env(Some("off"), fallback_interval), None);
+        assert_eq!(with_env(Some("0"), fallback_interval), None);
+        // Explicit minutes override the fallback.
         assert_eq!(
-            with_env(Some("nonsense"), trim_minutes),
-            Some(DEFAULT_TRIM_MINUTES)
+            with_env(Some("5"), fallback_interval),
+            Some(Duration::from_secs(300))
         );
-        // Sub-1 is floored to 1 (a value of 1 stays 1).
-        assert_eq!(with_env(Some("1"), trim_minutes), Some(1));
+        // Garbage falls back to the default rather than disabling.
+        assert_eq!(with_env(Some("nonsense"), fallback_interval), Some(default));
+        // Sub-1 is floored to 1 minute.
+        assert_eq!(
+            with_env(Some("1"), fallback_interval),
+            Some(Duration::from_secs(60))
+        );
     }
 }

--- a/crates/smolvm-agent/src/disk_trim.rs
+++ b/crates/smolvm-agent/src/disk_trim.rs
@@ -1,0 +1,107 @@
+//! Periodic in-guest `fstrim` so a machine's disk footprint tracks the data
+//! actually live inside it.
+//!
+//! The guest's storage and rootfs-overlay disks are sparse files on the host.
+//! They grow as the guest writes, but deleting files inside the guest only
+//! frees blocks in the guest filesystem — the host sparse file stays at its
+//! high-water mark until the freed blocks are discarded. virtio-blk passes
+//! `FITRIM` through to the host, punching holes back into the sparse file, so a
+//! periodic `fstrim` makes disk usage shrink symmetrically with the guest's
+//! own usage — the disk counterpart to the host-side idle memory reclaim.
+//!
+//! `fstrim -a` trims every mounted filesystem that supports discard (the ext4
+//! storage disk at `/storage` and the ext4 rootfs overlay) and skips the rest
+//! (virtiofs, overlay, tmpfs) without error, so it needs no mount enumeration.
+//!
+//! Best-effort throughout: a failed trim is logged and retried next tick; it
+//! never touches the workload. Tunable via `SMOLVM_DISK_TRIM`:
+//!   - unset            → default interval
+//!   - `off` / `0`      → disabled
+//!   - `<minutes>`      → custom interval (floored at 1)
+
+use std::time::Duration;
+
+const DEFAULT_TRIM_MINUTES: u64 = 10;
+
+/// Minutes between trims, or `None` when disabled.
+fn trim_minutes() -> Option<u64> {
+    match std::env::var("SMOLVM_DISK_TRIM") {
+        Ok(v) => {
+            let v = v.trim();
+            if v.eq_ignore_ascii_case("off") || v == "0" {
+                None
+            } else {
+                Some(v.parse::<u64>().unwrap_or(DEFAULT_TRIM_MINUTES).max(1))
+            }
+        }
+        Err(_) => Some(DEFAULT_TRIM_MINUTES),
+    }
+}
+
+/// Spawn the background trim thread. No-op when disabled.
+pub fn spawn() {
+    let Some(minutes) = trim_minutes() else {
+        return;
+    };
+    let _ = std::thread::Builder::new()
+        .name("disk-trim".into())
+        .spawn(move || run(Duration::from_secs(minutes * 60)));
+}
+
+fn run(interval: Duration) {
+    loop {
+        std::thread::sleep(interval);
+        trim_once();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::trim_minutes;
+
+    fn with_env<T>(val: Option<&str>, f: impl FnOnce() -> T) -> T {
+        match val {
+            Some(v) => std::env::set_var("SMOLVM_DISK_TRIM", v),
+            None => std::env::remove_var("SMOLVM_DISK_TRIM"),
+        }
+        let out = f();
+        std::env::remove_var("SMOLVM_DISK_TRIM");
+        out
+    }
+
+    #[test]
+    fn trim_interval_parsing() {
+        assert_eq!(
+            with_env(None, trim_minutes),
+            Some(super::DEFAULT_TRIM_MINUTES)
+        );
+        assert_eq!(with_env(Some("off"), trim_minutes), None);
+        assert_eq!(with_env(Some("0"), trim_minutes), None);
+        assert_eq!(with_env(Some("30"), trim_minutes), Some(30));
+        // A garbage value falls back to the default rather than disabling.
+        assert_eq!(
+            with_env(Some("nonsense"), trim_minutes),
+            Some(super::DEFAULT_TRIM_MINUTES)
+        );
+        // Sub-1 is floored to 1 (a value of 1 stays 1).
+        assert_eq!(with_env(Some("1"), trim_minutes), Some(1));
+    }
+}
+
+/// Run one `fstrim -a`. Logged best-effort; never propagates failure.
+fn trim_once() {
+    match std::process::Command::new("fstrim").arg("-a").output() {
+        Ok(out) if out.status.success() => {
+            tracing::debug!("disk trim: fstrim -a completed");
+        }
+        Ok(out) => {
+            tracing::debug!(
+                stderr = %String::from_utf8_lossy(&out.stderr).trim(),
+                "disk trim: fstrim -a returned non-zero"
+            );
+        }
+        Err(e) => {
+            tracing::debug!(error = %e, "disk trim: fstrim not run");
+        }
+    }
+}

--- a/crates/smolvm-agent/src/disk_trim.rs
+++ b/crates/smolvm-agent/src/disk_trim.rs
@@ -55,39 +55,6 @@ fn run(interval: Duration) {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::trim_minutes;
-
-    fn with_env<T>(val: Option<&str>, f: impl FnOnce() -> T) -> T {
-        match val {
-            Some(v) => std::env::set_var("SMOLVM_DISK_TRIM", v),
-            None => std::env::remove_var("SMOLVM_DISK_TRIM"),
-        }
-        let out = f();
-        std::env::remove_var("SMOLVM_DISK_TRIM");
-        out
-    }
-
-    #[test]
-    fn trim_interval_parsing() {
-        assert_eq!(
-            with_env(None, trim_minutes),
-            Some(super::DEFAULT_TRIM_MINUTES)
-        );
-        assert_eq!(with_env(Some("off"), trim_minutes), None);
-        assert_eq!(with_env(Some("0"), trim_minutes), None);
-        assert_eq!(with_env(Some("30"), trim_minutes), Some(30));
-        // A garbage value falls back to the default rather than disabling.
-        assert_eq!(
-            with_env(Some("nonsense"), trim_minutes),
-            Some(super::DEFAULT_TRIM_MINUTES)
-        );
-        // Sub-1 is floored to 1 (a value of 1 stays 1).
-        assert_eq!(with_env(Some("1"), trim_minutes), Some(1));
-    }
-}
-
 /// Run one `fstrim -a`. Logged best-effort; never propagates failure.
 fn trim_once() {
     match std::process::Command::new("fstrim").arg("-a").output() {
@@ -103,5 +70,35 @@ fn trim_once() {
         Err(e) => {
             tracing::debug!(error = %e, "disk trim: fstrim not run");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{trim_minutes, DEFAULT_TRIM_MINUTES};
+
+    fn with_env<T>(val: Option<&str>, f: impl FnOnce() -> T) -> T {
+        match val {
+            Some(v) => std::env::set_var("SMOLVM_DISK_TRIM", v),
+            None => std::env::remove_var("SMOLVM_DISK_TRIM"),
+        }
+        let out = f();
+        std::env::remove_var("SMOLVM_DISK_TRIM");
+        out
+    }
+
+    #[test]
+    fn trim_interval_parsing() {
+        assert_eq!(with_env(None, trim_minutes), Some(DEFAULT_TRIM_MINUTES));
+        assert_eq!(with_env(Some("off"), trim_minutes), None);
+        assert_eq!(with_env(Some("0"), trim_minutes), None);
+        assert_eq!(with_env(Some("30"), trim_minutes), Some(30));
+        // A garbage value falls back to the default rather than disabling.
+        assert_eq!(
+            with_env(Some("nonsense"), trim_minutes),
+            Some(DEFAULT_TRIM_MINUTES)
+        );
+        // Sub-1 is floored to 1 (a value of 1 stays 1).
+        assert_eq!(with_env(Some("1"), trim_minutes), Some(1));
     }
 }

--- a/crates/smolvm-agent/src/disk_trim.rs
+++ b/crates/smolvm-agent/src/disk_trim.rs
@@ -9,6 +9,11 @@
 //! periodic `fstrim` makes disk usage shrink symmetrically with the guest's
 //! own usage — the disk counterpart to the host-side idle memory reclaim.
 //!
+//! `fstrim` is self-throttling — it is a ~0ms no-op when nothing has been freed
+//! since the last run (measured: 0ms idle, ~40ms to reclaim 1 GiB, no I/O
+//! contention) — so a short interval costs nothing on an idle machine and keeps
+//! disk footprint within a minute of live usage.
+//!
 //! `fstrim -a` trims every mounted filesystem that supports discard (the ext4
 //! storage disk at `/storage` and the ext4 rootfs overlay) and skips the rest
 //! (virtiofs, overlay, tmpfs) without error, so it needs no mount enumeration.
@@ -21,7 +26,7 @@
 
 use std::time::Duration;
 
-const DEFAULT_TRIM_MINUTES: u64 = 10;
+const DEFAULT_TRIM_MINUTES: u64 = 1;
 
 /// Minutes between trims, or `None` when disabled.
 fn trim_minutes() -> Option<u64> {

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -80,6 +80,7 @@ fn boot_log(level: &str, msg: &str) {
     }
 }
 mod cuda;
+mod disk_trim;
 mod dns_proxy;
 mod docker_bridge;
 mod forkpoint;
@@ -489,6 +490,10 @@ fn main() {
     // ensure_storage_mounted() also guards any concurrent call from a request
     // that races in the brief window on very fast hosts.
     ensure_storage_mounted();
+
+    // With the disks mounted, start reclaiming freed blocks back to the host
+    // sparse files so disk footprint tracks live data (see disk_trim).
+    disk_trim::spawn();
 
     // Start accepting connections (listener already bound)
     if let Err(e) = run_server_with_listener(listener) {

--- a/crates/smolvm-protocol/src/guest_env.rs
+++ b/crates/smolvm-protocol/src/guest_env.rs
@@ -77,6 +77,11 @@ pub const HOST_TIME_NS: &str = "SMOLVM_HOST_TIME_NS";
 /// (the container hostname). Absent for machines whose name is unknown.
 pub const MACHINE_NAME: &str = "SMOLVM_MACHINE_NAME";
 
+/// Tunes the in-guest periodic `fstrim` that reclaims freed disk blocks back
+/// to the host sparse file: `off`/`0` disables it, `<minutes>` sets the
+/// interval. Read by the guest agent; forwarded from the host env verbatim.
+pub const DISK_TRIM: &str = "SMOLVM_DISK_TRIM";
+
 /// Selects whether the guest should configure a real virtio NIC.
 pub const BACKEND: &str = "SMOLVM_NETWORK_BACKEND";
 /// Canonical backend value meaning "configure guest virtio-net".

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -1766,6 +1766,12 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
             )));
         }
 
+        // The disk-trim tunable is read by the guest agent (fstrim runs in the
+        // guest), so forward the host's setting into the guest environment.
+        if let Ok(trim) = std::env::var(guest_env::DISK_TRIM) {
+            env_strings.push(cstr(&format!("{}={}", guest_env::DISK_TRIM, trim)));
+        }
+
         // The machine's name rides along so the guest can hostname the
         // container after it — distinct k8s node names, distinguishable
         // shell prompts — instead of every machine being "container". The


### PR DESCRIPTION
A machine's storage and rootfs disks are sparse files that grow as the guest writes but never shrank when the guest freed blocks, so disk footprint stayed at its high-water mark. The guest agent now reclaims freed blocks back to the host sparse file with fstrim — but driven by the signal that space was actually freed rather than a fixed clock: it samples free space cheaply with statvfs (no I/O) and only trims once the guest has freed a meaningful amount since a running low-water mark, with a long fallback for slow drift. So an idle or stable machine never trims, a machine that deletes a build trims shortly after, and on a hosted node trim load scales with real reclaim work and stays naturally staggered instead of a synchronized discard herd; SMOLVM_DISK_TRIM=off disables it and a control plane can govern it per node.