### PR TITLE
Add uid, gid and mode flags to machine cp and land streamed uploads inside the running workload container

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -2094,6 +2094,8 @@ fn handle_connection(stream: &mut impl ReadWrite) -> Result<(), Box<dyn std::err
         if let AgentRequest::FileWriteBegin {
             path,
             mode,
+            uid,
+            gid,
             total_size,
         } = request
         {
@@ -2101,7 +2103,7 @@ fn handle_connection(stream: &mut impl ReadWrite) -> Result<(), Box<dyn std::err
             // starting a new one. `take()` makes the drop explicit and keeps the
             // value from looking like a dead store.
             let _ = write_session.take();
-            let (new_session, response) = handle_file_write_begin(path, mode, total_size);
+            let (new_session, response) = handle_file_write_begin(path, mode, uid, gid, total_size);
             write_session = new_session;
             send_response(stream, &response)?;
             continue;
@@ -2380,7 +2382,13 @@ fn handle_request(
             AgentResponse::error("export layer not handled here", error_codes::INTERNAL_ERROR)
         }
 
-        AgentRequest::FileWrite { path, data, mode } => handle_file_write(&path, &data, mode),
+        AgentRequest::FileWrite {
+            path,
+            data,
+            mode,
+            uid,
+            gid,
+        } => handle_file_write(&path, &data, mode, uid, gid),
 
         // Streaming uploads go through `handle_connection`'s
         // per-connection session state so they can't land here.
@@ -2683,7 +2691,13 @@ fn resolve_guest_io_path(
 /// finalize step. The atomic-rename pattern is the thing both paths
 /// need to guarantee: partial contents never appear at `path` under
 /// any error or kill scenario.
-fn install_file_atomic(path: &str, data: &[u8], mode: Option<u32>) -> AgentResponse {
+fn install_file_atomic(
+    path: &str,
+    data: &[u8],
+    mode: Option<u32>,
+    uid: Option<u32>,
+    gid: Option<u32>,
+) -> AgentResponse {
     let resolved = match resolve_guest_io_path(path, FilePathAccess::Write) {
         Ok(p) => p,
         Err(resp) => return resp,
@@ -2726,6 +2740,17 @@ fn install_file_atomic(path: &str, data: &[u8], mode: Option<u32>) -> AgentRespo
     if let Some(m) = mode {
         apply_mode_best_effort(target, m);
     }
+    // Ownership was requested explicitly, so a failure is an error, not a
+    // best-effort shrug — a non-root workload silently unable to read its own
+    // upload is exactly the bug this exists to prevent.
+    if uid.is_some() || gid.is_some() {
+        if let Err(e) = std::os::unix::fs::chown(target, uid, gid) {
+            return AgentResponse::error(
+                format!("failed to chown {}: {}", path, e),
+                error_codes::FILE_IO_FAILED,
+            );
+        }
+    }
     info!(path = %path, size = data.len(), "file written");
     AgentResponse::Ok { data: None }
 }
@@ -2741,8 +2766,14 @@ fn install_file_atomic(path: &str, data: &[u8], mode: Option<u32>) -> AgentRespo
 /// With no running workload the local write is correct and is kept: overlayfs
 /// reads `upper` at mount time, so seeding it before the container starts is
 /// exactly how the file becomes visible once it does.
-fn handle_file_write(path: &str, data: &[u8], mode: Option<u32>) -> AgentResponse {
-    if let Some(result) = nsfile::write_to_container(path, data, mode) {
+fn handle_file_write(
+    path: &str,
+    data: &[u8],
+    mode: Option<u32>,
+    uid: Option<u32>,
+    gid: Option<u32>,
+) -> AgentResponse {
+    if let Some(result) = nsfile::write_to_container(path, data, mode, uid, gid) {
         return match result {
             Ok(()) => AgentResponse::Ok { data: None },
             Err(e) => AgentResponse::error(
@@ -2751,7 +2782,7 @@ fn handle_file_write(path: &str, data: &[u8], mode: Option<u32>) -> AgentRespons
             ),
         };
     }
-    install_file_atomic(path, data, mode)
+    install_file_atomic(path, data, mode, uid, gid)
 }
 
 /// State for an in-progress streaming file upload on one connection.
@@ -2770,6 +2801,10 @@ struct WriteSession {
     tmp_file: std::fs::File,
     /// Permissions to apply after rename.
     mode: Option<u32>,
+    /// Owner uid to apply after rename.
+    uid: Option<u32>,
+    /// Owner gid to apply after rename.
+    gid: Option<u32>,
     /// Running total — compared against `total_size` as a DoS guard.
     bytes_written: u64,
     /// Caller-declared total; the agent refuses chunks that would
@@ -2782,6 +2817,8 @@ impl WriteSession {
     fn open(
         target: std::path::PathBuf,
         mode: Option<u32>,
+        uid: Option<u32>,
+        gid: Option<u32>,
         total_size: u64,
     ) -> std::io::Result<Self> {
         if let Some(parent) = target.parent() {
@@ -2813,6 +2850,8 @@ impl WriteSession {
             tmp_path,
             tmp_file,
             mode,
+            uid,
+            gid,
             bytes_written: 0,
             total_size,
         })
@@ -2867,6 +2906,48 @@ impl WriteSession {
                 error_codes::FILE_IO_FAILED,
             );
         }
+        // A running workload reads the CONTAINER filesystem, not the agent's
+        // namespace — finalize through the ns helper there, mirroring the
+        // single-shot path (writing here would land in the overlay's upper
+        // beneath a live overlayfs, invisible to the workload: BUG-240's
+        // streaming twin). The staged bytes are piped, never re-buffered.
+        match std::fs::File::open(&self.tmp_path) {
+            Ok(mut staged) => {
+                if let Some(result) = nsfile::write_reader_to_container(
+                    &self.target.to_string_lossy(),
+                    &mut staged,
+                    self.mode,
+                    self.uid,
+                    self.gid,
+                ) {
+                    // Session Drop still cleans the staging file.
+                    return match result {
+                        Ok(()) => {
+                            info!(
+                                path = %self.target.display(),
+                                size = self.bytes_written,
+                                "file written into workload container"
+                            );
+                            AgentResponse::Ok { data: None }
+                        }
+                        Err(e) => AgentResponse::error(
+                            format!(
+                                "failed to write {} in the workload container: {}",
+                                self.target.display(),
+                                e
+                            ),
+                            error_codes::FILE_IO_FAILED,
+                        ),
+                    };
+                }
+            }
+            Err(e) => {
+                return AgentResponse::error(
+                    format!("failed to reopen staging file: {}", e),
+                    error_codes::FILE_IO_FAILED,
+                );
+            }
+        }
         // Disarm Drop before rename; if the rename fails we'll
         // re-arm below by restoring the path.
         let tmp = std::mem::take(&mut self.tmp_path);
@@ -2881,6 +2962,14 @@ impl WriteSession {
         }
         if let Some(m) = self.mode {
             apply_mode_best_effort(&self.target, m);
+        }
+        if self.uid.is_some() || self.gid.is_some() {
+            if let Err(e) = std::os::unix::fs::chown(&self.target, self.uid, self.gid) {
+                return AgentResponse::error(
+                    format!("failed to chown {}: {}", self.target.display(), e),
+                    error_codes::FILE_IO_FAILED,
+                );
+            }
         }
         info!(
             path = %self.target.display(),
@@ -2907,6 +2996,8 @@ impl Drop for WriteSession {
 fn handle_file_write_begin(
     path: String,
     mode: Option<u32>,
+    uid: Option<u32>,
+    gid: Option<u32>,
     total_size: u64,
 ) -> (Option<WriteSession>, AgentResponse) {
     if total_size > smolvm_protocol::FILE_TRANSFER_MAX_TOTAL {
@@ -2926,7 +3017,7 @@ fn handle_file_write_begin(
         Ok(p) => p,
         Err(resp) => return (None, resp),
     };
-    match WriteSession::open(resolved, mode, total_size) {
+    match WriteSession::open(resolved, mode, uid, gid, total_size) {
         Ok(session) => (Some(session), AgentResponse::Ok { data: None }),
         Err(e) => (
             None,
@@ -6704,6 +6795,8 @@ mod tests {
         let (session, resp) = handle_file_write_begin(
             target.to_string_lossy().into(),
             None,
+            None,
+            None,
             smolvm_protocol::FILE_TRANSFER_MAX_TOTAL + 1,
         );
         assert!(session.is_none(), "session must not be created");
@@ -6759,6 +6852,8 @@ mod tests {
         let (session, resp) = handle_file_write_begin(
             target.to_string_lossy().into(),
             Some(0o600),
+            None,
+            None,
             payload.len() as u64,
         );
         assert!(matches!(resp, AgentResponse::Ok { .. }));
@@ -6796,8 +6891,13 @@ mod tests {
         let target = tmp_target(&tmp, "multi.bin");
         let total = 1024usize;
 
-        let (mut session, resp) =
-            handle_file_write_begin(target.to_string_lossy().into(), None, total as u64);
+        let (mut session, resp) = handle_file_write_begin(
+            target.to_string_lossy().into(),
+            None,
+            None,
+            None,
+            total as u64,
+        );
         assert!(matches!(resp, AgentResponse::Ok { .. }));
 
         // Three chunks: 400 + 400 + 224 bytes, each a distinct fill byte.
@@ -6831,7 +6931,8 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let target = tmp_target(&tmp, "overflow.bin");
 
-        let (session, _resp) = handle_file_write_begin(target.to_string_lossy().into(), None, 10);
+        let (session, _resp) =
+            handle_file_write_begin(target.to_string_lossy().into(), None, None, None, 10);
         assert!(session.is_some());
 
         // First chunk fits.
@@ -6860,7 +6961,8 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let target = tmp_target(&tmp, "dropped.bin");
 
-        let (session, _) = handle_file_write_begin(target.to_string_lossy().into(), None, 100);
+        let (session, _) =
+            handle_file_write_begin(target.to_string_lossy().into(), None, None, None, 100);
         let (session, _) = handle_file_write_chunk(session, &[0u8; 50], false);
         assert!(session.is_some());
         // Staging file exists mid-stream.
@@ -6888,7 +6990,8 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let target = tmp_target(&tmp, "empty.bin");
 
-        let (session, _) = handle_file_write_begin(target.to_string_lossy().into(), None, 0);
+        let (session, _) =
+            handle_file_write_begin(target.to_string_lossy().into(), None, None, None, 0);
         let (session, resp) = handle_file_write_chunk(session, &[], true);
         assert!(matches!(resp, AgentResponse::Ok { .. }));
         assert!(session.is_none());
@@ -6911,7 +7014,7 @@ mod tests {
         let target = tmp_target(&tmp, "single.bin");
         let payload = b"small file contents".to_vec();
 
-        let resp = handle_file_write(&target.to_string_lossy(), &payload, Some(0o644));
+        let resp = handle_file_write(&target.to_string_lossy(), &payload, Some(0o644), None, None);
         assert!(
             matches!(resp, AgentResponse::Ok { .. }),
             "write failed: {:?}",

--- a/crates/smolvm-agent/src/nsfile.rs
+++ b/crates/smolvm-agent/src/nsfile.rs
@@ -54,18 +54,19 @@ pub fn helper_requested() -> bool {
     std::env::args().nth(1).as_deref() == Some(HELPER_ARG)
 }
 
-/// Entry point for `smolvm-agent ns-file <op> <pid> <path> [mode]`.
+/// Entry point for `smolvm-agent ns-file <op> <pid> <path> [mode [uid gid]]`.
 ///
 /// Protocol, chosen so the parent never buffers a whole file:
 /// * `read`  — stdout gets `OK <size>\n` then exactly `<size>` raw bytes, or
 ///   `ERR <message>\n`.
 /// * `write` — raw bytes arrive on stdin until EOF; stdout gets `OK\n` or
-///   `ERR <message>\n`.
+///   `ERR <message>\n`. mode/uid/gid are positional with `-` meaning
+///   "not requested".
 pub fn run_helper() -> i32 {
     let args: Vec<String> = std::env::args().collect();
-    // argv: [bin, "ns-file", op, pid, path, (mode)]
+    // argv: [bin, "ns-file", op, pid, path, (mode), (uid), (gid)]
     if args.len() < 5 {
-        eprintln!("ns-file: usage: ns-file <read|write> <pid> <path> [mode]");
+        eprintln!("ns-file: usage: ns-file <read|write> <pid> <path> [mode [uid gid]]");
         return 2;
     }
     let op = args[2].as_str();
@@ -74,7 +75,10 @@ pub fn run_helper() -> i32 {
         return 2;
     };
     let path = args[4].clone();
-    let mode = args.get(5).and_then(|m| u32::from_str_radix(m, 8).ok());
+    let opt = |i: usize| args.get(i).filter(|v| v.as_str() != "-");
+    let mode = opt(5).and_then(|m| u32::from_str_radix(m, 8).ok());
+    let uid = opt(6).and_then(|u| u.parse::<u32>().ok());
+    let gid = opt(7).and_then(|g| g.parse::<u32>().ok());
 
     if let Err(e) = enter_mount_namespace(pid) {
         // Report through the protocol so the parent surfaces one clean error.
@@ -84,7 +88,7 @@ pub fn run_helper() -> i32 {
 
     let result = match op {
         "read" => helper_read(&path),
-        "write" => helper_write(&path, mode),
+        "write" => helper_write(&path, mode, uid, gid),
         _ => Err("unknown op".to_string()),
     };
     match result {
@@ -150,7 +154,12 @@ fn helper_read(path: &str) -> Result<(), String> {
     Ok(())
 }
 
-fn helper_write(path: &str, mode: Option<u32>) -> Result<(), String> {
+fn helper_write(
+    path: &str,
+    mode: Option<u32>,
+    uid: Option<u32>,
+    gid: Option<u32>,
+) -> Result<(), String> {
     let target = Path::new(path);
     let parent = target.parent().filter(|p| !p.as_os_str().is_empty());
     if let Some(dir) = parent {
@@ -183,6 +192,12 @@ fn helper_write(path: &str, mode: Option<u32>) -> Result<(), String> {
         if let Err(e) = std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(m)) {
             let _ = std::fs::remove_file(&tmp);
             return Err(format!("chmod {path}: {e}"));
+        }
+    }
+    if uid.is_some() || gid.is_some() {
+        if let Err(e) = std::os::unix::fs::chown(&tmp, uid, gid) {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(format!("chown {path}: {e}"));
         }
     }
     if let Err(e) = std::fs::rename(&tmp, target) {
@@ -290,21 +305,54 @@ pub fn write_to_container(
     path: &str,
     data: &[u8],
     mode: Option<u32>,
+    uid: Option<u32>,
+    gid: Option<u32>,
 ) -> Option<Result<(), String>> {
     let pid = workload_container_pid()?;
-    Some(write_via_helper(pid, path, data, mode))
+    Some(write_via_helper(
+        pid,
+        path,
+        &mut std::io::Cursor::new(data),
+        mode,
+        uid,
+        gid,
+    ))
 }
 
-fn write_via_helper(pid: u32, path: &str, data: &[u8], mode: Option<u32>) -> Result<(), String> {
-    let mut args = vec![
+/// Stream an already-staged file into the workload container's namespace.
+/// Used by the streaming upload's finalize so large files land where the
+/// workload reads, exactly like the single-shot path. `None` = no running
+/// workload; the caller keeps its agent-namespace placement.
+pub fn write_reader_to_container<R: std::io::Read>(
+    path: &str,
+    reader: &mut R,
+    mode: Option<u32>,
+    uid: Option<u32>,
+    gid: Option<u32>,
+) -> Option<Result<(), String>> {
+    let pid = workload_container_pid()?;
+    Some(write_via_helper(pid, path, reader, mode, uid, gid))
+}
+
+fn write_via_helper<R: std::io::Read>(
+    pid: u32,
+    path: &str,
+    data: &mut R,
+    mode: Option<u32>,
+    uid: Option<u32>,
+    gid: Option<u32>,
+) -> Result<(), String> {
+    // Fixed positional args; "-" is the explicit "not requested" placeholder
+    // so uid/gid can follow an absent mode unambiguously.
+    let args = vec![
         HELPER_ARG.to_string(),
         "write".to_string(),
         pid.to_string(),
         path.to_string(),
+        mode.map_or_else(|| "-".to_string(), |m| format!("{m:o}")),
+        uid.map_or_else(|| "-".to_string(), |u| u.to_string()),
+        gid.map_or_else(|| "-".to_string(), |g| g.to_string()),
     ];
-    if let Some(m) = mode {
-        args.push(format!("{m:o}"));
-    }
     let mut child = Command::new(AGENT_BINARY)
         .args(&args)
         .stdin(Stdio::piped())
@@ -314,9 +362,7 @@ fn write_via_helper(pid: u32, path: &str, data: &[u8], mode: Option<u32>) -> Res
         .map_err(|e| format!("spawn ns-file helper: {e}"))?;
     {
         let mut stdin = child.stdin.take().expect("piped");
-        stdin
-            .write_all(data)
-            .map_err(|e| format!("ns-file helper write: {e}"))?;
+        std::io::copy(data, &mut stdin).map_err(|e| format!("ns-file helper write: {e}"))?;
     } // drop closes stdin → helper sees EOF
     let out = child
         .wait_with_output()

--- a/crates/smolvm-protocol/src/lib.rs
+++ b/crates/smolvm-protocol/src/lib.rs
@@ -467,6 +467,12 @@ pub enum AgentRequest {
         /// File mode (e.g., 0o644). None = default (0644).
         #[serde(default)]
         mode: Option<u32>,
+        /// Owner uid to apply after the write. None = leave as written (root).
+        #[serde(default)]
+        uid: Option<u32>,
+        /// Owner gid to apply after the write. None = leave as written (root).
+        #[serde(default)]
+        gid: Option<u32>,
     },
 
     /// Open a streaming file upload session on this connection.
@@ -484,6 +490,12 @@ pub enum AgentRequest {
         /// File mode (e.g., 0o644). None = default (0644).
         #[serde(default)]
         mode: Option<u32>,
+        /// Owner uid to apply on finalize. None = leave as written (root).
+        #[serde(default)]
+        uid: Option<u32>,
+        /// Owner gid to apply on finalize. None = leave as written (root).
+        #[serde(default)]
+        gid: Option<u32>,
         /// Expected total size in bytes. Rejected if it exceeds
         /// [`FILE_TRANSFER_MAX_TOTAL`]. The agent uses this for an
         /// early-fail check only; the actual size written is the sum
@@ -1222,6 +1234,21 @@ mod tests {
     use super::*;
 
     #[test]
+    fn file_write_without_owner_fields_still_parses() {
+        // Requests from clients predating uid/gid must keep deserializing.
+        let old = r#"{"method":"file_write","path":"/x","data":"aGk=","mode":420}"#;
+        let req: AgentRequest = serde_json::from_str(old).unwrap();
+        match req {
+            AgentRequest::FileWrite { mode, uid, gid, .. } => {
+                assert_eq!(mode, Some(420));
+                assert_eq!(uid, None);
+                assert_eq!(gid, None);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
     fn test_encode_decode_roundtrip() {
         let req = AgentRequest::Pull {
             image: "alpine:latest".to_string(),
@@ -1370,6 +1397,8 @@ mod tests {
         let req = AgentRequest::FileWriteBegin {
             path: "/tmp/target".into(),
             mode: Some(0o600),
+            uid: Some(1000),
+            gid: Some(1000),
             total_size: 123_456_789,
         };
         let bytes = encode_message(&req).unwrap();
@@ -1378,10 +1407,14 @@ mod tests {
             AgentRequest::FileWriteBegin {
                 path,
                 mode,
+                uid,
+                gid,
                 total_size,
             } => {
                 assert_eq!(path, "/tmp/target");
                 assert_eq!(mode, Some(0o600));
+                assert_eq!(uid, Some(1000));
+                assert_eq!(gid, Some(1000));
                 assert_eq!(total_size, 123_456_789);
             }
             _ => panic!("wrong variant"),

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -19,6 +19,29 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+/// Metadata applied to an uploaded file after it lands: permissions and
+/// ownership. Ownership matters for non-root workload images — a root-owned
+/// upload is unreadable/unwritable to the user the container actually runs as.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FileWriteMeta {
+    /// File mode (e.g. 0o644). None = the agent's default.
+    pub mode: Option<u32>,
+    /// Owner uid. None = leave as written.
+    pub uid: Option<u32>,
+    /// Owner gid. None = leave as written.
+    pub gid: Option<u32>,
+}
+
+impl FileWriteMeta {
+    /// The pre-existing mode-only shape, for callers without ownership needs.
+    pub fn mode_only(mode: Option<u32>) -> Self {
+        Self {
+            mode,
+            ..Self::default()
+        }
+    }
+}
+
 /// Events from a streaming exec session.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ExecEvent {
@@ -1936,7 +1959,7 @@ impl AgentClient {
     ///   limit — without it the send blocks the socket (EAGAIN
     ///   after write timeout) and risks OOMing the guest agent.
     pub fn write_file(&mut self, path: &str, data: &[u8], mode: Option<u32>) -> Result<()> {
-        self.write_file_with_progress(path, data, mode, |_| {})
+        self.write_file_with_progress(path, data, FileWriteMeta::mode_only(mode), |_| {})
     }
 
     /// Write a file into the VM with a progress callback.
@@ -1949,20 +1972,22 @@ impl AgentClient {
         &mut self,
         path: &str,
         data: &[u8],
-        mode: Option<u32>,
+        meta: FileWriteMeta,
         mut on_progress: F,
     ) -> Result<()> {
         if data.len() <= FILE_WRITE_SINGLE_SHOT_MAX {
             let resp = self.request(&AgentRequest::FileWrite {
                 path: path.to_string(),
                 data: data.to_vec(),
-                mode,
+                mode: meta.mode,
+                uid: meta.uid,
+                gid: meta.gid,
             })?;
             expect_ok(resp, "write file")?;
             on_progress(data.len() as u64);
             Ok(())
         } else {
-            self.write_file_streaming(path, data, mode, &mut on_progress)
+            self.write_file_streaming(path, data, meta, &mut on_progress)
         }
     }
 
@@ -1971,14 +1996,14 @@ impl AgentClient {
         &mut self,
         path: &str,
         data: &[u8],
-        mode: Option<u32>,
+        meta: FileWriteMeta,
         on_progress: &mut F,
     ) -> Result<()> {
         self.write_file_streaming_from_reader(
             path,
             &mut std::io::Cursor::new(data),
             data.len() as u64,
-            mode,
+            meta,
             on_progress,
         )
     }
@@ -1996,7 +2021,13 @@ impl AgentClient {
         total_size: u64,
         mode: Option<u32>,
     ) -> Result<()> {
-        self.write_file_from_reader_with_progress(path, reader, total_size, mode, |_| {})
+        self.write_file_from_reader_with_progress(
+            path,
+            reader,
+            total_size,
+            FileWriteMeta::mode_only(mode),
+            |_| {},
+        )
     }
 
     /// Stream a file from a [`Read`] source with progress callback.
@@ -2005,7 +2036,7 @@ impl AgentClient {
         path: &str,
         reader: R,
         total_size: u64,
-        mode: Option<u32>,
+        meta: FileWriteMeta,
         mut on_progress: F,
     ) -> Result<()> {
         if total_size <= FILE_WRITE_SINGLE_SHOT_MAX as u64 {
@@ -2013,13 +2044,13 @@ impl AgentClient {
             let mut data = Vec::with_capacity(total_size as usize);
             std::io::Read::read_to_end(&mut std::io::Read::take(reader, total_size), &mut data)
                 .map_err(|e| Error::agent("read source file", e.to_string()))?;
-            return self.write_file_with_progress(path, &data, mode, on_progress);
+            return self.write_file_with_progress(path, &data, meta, on_progress);
         }
         self.write_file_streaming_from_reader(
             path,
             &mut { reader },
             total_size,
-            mode,
+            meta,
             &mut on_progress,
         )
     }
@@ -2032,12 +2063,14 @@ impl AgentClient {
         path: &str,
         reader: &mut R,
         total_size: u64,
-        mode: Option<u32>,
+        meta: FileWriteMeta,
         on_progress: &mut F,
     ) -> Result<()> {
         let resp = self.request(&AgentRequest::FileWriteBegin {
             path: path.to_string(),
-            mode,
+            mode: meta.mode,
+            uid: meta.uid,
+            gid: meta.gid,
             total_size,
         })?;
         expect_ok(resp, "begin streaming write")?;

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -20,8 +20,8 @@ pub use crate::data::network::PortMapping;
 pub use crate::data::resources::VmResources;
 pub use crate::data::storage::HostMount;
 pub use client::{
-    file_transfer_max_total, pack_export_max_total, AgentClient, ExecEvent, InteractiveInput,
-    InteractiveOutput, PullOptions, RunConfig,
+    file_transfer_max_total, pack_export_max_total, AgentClient, ExecEvent, FileWriteMeta,
+    InteractiveInput, InteractiveOutput, PullOptions, RunConfig,
 };
 pub use fsnotify_watch::FsNotifyWatcher;
 pub use krun::KrunFunctions;

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -1981,6 +1981,14 @@ impl RunCmd {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn cp_mode_parses_common_octal_forms_and_rejects_garbage() {
+        assert_eq!(super::parse_octal_mode("644").unwrap(), 0o644);
+        assert_eq!(super::parse_octal_mode("0755").unwrap(), 0o755);
+        assert_eq!(super::parse_octal_mode("0o600").unwrap(), 0o600);
+        assert!(super::parse_octal_mode("8x").is_err());
+        assert!(super::parse_octal_mode("77777").is_err());
+    }
 
     use super::*;
     use clap::Parser;
@@ -4690,6 +4698,32 @@ pub struct CpCmd {
     /// Destination path (local file or machine:path)
     #[arg(value_name = "DST")]
     pub dst: String,
+
+    /// Set the file's mode on upload (octal, e.g. 644)
+    #[arg(long, value_name = "OCTAL")]
+    pub mode: Option<String>,
+
+    /// Set the file's owner uid on upload (default: root)
+    #[arg(long, value_name = "UID")]
+    pub uid: Option<u32>,
+
+    /// Set the file's owner gid on upload (default: root)
+    #[arg(long, value_name = "GID")]
+    pub gid: Option<u32>,
+}
+
+/// Parse a chmod-style octal mode ("644", "0755", "0o600").
+fn parse_octal_mode(s: &str) -> smolvm::Result<u32> {
+    let digits = s.trim_start_matches("0o");
+    u32::from_str_radix(digits, 8)
+        .ok()
+        .filter(|m| *m <= 0o7777)
+        .ok_or_else(|| {
+            smolvm::Error::config(
+                "cp",
+                format!("invalid octal mode '{s}' (expected e.g. 644)"),
+            )
+        })
 }
 
 impl CpCmd {
@@ -4708,6 +4742,13 @@ impl CpCmd {
                     "one of SRC or DST must use machine:path syntax (e.g., myvm:/workspace/file)",
                 ));
             };
+
+        if !is_upload && (self.mode.is_some() || self.uid.is_some() || self.gid.is_some()) {
+            return Err(smolvm::Error::config(
+                "cp",
+                "--mode/--uid/--gid apply to uploads only (host -> machine)",
+            ));
+        }
 
         let (manager, mut client) =
             vm_common::ensure_running_and_connect(&Some(machine_name.clone()))?;
@@ -4730,6 +4771,11 @@ impl CpCmd {
         }
 
         if is_upload {
+            let meta = smolvm::agent::FileWriteMeta {
+                mode: self.mode.as_deref().map(parse_octal_mode).transpose()?,
+                uid: self.uid,
+                gid: self.gid,
+            };
             // Stream from file — only one chunk (~1 MiB) in memory at a time.
             let file = std::fs::File::open(&local_path).map_err(|e| {
                 smolvm::Error::agent("read local file", format!("{}: {}", local_path, e))
@@ -4741,7 +4787,7 @@ impl CpCmd {
                 format!("Uploading {} -> {}", local_path, guest_path),
                 Some(size),
             );
-            client.write_file_from_reader_with_progress(&guest_path, file, size, None, |sent| {
+            client.write_file_from_reader_with_progress(&guest_path, file, size, meta, |sent| {
                 bar.update(sent)
             })?;
             bar.finish(size);


### PR DESCRIPTION
Files pushed with `machine cp` always arrived root-owned, which breaks images that run as a non-root user, so uploads now take `--uid`, `--gid` and `--mode` (applied natively by the agent, so distroless images without chown work too) — and fixing that surfaced that streamed uploads over 1 MiB were written in the agent's namespace where a running workload never sees them, so the streaming finalize now pipes the staged file through the same namespace helper as small uploads.