### PR TITLE
Rebuild a damaged imported layer cache from the source artifact instead of trusting the extraction marker

### DIFF
--- a/crates/smolvm-pack/src/extract.rs
+++ b/crates/smolvm-pack/src/extract.rs
@@ -758,6 +758,35 @@ pub fn is_extracted(cache_dir: &Path) -> bool {
     cache_dir.join(EXTRACTION_MARKER).exists()
 }
 
+/// Whether an extraction's `layers/` cache is structurally usable: every id in
+/// its `layer-order` index resolves to a layer dir or staged tar, or (with no
+/// index) at least one layer entry exists. The extraction MARKER only proves an
+/// extraction once finished — a cache cleaner that deletes the large layer
+/// files but leaves the tiny marker produces a cache that passes `is_extracted`
+/// yet can neither boot nor export, and the marker then blocks the re-extract
+/// that would repair it. Callers that need the layers should require BOTH.
+pub fn cached_layers_usable(cache_dir: &Path) -> bool {
+    let layers_dir = cache_dir.join("layers");
+    let has_form =
+        |id: &str| layers_dir.join(id).is_dir() || layers_dir.join(format!("{id}.tar")).is_file();
+    if let Ok(contents) = fs::read_to_string(layers_dir.join("layer-order")) {
+        let ids: Vec<&str> = contents
+            .lines()
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+            .collect();
+        return !ids.is_empty() && ids.iter().all(|id| has_form(id));
+    }
+    fs::read_dir(&layers_dir)
+        .map(|rd| {
+            rd.flatten().any(|e| {
+                let path = e.path();
+                path.is_dir() || path.extension().is_some_and(|x| x == "tar")
+            })
+        })
+        .unwrap_or(false)
+}
+
 /// Maximum total size of the pack extraction cache before LRU eviction kicks in.
 /// Override with `SMOLVM_PACK_CACHE_MAX_BYTES` (in bytes); default 5 GiB.
 pub fn pack_cache_max_bytes() -> u64 {
@@ -2500,6 +2529,27 @@ pub fn create_or_copy_storage_disk(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cached_layers_usable_requires_the_layers_not_just_the_marker() {
+        let temp = tempfile::tempdir().unwrap();
+        let cache = temp.path();
+        // Marker alone (a cache cleaner deleted the layer files): unusable.
+        fs::write(cache.join(EXTRACTION_MARKER), "").unwrap();
+        assert!(!cached_layers_usable(cache));
+        // Order file whose ids all resolve (dir or staged tar): usable.
+        let layers = cache.join("layers");
+        fs::create_dir_all(layers.join("aaa")).unwrap();
+        fs::write(layers.join("bbb.tar"), "x").unwrap();
+        fs::write(layers.join("layer-order"), "aaa\nbbb\n").unwrap();
+        assert!(cached_layers_usable(cache));
+        // An id in the order with no backing form: unusable again.
+        fs::write(layers.join("layer-order"), "aaa\nbbb\nccc\n").unwrap();
+        assert!(!cached_layers_usable(cache));
+        // No order file, at least one layer entry: usable (legacy caches).
+        fs::remove_file(layers.join("layer-order")).unwrap();
+        assert!(cached_layers_usable(cache));
+    }
 
     #[test]
     fn shared_artifact_digest_rejects_a_different_artifact_for_the_same_store() {

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -480,10 +480,14 @@ impl LaunchFeatures {
             return Ok(self);
         }
 
-        if !smolvm_pack::extract::is_extracted(layers_cache_dir) {
+        let marker_present = smolvm_pack::extract::is_extracted(layers_cache_dir);
+        if !marker_present || !smolvm_pack::extract::cached_layers_usable(layers_cache_dir) {
             // Fallback: layers not yet extracted into this machine's own dir
-            // (pre-this-layout machine, or an interrupted create). Extract from
-            // the source bundle, which must still be present in that case.
+            // (pre-this-layout machine, or an interrupted create), OR the
+            // extraction marker survived while the layer files themselves were
+            // deleted (cache cleaners take the large files and leave the tiny
+            // marker). Extract from the source bundle, which must still be
+            // present in that case; force past the marker when it lies.
             let sidecar = Path::new(sidecar_path);
             if !sidecar.exists() {
                 return Err(Error::agent(
@@ -496,10 +500,22 @@ impl LaunchFeatures {
                     ),
                 ));
             }
+            if marker_present {
+                tracing::info!(
+                    cache = %layers_cache_dir.display(),
+                    "layer cache marked extracted but unusable; re-extracting from the source bundle"
+                );
+            }
             let footer = smolvm_pack::packer::read_footer_from_sidecar(sidecar)
                 .map_err(|e| Error::agent("read sidecar footer", e.to_string()))?;
-            smolvm_pack::extract::extract_sidecar(sidecar, layers_cache_dir, &footer, false, false)
-                .map_err(|e| Error::agent("extract sidecar", e.to_string()))?;
+            smolvm_pack::extract::extract_sidecar(
+                sidecar,
+                layers_cache_dir,
+                &footer,
+                marker_present,
+                false,
+            )
+            .map_err(|e| Error::agent("extract sidecar", e.to_string()))?;
         }
 
         let layers_lease = smolvm_pack::extract::acquire_layers_lease(layers_cache_dir, false)

--- a/src/pack_export.rs
+++ b/src/pack_export.rs
@@ -118,7 +118,13 @@ pub fn collect_from_vm_assets(
     let mut image_env: Vec<String> = Vec::new();
 
     if is_artifact_sourced && !opts.rebase_from_image {
-        export_flattened_from_artifact_sourced(collector, vm_name, &vm_dir, staging_dir)?;
+        export_flattened_from_artifact_sourced(
+            collector,
+            vm_name,
+            &vm_dir,
+            staging_dir,
+            vm.source_smolmachine.as_deref(),
+        )?;
     } else if is_image_based {
         let image = vm.image.clone().unwrap();
         // A locally-sourced image (`--image -` / `--image file.tar` / a rootfs
@@ -403,17 +409,37 @@ fn export_flattened_from_artifact_sourced(
     vm_name: &str,
     vm_dir: &Path,
     _staging_dir: &Path,
+    source_smolmachine: Option<&str>,
 ) -> crate::Result<()> {
     let cache_dir = machine_layers_cache_dir(vm_name);
-    let pack_content_dir = read_shared_pack_pointer(&cache_dir).unwrap_or(cache_dir);
-    let layer_ids = ordered_cached_layer_ids(&pack_content_dir).ok_or_else(|| {
+    let pack_content_dir = read_shared_pack_pointer(&cache_dir).unwrap_or(cache_dir.clone());
+    let mut layer_ids = ordered_cached_layer_ids(&pack_content_dir);
+    // Self-heal a missing or damaged layer cache from the machine's source
+    // artifact (a cache cleaner can delete the layer files while leaving the
+    // extraction marker, in which case a start does NOT re-extract either —
+    // the old "start the machine once" advice was a dead end there). Only the
+    // per-machine cache is healed here; a shared-store entry heals at boot.
+    if layer_ids.is_none() && pack_content_dir == cache_dir {
+        if let Some(sidecar) = source_smolmachine.map(Path::new).filter(|s| s.exists()) {
+            eprintln!("Imported layer cache is missing; re-extracting from the source artifact...");
+            let footer = smolvm_pack::packer::read_footer_from_sidecar(sidecar)
+                .map_err(|e| Error::agent("read sidecar footer", e.to_string()))?;
+            smolvm_pack::extract::extract_sidecar(sidecar, &cache_dir, &footer, true, false)
+                .map_err(|e| Error::agent("re-extract source artifact", e.to_string()))?;
+            layer_ids = ordered_cached_layer_ids(&pack_content_dir);
+        }
+    }
+    let layer_ids = layer_ids.ok_or_else(|| {
         Error::agent(
             "pack from VM",
             format!(
                 "VM '{vm_name}' was created from a .smolmachine artifact, but its \
-                 imported layer cache is missing ({}). Start the machine once to \
-                 re-extract it, then re-run the export.",
-                pack_content_dir.display()
+                 imported layer cache is missing ({}) and could not be rebuilt: \
+                 the source artifact ({}) is not available. Restore the source \
+                 .smolmachine at that path, or start the machine once to \
+                 re-extract, then re-run the export.",
+                pack_content_dir.display(),
+                source_smolmachine.unwrap_or("unknown path"),
             ),
         )
     })?;


### PR DESCRIPTION
Rebuild a damaged imported layer cache from the machine's source artifact on start and export instead of trusting the extraction marker, so a cache whose layer files were deleted self-heals rather than dead-ending.