### PR TITLE
Report why a container failed to create and stop the Vulkan injection shadowing image libraries

### DIFF
--- a/crates/smolvm-agent/src/crun.rs
+++ b/crates/smolvm-agent/src/crun.rs
@@ -161,6 +161,52 @@ fn process_children(pid: libc::pid_t) -> Vec<libc::pid_t> {
         .collect()
 }
 
+/// Where crun records its own diagnostics for a [`CrunCommand::create`].
+///
+/// `crun create` hands its stdout and stderr to the container process, so the
+/// builder cannot capture them to find out why a create failed. `--log` is the
+/// one channel that carries crun's errors without touching container stdio.
+pub fn create_log_path(container_id: &str) -> PathBuf {
+    // Part of the id reaches here from a machine name, so it is reduced to
+    // characters that cannot walk out of the run directory.
+    let stem: String = container_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    Path::new(paths::CONTAINERS_RUN_DIR).join(format!("create-{stem}.log"))
+}
+
+/// Read back and remove the diagnostics crun recorded for a failed create.
+/// Empty when crun logged nothing, so callers should fall back to stderr.
+pub fn take_create_log(container_id: &str) -> String {
+    let path = create_log_path(container_id);
+    let text = std::fs::read_to_string(&path).unwrap_or_default();
+    let _ = std::fs::remove_file(&path);
+    text.trim().to_string()
+}
+
+/// Best available explanation for a failed create: crun's log, its stderr when
+/// the log is empty, and failing both the exit status -- which at least
+/// distinguishes a rejected config from a crun that died on a signal.
+pub fn create_failure_reason(container_id: &str, output: &std::process::Output) -> String {
+    let logged = take_create_log(container_id);
+    if !logged.is_empty() {
+        return logged;
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr = stderr.trim();
+    if !stderr.is_empty() {
+        return stderr.to_string();
+    }
+    format!("crun {} and reported nothing", output.status)
+}
+
 impl CrunCommand {
     /// Create a new crun command with standard configuration.
     ///
@@ -188,10 +234,23 @@ impl CrunCommand {
     /// Create a container: `crun create --bundle <path> <id>`
     ///
     /// This puts the container in "created" state, ready for `crun start`.
-    /// Stdio defaults to null because capturing pipes can block when child
-    /// processes inherit file descriptors.
+    /// Stdio is null because the created container inherits it: capturing the
+    /// pipes would make `output()` block until the container itself exits.
+    /// crun's own diagnostics therefore go to [`create_log_path`], which a
+    /// failed create reads back with [`take_create_log`].
     pub fn create(bundle_dir: &Path, container_id: &str) -> Self {
+        let log_path = create_log_path(container_id);
+        // A stale log from an earlier attempt would be misreported as this
+        // one's reason, and crun refuses to start if it cannot open the file.
+        let log_ready = std::fs::create_dir_all(paths::CONTAINERS_RUN_DIR).is_ok()
+            && match std::fs::remove_file(&log_path) {
+                Ok(()) => true,
+                Err(e) => e.kind() == std::io::ErrorKind::NotFound,
+            };
         let mut c = Self::new();
+        if log_ready {
+            c.cmd.args(["--log", &log_path.to_string_lossy()]);
+        }
         c.cmd.args([
             "create",
             "--bundle",

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -3831,11 +3831,13 @@ fn handle_run_detached(
     match create_output {
         Ok(output) if output.status.success() => {}
         Ok(output) => {
-            let stderr = String::from_utf8_lossy(&output.stderr);
             send_response(
                 stream,
                 &AgentResponse::error(
-                    format!("crun create failed: {}", stderr.trim()),
+                    format!(
+                        "crun create failed: {}",
+                        crun::create_failure_reason(&container_id, &output)
+                    ),
                     error_codes::SPAWN_FAILED,
                 ),
             )?;
@@ -4504,7 +4506,7 @@ fn ensure_main_container(
     if !create.status.success() {
         return Err(format!(
             "keep-alive crun create failed: {}",
-            String::from_utf8_lossy(&create.stderr).trim()
+            crun::create_failure_reason(&container_id, &create)
         )
         .into());
     }

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -783,13 +783,29 @@ fn ordered_packed_layer_names(packed_dir: &Path) -> Result<Vec<String>> {
         let entry = entry?;
         if entry.path().is_dir() {
             let name = entry.file_name().to_string_lossy().to_string();
-            if !name.ends_with(".tar") {
+            // A packed store is a volume root on macOS, so it always carries
+            // filesystem bookkeeping directories. They are not image layers,
+            // and mistaking one for the whole image builds a rootfs out of it.
+            if !name.ends_with(".tar") && !is_volume_metadata(&entry.file_name()) {
                 present.insert(name);
             }
         }
     }
 
+    // A store with no usable layer directory at all cannot produce the image's
+    // filesystem. Returning an empty list here would hand the caller an overlay
+    // with no lower layer, which surfaces much later as a missing executable.
+    if present.is_empty() {
+        return Err(StorageError::new(format!(
+            "no image layers are present in {}. The image has to be unpacked again \
+             before this machine can start.",
+            packed_dir.display()
+        )));
+    }
+
     // Prefer the explicit order index when it resolves to layers we actually have.
+    // A stale index that names a layer we do not have falls back to the name sort
+    // below rather than dropping the real layers that are here.
     if let Ok(contents) = std::fs::read_to_string(packed_dir.join(LAYER_ORDER_FILE)) {
         let ordered: Vec<String> = contents
             .lines()
@@ -2578,6 +2594,71 @@ pub fn garbage_collect(dry_run: bool) -> Result<u64> {
 ///
 /// Encapsulates the common logic for preparing overlay directories,
 /// mounting layers, and creating OCI bundles.
+/// Entries a filesystem puts at a volume root that never belong to an image
+/// layer. A layer store on macOS is an APFS volume, so it always carries at
+/// least `.fseventsd` -- which made an emptied store look populated and let a
+/// container start on an image that no longer had a filesystem.
+fn is_volume_metadata(name: &std::ffi::OsStr) -> bool {
+    matches!(
+        name.to_string_lossy().as_ref(),
+        ".fseventsd"
+            | ".Spotlight-V100"
+            | ".Trashes"
+            | ".TemporaryItems"
+            | ".DS_Store"
+            | ".DocumentRevisions-V100"
+            | "lost+found"
+    )
+}
+
+/// Reject lower layers that cannot produce the image's filesystem.
+///
+/// A single empty layer is legal -- an OCI layer may carry only metadata or
+/// whiteouts. Every layer being empty is not: the image then contributes
+/// nothing, the container runs on its upper layer alone, and the first sign of
+/// trouble is `executable file not found in $PATH` for a binary the image was
+/// supposed to provide. Failing here names the real problem instead.
+fn verify_layers(lowerdirs: &[String]) -> Result<()> {
+    let mut populated = 0usize;
+    for layer_path in lowerdirs {
+        let path = Path::new(layer_path);
+        if !path.exists() {
+            return Err(StorageError::new(format!(
+                "layer path does not exist: {}",
+                layer_path
+            )));
+        }
+        let entry_count = std::fs::read_dir(path)
+            .map(|entries| {
+                entries
+                    .filter_map(|e| e.ok())
+                    .filter(|e| !is_volume_metadata(&e.file_name()))
+                    .count()
+            })
+            .unwrap_or(0);
+        if entry_count == 0 {
+            warn!(layer = %layer_path, "layer directory is empty");
+        } else {
+            populated += 1;
+        }
+    }
+    if populated == 0 && !lowerdirs.is_empty() {
+        return Err(StorageError::new(format!(
+            "the machine's image layers are missing: all {} unpacked layer \
+             director{} empty, so the container would have no image \
+             filesystem. The image has to be unpacked again before this \
+             machine can start.",
+            lowerdirs.len(),
+            if lowerdirs.len() == 1 {
+                "y is"
+            } else {
+                "ies are"
+            },
+        )));
+    }
+    Ok(())
+}
+
 struct OverlaySetup {
     overlay_root: PathBuf,
     upper_path: PathBuf,
@@ -2687,23 +2768,7 @@ impl OverlaySetup {
 
     /// Verify that all layer paths exist and log warnings for empty layers.
     fn verify_layers(&self, lowerdirs: &[String]) -> Result<()> {
-        for layer_path in lowerdirs {
-            let path = Path::new(layer_path);
-            if !path.exists() {
-                return Err(StorageError::new(format!(
-                    "layer path does not exist: {}",
-                    layer_path
-                )));
-            }
-            // Check if layer has contents
-            let entry_count = std::fs::read_dir(path)
-                .map(|entries| entries.count())
-                .unwrap_or(0);
-            if entry_count == 0 {
-                warn!(layer = %layer_path, "layer directory is empty");
-            }
-        }
-        Ok(())
+        verify_layers(lowerdirs)
     }
 
     /// Mount the overlay filesystem with fallback from multi-lowerdir to sequential.
@@ -3685,7 +3750,7 @@ fn establish_keepalive_container(
     if !create.status.success() {
         return Err(StorageError::new(format!(
             "keep-alive crun create failed: {}",
-            String::from_utf8_lossy(&create.stderr).trim()
+            crate::crun::create_failure_reason(&container_id, &create)
         )));
     }
 
@@ -4635,6 +4700,106 @@ fn dir_size(path: &Path) -> Result<u64> {
 
 #[cfg(test)]
 mod tests {
+    /// One empty layer is a legal OCI layer (metadata or whiteouts only), so
+    /// verification must not reject an image just for containing one.
+    #[test]
+    fn a_single_empty_layer_beside_a_populated_one_is_accepted() {
+        let dir = tempfile::tempdir().unwrap();
+        let empty = dir.path().join("empty");
+        let full = dir.path().join("full");
+        std::fs::create_dir_all(&empty).unwrap();
+        std::fs::create_dir_all(full.join("usr")).unwrap();
+        let layers = vec![
+            empty.to_string_lossy().into_owned(),
+            full.to_string_lossy().into_owned(),
+        ];
+        assert!(verify_layers(&layers).is_ok());
+    }
+
+    /// Every layer empty means the container would run on its upper layer
+    /// alone. That used to be accepted with only a warning, and surfaced much
+    /// later as a misleading "executable file not found in $PATH".
+    #[test]
+    fn layers_that_are_all_empty_are_rejected_by_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a");
+        let b = dir.path().join("b");
+        std::fs::create_dir_all(&a).unwrap();
+        std::fs::create_dir_all(&b).unwrap();
+        let layers = vec![
+            a.to_string_lossy().into_owned(),
+            b.to_string_lossy().into_owned(),
+        ];
+        let err = verify_layers(&layers).expect_err("all-empty layers must not be accepted");
+        assert!(
+            err.to_string().contains("image layers are missing"),
+            "error should name the real problem, got: {err}"
+        );
+    }
+
+    /// The failure this pair of fixes came from: an emptied macOS layer store
+    /// still has `.fseventsd`, which was enumerated as the image's only layer,
+    /// so the container came up on a rootfs made of filesystem bookkeeping.
+    #[test]
+    fn volume_metadata_is_never_enumerated_as_an_image_layer() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".fseventsd")).unwrap();
+        std::fs::create_dir_all(dir.path().join(".Spotlight-V100")).unwrap();
+        let err = ordered_packed_layer_names(dir.path())
+            .expect_err("bookkeeping directories are not layers");
+        assert!(err.to_string().contains("no image layers"), "got: {err}");
+    }
+
+    /// A store with no usable layer directory cannot produce the image, so it
+    /// must fail by name rather than hand back an empty layer list.
+    #[test]
+    fn a_store_with_no_usable_layer_directory_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".fseventsd")).unwrap();
+        std::fs::write(dir.path().join(LAYER_ORDER_FILE), "aaaa1111bbbb\n").unwrap();
+        let err = ordered_packed_layer_names(dir.path())
+            .expect_err("a store holding no layer must not resolve");
+        assert!(err.to_string().contains("no image layers"), "got: {err}");
+    }
+
+    /// The fallback still works for a legacy store that has no index at all.
+    #[test]
+    fn a_store_without_an_order_index_still_sorts_by_name() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("bbbb")).unwrap();
+        std::fs::create_dir_all(dir.path().join("aaaa")).unwrap();
+        let names = ordered_packed_layer_names(dir.path()).unwrap();
+        assert_eq!(names, vec!["aaaa".to_string(), "bbbb".to_string()]);
+    }
+
+    /// The exact shape that got through: a layer store that is an emptied
+    /// macOS volume still carries `.fseventsd`, which counted as content and
+    /// let a container start on an image with no filesystem.
+    #[test]
+    fn a_layer_holding_only_volume_metadata_counts_as_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = dir.path().join("layers-cs");
+        std::fs::create_dir_all(store.join(".fseventsd")).unwrap();
+        std::fs::write(store.join(".DS_Store"), b"").unwrap();
+        let layers = vec![store.to_string_lossy().into_owned()];
+        let err = verify_layers(&layers).expect_err("volume metadata is not image content");
+        assert!(
+            err.to_string().contains("image layers are missing"),
+            "got: {err}"
+        );
+    }
+
+    /// A missing layer directory is still reported as such, not folded into
+    /// the all-empty case.
+    #[test]
+    fn a_missing_layer_path_is_reported_as_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let gone = dir.path().join("gone");
+        let layers = vec![gone.to_string_lossy().into_owned()];
+        let err = verify_layers(&layers).expect_err("a missing layer must not be accepted");
+        assert!(err.to_string().contains("does not exist"), "got: {err}");
+    }
+
     use super::*;
     // OCI layer helpers now live in the shared crate; these tests exercise them
     // through its public API (the crate also unit-tests them independently).

--- a/crates/smolvm-agent/src/vulkan.rs
+++ b/crates/smolvm-agent/src/vulkan.rs
@@ -80,7 +80,21 @@ fn inject_into_container_if(
 
     // Loader fallback for images without libvulkan.so.1 — appended, so an
     // image-provided loader earlier on the path still wins.
-    append_ld_library_path(&mut spec.process.env, CONTAINER_BUNDLE_DIR);
+    // 🔴 Only for images that ship no Vulkan loader of their own.
+    //
+    // Every LD_LIBRARY_PATH entry outranks the system paths, so exposing the
+    // whole bundle also shadows the libdrm and libexpat it carries -- against
+    // which the image's own Mesa was not built. Measured on Arch: with the
+    // bundle on the path, `eglInitialize` fails outright and every GL client in
+    // the container falls back to software. The injection meant to add Vulkan
+    // was silently removing OpenGL.
+    //
+    // The bundled driver resolves its dependencies from any normal image
+    // (verified: Venus enumerates with LD_LIBRARY_PATH unset), so the path is
+    // only needed when there is no loader to resolve against.
+    if !image_has_vulkan_loader(rootfs) {
+        append_ld_library_path(&mut spec.process.env, CONTAINER_BUNDLE_DIR);
+    }
 }
 
 /// Append the Vulkan loader pin (and the bundle's loader path) to an explicit
@@ -167,6 +181,22 @@ fn is_musl_image(rootfs: &std::path::Path) -> bool {
                 .any(|e| e.file_name().to_string_lossy().starts_with("ld-musl-"))
         })
         .unwrap_or(false)
+}
+
+/// Does the image ship its own Vulkan loader?
+///
+/// The bundle carries one for images that have none, but putting it on the
+/// library path is only safe when nothing else would be shadowed by it.
+fn image_has_vulkan_loader(rootfs: &std::path::Path) -> bool {
+    [
+        "usr/lib",
+        "usr/lib64",
+        "lib",
+        "usr/lib/x86_64-linux-gnu",
+        "usr/lib/aarch64-linux-gnu",
+    ]
+    .iter()
+    .any(|dir| rootfs.join(dir).join("libvulkan.so.1").exists())
 }
 
 /// Append `dir` to the spec's `LD_LIBRARY_PATH`, preserving an image-provided


### PR DESCRIPTION
A failed container create could never report a reason because the builder nulls crun's stdio, and the Vulkan driver bundle was placed on LD_LIBRARY_PATH for every image, shadowing the libdrm and libexpat the image's own Mesa and Python were built against.