### PR TITLE
Keep a forkable golden forkable across a config-change VM restart

### DIFF
--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -78,6 +78,13 @@ struct RunningVmConfig {
     mounts: Vec<HostMount>,
     ports: Vec<PortMapping>,
     resources: VmResources,
+    /// Whether the running VM was launched forkable (memfd-backed RAM). Persisted
+    /// so a config-change restart can re-assert it: without this a routine
+    /// reconfigure relaunches a forkable golden without memfd and silently breaks
+    /// forking — the live VM loses forkability while the control DB still marks
+    /// the machine forkable, so every later fork fails "no memfd-backed RAM".
+    #[serde(default)]
+    forkable: bool,
 }
 
 impl RunningVmConfig {
@@ -184,6 +191,10 @@ struct AgentInner {
     resources: VmResources,
     /// Whether the in-memory config is trustworthy.
     config_state: ConfigState,
+    /// Whether the running VM was launched forkable (memfd-backed RAM). Tracked so
+    /// a config-change restart preserves forkability instead of relaunching a
+    /// forkable golden as a plain VM. Restored from disk on reconnect.
+    forkable: bool,
     /// If true, the agent has been detached and should not be stopped on drop.
     detached: bool,
     /// True for the most recent launch via a fork snapshot. A clone resumes past
@@ -811,6 +822,7 @@ impl AgentManager {
                 ports: Vec::new(),
                 resources: VmResources::default(),
                 config_state: ConfigState::Unknown,
+                forkable: false,
                 detached: false,
                 is_clone: false,
                 is_cuda_clone: false,
@@ -1206,6 +1218,7 @@ impl AgentManager {
                             inner.mounts = config.mounts;
                             inner.ports = config.ports;
                             inner.resources = config.resources;
+                            inner.forkable = config.forkable;
                             inner.config_state = ConfigState::Known;
                         }
                         Err(reason) => {
@@ -1249,6 +1262,9 @@ impl AgentManager {
             mounts: mounts.to_vec(),
             ports: ports.to_vec(),
             resources: resources.clone(),
+            // Read from inner: the launch path sets `inner.forkable` before this
+            // runs, so the persisted config records how the VM was actually booted.
+            forkable: self.inner.lock().forkable,
         };
         match serde_json::to_string(&config) {
             Ok(json) => {
@@ -1489,6 +1505,16 @@ impl AgentManager {
         // Re-attach packed layers if a config-change restart dropped them
         // (see `rewire_packed_layers_if_extracted`).
         self.rewire_packed_layers_if_extracted(&mut features)?;
+
+        // Preserve forkability across the restart. `forkable` is durable in the
+        // control DB, but this path uses whatever features the caller assembled —
+        // usually non-forkable — so without this a routine reconfigure relaunches
+        // a forkable golden without memfd-backed RAM, silently breaking every
+        // later fork. `stop()` above leaves `inner.forkable` intact, so it still
+        // reflects how the VM was actually running.
+        if self.inner.lock().forkable {
+            features.forkable = true;
+        }
 
         // Start with new config
         self.start_with_full_config(mounts, ports, resources, features)?;
@@ -2023,6 +2049,7 @@ impl AgentManager {
             let mut inner = self.inner.lock();
             inner.is_clone = fork_clone;
             inner.is_cuda_clone = cuda_clone;
+            inner.forkable = features.forkable;
         }
 
         // Per-VM uid isolation: when running privileged (root `serve`), give this
@@ -2435,6 +2462,13 @@ impl AgentManager {
         // Re-attach packed layers if a config-change restart dropped them
         // (see `rewire_packed_layers_if_extracted`).
         self.rewire_packed_layers_if_extracted(&mut features)?;
+
+        // Preserve forkability across the restart (see the note in
+        // `ensure_running_with_full_config`): a reconfigure must not silently
+        // relaunch a forkable golden without memfd-backed RAM.
+        if self.inner.lock().forkable {
+            features.forkable = true;
+        }
 
         self.start_via_subprocess(mounts, ports, resources, features)?;
         Ok(true)
@@ -3138,6 +3172,38 @@ mod tests {
     fn restored_cuda_clones_fail_faster_than_other_boots() {
         assert_eq!(agent_ready_timeout(true), Duration::from_secs(10));
         assert_eq!(agent_ready_timeout(false), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn running_config_persists_forkable_and_stays_backward_compatible() {
+        // Round-trip: forkable survives save/load, so a config-change restart can
+        // re-assert it — the fix for a golden silently losing memfd-backed RAM
+        // when a routine reconfigure relaunches it without SMOLVM_FORKABLE.
+        let cfg = RunningVmConfig {
+            version: RunningVmConfig::CURRENT_VERSION,
+            mounts: Vec::new(),
+            ports: Vec::new(),
+            resources: VmResources::default(),
+            forkable: true,
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        let back: RunningVmConfig = serde_json::from_str(&json).unwrap();
+        assert!(
+            back.forkable,
+            "forkable must round-trip through the config file"
+        );
+
+        // Backward compatibility: a config written before this field existed (drop
+        // it from a real serialization) must still load, defaulting to
+        // non-forkable rather than failing the reconnect and forcing a restart.
+        let mut val: serde_json::Value = serde_json::from_str(&json).unwrap();
+        val.as_object_mut().unwrap().remove("forkable");
+        let parsed: RunningVmConfig =
+            serde_json::from_value(val).expect("a pre-forkable config must still deserialize");
+        assert!(
+            !parsed.forkable,
+            "a missing forkable field defaults to false"
+        );
     }
 
     /// The three denial shapes the virtio-net runtime emits parse into


### PR DESCRIPTION
A forkable golden silently loses its memfd-backed RAM shortly after its first fork, so every subsequent fork fails `no memfd-backed RAM (start the golden VM with SMOLVM_FORKABLE=1)` even though the control DB still records the machine as forkable.

**Root cause.** A fork pauses the golden, which makes its running config unverifiable, which trips `ensure_running_with_full_config`'s fail-closed "config changed → restart" path (`manager.rs`). That restart relaunches the VM with whatever `LaunchFeatures` the caller assembled — usually non-forkable — so the golden comes back without `SMOLVM_FORKABLE`, and the retained RAM checkpoint is evicted. `forkable` was durable in the DB but never re-asserted onto the VM, so a routine reconfigure downgraded a forkable golden to a plain one. Observed live: golden stayed `started` the whole time (no control-plane restart), yet its VM process was relaunched without the flag.

**Fix.** Track `forkable` on the VM: persist it in `RunningVmConfig` (with `#[serde(default)]` so pre-existing configs still load), set it on launch, restore it on reconnect, and re-assert it on both config-change restart paths so a reconfigure can never silently strip forkability. Non-forkable machines are unaffected (`inner.forkable` stays false).

Adds a round-trip + backward-compatibility test for the persisted config.