### PR TITLE
Give a pack machine's first boot a start window that covers the layer unpack

### DIFF
--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -109,7 +109,21 @@ const IMAGE_PULL_TIMEOUT_SECS: u64 = 600;
 /// Archive flattening may take arbitrarily long, but the agent streams progress
 /// while work is advancing. Each progress response starts a fresh socket read,
 /// so this remains an inactivity timeout rather than a total operation limit.
-const DETACHED_START_TIMEOUT_SECS: u64 = 120;
+const DETACHED_START_TIMEOUT_SECS: u64 = 600;
+
+/// Resolve the detached-start read window, honoring `SMOLVM_START_TIMEOUT_SECS`
+/// (seconds, must be > 0). A pack-backed machine's FIRST boot unpacks the whole
+/// flattened layer into guest storage before the workload can start, which on a
+/// loaded disk takes minutes — a window sized for warm boots kills every cold
+/// one.
+fn detached_start_timeout() -> Duration {
+    let secs = std::env::var("SMOLVM_START_TIMEOUT_SECS")
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .filter(|&s| s > 0)
+        .unwrap_or(DETACHED_START_TIMEOUT_SECS);
+    Duration::from_secs(secs)
+}
 
 // (Removed INTERACTIVE_TIMEOUT_SECS — no-user-timeout execs now disable
 // the socket read timeout entirely, matching interactive_session behavior.)
@@ -1778,8 +1792,7 @@ impl AgentClient {
         // Container startup involves overlay setup, a one-time flatten of a local
         // image archive into guest storage, and crun init, which can far exceed
         // the default 30s read timeout on first run (cold overlay, cold image).
-        let _timeout_guard =
-            self.set_extended_read_timeout(Duration::from_secs(DETACHED_START_TIMEOUT_SECS))?;
+        let _timeout_guard = self.set_extended_read_timeout(detached_start_timeout())?;
 
         self.send(&AgentRequest::Run {
             image: config.image,

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -105,37 +105,6 @@ fn is_missing_launch_metadata(message: &str) -> bool {
     message.contains("defines no entrypoint or cmd")
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // A plain machine's overlay is keyed by its own name; a fork clone's by
-    // its golden's name, so clone execs land in the CoW-inherited overlay
-    // (and its still-live restored mount) instead of a fresh empty one.
-    #[test]
-    fn overlay_owner_aliases_fork_clones_to_their_golden() {
-        assert_eq!(persistent_overlay_owner("m1", None), "m1");
-        assert_eq!(
-            persistent_overlay_owner("clone-a", Some("golden-a")),
-            "golden-a"
-        );
-    }
-
-    // Only the agent's metadata-less-image failure downgrades a machine start
-    // to a bare-agent boot; every other launch failure must stay fatal.
-    #[test]
-    fn only_the_missing_metadata_error_is_downgraded() {
-        assert!(is_missing_launch_metadata(
-            "agent operation failed: run container detached: no command given \
-             and image 'local-dir:/images/ubuntu' defines no entrypoint or cmd"
-        ));
-        assert!(!is_missing_launch_metadata("image not found: whatever"));
-        assert!(!is_missing_launch_metadata(
-            "run container detached: crun exited with status 1"
-        ));
-    }
-}
-
 /// Progress heartbeat for a long workload launch.
 ///
 /// A pack machine's first start unpacks the whole flattened image before the
@@ -205,5 +174,36 @@ impl Drop for WaitTicker {
         if let Some(h) = self.handle.take() {
             let _ = h.join();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A plain machine's overlay is keyed by its own name; a fork clone's by
+    // its golden's name, so clone execs land in the CoW-inherited overlay
+    // (and its still-live restored mount) instead of a fresh empty one.
+    #[test]
+    fn overlay_owner_aliases_fork_clones_to_their_golden() {
+        assert_eq!(persistent_overlay_owner("m1", None), "m1");
+        assert_eq!(
+            persistent_overlay_owner("clone-a", Some("golden-a")),
+            "golden-a"
+        );
+    }
+
+    // Only the agent's metadata-less-image failure downgrades a machine start
+    // to a bare-agent boot; every other launch failure must stay fatal.
+    #[test]
+    fn only_the_missing_metadata_error_is_downgraded() {
+        assert!(is_missing_launch_metadata(
+            "agent operation failed: run container detached: no command given \
+             and image 'local-dir:/images/ubuntu' defines no entrypoint or cmd"
+        ));
+        assert!(!is_missing_launch_metadata("image not found: whatever"));
+        assert!(!is_missing_launch_metadata(
+            "run container detached: crun exited with status 1"
+        ));
     }
 }

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -74,6 +74,8 @@ pub fn launch_image_workload(
     // Remote volumes are mounted by the agent itself, natively, between the
     // container's create and start — so the workload sees its data from its
     // first instruction and its command is never rewritten.
+    let _ticker =
+        WaitTicker::start("preparing the workload (a first start unpacks the machine image)");
     match client.run_container_detached(
         RunConfig::new(image, command)
             .with_workdir(record.workdir.clone())
@@ -131,5 +133,77 @@ mod tests {
         assert!(!is_missing_launch_metadata(
             "run container detached: crun exited with status 1"
         ));
+    }
+}
+
+/// Progress heartbeat for a long workload launch.
+///
+/// A pack machine's first start unpacks the whole flattened image before the
+/// workload can run — minutes of silence that read as a hang. After a short
+/// grace period this prints an elapsed-time line to stderr: rewritten in
+/// place on a terminal, one line every 30 s when piped. Dropping the guard
+/// stops the ticker and clears the line.
+struct WaitTicker {
+    stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl WaitTicker {
+    fn start(what: &'static str) -> Self {
+        use std::io::{IsTerminal, Write};
+        use std::sync::atomic::Ordering;
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let stop_flag = stop.clone();
+        let handle = std::thread::spawn(move || {
+            let started = std::time::Instant::now();
+            let tty = std::io::stderr().is_terminal();
+            let grace = std::time::Duration::from_secs(3);
+            let step = if tty {
+                std::time::Duration::from_secs(1)
+            } else {
+                std::time::Duration::from_secs(30)
+            };
+            let mut printed = false;
+            while !stop_flag.load(Ordering::Relaxed) {
+                std::thread::sleep(std::time::Duration::from_millis(250));
+                if started.elapsed() < grace {
+                    continue;
+                }
+                let due = match printed {
+                    false => true,
+                    true => started.elapsed().as_millis() % step.as_millis() < 250,
+                };
+                if !due {
+                    continue;
+                }
+                let secs = started.elapsed().as_secs();
+                let mut err = std::io::stderr();
+                if tty {
+                    let _ = write!(err, "\r  {what}... {secs}s");
+                } else {
+                    let _ = writeln!(err, "  {what}... {secs}s");
+                }
+                let _ = err.flush();
+                printed = true;
+            }
+            if printed && tty {
+                let mut err = std::io::stderr();
+                let _ = write!(err, "\r{}\r", " ".repeat(what.len() + 16));
+                let _ = err.flush();
+            }
+        });
+        Self {
+            stop,
+            handle: Some(handle),
+        }
+    }
+}
+
+impl Drop for WaitTicker {
+    fn drop(&mut self) {
+        self.stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
     }
 }


### PR DESCRIPTION
First boot of a pack-backed machine unpacks the whole flattened layer into guest storage before the workload starts, which exceeded the fixed 120s client window on loaded disks; the window is now 600s and overridable with SMOLVM_START_TIMEOUT_SECS.