### PR TITLE
Document the S3 volume source in machine run's --volume help

### DIFF
--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -524,11 +524,16 @@ pub struct RunCmd {
     )]
     pub oci_platform: Option<String>,
 
-    /// Mount host directory into container (can be used multiple times)
+    /// Mount host directory into container (can be used multiple times). Also
+    /// accepts S3-compatible object storage, mounted inside the container:
+    /// `s3://bucket/prefix:/data[:ro]` (credentials from --env
+    /// AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, optional AWS_ENDPOINT_URL
+    /// for R2/MinIO; anonymous without them). Nothing is required of the
+    /// image: the agent performs the mount itself.
     #[arg(
         short = 'v',
         long = "volume",
-        value_name = "HOST:CONTAINER[:ro]",
+        value_name = "HOST|REMOTE:CONTAINER[:ro]",
         help_heading = "Container"
     )]
     pub volume: Vec<String>,


### PR DESCRIPTION
`--volume` gained S3 sources, but only one of its six declarations says so. Checking each
declaration against the code path its values actually travel showed the gap is narrower than the
help text made it look: two of the six subcommands reach `remote_volume::split_specs`, and only
one of those two documented it.

| Declaration | Reaches `split_specs` | Grammar shown |
|---|---|---|
| `machine run`, `src/cli/machine.rs:531` | yes, `RunCmd::run` at `machine.rs:1375` | now `HOST\|REMOTE:CONTAINER[:ro]` |
| `machine create`, `src/cli/machine.rs:3063` | yes, `build_vm_record` at `vm_common.rs:604` | unchanged, already `HOST\|REMOTE:GUEST[:ro]` |
| `machine update`, `src/cli/machine.rs:4411` | no | unchanged `HOST:GUEST[:ro]` |
| `pack run`, `src/cli/pack_run.rs:215` | no | unchanged `HOST:CONTAINER[:ro]` |
| packed `run`, `src/cli/pack_run.rs:1215` | no | unchanged `HOST:GUEST[:ro]` |
| packed `start`, `src/cli/pack_run.rs:1272` | no | unchanged `HOST:GUEST[:ro]` |

The four narrow declarations pass their specs straight to `HostMount::parse`, which resolves the
source as a host directory and rejects an `s3://` spec with `MountSourceNotFound`. Widening their
help would advertise a value they refuse, so each keeps the grammar that matches what it accepts.

`machine run` keeps `CONTAINER` on the target side instead of moving to `GUEST`. Its `-v` sits
under the `Container` help heading beside `--workdir` and `--env`, and a remote volume is mounted
inside the workload container's mount namespace, so the existing word is accurate. Only the source
side of that value name changed.

One caveat on the widened string: `machine run --from <artifact>`, and the two bake paths that
resolve to a cached sidecar, hand their volume specs to `PackRunCmd` at `machine.rs:1079`, `:1215`
and `:1331` instead of reaching `split_specs`, so an `s3://` source is rejected in those modes. The
standard `machine run --image` path is the one that accepts it.

This is a help-text change only: no parser, no argument type, and no mount behavior is touched.
`machine run` with an `s3://` source is already covered end to end by section 11 of
`tests/test_remote_volumes.sh`, which mounts a bucket into an ephemeral run and reads a key back.

Effect for a user: `machine run --help` stops denying a source the command has accepted since S3
volumes shipped.
