### PR TITLE
Ship the engine as smolvm-vmm so a released node can complete the Kubernetes install

### DIFF
--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -347,6 +347,11 @@ if [[ "$(uname -s)" == "Linux" ]]; then
     mkdir -p "$DIST_DIR/kubernetes"
     cp ./target/release/containerd-shim-smolvm-v2 "$DIST_DIR/containerd-shim-smolvm-v2"
     chmod +x "$DIST_DIR/containerd-shim-smolvm-v2"
+    # The engine under the name install-k8s-runtime.sh copies into
+    # /var/lib/smolvm. Verified required: with it moved aside on a live node,
+    # every pod sandbox fails to create.
+    cp ./target/release/smolvm "$DIST_DIR/smolvm-vmm"
+    chmod +x "$DIST_DIR/smolvm-vmm"
     cp ./scripts/install-k8s-runtime.sh "$DIST_DIR/kubernetes/"
     chmod +x "$DIST_DIR/kubernetes/install-k8s-runtime.sh"
     cp ./deploy/kubernetes/runtimeclass.yaml ./deploy/kubernetes/example-pod.yaml "$DIST_DIR/kubernetes/"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -424,6 +424,10 @@ install_smolvm() {
     if [[ -f "$extracted_dir/containerd-shim-smolvm-v2" ]]; then
         cp "$extracted_dir/containerd-shim-smolvm-v2" "$prefix/"
         chmod +x "$prefix/containerd-shim-smolvm-v2"
+        if [[ -f "$extracted_dir/smolvm-vmm" ]]; then
+            cp "$extracted_dir/smolvm-vmm" "$prefix/"
+            chmod +x "$prefix/smolvm-vmm"
+        fi
         if [[ -d "$extracted_dir/kubernetes" ]]; then
             rm -rf "$prefix/kubernetes"
             cp -r "$extracted_dir/kubernetes" "$prefix/"


### PR DESCRIPTION
The Kubernetes installer copies an artifact named smolvm-vmm into /var/lib/smolvm and refuses without it, but no distribution ever contained it, so a node installed from a release could not complete the install even with the shim now packaged; the Linux distribution carries the engine under that name and the install script places it, verified on a live k3s node where moving the file aside made every pod sandbox fail to create and restoring it brought pods back to Running with the guest reporting kernel 6.12.95 against the host's 6.18.33.