### PR TITLE
Ship the containerd shim in the Linux release so Kubernetes support is reachable

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,34 @@ Known Limitations
 * GPU acceleration requires libkrun built with `GPU=1` and virglrenderer + a Vulkan driver on the host (see [GPU Acceleration](#gpu-acceleration) below).
 * Windows: `--net` works the same as on other platforms (virtio-net with inbound port-forwarding; TSI for outbound-only VMs), as do `machine exec` / interactive sessions and `machine stats`. Not yet available on Windows: GPU acceleration and `machine branch` / snapshot. Pack *create* needs `storage-template.ext4` / `overlay-template.ext4` next to `smolvm.exe` (Windows has no host `mkfs.ext4`).
 
+Kubernetes
+----------
+
+smolvm ships a **containerd shim v2**, so Kubernetes runs a pod as its own microVM
+through a `RuntimeClass`, the same integration point Kata uses. The Linux release
+carries the shim and the manifests; there is nothing to build.
+
+On each node that should run microVM pods (requires KVM):
+
+```bash
+# 1. install the shim + runtime artifacts, then apply the containerd config it prints
+sudo ./kubernetes/install-k8s-runtime.sh
+sudo systemctl restart containerd
+
+# 2. label the node so the RuntimeClass will schedule to it
+kubectl label node <node> smolvm-runtime=true
+```
+
+Then register the class and run a pod:
+
+```bash
+kubectl apply -f kubernetes/runtimeclass.yaml
+kubectl apply -f kubernetes/example-pod.yaml
+kubectl logs smolvm-hello    # prints the guest's own kernel, so it is a real VM
+```
+
+Any pod opts in with `runtimeClassName: smolvm`.
+
 GPU Acceleration
 ----------------
 

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -250,6 +250,13 @@ fi
 echo "Building release binaries..."
 LIBKRUN_BUNDLE="$WORK_LIB_DIR" cargo build --release --bin smolvm
 
+# The containerd shim, so a release can run pods as microVMs under Kubernetes
+# without a source checkout. Linux only: containerd is the only consumer, and
+# there is nothing to register it with on macOS or Windows.
+if [[ "$(uname -s)" == "Linux" ]]; then
+    LIBKRUN_BUNDLE="$WORK_LIB_DIR" cargo build --release --bin containerd-shim-smolvm-v2
+fi
+
 # Build the unified `smol` CLI if its source is present (it lives in a sibling
 # repo checked out at ./smol). It is a separate cargo workspace that depends on
 # the engine by path, so build it from inside ./smol with an ABSOLUTE
@@ -331,6 +338,20 @@ cp ./target/release/smolvm "$DIST_DIR/smolvm-bin"
 # Copy wrapper script
 cp ./scripts/smolvm-wrapper.sh "$DIST_DIR/smolvm"
 chmod +x "$DIST_DIR/smolvm"
+
+# Kubernetes runtime: the containerd shim plus everything needed to register
+# it. Shipping these means `runtimeClassName: smolvm` is reachable from a
+# downloaded release; previously the shim existed only in the source tree, so
+# the feature was invisible to anyone who installed the normal way.
+if [[ "$(uname -s)" == "Linux" ]]; then
+    mkdir -p "$DIST_DIR/kubernetes"
+    cp ./target/release/containerd-shim-smolvm-v2 "$DIST_DIR/containerd-shim-smolvm-v2"
+    chmod +x "$DIST_DIR/containerd-shim-smolvm-v2"
+    cp ./scripts/install-k8s-runtime.sh "$DIST_DIR/kubernetes/"
+    chmod +x "$DIST_DIR/kubernetes/install-k8s-runtime.sh"
+    cp ./deploy/kubernetes/runtimeclass.yaml ./deploy/kubernetes/example-pod.yaml "$DIST_DIR/kubernetes/"
+    echo "Bundled Kubernetes runtime: containerd-shim-smolvm-v2 + manifests"
+fi
 
 # Copy the unified smol CLI (binary renamed to smol-bin + its own wrapper).
 # The wrapper points at the same lib/ and agent-rootfs, so one tarball serves

--- a/scripts/install-k8s-runtime.sh
+++ b/scripts/install-k8s-runtime.sh
@@ -11,8 +11,9 @@
 # Usage:
 #   sudo ./scripts/install-k8s-runtime.sh [--shim PATH] [--runtime-dir DIR]
 #
-#   --shim PATH          The built containerd-shim-smolvm-v2 binary
-#                        (default: target/release/containerd-shim-smolvm-v2).
+#   --shim PATH          The built containerd-shim-smolvm-v2 binary (default:
+#                        the one beside this script in an unpacked release,
+#                        else target/release/containerd-shim-smolvm-v2).
 #   --runtime-dir DIR    A directory holding the smolvm runtime artifacts to
 #                        install into /var/lib/smolvm: lib/ (libkrun*.so),
 #                        init.krun, smolvm-vmm, agent-rootfs/. A smolvm Linux
@@ -22,7 +23,15 @@
 #
 set -euo pipefail
 
-SHIM_SRC="target/release/containerd-shim-smolvm-v2"
+# Default shim location, resolved for both layouts this script ships in: an
+# unpacked release, where it sits beside the runtime artifacts one level up
+# from this script, and a source checkout, where cargo leaves it in target/.
+_HERE="$(cd "$(dirname "$0")" && pwd)"
+if [ -x "$_HERE/../containerd-shim-smolvm-v2" ]; then
+    SHIM_SRC="$_HERE/../containerd-shim-smolvm-v2"
+else
+    SHIM_SRC="target/release/containerd-shim-smolvm-v2"
+fi
 RUNTIME_SRC=""
 DATA_DIR="/var/lib/smolvm"
 BIN_DIR="/usr/local/bin"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -417,6 +417,20 @@ install_smolvm() {
         has_smol=true
     fi
 
+    # Copy the Kubernetes runtime if the distribution includes it (Linux
+    # tarballs only; older ones won't have it). Without this the shim ships in
+    # the release but never reaches disk, so `runtimeClassName: smolvm` stays
+    # out of reach for anyone who installed with this script.
+    if [[ -f "$extracted_dir/containerd-shim-smolvm-v2" ]]; then
+        cp "$extracted_dir/containerd-shim-smolvm-v2" "$prefix/"
+        chmod +x "$prefix/containerd-shim-smolvm-v2"
+        if [[ -d "$extracted_dir/kubernetes" ]]; then
+            rm -rf "$prefix/kubernetes"
+            cp -r "$extracted_dir/kubernetes" "$prefix/"
+            chmod +x "$prefix/kubernetes/install-k8s-runtime.sh" 2>/dev/null || true
+        fi
+    fi
+
     # Copy disk templates if present
     if [[ -f "$extracted_dir/storage-template.ext4" ]]; then
         cp "$extracted_dir/storage-template.ext4" "$prefix/"


### PR DESCRIPTION
smolvm has run Kubernetes pods as microVMs through a containerd shim for a while, but the shim was only ever built from source and never packaged or installed, so anyone who installed from a release or the curl script had no way to use it and no mention of it in the README, which is how issue #1131 came to be asked; this ships containerd-shim-smolvm-v2 and the manifests in the Linux distribution, places them via the install script, resolves the installer's default shim path in an unpacked release, and documents the steps in the README.

Held as a draft: verifying it end to end on a Linux k3s node showed the shim cannot currently start a pod, failing with `PodStart: pod rootfs not found: /mnt/virtiofs/podshare/<id>/rootfs` because no podshare directory is ever created on the host side, and that reproduces with a shim and engine built from the same commit so it is not version skew; the release also ships neither smolvm-vmm (the engine binary the installer requires under another name) nor init.krun, so packaging the shim alone would still not give a working install.