### PR TITLE
Skip the /workspace fallback for volumes mounted below it, not only at it

### DIFF
--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -506,23 +506,43 @@ pub fn repair_boot_volume_mounts() -> Result<()> {
     Ok(())
 }
 
+/// True when a user mount target claims /workspace itself or anything beneath it.
+///
+/// Compares path *components*, not string prefixes: `/workspaces/project` begins
+/// with the characters of `/workspace` but is a sibling rather than a child, and
+/// must not suppress the fallback. Slash-normalized so a trailing `/` on the
+/// user's target still matches.
+fn claims_workspace(target: &str) -> bool {
+    Path::new(target.trim_end_matches('/')).starts_with(paths::WORKSPACE_GUEST_PATH)
+}
+
 /// Add the /storage/workspace → /workspace fallback bind mount to an OCI spec,
-/// unless a user-provided volume already claims /workspace.
+/// unless a user-provided volume already claims /workspace or a path under it.
 ///
 /// The fallback exposes the storage disk's workspace directory inside containers
 /// so that persistent files written to /workspace survive across VM restarts.
-/// It must be skipped when the user provides `-v host:/workspace` to avoid
-/// silently overwriting their virtiofs mount (which comes earlier in the spec).
-///
-/// Mount target comparison is slash-normalized to handle trailing slashes.
+/// It must be skipped whenever the user has mounted at or below /workspace, to
+/// avoid silently overwriting their virtiofs mount (which comes earlier in the
+/// spec). Binding /workspace on top of a user mount at, say, /workspace/project
+/// replaces the parent directory the nested mount hangs from: the mount stays in
+/// the namespace and is listed in /proc/self/mountinfo, but no longer resolves by
+/// path, so the user sees an empty directory instead of their files.
 pub fn add_workspace_fallback(spec: &mut OciSpec, mounts: &[(String, String, bool)]) {
     let workspace_src = Path::new(STORAGE_ROOT).join(WORKSPACE_DIR);
     if !workspace_src.exists() {
         return;
     }
-    let user_owns_workspace = mounts
-        .iter()
-        .any(|(_, path, _)| path.trim_end_matches('/') == paths::WORKSPACE_GUEST_PATH);
+    add_workspace_fallback_from(spec, mounts, &workspace_src);
+}
+
+/// Core of [`add_workspace_fallback`], with the fallback source injected so the
+/// rule can be exercised without a real /storage/workspace on the test host.
+fn add_workspace_fallback_from(
+    spec: &mut OciSpec,
+    mounts: &[(String, String, bool)],
+    workspace_src: &Path,
+) {
+    let user_owns_workspace = mounts.iter().any(|(_, path, _)| claims_workspace(path));
     if !user_owns_workspace {
         spec.add_bind_mount(
             &workspace_src.to_string_lossy(),
@@ -4521,6 +4541,83 @@ mod tests {
     // through its public API (the crate also unit-tests them independently).
     use smolvm_oci_layer::{classify_layer_entry, jailed_join, LayerEntry};
     use std::sync::{Mutex, OnceLock};
+
+    /// The /workspace fallback is bound on top of the user's mounts, so it must
+    /// stand down for anything at or below /workspace — not only an exact
+    /// `-v host:/workspace`. A user mount at /workspace/project that keeps the
+    /// fallback ends up shadowed by its own parent: still listed in
+    /// /proc/self/mountinfo, but unreachable by path.
+    ///
+    /// The sibling /workspaces/project is the trap: it shares the string prefix
+    /// but is not under /workspace, and must still get the fallback.
+    #[test]
+    fn a_user_mount_below_workspace_suppresses_the_fallback() {
+        let fallback_src = std::path::Path::new("/storage/workspace");
+        let user_source = "/host/source".to_string();
+
+        // (user mount target, mount destinations expected in the spec afterwards)
+        let cases: &[(&str, &[&str])] = &[
+            // At /workspace: fallback suppressed, only the user's mount.
+            ("/workspace", &["/workspace"]),
+            // Below /workspace: fallback suppressed — the bug this guards.
+            ("/workspace/project", &["/workspace/project"]),
+            // Trailing slash is the same claim.
+            ("/workspace/project/", &["/workspace/project/"]),
+            // Sibling that merely shares the prefix: fallback still applies.
+            (
+                "/workspaces/project",
+                &["/workspaces/project", "/workspace"],
+            ),
+            // Unrelated targets: fallback still applies.
+            ("/mnt/project", &["/mnt/project", "/workspace"]),
+            (
+                "/opt/workspace/project",
+                &["/opt/workspace/project", "/workspace"],
+            ),
+        ];
+
+        for (target, expected) in cases {
+            let mut spec = OciSpec::new(
+                &[],
+                &[],
+                "/",
+                false,
+                &crate::oci::ProcessIdentity::root(),
+                false,
+            );
+            spec.mounts.clear();
+            let mounts = vec![(user_source.clone(), (*target).to_string(), false)];
+            for (source, destination, read_only) in &mounts {
+                spec.add_bind_mount(source, destination, *read_only);
+            }
+
+            add_workspace_fallback_from(&mut spec, &mounts, fallback_src);
+
+            let got: Vec<&str> = spec.mounts.iter().map(|m| m.destination.as_str()).collect();
+            assert_eq!(
+                got, *expected,
+                "user mount at {target} produced the wrong mount set"
+            );
+        }
+    }
+
+    /// With no user mount in play the fallback must still be added, otherwise
+    /// /workspace stops surviving VM restarts.
+    #[test]
+    fn no_user_mount_still_gets_the_workspace_fallback() {
+        let mut spec = OciSpec::new(
+            &[],
+            &[],
+            "/",
+            false,
+            &crate::oci::ProcessIdentity::root(),
+            false,
+        );
+        spec.mounts.clear();
+        add_workspace_fallback_from(&mut spec, &[], std::path::Path::new("/storage/workspace"));
+        let got: Vec<&str> = spec.mounts.iter().map(|m| m.destination.as_str()).collect();
+        assert_eq!(got, vec!["/workspace"]);
+    }
 
     fn env_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -439,3 +439,106 @@ ensure_clean_test_environment() {
         ps aux | grep -E "(smolvm serve|smolvm-bin machine|smolvm machine)" | grep -v grep || true
     fi
 }
+
+# Drive the at/below-/workspace volume matrix against one machine source and
+# assert the host file RESOLVES inside the guest at every target.
+#
+# The /storage/workspace fallback is appended to the container spec after the
+# user's mounts. While its guard matched only an exact /workspace target, a user
+# mount at /workspace/project let the fallback through, and binding
+# /storage/workspace onto /workspace replaced the directory that nested mount
+# hangs from. The mount itself survived: /proc/self/mountinfo still listed the
+# target as virtiofs, so it still looked mounted, while every read through it
+# returned the empty fallback directory instead of the host's files.
+#
+# That is why this asserts file CONTENT. An assertion that greps
+# /proc/self/mountinfo passes on the broken build and is worth nothing here.
+#
+# Each target pins one rule:
+#   /workspace              exact match, always suppressed the fallback
+#   /workspace/project      the regression — absent before the fix
+#   /workspaces/project     the trap: shares the string prefix but is a sibling
+#                           rather than a child, so it still gets the fallback
+#                           and must still resolve
+#   /mnt/project            unrelated target, fallback still added
+#   /opt/workspace/project  /workspace appears mid-path and must not match
+#
+# A trailing-slash target is deliberately NOT driven here: any volume target
+# written with a trailing slash fails `machine start` outright, on /mnt/ and
+# /data/ just as much as under /workspace, so it cannot reach the guard this
+# exercises. The guard's own slash-normalization is covered by the unit test.
+#
+# Usage: assert_volume_targets_resolve <label> <machine-create-arg>...
+#   e.g. assert_volume_targets_resolve img --image alpine:latest --net
+#        assert_volume_targets_resolve packed --from /path/to/x.smolmachine
+assert_volume_targets_resolve() {
+    local label="$1"
+    shift
+    local source_args=("$@")
+
+    local targets=(
+        "/workspace"
+        "/workspace/project"
+        "/workspaces/project"
+        "/mnt/project"
+        "/opt/workspace/project"
+    )
+
+    local failures=()
+    local idx=0
+
+    for target in "${targets[@]}"; do
+        idx=$((idx + 1))
+        local vm_name="volws-$label-$idx-$$"
+        # The path to read back: the mount target without a trailing slash.
+        local read_path="${target%/}"
+        local marker="host-marker-$label-$idx-$$"
+
+        local tmpdir
+        tmpdir=$(mktemp -d)
+        echo "$marker" > "$tmpdir/marker.txt"
+
+        $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
+
+        if ! $SMOLVM machine create --name "$vm_name" "${source_args[@]}" \
+            -v "$tmpdir:$target" 2>&1; then
+            failures+=("$target: create failed")
+            rm -rf "$tmpdir"
+            continue
+        fi
+
+        run_with_timeout 120 $SMOLVM machine start --name "$vm_name" >/dev/null 2>&1
+        if [[ $? -eq 124 ]]; then
+            failures+=("$target: TIMEOUT on start")
+            $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
+            rm -rf "$tmpdir"
+            continue
+        fi
+
+        local exec_out
+        exec_out=$(run_with_timeout 30 $SMOLVM machine exec --name "$vm_name" -- \
+            cat "$read_path/marker.txt" 2>&1)
+        local exec_rc=$?
+
+        if [[ $exec_rc -eq 124 ]]; then
+            failures+=("$target: TIMEOUT on exec")
+        elif [[ "$exec_out" != *"$marker"* ]]; then
+            # When the fallback shadows the mount this reads as "No such file or
+            # directory" on a target the guest's mount table still lists.
+            failures+=("$target: expected '$marker', got '$exec_out'")
+        fi
+
+        $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
+        rm -rf "$tmpdir"
+        ensure_data_dir_deleted "$vm_name"
+    done
+
+    if [[ ${#failures[@]} -gt 0 ]]; then
+        echo "FAIL: ${#failures[@]} of ${#targets[@]} targets did not resolve:"
+        printf '  %s\n' "${failures[@]}"
+        return 1
+    fi
+    return 0
+}

--- a/tests/test_machine_packed.sh
+++ b/tests/test_machine_packed.sh
@@ -154,7 +154,34 @@ test_cp_preserves_state_on_packed_vm() {
 }
 
 
+# The same at/below-/workspace volume matrix as the --image suite, against a
+# packed machine. Packed layers only change where the rootfs comes from, not how
+# the container spec's mounts are assembled, so the matrix must come out
+# identical — this is the arm that proves it rather than assuming it.
+test_packed_volume_targets_resolve_inside_guest() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    local pack_output="$tmpdir/vol-matrix-pack"
+
+    if ! $SMOLVM pack create --image alpine:latest -o "$pack_output" --cpus 1 --mem 512 2>&1; then
+        echo "FAIL: pack create failed, packed arm not validated"
+        rm -rf "$tmpdir"
+        return 1
+    fi
+    if [[ ! -f "$pack_output.smolmachine" ]]; then
+        echo "FAIL: no .smolmachine sidecar produced"
+        rm -rf "$tmpdir"
+        return 1
+    fi
+
+    assert_volume_targets_resolve packed --from "$pack_output.smolmachine"
+    local rc=$?
+    rm -rf "$tmpdir"
+    return $rc
+}
+
 run_test "Create from .smolmachine" test_create_from_smolmachine || true
 run_test "File cp preserves state on packed VM" test_cp_preserves_state_on_packed_vm || true
+run_test "Packed: volume targets at/below /workspace resolve in guest" test_packed_volume_targets_resolve_inside_guest || true
 
 print_summary "Packed Machine Tests"

--- a/tests/test_volumes.sh
+++ b/tests/test_volumes.sh
@@ -236,11 +236,18 @@ EOF
 }
 
 
+# The at/below-/workspace volume matrix against a registry --image machine.
+# The driver and the reasoning live in common.sh.
+test_image_volume_targets_resolve_inside_guest() {
+    assert_volume_targets_resolve img --image alpine:latest --net
+}
+
 run_test "Volume: mount visible to exec" test_machine_volume_mount_visible_to_exec || true
 run_test "Volume: -v host:/workspace is virtiofs not symlink" test_volume_mount_workspace_is_virtiofs_not_symlink || true
 run_test "Volume: arbitrary mount path (/data)" test_volume_mount_arbitrary_path || true
 run_test "Volume: default /workspace symlink without -v" test_default_workspace_symlink_without_volume || true
 run_test "Create with --image: volume mount visible to exec" test_image_exec_volume_mount_visible || true
 run_test "Create with --image: Smolfile volumes visible to exec" test_image_exec_volume_mount_visible_smolfile || true
+run_test "Create with --image: volume targets at/below /workspace resolve in guest" test_image_volume_targets_resolve_inside_guest || true
 
 print_summary "Volume Tests"


### PR DESCRIPTION
A host volume mounted below `/workspace` is reported as a virtiofs mount but its files are not there. fgrehm's repro in #1004 isolates it: the same source works at `/mnt/project`, `/workspaces/project`, `/opt/workspace/project` and at `/workspace` itself, and only a nested path under `/workspace` fails.

The guard that suppresses the `/storage/workspace` fallback matched a mount target equal to `/workspace`, so a volume at `/workspace/project` missed it and the fallback went in anyway. The fallback is added after the user's mounts, so binding `/storage/workspace` onto `/workspace` replaced the directory the nested mount hangs from. The mount survives and `/proc/self/mountinfo` still lists it, but it stops resolving by path, and the user sees the empty fallback directory instead of their files. The guard now compares path components instead of a string prefix, because `/workspaces/project` shares the characters of `/workspace` but is a sibling rather than a child and must still get the fallback.

Not affected: an exact `-v host:/workspace` still suppresses the fallback, and a machine with no user mount there still gets it, so `/workspace` keeps surviving VM restarts. All four callers go through the unchanged wrapper.

Verified on Linux/KVM against the five targets from the issue, reading the host marker through `machine exec`:

| guest target | before | after |
| --- | --- | --- |
| `/workspace` | visible | visible |
| `/workspace/project` | **absent** | visible |
| `/workspaces/project` | visible | visible |
| `/mnt/project` | visible | visible |
| `/opt/workspace/project` | visible | visible |

The shadowing is visible inside the guest before the fix, where 59 is the user's mount and 72 is the fallback landing on its parent:

```
59 58 0:30  /          /workspace/project rw,relatime - virtiofs smolvm0
72 58 254:0 /workspace /workspace         rw,noatime  - ext4 /dev/vda
```

`a_user_mount_below_workspace_suppresses_the_fallback` drives those five targets plus a trailing-slash case and asserts the resulting mount set. On the old rule it fails with `/workspace` still in the set.

That matrix now runs against real VMs as well, on both machine sources.

`tests/common.sh` gains `assert_volume_targets_resolve`, which takes the machine source as arguments, boots a machine per target, and reads a host file back through `machine exec`. It asserts file contents rather than `/proc/self/mountinfo`, because a mount-table assertion passes on the broken build: the mount was listed there the whole time and simply stopped resolving by path. `test_volumes.sh` calls it for a registry `--image` machine and `test_machine_packed.sh` for a packed `--from` machine, so neither suite duplicates the driver.

| arm | before | after |
| --- | --- | --- |
| `--image alpine:latest` | `/workspace/project` absent, other four visible | all five visible |
| packed `--from *.smolmachine` | `/workspace/project` absent, other four visible | all five visible |

The before column is measured rather than inferred. Both suites were re-run against a guest agent built from `main` at `ef5d5f7a`, and in each arm exactly one target fails, with `cat: can't open '/workspace/project/marker.txt': No such file or directory`, while the other four pass. Packed reproduces the original bug and takes the fix identically, so the packed failure reported in the issue is this same defect and not a second one.

Environment: Apple silicon aarch64, Darwin 25.5, Hypervisor.framework. The earlier Linux aarch64 run stands; this adds a platform rather than replacing it.

⚠ Remaining: the trailing-slash target stays unit-test-only. Any volume target written with a trailing slash fails `machine start` before it reaches this guard, on `/mnt/project/` and `/data/` as much as under `/workspace`, so it cannot be driven end to end. `repair_boot_volume_mounts` checks `is_mountpoint` against the unnormalized target and rejects it. That is a separate pre-existing defect in the guest agent, present on `main` at the same line, and it is not touched here.

