### PR TITLE
[Public Docs] Point contributors at the docs repository from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,4 +289,15 @@ Development
 
 See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
 
+Documentation
+-------------
+
+The user documentation at [smolmachines.com/docs](https://smolmachines.com/docs/) is written in
+[smol-machines/docs](https://github.com/smol-machines/docs), and corrections and new pages are
+welcome there. It is Markdown only, with no build to run; its
+[CONTRIBUTING.md](https://github.com/smol-machines/docs/blob/main/CONTRIBUTING.md) covers the
+page format and how a change reaches the site.
+
+Bugs and feature requests for the runtime stay here.
+
 [Apache-2.0](LICENSE) · made by [@binsquare](https://github.com/BinSquare) · [twitter](https://x.com/binsquares) · [github](https://github.com/smol-machines/smolvm)


### PR DESCRIPTION
The documentation at [smolmachines.com/docs](https://smolmachines.com/docs/) moved into its own public repository, [smol-machines/docs](https://github.com/smol-machines/docs), on 27 August, and the website now consumes it as a submodule. Nothing in this repository says so.

That gap is what [#1074](https://github.com/smol-machines/smolvm/issues/1074) ran into: a contributor who wanted to expand the Smolfile page searched the whole organization for its title, got no match, and had to open an issue to ask. This repository has no `CONTRIBUTING.md` and no pull request or issue template, so the README is the only place the answer can live.

Adds a short Documentation section stating three things a would-be contributor needs: where the pages are, that the repository is Markdown only with no build to run, and that runtime bugs and feature requests still belong here rather than there. The linked `CONTRIBUTING.md` in the docs repository covers the page format, how a file maps to a URL, and the review path.

No behavior changes and nothing outside `README.md` is touched.
