### PR TITLE
Make the browser desktop responsive

### DIFF
--- a/docs/hardware-video.md
+++ b/docs/hardware-video.md
@@ -5,7 +5,9 @@ framebuffer pixels. It uses a host hardware encoder when available and a
 bounded software encoder on CPU-only Linux hosts. Keyboard and pointer input
 continue over RFB, and native VNC clients are unchanged.
 
-The path is opt-in and requires an FFmpeg build exposing the selected encoder:
+The path is on by default whenever an `ffmpeg` binary is on the host's PATH, and
+falls back to Raw RFB if the selected encoder is missing; set `SMOLVM_VIDEO=off` to
+disable it. It requires an FFmpeg build exposing the selected encoder:
 
 ```console
 SMOLVM_DISPLAY=1920x1080 \

--- a/src/agent/display.rs
+++ b/src/agent/display.rs
@@ -22,6 +22,7 @@ use crate::error::{Error, Result};
 
 /// `KRUN_DISPLAY_FEATURE_BASIC_FRAMEBUFFER`.
 const FEATURE_BASIC_FRAMEBUFFER: u64 = 1;
+const FEATURE_CURSOR: u64 = 2;
 
 const ERR_INVALID_SCANOUT_ID: i32 = -3;
 const ERR_INVALID_PARAM: i32 = -4;
@@ -74,11 +75,19 @@ struct BasicFramebufferVtable {
 }
 
 #[repr(C)]
+struct CursorVtable {
+    set_cursor:
+        Option<unsafe extern "C" fn(*mut c_void, u32, u32, u32, u32, u32, *const u8, usize) -> i32>,
+    move_cursor: Option<unsafe extern "C" fn(*mut c_void, u32, u32, u32) -> i32>,
+}
+
+#[repr(C)]
 struct KrunDisplayBackend {
     features: u64,
     create_userdata: *const c_void,
     create: Option<unsafe extern "C" fn(*mut *mut c_void, *const c_void, *const c_void) -> i32>,
     vtable: BasicFramebufferVtable,
+    cursor: CursorVtable,
 }
 
 // ---------------------------------------------------------------------------
@@ -101,6 +110,41 @@ pub struct Frame {
     pub generation: u64,
 }
 
+/// The guest's pointer as the VMM hands it over: the image the guest put on
+/// its hardware cursor plane and where the hot spot is. With the pointer on
+/// that plane the guest no longer draws it into frames, so viewers either
+/// draw it themselves or composite it onto the frames they send.
+#[derive(Clone, Default)]
+pub struct Cursor {
+    /// Image width in pixels; 0 when hidden.
+    pub width: u32,
+    /// Image height in pixels; 0 when hidden.
+    pub height: u32,
+    /// Hot spot x offset inside the image.
+    pub hot_x: u32,
+    /// Hot spot y offset inside the image.
+    pub hot_y: u32,
+    /// `width * height * 4` bytes, B,G,R,A with straight alpha; empty when
+    /// the pointer is hidden.
+    pub bgra: Vec<u8>,
+    /// Hot spot x position on the scanout.
+    pub x: u32,
+    /// Hot spot y position on the scanout.
+    pub y: u32,
+    /// Bumped on every image change or move.
+    pub generation: u64,
+    /// Bumped only when the image changes, so a viewer that draws the pointer
+    /// itself resends the image only when it has to.
+    pub image_generation: u64,
+}
+
+impl Cursor {
+    /// Whether there is an image to show at all.
+    pub fn is_visible(&self) -> bool {
+        self.width > 0 && self.height > 0 && !self.bgra.is_empty()
+    }
+}
+
 /// The buffer libkrun writes into. Deliberately *not* behind the mutex: the
 /// contract in `libkrun_display.h` is that every backend method is called from
 /// one and the same thread, so this is single-threaded state, and holding the
@@ -121,6 +165,9 @@ pub struct DisplayFramebuffer {
     staging: std::cell::UnsafeCell<Staging>,
     front: Mutex<Frame>,
     presented: Condvar,
+    cursor: Mutex<Cursor>,
+    /// Mirrors `cursor.generation` so waiters can test it under `front`.
+    cursor_generation: std::sync::atomic::AtomicU64,
     /// Optional call trace, enabled by `SMOLVM_DISPLAY_TRACE=<path>`.
     ///
     /// libkrun's own logging goes through `env_logger` in a process whose
@@ -168,6 +215,8 @@ impl DisplayFramebuffer {
                 generation: 0,
             }),
             presented: Condvar::new(),
+            cursor: Mutex::new(Cursor::default()),
+            cursor_generation: std::sync::atomic::AtomicU64::new(0),
             trace,
             traced_calls: std::sync::atomic::AtomicU64::new(0),
         }
@@ -235,6 +284,56 @@ impl DisplayFramebuffer {
             front.generation = 1;
         }
         fb
+    }
+
+    /// The pointer as last reported by the guest.
+    pub fn cursor(&self) -> Cursor {
+        self.cursor
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+
+    /// Block until a frame newer than `since_frame` is presented or the
+    /// pointer changes past `since_cursor`, or `timeout` elapses. Returns
+    /// whichever of the two is new.
+    pub fn wait_for_change(
+        &self,
+        since_frame: u64,
+        since_cursor: u64,
+        timeout: std::time::Duration,
+    ) -> (Option<Frame>, Option<Cursor>) {
+        use std::sync::atomic::Ordering;
+        let guard = self.front.lock().unwrap_or_else(|e| e.into_inner());
+        let (guard, _) = self
+            .presented
+            .wait_timeout_while(guard, timeout, |f| {
+                f.generation <= since_frame
+                    && self.cursor_generation.load(Ordering::Acquire) <= since_cursor
+            })
+            .unwrap_or_else(|e| e.into_inner());
+        let frame = (guard.generation > since_frame).then(|| guard.clone());
+        drop(guard);
+        let cursor = {
+            let c = self.cursor.lock().unwrap_or_else(|e| e.into_inner());
+            (c.generation > since_cursor).then(|| c.clone())
+        };
+        (frame, cursor)
+    }
+
+    /// Record a pointer change and wake viewers. Taken under `front` so a
+    /// viewer between its generation check and its wait cannot miss it.
+    fn cursor_changed(&self, apply: impl FnOnce(&mut Cursor)) {
+        use std::sync::atomic::Ordering;
+        let _front = self.front.lock().unwrap_or_else(|e| e.into_inner());
+        {
+            let mut c = self.cursor.lock().unwrap_or_else(|e| e.into_inner());
+            apply(&mut c);
+            c.generation = c.generation.wrapping_add(1);
+            self.cursor_generation
+                .store(c.generation, Ordering::Release);
+        }
+        self.presented.notify_all();
     }
 
     /// Block until a frame newer than `since` is presented, or `timeout`
@@ -411,6 +510,64 @@ unsafe extern "C" fn display_present_frame(
     0
 }
 
+unsafe extern "C" fn display_set_cursor(
+    instance: *mut c_void,
+    scanout_id: u32,
+    width: u32,
+    height: u32,
+    hot_x: u32,
+    hot_y: u32,
+    bgra: *const u8,
+    bgra_size: usize,
+) -> i32 {
+    if scanout_id != 0 {
+        return ERR_INVALID_SCANOUT_ID;
+    }
+    let Some(fb) = (unsafe { fb(instance) }) else {
+        return ERR_INVALID_PARAM;
+    };
+    let hidden = width == 0 || height == 0;
+    let needed = width as usize * height as usize * BYTES_PER_PIXEL;
+    if !hidden && (bgra.is_null() || bgra_size < needed || width > 512 || height > 512) {
+        return ERR_INVALID_PARAM;
+    }
+    let pixels = if hidden {
+        Vec::new()
+    } else {
+        // Safe: libkrun promises `bgra_size` readable bytes for the call.
+        unsafe { std::slice::from_raw_parts(bgra, needed) }.to_vec()
+    };
+    fb.cursor_changed(|c| {
+        c.width = if hidden { 0 } else { width };
+        c.height = if hidden { 0 } else { height };
+        c.hot_x = hot_x;
+        c.hot_y = hot_y;
+        c.bgra = pixels;
+        c.image_generation = c.image_generation.wrapping_add(1);
+    });
+    fb.trace_seq("set_cursor");
+    0
+}
+
+unsafe extern "C" fn display_move_cursor(
+    instance: *mut c_void,
+    scanout_id: u32,
+    x: u32,
+    y: u32,
+) -> i32 {
+    if scanout_id != 0 {
+        return ERR_INVALID_SCANOUT_ID;
+    }
+    let Some(fb) = (unsafe { fb(instance) }) else {
+        return ERR_INVALID_PARAM;
+    };
+    fb.cursor_changed(|c| {
+        c.x = x;
+        c.y = y;
+    });
+    0
+}
+
 // ---------------------------------------------------------------------------
 // Installation
 // ---------------------------------------------------------------------------
@@ -431,7 +588,7 @@ pub fn install(
     let raw = Arc::into_raw(Arc::clone(&state));
 
     let backend = KrunDisplayBackend {
-        features: FEATURE_BASIC_FRAMEBUFFER,
+        features: FEATURE_BASIC_FRAMEBUFFER | FEATURE_CURSOR,
         create_userdata: raw as *const c_void,
         create: Some(display_create),
         vtable: BasicFramebufferVtable {
@@ -440,6 +597,10 @@ pub fn install(
             configure_scanout: Some(display_configure_scanout),
             alloc_frame: Some(display_alloc_frame),
             present_frame: Some(display_present_frame),
+        },
+        cursor: CursorVtable {
+            set_cursor: Some(display_set_cursor),
+            move_cursor: Some(display_move_cursor),
         },
     };
 

--- a/src/agent/display.rs
+++ b/src/agent/display.rs
@@ -140,10 +140,16 @@ pub struct Cursor {
     /// Compositors hide and re-show the pointer around every buffer flip,
     /// so a hide only counts once it has lasted a moment.
     pub hidden_since: Option<std::time::Instant>,
+    /// When the guest last showed the pointer.
+    pub shown_at: Option<std::time::Instant>,
 }
 
 /// How long a hide must last before viewers stop showing the pointer.
 const HIDE_GRACE: std::time::Duration = std::time::Duration::from_millis(250);
+/// A hide this soon after a show is the tail of a buffer flip, not a hide:
+/// some compositors show the new pointer buffer and then hide the old one,
+/// leaving the plane hidden until the next move. Those are dropped outright.
+const FLIP_WINDOW: std::time::Duration = std::time::Duration::from_millis(150);
 
 impl Cursor {
     /// Whether there is an image to show right now.
@@ -550,6 +556,9 @@ unsafe extern "C" fn display_set_cursor(
     };
     fb.cursor_changed(|c| {
         if hidden {
+            if c.shown_at.is_some_and(|t| t.elapsed() < FLIP_WINDOW) {
+                return;
+            }
             // Keep the image; the hide takes effect only if it lasts.
             if c.hidden_since.is_none() {
                 c.hidden_since = Some(std::time::Instant::now());
@@ -557,6 +566,7 @@ unsafe extern "C" fn display_set_cursor(
             return;
         }
         c.hidden_since = None;
+        c.shown_at = Some(std::time::Instant::now());
         // Compositors re-send the same image on every move; only a real
         // change should make viewers re-fetch it.
         let same = c.width == width

--- a/src/agent/display.rs
+++ b/src/agent/display.rs
@@ -531,15 +531,26 @@ unsafe extern "C" fn display_set_cursor(
     if !hidden && (bgra.is_null() || bgra_size < needed || width > 512 || height > 512) {
         return ERR_INVALID_PARAM;
     }
-    let pixels = if hidden {
-        Vec::new()
+    let (width, height, hot_x, hot_y, pixels) = if hidden {
+        (0, 0, hot_x, hot_y, Vec::new())
     } else {
         // Safe: libkrun promises `bgra_size` readable bytes for the call.
-        unsafe { std::slice::from_raw_parts(bgra, needed) }.to_vec()
+        let full = unsafe { std::slice::from_raw_parts(bgra, needed) };
+        crop_cursor(full, width, height, hot_x, hot_y)
     };
     fb.cursor_changed(|c| {
-        c.width = if hidden { 0 } else { width };
-        c.height = if hidden { 0 } else { height };
+        // Compositors re-send the same image on every move; only a real
+        // change should make viewers re-fetch it.
+        let same = c.width == width
+            && c.height == height
+            && c.hot_x == hot_x
+            && c.hot_y == hot_y
+            && c.bgra == pixels;
+        if same {
+            return;
+        }
+        c.width = width;
+        c.height = height;
         c.hot_x = hot_x;
         c.hot_y = hot_y;
         c.bgra = pixels;
@@ -547,6 +558,51 @@ unsafe extern "C" fn display_set_cursor(
     });
     fb.trace_seq("set_cursor");
     0
+}
+
+/// Trim the transparent border off a pointer image and shift the hot spot to
+/// match. Compositors hand over the same pointer drawn at different offsets
+/// in a fixed 64x64 buffer; trimmed, those compare equal, so viewers are not
+/// sent a "new" image on every move, and the image itself gets much smaller.
+fn crop_cursor(
+    bgra: &[u8],
+    width: u32,
+    height: u32,
+    hot_x: u32,
+    hot_y: u32,
+) -> (u32, u32, u32, u32, Vec<u8>) {
+    let (w, h) = (width as usize, height as usize);
+    let (mut x0, mut y0, mut x1, mut y1) = (w, h, 0usize, 0usize);
+    for y in 0..h {
+        for x in 0..w {
+            if bgra[(y * w + x) * 4 + 3] != 0 {
+                x0 = x0.min(x);
+                y0 = y0.min(y);
+                x1 = x1.max(x + 1);
+                y1 = y1.max(y + 1);
+            }
+        }
+    }
+    if x0 >= x1 || y0 >= y1 {
+        return (0, 0, hot_x, hot_y, Vec::new());
+    }
+    // Keep the hot spot inside the trimmed image.
+    let x0 = x0.min(hot_x as usize);
+    let y0 = y0.min(hot_y as usize);
+    let x1 = x1.max(hot_x as usize + 1).min(w);
+    let y1 = y1.max(hot_y as usize + 1).min(h);
+    let (cw, ch) = (x1 - x0, y1 - y0);
+    let mut out = Vec::with_capacity(cw * ch * 4);
+    for y in y0..y1 {
+        out.extend_from_slice(&bgra[(y * w + x0) * 4..(y * w + x1) * 4]);
+    }
+    (
+        cw as u32,
+        ch as u32,
+        hot_x - x0 as u32,
+        hot_y - y0 as u32,
+        out,
+    )
 }
 
 unsafe extern "C" fn display_move_cursor(

--- a/src/agent/display.rs
+++ b/src/agent/display.rs
@@ -136,12 +136,22 @@ pub struct Cursor {
     /// Bumped only when the image changes, so a viewer that draws the pointer
     /// itself resends the image only when it has to.
     pub image_generation: u64,
+    /// When the guest last hid the pointer while an image was still known.
+    /// Compositors hide and re-show the pointer around every buffer flip,
+    /// so a hide only counts once it has lasted a moment.
+    pub hidden_since: Option<std::time::Instant>,
 }
 
+/// How long a hide must last before viewers stop showing the pointer.
+const HIDE_GRACE: std::time::Duration = std::time::Duration::from_millis(250);
+
 impl Cursor {
-    /// Whether there is an image to show at all.
+    /// Whether there is an image to show right now.
     pub fn is_visible(&self) -> bool {
-        self.width > 0 && self.height > 0 && !self.bgra.is_empty()
+        self.width > 0
+            && self.height > 0
+            && !self.bgra.is_empty()
+            && self.hidden_since.is_none_or(|t| t.elapsed() < HIDE_GRACE)
     }
 }
 
@@ -539,6 +549,14 @@ unsafe extern "C" fn display_set_cursor(
         crop_cursor(full, width, height, hot_x, hot_y)
     };
     fb.cursor_changed(|c| {
+        if hidden {
+            // Keep the image; the hide takes effect only if it lasts.
+            if c.hidden_since.is_none() {
+                c.hidden_since = Some(std::time::Instant::now());
+            }
+            return;
+        }
+        c.hidden_since = None;
         // Compositors re-send the same image on every move; only a real
         // change should make viewers re-fetch it.
         let same = c.width == width

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -41,6 +41,12 @@ pub mod video {
         }
     }
 
+    /// Encoded video is never configured on a non-Unix host, so the caller
+    /// does not try to start a helper that cannot exist here.
+    pub fn is_configured() -> bool {
+        false
+    }
+
     /// Non-Unix hosts always serve Raw VNC.
     pub fn is_available() -> bool {
         false

--- a/src/agent/video.rs
+++ b/src/agent/video.rs
@@ -434,6 +434,12 @@ fn feed_frames<W: Write>(
     // One duplicate after activity flushes the final changed frame; after
     // that an idle desktop sends no raw pixels at all.
     let mut needs_flush = true;
+    // Hardware encoders hold a few frames before emitting the first access
+    // unit, so an idle desktop would leave the viewer with nothing and the
+    // page would give up on video. Repeating the unchanged frame slowly
+    // keeps the pipeline primed for a few hundred bytes a second.
+    const IDLE_INTERVAL: Duration = Duration::from_secs(1);
+    let mut last_written = Instant::now();
     write_raw_frame(out, &frame)?;
     loop {
         next += interval;
@@ -456,9 +462,11 @@ fn feed_frames<W: Write>(
             generation = newer.generation;
             frame = newer;
             write_raw_frame(out, &frame)?;
+            last_written = Instant::now();
             needs_flush = true;
-        } else if needs_flush {
+        } else if needs_flush || last_written.elapsed() >= IDLE_INTERVAL {
             write_raw_frame(out, &frame)?;
+            last_written = Instant::now();
             needs_flush = false;
         }
     }

--- a/src/agent/video.rs
+++ b/src/agent/video.rs
@@ -751,10 +751,6 @@ fn ffmpeg_command(config: VideoConfig, width: u32, height: u32) -> std::process:
                 "1",
                 "-allow_sw",
                 "0",
-                "-profile:v",
-                "baseline",
-                "-bf",
-                "0",
                 "-pix_fmt",
                 "yuv420p",
             ]);
@@ -793,9 +789,16 @@ fn ffmpeg_command(config: VideoConfig, width: u32, height: u32) -> std::process:
         (config.bitrate_kbps / u32::from(config.fps)).max(1) * 2
     );
     let gop = config.fps.to_string();
+    // VideoToolbox writes no VUI, so a decoder cannot learn the reorder depth
+    // from the stream and buffers frames before showing the first; browsers
+    // treat Baseline itself as reorder-free and show each frame on arrival.
+    let profile = match config.encoder {
+        Encoder::VideoToolbox => "baseline",
+        _ => "main",
+    };
     command.args([
         "-profile:v",
-        "main",
+        profile,
         "-b:v",
         &bitrate,
         "-maxrate",

--- a/src/agent/video.rs
+++ b/src/agent/video.rs
@@ -739,12 +739,21 @@ fn ffmpeg_command(config: VideoConfig, width: u32, height: u32) -> std::process:
             ]);
         }
         Encoder::VideoToolbox => {
+            // Baseline with no B-frames: VideoToolbox writes no VUI, so a
+            // decoder cannot learn the reorder depth from the stream and
+            // buffers frames before showing the first one; browsers treat
+            // Baseline itself as reorder-free and display each frame as it
+            // arrives.
             command.args([
                 "-c:v",
                 "h264_videotoolbox",
                 "-realtime",
                 "1",
                 "-allow_sw",
+                "0",
+                "-profile:v",
+                "baseline",
+                "-bf",
                 "0",
                 "-pix_fmt",
                 "yuv420p",

--- a/src/agent/video.rs
+++ b/src/agent/video.rs
@@ -433,11 +433,16 @@ fn feed_frames<W: Write>(
     // The Annex-B parser uses the next AUD as the prior frame's boundary.
     // One duplicate after activity flushes the final changed frame; after
     // that an idle desktop sends no raw pixels at all.
-    let mut needs_flush = true;
-    // Hardware encoders hold a few frames before emitting the first access
-    // unit, so an idle desktop would leave the viewer with nothing and the
-    // page would give up on video. Repeating the unchanged frame slowly
-    // keeps the pipeline primed for a few hundred bytes a second.
+    // Hardware encoders hold several frames before emitting one (VideoToolbox
+    // emits its first access unit after the seventh input), so a lone change
+    // such as a typed character would sit in the encoder until enough later
+    // frames arrive. After every change the unchanged frame is repeated at
+    // the full cadence for this many ticks, which pushes the change through
+    // in a few tens of milliseconds for a few small delta frames.
+    const FLUSH_TICKS: u32 = 8;
+    let mut flush_ticks = FLUSH_TICKS;
+    // Once quiet, the unchanged frame is still repeated slowly so a viewer
+    // that connects to an idle desktop gets a picture at all.
     const IDLE_INTERVAL: Duration = Duration::from_secs(1);
     let mut last_written = Instant::now();
     write_raw_frame(out, &frame)?;
@@ -463,11 +468,11 @@ fn feed_frames<W: Write>(
             frame = newer;
             write_raw_frame(out, &frame)?;
             last_written = Instant::now();
-            needs_flush = true;
-        } else if needs_flush || last_written.elapsed() >= IDLE_INTERVAL {
+            flush_ticks = FLUSH_TICKS;
+        } else if flush_ticks > 0 || last_written.elapsed() >= IDLE_INTERVAL {
             write_raw_frame(out, &frame)?;
             last_written = Instant::now();
-            needs_flush = false;
+            flush_ticks = flush_ticks.saturating_sub(1);
         }
     }
 }

--- a/src/agent/video.rs
+++ b/src/agent/video.rs
@@ -61,10 +61,15 @@ struct VideoConfig {
 
 impl VideoConfig {
     fn from_env() -> Result<Option<Self>, String> {
-        let Some(raw) = std::env::var_os("SMOLVM_VIDEO") else {
-            return Ok(None);
+        // Unset means "use it when the host can": encoded video is on by
+        // default wherever an ffmpeg is on the PATH, since a browser then
+        // gets frames at a fraction of the raw cost and the raw path stays
+        // the fallback. `SMOLVM_VIDEO=off` disables it outright.
+        let raw = match std::env::var_os("SMOLVM_VIDEO") {
+            Some(raw) => raw.to_string_lossy().trim().to_ascii_lowercase(),
+            None if ffmpeg_on_path() => "auto".to_string(),
+            None => return Ok(None),
         };
-        let raw = raw.to_string_lossy().trim().to_ascii_lowercase();
         if raw.is_empty() || matches!(raw.as_str(), "0" | "off" | "false" | "disabled") {
             return Ok(None);
         }
@@ -108,6 +113,21 @@ where
         return Err(format!("{name} must be between {min} and {max}"));
     }
     Ok(value)
+}
+
+/// Whether an `ffmpeg` binary can be found on the PATH.
+fn ffmpeg_on_path() -> bool {
+    let Some(path) = std::env::var_os("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&path).any(|dir| {
+        let candidate = dir.join(if cfg!(windows) {
+            "ffmpeg.exe"
+        } else {
+            "ffmpeg"
+        });
+        candidate.is_file()
+    })
 }
 
 fn auto_encoder() -> Encoder {

--- a/src/agent/video.rs
+++ b/src/agent/video.rs
@@ -249,6 +249,12 @@ fn helper_socket_path() -> PathBuf {
     ))
 }
 
+/// Whether encoded video is configured for this VMM, explicitly or by
+/// default because an ffmpeg is on the PATH.
+pub fn is_configured() -> bool {
+    VideoConfig::from_env().ok().flatten().is_some()
+}
+
 /// Whether this VMM has an enabled, pre-started encoder helper.
 pub fn is_available() -> bool {
     VideoConfig::from_env().ok().flatten().is_some() && std::env::var_os(SOCKET_ENV).is_some()

--- a/src/agent/vnc.rs
+++ b/src/agent/vnc.rs
@@ -20,6 +20,8 @@
 
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::mpsc::{Sender, TryRecvError};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -49,6 +51,11 @@ const ENCODING_DESKTOP_SIZE: i32 = -223;
 /// The Cursor pseudo-encoding: the client draws the pointer itself from an
 /// image the server sends, so pointer motion costs no pixels at all.
 const ENCODING_CURSOR: i32 = -239;
+/// The ContinuousUpdates pseudo-encoding: once enabled, updates are pushed as
+/// the display changes instead of answering one request at a time.
+const ENCODING_CONTINUOUS_UPDATES: i32 = -313;
+const MSG_ENABLE_CONTINUOUS_UPDATES: u8 = 150;
+const MSG_END_OF_CONTINUOUS_UPDATES: u8 = 150;
 const ENCODING_RAW: i32 = 0;
 
 /// The pixel layout a client asked for. Defaults to what we natively hold, so
@@ -220,7 +227,8 @@ fn handle_connection(
     if speaks_http(&s) {
         serve_http(s, fb, input)
     } else {
-        handle_client(s, fb, input)
+        let writer = s.try_clone()?;
+        handle_client(s, writer, fb, input)
     }
 }
 
@@ -319,7 +327,8 @@ fn serve_http(
             return super::video::serve_browser(super::websocket::WsStream::new(s), fb);
         }
         tracing::info!("vnc browser client connected");
-        return handle_client(super::websocket::WsStream::new(s), fb, input);
+        let (reader, writer) = super::websocket::WsStream::new(s).split()?;
+        return handle_client(reader, writer, fb, input);
     }
 
     match request.path.as_str() {
@@ -407,21 +416,62 @@ fn respond<W: Write>(
 /// Drive one RFB session. Generic over the transport so the very same
 /// protocol code serves a native viewer on a raw socket and a browser over a
 /// WebSocket — the two differ only in how bytes are framed beneath this.
-fn handle_client<S: Read + Write>(
-    mut s: S,
+/// The write half of a client connection, which must also be able to close
+/// the whole connection so the reader thread unblocks when the session ends.
+trait CloseWrite: Write {
+    fn close(&self);
+}
+
+impl CloseWrite for TcpStream {
+    fn close(&self) {
+        let _ = self.shutdown(std::net::Shutdown::Both);
+    }
+}
+
+impl CloseWrite for super::websocket::WsWriter {
+    fn close(&self) {
+        self.close();
+    }
+}
+
+/// What the reader thread forwards to the update loop; keyboard and pointer
+/// events are injected by the reader itself and never wait on a frame.
+enum ClientMsg {
+    SetPixelFormat([u8; 16]),
+    SetEncodings(Vec<i32>),
+    UpdateRequest { incremental: bool },
+    ContinuousUpdates { enable: bool },
+}
+
+fn handle_client<R: Read + Send + 'static, W: CloseWrite>(
+    reader: R,
+    mut s: W,
     fb: Arc<DisplayFramebuffer>,
     input: Option<super::input::VncInput>,
 ) -> std::io::Result<()> {
+    let result = run_client(reader, &mut s, fb, input);
+    // Closing the connection is what unblocks the reader thread.
+    s.close();
+    result
+}
+
+fn run_client<R: Read + Send + 'static, W: Write>(
+    mut r: R,
+    s: &mut W,
+    fb: Arc<DisplayFramebuffer>,
+    input: Option<super::input::VncInput>,
+) -> std::io::Result<()> {
+    let mut s = s;
     // --- handshake -------------------------------------------------------
     s.write_all(RFB_VERSION)?;
     let mut version = [0u8; 12];
-    s.read_exact(&mut version)?;
+    r.read_exact(&mut version)?;
 
     // Offer only "None"; this port is expected to be bound to loopback or a
     // trusted interface by the caller.
     s.write_all(&[1, SECURITY_NONE])?;
     let mut chosen = [0u8; 1];
-    s.read_exact(&mut chosen)?;
+    r.read_exact(&mut chosen)?;
     if chosen[0] != SECURITY_NONE {
         // SecurityResult: failure, plus a reason string (3.8 requires one).
         let reason = b"only the None security type is offered";
@@ -434,7 +484,7 @@ fn handle_client<S: Read + Write>(
     s.write_all(&0u32.to_be_bytes())?; // SecurityResult: OK
 
     let mut shared = [0u8; 1];
-    s.read_exact(&mut shared)?; // ClientInit
+    r.read_exact(&mut shared)?; // ClientInit
 
     // Geometry has to be committed at ServerInit, before the guest may have
     // presented anything. Fall back to the configured display size so a client
@@ -445,7 +495,7 @@ fn handle_client<S: Read + Write>(
         .map(|f| (f.width, f.height))
         .unwrap_or((1280, 800));
 
-    let mut fmt = PixelFormat::bgrx();
+    let fmt = PixelFormat::bgrx();
     let name = b"smolvm";
     let mut init = Vec::with_capacity(32);
     init.extend_from_slice(&(width as u16).to_be_bytes());
@@ -461,17 +511,208 @@ fn handle_client<S: Read + Write>(
     let mut last_generation = 0u64;
     // BGRX pixels of the last frame this client was sent, for damage diffing.
     let mut last_sent: Option<Vec<u8>> = None;
-    let mut client_supports_resize = false;
-    // A client that lists the Cursor pseudo-encoding draws the pointer itself;
-    // any other client gets the pointer composited into the frames.
-    let mut client_supports_cursor = false;
-    // A client that lists no pixel encoding at all (only pseudo-encodings)
-    // is here for input and the pointer image, not for pixels.
-    let mut client_wants_pixels = true;
+    let mut fmt_state = ClientState {
+        fmt,
+        supports_resize: false,
+        supports_cursor: false,
+        wants_pixels: true,
+        pending: None,
+        continuous: false,
+    };
     let mut last_cursor_generation = 0u64;
     let mut last_cursor_image_generation = 0u64;
-    let mut last_button_mask = 0u8;
 
+    // The reader thread owns the socket's read half: input is injected the
+    // moment it arrives, and control messages reach this loop by channel, so
+    // waiting for a frame never delays a keystroke or a pointer move.
+    let size = Arc::new((AtomicU32::new(width), AtomicU32::new(height)));
+    let (tx, rx) = std::sync::mpsc::channel::<ClientMsg>();
+    {
+        let input = input.clone();
+        let size = Arc::clone(&size);
+        std::thread::Builder::new()
+            .name("smolvm-vnc-read".into())
+            .spawn(move || {
+                if let Err(e) = read_client_messages(&mut r, input, size, tx) {
+                    tracing::debug!(error = %e, "vnc reader ended");
+                }
+            })?;
+    }
+
+    loop {
+        // Everything the client has said so far, without blocking.
+        loop {
+            match rx.try_recv() {
+                Ok(msg) => apply_client_msg(msg, &mut fmt_state, &mut s)?,
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => return Ok(()),
+            }
+        }
+        if fmt_state.pending.is_none() && !fmt_state.continuous {
+            // Nothing to send until the client asks (or enables pushing).
+            match rx.recv() {
+                Ok(msg) => {
+                    apply_client_msg(msg, &mut fmt_state, &mut s)?;
+                    continue;
+                }
+                Err(_) => return Ok(()),
+            }
+        }
+        let incremental = fmt_state.pending.unwrap_or(true);
+
+        let (new_frame, new_cursor) = if incremental {
+            fb.wait_for_change(last_generation, last_cursor_generation, UPDATE_WAIT)
+        } else {
+            (fb.latest(), Some(fb.cursor()))
+        };
+        let frame_changed = new_frame.is_some();
+        let cursor_changed = new_cursor.is_some();
+        if !frame_changed && !cursor_changed {
+            if fmt_state.pending.is_some() && !fmt_state.continuous {
+                // A request the classic way: answer promptly, even if with
+                // nothing, so the client's request loop keeps turning.
+                s.write_all(&[0u8, 0, 0, 0])?;
+                fmt_state.pending = None;
+            }
+            continue;
+        }
+        let cursor = new_cursor.unwrap_or_else(|| fb.cursor());
+
+        let mut rects: Vec<Vec<u8>> = Vec::new();
+        // A client that draws the pointer itself needs pixels only for a new
+        // frame; one that does not needs them whenever the pointer moved,
+        // because the pointer lives in the pixels.
+        let need_pixels = fmt_state.wants_pixels
+            && (frame_changed || (cursor_changed && !fmt_state.supports_cursor));
+        if need_pixels {
+            let Some(frame) = new_frame.clone().or_else(|| fb.latest()) else {
+                if !fmt_state.continuous {
+                    s.write_all(&[0u8, 0, 0, 0])?;
+                    fmt_state.pending = None;
+                }
+                continue;
+            };
+            if (frame.width, frame.height) != (width, height) {
+                width = frame.width;
+                height = frame.height;
+                size.0.store(width, Ordering::Relaxed);
+                size.1.store(height, Ordering::Relaxed);
+                if fmt_state.supports_resize {
+                    send_resize(&mut s, width, height)?;
+                } else {
+                    tracing::warn!(
+                        width,
+                        height,
+                        "guest changed mode but the vnc client cannot resize; \
+                         reconnect to pick up the new size"
+                    );
+                }
+                last_sent = None;
+            }
+            let mut bgrx = display::to_bgrx(&frame).into_owned();
+            if !fmt_state.supports_cursor {
+                composite_cursor(&mut bgrx, frame.width, frame.height, &cursor);
+            }
+            match last_sent.as_ref() {
+                Some(prev) if incremental && prev.len() == bgrx.len() => {
+                    rects.extend(frame_diff_rects(&frame, &bgrx, prev, &fmt_state.fmt));
+                }
+                _ => rects.push(frame_rect(&frame, &bgrx, &fmt_state.fmt)),
+            }
+            last_sent = Some(bgrx);
+            last_generation = frame.generation;
+        } else if let Some(frame) = new_frame.as_ref() {
+            last_generation = frame.generation;
+        }
+        if fmt_state.supports_cursor
+            && (cursor.image_generation != last_cursor_image_generation || !incremental)
+        {
+            rects.push(cursor_rect(&cursor, &fmt_state.fmt));
+            last_cursor_image_generation = cursor.image_generation;
+        }
+        if cursor_changed {
+            last_cursor_generation = cursor.generation;
+        }
+        if rects.is_empty() && fmt_state.continuous {
+            // A pointer move for a client drawing its own pointer: nothing
+            // to push.
+            continue;
+        }
+        write_update(&mut s, &rects)?;
+        fmt_state.pending = None;
+    }
+}
+
+/// Per-client negotiated state that client messages change.
+struct ClientState {
+    fmt: PixelFormat,
+    supports_resize: bool,
+    supports_cursor: bool,
+    /// A client that lists no pixel encoding at all (only pseudo-encodings)
+    /// is here for input and the pointer image, not for pixels.
+    wants_pixels: bool,
+    /// An unanswered FramebufferUpdateRequest, `Some(incremental)`.
+    pending: Option<bool>,
+    /// ContinuousUpdates is on: push as the display changes.
+    continuous: bool,
+}
+
+fn apply_client_msg<W: Write>(
+    msg: ClientMsg,
+    st: &mut ClientState,
+    s: &mut W,
+) -> std::io::Result<()> {
+    match msg {
+        ClientMsg::SetPixelFormat(pf) => {
+            let requested = PixelFormat::parse(&pf);
+            if requested.is_supported() {
+                st.fmt = requested;
+            } else {
+                // Keep our format rather than emit pixels the client will
+                // misread; say so, because wrong colours are otherwise a
+                // baffling symptom.
+                tracing::warn!(
+                    bpp = requested.bits_per_pixel,
+                    true_colour = requested.true_colour,
+                    "vnc client asked for an unsupported pixel format; \
+                     continuing with 32-bit true colour"
+                );
+            }
+        }
+        ClientMsg::SetEncodings(listed) => {
+            st.supports_resize = listed.contains(&ENCODING_DESKTOP_SIZE);
+            st.supports_cursor = listed.contains(&ENCODING_CURSOR);
+            // Raw is implicit for ordinary clients, so only a client that
+            // asked for the pointer and for no real encoding is pixel-free.
+            st.wants_pixels = listed.iter().any(|e| *e >= 0) || !st.supports_cursor;
+            if listed.contains(&ENCODING_CONTINUOUS_UPDATES) {
+                // Tells the client the extension is available.
+                s.write_all(&[MSG_END_OF_CONTINUOUS_UPDATES])?;
+            }
+        }
+        ClientMsg::UpdateRequest { incremental } => {
+            // A full request outranks a pending incremental one.
+            st.pending = Some(st.pending.unwrap_or(true) && incremental);
+        }
+        ClientMsg::ContinuousUpdates { enable } => {
+            st.continuous = enable;
+            if !enable {
+                s.write_all(&[MSG_END_OF_CONTINUOUS_UPDATES])?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Parse client messages until the connection ends. Keyboard and pointer
+/// events go straight into the guest; the rest goes to the update loop.
+fn read_client_messages<R: Read>(
+    s: &mut R,
+    input: Option<super::input::VncInput>,
+    size: Arc<(AtomicU32, AtomicU32)>,
+    tx: Sender<ClientMsg>,
+) -> std::io::Result<()> {
+    let mut last_button_mask = 0u8;
     loop {
         let mut kind = [0u8; 1];
         if s.read_exact(&mut kind).is_err() {
@@ -484,19 +725,8 @@ fn handle_client<S: Read + Write>(
                 s.read_exact(&mut rest)?;
                 let mut pf = [0u8; 16];
                 pf.copy_from_slice(&rest[3..19]);
-                let requested = PixelFormat::parse(&pf);
-                if requested.is_supported() {
-                    fmt = requested;
-                } else {
-                    // Keep our format rather than emit pixels the client will
-                    // misread; say so, because wrong colours are otherwise a
-                    // baffling symptom.
-                    tracing::warn!(
-                        bpp = requested.bits_per_pixel,
-                        true_colour = requested.true_colour,
-                        "vnc client asked for an unsupported pixel format; \
-                         continuing with 32-bit true colour"
-                    );
+                if tx.send(ClientMsg::SetPixelFormat(pf)).is_err() {
+                    return Ok(());
                 }
             }
             2 => {
@@ -508,84 +738,27 @@ fn handle_client<S: Read + Write>(
                 s.read_exact(&mut encodings)?;
                 let (encodings, _) = encodings.as_chunks::<4>();
                 let listed: Vec<i32> = encodings.iter().map(|c| i32::from_be_bytes(*c)).collect();
-                client_supports_resize = listed.contains(&ENCODING_DESKTOP_SIZE);
-                client_supports_cursor = listed.contains(&ENCODING_CURSOR);
-                // Raw is implicit for ordinary clients, so only a client that
-                // asked for the pointer and for no real encoding is pixel-free.
-                client_wants_pixels = listed.iter().any(|e| *e >= 0) || !client_supports_cursor;
+                if tx.send(ClientMsg::SetEncodings(listed)).is_err() {
+                    return Ok(());
+                }
             }
             3 => {
                 // FramebufferUpdateRequest: incremental + x,y,w,h
                 let mut req = [0u8; 9];
                 s.read_exact(&mut req)?;
                 let incremental = req[0] != 0;
-
-                let (new_frame, new_cursor) = if incremental {
-                    fb.wait_for_change(last_generation, last_cursor_generation, UPDATE_WAIT)
-                } else {
-                    (fb.latest(), Some(fb.cursor()))
-                };
-                let frame_changed = new_frame.is_some();
-                let cursor_changed = new_cursor.is_some();
-                if !frame_changed && !cursor_changed {
-                    // Nothing new (or nothing presented yet): answer with an
-                    // empty update so the client stays in its request loop.
-                    s.write_all(&[0u8, 0, 0, 0])?;
-                    continue;
+                if tx.send(ClientMsg::UpdateRequest { incremental }).is_err() {
+                    return Ok(());
                 }
-                let cursor = new_cursor.unwrap_or_else(|| fb.cursor());
-
-                let mut rects: Vec<Vec<u8>> = Vec::new();
-                // A client that draws the pointer itself needs pixels only for
-                // a new frame; one that does not needs them whenever the
-                // pointer moved, because the pointer lives in the pixels.
-                let need_pixels = client_wants_pixels
-                    && (frame_changed || (cursor_changed && !client_supports_cursor));
-                if need_pixels {
-                    let Some(frame) = new_frame.clone().or_else(|| fb.latest()) else {
-                        s.write_all(&[0u8, 0, 0, 0])?;
-                        continue;
-                    };
-                    if (frame.width, frame.height) != (width, height) {
-                        width = frame.width;
-                        height = frame.height;
-                        if client_supports_resize {
-                            send_resize(&mut s, width, height)?;
-                        } else {
-                            tracing::warn!(
-                                width,
-                                height,
-                                "guest changed mode but the vnc client cannot resize; \
-                                 reconnect to pick up the new size"
-                            );
-                        }
-                        last_sent = None;
-                    }
-                    let mut bgrx = display::to_bgrx(&frame).into_owned();
-                    if !client_supports_cursor {
-                        composite_cursor(&mut bgrx, frame.width, frame.height, &cursor);
-                    }
-                    match last_sent.as_ref() {
-                        Some(prev) if incremental && prev.len() == bgrx.len() => {
-                            rects.extend(frame_diff_rects(&frame, &bgrx, prev, &fmt));
-                        }
-                        _ => rects.push(frame_rect(&frame, &bgrx, &fmt)),
-                    }
-                    last_sent = Some(bgrx);
-                    last_generation = frame.generation;
-                } else if let Some(frame) = new_frame.as_ref() {
-                    last_generation = frame.generation;
+            }
+            MSG_ENABLE_CONTINUOUS_UPDATES => {
+                // EnableContinuousUpdates: enable flag + x,y,w,h
+                let mut req = [0u8; 9];
+                s.read_exact(&mut req)?;
+                let enable = req[0] != 0;
+                if tx.send(ClientMsg::ContinuousUpdates { enable }).is_err() {
+                    return Ok(());
                 }
-                if client_supports_cursor
-                    && (cursor.image_generation != last_cursor_image_generation || !incremental)
-                {
-                    rects.push(cursor_rect(&cursor, &fmt));
-                    last_cursor_image_generation = cursor.image_generation;
-                }
-                if cursor_changed {
-                    last_cursor_generation = cursor.generation;
-                }
-                write_update(&mut s, &rects)?;
             }
             4 => {
                 // KeyEvent: down-flag, 2 bytes padding, u32 keysym.
@@ -612,7 +785,8 @@ fn handle_client<S: Read + Write>(
                     let mask = buf[0];
                     let x = u16::from_be_bytes([buf[1], buf[2]]) as u32;
                     let y = u16::from_be_bytes([buf[3], buf[4]]) as u32;
-
+                    let width = size.0.load(Ordering::Relaxed);
+                    let height = size.1.load(Ordering::Relaxed);
                     // Absolute axes use a fixed virtual range; scale from the
                     // framebuffer size the client is looking at so a guest
                     // mode change never needs new absinfo.

--- a/src/agent/vnc.rs
+++ b/src/agent/vnc.rs
@@ -23,7 +23,7 @@ use std::net::{TcpListener, TcpStream};
 use std::sync::Arc;
 use std::time::Duration;
 
-use super::display::{self, DisplayFramebuffer, Frame};
+use super::display::{self, Cursor, DisplayFramebuffer, Frame};
 
 const RFB_VERSION: &[u8; 12] = b"RFB 003.008\n";
 const SECURITY_NONE: u8 = 1;
@@ -46,6 +46,9 @@ const UPDATE_WAIT: Duration = Duration::from_millis(15);
 /// Pseudo-encoding letting us tell the client the desktop changed size, which
 /// happens when the compositor sets a mode different from the initial one.
 const ENCODING_DESKTOP_SIZE: i32 = -223;
+/// The Cursor pseudo-encoding: the client draws the pointer itself from an
+/// image the server sends, so pointer motion costs no pixels at all.
+const ENCODING_CURSOR: i32 = -239;
 const ENCODING_RAW: i32 = 0;
 
 /// The pixel layout a client asked for. Defaults to what we natively hold, so
@@ -459,6 +462,14 @@ fn handle_client<S: Read + Write>(
     // BGRX pixels of the last frame this client was sent, for damage diffing.
     let mut last_sent: Option<Vec<u8>> = None;
     let mut client_supports_resize = false;
+    // A client that lists the Cursor pseudo-encoding draws the pointer itself;
+    // any other client gets the pointer composited into the frames.
+    let mut client_supports_cursor = false;
+    // A client that lists no pixel encoding at all (only pseudo-encodings)
+    // is here for input and the pointer image, not for pixels.
+    let mut client_wants_pixels = true;
+    let mut last_cursor_generation = 0u64;
+    let mut last_cursor_image_generation = 0u64;
     let mut last_button_mask = 0u8;
 
     loop {
@@ -496,9 +507,12 @@ fn handle_client<S: Read + Write>(
                 let mut encodings = vec![0u8; count * 4];
                 s.read_exact(&mut encodings)?;
                 let (encodings, _) = encodings.as_chunks::<4>();
-                client_supports_resize = encodings
-                    .iter()
-                    .any(|c| i32::from_be_bytes(*c) == ENCODING_DESKTOP_SIZE);
+                let listed: Vec<i32> = encodings.iter().map(|c| i32::from_be_bytes(*c)).collect();
+                client_supports_resize = listed.contains(&ENCODING_DESKTOP_SIZE);
+                client_supports_cursor = listed.contains(&ENCODING_CURSOR);
+                // Raw is implicit for ordinary clients, so only a client that
+                // asked for the pointer and for no real encoding is pixel-free.
+                client_wants_pixels = listed.iter().any(|e| *e >= 0) || !client_supports_cursor;
             }
             3 => {
                 // FramebufferUpdateRequest: incremental + x,y,w,h
@@ -506,49 +520,72 @@ fn handle_client<S: Read + Write>(
                 s.read_exact(&mut req)?;
                 let incremental = req[0] != 0;
 
-                let frame = if incremental {
-                    fb.wait_for_frame(last_generation, UPDATE_WAIT)
-                        .or_else(|| fb.latest())
+                let (new_frame, new_cursor) = if incremental {
+                    fb.wait_for_change(last_generation, last_cursor_generation, UPDATE_WAIT)
                 } else {
-                    fb.latest()
+                    (fb.latest(), Some(fb.cursor()))
                 };
-
-                let Some(frame) = frame else {
-                    // Nothing presented yet. Answer with an empty update so the
-                    // client stays in its request loop instead of stalling.
-                    s.write_all(&[0u8, 0, 0, 0])?;
-                    continue;
-                };
-
-                if incremental && frame.generation == last_generation {
+                let frame_changed = new_frame.is_some();
+                let cursor_changed = new_cursor.is_some();
+                if !frame_changed && !cursor_changed {
+                    // Nothing new (or nothing presented yet): answer with an
+                    // empty update so the client stays in its request loop.
                     s.write_all(&[0u8, 0, 0, 0])?;
                     continue;
                 }
-                last_generation = frame.generation;
+                let cursor = new_cursor.unwrap_or_else(|| fb.cursor());
 
-                if (frame.width, frame.height) != (width, height) {
-                    width = frame.width;
-                    height = frame.height;
-                    if client_supports_resize {
-                        send_resize(&mut s, width, height)?;
-                    } else {
-                        tracing::warn!(
-                            width,
-                            height,
-                            "guest changed mode but the vnc client cannot resize; \
-                             reconnect to pick up the new size"
-                        );
+                let mut rects: Vec<Vec<u8>> = Vec::new();
+                // A client that draws the pointer itself needs pixels only for
+                // a new frame; one that does not needs them whenever the
+                // pointer moved, because the pointer lives in the pixels.
+                let need_pixels = client_wants_pixels
+                    && (frame_changed || (cursor_changed && !client_supports_cursor));
+                if need_pixels {
+                    let Some(frame) = new_frame.clone().or_else(|| fb.latest()) else {
+                        s.write_all(&[0u8, 0, 0, 0])?;
+                        continue;
+                    };
+                    if (frame.width, frame.height) != (width, height) {
+                        width = frame.width;
+                        height = frame.height;
+                        if client_supports_resize {
+                            send_resize(&mut s, width, height)?;
+                        } else {
+                            tracing::warn!(
+                                width,
+                                height,
+                                "guest changed mode but the vnc client cannot resize; \
+                                 reconnect to pick up the new size"
+                            );
+                        }
+                        last_sent = None;
                     }
-                }
-
-                let bgrx = display::to_bgrx(&frame);
-                match last_sent.as_ref() {
-                    Some(prev) if incremental && prev.len() == bgrx.len() => {
-                        send_frame_diff(&mut s, &frame, &bgrx, prev, &fmt)?;
+                    let mut bgrx = display::to_bgrx(&frame).into_owned();
+                    if !client_supports_cursor {
+                        composite_cursor(&mut bgrx, frame.width, frame.height, &cursor);
                     }
-                    _ => send_frame(&mut s, &frame, &bgrx, &fmt)?,
+                    match last_sent.as_ref() {
+                        Some(prev) if incremental && prev.len() == bgrx.len() => {
+                            rects.extend(frame_diff_rects(&frame, &bgrx, prev, &fmt));
+                        }
+                        _ => rects.push(frame_rect(&frame, &bgrx, &fmt)),
+                    }
+                    last_sent = Some(bgrx);
+                    last_generation = frame.generation;
+                } else if let Some(frame) = new_frame.as_ref() {
+                    last_generation = frame.generation;
                 }
-                last_sent = Some(bgrx.into_owned());
+                if client_supports_cursor
+                    && (cursor.image_generation != last_cursor_image_generation || !incremental)
+                {
+                    rects.push(cursor_rect(&cursor, &fmt));
+                    last_cursor_image_generation = cursor.image_generation;
+                }
+                if cursor_changed {
+                    last_cursor_generation = cursor.generation;
+                }
+                write_update(&mut s, &rects)?;
             }
             4 => {
                 // KeyEvent: down-flag, 2 bytes padding, u32 keysym.
@@ -681,36 +718,101 @@ fn send_resize<S: Write>(s: &mut S, width: u32, height: u32) -> std::io::Result<
     s.write_all(&msg)
 }
 
-fn send_frame<S: Write>(
-    s: &mut S,
-    frame: &Frame,
-    bgrx: &[u8],
-    fmt: &PixelFormat,
-) -> std::io::Result<()> {
-    let pixels = encode_pixels(bgrx, fmt);
-
-    let mut header = vec![0u8, 0];
-    header.extend_from_slice(&1u16.to_be_bytes()); // one rectangle
-    header.extend_from_slice(&0u16.to_be_bytes()); // x
-    header.extend_from_slice(&0u16.to_be_bytes()); // y
-    header.extend_from_slice(&(frame.width as u16).to_be_bytes());
-    header.extend_from_slice(&(frame.height as u16).to_be_bytes());
-    header.extend_from_slice(&ENCODING_RAW.to_be_bytes());
-    s.write_all(&header)?;
-    s.write_all(&pixels)
+/// One FramebufferUpdate carrying the given already-encoded rectangles.
+fn write_update<S: Write>(s: &mut S, rects: &[Vec<u8>]) -> std::io::Result<()> {
+    let mut msg = vec![0u8, 0];
+    msg.extend_from_slice(&(rects.len() as u16).to_be_bytes());
+    for r in rects {
+        msg.extend_from_slice(r);
+    }
+    s.write_all(&msg)
 }
 
-/// Send only the row bands that changed since the frame this client last
-/// received. Raw encoding ships every pixel of a rectangle, so cursor-sized
-/// damage would otherwise cost a full-frame update (~5 MB at 1440x900) on
-/// every pointer movement.
-fn send_frame_diff<S: Write>(
-    s: &mut S,
-    frame: &Frame,
-    bgrx: &[u8],
-    prev: &[u8],
-    fmt: &PixelFormat,
-) -> std::io::Result<()> {
+fn rect_header(x: u32, y: u32, w: u32, h: u32, encoding: i32) -> Vec<u8> {
+    let mut rect = Vec::with_capacity(12);
+    rect.extend_from_slice(&(x as u16).to_be_bytes());
+    rect.extend_from_slice(&(y as u16).to_be_bytes());
+    rect.extend_from_slice(&(w as u16).to_be_bytes());
+    rect.extend_from_slice(&(h as u16).to_be_bytes());
+    rect.extend_from_slice(&encoding.to_be_bytes());
+    rect
+}
+
+/// The whole frame as one Raw rectangle.
+fn frame_rect(frame: &Frame, bgrx: &[u8], fmt: &PixelFormat) -> Vec<u8> {
+    let mut rect = rect_header(0, 0, frame.width, frame.height, ENCODING_RAW);
+    rect.extend_from_slice(&encode_pixels(bgrx, fmt));
+    rect
+}
+
+/// The pointer as a Cursor pseudo-rectangle: the image in the client's pixel
+/// format followed by a one-bit-per-pixel mask, hot spot in the position
+/// fields. An empty (hidden) pointer is a 0x0 rectangle.
+fn cursor_rect(cursor: &Cursor, fmt: &PixelFormat) -> Vec<u8> {
+    if !cursor.is_visible() {
+        return rect_header(0, 0, 0, 0, ENCODING_CURSOR);
+    }
+    let (w, h) = (cursor.width as usize, cursor.height as usize);
+    let mut rect = rect_header(
+        cursor.hot_x,
+        cursor.hot_y,
+        cursor.width,
+        cursor.height,
+        ENCODING_CURSOR,
+    );
+    // The default format is a byte-for-byte pass-through, so the alpha
+    // channel survives for clients that can use it; other formats get the
+    // mask only.
+    rect.extend_from_slice(&encode_pixels(&cursor.bgra, fmt));
+    let row_bytes = w.div_ceil(8);
+    let mut mask = vec![0u8; row_bytes * h];
+    for y in 0..h {
+        for x in 0..w {
+            if cursor.bgra[(y * w + x) * 4 + 3] >= 0x80 {
+                mask[y * row_bytes + x / 8] |= 0x80 >> (x % 8);
+            }
+        }
+    }
+    rect.extend_from_slice(&mask);
+    rect
+}
+
+/// Draw the pointer into a B,G,R,X frame for a client that cannot draw it
+/// itself, straight-alpha blended and clipped to the frame.
+fn composite_cursor(bgrx: &mut [u8], width: u32, height: u32, cursor: &Cursor) {
+    if !cursor.is_visible() {
+        return;
+    }
+    let (fw, fh) = (width as i64, height as i64);
+    let left = cursor.x as i64 - cursor.hot_x as i64;
+    let top = cursor.y as i64 - cursor.hot_y as i64;
+    for cy in 0..cursor.height as i64 {
+        let y = top + cy;
+        if y < 0 || y >= fh {
+            continue;
+        }
+        for cx in 0..cursor.width as i64 {
+            let x = left + cx;
+            if x < 0 || x >= fw {
+                continue;
+            }
+            let src =
+                &cursor.bgra[((cy as usize) * cursor.width as usize + cx as usize) * 4..][..4];
+            let a = src[3] as u32;
+            if a == 0 {
+                continue;
+            }
+            let dst = &mut bgrx[((y as usize) * width as usize + x as usize) * 4..][..4];
+            for c in 0..3 {
+                dst[c] = ((src[c] as u32 * a + dst[c] as u32 * (255 - a)) / 255) as u8;
+            }
+        }
+    }
+}
+
+/// Only the changed tiles since `prev`, as Raw rectangles; empty when the
+/// pixels did not change.
+fn frame_diff_rects(frame: &Frame, bgrx: &[u8], prev: &[u8], fmt: &PixelFormat) -> Vec<Vec<u8>> {
     const BAND_ROWS: usize = 16;
     const TILE_COLS: usize = 64;
     let width = frame.width as usize;
@@ -761,31 +863,19 @@ fn send_frame_diff<S: Write>(
         }
     }
 
-    if merged.is_empty() {
-        // The frame generation moved but the pixels did not.
-        return s.write_all(&[0u8, 0, 0, 0]);
-    }
-
-    let mut header = vec![0u8, 0];
-    header.extend_from_slice(&(merged.len() as u16).to_be_bytes());
-    s.write_all(&header)?;
+    let mut out = Vec::with_capacity(merged.len());
     let mut pixels = Vec::new();
     for r in merged {
-        let mut rect = Vec::with_capacity(12);
-        rect.extend_from_slice(&(r.x as u16).to_be_bytes());
-        rect.extend_from_slice(&(r.y as u16).to_be_bytes());
-        rect.extend_from_slice(&(r.w as u16).to_be_bytes());
-        rect.extend_from_slice(&(r.h as u16).to_be_bytes());
-        rect.extend_from_slice(&ENCODING_RAW.to_be_bytes());
-        s.write_all(&rect)?;
+        let mut rect = rect_header(r.x as u32, r.y as u32, r.w as u32, r.h as u32, ENCODING_RAW);
         pixels.clear();
         for line in r.y..r.y + r.h {
             let a = line * row + r.x * 4;
             pixels.extend_from_slice(&bgrx[a..a + r.w * 4]);
         }
-        s.write_all(&encode_pixels(&pixels, fmt))?;
+        rect.extend_from_slice(&encode_pixels(&pixels, fmt));
+        out.push(rect);
     }
-    Ok(())
+    out
 }
 
 /// The URL to open in a browser for a server bound to `addr`. A wildcard

--- a/src/agent/vnc.rs
+++ b/src/agent/vnc.rs
@@ -439,8 +439,18 @@ impl CloseWrite for super::websocket::WsWriter {
 enum ClientMsg {
     SetPixelFormat([u8; 16]),
     SetEncodings(Vec<i32>),
-    UpdateRequest { incremental: bool },
-    ContinuousUpdates { enable: bool },
+    UpdateRequest {
+        incremental: bool,
+    },
+    ContinuousUpdates {
+        enable: bool,
+    },
+    /// Where the client just put its pointer, for compositing: the guest
+    /// follows it one-to-one, and this is known before the guest says so.
+    Pointer {
+        x: u32,
+        y: u32,
+    },
 }
 
 fn handle_client<R: Read + Send + 'static, W: CloseWrite>(
@@ -518,6 +528,8 @@ fn run_client<R: Read + Send + 'static, W: Write>(
         wants_pixels: true,
         pending: None,
         continuous: false,
+        pointer: None,
+        pointer_moved: false,
     };
     let mut last_cursor_generation = 0u64;
     let mut last_cursor_image_generation = 0u64;
@@ -566,7 +578,10 @@ fn run_client<R: Read + Send + 'static, W: Write>(
             (fb.latest(), Some(fb.cursor()))
         };
         let frame_changed = new_frame.is_some();
-        let cursor_changed = new_cursor.is_some();
+        // For a client that cannot draw the pointer, its own pointer move is
+        // a change too: the pointer is composited where the client put it.
+        let cursor_changed =
+            new_cursor.is_some() || (fmt_state.pointer_moved && !fmt_state.supports_cursor);
         if !frame_changed && !cursor_changed {
             if fmt_state.pending.is_some() && !fmt_state.continuous {
                 // A request the classic way: answer promptly, even if with
@@ -576,7 +591,13 @@ fn run_client<R: Read + Send + 'static, W: Write>(
             }
             continue;
         }
-        let cursor = new_cursor.unwrap_or_else(|| fb.cursor());
+        let guest_cursor_generation = new_cursor.as_ref().map(|c| c.generation);
+        let mut cursor = new_cursor.unwrap_or_else(|| fb.cursor());
+        if let (Some((x, y)), false) = (fmt_state.pointer, fmt_state.supports_cursor) {
+            cursor.x = x;
+            cursor.y = y;
+        }
+        fmt_state.pointer_moved = false;
 
         let mut rects: Vec<Vec<u8>> = Vec::new();
         // A client that draws the pointer itself needs pixels only for a new
@@ -630,8 +651,8 @@ fn run_client<R: Read + Send + 'static, W: Write>(
             rects.push(cursor_rect(&cursor, &fmt_state.fmt));
             last_cursor_image_generation = cursor.image_generation;
         }
-        if cursor_changed {
-            last_cursor_generation = cursor.generation;
+        if let Some(generation) = guest_cursor_generation {
+            last_cursor_generation = generation;
         }
         if rects.is_empty() && fmt_state.continuous {
             // A pointer move for a client drawing its own pointer: nothing
@@ -655,6 +676,10 @@ struct ClientState {
     pending: Option<bool>,
     /// ContinuousUpdates is on: push as the display changes.
     continuous: bool,
+    /// The client's own pointer position, if it has sent one.
+    pointer: Option<(u32, u32)>,
+    /// The client moved its pointer since the last update it was sent.
+    pointer_moved: bool,
 }
 
 fn apply_client_msg<W: Write>(
@@ -698,6 +723,12 @@ fn apply_client_msg<W: Write>(
             st.continuous = enable;
             if !enable {
                 s.write_all(&[MSG_END_OF_CONTINUOUS_UPDATES])?;
+            }
+        }
+        ClientMsg::Pointer { x, y } => {
+            if st.pointer != Some((x, y)) {
+                st.pointer = Some((x, y));
+                st.pointer_moved = true;
             }
         }
     }
@@ -787,6 +818,9 @@ fn read_client_messages<R: Read>(
                     let y = u16::from_be_bytes([buf[3], buf[4]]) as u32;
                     let width = size.0.load(Ordering::Relaxed);
                     let height = size.1.load(Ordering::Relaxed);
+                    if tx.send(ClientMsg::Pointer { x, y }).is_err() {
+                        return Ok(());
+                    }
                     // Absolute axes use a fixed virtual range; scale from the
                     // framebuffer size the client is looking at so a guest
                     // mode change never needs new absinfo.

--- a/src/agent/vnc.rs
+++ b/src/agent/vnc.rs
@@ -712,41 +712,78 @@ fn send_frame_diff<S: Write>(
     fmt: &PixelFormat,
 ) -> std::io::Result<()> {
     const BAND_ROWS: usize = 16;
-    let row = frame.width as usize * 4;
+    const TILE_COLS: usize = 64;
+    let width = frame.width as usize;
     let height = frame.height as usize;
+    let row = width * 4;
 
-    // Dirty 16-row bands, with adjacent bands merged into one rectangle.
-    let mut rects: Vec<(usize, usize)> = Vec::new();
-    let mut start = 0;
-    while start < height {
-        let rows = BAND_ROWS.min(height - start);
-        if bgrx[start * row..(start + rows) * row] != prev[start * row..(start + rows) * row] {
-            match rects.last_mut() {
-                Some(last) if last.0 + last.1 == start => last.1 += rows,
-                _ => rects.push((start, rows)),
+    // Dirty 64x16 tiles, merged horizontally within a band and then
+    // vertically across bands. Full-width bands made pointer-sized damage
+    // cost ~160 KB per frame at 1280 wide; a tile run costs a few KB.
+    struct Rect {
+        x: usize,
+        y: usize,
+        w: usize,
+        h: usize,
+    }
+    let mut rects: Vec<Rect> = Vec::new();
+    let mut y = 0;
+    while y < height {
+        let h = BAND_ROWS.min(height - y);
+        let mut x = 0;
+        while x < width {
+            let w = TILE_COLS.min(width - x);
+            let dirty = (y..y + h).any(|r| {
+                let a = r * row + x * 4;
+                bgrx[a..a + w * 4] != prev[a..a + w * 4]
+            });
+            if dirty {
+                match rects.last_mut() {
+                    Some(last) if last.y == y && last.x + last.w == x => last.w += w,
+                    _ => rects.push(Rect { x, y, w, h }),
+                }
             }
+            x += w;
         }
-        start += rows;
+        y += h;
+    }
+    // Merge a rect with the one directly above it when they span the same
+    // columns, so a scrolling window is still one rectangle, not sixteen.
+    let mut merged: Vec<Rect> = Vec::new();
+    for r in rects {
+        match merged
+            .iter_mut()
+            .rev()
+            .find(|m| m.x == r.x && m.w == r.w && m.y + m.h == r.y)
+        {
+            Some(m) => m.h += r.h,
+            None => merged.push(r),
+        }
     }
 
-    if rects.is_empty() {
+    if merged.is_empty() {
         // The frame generation moved but the pixels did not.
         return s.write_all(&[0u8, 0, 0, 0]);
     }
 
     let mut header = vec![0u8, 0];
-    header.extend_from_slice(&(rects.len() as u16).to_be_bytes());
+    header.extend_from_slice(&(merged.len() as u16).to_be_bytes());
     s.write_all(&header)?;
-    for (band_start, band_rows) in rects {
+    let mut pixels = Vec::new();
+    for r in merged {
         let mut rect = Vec::with_capacity(12);
-        rect.extend_from_slice(&0u16.to_be_bytes());
-        rect.extend_from_slice(&(band_start as u16).to_be_bytes());
-        rect.extend_from_slice(&(frame.width as u16).to_be_bytes());
-        rect.extend_from_slice(&(band_rows as u16).to_be_bytes());
+        rect.extend_from_slice(&(r.x as u16).to_be_bytes());
+        rect.extend_from_slice(&(r.y as u16).to_be_bytes());
+        rect.extend_from_slice(&(r.w as u16).to_be_bytes());
+        rect.extend_from_slice(&(r.h as u16).to_be_bytes());
         rect.extend_from_slice(&ENCODING_RAW.to_be_bytes());
         s.write_all(&rect)?;
-        let band = &bgrx[band_start * row..(band_start + band_rows) * row];
-        s.write_all(&encode_pixels(band, fmt))?;
+        pixels.clear();
+        for line in r.y..r.y + r.h {
+            let a = line * row + r.x * 4;
+            pixels.extend_from_slice(&bgrx[a..a + r.w * 4]);
+        }
+        s.write_all(&encode_pixels(&pixels, fmt))?;
     }
     Ok(())
 }

--- a/src/agent/vnc_client.html
+++ b/src/agent/vnc_client.html
@@ -261,7 +261,13 @@ function startVideo() {
           codec: "avc1.42E02A",                                 // Constrained Baseline 4.2
           codedWidth: fbWidth,
           codedHeight: fbHeight,
-          hardwareAcceleration: "prefer-hardware",
+          // The hardware decoder on macOS holds several frames before it
+          // outputs anything, whatever the latency hint says, which both
+          // delays the first picture past the fallback timeout on an idle
+          // desktop and adds a constant lag. Software decode of a desktop-
+          // sized stream costs a few milliseconds a frame and outputs each
+          // chunk as it arrives.
+          hardwareAcceleration: "prefer-software",
           optimizeForLatency: true,
         });
         configured = true;

--- a/src/agent/vnc_client.html
+++ b/src/agent/vnc_client.html
@@ -116,13 +116,15 @@ async function session() {
   // Keep RFB connected for keyboard and pointer input in both modes.  A
   // second WebSocket carries encoded H.264 when the browser and host support
   // it; otherwise this same session falls back to ordinary Raw rectangles.
-  const enc = new Uint8Array(12);
-  enc[0] = 2; putU16(enc, 2, 2); putI32(enc, 4, -223); putI32(enc, 8, 0);
-  send(enc);
-
+  // The Cursor pseudo-encoding (-239) makes the server hand over the pointer
+  // image instead of drawing it into frames; this page then shows it as the
+  // CSS cursor, so pointer motion never waits on a frame at all.
   if ("VideoDecoder" in window) {
     try {
+      setEncodings([-239, -223]);                             // pointer only, no pixels
       await startVideo();
+      requestUpdate(false);
+      updateLoop().catch((e) => setStatus(String(e && e.message || e), true));
       return;
     } catch (e) {
       console.info("encoded video unavailable; using Raw RFB", e);
@@ -131,16 +133,50 @@ async function session() {
   startRaw();
 }
 
+function setEncodings(list) {
+  const enc = new Uint8Array(4 + 4 * list.length);
+  enc[0] = 2; putU16(enc, 2, list.length);
+  list.forEach((e, i) => putI32(enc, 4 + 4 * i, e));
+  send(enc);
+}
+
 function startRaw() {
   if (rawStarted) return;
   rawStarted = true;
   if (videoSocket) { videoSocket.onclose = null; videoSocket.close(); }
   if (decoder) { try { decoder.close(); } catch (_) {} decoder = null; }
-  rawLoop().catch((e) => setStatus(String(e && e.message || e), true));
+  setEncodings([-239, -223, 0]);
+  requestUpdate(false);
+  updateLoop().catch((e) => setStatus(String(e && e.message || e), true));
 }
 
-async function rawLoop() {
-  requestUpdate(false);
+// Turn a Cursor pseudo-rectangle (B,G,R,A pixels plus a 1-bit mask) into the
+// page's CSS cursor, hot spot included. A 0x0 rectangle hides the pointer.
+function applyCursor(hotX, hotY, w, h, pixels, mask) {
+  if (!w || !h) { canvas.style.cursor = "none"; return; }
+  const c = document.createElement("canvas");
+  c.width = w; c.height = h;
+  const cctx = c.getContext("2d");
+  const img = cctx.createImageData(w, h);
+  const rowBytes = (w + 7) >> 3;
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const i = (y * w + x) * 4;
+      const on = (mask[y * rowBytes + (x >> 3)] >> (7 - (x & 7))) & 1;
+      img.data[i] = pixels[i + 2];
+      img.data[i + 1] = pixels[i + 1];
+      img.data[i + 2] = pixels[i];
+      img.data[i + 3] = on ? (pixels[i + 3] || 255) : 0;
+    }
+  }
+  cctx.putImageData(img, 0, 0);
+  canvas.style.cursor = `url(${c.toDataURL()}) ${hotX} ${hotY}, default`;
+}
+
+let loopRunning = false;
+async function updateLoop() {
+  if (loopRunning) return;
+  loopRunning = true;
   for (;;) {
     const type = (await recv(1))[0];
     if (type !== 0) throw new Error("unexpected server message " + type);
@@ -154,6 +190,10 @@ async function rawLoop() {
         draw(x, y, w, h, await recv(w * h * 4));
       } else if (encoding === -223) {
         resize(w, h);                                         // DesktopSize
+      } else if (encoding === -239) {
+        const pixels = w && h ? await recv(w * h * 4) : new Uint8Array(0);
+        const mask = w && h ? await recv(((w + 7) >> 3) * h) : new Uint8Array(0);
+        applyCursor(x, y, w, h, pixels, mask);
       } else {
         throw new Error("unsupported encoding " + encoding);
       }

--- a/src/agent/vnc_client.html
+++ b/src/agent/vnc_client.html
@@ -258,7 +258,7 @@ function startVideo() {
         const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
         resize(view.getUint32(1), view.getUint32(5));
         decoder.configure({
-          codec: "avc1.4D002A",
+          codec: "avc1.42E02A",                                 // Constrained Baseline 4.2
           codedWidth: fbWidth,
           codedHeight: fbHeight,
           hardwareAcceleration: "prefer-hardware",

--- a/src/agent/vnc_client.html
+++ b/src/agent/vnc_client.html
@@ -122,9 +122,11 @@ async function session() {
   if ("VideoDecoder" in window) {
     try {
       setEncodings([-313, -239, -223]);                       // pointer only, no pixels
-      await startVideo();
+      // The pointer and pushed updates start now, so the cursor is right
+      // even while the first encoded frame is still on its way.
       requestUpdate(false);
       updateLoop().catch((e) => setStatus(String(e && e.message || e), true));
+      await startVideo();
       return;
     } catch (e) {
       console.info("encoded video unavailable; using Raw RFB", e);

--- a/src/agent/vnc_client.html
+++ b/src/agent/vnc_client.html
@@ -237,17 +237,22 @@ function resize(w, h) {
 }
 
 // The server sends BGRX; canvas wants RGBA.
+// Reuse one ImageData per rectangle size and swizzle 32 bits at a time: a
+// fresh allocation and a per-byte copy for every rectangle at tens of MB/s
+// is what made the raw path stall the page and back up the socket.
+let drawImg = null, drawW = 0, drawH = 0;
 function draw(x, y, w, h, pixels) {
-  const img = ctx.createImageData(w, h);
-  const out = img.data;
-  for (let i = 0; i < w * h; i++) {
-    const p = i * 4;
-    out[p] = pixels[p + 2];
-    out[p + 1] = pixels[p + 1];
-    out[p + 2] = pixels[p];
-    out[p + 3] = 255;
+  if (!drawImg || drawW !== w || drawH !== h) {
+    drawImg = ctx.createImageData(w, h); drawW = w; drawH = h;
   }
-  ctx.putImageData(img, x, y);
+  if (pixels.byteOffset & 3) pixels = pixels.slice();          // Uint32 view needs alignment
+  const src = new Uint32Array(pixels.buffer, pixels.byteOffset, w * h);
+  const dst = new Uint32Array(drawImg.data.buffer);
+  for (let i = 0; i < src.length; i++) {
+    const v = src[i];                                            // little-endian B,G,R,X
+    dst[i] = 0xff000000 | ((v & 0xff) << 16) | (v & 0xff00) | ((v >>> 16) & 0xff);
+  }
+  ctx.putImageData(drawImg, x, y);
 }
 
 function requestUpdate(incremental) {
@@ -274,11 +279,25 @@ function sendPointer(mask, x, y) {
 function maskOf(ev) {
   return (ev.buttons & 1 ? 1 : 0) | (ev.buttons & 4 ? 2 : 0) | (ev.buttons & 2 ? 4 : 0);
 }
+// Motion is coalesced to one position per animation frame: forwarding every
+// mousemove event made the guest re-render (and the server re-encode) for each
+// one, hundreds of times a second. Button changes are sent at once.
+let pendingMove = null, moveScheduled = false;
+function flushMove() {
+  moveScheduled = false;
+  if (pendingMove) { sendPointer(pendingMove[0], pendingMove[1], pendingMove[2]); pendingMove = null; }
+}
 function onPointer(ev) {
   if (!fbWidth) return;
-  buttonMask = maskOf(ev);
+  const mask = maskOf(ev);
   const [x, y] = at(ev);
-  sendPointer(buttonMask, x, y);
+  if (ev.type !== "mousemove" || mask !== buttonMask) {
+    buttonMask = mask; pendingMove = null;
+    sendPointer(mask, x, y);
+    return;
+  }
+  pendingMove = [mask, x, y];
+  if (!moveScheduled) { moveScheduled = true; requestAnimationFrame(flushMove); }
 }
 canvas.addEventListener("mousemove", onPointer);
 canvas.addEventListener("mousedown", (ev) => { canvas.focus(); onPointer(ev); });

--- a/src/agent/vnc_client.html
+++ b/src/agent/vnc_client.html
@@ -121,7 +121,7 @@ async function session() {
   // CSS cursor, so pointer motion never waits on a frame at all.
   if ("VideoDecoder" in window) {
     try {
-      setEncodings([-239, -223]);                             // pointer only, no pixels
+      setEncodings([-313, -239, -223]);                       // pointer only, no pixels
       await startVideo();
       requestUpdate(false);
       updateLoop().catch((e) => setStatus(String(e && e.message || e), true));
@@ -145,7 +145,7 @@ function startRaw() {
   rawStarted = true;
   if (videoSocket) { videoSocket.onclose = null; videoSocket.close(); }
   if (decoder) { try { decoder.close(); } catch (_) {} decoder = null; }
-  setEncodings([-239, -223, 0]);
+  setEncodings([-313, -239, -223, 0]);
   requestUpdate(false);
   updateLoop().catch((e) => setStatus(String(e && e.message || e), true));
 }
@@ -173,12 +173,26 @@ function applyCursor(hotX, hotY, w, h, pixels, mask) {
   canvas.style.cursor = `url(${c.toDataURL()}) ${hotX} ${hotY}, default`;
 }
 
+// Ask the server to push updates as the display changes (RFB
+// ContinuousUpdates, -313) instead of answering one request at a time. The
+// server confirms support with an EndOfContinuousUpdates message.
+let continuous = false;
+function enableContinuousUpdates() {
+  const m = new Uint8Array(10);
+  m[0] = 150; m[1] = 1; putU16(m, 2, 0); putU16(m, 4, 0); putU16(m, 6, 0xffff); putU16(m, 8, 0xffff);
+  send(m);
+  continuous = true;
+}
 let loopRunning = false;
 async function updateLoop() {
   if (loopRunning) return;
   loopRunning = true;
   for (;;) {
     const type = (await recv(1))[0];
+    if (type === 150) {                                         // EndOfContinuousUpdates
+      if (!continuous) enableContinuousUpdates();
+      continue;
+    }
     if (type !== 0) throw new Error("unexpected server message " + type);
     await recv(1);                                            // padding
     const rects = u16(await recv(2), 0);
@@ -198,7 +212,7 @@ async function updateLoop() {
         throw new Error("unsupported encoding " + encoding);
       }
     }
-    requestUpdate(true);
+    if (!continuous) requestUpdate(true);
   }
 }
 

--- a/src/agent/websocket.rs
+++ b/src/agent/websocket.rs
@@ -158,6 +158,13 @@ impl<S: Read + Write> WsStream<S> {
 
     /// Write one frame. Server frames are never masked.
     fn send_frame(&mut self, opcode: u8, payload: &[u8]) -> Result<()> {
+        write_frame(&mut self.inner, opcode, payload)
+    }
+}
+
+/// Frame `payload` as one message on `w`.
+fn write_frame<W: Write>(w: &mut W, opcode: u8, payload: &[u8]) -> Result<()> {
+    {
         let mut header = Vec::with_capacity(10);
         header.push(0x80 | opcode); // FIN + opcode
         match payload.len() {
@@ -171,8 +178,40 @@ impl<S: Read + Write> WsStream<S> {
                 header.extend_from_slice(&(n as u64).to_be_bytes());
             }
         }
-        self.inner.write_all(&header)?;
-        self.inner.write_all(payload)
+        w.write_all(&header)?;
+        w.write_all(payload)
+    }
+}
+
+/// The write half of a split WebSocket connection: frames what it is given
+/// and can close the whole socket.
+pub struct WsWriter {
+    inner: std::net::TcpStream,
+}
+
+impl WsWriter {
+    pub fn close(&self) {
+        let _ = self.inner.shutdown(std::net::Shutdown::Both);
+    }
+}
+
+impl Write for WsWriter {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        write_frame(&mut self.inner, OP_BINARY, buf)?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        self.inner.flush()
+    }
+}
+
+impl WsStream<std::net::TcpStream> {
+    /// Split into a reading half (this stream) and an independent writing
+    /// half, so one thread can read input while another pushes frames.
+    pub fn split(self) -> Result<(Self, WsWriter)> {
+        let inner = self.inner.try_clone()?;
+        Ok((self, WsWriter { inner }))
     }
 }
 

--- a/src/cli/internal_boot.rs
+++ b/src/cli/internal_boot.rs
@@ -267,7 +267,7 @@ pub fn run(config_path: PathBuf) -> smolvm::Result<()> {
     // drop and Landlock/seccomp; the broker independently drops to the same
     // per-VM uid; hardware modes retain only render/video device groups while
     // software mode retains none. Any failure leaves Raw VNC intact.
-    if std::env::var_os("SMOLVM_VIDEO").is_some()
+    if smolvm::agent::video::is_configured()
         && std::env::var_os("SMOLVM_DISPLAY").is_some()
         && std::env::var_os("SMOLVM_VNC").is_some()
     {


### PR DESCRIPTION
Send only changed tiles, let the browser draw the guest pointer itself, push updates as the display changes, and stream encoded video by default.