### PR TITLE
Explain why a branch was refused and show what each machine was branched from

### DIFF
--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -111,6 +111,27 @@ fn lock_file_exclusive(file: &File) -> std::io::Result<()> {
     }
 }
 
+/// Turn a control-socket refusal into something the person who ran the command
+/// can act on.
+///
+/// The VMM answers in its own vocabulary — `ERR EINVAL no memfd-backed RAM
+/// (start the VM with SMOLVM_FORKABLE=1)` — which leaks an errno and points at
+/// an internal environment variable rather than the flag a person types. Every
+/// caller (CLI and serve API alike) funnels through here, so the mapping is
+/// written once. An unrecognised reply is passed through verbatim rather than
+/// guessed at, so a new VMM error is never disguised as a known one.
+fn explain_fork_reply(golden: &str, reply: &str) -> String {
+    if reply.contains("no memfd-backed RAM") {
+        return format!(
+            "machine '{golden}' was not started as branchable, so it has no copy-on-write \
+             memory to branch from. Restart it with `smolvm machine start --name {golden} \
+             --branchable`; branchability is decided at start time and cannot be turned on \
+             for an already-running machine."
+        );
+    }
+    format!("branching '{golden}' failed: {reply}")
+}
+
 /// Path to a forkable machine's control socket (pause/resume/checkpoint/FORK).
 pub fn control_socket_path(name: &str) -> PathBuf {
     vm_data_dir(name).join("control.sock")
@@ -1658,7 +1679,7 @@ pub(crate) fn prepare_forks_reusing(
                     golden,
                     &snapshot_dir,
                     false,
-                    Error::agent("fork", format!("golden FORK failed: {reply}")),
+                    Error::agent("fork", explain_fork_reply(golden, &reply)),
                 ));
             }
             Err(error) => {

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -2663,10 +2663,18 @@ pub fn list_vms(verbose: bool, json: bool) -> smolvm::Result<()> {
         println!("{}", json);
     } else {
         println!(
-            "{:<20} {:<12} {:>5} {:>10} {:>7} {:>7} {:>8} {:>8}",
-            "NAME", "STATE", "CPUS", "MEMORY", "MOUNTS", "PORTS", "STORAGE", "OVERLAY"
+            "{:<20} {:<12} {:>5} {:>10} {:>7} {:>7} {:>8} {:>8}  {:<18}",
+            "NAME",
+            "STATE",
+            "CPUS",
+            "MEMORY",
+            "MOUNTS",
+            "PORTS",
+            "STORAGE",
+            "OVERLAY",
+            "BRANCHED FROM"
         );
-        println!("{}", "-".repeat(88));
+        println!("{}", "-".repeat(108));
 
         for (name, record) in vms {
             let actual_state = smolvm::agent::state_probe::resolve_state(name, record);
@@ -2677,8 +2685,15 @@ pub fn list_vms(verbose: bool, json: bool) -> smolvm::Result<()> {
             };
             let storage_gb = record.storage_gb.unwrap_or(DEFAULT_STORAGE_SIZE_GIB);
             let overlay_gb = record.overlay_gb.unwrap_or(DEFAULT_OVERLAY_SIZE_GIB);
+            // A branch's source, so a tree of clones reads as a tree rather than
+            // a flat list of unrelated machines.
+            let branched_from = record
+                .golden
+                .as_deref()
+                .map(|g| truncate(g, 16))
+                .unwrap_or_else(|| "-".to_string());
             println!(
-                "{:<20} {:<12} {:>5} {:>10} {:>7} {:>7} {:>8} {:>8}",
+                "{:<20} {:<12} {:>5} {:>10} {:>7} {:>7} {:>8} {:>8}  {:<18}",
                 truncate(name, 18),
                 state_display,
                 record.cpus,
@@ -2687,6 +2702,7 @@ pub fn list_vms(verbose: bool, json: bool) -> smolvm::Result<()> {
                 record.ports.len(),
                 format!("{} GiB", storage_gb),
                 format!("{} GiB", overlay_gb),
+                branched_from,
             );
 
             if verbose {


### PR DESCRIPTION
Branching a machine that was not started branchable failed with the VMM's own wording, which leaked an errno and pointed at an internal environment variable instead of the flag a person types, and a tree of branched machines listed as unrelated rows because the parent each one came from was recorded but never shown; the refusal is now translated where every caller funnels through, so the CLI and the serve API both explain that branchability is decided at start time and name the flag to restart with, and `machine ls` gained a BRANCHED FROM column filled from the parent already stored on each record.