### PR TITLE
Bump the workspace crates to 1.12.0 so the library crates ship at the engine's version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2996,7 +2996,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smolfile"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-agent"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "flate2",
  "lazy_static",
@@ -3104,7 +3104,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "getrandom 0.3.4",
  "libc",
@@ -3113,11 +3113,11 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda-codegen"
-version = "1.11.1"
+version = "1.12.0"
 
 [[package]]
 name = "smolvm-cuda-guest"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "smolvm-cuda",
  "vsock",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda-shim"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "libc",
  "smolvm-cuda",
@@ -3134,7 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cudart-shim"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "libc",
  "smolvm-cuda",
@@ -3143,7 +3143,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-network"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "crossbeam-queue",
  "humantime",
@@ -3157,14 +3157,14 @@ dependencies = [
 
 [[package]]
 name = "smolvm-nvml-shim"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "smolvm-oci-layer"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "flate2",
  "libc",
@@ -3177,7 +3177,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-pack"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -3196,7 +3196,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "base64",
  "serde",
@@ -3206,7 +3206,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "bytes",
  "dirs",
@@ -3228,7 +3228,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-s3fs"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "hmac",
  "libc",

--- a/crates/smolvm-agent/Cargo.toml
+++ b/crates/smolvm-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-agent"
-version = "1.11.1"
+version = "1.12.0"
 edition = "2021"
 description = "Guest agent for smolvm VMs (handles OCI operations and command execution)"
 license = "Apache-2.0"

--- a/crates/smolvm-cuda-codegen/Cargo.toml
+++ b/crates/smolvm-cuda-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda-codegen"
-version = "1.11.1"
+version = "1.12.0"
 edition = "2021"
 description = "Generates forward-to-host-lib marshaling (guest stubs + host dispatch) from a function spec"
 license = "Apache-2.0"

--- a/crates/smolvm-cuda-guest/Cargo.toml
+++ b/crates/smolvm-cuda-guest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda-guest"
-version = "1.11.1"
+version = "1.12.0"
 edition = "2021"
 description = "Guest-side CUDA-over-vsock runner for smolvm microVMs (Linux)"
 license = "Apache-2.0"

--- a/crates/smolvm-cuda-shim/Cargo.toml
+++ b/crates/smolvm-cuda-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda-shim"
-version = "1.11.1"
+version = "1.12.0"
 edition = "2021"
 description = "Guest-side libcuda.so.1 drop-in: CUDA Driver API over smolvm's vsock RPC"
 license = "Apache-2.0"

--- a/crates/smolvm-cuda/Cargo.toml
+++ b/crates/smolvm-cuda/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda"
-version = "1.11.1"
+version = "1.12.0"
 edition = "2021"
 description = "CUDA Driver-API remoting over vsock for smolvm guests"
 license = "Apache-2.0"

--- a/crates/smolvm-cudart-shim/Cargo.toml
+++ b/crates/smolvm-cudart-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cudart-shim"
-version = "1.11.1"
+version = "1.12.0"
 edition = "2021"
 description = "Guest-side libcudart.so drop-in: CUDA Runtime API lowered to smolvm's Driver-API vsock RPC"
 license = "Apache-2.0"

--- a/crates/smolvm-network/Cargo.toml
+++ b/crates/smolvm-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-network"
-version = "1.11.1"
+version = "1.12.0"
 edition = "2021"
 description = "Host-side virtio-net runtime for smolvm"
 license = "Apache-2.0"

--- a/crates/smolvm-nvml-shim/Cargo.toml
+++ b/crates/smolvm-nvml-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-nvml-shim"
-version = "1.11.1"
+version = "1.12.0"
 edition = "2021"
 description = "Guest-side libnvidia-ml.so.1 drop-in: answers the NVML queries CUDA frameworks (vLLM) use for device detection, backed by the remoted CUDA driver"
 license = "Apache-2.0"

--- a/crates/smolvm-oci-layer/Cargo.toml
+++ b/crates/smolvm-oci-layer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-oci-layer"
-version = "1.11.1"
+version = "1.12.0"
 edition = "2021"
 description = "Pure-Rust OCI image-layer extraction: decompress a layer blob and unpack it into an overlayfs lowerdir, translating OCI whiteouts"
 license = "Apache-2.0"

--- a/crates/smolvm-pack/Cargo.toml
+++ b/crates/smolvm-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-pack"
-version = "1.11.1"
+version = "1.12.0"
 edition = "2021"
 description = "Single-binary packaging for smolvm"
 license = "Apache-2.0"

--- a/crates/smolvm-protocol/Cargo.toml
+++ b/crates/smolvm-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-protocol"
-version = "1.11.1"
+version = "1.12.0"
 edition = "2021"
 description = "Protocol types for smolvm host-guest communication"
 license = "Apache-2.0"

--- a/crates/smolvm-registry/Cargo.toml
+++ b/crates/smolvm-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-registry"
-version = "1.11.1"
+version = "1.12.0"
 edition = "2021"
 description = "OCI Distribution client for smolmachines registry"
 license = "Apache-2.0"

--- a/crates/smolvm-s3fs/Cargo.toml
+++ b/crates/smolvm-s3fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-s3fs"
-version = "1.11.1"
+version = "1.12.0"
 edition = "2021"
 description = "POSIX filesystem over S3-compatible object storage, mounted through FUSE without libfuse or a helper binary"
 license = "Apache-2.0"

--- a/crates/smolvm-smolfile/Cargo.toml
+++ b/crates/smolvm-smolfile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolfile"
-version = "1.11.1"
+version = "1.12.0"
 edition = "2021"
 description = "Smolfile specification and parser for smolvm microVM workloads"
 license = "Apache-2.0"


### PR DESCRIPTION
The 1.12.0 cut moved only the root package, leaving the 14 workspace crates at 1.11.1; this brings them in lockstep so the crates.io publish doesn't skip them as already-published.