### PR TITLE
Fix stale serve locks after out-of-band stops

### DIFF
--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -344,6 +344,43 @@ fn machine_entry_from_record(record: &VmRecord, manager: AgentManager) -> Machin
     }
 }
 
+/// Reconcile both control-plane representations after a VM process is confirmed dead.
+///
+/// `ApiState` keeps a long-lived `AgentManager` whose open `vm.lock` file owns the
+/// per-machine flock, while SQLite is shared with out-of-process CLI commands. A CLI
+/// stop or an unexpected process exit can therefore make the database truthful while
+/// leaving the serve process's cached manager in `Running`. Callers must hold the
+/// machine lifecycle and fork-source locks and must have confirmed process exit before
+/// entering here; releasing the cached flock for a live process would permit a second
+/// VMM to start with the same disks.
+async fn reconcile_confirmed_stopped_machine(
+    state: &Arc<ApiState>,
+    name: &str,
+    explicitly_stopped: bool,
+) -> Result<VmRecord, ApiError> {
+    if let Ok(entry) = state.get_machine(name) {
+        entry.lock().manager.mark_stopped();
+    }
+
+    state
+        .update_vm(name, move |record| {
+            record.state = RecordState::Stopped;
+            record.pid = None;
+            record.pid_start_time = None;
+            if explicitly_stopped {
+                // An explicit stop must suppress the restart supervisor even when
+                // the process had already exited before this request arrived.
+                record.restart.user_stopped = true;
+            }
+        })
+        .await?
+        .ok_or_else(|| {
+            ApiError::NotFound(format!(
+                "machine '{name}' disappeared from database while reconciling its stopped state"
+            ))
+        })
+}
+
 /// Attempt graceful shutdown, then force-terminate if still running.
 ///
 /// Uses verified signals to prevent killing an unrelated process if the
@@ -1406,6 +1443,7 @@ pub async fn start_machine(
         )));
     }
 
+    let mut recovered_unreachable = false;
     if resolved == RecordState::Unreachable {
         // Zombie: verified-kill the VMM and clear the DB record
         // before falling through to a clean fresh start. Any stale
@@ -1414,7 +1452,7 @@ pub async fn start_machine(
         // cannot be confirmed dead, refuse the start instead of
         // booting on top of it.
         let name_recover = name.clone();
-        tokio::task::spawn_blocking(move || {
+        recovered_unreachable = tokio::task::spawn_blocking(move || {
             crate::agent::state_probe::recover_if_unreachable(&name_recover)
         })
         .await
@@ -1424,6 +1462,27 @@ pub async fn start_machine(
                 "machine '{name}' is unreachable and zombie cleanup failed: {e}"
             ))
         })?;
+        if !recovered_unreachable {
+            // Reachability changed between the two probes. Do not release the
+            // cached manager's flock based on an observation that is no longer
+            // true, and do not risk launching a second VMM over a recovered one.
+            return Err(ApiError::Conflict(format!(
+                "machine '{name}' changed state while unreachable recovery was in progress; retry start"
+            )));
+        }
+    }
+
+    // A successful unreachable recovery, a Running record resolved Stopped by
+    // PID+agent probing, or a durable Stopped record written by an out-of-process
+    // CLI stop all prove that no VMM should still own this machine. Reconcile the
+    // serve process's cached manager before constructing a fresh manager below.
+    // Without this, the cached manager retains vm.lock and every restart wedges
+    // until the API server itself is restarted (issue #1124).
+    if recovered_unreachable
+        || (record.state == RecordState::Running && resolved == RecordState::Stopped)
+        || record.state == RecordState::Stopped
+    {
+        record = reconcile_confirmed_stopped_machine(&state, &name, false).await?;
     }
 
     if let Some(pool_size) = query.fork_pool_size {
@@ -2443,6 +2502,16 @@ pub async fn stop_machine(
             .await
             .map_err(|e| ApiError::internal(format!("task error: {}", e)))?;
         }
+        // The process is confirmed dead. This also handles an out-of-process
+        // CLI stop: SQLite already says Stopped, but the serve process may still
+        // cache the manager that owns vm.lock. Reconcile before the idempotent
+        // return so either this request or a later start repairs the lifecycle.
+        let record = if record.state == RecordState::Running || record.state == RecordState::Stopped
+        {
+            reconcile_confirmed_stopped_machine(&state, &name, true).await?
+        } else {
+            record
+        };
         return Ok(Json(record_to_info(&name, &record)));
     }
 
@@ -2507,31 +2576,9 @@ pub async fn stop_machine(
         )));
     }
 
-    // The VM process is confirmed dead, but the long-lived registry manager for
-    // this machine still holds the per-VM `vm.lock` flock in this serve process.
-    // Release it so a subsequent start can re-acquire the lock; otherwise start
-    // fails with "another process is already starting or running this VM".
-    if let Ok(entry) = state.get_machine(&name) {
-        entry.lock().manager.mark_stopped();
-    }
-
-    // Persist state to database and get updated record — only after confirmed stop
-    let record = state
-        .update_vm(&name, |r| {
-            r.state = RecordState::Stopped;
-            r.pid = None;
-            r.pid_start_time = None;
-            // Record the explicit stop so the restart supervisor does not
-            // resurrect this machine (any policy) until an explicit start.
-            r.restart.user_stopped = true;
-        })
-        .await?
-        .ok_or_else(|| {
-            ApiError::NotFound(format!(
-                "machine '{}' disappeared from database during stop",
-                name
-            ))
-        })?;
+    // Persist stopped state and release the long-lived registry manager's flock
+    // through the same path used for already-dead and out-of-process stops.
+    let record = reconcile_confirmed_stopped_machine(&state, &name, true).await?;
 
     Ok(Json(record_to_info(&name, &record)))
 }

--- a/tests/test_api.sh
+++ b/tests/test_api.sh
@@ -27,6 +27,7 @@ SERVER_LOG="$(mktemp -t smolvm-api-test-server)"
 SERVER_PID=""
 MACHINE_NAME="api-test-machine"
 REGISTRY_TEST_NAME="registry-coherence-test"
+OUT_OF_BAND_STOP_NAME="api-out-of-band-stop-test"
 
 # API client shortcut
 CURL=(curl --unix-socket "$API_SOCKET")
@@ -72,6 +73,7 @@ cleanup() {
     if "${CURL[@]}" -s "$API_URL/health" >/dev/null 2>&1; then
         "${CURL[@]}" -s -X DELETE "$API_URL/api/v1/machines/$MACHINE_NAME" >/dev/null 2>&1 || true
         "${CURL[@]}" -s -X DELETE "$API_URL/api/v1/machines/$REGISTRY_TEST_NAME" >/dev/null 2>&1 || true
+        "${CURL[@]}" -s -X DELETE "$API_URL/api/v1/machines/$OUT_OF_BAND_STOP_NAME" >/dev/null 2>&1 || true
     fi
     stop_server
 
@@ -244,6 +246,71 @@ test_registry_cleanup() {
     [[ "$status" == "200" ]]
 }
 
+# Regression for issue #1124. The API server owns a cached AgentManager while
+# the CLI changes the same machine through SQLite in a separate process. Both a
+# direct restart and an idempotent API stop must release the cached vm.lock.
+test_out_of_band_stop_reconciliation() {
+    local status response
+    status=$("${CURL[@]}" -s -o /dev/null -w "%{http_code}" -X POST "$API_URL/api/v1/machines" \
+        -H "Content-Type: application/json" \
+        -d "{\"name\": \"$OUT_OF_BAND_STOP_NAME\", \"cpus\": 1, \"mem\": 512}")
+    [[ "$status" == "200" ]] || { echo "create failed: $status"; return 1; }
+
+    response=$("${CURL[@]}" -s -X POST "$API_URL/api/v1/machines/$OUT_OF_BAND_STOP_NAME/start")
+    [[ "$response" == *'"state":"running"'* ]] || { echo "first start failed: $response"; return 1; }
+
+    $SMOLVM machine stop --name "$OUT_OF_BAND_STOP_NAME" >/dev/null 2>&1 || {
+        echo "out-of-band CLI stop failed"
+        return 1
+    }
+
+    # Before the fix this returned 500 because serve's cached manager still
+    # held vm.lock even though the CLI had stopped the process and updated DB.
+    response=$("${CURL[@]}" -s -X POST "$API_URL/api/v1/machines/$OUT_OF_BAND_STOP_NAME/start")
+    [[ "$response" == *'"state":"running"'* ]] || { echo "restart after CLI stop failed: $response"; return 1; }
+
+    $SMOLVM machine stop --name "$OUT_OF_BAND_STOP_NAME" >/dev/null 2>&1 || {
+        echo "second out-of-band CLI stop failed"
+        return 1
+    }
+
+    # Exercise stop's already-dead early return as well. It must reconcile the
+    # cached manager, not merely echo SQLite's stopped record.
+    response=$("${CURL[@]}" -s -X POST "$API_URL/api/v1/machines/$OUT_OF_BAND_STOP_NAME/stop")
+    [[ "$response" == *'"state":"stopped"'* ]] || { echo "idempotent API stop failed: $response"; return 1; }
+
+    response=$("${CURL[@]}" -s -X POST "$API_URL/api/v1/machines/$OUT_OF_BAND_STOP_NAME/start")
+    [[ "$response" == *'"state":"running"'* ]] || { echo "restart after reconciled stop failed: $response"; return 1; }
+
+    response=$("${CURL[@]}" -s -X POST "$API_URL/api/v1/machines/$OUT_OF_BAND_STOP_NAME/exec" \
+        -H "Content-Type: application/json" \
+        -d '{"command": ["echo", "out-of-band-restart-ok"]}')
+    [[ "$response" == *"out-of-band-restart-ok"* ]] || { echo "exec after restart failed: $response"; return 1; }
+
+    # The same stale-manager state occurs when the VMM exits unexpectedly and
+    # the supervisor records it as stopped. Terminate only the PID returned for
+    # this throwaway machine, then prove idempotent stop and restart recover it.
+    response=$("${CURL[@]}" -s "$API_URL/api/v1/machines/$OUT_OF_BAND_STOP_NAME")
+    local vm_pid
+    vm_pid=$(printf '%s' "$response" | sed -n 's/.*"pid":\([0-9][0-9]*\).*/\1/p')
+    [[ "$vm_pid" =~ ^[0-9]+$ ]] || { echo "could not read test VM pid: $response"; return 1; }
+    [[ "$vm_pid" != "$SERVER_PID" ]] || { echo "refusing to signal API server pid"; return 1; }
+    kill -9 "$vm_pid" || return 1
+    for _ in $(seq 1 100); do
+        kill -0 "$vm_pid" >/dev/null 2>&1 || break
+        sleep 0.05
+    done
+
+    response=$("${CURL[@]}" -s -X POST "$API_URL/api/v1/machines/$OUT_OF_BAND_STOP_NAME/stop")
+    [[ "$response" == *'"state":"stopped"'* ]] || { echo "stop after unexpected exit failed: $response"; return 1; }
+    response=$("${CURL[@]}" -s -X POST "$API_URL/api/v1/machines/$OUT_OF_BAND_STOP_NAME/start")
+    [[ "$response" == *'"state":"running"'* ]] || { echo "restart after unexpected exit failed: $response"; return 1; }
+
+    "${CURL[@]}" -s -X POST "$API_URL/api/v1/machines/$OUT_OF_BAND_STOP_NAME/stop" >/dev/null || return 1
+    status=$("${CURL[@]}" -s -o /dev/null -w "%{http_code}" -X DELETE "$API_URL/api/v1/machines/$OUT_OF_BAND_STOP_NAME")
+    [[ "$status" == "200" ]]
+}
+
 # =============================================================================
 # Run Tests
 # =============================================================================
@@ -271,6 +338,7 @@ run_test "Error: bad request (400)" test_error_bad_request || true
 run_test "Registry: create→start→exec in one session" test_registry_create_start_exec || true
 run_test "Registry: get machine after create" test_registry_get_machine || true
 run_test "Registry: cleanup test machine" test_registry_cleanup || true
+run_test "Lifecycle: reconcile out-of-band stop and restart" test_out_of_band_stop_reconciliation || true
 
 # Auto-generated names via API
 test_api_auto_generated_names() {


### PR DESCRIPTION
Reconcile the server's cached VM manager and persisted state after confirmed out-of-band stops or crashes so stopped machines can restart without restarting the API server.