### PR TITLE
Pin libkrun to the merged continuation commit

### DIFF
--- a/lib/libkrun.provenance
+++ b/lib/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=d0c6754e5560017fb7d0d46e724310a7c6bd9098
+libkrun=09cf9287e1cc83ad6bdb11a87e81a0fb60ae2157
 libkrunfw=8f1307644bdcb95fe1343bf0d6ccf30aa22f1549

--- a/lib/linux-aarch64/libkrun.provenance
+++ b/lib/linux-aarch64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=d0c6754e5560017fb7d0d46e724310a7c6bd9098
+libkrun=09cf9287e1cc83ad6bdb11a87e81a0fb60ae2157
 libkrunfw=8f1307644bdcb95fe1343bf0d6ccf30aa22f1549

--- a/lib/linux-x86_64/libkrun.provenance
+++ b/lib/linux-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=d0c6754e5560017fb7d0d46e724310a7c6bd9098
+libkrun=09cf9287e1cc83ad6bdb11a87e81a0fb60ae2157
 libkrunfw=8f1307644bdcb95fe1343bf0d6ccf30aa22f1549

--- a/lib/windows-x86_64/libkrun.provenance
+++ b/lib/windows-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=d0c6754e5560017fb7d0d46e724310a7c6bd9098
+libkrun=09cf9287e1cc83ad6bdb11a87e81a0fb60ae2157
 libkrunfw=8f1307644bdcb95fe1343bf0d6ccf30aa22f1549


### PR DESCRIPTION
Pins SmolVM and its artifact provenance to the durable libkrun main commit produced by the squash merge.