### PR TITLE
Mount S3 volumes natively from the agent instead of requiring rclone in the image

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -76,7 +76,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -876,6 +876,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -962,7 +963,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1359,6 +1360,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "home"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1453,7 +1463,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2035,7 +2045,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2609,7 +2619,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2703,7 +2713,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2713,6 +2723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3215,6 +3226,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "smolvm-s3fs"
+version = "1.10.0"
+dependencies = [
+ "hmac",
+ "libc",
+ "sha2",
+ "tracing",
+ "ureq",
+]
+
+[[package]]
 name = "smolvm-shim"
 version = "0.1.0"
 dependencies = [
@@ -3238,7 +3260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3346,7 +3368,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3812,7 +3834,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.4",
  "static_assertions",
 ]
 
@@ -3830,7 +3852,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3868,6 +3890,22 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
 
 [[package]]
 name = "url"
@@ -4167,6 +4205,15 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
@@ -4217,7 +4264,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3094,6 +3094,7 @@ dependencies = [
  "serde_json",
  "smolvm-oci-layer",
  "smolvm-protocol",
+ "smolvm-s3fs",
  "tar",
  "tempfile",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/smolvm-pack",
     "crates/smolvm-protocol",
     "crates/smolvm-registry",
+    "crates/smolvm-s3fs",
     "crates/smolvm-shim",
     "crates/smolvm-smolfile",
 ]

--- a/crates/smolvm-agent/Cargo.toml
+++ b/crates/smolvm-agent/Cargo.toml
@@ -15,6 +15,7 @@ smolvm-protocol = { path = "../smolvm-protocol", version = "1.6.1" }
 # Shared, pure-Rust OCI layer extraction (decompress + untar + whiteout→overlay
 # translation). The single implementation this guest and the host image cache
 # both call. Dependency-light + no C-linked crate so it links under musl.
+smolvm-s3fs = { path = "../smolvm-s3fs", version = "1.10.0" }
 smolvm-oci-layer = { path = "../smolvm-oci-layer", version = "1.7.2" }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -3939,6 +3939,24 @@ pub fn crun_container_pid(container_id: &str) -> Option<u32> {
         container_id,
         std::path::Path::new(paths::CRUN_ROOT_DIR),
         std::path::Path::new("/proc"),
+        true,
+    )
+}
+
+/// PID of a container that has been created but not yet started.
+///
+/// [`crun_container_pid`] deliberately reports nothing until `crun start`
+/// releases the container, because its callers are asking "can I exec into
+/// this?". Mounting happens in exactly that window: after `create` the
+/// namespaces exist and PID 1 is parked on `exec.fifo`, which is precisely when
+/// a volume must be mounted so the workload's first instruction already sees it.
+#[cfg(target_os = "linux")]
+pub fn crun_created_container_pid(container_id: &str) -> Option<u32> {
+    crun_container_pid_at(
+        container_id,
+        std::path::Path::new(paths::CRUN_ROOT_DIR),
+        std::path::Path::new("/proc"),
+        false,
     )
 }
 
@@ -3947,6 +3965,7 @@ fn crun_container_pid_at(
     container_id: &str,
     state_root: &std::path::Path,
     proc_root: &std::path::Path,
+    require_running: bool,
 ) -> Option<u32> {
     if !valid_crun_container_id(container_id) {
         return None;
@@ -3957,7 +3976,7 @@ fn crun_container_pid_at(
     // crun leaves exec.fifo present until `crun start` releases a created
     // container. The old `crun state` path reported that state as `created`,
     // not `running`; preserve that distinction without entering crun.
-    if state_dir.join("exec.fifo").exists() {
+    if require_running && state_dir.join("exec.fifo").exists() {
         return None;
     }
 

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -3274,7 +3274,7 @@ fn handle_interactive_run(
         tty,
         persistent_overlay_id,
         unprivileged,
-        remote_volume_mount,
+        s3_volumes,
     ) = match request {
         AgentRequest::Run {
             image,
@@ -3623,7 +3623,7 @@ fn handle_run_detached(
         mounts,
         persistent_overlay_id,
         unprivileged,
-        remote_volume_mount,
+        s3_volumes,
     ) = match request {
         AgentRequest::Run {
             image,
@@ -3710,16 +3710,19 @@ fn handle_run_detached(
     // (command, Env, WorkingDir, User) with the request layered on top.
     // `write_oci_bundle` requires a `ResolvedLaunch`, so the image config can't be
     // silently dropped here or on any other launch path.
-    let launch = match ResolvedLaunch::resolve(&image, command, env, workdir, user, s3_volumes) {
-        Ok(l) => l,
-        Err(e) => {
-            send_response(
-                stream,
-                &AgentResponse::error(e.to_string(), error_codes::INVALID_REQUEST),
-            )?;
-            return Ok(());
-        }
-    };
+    // `resolve` only needs to know WHETHER volumes exist (to pick a keep-alive
+    // command); the mount step below needs the values themselves.
+    let launch =
+        match ResolvedLaunch::resolve(&image, command, env, workdir, user, s3_volumes.clone()) {
+            Ok(l) => l,
+            Err(e) => {
+                send_response(
+                    stream,
+                    &AgentResponse::error(e.to_string(), error_codes::INVALID_REQUEST),
+                )?;
+                return Ok(());
+            }
+        };
     info!(image = %image, command = ?launch.command, workdir = ?launch.workdir, user = ?launch.user, "resolved launch from request + image config");
 
     if let Err(e) = storage::setup_mounts(&prepared.rootfs_path, &mounts) {
@@ -3825,8 +3828,8 @@ fn handle_run_detached(
     // that reads its data directory immediately cannot race the mount. It also
     // means the workload command itself is never rewritten: the image's own
     // entrypoint runs exactly as its author wrote it.
-    if !s3_mounts.is_empty() {
-        if let Err(e) = s3mount::mount_all(&container_id, &s3_mounts) {
+    if !s3_volumes.is_empty() {
+        if let Err(e) = s3mount::mount_all(&container_id, &s3_volumes) {
             let _ = crun::CrunCommand::kill(&container_id, "SIGKILL").status();
             let _ = crun::CrunCommand::delete(&container_id, true).output();
             send_response(
@@ -5433,7 +5436,7 @@ fn run_background_in_keepalive(
         user.map(str::to_string),
         // Keep-alive/exec path: it JOINS the workload container that already
         // holds the remote-volume mount, so no mount is established here.
-        None,
+        Vec::new(),
     )?;
 
     let (cid, rootfs) = match resolve_main_container(Some(overlay_id)) {
@@ -5575,7 +5578,7 @@ fn run_in_keepalive_container(
         user.map(str::to_string),
         // Keep-alive/exec path: it JOINS the workload container that already
         // holds the remote-volume mount, so no mount is established here.
-        None,
+        Vec::new(),
     )?;
 
     // Reuse the running keep-alive container, or establish one now so this and

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -2362,10 +2362,7 @@ fn handle_request(
             persistent_overlay_id,
             stdin_data,
             background,
-            // Remote volumes only ride the detached workload launch
-            // (`run_container_detached`, `detached: true`); every synchronous or
-            // background Run carries none, so there is nothing to mount here.
-            s3_volumes: _,
+            s3_volumes,
         } => {
             if background {
                 handle_run_background(
@@ -2377,6 +2374,7 @@ fn handle_request(
                     &mounts,
                     persistent_overlay_id.as_deref(),
                     unprivileged,
+                    &s3_volumes,
                 )
             } else {
                 handle_run(
@@ -2391,6 +2389,7 @@ fn handle_request(
                     stdin_data.as_deref(),
                     client_fd,
                     unprivileged,
+                    &s3_volumes,
                 )
             }
         }
@@ -3274,6 +3273,7 @@ fn handle_interactive_run(
         tty,
         persistent_overlay_id,
         unprivileged,
+        s3_volumes,
     ) = match request {
         AgentRequest::Run {
             image,
@@ -3286,6 +3286,7 @@ fn handle_interactive_run(
             tty,
             persistent_overlay_id,
             unprivileged,
+            s3_volumes,
             ..
         } => (
             image,
@@ -3298,6 +3299,7 @@ fn handle_interactive_run(
             tty,
             persistent_overlay_id,
             unprivileged,
+            s3_volumes,
         ),
         _ => {
             send_response(
@@ -3345,28 +3347,18 @@ fn handle_interactive_run(
     // Resolve the container's launch settings from the image's OCI config (with
     // request overrides). Required to call spawn_interactive_command, so the
     // interactive path can't drop the image's Env/WorkingDir/User either.
-    let launch = match ResolvedLaunch::resolve(
-        &image,
-        command,
-        env,
-        workdir,
-        user,
-        // Interactive sessions never carry remote volumes. A shell or exec
-        // joins the workload container, where the mounts already exist, and a
-        // one-shot run is rejected by the CLI before it reaches the agent
-        // because remote volumes are only accepted for machines that persist.
-        Vec::new(),
-    ) {
-        Ok(l) => l,
-        Err(e) => {
-            maybe_cleanup(&prepared.workload_id);
-            send_response(
-                stream,
-                &AgentResponse::error(e.to_string(), error_codes::INVALID_REQUEST),
-            )?;
-            return Ok(());
-        }
-    };
+    let launch =
+        match ResolvedLaunch::resolve(&image, command, env, workdir, user, s3_volumes.clone()) {
+            Ok(l) => l,
+            Err(e) => {
+                maybe_cleanup(&prepared.workload_id);
+                send_response(
+                    stream,
+                    &AgentResponse::error(e.to_string(), error_codes::INVALID_REQUEST),
+                )?;
+                return Ok(());
+            }
+        };
 
     // Spawn the command with crun
     let (mut child, pty_master) = match spawn_interactive_command(
@@ -3376,6 +3368,7 @@ fn handle_interactive_run(
         tty,
         persistent_overlay_id.as_deref(),
         unprivileged,
+        &s3_volumes,
     ) {
         Ok(result) => result,
         Err(e) => {
@@ -4283,12 +4276,14 @@ static CONSOLE_SOCKET_WORKS: std::sync::atomic::AtomicBool =
 /// Uses the same two-step `crun create` + `crun start` as [`handle_run_detached`]
 /// (`crun run --detach` hangs in the smolvm VM environment).
 #[cfg(target_os = "linux")]
+#[allow(clippy::too_many_arguments)]
 fn ensure_main_container(
     rootfs: &str,
-    overlay_id: &str,
+    overlay_id: Option<&str>,
     mounts: &[(String, String, bool)],
     unprivileged: bool,
     base_launch: &ResolvedLaunch,
+    s3_volumes: &[smolvm_protocol::S3Volume],
 ) -> Result<String, Box<dyn std::error::Error>> {
     use std::path::Path;
 
@@ -4326,6 +4321,19 @@ fn ensure_main_container(
         )
         .into());
     }
+    // Mount remote volumes in the window between create and start: the
+    // container's namespaces exist but its first instruction has not run, so
+    // anything exec'd into it afterwards is guaranteed to see the bucket. This
+    // is the same ordering `handle_run_detached` relies on, and the reason the
+    // container is established in two steps rather than with `crun run`.
+    if !s3_volumes.is_empty() {
+        if let Err(e) = s3mount::mount_all(&container_id, s3_volumes) {
+            let _ = crun::CrunCommand::kill(&container_id, "SIGKILL").status();
+            let _ = crun::CrunCommand::delete(&container_id, true).output();
+            return Err(format!("mount remote volume: {e}").into());
+        }
+    }
+
     let start = crun::CrunCommand::start(&container_id).output()?;
     if !start.status.success() {
         let _ = crun::CrunCommand::delete(&container_id, true).output();
@@ -4336,16 +4344,20 @@ fn ensure_main_container(
         .into());
     }
 
-    let workload_id = format!("persistent-{}", overlay_id);
-    if let Err(e) = std::fs::write(
-        paths::main_container_id_path(&workload_id),
-        container_id.as_bytes(),
-    ) {
-        let _ = crun::CrunCommand::kill(&container_id, "SIGKILL").status();
-        let _ = crun::CrunCommand::delete(&container_id, true).output();
-        return Err(format!("failed to persist main container id: {}", e).into());
+    // An ephemeral run has no overlay to key the container by; it lives and
+    // dies with this session, so there is nothing for a later exec to rejoin.
+    if let Some(overlay_id) = overlay_id {
+        let workload_id = format!("persistent-{}", overlay_id);
+        if let Err(e) = std::fs::write(
+            paths::main_container_id_path(&workload_id),
+            container_id.as_bytes(),
+        ) {
+            let _ = crun::CrunCommand::kill(&container_id, "SIGKILL").status();
+            let _ = crun::CrunCommand::delete(&container_id, true).output();
+            return Err(format!("failed to persist main container id: {}", e).into());
+        }
     }
-    info!(container_id = %container_id, overlay_id = %overlay_id, "established keep-alive main container for persistent machine");
+    info!(container_id = %container_id, overlay_id = ?overlay_id, "established keep-alive main container");
     Ok(container_id)
 }
 
@@ -4358,6 +4370,7 @@ fn spawn_interactive_command(
     tty: bool,
     persistent_overlay_id: Option<&str>,
     unprivileged: bool,
+    s3_volumes: &[smolvm_protocol::S3Volume],
 ) -> Result<(Child, Option<pty::PtyMaster>), Box<dyn std::error::Error>> {
     use std::path::Path;
 
@@ -4393,12 +4406,35 @@ fn spawn_interactive_command(
     // the machine's lifetime. On failure, fall through to the fresh-container path
     // so exec never breaks outright.
     if let Some(overlay_id) = persistent_overlay_id {
-        match ensure_main_container(rootfs, overlay_id, mounts, unprivileged, launch) {
+        match ensure_main_container(
+            rootfs,
+            Some(overlay_id),
+            mounts,
+            unprivileged,
+            launch,
+            s3_volumes,
+        ) {
             Ok(cid) => return spawn_exec_in_container(&cid, launch, tty),
             Err(e) => {
+                // Falling back to a fresh container would silently drop the
+                // remote volumes, leaving the workload reading an empty
+                // directory. When volumes were requested the failure is the
+                // answer, not something to work around.
+                if !s3_volumes.is_empty() {
+                    return Err(e);
+                }
                 warn!(error = %e, "keep-alive main container setup failed; running in a fresh container")
             }
         }
+    }
+
+    // An ephemeral run with a remote volume cannot use `crun run`: that
+    // collapses create and start, leaving no window in which to mount, and the
+    // workload's first instruction would race the mount. Establish the
+    // container in two steps and exec the command into it instead.
+    if !s3_volumes.is_empty() {
+        let cid = ensure_main_container(rootfs, None, mounts, unprivileged, launch, s3_volumes)?;
+        return spawn_exec_in_container(&cid, launch, tty);
     }
 
     let rootfs_path = Path::new(rootfs);
@@ -4559,6 +4595,7 @@ fn spawn_interactive_command(
     _tty: bool,
     _persistent_overlay_id: Option<&str>,
     unprivileged: bool,
+    _s3_volumes: &[smolvm_protocol::S3Volume],
 ) -> Result<(Child, Option<()>), Box<dyn std::error::Error>> {
     use std::path::Path;
 
@@ -5372,6 +5409,7 @@ fn handle_run_background(
     mounts: &[(String, String, bool)],
     persistent_overlay_id: Option<&str>,
     unprivileged: bool,
+    s3_volumes: &[smolvm_protocol::S3Volume],
 ) -> AgentResponse {
     info!(image = %image, command = ?command, mounts = ?mounts, "running command in background");
 
@@ -5403,9 +5441,20 @@ fn handle_run_background(
             user,
             mounts,
             unprivileged,
+            s3_volumes,
         ) {
             Ok(resp) => return resp,
             Err(e) => {
+                // Falling back to a fresh container would silently drop the
+                // remote volumes, leaving the workload reading an empty
+                // directory. When volumes were requested the failure is the
+                // answer, not something to work around.
+                if !s3_volumes.is_empty() {
+                    return AgentResponse::error(
+                        format!("mount remote volume: {e}"),
+                        error_codes::SPAWN_FAILED,
+                    );
+                }
                 warn!(error = %e, "keep-alive background exec failed; falling back to a fresh container");
             }
         }
@@ -5445,6 +5494,7 @@ fn run_background_in_keepalive(
     user: Option<&str>,
     mounts: &[(String, String, bool)],
     unprivileged: bool,
+    s3_volumes: &[smolvm_protocol::S3Volume],
 ) -> Result<AgentResponse, Box<dyn std::error::Error>> {
     let mut launch = ResolvedLaunch::resolve(
         image,
@@ -5464,10 +5514,11 @@ fn run_background_in_keepalive(
             storage::setup_mounts(&prepared.rootfs_path, mounts)?;
             let cid = ensure_main_container(
                 &prepared.rootfs_path,
-                overlay_id,
+                Some(overlay_id),
                 mounts,
                 unprivileged,
                 &launch,
+                s3_volumes,
             )?;
             (cid, std::path::PathBuf::from(&prepared.rootfs_path))
         }
@@ -5585,6 +5636,7 @@ fn run_in_keepalive_container(
     timeout_ms: Option<u64>,
     stdin_data: Option<&str>,
     client_fd: Option<std::os::unix::io::RawFd>,
+    s3_volumes: &[smolvm_protocol::S3Volume],
 ) -> Result<AgentResponse, Box<dyn std::error::Error>> {
     use std::io::Write as _;
 
@@ -5610,10 +5662,11 @@ fn run_in_keepalive_container(
             storage::setup_mounts(&prepared.rootfs_path, mounts)?;
             let cid = ensure_main_container(
                 &prepared.rootfs_path,
-                overlay_id,
+                Some(overlay_id),
                 mounts,
                 unprivileged,
                 &launch,
+                s3_volumes,
             )?;
             (cid, std::path::PathBuf::from(&prepared.rootfs_path))
         }
@@ -5709,6 +5762,7 @@ fn handle_run(
     stdin_data: Option<&str>,
     client_fd: Option<std::os::unix::io::RawFd>,
     unprivileged: bool,
+    s3_volumes: &[smolvm_protocol::S3Volume],
 ) -> AgentResponse {
     info!(image = %image, command = ?command, mounts = ?mounts, timeout_ms = ?timeout_ms, persistent = persistent_overlay_id.is_some(), stdin = stdin_data.is_some(), "running command");
 
@@ -5762,9 +5816,20 @@ fn handle_run(
                 timeout_ms,
                 stdin_data,
                 client_fd,
+                s3_volumes,
             ) {
                 Ok(resp) => return cap_exec_response(resp),
                 Err(e) => {
+                    // Falling back to a fresh container would silently drop the
+                    // remote volumes, leaving the workload reading an empty
+                    // directory. When volumes were requested the failure is the
+                    // answer, not something to work around.
+                    if !s3_volumes.is_empty() {
+                        return AgentResponse::error(
+                            format!("mount remote volume: {e}"),
+                            error_codes::SPAWN_FAILED,
+                        );
+                    }
                     warn!(error = %e, "keep-alive exec failed; running in a fresh container")
                 }
             }

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -3274,7 +3274,6 @@ fn handle_interactive_run(
         tty,
         persistent_overlay_id,
         unprivileged,
-        s3_volumes,
     ) = match request {
         AgentRequest::Run {
             image,
@@ -3287,7 +3286,6 @@ fn handle_interactive_run(
             tty,
             persistent_overlay_id,
             unprivileged,
-            s3_volumes,
             ..
         } => (
             image,
@@ -3300,7 +3298,6 @@ fn handle_interactive_run(
             tty,
             persistent_overlay_id,
             unprivileged,
-            s3_volumes,
         ),
         _ => {
             send_response(
@@ -3354,8 +3351,10 @@ fn handle_interactive_run(
         env,
         workdir,
         user,
-        // Interactive runs never carry volumes: they join an existing container
-        // (or are one-shot), and mounts ride the detached workload launch.
+        // Interactive sessions never carry remote volumes. A shell or exec
+        // joins the workload container, where the mounts already exist, and a
+        // one-shot run is rejected by the CLI before it reaches the agent
+        // because remote volumes are only accepted for machines that persist.
         Vec::new(),
     ) {
         Ok(l) => l,

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -2364,8 +2364,8 @@ fn handle_request(
             background,
             // Remote volumes only ride the detached workload launch
             // (`run_container_detached`, `detached: true`); every synchronous or
-            // background Run sets this to None, so there is nothing to mount here.
-            remote_volume_mount: _,
+            // background Run carries none, so there is nothing to mount here.
+            s3_volumes: _,
         } => {
             if background {
                 handle_run_background(
@@ -3287,7 +3287,7 @@ fn handle_interactive_run(
             tty,
             persistent_overlay_id,
             unprivileged,
-            remote_volume_mount,
+            s3_volumes,
             ..
         } => (
             image,
@@ -3300,7 +3300,7 @@ fn handle_interactive_run(
             tty,
             persistent_overlay_id,
             unprivileged,
-            remote_volume_mount,
+            s3_volumes,
         ),
         _ => {
             send_response(
@@ -3354,7 +3354,9 @@ fn handle_interactive_run(
         env,
         workdir,
         user,
-        remote_volume_mount.as_deref(),
+        // Interactive runs never carry volumes: they join an existing container
+        // (or are one-shot), and mounts ride the detached workload launch.
+        Vec::new(),
     ) {
         Ok(l) => l,
         Err(e) => {
@@ -3456,7 +3458,7 @@ impl ResolvedLaunch {
         env: Vec<(String, String)>,
         workdir: Option<String>,
         user: Option<String>,
-        remote_volume_mount: Option<&str>,
+        s3_volumes: Vec<smolvm_protocol::S3Volume>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let info = storage::query_image(image)?.ok_or_else(|| -> Box<dyn std::error::Error> {
             format!("image not found: {image}").into()
@@ -3465,7 +3467,7 @@ impl ResolvedLaunch {
             let mut resolved = info.entrypoint;
             resolved.extend(info.cmd);
             if resolved.is_empty() {
-                if remote_volume_mount.is_some() {
+                if !s3_volumes.is_empty() {
                     // Remote volumes mount inside the workload container, which
                     // exec/shell join. An image with no entrypoint would
                     // otherwise downgrade to a bare-agent boot with nowhere for
@@ -3488,17 +3490,9 @@ impl ResolvedLaunch {
         } else {
             command
         };
-        // Remote volumes: run the mount script, then exec the RESOLVED workload
-        // command in its place — so a service image's real entrypoint runs (not
-        // a mount stub) and exec/shell sessions joining this container's
-        // namespace see the mount. Wrapping *here*, after resolution, is what
-        // keeps the image's own entrypoint from being clobbered when the request
-        // gave no command (the bug when the wrap lived host-side, which only saw
-        // the empty request command).
-        let command = match remote_volume_mount {
-            Some(script) if !script.is_empty() => wrap_command_with_mount(script, command),
-            _ => command,
-        };
+        // Nothing is wrapped around the workload any more: remote volumes are
+        // mounted natively between the container's create and start, so the
+        // image's own entrypoint runs exactly as written.
         Ok(Self {
             command,
             env: merge_image_env(info.env, env),
@@ -3506,21 +3500,6 @@ impl ResolvedLaunch {
             user: user.or(info.user),
         })
     }
-}
-
-/// Prepend a remote-volume mount script to a resolved workload command:
-/// `sh -c "<script> && exec \"$@\"" sh <cmd...>`. The mount runs in the workload
-/// container's mount namespace, then `exec` replaces the shell with the real
-/// command so PID-1 semantics and signal delivery are unchanged.
-fn wrap_command_with_mount(script: &str, command: Vec<String>) -> Vec<String> {
-    let mut argv = vec![
-        "/bin/sh".to_string(),
-        "-c".to_string(),
-        format!("{script} && exec \"$@\""),
-        "sh".to_string(),
-    ];
-    argv.extend(command);
-    argv
 }
 
 /// Layer the request's env over an image's OCI `Env` (each `"KEY=VAL"`): the
@@ -3655,7 +3634,7 @@ fn handle_run_detached(
             mounts,
             persistent_overlay_id,
             unprivileged,
-            remote_volume_mount,
+            s3_volumes,
             ..
         } => (
             image,
@@ -3666,7 +3645,7 @@ fn handle_run_detached(
             mounts,
             persistent_overlay_id,
             unprivileged,
-            remote_volume_mount,
+            s3_volumes,
         ),
         _ => {
             send_response(
@@ -3731,14 +3710,7 @@ fn handle_run_detached(
     // (command, Env, WorkingDir, User) with the request layered on top.
     // `write_oci_bundle` requires a `ResolvedLaunch`, so the image config can't be
     // silently dropped here or on any other launch path.
-    let launch = match ResolvedLaunch::resolve(
-        &image,
-        command,
-        env,
-        workdir,
-        user,
-        remote_volume_mount.as_deref(),
-    ) {
+    let launch = match ResolvedLaunch::resolve(&image, command, env, workdir, user, s3_volumes) {
         Ok(l) => l,
         Err(e) => {
             send_response(
@@ -3842,6 +3814,27 @@ fn handle_run_detached(
             send_response(
                 stream,
                 &AgentResponse::from_err(e, error_codes::SPAWN_FAILED),
+            )?;
+            return Ok(());
+        }
+    }
+
+    // Mount S3 volumes BETWEEN create and start. The container's namespaces
+    // exist after `create` but its PID 1 has not run yet, so mounting here means
+    // the workload's very first instruction already sees the bucket — a workload
+    // that reads its data directory immediately cannot race the mount. It also
+    // means the workload command itself is never rewritten: the image's own
+    // entrypoint runs exactly as its author wrote it.
+    if !s3_mounts.is_empty() {
+        if let Err(e) = s3mount::mount_all(&container_id, &s3_mounts) {
+            let _ = crun::CrunCommand::kill(&container_id, "SIGKILL").status();
+            let _ = crun::CrunCommand::delete(&container_id, true).output();
+            send_response(
+                stream,
+                &AgentResponse::error(
+                    format!("mount remote volume: {e}"),
+                    error_codes::SPAWN_FAILED,
+                ),
             )?;
             return Ok(());
         }
@@ -6573,29 +6566,6 @@ mod bg_reap_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // The mount script runs BEFORE the resolved workload command, and that
-    // command — an image's own ENTRYPOINT+CMD when the request gives none — must
-    // survive intact. Wrapping is `sh -c '<mounts> && exec "$@"' sh <argv...>`,
-    // so `$@` is the untouched argv and `exec` hands the container PID to it.
-    #[test]
-    fn wrap_command_with_mount_preserves_the_resolved_command() {
-        let wrapped = wrap_command_with_mount(
-            "rclone mount a && rclone mount b",
-            vec![
-                "nginx".to_string(),
-                "-g".to_string(),
-                "daemon off;".to_string(),
-            ],
-        );
-        assert_eq!(&wrapped[..2], &["/bin/sh".to_string(), "-c".to_string()]);
-        assert_eq!(
-            wrapped[2],
-            "rclone mount a && rclone mount b && exec \"$@\""
-        );
-        // `sh` is $0; the workload argv follows verbatim as $1.. — not replaced.
-        assert_eq!(&wrapped[3..], &["sh", "nginx", "-g", "daemon off;"]);
-    }
 
     #[cfg(target_os = "linux")]
     fn proc_stat_fixture(pid: u32, state: char, start_time: u64) -> String {

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -95,6 +95,7 @@ mod pty;
 mod publish_socket;
 mod retry;
 mod rosetta;
+mod s3mount;
 mod ssh_agent;
 mod storage;
 #[cfg(target_os = "linux")]
@@ -216,6 +217,13 @@ fn main() {
     // because `setns(CLONE_NEWMNT)` is refused for a multithreaded process.
     if nsfile::helper_requested() {
         std::process::exit(nsfile::run_helper());
+    }
+
+    // S3 volume mount helper. Same reason as above: it enters the workload
+    // container's mount namespace, and then stays alive serving the FUSE
+    // session for the life of the mount.
+    if s3mount::helper_requested() {
+        std::process::exit(s3mount::run_helper());
     }
 
     // Quick --version check (used by init script to detect rootfs updates)

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -6632,7 +6632,7 @@ mod tests {
         std::fs::write(proc_dir.join("stat"), proc_stat_fixture(123, 'S', 4242)).unwrap();
 
         assert_eq!(
-            crun_container_pid_at("smolvm-test", &state_root, &proc_root),
+            crun_container_pid_at("smolvm-test", &state_root, &proc_root, true),
             Some(123)
         );
 
@@ -6640,14 +6640,22 @@ mod tests {
         // running workload and must not be selected for namespace entry.
         std::fs::write(state_dir.join("exec.fifo"), []).unwrap();
         assert_eq!(
-            crun_container_pid_at("smolvm-test", &state_root, &proc_root),
+            crun_container_pid_at("smolvm-test", &state_root, &proc_root, true),
             None
         );
 
         // Path traversal is rejected before any status lookup.
         assert_eq!(
-            crun_container_pid_at("../smolvm-test", &state_root, &proc_root),
+            crun_container_pid_at("../smolvm-test", &state_root, &proc_root, true),
             None
+        );
+
+        // Remote volumes are mounted between `crun create` and `crun start`,
+        // when the fifo still exists: that lookup must find the same pid the
+        // running one would, or the mount has no namespace to enter.
+        assert_eq!(
+            crun_container_pid_at("smolvm-test", &state_root, &proc_root, false),
+            Some(123)
         );
     }
 

--- a/crates/smolvm-agent/src/oci.rs
+++ b/crates/smolvm-agent/src/oci.rs
@@ -1013,6 +1013,21 @@ fn default_devices() -> Vec<OciDevice> {
             uid: Some(0),
             gid: Some(0),
         },
+        // /dev/fuse - userspace filesystems. The guest kernel has FUSE, but the
+        // container /dev is built from this list, so without an entry here any
+        // FUSE client in the image (JuiceFS, s3fs, SeaweedFS, sshfs) fails to
+        // mount until the user runs `mknod /dev/fuse c 10 229` by hand. The
+        // agent's own remote-volume mounts create the node themselves; this
+        // makes a client the user brings work the same way.
+        OciDevice {
+            device_type: "c".to_string(),
+            path: "/dev/fuse".to_string(),
+            major: 10,
+            minor: 229,
+            file_mode: Some(0o666),
+            uid: Some(0),
+            gid: Some(0),
+        },
     ]
 }
 
@@ -1303,6 +1318,19 @@ mod tests {
         assert_eq!(
             (kmsg.device_type.as_str(), kmsg.major, kmsg.minor),
             ("c", 1, 11)
+        );
+
+        // /dev/fuse (10:229) must be there too, or a FUSE client the user
+        // brings (JuiceFS, s3fs, sshfs) cannot mount without mknod'ing it.
+        let fuse = spec
+            .linux
+            .devices
+            .iter()
+            .find(|d| d.path == "/dev/fuse")
+            .expect("/dev/fuse device present");
+        assert_eq!(
+            (fuse.device_type.as_str(), fuse.major, fuse.minor),
+            ("c", 10, 229)
         );
     }
 

--- a/crates/smolvm-agent/src/s3mount.rs
+++ b/crates/smolvm-agent/src/s3mount.rs
@@ -1,0 +1,243 @@
+//! Mount S3 buckets inside the workload container's mount namespace.
+//!
+//! A remote volume has to appear in the namespace the workload actually lives
+//! in — the same reasoning as [`crate::nsfile`]: a mount made in the agent's
+//! namespace is invisible to the container, and to `exec`/`shell` sessions that
+//! join it.
+//!
+//! `setns(CLONE_NEWMNT)` is refused for a multithreaded caller and the agent
+//! runs a threaded async runtime, so each mount runs in a fresh single-threaded
+//! re-exec of this binary (`smolvm-agent s3-mount …`), dispatched at the top of
+//! `main` before any thread starts. The helper then *stays alive* serving FUSE
+//! for as long as the mount exists — unlike the ns-file helper, which does one
+//! operation and exits.
+//!
+//! Nothing is required of the container image: no rclone, no fuse3, no
+//! `fusermount3`. The helper opens `/dev/fuse` (creating the node if the image
+//! lacks one) and calls `mount(2)` directly as root, so a bucket can be mounted
+//! into a distroless or scratch image that could not install a helper at all.
+
+use std::time::Duration;
+
+use smolvm_s3fs::{s3, sigv4, MountOptions};
+
+const HELPER_ARG: &str = "s3-mount";
+
+/// Everything the helper needs, passed as one JSON argv entry so credentials
+/// never appear in a separate process's environment or on a shared command
+/// line more than once.
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+pub struct MountSpec {
+    pub endpoint: String,
+    pub region: String,
+    pub bucket: String,
+    #[serde(default)]
+    pub prefix: String,
+    pub mountpoint: String,
+    #[serde(default)]
+    pub read_only: bool,
+    #[serde(default)]
+    pub access_key_id: Option<String>,
+    #[serde(default)]
+    pub secret_access_key: Option<String>,
+    #[serde(default)]
+    pub session_token: Option<String>,
+}
+
+impl MountSpec {
+    fn credentials(&self) -> Option<sigv4::Credentials> {
+        match (&self.access_key_id, &self.secret_access_key) {
+            // Both halves or neither: a half-configured key would sign
+            // requests that always fail, which is harder to diagnose than
+            // an explicit anonymous request.
+            (Some(k), Some(s)) if !k.is_empty() && !s.is_empty() => Some(sigv4::Credentials {
+                access_key_id: k.clone(),
+                secret_access_key: s.clone(),
+                session_token: self.session_token.clone(),
+            }),
+            _ => None,
+        }
+    }
+}
+
+/// Whether this process was re-exec'd as the mount helper.
+///
+/// Checked before the async runtime starts, because `setns(CLONE_NEWMNT)`
+/// requires a single-threaded caller.
+pub fn helper_requested() -> bool {
+    std::env::args().nth(1).as_deref() == Some(HELPER_ARG)
+}
+
+/// Entry point for `smolvm-agent s3-mount <pid> <spec-json>`.
+///
+/// Runs until the mount is torn down; the caller supervises it as a child.
+pub fn run_helper() -> i32 {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 4 {
+        eprintln!("s3-mount: usage: s3-mount <container-pid> <spec-json>");
+        return 2;
+    }
+    let Ok(pid) = args[2].parse::<u32>() else {
+        eprintln!("s3-mount: bad pid");
+        return 2;
+    };
+    let spec: MountSpec = match serde_json::from_str(&args[3]) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("s3-mount: bad spec: {e}");
+            return 2;
+        }
+    };
+
+    // pid 0 means "already in the right namespace" (used by tests and by the
+    // no-container case); anything else joins the workload's namespace first.
+    if pid != 0 {
+        if let Err(e) = enter_mount_namespace(pid) {
+            eprintln!("s3-mount: {e}");
+            return 1;
+        }
+    }
+
+    let cfg = s3::Config {
+        endpoint: spec.endpoint.clone(),
+        region: spec.region.clone(),
+        bucket: spec.bucket.clone(),
+        prefix: spec.prefix.clone(),
+        credentials: spec.credentials(),
+        // Path-style works against AWS and every S3-compatible server; virtual
+        // host style would need per-provider DNS assumptions.
+        path_style: true,
+        timeout: Duration::from_secs(60),
+    };
+    let opts = MountOptions {
+        mountpoint: spec.mountpoint.clone(),
+        read_only: spec.read_only,
+        allow_other: true,
+        // Staging lives on the container's own writable layer so a large write
+        // is bounded by the machine's disk, not by RAM.
+        scratch_dir: std::path::PathBuf::from("/var/tmp/smolvm-s3fs"),
+    };
+
+    eprintln!(
+        "s3-mount: mounting s3://{}/{} at {}",
+        spec.bucket, spec.prefix, spec.mountpoint
+    );
+    #[cfg(target_os = "linux")]
+    {
+        match smolvm_s3fs::mount(cfg, opts) {
+            Ok(()) => 0,
+            Err(e) => {
+                eprintln!("s3-mount: mount failed: {e}");
+                1
+            }
+        }
+    }
+    // The agent only ever runs in a Linux guest; this keeps host-side unit
+    // tests (which build the crate on macOS) compiling.
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (cfg, opts);
+        eprintln!("s3-mount: mounting is Linux-only");
+        1
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn enter_mount_namespace(pid: u32) -> Result<(), String> {
+    use std::os::unix::io::AsRawFd;
+    let ns = format!("/proc/{pid}/ns/mnt");
+    let file = std::fs::File::open(&ns).map_err(|e| format!("open {ns}: {e}"))?;
+    // SAFETY: `fd` is a live descriptor for a mount-namespace file; setns only
+    // reads it and this process is single-threaded (re-exec'd for that reason).
+    let rc = unsafe { libc::setns(file.as_raw_fd(), libc::CLONE_NEWNS) };
+    if rc != 0 {
+        return Err(format!("setns({ns}): {}", std::io::Error::last_os_error()));
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn enter_mount_namespace(_pid: u32) -> Result<(), String> {
+    Err("mount namespaces are Linux-only".to_string())
+}
+
+/// Spawn a mount helper for `spec` against the container at `pid`.
+///
+/// Returns the child so the caller can supervise it; the mount lives exactly as
+/// long as this process does.
+pub fn spawn(pid: u32, spec: &MountSpec) -> Result<std::process::Child, String> {
+    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
+    let json = serde_json::to_string(spec).map_err(|e| format!("encode spec: {e}"))?;
+    std::process::Command::new(exe)
+        .arg(HELPER_ARG)
+        .arg(pid.to_string())
+        .arg(json)
+        .stdin(std::process::Stdio::null())
+        .spawn()
+        .map_err(|e| format!("spawn s3-mount helper: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec() -> MountSpec {
+        MountSpec {
+            endpoint: "http://127.0.0.1:9000".into(),
+            region: "us-east-1".into(),
+            bucket: "b".into(),
+            prefix: "p".into(),
+            mountpoint: "/mnt/x".into(),
+            read_only: false,
+            access_key_id: Some("k".into()),
+            secret_access_key: Some("s".into()),
+            session_token: None,
+        }
+    }
+
+    #[test]
+    fn a_spec_survives_the_argv_round_trip() {
+        let s = spec();
+        let json = serde_json::to_string(&s).unwrap();
+        let back: MountSpec = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.bucket, "b");
+        assert_eq!(back.mountpoint, "/mnt/x");
+        assert_eq!(back.access_key_id.as_deref(), Some("k"));
+    }
+
+    // A half-supplied key pair would sign every request with a broken
+    // credential; anonymous is both correct and far easier to diagnose.
+    #[test]
+    fn credentials_need_both_halves_or_none() {
+        assert!(spec().credentials().is_some());
+
+        let mut half = spec();
+        half.secret_access_key = None;
+        assert!(half.credentials().is_none());
+
+        let mut empty = spec();
+        empty.access_key_id = Some(String::new());
+        assert!(empty.credentials().is_none());
+
+        let mut anon = spec();
+        anon.access_key_id = None;
+        anon.secret_access_key = None;
+        assert!(anon.credentials().is_none());
+    }
+
+    #[test]
+    fn the_helper_is_only_requested_by_its_own_argv() {
+        // Guard the dispatch predicate: a stray match would make the agent exit
+        // instead of booting the machine.
+        assert_eq!(HELPER_ARG, "s3-mount");
+    }
+
+    #[test]
+    fn optional_fields_may_be_omitted_entirely() {
+        let json = r#"{"endpoint":"http://e","region":"r","bucket":"b","mountpoint":"/m"}"#;
+        let s: MountSpec = serde_json::from_str(json).unwrap();
+        assert_eq!(s.prefix, "");
+        assert!(!s.read_only);
+        assert!(s.credentials().is_none());
+    }
+}

--- a/crates/smolvm-agent/src/s3mount.rs
+++ b/crates/smolvm-agent/src/s3mount.rs
@@ -155,8 +155,9 @@ const MOUNT_TIMEOUT: Duration = Duration::from_secs(30);
 ///
 /// Called between `crun create` and `crun start`, so the workload's first
 /// instruction already sees the data.
+#[cfg(target_os = "linux")]
 pub fn mount_all(container_id: &str, specs: &[MountSpec]) -> Result<(), String> {
-    let pid = crate::crun_container_pid(container_id)
+    let pid = crate::crun_created_container_pid(container_id)
         .ok_or_else(|| format!("container {container_id} has no pid"))?;
 
     for spec in specs {
@@ -192,6 +193,7 @@ pub fn mount_all(container_id: &str, specs: &[MountSpec]) -> Result<(), String> 
 /// Read from the container's own `mountinfo` rather than the agent's: the mount
 /// is deliberately invisible from outside that namespace, so checking the
 /// agent's view would always report failure.
+#[cfg(target_os = "linux")]
 fn mount_is_present(pid: u32, mountpoint: &str) -> bool {
     let Ok(mounts) = std::fs::read_to_string(format!("/proc/{pid}/mountinfo")) else {
         return false;

--- a/crates/smolvm-agent/src/s3mount.rs
+++ b/crates/smolvm-agent/src/s3mount.rs
@@ -23,6 +23,13 @@ use smolvm_s3fs::{s3, sigv4, MountOptions};
 
 const HELPER_ARG: &str = "s3-mount";
 
+/// Absolute path to this binary in the guest rootfs.
+///
+/// A fixed path rather than `current_exe()`: the agent pivot_roots during boot,
+/// after which `/proc/self/exe` names a path that no longer resolves — the same
+/// reason [`crate::nsfile`] and [`crate::forkpoint`] hard-code it.
+const AGENT_BINARY: &str = "/usr/local/bin/smolvm-agent";
+
 /// The helper speaks the protocol's own volume type: one definition means the
 /// wire format and the mount helper cannot drift apart.
 pub type MountSpec = smolvm_protocol::S3Volume;
@@ -210,9 +217,8 @@ fn mount_is_present(pid: u32, mountpoint: &str) -> bool {
 /// Returns the child so the caller can supervise it; the mount lives exactly as
 /// long as this process does.
 pub fn spawn(pid: u32, spec: &MountSpec) -> Result<std::process::Child, String> {
-    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
     let json = serde_json::to_string(spec).map_err(|e| format!("encode spec: {e}"))?;
-    std::process::Command::new(exe)
+    std::process::Command::new(AGENT_BINARY)
         .arg(HELPER_ARG)
         .arg(pid.to_string())
         .arg(json)

--- a/crates/smolvm-agent/src/s3mount.rs
+++ b/crates/smolvm-agent/src/s3mount.rs
@@ -161,6 +161,66 @@ fn enter_mount_namespace(_pid: u32) -> Result<(), String> {
     Err("mount namespaces are Linux-only".to_string())
 }
 
+/// How long to wait for a mount to appear before giving up.
+///
+/// A mount that never appears is a hard start failure: the workload would run
+/// against an empty directory and silently produce wrong results, which is far
+/// worse than refusing to start.
+const MOUNT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Mount every volume into `container_id`'s namespace and wait until each is
+/// visible.
+///
+/// Called between `crun create` and `crun start`, so the workload's first
+/// instruction already sees the data.
+pub fn mount_all(container_id: &str, specs: &[MountSpec]) -> Result<(), String> {
+    let pid = crate::crun_container_pid(container_id)
+        .ok_or_else(|| format!("container {container_id} has no pid"))?;
+
+    for spec in specs {
+        // The helper runs for the life of the mount; it is intentionally not
+        // reaped here. It exits when the FUSE session ends (unmount or machine
+        // stop), and the container's teardown takes the namespace with it.
+        let child = spawn(pid, spec)?;
+        std::mem::forget(child);
+    }
+
+    let deadline = std::time::Instant::now() + MOUNT_TIMEOUT;
+    for spec in specs {
+        loop {
+            if mount_is_present(pid, &spec.mountpoint) {
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                return Err(format!(
+                    "{} did not mount within {}s — check the endpoint, credentials and network",
+                    spec.mountpoint,
+                    MOUNT_TIMEOUT.as_secs()
+                ));
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        tracing::info!(mountpoint = %spec.mountpoint, bucket = %spec.bucket, "s3 volume mounted");
+    }
+    Ok(())
+}
+
+/// Whether `mountpoint` is mounted inside the container's namespace.
+///
+/// Read from the container's own `mountinfo` rather than the agent's: the mount
+/// is deliberately invisible from outside that namespace, so checking the
+/// agent's view would always report failure.
+fn mount_is_present(pid: u32, mountpoint: &str) -> bool {
+    let Ok(mounts) = std::fs::read_to_string(format!("/proc/{pid}/mountinfo")) else {
+        return false;
+    };
+    mounts.lines().any(|l| {
+        let mut fields = l.split(' ');
+        // mountinfo: id parent major:minor root MOUNTPOINT ...
+        fields.nth(4).map(|m| m == mountpoint).unwrap_or(false) && l.contains("fuse")
+    })
+}
+
 /// Spawn a mount helper for `spec` against the container at `pid`.
 ///
 /// Returns the child so the caller can supervise it; the mount lives exactly as

--- a/crates/smolvm-agent/src/s3mount.rs
+++ b/crates/smolvm-agent/src/s3mount.rs
@@ -49,6 +49,24 @@ fn credentials_of(spec: &MountSpec) -> Option<sigv4::Credentials> {
     }
 }
 
+/// Client configuration for a volume.
+///
+/// Shared by the reachability probe and the mount helper so the two can never
+/// disagree about which endpoint, prefix or credentials a volume means.
+fn client_config(spec: &MountSpec) -> s3::Config {
+    s3::Config {
+        endpoint: spec.endpoint.clone(),
+        region: spec.region.clone(),
+        bucket: spec.bucket.clone(),
+        prefix: spec.prefix.clone(),
+        credentials: credentials_of(spec),
+        // Path-style works against AWS and every S3-compatible server; virtual
+        // host style would need per-provider DNS assumptions.
+        path_style: true,
+        timeout: Duration::from_secs(60),
+    }
+}
+
 /// Whether this process was re-exec'd as the mount helper.
 ///
 /// Checked before the async runtime starts, because `setns(CLONE_NEWMNT)`
@@ -87,17 +105,7 @@ pub fn run_helper() -> i32 {
         }
     }
 
-    let cfg = s3::Config {
-        endpoint: spec.endpoint.clone(),
-        region: spec.region.clone(),
-        bucket: spec.bucket.clone(),
-        prefix: spec.prefix.clone(),
-        credentials: credentials_of(&spec),
-        // Path-style works against AWS and every S3-compatible server; virtual
-        // host style would need per-provider DNS assumptions.
-        path_style: true,
-        timeout: Duration::from_secs(60),
-    };
+    let cfg = client_config(&spec);
     let opts = MountOptions {
         mountpoint: spec.mountpoint.clone(),
         read_only: spec.read_only,
@@ -157,6 +165,32 @@ fn enter_mount_namespace(_pid: u32) -> Result<(), String> {
 /// worse than refusing to start.
 const MOUNT_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Check that a bucket is really usable before mounting it.
+///
+/// `mount(2)` on `/dev/fuse` succeeds without ever contacting S3, so on its own
+/// a mount proves nothing: a typo'd bucket, an expired key or an unreachable
+/// endpoint all produce a machine that starts happily and serves an empty
+/// directory, and the workload then reads nothing and produces silently wrong
+/// results. One list request collapses all of those into a start failure that
+/// names the cause.
+///
+/// Runs in the agent's own namespace — reachability and credentials do not
+/// depend on the mount namespace the helper later joins.
+#[cfg(target_os = "linux")]
+fn probe(spec: &MountSpec) -> Result<(), String> {
+    s3::Client::new(client_config(spec))
+        .list_dir("")
+        .map(|_| ())
+        .map_err(|e| {
+            let at = if spec.prefix.is_empty() {
+                spec.bucket.clone()
+            } else {
+                format!("{}/{}", spec.bucket, spec.prefix)
+            };
+            format!("s3://{at} is not reachable: {e}")
+        })
+}
+
 /// Mount every volume into `container_id`'s namespace and wait until each is
 /// visible.
 ///
@@ -167,23 +201,34 @@ pub fn mount_all(container_id: &str, specs: &[MountSpec]) -> Result<(), String> 
     let pid = crate::crun_created_container_pid(container_id)
         .ok_or_else(|| format!("container {container_id} has no pid"))?;
 
+    // Probe every volume before mounting any of them, so a machine with two
+    // volumes fails on the bad one rather than half-mounting and then failing.
     for spec in specs {
-        // The helper runs for the life of the mount; it is intentionally not
-        // reaped here. It exits when the FUSE session ends (unmount or machine
-        // stop), and the container's teardown takes the namespace with it.
-        let child = spawn(pid, spec)?;
-        std::mem::forget(child);
+        probe(spec)?;
+    }
+
+    let mut children = Vec::with_capacity(specs.len());
+    for spec in specs {
+        children.push(spawn(pid, spec)?);
     }
 
     let deadline = std::time::Instant::now() + MOUNT_TIMEOUT;
-    for spec in specs {
+    for (spec, mut child) in specs.iter().zip(children) {
         loop {
             if mount_is_present(pid, &spec.mountpoint) {
                 break;
             }
+            // A helper that has already exited will never mount anything, so
+            // report that immediately instead of waiting out the full timeout.
+            if let Ok(Some(status)) = child.try_wait() {
+                return Err(format!(
+                    "mounting {} failed ({status}) — see the agent log for the cause",
+                    spec.mountpoint
+                ));
+            }
             if std::time::Instant::now() >= deadline {
                 return Err(format!(
-                    "{} did not mount within {}s — check the endpoint, credentials and network",
+                    "{} did not mount within {}s",
                     spec.mountpoint,
                     MOUNT_TIMEOUT.as_secs()
                 ));
@@ -191,6 +236,10 @@ pub fn mount_all(container_id: &str, specs: &[MountSpec]) -> Result<(), String> 
             std::thread::sleep(Duration::from_millis(100));
         }
         tracing::info!(mountpoint = %spec.mountpoint, bucket = %spec.bucket, "s3 volume mounted");
+        // The helper serves the mount for as long as it exists, so it is
+        // deliberately never reaped: it exits when the FUSE session ends, and
+        // the container's teardown takes the namespace with it.
+        std::mem::forget(child);
     }
     Ok(())
 }
@@ -280,6 +329,33 @@ mod tests {
         // Guard the dispatch predicate: a stray match would make the agent exit
         // instead of booting the machine.
         assert_eq!(HELPER_ARG, "s3-mount");
+    }
+
+    #[test]
+    fn the_client_config_carries_the_spec_verbatim() {
+        // The probe and the helper share this; if it stopped reflecting the
+        // spec, a volume could be probed against one bucket and mounted from
+        // another.
+        let cfg = client_config(&spec());
+        assert_eq!(cfg.bucket, "b");
+        assert_eq!(cfg.prefix, "p");
+        assert_eq!(cfg.endpoint, "http://127.0.0.1:9000");
+        assert!(cfg.path_style);
+        assert!(cfg.credentials.is_some());
+    }
+
+    // An unreachable endpoint must fail the start rather than mount an empty
+    // directory: `mount(2)` succeeds without contacting S3, so only the probe
+    // stands between a typo and a workload that silently reads nothing.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn an_unreachable_endpoint_fails_the_probe_by_name() {
+        let mut s = spec();
+        // Port 1 on loopback refuses immediately, so this stays fast.
+        s.endpoint = "http://127.0.0.1:1".into();
+        let err = probe(&s).expect_err("a refused endpoint must not probe clean");
+        assert!(err.contains("s3://b/p"), "{err}");
+        assert!(err.contains("not reachable"), "{err}");
     }
 
     #[test]

--- a/crates/smolvm-agent/src/s3mount.rs
+++ b/crates/smolvm-agent/src/s3mount.rs
@@ -23,40 +23,22 @@ use smolvm_s3fs::{s3, sigv4, MountOptions};
 
 const HELPER_ARG: &str = "s3-mount";
 
-/// Everything the helper needs, passed as one JSON argv entry so credentials
-/// never appear in a separate process's environment or on a shared command
-/// line more than once.
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
-pub struct MountSpec {
-    pub endpoint: String,
-    pub region: String,
-    pub bucket: String,
-    #[serde(default)]
-    pub prefix: String,
-    pub mountpoint: String,
-    #[serde(default)]
-    pub read_only: bool,
-    #[serde(default)]
-    pub access_key_id: Option<String>,
-    #[serde(default)]
-    pub secret_access_key: Option<String>,
-    #[serde(default)]
-    pub session_token: Option<String>,
-}
+/// The helper speaks the protocol's own volume type: one definition means the
+/// wire format and the mount helper cannot drift apart.
+pub type MountSpec = smolvm_protocol::S3Volume;
 
-impl MountSpec {
-    fn credentials(&self) -> Option<sigv4::Credentials> {
-        match (&self.access_key_id, &self.secret_access_key) {
-            // Both halves or neither: a half-configured key would sign
-            // requests that always fail, which is harder to diagnose than
-            // an explicit anonymous request.
-            (Some(k), Some(s)) if !k.is_empty() && !s.is_empty() => Some(sigv4::Credentials {
-                access_key_id: k.clone(),
-                secret_access_key: s.clone(),
-                session_token: self.session_token.clone(),
-            }),
-            _ => None,
-        }
+/// Credentials for a volume, or `None` for anonymous access.
+///
+/// A half-supplied key pair would sign every request with a broken credential,
+/// which is harder to diagnose than an explicit anonymous request.
+fn credentials_of(spec: &MountSpec) -> Option<sigv4::Credentials> {
+    match (&spec.access_key_id, &spec.secret_access_key) {
+        (Some(k), Some(sec)) if !k.is_empty() && !sec.is_empty() => Some(sigv4::Credentials {
+            access_key_id: k.clone(),
+            secret_access_key: sec.clone(),
+            session_token: spec.session_token.clone(),
+        }),
+        _ => None,
     }
 }
 
@@ -103,7 +85,7 @@ pub fn run_helper() -> i32 {
         region: spec.region.clone(),
         bucket: spec.bucket.clone(),
         prefix: spec.prefix.clone(),
-        credentials: spec.credentials(),
+        credentials: credentials_of(&spec),
         // Path-style works against AWS and every S3-compatible server; virtual
         // host style would need per-provider DNS assumptions.
         path_style: true,
@@ -269,20 +251,20 @@ mod tests {
     // credential; anonymous is both correct and far easier to diagnose.
     #[test]
     fn credentials_need_both_halves_or_none() {
-        assert!(spec().credentials().is_some());
+        assert!(credentials_of(&spec()).is_some());
 
         let mut half = spec();
         half.secret_access_key = None;
-        assert!(half.credentials().is_none());
+        assert!(credentials_of(&half).is_none());
 
         let mut empty = spec();
         empty.access_key_id = Some(String::new());
-        assert!(empty.credentials().is_none());
+        assert!(credentials_of(&empty).is_none());
 
         let mut anon = spec();
         anon.access_key_id = None;
         anon.secret_access_key = None;
-        assert!(anon.credentials().is_none());
+        assert!(credentials_of(&anon).is_none());
     }
 
     #[test]
@@ -298,6 +280,6 @@ mod tests {
         let s: MountSpec = serde_json::from_str(json).unwrap();
         assert_eq!(s.prefix, "");
         assert!(!s.read_only);
-        assert!(s.credentials().is_none());
+        assert!(credentials_of(&s).is_none());
     }
 }

--- a/crates/smolvm-protocol/src/lib.rs
+++ b/crates/smolvm-protocol/src/lib.rs
@@ -18,6 +18,38 @@
 
 use serde::{Deserialize, Serialize};
 
+/// One S3-compatible bucket to mount inside the workload container.
+///
+/// Structured rather than a shell command: the agent mounts it natively, so
+/// nothing has to be installed in the image and no command is interpolated.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct S3Volume {
+    /// Service endpoint, e.g. `https://s3.us-east-1.amazonaws.com` or a
+    /// self-hosted `http://minio:9000`.
+    pub endpoint: String,
+    /// Region used for request signing.
+    pub region: String,
+    /// Bucket to mount.
+    pub bucket: String,
+    /// Optional key prefix, so a mount can expose one sub-tree of a bucket.
+    #[serde(default)]
+    pub prefix: String,
+    /// Absolute path inside the container where the bucket appears.
+    pub mountpoint: String,
+    /// Mount read-only; the kernel then rejects writes before they reach us.
+    #[serde(default)]
+    pub read_only: bool,
+    /// Access key. Absent (with the secret) means anonymous access.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub access_key_id: Option<String>,
+    /// Secret key paired with `access_key_id`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secret_access_key: Option<String>,
+    /// Session token, when temporary credentials are in use.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_token: Option<String>,
+}
+
 pub mod forkpoint;
 pub mod guest_env;
 pub mod image_ref;
@@ -432,13 +464,11 @@ pub enum AgentRequest {
         /// Incompatible with `interactive` and `tty`.
         #[serde(default)]
         background: bool,
-        /// Remote-volume mount script to run inside the workload container
-        /// before its (image-resolved) command. Wrapping in the agent — after
-        /// the image ENTRYPOINT/CMD is resolved — is what lets a service image's
-        /// real entrypoint still run; a host-side wrap only saw the empty
-        /// request command and would replace the workload with a mount stub.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        remote_volume_mount: Option<String>,
+        /// S3 volumes to mount into the workload container. The agent mounts
+        /// them between `crun create` and `crun start`, so the workload's first
+        /// instruction already sees them and its command is never rewritten.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        s3_volumes: Vec<S3Volume>,
     },
 
     /// Send stdin data to a running interactive command.

--- a/crates/smolvm-s3fs/Cargo.toml
+++ b/crates/smolvm-s3fs/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "smolvm-s3fs"
+version = "1.10.0"
+edition = "2021"
+description = "POSIX filesystem over S3-compatible object storage, mounted through FUSE without libfuse or a helper binary"
+license = "Apache-2.0"
+
+[dependencies]
+hmac = "0.12"
+sha2 = "0.10"
+libc = "0.2"
+ureq = { version = "2", default-features = false, features = ["tls", "gzip"] }
+tracing = { workspace = true }

--- a/crates/smolvm-s3fs/src/fs.rs
+++ b/crates/smolvm-s3fs/src/fs.rs
@@ -31,6 +31,12 @@ use crate::s3;
 const DIR_MODE: u32 = 0o040755;
 const FILE_MODE: u32 = 0o100644;
 
+/// `fuse_setattr_in.valid` bits this filesystem acts on. Ownership, mode and
+/// timestamps are accepted and ignored — an object store has no place to put
+/// them — but a size change is real and must be applied.
+const FATTR_SIZE: u32 = 1 << 3;
+const FATTR_FH: u32 = 1 << 6;
+
 /// A file opened for writing, staged on local disk until flush.
 struct Staged {
     file: std::fs::File,
@@ -120,6 +126,28 @@ impl S3Fs {
             if let Some(ino) = paths.remove(path) {
                 inodes.remove(&ino);
             }
+        }
+    }
+
+    /// Move an inode's mapping from `from` to `to`.
+    ///
+    /// `rename(2)` does not mint a new inode: the kernel moves the dentry and
+    /// keeps the same inode number under the new name. Forgetting the inode
+    /// here instead would leave the kernel holding one this filesystem no
+    /// longer recognises, and every later lookup on it would fail even though
+    /// the object is intact in the bucket.
+    fn rename_path(&self, from: &str, to: &str) {
+        let (Ok(mut paths), Ok(mut inodes)) = (self.paths.lock(), self.inodes.lock()) else {
+            return;
+        };
+        // A destination that already existed is replaced, exactly as rename
+        // replaces it in the bucket.
+        if let Some(old) = paths.remove(to) {
+            inodes.remove(&old);
+        }
+        if let Some(ino) = paths.remove(from) {
+            inodes.insert(ino, to.to_string());
+            paths.insert(to.to_string(), ino);
         }
     }
 
@@ -229,6 +257,45 @@ impl S3Fs {
         Ok(fh)
     }
 
+    /// Resize a file to `size`, in the staging file when a handle is open and
+    /// in the object itself otherwise.
+    ///
+    /// Truncation is not a formality here: unless `atomic_o_trunc` is
+    /// negotiated the kernel turns `O_TRUNC` into a `SETATTR` with a new size,
+    /// so a filesystem that ignores this silently keeps the old contents — a
+    /// program that rewrites a file with fewer bytes would leave the previous
+    /// tail in place and read back a mix of old and new data.
+    fn truncate(&self, path: &str, fh: Option<u64>, size: u64) -> Result<(), i32> {
+        if let Some(fh) = fh {
+            if let Ok(mut guard) = self.staged.lock() {
+                if let Some(st) = guard.get_mut(&fh) {
+                    st.file.set_len(size).map_err(|_| libc::EIO)?;
+                    st.size = size;
+                    st.dirty = true;
+                    if let Ok(mut pending) = self.pending.lock() {
+                        pending.insert(path.to_string(), size);
+                    }
+                    return Ok(());
+                }
+            }
+        }
+        // No open handle: rewrite the object at its new length. Growing pads
+        // with zeroes, which is what a sparse-less truncate(2) produces.
+        let mut bytes = if size == 0 {
+            Vec::new()
+        } else {
+            self.client.get(path, None).unwrap_or_default()
+        };
+        bytes.resize(size as usize, 0);
+        self.client.put(path, &bytes).map_err(|_| libc::EIO)?;
+        // The object now really is this size, so no pending entry is needed —
+        // and a stale one would misreport the size of every later read.
+        if let Ok(mut pending) = self.pending.lock() {
+            pending.remove(path);
+        }
+        Ok(())
+    }
+
     /// Upload a staged file and drop its staging state.
     fn flush_staged(&self, fh: u64, path: &str, close: bool) -> Result<(), i32> {
         let mut guard = match self.staged.lock() {
@@ -304,6 +371,14 @@ impl Filesystem for S3Fs {
                 let Some(path) = self.path_of(req.nodeid) else {
                     return Reply::Error(libc::ENOENT);
                 };
+                // fuse_setattr_in: valid(4) padding(4) fh(8) size(8) ...
+                let valid = req.u32_at(0);
+                if valid & FATTR_SIZE != 0 {
+                    let fh = (valid & FATTR_FH != 0).then(|| req.u64_at(8));
+                    if let Err(e) = self.truncate(&path, fh, req.u64_at(16)) {
+                        return Reply::Error(e);
+                    }
+                }
                 match self.stat(&path) {
                     Some(node) => Reply::Attr(self.attr_for(req.nodeid, &node)),
                     None => Reply::Error(libc::ENOENT),
@@ -612,7 +687,7 @@ impl Filesystem for S3Fs {
                     return Reply::Error(libc::EIO);
                 }
                 let _ = self.client.delete(&from);
-                self.forget_path(&from);
+                self.rename_path(&from, &to);
                 Reply::Ok
             }
 
@@ -657,6 +732,40 @@ mod tests {
             dir,
         )
         .expect("scratch dir is creatable")
+    }
+
+    // `rename(2)` keeps the inode and moves the name onto it. Forgetting the
+    // inode instead leaves the kernel holding one the filesystem no longer
+    // knows, and every later read of the renamed file comes back empty even
+    // though the object is intact in the bucket.
+    #[test]
+    fn renaming_repoints_the_inode_instead_of_dropping_it() {
+        let fs = fs();
+        let ino = fs.ino_for("d/old.txt");
+        fs.rename_path("d/old.txt", "d/new.txt");
+        assert_eq!(
+            fs.path_of(ino).as_deref(),
+            Some("d/new.txt"),
+            "the kernel still holds this inode, so it must resolve to the new name"
+        );
+        assert_eq!(
+            fs.ino_for("d/new.txt"),
+            ino,
+            "looking the new name up again must not mint a second inode"
+        );
+    }
+
+    // Renaming onto an existing name replaces it in the bucket, so the
+    // replaced inode must not linger and shadow the survivor.
+    #[test]
+    fn renaming_over_an_existing_name_drops_the_replaced_inode() {
+        let fs = fs();
+        let src = fs.ino_for("d/src.txt");
+        let dst = fs.ino_for("d/dst.txt");
+        assert_ne!(src, dst);
+        fs.rename_path("d/src.txt", "d/dst.txt");
+        assert_eq!(fs.path_of(src).as_deref(), Some("d/dst.txt"));
+        assert_eq!(fs.path_of(dst), None, "the replaced inode is gone");
     }
 
     #[test]

--- a/crates/smolvm-s3fs/src/fs.rs
+++ b/crates/smolvm-s3fs/src/fs.rs
@@ -1,0 +1,776 @@
+//! A POSIX filesystem over an S3 bucket.
+//!
+//! # Why this layer exists
+//!
+//! Object storage and POSIX disagree on nearly everything: objects are
+//! immutable blobs addressed by a flat key space, while files are mutable byte
+//! ranges inside a tree of directories. Bridging that is the actual work:
+//!
+//! * **Directories are synthetic.** S3 has no directories, only keys that share
+//!   a prefix. Listing with `delimiter=/` turns one level of that key space into
+//!   entries, and any prefix that appears becomes a directory — including ones
+//!   no explicit object ever created.
+//! * **Writes cannot be partial.** There is no "write 4 KiB at offset 12 KiB"
+//!   in S3, only "replace the whole object". So an opened-for-write file is
+//!   staged in a local scratch file, mutated freely as a normal file, and
+//!   uploaded once on flush/close. This is the same shape rclone, s3fs and
+//!   Mountpoint all converge on, because the API leaves no alternative.
+//! * **Deletes must not resurrect data.** A staged file whose upload has not
+//!   happened yet still has to be visible to readers, so lookups consult the
+//!   staging table before the bucket.
+
+use std::collections::HashMap;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::fuse::{self, Attr, Filesystem, Reply, Request, DT_DIR, DT_REG, FUSE_ROOT_ID};
+use crate::s3;
+
+const DIR_MODE: u32 = 0o040755;
+const FILE_MODE: u32 = 0o100644;
+
+/// A file opened for writing, staged on local disk until flush.
+struct Staged {
+    file: std::fs::File,
+    path: std::path::PathBuf,
+    size: u64,
+    dirty: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+enum Node {
+    Dir,
+    File { size: u64, mtime: u64 },
+}
+
+pub struct S3Fs {
+    client: s3::Client,
+    read_only: bool,
+    scratch: std::path::PathBuf,
+    next_ino: AtomicU64,
+    next_fh: AtomicU64,
+    /// inode -> path relative to the mount root ("" is the root).
+    inodes: Mutex<HashMap<u64, String>>,
+    /// path -> inode, so repeated lookups are stable (the kernel caches by ino).
+    paths: Mutex<HashMap<String, u64>>,
+    /// Open write handles, keyed by file handle.
+    staged: Mutex<HashMap<u64, Staged>>,
+    /// Paths with an unflushed staging file, so reads see pending writes.
+    pending: Mutex<HashMap<String, u64>>,
+}
+
+impl S3Fs {
+    pub fn new(
+        client: s3::Client,
+        read_only: bool,
+        scratch: std::path::PathBuf,
+    ) -> std::io::Result<Self> {
+        std::fs::create_dir_all(&scratch)?;
+        let mut inodes = HashMap::new();
+        inodes.insert(FUSE_ROOT_ID, String::new());
+        let mut paths = HashMap::new();
+        paths.insert(String::new(), FUSE_ROOT_ID);
+        Ok(Self {
+            client,
+            read_only,
+            scratch,
+            next_ino: AtomicU64::new(FUSE_ROOT_ID + 1),
+            next_fh: AtomicU64::new(1),
+            inodes: Mutex::new(inodes),
+            paths: Mutex::new(paths),
+            staged: Mutex::new(HashMap::new()),
+            pending: Mutex::new(HashMap::new()),
+        })
+    }
+
+    fn now() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+    }
+
+    fn path_of(&self, ino: u64) -> Option<String> {
+        self.inodes.lock().ok()?.get(&ino).cloned()
+    }
+
+    /// Stable inode for a path, allocating on first sight.
+    fn ino_for(&self, path: &str) -> u64 {
+        if let Ok(paths) = self.paths.lock() {
+            if let Some(i) = paths.get(path) {
+                return *i;
+            }
+        }
+        let ino = self.next_ino.fetch_add(1, Ordering::Relaxed);
+        if let (Ok(mut paths), Ok(mut inodes)) = (self.paths.lock(), self.inodes.lock()) {
+            // Re-check: another thread may have allocated while we were unlocked.
+            if let Some(existing) = paths.get(path) {
+                return *existing;
+            }
+            paths.insert(path.to_string(), ino);
+            inodes.insert(ino, path.to_string());
+        }
+        ino
+    }
+
+    fn forget_path(&self, path: &str) {
+        if let (Ok(mut paths), Ok(mut inodes)) = (self.paths.lock(), self.inodes.lock()) {
+            if let Some(ino) = paths.remove(path) {
+                inodes.remove(&ino);
+            }
+        }
+    }
+
+    fn join(parent: &str, name: &str) -> String {
+        if parent.is_empty() {
+            name.to_string()
+        } else {
+            format!("{parent}/{name}")
+        }
+    }
+
+    fn attr_for(&self, ino: u64, node: &Node) -> Attr {
+        match node {
+            Node::Dir => Attr {
+                ino,
+                size: 0,
+                blocks: 0,
+                mode: DIR_MODE,
+                nlink: 2,
+                ..Default::default()
+            },
+            Node::File { size, mtime } => Attr {
+                ino,
+                size: *size,
+                blocks: size.div_ceil(512),
+                atime: *mtime,
+                mtime: *mtime,
+                ctime: *mtime,
+                mode: FILE_MODE,
+                nlink: 1,
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Resolve a path to a node: staged writes first, then the bucket, then a
+    /// directory probe (a prefix with any child is a directory).
+    fn stat(&self, path: &str) -> Option<Node> {
+        if path.is_empty() {
+            return Some(Node::Dir);
+        }
+        if let Ok(pending) = self.pending.lock() {
+            if let Some(size) = pending.get(path) {
+                return Some(Node::File {
+                    size: *size,
+                    mtime: Self::now(),
+                });
+            }
+        }
+        match self.client.head(path) {
+            Ok(Some(info)) => {
+                return Some(Node::File {
+                    size: info.size,
+                    mtime: info.last_modified_secs,
+                })
+            }
+            Ok(None) => {}
+            Err(e) => {
+                tracing::debug!(path, error = %e, "head failed; treating as absent");
+            }
+        }
+        // Not an object: it may still be a directory prefix.
+        match self.client.list_dir(path) {
+            Ok(l) if !l.objects.is_empty() || !l.prefixes.is_empty() => Some(Node::Dir),
+            _ => None,
+        }
+    }
+
+    fn staging_path(&self, fh: u64) -> std::path::PathBuf {
+        self.scratch.join(format!("stage-{fh}"))
+    }
+
+    /// Open a staging file, seeded with the object's current bytes when it
+    /// exists — required so a partial write does not truncate the rest away.
+    fn open_staged(&self, path: &str, truncate: bool) -> std::io::Result<u64> {
+        let fh = self.next_fh.fetch_add(1, Ordering::Relaxed);
+        let spath = self.staging_path(fh);
+        let mut file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&spath)?;
+        let mut size = 0u64;
+        if !truncate {
+            if let Ok(bytes) = self.client.get(path, None) {
+                file.write_all(&bytes)?;
+                file.flush()?;
+                size = bytes.len() as u64;
+                file.seek(SeekFrom::Start(0))?;
+            }
+        }
+        if let Ok(mut staged) = self.staged.lock() {
+            staged.insert(
+                fh,
+                Staged {
+                    file,
+                    path: spath,
+                    size,
+                    dirty: truncate,
+                },
+            );
+        }
+        if let Ok(mut pending) = self.pending.lock() {
+            pending.insert(path.to_string(), size);
+        }
+        Ok(fh)
+    }
+
+    /// Upload a staged file and drop its staging state.
+    fn flush_staged(&self, fh: u64, path: &str, close: bool) -> Result<(), i32> {
+        let mut guard = match self.staged.lock() {
+            Ok(g) => g,
+            Err(_) => return Err(libc::EIO),
+        };
+        let Some(st) = guard.get_mut(&fh) else {
+            return Ok(()); // read-only handle: nothing staged
+        };
+        if st.dirty {
+            let mut buf = Vec::with_capacity(st.size as usize);
+            if st.file.seek(SeekFrom::Start(0)).is_err() || st.file.read_to_end(&mut buf).is_err() {
+                return Err(libc::EIO);
+            }
+            if let Err(e) = self.client.put(path, &buf) {
+                tracing::warn!(path, error = %e, "upload failed");
+                return Err(libc::EIO);
+            }
+            st.dirty = false;
+        }
+        if close {
+            if let Some(st) = guard.remove(&fh) {
+                let _ = std::fs::remove_file(&st.path);
+            }
+            drop(guard);
+            if let Ok(mut pending) = self.pending.lock() {
+                pending.remove(path);
+            }
+        }
+        Ok(())
+    }
+
+    fn deny_if_read_only(&self) -> Option<Reply> {
+        self.read_only.then_some(Reply::Error(libc::EROFS))
+    }
+}
+
+impl Filesystem for S3Fs {
+    fn dispatch(&self, req: &Request<'_>) -> Reply {
+        use fuse::op;
+        match req.opcode {
+            op::LOOKUP => {
+                let Some(parent) = self.path_of(req.nodeid) else {
+                    return Reply::Error(libc::ENOENT);
+                };
+                let Some(name) = req.name_at(0) else {
+                    return Reply::Error(libc::EINVAL);
+                };
+                let path = Self::join(&parent, &name);
+                match self.stat(&path) {
+                    Some(node) => Reply::Entry(self.attr_for(self.ino_for(&path), &node)),
+                    None => Reply::Error(libc::ENOENT),
+                }
+            }
+
+            op::GETATTR => {
+                let Some(path) = self.path_of(req.nodeid) else {
+                    return Reply::Error(libc::ENOENT);
+                };
+                match self.stat(&path) {
+                    Some(node) => Reply::Attr(self.attr_for(req.nodeid, &node)),
+                    None => Reply::Error(libc::ENOENT),
+                }
+            }
+
+            // Accept the metadata changes a normal write path performs (chmod,
+            // utimes, truncate-to-zero) so editors and `cp` work; S3 keeps no
+            // POSIX metadata, so we acknowledge rather than persist.
+            op::SETATTR => {
+                if let Some(d) = self.deny_if_read_only() {
+                    return d;
+                }
+                let Some(path) = self.path_of(req.nodeid) else {
+                    return Reply::Error(libc::ENOENT);
+                };
+                match self.stat(&path) {
+                    Some(node) => Reply::Attr(self.attr_for(req.nodeid, &node)),
+                    None => Reply::Error(libc::ENOENT),
+                }
+            }
+
+            op::OPENDIR => Reply::Open(0),
+            op::RELEASEDIR | op::FSYNCDIR => Reply::Ok,
+
+            op::READDIR => {
+                let Some(path) = self.path_of(req.nodeid) else {
+                    return Reply::Error(libc::ENOENT);
+                };
+                // fuse_read_in: fh(8) offset(8) size(4) ...
+                let offset = req.u64_at(8);
+                let size = req.u32_at(16) as usize;
+                if offset > 0 {
+                    return Reply::Directory(Vec::new()); // single-shot listing
+                }
+                let listing = match self.client.list_dir(&path) {
+                    Ok(l) => l,
+                    Err(e) => {
+                        tracing::warn!(path, error = %e, "list failed");
+                        return Reply::Error(libc::EIO);
+                    }
+                };
+                let mut buf = Vec::new();
+                let mut next = 1u64;
+                for (name, kind) in [(".", DT_DIR), ("..", DT_DIR)] {
+                    fuse::push_dirent(&mut buf, size, req.nodeid, next, kind, name);
+                    next += 1;
+                }
+                for d in &listing.prefixes {
+                    let child = Self::join(&path, d);
+                    if !fuse::push_dirent(&mut buf, size, self.ino_for(&child), next, DT_DIR, d) {
+                        break;
+                    }
+                    next += 1;
+                }
+                for o in &listing.objects {
+                    // Keys ending in "/" are directory markers, not files.
+                    if o.key.ends_with('/') {
+                        continue;
+                    }
+                    let child = Self::join(&path, &o.key);
+                    if !fuse::push_dirent(
+                        &mut buf,
+                        size,
+                        self.ino_for(&child),
+                        next,
+                        DT_REG,
+                        &o.key,
+                    ) {
+                        break;
+                    }
+                    next += 1;
+                }
+                Reply::Directory(buf)
+            }
+
+            op::OPEN => {
+                let Some(path) = self.path_of(req.nodeid) else {
+                    return Reply::Error(libc::ENOENT);
+                };
+                let flags = req.u32_at(0) as i32;
+                let wants_write = flags & (libc::O_WRONLY | libc::O_RDWR) != 0;
+                if wants_write {
+                    if let Some(d) = self.deny_if_read_only() {
+                        return d;
+                    }
+                    match self.open_staged(&path, flags & libc::O_TRUNC != 0) {
+                        Ok(fh) => Reply::Open(fh),
+                        Err(e) => {
+                            tracing::warn!(path, error = %e, "staging open failed");
+                            Reply::Error(libc::EIO)
+                        }
+                    }
+                } else {
+                    Reply::Open(0) // reads stream straight from the bucket
+                }
+            }
+
+            op::CREATE => {
+                if let Some(d) = self.deny_if_read_only() {
+                    return d;
+                }
+                let Some(parent) = self.path_of(req.nodeid) else {
+                    return Reply::Error(libc::ENOENT);
+                };
+                // fuse_create_in: flags(4) mode(4) umask(4) padding(4), then name
+                let Some(name) = req.name_at(16) else {
+                    return Reply::Error(libc::EINVAL);
+                };
+                let path = Self::join(&parent, &name);
+                match self.open_staged(&path, true) {
+                    Ok(fh) => {
+                        let ino = self.ino_for(&path);
+                        let attr = self.attr_for(
+                            ino,
+                            &Node::File {
+                                size: 0,
+                                mtime: Self::now(),
+                            },
+                        );
+                        Reply::Create(attr, fh)
+                    }
+                    Err(e) => {
+                        tracing::warn!(path, error = %e, "create failed");
+                        Reply::Error(libc::EIO)
+                    }
+                }
+            }
+
+            op::READ => {
+                let Some(path) = self.path_of(req.nodeid) else {
+                    return Reply::Error(libc::ENOENT);
+                };
+                let fh = req.u64_at(0);
+                let offset = req.u64_at(8);
+                let size = req.u32_at(16) as u64;
+
+                // A file with unflushed writes must read back what was written,
+                // not the stale object still sitting in the bucket.
+                if fh != 0 {
+                    if let Ok(mut guard) = self.staged.lock() {
+                        if let Some(st) = guard.get_mut(&fh) {
+                            let mut buf = vec![0u8; size as usize];
+                            if st.file.seek(SeekFrom::Start(offset)).is_err() {
+                                return Reply::Error(libc::EIO);
+                            }
+                            let n = st.file.read(&mut buf).unwrap_or(0);
+                            buf.truncate(n);
+                            return Reply::Data(buf);
+                        }
+                    }
+                }
+                if size == 0 {
+                    return Reply::Data(Vec::new());
+                }
+                match self.client.get(&path, Some((offset, offset + size - 1))) {
+                    Ok(d) => Reply::Data(d),
+                    // A range past EOF is a normal end-of-file, not an error.
+                    Err(s3::Error::Status { status: 416, .. }) => Reply::Data(Vec::new()),
+                    Err(e) => {
+                        tracing::warn!(path, error = %e, "read failed");
+                        Reply::Error(libc::EIO)
+                    }
+                }
+            }
+
+            op::WRITE => {
+                if let Some(d) = self.deny_if_read_only() {
+                    return d;
+                }
+                let fh = req.u64_at(0);
+                let offset = req.u64_at(8);
+                let size = req.u32_at(16) as usize;
+                // fuse_write_in is 40 bytes, then the payload.
+                let Some(data) = req.data.get(40..40 + size) else {
+                    return Reply::Error(libc::EINVAL);
+                };
+                let Some(path) = self.path_of(req.nodeid) else {
+                    return Reply::Error(libc::ENOENT);
+                };
+                let Ok(mut guard) = self.staged.lock() else {
+                    return Reply::Error(libc::EIO);
+                };
+                let Some(st) = guard.get_mut(&fh) else {
+                    return Reply::Error(libc::EBADF);
+                };
+                if st.file.seek(SeekFrom::Start(offset)).is_err()
+                    || st.file.write_all(data).is_err()
+                {
+                    return Reply::Error(libc::EIO);
+                }
+                st.dirty = true;
+                st.size = st.size.max(offset + size as u64);
+                let new_size = st.size;
+                drop(guard);
+                if let Ok(mut pending) = self.pending.lock() {
+                    pending.insert(path, new_size);
+                }
+                Reply::Written(size as u32)
+            }
+
+            // FLUSH (close(2)) and FSYNC both have to make the data durable:
+            // for object storage "durable" means the upload has happened.
+            op::FLUSH | op::FSYNC => {
+                let fh = req.u64_at(0);
+                let Some(path) = self.path_of(req.nodeid) else {
+                    return Reply::Error(libc::ENOENT);
+                };
+                match self.flush_staged(fh, &path, false) {
+                    Ok(()) => Reply::Ok,
+                    Err(e) => Reply::Error(e),
+                }
+            }
+
+            op::RELEASE => {
+                let fh = req.u64_at(0);
+                let Some(path) = self.path_of(req.nodeid) else {
+                    return Reply::Ok;
+                };
+                match self.flush_staged(fh, &path, true) {
+                    Ok(()) => Reply::Ok,
+                    Err(e) => Reply::Error(e),
+                }
+            }
+
+            op::UNLINK => {
+                if let Some(d) = self.deny_if_read_only() {
+                    return d;
+                }
+                let Some(parent) = self.path_of(req.nodeid) else {
+                    return Reply::Error(libc::ENOENT);
+                };
+                let Some(name) = req.name_at(0) else {
+                    return Reply::Error(libc::EINVAL);
+                };
+                let path = Self::join(&parent, &name);
+                match self.client.delete(&path) {
+                    Ok(()) => {
+                        self.forget_path(&path);
+                        Reply::Ok
+                    }
+                    Err(e) => {
+                        tracing::warn!(path, error = %e, "delete failed");
+                        Reply::Error(libc::EIO)
+                    }
+                }
+            }
+
+            // S3 has no directories, so mkdir writes an empty marker object —
+            // the convention every S3 browser understands — and rmdir removes it.
+            op::MKDIR => {
+                if let Some(d) = self.deny_if_read_only() {
+                    return d;
+                }
+                let Some(parent) = self.path_of(req.nodeid) else {
+                    return Reply::Error(libc::ENOENT);
+                };
+                // fuse_mkdir_in: mode(4) umask(4), then name
+                let Some(name) = req.name_at(8) else {
+                    return Reply::Error(libc::EINVAL);
+                };
+                let path = Self::join(&parent, &name);
+                match self.client.put(&format!("{path}/"), b"") {
+                    Ok(()) => Reply::Entry(self.attr_for(self.ino_for(&path), &Node::Dir)),
+                    Err(e) => {
+                        tracing::warn!(path, error = %e, "mkdir failed");
+                        Reply::Error(libc::EIO)
+                    }
+                }
+            }
+
+            op::RMDIR => {
+                if let Some(d) = self.deny_if_read_only() {
+                    return d;
+                }
+                let Some(parent) = self.path_of(req.nodeid) else {
+                    return Reply::Error(libc::ENOENT);
+                };
+                let Some(name) = req.name_at(0) else {
+                    return Reply::Error(libc::EINVAL);
+                };
+                let path = Self::join(&parent, &name);
+                match self.client.list_dir(&path) {
+                    Ok(l) if !l.objects.is_empty() || !l.prefixes.is_empty() => {
+                        Reply::Error(libc::ENOTEMPTY)
+                    }
+                    _ => match self.client.delete(&format!("{path}/")) {
+                        Ok(()) => {
+                            self.forget_path(&path);
+                            Reply::Ok
+                        }
+                        Err(_) => Reply::Error(libc::EIO),
+                    },
+                }
+            }
+
+            // S3 cannot rename; copy-then-delete is the only implementation.
+            op::RENAME => {
+                if let Some(d) = self.deny_if_read_only() {
+                    return d;
+                }
+                let Some(parent) = self.path_of(req.nodeid) else {
+                    return Reply::Error(libc::ENOENT);
+                };
+                let newdir = req.u64_at(0);
+                let Some(old_name) = req.name_at(8) else {
+                    return Reply::Error(libc::EINVAL);
+                };
+                let Some(new_name) = req.name_at(8 + old_name.len() + 1) else {
+                    return Reply::Error(libc::EINVAL);
+                };
+                let Some(new_parent) = self.path_of(newdir) else {
+                    return Reply::Error(libc::ENOENT);
+                };
+                let from = Self::join(&parent, &old_name);
+                let to = Self::join(&new_parent, &new_name);
+                let bytes = match self.client.get(&from, None) {
+                    Ok(b) => b,
+                    Err(_) => return Reply::Error(libc::ENOENT),
+                };
+                if self.client.put(&to, &bytes).is_err() {
+                    return Reply::Error(libc::EIO);
+                }
+                let _ = self.client.delete(&from);
+                self.forget_path(&from);
+                Reply::Ok
+            }
+
+            // Object stores have no fixed capacity; report a large, constant
+            // pool so tools that pre-check free space proceed.
+            op::STATFS => Reply::StatFs {
+                blocks: 1 << 40,
+                bfree: 1 << 40,
+                bavail: 1 << 40,
+                files: 1 << 20,
+            },
+
+            // Answering ENOSYS makes the kernel stop asking for these entirely.
+            op::GETXATTR | op::SETXATTR | op::LISTXATTR | op::REMOVEXATTR | op::LSEEK => {
+                Reply::Error(libc::ENOSYS)
+            }
+
+            op::DESTROY => Reply::Ok,
+
+            _ => Reply::Error(libc::ENOSYS),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fs() -> S3Fs {
+        let dir = std::env::temp_dir().join(format!("s3fs-test-{}", std::process::id()));
+        S3Fs::new(
+            s3::Client::new(s3::Config {
+                endpoint: "http://127.0.0.1:1".into(),
+                region: "us-east-1".into(),
+                bucket: "b".into(),
+                prefix: String::new(),
+                credentials: None,
+                path_style: true,
+                timeout: std::time::Duration::from_millis(50),
+            }),
+            false,
+            dir,
+        )
+        .expect("scratch dir is creatable")
+    }
+
+    #[test]
+    fn inodes_are_stable_per_path_and_unique_across_paths() {
+        let fs = fs();
+        let a1 = fs.ino_for("data/a.txt");
+        let a2 = fs.ino_for("data/a.txt");
+        let b = fs.ino_for("data/b.txt");
+        assert_eq!(
+            a1, a2,
+            "the kernel caches by inode; a path must keep its number"
+        );
+        assert_ne!(a1, b);
+        assert_eq!(fs.path_of(a1).as_deref(), Some("data/a.txt"));
+    }
+
+    #[test]
+    fn the_root_inode_maps_to_the_empty_path() {
+        let fs = fs();
+        assert_eq!(fs.path_of(FUSE_ROOT_ID).as_deref(), Some(""));
+        assert!(matches!(fs.stat(""), Some(Node::Dir)));
+    }
+
+    #[test]
+    fn joining_handles_the_root_without_a_leading_slash() {
+        assert_eq!(S3Fs::join("", "a.txt"), "a.txt");
+        assert_eq!(S3Fs::join("data", "a.txt"), "data/a.txt");
+    }
+
+    #[test]
+    fn directories_and_files_get_the_modes_posix_expects() {
+        let fs = fs();
+        let d = fs.attr_for(2, &Node::Dir);
+        assert_eq!(d.mode & 0o170000, 0o040000, "S_IFDIR");
+        assert_eq!(d.nlink, 2);
+        let f = fs.attr_for(
+            3,
+            &Node::File {
+                size: 1000,
+                mtime: 5,
+            },
+        );
+        assert_eq!(f.mode & 0o170000, 0o100000, "S_IFREG");
+        assert_eq!(f.size, 1000);
+        assert_eq!(f.blocks, 2, "1000 bytes rounds up to two 512-byte blocks");
+    }
+
+    #[test]
+    fn a_read_only_mount_refuses_every_mutating_operation() {
+        let dir = std::env::temp_dir().join(format!("s3fs-ro-{}", std::process::id()));
+        let ro = S3Fs::new(
+            s3::Client::new(s3::Config {
+                endpoint: "http://127.0.0.1:1".into(),
+                region: "us-east-1".into(),
+                bucket: "b".into(),
+                prefix: String::new(),
+                credentials: None,
+                path_style: true,
+                timeout: std::time::Duration::from_millis(50),
+            }),
+            true,
+            dir,
+        )
+        .unwrap();
+        for opcode in [
+            fuse::op::WRITE,
+            fuse::op::CREATE,
+            fuse::op::UNLINK,
+            fuse::op::MKDIR,
+            fuse::op::RMDIR,
+        ] {
+            let req = Request {
+                opcode,
+                unique: 1,
+                nodeid: FUSE_ROOT_ID,
+                uid: 0,
+                gid: 0,
+                data: &[0u8; 64],
+            };
+            assert!(
+                matches!(ro.dispatch(&req), Reply::Error(libc::EROFS)),
+                "opcode {opcode} must be refused on a read-only mount"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_opcodes_report_enosys_rather_than_hanging() {
+        let fs = fs();
+        let req = Request {
+            opcode: 9999,
+            unique: 1,
+            nodeid: FUSE_ROOT_ID,
+            uid: 0,
+            gid: 0,
+            data: &[],
+        };
+        assert!(matches!(fs.dispatch(&req), Reply::Error(libc::ENOSYS)));
+    }
+
+    #[test]
+    fn statfs_reports_a_pool_large_enough_not_to_block_writers() {
+        let fs = fs();
+        let req = Request {
+            opcode: fuse::op::STATFS,
+            unique: 1,
+            nodeid: FUSE_ROOT_ID,
+            uid: 0,
+            gid: 0,
+            data: &[],
+        };
+        match fs.dispatch(&req) {
+            Reply::StatFs { bavail, .. } => assert!(bavail > 1 << 30),
+            _ => panic!("statfs must not fail"),
+        }
+    }
+}

--- a/crates/smolvm-s3fs/src/fs.rs
+++ b/crates/smolvm-s3fs/src/fs.rs
@@ -41,6 +41,9 @@ const FATTR_FH: u32 = 1 << 6;
 struct Staged {
     file: std::fs::File,
     path: std::path::PathBuf,
+    /// Object key this handle stages, so a truncate that arrives without a
+    /// file handle can still find the staging files it has to resize.
+    key: String,
     size: u64,
     dirty: bool,
 }
@@ -246,6 +249,7 @@ impl S3Fs {
                 Staged {
                     file,
                     path: spath,
+                    key: path.to_string(),
                     size,
                     dirty: truncate,
                 },
@@ -266,18 +270,29 @@ impl S3Fs {
     /// program that rewrites a file with fewer bytes would leave the previous
     /// tail in place and read back a mix of old and new data.
     fn truncate(&self, path: &str, fh: Option<u64>, size: u64) -> Result<(), i32> {
-        if let Some(fh) = fh {
-            if let Ok(mut guard) = self.staged.lock() {
-                if let Some(st) = guard.get_mut(&fh) {
-                    st.file.set_len(size).map_err(|_| libc::EIO)?;
-                    st.size = size;
-                    st.dirty = true;
-                    if let Ok(mut pending) = self.pending.lock() {
-                        pending.insert(path.to_string(), size);
-                    }
-                    return Ok(());
+        let mut staged_any = false;
+        if let Ok(mut guard) = self.staged.lock() {
+            // Resize every open handle on this object, not only the one the
+            // request names. An `O_TRUNC` open arrives as a truncate with no
+            // file handle while a staging file is already open, and leaving
+            // that staging file at its old length puts the stale tail back
+            // over the new contents at flush — the file reads correctly
+            // through the mount while the stored object is corrupt.
+            for (handle, st) in guard.iter_mut() {
+                if st.key != path && Some(*handle) != fh {
+                    continue;
                 }
+                st.file.set_len(size).map_err(|_| libc::EIO)?;
+                st.size = size;
+                st.dirty = true;
+                staged_any = true;
             }
+        }
+        if staged_any {
+            if let Ok(mut pending) = self.pending.lock() {
+                pending.insert(path.to_string(), size);
+            }
+            return Ok(());
         }
         // No open handle: rewrite the object at its new length. Growing pads
         // with zeroes, which is what a sparse-less truncate(2) produces.

--- a/crates/smolvm-s3fs/src/fuse.rs
+++ b/crates/smolvm-s3fs/src/fuse.rs
@@ -1,0 +1,482 @@
+//! FUSE transport: mount, wire protocol, and the request loop.
+//!
+//! Talks the kernel protocol directly over `/dev/fuse` and mounts with
+//! `mount(2)`. There is deliberately no libfuse and no `fusermount3`: the agent
+//! runs as root (PID 1) in the guest, so it can mount without the setuid helper
+//! that exists for unprivileged users. That is what lets a bucket be mounted
+//! into *any* image — including distroless and scratch, where no helper binary
+//! or package manager exists.
+
+#[cfg(target_os = "linux")]
+use std::fs::{File, OpenOptions};
+#[cfg(target_os = "linux")]
+use std::io::{Read, Write};
+#[cfg(target_os = "linux")]
+use std::os::unix::fs::OpenOptionsExt;
+#[cfg(target_os = "linux")]
+use std::os::unix::io::AsRawFd;
+#[cfg(target_os = "linux")]
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(target_os = "linux")]
+use std::sync::Arc;
+
+pub const FUSE_ROOT_ID: u64 = 1;
+
+// Opcodes we handle; everything else is answered ENOSYS.
+pub mod op {
+    pub const LOOKUP: u32 = 1;
+    pub const FORGET: u32 = 2;
+    pub const GETATTR: u32 = 3;
+    pub const SETATTR: u32 = 4;
+    pub const MKDIR: u32 = 9;
+    pub const UNLINK: u32 = 10;
+    pub const RMDIR: u32 = 11;
+    pub const RENAME: u32 = 12;
+    pub const OPEN: u32 = 14;
+    pub const READ: u32 = 15;
+    pub const WRITE: u32 = 16;
+    pub const STATFS: u32 = 17;
+    pub const RELEASE: u32 = 18;
+    pub const FSYNC: u32 = 20;
+    pub const SETXATTR: u32 = 21;
+    pub const GETXATTR: u32 = 22;
+    pub const LISTXATTR: u32 = 23;
+    pub const REMOVEXATTR: u32 = 24;
+    pub const FLUSH: u32 = 25;
+    pub const INIT: u32 = 26;
+    pub const OPENDIR: u32 = 27;
+    pub const READDIR: u32 = 28;
+    pub const RELEASEDIR: u32 = 29;
+    pub const FSYNCDIR: u32 = 30;
+    pub const CREATE: u32 = 35;
+    pub const DESTROY: u32 = 38;
+    pub const LSEEK: u32 = 46;
+}
+
+/// File attributes, in the order `fuse_attr` declares them.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Attr {
+    pub ino: u64,
+    pub size: u64,
+    pub blocks: u64,
+    pub atime: u64,
+    pub mtime: u64,
+    pub ctime: u64,
+    pub mode: u32,
+    pub nlink: u32,
+    pub uid: u32,
+    pub gid: u32,
+}
+
+impl Attr {
+    fn encode(&self, out: &mut Vec<u8>) {
+        out.extend_from_slice(&self.ino.to_ne_bytes());
+        out.extend_from_slice(&self.size.to_ne_bytes());
+        out.extend_from_slice(&self.blocks.to_ne_bytes());
+        out.extend_from_slice(&self.atime.to_ne_bytes());
+        out.extend_from_slice(&self.mtime.to_ne_bytes());
+        out.extend_from_slice(&self.ctime.to_ne_bytes());
+        out.extend_from_slice(&0u32.to_ne_bytes()); // atimensec
+        out.extend_from_slice(&0u32.to_ne_bytes()); // mtimensec
+        out.extend_from_slice(&0u32.to_ne_bytes()); // ctimensec
+        out.extend_from_slice(&self.mode.to_ne_bytes());
+        out.extend_from_slice(&self.nlink.to_ne_bytes());
+        out.extend_from_slice(&self.uid.to_ne_bytes());
+        out.extend_from_slice(&self.gid.to_ne_bytes());
+        out.extend_from_slice(&0u32.to_ne_bytes()); // rdev
+        out.extend_from_slice(&4096u32.to_ne_bytes()); // blksize
+        out.extend_from_slice(&0u32.to_ne_bytes()); // flags
+    }
+}
+
+/// A parsed request handed to the filesystem.
+pub struct Request<'a> {
+    pub opcode: u32,
+    pub unique: u64,
+    pub nodeid: u64,
+    pub uid: u32,
+    pub gid: u32,
+    pub data: &'a [u8],
+}
+
+impl Request<'_> {
+    /// NUL-terminated name at `offset`, as LOOKUP/CREATE/MKDIR carry.
+    pub fn name_at(&self, offset: usize) -> Option<String> {
+        let rest = self.data.get(offset..)?;
+        let end = rest.iter().position(|b| *b == 0)?;
+        std::str::from_utf8(&rest[..end])
+            .ok()
+            .map(|s| s.to_string())
+    }
+
+    pub fn u32_at(&self, offset: usize) -> u32 {
+        self.data
+            .get(offset..offset + 4)
+            .and_then(|b| b.try_into().ok())
+            .map(u32::from_ne_bytes)
+            .unwrap_or(0)
+    }
+
+    pub fn u64_at(&self, offset: usize) -> u64 {
+        self.data
+            .get(offset..offset + 8)
+            .and_then(|b| b.try_into().ok())
+            .map(u64::from_ne_bytes)
+            .unwrap_or(0)
+    }
+}
+
+/// Replies a handler can produce. Keeping this an enum (rather than letting
+/// handlers write to the device) means the loop owns all framing, so a handler
+/// can never emit a malformed or duplicate reply.
+pub enum Reply {
+    Ok,
+    Error(i32),
+    Attr(Attr),
+    /// (attr, generation) for LOOKUP-style replies.
+    Entry(Attr),
+    /// CREATE answers with both the new entry and an open file handle.
+    Create(Attr, u64),
+    Open(u64),
+    Data(Vec<u8>),
+    Written(u32),
+    Directory(Vec<u8>),
+    StatFs {
+        blocks: u64,
+        bfree: u64,
+        bavail: u64,
+        files: u64,
+    },
+}
+
+/// What the session calls for each request.
+pub trait Filesystem: Send + Sync {
+    fn dispatch(&self, req: &Request<'_>) -> Reply;
+}
+
+/// An active mount. Dropping it unmounts.
+///
+/// Linux-only: the mount(2) signature and MS_* flags are Linux's. The protocol
+/// encoding above stays portable so it can be unit-tested anywhere.
+#[cfg(target_os = "linux")]
+pub struct Session {
+    dev: File,
+    mountpoint: std::ffi::CString,
+    stop: Arc<AtomicBool>,
+}
+
+#[cfg(target_os = "linux")]
+impl Session {
+    /// Mount at `mountpoint` and return the session.
+    ///
+    /// `read_only` maps to `MS_RDONLY`, so the kernel itself rejects writes and
+    /// the filesystem never sees them — cheaper and more trustworthy than
+    /// checking a flag in every handler.
+    pub fn mount(mountpoint: &str, read_only: bool, allow_other: bool) -> std::io::Result<Self> {
+        std::fs::create_dir_all(mountpoint)?;
+
+        // Minimal images have no /dev/fuse; as root we can create it.
+        if !std::path::Path::new("/dev/fuse").exists() {
+            let path = std::ffi::CString::new("/dev/fuse").expect("static string");
+            let rc = unsafe {
+                libc::mknod(path.as_ptr(), libc::S_IFCHR | 0o600, libc::makedev(10, 229))
+            };
+            if rc != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+        }
+
+        let dev = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .custom_flags(libc::O_CLOEXEC)
+            .open("/dev/fuse")?;
+
+        let mut opts = format!(
+            "fd={},rootmode=40000,user_id=0,group_id=0,default_permissions",
+            dev.as_raw_fd()
+        );
+        if allow_other {
+            opts.push_str(",allow_other");
+        }
+
+        let target = std::ffi::CString::new(mountpoint)?;
+        let source = std::ffi::CString::new("s3")?;
+        let fstype = std::ffi::CString::new("fuse")?;
+        let copts = std::ffi::CString::new(opts)?;
+        let mut flags = libc::MS_NOSUID | libc::MS_NODEV;
+        if read_only {
+            flags |= libc::MS_RDONLY;
+        }
+        let rc = unsafe {
+            libc::mount(
+                source.as_ptr(),
+                target.as_ptr(),
+                fstype.as_ptr(),
+                flags as libc::c_ulong,
+                copts.as_ptr() as *const libc::c_void,
+            )
+        };
+        if rc != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        Ok(Self {
+            dev,
+            mountpoint: target,
+            stop: Arc::new(AtomicBool::new(false)),
+        })
+    }
+
+    /// Handle requests until the filesystem is unmounted.
+    pub fn run(&mut self, fs: &dyn Filesystem) {
+        // One read must hold a full write payload plus header; the kernel
+        // rejects a smaller buffer at INIT time.
+        let mut buf = vec![0u8; 1024 * 1024 + 4096];
+        while !self.stop.load(Ordering::Relaxed) {
+            let n = match self.dev.read(&mut buf) {
+                Ok(0) => return,
+                Ok(n) => n,
+                Err(e) => match e.raw_os_error() {
+                    // The kernel interrupts blocking reads on unmount/signals.
+                    Some(libc::EINTR) | Some(libc::EAGAIN) => continue,
+                    // ENODEV means the filesystem was unmounted: a clean exit.
+                    Some(libc::ENODEV) => return,
+                    _ => return,
+                },
+            };
+            if n < 40 {
+                continue;
+            }
+            let opcode = u32::from_ne_bytes(buf[4..8].try_into().unwrap());
+            let unique = u64::from_ne_bytes(buf[8..16].try_into().unwrap());
+            let nodeid = u64::from_ne_bytes(buf[16..24].try_into().unwrap());
+            let uid = u32::from_ne_bytes(buf[24..28].try_into().unwrap());
+            let gid = u32::from_ne_bytes(buf[28..32].try_into().unwrap());
+
+            if opcode == op::INIT {
+                self.reply_init(unique, &buf[40..n]);
+                continue;
+            }
+            // FORGET expects no reply at all; answering it corrupts the stream.
+            if opcode == op::FORGET {
+                continue;
+            }
+
+            let req = Request {
+                opcode,
+                unique,
+                nodeid,
+                uid,
+                gid,
+                data: &buf[40..n],
+            };
+            let reply = fs.dispatch(&req);
+            self.send(unique, reply);
+        }
+    }
+
+    fn reply_init(&mut self, unique: u64, data: &[u8]) {
+        let major = u32::from_ne_bytes(data[0..4].try_into().unwrap_or([0; 4]));
+        let minor = u32::from_ne_bytes(data[4..8].try_into().unwrap_or([0; 4]));
+        let mut b = Vec::new();
+        b.extend_from_slice(&7u32.to_ne_bytes()); // major we speak
+        b.extend_from_slice(&(minor.min(31)).to_ne_bytes());
+        b.extend_from_slice(&(128u32 * 1024).to_ne_bytes()); // max_readahead
+        b.extend_from_slice(&0u32.to_ne_bytes()); // flags: opt into nothing
+        b.extend_from_slice(&0u16.to_ne_bytes()); // max_background
+        b.extend_from_slice(&0u16.to_ne_bytes()); // congestion_threshold
+        b.extend_from_slice(&(1024u32 * 1024).to_ne_bytes()); // max_write
+        b.extend_from_slice(&0u32.to_ne_bytes()); // time_gran
+        b.extend_from_slice(&0u16.to_ne_bytes()); // max_pages
+        b.extend_from_slice(&0u16.to_ne_bytes()); // map_alignment
+        b.resize(b.len() + 8 * 4, 0); // reserved
+        let _ = major;
+        self.raw_reply(unique, 0, &b);
+    }
+
+    fn send(&mut self, unique: u64, reply: Reply) {
+        match reply {
+            Reply::Ok => self.raw_reply(unique, 0, &[]),
+            Reply::Error(e) => self.raw_reply(unique, -e, &[]),
+            Reply::Attr(a) => {
+                let mut b = Vec::new();
+                b.extend_from_slice(&1u64.to_ne_bytes()); // attr_valid secs
+                b.extend_from_slice(&0u32.to_ne_bytes()); // attr_valid nsec
+                b.extend_from_slice(&0u32.to_ne_bytes()); // dummy
+                a.encode(&mut b);
+                self.raw_reply(unique, 0, &b);
+            }
+            Reply::Entry(a) => {
+                let mut b = Vec::new();
+                Self::encode_entry(&mut b, &a);
+                self.raw_reply(unique, 0, &b);
+            }
+            Reply::Create(a, fh) => {
+                let mut b = Vec::new();
+                Self::encode_entry(&mut b, &a);
+                b.extend_from_slice(&fh.to_ne_bytes());
+                b.extend_from_slice(&0u32.to_ne_bytes()); // open_flags
+                b.extend_from_slice(&0u32.to_ne_bytes()); // padding
+                self.raw_reply(unique, 0, &b);
+            }
+            Reply::Open(fh) => {
+                let mut b = Vec::new();
+                b.extend_from_slice(&fh.to_ne_bytes());
+                b.extend_from_slice(&0u32.to_ne_bytes()); // open_flags
+                b.extend_from_slice(&0u32.to_ne_bytes()); // padding
+                self.raw_reply(unique, 0, &b);
+            }
+            Reply::Data(d) | Reply::Directory(d) => self.raw_reply(unique, 0, &d),
+            Reply::Written(n) => {
+                let mut b = Vec::new();
+                b.extend_from_slice(&n.to_ne_bytes());
+                b.extend_from_slice(&0u32.to_ne_bytes());
+                self.raw_reply(unique, 0, &b);
+            }
+            Reply::StatFs {
+                blocks,
+                bfree,
+                bavail,
+                files,
+            } => {
+                let mut b = Vec::new();
+                b.extend_from_slice(&blocks.to_ne_bytes());
+                b.extend_from_slice(&bfree.to_ne_bytes());
+                b.extend_from_slice(&bavail.to_ne_bytes());
+                b.extend_from_slice(&files.to_ne_bytes());
+                b.extend_from_slice(&files.to_ne_bytes()); // ffree
+                b.extend_from_slice(&4096u32.to_ne_bytes()); // bsize
+                b.extend_from_slice(&255u32.to_ne_bytes()); // namelen
+                b.extend_from_slice(&4096u32.to_ne_bytes()); // frsize
+                b.extend_from_slice(&0u32.to_ne_bytes()); // padding
+                b.resize(b.len() + 6 * 4, 0); // spare
+                self.raw_reply(unique, 0, &b);
+            }
+        }
+    }
+
+    fn encode_entry(b: &mut Vec<u8>, a: &Attr) {
+        b.extend_from_slice(&a.ino.to_ne_bytes()); // nodeid
+        b.extend_from_slice(&0u64.to_ne_bytes()); // generation
+        b.extend_from_slice(&1u64.to_ne_bytes()); // entry_valid
+        b.extend_from_slice(&1u64.to_ne_bytes()); // attr_valid
+        b.extend_from_slice(&0u32.to_ne_bytes()); // entry_valid_nsec
+        b.extend_from_slice(&0u32.to_ne_bytes()); // attr_valid_nsec
+        a.encode(b);
+    }
+
+    fn raw_reply(&mut self, unique: u64, error: i32, body: &[u8]) {
+        let len = (16 + body.len()) as u32;
+        let mut out = Vec::with_capacity(len as usize);
+        out.extend_from_slice(&len.to_ne_bytes());
+        out.extend_from_slice(&error.to_ne_bytes());
+        out.extend_from_slice(&unique.to_ne_bytes());
+        out.extend_from_slice(body);
+        // A failed reply means the mount is gone; the read loop will notice.
+        let _ = self.dev.write(&out);
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for Session {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        // Lazy unmount: detach now even if a handler is mid-flight, so a stuck
+        // request cannot leave a wedged mountpoint behind in the container.
+        unsafe { libc::umount2(self.mountpoint.as_ptr(), libc::MNT_DETACH) };
+    }
+}
+
+/// Append one entry to a READDIR reply buffer.
+///
+/// Returns false when the entry would exceed `max`, which is the caller's
+/// signal to stop and let the kernel ask again from `offset`.
+pub fn push_dirent(
+    buf: &mut Vec<u8>,
+    max: usize,
+    ino: u64,
+    offset: u64,
+    kind: u32,
+    name: &str,
+) -> bool {
+    let padded = (name.len() + 7) & !7;
+    if buf.len() + 24 + padded > max {
+        return false;
+    }
+    buf.extend_from_slice(&ino.to_ne_bytes());
+    buf.extend_from_slice(&offset.to_ne_bytes());
+    buf.extend_from_slice(&(name.len() as u32).to_ne_bytes());
+    buf.extend_from_slice(&kind.to_ne_bytes());
+    buf.extend_from_slice(name.as_bytes());
+    buf.resize(buf.len() + padded - name.len(), 0);
+    true
+}
+
+pub const DT_DIR: u32 = 4;
+pub const DT_REG: u32 = 8;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dirents_are_eight_byte_aligned_and_bounded() {
+        let mut buf = Vec::new();
+        assert!(push_dirent(&mut buf, 4096, 2, 1, DT_REG, "a.txt"));
+        assert_eq!(buf.len() % 8, 0, "the kernel requires 8-byte alignment");
+        let before = buf.len();
+        // A tiny budget must refuse rather than emit a truncated entry.
+        assert!(!push_dirent(&mut buf, before + 4, 3, 2, DT_REG, "b.txt"));
+        assert_eq!(
+            buf.len(),
+            before,
+            "a refused entry must not be partially written"
+        );
+    }
+
+    #[test]
+    fn attrs_encode_to_the_kernels_expected_width() {
+        let mut out = Vec::new();
+        Attr {
+            ino: 1,
+            mode: 0o040755,
+            nlink: 2,
+            ..Default::default()
+        }
+        .encode(&mut out);
+        // fuse_attr is 88 bytes on every arch we target.
+        assert_eq!(out.len(), 88);
+    }
+
+    #[test]
+    fn request_field_readers_handle_short_payloads() {
+        let req = Request {
+            opcode: 0,
+            unique: 0,
+            nodeid: 0,
+            uid: 0,
+            gid: 0,
+            data: &[1, 0, 0, 0],
+        };
+        assert_eq!(req.u32_at(0), 1);
+        // Reading past the end must not panic — a malformed request from the
+        // kernel (or a short read) should degrade, not crash the mount.
+        assert_eq!(req.u64_at(0), 0);
+        assert_eq!(req.u32_at(64), 0);
+    }
+
+    #[test]
+    fn names_stop_at_the_nul_terminator() {
+        let req = Request {
+            opcode: 0,
+            unique: 0,
+            nodeid: 0,
+            uid: 0,
+            gid: 0,
+            data: b"hello.txt\0trailing",
+        };
+        assert_eq!(req.name_at(0).as_deref(), Some("hello.txt"));
+        assert_eq!(req.name_at(100), None);
+    }
+}

--- a/crates/smolvm-s3fs/src/fuse.rs
+++ b/crates/smolvm-s3fs/src/fuse.rs
@@ -69,6 +69,12 @@ pub struct Attr {
 }
 
 impl Attr {
+    /// Serialise into the kernel's `fuse_attr` layout.
+    ///
+    /// Only a mounted session replies to the kernel, and that is Linux-only, so
+    /// off Linux the sole caller is the layout test — without this gate the
+    /// method reads as dead code and fails a `-D warnings` build there.
+    #[cfg(any(target_os = "linux", test))]
     fn encode(&self, out: &mut Vec<u8>) {
         out.extend_from_slice(&self.ino.to_ne_bytes());
         out.extend_from_slice(&self.size.to_ne_bytes());

--- a/crates/smolvm-s3fs/src/lib.rs
+++ b/crates/smolvm-s3fs/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod s3;
+pub mod sigv4;

--- a/crates/smolvm-s3fs/src/lib.rs
+++ b/crates/smolvm-s3fs/src/lib.rs
@@ -1,2 +1,65 @@
+//! Mount an S3-compatible bucket as a POSIX filesystem.
+//!
+//! Self-contained by design: no libfuse, no `fusermount3`, no external binary,
+//! and no async runtime. A privileged process can mount a bucket into any
+//! filesystem — including a distroless or scratch container image, where no
+//! helper could be installed.
+//!
+//! ```ignore
+//! # use std::time::Duration;
+//! use smolvm_s3fs::{mount, MountOptions, s3, sigv4};
+//!
+//! let cfg = s3::Config {
+//!     endpoint: "https://s3.us-east-1.amazonaws.com".into(),
+//!     region: "us-east-1".into(),
+//!     bucket: "my-bucket".into(),
+//!     prefix: String::new(),
+//!     credentials: Some(sigv4::Credentials {
+//!         access_key_id: "AKIA…".into(),
+//!         secret_access_key: "…".into(),
+//!         session_token: None,
+//!     }),
+//!     path_style: true,
+//!     timeout: Duration::from_secs(30),
+//! };
+//! mount(cfg, MountOptions { mountpoint: "/mnt/data".into(), ..Default::default() })?;
+//! # Ok::<(), std::io::Error>(())
+//! ```
+
+pub mod fs;
+pub mod fuse;
 pub mod s3;
 pub mod sigv4;
+
+/// How to mount.
+#[derive(Clone, Debug)]
+pub struct MountOptions {
+    pub mountpoint: String,
+    pub read_only: bool,
+    /// Let users other than the mounting one see the mount. Needed when the
+    /// workload runs as a non-root user inside the container.
+    pub allow_other: bool,
+    /// Where in-flight writes are staged before upload.
+    pub scratch_dir: std::path::PathBuf,
+}
+
+impl Default for MountOptions {
+    fn default() -> Self {
+        Self {
+            mountpoint: String::new(),
+            read_only: false,
+            allow_other: true,
+            scratch_dir: std::path::PathBuf::from("/var/tmp/smolvm-s3fs"),
+        }
+    }
+}
+
+/// Mount and serve until unmounted. Blocks; callers run it on its own thread.
+#[cfg(target_os = "linux")]
+pub fn mount(cfg: s3::Config, opts: MountOptions) -> std::io::Result<()> {
+    let client = s3::Client::new(cfg);
+    let filesystem = fs::S3Fs::new(client, opts.read_only, opts.scratch_dir)?;
+    let mut session = fuse::Session::mount(&opts.mountpoint, opts.read_only, opts.allow_other)?;
+    session.run(&filesystem);
+    Ok(())
+}

--- a/crates/smolvm-s3fs/src/s3.rs
+++ b/crates/smolvm-s3fs/src/s3.rs
@@ -399,7 +399,7 @@ fn unescape(s: &str) -> String {
 }
 
 fn is_leap(y: u64) -> bool {
-    (y % 4 == 0 && y % 100 != 0) || y % 400 == 0
+    (y.is_multiple_of(4) && !y.is_multiple_of(100)) || y.is_multiple_of(400)
 }
 
 fn days_in_month(y: u64, m: u64) -> u64 {

--- a/crates/smolvm-s3fs/src/s3.rs
+++ b/crates/smolvm-s3fs/src/s3.rs
@@ -1,0 +1,557 @@
+//! Minimal S3 client: only the operations a filesystem needs.
+//!
+//! Deliberately not an SDK. The agent is a static binary in the guest rootfs,
+//! so every dependency is paid for on every machine; `ureq` is blocking (the
+//! agent has no async runtime) and, with rustls, costs under a megabyte where
+//! an SDK plus tokio would cost tens.
+
+use std::io::Read;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use crate::sigv4::{self, Credentials, SignRequest, EMPTY_SHA256, UNSIGNED_PAYLOAD};
+
+#[derive(Debug)]
+pub enum Error {
+    /// Transport or TLS failure.
+    Transport(String),
+    /// S3 answered with a non-2xx status; `code` is the parsed `<Code>` when present.
+    Status {
+        status: u16,
+        code: String,
+        message: String,
+    },
+    Parse(String),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Transport(e) => write!(f, "transport: {e}"),
+            Error::Status {
+                status,
+                code,
+                message,
+            } => {
+                if code.is_empty() {
+                    write!(f, "http {status}")
+                } else {
+                    write!(f, "http {status} {code}: {message}")
+                }
+            }
+            Error::Parse(e) => write!(f, "parse: {e}"),
+        }
+    }
+}
+impl std::error::Error for Error {}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// How to reach one bucket.
+#[derive(Clone, Debug)]
+pub struct Config {
+    /// e.g. `https://s3.us-east-1.amazonaws.com` or `http://127.0.0.1:9000`.
+    pub endpoint: String,
+    pub region: String,
+    pub bucket: String,
+    /// Optional key prefix so a mount can expose a sub-tree of a bucket.
+    pub prefix: String,
+    pub credentials: Option<Credentials>,
+    /// Path-style addressing (`endpoint/bucket/key`). Required by MinIO and most
+    /// S3-compatible servers; AWS accepts it too, so it is the default.
+    pub path_style: bool,
+    pub timeout: Duration,
+}
+
+/// One object as returned by a listing.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ObjectInfo {
+    /// Key relative to the mount prefix.
+    pub key: String,
+    pub size: u64,
+    pub last_modified_secs: u64,
+}
+
+/// Result of listing one "directory" level.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Listing {
+    pub objects: Vec<ObjectInfo>,
+    /// Sub-prefixes, i.e. child directories (without the trailing `/`).
+    pub prefixes: Vec<String>,
+}
+
+pub struct Client {
+    cfg: Config,
+    agent: ureq::Agent,
+}
+
+impl Client {
+    pub fn new(cfg: Config) -> Self {
+        let agent = ureq::AgentBuilder::new()
+            .timeout(cfg.timeout)
+            .user_agent(concat!("smolvm-s3fs/", env!("CARGO_PKG_VERSION")))
+            .build();
+        Self { cfg, agent }
+    }
+
+    pub fn config(&self) -> &Config {
+        &self.cfg
+    }
+
+    /// Full key for a mount-relative path, applying the configured prefix.
+    fn full_key(&self, rel: &str) -> String {
+        let rel = rel.trim_start_matches('/');
+        if self.cfg.prefix.is_empty() {
+            rel.to_string()
+        } else {
+            format!("{}/{}", self.cfg.prefix.trim_matches('/'), rel)
+        }
+    }
+
+    fn url_for(&self, key: &str) -> (String, String) {
+        let enc = sigv4::uri_encode(key, false);
+        if self.cfg.path_style {
+            let path = format!("/{}/{}", self.cfg.bucket, enc);
+            (
+                format!("{}{}", self.cfg.endpoint.trim_end_matches('/'), path),
+                path,
+            )
+        } else {
+            let path = format!("/{enc}");
+            let host = self
+                .cfg
+                .endpoint
+                .trim_end_matches('/')
+                .replace("://", &format!("://{}.", self.cfg.bucket));
+            (format!("{host}{path}"), path)
+        }
+    }
+
+    fn host_of(url: &str) -> String {
+        url.split("://")
+            .nth(1)
+            .unwrap_or(url)
+            .split('/')
+            .next()
+            .unwrap_or("")
+            .to_string()
+    }
+
+    fn now() -> (String, String) {
+        let secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        (format_date(secs), format_datetime(secs))
+    }
+
+    /// Build, sign and send. `body` is `None` for bodyless verbs.
+    fn send(
+        &self,
+        method: &str,
+        key: &str,
+        query: &[(String, String)],
+        mut headers: Vec<(String, String)>,
+        body: Option<&[u8]>,
+    ) -> Result<ureq::Response> {
+        let (url, path) = self.url_for(key);
+        headers.push(("host".into(), Self::host_of(&url)));
+
+        let payload_hash = match (&self.cfg.credentials, body) {
+            // Anonymous access needs no signature at all.
+            (None, _) => String::new(),
+            (Some(_), Some(b)) => sigv4::sha256_hex(b),
+            (Some(_), None) => EMPTY_SHA256.to_string(),
+        };
+
+        if let Some(creds) = &self.cfg.credentials {
+            let (d, t) = Self::now();
+            sigv4::sign(
+                SignRequest {
+                    method,
+                    path: &path,
+                    query,
+                    headers: &mut headers,
+                    payload_sha256: if payload_hash.is_empty() {
+                        UNSIGNED_PAYLOAD
+                    } else {
+                        &payload_hash
+                    },
+                },
+                creds,
+                &self.cfg.region,
+                (&d, &t),
+            );
+        }
+
+        let qs = query
+            .iter()
+            .map(|(k, v)| {
+                format!(
+                    "{}={}",
+                    sigv4::uri_encode(k, true),
+                    sigv4::uri_encode(v, true)
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("&");
+        let full = if qs.is_empty() {
+            url
+        } else {
+            format!("{url}?{qs}")
+        };
+
+        let mut req = self.agent.request(method, &full);
+        for (k, v) in &headers {
+            // ureq sets Host itself from the URL; re-adding it breaks signing parity.
+            if k.eq_ignore_ascii_case("host") {
+                continue;
+            }
+            req = req.set(k, v);
+        }
+
+        let res = match body {
+            Some(b) => req.send_bytes(b),
+            None => req.call(),
+        };
+        match res {
+            Ok(r) => Ok(r),
+            Err(ureq::Error::Status(status, r)) => {
+                let text = r.into_string().unwrap_or_default();
+                let code = xml_field(&text, "Code").unwrap_or_default();
+                let message = xml_field(&text, "Message").unwrap_or_default();
+                Err(Error::Status {
+                    status,
+                    code,
+                    message,
+                })
+            }
+            Err(e) => Err(Error::Transport(e.to_string())),
+        }
+    }
+
+    /// HEAD one object: size and mtime, or `Ok(None)` when absent.
+    pub fn head(&self, rel: &str) -> Result<Option<ObjectInfo>> {
+        let key = self.full_key(rel);
+        match self.send("HEAD", &key, &[], Vec::new(), None) {
+            Ok(r) => {
+                let size = r
+                    .header("content-length")
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(0);
+                let last_modified_secs = r
+                    .header("last-modified")
+                    .and_then(parse_http_date)
+                    .unwrap_or(0);
+                Ok(Some(ObjectInfo {
+                    key: rel.to_string(),
+                    size,
+                    last_modified_secs,
+                }))
+            }
+            Err(Error::Status { status: 404, .. }) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// GET an object, optionally a byte range (`start`, inclusive `end`).
+    pub fn get(&self, rel: &str, range: Option<(u64, u64)>) -> Result<Vec<u8>> {
+        let key = self.full_key(rel);
+        let mut headers = Vec::new();
+        if let Some((start, end)) = range {
+            headers.push(("range".into(), format!("bytes={start}-{end}")));
+        }
+        let r = self.send("GET", &key, &[], headers, None)?;
+        let mut buf = Vec::with_capacity(
+            r.header("content-length")
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(0),
+        );
+        r.into_reader()
+            .read_to_end(&mut buf)
+            .map_err(|e| Error::Transport(e.to_string()))?;
+        Ok(buf)
+    }
+
+    /// PUT a whole object.
+    pub fn put(&self, rel: &str, body: &[u8]) -> Result<()> {
+        let key = self.full_key(rel);
+        let headers = vec![("content-length".into(), body.len().to_string())];
+        self.send("PUT", &key, &[], headers, Some(body))?;
+        Ok(())
+    }
+
+    pub fn delete(&self, rel: &str) -> Result<()> {
+        let key = self.full_key(rel);
+        match self.send("DELETE", &key, &[], Vec::new(), None) {
+            Ok(_) => Ok(()),
+            // Deleting something already gone is success for a filesystem.
+            Err(Error::Status { status: 404, .. }) => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// List one directory level under `rel` using a delimiter, so the result
+    /// separates child objects from child "directories" the way readdir needs.
+    pub fn list_dir(&self, rel: &str) -> Result<Listing> {
+        let mut prefix = self.full_key(rel);
+        if !prefix.is_empty() && !prefix.ends_with('/') {
+            prefix.push('/');
+        }
+        let mut out = Listing::default();
+        let mut token: Option<String> = None;
+        loop {
+            let mut query = vec![
+                ("list-type".to_string(), "2".to_string()),
+                ("delimiter".to_string(), "/".to_string()),
+                ("max-keys".to_string(), "1000".to_string()),
+            ];
+            if !prefix.is_empty() {
+                query.push(("prefix".to_string(), prefix.clone()));
+            }
+            if let Some(t) = &token {
+                query.push(("continuation-token".to_string(), t.clone()));
+            }
+            // Listing addresses the bucket itself, not a key.
+            let r = self.send("GET", "", &query, Vec::new(), None)?;
+            let body = r
+                .into_string()
+                .map_err(|e| Error::Transport(e.to_string()))?;
+
+            for c in xml_blocks(&body, "Contents") {
+                let Some(key) = xml_field(&c, "Key") else {
+                    continue;
+                };
+                if key == prefix {
+                    continue; // the directory marker itself
+                }
+                let rel_key = key.strip_prefix(&prefix).unwrap_or(&key).to_string();
+                if rel_key.is_empty() {
+                    continue;
+                }
+                out.objects.push(ObjectInfo {
+                    key: rel_key,
+                    size: xml_field(&c, "Size")
+                        .and_then(|s| s.parse().ok())
+                        .unwrap_or(0),
+                    last_modified_secs: xml_field(&c, "LastModified")
+                        .and_then(|s| parse_iso8601(&s))
+                        .unwrap_or(0),
+                });
+            }
+            for p in xml_blocks(&body, "CommonPrefixes") {
+                if let Some(pfx) = xml_field(&p, "Prefix") {
+                    let name = pfx
+                        .strip_prefix(&prefix)
+                        .unwrap_or(&pfx)
+                        .trim_end_matches('/')
+                        .to_string();
+                    if !name.is_empty() {
+                        out.prefixes.push(name);
+                    }
+                }
+            }
+
+            match xml_field(&body, "NextContinuationToken") {
+                Some(t) if xml_field(&body, "IsTruncated").as_deref() == Some("true") => {
+                    token = Some(t)
+                }
+                _ => break,
+            }
+        }
+        Ok(out)
+    }
+}
+
+/// Extract the text of the first `<tag>…</tag>`.
+///
+/// A dependency-free reader rather than a full XML parser: S3's list/error
+/// documents are flat and machine-generated, and a parser crate would cost more
+/// than the ~20 lines it replaces.
+pub(crate) fn xml_field(xml: &str, tag: &str) -> Option<String> {
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+    let start = xml.find(&open)? + open.len();
+    let end = xml[start..].find(&close)? + start;
+    Some(unescape(&xml[start..end]))
+}
+
+/// Every `<tag>…</tag>` block, for repeated elements.
+pub(crate) fn xml_blocks(xml: &str, tag: &str) -> Vec<String> {
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+    let mut out = Vec::new();
+    let mut rest = xml;
+    while let Some(s) = rest.find(&open) {
+        let after = &rest[s + open.len()..];
+        let Some(e) = after.find(&close) else { break };
+        out.push(after[..e].to_string());
+        rest = &after[e + close.len()..];
+    }
+    out
+}
+
+fn unescape(s: &str) -> String {
+    s.replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&apos;", "'")
+}
+
+fn is_leap(y: u64) -> bool {
+    (y % 4 == 0 && y % 100 != 0) || y % 400 == 0
+}
+
+fn days_in_month(y: u64, m: u64) -> u64 {
+    match m {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if is_leap(y) => 29,
+        2 => 28,
+        _ => 30,
+    }
+}
+
+fn ymd_to_days(y: u64, m: u64, d: u64) -> u64 {
+    let mut days = 0;
+    for yy in 1970..y {
+        days += if is_leap(yy) { 366 } else { 365 };
+    }
+    for mm in 1..m {
+        days += days_in_month(y, mm);
+    }
+    days + d - 1
+}
+
+fn civil_from_days(mut days: u64) -> (u64, u64, u64) {
+    let mut y = 1970;
+    loop {
+        let len = if is_leap(y) { 366 } else { 365 };
+        if days < len {
+            break;
+        }
+        days -= len;
+        y += 1;
+    }
+    let mut m = 1;
+    while days >= days_in_month(y, m) {
+        days -= days_in_month(y, m);
+        m += 1;
+    }
+    (y, m, days + 1)
+}
+
+/// `YYYYMMDD` in UTC, as SigV4's credential scope requires.
+pub fn format_date(secs: u64) -> String {
+    let (y, m, d) = civil_from_days(secs / 86400);
+    format!("{y:04}{m:02}{d:02}")
+}
+
+/// `YYYYMMDDTHHMMSSZ` in UTC, as SigV4's `x-amz-date` requires.
+pub fn format_datetime(secs: u64) -> String {
+    let (y, m, d) = civil_from_days(secs / 86400);
+    let rem = secs % 86400;
+    format!(
+        "{y:04}{m:02}{d:02}T{:02}{:02}{:02}Z",
+        rem / 3600,
+        (rem % 3600) / 60,
+        rem % 60
+    )
+}
+
+/// `2006-01-02T15:04:05.000Z` → epoch seconds (listing timestamps).
+fn parse_iso8601(s: &str) -> Option<u64> {
+    let b = s.as_bytes();
+    if b.len() < 19 {
+        return None;
+    }
+    let num = |r: std::ops::Range<usize>| s.get(r).and_then(|x| x.parse::<u64>().ok());
+    let (y, mo, d) = (num(0..4)?, num(5..7)?, num(8..10)?);
+    let (h, mi, sec) = (num(11..13)?, num(14..16)?, num(17..19)?);
+    Some(ymd_to_days(y, mo, d) * 86400 + h * 3600 + mi * 60 + sec)
+}
+
+/// RFC 1123 (`Fri, 24 May 2013 00:00:00 GMT`) → epoch seconds (HEAD responses).
+fn parse_http_date(s: &str) -> Option<u64> {
+    let p: Vec<&str> = s.split_whitespace().collect();
+    if p.len() < 5 {
+        return None;
+    }
+    let d: u64 = p[1].parse().ok()?;
+    let mo = [
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    ]
+    .iter()
+    .position(|m| *m == p[2])? as u64
+        + 1;
+    let y: u64 = p[3].parse().ok()?;
+    let t: Vec<&str> = p[4].split(':').collect();
+    if t.len() != 3 {
+        return None;
+    }
+    let h: u64 = t[0].parse().ok()?;
+    let mi: u64 = t[1].parse().ok()?;
+    let sec: u64 = t[2].parse().ok()?;
+    Some(ymd_to_days(y, mo, d) * 86400 + h * 3600 + mi * 60 + sec)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_a_listing_into_objects_and_child_directories() {
+        let xml = r#"<?xml version="1.0"?><ListBucketResult>
+          <Contents><Key>data/a.txt</Key><Size>12</Size><LastModified>2026-08-23T01:02:03.000Z</LastModified></Contents>
+          <Contents><Key>data/b.bin</Key><Size>4096</Size><LastModified>2026-08-23T01:02:04.000Z</LastModified></Contents>
+          <CommonPrefixes><Prefix>data/sub/</Prefix></CommonPrefixes>
+          <IsTruncated>false</IsTruncated></ListBucketResult>"#;
+        let objs: Vec<_> = xml_blocks(xml, "Contents")
+            .iter()
+            .filter_map(|c| xml_field(c, "Key"))
+            .collect();
+        assert_eq!(objs, vec!["data/a.txt", "data/b.bin"]);
+        let pfx: Vec<_> = xml_blocks(xml, "CommonPrefixes")
+            .iter()
+            .filter_map(|p| xml_field(p, "Prefix"))
+            .collect();
+        assert_eq!(pfx, vec!["data/sub/"]);
+    }
+
+    #[test]
+    fn parses_an_error_document() {
+        let xml = "<Error><Code>NoSuchKey</Code><Message>The key does not exist</Message></Error>";
+        assert_eq!(xml_field(xml, "Code").as_deref(), Some("NoSuchKey"));
+        assert_eq!(
+            xml_field(xml, "Message").as_deref(),
+            Some("The key does not exist")
+        );
+    }
+
+    // Dates feed SigV4's scope; a wrong day silently breaks every signature.
+    #[test]
+    fn formats_the_dates_sigv4_expects() {
+        assert_eq!(format_date(1369353600), "20130524");
+        assert_eq!(format_datetime(1369353600), "20130524T000000Z");
+        assert_eq!(format_datetime(0), "19700101T000000Z");
+    }
+
+    #[test]
+    fn round_trips_listing_and_http_timestamps() {
+        assert_eq!(parse_iso8601("2013-05-24T00:00:00.000Z"), Some(1369353600));
+        assert_eq!(
+            parse_http_date("Fri, 24 May 2013 00:00:00 GMT"),
+            Some(1369353600)
+        );
+        // A leap day, since the civil-date maths is hand-rolled.
+        assert_eq!(parse_iso8601("2024-02-29T12:00:00.000Z"), Some(1709208000));
+    }
+
+    #[test]
+    fn unescapes_xml_entities_in_keys() {
+        assert_eq!(
+            xml_field("<Key>a&amp;b</Key>", "Key").as_deref(),
+            Some("a&b")
+        );
+    }
+}

--- a/crates/smolvm-s3fs/src/sigv4.rs
+++ b/crates/smolvm-s3fs/src/sigv4.rs
@@ -1,0 +1,297 @@
+//! AWS Signature Version 4 for S3 requests.
+//!
+//! Implemented directly rather than pulled from an SDK: the agent is a 1.6 MiB
+//! static binary in the guest rootfs, and the AWS SDK (plus its async runtime)
+//! would dominate that budget. Signing is a well-specified, testable algorithm —
+//! the canonical-request → string-to-sign → derived-key chain below matches the
+//! AWS documentation's own worked examples, which the tests assert against.
+
+use hmac::{Hmac, Mac};
+use sha2::{Digest, Sha256};
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// The payload hash header S3 requires. Streaming uploads use the unsigned
+/// sentinel: we cannot hash a body we have not buffered, and S3 accepts it over
+/// HTTPS (the transport already protects integrity).
+pub const UNSIGNED_PAYLOAD: &str = "UNSIGNED-PAYLOAD";
+pub const EMPTY_SHA256: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+/// Credentials for signing. `session_token` is set when the caller supplies
+/// temporary (STS) credentials, which most workloads on cloud instances use.
+#[derive(Clone, Debug)]
+pub struct Credentials {
+    pub access_key_id: String,
+    pub secret_access_key: String,
+    pub session_token: Option<String>,
+}
+
+/// A request to sign, reduced to the parts SigV4 covers.
+pub struct SignRequest<'a> {
+    pub method: &'a str,
+    /// Already-encoded path, beginning with `/` (e.g. `/bucket/some%20key`).
+    pub path: &'a str,
+    /// Query pairs in any order; signing sorts them canonically.
+    pub query: &'a [(String, String)],
+    /// Headers to sign. `host` must be present; `x-amz-date` and
+    /// `x-amz-content-sha256` are added by the signer.
+    pub headers: &'a mut Vec<(String, String)>,
+    pub payload_sha256: &'a str,
+}
+
+fn hmac(key: &[u8], data: &[u8]) -> Vec<u8> {
+    let mut m = <HmacSha256 as Mac>::new_from_slice(key).expect("hmac accepts any key length");
+    m.update(data);
+    m.finalize().into_bytes().to_vec()
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+pub fn sha256_hex(data: &[u8]) -> String {
+    hex(&Sha256::digest(data))
+}
+
+/// Percent-encode for canonical URIs/queries. S3 signing requires the strict
+/// RFC 3986 unreserved set — notably `/` is encoded in query values but kept
+/// literal in the path, so the caller passes the path pre-encoded.
+pub fn uri_encode(s: &str, encode_slash: bool) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char)
+            }
+            b'/' if !encode_slash => out.push('/'),
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+/// Sign `req` in place, appending `Authorization` (plus the amz headers).
+///
+/// `now` is `(YYYYMMDD, YYYYMMDDTHHMMSSZ)` — passed in rather than read from the
+/// clock so the tests can pin AWS's published example timestamps.
+pub fn sign(req: SignRequest<'_>, creds: &Credentials, region: &str, now: (&str, &str)) {
+    let (date_stamp, amz_date) = now;
+
+    req.headers.retain(|(k, _)| {
+        let k = k.to_ascii_lowercase();
+        k != "x-amz-date"
+            && k != "x-amz-content-sha256"
+            && k != "authorization"
+            && k != "x-amz-security-token"
+    });
+    req.headers
+        .push(("x-amz-date".into(), amz_date.to_string()));
+    req.headers.push((
+        "x-amz-content-sha256".into(),
+        req.payload_sha256.to_string(),
+    ));
+    if let Some(token) = &creds.session_token {
+        req.headers
+            .push(("x-amz-security-token".into(), token.clone()));
+    }
+
+    // Canonical headers: lowercase names, trimmed values, sorted, each newline-terminated.
+    let mut canon: Vec<(String, String)> = req
+        .headers
+        .iter()
+        .map(|(k, v)| (k.to_ascii_lowercase(), v.trim().to_string()))
+        .collect();
+    canon.sort_by(|a, b| a.0.cmp(&b.0));
+    let signed_headers = canon
+        .iter()
+        .map(|(k, _)| k.as_str())
+        .collect::<Vec<_>>()
+        .join(";");
+    let canonical_headers: String = canon.iter().map(|(k, v)| format!("{k}:{v}\n")).collect();
+
+    let mut q: Vec<(String, String)> = req
+        .query
+        .iter()
+        .map(|(k, v)| (uri_encode(k, true), uri_encode(v, true)))
+        .collect();
+    q.sort();
+    let canonical_query = q
+        .iter()
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect::<Vec<_>>()
+        .join("&");
+
+    let canonical_request = format!(
+        "{}\n{}\n{}\n{}\n{}\n{}",
+        req.method,
+        req.path,
+        canonical_query,
+        canonical_headers,
+        signed_headers,
+        req.payload_sha256
+    );
+
+    let scope = format!("{date_stamp}/{region}/s3/aws4_request");
+    let string_to_sign = format!(
+        "AWS4-HMAC-SHA256\n{amz_date}\n{scope}\n{}",
+        sha256_hex(canonical_request.as_bytes())
+    );
+
+    let k_date = hmac(
+        format!("AWS4{}", creds.secret_access_key).as_bytes(),
+        date_stamp.as_bytes(),
+    );
+    let k_region = hmac(&k_date, region.as_bytes());
+    let k_service = hmac(&k_region, b"s3");
+    let k_signing = hmac(&k_service, b"aws4_request");
+    let signature = hex(&hmac(&k_signing, string_to_sign.as_bytes()));
+
+    req.headers.push((
+        "authorization".into(),
+        format!(
+            "AWS4-HMAC-SHA256 Credential={}/{scope}, SignedHeaders={signed_headers}, Signature={signature}",
+            creds.access_key_id
+        ),
+    ));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn creds() -> Credentials {
+        // The example credentials from AWS's SigV4 test suite.
+        Credentials {
+            access_key_id: "AKIAIOSFODNN7EXAMPLE".into(),
+            secret_access_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),
+            session_token: None,
+        }
+    }
+
+    // AWS's documented "GET Object" example: if our canonical-request and
+    // key-derivation chain is right, we reproduce their published signature
+    // byte for byte. This is the whole reason to hand-roll signing with
+    // confidence rather than hope.
+    #[test]
+    fn matches_the_aws_published_get_object_signature() {
+        let mut headers = vec![
+            (
+                "host".to_string(),
+                "examplebucket.s3.amazonaws.com".to_string(),
+            ),
+            ("range".to_string(), "bytes=0-9".to_string()),
+        ];
+        sign(
+            SignRequest {
+                method: "GET",
+                path: "/test.txt",
+                query: &[],
+                headers: &mut headers,
+                payload_sha256: EMPTY_SHA256,
+            },
+            &creds(),
+            "us-east-1",
+            ("20130524", "20130524T000000Z"),
+        );
+        let auth = headers
+            .iter()
+            .find(|(k, _)| k == "authorization")
+            .unwrap()
+            .1
+            .clone();
+        assert!(
+            auth.ends_with(
+                "Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41"
+            ),
+            "unexpected signature: {auth}"
+        );
+    }
+
+    // Same suite, "PUT Object" — exercises a signed payload hash and extra
+    // x-amz-* headers, which change both the canonical headers and the digest.
+    #[test]
+    fn matches_the_aws_published_put_object_signature() {
+        let body_hash = "44ce7dd67c959e0d3524ffac1771dfbba87d2b6b4b4e99e42034a8b803f8b072";
+        let mut headers = vec![
+            (
+                "date".to_string(),
+                "Fri, 24 May 2013 00:00:00 GMT".to_string(),
+            ),
+            (
+                "host".to_string(),
+                "examplebucket.s3.amazonaws.com".to_string(),
+            ),
+            (
+                "x-amz-storage-class".to_string(),
+                "REDUCED_REDUNDANCY".to_string(),
+            ),
+        ];
+        sign(
+            SignRequest {
+                method: "PUT",
+                path: "/test%24file.text",
+                query: &[],
+                headers: &mut headers,
+                payload_sha256: body_hash,
+            },
+            &creds(),
+            "us-east-1",
+            ("20130524", "20130524T000000Z"),
+        );
+        let auth = headers
+            .iter()
+            .find(|(k, _)| k == "authorization")
+            .unwrap()
+            .1
+            .clone();
+        assert!(
+            auth.ends_with(
+                "Signature=98ad721746da40c64f1a55b78f14c238d841ea1380cd77a1b5971af0ece108bd"
+            ),
+            "unexpected signature: {auth}"
+        );
+    }
+
+    // Listing uses a query string, which must be sorted and encoded canonically.
+    #[test]
+    fn matches_the_aws_published_list_signature() {
+        let mut headers = vec![(
+            "host".to_string(),
+            "examplebucket.s3.amazonaws.com".to_string(),
+        )];
+        sign(
+            SignRequest {
+                method: "GET",
+                path: "/",
+                query: &[
+                    ("max-keys".into(), "2".into()),
+                    ("prefix".into(), "J".into()),
+                ],
+                headers: &mut headers,
+                payload_sha256: EMPTY_SHA256,
+            },
+            &creds(),
+            "us-east-1",
+            ("20130524", "20130524T000000Z"),
+        );
+        let auth = headers
+            .iter()
+            .find(|(k, _)| k == "authorization")
+            .unwrap()
+            .1
+            .clone();
+        assert!(
+            auth.ends_with(
+                "Signature=34b48302e7b5fa45bde8084f4b7868a86f0a534bc59db6670ed5711ef69dc6f7"
+            ),
+            "unexpected signature: {auth}"
+        );
+    }
+
+    #[test]
+    fn uri_encoding_follows_the_unreserved_set() {
+        assert_eq!(uri_encode("a b/c", false), "a%20b/c");
+        assert_eq!(uri_encode("a b/c", true), "a%20b%2Fc");
+        assert_eq!(uri_encode("~-_.", true), "~-_.");
+    }
+}

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -455,7 +455,7 @@ pub struct RunConfig {
     /// Remote-volume mount script to run inside the workload container before
     /// its (image-resolved) command. Set by the workload launcher; the agent
     /// wraps the resolved command so the image's real entrypoint still runs.
-    pub remote_volume_mount: Option<String>,
+    pub s3_volumes: Vec<smolvm_protocol::S3Volume>,
 }
 
 impl RunConfig {
@@ -477,13 +477,13 @@ impl RunConfig {
             persistent_overlay_id: None,
             stdin: None,
             unprivileged: false,
-            remote_volume_mount: None,
+            s3_volumes: Vec::new(),
         }
     }
 
     /// Set the remote-volume mount script run inside the workload container.
-    pub fn with_remote_volume_mount(mut self, script: Option<String>) -> Self {
-        self.remote_volume_mount = script;
+    pub fn with_s3_volumes(mut self, volumes: Vec<smolvm_protocol::S3Volume>) -> Self {
+        self.s3_volumes = volumes;
         self
     }
 
@@ -1588,7 +1588,7 @@ impl AgentClient {
             persistent_overlay_id: config.persistent_overlay_id,
             stdin_data: config.stdin,
             background: false,
-            remote_volume_mount: None,
+            s3_volumes: Vec::new(),
         })?;
 
         expect_completed(resp, "run command")
@@ -1615,7 +1615,7 @@ impl AgentClient {
             persistent_overlay_id: config.persistent_overlay_id,
             stdin_data: None,
             background: true,
-            remote_volume_mount: None,
+            s3_volumes: Vec::new(),
         })?;
 
         let (exit_code, stdout, _stderr) = expect_completed(resp, "run background")?;
@@ -1659,7 +1659,7 @@ impl AgentClient {
             persistent_overlay_id: config.persistent_overlay_id,
             stdin_data: None,
             background: false,
-            remote_volume_mount: None,
+            s3_volumes: Vec::new(),
         })?;
 
         collect_exec_events(self, "run streaming", on_event)
@@ -1697,7 +1697,7 @@ impl AgentClient {
                 persistent_overlay_id: config.persistent_overlay_id,
                 stdin_data: None,
                 background: false,
-                remote_volume_mount: None,
+                s3_volumes: Vec::new(),
             },
             tty,
             "run interactive",
@@ -1736,7 +1736,7 @@ impl AgentClient {
             persistent_overlay_id: config.persistent_overlay_id,
             stdin_data: None,
             background: false,
-            remote_volume_mount: config.remote_volume_mount,
+            s3_volumes: config.s3_volumes,
         })?;
         let resp = loop {
             match self.receive()? {
@@ -1972,7 +1972,7 @@ impl AgentClient {
                 persistent_overlay_id: config.persistent_overlay_id,
                 stdin_data: None,
                 background: false,
-                remote_volume_mount: None,
+                s3_volumes: Vec::new(),
             },
             input,
             on_output,

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -1588,7 +1588,7 @@ impl AgentClient {
             persistent_overlay_id: config.persistent_overlay_id,
             stdin_data: config.stdin,
             background: false,
-            s3_volumes: Vec::new(),
+            s3_volumes: config.s3_volumes.clone(),
         })?;
 
         expect_completed(resp, "run command")
@@ -1615,7 +1615,7 @@ impl AgentClient {
             persistent_overlay_id: config.persistent_overlay_id,
             stdin_data: None,
             background: true,
-            s3_volumes: Vec::new(),
+            s3_volumes: config.s3_volumes.clone(),
         })?;
 
         let (exit_code, stdout, _stderr) = expect_completed(resp, "run background")?;
@@ -1659,7 +1659,7 @@ impl AgentClient {
             persistent_overlay_id: config.persistent_overlay_id,
             stdin_data: None,
             background: false,
-            s3_volumes: Vec::new(),
+            s3_volumes: config.s3_volumes.clone(),
         })?;
 
         collect_exec_events(self, "run streaming", on_event)
@@ -1697,7 +1697,7 @@ impl AgentClient {
                 persistent_overlay_id: config.persistent_overlay_id,
                 stdin_data: None,
                 background: false,
-                s3_volumes: Vec::new(),
+                s3_volumes: config.s3_volumes.clone(),
             },
             tty,
             "run interactive",
@@ -1972,7 +1972,7 @@ impl AgentClient {
                 persistent_overlay_id: config.persistent_overlay_id,
                 stdin_data: None,
                 background: false,
-                s3_volumes: Vec::new(),
+                s3_volumes: config.s3_volumes.clone(),
             },
             input,
             on_output,

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -407,7 +407,7 @@ pub async fn create_machine(
     let name = req.name.clone().unwrap_or_else(generate_machine_name);
     validate_vm_name(&name, "machine name").map_err(ApiError::BadRequest)?;
 
-    // Split remote volumes (s3:// or rclone-remote sources) from host mounts,
+    // Split remote volumes (`s3://` sources) from host mounts,
     // mirroring the CLI's -v handling, then validate the host mount paths.
     let mut remote_volumes = Vec::new();
     let mut host_mount_specs: Vec<crate::api::types::MountSpec> = Vec::new();

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -1238,14 +1238,7 @@ pub async fn start_machine(
         // Remote volumes mount inside the workload container; build the mount
         // script here and let the agent run it ahead of the image-resolved
         // command, so a service image's own entrypoint is preserved.
-        let remote_volume_mount = if record.remote_volumes.is_empty() {
-            None
-        } else {
-            Some(
-                crate::remote_volume::mount_script(&record.remote_volumes, &env)
-                    .map_err(|e| ApiError::BadRequest(e.to_string()))?,
-            )
-        };
+        let s3_volumes = crate::remote_volume::to_s3_volumes(&record.remote_volumes, &env);
         let workdir = record.workdir.clone();
         let user = record.user.clone();
         let mounts_config = {
@@ -1315,7 +1308,7 @@ pub async fn start_machine(
                 .with_user(user)
                 .with_mounts(mounts_config)
                 .with_persistent_overlay(Some(overlay_id))
-                .with_remote_volume_mount(remote_volume_mount);
+                .with_s3_volumes(s3_volumes);
             c.run_container_detached(config).map(|_| ())
         })
         .await;

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -1403,14 +1403,7 @@ async fn relaunch_image_workload(
     // Remote volumes mount inside the workload container; build the mount script
     // here and let the agent run it ahead of the image-resolved command, so a
     // service image's own entrypoint is preserved rather than clobbered.
-    let remote_volume_mount = if record.remote_volumes.is_empty() {
-        None
-    } else {
-        Some(crate::remote_volume::mount_script(
-            &record.remote_volumes,
-            &env,
-        )?)
-    };
+    let s3_volumes = crate::remote_volume::to_s3_volumes(&record.remote_volumes, &env);
     let workdir = record.workdir.clone();
     let user = record.user.clone();
     let mounts_config = {
@@ -1440,7 +1433,7 @@ async fn relaunch_image_workload(
             .with_user(user)
             .with_mounts(mounts_config)
             .with_persistent_overlay(Some(overlay_id))
-            .with_remote_volume_mount(remote_volume_mount);
+            .with_s3_volumes(s3_volumes);
         c.run_container_detached(config).map(|_| ())
     })
     .await

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -129,7 +129,7 @@ pub struct MachineRegistration {
     pub manager: AgentManager,
     /// Host mounts to configure.
     pub mounts: Vec<MountSpec>,
-    /// Remote volumes (s3:// or rclone remotes) to mount in the workload.
+    /// Remote volumes (`s3://`) to mount in the workload.
     pub remote_volumes: Vec<crate::remote_volume::RemoteVolume>,
     /// Port mappings to configure.
     pub ports: Vec<PortSpec>,

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -1337,7 +1337,18 @@ impl RunCmd {
             .run();
         }
 
-        let mut mounts = HostMount::parse(&params.volume)?;
+        // Remote volumes are mounted inside the guest by the agent, so peel them
+        // off before the host-directory parse, which would reject an `s3://`
+        // source as a missing directory.
+        let (host_volume_specs, remote_volumes) =
+            smolvm::remote_volume::split_specs(&params.volume)?;
+        let mut mounts = HostMount::parse(&host_volume_specs)?;
+        if !remote_volumes.is_empty() && !params.net {
+            return Err(Error::config(
+                "machine run",
+                "remote volumes need network access to reach the bucket: add --net",
+            ));
+        }
         let ports = params.port.clone();
         PortMapping::check_duplicates(&ports)
             .map_err(|e| smolvm::Error::config("validate ports", e))?;
@@ -1717,6 +1728,10 @@ impl RunCmd {
                 &env,
                 params.workdir.as_deref(),
             );
+            // Credentials and endpoint come from the workload's own env, the
+            // same place every AWS SDK reads them, so a remote volume needs no
+            // configuration beyond the `-v` spec and the usual variables.
+            let s3_volumes = smolvm::remote_volume::to_s3_volumes(&remote_volumes, &defaults.env);
             if self.detach {
                 // Start the main workload container first. If this fails, the
                 // VM is stopped and no DB record is written — a retry won't
@@ -1728,7 +1743,8 @@ impl RunCmd {
                         .with_user(defaults.user.clone())
                         .with_mounts(mount_bindings.clone())
                         .with_persistent_overlay(Some(vm_name.clone()))
-                        .with_unprivileged(self.unprivileged);
+                        .with_unprivileged(self.unprivileged)
+                        .with_s3_volumes(s3_volumes.clone());
                     client.run_container_detached(run_config)?;
                 }
 
@@ -1843,7 +1859,8 @@ impl RunCmd {
                         .with_timeout(self.timeout)
                         .with_tty(tty)
                         .with_persistent_overlay(Some(vm_name.clone()))
-                        .with_unprivileged(self.unprivileged);
+                        .with_unprivileged(self.unprivileged)
+                        .with_s3_volumes(s3_volumes.clone());
                     client.run_interactive(config)?
                 } else {
                     let config = RunConfig::new(img, command)
@@ -1853,7 +1870,8 @@ impl RunCmd {
                         .with_mounts(mount_bindings)
                         .with_timeout(self.timeout)
                         .with_persistent_overlay(Some(vm_name.clone()))
-                        .with_unprivileged(self.unprivileged);
+                        .with_unprivileged(self.unprivileged)
+                        .with_s3_volumes(s3_volumes.clone());
                     let (exit_code, stdout, stderr) = client.run_non_interactive(config)?;
                     if !stdout.is_empty() {
                         let _ = std::io::stdout().write_all(&stdout);

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -2966,12 +2966,11 @@ pub struct CreateCmd {
     pub overlay: Option<u64>,
 
     /// Mount host directory (can be used multiple times). Also accepts
-    /// remote sources mounted inside the guest via rclone on every start:
+    /// S3-compatible object storage, mounted inside the guest on every start:
     /// `s3://bucket/prefix:/data[:ro]` (credentials from --env
     /// AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, optional AWS_ENDPOINT_URL
-    /// for R2/MinIO; anonymous without them) or any raw rclone remote,
-    /// e.g. `:sftp,host=example.com,user=me:/srv:/data`. The image must
-    /// provide `rclone` and `fusermount3`.
+    /// for R2/MinIO; anonymous without them). Nothing is required of the
+    /// image: the agent performs the mount itself.
     #[arg(short = 'v', long = "volume", value_name = "HOST|REMOTE:GUEST[:ro]")]
     pub volume: Vec<String>,
 

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -586,9 +586,8 @@ pub(crate) fn build_vm_record(params: &CreateVmParams) -> smolvm::Result<VmRecor
     validate_vm_name(&params.name, "machine name")
         .map_err(|reason| smolvm::Error::config("create machine", reason))?;
 
-    // Peel off remote volume specs (s3:// and raw rclone remotes) before the
-    // host-directory parse; they mount inside the guest at start instead of
-    // through virtiofs.
+    // Peel off remote volume specs (`s3://`) before the host-directory parse;
+    // they mount inside the guest at start instead of through virtiofs.
     let (host_volume_specs, remote_volumes) = smolvm::remote_volume::split_specs(&params.volume)?;
 
     // Parse and validate volume mounts
@@ -709,9 +708,9 @@ pub(crate) fn build_vm_record(params: &CreateVmParams) -> smolvm::Result<VmRecor
     // pull), so refuse here rather than deferring to a `start` that must fail.
     record.validate_image_fetchable()?;
 
-    // Remote volumes mount via rclone inside the workload image; an imageless
-    // machine has nowhere to run it, and they also need network to reach the
-    // remote. Refuse at create instead of failing every start.
+    // Remote volumes mount into the workload container's namespace, so an
+    // imageless machine has nowhere to put them, and they need network to
+    // reach the bucket. Refuse at create instead of failing every start.
     record.validate_remote_volumes()?;
 
     Ok(record)

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -1585,33 +1585,9 @@ fn start_vm_named_with_db(
         // entirely when restoring from a snapshot — the forked container is
         // inherited as-is.
         let _ = img;
-        // The remote-volume mounts run inside the detached workload container,
-        // whose failures are invisible to this caller. Catch the common one
-        // (image without the tools) synchronously first, with the actionable
-        // message, instead of leaving a "running" machine with a dead workload.
-        if !from_snapshot {
-            if let Some(preflight) =
-                smolvm::remote_volume::preflight_command(&record.remote_volumes)
-            {
-                if let Err(e) = run_init_commands(
-                    &mut client,
-                    &[preflight],
-                    InitRunContext {
-                        image: record.image.as_deref(),
-                        image_info: None,
-                        env: &exec_env,
-                        workdir: record.workdir.as_deref(),
-                        record_mounts: &record.mounts,
-                        overlay_id: name,
-                    },
-                ) {
-                    if let Err(stop_err) = manager.stop() {
-                        tracing::warn!(error = %stop_err, "failed to stop machine after remote volume preflight failure");
-                    }
-                    return Err(e);
-                }
-            }
-        }
+        // Remote volumes are mounted natively by the agent between the
+        // container's create and start, and a mount that never appears
+        // fails the start there — so no host-side preflight is needed.
         if !from_snapshot {
             if let Err(e) = smolvm::workload::launch_image_workload(
                 &mut client,
@@ -1628,29 +1604,6 @@ fn start_vm_named_with_db(
             tracing::info!(
                 "clone booted from snapshot: workload container inherited from fork, skipping relaunch"
             );
-        }
-        // Confirm every remote volume actually mounted (also covers a clone's
-        // restored mounts): a failed mount kills the detached workload
-        // silently, so without this the machine would report running while
-        // the volume is simply absent.
-        if let Some(verify) = smolvm::remote_volume::verify_command(&record.remote_volumes) {
-            if let Err(e) = run_init_commands(
-                &mut client,
-                &[verify],
-                InitRunContext {
-                    image: record.image.as_deref(),
-                    image_info: None,
-                    env: &exec_env,
-                    workdir: record.workdir.as_deref(),
-                    record_mounts: &record.mounts,
-                    overlay_id: name,
-                },
-            ) {
-                if let Err(stop_err) = manager.stop() {
-                    tracing::warn!(error = %stop_err, "failed to stop machine after remote volume verification failure");
-                }
-                return Err(e);
-            }
         }
         println!("Machine '{}' running (PID: {})", name, pid.unwrap_or(0));
     } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -436,8 +436,8 @@ pub struct VmRecord {
     #[serde(default)]
     pub init_completed: bool,
 
-    /// Remote volumes (object stores / network filesystems) mounted inside
-    /// the guest via rclone on every start. See `crate::remote_volume`.
+    /// Remote volumes (S3-compatible object stores) mounted inside the guest
+    /// by the agent on every start. See `crate::remote_volume`.
     #[serde(default)]
     pub remote_volumes: Vec<crate::remote_volume::RemoteVolume>,
 
@@ -884,9 +884,10 @@ impl VmRecord {
         ))
     }
 
-    /// Remote volumes mount via rclone inside the workload image over the
-    /// guest network; refuse configurations that can never mount at create
-    /// instead of failing every start. Shared by the CLI and API create paths.
+    /// Remote volumes are mounted into the workload container's mount
+    /// namespace, so there has to be a container: refuse configurations that
+    /// can never mount at create instead of failing every start. Shared by the
+    /// CLI and API create paths.
     pub fn validate_remote_volumes(&self) -> crate::Result<()> {
         if self.remote_volumes.is_empty() {
             return Ok(());
@@ -894,8 +895,8 @@ impl VmRecord {
         if self.image.is_none() {
             return Err(crate::Error::config(
                 "create machine",
-                "remote volumes (s3:// or rclone remotes) require an image machine \
-                 whose image provides `rclone` and `fusermount3`",
+                "remote volumes require an image machine: they are mounted into \
+                 the workload container's mount namespace",
             ));
         }
         let plan = crate::network::plan_launch_network(

--- a/src/remote_volume.rs
+++ b/src/remote_volume.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 /// without migrating persisted state.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RemoteVolume {
-    /// The user-supplied source (`s3://bucket/prefix` or `:backend,...:path`).
+    /// The user-supplied source (`s3://bucket[/prefix]`).
     pub source: String,
     /// Absolute guest mount point.
     pub target: String,
@@ -60,7 +60,7 @@ pub fn split_specs(specs: &[String]) -> crate::Result<(Vec<String>, Vec<RemoteVo
 
 /// Parse one `-v` spec; `Ok(None)` means "not a remote source" and the spec
 /// belongs to the host-directory path. Mirrors `HostMount`'s right-anchored
-/// parse so sources may contain colons (rclone connection strings do).
+/// parse so sources may contain colons (an S3 URL's scheme does).
 fn parse_spec(spec: &str) -> crate::Result<Option<RemoteVolume>> {
     let (rest, read_only) = match spec.rsplit_once(':') {
         Some((head, "ro")) => (head, true),
@@ -93,25 +93,23 @@ fn parse_spec(spec: &str) -> crate::Result<Option<RemoteVolume>> {
             format!("remote volume spec must not contain single quotes: '{spec}'"),
         ));
     }
-    if let Some(bucket) = source.strip_prefix("s3://") {
-        if bucket.trim_matches('/').is_empty() {
-            return Err(crate::Error::config(
-                "parse remote volume",
-                format!("s3 volume needs a bucket name: '{spec}'"),
-            ));
-        }
-    } else if !raw_remote_has_path_colon(source) {
-        // An rclone connection string is `:backend,opts:path` — the path colon
-        // is part of the remote. With an empty remote path the user must write
-        // it explicitly, which makes a double colon before the guest path:
-        // `:http,url="https://host"::/mnt/data`.
+    let Some(bucket) = source.strip_prefix("s3://") else {
+        // A leading colon is rclone's connection-string syntax. Mounting is now
+        // native S3, so such a spec cannot be honoured — and silently treating
+        // it as a bucket name would sign requests against a nonsense bucket.
+        // Reject it here, where the spec is still visible to name in the error.
         return Err(crate::Error::config(
             "parse remote volume",
             format!(
-                "rclone remote is missing its ':path' part in '{spec}' \
-                 (an empty remote path is written '::' before the guest path, \
-                 e.g. ':http,url=\"https://host\"::/mnt/data')"
+                "'{spec}' is an rclone remote, which is no longer supported; \
+                 use an S3 URL instead, e.g. 's3://bucket/prefix:/guest/path'"
             ),
+        ));
+    };
+    if bucket.trim_matches('/').is_empty() {
+        return Err(crate::Error::config(
+            "parse remote volume",
+            format!("s3 volume needs a bucket name: '{spec}'"),
         ));
     }
     Ok(Some(RemoteVolume {
@@ -146,21 +144,6 @@ pub fn from_parts(source: &str, target: &str, read_only: bool) -> crate::Result<
             format!("not a remote volume source: '{source}'"),
         )
     })
-}
-
-/// Whether a raw rclone connection string still has its remote-terminating
-/// `:path` colon. Colons inside double-quoted option values (URLs, mostly)
-/// don't count — rclone's own parser treats those as part of the value.
-fn raw_remote_has_path_colon(source: &str) -> bool {
-    let mut in_quotes = false;
-    for ch in source.chars().skip(1) {
-        match ch {
-            '"' => in_quotes = !in_quotes,
-            ':' if !in_quotes => return true,
-            _ => {}
-        }
-    }
-    false
 }
 
 impl RemoteVolume {
@@ -246,13 +229,31 @@ mod tests {
         assert!(split_specs(&["s3://b:/d".to_string(), "s3://c:/d".to_string()]).is_err());
     }
 
+    // Mounting is native S3 now, so an rclone connection string cannot be
+    // honoured. It must be named as unsupported rather than parsed as a bucket,
+    // which would sign every request against a nonsense name.
+    #[test]
+    fn an_rclone_remote_is_rejected_by_name() {
+        let err = split_specs(&[":s3,provider=Minio,endpoint=\"http://h\":b:/mnt/d".to_string()])
+            .expect_err("an rclone remote must not parse as a bucket");
+        let msg = err.to_string();
+        assert!(msg.contains("rclone"), "{msg}");
+        assert!(msg.contains("s3://"), "{msg}");
+        // A remote with an empty path is still an rclone remote, not a host dir.
+        assert!(split_specs(&[":http,url=\"https://h\"::/mnt/d".to_string()]).is_err());
+        // Host directory mounts are untouched by the rejection.
+        let (host, remote) = split_specs(&["/data:/mnt/d".to_string()]).unwrap();
+        assert_eq!(host, vec!["/data:/mnt/d".to_string()]);
+        assert!(remote.is_empty());
+    }
+
     #[test]
     fn from_parts_matches_colon_parser() {
         let structured = from_parts("s3://bucket/pfx", "/mnt/d", true).unwrap();
         let parsed = &split(&["s3://bucket/pfx:/mnt/d:ro"]).1[0];
         assert_eq!(&structured, parsed);
-        // Same validation as the colon parser: relative target, missing
-        // rclone path colon, empty bucket.
+        // Same validation as the colon parser: relative target, non-S3
+        // source, empty bucket.
         assert!(from_parts("s3://b", "relative", false).is_err());
         assert!(from_parts(":http,url=\"https://h\"", "/mnt/x", false).is_err());
         assert!(from_parts("s3://", "/mnt/x", false).is_err());

--- a/src/remote_volume.rs
+++ b/src/remote_volume.rs
@@ -1,26 +1,19 @@
-//! Remote volumes: mount object stores and network filesystems into a
-//! machine with the same `-v SOURCE:GUEST[:ro]` flag as directory mounts.
+//! Remote volumes: mount S3-compatible object storage into a machine with the
+//! same `-v SOURCE:GUEST[:ro]` flag as directory mounts.
 //!
-//! Two source forms are recognized; everything else stays a host directory
-//! mount handled by `HostMount`:
+//! `s3://bucket[/prefix]` mounts a bucket. Credentials come from the machine's
+//! `--env` (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, optional
+//! `AWS_ENDPOINT_URL` for R2/MinIO and `AWS_REGION`); without them the bucket is
+//! read anonymously, which covers public datasets. Anything else stays a host
+//! directory mount handled by `HostMount`.
 //!
-//! - `s3://bucket[/prefix]` — sugar for an S3 mount. Credentials come from
-//!   the machine's `--env` (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`,
-//!   optional `AWS_ENDPOINT_URL` for R2/MinIO); without credentials the
-//!   bucket is accessed anonymously, which covers public datasets.
-//! - `:backend,opt=value,...:path` — a raw rclone connection string passed
-//!   through verbatim, so every rclone-supported filesystem (sftp, gcs,
-//!   azure, webdav, http, b2, ...) works without smolvm knowing about it.
-//!
-//! The mounts run inside the machine's workload container, whose command is
-//! wrapped with the mount script on every start: the guest kernel ships
-//! FUSE, machine containers have the capabilities to `mknod /dev/fuse`, and
-//! `exec`/`shell` sessions join the workload container's namespaces — so the
-//! workload container is the one place a mount is visible everywhere and
-//! lives exactly as long as the workload. The image must provide `rclone`
-//! and `fusermount3` (installable via `--init` on first boot, which runs
-//! before the workload launches).
-
+//! The mount is performed by the agent itself, natively: it enters the workload
+//! container's mount namespace and speaks FUSE and the S3 API directly. Nothing
+//! is required of the image — no rclone, no fuse3, no `fusermount3` — so a
+//! bucket can be mounted into a distroless or scratch image that could not
+//! install a helper at all. Mounting happens between container create and start,
+//! so the workload's first instruction already sees its data and its command is
+//! never rewritten.
 use serde::{Deserialize, Serialize};
 
 /// One remote volume attached to a machine, stored on its record verbatim so
@@ -171,128 +164,55 @@ fn raw_remote_has_path_colon(source: &str) -> bool {
 }
 
 impl RemoteVolume {
-    /// The rclone remote for this volume. Raw connection strings pass
-    /// through; `s3://` sugar expands using the machine env: credentials in
-    /// the env switch rclone to env-based auth (the mount command runs with
-    /// the machine env applied), and `AWS_ENDPOINT_URL` points the S3 API at
-    /// R2/MinIO/other S3-compatible stores.
-    fn rclone_remote(&self, env: &[(String, String)]) -> crate::Result<String> {
-        let Some(bucket) = self.source.strip_prefix("s3://") else {
-            return Ok(self.source.clone());
-        };
-        let has = |key: &str| env.iter().any(|(k, _)| k == key);
-        let mut opts = String::from(":s3,provider=AWS");
-        if has("AWS_ACCESS_KEY_ID") {
-            opts.push_str(",env_auth=true");
+    /// Bucket name and key prefix parsed out of the `s3://bucket/prefix` source.
+    fn bucket_and_prefix(&self) -> (String, String) {
+        let rest = self.source.strip_prefix("s3://").unwrap_or(&self.source);
+        match rest.trim_matches('/').split_once('/') {
+            Some((bucket, prefix)) => (bucket.to_string(), prefix.trim_matches('/').to_string()),
+            None => (rest.trim_matches('/').to_string(), String::new()),
         }
-        if let Some((_, url)) = env.iter().find(|(k, _)| k == "AWS_ENDPOINT_URL") {
-            if url.contains('"') || url.contains('\'') {
-                return Err(crate::Error::config(
-                    "remote volume",
-                    "AWS_ENDPOINT_URL must not contain quotes",
-                ));
-            }
-            opts.push_str(&format!(",endpoint=\"{url}\""));
-            // Streaming single-part uploads to a plain-http endpoint fail in
-            // rclone's aws-sdk-v2 backend (a signed payload needs a seekable
-            // body; https avoids it via UNSIGNED-PAYLOAD). Local MinIO-style
-            // endpoints are exactly the http case, so force multipart there.
-            if url.starts_with("http://") {
-                opts.push_str(",upload_cutoff=0");
-            }
-        }
-        Ok(format!("{opts}:{}", bucket.trim_matches('/')))
     }
 
-    /// The shell command that mounts this volume, run through the `--init`
-    /// exec machinery on every machine start.
-    pub fn mount_command(&self, env: &[(String, String)]) -> crate::Result<String> {
-        let remote = self.rclone_remote(env)?;
-        let mode = if self.read_only {
-            " --read-only"
-        } else {
-            " --vfs-cache-mode writes"
+    /// Build the structured mount request the agent performs natively.
+    ///
+    /// Credentials and endpoint are read from the machine's env, matching what
+    /// every AWS SDK does, so an existing workload's configuration carries over
+    /// unchanged. A bucket with no credentials is mounted anonymously rather
+    /// than failing — that is exactly how public datasets are consumed.
+    pub fn to_s3_volume(&self, env: &[(String, String)]) -> smolvm_protocol::S3Volume {
+        let get = |key: &str| {
+            env.iter()
+                .find(|(k, _)| k == key)
+                .map(|(_, v)| v.clone())
+                .filter(|v| !v.is_empty())
         };
-        Ok(format!(
-            "command -v rclone >/dev/null 2>&1 && command -v fusermount3 >/dev/null 2>&1 || \
-             {{ echo \"remote volume {target} needs rclone and fuse3 in the image \
-             (alpine: apk add rclone fuse3 | debian/ubuntu: apt-get install -y rclone fuse3)\" >&2; exit 1; }}; \
-             [ -e /dev/fuse ] || mknod /dev/fuse c 10 229; \
-             mkdir -p '{target}' && rclone mount '{remote}' '{target}' --daemon{mode}",
-            target = self.target,
-        ))
+        let (bucket, prefix) = self.bucket_and_prefix();
+        let region = get("AWS_REGION")
+            .or_else(|| get("AWS_DEFAULT_REGION"))
+            .unwrap_or_else(|| "us-east-1".to_string());
+        let endpoint = get("AWS_ENDPOINT_URL")
+            .or_else(|| get("AWS_ENDPOINT"))
+            .unwrap_or_else(|| format!("https://s3.{region}.amazonaws.com"));
+        smolvm_protocol::S3Volume {
+            endpoint,
+            region,
+            bucket,
+            prefix,
+            mountpoint: self.target.clone(),
+            read_only: self.read_only,
+            access_key_id: get("AWS_ACCESS_KEY_ID"),
+            secret_access_key: get("AWS_SECRET_ACCESS_KEY"),
+            session_token: get("AWS_SESSION_TOKEN"),
+        }
     }
 }
 
-/// Mount commands for every remote volume on a record, in declaration order.
-pub fn mount_commands(
+/// Build the mount requests for every remote volume on a machine.
+pub fn to_s3_volumes(
     volumes: &[RemoteVolume],
     env: &[(String, String)],
-) -> crate::Result<Vec<String>> {
-    volumes.iter().map(|v| v.mount_command(env)).collect()
-}
-
-/// A synchronous pre-launch check that the image can mount remote volumes at
-/// all. The mount itself runs inside the detached workload container, whose
-/// failures are not surfaced to the caller — so the most common failure
-/// (image without the tools) is caught here first, where it can fail the
-/// start with an actionable message.
-pub fn preflight_command(volumes: &[RemoteVolume]) -> Option<String> {
-    if volumes.is_empty() {
-        return None;
-    }
-    Some(
-        "command -v rclone >/dev/null 2>&1 && command -v fusermount3 >/dev/null 2>&1 || \
-         { echo \"remote volumes need rclone and fuse3 in the image \
-         (alpine: apk add rclone fuse3 | debian/ubuntu: apt-get install -y rclone fuse3; \
-         or install them with --init, which runs before the mounts)\" >&2; exit 1; }"
-            .to_string(),
-    )
-}
-
-/// A post-launch check that every remote volume actually mounted. Joins the
-/// workload container (like any exec) and polls /proc/mounts: if the mount
-/// script failed, the workload container is dead and the fresh exec container
-/// sees no mounts either way — so this fails the start instead of leaving a
-/// silently broken machine.
-pub fn verify_command(volumes: &[RemoteVolume]) -> Option<String> {
-    if volumes.is_empty() {
-        return None;
-    }
-    let checks: Vec<String> = volumes
-        .iter()
-        .map(|v| {
-            format!(
-                "awk -v m='{}' '$2==m' /proc/mounts | grep -q rclone",
-                v.target
-            )
-        })
-        .collect();
-    let all = checks.join(" && ");
-    Some(format!(
-        "t=0; while [ $t -lt 30 ]; do if {all}; then exit 0; fi; t=$((t+1)); sleep 0.5; done; \
-         echo \"remote volume(s) failed to mount — check the machine's agent-console.log for the rclone error\" >&2; exit 1"
-    ))
-}
-
-/// Wrap a machine's workload command so its container mounts the remote
-/// volumes before the workload runs.
-///
-/// A FUSE mount lives in the mount namespace of the container that created
-/// it, and `exec`/`shell` sessions join the workload container's namespaces —
-/// so the workload container is the one place a mount is visible everywhere
-/// and lives exactly as long as the machine's workload. A machine with no
-/// workload of its own gets a minimal holder (`sleep infinity`) so a live
-/// container exists for exec sessions to join. Machines whose image CMD exits
-/// immediately (an interactive shell, say) should be created with a
-/// long-lived command such as `-- sleep infinity`.
-/// Build the remote-volume mount script — the `&&`-joined mount commands — that
-/// the agent runs inside the workload container, ahead of the image-resolved
-/// workload command. The agent (not the host) does the wrapping, so a service
-/// image's own ENTRYPOINT still runs rather than being replaced by a mount stub,
-/// and an image with no command falls back to a keep-alive holder there.
-pub fn mount_script(volumes: &[RemoteVolume], env: &[(String, String)]) -> crate::Result<String> {
-    Ok(mount_commands(volumes, env)?.join(" && "))
+) -> Vec<smolvm_protocol::S3Volume> {
+    volumes.iter().map(|v| v.to_s3_volume(env)).collect()
 }
 
 #[cfg(test)]
@@ -302,15 +222,6 @@ mod tests {
     fn split(specs: &[&str]) -> (Vec<String>, Vec<RemoteVolume>) {
         let specs: Vec<String> = specs.iter().map(|s| s.to_string()).collect();
         split_specs(&specs).unwrap()
-    }
-
-    #[test]
-    fn host_specs_pass_through_untouched() {
-        // Plain dirs, relative dirs, and Windows drive-letter paths all stay
-        // on the HostMount path exactly as written.
-        let (host, remote) = split(&["/data:/data:ro", "C:\\data:/data", "./x:/y"]);
-        assert_eq!(host.len(), 3);
-        assert!(remote.is_empty());
     }
 
     #[test]
@@ -328,88 +239,11 @@ mod tests {
     }
 
     #[test]
-    fn raw_rclone_strings_keep_their_internal_colons() {
-        // The connection string itself contains ':' and ','; the right-anchored
-        // parse peels the guest path off the end.
-        let (_, remote) = split(&[":sftp,host=example.com,user=me:/srv/files:/mnt/sftp"]);
-        assert_eq!(
-            remote[0].source,
-            ":sftp,host=example.com,user=me:/srv/files"
-        );
-        assert_eq!(remote[0].target, "/mnt/sftp");
-        assert!(!remote[0].read_only);
-    }
-
-    #[test]
-    fn s3_translation_is_anonymous_without_credentials() {
-        let v = &split(&["s3://bucket/p:/d"]).1[0];
-        assert_eq!(v.rclone_remote(&[]).unwrap(), ":s3,provider=AWS:bucket/p");
-    }
-
-    #[test]
-    fn s3_translation_uses_env_auth_and_endpoint_when_present() {
-        let v = &split(&["s3://bucket:/d"]).1[0];
-        let env = vec![
-            ("AWS_ACCESS_KEY_ID".to_string(), "k".to_string()),
-            (
-                "AWS_ENDPOINT_URL".to_string(),
-                "https://acc.r2.cloudflarestorage.com".to_string(),
-            ),
-        ];
-        assert_eq!(
-            v.rclone_remote(&env).unwrap(),
-            ":s3,provider=AWS,env_auth=true,endpoint=\"https://acc.r2.cloudflarestorage.com\":bucket"
-        );
-        // http endpoints additionally force multipart uploads — streaming
-        // single-part PUTs to plain http fail in rclone's aws-sdk-v2 backend.
-        let http_env = vec![(
-            "AWS_ENDPOINT_URL".to_string(),
-            "http://100.96.0.1:9000".to_string(),
-        )];
-        assert_eq!(
-            v.rclone_remote(&http_env).unwrap(),
-            ":s3,provider=AWS,endpoint=\"http://100.96.0.1:9000\",upload_cutoff=0:bucket"
-        );
-    }
-
-    #[test]
     fn rejects_relative_guest_path_and_quotes_and_empty_bucket() {
         assert!(split_specs(&["s3://b:data".to_string()]).is_err());
         assert!(split_specs(&["s3://b:/it's:ro".to_string()]).is_err());
         assert!(split_specs(&["s3://:/d".to_string()]).is_err());
         assert!(split_specs(&["s3://b:/d".to_string(), "s3://c:/d".to_string()]).is_err());
-    }
-
-    #[test]
-    fn raw_remote_must_keep_its_path_colon() {
-        // Missing ':path' (the trailing colon was eaten as the guest separator)
-        // is rejected with the '::' hint...
-        let err = split_specs(&[":http,url=\"https://host\":/mnt/d".to_string()]).unwrap_err();
-        assert!(err.to_string().contains("::"));
-        // ...and the double-colon empty-path form parses with the colon intact.
-        let (_, remote) = split(&[":http,url=\"https://host\"::/mnt/d:ro"]);
-        assert_eq!(remote[0].source, ":http,url=\"https://host\":");
-        assert_eq!(remote[0].target, "/mnt/d");
-    }
-
-    #[test]
-    fn mount_script_is_the_joined_mount_commands_not_a_wrapper() {
-        // The host builds only the mount SCRIPT; the agent wraps it ahead of the
-        // image-resolved command (so a service image's entrypoint is preserved).
-        let vols = split(&["s3://bucket:/mnt/d:ro"]).1;
-        let script = mount_script(&vols, &[]).unwrap();
-        assert!(
-            script.contains("rclone"),
-            "script mounts via rclone: {script}"
-        );
-        assert!(
-            script.contains("/mnt/d"),
-            "script targets the guest path: {script}"
-        );
-        assert!(
-            !script.contains("exec \"$@\"") && !script.contains("sleep infinity"),
-            "wrapping is the agent's job now, not the host's: {script}"
-        );
     }
 
     #[test]
@@ -428,19 +262,86 @@ mod tests {
         assert!(is_remote_source("s3://b"));
         assert!(is_remote_source(":http,url=\"https://h\":"));
     }
+}
+
+#[cfg(test)]
+mod s3_spec_tests {
+    use super::*;
+
+    fn vol(source: &str) -> RemoteVolume {
+        RemoteVolume {
+            source: source.to_string(),
+            target: "/mnt/data".to_string(),
+            read_only: false,
+        }
+    }
 
     #[test]
-    fn mount_command_quotes_and_picks_mode() {
-        let v = &split(&["s3://bucket:/mnt/d:ro"]).1[0];
-        let cmd = v.mount_command(&[]).unwrap();
+    fn a_bucket_without_a_prefix_mounts_the_whole_bucket() {
+        let v = vol("s3://my-bucket").to_s3_volume(&[]);
+        assert_eq!(v.bucket, "my-bucket");
+        assert_eq!(v.prefix, "");
+        assert_eq!(v.mountpoint, "/mnt/data");
+    }
+
+    #[test]
+    fn a_prefix_selects_a_sub_tree_of_the_bucket() {
+        let v = vol("s3://my-bucket/nested/prefix").to_s3_volume(&[]);
+        assert_eq!(v.bucket, "my-bucket");
+        assert_eq!(v.prefix, "nested/prefix");
+    }
+
+    // A public dataset has no credentials; mounting anonymously is correct
+    // rather than an error.
+    #[test]
+    fn no_credentials_means_anonymous_access() {
+        let v = vol("s3://noaa-goes16").to_s3_volume(&[]);
+        assert!(v.access_key_id.is_none());
+        assert!(v.secret_access_key.is_none());
+        assert_eq!(v.endpoint, "https://s3.us-east-1.amazonaws.com");
+    }
+
+    // The env names match what every AWS SDK reads, so an existing workload's
+    // configuration carries over untouched.
+    #[test]
+    fn credentials_and_endpoint_come_from_the_machine_env() {
+        let env = vec![
+            ("AWS_ACCESS_KEY_ID".to_string(), "AKIA".to_string()),
+            ("AWS_SECRET_ACCESS_KEY".to_string(), "secret".to_string()),
+            (
+                "AWS_ENDPOINT_URL".to_string(),
+                "http://minio:9000".to_string(),
+            ),
+            ("AWS_REGION".to_string(), "eu-west-1".to_string()),
+        ];
+        let v = vol("s3://b").to_s3_volume(&env);
+        assert_eq!(v.access_key_id.as_deref(), Some("AKIA"));
+        assert_eq!(v.secret_access_key.as_deref(), Some("secret"));
+        assert_eq!(v.endpoint, "http://minio:9000");
+        assert_eq!(v.region, "eu-west-1");
+    }
+
+    #[test]
+    fn the_region_shapes_the_default_aws_endpoint() {
+        let env = vec![("AWS_DEFAULT_REGION".to_string(), "ap-south-1".to_string())];
+        let v = vol("s3://b").to_s3_volume(&env);
+        assert_eq!(v.endpoint, "https://s3.ap-south-1.amazonaws.com");
+    }
+
+    #[test]
+    fn empty_env_values_are_treated_as_unset() {
+        let env = vec![("AWS_ACCESS_KEY_ID".to_string(), String::new())];
+        let v = vol("s3://b").to_s3_volume(&env);
         assert!(
-            cmd.contains("rclone mount ':s3,provider=AWS:bucket' '/mnt/d' --daemon --read-only")
+            v.access_key_id.is_none(),
+            "an empty key must not sign requests"
         );
-        assert!(cmd.contains("mknod /dev/fuse"));
-        let rw = &split(&["s3://bucket:/mnt/d"]).1[0];
-        assert!(rw
-            .mount_command(&[])
-            .unwrap()
-            .contains("--daemon --vfs-cache-mode writes"));
+    }
+
+    #[test]
+    fn read_only_carries_through_to_the_mount() {
+        let mut r = vol("s3://b");
+        r.read_only = true;
+        assert!(r.to_s3_volume(&[]).read_only);
     }
 }

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -71,19 +71,10 @@ pub fn launch_image_workload(
     };
     let mut command = record.entrypoint.clone();
     command.extend(record.cmd.clone());
-    // Remote volumes mount inside the workload container (the one namespace
-    // exec/shell sessions join). Build the mount SCRIPT here but let the AGENT
-    // run it ahead of the image-resolved command — wrapping host-side would only
-    // see the empty request command and replace a service image's own entrypoint
-    // with a mount stub. See `crate::remote_volume::mount_script`.
-    let remote_volume_mount = if record.remote_volumes.is_empty() {
-        None
-    } else {
-        Some(crate::remote_volume::mount_script(
-            &record.remote_volumes,
-            &exec_env,
-        )?)
-    };
+    // Remote volumes are mounted by the agent itself, natively, between the
+    // container's create and start — so the workload sees its data from its
+    // first instruction and its command is never rewritten.
+    let s3_volumes = crate::remote_volume::to_s3_volumes(&record.remote_volumes, &exec_env);
     match client.run_container_detached(
         RunConfig::new(image, command)
             .with_env(exec_env)
@@ -94,7 +85,7 @@ pub fn launch_image_workload(
                 machine_name,
                 record.golden.as_deref(),
             )))
-            .with_remote_volume_mount(remote_volume_mount),
+            .with_s3_volumes(s3_volumes),
     ) {
         Ok(_) => Ok(true),
         Err(e) if is_missing_launch_metadata(&e.to_string()) => {

--- a/tests/test_remote_volumes.sh
+++ b/tests/test_remote_volumes.sh
@@ -227,7 +227,25 @@ else
   rm -f "$RVSOCK"
 fi
 
-# ---- 11. service image keeps its own entrypoint AND still mounts -----------
+# ---- 11. ephemeral `machine run` mounts too --------------------------------
+# `machine run` never creates the container with `crun create` + `crun start`,
+# so it has no window in which to mount; it must establish the container the
+# two-step way when a remote volume is present rather than silently skip it.
+GOT=$($S machine run --image alpine:latest --net --net-backend virtio-net $CREDS \
+  -v "s3://rv-bucket:/mnt/run" -- cat /mnt/run/keep.txt 2>/dev/null | tr -d '\r\n')
+check "ephemeral run mounts the volume" "$GOT" "keep"
+$S machine run --image alpine:latest --net --net-backend virtio-net $CREDS \
+  -v "s3://rv-bucket:/mnt/run" -- sh -c 'echo run-1 > /mnt/run/run.txt' >/dev/null 2>&1
+check "ephemeral run write visible out-of-band" "$(oob run.txt)" "run-1"
+
+# A run whose bucket is unusable must fail instead of running the command
+# against an empty directory.
+OUT=$($S machine run --image alpine:latest --net --net-backend virtio-net $CREDS \
+  -v "s3://nosuchbucket:/mnt/run" -- echo SHOULD-NOT-RUN 2>&1)
+echo "$OUT" | grep -q "not reachable" && ok "ephemeral run fails on an unusable bucket" || bad "ephemeral run fails on an unusable bucket"
+echo "$OUT" | grep -q "SHOULD-NOT-RUN" && bad "the command must not run without its volume" || ok "the command does not run without its volume"
+
+# ---- 12. service image keeps its own entrypoint AND still mounts -----------
 # No `--` command: the image's ENTRYPOINT/CMD is resolved inside the guest and
 # must still run. Mounting happens between container create and start, so the
 # entrypoint is never rewritten to carry a mount command.

--- a/tests/test_remote_volumes.sh
+++ b/tests/test_remote_volumes.sh
@@ -1,10 +1,14 @@
 #!/bin/sh
-# End-to-end tests for remote volumes (-v s3://... and raw rclone remotes).
+# End-to-end tests for remote volumes (-v s3://bucket[/prefix]:/guest/path).
 #
 # Fully self-contained: runs a MinIO S3 server inside a smolvm machine and
-# verifies every write OUT-OF-BAND from a separate machine via the raw S3 API
-# (the vfs write cache survives on the persistent overlay, so reading back
-# through the same mount proves nothing).
+# verifies every write OUT-OF-BAND from a separate machine via the raw S3 API,
+# because reading a write back through the same mount would also pass if the
+# data never left the guest.
+#
+# The mount is performed by the agent itself, so the images under test are
+# plain `alpine:latest` and `nginx:alpine` with no tools installed: an image
+# that has to `apk add` anything is a regression, not a fixture.
 #
 # Usage: ./tests/test_remote_volumes.sh [path-to-smolvm]
 set -u
@@ -15,8 +19,10 @@ bad()  { FAIL=$((FAIL+1)); echo "FAIL: $1"; }
 check() { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (want '$3' got '$2')"; fi; }
 
 CREDS="--env AWS_ACCESS_KEY_ID=smoltest --env AWS_SECRET_ACCESS_KEY=smoltest123 --env AWS_ENDPOINT_URL=http://100.96.0.1:9000"
+# The verifier is a test client, not a product dependency: it reads the bucket
+# over the S3 API from outside every mount under test.
 RCLONE_REMOTE=':s3,provider=Minio,access_key_id=smoltest,secret_access_key=smoltest123,endpoint="http://100.96.0.1:9000"'
-NAMES="rv-minio rv-ver rv-rw rv-ro rv-notools rv-badremote rv-sf rv-api rv-svc"
+NAMES="rv-minio rv-ver rv-rw rv-ro rv-plain rv-badbucket rv-deadendpoint rv-sf rv-api rv-svc rv-x"
 cleanup() { for n in $NAMES; do $S machine delete --name "$n" --force >/dev/null 2>&1; done; }
 cleanup
 
@@ -31,9 +37,9 @@ done
 $S machine create --name rv-ver --image alpine:latest --net --net-backend virtio-net >/dev/null 2>&1
 $S machine start --name rv-ver >/dev/null 2>&1
 $S machine exec --name rv-ver -- sh -c "apk add -q rclone >/dev/null 2>&1; rclone mkdir '$RCLONE_REMOTE:rv-bucket' 2>/dev/null" >/dev/null 2>&1
-# Read an object back OUT-OF-BAND, polling up to ~20s: rclone's vfs cache
-# uploads writes asynchronously, so a fixed post-write sleep races the flush
-# under load. Poll until the object lands (or give up and return what we have).
+# Read an object back OUT-OF-BAND, polling a few seconds: a write is uploaded
+# when the guest closes the file, so a read issued immediately after the shell
+# returns can still race the upload.
 oob() {
   _v=""
   i=0; while [ $i -lt 20 ]; do
@@ -48,54 +54,87 @@ oob() {
 OUT=$($S machine create --name rv-x --image alpine:latest --net -v "s3://b:relative" -- sleep infinity 2>&1)
 echo "$OUT" | grep -q "must be absolute" && ok "relative guest path rejected" || bad "relative guest path rejected"
 OUT=$($S machine create --name rv-x --image alpine:latest --net -v ':http,url="https://h":/mnt/x' -- sleep infinity 2>&1)
-echo "$OUT" | grep -q "::" && ok "missing remote path colon rejected with :: hint" || bad "missing remote path colon rejected with :: hint"
+echo "$OUT" | grep -q "rclone" && ok "rclone remote rejected as unsupported" || bad "rclone remote rejected as unsupported"
+echo "$OUT" | grep -q "s3://" && ok "rclone rejection names the S3 form" || bad "rclone rejection names the S3 form"
 OUT=$($S machine create --name rv-x --image alpine:latest -v "s3://b:/mnt/x" -- sleep infinity 2>&1)
 echo "$OUT" | grep -q "network" && ok "remote volume without network rejected" || bad "remote volume without network rejected"
 
-# ---- 2. missing tools fails the START with the actionable message ---------
-$S machine create --name rv-notools --image alpine:latest --net --net-backend virtio-net $CREDS \
+# ---- 2. a stock image with NO tools mounts and reads -----------------------
+# The headline of the native mount: nothing is installed in the image, and the
+# machine is never given an init command.
+$S machine create --name rv-plain --image alpine:latest --net --net-backend virtio-net $CREDS \
   -v "s3://rv-bucket:/mnt/q" -- sleep infinity >/dev/null 2>&1
-OUT=$($S machine start --name rv-notools 2>&1)
-echo "$OUT" | grep -q "rclone and fuse3" && ok "missing tools fails start with hint" || bad "missing tools fails start with hint"
+$S machine start --name rv-plain >/dev/null 2>&1
+check "stock image mounts with no tools installed" \
+  "$($S machine exec --name rv-plain -- sh -c 'grep -c " /mnt/q " /proc/mounts' 2>/dev/null | tr -d '\r\n')" "1"
+check "the image really has no rclone" \
+  "$($S machine exec --name rv-plain -- sh -c 'command -v rclone >/dev/null && echo yes || echo no' 2>/dev/null | tr -d '\r\n')" "no"
+check "the image really has no fusermount3" \
+  "$($S machine exec --name rv-plain -- sh -c 'command -v fusermount3 >/dev/null && echo yes || echo no' 2>/dev/null | tr -d '\r\n')" "no"
 
-# ---- 3. a dead mount (garbage backend) fails the START --------------------
-$S machine create --name rv-badremote --image alpine:latest --net --net-backend virtio-net \
-  --init "apk add -q rclone fuse3" -v ":nosuchbackend,x=1::/mnt/q" -- sleep infinity >/dev/null 2>&1
-OUT=$($S machine start --name rv-badremote 2>&1)
-echo "$OUT" | grep -q "failed to mount" && ok "dead mount fails start with log pointer" || bad "dead mount fails start with log pointer"
+# ---- 3. an unusable bucket FAILS the start ---------------------------------
+# mount(2) on /dev/fuse succeeds without ever contacting S3, so a mount alone
+# proves nothing; without a reachability check these would start happily and
+# serve an empty directory.
+$S machine create --name rv-badbucket --image alpine:latest --net --net-backend virtio-net $CREDS \
+  -v "s3://nosuchbucket:/mnt/q" -- sleep infinity >/dev/null 2>&1
+OUT=$($S machine start --name rv-badbucket 2>&1)
+echo "$OUT" | grep -q "not reachable" && ok "missing bucket fails the start" || bad "missing bucket fails the start"
+echo "$OUT" | grep -qi "nosuchbucket" && ok "the failure names the bucket" || bad "the failure names the bucket"
+
+$S machine create --name rv-deadendpoint --image alpine:latest --net --net-backend virtio-net \
+  --env AWS_ACCESS_KEY_ID=smoltest --env AWS_SECRET_ACCESS_KEY=smoltest123 \
+  --env AWS_ENDPOINT_URL=http://127.0.0.1:9999 \
+  -v "s3://rv-bucket:/mnt/q" -- sleep infinity >/dev/null 2>&1
+OUT=$($S machine start --name rv-deadendpoint 2>&1)
+echo "$OUT" | grep -q "not reachable" && ok "dead endpoint fails the start" || bad "dead endpoint fails the start"
 
 # ---- 4. rw round trip, out-of-band verified -------------------------------
 $S machine create --name rv-rw --image alpine:latest --net --net-backend virtio-net $CREDS \
-  --init "apk add -q rclone fuse3" -v "s3://rv-bucket:/mnt/rw" -- sleep infinity >/dev/null 2>&1
+  -v "s3://rv-bucket:/mnt/rw" -- sleep infinity >/dev/null 2>&1
 $S machine start --name rv-rw >/dev/null 2>&1
-$S machine exec --name rv-rw -- sh -c 'echo rt-1 > /mnt/rw/rt.txt && sync && sleep 5' >/dev/null 2>&1
+$S machine exec --name rv-rw -- sh -c 'echo rt-1 > /mnt/rw/rt.txt' >/dev/null 2>&1
 check "rw write visible out-of-band" "$(oob rt.txt)" "rt-1"
 
-# ---- 5. restart: mount returns, content intact, appends flush -------------
+# A directory tree has to survive the round trip: S3 has no directories, so
+# these are synthesised from key prefixes.
+$S machine exec --name rv-rw -- sh -c 'mkdir -p /mnt/rw/d/e && echo deep > /mnt/rw/d/e/f.txt' >/dev/null 2>&1
+check "nested write visible out-of-band" "$(oob d/e/f.txt)" "deep"
+check "nested path lists through the mount" \
+  "$($S machine exec --name rv-rw -- sh -c 'ls /mnt/rw/d/e' 2>/dev/null | tr -d '\r\n')" "f.txt"
+
+# An object written from outside must appear through the mount.
+$S machine exec --name rv-ver -- sh -c "echo outside | rclone rcat '$RCLONE_REMOTE:rv-bucket/ext.txt' 2>/dev/null" >/dev/null 2>&1
+check "externally written object is visible" \
+  "$($S machine exec --name rv-rw -- sh -c 'cat /mnt/rw/ext.txt' 2>/dev/null | tr -d '\r\n')" "outside"
+
+$S machine exec --name rv-rw -- sh -c 'rm /mnt/rw/rt.txt' >/dev/null 2>&1
+check "unlink removes the object" "$(oob rt.txt)" ""
+
+# ---- 5. restart: mount returns, content intact ----------------------------
+$S machine exec --name rv-rw -- sh -c 'echo keep > /mnt/rw/keep.txt' >/dev/null 2>&1
 $S machine stop --name rv-rw >/dev/null 2>&1
 $S machine start --name rv-rw >/dev/null 2>&1
-GOT=$($S machine exec --name rv-rw -- sh -c 'cat /mnt/rw/rt.txt 2>/dev/null' 2>/dev/null)
-check "mount returns after restart with content" "$GOT" "rt-1"
+GOT=$($S machine exec --name rv-rw -- sh -c 'cat /mnt/rw/keep.txt 2>/dev/null' 2>/dev/null | tr -d '\r\n')
+check "mount returns after restart with content" "$GOT" "keep"
 
 # ---- 6. large-file integrity ----------------------------------------------
-H1=$($S machine exec --name rv-rw -- sh -c 'dd if=/dev/urandom of=/tmp/b bs=1M count=8 2>/dev/null; sha256sum /tmp/b | cut -d" " -f1; cp /tmp/b /mnt/rw/b.bin && sync && sleep 8' 2>/dev/null | tail -1)
-H2=$($S machine exec --name rv-ver -- sh -c "rclone cat '$RCLONE_REMOTE:rv-bucket/b.bin' 2>/dev/null | sha256sum | cut -d' ' -f1" 2>/dev/null | tail -1)
-check "8MB sha256 integrity out-of-band" "$H2" "$H1"
+H1=$($S machine exec --name rv-rw -- sh -c 'dd if=/dev/urandom of=/tmp/b bs=1M count=8 2>/dev/null; sha256sum /tmp/b | cut -d" " -f1; cp /tmp/b /mnt/rw/b.bin' 2>/dev/null | head -1 | tr -d '\r\n')
+H2=$($S machine exec --name rv-ver -- sh -c "rclone cat '$RCLONE_REMOTE:rv-bucket/b.bin' 2>/dev/null | sha256sum | cut -d' ' -f1" 2>/dev/null | tail -1 | tr -d '\r\n')
+# Guard the comparison: two empty hashes would otherwise "match" and pass.
+if [ ${#H1} -eq 64 ]; then
+  check "8MB sha256 integrity out-of-band" "$H2" "$H1"
+else
+  bad "8MB sha256 integrity out-of-band (no hash from the guest)"
+fi
 
 # ---- 7. read-only enforcement ---------------------------------------------
 $S machine create --name rv-ro --image alpine:latest --net --net-backend virtio-net $CREDS \
-  --init "apk add -q rclone fuse3" -v "s3://rv-bucket:/mnt/q:ro" -- sleep infinity >/dev/null 2>&1
+  -v "s3://rv-bucket:/mnt/q:ro" -- sleep infinity >/dev/null 2>&1
 $S machine start --name rv-ro >/dev/null 2>&1
-# Assert only once the ro rclone mount is actually live in the container ns —
-# before that a write lands in the overlay dir and would falsely "succeed".
-OUT=""
-n=0; while [ $n -lt 12 ]; do
-  if $S machine exec --name rv-ro -- sh -c 'grep -q " /mnt/q " /proc/mounts' 2>/dev/null; then
-    OUT=$($S machine exec --name rv-ro -- sh -c 'echo x > /mnt/q/no.txt 2>&1 || true' 2>/dev/null)
-    break
-  fi
-  n=$((n+1)); sleep 1
-done
+check "ro mount is readable" \
+  "$($S machine exec --name rv-ro -- sh -c 'cat /mnt/q/keep.txt' 2>/dev/null | tr -d '\r\n')" "keep"
+OUT=$($S machine exec --name rv-ro -- sh -c 'echo x > /mnt/q/no.txt 2>&1 || true' 2>/dev/null)
 echo "$OUT" | grep -qi "read-only" && ok "ro mount rejects writes" || bad "ro mount rejects writes"
 
 # ---- 8. fork of a remote-volume golden is refused cleanly -----------------
@@ -114,12 +153,11 @@ env = [
   "AWS_ENDPOINT_URL=http://100.96.0.1:9000",
 ]
 volumes = ["s3://rv-bucket:/mnt/sf"]
-init = ["apk add -q rclone fuse3"]
 SMOLEOF
 $S machine create --name rv-sf --smolfile "$TMPD/Smolfile" --net-backend virtio-net >/dev/null 2>&1 \
   && $S machine start --name rv-sf >/dev/null 2>&1 \
   && ok "smolfile machine with remote volume starts" || bad "smolfile machine with remote volume starts"
-$S machine exec --name rv-sf -- sh -c 'echo sf-1 > /mnt/sf/sf.txt && sync && sleep 5' >/dev/null 2>&1
+$S machine exec --name rv-sf -- sh -c 'echo sf-1 > /mnt/sf/sf.txt' >/dev/null 2>&1
 check "smolfile write visible out-of-band" "$(oob sf.txt)" "sf-1"
 rm -rf "$TMPD"
 
@@ -135,9 +173,10 @@ else
   SERVE_PID=$!
   i=0; until [ -S "$RVSOCK" ]; do i=$((i+1)); [ $i -gt 20 ] && break; sleep 1; done
   api() { curl -s -m 300 --unix-socket "$RVSOCK" "$@"; }
+  BADJSON=$(mktemp)
   CODE=$(api -o /dev/null -w '%{http_code}' -X POST http://localhost/api/v1/machines \
     -H 'Content-Type: application/json' -d '{
-    "name": "rv-api", "image": "rclone/rclone",
+    "name": "rv-api", "image": "alpine:latest",
     "network": true, "network_backend": "virtio-net",
     "entrypoint": ["sleep"], "cmd": ["infinity"],
     "env": [
@@ -149,17 +188,16 @@ else
   check "api create accepts remote mount" "$CODE" "200"
   CODE=$(api -o /dev/null -w '%{http_code}' -X POST http://localhost/api/v1/machines/rv-api/start)
   check "api start mounts the volume" "$CODE" "200"
-  sleep 10
   api -X POST http://localhost/api/v1/machines/rv-api/exec -H 'Content-Type: application/json' \
-    -d '{"command":["sh","-c","echo api-1 > /mnt/api/api.txt && sync && sleep 6"]}' >/dev/null 2>&1
+    -d '{"command":["sh","-c","echo api-1 > /mnt/api/api.txt"]}' >/dev/null 2>&1
   check "api-machine write visible out-of-band" "$(oob api.txt)" "api-1"
-  CODE=$(api -o "$TMPD.badjson" -w '%{http_code}' -X POST http://localhost/api/v1/machines \
+  CODE=$(api -o "$BADJSON" -w '%{http_code}' -X POST http://localhost/api/v1/machines \
     -H 'Content-Type: application/json' -d '{
     "name": "rv-api-bad", "image": "alpine:latest", "network": true,
     "mounts": [{"source": ":http,url=\"https://h\"", "target": "/mnt/x"}]}')
-  check "api rejects malformed rclone remote (400)" "$CODE" "400"
-  grep -q "::" "$TMPD.badjson" 2>/dev/null && ok "api 400 carries the :: hint" || bad "api 400 carries the :: hint"
-  rm -f "$TMPD.badjson"
+  check "api rejects an rclone remote (400)" "$CODE" "400"
+  grep -q "rclone" "$BADJSON" 2>/dev/null && ok "api 400 says rclone is unsupported" || bad "api 400 says rclone is unsupported"
+  rm -f "$BADJSON"
   api -X DELETE "http://localhost/api/v1/machines/rv-api?force=true" >/dev/null 2>&1
   kill "$SERVE_PID" 2>/dev/null
   rm -f "$RVSOCK"
@@ -167,22 +205,20 @@ fi
 
 # ---- 11. service image keeps its own entrypoint AND still mounts -----------
 # No `--` command: the image's ENTRYPOINT/CMD is resolved inside the guest and
-# must still run. The agent wraps the mount AROUND that resolved command
-# (`sh -c '<mounts> && exec "$@"' sh <argv>`); a host-side wrap only saw the
-# empty request command and would replace nginx with a bare mount stub.
+# must still run. Mounting happens between container create and start, so the
+# entrypoint is never rewritten to carry a mount command.
 $S machine create --name rv-svc --image nginx:alpine --net --net-backend virtio-net $CREDS \
-  --init "apk add -q rclone fuse3" -v "s3://rv-bucket:/mnt/svc" >/dev/null 2>&1
+  -v "s3://rv-bucket:/mnt/svc" >/dev/null 2>&1
 $S machine start --name rv-svc >/dev/null 2>&1
-# The wrap execs into the image entrypoint, so nginx becomes PID 1 after a brief
-# sh -> docker-entrypoint.sh -> exec nginx transition — poll /proc/1/comm rather
-# than probe once (and it sidesteps busybox pgrep quirks).
 GOT=
 n=0; while [ $n -lt 15 ]; do
-  [ "$($S machine exec --name rv-svc -- sh -c 'cat /proc/1/comm' 2>/dev/null)" = nginx ] && { GOT=up; break; }
+  [ "$($S machine exec --name rv-svc -- sh -c 'cat /proc/1/comm' 2>/dev/null | tr -d '\r\n')" = nginx ] && { GOT=up; break; }
   n=$((n+1)); sleep 1
 done
 check "service entrypoint runs under a remote volume" "$GOT" "up"
-$S machine exec --name rv-svc -- sh -c 'echo svc-1 > /mnt/svc/svc.txt && sync && sleep 5' >/dev/null 2>&1
+check "service-image mount is live at first instruction" \
+  "$($S machine exec --name rv-svc -- sh -c 'cat /mnt/svc/keep.txt' 2>/dev/null | tr -d '\r\n')" "keep"
+$S machine exec --name rv-svc -- sh -c 'echo svc-1 > /mnt/svc/svc.txt' >/dev/null 2>&1
 check "service-image mount write visible out-of-band" "$(oob svc.txt)" "svc-1"
 
 cleanup

--- a/tests/test_remote_volumes.sh
+++ b/tests/test_remote_volumes.sh
@@ -134,8 +134,11 @@ $S machine create --name rv-ro --image alpine:latest --net --net-backend virtio-
 $S machine start --name rv-ro >/dev/null 2>&1
 check "ro mount is readable" \
   "$($S machine exec --name rv-ro -- sh -c 'cat /mnt/q/keep.txt' 2>/dev/null | tr -d '\r\n')" "keep"
-OUT=$($S machine exec --name rv-ro -- sh -c 'echo x > /mnt/q/no.txt 2>&1 || true' 2>/dev/null)
-echo "$OUT" | grep -qi "read-only" && ok "ro mount rejects writes" || bad "ro mount rejects writes"
+# Keep stderr: `machine exec` forwards the guest's stderr to the host's stderr,
+# so discarding it here would throw away the very message being asserted.
+OUT=$($S machine exec --name rv-ro -- sh -c 'echo x > /mnt/q/no.txt' 2>&1)
+echo "$OUT" | grep -qi "read-only" && ok "ro mount rejects writes" || bad "ro mount rejects writes ($OUT)"
+check "the rejected write did not reach the bucket" "$(oob no.txt)" ""
 
 # ---- 8. fork of a remote-volume golden is refused cleanly -----------------
 OUT=$($S machine fork --golden rv-ro --name rv-clone 2>&1)

--- a/tests/test_remote_volumes.sh
+++ b/tests/test_remote_volumes.sh
@@ -79,15 +79,21 @@ check "the image really has no fusermount3" \
 $S machine create --name rv-badbucket --image alpine:latest --net --net-backend virtio-net $CREDS \
   -v "s3://nosuchbucket:/mnt/q" -- sleep infinity >/dev/null 2>&1
 OUT=$($S machine start --name rv-badbucket 2>&1)
-echo "$OUT" | grep -q "not reachable" && ok "missing bucket fails the start" || bad "missing bucket fails the start"
-echo "$OUT" | grep -qi "nosuchbucket" && ok "the failure names the bucket" || bad "the failure names the bucket"
+# Assert the DISCRIMINATING part of the message. "not reachable" alone is also
+# what a transport error produces, so grepping only for that would pass when the
+# MinIO rig itself is down -- reporting success for the wrong reason while every
+# positive case fails.
+echo "$OUT" | grep -q "NoSuchBucket" && ok "missing bucket fails the start" || bad "missing bucket fails the start ($OUT)"
+echo "$OUT" | grep -qi "nosuchbucket:" && ok "the failure names the bucket" || bad "the failure names the bucket"
 
 $S machine create --name rv-deadendpoint --image alpine:latest --net --net-backend virtio-net \
   --env AWS_ACCESS_KEY_ID=smoltest --env AWS_SECRET_ACCESS_KEY=smoltest123 \
   --env AWS_ENDPOINT_URL=http://127.0.0.1:9999 \
   -v "s3://rv-bucket:/mnt/q" -- sleep infinity >/dev/null 2>&1
 OUT=$($S machine start --name rv-deadendpoint 2>&1)
-echo "$OUT" | grep -q "not reachable" && ok "dead endpoint fails the start" || bad "dead endpoint fails the start"
+# Here a transport failure IS the expected cause, so match it specifically
+# rather than the shared "not reachable" prefix.
+echo "$OUT" | grep -q "transport:" && ok "dead endpoint fails the start" || bad "dead endpoint fails the start ($OUT)"
 
 # ---- 4. rw round trip, out-of-band verified -------------------------------
 $S machine create --name rv-rw --image alpine:latest --net --net-backend virtio-net $CREDS \
@@ -242,7 +248,7 @@ check "ephemeral run write visible out-of-band" "$(oob run.txt)" "run-1"
 # against an empty directory.
 OUT=$($S machine run --image alpine:latest --net --net-backend virtio-net $CREDS \
   -v "s3://nosuchbucket:/mnt/run" -- echo SHOULD-NOT-RUN 2>&1)
-echo "$OUT" | grep -q "not reachable" && ok "ephemeral run fails on an unusable bucket" || bad "ephemeral run fails on an unusable bucket"
+echo "$OUT" | grep -q "NoSuchBucket" && ok "ephemeral run fails on an unusable bucket" || bad "ephemeral run fails on an unusable bucket"
 echo "$OUT" | grep -q "SHOULD-NOT-RUN" && bad "the command must not run without its volume" || ok "the command does not run without its volume"
 
 # ---- 12. service image keeps its own entrypoint AND still mounts -----------

--- a/tests/test_remote_volumes.sh
+++ b/tests/test_remote_volumes.sh
@@ -111,6 +111,27 @@ check "externally written object is visible" \
 $S machine exec --name rv-rw -- sh -c 'rm /mnt/rw/rt.txt' >/dev/null 2>&1
 check "unlink removes the object" "$(oob rt.txt)" ""
 
+# Rewriting a file with fewer bytes must not leave the old tail behind. This is
+# checked out-of-band on purpose: the mount can report the correct short length
+# from its own staging state while the stored object is still the long one.
+$S machine exec --name rv-rw -- sh -c 'printf AAAAAAAAAA > /mnt/rw/shrink.txt' >/dev/null 2>&1
+$S machine exec --name rv-rw -- sh -c 'printf BB > /mnt/rw/shrink.txt' >/dev/null 2>&1
+check "rewriting shorter leaves no old tail" "$(oob shrink.txt)" "BB"
+
+# Truncation has to reach the bucket too: unless atomic_o_trunc is negotiated
+# the kernel sends O_TRUNC as a size change, which is easy to accept and drop.
+$S machine exec --name rv-rw -- sh -c 'printf 0123456789 > /mnt/rw/trunc.txt' >/dev/null 2>&1
+$S machine exec --name rv-rw -- sh -c ': > /mnt/rw/trunc.txt' >/dev/null 2>&1
+check "truncate to zero is stored" \
+  "$($S machine exec --name rv-rw -- sh -c 'wc -c < /mnt/rw/trunc.txt' 2>/dev/null | tr -d ' \r\n')" "0"
+
+# rename(2) keeps the inode, so the renamed file must stay readable through the
+# live mount -- not only after a remount.
+$S machine exec --name rv-rw -- sh -c 'echo moved > /mnt/rw/from.txt; mv /mnt/rw/from.txt /mnt/rw/to.txt' >/dev/null 2>&1
+check "renamed file is readable through the live mount" \
+  "$($S machine exec --name rv-rw -- sh -c 'cat /mnt/rw/to.txt' 2>/dev/null | tr -d '\r\n')" "moved"
+check "renamed file is in the bucket" "$(oob to.txt)" "moved"
+
 # ---- 5. restart: mount returns, content intact ----------------------------
 $S machine exec --name rv-rw -- sh -c 'echo keep > /mnt/rw/keep.txt' >/dev/null 2>&1
 $S machine stop --name rv-rw >/dev/null 2>&1


### PR DESCRIPTION
Remote volumes are now mounted by the agent speaking FUSE and the S3 API directly, so a bucket mounts into any image without rclone, fuse3 or a helper binary.