### PR TITLE
Re-stage a damaged image-archive cache entry instead of trusting that the path exists

### DIFF
--- a/src/data/image_source.rs
+++ b/src/data/image_source.rs
@@ -237,8 +237,20 @@ fn stage_from_file(path: &Path, cache_base: &Path) -> Result<String> {
     }
     let hash = hash_file(path)?;
     let archive_path = cache_base.join(&hash).join(ARCHIVE_FILE);
-    if !archive_path.exists() {
+    // A cache hit is trusted only if the staged file is still the size we just
+    // hashed. `link_or_copy` HARDLINKS the caller's archive when it can, so the
+    // cache entry and their file share an inode: a later in-place rewrite of
+    // that path — `docker save -o the-same-file.tar` truncates rather than
+    // replaces — mutates the cache too. The entry is keyed by content hash, so
+    // the damaged copy is then reused forever for that content, and every boot
+    // fails in the guest with a `manifest.json not found in tar` that points at
+    // the user's (valid) archive rather than at the cache. Re-stage instead.
+    let staged_len = std::fs::metadata(&archive_path).ok().map(|m| m.len());
+    if staged_len != Some(meta.len()) {
         std::fs::create_dir_all(archive_path.parent().expect("hash dir has a parent"))?;
+        // Remove first: the stale entry may be a hardlink to the caller's file,
+        // and linking onto an existing path fails.
+        let _ = std::fs::remove_file(&archive_path);
         link_or_copy(path, &archive_path)?;
     }
     Ok(hash)
@@ -267,9 +279,13 @@ fn stage_from_stdin(cache_base: &Path) -> Result<String> {
     tmp.flush()?;
     let hash = hex::encode(hasher.finalize());
     let archive_path = cache_base.join(&hash).join(ARCHIVE_FILE);
-    if archive_path.exists() {
+    // Same validation as the file path: an entry staged earlier may have been
+    // truncated through a hardlink to the original archive, and reusing it
+    // would fail the boot with a misleading "manifest.json not found in tar".
+    if std::fs::metadata(&archive_path).is_ok_and(|m| m.len() == total) {
         return Ok(hash); // already staged; the temp file is dropped/removed
     }
+    let _ = std::fs::remove_file(&archive_path);
     std::fs::create_dir_all(archive_path.parent().expect("hash dir has a parent"))?;
     tmp.persist(&archive_path)
         .map_err(|e| Error::storage("stage stdin archive", e.to_string()))?;
@@ -342,6 +358,63 @@ fn too_large(bytes: u64) -> Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The staged copy is hardlinked to the caller's archive when the cache is
+    /// on the same filesystem, so truncating that file through its own path —
+    /// what `docker save -o same-file.tar` does — empties the cache entry too.
+    /// Keyed by content hash, the damaged entry would otherwise be reused for
+    /// that content forever, failing every boot with a `manifest.json not found
+    /// in tar` that blames the user's perfectly valid archive.
+    #[test]
+    fn a_truncated_cache_entry_is_restaged_rather_than_reused() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = dir.path().join("cache");
+        std::fs::create_dir_all(&cache).expect("cache dir");
+        let archive = dir.path().join("image.tar");
+        std::fs::write(&archive, b"a valid archive's bytes").expect("write archive");
+
+        let hash = stage_from_file(&archive, &cache).expect("first stage");
+        let staged = cache.join(&hash).join(ARCHIVE_FILE);
+        assert_eq!(
+            std::fs::read(&staged).expect("staged"),
+            b"a valid archive's bytes"
+        );
+
+        // Truncate through the ORIGINAL path; the hardlinked cache entry follows.
+        std::fs::write(&archive, b"").expect("truncate");
+        std::fs::write(&archive, b"a valid archive's bytes").expect("rewrite");
+
+        let again = stage_from_file(&archive, &cache).expect("second stage");
+        assert_eq!(again, hash, "same content still hashes the same");
+        assert_eq!(
+            std::fs::read(cache.join(&again).join(ARCHIVE_FILE)).expect("restaged"),
+            b"a valid archive's bytes",
+            "a stale/short entry must be replaced, not trusted"
+        );
+    }
+
+    #[test]
+    fn an_intact_cache_entry_is_reused_without_recopying() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = dir.path().join("cache");
+        std::fs::create_dir_all(&cache).expect("cache dir");
+        let archive = dir.path().join("image.tar");
+        std::fs::write(&archive, b"stable bytes").expect("write archive");
+
+        let hash = stage_from_file(&archive, &cache).expect("first stage");
+        let staged = cache.join(&hash).join(ARCHIVE_FILE);
+        let before = std::fs::metadata(&staged)
+            .expect("meta")
+            .modified()
+            .expect("mtime");
+        let again = stage_from_file(&archive, &cache).expect("second stage");
+        assert_eq!(again, hash);
+        let after = std::fs::metadata(&staged)
+            .expect("meta")
+            .modified()
+            .expect("mtime");
+        assert_eq!(before, after, "an intact entry must not be re-staged");
+    }
 
     #[test]
     fn registry_refs_are_not_treated_as_local() {


### PR DESCRIPTION
The image-archive cache hardlinks the caller's file and then reuses that entry on existence alone, so rewriting the archive in place (`docker save -o same-file.tar` truncates rather than replaces) empties the cache entry through the shared inode and every later boot of that content fails with `crane export failed: file manifest.json not found in tar` — validate the staged file's length against the source before reusing it, and re-stage when it differs.