### PR TITLE
Make branching the primary machine lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ A tool to build and run portable, self-contained virtual machines locally. <200m
 | Linux x86_64 / aarch64 | matching Linux | KVM | `/dev/kvm` |
 | Windows x86_64 | x86_64 Linux | Windows Hypervisor Platform (WHP) | WHP feature enabled |
 
-Windows caveats (run, persistent machines, volumes, port-forwarding, pack create/run, and interactive TTY all work): networking is TSI-only (TCP/UDP + inbound `-p`, no virtio-net); no GPU acceleration; no fork/snapshot. `pack create` needs `storage-template.ext4` / `overlay-template.ext4` beside `smolvm.exe` (Windows has no host `mkfs.ext4`). Set `SMOLVM_LIB_DIR` (folder holding `krun.dll` + `libkrunfw.dll`) and `SMOLVM_AGENT_ROOTFS` when running from a non-standard layout.
+Windows caveats (run, persistent machines, volumes, port-forwarding, pack create/run, and interactive TTY all work): networking is TSI-only (TCP/UDP + inbound `-p`, no virtio-net); no GPU acceleration; no branch/snapshot. `pack create` needs `storage-template.ext4` / `overlay-template.ext4` beside `smolvm.exe` (Windows has no host `mkfs.ext4`). Set `SMOLVM_LIB_DIR` (folder holding `krun.dll` + `libkrunfw.dll`) and `SMOLVM_AGENT_ROOTFS` when running from a non-standard layout.
 
 ## Quick Reference
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ Common keys: `image`, `cpus`, `memory`, `net`, `ports`, `volumes`, `env`,
 `init`, `workdir`, `gpu`, `cuda`, `docker_socket`, `storage`, `overlay`, and the
 `[network]`, `[dev]`, `[auth]`, `[health]`, `[restart]`, `[service]` tables.
 
+### Branch a running machine
+
+Start a prepared machine as branchable, then create independent copy-on-write
+children from its live RAM and disk state:
+
+```bash
+smolvm machine start --name source --branchable
+smolvm machine branch --from source --name child
+smolvm machine branch --from source --count 8 --name-prefix worker --parallel 8
+```
+
+Add `--branchable` to a child when it must branch again. `fork`, `--golden`, and
+`--forkable` remain compatibility aliases; `checkpoint` is reserved for a
+durable `.smolcheckpoint` artifact that can be restored later or elsewhere.
+
 ### Snapshot a machine into a reusable image
 
 You don't need a Dockerfile to keep an environment. Set a machine up however you
@@ -235,7 +250,7 @@ Known Limitations
 * macOS: binary must be signed with Hypervisor.framework entitlements (`com.apple.security.hypervisor`). The shipped release is; a re-signed or freshly built binary silently loses it and every VM start then fails with `krun_start_enter returned: -22 (EINVAL)`. Re-sign it (ad-hoc is fine): `codesign --force --sign - --entitlements hv.entitlements <smolvm-bin>` where `hv.entitlements` is a plist containing `<key>com.apple.security.hypervisor</key><true/>`.
 * `--ssh-agent` requires an SSH agent running on the host (`SSH_AUTH_SOCK` must be set).
 * GPU acceleration requires libkrun built with `GPU=1` and virglrenderer + a Vulkan driver on the host (see [GPU Acceleration](#gpu-acceleration) below).
-* Windows: `--net` works the same as on other platforms (virtio-net with inbound port-forwarding; TSI for outbound-only VMs), as do `machine exec` / interactive sessions and `machine stats`. Not yet available on Windows: GPU acceleration and `machine fork` / snapshot. Pack *create* needs `storage-template.ext4` / `overlay-template.ext4` next to `smolvm.exe` (Windows has no host `mkfs.ext4`).
+* Windows: `--net` works the same as on other platforms (virtio-net with inbound port-forwarding; TSI for outbound-only VMs), as do `machine exec` / interactive sessions and `machine stats`. Not yet available on Windows: GPU acceleration and `machine branch` / snapshot. Pack *create* needs `storage-template.ext4` / `overlay-template.ext4` next to `smolvm.exe` (Windows has no host `mkfs.ext4`).
 
 GPU Acceleration
 ----------------

--- a/crates/smolvm-agent/src/forkpoint.rs
+++ b/crates/smolvm-agent/src/forkpoint.rs
@@ -1,8 +1,8 @@
-//! Workload-facing live-fork coordination.
+//! Workload-facing live-branch coordination.
 //!
-//! A workload calls `smolvm-fork-ready` after initialization. The helper writes
+//! A workload calls `smolvm-branch-ready` after initialization. The helper writes
 //! a marker and blocks, so the application cannot mutate training state while
-//! the host freezes the golden. Restored clones are released independently by
+//! the host captures the source. Restored children are released independently by
 //! the host through a VM-private directory bind-mounted into the container.
 
 use std::io::{Read as _, Write as _};
@@ -12,9 +12,10 @@ use std::time::Duration;
 
 const AGENT_BINARY: &str = "/usr/local/bin/smolvm-agent";
 use smolvm_protocol::forkpoint::{
-    CUDA_PRELOAD_MODULES_HINT, FORK_ENV_PATH, GENERATION_PREFIX, HELPER_PATH, LEGACY_RELEASE_TOKEN,
-    READY_PATH, READY_VERSION, RELEASE_PATH, RELEASE_PREFIX, RESTORED_CONTAINER_PATH,
-    RESTORED_PATH, STATE_DIR, WORKER_READY_HELPER_PATH, WORKER_READY_PATH, WORKER_READY_TOKEN_ENV,
+    BRANCH_ENV_PATH, BRANCH_HELPER_PATH, CUDA_PRELOAD_MODULES_HINT, FORK_ENV_PATH,
+    GENERATION_PREFIX, HELPER_PATH, LEGACY_RELEASE_TOKEN, READY_PATH, READY_VERSION, RELEASE_PATH,
+    RELEASE_PREFIX, RESTORED_CONTAINER_PATH, RESTORED_PATH, STATE_DIR, WORKER_READY_HELPER_PATH,
+    WORKER_READY_PATH, WORKER_READY_TOKEN_ENV,
 };
 
 fn enabled() -> bool {
@@ -29,8 +30,11 @@ pub fn helper_requested() -> bool {
     let argv0 = args.next().unwrap_or_default();
     let helper_argv0 = Path::new(&argv0)
         .file_name()
-        .is_some_and(|name| name == "smolvm-fork-ready");
-    helper_argv0 || args.next().is_some_and(|arg| arg == "fork-ready")
+        .is_some_and(|name| name == "smolvm-fork-ready" || name == "smolvm-branch-ready");
+    helper_argv0
+        || args
+            .next()
+            .is_some_and(|arg| arg == "fork-ready" || arg == "branch-ready")
 }
 
 /// Whether this invocation is the post-restore worker-readiness helper.
@@ -64,7 +68,7 @@ pub fn setup() {
     let _ = std::fs::remove_file(RELEASE_PATH);
     let _ = std::fs::remove_file(WORKER_READY_PATH);
 
-    for helper in [HELPER_PATH, WORKER_READY_HELPER_PATH] {
+    for helper in [BRANCH_HELPER_PATH, HELPER_PATH, WORKER_READY_HELPER_PATH] {
         if !Path::new(helper).exists() {
             if let Err(error) = std::os::unix::fs::symlink(AGENT_BINARY, helper) {
                 tracing::warn!(%error, helper, "failed to install bare-VM forkpoint helper");
@@ -89,6 +93,7 @@ fn inject_into_container_if(
         return;
     }
     spec.add_bind_mount(agent_binary, HELPER_PATH, true);
+    spec.add_bind_mount(agent_binary, BRANCH_HELPER_PATH, true);
     spec.add_bind_mount(agent_binary, WORKER_READY_HELPER_PATH, true);
     spec.add_bind_mount(state_dir, STATE_DIR, false);
 }
@@ -97,7 +102,7 @@ fn inject_into_container_if(
 pub fn run_helper() -> i32 {
     let preload_modules = std::env::args_os().any(|argument| argument == "--cuda-preload-modules");
     if let Err(error) = run_helper_inner(preload_modules) {
-        eprintln!("smolvm-fork-ready: {error}");
+        eprintln!("smolvm-branch-ready: {error}");
         return 1;
     }
     0
@@ -145,7 +150,7 @@ fn run_helper_at(
             ready_path.display()
         )
     })?;
-    println!("smolvm forkpoint ready; waiting for clone release");
+    println!("smolvm branch point ready; waiting for child release");
     let _ = std::io::stdout().flush();
 
     // Keep the snapshot boundary out of a timed kernel wait. Some VMM restore
@@ -172,9 +177,14 @@ fn run_helper_at(
 
 /// Publish the host-issued activation token after clone-local setup completes.
 pub fn run_worker_ready_helper() -> i32 {
+    let env_path = if Path::new(BRANCH_ENV_PATH).is_file() {
+        BRANCH_ENV_PATH
+    } else {
+        FORK_ENV_PATH
+    };
     if let Err(error) = write_worker_ready_at(
         Path::new(STATE_DIR),
-        Path::new(FORK_ENV_PATH),
+        Path::new(env_path),
         Path::new(WORKER_READY_PATH),
     ) {
         eprintln!("smolvm-worker-ready: {error}");
@@ -311,6 +321,7 @@ mod tests {
             .mounts
             .iter()
             .all(|mount| mount.destination != HELPER_PATH
+                && mount.destination != BRANCH_HELPER_PATH
                 && mount.destination != WORKER_READY_HELPER_PATH));
     }
 
@@ -336,6 +347,13 @@ mod tests {
             .unwrap();
         assert_eq!(helper.source, agent.to_str().unwrap());
         assert!(helper.options.iter().any(|option| option == "ro"));
+        let branch_helper = spec
+            .mounts
+            .iter()
+            .find(|mount| mount.destination == BRANCH_HELPER_PATH)
+            .unwrap();
+        assert_eq!(branch_helper.source, agent.to_str().unwrap());
+        assert!(branch_helper.options.iter().any(|option| option == "ro"));
         let worker_ready_helper = spec
             .mounts
             .iter()

--- a/crates/smolvm-protocol/src/forkpoint.rs
+++ b/crates/smolvm-protocol/src/forkpoint.rs
@@ -1,4 +1,4 @@
-//! Stable guest paths used to coordinate a live fork.
+//! Stable guest paths used to coordinate a live branch.
 
 /// Directory privately inherited by each restored VM.
 pub const STATE_DIR: &str = "/run/smolvm/forkpoint";
@@ -45,11 +45,17 @@ pub const WORKER_READY_PATH: &str = "/run/smolvm/forkpoint/worker-ready";
 /// Per-clone environment installed by the host before workload release.
 pub const FORK_ENV_PATH: &str = "/etc/smolvm/fork-env";
 
+/// Preferred branch-lifecycle alias for [`FORK_ENV_PATH`].
+pub const BRANCH_ENV_PATH: &str = "/etc/smolvm/branch-env";
+
 /// Host-generated readiness token delivered through [`FORK_ENV_PATH`].
 pub const WORKER_READY_TOKEN_ENV: &str = "SMOLVM_WORKER_READY_TOKEN";
 
 /// Workload-facing helper installed in bare VMs and workload containers.
 pub const HELPER_PATH: &str = "/usr/local/bin/smolvm-fork-ready";
+
+/// Preferred branch-lifecycle alias for [`HELPER_PATH`].
+pub const BRANCH_HELPER_PATH: &str = "/usr/local/bin/smolvm-branch-ready";
 
 /// Helper used by a released workload after clone-local preparation finishes.
 pub const WORKER_READY_HELPER_PATH: &str = "/usr/local/bin/smolvm-worker-ready";

--- a/crates/smolvm-smolfile/src/lib.rs
+++ b/crates/smolvm-smolfile/src/lib.rs
@@ -66,17 +66,18 @@
 //! | `allow_hosts` | string[] | Allowed hostnames (resolved to IPs at start) |
 //! | `allow_cidrs` | string[] | Allowed CIDR ranges (`"10.0.0.0/8"`) |
 //!
-//! ### `[fork]` — Forkable launch and CUDA capacity
+//! ### `[branch]` — Branchable launch and CUDA capacity
 //!
 //! Controls how a machine created from this Smolfile starts. A configured pool
 //! size implies `enabled = true` and applies the same transparent CUDA capacity
-//! policy as `machine start --fork-pool-size`.
+//! policy as `machine start --branch-pool-size`. `[fork]` remains accepted as a
+//! compatibility alias.
 //!
 //! | Field | Type | Description |
 //! |-------|------|-------------|
-//! | `enabled` | bool | Start as a copy-on-write fork base |
-//! | `pool_size` | int | Planned number of runnable CUDA clones; implies `enabled` |
-//! | `cuda_vram_limit_mib` | int | Logical VRAM limit per golden/clone; requires `pool_size` |
+//! | `enabled` | bool | Start as a copy-on-write branch source |
+//! | `pool_size` | int | Planned number of runnable CUDA children; implies `enabled` |
+//! | `cuda_vram_limit_mib` | int | Logical VRAM limit per source/child; requires `pool_size` |
 //!
 //! ### `[health]` — Health checks
 //!
@@ -160,7 +161,7 @@
 //! allow_hosts = ["pypi.org"]
 //! allow_cidrs = ["10.0.0.0/8"]
 //!
-//! [fork]
+//! [branch]
 //! enabled = true
 //! pool_size = 8
 //! cuda_vram_limit_mib = 8192
@@ -296,7 +297,11 @@ pub struct Smolfile {
     // Sections
     /// Network egress policy.
     pub network: Option<NetworkConfig>,
-    /// Forkable launch and CUDA fork-capacity policy.
+    /// Branchable launch and CUDA branch-capacity policy.
+    ///
+    /// `[branch]` is the preferred section name; `[fork]` remains accepted for
+    /// compatibility with existing Smolfiles.
+    #[serde(alias = "branch")]
     pub fork: Option<ForkConfig>,
     /// Health check configuration.
     pub health: Option<HealthConfig>,
@@ -320,18 +325,21 @@ pub struct NetworkConfig {
     pub allow_cidrs: Vec<String>,
 }
 
-/// Forkable launch and CUDA fork-capacity policy.
+/// Branchable launch and CUDA branch-capacity policy.
 #[derive(Debug, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct ForkConfig {
-    /// Start the machine as a copy-on-write fork base.
+    /// Start the machine as a copy-on-write branch source.
     pub enabled: Option<bool>,
-    /// Planned number of runnable CUDA clones. Implies `enabled`.
+    /// Planned number of runnable CUDA children. Implies `enabled`.
     pub pool_size: Option<u32>,
-    /// Explicit logical VRAM limit for each golden/clone CUDA session.
+    /// Explicit logical VRAM limit for each source/child CUDA session.
     /// Requires `pool_size`.
     pub cuda_vram_limit_mib: Option<u64>,
 }
+
+/// Preferred public name for [`ForkConfig`].
+pub type BranchConfig = ForkConfig;
 
 /// Credential forwarding configuration.
 #[derive(Debug, Deserialize, Default)]
@@ -637,6 +645,34 @@ cuda_vram_limit_mib = 4096
         assert_eq!(fork.enabled, Some(true));
         assert_eq!(fork.pool_size, Some(16));
         assert_eq!(fork.cuda_vram_limit_mib, Some(4096));
+    }
+
+    #[test]
+    fn parse_branch_section_and_reject_duplicate_legacy_section() {
+        let sf = parse(
+            r#"
+[branch]
+enabled = true
+pool_size = 16
+cuda_vram_limit_mib = 4096
+"#,
+        )
+        .unwrap();
+        let branch = sf.fork.unwrap();
+        assert_eq!(branch.enabled, Some(true));
+        assert_eq!(branch.pool_size, Some(16));
+        assert_eq!(branch.cuda_vram_limit_mib, Some(4096));
+
+        assert!(parse(
+            r#"
+[branch]
+enabled = true
+
+[fork]
+enabled = true
+"#,
+        )
+        .is_err());
     }
 
     #[test]

--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -2648,13 +2648,15 @@ pub fn activate_held_fork(
     );
     let receipt = format!("{}/activation", smolvm_protocol::forkpoint::STATE_DIR);
     let script = build_activation_script(
-        smolvm_protocol::forkpoint::READY_PATH,
-        smolvm_protocol::forkpoint::RELEASE_PATH,
-        smolvm_protocol::forkpoint::WORKER_READY_PATH,
-        &receipt,
+        ActivationScriptPaths {
+            ready: smolvm_protocol::forkpoint::READY_PATH,
+            release: smolvm_protocol::forkpoint::RELEASE_PATH,
+            worker_ready: smolvm_protocol::forkpoint::WORKER_READY_PATH,
+            receipt: &receipt,
+            env: &env_path,
+            branch_env: &branch_env_path,
+        },
         &ensure_env_parent,
-        &env_path,
-        &branch_env_path,
         &activation_token,
     );
     let socket = vm_data_dir(clone).join("agent.sock");
@@ -2826,16 +2828,28 @@ fn build_worker_ready_wait_script(worker_ready: &str) -> String {
     )
 }
 
+struct ActivationScriptPaths<'a> {
+    ready: &'a str,
+    release: &'a str,
+    worker_ready: &'a str,
+    receipt: &'a str,
+    env: &'a str,
+    branch_env: &'a str,
+}
+
 fn build_activation_script(
-    ready: &str,
-    release: &str,
-    worker_ready: &str,
-    receipt: &str,
+    paths: ActivationScriptPaths<'_>,
     ensure_env_parent: &str,
-    env_path: &str,
-    branch_env_path: &str,
     activation_token: &str,
 ) -> String {
+    let ActivationScriptPaths {
+        ready,
+        release,
+        worker_ready,
+        receipt,
+        env: env_path,
+        branch_env: branch_env_path,
+    } = paths;
     format!(
         "set -e; \
          if [ -f '{release}' ]; then \
@@ -3503,13 +3517,15 @@ mod tests {
         let token = "0123456789abcdef";
         std::fs::write(&worker_ready, b"stale\n").unwrap();
         let script = build_activation_script(
-            ready.to_str().unwrap(),
-            release.to_str().unwrap(),
-            worker_ready.to_str().unwrap(),
-            receipt.to_str().unwrap(),
+            ActivationScriptPaths {
+                ready: ready.to_str().unwrap(),
+                release: release.to_str().unwrap(),
+                worker_ready: worker_ready.to_str().unwrap(),
+                receipt: receipt.to_str().unwrap(),
+                env: env_path.to_str().unwrap(),
+                branch_env: branch_env_path.to_str().unwrap(),
+            },
             &ensure_parent,
-            env_path.to_str().unwrap(),
-            branch_env_path.to_str().unwrap(),
             token,
         );
 
@@ -3552,13 +3568,15 @@ mod tests {
         assert_eq!(std::fs::read_to_string(&env_path).unwrap(), "LR=1e-4\n");
 
         let other = build_activation_script(
-            ready.to_str().unwrap(),
-            release.to_str().unwrap(),
-            worker_ready.to_str().unwrap(),
-            receipt.to_str().unwrap(),
+            ActivationScriptPaths {
+                ready: ready.to_str().unwrap(),
+                release: release.to_str().unwrap(),
+                worker_ready: worker_ready.to_str().unwrap(),
+                receipt: receipt.to_str().unwrap(),
+                env: env_path.to_str().unwrap(),
+                branch_env: branch_env_path.to_str().unwrap(),
+            },
             &ensure_parent,
-            env_path.to_str().unwrap(),
-            branch_env_path.to_str().unwrap(),
             "fedcba9876543210",
         );
         assert_eq!(
@@ -3585,13 +3603,15 @@ mod tests {
         let token = "0123456789abcdef";
         std::fs::write(&receipt, format!("{token}\n")).unwrap();
         let script = build_activation_script(
-            ready.to_str().unwrap(),
-            release.to_str().unwrap(),
-            worker_ready.to_str().unwrap(),
-            receipt.to_str().unwrap(),
+            ActivationScriptPaths {
+                ready: ready.to_str().unwrap(),
+                release: release.to_str().unwrap(),
+                worker_ready: worker_ready.to_str().unwrap(),
+                receipt: receipt.to_str().unwrap(),
+                env: env_path.to_str().unwrap(),
+                branch_env: branch_env_path.to_str().unwrap(),
+            },
             &ensure_parent,
-            env_path.to_str().unwrap(),
-            branch_env_path.to_str().unwrap(),
             token,
         );
 

--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -2456,6 +2456,8 @@ fn rejuvenate_once(
 /// if the restored container is recycled — the overlay is the only surface
 /// shared by every instance and the running workload alike.
 pub const FORK_ENV_GUEST_PATH: &str = smolvm_protocol::forkpoint::FORK_ENV_PATH;
+/// Preferred branch-lifecycle alias for [`FORK_ENV_GUEST_PATH`].
+pub const BRANCH_ENV_GUEST_PATH: &str = smolvm_protocol::forkpoint::BRANCH_ENV_PATH;
 
 /// Validate per-fork parameters: keys must be non-empty `[A-Za-z_][A-Za-z0-9_]*`
 /// (they double as env var names for exec sessions) and values must be free of
@@ -2560,10 +2562,15 @@ pub fn write_fork_env(clone: &str, record: &VmRecord, env: &[(String, String)]) 
         format!(
             "if [ ! -d {merged} ]; then echo \"missing {merged}; overlays:\" >&2; \
              ls /storage/overlays >&2; exit 41; fi; \
-             mkdir -p {merged}/etc/smolvm && umask 077 && cat > {merged}{FORK_ENV_GUEST_PATH}"
+             mkdir -p {merged}/etc/smolvm && umask 077 && \
+             cat > {merged}{FORK_ENV_GUEST_PATH} && \
+             ln -sfn fork-env {merged}{BRANCH_ENV_GUEST_PATH}"
         )
     } else {
-        format!("mkdir -p /etc/smolvm && umask 077 && cat > {FORK_ENV_GUEST_PATH}")
+        format!(
+            "mkdir -p /etc/smolvm && umask 077 && cat > {FORK_ENV_GUEST_PATH} && \
+             ln -sfn fork-env {BRANCH_ENV_GUEST_PATH}"
+        )
     };
     let sock = vm_data_dir(clone).join("agent.sock");
     let mut client = AgentClient::connect_with_retry(&sock)
@@ -2616,6 +2623,11 @@ pub fn activate_held_fork(
     } else {
         FORK_ENV_GUEST_PATH.to_string()
     };
+    let branch_env_path = if record.image.is_some() {
+        format!("{merged_root}{BRANCH_ENV_GUEST_PATH}")
+    } else {
+        BRANCH_ENV_GUEST_PATH.to_string()
+    };
     let ensure_env_parent = if record.image.is_some() {
         format!(
             "if [ ! -d '{merged_root}' ]; then echo 'missing {merged_root}' >&2; exit 41; fi; \
@@ -2642,6 +2654,7 @@ pub fn activate_held_fork(
         &receipt,
         &ensure_env_parent,
         &env_path,
+        &branch_env_path,
         &activation_token,
     );
     let socket = vm_data_dir(clone).join("agent.sock");
@@ -2820,6 +2833,7 @@ fn build_activation_script(
     receipt: &str,
     ensure_env_parent: &str,
     env_path: &str,
+    branch_env_path: &str,
     activation_token: &str,
 ) -> String {
     format!(
@@ -2843,6 +2857,7 @@ fn build_activation_script(
          release_tmp='{release}.{activation_token}.'$$; \
          trap 'rm -f \"$env_tmp\" \"$release_tmp\"' EXIT; \
          cat > \"$env_tmp\"; mv \"$env_tmp\" '{env_path}'; \
+         ln -sfn fork-env '{branch_env_path}'; \
          if [ \"${{#generation}}\" -eq 32 ]; then \
            printf '%s%s\\n' '{release_prefix}' \"$generation\" > \"$release_tmp\"; \
          else printf '%s\\n' '{legacy_release}' > \"$release_tmp\"; fi; \
@@ -3483,6 +3498,7 @@ mod tests {
         let worker_ready = state.join("worker-ready");
         let receipt = state.join("activation");
         let env_path = workspace.join("fork-env");
+        let branch_env_path = workspace.join("branch-env");
         let ensure_parent = format!("mkdir -p '{}'", workspace.display());
         let token = "0123456789abcdef";
         std::fs::write(&worker_ready, b"stale\n").unwrap();
@@ -3493,6 +3509,7 @@ mod tests {
             receipt.to_str().unwrap(),
             &ensure_parent,
             env_path.to_str().unwrap(),
+            branch_env_path.to_str().unwrap(),
             token,
         );
 
@@ -3503,6 +3520,10 @@ mod tests {
             String::from_utf8_lossy(&first.stderr)
         );
         assert_eq!(std::fs::read_to_string(&env_path).unwrap(), "LR=1e-4\n");
+        assert_eq!(
+            std::fs::read_to_string(&branch_env_path).unwrap(),
+            "LR=1e-4\n"
+        );
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -3537,6 +3558,7 @@ mod tests {
             receipt.to_str().unwrap(),
             &ensure_parent,
             env_path.to_str().unwrap(),
+            branch_env_path.to_str().unwrap(),
             "fedcba9876543210",
         );
         assert_eq!(
@@ -3558,6 +3580,7 @@ mod tests {
         let worker_ready = state.join("worker-ready");
         let receipt = state.join("activation");
         let env_path = workspace.join("fork-env");
+        let branch_env_path = workspace.join("branch-env");
         let ensure_parent = format!("mkdir -p '{}'", workspace.display());
         let token = "0123456789abcdef";
         std::fs::write(&receipt, format!("{token}\n")).unwrap();
@@ -3568,6 +3591,7 @@ mod tests {
             receipt.to_str().unwrap(),
             &ensure_parent,
             env_path.to_str().unwrap(),
+            branch_env_path.to_str().unwrap(),
             token,
         );
 
@@ -3578,6 +3602,10 @@ mod tests {
             String::from_utf8_lossy(&retry.stderr)
         );
         assert_eq!(std::fs::read_to_string(&env_path).unwrap(), "LR=3e-4\n");
+        assert_eq!(
+            std::fs::read_to_string(&branch_env_path).unwrap(),
+            "LR=3e-4\n"
+        );
         assert!(release.is_file());
     }
 

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -114,9 +114,13 @@ fn record_to_info(name: &str, record: &VmRecord) -> MachineInfo {
         // when unset.
         storage_gb: Some(record.storage_gb.unwrap_or(DEFAULT_STORAGE_SIZE_GIB)),
         overlay_gb: Some(record.overlay_gb.unwrap_or(DEFAULT_OVERLAY_SIZE_GIB)),
+        branchable: record.forkable_on_start(),
         forkable: record.forkable_on_start(),
+        parent_machine: record.golden.clone(),
+        cuda_branch_pool_size: record.cuda_fork_pool_size,
         cuda_fork_pool_size: record.cuda_fork_pool_size,
         cuda_vram_limit_mib: record.cuda_vram_limit_mib,
+        branchpoint_held: record.forkpoint_held,
         forkpoint_held: record.forkpoint_held,
         // Cumulative egress, read from the per-VM telemetry file the subprocess
         // flushes. Surfaced here so the control plane reads it from the machine
@@ -1752,6 +1756,31 @@ pub async fn fork_machine(
     Json(req): Json<ForkRequest>,
 ) -> Result<Json<MachineInfo>, ApiError> {
     fork_machine_inner(state, golden, req).await.map(Json)
+}
+
+/// Branch a running, branchable source machine into a new independent child.
+#[utoipa::path(
+    post,
+    path = "/api/v1/machines/{name}/branches",
+    tag = "Machines",
+    params(
+        ("name" = String, Path, description = "Branch source machine name")
+    ),
+    request_body = ForkRequest,
+    responses(
+        (status = 200, description = "Child branched and running", body = MachineInfo),
+        (status = 400, description = "Invalid or unsupported branch request", body = ApiErrorResponse),
+        (status = 404, description = "Source machine not found", body = ApiErrorResponse),
+        (status = 409, description = "Source is not branchable, or child name already exists", body = ApiErrorResponse),
+        (status = 500, description = "Branch failed", body = ApiErrorResponse)
+    )
+)]
+pub async fn branch_machine(
+    State(state): State<Arc<ApiState>>,
+    Path(source): Path<String>,
+    Json(req): Json<ForkRequest>,
+) -> Result<Json<MachineInfo>, ApiError> {
+    fork_machine_inner(state, source, req).await.map(Json)
 }
 
 /// Internal fork entry point shared by the HTTP handler and pool reconciler.
@@ -3540,6 +3569,8 @@ mod tests {
         );
         record.gpu = Some(true);
         record.cuda = true;
+        record.forkable = true;
+        record.golden = Some("parent-vm".to_string());
 
         let info = record_to_info("test-vm", &record);
 
@@ -3552,6 +3583,11 @@ mod tests {
         assert!(!info.network);
         assert!(info.gpu);
         assert!(info.cuda);
+        assert!(info.branchable);
+        assert!(info.forkable);
+        assert_eq!(info.parent_machine.as_deref(), Some("parent-vm"));
+        assert_eq!(info.cuda_branch_pool_size, info.cuda_fork_pool_size);
+        assert_eq!(info.branchpoint_held, info.forkpoint_held);
         assert!(info.pid.is_none());
     }
 

--- a/src/api/handlers/pools.rs
+++ b/src/api/handlers/pools.rs
@@ -467,6 +467,7 @@ async fn pool_info(state: &ApiState, pool: ForkPoolRecord) -> Result<ForkPoolInf
     }
     Ok(ForkPoolInfo {
         name: pool.name,
+        source: pool.golden.clone(),
         golden: pool.golden,
         desired_ready: pool.desired_ready,
         max_active: pool.max_active,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -94,6 +94,7 @@ use state::ApiState;
         handlers::machines::get_machine,
         handlers::machines::get_machine_egress_events,
         handlers::machines::start_machine,
+        handlers::machines::branch_machine,
         handlers::machines::fork_machine,
         handlers::machines::release_held_fork,
         handlers::machines::stop_machine,
@@ -270,7 +271,12 @@ pub fn create_router(state: Arc<ApiState>, cors_origins: Vec<String>) -> Router 
             get(handlers::machines::get_machine_egress_events),
         )
         .route("/{id}/start", post(handlers::machines::start_machine))
+        .route("/{id}/branches", post(handlers::machines::branch_machine))
         .route("/{id}/fork", post(handlers::machines::fork_machine))
+        .route(
+            "/{id}/branch-release",
+            post(handlers::machines::release_held_fork),
+        )
         .route(
             "/{id}/fork-release",
             post(handlers::machines::release_held_fork),

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -1678,9 +1678,15 @@ pub fn machine_entry_to_info(name: String, entry: &MachineEntry) -> MachineInfo 
         allowed_hosts: entry.resources.allowed_hosts.clone(),
         storage_gb: entry.resources.storage_gb,
         overlay_gb: entry.resources.overlay_gb,
+        branchable: entry.forkable,
         forkable: entry.forkable,
+        // MachineEntry is an in-memory runtime view and does not retain the
+        // persisted parent relationship; database-backed responses include it.
+        parent_machine: None,
+        cuda_branch_pool_size: entry.cuda_fork_pool_size,
         cuda_fork_pool_size: entry.cuda_fork_pool_size,
         cuda_vram_limit_mib: entry.cuda_vram_limit_mib,
+        branchpoint_held: entry.forkpoint_held,
         forkpoint_held: entry.forkpoint_held,
         egress_bytes,
         cpu_seconds,

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -685,16 +685,26 @@ pub struct MachineInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(example = 2)]
     pub overlay_gb: Option<u64>,
-    /// Whether ordinary starts launch this machine as a fork base.
+    /// Whether ordinary starts launch this machine as a branch source.
+    pub branchable: bool,
+    /// Legacy alias for `branchable`.
     pub forkable: bool,
-    /// Planned runnable CUDA clone count used for automatic capacity budgeting.
+    /// Immediate parent machine when this machine was created by branching.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_machine: Option<String>,
+    /// Planned runnable CUDA child count used for automatic capacity budgeting.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cuda_branch_pool_size: Option<u32>,
+    /// Legacy alias for `cuda_branch_pool_size`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cuda_fork_pool_size: Option<u32>,
-    /// Explicit logical CUDA memory limit per golden/clone session, in MiB.
+    /// Explicit logical CUDA memory limit per source/child session, in MiB.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cuda_vram_limit_mib: Option<u64>,
-    /// True while this clone is an already-booted clean slot parked at the
-    /// workload forkpoint and available for one assignment.
+    /// True while this child is an already-booted clean slot parked at the
+    /// workload branchpoint and available for one assignment.
+    pub branchpoint_held: bool,
+    /// Legacy alias for `branchpoint_held`.
     pub forkpoint_held: bool,
     /// Cumulative guest-outbound (egress) bytes since boot, for billing. Present
     /// only for virtio-net machines that have reported a value; omitted for TSI
@@ -822,18 +832,18 @@ pub struct ResizeMachineRequest {
 /// Query string for `POST /machines/{name}/start`.
 #[derive(Debug, Default, Deserialize, ToSchema)]
 pub struct StartMachineQuery {
-    /// Start as a fork base: back the guest RAM with a memfd (copy-on-write
-    /// cloneable) and expose a control socket so the machine can later be forked
-    /// with `POST /machines/{name}/fork`. Linux/x86_64 keeps the source running;
+    /// Start as a branch source: back the guest RAM with a memfd (copy-on-write
+    /// cloneable) and expose a control socket so the machine can later be branched
+    /// with `POST /machines/{name}/branches`. Linux/x86_64 keeps the source running;
     /// other hosts retain it as the frozen copy-on-write base.
-    #[serde(default)]
+    #[serde(default, rename = "branchable", alias = "forkable")]
     pub forkable: bool,
-    /// Number of runnable CUDA fork clones planned for this golden. Supplying
-    /// it enables forkable launch and transparent pre-initialization VRAM
+    /// Number of runnable CUDA children planned for this source. Supplying it
+    /// enables branchable launch and transparent pre-initialization VRAM
     /// budgeting for cache-sizing frameworks.
-    #[serde(default, rename = "forkPoolSize")]
+    #[serde(default, rename = "branchPoolSize", alias = "forkPoolSize")]
     pub fork_pool_size: Option<u32>,
-    /// Explicit logical VRAM limit per golden/clone session, in MiB.
+    /// Explicit logical VRAM limit per source/child session, in MiB.
     #[serde(default, rename = "cudaVramLimitMib")]
     pub cuda_vram_limit_mib: Option<u64>,
 }
@@ -892,17 +902,17 @@ pub struct StartMachineRequest {
     pub registry_auth: Option<RegistryAuthSpec>,
 }
 
-/// Request to fork a running, forkable golden machine into a new clone.
+/// Request to branch a running, branchable source machine into a new child.
 #[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ForkRequest {
-    /// Name for the new clone machine.
+    /// Name for the new child machine.
     #[schema(example = "clone-1")]
     pub name: String,
-    /// Materialize the restored clone as a new checkpoint source so it can be
-    /// forked again. This pays one eager guest-memory copy at clone boot;
+    /// Materialize the restored child as a new branch source so it can be
+    /// branched again. This pays one eager guest-memory copy at child boot;
     /// descendants remain copy-on-write.
-    #[serde(default)]
+    #[serde(default, rename = "branchable", alias = "forkable")]
     pub forkable: bool,
     /// Pin the clone's inbound port forwards. Without this, the golden's
     /// forwards are remapped to freshly-allocated host ports so the clone does
@@ -943,6 +953,9 @@ pub struct ForkRequest {
     pub secrets: RequestSecretRefs,
 }
 
+/// Preferred public name for [`ForkRequest`].
+pub type BranchRequest = ForkRequest;
+
 /// Assignment for one already-booted held fork slot.
 #[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
@@ -952,6 +965,9 @@ pub struct ForkReleaseRequest {
     #[serde(default)]
     pub env: Vec<String>,
 }
+
+/// Preferred public name for [`ForkReleaseRequest`].
+pub type BranchReleaseRequest = ForkReleaseRequest;
 
 // ============================================================================
 // Automatic fork-pool types
@@ -964,8 +980,9 @@ pub struct CreateForkPoolRequest {
     /// Stable pool name.
     #[schema(example = "grpo-rollouts")]
     pub name: String,
-    /// Existing running forkable machine whose workload is at the forkpoint.
-    #[schema(example = "policy-golden")]
+    /// Existing running branchable machine whose workload is at the branch point.
+    #[serde(rename = "source", alias = "golden")]
+    #[schema(example = "policy-source")]
     pub golden: String,
     /// Number of clean workers kept booted and ready.
     #[schema(example = 8)]
@@ -988,6 +1005,9 @@ pub struct CreateForkPoolRequest {
     pub lease_ttl_secs: Option<u64>,
 }
 
+/// Preferred public name for [`CreateForkPoolRequest`].
+pub type CreateBranchPoolRequest = CreateForkPoolRequest;
+
 /// Query parameters for deleting a fork pool.
 #[derive(Debug, Clone, Default, Deserialize, ToSchema)]
 pub struct DeleteForkPoolQuery {
@@ -995,6 +1015,9 @@ pub struct DeleteForkPoolQuery {
     #[serde(default)]
     pub force: bool,
 }
+
+/// Preferred public name for [`DeleteForkPoolQuery`].
+pub type DeleteBranchPoolQuery = DeleteForkPoolQuery;
 
 /// Request to change a pool's clean-worker target.
 #[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
@@ -1004,13 +1027,18 @@ pub struct ResizeForkPoolRequest {
     pub desired_ready: u32,
 }
 
+/// Preferred public name for [`ResizeForkPoolRequest`].
+pub type ResizeBranchPoolRequest = ResizeForkPoolRequest;
+
 /// Current size and lifecycle state of an automatic fork pool.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ForkPoolInfo {
     /// Stable pool name.
     pub name: String,
-    /// Forkable source machine.
+    /// Branchable source machine.
+    pub source: String,
+    /// Legacy alias for `source`.
     pub golden: String,
     /// Configured clean-worker target.
     pub desired_ready: u32,
@@ -1066,12 +1094,18 @@ pub struct ForkPoolInfo {
     pub created_at: u64,
 }
 
+/// Preferred public name for [`ForkPoolInfo`].
+pub type BranchPoolInfo = ForkPoolInfo;
+
 /// List response for automatic fork pools.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct ListForkPoolsResponse {
     /// All pools on this node.
     pub pools: Vec<ForkPoolInfo>,
 }
+
+/// Preferred public name for [`ListForkPoolsResponse`].
+pub type ListBranchPoolsResponse = ListForkPoolsResponse;
 
 /// Request to acquire one clean worker from a fork pool.
 #[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
@@ -1103,6 +1137,9 @@ pub struct AcquireForkLeaseRequest {
     pub rollout_access: Option<RolloutLeaseAccess>,
 }
 
+/// Preferred public name for [`AcquireForkLeaseRequest`].
+pub type AcquireBranchLeaseRequest = AcquireForkLeaseRequest;
+
 /// A bounded group of ordinary fork-pool lease requests.
 #[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
@@ -1111,6 +1148,9 @@ pub struct AcquireForkLeaseBatchRequest {
     /// at most 32 items may wait for workload readiness in one call.
     pub leases: Vec<AcquireForkLeaseRequest>,
 }
+
+/// Preferred public name for [`AcquireForkLeaseBatchRequest`].
+pub type AcquireBranchLeaseBatchRequest = AcquireForkLeaseBatchRequest;
 
 /// One ordered result from a fork-pool lease batch.
 #[derive(Debug, Clone, Serialize, ToSchema)]
@@ -1129,6 +1169,9 @@ pub struct ForkLeaseBatchItemResponse {
     pub error: Option<String>,
 }
 
+/// Preferred public name for [`ForkLeaseBatchItemResponse`].
+pub type BranchLeaseBatchItemResponse = ForkLeaseBatchItemResponse;
+
 /// Ordered results from a bounded fork-pool lease batch.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
@@ -1136,6 +1179,9 @@ pub struct AcquireForkLeaseBatchResponse {
     /// One result per submitted lease request, in input order.
     pub leases: Vec<ForkLeaseBatchItemResponse>,
 }
+
+/// Preferred public name for [`AcquireForkLeaseBatchResponse`].
+pub type AcquireBranchLeaseBatchResponse = AcquireForkLeaseBatchResponse;
 
 /// Least-privilege fused-rollout scope injected into one pool worker.
 #[derive(Debug, Clone, Deserialize, Serialize, ToSchema, PartialEq, Eq)]
@@ -1162,6 +1208,9 @@ pub struct ForkLeasePayloadFile {
     #[schema(example = 420)]
     pub mode: Option<u32>,
 }
+
+/// Preferred public name for [`ForkLeasePayloadFile`].
+pub type BranchLeasePayloadFile = ForkLeasePayloadFile;
 
 impl std::fmt::Debug for ForkLeasePayloadFile {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -1193,6 +1242,9 @@ pub struct ForkLeaseInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
+
+/// Preferred public name for [`ForkLeaseInfo`].
+pub type BranchLeaseInfo = ForkLeaseInfo;
 
 #[cfg(test)]
 mod deny_unknown_field_tests {
@@ -1307,5 +1359,45 @@ mod registry_auth_tests {
         assert!(!request.wait_ready);
         assert!(!request.hold);
         assert_eq!(request.ready_timeout_secs, None);
+    }
+
+    #[test]
+    fn branch_requests_accept_new_and_legacy_branchable_names() {
+        let branch: ForkRequest = serde_json::from_value(serde_json::json!({
+            "name": "child-1",
+            "branchable": true
+        }))
+        .unwrap();
+        assert!(branch.forkable);
+
+        let legacy: ForkRequest = serde_json::from_value(serde_json::json!({
+            "name": "child-2",
+            "forkable": true
+        }))
+        .unwrap();
+        assert!(legacy.forkable);
+
+        let serialized = serde_json::to_value(branch).unwrap();
+        assert_eq!(serialized["branchable"], true);
+        assert!(serialized.get("forkable").is_none());
+    }
+
+    #[test]
+    fn start_query_accepts_new_and_legacy_branchable_names() {
+        let branch: StartMachineQuery =
+            serde_json::from_value(serde_json::json!({"branchable": true})).unwrap();
+        assert!(branch.forkable);
+
+        let legacy: StartMachineQuery =
+            serde_json::from_value(serde_json::json!({"forkable": true})).unwrap();
+        assert!(legacy.forkable);
+
+        let branch_pool: StartMachineQuery =
+            serde_json::from_value(serde_json::json!({"branchPoolSize": 8})).unwrap();
+        assert_eq!(branch_pool.fork_pool_size, Some(8));
+
+        let legacy_pool: StartMachineQuery =
+            serde_json::from_value(serde_json::json!({"forkPoolSize": 4})).unwrap();
+        assert_eq!(legacy_pool.fork_pool_size, Some(4));
     }
 }

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -331,14 +331,16 @@ pub enum MachineCmd {
     /// Start a machine
     Start(StartCmd),
 
-    /// Fork a running forkable machine into a new clone (CoW memory + disks)
-    Fork(ForkCmd),
+    /// Branch a running branchable machine into an independent child (CoW memory + disks)
+    #[command(name = "branch", visible_alias = "fork")]
+    Branch(ForkCmd),
 
     /// Save a running machine, including RAM, as a portable checkpoint
     Checkpoint(super::pack::CheckpointCmd),
 
-    /// Assign parameters and release one held fork-pool slot
-    ForkRelease(ForkReleaseCmd),
+    /// Assign parameters and release one held branch-pool slot
+    #[command(name = "branch-release", visible_alias = "fork-release")]
+    BranchRelease(ForkReleaseCmd),
 
     /// Stop a running machine
     Stop(StopCmd),
@@ -412,9 +414,9 @@ impl MachineCmd {
             MachineCmd::Exec(cmd) => cmd.run(),
             MachineCmd::Create(cmd) => cmd.run(),
             MachineCmd::Start(cmd) => cmd.run(),
-            MachineCmd::Fork(cmd) => cmd.run(),
+            MachineCmd::Branch(cmd) => cmd.run(),
             MachineCmd::Checkpoint(cmd) => cmd.run(),
-            MachineCmd::ForkRelease(cmd) => cmd.run(),
+            MachineCmd::BranchRelease(cmd) => cmd.run(),
             MachineCmd::Stop(cmd) => cmd.run(),
             MachineCmd::Delete(cmd) => cmd.run(),
             MachineCmd::Status(cmd) => cmd.run(),
@@ -2398,11 +2400,11 @@ mod tests {
     }
 
     #[test]
-    fn fork_accepts_single_and_batch_forms() {
+    fn branch_accepts_single_batch_and_legacy_fork_forms() {
         let single =
-            TestMachineCli::parse_from(["machine", "fork", "--golden", "base", "--name", "worker"]);
-        let MachineCmd::Fork(single) = single.command else {
-            panic!("expected machine fork command");
+            TestMachineCli::parse_from(["machine", "branch", "--from", "base", "--name", "worker"]);
+        let MachineCmd::Branch(single) = single.command else {
+            panic!("expected machine branch command");
         };
         assert_eq!(single.clone.as_deref(), Some("worker"));
         assert_eq!(single.count.get(), 1);
@@ -2410,8 +2412,8 @@ mod tests {
 
         let batch = TestMachineCli::parse_from([
             "machine",
-            "fork",
-            "--golden",
+            "branch",
+            "--from",
             "base",
             "--count",
             "8",
@@ -2422,8 +2424,8 @@ mod tests {
             "--ready-timeout",
             "2m",
         ]);
-        let MachineCmd::Fork(batch) = batch.command else {
-            panic!("expected machine fork command");
+        let MachineCmd::Branch(batch) = batch.command else {
+            panic!("expected machine branch command");
         };
         assert_eq!(batch.count.get(), 8);
         assert_eq!(batch.name_prefix.as_deref(), Some("worker"));
@@ -2450,17 +2452,32 @@ mod tests {
 
         let release = TestMachineCli::parse_from([
             "machine",
-            "fork-release",
+            "branch-release",
             "--name",
             "worker-0",
             "--env",
             "LR=3e-4",
         ]);
-        let MachineCmd::ForkRelease(release) = release.command else {
-            panic!("expected fork-release command");
+        let MachineCmd::BranchRelease(release) = release.command else {
+            panic!("expected branch-release command");
         };
         assert_eq!(release.name, "worker-0");
         assert_eq!(release.env, vec!["LR=3e-4"]);
+
+        let legacy = TestMachineCli::parse_from([
+            "machine",
+            "fork",
+            "--golden",
+            "base",
+            "--name",
+            "legacy-worker",
+            "--forkable",
+        ]);
+        let MachineCmd::Branch(legacy) = legacy.command else {
+            panic!("expected legacy fork alias to resolve to branch command");
+        };
+        assert_eq!(legacy.golden, "base");
+        assert!(legacy.forkable);
     }
 
     #[test]
@@ -2486,8 +2503,12 @@ mod tests {
             vec![
                 ("TRIAL".to_string(), "3".to_string()),
                 ("OUTPUT".to_string(), "/runs/worker-3".to_string()),
+                ("SMOLVM_BRANCH_INDEX".to_string(), "3".to_string()),
+                ("SMOLVM_BRANCH_NAME".to_string(), "worker-3".to_string()),
                 ("SMOLVM_FORK_INDEX".to_string(), "3".to_string()),
                 ("SMOLVM_FORK_NAME".to_string(), "worker-3".to_string()),
+                ("SMOLVM_BRANCH_BATCH_ID".to_string(), "batch-1".to_string()),
+                ("SMOLVM_BRANCH_BATCH_SIZE".to_string(), "8".to_string()),
                 ("SMOLVM_FORK_BATCH_ID".to_string(), "batch-1".to_string()),
                 ("SMOLVM_FORK_BATCH_SIZE".to_string(), "8".to_string()),
             ]
@@ -2497,6 +2518,8 @@ mod tests {
             vec![
                 ("TRIAL".to_string(), "3".to_string()),
                 ("OUTPUT".to_string(), "/runs/worker-3".to_string()),
+                ("SMOLVM_BRANCH_INDEX".to_string(), "3".to_string()),
+                ("SMOLVM_BRANCH_NAME".to_string(), "worker-3".to_string()),
                 ("SMOLVM_FORK_INDEX".to_string(), "3".to_string()),
                 ("SMOLVM_FORK_NAME".to_string(), "worker-3".to_string()),
             ]
@@ -3200,7 +3223,7 @@ pub struct CreateCmd {
 
     /// Command to run as the machine's persistent workload (image machines).
     /// Launched as a detached container on every `start`, so it stays running
-    /// (e.g. a pre-warmed browser to be forked). Without this, the image's own
+    /// (e.g. a pre-warmed browser to be branched). Without this, the image's own
     /// ENTRYPOINT/CMD is launched instead; if the image defines neither (e.g.
     /// a bare rootfs directory), the machine boots to just the agent and
     /// commands come from `exec`/`shell`.
@@ -3826,20 +3849,24 @@ pub struct StartCmd {
     #[arg(short = 'n', long, value_name = "NAME")]
     pub name: Option<String>,
 
-    /// Start as a fork base: back guest RAM with a memfd (CoW-cloneable) and
-    /// expose a control socket so the machine can be forked with `machine fork`.
-    #[arg(long)]
+    /// Start as a branch source: back guest RAM with a memfd (CoW-cloneable) and
+    /// expose a control socket so the running machine can later be branched.
+    #[arg(long = "branchable", visible_alias = "forkable")]
     pub forkable: bool,
 
-    /// Plan a CUDA fork pool with this many runnable clones. Smolvm reports a
-    /// safe per-session VRAM share before the golden initializes, so vLLM and
+    /// Plan a CUDA branch pool with this many runnable children. Smolvm reports a
+    /// safe per-session VRAM share before the source initializes, so vLLM and
     /// similar runtimes size private caches without workload changes. Implies
-    /// --forkable.
-    #[arg(long, value_name = "CLONES")]
+    /// --branchable.
+    #[arg(
+        long = "branch-pool-size",
+        visible_alias = "fork-pool-size",
+        value_name = "CHILDREN"
+    )]
     pub fork_pool_size: Option<std::num::NonZeroU32>,
 
-    /// Override the automatic logical VRAM budget for each golden/clone CUDA
-    /// session. The workload still needs no changes. Requires --fork-pool-size.
+    /// Override the automatic logical VRAM budget for each source/child CUDA
+    /// session. The workload still needs no changes. Requires --branch-pool-size.
     #[arg(long, value_name = "MIB", requires = "fork_pool_size")]
     pub cuda_vram_limit_mib: Option<std::num::NonZeroU64>,
 
@@ -3885,53 +3912,53 @@ impl StartCmd {
 // Fork Command
 // ============================================================================
 
-/// Fork a running forkable machine into a new clone.
+/// Branch a running branchable machine into a new independent child.
 ///
-/// Captures the source (the "golden") through its control socket, copy-on-write
-/// clones its disks, and boots the new machine from the source's in-memory
+/// Captures the source through its control socket, copy-on-write
+/// branches its disks, and boots the new machine from the source's in-memory
 /// snapshot instead of cold-booting. Linux/x86_64 resumes the source after the
 /// boundary; other hosts retain it as the frozen copy-on-write base.
 ///
-/// The golden must have been started with `--forkable`.
+/// The source must have been started with `--branchable`.
 #[derive(Args, Debug)]
 pub struct ForkCmd {
-    /// The running, forkable source machine to clone from.
-    #[arg(long, visible_alias = "from", value_name = "NAME")]
+    /// The running, branchable source machine to branch from.
+    #[arg(long = "from", visible_alias = "golden", value_name = "NAME")]
     pub golden: String,
 
-    /// Name for the new clone machine.
+    /// Name for the new child machine.
     #[arg(short = 'n', long = "name", value_name = "NAME")]
     pub clone: Option<String>,
 
-    /// Number of clones to create from one snapshot. Batch forks wait for the
-    /// standard `smolvm-fork-ready` boundary automatically. Direct batches
-    /// receive one shared `SMOLVM_FORK_BATCH_ID` and `SMOLVM_FORK_BATCH_SIZE`;
+    /// Number of children to create from one snapshot. Batch branches wait for the
+    /// standard `smolvm-branch-ready` boundary automatically. Direct batches
+    /// receive one shared `SMOLVM_BRANCH_BATCH_ID` and `SMOLVM_BRANCH_BATCH_SIZE`;
     /// held slots remain independent until assigned by their controller.
     #[arg(long, default_value = "1", value_name = "COUNT")]
     pub count: std::num::NonZeroU32,
 
-    /// Name batch clones PREFIX-0 through PREFIX-(COUNT-1).
+    /// Name batch children PREFIX-0 through PREFIX-(COUNT-1).
     #[arg(long, value_name = "PREFIX")]
     pub name_prefix: Option<String>,
 
-    /// Maximum number of clone boots in flight during a batch fork.
+    /// Maximum number of child boots in flight during a batch branch.
     #[arg(long, default_value = "4", value_name = "COUNT")]
     pub parallel: std::num::NonZeroU32,
 
-    /// Wait for `smolvm-fork-ready` in a single-clone fork. Batch forks always
-    /// wait; unless held, they release clones only after identity and fork env
+    /// Wait for `smolvm-branch-ready` in a single-child branch. Batch branches always
+    /// wait; unless held, they release children only after identity and branch env
     /// are installed.
     #[arg(long)]
     pub wait_ready: bool,
 
-    /// Keep each clone parked at the inherited forkpoint as an already-booted
-    /// pool slot. Assign and release a slot later with `machine fork-release`.
-    /// A consumed slot is disposable; delete and replenish it from the golden
+    /// Keep each child parked at the inherited branch point as an already-booted
+    /// pool slot. Assign and release a slot later with `machine branch-release`.
+    /// A consumed slot is disposable; delete and replenish it from the source
     /// rather than reusing mutated training state.
     #[arg(long)]
     pub hold: bool,
 
-    /// Maximum time to wait for the golden workload's forkpoint.
+    /// Maximum time to wait for the source workload's branch boundary.
     #[arg(
         long,
         default_value = "10m",
@@ -3940,36 +3967,39 @@ pub struct ForkCmd {
     )]
     pub ready_timeout: Duration,
 
-    /// Make the clone itself forkable (memfd RAM + control socket), so it can
-    /// in turn be forked.
-    #[arg(long, visible_alias = "checkpointable")]
+    /// Make the child itself branchable (memfd RAM + control socket), so it can
+    /// in turn be branched.
+    #[arg(
+        long = "branchable",
+        visible_aliases = ["forkable", "checkpointable"]
+    )]
     pub forkable: bool,
 
-    /// Pin the clone's inbound port forwards (single port or one-to-one range, repeatable).
-    /// Without this, the golden's forwards are remapped to freshly-allocated host ports.
+    /// Pin the child's inbound port forwards (single port or one-to-one range, repeatable).
+    /// Without this, the source's forwards are remapped to freshly-allocated host ports.
     #[arg(short = 'p', long = "port", value_parser = PortMappingSpec::parse, value_name = "PORT[-END]|HOST[-END]:GUEST[-END]", help_heading = "Network")]
     pub port: Vec<PortMappingSpec>,
 
-    /// Share the golden's loaded CUDA weights with this clone instead of
-    /// copying them — sibling clones then keep ONE copy of the base model in
+    /// Share the source's loaded CUDA weights with this child instead of
+    /// copying them — sibling children then keep ONE copy of the base model in
     /// VRAM. Correct when the base stays frozen (LoRA/QLoRA fine-tuning,
-    /// inference); use a plain fork when the clone trains the base weights.
+    /// inference); use a plain branch when the child trains the base weights.
     #[arg(long)]
     pub share_weights: bool,
 
-    /// Per-fork parameter (repeatable, KEY=VALUE). Delivered to the clone as
-    /// `/etc/smolvm/fork-env` (dotenv format) for the already-running workload
-    /// to read, and merged into the clone's env for later `machine exec`
-    /// sessions. This is how sweep/rollout clones learn which variant they
+    /// Per-branch parameter (repeatable, KEY=VALUE). Delivered to the child as
+    /// `/etc/smolvm/branch-env` (dotenv format) for the already-running workload
+    /// to read, and merged into the child's env for later `machine exec`
+    /// sessions. This is how sweep/rollout children learn which variant they
     /// are — no shared-mount claim files needed.
     #[arg(short = 'e', long = "env", value_name = "KEY=VALUE")]
     pub env: Vec<String>,
 
-    /// Inject a per-fork secret from a host env var (GUEST_VAR=HOST_VAR),
-    /// resolved fresh on every `exec` in the clone. Unlike `--env`, the value is
-    /// never written to the clone's record, the overlay/pack, or the fork-env
-    /// guest file — and each clone's secrets are its own, invisible to the
-    /// golden and sibling clones.
+    /// Inject a per-branch secret from a host env var (GUEST_VAR=HOST_VAR),
+    /// resolved fresh on every `exec` in the child. Unlike `--env`, the value is
+    /// never written to the child's record, the overlay/pack, or the branch-env
+    /// guest file — and each child's secrets are its own, invisible to the
+    /// source and siblings.
     #[arg(
         long = "secret-env",
         value_name = "GUEST_VAR=HOST_VAR",
@@ -3977,9 +4007,9 @@ pub struct ForkCmd {
     )]
     pub secret_env: Vec<String>,
 
-    /// Inject a per-fork secret from a host file (GUEST_VAR=/abs/path), resolved
-    /// fresh on every `exec` in the clone. Never persisted to the record,
-    /// overlay/pack, or fork-env guest file. See `--secret-env`.
+    /// Inject a per-branch secret from a host file (GUEST_VAR=/abs/path), resolved
+    /// fresh on every `exec` in the child. Never persisted to the record,
+    /// overlay/pack, or branch-env guest file. See `--secret-env`.
     #[arg(
         long = "secret-file",
         value_name = "GUEST_VAR=PATH",
@@ -3991,7 +4021,7 @@ pub struct ForkCmd {
 impl ForkCmd {
     pub fn run(self) -> smolvm::Result<()> {
         let ports: Vec<(u16, u16)> = PortMappingSpec::expand_all(&self.port)
-            .map_err(|e| smolvm::Error::config("fork ports", e))?
+            .map_err(|e| smolvm::Error::config("branch ports", e))?
             .into_iter()
             .map(|port| port.to_tuple())
             .collect();
@@ -4002,14 +4032,14 @@ impl ForkCmd {
         let wait_ready = forkpoint_timeout(count, self.wait_ready, self.hold, self.ready_timeout);
         if count > 1024 {
             return Err(smolvm::Error::config(
-                "fork",
-                "--count cannot exceed 1024 clones per batch",
+                "branch",
+                "--count cannot exceed 1024 children per batch",
             ));
         }
         if self.hold && self.forkable {
             return Err(smolvm::Error::config(
-                "fork",
-                "--hold cannot be combined with --forkable; pool slots are disposable leaves",
+                "branch",
+                "--hold cannot be combined with --branchable; pool slots are disposable leaves",
             ));
         }
 
@@ -4019,14 +4049,14 @@ impl ForkCmd {
                 (None, Some(prefix)) => format!("{prefix}-0"),
                 (Some(_), Some(_)) => {
                     return Err(smolvm::Error::config(
-                        "fork",
+                        "branch",
                         "use either --name or --name-prefix, not both",
                     ));
                 }
                 (None, None) => {
                     return Err(smolvm::Error::config(
-                        "fork",
-                        "--name is required for one clone; use --name-prefix with --count for a batch",
+                        "branch",
+                        "--name is required for one child; use --name-prefix with --count for a batch",
                     ));
                 }
             };
@@ -4048,25 +4078,25 @@ impl ForkCmd {
 
         if self.clone.is_some() {
             return Err(smolvm::Error::config(
-                "fork",
+                "branch",
                 "--name cannot be used with --count greater than 1; use --name-prefix",
             ));
         }
         let prefix = self.name_prefix.ok_or_else(|| {
             smolvm::Error::config(
-                "fork",
+                "branch",
                 "--name-prefix is required with --count greater than 1",
             )
         })?;
         if self.forkable {
             return Err(smolvm::Error::config(
-                "fork",
-                "--forkable is not supported for batch clones",
+                "branch",
+                "--branchable is not supported for batch children",
             ));
         }
         if !ports.is_empty() {
             return Err(smolvm::Error::config(
-                "fork",
+                "branch",
                 "pinned --port mappings are not supported for a batch; inherited ports are remapped automatically",
             ));
         }
@@ -4094,10 +4124,10 @@ impl ForkCmd {
     }
 }
 
-/// Assign job-specific parameters and release one held fork-pool slot.
+/// Assign job-specific parameters and release one held branch-pool slot.
 #[derive(Args, Debug)]
 pub struct ForkReleaseCmd {
-    /// Held clone to assign and release.
+    /// Held child to assign and release.
     #[arg(short = 'n', long = "name", value_name = "NAME")]
     pub name: String,
 
@@ -4131,15 +4161,26 @@ fn render_indexed_fork_env(
         env.retain(|(key, _)| {
             !matches!(
                 key.as_str(),
-                "SMOLVM_FORK_INDEX"
+                "SMOLVM_BRANCH_INDEX"
+                    | "SMOLVM_BRANCH_NAME"
+                    | "SMOLVM_BRANCH_BATCH_ID"
+                    | "SMOLVM_BRANCH_BATCH_SIZE"
+                    | "SMOLVM_FORK_INDEX"
                     | "SMOLVM_FORK_NAME"
                     | "SMOLVM_FORK_BATCH_ID"
                     | "SMOLVM_FORK_BATCH_SIZE"
             )
         });
+        env.push(("SMOLVM_BRANCH_INDEX".to_string(), index.to_string()));
+        env.push(("SMOLVM_BRANCH_NAME".to_string(), name.to_string()));
         env.push(("SMOLVM_FORK_INDEX".to_string(), index.to_string()));
         env.push(("SMOLVM_FORK_NAME".to_string(), name.to_string()));
         if let Some(batch) = batch {
+            env.push(("SMOLVM_BRANCH_BATCH_ID".to_string(), batch.id.clone()));
+            env.push((
+                "SMOLVM_BRANCH_BATCH_SIZE".to_string(),
+                batch.size.to_string(),
+            ));
             env.push(("SMOLVM_FORK_BATCH_ID".to_string(), batch.id.clone()));
             env.push(("SMOLVM_FORK_BATCH_SIZE".to_string(), batch.size.to_string()));
         }
@@ -4218,9 +4259,9 @@ pub struct DeleteCmd {
     #[arg(short, long)]
     pub force: bool,
 
-    /// Also delete any clones forked from this machine. A fork base cannot be
-    /// removed while its clones' disks depend on it; --cascade removes the
-    /// clones first (children before the base). Implies no confirmation.
+    /// Also delete any children branched from this machine. A branch source
+    /// cannot be removed while its children's disks depend on it; --cascade
+    /// removes children first. Implies no confirmation.
     #[arg(long)]
     pub cascade: bool,
 }

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -26,6 +26,8 @@ API ENDPOINTS:
   GET    /api/v1/machines             List machines
   GET    /api/v1/machines/:id         Get machine status
   POST   /api/v1/machines/:id/start   Start machine
+  POST   /api/v1/machines/:id/branches Create a copy-on-write child
+  POST   /api/v1/machines/:id/checkpoint Capture a durable checkpoint
   POST   /api/v1/machines/:id/stop    Stop machine
   POST   /api/v1/machines/:id/exec    Execute command
   DELETE /api/v1/machines/:id         Delete machine

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -826,7 +826,7 @@ pub fn fork_vm(golden: &str, clone: &str, options: ForkVmOptions<'_>) -> smolvm:
             return Err(smolvm::Error::config(
                 "machine fork",
                 format!(
-                    "machine '{golden}' has remote volumes, which cannot be forked yet: \
+                    "machine '{golden}' has remote volumes, which cannot be branched yet: \
                      a mounted remote filesystem does not survive the freeze/restore"
                 ),
             ));
@@ -834,7 +834,7 @@ pub fn fork_vm(golden: &str, clone: &str, options: ForkVmOptions<'_>) -> smolvm:
     }
 
     if let Some(timeout) = options.wait_ready {
-        eprintln!("Waiting for golden '{golden}' to reach its forkpoint...");
+        eprintln!("Waiting for source '{golden}' to reach its branchpoint...");
         smolvm::agent::fork::wait_for_forkpoint(golden, timeout)?;
     }
 
@@ -844,7 +844,7 @@ pub fn fork_vm(golden: &str, clone: &str, options: ForkVmOptions<'_>) -> smolvm:
     if smolvm::agent::fork::fork_continue_enabled() {
         eprintln!("Checkpointing '{golden}' while keeping it running...");
     } else {
-        eprintln!("Freezing golden '{golden}' as fork base...");
+        eprintln!("Freezing source '{golden}' as branch base...");
     }
     let prep = if options.hold {
         smolvm::agent::fork::prepare_held_fork(
@@ -869,7 +869,7 @@ pub fn fork_vm(golden: &str, clone: &str, options: ForkVmOptions<'_>) -> smolvm:
     for (golden_host, guest, clone_host) in &prep.port_remaps {
         if options.pinned_ports.is_empty() {
             eprintln!(
-                "  port {golden_host}->{guest} (golden) remapped to {clone_host}->{guest} (clone)"
+                "  port {golden_host}->{guest} (source) remapped to {clone_host}->{guest} (child)"
             );
         } else {
             eprintln!("  port {clone_host}->{guest} (pinned)");
@@ -897,15 +897,15 @@ pub fn fork_vm(golden: &str, clone: &str, options: ForkVmOptions<'_>) -> smolvm:
     }
     if options.hold {
         eprintln!(
-            "Forked '{golden}' -> held slot '{clone}'. Release it with \
-             `smolvm machine fork-release --name {clone}`."
+            "Branched '{golden}' -> held slot '{clone}'. Release it with \
+             `smolvm machine branch-release --name {clone}`."
         );
     } else if smolvm::agent::fork::fork_continue_enabled() {
-        eprintln!("Forked '{golden}' -> '{clone}'. Source continues running.");
+        eprintln!("Branched '{golden}' -> '{clone}'. Source continues running.");
     } else {
         eprintln!(
-            "Forked '{golden}' -> '{clone}'. Golden stays frozen as the fork base \
-             (do not start it again while clones exist)."
+            "Branched '{golden}' -> '{clone}'. Source stays frozen as the branch base \
+             (do not start it again while children exist)."
         );
     }
     Ok(())
@@ -934,7 +934,7 @@ pub fn fork_vm_batch(
             return Err(smolvm::Error::config(
                 "machine fork",
                 format!(
-                    "machine '{golden}' has remote volumes, which cannot be forked yet: \
+                    "machine '{golden}' has remote volumes, which cannot be branched yet: \
                      a mounted remote filesystem does not survive the freeze/restore"
                 ),
             ));
@@ -942,7 +942,7 @@ pub fn fork_vm_batch(
     }
 
     if let Some(timeout) = wait_ready {
-        eprintln!("Waiting for golden '{golden}' to reach its forkpoint...");
+        eprintln!("Waiting for source '{golden}' to reach its branchpoint...");
         smolvm::agent::fork::wait_for_forkpoint(golden, timeout)?;
     }
 
@@ -964,7 +964,7 @@ pub fn fork_vm_batch(
         );
     } else {
         eprintln!(
-            "Freezing golden '{golden}' once for {} clones...",
+            "Freezing source '{golden}' once for {} children...",
             clones.len()
         );
     }
@@ -1043,7 +1043,7 @@ pub fn fork_vm_batch(
     for (name, result) in results {
         if let Err(error) = result {
             first_error.get_or_insert_with(|| {
-                smolvm::Error::agent("batch fork", format!("clone '{name}' failed: {error}"))
+                smolvm::Error::agent("batch branch", format!("child '{name}' failed: {error}"))
             });
         }
     }
@@ -1071,12 +1071,12 @@ pub fn fork_vm_batch(
 
     if hold {
         eprintln!(
-            "Provisioned {} held slots from '{golden}' with one snapshot.",
+            "Provisioned {} held branch slots from '{golden}' with one snapshot.",
             all_names.len()
         );
     } else {
         eprintln!(
-            "Forked {} clones from '{golden}' with one snapshot.",
+            "Branched {} children from '{golden}' with one snapshot.",
             all_names.len()
         );
     }
@@ -1094,13 +1094,13 @@ pub fn release_held_fork(clone: &str, assignment: &[(String, String)]) -> smolvm
     if record.golden.is_none() {
         return Err(smolvm::Error::agent(
             "release held fork",
-            format!("machine '{clone}' is not a fork clone"),
+            format!("machine '{clone}' is not a branch child"),
         ));
     }
     if !record.forkpoint_held {
         return Err(smolvm::Error::agent(
             "release held fork",
-            format!("clone '{clone}' is not a held pool slot"),
+            format!("child '{clone}' is not a held branch-pool slot"),
         ));
     }
 
@@ -1117,7 +1117,7 @@ pub fn release_held_fork(clone: &str, assignment: &[(String, String)]) -> smolvm
     if !claimed.get() {
         return Err(smolvm::Error::agent(
             "release held fork",
-            format!("clone '{clone}' was already claimed"),
+            format!("child '{clone}' was already claimed"),
         ));
     }
     let activated = smolvm::agent::fork::activate_held_fork(clone, &record, assignment).map_err(
@@ -1132,8 +1132,8 @@ pub fn release_held_fork(clone: &str, assignment: &[(String, String)]) -> smolvm
     )?;
     debug_assert_eq!(activated, merged);
     eprintln!(
-        "Released held slot '{clone}'. Replace it from '{}' after the workload completes.",
-        record.golden.as_deref().unwrap_or("its golden")
+        "Released held branch slot '{clone}'. Replace it from '{}' after the workload completes.",
+        record.golden.as_deref().unwrap_or("its source")
     );
     Ok(())
 }
@@ -1148,7 +1148,7 @@ fn boot_prepared_fork(
 ) -> smolvm::Result<()> {
     let preload_modules = prep.clone_record.cuda_preload_modules;
     let clone_forkable = prep.clone_record.forkable;
-    eprintln!("Booting clone '{clone}' from snapshot...");
+    eprintln!("Booting child '{clone}' from snapshot...");
     let mut start = || {
         start_vm_named_with_db(
             db,
@@ -1168,7 +1168,7 @@ fn boot_prepared_fork(
     };
     let started = match retry_gate {
         Some(gate) => retry_once_serialized(gate, &mut start, |error| {
-            eprintln!("Clone '{clone}' boot failed once; retrying serially: {error}");
+            eprintln!("Child '{clone}' boot failed once; retrying serially: {error}");
             std::thread::sleep(std::time::Duration::from_millis(100));
         })
         .map_err(|(first, retry)| {
@@ -1242,7 +1242,7 @@ fn persist_batch_clones_running(db: &SmolvmDb, clones: &[String]) -> smolvm::Res
     let mut processes = std::collections::HashMap::with_capacity(clones.len());
     for clone in clones {
         let manager = AgentManager::for_vm(clone)
-            .map_err(|error| smolvm::Error::agent("batch fork", error.to_string()))?;
+            .map_err(|error| smolvm::Error::agent("batch branch", error.to_string()))?;
         let identity = manager.pid_and_start_time().ok_or_else(|| {
             smolvm::Error::agent(
                 "batch fork",
@@ -1430,7 +1430,7 @@ fn start_vm_named_with_db(
                     .to_string()
             } else {
                 format!(
-                    "it is the fork base for {} live clone(s) ({}); their disks are copy-on-write overlays backed by its disks, so it cannot be re-launched while they exist — delete the clones first",
+                    "it is the branch source for {} live child machine(s) ({}); their disks are copy-on-write overlays backed by its disks, so it cannot be re-launched while they exist — delete the children first",
                     clones.len(),
                     clones.join(", ")
                 )
@@ -1452,7 +1452,7 @@ fn start_vm_named_with_db(
         if !record.cuda {
             return Err(Error::config(
                 "fork pool",
-                "--fork-pool-size requires a CUDA-enabled machine",
+                "--branch-pool-size requires a CUDA-enabled machine",
             ));
         }
         record.cuda_fork_pool_size = Some(pool_size);
@@ -2384,7 +2384,7 @@ pub fn delete_vm(name: &str, force: bool, options: DeleteVmOptions) -> smolvm::R
         // Delete the full lineage deepest-first. Every qcow2 overlay must
         // disappear before the parent image that backs it.
         for clone in db.dependent_descendants_postorder(name)? {
-            println!("Deleting dependent clone '{clone}' (cascade)...");
+            println!("Deleting dependent child '{clone}' (cascade)...");
             delete_vm(
                 &clone,
                 true, // no per-clone confirmation during a cascade
@@ -2587,9 +2587,13 @@ fn machine_status_json(name: &str, record: &VmRecord) -> serde_json::Value {
         "gpu": record.gpu.unwrap_or(false),
         "gpu_vram_mib": record.gpu_vram_mib,
         "cuda": record.cuda,
+        "branchable": record.forkable_on_start(),
         "forkable": record.forkable_on_start(),
+        "parent_machine": record.golden,
+        "cuda_branch_pool_size": record.cuda_fork_pool_size,
         "cuda_fork_pool_size": record.cuda_fork_pool_size,
         "cuda_vram_limit_mib": record.cuda_vram_limit_mib,
+        "branchpoint_held": record.forkpoint_held,
         "forkpoint_held": record.forkpoint_held,
         "labels": record.labels,
         "restart_policy": record.restart.policy.to_string(),
@@ -2706,16 +2710,16 @@ pub fn list_vms(verbose: bool, json: bool) -> smolvm::Result<()> {
                     }
                 }
                 if record.forkable_on_start() {
-                    println!("  Forkable: enabled");
+                    println!("  Branchable: enabled");
                 }
                 if let Some(pool_size) = record.cuda_fork_pool_size {
-                    println!("  CUDA fork pool: {} clone(s)", pool_size);
+                    println!("  CUDA branch pool: {} child machine(s)", pool_size);
                 }
                 if let Some(limit_mib) = record.cuda_vram_limit_mib {
                     println!("  CUDA VRAM limit: {} MiB per session", limit_mib);
                 }
                 if record.forkpoint_held {
-                    println!("  Fork slot: held");
+                    println!("  Branch slot: held");
                 }
                 for cmd in &record.init {
                     println!("  Init: {}", cmd);


### PR DESCRIPTION
Makes branch the primary live copy-on-write lifecycle across the CLI, API, Smolfile, guest helpers, and status metadata while retaining fork compatibility aliases.