### PR TITLE
Stop typing stalling behind a frame wait and stop held keys repeating twice

### DIFF
--- a/src/agent/vnc.rs
+++ b/src/agent/vnc.rs
@@ -31,7 +31,17 @@ const SECURITY_NONE: u8 = 1;
 /// How long a client's incremental update request waits for a new frame
 /// before we answer with the current one. Without a bound, a client would
 /// hang for as long as the desktop is idle and look disconnected.
-const UPDATE_WAIT: Duration = Duration::from_secs(2);
+///
+/// This also bounds INPUT latency, which is why it is short. A session is one
+/// loop: read a message, act on it, repeat. While it is parked in
+/// `wait_for_frame` nothing is reading the socket, so a keystroke that arrives
+/// mid-wait is not seen until the wait ends. With a two-second bound — the
+/// value this started at — typing into a still screen stalled for up to two
+/// seconds per keypress, because a still screen is exactly the case that runs
+/// the wait to its full length. A frame arriving still wakes the wait
+/// immediately via the condvar, so shortening it costs only an empty
+/// four-byte reply per tick on an idle desktop.
+const UPDATE_WAIT: Duration = Duration::from_millis(15);
 
 /// Pseudo-encoding letting us tell the client the desktop changed size, which
 /// happens when the compositor sets a mode different from the initial one.
@@ -1005,6 +1015,38 @@ mod tests {
         let pixels = drive_rfb_session(&mut s);
         assert_eq!(pixels.len(), (TEST_W * TEST_H * 4) as usize);
         assert_eq!(&pixels[..4], &[9, 8, 7, 255]);
+    }
+
+    #[test]
+    fn an_idle_incremental_request_returns_promptly_so_input_is_not_starved() {
+        // A session is one loop: read a message, act on it, repeat. While it
+        // is parked in `wait_for_frame` nothing is reading the socket, so a
+        // keystroke arriving mid-wait is not seen until the wait ends — and a
+        // still screen is exactly what runs the wait to its full length.
+        // Bounding the wait is therefore what keeps typing responsive, so
+        // assert the bound rather than the constant.
+        let mut s = connect(serve_a_test_desktop());
+        drive_rfb_session(&mut s); // consume the first, full-frame update
+
+        // Nothing has changed since, so this request exercises the wait path.
+        let mut req = vec![3u8, 1]; // incremental
+        req.extend_from_slice(&0u16.to_be_bytes());
+        req.extend_from_slice(&0u16.to_be_bytes());
+        req.extend_from_slice(&(TEST_W as u16).to_be_bytes());
+        req.extend_from_slice(&(TEST_H as u16).to_be_bytes());
+
+        let started = std::time::Instant::now();
+        s.write_all(&req).unwrap();
+        let mut head = [0u8; 4];
+        s.read_exact(&mut head).unwrap();
+        let waited = started.elapsed();
+
+        assert_eq!(head[0], 0, "expected a FramebufferUpdate");
+        assert!(
+            waited < Duration::from_millis(500),
+            "an idle incremental request took {waited:?}; input would stall for \
+             that long behind it"
+        );
     }
 
     #[test]

--- a/src/agent/vnc_client.html
+++ b/src/agent/vnc_client.html
@@ -316,6 +316,11 @@ function sendKey(down, keysym) {
 }
 for (const [type, down] of [["keydown", true], ["keyup", false]]) {
   canvas.addEventListener(type, (ev) => {
+    // A held key repeats in the browser AND again in the guest, because the
+    // guest runs its own evdev auto-repeat. Forwarding the browser's repeats
+    // stacks the two, which doubles characters and makes a held backspace run
+    // away. Send the press once and let the guest repeat it.
+    if (ev.repeat) { ev.preventDefault(); return; }
     const keysym = keysymOf(ev);
     if (keysym === null) return;
     ev.preventDefault();


### PR DESCRIPTION
A session reads one message at a time, so while it waited up to two seconds for the guest to present a new frame nothing was reading the socket and a keystroke arriving mid-wait went unseen until the wait ended, which is worst on a still screen; the wait is now bounded to a frame time so input latency is bounded with it, and the browser client no longer forwards auto-repeat key presses that the guest already generates itself, which was doubling characters and making a held backspace run away.