### PR TITLE
Resume and bound-retry a broken blob download so a stalled registry cannot hang a machine create indefinitely

### DIFF
--- a/crates/smolvm-registry/src/client.rs
+++ b/crates/smolvm-registry/src/client.rs
@@ -9,7 +9,7 @@
 
 use crate::{OciIndex, OciPlatform, RegistryError, Result, INDEX_MEDIA_TYPE, MANIFEST_MEDIA_TYPE};
 use reqwest::header::{
-    ACCEPT, CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE, LINK, LOCATION, WWW_AUTHENTICATE,
+    ACCEPT, CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE, LINK, LOCATION, RANGE, WWW_AUTHENTICATE,
 };
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
@@ -27,6 +27,32 @@ const MAX_MANIFEST_BYTES: usize = 32 * 1024 * 1024;
 /// [`RegistryClient::pull_blob_stream`], which streams to disk. 64 MiB is a
 /// generous ceiling that still bounds the in-memory buffer.
 const MAX_BLOB_BYTES: usize = 64 * 1024 * 1024;
+
+/// How long to wait for a connection to the registry.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// How long a response may go without delivering any bytes.
+///
+/// This is a gap-between-reads deadline, NOT a deadline on the whole transfer,
+/// which is the distinction that matters for a multi-hundred-megabyte layer: a
+/// slow-but-progressing download runs as long as it needs, while a registry that
+/// accepts the connection and then goes silent fails in seconds. A whole-request
+/// `timeout()` cannot be used here — it would abort large healthy pulls. Without
+/// either one, a half-open connection parks the caller forever: the request task
+/// never wakes, and enough of them turn a node into one that accepts creates and
+/// completes none.
+const READ_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// The shared HTTP client for every registry request, with the deadlines above.
+fn http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .read_timeout(READ_TIMEOUT)
+        .build()
+        // A builder failure here means no TLS backend; the default client at
+        // least keeps the caller working (timeouts are the thing lost).
+        .unwrap_or_else(|_| reqwest::Client::new())
+}
 
 /// Buffer a response body into memory, refusing to read more than `cap` bytes.
 ///
@@ -102,7 +128,7 @@ impl RegistryClient {
     /// Create a new client for the given registry base URL.
     pub fn new(base_url: String) -> Self {
         Self {
-            http: reqwest::Client::new(),
+            http: http_client(),
             base_url,
             auth_token: None,
             identity_token: None,
@@ -487,7 +513,58 @@ impl RegistryClient {
         self.resolve_location(loc)
     }
 
-    /// Download a blob as a byte stream.
+    /// Download a blob as a byte stream, optionally resuming at `offset`.
+    ///
+    /// Returns the stream and the byte offset the body actually begins at: the
+    /// requested `offset` when the registry honored the range (206), or 0 when it
+    /// ignored the header and restarted the whole blob (200). A caller resuming a
+    /// partial file MUST truncate it when 0 comes back, or it would concatenate a
+    /// second copy onto the first and fail the digest check.
+    ///
+    /// Resuming matters for large layers: without it, a transfer that breaks near
+    /// the end restarts from byte zero, so a registry dropping connections at a
+    /// consistent point means the download never converges no matter how many
+    /// times it is retried.
+    ///
+    /// Returns the stream after verifying the response status. The caller is
+    /// responsible for digest verification (hash while writing to disk).
+    pub async fn pull_blob_stream_from(
+        &self,
+        repo: &str,
+        digest: &str,
+        offset: u64,
+    ) -> Result<(
+        impl futures_util::Stream<Item = reqwest::Result<bytes::Bytes>>,
+        u64,
+    )> {
+        validate_digest(digest)?;
+        let url = format!("{}/v2/{}/blobs/{}", self.base_url, repo, digest);
+        let mut req = self.request(reqwest::Method::GET, &url);
+        if offset > 0 {
+            req = req.header(RANGE, format!("bytes={offset}-"));
+        }
+        let resp = self.send_replayable(req).await?;
+
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Err(RegistryError::BlobNotFound(digest.to_string()));
+        }
+
+        if !resp.status().is_success() {
+            return Err(RegistryError::ApiError {
+                status: resp.status().as_u16(),
+                body: resp.text().await.unwrap_or_default(),
+            });
+        }
+
+        let resumed_at = if resp.status() == reqwest::StatusCode::PARTIAL_CONTENT {
+            offset
+        } else {
+            0
+        };
+        Ok((resp.bytes_stream(), resumed_at))
+    }
+
+    /// Download a blob as a byte stream from the beginning.
     ///
     /// Returns the stream after verifying the response status. The caller is
     /// responsible for digest verification (hash while writing to disk).

--- a/crates/smolvm-registry/src/lib.rs
+++ b/crates/smolvm-registry/src/lib.rs
@@ -161,6 +161,13 @@ pub enum RegistryError {
     #[error("blob not found: {0}")]
     BlobNotFound(String),
 
+    #[error("blob download stalled after {received} of {total} bytes: {digest}")]
+    DownloadStalled {
+        digest: String,
+        received: u64,
+        total: u64,
+    },
+
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 

--- a/crates/smolvm-registry/src/pull.rs
+++ b/crates/smolvm-registry/src/pull.rs
@@ -14,7 +14,8 @@ use crate::{OciManifest, RegistryError, Result, LAYER_MEDIA_TYPE};
 use futures_util::StreamExt;
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
-use tokio::io::AsyncWriteExt;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 /// Result of a successful pull.
 #[derive(Debug)]
@@ -109,16 +110,189 @@ pub async fn pull(
         }
     }
 
-    // 5. Stream blob from the registry to disk while computing + verifying the
-    //    digest, then adopt into cache.
+    // 5. Stream blob from the registry to disk, resuming and retrying a broken
+    //    transfer, then verify the digest and adopt into cache.
     tracing::info!(digest = %digest, size, "downloading blob...");
 
-    let stream = client.pull_blob_stream(repo, digest).await?;
-    let result = stream_verify_adopt(stream, digest, output, cache).await?;
+    let result = download_with_resume(client, repo, digest, size, output, cache).await?;
 
     tracing::info!(digest = %digest, size = result.size, "pull complete");
 
     Ok(result)
+}
+
+/// Attempts allowed for one blob (first try plus retries).
+const MAX_ATTEMPTS: u32 = 5;
+
+/// Delay before the first retry; doubles each attempt.
+const RETRY_BACKOFF: Duration = Duration::from_millis(500);
+
+/// Download `digest` into the cache, resuming a partial file across attempts.
+///
+/// Each attempt appends to `<digest>.partial` from wherever the last one stopped,
+/// so a 90 MiB layer that breaks at 80 MiB resumes at 80 MiB instead of starting
+/// over — the difference between converging and never finishing when a registry
+/// drops long transfers. Retries are bounded and backed off, so a genuinely
+/// broken blob fails in seconds with a real error instead of hammering the
+/// registry forever (the retry storm that hid the original fault).
+///
+/// The digest is verified from the finished file rather than hashed incrementally
+/// while streaming: resumed attempts would otherwise need the hasher state from a
+/// previous attempt. Re-reading is cheap next to the transfer, and it verifies
+/// exactly the bytes that landed on disk.
+async fn download_with_resume(
+    client: &RegistryClient,
+    repo: &str,
+    digest: &str,
+    expected_size: u64,
+    output: Option<&Path>,
+    cache: &BlobCache,
+) -> Result<PullResult> {
+    let partial_path = cache.blob_path_for(digest).with_extension("partial");
+
+    for attempt in 1..=MAX_ATTEMPTS {
+        // Resume from whatever a previous attempt left behind. A stale partial
+        // from an earlier pull is fine: the digest check at the end rejects it,
+        // and a mismatch clears it so the next pull starts clean.
+        let have = tokio::fs::metadata(&partial_path)
+            .await
+            .map(|m| m.len())
+            .unwrap_or(0);
+
+        match fetch_into_partial(client, repo, digest, have, expected_size, &partial_path).await {
+            Ok(written) => {
+                let actual = hash_file(&partial_path).await?;
+                if actual != *digest {
+                    // Corrupt or mismatched bytes: remove them so a retry cannot
+                    // resume onto a poisoned prefix, and fail — retrying the same
+                    // content would only reproduce the mismatch.
+                    if let Err(e) = tokio::fs::remove_file(&partial_path).await {
+                        tracing::warn!(
+                            error = %e,
+                            path = %partial_path.display(),
+                            "failed to clean up partial blob after digest mismatch"
+                        );
+                    }
+                    return Err(RegistryError::DigestMismatch {
+                        expected: digest.to_string(),
+                        actual,
+                    });
+                }
+
+                let cached_path = cache.adopt(digest, written)?;
+                let result_path = if let Some(out) = output {
+                    tokio::fs::copy(&cached_path, out).await?;
+                    PathBuf::from(out)
+                } else {
+                    cached_path
+                };
+                return Ok(PullResult {
+                    path: result_path,
+                    digest: digest.to_string(),
+                    size: written,
+                    cached: false,
+                });
+            }
+            Err(e) if attempt < MAX_ATTEMPTS && is_retryable(&e) => {
+                let backoff = RETRY_BACKOFF * 2u32.pow(attempt - 1);
+                tracing::warn!(
+                    digest = %digest,
+                    attempt,
+                    max_attempts = MAX_ATTEMPTS,
+                    have_bytes = have,
+                    backoff_ms = backoff.as_millis(),
+                    error = %e,
+                    "blob download failed; resuming after backoff"
+                );
+                tokio::time::sleep(backoff).await;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
+    unreachable!("loop returns on the final attempt")
+}
+
+/// One download attempt: append the blob to `partial_path` starting at `have`.
+///
+/// Returns the total bytes on disk when the body ends.
+async fn fetch_into_partial(
+    client: &RegistryClient,
+    repo: &str,
+    digest: &str,
+    have: u64,
+    expected_size: u64,
+    partial_path: &Path,
+) -> Result<u64> {
+    let (stream, resumed_at) = client.pull_blob_stream_from(repo, digest, have).await?;
+
+    // `resumed_at == 0` with bytes already on disk means the registry ignored the
+    // Range header and is resending the whole blob, so the partial must be
+    // truncated — appending would produce a file with a duplicated prefix.
+    let mut file = if resumed_at > 0 {
+        tokio::fs::OpenOptions::new()
+            .append(true)
+            .open(partial_path)
+            .await?
+    } else {
+        tokio::fs::File::create(partial_path).await?
+    };
+
+    let mut written = resumed_at;
+    let mut stream = std::pin::pin!(stream);
+    while let Some(chunk_result) = stream.next().await {
+        let chunk: bytes::Bytes = chunk_result.map_err(RegistryError::Http)?;
+        file.write_all(&chunk).await?;
+        written += chunk.len() as u64;
+    }
+    file.flush().await?;
+    drop(file);
+
+    // A body that ends early is a truncated transfer, not a complete download.
+    // Without this the short file would reach the digest check, mismatch, and be
+    // deleted — throwing away bytes a resume could have kept.
+    if expected_size > 0 && written < expected_size {
+        return Err(RegistryError::DownloadStalled {
+            digest: digest.to_string(),
+            received: written,
+            total: expected_size,
+        });
+    }
+
+    Ok(written)
+}
+
+/// SHA-256 of a file on disk, read in chunks so a large layer is never buffered.
+async fn hash_file(path: &Path) -> Result<String> {
+    let mut file = tokio::fs::File::open(path).await?;
+    let mut hasher = Sha256::new();
+    let mut buf = vec![0u8; 128 * 1024];
+    loop {
+        let n = file.read(&mut buf).await?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(format!("sha256:{}", hex::encode(hasher.finalize())))
+}
+
+/// Whether a failed attempt is worth resuming.
+///
+/// Transport faults and 5xx are transient — exactly the mid-transfer breakage
+/// resume exists for. A missing blob, an auth failure, or a digest mismatch are
+/// terminal: retrying re-fetches the same wrong answer and only delays the error
+/// the caller needs to see.
+fn is_retryable(err: &RegistryError) -> bool {
+    match err {
+        RegistryError::Http(e) => {
+            e.is_timeout() || e.is_connect() || e.is_request() || e.is_body() || e.is_decode()
+        }
+        RegistryError::DownloadStalled { .. } => true,
+        RegistryError::Io(_) => false,
+        RegistryError::ApiError { status, .. } => *status >= 500,
+        _ => false,
+    }
 }
 
 /// Stream `stream` into the cache's `.partial` file for `digest`, hashing while
@@ -249,5 +423,145 @@ mod tests {
             "blob must be adopted into cache"
         );
         // MockServer drop asserts the blob endpoint's expect(1) was satisfied.
+    }
+
+    /// Build a manifest whose single layer declares `digest`/`size`.
+    fn manifest_for(digest: &str, size: usize) -> serde_json::Value {
+        serde_json::json!({
+            "schemaVersion": 2,
+            "mediaType": MANIFEST_MEDIA_TYPE,
+            "config": {
+                "mediaType": CONFIG_MEDIA_TYPE,
+                "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+                "size": 2
+            },
+            "layers": [ { "mediaType": LAYER_MEDIA_TYPE, "digest": digest, "size": size } ],
+        })
+    }
+
+    /// The incident behaviour: a transfer that dies mid-blob must RESUME from the
+    /// bytes already on disk, not restart at zero.
+    ///
+    /// The registry here truncates the first response, then serves the remainder
+    /// only to a ranged request. A client that restarts would keep receiving the
+    /// same truncated prefix forever; one that resumes completes on the second
+    /// attempt.
+    #[tokio::test]
+    async fn broken_transfer_resumes_instead_of_restarting() {
+        use sha2::{Digest, Sha256};
+        use wiremock::matchers::header_exists;
+
+        let data: Vec<u8> = (0..4096u32).map(|i| (i % 251) as u8).collect();
+        let digest = format!("sha256:{}", hex::encode(Sha256::digest(&data)));
+        let split = 1500;
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v2/myrepo/manifests/latest"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                serde_json::to_vec(&manifest_for(&digest, data.len())).unwrap(),
+                MANIFEST_MEDIA_TYPE,
+            ))
+            .mount(&server)
+            .await;
+
+        // Registered first so it wins for ranged requests: serve the tail as 206.
+        Mock::given(method("GET"))
+            .and(path(format!("/v2/myrepo/blobs/{digest}")))
+            .and(header_exists("range"))
+            .respond_with(ResponseTemplate::new(206).set_body_bytes(data[split..].to_vec()))
+            .expect(1)
+            .mount(&server)
+            .await;
+        // Un-ranged first attempt: hand back a truncated body.
+        Mock::given(method("GET"))
+            .and(path(format!("/v2/myrepo/blobs/{digest}")))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(data[..split].to_vec()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = BlobCache::open(tmp.path().to_path_buf(), 1024 * 1024).unwrap();
+        let client = RegistryClient::new(server.uri());
+
+        let result = pull(&client, "myrepo", "latest", None, &cache, &[])
+            .await
+            .expect("a truncated transfer must be resumed and completed");
+
+        assert_eq!(
+            result.size,
+            data.len() as u64,
+            "full blob must land on disk"
+        );
+        assert_eq!(result.digest, digest);
+        let cached = cache.get(&digest).expect("blob must be adopted into cache");
+        assert_eq!(
+            tokio::fs::read(&cached).await.unwrap(),
+            data,
+            "resumed file must be byte-identical, not a duplicated prefix"
+        );
+        // Each expect(1) asserts the resume happened exactly once: one truncated
+        // attempt, one ranged continuation.
+    }
+
+    /// A terminal failure must NOT be retried. A missing blob is the same answer
+    /// however many times it is asked for, and retrying only delays the error.
+    #[tokio::test]
+    async fn missing_blob_fails_without_retrying() {
+        let digest = "sha256:2222222222222222222222222222222222222222222222222222222222222222";
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v2/myrepo/manifests/latest"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                serde_json::to_vec(&manifest_for(digest, 64)).unwrap(),
+                MANIFEST_MEDIA_TYPE,
+            ))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/v2/myrepo/blobs/{digest}")))
+            .respond_with(ResponseTemplate::new(404))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = BlobCache::open(tmp.path().to_path_buf(), 1024 * 1024).unwrap();
+        let client = RegistryClient::new(server.uri());
+
+        let err = pull(&client, "myrepo", "latest", None, &cache, &[])
+            .await
+            .expect_err("a missing blob must fail");
+        assert!(
+            matches!(err, RegistryError::BlobNotFound(_)),
+            "expected BlobNotFound, got {err:?}"
+        );
+        // expect(1) asserts the blob endpoint was hit once, not MAX_ATTEMPTS times.
+    }
+
+    /// Retry classification: transient transport/5xx faults resume, terminal ones
+    /// do not. This is what keeps a broken pull from becoming a retry storm.
+    #[test]
+    fn retry_classification_splits_transient_from_terminal() {
+        assert!(is_retryable(&RegistryError::DownloadStalled {
+            digest: "sha256:x".into(),
+            received: 1,
+            total: 2,
+        }));
+        assert!(is_retryable(&RegistryError::ApiError {
+            status: 503,
+            body: String::new(),
+        }));
+        assert!(!is_retryable(&RegistryError::ApiError {
+            status: 404,
+            body: String::new(),
+        }));
+        assert!(!is_retryable(&RegistryError::BlobNotFound("x".into())));
+        assert!(!is_retryable(&RegistryError::DigestMismatch {
+            expected: "a".into(),
+            actual: "b".into(),
+        }));
     }
 }


### PR DESCRIPTION
The pull path had no transport deadlines, no resume, and no retry: a registry that accepted a connection and then went quiet parked the request forever, and a transfer that broke near the end of a large layer restarted from zero and never converged.