### PR TITLE
Build the containerd shim by package name and ship the engine its installer needs

### DIFF
--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -254,7 +254,7 @@ LIBKRUN_BUNDLE="$WORK_LIB_DIR" cargo build --release --bin smolvm
 # without a source checkout. Linux only: containerd is the only consumer, and
 # there is nothing to register it with on macOS or Windows.
 if [[ "$(uname -s)" == "Linux" ]]; then
-    LIBKRUN_BUNDLE="$WORK_LIB_DIR" cargo build --release --bin containerd-shim-smolvm-v2
+    LIBKRUN_BUNDLE="$WORK_LIB_DIR" cargo build --release -p smolvm-shim --bin containerd-shim-smolvm-v2
 fi
 
 # Build the unified `smol` CLI if its source is present (it lives in a sibling


### PR DESCRIPTION
The Linux distribution build invoked cargo with a bare --bin, which cargo refuses because it does not resolve past the workspace's default-run package, so the next release build would have failed outright, and the distribution also omitted the engine binary under the smolvm-vmm name that the Kubernetes installer copies into /var/lib/smolvm, without which every pod sandbox fails to create; both are fixed here, verified end to end on a Linux k3s node where a pod now boots as a real microVM reporting guest kernel 6.12.95 against the host's 6.18.33.