### PR TITLE
Rebuild the bundled libkrun and macOS virglrenderer from the merged sources

### DIFF
--- a/lib/libkrun.dylib
+++ b/lib/libkrun.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0bb2b22c175d85824eadc61195268b7f13d27935060a892b004bbb6d91734009
-size 6724320
+oid sha256:82fe6accf7e33f4976a4b00e360bcfc22313a2a35d8bbd714fe76ce5ad687ca6
+size 6716944

--- a/lib/libkrun.provenance
+++ b/lib/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=dbf5f235047333ac7b831b5a32497aa8c1d46663
+libkrun=a11021850b8066fb6c7a58871e8724cf2715f130
 libkrunfw=55bb7c5273178826240b39e907475fb6011afd8e

--- a/lib/libvirglrenderer.1.dylib
+++ b/lib/libvirglrenderer.1.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9375c2e8fb93df53c3fb09de934cfff9faf1661a6805e7c2cff37688d04b1219
-size 2309456
+oid sha256:6ad956b217da875edd64a25f799f3d2036c611626053d39b2cc4e36577645205
+size 2309616

--- a/lib/linux-aarch64/libkrun.provenance
+++ b/lib/linux-aarch64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=dbf5f235047333ac7b831b5a32497aa8c1d46663
+libkrun=a11021850b8066fb6c7a58871e8724cf2715f130
 libkrunfw=55bb7c5273178826240b39e907475fb6011afd8e

--- a/lib/linux-aarch64/libkrun.so
+++ b/lib/linux-aarch64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cdc32a768383b7e1ad4be24944dab327ac37edb945e8b99189fabfd282e0a782
-size 7666352
+oid sha256:aa528ed6a3556ad3fa553e2a1c472aeefec9851e2a3b0da140d72974bced8aed
+size 7677832

--- a/lib/linux-aarch64/libkrun.so.2.0.0
+++ b/lib/linux-aarch64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cdc32a768383b7e1ad4be24944dab327ac37edb945e8b99189fabfd282e0a782
-size 7666352
+oid sha256:aa528ed6a3556ad3fa553e2a1c472aeefec9851e2a3b0da140d72974bced8aed
+size 7677832

--- a/lib/linux-x86_64/libkrun.provenance
+++ b/lib/linux-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=dbf5f235047333ac7b831b5a32497aa8c1d46663
+libkrun=a11021850b8066fb6c7a58871e8724cf2715f130
 libkrunfw=55bb7c5273178826240b39e907475fb6011afd8e

--- a/lib/linux-x86_64/libkrun.so
+++ b/lib/linux-x86_64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6171b19c4e0729f81efabe72b9a217377616b82cf2ffb40227201d58c4839cef
-size 8527880
+oid sha256:2d3511bbaba63fd5f7d61e4d27483d3493be140f37c564a0347726a10a5614be
+size 8516448

--- a/lib/linux-x86_64/libkrun.so.2.0.0
+++ b/lib/linux-x86_64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6171b19c4e0729f81efabe72b9a217377616b82cf2ffb40227201d58c4839cef
-size 8527880
+oid sha256:2d3511bbaba63fd5f7d61e4d27483d3493be140f37c564a0347726a10a5614be
+size 8516448

--- a/lib/windows-x86_64/libkrun.provenance
+++ b/lib/windows-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=dbf5f235047333ac7b831b5a32497aa8c1d46663
+libkrun=a11021850b8066fb6c7a58871e8724cf2715f130
 libkrunfw=55bb7c5273178826240b39e907475fb6011afd8e


### PR DESCRIPTION
Ships the merged display fixes on every platform.