### PR TITLE
Expose the portable checkpoint lifecycle

### DIFF
--- a/lib/libkrun.provenance
+++ b/lib/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=09cf9287e1cc83ad6bdb11a87e81a0fb60ae2157
+libkrun=601f6515d2757a4baf9f3190088a19b43020f6d5
 libkrunfw=8f1307644bdcb95fe1343bf0d6ccf30aa22f1549

--- a/lib/linux-aarch64/libkrun.provenance
+++ b/lib/linux-aarch64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=09cf9287e1cc83ad6bdb11a87e81a0fb60ae2157
+libkrun=601f6515d2757a4baf9f3190088a19b43020f6d5
 libkrunfw=8f1307644bdcb95fe1343bf0d6ccf30aa22f1549

--- a/lib/linux-aarch64/libkrun.so
+++ b/lib/linux-aarch64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:48d468c93ec9aadd73aa29958a75b56b9f65a8e0aded71e0356a66d384acbbef
-size 7615040
+oid sha256:929bde6380f58ab3c03e7f2e454f7a8a850c22cb4195a1d640b6664f2c11207d
+size 7645536

--- a/lib/linux-aarch64/libkrun.so.2.0.0
+++ b/lib/linux-aarch64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:48d468c93ec9aadd73aa29958a75b56b9f65a8e0aded71e0356a66d384acbbef
-size 7615040
+oid sha256:929bde6380f58ab3c03e7f2e454f7a8a850c22cb4195a1d640b6664f2c11207d
+size 7645536

--- a/lib/linux-x86_64/libkrun.provenance
+++ b/lib/linux-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=09cf9287e1cc83ad6bdb11a87e81a0fb60ae2157
+libkrun=601f6515d2757a4baf9f3190088a19b43020f6d5
 libkrunfw=8f1307644bdcb95fe1343bf0d6ccf30aa22f1549

--- a/lib/linux-x86_64/libkrun.so
+++ b/lib/linux-x86_64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bed4d514db5f212ffe1296571dfb23e16daa78ddfde27cc93bd4b3ee5cb786de
-size 8482840
+oid sha256:3f517657b89b8db8da8678b32ca49c726aa880f6f615310504e11eb8572fcb7b
+size 8478704

--- a/lib/linux-x86_64/libkrun.so.2.0.0
+++ b/lib/linux-x86_64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bed4d514db5f212ffe1296571dfb23e16daa78ddfde27cc93bd4b3ee5cb786de
-size 8482840
+oid sha256:3f517657b89b8db8da8678b32ca49c726aa880f6f615310504e11eb8572fcb7b
+size 8478704

--- a/lib/windows-x86_64/libkrun.provenance
+++ b/lib/windows-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=09cf9287e1cc83ad6bdb11a87e81a0fb60ae2157
+libkrun=601f6515d2757a4baf9f3190088a19b43020f6d5
 libkrunfw=8f1307644bdcb95fe1343bf0d6ccf30aa22f1549

--- a/src/embedded/runtime.rs
+++ b/src/embedded/runtime.rs
@@ -54,6 +54,63 @@ impl EmbeddedRuntime {
         })
     }
 
+    /// Capture a running checkpointable machine into a portable artifact.
+    ///
+    /// The source resumes as soon as its consistent RAM/disk boundary is
+    /// staged; compression continues without holding the source pause.
+    pub fn checkpoint_machine(
+        &self,
+        name: &str,
+        output: &std::path::Path,
+        options: &crate::portable_checkpoint::CaptureOptions,
+    ) -> Result<crate::portable_checkpoint::CaptureResult> {
+        self.with_name_lock(name, || {
+            crate::portable_checkpoint::capture_to_path(name, output, options)
+        })
+    }
+
+    /// Create a stopped machine from a portable live checkpoint artifact.
+    ///
+    /// Its first start resumes the captured execution state. The restored
+    /// machine is also a fork/checkpoint source, which makes it suitable as a
+    /// durable rollback root.
+    pub fn restore_checkpoint_machine(&self, name: &str, artifact: &std::path::Path) -> Result<()> {
+        self.with_name_lock(name, || {
+            crate::portable_checkpoint::restore_from_path(&self.db, name, artifact)
+        })
+    }
+
+    /// Restore and start a checkpoint for a detached CLI operation.
+    ///
+    /// The VMM outlives the caller, unlike the process-owned SDK handle.
+    pub fn restore_checkpoint_machine_detached(
+        &self,
+        name: &str,
+        artifact: &std::path::Path,
+    ) -> Result<()> {
+        self.with_name_lock(name, || {
+            crate::portable_checkpoint::restore_from_path(&self.db, name, artifact)?;
+            let start = (|| -> Result<VmHandle> {
+                let started = control::start_vm(&self.db, name)?;
+                let mut handle = started.handle;
+                if started.freshly_started {
+                    self.launch_image_workload(name, &mut handle)?;
+                }
+                Ok(handle)
+            })();
+            match start {
+                Ok(handle) => {
+                    handle.detach();
+                    Ok(())
+                }
+                Err(error) => {
+                    let _ = control::delete_vm(&self.db, name);
+                    Err(error)
+                }
+            }
+        })
+    }
+
     /// Reclaim shim-managed sandbox VMs whose process is gone (node reboot or a
     /// shim crash left the record + disks behind). See
     /// [`control::reconcile_runtime_machines`]. Returns the count reclaimed.
@@ -180,8 +237,8 @@ impl EmbeddedRuntime {
     /// Fork a running, forkable `golden` into a new `clone` (copy-on-write guest
     /// RAM + disks, same host) and cache the clone's handle so it can be exec'd
     /// by name. `ports` are `(host, guest)` inbound forwards for the clone; empty
-    /// remaps the golden's forwards to fresh host ports. The golden freezes as the
-    /// shared base and must not be started again while clones exist.
+    /// remaps the golden's forwards to fresh host ports. Supported hosts resume
+    /// the source after publishing a consistent fork generation.
     pub fn fork_machine(&self, golden: &str, clone: &str, ports: &[(u16, u16)]) -> Result<()> {
         self.with_name_locks(&[golden, clone], || {
             let handle = control::fork_vm(&self.db, golden, clone, ports)?;
@@ -238,6 +295,31 @@ impl EmbeddedRuntime {
             };
             for (name, handle) in started {
                 registry.insert(name, Arc::new(Mutex::new(handle)));
+            }
+            Ok(())
+        })
+    }
+
+    /// Fork several machines for a detached CLI operation. The group is
+    /// prepared transactionally from one generation and every successful clone
+    /// outlives this process.
+    pub fn fork_machines_detached(
+        &self,
+        golden: &str,
+        clones: &[String],
+        ports: &[(u16, u16)],
+        parallel: usize,
+    ) -> Result<()> {
+        let mut lock_names = Vec::with_capacity(clones.len() + 1);
+        lock_names.push(golden);
+        lock_names.extend(clones.iter().map(String::as_str));
+        self.with_name_locks(&lock_names, || {
+            let requests: Vec<_> = clones
+                .iter()
+                .map(|name| (name.clone(), ports.to_vec()))
+                .collect();
+            for (_, handle) in control::fork_vm_batch(&self.db, golden, &requests, parallel)? {
+                handle.detach();
             }
             Ok(())
         })

--- a/src/portable_checkpoint.rs
+++ b/src/portable_checkpoint.rs
@@ -21,7 +21,7 @@ use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
 /// Current portable-checkpoint metadata version.
-pub const FORMAT_VERSION: u32 = 3;
+pub const FORMAT_VERSION: u32 = 4;
 /// libkrun VM/vCPU/device-state compatibility identifier.
 pub const RUNTIME_ABI: &str = "libkrun-portable-snapshot-v1";
 /// Device topology supported by the initial portable checkpoint profile.
@@ -53,6 +53,191 @@ pub struct CaptureResult {
     pub source_pause: std::time::Duration,
     /// Complete capture and compression time.
     pub elapsed: std::time::Duration,
+}
+
+/// Restore a portable live checkpoint into a new stopped machine record.
+///
+/// The restored machine preserves the checkpoint's CPU, memory, disks,
+/// workload, and network topology. Its first start resumes the captured live
+/// state, and the machine remains checkpointable so it can immediately serve
+/// as a reusable rollback/fork root.
+pub fn restore_from_path(db: &crate::db::SmolvmDb, name: &str, artifact: &Path) -> Result<()> {
+    crate::data::validate_vm_name(name, "machine name")
+        .map_err(|reason| Error::config("restore checkpoint", reason))?;
+    if !artifact.is_file() {
+        return Err(Error::config(
+            "restore checkpoint",
+            format!("file not found: {}", artifact.display()),
+        ));
+    }
+
+    let manifest = smolvm_pack::packer::read_manifest_from_sidecar(artifact)
+        .map_err(|error| Error::agent("read checkpoint manifest", error.to_string()))?;
+    let checkpoint = manifest.checkpoint.as_ref().ok_or_else(|| {
+        Error::config(
+            "restore checkpoint",
+            format!("{} is not a .smolcheckpoint artifact", artifact.display()),
+        )
+    })?;
+    validate_compatibility(checkpoint)?;
+    crate::platform::ensure_artifact_arch_matches_host(&manifest.platform)?;
+
+    // Reserve the name before touching its data directory. SDKs and CLIs may
+    // run in separate processes, so a process-local lifecycle mutex is not a
+    // sufficient creation boundary.
+    let token = crate::db::SmolvmDb::create_reservation_token();
+    if !db.reserve_vm_create(name, &token)? {
+        return Err(Error::agent_conflict(
+            "restore checkpoint",
+            format!("machine '{name}' already exists or is being created"),
+        ));
+    }
+    let mut reservation = RestoreReservation {
+        db: db.clone(),
+        name: name.to_string(),
+        token,
+        committed: false,
+    };
+
+    let record = restored_record(name, &manifest, checkpoint)?;
+    let footer = smolvm_pack::packer::read_footer_from_sidecar(artifact)
+        .map_err(|error| Error::agent("read checkpoint footer", error.to_string()))?;
+    let vm_data = crate::agent::vm_data_dir(name);
+    let cache_dir = crate::agent::machine_layers_cache_dir(name);
+    let result = (|| -> Result<()> {
+        let _manager = crate::agent::AgentManager::for_vm_with_sizes(
+            name,
+            checkpoint.storage_gib,
+            checkpoint.overlay_gib,
+        )?;
+        smolvm_pack::extract::force_detach_layers_volume(&cache_dir);
+        match std::fs::remove_dir_all(&cache_dir) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(Error::agent(
+                    "clear checkpoint extraction",
+                    error.to_string(),
+                ));
+            }
+        }
+        smolvm_pack::extract::extract_sidecar(artifact, &cache_dir, &footer, false, false)
+            .map_err(|error| Error::agent("extract checkpoint", error.to_string()))?;
+        install(&cache_dir, &vm_data, checkpoint)?;
+        discard_transport_pack(&vm_data)?;
+        if !reservation
+            .db
+            .commit_reserved_vm(name, &reservation.token, &record)?
+        {
+            return Err(Error::agent_conflict(
+                "restore checkpoint",
+                format!("machine '{name}' is no longer reserved"),
+            ));
+        }
+        reservation.committed = true;
+        Ok(())
+    })();
+    smolvm_pack::extract::force_detach_layers_volume(&cache_dir);
+    if let Err(error) = result {
+        if let Err(remove_error) = std::fs::remove_dir_all(&vm_data) {
+            if remove_error.kind() != std::io::ErrorKind::NotFound {
+                tracing::warn!(
+                    machine = %name,
+                    error = %remove_error,
+                    "failed to clean checkpoint restore after error"
+                );
+            }
+        }
+        return Err(error);
+    }
+    Ok(())
+}
+
+struct RestoreReservation {
+    db: crate::db::SmolvmDb,
+    name: String,
+    token: String,
+    committed: bool,
+}
+
+impl Drop for RestoreReservation {
+    fn drop(&mut self) {
+        if !self.committed {
+            if let Err(error) = self
+                .db
+                .release_vm_create_reservation(&self.name, &self.token)
+            {
+                tracing::warn!(
+                    machine = %self.name,
+                    %error,
+                    "failed to release checkpoint restore reservation"
+                );
+            }
+        }
+    }
+}
+
+fn restored_record(
+    name: &str,
+    manifest: &PackManifest,
+    checkpoint: &PortableCheckpointManifest,
+) -> Result<VmRecord> {
+    let network = checkpoint.network.as_ref();
+    let mut record = VmRecord::new(
+        name.to_string(),
+        checkpoint.cpus,
+        checkpoint.memory_mib,
+        Vec::new(),
+        network
+            .into_iter()
+            .flat_map(|network| network.ports.iter())
+            .map(|port| (port.host, port.guest))
+            .collect(),
+        network.is_some_and(|network| network.enabled),
+    );
+    record.storage_gb = checkpoint.storage_gib;
+    record.overlay_gb = checkpoint.overlay_gib;
+    record.allowed_cidrs = network.and_then(|network| network.allowed_cidrs.clone());
+    record.dns_filter_hosts = network.and_then(|network| network.dns_filter_hosts.clone());
+    record.network_backend = restored_network_backend(checkpoint)?;
+    record.dns = network
+        .and_then(|network| network.dns.as_deref())
+        .map(str::parse)
+        .transpose()
+        .map_err(|error: std::net::AddrParseError| {
+            Error::config("restore checkpoint DNS", error.to_string())
+        })?;
+    record.network_name = network.and_then(|network| network.network_name.clone());
+    record.entrypoint = manifest.entrypoint.clone();
+    record.cmd = manifest.cmd.clone();
+    record.env = crate::util::parse_env_list(&manifest.env);
+    record.workdir = manifest.workdir.clone();
+    record.secret_refs = manifest.secret_refs.clone();
+    for (key, reference) in &record.secret_refs {
+        crate::secrets::validate_ref(reference, crate::secrets::ResolutionScope::Untrusted)
+            .map_err(|error| {
+                Error::config(
+                    "restore checkpoint",
+                    format!("secret '{key}': {error} (checkpoints may not carry host secret refs)"),
+                )
+            })?;
+    }
+    if let Some(workload) = &checkpoint.workload {
+        record.image = Some(workload.image.clone());
+        record.user = workload.user.clone();
+        record.fork_overlay_owner = Some(workload.overlay_owner.clone());
+        record.restart.policy = workload
+            .restart_policy
+            .parse()
+            .map_err(|error: String| Error::config("restore checkpoint restart policy", error))?;
+        record.restart.max_retries = workload.restart_max_retries;
+        record.restart.max_backoff_secs = workload.restart_max_backoff_secs;
+    }
+    // The live guest already contains the initialized workload. Re-running
+    // image pull/init on its first start would duplicate side effects.
+    record.init_completed = true;
+    record.forkable = true;
+    Ok(record)
 }
 
 struct SavedVmPause {
@@ -595,23 +780,29 @@ fn disk_target(role: &str, index: usize, format: &str) -> Result<String> {
             )),
         };
     }
-    let alphabet = match role {
-        "storage" => b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ".as_slice(),
-        "overlay" => b"abcdefghijklmnopqrstuvwxyz".as_slice(),
-        _ => {
-            return Err(Error::agent(
-                "checkpoint disk",
-                format!("invalid disk role '{role}'"),
-            ));
-        }
-    };
-    let byte = *alphabet.get(index - 1).ok_or_else(|| {
-        Error::agent(
+    if role != "storage" && role != "overlay" {
+        return Err(Error::agent(
+            "checkpoint disk",
+            format!("invalid disk role '{role}'"),
+        ));
+    }
+    if format != "raw" && format != "qcow2" {
+        return Err(Error::agent(
+            "checkpoint disk",
+            format!("invalid disk format '{format}'"),
+        ));
+    }
+    if index >= 64 {
+        return Err(Error::agent(
             "checkpoint disk",
             format!("{role} backing chain is too deep"),
-        )
-    })?;
-    Ok(char::from(byte).to_string())
+        ));
+    }
+    // Backings live beside the active top layer because qcow2 backing paths
+    // are relative to the image that references them. Use an explicit reserved
+    // namespace: the earlier single-character names eventually collided with
+    // live-fork's `d/` disk-generation directory at deeper lineage depths.
+    Ok(format!(".smolcheckpoint-{role}-{index}.{format}"))
 }
 
 fn inspect_qcow2(path: &Path) -> Result<(Option<String>, Option<String>)> {
@@ -755,24 +946,7 @@ pub fn stage_disk_chains(
             let target = disk_target(role, index, format)?;
             let artifact_path = format!("checkpoint/disks/{role}/{index}");
             let staged = disk_staging.join(index.to_string());
-            if index == 0 {
-                // The active top layer is writable. Capture an independent
-                // reflink/sparse copy at the frozen disk boundary.
-                crate::disk_utils::clone_or_copy_file(&source, &staged)?;
-            } else {
-                // Qcow backings are immutable while referenced by a writable
-                // top. An owned hard link is an exact O(1) snapshot and remains
-                // valid even if the source machine is later deleted.
-                match std::fs::hard_link(&source, &staged) {
-                    Ok(()) => {}
-                    Err(error) if error.raw_os_error() == Some(libc::EXDEV) => {
-                        crate::disk_utils::clone_or_copy_file(&source, &staged)?;
-                    }
-                    Err(error) => {
-                        return Err(Error::agent("stage checkpoint disk", error.to_string()));
-                    }
-                }
-            }
+            stage_checkpoint_disk_layer(&source, &staged, index, format)?;
 
             let next = if format == "qcow2" {
                 let (backing, backing_format) = inspect_qcow2(&source)?;
@@ -837,6 +1011,31 @@ pub fn stage_disk_chains(
         ));
     }
     Ok(disks)
+}
+
+fn stage_checkpoint_disk_layer(
+    source: &Path,
+    staged: &Path,
+    index: usize,
+    format: &str,
+) -> Result<()> {
+    if index == 0 || format == "qcow2" {
+        // The active top is writable, and every qcow2 layer below it has a
+        // backing filename that is rewritten for the self-contained artifact.
+        // Both therefore need a private inode. Hard-linking a qcow2 backing and
+        // editing its header corrupts the live source's disk chain.
+        return crate::disk_utils::clone_or_copy_file(source, staged);
+    }
+
+    // Terminal raw backings are immutable and carry no header to rewrite. An
+    // owned hard link is an exact O(1) snapshot and survives source deletion.
+    match std::fs::hard_link(source, staged) {
+        Ok(()) => Ok(()),
+        Err(error) if error.raw_os_error() == Some(libc::EXDEV) => {
+            crate::disk_utils::clone_or_copy_file(source, staged)
+        }
+        Err(error) => Err(Error::agent("stage checkpoint disk", error.to_string())),
+    }
 }
 
 /// Build an integrity entry for a staged checkpoint payload.
@@ -1576,6 +1775,42 @@ mod tests {
         discard_transport_pack(machine.path()).unwrap();
 
         assert!(!pack.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn qcow2_backing_staging_never_aliases_the_live_header() {
+        use std::os::unix::fs::MetadataExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source");
+        let qcow_staged = dir.path().join("qcow-staged");
+        let raw_staged = dir.path().join("raw-staged");
+        std::fs::write(&source, b"disk-layer").unwrap();
+
+        stage_checkpoint_disk_layer(&source, &qcow_staged, 1, "qcow2").unwrap();
+        assert_ne!(
+            std::fs::metadata(&source).unwrap().ino(),
+            std::fs::metadata(&qcow_staged).unwrap().ino()
+        );
+
+        stage_checkpoint_disk_layer(&source, &raw_staged, 1, "raw").unwrap();
+        assert_eq!(
+            std::fs::metadata(&source).unwrap().ino(),
+            std::fs::metadata(&raw_staged).unwrap().ino()
+        );
+    }
+
+    #[test]
+    fn checkpoint_backings_do_not_collide_with_runtime_directories() {
+        for role in ["storage", "overlay"] {
+            for index in 1..64 {
+                let target = disk_target(role, index, "qcow2").unwrap();
+                assert_ne!(target, "d");
+                assert_ne!(target, "s");
+                assert!(target.starts_with(".smolcheckpoint-"));
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Exposes embedded checkpoint, restore, and detached batch-fork primitives while hardening portable checkpoint disk lineage.