### PR TITLE
Project create parameters onto a machine record in one place

### DIFF
--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -1822,46 +1822,34 @@ impl RunCmd {
                             &mut config,
                             &vm_name,
                             manager.child_pid(),
-                            Some(DefaultVmOverrides {
-                                // Persist the REFS (re-resolved at each start via
-                                // record_env_with_secrets), never the resolved
-                                // plaintext — see `env` below.
-                                secret_refs: params.secret_refs.clone(),
-                                cpus: params.cpus,
-                                mem: params.mem,
-                                mounts: mount_tuples,
-                                staged_mounts,
-                                ports: port_tuples,
-                                network: params.net,
-                                network_backend: params.network_backend,
-                                dns: params.dns,
-                                network_name: params.network_name.clone(),
-                                storage_gb: params.storage_gb,
-                                overlay_gb: params.overlay_gb,
-                                allowed_cidrs: params.allowed_cidrs.clone(),
-                                init: params.init.clone(),
-                                // Strip resolved secret values so plaintext never
-                                // reaches the DB/pack record. defaults.env still
-                                // carries them for RUNNING the container above; the
-                                // record keeps only refs + non-secret env.
-                                env: defaults
+                            Some({
+                                let mut o = DefaultVmOverrides::from_create_params(
+                                    &params,
+                                    mount_tuples,
+                                    staged_mounts,
+                                    port_tuples,
+                                );
+                                // An image machine records what the image
+                                // resolved to: its env (minus secret values, which
+                                // stay as refs), workdir and user, the image itself
+                                // and the workload command.
+                                o.env = defaults
                                     .env
                                     .iter()
                                     .filter(|(k, _)| !params.secret_refs.contains_key(k))
                                     .cloned()
-                                    .collect(),
-                                workdir: defaults.workdir.clone(),
-                                user: defaults.user.clone(),
-                                image: Some(img.clone()),
-                                entrypoint: Vec::new(),
-                                cmd: command.clone(),
-                                ssh_agent: self.ssh_agent || params.ssh_agent,
-                                cuda: self.cuda || params.cuda,
-                                docker_socket: self.docker_socket || params.docker_socket,
-                                dns_filter_hosts: params.dns_filter_hosts.clone(),
-                                gpu: self.gpu || params.gpu,
-                                gpu_vram_mib: self.gpu_vram_mib.or(params.gpu_vram_mib),
-                                rosetta: self.rosetta || params.rosetta,
+                                    .collect();
+                                o.workdir = defaults.workdir.clone();
+                                o.user = defaults.user.clone();
+                                o.image = Some(img.clone());
+                                o.entrypoint = Vec::new();
+                                o.cmd = command.clone();
+                                o.ssh_agent = self.ssh_agent || o.ssh_agent;
+                                o.cuda = self.cuda || o.cuda;
+                                o.docker_socket = self.docker_socket || o.docker_socket;
+                                o.gpu = self.gpu || o.gpu;
+                                o.gpu_vram_mib = self.gpu_vram_mib.or(o.gpu_vram_mib);
+                                o
                             }),
                         )
                     });
@@ -1995,36 +1983,23 @@ impl RunCmd {
                         &mut config,
                         &vm_name,
                         manager.child_pid(),
-                        Some(DefaultVmOverrides {
-                            // Persist the refs so secrets re-resolve on restart
-                            // (env below is already secret-free: parse_env_list).
-                            secret_refs: params.secret_refs.clone(),
-                            cpus: params.cpus,
-                            mem: params.mem,
-                            mounts: mount_tuples,
-                            staged_mounts,
-                            ports: port_tuples,
-                            network: params.net,
-                            network_backend: params.network_backend,
-                            dns: params.dns,
-                            network_name: params.network_name.clone(),
-                            storage_gb: params.storage_gb,
-                            overlay_gb: params.overlay_gb,
-                            allowed_cidrs: params.allowed_cidrs.clone(),
-                            init: params.init.clone(),
-                            env: parse_env_list(&params.env),
-                            workdir: params.workdir.clone(),
-                            user: params.user.clone(),
-                            image: None,
-                            entrypoint: params.entrypoint.clone(),
-                            cmd: params.cmd.clone(),
-                            ssh_agent: self.ssh_agent || params.ssh_agent,
-                            cuda: self.cuda || params.cuda,
-                            docker_socket: self.docker_socket || params.docker_socket,
-                            dns_filter_hosts: params.dns_filter_hosts.clone(),
-                            gpu: self.gpu || params.gpu,
-                            gpu_vram_mib: self.gpu_vram_mib.or(params.gpu_vram_mib),
-                            rosetta: false,
+                        Some({
+                            let mut o = DefaultVmOverrides::from_create_params(
+                                &params,
+                                mount_tuples,
+                                staged_mounts,
+                                port_tuples,
+                            );
+                            // A one-shot run keeps no image on its record; the
+                            // command line flags may enable features on top of
+                            // what the Smolfile asked for.
+                            o.image = None;
+                            o.ssh_agent = self.ssh_agent || o.ssh_agent;
+                            o.cuda = self.cuda || o.cuda;
+                            o.docker_socket = self.docker_socket || o.docker_socket;
+                            o.gpu = self.gpu || o.gpu;
+                            o.gpu_vram_mib = self.gpu_vram_mib.or(o.gpu_vram_mib);
+                            o
                         }),
                     )?;
                 }

--- a/src/cli/smolfile.rs
+++ b/src/cli/smolfile.rs
@@ -528,6 +528,96 @@ mod tests {
         )
     }
 
+    /// Every launch setting a Smolfile can express must reach every carrier
+    /// it is later read from. Each hop below is the one function that path
+    /// uses, so a setting added to the Smolfile but not carried by one of them
+    /// fails here instead of surfacing as a machine that silently ignores it
+    /// (which is how `user` was lost once on the record and once on the pack
+    /// manifest). Add a line per hop when adding a launch setting.
+    #[test]
+    fn every_launch_setting_survives_every_hop() {
+        use crate::cli::vm_common::{apply_overrides, build_vm_record, DefaultVmOverrides};
+        use smolvm::config::VmRecord;
+        use smolvm::pack_export::{seed_manifest_from_vm, FromVmAssets};
+        use smolvm_pack::format::{PackManifest, PackMode};
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("Smolfile");
+        std::fs::write(
+            &path,
+            r#"
+image = "library/alpine:latest"
+net = true
+entrypoint = ["/bin/sh", "-c"]
+cmd = ["sleep infinity"]
+env = ["GREETING=hello", "EMPTY="]
+workdir = "/srv/app"
+user = "501:20"
+init = ["echo init"]
+"#,
+        )
+        .unwrap();
+        let params = build_from_smolfile(path).unwrap();
+
+        // Hop 1: Smolfile -> create params.
+        assert_eq!(params.image.as_deref(), Some("library/alpine:latest"));
+        assert_eq!(params.entrypoint, vec!["/bin/sh", "-c"]);
+        assert_eq!(params.cmd, vec!["sleep infinity"]);
+        assert_eq!(params.env, vec!["GREETING=hello", "EMPTY="]);
+        assert_eq!(params.workdir.as_deref(), Some("/srv/app"));
+        assert_eq!(params.user.as_deref(), Some("501:20"));
+        assert_eq!(params.init, vec!["echo init"]);
+
+        // Hop 2a: create params -> record, the `machine create` path.
+        let created = build_vm_record(&params).unwrap();
+        assert_eq!(created.image, params.image);
+        assert_eq!(created.entrypoint, params.entrypoint);
+        assert_eq!(created.cmd, params.cmd);
+        assert_eq!(
+            created.env,
+            vec![
+                ("GREETING".to_string(), "hello".to_string()),
+                ("EMPTY".to_string(), String::new())
+            ]
+        );
+        assert_eq!(created.workdir, params.workdir);
+        assert_eq!(created.user, params.user);
+        assert_eq!(created.init, params.init);
+
+        // Hop 2b: create params -> overrides -> record, the `run` and
+        // first-launch paths.
+        let overrides = DefaultVmOverrides::from_create_params(&params, vec![], vec![], vec![]);
+        let mut persisted = VmRecord::new("parity".to_string(), 1, 512, vec![], vec![], true);
+        apply_overrides(&mut persisted, &overrides);
+        assert_eq!(persisted.image, params.image);
+        assert_eq!(persisted.entrypoint, params.entrypoint);
+        assert_eq!(persisted.cmd, params.cmd);
+        assert_eq!(persisted.env, created.env);
+        assert_eq!(persisted.workdir, params.workdir);
+        assert_eq!(persisted.user, params.user);
+        assert_eq!(persisted.init, params.init);
+
+        // Hop 3: record -> pack manifest, the `pack create --from-vm` path.
+        let mut manifest = PackManifest::new(
+            "library/alpine:latest".to_string(),
+            "sha256:0".to_string(),
+            "linux/arm64".to_string(),
+            "darwin/arm64".to_string(),
+        );
+        let assets = FromVmAssets {
+            mode: PackMode::Container,
+            image: params.image.clone(),
+            image_env: vec![],
+            layer_bytes: 0,
+        };
+        seed_manifest_from_vm(&mut manifest, &persisted, &assets);
+        assert_eq!(manifest.entrypoint, params.entrypoint);
+        assert_eq!(manifest.cmd, params.cmd);
+        assert!(manifest.env.contains(&"GREETING=hello".to_string()));
+        assert_eq!(manifest.workdir, params.workdir);
+        assert_eq!(manifest.user, params.user);
+    }
+
     #[test]
     fn smolfile_port_ranges_expand_before_create() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -1797,6 +1797,43 @@ fn start_vm_named_with_db(
 ///
 /// Creates the record if it doesn't exist, then updates state to Running
 /// with the current PID and optional config overrides (cpus, mem, etc.).
+/// The one place a machine record takes its settings from a set of overrides.
+///
+/// Every field a record carries for a workload is written here and nowhere
+/// else, so a setting added to [`DefaultVmOverrides`] cannot be persisted on
+/// one path and dropped on another. Covered by the launch-settings round-trip
+/// test in this module.
+pub(crate) fn apply_overrides(r: &mut VmRecord, o: &DefaultVmOverrides) {
+    r.cpus = o.cpus;
+    r.mem = o.mem;
+    r.mounts = o.mounts.clone();
+    r.staged_mounts = o.staged_mounts.clone();
+    r.ports = o.ports.clone();
+    r.network = o.network;
+    r.network_backend = o.network_backend;
+    r.dns = o.dns;
+    r.network_name = o.network_name.clone();
+    r.storage_gb = o.storage_gb;
+    r.overlay_gb = o.overlay_gb;
+    r.allowed_cidrs = o.allowed_cidrs.clone();
+    r.init = o.init.clone();
+    r.init_completed = false;
+    r.env = o.env.clone();
+    r.secret_refs = o.secret_refs.clone();
+    r.workdir = o.workdir.clone();
+    r.user = o.user.clone();
+    r.image = o.image.clone();
+    r.entrypoint = o.entrypoint.clone();
+    r.cmd = o.cmd.clone();
+    r.ssh_agent = o.ssh_agent;
+    r.cuda = o.cuda;
+    r.docker_socket = o.docker_socket;
+    r.dns_filter_hosts = o.dns_filter_hosts.clone();
+    r.gpu = if o.gpu { Some(true) } else { None };
+    r.gpu_vram_mib = o.gpu_vram_mib;
+    r.rosetta = if o.rosetta { Some(true) } else { None };
+}
+
 pub fn persist_named_running(
     config: &mut SmolvmConfig,
     name: &str,
@@ -1821,34 +1858,7 @@ pub fn persist_named_running(
             r.pid = pid;
             r.pid_start_time = pid_start_time;
             if let Some(ref o) = overrides {
-                r.cpus = o.cpus;
-                r.mem = o.mem;
-                r.mounts = o.mounts.clone();
-                r.staged_mounts = o.staged_mounts.clone();
-                r.ports = o.ports.clone();
-                r.network = o.network;
-                r.network_backend = o.network_backend;
-                r.dns = o.dns;
-                r.network_name = o.network_name.clone();
-                r.storage_gb = o.storage_gb;
-                r.overlay_gb = o.overlay_gb;
-                r.allowed_cidrs = o.allowed_cidrs.clone();
-                r.init = o.init.clone();
-                r.init_completed = false;
-                r.env = o.env.clone();
-                r.secret_refs = o.secret_refs.clone();
-                r.workdir = o.workdir.clone();
-                r.user = o.user.clone();
-                r.image = o.image.clone();
-                r.entrypoint = o.entrypoint.clone();
-                r.cmd = o.cmd.clone();
-                r.ssh_agent = o.ssh_agent;
-                r.cuda = o.cuda;
-                r.docker_socket = o.docker_socket;
-                r.dns_filter_hosts = o.dns_filter_hosts.clone();
-                r.gpu = if o.gpu { Some(true) } else { None };
-                r.gpu_vram_mib = o.gpu_vram_mib;
-                r.rosetta = if o.rosetta { Some(true) } else { None };
+                apply_overrides(r, o);
             }
         })
         .ok_or_else(|| smolvm::Error::config(
@@ -1890,6 +1900,52 @@ pub struct DefaultVmOverrides {
     pub gpu: bool,
     pub gpu_vram_mib: Option<u32>,
     pub rosetta: bool,
+}
+
+impl DefaultVmOverrides {
+    /// The one projection of create parameters onto the settings a machine
+    /// record keeps. Both the image-machine and the one-shot `run` path build
+    /// their record through here and then adjust only what is genuinely
+    /// path-specific (the image-resolved env, workdir and user; the image and
+    /// command). Before this each path spelled the projection out by hand, and
+    /// the two copies drifted: one persisted `user` while the other silently
+    /// wrote `None`.
+    pub(crate) fn from_create_params(
+        params: &CreateVmParams,
+        mounts: Vec<(String, String, bool)>,
+        staged_mounts: Vec<(usize, String, String)>,
+        ports: Vec<(u16, u16)>,
+    ) -> Self {
+        Self {
+            secret_refs: params.secret_refs.clone(),
+            cpus: params.cpus,
+            mem: params.mem,
+            mounts,
+            staged_mounts,
+            ports,
+            network: params.net,
+            network_backend: params.network_backend,
+            dns: params.dns,
+            network_name: params.network_name.clone(),
+            storage_gb: params.storage_gb,
+            overlay_gb: params.overlay_gb,
+            allowed_cidrs: params.allowed_cidrs.clone(),
+            init: params.init.clone(),
+            env: smolvm::util::parse_env_list(&params.env),
+            workdir: params.workdir.clone(),
+            user: params.user.clone(),
+            image: params.image.clone(),
+            entrypoint: params.entrypoint.clone(),
+            cmd: params.cmd.clone(),
+            ssh_agent: params.ssh_agent,
+            cuda: params.cuda,
+            docker_socket: params.docker_socket,
+            dns_filter_hosts: params.dns_filter_hosts.clone(),
+            gpu: params.gpu,
+            gpu_vram_mib: params.gpu_vram_mib,
+            rosetta: false,
+        }
+    }
 }
 
 /// Check if any running VM already binds to the same host ports.


### PR DESCRIPTION
One conversion per hop plus a round-trip test, so a launch setting can no longer be kept on one path and dropped on another.