### PR TITLE
Cut v1.12.0 with the display-capable libkrun and rebuilt platform libraries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3022,7 +3022,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "2"
 
 [package]
 name = "smolvm"
-version = "1.11.1"
+version = "1.12.0"
 edition = "2021"
 description = "OCI-native microVM runtime"
 license = "Apache-2.0"

--- a/lib/libkrun.dylib
+++ b/lib/libkrun.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:84abc3a93f0c339b3c8027c3e2f0f02bf6c01485fba1e92ab1bc6f97b8992eab
-size 6558256
+oid sha256:41e00c17c3adf1759c9fc8bf6fa965152ac2b0fa67a7fafb99b327b973156d47
+size 6557408

--- a/lib/libkrun.provenance
+++ b/lib/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=f56c733111814b3ffecc5589a6648dfa3e9c42fd
+libkrun=b51f1b113985153b426e838d5287c94e6a17781a
 libkrunfw=8f1307644bdcb95fe1343bf0d6ccf30aa22f1549

--- a/lib/linux-aarch64/libkrun.provenance
+++ b/lib/linux-aarch64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=f56c733111814b3ffecc5589a6648dfa3e9c42fd
+libkrun=b51f1b113985153b426e838d5287c94e6a17781a
 libkrunfw=8f1307644bdcb95fe1343bf0d6ccf30aa22f1549

--- a/lib/linux-aarch64/libkrun.so
+++ b/lib/linux-aarch64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:07de6eb95ababd01d417de800356dfdaef8eb32d23aa73aebb3a83fec38d853e
-size 7414696
+oid sha256:9e222d30cf62ea07f3dc0cb14257b9ad3454042980ceedfea97ce8a6ac0583ab
+size 7480864

--- a/lib/linux-x86_64/libkrun.provenance
+++ b/lib/linux-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=f56c733111814b3ffecc5589a6648dfa3e9c42fd
+libkrun=b51f1b113985153b426e838d5287c94e6a17781a
 libkrunfw=8f1307644bdcb95fe1343bf0d6ccf30aa22f1549

--- a/lib/linux-x86_64/libkrun.so
+++ b/lib/linux-x86_64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7624aaf0fe5ca3549430e013e33876a07387a8ef27c46ba9d42ea16cce3e46bb
-size 8203072
+oid sha256:2da46f242ca5d4dd482abd35e0d5dc63e42171ddd7da313763c51de8b093668a
+size 8227824

--- a/lib/windows-x86_64/libkrun.provenance
+++ b/lib/windows-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=f56c733111814b3ffecc5589a6648dfa3e9c42fd
+libkrun=b51f1b113985153b426e838d5287c94e6a17781a
 libkrunfw=8f1307644bdcb95fe1343bf0d6ccf30aa22f1549


### PR DESCRIPTION
Bump libkrun to the merged macOS display fixes, rebuild the macOS dylib and both Linux libraries at that pin, restamp the unaffected Windows library, and bump the version to 1.12.0.