### PR TITLE
Accept a user on the exec and run API so a caller can run a command as a chosen account

### DIFF
--- a/src/api/handlers/exec.rs
+++ b/src/api/handlers/exec.rs
@@ -82,6 +82,7 @@ pub async fn exec_command(
     if req.background {
         let command = req.command.clone();
         let workdir = req.workdir.clone();
+        let user = req.user.clone();
         let machine_rec = state.lookup_vm(&id).await?;
         // An exec may be what establishes the workload container — the machine's
         // command exited, or the image's own default was short-lived — and that
@@ -108,6 +109,7 @@ pub async fn exec_command(
                 let config = crate::agent::RunConfig::new(image, command)
                     .with_env(env)
                     .with_workdir(workdir)
+                    .with_user(user)
                     .with_mounts(mounts_config)
                     .in_machine_opt(machine_for_run.as_ref(), &id, &env_for_volumes);
                 c.run_background(config)
@@ -133,6 +135,7 @@ pub async fn exec_command(
     // path); env precedence is req.env < record.secret_refs < req.secrets.
     let command = req.command.clone();
     let workdir = req.workdir.clone();
+    let user = req.user.clone();
     let timeout = req.timeout_secs.map(Duration::from_secs);
     let stdin_data = req.stdin.clone();
 
@@ -172,6 +175,7 @@ pub async fn exec_command(
             let config = crate::agent::RunConfig::new(image, command)
                 .with_env(env)
                 .with_workdir(workdir)
+                .with_user(user)
                 .with_mounts(mounts_config)
                 .with_timeout(timeout)
                 .in_machine_opt(machine_for_run.as_ref(), &id, &env_for_volumes)
@@ -238,6 +242,7 @@ pub async fn exec_stream(
     env.extend(crate::secrets::expose_into_env(record_env));
     env.extend(crate::secrets::expose_into_env(req_env));
     let workdir = req.workdir.clone();
+    let user = req.user.clone();
     let timeout = req.timeout_secs.map(Duration::from_secs);
 
     // Image-based machines stream from a container in their image (persistent
@@ -285,6 +290,7 @@ pub async fn exec_stream(
                 let config = crate::agent::RunConfig::new(image, command)
                     .with_env(env)
                     .with_workdir(workdir)
+                    .with_user(user)
                     .with_mounts(mounts_config)
                     .with_timeout(timeout)
                     .in_machine_opt(machine_for_run.as_ref(), &id, &env_for_volumes);
@@ -379,6 +385,7 @@ pub async fn run_command(
     env.extend(crate::secrets::expose_into_env(record_env));
     env.extend(crate::secrets::expose_into_env(req_env));
     let workdir = req.workdir.clone();
+    let user = req.user.clone();
     let timeout = req.timeout_secs.map(Duration::from_secs);
 
     // Get mounts from machine config (converted to protocol format)
@@ -400,6 +407,7 @@ pub async fn run_command(
         let config = crate::agent::RunConfig::new(image, command)
             .with_env(env)
             .with_workdir(workdir)
+            .with_user(user)
             .with_mounts(mounts_config)
             .with_timeout(timeout);
         c.run_non_interactive(config)

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -158,6 +158,12 @@ pub struct ExecRequest {
     #[serde(default)]
     #[schema(example = "/workspace")]
     pub workdir: Option<String>,
+    /// Run as this user: a name from the image or a numeric `uid[:gid]`,
+    /// overriding the image's USER. Only meaningful for image machines; a bare
+    /// VM has no container user to become.
+    #[serde(default)]
+    #[schema(example = "1000:1000")]
+    pub user: Option<String>,
     /// Timeout in seconds.
     #[serde(default)]
     #[schema(example = 30)]
@@ -314,6 +320,11 @@ pub struct RunRequest {
     /// Working directory.
     #[serde(default)]
     pub workdir: Option<String>,
+    /// Run as this user: a name from the image or a numeric `uid[:gid]`,
+    /// overriding the image's USER.
+    #[serde(default)]
+    #[schema(example = "1000:1000")]
+    pub user: Option<String>,
     /// Timeout in seconds.
     #[serde(default)]
     pub timeout_secs: Option<u64>,
@@ -1256,6 +1267,28 @@ mod deny_unknown_field_tests {
     use super::*;
 
     /// The correct camelCase `timeoutSecs` deserializes and applies.
+    /// `user` is accepted on both exec and ephemeral run, and is absent by
+    /// default so every existing client keeps working. `deny_unknown_fields`
+    /// on these types is what makes an older serve REJECT the field instead of
+    /// silently running as the wrong account, so this is the contract both
+    /// the control plane and the CLI rely on.
+    #[test]
+    fn exec_and_run_requests_carry_an_optional_user() {
+        let exec: ExecRequest = serde_json::from_value(
+            serde_json::json!({"command": ["id", "-u"], "user": "1000:1000"}),
+        )
+        .unwrap();
+        assert_eq!(exec.user.as_deref(), Some("1000:1000"));
+        let bare: ExecRequest =
+            serde_json::from_value(serde_json::json!({"command": ["id", "-u"]})).unwrap();
+        assert_eq!(bare.user, None);
+        let run: RunRequest = serde_json::from_value(
+            serde_json::json!({"image": "alpine", "command": ["id", "-u"], "user": "app"}),
+        )
+        .unwrap();
+        assert_eq!(run.user.as_deref(), Some("app"));
+    }
+
     #[test]
     fn exec_request_accepts_camelcase_timeout() {
         let req: ExecRequest = serde_json::from_value(


### PR DESCRIPTION
The serve API now carries the same user the CLI and Smolfile already do, so a control plane can forward it instead of dropping it.