### PR TITLE
Bump the workspace to 1.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3078,7 +3078,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smolfile"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -3104,7 +3104,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "async-stream",
  "axum",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-agent"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "flate2",
  "lazy_static",
@@ -3188,7 +3188,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "getrandom 0.3.4",
  "libc",
@@ -3197,11 +3197,11 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda-codegen"
-version = "1.13.0"
+version = "1.13.1"
 
 [[package]]
 name = "smolvm-cuda-guest"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "smolvm-cuda",
  "vsock",
@@ -3209,7 +3209,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda-shim"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "libc",
  "smolvm-cuda",
@@ -3218,7 +3218,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cudart-shim"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "libc",
  "smolvm-cuda",
@@ -3227,7 +3227,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-network"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "crossbeam-queue",
  "humantime",
@@ -3241,14 +3241,14 @@ dependencies = [
 
 [[package]]
 name = "smolvm-nvml-shim"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "smolvm-oci-layer"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "flate2",
  "libc",
@@ -3261,7 +3261,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-pack"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "base64",
  "serde",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "bytes",
  "dirs",
@@ -3312,7 +3312,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-s3fs"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "hmac",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "2"
 
 [package]
 name = "smolvm"
-version = "1.13.0"
+version = "1.13.1"
 edition = "2021"
 description = "OCI-native microVM runtime"
 license = "Apache-2.0"

--- a/crates/smolvm-agent/Cargo.toml
+++ b/crates/smolvm-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-agent"
-version = "1.13.0"
+version = "1.13.1"
 edition = "2021"
 description = "Guest agent for smolvm VMs (handles OCI operations and command execution)"
 license = "Apache-2.0"

--- a/crates/smolvm-cuda-codegen/Cargo.toml
+++ b/crates/smolvm-cuda-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda-codegen"
-version = "1.13.0"
+version = "1.13.1"
 edition = "2021"
 description = "Generates forward-to-host-lib marshaling (guest stubs + host dispatch) from a function spec"
 license = "Apache-2.0"

--- a/crates/smolvm-cuda-guest/Cargo.toml
+++ b/crates/smolvm-cuda-guest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda-guest"
-version = "1.13.0"
+version = "1.13.1"
 edition = "2021"
 description = "Guest-side CUDA-over-vsock runner for smolvm microVMs (Linux)"
 license = "Apache-2.0"

--- a/crates/smolvm-cuda-shim/Cargo.toml
+++ b/crates/smolvm-cuda-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda-shim"
-version = "1.13.0"
+version = "1.13.1"
 edition = "2021"
 description = "Guest-side libcuda.so.1 drop-in: CUDA Driver API over smolvm's vsock RPC"
 license = "Apache-2.0"

--- a/crates/smolvm-cuda/Cargo.toml
+++ b/crates/smolvm-cuda/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda"
-version = "1.13.0"
+version = "1.13.1"
 edition = "2021"
 description = "CUDA Driver-API remoting over vsock for smolvm guests"
 license = "Apache-2.0"

--- a/crates/smolvm-cudart-shim/Cargo.toml
+++ b/crates/smolvm-cudart-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cudart-shim"
-version = "1.13.0"
+version = "1.13.1"
 edition = "2021"
 description = "Guest-side libcudart.so drop-in: CUDA Runtime API lowered to smolvm's Driver-API vsock RPC"
 license = "Apache-2.0"

--- a/crates/smolvm-network/Cargo.toml
+++ b/crates/smolvm-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-network"
-version = "1.13.0"
+version = "1.13.1"
 edition = "2021"
 description = "Host-side virtio-net runtime for smolvm"
 license = "Apache-2.0"

--- a/crates/smolvm-nvml-shim/Cargo.toml
+++ b/crates/smolvm-nvml-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-nvml-shim"
-version = "1.13.0"
+version = "1.13.1"
 edition = "2021"
 description = "Guest-side libnvidia-ml.so.1 drop-in: answers the NVML queries CUDA frameworks (vLLM) use for device detection, backed by the remoted CUDA driver"
 license = "Apache-2.0"

--- a/crates/smolvm-oci-layer/Cargo.toml
+++ b/crates/smolvm-oci-layer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-oci-layer"
-version = "1.13.0"
+version = "1.13.1"
 edition = "2021"
 description = "Pure-Rust OCI image-layer extraction: decompress a layer blob and unpack it into an overlayfs lowerdir, translating OCI whiteouts"
 license = "Apache-2.0"

--- a/crates/smolvm-pack/Cargo.toml
+++ b/crates/smolvm-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-pack"
-version = "1.13.0"
+version = "1.13.1"
 edition = "2021"
 description = "Single-binary packaging for smolvm"
 license = "Apache-2.0"

--- a/crates/smolvm-protocol/Cargo.toml
+++ b/crates/smolvm-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-protocol"
-version = "1.13.0"
+version = "1.13.1"
 edition = "2021"
 description = "Protocol types for smolvm host-guest communication"
 license = "Apache-2.0"

--- a/crates/smolvm-registry/Cargo.toml
+++ b/crates/smolvm-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-registry"
-version = "1.13.0"
+version = "1.13.1"
 edition = "2021"
 description = "OCI Distribution client for smolmachines registry"
 license = "Apache-2.0"

--- a/crates/smolvm-s3fs/Cargo.toml
+++ b/crates/smolvm-s3fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-s3fs"
-version = "1.13.0"
+version = "1.13.1"
 edition = "2021"
 description = "POSIX filesystem over S3-compatible object storage, mounted through FUSE without libfuse or a helper binary"
 license = "Apache-2.0"

--- a/crates/smolvm-smolfile/Cargo.toml
+++ b/crates/smolvm-smolfile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolfile"
-version = "1.13.0"
+version = "1.13.1"
 edition = "2021"
 description = "Smolfile specification and parser for smolvm microVM workloads"
 license = "Apache-2.0"


### PR DESCRIPTION
Bumps every workspace crate and the nix package to 1.13.1 so the repository matches the released engine version.