### PR TITLE
Remote volumes: mount S3 and any rclone remote with the volume flag

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -2336,6 +2336,10 @@ fn handle_request(
             persistent_overlay_id,
             stdin_data,
             background,
+            // Remote volumes only ride the detached workload launch
+            // (`run_container_detached`, `detached: true`); every synchronous or
+            // background Run sets this to None, so there is nothing to mount here.
+            remote_volume_mount: _,
         } => {
             if background {
                 handle_run_background(
@@ -3244,6 +3248,7 @@ fn handle_interactive_run(
         tty,
         persistent_overlay_id,
         unprivileged,
+        remote_volume_mount,
     ) = match request {
         AgentRequest::Run {
             image,
@@ -3256,6 +3261,7 @@ fn handle_interactive_run(
             tty,
             persistent_overlay_id,
             unprivileged,
+            remote_volume_mount,
             ..
         } => (
             image,
@@ -3268,6 +3274,7 @@ fn handle_interactive_run(
             tty,
             persistent_overlay_id,
             unprivileged,
+            remote_volume_mount,
         ),
         _ => {
             send_response(
@@ -3315,7 +3322,14 @@ fn handle_interactive_run(
     // Resolve the container's launch settings from the image's OCI config (with
     // request overrides). Required to call spawn_interactive_command, so the
     // interactive path can't drop the image's Env/WorkingDir/User either.
-    let launch = match ResolvedLaunch::resolve(&image, command, env, workdir, user) {
+    let launch = match ResolvedLaunch::resolve(
+        &image,
+        command,
+        env,
+        workdir,
+        user,
+        remote_volume_mount.as_deref(),
+    ) {
         Ok(l) => l,
         Err(e) => {
             maybe_cleanup(&prepared.workload_id);
@@ -3416,6 +3430,7 @@ impl ResolvedLaunch {
         env: Vec<(String, String)>,
         workdir: Option<String>,
         user: Option<String>,
+        remote_volume_mount: Option<&str>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let info = storage::query_image(image)?.ok_or_else(|| -> Box<dyn std::error::Error> {
             format!("image not found: {image}").into()
@@ -3424,18 +3439,39 @@ impl ResolvedLaunch {
             let mut resolved = info.entrypoint;
             resolved.extend(info.cmd);
             if resolved.is_empty() {
-                // The host's workload launcher matches on this exact phrase to
-                // downgrade a metadata-less image (e.g. a bare rootfs
-                // directory) to a bare-agent boot instead of failing the
-                // machine start — keep the wording stable.
-                return Err(format!(
-                    "no command given and image '{image}' defines no entrypoint or cmd"
-                )
-                .into());
+                if remote_volume_mount.is_some() {
+                    // Remote volumes mount inside the workload container, which
+                    // exec/shell join. An image with no entrypoint would
+                    // otherwise downgrade to a bare-agent boot with nowhere for
+                    // the mount to live — give it a keep-alive workload so the
+                    // FUSE mount persists and is reachable.
+                    vec!["sleep".to_string(), "infinity".to_string()]
+                } else {
+                    // The host's workload launcher matches on this exact phrase
+                    // to downgrade a metadata-less image (e.g. a bare rootfs
+                    // directory) to a bare-agent boot instead of failing the
+                    // machine start — keep the wording stable.
+                    return Err(format!(
+                        "no command given and image '{image}' defines no entrypoint or cmd"
+                    )
+                    .into());
+                }
+            } else {
+                resolved
             }
-            resolved
         } else {
             command
+        };
+        // Remote volumes: run the mount script, then exec the RESOLVED workload
+        // command in its place — so a service image's real entrypoint runs (not
+        // a mount stub) and exec/shell sessions joining this container's
+        // namespace see the mount. Wrapping *here*, after resolution, is what
+        // keeps the image's own entrypoint from being clobbered when the request
+        // gave no command (the bug when the wrap lived host-side, which only saw
+        // the empty request command).
+        let command = match remote_volume_mount {
+            Some(script) if !script.is_empty() => wrap_command_with_mount(script, command),
+            _ => command,
         };
         Ok(Self {
             command,
@@ -3444,6 +3480,21 @@ impl ResolvedLaunch {
             user: user.or(info.user),
         })
     }
+}
+
+/// Prepend a remote-volume mount script to a resolved workload command:
+/// `sh -c "<script> && exec \"$@\"" sh <cmd...>`. The mount runs in the workload
+/// container's mount namespace, then `exec` replaces the shell with the real
+/// command so PID-1 semantics and signal delivery are unchanged.
+fn wrap_command_with_mount(script: &str, command: Vec<String>) -> Vec<String> {
+    let mut argv = vec![
+        "/bin/sh".to_string(),
+        "-c".to_string(),
+        format!("{script} && exec \"$@\""),
+        "sh".to_string(),
+    ];
+    argv.extend(command);
+    argv
 }
 
 /// Layer the request's env over an image's OCI `Env` (each `"KEY=VAL"`): the
@@ -3558,36 +3609,47 @@ fn handle_run_detached(
 
     ensure_storage_mounted();
 
-    let (image, command, env, workdir, user, mounts, persistent_overlay_id, unprivileged) =
-        match request {
-            AgentRequest::Run {
-                image,
-                command,
-                env,
-                workdir,
-                user,
-                mounts,
-                persistent_overlay_id,
-                unprivileged,
-                ..
-            } => (
-                image,
-                command,
-                env,
-                workdir,
-                user,
-                mounts,
-                persistent_overlay_id,
-                unprivileged,
-            ),
-            _ => {
-                send_response(
-                    stream,
-                    &AgentResponse::error("expected Run request", error_codes::INVALID_REQUEST),
-                )?;
-                return Ok(());
-            }
-        };
+    let (
+        image,
+        command,
+        env,
+        workdir,
+        user,
+        mounts,
+        persistent_overlay_id,
+        unprivileged,
+        remote_volume_mount,
+    ) = match request {
+        AgentRequest::Run {
+            image,
+            command,
+            env,
+            workdir,
+            user,
+            mounts,
+            persistent_overlay_id,
+            unprivileged,
+            remote_volume_mount,
+            ..
+        } => (
+            image,
+            command,
+            env,
+            workdir,
+            user,
+            mounts,
+            persistent_overlay_id,
+            unprivileged,
+            remote_volume_mount,
+        ),
+        _ => {
+            send_response(
+                stream,
+                &AgentResponse::error("expected Run request", error_codes::INVALID_REQUEST),
+            )?;
+            return Ok(());
+        }
+    };
 
     // An empty command is allowed here: it means "run the image's own
     // ENTRYPOINT/CMD". We resolve it from the image config below, after the
@@ -3643,7 +3705,14 @@ fn handle_run_detached(
     // (command, Env, WorkingDir, User) with the request layered on top.
     // `write_oci_bundle` requires a `ResolvedLaunch`, so the image config can't be
     // silently dropped here or on any other launch path.
-    let launch = match ResolvedLaunch::resolve(&image, command, env, workdir, user) {
+    let launch = match ResolvedLaunch::resolve(
+        &image,
+        command,
+        env,
+        workdir,
+        user,
+        remote_volume_mount.as_deref(),
+    ) {
         Ok(l) => l,
         Err(e) => {
             send_response(
@@ -5343,6 +5412,9 @@ fn run_background_in_keepalive(
         env.to_vec(),
         workdir.map(str::to_string),
         user.map(str::to_string),
+        // Keep-alive/exec path: it JOINS the workload container that already
+        // holds the remote-volume mount, so no mount is established here.
+        None,
     )?;
 
     let (cid, rootfs) = match resolve_main_container(Some(overlay_id)) {
@@ -5482,6 +5554,9 @@ fn run_in_keepalive_container(
         env.to_vec(),
         workdir.map(str::to_string),
         user.map(str::to_string),
+        // Keep-alive/exec path: it JOINS the workload container that already
+        // holds the remote-volume mount, so no mount is established here.
+        None,
     )?;
 
     // Reuse the running keep-alive container, or establish one now so this and
@@ -6472,6 +6547,29 @@ mod bg_reap_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // The mount script runs BEFORE the resolved workload command, and that
+    // command — an image's own ENTRYPOINT+CMD when the request gives none — must
+    // survive intact. Wrapping is `sh -c '<mounts> && exec "$@"' sh <argv...>`,
+    // so `$@` is the untouched argv and `exec` hands the container PID to it.
+    #[test]
+    fn wrap_command_with_mount_preserves_the_resolved_command() {
+        let wrapped = wrap_command_with_mount(
+            "rclone mount a && rclone mount b",
+            vec![
+                "nginx".to_string(),
+                "-g".to_string(),
+                "daemon off;".to_string(),
+            ],
+        );
+        assert_eq!(&wrapped[..2], &["/bin/sh".to_string(), "-c".to_string()]);
+        assert_eq!(
+            wrapped[2],
+            "rclone mount a && rclone mount b && exec \"$@\""
+        );
+        // `sh` is $0; the workload argv follows verbatim as $1.. — not replaced.
+        assert_eq!(&wrapped[3..], &["sh", "nginx", "-g", "daemon off;"]);
+    }
 
     #[cfg(target_os = "linux")]
     fn proc_stat_fixture(pid: u32, state: char, start_time: u64) -> String {

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -2016,6 +2016,24 @@ fn handle_connection(stream: &mut impl ReadWrite) -> Result<(), Box<dyn std::err
             continue;
         }
 
+        // A Stdin/Resize frame at the TOP level is a stray leftover from a
+        // just-ended interactive session: that session's async FrameWriter can
+        // flush a still-queued EOF-stdin or resize frame during teardown, after
+        // the session's own request/response already completed. It has no
+        // interactive session to apply to (interactive Run/VmExec/PodStart
+        // consume their own stdin/resize internally), and it is fire-and-forget
+        // — the host never awaits a response to it. Drop it silently; replying
+        // with an error here instead desynchronizes the stream, because the host
+        // reads that error as the response to its NEXT request (e.g. a detached
+        // workload launch during a remote-volume start), failing it spuriously.
+        if matches!(
+            &request,
+            AgentRequest::Stdin { .. } | AgentRequest::Resize { .. }
+        ) {
+            debug!("ignoring stray stdin/resize outside an interactive session");
+            continue;
+        }
+
         // Check if this is an interactive run request
         if let AgentRequest::Run {
             interactive: true, ..

--- a/crates/smolvm-protocol/src/lib.rs
+++ b/crates/smolvm-protocol/src/lib.rs
@@ -432,6 +432,13 @@ pub enum AgentRequest {
         /// Incompatible with `interactive` and `tty`.
         #[serde(default)]
         background: bool,
+        /// Remote-volume mount script to run inside the workload container
+        /// before its (image-resolved) command. Wrapping in the agent — after
+        /// the image ENTRYPOINT/CMD is resolved — is what lets a service image's
+        /// real entrypoint still run; a host-side wrap only saw the empty
+        /// request command and would replace the workload with a mount stub.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        remote_volume_mount: Option<String>,
     },
 
     /// Send stdin data to a running interactive command.

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -434,6 +434,10 @@ pub struct RunConfig {
     /// Run as an unprivileged container (restricted caps, ro cgroup, no extra
     /// tmpfs). Default false = "VM-grade" (the microVM is the boundary).
     pub unprivileged: bool,
+    /// Remote-volume mount script to run inside the workload container before
+    /// its (image-resolved) command. Set by the workload launcher; the agent
+    /// wraps the resolved command so the image's real entrypoint still runs.
+    pub remote_volume_mount: Option<String>,
 }
 
 impl RunConfig {
@@ -455,7 +459,14 @@ impl RunConfig {
             persistent_overlay_id: None,
             stdin: None,
             unprivileged: false,
+            remote_volume_mount: None,
         }
+    }
+
+    /// Set the remote-volume mount script run inside the workload container.
+    pub fn with_remote_volume_mount(mut self, script: Option<String>) -> Self {
+        self.remote_volume_mount = script;
+        self
     }
 
     /// Set environment variables.
@@ -1553,6 +1564,7 @@ impl AgentClient {
             persistent_overlay_id: config.persistent_overlay_id,
             stdin_data: config.stdin,
             background: false,
+            remote_volume_mount: None,
         })?;
 
         expect_completed(resp, "run command")
@@ -1579,6 +1591,7 @@ impl AgentClient {
             persistent_overlay_id: config.persistent_overlay_id,
             stdin_data: None,
             background: true,
+            remote_volume_mount: None,
         })?;
 
         let (exit_code, stdout, _stderr) = expect_completed(resp, "run background")?;
@@ -1622,6 +1635,7 @@ impl AgentClient {
             persistent_overlay_id: config.persistent_overlay_id,
             stdin_data: None,
             background: false,
+            remote_volume_mount: None,
         })?;
 
         collect_exec_events(self, "run streaming", on_event)
@@ -1659,6 +1673,7 @@ impl AgentClient {
                 persistent_overlay_id: config.persistent_overlay_id,
                 stdin_data: None,
                 background: false,
+                remote_volume_mount: None,
             },
             tty,
             "run interactive",
@@ -1697,6 +1712,7 @@ impl AgentClient {
             persistent_overlay_id: config.persistent_overlay_id,
             stdin_data: None,
             background: false,
+            remote_volume_mount: config.remote_volume_mount,
         })?;
         let resp = loop {
             match self.receive()? {
@@ -1932,6 +1948,7 @@ impl AgentClient {
                 persistent_overlay_id: config.persistent_overlay_id,
                 stdin_data: None,
                 background: false,
+                remote_volume_mount: None,
             },
             input,
             on_output,

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -1233,13 +1233,17 @@ pub async fn start_machine(
         env.extend(crate::secrets::expose_into_env(
             super::record_secret_refs_env(&entry)?,
         ));
-        // Remote volumes mount inside the workload container; every launch
-        // path must wrap the command or the mounts are silently absent.
-        if !record.remote_volumes.is_empty() {
-            command =
-                crate::remote_volume::wrap_workload_command(&record.remote_volumes, &env, command)
-                    .map_err(|e| ApiError::BadRequest(e.to_string()))?;
-        }
+        // Remote volumes mount inside the workload container; build the mount
+        // script here and let the agent run it ahead of the image-resolved
+        // command, so a service image's own entrypoint is preserved.
+        let remote_volume_mount = if record.remote_volumes.is_empty() {
+            None
+        } else {
+            Some(
+                crate::remote_volume::mount_script(&record.remote_volumes, &env)
+                    .map_err(|e| ApiError::BadRequest(e.to_string()))?,
+            )
+        };
         let workdir = record.workdir.clone();
         let user = record.user.clone();
         let mounts_config = {
@@ -1308,7 +1312,8 @@ pub async fn start_machine(
                 .with_workdir(workdir)
                 .with_user(user)
                 .with_mounts(mounts_config)
-                .with_persistent_overlay(Some(overlay_id));
+                .with_persistent_overlay(Some(overlay_id))
+                .with_remote_volume_mount(remote_volume_mount);
             c.run_container_detached(config).map(|_| ())
         })
         .await;

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -405,9 +405,21 @@ pub async fn create_machine(
     let name = req.name.clone().unwrap_or_else(generate_machine_name);
     validate_vm_name(&name, "machine name").map_err(ApiError::BadRequest)?;
 
-    // Validate mount paths
-    let host_mounts: Vec<HostMount> = req
-        .mounts
+    // Split remote volumes (s3:// or rclone-remote sources) from host mounts,
+    // mirroring the CLI's -v handling, then validate the host mount paths.
+    let mut remote_volumes = Vec::new();
+    let mut host_mount_specs: Vec<crate::api::types::MountSpec> = Vec::new();
+    for m in &req.mounts {
+        if crate::remote_volume::is_remote_source(&m.source) {
+            remote_volumes.push(
+                crate::remote_volume::from_parts(&m.source, &m.target, m.readonly)
+                    .map_err(|e| ApiError::BadRequest(e.to_string()))?,
+            );
+        } else {
+            host_mount_specs.push(m.clone());
+        }
+    }
+    let host_mounts: Vec<HostMount> = host_mount_specs
         .iter()
         .map(|m| HostMount::try_from(m).map_err(|e| ApiError::BadRequest(e.to_string())))
         .collect::<Result<_, _>>()?;
@@ -415,6 +427,20 @@ pub async fn create_machine(
     // ambiguous same-target mount is a clean 400 rather than a silent shadow.
     HostMount::ensure_unique_targets(&host_mounts)
         .map_err(|e| ApiError::BadRequest(e.to_string()))?;
+    {
+        let mut seen = std::collections::HashSet::new();
+        for target in remote_volumes
+            .iter()
+            .map(|v| v.target.as_str())
+            .chain(host_mount_specs.iter().map(|m| m.target.as_str()))
+        {
+            if !seen.insert(target) {
+                return Err(ApiError::BadRequest(format!(
+                    "duplicate mount target: {target} is specified more than once"
+                )));
+            }
+        }
+    }
 
     // Validate published ports, matching the CLI (which rejects these before
     // launch): port 0 is invalid for forwarding, and each host port may be
@@ -777,7 +803,8 @@ pub async fn create_machine(
     // Complete registration: persists to DB + registers in ApiState
     let complete_result = guard.complete(MachineRegistration {
         manager,
-        mounts: req.mounts.clone(),
+        mounts: host_mount_specs,
+        remote_volumes,
         ports: req.ports.clone(),
         resources: resources.clone(),
         restart: match req.restart {
@@ -1206,6 +1233,13 @@ pub async fn start_machine(
         env.extend(crate::secrets::expose_into_env(
             super::record_secret_refs_env(&entry)?,
         ));
+        // Remote volumes mount inside the workload container; every launch
+        // path must wrap the command or the mounts are silently absent.
+        if !record.remote_volumes.is_empty() {
+            command =
+                crate::remote_volume::wrap_workload_command(&record.remote_volumes, &env, command)
+                    .map_err(|e| ApiError::BadRequest(e.to_string()))?;
+        }
         let workdir = record.workdir.clone();
         let user = record.user.clone();
         let mounts_config = {

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -1367,12 +1367,17 @@ async fn relaunch_image_workload(
         crate::api::handlers::record_secret_refs_env(entry)
             .map_err(|e| crate::Error::agent("resolve workload secrets", format!("{e:?}")))?,
     ));
-    // Remote volumes mount inside the workload container; every launch path
-    // must wrap the command or a serve-side (re)start silently loses them.
-    if !record.remote_volumes.is_empty() {
-        command =
-            crate::remote_volume::wrap_workload_command(&record.remote_volumes, &env, command)?;
-    }
+    // Remote volumes mount inside the workload container; build the mount script
+    // here and let the agent run it ahead of the image-resolved command, so a
+    // service image's own entrypoint is preserved rather than clobbered.
+    let remote_volume_mount = if record.remote_volumes.is_empty() {
+        None
+    } else {
+        Some(crate::remote_volume::mount_script(
+            &record.remote_volumes,
+            &env,
+        )?)
+    };
     let workdir = record.workdir.clone();
     let user = record.user.clone();
     let mounts_config = {
@@ -1401,7 +1406,8 @@ async fn relaunch_image_workload(
             .with_workdir(workdir)
             .with_user(user)
             .with_mounts(mounts_config)
-            .with_persistent_overlay(Some(overlay_id));
+            .with_persistent_overlay(Some(overlay_id))
+            .with_remote_volume_mount(remote_volume_mount);
         c.run_container_detached(config).map(|_| ())
     })
     .await

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -120,6 +120,8 @@ pub struct MachineRegistration {
     pub manager: AgentManager,
     /// Host mounts to configure.
     pub mounts: Vec<MountSpec>,
+    /// Remote volumes (s3:// or rclone remotes) to mount in the workload.
+    pub remote_volumes: Vec<crate::remote_volume::RemoteVolume>,
     /// Port mappings to configure.
     pub ports: Vec<PortSpec>,
     /// VM resources to configure.
@@ -886,6 +888,10 @@ impl ApiState {
         record.env = reg.env;
         record.workdir = reg.workdir;
         record.secret_refs = reg.secret_refs.clone();
+        record.remote_volumes = reg.remote_volumes.clone();
+        record
+            .validate_remote_volumes()
+            .map_err(|e| ApiError::BadRequest(e.to_string()))?;
 
         // A registry image with no network can never be pulled (the guest runs
         // the pull), so reject with a 400 here instead of persisting a machine
@@ -1361,6 +1367,12 @@ async fn relaunch_image_workload(
         crate::api::handlers::record_secret_refs_env(entry)
             .map_err(|e| crate::Error::agent("resolve workload secrets", format!("{e:?}")))?,
     ));
+    // Remote volumes mount inside the workload container; every launch path
+    // must wrap the command or a serve-side (re)start silently loses them.
+    if !record.remote_volumes.is_empty() {
+        command =
+            crate::remote_volume::wrap_workload_command(&record.remote_volumes, &env, command)?;
+    }
     let workdir = record.workdir.clone();
     let user = record.user.clone();
     let mounts_config = {

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -2894,8 +2894,14 @@ pub struct CreateCmd {
     #[arg(long, value_name = "GiB")]
     pub overlay: Option<u64>,
 
-    /// Mount host directory (can be used multiple times)
-    #[arg(short = 'v', long = "volume", value_name = "HOST:GUEST[:ro]")]
+    /// Mount host directory (can be used multiple times). Also accepts
+    /// remote sources mounted inside the guest via rclone on every start:
+    /// `s3://bucket/prefix:/data[:ro]` (credentials from --env
+    /// AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, optional AWS_ENDPOINT_URL
+    /// for R2/MinIO; anonymous without them) or any raw rclone remote,
+    /// e.g. `:sftp,host=example.com,user=me:/srv:/data`. The image must
+    /// provide `rclone` and `fusermount3`.
+    #[arg(short = 'v', long = "volume", value_name = "HOST|REMOTE:GUEST[:ro]")]
     pub volume: Vec<String>,
 
     /// Expose port from VM to host (can be used multiple times)

--- a/src/cli/pack.rs
+++ b/src/cli/pack.rs
@@ -542,6 +542,22 @@ impl PackCreateCmd {
             ));
         }
 
+        // The pack format has no notion of remote volumes; packing quietly
+        // producing an artifact without them would look like data loss at run
+        // time, so say it up front.
+        if !vm.remote_volumes.is_empty() {
+            warn!(
+                "VM '{}' has remote volumes ({}); .smolmachine artifacts do not carry them — \
+                 re-attach with -v when creating machines from this artifact",
+                vm_name,
+                vm.remote_volumes
+                    .iter()
+                    .map(|v| v.target.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
+
         println!("Packing VM '{}' snapshot...", vm_name);
 
         // 2. Create temporary staging directory

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -586,11 +586,27 @@ pub(crate) fn build_vm_record(params: &CreateVmParams) -> smolvm::Result<VmRecor
     validate_vm_name(&params.name, "machine name")
         .map_err(|reason| smolvm::Error::config("create machine", reason))?;
 
+    // Peel off remote volume specs (s3:// and raw rclone remotes) before the
+    // host-directory parse; they mount inside the guest at start instead of
+    // through virtiofs.
+    let (host_volume_specs, remote_volumes) = smolvm::remote_volume::split_specs(&params.volume)?;
+
     // Parse and validate volume mounts
-    let mounts = HostMount::parse(&params.volume)?
+    let mounts: Vec<(String, String, bool)> = HostMount::parse(&host_volume_specs)?
         .into_iter()
         .map(|m| m.to_storage_tuple())
         .collect();
+    for volume in &remote_volumes {
+        if mounts.iter().any(|(_, target, _)| target == &volume.target) {
+            return Err(smolvm::Error::config(
+                "create machine",
+                format!(
+                    "duplicate mount target: {} is specified more than once",
+                    volume.target
+                ),
+            ));
+        }
+    }
 
     // Convert port mappings to tuple format for storage
     let ports = PortMapping::to_tuples(&params.port);
@@ -653,6 +669,7 @@ pub(crate) fn build_vm_record(params: &CreateVmParams) -> smolvm::Result<VmRecor
         restart,
     );
     record.init = params.init.clone();
+    record.remote_volumes = remote_volumes;
     record.env = env;
     record.secret_refs = params.secret_refs.clone();
     record.workdir = params.workdir.clone();
@@ -691,6 +708,24 @@ pub(crate) fn build_vm_record(params: &CreateVmParams) -> smolvm::Result<VmRecor
     // A registry image with no network can never be pulled (the guest runs the
     // pull), so refuse here rather than deferring to a `start` that must fail.
     record.validate_image_fetchable()?;
+
+    // Remote volumes mount via rclone inside the workload image; an imageless
+    // machine has nowhere to run it, and they also need network to reach the
+    // remote. Refuse at create instead of failing every start.
+    if !record.remote_volumes.is_empty() {
+        if record.image.is_none() {
+            return Err(smolvm::Error::config(
+                "create machine",
+                "remote volumes (s3:// or rclone remotes) require an image machine                  whose image provides `rclone` and `fusermount3`",
+            ));
+        }
+        if !params.net && params.allowed_cidrs.is_none() && params.dns_filter_hosts.is_none() {
+            return Err(smolvm::Error::config(
+                "create machine",
+                "remote volumes need network access: add --net (or an egress policy)",
+            ));
+        }
+    }
 
     Ok(record)
 }

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -811,6 +811,21 @@ pub struct ForkVmOptions<'a> {
 pub fn fork_vm(golden: &str, clone: &str, options: ForkVmOptions<'_>) -> smolvm::Result<()> {
     let db = SmolvmDb::open()?;
 
+    // A live FUSE mount does not survive the freeze/restore: the restored
+    // clone's mount wedges its container namespace and every exec hangs.
+    // Refuse cleanly until fork remounts remote volumes on restore.
+    if let Some(record) = db.get_vm(golden)? {
+        if !record.remote_volumes.is_empty() {
+            return Err(smolvm::Error::config(
+                "machine fork",
+                format!(
+                    "machine '{golden}' has remote volumes, which cannot be forked yet: \
+                     a mounted remote filesystem does not survive the freeze/restore"
+                ),
+            ));
+        }
+    }
+
     if let Some(timeout) = options.wait_ready {
         eprintln!("Waiting for golden '{golden}' to reach its forkpoint...");
         smolvm::agent::fork::wait_for_forkpoint(golden, timeout)?;
@@ -897,6 +912,22 @@ pub fn fork_vm_batch(
     hold: bool,
 ) -> smolvm::Result<()> {
     let db = SmolvmDb::open()?;
+
+    // A live FUSE mount does not survive the freeze/restore: the restored
+    // clone's mount wedges its container namespace and every exec hangs.
+    // Refuse cleanly until fork remounts remote volumes on restore.
+    if let Some(record) = db.get_vm(golden)? {
+        if !record.remote_volumes.is_empty() {
+            return Err(smolvm::Error::config(
+                "machine fork",
+                format!(
+                    "machine '{golden}' has remote volumes, which cannot be forked yet: \
+                     a mounted remote filesystem does not survive the freeze/restore"
+                ),
+            ));
+        }
+    }
+
     if let Some(timeout) = wait_ready {
         eprintln!("Waiting for golden '{golden}' to reach its forkpoint...");
         smolvm::agent::fork::wait_for_forkpoint(golden, timeout)?;
@@ -1567,6 +1598,33 @@ fn start_vm_named_with_db(
         // entirely when restoring from a snapshot — the forked container is
         // inherited as-is.
         let _ = img;
+        // The remote-volume mounts run inside the detached workload container,
+        // whose failures are invisible to this caller. Catch the common one
+        // (image without the tools) synchronously first, with the actionable
+        // message, instead of leaving a "running" machine with a dead workload.
+        if !from_snapshot {
+            if let Some(preflight) =
+                smolvm::remote_volume::preflight_command(&record.remote_volumes)
+            {
+                if let Err(e) = run_init_commands(
+                    &mut client,
+                    &[preflight],
+                    InitRunContext {
+                        image: record.image.as_deref(),
+                        image_info: None,
+                        env: &exec_env,
+                        workdir: record.workdir.as_deref(),
+                        record_mounts: &record.mounts,
+                        overlay_id: name,
+                    },
+                ) {
+                    if let Err(stop_err) = manager.stop() {
+                        tracing::warn!(error = %stop_err, "failed to stop machine after remote volume preflight failure");
+                    }
+                    return Err(e);
+                }
+            }
+        }
         if !from_snapshot {
             if let Err(e) = smolvm::workload::launch_image_workload(
                 &mut client,
@@ -1583,6 +1641,29 @@ fn start_vm_named_with_db(
             tracing::info!(
                 "clone booted from snapshot: workload container inherited from fork, skipping relaunch"
             );
+        }
+        // Confirm every remote volume actually mounted (also covers a clone's
+        // restored mounts): a failed mount kills the detached workload
+        // silently, so without this the machine would report running while
+        // the volume is simply absent.
+        if let Some(verify) = smolvm::remote_volume::verify_command(&record.remote_volumes) {
+            if let Err(e) = run_init_commands(
+                &mut client,
+                &[verify],
+                InitRunContext {
+                    image: record.image.as_deref(),
+                    image_info: None,
+                    env: &exec_env,
+                    workdir: record.workdir.as_deref(),
+                    record_mounts: &record.mounts,
+                    overlay_id: name,
+                },
+            ) {
+                if let Err(stop_err) = manager.stop() {
+                    tracing::warn!(error = %stop_err, "failed to stop machine after remote volume verification failure");
+                }
+                return Err(e);
+            }
         }
         println!("Machine '{}' running (PID: {})", name, pid.unwrap_or(0));
     } else {

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -712,20 +712,7 @@ pub(crate) fn build_vm_record(params: &CreateVmParams) -> smolvm::Result<VmRecor
     // Remote volumes mount via rclone inside the workload image; an imageless
     // machine has nowhere to run it, and they also need network to reach the
     // remote. Refuse at create instead of failing every start.
-    if !record.remote_volumes.is_empty() {
-        if record.image.is_none() {
-            return Err(smolvm::Error::config(
-                "create machine",
-                "remote volumes (s3:// or rclone remotes) require an image machine                  whose image provides `rclone` and `fusermount3`",
-            ));
-        }
-        if !params.net && params.allowed_cidrs.is_none() && params.dns_filter_hosts.is_none() {
-            return Err(smolvm::Error::config(
-                "create machine",
-                "remote volumes need network access: add --net (or an egress policy)",
-            ));
-        }
-    }
+    record.validate_remote_volumes()?;
 
     Ok(record)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -436,6 +436,11 @@ pub struct VmRecord {
     #[serde(default)]
     pub init_completed: bool,
 
+    /// Remote volumes (object stores / network filesystems) mounted inside
+    /// the guest via rclone on every start. See `crate::remote_volume`.
+    #[serde(default)]
+    pub remote_volumes: Vec<crate::remote_volume::RemoteVolume>,
+
     /// Environment variables for init commands.
     #[serde(default)]
     pub env: Vec<(String, String)>,
@@ -666,6 +671,7 @@ impl VmRecord {
             last_exit_code: None,
             init: Vec::new(),
             init_completed: false,
+            remote_volumes: Vec::new(),
             env: Vec::new(),
             secret_refs: std::collections::BTreeMap::new(),
             workdir: None,
@@ -731,6 +737,7 @@ impl VmRecord {
             last_exit_code: None,
             init: Vec::new(),
             init_completed: false,
+            remote_volumes: Vec::new(),
             env: Vec::new(),
             secret_refs: std::collections::BTreeMap::new(),
             workdir: None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -884,6 +884,34 @@ impl VmRecord {
         ))
     }
 
+    /// Remote volumes mount via rclone inside the workload image over the
+    /// guest network; refuse configurations that can never mount at create
+    /// instead of failing every start. Shared by the CLI and API create paths.
+    pub fn validate_remote_volumes(&self) -> crate::Result<()> {
+        if self.remote_volumes.is_empty() {
+            return Ok(());
+        }
+        if self.image.is_none() {
+            return Err(crate::Error::config(
+                "create machine",
+                "remote volumes (s3:// or rclone remotes) require an image machine \
+                 whose image provides `rclone` and `fusermount3`",
+            ));
+        }
+        let plan = crate::network::plan_launch_network(
+            &self.vm_resources(),
+            self.dns_filter_hosts.as_deref(),
+            self.ports.len(),
+        );
+        if !plan.has_network() {
+            return Err(crate::Error::config(
+                "create machine",
+                "remote volumes need network access: add --net (or an egress policy)",
+            ));
+        }
+        Ok(())
+    }
+
     /// Convert record fields to VmResources.
     pub fn vm_resources(&self) -> crate::agent::VmResources {
         crate::agent::VmResources {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,7 @@ pub mod platform;
 pub mod pool;
 pub mod process;
 pub mod registry;
+pub mod remote_volume;
 pub mod secrets;
 pub mod settings;
 pub mod smolfile;

--- a/src/remote_volume.rs
+++ b/src/remote_volume.rs
@@ -1,0 +1,348 @@
+//! Remote volumes: mount object stores and network filesystems into a
+//! machine with the same `-v SOURCE:GUEST[:ro]` flag as directory mounts.
+//!
+//! Two source forms are recognized; everything else stays a host directory
+//! mount handled by `HostMount`:
+//!
+//! - `s3://bucket[/prefix]` — sugar for an S3 mount. Credentials come from
+//!   the machine's `--env` (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`,
+//!   optional `AWS_ENDPOINT_URL` for R2/MinIO); without credentials the
+//!   bucket is accessed anonymously, which covers public datasets.
+//! - `:backend,opt=value,...:path` — a raw rclone connection string passed
+//!   through verbatim, so every rclone-supported filesystem (sftp, gcs,
+//!   azure, webdav, http, b2, ...) works without smolvm knowing about it.
+//!
+//! The mounts run inside the machine's workload container, whose command is
+//! wrapped with the mount script on every start: the guest kernel ships
+//! FUSE, machine containers have the capabilities to `mknod /dev/fuse`, and
+//! `exec`/`shell` sessions join the workload container's namespaces — so the
+//! workload container is the one place a mount is visible everywhere and
+//! lives exactly as long as the workload. The image must provide `rclone`
+//! and `fusermount3` (installable via `--init` on first boot, which runs
+//! before the workload launches).
+
+use serde::{Deserialize, Serialize};
+
+/// One remote volume attached to a machine, stored on its record verbatim so
+/// `status` can echo what the user wrote and the mount command can evolve
+/// without migrating persisted state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RemoteVolume {
+    /// The user-supplied source (`s3://bucket/prefix` or `:backend,...:path`).
+    pub source: String,
+    /// Absolute guest mount point.
+    pub target: String,
+    /// Mount read-only.
+    pub read_only: bool,
+}
+
+/// Split raw `-v` specs into host-directory specs (returned untouched for
+/// `HostMount::parse`, preserving its validation and error messages) and
+/// parsed remote volumes.
+pub fn split_specs(specs: &[String]) -> crate::Result<(Vec<String>, Vec<RemoteVolume>)> {
+    let mut host = Vec::new();
+    let mut remote = Vec::new();
+    for spec in specs {
+        match parse_spec(spec)? {
+            Some(volume) => remote.push(volume),
+            None => host.push(spec.clone()),
+        }
+    }
+    // Remote targets must not collide with each other; the caller checks
+    // them against host mount targets once those are parsed.
+    let mut seen = std::collections::HashSet::new();
+    for volume in &remote {
+        if !seen.insert(&volume.target) {
+            return Err(crate::Error::config(
+                "parse remote volume",
+                format!(
+                    "duplicate mount target: {} is specified more than once",
+                    volume.target
+                ),
+            ));
+        }
+    }
+    Ok((host, remote))
+}
+
+/// Parse one `-v` spec; `Ok(None)` means "not a remote source" and the spec
+/// belongs to the host-directory path. Mirrors `HostMount`'s right-anchored
+/// parse so sources may contain colons (rclone connection strings do).
+fn parse_spec(spec: &str) -> crate::Result<Option<RemoteVolume>> {
+    let (rest, read_only) = match spec.rsplit_once(':') {
+        Some((head, "ro")) => (head, true),
+        Some((head, "rw")) => (head, false),
+        _ => (spec, false),
+    };
+    let Some((source, target)) = rest.rsplit_once(':') else {
+        return Ok(None);
+    };
+    let is_remote = source.starts_with("s3://") || source.starts_with(':');
+    if !is_remote {
+        return Ok(None);
+    }
+    if !target.starts_with('/') {
+        return Err(crate::Error::config(
+            "parse remote volume",
+            format!("remote volume guest path must be absolute: '{spec}'"),
+        ));
+    }
+    // Both values end up inside a single-quoted shell word.
+    if source.contains('\'') || target.contains('\'') {
+        return Err(crate::Error::config(
+            "parse remote volume",
+            format!("remote volume spec must not contain single quotes: '{spec}'"),
+        ));
+    }
+    if let Some(bucket) = source.strip_prefix("s3://") {
+        if bucket.trim_matches('/').is_empty() {
+            return Err(crate::Error::config(
+                "parse remote volume",
+                format!("s3 volume needs a bucket name: '{spec}'"),
+            ));
+        }
+    } else if !raw_remote_has_path_colon(source) {
+        // An rclone connection string is `:backend,opts:path` — the path colon
+        // is part of the remote. With an empty remote path the user must write
+        // it explicitly, which makes a double colon before the guest path:
+        // `:http,url="https://host"::/mnt/data`.
+        return Err(crate::Error::config(
+            "parse remote volume",
+            format!(
+                "rclone remote is missing its ':path' part in '{spec}' \
+                 (an empty remote path is written '::' before the guest path, \
+                 e.g. ':http,url=\"https://host\"::/mnt/data')"
+            ),
+        ));
+    }
+    Ok(Some(RemoteVolume {
+        source: source.to_string(),
+        target: target.to_string(),
+        read_only,
+    }))
+}
+
+/// Whether a raw rclone connection string still has its remote-terminating
+/// `:path` colon. Colons inside double-quoted option values (URLs, mostly)
+/// don't count — rclone's own parser treats those as part of the value.
+fn raw_remote_has_path_colon(source: &str) -> bool {
+    let mut in_quotes = false;
+    for ch in source.chars().skip(1) {
+        match ch {
+            '"' => in_quotes = !in_quotes,
+            ':' if !in_quotes => return true,
+            _ => {}
+        }
+    }
+    false
+}
+
+impl RemoteVolume {
+    /// The rclone remote for this volume. Raw connection strings pass
+    /// through; `s3://` sugar expands using the machine env: credentials in
+    /// the env switch rclone to env-based auth (the mount command runs with
+    /// the machine env applied), and `AWS_ENDPOINT_URL` points the S3 API at
+    /// R2/MinIO/other S3-compatible stores.
+    fn rclone_remote(&self, env: &[(String, String)]) -> crate::Result<String> {
+        let Some(bucket) = self.source.strip_prefix("s3://") else {
+            return Ok(self.source.clone());
+        };
+        let has = |key: &str| env.iter().any(|(k, _)| k == key);
+        let mut opts = String::from(":s3,provider=AWS");
+        if has("AWS_ACCESS_KEY_ID") {
+            opts.push_str(",env_auth=true");
+        }
+        if let Some((_, url)) = env.iter().find(|(k, _)| k == "AWS_ENDPOINT_URL") {
+            if url.contains('"') || url.contains('\'') {
+                return Err(crate::Error::config(
+                    "remote volume",
+                    "AWS_ENDPOINT_URL must not contain quotes",
+                ));
+            }
+            opts.push_str(&format!(",endpoint=\"{url}\""));
+        }
+        Ok(format!("{opts}:{}", bucket.trim_matches('/')))
+    }
+
+    /// The shell command that mounts this volume, run through the `--init`
+    /// exec machinery on every machine start.
+    pub fn mount_command(&self, env: &[(String, String)]) -> crate::Result<String> {
+        let remote = self.rclone_remote(env)?;
+        let mode = if self.read_only {
+            " --read-only"
+        } else {
+            " --vfs-cache-mode writes"
+        };
+        Ok(format!(
+            "command -v rclone >/dev/null 2>&1 && command -v fusermount3 >/dev/null 2>&1 || \
+             {{ echo \"remote volume {target} needs rclone and fuse3 in the image \
+             (alpine: apk add rclone fuse3 | debian/ubuntu: apt-get install -y rclone fuse3)\" >&2; exit 1; }}; \
+             [ -e /dev/fuse ] || mknod /dev/fuse c 10 229; \
+             mkdir -p '{target}' && rclone mount '{remote}' '{target}' --daemon{mode}",
+            target = self.target,
+        ))
+    }
+}
+
+/// Mount commands for every remote volume on a record, in declaration order.
+pub fn mount_commands(
+    volumes: &[RemoteVolume],
+    env: &[(String, String)],
+) -> crate::Result<Vec<String>> {
+    volumes.iter().map(|v| v.mount_command(env)).collect()
+}
+
+/// Wrap a machine's workload command so its container mounts the remote
+/// volumes before the workload runs.
+///
+/// A FUSE mount lives in the mount namespace of the container that created
+/// it, and `exec`/`shell` sessions join the workload container's namespaces —
+/// so the workload container is the one place a mount is visible everywhere
+/// and lives exactly as long as the machine's workload. A machine with no
+/// workload of its own gets a minimal holder (`sleep infinity`) so a live
+/// container exists for exec sessions to join. Machines whose image CMD exits
+/// immediately (an interactive shell, say) should be created with a
+/// long-lived command such as `-- sleep infinity`.
+pub fn wrap_workload_command(
+    volumes: &[RemoteVolume],
+    env: &[(String, String)],
+    command: Vec<String>,
+) -> crate::Result<Vec<String>> {
+    let script = mount_commands(volumes, env)?.join(" && ");
+    Ok(if command.is_empty() {
+        vec![
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            format!("{script} && exec sleep infinity"),
+        ]
+    } else {
+        let mut argv = vec![
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            format!("{script} && exec \"$@\""),
+            "sh".to_string(),
+        ];
+        argv.extend(command);
+        argv
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn split(specs: &[&str]) -> (Vec<String>, Vec<RemoteVolume>) {
+        let specs: Vec<String> = specs.iter().map(|s| s.to_string()).collect();
+        split_specs(&specs).unwrap()
+    }
+
+    #[test]
+    fn host_specs_pass_through_untouched() {
+        // Plain dirs, relative dirs, and Windows drive-letter paths all stay
+        // on the HostMount path exactly as written.
+        let (host, remote) = split(&["/data:/data:ro", "C:\\data:/data", "./x:/y"]);
+        assert_eq!(host.len(), 3);
+        assert!(remote.is_empty());
+    }
+
+    #[test]
+    fn s3_sugar_parses_with_mode() {
+        let (host, remote) = split(&["s3://my-bucket/prefix:/mnt/data:ro"]);
+        assert!(host.is_empty());
+        assert_eq!(
+            remote,
+            vec![RemoteVolume {
+                source: "s3://my-bucket/prefix".into(),
+                target: "/mnt/data".into(),
+                read_only: true,
+            }]
+        );
+    }
+
+    #[test]
+    fn raw_rclone_strings_keep_their_internal_colons() {
+        // The connection string itself contains ':' and ','; the right-anchored
+        // parse peels the guest path off the end.
+        let (_, remote) = split(&[":sftp,host=example.com,user=me:/srv/files:/mnt/sftp"]);
+        assert_eq!(
+            remote[0].source,
+            ":sftp,host=example.com,user=me:/srv/files"
+        );
+        assert_eq!(remote[0].target, "/mnt/sftp");
+        assert!(!remote[0].read_only);
+    }
+
+    #[test]
+    fn s3_translation_is_anonymous_without_credentials() {
+        let v = &split(&["s3://bucket/p:/d"]).1[0];
+        assert_eq!(v.rclone_remote(&[]).unwrap(), ":s3,provider=AWS:bucket/p");
+    }
+
+    #[test]
+    fn s3_translation_uses_env_auth_and_endpoint_when_present() {
+        let v = &split(&["s3://bucket:/d"]).1[0];
+        let env = vec![
+            ("AWS_ACCESS_KEY_ID".to_string(), "k".to_string()),
+            (
+                "AWS_ENDPOINT_URL".to_string(),
+                "https://acc.r2.cloudflarestorage.com".to_string(),
+            ),
+        ];
+        assert_eq!(
+            v.rclone_remote(&env).unwrap(),
+            ":s3,provider=AWS,env_auth=true,endpoint=\"https://acc.r2.cloudflarestorage.com\":bucket"
+        );
+    }
+
+    #[test]
+    fn rejects_relative_guest_path_and_quotes_and_empty_bucket() {
+        assert!(split_specs(&["s3://b:data".to_string()]).is_err());
+        assert!(split_specs(&["s3://b:/it's:ro".to_string()]).is_err());
+        assert!(split_specs(&["s3://:/d".to_string()]).is_err());
+        assert!(split_specs(&["s3://b:/d".to_string(), "s3://c:/d".to_string()]).is_err());
+    }
+
+    #[test]
+    fn raw_remote_must_keep_its_path_colon() {
+        // Missing ':path' (the trailing colon was eaten as the guest separator)
+        // is rejected with the '::' hint...
+        let err = split_specs(&[":http,url=\"https://host\":/mnt/d".to_string()]).unwrap_err();
+        assert!(err.to_string().contains("::"));
+        // ...and the double-colon empty-path form parses with the colon intact.
+        let (_, remote) = split(&[":http,url=\"https://host\"::/mnt/d:ro"]);
+        assert_eq!(remote[0].source, ":http,url=\"https://host\":");
+        assert_eq!(remote[0].target, "/mnt/d");
+    }
+
+    #[test]
+    fn wrapping_preserves_the_workload_argv_and_holds_commandless_machines() {
+        let vols = split(&["s3://bucket:/mnt/d:ro"]).1;
+        let wrapped = wrap_workload_command(
+            &vols,
+            &[],
+            vec!["nginx".into(), "-g".into(), "daemon off;".into()],
+        )
+        .unwrap();
+        assert_eq!(&wrapped[..2], &["/bin/sh".to_string(), "-c".to_string()]);
+        assert!(wrapped[2].ends_with("&& exec \"$@\""));
+        assert_eq!(&wrapped[3..], &["sh", "nginx", "-g", "daemon off;"]);
+
+        let holder = wrap_workload_command(&vols, &[], vec![]).unwrap();
+        assert!(holder[2].ends_with("&& exec sleep infinity"));
+    }
+
+    #[test]
+    fn mount_command_quotes_and_picks_mode() {
+        let v = &split(&["s3://bucket:/mnt/d:ro"]).1[0];
+        let cmd = v.mount_command(&[]).unwrap();
+        assert!(
+            cmd.contains("rclone mount ':s3,provider=AWS:bucket' '/mnt/d' --daemon --read-only")
+        );
+        assert!(cmd.contains("mknod /dev/fuse"));
+        let rw = &split(&["s3://bucket:/mnt/d"]).1[0];
+        assert!(rw
+            .mount_command(&[])
+            .unwrap()
+            .contains("--daemon --vfs-cache-mode writes"));
+    }
+}

--- a/src/remote_volume.rs
+++ b/src/remote_volume.rs
@@ -128,6 +128,33 @@ fn parse_spec(spec: &str) -> crate::Result<Option<RemoteVolume>> {
     }))
 }
 
+/// Whether a structured mount source (the API's `MountSpec.source`) denotes a
+/// remote volume rather than a host directory.
+pub fn is_remote_source(source: &str) -> bool {
+    source.starts_with("s3://") || source.starts_with(':')
+}
+
+/// Build a remote volume from already-split parts (the API's structured mount
+/// spec), reusing the colon-spec parser so both entry points validate
+/// identically.
+pub fn from_parts(source: &str, target: &str, read_only: bool) -> crate::Result<RemoteVolume> {
+    // The parser is right-anchored, so a colon in the target would mis-split
+    // the reassembled spec; targets never legitimately contain one.
+    if target.contains(':') {
+        return Err(crate::Error::config(
+            "parse remote volume",
+            format!("remote volume guest path must not contain ':': '{target}'"),
+        ));
+    }
+    let spec = format!("{source}:{target}{}", if read_only { ":ro" } else { "" });
+    parse_spec(&spec)?.ok_or_else(|| {
+        crate::Error::config(
+            "parse remote volume",
+            format!("not a remote volume source: '{source}'"),
+        )
+    })
+}
+
 /// Whether a raw rclone connection string still has its remote-terminating
 /// `:path` colon. Colons inside double-quoted option values (URLs, mostly)
 /// don't count — rclone's own parser treats those as part of the value.
@@ -395,6 +422,23 @@ mod tests {
 
         let holder = wrap_workload_command(&vols, &[], vec![]).unwrap();
         assert!(holder[2].ends_with("&& exec sleep infinity"));
+    }
+
+    #[test]
+    fn from_parts_matches_colon_parser() {
+        let structured = from_parts("s3://bucket/pfx", "/mnt/d", true).unwrap();
+        let parsed = &split(&["s3://bucket/pfx:/mnt/d:ro"]).1[0];
+        assert_eq!(&structured, parsed);
+        // Same validation as the colon parser: relative target, missing
+        // rclone path colon, empty bucket.
+        assert!(from_parts("s3://b", "relative", false).is_err());
+        assert!(from_parts(":http,url=\"https://h\"", "/mnt/x", false).is_err());
+        assert!(from_parts("s3://", "/mnt/x", false).is_err());
+        // Colon in a structured target would mis-split the reassembled spec.
+        assert!(from_parts("s3://b", "/mnt/a:ro", false).is_err());
+        assert!(!is_remote_source("/host/dir"));
+        assert!(is_remote_source("s3://b"));
+        assert!(is_remote_source(":http,url=\"https://h\":"));
     }
 
     #[test]

--- a/src/remote_volume.rs
+++ b/src/remote_volume.rs
@@ -286,28 +286,13 @@ pub fn verify_command(volumes: &[RemoteVolume]) -> Option<String> {
 /// container exists for exec sessions to join. Machines whose image CMD exits
 /// immediately (an interactive shell, say) should be created with a
 /// long-lived command such as `-- sleep infinity`.
-pub fn wrap_workload_command(
-    volumes: &[RemoteVolume],
-    env: &[(String, String)],
-    command: Vec<String>,
-) -> crate::Result<Vec<String>> {
-    let script = mount_commands(volumes, env)?.join(" && ");
-    Ok(if command.is_empty() {
-        vec![
-            "/bin/sh".to_string(),
-            "-c".to_string(),
-            format!("{script} && exec sleep infinity"),
-        ]
-    } else {
-        let mut argv = vec![
-            "/bin/sh".to_string(),
-            "-c".to_string(),
-            format!("{script} && exec \"$@\""),
-            "sh".to_string(),
-        ];
-        argv.extend(command);
-        argv
-    })
+/// Build the remote-volume mount script — the `&&`-joined mount commands — that
+/// the agent runs inside the workload container, ahead of the image-resolved
+/// workload command. The agent (not the host) does the wrapping, so a service
+/// image's own ENTRYPOINT still runs rather than being replaced by a mount stub,
+/// and an image with no command falls back to a keep-alive holder there.
+pub fn mount_script(volumes: &[RemoteVolume], env: &[(String, String)]) -> crate::Result<String> {
+    Ok(mount_commands(volumes, env)?.join(" && "))
 }
 
 #[cfg(test)]
@@ -408,20 +393,23 @@ mod tests {
     }
 
     #[test]
-    fn wrapping_preserves_the_workload_argv_and_holds_commandless_machines() {
+    fn mount_script_is_the_joined_mount_commands_not_a_wrapper() {
+        // The host builds only the mount SCRIPT; the agent wraps it ahead of the
+        // image-resolved command (so a service image's entrypoint is preserved).
         let vols = split(&["s3://bucket:/mnt/d:ro"]).1;
-        let wrapped = wrap_workload_command(
-            &vols,
-            &[],
-            vec!["nginx".into(), "-g".into(), "daemon off;".into()],
-        )
-        .unwrap();
-        assert_eq!(&wrapped[..2], &["/bin/sh".to_string(), "-c".to_string()]);
-        assert!(wrapped[2].ends_with("&& exec \"$@\""));
-        assert_eq!(&wrapped[3..], &["sh", "nginx", "-g", "daemon off;"]);
-
-        let holder = wrap_workload_command(&vols, &[], vec![]).unwrap();
-        assert!(holder[2].ends_with("&& exec sleep infinity"));
+        let script = mount_script(&vols, &[]).unwrap();
+        assert!(
+            script.contains("rclone"),
+            "script mounts via rclone: {script}"
+        );
+        assert!(
+            script.contains("/mnt/d"),
+            "script targets the guest path: {script}"
+        );
+        assert!(
+            !script.contains("exec \"$@\"") && !script.contains("sleep infinity"),
+            "wrapping is the agent's job now, not the host's: {script}"
+        );
     }
 
     #[test]

--- a/src/remote_volume.rs
+++ b/src/remote_volume.rs
@@ -160,6 +160,13 @@ impl RemoteVolume {
                 ));
             }
             opts.push_str(&format!(",endpoint=\"{url}\""));
+            // Streaming single-part uploads to a plain-http endpoint fail in
+            // rclone's aws-sdk-v2 backend (a signed payload needs a seekable
+            // body; https avoids it via UNSIGNED-PAYLOAD). Local MinIO-style
+            // endpoints are exactly the http case, so force multipart there.
+            if url.starts_with("http://") {
+                opts.push_str(",upload_cutoff=0");
+            }
         }
         Ok(format!("{opts}:{}", bucket.trim_matches('/')))
     }
@@ -291,6 +298,16 @@ mod tests {
         assert_eq!(
             v.rclone_remote(&env).unwrap(),
             ":s3,provider=AWS,env_auth=true,endpoint=\"https://acc.r2.cloudflarestorage.com\":bucket"
+        );
+        // http endpoints additionally force multipart uploads — streaming
+        // single-part PUTs to plain http fail in rclone's aws-sdk-v2 backend.
+        let http_env = vec![(
+            "AWS_ENDPOINT_URL".to_string(),
+            "http://100.96.0.1:9000".to_string(),
+        )];
+        assert_eq!(
+            v.rclone_remote(&http_env).unwrap(),
+            ":s3,provider=AWS,endpoint=\"http://100.96.0.1:9000\",upload_cutoff=0:bucket"
         );
     }
 

--- a/src/remote_volume.rs
+++ b/src/remote_volume.rs
@@ -87,6 +87,12 @@ fn parse_spec(spec: &str) -> crate::Result<Option<RemoteVolume>> {
             format!("remote volume guest path must be absolute: '{spec}'"),
         ));
     }
+    if target.contains(' ') {
+        return Err(crate::Error::config(
+            "parse remote volume",
+            format!("remote volume guest path must not contain spaces: '{spec}'"),
+        ));
+    }
     // Both values end up inside a single-quoted shell word.
     if source.contains('\'') || target.contains('\'') {
         return Err(crate::Error::config(
@@ -197,6 +203,49 @@ pub fn mount_commands(
     env: &[(String, String)],
 ) -> crate::Result<Vec<String>> {
     volumes.iter().map(|v| v.mount_command(env)).collect()
+}
+
+/// A synchronous pre-launch check that the image can mount remote volumes at
+/// all. The mount itself runs inside the detached workload container, whose
+/// failures are not surfaced to the caller — so the most common failure
+/// (image without the tools) is caught here first, where it can fail the
+/// start with an actionable message.
+pub fn preflight_command(volumes: &[RemoteVolume]) -> Option<String> {
+    if volumes.is_empty() {
+        return None;
+    }
+    Some(
+        "command -v rclone >/dev/null 2>&1 && command -v fusermount3 >/dev/null 2>&1 || \
+         { echo \"remote volumes need rclone and fuse3 in the image \
+         (alpine: apk add rclone fuse3 | debian/ubuntu: apt-get install -y rclone fuse3; \
+         or install them with --init, which runs before the mounts)\" >&2; exit 1; }"
+            .to_string(),
+    )
+}
+
+/// A post-launch check that every remote volume actually mounted. Joins the
+/// workload container (like any exec) and polls /proc/mounts: if the mount
+/// script failed, the workload container is dead and the fresh exec container
+/// sees no mounts either way — so this fails the start instead of leaving a
+/// silently broken machine.
+pub fn verify_command(volumes: &[RemoteVolume]) -> Option<String> {
+    if volumes.is_empty() {
+        return None;
+    }
+    let checks: Vec<String> = volumes
+        .iter()
+        .map(|v| {
+            format!(
+                "awk -v m='{}' '$2==m' /proc/mounts | grep -q rclone",
+                v.target
+            )
+        })
+        .collect();
+    let all = checks.join(" && ");
+    Some(format!(
+        "t=0; while [ $t -lt 30 ]; do if {all}; then exit 0; fi; t=$((t+1)); sleep 0.5; done; \
+         echo \"remote volume(s) failed to mount — check the machine's agent-console.log for the rclone error\" >&2; exit 1"
+    ))
 }
 
 /// Wrap a machine's workload command so its container mounts the remote

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -61,6 +61,16 @@ pub fn launch_image_workload(
     };
     let mut command = record.entrypoint.clone();
     command.extend(record.cmd.clone());
+    // Remote volumes mount inside the workload container (the one namespace
+    // exec/shell sessions join), so the workload command is wrapped with the
+    // mount script; see `crate::remote_volume::wrap_workload_command`.
+    if !record.remote_volumes.is_empty() {
+        command = crate::remote_volume::wrap_workload_command(
+            &record.remote_volumes,
+            &exec_env,
+            command,
+        )?;
+    }
     match client.run_container_detached(
         RunConfig::new(image, command)
             .with_env(exec_env)

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -57,20 +57,33 @@ pub fn launch_image_workload(
     exec_env: Vec<(String, String)>,
 ) -> crate::Result<bool> {
     let Some(ref image) = record.image else {
+        // Remote volumes mount inside a workload container, which a machine with
+        // no image never launches — honoring the volume is impossible. Fail
+        // loudly instead of silently dropping it.
+        if !record.remote_volumes.is_empty() {
+            return Err(crate::Error::agent(
+                "launch workload",
+                "remote volumes require an image-backed machine — there is no \
+                 workload container to mount into",
+            ));
+        }
         return Ok(false);
     };
     let mut command = record.entrypoint.clone();
     command.extend(record.cmd.clone());
     // Remote volumes mount inside the workload container (the one namespace
-    // exec/shell sessions join), so the workload command is wrapped with the
-    // mount script; see `crate::remote_volume::wrap_workload_command`.
-    if !record.remote_volumes.is_empty() {
-        command = crate::remote_volume::wrap_workload_command(
+    // exec/shell sessions join). Build the mount SCRIPT here but let the AGENT
+    // run it ahead of the image-resolved command — wrapping host-side would only
+    // see the empty request command and replace a service image's own entrypoint
+    // with a mount stub. See `crate::remote_volume::mount_script`.
+    let remote_volume_mount = if record.remote_volumes.is_empty() {
+        None
+    } else {
+        Some(crate::remote_volume::mount_script(
             &record.remote_volumes,
             &exec_env,
-            command,
-        )?;
-    }
+        )?)
+    };
     match client.run_container_detached(
         RunConfig::new(image, command)
             .with_env(exec_env)
@@ -80,7 +93,8 @@ pub fn launch_image_workload(
             .with_persistent_overlay(Some(persistent_overlay_owner(
                 machine_name,
                 record.golden.as_deref(),
-            ))),
+            )))
+            .with_remote_volume_mount(remote_volume_mount),
     ) {
         Ok(_) => Ok(true),
         Err(e) if is_missing_launch_metadata(&e.to_string()) => {

--- a/tests/test_remote_volumes.sh
+++ b/tests/test_remote_volumes.sh
@@ -16,7 +16,7 @@ check() { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (want '$3' got '$2')"; 
 
 CREDS="--env AWS_ACCESS_KEY_ID=smoltest --env AWS_SECRET_ACCESS_KEY=smoltest123 --env AWS_ENDPOINT_URL=http://100.96.0.1:9000"
 RCLONE_REMOTE=':s3,provider=Minio,access_key_id=smoltest,secret_access_key=smoltest123,endpoint="http://100.96.0.1:9000"'
-NAMES="rv-minio rv-ver rv-rw rv-ro rv-notools rv-badremote"
+NAMES="rv-minio rv-ver rv-rw rv-ro rv-notools rv-badremote rv-sf rv-api"
 cleanup() { for n in $NAMES; do $S machine delete --name "$n" --force >/dev/null 2>&1; done; }
 cleanup
 
@@ -81,6 +81,69 @@ echo "$OUT" | grep -qi "read-only" && ok "ro mount rejects writes" || bad "ro mo
 # ---- 8. fork of a remote-volume golden is refused cleanly -----------------
 OUT=$($S machine fork --golden rv-ro --name rv-clone 2>&1)
 echo "$OUT" | grep -q "cannot be forked yet" && ok "fork refused for remote-volume golden" || bad "fork refused for remote-volume golden"
+
+# ---- 9. Smolfile surface: volumes = ["s3://..."] flows through create -----
+TMPD=$(mktemp -d)
+cat > "$TMPD/Smolfile" <<'SMOLEOF'
+image = "alpine:latest"
+net = true
+cmd = ["sleep", "infinity"]
+env = [
+  "AWS_ACCESS_KEY_ID=smoltest",
+  "AWS_SECRET_ACCESS_KEY=smoltest123",
+  "AWS_ENDPOINT_URL=http://100.96.0.1:9000",
+]
+volumes = ["s3://rv-bucket:/mnt/sf"]
+init = ["apk add -q rclone fuse3"]
+SMOLEOF
+$S machine create --name rv-sf --smolfile "$TMPD/Smolfile" --net-backend virtio-net >/dev/null 2>&1 \
+  && $S machine start --name rv-sf >/dev/null 2>&1 \
+  && ok "smolfile machine with remote volume starts" || bad "smolfile machine with remote volume starts"
+$S machine exec --name rv-sf -- sh -c 'echo sf-1 > /mnt/sf/sf.txt && sync && sleep 5' >/dev/null 2>&1
+check "smolfile write visible out-of-band" "$(oob sf.txt)" "sf-1"
+rm -rf "$TMPD"
+
+# ---- 10. serve API surface: structured MountSpec with a remote source ------
+# Needs its own serve (the guest-rollout ingress port is exclusive) with the
+# egress floor lowered so the guest may dial the host-local MinIO; skipped if
+# a serve is already running.
+if pgrep -f "smolvm.* serve start" >/dev/null 2>&1; then
+  echo "SKIP: serve API cases (a serve is already running)"
+else
+  RVSOCK=$(mktemp -u /tmp/rv-serve.XXXXXX.sock)
+  SMOLVM_EGRESS_FLOOR=metadata "$S" serve start --listen "unix://$RVSOCK" >/dev/null 2>&1 &
+  SERVE_PID=$!
+  i=0; until [ -S "$RVSOCK" ]; do i=$((i+1)); [ $i -gt 20 ] && break; sleep 1; done
+  api() { curl -s -m 300 --unix-socket "$RVSOCK" "$@"; }
+  CODE=$(api -o /dev/null -w '%{http_code}' -X POST http://localhost/api/v1/machines \
+    -H 'Content-Type: application/json' -d '{
+    "name": "rv-api", "image": "rclone/rclone",
+    "network": true, "network_backend": "virtio-net",
+    "entrypoint": ["sleep"], "cmd": ["infinity"],
+    "env": [
+      {"name": "AWS_ACCESS_KEY_ID", "value": "smoltest"},
+      {"name": "AWS_SECRET_ACCESS_KEY", "value": "smoltest123"},
+      {"name": "AWS_ENDPOINT_URL", "value": "http://100.96.0.1:9000"}
+    ],
+    "mounts": [{"source": "s3://rv-bucket", "target": "/mnt/api"}]}')
+  check "api create accepts remote mount" "$CODE" "200"
+  CODE=$(api -o /dev/null -w '%{http_code}' -X POST http://localhost/api/v1/machines/rv-api/start)
+  check "api start mounts the volume" "$CODE" "200"
+  sleep 10
+  api -X POST http://localhost/api/v1/machines/rv-api/exec -H 'Content-Type: application/json' \
+    -d '{"command":["sh","-c","echo api-1 > /mnt/api/api.txt && sync && sleep 6"]}' >/dev/null 2>&1
+  check "api-machine write visible out-of-band" "$(oob api.txt)" "api-1"
+  CODE=$(api -o "$TMPD.badjson" -w '%{http_code}' -X POST http://localhost/api/v1/machines \
+    -H 'Content-Type: application/json' -d '{
+    "name": "rv-api-bad", "image": "alpine:latest", "network": true,
+    "mounts": [{"source": ":http,url=\"https://h\"", "target": "/mnt/x"}]}')
+  check "api rejects malformed rclone remote (400)" "$CODE" "400"
+  grep -q "::" "$TMPD.badjson" 2>/dev/null && ok "api 400 carries the :: hint" || bad "api 400 carries the :: hint"
+  rm -f "$TMPD.badjson"
+  api -X DELETE "http://localhost/api/v1/machines/rv-api?force=true" >/dev/null 2>&1
+  kill "$SERVE_PID" 2>/dev/null
+  rm -f "$RVSOCK"
+fi
 
 cleanup
 echo ""

--- a/tests/test_remote_volumes.sh
+++ b/tests/test_remote_volumes.sh
@@ -31,7 +31,18 @@ done
 $S machine create --name rv-ver --image alpine:latest --net --net-backend virtio-net >/dev/null 2>&1
 $S machine start --name rv-ver >/dev/null 2>&1
 $S machine exec --name rv-ver -- sh -c "apk add -q rclone >/dev/null 2>&1; rclone mkdir '$RCLONE_REMOTE:rv-bucket' 2>/dev/null" >/dev/null 2>&1
-oob() { $S machine exec --name rv-ver -- sh -c "rclone cat '$RCLONE_REMOTE:rv-bucket/$1' 2>/dev/null"; }
+# Read an object back OUT-OF-BAND, polling up to ~20s: rclone's vfs cache
+# uploads writes asynchronously, so a fixed post-write sleep races the flush
+# under load. Poll until the object lands (or give up and return what we have).
+oob() {
+  _v=""
+  i=0; while [ $i -lt 20 ]; do
+    _v=$($S machine exec --name rv-ver -- sh -c "rclone cat '$RCLONE_REMOTE:rv-bucket/$1' 2>/dev/null")
+    [ -n "$_v" ] && break
+    i=$((i+1)); sleep 1
+  done
+  echo "$_v"
+}
 
 # ---- 1. parse rejections happen at create, with hints ---------------------
 OUT=$($S machine create --name rv-x --image alpine:latest --net -v "s3://b:relative" -- sleep infinity 2>&1)
@@ -153,7 +164,9 @@ fi
 $S machine create --name rv-svc --image nginx:alpine --net --net-backend virtio-net $CREDS \
   --init "apk add -q rclone fuse3" -v "s3://rv-bucket:/mnt/svc" >/dev/null 2>&1
 $S machine start --name rv-svc >/dev/null 2>&1
-GOT=$($S machine exec --name rv-svc -- sh -c 'pgrep -x nginx >/dev/null 2>&1 && echo up' 2>/dev/null)
+# The wrap execs into the image entrypoint, so nginx becomes PID 1 — check
+# /proc/1/comm rather than pgrep (absent/limited in nginx:alpine's busybox).
+GOT=$($S machine exec --name rv-svc -- sh -c '[ "$(cat /proc/1/comm)" = nginx ] && echo up' 2>/dev/null)
 check "service entrypoint runs under a remote volume" "$GOT" "up"
 $S machine exec --name rv-svc -- sh -c 'echo svc-1 > /mnt/svc/svc.txt && sync && sleep 5' >/dev/null 2>&1
 check "service-image mount write visible out-of-band" "$(oob svc.txt)" "svc-1"

--- a/tests/test_remote_volumes.sh
+++ b/tests/test_remote_volumes.sh
@@ -16,7 +16,7 @@ check() { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (want '$3' got '$2')"; 
 
 CREDS="--env AWS_ACCESS_KEY_ID=smoltest --env AWS_SECRET_ACCESS_KEY=smoltest123 --env AWS_ENDPOINT_URL=http://100.96.0.1:9000"
 RCLONE_REMOTE=':s3,provider=Minio,access_key_id=smoltest,secret_access_key=smoltest123,endpoint="http://100.96.0.1:9000"'
-NAMES="rv-minio rv-ver rv-rw rv-ro rv-notools rv-badremote rv-sf rv-api"
+NAMES="rv-minio rv-ver rv-rw rv-ro rv-notools rv-badremote rv-sf rv-api rv-svc"
 cleanup() { for n in $NAMES; do $S machine delete --name "$n" --force >/dev/null 2>&1; done; }
 cleanup
 
@@ -144,6 +144,19 @@ else
   kill "$SERVE_PID" 2>/dev/null
   rm -f "$RVSOCK"
 fi
+
+# ---- 11. service image keeps its own entrypoint AND still mounts -----------
+# No `--` command: the image's ENTRYPOINT/CMD is resolved inside the guest and
+# must still run. The agent wraps the mount AROUND that resolved command
+# (`sh -c '<mounts> && exec "$@"' sh <argv>`); a host-side wrap only saw the
+# empty request command and would replace nginx with a bare mount stub.
+$S machine create --name rv-svc --image nginx:alpine --net --net-backend virtio-net $CREDS \
+  --init "apk add -q rclone fuse3" -v "s3://rv-bucket:/mnt/svc" >/dev/null 2>&1
+$S machine start --name rv-svc >/dev/null 2>&1
+GOT=$($S machine exec --name rv-svc -- sh -c 'pgrep -x nginx >/dev/null 2>&1 && echo up' 2>/dev/null)
+check "service entrypoint runs under a remote volume" "$GOT" "up"
+$S machine exec --name rv-svc -- sh -c 'echo svc-1 > /mnt/svc/svc.txt && sync && sleep 5' >/dev/null 2>&1
+check "service-image mount write visible out-of-band" "$(oob svc.txt)" "svc-1"
 
 cleanup
 echo ""

--- a/tests/test_remote_volumes.sh
+++ b/tests/test_remote_volumes.sh
@@ -86,7 +86,16 @@ check "8MB sha256 integrity out-of-band" "$H2" "$H1"
 $S machine create --name rv-ro --image alpine:latest --net --net-backend virtio-net $CREDS \
   --init "apk add -q rclone fuse3" -v "s3://rv-bucket:/mnt/q:ro" -- sleep infinity >/dev/null 2>&1
 $S machine start --name rv-ro >/dev/null 2>&1
-OUT=$($S machine exec --name rv-ro -- sh -c 'echo x > /mnt/q/no.txt 2>&1 || true' 2>/dev/null)
+# Assert only once the ro rclone mount is actually live in the container ns —
+# before that a write lands in the overlay dir and would falsely "succeed".
+OUT=""
+n=0; while [ $n -lt 12 ]; do
+  if $S machine exec --name rv-ro -- sh -c 'grep -q " /mnt/q " /proc/mounts' 2>/dev/null; then
+    OUT=$($S machine exec --name rv-ro -- sh -c 'echo x > /mnt/q/no.txt 2>&1 || true' 2>/dev/null)
+    break
+  fi
+  n=$((n+1)); sleep 1
+done
 echo "$OUT" | grep -qi "read-only" && ok "ro mount rejects writes" || bad "ro mount rejects writes"
 
 # ---- 8. fork of a remote-volume golden is refused cleanly -----------------
@@ -164,9 +173,14 @@ fi
 $S machine create --name rv-svc --image nginx:alpine --net --net-backend virtio-net $CREDS \
   --init "apk add -q rclone fuse3" -v "s3://rv-bucket:/mnt/svc" >/dev/null 2>&1
 $S machine start --name rv-svc >/dev/null 2>&1
-# The wrap execs into the image entrypoint, so nginx becomes PID 1 — check
-# /proc/1/comm rather than pgrep (absent/limited in nginx:alpine's busybox).
-GOT=$($S machine exec --name rv-svc -- sh -c '[ "$(cat /proc/1/comm)" = nginx ] && echo up' 2>/dev/null)
+# The wrap execs into the image entrypoint, so nginx becomes PID 1 after a brief
+# sh -> docker-entrypoint.sh -> exec nginx transition — poll /proc/1/comm rather
+# than probe once (and it sidesteps busybox pgrep quirks).
+GOT=
+n=0; while [ $n -lt 15 ]; do
+  [ "$($S machine exec --name rv-svc -- sh -c 'cat /proc/1/comm' 2>/dev/null)" = nginx ] && { GOT=up; break; }
+  n=$((n+1)); sleep 1
+done
 check "service entrypoint runs under a remote volume" "$GOT" "up"
 $S machine exec --name rv-svc -- sh -c 'echo svc-1 > /mnt/svc/svc.txt && sync && sleep 5' >/dev/null 2>&1
 check "service-image mount write visible out-of-band" "$(oob svc.txt)" "svc-1"

--- a/tests/test_remote_volumes.sh
+++ b/tests/test_remote_volumes.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+# End-to-end tests for remote volumes (-v s3://... and raw rclone remotes).
+#
+# Fully self-contained: runs a MinIO S3 server inside a smolvm machine and
+# verifies every write OUT-OF-BAND from a separate machine via the raw S3 API
+# (the vfs write cache survives on the persistent overlay, so reading back
+# through the same mount proves nothing).
+#
+# Usage: ./tests/test_remote_volumes.sh [path-to-smolvm]
+set -u
+S=${1:-smolvm}
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); echo "PASS: $1"; }
+bad()  { FAIL=$((FAIL+1)); echo "FAIL: $1"; }
+check() { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (want '$3' got '$2')"; fi; }
+
+CREDS="--env AWS_ACCESS_KEY_ID=smoltest --env AWS_SECRET_ACCESS_KEY=smoltest123 --env AWS_ENDPOINT_URL=http://100.96.0.1:9000"
+RCLONE_REMOTE=':s3,provider=Minio,access_key_id=smoltest,secret_access_key=smoltest123,endpoint="http://100.96.0.1:9000"'
+NAMES="rv-minio rv-ver rv-rw rv-ro rv-notools rv-badremote"
+cleanup() { for n in $NAMES; do $S machine delete --name "$n" --force >/dev/null 2>&1; done; }
+cleanup
+
+# ---- rig: MinIO + out-of-band verifier ------------------------------------
+$S machine create --name rv-minio --image minio/minio --net -p 9000:9000 \
+  --env MINIO_ROOT_USER=smoltest --env MINIO_ROOT_PASSWORD=smoltest123 \
+  -- minio server /data --address :9000 >/dev/null 2>&1
+$S machine start --name rv-minio >/dev/null 2>&1
+i=0; until curl -s -m 2 http://127.0.0.1:9000/minio/health/live >/dev/null 2>&1; do
+  i=$((i+1)); [ $i -gt 30 ] && { echo "ABORT: minio never came up"; cleanup; exit 1; }; sleep 2
+done
+$S machine create --name rv-ver --image alpine:latest --net --net-backend virtio-net >/dev/null 2>&1
+$S machine start --name rv-ver >/dev/null 2>&1
+$S machine exec --name rv-ver -- sh -c "apk add -q rclone >/dev/null 2>&1; rclone mkdir '$RCLONE_REMOTE:rv-bucket' 2>/dev/null" >/dev/null 2>&1
+oob() { $S machine exec --name rv-ver -- sh -c "rclone cat '$RCLONE_REMOTE:rv-bucket/$1' 2>/dev/null"; }
+
+# ---- 1. parse rejections happen at create, with hints ---------------------
+OUT=$($S machine create --name rv-x --image alpine:latest --net -v "s3://b:relative" -- sleep infinity 2>&1)
+echo "$OUT" | grep -q "must be absolute" && ok "relative guest path rejected" || bad "relative guest path rejected"
+OUT=$($S machine create --name rv-x --image alpine:latest --net -v ':http,url="https://h":/mnt/x' -- sleep infinity 2>&1)
+echo "$OUT" | grep -q "::" && ok "missing remote path colon rejected with :: hint" || bad "missing remote path colon rejected with :: hint"
+OUT=$($S machine create --name rv-x --image alpine:latest -v "s3://b:/mnt/x" -- sleep infinity 2>&1)
+echo "$OUT" | grep -q "network" && ok "remote volume without network rejected" || bad "remote volume without network rejected"
+
+# ---- 2. missing tools fails the START with the actionable message ---------
+$S machine create --name rv-notools --image alpine:latest --net --net-backend virtio-net $CREDS \
+  -v "s3://rv-bucket:/mnt/q" -- sleep infinity >/dev/null 2>&1
+OUT=$($S machine start --name rv-notools 2>&1)
+echo "$OUT" | grep -q "rclone and fuse3" && ok "missing tools fails start with hint" || bad "missing tools fails start with hint"
+
+# ---- 3. a dead mount (garbage backend) fails the START --------------------
+$S machine create --name rv-badremote --image alpine:latest --net --net-backend virtio-net \
+  --init "apk add -q rclone fuse3" -v ":nosuchbackend,x=1::/mnt/q" -- sleep infinity >/dev/null 2>&1
+OUT=$($S machine start --name rv-badremote 2>&1)
+echo "$OUT" | grep -q "failed to mount" && ok "dead mount fails start with log pointer" || bad "dead mount fails start with log pointer"
+
+# ---- 4. rw round trip, out-of-band verified -------------------------------
+$S machine create --name rv-rw --image alpine:latest --net --net-backend virtio-net $CREDS \
+  --init "apk add -q rclone fuse3" -v "s3://rv-bucket:/mnt/rw" -- sleep infinity >/dev/null 2>&1
+$S machine start --name rv-rw >/dev/null 2>&1
+$S machine exec --name rv-rw -- sh -c 'echo rt-1 > /mnt/rw/rt.txt && sync && sleep 5' >/dev/null 2>&1
+check "rw write visible out-of-band" "$(oob rt.txt)" "rt-1"
+
+# ---- 5. restart: mount returns, content intact, appends flush -------------
+$S machine stop --name rv-rw >/dev/null 2>&1
+$S machine start --name rv-rw >/dev/null 2>&1
+GOT=$($S machine exec --name rv-rw -- sh -c 'cat /mnt/rw/rt.txt 2>/dev/null' 2>/dev/null)
+check "mount returns after restart with content" "$GOT" "rt-1"
+
+# ---- 6. large-file integrity ----------------------------------------------
+H1=$($S machine exec --name rv-rw -- sh -c 'dd if=/dev/urandom of=/tmp/b bs=1M count=8 2>/dev/null; sha256sum /tmp/b | cut -d" " -f1; cp /tmp/b /mnt/rw/b.bin && sync && sleep 8' 2>/dev/null | tail -1)
+H2=$($S machine exec --name rv-ver -- sh -c "rclone cat '$RCLONE_REMOTE:rv-bucket/b.bin' 2>/dev/null | sha256sum | cut -d' ' -f1" 2>/dev/null | tail -1)
+check "8MB sha256 integrity out-of-band" "$H2" "$H1"
+
+# ---- 7. read-only enforcement ---------------------------------------------
+$S machine create --name rv-ro --image alpine:latest --net --net-backend virtio-net $CREDS \
+  --init "apk add -q rclone fuse3" -v "s3://rv-bucket:/mnt/q:ro" -- sleep infinity >/dev/null 2>&1
+$S machine start --name rv-ro >/dev/null 2>&1
+OUT=$($S machine exec --name rv-ro -- sh -c 'echo x > /mnt/q/no.txt 2>&1 || true' 2>/dev/null)
+echo "$OUT" | grep -qi "read-only" && ok "ro mount rejects writes" || bad "ro mount rejects writes"
+
+# ---- 8. fork of a remote-volume golden is refused cleanly -----------------
+OUT=$($S machine fork --golden rv-ro --name rv-clone 2>&1)
+echo "$OUT" | grep -q "cannot be forked yet" && ok "fork refused for remote-volume golden" || bad "fork refused for remote-volume golden"
+
+cleanup
+echo ""
+echo "remote volumes e2e: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ]


### PR DESCRIPTION
The volume flag now accepts remote sources mounted inside the guest via rclone — s3://bucket/prefix sugar with credentials from the machine env and an endpoint override for S3-compatible stores, plus raw rclone connection strings so every rclone-supported filesystem works — with the mounts running in the workload container so exec and shell sessions see them and they return on every start.