### PR TITLE
Resolve the guest agent rootfs in one place

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -14,6 +14,7 @@ mod launcher;
 pub mod launcher_dynamic;
 mod manager;
 pub mod pod_net;
+pub mod rootfs;
 pub mod state_probe;
 pub mod terminal;
 #[cfg(unix)]

--- a/src/agent/rootfs.rs
+++ b/src/agent/rootfs.rs
@@ -1,0 +1,85 @@
+//! The one place a host process decides which guest agent rootfs to boot.
+//!
+//! Every command that starts a guest (`machine start`), builds one into an
+//! artifact (`pack create`), or captures one (a portable checkpoint) must boot
+//! the *same* agent as the machines it operates on. Until now each had its own
+//! search with a different order and a different data directory, so on one box
+//! `pack create` could export a machine through an older agent than
+//! `machine start` had booted it with, failing deep inside the export with an
+//! unknown-request error the moment the agent protocol grew. Routing them all
+//! through [`resolve`] makes that disagreement impossible by construction.
+
+use std::path::{Path, PathBuf};
+
+use super::manager::AgentManager;
+use crate::{Error, Result};
+
+/// Locate the agent rootfs this host should boot.
+///
+/// An explicit `override_dir` (a `--rootfs-dir` flag) wins outright. Otherwise
+/// the search is the one `machine start` uses: `SMOLVM_AGENT_ROOTFS`, then
+/// `SMOLVM_AGENT_ROOTFS_TAR`, then a rootfs directory or bundled tarball next
+/// to the executable (extracted once and refreshed when the tarball changes),
+/// then the platform data directory. The result is checked to actually hold an
+/// agent (`sbin/init` is present) so a caller that copies it, rather than boots
+/// it, cannot silently package an empty directory.
+pub fn resolve(override_dir: Option<&Path>) -> Result<PathBuf> {
+    let dir = match override_dir {
+        Some(dir) => dir.to_path_buf(),
+        None => AgentManager::default_rootfs_path()?,
+    };
+    // `symlink_metadata`, not `exists`: `sbin/init` is a symlink to a guest-only
+    // target that does not exist on the host, and `exists` would follow it.
+    if std::fs::symlink_metadata(dir.join("sbin/init")).is_ok() {
+        return Ok(dir);
+    }
+    Err(Error::agent(
+        "find agent rootfs",
+        format!(
+            "no agent rootfs at {} (no sbin/init); set SMOLVM_AGENT_ROOTFS or pass --rootfs-dir",
+            dir.display()
+        ),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rootfs_with_init(root: &Path) -> PathBuf {
+        let dir = root.join("agent-rootfs");
+        std::fs::create_dir_all(dir.join("sbin")).unwrap();
+        // A dangling symlink, exactly as a real rootfs carries it on the host.
+        #[cfg(unix)]
+        std::os::unix::fs::symlink("/usr/local/bin/smolvm-agent", dir.join("sbin/init")).unwrap();
+        #[cfg(not(unix))]
+        std::fs::write(dir.join("sbin/init"), b"").unwrap();
+        dir
+    }
+
+    // An explicit directory is taken as given, but still has to be a rootfs:
+    // the point of one resolver is that no caller can be handed something that
+    // is not bootable.
+    #[test]
+    fn an_explicit_dir_wins_but_must_hold_an_agent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let good = rootfs_with_init(tmp.path());
+        assert_eq!(resolve(Some(&good)).unwrap(), good);
+
+        let empty = tmp.path().join("empty");
+        std::fs::create_dir_all(&empty).unwrap();
+        let err = resolve(Some(&empty)).unwrap_err().to_string();
+        assert!(err.contains("no sbin/init"), "got: {err}");
+    }
+
+    // The dangling `sbin/init` symlink must count as present. A resolver that
+    // used `exists()` here would reject every genuine rootfs on the host.
+    #[cfg(unix)]
+    #[test]
+    fn a_dangling_init_symlink_counts_as_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = rootfs_with_init(tmp.path());
+        assert!(!dir.join("sbin/init").exists(), "fixture must dangle");
+        assert!(resolve(Some(&dir)).is_ok());
+    }
+}

--- a/src/cli/pack.rs
+++ b/src/cli/pack.rs
@@ -937,36 +937,9 @@ impl PackCreateCmd {
     /// `target/agent-rootfs` is NOT checked — it can contain stale builds.
     /// Use `--rootfs-dir` or `SMOLVM_AGENT_ROOTFS` env var to override.
     fn find_rootfs_dir(&self) -> smolvm::Result<PathBuf> {
-        if let Some(ref dir) = self.rootfs_dir {
-            return Ok(dir.clone());
-        }
-
-        let candidates = [
-            // SMOLVM_AGENT_ROOTFS env var
-            std::env::var("SMOLVM_AGENT_ROOTFS").ok().map(PathBuf::from),
-            // Installed location (canonical)
-            dirs::data_dir().map(|d| d.join("smolvm/agent-rootfs")),
-            // Next to the executable (for distribution tarballs)
-            std::env::current_exe()
-                .ok()
-                .and_then(|p| p.parent().map(|d| d.join("agent-rootfs"))),
-        ];
-
-        for candidate in candidates.into_iter().flatten() {
-            // Use symlink_metadata instead of exists() because sbin/init
-            // is a symlink to a guest-only path (/usr/local/bin/smolvm-agent)
-            // that doesn't exist on the host. exists() follows symlinks and
-            // returns false for broken symlinks.
-            if std::fs::symlink_metadata(candidate.join("sbin/init")).is_ok() {
-                debug!(rootfs_dir = %candidate.display(), "found agent rootfs");
-                return Ok(candidate);
-            }
-        }
-
-        Err(Error::agent(
-            "find agent rootfs",
-            "could not find agent rootfs. Use --rootfs-dir to specify the location.",
-        ))
+        // The same search `machine start` uses, so the agent packed here is the
+        // one the machine was running.
+        smolvm::agent::rootfs::resolve(self.rootfs_dir.as_deref())
     }
 
     /// Find the smolvm binary to embed as the packed runtime.

--- a/src/portable_checkpoint.rs
+++ b/src/portable_checkpoint.rs
@@ -300,24 +300,9 @@ fn checkpoint_lib_dir(options: &CaptureOptions) -> Result<PathBuf> {
 }
 
 fn checkpoint_rootfs_dir(options: &CaptureOptions) -> Result<PathBuf> {
-    let candidates = [
-        options.rootfs_dir.clone(),
-        std::env::var_os("SMOLVM_AGENT_ROOTFS").map(PathBuf::from),
-        dirs::data_dir().map(|dir| dir.join("smolvm/agent-rootfs")),
-        std::env::current_exe()
-            .ok()
-            .and_then(|path| path.parent().map(|dir| dir.join("agent-rootfs"))),
-    ];
-    candidates
-        .into_iter()
-        .flatten()
-        .find(|candidate| std::fs::symlink_metadata(candidate.join("sbin/init")).is_ok())
-        .ok_or_else(|| {
-            Error::agent(
-                "find checkpoint agent rootfs",
-                "could not find agent rootfs; set SMOLVM_AGENT_ROOTFS",
-            )
-        })
+    // The same search `machine start` uses, so a checkpoint carries the agent
+    // the machine was actually booted with.
+    crate::agent::rootfs::resolve(options.rootfs_dir.as_deref())
 }
 
 fn validated_capture_source(name: &str) -> Result<SmolvmConfig> {


### PR DESCRIPTION
`machine start`, `pack create` and portable checkpoint capture each located the agent rootfs with their own search, differing in order (a tarball beside the binary won for one and lost for another), in the data directory used (`Local` versus `Roaming` on Windows) and in which override variables they honoured, so a machine could be exported through a different agent than it had booted with and fail only once the agent protocol grew; they now share the search `machine start` already used, checked to hold an agent before it is returned.