### PR TITLE
Add staged mounts for metadata-heavy workloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3145,6 +3145,7 @@ dependencies = [
  "smolvm-protocol",
  "smolvm-registry",
  "socket2",
+ "tar",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ base64 = { workspace = true }
 zeroize = { version = "1", features = ["zeroize_derive"] }
 humantime = "2"
 tempfile = "3"
+tar = "0.4"
 # Inspect and safely rebase qcow2 backing chains in portable checkpoints.
 imago = { version = "0.2.3", features = ["sync-wrappers"] }
 

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -427,12 +427,25 @@ fn main() {
         );
     }
 
+    // Staged mounts keep their working copy on the persistent storage disk.
+    // Mount it before volume initialization instead of using the normal
+    // post-ready overlap, otherwise the later /storage mount can hide a newly
+    // seeded working tree and lose it across restart.
+    if storage::staged_boot_mount_requested() && !ensure_storage_mounted() {
+        error!("staged volume mount requires the guest storage disk");
+        std::process::exit(1);
+    }
+
     // Initialize volume mounts from SMOLVM_MOUNT_* env vars.
     // MUST run before the /workspace symlink below — if the user passed
     // `-v host:/workspace`, the bind mount claims /workspace first and
     // the symlink's `!exists()` guard correctly skips creation.
     let t0 = uptime_ms();
     let boot_mounts = storage::init_volume_mounts();
+    if storage::staged_boot_mount_requested() && storage::boot_volume_mounts_failed() {
+        error!("failed to initialize staged volume mount");
+        std::process::exit(1);
+    }
     if !boot_mounts.is_empty() {
         info!(
             duration_ms = uptime_ms() - t0,
@@ -535,6 +548,9 @@ fn main() {
     // ensure_storage_mounted() also guards any concurrent call from a request
     // that races in the brief window on very fast hosts.
     ensure_storage_mounted();
+    if let Err(error) = storage::prune_staged_working_copies(storage::init_volume_mounts()) {
+        warn!(error = %error, "failed to clean stale staged working copies");
+    }
 
     // With the disks mounted, start reclaiming freed blocks back to the host
     // sparse files so disk footprint tracks live data (see disk_trim).
@@ -2196,6 +2212,11 @@ fn handle_connection(stream: &mut impl ReadWrite) -> Result<(), Box<dyn std::err
             continue;
         }
 
+        if let AgentRequest::ArchiveDirectory { ref path } = request {
+            handle_streaming_archive_directory(stream, path)?;
+            continue;
+        }
+
         // Streaming file upload: Begin opens a session, Chunk appends
         // or finalizes. Any other request type closes the session
         // implicitly (Drop runs on the Option assignment to None).
@@ -2512,10 +2533,12 @@ fn handle_request(
 
         // Streaming read goes through `handle_connection`'s explicit
         // dispatch so it can emit multiple responses per request.
-        AgentRequest::FileRead { .. } => AgentResponse::error(
-            "streaming file read must be handled at connection level",
-            error_codes::INTERNAL_ERROR,
-        ),
+        AgentRequest::FileRead { .. } | AgentRequest::ArchiveDirectory { .. } => {
+            AgentResponse::error(
+                "streaming read must be handled at connection level",
+                error_codes::INTERNAL_ERROR,
+            )
+        }
 
         // Pod-container lifecycle (containerd shim v2 datapath, see pod.rs).
         AgentRequest::PodCreate {
@@ -3197,6 +3220,26 @@ fn send_data_chunks<R: Read>(
     error_context: &str,
     error_code: &'static str,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    send_data_chunks_body(stream, reader, chunk_size, error_context, error_code)?;
+    send_response(
+        stream,
+        &AgentResponse::DataChunk {
+            data: vec![],
+            done: true,
+        },
+    )?;
+    Ok(())
+}
+
+/// Send data chunks without the terminal frame so a producer can verify its
+/// final status before reporting a successful end-of-stream.
+fn send_data_chunks_body<R: Read>(
+    stream: &mut impl Write,
+    reader: &mut R,
+    chunk_size: usize,
+    error_context: &str,
+    error_code: &'static str,
+) -> Result<(), Box<dyn std::error::Error>> {
     let mut buf = vec![0u8; chunk_size];
     loop {
         // Fill as much of the buffer as possible in one chunk.
@@ -3220,14 +3263,6 @@ fn send_data_chunks<R: Read>(
         }
 
         if pending == 0 {
-            // EOF — emit the terminator frame.
-            send_response(
-                stream,
-                &AgentResponse::DataChunk {
-                    data: vec![],
-                    done: true,
-                },
-            )?;
             return Ok(());
         }
 
@@ -3335,6 +3370,91 @@ fn handle_streaming_file_read(
         "failed to read file",
         error_codes::FILE_IO_FAILED,
     )
+}
+
+/// Stream a tar archive of a directory directly over vsock.
+///
+/// This deliberately runs in the agent namespace: boot-time staged mounts are
+/// visible there even when an image workload is active, and no temporary
+/// archive needs to traverse virtiofs or occupy the guest disk.
+fn handle_streaming_archive_directory(
+    stream: &mut impl ReadWrite,
+    path: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let normalized = match normalize_guest_path(path) {
+        Ok(path) => path,
+        Err(response) => {
+            send_response(stream, &response)?;
+            return Ok(());
+        }
+    };
+    let directory = std::path::Path::new(&normalized);
+    if !directory.is_dir() {
+        send_response(
+            stream,
+            &AgentResponse::error(
+                format!("not a directory: {path}"),
+                error_codes::FILE_IO_FAILED,
+            ),
+        )?;
+        return Ok(());
+    }
+
+    let mut child = match std::process::Command::new("tar")
+        .args(["-cf", "-", "-C"])
+        .arg(directory)
+        .arg(".")
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(error) => {
+            send_response(
+                stream,
+                &AgentResponse::error(
+                    format!("failed to start directory archive: {error}"),
+                    error_codes::FILE_IO_FAILED,
+                ),
+            )?;
+            return Ok(());
+        }
+    };
+    let mut stdout = child.stdout.take().expect("piped tar stdout");
+    let result = send_data_chunks_body(
+        stream,
+        &mut stdout,
+        smolvm_protocol::LAYER_CHUNK_SIZE,
+        "failed to read directory archive",
+        error_codes::FILE_IO_FAILED,
+    );
+    if result.is_err() {
+        let _ = child.kill();
+    }
+    result?;
+    match child.wait() {
+        Ok(status) if status.success() => send_response(
+            stream,
+            &AgentResponse::DataChunk {
+                data: Vec::new(),
+                done: true,
+            },
+        ),
+        Ok(status) => send_response(
+            stream,
+            &AgentResponse::error(
+                format!("directory archive exited with {status}"),
+                error_codes::FILE_IO_FAILED,
+            ),
+        ),
+        Err(error) => send_response(
+            stream,
+            &AgentResponse::error(
+                format!("failed to wait for directory archive: {error}"),
+                error_codes::FILE_IO_FAILED,
+            ),
+        ),
+    }
 }
 
 /// Handle an interactive run session with streaming I/O.
@@ -3622,8 +3742,6 @@ fn write_oci_bundle(
     unprivileged: bool,
     container_init: bool,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    use std::path::Path;
-
     let workdir_str = launch.workdir.as_deref().unwrap_or("/");
     let identity = oci::resolve_process_identity(rootfs_path, launch.user.as_deref())?;
     let mut spec = oci::OciSpec::new(
@@ -3658,7 +3776,7 @@ fn write_oci_bundle(
     }
 
     for (tag, container_path, read_only) in mounts {
-        let virtiofs_mount = Path::new(paths::VIRTIOFS_MOUNT_ROOT).join(tag);
+        let virtiofs_mount = storage::volume_bind_source(tag);
         spec.add_bind_mount(
             &virtiofs_mount.to_string_lossy(),
             container_path,
@@ -4870,7 +4988,7 @@ fn spawn_interactive_command(
     spec.add_gpu_devices_if_available();
 
     for (tag, container_path, read_only) in mounts {
-        let virtiofs_mount = Path::new(paths::VIRTIOFS_MOUNT_ROOT).join(tag);
+        let virtiofs_mount = storage::volume_bind_source(tag);
         spec.add_bind_mount(
             &virtiofs_mount.to_string_lossy(),
             container_path,

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -327,6 +327,35 @@ static PACKED_LAYERS_DIR: OnceLock<Option<PathBuf>> = OnceLock::new();
 /// Global state for boot-time volume mounts.
 /// Set at startup if SMOLVM_MOUNT_COUNT env var is present.
 static BOOT_VOLUME_MOUNTS: OnceLock<Vec<(String, String, bool)>> = OnceLock::new();
+static BOOT_VOLUME_MOUNTS_FAILED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Prefix used only inside the guest agent's mount table. Runtime tags are
+/// `staged+<stable-id>+<device-tag>`: the virtiofs device keeps `device-tag`,
+/// while `stable-id` prevents reordered/replaced mounts from reusing stale data.
+const STAGED_MOUNT_TAG_PREFIX: &str = "staged+";
+const STAGED_MOUNT_ROOT: &str = "/storage/staged-mounts";
+
+fn split_staged_mount_tag(tag: &str) -> (&str, Option<&str>) {
+    if let Some(rest) = tag.strip_prefix(STAGED_MOUNT_TAG_PREFIX) {
+        if let Some((working_id, device_tag)) = rest.split_once('+') {
+            return (device_tag, Some(working_id));
+        }
+    }
+    (tag, None)
+}
+
+/// Path a workload container should bind for a prepared mount.
+/// Staged mounts bind the guest-local working copy; live mounts bind the
+/// virtiofs staging directory.
+pub fn volume_bind_source(tag: &str) -> PathBuf {
+    let (device_tag, staged_id) = split_staged_mount_tag(tag);
+    if let Some(staged_id) = staged_id {
+        Path::new(STAGED_MOUNT_ROOT).join(staged_id)
+    } else {
+        Path::new(paths::VIRTIOFS_MOUNT_ROOT).join(device_tag)
+    }
+}
 
 /// Mount a virtiofs device with one policy for every host-backed filesystem:
 /// request DAX first, then fall back to the normal buffered data path when the
@@ -437,6 +466,25 @@ pub fn get_packed_layers_dir() -> Option<&'static PathBuf> {
     PACKED_LAYERS_DIR.get_or_init(init_packed_layers).as_ref()
 }
 
+/// Whether any boot-time mount needs the persistent guest storage disk.
+///
+/// Live virtiofs mounts can be initialized before `/storage` is available, but
+/// staged mounts place their working copy there and must not race the deferred
+/// storage mount.
+pub fn staged_boot_mount_requested() -> bool {
+    let count = std::env::var("SMOLVM_MOUNT_COUNT")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(0);
+    (0..count).any(|index| {
+        std::env::var(format!("SMOLVM_MOUNT_{index}")).is_ok_and(|value| value.ends_with(":staged"))
+    })
+}
+
+pub fn boot_volume_mounts_failed() -> bool {
+    BOOT_VOLUME_MOUNTS_FAILED.load(std::sync::atomic::Ordering::Acquire)
+}
+
 /// Initialize volume mounts at boot by reading SMOLVM_MOUNT_* env vars.
 ///
 /// The host launcher sets:
@@ -478,18 +526,36 @@ pub fn init_volume_mounts() -> &'static [(String, String, bool)] {
                 continue;
             }
 
+            let staged = parts[2] == "staged";
+            if staged && split_staged_mount_tag(parts[0]).1.is_none() {
+                BOOT_VOLUME_MOUNTS_FAILED.store(true, std::sync::atomic::Ordering::Release);
+                warn!(key = %env_key, "staged mount is missing its stable working-copy identity");
+                continue;
+            }
             let tag = parts[0].to_string();
             let guest_path = parts[1].to_string();
             let read_only = parts[2] == "ro";
 
-            info!(tag = %tag, guest_path = %guest_path, read_only = read_only, "boot volume mount");
+            info!(tag = %tag, guest_path = %guest_path, read_only, staged, "boot volume mount");
             mounts.push((tag, guest_path, read_only));
+        }
+
+        if mounts
+            .iter()
+            .any(|(tag, _, _)| split_staged_mount_tag(tag).1.is_some())
+        {
+            if let Err(error) = prune_staged_working_copies(&mounts) {
+                BOOT_VOLUME_MOUNTS_FAILED.store(true, std::sync::atomic::Ordering::Release);
+                warn!(error = %error, "failed to prune stale staged working copies");
+                return mounts;
+            }
         }
 
         // Mount using existing logic with empty rootfs prefix so bind mounts
         // go to absolute guest paths (e.g., "/data"), visible to VmExec.
         if !mounts.is_empty() {
             if let Err(e) = setup_volume_mounts("/", &mounts) {
+                BOOT_VOLUME_MOUNTS_FAILED.store(true, std::sync::atomic::Ordering::Release);
                 warn!(error = %e, "failed to setup boot volume mounts");
             }
         }
@@ -520,7 +586,8 @@ pub fn repair_boot_volume_mounts() -> Result<()> {
 
     for mount in &missing {
         let (tag, target, _) = mount;
-        let staging = Path::new(paths::VIRTIOFS_MOUNT_ROOT).join(tag);
+        let (device_tag, _) = split_staged_mount_tag(tag);
+        let staging = Path::new(paths::VIRTIOFS_MOUNT_ROOT).join(device_tag);
         if is_mountpoint(&staging) {
             detach_mount(&staging);
         }
@@ -531,7 +598,7 @@ pub fn repair_boot_volume_mounts() -> Result<()> {
                 tag, target
             )));
         }
-        info!(tag = %tag, target = %target, "restored boot volume mount after clone resume");
+        info!(tag = %device_tag, target = %target, "restored boot volume mount after clone resume");
     }
     Ok(())
 }
@@ -3311,7 +3378,7 @@ pub fn run_command(
             let mut spec = OciSpec::new(cmd, spec_env, workdir_str, false, &identity, unprivileged);
             spec.add_gpu_devices_if_available();
             for (tag, container_path, read_only) in mounts {
-                let virtiofs_mount = Path::new(paths::VIRTIOFS_MOUNT_ROOT).join(tag);
+                let virtiofs_mount = volume_bind_source(tag);
                 spec.add_bind_mount(
                     &virtiofs_mount.to_string_lossy(),
                     container_path,
@@ -3435,7 +3502,7 @@ pub fn spawn_in_overlay(
     let mut spec = OciSpec::new(command, env, workdir_str, false, &identity, unprivileged);
 
     for (tag, container_path, read_only) in mounts {
-        let virtiofs_mount = Path::new(paths::VIRTIOFS_MOUNT_ROOT).join(tag);
+        let virtiofs_mount = volume_bind_source(tag);
         spec.add_bind_mount(
             &virtiofs_mount.to_string_lossy(),
             container_path,
@@ -3537,12 +3604,14 @@ where
 /// Request mounts merged with the BOOT env mounts (SMOLVM_MOUNT_*): boot-time
 /// binds land in a rootfs the workload's overlay later mounts OVER, so
 /// launcher-injected mounts (e.g. the CUDA ring mount) must ride every
-/// container's own mount list. Request entries win on target collision.
+/// container's own mount list. Boot entries win on target collision because
+/// they retain the launch-time positional tag and staged/live mode; a caller
+/// rebuilding bindings from an older persisted shape may not have either.
 pub fn merged_with_boot_mounts(mounts: &[(String, String, bool)]) -> Vec<(String, String, bool)> {
-    let mut v: Vec<(String, String, bool)> = mounts.to_vec();
-    for bm in init_volume_mounts() {
-        if !v.iter().any(|(_, t, _)| t == &bm.1) {
-            v.push(bm.clone());
+    let mut v = init_volume_mounts().to_vec();
+    for mount in mounts {
+        if !v.iter().any(|(_, target, _)| target == &mount.1) {
+            v.push(mount.clone());
         }
     }
     v
@@ -3560,26 +3629,40 @@ fn setup_volume_mounts(rootfs: &str, mounts: &[(String, String, bool)]) -> Resul
     let rootfs_path = Path::new(rootfs);
 
     for (tag, container_path, read_only) in mounts {
-        validate_storage_id(tag, "mount tag")?;
-        debug!(tag = %tag, container_path = %container_path, read_only = %read_only, "setting up volume mount");
+        let (device_tag, staged_id) = split_staged_mount_tag(tag);
+        let staged = staged_id.is_some();
+        validate_storage_id(device_tag, "mount tag")?;
+        if let Some(staged_id) = staged_id {
+            validate_storage_id(staged_id, "staged mount identity")?;
+        }
+        debug!(tag = %device_tag, container_path = %container_path, read_only = %read_only, staged, "setting up volume mount");
 
         // First, mount the virtiofs device at a staging location
-        let virtiofs_mount = Path::new(paths::VIRTIOFS_MOUNT_ROOT).join(tag);
+        let virtiofs_mount = Path::new(paths::VIRTIOFS_MOUNT_ROOT).join(device_tag);
         std::fs::create_dir_all(&virtiofs_mount)?;
 
         // Check if already mounted
         if !is_mountpoint(&virtiofs_mount) {
-            info!(tag = %tag, mount_point = %virtiofs_mount.display(), "mounting virtiofs");
+            info!(tag = %device_tag, mount_point = %virtiofs_mount.display(), "mounting virtiofs");
 
-            let dax = match mount_virtiofs(tag, &virtiofs_mount) {
+            let dax = match mount_virtiofs(device_tag, &virtiofs_mount) {
                 Ok(dax) => dax,
                 Err(err) => {
-                    warn!(error = %err, tag = %tag, "failed to mount virtiofs device");
+                    warn!(error = %err, tag = %device_tag, "failed to mount virtiofs device");
+                    if staged {
+                        return Err(err.into());
+                    }
                     continue;
                 }
             };
-            info!(tag = %tag, dax, "virtiofs mount active");
+            info!(tag = %device_tag, dax, "virtiofs mount active");
         }
+
+        let bind_source = if staged {
+            ensure_staged_working_copy(staged_id.expect("checked staged id"), &virtiofs_mount)?
+        } else {
+            virtiofs_mount.clone()
+        };
 
         // Now bind-mount into the container rootfs
         let target_path = ensure_mount_target_under_root(rootfs_path, container_path)?;
@@ -3587,16 +3670,18 @@ fn setup_volume_mounts(rootfs: &str, mounts: &[(String, String, bool)]) -> Resul
         // Check if already bind-mounted
         if !is_mountpoint(&target_path) {
             info!(
-                source = %virtiofs_mount.display(),
+                source = %bind_source.display(),
                 target = %target_path.display(),
                 read_only = %read_only,
                 "bind-mounting into container"
             );
 
             // Bind mount using direct syscall
-            let bind_src = std::ffi::CString::new(virtiofs_mount.to_string_lossy().as_ref())
-                .map_err(|e| StorageError::Internal {
-                    message: format!("invalid source: {}", e),
+            let bind_src =
+                std::ffi::CString::new(bind_source.to_string_lossy().as_ref()).map_err(|e| {
+                    StorageError::Internal {
+                        message: format!("invalid source: {}", e),
+                    }
                 })?;
             let bind_dst =
                 std::ffi::CString::new(target_path.to_string_lossy().as_ref()).map_err(|e| {
@@ -3617,6 +3702,13 @@ fn setup_volume_mounts(rootfs: &str, mounts: &[(String, String, bool)]) -> Resul
             if rc != 0 {
                 let err = std::io::Error::last_os_error();
                 warn!(error = %err, target = %target_path.display(), "failed to bind-mount");
+                if staged {
+                    return Err(StorageError::new(format!(
+                        "failed to bind staged mount '{}' at '{}': {err}",
+                        device_tag,
+                        target_path.display()
+                    )));
+                }
                 continue;
             }
 
@@ -3639,6 +3731,87 @@ fn setup_volume_mounts(rootfs: &str, mounts: &[(String, String, bool)]) -> Resul
     }
 
     Ok(mounted_paths)
+}
+
+/// Materialize a host share once into the guest storage disk. The temporary
+/// directory and atomic rename mean an interrupted first boot can never leave
+/// a partially seeded working tree looking complete on the next start.
+#[cfg(target_os = "linux")]
+fn ensure_staged_working_copy(tag: &str, source: &Path) -> Result<PathBuf> {
+    use std::process::{Command, Stdio};
+
+    validate_storage_id(tag, "staged mount tag")?;
+    let root = Path::new(STAGED_MOUNT_ROOT);
+    std::fs::create_dir_all(root)?;
+    let destination = root.join(tag);
+    if destination.exists() {
+        return Ok(destination);
+    }
+
+    let temporary = root.join(format!(".{tag}.seed-{}", std::process::id()));
+    if temporary.exists() {
+        std::fs::remove_dir_all(&temporary)?;
+    }
+    std::fs::create_dir(&temporary)?;
+
+    let mut producer = Command::new("tar")
+        .args(["-cf", "-", "-C"])
+        .arg(source)
+        .arg(".")
+        .stdout(Stdio::piped())
+        .spawn()
+        .map_err(|error| StorageError::new(format!("start staged mount archive: {error}")))?;
+    let producer_stdout = producer
+        .stdout
+        .take()
+        .ok_or_else(|| StorageError::new("staged mount archive stdout was not captured"))?;
+    let consumer_status = Command::new("tar")
+        .args(["-xf", "-", "-C"])
+        .arg(&temporary)
+        .stdin(Stdio::from(producer_stdout))
+        .status()
+        .map_err(|error| StorageError::new(format!("extract staged mount archive: {error}")))?;
+    let producer_status = producer
+        .wait()
+        .map_err(|error| StorageError::new(format!("wait for staged mount archive: {error}")))?;
+    if !producer_status.success() || !consumer_status.success() {
+        let _ = std::fs::remove_dir_all(&temporary);
+        return Err(StorageError::new(format!(
+            "staged mount seed failed (archive={producer_status}, extract={consumer_status})"
+        )));
+    }
+    std::fs::rename(&temporary, &destination)?;
+    Ok(destination)
+}
+
+#[cfg(target_os = "linux")]
+pub fn prune_staged_working_copies(mounts: &[(String, String, bool)]) -> Result<()> {
+    let root = Path::new(STAGED_MOUNT_ROOT);
+    if !root.exists() {
+        return Ok(());
+    }
+    let wanted = mounts
+        .iter()
+        .filter_map(|(tag, _, _)| split_staged_mount_tag(tag).1)
+        .collect::<std::collections::HashSet<_>>();
+    for entry in std::fs::read_dir(root)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        if !wanted.contains(name.to_string_lossy().as_ref()) {
+            let metadata = entry.metadata()?;
+            if metadata.is_dir() {
+                std::fs::remove_dir_all(entry.path())?;
+            } else {
+                std::fs::remove_file(entry.path())?;
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn prune_staged_working_copies(_mounts: &[(String, String, bool)]) -> Result<()> {
+    Ok(())
 }
 
 /// Stub for non-Linux platforms.

--- a/crates/smolvm-protocol/src/lib.rs
+++ b/crates/smolvm-protocol/src/lib.rs
@@ -559,6 +559,14 @@ pub enum AgentRequest {
         path: String,
     },
 
+    /// Stream a tar archive of a guest directory without creating a guest-side
+    /// temporary file. Used by staged mounts to batch many small files across
+    /// vsock instead of paying one virtiofs round trip per file.
+    ArchiveDirectory {
+        /// Absolute directory path in the VM filesystem.
+        path: String,
+    },
+
     /// Create (without starting) a Kubernetes pod container whose rootfs is a
     /// virtiofs-shared host directory (containerd snapshotter output) and whose
     /// process definition comes from the host's OCI config. The agent builds
@@ -687,6 +695,7 @@ impl AgentRequest {
             AgentRequest::FileWriteBegin { .. } => "FileWriteBegin".into(),
             AgentRequest::FileWriteChunk { .. } => "FileWriteChunk".into(),
             AgentRequest::FileRead { .. } => "FileRead".into(),
+            AgentRequest::ArchiveDirectory { .. } => "ArchiveDirectory".into(),
             // Pod requests: spec/process JSON may carry env secrets — emit ids only.
             AgentRequest::PodCreate { id, .. } => format!("PodCreate {{ id: {id} }}"),
             AgentRequest::PodStart { id, exec_id } => match exec_id {

--- a/crates/smolvm-smolfile/src/lib.rs
+++ b/crates/smolvm-smolfile/src/lib.rs
@@ -27,7 +27,7 @@
 //! | `storage` | int | No | Storage disk size in GiB. |
 //! | `overlay` | int | No | Overlay disk size in GiB. |
 //! | `ports` | string[] | No | Port mappings (`"host:guest"` or equal-length `"host-start-host-end:guest-start-guest-end"` ranges). Prefer `[dev] ports`. |
-//! | `volumes` | string[] | No | Volume mounts (`"host:guest"`). Prefer `[dev] volumes`. |
+//! | `volumes` | string[] | No | Volume mounts (`"host:guest[:ro|rw|staged]"`). Prefer `[dev] volumes`. |
 //! | `init` | string[] | No | Commands run on every VM start. Prefer `[dev] init`. |
 //!
 //! ## Sections
@@ -38,7 +38,7 @@
 //!
 //! | Field | Type | Description |
 //! |-------|------|-------------|
-//! | `volumes` | string[] | Bind mounts (`"./src:/app"`) |
+//! | `volumes` | string[] | Mounts (`"./src:/app[:ro|rw|staged]"`) |
 //! | `env` | string[] | Dev-only environment variables |
 //! | `init` | string[] | Bootstrap commands run on start |
 //! | `workdir` | string | Dev working directory override |

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -2300,15 +2300,47 @@ impl AgentClient {
         guest_path: &str,
         local_path: &std::path::Path,
         cap: u64,
-        mut on_progress: F,
+        on_progress: F,
     ) -> Result<u64> {
-        use std::io::Write;
         const FILE_READ_TIMEOUT: Duration = Duration::from_secs(600);
 
         let _timeout_guard = self.set_extended_read_timeout(FILE_READ_TIMEOUT)?;
         self.send_raw(&AgentRequest::FileRead {
             path: guest_path.to_string(),
         })?;
+        self.receive_stream_to_path(local_path, cap, on_progress, "read file")
+    }
+
+    /// Stream a guest directory as a tar archive directly into a host file.
+    /// The archive is generated on demand and never materialized in the guest.
+    pub fn archive_directory_to_path<F: FnMut(u64)>(
+        &mut self,
+        guest_path: &str,
+        local_path: &std::path::Path,
+        on_progress: F,
+    ) -> Result<u64> {
+        const ARCHIVE_READ_TIMEOUT: Duration = Duration::from_secs(600);
+
+        let _timeout_guard = self.set_extended_read_timeout(ARCHIVE_READ_TIMEOUT)?;
+        self.send_raw(&AgentRequest::ArchiveDirectory {
+            path: guest_path.to_string(),
+        })?;
+        self.receive_stream_to_path(
+            local_path,
+            file_transfer_max_total(),
+            on_progress,
+            "archive directory",
+        )
+    }
+
+    fn receive_stream_to_path<F: FnMut(u64)>(
+        &mut self,
+        local_path: &std::path::Path,
+        cap: u64,
+        mut on_progress: F,
+        operation: &str,
+    ) -> Result<u64> {
+        use std::io::Write;
 
         let mut file = std::fs::File::create(local_path).map_err(|e| {
             Error::agent(
@@ -2325,7 +2357,7 @@ impl AgentClient {
                     if next_total > cap {
                         let _ = std::fs::remove_file(local_path);
                         return Err(Error::agent(
-                            "read file",
+                            operation,
                             format!(
                                 "guest streamed {} bytes, exceeding the {} byte cap",
                                 next_total, cap
@@ -2346,11 +2378,11 @@ impl AgentClient {
                 }
                 AgentResponse::Error { message, .. } => {
                     let _ = std::fs::remove_file(local_path);
-                    return Err(Error::agent("read file", message));
+                    return Err(Error::agent(operation, message));
                 }
                 _ => {
                     let _ = std::fs::remove_file(local_path);
-                    return Err(Error::agent("read file", "unexpected response"));
+                    return Err(Error::agent(operation, "unexpected response"));
                 }
             }
         }

--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -1508,6 +1508,12 @@ pub(crate) fn prepare_forks_reusing(
     let golden_rec = db
         .get_vm(golden)?
         .ok_or_else(|| Error::vm_not_found(golden))?;
+    if !golden_rec.staged_mounts.is_empty() {
+        return Err(Error::config(
+            "fork",
+            "staged mounts cannot be branched yet because multiple descendants would synchronize into the same host directory; use a live rw mount or remove the staged mount first",
+        ));
+    }
     let child_depth = db
         .fork_lineage_depth(golden)?
         .checked_add(1)

--- a/src/agent/fsnotify_watch.rs
+++ b/src/agent/fsnotify_watch.rs
@@ -80,6 +80,10 @@ impl FsNotifyWatcher {
             mounts
                 .iter()
                 .enumerate()
+                // A staged mount intentionally has no live host/guest
+                // coherence. Watching it would promise invalidations that the
+                // guest-local working copy cannot observe.
+                .filter(|(_, mount)| !mount.staged)
                 .map(|(i, mount)| (mount.source.clone(), HostMount::mount_tag(i))),
         )
     }

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -694,6 +694,7 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
                         source: dir,
                         target: std::path::PathBuf::from("/opt/smolvm-ring"),
                         read_only: false,
+                        staged: false,
                     });
                 }
             }
@@ -1909,14 +1910,20 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
         // Pass mount info to the agent via environment
         // Format: SMOLVM_MOUNT_0=tag:guest_path:ro
         for (i, mount) in mounts.iter().enumerate() {
-            let mount_tag = HostMount::mount_tag(i);
-            let ro_flag = if mount.read_only { "ro" } else { "rw" };
+            let mount_tag = mount.runtime_mount_tag(i);
+            let mode = if mount.staged {
+                "staged"
+            } else if mount.read_only {
+                "ro"
+            } else {
+                "rw"
+            };
             let env_val = format!(
                 "SMOLVM_MOUNT_{}={}:{}:{}",
                 i,
                 mount_tag,
                 mount.target.display(),
-                ro_flag
+                mode
             );
             if let Ok(cstr) = CString::new(env_val) {
                 env_strings.push(cstr);

--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -34,12 +34,16 @@ use super::VmResources;
 pub struct PackedMount {
     /// Virtiofs tag (e.g., "smolvm0").
     pub tag: String,
+    /// Agent/container tag, including staged working-copy identity when used.
+    pub runtime_tag: String,
     /// Host source path (passed to `krun_add_virtiofs`).
     pub host_path: String,
     /// Guest mount path (passed to agent via `SMOLVM_MOUNT_*` env).
     pub guest_path: String,
     /// Whether the mount is read-only.
     pub read_only: bool,
+    /// Whether the guest uses a local staged working copy.
+    pub staged: bool,
 }
 
 /// Configuration for launching a packed VM.
@@ -702,10 +706,16 @@ pub fn launch_agent_vm_dynamic(
 
     // Pass mount info to the agent via environment
     for (i, mount) in config.mounts.iter().enumerate() {
-        let ro_flag = if mount.read_only { "ro" } else { "rw" };
+        let mode = if mount.staged {
+            "staged"
+        } else if mount.read_only {
+            "ro"
+        } else {
+            "rw"
+        };
         let env_val = format!(
             "SMOLVM_MOUNT_{}={}:{}:{}",
-            i, mount.tag, mount.guest_path, ro_flag
+            i, mount.runtime_tag, mount.guest_path, mode
         );
         if let Ok(cstr) = CString::new(env_val) {
             env_strings.push(cstr);

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -209,6 +209,7 @@ pub fn docker_config_mount() -> Option<HostMount> {
         source: docker_dir,
         target: PathBuf::from("/root/.docker"),
         read_only: true,
+        staged: false,
     })
 }
 

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -82,14 +82,15 @@ fn record_to_info(name: &str, record: &VmRecord) -> MachineInfo {
         mem: record.mem,
         pid,
         mounts: record
-            .mounts
+            .host_mounts()
             .iter()
             .enumerate()
-            .map(|(i, (source, target, readonly))| MountInfo {
+            .map(|(i, mount)| MountInfo {
                 tag: HostMount::mount_tag(i),
-                source: source.clone(),
-                target: target.clone(),
-                readonly: *readonly,
+                source: mount.source.to_string_lossy().into_owned(),
+                target: mount.target.to_string_lossy().into_owned(),
+                readonly: mount.read_only,
+                staged: mount.staged,
             })
             .collect(),
         ports: record
@@ -313,15 +314,7 @@ pub async fn restore_portable_checkpoint(
 /// or during registry repair. Centralizes the record→entry conversion
 /// so the two branches don't drift.
 fn machine_entry_from_record(record: &VmRecord, manager: AgentManager) -> MachineEntry {
-    let mounts = record
-        .mounts
-        .iter()
-        .map(|(s, t, ro)| MountSpec {
-            source: s.clone(),
-            target: t.clone(),
-            readonly: *ro,
-        })
-        .collect();
+    let mounts = record.host_mounts().iter().map(MountSpec::from).collect();
     let ports = record
         .ports
         .iter()
@@ -2453,6 +2446,24 @@ pub async fn stop_machine(
         return Ok(Json(record_to_info(&name, &record)));
     }
 
+    // A staged mount makes its guest-local copy authoritative while the VM is
+    // running. Flush it before graceful shutdown; if synchronization fails,
+    // leave the VM alive so the caller can retry instead of silently losing
+    // the only current copy. An unreachable agent cannot be synchronized, but
+    // its persistent storage disk remains available for a later restart.
+    if !record.staged_mounts.is_empty() && resolved != RecordState::Unreachable {
+        let sync_name = name.clone();
+        let sync_record = record.clone();
+        tokio::task::spawn_blocking(move || {
+            let manager = AgentManager::for_vm(&sync_name)?;
+            let mut client = AgentClient::connect_with_retry(manager.vsock_socket())?;
+            crate::staged_mount::sync_staged_mounts(&sync_record, &mut client)
+        })
+        .await
+        .map_err(|error| ApiError::internal(format!("task error: {error}")))?
+        .map_err(|error| ApiError::internal(format!("sync staged mounts: {error}")))?;
+    }
+
     // Get PID and start time from database record - this is the source of truth
     let pid = record.pid;
     let pid_start_time = record.pid_start_time;
@@ -2525,6 +2536,52 @@ pub async fn stop_machine(
     Ok(Json(record_to_info(&name, &record)))
 }
 
+/// Synchronize guest-local staged mounts without stopping the machine.
+#[utoipa::path(
+    post,
+    path = "/api/v1/machines/{name}/sync",
+    tag = "Machines",
+    params(("name" = String, Path, description = "Machine name")),
+    responses(
+        (status = 200, description = "Staged mounts synchronized", body = MachineInfo),
+        (status = 404, description = "Machine not found", body = ApiErrorResponse),
+        (status = 409, description = "Machine is not running", body = ApiErrorResponse)
+    )
+)]
+pub async fn sync_machine(
+    State(state): State<Arc<ApiState>>,
+    Path(name): Path<String>,
+) -> Result<Json<MachineInfo>, ApiError> {
+    let lifecycle = state.lifecycle_lock(&name);
+    let _guard = lifecycle.lock().await;
+    let _source_lock = acquire_fork_source_lock(name.clone()).await?;
+    let record = state
+        .lookup_vm(&name)
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("machine '{name}' not found")))?;
+    if record.staged_mounts.is_empty() {
+        return Ok(Json(record_to_info(&name, &record)));
+    }
+    if crate::agent::state_probe::resolve_state(&name, &record) != RecordState::Running {
+        return Err(ApiError::Conflict(format!(
+            "machine '{name}' must be running to synchronize staged mounts"
+        )));
+    }
+
+    let sync_name = name.clone();
+    let sync_record = record.clone();
+    tokio::task::spawn_blocking(move || {
+        let manager = AgentManager::for_vm(&sync_name)?;
+        let mut client = AgentClient::connect_with_retry(manager.vsock_socket())?;
+        crate::staged_mount::sync_staged_mounts(&sync_record, &mut client)
+    })
+    .await
+    .map_err(|error| ApiError::internal(format!("task error: {error}")))?
+    .map_err(|error| ApiError::internal(error.to_string()))?;
+
+    Ok(Json(record_to_info(&name, &record)))
+}
+
 /// `POST /drain` — explicit, control-initiated node drain (decommission).
 ///
 /// Once serve restarts are lossless (per-VM systemd scopes + detach), drain is no
@@ -2545,11 +2602,10 @@ pub async fn drain_node(State(state): State<Arc<ApiState>>) -> axum::http::Statu
 /// the control plane can reschedule. Best-effort, concurrent, and bounded so it
 /// fits inside the host's termination grace period.
 pub async fn drain_machines(state: &Arc<ApiState>) {
-    let running: Vec<(String, Option<i32>, Option<u64>)> = match state.list_vm_records().await {
+    let running: Vec<(String, VmRecord)> = match state.list_vm_records().await {
         Ok(vms) => vms
             .into_iter()
             .filter(|(_, r)| r.actual_state() == RecordState::Running && r.is_process_alive())
-            .map(|(name, r)| (name, r.pid, r.pid_start_time))
             .collect(),
         Err(e) => {
             tracing::error!(error = ?e, "drain: failed to list machines");
@@ -2565,37 +2621,62 @@ pub async fn drain_machines(state: &Arc<ApiState>) {
     );
 
     let mut handles = Vec::with_capacity(running.len());
-    for (name, pid, pid_start_time) in running {
+    for (name, record) in running {
         let state = state.clone();
         handles.push(tokio::spawn(async move {
             let name_for_kill = name.clone();
             let entry = state.get_machine(&name).ok();
             let stopped = tokio::task::spawn_blocking(move || {
+                let _source_lock = match crate::agent::fork::lock_fork_source(&name_for_kill) {
+                    Ok(lock) => lock,
+                    Err(error) => {
+                        tracing::warn!(machine = %name_for_kill, error = %error, "drain: failed to lock machine");
+                        return false;
+                    }
+                };
+                if !record.staged_mounts.is_empty() {
+                    let sync_result = AgentManager::for_vm(&name_for_kill).and_then(|manager| {
+                        let mut client = AgentClient::connect_with_retry(manager.vsock_socket())?;
+                        crate::staged_mount::sync_staged_mounts(&record, &mut client)
+                    });
+                    if let Err(error) = sync_result {
+                        tracing::warn!(machine = %name_for_kill, error = %error, "drain: staged mount sync failed; leaving machine running");
+                        return false;
+                    }
+                }
                 // Prefer the registered manager (holds the flock); fall back to a
                 // PID-verified signal — same path as the stop handler.
                 let via_manager = entry
                     .as_ref()
                     .map(|e| e.lock().manager.stop().is_ok())
                     .unwrap_or(false);
-                via_manager || shutdown_machine_process(&name_for_kill, pid, pid_start_time, true)
+                via_manager
+                    || shutdown_machine_process(
+                        &name_for_kill,
+                        record.pid,
+                        record.pid_start_time,
+                        true,
+                    )
             })
             .await
             .unwrap_or(false);
-            if let Ok(entry) = state.get_machine(&name) {
-                entry.lock().manager.mark_stopped();
+            if stopped {
+                if let Ok(entry) = state.get_machine(&name) {
+                    entry.lock().manager.mark_stopped();
+                }
+                let _ = state
+                    .update_vm(&name, |r| {
+                        r.state = RecordState::Stopped;
+                        r.pid = None;
+                        r.pid_start_time = None;
+                        // A drain is a deliberate decommission: mark the machine
+                        // user-stopped so the restart supervisor does not resurrect it
+                        // in the window before the host is terminated (or if drain is
+                        // used standalone). An explicit start elsewhere clears this.
+                        r.restart.user_stopped = true;
+                    })
+                    .await;
             }
-            let _ = state
-                .update_vm(&name, |r| {
-                    r.state = RecordState::Stopped;
-                    r.pid = None;
-                    r.pid_start_time = None;
-                    // A drain is a deliberate decommission: mark the machine
-                    // user-stopped so the restart supervisor does not resurrect it
-                    // in the window before the host is terminated (or if drain is
-                    // used standalone). An explicit start elsewhere clears this.
-                    r.restart.user_stopped = true;
-                })
-                .await;
             tracing::info!(machine = %name, stopped, "drain: machine stopped");
         }));
     }
@@ -2696,6 +2777,32 @@ pub(crate) async fn delete_one(
                 clones.len(),
                 clones.join(", ")
             )));
+        }
+    }
+
+    // A running staged mount owns state that is newer than its host source.
+    // Flush it before delete; on failure leave both the VM and its data dir
+    // intact so the caller can repair and retry.
+    if !record.staged_mounts.is_empty() {
+        match crate::agent::state_probe::resolve_state(&name, &record) {
+            RecordState::Running => {
+                let sync_name = name.clone();
+                let sync_record = record.clone();
+                tokio::task::spawn_blocking(move || {
+                    let manager = AgentManager::for_vm(&sync_name)?;
+                    let mut client = AgentClient::connect_with_retry(manager.vsock_socket())?;
+                    crate::staged_mount::sync_staged_mounts(&sync_record, &mut client)
+                })
+                .await
+                .map_err(|error| ApiError::internal(format!("task error: {error}")))?
+                .map_err(|error| ApiError::internal(format!("sync staged mounts: {error}")))?;
+            }
+            RecordState::Unreachable => {
+                return Err(ApiError::Conflict(format!(
+                    "machine '{name}' has unsynchronized staged mounts but its agent is unreachable"
+                )));
+            }
+            _ => {}
         }
     }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -98,6 +98,7 @@ use state::ApiState;
         handlers::machines::fork_machine,
         handlers::machines::release_held_fork,
         handlers::machines::stop_machine,
+        handlers::machines::sync_machine,
         handlers::machines::delete_machine,
         handlers::machines::resize_machine,
         handlers::machines::export_machine,
@@ -282,6 +283,7 @@ pub fn create_router(state: Arc<ApiState>, cors_origins: Vec<String>) -> Router 
             post(handlers::machines::release_held_fork),
         )
         .route("/{id}/stop", post(handlers::machines::stop_machine))
+        .route("/{id}/sync", post(handlers::machines::sync_machine))
         .route("/{id}/resize", post(handlers::machines::resize_machine))
         .route("/{id}/export", post(handlers::machines::export_machine))
         .route("/{id}", delete(handlers::machines::delete_machine))

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -465,15 +465,7 @@ impl ApiState {
             }
 
             // Convert VmRecord to MachineEntry
-            let mounts: Vec<MountSpec> = record
-                .mounts
-                .iter()
-                .map(|(source, target, readonly)| MountSpec {
-                    source: source.clone(),
-                    target: target.clone(),
-                    readonly: *readonly,
-                })
-                .collect();
+            let mounts: Vec<MountSpec> = record.host_mounts().iter().map(MountSpec::from).collect();
 
             let ports: Vec<PortSpec> = record
                 .ports
@@ -949,20 +941,25 @@ impl ApiState {
         reg: MachineRegistration,
     ) -> Result<(), ApiError> {
         // Persist to database (with conflict detection)
+        let host_mounts = reg
+            .mounts
+            .iter()
+            .map(HostMount::try_from)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| ApiError::BadRequest(error.to_string()))?;
+        let (mounts, staged_mounts) = HostMount::split_storage_tuples(&host_mounts);
         let mut record = VmRecord::new_with_restart(
             name.clone(),
             reg.resources.cpus.unwrap_or(DEFAULT_MICROVM_CPU_COUNT),
             reg.resources
                 .memory_mb
                 .unwrap_or(DEFAULT_MICROVM_MEMORY_MIB),
-            reg.mounts
-                .iter()
-                .map(|m| (m.source.clone(), m.target.clone(), m.readonly))
-                .collect(),
+            mounts,
             reg.ports.iter().map(|p| (p.host, p.guest)).collect(),
             reg.network,
             reg.restart.clone(),
         );
+        record.staged_mounts = staged_mounts;
         record.storage_gb = reg.resources.storage_gb;
         record.overlay_gb = reg.resources.overlay_gb;
         // Persist egress policy + backend selection from the request (previously
@@ -1375,15 +1372,7 @@ pub async fn ensure_running_and_persist(
     // one, ensure_machine_running early-returns before the config matters.
     if let Ok(Some(record)) = state.lookup_vm(name).await {
         let mut e = entry.lock();
-        e.mounts = record
-            .mounts
-            .iter()
-            .map(|(source, target, readonly)| MountSpec {
-                source: source.clone(),
-                target: target.clone(),
-                readonly: *readonly,
-            })
-            .collect();
+        e.mounts = record.host_mounts().iter().map(MountSpec::from).collect();
         e.ports = record
             .ports
             .iter()
@@ -1522,6 +1511,12 @@ impl TryFrom<&MountSpec> for HostMount {
     /// allows relative host paths that are canonicalized against the current
     /// working directory.
     fn try_from(spec: &MountSpec) -> Result<Self, Self::Error> {
+        if spec.readonly && spec.staged {
+            return Err(crate::Error::mount(
+                "validate mount mode",
+                "a mount cannot be both readonly and staged",
+            ));
+        }
         let source = Path::new(&spec.source);
         if !source.is_absolute() {
             return Err(crate::Error::mount(
@@ -1530,7 +1525,9 @@ impl TryFrom<&MountSpec> for HostMount {
             ));
         }
 
-        HostMount::new(&spec.source, &spec.target, spec.readonly)
+        let mut mount = HostMount::new(&spec.source, &spec.target, spec.readonly)?;
+        mount.staged = spec.staged;
+        Ok(mount)
     }
 }
 
@@ -1540,6 +1537,7 @@ impl From<&HostMount> for MountSpec {
             source: mount.source.to_string_lossy().to_string(),
             target: mount.target.to_string_lossy().to_string(),
             readonly: mount.read_only,
+            staged: mount.staged,
         }
     }
 }
@@ -1667,6 +1665,7 @@ pub fn machine_entry_to_info(name: String, entry: &MachineEntry) -> MachineInfo 
                 source: m.source.clone(),
                 target: m.target.clone(),
                 readonly: m.readonly,
+                staged: m.staged,
             })
             .collect(),
         ports: entry.ports.clone(),
@@ -1749,6 +1748,7 @@ mod tests {
             source: "/tmp".into(),
             target: "/guest".into(),
             readonly: true,
+            staged: false,
         };
         assert!(HostMount::try_from(&spec).unwrap().read_only);
 
@@ -1756,6 +1756,7 @@ mod tests {
             source: "/tmp".into(),
             target: "/guest".into(),
             readonly: false,
+            staged: false,
         };
         assert!(!HostMount::try_from(&spec).unwrap().read_only);
 
@@ -1765,6 +1766,7 @@ mod tests {
             source: "/etc".into(),
             target: "/host/etc".into(),
             readonly: true,
+            staged: false,
         };
         assert!(HostMount::try_from(&system_spec).is_err());
 

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -44,6 +44,9 @@ pub struct MountSpec {
     /// Read-only mount.
     #[serde(default)]
     pub readonly: bool,
+    /// Use a guest-local working copy and synchronize it in batches.
+    #[serde(default)]
+    pub staged: bool,
 }
 
 /// Mount information (for responses, includes virtiofs tag).
@@ -60,6 +63,8 @@ pub struct MountInfo {
     pub target: String,
     /// Read-only mount.
     pub readonly: bool,
+    /// Whether this is a guest-local staged mount.
+    pub staged: bool,
 }
 
 /// Port mapping specification.

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -379,6 +379,9 @@ pub enum MachineCmd {
     /// Copy files between host and machine
     Cp(CpCmd),
 
+    /// Synchronize guest-local staged mounts back to their host directories
+    Sync(SyncCmd),
+
     /// Monitor a machine with health checks and restart policy
     Monitor(MonitorCmd),
 
@@ -428,6 +431,7 @@ impl MachineCmd {
             MachineCmd::Prune(cmd) => cmd.run(),
             MachineCmd::Shell(cmd) => cmd.run(),
             MachineCmd::Cp(cmd) => cmd.run(),
+            MachineCmd::Sync(cmd) => cmd.run(),
             MachineCmd::Monitor(cmd) => cmd.run(),
             MachineCmd::NetworkTest(cmd) => cmd.run(),
             MachineCmd::DataDir(cmd) => cmd.run(),
@@ -531,11 +535,13 @@ pub struct RunCmd {
     /// `s3://bucket/prefix:/data[:ro]` (credentials from --env
     /// AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, optional AWS_ENDPOINT_URL
     /// for R2/MinIO; anonymous without them). Nothing is required of the
-    /// image: the agent performs the mount itself.
+    /// image: the agent performs the mount itself. `:staged` runs from a
+    /// guest-local copy for metadata-heavy workloads; `machine sync` and
+    /// graceful stop copy it back, so do not modify its host source concurrently.
     #[arg(
         short = 'v',
         long = "volume",
-        value_name = "HOST|REMOTE:CONTAINER[:ro]",
+        value_name = "HOST|REMOTE:CONTAINER[:ro|rw|staged]",
         help_heading = "Container"
     )]
     pub volume: Vec<String>,
@@ -1633,6 +1639,7 @@ impl RunCmd {
                 params.mem,
                 params.net,
                 image.clone(),
+                &mounts,
             );
         }
 
@@ -1703,16 +1710,7 @@ impl RunCmd {
             // tuples the runner expects. This is a thin local conversion;
             // the runner does its own tag assignment internally so call
             // sites don't have to track which form the agent wants.
-            let record_mounts: Vec<(String, String, bool)> = mounts
-                .iter()
-                .map(|m| {
-                    (
-                        m.source.to_string_lossy().into_owned(),
-                        m.target.to_string_lossy().into_owned(),
-                        m.read_only,
-                    )
-                })
-                .collect();
+            let (record_mounts, _) = HostMount::split_storage_tuples(&mounts);
             let mut init_env = parse_env_list(&params.env);
             init_env.extend(resolved_secrets.iter().cloned());
             // Use the machine name as the overlay ID so any rootfs changes
@@ -1805,16 +1803,7 @@ impl RunCmd {
                 {
                     use smolvm::config::SmolvmConfig;
                     use vm_common::DefaultVmOverrides;
-                    let mount_tuples: Vec<(String, String, bool)> = mounts
-                        .iter()
-                        .map(|m| {
-                            (
-                                m.source.to_string_lossy().to_string(),
-                                m.target.to_string_lossy().to_string(),
-                                m.read_only,
-                            )
-                        })
-                        .collect();
+                    let (mount_tuples, staged_mounts) = HostMount::split_storage_tuples(&mounts);
                     let port_tuples: Vec<(u16, u16)> =
                         params.port.iter().map(|p| (p.host, p.guest)).collect();
                     let persist_result = SmolvmConfig::load().and_then(|mut config| {
@@ -1830,6 +1819,7 @@ impl RunCmd {
                                 cpus: params.cpus,
                                 mem: params.mem,
                                 mounts: mount_tuples,
+                                staged_mounts,
                                 ports: port_tuples,
                                 network: params.net,
                                 network_backend: params.network_backend,
@@ -1935,6 +1925,21 @@ impl RunCmd {
                     exit_code
                 };
 
+                if mounts.iter().any(|mount| mount.staged) {
+                    if let Err(error) = smolvm::staged_mount::sync_mounts(&mounts, &mut client) {
+                        // Preserve the VM and its ephemeral DB record so the
+                        // guest-local copy remains recoverable and sync can be
+                        // retried by machine name.
+                        manager.detach();
+                        return Err(Error::agent(
+                            "sync staged mounts",
+                            format!(
+                                "{error}; machine '{vm_name}' was left running so synchronization can be retried"
+                            ),
+                        ));
+                    }
+                }
+
                 // Ephemeral run — tear down VM and its data directory.
                 // Spawn a detached helper so the parent exits immediately after
                 // flushing output. Falls back to synchronous cleanup if spawn fails.
@@ -1971,16 +1976,7 @@ impl RunCmd {
                 {
                     use smolvm::config::SmolvmConfig;
                     use vm_common::DefaultVmOverrides;
-                    let mount_tuples: Vec<(String, String, bool)> = mounts
-                        .iter()
-                        .map(|m| {
-                            (
-                                m.source.to_string_lossy().to_string(),
-                                m.target.to_string_lossy().to_string(),
-                                m.read_only,
-                            )
-                        })
-                        .collect();
+                    let (mount_tuples, staged_mounts) = HostMount::split_storage_tuples(&mounts);
                     let port_tuples: Vec<(u16, u16)> =
                         params.port.iter().map(|p| (p.host, p.guest)).collect();
                     let mut config = SmolvmConfig::load()?;
@@ -1995,6 +1991,7 @@ impl RunCmd {
                             cpus: params.cpus,
                             mem: params.mem,
                             mounts: mount_tuples,
+                            staged_mounts,
                             ports: port_tuples,
                             network: params.net,
                             network_backend: params.network_backend,
@@ -2090,6 +2087,17 @@ impl RunCmd {
                     flush_output();
                     exit_code
                 };
+                if mounts.iter().any(|mount| mount.staged) {
+                    if let Err(error) = smolvm::staged_mount::sync_mounts(&mounts, &mut client) {
+                        manager.detach();
+                        return Err(Error::agent(
+                            "sync staged mounts",
+                            format!(
+                                "{error}; machine '{vm_name}' was left running so synchronization can be retried"
+                            ),
+                        ));
+                    }
+                }
                 // Ephemeral run — tear down VM and its data directory.
                 // Spawn a detached helper so the parent exits immediately after
                 // flushing output. Falls back to synchronous cleanup if spawn fails.
@@ -3101,8 +3109,14 @@ pub struct CreateCmd {
     /// `s3://bucket/prefix:/data[:ro]` (credentials from --env
     /// AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, optional AWS_ENDPOINT_URL
     /// for R2/MinIO; anonymous without them). Nothing is required of the
-    /// image: the agent performs the mount itself.
-    #[arg(short = 'v', long = "volume", value_name = "HOST|REMOTE:GUEST[:ro]")]
+    /// image: the agent performs the mount itself. `:staged` runs from a
+    /// guest-local copy for metadata-heavy workloads; `machine sync` and
+    /// graceful stop copy it back, so do not modify its host source concurrently.
+    #[arg(
+        short = 'v',
+        long = "volume",
+        value_name = "HOST|REMOTE:GUEST[:ro|rw|staged]"
+    )]
     pub volume: Vec<String>,
 
     /// Allow trusted read-only host `/etc` and `/var/log` mounts below `/host`.
@@ -4475,8 +4489,9 @@ pub struct UpdateCmd {
     #[arg(short = 'n', long, value_name = "NAME")]
     pub name: String,
 
-    /// Add volume mount (HOST:GUEST[:ro])
-    #[arg(short = 'v', long = "volume", value_name = "HOST:GUEST[:ro]")]
+    /// Add volume mount. A staged mount is guest-local until sync or graceful stop;
+    /// do not modify its host source concurrently.
+    #[arg(short = 'v', long = "volume", value_name = "HOST:GUEST[:ro|rw|staged]")]
     pub volume: Vec<String>,
 
     /// Allow adding trusted read-only host `/etc` and `/var/log` mounts below
@@ -4632,47 +4647,39 @@ impl UpdateCmd {
                 .map_err(|e| smolvm::Error::config("update", e))?;
         }
 
-        // Validate no duplicate guest mount targets after proposed changes. The
-        // merge below only skips an exact (source,target) re-add, so a new mount
-        // whose guest target collides with a DIFFERENT existing source would
-        // otherwise leave two virtiofs mounts at one guest path — the ambiguous
-        // config create-time validation rejects. Mirror the port check above by
-        // computing the final mount set exactly as the DB closure does, then
-        // rejecting duplicate targets.
-        {
-            let mut final_mounts: Vec<(String, String, bool)> = record.mounts.clone();
-            for rm in &self.remove_volume {
-                let canonical_rm = if let Some((rm_src, rm_tgt)) = rm.split_once(':') {
-                    let resolved = std::fs::canonicalize(rm_src)
-                        .unwrap_or_else(|_| std::path::PathBuf::from(rm_src));
-                    format!("{}:{}", resolved.display(), rm_tgt)
-                } else {
-                    rm.clone()
-                };
-                final_mounts.retain(|(src, tgt, _)| {
-                    let spec = format!("{}:{}", src, tgt);
-                    spec != canonical_rm && spec != *rm
-                });
-            }
-            for m in &new_mounts {
-                let tuple = m.to_storage_tuple();
-                if !final_mounts
-                    .iter()
-                    .any(|(s, t, _)| *s == tuple.0 && *t == tuple.1)
-                {
-                    final_mounts.push(tuple);
-                }
-            }
-            let mut seen = std::collections::HashSet::new();
-            for (_, tgt, _) in &final_mounts {
-                if !seen.insert(tgt.clone()) {
-                    return Err(smolvm::Error::config(
-                        "update",
-                        format!("duplicate mount target: {tgt} is specified more than once"),
-                    ));
-                }
+        // Compute the complete mount set in its rich form so changing a stopped
+        // machine cannot lose the staged/live distinction or mount order.
+        let mut final_mounts = record.host_mounts();
+        for rm in &self.remove_volume {
+            let rm_without_mode = rm
+                .strip_suffix(":ro")
+                .or_else(|| rm.strip_suffix(":rw"))
+                .or_else(|| rm.strip_suffix(":staged"))
+                .unwrap_or(rm);
+            let canonical_rm = if let Some((rm_src, rm_tgt)) = rm_without_mode.rsplit_once(':') {
+                let resolved = std::fs::canonicalize(rm_src)
+                    .unwrap_or_else(|_| std::path::PathBuf::from(rm_src));
+                Some((resolved, std::path::PathBuf::from(rm_tgt)))
+            } else {
+                None
+            };
+            final_mounts.retain(|mount| {
+                canonical_rm.as_ref().is_none_or(|(source, target)| {
+                    mount.source != *source || mount.target != *target
+                })
+            });
+        }
+        for mount in &new_mounts {
+            if !final_mounts
+                .iter()
+                .any(|current| current.source == mount.source && current.target == mount.target)
+            {
+                final_mounts.push(mount.clone());
             }
         }
+        HostMount::ensure_unique_targets(&final_mounts)?;
+        let (final_live_mounts, final_staged_mounts) =
+            HostMount::split_storage_tuples(&final_mounts);
 
         // Expand physical disk files before the DB write. If expansion fails,
         // no DB changes are made — the record stays consistent.
@@ -4692,41 +4699,27 @@ impl UpdateCmd {
             if let Some(o) = self.overlay {
                 r.overlay_gb = Some(o);
             }
-            // Volumes: add new, remove specified.
-            // Canonicalize the remove spec's source path so ./src matches
-            // the stored /absolute/path/to/src.
-            for rm in &self.remove_volume {
-                let canonical_rm = if let Some((rm_src, rm_tgt)) = rm.split_once(':') {
-                    let resolved = std::fs::canonicalize(rm_src)
-                        .unwrap_or_else(|_| std::path::PathBuf::from(rm_src));
-                    format!("{}:{}", resolved.display(), rm_tgt)
-                } else {
-                    rm.clone()
-                };
-                let before = r.mounts.len();
-                r.mounts.retain(|(src, tgt, _)| {
-                    let spec = format!("{}:{}", src, tgt);
-                    spec != canonical_rm && spec != *rm
-                });
-                if r.mounts.len() < before {
-                    changes.push(format!("  removed volume: {}", rm));
+            if !self.remove_volume.is_empty() || !new_mounts.is_empty() {
+                for rm in &self.remove_volume {
+                    changes.push(format!("  removed volume: {rm}"));
                 }
-            }
-            for m in &new_mounts {
-                let tuple = m.to_storage_tuple();
-                if !r
-                    .mounts
-                    .iter()
-                    .any(|(s, t, _)| *s == tuple.0 && *t == tuple.1)
-                {
+                for mount in &new_mounts {
+                    let mode = if mount.staged {
+                        ":staged"
+                    } else if mount.read_only {
+                        ":ro"
+                    } else {
+                        ""
+                    };
                     changes.push(format!(
                         "  added volume: {}:{}{}",
-                        tuple.0,
-                        tuple.1,
-                        if tuple.2 { ":ro" } else { "" }
+                        mount.source.display(),
+                        mount.target.display(),
+                        mode
                     ));
-                    r.mounts.push(tuple);
                 }
+                r.mounts = final_live_mounts.clone();
+                r.staged_mounts = final_staged_mounts.clone();
             }
 
             // Ports: add new, remove specified
@@ -5289,6 +5282,41 @@ impl CpCmd {
             bar.finish(size);
         }
 
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Sync Command
+// ============================================================================
+
+/// Synchronize staged mounts from a running machine to their host sources.
+#[derive(Args, Debug)]
+pub struct SyncCmd {
+    /// Machine to synchronize (default: "default")
+    #[arg(short = 'n', long, value_name = "NAME")]
+    pub name: Option<String>,
+}
+
+impl SyncCmd {
+    pub fn run(self) -> smolvm::Result<()> {
+        let name = self.name.unwrap_or_else(|| "default".to_string());
+        let db = smolvm::db::SmolvmDb::open()?;
+        let record = db
+            .get_vm(&name)?
+            .ok_or_else(|| smolvm::Error::vm_not_found(&name))?;
+        if record.staged_mounts.is_empty() {
+            println!("Machine '{name}' has no staged mounts");
+            return Ok(());
+        }
+
+        let _source_lock = smolvm::agent::fork::lock_fork_source(&name)?;
+        let (manager, mut client) = vm_common::ensure_running_and_connect(&Some(name.clone()))?;
+        // This command observes an existing persistent VM; a failed sync must
+        // leave it running so the user can fix the cause and retry.
+        manager.detach();
+        smolvm::staged_mount::sync_staged_mounts(&record, &mut client)?;
+        println!("Synchronized staged mounts for '{name}'");
         Ok(())
     }
 }

--- a/src/cli/pack_run.rs
+++ b/src/cli/pack_run.rs
@@ -148,9 +148,11 @@ fn mounts_to_packed(mounts: &[smolvm::data::storage::HostMount]) -> Vec<PackedMo
         .enumerate()
         .map(|(i, m)| PackedMount {
             tag: HostMount::mount_tag(i),
+            runtime_tag: m.runtime_mount_tag(i),
             host_path: m.source.to_string_lossy().to_string(),
             guest_path: m.target.to_string_lossy().to_string(),
             read_only: m.read_only,
+            staged: m.staged,
         })
         .collect()
 }
@@ -589,6 +591,7 @@ impl PackRunCmd {
                     config
                         .mounts
                         .iter()
+                        .filter(|mount| !mount.staged)
                         .map(|mount| (PathBuf::from(&mount.host_path), mount.tag.clone())),
                 );
 
@@ -1223,8 +1226,8 @@ struct PackedRunArgs {
     #[arg(short = 'e', long = "env", value_name = "KEY=VALUE")]
     env: Vec<String>,
 
-    /// Mount a volume (HOST:GUEST[:ro])
-    #[arg(short = 'v', long = "volume", value_name = "HOST:GUEST[:ro]")]
+    /// Mount a volume (HOST:GUEST[:ro|rw|staged])
+    #[arg(short = 'v', long = "volume", value_name = "HOST:GUEST[:ro|rw|staged]")]
     volume: Vec<String>,
 
     /// Allow trusted read-only host `/etc` and `/var/log` mounts below `/host`.
@@ -1284,8 +1287,8 @@ struct PackedStartArgs {
     #[arg(long, value_name = "GiB")]
     overlay: Option<u64>,
 
-    /// Mount a volume (HOST:GUEST[:ro])
-    #[arg(short = 'v', long = "volume", value_name = "HOST:GUEST[:ro]")]
+    /// Mount a volume (HOST:GUEST[:ro|rw|staged])
+    #[arg(short = 'v', long = "volume", value_name = "HOST:GUEST[:ro|rw|staged]")]
     volume: Vec<String>,
 
     /// Allow trusted read-only host `/etc` and `/var/log` mounts below `/host`.
@@ -1642,6 +1645,7 @@ fn run_from_cache(
             config
                 .mounts
                 .iter()
+                .filter(|mount| !mount.staged)
                 .map(|mount| (PathBuf::from(&mount.host_path), mount.tag.clone())),
         );
 
@@ -2089,6 +2093,7 @@ fn daemon_start(
             config
                 .mounts
                 .iter()
+                .filter(|mount| !mount.staged)
                 .map(|mount| (PathBuf::from(&mount.host_path), mount.tag.clone())),
         );
 

--- a/src/cli/parsers.rs
+++ b/src/cli/parsers.rs
@@ -59,14 +59,20 @@ pub use smolvm::util::{parse_env_list, parse_env_spec};
 /// thin wrappers below ([`mounts_to_virtiofs_bindings`] and
 /// [`record_mounts_to_runconfig_bindings`]) preserve the caller-side
 /// ergonomics.
-fn assign_virtiofs_tags<I>(items: I) -> Vec<(String, String, bool)>
+fn assign_virtiofs_tags<'a, I>(items: I) -> Vec<(String, String, bool)>
 where
-    I: IntoIterator<Item = (String, bool)>,
+    I: IntoIterator<Item = &'a HostMount>,
 {
     items
         .into_iter()
         .enumerate()
-        .map(|(i, (target, ro))| (HostMount::mount_tag(i), target, ro))
+        .map(|(i, mount)| {
+            (
+                mount.runtime_mount_tag(i),
+                mount.target.to_string_lossy().into_owned(),
+                mount.read_only,
+            )
+        })
         .collect()
 }
 
@@ -75,11 +81,7 @@ where
 /// Used by `machine run` paths that already hold the validated, parsed
 /// mount type. See [`assign_virtiofs_tags`] for the tag rule.
 pub fn mounts_to_virtiofs_bindings(mounts: &[HostMount]) -> Vec<(String, String, bool)> {
-    assign_virtiofs_tags(
-        mounts
-            .iter()
-            .map(|m| (m.target.to_string_lossy().into_owned(), m.read_only)),
-    )
+    assign_virtiofs_tags(mounts.iter())
 }
 
 /// Convert a `VmRecord`-style mount list to virtiofs binding format.
@@ -91,11 +93,13 @@ pub fn mounts_to_virtiofs_bindings(mounts: &[HostMount]) -> Vec<(String, String,
 pub fn record_mounts_to_runconfig_bindings(
     mounts: &[(String, String, bool)],
 ) -> Vec<(String, String, bool)> {
-    assign_virtiofs_tags(
-        mounts
-            .iter()
-            .map(|(_host, target, ro)| (target.clone(), *ro)),
-    )
+    let host_mounts = mounts
+        .iter()
+        .map(|(source, target, read_only)| {
+            HostMount::from_storage_tuple(source.clone(), target.clone(), *read_only)
+        })
+        .collect::<Vec<_>>();
+    assign_virtiofs_tags(host_mounts.iter())
 }
 
 // Network helpers delegated to the library.
@@ -212,11 +216,12 @@ mod tests {
         // around this — pin the indexing rule here so neither wrapper
         // can drift away from the canonical "smolvm{i}" naming or from
         // preserving caller order.
-        let out = assign_virtiofs_tags(vec![
-            ("/a".to_string(), false),
-            ("/b".to_string(), true),
-            ("/c".to_string(), false),
-        ]);
+        let mounts = [
+            HostMount::from_storage_tuple("/tmp".into(), "/a".into(), false),
+            HostMount::from_storage_tuple("/tmp".into(), "/b".into(), true),
+            HostMount::from_storage_tuple("/tmp".into(), "/c".into(), false),
+        ];
+        let out = assign_virtiofs_tags(mounts.iter());
         assert_eq!(
             out,
             vec![
@@ -238,11 +243,38 @@ mod tests {
             source: PathBuf::from("/tmp"), // any existing dir; not validated by the converter
             target: PathBuf::from("/app"),
             read_only: true,
+            staged: false,
         };
         let from_parsed = mounts_to_virtiofs_bindings(&[host_mount]);
         let from_record =
             record_mounts_to_runconfig_bindings(&[("/tmp".to_string(), "/app".to_string(), true)]);
         assert_eq!(from_parsed, from_record);
+    }
+
+    #[test]
+    fn staged_binding_keeps_device_index_and_marks_guest_local_mode() {
+        use std::path::PathBuf;
+        let mounts = vec![
+            HostMount {
+                source: PathBuf::from("/tmp"),
+                target: PathBuf::from("/live"),
+                read_only: false,
+                staged: false,
+            },
+            HostMount {
+                source: PathBuf::from("/tmp"),
+                target: PathBuf::from("/staged"),
+                read_only: false,
+                staged: true,
+            },
+        ];
+        assert_eq!(
+            mounts_to_virtiofs_bindings(&mounts),
+            vec![
+                ("smolvm0".into(), "/live".into(), false),
+                (mounts[1].runtime_mount_tag(1), "/staged".into(), false),
+            ]
+        );
     }
 
     #[test]

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -28,6 +28,7 @@ API ENDPOINTS:
   POST   /api/v1/machines/:id/start   Start machine
   POST   /api/v1/machines/:id/branches Create a copy-on-write child
   POST   /api/v1/machines/:id/checkpoint Capture a durable checkpoint
+  POST   /api/v1/machines/:id/sync    Synchronize staged mounts
   POST   /api/v1/machines/:id/stop    Stop machine
   POST   /api/v1/machines/:id/exec    Execute command
   DELETE /api/v1/machines/:id         Delete machine

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -606,13 +606,15 @@ pub(crate) fn build_vm_record(params: &CreateVmParams) -> smolvm::Result<VmRecor
     let (host_volume_specs, remote_volumes) = smolvm::remote_volume::split_specs(&params.volume)?;
 
     // Parse and validate volume mounts
-    let mounts: Vec<(String, String, bool)> =
-        HostMount::parse_with_system_mounts(&host_volume_specs, params.allow_system_mounts)?
-            .into_iter()
-            .map(|m| m.to_storage_tuple())
-            .collect();
+    let parsed_mounts =
+        HostMount::parse_with_system_mounts(&host_volume_specs, params.allow_system_mounts)?;
+    let (mounts, staged_mounts) = HostMount::split_storage_tuples(&parsed_mounts);
     for volume in &remote_volumes {
-        if mounts.iter().any(|(_, target, _)| target == &volume.target) {
+        if mounts.iter().any(|(_, target, _)| target == &volume.target)
+            || staged_mounts
+                .iter()
+                .any(|(_, _, target)| target == &volume.target)
+        {
             return Err(smolvm::Error::config(
                 "create machine",
                 format!(
@@ -683,6 +685,7 @@ pub(crate) fn build_vm_record(params: &CreateVmParams) -> smolvm::Result<VmRecor
         params.net,
         restart,
     );
+    record.staged_mounts = staged_mounts;
     record.init = params.init.clone();
     record.remote_volumes = remote_volumes;
     record.env = env;
@@ -1806,6 +1809,7 @@ pub fn persist_named_running(
                 r.cpus = o.cpus;
                 r.mem = o.mem;
                 r.mounts = o.mounts.clone();
+                r.staged_mounts = o.staged_mounts.clone();
                 r.ports = o.ports.clone();
                 r.network = o.network;
                 r.network_backend = o.network_backend;
@@ -1847,6 +1851,7 @@ pub struct DefaultVmOverrides {
     pub cpus: u8,
     pub mem: u32,
     pub mounts: Vec<(String, String, bool)>,
+    pub staged_mounts: Vec<(usize, String, String)>,
     pub ports: Vec<(u16, u16)>,
     pub network: bool,
     pub network_backend: Option<NetworkBackend>,
@@ -2097,6 +2102,10 @@ pub fn stop_vm_named(name: &str) -> smolvm::Result<()> {
 
     let manager = AgentManager::for_vm(name)
         .map_err(|e| smolvm::Error::agent("create agent manager", e.to_string()))?;
+    if !record.staged_mounts.is_empty() {
+        let mut client = smolvm::agent::AgentClient::connect_with_retry(manager.vsock_socket())?;
+        smolvm::staged_mount::sync_staged_mounts(&record, &mut client)?;
+    }
     manager.stop()?;
 
     // Detach the machine's case-sensitive layers volume now that its process is
@@ -2174,10 +2183,21 @@ fn kill_orphaned_boot_process(name: &str) {
 pub fn stop_vm_default() -> smolvm::Result<()> {
     let manager = AgentManager::new_default()?;
 
+    let record = SmolvmConfig::load()
+        .ok()
+        .and_then(|config| config.get_vm("default").cloned());
+
     // try_connect_existing sets internal state if agent is reachable;
     // stop() handles both responsive agents and orphans via PID file.
     manager.try_connect_existing();
     println!("Stopping machine 'default'...");
+    if let Some(record) = record
+        .as_ref()
+        .filter(|record| !record.staged_mounts.is_empty())
+    {
+        let mut client = smolvm::agent::AgentClient::connect_with_retry(manager.vsock_socket())?;
+        smolvm::staged_mount::sync_staged_mounts(record, &mut client)?;
+    }
     manager.stop()?;
 
     // Update database record if it exists
@@ -2405,6 +2425,11 @@ pub fn delete_vm(name: &str, force: bool, options: DeleteVmOptions) -> smolvm::R
             RecordState::Running => {
                 let manager = AgentManager::for_vm(name)?;
                 println!("Stopping machine '{}'...", name);
+                if !record.staged_mounts.is_empty() {
+                    let mut client =
+                        smolvm::agent::AgentClient::connect_with_retry(manager.vsock_socket())?;
+                    smolvm::staged_mount::sync_staged_mounts(&record, &mut client)?;
+                }
                 manager.stop()?;
                 if record.pid.is_some_and(smolvm::process::is_alive) {
                     return Err(smolvm::Error::agent(
@@ -2575,7 +2600,7 @@ fn machine_status_json(name: &str, record: &VmRecord) -> serde_json::Value {
         "cpus": record.cpus,
         "memory_mib": record.mem,
         "pid": record.pid,
-        "mounts": record.mounts.len(),
+        "mounts": record.mounts.len() + record.staged_mounts.len(),
         "ports": record.ports.len(),
         "created_at": record.created_at,
         "storage_gb": record.storage_gb,
@@ -2683,7 +2708,7 @@ pub fn list_vms(verbose: bool, json: bool) -> smolvm::Result<()> {
                 state_display,
                 record.cpus,
                 format!("{} MiB", record.mem),
-                record.mounts.len(),
+                record.mounts.len() + record.staged_mounts.len(),
                 record.ports.len(),
                 format!("{} GiB", storage_gb),
                 format!("{} GiB", overlay_gb),
@@ -2907,8 +2932,11 @@ pub fn register_ephemeral_vm(
     mem: u32,
     network: bool,
     image: Option<String>,
+    mounts: &[HostMount],
 ) {
-    let mut record = VmRecord::new(name.to_string(), cpus, mem, vec![], vec![], network);
+    let (live_mounts, staged_mounts) = HostMount::split_storage_tuples(mounts);
+    let mut record = VmRecord::new(name.to_string(), cpus, mem, live_mounts, vec![], network);
+    record.staged_mounts = staged_mounts;
     record.ephemeral = true;
     record.state = RecordState::Running;
     record.pid = pid;

--- a/src/config.rs
+++ b/src/config.rs
@@ -394,6 +394,13 @@ pub struct VmRecord {
     #[serde(default)]
     pub mounts: Vec<(String, String, bool)>,
 
+    /// Guest-local working trees synchronized with host directories in
+    /// batches. Kept separate from `mounts` so existing records retain their
+    /// tuple encoding and cannot accidentally reinterpret a staged mount as a
+    /// live writable virtiofs mount.
+    #[serde(default)]
+    pub staged_mounts: Vec<(usize, String, String)>,
+
     /// Port mappings (host_port, guest_port).
     #[serde(default)]
     pub ports: Vec<(u16, u16)>,
@@ -675,6 +682,7 @@ impl VmRecord {
             cpus,
             mem,
             mounts,
+            staged_mounts: Vec::new(),
             ports,
             published_sockets: Vec::new(),
             network,
@@ -743,6 +751,7 @@ impl VmRecord {
             cpus,
             mem,
             mounts,
+            staged_mounts: Vec::new(),
             ports,
             published_sockets: Vec::new(),
             network,
@@ -819,14 +828,42 @@ impl VmRecord {
 
     /// Convert stored mounts to HostMount format.
     pub fn host_mounts(&self) -> Vec<crate::data::storage::HostMount> {
-        self.mounts
+        let mut live = self
+            .mounts
             .iter()
             .map(|(host, guest, ro)| crate::data::storage::HostMount {
                 source: std::path::PathBuf::from(host),
                 target: std::path::PathBuf::from(guest),
                 read_only: *ro,
+                staged: false,
             })
-            .collect()
+            .collect::<std::collections::VecDeque<_>>();
+        let staged = self
+            .staged_mounts
+            .iter()
+            .map(|(index, host, guest)| {
+                (
+                    *index,
+                    crate::data::storage::HostMount::from_staged_storage_tuple(
+                        host.clone(),
+                        guest.clone(),
+                    ),
+                )
+            })
+            .collect::<std::collections::BTreeMap<_, _>>();
+        let total = live.len() + staged.len();
+        let mut mounts = Vec::with_capacity(total);
+        for index in 0..total {
+            if let Some(mount) = staged.get(&index) {
+                mounts.push(mount.clone());
+            } else if let Some(mount) = live.pop_front() {
+                mounts.push(mount);
+            }
+        }
+        // Malformed records with duplicate/out-of-range staged indices remain
+        // inspectable rather than silently dropping their live mounts.
+        mounts.extend(live);
+        mounts
     }
 
     /// Convert stored ports to PortMapping format.

--- a/src/data/storage.rs
+++ b/src/data/storage.rs
@@ -1,5 +1,6 @@
 use crate::data::error::{Error, Result};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 
 /// Default size for the rootfs overlay disk (10 GiB sparse).
@@ -18,6 +19,12 @@ pub const OVERLAY_DISK_FILENAME: &str = "overlay.raw";
 /// Storage disk filename.
 pub const STORAGE_DISK_FILENAME: &str = "storage.raw";
 
+/// Persisted live-mount tuple: host source, guest target, read-only flag.
+pub type StoredHostMount = (String, String, bool);
+
+/// Persisted staged-mount tuple: original position, host source, guest target.
+pub type StoredStagedMount = (usize, String, String);
+
 /// Host directory mount.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct HostMount {
@@ -29,6 +36,13 @@ pub struct HostMount {
 
     /// Read-only mount (default: true per DESIGN.md).
     pub read_only: bool,
+
+    /// Keep the working copy on the guest storage disk and synchronize it in
+    /// batches instead of forwarding every filesystem operation over
+    /// virtiofs. Staged mounts are writable and deliberately trade live
+    /// host/guest coherence for metadata-heavy workload performance.
+    #[serde(default)]
+    pub staged: bool,
 }
 
 impl HostMount {
@@ -102,6 +116,7 @@ impl HostMount {
             source: source.into(),
             target: target.into(),
             read_only,
+            staged: false,
         };
 
         if !mount.source.exists() {
@@ -143,17 +158,21 @@ impl HostMount {
         // colon (e.g. `C:\data:/data:ro`). The guest path is a Unix path with no
         // colon, and the optional trailing mode is `ro`/`rw`; everything before
         // the guest path is the host source.
-        let (rest, read_only) = match spec.rsplit_once(':') {
-            Some((head, "ro")) => (head, true),
-            Some((head, "rw")) => (head, false),
-            _ => (spec, false),
+        let (rest, read_only, staged) = match spec.rsplit_once(':') {
+            Some((head, "ro")) => (head, true, false),
+            Some((head, "rw")) => (head, false, false),
+            Some((head, "staged")) => (head, false, true),
+            _ => (spec, false, false),
         };
         match rest.rsplit_once(':') {
             Some((source, target)) if !source.is_empty() && !target.is_empty() => {
-                Self::new_with_system_mounts(source, target, read_only, allow_system_mounts)
+                let mut mount =
+                    Self::new_with_system_mounts(source, target, read_only, allow_system_mounts)?;
+                mount.staged = staged;
+                Ok(mount)
             }
             _ => Err(Error::invalid_mount_path(format!(
-                "invalid format '{}' (expected host:guest[:ro|:rw])",
+                "invalid format '{}' (expected host:guest[:ro|:rw|:staged])",
                 spec
             ))),
         }
@@ -301,6 +320,23 @@ impl HostMount {
         format!("smolvm{}", index)
     }
 
+    /// Tag carried in agent/container mount metadata. Live mounts use their
+    /// virtiofs device tag directly; staged mounts add a stable identity so a
+    /// reordered or replaced mount can never reuse another source's guest-local
+    /// working copy.
+    pub fn runtime_mount_tag(&self, index: usize) -> String {
+        let device_tag = Self::mount_tag(index);
+        if !self.staged {
+            return device_tag;
+        }
+        let mut hasher = Sha256::new();
+        hasher.update(self.source.as_os_str().as_encoded_bytes());
+        hasher.update([0]);
+        hasher.update(self.target.as_os_str().as_encoded_bytes());
+        let digest = hex::encode(hasher.finalize());
+        format!("staged+{}+{}", &digest[..16], device_tag)
+    }
+
     /// Create without validation (for loading from database).
     ///
     /// Use this only when loading persisted mounts that were previously validated.
@@ -309,6 +345,17 @@ impl HostMount {
             source: PathBuf::from(source),
             target: PathBuf::from(target),
             read_only,
+            staged: false,
+        }
+    }
+
+    /// Create a staged mount from its persisted representation.
+    pub fn from_staged_storage_tuple(source: String, target: String) -> Self {
+        Self {
+            source: PathBuf::from(source),
+            target: PathBuf::from(target),
+            read_only: false,
+            staged: true,
         }
     }
 
@@ -319,6 +366,30 @@ impl HostMount {
             self.target.to_string_lossy().to_string(),
             self.read_only,
         )
+    }
+
+    /// Convert this staged mount to its compact persistence representation.
+    pub fn to_staged_storage_tuple(&self) -> (String, String) {
+        (
+            self.source.to_string_lossy().to_string(),
+            self.target.to_string_lossy().to_string(),
+        )
+    }
+
+    /// Split validated mounts into their backward-compatible live-mount tuples
+    /// and staged-mount tuples for [`crate::config::VmRecord`].
+    pub fn split_storage_tuples(mounts: &[Self]) -> (Vec<StoredHostMount>, Vec<StoredStagedMount>) {
+        let mut live = Vec::new();
+        let mut staged = Vec::new();
+        for (index, mount) in mounts.iter().enumerate() {
+            if mount.staged {
+                let (source, target) = mount.to_staged_storage_tuple();
+                staged.push((index, source, target));
+            } else {
+                live.push(mount.to_storage_tuple());
+            }
+        }
+        (live, staged)
     }
 }
 
@@ -345,6 +416,28 @@ mod tests {
         );
         // Distinct targets are fine.
         assert!(HostMount::parse(&[format!("{a}:/app"), format!("{b}:/data")]).is_ok());
+    }
+
+    #[test]
+    fn parse_staged_mount_is_writable_and_persists_separately() {
+        let source = std::env::temp_dir().join("smolvm_staged_parse");
+        std::fs::create_dir_all(&source).unwrap();
+        let mounts =
+            HostMount::parse(&[format!("{}:/workspace:staged", source.display())]).unwrap();
+        assert_eq!(mounts.len(), 1);
+        assert!(mounts[0].staged);
+        assert!(!mounts[0].read_only);
+
+        let (live, staged) = HostMount::split_storage_tuples(&mounts);
+        assert!(live.is_empty());
+        assert_eq!(
+            staged,
+            vec![(
+                0,
+                source.canonicalize().unwrap().display().to_string(),
+                "/workspace".into()
+            )]
+        );
     }
 
     #[test]
@@ -473,6 +566,7 @@ mod tests {
                 source: PathBuf::from(path),
                 target: PathBuf::from("/guest/path"),
                 read_only: true,
+                staged: false,
             };
             let err = HostMount::validate(&mount).unwrap_err().to_string();
             assert!(
@@ -503,6 +597,25 @@ mod tests {
         assert_eq!(mount.source, PathBuf::from("/tmp").canonicalize().unwrap());
         assert_eq!(mount.target, PathBuf::from("/guest/path"));
         assert!(!mount.read_only);
+    }
+
+    #[test]
+    fn staged_runtime_tag_is_stable_across_device_reordering_and_unique_by_source() {
+        let first = HostMount::from_staged_storage_tuple("/tmp/a".into(), "/workspace".into());
+        let second = HostMount::from_staged_storage_tuple("/tmp/b".into(), "/workspace".into());
+        let first_at_zero = first.runtime_mount_tag(0);
+        let first_at_three = first.runtime_mount_tag(3);
+        assert!(first_at_zero.starts_with("staged+"));
+        assert_eq!(
+            first_at_zero.split('+').nth(1),
+            first_at_three.split('+').nth(1)
+        );
+        assert_ne!(
+            first_at_zero.split('+').nth(1),
+            second.runtime_mount_tag(0).split('+').nth(1)
+        );
+        assert!(first_at_zero.ends_with("+smolvm0"));
+        assert!(first_at_three.ends_with("+smolvm3"));
     }
 
     #[test]

--- a/src/embedded/control.rs
+++ b/src/embedded/control.rs
@@ -563,6 +563,10 @@ pub fn stop_vm(db: &SmolvmDb, name: &str) -> Result<()> {
     let manager = AgentManager::for_vm_with_sizes(name, record.storage_gb, record.overlay_gb)
         .map_err(|e| Error::agent("create agent manager", e.to_string()))?;
     manager.try_connect_existing();
+    if !record.staged_mounts.is_empty() {
+        let mut client = AgentClient::connect_with_retry(manager.vsock_socket())?;
+        crate::staged_mount::sync_staged_mounts(&record, &mut client)?;
+    }
     manager.stop()?;
     // Detach the per-machine layers volume if a (possibly cross-tool) bundle start
     // left it mounted. Unconditional on purpose: the embedded record may carry no

--- a/src/embedded/control.rs
+++ b/src/embedded/control.rs
@@ -62,17 +62,16 @@ pub struct MachineSpec {
 impl MachineSpec {
     /// Convert the embedded-machine spec into the canonical DB record.
     pub fn to_record(&self) -> VmRecord {
+        let (mounts, staged_mounts) = HostMount::split_storage_tuples(&self.mounts);
         let mut record = VmRecord::new(
             self.name.clone(),
             self.resources.cpus,
             self.resources.memory_mib,
-            self.mounts
-                .iter()
-                .map(HostMount::to_storage_tuple)
-                .collect(),
+            mounts,
             self.ports.iter().map(PortMapping::to_tuple).collect(),
             self.resources.network,
         );
+        record.staged_mounts = staged_mounts;
         record.storage_gb = self.resources.storage_gib;
         record.overlay_gb = self.resources.overlay_gib;
         record.allowed_cidrs = self.resources.allowed_cidrs.clone();

--- a/src/embedded/handle.rs
+++ b/src/embedded/handle.rs
@@ -154,6 +154,11 @@ impl VmHandle {
         self.client_mut()?.run_streaming_with(config, on_event)
     }
 
+    /// Copy every guest-local staged mount back to its host source.
+    pub fn sync_staged_mounts(&mut self, record: &crate::config::VmRecord) -> Result<()> {
+        crate::staged_mount::sync_staged_mounts(record, self.client_mut()?)
+    }
+
     /// Stop the VM and drop the cached agent client.
     pub fn stop(&mut self) -> Result<()> {
         self.client = None;

--- a/src/embedded/runtime.rs
+++ b/src/embedded/runtime.rs
@@ -451,6 +451,13 @@ impl EmbeddedRuntime {
                 // response that cannot arrive.
                 self.remove_cached_handle(name)?;
                 crate::agent::state_probe::recover_unreachable_machine_in_db(&record, &self.db)?;
+            } else if matches!(
+                state,
+                crate::config::RecordState::Stopped | crate::config::RecordState::Created
+            ) {
+                // A graceful stop already synchronized staged mounts. Do not
+                // reconnect to the now-absent agent and fail a subsequent delete.
+                self.remove_cached_handle(name)?;
             } else if let Some(handle) = self.remove_cached_handle(name)? {
                 let mut handle = lock_handle(&handle)?;
                 if !record.staged_mounts.is_empty() {
@@ -1073,6 +1080,19 @@ mod tests {
             .read()
             .expect("name locks should not be poisoned")
             .contains_key("runtime-delete-lock"));
+    }
+
+    #[test]
+    fn delete_already_stopped_staged_machine_does_not_reconnect() {
+        let db = test_db();
+        let runtime = EmbeddedRuntime::with_db(db.clone());
+        let mut record = test_spec("delete-stopped-staged", true).to_record();
+        record.state = crate::config::RecordState::Stopped;
+        record.staged_mounts = vec![(0, "/host/work".into(), "/work".into())];
+        db.insert_vm("delete-stopped-staged", &record).unwrap();
+
+        runtime.delete_machine("delete-stopped-staged").unwrap();
+        assert!(db.get_vm("delete-stopped-staged").unwrap().is_none());
     }
 
     #[test]

--- a/src/embedded/runtime.rs
+++ b/src/embedded/runtime.rs
@@ -393,6 +393,7 @@ impl EmbeddedRuntime {
     pub fn stop_machine(&self, name: &str) -> Result<()> {
         self.with_name_lock(name, || {
             let _source_lock = crate::agent::fork::lock_fork_source(name)?;
+            let record = control::get_record(&self.db, name)?;
             let dependents = self.db.dependent_clones(name)?;
             if !dependents.is_empty() {
                 return Err(Error::agent(
@@ -404,7 +405,11 @@ impl EmbeddedRuntime {
                 ));
             }
             if let Some(handle) = self.remove_cached_handle(name)? {
-                lock_handle(&handle)?.stop()?;
+                let mut handle = lock_handle(&handle)?;
+                if !record.staged_mounts.is_empty() {
+                    handle.sync_staged_mounts(&record)?;
+                }
+                handle.stop()?;
                 control::mark_stopped(&self.db, name)?;
                 return Ok(());
             }
@@ -447,9 +452,13 @@ impl EmbeddedRuntime {
                 self.remove_cached_handle(name)?;
                 crate::agent::state_probe::recover_unreachable_machine_in_db(&record, &self.db)?;
             } else if let Some(handle) = self.remove_cached_handle(name)? {
-                let _ = lock_handle(&handle)?.stop();
+                let mut handle = lock_handle(&handle)?;
+                if !record.staged_mounts.is_empty() {
+                    handle.sync_staged_mounts(&record)?;
+                }
+                handle.stop()?;
             } else {
-                let _ = control::stop_vm(&self.db, name);
+                control::stop_vm(&self.db, name)?;
             }
 
             // Idempotent: deleting an already-deleted machine is a no-op success
@@ -461,6 +470,21 @@ impl EmbeddedRuntime {
             }
             self.remove_name_lock(name)?;
             Ok(())
+        })
+    }
+
+    /// Copy guest-local staged mounts back to their host sources without
+    /// stopping the machine.
+    pub fn sync_machine(&self, name: &str) -> Result<()> {
+        self.with_name_lock(name, || {
+            let _source_lock = crate::agent::fork::lock_fork_source(name)?;
+            let record = control::get_record(&self.db, name)?;
+            if record.staged_mounts.is_empty() {
+                return Ok(());
+            }
+            let handle = self.started_handle(name)?;
+            let result = lock_handle(&handle)?.sync_staged_mounts(&record);
+            result
         })
     }
 

--- a/src/embedded/runtime.rs
+++ b/src/embedded/runtime.rs
@@ -511,6 +511,7 @@ impl EmbeddedRuntime {
                     .with_env(env)
                     .with_workdir(workdir)
                     .with_timeout(timeout)
+                    .with_mounts(self.mount_bindings_for(name)?)
                     .with_s3_volumes(self.s3_volumes_for(name)?)
                     .with_persistent_overlay(Some(overlay_owner));
                 handle.run_config(config)
@@ -530,9 +531,24 @@ impl EmbeddedRuntime {
         workdir: Option<String>,
         timeout: Option<Duration>,
     ) -> Result<(i32, Vec<u8>, Vec<u8>)> {
+        let (_, overlay_owner) = self.image_and_overlay_owner(name)?;
+        let mount_bindings = self.mount_bindings_for(name)?;
+        let s3_volumes = self.s3_volumes_for(name)?;
         let handle = self.started_handle(name)?;
         let mut handle = lock_handle(&handle)?;
-        handle.run(image, command, env, workdir, timeout)
+        if mount_bindings.is_empty() && s3_volumes.is_empty() {
+            return handle.run(image, command, env, workdir, timeout);
+        }
+        handle.pull_image(image)?;
+        handle.run_config(
+            RunConfig::new(image, command)
+                .with_env(env)
+                .with_workdir(workdir)
+                .with_timeout(timeout)
+                .with_mounts(mount_bindings)
+                .with_s3_volumes(s3_volumes)
+                .with_persistent_overlay(Some(overlay_owner)),
+        )
     }
 
     /// Pull an OCI image into the machine's storage.
@@ -558,18 +574,20 @@ impl EmbeddedRuntime {
         mode: Option<u32>,
     ) -> Result<()> {
         let (image, overlay_owner) = self.image_and_overlay_owner(name)?;
+        let mount_bindings = self.mount_bindings_for(name)?;
         let handle = self.started_handle(name)?;
         let mut handle = lock_handle(&handle)?;
-        Self::activate_image_overlay(&mut handle, image, overlay_owner)?;
+        Self::activate_image_overlay(&mut handle, image, overlay_owner, mount_bindings)?;
         handle.write_file(path, &data, mode)
     }
 
     /// Read a file from the machine.
     pub fn read_file(&self, name: &str, path: &str) -> Result<Vec<u8>> {
         let (image, overlay_owner) = self.image_and_overlay_owner(name)?;
+        let mount_bindings = self.mount_bindings_for(name)?;
         let handle = self.started_handle(name)?;
         let mut handle = lock_handle(&handle)?;
-        Self::activate_image_overlay(&mut handle, image, overlay_owner)?;
+        Self::activate_image_overlay(&mut handle, image, overlay_owner, mount_bindings)?;
         handle.read_file(path)
     }
 
@@ -580,12 +598,14 @@ impl EmbeddedRuntime {
         handle: &mut VmHandle,
         image: Option<String>,
         overlay_owner: String,
+        mount_bindings: Vec<(String, String, bool)>,
     ) -> Result<()> {
         let Some(image) = image else {
             return Ok(());
         };
         let (code, _, stderr) = handle.run_config(
             RunConfig::new(image, vec!["/bin/true".to_string()])
+                .with_mounts(mount_bindings)
                 .with_persistent_overlay(Some(overlay_owner)),
         )?;
         if code == 0 {
@@ -641,6 +661,11 @@ impl EmbeddedRuntime {
         ))
     }
 
+    fn mount_bindings_for(&self, name: &str) -> Result<Vec<(String, String, bool)>> {
+        let record = control::get_record(&self.db, name)?;
+        Ok(crate::workload::record_mounts_to_bindings(&record))
+    }
+
     /// The machine's image, if it is an image (container-workload) machine.
     /// Streamed execs on such a machine must run inside its persistent container
     /// overlay so their writes survive — matching non-streaming exec.
@@ -692,6 +717,7 @@ impl EmbeddedRuntime {
                     .with_env(env)
                     .with_workdir(workdir)
                     .with_timeout(timeout)
+                    .with_mounts(self.mount_bindings_for(name)?)
                     .with_s3_volumes(self.s3_volumes_for(name)?)
                     .with_persistent_overlay(Some(overlay_owner));
                 handle.run_streaming_with(config, on_event)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,8 @@ pub mod remote_volume;
 pub mod secrets;
 pub mod settings;
 pub mod smolfile;
+/// Guest-local staged mount synchronization.
+pub mod staged_mount;
 pub mod storage;
 pub mod systemd_scope;
 pub mod util;

--- a/src/portable_checkpoint.rs
+++ b/src/portable_checkpoint.rs
@@ -838,7 +838,7 @@ fn validate_cpu_compatibility(checkpoint: &PortableCheckpointManifest) -> Result
 /// Reject host-bound device state that cannot yet be resumed from an artifact.
 pub fn validate_capture_profile(vm: &VmRecord) -> Result<()> {
     let mut unsupported = Vec::new();
-    if !vm.mounts.is_empty() {
+    if !vm.mounts.is_empty() || !vm.staged_mounts.is_empty() {
         unsupported.push("host mounts");
     }
     if !vm.published_sockets.is_empty() {

--- a/src/staged_mount.rs
+++ b/src/staged_mount.rs
@@ -1,0 +1,288 @@
+//! Batched synchronization for guest-local staged mounts.
+//!
+//! A staged mount runs from a guest-local working copy. Synchronization streams
+//! one tar archive over vsock, then applies it on the host in a filesystem
+//! batch. This avoids one virtiofs round trip per small file while keeping the
+//! mode explicit.
+
+use crate::agent::AgentClient;
+use crate::config::VmRecord;
+use crate::HostMount;
+use crate::{Error, Result};
+use std::collections::HashSet;
+use std::path::Component;
+use std::path::{Path, PathBuf};
+
+/// Synchronize every staged mount in `record` back to its host source.
+///
+/// Live `rw` and `ro` mounts are ignored. The caller must hold the machine's
+/// lifecycle lock (or otherwise serialize agent operations) while this runs.
+pub fn sync_staged_mounts(record: &VmRecord, client: &mut AgentClient) -> Result<()> {
+    sync_mounts(&record.host_mounts(), client)
+}
+
+/// Synchronize staged mounts from a launch configuration that has not yet been
+/// persisted as a named machine (the foreground `machine run` path).
+pub fn sync_mounts(mounts: &[HostMount], client: &mut AgentClient) -> Result<()> {
+    for mount in mounts {
+        if !mount.staged {
+            continue;
+        }
+        sync_one(&mount.source, &mount.target, client)?;
+    }
+    Ok(())
+}
+
+fn sync_one(host_source: &Path, guest_target: &Path, client: &mut AgentClient) -> Result<()> {
+    let temporary = tempfile::Builder::new()
+        .prefix("smolvm-staged-sync-")
+        .tempdir()
+        .map_err(|error| Error::agent("sync staged mount", error.to_string()))?;
+    let archive_path = temporary.path().join("contents.tar");
+    client.archive_directory_to_path(&guest_target.to_string_lossy(), &archive_path, |_| {})?;
+    apply_archive(&archive_path, host_source)
+}
+
+fn apply_archive(archive_path: &Path, destination: &Path) -> Result<()> {
+    std::fs::create_dir_all(destination)
+        .map_err(|error| Error::agent("create sync destination", error.to_string()))?;
+
+    // Validate the complete archive before touching the host tree. Besides
+    // blocking special files, this first pass records the desired entry types
+    // so the extraction pass can safely replace file <-> directory changes.
+    let file = std::fs::File::open(archive_path)
+        .map_err(|error| Error::agent("open staged archive", error.to_string()))?;
+    let mut archive = tar::Archive::new(file);
+    let mut wanted = HashSet::<PathBuf>::new();
+    let mut desired_types = Vec::new();
+    for entry in archive
+        .entries()
+        .map_err(|error| Error::agent("read staged archive", error.to_string()))?
+    {
+        let entry =
+            entry.map_err(|error| Error::agent("read staged archive", error.to_string()))?;
+        let raw_path = entry
+            .path()
+            .map_err(|error| Error::agent("read staged archive path", error.to_string()))?
+            .into_owned();
+        let relative = normalize_archive_path(&raw_path)?;
+        if relative.as_os_str().is_empty() {
+            continue;
+        }
+        let entry_type = entry.header().entry_type();
+        if !entry_type.is_file() && !entry_type.is_dir() && !entry_type.is_symlink() {
+            return Err(Error::agent(
+                "sync staged mount",
+                format!(
+                    "unsupported special file in staged tree: {}",
+                    raw_path.display()
+                ),
+            ));
+        }
+        desired_types.push((relative.clone(), entry_type));
+        let mut ancestor = Some(relative.as_path());
+        while let Some(path) = ancestor {
+            if !path.as_os_str().is_empty() {
+                wanted.insert(path.to_path_buf());
+            }
+            ancestor = path.parent();
+        }
+    }
+
+    drop(archive);
+    let file = std::fs::File::open(archive_path)
+        .map_err(|error| Error::agent("reopen staged archive", error.to_string()))?;
+    let mut archive = tar::Archive::new(file);
+    let mut desired_types = desired_types.into_iter();
+    for entry in archive
+        .entries()
+        .map_err(|error| Error::agent("read staged archive", error.to_string()))?
+    {
+        let mut entry =
+            entry.map_err(|error| Error::agent("read staged archive", error.to_string()))?;
+        let raw_path = entry
+            .path()
+            .map_err(|error| Error::agent("read staged archive path", error.to_string()))?
+            .into_owned();
+        let relative = normalize_archive_path(&raw_path)?;
+        if relative.as_os_str().is_empty() {
+            continue;
+        }
+        let (validated_path, entry_type) = desired_types.next().ok_or_else(|| {
+            Error::agent(
+                "sync staged mount",
+                "archive changed between validation and extraction",
+            )
+        })?;
+        if relative != validated_path {
+            return Err(Error::agent(
+                "sync staged mount",
+                "archive changed between validation and extraction",
+            ));
+        }
+        prepare_entry_destination(destination, &relative, entry_type)?;
+        if !entry
+            .unpack_in(destination)
+            .map_err(|error| Error::agent("extract staged archive", error.to_string()))?
+        {
+            return Err(Error::agent(
+                "extract staged archive",
+                format!(
+                    "archive path '{}' escaped the destination",
+                    relative.display()
+                ),
+            ));
+        }
+    }
+    if desired_types.next().is_some() {
+        return Err(Error::agent(
+            "sync staged mount",
+            "archive changed between validation and extraction",
+        ));
+    }
+
+    drop(archive);
+    std::fs::remove_file(archive_path)
+        .map_err(|error| Error::agent("remove staged archive", error.to_string()))?;
+    prune_stale_paths(destination, Path::new(""), &wanted)
+}
+
+fn prepare_entry_destination(root: &Path, relative: &Path, desired: tar::EntryType) -> Result<()> {
+    let path = root.join(relative);
+    let Ok(existing) = std::fs::symlink_metadata(&path) else {
+        return Ok(());
+    };
+    let existing_is_dir = existing.is_dir() && !existing.file_type().is_symlink();
+    let desired_is_dir = desired.is_dir();
+    if existing_is_dir != desired_is_dir
+        || existing.file_type().is_symlink()
+        || desired.is_symlink()
+    {
+        remove_path(&path)?;
+    }
+    Ok(())
+}
+
+fn normalize_archive_path(path: &Path) -> Result<PathBuf> {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(value) => normalized.push(value),
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(Error::agent(
+                    "sync staged mount",
+                    format!("archive contains unsafe path '{}'", path.display()),
+                ));
+            }
+        }
+    }
+    Ok(normalized)
+}
+
+fn prune_stale_paths(root: &Path, relative: &Path, wanted: &HashSet<PathBuf>) -> Result<()> {
+    let directory = root.join(relative);
+    for entry in std::fs::read_dir(&directory)
+        .map_err(|error| Error::agent("read sync destination", error.to_string()))?
+    {
+        let entry =
+            entry.map_err(|error| Error::agent("read sync destination", error.to_string()))?;
+        let name = entry.file_name();
+        let child_relative = relative.join(name);
+        if !wanted.contains(&child_relative) {
+            remove_path(&entry.path())?;
+            continue;
+        }
+        let metadata = std::fs::symlink_metadata(entry.path())
+            .map_err(|error| Error::agent("inspect staged path", error.to_string()))?;
+        if metadata.is_dir() && !metadata.file_type().is_symlink() {
+            prune_stale_paths(root, &child_relative, wanted)?;
+        }
+    }
+    Ok(())
+}
+
+fn remove_path(path: &Path) -> Result<()> {
+    let metadata = std::fs::symlink_metadata(path)
+        .map_err(|error| Error::agent("inspect stale staged path", error.to_string()))?;
+    if metadata.is_dir() && !metadata.file_type().is_symlink() {
+        std::fs::remove_dir_all(path)
+            .map_err(|error| Error::agent("remove stale staged directory", error.to_string()))
+    } else {
+        std::fs::remove_file(path)
+            .map_err(|error| Error::agent("remove stale staged file", error.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mirror_updates_creates_and_deletes_without_following_symlinks() {
+        let source = tempfile::tempdir().unwrap();
+        let destination = tempfile::tempdir().unwrap();
+        std::fs::write(source.path().join("changed"), b"new").unwrap();
+        std::fs::create_dir(source.path().join("dir")).unwrap();
+        std::fs::write(source.path().join("dir/added"), b"added").unwrap();
+        std::fs::write(destination.path().join("changed"), b"old").unwrap();
+        std::fs::write(destination.path().join("deleted"), b"delete me").unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink("changed", source.path().join("link")).unwrap();
+
+        let archive_path = destination.path().join(".smolvm-staged-sync-test.tar");
+        let archive_file = std::fs::File::create(&archive_path).unwrap();
+        let mut builder = tar::Builder::new(archive_file);
+        builder.follow_symlinks(false);
+        builder.append_dir_all(".", source.path()).unwrap();
+        builder.finish().unwrap();
+        drop(builder);
+
+        apply_archive(&archive_path, destination.path()).unwrap();
+
+        assert_eq!(
+            std::fs::read(destination.path().join("changed")).unwrap(),
+            b"new"
+        );
+        assert_eq!(
+            std::fs::read(destination.path().join("dir/added")).unwrap(),
+            b"added"
+        );
+        assert!(!destination.path().join("deleted").exists());
+        #[cfg(unix)]
+        assert_eq!(
+            std::fs::read_link(destination.path().join("link")).unwrap(),
+            PathBuf::from("changed")
+        );
+    }
+
+    #[test]
+    fn mirror_replaces_files_and_directories_in_both_directions() {
+        let source = tempfile::tempdir().unwrap();
+        let destination = tempfile::tempdir().unwrap();
+        std::fs::create_dir(source.path().join("was-file")).unwrap();
+        std::fs::write(source.path().join("was-file/child"), b"child").unwrap();
+        std::fs::write(source.path().join("was-dir"), b"file now").unwrap();
+        std::fs::write(destination.path().join("was-file"), b"old file").unwrap();
+        std::fs::create_dir(destination.path().join("was-dir")).unwrap();
+        std::fs::write(destination.path().join("was-dir/old"), b"old child").unwrap();
+
+        let archive_path = destination.path().join(".smolvm-staged-types.tar");
+        let archive_file = std::fs::File::create(&archive_path).unwrap();
+        let mut builder = tar::Builder::new(archive_file);
+        builder.append_dir_all(".", source.path()).unwrap();
+        builder.finish().unwrap();
+        drop(builder);
+
+        apply_archive(&archive_path, destination.path()).unwrap();
+
+        assert_eq!(
+            std::fs::read(destination.path().join("was-file/child")).unwrap(),
+            b"child"
+        );
+        assert_eq!(
+            std::fs::read(destination.path().join("was-dir")).unwrap(),
+            b"file now"
+        );
+    }
+}

--- a/src/vm/config.rs
+++ b/src/vm/config.rs
@@ -469,6 +469,7 @@ mod tests {
                 source: "/host".into(),
                 target: "/guest".into(),
                 read_only: true,
+                staged: false,
             })
             .command(vec!["/bin/sh".to_string()])
             .workdir("/app")

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -8,17 +8,22 @@
 
 use crate::agent::{AgentClient, RunConfig};
 use crate::config::VmRecord;
-use crate::data::storage::HostMount;
 
-/// Convert a `VmRecord` mount list (`(host_source, guest_target, read_only)`
-/// triples) to the agent's virtiofs binding format. The host source is
-/// dropped — the agent only needs the guest-facing target and the positional
-/// `smolvm{i}` tag.
-pub fn record_mounts_to_bindings(mounts: &[(String, String, bool)]) -> Vec<(String, String, bool)> {
-    mounts
+/// Convert a record's live and staged host mounts to the agent's binding form.
+/// Reconstructing the rich list preserves original device order, while staged
+/// mounts use their stable runtime identity instead of a plain virtiofs tag.
+pub fn record_mounts_to_bindings(record: &VmRecord) -> Vec<(String, String, bool)> {
+    record
+        .host_mounts()
         .iter()
         .enumerate()
-        .map(|(i, (_host, target, ro))| (HostMount::mount_tag(i), target.clone(), *ro))
+        .map(|(i, mount)| {
+            (
+                mount.runtime_mount_tag(i),
+                mount.target.to_string_lossy().into_owned(),
+                mount.read_only,
+            )
+        })
         .collect()
 }
 
@@ -92,7 +97,7 @@ pub fn launch_image_workload(
             RunConfig::new(image, command.clone())
                 .with_workdir(record.workdir.clone())
                 .with_user(record.user.clone())
-                .with_mounts(record_mounts_to_bindings(&record.mounts))
+                .with_mounts(record_mounts_to_bindings(record))
                 .in_machine(record, machine_name, &exec_env)
                 .with_env(exec_env.clone()),
         )
@@ -253,6 +258,27 @@ mod tests {
             persistent_overlay_owner_with_lineage("grandchild", Some("child"), Some("root")),
             "root"
         );
+    }
+
+    #[test]
+    fn bindings_preserve_staged_mount_order_and_identity() {
+        let mut record = VmRecord::new(
+            "test".into(),
+            1,
+            256,
+            vec![("/host/live".into(), "/live".into(), true)],
+            Vec::new(),
+            false,
+        );
+        record.staged_mounts = vec![(0, "/host/staged".into(), "/work".into())];
+
+        let bindings = record_mounts_to_bindings(&record);
+        assert_eq!(bindings.len(), 2);
+        assert!(bindings[0].0.starts_with("staged+"));
+        assert!(bindings[0].0.ends_with("+smolvm0"));
+        assert_eq!(bindings[0].1, "/work");
+        assert!(!bindings[0].2);
+        assert_eq!(bindings[1], ("smolvm1".into(), "/live".into(), true));
     }
 
     // Only the agent's metadata-less-image failure downgrades a machine start

--- a/tests/test_volumes.sh
+++ b/tests/test_volumes.sh
@@ -331,6 +331,41 @@ EOF
     [[ "$exec_out" == *"smolfile-exec-volume-regression-marker"* ]]
 }
 
+test_staged_volume_sync_and_restart() {
+    local vm_name="vol-staged-$$"
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    echo "staged-seed" > "$tmpdir/input.txt"
+
+    $SMOLVM machine create --name "$vm_name" --cpus 2 --mem 512 \
+        -v "$tmpdir:/workspace:staged" >/dev/null 2>&1 || { rm -rf "$tmpdir"; return 1; }
+    $SMOLVM machine start --name "$vm_name" >/dev/null 2>&1 || {
+        $SMOLVM machine delete --name "$vm_name" -f >/dev/null 2>&1 || true
+        rm -rf "$tmpdir"
+        return 1
+    }
+
+    $SMOLVM machine exec --name "$vm_name" -- sh -lc \
+        'test "$(cat /workspace/input.txt)" = staged-seed && printf staged-output > /workspace/output.txt' \
+        >/dev/null 2>&1 || return 1
+    [[ ! -e "$tmpdir/output.txt" ]] || return 1
+    $SMOLVM machine sync --name "$vm_name" >/dev/null 2>&1 || return 1
+    [[ "$(cat "$tmpdir/output.txt")" == "staged-output" ]] || return 1
+
+    $SMOLVM machine stop --name "$vm_name" >/dev/null 2>&1 || return 1
+    $SMOLVM machine start --name "$vm_name" >/dev/null 2>&1 || return 1
+    $SMOLVM machine exec --name "$vm_name" -- sh -lc \
+        'test "$(cat /workspace/output.txt)" = staged-output && printf stop-sync > /workspace/final.txt' \
+        >/dev/null 2>&1 || return 1
+    $SMOLVM machine stop --name "$vm_name" >/dev/null 2>&1 || return 1
+
+    local ok=0
+    [[ "$(cat "$tmpdir/final.txt")" == "stop-sync" ]] && ok=1
+    $SMOLVM machine delete --name "$vm_name" -f >/dev/null 2>&1 || true
+    rm -rf "$tmpdir"
+    [[ $ok -eq 1 ]]
+}
+
 
 # The at/below-/workspace volume matrix against a registry --image machine.
 # The driver and the reasoning live in common.sh.
@@ -347,5 +382,6 @@ run_test "Volume: default /workspace symlink without -v" test_default_workspace_
 run_test "Create with --image: volume mount visible to exec" test_image_exec_volume_mount_visible || true
 run_test "Create with --image: Smolfile volumes visible to exec" test_image_exec_volume_mount_visible_smolfile || true
 run_test "Create with --image: volume targets at/below /workspace resolve in guest" test_image_volume_targets_resolve_inside_guest || true
+run_test "Volume: staged sync and restart persistence" test_staged_volume_sync_and_restart || true
 
 print_summary "Volume Tests"


### PR DESCRIPTION
Adds an explicit staged mount mode that runs metadata-heavy work on guest-local storage and safely synchronizes results through the CLI and API.