### PR TITLE
Park idle branchpoints until capture

### DIFF
--- a/crates/smolvm-agent/src/forkpoint.rs
+++ b/crates/smolvm-agent/src/forkpoint.rs
@@ -10,16 +10,30 @@ use std::os::unix::fs::PermissionsExt as _;
 use std::path::Path;
 use std::time::Duration;
 
+#[cfg(target_os = "linux")]
+use std::os::fd::{AsRawFd as _, FromRawFd as _, OwnedFd};
+#[cfg(target_os = "linux")]
+use std::os::unix::ffi::OsStrExt as _;
+
 const AGENT_BINARY: &str = "/usr/local/bin/smolvm-agent";
 use smolvm_protocol::forkpoint::{
-    BRANCH_ENV_PATH, BRANCH_HELPER_PATH, CUDA_PRELOAD_MODULES_HINT, FORK_ENV_PATH,
-    GENERATION_PREFIX, HELPER_PATH, LEGACY_RELEASE_TOKEN, READY_PATH, READY_VERSION, RELEASE_PATH,
-    RELEASE_PREFIX, RESTORED_CONTAINER_PATH, RESTORED_PATH, STATE_DIR, WORKER_READY_HELPER_PATH,
-    WORKER_READY_PATH, WORKER_READY_TOKEN_ENV,
+    ARMED_PATH, ARMED_PREFIX, ARM_PATH, ARM_PREFIX, BRANCH_ENV_PATH, BRANCH_HELPER_PATH,
+    CUDA_PRELOAD_MODULES_HINT, FORK_ENV_PATH, GENERATION_PREFIX, HELPER_PATH, LEGACY_RELEASE_TOKEN,
+    READY_PATH, READY_VERSION, RELEASE_PATH, RELEASE_PREFIX, RESTORED_CONTAINER_PATH,
+    RESTORED_PATH, STATE_DIR, WORKER_READY_HELPER_PATH, WORKER_READY_PATH, WORKER_READY_TOKEN_ENV,
 };
 
 fn enabled() -> bool {
     std::env::var(smolvm_protocol::guest_env::FORKABLE).as_deref()
+        == Ok(smolvm_protocol::guest_env::VALUE_ON)
+}
+
+/// Whether the paired host supports parking and arming an idle branchpoint.
+///
+/// This is negotiated by the host at boot. A new guest launched by an older
+/// host leaves it unset and retains the legacy always-spinning behavior.
+pub fn arming_enabled() -> bool {
+    std::env::var(smolvm_protocol::guest_env::BRANCHPOINT_ARMING).as_deref()
         == Ok(smolvm_protocol::guest_env::VALUE_ON)
 }
 
@@ -67,6 +81,8 @@ pub fn setup() {
     let _ = std::fs::remove_file(RESTORED_PATH);
     let _ = std::fs::remove_file(RELEASE_PATH);
     let _ = std::fs::remove_file(WORKER_READY_PATH);
+    let _ = std::fs::remove_file(ARM_PATH);
+    let _ = std::fs::remove_file(ARMED_PATH);
 
     for helper in [BRANCH_HELPER_PATH, HELPER_PATH, WORKER_READY_HELPER_PATH] {
         if !Path::new(helper).exists() {
@@ -80,12 +96,13 @@ pub fn setup() {
 /// Expose the forkpoint helper and its VM-private state directory inside a
 /// workload container. No-op for ordinary machines.
 pub fn inject_into_container(spec: &mut crate::oci::OciSpec) {
-    inject_into_container_if(spec, enabled(), AGENT_BINARY, STATE_DIR);
+    inject_into_container_if(spec, enabled(), arming_enabled(), AGENT_BINARY, STATE_DIR);
 }
 
 fn inject_into_container_if(
     spec: &mut crate::oci::OciSpec,
     enabled: bool,
+    armable: bool,
     agent_binary: &str,
     state_dir: &str,
 ) {
@@ -96,6 +113,12 @@ fn inject_into_container_if(
     spec.add_bind_mount(agent_binary, BRANCH_HELPER_PATH, true);
     spec.add_bind_mount(agent_binary, WORKER_READY_HELPER_PATH, true);
     spec.add_bind_mount(state_dir, STATE_DIR, false);
+    if armable {
+        spec.add_env(
+            smolvm_protocol::guest_env::BRANCHPOINT_ARMING,
+            smolvm_protocol::guest_env::VALUE_ON,
+        );
+    }
 }
 
 /// Mark the workload ready and block until this VM is a released clone.
@@ -110,23 +133,108 @@ pub fn run_helper() -> i32 {
 
 fn run_helper_inner(preload_modules: bool) -> Result<(), String> {
     run_helper_at(
-        Path::new(STATE_DIR),
-        Path::new(READY_PATH),
-        Path::new(RESTORED_PATH),
-        Path::new(RELEASE_PATH),
+        ForkpointPaths {
+            state_dir: Path::new(STATE_DIR),
+            ready_path: Path::new(READY_PATH),
+            restored_path: Path::new(RESTORED_PATH),
+            release_path: Path::new(RELEASE_PATH),
+            arm_path: Path::new(ARM_PATH),
+            armed_path: Path::new(ARMED_PATH),
+        },
         Duration::from_millis(20),
         preload_modules,
+        arming_enabled(),
     )
 }
 
+/// Block in the guest kernel until the host changes branchpoint state. The
+/// helper always checks the marker files before waiting, so the inotify queue
+/// closes the check/sleep race without periodic vCPU wakeups. If inotify is
+/// unavailable, the caller retains the bounded polling fallback.
+#[cfg(target_os = "linux")]
+struct StateChangeWaiter {
+    fd: OwnedFd,
+}
+
+#[cfg(target_os = "linux")]
+impl StateChangeWaiter {
+    fn new(state_dir: &Path) -> std::io::Result<Self> {
+        let path = std::ffi::CString::new(state_dir.as_os_str().as_bytes()).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "branchpoint state path contains NUL",
+            )
+        })?;
+        let raw_fd = unsafe { libc::inotify_init1(libc::IN_CLOEXEC | libc::IN_NONBLOCK) };
+        if raw_fd < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        let fd = unsafe { OwnedFd::from_raw_fd(raw_fd) };
+        let mask = libc::IN_CREATE
+            | libc::IN_DELETE
+            | libc::IN_MOVED_FROM
+            | libc::IN_MOVED_TO
+            | libc::IN_CLOSE_WRITE;
+        if unsafe { libc::inotify_add_watch(fd.as_raw_fd(), path.as_ptr(), mask) } < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(Self { fd })
+    }
+
+    fn wait(&self) -> bool {
+        let mut descriptor = libc::pollfd {
+            fd: self.fd.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        loop {
+            let ready = unsafe { libc::poll(&mut descriptor, 1, -1) };
+            if ready > 0 {
+                let mut events = [0_u8; 1024];
+                let _ = unsafe {
+                    libc::read(
+                        self.fd.as_raw_fd(),
+                        events.as_mut_ptr().cast(),
+                        events.len(),
+                    )
+                };
+                return true;
+            }
+            if ready == 0 {
+                continue;
+            }
+            let error = std::io::Error::last_os_error();
+            if error.kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            return false;
+        }
+    }
+}
+
+struct ForkpointPaths<'a> {
+    state_dir: &'a Path,
+    ready_path: &'a Path,
+    restored_path: &'a Path,
+    release_path: &'a Path,
+    arm_path: &'a Path,
+    armed_path: &'a Path,
+}
+
 fn run_helper_at(
-    state_dir: &Path,
-    ready_path: &Path,
-    restored_path: &Path,
-    release_path: &Path,
+    paths: ForkpointPaths<'_>,
     poll_interval: Duration,
     preload_modules: bool,
+    use_arming: bool,
 ) -> Result<(), String> {
+    let ForkpointPaths {
+        state_dir,
+        ready_path,
+        restored_path,
+        release_path,
+        arm_path,
+        armed_path,
+    } = paths;
     std::fs::create_dir_all(state_dir)
         .map_err(|error| format!("create {}: {error}", state_dir.display()))?;
     let _ = std::fs::remove_file(release_path);
@@ -153,17 +261,54 @@ fn run_helper_at(
     println!("smolvm branch point ready; waiting for child release");
     let _ = std::io::stdout().flush();
 
-    // Keep the snapshot boundary out of a timed kernel wait. Some VMM restore
-    // paths cannot reliably re-arm an inherited sleeping thread, which can
-    // leave every clone from that checkpoint parked after a successful host
-    // release. A restored clone writes RESTORED_PATH during identity setup;
-    // waits started after that point are native to the clone and safe to use.
-    while !restored_path.is_file() {
-        if release_matches(release_path, &generation) {
-            acknowledge_generation(ready_path, &generation);
-            return Ok(());
+    #[cfg(target_os = "linux")]
+    let mut change_waiter = use_arming
+        .then(|| StateChangeWaiter::new(state_dir).ok())
+        .flatten();
+
+    // A timed kernel wait captured in the snapshot is not reliably re-armed by
+    // every VMM restore path. Older hosts therefore require the legacy
+    // userspace loop below. A paired host advertises the arming protocol: the
+    // source sleeps while idle, the host writes ARM_PATH immediately before
+    // capture and waits for ARMED_PATH, and only that short capture window uses
+    // the restore-safe userspace loop. Once the source continues, removing the
+    // arm marker parks it again instead of consuming one host core forever.
+    if use_arming {
+        while !restored_path.is_file() {
+            if release_matches(release_path, &generation) {
+                acknowledge_generation(ready_path, &generation);
+                return Ok(());
+            }
+            if arm_matches(arm_path, &generation) {
+                publish_generation_marker(armed_path, ARMED_PREFIX, &generation)?;
+                while !restored_path.is_file() && arm_matches(arm_path, &generation) {
+                    if release_matches(release_path, &generation) {
+                        let _ = std::fs::remove_file(armed_path);
+                        acknowledge_generation(ready_path, &generation);
+                        return Ok(());
+                    }
+                    std::thread::yield_now();
+                }
+                let _ = std::fs::remove_file(armed_path);
+            } else {
+                #[cfg(target_os = "linux")]
+                if let Some(waiter) = &change_waiter {
+                    if waiter.wait() {
+                        continue;
+                    }
+                    change_waiter = None;
+                }
+                std::thread::sleep(poll_interval);
+            }
         }
-        std::thread::yield_now();
+    } else {
+        while !restored_path.is_file() {
+            if release_matches(release_path, &generation) {
+                acknowledge_generation(ready_path, &generation);
+                return Ok(());
+            }
+            std::thread::yield_now();
+        }
     }
 
     loop {
@@ -265,6 +410,35 @@ fn release_matches(release_path: &Path, generation: &str) -> bool {
     })
 }
 
+fn arm_matches(arm_path: &Path, generation: &str) -> bool {
+    marker_matches(arm_path, ARM_PREFIX, generation)
+}
+
+fn marker_matches(path: &Path, prefix: &str, generation: &str) -> bool {
+    std::fs::read_to_string(path)
+        .is_ok_and(|marker| marker.trim() == format!("{prefix}{generation}"))
+}
+
+fn publish_generation_marker(path: &Path, prefix: &str, generation: &str) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("{} has no parent", path.display()))?;
+    let temporary = parent.join(format!(".armed.{}.tmp", std::process::id()));
+    let mut marker = std::fs::File::create(&temporary)
+        .map_err(|error| format!("create {}: {error}", temporary.display()))?;
+    if let Err(error) = marker
+        .write_all(format!("{prefix}{generation}\n").as_bytes())
+        .and_then(|()| marker.sync_all())
+    {
+        let _ = std::fs::remove_file(&temporary);
+        return Err(format!("write {}: {error}", temporary.display()));
+    }
+    std::fs::rename(&temporary, path).map_err(|error| {
+        let _ = std::fs::remove_file(&temporary);
+        format!("publish {}: {error}", path.display())
+    })
+}
+
 fn acknowledge_generation(ready_path: &Path, generation: &str) {
     let is_current = std::fs::read_to_string(ready_path).is_ok_and(|ready| {
         ready
@@ -316,7 +490,7 @@ mod tests {
     #[test]
     fn ordinary_container_does_not_receive_helper() {
         let mut spec = spec();
-        inject_into_container_if(&mut spec, false, "/missing-agent", "/missing-state");
+        inject_into_container_if(&mut spec, false, false, "/missing-agent", "/missing-state");
         assert!(spec
             .mounts
             .iter()
@@ -336,6 +510,7 @@ mod tests {
         let mut spec = spec();
         inject_into_container_if(
             &mut spec,
+            true,
             true,
             agent.to_str().unwrap(),
             state.to_str().unwrap(),
@@ -364,6 +539,11 @@ mod tests {
             .options
             .iter()
             .any(|option| option == "ro"));
+        assert!(spec.process.env.contains(&format!(
+            "{}={}",
+            smolvm_protocol::guest_env::BRANCHPOINT_ARMING,
+            smolvm_protocol::guest_env::VALUE_ON
+        )));
         let state_mount = spec
             .mounts
             .iter()
@@ -374,12 +554,40 @@ mod tests {
     }
 
     #[test]
+    fn older_host_does_not_enable_arming_in_a_new_container() {
+        let temp = tempfile::tempdir().unwrap();
+        let agent = temp.path().join("smolvm-agent");
+        let state = temp.path().join("forkpoint");
+        std::fs::write(&agent, b"agent").unwrap();
+        std::fs::set_permissions(&agent, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::create_dir(&state).unwrap();
+        let mut spec = spec();
+
+        inject_into_container_if(
+            &mut spec,
+            true,
+            false,
+            agent.to_str().unwrap(),
+            state.to_str().unwrap(),
+        );
+
+        let prefix = format!("{}=", smolvm_protocol::guest_env::BRANCHPOINT_ARMING);
+        assert!(spec
+            .process
+            .env
+            .iter()
+            .all(|entry| !entry.starts_with(&prefix)));
+    }
+
+    #[test]
     fn helper_blocks_until_release_marker() {
         let temp = tempfile::tempdir().unwrap();
         let state = temp.path().join("forkpoint");
         let ready = state.join("ready");
         let restored = state.join("restored");
         let release = state.join("release");
+        let arm = state.join("arm");
+        let armed = state.join("armed");
         std::fs::create_dir(&state).unwrap();
 
         let state_thread = state.clone();
@@ -387,11 +595,16 @@ mod tests {
         let release_thread = release.clone();
         let helper = std::thread::spawn(move || {
             run_helper_at(
-                &state_thread,
-                &ready_thread,
-                &state_thread.join("restored"),
-                &release_thread,
+                ForkpointPaths {
+                    state_dir: &state_thread,
+                    ready_path: &ready_thread,
+                    restored_path: &state_thread.join("restored"),
+                    release_path: &release_thread,
+                    arm_path: &state_thread.join("arm"),
+                    armed_path: &state_thread.join("armed"),
+                },
                 Duration::from_millis(1),
+                false,
                 false,
             )
         });
@@ -406,6 +619,8 @@ mod tests {
         std::fs::write(&release, format!("{RELEASE_PREFIX}{generation}\n")).unwrap();
         helper.join().unwrap().unwrap();
         assert!(!ready.exists());
+        assert!(!arm.exists());
+        assert!(!armed.exists());
     }
 
     #[test]
@@ -423,11 +638,16 @@ mod tests {
         let release_thread = release.clone();
         let helper = std::thread::spawn(move || {
             run_helper_at(
-                &state_thread,
-                &ready_thread,
-                &restored_thread,
-                &release_thread,
+                ForkpointPaths {
+                    state_dir: &state_thread,
+                    ready_path: &ready_thread,
+                    restored_path: &restored_thread,
+                    release_path: &release_thread,
+                    arm_path: &state_thread.join("arm"),
+                    armed_path: &state_thread.join("armed"),
+                },
                 Duration::from_secs(60),
+                false,
                 false,
             )
         });
@@ -437,6 +657,62 @@ mod tests {
         std::fs::write(&release, format!("{RELEASE_PREFIX}{generation}\n")).unwrap();
         helper.join().unwrap().unwrap();
         assert!(!ready.exists());
+    }
+
+    #[test]
+    fn armable_helper_sleeps_until_capture_and_parks_again_after_disarm() {
+        let temp = tempfile::tempdir().unwrap();
+        let state = temp.path().join("forkpoint");
+        let ready = state.join("ready");
+        let restored = state.join("restored");
+        let release = state.join("release");
+        let arm = state.join("arm");
+        let armed = state.join("armed");
+        std::fs::create_dir(&state).unwrap();
+
+        let state_thread = state.clone();
+        let ready_thread = ready.clone();
+        let restored_thread = restored.clone();
+        let release_thread = release.clone();
+        let arm_thread = arm.clone();
+        let armed_thread = armed.clone();
+        let helper = std::thread::spawn(move || {
+            run_helper_at(
+                ForkpointPaths {
+                    state_dir: &state_thread,
+                    ready_path: &ready_thread,
+                    restored_path: &restored_thread,
+                    release_path: &release_thread,
+                    arm_path: &arm_thread,
+                    armed_path: &armed_thread,
+                },
+                Duration::from_millis(1),
+                false,
+                true,
+            )
+        });
+        wait_for_marker(&ready);
+        let generation = marker_generation(&ready);
+        assert!(!armed.exists());
+
+        std::fs::write(&arm, format!("{ARM_PREFIX}{generation}\n")).unwrap();
+        wait_for_marker(&armed);
+        assert!(marker_matches(&armed, ARMED_PREFIX, &generation));
+        std::fs::remove_file(&arm).unwrap();
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while armed.exists() && std::time::Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert!(!armed.exists());
+        assert!(!helper.is_finished());
+
+        std::fs::write(&arm, format!("{ARM_PREFIX}{generation}\n")).unwrap();
+        wait_for_marker(&armed);
+        std::fs::write(&restored, b"restored\n").unwrap();
+        std::fs::write(&release, format!("{RELEASE_PREFIX}{generation}\n")).unwrap();
+        helper.join().unwrap().unwrap();
+        assert!(!ready.exists());
+        assert!(!armed.exists());
     }
 
     #[test]

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -2313,10 +2313,17 @@ fn handle_request(
     }
 
     match request {
-        AgentRequest::Ping => AgentResponse::Pong {
-            version: PROTOCOL_VERSION,
-            capabilities: vec![smolvm_protocol::forkpoint::WORKER_READY_CAPABILITY.to_string()],
-        },
+        AgentRequest::Ping => {
+            let mut capabilities =
+                vec![smolvm_protocol::forkpoint::WORKER_READY_CAPABILITY.to_string()];
+            if forkpoint::arming_enabled() {
+                capabilities.push(smolvm_protocol::forkpoint::ARMING_CAPABILITY.to_string());
+            }
+            AgentResponse::Pong {
+                version: PROTOCOL_VERSION,
+                capabilities,
+            }
+        }
 
         AgentRequest::FsNotify { events } => handle_fsnotify(&events),
 

--- a/crates/smolvm-protocol/src/forkpoint.rs
+++ b/crates/smolvm-protocol/src/forkpoint.rs
@@ -19,6 +19,21 @@ pub const CUDA_PRELOAD_MODULES_HINT: &str = "cuda-preload-modules";
 /// Agent capability required by readiness-gated fork-pool leases.
 pub const WORKER_READY_CAPABILITY: &str = "fork-worker-ready-v1";
 
+/// Agent capability for parking an idle branchpoint until the host arms it.
+pub const ARMING_CAPABILITY: &str = "branchpoint-arming-v1";
+
+/// Host marker that asks the branchpoint helper to enter its capture-safe loop.
+pub const ARM_PATH: &str = "/run/smolvm/forkpoint/arm";
+
+/// Helper acknowledgement that it is safe for the host to capture the vCPU.
+pub const ARMED_PATH: &str = "/run/smolvm/forkpoint/armed";
+
+/// Generation-addressed arm marker prefix.
+pub const ARM_PREFIX: &str = "smolvm-forkpoint-arm-v1:";
+
+/// Generation-addressed arm acknowledgement prefix.
+pub const ARMED_PREFIX: &str = "smolvm-forkpoint-armed-v1:";
+
 /// Marker written after a restored clone can safely enter ordinary timed waits.
 pub const RESTORED_PATH: &str = "/run/smolvm/forkpoint/restored";
 

--- a/crates/smolvm-protocol/src/guest_env.rs
+++ b/crates/smolvm-protocol/src/guest_env.rs
@@ -35,6 +35,14 @@ pub const CUDA_ZEROCOPY: &str = "SMOLVM_CUDA_ZEROCOPY";
 /// Fork clones inherit the already-running helper from the golden snapshot.
 pub const FORKABLE: &str = "SMOLVM_FORKABLE";
 
+/// The host can arm a branchpoint immediately before capture.
+///
+/// New agents use this handshake to sleep while a branchable source is idle,
+/// then enter the restore-safe userspace loop only for the brief capture
+/// window. An older host does not set the sentinel, so a newer agent preserves
+/// the legacy always-spinning behavior and remains compatible.
+pub const BRANCHPOINT_ARMING: &str = "SMOLVM_BRANCHPOINT_ARMING";
+
 /// Planned CUDA fork-pool size passed to the guest agent.
 ///
 /// The agent uses this to select fork-friendly workload defaults only when a

--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -261,6 +261,114 @@ pub fn wait_for_forkpoint(golden: &str, timeout: Duration) -> Result<()> {
     }
 }
 
+fn build_arm_forkpoint_script() -> String {
+    format!(
+        "if [ ! -f '{ready}' ]; then exit 3; fi; \
+         generation=$(sed -n 's/^{generation_prefix}//p' '{ready}' | head -n 1); \
+         case \"$generation\" in ''|*[!0-9a-fA-F]*) exit 4 ;; esac; \
+         [ \"${{#generation}}\" -eq 32 ] || exit 4; \
+         rm -f '{arm}'; \
+         i=0; while [ -e '{armed}' ]; do \
+           i=$((i + 1)); [ \"$i\" -lt 400 ] || exit 47; sleep 0.005; \
+         done; \
+         printf '%s%s\\n' '{arm_prefix}' \"$generation\" > '{arm}.tmp'; \
+         mv '{arm}.tmp' '{arm}'; \
+         i=0; until grep -q -x '{armed_prefix}'\"$generation\" '{armed}' 2>/dev/null; do \
+           i=$((i + 1)); [ \"$i\" -lt 400 ] || exit 47; sleep 0.005; \
+         done",
+        arm = smolvm_protocol::forkpoint::ARM_PATH,
+        armed = smolvm_protocol::forkpoint::ARMED_PATH,
+        arm_prefix = smolvm_protocol::forkpoint::ARM_PREFIX,
+        armed_prefix = smolvm_protocol::forkpoint::ARMED_PREFIX,
+        generation_prefix = smolvm_protocol::forkpoint::GENERATION_PREFIX,
+        ready = smolvm_protocol::forkpoint::READY_PATH,
+    )
+}
+
+/// Put a negotiated workload helper into its restore-safe userspace loop just
+/// before capture. A branchable machine without a helper remains a valid
+/// immediate snapshot source, and an older guest keeps its legacy loop.
+fn arm_forkpoint_for_capture(golden: &str) -> Result<bool> {
+    let socket = vm_data_dir(golden).join("agent.sock");
+    let mut client = AgentClient::connect_with_retry(&socket)
+        .map_err(|e| Error::agent("arm branchpoint", format!("agent connect: {e}")))?;
+    if !client
+        .supports_capability(smolvm_protocol::forkpoint::ARMING_CAPABILITY)
+        .map_err(|e| Error::agent("arm branchpoint", e.to_string()))?
+    {
+        return Ok(false);
+    }
+    match client.vm_exec(
+        vec!["/bin/sh".into(), "-c".into(), build_arm_forkpoint_script()],
+        vec![],
+        None,
+        Some(Duration::from_secs(3)),
+        None,
+    ) {
+        Ok((0, _, _)) => Ok(true),
+        Ok((3, _, _)) => Ok(false),
+        Ok((47, _, _)) => Err(Error::agent(
+            "arm branchpoint",
+            format!("source '{golden}' did not acknowledge the capture arm marker"),
+        )),
+        Ok((code, _, stderr)) => Err(Error::agent(
+            "arm branchpoint",
+            format!(
+                "source '{golden}' arm exited {code}: {}",
+                String::from_utf8_lossy(&stderr).trim()
+            ),
+        )),
+        Err(error) => Err(Error::agent(
+            "arm branchpoint",
+            format!("source '{golden}': {error}"),
+        )),
+    }
+}
+
+fn build_park_forkpoint_script() -> String {
+    format!(
+        "rm -f '{arm}'; \
+         i=0; while [ -e '{armed}' ]; do \
+           i=$((i + 1)); [ \"$i\" -lt 400 ] || exit 47; sleep 0.005; \
+         done",
+        arm = smolvm_protocol::forkpoint::ARM_PATH,
+        armed = smolvm_protocol::forkpoint::ARMED_PATH,
+    )
+}
+
+/// Park the continued source after capture. Failure is reported to the caller,
+/// which can retain the valid snapshot while making the performance fault
+/// visible instead of corrupting a completed branch generation.
+fn park_forkpoint_after_capture(golden: &str) -> Result<()> {
+    let socket = vm_data_dir(golden).join("agent.sock");
+    let mut client = AgentClient::connect_with_retry(&socket)
+        .map_err(|e| Error::agent("park branchpoint", format!("agent connect: {e}")))?;
+    match client.vm_exec(
+        vec!["/bin/sh".into(), "-c".into(), build_park_forkpoint_script()],
+        vec![],
+        None,
+        Some(Duration::from_secs(3)),
+        None,
+    ) {
+        Ok((0, _, _)) => Ok(()),
+        Ok((47, _, _)) => Err(Error::agent(
+            "park branchpoint",
+            format!("source '{golden}' did not leave its capture loop"),
+        )),
+        Ok((code, _, stderr)) => Err(Error::agent(
+            "park branchpoint",
+            format!(
+                "source '{golden}' park exited {code}: {}",
+                String::from_utf8_lossy(&stderr).trim()
+            ),
+        )),
+        Err(error) => Err(Error::agent(
+            "park branchpoint",
+            format!("source '{golden}': {error}"),
+        )),
+    }
+}
+
 fn fork_base_already_paused(status: &str) -> bool {
     status.trim() == "OK paused"
 }
@@ -1653,10 +1761,25 @@ pub(crate) fn prepare_forks_reusing(
             return Err(error);
         }
 
+        let forkpoint_armed = match arm_forkpoint_for_capture(golden) {
+            Ok(armed) => armed,
+            Err(error) => {
+                // An acknowledgement timeout may still have left the helper in
+                // its capture loop. Best-effort parking keeps a failed capture
+                // from turning into a permanent host-CPU leak.
+                let _ = park_forkpoint_after_capture(golden);
+                let _ = std::fs::remove_dir_all(&snapshot_dir);
+                return Err(error);
+            }
+        };
+
         let fork_continue = fork_continue_enabled();
         if fork_continue {
             #[cfg(any(target_os = "linux", target_os = "macos"))]
             if let Err(error) = prepare_running_disk_generation(&gdir, &snapshot_dir, vm_ids) {
+                if forkpoint_armed {
+                    let _ = park_forkpoint_after_capture(golden);
+                }
                 let _ = std::fs::remove_dir_all(&snapshot_dir);
                 return Err(error);
             }
@@ -1677,6 +1800,11 @@ pub(crate) fn prepare_forks_reusing(
             "FORK"
         };
         let reply = control_socket_cmd(&ctl, &format!("{fork_verb} {}", snapshot_dir.display()));
+        if fork_continue && forkpoint_armed {
+            if let Err(error) = park_forkpoint_after_capture(golden) {
+                tracing::warn!(%golden, %error, "continued source did not park after capture");
+            }
+        }
         let reply = match reply {
             Ok(reply) if reply.starts_with("OK") => reply,
             Ok(reply) => {
@@ -3186,6 +3314,41 @@ mod tests {
             .expect("ready marker must be observed");
         assert!(publish < acknowledge);
         assert!(script.contains("exit 46"));
+    }
+
+    #[test]
+    fn forkpoint_arm_is_generation_scoped_and_waits_for_acknowledgement() {
+        let script = build_arm_forkpoint_script();
+        let ready = script
+            .find(smolvm_protocol::forkpoint::READY_PATH)
+            .expect("ready marker must be read");
+        let publish = script
+            .find(smolvm_protocol::forkpoint::ARM_PATH)
+            .expect("arm marker must be published");
+        let acknowledge = script
+            .rfind(smolvm_protocol::forkpoint::ARMED_PATH)
+            .expect("armed marker must be observed");
+
+        assert!(ready < publish);
+        assert!(publish < acknowledge);
+        assert!(script.contains(smolvm_protocol::forkpoint::GENERATION_PREFIX));
+        assert!(script.contains(smolvm_protocol::forkpoint::ARM_PREFIX));
+        assert!(script.contains(smolvm_protocol::forkpoint::ARMED_PREFIX));
+        assert!(script.contains("exit 47"));
+    }
+
+    #[test]
+    fn forkpoint_park_disarms_before_waiting_for_idle_acknowledgement() {
+        let script = build_park_forkpoint_script();
+        let disarm = script
+            .find(smolvm_protocol::forkpoint::ARM_PATH)
+            .expect("arm marker must be removed");
+        let idle_ack = script
+            .rfind(smolvm_protocol::forkpoint::ARMED_PATH)
+            .expect("armed marker removal must be observed");
+
+        assert!(disarm < idle_ack);
+        assert!(script.contains("exit 47"));
     }
 
     #[test]

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -1989,6 +1989,14 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
             )));
         }
 
+        if std::env::var(guest_env::BRANCHPOINT_ARMING).as_deref() == Ok(guest_env::VALUE_ON) {
+            env_strings.push(cstr(&format!(
+                "{}={}",
+                guest_env::BRANCHPOINT_ARMING,
+                guest_env::VALUE_ON
+            )));
+        }
+
         if let Ok(pool_size) = std::env::var(guest_env::CUDA_FORK_POOL_SIZE) {
             env_strings.push(cstr(&format!(
                 "{}={pool_size}",

--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -763,6 +763,14 @@ pub fn launch_agent_vm_dynamic(
         )));
     }
 
+    if std::env::var(guest_env::BRANCHPOINT_ARMING).as_deref() == Ok(guest_env::VALUE_ON) {
+        env_strings.push(cstr(&format!(
+            "{}={}",
+            guest_env::BRANCHPOINT_ARMING,
+            guest_env::VALUE_ON
+        )));
+    }
+
     // Enable Rosetta only when requested AND actually available on this host, so
     // a stray `--rosetta` on a non-Rosetta host degrades to a no-op rather than a
     // dangling virtiofs tag the guest would fail to mount. The guest agent reads

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -1983,6 +1983,10 @@ impl AgentManager {
             let mut v = Vec::new();
             if features.forkable {
                 v.push((smolvm_protocol::guest_env::FORKABLE, "1".to_string()));
+                v.push((
+                    smolvm_protocol::guest_env::BRANCHPOINT_ARMING,
+                    smolvm_protocol::guest_env::VALUE_ON.to_string(),
+                ));
             }
             // Embedder override for the control socket path; without it the
             // launcher defaults to control.sock in the per-VM dir.


### PR DESCRIPTION
Park ready branch sources until a negotiated capture arm arrives, eliminating the idle vCPU spin while preserving rolling host-agent compatibility.