### PR TITLE
Preserve fork checkpoints across runtime restarts

### DIFF
--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -225,15 +225,16 @@ fn fork_base_already_paused(status: &str) -> bool {
     status.trim() == "OK paused"
 }
 
-/// Flush guest filesystems before checkpointing a restored clone again.
+/// Flush guest filesystems before capturing a new live checkpoint.
 ///
-/// A first-generation clone may have just changed its persistent container
-/// overlay during identity rejuvenation. Capturing the next generation while
-/// those writes are still in the guest page cache can restore an overlayfs
-/// mount whose first lookup blocks indefinitely. `sync` is the guest-visible
-/// durability boundary: it completes before libkrun drains the block workers
-/// and freezes the vCPUs.
-fn sync_nested_fork_source(name: &str) -> Result<()> {
+/// A branch sees dirty guest page-cache state through the RAM snapshot, but a
+/// later stop/restart of the source can only reopen its host disk images. If we
+/// freeze before `sync`, that restart silently loses writes that every live
+/// branch appeared to inherit. Restored children also need this boundary to
+/// avoid capturing an overlayfs mount whose first lookup can block. Complete
+/// the guest-visible durability boundary before libkrun drains block workers
+/// and freezes the vCPUs for every newly captured checkpoint.
+fn sync_fork_source(name: &str) -> Result<()> {
     let socket = vm_data_dir(name).join("agent.sock");
     let mut client = AgentClient::connect_with_retry(&socket)
         .map_err(|error| Error::agent("sync fork source", error.to_string()))?;
@@ -660,11 +661,9 @@ pub(crate) fn prepare_forks_reusing(
                 .map_err(|e| Error::agent("fork: chown snapshot dir", e.to_string()))?;
         }
 
-        if golden_rec.golden.is_some() {
-            if let Err(error) = sync_nested_fork_source(golden) {
-                let _ = std::fs::remove_dir_all(&snapshot_dir);
-                return Err(error);
-            }
+        if let Err(error) = sync_fork_source(golden) {
+            let _ = std::fs::remove_dir_all(&snapshot_dir);
+            return Err(error);
         }
 
         let t_snap = std::time::Instant::now();

--- a/src/api/pool_controller.rs
+++ b/src/api/pool_controller.rs
@@ -241,27 +241,28 @@ impl ForkPoolController {
             .await
             .map_err(|e| e.to_string())?
             .map_err(|e| e.to_string())?;
-        let active_goldens = pools
-            .iter()
-            .filter(|pool| !pool.deleting)
-            .map(|pool| pool.golden.as_str())
+        // Retained checkpoints are shared by automatic pools and the plain
+        // machine fork API.  A checkpoint stays valid for as long as its
+        // source VM record exists; limiting this set to active pool goldens
+        // discarded ordinary fork checkpoints on the first serve restart.
+        let db = self.state.db().clone();
+        let checkpoint_sources = tokio::task::spawn_blocking(move || db.list_vms())
+            .await
+            .map_err(|e| e.to_string())?
+            .map_err(|e| e.to_string())?
+            .into_iter()
+            .map(|(name, _)| name)
             .collect::<std::collections::HashSet<_>>();
         let stale_snapshots = {
             let mut snapshots = self.retained_snapshots.lock();
-            let stale = snapshots
-                .keys()
-                .filter(|golden| !active_goldens.contains(golden.as_str()))
-                .cloned()
-                .collect::<Vec<_>>();
-            snapshots.retain(|golden, _| active_goldens.contains(golden.as_str()));
-            stale
+            retain_existing_checkpoint_sources(&mut snapshots, &checkpoint_sources)
         };
         if !stale_snapshots.is_empty() {
             let db = self.state.db().clone();
             match tokio::task::spawn_blocking(move || {
                 for golden in stale_snapshots {
                     if let Err(error) = db.remove_retained_fork_snapshot(&golden) {
-                        tracing::warn!(%golden, %error, "failed to remove inactive fork pool checkpoint");
+                        tracing::warn!(%golden, %error, "failed to remove orphan retained fork checkpoint");
                     }
                 }
             })
@@ -269,7 +270,7 @@ impl ForkPoolController {
             {
                 Ok(()) => {}
                 Err(error) => {
-                    tracing::warn!(%error, "inactive fork pool checkpoint cleanup task failed");
+                    tracing::warn!(%error, "orphan retained fork checkpoint cleanup task failed");
                 }
             }
         }
@@ -688,6 +689,19 @@ fn update_retained_snapshot(
     }
 }
 
+fn retain_existing_checkpoint_sources(
+    snapshots: &mut std::collections::HashMap<String, crate::agent::fork::RetainedForkSnapshot>,
+    checkpoint_sources: &std::collections::HashSet<String>,
+) -> Vec<String> {
+    let stale = snapshots
+        .keys()
+        .filter(|golden| !checkpoint_sources.contains(golden.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+    snapshots.retain(|golden, _| checkpoint_sources.contains(golden.as_str()));
+    stale
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -720,6 +734,29 @@ mod tests {
         snapshots.insert("golden".into(), newer.clone());
         update_retained_snapshot(&mut snapshots, "golden", Some(&prior), None);
         assert_eq!(snapshots.get("golden"), Some(&newer));
+    }
+
+    #[test]
+    fn reconciliation_keeps_plain_machine_checkpoints_without_a_pool() {
+        let plain = snapshot("12345678", 1);
+        let pooled = snapshot("abcdef01", 2);
+        let orphan = snapshot("deadbeef", 3);
+        let mut snapshots = std::collections::HashMap::from([
+            ("plain-machine".into(), plain.clone()),
+            ("pool-golden".into(), pooled.clone()),
+            ("removed-machine".into(), orphan),
+        ]);
+        let checkpoint_sources = std::collections::HashSet::from([
+            "plain-machine".to_string(),
+            "pool-golden".to_string(),
+        ]);
+
+        let mut stale = retain_existing_checkpoint_sources(&mut snapshots, &checkpoint_sources);
+        stale.sort();
+
+        assert_eq!(stale, vec!["removed-machine"]);
+        assert_eq!(snapshots.get("plain-machine"), Some(&plain));
+        assert_eq!(snapshots.get("pool-golden"), Some(&pooled));
     }
 
     #[test]

--- a/src/embedded/runtime.rs
+++ b/src/embedded/runtime.rs
@@ -310,6 +310,17 @@ impl EmbeddedRuntime {
     /// Stop a machine and persist stopped state.
     pub fn stop_machine(&self, name: &str) -> Result<()> {
         self.with_name_lock(name, || {
+            let _source_lock = crate::agent::fork::lock_fork_source(name)?;
+            let dependents = self.db.dependent_clones(name)?;
+            if !dependents.is_empty() {
+                return Err(Error::agent(
+                    "stop machine",
+                    format!(
+                        "machine '{name}' has dependent fork(s) ({}); delete descendants first",
+                        dependents.join(", ")
+                    ),
+                ));
+            }
             if let Some(handle) = self.remove_cached_handle(name)? {
                 lock_handle(&handle)?.stop()?;
                 control::mark_stopped(&self.db, name)?;
@@ -946,6 +957,23 @@ mod tests {
         assert!(error.to_string().contains("dependent fork"));
         assert!(db.get_vm("delete-parent").unwrap().is_some());
         assert!(db.get_vm("delete-child").unwrap().is_some());
+    }
+
+    #[test]
+    fn stop_machine_refuses_a_live_fork_parent_before_teardown() {
+        let db = test_db();
+        let runtime = EmbeddedRuntime::with_db(db.clone());
+        runtime
+            .create_machine(test_spec("stop-parent", true))
+            .unwrap();
+        let mut child = test_spec("stop-child", true).to_record();
+        child.golden = Some("stop-parent".to_string());
+        db.insert_vm("stop-child", &child).unwrap();
+
+        let error = runtime.stop_machine("stop-parent").unwrap_err();
+        assert!(error.to_string().contains("dependent fork"));
+        assert!(db.get_vm("stop-parent").unwrap().is_some());
+        assert!(db.get_vm("stop-child").unwrap().is_some());
     }
 
     #[test]


### PR DESCRIPTION
Keeps plain machine checkpoints through serve restarts and flushes guest filesystems before checkpoint capture.