### PR TITLE
Derive the Kubernetes runtime VMM from the engine the distribution already ships

### DIFF
--- a/scripts/install-k8s-runtime.sh
+++ b/scripts/install-k8s-runtime.sh
@@ -54,6 +54,19 @@ echo "==> Installing runtime artifacts into $DATA_DIR"
 mkdir -p "$DATA_DIR"
 if [ -n "$RUNTIME_SRC" ]; then
     [ -d "$RUNTIME_SRC" ] || { echo "error: --runtime-dir not a directory: $RUNTIME_SRC" >&2; exit 1; }
+    # `smolvm-vmm` is just the engine under the name the runtime resolves. A
+    # distribution ships the engine once, as `smolvm-bin` (with `smolvm` as its
+    # wrapper script), so derive the VMM from it rather than asking releases to
+    # carry a second 30MB copy of the same binary.
+    if [ ! -e "$RUNTIME_SRC/smolvm-vmm" ]; then
+        for cand in smolvm-bin smolvm; do
+            if [ -f "$RUNTIME_SRC/$cand" ] && [ -x "$RUNTIME_SRC/$cand" ] && head -c4 "$RUNTIME_SRC/$cand" | grep -q ELF; then
+                echo "    (deriving smolvm-vmm from $cand)"
+                cp "$RUNTIME_SRC/$cand" "$RUNTIME_SRC/smolvm-vmm"
+                break
+            fi
+        done
+    fi
     for a in "${RUNTIME_ARTIFACTS[@]}"; do
         if [ -e "$RUNTIME_SRC/$a" ]; then
             echo "    $a"


### PR DESCRIPTION
The Kubernetes installer refuses without an artifact named smolvm-vmm in /var/lib/smolvm, which is simply the engine binary under another name, and no distribution contains it, so a node installed from a release could not complete the install; rather than have every release carry a second thirty-megabyte copy of a binary it already ships, the installer now derives it from the engine in the runtime directory, verified on a live k3s node from a release-shaped directory holding only lib, agent-rootfs and smolvm-bin, where a pod boots as a real microVM reporting guest kernel 6.12.95 against the host's 6.18.33.