### PR TITLE
Bind a machine's overlay and remote volumes to one call so launch and exec sites cannot set one without the other

### DIFF
--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -481,6 +481,52 @@ impl RunConfig {
         }
     }
 
+    /// Target an existing machine: the overlay it runs in AND the buckets it
+    /// mounts, which must travel together.
+    ///
+    /// These two facts were previously set independently at ~15 launch and exec
+    /// sites, and a site that set the overlay but forgot the volumes produced a
+    /// workload running in the right filesystem with its bucket silently
+    /// missing — an empty directory, not an error. Binding them to one call
+    /// means a site either targets a machine completely or not at all, and a
+    /// future per-machine fact is added here rather than at every caller.
+    ///
+    /// `env` is the environment the machine will actually see (request env and
+    /// resolved secrets merged over the record's), because that is where the
+    /// bucket credentials come from.
+    pub fn in_machine(
+        mut self,
+        record: &crate::config::VmRecord,
+        machine_name: &str,
+        env: &[(String, String)],
+    ) -> Self {
+        // A caller with no env of its own (an interactive session, say) still
+        // needs the machine's credentials, which live on the record.
+        let env = if env.is_empty() { &record.env } else { env };
+        self.s3_volumes = crate::remote_volume::to_s3_volumes(&record.remote_volumes, env);
+        self.persistent_overlay_id = Some(crate::workload::persistent_overlay_owner(
+            machine_name,
+            record.golden.as_deref(),
+        ));
+        self
+    }
+
+    /// [`Self::in_machine`] for callers holding an optional record.
+    ///
+    /// A machine with no record (an ephemeral or bare-VM session) simply keeps
+    /// the config as-is, so a caller never has to branch on it.
+    pub fn in_machine_opt(
+        self,
+        record: Option<&crate::config::VmRecord>,
+        machine_name: &str,
+        env: &[(String, String)],
+    ) -> Self {
+        match record {
+            Some(record) => self.in_machine(record, machine_name, env),
+            None => self,
+        }
+    }
+
     /// Set the remote-volume mount script run inside the workload container.
     pub fn with_s3_volumes(mut self, volumes: Vec<smolvm_protocol::S3Volume>) -> Self {
         self.s3_volumes = volumes;

--- a/src/api/handlers/exec.rs
+++ b/src/api/handlers/exec.rs
@@ -83,15 +83,11 @@ pub async fn exec_command(
         let command = req.command.clone();
         let workdir = req.workdir.clone();
         let machine_rec = state.lookup_vm(&id).await?;
-        let machine_golden = machine_rec.as_ref().and_then(|r| r.golden.clone());
         // An exec may be what establishes the workload container — the machine's
         // command exited, or the image's own default was short-lived — and that
-        // container is where the mount lives. Carry the machine's volumes so the
-        // bucket is present in whichever container serves this session.
-        let exec_s3_volumes = machine_rec
-            .as_ref()
-            .map(|r| crate::remote_volume::to_s3_volumes(&r.remote_volumes, &r.env))
-            .unwrap_or_default();
+        // container is where the mount lives, so the config has to target the
+        // machine rather than merely reuse its overlay.
+        let machine_for_run = machine_rec.clone();
         let machine_image = machine_rec.and_then(|r| r.image);
         let pid = if let Some(image) = machine_image {
             let mounts_config = {
@@ -102,20 +98,18 @@ pub async fn exec_command(
                     .map(|(i, m)| (HostMount::mount_tag(i), m.target.clone(), m.readonly))
                     .collect::<Vec<_>>()
             };
-            // A fork clone's inherited overlay lives under the golden's id
-            // (see `persistent_overlay_owner`).
-            let overlay_id =
-                crate::workload::persistent_overlay_owner(&id, machine_golden.as_deref());
             with_machine_client_traced(&entry, tid, move |c| {
                 if c.query(&image)?.is_none() {
                     c.pull_with_registry_config(&image)?;
                 }
+                // The volumes are derived from the env the machine will see, so
+                // keep a copy before the builder consumes it.
+                let env_for_volumes = env.clone();
                 let config = crate::agent::RunConfig::new(image, command)
                     .with_env(env)
                     .with_workdir(workdir)
                     .with_mounts(mounts_config)
-                    .with_s3_volumes(exec_s3_volumes.clone())
-                    .with_persistent_overlay(Some(overlay_id));
+                    .in_machine_opt(machine_for_run.as_ref(), &id, &env_for_volumes);
                 c.run_background(config)
             })
             .await?
@@ -148,15 +142,11 @@ pub async fn exec_command(
     // etc.) — the image is never entered. Plain machines exec in the VM
     // directly via `vm_exec`.
     let machine_rec = state.lookup_vm(&id).await?;
-    let machine_golden = machine_rec.as_ref().and_then(|r| r.golden.clone());
     // An exec may be what establishes the workload container — the machine's
     // command exited, or the image's own default was short-lived — and that
-    // container is where the mount lives. Carry the machine's volumes so the
-    // bucket is present in whichever container serves this session.
-    let exec_s3_volumes = machine_rec
-        .as_ref()
-        .map(|r| crate::remote_volume::to_s3_volumes(&r.remote_volumes, &r.env))
-        .unwrap_or_default();
+    // container is where the mount lives, so the config has to target the
+    // machine rather than merely reuse its overlay.
+    let machine_for_run = machine_rec.clone();
     let machine_image = machine_rec.and_then(|r| r.image);
 
     let start = std::time::Instant::now();
@@ -170,7 +160,6 @@ pub async fn exec_command(
                 .collect::<Vec<_>>()
         };
         // A fork clone's inherited overlay lives under the golden's id.
-        let overlay_id = crate::workload::persistent_overlay_owner(&id, machine_golden.as_deref());
         let stdin_data = stdin_data.clone();
         with_machine_client_traced(&entry, tid, move |c| {
             // Pull only if the image isn't already present — avoids a registry
@@ -179,13 +168,13 @@ pub async fn exec_command(
             if c.query(&image)?.is_none() {
                 c.pull_with_registry_config(&image)?;
             }
+            let env_for_volumes = env.clone();
             let config = crate::agent::RunConfig::new(image, command)
                 .with_env(env)
                 .with_workdir(workdir)
                 .with_mounts(mounts_config)
                 .with_timeout(timeout)
-                .with_s3_volumes(exec_s3_volumes.clone())
-                .with_persistent_overlay(Some(overlay_id))
+                .in_machine_opt(machine_for_run.as_ref(), &id, &env_for_volumes)
                 .with_stdin(stdin_data);
             c.run_non_interactive(config)
         })
@@ -256,15 +245,11 @@ pub async fn exec_stream(
     // directly. Without this, streaming exec on an image machine produces no
     // output (the agent-base streaming path doesn't enter the container).
     let machine_rec = state.lookup_vm(&id).await?;
-    let machine_golden = machine_rec.as_ref().and_then(|r| r.golden.clone());
     // An exec may be what establishes the workload container — the machine's
     // command exited, or the image's own default was short-lived — and that
-    // container is where the mount lives. Carry the machine's volumes so the
-    // bucket is present in whichever container serves this session.
-    let exec_s3_volumes = machine_rec
-        .as_ref()
-        .map(|r| crate::remote_volume::to_s3_volumes(&r.remote_volumes, &r.env))
-        .unwrap_or_default();
+    // container is where the mount lives, so the config has to target the
+    // machine rather than merely reuse its overlay.
+    let machine_for_run = machine_rec.clone();
     let machine_image = machine_rec.and_then(|r| r.image);
 
     // Bridge the blocking, synchronous vsock streaming exec to an async SSE
@@ -290,20 +275,19 @@ pub async fn exec_stream(
                     .map(|(i, m)| (HostMount::mount_tag(i), m.target.clone(), m.readonly))
                     .collect::<Vec<_>>()
             };
-            // A fork clone's inherited overlay lives under the golden's id.
-            let overlay_id =
-                crate::workload::persistent_overlay_owner(&id, machine_golden.as_deref());
             with_machine_client_traced(&entry_exec, tid, move |c| {
                 if c.query(&image)?.is_none() {
                     c.pull_with_registry_config(&image)?;
                 }
+                // The volumes are derived from the env the machine will see, so
+                // keep a copy before the builder consumes it.
+                let env_for_volumes = env.clone();
                 let config = crate::agent::RunConfig::new(image, command)
                     .with_env(env)
                     .with_workdir(workdir)
                     .with_mounts(mounts_config)
                     .with_timeout(timeout)
-                    .with_s3_volumes(exec_s3_volumes.clone())
-                    .with_persistent_overlay(Some(overlay_id));
+                    .in_machine_opt(machine_for_run.as_ref(), &id, &env_for_volumes);
                 c.run_streaming_with(config, |e| {
                     let _ = tx.send(e);
                 })
@@ -467,12 +451,9 @@ pub async fn exec_interactive(
 
     let machine_record = state.lookup_vm(&id).await?;
     let machine_image = machine_record.as_ref().and_then(|r| r.image.clone());
-    // Carry the machine's bucket mounts: an interactive session may be what
-    // establishes the workload container, and the mount lives there.
-    let exec_s3_volumes = machine_record
-        .as_ref()
-        .map(|r| crate::remote_volume::to_s3_volumes(&r.remote_volumes, &r.env))
-        .unwrap_or_default();
+    // An interactive session may be what establishes the workload container,
+    // and the mount lives there.
+    let machine_for_run = machine_record.clone();
 
     let command = vec![q.cmd.clone().unwrap_or_else(|| "/bin/sh".to_string())];
     let init_size = (q.cols.unwrap_or(80), q.rows.unwrap_or(24));
@@ -542,8 +523,7 @@ pub async fn exec_interactive(
                     let config = crate::agent::RunConfig::new(image, command)
                         .with_mounts(mounts_config)
                         .with_tty(true)
-                        .with_s3_volumes(exec_s3_volumes.clone())
-                        .with_persistent_overlay(Some(id));
+                        .in_machine_opt(machine_for_run.as_ref(), &id, &[]);
                     client
                         .run_interactive_io(config, in_rx, on_output)
                         .unwrap_or_else(|e| {

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -74,18 +74,13 @@ pub fn launch_image_workload(
     // Remote volumes are mounted by the agent itself, natively, between the
     // container's create and start — so the workload sees its data from its
     // first instruction and its command is never rewritten.
-    let s3_volumes = crate::remote_volume::to_s3_volumes(&record.remote_volumes, &exec_env);
     match client.run_container_detached(
         RunConfig::new(image, command)
-            .with_env(exec_env)
             .with_workdir(record.workdir.clone())
             .with_user(record.user.clone())
             .with_mounts(record_mounts_to_bindings(&record.mounts))
-            .with_persistent_overlay(Some(persistent_overlay_owner(
-                machine_name,
-                record.golden.as_deref(),
-            )))
-            .with_s3_volumes(s3_volumes),
+            .in_machine(record, machine_name, &exec_env)
+            .with_env(exec_env),
     ) {
         Ok(_) => Ok(true),
         Err(e) if is_missing_launch_metadata(&e.to_string()) => {


### PR DESCRIPTION
Launch and exec sites set the overlay and the machine's buckets independently, so a site that set one and forgot the other ran in the right filesystem with the bucket silently missing.