### PR TITLE
Harden live fork execution for rollout sandboxes

### DIFF
--- a/crates/smolvm-agent/src/crun.rs
+++ b/crates/smolvm-agent/src/crun.rs
@@ -31,6 +31,14 @@ fn ensure_path_in_env(env: &[(String, String)]) -> Vec<(String, String)> {
     }
 }
 
+/// Compose the environment used for an exec that joins a workload container.
+///
+/// Kept public within the agent so the restored-container namespace path and
+/// ordinary `crun exec` receive the same PATH, CUDA, and Vulkan additions.
+pub(crate) fn augmented_exec_env(env: &[(String, String)]) -> Vec<(String, String)> {
+    crate::vulkan::augment_exec_env(crate::cuda::augment_exec_env(ensure_path_in_env(env)))
+}
+
 /// Builder for crun commands with consistent configuration.
 ///
 /// This ensures all crun invocations use the same cgroup-manager setting
@@ -275,8 +283,7 @@ impl CrunCommand {
         let mut c = Self::new();
         c.cmd.arg("exec").arg("--tty");
         c.cmd.arg("--console-socket").arg(console_socket);
-        let env_with_path =
-            crate::vulkan::augment_exec_env(crate::cuda::augment_exec_env(ensure_path_in_env(env)));
+        let env_with_path = augmented_exec_env(env);
         for (key, value) in &env_with_path {
             c.cmd.arg("--env").arg(format!("{}={}", key, value));
         }
@@ -346,8 +353,7 @@ impl CrunCommand {
             c.cmd.arg("--tty");
         }
         // Ensure PATH is set for command lookup; forward CUDA zero-copy opt-in.
-        let env_with_path =
-            crate::vulkan::augment_exec_env(crate::cuda::augment_exec_env(ensure_path_in_env(env)));
+        let env_with_path = augmented_exec_env(env);
         for (key, value) in &env_with_path {
             c.cmd.arg("--env").arg(format!("{}={}", key, value));
         }

--- a/crates/smolvm-agent/src/forkpoint.rs
+++ b/crates/smolvm-agent/src/forkpoint.rs
@@ -13,7 +13,8 @@ use std::time::Duration;
 const AGENT_BINARY: &str = "/usr/local/bin/smolvm-agent";
 use smolvm_protocol::forkpoint::{
     CUDA_PRELOAD_MODULES_HINT, FORK_ENV_PATH, HELPER_PATH, READY_PATH, READY_VERSION, RELEASE_PATH,
-    RESTORED_PATH, STATE_DIR, WORKER_READY_HELPER_PATH, WORKER_READY_PATH, WORKER_READY_TOKEN_ENV,
+    RESTORED_CONTAINER_PATH, RESTORED_PATH, STATE_DIR, WORKER_READY_HELPER_PATH, WORKER_READY_PATH,
+    WORKER_READY_TOKEN_ENV,
 };
 
 fn enabled() -> bool {
@@ -58,6 +59,7 @@ pub fn setup() {
         tracing::warn!(%error, "failed to set forkpoint state permissions");
     }
     let _ = std::fs::remove_file(READY_PATH);
+    let _ = std::fs::remove_file(RESTORED_CONTAINER_PATH);
     let _ = std::fs::remove_file(RESTORED_PATH);
     let _ = std::fs::remove_file(RELEASE_PATH);
     let _ = std::fs::remove_file(WORKER_READY_PATH);

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -126,6 +126,37 @@ const NETWORK_TEST_TIMEOUT_SECS: u64 = 10;
 /// Poll interval for checking process completion in VM exec.
 const PROCESS_POLL_INTERVAL_MS: u64 = 10;
 
+/// Match mainstream container runtimes and leave enough descriptor headroom
+/// for package managers, browsers, language servers, and concurrent tools.
+pub(crate) const DEFAULT_NOFILE_LIMIT: u64 = 1_048_576;
+
+#[cfg(target_os = "linux")]
+fn raise_nofile_limit() {
+    let desired = libc::rlimit {
+        rlim_cur: DEFAULT_NOFILE_LIMIT as libc::rlim_t,
+        rlim_max: DEFAULT_NOFILE_LIMIT as libc::rlim_t,
+    };
+    // SAFETY: `desired` is initialized and setrlimit copies it synchronously.
+    if unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &desired) } == 0 {
+        return;
+    }
+
+    // Some kernels cap the hard limit below the conventional 1M default. Use
+    // every descriptor the guest was granted instead of leaving the legacy
+    // soft limit at 1,024.
+    let mut available = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    // SAFETY: `available` points to writable storage for one rlimit value.
+    if unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut available) } == 0 {
+        available.rlim_cur = available.rlim_max;
+        // SAFETY: `available` came from getrlimit and only its soft limit was
+        // raised to the already-authorized hard limit.
+        let _ = unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &available) };
+    }
+}
+
 /// Get system uptime in milliseconds (for timing relative to boot).
 fn uptime_ms() -> u64 {
     if let Ok(contents) = std::fs::read_to_string("/proc/uptime") {
@@ -238,6 +269,11 @@ fn main() {
         "INFO",
         &format!("boot agent_entry uptime_ms={}", boottime_ms()),
     );
+
+    // crun exec inherits the agent's descriptor ceiling rather than the
+    // original OCI process limit, so raise PID 1 before launching workloads.
+    #[cfg(target_os = "linux")]
+    raise_nofile_limit();
 
     // Seed the guest wall clock from the host's launch time when the hypervisor
     // gives the guest no readable paravirt clock and it boots at ~1999 (WHP on
@@ -4067,9 +4103,10 @@ fn spawn_exec_in_container(
     container_id: &str,
     launch: &ResolvedLaunch,
     tty: bool,
+    unprivileged: bool,
 ) -> Result<(Child, Option<pty::PtyMaster>), Box<dyn std::error::Error>> {
     use std::io::Read as _;
-    use std::os::unix::io::AsRawFd as _;
+    use std::os::unix::io::{AsRawFd as _, FromRawFd as _};
     use std::sync::atomic::Ordering;
 
     // An exec joining a running container inherits the same image-resolved env /
@@ -4082,8 +4119,37 @@ fn spawn_exec_in_container(
         container_id = %container_id,
         command = ?command,
         tty = tty,
-        "joining running container via crun exec"
+        "joining running container"
     );
+
+    // A restored crun runtime can accept several execs and then stall even
+    // though the container and its processes remain healthy. Entering the
+    // inherited namespaces directly avoids that restored-runtime state while
+    // preserving the workload's live memory and process tree.
+    if !unprivileged {
+        if let Some(mut command) = restored_container_exec_command(container_id, launch)? {
+            if tty {
+                let (pty_master, slave_fd) = pty::open_pty(80, 24)?;
+                let slave_raw = slave_fd.as_raw_fd();
+                // SAFETY: `slave_fd` is a valid open PTY slave descriptor.
+                unsafe {
+                    command
+                        .stdin(Stdio::from_raw_fd(libc::dup(slave_raw)))
+                        .stdout(Stdio::from_raw_fd(libc::dup(slave_raw)))
+                        .stderr(Stdio::from_raw_fd(libc::dup(slave_raw)));
+                }
+                let child = command.spawn()?;
+                drop(slave_fd);
+                return Ok((child, Some(pty_master)));
+            }
+            let child = command
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()?;
+            return Ok((child, None));
+        }
+    }
 
     if tty {
         // Preferred: console socket (resizable). Mirrors the create path.
@@ -4156,6 +4222,127 @@ fn spawn_exec_in_container(
             .spawn()?;
         Ok((child, None))
     }
+}
+
+#[cfg(target_os = "linux")]
+fn restored_container_id() -> Option<String> {
+    restored_container_id_at(std::path::Path::new(
+        smolvm_protocol::forkpoint::RESTORED_CONTAINER_PATH,
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn restored_container_id_at(path: &std::path::Path) -> Option<String> {
+    std::fs::read_to_string(path)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+#[cfg(target_os = "linux")]
+fn container_workdir_path(
+    root: &std::path::Path,
+    guest_workdir: &str,
+) -> Result<std::path::PathBuf, String> {
+    use std::path::Component;
+
+    let path = std::path::Path::new(guest_workdir);
+    if !path.is_absolute() {
+        return Err(format!(
+            "container workdir must be absolute: {guest_workdir}"
+        ));
+    }
+    let mut relative = std::path::PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::RootDir | Component::CurDir => {}
+            Component::Normal(value) => relative.push(value),
+            Component::ParentDir => {
+                if !relative.pop() {
+                    return Err(format!(
+                        "container workdir escapes its root: {guest_workdir}"
+                    ));
+                }
+            }
+            Component::Prefix(_) => {
+                return Err(format!("invalid container workdir: {guest_workdir}"));
+            }
+        }
+    }
+    Ok(root.join(relative))
+}
+
+/// Build a process that enters a snapshot-restored workload container without
+/// asking crun to create another process through restored runtime state.
+///
+/// Returning `None` means this is a fresh container and should use the normal
+/// OCI runtime path. Unprivileged workloads deliberately never call this path.
+#[cfg(target_os = "linux")]
+fn restored_container_exec_command(
+    container_id: &str,
+    launch: &ResolvedLaunch,
+) -> Result<Option<Command>, Box<dyn std::error::Error>> {
+    if restored_container_id().as_deref() != Some(container_id) {
+        return Ok(None);
+    }
+    let pid = crun_container_pid(container_id).ok_or_else(|| {
+        format!("restored container '{container_id}' no longer has a live init process")
+    })?;
+    let root = std::path::PathBuf::from(format!("/proc/{pid}/root"));
+    let guest_workdir = launch.workdir.as_deref().unwrap_or("/");
+    let host_workdir = container_workdir_path(&root, guest_workdir)?;
+
+    let target_environment = std::fs::read(format!("/proc/{pid}/environ"))?;
+    let mut environment = target_environment
+        .split(|byte| *byte == 0)
+        .filter_map(|entry| std::str::from_utf8(entry).ok())
+        .filter_map(|entry| entry.split_once('='))
+        .map(|(key, value)| (key.to_string(), value.to_string()))
+        .collect::<Vec<_>>();
+    for (key, value) in &launch.env {
+        environment.retain(|(existing, _)| existing != key);
+        environment.push((key.clone(), value.clone()));
+    }
+    let environment = crun::augmented_exec_env(&environment);
+
+    let user = launch.user.as_deref().unwrap_or("0:0");
+    let (uid, gid) = user
+        .split_once(':')
+        .ok_or_else(|| format!("resolved container user is not uid:gid: {user}"))?;
+    let uid: u32 = uid.parse()?;
+    let gid: u32 = gid.parse()?;
+
+    let mut command = Command::new("/usr/bin/nsenter");
+    command
+        .arg("--target")
+        .arg(pid.to_string())
+        .args(["--mount", "--uts", "--ipc", "--pid"])
+        .arg(format!("--root={}", root.display()))
+        .arg(format!("--wd={}", host_workdir.display()))
+        .arg(format!("--setgid={gid}"))
+        .arg(format!("--setuid={uid}"))
+        .arg("--")
+        .args(&launch.command)
+        .env_clear()
+        .envs(environment);
+
+    use std::os::unix::process::CommandExt as _;
+    // SAFETY: setgroups is async-signal-safe and touches only child credentials.
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setgroups(0, std::ptr::null()) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    info!(
+        container_id,
+        pid,
+        command = ?launch.command,
+        "joining snapshot-restored container namespaces"
+    );
+    Ok(Some(command))
 }
 
 /// Look up a running main workload container for the given overlay ID.
@@ -4393,7 +4580,7 @@ fn spawn_interactive_command(
 
     // If a main workload container is running for this overlay, join it.
     if let Some(cid) = resolve_main_container(persistent_overlay_id) {
-        return spawn_exec_in_container(&cid, launch, tty);
+        return spawn_exec_in_container(&cid, launch, tty, unprivileged);
     }
 
     // On a persistent machine with no main container yet, establish a long-lived
@@ -4414,7 +4601,7 @@ fn spawn_interactive_command(
             launch,
             s3_volumes,
         ) {
-            Ok(cid) => return spawn_exec_in_container(&cid, launch, tty),
+            Ok(cid) => return spawn_exec_in_container(&cid, launch, tty, unprivileged),
             Err(e) => {
                 // Falling back to a fresh container would silently drop the
                 // remote volumes, leaving the workload reading an empty
@@ -4434,7 +4621,7 @@ fn spawn_interactive_command(
     // container in two steps and exec the command into it instead.
     if !s3_volumes.is_empty() {
         let cid = ensure_main_container(rootfs, None, mounts, unprivileged, launch, s3_volumes)?;
-        return spawn_exec_in_container(&cid, launch, tty);
+        return spawn_exec_in_container(&cid, launch, tty, unprivileged);
     }
 
     let rootfs_path = Path::new(rootfs);
@@ -5541,30 +5728,20 @@ fn run_background_in_keepalive(
             .map(|d| d.as_nanos())
             .unwrap_or(0)
     ));
-    let status = crun::CrunCommand::exec_detached(
-        &cid,
-        &launch.env,
-        &launch.command,
-        launch.workdir.as_deref(),
-        Some(&pid_file),
-    )
-    .user(launch.user.as_deref())
-    .stdin_null()
-    .discard_output()
-    .status()?;
-    if !status.success() {
-        let _ = std::fs::remove_file(&pid_file);
-        return Err(format!(
-            "crun exec --detach failed (exit {})",
-            status.code().unwrap_or(-1)
-        )
-        .into());
-    }
-
-    let pid: u32 = std::fs::read_to_string(&pid_file)
-        .ok()
-        .and_then(|s| s.trim().parse().ok())
-        .unwrap_or(0);
+    let pid = if !unprivileged {
+        if let Some(mut command) = restored_container_exec_command(&cid, &launch)? {
+            let child = command
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()?;
+            child.id()
+        } else {
+            run_crun_background_exec(&cid, &launch, &pid_file)?
+        }
+    } else {
+        run_crun_background_exec(&cid, &launch, &pid_file)?
+    };
     let _ = std::fs::remove_file(&pid_file);
 
     Ok(AgentResponse::Completed {
@@ -5572,6 +5749,36 @@ fn run_background_in_keepalive(
         stdout: format!("{pid}").into_bytes(),
         stderr: Vec::new(),
     })
+}
+
+#[cfg(target_os = "linux")]
+fn run_crun_background_exec(
+    container_id: &str,
+    launch: &ResolvedLaunch,
+    pid_file: &std::path::Path,
+) -> Result<u32, Box<dyn std::error::Error>> {
+    let status = crun::CrunCommand::exec_detached(
+        container_id,
+        &launch.env,
+        &launch.command,
+        launch.workdir.as_deref(),
+        Some(pid_file),
+    )
+    .user(launch.user.as_deref())
+    .stdin_null()
+    .discard_output()
+    .status()?;
+    if !status.success() {
+        return Err(format!(
+            "crun exec --detach failed (exit {})",
+            status.code().unwrap_or(-1)
+        )
+        .into());
+    }
+    Ok(std::fs::read_to_string(pid_file)
+        .ok()
+        .and_then(|value| value.trim().parse().ok())
+        .unwrap_or(0))
 }
 
 /// Non-streaming exec/run returns the whole output in a single wire frame. If it
@@ -5717,22 +5924,30 @@ fn run_in_keepalive_container(
     // silently ignored `timeout_ms` — an `exec --timeout N` against an image
     // machine ran to completion regardless (found by QA 2026-07-19).
     let exec_pid_file = crun::ExecPidFile::new()?;
-    let mut builder = crun::CrunCommand::exec(
-        &cid,
-        &launch.env,
-        &launch.command,
-        launch.workdir.as_deref(),
-        false,
-    )
-    .user(launch.user.as_deref())
-    .pid_file(exec_pid_file.path())
-    .capture_output();
-    builder = if stdin_data.is_some() {
-        builder.stdin_piped()
+    let (mut child, namespace_exec) = if !unprivileged {
+        if let Some(mut command) = restored_container_exec_command(&cid, &launch)? {
+            command.stdout(Stdio::piped()).stderr(Stdio::piped());
+            if stdin_data.is_some() {
+                command.stdin(Stdio::piped());
+            } else {
+                command.stdin(Stdio::null());
+            }
+            (command.spawn()?, true)
+        } else {
+            (
+                spawn_crun_foreground_exec(&cid, &launch, &exec_pid_file, stdin_data)?,
+                false,
+            )
+        }
     } else {
-        builder.stdin_null()
+        (
+            spawn_crun_foreground_exec(&cid, &launch, &exec_pid_file, stdin_data)?,
+            false,
+        )
     };
-    let mut child = builder.spawn()?;
+    if namespace_exec {
+        std::fs::write(exec_pid_file.path(), child.id().to_string())?;
+    }
     if let (Some(data), Some(mut stdin)) = (stdin_data, child.stdin.take()) {
         let _ = stdin.write_all(data.as_bytes());
         // Drop closes the pipe → the command sees EOF.
@@ -5777,6 +5992,31 @@ fn run_in_keepalive_container(
             }
         }
     })
+}
+
+#[cfg(target_os = "linux")]
+fn spawn_crun_foreground_exec(
+    container_id: &str,
+    launch: &ResolvedLaunch,
+    exec_pid_file: &crun::ExecPidFile,
+    stdin_data: Option<&str>,
+) -> Result<Child, Box<dyn std::error::Error>> {
+    let mut builder = crun::CrunCommand::exec(
+        container_id,
+        &launch.env,
+        &launch.command,
+        launch.workdir.as_deref(),
+        false,
+    )
+    .user(launch.user.as_deref())
+    .pid_file(exec_pid_file.path())
+    .capture_output();
+    builder = if stdin_data.is_some() {
+        builder.stdin_piped()
+    } else {
+        builder.stdin_null()
+    };
+    Ok(builder.spawn()?)
 }
 
 // Mirrors `storage::run_command`'s workload parameter list one-for-one; both
@@ -6688,6 +6928,33 @@ mod bg_reap_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn restored_container_marker_is_trimmed_and_empty_is_absent() {
+        let temp = tempfile::tempdir().unwrap();
+        let marker = temp.path().join("restored-container");
+        assert_eq!(restored_container_id_at(&marker), None);
+        std::fs::write(&marker, "  smolvm-restored-1\n").unwrap();
+        assert_eq!(
+            restored_container_id_at(&marker).as_deref(),
+            Some("smolvm-restored-1")
+        );
+        std::fs::write(&marker, " \n").unwrap();
+        assert_eq!(restored_container_id_at(&marker), None);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn restored_container_workdir_cannot_escape_proc_root() {
+        let root = std::path::Path::new("/proc/123/root");
+        assert_eq!(
+            container_workdir_path(root, "/testbed/./src/../tests").unwrap(),
+            root.join("testbed/tests")
+        );
+        assert!(container_workdir_path(root, "relative").is_err());
+        assert!(container_workdir_path(root, "/../../agent-root").is_err());
+    }
 
     #[cfg(target_os = "linux")]
     fn proc_stat_fixture(pid: u32, state: char, start_time: u64) -> String {

--- a/crates/smolvm-agent/src/oci.rs
+++ b/crates/smolvm-agent/src/oci.rs
@@ -537,8 +537,8 @@ impl OciSpec {
                 capabilities: Some(capabilities),
                 rlimits: Some(vec![OciRlimit {
                     rlimit_type: "RLIMIT_NOFILE".to_string(),
-                    hard: 1024,
-                    soft: 1024,
+                    hard: crate::DEFAULT_NOFILE_LIMIT,
+                    soft: crate::DEFAULT_NOFILE_LIMIT,
                 }]),
                 no_new_privileges: false,
             },
@@ -1413,6 +1413,25 @@ mod tests {
                 .is_none(),
             "consoleSize must be omitted when unset"
         );
+    }
+
+    #[test]
+    fn default_nofile_limit_supports_dependency_heavy_workloads() {
+        let spec = OciSpec::new(
+            &["sh".to_string()],
+            &[],
+            "/",
+            false,
+            &ProcessIdentity::root(),
+            false,
+        );
+        let limits = spec.process.rlimits.expect("default process limits");
+        let nofile = limits
+            .iter()
+            .find(|limit| limit.rlimit_type == "RLIMIT_NOFILE")
+            .expect("RLIMIT_NOFILE");
+        assert_eq!(nofile.soft, 1_048_576);
+        assert_eq!(nofile.hard, 1_048_576);
     }
 
     #[test]

--- a/crates/smolvm-agent/src/pod.rs
+++ b/crates/smolvm-agent/src/pod.rs
@@ -1491,7 +1491,7 @@ fn spawn_pod_exec(
     use_process_spec: bool,
 ) -> Result<(std::process::Child, Option<crate::pty::PtyMaster>), Box<dyn std::error::Error>> {
     if !use_process_spec {
-        return crate::spawn_exec_in_container(id, launch, entry.tty);
+        return crate::spawn_exec_in_container(id, launch, entry.tty, false);
     }
     let bundle = pod_dir(id).join("bundle");
     std::fs::create_dir_all(&bundle)?;

--- a/crates/smolvm-protocol/src/forkpoint.rs
+++ b/crates/smolvm-protocol/src/forkpoint.rs
@@ -18,6 +18,13 @@ pub const WORKER_READY_CAPABILITY: &str = "fork-worker-ready-v1";
 /// Marker written after a restored clone can safely enter ordinary timed waits.
 pub const RESTORED_PATH: &str = "/run/smolvm/forkpoint/restored";
 
+/// Container ID inherited with a live VM snapshot.
+///
+/// The restored container remains the owner of the workload's live process
+/// state, but new commands must join its namespaces directly: a post-restore
+/// `crun exec` can fail after trivial commands have already succeeded.
+pub const RESTORED_CONTAINER_PATH: &str = "/run/smolvm/forkpoint/restored-container";
+
 /// Marker written by the host after a clone is ready to resume.
 pub const RELEASE_PATH: &str = "/run/smolvm/forkpoint/release";
 

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -729,6 +729,20 @@ pub struct AgentClient {
     trace_id: Option<String>,
 }
 
+fn stalled_read_error(bytes_read: usize, propagate_initial_wouldblock: bool) -> std::io::Error {
+    if bytes_read == 0 && propagate_initial_wouldblock {
+        std::io::Error::new(
+            std::io::ErrorKind::WouldBlock,
+            "timed out waiting for an agent response frame",
+        )
+    } else {
+        std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "timed out reading frame body: peer stalled mid-frame",
+        )
+    }
+}
+
 // ============================================================================
 // Response match helpers
 // ============================================================================
@@ -2476,6 +2490,43 @@ impl AgentClient {
 
         let mut pos = 0;
         while pos < buf.len() {
+            // SO_RCVTIMEO is normally enough to bound a blocking read, but a
+            // restored vsock/UDS bridge can occasionally leave recv() blocked
+            // past that socket timeout while many clones reconnect at once.
+            // Poll the descriptor against the same idle deadline before every
+            // read on Unix so a missing response cannot pin a fork-batch worker
+            // forever. A readable event also covers EOF/error; read() below
+            // preserves the precise result in those cases.
+            #[cfg(unix)]
+            if let Some(d) = deadline {
+                let mut pollfd = libc::pollfd {
+                    fd: std::os::unix::io::AsRawFd::as_raw_fd(&self.stream),
+                    events: libc::POLLIN | libc::POLLHUP | libc::POLLERR,
+                    revents: 0,
+                };
+                loop {
+                    let now = std::time::Instant::now();
+                    if now >= d {
+                        return Err(stalled_read_error(pos, propagate_initial_wouldblock));
+                    }
+                    let remaining = d.saturating_duration_since(now);
+                    let timeout_ms = remaining.as_millis().max(1).min(i32::MAX as u128) as i32;
+                    // SAFETY: `pollfd` points to one initialized entry for the
+                    // duration of the call; poll does not retain the pointer.
+                    let ready = unsafe { libc::poll(&mut pollfd, 1, timeout_ms) };
+                    if ready > 0 {
+                        break;
+                    }
+                    if ready == 0 {
+                        return Err(stalled_read_error(pos, propagate_initial_wouldblock));
+                    }
+                    let error = std::io::Error::last_os_error();
+                    if error.kind() == std::io::ErrorKind::Interrupted {
+                        continue;
+                    }
+                    return Err(error);
+                }
+            }
             match self.stream.read(&mut buf[pos..]) {
                 Ok(0) => {
                     return Err(std::io::Error::new(
@@ -2500,10 +2551,7 @@ impl AgentClient {
                     // can't busy-spin forever.
                     if let Some(d) = deadline {
                         if std::time::Instant::now() >= d {
-                            return Err(std::io::Error::new(
-                                std::io::ErrorKind::TimedOut,
-                                "timed out reading frame body: peer stalled mid-frame",
-                            ));
+                            return Err(stalled_read_error(pos, propagate_initial_wouldblock));
                         }
                     }
                     std::thread::sleep(std::time::Duration::from_millis(1));
@@ -3434,6 +3482,33 @@ mod stalled_body_tests {
     use super::*;
     use std::io::Write;
     use std::time::{Duration, Instant};
+
+    #[test]
+    fn receive_times_out_when_peer_never_starts_a_frame() {
+        let (client_stream, server_stream) = UdsStream::pair().unwrap();
+        client_stream
+            .set_read_timeout(Some(Duration::from_millis(100)))
+            .expect("set read timeout");
+
+        let server = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_secs(3));
+            drop(server_stream);
+        });
+        let mut client = AgentClient::from_stream(client_stream);
+
+        let start = Instant::now();
+        let error = client
+            .receive()
+            .expect_err("an idle peer must not block receive forever");
+        let elapsed = start.elapsed();
+
+        assert!(error.to_string().contains("timed out waiting"));
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "an idle response must honor the socket deadline (got {elapsed:?})"
+        );
+        server.join().expect("server thread joined");
+    }
 
     #[test]
     fn receive_times_out_on_stalled_mid_frame_body() {

--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -139,27 +139,39 @@ fn fork_base_already_paused(status: &str) -> bool {
     status.trim() == "OK paused"
 }
 
+/// Build the clone-local release and acknowledgement script.
+fn build_release_forkpoint_script() -> String {
+    format!(
+        "set -e; mkdir -p '{dir}'; umask 077; printf '%s\\n' smolvm-forkpoint-release-v1 > '{release}.tmp'; mv '{release}.tmp' '{release}'; \
+         i=0; while [ -f '{ready}' ]; do i=$((i + 1)); [ \"$i\" -lt 500 ] || exit 46; sleep 0.02; done",
+        dir = smolvm_protocol::forkpoint::STATE_DIR,
+        release = smolvm_protocol::forkpoint::RELEASE_PATH,
+        ready = smolvm_protocol::forkpoint::READY_PATH,
+    )
+}
+
 /// Release the workload restored in `clone` after its identity and per-fork
 /// environment are installed. The state directory is private guest RAM, so a
 /// release marker wakes only this clone even though every clone inherited the
-/// same blocked helper process.
+/// same blocked helper process. Success means the helper also acknowledged the
+/// marker and left the fork boundary; callers may safely vend the clone.
 pub fn release_forkpoint(clone: &str) -> Result<()> {
     let socket = vm_data_dir(clone).join("agent.sock");
     let mut client = AgentClient::connect_with_retry(&socket)
         .map_err(|e| Error::agent("release forkpoint", format!("agent connect: {e}")))?;
-    let script = format!(
-        "set -e; mkdir -p '{dir}'; umask 077; printf '%s\\n' smolvm-forkpoint-release-v1 > '{release}.tmp'; mv '{release}.tmp' '{release}'",
-        dir = smolvm_protocol::forkpoint::STATE_DIR,
-        release = smolvm_protocol::forkpoint::RELEASE_PATH,
-    );
+    let script = build_release_forkpoint_script();
     match client.vm_exec(
         vec!["/bin/sh".into(), "-c".into(), script],
         vec![],
         None,
-        Some(Duration::from_secs(10)),
+        Some(Duration::from_secs(15)),
         None,
     ) {
         Ok((0, _, _)) => Ok(()),
+        Ok((46, _, _)) => Err(Error::agent(
+            "release forkpoint",
+            format!("clone '{clone}' did not acknowledge its release marker"),
+        )),
         Ok((code, _, stderr)) => Err(Error::agent(
             "release forkpoint",
             format!(
@@ -932,7 +944,7 @@ fn build_rejuvenation_script(clone: &str, seed: &str, record: &VmRecord) -> Stri
     // `merged` mount, exactly as [`write_fork_env`] does and for the same
     // reason: a container exec would recycle the workload the fork just
     // restored. A bare VM (no image) keeps the plain VM-rootfs paths.
-    let (root, require_root, runtime_hostname) = match record.image {
+    let (root, require_root, runtime_hostname, restored_container) = match record.image {
         Some(_) => {
             let owner = crate::workload::persistent_overlay_owner(clone, record.golden.as_deref());
             let merged = format!("/storage/overlays/persistent-{owner}/merged");
@@ -964,9 +976,19 @@ fn build_rejuvenation_script(clone: &str, seed: &str, record: &VmRecord) -> Stri
                      esac; \
                  fi; "
             );
-            (merged, require, runtime_hostname)
+            let restored_container = format!(
+                "mkdir -p '{state_dir}'; \
+                 if [ -s '{container_id}' ]; then \
+                     cat '{container_id}' > '{restored_container_path}'; \
+                 else \
+                     rm -f '{restored_container_path}'; \
+                 fi; ",
+                restored_container_path = smolvm_protocol::forkpoint::RESTORED_CONTAINER_PATH,
+                state_dir = smolvm_protocol::forkpoint::STATE_DIR,
+            );
+            (merged, require, runtime_hostname, restored_container)
         }
-        None => (String::new(), String::new(), String::new()),
+        None => (String::new(), String::new(), String::new(), String::new()),
     };
     // `ssh-keygen -A` writes to a hardcoded /etc/ssh, so regenerating the
     // container's keys means running the container's own binary under chroot.
@@ -1030,6 +1052,7 @@ fn build_rejuvenation_script(clone: &str, seed: &str, record: &VmRecord) -> Stri
          {require_root}\
          hostname '{c}' 2>/dev/null || true; \
          {runtime_hostname}\
+         {restored_container}\
          printf '%s' '{s}' > /dev/urandom 2>/dev/null || true; \
          MID=$(printf '%.32s' '{s}'); \
          printf '%s\\n' '{c}' > {root}/etc/hostname; \
@@ -1046,6 +1069,7 @@ fn build_rejuvenation_script(clone: &str, seed: &str, record: &VmRecord) -> Stri
         c = clone,
         s = seed,
         runtime_hostname = runtime_hostname,
+        restored_container = restored_container,
         state_dir = smolvm_protocol::forkpoint::STATE_DIR,
         restored = smolvm_protocol::forkpoint::RESTORED_PATH,
     )
@@ -1620,6 +1644,19 @@ mod tests {
     }
 
     #[test]
+    fn forkpoint_release_waits_for_clone_acknowledgement() {
+        let script = build_release_forkpoint_script();
+        let publish = script
+            .find(smolvm_protocol::forkpoint::RELEASE_PATH)
+            .expect("release marker must be published");
+        let acknowledge = script
+            .rfind(smolvm_protocol::forkpoint::READY_PATH)
+            .expect("ready marker must be observed");
+        assert!(publish < acknowledge);
+        assert!(script.contains("exit 46"));
+    }
+
+    #[test]
     fn golden_rollback_reapplies_a_completed_checkpoint_only() {
         let temp = tempfile::tempdir().unwrap();
         assert_eq!(golden_resume_command(temp.path()).unwrap(), "RESUME");
@@ -2064,6 +2101,7 @@ mod tests {
         // place so gethostname()/`hostname` agree with the on-disk identity
         // without restarting the warm workload.
         assert!(script.contains("main_container_id"));
+        assert!(script.contains(smolvm_protocol::forkpoint::RESTORED_CONTAINER_PATH));
         assert!(script.contains("--root /storage/containers/crun"));
         assert!(script.contains("/usr/bin/nsenter --uts="));
         assert!(script.contains("/bin/hostname 'clone-a'"));

--- a/src/db.rs
+++ b/src/db.rs
@@ -565,7 +565,14 @@ impl SmolvmDb {
     /// Read + delete happen in a single transaction to prevent TOCTOU races.
     pub fn remove_vm(&self, name: &str) -> Result<Option<VmRecord>> {
         self.with_conn(|conn| {
-            let tx = conn.transaction().db_err("begin transaction")?;
+            // Reserve the writer before reading. A deferred transaction can
+            // observe a record, lose a cross-process writer race, and fail its
+            // DELETE upgrade with SQLITE_BUSY_SNAPSHOT — which surfaced when
+            // NeMo Gym closed 100 fork leaves concurrently. `busy_timeout`
+            // cannot repair a stale snapshot; IMMEDIATE prevents one.
+            let tx = conn
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .db_err("begin vm removal")?;
 
             let data: Option<Vec<u8>> = tx
                 .query_row(

--- a/src/embedded/control.rs
+++ b/src/embedded/control.rs
@@ -303,7 +303,7 @@ pub(crate) fn fork_vm_with_options(
         &std::collections::BTreeMap::new(),
     )?;
 
-    boot_prepared_fork(db, clone, prep, share_weights, watch_parent)
+    boot_prepared_fork(db, clone, prep, share_weights, watch_parent, None)
 }
 
 fn boot_prepared_fork(
@@ -312,6 +312,7 @@ fn boot_prepared_fork(
     prep: crate::agent::fork::PreparedFork,
     share_weights: bool,
     watch_parent: Option<bool>,
+    retry_gate: Option<&std::sync::Mutex<()>>,
 ) -> Result<VmHandle> {
     // Boot the clone from the golden's in-memory snapshot instead of cold-booting.
     let features = LaunchFeatures {
@@ -321,31 +322,69 @@ fn boot_prepared_fork(
         watch_parent,
         ..LaunchFeatures::default()
     };
-    match launch_from_record(&prep.clone_record, features) {
-        Ok(started) => {
+    // A restore can reach the agent socket and still fail its first command on
+    // affected KVM hosts. Retry the complete boot transaction, not just VMM
+    // launch: a clone is not usable until identity reset and forkpoint release
+    // have both been acknowledged. The first failed attempt is stopped but its
+    // prepared CoW disks and DB record are retained for the clean restore retry.
+    let attempt = || {
+        let started = launch_from_record(&prep.clone_record, features.clone())?;
+        (|| {
             let mut handle = started.handle;
             // Fresh on-disk identity (hostname, machine-id, SSH host keys, RNG).
             // FAIL-CLOSED: if the reset can't be confirmed, stop the booted clone
             // and roll it back rather than leave it live with the golden's
             // per-machine secrets.
-            crate::agent::fork::fail_closed_on_rejuvenation(
-                crate::agent::fork::rejuvenate_clone(clone, &prep.clone_record),
-                || {
-                    let _ = handle.stop();
-                    let _ = db.remove_vm(clone);
-                    let _ = std::fs::remove_dir_all(crate::agent::vm_data_dir(clone));
-                },
-            )?;
-            mark_running(db, clone, handle.child_pid())?;
+            if let Err(error) = crate::agent::fork::rejuvenate_clone(clone, &prep.clone_record) {
+                let _ = handle.stop();
+                return Err(error);
+            }
+            // Embedded SDK forks are immediately consumable workers (there is
+            // no held-slot option on this path). A live workload may be parked
+            // in `smolvm-fork-ready` in the retained snapshot; release that
+            // clone-local barrier only after identity reset succeeds, matching
+            // the CLI and serve fork paths. Publishing a release marker is
+            // harmless for an arbitrary checkpoint with no waiting helper.
+            if let Err(error) = crate::agent::fork::release_forkpoint(clone) {
+                let _ = handle.stop();
+                return Err(error);
+            }
+            if let Err(error) = mark_running(db, clone, handle.child_pid()) {
+                let _ = handle.stop();
+                return Err(error);
+            }
             Ok(handle)
-        }
-        Err(e) => {
-            // prepare_fork already registered the clone; roll it back on boot failure.
+        })()
+    };
+    match retry_once_serialized(retry_gate, attempt) {
+        Ok(handle) => Ok(handle),
+        Err((first, retry)) => {
+            // prepare_fork already registered the clone; fail closed only after
+            // both complete boot transactions fail.
             let _ = db.remove_vm(clone);
             let _ = std::fs::remove_dir_all(crate::agent::vm_data_dir(clone));
-            Err(e)
+            Err(Error::agent(
+                "fork clone boot",
+                format!("clone '{clone}' first attempt failed: {first}; retry failed: {retry}"),
+            ))
         }
     }
+}
+
+fn retry_once_serialized<T, E>(
+    gate: Option<&std::sync::Mutex<()>>,
+    mut operation: impl FnMut() -> std::result::Result<T, E>,
+) -> std::result::Result<T, (E, E)> {
+    let first = match operation() {
+        Ok(value) => return Ok(value),
+        Err(error) => error,
+    };
+    let _guard = gate.map(|gate| {
+        gate.lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    });
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    operation().map_err(|retry| (first, retry))
 }
 
 /// Fork a group of embedded machines from one retained snapshot and boot them
@@ -384,6 +423,7 @@ pub fn fork_vm_batch(
         prepared.into_iter().enumerate().collect::<Vec<_>>(),
     ));
     let stop = std::sync::atomic::AtomicBool::new(false);
+    let retry_gate = std::sync::Mutex::new(());
 
     let results = std::thread::scope(|scope| {
         let workers: Vec<_> = (0..width)
@@ -391,6 +431,7 @@ pub fn fork_vm_batch(
                 let db = db.clone();
                 let queue = &queue;
                 let stop = &stop;
+                let retry_gate = &retry_gate;
                 scope.spawn(move || {
                     let mut results = Vec::new();
                     loop {
@@ -406,7 +447,7 @@ pub fn fork_vm_batch(
                         };
                         let clone = prep.clone_record.name.clone();
                         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                            boot_prepared_fork(&db, &clone, prep, false, None)
+                            boot_prepared_fork(&db, &clone, prep, false, None, Some(retry_gate))
                         }))
                         .unwrap_or_else(|_| {
                             Err(Error::agent(
@@ -600,6 +641,23 @@ pub fn mark_stopped(db: &SmolvmDb, name: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn fork_clone_transaction_retries_once() {
+        let attempts = std::cell::Cell::new(0);
+        let gate = std::sync::Mutex::new(());
+        let result = retry_once_serialized(Some(&gate), || {
+            let attempt = attempts.get() + 1;
+            attempts.set(attempt);
+            if attempt == 1 {
+                Err("transient")
+            } else {
+                Ok("ready")
+            }
+        });
+        assert_eq!(result, Ok("ready"));
+        assert_eq!(attempts.get(), 2);
+    }
 
     fn test_db() -> SmolvmDb {
         let unique = std::time::SystemTime::now()


### PR DESCRIPTION
Preserve restored workload state while making forked exec, retries, descriptor limits, transport deadlines, and concurrent cleanup reliable.