### PR TITLE
Allow the two new clippy 1.98 lints that turned every CI job red

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,16 @@ wiremock = "0.6"
 [build-dependencies]
 pkg-config = "0.3"
 
+# clippy 1.98 added `chunks_exact_to_as_chunks`, which fires under `-D warnings`
+# on ~19 pre-existing `chunks_exact(N)` sites across six crates and turned CI red
+# repo-wide. Allowed here so the lint does not gate unrelated work; converting the
+# call sites to `as_chunks::<N>()` is worth doing deliberately, not in a sweep
+# (one of them is the ICMP checksum, which also uses `.remainder()`).
+[workspace.lints.clippy]
+chunks_exact_to_as_chunks = "allow"
+# `for tick in 0..` in the CUDA probe binary is a deliberate polling loop.
+for_unbounded_range = "allow"
+
 [workspace.dependencies]
 base64 = "0.22"
 serde = { version = "1", features = ["derive"] }

--- a/crates/smolvm-cuda-guest/Cargo.toml
+++ b/crates/smolvm-cuda-guest/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 description = "Guest-side CUDA-over-vsock runner for smolvm microVMs (Linux)"
 license = "Apache-2.0"
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "smolvm-cuda-run"
 path = "src/main.rs"

--- a/crates/smolvm-cuda-shim/Cargo.toml
+++ b/crates/smolvm-cuda-shim/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 description = "Guest-side libcuda.so.1 drop-in: CUDA Driver API over smolvm's vsock RPC"
 license = "Apache-2.0"
 
+[lints]
+workspace = true
+
 [lib]
 name = "cuda"
 crate-type = ["cdylib"]

--- a/crates/smolvm-cuda/Cargo.toml
+++ b/crates/smolvm-cuda/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 description = "CUDA Driver-API remoting over vsock for smolvm guests"
 license = "Apache-2.0"
 
+[lints]
+workspace = true
+
 [features]
 # host: server-side dispatch + CPU emulation backend (std only).
 # gpu:  real driver backend via libloading (implies host).

--- a/crates/smolvm-cudart-shim/Cargo.toml
+++ b/crates/smolvm-cudart-shim/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 description = "Guest-side libcudart.so drop-in: CUDA Runtime API lowered to smolvm's Driver-API vsock RPC"
 license = "Apache-2.0"
 
+[lints]
+workspace = true
+
 [lib]
 name = "cudart"
 crate-type = ["cdylib"]

--- a/crates/smolvm-network/Cargo.toml
+++ b/crates/smolvm-network/Cargo.toml
@@ -6,6 +6,9 @@ description = "Host-side virtio-net runtime for smolvm"
 license = "Apache-2.0"
 repository = "https://github.com/smol-machines/smolvm"
 
+[lints]
+workspace = true
+
 [dependencies]
 crossbeam-queue = "0.3"
 humantime = "2"

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -1996,7 +1996,9 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
                         return None;
                     }
                     Some(
-                        buf.chunks_exact(3)
+                        buf.as_chunks::<3>()
+                            .0
+                            .iter()
                             .map(|c| (c[0], c[1], c[2]))
                             .collect::<Vec<_>>(),
                     )

--- a/src/api/device_handoff.rs
+++ b/src/api/device_handoff.rs
@@ -200,7 +200,7 @@ fn validate_bundle_metadata(metadata: &[u8], allocation_size: u64) -> Result<(),
     for (tensor, range) in manifest
         .tensors
         .iter()
-        .zip(metadata[ranges_offset..].chunks_exact(16))
+        .zip(metadata[ranges_offset..].as_chunks::<16>().0)
     {
         if tensor.name.is_empty()
             || tensor.name.len() > MAX_TENSOR_NAME_BYTES

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -475,7 +475,7 @@ fn validate_tensor_bundle_metadata(metadata: &[u8], allocation_size: u64) -> io:
         ));
     }
     let mut prior_end = 0u64;
-    for tensor in metadata[8 + manifest_len..].chunks_exact(16) {
+    for tensor in metadata[8 + manifest_len..].as_chunks::<16>().0 {
         let offset = u64::from_le_bytes(tensor[0..8].try_into().unwrap());
         let size = u64::from_le_bytes(tensor[8..16].try_into().unwrap());
         let end = offset
@@ -4287,7 +4287,7 @@ fn decode_attach_procmem(data: &[u8]) -> io::Result<Option<ProcMemAdvert>> {
         return Ok(None);
     }
     let mut regions = Vec::with_capacity(n);
-    for chunk in data[12..].chunks_exact(24) {
+    for chunk in data[12..].as_chunks::<24>().0 {
         regions.push((
             u64::from_le_bytes(chunk[0..8].try_into().unwrap()),
             u64::from_le_bytes(chunk[8..16].try_into().unwrap()),


### PR DESCRIPTION
Every clippy job went red today, and not because of anything in the tree. `rust-toolchain.toml` tracks `channel = "stable"`, stable rolled to clippy 1.98, and two of its new lints fire under `-D warnings` on code that has been there for months. We hit this opening #1005 for #1004, and it blocks that PR and every other one until it is resolved, so community fixes cannot land behind it.

`chunks_exact_to_as_chunks` is most of it, on 19 sites across six crates, and `for_unbounded_range` fires once on the deliberate `for tick in 0..` polling loop in the CUDA probe binary. Both are allowed at the workspace level instead of swept, because the conversion deserves doing deliberately rather than mechanically: one site is the ICMP one's-complement checksum in `smolvm-network`, which pairs `chunks_exact(2)` with `.remainder()` and needs the two-value form, and six more are example binaries. The four sites in the root crate are converted here instead, because the root package does not pick up `[workspace.lints]` the way the member crates do.

Not affected: no behaviour changes anywhere. `as_chunks::<N>().0` yields exactly the complete chunks `chunks_exact(N)` yielded, with the remainder in `.1` rather than `.remainder()`, and all four converted sites already discarded the remainder.

Verified on clippy 1.98, the version that flagged it:

```
cargo +1.98.0 clippy --workspace --all-targets -- -D warnings                     exit 0
cargo +1.98.0 clippy -p smolvm-cuda --no-default-features --lib -- -D warnings    exit 0
cargo fmt --all -- --check                                                        exit 0
cargo test --lib                                                                  640 passed
cargo test -p smolvm-agent --bins                                                 158 passed
```

⚠ Remaining: this stops the bleeding, it does not fix the cause. `rust-toolchain.toml` pins a moving channel, so the next lint that lands repeats this. Pinning a specific version is a separate change and is not done here.
