### PR TITLE
Refresh libkrun directory metadata handling

### DIFF
--- a/lib/libkrun.dylib
+++ b/lib/libkrun.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b0fbe1f3813d394326f6cae52ef0224228031cba13e46369084766b7d7c5662a
-size 6483440
+oid sha256:e04ffea6baac399ddc351b2d7779364736cf49cd349f9cb1f25b8e8eaf848016
+size 6758944

--- a/lib/libkrun.provenance
+++ b/lib/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=1a42f991d800e71048cfdf6a6bcd53d0625b4f11
+libkrun=bc0962ad68851c770c1dd0bb01bdcbeab76ba308
 libkrunfw=55bb7c5273178826240b39e907475fb6011afd8e

--- a/lib/linux-aarch64/libkrun.provenance
+++ b/lib/linux-aarch64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=1a42f991d800e71048cfdf6a6bcd53d0625b4f11
+libkrun=bc0962ad68851c770c1dd0bb01bdcbeab76ba308
 libkrunfw=55bb7c5273178826240b39e907475fb6011afd8e

--- a/lib/linux-aarch64/libkrun.so
+++ b/lib/linux-aarch64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1402a28e15aa86bd9d1e006ebbe58c650f15bdcc8c1c5b49801cfe4774b69312
-size 7656976
+oid sha256:38a662407ad4c1d82fafdb2f06d32c4dfc50647e5a94e1dbcc857c0f83924882
+size 7667664

--- a/lib/linux-aarch64/libkrun.so.2.0.0
+++ b/lib/linux-aarch64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1402a28e15aa86bd9d1e006ebbe58c650f15bdcc8c1c5b49801cfe4774b69312
-size 7656976
+oid sha256:38a662407ad4c1d82fafdb2f06d32c4dfc50647e5a94e1dbcc857c0f83924882
+size 7667664

--- a/lib/linux-x86_64/libkrun.provenance
+++ b/lib/linux-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=1a42f991d800e71048cfdf6a6bcd53d0625b4f11
+libkrun=bc0962ad68851c770c1dd0bb01bdcbeab76ba308
 libkrunfw=55bb7c5273178826240b39e907475fb6011afd8e

--- a/lib/linux-x86_64/libkrun.so
+++ b/lib/linux-x86_64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ec0f227caa0ae1b67b2d289f4ad82cb6926ecc920f117f67fa73ee926aef70d6
-size 8520568
+oid sha256:951f100e49fdd04d6e7e71c69d402eef60fff9c56ff611bdff910f7dde3da6f7
+size 8530720

--- a/lib/linux-x86_64/libkrun.so.2.0.0
+++ b/lib/linux-x86_64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ec0f227caa0ae1b67b2d289f4ad82cb6926ecc920f117f67fa73ee926aef70d6
-size 8520568
+oid sha256:951f100e49fdd04d6e7e71c69d402eef60fff9c56ff611bdff910f7dde3da6f7
+size 8530720

--- a/lib/windows-x86_64/krun.dll
+++ b/lib/windows-x86_64/krun.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:75f604afee21cb9c6510f40f2324741a4eff177e0bbb7f7079e01b2998c02c89
-size 10947900
+oid sha256:0f09c6941dd42a5bda0268d9533866aabe4a5882d0706f24e17c5a335da1725c
+size 10938913

--- a/lib/windows-x86_64/libkrun.provenance
+++ b/lib/windows-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=1a42f991d800e71048cfdf6a6bcd53d0625b4f11
+libkrun=bc0962ad68851c770c1dd0bb01bdcbeab76ba308
 libkrunfw=55bb7c5273178826240b39e907475fb6011afd8e


### PR DESCRIPTION
Refresh the bundled cross-platform runtimes with handle-free Linux directory operations for faster virtio-fs metadata traversal.