### PR TITLE
Use shared COW disk bases for VM-mode creates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,9 +1256,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/crates/smolvm-pack/src/assets.rs
+++ b/crates/smolvm-pack/src/assets.rs
@@ -218,6 +218,7 @@ impl AssetCollector {
                 },
                 layers: Vec::new(),
                 storage_template: None,
+                storage_logical_size: None,
                 overlay_template: None,
                 overlay_logical_size: None,
             },
@@ -636,6 +637,28 @@ impl AssetCollector {
         Ok(())
     }
 
+    /// Add a stopped VM's persistent storage disk as the VM-mode template.
+    /// Trailing sparse space is stripped for packing and its original logical
+    /// size is recorded so cold-create can normalize one safe COW base.
+    pub fn add_vm_storage_template(&mut self, path: &Path) -> Result<()> {
+        if !path.exists() {
+            return Err(PackError::AssetNotFound(format!(
+                "storage disk not found: {}",
+                path.display()
+            )));
+        }
+
+        const STORAGE_NAME: &str = "storage.ext4";
+        let dst = self.staging_dir.join(STORAGE_NAME);
+        let (logical_size, truncated_size) = sparse_copy_overlay(path, &dst)?;
+        self.inventory.storage_template = Some(AssetEntry {
+            path: STORAGE_NAME.to_string(),
+            size: truncated_size,
+        });
+        self.inventory.storage_logical_size = Some(logical_size);
+        Ok(())
+    }
+
     /// Get the current asset inventory.
     pub fn inventory(&self) -> &AssetInventory {
         &self.inventory
@@ -959,6 +982,33 @@ mod tests {
         assert_eq!(dst_data[0], 0x01);
         assert_eq!(dst_data[511], 0xFF);
         assert_eq!(dst_data[256], 0x00); // interior zero is preserved
+    }
+
+    #[test]
+    fn vm_storage_template_preserves_logical_size_without_packing_the_tail() {
+        let temp = tempfile::tempdir().unwrap();
+        let source = temp.path().join("storage.raw");
+        let mut file = File::create(&source).unwrap();
+        file.write_all(b"docker-layer").unwrap();
+        file.set_len(4 * 1024 * 1024).unwrap();
+
+        let staging = temp.path().join("staging");
+        let mut collector = AssetCollector::new(staging.clone()).unwrap();
+        collector.add_vm_storage_template(&source).unwrap();
+        let inventory = collector.inventory();
+        let template = inventory.storage_template.as_ref().unwrap();
+
+        assert_eq!(template.path, "storage.ext4");
+        assert_eq!(inventory.storage_logical_size, Some(4 * 1024 * 1024));
+        assert_eq!(
+            fs::metadata(staging.join(&template.path)).unwrap().len(),
+            template.size
+        );
+        assert!(template.size < 4 * 1024 * 1024);
+        assert_eq!(
+            fs::read(staging.join(&template.path)).unwrap(),
+            b"docker-layer"
+        );
     }
 
     #[test]

--- a/crates/smolvm-pack/src/extract.rs
+++ b/crates/smolvm-pack/src/extract.rs
@@ -4,6 +4,8 @@
 //! (sidecar mode via `runpack`) and the standalone stub executable.
 
 use crate::format::{PackFooter, SIDECAR_EXTENSION};
+use sha2::{Digest, Sha256};
+use std::fmt::Write as _;
 use std::fs::{self, File};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
@@ -1089,12 +1091,170 @@ pub fn extract_sidecar_shared(
     // per-VM lease, so an oldest-first size-cap here would delete a pack still
     // mounted by live pool VMs. See `extract_sidecar_capped`.
     extract_sidecar_capped(sidecar_path, &shared_dir, footer, false, debug, false)?;
+    ensure_shared_artifact_sha256(sidecar_path, &shared_dir)?;
     // Lock down the store so a dropped per-VM uid can't read the shared copy
     // directly (it must go through its idmapped mount). Best-effort: traversal
     // by root (the VMM before it drops privileges) is unaffected by 0700.
     restrict_to_owner(shared_root);
     restrict_to_owner(&shared_dir);
     Ok(shared_dir)
+}
+
+/// Path of the cached SHA-256 identity for one shared artifact extraction.
+///
+/// The digest sits beside (rather than inside) the extracted tree so the tree
+/// remains byte-for-byte identical to a private extraction and can continue to
+/// be mounted read-only into guests.
+pub fn shared_artifact_sha256_path(shared_dir: &Path) -> PathBuf {
+    shared_dir.with_extension("artifact-sha256")
+}
+
+/// Read and validate the full-artifact SHA-256 cached for a shared extraction.
+/// Returns the lowercase 64-character hex digest without an algorithm prefix.
+pub fn read_shared_artifact_sha256(shared_dir: &Path) -> std::io::Result<String> {
+    let path = shared_artifact_sha256_path(shared_dir);
+    let digest = fs::read_to_string(&path)?.trim().to_string();
+    if digest.len() != 64
+        || !digest
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("invalid artifact SHA-256 marker: {}", path.display()),
+        ));
+    }
+    Ok(digest)
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+struct ArtifactSourceIdentity {
+    canonical_path: String,
+    len: u64,
+    modified_secs: Option<u64>,
+    modified_nanos: Option<u32>,
+}
+
+fn artifact_source_identity(sidecar_path: &Path) -> std::io::Result<ArtifactSourceIdentity> {
+    let canonical = sidecar_path.canonicalize()?;
+    let metadata = fs::metadata(&canonical)?;
+    let modified = metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok());
+    Ok(ArtifactSourceIdentity {
+        canonical_path: canonical.to_string_lossy().into_owned(),
+        len: metadata.len(),
+        modified_secs: modified.map(|duration| duration.as_secs()),
+        modified_nanos: modified.map(|duration| duration.subsec_nanos()),
+    })
+}
+
+fn shared_artifact_source_path(shared_dir: &Path) -> PathBuf {
+    shared_dir.with_extension("artifact-source.json")
+}
+
+fn hash_artifact_sha256(sidecar_path: &Path) -> std::io::Result<String> {
+    let mut source = File::open(sidecar_path)?;
+    let mut hasher = Sha256::new();
+    let mut buffer = vec![0_u8; 4 * 1024 * 1024];
+    loop {
+        let read = source.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    let mut digest = String::with_capacity(64);
+    for byte in hasher.finalize() {
+        write!(&mut digest, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    Ok(digest)
+}
+
+fn write_atomic_marker(path: &Path, contents: &[u8]) -> std::io::Result<()> {
+    let tmp_path = path.with_extension(format!("tmp-{}", std::process::id()));
+    // A process may have died after creating its PID-scoped temp file. The
+    // caller's flock proves no live writer owns it now.
+    if tmp_path.exists() {
+        fs::remove_file(&tmp_path)?;
+    }
+    let write_result = (|| {
+        let mut tmp = fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&tmp_path)?;
+        tmp.write_all(contents)?;
+        tmp.sync_all()?;
+        fs::rename(&tmp_path, path)?;
+        Ok::<(), std::io::Error>(())
+    })();
+    if write_result.is_err() {
+        let _ = fs::remove_file(&tmp_path);
+    }
+    write_result
+}
+
+/// Compute a shared artifact's full SHA-256 once, atomically, under a lock.
+///
+/// The pack footer uses CRC32 for compatibility. Disk COW bases need a
+/// collision-resistant identity, so the first shared extraction pays one
+/// streaming hash pass and every later machine only reads this tiny marker.
+fn ensure_shared_artifact_sha256(
+    sidecar_path: &Path,
+    shared_dir: &Path,
+) -> std::io::Result<String> {
+    let digest_path = shared_artifact_sha256_path(shared_dir);
+    let lock_path = digest_path.with_extension("artifact-sha256.lock");
+    let lock_file = fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)?;
+    lock_file_exclusive(&lock_file)?;
+
+    let source_path = shared_artifact_source_path(shared_dir);
+    let source_identity = artifact_source_identity(sidecar_path)?;
+    if digest_path.exists() {
+        let cached_digest = read_shared_artifact_sha256(shared_dir)?;
+        let cached_source = fs::read(&source_path)
+            .ok()
+            .and_then(|bytes| serde_json::from_slice::<ArtifactSourceIdentity>(&bytes).ok());
+        if cached_source.as_ref() == Some(&source_identity) {
+            return Ok(cached_digest);
+        }
+
+        // The shared extraction directory is historically keyed by the pack's
+        // CRC32 footer. If a different artifact ever collides with that key,
+        // fail instead of associating its SHA-256 with the already-extracted
+        // bytes. A second path to identical content is safe and refreshes the
+        // cheap source fingerprint for later warm creates.
+        let actual_digest = hash_artifact_sha256(sidecar_path)?;
+        if actual_digest != cached_digest {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "shared pack checksum collision at {}: artifact SHA-256 differs",
+                    shared_dir.display()
+                ),
+            ));
+        }
+        write_atomic_marker(
+            &source_path,
+            &serde_json::to_vec(&source_identity)
+                .map_err(|error| std::io::Error::other(error.to_string()))?,
+        )?;
+        return Ok(cached_digest);
+    }
+
+    let digest = hash_artifact_sha256(sidecar_path)?;
+    write_atomic_marker(&digest_path, format!("{digest}\n").as_bytes())?;
+    write_atomic_marker(
+        &source_path,
+        &serde_json::to_vec(&source_identity)
+            .map_err(|error| std::io::Error::other(error.to_string()))?,
+    )?;
+    Ok(digest)
 }
 
 /// Set a directory to `0700` (owner-only) if possible. Best-effort; errors are
@@ -2289,6 +2449,7 @@ pub fn create_or_copy_storage_disk(
     cache_dir: &Path,
     template_path: Option<&str>,
     storage_path: &Path,
+    storage_logical_size: Option<u64>,
     size_gb_override: Option<u64>,
 ) -> std::io::Result<()> {
     if let Some(template) = template_path {
@@ -2299,35 +2460,64 @@ pub fn create_or_copy_storage_disk(
             // turning ~25 MiB of real data into its full logical size of zeros on
             // disk and risking ENOSPC when several extractions run.
             sparse_copy(&template_path, storage_path)?;
-            // If a custom size was requested and it's larger than the template,
-            // extend the sparse file (resize2fs in the agent will expand the FS).
-            if let Some(gb) = size_gb_override {
-                let desired = gb * 1024 * 1024 * 1024;
-                let current = fs::metadata(storage_path)?.len();
-                if desired > current {
-                    let file = fs::OpenOptions::new().write(true).open(storage_path)?;
-                    // On Windows/NTFS, extending with set_len would allocate the
-                    // whole gap unless the file is sparse. Mark sparse first
-                    // (idempotent).
-                    #[cfg(windows)]
-                    mark_file_sparse(&file)?;
-                    file.set_len(desired)?;
-                }
+            // Restore a VM-mode disk's original trailing sparse extent and/or
+            // honor a larger requested size. resize2fs in the guest grows only
+            // when the requested block device is larger than the inherited FS.
+            let current = fs::metadata(storage_path)?.len();
+            let desired = [
+                Some(current),
+                storage_logical_size,
+                size_gb_override.map(|gb| gb * 1024 * 1024 * 1024),
+            ]
+            .into_iter()
+            .flatten()
+            .max()
+            .unwrap_or(current);
+            if desired > current {
+                let file = fs::OpenOptions::new().write(true).open(storage_path)?;
+                // On Windows/NTFS, extending with set_len would allocate the
+                // whole gap unless the file is sparse. Mark sparse first
+                // (idempotent).
+                #[cfg(windows)]
+                mark_file_sparse(&file)?;
+                file.set_len(desired)?;
             }
             return Ok(());
         }
     }
     // Fallback: create empty sparse file (agent will format on first boot)
-    let size = match size_gb_override {
-        Some(gb) => gb * 1024 * 1024 * 1024,
-        None => 512 * 1024 * 1024,
-    };
+    let size = [
+        storage_logical_size,
+        size_gb_override.map(|gb| gb * 1024 * 1024 * 1024),
+    ]
+    .into_iter()
+    .flatten()
+    .max()
+    .unwrap_or(512 * 1024 * 1024);
     create_storage_disk(storage_path, size)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn shared_artifact_digest_rejects_a_different_artifact_for_the_same_store() {
+        let temp = tempfile::tempdir().unwrap();
+        let shared = temp.path().join("shared");
+        fs::create_dir(&shared).unwrap();
+        let first = temp.path().join("first.smolmachine");
+        let second = temp.path().join("second.smolmachine");
+        fs::write(&first, b"first artifact").unwrap();
+        fs::write(&second, b"different artifact").unwrap();
+
+        let first_digest = ensure_shared_artifact_sha256(&first, &shared).unwrap();
+        let error = ensure_shared_artifact_sha256(&second, &shared).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("checksum collision"));
+        assert_eq!(read_shared_artifact_sha256(&shared).unwrap(), first_digest);
+    }
 
     /// Build a single-file tar archive in memory with the given name and data.
     fn make_tar(name: &str, data: &[u8]) -> Vec<u8> {
@@ -2967,6 +3157,7 @@ mod tests {
             Some("symlink-out/storage-template.ext4"),
             &storage_path,
             None,
+            None,
         );
         assert!(result.is_err());
         assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::InvalidInput);
@@ -2990,8 +3181,14 @@ mod tests {
         }
 
         let dest = cache_dir.path().join("storage.ext4");
-        create_or_copy_storage_disk(cache_dir.path(), Some("storage-template.ext4"), &dest, None)
-            .unwrap();
+        create_or_copy_storage_disk(
+            cache_dir.path(),
+            Some("storage-template.ext4"),
+            &dest,
+            None,
+            None,
+        )
+        .unwrap();
 
         let meta = fs::metadata(&dest).unwrap();
         // Logical size is preserved...

--- a/crates/smolvm-pack/src/extract.rs
+++ b/crates/smolvm-pack/src/extract.rs
@@ -952,12 +952,12 @@ pub fn extract_sidecar(
 /// `cache_dir.parent()` after a successful extraction.
 ///
 /// It MUST be `false` for the node-shared store (`_shared`): those entries are
-/// reference-shared across many VMs via `.pack-shared` pointers and hold NO
-/// per-VM lease, so capping the shared root would LRU-evict a pack still mounted
-/// by live pool VMs — their `/packed_layers` then reads empty and the guest
-/// fails with "no layer directories found in /packed_layers" (exit 255 on
-/// connect/exec). Only the private per-machine cache (`smolvm-pack/<checksum>`),
-/// whose running entries DO hold leases, is safe to cap. See
+/// reference-shared across many VMs via durable `.pack-shared` pointer leases,
+/// but this generic size cap does not inspect those pointers. Blindly capping
+/// the shared root could therefore evict a pack still mounted by live pool VMs —
+/// their `/packed_layers` then reads empty and the guest fails with "no layer
+/// directories found in /packed_layers" (exit 255 on connect/exec). Explicit
+/// `smolvm pack prune` performs the reference-aware cleanup instead. See
 /// `extract_sidecar_shared`, which passes `false`.
 fn extract_sidecar_capped(
     sidecar_path: &Path,
@@ -1086,10 +1086,10 @@ pub fn extract_sidecar_shared(
     debug: bool,
 ) -> std::io::Result<PathBuf> {
     let shared_dir = shared_pack_dir(shared_root, footer.checksum);
-    // cap_cache=false: NEVER LRU-evict the shared store. Its entries are
-    // reference-shared across every VM via `.pack-shared` pointers and take no
-    // per-VM lease, so an oldest-first size-cap here would delete a pack still
-    // mounted by live pool VMs. See `extract_sidecar_capped`.
+    // cap_cache=false: never perform blind automatic LRU eviction here. Shared
+    // entries are maintained explicitly by `smolvm pack prune`, which treats
+    // each machine's `.pack-shared` pointer as a durable lease and therefore
+    // cannot delete a pack mounted by a running or stopped VM.
     extract_sidecar_capped(sidecar_path, &shared_dir, footer, false, debug, false)?;
     ensure_shared_artifact_sha256(sidecar_path, &shared_dir)?;
     // Lock down the store so a dropped per-VM uid can't read the shared copy

--- a/crates/smolvm-pack/src/format.rs
+++ b/crates/smolvm-pack/src/format.rs
@@ -435,6 +435,14 @@ pub struct AssetInventory {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub storage_template: Option<AssetEntry>,
 
+    /// Original sparse size of a VM-mode storage disk, in bytes.
+    ///
+    /// Like the root overlay, a stopped VM's storage disk is packed without its
+    /// trailing hole and must be extended to this size before it is used as a
+    /// raw backing disk.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub storage_logical_size: Option<u64>,
+
     /// Overlay disk template (optional, VM mode only).
     /// Contains the VM's persistent rootfs state from a `--from-vm` pack.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -509,6 +517,7 @@ impl PackManifest {
                 },
                 layers: Vec::new(),
                 storage_template: None,
+                storage_logical_size: None,
                 overlay_template: None,
                 overlay_logical_size: None,
             },

--- a/crates/smolvm-pack/tests/shared_extract.rs
+++ b/crates/smolvm-pack/tests/shared_extract.rs
@@ -13,8 +13,12 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
+use sha2::{Digest, Sha256};
 use smolvm_pack::assets::AssetCollector;
-use smolvm_pack::extract::{extract_sidecar, extract_sidecar_shared, shared_extract_enabled};
+use smolvm_pack::extract::{
+    extract_sidecar, extract_sidecar_shared, read_shared_artifact_sha256,
+    shared_artifact_sha256_path, shared_extract_enabled,
+};
 use smolvm_pack::format::PackManifest;
 use smolvm_pack::{read_footer_from_sidecar, sidecar_path_for, Packer};
 
@@ -112,6 +116,13 @@ fn shared_extraction_is_content_addressed_idempotent_and_locked_down() {
         "shared dir must be keyed by the footer checksum"
     );
     assert!(shared_dir.is_dir(), "shared extraction dir must exist");
+    let expected_digest = format!("{:x}", Sha256::digest(fs::read(&sidecar).unwrap()));
+    assert_eq!(
+        read_shared_artifact_sha256(&shared_dir).unwrap(),
+        expected_digest,
+        "shared extraction must cache the full artifact SHA-256"
+    );
+    assert!(shared_artifact_sha256_path(&shared_dir).is_file());
 
     // 2) The shared view is byte-identical to a plain per-machine extraction —
     //    the idmapped mount only remaps ownership, never content.

--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -730,23 +730,25 @@ fn prepare_clone_from_snapshot(
             .map_err(|e| Error::agent("create clone dir", e.to_string()))?;
 
         let golden_layers = crate::agent::machine_layers_cache_dir(golden);
-        let golden_ptr = crate::agent::shared_pack_pointer_path(&golden_layers);
-        if golden_ptr.exists() {
+        #[cfg(target_os = "linux")]
+        {
             let clone_layers = crate::agent::machine_layers_cache_dir(clone);
-            std::fs::create_dir_all(&clone_layers)
-                .map_err(|e| Error::agent("create clone pack dir", e.to_string()))?;
-            std::fs::copy(
-                &golden_ptr,
-                crate::agent::shared_pack_pointer_path(&clone_layers),
-            )
-            .map_err(|e| Error::agent("copy shared pack pointer", e.to_string()))?;
-        } else if smolvm_pack::extract::is_extracted(&golden_layers) {
+            let copied_shared_lease =
+                crate::artifact_cache::copy_shared_pack_lease(&golden_layers, &clone_layers)
+                    .map_err(|e| Error::agent("copy shared pack lease", e.to_string()))?;
+            if copied_shared_lease.is_none() && smolvm_pack::extract::is_extracted(&golden_layers) {
+                std::os::unix::fs::symlink(&golden_layers, &clone_layers)
+                    .map_err(|e| Error::agent("link clone pack dir", e.to_string()))?;
+            }
+        }
+        #[cfg(not(target_os = "linux"))]
+        if smolvm_pack::extract::is_extracted(&golden_layers) {
             #[cfg(unix)]
-            std::os::unix::fs::symlink(
-                &golden_layers,
-                crate::agent::machine_layers_cache_dir(clone),
-            )
-            .map_err(|e| Error::agent("link clone pack dir", e.to_string()))?;
+            {
+                let clone_layers = crate::agent::machine_layers_cache_dir(clone);
+                std::os::unix::fs::symlink(&golden_layers, &clone_layers)
+                    .map_err(|e| Error::agent("link clone pack dir", e.to_string()))?;
+            }
         }
 
         let mut clone_rec = golden_rec.clone();

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -2088,6 +2088,15 @@ impl AgentManager {
                 if let Some(home) = dirs::home_dir() {
                     crate::process::ensure_traversable(&home.join(".smolvm"));
                 }
+                #[cfg(target_os = "linux")]
+                {
+                    // VM-mode `create --from` qcow2 disks point at immutable bases
+                    // in the node-wide COW store. libkrun opens those paths after
+                    // this process drops to the per-VM uid, so make the store's
+                    // ancestor chain traversable (the store itself remains
+                    // non-listable and Landlock grants only this VM's exact chain).
+                    crate::process::ensure_traversable(&crate::storage::cow_base_cache_root());
+                }
                 // Pre-create this VM's per-VM readiness marker owned by its uid
                 // (0600): the dropped guest can overwrite it but couldn't create a
                 // file in the shared, host-user-owned rootfs. Per-VM name + 0600 =

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -631,31 +631,27 @@ pub async fn create_machine(
                 let footer = smolvm_pack::packer::read_footer_from_sidecar(path)
                     .map_err(|e| ApiError::internal(format!("read sidecar footer: {}", e)))?;
                 if smolvm_pack::extract::shared_extract_enabled() {
-                    // Shared content-addressed store: extract the build-constant
-                    // pack ONCE per node into `_shared/<checksum>` (root-owned,
-                    // read-only) instead of a private per-machine copy, and drop a
-                    // pointer beside this machine. The per-machine `pack` dir is
-                    // left an empty mountpoint that the boot path idmap-binds the
-                    // shared copy onto (mapping on-disk uid 0 -> the VM's dropped
-                    // uid), so a 28.6 MB / 362-file agent-rootfs decodes once per
-                    // node rather than once per machine — the cold-start tax this
-                    // removes — with the per-VM uid isolation (#456) preserved.
-                    let shared_root = crate::agent::shared_pack_cache_root();
-                    let shared_dir = smolvm_pack::extract::extract_sidecar_shared(
-                        path,
-                        &shared_root,
-                        &footer,
-                        false,
-                    )
-                    .map_err(|e| ApiError::internal(format!("extract sidecar (shared): {}", e)))?;
-                    std::fs::create_dir_all(&cache_dir).map_err(|e| {
-                        ApiError::internal(format!("create pack mountpoint: {}", e))
-                    })?;
-                    let pointer = crate::agent::shared_pack_pointer_path(&cache_dir);
-                    std::fs::write(&pointer, shared_dir.to_string_lossy().as_bytes()).map_err(
-                        |e| ApiError::internal(format!("write shared pack pointer: {}", e)),
-                    )?;
-                    Ok(())
+                    #[cfg(target_os = "linux")]
+                    {
+                        // Shared content-addressed store: extract the build-constant
+                        // pack ONCE per node into `_shared/<checksum>` (root-owned,
+                        // read-only) instead of a private per-machine copy, and drop a
+                        // pointer beside this machine. The per-machine `pack` dir is
+                        // left an empty mountpoint that the boot path idmap-binds the
+                        // shared copy onto (mapping on-disk uid 0 -> the VM's dropped
+                        // uid), so a 28.6 MB / 362-file agent-rootfs decodes once per
+                        // node rather than once per machine — the cold-start tax this
+                        // removes — with the per-VM uid isolation (#456) preserved.
+                        crate::artifact_cache::materialize_shared_pack_lease(
+                            path, &footer, &cache_dir, false,
+                        )
+                        .map_err(|e| {
+                            ApiError::internal(format!("extract sidecar (shared): {}", e))
+                        })?;
+                        Ok(())
+                    }
+                    #[cfg(not(target_os = "linux"))]
+                    unreachable!("shared pack extraction is Linux-only")
                 } else {
                     // Per-machine extraction: macOS case-sensitive layers volume
                     // (owned 1:1 by the machine), or the `SMOLVM_DISABLE_SHARED_EXTRACT`

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -298,6 +298,8 @@ struct VmModeSeed {
     /// template has its trailing zero extent stripped, so the disk must be
     /// ftruncated back to this before boot or it isn't a valid full filesystem.
     overlay_logical_size: Option<u64>,
+    /// Original virtual size of the packed persistent storage disk.
+    storage_logical_size: Option<u64>,
     /// Requested disk sizes (GiB) from the create request, honored as a lower
     /// bound on the seeded disks (the guest grows the inherited fs with resize2fs).
     storage_gb: Option<u64>,
@@ -521,6 +523,7 @@ pub async fn create_machine(
                     .as_ref()
                     .map(|t| t.path.clone()),
                 overlay_logical_size: manifest.assets.overlay_logical_size,
+                storage_logical_size: manifest.assets.storage_logical_size,
                 storage_gb: req.storage_gb,
                 overlay_gb: req.overlay_gb,
             })
@@ -713,16 +716,31 @@ pub async fn create_machine(
             // (the per-machine `pack` dir is an empty mountpoint), so seed the
             // VM-mode disk templates from the shared copy. Falls back to the
             // per-machine dir when no pointer was written (macOS / kill-switch).
-            let pack_content_dir =
-                crate::agent::read_shared_pack_pointer(&cache_dir).unwrap_or(cache_dir);
+            let (pack_content_dir, artifact_sha256) =
+                if let Some(shared_dir) = crate::agent::read_shared_pack_pointer(&cache_dir) {
+                    let digest = smolvm_pack::extract::read_shared_artifact_sha256(&shared_dir)
+                        .map_err(|e| {
+                            ApiError::internal(format!(
+                                "read shared artifact SHA-256 {}: {e}",
+                                shared_dir.display()
+                            ))
+                        })?;
+                    (shared_dir, Some(digest))
+                } else {
+                    (cache_dir, None)
+                };
             crate::storage::seed_vm_mode_disks(
                 &disk_dir,
                 &pack_content_dir,
-                seed.overlay_template.as_deref(),
-                seed.storage_template.as_deref(),
-                seed.overlay_logical_size,
-                seed.overlay_gb,
-                seed.storage_gb,
+                crate::storage::VmModeDiskSeedSpec {
+                    artifact_sha256: artifact_sha256.as_deref(),
+                    overlay_template: seed.overlay_template.as_deref(),
+                    storage_template: seed.storage_template.as_deref(),
+                    overlay_logical_size: seed.overlay_logical_size,
+                    storage_logical_size: seed.storage_logical_size,
+                    overlay_gb: seed.overlay_gb,
+                    storage_gb: seed.storage_gb,
+                },
             )
             .map_err(|e| ApiError::internal(format!("seed VM-mode disks: {}", e)))
         })

--- a/src/artifact_cache.rs
+++ b/src/artifact_cache.rs
@@ -1,0 +1,899 @@
+//! Reference-safe lifecycle management for Linux artifact caches.
+//!
+//! A machine created from a shared `.smolmachine` owns a small `.pack-shared`
+//! pointer in its data directory. That pointer is the durable lease for both the
+//! extracted shared pack and any immutable COW disk bases derived from it. The
+//! cache-wide flock in this module serializes lease publication with pruning;
+//! machine creation remains concurrent because publishers take a shared lock.
+
+use crate::agent::{
+    shared_pack_cache_root, shared_pack_pointer_path, vm_cache_root, SHARED_PACK_POINTER,
+};
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::io::{self, Write};
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const CACHE_LOCK_FILENAME: &str = ".artifact-cache.lock";
+static POINTER_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+/// A validated machine reference to one shared artifact.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SharedPackLease {
+    /// Canonical `_shared/<checksum>` directory used by the machine.
+    pub shared_dir: PathBuf,
+    /// Full SHA-256 used to key immutable COW disk bases.
+    pub artifact_sha256: String,
+}
+
+/// One unused artifact selected by reference-aware cache pruning.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArtifactCachePruneEntry {
+    /// Artifact SHA-256, or `shared:<checksum>` for an old unidentifiable entry.
+    pub artifact: String,
+    /// Cache directories removed, or that would be removed in a dry run.
+    pub paths: Vec<PathBuf>,
+    /// Real allocated bytes occupied by the entry, including sparse-file blocks.
+    pub allocated_bytes: u64,
+}
+
+/// Result of one reference-aware artifact cache prune.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArtifactCachePruneReport {
+    /// Unused artifact entries removed, or selected by a dry run.
+    pub entries: Vec<ArtifactCachePruneEntry>,
+    /// Artifact entries retained because at least one machine references them.
+    pub referenced_entries: usize,
+}
+
+struct ArtifactCacheLock(fs::File);
+
+impl Drop for ArtifactCacheLock {
+    fn drop(&mut self) {
+        let _ = unsafe { libc::flock(self.0.as_raw_fd(), libc::LOCK_UN) };
+    }
+}
+
+fn lock_artifact_cache(vm_root: &Path, exclusive: bool) -> io::Result<ArtifactCacheLock> {
+    fs::create_dir_all(vm_root)?;
+    let path = vm_root.join(CACHE_LOCK_FILENAME);
+    let file = fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(&path)?;
+    // Do not trust an older umask or manually-created lock file.
+    file.set_permissions(fs::Permissions::from_mode(0o600))?;
+    let operation = if exclusive {
+        libc::LOCK_EX
+    } else {
+        libc::LOCK_SH
+    };
+    if unsafe { libc::flock(file.as_raw_fd(), operation) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(ArtifactCacheLock(file))
+}
+
+fn is_lower_hex(value: &str, len: usize) -> bool {
+    value.len() == len
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn canonical_shared_dir(shared_dir: &Path, shared_root: &Path) -> io::Result<PathBuf> {
+    if !shared_dir.is_absolute() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "shared pack pointer is not absolute: {}",
+                shared_dir.display()
+            ),
+        ));
+    }
+    validate_real_cache_root(shared_root)?;
+    let original_metadata = fs::symlink_metadata(shared_dir)?;
+    if !original_metadata.file_type().is_dir() || original_metadata.file_type().is_symlink() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "shared pack target is not a real directory: {}",
+                shared_dir.display()
+            ),
+        ));
+    }
+    let root = shared_root.canonicalize().map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!(
+                "canonicalize shared pack root {}: {error}",
+                shared_root.display()
+            ),
+        )
+    })?;
+    let shared = shared_dir.canonicalize().map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!("canonicalize shared pack {}: {error}", shared_dir.display()),
+        )
+    })?;
+    let valid_name = shared
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| is_lower_hex(name, 8));
+    if shared.parent() != Some(root.as_path()) || !valid_name {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "shared pack pointer escapes the cache root: {}",
+                shared_dir.display()
+            ),
+        ));
+    }
+    Ok(shared)
+}
+
+fn read_artifact_digest(shared_dir: &Path) -> io::Result<String> {
+    let marker = smolvm_pack::extract::shared_artifact_sha256_path(shared_dir);
+    let metadata = fs::symlink_metadata(&marker)?;
+    if !metadata.file_type().is_file() || metadata.file_type().is_symlink() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "artifact SHA marker is not a regular file: {}",
+                marker.display()
+            ),
+        ));
+    }
+    smolvm_pack::extract::read_shared_artifact_sha256(shared_dir)
+}
+
+fn atomic_publish_pointer(pointer: &Path, shared_dir: &Path) -> io::Result<()> {
+    let parent = pointer.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("shared pack pointer has no parent: {}", pointer.display()),
+        )
+    })?;
+    fs::create_dir_all(parent)?;
+    let sequence = POINTER_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let temp = parent.join(format!(
+        ".{SHARED_PACK_POINTER}.tmp-{}-{sequence}",
+        std::process::id()
+    ));
+    let result = (|| {
+        let mut file = fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .mode(0o600)
+            .open(&temp)?;
+        writeln!(file, "{}", shared_dir.display())?;
+        file.sync_all()?;
+        fs::rename(&temp, pointer)?;
+        fs::File::open(parent)?.sync_all()?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temp);
+    }
+    result
+}
+
+fn read_lease_from_machine_dir(
+    machine_dir: &Path,
+    shared_root: &Path,
+) -> io::Result<Option<SharedPackLease>> {
+    let pointer = machine_dir.join(SHARED_PACK_POINTER);
+    let metadata = match fs::symlink_metadata(&pointer) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    if !metadata.file_type().is_file() || metadata.file_type().is_symlink() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "shared pack pointer is not a regular file: {}",
+                pointer.display()
+            ),
+        ));
+    }
+    let raw = fs::read_to_string(&pointer)?;
+    let target = raw.trim();
+    if target.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("empty shared pack pointer: {}", pointer.display()),
+        ));
+    }
+    let shared_dir = canonical_shared_dir(Path::new(target), shared_root)?;
+    let artifact_sha256 = read_artifact_digest(&shared_dir)?;
+    Ok(Some(SharedPackLease {
+        shared_dir,
+        artifact_sha256,
+    }))
+}
+
+fn touch_lease(lease: &SharedPackLease) {
+    let marker = smolvm_pack::extract::shared_artifact_sha256_path(&lease.shared_dir);
+    if let Ok(file) = fs::OpenOptions::new().read(true).open(marker) {
+        let _ = file.set_modified(SystemTime::now());
+    }
+}
+
+/// Extract a shared pack and atomically publish the machine lease for it.
+///
+/// The lease is published while holding the cache's shared flock. An exclusive
+/// prune therefore observes either no pointer and the pre-create cache state, or
+/// the complete pointer plus its validated SHA marker—never the gap between them.
+pub fn materialize_shared_pack_lease(
+    sidecar_path: &Path,
+    footer: &smolvm_pack::PackFooter,
+    machine_layers_dir: &Path,
+    debug: bool,
+) -> io::Result<SharedPackLease> {
+    let vm_root = vm_cache_root();
+    let shared_root = shared_pack_cache_root();
+    let _lock = lock_artifact_cache(&vm_root, false)?;
+    let shared_dir =
+        smolvm_pack::extract::extract_sidecar_shared(sidecar_path, &shared_root, footer, debug)?;
+    let shared_dir = canonical_shared_dir(&shared_dir, &shared_root)?;
+    let artifact_sha256 = read_artifact_digest(&shared_dir)?;
+    fs::create_dir_all(machine_layers_dir)?;
+    atomic_publish_pointer(&shared_pack_pointer_path(machine_layers_dir), &shared_dir)?;
+    let lease = SharedPackLease {
+        shared_dir,
+        artifact_sha256,
+    };
+    touch_lease(&lease);
+    Ok(lease)
+}
+
+/// Copy a golden machine's shared artifact lease to a fork clone atomically.
+///
+/// Returns `None` when the golden uses a private extraction rather than the
+/// Linux shared store. A malformed existing pointer is an error, not a fallback.
+pub fn copy_shared_pack_lease(
+    golden_layers_dir: &Path,
+    clone_layers_dir: &Path,
+) -> io::Result<Option<SharedPackLease>> {
+    let vm_root = vm_cache_root();
+    let shared_root = shared_pack_cache_root();
+    copy_shared_pack_lease_in(&vm_root, &shared_root, golden_layers_dir, clone_layers_dir)
+}
+
+fn copy_shared_pack_lease_in(
+    vm_root: &Path,
+    shared_root: &Path,
+    golden_layers_dir: &Path,
+    clone_layers_dir: &Path,
+) -> io::Result<Option<SharedPackLease>> {
+    let _lock = lock_artifact_cache(vm_root, false)?;
+    let golden_machine_dir = golden_layers_dir.parent().ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidInput, "golden pack dir has no parent")
+    })?;
+    let Some(lease) = read_lease_from_machine_dir(golden_machine_dir, shared_root)? else {
+        return Ok(None);
+    };
+    fs::create_dir_all(clone_layers_dir)?;
+    atomic_publish_pointer(
+        &shared_pack_pointer_path(clone_layers_dir),
+        &lease.shared_dir,
+    )?;
+    touch_lease(&lease);
+    Ok(Some(lease))
+}
+
+pub(crate) fn validate_cow_lease(
+    machine_dir: &Path,
+    shared_dir: &Path,
+    artifact_sha256: &str,
+) -> io::Result<()> {
+    validate_cow_lease_in(
+        machine_dir,
+        shared_dir,
+        artifact_sha256,
+        &shared_pack_cache_root(),
+    )
+}
+
+fn validate_cow_lease_in(
+    machine_dir: &Path,
+    shared_dir: &Path,
+    artifact_sha256: &str,
+    shared_root: &Path,
+) -> io::Result<()> {
+    let lease = read_lease_from_machine_dir(machine_dir, shared_root)?.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "COW disk creation requires {}",
+                machine_dir.join(SHARED_PACK_POINTER).display()
+            ),
+        )
+    })?;
+    let expected_shared = shared_dir.canonicalize()?;
+    if lease.shared_dir != expected_shared || lease.artifact_sha256 != artifact_sha256 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "COW artifact does not match the machine's shared pack lease",
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+struct CacheCandidate {
+    artifact: String,
+    digest: Option<String>,
+    shared_dirs: Vec<PathBuf>,
+    cow_dirs: Vec<PathBuf>,
+    metadata_files: Vec<PathBuf>,
+    modified: SystemTime,
+    allocated_bytes: u64,
+}
+
+impl CacheCandidate {
+    fn new(artifact: String, digest: Option<String>) -> Self {
+        Self {
+            artifact,
+            digest,
+            shared_dirs: Vec::new(),
+            cow_dirs: Vec::new(),
+            metadata_files: Vec::new(),
+            modified: UNIX_EPOCH,
+            allocated_bytes: 0,
+        }
+    }
+
+    fn visible_paths(&self) -> Vec<PathBuf> {
+        self.shared_dirs
+            .iter()
+            .chain(self.cow_dirs.iter())
+            .cloned()
+            .collect()
+    }
+}
+
+fn is_vm_dir_name(name: &str) -> bool {
+    is_lower_hex(name, 16)
+}
+
+fn collect_machine_leases(
+    vm_root: &Path,
+    shared_root: &Path,
+) -> io::Result<(HashSet<String>, HashSet<PathBuf>)> {
+    let mut digests = HashSet::new();
+    let mut shared_dirs = HashSet::new();
+    let entries = match fs::read_dir(vm_root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Ok((digests, shared_dirs));
+        }
+        Err(error) => return Err(error),
+    };
+    for entry in entries {
+        let entry = entry?;
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if !is_vm_dir_name(name) {
+            continue;
+        }
+        let file_type = entry.file_type()?;
+        if !file_type.is_dir() || file_type.is_symlink() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "VM cache entry is not a real directory: {}",
+                    entry.path().display()
+                ),
+            ));
+        }
+        if let Some(lease) = read_lease_from_machine_dir(&entry.path(), shared_root)? {
+            digests.insert(lease.artifact_sha256);
+            shared_dirs.insert(lease.shared_dir);
+        }
+    }
+    Ok((digests, shared_dirs))
+}
+
+fn metadata_paths_for_shared(shared_dir: &Path) -> Vec<PathBuf> {
+    let digest = smolvm_pack::extract::shared_artifact_sha256_path(shared_dir);
+    vec![
+        shared_dir.with_extension("lock"),
+        digest.clone(),
+        digest.with_extension("artifact-sha256.lock"),
+        shared_dir.with_extension("artifact-source.json"),
+    ]
+}
+
+fn allocated_usage(path: &Path) -> io::Result<u64> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(0),
+        Err(error) => return Err(error),
+    };
+    let mut bytes = metadata.blocks().saturating_mul(512);
+    if metadata.file_type().is_dir() && !metadata.file_type().is_symlink() {
+        for entry in fs::read_dir(path)? {
+            bytes = bytes.saturating_add(allocated_usage(&entry?.path())?);
+        }
+    }
+    Ok(bytes)
+}
+
+fn path_modified(path: &Path) -> io::Result<SystemTime> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => Ok(metadata.modified().unwrap_or(UNIX_EPOCH)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(UNIX_EPOCH),
+        Err(error) => Err(error),
+    }
+}
+
+fn add_candidate_path(candidate: &mut CacheCandidate, path: &Path) -> io::Result<()> {
+    candidate.allocated_bytes = candidate
+        .allocated_bytes
+        .saturating_add(allocated_usage(path)?);
+    candidate.modified = candidate.modified.max(path_modified(path)?);
+    Ok(())
+}
+
+fn inventory_candidates(
+    shared_root: &Path,
+    cow_root: &Path,
+    referenced_shared: &HashSet<PathBuf>,
+) -> io::Result<HashMap<String, CacheCandidate>> {
+    let mut candidates = HashMap::<String, CacheCandidate>::new();
+
+    if shared_root.exists() {
+        validate_real_cache_root(shared_root)?;
+        for entry in fs::read_dir(shared_root)? {
+            let entry = entry?;
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else { continue };
+            if !is_lower_hex(name, 8) {
+                continue;
+            }
+            let file_type = entry.file_type()?;
+            if !file_type.is_dir() || file_type.is_symlink() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "shared cache candidate is not a real directory: {}",
+                        entry.path().display()
+                    ),
+                ));
+            }
+            let shared_dir = entry.path().canonicalize()?;
+            let digest_result = read_artifact_digest(&shared_dir);
+            let (key, digest) = match digest_result {
+                Ok(digest) => (digest.clone(), Some(digest)),
+                Err(error) if !referenced_shared.contains(&shared_dir) => {
+                    tracing::warn!(
+                        path = %shared_dir.display(),
+                        error = %error,
+                        "unreferenced legacy shared cache has no valid artifact SHA"
+                    );
+                    (format!("shared:{name}"), None)
+                }
+                Err(error) => return Err(error),
+            };
+            let candidate = candidates
+                .entry(key.clone())
+                .or_insert_with(|| CacheCandidate::new(key, digest));
+            add_candidate_path(candidate, &shared_dir)?;
+            candidate.shared_dirs.push(shared_dir.clone());
+            for metadata_path in metadata_paths_for_shared(&shared_dir) {
+                add_candidate_path(candidate, &metadata_path)?;
+                candidate.metadata_files.push(metadata_path);
+            }
+        }
+    }
+
+    if cow_root.exists() {
+        validate_real_cache_root(cow_root)?;
+        for entry in fs::read_dir(cow_root)? {
+            let entry = entry?;
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else { continue };
+            if !is_lower_hex(name, 64) {
+                continue;
+            }
+            let file_type = entry.file_type()?;
+            if !file_type.is_dir() || file_type.is_symlink() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "COW cache candidate is not a real directory: {}",
+                        entry.path().display()
+                    ),
+                ));
+            }
+            let digest = name.to_string();
+            let cow_dir = entry.path();
+            let candidate = candidates
+                .entry(digest.clone())
+                .or_insert_with(|| CacheCandidate::new(digest.clone(), Some(digest.clone())));
+            add_candidate_path(candidate, &cow_dir)?;
+            candidate.cow_dirs.push(cow_dir);
+        }
+    }
+    Ok(candidates)
+}
+
+fn validate_real_cache_root(path: &Path) -> io::Result<()> {
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.file_type().is_dir() && !metadata.file_type().is_symlink() {
+        return Ok(());
+    }
+    Err(io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!(
+            "artifact cache root is not a real directory: {}",
+            path.display()
+        ),
+    ))
+}
+
+fn make_tree_owner_writable(path: &Path) -> io::Result<()> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    if metadata.file_type().is_symlink() {
+        // `remove_dir_all` unlinks an in-tree symlink rather than traversing it.
+        // Do not chmod or recurse through artifact-owned links.
+        return Ok(());
+    }
+    if metadata.file_type().is_dir() {
+        let mode = metadata.permissions().mode();
+        fs::set_permissions(path, fs::Permissions::from_mode(mode | 0o700))?;
+        for entry in fs::read_dir(path)? {
+            make_tree_owner_writable(&entry?.path())?;
+        }
+    }
+    Ok(())
+}
+
+fn remove_candidate(candidate: &CacheCandidate) -> io::Result<()> {
+    for path in &candidate.cow_dirs {
+        make_tree_owner_writable(path)?;
+        fs::remove_dir_all(path)?;
+    }
+    for path in &candidate.shared_dirs {
+        smolvm_pack::extract::force_detach_layers_volume(path);
+        make_tree_owner_writable(path)?;
+        fs::remove_dir_all(path)?;
+    }
+    for path in &candidate.metadata_files {
+        match fs::remove_file(path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
+
+fn prune_artifact_caches_in(
+    vm_root: &Path,
+    keep: usize,
+    dry_run: bool,
+) -> io::Result<ArtifactCachePruneReport> {
+    let _lock = lock_artifact_cache(vm_root, true)?;
+    let shared_root = vm_root.join("_shared");
+    let cow_root = vm_root.join("_cow-bases");
+    let (referenced_digests, referenced_shared) = collect_machine_leases(vm_root, &shared_root)?;
+    // Finish the complete reference scan and candidate inventory before the
+    // first mutation. Any malformed live pointer therefore fails closed.
+    let candidates = inventory_candidates(&shared_root, &cow_root, &referenced_shared)?;
+    let mut referenced_entries = 0usize;
+    let mut unused = Vec::new();
+    for candidate in candidates.into_values() {
+        let referenced = candidate
+            .digest
+            .as_ref()
+            .is_some_and(|digest| referenced_digests.contains(digest))
+            || candidate
+                .shared_dirs
+                .iter()
+                .any(|path| referenced_shared.contains(path));
+        if referenced {
+            referenced_entries += 1;
+        } else {
+            unused.push(candidate);
+        }
+    }
+    unused.sort_by(|left, right| {
+        right
+            .modified
+            .cmp(&left.modified)
+            .then_with(|| left.artifact.cmp(&right.artifact))
+    });
+
+    let mut entries = Vec::new();
+    for candidate in unused.into_iter().skip(keep) {
+        if !dry_run {
+            remove_candidate(&candidate)?;
+        }
+        entries.push(ArtifactCachePruneEntry {
+            artifact: candidate.artifact.clone(),
+            paths: candidate.visible_paths(),
+            allocated_bytes: candidate.allocated_bytes,
+        });
+    }
+    Ok(ArtifactCachePruneReport {
+        entries,
+        referenced_entries,
+    })
+}
+
+/// Prune unreferenced Linux shared-pack and immutable COW-base caches.
+///
+/// `keep` applies only to unused artifacts; every artifact referenced by a
+/// machine lease is retained in addition to that count. With `dry_run`, the
+/// returned report describes the selection without changing the filesystem.
+pub fn prune_artifact_caches(keep: usize, dry_run: bool) -> io::Result<ArtifactCachePruneReport> {
+    prune_artifact_caches_in(&vm_cache_root(), keep, dry_run)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DIGEST_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const DIGEST_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    fn machine_dir(root: &Path, suffix: &str) -> PathBuf {
+        root.join(format!("00000000000000{suffix}"))
+    }
+
+    fn install_artifact(root: &Path, checksum: &str, digest: &str) -> (PathBuf, PathBuf) {
+        let shared = root.join("_shared").join(checksum);
+        fs::create_dir_all(shared.join("layers")).unwrap();
+        fs::write(shared.join("layers/data"), b"shared").unwrap();
+        fs::write(
+            smolvm_pack::extract::shared_artifact_sha256_path(&shared),
+            format!("{digest}\n"),
+        )
+        .unwrap();
+        let cow = root.join("_cow-bases").join(digest).join("overlay-4096");
+        fs::create_dir_all(&cow).unwrap();
+        fs::write(cow.join("base.raw"), b"base").unwrap();
+        fs::set_permissions(&cow, fs::Permissions::from_mode(0o555)).unwrap();
+        (shared, root.join("_cow-bases").join(digest))
+    }
+
+    fn publish_test_lease(machine: &Path, shared: &Path) {
+        fs::create_dir_all(machine.join("pack")).unwrap();
+        atomic_publish_pointer(&machine.join(SHARED_PACK_POINTER), shared).unwrap();
+    }
+
+    #[test]
+    fn leases_protect_both_caches_until_the_last_machine_is_deleted() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("vms");
+        let (shared, cow) = install_artifact(&root, "deadbeef", DIGEST_A);
+        let first = machine_dir(&root, "01");
+        let second = machine_dir(&root, "02");
+        publish_test_lease(&first, &shared);
+        publish_test_lease(&second, &shared);
+
+        let report = prune_artifact_caches_in(&root, 0, false).unwrap();
+        assert!(report.entries.is_empty());
+        assert_eq!(report.referenced_entries, 1);
+        fs::remove_dir_all(&first).unwrap();
+        assert!(prune_artifact_caches_in(&root, 0, false)
+            .unwrap()
+            .entries
+            .is_empty());
+        assert!(shared.exists());
+        assert!(cow.exists());
+
+        fs::remove_dir_all(&second).unwrap();
+        let report = prune_artifact_caches_in(&root, 0, false).unwrap();
+        assert_eq!(report.entries.len(), 1);
+        assert!(!shared.exists());
+        assert!(!cow.exists());
+        assert!(!smolvm_pack::extract::shared_artifact_sha256_path(&shared).exists());
+    }
+
+    #[test]
+    fn malformed_live_pointer_fails_closed_before_any_removal() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("vms");
+        let (shared, cow) = install_artifact(&root, "deadbeef", DIGEST_A);
+        let machine = machine_dir(&root, "01");
+        fs::create_dir_all(&machine).unwrap();
+        fs::write(machine.join(SHARED_PACK_POINTER), "../../escape\n").unwrap();
+
+        let error = prune_artifact_caches_in(&root, 0, false).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(shared.exists());
+        assert!(cow.exists());
+    }
+
+    #[test]
+    fn symlinked_digest_marker_fails_closed_for_a_live_lease() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("vms");
+        let (shared, cow) = install_artifact(&root, "deadbeef", DIGEST_A);
+        let marker = smolvm_pack::extract::shared_artifact_sha256_path(&shared);
+        fs::remove_file(&marker).unwrap();
+        let outside = temp.path().join("digest");
+        fs::write(&outside, format!("{DIGEST_A}\n")).unwrap();
+        std::os::unix::fs::symlink(&outside, &marker).unwrap();
+        let machine = machine_dir(&root, "01");
+        publish_test_lease(&machine, &shared);
+
+        let error = prune_artifact_caches_in(&root, 0, false).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(shared.exists());
+        assert!(cow.exists());
+        assert_eq!(
+            fs::read(&outside).unwrap(),
+            format!("{DIGEST_A}\n").as_bytes()
+        );
+    }
+
+    #[test]
+    fn symlinked_cache_root_is_never_traversed() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("vms");
+        fs::create_dir_all(&root).unwrap();
+        let outside = temp.path().join("outside-cow");
+        fs::create_dir_all(outside.join(DIGEST_A)).unwrap();
+        fs::write(outside.join(DIGEST_A).join("keep"), b"outside").unwrap();
+        std::os::unix::fs::symlink(&outside, root.join("_cow-bases")).unwrap();
+
+        let error = prune_artifact_caches_in(&root, 0, false).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(
+            fs::read(outside.join(DIGEST_A).join("keep")).unwrap(),
+            b"outside"
+        );
+    }
+
+    #[test]
+    fn dry_run_and_keep_apply_only_to_unused_artifacts() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("vms");
+        let (shared_a, cow_a) = install_artifact(&root, "deadbeef", DIGEST_A);
+        let (shared_b, cow_b) = install_artifact(&root, "cafebabe", DIGEST_B);
+        fs::OpenOptions::new()
+            .read(true)
+            .open(smolvm_pack::extract::shared_artifact_sha256_path(&shared_b))
+            .unwrap()
+            .set_modified(SystemTime::now())
+            .unwrap();
+
+        let dry = prune_artifact_caches_in(&root, 1, true).unwrap();
+        assert_eq!(dry.entries.len(), 1);
+        assert_eq!(dry.entries[0].artifact, DIGEST_A);
+        assert!(dry.entries[0].allocated_bytes > 0);
+        assert!(shared_a.exists() && cow_a.exists());
+        assert!(shared_b.exists() && cow_b.exists());
+
+        let real = prune_artifact_caches_in(&root, 1, false).unwrap();
+        assert_eq!(real.entries.len(), 1);
+        assert!(!shared_a.exists() && !cow_a.exists());
+        assert!(shared_b.exists() && cow_b.exists());
+    }
+
+    #[test]
+    fn copy_lease_publishes_an_identical_clone_reference() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("vms");
+        let shared_root = root.join("_shared");
+        let (shared, _) = install_artifact(&root, "deadbeef", DIGEST_A);
+        let golden = machine_dir(&root, "01");
+        let clone = machine_dir(&root, "02");
+        publish_test_lease(&golden, &shared);
+
+        let lease = copy_shared_pack_lease_in(
+            &root,
+            &shared_root,
+            &golden.join("pack"),
+            &clone.join("pack"),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            read_lease_from_machine_dir(&clone, &shared_root)
+                .unwrap()
+                .unwrap(),
+            lease
+        );
+    }
+
+    #[test]
+    fn cow_creation_requires_a_matching_machine_lease() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("vms");
+        let shared_root = root.join("_shared");
+        let (shared, _) = install_artifact(&root, "deadbeef", DIGEST_A);
+        let machine = machine_dir(&root, "01");
+        fs::create_dir_all(&machine).unwrap();
+
+        let missing = validate_cow_lease_in(&machine, &shared, DIGEST_A, &shared_root).unwrap_err();
+        assert_eq!(missing.kind(), io::ErrorKind::InvalidData);
+        publish_test_lease(&machine, &shared);
+        validate_cow_lease_in(&machine, &shared, DIGEST_A, &shared_root).unwrap();
+        let mismatch =
+            validate_cow_lease_in(&machine, &shared, DIGEST_B, &shared_root).unwrap_err();
+        assert_eq!(mismatch.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn prune_waits_for_atomic_lease_publication() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("vms");
+        let (shared, cow) = install_artifact(&root, "deadbeef", DIGEST_A);
+        let machine = machine_dir(&root, "01");
+        let publisher = lock_artifact_cache(&root, false).unwrap();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (done_tx, done_rx) = mpsc::channel();
+        let prune_root = root.clone();
+        let worker = std::thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            let result = prune_artifact_caches_in(&prune_root, 0, false);
+            done_tx.send(result).unwrap();
+        });
+        started_rx.recv().unwrap();
+        assert!(matches!(
+            done_rx.recv_timeout(Duration::from_millis(100)),
+            Err(mpsc::RecvTimeoutError::Timeout)
+        ));
+
+        publish_test_lease(&machine, &shared);
+        drop(publisher);
+        let report = done_rx
+            .recv_timeout(Duration::from_secs(2))
+            .unwrap()
+            .unwrap();
+        worker.join().unwrap();
+        assert!(report.entries.is_empty());
+        assert!(shared.exists());
+        assert!(cow.exists());
+    }
+
+    #[test]
+    fn prune_unlinks_in_tree_symlinks_without_following_them() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("vms");
+        let (shared, _) = install_artifact(&root, "deadbeef", DIGEST_A);
+        let outside = temp.path().join("outside");
+        fs::write(&outside, b"keep").unwrap();
+        std::os::unix::fs::symlink(&outside, shared.join("layers/link")).unwrap();
+
+        let report = prune_artifact_caches_in(&root, 0, false).unwrap();
+        assert_eq!(report.entries.len(), 1);
+        assert_eq!(fs::read(&outside).unwrap(), b"keep");
+    }
+
+    #[test]
+    fn legacy_unreferenced_shared_entry_can_be_pruned_without_a_digest() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("vms");
+        let shared = root.join("_shared/deadbeef");
+        fs::create_dir_all(&shared).unwrap();
+        fs::write(shared.join("old"), b"cache").unwrap();
+
+        let report = prune_artifact_caches_in(&root, 0, false).unwrap();
+        assert_eq!(report.entries.len(), 1);
+        assert_eq!(report.entries[0].artifact, "shared:deadbeef");
+        assert!(!shared.exists());
+    }
+}

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -3343,7 +3343,7 @@ impl CreateCmd {
                     false,
                     false,
                 )
-                .map(|()| (cache_dir.clone(), None))
+                .map(|()| (cache_dir.clone(), None::<String>))
                 .map_err(|e| smolvm::Error::agent("extract sidecar", e.to_string()))
             };
             // Detach unconditionally: extraction mounts the case-sensitive volume on

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -3122,24 +3122,30 @@ impl CreateCmd {
         // `manifest` is moved into `params`; the disks are seeded from them after
         // extraction below, or the machine boots the bare agent-rootfs with no
         // /bin/sh (mirrors pack_run + the serve API create path).
-        let vm_seed: Option<(Option<String>, Option<String>, Option<u64>)> =
-            if manifest.mode == smolvm_pack::format::PackMode::Vm {
-                Some((
-                    manifest
-                        .assets
-                        .overlay_template
-                        .as_ref()
-                        .map(|t| t.path.clone()),
-                    manifest
-                        .assets
-                        .storage_template
-                        .as_ref()
-                        .map(|t| t.path.clone()),
-                    manifest.assets.overlay_logical_size,
-                ))
-            } else {
-                None
-            };
+        struct VmModeSeed {
+            overlay_template: Option<String>,
+            storage_template: Option<String>,
+            overlay_logical_size: Option<u64>,
+            storage_logical_size: Option<u64>,
+        }
+        let vm_seed = if manifest.mode == smolvm_pack::format::PackMode::Vm {
+            Some(VmModeSeed {
+                overlay_template: manifest
+                    .assets
+                    .overlay_template
+                    .as_ref()
+                    .map(|t| t.path.clone()),
+                storage_template: manifest
+                    .assets
+                    .storage_template
+                    .as_ref()
+                    .map(|t| t.path.clone()),
+                overlay_logical_size: manifest.assets.overlay_logical_size,
+                storage_logical_size: manifest.assets.storage_logical_size,
+            })
+        } else {
+            None
+        };
 
         // Resolve the canonical path for storage in VmRecord.
         let canonical_path = sidecar_path
@@ -3315,19 +3321,42 @@ impl CreateCmd {
             }
 
             println!("Extracting .smolmachine assets...");
-            let result = smolvm_pack::extract::extract_sidecar(
-                sidecar_path,
-                &cache_dir,
-                &footer,
-                false,
-                false,
-            )
-            .map_err(|e| smolvm::Error::agent("extract sidecar", e.to_string()));
+            let result = if smolvm_pack::extract::shared_extract_enabled() {
+                let shared_dir = smolvm_pack::extract::extract_sidecar_shared(
+                    sidecar_path,
+                    &smolvm::agent::shared_pack_cache_root(),
+                    &footer,
+                    false,
+                )
+                .map_err(|e| smolvm::Error::agent("extract sidecar (shared)", e.to_string()))?;
+                std::fs::create_dir_all(&cache_dir)
+                    .map_err(|e| smolvm::Error::agent("create pack mountpoint", e.to_string()))?;
+                std::fs::write(
+                    smolvm::agent::shared_pack_pointer_path(&cache_dir),
+                    shared_dir.to_string_lossy().as_bytes(),
+                )
+                .map_err(|e| smolvm::Error::agent("write shared pack pointer", e.to_string()))?;
+                let digest = smolvm_pack::extract::read_shared_artifact_sha256(&shared_dir)
+                    .map_err(|e| {
+                        smolvm::Error::agent("read shared artifact SHA-256", e.to_string())
+                    })?;
+                Ok((shared_dir, Some(digest)))
+            } else {
+                smolvm_pack::extract::extract_sidecar(
+                    sidecar_path,
+                    &cache_dir,
+                    &footer,
+                    false,
+                    false,
+                )
+                .map(|()| (cache_dir.clone(), None))
+                .map_err(|e| smolvm::Error::agent("extract sidecar", e.to_string()))
+            };
             // Detach unconditionally: extraction mounts the case-sensitive volume on
             // macOS even when it later fails, so the detach must run on both success
             // and failure paths to honor the "mounted iff running" invariant.
             smolvm_pack::extract::force_detach_layers_volume(&cache_dir);
-            result?;
+            let (pack_content_dir, artifact_sha256) = result?;
 
             // VM-mode pack: seed this machine's overlay+storage disks from the
             // packed templates so a start boots the source VM's rootfs rather than
@@ -3337,7 +3366,7 @@ impl CreateCmd {
             // (Writing the resized copy onto `manager.overlay_path()` — the default
             // `.qcow2` — handed the guest raw bytes named `.qcow2`, the /bin/sh-missing
             // bug's disk counterpart.)
-            if let Some((overlay_template, storage_template, overlay_logical_size)) = &vm_seed {
+            if let Some(seed) = &vm_seed {
                 let disk_dir = manager
                     .storage_path()
                     .parent()
@@ -3345,12 +3374,16 @@ impl CreateCmd {
                     .unwrap_or_else(|| smolvm::agent::vm_data_dir(&name_for_layers));
                 smolvm::storage::seed_vm_mode_disks(
                     &disk_dir,
-                    &cache_dir,
-                    overlay_template.as_deref(),
-                    storage_template.as_deref(),
-                    *overlay_logical_size,
-                    params.overlay_gb,
-                    params.storage_gb,
+                    &pack_content_dir,
+                    smolvm::storage::VmModeDiskSeedSpec {
+                        artifact_sha256: artifact_sha256.as_deref(),
+                        overlay_template: seed.overlay_template.as_deref(),
+                        storage_template: seed.storage_template.as_deref(),
+                        overlay_logical_size: seed.overlay_logical_size,
+                        storage_logical_size: seed.storage_logical_size,
+                        overlay_gb: params.overlay_gb,
+                        storage_gb: params.storage_gb,
+                    },
                 )
                 .map_err(|e| smolvm::Error::agent("seed VM-mode disks", e.to_string()))?;
             }

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -3322,25 +3322,19 @@ impl CreateCmd {
 
             println!("Extracting .smolmachine assets...");
             let result = if smolvm_pack::extract::shared_extract_enabled() {
-                let shared_dir = smolvm_pack::extract::extract_sidecar_shared(
-                    sidecar_path,
-                    &smolvm::agent::shared_pack_cache_root(),
-                    &footer,
-                    false,
-                )
-                .map_err(|e| smolvm::Error::agent("extract sidecar (shared)", e.to_string()))?;
-                std::fs::create_dir_all(&cache_dir)
-                    .map_err(|e| smolvm::Error::agent("create pack mountpoint", e.to_string()))?;
-                std::fs::write(
-                    smolvm::agent::shared_pack_pointer_path(&cache_dir),
-                    shared_dir.to_string_lossy().as_bytes(),
-                )
-                .map_err(|e| smolvm::Error::agent("write shared pack pointer", e.to_string()))?;
-                let digest = smolvm_pack::extract::read_shared_artifact_sha256(&shared_dir)
-                    .map_err(|e| {
-                        smolvm::Error::agent("read shared artifact SHA-256", e.to_string())
-                    })?;
-                Ok((shared_dir, Some(digest)))
+                #[cfg(target_os = "linux")]
+                {
+                    let lease = smolvm::artifact_cache::materialize_shared_pack_lease(
+                        sidecar_path,
+                        &footer,
+                        &cache_dir,
+                        false,
+                    )
+                    .map_err(|e| smolvm::Error::agent("extract sidecar (shared)", e.to_string()))?;
+                    Ok((lease.shared_dir, Some(lease.artifact_sha256)))
+                }
+                #[cfg(not(target_os = "linux"))]
+                unreachable!("shared pack extraction is Linux-only")
             } else {
                 smolvm_pack::extract::extract_sidecar(
                     sidecar_path,

--- a/src/cli/pack.rs
+++ b/src/cli/pack.rs
@@ -1046,7 +1046,9 @@ impl PackCreateCmd {
 /// Clean up cached pack extractions to free disk space.
 ///
 /// Removes old extracted pack caches from ~/.cache/smolvm-pack/ and
-/// ~/.cache/smolvm-libs/. By default keeps the 5 most recently used.
+/// ~/.cache/smolvm-libs/. On Linux it also removes unreferenced shared pack
+/// extractions and immutable COW disk bases. By default keeps the 5 most
+/// recently used entries in addition to every artifact referenced by a machine.
 ///
 /// Examples:
 ///   smolvm pack prune              # keep 5 most recent
@@ -1055,11 +1057,11 @@ impl PackCreateCmd {
 ///   smolvm pack prune --dry-run    # show what would be removed
 #[derive(Args, Debug)]
 pub struct PackPruneCmd {
-    /// Number of cached extractions to keep (default: 5)
+    /// Number of unused cached entries to keep (default: 5)
     #[arg(long, default_value = "5", value_name = "N")]
     pub keep: usize,
 
-    /// Remove all cached extractions
+    /// Remove all unused cached entries (machine references are always retained)
     #[arg(long)]
     pub all: bool,
 
@@ -1074,6 +1076,53 @@ impl PackPruneCmd {
 
         let mut total_freed: u64 = 0;
         let mut total_removed: usize = 0;
+
+        // Validate every machine artifact lease before pruning any cache. A
+        // malformed live pointer therefore fails the whole command closed,
+        // without first deleting unrelated generic pack caches.
+        #[cfg(target_os = "linux")]
+        {
+            let report = smolvm::artifact_cache::prune_artifact_caches(keep, self.dry_run)
+                .map_err(|error| {
+                    smolvm::Error::agent("prune shared artifact caches", error.to_string())
+                })?;
+            if report.referenced_entries > 0 {
+                let noun = if report.referenced_entries == 1 {
+                    "entry"
+                } else {
+                    "entries"
+                };
+                println!(
+                    "  retaining {} artifact cache {} referenced by machines",
+                    report.referenced_entries, noun
+                );
+            }
+            for entry in report.entries {
+                let paths = entry
+                    .paths
+                    .iter()
+                    .map(|path| path.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                if self.dry_run {
+                    println!(
+                        "  would remove artifact cache {}: {} ({})",
+                        entry.artifact,
+                        paths,
+                        crate::cli::format_bytes(entry.allocated_bytes)
+                    );
+                } else {
+                    println!(
+                        "  removed artifact cache {}: {} ({})",
+                        entry.artifact,
+                        paths,
+                        crate::cli::format_bytes(entry.allocated_bytes)
+                    );
+                }
+                total_freed = total_freed.saturating_add(entry.allocated_bytes);
+                total_removed += 1;
+            }
+        }
 
         // Clean pack sidecar cache
         if let Some(base) = dirs::cache_dir() {

--- a/src/cli/pack_run.rs
+++ b/src/cli/pack_run.rs
@@ -461,8 +461,14 @@ impl PackRunCmd {
             .storage_template
             .as_ref()
             .map(|t| t.path.as_str());
-        extract::create_or_copy_storage_disk(&cache_dir, template, &storage_path, storage_gib)
-            .map_err(|e| Error::agent("create storage disk", e.to_string()))?;
+        extract::create_or_copy_storage_disk(
+            &cache_dir,
+            template,
+            &storage_path,
+            manifest.assets.storage_logical_size,
+            storage_gib,
+        )
+        .map_err(|e| Error::agent("create storage disk", e.to_string()))?;
 
         let overlay_runtime_path = setup_vm_overlay(
             &manifest,
@@ -1532,8 +1538,14 @@ fn run_from_cache(
         .storage_template
         .as_ref()
         .map(|t| t.path.as_str());
-    extract::create_or_copy_storage_disk(cache_dir, template, &storage_path, storage_gib)
-        .map_err(|e| Error::agent("create storage disk", e.to_string()))?;
+    extract::create_or_copy_storage_disk(
+        cache_dir,
+        template,
+        &storage_path,
+        manifest.assets.storage_logical_size,
+        storage_gib,
+    )
+    .map_err(|e| Error::agent("create storage disk", e.to_string()))?;
 
     let overlay_runtime_path = setup_vm_overlay(
         manifest,
@@ -1933,8 +1945,14 @@ fn daemon_start(
             .storage_template
             .as_ref()
             .map(|t| t.path.as_str());
-        extract::create_or_copy_storage_disk(&cache_dir, template, &storage_path, storage_gib)
-            .map_err(|e| Error::agent("create storage disk", e.to_string()))?;
+        extract::create_or_copy_storage_disk(
+            &cache_dir,
+            template,
+            &storage_path,
+            manifest.assets.storage_logical_size,
+            storage_gib,
+        )
+        .map_err(|e| Error::agent("create storage disk", e.to_string()))?;
     }
 
     // Create overlay disk (preserves existing disk on restart)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,9 @@
 
 pub mod agent;
 pub mod api;
+/// Reference-safe lifecycle management for Linux shared pack and COW caches.
+#[cfg(target_os = "linux")]
+pub mod artifact_cache;
 pub mod config;
 // The shared CUDA daemon manages unix-domain sockets, flock, and detached
 // process groups — all POSIX. GPU acceleration is unavailable on Windows anyway,

--- a/src/pack_export.rs
+++ b/src/pack_export.rs
@@ -98,6 +98,7 @@ pub fn collect_from_vm_assets(
 
     let vm_dir = vm_data_dir(vm_name);
     let (overlay_disk, overlay_fmt) = resolve_disk_image(&vm_dir, OVERLAY_DISK_FILENAME);
+    let (storage_disk, storage_fmt) = resolve_disk_image(&vm_dir, STORAGE_DISK_FILENAME);
     let is_image_based = vm.image.is_some();
     let is_artifact_sourced = is_image_based && vm.source_smolmachine.is_some();
 
@@ -155,6 +156,25 @@ pub fn collect_from_vm_assets(
         collector
             .add_overlay_template(&overlay_for_pack)
             .map_err(|e| Error::agent("collect overlay", e.to_string()))?;
+
+        if !storage_disk.exists() {
+            return Err(Error::agent(
+                "collect storage",
+                format!("storage disk not found at {}", storage_disk.display()),
+            ));
+        }
+        let storage_for_pack = match storage_fmt {
+            DiskFormat::Raw => storage_disk.clone(),
+            DiskFormat::Qcow2 => {
+                let flat = staging_dir.join("storage-flat.raw");
+                flatten_qcow2_to_raw(&storage_disk, &flat)?;
+                flat
+            }
+        };
+        println!("Copying storage disk ({})...", storage_for_pack.display());
+        collector
+            .add_vm_storage_template(&storage_for_pack)
+            .map_err(|e| Error::agent("collect storage", e.to_string()))?;
     }
 
     Ok(FromVmAssets {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -27,6 +27,13 @@ use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
 
+#[cfg(any(target_os = "linux", all(test, unix)))]
+use std::os::fd::AsRawFd;
+#[cfg(any(target_os = "linux", all(test, unix)))]
+use std::os::unix::fs::PermissionsExt;
+#[cfg(any(target_os = "linux", all(test, unix)))]
+use std::sync::atomic::{AtomicU64, Ordering};
+
 /// Seed a VM-mode machine's overlay+storage disks from extracted pack templates so
 /// it boots the source VM's filesystem rather than a freshly-mkfs'd empty overlay.
 ///
@@ -34,9 +41,12 @@ use std::path::{Path, PathBuf};
 /// template has its trailing zero extent stripped, so the disk must be grown back to
 /// its logical size before boot. The caller's [`AgentManager`] has already created
 /// default `.qcow2` overlays backed by the EMPTY default template; this removes them
-/// and writes the seeded RAW disks under their place so [`resolve_disk_image`] picks
-/// these at start. A `.formatted` marker stops the host from reformatting the
-/// inherited (already-formatted) filesystem; the guest still grows it with resize2fs.
+/// and replaces them with disks backed by the packed image. On Linux, a shared
+/// extraction with an artifact SHA-256 creates one immutable, normalized raw base
+/// per artifact/disk/size and gives every machine a tiny qcow2 overlay. macOS keeps
+/// using APFS clonefile, while unsupported qcow2 hosts retain the sparse-copy path.
+/// A `.formatted` marker stops the host from reformatting the inherited filesystem;
+/// the guest still grows it with resize2fs.
 ///
 /// The template → disk copy uses [`crate::disk_utils::clone_or_copy_file`] (clonefile
 /// CoW on macOS, `SEEK_HOLE` sparse copy on Linux), NOT a dense `fs::copy`: the
@@ -49,14 +59,29 @@ use std::path::{Path, PathBuf};
 ///
 /// [`AgentManager`]: crate::agent::AgentManager
 /// [`resolve_disk_image`]: crate::agent::manager::resolve_disk_image
+#[derive(Debug, Clone, Copy)]
+pub struct VmModeDiskSeedSpec<'a> {
+    /// SHA-256 of the source pack, used to key immutable Linux COW bases.
+    pub artifact_sha256: Option<&'a str>,
+    /// Relative path to the packed root overlay template.
+    pub overlay_template: Option<&'a str>,
+    /// Relative path to the packed persistent storage template.
+    pub storage_template: Option<&'a str>,
+    /// Logical byte length to restore for the root overlay.
+    pub overlay_logical_size: Option<u64>,
+    /// Logical byte length to restore for persistent storage.
+    pub storage_logical_size: Option<u64>,
+    /// Requested root overlay size when the manifest lacks a logical length.
+    pub overlay_gb: Option<u64>,
+    /// Requested storage size when the manifest lacks a logical length.
+    pub storage_gb: Option<u64>,
+}
+
+/// Seeds one VM-mode machine from the extracted pack disk templates.
 pub fn seed_vm_mode_disks(
     disk_dir: &Path,
     cache_dir: &Path,
-    overlay_template: Option<&str>,
-    storage_template: Option<&str>,
-    overlay_logical_size: Option<u64>,
-    overlay_gb: Option<u64>,
-    storage_gb: Option<u64>,
+    seed: VmModeDiskSeedSpec<'_>,
 ) -> std::io::Result<()> {
     // Drop the manager's default qcow2 overlays (backed by the empty default
     // template) so the seeded raw disks below are what start resolves.
@@ -65,24 +90,295 @@ pub fn seed_vm_mode_disks(
         let _ = std::fs::remove_file(disk_dir.join(stem.with_extension("qcow2")));
     }
 
-    // The overlay carries the rootfs and is grown back to its (pre-truncation)
-    // logical size; storage to the requested size. Both VM-mode templates are
-    // normally present, but tolerate a missing one with an empty disk.
+    #[cfg(target_os = "linux")]
+    if let Some(artifact_sha256) = seed.artifact_sha256 {
+        if try_seed_vm_mode_disks_cow(
+            disk_dir,
+            cache_dir,
+            artifact_sha256,
+            seed,
+            crate::agent::create_disk_overlays,
+        )? {
+            return Ok(());
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    let _ = seed.artifact_sha256;
+
+    seed_vm_mode_disks_by_copy(disk_dir, cache_dir, seed)
+}
+
+/// Portable sparse-copy fallback for VM-mode disks.
+fn seed_vm_mode_disks_by_copy(
+    disk_dir: &Path,
+    cache_dir: &Path,
+    seed: VmModeDiskSeedSpec<'_>,
+) -> std::io::Result<()> {
     seed_one_disk(
         cache_dir,
-        overlay_template,
+        seed.overlay_template,
         &disk_dir.join(OVERLAY_DISK_FILENAME),
-        overlay_logical_size,
-        overlay_gb,
+        seed.overlay_logical_size,
+        seed.overlay_gb,
     )?;
     seed_one_disk(
         cache_dir,
-        storage_template,
+        seed.storage_template,
         &disk_dir.join(STORAGE_DISK_FILENAME),
-        None,
-        storage_gb,
-    )?;
-    Ok(())
+        seed.storage_logical_size,
+        seed.storage_gb,
+    )
+}
+
+#[cfg(any(target_os = "linux", all(test, unix)))]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct CowBaseMetadata {
+    artifact_sha256: String,
+    disk_type: String,
+    source_template: String,
+    source_size: u64,
+    logical_size: u64,
+}
+
+#[cfg(any(target_os = "linux", all(test, unix)))]
+static COW_BASE_STAGING_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+/// Build all immutable bases first, then create both private overlays in one
+/// libkrun load. A missing/corrupt base is a hard error; only an unavailable
+/// qcow2 implementation falls back to the existing sparse-copy behavior.
+#[cfg(any(target_os = "linux", all(test, unix)))]
+fn try_seed_vm_mode_disks_cow<F>(
+    disk_dir: &Path,
+    cache_dir: &Path,
+    artifact_sha256: &str,
+    seed: VmModeDiskSeedSpec<'_>,
+    create_overlays: F,
+) -> std::io::Result<bool>
+where
+    F: FnOnce(&[crate::agent::DiskOverlaySpec]) -> crate::Result<()>,
+{
+    validate_artifact_sha256(artifact_sha256)?;
+    let definitions = [
+        (
+            "overlay",
+            seed.overlay_template,
+            disk_dir.join(OVERLAY_DISK_FILENAME),
+            seed.overlay_logical_size,
+            seed.overlay_gb,
+        ),
+        (
+            "storage",
+            seed.storage_template,
+            disk_dir.join(STORAGE_DISK_FILENAME),
+            seed.storage_logical_size,
+            seed.storage_gb,
+        ),
+    ];
+
+    let mut overlay_specs = Vec::with_capacity(2);
+    let mut overlay_paths = Vec::with_capacity(2);
+    for (disk_type, template, dest, logical_size, size_gb_override) in &definitions {
+        let Some(template) = template else {
+            continue;
+        };
+        let source = resolve_template_in_cache(cache_dir, template)?;
+        let source_size = std::fs::metadata(&source)
+            .map_err(|error| {
+                std::io::Error::new(
+                    error.kind(),
+                    format!("VM-mode template {}: {error}", source.display()),
+                )
+            })?
+            .len();
+        let target_size = disk_target_size(source_size, *logical_size, *size_gb_override)?;
+        let base = prepare_cow_base(
+            cache_dir,
+            artifact_sha256,
+            disk_type,
+            template,
+            &source,
+            source_size,
+            target_size,
+        )?;
+        let overlay = dest.with_extension("qcow2");
+        let _ = std::fs::remove_file(dest);
+        let _ = std::fs::remove_file(dest.with_extension("formatted"));
+        let _ = std::fs::remove_file(&overlay);
+        overlay_specs.push((overlay.clone(), base, DiskFormat::Raw));
+        overlay_paths.push(overlay);
+    }
+
+    if overlay_specs.is_empty() {
+        return Ok(false);
+    }
+
+    if let Err(error) = create_overlays(&overlay_specs) {
+        for overlay in &overlay_paths {
+            let _ = std::fs::remove_file(overlay);
+        }
+        tracing::warn!(
+            %error,
+            "VM-mode qcow2 overlay creation unavailable; falling back to sparse disk copies"
+        );
+        return Ok(false);
+    }
+
+    for (_, template, dest, _, size_gb_override) in definitions {
+        if template.is_some() {
+            std::fs::write(dest.with_extension("formatted"), b"1")?;
+        } else {
+            seed_one_disk(cache_dir, None, &dest, None, size_gb_override)?;
+        }
+    }
+    Ok(true)
+}
+
+#[cfg(any(target_os = "linux", all(test, unix)))]
+fn validate_artifact_sha256(digest: &str) -> std::io::Result<()> {
+    if digest.len() == 64
+        && digest
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Ok(());
+    }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        "artifact SHA-256 must be 64 lowercase hexadecimal characters",
+    ))
+}
+
+#[cfg(any(target_os = "linux", all(test, unix)))]
+fn disk_target_size(
+    source_size: u64,
+    logical_size: Option<u64>,
+    size_gb_override: Option<u64>,
+) -> std::io::Result<u64> {
+    let requested_size = size_gb_override
+        .map(|gb| {
+            gb.checked_mul(BYTES_PER_GIB).ok_or_else(|| {
+                std::io::Error::new(std::io::ErrorKind::InvalidInput, "disk size overflow")
+            })
+        })
+        .transpose()?;
+    Ok([Some(source_size), logical_size, requested_size]
+        .into_iter()
+        .flatten()
+        .max()
+        .unwrap_or(source_size))
+}
+
+/// Return one immutable normalized raw base, creating it atomically on the
+/// first request. The final directory is the completion marker: readers can
+/// never observe a base without matching metadata.
+#[cfg(any(target_os = "linux", all(test, unix)))]
+#[allow(clippy::too_many_arguments)]
+fn prepare_cow_base(
+    cache_dir: &Path,
+    artifact_sha256: &str,
+    disk_type: &str,
+    source_template: &str,
+    source: &Path,
+    source_size: u64,
+    logical_size: u64,
+) -> std::io::Result<PathBuf> {
+    validate_artifact_sha256(artifact_sha256)?;
+    let digest_dir = cache_dir.join(".cow-bases").join(artifact_sha256);
+    std::fs::create_dir_all(&digest_dir)?;
+    std::fs::set_permissions(&digest_dir, std::fs::Permissions::from_mode(0o700))?;
+
+    let key = format!("{disk_type}-{logical_size}");
+    let final_dir = digest_dir.join(&key);
+    let lock_path = digest_dir.join(format!("{key}.lock"));
+    let lock_file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(lock_path)?;
+    let lock_result = unsafe { libc::flock(lock_file.as_raw_fd(), libc::LOCK_EX) };
+    if lock_result != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    let expected = CowBaseMetadata {
+        artifact_sha256: artifact_sha256.to_string(),
+        disk_type: disk_type.to_string(),
+        source_template: source_template.to_string(),
+        source_size,
+        logical_size,
+    };
+    if final_dir.exists() {
+        return validate_cow_base(&final_dir, &expected);
+    }
+
+    let sequence = COW_BASE_STAGING_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let staging_dir = digest_dir.join(format!(".{key}.tmp-{}-{sequence}", std::process::id()));
+    let result = (|| {
+        std::fs::create_dir(&staging_dir)?;
+        let base = staging_dir.join("base.raw");
+        crate::disk_utils::clone_or_copy_file(source, &base)
+            .map_err(|error| std::io::Error::other(error.to_string()))?;
+        let file = std::fs::OpenOptions::new().write(true).open(&base)?;
+        file.set_len(logical_size)?;
+        file.sync_all()?;
+        std::fs::set_permissions(&base, std::fs::Permissions::from_mode(0o444))?;
+
+        let metadata_bytes = serde_json::to_vec_pretty(&expected)
+            .map_err(|error| std::io::Error::other(error.to_string()))?;
+        let metadata_path = staging_dir.join("metadata.json");
+        let mut metadata_file = std::fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&metadata_path)?;
+        use std::io::Write as _;
+        metadata_file.write_all(&metadata_bytes)?;
+        metadata_file.sync_all()?;
+        std::fs::set_permissions(&metadata_path, std::fs::Permissions::from_mode(0o444))?;
+        std::fs::set_permissions(&staging_dir, std::fs::Permissions::from_mode(0o555))?;
+        std::fs::rename(&staging_dir, &final_dir)?;
+        validate_cow_base(&final_dir, &expected)
+    })();
+    if result.is_err() && staging_dir.exists() {
+        let _ = std::fs::set_permissions(&staging_dir, std::fs::Permissions::from_mode(0o700));
+        let _ = std::fs::remove_dir_all(&staging_dir);
+    }
+    result
+}
+
+#[cfg(any(target_os = "linux", all(test, unix)))]
+fn validate_cow_base(base_dir: &Path, expected: &CowBaseMetadata) -> std::io::Result<PathBuf> {
+    let base = base_dir.join("base.raw");
+    let metadata_path = base_dir.join("metadata.json");
+    let actual: CowBaseMetadata =
+        serde_json::from_slice(&std::fs::read(&metadata_path)?).map_err(|error| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "corrupt COW base metadata {}: {error}",
+                    metadata_path.display()
+                ),
+            )
+        })?;
+    if &actual != expected {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("COW base metadata mismatch: {}", base_dir.display()),
+        ));
+    }
+    let file_metadata = std::fs::metadata(&base)?;
+    if !file_metadata.is_file() || file_metadata.len() != expected.logical_size {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("COW base has an unsafe size or type: {}", base.display()),
+        ));
+    }
+    if file_metadata.permissions().mode() & 0o222 != 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("COW base is writable: {}", base.display()),
+        ));
+    }
+    base.canonicalize()
 }
 
 /// Sparse-copy one packed template into `dest`, grow it to the largest of its copied
@@ -545,6 +841,293 @@ pub fn expand_disk<D: DiskType>(path: &Path, new_size_gb: u64) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    const TEST_ARTIFACT_SHA256: &str =
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    #[cfg(unix)]
+    fn write_sparse_template(path: &Path, logical_size: u64, marker: &[u8]) {
+        let mut file = std::fs::File::create(path).unwrap();
+        use std::io::Write as _;
+        file.write_all(marker).unwrap();
+        file.set_len(logical_size).unwrap();
+    }
+
+    #[cfg(unix)]
+    fn make_fake_overlays(specs: &[crate::agent::DiskOverlaySpec]) -> crate::Result<()> {
+        for (overlay, _, _) in specs {
+            let mut file = std::fs::File::create(overlay)?;
+            use std::io::Write as _;
+            file.write_all(b"QFI\xfb")?;
+            file.set_len(256 * 1024)?;
+        }
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    fn make_tree_removable(root: &Path) {
+        if let Ok(entries) = std::fs::read_dir(root) {
+            for entry in entries.flatten() {
+                if entry.path().is_dir() {
+                    make_tree_removable(&entry.path());
+                }
+            }
+        }
+        let _ = std::fs::set_permissions(root, std::fs::Permissions::from_mode(0o700));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn vm_mode_cow_uses_tiny_private_disks_and_one_immutable_base() {
+        let temp = tempfile::tempdir().unwrap();
+        let cache = temp.path().join("shared-pack");
+        let first = temp.path().join("machine-a");
+        let second = temp.path().join("machine-b");
+        std::fs::create_dir_all(&cache).unwrap();
+        std::fs::create_dir_all(&first).unwrap();
+        std::fs::create_dir_all(&second).unwrap();
+        write_sparse_template(&cache.join("overlay.raw"), 2 * 1024 * 1024, b"root-a");
+        write_sparse_template(&cache.join("storage.raw"), 1024 * 1024, b"data-a");
+
+        for machine in [&first, &second] {
+            assert!(try_seed_vm_mode_disks_cow(
+                machine,
+                &cache,
+                TEST_ARTIFACT_SHA256,
+                VmModeDiskSeedSpec {
+                    artifact_sha256: Some(TEST_ARTIFACT_SHA256),
+                    overlay_template: Some("overlay.raw"),
+                    storage_template: Some("storage.raw"),
+                    overlay_logical_size: Some(4 * 1024 * 1024),
+                    storage_logical_size: Some(3 * 1024 * 1024),
+                    overlay_gb: None,
+                    storage_gb: None,
+                },
+                make_fake_overlays,
+            )
+            .unwrap());
+            for disk in ["overlay.qcow2", "storage.qcow2"] {
+                let metadata = std::fs::metadata(machine.join(disk)).unwrap();
+                assert_eq!(metadata.len(), 256 * 1024, "private disk must stay tiny");
+            }
+            assert!(!machine.join(OVERLAY_DISK_FILENAME).exists());
+            assert!(!machine.join(STORAGE_DISK_FILENAME).exists());
+            assert!(machine.join("overlay.formatted").exists());
+            assert!(machine.join("storage.formatted").exists());
+        }
+
+        let base_root = cache.join(".cow-bases").join(TEST_ARTIFACT_SHA256);
+        let bases: Vec<_> = std::fs::read_dir(&base_root)
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.path().is_dir())
+            .collect();
+        assert_eq!(bases.len(), 2, "one normalized base per disk type");
+        for entry in &bases {
+            let base = entry.path().join("base.raw");
+            assert_eq!(
+                std::fs::metadata(base).unwrap().permissions().mode() & 0o222,
+                0
+            );
+        }
+
+        std::fs::write(first.join("overlay.qcow2"), b"first-private").unwrap();
+        assert_eq!(
+            std::fs::read(second.join("overlay.qcow2")).unwrap()[..4],
+            *b"QFI\xfb"
+        );
+        assert_eq!(
+            std::fs::read(base_root.join("overlay-4194304/base.raw")).unwrap()[..6],
+            *b"root-a"
+        );
+
+        std::fs::remove_dir_all(&first).unwrap();
+        assert!(second.join("overlay.qcow2").exists());
+        assert!(
+            bases.iter().all(|entry| entry.path().exists()),
+            "deleting a sibling must retain shared bases"
+        );
+        make_tree_removable(&cache);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn concurrent_first_cow_base_creation_is_atomic() {
+        use std::sync::{Arc, Barrier};
+
+        let temp = tempfile::tempdir().unwrap();
+        let cache = temp.path().join("shared-pack");
+        std::fs::create_dir_all(&cache).unwrap();
+        let source = cache.join("overlay.raw");
+        write_sparse_template(&source, 1024 * 1024, b"root");
+        let barrier = Arc::new(Barrier::new(8));
+        let mut workers = Vec::new();
+        for _ in 0..8 {
+            let cache = cache.clone();
+            let source = source.clone();
+            let barrier = Arc::clone(&barrier);
+            workers.push(std::thread::spawn(move || {
+                barrier.wait();
+                prepare_cow_base(
+                    &cache,
+                    TEST_ARTIFACT_SHA256,
+                    "overlay",
+                    "overlay.raw",
+                    &source,
+                    1024 * 1024,
+                    4 * 1024 * 1024,
+                )
+                .unwrap()
+            }));
+        }
+        let paths: Vec<_> = workers
+            .into_iter()
+            .map(|worker| worker.join().unwrap())
+            .collect();
+        assert!(paths.iter().all(|path| path == &paths[0]));
+        assert_eq!(std::fs::metadata(&paths[0]).unwrap().len(), 4 * 1024 * 1024);
+        let digest_dir = cache.join(".cow-bases").join(TEST_ARTIFACT_SHA256);
+        assert_eq!(
+            std::fs::read_dir(&digest_dir)
+                .unwrap()
+                .filter_map(|entry| entry.ok())
+                .filter(|entry| entry.path().is_dir())
+                .count(),
+            1
+        );
+        make_tree_removable(&cache);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn corrupt_cow_base_is_rejected_without_replacement() {
+        let temp = tempfile::tempdir().unwrap();
+        let cache = temp.path().join("shared-pack");
+        std::fs::create_dir_all(&cache).unwrap();
+        let source = cache.join("overlay.raw");
+        write_sparse_template(&source, 1024 * 1024, b"root");
+        let base = prepare_cow_base(
+            &cache,
+            TEST_ARTIFACT_SHA256,
+            "overlay",
+            "overlay.raw",
+            &source,
+            1024 * 1024,
+            2 * 1024 * 1024,
+        )
+        .unwrap();
+        std::fs::set_permissions(&base, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let error = prepare_cow_base(
+            &cache,
+            TEST_ARTIFACT_SHA256,
+            "overlay",
+            "overlay.raw",
+            &source,
+            1024 * 1024,
+            2 * 1024 * 1024,
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("writable"));
+        assert_eq!(std::fs::metadata(&base).unwrap().len(), 2 * 1024 * 1024);
+        make_tree_removable(&cache);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn missing_file_in_completed_cow_base_fails_without_rebuilding() {
+        let temp = tempfile::tempdir().unwrap();
+        let cache = temp.path().join("shared-pack");
+        std::fs::create_dir_all(&cache).unwrap();
+        let source = cache.join("overlay.raw");
+        write_sparse_template(&source, 1024 * 1024, b"root");
+        let base = prepare_cow_base(
+            &cache,
+            TEST_ARTIFACT_SHA256,
+            "overlay",
+            "overlay.raw",
+            &source,
+            1024 * 1024,
+            2 * 1024 * 1024,
+        )
+        .unwrap();
+        let base_dir = base.parent().unwrap();
+        std::fs::set_permissions(base_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::remove_file(&base).unwrap();
+        std::fs::set_permissions(base_dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        let error = prepare_cow_base(
+            &cache,
+            TEST_ARTIFACT_SHA256,
+            "overlay",
+            "overlay.raw",
+            &source,
+            1024 * 1024,
+            2 * 1024 * 1024,
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
+        assert!(
+            !base.exists(),
+            "a completed but broken base is never replaced"
+        );
+        make_tree_removable(&cache);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn unavailable_qcow_support_leaves_no_partial_overlay_and_copy_fallback_works() {
+        let temp = tempfile::tempdir().unwrap();
+        let cache = temp.path().join("shared-pack");
+        let machine = temp.path().join("machine");
+        std::fs::create_dir_all(&cache).unwrap();
+        std::fs::create_dir_all(&machine).unwrap();
+        write_sparse_template(&cache.join("overlay.raw"), 1024 * 1024, b"root");
+        let used_cow = try_seed_vm_mode_disks_cow(
+            &machine,
+            &cache,
+            TEST_ARTIFACT_SHA256,
+            VmModeDiskSeedSpec {
+                artifact_sha256: Some(TEST_ARTIFACT_SHA256),
+                overlay_template: Some("overlay.raw"),
+                storage_template: None,
+                overlay_logical_size: None,
+                storage_logical_size: None,
+                overlay_gb: None,
+                storage_gb: None,
+            },
+            |specs| {
+                std::fs::write(&specs[0].0, b"partial")?;
+                Err(Error::agent("create disk overlay", "unsupported"))
+            },
+        )
+        .unwrap();
+        assert!(!used_cow);
+        assert!(!machine.join("overlay.qcow2").exists());
+        seed_vm_mode_disks_by_copy(
+            &machine,
+            &cache,
+            VmModeDiskSeedSpec {
+                artifact_sha256: None,
+                overlay_template: Some("overlay.raw"),
+                storage_template: None,
+                overlay_logical_size: Some(2 * 1024 * 1024),
+                storage_logical_size: None,
+                overlay_gb: None,
+                storage_gb: None,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            std::fs::metadata(machine.join(OVERLAY_DISK_FILENAME))
+                .unwrap()
+                .len(),
+            2 * 1024 * 1024
+        );
+        assert!(machine.join("overlay.formatted").exists());
+        make_tree_removable(&cache);
+    }
 
     #[test]
     fn test_disk_version_compatibility() {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -92,6 +92,9 @@ pub fn seed_vm_mode_disks(
 
     #[cfg(target_os = "linux")]
     if let Some(artifact_sha256) = seed.artifact_sha256 {
+        // `.pack-shared` is the durable lease used by reference-aware pruning.
+        // Never publish a qcow2 backing dependency that has no matching lease.
+        crate::artifact_cache::validate_cow_lease(disk_dir, cache_dir, artifact_sha256)?;
         if try_seed_vm_mode_disks_cow(
             disk_dir,
             cache_dir,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -95,6 +95,7 @@ pub fn seed_vm_mode_disks(
         if try_seed_vm_mode_disks_cow(
             disk_dir,
             cache_dir,
+            &cow_base_cache_root(),
             artifact_sha256,
             seed,
             crate::agent::create_disk_overlays,
@@ -143,6 +144,16 @@ struct CowBaseMetadata {
 #[cfg(target_os = "linux")]
 static COW_BASE_STAGING_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
+/// Root for immutable VM-mode disk bases. Keep it outside the root-only shared
+/// pack extraction tree: each VMM drops to a distinct uid before libkrun opens
+/// its qcow2 backing files, so those uids must be able to traverse the base
+/// path. Directories below this root are execute-only to other uids and the VMM
+/// is still Landlock-confined to its exact backing chain.
+#[cfg(target_os = "linux")]
+pub(crate) fn cow_base_cache_root() -> PathBuf {
+    crate::agent::vm_cache_root().join("_cow-bases")
+}
+
 /// Build all immutable bases first, then create both private overlays in one
 /// libkrun load. A missing/corrupt base is a hard error; only an unavailable
 /// qcow2 implementation falls back to the existing sparse-copy behavior.
@@ -150,6 +161,7 @@ static COW_BASE_STAGING_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 fn try_seed_vm_mode_disks_cow<F>(
     disk_dir: &Path,
     cache_dir: &Path,
+    base_cache_root: &Path,
     artifact_sha256: &str,
     seed: VmModeDiskSeedSpec<'_>,
     create_overlays: F,
@@ -192,7 +204,7 @@ where
             .len();
         let target_size = disk_target_size(source_size, *logical_size, *size_gb_override)?;
         let base = prepare_cow_base(
-            cache_dir,
+            base_cache_root,
             artifact_sha256,
             disk_type,
             template,
@@ -274,7 +286,7 @@ fn disk_target_size(
 #[cfg(target_os = "linux")]
 #[allow(clippy::too_many_arguments)]
 fn prepare_cow_base(
-    cache_dir: &Path,
+    base_cache_root: &Path,
     artifact_sha256: &str,
     disk_type: &str,
     source_template: &str,
@@ -283,9 +295,11 @@ fn prepare_cow_base(
     logical_size: u64,
 ) -> std::io::Result<PathBuf> {
     validate_artifact_sha256(artifact_sha256)?;
-    let digest_dir = cache_dir.join(".cow-bases").join(artifact_sha256);
+    std::fs::create_dir_all(base_cache_root)?;
+    std::fs::set_permissions(base_cache_root, std::fs::Permissions::from_mode(0o711))?;
+    let digest_dir = base_cache_root.join(artifact_sha256);
     std::fs::create_dir_all(&digest_dir)?;
-    std::fs::set_permissions(&digest_dir, std::fs::Permissions::from_mode(0o700))?;
+    std::fs::set_permissions(&digest_dir, std::fs::Permissions::from_mode(0o711))?;
 
     let key = format!("{disk_type}-{logical_size}");
     let final_dir = digest_dir.join(&key);
@@ -882,6 +896,7 @@ mod tests {
     fn vm_mode_cow_uses_tiny_private_disks_and_one_immutable_base() {
         let temp = tempfile::tempdir().unwrap();
         let cache = temp.path().join("shared-pack");
+        let base_cache = temp.path().join("cow-bases");
         let first = temp.path().join("machine-a");
         let second = temp.path().join("machine-b");
         std::fs::create_dir_all(&cache).unwrap();
@@ -894,6 +909,7 @@ mod tests {
             assert!(try_seed_vm_mode_disks_cow(
                 machine,
                 &cache,
+                &base_cache,
                 TEST_ARTIFACT_SHA256,
                 VmModeDiskSeedSpec {
                     artifact_sha256: Some(TEST_ARTIFACT_SHA256),
@@ -917,7 +933,17 @@ mod tests {
             assert!(machine.join("storage.formatted").exists());
         }
 
-        let base_root = cache.join(".cow-bases").join(TEST_ARTIFACT_SHA256);
+        assert_eq!(
+            std::fs::metadata(&base_cache).unwrap().permissions().mode() & 0o777,
+            0o711,
+            "the uid-dropped VMM must be able to traverse the shared base store"
+        );
+        let base_root = base_cache.join(TEST_ARTIFACT_SHA256);
+        assert_eq!(
+            std::fs::metadata(&base_root).unwrap().permissions().mode() & 0o777,
+            0o711,
+            "the artifact digest directory must be traversable but non-listable"
+        );
         let bases: Vec<_> = std::fs::read_dir(&base_root)
             .unwrap()
             .filter_map(|entry| entry.ok())
@@ -926,9 +952,12 @@ mod tests {
         assert_eq!(bases.len(), 2, "one normalized base per disk type");
         for entry in &bases {
             let base = entry.path().join("base.raw");
-            assert_eq!(
-                std::fs::metadata(base).unwrap().permissions().mode() & 0o222,
-                0
+            let metadata = std::fs::metadata(base).unwrap();
+            assert_eq!(metadata.permissions().mode() & 0o222, 0);
+            use std::os::unix::fs::MetadataExt as _;
+            assert!(
+                metadata.blocks() * 512 < metadata.len() / 2,
+                "restoring the logical tail must keep the immutable base sparse"
             );
         }
 
@@ -949,6 +978,7 @@ mod tests {
             "deleting a sibling must retain shared bases"
         );
         make_tree_removable(&cache);
+        make_tree_removable(&base_cache);
     }
 
     #[test]
@@ -958,19 +988,20 @@ mod tests {
 
         let temp = tempfile::tempdir().unwrap();
         let cache = temp.path().join("shared-pack");
+        let base_cache = temp.path().join("cow-bases");
         std::fs::create_dir_all(&cache).unwrap();
         let source = cache.join("overlay.raw");
         write_sparse_template(&source, 1024 * 1024, b"root");
         let barrier = Arc::new(Barrier::new(8));
         let mut workers = Vec::new();
         for _ in 0..8 {
-            let cache = cache.clone();
+            let base_cache = base_cache.clone();
             let source = source.clone();
             let barrier = Arc::clone(&barrier);
             workers.push(std::thread::spawn(move || {
                 barrier.wait();
                 prepare_cow_base(
-                    &cache,
+                    &base_cache,
                     TEST_ARTIFACT_SHA256,
                     "overlay",
                     "overlay.raw",
@@ -987,7 +1018,7 @@ mod tests {
             .collect();
         assert!(paths.iter().all(|path| path == &paths[0]));
         assert_eq!(std::fs::metadata(&paths[0]).unwrap().len(), 4 * 1024 * 1024);
-        let digest_dir = cache.join(".cow-bases").join(TEST_ARTIFACT_SHA256);
+        let digest_dir = base_cache.join(TEST_ARTIFACT_SHA256);
         assert_eq!(
             std::fs::read_dir(&digest_dir)
                 .unwrap()
@@ -997,6 +1028,7 @@ mod tests {
             1
         );
         make_tree_removable(&cache);
+        make_tree_removable(&base_cache);
     }
 
     #[test]
@@ -1004,11 +1036,12 @@ mod tests {
     fn corrupt_cow_base_is_rejected_without_replacement() {
         let temp = tempfile::tempdir().unwrap();
         let cache = temp.path().join("shared-pack");
+        let base_cache = temp.path().join("cow-bases");
         std::fs::create_dir_all(&cache).unwrap();
         let source = cache.join("overlay.raw");
         write_sparse_template(&source, 1024 * 1024, b"root");
         let base = prepare_cow_base(
-            &cache,
+            &base_cache,
             TEST_ARTIFACT_SHA256,
             "overlay",
             "overlay.raw",
@@ -1019,7 +1052,7 @@ mod tests {
         .unwrap();
         std::fs::set_permissions(&base, std::fs::Permissions::from_mode(0o644)).unwrap();
         let error = prepare_cow_base(
-            &cache,
+            &base_cache,
             TEST_ARTIFACT_SHA256,
             "overlay",
             "overlay.raw",
@@ -1032,6 +1065,7 @@ mod tests {
         assert!(error.to_string().contains("writable"));
         assert_eq!(std::fs::metadata(&base).unwrap().len(), 2 * 1024 * 1024);
         make_tree_removable(&cache);
+        make_tree_removable(&base_cache);
     }
 
     #[test]
@@ -1039,11 +1073,12 @@ mod tests {
     fn missing_file_in_completed_cow_base_fails_without_rebuilding() {
         let temp = tempfile::tempdir().unwrap();
         let cache = temp.path().join("shared-pack");
+        let base_cache = temp.path().join("cow-bases");
         std::fs::create_dir_all(&cache).unwrap();
         let source = cache.join("overlay.raw");
         write_sparse_template(&source, 1024 * 1024, b"root");
         let base = prepare_cow_base(
-            &cache,
+            &base_cache,
             TEST_ARTIFACT_SHA256,
             "overlay",
             "overlay.raw",
@@ -1058,7 +1093,7 @@ mod tests {
         std::fs::set_permissions(base_dir, std::fs::Permissions::from_mode(0o555)).unwrap();
 
         let error = prepare_cow_base(
-            &cache,
+            &base_cache,
             TEST_ARTIFACT_SHA256,
             "overlay",
             "overlay.raw",
@@ -1073,6 +1108,7 @@ mod tests {
             "a completed but broken base is never replaced"
         );
         make_tree_removable(&cache);
+        make_tree_removable(&base_cache);
     }
 
     #[test]
@@ -1080,6 +1116,7 @@ mod tests {
     fn unavailable_qcow_support_leaves_no_partial_overlay_and_copy_fallback_works() {
         let temp = tempfile::tempdir().unwrap();
         let cache = temp.path().join("shared-pack");
+        let base_cache = temp.path().join("cow-bases");
         let machine = temp.path().join("machine");
         std::fs::create_dir_all(&cache).unwrap();
         std::fs::create_dir_all(&machine).unwrap();
@@ -1087,6 +1124,7 @@ mod tests {
         let used_cow = try_seed_vm_mode_disks_cow(
             &machine,
             &cache,
+            &base_cache,
             TEST_ARTIFACT_SHA256,
             VmModeDiskSeedSpec {
                 artifact_sha256: Some(TEST_ARTIFACT_SHA256),
@@ -1127,6 +1165,7 @@ mod tests {
         );
         assert!(machine.join("overlay.formatted").exists());
         make_tree_removable(&cache);
+        make_tree_removable(&base_cache);
     }
 
     #[test]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -27,11 +27,11 @@ use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
 
-#[cfg(any(target_os = "linux", all(test, unix)))]
+#[cfg(target_os = "linux")]
 use std::os::fd::AsRawFd;
-#[cfg(any(target_os = "linux", all(test, unix)))]
+#[cfg(target_os = "linux")]
 use std::os::unix::fs::PermissionsExt;
-#[cfg(any(target_os = "linux", all(test, unix)))]
+#[cfg(target_os = "linux")]
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Seed a VM-mode machine's overlay+storage disks from extracted pack templates so
@@ -130,7 +130,7 @@ fn seed_vm_mode_disks_by_copy(
     )
 }
 
-#[cfg(any(target_os = "linux", all(test, unix)))]
+#[cfg(target_os = "linux")]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 struct CowBaseMetadata {
     artifact_sha256: String,
@@ -140,13 +140,13 @@ struct CowBaseMetadata {
     logical_size: u64,
 }
 
-#[cfg(any(target_os = "linux", all(test, unix)))]
+#[cfg(target_os = "linux")]
 static COW_BASE_STAGING_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 /// Build all immutable bases first, then create both private overlays in one
 /// libkrun load. A missing/corrupt base is a hard error; only an unavailable
 /// qcow2 implementation falls back to the existing sparse-copy behavior.
-#[cfg(any(target_os = "linux", all(test, unix)))]
+#[cfg(target_os = "linux")]
 fn try_seed_vm_mode_disks_cow<F>(
     disk_dir: &Path,
     cache_dir: &Path,
@@ -233,7 +233,7 @@ where
     Ok(true)
 }
 
-#[cfg(any(target_os = "linux", all(test, unix)))]
+#[cfg(target_os = "linux")]
 fn validate_artifact_sha256(digest: &str) -> std::io::Result<()> {
     if digest.len() == 64
         && digest
@@ -248,7 +248,7 @@ fn validate_artifact_sha256(digest: &str) -> std::io::Result<()> {
     ))
 }
 
-#[cfg(any(target_os = "linux", all(test, unix)))]
+#[cfg(target_os = "linux")]
 fn disk_target_size(
     source_size: u64,
     logical_size: Option<u64>,
@@ -271,7 +271,7 @@ fn disk_target_size(
 /// Return one immutable normalized raw base, creating it atomically on the
 /// first request. The final directory is the completion marker: readers can
 /// never observe a base without matching metadata.
-#[cfg(any(target_os = "linux", all(test, unix)))]
+#[cfg(target_os = "linux")]
 #[allow(clippy::too_many_arguments)]
 fn prepare_cow_base(
     cache_dir: &Path,
@@ -345,7 +345,7 @@ fn prepare_cow_base(
     result
 }
 
-#[cfg(any(target_os = "linux", all(test, unix)))]
+#[cfg(target_os = "linux")]
 fn validate_cow_base(base_dir: &Path, expected: &CowBaseMetadata) -> std::io::Result<PathBuf> {
     let base = base_dir.join("base.raw");
     let metadata_path = base_dir.join("metadata.json");
@@ -842,11 +842,11 @@ pub fn expand_disk<D: DiskType>(path: &Path, new_size_gb: u64) -> Result<()> {
 mod tests {
     use super::*;
 
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     const TEST_ARTIFACT_SHA256: &str =
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     fn write_sparse_template(path: &Path, logical_size: u64, marker: &[u8]) {
         let mut file = std::fs::File::create(path).unwrap();
         use std::io::Write as _;
@@ -854,7 +854,7 @@ mod tests {
         file.set_len(logical_size).unwrap();
     }
 
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     fn make_fake_overlays(specs: &[crate::agent::DiskOverlaySpec]) -> crate::Result<()> {
         for (overlay, _, _) in specs {
             let mut file = std::fs::File::create(overlay)?;
@@ -865,7 +865,7 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     fn make_tree_removable(root: &Path) {
         if let Ok(entries) = std::fs::read_dir(root) {
             for entry in entries.flatten() {
@@ -878,7 +878,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     fn vm_mode_cow_uses_tiny_private_disks_and_one_immutable_base() {
         let temp = tempfile::tempdir().unwrap();
         let cache = temp.path().join("shared-pack");
@@ -952,7 +952,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     fn concurrent_first_cow_base_creation_is_atomic() {
         use std::sync::{Arc, Barrier};
 
@@ -1000,7 +1000,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     fn corrupt_cow_base_is_rejected_without_replacement() {
         let temp = tempfile::tempdir().unwrap();
         let cache = temp.path().join("shared-pack");
@@ -1035,7 +1035,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     fn missing_file_in_completed_cow_base_fails_without_rebuilding() {
         let temp = tempfile::tempdir().unwrap();
         let cache = temp.path().join("shared-pack");
@@ -1076,7 +1076,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     fn unavailable_qcow_support_leaves_no_partial_overlay_and_copy_fallback_works() {
         let temp = tempfile::tempdir().unwrap();
         let cache = temp.path().join("shared-pack");

--- a/tests/test_pack.sh
+++ b/tests/test_pack.sh
@@ -661,6 +661,10 @@ test_from_vm_setup() {
         return 1
     }
 
+    # VM-mode packs must snapshot the independent persistent storage disk too.
+    $SMOLVM machine exec --name "$FROM_VM_NAME" -- sh -c \
+        "printf source > /storage/from-vm-cow-marker" 2>&1 || return 1
+
     # Stop the VM (pack requires it to be stopped)
     $SMOLVM machine stop --name "$FROM_VM_NAME" 2>&1
 }
@@ -710,6 +714,69 @@ test_from_vm_run_finds_installed_package() {
 
     [[ $exit_code -eq 124 ]] && { echo "TIMEOUT"; return 1; }
     [[ "$result" == *"/usr/bin/curl"* ]]
+}
+
+test_from_vm_cow_cold_boot_isolation_and_persistence() {
+    if [[ ! -f "$FROM_VM_OUTPUT.smolmachine" ]]; then
+        echo "SKIP: no packed sidecar (setup or pack failed)"
+        return 1
+    fi
+
+    local first="from-vm-cow-a-$$"
+    local second="from-vm-cow-b-$$"
+    cleanup_from_vm_cow() {
+        $SMOLVM machine stop --name "$first" 2>/dev/null || true
+        $SMOLVM machine delete --name "$first" -f 2>/dev/null || true
+        $SMOLVM machine stop --name "$second" 2>/dev/null || true
+        $SMOLVM machine delete --name "$second" -f 2>/dev/null || true
+    }
+    cleanup_from_vm_cow
+
+    $SMOLVM machine create --name "$first" --from "$FROM_VM_OUTPUT.smolmachine" 2>&1 || {
+        cleanup_from_vm_cow; return 1
+    }
+    $SMOLVM machine create --name "$second" --from "$FROM_VM_OUTPUT.smolmachine" 2>&1 || {
+        cleanup_from_vm_cow; return 1
+    }
+    $SMOLVM machine start --name "$first" 2>&1 || { cleanup_from_vm_cow; return 1; }
+    $SMOLVM machine start --name "$second" 2>&1 || { cleanup_from_vm_cow; return 1; }
+
+    local first_value second_value
+    first_value=$($SMOLVM machine exec --name "$first" -- cat /storage/from-vm-cow-marker 2>&1) || {
+        cleanup_from_vm_cow; return 1
+    }
+    second_value=$($SMOLVM machine exec --name "$second" -- cat /storage/from-vm-cow-marker 2>&1) || {
+        cleanup_from_vm_cow; return 1
+    }
+    [[ "$first_value" == *"source"* && "$second_value" == *"source"* ]] || {
+        cleanup_from_vm_cow; return 1
+    }
+
+    $SMOLVM machine exec --name "$first" -- sh -c \
+        "printf first-private > /storage/from-vm-cow-marker" 2>&1 || {
+        cleanup_from_vm_cow; return 1
+    }
+    second_value=$($SMOLVM machine exec --name "$second" -- cat /storage/from-vm-cow-marker 2>&1) || {
+        cleanup_from_vm_cow; return 1
+    }
+    [[ "$second_value" == *"source"* ]] || { cleanup_from_vm_cow; return 1; }
+
+    $SMOLVM machine stop --name "$first" 2>&1 || { cleanup_from_vm_cow; return 1; }
+    $SMOLVM machine start --name "$first" 2>&1 || { cleanup_from_vm_cow; return 1; }
+    first_value=$($SMOLVM machine exec --name "$first" -- cat /storage/from-vm-cow-marker 2>&1) || {
+        cleanup_from_vm_cow; return 1
+    }
+    [[ "$first_value" == *"first-private"* ]] || { cleanup_from_vm_cow; return 1; }
+
+    $SMOLVM machine stop --name "$first" 2>&1 || true
+    $SMOLVM machine delete --name "$first" -f 2>&1 || { cleanup_from_vm_cow; return 1; }
+    second_value=$($SMOLVM machine exec --name "$second" -- cat /storage/from-vm-cow-marker 2>&1) || {
+        cleanup_from_vm_cow; return 1
+    }
+    [[ "$second_value" == *"source"* ]] || { cleanup_from_vm_cow; return 1; }
+
+    cleanup_from_vm_cow
+    return 0
 }
 
 test_from_vm_cleanup() {
@@ -1650,6 +1717,7 @@ if [[ "$QUICK_MODE" != "true" ]]; then
     run_test "from-vm: setup VM with curl" test_from_vm_setup || true
     run_test "from-vm: pack stopped VM" test_from_vm_pack || true
     run_test "from-vm: finds installed package" test_from_vm_run_finds_installed_package || true
+    run_test "from-vm: COW cold boots isolate and persist storage" test_from_vm_cow_cold_boot_isolation_and_persistence || true
     run_test "from-vm: cleanup" test_from_vm_cleanup || true
 
     echo ""


### PR DESCRIPTION
## Summary

- materialize each packed VM disk once as an immutable, content-addressed raw base keyed by artifact SHA-256, disk type, and logical size
- create private qcow2 overlays for Linux `machine create --from` while retaining the sparse-copy fallback and existing CLI/API shape
- include persistent storage in VM-mode packs and restore its original sparse logical size
- make shared artifact identity and first-use base creation locked, atomic, collision-safe, and corruption-aware
- retain shared cache groups while machines reference them and make `pack prune` remove only unreferenced groups

## Motivation

Linux VM-mode creates currently sparse-copy every packed disk for every machine. Fork already has the required qcow2 overlay primitive, but cold creates should be able to reuse that disk mechanism without restoring memory or requiring a running golden.

This changes cold create from work proportional to artifact size and machine count into one base materialization followed by metadata-only private disks.

## Safety and compatibility

- machine-local `.pack-shared` references act as durable leases for shared extraction and COW base groups
- pruning takes the cache lock, scans machine leases, refuses malformed references, and removes only groups with no remaining references
- machine deletion does not directly delete shared bases; a later `pack prune` reclaims them safely
- completed bases are validated for digest metadata, type, logical size, and read-only permissions
- broken completed bases fail safely rather than being silently replaced
- VM UID isolation retains read-only access to shared bases without making them writable
- macOS retains clonefile/APFS behavior
- hosts without qcow2 support fall back to the existing sparse-copy path
- no create request or CLI fields change

## Validation

- all 12 required CI checks passed: [CI run](https://github.com/smol-machines/smolvm/actions/runs/32219765131)
- `cargo +stable clippy --tests -- -D warnings`
- `cargo +stable test --lib`: 574 passed
- `cargo +stable test -p smolvm-pack --lib`: 104 passed
- real macOS cold-boot smoke: sibling root/storage isolation, stop/start persistence, and deletion safety passed
- Linux libkrun filesystem smoke: 100 qcow2 disks for 50 two-disk VMs created in 115.6 ms and allocated 20.1 MB total over two 4 GiB bases
- downstream [AnyCloud qualification](https://github.com/anycloud-sh/anycloud/actions/runs/32219381435) completed 50/50 deployments, left zero machines, and reclaimed 1.4 GB with `pack prune`

The downstream run validates the COW storage, deployment lifecycle, cleanup, and pruning paths, but not 50 simultaneously ready VMs: 46 initial starts hit the existing 30-second agent-readiness timeout, one VMM exited early, and deployment retries produced 97 total boot attempts. The maximum sampled concurrently running count was nine. Readiness/start-operation semantics are a separate follow-up from this storage change.
