### PR TITLE
fix: validate local image archive CPU architecture and improve launcher symlink resolution

### DIFF
--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -1319,7 +1319,45 @@ fn recover_archive_config(archive: &Path, dest: &Path) -> Result<()> {
         StorageError::new("archive manifest.json has no Config entry".to_string())
     })?;
     let config_bytes = extract_tar_member(archive, config_path)?;
+    if let Ok(config_json) = serde_json::from_slice::<serde_json::Value>(&config_bytes) {
+        if let Some(arch) = config_json["architecture"].as_str() {
+            ensure_archive_arch_compatible(arch)?;
+        }
+    }
     std::fs::write(dest, &config_bytes)?;
+    Ok(())
+}
+
+/// Validate that a local image archive's architecture is compatible with the guest microVM.
+fn ensure_archive_arch_compatible(archive_arch: &str) -> Result<()> {
+    let guest_arch = match std::env::consts::ARCH {
+        "x86_64" => "amd64",
+        "aarch64" => "arm64",
+        other => other,
+    };
+    let norm_arch = match archive_arch.trim() {
+        "x86_64" => "amd64",
+        "aarch64" => "arm64",
+        "i386" | "i486" | "i586" | "i686" => "386",
+        "armhf" | "armel" | "armv5" | "armv6" | "armv7" => "arm",
+        other => other,
+    };
+
+    // If Rosetta translation is active on an arm64 guest, amd64 is supported.
+    let rosetta_supported =
+        guest_arch == "arm64" && norm_arch == "amd64" && crate::rosetta::is_enabled();
+
+    if matches!(
+        norm_arch,
+        "amd64" | "arm64" | "386" | "arm" | "riscv64" | "ppc64le" | "s390x"
+    ) && norm_arch != guest_arch
+        && !rosetta_supported
+    {
+        return Err(StorageError::new(format!(
+            "this local image archive is built for architecture '{archive_arch}', but this guest microVM is '{guest_arch}'. \
+             A local image archive carries native binaries and cannot run on an incompatible CPU architecture — save the image on or for an '{guest_arch}' system."
+        )));
+    }
     Ok(())
 }
 
@@ -4700,6 +4738,31 @@ fn dir_size(path: &Path) -> Result<u64> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    #[test]
+    fn test_archive_arch_compatibility() {
+        let guest_arch = match std::env::consts::ARCH {
+            "x86_64" => "amd64",
+            "aarch64" => "arm64",
+            other => other,
+        };
+        let other_arch = if guest_arch == "amd64" {
+            "arm64"
+        } else {
+            "386"
+        };
+
+        // Same arch is accepted
+        assert!(ensure_archive_arch_compatible(guest_arch).is_ok());
+        // Unknown / empty arch is leniently accepted
+        assert!(ensure_archive_arch_compatible("").is_ok());
+        assert!(ensure_archive_arch_compatible("unknown_arch").is_ok());
+        // Incompatible arch is rejected
+        let err = ensure_archive_arch_compatible(other_arch).unwrap_err();
+        assert!(err.to_string().contains("is built for architecture"));
+    }
+
     /// One empty layer is a legal OCI layer (metadata or whiteouts only), so
     /// verification must not reject an image just for containing one.
     #[test]

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -4863,7 +4863,6 @@ mod tests {
         assert!(err.to_string().contains("does not exist"), "got: {err}");
     }
 
-    use super::*;
     // OCI layer helpers now live in the shared crate; these tests exercise them
     // through its public API (the crate also unit-tests them independently).
     use smolvm_oci_layer::{classify_layer_entry, jailed_join, LayerEntry};

--- a/scripts/smol-wrapper.sh
+++ b/scripts/smol-wrapper.sh
@@ -11,6 +11,21 @@ set -e
 # Resolve symlinks to get the actual script location
 resolve_symlink() {
     local target="$1"
+    # If target is a relative path or bare command from PATH, resolve it to an absolute path first
+    if [[ "$target" != /* ]]; then
+        if [[ "$target" == */* ]]; then
+            target="$PWD/$target"
+        else
+            local found
+            found="$(command -v "$target" 2>/dev/null || type -P "$target" 2>/dev/null || true)"
+            if [[ -n "$found" && -e "$found" ]]; then
+                target="$found"
+            else
+                target="$PWD/$target"
+            fi
+        fi
+    fi
+
     while [[ -L "$target" ]]; do
         local link_dir
         link_dir="$(cd "$(dirname "$target")" && pwd)"

--- a/scripts/smolvm-wrapper.sh
+++ b/scripts/smolvm-wrapper.sh
@@ -7,6 +7,21 @@ set -e
 # Resolve symlinks to get the actual script location
 resolve_symlink() {
     local target="$1"
+    # If target is a relative path or bare command from PATH, resolve it to an absolute path first
+    if [[ "$target" != /* ]]; then
+        if [[ "$target" == */* ]]; then
+            target="$PWD/$target"
+        else
+            local found
+            found="$(command -v "$target" 2>/dev/null || type -P "$target" 2>/dev/null || true)"
+            if [[ -n "$found" && -e "$found" ]]; then
+                target="$found"
+            else
+                target="$PWD/$target"
+            fi
+        fi
+    fi
+
     while [[ -L "$target" ]]; do
         local link_dir
         link_dir="$(cd "$(dirname "$target")" && pwd)"

--- a/src/cli/pack.rs
+++ b/src/cli/pack.rs
@@ -287,6 +287,32 @@ impl PackCreateCmd {
                 "no image specified. Provide IMAGE argument or set 'image' in Smolfile",
             )
         })?;
+
+        // `pack create` pulls directly from an OCI container registry. If a user passes
+        // a local file path, image archive, or rootfs directory, provide a helpful diagnostic
+        // rather than failing on OCI reference character validation.
+        let image_trimmed = image.trim();
+        if image_trimmed.starts_with("./")
+            || image_trimmed.starts_with("../")
+            || image_trimmed.starts_with('/')
+            || image_trimmed.starts_with('~')
+            || image_trimmed.ends_with(".tar")
+            || image_trimmed.ends_with(".tar.gz")
+            || image_trimmed.ends_with(".tar.zst")
+            || image_trimmed.ends_with(".tgz")
+            || std::path::Path::new(image_trimmed).exists()
+        {
+            return Err(Error::config(
+                "pack create",
+                format!(
+                    "'--image' accepts container registry references (e.g. 'alpine:latest'). \
+                     To create a packed executable from a local image archive or rootfs directory ('{image}'), \
+                     first create the machine with 'smolvm machine create --image {image}' and then pack it \
+                     with 'smolvm pack create --from-vm <name>'."
+                ),
+            ));
+        }
+
         info!(image = %image, output = %self.output.display(), "packing image");
 
         // Create temporary staging directory
@@ -1829,6 +1855,40 @@ mod tests {
             client.identity_token(),
             Some("eyJ_identity"),
             "identity_token must take precedence over password"
+        );
+    }
+
+    #[test]
+    fn pack_create_rejects_local_archive_paths_with_clear_diagnostic() {
+        let cmd = PackCreateCmd {
+            image: Some("./local-image.tar".to_string()),
+            from_vm: None,
+            rebase_from_image: false,
+            output: PathBuf::from("test-output"),
+            cpus: 2,
+            mem: 1024,
+            oci_platform: None,
+            entrypoint: None,
+            no_sign: false,
+            single_file: false,
+            stub: None,
+            lib_dir: None,
+            rootfs_dir: None,
+            smolfile: None,
+            gpu: false,
+            staging_dir: None,
+            proxy_opts: crate::cli::proxy_opts::ProxyOpts::default(),
+        };
+
+        let err = cmd.run().expect_err("local archive path must be rejected");
+        let err_msg = err.to_string();
+        assert!(
+            err_msg.contains("'--image' accepts container registry references"),
+            "Expected registry reference explanation, got: {err_msg}"
+        );
+        assert!(
+            err_msg.contains("pack create --from-vm"),
+            "Expected recommendation to use pack create --from-vm, got: {err_msg}"
         );
     }
 }


### PR DESCRIPTION
### Summary

1. **Local Image Archive CPU Architecture Validation (#912)**:
   - Validates extracted image architecture against guest microVM CPU (including Rosetta translation on Apple Silicon) before boot.
   - Prevents cryptic runtime failures from incompatible architectures.

2. **Pack Diagnostic for Local Paths (#912)**:
   - When `smolvm pack create --image` receives a local archive/directory, provides actionable guidance to use `smolvm machine create --image` first, instead of failing on OCI reference validation.

3. **Launcher Softlink Resolution (#988)**:
   - Updates `resolve_symlink` in wrapper scripts to normalize relative paths and bare `$PATH` commands to absolute paths before following symlinks.

Fixes #912, #988