### PR TITLE
Capture a Windows machine's console output so a failed boot leaves a record

### DIFF
--- a/src/agent/krun.rs
+++ b/src/agent/krun.rs
@@ -49,8 +49,17 @@ pub struct KrunFunctions {
     pub add_vsock: unsafe extern "C" fn(u32, u32) -> i32,
     /// Add a virtio-console device (the upstream replacement for the removed
     /// `krun_set_console_output`). Unix: input/output/err file descriptors.
+    #[cfg(unix)]
     pub add_virtio_console_default:
         unsafe extern "C" fn(u32, libc::c_int, libc::c_int, libc::c_int) -> i32,
+    /// Windows takes the same three streams as handles rather than descriptors.
+    #[cfg(windows)]
+    pub add_virtio_console_default: unsafe extern "C" fn(
+        u32,
+        *mut std::ffi::c_void,
+        *mut std::ffi::c_void,
+        *mut std::ffi::c_void,
+    ) -> i32,
     pub set_egress_policy: Option<
         unsafe extern "C" fn(
             u32,
@@ -287,16 +296,39 @@ impl KrunFunctions {
         unsafe { (self.add_virtio_console_default)(ctx, null_fd, out_fd, out_fd) }
     }
 
-    /// Windows stub: the virtio-console redirection relies on POSIX file
-    /// descriptors passed to libkrun. The Windows libkrun ABI/console wiring is
-    /// not implemented here, so this is a no-op that reports failure.
+    /// Redirect the guest console output to `path` on Windows, where libkrun
+    /// takes handles instead of file descriptors.
+    ///
+    /// Without this a Windows guest's console goes nowhere, so a machine that
+    /// fails to boot leaves no record of why -- the log the other platforms
+    /// write is simply absent.
+    ///
+    /// The opened handles are intentionally leaked, for the same reason as on
+    /// Unix: the console device holds them for the VM's lifetime, and
+    /// `krun_start_enter` runs the VM in this process.
     ///
     /// # Safety
-    /// `unsafe` only to match the Unix signature (which dereferences libkrun
-    /// function pointers). This stub touches nothing and is always sound to call.
-    #[cfg(not(unix))]
-    pub unsafe fn console_output_to_file(&self, _ctx: u32, _path: &Path) -> i32 {
-        -1
+    /// `ctx` must be a valid libkrun context that has not yet been started.
+    #[cfg(windows)]
+    pub unsafe fn console_output_to_file(&self, ctx: u32, path: &Path) -> i32 {
+        use std::os::windows::io::IntoRawHandle;
+
+        let Ok(out) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+        else {
+            return -1;
+        };
+        // Console input comes from the null device (the agent talks over vsock,
+        // not the console); output and stderr both go to the log file.
+        let Ok(null) = std::fs::OpenOptions::new().read(true).open("NUL") else {
+            return -1;
+        };
+
+        let out_handle = out.into_raw_handle();
+        let null_handle = null.into_raw_handle();
+        unsafe { (self.add_virtio_console_default)(ctx, null_handle, out_handle, out_handle) }
     }
 }
 

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -1640,14 +1640,6 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
             // a failed boot. See launcher_dynamic::truncate_console_log.
             super::launcher_dynamic::truncate_console_log(log_path);
             if krun.console_output_to_file(ctx, log_path) < 0 {
-                // Expected on Windows (fd-based console redirection is a no-op
-                // there); don't let a benign WARN mask the real boot failure the
-                // readiness monitor reports. See `boot_failure_reason`.
-                #[cfg(windows)]
-                tracing::debug!(
-                    "guest console not captured on Windows (fd redirection unsupported)"
-                );
-                #[cfg(not(windows))]
                 tracing::warn!("failed to set console output");
             }
         }

--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -671,15 +671,6 @@ pub fn launch_agent_vm_dynamic(
     // upstream virtio-console API (krun_set_console_output was removed).
     // SAFETY: ctx is a valid, not-yet-started libkrun context.
     if unsafe { krun.console_output_to_file(ctx, &config.console_log) } < 0 {
-        // On Windows the fd-based virtio-console redirection isn't wired (the
-        // wrapper is a known no-op that always returns < 0), so this is expected
-        // — NOT a boot failure. Keep it out of the startup error log at WARN so a
-        // benign line can't become what the readiness monitor surfaces as "the
-        // error" when the boot later fails for a real reason (see
-        // `boot_failure_reason`).
-        #[cfg(windows)]
-        tracing::debug!("guest console not captured on Windows (fd redirection unsupported)");
-        #[cfg(not(windows))]
         tracing::warn!("failed to set console output");
     }
 


### PR DESCRIPTION
The virtio-console redirection was a no-op on Windows, so a machine that failed to boot there left no guest log at all; this wires it to the handle-based libkrun entry point that Windows exports.