### PR TITLE
Rebuild the Windows krun.dll so machines boot on WHP again

### DIFF
--- a/lib/windows-x86_64/krun.dll
+++ b/lib/windows-x86_64/krun.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5a951f9cb17fcecb068c4fccf17dd20802a66467171ae2179e9152c604bff45a
-size 10520182
+oid sha256:cf7224b0c77195b512234b831e1ef3b60cc3edcd0ed59be0d8e19ad8b74057ab
+size 10830343


### PR DESCRIPTION
The committed Windows krun.dll crashed the boot process with 0xC0000005 before the agent came up, so no machine could start on WHP; this rebuilds it from the pinned libkrun commit with a known-good toolchain, restoring boot (verified end to end: machine start, image pull, in-guest exec, and network all work again).