### PR TITLE
Resolve the agent rootfs the same way for pack create, checkpoints, serve and machine boot

### DIFF
--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -995,6 +995,33 @@ impl AgentManager {
         Ok(data_dir.join("smolvm").join("agent-rootfs"))
     }
 
+    /// Resolve the agent rootfs an operation should use, and insist it is real.
+    ///
+    /// `explicit` is a caller-supplied override (`--rootfs-dir`, a checkpoint's
+    /// `rootfs_dir`) and wins outright. Otherwise this is exactly what a machine
+    /// boots with — [`Self::default_rootfs_path`] — so `pack create`, checkpoints
+    /// and `machine run` can never disagree about which agent they mean.
+    ///
+    /// The result is checked for `sbin/init` via `symlink_metadata`: that entry
+    /// is a symlink to a guest-only path, so `exists()` would follow it and
+    /// wrongly report a perfectly good rootfs as missing.
+    pub fn resolve_rootfs_path(explicit: Option<PathBuf>, what: &str) -> Result<PathBuf> {
+        let dir = match explicit {
+            Some(dir) => dir,
+            None => Self::default_rootfs_path()?,
+        };
+        if std::fs::symlink_metadata(dir.join("sbin/init")).is_ok() {
+            return Ok(dir);
+        }
+        Err(Error::agent(
+            what,
+            format!(
+                "could not find agent rootfs at {}; set SMOLVM_AGENT_ROOTFS or reinstall",
+                dir.display()
+            ),
+        ))
+    }
+
     /// Extract a bundled agent-rootfs tarball to a cache dir (idempotent) and
     /// return that dir. Keyed by the tarball's size+mtime so a newer SDK build
     /// re-extracts; extraction is staged in a temp dir then atomically renamed so
@@ -3250,6 +3277,30 @@ fn boot_failure_reason(exit_code: Option<i32>, startup_log: Option<&str>) -> Str
 
 #[cfg(test)]
 mod tests {
+    /// An explicit override must win even over a real default, and a rootfs
+    /// is only accepted when `sbin/init` is present — checked without following
+    /// the symlink, because in a real rootfs it points at a guest-only path.
+    #[test]
+    fn resolve_rootfs_path_honours_override_and_requires_init() {
+        let tmp = tempfile::tempdir().unwrap();
+        let good = tmp.path().join("good");
+        std::fs::create_dir_all(good.join("sbin")).unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink("/usr/local/bin/smolvm-agent", good.join("sbin/init")).unwrap();
+        #[cfg(not(unix))]
+        std::fs::write(good.join("sbin/init"), b"").unwrap();
+        let got = super::AgentManager::resolve_rootfs_path(Some(good.clone()), "test").unwrap();
+        assert_eq!(got, good);
+
+        let bare = tmp.path().join("bare");
+        std::fs::create_dir_all(&bare).unwrap();
+        let err = super::AgentManager::resolve_rootfs_path(Some(bare.clone()), "test")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("could not find agent rootfs"), "{err}");
+        assert!(err.contains(&bare.display().to_string()), "{err}");
+    }
+
     use super::*;
 
     #[test]

--- a/src/cli/pack.rs
+++ b/src/cli/pack.rs
@@ -963,36 +963,15 @@ impl PackCreateCmd {
     /// `target/agent-rootfs` is NOT checked — it can contain stale builds.
     /// Use `--rootfs-dir` or `SMOLVM_AGENT_ROOTFS` env var to override.
     fn find_rootfs_dir(&self) -> smolvm::Result<PathBuf> {
-        if let Some(ref dir) = self.rootfs_dir {
-            return Ok(dir.clone());
-        }
-
-        let candidates = [
-            // SMOLVM_AGENT_ROOTFS env var
-            std::env::var("SMOLVM_AGENT_ROOTFS").ok().map(PathBuf::from),
-            // Installed location (canonical)
-            dirs::data_dir().map(|d| d.join("smolvm/agent-rootfs")),
-            // Next to the executable (for distribution tarballs)
-            std::env::current_exe()
-                .ok()
-                .and_then(|p| p.parent().map(|d| d.join("agent-rootfs"))),
-        ];
-
-        for candidate in candidates.into_iter().flatten() {
-            // Use symlink_metadata instead of exists() because sbin/init
-            // is a symlink to a guest-only path (/usr/local/bin/smolvm-agent)
-            // that doesn't exist on the host. exists() follows symlinks and
-            // returns false for broken symlinks.
-            if std::fs::symlink_metadata(candidate.join("sbin/init")).is_ok() {
-                debug!(rootfs_dir = %candidate.display(), "found agent rootfs");
-                return Ok(candidate);
-            }
-        }
-
-        Err(Error::agent(
+        // Same resolver a machine boots with, so the pack bundles the agent
+        // `machine run` would use, not whichever copy happened to sit in a
+        // stale data directory.
+        let dir = smolvm::agent::AgentManager::resolve_rootfs_path(
+            self.rootfs_dir.clone(),
             "find agent rootfs",
-            "could not find agent rootfs. Use --rootfs-dir to specify the location.",
-        ))
+        )?;
+        debug!(rootfs_dir = %dir.display(), "found agent rootfs");
+        Ok(dir)
     }
 
     /// Find the smolvm binary to embed as the packed runtime.

--- a/src/portable_checkpoint.rs
+++ b/src/portable_checkpoint.rs
@@ -300,24 +300,11 @@ fn checkpoint_lib_dir(options: &CaptureOptions) -> Result<PathBuf> {
 }
 
 fn checkpoint_rootfs_dir(options: &CaptureOptions) -> Result<PathBuf> {
-    let candidates = [
+    // The same resolver a machine boots with; see `AgentManager::resolve_rootfs_path`.
+    crate::agent::AgentManager::resolve_rootfs_path(
         options.rootfs_dir.clone(),
-        std::env::var_os("SMOLVM_AGENT_ROOTFS").map(PathBuf::from),
-        dirs::data_dir().map(|dir| dir.join("smolvm/agent-rootfs")),
-        std::env::current_exe()
-            .ok()
-            .and_then(|path| path.parent().map(|dir| dir.join("agent-rootfs"))),
-    ];
-    candidates
-        .into_iter()
-        .flatten()
-        .find(|candidate| std::fs::symlink_metadata(candidate.join("sbin/init")).is_ok())
-        .ok_or_else(|| {
-            Error::agent(
-                "find checkpoint agent rootfs",
-                "could not find agent rootfs; set SMOLVM_AGENT_ROOTFS",
-            )
-        })
+        "find checkpoint agent rootfs",
+    )
 }
 
 fn validated_capture_source(name: &str) -> Result<SmolvmConfig> {


### PR DESCRIPTION
A pack bundles the agent a machine actually boots, and a root serve that relocates its state still looks for the rootfs where the root CLI does.