### PR TITLE
Support nested machine checkpoints

### DIFF
--- a/crates/smolvm-agent/src/forkpoint.rs
+++ b/crates/smolvm-agent/src/forkpoint.rs
@@ -5,16 +5,16 @@
 //! the host freezes the golden. Restored clones are released independently by
 //! the host through a VM-private directory bind-mounted into the container.
 
-use std::io::Write as _;
+use std::io::{Read as _, Write as _};
 use std::os::unix::fs::PermissionsExt as _;
 use std::path::Path;
 use std::time::Duration;
 
 const AGENT_BINARY: &str = "/usr/local/bin/smolvm-agent";
 use smolvm_protocol::forkpoint::{
-    CUDA_PRELOAD_MODULES_HINT, FORK_ENV_PATH, HELPER_PATH, READY_PATH, READY_VERSION, RELEASE_PATH,
-    RESTORED_CONTAINER_PATH, RESTORED_PATH, STATE_DIR, WORKER_READY_HELPER_PATH, WORKER_READY_PATH,
-    WORKER_READY_TOKEN_ENV,
+    CUDA_PRELOAD_MODULES_HINT, FORK_ENV_PATH, GENERATION_PREFIX, HELPER_PATH, LEGACY_RELEASE_TOKEN,
+    READY_PATH, READY_VERSION, RELEASE_PATH, RELEASE_PREFIX, RESTORED_CONTAINER_PATH,
+    RESTORED_PATH, STATE_DIR, WORKER_READY_HELPER_PATH, WORKER_READY_PATH, WORKER_READY_TOKEN_ENV,
 };
 
 fn enabled() -> bool {
@@ -126,10 +126,11 @@ fn run_helper_at(
         .map_err(|error| format!("create {}: {error}", state_dir.display()))?;
     let _ = std::fs::remove_file(release_path);
 
+    let generation = forkpoint_generation()?;
     let ready_temp = state_dir.join(format!(".ready.{}.tmp", std::process::id()));
     let mut ready = std::fs::File::create(&ready_temp)
         .map_err(|error| format!("create {}: {error}", ready_temp.display()))?;
-    let ready_content = ready_content(preload_modules);
+    let ready_content = ready_content(preload_modules, &generation);
     ready
         .write_all(ready_content.as_bytes())
         .map_err(|error| format!("write {}: {error}", ready_temp.display()))?;
@@ -153,16 +154,16 @@ fn run_helper_at(
     // release. A restored clone writes RESTORED_PATH during identity setup;
     // waits started after that point are native to the clone and safe to use.
     while !restored_path.is_file() {
-        if release_path.is_file() {
-            let _ = std::fs::remove_file(ready_path);
+        if release_matches(release_path, &generation) {
+            acknowledge_generation(ready_path, &generation);
             return Ok(());
         }
         std::thread::yield_now();
     }
 
     loop {
-        if release_path.is_file() {
-            let _ = std::fs::remove_file(ready_path);
+        if release_matches(release_path, &generation) {
+            acknowledge_generation(ready_path, &generation);
             return Ok(());
         }
         std::thread::sleep(poll_interval);
@@ -231,11 +232,37 @@ fn write_worker_ready_at(
     })
 }
 
-fn ready_content(preload_modules: bool) -> String {
+fn forkpoint_generation() -> Result<String, String> {
+    let mut bytes = [0_u8; 16];
+    std::fs::File::open("/dev/urandom")
+        .and_then(|mut random| random.read_exact(&mut bytes))
+        .map_err(|error| format!("generate forkpoint token: {error}"))?;
+    Ok(bytes.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
+fn ready_content(preload_modules: bool, generation: &str) -> String {
     if preload_modules {
-        format!("{READY_VERSION}\n{CUDA_PRELOAD_MODULES_HINT}\n")
+        format!("{READY_VERSION}\n{GENERATION_PREFIX}{generation}\n{CUDA_PRELOAD_MODULES_HINT}\n")
     } else {
-        format!("{READY_VERSION}\n")
+        format!("{READY_VERSION}\n{GENERATION_PREFIX}{generation}\n")
+    }
+}
+
+fn release_matches(release_path: &Path, generation: &str) -> bool {
+    std::fs::read_to_string(release_path).is_ok_and(|release| {
+        let release = release.trim();
+        release == format!("{RELEASE_PREFIX}{generation}") || release == LEGACY_RELEASE_TOKEN
+    })
+}
+
+fn acknowledge_generation(ready_path: &Path, generation: &str) {
+    let is_current = std::fs::read_to_string(ready_path).is_ok_and(|ready| {
+        ready
+            .lines()
+            .any(|line| line == format!("{GENERATION_PREFIX}{generation}"))
+    });
+    if is_current {
+        let _ = std::fs::remove_file(ready_path);
     }
 }
 
@@ -254,6 +281,15 @@ mod tests {
             "marker was not published: {}",
             path.display()
         );
+    }
+
+    fn marker_generation(path: &Path) -> String {
+        std::fs::read_to_string(path)
+            .unwrap()
+            .lines()
+            .find_map(|line| line.strip_prefix(GENERATION_PREFIX))
+            .unwrap()
+            .to_string()
     }
 
     fn spec() -> OciSpec {
@@ -342,13 +378,14 @@ mod tests {
             )
         });
         wait_for_marker(&ready);
+        let generation = marker_generation(&ready);
         assert_eq!(
             std::fs::read_to_string(&ready).unwrap(),
-            ready_content(false)
+            ready_content(false, &generation)
         );
         assert!(!helper.is_finished());
         std::fs::write(&restored, b"restored\n").unwrap();
-        std::fs::write(&release, b"release\n").unwrap();
+        std::fs::write(&release, format!("{RELEASE_PREFIX}{generation}\n")).unwrap();
         helper.join().unwrap().unwrap();
         assert!(!ready.exists());
     }
@@ -377,8 +414,9 @@ mod tests {
             )
         });
         wait_for_marker(&ready);
+        let generation = marker_generation(&ready);
         assert!(!restored.exists());
-        std::fs::write(&release, b"release\n").unwrap();
+        std::fs::write(&release, format!("{RELEASE_PREFIX}{generation}\n")).unwrap();
         helper.join().unwrap().unwrap();
         assert!(!ready.exists());
     }
@@ -433,9 +471,24 @@ mod tests {
     #[test]
     fn helper_records_cuda_module_preload_hint() {
         assert_eq!(
-            ready_content(true),
-            "smolvm-forkpoint-v1\ncuda-preload-modules\n"
+            ready_content(true, "0123"),
+            "smolvm-forkpoint-v1\ngeneration=0123\ncuda-preload-modules\n"
         );
-        assert_eq!(ready_content(false), "smolvm-forkpoint-v1\n");
+        assert_eq!(
+            ready_content(false, "0123"),
+            "smolvm-forkpoint-v1\ngeneration=0123\n"
+        );
+    }
+
+    #[test]
+    fn release_requires_its_generation_or_the_legacy_token() {
+        let temp = tempfile::tempdir().unwrap();
+        let release = temp.path().join("release");
+        std::fs::write(&release, format!("{RELEASE_PREFIX}old\n")).unwrap();
+        assert!(!release_matches(&release, "new"));
+        assert!(release_matches(&release, "old"));
+
+        std::fs::write(&release, format!("{LEGACY_RELEASE_TOKEN}\n")).unwrap();
+        assert!(release_matches(&release, "new"));
     }
 }

--- a/crates/smolvm-protocol/src/forkpoint.rs
+++ b/crates/smolvm-protocol/src/forkpoint.rs
@@ -9,6 +9,10 @@ pub const READY_PATH: &str = "/run/smolvm/forkpoint/ready";
 /// First line of every supported forkpoint readiness marker.
 pub const READY_VERSION: &str = "smolvm-forkpoint-v1";
 
+/// Prefix of the per-invocation token in a readiness marker. The token lets a
+/// releaser distinguish a new forkpoint from the previous helper's marker.
+pub const GENERATION_PREFIX: &str = "generation=";
+
 /// Optional readiness-marker capability requesting eager clone module loading.
 pub const CUDA_PRELOAD_MODULES_HINT: &str = "cuda-preload-modules";
 
@@ -27,6 +31,13 @@ pub const RESTORED_CONTAINER_PATH: &str = "/run/smolvm/forkpoint/restored-contai
 
 /// Marker written by the host after a clone is ready to resume.
 pub const RELEASE_PATH: &str = "/run/smolvm/forkpoint/release";
+
+/// Release token used before generation-addressed forkpoints. Accepting it in
+/// newer guests keeps independently-updated host and agent packages compatible.
+pub const LEGACY_RELEASE_TOKEN: &str = "smolvm-forkpoint-release-v1";
+
+/// Prefix of a generation-addressed release marker.
+pub const RELEASE_PREFIX: &str = "smolvm-forkpoint-release-v2:";
 
 /// Marker written after a released worker finishes clone-local preparation.
 pub const WORKER_READY_PATH: &str = "/run/smolvm/forkpoint/worker-ready";

--- a/lib/libkrun.provenance
+++ b/lib/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=b51f1b113985153b426e838d5287c94e6a17781a
+libkrun=00d03003bd8e7e1538dbed0c7ab00812881b5b53
 libkrunfw=8f1307644bdcb95fe1343bf0d6ccf30aa22f1549

--- a/lib/linux-aarch64/libkrun.provenance
+++ b/lib/linux-aarch64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=b51f1b113985153b426e838d5287c94e6a17781a
+libkrun=00d03003bd8e7e1538dbed0c7ab00812881b5b53
 libkrunfw=8f1307644bdcb95fe1343bf0d6ccf30aa22f1549

--- a/lib/linux-aarch64/libkrun.so
+++ b/lib/linux-aarch64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9e222d30cf62ea07f3dc0cb14257b9ad3454042980ceedfea97ce8a6ac0583ab
-size 7480864
+oid sha256:c0be8c9224779e413fb948f526b1df3c9ff2366aadee0299ed1b068ebb7fde1e
+size 7426120

--- a/lib/linux-aarch64/libkrun.so.2.0.0
+++ b/lib/linux-aarch64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:07de6eb95ababd01d417de800356dfdaef8eb32d23aa73aebb3a83fec38d853e
-size 7414696
+oid sha256:c0be8c9224779e413fb948f526b1df3c9ff2366aadee0299ed1b068ebb7fde1e
+size 7426120

--- a/lib/linux-x86_64/libkrun.provenance
+++ b/lib/linux-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=b51f1b113985153b426e838d5287c94e6a17781a
+libkrun=00d03003bd8e7e1538dbed0c7ab00812881b5b53
 libkrunfw=8f1307644bdcb95fe1343bf0d6ccf30aa22f1549

--- a/lib/linux-x86_64/libkrun.so
+++ b/lib/linux-x86_64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2da46f242ca5d4dd482abd35e0d5dc63e42171ddd7da313763c51de8b093668a
-size 8227824
+oid sha256:021440fde1b5ae32f27309c1695f95fcc3bf738cd7cf569c4d57541b4b770c17
+size 8227088

--- a/lib/linux-x86_64/libkrun.so.2.0.0
+++ b/lib/linux-x86_64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7624aaf0fe5ca3549430e013e33876a07387a8ef27c46ba9d42ea16cce3e46bb
-size 8203072
+oid sha256:021440fde1b5ae32f27309c1695f95fcc3bf738cd7cf569c4d57541b4b770c17
+size 8227088

--- a/lib/windows-x86_64/libkrun.provenance
+++ b/lib/windows-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=b51f1b113985153b426e838d5287c94e6a17781a
+libkrun=00d03003bd8e7e1538dbed0c7ab00812881b5b53
 libkrunfw=8f1307644bdcb95fe1343bf0d6ccf30aa22f1549

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -518,7 +518,7 @@ impl RunConfig {
         // needs the machine's credentials, which live on the record.
         let env = if env.is_empty() { &record.env } else { env };
         self.s3_volumes = crate::remote_volume::to_s3_volumes(&record.remote_volumes, env);
-        self.persistent_overlay_id = Some(crate::workload::persistent_overlay_owner(
+        self.persistent_overlay_id = Some(crate::workload::persistent_overlay_owner_with_lineage(
             machine_name,
             record.golden.as_deref(),
             record.fork_overlay_owner.as_deref(),

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -521,6 +521,7 @@ impl RunConfig {
         self.persistent_overlay_id = Some(crate::workload::persistent_overlay_owner(
             machine_name,
             record.golden.as_deref(),
+            record.fork_overlay_owner.as_deref(),
         ));
         self
     }

--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -18,6 +18,10 @@ use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+/// Bound qcow2 ancestry and recursive lifecycle work. Longer chains should be
+/// compacted into a new root rather than accumulating unbounded lookup cost.
+const MAX_FORK_LINEAGE_DEPTH: usize = 32;
+
 /// Path to a forkable machine's control socket (pause/resume/checkpoint/FORK).
 pub fn control_socket_path(name: &str) -> PathBuf {
     vm_data_dir(name).join("control.sock")
@@ -139,13 +143,57 @@ fn fork_base_already_paused(status: &str) -> bool {
     status.trim() == "OK paused"
 }
 
+/// Flush guest filesystems before checkpointing a restored clone again.
+///
+/// A first-generation clone may have just changed its persistent container
+/// overlay during identity rejuvenation. Capturing the next generation while
+/// those writes are still in the guest page cache can restore an overlayfs
+/// mount whose first lookup blocks indefinitely. `sync` is the guest-visible
+/// durability boundary: it completes before libkrun drains the block workers
+/// and freezes the vCPUs.
+fn sync_nested_fork_source(name: &str) -> Result<()> {
+    let socket = vm_data_dir(name).join("agent.sock");
+    let mut client = AgentClient::connect_with_retry(&socket)
+        .map_err(|error| Error::agent("sync fork source", error.to_string()))?;
+    match client.vm_exec(
+        vec!["/bin/sync".to_string()],
+        Vec::new(),
+        None,
+        Some(Duration::from_secs(30)),
+        None,
+    ) {
+        Ok((0, _, _)) => Ok(()),
+        Ok((code, _, stderr)) => Err(Error::agent(
+            "sync fork source",
+            format!(
+                "guest sync exited {code}: {}",
+                String::from_utf8_lossy(&stderr).trim()
+            ),
+        )),
+        Err(error) => Err(Error::agent("sync fork source", error.to_string())),
+    }
+}
+
 /// Build the clone-local release and acknowledgement script.
 fn build_release_forkpoint_script() -> String {
     format!(
-        "set -e; mkdir -p '{dir}'; umask 077; printf '%s\\n' smolvm-forkpoint-release-v1 > '{release}.tmp'; mv '{release}.tmp' '{release}'; \
-         i=0; while [ -f '{ready}' ]; do i=$((i + 1)); [ \"$i\" -lt 500 ] || exit 46; sleep 0.02; done",
+        "set -e; mkdir -p '{dir}'; umask 077; \
+         if [ -f '{ready}' ]; then generation=$(sed -n 's/^{generation_prefix}//p' '{ready}' | head -n 1); else generation=''; fi; \
+         case \"$generation\" in ''|*[!0-9a-fA-F]*) generation='' ;; esac; \
+         if [ \"${{#generation}}\" -eq 32 ]; then \
+           printf '%s%s\\n' '{release_prefix}' \"$generation\" > '{release}.tmp'; \
+         else \
+           generation=''; printf '%s\\n' '{legacy_release}' > '{release}.tmp'; \
+         fi; \
+         mv '{release}.tmp' '{release}'; i=0; \
+         while if [ -n \"$generation\" ]; then grep -q -x \"{generation_prefix}$generation\" '{ready}' 2>/dev/null; else [ -f '{ready}' ]; fi; do \
+           i=$((i + 1)); [ \"$i\" -lt 500 ] || exit 46; sleep 0.02; \
+         done",
         dir = smolvm_protocol::forkpoint::STATE_DIR,
+        generation_prefix = smolvm_protocol::forkpoint::GENERATION_PREFIX,
+        legacy_release = smolvm_protocol::forkpoint::LEGACY_RELEASE_TOKEN,
         release = smolvm_protocol::forkpoint::RELEASE_PATH,
+        release_prefix = smolvm_protocol::forkpoint::RELEASE_PREFIX,
         ready = smolvm_protocol::forkpoint::READY_PATH,
     )
 }
@@ -418,10 +466,10 @@ pub(crate) fn prepare_forks_reusing(
                 format!("duplicate clone name '{}'", spec.clone),
             ));
         }
-        if spec.clone_forkable {
+        if spec.hold && spec.clone_forkable {
             return Err(Error::agent(
                 "fork",
-                "nested fork is not supported: a clone cannot be re-forked, so `forkable` on a fork has no effect (drop it)",
+                "a held pool slot cannot be forkable; release or replenish held slots instead",
             ));
         }
         if db.get_vm(spec.clone)?.is_some() {
@@ -443,6 +491,24 @@ pub(crate) fn prepare_forks_reusing(
     let golden_rec = db
         .get_vm(golden)?
         .ok_or_else(|| Error::vm_not_found(golden))?;
+    let child_depth = db
+        .fork_lineage_depth(golden)?
+        .checked_add(1)
+        .ok_or_else(|| Error::agent("fork", "fork lineage depth overflow"))?;
+    if child_depth > MAX_FORK_LINEAGE_DEPTH {
+        return Err(Error::agent(
+            "fork",
+            format!(
+                "fork lineage would exceed {MAX_FORK_LINEAGE_DEPTH} generations; compact this state into a new root first"
+            ),
+        ));
+    }
+    if golden_rec.cuda && specs.iter().any(|spec| spec.clone_forkable) {
+        return Err(Error::agent(
+            "fork",
+            "CUDA fork descendants are not supported yet; create a leaf clone without `forkable`",
+        ));
+    }
     let ctl = control_socket_path(golden);
     if !ctl.exists() {
         return Err(Error::agent(
@@ -516,6 +582,13 @@ pub(crate) fn prepare_forks_reusing(
                 result.map_err(|e| Error::agent("fork: resolve golden uid", e.to_string()))?;
             crate::process::chown_tree(&snapshot_dir, uid, gid)
                 .map_err(|e| Error::agent("fork: chown snapshot dir", e.to_string()))?;
+        }
+
+        if golden_rec.golden.is_some() {
+            if let Err(error) = sync_nested_fork_source(golden) {
+                let _ = std::fs::remove_dir_all(&snapshot_dir);
+                return Err(error);
+            }
         }
 
         let t_snap = std::time::Instant::now();
@@ -803,9 +876,18 @@ fn prepare_clone_from_snapshot(
             }
             clone_rec.ports = remapped;
         }
+        clone_rec.fork_overlay_owner = Some(
+            golden_rec
+                .fork_overlay_owner
+                .as_deref()
+                .or(golden_rec.golden.as_deref())
+                .unwrap_or(golden)
+                .to_string(),
+        );
         clone_rec.golden = Some(golden.to_string());
-        // Clones are leaf machines. Do not inherit a Smolfile-declared
-        // forkable launch default from the golden on later cold starts.
+        // Forkability is explicit per clone. A normal clone remains a cheap
+        // leaf; a forkable clone materializes its restored RAM into fresh
+        // backing files at boot so it can later checkpoint its own state.
         clone_rec.forkable = spec.clone_forkable;
         clone_rec.forkpoint_held = spec.hold;
         clone_rec.fork_env = spec.fork_env.to_vec();
@@ -946,7 +1028,11 @@ fn build_rejuvenation_script(clone: &str, seed: &str, record: &VmRecord) -> Stri
     // restored. A bare VM (no image) keeps the plain VM-rootfs paths.
     let (root, require_root, runtime_hostname, restored_container) = match record.image {
         Some(_) => {
-            let owner = crate::workload::persistent_overlay_owner(clone, record.golden.as_deref());
+            let owner = crate::workload::persistent_overlay_owner(
+                clone,
+                record.golden.as_deref(),
+                record.fork_overlay_owner.as_deref(),
+            );
             let merged = format!("/storage/overlays/persistent-{owner}/merged");
             let container_id = format!("/storage/overlays/persistent-{owner}/main_container_id");
             let require = format!(
@@ -1049,10 +1135,13 @@ fn build_rejuvenation_script(clone: &str, seed: &str, record: &VmRecord) -> Stri
     };
     format!(
         "set -e; \
+         echo 'rejuvenate-stage=overlay' >&2; \
          {require_root}\
+         echo 'rejuvenate-stage=hostname' >&2; \
          hostname '{c}' 2>/dev/null || true; \
          {runtime_hostname}\
          {restored_container}\
+         echo 'rejuvenate-stage=identity' >&2; \
          printf '%s' '{s}' > /dev/urandom 2>/dev/null || true; \
          MID=$(printf '%.32s' '{s}'); \
          printf '%s\\n' '{c}' > {root}/etc/hostname; \
@@ -1137,7 +1226,15 @@ fn rejuvenate_once(sock: &Path, script: &str) -> std::result::Result<(), String>
     let mut client =
         AgentClient::connect_with_retry(sock).map_err(|e| format!("agent connect: {e}"))?;
     match client.vm_exec(
-        vec!["/bin/sh".into(), "-c".into(), script.to_string()],
+        vec![
+            "/usr/bin/timeout".into(),
+            "-k".into(),
+            "1".into(),
+            "7".into(),
+            "/bin/sh".into(),
+            "-c".into(),
+            script.to_string(),
+        ],
         vec![],
         None,
         Some(std::time::Duration::from_secs(10)),
@@ -1252,7 +1349,11 @@ pub fn write_fork_env(clone: &str, record: &VmRecord, env: &[(String, String)]) 
     // Overlay owner is a validated machine name (alphanumeric + dashes), so
     // splicing it into the script is injection-safe — same contract as the
     // rejuvenation script's clone name.
-    let owner = crate::workload::persistent_overlay_owner(clone, record.golden.as_deref());
+    let owner = crate::workload::persistent_overlay_owner(
+        clone,
+        record.golden.as_deref(),
+        record.fork_overlay_owner.as_deref(),
+    );
     let merged = format!("/storage/overlays/persistent-{owner}/merged");
     // Image machines MUST land the file in the workload container's rootfs
     // (the overlay merged dir): falling through silently would strand it in
@@ -1307,7 +1408,11 @@ pub fn activate_held_fork(
     validate_fork_env(assignment)?;
     let merged = merge_fork_env(&record.fork_env, assignment);
     let content = render_fork_env(&merged);
-    let owner = crate::workload::persistent_overlay_owner(clone, record.golden.as_deref());
+    let owner = crate::workload::persistent_overlay_owner(
+        clone,
+        record.golden.as_deref(),
+        record.fork_overlay_owner.as_deref(),
+    );
     let merged_root = format!("/storage/overlays/persistent-{owner}/merged");
     let env_path = if record.image.is_some() {
         format!("{merged_root}{FORK_ENV_GUEST_PATH}")
@@ -1527,6 +1632,8 @@ fn build_activation_script(
            exit 42; \
          fi; \
          if [ ! -f '{ready}' ]; then exit 43; fi; \
+         generation=$(sed -n 's/^{generation_prefix}//p' '{ready}' | head -n 1); \
+         case \"$generation\" in ''|*[!0-9a-fA-F]*) generation='' ;; esac; \
          rm -f '{worker_ready}'; \
          receipt_tmp='{receipt}.{activation_token}.'$$; \
          printf '%s\\n' '{activation_token}' > \"$receipt_tmp\"; \
@@ -1539,8 +1646,13 @@ fn build_activation_script(
          release_tmp='{release}.{activation_token}.'$$; \
          trap 'rm -f \"$env_tmp\" \"$release_tmp\"' EXIT; \
          cat > \"$env_tmp\"; mv \"$env_tmp\" '{env_path}'; \
-         printf '%s\\n' smolvm-forkpoint-release-v1 > \"$release_tmp\"; \
-         mv \"$release_tmp\" '{release}'"
+         if [ \"${{#generation}}\" -eq 32 ]; then \
+           printf '%s%s\\n' '{release_prefix}' \"$generation\" > \"$release_tmp\"; \
+         else printf '%s\\n' '{legacy_release}' > \"$release_tmp\"; fi; \
+         mv \"$release_tmp\" '{release}'",
+        generation_prefix = smolvm_protocol::forkpoint::GENERATION_PREFIX,
+        legacy_release = smolvm_protocol::forkpoint::LEGACY_RELEASE_TOKEN,
+        release_prefix = smolvm_protocol::forkpoint::RELEASE_PREFIX,
     )
 }
 
@@ -1829,7 +1941,16 @@ mod tests {
         let state = temp.path().join("state");
         let workspace = temp.path().join("workspace");
         std::fs::create_dir_all(&state).unwrap();
-        std::fs::write(state.join("ready"), b"ready\n").unwrap();
+        let generation = "0123456789abcdef0123456789abcdef";
+        std::fs::write(
+            state.join("ready"),
+            format!(
+                "{}\n{}{generation}\n",
+                smolvm_protocol::forkpoint::READY_VERSION,
+                smolvm_protocol::forkpoint::GENERATION_PREFIX
+            ),
+        )
+        .unwrap();
         let ready = state.join("ready");
         let release = state.join("release");
         let worker_ready = state.join("worker-ready");
@@ -1867,7 +1988,13 @@ mod tests {
             std::fs::read_to_string(&receipt).unwrap(),
             format!("{token}\n")
         );
-        assert!(release.is_file());
+        assert_eq!(
+            std::fs::read_to_string(&release).unwrap(),
+            format!(
+                "{}{generation}\n",
+                smolvm_protocol::forkpoint::RELEASE_PREFIX
+            )
+        );
         assert!(!worker_ready.exists());
 
         // A lost reply may cause the host to send the same activation again.

--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -15,12 +15,94 @@ use crate::data::validate_vm_name;
 use crate::db::SmolvmDb;
 use crate::{Error, Result};
 use std::collections::{BTreeMap, HashSet};
+use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 /// Bound qcow2 ancestry and recursive lifecycle work. Longer chains should be
 /// compacted into a new root rather than accumulating unbounded lookup cost.
 const MAX_FORK_LINEAGE_DEPTH: usize = 32;
+
+/// Cross-process guard for one source machine's complete fork transaction.
+///
+/// The in-process API/SDK lifecycle locks cannot serialize a separate CLI
+/// process. Without this guard, two first forks can both wait in the guest;
+/// after one freezes it, the other remains blocked in the now-paused VM. The
+/// lock spans readiness, checkpointing, clone boot, and any rollback.
+pub struct ForkSourceLock {
+    _file: File,
+}
+
+impl ForkSourceLock {
+    fn acquire_at(path: &Path) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|error| Error::agent("fork source lock", error.to_string()))?;
+        }
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(path)
+            .map_err(|error| Error::agent("fork source lock", error.to_string()))?;
+        lock_file_exclusive(&file)
+            .map_err(|error| Error::agent("fork source lock", error.to_string()))?;
+        Ok(Self { _file: file })
+    }
+}
+
+/// Serialize a complete fork operation for `source` across CLI, SDK, and serve
+/// processes. The sibling lock file intentionally lives outside the machine's
+/// removable data directory, so a concurrent delete cannot replace its inode.
+pub fn lock_fork_source(source: &str) -> Result<ForkSourceLock> {
+    validate_vm_name(source, "fork source").map_err(|error| Error::config("fork source", error))?;
+    ForkSourceLock::acquire_at(&fork_source_lock_path(source))
+}
+
+fn fork_source_lock_path(source: &str) -> PathBuf {
+    let data_dir = vm_data_dir(source);
+    data_dir
+        .parent()
+        .expect("a VM data directory always has a parent")
+        .join(format!(".{source}.fork-operation.lock"))
+}
+
+#[cfg(unix)]
+fn lock_file_exclusive(file: &File) -> std::io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(windows)]
+fn lock_file_exclusive(file: &File) -> std::io::Result<()> {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::{LockFileEx, LOCKFILE_EXCLUSIVE_LOCK};
+    use windows_sys::Win32::System::IO::OVERLAPPED;
+
+    let handle = file.as_raw_handle() as windows_sys::Win32::Foundation::HANDLE;
+    let mut overlapped: OVERLAPPED = unsafe { std::mem::zeroed() };
+    let result = unsafe {
+        LockFileEx(
+            handle,
+            LOCKFILE_EXCLUSIVE_LOCK,
+            0,
+            u32::MAX,
+            u32::MAX,
+            &mut overlapped,
+        )
+    };
+    if result != 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
 
 /// Path to a forkable machine's control socket (pause/resume/checkpoint/FORK).
 pub fn control_socket_path(name: &str) -> PathBuf {
@@ -317,10 +399,6 @@ pub struct PreparedFork {
     /// caller to log. Empty when the golden has no forwards. When ports were
     /// pinned, `golden_host == clone_host`.
     pub port_remaps: Vec<(u16, u16, u16)>,
-    /// Whether a caller must resume the golden if clone boot/finalization fails.
-    /// False for pool refill from an already-paused golden: resuming that base
-    /// would invalidate every existing clone and retained CUDA snapshot.
-    pub resume_golden_on_rollback: bool,
 }
 
 /// A checkpoint that may be reused while the exact same golden process remains
@@ -343,8 +421,6 @@ pub(crate) struct PreparedForkBatch {
     /// Checkpoint bound to the current golden process, when its identity is
     /// strong enough to reuse safely.
     pub(crate) retained_snapshot: Option<RetainedForkSnapshot>,
-    /// Whether this call reused `retained_snapshot` instead of checkpointing.
-    pub(crate) snapshot_reused: bool,
 }
 
 /// Parameters for one clone in a single-snapshot fork operation.
@@ -669,32 +745,28 @@ pub(crate) fn prepare_forks_reusing(
             spec,
             &mut reserved_ports,
         ) {
-            Ok(mut clone) => {
-                clone.resume_golden_on_rollback = !golden_was_paused;
-                prepared.push(clone);
-            }
+            Ok(clone) => prepared.push(clone),
             Err(error) => {
                 for clone in &prepared {
                     let _ = db.remove_vm(&clone.clone_record.name);
                     let _ = std::fs::remove_dir_all(vm_data_dir(&clone.clone_record.name));
                 }
-                if snapshot_reused || golden_was_paused {
-                    return Err(error);
-                }
-                return Err(rollback_new_snapshot(
-                    db,
-                    golden,
-                    &snapshot_dir,
-                    persist_snapshot,
-                    error,
-                ));
+                return Err(if snapshot_reused || golden_was_paused {
+                    error
+                } else {
+                    Error::agent(
+                        "fork",
+                        format!(
+                            "{error}; source '{golden}' remains frozen at its retained checkpoint so the fork can be retried safely"
+                        ),
+                    )
+                });
             }
         }
     }
     Ok(PreparedForkBatch {
         forks: prepared,
         retained_snapshot,
-        snapshot_reused,
     })
 }
 
@@ -904,7 +976,6 @@ fn prepare_clone_from_snapshot(
             snapshot_dir: snapshot_dir.to_path_buf(),
             clone_record: clone_rec,
             port_remaps,
-            resume_golden_on_rollback: true,
         })
     })();
 
@@ -1028,7 +1099,7 @@ fn build_rejuvenation_script(clone: &str, seed: &str, record: &VmRecord) -> Stri
     // restored. A bare VM (no image) keeps the plain VM-rootfs paths.
     let (root, require_root, runtime_hostname, restored_container) = match record.image {
         Some(_) => {
-            let owner = crate::workload::persistent_overlay_owner(
+            let owner = crate::workload::persistent_overlay_owner_with_lineage(
                 clone,
                 record.golden.as_deref(),
                 record.fork_overlay_owner.as_deref(),
@@ -1349,7 +1420,7 @@ pub fn write_fork_env(clone: &str, record: &VmRecord, env: &[(String, String)]) 
     // Overlay owner is a validated machine name (alphanumeric + dashes), so
     // splicing it into the script is injection-safe — same contract as the
     // rejuvenation script's clone name.
-    let owner = crate::workload::persistent_overlay_owner(
+    let owner = crate::workload::persistent_overlay_owner_with_lineage(
         clone,
         record.golden.as_deref(),
         record.fork_overlay_owner.as_deref(),
@@ -1408,7 +1479,7 @@ pub fn activate_held_fork(
     validate_fork_env(assignment)?;
     let merged = merge_fork_env(&record.fork_env, assignment);
     let content = render_fork_env(&merged);
-    let owner = crate::workload::persistent_overlay_owner(
+    let owner = crate::workload::persistent_overlay_owner_with_lineage(
         clone,
         record.golden.as_deref(),
         record.fork_overlay_owner.as_deref(),
@@ -1718,6 +1789,41 @@ fn host_random_hex(hex_len: usize) -> Result<String> {
 mod tests {
     use super::*;
     use std::cell::Cell;
+
+    #[test]
+    #[cfg(unix)]
+    fn fork_source_lock_serializes_independent_open_handles() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("source.lock");
+        let first = ForkSourceLock::acquire_at(&path).unwrap();
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (acquired_tx, acquired_rx) = std::sync::mpsc::channel();
+        let waiter_path = path.clone();
+        let waiter = std::thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            let _second = ForkSourceLock::acquire_at(&waiter_path).unwrap();
+            acquired_tx.send(()).unwrap();
+        });
+
+        started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert!(
+            acquired_rx
+                .recv_timeout(Duration::from_millis(100))
+                .is_err(),
+            "a second fork transaction must wait for the first"
+        );
+        drop(first);
+        acquired_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        waiter.join().unwrap();
+    }
+
+    #[test]
+    fn dotted_machine_names_have_distinct_fork_locks() {
+        assert_ne!(
+            fork_source_lock_path("worker.one"),
+            fork_source_lock_path("worker.two")
+        );
+    }
 
     // Per-fork parameters double as env var names and dotenv file lines, so
     // keys must be valid identifiers and values single-line — anything else

--- a/src/agent/state_probe.rs
+++ b/src/agent/state_probe.rs
@@ -137,7 +137,10 @@ pub fn recover_unreachable_machine(record: &VmRecord) -> crate::Result<()> {
     recover_unreachable_machine_in_db(record, &db)
 }
 
-fn recover_unreachable_machine_in_db(record: &VmRecord, db: &SmolvmDb) -> crate::Result<()> {
+pub(crate) fn recover_unreachable_machine_in_db(
+    record: &VmRecord,
+    db: &SmolvmDb,
+) -> crate::Result<()> {
     if let Some(pid) = record.pid {
         if crate::process::is_alive(pid) {
             if !crate::process::is_our_process_strict(pid, record.pid_start_time) {

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -1249,7 +1249,11 @@ pub async fn start_machine(
                 .map(|(i, m)| (HostMount::mount_tag(i), m.target.clone(), m.readonly))
                 .collect::<Vec<_>>()
         };
-        let overlay_id = crate::workload::persistent_overlay_owner(&name, record.golden.as_deref());
+        let overlay_id = crate::workload::persistent_overlay_owner(
+            &name,
+            record.golden.as_deref(),
+            record.fork_overlay_owner.as_deref(),
+        );
         // Pull the image FIRST, as a FATAL step. A pull failure — the image /
         // tag doesn't exist, is private without access, or the machine has no
         // network to reach the registry — is a permanent, user-fixable
@@ -1356,12 +1360,12 @@ pub async fn start_machine(
 
 /// Classify a fork-preparation failure into the right HTTP status. The golden
 /// missing is a 404; the golden not being forkable / not yet ready, or the clone
-/// name already being taken, is a 409; a nested-fork request is a 400; anything
-/// else is a 500.
+/// name already being taken, is a 409; an unsupported descendant shape is a
+/// 400; anything else is a 500.
 fn classify_fork_error(e: SmolvmError) -> ApiError {
     let msg = e.to_string();
     let lc = msg.to_ascii_lowercase();
-    if lc.contains("nested fork") {
+    if lc.contains("cuda fork descendants") || lc.contains("fork lineage would exceed") {
         ApiError::BadRequest(msg)
     } else if lc.contains("already exists")
         || lc.contains("not running forkable")
@@ -1392,7 +1396,7 @@ fn classify_fork_error(e: SmolvmError) -> ApiError {
     request_body = ForkRequest,
     responses(
         (status = 200, description = "Clone forked and running", body = MachineInfo),
-        (status = 400, description = "Invalid request (e.g. nested fork)", body = ApiErrorResponse),
+        (status = 400, description = "Invalid or unsupported fork request", body = ApiErrorResponse),
         (status = 404, description = "Golden machine not found", body = ApiErrorResponse),
         (status = 409, description = "Golden not forkable, or clone name already exists", body = ApiErrorResponse),
         (status = 500, description = "Fork failed", body = ApiErrorResponse)
@@ -1415,6 +1419,7 @@ pub(crate) async fn fork_machine_inner(
     let clone = req.name.clone();
     let pinned_ports: Vec<(u16, u16)> = req.ports.iter().map(|p| (p.host, p.guest)).collect();
     let req_share_weights = req.share_weights;
+    let req_forkable = req.forkable;
     let req_hold = req.hold;
     let wait_ready = req.wait_ready || req_hold;
     let ready_timeout = std::time::Duration::from_secs(req.ready_timeout_secs.unwrap_or(240));
@@ -1426,6 +1431,12 @@ pub(crate) async fn fork_machine_inner(
     let fork_secrets = req.secrets.clone();
     crate::agent::fork::validate_fork_env(&fork_env)
         .map_err(|e| ApiError::BadRequest(e.to_string()))?;
+    if req_hold && req_forkable {
+        return Err(ApiError::BadRequest(
+            "hold and forkable cannot be combined; held pool slots are disposable leaves"
+                .to_string(),
+        ));
+    }
 
     if clone == golden {
         return Err(ApiError::Conflict(format!(
@@ -1505,7 +1516,12 @@ pub(crate) async fn fork_machine_inner(
                 )
             } else {
                 crate::agent::fork::prepare_fork(
-                    &db, &golden_b, &clone_b, &ports, /* clone_forkable */ false, &env,
+                    &db,
+                    &golden_b,
+                    &clone_b,
+                    &ports,
+                    req_forkable,
+                    &env,
                     &secrets,
                 )
             }
@@ -1832,6 +1848,7 @@ async fn boot_prepared_fork_inner(
         )
         .map_err(|e| format!("failed to prepare packed layers: {}", e))?;
         // Boot from the golden's snapshot instead of cold-booting.
+        features.forkable = record.forkable;
         features.snapshot_dir = Some(prep.snapshot_dir);
         features.cuda_share_weights = share_weights;
         features.cuda_preload_modules = record.cuda_preload_modules;
@@ -2301,18 +2318,18 @@ pub async fn delete_machine(
     Path(name): Path<String>,
     Query(query): Query<DeleteQuery>,
 ) -> Result<Json<DeleteResponse>, ApiError> {
-    // Cascade: remove each dependent clone before the golden so its own delete
-    // (below) sees no dependents. Clones are leaves (launched non-forkable), so
-    // one level is exhaustive; the read is unlocked but delete_one re-checks
-    // under the golden's lifecycle lock, so a clone forked in the race still
-    // refuses rather than dangling.
+    // Cascade: remove the entire lineage deepest-first so every qcow2 overlay
+    // disappears before the image that backs it. The read is unlocked, but
+    // delete_one re-checks direct dependants under each lifecycle lock, so a
+    // concurrently-created child still refuses instead of dangling.
     if query.cascade {
         let db = state.db().clone();
         let golden = name.clone();
-        let clones = tokio::task::spawn_blocking(move || db.dependent_clones(&golden))
-            .await
-            .map_err(|e| ApiError::internal(format!("task error: {}", e)))?
-            .map_err(ApiError::database)?;
+        let clones =
+            tokio::task::spawn_blocking(move || db.dependent_descendants_postorder(&golden))
+                .await
+                .map_err(|e| ApiError::internal(format!("task error: {}", e)))?
+                .map_err(ApiError::database)?;
         for clone in clones {
             delete_one(state.clone(), clone).await?;
         }

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -1249,7 +1249,7 @@ pub async fn start_machine(
                 .map(|(i, m)| (HostMount::mount_tag(i), m.target.clone(), m.readonly))
                 .collect::<Vec<_>>()
         };
-        let overlay_id = crate::workload::persistent_overlay_owner(
+        let overlay_id = crate::workload::persistent_overlay_owner_with_lineage(
             &name,
             record.golden.as_deref(),
             record.fork_overlay_owner.as_deref(),
@@ -1384,6 +1384,15 @@ fn classify_fork_error(e: SmolvmError) -> ApiError {
     }
 }
 
+async fn acquire_fork_source_lock(
+    source: String,
+) -> Result<crate::agent::fork::ForkSourceLock, ApiError> {
+    tokio::task::spawn_blocking(move || crate::agent::fork::lock_fork_source(&source))
+        .await
+        .map_err(|error| ApiError::internal(format!("fork lock task failed: {error}")))?
+        .map_err(classify_fork_error)
+}
+
 /// Fork a running, forkable golden machine into a new clone (copy-on-write
 /// memory + disks).
 #[utoipa::path(
@@ -1471,6 +1480,7 @@ pub(crate) async fn fork_machine_inner(
     // observe the golden between failed-clone teardown and rollback.
     let golden_lifecycle = state.lifecycle_lock(&golden);
     let _golden_guard = golden_lifecycle.lock().await;
+    let _source_lock = acquire_fork_source_lock(golden.clone()).await?;
 
     // Reject an already-registered target before taking its lifecycle lock.
     // Besides avoiding a pointless forkpoint wait, this prevents two invalid
@@ -1531,9 +1541,7 @@ pub(crate) async fn fork_machine_inner(
         .map_err(classify_fork_error)?
     };
 
-    let snapshot_dir = prep.snapshot_dir.clone();
-    let resume_golden_on_rollback = prep.resume_golden_on_rollback;
-    let result = boot_prepared_fork_inner(
+    boot_prepared_fork_inner(
         state.clone(),
         clone,
         prep,
@@ -1546,40 +1554,7 @@ pub(crate) async fn fork_machine_inner(
             boot_permit: None,
         },
     )
-    .await;
-
-    let Err(ApiError::CloneIdentityRejuvenationFailed(message)) = result else {
-        return result;
-    };
-    if !resume_golden_on_rollback {
-        return Err(ApiError::CloneIdentityRejuvenationFailed(message));
-    }
-
-    // `fail_closed_on_rejuvenation` has torn down the only clone prepared from
-    // this new checkpoint. It is therefore safe to restore the initially-running
-    // golden and invalidate the checkpoint before releasing its lifecycle lock.
-    let db = state.db().clone();
-    let golden_for_rollback = golden.clone();
-    let rollback = match tokio::task::spawn_blocking(move || {
-        crate::agent::fork::rollback_retained_fork_snapshot(
-            &db,
-            &golden_for_rollback,
-            &snapshot_dir,
-            true,
-        )
-    })
     .await
-    {
-        Ok(result) => result,
-        Err(error) => Err(SmolvmError::agent(
-            "fork rollback",
-            format!("task error: {error}"),
-        )),
-    };
-    match rollback {
-        Ok(()) => Err(ApiError::CloneIdentityRejuvenationFailed(message)),
-        Err(rollback_error) => Err(ApiError::Internal(format!("{message}; {rollback_error}"))),
-    }
 }
 
 /// Prepare several clean held workers from one golden checkpoint and boot them
@@ -1618,6 +1593,8 @@ pub(crate) async fn fork_held_machines_inner(
     if clones.is_empty() {
         return Ok(ForkBatchOutcome { retained_snapshot });
     }
+
+    let _source_lock = acquire_fork_source_lock(golden.clone()).await?;
 
     let golden_for_wait = golden.clone();
     tokio::task::spawn_blocking(move || {
@@ -1668,9 +1645,6 @@ pub(crate) async fn fork_held_machines_inner(
         .map_err(classify_fork_error)?
     };
 
-    let snapshot_dir = prepared.forks[0].snapshot_dir.clone();
-    let resume_golden_on_rollback = prepared.forks[0].resume_golden_on_rollback;
-    let snapshot_reused = prepared.snapshot_reused;
     let reusable_snapshot = prepared.retained_snapshot.clone();
     let pending_boots = prepared.forks.len();
     let boots = prepared.forks.into_iter().zip(clones).map(|(prep, clone)| {
@@ -1705,7 +1679,7 @@ pub(crate) async fn fork_held_machines_inner(
     // permit and wait for CUDA reconstruction without blocking the next VM.
     // The semaphore, not this result stream, preserves the qualified launch
     // width; completed results are still reported as soon as each is usable.
-    let any_succeeded = run_bounded_futures(boots, pending_boots, |result| {
+    run_bounded_futures(boots, pending_boots, |result| {
         let succeeded = result.1.is_ok();
         if succeeded {
             if let (Some(sender), Some(snapshot)) =
@@ -1721,50 +1695,14 @@ pub(crate) async fn fork_held_machines_inner(
     })
     .await;
 
-    // If every restore failed, no clone depends on this checkpoint and an
-    // initially-running golden can safely resume for a later retry. A partial
-    // success must retain the paused golden and shared snapshot.
-    let mut rollback_completed = true;
-    if !any_succeeded && !snapshot_reused {
-        if resume_golden_on_rollback {
-            if let Err(error) = crate::agent::fork::resume_golden(&golden, &snapshot_dir) {
-                tracing::warn!(%golden, %error, "failed to resume golden after batch restore failure");
-                rollback_completed = false;
-            }
-        }
-        if rollback_completed {
-            if let Err(error) = state.db().remove_retained_fork_snapshot(&golden) {
-                tracing::warn!(%golden, %error, "failed to remove rolled-back fork pool checkpoint");
-            }
-            if let Err(error) = std::fs::remove_dir_all(&snapshot_dir) {
-                tracing::warn!(path = %snapshot_dir.display(), %error, "failed to remove unused batch fork snapshot");
-            }
-        }
-    }
-
     drop(guards);
     Ok(ForkBatchOutcome {
-        retained_snapshot: retained_snapshot_after_boots(
-            snapshot_reused,
-            any_succeeded,
-            rollback_completed,
-            reusable_snapshot,
-        ),
+        // A completed checkpoint remains the safe retry source even when every
+        // clone boot fails. In-place golden rollback has proven capable of
+        // resuming vCPUs while leaving virtio I/O wedged; keep the known-good
+        // frozen snapshot instead.
+        retained_snapshot: reusable_snapshot,
     })
-}
-
-fn retained_snapshot_after_boots(
-    snapshot_reused: bool,
-    any_succeeded: bool,
-    rollback_completed: bool,
-    reusable_snapshot: Option<crate::agent::fork::RetainedForkSnapshot>,
-) -> Option<crate::agent::fork::RetainedForkSnapshot> {
-    // A failed boot does not invalidate a checkpoint that preparation just
-    // verified against the paused golden. Keep it so a transient KVM or guest
-    // readiness failure cannot strand that golden without a refill path.
-    (snapshot_reused || any_succeeded || !rollback_completed)
-        .then_some(reusable_snapshot)
-        .flatten()
 }
 
 async fn run_bounded_futures<F, T>(
@@ -2353,6 +2291,7 @@ pub(crate) async fn delete_one(
     // detach is a no-op.
     let lifecycle = state.lifecycle_lock(&name);
     let _guard = lifecycle.lock().await;
+    let _source_lock = acquire_fork_source_lock(name.clone()).await?;
 
     // Check if VM exists and get its state (off the reactor)
     let record = state
@@ -2926,49 +2865,6 @@ mod tests {
     use crate::db::SmolvmDb;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tempfile::TempDir;
-
-    fn retained_snapshot() -> crate::agent::fork::RetainedForkSnapshot {
-        crate::agent::fork::RetainedForkSnapshot {
-            path: std::path::PathBuf::from("/golden/s/12345678"),
-            golden_pid: 123,
-            golden_pid_start_time: 456,
-        }
-    }
-
-    #[test]
-    fn failed_reused_checkpoint_remains_available_for_retry() {
-        let snapshot = retained_snapshot();
-        assert_eq!(
-            retained_snapshot_after_boots(true, false, true, Some(snapshot.clone())),
-            Some(snapshot)
-        );
-    }
-
-    #[test]
-    fn failed_new_checkpoint_is_not_retained() {
-        assert_eq!(
-            retained_snapshot_after_boots(false, false, true, Some(retained_snapshot())),
-            None
-        );
-    }
-
-    #[test]
-    fn successful_new_checkpoint_is_retained() {
-        let snapshot = retained_snapshot();
-        assert_eq!(
-            retained_snapshot_after_boots(false, true, true, Some(snapshot.clone())),
-            Some(snapshot)
-        );
-    }
-
-    #[test]
-    fn failed_new_checkpoint_remains_available_when_rollback_fails() {
-        let snapshot = retained_snapshot();
-        assert_eq!(
-            retained_snapshot_after_boots(false, false, false, Some(snapshot.clone())),
-            Some(snapshot)
-        );
-    }
 
     #[tokio::test]
     async fn bounded_futures_stream_results_without_exceeding_the_limit() {

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -1414,7 +1414,7 @@ async fn relaunch_image_workload(
             .map(|(i, m)| (HostMount::mount_tag(i), m.target.clone(), m.readonly))
             .collect::<Vec<_>>()
     };
-    let overlay_id = crate::workload::persistent_overlay_owner(
+    let overlay_id = crate::workload::persistent_overlay_owner_with_lineage(
         name,
         record.golden.as_deref(),
         record.fork_overlay_owner.as_deref(),

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -1414,7 +1414,11 @@ async fn relaunch_image_workload(
             .map(|(i, m)| (HostMount::mount_tag(i), m.target.clone(), m.readonly))
             .collect::<Vec<_>>()
     };
-    let overlay_id = crate::workload::persistent_overlay_owner(name, record.golden.as_deref());
+    let overlay_id = crate::workload::persistent_overlay_owner(
+        name,
+        record.golden.as_deref(),
+        record.fork_overlay_owner.as_deref(),
+    );
 
     let image_pull = image.clone();
     with_machine_client_traced(entry, None, move |c| {

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -897,6 +897,11 @@ pub struct ForkRequest {
     /// Name for the new clone machine.
     #[schema(example = "clone-1")]
     pub name: String,
+    /// Materialize the restored clone as a new checkpoint source so it can be
+    /// forked again. This pays one eager guest-memory copy at clone boot;
+    /// descendants remain copy-on-write.
+    #[serde(default)]
+    pub forkable: bool,
     /// Pin the clone's inbound port forwards. Without this, the golden's
     /// forwards are remapped to freshly-allocated host ports so the clone does
     /// not collide with the still-running golden or sibling clones.

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -2640,7 +2640,7 @@ fn persistent_overlay_owner_for_record(
     machine_name: &str,
     record: Option<&smolvm::config::VmRecord>,
 ) -> String {
-    smolvm::workload::persistent_overlay_owner(
+    smolvm::workload::persistent_overlay_owner_with_lineage(
         machine_name,
         record.and_then(|record| record.golden.as_deref()),
         record.and_then(|record| record.fork_overlay_owner.as_deref()),

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -2643,6 +2643,7 @@ fn persistent_overlay_owner_for_record(
     smolvm::workload::persistent_overlay_owner(
         machine_name,
         record.and_then(|record| record.golden.as_deref()),
+        record.and_then(|record| record.fork_overlay_owner.as_deref()),
     )
 }
 
@@ -3709,7 +3710,7 @@ impl StartCmd {
 #[derive(Args, Debug)]
 pub struct ForkCmd {
     /// The running, forkable source machine to clone from.
-    #[arg(long, value_name = "NAME")]
+    #[arg(long, visible_alias = "from", value_name = "NAME")]
     pub golden: String,
 
     /// Name for the new clone machine.
@@ -3755,7 +3756,7 @@ pub struct ForkCmd {
 
     /// Make the clone itself forkable (memfd RAM + control socket), so it can
     /// in turn be forked.
-    #[arg(long)]
+    #[arg(long, visible_alias = "checkpointable")]
     pub forkable: bool,
 
     /// Pin the clone's inbound port forwards (repeatable). Without this, the

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -1121,6 +1121,7 @@ fn boot_prepared_fork(
     retry_gate: Option<&std::sync::Mutex<()>>,
 ) -> smolvm::Result<()> {
     let preload_modules = prep.clone_record.cuda_preload_modules;
+    let clone_forkable = prep.clone_record.forkable;
     eprintln!("Booting clone '{clone}' from snapshot...");
     let mut start = || {
         start_vm_named_with_db(
@@ -1130,6 +1131,7 @@ fn boot_prepared_fork(
             None,
             true,
             ForkLaunch {
+                forkable: clone_forkable,
                 snapshot_dir: Some(prep.snapshot_dir.clone()),
                 share_weights,
                 preload_modules,
@@ -2223,17 +2225,16 @@ pub fn delete_vm(name: &str, force: bool, options: DeleteVmOptions) -> smolvm::R
     // A golden's disks are the copy-on-write backing for its clones' overlays,
     // so it must outlive them. Refuse to delete a golden while clones depend on
     // it (unless forced, in which case the clones' overlays are left dangling).
-    let dependent_clones = SmolvmDb::open()?.dependent_clones(name)?;
+    let db = SmolvmDb::open()?;
+    let dependent_clones = db.dependent_clones(name)?;
     if !dependent_clones.is_empty() {
         if options.cascade {
-            // Children before the fork base: delete each dependent clone first,
-            // then fall through to remove the golden. A clone is never itself a
-            // fork base (clones launch non-forkable), so one level of recursion
-            // is exhaustive — no name-guessing, no stale overlays left dangling.
-            for clone in &dependent_clones {
+            // Delete the full lineage deepest-first. Every qcow2 overlay must
+            // disappear before the parent image that backs it.
+            for clone in db.dependent_descendants_postorder(name)? {
                 println!("Deleting dependent clone '{clone}' (cascade)...");
                 delete_vm(
-                    clone,
+                    &clone,
                     true, // no per-clone confirmation during a cascade
                     DeleteVmOptions {
                         stop_if_running: true,

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -796,6 +796,7 @@ pub struct ForkVmOptions<'a> {
 
 pub fn fork_vm(golden: &str, clone: &str, options: ForkVmOptions<'_>) -> smolvm::Result<()> {
     let db = SmolvmDb::open()?;
+    let _source_lock = smolvm::agent::fork::lock_fork_source(golden)?;
 
     // A live FUSE mount does not survive the freeze/restore: the restored
     // clone's mount wedges its container namespace and every exec hangs.
@@ -852,7 +853,6 @@ pub fn fork_vm(golden: &str, clone: &str, options: ForkVmOptions<'_>) -> smolvm:
     }
 
     let snapshot_dir = prep.snapshot_dir.clone();
-    let resume_golden = prep.resume_golden_on_rollback;
     if let Err(error) = boot_prepared_fork(
         &db,
         clone,
@@ -861,14 +861,14 @@ pub fn fork_vm(golden: &str, clone: &str, options: ForkVmOptions<'_>) -> smolvm:
         options.fork_env,
         None,
     ) {
-        return rollback_failed_fork(golden, &snapshot_dir, resume_golden, error);
+        return retain_failed_fork(golden, &snapshot_dir, error);
     }
     if options.wait_ready.is_some() && !options.hold {
         if let Err(error) = smolvm::agent::fork::fail_closed_on_rejuvenation(
             smolvm::agent::fork::release_forkpoint(clone),
             || teardown_fork_clone(&db, clone),
         ) {
-            return rollback_failed_fork(golden, &snapshot_dir, resume_golden, error);
+            return retain_failed_fork(golden, &snapshot_dir, error);
         }
     }
     if options.hold {
@@ -898,6 +898,7 @@ pub fn fork_vm_batch(
     hold: bool,
 ) -> smolvm::Result<()> {
     let db = SmolvmDb::open()?;
+    let _source_lock = smolvm::agent::fork::lock_fork_source(golden)?;
 
     // A live FUSE mount does not survive the freeze/restore: the restored
     // clone's mount wedges its container namespace and every exec hangs.
@@ -936,7 +937,6 @@ pub fn fork_vm_batch(
     );
     let prepared = smolvm::agent::fork::prepare_forks(&db, golden, &specs)?;
     let snapshot_dir = prepared[0].snapshot_dir.clone();
-    let resume_golden = prepared[0].resume_golden_on_rollback;
     let all_names: Vec<String> = clones.iter().map(|(name, _)| name.clone()).collect();
     let jobs: Vec<_> = prepared
         .into_iter()
@@ -1040,7 +1040,7 @@ pub fn fork_vm_batch(
         for name in &all_names {
             teardown_fork_clone(&db, name);
         }
-        return rollback_failed_fork(golden, &snapshot_dir, resume_golden, error);
+        return retain_failed_fork(golden, &snapshot_dir, error);
     }
 
     if hold {
@@ -1192,31 +1192,18 @@ fn teardown_fork_clone(db: &SmolvmDb, clone: &str) {
     let _ = std::fs::remove_dir_all(vm_data_dir(clone));
 }
 
-fn rollback_failed_fork(
+fn retain_failed_fork(
     golden: &str,
     snapshot_dir: &std::path::Path,
-    resume_golden: bool,
     error: smolvm::Error,
 ) -> smolvm::Result<()> {
-    if resume_golden {
-        if let Err(resume_error) = smolvm::agent::fork::resume_golden(golden, snapshot_dir) {
-            return Err(smolvm::Error::agent(
-                "fork rollback",
-                format!(
-                    "{error}; golden rollback failed: {resume_error}; preserved checkpoint {} for recovery",
-                    snapshot_dir.display()
-                ),
-            ));
-        }
-    }
-    let cleanup_error = std::fs::remove_dir_all(snapshot_dir).err();
-    match cleanup_error {
-        None => Err(error),
-        Some(cleanup) => Err(smolvm::Error::agent(
-            "fork rollback",
-            format!("{error}; golden rollback succeeded but snapshot cleanup failed: {cleanup}"),
-        )),
-    }
+    Err(smolvm::Error::agent(
+        "fork clone boot",
+        format!(
+            "{error}; source '{golden}' remains frozen at retained checkpoint {} so the fork can be retried safely",
+            snapshot_dir.display()
+        ),
+    ))
 }
 
 fn persist_batch_clone_running(db: &SmolvmDb, clone: &str) -> smolvm::Result<()> {
@@ -2212,8 +2199,28 @@ fn remove_vm_data_and_record(
     Ok(())
 }
 
+fn ensure_fork_base_delete_is_safe(
+    name: &str,
+    dependent_clones: &[String],
+    cascade: bool,
+) -> smolvm::Result<()> {
+    if dependent_clones.is_empty() || cascade {
+        return Ok(());
+    }
+    Err(smolvm::Error::agent(
+        "delete",
+        format!(
+            "machine '{name}' is the fork base for {} clone(s) ({}); \
+             delete the clones first or use --cascade to remove them too",
+            dependent_clones.len(),
+            dependent_clones.join(", ")
+        ),
+    ))
+}
+
 /// Delete a named machine configuration.
 pub fn delete_vm(name: &str, force: bool, options: DeleteVmOptions) -> smolvm::Result<()> {
+    let _fork_source_lock = smolvm::agent::fork::lock_fork_source(name)?;
     let config = SmolvmConfig::load()?;
 
     // Check if exists
@@ -2223,42 +2230,25 @@ pub fn delete_vm(name: &str, force: bool, options: DeleteVmOptions) -> smolvm::R
         .clone();
 
     // A golden's disks are the copy-on-write backing for its clones' overlays,
-    // so it must outlive them. Refuse to delete a golden while clones depend on
-    // it (unless forced, in which case the clones' overlays are left dangling).
+    // so it must outlive them. `--force` only suppresses confirmation; it must
+    // never bypass this storage-integrity boundary. `--cascade` is the explicit
+    // operation that removes descendants deepest-first.
     let db = SmolvmDb::open()?;
     let dependent_clones = db.dependent_clones(name)?;
-    if !dependent_clones.is_empty() {
-        if options.cascade {
-            // Delete the full lineage deepest-first. Every qcow2 overlay must
-            // disappear before the parent image that backs it.
-            for clone in db.dependent_descendants_postorder(name)? {
-                println!("Deleting dependent clone '{clone}' (cascade)...");
-                delete_vm(
-                    &clone,
-                    true, // no per-clone confirmation during a cascade
-                    DeleteVmOptions {
-                        stop_if_running: true,
-                        cascade: false,
-                    },
-                )?;
-            }
-        } else if !force {
-            return Err(smolvm::Error::agent(
-                "delete",
-                format!(
-                    "machine '{name}' is the fork base for {} clone(s) ({}); \
-                     delete the clones first, use --cascade to remove them too, \
-                     or --force to break them",
-                    dependent_clones.len(),
-                    dependent_clones.join(", ")
-                ),
-            ));
-        } else {
-            tracing::warn!(
-                golden = name,
-                clones = %dependent_clones.join(", "),
-                "force-deleting a golden; dependent clones' disk overlays will dangle"
-            );
+    ensure_fork_base_delete_is_safe(name, &dependent_clones, options.cascade)?;
+    if !dependent_clones.is_empty() && options.cascade {
+        // Delete the full lineage deepest-first. Every qcow2 overlay must
+        // disappear before the parent image that backs it.
+        for clone in db.dependent_descendants_postorder(name)? {
+            println!("Deleting dependent clone '{clone}' (cascade)...");
+            delete_vm(
+                &clone,
+                true, // no per-clone confirmation during a cascade
+                DeleteVmOptions {
+                    stop_if_running: true,
+                    cascade: false,
+                },
+            )?;
         }
     }
 
@@ -2281,18 +2271,14 @@ pub fn delete_vm(name: &str, force: bool, options: DeleteVmOptions) -> smolvm::R
             }
             RecordState::Unreachable => {
                 // Reap unconditionally: we're past the dependent-clones
-                // guard above, so either this isn't a fork base or --force
-                // was given. The guarded `cli_recover_if_unreachable` would
-                // skip a frozen fork base, orphaning its VMM after we remove
-                // the record below.
+                // guard above, so this machine has no live child dependency.
+                // The guarded `cli_recover_if_unreachable` would skip a frozen
+                // fork base, orphaning its VMM after we remove the record below.
                 smolvm::agent::state_probe::recover_unreachable_machine(&record)?;
             }
             RecordState::Frozen => {
-                // A frozen fork base only reaches here under --force (the
-                // dependent-clones guard above blocks the non-force path).
-                // Reap its paused VMM so it isn't orphaned once the record
-                // is removed; the clones' overlays are left dangling, as
-                // the force-delete warning already states.
+                // All descendants are gone (or a cascade removed them above),
+                // so reap the paused VMM before removing its record.
                 smolvm::agent::state_probe::recover_unreachable_machine(&record)?;
             }
             _ => {}
@@ -3315,6 +3301,47 @@ mod init_runner_tests {
                 ("BAZ".to_string(), "from-cli".to_string()),
             ]
         );
+    }
+}
+
+#[cfg(test)]
+mod delete_lineage_tests {
+    use super::{ensure_fork_base_delete_is_safe, retain_failed_fork};
+
+    #[test]
+    fn force_cannot_bypass_a_live_fork_dependency() {
+        // `force` deliberately is not an input to the safety gate: it controls
+        // confirmation only and cannot make a dangling qcow2 chain acceptable.
+        let children = vec!["child-a".to_string(), "child-b".to_string()];
+        let error = ensure_fork_base_delete_is_safe("root", &children, false)
+            .expect_err("a live child must protect its parent");
+        let message = error.to_string();
+        assert!(message.contains("child-a, child-b"));
+        assert!(message.contains("--cascade"));
+    }
+
+    #[test]
+    fn cascade_and_childless_deletes_pass_the_lineage_gate() {
+        let children = vec!["child".to_string()];
+        ensure_fork_base_delete_is_safe("root", &children, true).unwrap();
+        ensure_fork_base_delete_is_safe("leaf", &[], false).unwrap();
+    }
+
+    #[test]
+    fn failed_clone_boot_preserves_the_retry_checkpoint() {
+        let temp = tempfile::tempdir().unwrap();
+        let checkpoint = temp.path().join("checkpoint.bin");
+        std::fs::write(&checkpoint, b"checkpoint").unwrap();
+        let error = retain_failed_fork(
+            "root",
+            temp.path(),
+            smolvm::Error::agent("clone boot", "injected failure"),
+        )
+        .expect_err("the original boot failure must be returned");
+
+        assert!(checkpoint.exists(), "the retry checkpoint must survive");
+        assert!(error.to_string().contains("remains frozen"));
+        assert!(error.to_string().contains("retried safely"));
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -582,6 +582,13 @@ pub struct VmRecord {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub golden: Option<String>,
 
+    /// Persistent container-overlay owner inherited from the root of a fork
+    /// lineage. A clone's live overlay keeps its original on-disk name across
+    /// every generation; descendants must continue addressing that root name.
+    /// Older one-level clone records omit this and fall back to `golden`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fork_overlay_owner: Option<String>,
+
     /// Whether a fork clone is still parked at the inherited workload
     /// forkpoint. Held clones are clean, already-booted pool slots: a caller
     /// installs the job-specific fork parameters and releases each slot once.
@@ -702,6 +709,7 @@ impl VmRecord {
             ephemeral: false,
             source_smolmachine: None,
             golden: None,
+            fork_overlay_owner: None,
             forkpoint_held: false,
             fork_env: Vec::new(),
             runtime_managed: false,
@@ -768,6 +776,7 @@ impl VmRecord {
             ephemeral: false,
             source_smolmachine: None,
             golden: None,
+            fork_overlay_owner: None,
             forkpoint_held: false,
             fork_env: Vec::new(),
             runtime_managed: false,
@@ -1465,6 +1474,7 @@ mod tests {
     fn held_fork_state_roundtrips_and_legacy_records_default_released() {
         let mut record = VmRecord::new("slot-0".to_string(), 2, 1024, vec![], vec![], false);
         record.golden = Some("golden".to_string());
+        record.fork_overlay_owner = Some("root".to_string());
         record.forkpoint_held = true;
         record.fork_env = vec![("SMOLVM_FORK_INDEX".to_string(), "0".to_string())];
 
@@ -1472,14 +1482,17 @@ mod tests {
         let decoded: VmRecord = serde_json::from_value(encoded.clone()).unwrap();
         assert!(decoded.forkpoint_held);
         assert_eq!(decoded.fork_env, record.fork_env);
+        assert_eq!(decoded.fork_overlay_owner.as_deref(), Some("root"));
 
         let mut legacy_value = encoded;
         let legacy_object = legacy_value.as_object_mut().unwrap();
         legacy_object.remove("forkpoint_held");
         legacy_object.remove("fork_env");
+        legacy_object.remove("fork_overlay_owner");
         let legacy: VmRecord = serde_json::from_value(legacy_value).unwrap();
         assert!(!legacy.forkpoint_held);
         assert!(legacy.fork_env.is_empty());
+        assert!(legacy.fork_overlay_owner.is_none());
     }
 
     #[test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -17,7 +17,7 @@ use crate::pool::{
 };
 use parking_lot::{Condvar, Mutex};
 use rusqlite::{params, Connection, OptionalExtension, TransactionBehavior};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -642,6 +642,86 @@ impl SmolvmDb {
             .filter(|(_, r)| r.golden.as_deref() == Some(golden))
             .map(|(name, _)| name)
             .collect())
+    }
+
+    /// All descendants of `source`, ordered deepest-first so each machine can
+    /// be deleted before the disk backing it depends on. Rejects a corrupted
+    /// cyclic lineage instead of recursing forever or deleting an ancestor
+    /// before its child.
+    pub fn dependent_descendants_postorder(&self, source: &str) -> Result<Vec<String>> {
+        let mut children: HashMap<String, Vec<String>> = HashMap::new();
+        for (name, record) in self.list_vms()? {
+            if let Some(parent) = record.golden {
+                children.entry(parent).or_default().push(name);
+            }
+        }
+        for names in children.values_mut() {
+            names.sort();
+        }
+
+        fn visit(
+            parent: &str,
+            children: &HashMap<String, Vec<String>>,
+            visiting: &mut HashSet<String>,
+            visited: &mut HashSet<String>,
+            ordered: &mut Vec<String>,
+        ) -> Result<()> {
+            if !visiting.insert(parent.to_string()) {
+                return Err(Error::database(
+                    "resolve fork lineage",
+                    format!("cycle detected at machine '{parent}'"),
+                ));
+            }
+            if let Some(direct) = children.get(parent) {
+                for child in direct {
+                    if !visited.contains(child) {
+                        visit(child, children, visiting, visited, ordered)?;
+                        visited.insert(child.clone());
+                        ordered.push(child.clone());
+                    }
+                }
+            }
+            visiting.remove(parent);
+            Ok(())
+        }
+
+        let mut ordered = Vec::new();
+        visit(
+            source,
+            &children,
+            &mut HashSet::new(),
+            &mut HashSet::new(),
+            &mut ordered,
+        )?;
+        Ok(ordered)
+    }
+
+    /// Number of fork edges from a root machine to `name`.
+    pub fn fork_lineage_depth(&self, name: &str) -> Result<usize> {
+        let records: HashMap<String, VmRecord> = self.list_vms()?.into_iter().collect();
+        let mut current = name;
+        let mut seen = HashSet::new();
+        let mut depth = 0;
+        while let Some(parent) = records
+            .get(current)
+            .and_then(|record| record.golden.as_ref())
+        {
+            if !seen.insert(current.to_string()) {
+                return Err(Error::database(
+                    "resolve fork lineage",
+                    format!("cycle detected at machine '{current}'"),
+                ));
+            }
+            if !records.contains_key(parent) {
+                return Err(Error::database(
+                    "resolve fork lineage",
+                    format!("machine '{current}' references missing parent '{parent}'"),
+                ));
+            }
+            depth += 1;
+            current = parent;
+        }
+        Ok(depth)
     }
 
     /// Update a VM record in place using a closure.
@@ -2063,6 +2143,46 @@ mod tests {
         assert_eq!(removed.name, "test-vm");
 
         assert!(db.get_vm("test-vm").unwrap().is_none());
+    }
+
+    #[test]
+    fn fork_descendants_are_returned_deepest_first() {
+        let (_dir, db) = temp_db();
+        for (name, parent) in [
+            ("root", None),
+            ("child-b", Some("root")),
+            ("child-a", Some("root")),
+            ("grandchild", Some("child-a")),
+            ("great-grandchild", Some("grandchild")),
+        ] {
+            let mut record = VmRecord::new(name.to_string(), 1, 128, vec![], vec![], false);
+            record.golden = parent.map(str::to_string);
+            db.insert_vm(name, &record).unwrap();
+        }
+
+        assert_eq!(
+            db.dependent_descendants_postorder("root").unwrap(),
+            vec!["great-grandchild", "grandchild", "child-a", "child-b"]
+        );
+        assert_eq!(db.fork_lineage_depth("root").unwrap(), 0);
+        assert_eq!(db.fork_lineage_depth("great-grandchild").unwrap(), 3);
+    }
+
+    #[test]
+    fn fork_lineage_rejects_cycles_and_missing_parents() {
+        let (_dir, db) = temp_db();
+        for (name, parent) in [("a", "b"), ("b", "a")] {
+            let mut record = VmRecord::new(name.to_string(), 1, 128, vec![], vec![], false);
+            record.golden = Some(parent.to_string());
+            db.insert_vm(name, &record).unwrap();
+        }
+        assert!(db.dependent_descendants_postorder("a").is_err());
+        assert!(db.fork_lineage_depth("a").is_err());
+
+        let mut orphan = VmRecord::new("orphan".to_string(), 1, 128, vec![], vec![], false);
+        orphan.golden = Some("missing".to_string());
+        db.insert_vm("orphan", &orphan).unwrap();
+        assert!(db.fork_lineage_depth("orphan").is_err());
     }
 
     #[test]

--- a/src/embedded/control.rs
+++ b/src/embedded/control.rs
@@ -279,7 +279,7 @@ pub fn fork_vm(
     clone: &str,
     pinned_ports: &[(u16, u16)],
 ) -> Result<VmHandle> {
-    fork_vm_with_options(db, golden, clone, pinned_ports, false, None)
+    fork_vm_with_options(db, golden, clone, pinned_ports, false, false, None)
 }
 
 /// Fork a machine with launch options needed by non-embedded front-ends.
@@ -288,17 +288,17 @@ pub(crate) fn fork_vm_with_options(
     golden: &str,
     clone: &str,
     pinned_ports: &[(u16, u16)],
+    clone_forkable: bool,
     share_weights: bool,
     watch_parent: Option<bool>,
 ) -> Result<VmHandle> {
-    // Freeze + snapshot the golden, register the clone (CoW disks + DB record).
-    // `clone_forkable = false`: a clone can't itself be re-forked (nested fork).
+    // Freeze + snapshot the source, then register the clone and its CoW disks.
     let prep = crate::agent::fork::prepare_fork(
         db,
         golden,
         clone,
         pinned_ports,
-        false,
+        clone_forkable,
         &[],
         &std::collections::BTreeMap::new(),
     )?;
@@ -316,6 +316,7 @@ fn boot_prepared_fork(
 ) -> Result<VmHandle> {
     // Boot the clone from the golden's in-memory snapshot instead of cold-booting.
     let features = LaunchFeatures {
+        forkable: prep.clone_record.forkable,
         snapshot_dir: Some(prep.snapshot_dir.clone()),
         cuda_share_weights: share_weights,
         cuda_preload_modules: prep.clone_record.cuda_preload_modules,
@@ -561,6 +562,16 @@ pub fn stop_vm(db: &SmolvmDb, name: &str) -> Result<()> {
 
 /// Remove a VM record and its storage directory.
 pub fn delete_vm(db: &SmolvmDb, name: &str) -> Result<()> {
+    let dependents = db.dependent_clones(name)?;
+    if !dependents.is_empty() {
+        return Err(Error::agent(
+            "delete machine",
+            format!(
+                "machine '{name}' has dependent fork(s) ({}); delete descendants first",
+                dependents.join(", ")
+            ),
+        ));
+    }
     let removed = db.remove_vm(name)?;
     if removed.is_none() {
         return Err(Error::vm_not_found(name));

--- a/src/embedded/control.rs
+++ b/src/embedded/control.rs
@@ -292,6 +292,7 @@ pub(crate) fn fork_vm_with_options(
     share_weights: bool,
     watch_parent: Option<bool>,
 ) -> Result<VmHandle> {
+    let _source_lock = crate::agent::fork::lock_fork_source(golden)?;
     // Freeze + snapshot the source, then register the clone and its CoW disks.
     let prep = crate::agent::fork::prepare_fork(
         db,
@@ -400,6 +401,7 @@ pub fn fork_vm_batch(
     clones: &[(String, Vec<(u16, u16)>)],
     parallel: usize,
 ) -> Result<Vec<(String, VmHandle)>> {
+    let _source_lock = crate::agent::fork::lock_fork_source(golden)?;
     if clones.is_empty() {
         return Err(Error::config(
             "fork batch",
@@ -562,6 +564,12 @@ pub fn stop_vm(db: &SmolvmDb, name: &str) -> Result<()> {
 
 /// Remove a VM record and its storage directory.
 pub fn delete_vm(db: &SmolvmDb, name: &str) -> Result<()> {
+    let _source_lock = crate::agent::fork::lock_fork_source(name)?;
+    delete_vm_locked(db, name)
+}
+
+/// Delete with the caller already holding this machine's fork-source lock.
+pub(crate) fn delete_vm_locked(db: &SmolvmDb, name: &str) -> Result<()> {
     let dependents = db.dependent_clones(name)?;
     if !dependents.is_empty() {
         return Err(Error::agent(

--- a/src/embedded/runtime.rs
+++ b/src/embedded/runtime.rs
@@ -323,6 +323,7 @@ impl EmbeddedRuntime {
     /// Stop best-effort, remove from the registry and DB, and delete storage.
     pub fn delete_machine(&self, name: &str) -> Result<()> {
         self.with_name_lock(name, || {
+            let _source_lock = crate::agent::fork::lock_fork_source(name)?;
             let Some(record) = self.db.get_vm(name)? else {
                 self.remove_name_lock(name)?;
                 return Ok(());
@@ -361,7 +362,7 @@ impl EmbeddedRuntime {
             // Idempotent: deleting an already-deleted machine is a no-op success
             // (the desired end state — gone — already holds). Lets SDK callers
             // call delete() more than once without an error.
-            match control::delete_vm(&self.db, name) {
+            match control::delete_vm_locked(&self.db, name) {
                 Ok(()) | Err(crate::Error::VmNotFound { .. }) => {}
                 Err(e) => return Err(e),
             }
@@ -528,7 +529,7 @@ impl EmbeddedRuntime {
     /// overlay so their writes survive — matching non-streaming exec.
     fn image_and_overlay_owner(&self, name: &str) -> Result<(Option<String>, String)> {
         let record = control::get_record(&self.db, name)?;
-        let overlay_owner = crate::workload::persistent_overlay_owner(
+        let overlay_owner = crate::workload::persistent_overlay_owner_with_lineage(
             name,
             record.golden.as_deref(),
             record.fork_overlay_owner.as_deref(),

--- a/src/embedded/runtime.rs
+++ b/src/embedded/runtime.rs
@@ -190,6 +190,23 @@ impl EmbeddedRuntime {
         })
     }
 
+    /// Fork a machine and make the restored clone a new checkpoint source.
+    /// This pays one eager guest-memory copy during clone boot; later forks of
+    /// `clone` use the normal copy-on-write path.
+    pub fn fork_checkpointable_machine(
+        &self,
+        source: &str,
+        clone: &str,
+        ports: &[(u16, u16)],
+    ) -> Result<()> {
+        self.with_name_locks(&[source, clone], || {
+            let handle =
+                control::fork_vm_with_options(&self.db, source, clone, ports, true, false, None)?;
+            self.insert_handle(clone, handle)?;
+            Ok(())
+        })
+    }
+
     /// Fork several clones from one retained snapshot and boot them with
     /// bounded parallelism. All names are locked together so overlapping SDK
     /// calls cannot race the golden freeze or claim the same clone name.
@@ -242,7 +259,31 @@ impl EmbeddedRuntime {
                 golden,
                 clone,
                 ports,
+                false,
                 share_weights,
+                Some(false),
+            )?;
+            handle.detach();
+            Ok(())
+        })
+    }
+
+    /// Fork a checkpointable child for a detached CLI operation. The child
+    /// outlives this process and can become the source of another fork.
+    pub fn fork_checkpointable_machine_detached(
+        &self,
+        source: &str,
+        clone: &str,
+        ports: &[(u16, u16)],
+    ) -> Result<()> {
+        self.with_name_locks(&[source, clone], || {
+            let handle = control::fork_vm_with_options(
+                &self.db,
+                source,
+                clone,
+                ports,
+                true,
+                false,
                 Some(false),
             )?;
             handle.detach();
@@ -282,7 +323,36 @@ impl EmbeddedRuntime {
     /// Stop best-effort, remove from the registry and DB, and delete storage.
     pub fn delete_machine(&self, name: &str) -> Result<()> {
         self.with_name_lock(name, || {
-            if let Some(handle) = self.remove_cached_handle(name)? {
+            let Some(record) = self.db.get_vm(name)? else {
+                self.remove_name_lock(name)?;
+                return Ok(());
+            };
+
+            // A parent's RAM and disks back every direct child. Check before
+            // stopping it: discovering the dependency after teardown would
+            // leave live descendants dangling.
+            let dependents = self.db.dependent_clones(name)?;
+            if !dependents.is_empty() {
+                return Err(Error::agent(
+                    "delete machine",
+                    format!(
+                        "machine '{name}' has dependent fork(s) ({}); delete descendants first",
+                        dependents.join(", ")
+                    ),
+                ));
+            }
+
+            let state = crate::agent::state_probe::resolve_state(name, &record);
+            if matches!(
+                state,
+                crate::config::RecordState::Frozen | crate::config::RecordState::Unreachable
+            ) {
+                // Paused vCPUs cannot acknowledge the normal guest shutdown.
+                // Reap the verified VMM directly instead of waiting for a
+                // response that cannot arrive.
+                self.remove_cached_handle(name)?;
+                crate::agent::state_probe::recover_unreachable_machine_in_db(&record, &self.db)?;
+            } else if let Some(handle) = self.remove_cached_handle(name)? {
                 let _ = lock_handle(&handle)?.stop();
             } else {
                 let _ = control::stop_vm(&self.db, name);
@@ -458,8 +528,11 @@ impl EmbeddedRuntime {
     /// overlay so their writes survive — matching non-streaming exec.
     fn image_and_overlay_owner(&self, name: &str) -> Result<(Option<String>, String)> {
         let record = control::get_record(&self.db, name)?;
-        let overlay_owner =
-            crate::workload::persistent_overlay_owner(name, record.golden.as_deref());
+        let overlay_owner = crate::workload::persistent_overlay_owner(
+            name,
+            record.golden.as_deref(),
+            record.fork_overlay_owner.as_deref(),
+        );
         Ok((record.image, overlay_owner))
     }
 
@@ -855,5 +928,34 @@ mod tests {
             .read()
             .expect("name locks should not be poisoned")
             .contains_key("runtime-delete-lock"));
+    }
+
+    #[test]
+    fn delete_machine_refuses_a_live_fork_parent_before_teardown() {
+        let db = test_db();
+        let runtime = EmbeddedRuntime::with_db(db.clone());
+        runtime
+            .create_machine(test_spec("delete-parent", true))
+            .unwrap();
+        let mut child = test_spec("delete-child", true).to_record();
+        child.golden = Some("delete-parent".to_string());
+        db.insert_vm("delete-child", &child).unwrap();
+
+        let error = runtime.delete_machine("delete-parent").unwrap_err();
+        assert!(error.to_string().contains("dependent fork"));
+        assert!(db.get_vm("delete-parent").unwrap().is_some());
+        assert!(db.get_vm("delete-child").unwrap().is_some());
+    }
+
+    #[test]
+    fn delete_machine_reaps_a_frozen_checkpoint_without_guest_shutdown() {
+        let db = test_db();
+        let runtime = EmbeddedRuntime::with_db(db.clone());
+        let mut record = test_spec("delete-frozen", true).to_record();
+        record.state = crate::config::RecordState::Frozen;
+        db.insert_vm("delete-frozen", &record).unwrap();
+
+        runtime.delete_machine("delete-frozen").unwrap();
+        assert!(db.get_vm("delete-frozen").unwrap().is_none());
     }
 }

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -31,7 +31,14 @@ pub fn record_mounts_to_bindings(mounts: &[(String, String, bool)]) -> Vec<(Stri
 /// workload container running from it). Aliasing the lookup, instead of
 /// renaming the directory on disk, keeps that live mount valid while making
 /// the clone's execs land in the inherited state.
-pub fn persistent_overlay_owner(
+pub fn persistent_overlay_owner(name: &str, golden: Option<&str>) -> String {
+    persistent_overlay_owner_with_lineage(name, golden, None)
+}
+
+/// Resolve the persistent overlay owner for a machine whose immediate parent
+/// may itself be a fork. `fork_overlay_owner` keeps every generation pointed
+/// at the root overlay inherited by the live restored workload.
+pub fn persistent_overlay_owner_with_lineage(
     name: &str,
     golden: Option<&str>,
     fork_overlay_owner: Option<&str>,
@@ -45,8 +52,8 @@ pub fn persistent_overlay_owner(
 /// a host-side concern the caller owns. An empty entrypoint+cmd makes the
 /// agent resolve the image's own ENTRYPOINT+CMD, so service-style images
 /// start as their authors intended. The persistent overlay is keyed by
-/// [`persistent_overlay_owner`] (the machine name, or the golden's for a fork
-/// clone) so filesystem state survives restarts and forks.
+/// [`persistent_overlay_owner_with_lineage`] (the machine name, or the root
+/// golden's for a fork clone) so filesystem state survives restarts and forks.
 ///
 /// Returns `Ok(false)` (no launch) for machines without an image, and for
 /// image machines where neither the record nor the image supplies a command —
@@ -190,13 +197,13 @@ mod tests {
     // (and its still-live restored mount) instead of a fresh empty one.
     #[test]
     fn overlay_owner_aliases_fork_clones_to_their_golden() {
-        assert_eq!(persistent_overlay_owner("m1", None, None), "m1");
+        assert_eq!(persistent_overlay_owner("m1", None), "m1");
         assert_eq!(
-            persistent_overlay_owner("clone-a", Some("golden-a"), None),
+            persistent_overlay_owner("clone-a", Some("golden-a")),
             "golden-a"
         );
         assert_eq!(
-            persistent_overlay_owner("grandchild", Some("child"), Some("root")),
+            persistent_overlay_owner_with_lineage("grandchild", Some("child"), Some("root")),
             "root"
         );
     }

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -31,8 +31,12 @@ pub fn record_mounts_to_bindings(mounts: &[(String, String, bool)]) -> Vec<(Stri
 /// workload container running from it). Aliasing the lookup, instead of
 /// renaming the directory on disk, keeps that live mount valid while making
 /// the clone's execs land in the inherited state.
-pub fn persistent_overlay_owner(name: &str, golden: Option<&str>) -> String {
-    golden.unwrap_or(name).to_string()
+pub fn persistent_overlay_owner(
+    name: &str,
+    golden: Option<&str>,
+    fork_overlay_owner: Option<&str>,
+) -> String {
+    fork_overlay_owner.or(golden).unwrap_or(name).to_string()
 }
 
 /// Launch an image machine's workload container in the background.
@@ -186,10 +190,14 @@ mod tests {
     // (and its still-live restored mount) instead of a fresh empty one.
     #[test]
     fn overlay_owner_aliases_fork_clones_to_their_golden() {
-        assert_eq!(persistent_overlay_owner("m1", None), "m1");
+        assert_eq!(persistent_overlay_owner("m1", None, None), "m1");
         assert_eq!(
-            persistent_overlay_owner("clone-a", Some("golden-a")),
+            persistent_overlay_owner("clone-a", Some("golden-a"), None),
             "golden-a"
+        );
+        assert_eq!(
+            persistent_overlay_owner("grandchild", Some("child"), Some("root")),
+            "root"
         );
     }
 


### PR DESCRIPTION
Allows checkpointable descendants to become new copy-on-write fork sources with lineage-safe overlays, readiness, and cleanup after smol-machines/libkrun#67.