### PR TITLE
Bump libkrun to the build with aarch64-KVM snapshot and fork support so machine fork works on Linux aarch64

### DIFF
--- a/lib/libkrun.dylib
+++ b/lib/libkrun.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a51b00d7828b5ee9be07482853dbca0a380d4d25506534713c4e0f91ea09a9e1
-size 6216480
+oid sha256:5cbce6dc0361ecd4e5e4263221cc545b0814a6404ff24cea95ef1c9e05d61373
+size 6506752

--- a/lib/libkrun.provenance
+++ b/lib/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=b79ad79fa817a2bc53ea6316c363d3a80f6fbad8
+libkrun=392eabc18c97a0e345005b3015b1ce95bd5e5527
 libkrunfw=7c1151f9c2ae1d278e243b6583850d5d848284d5

--- a/lib/linux-aarch64/libkrun.provenance
+++ b/lib/linux-aarch64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=b79ad79fa817a2bc53ea6316c363d3a80f6fbad8
+libkrun=392eabc18c97a0e345005b3015b1ce95bd5e5527
 libkrunfw=7c1151f9c2ae1d278e243b6583850d5d848284d5

--- a/lib/linux-aarch64/libkrun.so
+++ b/lib/linux-aarch64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:89dcb85997add84ac1310b3cfbb9dcd748faf7b7b817a180d3b808f87173ab30
-size 6972936
+oid sha256:48f7383d7b866e5b221593e228255a69ea64e1255a21e15505b5a3fe75e9aa07
+size 7331040

--- a/lib/linux-aarch64/libkrun.so.2.0.0
+++ b/lib/linux-aarch64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:89dcb85997add84ac1310b3cfbb9dcd748faf7b7b817a180d3b808f87173ab30
-size 6972936
+oid sha256:48f7383d7b866e5b221593e228255a69ea64e1255a21e15505b5a3fe75e9aa07
+size 7331040

--- a/lib/linux-x86_64/libkrun.provenance
+++ b/lib/linux-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=b79ad79fa817a2bc53ea6316c363d3a80f6fbad8
+libkrun=392eabc18c97a0e345005b3015b1ce95bd5e5527
 libkrunfw=7c1151f9c2ae1d278e243b6583850d5d848284d5

--- a/lib/linux-x86_64/libkrun.so
+++ b/lib/linux-x86_64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0f78d6a62ef0deff76a93ae0a7872f93f876a8f2706708ce602b35705898997d
-size 8138576
+oid sha256:7da6bb3fd33ef5ad44c55adf27b4a38ae8654723f2292749926cb3e7861ebec8
+size 8137952

--- a/lib/linux-x86_64/libkrun.so.2.0.0
+++ b/lib/linux-x86_64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0f78d6a62ef0deff76a93ae0a7872f93f876a8f2706708ce602b35705898997d
-size 8138576
+oid sha256:7da6bb3fd33ef5ad44c55adf27b4a38ae8654723f2292749926cb3e7861ebec8
+size 8137952

--- a/lib/windows-x86_64/krun.dll
+++ b/lib/windows-x86_64/krun.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bdd66a0a4371cafc244d97ff40a9983624af77f182eb52d74c45182d1b9b0145
-size 10528272
+oid sha256:5a951f9cb17fcecb068c4fccf17dd20802a66467171ae2179e9152c604bff45a
+size 10520182

--- a/lib/windows-x86_64/libkrun.provenance
+++ b/lib/windows-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=b79ad79fa817a2bc53ea6316c363d3a80f6fbad8
+libkrun=392eabc18c97a0e345005b3015b1ce95bd5e5527
 libkrunfw=7c1151f9c2ae1d278e243b6583850d5d848284d5


### PR DESCRIPTION
Rebuilds the bundled libkrun for macOS and both Linux arches; the Windows krun.dll rebuild is still pending so this stays a draft until that lib is refreshed.