### PR TITLE
Serve a browser client on the VNC port so a machine's desktop opens in any browser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3136,6 +3136,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha1",
  "sha2",
  "smolfile",
  "smolvm-cuda",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ libloading = "0.8"
 # on Windows 10 1809+. See src/platform/uds.rs.
 socket2 = "0.6"
 dirs = "5"
+sha1 = "0.10"
 sha2 = "0.10"
 hex = "0.4"
 getrandom = "0.3"

--- a/src/agent/display.rs
+++ b/src/agent/display.rs
@@ -212,6 +212,21 @@ impl DisplayFramebuffer {
         }
     }
 
+    /// A framebuffer already holding one presented frame, so viewer tests
+    /// have something to serve without a guest behind them.
+    #[cfg(test)]
+    pub(crate) fn with_presented_frame(width: u32, height: u32, pixel: [u8; 4]) -> Self {
+        let fb = Self::new();
+        {
+            let mut front = fb.front.lock().unwrap();
+            front.buf = pixel.repeat((width * height) as usize);
+            front.width = width;
+            front.height = height;
+            front.generation = 1;
+        }
+        fb
+    }
+
     /// Block until a frame newer than `since` is presented, or `timeout`
     /// elapses. Returns the frame if one arrived.
     pub fn wait_for_frame(&self, since: u64, timeout: std::time::Duration) -> Option<Frame> {

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -913,7 +913,11 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
                         }
                     };
                     match super::vnc::serve(&bind, framebuffer, input) {
-                        Ok(addr) => tracing::info!(%addr, "vnc server listening"),
+                        Ok(addr) => tracing::info!(
+                            %addr,
+                            url = %super::vnc::browser_url(addr),
+                            "vnc server listening"
+                        ),
                         Err(e) => {
                             // A failed viewer must not take down the VM: the
                             // display itself is already working without it.

--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -294,9 +294,11 @@ pub fn launch_agent_vm_dynamic(
                                     }
                                 };
                                 match crate::agent::vnc::serve(&bind, framebuffer, input) {
-                                    Ok(addr) => {
-                                        tracing::info!(%addr, "vnc server listening")
-                                    }
+                                    Ok(addr) => tracing::info!(
+                                        %addr,
+                                        url = %crate::agent::vnc::browser_url(addr),
+                                        "vnc server listening"
+                                    ),
                                     // A failed viewer must not take down the
                                     // VM; the display works without it.
                                     Err(e) => tracing::warn!(

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -18,6 +18,7 @@ pub mod state_probe;
 pub mod terminal;
 pub mod vnc;
 mod vsock_service;
+mod websocket;
 
 pub use crate::data::network::PortMapping;
 pub use crate::data::resources::VmResources;

--- a/src/agent/vnc.rs
+++ b/src/agent/vnc.rs
@@ -10,6 +10,13 @@
 //! When the launcher attaches virtio-input devices, client key and pointer
 //! events are injected into the guest; on a libkrun without the input
 //! feature the session degrades to view-only and events are discarded.
+//!
+//! The same port also answers HTTP, serving a small browser client and
+//! upgrading it to a WebSocket carrying that identical RFB stream. That is
+//! what lets a plain browser open the desktop with nothing installed, and it
+//! is also what lets the cloud reach it: an HTTP port traverses an ingress,
+//! TLS terminator and authenticating proxy, where a raw RFB socket cannot.
+//! Native viewers are unaffected — the protocol is chosen per connection.
 
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
@@ -150,7 +157,7 @@ pub fn serve(
                         if let Err(e) = std::thread::Builder::new()
                             .name("smolvm-vnc-client".into())
                             .spawn(move || {
-                                if let Err(e) = handle_client(s, fb, input) {
+                                if let Err(e) = handle_connection(s, fb, input) {
                                     tracing::debug!(?peer, error = %e, "vnc client ended");
                                 }
                             })
@@ -190,13 +197,192 @@ fn is_transient_accept_error(e: &std::io::Error) -> bool {
         || e.raw_os_error() == Some(libc::ENOMEM)
 }
 
-fn handle_client(
-    mut s: TcpStream,
+/// Route one accepted connection to whichever protocol the peer speaks.
+fn handle_connection(
+    s: TcpStream,
     fb: Arc<DisplayFramebuffer>,
     input: Option<super::input::VncInput>,
 ) -> std::io::Result<()> {
     s.set_nodelay(true).ok();
+    if speaks_http(&s) {
+        serve_http(s, fb, input)
+    } else {
+        handle_client(s, fb, input)
+    }
+}
 
+/// Did the peer open with an HTTP request line?
+///
+/// This has to be a bounded wait rather than a blocking peek, because in RFB
+/// the *server* speaks first: a native viewer connects and then stays silent
+/// until it has been greeted, so blocking here would hang exactly the clients
+/// that must keep working. A browser sends its request immediately. Waiting
+/// briefly for bytes therefore tells the two apart, and only costs a native
+/// viewer this much delay before its greeting.
+fn speaks_http(s: &TcpStream) -> bool {
+    const SNIFF_WAIT: Duration = Duration::from_millis(300);
+
+    let restore = s.read_timeout().ok().flatten();
+    if s.set_read_timeout(Some(SNIFF_WAIT)).is_err() {
+        return false;
+    }
+
+    let deadline = std::time::Instant::now() + SNIFF_WAIT;
+    let mut probe = [0u8; 4];
+    let verdict = loop {
+        // Peek leaves the bytes in the socket, so whichever handler runs next
+        // sees an untouched stream and needs no hand-off buffer.
+        match s.peek(&mut probe) {
+            Ok(4) => break &probe == b"GET ",
+            // A short read means the request line is still arriving. Only
+            // wait on it while what did arrive is still a prefix of "GET ".
+            Ok(n) if n > 0 && probe[..n] == b"GET "[..n] => {
+                if std::time::Instant::now() >= deadline {
+                    break false;
+                }
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            _ => break false,
+        }
+    };
+
+    let _ = s.set_read_timeout(restore);
+    verdict
+}
+
+/// The browser client, served from the same port the RFB protocol uses.
+const CLIENT_HTML: &str = include_str!("vnc_client.html");
+
+struct HttpRequest {
+    path: String,
+    /// Present only on a well-formed upgrade request.
+    websocket_key: Option<String>,
+    wants_binary_subprotocol: bool,
+}
+
+fn serve_http(
+    mut s: TcpStream,
+    fb: Arc<DisplayFramebuffer>,
+    input: Option<super::input::VncInput>,
+) -> std::io::Result<()> {
+    let Some(request) = read_request(&mut s)? else {
+        return respond(
+            &mut s,
+            "400 Bad Request",
+            "text/plain",
+            b"malformed request",
+        );
+    };
+
+    if let Some(key) = request.websocket_key.as_deref() {
+        let mut reply = format!(
+            "HTTP/1.1 101 Switching Protocols\r\n\
+             Upgrade: websocket\r\n\
+             Connection: Upgrade\r\n\
+             Sec-WebSocket-Accept: {}\r\n",
+            super::websocket::accept_key(key)
+        );
+        // A client that offered a subprotocol expects to be told which one was
+        // taken; staying silent makes some of them close the connection.
+        if request.wants_binary_subprotocol {
+            reply.push_str("Sec-WebSocket-Protocol: binary\r\n");
+        }
+        reply.push_str("\r\n");
+        s.write_all(reply.as_bytes())?;
+        tracing::info!("vnc browser client connected");
+        return handle_client(super::websocket::WsStream::new(s), fb, input);
+    }
+
+    match request.path.as_str() {
+        "/" | "/index.html" => respond(
+            &mut s,
+            "200 OK",
+            "text/html; charset=utf-8",
+            CLIENT_HTML.as_bytes(),
+        ),
+        _ => respond(&mut s, "404 Not Found", "text/plain", b"not found"),
+    }
+}
+
+/// Read and parse the request head, or `None` if it is not one we serve.
+///
+/// Deliberately reads a byte at a time instead of wrapping the stream in a
+/// `BufReader`: on an upgrade the very next bytes belong to the WebSocket, and
+/// anything a buffered reader pulled past the blank line would be stranded in
+/// a buffer the frame decoder never sees.
+fn read_request<R: Read>(s: &mut R) -> std::io::Result<Option<HttpRequest>> {
+    const MAX_HEAD: usize = 8 << 10;
+
+    let mut head = Vec::with_capacity(512);
+    let mut byte = [0u8; 1];
+    while !head.ends_with(b"\r\n\r\n") {
+        if head.len() >= MAX_HEAD || s.read(&mut byte)? == 0 {
+            return Ok(None);
+        }
+        head.push(byte[0]);
+    }
+
+    let text = String::from_utf8_lossy(&head);
+    let mut lines = text.split("\r\n");
+    let mut request_line = lines.next().unwrap_or_default().split_whitespace();
+    if request_line.next() != Some("GET") {
+        return Ok(None);
+    }
+    let path = request_line.next().unwrap_or("/");
+
+    let mut websocket_key = None;
+    let mut upgrading = false;
+    let mut wants_binary_subprotocol = false;
+    for line in lines {
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        let value = value.trim();
+        match name.trim().to_ascii_lowercase().as_str() {
+            "upgrade" => upgrading = value.eq_ignore_ascii_case("websocket"),
+            "sec-websocket-key" => websocket_key = Some(value.to_string()),
+            "sec-websocket-protocol" => {
+                wants_binary_subprotocol = value
+                    .split(',')
+                    .any(|p| p.trim().eq_ignore_ascii_case("binary"));
+            }
+            _ => {}
+        }
+    }
+
+    Ok(Some(HttpRequest {
+        path: path.split('?').next().unwrap_or("/").to_string(),
+        websocket_key: upgrading.then_some(websocket_key).flatten(),
+        wants_binary_subprotocol,
+    }))
+}
+
+fn respond<W: Write>(
+    s: &mut W,
+    status: &str,
+    content_type: &str,
+    body: &[u8],
+) -> std::io::Result<()> {
+    let head = format!(
+        "HTTP/1.1 {status}\r\n\
+         Content-Type: {content_type}\r\n\
+         Content-Length: {}\r\n\
+         Cache-Control: no-store\r\n\
+         Connection: close\r\n\r\n",
+        body.len()
+    );
+    s.write_all(head.as_bytes())?;
+    s.write_all(body)
+}
+
+/// Drive one RFB session. Generic over the transport so the very same
+/// protocol code serves a native viewer on a raw socket and a browser over a
+/// WebSocket — the two differ only in how bytes are framed beneath this.
+fn handle_client<S: Read + Write>(
+    mut s: S,
+    fb: Arc<DisplayFramebuffer>,
+    input: Option<super::input::VncInput>,
+) -> std::io::Result<()> {
     // --- handshake -------------------------------------------------------
     s.write_all(RFB_VERSION)?;
     let mut version = [0u8; 12];
@@ -421,7 +607,7 @@ fn handle_client(
     }
 }
 
-fn send_resize(s: &mut TcpStream, width: u32, height: u32) -> std::io::Result<()> {
+fn send_resize<S: Write>(s: &mut S, width: u32, height: u32) -> std::io::Result<()> {
     let mut msg = vec![0u8, 0];
     msg.extend_from_slice(&1u16.to_be_bytes()); // one rectangle
     msg.extend_from_slice(&0u16.to_be_bytes()); // x
@@ -432,8 +618,8 @@ fn send_resize(s: &mut TcpStream, width: u32, height: u32) -> std::io::Result<()
     s.write_all(&msg)
 }
 
-fn send_frame(
-    s: &mut TcpStream,
+fn send_frame<S: Write>(
+    s: &mut S,
     frame: &Frame,
     bgrx: &[u8],
     fmt: &PixelFormat,
@@ -455,8 +641,8 @@ fn send_frame(
 /// received. Raw encoding ships every pixel of a rectangle, so cursor-sized
 /// damage would otherwise cost a full-frame update (~5 MB at 1440x900) on
 /// every pointer movement.
-fn send_frame_diff(
-    s: &mut TcpStream,
+fn send_frame_diff<S: Write>(
+    s: &mut S,
     frame: &Frame,
     bgrx: &[u8],
     prev: &[u8],
@@ -500,6 +686,25 @@ fn send_frame_diff(
         s.write_all(&encode_pixels(band, fmt))?;
     }
     Ok(())
+}
+
+/// The URL to open in a browser for a server bound to `addr`. A wildcard
+/// bind is reported as loopback, because that is the address whoever reads
+/// the log can actually open.
+pub fn browser_url(addr: std::net::SocketAddr) -> String {
+    let ip = addr.ip();
+    let host = if ip.is_unspecified() {
+        if addr.is_ipv6() {
+            "[::1]".to_string()
+        } else {
+            "127.0.0.1".to_string()
+        }
+    } else if addr.is_ipv6() {
+        format!("[{ip}]")
+    } else {
+        ip.to_string()
+    };
+    format!("http://{host}:{}/", addr.port())
 }
 
 /// Resolve `SMOLVM_VNC` into a bind address. Accepts a bare port ("5900"), a
@@ -588,5 +793,309 @@ mod tests {
             ..PixelFormat::bgrx()
         };
         assert!(!fmt.is_supported());
+    }
+
+    fn request_of(raw: &str) -> Option<HttpRequest> {
+        read_request(&mut std::io::Cursor::new(raw.as_bytes().to_vec())).unwrap()
+    }
+
+    #[test]
+    fn websocket_upgrade_is_recognised() {
+        let r = request_of(
+            "GET /websockify HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\n\
+             Connection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\
+             Sec-WebSocket-Protocol: binary\r\n\r\n",
+        )
+        .unwrap();
+        assert_eq!(r.websocket_key.as_deref(), Some("dGhlIHNhbXBsZSBub25jZQ=="));
+        assert!(r.wants_binary_subprotocol);
+    }
+
+    #[test]
+    fn a_key_without_an_upgrade_is_not_a_websocket() {
+        // Otherwise a plain GET carrying a stray header would be handed to
+        // the frame decoder, which would then read HTML as frame bytes.
+        let r = request_of("GET / HTTP/1.1\r\nSec-WebSocket-Key: abc\r\n\r\n").unwrap();
+        assert!(r.websocket_key.is_none());
+    }
+
+    #[test]
+    fn header_names_are_case_insensitive() {
+        let r = request_of("GET / HTTP/1.1\r\nUPGRADE: WebSocket\r\nSEC-WEBSOCKET-KEY: k\r\n\r\n")
+            .unwrap();
+        assert_eq!(r.websocket_key.as_deref(), Some("k"));
+    }
+
+    #[test]
+    fn query_strings_do_not_change_the_route() {
+        assert_eq!(
+            request_of("GET /?scale=1 HTTP/1.1\r\n\r\n").unwrap().path,
+            "/"
+        );
+    }
+
+    #[test]
+    fn non_get_methods_are_refused() {
+        assert!(request_of("POST / HTTP/1.1\r\n\r\n").is_none());
+    }
+
+    #[test]
+    fn a_truncated_head_is_not_a_request() {
+        assert!(request_of("GET / HTTP/1.1\r\nHost: x\r\n").is_none());
+    }
+
+    #[test]
+    fn an_endless_head_is_bounded() {
+        // A client that never sends the blank line must not grow the buffer
+        // without limit.
+        let mut raw = String::from("GET / HTTP/1.1\r\n");
+        while raw.len() < 16 << 10 {
+            raw.push_str("X-Pad: filler\r\n");
+        }
+        assert!(request_of(&raw).is_none());
+    }
+
+    #[test]
+    fn responses_carry_a_length_and_close() {
+        let mut out = Vec::new();
+        respond(&mut out, "200 OK", "text/plain", b"hi").unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.starts_with("HTTP/1.1 200 OK\r\n"));
+        assert!(text.contains("Content-Length: 2\r\n"));
+        assert!(text.ends_with("\r\n\r\nhi"));
+    }
+
+    #[test]
+    fn wildcard_bind_is_advertised_as_loopback() {
+        assert_eq!(
+            browser_url("0.0.0.0:5900".parse().unwrap()),
+            "http://127.0.0.1:5900/"
+        );
+    }
+
+    #[test]
+    fn a_concrete_address_is_kept() {
+        assert_eq!(
+            browser_url("192.168.1.5:5901".parse().unwrap()),
+            "http://192.168.1.5:5901/"
+        );
+    }
+
+    #[test]
+    fn ipv6_hosts_are_bracketed() {
+        assert_eq!(
+            browser_url("[::]:5900".parse().unwrap()),
+            "http://[::1]:5900/"
+        );
+    }
+
+    #[test]
+    fn the_embedded_client_is_a_whole_document() {
+        // A truncated or mis-pathed asset would only show up as a blank page
+        // in a browser, long after the build went green.
+        assert!(CLIENT_HTML.starts_with("<!doctype html>"));
+        assert!(CLIENT_HTML.contains("/websockify"));
+        assert!(CLIENT_HTML.trim_end().ends_with("</html>"));
+    }
+
+    // --- end to end over a real socket ----------------------------------
+    //
+    // These drive the listener the way a client does, so the sniffer, the
+    // HTTP layer, the frame codec and the RFB code are exercised together
+    // rather than each in isolation.
+
+    const TEST_W: u32 = 64;
+    const TEST_H: u32 = 32;
+
+    fn serve_a_test_desktop() -> std::net::SocketAddr {
+        let fb = Arc::new(display::DisplayFramebuffer::with_presented_frame(
+            TEST_W,
+            TEST_H,
+            [9, 8, 7, 255],
+        ));
+        serve("127.0.0.1:0", fb, None).unwrap()
+    }
+
+    fn connect(addr: std::net::SocketAddr) -> TcpStream {
+        let s = TcpStream::connect(addr).unwrap();
+        // Never let a protocol bug turn into a hung test run.
+        s.set_read_timeout(Some(Duration::from_secs(10))).unwrap();
+        s
+    }
+
+    /// Run a client-side RFB 3.8 session and pull one full-frame update.
+    /// Returns the pixel bytes of the rectangle received.
+    fn drive_rfb_session<S: Read + Write>(s: &mut S) -> Vec<u8> {
+        let mut version = [0u8; 12];
+        s.read_exact(&mut version).unwrap();
+        assert_eq!(&version, RFB_VERSION);
+        s.write_all(RFB_VERSION).unwrap();
+
+        let mut offered = [0u8; 1];
+        s.read_exact(&mut offered).unwrap();
+        let mut types = vec![0u8; offered[0] as usize];
+        s.read_exact(&mut types).unwrap();
+        assert!(types.contains(&SECURITY_NONE));
+        s.write_all(&[SECURITY_NONE]).unwrap();
+
+        let mut result = [0u8; 4];
+        s.read_exact(&mut result).unwrap();
+        assert_eq!(u32::from_be_bytes(result), 0, "security handshake rejected");
+
+        s.write_all(&[1]).unwrap(); // ClientInit: shared
+
+        let mut init = [0u8; 24];
+        s.read_exact(&mut init).unwrap();
+        assert_eq!(u16::from_be_bytes([init[0], init[1]]) as u32, TEST_W);
+        assert_eq!(u16::from_be_bytes([init[2], init[3]]) as u32, TEST_H);
+        let name_len = u32::from_be_bytes(init[20..24].try_into().unwrap()) as usize;
+        let mut name = vec![0u8; name_len];
+        s.read_exact(&mut name).unwrap();
+
+        // FramebufferUpdateRequest, non-incremental so we get pixels now.
+        let mut req = vec![3u8, 0];
+        req.extend_from_slice(&0u16.to_be_bytes());
+        req.extend_from_slice(&0u16.to_be_bytes());
+        req.extend_from_slice(&(TEST_W as u16).to_be_bytes());
+        req.extend_from_slice(&(TEST_H as u16).to_be_bytes());
+        s.write_all(&req).unwrap();
+
+        let mut head = [0u8; 4];
+        s.read_exact(&mut head).unwrap();
+        assert_eq!(head[0], 0, "expected a FramebufferUpdate");
+        assert_eq!(u16::from_be_bytes([head[2], head[3]]), 1, "one rectangle");
+
+        let mut rect = [0u8; 12];
+        s.read_exact(&mut rect).unwrap();
+        let w = u16::from_be_bytes([rect[4], rect[5]]) as usize;
+        let h = u16::from_be_bytes([rect[6], rect[7]]) as usize;
+        assert_eq!(
+            i32::from_be_bytes(rect[8..12].try_into().unwrap()),
+            ENCODING_RAW
+        );
+
+        let mut pixels = vec![0u8; w * h * 4];
+        s.read_exact(&mut pixels).unwrap();
+        pixels
+    }
+
+    #[test]
+    fn a_native_viewer_still_gets_a_plain_rfb_session() {
+        // The back-compat guarantee: adding HTTP to this port must not
+        // disturb a client that opens with silence and waits to be greeted.
+        let mut s = connect(serve_a_test_desktop());
+        let pixels = drive_rfb_session(&mut s);
+        assert_eq!(pixels.len(), (TEST_W * TEST_H * 4) as usize);
+        assert_eq!(&pixels[..4], &[9, 8, 7, 255]);
+    }
+
+    #[test]
+    fn a_browser_is_served_the_embedded_client() {
+        let mut s = connect(serve_a_test_desktop());
+        s.write_all(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n").unwrap();
+        let mut page = Vec::new();
+        s.read_to_end(&mut page).unwrap();
+        let page = String::from_utf8_lossy(&page);
+        assert!(page.starts_with("HTTP/1.1 200 OK"), "got: {page:.60}");
+        assert!(page.contains("<!doctype html>"));
+    }
+
+    #[test]
+    fn an_unknown_path_is_a_404() {
+        let mut s = connect(serve_a_test_desktop());
+        s.write_all(b"GET /nope HTTP/1.1\r\nHost: x\r\n\r\n")
+            .unwrap();
+        let mut reply = Vec::new();
+        s.read_to_end(&mut reply).unwrap();
+        assert!(String::from_utf8_lossy(&reply).starts_with("HTTP/1.1 404"));
+    }
+
+    /// The client half of a WebSocket: masks what it writes, unmasks what it
+    /// reads. Only as much of RFC 6455 as our server speaks.
+    struct ClientWs(TcpStream, Vec<u8>, usize);
+
+    impl Write for ClientWs {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            let mask = [0x37u8, 0xfa, 0x21, 0x3d];
+            let mut frame = vec![0x82]; // FIN + binary
+            match buf.len() {
+                n if n < 126 => frame.push(0x80 | n as u8),
+                n => {
+                    frame.push(0x80 | 126);
+                    frame.extend_from_slice(&(n as u16).to_be_bytes());
+                }
+            }
+            frame.extend_from_slice(&mask);
+            frame.extend(buf.iter().enumerate().map(|(i, b)| b ^ mask[i & 3]));
+            self.0.write_all(&frame)?;
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            self.0.flush()
+        }
+    }
+
+    impl Read for ClientWs {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            while self.2 >= self.1.len() {
+                let mut head = [0u8; 2];
+                self.0.read_exact(&mut head)?;
+                let len = match head[1] & 0x7f {
+                    126 => {
+                        let mut e = [0u8; 2];
+                        self.0.read_exact(&mut e)?;
+                        u16::from_be_bytes(e) as usize
+                    }
+                    127 => {
+                        let mut e = [0u8; 8];
+                        self.0.read_exact(&mut e)?;
+                        u64::from_be_bytes(e) as usize
+                    }
+                    n => n as usize,
+                };
+                // Server frames are never masked, so the payload is literal.
+                let mut payload = vec![0u8; len];
+                self.0.read_exact(&mut payload)?;
+                self.1 = payload;
+                self.2 = 0;
+            }
+            let n = (self.1.len() - self.2).min(buf.len());
+            buf[..n].copy_from_slice(&self.1[self.2..self.2 + n]);
+            self.2 += n;
+            Ok(n)
+        }
+    }
+
+    #[test]
+    fn a_browser_gets_the_same_rfb_session_over_a_websocket() {
+        let mut s = connect(serve_a_test_desktop());
+        s.write_all(
+            b"GET /websockify HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\n\
+              Connection: Upgrade\r\nSec-WebSocket-Version: 13\r\n\
+              Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\
+              Sec-WebSocket-Protocol: binary\r\n\r\n",
+        )
+        .unwrap();
+
+        // Read exactly the response head, leaving frame bytes in the socket.
+        let mut head = Vec::new();
+        let mut byte = [0u8; 1];
+        while !head.ends_with(b"\r\n\r\n") {
+            assert_eq!(s.read(&mut byte).unwrap(), 1, "connection closed early");
+            head.push(byte[0]);
+        }
+        let head = String::from_utf8_lossy(&head);
+        assert!(
+            head.starts_with("HTTP/1.1 101 Switching Protocols"),
+            "{head}"
+        );
+        assert!(head.contains("Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo="));
+        assert!(head.contains("Sec-WebSocket-Protocol: binary"));
+
+        // The identical protocol now runs inside frames.
+        let mut ws = ClientWs(s, Vec::new(), 0);
+        let pixels = drive_rfb_session(&mut ws);
+        assert_eq!(pixels.len(), (TEST_W * TEST_H * 4) as usize);
+        assert_eq!(&pixels[..4], &[9, 8, 7, 255]);
     }
 }

--- a/src/agent/vnc_client.html
+++ b/src/agent/vnc_client.html
@@ -1,0 +1,237 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>smolvm desktop</title>
+<style>
+  :root { color-scheme: dark; }
+  html, body { margin: 0; height: 100%; background: #111; overflow: hidden; }
+  body { display: flex; align-items: center; justify-content: center;
+         font: 13px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; color: #ddd; }
+  canvas { max-width: 100vw; max-height: 100vh; image-rendering: pixelated;
+           display: none; touch-action: none; outline: none; }
+  #status { position: fixed; inset: 0; display: flex; align-items: center;
+            justify-content: center; text-align: center; padding: 2rem; }
+  #status.error { color: #ff8a8a; white-space: pre-wrap; }
+  #status.hidden { display: none; }
+</style>
+</head>
+<body>
+<div id="status">connecting…</div>
+<canvas id="screen" tabindex="0"></canvas>
+<script>
+"use strict";
+
+const canvas = document.getElementById("screen");
+const ctx = canvas.getContext("2d", { alpha: false });
+const statusEl = document.getElementById("status");
+
+let fbWidth = 0, fbHeight = 0, buttonMask = 0;
+
+function setStatus(text, isError) {
+  statusEl.textContent = text;
+  statusEl.classList.toggle("error", !!isError);
+  statusEl.classList.remove("hidden");
+  if (isError) canvas.style.display = "none";
+}
+function clearStatus() {
+  statusEl.classList.add("hidden");
+  canvas.style.display = "block";
+}
+
+// ---------------------------------------------------------------- transport
+// The socket delivers arbitrarily-sized chunks; RFB wants exact byte counts.
+// Buffer whatever arrives and hand it out in the sizes the protocol asks for.
+const ws = new WebSocket(
+  (location.protocol === "https:" ? "wss://" : "ws://") + location.host + "/websockify"
+);
+ws.binaryType = "arraybuffer";
+
+let chunks = [], available = 0, waiter = null;
+
+ws.onmessage = (ev) => {
+  chunks.push(new Uint8Array(ev.data));
+  available += ev.data.byteLength;
+  if (waiter && available >= waiter.need) {
+    const { need, resolve } = waiter;
+    waiter = null;
+    resolve(take(need));
+  }
+};
+ws.onerror = () => setStatus("connection failed", true);
+ws.onclose = () => setStatus("disconnected", true);
+ws.onopen = () => { session().catch((e) => setStatus(String(e && e.message || e), true)); };
+
+function take(n) {
+  const out = new Uint8Array(n);
+  let off = 0;
+  while (off < n) {
+    const head = chunks[0];
+    const used = Math.min(head.length, n - off);
+    out.set(head.subarray(0, used), off);
+    if (used === head.length) chunks.shift(); else chunks[0] = head.subarray(used);
+    off += used;
+  }
+  available -= n;
+  return out;
+}
+function recv(n) {
+  if (n === 0) return Promise.resolve(new Uint8Array(0));
+  if (available >= n) return Promise.resolve(take(n));
+  return new Promise((resolve) => { waiter = { need: n, resolve }; });
+}
+function send(bytes) { if (ws.readyState === WebSocket.OPEN) ws.send(bytes); }
+
+const u16 = (b, o) => (b[o] << 8) | b[o + 1];
+const u32 = (b, o) => ((b[o] << 24) | (b[o + 1] << 16) | (b[o + 2] << 8) | b[o + 3]) >>> 0;
+const i32 = (b, o) => (b[o] << 24) | (b[o + 1] << 16) | (b[o + 2] << 8) | b[o + 3];
+function putU16(b, o, v) { b[o] = v >> 8; b[o + 1] = v & 0xff; }
+function putI32(b, o, v) { b[o] = (v >> 24) & 0xff; b[o + 1] = (v >> 16) & 0xff;
+                           b[o + 2] = (v >> 8) & 0xff; b[o + 3] = v & 0xff; }
+
+// ------------------------------------------------------------------ session
+async function session() {
+  await recv(12);                                             // ServerVersion
+  send(new TextEncoder().encode("RFB 003.008\n"));
+
+  const count = (await recv(1))[0];
+  if (count === 0) {
+    const reason = await recv(u32(await recv(4), 0));
+    throw new Error(new TextDecoder().decode(reason));
+  }
+  const types = await recv(count);
+  if (!types.includes(1)) throw new Error("server does not offer None security");
+  send(new Uint8Array([1]));                                  // choose None
+  if (u32(await recv(4), 0) !== 0) throw new Error("security handshake rejected");
+
+  send(new Uint8Array([1]));                                  // ClientInit: shared
+  const init = await recv(24);                                // ServerInit
+  await recv(u32(init, 20));                                  // desktop name
+  resize(u16(init, 0), u16(init, 2));
+  clearStatus();
+  canvas.focus();
+
+  // Ask for DesktopSize so a guest mode change resizes us instead of
+  // silently cropping, plus Raw — the only encoding this server emits.
+  const enc = new Uint8Array(12);
+  enc[0] = 2; putU16(enc, 2, 2); putI32(enc, 4, -223); putI32(enc, 8, 0);
+  send(enc);
+
+  requestUpdate(false);
+  for (;;) {
+    const type = (await recv(1))[0];
+    if (type !== 0) throw new Error("unexpected server message " + type);
+    await recv(1);                                            // padding
+    const rects = u16(await recv(2), 0);
+    for (let i = 0; i < rects; i++) {
+      const r = await recv(12);
+      const x = u16(r, 0), y = u16(r, 2), w = u16(r, 4), h = u16(r, 6);
+      const encoding = i32(r, 8);
+      if (encoding === 0) {
+        draw(x, y, w, h, await recv(w * h * 4));
+      } else if (encoding === -223) {
+        resize(w, h);                                         // DesktopSize
+      } else {
+        throw new Error("unsupported encoding " + encoding);
+      }
+    }
+    requestUpdate(true);
+  }
+}
+
+function resize(w, h) {
+  if (w === fbWidth && h === fbHeight) return;
+  fbWidth = w; fbHeight = h;
+  canvas.width = w; canvas.height = h;
+}
+
+// The server sends BGRX; canvas wants RGBA.
+function draw(x, y, w, h, pixels) {
+  const img = ctx.createImageData(w, h);
+  const out = img.data;
+  for (let i = 0; i < w * h; i++) {
+    const p = i * 4;
+    out[p] = pixels[p + 2];
+    out[p + 1] = pixels[p + 1];
+    out[p + 2] = pixels[p];
+    out[p + 3] = 255;
+  }
+  ctx.putImageData(img, x, y);
+}
+
+function requestUpdate(incremental) {
+  const m = new Uint8Array(10);
+  m[0] = 3; m[1] = incremental ? 1 : 0;
+  putU16(m, 6, fbWidth); putU16(m, 8, fbHeight);
+  send(m);
+}
+
+// -------------------------------------------------------------------- input
+function at(ev) {
+  const r = canvas.getBoundingClientRect();
+  const x = Math.round((ev.clientX - r.left) * fbWidth / r.width);
+  const y = Math.round((ev.clientY - r.top) * fbHeight / r.height);
+  const clamp = (v, hi) => Math.max(0, Math.min(hi - 1, v));
+  return [clamp(x, fbWidth), clamp(y, fbHeight)];
+}
+function sendPointer(mask, x, y) {
+  const m = new Uint8Array(6);
+  m[0] = 5; m[1] = mask; putU16(m, 2, x); putU16(m, 4, y);
+  send(m);
+}
+// DOM buttons are left=1, right=2, middle=4; RFB wants left, middle, right.
+function maskOf(ev) {
+  return (ev.buttons & 1 ? 1 : 0) | (ev.buttons & 4 ? 2 : 0) | (ev.buttons & 2 ? 4 : 0);
+}
+function onPointer(ev) {
+  if (!fbWidth) return;
+  buttonMask = maskOf(ev);
+  const [x, y] = at(ev);
+  sendPointer(buttonMask, x, y);
+}
+canvas.addEventListener("mousemove", onPointer);
+canvas.addEventListener("mousedown", (ev) => { canvas.focus(); onPointer(ev); });
+canvas.addEventListener("mouseup", onPointer);
+canvas.addEventListener("contextmenu", (ev) => ev.preventDefault());
+canvas.addEventListener("wheel", (ev) => {
+  if (!fbWidth) return;
+  ev.preventDefault();
+  // Wheel notches are a press and release of bit 3 (up) or 4 (down).
+  const bit = ev.deltaY < 0 ? 8 : 16;
+  const [x, y] = at(ev);
+  sendPointer(buttonMask | bit, x, y);
+  sendPointer(buttonMask, x, y);
+}, { passive: false });
+
+const KEYSYMS = {
+  Backspace: 0xff08, Tab: 0xff09, Enter: 0xff0d, Escape: 0xff1b,
+  Insert: 0xff63, Delete: 0xffff, Home: 0xff50, End: 0xff57,
+  PageUp: 0xff55, PageDown: 0xff56, CapsLock: 0xffe5,
+  ArrowLeft: 0xff51, ArrowUp: 0xff52, ArrowRight: 0xff53, ArrowDown: 0xff54,
+  Shift: 0xffe1, Control: 0xffe3, Alt: 0xffe9, Meta: 0xffeb,
+  F1: 0xffbe, F2: 0xffbf, F3: 0xffc0, F4: 0xffc1, F5: 0xffc2, F6: 0xffc3,
+  F7: 0xffc4, F8: 0xffc5, F9: 0xffc6, F10: 0xffc7, F11: 0xffc8, F12: 0xffc9,
+};
+function keysymOf(ev) {
+  if (KEYSYMS[ev.key] !== undefined) return KEYSYMS[ev.key];
+  // Latin-1 keysyms are the code point itself, which covers printable keys.
+  return ev.key.length === 1 ? ev.key.codePointAt(0) : null;
+}
+function sendKey(down, keysym) {
+  const m = new Uint8Array(8);
+  m[0] = 4; m[1] = down ? 1 : 0;
+  putI32(m, 4, keysym);
+  send(m);
+}
+for (const [type, down] of [["keydown", true], ["keyup", false]]) {
+  canvas.addEventListener(type, (ev) => {
+    const keysym = keysymOf(ev);
+    if (keysym === null) return;
+    ev.preventDefault();
+    sendKey(down, keysym);
+  });
+}
+</script>
+</body>
+</html>

--- a/src/agent/websocket.rs
+++ b/src/agent/websocket.rs
@@ -1,0 +1,352 @@
+//! Server-side RFC 6455: the handshake reply and a `Read + Write` adapter
+//! that turns WebSocket frames back into a plain byte stream.
+//!
+//! This exists so a browser can drive the RFB server on the same port a native
+//! VNC viewer uses. RFB is a byte stream while WebSocket carries messages, so
+//! the adapter deliberately discards message boundaries and concatenates
+//! payloads: nothing above it has to know the transport is framed.
+
+use std::io::{ErrorKind, Read, Result, Write};
+
+use base64::Engine as _;
+
+/// RFC 6455 §4.2.2: the fixed GUID a server appends to the client's key
+/// before hashing.
+const WS_GUID: &str = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+const OP_CONTINUATION: u8 = 0x0;
+const OP_TEXT: u8 = 0x1;
+const OP_BINARY: u8 = 0x2;
+const OP_CLOSE: u8 = 0x8;
+const OP_PING: u8 = 0x9;
+const OP_PONG: u8 = 0xa;
+
+/// Refuse to buffer a single frame larger than this. A client controls the
+/// declared length, so an unbounded value would let one header allocate
+/// arbitrary memory before a single byte of payload arrives.
+const MAX_FRAME: u64 = 16 << 20;
+
+/// The value for `Sec-WebSocket-Accept`, proving to the client that we
+/// understood the handshake rather than echoing bytes back.
+pub fn accept_key(client_key: &str) -> String {
+    use sha1::{Digest, Sha1};
+    let mut hasher = Sha1::new();
+    hasher.update(client_key.as_bytes());
+    hasher.update(WS_GUID.as_bytes());
+    base64::engine::general_purpose::STANDARD.encode(hasher.finalize())
+}
+
+/// A WebSocket seen as a byte stream. Reads yield payload bytes in order;
+/// each write becomes one binary frame.
+pub struct WsStream<S> {
+    inner: S,
+    /// Payload decoded from frames but not yet handed to the reader.
+    pending: Vec<u8>,
+    /// How much of `pending` has been consumed.
+    read_at: usize,
+    /// The peer sent Close, or we did: further reads are EOF.
+    closed: bool,
+}
+
+impl<S: Read + Write> WsStream<S> {
+    pub fn new(inner: S) -> Self {
+        Self {
+            inner,
+            pending: Vec::new(),
+            read_at: 0,
+            closed: false,
+        }
+    }
+
+    /// Read frames until one carries payload. Control frames are answered
+    /// here and never surface to the caller.
+    ///
+    /// Returns `false` once the stream is closed.
+    fn next_payload(&mut self) -> Result<bool> {
+        loop {
+            let mut head = [0u8; 2];
+            match self.inner.read_exact(&mut head) {
+                Ok(()) => {}
+                // A peer that vanishes mid-session is a normal end of
+                // session here, not an error worth propagating upward.
+                Err(e) if e.kind() == ErrorKind::UnexpectedEof => {
+                    self.closed = true;
+                    return Ok(false);
+                }
+                Err(e) => return Err(e),
+            }
+
+            let opcode = head[0] & 0x0f;
+            let masked = head[1] & 0x80 != 0;
+            let len = match head[1] & 0x7f {
+                126 => {
+                    let mut ext = [0u8; 2];
+                    self.inner.read_exact(&mut ext)?;
+                    u16::from_be_bytes(ext) as u64
+                }
+                127 => {
+                    let mut ext = [0u8; 8];
+                    self.inner.read_exact(&mut ext)?;
+                    u64::from_be_bytes(ext)
+                }
+                n => n as u64,
+            };
+
+            // RFC 6455 §5.1 requires every client frame to be masked. Browsers
+            // always do; refusing an unmasked one keeps us from decoding a
+            // stream some other peer framed differently than we assume.
+            if !masked {
+                return Err(std::io::Error::new(
+                    ErrorKind::InvalidData,
+                    "websocket client frame was not masked",
+                ));
+            }
+            if len > MAX_FRAME {
+                return Err(std::io::Error::new(
+                    ErrorKind::InvalidData,
+                    "websocket frame exceeds the maximum accepted size",
+                ));
+            }
+
+            let mut mask = [0u8; 4];
+            self.inner.read_exact(&mut mask)?;
+
+            let mut payload = vec![0u8; len as usize];
+            self.inner.read_exact(&mut payload)?;
+            for (i, byte) in payload.iter_mut().enumerate() {
+                *byte ^= mask[i & 3];
+            }
+
+            match opcode {
+                OP_BINARY | OP_TEXT | OP_CONTINUATION => {
+                    // Fragmentation is irrelevant to a byte stream: whatever
+                    // arrived is simply the next bytes.
+                    if payload.is_empty() {
+                        continue;
+                    }
+                    self.pending = payload;
+                    self.read_at = 0;
+                    return Ok(true);
+                }
+                OP_PING => {
+                    self.send_frame(OP_PONG, &payload)?;
+                }
+                OP_PONG => {}
+                OP_CLOSE => {
+                    // Echo the close so the browser sees a clean shutdown
+                    // rather than a dropped socket.
+                    let _ = self.send_frame(OP_CLOSE, &payload);
+                    self.closed = true;
+                    return Ok(false);
+                }
+                other => {
+                    return Err(std::io::Error::new(
+                        ErrorKind::InvalidData,
+                        format!("unknown websocket opcode {other}"),
+                    ));
+                }
+            }
+        }
+    }
+
+    /// Write one frame. Server frames are never masked.
+    fn send_frame(&mut self, opcode: u8, payload: &[u8]) -> Result<()> {
+        let mut header = Vec::with_capacity(10);
+        header.push(0x80 | opcode); // FIN + opcode
+        match payload.len() {
+            n if n < 126 => header.push(n as u8),
+            n if n <= u16::MAX as usize => {
+                header.push(126);
+                header.extend_from_slice(&(n as u16).to_be_bytes());
+            }
+            n => {
+                header.push(127);
+                header.extend_from_slice(&(n as u64).to_be_bytes());
+            }
+        }
+        self.inner.write_all(&header)?;
+        self.inner.write_all(payload)
+    }
+}
+
+impl<S: Read + Write> Read for WsStream<S> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        while self.read_at >= self.pending.len() {
+            if self.closed || !self.next_payload()? {
+                return Ok(0);
+            }
+        }
+        let n = (self.pending.len() - self.read_at).min(buf.len());
+        buf[..n].copy_from_slice(&self.pending[self.read_at..self.read_at + n]);
+        self.read_at += n;
+        Ok(n)
+    }
+}
+
+impl<S: Read + Write> Write for WsStream<S> {
+    /// One frame per call. The RFB code writes a header then a payload, so
+    /// this costs a few bytes of framing per update rather than the buffering
+    /// machinery a flush-based design would need.
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        self.send_frame(OP_BINARY, buf)?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        self.inner.flush()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    /// A stream that reads from a fixed script and records what was written.
+    struct Duplex {
+        input: Cursor<Vec<u8>>,
+        output: Vec<u8>,
+    }
+
+    impl Read for Duplex {
+        fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+            self.input.read(buf)
+        }
+    }
+
+    impl Write for Duplex {
+        fn write(&mut self, buf: &[u8]) -> Result<usize> {
+            self.output.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    fn duplex(input: Vec<u8>) -> WsStream<Duplex> {
+        WsStream::new(Duplex {
+            input: Cursor::new(input),
+            output: Vec::new(),
+        })
+    }
+
+    /// Build a masked client frame the way a browser would.
+    fn client_frame(opcode: u8, payload: &[u8]) -> Vec<u8> {
+        let mask = [0xa1u8, 0xb2, 0xc3, 0xd4];
+        let mut out = vec![0x80 | opcode];
+        match payload.len() {
+            n if n < 126 => out.push(0x80 | n as u8),
+            n if n <= u16::MAX as usize => {
+                out.push(0x80 | 126);
+                out.extend_from_slice(&(n as u16).to_be_bytes());
+            }
+            n => {
+                out.push(0x80 | 127);
+                out.extend_from_slice(&(n as u64).to_be_bytes());
+            }
+        }
+        out.extend_from_slice(&mask);
+        out.extend(payload.iter().enumerate().map(|(i, b)| b ^ mask[i & 3]));
+        out
+    }
+
+    #[test]
+    fn accept_key_matches_the_rfc_example() {
+        // RFC 6455 §1.3 worked example.
+        assert_eq!(
+            accept_key("dGhlIHNhbXBsZSBub25jZQ=="),
+            "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="
+        );
+    }
+
+    #[test]
+    fn masked_payload_is_decoded() {
+        let mut ws = duplex(client_frame(OP_BINARY, b"RFB 003.008\n"));
+        let mut got = [0u8; 12];
+        ws.read_exact(&mut got).unwrap();
+        assert_eq!(&got, b"RFB 003.008\n");
+    }
+
+    #[test]
+    fn frames_concatenate_into_one_byte_stream() {
+        // Message boundaries must not be visible to the RFB code above: a
+        // read spanning two frames has to succeed.
+        let mut input = client_frame(OP_BINARY, b"abc");
+        input.extend(client_frame(OP_BINARY, b"def"));
+        let mut ws = duplex(input);
+        let mut got = [0u8; 6];
+        ws.read_exact(&mut got).unwrap();
+        assert_eq!(&got, b"abcdef");
+    }
+
+    #[test]
+    fn continuation_frames_are_just_more_bytes() {
+        let mut input = client_frame(OP_BINARY, b"one");
+        input.extend(client_frame(OP_CONTINUATION, b"two"));
+        let mut ws = duplex(input);
+        let mut got = [0u8; 6];
+        ws.read_exact(&mut got).unwrap();
+        assert_eq!(&got, b"onetwo");
+    }
+
+    #[test]
+    fn ping_is_answered_with_pong_and_hidden_from_the_reader() {
+        let mut input = client_frame(OP_PING, b"hi");
+        input.extend(client_frame(OP_BINARY, b"data"));
+        let mut ws = duplex(input);
+        let mut got = [0u8; 4];
+        ws.read_exact(&mut got).unwrap();
+        assert_eq!(&got, b"data");
+        // A pong carrying the ping's payload went back, unmasked.
+        assert_eq!(ws.inner.output, vec![0x80 | OP_PONG, 2, b'h', b'i']);
+    }
+
+    #[test]
+    fn close_reads_as_end_of_stream() {
+        let mut ws = duplex(client_frame(OP_CLOSE, &[]));
+        let mut got = [0u8; 1];
+        assert_eq!(ws.read(&mut got).unwrap(), 0);
+    }
+
+    #[test]
+    fn peer_vanishing_is_end_of_stream_not_an_error() {
+        let mut ws = duplex(Vec::new());
+        let mut got = [0u8; 1];
+        assert_eq!(ws.read(&mut got).unwrap(), 0);
+    }
+
+    #[test]
+    fn unmasked_client_frame_is_rejected() {
+        // Same frame as a browser would send, minus the mask bit.
+        let mut ws = duplex(vec![0x80 | OP_BINARY, 3, b'a', b'b', b'c']);
+        let mut got = [0u8; 3];
+        assert!(ws.read_exact(&mut got).is_err());
+    }
+
+    #[test]
+    fn oversized_frame_is_refused_before_allocating() {
+        let mut input = vec![0x80 | OP_BINARY, 0x80 | 127];
+        input.extend_from_slice(&(MAX_FRAME + 1).to_be_bytes());
+        input.extend_from_slice(&[0u8; 4]); // mask
+        let mut ws = duplex(input);
+        let mut got = [0u8; 1];
+        assert!(ws.read(&mut got).is_err());
+    }
+
+    #[test]
+    fn writes_become_unmasked_binary_frames() {
+        let mut ws = duplex(Vec::new());
+        ws.write_all(b"xy").unwrap();
+        assert_eq!(ws.inner.output, vec![0x80 | OP_BINARY, 2, b'x', b'y']);
+    }
+
+    #[test]
+    fn large_writes_use_an_extended_length() {
+        let mut ws = duplex(Vec::new());
+        let payload = vec![7u8; 1000];
+        ws.write_all(&payload).unwrap();
+        assert_eq!(&ws.inner.output[..4], &[0x80 | OP_BINARY, 126, 0x03, 0xe8]);
+        assert_eq!(&ws.inner.output[4..], &payload[..]);
+    }
+}


### PR DESCRIPTION
The VNC port now answers HTTP as well as RFB, serving a small self-contained client and upgrading it to a WebSocket that carries the same RFB stream, so a machine's desktop can be opened in a plain browser with nothing installed while native VNC viewers keep working unchanged.