### PR TITLE
Fail when the release lookup fails instead of falling back to a hardcoded 0.1.1

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -161,20 +161,40 @@ check_requirements() {
 # Get latest version from GitHub
 get_latest_version() {
     local url="https://api.github.com/repos/${GITHUB_REPO}/releases/latest"
-    local version
+    local body version
 
+    # Keep the body rather than piping straight into grep: on a rate-limit the
+    # API answers 200-or-403 with a JSON error object, and that object is the
+    # only thing that says which failure this is. `|| body=""` because `set -e`
+    # would otherwise kill the subshell before the diagnosis below can run.
     if command -v curl &> /dev/null; then
-        version=$(curl -sSL "$url" 2>/dev/null | grep '"tag_name"' | sed -E 's/.*"tag_name": *"v?([^"]+)".*/\1/')
+        body=$(curl -sSL "$url" 2>/dev/null) || body=""
     else
-        version=$(wget -qO- "$url" 2>/dev/null | grep '"tag_name"' | sed -E 's/.*"tag_name": *"v?([^"]+)".*/\1/')
+        body=$(wget -qO- "$url" 2>/dev/null) || body=""
     fi
 
-    if [[ -z "$version" ]]; then
-        # Fallback to a default version if GitHub API fails
-        echo "0.1.1"
-    else
+    version=$(printf '%s' "$body" | grep '"tag_name"' | sed -E 's/.*"tag_name": *"v?([^"]+)".*/\1/')
+
+    if [[ -n "$version" ]]; then
         echo "$version"
+        return 0
     fi
+
+    # No tag_name means the API did not hand us a release. Never guess one: the
+    # hardcoded fallback that used to live here published no Linux asset, so it
+    # 404'd there, and on macOS it silently installed *older* than what was
+    # already on the machine. Failing loudly is the only safe answer.
+    error "Could not determine the latest smolvm version from the GitHub API."
+    if printf '%s' "$body" | grep -q "rate limit exceeded"; then
+        error "GitHub is rate-limiting this machine, so the release lookup was refused."
+        error "Wait for the limit to reset, or install a specific version:"
+    else
+        error "No release information came back from $url"
+        error "Check network access to api.github.com, or install a specific version:"
+    fi
+    error "  curl -sSL https://smolmachines.com/install.sh | bash -s -- --version VERSION"
+    error "Released versions: https://github.com/${GITHUB_REPO}/releases"
+    exit 1
 }
 
 # Download file


### PR DESCRIPTION
`get_latest_version()` resolves the version by piping the releases API through `grep '"tag_name"'`. When the API answers with anything that is not a release, the grep matches nothing, `version` is empty, and the function returned a hardcoded `0.1.1`.

Context: #1016. That issue is closed, and this is not a reopen. simon--taylor re-checked it on 2026-08-25 and the fallback path is still there, so this is the fix for what he re-confirmed rather than a new report.

## What he sees

A rate-limited machine gets a JSON error object, which has no `tag_name`:

```json
{"message":"API rate limit exceeded for 34.138.70.217. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}
```

`0.1.1` is not a safe default for either platform, and the release metadata is the reason:

| version | assets |
| --- | --- |
| `v0.1.1` | `checksums.txt`, `smolvm-0.1.1-darwin-arm64.tar.gz` |
| `v1.12.0` | `checksums.sha256`, plus darwin-arm64, linux-arm64, linux-x86_64, windows-x86_64 |

There is no Linux asset in `v0.1.1`, so Linux 404s. macOS has one, so it installs and quietly moves the machine backwards from whatever was already there. Neither failure mentions the API, which is the actual cause.

## What changed

The lookup keeps the response body instead of piping it straight into `grep`, because that body is the only thing that says which failure this is. On an empty result it fails with a message that names the cause and the way out, and it never guesses a version.

Rate limiting is called out separately because the remedy differs: waiting or passing `--version`, which the installer already supports. The body is captured with `|| body=""` so a curl that exits non-zero, such as an unresolvable host, still reaches the diagnosis instead of dying under `set -e` before printing anything.

## What deliberately did not change

**Checksum verification is untouched.** Two things are worth recording, because the issue's second half reads worse than it is.

The asset name is already correct. `v1.10.0` and `v1.12.0` both publish an asset literally named `checksums.sha256`, which is what the installer asks for, and `6c620646` was a deliberate fix to point at that name. The `checksums.txt` mismatch only exists on `v0.1.1`, so it can only be reached once the fallback has already put you there. Removing the fallback removes the trigger.

The skip is also not silent. `install.sh:285` on `main` already prints `warning: Checksums not available for this release, skipping verification` when the download fails. Verification stays optional, as the comment above it intends, and this PR does not change that.

Retry, backoff, and authenticating the API call are all out of scope here.

## Validation

Run on macOS 26.5.2 arm64. The function was extracted from both `main` and this branch and driven through the real call shape from `install.sh:700`, `VERSION=$(get_latest_version)` under `set -e`, with `curl` stubbed to return the exact body above.

Rate-limit body, before:

```
RESULT: VERSION='0.1.1'
exit=0
```

Rate-limit body, after:

```
error: Could not determine the latest smolvm version from the GitHub API.
error: GitHub is rate-limiting this machine, so the release lookup was refused.
error: Wait for the limit to reset, or install a specific version:
error:   curl -sSL https://smolmachines.com/install.sh | bash -s -- --version VERSION
error: Released versions: https://github.com/smol-machines/smolvm/releases
exit=1
```

`RESULT:` never prints, which is the point: the non-zero exit propagates out of the command substitution and `set -e` stops the install rather than continuing with an empty or invented version.

Empty body, standing in for no network, gives the same exit with the network wording instead. A curl that exits non-zero, simulated with rc 6, reaches the same diagnosis rather than aborting silently.

Success path against the real API is unchanged, both before and after:

```
--- OLD --- RESULT: VERSION='1.12.0'
--- NEW --- RESULT: VERSION='1.12.0'
```

which matches `gh release view` reporting `v1.12.0`.

## The served copy

`smolmachines/static/install.sh` is byte-identical to this file on `main` today, and this change makes the two diverge until it is copied across. The reporter downloaded from smolmachines.com, so the served copy is the one that bit him.
