### PR TITLE
Rewrite a loopback proxy host to the host's outbound address so guests can reach it

### DIFF
--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -1290,7 +1290,7 @@ impl RunCmd {
                 self.smolfile.as_deref(),
                 self.rebuild_init_cache,
                 resolved_digest.as_deref(),
-                self.proxy_opts.proxy().as_deref(),
+                self.proxy_opts.resolved_proxy()?.as_deref(),
                 self.proxy_opts.no_proxy().as_deref(),
             )?;
             // The real workload: CLI trailing args win, else the Smolfile's
@@ -1611,7 +1611,7 @@ impl RunCmd {
                 &mut client,
                 img,
                 effective_platform.as_deref(),
-                self.proxy_opts.proxy().as_deref(),
+                self.proxy_opts.resolved_proxy()?.as_deref(),
                 self.proxy_opts.no_proxy().as_deref(),
             ) {
                 Ok(info) => Some(info),
@@ -3649,7 +3649,7 @@ impl StartCmd {
     pub fn run(self) -> smolvm::Result<()> {
         let explicit_name = self.name.is_some();
         let name = self.name.unwrap_or_else(|| "default".to_string());
-        let proxy = self.proxy_opts.proxy();
+        let proxy = self.proxy_opts.resolved_proxy()?;
         let no_proxy = self.proxy_opts.no_proxy();
         // Forkable start: memfd-back guest RAM and register a control socket at a
         // known path so `machine fork` can later freeze this machine as a CoW base.

--- a/src/cli/pack.rs
+++ b/src/cli/pack.rs
@@ -340,7 +340,7 @@ impl PackCreateCmd {
             &mut client,
             &image,
             pack_config.oci_platform.as_deref(),
-            self.proxy_opts.proxy().as_deref(),
+            self.proxy_opts.resolved_proxy()?.as_deref(),
             self.proxy_opts.no_proxy().as_deref(),
         )?;
         debug!(image_info = ?image_info, "image pulled");
@@ -575,7 +575,7 @@ impl PackCreateCmd {
         // single-layer flatten).
         self.collect_base_assets(&mut collector)?;
         let export_opts = smolvm::pack_export::FromVmExportOptions {
-            proxy: self.proxy_opts.proxy(),
+            proxy: self.proxy_opts.resolved_proxy()?,
             no_proxy: self.proxy_opts.no_proxy(),
             rebase_from_image: self.rebase_from_image,
         };

--- a/src/cli/proxy_opts.rs
+++ b/src/cli/proxy_opts.rs
@@ -43,6 +43,131 @@ impl ProxyOpts {
             .clone()
             .or_else(|| first_nonempty_env(&["NO_PROXY", "no_proxy"]))
     }
+
+    /// [`Self::proxy`], with a loopback proxy host translated to an address the
+    /// GUEST can reach.
+    ///
+    /// `https_proxy=http://localhost:8118` means "the proxy on my machine", but
+    /// passed verbatim into a machine it points at the machine's own loopback,
+    /// where nothing listens — under TSI guest-loopback connections stay inside
+    /// the guest by design. The host's non-loopback address IS reachable from
+    /// the guest (TSI executes outbound connects host-side; virtio-net NATs
+    /// through the host), so a loopback proxy host is rewritten to the host's
+    /// primary outbound IP. When the proxy only listens on loopback the rewrite
+    /// cannot help, and this fails up front with what to change instead of
+    /// letting the pull die on an opaque in-guest "connection refused".
+    pub fn resolved_proxy(&self) -> smolvm::Result<Option<String>> {
+        self.proxy()
+            .map(|raw| resolve_loopback_proxy(&raw))
+            .transpose()
+    }
+}
+
+/// Rewrite `raw`'s host to the host machine's primary outbound IP when it is a
+/// loopback address; pass every other URL through untouched.
+fn resolve_loopback_proxy(raw: &str) -> smolvm::Result<String> {
+    let Some((host, port)) = proxy_authority(raw) else {
+        return Ok(raw.to_string());
+    };
+    if !is_loopback_host(&host) {
+        return Ok(raw.to_string());
+    }
+
+    // The host's outbound IP: a connected UDP socket consults the routing
+    // table without sending a packet, so this works on proxy-only networks too
+    // (they still route somewhere; the address is what matters, not delivery).
+    let outbound = std::net::UdpSocket::bind("0.0.0.0:0")
+        .and_then(|s| {
+            s.connect("8.8.8.8:80")?;
+            Ok(s.local_addr()?.ip())
+        })
+        .map_err(|e| {
+            smolvm::Error::config(
+                "--proxy",
+                format!(
+                    "proxy '{raw}' points at this host's loopback, which inside a \
+                     machine is the machine itself; could not determine a host \
+                     address the guest can reach ({e}) — pass --proxy with an \
+                     address reachable from the guest (e.g. this host's LAN IP)"
+                ),
+            )
+        })?;
+
+    // Probe the rewritten target from the host. A proxy bound only to loopback
+    // is unreachable from the guest no matter what we rewrite to; say so now.
+    if let Some(port) = port {
+        let target = std::net::SocketAddr::new(outbound, port);
+        let timeout = std::time::Duration::from_millis(800);
+        if std::net::TcpStream::connect_timeout(&target, timeout).is_err() {
+            let loopback: std::net::SocketAddr = ([127, 0, 0, 1], port).into();
+            let hint = if std::net::TcpStream::connect_timeout(&loopback, timeout).is_ok() {
+                format!(
+                    "the proxy answers on 127.0.0.1:{port} but not {target}, so it is \
+                     bound to loopback only; bind it to a non-loopback address \
+                     (e.g. 0.0.0.0)"
+                )
+            } else {
+                format!("nothing answered on {target} or 127.0.0.1:{port}")
+            };
+            return Err(smolvm::Error::config(
+                "--proxy",
+                format!(
+                    "proxy '{raw}' is not reachable from inside a machine \
+                     (localhost there is the machine itself): {hint}, or pass \
+                     --proxy with an address reachable from the guest"
+                ),
+            ));
+        }
+    }
+
+    let rewritten = replace_proxy_host(raw, &host, &outbound.to_string());
+    tracing::info!(
+        original = %raw,
+        rewritten = %rewritten,
+        "loopback proxy host rewritten to the host's outbound address for guest reachability"
+    );
+    Ok(rewritten)
+}
+
+/// Extract (host, port) from a proxy URL's authority, tolerating a missing
+/// scheme, userinfo, and bracketed IPv6. Returns `None` when no host is found.
+fn proxy_authority(raw: &str) -> Option<(String, Option<u16>)> {
+    let rest = raw.split_once("://").map_or(raw, |(_, r)| r);
+    let authority = rest.split(['/', '?']).next()?;
+    let hostport = authority.rsplit_once('@').map_or(authority, |(_, h)| h);
+    let (host, port) = if let Some(v6) = hostport.strip_prefix('[') {
+        let (host, tail) = v6.split_once(']')?;
+        (host, tail.strip_prefix(':'))
+    } else {
+        match hostport.rsplit_once(':') {
+            Some((h, p)) => (h, Some(p)),
+            None => (hostport, None),
+        }
+    };
+    if host.is_empty() {
+        return None;
+    }
+    Some((host.to_string(), port.and_then(|p| p.parse().ok())))
+}
+
+/// True for hosts that resolve to this machine's loopback.
+fn is_loopback_host(host: &str) -> bool {
+    host.eq_ignore_ascii_case("localhost")
+        || host
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|ip| ip.is_loopback())
+}
+
+/// Replace the first occurrence of `host` in `raw` (the authority parsed from
+/// it) with `new_host`, keeping brackets off IPv4 and preserving everything
+/// else byte-for-byte.
+fn replace_proxy_host(raw: &str, host: &str, new_host: &str) -> String {
+    let needle = if raw.contains(&format!("[{host}]")) {
+        format!("[{host}]")
+    } else {
+        host.to_string()
+    };
+    raw.replacen(&needle, new_host, 1)
 }
 
 /// First environment variable in `names` that is set to a non-empty value.
@@ -82,6 +207,84 @@ mod tests {
         );
         std::env::remove_var(a);
         std::env::remove_var(b);
+    }
+
+    #[test]
+    fn authority_parsing_handles_proxy_url_shapes() {
+        let cases = [
+            ("http://localhost:8118", ("localhost", Some(8118))),
+            ("http://user:pw@127.0.0.1:3128", ("127.0.0.1", Some(3128))),
+            ("socks5://[::1]:1080", ("::1", Some(1080))),
+            ("localhost:8118", ("localhost", Some(8118))),
+            ("http://proxy.corp.example", ("proxy.corp.example", None)),
+            ("http://10.0.0.7:3128/path", ("10.0.0.7", Some(3128))),
+        ];
+        for (raw, (host, port)) in cases {
+            assert_eq!(
+                proxy_authority(raw),
+                Some((host.to_string(), port)),
+                "parsing {raw}"
+            );
+        }
+    }
+
+    #[test]
+    fn loopback_detection_and_host_rewrite() {
+        assert!(is_loopback_host("localhost"));
+        assert!(is_loopback_host("LOCALHOST"));
+        assert!(is_loopback_host("127.0.0.1"));
+        assert!(is_loopback_host("127.8.9.10"));
+        assert!(is_loopback_host("::1"));
+        assert!(!is_loopback_host("proxy.corp.example"));
+        assert!(!is_loopback_host("10.0.0.7"));
+
+        assert_eq!(
+            replace_proxy_host("http://user@localhost:8118", "localhost", "10.1.2.3"),
+            "http://user@10.1.2.3:8118"
+        );
+        assert_eq!(
+            replace_proxy_host("socks5://[::1]:1080", "::1", "10.1.2.3"),
+            "socks5://10.1.2.3:1080"
+        );
+    }
+
+    #[test]
+    fn non_loopback_proxy_passes_through_untouched() {
+        for raw in [
+            "http://proxy.corp.example:3128",
+            "http://10.0.0.7:3128",
+            "not a url at all",
+        ] {
+            assert_eq!(resolve_loopback_proxy(raw).unwrap(), raw);
+        }
+    }
+
+    #[test]
+    fn loopback_proxy_with_dead_port_fails_with_guidance() {
+        // Nothing listens on this port anywhere; the resolver must refuse the
+        // URL up front rather than hand the guest a dead loopback address.
+        let err = resolve_loopback_proxy("http://localhost:1").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("reachable from the guest"),
+            "error must tell the user what to do, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn loopback_proxy_with_live_listener_is_rewritten() {
+        // Bind on all interfaces the way a guest-reachable proxy would.
+        let listener = std::net::TcpListener::bind("0.0.0.0:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let resolved = resolve_loopback_proxy(&format!("http://localhost:{port}")).unwrap();
+        assert!(
+            !resolved.contains("localhost"),
+            "loopback host must be rewritten, got: {resolved}"
+        );
+        assert!(
+            resolved.ends_with(&format!(":{port}")),
+            "port kept: {resolved}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Resolve a loopback proxy host to the host's outbound address so machines can reach it, and fail up front with guidance when the proxy is bound to loopback only.