### PR TITLE
Add an opt-in virtio-gpu scanout with a host-side VNC server and virtio-input so machines can run an interactive Linux desktop

### DIFF
--- a/examples/desktop/README.md
+++ b/examples/desktop/README.md
@@ -21,18 +21,19 @@ connector, and every DRM compositor refuses to start with "not a KMS device".
 `SMOLVM_VNC=[host:]port` serves the resulting framebuffer over RFB. A bare port
 binds loopback only. The session is interactive: smolvm attaches a virtio
 keyboard and an absolute pointer, and client key/pointer events are injected
-into the guest. This needs a libkrun built with the input feature and a guest
-that runs udevd (see below); with either missing the session degrades to
-view-only.
+into the guest. This needs a libkrun built with the input feature; without it
+the session degrades to view-only.
 
-For the guest's compositor to *see* the devices, libinput's udev backend
-needs a udev database — a workload container does not run one, so start it
-before the compositor:
+For the guest's compositor to *see* the devices, two container-guest gaps
+must be bridged before it starts (both handled by `omarchy.sh`):
 
-```sh
-/usr/lib/systemd/systemd-udevd --daemon
-udevadm trigger --action=add && udevadm settle
-```
+- `/dev` is not devtmpfs, so the evdev nodes the kernel registers never
+  appear — `mknod` them from `/sys/class/input/event*/dev`.
+- libinput only adopts devices classified in the udev database, and
+  `systemd-udevd` cannot populate it without a full systemd runtime. libudev
+  reads `/run/udev/data` directly, so write `c<major>:<minor>` entries by
+  hand with `E:ID_INPUT=1` plus a type (`E:ID_INPUT_KEYBOARD=1` /
+  `E:ID_INPUT_MOUSE=1`).
 
 Both are opt-in. A connector changes guest topology, and existing GPU workloads
 (CUDA remoting, headless Vulkan) neither need nor want one.

--- a/examples/desktop/README.md
+++ b/examples/desktop/README.md
@@ -19,9 +19,20 @@ gives the guest GPU *rendering* only: `/dev/dri/card0` is a render node with no
 connector, and every DRM compositor refuses to start with "not a KMS device".
 
 `SMOLVM_VNC=[host:]port` serves the resulting framebuffer over RFB. A bare port
-binds loopback only. Output is one-way today — smolvm does not yet attach a
-virtio-input device, so keyboard and pointer events from the client are
-discarded rather than pretending to work.
+binds loopback only. The session is interactive: smolvm attaches a virtio
+keyboard and an absolute pointer, and client key/pointer events are injected
+into the guest. This needs a libkrun built with the input feature and a guest
+that runs udevd (see below); with either missing the session degrades to
+view-only.
+
+For the guest's compositor to *see* the devices, libinput's udev backend
+needs a udev database — a workload container does not run one, so start it
+before the compositor:
+
+```sh
+/usr/lib/systemd/systemd-udevd --daemon
+udevadm trigger --action=add && udevadm settle
+```
 
 Both are opt-in. A connector changes guest topology, and existing GPU workloads
 (CUDA remoting, headless Vulkan) neither need nor want one.

--- a/examples/desktop/README.md
+++ b/examples/desktop/README.md
@@ -1,0 +1,62 @@
+# A Linux desktop in a machine
+
+Runs a real DRM Wayland compositor (Hyprland) inside a smolvm machine and
+serves it over VNC from the **host**, so the guest needs no capture tool and no
+compositor-specific screencopy protocol.
+
+```sh
+SMOLVM_DISPLAY=1280x800 SMOLVM_VNC=127.0.0.1:5900 \
+  smolvm machine run --net --gpu --cpus 4 --mem 6144 \
+    -v "$PWD:/in" --image archlinux:latest -- bash /in/run.sh
+```
+
+Then point any VNC client at `127.0.0.1:5900`.
+
+## The two environment variables
+
+`SMOLVM_DISPLAY=WIDTHxHEIGHT` adds a virtio-gpu scanout. Without it `--gpu`
+gives the guest GPU *rendering* only: `/dev/dri/card0` is a render node with no
+connector, and every DRM compositor refuses to start with "not a KMS device".
+
+`SMOLVM_VNC=[host:]port` serves the resulting framebuffer over RFB. A bare port
+binds loopback only. Output is one-way today — smolvm does not yet attach a
+virtio-input device, so keyboard and pointer events from the client are
+discarded rather than pretending to work.
+
+Both are opt-in. A connector changes guest topology, and existing GPU workloads
+(CUDA remoting, headless Vulkan) neither need nor want one.
+
+## The one thing the guest must do
+
+Run `seatd` with **`SEATD_VTBOUND=0`**:
+
+```sh
+SEATD_VTBOUND=0 seatd -g wheel &
+```
+
+seatd defaults to a *VT-bound* seat, which needs `/dev/tty0`. A workload
+container has no VT, so a VT-bound seat cannot open a session — and because
+seatd itself starts fine either way, the failure surfaces much later and in the
+client, as libseat's misleading "Failed to open a session". This costs an hour
+if you have not seen it before.
+
+## Verifying it actually renders
+
+A listening socket proves a server and an RFB banner proves a handshake;
+neither proves a frame was ever presented. `rfb_probe.py` speaks the protocol,
+pulls two full framebuffer updates a few seconds apart, and reports whether the
+pixels are non-uniform (something was drawn) and whether they changed (it is
+live):
+
+```sh
+python3 rfb_probe.py 127.0.0.1 5900
+```
+
+## Not Omarchy yet
+
+Omarchy ships as an ISO that pacstraps `install/omarchy-base.packages`. 126 of
+those 148 packages resolve from the official Arch repos and install cleanly
+here; the remaining 22 are AUR or Omarchy-published (`omarchy-nvim`, `omacut`,
+`aether`, …) and are ordinary Arch packaging work, not a smolvm limitation.
+`run.sh` installs the Arch-resolvable base, which is the same compositor and
+the same session — just without Omarchy's own packages and theming.

--- a/examples/desktop/README.md
+++ b/examples/desktop/README.md
@@ -52,11 +52,36 @@ live):
 python3 rfb_probe.py 127.0.0.1 5900
 ```
 
-## Not Omarchy yet
+## Omarchy
 
-Omarchy ships as an ISO that pacstraps `install/omarchy-base.packages`. 126 of
-those 148 packages resolve from the official Arch repos and install cleanly
-here; the remaining 22 are AUR or Omarchy-published (`omarchy-nvim`, `omacut`,
-`aether`, …) and are ordinary Arch packaging work, not a smolvm limitation.
-`run.sh` installs the Arch-resolvable base, which is the same compositor and
-the same session — just without Omarchy's own packages and theming.
+`omarchy.sh` runs the real thing: omarchy's package set (126 of its 148 base
+packages resolve from the official Arch repos; the rest are AUR or
+Omarchy-published and are packaging work, not a smolvm limitation), omarchy's
+actual Hyprland Lua config, and its theme — verified live over VNC with a
+two-captures-differ check.
+
+```sh
+SMOLVM_DISPLAY=1280x800 SMOLVM_VNC=127.0.0.1:5900 \
+  smolvm machine run --net --gpu --cpus 4 --mem 6144 \
+    -v "$PWD:/in" --image archlinux:latest -- bash /in/omarchy.sh
+```
+
+Four things the script handles that cost real debugging time:
+
+- omarchy's `hyprland.lua` loads `/usr/share/omarchy/default/hypr/bootstrap.lua`
+  — the **system** path. With the repo only under `~/.local/share`, the Lua
+  config errors and Hyprland silently drops into emergency mode: desktop up,
+  but no binds and no autostart.
+- `foot.ini` (and other app configs) include the **state** theme link
+  `~/.local/state/omarchy/current/theme/…`, which the installer normally
+  creates — without it foot exits at startup.
+- omarchy's shell (bar, notifications, wallpaper) is a single Quickshell app
+  launched through systemd user units; a workload container has no systemd
+  user session (and no `/etc/machine-id`, which D-Bus requires), so the script
+  runs `dbus-uuidgen --ensure`, starts a session bus, and spawns
+  `quickshell -p "$OMARCHY_PATH/shell"` directly. Under the Lua config,
+  `hyprctl dispatch exec` parses its argument as Lua — spawn clients as plain
+  processes.
+- virtio-gpu has no explicit-sync or hardware-cursor support yet:
+  `AQ_NO_ATOMIC=1` plus runtime `hyprctl keyword render:explicit_sync 0` and
+  `cursor:no_hardware_cursors true`.

--- a/examples/desktop/omarchy.sh
+++ b/examples/desktop/omarchy.sh
@@ -34,9 +34,16 @@ printf '%%wheel ALL=(ALL) NOPASSWD: ALL\n' > /etc/sudoers.d/wheel && chmod 440 /
 RT=/run/user/1000; mkdir -p "$RT"; chown omar:omar "$RT"; chmod 700 "$RT"
 chmod 666 /dev/dri/* 2>/dev/null
 
-# D-Bus refuses to start without a machine id, and mako/waybar need a session
-# bus — a container guest has neither out of the box.
+# D-Bus refuses to start without a machine id, and the session components
+# need a session bus — a container guest has neither out of the box.
 dbus-uuidgen --ensure 2>/dev/null || true
+
+# libinput's udev backend only sees devices that are in the udev database; a
+# container guest runs no udevd, so without this the compositor gets no
+# keyboard or pointer even though /dev/input has them.
+/usr/lib/systemd/systemd-udevd --daemon 2>/dev/null
+udevadm trigger --action=add 2>/dev/null
+udevadm settle 2>/dev/null
 
 # A VT-bound seat cannot open a session in a container with no /dev/tty0.
 SEATD_VTBOUND=0 seatd -g wheel >/tmp/seatd.log 2>&1 &

--- a/examples/desktop/omarchy.sh
+++ b/examples/desktop/omarchy.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Omarchy (DHH's Arch + Hyprland setup) inside a smolvm machine, end to end:
+# package set -> real omarchy Hyprland session on the DRM backend -> live
+# pixels served by the host's VNC server (SMOLVM_VNC).
+#
+# Launch from the host with:
+#   SMOLVM_DISPLAY=1280x800 SMOLVM_VNC=127.0.0.1:5900 \
+#     smolvm machine run --net --gpu --cpus 4 --mem 6144 \
+#       -v "$PWD:/in" --image archlinux:latest -- bash /in/omarchy.sh
+set -o pipefail
+export LANG=C
+
+# Pin a coherent snapshot: rolling mirrors routinely serve a mesa that needs a
+# libdrm symbol the same mirror has not published yet. Parallel downloads and
+# no per-file timeout ride out archive.archlinux.org's throttling.
+echo 'Server=https://archive.archlinux.org/repos/2026/08/20/$repo/os/$arch' > /etc/pacman.d/mirrorlist
+sed -i 's/^#ParallelDownloads.*/ParallelDownloads = 8/' /etc/pacman.conf
+
+pacman -Sy --noconfirm --needed --disable-download-timeout git sudo >/dev/null 2>&1 || exit 1
+git clone -q --depth 1 https://github.com/basecamp/omarchy /tmp/om || exit 1
+
+# Install every omarchy base package the official repos carry (the rest are
+# AUR/omarchy-published and orthogonal to running the session).
+mapfile -t PKGS < <(grep -vE "^\s*#|^\s*$" /tmp/om/install/omarchy-base.packages)
+OK=()
+for p in "${PKGS[@]}"; do pacman -Si "$p" >/dev/null 2>&1 && OK+=("$p"); done
+for attempt in 1 2 3; do
+  pacman -S --noconfirm --needed --disable-download-timeout "${OK[@]}" foot grim >/tmp/pac.log 2>&1 && break
+  sleep 20
+done
+
+id omar >/dev/null 2>&1 || useradd -m -G wheel,video,input,seat,render omar
+printf '%%wheel ALL=(ALL) NOPASSWD: ALL\n' > /etc/sudoers.d/wheel && chmod 440 /etc/sudoers.d/wheel
+RT=/run/user/1000; mkdir -p "$RT"; chown omar:omar "$RT"; chmod 700 "$RT"
+chmod 666 /dev/dri/* 2>/dev/null
+
+# D-Bus refuses to start without a machine id, and mako/waybar need a session
+# bus — a container guest has neither out of the box.
+dbus-uuidgen --ensure 2>/dev/null || true
+
+# A VT-bound seat cannot open a session in a container with no /dev/tty0.
+SEATD_VTBOUND=0 seatd -g wheel >/tmp/seatd.log 2>&1 &
+sleep 2
+
+# Omarchy's layout, as its installer creates it:
+#   - the repo at /usr/share/omarchy (hyprland.lua dofile()s
+#     /usr/share/omarchy/default/hypr/bootstrap.lua — the SYSTEM path; with it
+#     missing the lua config errors and Hyprland trips emergency mode)
+#   - config tree copied to ~/.config
+#   - the STATE theme link ~/.local/state/omarchy/current/theme, which
+#     foot.ini and friends include (distinct from ~/.config/omarchy/current)
+cp -r /tmp/om /usr/share/omarchy
+install -d -o omar -g omar /home/omar/.local/share
+cp -r /tmp/om /home/omar/.local/share/omarchy
+install -d -o omar -g omar /home/omar/.config
+cp -r /tmp/om/config/* /home/omar/.config/ 2>/dev/null
+THEME=/home/omar/.local/share/omarchy/themes/tokyo-night
+install -d -o omar -g omar /home/omar/.local/state/omarchy/current
+ln -sfn "$THEME" /home/omar/.local/state/omarchy/current/theme
+BG=$(ls "$THEME"/backgrounds/* 2>/dev/null | head -1)
+[ -n "$BG" ] && ln -sfn "$BG" /home/omar/.local/state/omarchy/current/background
+install -d /home/omar/.config/omarchy
+ln -sfn "$THEME" /home/omar/.config/omarchy/current
+chown -R omar:omar /home/omar/.config /home/omar/.local
+
+sudo -u omar env HOME=/home/omar XDG_RUNTIME_DIR=$RT XDG_SESSION_TYPE=wayland \
+  LIBSEAT_BACKEND=seatd AQ_NO_ATOMIC=1 bash -s <<'INNER'
+set -o pipefail
+Hyprland >/tmp/hypr.log 2>&1 &
+for i in $(seq 1 40); do ls "$XDG_RUNTIME_DIR"/wayland-* >/dev/null 2>&1 && break; sleep 1; done
+S=$(ls "$XDG_RUNTIME_DIR"/wayland-* 2>/dev/null | grep -v '\.lock$' | head -1)
+[ -z "$S" ] && { echo "compositor failed"; tail -20 /tmp/hypr.log; exit 1; }
+export WAYLAND_DISPLAY=$(basename "$S")
+export HYPRLAND_INSTANCE_SIGNATURE=$(ls -t "$XDG_RUNTIME_DIR"/hypr 2>/dev/null | head -1)
+echo "omarchy hyprland up on $WAYLAND_DISPLAY"
+
+# virtio-gpu has no explicit-sync or hardware-cursor support yet; the lua
+# config owns the file-level settings, so apply these at runtime.
+timeout 10 hyprctl keyword render:explicit_sync 0 >/dev/null 2>&1
+timeout 10 hyprctl keyword cursor:no_hardware_cursors true >/dev/null 2>&1
+
+# Omarchy's shell (bar, notifications, wallpaper) is one Quickshell app,
+# normally launched by omarchy-launch-shell through systemd user units — which
+# a container guest does not run. Spawn it directly. (Under the lua config
+# `hyprctl dispatch exec` parses its argument as lua — spawn clients as plain
+# processes instead.)
+export $(dbus-launch 2>/dev/null)
+export OMARCHY_PATH=$HOME/.local/share/omarchy
+(setsid env DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS \
+  QS_DISABLE_FILE_WATCHER=1 QS_NO_RELOAD_POPUP=1 \
+  quickshell -n -p "$OMARCHY_PATH/shell" >/dev/null 2>&1 &)
+(setsid foot -e watch -n1 date >/dev/null 2>&1 &)
+
+sleep 12
+timeout 10 hyprctl monitors | head -4
+# Liveness: two captures a few seconds apart must differ (the clock ticks).
+grim /tmp/a.png; sleep 3; grim /tmp/b.png
+[ "$(sha256sum </tmp/a.png)" != "$(sha256sum </tmp/b.png)" ] && echo "LIVE: frames differ" || echo "static"
+INNER
+
+cp /tmp/*.png /in/ 2>/dev/null
+echo "desktop is up; connect a VNC client to the host's SMOLVM_VNC address"
+sleep 600

--- a/examples/desktop/omarchy.sh
+++ b/examples/desktop/omarchy.sh
@@ -38,12 +38,31 @@ chmod 666 /dev/dri/* 2>/dev/null
 # need a session bus — a container guest has neither out of the box.
 dbus-uuidgen --ensure 2>/dev/null || true
 
-# libinput's udev backend only sees devices that are in the udev database; a
-# container guest runs no udevd, so without this the compositor gets no
-# keyboard or pointer even though /dev/input has them.
-/usr/lib/systemd/systemd-udevd --daemon 2>/dev/null
-udevadm trigger --action=add 2>/dev/null
-udevadm settle 2>/dev/null
+# Input devices need two container-guest fixes. First: /dev is not devtmpfs,
+# so the evdev nodes the kernel registered (visible in /sys/class/input)
+# never appear in /dev — create them, the same way k3d guests need /dev/kmsg.
+mkdir -p /dev/input
+for e in /sys/class/input/event*; do
+  [ -e "$e" ] || continue
+  n=$(basename "$e")
+  maj=$(cut -d: -f1 "$e/dev"); min=$(cut -d: -f2 "$e/dev")
+  [ -e "/dev/input/$n" ] || mknod "/dev/input/$n" c "$maj" "$min"
+done
+
+# Second: libinput only adopts devices classified in the udev database, and
+# systemd-udevd cannot populate it without a full systemd runtime. libudev
+# reads /run/udev/data directly and needs no daemon, so write the entries by
+# hand (the file's existence also marks the device "initialized").
+mkdir -p /run/udev/data
+for e in /sys/class/input/event*; do
+  [ -e "$e" ] || continue
+  devnum=$(cat "$e/dev")
+  case "$(cat "$e/device/name" 2>/dev/null)" in
+    *keyboard*) type=ID_INPUT_KEYBOARD ;;
+    *)          type=ID_INPUT_MOUSE ;;
+  esac
+  printf 'E:ID_INPUT=1\nE:%s=1\nG:seat\nQ:seat\n' "$type" > "/run/udev/data/c$devnum"
+done
 
 # A VT-bound seat cannot open a session in a container with no /dev/tty0.
 SEATD_VTBOUND=0 seatd -g wheel >/tmp/seatd.log 2>&1 &

--- a/lib/libkrun.dylib
+++ b/lib/libkrun.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:890c31f48ab630dc37beab61f3153a3d1163b40e49d145b3238b0a004807c1d7
-size 6506752
+oid sha256:1293cb5f4c413557ecf1f9c5674059bbe8a771a58fc2880b64174e6dbfd37a89
+size 6511680

--- a/lib/libkrun.provenance
+++ b/lib/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=2d3f594f9639e886d84032fb1b8729dd1baa95c9
+libkrun=f56c733111814b3ffecc5589a6648dfa3e9c42fd
 libkrunfw=62b3de1465c4e28f0f92f57e2ec19ddb446e7159

--- a/lib/linux-aarch64/libkrun.provenance
+++ b/lib/linux-aarch64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=2d3f594f9639e886d84032fb1b8729dd1baa95c9
+libkrun=f56c733111814b3ffecc5589a6648dfa3e9c42fd
 libkrunfw=62b3de1465c4e28f0f92f57e2ec19ddb446e7159

--- a/lib/linux-aarch64/libkrun.so
+++ b/lib/linux-aarch64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6f268c326f42dd5a990fdf69c725672121c8c67948abadd2cc103780cd6fc9c2
-size 7509800
+oid sha256:07de6eb95ababd01d417de800356dfdaef8eb32d23aa73aebb3a83fec38d853e
+size 7414696

--- a/lib/linux-x86_64/libkrun.provenance
+++ b/lib/linux-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=2d3f594f9639e886d84032fb1b8729dd1baa95c9
+libkrun=f56c733111814b3ffecc5589a6648dfa3e9c42fd
 libkrunfw=62b3de1465c4e28f0f92f57e2ec19ddb446e7159

--- a/lib/linux-x86_64/libkrun.so
+++ b/lib/linux-x86_64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:77f916244fe1d6353f9ce5fbc03b5438e214574f1248c2ee8c82ce5024f1167d
-size 8192984
+oid sha256:7624aaf0fe5ca3549430e013e33876a07387a8ef27c46ba9d42ea16cce3e46bb
+size 8203072

--- a/lib/windows-x86_64/libkrun.provenance
+++ b/lib/windows-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=2d3f594f9639e886d84032fb1b8729dd1baa95c9
+libkrun=f56c733111814b3ffecc5589a6648dfa3e9c42fd
 libkrunfw=62b3de1465c4e28f0f92f57e2ec19ddb446e7159

--- a/scripts/build-libkrun-linux.sh
+++ b/scripts/build-libkrun-linux.sh
@@ -123,7 +123,7 @@ else
 fi
 
 # --- 4. libkrun (VMM) --------------------------------------------------------
-echo "--- building libkrun (BLK=1 NET=1 ${GPU_FLAG}) ---"
+echo "--- building libkrun (BLK=1 NET=1 INPUT=1 ${GPU_FLAG}) ---"
 # Link with partial RELRO (lazy binding), NOT full RELRO. The GPU-enabled libkrun
 # carries a hard virglrenderer NEEDED that build-dist.sh strips via patchelf so
 # non-GPU hosts can dlopen it (paired with RTLD_LAZY in src/agent/krun.rs). That
@@ -133,7 +133,7 @@ echo "--- building libkrun (BLK=1 NET=1 ${GPU_FLAG}) ---"
 ( cd libkrun && make clean >/dev/null 2>&1 || true; \
   env "${INIT_ENV[@]}" \
   RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }-C relro-level=partial" \
-  make --no-print-directory BLK=1 NET=1 "${GPU_FLAG}" )
+  make --no-print-directory BLK=1 NET=1 INPUT=1 "${GPU_FLAG}" )
 KRUN_SO="$(ls -1 libkrun/target/release/libkrun.so.*.*.* 2>/dev/null | head -1)"
 [[ -n "$KRUN_SO" ]] || { echo "ERROR: libkrun build produced no .so" >&2; exit 1; }
 

--- a/src/agent/display.rs
+++ b/src/agent/display.rs
@@ -1,0 +1,518 @@
+//! Host-side virtio-gpu display backend.
+//!
+//! `krun_add_display` describes a display: it makes the device report a
+//! scanout, so the guest builds a connector with an EDID and a mode list and
+//! `/dev/dri/card0` becomes a KMS device. That is necessary for a DRM
+//! compositor to *start*, but it is not enough for one to *run*. Frames are
+//! consumed by a display backend registered separately through
+//! `krun_set_display_backend`, and when none is registered libkrun installs a
+//! no-op whose `configure_scanout`/`alloc_frame`/`present_frame` all fail with
+//! `InvalidScanoutId`. The guest's first page flip then never completes and
+//! the compositor blocks forever on it — Hyprland reports
+//! "Cannot commit when a page-flip is awaiting" and stops responding.
+//!
+//! This module is that missing consumer. It keeps the framebuffer on the host,
+//! which is also what lets `vnc` serve the desktop without the guest running a
+//! capture tool of its own.
+
+use std::ffi::c_void;
+use std::sync::{Arc, Condvar, Mutex};
+
+use crate::error::{Error, Result};
+
+/// `KRUN_DISPLAY_FEATURE_BASIC_FRAMEBUFFER`.
+const FEATURE_BASIC_FRAMEBUFFER: u64 = 1;
+
+const ERR_INVALID_SCANOUT_ID: i32 = -3;
+const ERR_INVALID_PARAM: i32 = -4;
+
+/// virtio-gpu pixel formats, as re-exported by `libkrun_display.h`. The names
+/// describe byte order in memory, so `B8G8R8A8` is B,G,R,A — the same order
+/// RFB wants for a little-endian true-colour pixel with shifts R=16/G=8/B=0,
+/// which is why those two need no conversion on the way out.
+pub const FORMAT_B8G8R8A8: u32 = 1;
+/// Bytes B,G,R,X in memory; the alpha byte is ignored.
+pub const FORMAT_B8G8R8X8: u32 = 2;
+/// Bytes A,R,G,B in memory — needs swizzling for RFB.
+pub const FORMAT_A8R8G8B8: u32 = 3;
+/// Bytes X,R,G,B in memory — needs swizzling for RFB.
+pub const FORMAT_X8R8G8B8: u32 = 4;
+
+const BYTES_PER_PIXEL: usize = 4;
+
+/// Refuse absurd scanout geometry rather than allocating from it. libkrun is
+/// trusted here, but this is guest-influenced state and the allocation is
+/// `width * height * 4`.
+const MAX_DIM: u32 = 16384;
+
+// ---------------------------------------------------------------------------
+// C ABI (see libkrun/src/display/libkrun_display.h)
+// ---------------------------------------------------------------------------
+
+/// `struct krun_rect` — a damage rectangle passed to `present_frame`.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct KrunRect {
+    /// Left edge, in pixels.
+    pub x: u32,
+    /// Top edge, in pixels.
+    pub y: u32,
+    /// Width of the damaged area, in pixels.
+    pub width: u32,
+    /// Height of the damaged area, in pixels.
+    pub height: u32,
+}
+
+#[repr(C)]
+struct BasicFramebufferVtable {
+    destroy: Option<unsafe extern "C" fn(*mut c_void) -> i32>,
+    disable_scanout: Option<unsafe extern "C" fn(*mut c_void, u32) -> i32>,
+    configure_scanout:
+        Option<unsafe extern "C" fn(*mut c_void, u32, u32, u32, u32, u32, u32) -> i32>,
+    alloc_frame: Option<unsafe extern "C" fn(*mut c_void, u32, *mut *mut u8, *mut usize) -> i32>,
+    present_frame: Option<unsafe extern "C" fn(*mut c_void, u32, u32, *const KrunRect) -> i32>,
+}
+
+#[repr(C)]
+struct KrunDisplayBackend {
+    features: u64,
+    create_userdata: *const c_void,
+    create: Option<unsafe extern "C" fn(*mut *mut c_void, *const c_void, *const c_void) -> i32>,
+    vtable: BasicFramebufferVtable,
+}
+
+// ---------------------------------------------------------------------------
+// Shared framebuffer state
+// ---------------------------------------------------------------------------
+
+/// A fully presented frame, plus the geometry it was presented at.
+#[derive(Clone)]
+pub struct Frame {
+    /// Raw pixels, `width * height * 4` bytes in `format`'s byte order.
+    pub buf: Vec<u8>,
+    /// Frame width in pixels.
+    pub width: u32,
+    /// Frame height in pixels.
+    pub height: u32,
+    /// One of the `FORMAT_*` constants.
+    pub format: u32,
+    /// Bumped on every present. Viewers compare against their last value to
+    /// tell a new frame from a repeat without diffing pixels.
+    pub generation: u64,
+}
+
+/// The buffer libkrun writes into. Deliberately *not* behind the mutex: the
+/// contract in `libkrun_display.h` is that every backend method is called from
+/// one and the same thread, so this is single-threaded state, and holding the
+/// viewer lock across a whole guest frame render would stall the GPU device.
+struct Staging {
+    buf: Vec<u8>,
+    width: u32,
+    height: u32,
+    format: u32,
+    configured: bool,
+}
+
+/// The host-side framebuffer the guest presents into, shared between
+/// libkrun's GPU thread and any viewers.
+pub struct DisplayFramebuffer {
+    /// # Safety
+    /// Only ever touched from the libkrun GPU thread — see `Staging`.
+    staging: std::cell::UnsafeCell<Staging>,
+    front: Mutex<Frame>,
+    presented: Condvar,
+}
+
+// SAFETY: `staging` is only accessed from the single thread libkrun uses for
+// every display-backend callback (documented in libkrun_display.h). `front`
+// and `presented` are ordinary sync primitives.
+unsafe impl Sync for DisplayFramebuffer {}
+unsafe impl Send for DisplayFramebuffer {}
+
+impl DisplayFramebuffer {
+    fn new() -> Self {
+        Self {
+            staging: std::cell::UnsafeCell::new(Staging {
+                buf: Vec::new(),
+                width: 0,
+                height: 0,
+                format: FORMAT_B8G8R8A8,
+                configured: false,
+            }),
+            front: Mutex::new(Frame {
+                buf: Vec::new(),
+                width: 0,
+                height: 0,
+                format: FORMAT_B8G8R8A8,
+                generation: 0,
+            }),
+            presented: Condvar::new(),
+        }
+    }
+
+    /// The most recently presented frame, or `None` before the guest has
+    /// presented anything.
+    pub fn latest(&self) -> Option<Frame> {
+        let f = self.front.lock().unwrap_or_else(|e| e.into_inner());
+        if f.generation == 0 {
+            None
+        } else {
+            Some(f.clone())
+        }
+    }
+
+    /// Block until a frame newer than `since` is presented, or `timeout`
+    /// elapses. Returns the frame if one arrived.
+    pub fn wait_for_frame(&self, since: u64, timeout: std::time::Duration) -> Option<Frame> {
+        let guard = self.front.lock().unwrap_or_else(|e| e.into_inner());
+        let (guard, _) = self
+            .presented
+            .wait_timeout_while(guard, timeout, |f| f.generation <= since)
+            .unwrap_or_else(|e| e.into_inner());
+        if guard.generation > since {
+            Some(guard.clone())
+        } else {
+            None
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Backend callbacks
+// ---------------------------------------------------------------------------
+
+/// # Safety
+/// `instance` must be the pointer handed back by `display_create`, i.e. a
+/// borrowed `Arc<DisplayFramebuffer>` that outlives the VM.
+unsafe fn fb<'a>(instance: *mut c_void) -> Option<&'a DisplayFramebuffer> {
+    if instance.is_null() {
+        None
+    } else {
+        Some(unsafe { &*(instance as *const DisplayFramebuffer) })
+    }
+}
+
+unsafe extern "C" fn display_create(
+    instance: *mut *mut c_void,
+    userdata: *const c_void,
+    _reserved: *const c_void,
+) -> i32 {
+    if instance.is_null() {
+        return ERR_INVALID_PARAM;
+    }
+    // The state is created up front and leaked; `create` just hands it back as
+    // the `self` pointer for subsequent calls.
+    unsafe { *instance = userdata as *mut c_void };
+    0
+}
+
+unsafe extern "C" fn display_destroy(_instance: *mut c_void) -> i32 {
+    // The state is intentionally leaked for the process lifetime: viewer
+    // threads hold `Arc`s and the VM teardown path is the process exiting.
+    0
+}
+
+unsafe extern "C" fn display_configure_scanout(
+    instance: *mut c_void,
+    scanout_id: u32,
+    _display_width: u32,
+    _display_height: u32,
+    width: u32,
+    height: u32,
+    format: u32,
+) -> i32 {
+    // Only scanout 0 exists: smolvm adds exactly one display.
+    if scanout_id != 0 {
+        return ERR_INVALID_SCANOUT_ID;
+    }
+    if width == 0 || height == 0 || width > MAX_DIM || height > MAX_DIM {
+        return ERR_INVALID_PARAM;
+    }
+    let Some(fb) = (unsafe { fb(instance) }) else {
+        return ERR_INVALID_PARAM;
+    };
+
+    let staging = unsafe { &mut *fb.staging.get() };
+    let len = width as usize * height as usize * BYTES_PER_PIXEL;
+    staging.buf.clear();
+    staging.buf.resize(len, 0);
+    staging.width = width;
+    staging.height = height;
+    staging.format = format;
+    staging.configured = true;
+
+    tracing::info!(
+        width,
+        height,
+        format,
+        "virtio-gpu scanout configured (host framebuffer ready)"
+    );
+    0
+}
+
+unsafe extern "C" fn display_disable_scanout(instance: *mut c_void, scanout_id: u32) -> i32 {
+    if scanout_id != 0 {
+        return ERR_INVALID_SCANOUT_ID;
+    }
+    let Some(fb) = (unsafe { fb(instance) }) else {
+        return ERR_INVALID_PARAM;
+    };
+    let staging = unsafe { &mut *fb.staging.get() };
+    staging.configured = false;
+    tracing::debug!("virtio-gpu scanout disabled");
+    0
+}
+
+unsafe extern "C" fn display_alloc_frame(
+    instance: *mut c_void,
+    scanout_id: u32,
+    buffer: *mut *mut u8,
+    buffer_size: *mut usize,
+) -> i32 {
+    if scanout_id != 0 {
+        return ERR_INVALID_SCANOUT_ID;
+    }
+    if buffer.is_null() || buffer_size.is_null() {
+        return ERR_INVALID_PARAM;
+    }
+    let Some(fb) = (unsafe { fb(instance) }) else {
+        return ERR_INVALID_PARAM;
+    };
+
+    let staging = unsafe { &mut *fb.staging.get() };
+    if !staging.configured || staging.buf.is_empty() {
+        return ERR_INVALID_SCANOUT_ID;
+    }
+
+    unsafe {
+        *buffer = staging.buf.as_mut_ptr();
+        *buffer_size = staging.buf.len();
+    }
+    // Single staging buffer, so there is only ever one live frame id.
+    0
+}
+
+unsafe extern "C" fn display_present_frame(
+    instance: *mut c_void,
+    scanout_id: u32,
+    _frame_id: u32,
+    _damage: *const KrunRect,
+) -> i32 {
+    if scanout_id != 0 {
+        return ERR_INVALID_SCANOUT_ID;
+    }
+    let Some(fb) = (unsafe { fb(instance) }) else {
+        return ERR_INVALID_PARAM;
+    };
+
+    let staging = unsafe { &*fb.staging.get() };
+    if !staging.configured {
+        return ERR_INVALID_SCANOUT_ID;
+    }
+
+    {
+        let mut front = fb.front.lock().unwrap_or_else(|e| e.into_inner());
+        // Copy the whole frame rather than honouring the damage rect: the
+        // front buffer may be a different generation than the damage was
+        // computed against, and a viewer that joined mid-stream would inherit
+        // stale pixels outside the damaged area.
+        front.buf.clear();
+        front.buf.extend_from_slice(&staging.buf);
+        front.width = staging.width;
+        front.height = staging.height;
+        front.format = staging.format;
+        front.generation = front.generation.wrapping_add(1);
+    }
+    fb.presented.notify_all();
+    0
+}
+
+// ---------------------------------------------------------------------------
+// Installation
+// ---------------------------------------------------------------------------
+
+/// Register a host framebuffer as the VM's display backend.
+///
+/// Must be called before boot and after `krun_add_display`, and the returned
+/// handle is what viewers (e.g. the VNC server) read frames from.
+pub fn install(
+    set_display_backend: unsafe extern "C" fn(u32, *const c_void, usize) -> i32,
+    ctx: u32,
+) -> Result<Arc<DisplayFramebuffer>> {
+    let state = Arc::new(DisplayFramebuffer::new());
+
+    // libkrun keeps `create_userdata` and calls back into it for the life of
+    // the VM, so this reference is deliberately leaked rather than tied to a
+    // Rust lifetime the FFI boundary cannot express.
+    let raw = Arc::into_raw(Arc::clone(&state));
+
+    let backend = KrunDisplayBackend {
+        features: FEATURE_BASIC_FRAMEBUFFER,
+        create_userdata: raw as *const c_void,
+        create: Some(display_create),
+        vtable: BasicFramebufferVtable {
+            destroy: Some(display_destroy),
+            disable_scanout: Some(display_disable_scanout),
+            configure_scanout: Some(display_configure_scanout),
+            alloc_frame: Some(display_alloc_frame),
+            present_frame: Some(display_present_frame),
+        },
+    };
+
+    // libkrun copies the struct out (read_unaligned), so a stack pointer is
+    // fine; only `create_userdata` has to outlive this call.
+    let ret = unsafe {
+        set_display_backend(
+            ctx,
+            &backend as *const KrunDisplayBackend as *const c_void,
+            std::mem::size_of::<KrunDisplayBackend>(),
+        )
+    };
+    if ret < 0 {
+        // Reclaim the leak so a failed install does not also lose memory.
+        unsafe { drop(Arc::from_raw(raw)) };
+        return Err(Error::agent(
+            "configure display",
+            format!("krun_set_display_backend failed (ret={ret})"),
+        ));
+    }
+
+    Ok(state)
+}
+
+/// Convert a presented frame into RFB's little-endian 32-bit true-colour
+/// layout (shifts R=16, G=8, B=0), which is byte order B,G,R,X in memory.
+///
+/// Returns `Cow::Borrowed` for the formats that already match, so the common
+/// path copies nothing.
+pub fn to_bgrx(frame: &Frame) -> std::borrow::Cow<'_, [u8]> {
+    match frame.format {
+        // Already B,G,R,{A,X} in memory.
+        FORMAT_B8G8R8A8 | FORMAT_B8G8R8X8 => std::borrow::Cow::Borrowed(&frame.buf),
+        // A,R,G,B in memory -> B,G,R,A.
+        FORMAT_A8R8G8B8 | FORMAT_X8R8G8B8 => {
+            let mut out = vec![0u8; frame.buf.len()];
+            let (src_px, _) = frame.buf.as_chunks::<BYTES_PER_PIXEL>();
+            let (dst_px, _) = out.as_chunks_mut::<BYTES_PER_PIXEL>();
+            for (src, dst) in src_px.iter().zip(dst_px.iter_mut()) {
+                dst[0] = src[3];
+                dst[1] = src[2];
+                dst[2] = src[1];
+                dst[3] = src[0];
+            }
+            std::borrow::Cow::Owned(out)
+        }
+        // Unknown format: pass through rather than mangle. Colours may be
+        // wrong but the geometry and liveness are still meaningful.
+        _ => std::borrow::Cow::Borrowed(&frame.buf),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn frame(format: u32, buf: Vec<u8>) -> Frame {
+        Frame {
+            buf,
+            width: 1,
+            height: 1,
+            format,
+            generation: 1,
+        }
+    }
+
+    #[test]
+    fn bgra_passes_through_without_copying() {
+        let f = frame(FORMAT_B8G8R8A8, vec![1, 2, 3, 4]);
+        assert!(matches!(to_bgrx(&f), std::borrow::Cow::Borrowed(_)));
+        assert_eq!(&*to_bgrx(&f), &[1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn argb_is_swizzled_to_bgra() {
+        // memory A,R,G,B = 0xAA,0xRR,0xGG,0xBB -> B,G,R,A
+        let f = frame(FORMAT_A8R8G8B8, vec![0xAA, 0x11, 0x22, 0x33]);
+        assert_eq!(&*to_bgrx(&f), &[0x33, 0x22, 0x11, 0xAA]);
+    }
+
+    #[test]
+    fn unknown_format_is_passed_through_not_mangled() {
+        let f = frame(9999, vec![9, 8, 7, 6]);
+        assert_eq!(&*to_bgrx(&f), &[9, 8, 7, 6]);
+    }
+
+    #[test]
+    fn latest_is_none_before_any_present() {
+        let fb = DisplayFramebuffer::new();
+        assert!(fb.latest().is_none());
+    }
+
+    #[test]
+    fn present_publishes_a_frame_and_bumps_generation() {
+        let fb = Arc::new(DisplayFramebuffer::new());
+        let raw = Arc::as_ptr(&fb) as *mut c_void;
+        unsafe {
+            assert_eq!(
+                display_configure_scanout(raw, 0, 2, 2, 2, 2, FORMAT_B8G8R8A8),
+                0
+            );
+            let mut buf: *mut u8 = std::ptr::null_mut();
+            let mut len: usize = 0;
+            assert_eq!(display_alloc_frame(raw, 0, &mut buf, &mut len), 0);
+            assert_eq!(len, 2 * 2 * 4);
+            std::ptr::write_bytes(buf, 0x7f, len);
+            assert_eq!(display_present_frame(raw, 0, 0, std::ptr::null()), 0);
+        }
+        let f = fb.latest().expect("a frame was presented");
+        assert_eq!((f.width, f.height), (2, 2));
+        assert_eq!(f.generation, 1);
+        assert!(f.buf.iter().all(|&b| b == 0x7f));
+    }
+
+    #[test]
+    fn alloc_before_configure_is_rejected() {
+        let fb = Arc::new(DisplayFramebuffer::new());
+        let raw = Arc::as_ptr(&fb) as *mut c_void;
+        let mut buf: *mut u8 = std::ptr::null_mut();
+        let mut len: usize = 0;
+        // Without this guard alloc_frame would hand back a zero-length slice
+        // and the guest would present into nothing.
+        assert_eq!(
+            unsafe { display_alloc_frame(raw, 0, &mut buf, &mut len) },
+            ERR_INVALID_SCANOUT_ID
+        );
+    }
+
+    #[test]
+    fn non_zero_scanout_is_rejected() {
+        let fb = Arc::new(DisplayFramebuffer::new());
+        let raw = Arc::as_ptr(&fb) as *mut c_void;
+        unsafe {
+            assert_eq!(
+                display_configure_scanout(raw, 1, 2, 2, 2, 2, FORMAT_B8G8R8A8),
+                ERR_INVALID_SCANOUT_ID
+            );
+            assert_eq!(
+                display_present_frame(raw, 1, 0, std::ptr::null()),
+                ERR_INVALID_SCANOUT_ID
+            );
+        }
+    }
+
+    #[test]
+    fn absurd_geometry_is_rejected_before_allocating() {
+        let fb = Arc::new(DisplayFramebuffer::new());
+        let raw = Arc::as_ptr(&fb) as *mut c_void;
+        unsafe {
+            assert_eq!(
+                display_configure_scanout(raw, 0, 0, 0, 0, 100, FORMAT_B8G8R8A8),
+                ERR_INVALID_PARAM
+            );
+            assert_eq!(
+                display_configure_scanout(raw, 0, 0, 0, 99999, 100, FORMAT_B8G8R8A8),
+                ERR_INVALID_PARAM
+            );
+        }
+    }
+}

--- a/src/agent/display.rs
+++ b/src/agent/display.rs
@@ -121,6 +121,17 @@ pub struct DisplayFramebuffer {
     staging: std::cell::UnsafeCell<Staging>,
     front: Mutex<Frame>,
     presented: Condvar,
+    /// Optional call trace, enabled by `SMOLVM_DISPLAY_TRACE=<path>`.
+    ///
+    /// libkrun's own logging goes through `env_logger` in a process whose
+    /// stdout and stderr are `/dev/null` unless `SMOLVM_BOOT_DEBUG` is set,
+    /// and even with it set no libkrun line has ever reached us. Writing our
+    /// own trace to a plain file is the only way to see whether the guest is
+    /// actually presenting, which is the question that matters when a
+    /// compositor renders once and then stalls.
+    trace: Option<Mutex<std::fs::File>>,
+    /// Monotonic counter so trace lines are ordered and countable.
+    traced_calls: std::sync::atomic::AtomicU64,
 }
 
 // SAFETY: `staging` is only accessed from the single thread libkrun uses for
@@ -131,6 +142,16 @@ unsafe impl Send for DisplayFramebuffer {}
 
 impl DisplayFramebuffer {
     fn new() -> Self {
+        // Best effort: a missing or unwritable path just disables tracing
+        // rather than failing the boot.
+        let trace = std::env::var("SMOLVM_DISPLAY_TRACE").ok().and_then(|path| {
+            std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)
+                .ok()
+                .map(Mutex::new)
+        });
         Self {
             staging: std::cell::UnsafeCell::new(Staging {
                 buf: Vec::new(),
@@ -147,7 +168,37 @@ impl DisplayFramebuffer {
                 generation: 0,
             }),
             presented: Condvar::new(),
+            trace,
+            traced_calls: std::sync::atomic::AtomicU64::new(0),
         }
+    }
+
+    /// Append a numbered line to the call trace, bounded so a long-running
+    /// desktop cannot fill the disk. Sampling was a mistake the first time
+    /// round: it could not distinguish "presents stopped" from "presents
+    /// continued but missed the sampling window".
+    fn trace_seq(&self, what: &str) {
+        if self.trace.is_none() {
+            return;
+        }
+        const MAX_TRACED_CALLS: u64 = 2000;
+        let n = self
+            .traced_calls
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if n < MAX_TRACED_CALLS {
+            self.trace(&format!("{n:05} {what}"));
+        } else if n == MAX_TRACED_CALLS {
+            self.trace("... trace limit reached, further calls not logged");
+        }
+    }
+
+    /// Append one line to the call trace, if enabled.
+    fn trace(&self, line: &str) {
+        let Some(f) = self.trace.as_ref() else { return };
+        use std::io::Write;
+        let mut f = f.lock().unwrap_or_else(|e| e.into_inner());
+        let _ = writeln!(f, "{line}");
+        let _ = f.flush();
     }
 
     /// The most recently presented frame, or `None` before the guest has
@@ -241,6 +292,9 @@ unsafe extern "C" fn display_configure_scanout(
     staging.format = format;
     staging.configured = true;
 
+    fb.trace(&format!(
+        "configure_scanout scanout=0 {width}x{height} format={format} bytes={len}"
+    ));
     tracing::info!(
         width,
         height,
@@ -259,6 +313,7 @@ unsafe extern "C" fn display_disable_scanout(instance: *mut c_void, scanout_id: 
     };
     let staging = unsafe { &mut *fb.staging.get() };
     staging.configured = false;
+    fb.trace("disable_scanout scanout=0");
     tracing::debug!("virtio-gpu scanout disabled");
     0
 }
@@ -281,6 +336,7 @@ unsafe extern "C" fn display_alloc_frame(
 
     let staging = unsafe { &mut *fb.staging.get() };
     if !staging.configured || staging.buf.is_empty() {
+        fb.trace("alloc_frame REJECTED (scanout not configured)");
         return ERR_INVALID_SCANOUT_ID;
     }
 
@@ -288,6 +344,7 @@ unsafe extern "C" fn display_alloc_frame(
         *buffer = staging.buf.as_mut_ptr();
         *buffer_size = staging.buf.len();
     }
+    fb.trace_seq("alloc_frame");
     // Single staging buffer, so there is only ever one live frame id.
     0
 }
@@ -324,6 +381,8 @@ unsafe extern "C" fn display_present_frame(
         front.generation = front.generation.wrapping_add(1);
     }
     fb.presented.notify_all();
+
+    fb.trace_seq("present_frame");
     0
 }
 
@@ -377,6 +436,7 @@ pub fn install(
         ));
     }
 
+    state.trace("display backend installed");
     Ok(state)
 }
 

--- a/src/agent/input.rs
+++ b/src/agent/input.rs
@@ -1,0 +1,633 @@
+//! Virtio-input devices fed by the VNC server, so a connected client can
+//! type and point instead of only watching.
+//!
+//! libkrun's input device is backend-driven like the display: the embedder
+//! hands `krun_add_input_device` a *config* vtable (device identity and
+//! capability bitmaps, queried once by the guest driver) and an *event
+//! provider* vtable (a ready fd plus a non-blocking `next_event` pop). Two
+//! devices are registered — a keyboard and an absolute pointer — because a
+//! single device advertising both keys and absolute axes classifies poorly
+//! in libinput, while the split matches what QEMU exposes and every guest
+//! stack already understands.
+
+use std::collections::VecDeque;
+use std::ffi::c_void;
+use std::sync::{Arc, Mutex};
+
+use crate::{Error, Result};
+
+// ---------------------------------------------------------------------------
+// C ABI mirrors of libkrun_input.h
+// ---------------------------------------------------------------------------
+
+/// Linux `EV_SYN` event type (frame terminator).
+pub const EV_SYN: u16 = 0x00;
+/// Linux `EV_KEY` event type (keys and buttons).
+pub const EV_KEY: u16 = 0x01;
+/// Linux `EV_REL` event type (relative axes; used for the scroll wheel).
+pub const EV_REL: u16 = 0x02;
+/// Linux `EV_ABS` event type (absolute axes; pointer position).
+pub const EV_ABS: u16 = 0x03;
+const SYN_REPORT: u16 = 0;
+
+/// Linux `BTN_LEFT` keycode.
+pub const BTN_LEFT: u16 = 0x110;
+/// Linux `BTN_RIGHT` keycode.
+pub const BTN_RIGHT: u16 = 0x111;
+/// Linux `BTN_MIDDLE` keycode.
+pub const BTN_MIDDLE: u16 = 0x112;
+/// Linux `REL_WHEEL` axis code.
+pub const REL_WHEEL: u16 = 8;
+#[cfg(unix)]
+const ABS_X: u16 = 0;
+#[cfg(unix)]
+const ABS_Y: u16 = 1;
+
+/// Absolute axes are reported in a fixed virtual range and scaled from pixel
+/// coordinates, so a guest mode change never invalidates the device's absinfo.
+pub const ABS_RANGE: u32 = 32767;
+
+#[cfg(unix)]
+const ERR_INVALID_PARAM: i32 = -4;
+
+#[cfg(unix)]
+const FEATURE_QUERY: u64 = 1;
+#[cfg(unix)]
+const FEATURE_QUEUE: u64 = 1;
+
+/// One input event in libkrun's wire layout, matching `struct
+/// krun_input_event` and the virtio-input event the guest receives.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct KrunInputEvent {
+    /// Event type (`EV_KEY`, `EV_ABS`, ...).
+    pub type_: u16,
+    /// Event code within the type (keycode, axis, ...).
+    pub code: u16,
+    /// Event value (press state, axis position, wheel delta).
+    pub value: u32,
+}
+
+#[cfg(unix)]
+#[repr(C)]
+struct KrunInputDeviceIds {
+    bustype: u16,
+    vendor: u16,
+    product: u16,
+    version: u16,
+}
+
+#[cfg(unix)]
+#[repr(C)]
+struct KrunInputAbsinfo {
+    min: u32,
+    max: u32,
+    fuzz: u32,
+    flat: u32,
+    res: u32,
+}
+
+#[cfg(unix)]
+type CreateFn = unsafe extern "C" fn(*mut *mut c_void, *const c_void, *const c_void) -> i32;
+
+#[cfg(unix)]
+#[repr(C)]
+struct ConfigVtable {
+    destroy: Option<unsafe extern "C" fn(*mut c_void) -> i32>,
+    query_device_name: Option<unsafe extern "C" fn(*mut c_void, *mut u8, usize) -> i32>,
+    query_serial_name: Option<unsafe extern "C" fn(*mut c_void, *mut u8, usize) -> i32>,
+    query_device_ids: Option<unsafe extern "C" fn(*mut c_void, *mut KrunInputDeviceIds) -> i32>,
+    query_event_capabilities: Option<unsafe extern "C" fn(*mut c_void, u8, *mut u8, usize) -> i32>,
+    query_abs_info: Option<unsafe extern "C" fn(*mut c_void, u8, *mut KrunInputAbsinfo) -> i32>,
+    query_properties: Option<unsafe extern "C" fn(*mut c_void, *mut u8, usize) -> i32>,
+}
+
+#[cfg(unix)]
+#[repr(C)]
+struct KrunInputConfig {
+    features: u64,
+    create_userdata: *const c_void,
+    create: Option<CreateFn>,
+    vtable: ConfigVtable,
+}
+
+#[cfg(unix)]
+#[repr(C)]
+struct ProviderVtable {
+    destroy: Option<unsafe extern "C" fn(*mut c_void) -> i32>,
+    get_ready_efd: Option<unsafe extern "C" fn(*mut c_void) -> i32>,
+    next_event: Option<unsafe extern "C" fn(*mut c_void, *mut KrunInputEvent) -> i32>,
+}
+
+#[cfg(unix)]
+#[repr(C)]
+struct KrunInputEventProvider {
+    features: u64,
+    create_userdata: *const c_void,
+    create: Option<CreateFn>,
+    vtable: ProviderVtable,
+}
+
+// ---------------------------------------------------------------------------
+// Event queue shared between the VNC server (producer) and libkrun's input
+// worker (consumer)
+// ---------------------------------------------------------------------------
+
+/// A pipe is used for readiness instead of an eventfd so the same code builds
+/// on macOS. The worker epolls the read end level-triggered and never reads
+/// it, so `next_event` must drain the pipe when reporting empty — under the
+/// queue lock, so a concurrent push (which writes the pipe *after* enqueuing)
+/// can never be swallowed.
+pub struct InputQueue {
+    events: Mutex<VecDeque<KrunInputEvent>>,
+    #[cfg(unix)]
+    read_fd: i32,
+    #[cfg(unix)]
+    write_fd: i32,
+}
+
+// SAFETY: the fds are plain integers used with thread-safe syscalls, and the
+// queue itself is behind a Mutex.
+unsafe impl Send for InputQueue {}
+unsafe impl Sync for InputQueue {}
+
+impl InputQueue {
+    #[cfg(unix)]
+    fn new() -> Result<Self> {
+        let mut fds = [0i32; 2];
+        // SAFETY: fds is a valid out-array for pipe(2).
+        if unsafe { libc::pipe(fds.as_mut_ptr()) } != 0 {
+            return Err(Error::agent(
+                "configure input",
+                format!("pipe failed: {}", std::io::Error::last_os_error()),
+            ));
+        }
+        for fd in fds {
+            // SAFETY: fd was just returned by pipe(2).
+            unsafe {
+                let flags = libc::fcntl(fd, libc::F_GETFL);
+                libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
+            }
+        }
+        Ok(Self {
+            events: Mutex::new(VecDeque::new()),
+            read_fd: fds[0],
+            write_fd: fds[1],
+        })
+    }
+
+    /// Queue a batch of events followed by a SYN_REPORT frame terminator,
+    /// then signal the ready fd.
+    pub fn push(&self, batch: &[(u16, u16, u32)]) {
+        if batch.is_empty() {
+            return;
+        }
+        {
+            let mut q = self.events.lock().unwrap();
+            for &(type_, code, value) in batch {
+                q.push_back(KrunInputEvent { type_, code, value });
+            }
+            q.push_back(KrunInputEvent {
+                type_: EV_SYN,
+                code: SYN_REPORT,
+                value: 0,
+            });
+        }
+        // A full pipe is fine: it is still readable, which is all the worker
+        // needs to wake up.
+        // SAFETY: write_fd is a valid non-blocking pipe write end.
+        #[cfg(unix)]
+        unsafe {
+            libc::write(self.write_fd, [1u8].as_ptr() as *const c_void, 1)
+        };
+    }
+
+    #[cfg(unix)]
+    fn pop(&self) -> Option<KrunInputEvent> {
+        let mut q = self.events.lock().unwrap();
+        match q.pop_front() {
+            Some(ev) => Some(ev),
+            None => {
+                // Clear readiness while holding the lock; see type docs.
+                #[cfg(unix)]
+                {
+                    let mut buf = [0u8; 64];
+                    // SAFETY: read_fd is a valid non-blocking pipe read end.
+                    while unsafe { libc::read(self.read_fd, buf.as_mut_ptr() as *mut c_void, 64) }
+                        > 0
+                    {}
+                }
+                None
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for InputQueue {
+    fn drop(&mut self) {
+        // SAFETY: both fds are owned by this queue.
+        unsafe {
+            libc::close(self.read_fd);
+            libc::close(self.write_fd);
+        }
+    }
+}
+
+/// Handles the VNC server holds to feed the guest's input devices.
+#[derive(Clone)]
+pub struct VncInput {
+    /// Event queue of the virtio keyboard device.
+    pub keyboard: Arc<InputQueue>,
+    /// Event queue of the virtio absolute-pointer device.
+    pub pointer: Arc<InputQueue>,
+}
+
+// ---------------------------------------------------------------------------
+// Config backends
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+enum DeviceKind {
+    Keyboard,
+    Pointer,
+}
+
+#[cfg(unix)]
+struct DeviceDesc {
+    name: &'static str,
+    kind: DeviceKind,
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn passthrough_create(
+    instance: *mut *mut c_void,
+    userdata: *const c_void,
+    _reserved: *const c_void,
+) -> i32 {
+    // The userdata *is* the instance: config state is immutable and the
+    // event queue is internally synchronized.
+    unsafe { *instance = userdata as *mut c_void };
+    0
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn config_query_device_name(
+    instance: *mut c_void,
+    buf: *mut u8,
+    len: usize,
+) -> i32 {
+    let desc = unsafe { &*(instance as *const DeviceDesc) };
+    let bytes = desc.name.as_bytes();
+    if bytes.len() > len {
+        return ERR_INVALID_PARAM;
+    }
+    unsafe { std::ptr::copy_nonoverlapping(bytes.as_ptr(), buf, bytes.len()) };
+    bytes.len() as i32
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn config_query_serial_name(
+    _instance: *mut c_void,
+    _buf: *mut u8,
+    _len: usize,
+) -> i32 {
+    0
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn config_query_device_ids(
+    instance: *mut c_void,
+    ids: *mut KrunInputDeviceIds,
+) -> i32 {
+    let desc = unsafe { &*(instance as *const DeviceDesc) };
+    let product = match desc.kind {
+        DeviceKind::Keyboard => 1,
+        DeviceKind::Pointer => 2,
+    };
+    unsafe {
+        *ids = KrunInputDeviceIds {
+            bustype: 0x06, // BUS_VIRTUAL
+            vendor: 0x1af4,
+            product,
+            version: 1,
+        };
+    }
+    0
+}
+
+/// Write a byte bitmap with the given bit positions set. Returns the number
+/// of bytes the bitmap spans, which is what the caller forwards to the guest.
+#[cfg(unix)]
+fn write_bitmap(buf: *mut u8, len: usize, bits: &[u16]) -> i32 {
+    let span = match bits.iter().max() {
+        Some(&m) => (m as usize / 8) + 1,
+        None => return 0,
+    };
+    if span > len {
+        return ERR_INVALID_PARAM;
+    }
+    // SAFETY: caller guarantees buf points at len writable bytes.
+    unsafe {
+        std::ptr::write_bytes(buf, 0, span);
+        for &bit in bits {
+            *buf.add(bit as usize / 8) |= 1 << (bit % 8);
+        }
+    }
+    span as i32
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn config_query_event_capabilities(
+    instance: *mut c_void,
+    event_type: u8,
+    buf: *mut u8,
+    len: usize,
+) -> i32 {
+    let desc = unsafe { &*(instance as *const DeviceDesc) };
+    match (&desc.kind, event_type as u16) {
+        (DeviceKind::Keyboard, EV_KEY) => {
+            // All plain keyboard keycodes. 1..=248 covers everything the
+            // keysym table below can produce, with room for layouts we may
+            // map later.
+            let keys: Vec<u16> = (1u16..=248).collect();
+            write_bitmap(buf, len, &keys)
+        }
+        (DeviceKind::Pointer, EV_KEY) => write_bitmap(buf, len, &[BTN_LEFT, BTN_RIGHT, BTN_MIDDLE]),
+        (DeviceKind::Pointer, EV_ABS) => write_bitmap(buf, len, &[ABS_X, ABS_Y]),
+        (DeviceKind::Pointer, EV_REL) => write_bitmap(buf, len, &[REL_WHEEL]),
+        _ => 0,
+    }
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn config_query_abs_info(
+    instance: *mut c_void,
+    abs_axis: u8,
+    abs_info: *mut KrunInputAbsinfo,
+) -> i32 {
+    let desc = unsafe { &*(instance as *const DeviceDesc) };
+    match (&desc.kind, abs_axis as u16) {
+        (DeviceKind::Pointer, ABS_X) | (DeviceKind::Pointer, ABS_Y) => {
+            unsafe {
+                *abs_info = KrunInputAbsinfo {
+                    min: 0,
+                    max: ABS_RANGE,
+                    fuzz: 0,
+                    flat: 0,
+                    res: 0,
+                };
+            }
+            0
+        }
+        _ => ERR_INVALID_PARAM,
+    }
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn config_query_properties(
+    _instance: *mut c_void,
+    _buf: *mut u8,
+    _len: usize,
+) -> i32 {
+    0
+}
+
+// ---------------------------------------------------------------------------
+// Event provider backend
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+unsafe extern "C" fn provider_get_ready_efd(instance: *mut c_void) -> i32 {
+    let queue = unsafe { &*(instance as *const InputQueue) };
+    queue.read_fd
+}
+
+#[cfg(unix)]
+unsafe extern "C" fn provider_next_event(instance: *mut c_void, out: *mut KrunInputEvent) -> i32 {
+    let queue = unsafe { &*(instance as *const InputQueue) };
+    match queue.pop() {
+        Some(ev) => {
+            unsafe { *out = ev };
+            1
+        }
+        None => 0,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Installation
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+fn add_device(
+    add_input_device: unsafe extern "C" fn(u32, *const c_void, usize, *const c_void, usize) -> i32,
+    ctx: u32,
+    desc: DeviceDesc,
+) -> Result<Arc<InputQueue>> {
+    let queue = Arc::new(InputQueue::new()?);
+
+    // libkrun keeps both userdata pointers and calls back into them for the
+    // life of the VM; leak deliberately, exactly like the display backend.
+    let desc_raw = Box::into_raw(Box::new(desc));
+    let queue_raw = Arc::into_raw(Arc::clone(&queue));
+
+    let config = KrunInputConfig {
+        features: FEATURE_QUERY,
+        create_userdata: desc_raw as *const c_void,
+        create: Some(passthrough_create),
+        vtable: ConfigVtable {
+            destroy: None,
+            query_device_name: Some(config_query_device_name),
+            query_serial_name: Some(config_query_serial_name),
+            query_device_ids: Some(config_query_device_ids),
+            query_event_capabilities: Some(config_query_event_capabilities),
+            query_abs_info: Some(config_query_abs_info),
+            query_properties: Some(config_query_properties),
+        },
+    };
+    let provider = KrunInputEventProvider {
+        features: FEATURE_QUEUE,
+        create_userdata: queue_raw as *const c_void,
+        create: Some(passthrough_create),
+        vtable: ProviderVtable {
+            destroy: None,
+            get_ready_efd: Some(provider_get_ready_efd),
+            next_event: Some(provider_next_event),
+        },
+    };
+
+    // libkrun copies both structs out; only the userdata must outlive this.
+    let ret = unsafe {
+        add_input_device(
+            ctx,
+            &config as *const KrunInputConfig as *const c_void,
+            std::mem::size_of::<KrunInputConfig>(),
+            &provider as *const KrunInputEventProvider as *const c_void,
+            std::mem::size_of::<KrunInputEventProvider>(),
+        )
+    };
+    if ret < 0 {
+        // Reclaim the leaks so a failed install does not also lose memory.
+        unsafe {
+            drop(Box::from_raw(desc_raw));
+            drop(Arc::from_raw(queue_raw));
+        }
+        return Err(Error::agent(
+            "configure input",
+            format!("krun_add_input_device failed (ret={ret})"),
+        ));
+    }
+    Ok(queue)
+}
+
+/// Register the keyboard and pointer devices. Must be called before boot.
+#[cfg(unix)]
+pub fn install(
+    add_input_device: unsafe extern "C" fn(u32, *const c_void, usize, *const c_void, usize) -> i32,
+    ctx: u32,
+) -> Result<VncInput> {
+    let keyboard = add_device(
+        add_input_device,
+        ctx,
+        DeviceDesc {
+            name: "smolvm vnc keyboard",
+            kind: DeviceKind::Keyboard,
+        },
+    )?;
+    let pointer = add_device(
+        add_input_device,
+        ctx,
+        DeviceDesc {
+            name: "smolvm vnc pointer",
+            kind: DeviceKind::Pointer,
+        },
+    )?;
+    Ok(VncInput { keyboard, pointer })
+}
+
+// ---------------------------------------------------------------------------
+// X11 keysym -> Linux evdev keycode
+// ---------------------------------------------------------------------------
+
+/// RFB carries X11 keysyms. Clients send the *shifted* symbol together with
+/// real Shift key events, so shifted symbols map to the same physical key as
+/// their unshifted partner (US layout) and the guest's own Shift state does
+/// the rest. Returns None for keysyms with no mapping, which are dropped.
+pub fn keysym_to_evdev(keysym: u32) -> Option<u16> {
+    Some(match keysym {
+        // Letters: keysyms mirror ASCII; upper and lower map to the same key.
+        0x61..=0x7a | 0x41..=0x5a => {
+            const LETTERS: [u16; 26] = [
+                30, 48, 46, 32, 18, 33, 34, 35, 23, 36, 37, 38, 50, // a-m
+                49, 24, 25, 16, 19, 31, 20, 22, 47, 17, 45, 21, 44, // n-z
+            ];
+            let idx = if keysym >= 0x61 {
+                keysym - 0x61
+            } else {
+                keysym - 0x41
+            };
+            LETTERS[idx as usize]
+        }
+        // Digit row, with each key's shifted symbol.
+        0x31 => 2,
+        0x21 => 2, // 1 !
+        0x32 => 3,
+        0x40 => 3, // 2 @
+        0x33 => 4,
+        0x23 => 4, // 3 #
+        0x34 => 5,
+        0x24 => 5, // 4 $
+        0x35 => 6,
+        0x25 => 6, // 5 %
+        0x36 => 7,
+        0x5e => 7, // 6 ^
+        0x37 => 8,
+        0x26 => 8, // 7 &
+        0x38 => 9,
+        0x2a => 9, // 8 *
+        0x39 => 10,
+        0x28 => 10, // 9 (
+        0x30 => 11,
+        0x29 => 11, // 0 )
+        // Punctuation row keys.
+        0x2d => 12,
+        0x5f => 12, // - _
+        0x3d => 13,
+        0x2b => 13, // = +
+        0x5b => 26,
+        0x7b => 26, // [ {
+        0x5d => 27,
+        0x7d => 27, // ] }
+        0x3b => 39,
+        0x3a => 39, // ; :
+        0x27 => 40,
+        0x22 => 40, // ' "
+        0x60 => 41,
+        0x7e => 41, // ` ~
+        0x5c => 43,
+        0x7c => 43, // \ |
+        0x2c => 51,
+        0x3c => 51, // , <
+        0x2e => 52,
+        0x3e => 52, // . >
+        0x2f => 53,
+        0x3f => 53, // / ?
+        0x20 => 57, // space
+        // Controls and navigation.
+        0xff08 => 14,  // BackSpace
+        0xff09 => 15,  // Tab
+        0xfe20 => 15,  // ISO_Left_Tab (Shift+Tab)
+        0xff0d => 28,  // Return
+        0xff8d => 96,  // KP_Enter
+        0xff1b => 1,   // Escape
+        0xff63 => 110, // Insert
+        0xffff => 111, // Delete
+        0xff50 => 102, // Home
+        0xff51 => 105, // Left
+        0xff52 => 103, // Up
+        0xff53 => 106, // Right
+        0xff54 => 108, // Down
+        0xff55 => 104, // PageUp
+        0xff56 => 109, // PageDown
+        0xff57 => 107, // End
+        0xff67 => 127, // Menu
+        // Function keys.
+        0xffbe => 59,
+        0xffbf => 60,
+        0xffc0 => 61,
+        0xffc1 => 62, // F1-F4
+        0xffc2 => 63,
+        0xffc3 => 64,
+        0xffc4 => 65,
+        0xffc5 => 66, // F5-F8
+        0xffc6 => 67,
+        0xffc7 => 68,
+        0xffc8 => 87,
+        0xffc9 => 88, // F9-F12
+        // Modifiers.
+        0xffe1 => 42,  // Shift_L
+        0xffe2 => 54,  // Shift_R
+        0xffe3 => 29,  // Control_L
+        0xffe4 => 97,  // Control_R
+        0xffe5 => 58,  // Caps_Lock
+        0xffe9 => 56,  // Alt_L
+        0xffea => 100, // Alt_R
+        0xffeb => 125, // Super_L
+        0xffec => 126, // Super_R
+        _ => return None,
+    })
+}
+
+/// Windows builds have no POSIX pipe for the event provider (and the krun
+/// dll ships without the input feature), so the session stays view-only.
+#[cfg(not(unix))]
+pub fn install(
+    _add_input_device: unsafe extern "C" fn(u32, *const c_void, usize, *const c_void, usize) -> i32,
+    _ctx: u32,
+) -> Result<VncInput> {
+    Err(Error::agent(
+        "configure input",
+        "virtio-input requires a unix host",
+    ))
+}

--- a/src/agent/krun.rs
+++ b/src/agent/krun.rs
@@ -59,6 +59,13 @@ pub struct KrunFunctions {
     >,
     pub get_egress_handle: Option<unsafe extern "C" fn(u32) -> *mut libc::c_void>,
     pub set_gpu_options2: Option<unsafe extern "C" fn(u32, u32, u64) -> i32>,
+    /// Add a virtio-gpu scanout (display) of the given width/height.
+    ///
+    /// Without at least one display the device reports `num_scanouts = 0`, the
+    /// guest virtio-gpu driver creates no connector, and `/dev/dri/card0` is a
+    /// render node only — so DRM compositors (Hyprland, GNOME, KDE) refuse to
+    /// start with "not a KMS device". `None` on libkrun builds predating the API.
+    pub add_display: Option<unsafe extern "C" fn(u32, u32, u32) -> i32>,
     /// Retrieve guest RAM regions (`gpa_start, host_va, len` triples) for
     /// zero-copy CUDA transfers. `None` on libkrun builds that predate the API.
     pub get_guest_ram: Option<unsafe extern "C" fn(u32, *mut u64, u32, *mut u64) -> i32>,
@@ -151,6 +158,7 @@ impl KrunFunctions {
         let add_net_unixstream = load_optional_sym!("krun_add_net_unixstream");
         let get_egress_handle = load_optional_sym!("krun_get_egress_handle");
         let set_gpu_options2 = load_optional_sym!("krun_set_gpu_options2");
+        let add_display = load_optional_sym!("krun_add_display");
         let get_guest_ram = load_optional_sym!("krun_get_guest_ram");
         let set_control_socket = load_optional_sym!("krun_set_control_socket");
         let set_snapshot = load_optional_sym!("krun_set_snapshot");
@@ -177,6 +185,7 @@ impl KrunFunctions {
             add_net_unixstream,
             get_egress_handle,
             set_gpu_options2,
+            add_display,
             get_guest_ram,
             set_control_socket,
             set_snapshot,

--- a/src/agent/krun.rs
+++ b/src/agent/krun.rs
@@ -74,6 +74,11 @@ pub struct KrunFunctions {
     /// completes and a compositor blocks on it forever. `None` on libkrun
     /// builds predating the API.
     pub set_display_backend: Option<unsafe extern "C" fn(u32, *const libc::c_void, usize) -> i32>,
+    /// Registers a virtio-input device from a config vtable and an event
+    /// provider vtable; present only in libkrun builds with the input feature.
+    pub add_input_device: Option<
+        unsafe extern "C" fn(u32, *const libc::c_void, usize, *const libc::c_void, usize) -> i32,
+    >,
     /// Retrieve guest RAM regions (`gpa_start, host_va, len` triples) for
     /// zero-copy CUDA transfers. `None` on libkrun builds that predate the API.
     pub get_guest_ram: Option<unsafe extern "C" fn(u32, *mut u64, u32, *mut u64) -> i32>,
@@ -168,6 +173,7 @@ impl KrunFunctions {
         let set_gpu_options2 = load_optional_sym!("krun_set_gpu_options2");
         let add_display = load_optional_sym!("krun_add_display");
         let set_display_backend = load_optional_sym!("krun_set_display_backend");
+        let add_input_device = load_optional_sym!("krun_add_input_device");
         let get_guest_ram = load_optional_sym!("krun_get_guest_ram");
         let set_control_socket = load_optional_sym!("krun_set_control_socket");
         let set_snapshot = load_optional_sym!("krun_set_snapshot");
@@ -196,6 +202,7 @@ impl KrunFunctions {
             set_gpu_options2,
             add_display,
             set_display_backend,
+            add_input_device,
             get_guest_ram,
             set_control_socket,
             set_snapshot,

--- a/src/agent/krun.rs
+++ b/src/agent/krun.rs
@@ -66,6 +66,14 @@ pub struct KrunFunctions {
     /// render node only — so DRM compositors (Hyprland, GNOME, KDE) refuse to
     /// start with "not a KMS device". `None` on libkrun builds predating the API.
     pub add_display: Option<unsafe extern "C" fn(u32, u32, u32) -> i32>,
+    /// Register a host display backend that consumes scanout frames.
+    ///
+    /// `krun_add_display` only *describes* a display. Without a backend
+    /// libkrun installs a no-op whose `configure_scanout`/`alloc_frame`/
+    /// `present_frame` all fail, so the guest's first page flip never
+    /// completes and a compositor blocks on it forever. `None` on libkrun
+    /// builds predating the API.
+    pub set_display_backend: Option<unsafe extern "C" fn(u32, *const libc::c_void, usize) -> i32>,
     /// Retrieve guest RAM regions (`gpa_start, host_va, len` triples) for
     /// zero-copy CUDA transfers. `None` on libkrun builds that predate the API.
     pub get_guest_ram: Option<unsafe extern "C" fn(u32, *mut u64, u32, *mut u64) -> i32>,
@@ -159,6 +167,7 @@ impl KrunFunctions {
         let get_egress_handle = load_optional_sym!("krun_get_egress_handle");
         let set_gpu_options2 = load_optional_sym!("krun_set_gpu_options2");
         let add_display = load_optional_sym!("krun_add_display");
+        let set_display_backend = load_optional_sym!("krun_set_display_backend");
         let get_guest_ram = load_optional_sym!("krun_get_guest_ram");
         let set_control_socket = load_optional_sym!("krun_set_control_socket");
         let set_snapshot = load_optional_sym!("krun_set_snapshot");
@@ -186,6 +195,7 @@ impl KrunFunctions {
             get_egress_handle,
             set_gpu_options2,
             add_display,
+            set_display_backend,
             get_guest_ram,
             set_control_socket,
             set_snapshot,

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -817,6 +817,43 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
                 ));
             }
             tracing::info!("GPU enabled (Venus/Vulkan via virtio-gpu)");
+
+            // Optional virtio-gpu scanout. Venus gives the guest GPU
+            // *rendering*; a scanout gives it a *display*. With no display the
+            // device reports num_scanouts = 0, the guest creates no connector,
+            // and card0 is a render node only — which is why DRM compositors
+            // (Hyprland, GNOME, KDE) refuse to start with "not a KMS device".
+            //
+            // Opt-in: a connector changes guest topology, and existing GPU
+            // workloads (CUDA, headless Vulkan) neither need nor want one.
+            if let Some((w, h)) =
+                super::parse_display_size(std::env::var("SMOLVM_DISPLAY").ok().as_deref())
+            {
+                let add_display = match krun.add_display {
+                    Some(f) => f,
+                    None => {
+                        krun_free_ctx(ctx);
+                        return Err(Error::agent(
+                            "configure display",
+                            "SMOLVM_DISPLAY set but this libkrun has no krun_add_display",
+                        ));
+                    }
+                };
+                let ret = add_display(ctx, w, h);
+                if ret < 0 {
+                    krun_free_ctx(ctx);
+                    return Err(Error::agent(
+                        "configure display",
+                        format!("krun_add_display({w}x{h}) failed (ret={ret})"),
+                    ));
+                }
+                tracing::info!(
+                    width = w,
+                    height = h,
+                    display_id = ret,
+                    "virtio-gpu scanout added (guest gets a KMS connector)"
+                );
+            }
         }
 
         // Helper: evaluate a fallible expression, freeing ctx if it fails.

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -886,7 +886,28 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
                     .as_deref()
                     .and_then(super::vnc::parse_bind_addr)
                 {
-                    match super::vnc::serve(&bind, framebuffer) {
+                    // Input is best-effort: a libkrun without the input
+                    // feature (or an install failure) degrades the session to
+                    // view-only rather than blocking the display.
+                    let input = match krun.add_input_device {
+                        Some(add_input) => match super::input::install(add_input, ctx) {
+                            Ok(i) => {
+                                tracing::info!("vnc input devices attached (keyboard + pointer)");
+                                Some(i)
+                            }
+                            Err(e) => {
+                                tracing::warn!(error = %e, "vnc input unavailable; view-only");
+                                None
+                            }
+                        },
+                        None => {
+                            tracing::info!(
+                                "libkrun has no krun_add_input_device; vnc is view-only"
+                            );
+                            None
+                        }
+                    };
+                    match super::vnc::serve(&bind, framebuffer, input) {
                         Ok(addr) => tracing::info!(%addr, "vnc server listening"),
                         Err(e) => {
                             // A failed viewer must not take down the VM: the

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -853,6 +853,48 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
                     display_id = ret,
                     "virtio-gpu scanout added (guest gets a KMS connector)"
                 );
+
+                // A described display is not a usable one. Without a backend
+                // to consume frames libkrun installs a no-op that fails every
+                // scanout call, so the guest's first page flip never completes
+                // and the compositor blocks on it forever. Register the host
+                // framebuffer that actually takes the frames.
+                let set_backend = match krun.set_display_backend {
+                    Some(f) => f,
+                    None => {
+                        krun_free_ctx(ctx);
+                        return Err(Error::agent(
+                            "configure display",
+                            "SMOLVM_DISPLAY set but this libkrun has no \
+                             krun_set_display_backend; without it the guest \
+                             would hang on its first page flip",
+                        ));
+                    }
+                };
+                let framebuffer = match super::display::install(set_backend, ctx) {
+                    Ok(fb) => fb,
+                    Err(e) => {
+                        krun_free_ctx(ctx);
+                        return Err(e);
+                    }
+                };
+
+                // Serving RFB from the host means the guest needs no capture
+                // tool and no compositor-specific screencopy protocol.
+                if let Some(bind) = std::env::var("SMOLVM_VNC")
+                    .ok()
+                    .as_deref()
+                    .and_then(super::vnc::parse_bind_addr)
+                {
+                    match super::vnc::serve(&bind, framebuffer) {
+                        Ok(addr) => tracing::info!(%addr, "vnc server listening"),
+                        Err(e) => {
+                            // A failed viewer must not take down the VM: the
+                            // display itself is already working without it.
+                            tracing::warn!(bind = %bind, error = %e, "vnc server failed to start");
+                        }
+                    }
+                }
             }
         }
 

--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -206,6 +206,39 @@ pub fn launch_agent_vm_dynamic(
                     ));
                 }
                 tracing::info!("GPU enabled (Venus/Vulkan via virtio-gpu)");
+
+                // Optional virtio-gpu scanout. Venus gives the guest GPU
+                // *rendering*; a scanout gives it a *display*. Without one the
+                // device reports num_scanouts = 0, so the guest sees no
+                // connector and card0 is render-only — which is why DRM
+                // compositors fail with "not a KMS device". Opt-in for now:
+                // adding a connector changes guest topology, and existing GPU
+                // workloads (CUDA, headless Vulkan) neither need nor want one.
+                if let Some((w, h)) =
+                    super::parse_display_size(std::env::var("SMOLVM_DISPLAY").ok().as_deref())
+                {
+                    match krun.add_display {
+                        Some(add_display) => {
+                            let ret = unsafe { add_display(ctx, w, h) };
+                            if ret < 0 {
+                                free_ctx_on_err!(format!(
+                                    "krun_add_display({w}x{h}) failed (ret={ret})"
+                                ));
+                            }
+                            tracing::info!(
+                                width = w,
+                                height = h,
+                                display_id = ret,
+                                "virtio-gpu scanout added (guest gets a KMS connector)"
+                            );
+                        }
+                        None => {
+                            free_ctx_on_err!(
+                                "SMOLVM_DISPLAY set but this libkrun has no krun_add_display"
+                            );
+                        }
+                    }
+                }
             }
             None => {
                 free_ctx_on_err!(

--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -231,6 +231,46 @@ pub fn launch_agent_vm_dynamic(
                                 display_id = ret,
                                 "virtio-gpu scanout added (guest gets a KMS connector)"
                             );
+
+                            // A described display is not a usable one. With no
+                            // backend to consume frames libkrun installs a
+                            // no-op that fails every scanout call, so the
+                            // guest's first page flip never completes and a
+                            // compositor blocks on it forever.
+                            let Some(set_backend) = krun.set_display_backend else {
+                                free_ctx_on_err!(
+                                    "SMOLVM_DISPLAY set but this libkrun has no \
+                                     krun_set_display_backend; without it the guest \
+                                     would hang on its first page flip"
+                                );
+                            };
+                            let framebuffer = match crate::agent::display::install(set_backend, ctx)
+                            {
+                                Ok(fb) => fb,
+                                Err(e) => free_ctx_on_err!(e.to_string()),
+                            };
+
+                            // Serving RFB from the host means the guest needs
+                            // no capture tool and no compositor-specific
+                            // screencopy protocol.
+                            if let Some(bind) = std::env::var("SMOLVM_VNC")
+                                .ok()
+                                .as_deref()
+                                .and_then(crate::agent::vnc::parse_bind_addr)
+                            {
+                                match crate::agent::vnc::serve(&bind, framebuffer) {
+                                    Ok(addr) => {
+                                        tracing::info!(%addr, "vnc server listening")
+                                    }
+                                    // A failed viewer must not take down the
+                                    // VM; the display works without it.
+                                    Err(e) => tracing::warn!(
+                                        bind = %bind,
+                                        error = %e,
+                                        "vnc server failed to start"
+                                    ),
+                                }
+                            }
                         }
                         None => {
                             free_ctx_on_err!(

--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -258,7 +258,37 @@ pub fn launch_agent_vm_dynamic(
                                 .as_deref()
                                 .and_then(crate::agent::vnc::parse_bind_addr)
                             {
-                                match crate::agent::vnc::serve(&bind, framebuffer) {
+                                // Input is best-effort: a libkrun without the
+                                // input feature degrades to view-only rather
+                                // than blocking the display.
+                                let input = match krun.add_input_device {
+                                    Some(add_input) => {
+                                        match crate::agent::input::install(add_input, ctx) {
+                                            Ok(i) => {
+                                                tracing::info!(
+                                                    "vnc input devices attached \
+                                                     (keyboard + pointer)"
+                                                );
+                                                Some(i)
+                                            }
+                                            Err(e) => {
+                                                tracing::warn!(
+                                                    error = %e,
+                                                    "vnc input unavailable; view-only"
+                                                );
+                                                None
+                                            }
+                                        }
+                                    }
+                                    None => {
+                                        tracing::info!(
+                                            "libkrun has no krun_add_input_device; \
+                                             vnc is view-only"
+                                        );
+                                        None
+                                    }
+                                };
+                                match crate::agent::vnc::serve(&bind, framebuffer, input) {
                                     Ok(addr) => {
                                         tracing::info!(%addr, "vnc server listening")
                                     }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -8,6 +8,7 @@ mod client;
 pub mod display;
 pub mod fork;
 mod fsnotify_watch;
+pub mod input;
 mod krun;
 mod launcher;
 pub mod launcher_dynamic;

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod boot_config;
 mod client;
+pub mod display;
 pub mod fork;
 mod fsnotify_watch;
 mod krun;
@@ -14,6 +15,7 @@ mod manager;
 pub mod pod_net;
 pub mod state_probe;
 pub mod terminal;
+pub mod vnc;
 mod vsock_service;
 
 pub use crate::data::network::PortMapping;

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -41,6 +41,30 @@ pub use manager::{
 /// Agent VM name.
 pub const AGENT_VM_NAME: &str = "smolvm-agent";
 
+/// Parse a `WIDTHxHEIGHT` display size (e.g. `"1920x1080"`).
+///
+/// Returns `None` for absent/blank input so "no display" stays the default —
+/// a scanout adds a KMS connector the guest can see, which existing GPU
+/// workloads (CUDA, headless Vulkan) do not need.
+///
+/// Rejects zero and absurd dimensions rather than passing them to libkrun: the
+/// virtio-gpu EDID generator will happily build a nonsense mode, and the guest
+/// then fails far away from the cause.
+pub fn parse_display_size(raw: Option<&str>) -> Option<(u32, u32)> {
+    const MAX_DIM: u32 = 16384;
+    let raw = raw?.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    let (w, h) = raw.split_once(['x', 'X'])?;
+    let w: u32 = w.trim().parse().ok()?;
+    let h: u32 = h.trim().parse().ok()?;
+    if w == 0 || h == 0 || w > MAX_DIM || h > MAX_DIM {
+        return None;
+    }
+    Some((w, h))
+}
+
 /// Compute the `virgl_flags` bitmask for `krun_set_gpu_options2`.
 ///
 /// Shared by both the static (`launcher.rs`) and dynamic (`launcher_dynamic.rs`)
@@ -122,4 +146,42 @@ fn format_mac(mac: [u8; 6]) -> String {
         "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
         mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
     )
+}
+
+#[cfg(test)]
+mod display_size_tests {
+    use super::parse_display_size;
+
+    #[test]
+    fn parses_wxh() {
+        assert_eq!(parse_display_size(Some("1920x1080")), Some((1920, 1080)));
+        assert_eq!(parse_display_size(Some("1280X800")), Some((1280, 800)));
+        assert_eq!(parse_display_size(Some("  1024x768 ")), Some((1024, 768)));
+    }
+
+    // Absent/blank must mean "no display", not a default one: adding a scanout
+    // changes guest topology for every existing --gpu workload.
+    #[test]
+    fn absent_or_blank_means_no_display() {
+        assert_eq!(parse_display_size(None), None);
+        assert_eq!(parse_display_size(Some("")), None);
+        assert_eq!(parse_display_size(Some("   ")), None);
+    }
+
+    #[test]
+    fn rejects_malformed() {
+        for bad in ["1920", "1920x", "x1080", "axb", "1920*1080", "1920x1080x60"] {
+            assert_eq!(parse_display_size(Some(bad)), None, "should reject {bad}");
+        }
+    }
+
+    // Zero would produce a degenerate EDID mode; huge values blow up the
+    // framebuffer allocation. Fail here, where the error names the cause.
+    #[test]
+    fn rejects_zero_and_absurd() {
+        assert_eq!(parse_display_size(Some("0x1080")), None);
+        assert_eq!(parse_display_size(Some("1920x0")), None);
+        assert_eq!(parse_display_size(Some("99999x1080")), None);
+        assert_eq!(parse_display_size(Some("1920x99999")), None);
+    }
 }

--- a/src/agent/vnc.rs
+++ b/src/agent/vnc.rs
@@ -1,0 +1,463 @@
+//! A minimal RFB (VNC) server over the host-side framebuffer.
+//!
+//! Serving from the host rather than the guest is the point: the guest needs
+//! no capture tool, no seat-visible VNC port and no compositor-specific
+//! screencopy protocol. Anything that can drive a KMS display — Hyprland,
+//! sway, GNOME, a plain framebuffer — is visible through this without knowing
+//! it is being watched.
+//!
+//! Scope is deliberately small: RFB 3.8, no authentication, Raw encoding,
+//! output only. Input (keyboard/pointer) needs a virtio-input device that
+//! smolvm does not yet attach, so client input events are read and discarded
+//! rather than silently appearing to work.
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::Arc;
+use std::time::Duration;
+
+use super::display::{self, DisplayFramebuffer, Frame};
+
+const RFB_VERSION: &[u8; 12] = b"RFB 003.008\n";
+const SECURITY_NONE: u8 = 1;
+
+/// How long a client's incremental update request waits for a new frame
+/// before we answer with the current one. Without a bound, a client would
+/// hang for as long as the desktop is idle and look disconnected.
+const UPDATE_WAIT: Duration = Duration::from_secs(2);
+
+/// Pseudo-encoding letting us tell the client the desktop changed size, which
+/// happens when the compositor sets a mode different from the initial one.
+const ENCODING_DESKTOP_SIZE: i32 = -223;
+const ENCODING_RAW: i32 = 0;
+
+/// The pixel layout a client asked for. Defaults to what we natively hold, so
+/// a client that never sends SetPixelFormat gets a zero-copy path.
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct PixelFormat {
+    bits_per_pixel: u8,
+    depth: u8,
+    big_endian: bool,
+    true_colour: bool,
+    red_max: u16,
+    green_max: u16,
+    blue_max: u16,
+    red_shift: u8,
+    green_shift: u8,
+    blue_shift: u8,
+}
+
+impl PixelFormat {
+    /// Little-endian 32-bit true colour with R=16/G=8/B=0, i.e. bytes B,G,R,X
+    /// in memory — the layout `display::to_bgrx` produces.
+    const fn bgrx() -> Self {
+        Self {
+            bits_per_pixel: 32,
+            depth: 24,
+            big_endian: false,
+            true_colour: true,
+            red_max: 255,
+            green_max: 255,
+            blue_max: 255,
+            red_shift: 16,
+            green_shift: 8,
+            blue_shift: 0,
+        }
+    }
+
+    fn write(&self, out: &mut Vec<u8>) {
+        out.push(self.bits_per_pixel);
+        out.push(self.depth);
+        out.push(self.big_endian as u8);
+        out.push(self.true_colour as u8);
+        out.extend_from_slice(&self.red_max.to_be_bytes());
+        out.extend_from_slice(&self.green_max.to_be_bytes());
+        out.extend_from_slice(&self.blue_max.to_be_bytes());
+        out.push(self.red_shift);
+        out.push(self.green_shift);
+        out.push(self.blue_shift);
+        out.extend_from_slice(&[0u8; 3]); // padding
+    }
+
+    fn parse(raw: &[u8; 16]) -> Self {
+        Self {
+            bits_per_pixel: raw[0],
+            depth: raw[1],
+            big_endian: raw[2] != 0,
+            true_colour: raw[3] != 0,
+            red_max: u16::from_be_bytes([raw[4], raw[5]]),
+            green_max: u16::from_be_bytes([raw[6], raw[7]]),
+            blue_max: u16::from_be_bytes([raw[8], raw[9]]),
+            red_shift: raw[10],
+            green_shift: raw[11],
+            blue_shift: raw[12],
+        }
+    }
+
+    /// Can we serve this layout by rewriting our BGRX bytes?
+    fn is_supported(&self) -> bool {
+        self.bits_per_pixel == 32 && self.true_colour
+    }
+}
+
+/// Rewrite BGRX pixels into the client's requested 32-bit layout.
+///
+/// Borrows rather than copies when the client wants exactly what we already
+/// hold — the common case, and a whole framebuffer per update otherwise.
+fn encode_pixels<'a>(bgrx: &'a [u8], fmt: &PixelFormat) -> std::borrow::Cow<'a, [u8]> {
+    if *fmt == PixelFormat::bgrx() {
+        return std::borrow::Cow::Borrowed(bgrx);
+    }
+    let mut out = vec![0u8; bgrx.len()];
+    let (src_px, _) = bgrx.as_chunks::<4>();
+    let (dst_px, _) = out.as_chunks_mut::<4>();
+    for (src, dst) in src_px.iter().zip(dst_px.iter_mut()) {
+        // Our source is B,G,R,X in memory.
+        let (b, g, r) = (src[0] as u32, src[1] as u32, src[2] as u32);
+        let px = ((r * fmt.red_max as u32) / 255) << fmt.red_shift
+            | ((g * fmt.green_max as u32) / 255) << fmt.green_shift
+            | ((b * fmt.blue_max as u32) / 255) << fmt.blue_shift;
+        let bytes = if fmt.big_endian {
+            px.to_be_bytes()
+        } else {
+            px.to_le_bytes()
+        };
+        dst.copy_from_slice(&bytes);
+    }
+    std::borrow::Cow::Owned(out)
+}
+
+/// Start the RFB server. Returns the bound address so callers can log it.
+pub fn serve(addr: &str, fb: Arc<DisplayFramebuffer>) -> std::io::Result<std::net::SocketAddr> {
+    let listener = TcpListener::bind(addr)?;
+    let local = listener.local_addr()?;
+
+    std::thread::Builder::new()
+        .name("smolvm-vnc".into())
+        .spawn(move || {
+            for stream in listener.incoming() {
+                match stream {
+                    Ok(s) => {
+                        let fb = Arc::clone(&fb);
+                        let peer = s.peer_addr().ok();
+                        if let Err(e) = std::thread::Builder::new()
+                            .name("smolvm-vnc-client".into())
+                            .spawn(move || {
+                                if let Err(e) = handle_client(s, fb) {
+                                    tracing::debug!(?peer, error = %e, "vnc client ended");
+                                }
+                            })
+                        {
+                            tracing::warn!(error = %e, "could not spawn vnc client thread");
+                        }
+                    }
+                    // A per-connection failure must not retire the listener:
+                    // treating every accept error as fatal means one transient
+                    // ECONNABORTED/EMFILE silently ends VNC for the life of
+                    // the VM, with the port simply gone and nothing logged
+                    // after the fact.
+                    Err(e) if is_transient_accept_error(&e) => {
+                        tracing::debug!(error = %e, "vnc accept failed; continuing");
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "vnc listener stopped");
+                        break;
+                    }
+                }
+            }
+        })?;
+
+    Ok(local)
+}
+
+/// Accept errors that say something about one connection or a momentary
+/// resource shortage, rather than about the listening socket itself.
+fn is_transient_accept_error(e: &std::io::Error) -> bool {
+    use std::io::ErrorKind::*;
+    matches!(
+        e.kind(),
+        ConnectionAborted | ConnectionReset | Interrupted | WouldBlock | TimedOut
+    ) || e.raw_os_error() == Some(libc::EMFILE)
+        || e.raw_os_error() == Some(libc::ENFILE)
+        || e.raw_os_error() == Some(libc::ENOBUFS)
+        || e.raw_os_error() == Some(libc::ENOMEM)
+}
+
+fn handle_client(mut s: TcpStream, fb: Arc<DisplayFramebuffer>) -> std::io::Result<()> {
+    s.set_nodelay(true).ok();
+
+    // --- handshake -------------------------------------------------------
+    s.write_all(RFB_VERSION)?;
+    let mut version = [0u8; 12];
+    s.read_exact(&mut version)?;
+
+    // Offer only "None"; this port is expected to be bound to loopback or a
+    // trusted interface by the caller.
+    s.write_all(&[1, SECURITY_NONE])?;
+    let mut chosen = [0u8; 1];
+    s.read_exact(&mut chosen)?;
+    if chosen[0] != SECURITY_NONE {
+        // SecurityResult: failure, plus a reason string (3.8 requires one).
+        let reason = b"only the None security type is offered";
+        let mut msg = 1u32.to_be_bytes().to_vec();
+        msg.extend_from_slice(&(reason.len() as u32).to_be_bytes());
+        msg.extend_from_slice(reason);
+        s.write_all(&msg)?;
+        return Ok(());
+    }
+    s.write_all(&0u32.to_be_bytes())?; // SecurityResult: OK
+
+    let mut shared = [0u8; 1];
+    s.read_exact(&mut shared)?; // ClientInit
+
+    // Geometry has to be committed at ServerInit, before the guest may have
+    // presented anything. Fall back to the configured display size so a client
+    // that connects during boot still gets a sane desktop rather than 0x0.
+    let first = fb.latest();
+    let (mut width, mut height) = first
+        .as_ref()
+        .map(|f| (f.width, f.height))
+        .unwrap_or((1280, 800));
+
+    let mut fmt = PixelFormat::bgrx();
+    let name = b"smolvm";
+    let mut init = Vec::with_capacity(32);
+    init.extend_from_slice(&(width as u16).to_be_bytes());
+    init.extend_from_slice(&(height as u16).to_be_bytes());
+    fmt.write(&mut init);
+    init.extend_from_slice(&(name.len() as u32).to_be_bytes());
+    init.extend_from_slice(name);
+    s.write_all(&init)?;
+
+    tracing::info!(width, height, "vnc client connected");
+
+    // --- message loop ----------------------------------------------------
+    let mut last_generation = 0u64;
+    let mut client_supports_resize = false;
+
+    loop {
+        let mut kind = [0u8; 1];
+        if s.read_exact(&mut kind).is_err() {
+            return Ok(()); // client hung up
+        }
+        match kind[0] {
+            0 => {
+                // SetPixelFormat: 3 bytes padding + 16 byte PixelFormat
+                let mut rest = [0u8; 19];
+                s.read_exact(&mut rest)?;
+                let mut pf = [0u8; 16];
+                pf.copy_from_slice(&rest[3..19]);
+                let requested = PixelFormat::parse(&pf);
+                if requested.is_supported() {
+                    fmt = requested;
+                } else {
+                    // Keep our format rather than emit pixels the client will
+                    // misread; say so, because wrong colours are otherwise a
+                    // baffling symptom.
+                    tracing::warn!(
+                        bpp = requested.bits_per_pixel,
+                        true_colour = requested.true_colour,
+                        "vnc client asked for an unsupported pixel format; \
+                         continuing with 32-bit true colour"
+                    );
+                }
+            }
+            2 => {
+                // SetEncodings: 1 byte padding + u16 count + count * i32
+                let mut head = [0u8; 3];
+                s.read_exact(&mut head)?;
+                let count = u16::from_be_bytes([head[1], head[2]]) as usize;
+                let mut encodings = vec![0u8; count * 4];
+                s.read_exact(&mut encodings)?;
+                let (encodings, _) = encodings.as_chunks::<4>();
+                client_supports_resize = encodings
+                    .iter()
+                    .any(|c| i32::from_be_bytes(*c) == ENCODING_DESKTOP_SIZE);
+            }
+            3 => {
+                // FramebufferUpdateRequest: incremental + x,y,w,h
+                let mut req = [0u8; 9];
+                s.read_exact(&mut req)?;
+                let incremental = req[0] != 0;
+
+                let frame = if incremental {
+                    fb.wait_for_frame(last_generation, UPDATE_WAIT)
+                        .or_else(|| fb.latest())
+                } else {
+                    fb.latest()
+                };
+
+                let Some(frame) = frame else {
+                    // Nothing presented yet. Answer with an empty update so the
+                    // client stays in its request loop instead of stalling.
+                    s.write_all(&[0u8, 0, 0, 0])?;
+                    continue;
+                };
+
+                if incremental && frame.generation == last_generation {
+                    s.write_all(&[0u8, 0, 0, 0])?;
+                    continue;
+                }
+                last_generation = frame.generation;
+
+                if (frame.width, frame.height) != (width, height) {
+                    width = frame.width;
+                    height = frame.height;
+                    if client_supports_resize {
+                        send_resize(&mut s, width, height)?;
+                    } else {
+                        tracing::warn!(
+                            width,
+                            height,
+                            "guest changed mode but the vnc client cannot resize; \
+                             reconnect to pick up the new size"
+                        );
+                    }
+                }
+
+                send_frame(&mut s, &frame, &fmt)?;
+            }
+            4 => {
+                // KeyEvent — read and drop; no input device is attached.
+                let mut buf = [0u8; 7];
+                s.read_exact(&mut buf)?;
+            }
+            5 => {
+                // PointerEvent — read and drop.
+                let mut buf = [0u8; 5];
+                s.read_exact(&mut buf)?;
+            }
+            6 => {
+                // ClientCutText: 3 padding + u32 length + text
+                let mut head = [0u8; 7];
+                s.read_exact(&mut head)?;
+                let len = u32::from_be_bytes([head[3], head[4], head[5], head[6]]) as usize;
+                // Bound it: a hostile length would otherwise allocate freely.
+                if len > 1 << 20 {
+                    return Ok(());
+                }
+                let mut text = vec![0u8; len];
+                s.read_exact(&mut text)?;
+            }
+            other => {
+                tracing::debug!(message_type = other, "unknown vnc client message; closing");
+                return Ok(());
+            }
+        }
+    }
+}
+
+fn send_resize(s: &mut TcpStream, width: u32, height: u32) -> std::io::Result<()> {
+    let mut msg = vec![0u8, 0];
+    msg.extend_from_slice(&1u16.to_be_bytes()); // one rectangle
+    msg.extend_from_slice(&0u16.to_be_bytes()); // x
+    msg.extend_from_slice(&0u16.to_be_bytes()); // y
+    msg.extend_from_slice(&(width as u16).to_be_bytes());
+    msg.extend_from_slice(&(height as u16).to_be_bytes());
+    msg.extend_from_slice(&ENCODING_DESKTOP_SIZE.to_be_bytes());
+    s.write_all(&msg)
+}
+
+fn send_frame(s: &mut TcpStream, frame: &Frame, fmt: &PixelFormat) -> std::io::Result<()> {
+    let bgrx = display::to_bgrx(frame);
+    let pixels = encode_pixels(&bgrx, fmt);
+
+    let mut header = vec![0u8, 0];
+    header.extend_from_slice(&1u16.to_be_bytes()); // one rectangle
+    header.extend_from_slice(&0u16.to_be_bytes()); // x
+    header.extend_from_slice(&0u16.to_be_bytes()); // y
+    header.extend_from_slice(&(frame.width as u16).to_be_bytes());
+    header.extend_from_slice(&(frame.height as u16).to_be_bytes());
+    header.extend_from_slice(&ENCODING_RAW.to_be_bytes());
+    s.write_all(&header)?;
+    s.write_all(&pixels)
+}
+
+/// Resolve `SMOLVM_VNC` into a bind address. Accepts a bare port ("5900"), a
+/// host:port pair, or a bare host (defaulting to 5900).
+pub fn parse_bind_addr(raw: &str) -> Option<String> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    if let Ok(port) = raw.parse::<u16>() {
+        // Bare port stays on loopback: a desktop framebuffer is not something
+        // to expose on every interface because a number was set.
+        return Some(format!("127.0.0.1:{port}"));
+    }
+    if raw.contains(':') {
+        return Some(raw.to_string());
+    }
+    Some(format!("{raw}:5900"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_port_binds_loopback_only() {
+        assert_eq!(parse_bind_addr("5900").as_deref(), Some("127.0.0.1:5900"));
+    }
+
+    #[test]
+    fn host_port_is_passed_through() {
+        assert_eq!(
+            parse_bind_addr("0.0.0.0:5901").as_deref(),
+            Some("0.0.0.0:5901")
+        );
+    }
+
+    #[test]
+    fn bare_host_gets_the_default_port() {
+        assert_eq!(parse_bind_addr("0.0.0.0").as_deref(), Some("0.0.0.0:5900"));
+    }
+
+    #[test]
+    fn blank_means_disabled() {
+        assert_eq!(parse_bind_addr(""), None);
+        assert_eq!(parse_bind_addr("   "), None);
+    }
+
+    #[test]
+    fn pixel_format_round_trips() {
+        let fmt = PixelFormat::bgrx();
+        let mut out = Vec::new();
+        fmt.write(&mut out);
+        assert_eq!(out.len(), 16);
+        let mut raw = [0u8; 16];
+        raw.copy_from_slice(&out);
+        assert!(PixelFormat::parse(&raw) == fmt);
+    }
+
+    #[test]
+    fn native_format_encodes_unchanged() {
+        let src = vec![0x11, 0x22, 0x33, 0xff];
+        let out = encode_pixels(&src, &PixelFormat::bgrx());
+        assert_eq!(&*out, &src[..]);
+    }
+
+    #[test]
+    fn rgbx_client_gets_channels_reordered() {
+        // Client wants R at shift 0, B at shift 16 (the mirror of ours).
+        let fmt = PixelFormat {
+            red_shift: 0,
+            blue_shift: 16,
+            ..PixelFormat::bgrx()
+        };
+        // Source memory B,G,R,X = 0x11,0x22,0x33
+        let out = encode_pixels(&[0x11, 0x22, 0x33, 0xff], &fmt);
+        // px = R<<0 | G<<8 | B<<16 = 0x112233 -> little-endian bytes
+        assert_eq!(&*out, &[0x33, 0x22, 0x11, 0x00]);
+    }
+
+    #[test]
+    fn unsupported_format_is_rejected_so_we_keep_our_own() {
+        let fmt = PixelFormat {
+            bits_per_pixel: 8,
+            true_colour: false,
+            ..PixelFormat::bgrx()
+        };
+        assert!(!fmt.is_supported());
+    }
+}

--- a/src/agent/vnc.rs
+++ b/src/agent/vnc.rs
@@ -6,10 +6,10 @@
 //! sway, GNOME, a plain framebuffer — is visible through this without knowing
 //! it is being watched.
 //!
-//! Scope is deliberately small: RFB 3.8, no authentication, Raw encoding,
-//! output only. Input (keyboard/pointer) needs a virtio-input device that
-//! smolvm does not yet attach, so client input events are read and discarded
-//! rather than silently appearing to work.
+//! Scope is deliberately small: RFB 3.8, no authentication, Raw encoding.
+//! When the launcher attaches virtio-input devices, client key and pointer
+//! events are injected into the guest; on a libkrun without the input
+//! feature the session degrades to view-only and events are discarded.
 
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
@@ -128,7 +128,13 @@ fn encode_pixels<'a>(bgrx: &'a [u8], fmt: &PixelFormat) -> std::borrow::Cow<'a, 
 }
 
 /// Start the RFB server. Returns the bound address so callers can log it.
-pub fn serve(addr: &str, fb: Arc<DisplayFramebuffer>) -> std::io::Result<std::net::SocketAddr> {
+/// With `input` present, client key and pointer events are injected into the
+/// guest's virtio-input devices; without it the session is view-only.
+pub fn serve(
+    addr: &str,
+    fb: Arc<DisplayFramebuffer>,
+    input: Option<super::input::VncInput>,
+) -> std::io::Result<std::net::SocketAddr> {
     let listener = TcpListener::bind(addr)?;
     let local = listener.local_addr()?;
 
@@ -139,11 +145,12 @@ pub fn serve(addr: &str, fb: Arc<DisplayFramebuffer>) -> std::io::Result<std::ne
                 match stream {
                     Ok(s) => {
                         let fb = Arc::clone(&fb);
+                        let input = input.clone();
                         let peer = s.peer_addr().ok();
                         if let Err(e) = std::thread::Builder::new()
                             .name("smolvm-vnc-client".into())
                             .spawn(move || {
-                                if let Err(e) = handle_client(s, fb) {
+                                if let Err(e) = handle_client(s, fb, input) {
                                     tracing::debug!(?peer, error = %e, "vnc client ended");
                                 }
                             })
@@ -183,7 +190,11 @@ fn is_transient_accept_error(e: &std::io::Error) -> bool {
         || e.raw_os_error() == Some(libc::ENOMEM)
 }
 
-fn handle_client(mut s: TcpStream, fb: Arc<DisplayFramebuffer>) -> std::io::Result<()> {
+fn handle_client(
+    mut s: TcpStream,
+    fb: Arc<DisplayFramebuffer>,
+    input: Option<super::input::VncInput>,
+) -> std::io::Result<()> {
     s.set_nodelay(true).ok();
 
     // --- handshake -------------------------------------------------------
@@ -234,6 +245,7 @@ fn handle_client(mut s: TcpStream, fb: Arc<DisplayFramebuffer>) -> std::io::Resu
     // --- message loop ----------------------------------------------------
     let mut last_generation = 0u64;
     let mut client_supports_resize = false;
+    let mut last_button_mask = 0u8;
 
     loop {
         let mut kind = [0u8; 1];
@@ -318,14 +330,67 @@ fn handle_client(mut s: TcpStream, fb: Arc<DisplayFramebuffer>) -> std::io::Resu
                 send_frame(&mut s, &frame, &fmt)?;
             }
             4 => {
-                // KeyEvent — read and drop; no input device is attached.
+                // KeyEvent: down-flag, 2 bytes padding, u32 keysym.
                 let mut buf = [0u8; 7];
                 s.read_exact(&mut buf)?;
+                if let Some(ref input) = input {
+                    let down = buf[0] != 0;
+                    let keysym = u32::from_be_bytes([buf[3], buf[4], buf[5], buf[6]]);
+                    match super::input::keysym_to_evdev(keysym) {
+                        Some(code) => {
+                            input
+                                .keyboard
+                                .push(&[(super::input::EV_KEY, code, down as u32)])
+                        }
+                        None => tracing::debug!(keysym, "vnc keysym with no evdev mapping"),
+                    }
+                }
             }
             5 => {
-                // PointerEvent — read and drop.
+                // PointerEvent: button mask, u16 x, u16 y.
                 let mut buf = [0u8; 5];
                 s.read_exact(&mut buf)?;
+                if let Some(ref input) = input {
+                    let mask = buf[0];
+                    let x = u16::from_be_bytes([buf[1], buf[2]]) as u32;
+                    let y = u16::from_be_bytes([buf[3], buf[4]]) as u32;
+
+                    // Absolute axes use a fixed virtual range; scale from the
+                    // framebuffer size the client is looking at so a guest
+                    // mode change never needs new absinfo.
+                    let scale = |v: u32, span: u32| -> u32 {
+                        let span = span.max(2);
+                        (v.min(span - 1) * super::input::ABS_RANGE) / (span - 1)
+                    };
+                    let mut batch: Vec<(u16, u16, u32)> = vec![
+                        (super::input::EV_ABS, 0, scale(x, width)),
+                        (super::input::EV_ABS, 1, scale(y, height)),
+                    ];
+
+                    // RFB buttons: bit 0 = left, 1 = middle, 2 = right;
+                    // bits 3/4 are wheel up/down, sent as press+release per
+                    // notch, so only the rising edge scrolls.
+                    let changed = mask ^ last_button_mask;
+                    for (bit, code) in [
+                        (0u8, super::input::BTN_LEFT),
+                        (1, super::input::BTN_MIDDLE),
+                        (2, super::input::BTN_RIGHT),
+                    ] {
+                        if changed & (1 << bit) != 0 {
+                            let down = mask & (1 << bit) != 0;
+                            batch.push((super::input::EV_KEY, code, down as u32));
+                        }
+                    }
+                    if changed & mask & (1 << 3) != 0 {
+                        batch.push((super::input::EV_REL, super::input::REL_WHEEL, 1));
+                    }
+                    if changed & mask & (1 << 4) != 0 {
+                        batch.push((super::input::EV_REL, super::input::REL_WHEEL, -1i32 as u32));
+                    }
+                    last_button_mask = mask;
+
+                    input.pointer.push(&batch);
+                }
             }
             6 => {
                 // ClientCutText: 3 padding + u32 length + text


### PR DESCRIPTION
SMOLVM_DISPLAY adds a KMS connector, SMOLVM_VNC serves the host-held framebuffer over RFB with client keyboard and pointer events injected through virtio-input devices, and examples/desktop carries the validated Hyprland and Omarchy recipes.