### PR TITLE
Accept --init on machine run and keep what init writes to /workspace in the init-layer cache

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -36,6 +36,9 @@ fn ensure_storage_mounted() -> bool {
                 "INFO",
                 &format!("storage disk mounted (duration_ms={})", uptime_ms() - t0),
             );
+            // Before anything reads /workspace: a pack made with
+            // --include-workspace seeds it onto this (fresh) storage disk.
+            storage::seed_workspace_from_pack();
         } else {
             boot_log(
                 "ERROR",

--- a/crates/smolvm-agent/src/storage.rs
+++ b/crates/smolvm-agent/src/storage.rs
@@ -464,6 +464,48 @@ pub fn init_packed_layers() -> Option<PathBuf> {
 }
 
 /// Get the packed layers directory if available.
+/// Seed `/storage/workspace` from a pack's workspace seed, once.
+///
+/// `pack create --from-vm --include-workspace` ships the source machine's
+/// `/workspace` as `workspace-seed/workspace.tar` beside the staged layers. The
+/// workspace lives on the storage disk, which is fresh for every ephemeral run
+/// and for a machine's first boot, so this is the only way those files reach
+/// it. Runs as root, so ownership is exactly what the source machine had.
+///
+/// Guarded by a marker on the storage disk: a persistent machine seeds on its
+/// first boot only, and later boots leave whatever the user has done since.
+/// Absent seed, or any failure, leaves the workspace as it was.
+pub fn seed_workspace_from_pack() {
+    const SEED_DIR: &str = "workspace-seed";
+    const SEED_FILE: &str = "workspace.tar";
+    const MARKER: &str = ".smolvm-workspace-seeded";
+    let Some(packed) = get_packed_layers_dir() else {
+        return;
+    };
+    let seed = packed.join(SEED_DIR).join(SEED_FILE);
+    if !seed.is_file() {
+        return;
+    }
+    let workspace = Path::new(STORAGE_ROOT).join(WORKSPACE_DIR);
+    let marker = workspace.join(MARKER);
+    if marker.exists() {
+        return;
+    }
+    if let Err(e) = std::fs::create_dir_all(&workspace) {
+        warn!(error = %e, "workspace seed: cannot create workspace dir");
+        return;
+    }
+    info!("seeding /workspace from the pack");
+    match extract_layer_tar(&seed, &workspace) {
+        Ok(()) => {
+            if let Err(e) = std::fs::write(&marker, b"") {
+                warn!(error = %e, "workspace seed: cannot write marker");
+            }
+        }
+        Err(e) => warn!(error = %e, "workspace seed: extraction failed; workspace left as-is"),
+    }
+}
+
 pub fn get_packed_layers_dir() -> Option<&'static PathBuf> {
     PACKED_LAYERS_DIR.get_or_init(init_packed_layers).as_ref()
 }

--- a/crates/smolvm-pack/src/assets.rs
+++ b/crates/smolvm-pack/src/assets.rs
@@ -394,6 +394,12 @@ fn decompress_sparse(src: &Path, dest: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
+/// Subdirectory of `layers/` holding the workspace seed. Shared with the guest
+/// agent, which looks for exactly this path under `/packed_layers`.
+pub const WORKSPACE_SEED_DIR: &str = "workspace-seed";
+/// Name of the workspace seed tar inside [`WORKSPACE_SEED_DIR`].
+pub const WORKSPACE_SEED_FILE: &str = "workspace.tar";
+
 /// Asset collector for gathering runtime components.
 pub struct AssetCollector {
     staging_dir: PathBuf,
@@ -419,6 +425,7 @@ impl AssetCollector {
                 storage_logical_size: None,
                 overlay_template: None,
                 overlay_logical_size: None,
+                workspace_seed: None,
             },
         })
     }
@@ -854,6 +861,30 @@ impl AssetCollector {
             size: truncated_size,
         });
         self.inventory.storage_logical_size = Some(logical_size);
+        Ok(())
+    }
+
+    /// Record a tar of the source machine's `/workspace` as the pack's
+    /// workspace seed.
+    ///
+    /// It lives in its own subdirectory under `layers/` so the guest, which
+    /// treats every top-level `*.tar` there as an image layer, never mistakes
+    /// it for one.
+    pub fn add_workspace_seed(&mut self, tar: &Path) -> Result<()> {
+        if !tar.exists() {
+            return Err(PackError::AssetNotFound(format!(
+                "workspace seed not found: {}",
+                tar.display()
+            )));
+        }
+        let rel = format!("layers/{}/{}", WORKSPACE_SEED_DIR, WORKSPACE_SEED_FILE);
+        let dst = self.staging_dir.join(&rel);
+        if let Some(parent) = dst.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::rename(tar, &dst).or_else(|_| std::fs::copy(tar, &dst).map(|_| ()))?;
+        let size = std::fs::metadata(&dst)?.len();
+        self.inventory.workspace_seed = Some(AssetEntry { path: rel, size });
         Ok(())
     }
 

--- a/crates/smolvm-pack/src/format.rs
+++ b/crates/smolvm-pack/src/format.rs
@@ -645,6 +645,11 @@ pub struct AssetInventory {
     /// this size via `ftruncate`, restoring the sparse skeleton the VM expects.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub overlay_logical_size: Option<u64>,
+    /// Contents of the machine's `/workspace` at pack time, as a tar the guest
+    /// unpacks onto a fresh storage disk on first boot. Absent from packs made
+    /// without `--include-workspace`, and from packs older than this field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_seed: Option<AssetEntry>,
 }
 
 /// An asset file entry.
@@ -711,6 +716,7 @@ impl PackManifest {
                 storage_logical_size: None,
                 overlay_template: None,
                 overlay_logical_size: None,
+                workspace_seed: None,
             },
             checkpoint: None,
         }

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -684,6 +684,11 @@ pub struct RunCmd {
     )]
     pub secret_file: Vec<String>,
 
+    /// Run command before the workload (can be used multiple times); the same
+    /// as `init` in a Smolfile, and the CLI form wins when both are given
+    #[arg(long = "init", value_name = "COMMAND")]
+    pub init: Vec<String>,
+
     /// Skip the init-layer cache: re-run `init` on every ephemeral run instead of
     /// baking `image + init` once into a cached, reusable artifact. Use this when
     /// `init` depends on live volume contents (and so cannot be safely cached).
@@ -916,15 +921,6 @@ fn ensure_init_layer(
         return Ok(cached);
     }
 
-    // The Smolfile is the source of init commands, so it's required only when there
-    // ARE init steps. A bare `--oci-cache` image (no init) bakes from `--image`
-    // alone and needs no Smolfile.
-    if !params.init.is_empty() && smolfile.is_none() {
-        return Err(smolvm::Error::config(
-            "init-layer cache",
-            "init caching requires a --smolfile (the init source); pass --no-init-cache otherwise",
-        ));
-    }
     if params.init.is_empty() {
         println!("Caching image {key} (one-time; reused on later runs)");
     } else {
@@ -981,6 +977,23 @@ fn ensure_init_layer(
             create.push("-e".into());
             create.push(e.clone());
         }
+        // Forward the RESOLVED init steps too: they may have come from `--init`
+        // rather than the Smolfile, and the cache key is derived from them, so
+        // the baked rootfs must run exactly these.
+        for step in &params.init {
+            create.push("--init".into());
+            create.push(step.clone());
+        }
+        // Init runs in the resolved workdir as the resolved user; without these
+        // a step like `echo x > $WORKDIR/f` has no directory to write into.
+        if let Some(workdir) = &params.workdir {
+            create.push("--workdir".into());
+            create.push(workdir.clone());
+        }
+        if let Some(user) = &params.user {
+            create.push("--user".into());
+            create.push(user.clone());
+        }
         if params.allow_system_mounts {
             create.push("--allow-system-mounts".into());
         }
@@ -1014,6 +1027,17 @@ fn ensure_init_layer(
         // even when the outer run was given --proxy.
         let start = bake_start_args(&tmp, proxy, no_proxy);
         run_smolvm(&exe, &start)?;
+        // The snapshot below captures the rootfs overlay only. /workspace is the
+        // machine's storage disk, so anything init wrote there is NOT in the
+        // cached artifact and every cached run starts without it. Say so
+        // rather than let a `cat $WORKDIR/file` fail with no explanation.
+        if !params.init.is_empty() && bake_workspace_has_files(&exe, &tmp) {
+            eprintln!(
+                "warning: init wrote files under /workspace, which the init-layer cache does not \
+                 capture (it snapshots the root filesystem only); cached runs will start \
+                 without them. Pass --no-init-cache to run init live instead."
+            );
+        }
         run_smolvm(&exe, &["machine", "stop", "--name", &tmp])?;
         println!("  · snapshotting...");
         run_smolvm(
@@ -1052,6 +1076,26 @@ fn ensure_init_layer(
 /// CAPTURED (not inherited) so the bake's internal create/pull/pack chatter — and
 /// the harmless "vm not found" from the best-effort pre-clean — never reach the
 /// user's terminal; on failure the captured stderr tail is surfaced in the error.
+/// Whether init left anything on the bake machine's /workspace (its storage
+/// disk). Best effort: a failed probe reads as "nothing there" so it can never
+/// turn a good bake into an error.
+fn bake_workspace_has_files(exe: &Path, name: &str) -> bool {
+    std::process::Command::new(exe)
+        .args([
+            "machine",
+            "exec",
+            "--name",
+            name,
+            "--",
+            "sh",
+            "-c",
+            "find /workspace -mindepth 1 -print -quit 2>/dev/null | grep -q .",
+        ])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
 fn run_smolvm(exe: &Path, args: &[&str]) -> smolvm::Result<()> {
     let out = std::process::Command::new(exe)
         .args(args)
@@ -1194,7 +1238,7 @@ impl RunCmd {
             self.net_backend,
             self.dns,
             self.network_name.clone(),
-            vec![],
+            self.init.clone(),
             self.env,
             self.workdir,
             self.user,

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -1027,22 +1027,23 @@ fn ensure_init_layer(
         // even when the outer run was given --proxy.
         let start = bake_start_args(&tmp, proxy, no_proxy);
         run_smolvm(&exe, &start)?;
-        // The snapshot below captures the rootfs overlay only. /workspace is the
-        // machine's storage disk, so anything init wrote there is NOT in the
-        // cached artifact and every cached run starts without it. Say so
-        // rather than let a `cat $WORKDIR/file` fail with no explanation.
-        if !params.init.is_empty() && bake_workspace_has_files(&exe, &tmp) {
-            eprintln!(
-                "warning: init wrote files under /workspace, which the init-layer cache does not \
-                 capture (it snapshots the root filesystem only); cached runs will start \
-                 without them. Pass --no-init-cache to run init live instead."
-            );
-        }
         run_smolvm(&exe, &["machine", "stop", "--name", &tmp])?;
         println!("  · snapshotting...");
         run_smolvm(
             &exe,
-            &["pack", "create", "--from-vm", &tmp, "-o", &staged_out],
+            // `--include-workspace`: init may well have written into the workdir,
+            // which is the storage disk rather than the rootfs the snapshot
+            // captures; without it every cached run would start without those
+            // files and nothing would say why.
+            &[
+                "pack",
+                "create",
+                "--from-vm",
+                &tmp,
+                "--include-workspace",
+                "-o",
+                &staged_out,
+            ],
         )?;
         if !staged_sidecar.exists() {
             return Err(smolvm::Error::config(
@@ -1076,26 +1077,6 @@ fn ensure_init_layer(
 /// CAPTURED (not inherited) so the bake's internal create/pull/pack chatter — and
 /// the harmless "vm not found" from the best-effort pre-clean — never reach the
 /// user's terminal; on failure the captured stderr tail is surfaced in the error.
-/// Whether init left anything on the bake machine's /workspace (its storage
-/// disk). Best effort: a failed probe reads as "nothing there" so it can never
-/// turn a good bake into an error.
-fn bake_workspace_has_files(exe: &Path, name: &str) -> bool {
-    std::process::Command::new(exe)
-        .args([
-            "machine",
-            "exec",
-            "--name",
-            name,
-            "--",
-            "sh",
-            "-c",
-            "find /workspace -mindepth 1 -print -quit 2>/dev/null | grep -q .",
-        ])
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
-}
-
 fn run_smolvm(exe: &Path, args: &[&str]) -> smolvm::Result<()> {
     let out = std::process::Command::new(exe)
         .args(args)

--- a/src/cli/pack.rs
+++ b/src/cli/pack.rs
@@ -151,6 +151,10 @@ pub struct PackCreateCmd {
     #[arg(long = "rebase-from-image", requires = "from_vm")]
     pub rebase_from_image: bool,
 
+    /// Also capture the machine's /workspace, so a machine made from the pack starts with those files. It lives on the storage disk, which packs otherwise never carry.
+    #[arg(long = "include-workspace", requires = "from_vm")]
+    pub include_workspace: bool,
+
     /// Output file path for the packed binary
     #[arg(short = 'o', long, value_name = "PATH")]
     pub output: PathBuf,
@@ -660,6 +664,7 @@ impl PackCreateCmd {
             proxy: self.proxy_opts.resolved_proxy()?,
             no_proxy: self.proxy_opts.no_proxy(),
             rebase_from_image: self.rebase_from_image,
+            include_workspace: self.include_workspace,
         };
         let assets = smolvm::pack_export::collect_from_vm_assets(
             &mut collector,
@@ -1864,6 +1869,7 @@ mod tests {
             image: Some("./local-image.tar".to_string()),
             from_vm: None,
             rebase_from_image: false,
+            include_workspace: false,
             output: PathBuf::from("test-output"),
             cpus: 2,
             mem: 1024,

--- a/src/pack_export.rs
+++ b/src/pack_export.rs
@@ -39,6 +39,10 @@ pub struct FromVmExportOptions {
     /// For artifact-sourced machines: rebuild base layers from `vm.image`
     /// (re-pull from the registry) instead of preserving imported layers.
     pub rebase_from_image: bool,
+    /// Also capture the machine's `/workspace` so a machine made from the pack
+    /// starts with those files. It lives on the storage disk, which container
+    /// packs otherwise never carry, so without this a pack silently loses it.
+    pub include_workspace: bool,
 }
 
 /// What the export decided about the machine, for the caller's manifest.
@@ -124,6 +128,7 @@ pub fn collect_from_vm_assets(
             &vm_dir,
             staging_dir,
             vm.source_smolmachine.as_deref(),
+            opts.include_workspace,
         )?;
     } else if is_image_based {
         let image = vm.image.clone().unwrap();
@@ -137,7 +142,13 @@ pub fn collect_from_vm_assets(
             // reachable: an archive was flattened onto the machine's own storage
             // disk at boot, and a rootfs dir is still the host directory the
             // machine boots from. Either can be the lower layer.
-            export_flattened_from_local_image(collector, vm_name, &vm_dir, &image)?;
+            export_flattened_from_local_image(
+                collector,
+                vm_name,
+                &vm_dir,
+                &image,
+                opts.include_workspace,
+            )?;
         } else {
             image_env =
                 export_flattened_from_registry_image(collector, vm_name, &vm_dir, &image, opts)?;
@@ -393,7 +404,13 @@ fn export_flattened_from_registry_image(
         })
         .collect();
 
-    flatten_and_export(collector, &mut client, vm_name, &lowers)?;
+    flatten_and_export(
+        collector,
+        &mut client,
+        vm_name,
+        &lowers,
+        opts.include_workspace,
+    )?;
     Ok(image_info.env)
 }
 
@@ -422,6 +439,7 @@ fn export_flattened_from_local_image(
     vm_name: &str,
     vm_dir: &Path,
     image: &str,
+    include_workspace: bool,
 ) -> crate::Result<()> {
     let host_dir = crate::data::image_source::packed_layers_dir_for_ref(image);
     let is_dir_source = image.starts_with("local-dir:");
@@ -478,7 +496,7 @@ fn export_flattened_from_local_image(
         ));
     }
 
-    flatten_and_export(collector, &mut client, vm_name, &[dst])
+    flatten_and_export(collector, &mut client, vm_name, &[dst], include_workspace)
 }
 
 /// The flattened rootfs of a local *archive* image on the source machine's
@@ -536,6 +554,7 @@ fn export_flattened_from_artifact_sourced(
     vm_dir: &Path,
     _staging_dir: &Path,
     source_smolmachine: Option<&str>,
+    include_workspace: bool,
 ) -> crate::Result<()> {
     let cache_dir = machine_layers_cache_dir(vm_name);
     let pack_content_dir = read_shared_pack_pointer(&cache_dir).unwrap_or(cache_dir.clone());
@@ -613,7 +632,7 @@ fn export_flattened_from_artifact_sourced(
         lowers.push(dst);
     }
 
-    flatten_and_export(collector, &mut client, vm_name, &lowers)
+    flatten_and_export(collector, &mut client, vm_name, &lowers, include_workspace)
 }
 
 /// The cached layers of an imported pack, bottom -> top, as paths relative to
@@ -670,6 +689,7 @@ fn flatten_and_export(
     client: &mut AgentClient,
     vm_name: &str,
     lowers: &[String],
+    include_workspace: bool,
 ) -> crate::Result<()> {
     if lowers.is_empty() {
         return Err(Error::agent("flatten layers", "no layers to flatten"));
@@ -739,6 +759,63 @@ fn flatten_and_export(
         .register_layer(&digest)
         .map_err(|e| Error::agent("register flattened layer", e.to_string()))?;
     println!("  Flattened layer: {} bytes", total);
+    if include_workspace {
+        export_workspace_seed(collector, client)?;
+    }
+    Ok(())
+}
+
+/// Capture the source machine's `/workspace` as the pack's workspace seed.
+///
+/// The flattened layer above is the container's root filesystem; `/workspace`
+/// is a directory on the machine's storage disk, mounted at
+/// `/mnt/source-storage` in the helper, and is not part of any layer. Same
+/// mechanics as the layer: the agent tars it in the guest (so ownership is
+/// exactly what the machine had) and the host streams the result to disk. An
+/// empty workspace records nothing.
+fn export_workspace_seed(
+    collector: &mut AssetCollector,
+    client: &mut AgentClient,
+) -> crate::Result<()> {
+    const GUEST_WORKSPACE: &str = "/mnt/source-storage/workspace";
+    const GUEST_TAR: &str = "/storage/workspace-seed.tar";
+    let listing = client
+        .vm_exec(
+            vec![
+                "sh".into(),
+                "-c".into(),
+                format!("find {GUEST_WORKSPACE} -mindepth 1 -print -quit 2>/dev/null"),
+            ],
+            vec![],
+            None,
+            None,
+            None,
+        )
+        .map_err(|e| Error::agent("inspect workspace", e.to_string()))?;
+    if String::from_utf8_lossy(&listing.1).trim().is_empty() {
+        return Ok(());
+    }
+    println!("Capturing /workspace...");
+    client.flatten_layers(&[GUEST_WORKSPACE.to_string()], GUEST_TAR)?;
+    let tmp_file = collector
+        .layer_staging_path(&format!("sha256:{}", "0".repeat(64)))
+        .with_file_name("workspace-seed.tmp");
+    let total = client
+        .read_file_to_path_capped(
+            GUEST_TAR,
+            &tmp_file,
+            crate::agent::pack_export_max_total(),
+            |_| {},
+        )
+        .map_err(|e| Error::agent("export workspace", e.to_string()))?;
+    if total == 0 {
+        let _ = std::fs::remove_file(&tmp_file);
+        return Ok(());
+    }
+    collector
+        .add_workspace_seed(&tmp_file)
+        .map_err(|e| Error::agent("register workspace seed", e.to_string()))?;
+    println!("  Workspace seed: {} bytes", total);
     Ok(())
 }
 


### PR DESCRIPTION
The flag now matches what a Smolfile already allowed, and a pack can carry the machine's /workspace so a cached init no longer loses the files it wrote there.