### PR TITLE
Ship the guest Chromium wrapper in the desktop recipes with software WebGL enabled

### DIFF
--- a/examples/desktop/omarchy-aarch64.sh
+++ b/examples/desktop/omarchy-aarch64.sh
@@ -114,6 +114,17 @@ if [ -n "$dir" ] && [ -d "$dir" ]; then exec foot -D "$dir" "$@"; fi
 exec foot "$@"
 EOF
   chmod +x /usr/local/bin/uwsm-app /usr/local/bin/xdg-terminal-exec
+
+  # Chromium: Wayland, software rendering, and software WebGL. The Arch ARM
+  # chromium is a bare ELF with no flags-file launcher, so a PATH wrapper is
+  # the only way to apply flags to every launch. --enable-unsafe-swiftshader
+  # matters: modern Chromium blocks software WebGL in windowed mode without
+  # it (headless allows it), so CAD/3D sites silently render nothing.
+  cat > /usr/local/bin/chromium <<'CHROMIUMWRAP'
+#!/bin/bash
+exec /usr/bin/chromium --ozone-platform=wayland --disable-gpu --enable-unsafe-swiftshader "$@"
+CHROMIUMWRAP
+  chmod +x /usr/local/bin/chromium
   log "setup complete"
 fi
 

--- a/examples/desktop/omarchy.sh
+++ b/examples/desktop/omarchy.sh
@@ -43,6 +43,15 @@ mount -o remount,size=2G /dev/shm 2>/dev/null || true
 # need a session bus — a container guest has neither out of the box.
 dbus-uuidgen --ensure 2>/dev/null || true
 
+# Chromium wrapper: Wayland, software rendering, and software WebGL —
+# --enable-unsafe-swiftshader matters: modern Chromium blocks software WebGL
+# in windowed mode without it, so CAD/3D sites silently render nothing.
+cat > /usr/local/bin/chromium <<'CHROMIUMWRAP'
+#!/bin/bash
+exec /usr/bin/chromium --ozone-platform=wayland --disable-gpu --enable-unsafe-swiftshader "$@"
+CHROMIUMWRAP
+chmod +x /usr/local/bin/chromium
+
 # Input devices need two container-guest fixes. First: /dev is not devtmpfs,
 # so the evdev nodes the kernel registered (visible in /sys/class/input)
 # never appear in /dev — create them, the same way k3d guests need /dev/kmsg.


### PR DESCRIPTION
The desktop recipes never installed the Chromium PATH wrapper the sessions rely on, and windowed Chromium blocks software WebGL without --enable-unsafe-swiftshader, so 3D sites rendered blank.