### PR TITLE
Carry remote volumes on the embedded machine spec so SDK machines can mount buckets

### DIFF
--- a/crates/smolvm-shim/src/engine.rs
+++ b/crates/smolvm-shim/src/engine.rs
@@ -614,7 +614,9 @@ impl PodBackend for EnginePodBackend {
                 },
                 persistent: true,
                 runtime_managed: true,
-                labels: Default::default(),
+                // Spread the rest so a new spec field does not break the shim.
+                // A pod sandbox mounts nothing remote of its own.
+                ..Default::default()
             };
             match rt.create_machine(spec.clone()) {
                 Ok(()) => {}

--- a/examples/doubledelete_test.rs
+++ b/examples/doubledelete_test.rs
@@ -19,7 +19,8 @@ fn main() {
         image: None,
         persistent: false,
         runtime_managed: false,
-        labels: Default::default(),
+        // Spread the rest so a new spec field does not break the fixture.
+        ..Default::default()
     })
     .expect("create");
     rt.delete_machine(name).expect("first delete");

--- a/examples/largeoutput_test.rs
+++ b/examples/largeoutput_test.rs
@@ -20,7 +20,8 @@ fn main() {
         image: None,
         persistent: false,
         runtime_managed: false,
-        labels: Default::default(),
+        // Spread the rest so a new spec field does not break the fixture.
+        ..Default::default()
     });
     rt.start_machine(name).expect("start");
     // small output: works

--- a/examples/orphan_test.rs
+++ b/examples/orphan_test.rs
@@ -24,7 +24,8 @@ fn main() {
         image: None,
         persistent: false,
         runtime_managed: false,
-        labels: Default::default(),
+        // Spread the rest so a new spec field does not break the fixture.
+        ..Default::default()
     };
     let _ = rt.create_machine(spec); // ignore "already exists" on reruns
     rt.start_machine(&name).expect("start machine");

--- a/examples/readfile_fix_test.rs
+++ b/examples/readfile_fix_test.rs
@@ -21,7 +21,8 @@ fn main() {
         image: None,
         persistent: false,
         runtime_managed: false,
-        labels: Default::default(),
+        // Spread the rest so a new spec field does not break the fixture.
+        ..Default::default()
     });
     rt.start_machine(name).expect("start");
 

--- a/examples/reattach_test.rs
+++ b/examples/reattach_test.rs
@@ -21,7 +21,8 @@ fn main() {
         image: None,
         persistent: true,
         runtime_managed: false,
-        labels: Default::default(),
+        // Spread the rest so a new spec field does not break the fixture.
+        ..Default::default()
     })
     .expect("create");
     rt.start_machine(name).expect("start");

--- a/src/embedded/control.rs
+++ b/src/embedded/control.rs
@@ -43,6 +43,8 @@ pub struct MachineSpec {
     /// record so node-reboot reconciliation can reclaim it (and only it) when
     /// its process is gone. Defaults to false for CLI/SDK machines.
     pub runtime_managed: bool,
+    /// S3-compatible volumes the agent mounts inside the guest on every start.
+    pub remote_volumes: Vec<crate::remote_volume::RemoteVolume>,
 }
 
 impl MachineSpec {
@@ -70,6 +72,7 @@ impl MachineSpec {
         record.labels = self.labels.clone();
         record.ephemeral = !self.persistent;
         record.runtime_managed = self.runtime_managed;
+        record.remote_volumes = self.remote_volumes.clone();
         record
     }
 }


### PR DESCRIPTION
The embedded machine spec dropped remote volumes when building the machine record, so a bucket requested through the SDKs was silently never mounted.