### PR TITLE
Use as_chunks instead of chunks_exact with a constant size across the workspace

### DIFF
--- a/crates/smolvm-cuda-guest/src/main.rs
+++ b/crates/smolvm-cuda-guest/src/main.rs
@@ -96,8 +96,10 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     let out = cu.memcpy_dtoh(dc, bytes, 0)?;
     let c: Vec<f32> = out
-        .chunks_exact(4)
-        .map(|p| f32::from_le_bytes(p.try_into().unwrap()))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|p| f32::from_le_bytes(*p))
         .collect();
 
     for i in 0..n {
@@ -181,7 +183,10 @@ fn run_loop() -> Result<(), Box<dyn std::error::Error>> {
     cu.ctx_synchronize()?;
     append(format!("BOOT tag={tag} dptr=0x{dptr:x} token={token}"));
 
-    for tick in 0.. {
+    let mut counter: u64 = 0;
+    loop {
+        let tick = counter;
+        counter += 1;
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_millis())
@@ -189,8 +194,10 @@ fn run_loop() -> Result<(), Box<dyn std::error::Error>> {
         match cu.memcpy_dtoh(dptr, 16, 0) {
             Ok(bytes) => {
                 let v: Vec<f32> = bytes
-                    .chunks_exact(4)
-                    .map(|p| f32::from_le_bytes(p.try_into().unwrap()))
+                    .as_chunks::<4>()
+                    .0
+                    .iter()
+                    .map(|p| f32::from_le_bytes(*p))
                     .collect();
                 let ok = v
                     .iter()
@@ -216,7 +223,6 @@ fn run_loop() -> Result<(), Box<dyn std::error::Error>> {
         }
         std::thread::sleep(std::time::Duration::from_millis(500));
     }
-    Ok(())
 }
 
 #[cfg(target_os = "linux")]
@@ -256,8 +262,10 @@ fn run_reader(
     let dptr = u64::from_str_radix(ptr_env.trim().trim_start_matches("0x"), 16)?;
     let out = cu.memcpy_dtoh(dptr, 16, 0)?;
     let got: Vec<f32> = out
-        .chunks_exact(4)
-        .map(|p| f32::from_le_bytes(p.try_into().unwrap()))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|p| f32::from_le_bytes(*p))
         .collect();
     let ok = got
         .iter()

--- a/crates/smolvm-cuda-shim/src/lib.rs
+++ b/crates/smolvm-cuda-shim/src/lib.rs
@@ -1794,8 +1794,8 @@ mod mapped_host_memory {
         file.read_exact_at(&mut entries, (base / PAGE) as u64 * 8)
             .ok()?;
         let mut first = None;
-        for (index, entry) in entries.chunks_exact(8).enumerate() {
-            let entry = u64::from_le_bytes(entry.try_into().unwrap());
+        for (index, entry) in entries.as_chunks::<8>().0.iter().enumerate() {
+            let entry = u64::from_le_bytes(*entry);
             if entry & (1 << 63) == 0 {
                 return None;
             }

--- a/crates/smolvm-cuda/examples/gpu_loopback.rs
+++ b/crates/smolvm-cuda/examples/gpu_loopback.rs
@@ -98,8 +98,10 @@ fn main() {
 
     let out = cu.memcpy_dtoh(dc, bytes, 0).expect("d2h");
     let c: Vec<f32> = out
-        .chunks_exact(4)
-        .map(|p| f32::from_le_bytes(p.try_into().unwrap()))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|p| f32::from_le_bytes(*p))
         .collect();
     for i in 0..n {
         let expect = a[i] + b[i]; // i + 3i = 4i
@@ -172,8 +174,10 @@ fn main() {
         .expect("synchronize updated graph");
     let updated = cu.memcpy_dtoh(dc, bytes, stream).expect("updated d2h");
     let updated: Vec<f32> = updated
-        .chunks_exact(4)
-        .map(|p| f32::from_le_bytes(p.try_into().unwrap()))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|p| f32::from_le_bytes(*p))
         .collect();
     for (i, &value) in updated.iter().enumerate() {
         let expect = (2 * i) as f32;

--- a/crates/smolvm-cuda/examples/m1_route_probe.rs
+++ b/crates/smolvm-cuda/examples/m1_route_probe.rs
@@ -79,8 +79,10 @@ fn main() {
     cu.ctx_synchronize().expect("sync");
     let out = cu.memcpy_dtoh(dc, bytes, 0).expect("d2h");
     let c: Vec<f32> = out
-        .chunks_exact(4)
-        .map(|p| f32::from_le_bytes(p.try_into().unwrap()))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|p| f32::from_le_bytes(*p))
         .collect();
     let ok = (0..n).all(|i| (c[i] - (a[i] + b[i])).abs() < 1e-2);
     println!(

--- a/crates/smolvm-cuda/examples/m3a_probe.rs
+++ b/crates/smolvm-cuda/examples/m3a_probe.rs
@@ -61,8 +61,10 @@ fn main() {
             let check: Vec<f32> = cu
                 .memcpy_dtoh(va_a, 32, 0)
                 .unwrap()
-                .chunks_exact(4)
-                .map(|p| f32::from_le_bytes(p.try_into().unwrap()))
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .map(|p| f32::from_le_bytes(*p))
                 .collect();
             eprintln!("golden: wrote a; reads back a[0..8]={check:?}");
             std::fs::write(state, format!("{token} {va_a} {va_b} {va_c} {func}")).unwrap();
@@ -96,14 +98,18 @@ fn main() {
             let ra: Vec<f32> = cu
                 .memcpy_dtoh(va_a, 32, 0)
                 .expect("d2h a")
-                .chunks_exact(4)
-                .map(|p| f32::from_le_bytes(p.try_into().unwrap()))
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .map(|p| f32::from_le_bytes(*p))
                 .collect();
             let rb: Vec<f32> = cu
                 .memcpy_dtoh(va_b, 32, 0)
                 .expect("d2h b")
-                .chunks_exact(4)
-                .map(|p| f32::from_le_bytes(p.try_into().unwrap()))
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .map(|p| f32::from_le_bytes(*p))
                 .collect();
             eprintln!("clone: read golden a[0..8]={ra:?} b[0..8]={rb:?}");
             eprintln!("clone: launching vecadd with INHERITED func={func:#x}");
@@ -126,8 +132,10 @@ fn main() {
             cu.ctx_synchronize().expect("sync");
             let out = cu.memcpy_dtoh(va_c, (N * 4) as u64, 0).expect("d2h");
             let c: Vec<f32> = out
-                .chunks_exact(4)
-                .map(|p| f32::from_le_bytes(p.try_into().unwrap()))
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .map(|p| f32::from_le_bytes(*p))
                 .collect();
             let ok = (0..N).all(|i| (c[i] - (4 * i) as f32).abs() < 1e-2);
             std::fs::write(&done, "done").ok();

--- a/crates/smolvm-cuda/examples/m3a_stream_probe.rs
+++ b/crates/smolvm-cuda/examples/m3a_stream_probe.rs
@@ -121,8 +121,10 @@ fn main() {
             cu.stream_synchronize(stream).expect("stream_synchronize");
             let out = cu.memcpy_dtoh(va_c, (N * 4) as u64, 0).expect("d2h");
             let c: Vec<f32> = out
-                .chunks_exact(4)
-                .map(|p| f32::from_le_bytes(p.try_into().unwrap()))
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .map(|p| f32::from_le_bytes(*p))
                 .collect();
             let ok = (0..N).all(|i| (c[i] - (4 * i) as f32).abs() < 1e-2);
             std::fs::write(&done, "done").ok();

--- a/crates/smolvm-cuda/src/client.rs
+++ b/crates/smolvm-cuda/src/client.rs
@@ -1449,8 +1449,10 @@ impl<S: Read + Write> Client<S> {
             Op::FuncGetParamInfo,
         )? {
             Response::Data(d) if d.len() % 4 == 0 => Ok(d
-                .chunks_exact(4)
-                .map(|c| u32::from_le_bytes(c.try_into().unwrap()))
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .map(|c| u32::from_le_bytes(*c))
                 .collect()),
             _ => Err(CudaRpcError::Protocol("expected u32-array Data")),
         }
@@ -1552,8 +1554,10 @@ impl<S: Read + Write> Client<S> {
             Op::EventCreateBatch,
         )? {
             Response::Data(bytes) if bytes.len() == count as usize * 8 => Ok(bytes
-                .chunks_exact(8)
-                .map(|chunk| u64::from_le_bytes(chunk.try_into().expect("8-byte chunk")))
+                .as_chunks::<8>()
+                .0
+                .iter()
+                .map(|chunk| u64::from_le_bytes(*chunk))
                 .collect()),
             Response::Data(_) => Err(CudaRpcError::Protocol("invalid event batch length")),
             _ => Err(CudaRpcError::Protocol("expected Data")),

--- a/crates/smolvm-cuda/src/host.rs
+++ b/crates/smolvm-cuda/src/host.rs
@@ -4333,8 +4333,8 @@ fn dispatch(sess: &mut Session, b: &mut dyn Backend, req: Request) -> (i32, Resp
                     let (mut found, mut sample) = (0u64, Vec::new());
                     for (cptr, size) in copies {
                         if let Ok(bytes) = b.memcpy_dtoh(cptr, size, 0) {
-                            for ch in bytes.chunks_exact(8) {
-                                let v = u64::from_ne_bytes(ch.try_into().unwrap());
+                            for ch in bytes.as_chunks::<8>().0 {
+                                let v = u64::from_ne_bytes(*ch);
                                 if ranges.iter().any(|&(lo, hi)| v >= lo && v < hi) {
                                     found += 1;
                                     if sample.len() < 6 {

--- a/crates/smolvm-cuda/src/host/gpu.rs
+++ b/crates/smolvm-cuda/src/host/gpu.rs
@@ -1312,7 +1312,8 @@ impl Backend for GpuBackend {
         let func_info = self.func_get_param_info.ok_or(CUDA_ERROR_NOT_SUPPORTED)?;
         let mut selected = func_info;
         let mut sizes = Vec::new();
-        for i in 0.. {
+        let mut i = 0;
+        loop {
             let (mut offset, mut size): (usize, usize) = (0, 0);
             let mut code = unsafe { selected(function as *mut c_void, i, &mut offset, &mut size) };
             if i == 0 && code == CUDA_ERROR_INVALID_RESOURCE_HANDLE {
@@ -1327,6 +1328,7 @@ impl Backend for GpuBackend {
                 CUDA_ERROR_INVALID_VALUE => break,
                 other => return Err(other),
             }
+            i += 1;
         }
         Ok(sizes)
     }
@@ -2703,8 +2705,8 @@ impl CudnnBackend {
                 let count = rd_i64(args, 16);
                 let mut elems = args[24..].to_vec();
                 if handle_bearing(ty) {
-                    for chunk in elems.chunks_exact_mut(8) {
-                        let h = u64::from_le_bytes(chunk.try_into().unwrap());
+                    for chunk in elems.as_chunks_mut::<8>().0 {
+                        let h = u64::from_le_bytes(*chunk);
                         // VOID_PTR(6) = device pointer (fork-translate); HANDLE(0)
                         // / BACKEND_DESCRIPTOR(15) = opaque handle (vh_resolve).
                         let r = if ty == 6 {
@@ -2712,7 +2714,7 @@ impl CudnnBackend {
                         } else {
                             vh_resolve(vh, h)
                         };
-                        chunk.copy_from_slice(&r.to_le_bytes());
+                        *chunk = r.to_le_bytes();
                     }
                 }
                 let st = unsafe { (self.set_attr)(desc, name, ty, count, elems.as_ptr().cast()) };
@@ -2734,14 +2736,14 @@ impl CudnnBackend {
                 let seed = input.len().min(cap);
                 buf[..seed].copy_from_slice(&input[..seed]);
                 if handle_bearing(ty) {
-                    for chunk in buf[..seed].chunks_exact_mut(8) {
-                        let h = u64::from_le_bytes(chunk.try_into().unwrap());
+                    for chunk in buf[..seed].as_chunks_mut::<8>().0 {
+                        let h = u64::from_le_bytes(*chunk);
                         let r = if ty == 6 {
                             dptr_resolve(h)
                         } else {
                             vh_resolve(vh, h)
                         };
-                        chunk.copy_from_slice(&r.to_le_bytes());
+                        *chunk = r.to_le_bytes();
                     }
                 }
                 let mut count: i64 = 0;

--- a/crates/smolvm-cudart-shim/src/lib.rs
+++ b/crates/smolvm-cudart-shim/src/lib.rs
@@ -5173,8 +5173,8 @@ fn bn_memo_key(func: u16, args: &[u8]) -> Option<Vec<u8>> {
     let mut key = Vec::with_capacity(args.len() * 4);
     key.extend_from_slice(&func.to_le_bytes());
     key.extend_from_slice(&args[..16]);
-    for chunk in args[16..].chunks_exact(8) {
-        let h = u64::from_le_bytes(chunk.try_into().unwrap());
+    for chunk in args[16..].as_chunks::<8>().0 {
+        let h = u64::from_le_bytes(*chunk);
         if h == 0 {
             key.push(0);
             continue;

--- a/crates/smolvm-network/src/icmp_relay.rs
+++ b/crates/smolvm-network/src/icmp_relay.rs
@@ -346,12 +346,12 @@ fn echo_request_bytes(destination: IpAddr, seq: u16, data: &[u8]) -> Vec<u8> {
 /// One's-complement sum of 16-bit words, complemented — the ICMP/IP checksum.
 fn internet_checksum(bytes: &[u8]) -> u16 {
     let mut sum: u32 = 0;
-    let mut chunks = bytes.chunks_exact(2);
-    for chunk in &mut chunks {
+    let (words, rem) = bytes.as_chunks::<2>();
+    for chunk in words {
         sum += u16::from_be_bytes([chunk[0], chunk[1]]) as u32;
     }
     // A trailing odd byte is padded on the right with zero.
-    if let [last] = chunks.remainder() {
+    if let [last] = rem {
         sum += (*last as u32) << 8;
     }
     while sum >> 16 != 0 {

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -1996,7 +1996,9 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
                         return None;
                     }
                     Some(
-                        buf.chunks_exact(3)
+                        buf.as_chunks::<3>()
+                            .0
+                            .iter()
                             .map(|c| (c[0], c[1], c[2]))
                             .collect::<Vec<_>>(),
                     )

--- a/src/api/device_handoff.rs
+++ b/src/api/device_handoff.rs
@@ -200,7 +200,7 @@ fn validate_bundle_metadata(metadata: &[u8], allocation_size: u64) -> Result<(),
     for (tensor, range) in manifest
         .tensors
         .iter()
-        .zip(metadata[ranges_offset..].chunks_exact(16))
+        .zip(metadata[ranges_offset..].as_chunks::<16>().0.iter())
     {
         if tensor.name.is_empty()
             || tensor.name.len() > MAX_TENSOR_NAME_BYTES

--- a/src/cuda_daemon.rs
+++ b/src/cuda_daemon.rs
@@ -475,7 +475,7 @@ fn validate_tensor_bundle_metadata(metadata: &[u8], allocation_size: u64) -> io:
         ));
     }
     let mut prior_end = 0u64;
-    for tensor in metadata[8 + manifest_len..].chunks_exact(16) {
+    for tensor in metadata[8 + manifest_len..].as_chunks::<16>().0 {
         let offset = u64::from_le_bytes(tensor[0..8].try_into().unwrap());
         let size = u64::from_le_bytes(tensor[8..16].try_into().unwrap());
         let end = offset
@@ -4287,7 +4287,7 @@ fn decode_attach_procmem(data: &[u8]) -> io::Result<Option<ProcMemAdvert>> {
         return Ok(None);
     }
     let mut regions = Vec::with_capacity(n);
-    for chunk in data[12..].chunks_exact(24) {
+    for chunk in data[12..].as_chunks::<24>().0 {
         regions.push((
             u64::from_le_bytes(chunk[0..8].try_into().unwrap()),
             u64::from_le_bytes(chunk[8..16].try_into().unwrap()),


### PR DESCRIPTION
A newer clippy (1.98) promotes chunks_exact/chunks_exact_mut with a constant size to a -D-warnings error, failing CI across every open PR; rewrite all occurrences to as_chunks/as_chunks_mut (which also drops the defensive try_into panics), including the ICMP checksum's remainder handling. No lint suppression.