### PR TITLE
Bump libkrun to the NVIDIA fence-thread fix and rebuild the Linux blobs

### DIFF
--- a/lib/libkrun.dylib
+++ b/lib/libkrun.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:82fe6accf7e33f4976a4b00e360bcfc22313a2a35d8bbd714fe76ce5ad687ca6
+oid sha256:2d302eb3e2f3c496323b252e12bdb3412b644def68eb693ac5ecafc88cb2bcbc
 size 6716944

--- a/lib/libkrun.provenance
+++ b/lib/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=a11021850b8066fb6c7a58871e8724cf2715f130
+libkrun=f4cb46a5e6189872394d205494c14e9a6974816c
 libkrunfw=55bb7c5273178826240b39e907475fb6011afd8e

--- a/lib/linux-aarch64/libkrun.provenance
+++ b/lib/linux-aarch64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=a11021850b8066fb6c7a58871e8724cf2715f130
+libkrun=f4cb46a5e6189872394d205494c14e9a6974816c
 libkrunfw=55bb7c5273178826240b39e907475fb6011afd8e

--- a/lib/linux-aarch64/libkrun.so
+++ b/lib/linux-aarch64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aa528ed6a3556ad3fa553e2a1c472aeefec9851e2a3b0da140d72974bced8aed
-size 7677832
+oid sha256:9d62bc48a0b5976afd1ed0a840275f1ea2381f2984744db2a98a12082159a9d3
+size 7690424

--- a/lib/linux-aarch64/libkrun.so.2.0.0
+++ b/lib/linux-aarch64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aa528ed6a3556ad3fa553e2a1c472aeefec9851e2a3b0da140d72974bced8aed
-size 7677832
+oid sha256:9d62bc48a0b5976afd1ed0a840275f1ea2381f2984744db2a98a12082159a9d3
+size 7690424

--- a/lib/linux-x86_64/libkrun.provenance
+++ b/lib/linux-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=a11021850b8066fb6c7a58871e8724cf2715f130
+libkrun=f4cb46a5e6189872394d205494c14e9a6974816c
 libkrunfw=55bb7c5273178826240b39e907475fb6011afd8e

--- a/lib/linux-x86_64/libkrun.so
+++ b/lib/linux-x86_64/libkrun.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2d3511bbaba63fd5f7d61e4d27483d3493be140f37c564a0347726a10a5614be
-size 8516448
+oid sha256:3f021ac366152b33c7c329f893804fa9adda5d4352fac4b88214ae28fb89ebd0
+size 8515720

--- a/lib/linux-x86_64/libkrun.so.2.0.0
+++ b/lib/linux-x86_64/libkrun.so.2.0.0
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2d3511bbaba63fd5f7d61e4d27483d3493be140f37c564a0347726a10a5614be
-size 8516448
+oid sha256:3f021ac366152b33c7c329f893804fa9adda5d4352fac4b88214ae28fb89ebd0
+size 8515720

--- a/lib/windows-x86_64/libkrun.provenance
+++ b/lib/windows-x86_64/libkrun.provenance
@@ -2,5 +2,5 @@
 # The libkrun/libkrunfw submodule commits the bundled libs in this dir were
 # built from. Verified against the pinned submodules by
 # scripts/check-libkrun-provenance.sh (run in CI).
-libkrun=a11021850b8066fb6c7a58871e8724cf2715f130
+libkrun=f4cb46a5e6189872394d205494c14e9a6974816c
 libkrunfw=55bb7c5273178826240b39e907475fb6011afd8e


### PR DESCRIPTION
Stops --gpu machines from crashing on NVIDIA hosts, verified on the affected host.