### PR TITLE
Stamp the bundled virglrenderer with its sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
       # (issue #636). Gate every push so a wrong-host lib can't ship again.
       - name: Bundled libkrun keeps a glibc floor <= 2.35
         run: ./scripts/check-libkrun-glibc-floor.sh
+      - name: Check bundled virglrenderer matches its patch set
+        run: ./scripts/check-virglrenderer-provenance.sh
 
   audit:
     name: Cargo Audit

--- a/lib/libvirglrenderer.provenance
+++ b/lib/libvirglrenderer.provenance
@@ -1,0 +1,2 @@
+virglrenderer=0.10.4e-krunkit
+patches=8242cb6e82b6c1b5

--- a/scripts/build-virglrenderer-macos.sh
+++ b/scripts/build-virglrenderer-macos.sh
@@ -62,4 +62,11 @@ otool -L "$OUT" | awk 'NR>1 {print $1}' | grep -E 'libMoltenVK|libepoxy' | while
 done
 codesign --force --sign - "$OUT" 2>/dev/null
 echo "Installed: $OUT"
+# Record what this library was built from, so CI can tell when the patch set
+# or version moves on without a rebuild (scripts/check-virglrenderer-provenance.sh).
+cat > "$(dirname "$OUT")/libvirglrenderer.provenance" <<PROV
+virglrenderer=$VIRGL_VERSION
+patches=$("$ROOT/scripts/virglrenderer-patch-digest.sh")
+PROV
+echo "Stamped: $(dirname "$OUT")/libvirglrenderer.provenance"
 otool -L "$OUT" | grep -E '@loader_path|MoltenVK|epoxy' | sed 's/^/  /'

--- a/scripts/check-virglrenderer-provenance.sh
+++ b/scripts/check-virglrenderer-provenance.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Verify that the bundled macOS virglrenderer was built from the sources the
+# tree currently describes: the krunkit tarball version named in
+# scripts/build-virglrenderer-macos.sh and the patches in patches/virglrenderer/.
+#
+# The library is a checked-in binary that the release copies as-is, so a change
+# to the bridge patch reaches nobody until the library is rebuilt. Without this
+# guard such a change merges green and ships nothing. Exit codes:
+#   PASS → lib/libvirglrenderer.provenance matches the version and patch set
+#   FAIL → the stamp is missing or was made from different sources
+set -euo pipefail
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+LIB="lib/libvirglrenderer.1.dylib"
+PROV="lib/libvirglrenderer.provenance"
+[[ -f "$LIB" ]] || { echo "SKIP  no $LIB in this tree"; exit 0; }
+
+want_version="$(sed -n 's/^VIRGL_VERSION="\(.*\)"$/\1/p' scripts/build-virglrenderer-macos.sh)"
+want_patches="$(scripts/virglrenderer-patch-digest.sh)"
+
+if [[ ! -f "$PROV" ]]; then
+  echo "FAIL  $LIB has no $PROV — the sources it was built from are unknown."
+  echo "      Rebuild and stamp with: ./scripts/build-virglrenderer-macos.sh"
+  exit 1
+fi
+got_version="$(grep '^virglrenderer=' "$PROV" | cut -d= -f2-)"
+got_patches="$(grep '^patches=' "$PROV" | cut -d= -f2-)"
+
+fail=0
+if [[ "$got_version" != "$want_version" ]]; then
+  echo "FAIL  $LIB was built from virglrenderer $got_version but the build script names $want_version"; fail=1
+fi
+if [[ "$got_patches" != "$want_patches" ]]; then
+  echo "FAIL  $LIB was built with patch set $got_patches but patches/virglrenderer/ now hashes to $want_patches"
+  echo "      The bridge patch changed without a rebuild, so the change would ship nothing."; fail=1
+fi
+if [[ "$fail" == "1" ]]; then
+  echo "      Rebuild and stamp with: ./scripts/build-virglrenderer-macos.sh"
+  exit 1
+fi
+echo "OK    $LIB (virglrenderer=$got_version patches=$got_patches)"

--- a/scripts/virglrenderer-patch-digest.sh
+++ b/scripts/virglrenderer-patch-digest.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Print one digest for the whole patch set in patches/virglrenderer/, in name
+# order, so the same patches always yield the same value on any host.
+set -euo pipefail
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if command -v sha256sum >/dev/null 2>&1; then
+  cat $(ls patches/virglrenderer/*.patch | sort) | sha256sum | cut -c1-16
+else
+  cat $(ls patches/virglrenderer/*.patch | sort) | shasum -a 256 | cut -c1-16
+fi


### PR DESCRIPTION
Fails CI when the bridge patch or version changes without the library being rebuilt.