### PR TITLE
Fix arm64 forks on heterogeneous CPUs

### DIFF
--- a/lib/libkrun.dylib
+++ b/lib/libkrun.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e04ffea6baac399ddc351b2d7779364736cf49cd349f9cb1f25b8e8eaf848016
-size 6758944
+oid sha256:0bb2b22c175d85824eadc61195268b7f13d27935060a892b004bbb6d91734009
+size 6724320

--- a/lib/libkrun.provenance
+++ b/lib/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=bc0962ad68851c770c1dd0bb01bdcbeab76ba308
+libkrun=dbf5f235047333ac7b831b5a32497aa8c1d46663
 libkrunfw=55bb7c5273178826240b39e907475fb6011afd8e

--- a/lib/linux-aarch64/libkrun.provenance
+++ b/lib/linux-aarch64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=bc0962ad68851c770c1dd0bb01bdcbeab76ba308
+libkrun=dbf5f235047333ac7b831b5a32497aa8c1d46663
 libkrunfw=55bb7c5273178826240b39e907475fb6011afd8e

--- a/lib/linux-aarch64/libkrun.so
+++ b/lib/linux-aarch64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:38a662407ad4c1d82fafdb2f06d32c4dfc50647e5a94e1dbcc857c0f83924882
-size 7667664
+oid sha256:cdc32a768383b7e1ad4be24944dab327ac37edb945e8b99189fabfd282e0a782
+size 7666352

--- a/lib/linux-aarch64/libkrun.so.2.0.0
+++ b/lib/linux-aarch64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:38a662407ad4c1d82fafdb2f06d32c4dfc50647e5a94e1dbcc857c0f83924882
-size 7667664
+oid sha256:cdc32a768383b7e1ad4be24944dab327ac37edb945e8b99189fabfd282e0a782
+size 7666352

--- a/lib/linux-x86_64/libkrun.provenance
+++ b/lib/linux-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=bc0962ad68851c770c1dd0bb01bdcbeab76ba308
+libkrun=dbf5f235047333ac7b831b5a32497aa8c1d46663
 libkrunfw=55bb7c5273178826240b39e907475fb6011afd8e

--- a/lib/linux-x86_64/libkrun.so
+++ b/lib/linux-x86_64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:951f100e49fdd04d6e7e71c69d402eef60fff9c56ff611bdff910f7dde3da6f7
-size 8530720
+oid sha256:6171b19c4e0729f81efabe72b9a217377616b82cf2ffb40227201d58c4839cef
+size 8527880

--- a/lib/linux-x86_64/libkrun.so.2.0.0
+++ b/lib/linux-x86_64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:951f100e49fdd04d6e7e71c69d402eef60fff9c56ff611bdff910f7dde3da6f7
-size 8530720
+oid sha256:6171b19c4e0729f81efabe72b9a217377616b82cf2ffb40227201d58c4839cef
+size 8527880

--- a/lib/windows-x86_64/krun.dll
+++ b/lib/windows-x86_64/krun.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0f09c6941dd42a5bda0268d9533866aabe4a5882d0706f24e17c5a335da1725c
-size 10938913
+oid sha256:facfa19025034b03c38f7e516ad94b64f932c34da40fb594ae777d945e213db6
+size 10943016

--- a/lib/windows-x86_64/libkrun.provenance
+++ b/lib/windows-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=bc0962ad68851c770c1dd0bb01bdcbeab76ba308
+libkrun=dbf5f235047333ac7b831b5a32497aa8c1d46663
 libkrunfw=55bb7c5273178826240b39e907475fb6011afd8e


### PR DESCRIPTION
Exclude physical ARM cache descriptors from checkpoint state and refresh bundled runtimes so multi-vCPU forks restore across heterogeneous CPU clusters, closing #1035.