### PR TITLE
Floor host loopback in the default local egress mode

### DIFF
--- a/crates/smolvm-network/src/egress.rs
+++ b/crates/smolvm-network/src/egress.rs
@@ -102,12 +102,19 @@ enum FloorMode {
     /// Trusted single-tenant/local override (`SMOLVM_EGRESS_ALLOW_PRIVATE=1`):
     /// floor nothing — the guest reaches exactly what the host can.
     Off,
-    /// Local default: deny ONLY the cloud-metadata link-local range
-    /// (`169.254.0.0/16`, incl. `169.254.169.254`) — never a legitimate
-    /// destination and the canonical SSRF/credential-theft target, but still
-    /// protects users running on their own cloud VM. The guest keeps reaching the
-    /// host's LAN, loopback, etc., so local behavior is reasonable and clear.
+    /// Loopback-permitted local mode (`SMOLVM_ALLOW_HOST_LOOPBACK=1`, e.g. the
+    /// `--allow-host-loopback` CLI flag): deny ONLY the cloud-metadata link-local
+    /// range, leaving the host's own loopback reachable so a developer can hit a
+    /// service on their host's `127.0.0.1` from the sandbox on purpose.
     MetadataOnly,
+    /// Local DEFAULT: deny the cloud-metadata link-local range
+    /// (`169.254.0.0/16`, incl. `169.254.169.254`) AND the host's own loopback
+    /// (`127.0.0.0/8`, `::1`, `0.0.0.0`/`::`). A guest reaching `127.0.0.1`
+    /// means "myself", but the gateway would forward it to the HOST's loopback —
+    /// a confused-deputy path onto host debuggers, Docker, and local databases.
+    /// The host's LAN stays reachable (legitimate local dev), and an explicit
+    /// allow-list entry can also re-open loopback (see [`EgressPolicy::allows`]).
+    MetadataAndLoopback,
     /// Multi-tenant/fleet (`SMOLVM_PUBLISH_ADDR` set): the full floor — metadata,
     /// host/control internal subnets, loopback, link/unique-local, and the
     /// gateway CGNAT range — so a guest can't steal host credentials, pivot to
@@ -146,11 +153,21 @@ fn floor_mode() -> FloorMode {
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
         .unwrap_or(false);
     if allow_private {
-        FloorMode::Off
-    } else if std::env::var_os("SMOLVM_PUBLISH_ADDR").is_some() {
-        FloorMode::Strict
-    } else {
+        return FloorMode::Off;
+    }
+    // Fleet mode is absolute: `SMOLVM_ALLOW_HOST_LOOPBACK` only relaxes the LOCAL
+    // default, never Strict, so it can't re-expose the host loopback / control
+    // door on a multi-tenant node.
+    if std::env::var_os("SMOLVM_PUBLISH_ADDR").is_some() {
+        return FloorMode::Strict;
+    }
+    let allow_host_loopback = std::env::var("SMOLVM_ALLOW_HOST_LOOPBACK")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+    if allow_host_loopback {
         FloorMode::MetadataOnly
+    } else {
+        FloorMode::MetadataAndLoopback
     }
 }
 
@@ -163,6 +180,24 @@ fn is_link_local(ip: IpAddr) -> bool {
         IpAddr::V6(v6) => {
             (v6.segments()[0] & 0xffc0) == 0xfe80
                 || v6.to_ipv4_mapped().is_some_and(|v4| v4.is_link_local())
+        }
+    }
+}
+
+/// The host's own loopback / unspecified addresses — what `127.0.0.1` and `::1`
+/// mean to the guest, but which the gateway forwards to the HOST. Floored in
+/// every mode except `Off`; re-openable in the local modes only by an explicit
+/// static allow-list entry (never a learned DNS IP, so it can't be reached by
+/// rebinding). Covers the IPv4-mapped IPv6 form so it can't be smuggled past.
+fn is_host_loopback(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => v4.is_loopback() || v4.is_unspecified(),
+        IpAddr::V6(v6) => {
+            v6.is_loopback()
+                || v6.is_unspecified()
+                || v6
+                    .to_ipv4_mapped()
+                    .is_some_and(|v4| v4.is_loopback() || v4.is_unspecified())
         }
     }
 }
@@ -184,6 +219,7 @@ fn is_floored(ip: IpAddr, mode: FloorMode) -> bool {
     match mode {
         FloorMode::Off => false,
         FloorMode::MetadataOnly => is_link_local(ip),
+        FloorMode::MetadataAndLoopback => is_link_local(ip) || is_host_loopback(ip),
         FloorMode::Strict => match ip {
             IpAddr::V4(v4) => is_reserved_v4(v4),
             IpAddr::V6(v6) => {
@@ -328,9 +364,24 @@ impl EgressPolicy {
 
     /// Whether an outbound connection to `ip` (v4 or v6) is permitted.
     pub fn allows(&self, ip: IpAddr) -> bool {
-        // Platform hard-floor: deny per the resolved FloorMode (metadata-only
-        // locally, full floor under fleet mode) regardless of the allow-list.
+        // Platform hard-floor: deny per the resolved FloorMode (metadata + host
+        // loopback locally, the full internal floor under fleet mode). The floor
+        // is absolute under `Strict`; in the softer local modes an EXPLICIT
+        // static allow-list CIDR (`--allow-cidr`, `--outbound-localhost-only`)
+        // may deliberately re-open a floored destination — e.g. reaching a dev
+        // server on the host's 127.0.0.1. A learned DNS IP never qualifies, so
+        // the floor still defeats DNS rebinding.
         if is_floored(ip, self.floor) {
+            // Only host loopback, floored by the local default, may be
+            // deliberately re-opened by an explicit static CIDR. Cloud-metadata
+            // (link-local) and — under Strict — the internal ranges stay
+            // absolute: no allow-list entry can re-expose the credential door.
+            if self.floor != FloorMode::Strict && is_host_loopback(ip) {
+                return self
+                    .inner
+                    .as_ref()
+                    .is_some_and(|list| list.cidrs.iter().any(|cidr| cidr.contains(ip)));
+            }
             return false;
         }
         match &self.inner {
@@ -436,18 +487,36 @@ mod tests {
     }
 
     #[test]
-    fn unrestricted_local_floors_only_metadata() {
-        // Local default (no fleet mode): only the cloud-metadata link-local range
-        // is denied; the host's LAN, loopback, and CGNAT stay reachable — so a
-        // local VM behaves predictably.
+    fn unrestricted_local_floors_metadata_and_loopback() {
+        // Local default (no fleet mode): the cloud-metadata link-local range AND
+        // the host's own loopback are denied — a guest reaching `127.0.0.1` would
+        // otherwise hit the host's loopback services. The host's LAN and CGNAT
+        // stay reachable, so a local VM still behaves predictably.
         let p = EgressPolicy::unrestricted();
         assert!(!p.allows_v4(Ipv4Addr::new(169, 254, 169, 254))); // metadata: denied
+        assert!(!p.allows_v4(Ipv4Addr::new(127, 0, 0, 1))); // loopback: denied
+        assert!(!p.allows_v4(Ipv4Addr::new(0, 0, 0, 0))); // unspecified: denied
         assert!(p.allows_v4(Ipv4Addr::new(10, 0, 0, 4))); // LAN: reachable
-        assert!(p.allows_v4(Ipv4Addr::new(127, 0, 0, 1))); // loopback: reachable
         assert!(p.allows_v4(Ipv4Addr::new(192, 168, 1, 1)));
         assert!(p.allows_v4(Ipv4Addr::new(172, 16, 0, 1)));
         assert!(p.allows_v4(Ipv4Addr::new(100, 96, 0, 1))); // CGNAT: reachable
         assert!(p.allows_v4(Ipv4Addr::new(1, 1, 1, 1))); // public: reachable
+    }
+
+    #[test]
+    fn explicit_cidr_reopens_loopback_locally_but_learned_ip_does_not() {
+        // A developer who deliberately allow-lists loopback CAN reach a host
+        // service on 127.0.0.1 in the local modes...
+        let local = EgressPolicy::new(Some(&["127.0.0.1/32".into()]), None);
+        assert!(local.allows_v4(Ipv4Addr::new(127, 0, 0, 1)));
+        // ...but only the named address — a sibling loopback IP stays floored.
+        assert!(!local.allows_v4(Ipv4Addr::new(127, 0, 0, 2)));
+        // A learned DNS answer for loopback never re-opens it (anti-rebinding):
+        // only a static CIDR defeats the floor, and Strict keeps it absolute
+        // (see `floor_strict_blocks_internal_and_metadata`).
+        let learned = EgressPolicy::new(None, Some(&["evil.test".into()]));
+        learned.learn_ip_records(&[(IpAddr::V4(Ipv4Addr::LOCALHOST), 300)]);
+        assert!(!learned.allows_v4(Ipv4Addr::LOCALHOST));
     }
 
     #[test]
@@ -467,7 +536,7 @@ mod tests {
 
     #[test]
     fn metadata_floor_blocks_mapped_and_v6_link_local() {
-        let p = EgressPolicy::unrestricted(); // MetadataOnly default
+        let p = EgressPolicy::unrestricted(); // MetadataAndLoopback default
                                               // mapped metadata + v6 link-local are denied...
         assert!(!p.allows_v6("::ffff:169.254.169.254".parse().unwrap()));
         assert!(!p.allows_v6("fe80::1".parse().unwrap()));
@@ -554,28 +623,55 @@ mod tests {
     }
 
     #[test]
-    fn floor_metadata_only_blocks_just_link_local() {
-        // Local default: only the cloud-metadata link-local range is denied; the
-        // host's LAN, loopback and the public internet stay reachable.
-        assert!(is_floored(v4(169, 254, 169, 254), FloorMode::MetadataOnly));
-        assert!(is_floored(v4(169, 254, 0, 1), FloorMode::MetadataOnly));
+    fn floor_default_blocks_link_local_and_loopback() {
+        // Local default: the cloud-metadata link-local range AND host loopback /
+        // unspecified are denied; the host's LAN and the public internet stay
+        // reachable.
+        for ip in [
+            v4(169, 254, 169, 254),
+            v4(169, 254, 0, 1),
+            v4(127, 0, 0, 1), // loopback
+            v4(127, 1, 2, 3),
+            v4(0, 0, 0, 0), // unspecified
+        ] {
+            assert!(
+                is_floored(ip, FloorMode::MetadataAndLoopback),
+                "{ip} should be floored locally"
+            );
+        }
         for ip in [
             v4(8, 8, 8, 8),
             v4(192, 168, 1, 5),
             v4(10, 0, 0, 7),
-            v4(127, 0, 0, 1),
             v4(172, 16, 5, 5),
         ] {
             assert!(
-                !is_floored(ip, FloorMode::MetadataOnly),
+                !is_floored(ip, FloorMode::MetadataAndLoopback),
                 "{ip} should be reachable locally"
             );
         }
-        // IPv4-mapped metadata must not slip past.
+        // IPv4-mapped metadata and loopback must not slip past via the v6 form.
         assert!(is_floored(
             "::ffff:169.254.169.254".parse().unwrap(),
-            FloorMode::MetadataOnly
+            FloorMode::MetadataAndLoopback
         ));
+        assert!(is_floored(
+            "::1".parse().unwrap(),
+            FloorMode::MetadataAndLoopback
+        ));
+        assert!(is_floored(
+            "::ffff:127.0.0.1".parse().unwrap(),
+            FloorMode::MetadataAndLoopback
+        ));
+    }
+
+    #[test]
+    fn floor_metadata_only_allows_loopback() {
+        // The `--allow-host-loopback` mode floors cloud-metadata but lets a guest
+        // reach the host's own 127.0.0.1 on purpose.
+        assert!(is_floored(v4(169, 254, 169, 254), FloorMode::MetadataOnly));
+        assert!(!is_floored(v4(127, 0, 0, 1), FloorMode::MetadataOnly));
+        assert!(!is_floored(v4(0, 0, 0, 0), FloorMode::MetadataOnly));
     }
 
     #[test]

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -563,6 +563,12 @@ pub struct RunCmd {
     #[arg(long, help_heading = "Network")]
     pub outbound_localhost_only: bool,
 
+    /// Let the guest reach services on the HOST's own loopback (127.0.0.1 / ::1);
+    /// off by default so a sandbox can't reach host debuggers, Docker, or local
+    /// databases. Cloud-metadata stays blocked. Implies --net.
+    #[arg(long = "allow-host-loopback", help_heading = "Network")]
+    pub allow_host_loopback: bool,
+
     /// Enable GPU acceleration (Vulkan via virtio-gpu)
     #[arg(long, help_heading = "Resources")]
     pub gpu: bool,
@@ -1112,11 +1118,20 @@ impl RunCmd {
             }
         }
 
+        // `--allow-host-loopback` relaxes only the host-loopback part of the egress
+        // floor via libkrun's `SMOLVM_ALLOW_HOST_LOOPBACK` env (read once at launch),
+        // rather than adding loopback to the allow-list — an allow-list would make
+        // egress restrictive and force the guest onto virtio-net, where a guest's
+        // 127.0.0.1 never reaches the host. Setting the env keeps the default TSI
+        // datapath and leaves cloud-metadata blocked.
+        if self.allow_host_loopback {
+            std::env::set_var("SMOLVM_ALLOW_HOST_LOOPBACK", "1");
+        }
         let (cli_allow_cidrs, net, cli_dns_filter_hosts) = resolve_egress_flags(
             self.allow_cidr,
             self.allow_host,
             self.outbound_localhost_only,
-            self.net,
+            self.net || self.allow_host_loopback,
         )?;
 
         let params = crate::cli::smolfile::build_create_params(


### PR DESCRIPTION
Deny a guest's connections to the host's own loopback and unspecified addresses by default, while letting an explicit static allow-list entry re-open them for a developer who intends it.