### PR TITLE
Speed up large OCI image preparation

### DIFF
--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -12,7 +12,9 @@ use crate::crun::CrunCommand;
 use crate::oci::{generate_container_id, OciSpec};
 use crate::paths::{self, STORAGE_ROOT};
 use crate::process::{WaitResult, TIMEOUT_EXIT_CODE};
-use smolvm_oci_layer::{decompress_layer_reader, extract_oci_layer};
+#[cfg(test)]
+use smolvm_oci_layer::extract_oci_layer;
+use smolvm_oci_layer::{decompress_layer_reader, extract_oci_layer_with_size};
 use smolvm_protocol::guest_env;
 use smolvm_protocol::{
     image_repo, normalize_image_ref, ImageInfo, OverlayInfo, RegistryAuth, StorageStatus,
@@ -1800,6 +1802,23 @@ fn layer_ok_marker(layer_dir: &Path) -> PathBuf {
     layer_dir.with_file_name(name)
 }
 
+/// Cached logical size of one immutable content-addressed layer. Like the
+/// completion marker, this lives beside the lowerdir so it never appears in a
+/// container filesystem.
+fn layer_size_marker(layer_dir: &Path) -> PathBuf {
+    let mut name = layer_dir.file_name().unwrap_or_default().to_os_string();
+    name.push(".size");
+    layer_dir.with_file_name(name)
+}
+
+fn read_layer_size(layer_dir: &Path) -> Option<u64> {
+    std::fs::read_to_string(layer_size_marker(layer_dir))
+        .ok()?
+        .trim()
+        .parse()
+        .ok()
+}
+
 fn image_size_cache_path(root: &Path, image: &str) -> PathBuf {
     root.join(IMAGE_METADATA_DIR)
         .join(sanitize_image_name(image) + ".size")
@@ -1818,7 +1837,8 @@ fn calculate_image_size(root: &Path, layers: &[String]) -> u64 {
         .iter()
         .filter_map(|digest| {
             let id = digest.strip_prefix("sha256:").unwrap_or(digest);
-            dir_size(&root.join(LAYERS_DIR).join(id)).ok()
+            let layer_dir = root.join(LAYERS_DIR).join(id);
+            read_layer_size(&layer_dir).or_else(|| dir_size(&layer_dir).ok())
         })
         .sum()
 }
@@ -2213,10 +2233,19 @@ where
     // Extract layers with progress updates
     // Layers extracted by THIS pull; their completion markers are written only
     // after the writeback barrier below confirms the data reached the disk.
-    let mut newly_extracted: Vec<PathBuf> = Vec::new();
+    let mut newly_extracted: Vec<(PathBuf, u64)> = Vec::new();
     for (i, layer_digest) in layers.iter().enumerate() {
         let layer_id = layer_digest.strip_prefix("sha256:").unwrap_or(layer_digest);
         let layer_dir = root.join(LAYERS_DIR).join(layer_id);
+
+        // A manifest can legally reference the same layer more than once. Its
+        // durable completion marker is delayed until the final writeback
+        // barrier, so remember successful work from this pull rather than
+        // deleting and extracting the same directory again.
+        if newly_extracted.iter().any(|(dir, _)| dir == &layer_dir) {
+            progress(i + 1, total_layers, layer_id);
+            continue;
+        }
 
         if is_layer_cached(&layer_dir) {
             info!(layer = %layer_id, "layer already cached");
@@ -2234,6 +2263,7 @@ where
             }
         }
         let _ = std::fs::remove_file(layer_ok_marker(&layer_dir));
+        let _ = std::fs::remove_file(layer_size_marker(&layer_dir));
 
         info!(
             layer = %layer_id,
@@ -2291,7 +2321,7 @@ where
             .take()
             .ok_or_else(|| StorageError::new("failed to capture crane stdout".to_string()))?;
 
-        let extract_result = extract_oci_layer(crane_stdout, &layer_dir);
+        let extract_result = extract_oci_layer_with_size(crane_stdout, &layer_dir);
 
         let crane_status = crane
             .wait()
@@ -2313,7 +2343,7 @@ where
                 "crane blob failed for layer {}: {}",
                 layer_digest, crane_stderr
             ))
-        } else if let Err(e) = extract_result {
+        } else if let Err(ref e) = extract_result {
             Some(format!(
                 "layer extraction failed for layer {}: {}",
                 layer_digest, e
@@ -2331,7 +2361,7 @@ where
             return Err(StorageError::new(message));
         }
 
-        newly_extracted.push(layer_dir);
+        newly_extracted.push((layer_dir, extract_result.unwrap_or(0)));
 
         // Report progress after successful extraction
         progress(i + 1, total_layers, layer_id);
@@ -2350,17 +2380,20 @@ where
     //    (a host out of disk surfaces exactly this way) — only an error-reporting
     //    sync catches it, and a pull must FAIL then, not report done.
     if let Err(sync_error) = sync_layer_writeback(root) {
-        for dir in &newly_extracted {
+        for (dir, _) in &newly_extracted {
             let _ = std::fs::remove_dir_all(dir);
             let _ = std::fs::remove_file(layer_ok_marker(dir));
+            let _ = std::fs::remove_file(layer_size_marker(dir));
         }
         return Err(sync_error);
     }
 
     // Markers last: a layer without one is re-pulled, never trusted.
-    for dir in &newly_extracted {
+    for (dir, logical_bytes) in &newly_extracted {
         std::fs::write(layer_ok_marker(dir), "ok")
             .map_err(|e| StorageError::new(format!("write layer completion marker: {}", e)))?;
+        std::fs::write(layer_size_marker(dir), logical_bytes.to_string())
+            .map_err(|e| StorageError::new(format!("write layer size marker: {}", e)))?;
     }
 
     // Directory traversal is expensive for multi-gigabyte images and image
@@ -2675,14 +2708,23 @@ pub fn garbage_collect(dry_run: bool) -> Result<u64> {
     if layers_dir.exists() {
         for entry in std::fs::read_dir(&layers_dir)? {
             let entry = entry?;
+            if !entry.file_type()?.is_dir() {
+                // Completion and size sidecars live beside layer directories;
+                // they are handled with their directory below, not mistaken
+                // for independently garbage-collectable layers.
+                continue;
+            }
             let layer_id = entry.file_name().to_string_lossy().to_string();
 
             if !referenced_layers.contains(&layer_id) {
-                let size = dir_size(&entry.path()).unwrap_or(0);
+                let size = read_layer_size(&entry.path())
+                    .unwrap_or_else(|| dir_size(&entry.path()).unwrap_or(0));
                 info!(layer = %layer_id, size = size, dry_run = dry_run, "unreferenced layer");
 
                 if !dry_run {
                     std::fs::remove_dir_all(entry.path())?;
+                    let _ = std::fs::remove_file(layer_ok_marker(&entry.path()));
+                    let _ = std::fs::remove_file(layer_size_marker(&entry.path()));
                 }
 
                 freed += size;
@@ -2880,9 +2922,16 @@ impl OverlaySetup {
 
     /// Mount the overlay filesystem with fallback from multi-lowerdir to sequential.
     fn mount(&self, lowerdirs: &[String]) -> Result<()> {
+        // OCI manifests may repeat a content-addressed layer. Reapplying the
+        // exact same filesystem diff is idempotent, while passing the same
+        // directory to overlayfs twice makes fsconfig reject the stack with
+        // ELOOP and needlessly sends large images through the physical merge
+        // fallback.
+        let lowerdirs = unique_lowerdirs(lowerdirs);
+
         // Try multi-lowerdir mount first (efficient)
         let mount_result = try_mount_overlay_multi_lower(
-            lowerdirs,
+            &lowerdirs,
             &self.upper_path,
             &self.work_path,
             &self.merged_path,
@@ -2898,7 +2947,7 @@ impl OverlaySetup {
                 );
 
                 mount_overlay_sequential(
-                    lowerdirs,
+                    &lowerdirs,
                     &self.upper_path,
                     &self.work_path,
                     &self.merged_path,
@@ -4266,7 +4315,7 @@ fn mount_overlay_fsconfig(
 /// is tarred directly, since overlayfs requires two lower layers when there is no
 /// upperdir.
 pub fn flatten_layers_to_tar(lowerdirs: &[String], output: &Path) -> Result<()> {
-    let present = mountable_lowerdirs(lowerdirs);
+    let present = unique_lowerdirs(&mountable_lowerdirs(lowerdirs));
 
     let source = match present.len() {
         0 => {
@@ -4311,6 +4360,16 @@ fn mountable_lowerdirs(lowerdirs: &[String]) -> Vec<String> {
                     .map(|mut entries| entries.next().is_some())
                     .unwrap_or(false)
         })
+        .cloned()
+        .collect()
+}
+
+/// Keep the first (highest-priority) occurrence of each lower directory.
+fn unique_lowerdirs(lowerdirs: &[String]) -> Vec<String> {
+    let mut seen = std::collections::HashSet::with_capacity(lowerdirs.len());
+    lowerdirs
+        .iter()
+        .filter(|dir| seen.insert((*dir).clone()))
         .cloned()
         .collect()
 }
@@ -5108,6 +5167,24 @@ mod tests {
         );
     }
 
+    #[test]
+    fn duplicate_lowerdirs_keep_the_highest_priority_occurrence() {
+        let dirs = vec![
+            "/layers/top".to_string(),
+            "/layers/shared".to_string(),
+            "/layers/base".to_string(),
+            "/layers/shared".to_string(),
+        ];
+        assert_eq!(
+            unique_lowerdirs(&dirs),
+            vec![
+                "/layers/top".to_string(),
+                "/layers/shared".to_string(),
+                "/layers/base".to_string(),
+            ]
+        );
+    }
+
     /// Order is the whole contract — `lowerdir+` ranks each layer below the one
     /// before it, so the caller's topmost-first list must survive filtering
     /// unreordered. Passing it bottom-up instead inverts precedence silently:
@@ -5804,6 +5881,26 @@ mod tests {
     }
 
     #[test]
+    fn image_size_uses_layer_sidecars_and_falls_back_for_old_caches() {
+        let tmp = tempfile::tempdir().unwrap();
+        let layers_root = tmp.path().join(LAYERS_DIR);
+        let cached = layers_root.join("cached");
+        let legacy = layers_root.join("legacy");
+        std::fs::create_dir_all(&cached).unwrap();
+        std::fs::create_dir_all(&legacy).unwrap();
+        std::fs::write(cached.join("ignored-by-sidecar"), b"123456789").unwrap();
+        std::fs::write(legacy.join("measured"), b"1234").unwrap();
+        std::fs::write(layer_size_marker(&cached), "7").unwrap();
+
+        assert_eq!(
+            calculate_image_size(tmp.path(), &["cached".into(), "legacy".into()]),
+            11
+        );
+        assert_eq!(read_layer_size(&cached), Some(7));
+        assert_eq!(layer_size_marker(&cached).parent(), cached.parent());
+    }
+
+    #[test]
     fn test_validate_storage_id_rejects_traversal() {
         assert!(validate_storage_id("../escape", "workload_id").is_err());
         assert!(validate_storage_id("foo/bar", "workload_id").is_err());
@@ -5989,6 +6086,47 @@ mod tests {
         // The merged view exposes files from every layer.
         assert!(merged.join("f0").exists());
         assert!(merged.join("f7").exists());
+        let _ = std::process::Command::new("umount").arg(&merged).status();
+    }
+
+    /// Verify that the new mount API preserves OCI layer precedence and hides a
+    /// lower-layer name deleted by a whiteout in the top layer. This catches
+    /// ordering changes that ordinary additive-layer tests cannot observe.
+    #[test]
+    #[ignore = "requires root + Linux overlayfs"]
+    #[cfg(target_os = "linux")]
+    fn overlay_fsconfig_applies_lower_layer_whiteouts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let base = root.join("base");
+        let top = root.join("top");
+        let upper = root.join("upper");
+        let work = root.join("work");
+        let merged = root.join("merged");
+        for path in [&base, &top, &upper, &work, &merged] {
+            std::fs::create_dir_all(path).unwrap();
+        }
+        std::fs::create_dir_all(base.join("dir")).unwrap();
+        std::fs::create_dir_all(top.join("dir")).unwrap();
+        std::fs::write(base.join("priority"), b"base").unwrap();
+        std::fs::write(top.join("priority"), b"top").unwrap();
+        std::fs::write(base.join("dir/deleted"), b"lower payload").unwrap();
+        smolvm_oci_layer::create_overlay_whiteout(&top.join("dir/deleted")).unwrap();
+
+        let lowerdirs = vec![
+            top.to_string_lossy().into_owned(),
+            base.to_string_lossy().into_owned(),
+        ];
+        mount_overlay_fsconfig(&lowerdirs, &upper, &work, &merged).unwrap();
+
+        assert_eq!(std::fs::read(merged.join("priority")).unwrap(), b"top");
+        assert!(!merged.join("dir/deleted").exists());
+        let names: Vec<_> = std::fs::read_dir(merged.join("dir"))
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect();
+        assert!(!names.iter().any(|name| name == "deleted"));
+
         let _ = std::process::Command::new("umount").arg(&merged).status();
     }
 }

--- a/crates/smolvm-oci-layer/src/lib.rs
+++ b/crates/smolvm-oci-layer/src/lib.rs
@@ -233,6 +233,19 @@ fn pack_sidecar_sentinel(path: &Path) -> Option<&'static str> {
 /// whiteout translation only takes effect on Linux; on other hosts the markers
 /// would surface as `Unsupported` errors, so this is called on the Linux node.
 pub fn extract_oci_layer<R: Read>(reader: R, dest: &Path) -> std::io::Result<()> {
+    extract_oci_layer_with_size(reader, dest).map(|_| ())
+}
+
+/// Extract one OCI layer and return the logical bytes carried by regular file
+/// entries. Computing this while tar headers are already in hand avoids a full
+/// post-extraction directory walk, which is especially costly inside a VM for
+/// package-heavy images containing hundreds of thousands of files.
+pub fn extract_oci_layer_with_size<R: Read>(reader: R, dest: &Path) -> std::io::Result<u64> {
+    #[cfg(unix)]
+    use std::collections::{HashMap, HashSet};
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
     // Layers arrive gzip- or zstd-compressed (or, rarely, plain). Decompress
     // transparently so a zstd layer no longer breaks extraction.
     let reader = decompress_layer_reader(reader)?;
@@ -245,9 +258,21 @@ pub fn extract_oci_layer<R: Read>(reader: R, dest: &Path) -> std::io::Result<()>
     archive.set_preserve_ownerships(true);
     archive.set_overwrite(true);
 
+    // A layer can declare a read-only directory before its children. Relax each
+    // such parent at most once, then restore its declared mode after extraction.
+    // The old path chmodded the parent for every tar entry, which turned images
+    // with large package trees into hundreds of thousands of redundant metadata
+    // writes and also left restrictive directory modes changed to 0755.
+    #[cfg(unix)]
+    let mut checked_parents = HashSet::<PathBuf>::new();
+    #[cfg(unix)]
+    let mut relaxed_parents = HashMap::<PathBuf, u32>::new();
+    let mut logical_bytes = 0u64;
+
     for entry in archive.entries()? {
         let mut entry = entry?;
         let path = entry.path()?.into_owned();
+        let entry_type = entry.header().entry_type();
 
         // A smolmachine PACK blob is not an OCI filesystem layer: it is a
         // .smolmachine sidecar carrying agent-rootfs.tar and a multi-GiB non-sparse
@@ -306,12 +331,24 @@ pub fn extract_oci_layer<R: Read>(reader: R, dest: &Path) -> std::io::Result<()>
         // on the macOS/Windows host builds of the main engine.
         #[cfg(unix)]
         if let Some(parent) = full_path.parent() {
-            use std::os::unix::fs::PermissionsExt;
-            if parent.is_dir() {
-                let _ = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o755));
+            let parent = parent.to_path_buf();
+            if checked_parents.insert(parent.clone()) {
+                if let Ok(metadata) = std::fs::symlink_metadata(&parent) {
+                    if metadata.is_dir() {
+                        let mode = metadata.permissions().mode();
+                        if mode & 0o300 != 0o300 {
+                            std::fs::set_permissions(
+                                &parent,
+                                std::fs::Permissions::from_mode(mode | 0o700),
+                            )?;
+                            relaxed_parents.insert(parent, mode);
+                        }
+                    }
+                }
             }
         }
 
+        let entry_size = entry.header().size().unwrap_or(0);
         if let Err(e) = entry.unpack_in(dest) {
             // Regular files and directories failing is a real error; non-regular
             // entries (symlinks, device nodes, fifos) can fail benignly — skip.
@@ -329,9 +366,31 @@ pub fn extract_oci_layer<R: Read>(reader: R, dest: &Path) -> std::io::Result<()>
                     warn!(path = %path.display(), error = %e, "skipping non-regular layer entry");
                 }
             }
+        } else if matches!(
+            entry_type,
+            tar::EntryType::Regular | tar::EntryType::GNUSparse | tar::EntryType::Continuous
+        ) {
+            logical_bytes = logical_bytes.saturating_add(entry_size);
+        }
+
+        // A repeated directory entry may reset its own mode. Forget any earlier
+        // relaxation so later children re-check the newly declared permissions.
+        #[cfg(unix)]
+        if entry_type == tar::EntryType::Directory {
+            checked_parents.remove(&full_path);
+            relaxed_parents.remove(&full_path);
         }
     }
-    Ok(())
+
+    #[cfg(unix)]
+    {
+        let mut relaxed: Vec<_> = relaxed_parents.into_iter().collect();
+        relaxed.sort_by_key(|(path, _)| std::cmp::Reverse(path.components().count()));
+        for (path, mode) in relaxed {
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))?;
+        }
+    }
+    Ok(logical_bytes)
 }
 
 #[cfg(test)]
@@ -466,5 +525,85 @@ mod tests {
                 .collect();
             assert_eq!(names, vec!["hello".to_string()], "{label} entry list");
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn extraction_restores_restrictive_directory_modes() {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let owner = std::fs::metadata(tmp.path()).unwrap();
+        let mut builder = tar::Builder::new(Vec::new());
+
+        let mut directory = tar::Header::new_gnu();
+        directory.set_entry_type(tar::EntryType::Directory);
+        directory.set_size(0);
+        directory.set_mode(0o555);
+        directory.set_uid(owner.uid() as u64);
+        directory.set_gid(owner.gid() as u64);
+        directory.set_cksum();
+        builder
+            .append_data(&mut directory, "readonly", std::io::empty())
+            .unwrap();
+
+        let payload = b"still extracted";
+        let mut file = tar::Header::new_gnu();
+        file.set_size(payload.len() as u64);
+        file.set_mode(0o644);
+        file.set_uid(owner.uid() as u64);
+        file.set_gid(owner.gid() as u64);
+        file.set_cksum();
+        builder
+            .append_data(&mut file, "readonly/file", &payload[..])
+            .unwrap();
+
+        let layer = builder.into_inner().unwrap();
+        let destination = tmp.path().join("layer");
+        std::fs::create_dir(&destination).unwrap();
+        extract_oci_layer(&layer[..], &destination).unwrap();
+
+        assert_eq!(
+            std::fs::read(destination.join("readonly/file")).unwrap(),
+            payload
+        );
+        assert_eq!(
+            std::fs::metadata(destination.join("readonly"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o555
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn extraction_reports_regular_file_bytes_without_a_directory_walk() {
+        use std::os::unix::fs::MetadataExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let owner = std::fs::metadata(tmp.path()).unwrap();
+        let mut builder = tar::Builder::new(Vec::new());
+        for (path, payload) in [("one", &b"123"[..]), ("nested/two", &b"45678"[..])] {
+            let mut file = tar::Header::new_gnu();
+            file.set_size(payload.len() as u64);
+            file.set_mode(0o644);
+            file.set_uid(owner.uid() as u64);
+            file.set_gid(owner.gid() as u64);
+            file.set_cksum();
+            builder.append_data(&mut file, path, payload).unwrap();
+        }
+
+        let destination = tmp.path().join("layer");
+        std::fs::create_dir(&destination).unwrap();
+        let bytes =
+            extract_oci_layer_with_size(&builder.into_inner().unwrap()[..], &destination).unwrap();
+
+        assert_eq!(bytes, 8);
+        assert_eq!(
+            std::fs::read(destination.join("nested/two")).unwrap(),
+            b"45678"
+        );
     }
 }


### PR DESCRIPTION
Speeds up package-heavy OCI extraction, avoids duplicate layer mounts, and preserves whiteout correctness for repeated layers.