### PR TITLE
Support one-to-one port ranges in Smolfiles and CLI mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ net = true
 cpus = 4
 memory = 4096
 
-ports = ["8000:8000"]
+ports = ["8000:8000", "5173-5180:5173-5180"]
 volumes = ["./src:/app"]
 init = ["pip install -r /app/requirements.txt"]
 
@@ -72,6 +72,8 @@ ssh_agent = true
 smolvm machine create --name myvm -s Smolfile   # or --smolfile <PATH>
 smolvm machine start --name myvm
 ```
+
+Port mappings accept a single port (`"8080"`), an explicit mapping (`"8080:80"`), or equal-length one-to-one ranges (`"5173-5180:5173-5180"`). A machine can publish at most 64 concrete mappings.
 
 Unknown keys are rejected rather than ignored, so a typo fails at create time
 instead of silently doing nothing.

--- a/crates/smolvm-network/src/tcp_listeners.rs
+++ b/crates/smolvm-network/src/tcp_listeners.rs
@@ -65,6 +65,10 @@ pub struct TcpPortListeners {
 
 impl TcpPortListeners {
     /// Start one non-blocking listener thread per published port.
+    ///
+    /// The CLI caps published mappings because every mapping creates this thread
+    /// and normally a second IPv6 thread. Raise that cap only after replacing
+    /// this per-listener model with multiplexed listeners or a bounded worker pool.
     pub fn start(
         port_mappings: &[PortMapping],
         tcp_sender: SyncSender<AcceptedTcpConnection>,

--- a/crates/smolvm-smolfile/src/lib.rs
+++ b/crates/smolvm-smolfile/src/lib.rs
@@ -26,7 +26,7 @@
 //! | `auto_graph` | bool | No | Best-effort framework CUDA graphs; implies `cuda`. |
 //! | `storage` | int | No | Storage disk size in GiB. |
 //! | `overlay` | int | No | Overlay disk size in GiB. |
-//! | `ports` | string[] | No | Port mappings (`"host:guest"`). Prefer `[dev] ports`. |
+//! | `ports` | string[] | No | Port mappings (`"host:guest"` or equal-length `"host-start-host-end:guest-start-guest-end"` ranges). Prefer `[dev] ports`. |
 //! | `volumes` | string[] | No | Volume mounts (`"host:guest"`). Prefer `[dev] volumes`. |
 //! | `init` | string[] | No | Commands run on every VM start. Prefer `[dev] init`. |
 //!
@@ -42,7 +42,7 @@
 //! | `env` | string[] | Dev-only environment variables |
 //! | `init` | string[] | Bootstrap commands run on start |
 //! | `workdir` | string | Dev working directory override |
-//! | `ports` | string[] | Port mappings for development |
+//! | `ports` | string[] | Port mappings or equal-length one-to-one ranges for development |
 //!
 //! ### `[artifact]` — Pack/distribution overrides
 //!

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -18,7 +18,7 @@ use crate::cli::vm_common::{self, DeleteVmOptions};
 use clap::{Args, Subcommand};
 use sha2::{Digest, Sha256};
 use smolvm::agent::{docker_config_mount, AgentClient, AgentManager, RunConfig, VmResources};
-use smolvm::data::network::PortMapping;
+use smolvm::data::network::{PortMapping, PortMappingSpec, MAX_PORT_MAPPINGS};
 use smolvm::data::resources::{DEFAULT_MICROVM_CPU_COUNT, DEFAULT_MICROVM_MEMORY_MIB};
 use smolvm::data::storage::HostMount;
 use smolvm::network::{validate_requested_network_backend, NetworkBackend};
@@ -530,8 +530,8 @@ pub struct RunCmd {
     pub volume: Vec<String>,
 
     /// Expose port from container to host (can be used multiple times)
-    #[arg(short = 'p', long = "port", value_parser = PortMapping::parse, value_name = "HOST:GUEST", help_heading = "Network")]
-    pub port: Vec<PortMapping>,
+    #[arg(short = 'p', long = "port", value_parser = PortMappingSpec::parse, value_name = "HOST:GUEST", help_heading = "Network")]
+    pub port: Vec<PortMappingSpec>,
 
     /// Enable outbound network access
     #[arg(long, help_heading = "Network")]
@@ -1066,6 +1066,8 @@ impl RunCmd {
         // flags pass through. Flags the sidecar runner can't honor are rejected
         // at parse time via `conflicts_with_all` on `from`.
         if let Some(from) = self.from {
+            let port = PortMappingSpec::expand_all(&self.port)
+                .map_err(|e| smolvm::Error::config("machine run ports", e))?;
             let mut env = self.env;
             if self.auto_graph {
                 smolvm::util::enable_cuda_auto_graph_env_specs(&mut env);
@@ -1079,7 +1081,7 @@ impl RunCmd {
                 workdir: self.workdir,
                 env,
                 volume: self.volume,
-                port: self.port,
+                port: port.into_iter().map(PortMappingSpec::from).collect(),
                 net: self.net,
                 net_backend: self.net_backend,
                 cpus: (self.cpus != DEFAULT_MICROVM_CPU_COUNT).then_some(self.cpus),
@@ -1215,7 +1217,12 @@ impl RunCmd {
                     workdir: params.workdir.clone(),
                     env: params.env.clone(),
                     volume: params.volume.clone(),
-                    port: params.port.clone(),
+                    port: params
+                        .port
+                        .iter()
+                        .copied()
+                        .map(PortMappingSpec::from)
+                        .collect(),
                     net: params.net,
                     net_backend: params.network_backend,
                     cpus: (params.cpus != DEFAULT_MICROVM_CPU_COUNT).then_some(params.cpus),
@@ -1326,7 +1333,12 @@ impl RunCmd {
                 workdir: params.workdir.clone(),
                 env: params.env.clone(),
                 volume: params.volume.clone(),
-                port: params.port.clone(),
+                port: params
+                    .port
+                    .iter()
+                    .copied()
+                    .map(PortMappingSpec::from)
+                    .collect(),
                 net: params.net,
                 net_backend: params.network_backend,
                 cpus: (params.cpus != DEFAULT_MICROVM_CPU_COUNT).then_some(params.cpus),
@@ -2297,6 +2309,30 @@ mod tests {
     }
 
     #[test]
+    fn create_accepts_port_ranges() {
+        let cli = TestMachineCli::parse_from([
+            "machine",
+            "create",
+            "--name",
+            "range-test",
+            "--port",
+            "5173-5175:6173-6175",
+        ]);
+        let MachineCmd::Create(cmd) = cli.command else {
+            panic!("expected machine create command");
+        };
+
+        assert_eq!(
+            PortMappingSpec::expand_all(&cmd.port).unwrap(),
+            vec![
+                PortMapping::new(5173, 6173),
+                PortMapping::new(5174, 6174),
+                PortMapping::new(5175, 6175),
+            ]
+        );
+    }
+
+    #[test]
     fn run_detach_accepts_name_flag() {
         let cli = TestMachineCli::parse_from([
             "machine", "run", "-d", "--name", "foo", "--image", "alpine",
@@ -3024,8 +3060,8 @@ pub struct CreateCmd {
     pub volume: Vec<String>,
 
     /// Expose port from VM to host (can be used multiple times)
-    #[arg(short = 'p', long = "port", value_parser = PortMapping::parse, value_name = "HOST:GUEST")]
-    pub port: Vec<PortMapping>,
+    #[arg(short = 'p', long = "port", value_parser = PortMappingSpec::parse, value_name = "HOST:GUEST")]
+    pub port: Vec<PortMappingSpec>,
 
     /// Enable outbound network access
     #[arg(long)]
@@ -3421,6 +3457,8 @@ impl CreateCmd {
             )?;
         }
 
+        let ports = PortMappingSpec::expand_all(&self.port)
+            .map_err(|e| smolvm::Error::config("create from .smolmachine ports", e))?;
         let params = vm_common::CreateVmParams {
             secret_refs: manifest.secret_refs,
             name,
@@ -3449,7 +3487,7 @@ impl CreateCmd {
             cpus,
             mem,
             volume: self.volume.clone(),
-            port: self.port.clone(),
+            port: ports,
             net: network,
             network_backend: self.net_backend,
             dns: self.dns,
@@ -3761,8 +3799,8 @@ pub struct ForkCmd {
 
     /// Pin the clone's inbound port forwards (repeatable). Without this, the
     /// golden's forwards are remapped to freshly-allocated host ports.
-    #[arg(short = 'p', long = "port", value_parser = PortMapping::parse, value_name = "HOST:GUEST", help_heading = "Network")]
-    pub port: Vec<PortMapping>,
+    #[arg(short = 'p', long = "port", value_parser = PortMappingSpec::parse, value_name = "HOST:GUEST", help_heading = "Network")]
+    pub port: Vec<PortMappingSpec>,
 
     /// Share the golden's loaded CUDA weights with this clone instead of
     /// copying them — sibling clones then keep ONE copy of the base model in
@@ -3804,7 +3842,11 @@ pub struct ForkCmd {
 
 impl ForkCmd {
     pub fn run(self) -> smolvm::Result<()> {
-        let ports: Vec<(u16, u16)> = self.port.iter().map(|p| (p.host, p.guest)).collect();
+        let ports: Vec<(u16, u16)> = PortMappingSpec::expand_all(&self.port)
+            .map_err(|e| smolvm::Error::config("fork ports", e))?
+            .into_iter()
+            .map(|port| port.to_tuple())
+            .collect();
         // Parse per-fork secret refs (TrustedLocal — host env/absolute file);
         // they merge into the clone's secret_refs and resolve fresh per exec.
         let fork_secrets = parse_cli_secret_refs(&self.secret_env, &self.secret_file)?;
@@ -4253,12 +4295,12 @@ pub struct UpdateCmd {
     pub remove_volume: Vec<String>,
 
     /// Add port mapping (HOST:GUEST)
-    #[arg(short = 'p', long = "port", value_parser = PortMapping::parse, value_name = "HOST:GUEST")]
-    pub port: Vec<PortMapping>,
+    #[arg(short = 'p', long = "port", value_parser = PortMappingSpec::parse, value_name = "HOST:GUEST")]
+    pub port: Vec<PortMappingSpec>,
 
     /// Remove port mapping (HOST:GUEST)
-    #[arg(long, value_parser = PortMapping::parse, value_name = "HOST:GUEST")]
-    pub remove_port: Vec<PortMapping>,
+    #[arg(long, value_parser = PortMappingSpec::parse, value_name = "HOST:GUEST")]
+    pub remove_port: Vec<PortMappingSpec>,
 
     /// Set vCPU count
     #[arg(long, value_name = "N")]
@@ -4361,27 +4403,35 @@ impl UpdateCmd {
         // Parse and validate new mounts (after state check so
         // "machine is running" takes priority over "directory not found")
         let new_mounts = HostMount::parse(&self.volume)?;
+        let add_ports = PortMappingSpec::expand_all(&self.port)
+            .map_err(|e| smolvm::Error::config("update ports", e))?;
+        let remove_ports = PortMappingSpec::expand_all(&self.remove_port)
+            .map_err(|e| smolvm::Error::config("update remove ports", e))?;
 
         // Validate no duplicate host ports after proposed changes
         {
             let mut final_ports: Vec<PortMapping> = record
                 .ports
                 .iter()
-                .filter(|&&(h, g)| {
-                    !self
-                        .remove_port
-                        .iter()
-                        .any(|rm| rm.host == h && rm.guest == g)
-                })
+                .filter(|&&(h, g)| !remove_ports.iter().any(|rm| rm.host == h && rm.guest == g))
                 .map(|&(h, g)| PortMapping::new(h, g))
                 .collect();
-            for p in &self.port {
+            for p in &add_ports {
                 if !final_ports
                     .iter()
                     .any(|existing| existing.host == p.host && existing.guest == p.guest)
                 {
                     final_ports.push(*p);
                 }
+            }
+            if final_ports.len() > MAX_PORT_MAPPINGS {
+                return Err(smolvm::Error::config(
+                    "update",
+                    format!(
+                        "port mappings expand to {} entries; the maximum per machine is {MAX_PORT_MAPPINGS}",
+                        final_ports.len()
+                    ),
+                ));
             }
             PortMapping::check_duplicates(&final_ports)
                 .map_err(|e| smolvm::Error::config("update", e))?;
@@ -4485,14 +4535,14 @@ impl UpdateCmd {
             }
 
             // Ports: add new, remove specified
-            for rm in &self.remove_port {
+            for rm in &remove_ports {
                 let before = r.ports.len();
                 r.ports.retain(|&(h, g)| h != rm.host || g != rm.guest);
                 if r.ports.len() < before {
                     changes.push(format!("  removed port: {}:{}", rm.host, rm.guest));
                 }
             }
-            for p in &self.port {
+            for p in &add_ports {
                 let tuple = p.to_tuple();
                 if !r.ports.contains(&tuple) {
                     changes.push(format!("  added port: {}:{}", tuple.0, tuple.1));

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -529,8 +529,8 @@ pub struct RunCmd {
     )]
     pub volume: Vec<String>,
 
-    /// Expose port from container to host (can be used multiple times)
-    #[arg(short = 'p', long = "port", value_parser = PortMappingSpec::parse, value_name = "HOST:GUEST", help_heading = "Network")]
+    /// Expose port from container to host (single port or one-to-one range, repeatable)
+    #[arg(short = 'p', long = "port", value_parser = PortMappingSpec::parse, value_name = "PORT[-END]|HOST[-END]:GUEST[-END]", help_heading = "Network")]
     pub port: Vec<PortMappingSpec>,
 
     /// Enable outbound network access
@@ -3059,8 +3059,8 @@ pub struct CreateCmd {
     #[arg(short = 'v', long = "volume", value_name = "HOST|REMOTE:GUEST[:ro]")]
     pub volume: Vec<String>,
 
-    /// Expose port from VM to host (can be used multiple times)
-    #[arg(short = 'p', long = "port", value_parser = PortMappingSpec::parse, value_name = "HOST:GUEST")]
+    /// Expose port from VM to host (single port or one-to-one range, repeatable)
+    #[arg(short = 'p', long = "port", value_parser = PortMappingSpec::parse, value_name = "PORT[-END]|HOST[-END]:GUEST[-END]")]
     pub port: Vec<PortMappingSpec>,
 
     /// Enable outbound network access
@@ -3797,9 +3797,9 @@ pub struct ForkCmd {
     #[arg(long, visible_alias = "checkpointable")]
     pub forkable: bool,
 
-    /// Pin the clone's inbound port forwards (repeatable). Without this, the
-    /// golden's forwards are remapped to freshly-allocated host ports.
-    #[arg(short = 'p', long = "port", value_parser = PortMappingSpec::parse, value_name = "HOST:GUEST", help_heading = "Network")]
+    /// Pin the clone's inbound port forwards (single port or one-to-one range, repeatable).
+    /// Without this, the golden's forwards are remapped to freshly-allocated host ports.
+    #[arg(short = 'p', long = "port", value_parser = PortMappingSpec::parse, value_name = "PORT[-END]|HOST[-END]:GUEST[-END]", help_heading = "Network")]
     pub port: Vec<PortMappingSpec>,
 
     /// Share the golden's loaded CUDA weights with this clone instead of
@@ -4294,12 +4294,12 @@ pub struct UpdateCmd {
     #[arg(long, value_name = "HOST:GUEST")]
     pub remove_volume: Vec<String>,
 
-    /// Add port mapping (HOST:GUEST)
-    #[arg(short = 'p', long = "port", value_parser = PortMappingSpec::parse, value_name = "HOST:GUEST")]
+    /// Add port mapping or one-to-one range
+    #[arg(short = 'p', long = "port", value_parser = PortMappingSpec::parse, value_name = "PORT[-END]|HOST[-END]:GUEST[-END]")]
     pub port: Vec<PortMappingSpec>,
 
-    /// Remove port mapping (HOST:GUEST)
-    #[arg(long, value_parser = PortMappingSpec::parse, value_name = "HOST:GUEST")]
+    /// Remove port mapping or one-to-one range
+    #[arg(long, value_parser = PortMappingSpec::parse, value_name = "PORT[-END]|HOST[-END]:GUEST[-END]")]
     pub remove_port: Vec<PortMappingSpec>,
 
     /// Set vCPU count

--- a/src/cli/pack_run.rs
+++ b/src/cli/pack_run.rs
@@ -1215,8 +1215,8 @@ struct PackedRunArgs {
     #[arg(short = 'v', long = "volume", value_name = "HOST:GUEST[:ro]")]
     volume: Vec<String>,
 
-    /// Expose port from container to host
-    #[arg(short = 'p', long = "port", value_parser = PortMappingSpec::parse, value_name = "HOST:GUEST")]
+    /// Expose port from container to host (single port or one-to-one range)
+    #[arg(short = 'p', long = "port", value_parser = PortMappingSpec::parse, value_name = "PORT[-END]|HOST[-END]:GUEST[-END]")]
     port: Vec<PortMappingSpec>,
 
     /// Enable outbound network access
@@ -1272,8 +1272,8 @@ struct PackedStartArgs {
     #[arg(short = 'v', long = "volume", value_name = "HOST:GUEST[:ro]")]
     volume: Vec<String>,
 
-    /// Expose port from container to host
-    #[arg(short = 'p', long = "port", value_parser = PortMappingSpec::parse, value_name = "HOST:GUEST")]
+    /// Expose port from container to host (single port or one-to-one range)
+    #[arg(short = 'p', long = "port", value_parser = PortMappingSpec::parse, value_name = "PORT[-END]|HOST[-END]:GUEST[-END]")]
     port: Vec<PortMappingSpec>,
 
     /// Enable outbound network access

--- a/src/cli/pack_run.rs
+++ b/src/cli/pack_run.rs
@@ -14,7 +14,7 @@ use smolvm::agent::launcher_dynamic::{
     launch_agent_vm_dynamic, KrunFunctions, PackedLaunchConfig, PackedMount,
 };
 use smolvm::agent::{AgentClient, RunConfig, VmResources};
-use smolvm::data::network::PortMapping;
+use smolvm::data::network::{PortMapping, PortMappingSpec};
 use smolvm::data::storage::HostMount;
 use smolvm::network::{validate_requested_network_backend, NetworkBackend};
 use smolvm::platform::Platform;
@@ -221,11 +221,11 @@ pub struct PackRunCmd {
     #[arg(
         short = 'p',
         long = "port",
-        value_parser = PortMapping::parse,
+        value_parser = PortMappingSpec::parse,
         value_name = "HOST:GUEST",
         help_heading = "Network"
     )]
-    pub port: Vec<PortMapping>,
+    pub port: Vec<PortMappingSpec>,
 
     /// Enable outbound network access
     #[arg(long, help_heading = "Network")]
@@ -479,7 +479,9 @@ impl PackRunCmd {
 
         // 8. Parse CLI args
         let mounts = HostMount::parse(&self.volume)?;
-        let port_mappings = PortMapping::to_tuples(&self.port);
+        let ports = PortMappingSpec::expand_all(&self.port)
+            .map_err(|e| Error::config("pack run ports", e))?;
+        let port_mappings = PortMapping::to_tuples(&ports);
 
         let resources = VmResources {
             cpus: self.cpus.unwrap_or(manifest.cpus),
@@ -488,7 +490,7 @@ impl PackRunCmd {
                 self.egress.as_ref(),
                 self.net,
                 manifest.network,
-                !self.port.is_empty(),
+                !ports.is_empty(),
             ),
             network_backend: self.net_backend,
             dns: None,
@@ -509,7 +511,7 @@ impl PackRunCmd {
             self.egress
                 .as_ref()
                 .and_then(|policy| policy.dns_filter_hosts.as_deref()),
-            self.port.len(),
+            ports.len(),
         )?;
 
         // Build packed mounts for the launcher
@@ -615,7 +617,7 @@ impl PackRunCmd {
                     .overlay
                     .unwrap_or(smolvm::storage::DEFAULT_OVERLAY_SIZE_GIB),
                 mounts: mounts.clone(),
-                ports: self.port.clone(),
+                ports: ports.clone(),
                 resources: resources.clone(),
                 ssh_agent_socket: None,
                 cuda: false,
@@ -1214,8 +1216,8 @@ struct PackedRunArgs {
     volume: Vec<String>,
 
     /// Expose port from container to host
-    #[arg(short = 'p', long = "port", value_parser = PortMapping::parse, value_name = "HOST:GUEST")]
-    port: Vec<PortMapping>,
+    #[arg(short = 'p', long = "port", value_parser = PortMappingSpec::parse, value_name = "HOST:GUEST")]
+    port: Vec<PortMappingSpec>,
 
     /// Enable outbound network access
     #[arg(long)]
@@ -1271,8 +1273,8 @@ struct PackedStartArgs {
     volume: Vec<String>,
 
     /// Expose port from container to host
-    #[arg(short = 'p', long = "port", value_parser = PortMapping::parse, value_name = "HOST:GUEST")]
-    port: Vec<PortMapping>,
+    #[arg(short = 'p', long = "port", value_parser = PortMappingSpec::parse, value_name = "HOST:GUEST")]
+    port: Vec<PortMappingSpec>,
 
     /// Enable outbound network access
     #[arg(long)]
@@ -1555,11 +1557,13 @@ fn run_from_cache(
     )?;
 
     let mounts = HostMount::parse(&args.volume)?;
-    let port_mappings = PortMapping::to_tuples(&args.port);
+    let ports = PortMappingSpec::expand_all(&args.port)
+        .map_err(|e| Error::config("packed run ports", e))?;
+    let port_mappings = PortMapping::to_tuples(&ports);
     let resources = VmResources {
         cpus: args.cpus.unwrap_or(manifest.cpus),
         memory_mib: args.mem.unwrap_or(manifest.mem),
-        network: args.net || manifest.network || !args.port.is_empty(),
+        network: args.net || manifest.network || !ports.is_empty(),
         network_backend: args.net_backend,
         dns: None,
         network_name: None,
@@ -1571,7 +1575,7 @@ fn run_from_cache(
         rosetta: false,
         allowed_cidrs: None,
     };
-    validate_requested_network_backend(&resources, None, args.port.len())?;
+    validate_requested_network_backend(&resources, None, ports.len())?;
 
     let packed_mounts = mounts_to_packed(&mounts);
 
@@ -1641,7 +1645,7 @@ fn run_from_cache(
                 .overlay
                 .unwrap_or(smolvm::storage::DEFAULT_OVERLAY_SIZE_GIB),
             mounts: mounts.clone(),
-            ports: args.port.clone(),
+            ports: ports.clone(),
             resources: resources.clone(),
             ssh_agent_socket: None,
             cuda: false,
@@ -1968,11 +1972,13 @@ fn daemon_start(
 
     // Parse CLI args
     let mounts = HostMount::parse(&args.volume)?;
-    let port_mappings = PortMapping::to_tuples(&args.port);
+    let ports = PortMappingSpec::expand_all(&args.port)
+        .map_err(|e| Error::config("packed start ports", e))?;
+    let port_mappings = PortMapping::to_tuples(&ports);
     let resources = VmResources {
         cpus: args.cpus.unwrap_or(manifest.cpus),
         memory_mib: args.mem.unwrap_or(manifest.mem),
-        network: args.net || manifest.network || !args.port.is_empty(),
+        network: args.net || manifest.network || !ports.is_empty(),
         network_backend: args.net_backend,
         dns: None,
         network_name: None,
@@ -1984,7 +1990,7 @@ fn daemon_start(
         rosetta: false,
         allowed_cidrs: None,
     };
-    validate_requested_network_backend(&resources, None, args.port.len())?;
+    validate_requested_network_backend(&resources, None, ports.len())?;
 
     let packed_mounts = mounts_to_packed(&mounts);
 

--- a/src/cli/smolfile.rs
+++ b/src/cli/smolfile.rs
@@ -6,7 +6,7 @@
 
 use crate::cli::parsers::parse_cidr;
 use crate::cli::vm_common::CreateVmParams;
-use smolvm::data::network::PortMapping;
+use smolvm::data::network::PortMappingSpec;
 use smolvm::data::resources::{DEFAULT_MICROVM_CPU_COUNT, DEFAULT_MICROVM_MEMORY_MIB};
 use smolvm::network::NetworkBackend;
 use std::path::PathBuf;
@@ -39,7 +39,7 @@ pub fn build_create_params(
     cli_cpus: u8,
     cli_mem: u32,
     cli_volume: Vec<String>,
-    cli_port: Vec<PortMapping>,
+    cli_port: Vec<PortMappingSpec>,
     cli_net: bool,
     cli_network_backend: Option<NetworkBackend>,
     cli_dns: Option<std::net::Ipv4Addr>,
@@ -61,6 +61,8 @@ pub fn build_create_params(
     let sf = match smolfile_path {
         Some(path) => load(&path)?,
         None => {
+            let ports = PortMappingSpec::expand_all(&cli_port)
+                .map_err(|e| smolvm::Error::config("CLI ports", e))?;
             let net = cli_net
                 || !cli_allow_cidr.is_empty()
                 || cli_dns.is_some()
@@ -75,7 +77,7 @@ pub fn build_create_params(
                 cpus: cli_cpus,
                 mem: cli_mem,
                 volume: cli_volume,
-                port: cli_port,
+                port: ports,
                 net,
                 network_backend: cli_network_backend,
                 dns: cli_dns,
@@ -160,12 +162,14 @@ pub fn build_create_params(
     } else {
         sf.ports
     };
-    let mut ports: Vec<PortMapping> = sf_ports
+    let mut port_specs: Vec<PortMappingSpec> = sf_ports
         .iter()
-        .map(|s| PortMapping::parse(s))
-        .collect::<Result<Vec<_>, _>>()
+        .map(|s| PortMappingSpec::parse(s))
+        .collect::<Result<_, _>>()
         .map_err(|e| smolvm::Error::config("smolfile ports", e))?;
-    ports.extend(cli_port);
+    port_specs.extend(cli_port);
+    let ports = PortMappingSpec::expand_all(&port_specs)
+        .map_err(|e| smolvm::Error::config("smolfile ports", e))?;
 
     // Volumes: [dev].volumes > top-level volumes, then CLI extends
     let sf_volumes = if !dev.volumes.is_empty() {
@@ -489,6 +493,7 @@ pub fn resolve_pack_config(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use smolvm::data::network::PortMapping;
 
     fn build_from_smolfile(path: PathBuf) -> smolvm::Result<CreateVmParams> {
         build_create_params(
@@ -513,6 +518,24 @@ mod tests {
             vec![],
             Default::default(),
         )
+    }
+
+    #[test]
+    fn smolfile_port_ranges_expand_before_create() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("Smolfile");
+        std::fs::write(&path, "[dev]\nports = [\"5173-5175:6173-6175\"]\n").unwrap();
+
+        let params = build_from_smolfile(path).unwrap();
+
+        assert_eq!(
+            params.port,
+            vec![
+                PortMapping::new(5173, 6173),
+                PortMapping::new(5174, 6174),
+                PortMapping::new(5175, 6175),
+            ]
+        );
     }
 
     #[test]

--- a/src/data/network.rs
+++ b/src/data/network.rs
@@ -157,14 +157,6 @@ impl PortMappingSpec {
         Ok(Self { host, guest })
     }
 
-    /// Expand this specification into its concrete host-to-guest mappings.
-    pub fn expand(self) -> Vec<PortMapping> {
-        (self.host.start..=self.host.end)
-            .zip(self.guest.start..=self.guest.end)
-            .map(|(host, guest)| PortMapping::new(host, guest))
-            .collect()
-    }
-
     /// Expand all user-supplied specs while enforcing the per-machine mapping cap.
     pub fn expand_all(specs: &[Self]) -> Result<Vec<PortMapping>, String> {
         let count = specs.iter().map(|spec| spec.host.len() as usize).sum();
@@ -176,7 +168,11 @@ impl PortMappingSpec {
 
         let mut ports = Vec::with_capacity(count);
         for spec in specs {
-            ports.extend(spec.expand());
+            ports.extend(
+                (spec.host.start..=spec.host.end)
+                    .zip(spec.guest.start..=spec.guest.end)
+                    .map(|(host, guest)| PortMapping::new(host, guest)),
+            );
         }
         Ok(ports)
     }
@@ -376,9 +372,8 @@ mod tests {
 
     #[test]
     fn port_mapping_spec_expands_equal_length_ranges() {
-        let ports = PortMappingSpec::parse("5173-5175:6173-6175")
-            .unwrap()
-            .expand();
+        let spec = PortMappingSpec::parse("5173-5175:6173-6175").unwrap();
+        let ports = PortMappingSpec::expand_all(&[spec]).unwrap();
 
         assert_eq!(
             ports,
@@ -391,10 +386,22 @@ mod tests {
     }
 
     #[test]
-    fn port_mapping_spec_rejects_invalid_ranges() {
+    fn port_mapping_spec_rejects_mismatched_range_lengths() {
         assert!(PortMappingSpec::parse("5173-5175:6173-6174").is_err());
+    }
+
+    #[test]
+    fn port_mapping_spec_rejects_descending_ranges() {
         assert!(PortMappingSpec::parse("5175-5173").is_err());
+    }
+
+    #[test]
+    fn port_mapping_spec_rejects_zero_in_ranges() {
         assert!(PortMappingSpec::parse("0-1").is_err());
+    }
+
+    #[test]
+    fn port_mapping_spec_rejects_malformed_ranges() {
         assert!(PortMappingSpec::parse("5173--5175").is_err());
     }
 

--- a/src/data/network.rs
+++ b/src/data/network.rs
@@ -158,11 +158,11 @@ impl PortMappingSpec {
     }
 
     /// Expand this specification into its concrete host-to-guest mappings.
-    pub fn expand(self) -> Result<Vec<PortMapping>, String> {
-        Ok((self.host.start..=self.host.end)
+    pub fn expand(self) -> Vec<PortMapping> {
+        (self.host.start..=self.host.end)
             .zip(self.guest.start..=self.guest.end)
             .map(|(host, guest)| PortMapping::new(host, guest))
-            .collect())
+            .collect()
     }
 
     /// Expand all user-supplied specs while enforcing the per-machine mapping cap.
@@ -176,7 +176,7 @@ impl PortMappingSpec {
 
         let mut ports = Vec::with_capacity(count);
         for spec in specs {
-            ports.extend(spec.expand()?);
+            ports.extend(spec.expand());
         }
         Ok(ports)
     }
@@ -378,8 +378,7 @@ mod tests {
     fn port_mapping_spec_expands_equal_length_ranges() {
         let ports = PortMappingSpec::parse("5173-5175:6173-6175")
             .unwrap()
-            .expand()
-            .unwrap();
+            .expand();
 
         assert_eq!(
             ports,
@@ -389,6 +388,14 @@ mod tests {
                 PortMapping::new(5175, 6175),
             ]
         );
+    }
+
+    #[test]
+    fn port_mapping_spec_rejects_invalid_ranges() {
+        assert!(PortMappingSpec::parse("5173-5175:6173-6174").is_err());
+        assert!(PortMappingSpec::parse("5175-5173").is_err());
+        assert!(PortMappingSpec::parse("0-1").is_err());
+        assert!(PortMappingSpec::parse("5173--5175").is_err());
     }
 
     #[test]

--- a/src/data/network.rs
+++ b/src/data/network.rs
@@ -51,6 +51,27 @@ pub struct PortMapping {
     pub guest: u16,
 }
 
+/// Maximum concrete mappings permitted for one machine.
+///
+/// The current forwarding implementation starts listener thread(s) per mapping,
+/// so raising this limit requires multiplexing listeners or bounding the worker
+/// pool in `smolvm-network` first.
+pub const MAX_PORT_MAPPINGS: usize = 64;
+
+/// A CLI or Smolfile port mapping before range expansion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PortMappingSpec {
+    host: PortRange,
+    guest: PortRange,
+}
+
+/// An inclusive range of TCP ports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PortRange {
+    start: u16,
+    end: u16,
+}
+
 /// Check if any CIDR in the list covers the given IP address.
 pub fn cidrs_contain_ip(cidrs: &[String], ip: &str) -> bool {
     let ip: IpAddr = match ip.parse() {
@@ -95,6 +116,109 @@ pub fn ensure_dns_in_cidrs(cidrs: &mut Vec<String>) {
     if !cidrs_contain_ip(cidrs, &dns.to_string()) {
         cidrs.push(IpNet::from(dns).to_string());
     }
+}
+
+impl From<PortMapping> for PortMappingSpec {
+    fn from(mapping: PortMapping) -> Self {
+        let range = PortRange {
+            start: mapping.host,
+            end: mapping.host,
+        };
+        Self {
+            host: range,
+            guest: PortRange {
+                start: mapping.guest,
+                end: mapping.guest,
+            },
+        }
+    }
+}
+
+impl PortMappingSpec {
+    /// Parse a port mapping specification (`HOST:GUEST`, `PORT`, or equal-length ranges).
+    pub fn parse(spec: &str) -> Result<Self, String> {
+        let (host, guest) = match spec.split_once(':') {
+            Some((host, guest)) => (
+                PortRange::parse(host, "host")?,
+                PortRange::parse(guest, "guest")?,
+            ),
+            None => {
+                let range = PortRange::parse(spec, "")?;
+                (range, range)
+            }
+        };
+
+        if host.len() != guest.len() {
+            return Err(format!(
+                "host and guest port ranges must have the same number of ports: {spec}"
+            ));
+        }
+
+        Ok(Self { host, guest })
+    }
+
+    /// Expand this specification into its concrete host-to-guest mappings.
+    pub fn expand(self) -> Result<Vec<PortMapping>, String> {
+        Ok((self.host.start..=self.host.end)
+            .zip(self.guest.start..=self.guest.end)
+            .map(|(host, guest)| PortMapping::new(host, guest))
+            .collect())
+    }
+
+    /// Expand all user-supplied specs while enforcing the per-machine mapping cap.
+    pub fn expand_all(specs: &[Self]) -> Result<Vec<PortMapping>, String> {
+        let count = specs.iter().map(|spec| spec.host.len() as usize).sum();
+        if count > MAX_PORT_MAPPINGS {
+            return Err(format!(
+                "port mappings expand to {count} entries; the maximum per machine is {MAX_PORT_MAPPINGS}"
+            ));
+        }
+
+        let mut ports = Vec::with_capacity(count);
+        for spec in specs {
+            ports.extend(spec.expand()?);
+        }
+        Ok(ports)
+    }
+}
+
+impl PortRange {
+    fn parse(spec: &str, kind: &str) -> Result<Self, String> {
+        let (start, end) = match spec.split_once('-') {
+            Some((start, end)) => (parse_port(start, kind)?, parse_port(end, kind)?),
+            None => {
+                let port = parse_port(spec, kind)?;
+                (port, port)
+            }
+        };
+
+        if start > end {
+            return Err(format!(
+                "{kind} port range start must not exceed its end: {spec}"
+            ));
+        }
+
+        Ok(Self { start, end })
+    }
+
+    const fn len(self) -> u32 {
+        self.end as u32 - self.start as u32 + 1
+    }
+}
+
+fn parse_port(spec: &str, kind: &str) -> Result<u16, String> {
+    let label = if kind.is_empty() {
+        "port".to_string()
+    } else {
+        format!("{kind} port")
+    };
+    let port: u16 = spec
+        .parse()
+        .map_err(|_| format!("invalid {label}: {spec}"))?;
+    if port == 0 {
+        return Err(format!("{label} 0 is not valid for VM port forwarding"));
+    }
+    Ok(port)
 }
 
 impl PortMapping {
@@ -248,6 +372,35 @@ mod tests {
         assert!(PortMapping::parse("0").is_err());
         assert!(PortMapping::parse("1:1").is_ok());
         assert!(PortMapping::parse("8080:80").is_ok());
+    }
+
+    #[test]
+    fn port_mapping_spec_expands_equal_length_ranges() {
+        let ports = PortMappingSpec::parse("5173-5175:6173-6175")
+            .unwrap()
+            .expand()
+            .unwrap();
+
+        assert_eq!(
+            ports,
+            vec![
+                PortMapping::new(5173, 6173),
+                PortMapping::new(5174, 6174),
+                PortMapping::new(5175, 6175),
+            ]
+        );
+    }
+
+    #[test]
+    fn port_mapping_spec_limits_total_expanded_mappings() {
+        let specs = [
+            PortMappingSpec::parse("1-32").unwrap(),
+            PortMappingSpec::parse("33-64").unwrap(),
+        ];
+        assert_eq!(PortMappingSpec::expand_all(&specs).unwrap().len(), 64);
+
+        let too_many = [PortMappingSpec::parse("1-65").unwrap()];
+        assert!(PortMappingSpec::expand_all(&too_many).is_err());
     }
 
     #[test]

--- a/tests/test_ports.sh
+++ b/tests/test_ports.sh
@@ -19,41 +19,50 @@ echo "  Port Mapping Tests"
 echo "=========================================="
 echo ""
 
-test_machine_port_mapping_http() {
+test_machine_port_range_mapping_http() {
     local vm_name="test-vm-portmap"
 
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
     $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
 
-    # Create and start VM with port mapping (host 18199 -> guest 8080)
-    $SMOLVM machine create --name "$vm_name" -p 18199:8080 2>&1 || return 1
+    # Create and start VM with one-to-one port mappings:
+    # host 18199 -> guest 8080 and host 18200 -> guest 8081.
+    $SMOLVM machine create --name "$vm_name" -p 18199-18200:8080-8081 2>&1 || return 1
     $SMOLVM machine start --name "$vm_name" 2>&1 || {
         $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null
         return 1
     }
 
-    # Start a simple HTTP responder inside the VM (background exec)
+    # Each nc responder serves one request. Avoid readiness probes because they
+    # would consume that request before curl reaches the published port.
     $SMOLVM machine exec --name "$vm_name" -- \
-        sh -c 'echo -e "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok" | nc -l -p 8080 -w 5' &
-    local server_pid=$!
-    # nc serves exactly one connection; any TCP probe would consume it before
-    # curl gets a chance. A fixed sleep is the right wait here.
+        sh -c 'echo -e "HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\none" | nc -l -p 8080 -w 5' &
+    local first_server_pid=$!
+    $SMOLVM machine exec --name "$vm_name" -- \
+        sh -c 'echo -e "HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\ntwo" | nc -l -p 8081 -w 5' &
+    local second_server_pid=$!
     sleep 1
 
-    # Curl the mapped port from the host
-    local output
-    output=$(curl -s --connect-timeout 5 http://127.0.0.1:18199/ 2>&1)
-    local curl_rc=$?
+    local first_output
+    local first_curl_rc
+    first_output=$(curl -s --connect-timeout 5 http://127.0.0.1:18199/ 2>&1)
+    first_curl_rc=$?
 
-    kill "$server_pid" 2>/dev/null || true
-    wait "$server_pid" 2>/dev/null || true
+    local second_output
+    local second_curl_rc
+    second_output=$(curl -s --connect-timeout 5 http://127.0.0.1:18200/ 2>&1)
+    second_curl_rc=$?
+
+    kill "$first_server_pid" "$second_server_pid" 2>/dev/null || true
+    wait "$first_server_pid" "$second_server_pid" 2>/dev/null || true
 
     # Cleanup
     $SMOLVM machine stop --name "$vm_name" 2>/dev/null || true
     $SMOLVM machine delete --name "$vm_name" -f 2>/dev/null || true
     ensure_data_dir_deleted "$vm_name"
 
-    [[ $curl_rc -eq 0 ]] && [[ "$output" == *"ok"* ]]
+    [[ $first_curl_rc -eq 0 ]] && [[ "$first_output" == *"one"* ]] &&
+        [[ $second_curl_rc -eq 0 ]] && [[ "$second_output" == *"two"* ]]
 }
 
 test_port_conflict_across_vms() {
@@ -84,7 +93,7 @@ test_port_conflict_across_vms() {
 }
 
 
-run_test "Port: mapping host to guest HTTP" test_machine_port_mapping_http || true
+run_test "Port: range mappings reach distinct guest HTTP servers" test_machine_port_range_mapping_http || true
 run_test "Port: cross-VM conflict detected" test_port_conflict_across_vms || true
 
 print_summary "Port Tests"


### PR DESCRIPTION
Closes #1061.

In my current docker compose dev setup I use consecutive ports for Rails, Vite, YARD, and ad hoc web processes across multiple worktrees. Listing every mapping individually in a Smolfile or passing those as arguments through the CLI would be a PITA, so this adds one-to-one range expansion at the CLI and Smolfile boundary:

```toml
[dev]
ports = [
  "3000-3009:3000-3009",
  "3036-3045:3036-3045",
  "8808-8817:8808-8817",
]
```

The same works with `-p`:

```bash
smolvm machine run \
  -p 5173-5180:5173-5180 \
  --image alpine -- ...
```

## Notes

- Existing `PORT` and `HOST:GUEST` forms keep working and a bare range such as `5173-5180` maps the same host and guest range
- Paired ranges must have the same length or things fail
- Docker/Compose supports host-range-to-one-port allocation such as `8000-9000:5000` but this PR deliberately rejects that form because smolvm currently persists concrete mappings and has no allocation/reporting model for the selected host port
- Ranges expand before persistence and launch, so the agent and network backend still receive normal individual mappings. The behavior should apply to machine run/create/update/fork and packed run/start paths


## Important: There is a 64 concrete-mapping limit per machine

Each mapping currently creates at least one host listener thread, and usually two for IPv4 and IPv6. The 64-port limit keeps that per-machine cost bounded. We can revisit it when forwarding many ports does not require creating more threads for each one.

## Validation

```text
CARGO_BUILD_JOBS=4 cargo test -p smolvm --lib
CARGO_BUILD_JOBS=4 cargo test -p smolvm --bin smolvm
CARGO_BUILD_JOBS=4 cargo clippy -p smolvm --all-targets -- -D warnings
cargo fmt --check

CARGO_BUILD_JOBS=4 cargo make dev
SMOLVM="$PWD/target/release/smolvm" ./tests/test_ports.sh
# 2 passed, including two HTTP services reached through
# -p 18199-18200:8080-8081 on a real VM.
```

---

_DISCLAIMER: Code generated with assistance of gpt-5.6-terra through Pi with reasoning set to low. I have not previously written any Rust code by hand, apologies in advance if any of this doesn't follow best practices and the like._
