### PR TITLE
Keep macOS fork sources running

### DIFF
--- a/lib/libkrun.dylib
+++ b/lib/libkrun.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:99c6b4256478c5f0fdaaa9bc167e1cc9bf4b073dbaf78ef18ca494619b91f1cb
-size 6366528
+oid sha256:6927389717c47cd3aef2bb31acf79516a97e68d0809873def4de2d6db75d201d
+size 6427808

--- a/lib/libkrun.provenance
+++ b/lib/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=e01076251a36bac2bd6108afc70855f4e4224a01
+libkrun=d0c6754e5560017fb7d0d46e724310a7c6bd9098
 libkrunfw=8f1307644bdcb95fe1343bf0d6ccf30aa22f1549

--- a/lib/linux-aarch64/libkrun.provenance
+++ b/lib/linux-aarch64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=e01076251a36bac2bd6108afc70855f4e4224a01
+libkrun=d0c6754e5560017fb7d0d46e724310a7c6bd9098
 libkrunfw=8f1307644bdcb95fe1343bf0d6ccf30aa22f1549

--- a/lib/linux-aarch64/libkrun.so
+++ b/lib/linux-aarch64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8a5b35bb7b243e38a879e064505ffe079d9c81c0dcedb9f3b3845d553ab74d21
-size 7615064
+oid sha256:48d468c93ec9aadd73aa29958a75b56b9f65a8e0aded71e0356a66d384acbbef
+size 7615040

--- a/lib/linux-aarch64/libkrun.so.2.0.0
+++ b/lib/linux-aarch64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8a5b35bb7b243e38a879e064505ffe079d9c81c0dcedb9f3b3845d553ab74d21
-size 7615064
+oid sha256:48d468c93ec9aadd73aa29958a75b56b9f65a8e0aded71e0356a66d384acbbef
+size 7615040

--- a/lib/linux-x86_64/libkrun.provenance
+++ b/lib/linux-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=e01076251a36bac2bd6108afc70855f4e4224a01
+libkrun=d0c6754e5560017fb7d0d46e724310a7c6bd9098
 libkrunfw=8f1307644bdcb95fe1343bf0d6ccf30aa22f1549

--- a/lib/linux-x86_64/libkrun.so
+++ b/lib/linux-x86_64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a876e67d714f10ecb0363a0b17906846e783735169413ac7894879e932d62669
+oid sha256:bed4d514db5f212ffe1296571dfb23e16daa78ddfde27cc93bd4b3ee5cb786de
 size 8482840

--- a/lib/linux-x86_64/libkrun.so.2.0.0
+++ b/lib/linux-x86_64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a876e67d714f10ecb0363a0b17906846e783735169413ac7894879e932d62669
+oid sha256:bed4d514db5f212ffe1296571dfb23e16daa78ddfde27cc93bd4b3ee5cb786de
 size 8482840

--- a/lib/windows-x86_64/krun.dll
+++ b/lib/windows-x86_64/krun.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1dbe159ed1232e8b21c9cc9fbe478351e67bc6c43309b80042c06ff2b01fc310
-size 10866801
+oid sha256:46c4c3a438e4f11ff534d8fb6f56524c83143cbfc3f20dd90791da3e75dc7172
+size 10278912

--- a/lib/windows-x86_64/libkrun.provenance
+++ b/lib/windows-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=e01076251a36bac2bd6108afc70855f4e4224a01
+libkrun=d0c6754e5560017fb7d0d46e724310a7c6bd9098
 libkrunfw=8f1307644bdcb95fe1343bf0d6ccf30aa22f1549

--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -3,8 +3,8 @@
 //!
 //! A fork snapshots a running, forkable machine's RAM, device state, and disks,
 //! gives the clone private copy-on-write layers, and lets the caller boot the
-//! clone from that exact boundary. Linux/x86_64 resumes the source immediately
-//! on new private layers; other hosts retain the source as the frozen CoW base.
+//! clone from that exact boundary. Linux/x86_64 and macOS resume the source
+//! immediately on new private layers; other hosts retain a frozen CoW base.
 //! The boot itself differs between callers (the CLI uses `start_vm_named`; the
 //! API uses `AgentManager`), so it stays out of here; everything up to and
 //! including the snapshot + disk clone is shared so the two entry points can
@@ -17,7 +17,7 @@ use crate::db::SmolvmDb;
 use crate::{Error, Result};
 use std::collections::{BTreeMap, HashSet};
 use std::fs::File;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -189,7 +189,7 @@ pub fn wait_for_forkpoint(golden: &str, timeout: Duration) -> Result<()> {
     // new agent exec inside that paused VM: its vCPUs cannot answer, even
     // though the already-proven forkpoint remains the exact snapshot source.
     // The VMM control plane remains live, so recognize it before touching the
-    // guest. A continuing Linux source reports `OK running` and takes the
+    // guest. A continuing source reports `OK running` and takes the
     // ordinary agent readiness path below.
     let control = control_socket_path(golden);
     if control.exists() {
@@ -242,11 +242,14 @@ fn fork_base_already_paused(status: &str) -> bool {
     status.trim() == "OK paused"
 }
 
-/// Linux/KVM can atomically checkpoint a fork generation and resume the source
-/// on private RAM and disk layers. Other hosts retain the established frozen
-/// fork-base behavior.
+/// Linux/KVM and macOS/HVF can atomically checkpoint a fork generation and
+/// resume the source on private RAM and disk layers. Other hosts retain the
+/// established frozen fork-base behavior.
 pub fn fork_continue_enabled() -> bool {
-    cfg!(all(target_os = "linux", target_arch = "x86_64"))
+    cfg!(any(
+        all(target_os = "linux", target_arch = "x86_64"),
+        target_os = "macos"
+    ))
 }
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
@@ -304,17 +307,17 @@ pub fn restart_blocking_dependent_clones(db: &SmolvmDb, golden: &str) -> Result<
     restart_blocking_dependent_clones_in(db, golden, &vm_data_dir(golden).join("s"))
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn fork_continue_snapshot(snapshot_dir: &Path) -> bool {
     snapshot_dir.join("generation-disks.tsv").is_file()
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
 fn fork_continue_snapshot(_snapshot_dir: &Path) -> bool {
     false
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn atomic_write_snapshot_file(path: &Path, contents: &[u8]) -> Result<()> {
     let partial = path.with_extension(format!(
         "{}.partial",
@@ -480,7 +483,7 @@ fn stop_snapshot_guardians(snapshot_root: &Path) -> Result<()> {
     Ok(())
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn prepare_running_disk_generation(
     gdir: &Path,
     snapshot_dir: &Path,
@@ -604,10 +607,10 @@ fn prepare_running_disk_generation(
     Ok(())
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 const MAX_FORK_DISK_CHAIN_DEPTH: usize = 32;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn qcow2_backing_depth(path: &Path) -> Result<usize> {
     use std::io::{Read, Seek, SeekFrom};
 
@@ -704,7 +707,7 @@ fn qcow2_backing_depth(path: &Path) -> Result<usize> {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn ensure_fork_disk_chain_is_bounded(gdir: &Path) -> Result<()> {
     for raw in [
         crate::data::storage::STORAGE_DISK_FILENAME,
@@ -736,7 +739,7 @@ fn ensure_fork_disk_chain_is_bounded(gdir: &Path) -> Result<()> {
 /// cannot resume after switching to the new active overlays until the marker
 /// is durable, so a running source without the marker still owns the rotated
 /// base files and this operation is safe and idempotent.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn rollback_uncommitted_disk_generation(gdir: &Path, snapshot_dir: &Path) -> Result<()> {
     use crate::data::disk::DiskFormat;
 
@@ -852,7 +855,7 @@ fn rollback_uncommitted_disk_generation(gdir: &Path, snapshot_dir: &Path) -> Res
         .map_err(|error| Error::agent("sync recovered disk generation", error.to_string()))
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn recover_uncommitted_generations(
     db: &SmolvmDb,
     golden: &str,
@@ -902,7 +905,7 @@ fn snapshot_generation_id(snapshot: &Path) -> Option<&str> {
         .filter(|name| name.len() == 8 && name.as_bytes().iter().all(u8::is_ascii_hexdigit))
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn gc_unreferenced_fork_generations(
     db: &SmolvmDb,
     golden: &str,
@@ -952,7 +955,7 @@ fn gc_unreferenced_fork_generations(
     Ok(())
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn rollback_prepared_disk_generation(
     overlays: &[(PathBuf, PathBuf, crate::data::disk::DiskFormat)],
     rotations: &[(PathBuf, PathBuf)],
@@ -967,7 +970,7 @@ fn rollback_prepared_disk_generation(
     let _ = std::fs::remove_dir(generation_disk_dir);
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn read_generation_fork_disks(snapshot_dir: &Path) -> Result<Option<Vec<ForkDisk>>> {
     use crate::data::disk::DiskFormat;
 
@@ -1321,10 +1324,10 @@ pub fn prepare_held_fork(
 /// Preparation is transactional: if any clone fails, all clone records and
 /// disks created by this call are removed.
 ///
-/// Linux/x86_64 resumes the source after atomically rotating its writable disks;
-/// other hosts retain the source in its paused copy-on-write state. A direct
-/// later Linux fork captures current state; explicit pool replenishment can
-/// reuse its retained generation.
+/// Linux/x86_64 and macOS resume the source after atomically rotating its
+/// writable disks; other hosts retain the source in its paused copy-on-write
+/// state. A later direct fork captures current state; explicit pool
+/// replenishment can reuse its retained generation.
 pub fn prepare_forks(
     db: &SmolvmDb,
     golden: &str,
@@ -1435,7 +1438,7 @@ pub(crate) fn prepare_forks_reusing(
     // Never remove a colliding random directory because a live clone may still
     // be using an older snapshot.
     let snapshot_root = gdir.join("s");
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     if fork_continue_enabled() && !golden_was_paused {
         recover_uncommitted_generations(db, golden, &gdir, &snapshot_root)?;
     }
@@ -1507,7 +1510,7 @@ pub(crate) fn prepare_forks_reusing(
 
         let fork_continue = fork_continue_enabled();
         if fork_continue {
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             if let Err(error) = prepare_running_disk_generation(&gdir, &snapshot_dir, vm_ids) {
                 let _ = std::fs::remove_dir_all(&snapshot_dir);
                 return Err(error);
@@ -1592,7 +1595,7 @@ pub(crate) fn prepare_forks_reusing(
                 error,
             ));
         }
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         gc_unreferenced_fork_generations(db, golden, &snapshot_root, retained_snapshot.as_ref())?;
     }
 
@@ -1661,9 +1664,9 @@ pub(crate) fn rollback_retained_fork_snapshot(
     }
 
     let mut rollback_errors = Vec::new();
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     let source_continues = fork_continue_snapshot(snapshot_dir);
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     let source_continues = false;
     if source_continues {
         let status = control_socket_cmd(&control_socket_path(golden), "STATUS").map_err(|error| {
@@ -1685,10 +1688,10 @@ pub(crate) fn rollback_retained_fork_snapshot(
             ));
         }
         if !snapshot_dir.join("source-continues-v1").is_file() {
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             rollback_uncommitted_disk_generation(&vm_data_dir(golden), snapshot_dir)?;
-            #[cfg(not(target_os = "linux"))]
-            unreachable!("a non-Linux snapshot cannot carry fork-continue disk metadata");
+            #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+            unreachable!("this platform cannot carry fork-continue disk metadata");
         }
     } else if let Err(resume_error) = resume_golden(golden, snapshot_dir) {
         return Err(Error::agent(
@@ -1896,14 +1899,14 @@ fn prepare_clone_from_snapshot(
 
 /// Give the clone its own disks. The source's block workers were quiesced and
 /// flushed at the checkpoint boundary, so the generation is a consistent
-/// backing even when the Linux source has resumed. On Linux each
+/// backing even when the source has resumed. On Linux each
 /// disk is a qcow2 copy-on-write overlay over the golden's — filesystem
 /// independent, so the overlay starts near-empty and the fork is O(metadata)
 /// regardless of how much data the golden holds. macOS clonefiles the disks
 /// (APFS CoW). Either way the `.formatted` marker is copied so the clone never
 /// reformats and wipes the inherited filesystem.
 fn clone_fork_disks(gdir: &Path, snapshot_dir: &Path, clone_dir: &Path) -> Result<()> {
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     let _ = snapshot_dir;
     // The golden's actual disks that exist, resolved by file presence (`.qcow2`
     // if the golden is itself a clone, else `.raw`) — the same single source of
@@ -1923,9 +1926,9 @@ fn clone_fork_disks(gdir: &Path, snapshot_dir: &Path, clone_dir: &Path) -> Resul
         .filter(|(_, src, _)| src.exists())
         .collect()
     };
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     let disks = read_generation_fork_disks(snapshot_dir)?.unwrap_or_else(fallback_disks);
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     let disks = fallback_disks();
 
     #[cfg(target_os = "linux")]
@@ -1956,14 +1959,21 @@ fn clone_fork_disks(gdir: &Path, snapshot_dir: &Path, clone_dir: &Path) -> Resul
     }
     #[cfg(target_os = "macos")]
     {
-        // macOS uses clonefile (APFS CoW), keeping the golden's disk format.
-        for (_, src, _) in &disks {
-            let dst = clone_dir.join(src.file_name().unwrap());
+        // macOS uses clonefile (APFS CoW) over the immutable generation disk,
+        // keeping its source format while the running VM writes a new overlay.
+        for (raw, src, format) in &disks {
+            let dst = match format {
+                crate::data::disk::DiskFormat::Raw => clone_dir.join(raw),
+                crate::data::disk::DiskFormat::Qcow2 => {
+                    clone_dir.join(Path::new(raw).with_extension("qcow2"))
+                }
+            };
             crate::disk_utils::clone_or_copy_file(src, &dst)
                 .map_err(|e| Error::agent("clone disk", format!("{}: {e}", src.display())))?;
-            let src_marker = src.with_extension("formatted");
+            let marker = Path::new(raw).with_extension("formatted");
+            let src_marker = gdir.join(&marker);
             if src_marker.exists() {
-                let _ = std::fs::copy(&src_marker, dst.with_extension("formatted"));
+                let _ = std::fs::copy(&src_marker, clone_dir.join(&marker));
             }
         }
     }
@@ -3224,7 +3234,7 @@ mod tests {
         );
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]
     fn atomic_snapshot_metadata_never_overwrites_a_published_file() {
         let temp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Resume macOS fork sources on private RAM and disk generations while preserving nested forks, batch forks, and existing Linux behavior.