### PR TITLE
Mount the pod sandbox share read-only, as the guest-side code already assumes

### DIFF
--- a/crates/smolvm-shim/src/engine.rs
+++ b/crates/smolvm-shim/src/engine.rs
@@ -56,6 +56,15 @@ const POD_SHARE_GUEST_PATH: &str = "/podshare";
 /// stay in lockstep with those constants.
 const POD_SHARE_GUEST_MOUNT: &str = "/mnt/virtiofs/podshare";
 
+/// Build the sandbox's single host mount.
+///
+/// Read-only: nothing in the guest writes the share, and the agent stacks a
+/// writable overlay over it for the container rootfs.
+fn pod_share_mount(share_dir: &Path) -> Result<HostMount, String> {
+    HostMount::new(share_dir, POD_SHARE_GUEST_PATH, true)
+        .map_err(|e| format!("pod share mount: {e}"))
+}
+
 /// Default sandbox VM sizing until pod-overhead plumbing lands.
 const SANDBOX_CPUS: u8 = 2;
 const SANDBOX_MEMORY_MIB: u32 = 1024;
@@ -653,8 +662,7 @@ impl PodBackend for EnginePodBackend {
                 .map_err(|e| format!("mkdir {}: {e}", share_dir.display()))?;
 
             let rt = smolvm::embedded::runtime().map_err(|e| e.to_string())?;
-            let mount = HostMount::new(&share_dir, POD_SHARE_GUEST_PATH, false)
-                .map_err(|e| format!("pod share mount: {e}"))?;
+            let mount = pod_share_mount(&share_dir)?;
             let spec = MachineSpec {
                 name: id_owned.clone(),
                 mounts: vec![mount],
@@ -1326,6 +1334,19 @@ impl PodBackend for ShimBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The share was created writable while every guest-side path that touches it
+    /// treats it as read-only: the agent copies CRI mounts out of it and stacks an
+    /// overlay over the rootfs precisely because writes return EACCES. A writable
+    /// share contradicts that and removes the boundary those paths rely on.
+    #[test]
+    fn the_pod_share_is_mounted_read_only() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mount = pod_share_mount(dir.path()).expect("pod share mount");
+
+        assert!(mount.read_only, "the pod share must be mounted read-only");
+        assert_eq!(mount.target, Path::new(POD_SHARE_GUEST_PATH));
+    }
 
     fn spec_with(annotations: serde_json::Value) -> serde_json::Value {
         serde_json::json!({ "annotations": annotations })


### PR DESCRIPTION
The shim creates the pod sandbox's single host mount with `read_only` false, while every guest-side path that touches that share treats it as read-only.

`HostMount`'s `read_only` field documents the default as true per DESIGN.md (`src/data/storage.rs:30`), so this call was passing the non-default.

## Why the guest-side code assumes read-only

`crates/smolvm-agent/src/pod.rs` copies each materialized CRI mount out of the share into a per-container writable dir, and stacks a guest-writable overlay over the container rootfs. It does both precisely because writes to the share return EACCES:

```
// The virtiofs share is READ-ONLY to the guest (writes EACCES), so crun
// can't create its /proc,/sys,/dev mountpoints directly on it. Stack a
// guest-writable overlay [...]
```

There is one share, not two: the container rootfs lives under it, so those comments and this mount describe the same object.

## Why guests are unaffected

Nothing in the guest writes the share. Guest writes are already blocked by uid mapping: the VMM runs as a dropped per-VM uid against a root-owned 0755 tree, so a write gets EACCES before the mount flag is consulted. This is defense in depth plus honesty, not a behavior change.

## Test

The mount construction moves into a small helper so the test can assert the flag on the mount the sandbox actually builds, rather than on one the test constructs itself. The test asserts `read_only` is true and that the target is the pod share path. It fails on the previous value:

```
test engine::tests::the_pod_share_is_mounted_read_only ... FAILED
assertion failed: the pod share must be mounted read-only
```

Verified on Linux, where the shim compiles: `cargo test -p smolvm-shim` 10 passed 0 failed, `cargo clippy -p smolvm-shim --all-targets -- -D warnings` clean on clippy 0.1.98, `cargo fmt --check` clean.
