### PR TITLE
Bump the workspace to 1.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3078,7 +3078,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smolfile"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "serde",
  "smolvm-protocol",
@@ -3104,7 +3104,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -3166,7 +3166,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-agent"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "flate2",
  "lazy_static",
@@ -3189,7 +3189,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "getrandom 0.3.4",
  "libc",
@@ -3198,11 +3198,11 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda-codegen"
-version = "1.13.1"
+version = "1.14.0"
 
 [[package]]
 name = "smolvm-cuda-guest"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "smolvm-cuda",
  "vsock",
@@ -3210,7 +3210,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cuda-shim"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "libc",
  "smolvm-cuda",
@@ -3219,7 +3219,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-cudart-shim"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "libc",
  "smolvm-cuda",
@@ -3228,7 +3228,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-network"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "crossbeam-queue",
  "humantime",
@@ -3242,14 +3242,14 @@ dependencies = [
 
 [[package]]
 name = "smolvm-nvml-shim"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "smolvm-oci-layer"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "flate2",
  "libc",
@@ -3262,7 +3262,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-pack"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "crc32fast",
  "dirs",
@@ -3281,7 +3281,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-protocol"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "base64",
  "serde",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-registry"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "bytes",
  "dirs",
@@ -3313,7 +3313,7 @@ dependencies = [
 
 [[package]]
 name = "smolvm-s3fs"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "hmac",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "2"
 
 [package]
 name = "smolvm"
-version = "1.13.1"
+version = "1.14.0"
 edition = "2021"
 description = "OCI-native microVM runtime"
 license = "Apache-2.0"
@@ -38,12 +38,12 @@ name = "smolvm"
 path = "src/main.rs"
 
 [dependencies]
-smolvm-network = { path = "crates/smolvm-network", version = "1.7.5" }
-smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.7.5" }
-smolvm-cuda = { path = "crates/smolvm-cuda", version = "1.7.5" }
-smolvm-pack = { path = "crates/smolvm-pack", version = "1.7.5" }
-smolvm-registry = { path = "crates/smolvm-registry", version = "1.7.5" }
-smolfile = { path = "crates/smolvm-smolfile", version = "1.7.5" }
+smolvm-network = { path = "crates/smolvm-network", version = "1.14.0" }
+smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.14.0" }
+smolvm-cuda = { path = "crates/smolvm-cuda", version = "1.14.0" }
+smolvm-pack = { path = "crates/smolvm-pack", version = "1.14.0" }
+smolvm-registry = { path = "crates/smolvm-registry", version = "1.14.0" }
+smolfile = { path = "crates/smolvm-smolfile", version = "1.14.0" }
 thiserror = "1"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
@@ -132,7 +132,7 @@ windows-sys = { version = "0.60", features = [
 
 [dev-dependencies]
 tempfile = "3"
-smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.7.5" }
+smolvm-protocol = { path = "crates/smolvm-protocol", version = "1.14.0" }
 regex = "1"
 tower = { version = "0.5", features = ["util"] }
 wiremock = "0.6"

--- a/crates/smolvm-agent/Cargo.toml
+++ b/crates/smolvm-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-agent"
-version = "1.13.1"
+version = "1.14.0"
 edition = "2021"
 description = "Guest agent for smolvm VMs (handles OCI operations and command execution)"
 license = "Apache-2.0"

--- a/crates/smolvm-cuda-codegen/Cargo.toml
+++ b/crates/smolvm-cuda-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda-codegen"
-version = "1.13.1"
+version = "1.14.0"
 edition = "2021"
 description = "Generates forward-to-host-lib marshaling (guest stubs + host dispatch) from a function spec"
 license = "Apache-2.0"

--- a/crates/smolvm-cuda-guest/Cargo.toml
+++ b/crates/smolvm-cuda-guest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda-guest"
-version = "1.13.1"
+version = "1.14.0"
 edition = "2021"
 description = "Guest-side CUDA-over-vsock runner for smolvm microVMs (Linux)"
 license = "Apache-2.0"

--- a/crates/smolvm-cuda-shim/Cargo.toml
+++ b/crates/smolvm-cuda-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda-shim"
-version = "1.13.1"
+version = "1.14.0"
 edition = "2021"
 description = "Guest-side libcuda.so.1 drop-in: CUDA Driver API over smolvm's vsock RPC"
 license = "Apache-2.0"

--- a/crates/smolvm-cuda/Cargo.toml
+++ b/crates/smolvm-cuda/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cuda"
-version = "1.13.1"
+version = "1.14.0"
 edition = "2021"
 description = "CUDA Driver-API remoting over vsock for smolvm guests"
 license = "Apache-2.0"

--- a/crates/smolvm-cudart-shim/Cargo.toml
+++ b/crates/smolvm-cudart-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-cudart-shim"
-version = "1.13.1"
+version = "1.14.0"
 edition = "2021"
 description = "Guest-side libcudart.so drop-in: CUDA Runtime API lowered to smolvm's Driver-API vsock RPC"
 license = "Apache-2.0"

--- a/crates/smolvm-network/Cargo.toml
+++ b/crates/smolvm-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-network"
-version = "1.13.1"
+version = "1.14.0"
 edition = "2021"
 description = "Host-side virtio-net runtime for smolvm"
 license = "Apache-2.0"

--- a/crates/smolvm-nvml-shim/Cargo.toml
+++ b/crates/smolvm-nvml-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-nvml-shim"
-version = "1.13.1"
+version = "1.14.0"
 edition = "2021"
 description = "Guest-side libnvidia-ml.so.1 drop-in: answers the NVML queries CUDA frameworks (vLLM) use for device detection, backed by the remoted CUDA driver"
 license = "Apache-2.0"

--- a/crates/smolvm-oci-layer/Cargo.toml
+++ b/crates/smolvm-oci-layer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-oci-layer"
-version = "1.13.1"
+version = "1.14.0"
 edition = "2021"
 description = "Pure-Rust OCI image-layer extraction: decompress a layer blob and unpack it into an overlayfs lowerdir, translating OCI whiteouts"
 license = "Apache-2.0"

--- a/crates/smolvm-pack/Cargo.toml
+++ b/crates/smolvm-pack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-pack"
-version = "1.13.1"
+version = "1.14.0"
 edition = "2021"
 description = "Single-binary packaging for smolvm"
 license = "Apache-2.0"

--- a/crates/smolvm-protocol/Cargo.toml
+++ b/crates/smolvm-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-protocol"
-version = "1.13.1"
+version = "1.14.0"
 edition = "2021"
 description = "Protocol types for smolvm host-guest communication"
 license = "Apache-2.0"

--- a/crates/smolvm-registry/Cargo.toml
+++ b/crates/smolvm-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-registry"
-version = "1.13.1"
+version = "1.14.0"
 edition = "2021"
 description = "OCI Distribution client for smolmachines registry"
 license = "Apache-2.0"

--- a/crates/smolvm-s3fs/Cargo.toml
+++ b/crates/smolvm-s3fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolvm-s3fs"
-version = "1.13.1"
+version = "1.14.0"
 edition = "2021"
 description = "POSIX filesystem over S3-compatible object storage, mounted through FUSE without libfuse or a helper binary"
 license = "Apache-2.0"

--- a/crates/smolvm-smolfile/Cargo.toml
+++ b/crates/smolvm-smolfile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smolfile"
-version = "1.13.1"
+version = "1.14.0"
 edition = "2021"
 description = "Smolfile specification and parser for smolvm microVM workloads"
 license = "Apache-2.0"


### PR DESCRIPTION
Bumps every workspace crate from 1.13.1 to 1.14.0 and refreshes the internal dependency specs in the root manifest, which had drifted and been stuck at 1.7.5.