### PR TITLE
Make image pulls work behind a proxy: thread it through the init bake and inherit it from the environment

### DIFF
--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -795,6 +795,27 @@ fn image_bakeable(image: Option<&str>) -> bool {
     )
 }
 
+/// Build the bake's `machine start` argv, forwarding the run's `--proxy` /
+/// `--no-proxy` so the one-time init pull reaches the registry through the same
+/// proxy the outer run uses. Without this, a Smolfile with `init` steps pulls
+/// direct in the bake and times out on a proxy-only network.
+fn bake_start_args<'a>(
+    tmp: &'a str,
+    proxy: Option<&'a str>,
+    no_proxy: Option<&'a str>,
+) -> Vec<&'a str> {
+    let mut start = vec!["machine", "start", "--name", tmp];
+    if let Some(p) = proxy {
+        start.push("--proxy");
+        start.push(p);
+    }
+    if let Some(n) = no_proxy {
+        start.push("--no-proxy");
+        start.push(n);
+    }
+    start
+}
+
 /// Bake `image + init` into a cached `.smolmachine` (or reuse an existing one) and
 /// return its path. Runs the well-tested `machine create/start/stop` + `pack create
 /// --from-vm` flow as subprocesses of this same binary: create a temp machine from
@@ -806,6 +827,8 @@ fn ensure_init_layer(
     smolfile: Option<&Path>,
     rebuild: bool,
     digest: Option<&str>,
+    proxy: Option<&str>,
+    no_proxy: Option<&str>,
 ) -> smolvm::Result<PathBuf> {
     // The bake here only ever receives a registry image: `ensure_init_layer` is
     // gated on `image_bakeable()` (local archives/dirs take the direct path),
@@ -920,7 +943,12 @@ fn ensure_init_layer(
 
         println!("  · pulling image and running init...");
         run_smolvm(&exe, &create)?;
-        run_smolvm(&exe, &["machine", "start", "--name", &tmp])?;
+        // The image pull happens at `start`; forward the run's proxy so the
+        // bake reaches the registry through a corporate/loopback proxy too —
+        // otherwise a Smolfile with `init` steps pulls direct and times out
+        // even when the outer run was given --proxy.
+        let start = bake_start_args(&tmp, proxy, no_proxy);
+        run_smolvm(&exe, &start)?;
         run_smolvm(&exe, &["machine", "stop", "--name", &tmp])?;
         println!("  · snapshotting...");
         run_smolvm(
@@ -1234,6 +1262,8 @@ impl RunCmd {
                 self.smolfile.as_deref(),
                 self.rebuild_init_cache,
                 resolved_digest.as_deref(),
+                self.proxy_opts.proxy(),
+                self.proxy_opts.no_proxy(),
             )?;
             // The real workload: CLI trailing args win, else the Smolfile's
             // entrypoint+cmd (the baked artifact's own command is a `/bin/true` no-op).
@@ -1981,6 +2011,41 @@ impl RunCmd {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn bake_start_forwards_proxy_when_set() {
+        // No proxy: plain start.
+        assert_eq!(
+            super::bake_start_args("t", None, None),
+            ["machine", "start", "--name", "t"]
+        );
+        // Proxy only.
+        assert_eq!(
+            super::bake_start_args("t", Some("http://host.smolvm.internal:8118"), None),
+            [
+                "machine",
+                "start",
+                "--name",
+                "t",
+                "--proxy",
+                "http://host.smolvm.internal:8118"
+            ]
+        );
+        // Proxy + no_proxy.
+        assert_eq!(
+            super::bake_start_args("t", Some("http://p:3128"), Some("localhost,.internal")),
+            [
+                "machine",
+                "start",
+                "--name",
+                "t",
+                "--proxy",
+                "http://p:3128",
+                "--no-proxy",
+                "localhost,.internal"
+            ]
+        );
+    }
+
     #[test]
     fn cp_mode_parses_common_octal_forms_and_rejects_garbage() {
         assert_eq!(super::parse_octal_mode("644").unwrap(), 0o644);

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -1262,8 +1262,8 @@ impl RunCmd {
                 self.smolfile.as_deref(),
                 self.rebuild_init_cache,
                 resolved_digest.as_deref(),
-                self.proxy_opts.proxy(),
-                self.proxy_opts.no_proxy(),
+                self.proxy_opts.proxy().as_deref(),
+                self.proxy_opts.no_proxy().as_deref(),
             )?;
             // The real workload: CLI trailing args win, else the Smolfile's
             // entrypoint+cmd (the baked artifact's own command is a `/bin/true` no-op).
@@ -1572,8 +1572,8 @@ impl RunCmd {
                 &mut client,
                 img,
                 effective_platform.as_deref(),
-                self.proxy_opts.proxy(),
-                self.proxy_opts.no_proxy(),
+                self.proxy_opts.proxy().as_deref(),
+                self.proxy_opts.no_proxy().as_deref(),
             ) {
                 Ok(info) => Some(info),
                 Err(e) if !params.net => {
@@ -3533,13 +3533,17 @@ impl StartCmd {
             vm_common::ForkLaunch::default()
         };
         match vm_common::start_vm_named(
-            &name, proxy, no_proxy, /* from_snapshot */ false, fork,
+            &name,
+            proxy.as_deref(),
+            no_proxy.as_deref(),
+            /* from_snapshot */ false,
+            fork,
         ) {
             Ok(()) => Ok(()),
             Err(smolvm::Error::VmNotFound { .. }) if !explicit_name => {
                 // Only fall back to creating a default VM when no --name was given.
                 // With an explicit --name, VmNotFound is a real error.
-                vm_common::start_vm_default(proxy, no_proxy)
+                vm_common::start_vm_default(proxy.as_deref(), no_proxy.as_deref())
             }
             Err(e) => Err(e),
         }

--- a/src/cli/pack.rs
+++ b/src/cli/pack.rs
@@ -340,8 +340,8 @@ impl PackCreateCmd {
             &mut client,
             &image,
             pack_config.oci_platform.as_deref(),
-            self.proxy_opts.proxy(),
-            self.proxy_opts.no_proxy(),
+            self.proxy_opts.proxy().as_deref(),
+            self.proxy_opts.no_proxy().as_deref(),
         )?;
         debug!(image_info = ?image_info, "image pulled");
 
@@ -559,8 +559,8 @@ impl PackCreateCmd {
         // single-layer flatten).
         self.collect_base_assets(&mut collector)?;
         let export_opts = smolvm::pack_export::FromVmExportOptions {
-            proxy: self.proxy_opts.proxy().map(str::to_string),
-            no_proxy: self.proxy_opts.no_proxy().map(str::to_string),
+            proxy: self.proxy_opts.proxy(),
+            no_proxy: self.proxy_opts.no_proxy(),
             rebase_from_image: self.rebase_from_image,
         };
         let assets = smolvm::pack_export::collect_from_vm_assets(

--- a/src/cli/proxy_opts.rs
+++ b/src/cli/proxy_opts.rs
@@ -20,11 +20,78 @@ pub struct ProxyOpts {
 }
 
 impl ProxyOpts {
-    pub fn proxy(&self) -> Option<&str> {
-        self.proxy.as_deref()
+    /// Proxy URL for the in-VM image pull: the explicit `--proxy` flag, else the
+    /// standard proxy environment variables (`HTTPS_PROXY`/`HTTP_PROXY`/
+    /// `ALL_PROXY`, upper- or lower-case), so it works out of the box on a
+    /// proxy-only network the way curl/docker/go do.
+    pub fn proxy(&self) -> Option<String> {
+        self.proxy.clone().or_else(|| {
+            first_nonempty_env(&[
+                "HTTPS_PROXY",
+                "https_proxy",
+                "HTTP_PROXY",
+                "http_proxy",
+                "ALL_PROXY",
+                "all_proxy",
+            ])
+        })
     }
 
-    pub fn no_proxy(&self) -> Option<&str> {
-        self.no_proxy.as_deref()
+    /// NO_PROXY bypass list: the `--no-proxy` flag, else `NO_PROXY`/`no_proxy`.
+    pub fn no_proxy(&self) -> Option<String> {
+        self.no_proxy
+            .clone()
+            .or_else(|| first_nonempty_env(&["NO_PROXY", "no_proxy"]))
+    }
+}
+
+/// First environment variable in `names` that is set to a non-empty value.
+fn first_nonempty_env(names: &[&str]) -> Option<String> {
+    names
+        .iter()
+        .find_map(|n| std::env::var(n).ok().filter(|v| !v.trim().is_empty()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn env_fallback_picks_first_nonempty_in_order() {
+        // Isolated names so the test never races real proxy vars.
+        let a = "SMOLVM_TEST_PROXY_A_q7";
+        let b = "SMOLVM_TEST_PROXY_B_q7";
+        std::env::remove_var(a);
+        std::env::remove_var(b);
+        assert_eq!(first_nonempty_env(&[a, b]), None);
+        std::env::set_var(b, "http://b:3128");
+        assert_eq!(
+            first_nonempty_env(&[a, b]).as_deref(),
+            Some("http://b:3128")
+        );
+        // Whitespace-only is treated as unset; earlier-listed wins once real.
+        std::env::set_var(a, "   ");
+        assert_eq!(
+            first_nonempty_env(&[a, b]).as_deref(),
+            Some("http://b:3128")
+        );
+        std::env::set_var(a, "http://a:3128");
+        assert_eq!(
+            first_nonempty_env(&[a, b]).as_deref(),
+            Some("http://a:3128")
+        );
+        std::env::remove_var(a);
+        std::env::remove_var(b);
+    }
+
+    #[test]
+    fn explicit_flag_wins_over_env() {
+        let opts = ProxyOpts {
+            proxy: Some("http://flag:3128".to_string()),
+            no_proxy: Some("localhost".to_string()),
+        };
+        // The flag short-circuits before any env lookup.
+        assert_eq!(opts.proxy().as_deref(), Some("http://flag:3128"));
+        assert_eq!(opts.no_proxy().as_deref(), Some("localhost"));
     }
 }


### PR DESCRIPTION
Two fixes so a proxy-only network can pull images: (1) forward the run's proxy to the init-layer bake's start subprocess, which previously dropped it so a Smolfile with init steps pulled direct and timed out; (2) inherit HTTPS_PROXY/HTTP_PROXY/ALL_PROXY and NO_PROXY from the environment when --proxy is not given, matching curl/docker/go.