### PR TITLE
Seed artifact disks before VM manager initialization

### DIFF
--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -3217,6 +3217,31 @@ mod tests {
     }
 
     #[test]
+    fn manager_open_uses_preseeded_qcow_disks_without_creating_raw_disks() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage_qcow = temp.path().join("storage.qcow2");
+        let overlay_qcow = temp.path().join("overlay.qcow2");
+        std::fs::write(&storage_qcow, b"QFI\xfb-storage").unwrap();
+        std::fs::write(&overlay_qcow, b"QFI\xfb-overlay").unwrap();
+
+        let (storage_path, storage_format) =
+            resolve_disk_image(temp.path(), crate::storage::STORAGE_DISK_FILENAME);
+        let (overlay_path, overlay_format) =
+            resolve_disk_image(temp.path(), crate::storage::OVERLAY_DISK_FILENAME);
+        let storage =
+            open_storage_disk_for_manager(&storage_path, storage_format, Some(20)).unwrap();
+        let overlay =
+            open_overlay_disk_for_manager(&overlay_path, overlay_format, Some(10)).unwrap();
+
+        assert_eq!(storage.path(), storage_qcow);
+        assert_eq!(storage.format(), DiskFormat::Qcow2);
+        assert_eq!(overlay.path(), overlay_qcow);
+        assert_eq!(overlay.format(), DiskFormat::Qcow2);
+        assert!(!temp.path().join("storage.raw").exists());
+        assert!(!temp.path().join("overlay.raw").exists());
+    }
+
+    #[test]
     fn restored_cuda_clones_fail_faster_than_other_boots() {
         assert_eq!(agent_ready_timeout(true), Duration::from_secs(10));
         assert_eq!(agent_ready_timeout(false), Duration::from_secs(30));

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -906,6 +906,59 @@ impl AgentManager {
         // different name).
         let storage_dir = ensure_vm_dir(&name)?;
 
+        Self::open_for_vm_at(name, rootfs_path, storage_dir, storage_gb, overlay_gb)
+    }
+
+    /// Prepare a named VM's final disks before opening them through the manager.
+    ///
+    /// VM-mode artifacts use this to avoid initializing generic blank disk
+    /// templates that the artifact restore would immediately replace. The
+    /// rootfs lookup and name binding still happen before `prepare`, preserving
+    /// the validation and collision checks performed by ordinary VM creation.
+    pub fn for_vm_with_prepared_disks<F>(
+        name: impl Into<String>,
+        storage_gb: Option<u64>,
+        overlay_gb: Option<u64>,
+        prepare: F,
+    ) -> Result<Self>
+    where
+        F: FnOnce(&Path) -> Result<()>,
+    {
+        let name = name.into();
+        let rootfs_path = Self::default_rootfs_path()?;
+        let storage_dir = ensure_vm_dir(&name)?;
+        Self::for_vm_with_prepared_disks_at(
+            name,
+            rootfs_path,
+            storage_dir,
+            storage_gb,
+            overlay_gb,
+            prepare,
+        )
+    }
+
+    fn for_vm_with_prepared_disks_at<F>(
+        name: String,
+        rootfs_path: PathBuf,
+        storage_dir: PathBuf,
+        storage_gb: Option<u64>,
+        overlay_gb: Option<u64>,
+        prepare: F,
+    ) -> Result<Self>
+    where
+        F: FnOnce(&Path) -> Result<()>,
+    {
+        prepare(&storage_dir)?;
+        Self::open_for_vm_at(name, rootfs_path, storage_dir, storage_gb, overlay_gb)
+    }
+
+    fn open_for_vm_at(
+        name: String,
+        rootfs_path: PathBuf,
+        storage_dir: PathBuf,
+        storage_gb: Option<u64>,
+        overlay_gb: Option<u64>,
+    ) -> Result<Self> {
         // A fork clone has a `.qcow2` copy-on-write overlay in place of the
         // `.raw` disk; detect it by file presence (the on-disk file is the
         // source of truth) and open it as-is rather than creating/formatting.
@@ -3239,6 +3292,88 @@ mod tests {
         assert_eq!(overlay.format(), DiskFormat::Qcow2);
         assert!(!temp.path().join("storage.raw").exists());
         assert!(!temp.path().join("overlay.raw").exists());
+    }
+
+    #[test]
+    fn vm_artifact_raw_fallback_is_seeded_before_generic_disk_initialization() {
+        let temp = tempfile::tempdir().unwrap();
+        let rootfs = temp.path().join("rootfs");
+        let disk_dir = temp.path().join("vm");
+        let pack_dir = temp.path().join("pack");
+        std::fs::create_dir_all(&rootfs).unwrap();
+        std::fs::create_dir_all(&disk_dir).unwrap();
+        std::fs::create_dir_all(&pack_dir).unwrap();
+
+        let overlay_template = pack_dir.join("overlay-template.raw");
+        let storage_template = pack_dir.join("storage-template.raw");
+        std::fs::write(&overlay_template, b"artifact-overlay").unwrap();
+        std::fs::write(&storage_template, b"artifact-storage").unwrap();
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&overlay_template)
+            .unwrap()
+            .set_len(4096)
+            .unwrap();
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&storage_template)
+            .unwrap()
+            .set_len(4096)
+            .unwrap();
+
+        let manager = AgentManager::for_vm_with_prepared_disks_at(
+            "artifact-vm".to_string(),
+            rootfs,
+            disk_dir.clone(),
+            None,
+            None,
+            |prepared_dir| {
+                // This is the regression assertion: the old create order opened
+                // AgentManager first, so both generic disks already existed here.
+                assert!(!prepared_dir.join("storage.raw").exists());
+                assert!(!prepared_dir.join("overlay.raw").exists());
+                assert!(!prepared_dir.join("storage.qcow2").exists());
+                assert!(!prepared_dir.join("overlay.qcow2").exists());
+
+                crate::storage::seed_vm_mode_disks(
+                    prepared_dir,
+                    &pack_dir,
+                    crate::storage::VmModeDiskSeedSpec {
+                        // Exercise the portable sparse-copy/raw fallback rather
+                        // than Linux's content-addressed qcow2 base path.
+                        artifact_sha256: None,
+                        overlay_template: Some("overlay-template.raw"),
+                        storage_template: Some("storage-template.raw"),
+                        overlay_logical_size: Some(4096),
+                        storage_logical_size: Some(4096),
+                        overlay_gb: None,
+                        storage_gb: None,
+                    },
+                )
+                .map_err(|error| Error::agent("seed test VM-mode disks", error.to_string()))
+            },
+        )
+        .unwrap();
+
+        assert_eq!(manager.storage_path(), disk_dir.join("storage.raw"));
+        assert_eq!(manager.overlay_path(), disk_dir.join("overlay.raw"));
+        let read_prefix = |path: &Path| {
+            use std::io::Read as _;
+            let mut prefix = [0_u8; 16];
+            std::fs::File::open(path)
+                .unwrap()
+                .read_exact(&mut prefix)
+                .unwrap();
+            prefix
+        };
+        assert_eq!(
+            read_prefix(&disk_dir.join("storage.raw")),
+            *b"artifact-storage"
+        );
+        assert_eq!(
+            read_prefix(&disk_dir.join("overlay.raw")),
+            *b"artifact-overlay"
+        );
     }
 
     #[test]

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -468,6 +468,19 @@ struct VmModeSeed {
     overlay_gb: Option<u64>,
 }
 
+async fn create_agent_manager(
+    name: String,
+    storage_gb: Option<u64>,
+    overlay_gb: Option<u64>,
+) -> Result<AgentManager, ApiError> {
+    tokio::task::spawn_blocking(move || {
+        AgentManager::for_vm_with_sizes(&name, storage_gb, overlay_gb)
+            .map_err(|e| ApiError::internal(format!("failed to create agent manager: {e}")))
+    })
+    .await
+    .map_err(|e| ApiError::internal(format!("task error: {e}")))?
+}
+
 /// Create a new machine.
 #[utoipa::path(
     post,
@@ -673,8 +686,8 @@ pub async fn create_machine(
         // different-arch guest kernel. Guest arch must match; host OS need not.
         crate::platform::ensure_artifact_arch_matches_host(&manifest.platform)
             .map_err(|e| ApiError::BadRequest(e.to_string()))?;
-        // Extraction happens after the agent manager creates this machine's data
-        // dir (below), so the layers land in the machine's own dir, not here.
+        // Extraction happens after the name is reserved and this machine's data
+        // dir is prepared below, so the layers land in the machine's own dir.
         let canonical = path
             .canonicalize()
             .unwrap_or_else(|_| path.to_path_buf())
@@ -864,21 +877,23 @@ pub async fn create_machine(
     // Reserve the name atomically (prevents concurrent creation)
     let guard = ReservationGuard::new(&state, name.clone())?;
 
-    // Create manager (does not boot the VM)
-    let manager = tokio::task::spawn_blocking({
-        let name = name.clone();
-        let storage_gb = restored_storage_gb;
-        let overlay_gb = restored_overlay_gb;
-        move || {
-            AgentManager::for_vm_with_sizes(&name, storage_gb, overlay_gb)
-                .map_err(|e| ApiError::internal(format!("failed to create agent manager: {}", e)))
-        }
-    })
-    .await
-    .map_err(|e| ApiError::internal(format!("task error: {}", e)))??;
+    // VM-mode artifacts carry their final block devices. Their manager must be
+    // opened after those disks are seeded or it initializes generic blank disks
+    // that are immediately discarded. Preserve the existing order for image-mode
+    // artifacts, ordinary creates, and live checkpoints.
+    let mut manager = if vm_seed.is_some() {
+        let name_for_dir = name.clone();
+        tokio::task::spawn_blocking(move || crate::agent::ensure_vm_dir(&name_for_dir))
+            .await
+            .map_err(|e| ApiError::internal(format!("task error: {e}")))?
+            .map_err(|e| ApiError::internal(format!("failed to create machine data dir: {e}")))?;
+        None
+    } else {
+        Some(create_agent_manager(name.clone(), restored_storage_gb, restored_overlay_gb).await?)
+    };
 
-    // Extract the bundle's OCI layers into this machine's own data dir (created
-    // by the manager above) rather than the shared pack cache, so every start is
+    // Extract the bundle's OCI layers into this machine's own data dir rather
+    // than the shared pack cache, so every start is
     // independent of the .smolmachine file surviving and the macOS layers volume
     // is owned 1:1 by the machine. Extraction mounts the case-sensitive volume on
     // macOS; detach it immediately so a created-but-unstarted machine leaves
@@ -940,8 +955,8 @@ pub async fn create_machine(
             // rollback below can remove the data dir cleanly (macOS; no-op on Linux).
             smolvm_pack::extract::force_detach_layers_volume(&cache_dir);
             if let Err(e) = result {
-                // Extraction failed after the manager created the machine's data
-                // dir. guard.complete() will not run, so no DB record persists and
+                // Extraction failed after the machine data dir was created.
+                // guard.complete() will not run, so no DB record persists and
                 // the name is released on drop — but the on-disk dir would be left
                 // orphaned. Roll it back so a retry starts clean. Best-effort: a
                 // remove failure only leaves the orphan, never a worse state.
@@ -959,17 +974,13 @@ pub async fn create_machine(
 
     // VM-mode pack: seed this machine's overlay + storage disks from the packed
     // templates (extracted above) so a start boots the source VM's rootfs rather
-    // than the bare agent-rootfs (the /bin/sh-missing bug). `open_or_create_at`
-    // reuses an existing disk, so seeding once at create persists across starts.
+    // than the bare agent-rootfs (the /bin/sh-missing bug). The manager is opened
+    // only after these final disks exist, and seeding once persists across starts.
     // Mirrors `pack_run`'s VM-mode disk restore (`setup_vm_overlay` +
     // `create_or_copy_storage_disk`).
     if let Some(seed) = vm_seed {
         let name2 = name.clone();
-        let disk_dir = manager
-            .storage_path()
-            .parent()
-            .map(std::path::Path::to_path_buf)
-            .unwrap_or_else(|| vm_data_dir(&name));
+        let disk_dir = vm_data_dir(&name);
         let seed_result = tokio::task::spawn_blocking(move || -> Result<(), ApiError> {
             let cache_dir = crate::agent::machine_layers_cache_dir(&name2);
             // With the shared store, the pack contents live in `_shared/<checksum>`
@@ -1011,6 +1022,20 @@ pub async fn create_machine(
         if let Err(e) = seed_result {
             let _ = std::fs::remove_dir_all(vm_data_dir(&name));
             return Err(e);
+        }
+    }
+
+    // VM-mode disks are now final. Constructing the manager here makes it open
+    // those prepared qcow2/raw files instead of initializing generic templates.
+    if manager.is_none() {
+        let manager_result =
+            create_agent_manager(name.clone(), restored_storage_gb, restored_overlay_gb).await;
+        match manager_result {
+            Ok(created) => manager = Some(created),
+            Err(error) => {
+                let _ = std::fs::remove_dir_all(vm_data_dir(&name));
+                return Err(error);
+            }
         }
     }
 
@@ -1071,7 +1096,7 @@ pub async fn create_machine(
 
     // Complete registration: persists to DB + registers in ApiState
     let complete_result = guard.complete(MachineRegistration {
-        manager,
+        manager: manager.expect("manager is constructed before registration"),
         mounts: host_mount_specs,
         remote_volumes,
         ports: restored_ports,

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -883,10 +883,18 @@ pub async fn create_machine(
     // artifacts, ordinary creates, and live checkpoints.
     let mut manager = if vm_seed.is_some() {
         let name_for_dir = name.clone();
-        tokio::task::spawn_blocking(move || crate::agent::ensure_vm_dir(&name_for_dir))
-            .await
-            .map_err(|e| ApiError::internal(format!("task error: {e}")))?
-            .map_err(|e| ApiError::internal(format!("failed to create machine data dir: {e}")))?;
+        tokio::task::spawn_blocking(move || -> Result<(), ApiError> {
+            // Preserve the manager's cheap rootfs preflight before extraction
+            // creates or populates any machine-owned paths.
+            AgentManager::default_rootfs_path()
+                .map_err(|e| ApiError::internal(format!("failed to resolve agent rootfs: {e}")))?;
+            crate::agent::ensure_vm_dir(&name_for_dir).map_err(|e| {
+                ApiError::internal(format!("failed to create machine data dir: {e}"))
+            })?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| ApiError::internal(format!("task error: {e}")))??;
         None
     } else {
         Some(create_agent_manager(name.clone(), restored_storage_gb, restored_overlay_gb).await?)
@@ -980,8 +988,9 @@ pub async fn create_machine(
     // `create_or_copy_storage_disk`).
     if let Some(seed) = vm_seed {
         let name2 = name.clone();
-        let disk_dir = vm_data_dir(&name);
-        let seed_result = tokio::task::spawn_blocking(move || -> Result<(), ApiError> {
+        let storage_gb = restored_storage_gb;
+        let overlay_gb = restored_overlay_gb;
+        let seed_result = tokio::task::spawn_blocking(move || -> Result<AgentManager, ApiError> {
             let cache_dir = crate::agent::machine_layers_cache_dir(&name2);
             // With the shared store, the pack contents live in `_shared/<checksum>`
             // (the per-machine `pack` dir is an empty mountpoint), so seed the
@@ -1000,37 +1009,29 @@ pub async fn create_machine(
                 } else {
                     (cache_dir, None)
                 };
-            crate::storage::seed_vm_mode_disks(
-                &disk_dir,
-                &pack_content_dir,
-                crate::storage::VmModeDiskSeedSpec {
-                    artifact_sha256: artifact_sha256.as_deref(),
-                    overlay_template: seed.overlay_template.as_deref(),
-                    storage_template: seed.storage_template.as_deref(),
-                    overlay_logical_size: seed.overlay_logical_size,
-                    storage_logical_size: seed.storage_logical_size,
-                    overlay_gb: seed.overlay_gb,
-                    storage_gb: seed.storage_gb,
-                },
-            )
-            .map_err(|e| ApiError::internal(format!("seed VM-mode disks: {}", e)))
+            AgentManager::for_vm_with_prepared_disks(&name2, storage_gb, overlay_gb, |disk_dir| {
+                crate::storage::seed_vm_mode_disks(
+                    disk_dir,
+                    &pack_content_dir,
+                    crate::storage::VmModeDiskSeedSpec {
+                        artifact_sha256: artifact_sha256.as_deref(),
+                        overlay_template: seed.overlay_template.as_deref(),
+                        storage_template: seed.storage_template.as_deref(),
+                        overlay_logical_size: seed.overlay_logical_size,
+                        storage_logical_size: seed.storage_logical_size,
+                        overlay_gb: seed.overlay_gb,
+                        storage_gb: seed.storage_gb,
+                    },
+                )
+                .map_err(|e| crate::Error::agent("seed VM-mode disks", e.to_string()))
+            })
+            .map_err(|e| ApiError::internal(format!("prepare VM-mode disks: {e}")))
         })
         .await
         .map_err(|e| ApiError::internal(format!("task error: {}", e)))?;
         // On failure roll back the data dir the manager created, so a retry starts
         // clean (the reservation guard releases the name but leaves the dir).
-        if let Err(e) = seed_result {
-            let _ = std::fs::remove_dir_all(vm_data_dir(&name));
-            return Err(e);
-        }
-    }
-
-    // VM-mode disks are now final. Constructing the manager here makes it open
-    // those prepared qcow2/raw files instead of initializing generic templates.
-    if manager.is_none() {
-        let manager_result =
-            create_agent_manager(name.clone(), restored_storage_gb, restored_overlay_gb).await;
-        match manager_result {
+        match seed_result {
             Ok(created) => manager = Some(created),
             Err(error) => {
                 let _ = std::fs::remove_dir_all(vm_data_dir(&name));

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -3678,6 +3678,9 @@ impl CreateCmd {
             // templates, only for `seed_vm_mode_disks` to discard them below.
             // Image-mode artifacts and checkpoints retain their existing order.
             let manager = if vm_seed.is_some() {
+                // Preserve the manager's cheap rootfs preflight before any
+                // artifact extraction mutates this machine's data directory.
+                AgentManager::default_rootfs_path()?;
                 smolvm::agent::ensure_vm_dir(&name_for_layers)?;
                 None
             } else {
@@ -3733,38 +3736,33 @@ impl CreateCmd {
             smolvm_pack::extract::force_detach_layers_volume(&cache_dir);
             let (pack_content_dir, artifact_sha256) = result?;
 
-            // VM-mode pack: seed this machine's overlay+storage disks from the
-            // packed templates so a start boots the source VM's rootfs rather than
-            // the bare agent-rootfs. This happens before manager construction, so
-            // the manager opens these final artifact-backed disks directly.
-            if let Some(seed) = &vm_seed {
-                let disk_dir = smolvm::agent::vm_data_dir(&name_for_layers);
-                smolvm::storage::seed_vm_mode_disks(
-                    &disk_dir,
-                    &pack_content_dir,
-                    smolvm::storage::VmModeDiskSeedSpec {
-                        artifact_sha256: artifact_sha256.as_deref(),
-                        overlay_template: seed.overlay_template.as_deref(),
-                        storage_template: seed.storage_template.as_deref(),
-                        overlay_logical_size: seed.overlay_logical_size,
-                        storage_logical_size: seed.storage_logical_size,
-                        overlay_gb: params.overlay_gb,
-                        storage_gb: params.storage_gb,
-                    },
-                )
-                .map_err(|e| smolvm::Error::agent("seed VM-mode disks", e.to_string()))?;
-            }
-
             // VM-mode disks now exist, so construction resolves their qcow2/raw
             // format without touching the generic blank-disk templates. Keep the
             // manager alive through publication, matching the original lifetime.
-            let _manager = match manager {
-                Some(manager) => manager,
-                None => AgentManager::for_vm_with_sizes(
+            let _manager = match (manager, vm_seed.as_ref()) {
+                (Some(manager), _) => manager,
+                (None, Some(seed)) => AgentManager::for_vm_with_prepared_disks(
                     &name_for_layers,
                     params.storage_gb,
                     params.overlay_gb,
+                    |disk_dir| {
+                        smolvm::storage::seed_vm_mode_disks(
+                            disk_dir,
+                            &pack_content_dir,
+                            smolvm::storage::VmModeDiskSeedSpec {
+                                artifact_sha256: artifact_sha256.as_deref(),
+                                overlay_template: seed.overlay_template.as_deref(),
+                                storage_template: seed.storage_template.as_deref(),
+                                overlay_logical_size: seed.overlay_logical_size,
+                                storage_logical_size: seed.storage_logical_size,
+                                overlay_gb: params.overlay_gb,
+                                storage_gb: params.storage_gb,
+                            },
+                        )
+                        .map_err(|e| smolvm::Error::agent("seed VM-mode disks", e.to_string()))
+                    },
                 )?,
+                (None, None) => unreachable!("only VM-mode artifacts defer the manager"),
             };
 
             if let Some(ref checkpoint) = checkpoint {

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -3399,8 +3399,8 @@ impl CreateCmd {
         smolvm::platform::ensure_artifact_arch_matches_host(&manifest.platform)?;
 
         // Read the footer now; the bundle is extracted into the machine's own
-        // data dir after `create_vm` succeeds (below), so a duplicate-name create
-        // cannot clobber an existing machine's layers.
+        // data dir while the name reservation is held below, so a duplicate-name
+        // create cannot clobber an existing machine's layers.
         let footer = smolvm_pack::packer::read_footer_from_sidecar(sidecar_path)
             .map_err(|e| smolvm::Error::agent("read sidecar footer", e.to_string()))?;
 
@@ -3672,11 +3672,21 @@ impl CreateCmd {
         // extract before publishing the VM row. Other processes either see the
         // reservation conflict or the finished VM, never a half-created record.
         let create_result = (|| -> smolvm::Result<()> {
-            let manager = AgentManager::for_vm_with_sizes(
-                &name_for_layers,
-                params.storage_gb,
-                params.overlay_gb,
-            )?;
+            // A VM-mode artifact carries its final block devices. Do not open the
+            // manager until those disks are in place: an empty machine directory
+            // makes manager construction initialize the generic 10/20 GiB disk
+            // templates, only for `seed_vm_mode_disks` to discard them below.
+            // Image-mode artifacts and checkpoints retain their existing order.
+            let manager = if vm_seed.is_some() {
+                smolvm::agent::ensure_vm_dir(&name_for_layers)?;
+                None
+            } else {
+                Some(AgentManager::for_vm_with_sizes(
+                    &name_for_layers,
+                    params.storage_gb,
+                    params.overlay_gb,
+                )?)
+            };
 
             let cache_dir = smolvm::agent::machine_layers_cache_dir(&name_for_layers);
             smolvm_pack::extract::force_detach_layers_volume(&cache_dir);
@@ -3725,18 +3735,10 @@ impl CreateCmd {
 
             // VM-mode pack: seed this machine's overlay+storage disks from the
             // packed templates so a start boots the source VM's rootfs rather than
-            // the bare agent-rootfs. Shared with the serve API create path: it
-            // resizes the truncated templates into valid raw disks and removes the
-            // manager's default `.qcow2` overlays so the start resolves these.
-            // (Writing the resized copy onto `manager.overlay_path()` — the default
-            // `.qcow2` — handed the guest raw bytes named `.qcow2`, the /bin/sh-missing
-            // bug's disk counterpart.)
+            // the bare agent-rootfs. This happens before manager construction, so
+            // the manager opens these final artifact-backed disks directly.
             if let Some(seed) = &vm_seed {
-                let disk_dir = manager
-                    .storage_path()
-                    .parent()
-                    .map(std::path::Path::to_path_buf)
-                    .unwrap_or_else(|| smolvm::agent::vm_data_dir(&name_for_layers));
+                let disk_dir = smolvm::agent::vm_data_dir(&name_for_layers);
                 smolvm::storage::seed_vm_mode_disks(
                     &disk_dir,
                     &pack_content_dir,
@@ -3752,6 +3754,18 @@ impl CreateCmd {
                 )
                 .map_err(|e| smolvm::Error::agent("seed VM-mode disks", e.to_string()))?;
             }
+
+            // VM-mode disks now exist, so construction resolves their qcow2/raw
+            // format without touching the generic blank-disk templates. Keep the
+            // manager alive through publication, matching the original lifetime.
+            let _manager = match manager {
+                Some(manager) => manager,
+                None => AgentManager::for_vm_with_sizes(
+                    &name_for_layers,
+                    params.storage_gb,
+                    params.overlay_gb,
+                )?,
+            };
 
             if let Some(ref checkpoint) = checkpoint {
                 let vm_data_dir = smolvm::agent::vm_data_dir(&name_for_layers);

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -39,12 +39,13 @@ use std::sync::atomic::{AtomicU64, Ordering};
 ///
 /// VM-mode (`--from-vm`) packs carry the source VM's rootfs DISKS, but the packed
 /// template has its trailing zero extent stripped, so the disk must be grown back to
-/// its logical size before boot. The caller's [`AgentManager`] has already created
-/// default `.qcow2` overlays backed by the EMPTY default template; this removes them
-/// and replaces them with disks backed by the packed image. On Linux, a shared
-/// extraction with an artifact SHA-256 creates one immutable, normalized raw base
-/// per artifact/disk/size and gives every machine a tiny qcow2 overlay. macOS keeps
-/// using APFS clonefile, while unsupported qcow2 hosts retain the sparse-copy path.
+/// its logical size before boot. Create paths call this before constructing their
+/// [`AgentManager`], allowing the manager to open the final artifact disks directly.
+/// Any stale default overlays from an interrupted/older create are removed first.
+/// On Linux, a shared extraction with an artifact SHA-256 creates one immutable,
+/// normalized raw base per artifact/disk/size and gives every machine a tiny qcow2
+/// overlay. macOS keeps using APFS clonefile, while unsupported qcow2 hosts retain
+/// the sparse-copy path.
 /// A `.formatted` marker stops the host from reformatting the inherited filesystem;
 /// the guest still grows it with resize2fs.
 ///
@@ -53,7 +54,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// templates are sparse (~25 MiB of real data in a multi-GiB logical file), so a dense
 /// copy would balloon every machine to its full logical size (~28 GiB) on disk.
 ///
-/// `disk_dir` is the machine's data dir (the parent of `manager.storage_path()`).
+/// `disk_dir` is the machine's prepared data directory.
 /// Shared by both the serve API create path and the `smolvm machine create --from`
 /// CLI path so a VM-mode pack restores identically through either entry point.
 ///


### PR DESCRIPTION
Avoid initializing the default 10 GiB overlay and 20 GiB storage disks before restoring VM-mode artifact disks. In our testing, this reduced fresh creation from roughly 30 seconds to under one second.