### PR TITLE
Set SSH_AUTH_SOCK for interactive runs so --ssh-agent works with -i/-t

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -3425,6 +3425,18 @@ fn handle_interactive_run(
         return Ok(());
     }
 
+    // SSH agent forwarding: mirror `handle_run`'s injection. The #542 fix wired
+    // SSH_AUTH_SOCK into the exec/run env because the keep-alive `crun exec` path
+    // builds a fresh process env rather than inheriting the container's — but it
+    // only did so for the non-interactive handler. Interactive sessions reach the
+    // same keep-alive container (an ephemeral `machine run` also carries a
+    // persistent overlay id, so `-i`/`-t` joins it too), so without this the
+    // variable is silently absent for every interactive session and the
+    // container-spec injection alone never reaches it. No-op when forwarding is
+    // off; never overrides a user-supplied value.
+    let mut env = env;
+    ssh_agent::inject_into_env(&mut env);
+
     // Resolve the container's launch settings from the image's OCI config (with
     // request overrides). Required to call spawn_interactive_command, so the
     // interactive path can't drop the image's Env/WorkingDir/User either.

--- a/crates/smolvm-agent/src/ssh_agent.rs
+++ b/crates/smolvm-agent/src/ssh_agent.rs
@@ -330,6 +330,30 @@ mod tests {
         assert_eq!(env[0].1, "/custom.sock");
     }
 
+    // Regression guard for the interactive half of the same gap: every handler
+    // that launches a container command has to put SSH_AUTH_SOCK into the launch
+    // env itself, because the keep-alive `crun exec` path builds a fresh process
+    // env. #542 fixed the non-interactive handler and missed the interactive one,
+    // which left `--ssh-agent` silently broken for every `-i`/`-t` session. Pin
+    // both call sites so the pair can't drift apart again.
+    #[test]
+    fn both_run_handlers_inject_ssh_auth_sock_into_the_launch_env() {
+        const AGENT_MAIN: &str = include_str!("main.rs");
+
+        for handler in ["fn handle_run(", "fn handle_interactive_run("] {
+            let start = AGENT_MAIN
+                .find(handler)
+                .unwrap_or_else(|| panic!("{handler} not found in main.rs"));
+            let body = &AGENT_MAIN[start..];
+            let end = body.find("\nfn ").unwrap_or(body.len());
+            assert!(
+                body[..end].contains("ssh_agent::inject_into_env("),
+                "{handler} must call ssh_agent::inject_into_env(..) - without it, \
+                 --ssh-agent forwarding silently fails for commands taking this path"
+            );
+        }
+    }
+
     #[test]
     fn inject_is_noop_when_disabled() {
         let mut spec = OciSpec::new(


### PR DESCRIPTION
## Problem

`--ssh-agent` forwarding silently does nothing the moment `-i` or `-t` is added. `SSH_AUTH_SOCK` is empty in the guest and `ssh-add -l` fails with "Could not open a connection to your authentication agent" — no error, no warning.

```bash
# Works — SSH_AUTH_SOCK set, keys listed.
smolvm machine run --ssh-agent --net --image alpine \
  -- sh -c 'apk add -q openssh-client && ssh-add -l'

# Fails — SSH_AUTH_SOCK empty.
smolvm machine run --ssh-agent --net -it --image alpine \
  -- sh -c 'apk add -q openssh-client && ssh-add -l' </dev/null
```

Since nearly every real interactive use of `--ssh-agent` (a shell session, a TUI that shells out to `git`/`ssh`) needs `-it`, the flag is effectively unusable outside scripted invocations.

Reproduced on smolvm 1.11.1, macOS/Apple Silicon, with a 1Password agent socket. Ruled out during isolation: volume mounts, custom `ENTRYPOINT` vs. `/bin/sh`, startup races (`sleep 2`–`10` before the check), `-i` alone, `-t` alone, both `machine run` and persistent `machine create`/`start`/`exec`, and a `docker save`-imported image vs. stock `alpine`. All reproduce identically.

## Root cause

Since #542 both run paths execute the command via `crun exec` into the keep-alive container, which gets a **fresh process env** rather than inheriting the container's — so the `ssh_agent::inject_into_container` spec injection never reaches it. That PR added `ssh_agent::inject_into_env` to `handle_run` (`crates/smolvm-agent/src/main.rs:6101`).

But the request dispatcher (`main.rs:2127`) routes `Run { interactive: true } | Run { tty: true }` to `handle_interactive_run` (`main.rs:3341`), which never got the same call. The fix closed only half the gap.

Ephemeral `machine run` is not exempt: `src/cli/machine.rs:1897` sets `.with_persistent_overlay(Some(vm_name))` even for ephemeral runs, so `spawn_interactive_command` → `ensure_main_container` → `spawn_exec_in_container` launches with `launch.env`, which has no `SSH_AUTH_SOCK`. That is why both the ephemeral and persistent paths fail, and why `-i` alone and `-t` alone both reproduce — the dispatcher branches on either flag.

Bare-VM interactive exec (`handle_interactive_vm_exec`) is unaffected: it spawns directly and inherits the agent's own env, which sets `SSH_AUTH_SOCK` at `main.rs:476`.

## Fix

Mirror `handle_run`'s injection in `handle_interactive_run`, before `ResolvedLaunch::resolve`, so the variable flows into `launch.env` and reaches every branch of `spawn_interactive_command` (keep-alive exec, remote-volume exec, and the fresh-container fallback). `OciSpec::add_env` replaces rather than appends, so the fresh-container path does not end up with a duplicate entry. `inject_into_env` is a no-op when forwarding is off and never overrides a user-supplied `-e SSH_AUTH_SOCK`.

## Testing

- New unit test pins **both** call sites so the pair cannot drift apart a third time. It is written in the spirit of `scripts/check-secrets-guards.sh` — a conservative static invariant, no runtime deps. Confirmed it fails when the fix is reverted.
- `cargo fmt --all -- --check` clean; `cargo clippy -p smolvm-agent --bins --tests` introduces no new warnings.
- All 5 `ssh_agent` unit tests pass.

**Not verified against a running VM** — I don't have a local smolvm build set up, so this is static analysis plus unit-level verification. Please confirm against the repro above before merging. Happy to adjust if you'd prefer the injection at a different seam (e.g. inside `spawn_interactive_command`, which would cover pod exec paths too — I kept it symmetric with `handle_run` instead).

Related: #145 (same symptom, different cause, fixed in v0.5.17 via #148), #542.