### PR TITLE
Pack a machine created from a local image archive or rootfs directory

### DIFF
--- a/src/pack_export.rs
+++ b/src/pack_export.rs
@@ -133,19 +133,15 @@ pub fn collect_from_vm_assets(
         // message instead of a confusing registry "UNAUTHORIZED" on
         // `local:<hash>`.
         if crate::data::image_source::is_local_ref(&image) {
-            return Err(Error::agent(
-                "pack from VM",
-                format!(
-                    "VM '{vm_name}' was created from a local image ({image}). \
-                     `pack create --from-vm` can only snapshot VMs created from a \
-                     REGISTRY image — local archives and rootfs directories are \
-                     flattened on boot and have no registry manifest to re-pull. \
-                     Recreate the machine from a registry reference to pack it."
-                ),
-            ));
+            // No registry manifest to re-pull, but the base rootfs is still
+            // reachable: an archive was flattened onto the machine's own storage
+            // disk at boot, and a rootfs dir is still the host directory the
+            // machine boots from. Either can be the lower layer.
+            export_flattened_from_local_image(collector, vm_name, &vm_dir, &image)?;
+        } else {
+            image_env =
+                export_flattened_from_registry_image(collector, vm_name, &vm_dir, &image, opts)?;
         }
-        image_env =
-            export_flattened_from_registry_image(collector, vm_name, &vm_dir, &image, opts)?;
     } else {
         // Bare VM: its state is the rootfs overlay disk. VM-mode restores boot
         // from the template; a default-size overlay is a qcow2 CoW image and
@@ -404,6 +400,135 @@ fn export_flattened_from_registry_image(
 /// machine layers cache; share them into the helper VM, stage them onto its
 /// local disk (overlayfs cannot use virtiofs-backed lowers), and flatten with
 /// the current container overlay.
+/// Export a machine created from a local image (`--image ./x.tar`, `--image -`,
+/// or `--image ./rootfs/`).
+///
+/// There is no registry manifest to re-pull, but the base rootfs is still
+/// available in one of two places depending on how it was supplied:
+///
+/// - **archive** (`local:<hash>`): flattened onto the machine's own storage disk
+///   at boot, under `image-archives/<key>/0000_rootfs`. The helper already
+///   mounts that disk read-only, so the layer is read straight from it.
+/// - **rootfs dir** (`local-dir:<path>`): never copied into the machine at all —
+///   the guest boots from the host directory over virtiofs, so the export shares
+///   that same directory into the helper.
+///
+/// Either way the machine's persistent container overlay goes on top, exactly as
+/// the registry and artifact paths do, so the packed result is the machine as it
+/// actually is rather than as it was first created.
+fn export_flattened_from_local_image(
+    collector: &mut AssetCollector,
+    vm_name: &str,
+    vm_dir: &Path,
+    image: &str,
+) -> crate::Result<()> {
+    let host_dir = crate::data::image_source::packed_layers_dir_for_ref(image);
+    let is_dir_source = image.starts_with("local-dir:");
+
+    // A rootfs dir is the only source of its own base layer: if the host
+    // directory is gone, nothing on the machine can stand in for it.
+    if is_dir_source {
+        match host_dir.as_deref() {
+            Some(dir) if dir.is_dir() => {}
+            _ => {
+                return Err(Error::agent(
+                    "pack from VM",
+                    format!(
+                        "machine '{vm_name}' was created from the rootfs directory {image}, \
+                         but that directory is no longer present. The machine boots its base \
+                         layer from there, so it has to exist to export. Restore it, or \
+                         recreate the machine from an image that carries its own layers."
+                    ),
+                ));
+            }
+        }
+    }
+
+    let export_vm = ExportVm::start(vm_name, vm_dir, host_dir.clone(), false)?;
+    let mut client = export_vm.connect()?;
+    export_vm.mount_source_storage(&mut client)?;
+
+    // Stage the base layer onto the helper's own disk through tar, so whiteout
+    // devices and opaque-dir xattrs survive into the overlay mount below.
+    let src = if is_dir_source {
+        "/packed_layers".to_string()
+    } else {
+        locate_flattened_archive_rootfs(&mut client, vm_name)?
+    };
+    println!("Staging the machine's base layer for flatten...");
+    let dst = "/storage/stage/0".to_string();
+    let stage_cmd =
+        format!("mkdir -p '{dst}' && (cd '{src}' && tar cf - .) | (cd '{dst}' && tar xf -)");
+    let (exit_code, _, stderr) = client.vm_exec(
+        vec!["sh".to_string(), "-c".to_string(), stage_cmd],
+        vec![],
+        None,
+        None,
+        None,
+    )?;
+    if exit_code != 0 {
+        return Err(Error::agent(
+            "stage local base layer",
+            format!(
+                "staging {src} failed (exit {}): {}",
+                exit_code,
+                String::from_utf8_lossy(&stderr)
+            ),
+        ));
+    }
+
+    flatten_and_export(collector, &mut client, vm_name, &[dst])
+}
+
+/// The flattened rootfs of a local *archive* image on the source machine's
+/// storage disk, as a helper-local path.
+///
+/// The directory is keyed by a content hash the exporter does not have, so it is
+/// discovered rather than computed; a machine boots exactly one local archive,
+/// so a single match is expected.
+fn locate_flattened_archive_rootfs(
+    client: &mut AgentClient,
+    vm_name: &str,
+) -> crate::Result<String> {
+    let (exit_code, stdout, _) = client.vm_exec(
+        vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "ls -d /mnt/source-storage/image-archives/*/0000_rootfs 2>/dev/null".to_string(),
+        ],
+        vec![],
+        None,
+        None,
+        None,
+    )?;
+    let found: Vec<String> = String::from_utf8_lossy(&stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+        .collect();
+    match found.as_slice() {
+        [one] if exit_code == 0 => Ok(one.clone()),
+        [] => Err(Error::agent(
+            "pack from VM",
+            format!(
+                "machine '{vm_name}' was created from a local image archive, but no flattened \
+                 rootfs was found on its storage disk. The archive is flattened on first boot — \
+                 start the machine once, then re-run the export."
+            ),
+        )),
+        many => Err(Error::agent(
+            "pack from VM",
+            format!(
+                "machine '{vm_name}' has {} flattened image archives on its storage disk, so \
+                 the base layer is ambiguous. Recreate the machine from a single image and \
+                 export that.",
+                many.len()
+            ),
+        )),
+    }
+}
+
 fn export_flattened_from_artifact_sourced(
     collector: &mut AssetCollector,
     vm_name: &str,

--- a/tests/test_pack.sh
+++ b/tests/test_pack.sh
@@ -1319,6 +1319,103 @@ test_from_vm_short_name() {
 }
 
 # =============================================================================
+# Local-image --from-vm tests
+#
+# A machine created from a rootfs dir or an image archive has no registry
+# manifest to re-pull, and the export used to refuse it outright. The base layer
+# is still reachable — a dir machine boots from the host directory, an archive
+# machine has the archive flattened onto its own storage disk — so both must
+# pack, with the machine's own writes layered on top.
+# =============================================================================
+
+test_from_vm_local_rootfs_dir() {
+    local vm_name="pack-localdir-$$"
+    local pack_output="$TEST_DIR/from-vm-localdir"
+    local rootfs="$TEST_DIR/localdir-rootfs"
+
+    # A rootfs the guest can actually run: reuse the agent rootfs, which ships
+    # busybox, and mark it so the packed result can be identified.
+    rm -rf "$rootfs"
+    local agent_rootfs="$PROJECT_ROOT/target/release/agent-rootfs"
+    [[ -d "$agent_rootfs" ]] || {
+        echo "SKIP: no agent rootfs at $agent_rootfs to build a local dir image from"
+        return 0
+    }
+    cp -R "$agent_rootfs" "$rootfs" || return 1
+    echo "local-dir-base" > "$rootfs/etc/pack-marker"
+
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
+    rm -f "$pack_output" "$pack_output.smolmachine"
+
+    $SMOLVM machine create --name "$vm_name" --image "$rootfs" 2>&1 || return 1
+    $SMOLVM machine start --name "$vm_name" 2>&1 || {
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1
+    }
+    $SMOLVM machine exec --name "$vm_name" -- sh -c 'echo written-after > /etc/pack-state' 2>&1 || true
+    $SMOLVM machine stop --name "$vm_name" 2>&1 || true
+
+    local exit_code=0
+    $SMOLVM pack create --from-vm "$vm_name" -o "$pack_output" 2>&1 || exit_code=$?
+    if [[ $exit_code -ne 0 ]]; then
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
+        echo "FAIL: pack create --from-vm refused a local rootfs dir machine (exit $exit_code)"
+        return 1
+    fi
+
+    # The pack must carry BOTH the base layer and the machine's own writes.
+    local out
+    out=$("$pack_output" run -- sh -c 'cat /etc/pack-marker; cat /etc/pack-state' 2>&1)
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
+    rm -rf "$rootfs"; rm -f "$pack_output" "$pack_output.smolmachine"
+
+    echo "$out" | grep -q "local-dir-base" || {
+        echo "FAIL: packed local-dir machine lost its base layer: $out"; return 1; }
+    echo "$out" | grep -q "written-after" || {
+        echo "FAIL: packed local-dir machine lost the machine's own writes: $out"; return 1; }
+}
+
+test_from_vm_local_archive() {
+    local vm_name="pack-localtar-$$"
+    local pack_output="$TEST_DIR/from-vm-localtar"
+    local archive="$TEST_DIR/local-image.tar"
+
+    command -v crane >/dev/null 2>&1 || {
+        echo "SKIP: crane not available to build a local image archive"
+        return 0
+    }
+    crane pull alpine:latest "$archive" 2>&1 || {
+        echo "SKIP: could not pull an image archive"
+        return 0
+    }
+
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
+    rm -f "$pack_output" "$pack_output.smolmachine"
+
+    $SMOLVM machine create --name "$vm_name" --image "$archive" 2>&1 || return 1
+    $SMOLVM machine start --name "$vm_name" 2>&1 || {
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null; return 1
+    }
+    $SMOLVM machine exec --name "$vm_name" -- sh -c 'echo archive-state > /etc/pack-state' 2>&1 || true
+    $SMOLVM machine stop --name "$vm_name" 2>&1 || true
+
+    local exit_code=0
+    $SMOLVM pack create --from-vm "$vm_name" -o "$pack_output" 2>&1 || exit_code=$?
+    if [[ $exit_code -ne 0 ]]; then
+        $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
+        echo "FAIL: pack create --from-vm refused a local archive machine (exit $exit_code)"
+        return 1
+    fi
+
+    local out
+    out=$("$pack_output" run -- sh -c 'cat /etc/alpine-release; cat /etc/pack-state' 2>&1)
+    $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
+    rm -f "$archive" "$pack_output" "$pack_output.smolmachine"
+
+    echo "$out" | grep -q "archive-state" || {
+        echo "FAIL: packed archive machine lost the machine's own writes: $out"; return 1; }
+}
+
+# =============================================================================
 # Case-Insensitive Collision Test (macOS regression)
 #
 # =============================================================================
@@ -1740,6 +1837,8 @@ if [[ "$QUICK_MODE" != "true" ]]; then
     echo ""
 
     run_test "from-vm: short VM name (1 char) does not panic" test_from_vm_short_name || true
+    run_test "from-vm: local rootfs dir packs with the machine's writes" test_from_vm_local_rootfs_dir || true
+    run_test "from-vm: local image archive packs with the machine's writes" test_from_vm_local_archive || true
 fi
 
 # =============================================================================


### PR DESCRIPTION
The export refused any machine whose image was a local archive or rootfs directory, even though the base layer is still reachable from the machine's storage disk or the host directory it boots from.