### PR TITLE
Document the experimental host-mount DAX window

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,7 @@ rejected with a hint to build first (`docker build … && docker save … | … 
 | `--net` | | run, create | Enable outbound networking (off by default) |
 | `--gpu` | | run, create | Enable GPU acceleration (Vulkan via virtio-gpu) |
 | `--gpu-vram` | | run, create | GPU shared-memory region size in MiB (default: 4096). Ignored without `--gpu`. |
-| `--volume` | `-v` | run, create, update | Mount host dir: `HOST:GUEST[:ro]` |
+| `--volume` | `-v` | run, create, update | Mount host dir: `HOST:GUEST[:ro]`. Served over virtio-fs, so operation-heavy work is slow on it (see Host Mounts) |
 | `--allow-system-mounts` | | run, create, update, pack run | Permit trusted read-only `/etc` and `/var/log` mounts below `/host` |
 | `--port` | `-p` | run, create, update | Port mapping: `HOST:GUEST` |
 | `--smolfile` | `-s` | run, create, pack create | Load config from Smolfile |
@@ -177,6 +177,20 @@ rejected with a hint to build first (`docker build … && docker save … | … 
 | `--allow-cidr` | | run, create | CIDR egress filter (implies --net) |
 | `--allow-host` | | run, create | Hostname egress filter, resolved at VM start (implies --net) |
 | `--ssh-agent` | | run, create | Forward host SSH agent (git/ssh without exposing keys) |
+
+## Host Mounts
+
+A `-v` directory is served over virtio-fs: each file operation is a round trip
+to the host. Bulk I/O is near host speed; installing dependencies, first builds
+and large directory walks are far slower than on the machine's own disk.
+
+- Keep generated directories (`node_modules`, `target`, `.venv`) inside the
+  machine, not on the host mount.
+- `SMOLVM_MOUNT_DAX=1` on the process that starts the machine adds a 512 MiB
+  DAX window per host mount. It helps sequential and `mmap` reads only, needs a
+  stop and start, and falls back silently. Confirm in the guest with
+  `grep virtiofs /proc/mounts`: an active mount ends in `dax=always`.
+  Linux only today; on macOS it has no effect.
 
 ## Smolfile Reference
 

--- a/README.md
+++ b/README.md
@@ -237,6 +237,30 @@ Known Limitations
 * GPU acceleration requires libkrun built with `GPU=1` and virglrenderer + a Vulkan driver on the host (see [GPU Acceleration](#gpu-acceleration) below).
 * Windows: `--net` works the same as on other platforms (virtio-net with inbound port-forwarding; TSI for outbound-only VMs), as do `machine exec` / interactive sessions and `machine stats`. Not yet available on Windows: GPU acceleration and `machine fork` / snapshot. Pack *create* needs `storage-template.ext4` / `overlay-template.ext4` next to `smolvm.exe` (Windows has no host `mkfs.ext4`).
 
+Host Mount Performance
+----------------------
+
+A `--volume` directory is served over virtio-fs, so every file operation is a
+round trip to the host. Bulk reads and writes run near host speed, but
+operation-heavy work (installing dependencies, a first build, walking a big
+repository) is far slower than on the machine's own disk. Keep generated
+directories such as `node_modules`, `target` and `.venv` inside the machine.
+
+`SMOLVM_MOUNT_DAX=1` (experimental) gives each host mount a 512 MiB DAX window,
+which helps sequential and `mmap`-heavy reads but not directory traversal,
+`stat` or file creation. Set it on the process that starts the machine, with
+the value exactly `1`; a running machine needs a stop and start. It falls back
+silently, so confirm it took effect inside the guest, where the mount ends in
+`dax=always`:
+
+```bash
+SMOLVM_MOUNT_DAX=1 smolvm machine start --name NAME
+smolvm machine exec --name NAME -- grep virtiofs /proc/mounts
+```
+
+Verified on Linux x86_64. On macOS the bundled libkrun currently falls back,
+so the variable has no effect there.
+
 GPU Acceleration
 ----------------
 


### PR DESCRIPTION
Host mounts are served over virtio-fs so operation-heavy work is much slower than the machine's own disk, and the DAX window that helps sequential reads was an undocumented environment variable with a silent fallback, so both are now described with the scope, the caveats and the way to tell whether it actually took effect.