### PR TITLE
Improve host mount performance and coherence

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,18 @@ smolvm machine exec --name myvm -it -- /bin/sh
 smolvm machine stop --name myvm
 ```
 
+Host directory mounts propagate host-side changes into guest inotify, so tools
+such as Vite, nodemon, and file-watch test runners reload without polling. Set
+`SMOL_NO_HOT_RELOAD=1` in the host process to disable recursive watching for a
+machine with an unusually large directory tree.
+
+For sequential or mmap-heavy reads, `SMOLVM_MOUNT_DAX=1` enables a 2 GiB
+virtiofs DAX window for each user mount when the machine starts. This is a host
+process setting (set it on `smolvm serve` for served machines), and an existing
+machine needs a stop/start to apply it. DAX does not materially accelerate
+metadata-heavy traversal. Confirm it in the guest with
+`grep virtiofs /proc/mounts`; an active mount includes `dax=always`.
+
 **Use git and SSH without copying private keys into the guest.** Forward your host SSH agent into the VM. The guest can ask the agent to sign with any forwarded key while the socket is available, so forward it only to workloads you trust. Requires an SSH agent running on your host (`ssh-add -l` to check).
 
 ```bash

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -328,6 +328,51 @@ static PACKED_LAYERS_DIR: OnceLock<Option<PathBuf>> = OnceLock::new();
 /// Set at startup if SMOLVM_MOUNT_COUNT env var is present.
 static BOOT_VOLUME_MOUNTS: OnceLock<Vec<(String, String, bool)>> = OnceLock::new();
 
+/// Mount a virtiofs device with one policy for every host-backed filesystem:
+/// request DAX first, then fall back to the normal synchronous data path when
+/// the host did not give this device a DAX window.
+#[cfg(target_os = "linux")]
+fn mount_virtiofs(tag: &str, mount_point: &Path) -> std::io::Result<bool> {
+    let src = std::ffi::CString::new(tag)
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "invalid tag"))?;
+    let dst = std::ffi::CString::new(mount_point.to_string_lossy().as_bytes()).map_err(|_| {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, "invalid mount point")
+    })?;
+    let fstype = std::ffi::CString::new("virtiofs").expect("static filesystem type");
+    let opts_dax = std::ffi::CString::new("dax,sync").expect("static mount options");
+    let opts_plain = std::ffi::CString::new("sync").expect("static mount options");
+
+    // SAFETY: every argument is a valid, live CString and mount() copies them.
+    let dax_rc = unsafe {
+        libc::mount(
+            src.as_ptr(),
+            dst.as_ptr(),
+            fstype.as_ptr(),
+            0,
+            opts_dax.as_ptr() as *const libc::c_void,
+        )
+    };
+    if dax_rc == 0 {
+        return Ok(true);
+    }
+
+    // SAFETY: same arguments and lifetime as the DAX attempt above.
+    let plain_rc = unsafe {
+        libc::mount(
+            src.as_ptr(),
+            dst.as_ptr(),
+            fstype.as_ptr(),
+            0,
+            opts_plain.as_ptr() as *const libc::c_void,
+        )
+    };
+    if plain_rc == 0 {
+        Ok(false)
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
 /// Initialize packed layers support by checking SMOLVM_PACKED_LAYERS env var.
 /// Format: "virtiofs_tag:mount_point" (e.g., "smolvm_layers:/packed_layers")
 /// Returns the mount point path if successfully mounted.
@@ -358,26 +403,14 @@ pub fn init_packed_layers() -> Option<PathBuf> {
     // Mount virtiofs using direct syscall (avoids ~3-5ms fork+exec overhead)
     #[cfg(target_os = "linux")]
     {
-        let src = std::ffi::CString::new(tag).ok()?;
-        let dst = std::ffi::CString::new(mount_point.to_str()?).ok()?;
-        let fstype = std::ffi::CString::new("virtiofs").unwrap();
-        // SAFETY: mount virtiofs with valid CString arguments
-        let rc = unsafe {
-            libc::mount(
-                src.as_ptr(),
-                dst.as_ptr(),
-                fstype.as_ptr(),
-                0,
-                std::ptr::null(),
-            )
+        let dax = match mount_virtiofs(tag, &mount_point) {
+            Ok(dax) => dax,
+            Err(err) => {
+                warn!(error = %err, tag = %tag, "failed to mount packed layers virtiofs");
+                return None;
+            }
         };
-
-        if rc != 0 {
-            let err = std::io::Error::last_os_error();
-            warn!(error = %err, tag = %tag, "failed to mount packed layers virtiofs");
-            return None;
-        }
-        info!(mount_point = %mount_point.display(), "packed layers mounted successfully");
+        info!(mount_point = %mount_point.display(), dax, "packed layers mounted successfully");
 
         // List contents for debugging (only at debug level to avoid boot overhead)
         if let Ok(entries) = std::fs::read_dir(&mount_point) {
@@ -3537,54 +3570,14 @@ fn setup_volume_mounts(rootfs: &str, mounts: &[(String, String, bool)]) -> Resul
         if !is_mountpoint(&virtiofs_mount) {
             info!(tag = %tag, mount_point = %virtiofs_mount.display(), "mounting virtiofs");
 
-            // Mount virtiofs using direct syscall (avoids ~3-5ms fork+exec overhead).
-            // Use sync option to ensure writes are persisted immediately.
-            let src = std::ffi::CString::new(tag.as_str()).map_err(|e| StorageError::Internal {
-                message: format!("invalid tag: {}", e),
-            })?;
-            let dst =
-                std::ffi::CString::new(virtiofs_mount.to_string_lossy().as_ref()).map_err(|e| {
-                    StorageError::Internal {
-                        message: format!("invalid mount point: {}", e),
-                    }
-                })?;
-            let fstype = std::ffi::CString::new("virtiofs").unwrap();
-            // DAX first: when the device has a DAX window (host passed a
-            // nonzero shm_size — SMOLVM_MOUNT_DAX=1), a dax mount maps host
-            // page-cache pages directly into the guest, making guest/host
-            // MAP_SHARED mmaps of the same file coherent shared memory (the
-            // clone-ring transport). The kernel silently downgrades dax on a
-            // window-less device; the explicit fallback covers kernels that
-            // reject the option outright.
-            let opts_dax = std::ffi::CString::new("dax,sync").unwrap();
-            let opts_plain = std::ffi::CString::new("sync").unwrap();
-            // SAFETY: mount virtiofs with valid CString arguments
-            let mut rc = unsafe {
-                libc::mount(
-                    src.as_ptr(),
-                    dst.as_ptr(),
-                    fstype.as_ptr(),
-                    0,
-                    opts_dax.as_ptr() as *const libc::c_void,
-                )
+            let dax = match mount_virtiofs(tag, &virtiofs_mount) {
+                Ok(dax) => dax,
+                Err(err) => {
+                    warn!(error = %err, tag = %tag, "failed to mount virtiofs device");
+                    continue;
+                }
             };
-            if rc != 0 {
-                // SAFETY: as above, plain options.
-                rc = unsafe {
-                    libc::mount(
-                        src.as_ptr(),
-                        dst.as_ptr(),
-                        fstype.as_ptr(),
-                        0,
-                        opts_plain.as_ptr() as *const libc::c_void,
-                    )
-                };
-            }
-            if rc != 0 {
-                let err = std::io::Error::last_os_error();
-                warn!(error = %err, tag = %tag, "failed to mount virtiofs device");
-                continue;
-            }
+            info!(tag = %tag, dax, "virtiofs mount active");
         }
 
         // Now bind-mount into the container rootfs

--- a/src/agent/fsnotify_watch.rs
+++ b/src/agent/fsnotify_watch.rs
@@ -46,6 +46,11 @@ const GUEST_VIRTIOFS_ROOT: &str = "/mnt/virtiofs";
 /// into one round-trip while keeping latency well under a human-perceptible
 /// reload delay.
 const COALESCE_WINDOW: Duration = Duration::from_millis(25);
+/// Watcher startup is independent of VM readiness. Poll in short increments so
+/// a failed launch can tear down immediately instead of joining a sleeping
+/// exponential-backoff thread.
+const CONNECT_RETRY_INTERVAL: Duration = Duration::from_millis(50);
+const CONNECT_RETRY_LIMIT: usize = 200;
 
 /// A single watched mount: host source directory → guest virtiofs staging base.
 struct WatchTarget {
@@ -70,6 +75,22 @@ impl FsNotifyWatcher {
     /// thread can't be spawned — the mount still works, only live change
     /// notifications are unavailable.
     pub fn start(socket_path: PathBuf, mounts: &[HostMount]) -> Option<Self> {
+        Self::start_tagged(
+            socket_path,
+            mounts
+                .iter()
+                .enumerate()
+                .map(|(i, mount)| (mount.source.clone(), HostMount::mount_tag(i))),
+        )
+    }
+
+    /// Start a watcher for launch paths that already resolved their virtiofs
+    /// tags (notably packed/sidecar VMs).
+    #[doc(hidden)]
+    pub fn start_tagged(
+        socket_path: PathBuf,
+        mounts: impl IntoIterator<Item = (PathBuf, String)>,
+    ) -> Option<Self> {
         // Opt-out escape hatch: setting SMOL_NO_HOT_RELOAD disables host FS
         // watching entirely (e.g. very large trees, or privacy preference).
         if std::env::var_os("SMOL_NO_HOT_RELOAD").is_some() {
@@ -80,12 +101,11 @@ impl FsNotifyWatcher {
         // is skipped. Read-only mounts are still watched: the host may edit them
         // (that is exactly the read-only-source hot-reload case).
         let targets: Vec<WatchTarget> = mounts
-            .iter()
-            .enumerate()
-            .filter(|(_, m)| m.source.is_dir())
-            .map(|(i, m)| WatchTarget {
-                host_source: m.source.clone(),
-                guest_base: format!("{GUEST_VIRTIOFS_ROOT}/smolvm{i}"),
+            .into_iter()
+            .filter(|(source, _)| source.is_dir())
+            .map(|(host_source, tag)| WatchTarget {
+                host_source,
+                guest_base: format!("{GUEST_VIRTIOFS_ROOT}/{tag}"),
             })
             .collect();
         if targets.is_empty() {
@@ -139,12 +159,9 @@ fn run_watch(socket_path: PathBuf, targets: Vec<WatchTarget>, stop: Arc<AtomicBo
 
     // A dedicated connection so injected events never interleave with the
     // command's own request/response stream on the primary connection.
-    let mut client = match AgentClient::connect_with_retry(&socket_path) {
-        Ok(c) => c,
-        Err(e) => {
-            debug!(error = %e, "fsnotify watcher could not connect to agent; disabled");
-            return;
-        }
+    let mut client = match connect_to_agent(&socket_path, &stop) {
+        Some(client) => client,
+        None => return,
     };
 
     info!(
@@ -188,13 +205,28 @@ fn run_watch(socket_path: PathBuf, targets: Vec<WatchTarget>, stop: Arc<AtomicBo
     }
 }
 
+fn connect_to_agent(socket_path: &Path, stop: &AtomicBool) -> Option<AgentClient> {
+    let mut last_error = None;
+    for _ in 0..CONNECT_RETRY_LIMIT {
+        if stop.load(Ordering::SeqCst) {
+            return None;
+        }
+        match AgentClient::connect(socket_path) {
+            Ok(client) => return Some(client),
+            Err(error) => last_error = Some(error),
+        }
+        std::thread::sleep(CONNECT_RETRY_INTERVAL);
+    }
+    if let Some(error) = last_error {
+        debug!(%error, "fsnotify watcher could not connect to agent; disabled");
+    }
+    None
+}
+
 /// Translate one host event into guest-side [`FsNotifyEvent`]s, appended to `out`.
 fn collect_events(event: &Event, targets: &[WatchTarget], out: &mut Vec<FsNotifyEvent>) {
     for host_path in &event.paths {
-        let Some(t) = targets
-            .iter()
-            .find(|t| host_path.starts_with(&t.host_source))
-        else {
+        let Some(t) = matching_target(host_path, targets) else {
             continue;
         };
         let Ok(rel) = host_path.strip_prefix(&t.host_source) else {
@@ -223,6 +255,13 @@ fn collect_events(event: &Event, targets: &[WatchTarget], out: &mut Vec<FsNotify
             });
         }
     }
+}
+
+fn matching_target<'a>(path: &Path, targets: &'a [WatchTarget]) -> Option<&'a WatchTarget> {
+    targets
+        .iter()
+        .filter(|target| path.starts_with(&target.host_source))
+        .max_by_key(|target| target.host_source.components().count())
 }
 
 /// Join a guest base path with a host-relative path, normalizing separators.
@@ -334,5 +373,19 @@ mod tests {
         ];
         dedup(&mut batch);
         assert_eq!(batch.len(), 1);
+    }
+
+    #[test]
+    fn nested_mount_uses_most_specific_target() {
+        let targets = vec![
+            WatchTarget {
+                host_source: PathBuf::from("/host/project/vendor"),
+                guest_base: "/mnt/virtiofs/smolvm1".into(),
+            },
+            target(),
+        ];
+        let selected = matching_target(Path::new("/host/project/vendor/lib.js"), &targets)
+            .expect("nested path should match");
+        assert_eq!(selected.guest_base, "/mnt/virtiofs/smolvm1");
     }
 }

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -40,14 +40,6 @@ use super::{KrunFunctions, PortMapping, VmResources};
 /// a host resolves to many IPs across many refresh cycles.
 const EGRESS_CIDR_CAP: usize = 512;
 
-/// Hidden benchmark knob for root virtiofs DAX.
-///
-/// Default configures the root virtiofs device with a 512 MB DAX window (the
-/// same default the removed `krun_set_root` used). Set `SMOLVM_ROOTFS_DAX=0` to
-/// use `krun_add_virtiofs3("/dev/root", ..., shm_size=0, read_only=false)`,
-/// disabling the root DAX region for benchmarking.
-const ENV_SMOLVM_ROOTFS_DAX: &str = "SMOLVM_ROOTFS_DAX";
-
 /// Stable tmpfs directory used by one VM's CUDA file-ring transport.
 ///
 /// The path is derived from the full per-VM runtime directory rather than its
@@ -137,14 +129,6 @@ fn create_owned_directory(path: &Path) -> std::io::Result<()> {
     let mut builder = std::fs::DirBuilder::new();
     builder.mode(0o700).create(path)
 }
-
-/// Root virtiofs DAX window (512 MB), matching the default the removed
-/// `krun_set_root` configured. DAX gives the host a coherent shared mapping of
-/// the root fs so the guest agent's ready-marker write is visible to the host
-/// immediately. Plain `krun_add_virtiofs` passes shm_size=0 (no DAX), dropping
-/// virtiofs to writeback caching — the marker isn't seen until the multi-second
-/// socket-probe grace, regressing boot time from ~hundreds of ms to ~5 s.
-const ROOTFS_DAX_WINDOW: u64 = 1 << 29;
 
 /// The Arc type shared between the egress-refresh thread and libkrun's vsock muxer.
 type EgressArc = std::sync::Arc<std::sync::RwLock<Vec<(std::net::IpAddr, u8)>>>;
@@ -958,17 +942,16 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
         // Set root filesystem via the root virtiofs tag ("/dev/root").
         //
         // Upstream libkrun removed krun_set_root in favor of krun_add_virtiofs*
-        // with KRUN_FS_ROOT_TAG. Default path: krun_add_virtiofs, preserving the
-        // established rootfs DAX defaults. Benchmark path: SMOLVM_ROOTFS_DAX=0
-        // uses krun_add_virtiofs3 with shm_size=0, disabling the root DAX region
-        // while keeping the root read-write.
+        // with KRUN_FS_ROOT_TAG. Use virtiofs3 for both policy states so every
+        // launcher interprets the shared rootfs DAX setting identically.
         let root = try_or_free_ctx!(
             path_to_cstring(rootfs_path),
             "set rootfs",
             "path contains null byte"
         );
         let root_tag = cstr("/dev/root");
-        if rootfs_dax_disabled() {
+        let rootfs_dax_window = super::virtiofs::rootfs_dax_window();
+        if rootfs_dax_window == 0 {
             let Some(add_virtiofs3) = krun_add_virtiofs3 else {
                 krun_free_ctx(ctx);
                 return Err(Error::agent(
@@ -1001,7 +984,7 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
                 ctx,
                 root_tag.as_ptr(),
                 root.as_ptr(),
-                ROOTFS_DAX_WINDOW,
+                rootfs_dax_window,
                 false,
             ) < 0
             {
@@ -1745,18 +1728,9 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
             // host page-cache pages into the guest), which is the transport
             // for CLONE rings — clone guest RAM is COW-private, but the DAX
             // window is device memory, re-established per-VM, so it dodges
-            // the COW wall entirely. libkrun supports per-device windows
-            // (ShmManager::create_fs_region per fs index); the old code just
-            // never asked (shm_size=0 here while launcher_dynamic asked for
-            // 2 GiB — the source of the "only root has DAX" misdiagnosis).
-            let is_ring_mount = mount.target == std::path::Path::new("/opt/smolvm-ring");
-            let dax_window: u64 = match std::env::var("SMOLVM_MOUNT_DAX").as_deref() {
-                Ok("1") => 1 << 29,
-                // The implicit CUDA ring mount ALWAYS gets a window — it exists
-                // solely to be dax-mmap'd (512 MB, the proven window size).
-                _ if is_ring_mount => 1 << 29,
-                _ => 0,
-            };
+            // the COW wall entirely. The shared policy keeps this launcher,
+            // packed VMs, and the direct backend on the same window size.
+            let dax_window = super::virtiofs::user_mount_dax_window(&mount.target);
             // Read-only mounts must be enforced host-side by the virtiofs
             // device (krun_add_virtiofs3's read_only flag), not only by the
             // guest's bind-remount: a root process in the guest can undo a
@@ -1772,18 +1746,11 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
                             "read-only mounts require libkrun with krun_add_virtiofs3",
                         ));
                     }
-                    // DAX requested but symbol missing: fall back to plain.
-                    if krun_add_virtiofs(ctx, tag.as_ptr(), host_path.as_ptr()) < 0 {
-                        krun_free_ctx(ctx);
-                        return Err(Error::agent(
-                            "add virtiofs mount",
-                            format!(
-                                "krun_add_virtiofs failed for '{}' - requested mount cannot be attached",
-                                mount.source.display()
-                            ),
-                        ));
-                    }
-                    continue;
+                    krun_free_ctx(ctx);
+                    return Err(Error::agent(
+                        "add virtiofs mount",
+                        "DAX mounts require libkrun with krun_add_virtiofs3",
+                    ));
                 };
                 if add_virtiofs3(
                     ctx,
@@ -1801,6 +1768,13 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
                             mount.source.display()
                         ),
                     ));
+                }
+                if dax_window > 0 {
+                    tracing::info!(
+                        tag = %mount_tag,
+                        dax_window_mib = dax_window >> 20,
+                        "virtiofs DAX enabled"
+                    );
                 }
             } else if krun_add_virtiofs(ctx, tag.as_ptr(), host_path.as_ptr()) < 0 {
                 krun_free_ctx(ctx);
@@ -1821,11 +1795,25 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
             if layers_dir.exists() {
                 let tag = cstr("smolvm_layers");
                 let host_path = path_to_cstring(layers_dir)?;
-                if krun_add_virtiofs(ctx, tag.as_ptr(), host_path.as_ptr()) < 0 {
+                let Some(add_virtiofs3) = krun_add_virtiofs3 else {
                     krun_free_ctx(ctx);
                     return Err(Error::agent(
                         "add packed layers virtiofs",
-                        "krun_add_virtiofs failed for packed layers",
+                        "packed-layer DAX requires libkrun with krun_add_virtiofs3",
+                    ));
+                };
+                if add_virtiofs3(
+                    ctx,
+                    tag.as_ptr(),
+                    host_path.as_ptr(),
+                    super::virtiofs::DATA_DAX_WINDOW,
+                    false,
+                ) < 0
+                {
+                    krun_free_ctx(ctx);
+                    return Err(Error::agent(
+                        "add packed layers virtiofs",
+                        "krun_add_virtiofs3 failed for packed layers",
                     ));
                 }
             } else {
@@ -2167,17 +2155,6 @@ fn cstr(s: &str) -> CString {
 fn path_to_cstring(path: &Path) -> Result<CString> {
     CString::new(path.to_string_lossy().as_bytes())
         .map_err(|_| Error::agent("convert path", "path contains null byte"))
-}
-
-fn rootfs_dax_disabled() -> bool {
-    std::env::var(ENV_SMOLVM_ROOTFS_DAX)
-        .map(|value| {
-            matches!(
-                value.as_str(),
-                "0" | "false" | "False" | "FALSE" | "no" | "off"
-            )
-        })
-        .unwrap_or(false)
 }
 
 // Unix-only: virtio-net is the sole caller and is itself unix-gated.

--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -348,7 +348,16 @@ pub fn launch_agent_vm_dynamic(
         free_ctx_on_err!("root DAX requires libkrun with krun_add_virtiofs3");
     };
     // SAFETY: ctx is valid; root_tag/root are valid null-terminated C strings.
-    if unsafe { add_virtiofs3(ctx, root_tag.as_ptr(), root.as_ptr(), 1 << 29, false) } < 0 {
+    if unsafe {
+        add_virtiofs3(
+            ctx,
+            root_tag.as_ptr(),
+            root.as_ptr(),
+            super::virtiofs::rootfs_dax_window(),
+            false,
+        )
+    } < 0
+    {
         free_ctx_on_err!("krun_add_virtiofs3 failed for root filesystem");
     }
 
@@ -780,15 +789,8 @@ pub fn launch_agent_vm_dynamic(
         free_ctx_on_err!("krun_set_exec failed");
     }
 
-    // Every virtiofs mount gets a DAX window (like the root fs above): without
-    // DAX, virtiofs falls back to writeback caching where each file access is a
-    // FUSE round-trip over the virtio queue — pathological for read-heavy mounts
-    // with many files (a multi-GB Python venv took minutes just to import, and a
-    // single file larger than the window stalled entirely). 2 GiB exceeds any
-    // realistic single mapped file; the window is virtual host address space
-    // backed on demand, so oversizing costs nothing until touched.
-    const VIRTIOFS_DAX_WINDOW: u64 = 1 << 31;
-
+    // Packed image layers always use the shared data DAX window. User mounts
+    // follow the same explicit policy as every other launch path below.
     // Add virtiofs mount for packed layers (AFTER set_exec)
     if config.layers_dir.exists() {
         let layers_tag = cstr("smolvm_layers");
@@ -802,7 +804,7 @@ pub fn launch_agent_vm_dynamic(
                 ctx,
                 layers_tag.as_ptr(),
                 layers_path.as_ptr(),
-                VIRTIOFS_DAX_WINDOW,
+                super::virtiofs::DATA_DAX_WINDOW,
                 false,
             )
         } < 0
@@ -822,13 +824,14 @@ pub fn launch_agent_vm_dynamic(
             "mount path contains null byte"
         );
 
+        let dax_window = super::virtiofs::user_mount_dax_window(Path::new(&mount.guest_path));
         // SAFETY: ctx is valid, tag and host_path are valid C strings
         if unsafe {
             add_virtiofs3(
                 ctx,
                 tag.as_ptr(),
                 host_path.as_ptr(),
-                VIRTIOFS_DAX_WINDOW,
+                dax_window,
                 mount.read_only,
             )
         } < 0
@@ -837,6 +840,13 @@ pub fn launch_agent_vm_dynamic(
                 "krun_add_virtiofs failed for '{}' - requested mount cannot be attached",
                 mount.tag
             ));
+        }
+        if dax_window > 0 {
+            tracing::info!(
+                tag = %mount.tag,
+                dax_window_mib = dax_window >> 20,
+                "virtiofs DAX enabled"
+            );
         }
     }
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -18,6 +18,7 @@ pub mod state_probe;
 pub mod terminal;
 #[cfg(unix)]
 pub mod video;
+pub(crate) mod virtiofs;
 /// Encoded browser video is unavailable on non-Unix hosts because the helper
 /// transport uses a mode-restricted Unix socket.
 #[cfg(not(unix))]

--- a/src/agent/virtiofs.rs
+++ b/src/agent/virtiofs.rs
@@ -1,0 +1,46 @@
+//! Shared virtiofs DAX policy for every libkrun launch path.
+
+use std::path::Path;
+
+/// Root DAX keeps the guest ready marker coherent with the host.
+pub(crate) const ROOTFS_DAX_WINDOW: u64 = 1 << 29;
+/// Data mounts need room for large mapped libraries and model/data files.
+pub(crate) const DATA_DAX_WINDOW: u64 = 1 << 31;
+/// The CUDA file ring has a fixed, separately validated aperture.
+pub(crate) const CUDA_RING_DAX_WINDOW: u64 = 1 << 29;
+
+const ENV_ROOTFS_DAX: &str = "SMOLVM_ROOTFS_DAX";
+const ENV_MOUNT_DAX: &str = "SMOLVM_MOUNT_DAX";
+
+/// DAX window for the root filesystem. Root DAX is on unless explicitly
+/// disabled for benchmarking.
+pub(crate) fn rootfs_dax_window() -> u64 {
+    if env_is_false(ENV_ROOTFS_DAX) {
+        0
+    } else {
+        ROOTFS_DAX_WINDOW
+    }
+}
+
+/// DAX window for one user mount. Normal mounts are explicit opt-in; the CUDA
+/// ring is always DAX because it cannot function as a plain virtiofs mount.
+pub(crate) fn user_mount_dax_window(guest_path: &Path) -> u64 {
+    if guest_path == Path::new("/opt/smolvm-ring") {
+        CUDA_RING_DAX_WINDOW
+    } else if std::env::var(ENV_MOUNT_DAX).as_deref() == Ok("1") {
+        DATA_DAX_WINDOW
+    } else {
+        0
+    }
+}
+
+fn env_is_false(name: &str) -> bool {
+    std::env::var(name)
+        .map(|value| {
+            matches!(
+                value.as_str(),
+                "0" | "false" | "False" | "FALSE" | "no" | "off"
+            )
+        })
+        .unwrap_or(false)
+}

--- a/src/cli/internal_boot.rs
+++ b/src/cli/internal_boot.rs
@@ -7,7 +7,7 @@
 //! Usage: smolvm _boot-vm <config-path>
 
 use smolvm::agent::boot_config::BootConfig;
-use smolvm::agent::{launch_agent_vm, LaunchConfig, VmDisks};
+use smolvm::agent::{launch_agent_vm, FsNotifyWatcher, LaunchConfig, VmDisks};
 use smolvm::data::disk::{DiskFormat, DiskType};
 use smolvm::storage::VmDisk;
 use std::path::{Path, PathBuf};
@@ -510,6 +510,12 @@ pub fn run(config_path: PathBuf) -> smolvm::Result<()> {
         }
         _ => {}
     }
+
+    // The boot subprocess owns the VM for its full lifetime, including
+    // persistent machines whose initiating CLI has exited. Keep host→guest
+    // filesystem notifications here so the watcher cannot disappear early.
+    // Start after seccomp installation so its thread inherits the VMM policy.
+    let _fsnotify_watcher = FsNotifyWatcher::start(config.vsock_socket.clone(), &config.mounts);
 
     // Emit subprocess startup timing to the startup error log (stderr after
     // the stdio redirect above). These lines decompose the dark window between

--- a/src/cli/pack_run.rs
+++ b/src/cli/pack_run.rs
@@ -584,6 +584,14 @@ impl PackRunCmd {
                 // steal keystrokes or corrupt terminal state.
                 detach_vm_child_stdio();
 
+                let _fsnotify_watcher = smolvm::agent::FsNotifyWatcher::start_tagged(
+                    config.vsock_socket.to_path_buf(),
+                    config
+                        .mounts
+                        .iter()
+                        .map(|mount| (PathBuf::from(&mount.host_path), mount.tag.clone())),
+                );
+
                 if let Err(e) = launch_agent_vm_dynamic(&krun, &config) {
                     let msg = format!("launch_agent_vm_dynamic failed: {}\n", e);
                     let _ = std::fs::write(&config.console_log, &msg);
@@ -1629,6 +1637,14 @@ fn run_from_cache(
         // steal keystrokes or corrupt terminal state.
         detach_vm_child_stdio();
 
+        let _fsnotify_watcher = smolvm::agent::FsNotifyWatcher::start_tagged(
+            config.vsock_socket.to_path_buf(),
+            config
+                .mounts
+                .iter()
+                .map(|mount| (PathBuf::from(&mount.host_path), mount.tag.clone())),
+        );
+
         if let Err(e) = launch_agent_vm_dynamic(&krun, &config) {
             let msg = format!("launch_agent_vm_dynamic failed: {}\n", e);
             let _ = std::fs::write(&config.console_log, &msg);
@@ -2067,6 +2083,14 @@ fn daemon_start(
         // Without this, libkrun's threads inherit stdin and steal
         // keystrokes from the user's shell.
         detach_vm_child_stdio();
+
+        let _fsnotify_watcher = smolvm::agent::FsNotifyWatcher::start_tagged(
+            config.vsock_socket.to_path_buf(),
+            config
+                .mounts
+                .iter()
+                .map(|mount| (PathBuf::from(&mount.host_path), mount.tag.clone())),
+        );
 
         if let Err(e) = launch_agent_vm_dynamic(&krun, &config) {
             let msg = format!("launch_agent_vm_dynamic failed: {}\n", e);

--- a/src/process.rs
+++ b/src/process.rs
@@ -604,6 +604,10 @@ fn build_seccomp_program(enforce: bool) -> std::result::Result<seccompiler::BpfP
         libc::SYS_dup, libc::SYS_dup3, libc::SYS_getdents64,
         libc::SYS_readlinkat, libc::SYS_faccessat, libc::SYS_faccessat2, libc::SYS_umask,
         libc::SYS_fgetxattr, libc::SYS_flistxattr, libc::SYS_pipe2,
+        // The VMM-owned host-mount watcher mirrors host changes into guest
+        // fsnotify after this filter is installed. `notify` uses inotify on
+        // Linux; without these, enabling a `-v` mount kills an enforced VMM.
+        libc::SYS_inotify_init1, libc::SYS_inotify_add_watch, libc::SYS_inotify_rm_watch,
         // memory (guest RAM, dlopen of libkrun)
         libc::SYS_mmap, libc::SYS_munmap, libc::SYS_mremap, libc::SYS_mprotect,
         libc::SYS_madvise, libc::SYS_brk,
@@ -703,6 +707,9 @@ fn build_seccomp_program(enforce: bool) -> std::result::Result<seccompiler::BpfP
         libc::SYS_access,
         libc::SYS_epoll_wait,
         libc::SYS_poll,
+        // notify-rs uses legacy inotify_init on x86_64; newer architectures
+        // expose only inotify_init1.
+        libc::SYS_inotify_init,
         libc::SYS_arch_prctl,
     ]);
     #[cfg(target_arch = "aarch64")]

--- a/src/vm/backend/libkrun.rs
+++ b/src/vm/backend/libkrun.rs
@@ -153,7 +153,13 @@ impl LibkrunVm {
                     "root DAX requires libkrun with krun_add_virtiofs3",
                 ));
             };
-            let ret = krun_add_virtiofs3(ctx, root_tag.as_ptr(), root.as_ptr(), 1 << 29, false);
+            let ret = krun_add_virtiofs3(
+                ctx,
+                root_tag.as_ptr(),
+                root.as_ptr(),
+                crate::agent::virtiofs::rootfs_dax_window(),
+                false,
+            );
             tracing::debug!("[libkrun] krun_add_virtiofs3(root) returned: {}", ret);
             if ret < 0 {
                 krun_free_ctx(ctx);
@@ -238,31 +244,21 @@ impl LibkrunVm {
                 return Err(Error::vm_creation("failed to set exec command"));
             }
 
-            // Add virtiofs mounts for host directories. Prefer krun_add_virtiofs3
-            // with a DAX window (like the root fs): without DAX, virtiofs falls
-            // back to writeback caching where every file access is a FUSE
-            // round-trip over the virtio queue — pathological for read-heavy
-            // mounts with many files (e.g. a multi-GB Python venv taking minutes
-            // just to import). DAX maps file contents through a coherent host
-            // window, giving near-native read throughput. Fall back to the plain
-            // API only on an older libkrun that lacks virtiofs3.
-            // 2 GiB: the window must exceed the largest single file mapped from
-            // the volume, or mapping that file stalls (a 902 MB libtorch_cuda.so
-            // hung against a 512 MB window). The window is virtual host address
-            // space backed on demand, so oversizing costs nothing until touched.
-            const VIRTIOFS_DAX_WINDOW: u64 = 1 << 31;
+            // User mounts follow the same explicit DAX policy as the agent and
+            // packed launchers. Read-only enforcement still requires virtiofs3.
             for (i, mount) in config.mounts.iter().enumerate() {
                 let tag = CString::new(HostMount::mount_tag(i))
                     .map_err(|_| Error::mount("create mount tag", "tag contains null byte"))?;
                 let path = path_to_cstring(&mount.source)?;
 
                 // `krun_add_virtiofs3` is already unwrapped above (the root fs
-                // requires it), so use it directly with a DAX window.
+                // requires it), so use it directly with the shared policy.
+                let dax_window = crate::agent::virtiofs::user_mount_dax_window(&mount.target);
                 let ret = krun_add_virtiofs3(
                     ctx,
                     tag.as_ptr(),
                     path.as_ptr(),
-                    VIRTIOFS_DAX_WINDOW,
+                    dax_window,
                     mount.read_only,
                 );
                 if ret < 0 {
@@ -270,6 +266,13 @@ impl LibkrunVm {
                         "failed to add virtiofs mount: {} -> {}",
                         mount.source.display(),
                         mount.target.display()
+                    );
+                }
+                if dax_window > 0 {
+                    tracing::info!(
+                        tag = %HostMount::mount_tag(i),
+                        dax_window_mib = dax_window >> 20,
+                        "virtiofs DAX enabled"
                     );
                 }
             }

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,7 +4,6 @@ Integration tests for smolvm. All tests invoke the `smolvm` binary directly
 against real VMs — no mocking.
 
 ---
-
 ## Runner: `run_tests.sh`
 
 Single entry point for all test suites.
@@ -22,7 +21,7 @@ SMOLVM_SKIP_SLOW=1 ./tests/run_tests.sh   # skip tests with long sleeps (~5 min)
 | `bare` | `test_machine_bare.sh` | 22 | Lifecycle, exec, shell, file I/O, observability |
 | `db` | `test_db.sh` | 6 | DB state persistence, VM state transitions |
 | `network` | `test_network.sh` | 17 | Network disable, DNS, egress, DNS filter, Smolfile allow_hosts |
-| `volumes` | `test_volumes.sh` | 6 | virtiofs mounts, /workspace priority |
+| `volumes` | `test_volumes.sh` | 9 | virtiofs mounts, hot reload, DAX, /workspace priority |
 | `ports` | `test_ports.sh` | 2 | Port mapping, cross-VM conflict detection |
 | `storage` | `test_storage.sh` | 12 | Overlay, image list, prune, storage resize |
 | `resources` | `test_resources.sh` | 8 | CLI validation — no VMs required |
@@ -94,4 +93,3 @@ Tests find the `smolvm` binary in this order:
 3. `dist/smolvm-*-darwin-*/smolvm` or `dist/smolvm-*-linux-*/smolvm`
 
 ---
-

--- a/tests/test_volumes.sh
+++ b/tests/test_volumes.sh
@@ -183,6 +183,49 @@ test_trusted_system_mount_is_explicit_and_readonly() {
     [[ ! -e "/etc/$probe" ]]
 }
 
+test_volume_mount_hot_reload_and_dax() {
+    local vm_name="vol-hot-reload-$$"
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    echo "before" > "$tmpdir/watched.txt"
+
+    $SMOLVM machine create --name "$vm_name" --cpus 2 --mem 512 \
+        -v "$tmpdir:/work" >/dev/null 2>&1 || { rm -rf "$tmpdir"; return 1; }
+    SMOLVM_MOUNT_DAX=1 $SMOLVM machine start --name "$vm_name" >/dev/null 2>&1 || {
+        $SMOLVM machine delete --name "$vm_name" -f >/dev/null 2>&1
+        rm -rf "$tmpdir"
+        return 1
+    }
+
+    local mount_options
+    mount_options=$($SMOLVM machine exec --name "$vm_name" -- \
+        sh -lc "awk '\$2 == \"/work\" { print \$4 }' /proc/mounts")
+    if [[ "$mount_options" != *"dax=always"* ]]; then
+        echo "FAIL: DAX was requested but /work options were: $mount_options"
+        $SMOLVM machine stop --name "$vm_name" >/dev/null 2>&1 || true
+        $SMOLVM machine delete --name "$vm_name" -f >/dev/null 2>&1 || true
+        rm -rf "$tmpdir"
+        return 1
+    fi
+
+    local watcher_pid
+    watcher_pid=$($SMOLVM machine exec --name "$vm_name" --detach -- \
+        sh -lc 'exec inotifyd - /work >/tmp/host-events')
+    sleep 1
+    echo "after" > "$tmpdir/watched.txt"
+    sleep 1
+
+    local content events
+    content=$($SMOLVM machine exec --name "$vm_name" -- cat /work/watched.txt)
+    events=$($SMOLVM machine exec --name "$vm_name" -- cat /tmp/host-events)
+    $SMOLVM machine exec --name "$vm_name" -- kill "$watcher_pid" >/dev/null 2>&1 || true
+    $SMOLVM machine stop --name "$vm_name" >/dev/null 2>&1 || true
+    $SMOLVM machine delete --name "$vm_name" -f >/dev/null 2>&1 || true
+    rm -rf "$tmpdir"
+
+    [[ "$content" == "after" && "$events" == *"watched.txt"* ]]
+}
+
 test_default_workspace_symlink_without_volume() {
     local vm_name="vol-ws-default-$$"
 
@@ -297,6 +340,7 @@ run_test "Volume: mount visible to exec" test_machine_volume_mount_visible_to_ex
 run_test "Volume: -v host:/workspace is virtiofs not symlink" test_volume_mount_workspace_is_virtiofs_not_symlink || true
 run_test "Volume: arbitrary mount path (/data)" test_volume_mount_arbitrary_path || true
 run_test "Volume: trusted host system mount is explicit and read-only" test_trusted_system_mount_is_explicit_and_readonly || true
+run_test "Volume: host changes notify guest and DAX is consistent" test_volume_mount_hot_reload_and_dax || true
 run_test "Volume: default /workspace symlink without -v" test_default_workspace_symlink_without_volume || true
 run_test "Create with --image: volume mount visible to exec" test_image_exec_volume_mount_visible || true
 run_test "Create with --image: Smolfile volumes visible to exec" test_image_exec_volume_mount_visible_smolfile || true


### PR DESCRIPTION
Use buffered virtiofs writes, invalidate stale host-mount entries, and consistently wire DAX and host filesystem notifications across every launch path.