### PR TITLE
Pack machines with the entrypoint they were created with and the overlay they actually write to

### DIFF
--- a/src/cli/smolfile.rs
+++ b/src/cli/smolfile.rs
@@ -1127,3 +1127,69 @@ mod smolfile_local_image_tests {
         assert_eq!(flagged.image, Some(image));
     }
 }
+
+#[cfg(test)]
+mod cli_entrypoint_tests {
+    use super::resolve_pack_config;
+
+    /// `--entrypoint ""` used to become an entrypoint of one empty string,
+    /// which the runtime then tried to execute. It must resolve to no
+    /// override at all.
+    #[test]
+    fn an_empty_cli_entrypoint_is_not_an_entrypoint() {
+        let cfg = resolve_pack_config(
+            Some("alpine".to_string()),
+            Some(String::new()),
+            None,
+            None,
+            None,
+            false,
+            None,
+        )
+        .expect("resolves");
+
+        assert!(cfg.entrypoint.is_empty(), "got {:?}", cfg.entrypoint);
+    }
+
+    /// Same through the Smolfile route, where the CLI value competes with an
+    /// [artifact] entrypoint: an empty flag must not shadow it.
+    #[test]
+    fn an_empty_cli_entrypoint_does_not_shadow_a_smolfile_one() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("Smolfile");
+        std::fs::write(
+            &path,
+            "image = \"alpine\"\nentrypoint = [\"/from/smolfile\"]\n",
+        )
+        .expect("write");
+
+        let cfg = resolve_pack_config(
+            None,
+            Some(String::new()),
+            None,
+            None,
+            None,
+            false,
+            Some(path),
+        )
+        .expect("resolves");
+
+        assert_eq!(cfg.entrypoint, vec!["/from/smolfile"]);
+    }
+
+    #[test]
+    fn a_real_cli_entrypoint_is_kept() {
+        let cfg = resolve_pack_config(
+            Some("alpine".to_string()),
+            Some("/app/run".to_string()),
+            None,
+            None,
+            None,
+            false,
+            None,
+        )
+        .expect("resolves");
+
+        assert_eq!(cfg.entrypoint, vec!["/app/run"]);
+    }
+}

--- a/src/pack_export.rs
+++ b/src/pack_export.rs
@@ -77,6 +77,20 @@ pub struct FromVmAssets {
     pub layer_bytes: u64,
 }
 
+/// The persistent overlay a machine's rootfs writes live in. A branched or
+/// checkpoint-restored machine keeps its source's overlay rather than getting
+/// one named after itself, so the directory is a property of lineage, not of
+/// the machine's current name. Every other reader resolves it this way; export
+/// must too, or a restored machine flattens an empty overlay and silently
+/// loses every rootfs change made through exec.
+pub fn export_overlay_owner(vm_name: &str, vm: &VmRecord) -> String {
+    crate::workload::persistent_overlay_owner_with_lineage(
+        vm_name,
+        vm.golden.as_deref(),
+        vm.fork_overlay_owner.as_deref(),
+    )
+}
+
 /// Collect a stopped machine's pack assets into `collector` and report the
 /// pack mode. The caller has already: loaded the record, verified the machine
 /// is stopped, and collected its base assets (runtime libs, agent rootfs,
@@ -89,6 +103,7 @@ pub fn collect_from_vm_assets(
     staging_dir: &Path,
     opts: &FromVmExportOptions,
 ) -> crate::Result<FromVmAssets> {
+    let overlay_owner = export_overlay_owner(vm_name, vm);
     // A fork clone's disks are CoW qcow2 overlays that only the fork/resume
     // machinery can assemble — the export helper cold-boots them and libkrun
     // rejects the stack with an opaque -22 EINVAL (same class as clone
@@ -131,6 +146,7 @@ pub fn collect_from_vm_assets(
         export_flattened_from_artifact_sourced(
             collector,
             vm_name,
+            &overlay_owner,
             &vm_dir,
             staging_dir,
             vm.source_smolmachine.as_deref(),
@@ -151,13 +167,20 @@ pub fn collect_from_vm_assets(
             export_flattened_from_local_image(
                 collector,
                 vm_name,
+                &overlay_owner,
                 &vm_dir,
                 &image,
                 opts.include_workspace,
             )?;
         } else {
-            (image_env, image_user) =
-                export_flattened_from_registry_image(collector, vm_name, &vm_dir, &image, opts)?;
+            (image_env, image_user) = export_flattened_from_registry_image(
+                collector,
+                vm_name,
+                &overlay_owner,
+                &vm_dir,
+                &image,
+                opts,
+            )?;
         }
     } else {
         // Bare VM: its state is the rootfs overlay disk. VM-mode restores boot
@@ -223,11 +246,13 @@ pub fn seed_manifest_from_vm(manifest: &mut PackManifest, vm: &VmRecord, assets:
     manifest.network = vm.network;
     manifest.gpu = vm.gpu.unwrap_or(false);
     manifest.cuda = vm.cuda;
-    manifest.entrypoint = if !vm.entrypoint.is_empty() {
-        vm.entrypoint.clone()
-    } else {
-        vec!["/bin/sh".to_string()]
-    };
+    // Carry the record's (entrypoint, cmd) through as-is. An empty entrypoint
+    // is meaningful: a machine created with trailing args stores them as `cmd`
+    // with no entrypoint, and an image machine with neither lets the agent use
+    // the image's own ENTRYPOINT+CMD. Synthesising `/bin/sh` here turned the
+    // former into `/bin/sh sh -c ...` (a shell trying to run a script named
+    // `sh`) and the latter into a bare shell instead of the image's service.
+    manifest.entrypoint = vm.entrypoint.clone();
     manifest.cmd = vm.cmd.clone();
     manifest.env = merge_env(&assets.image_env, &vm.env);
     manifest.workdir = vm.workdir.clone();
@@ -387,6 +412,7 @@ impl Drop for ExportVm {
 fn export_flattened_from_registry_image(
     collector: &mut AssetCollector,
     vm_name: &str,
+    overlay_owner: &str,
     vm_dir: &Path,
     image: &str,
     opts: &FromVmExportOptions,
@@ -417,7 +443,7 @@ fn export_flattened_from_registry_image(
     flatten_and_export(
         collector,
         &mut client,
-        vm_name,
+        overlay_owner,
         &lowers,
         opts.include_workspace,
     )?;
@@ -447,6 +473,7 @@ fn export_flattened_from_registry_image(
 fn export_flattened_from_local_image(
     collector: &mut AssetCollector,
     vm_name: &str,
+    overlay_owner: &str,
     vm_dir: &Path,
     image: &str,
     include_workspace: bool,
@@ -506,7 +533,13 @@ fn export_flattened_from_local_image(
         ));
     }
 
-    flatten_and_export(collector, &mut client, vm_name, &[dst], include_workspace)
+    flatten_and_export(
+        collector,
+        &mut client,
+        overlay_owner,
+        &[dst],
+        include_workspace,
+    )
 }
 
 /// The flattened rootfs of a local *archive* image on the source machine's
@@ -561,6 +594,7 @@ fn locate_flattened_archive_rootfs(
 fn export_flattened_from_artifact_sourced(
     collector: &mut AssetCollector,
     vm_name: &str,
+    overlay_owner: &str,
     vm_dir: &Path,
     _staging_dir: &Path,
     source_smolmachine: Option<&str>,
@@ -642,7 +676,13 @@ fn export_flattened_from_artifact_sourced(
         lowers.push(dst);
     }
 
-    flatten_and_export(collector, &mut client, vm_name, &lowers, include_workspace)
+    flatten_and_export(
+        collector,
+        &mut client,
+        overlay_owner,
+        &lowers,
+        include_workspace,
+    )
 }
 
 /// The cached layers of an imported pack, bottom -> top, as paths relative to
@@ -697,7 +737,7 @@ fn ordered_cached_layer_ids(pack_content_dir: &Path) -> Option<Vec<String>> {
 fn flatten_and_export(
     collector: &mut AssetCollector,
     client: &mut AgentClient,
-    vm_name: &str,
+    overlay_owner: &str,
     lowers: &[String],
     include_workspace: bool,
 ) -> crate::Result<()> {
@@ -710,7 +750,7 @@ fn flatten_and_export(
     // reversed — leaving it as-is makes the base layer win every conflict.
     // The agent drops the overlay if the machine never wrote to it, so it needs
     // no probe from here.
-    let upper = format!("/mnt/source-storage/overlays/persistent-{}/upper", vm_name);
+    let upper = format!("/mnt/source-storage/overlays/persistent-{overlay_owner}/upper");
     let mut stack: Vec<String> = vec![upper];
     stack.extend(lowers.iter().rev().cloned());
 
@@ -1020,5 +1060,113 @@ mod env_merge_tests {
     fn machine_env_stands_alone_without_an_image() {
         let vm = vec![("FOO".to_string(), "bar".to_string())];
         assert_eq!(merge_env(&[], &vm), vec!["FOO=bar".to_string()]);
+    }
+}
+
+#[cfg(test)]
+mod from_vm_manifest_tests {
+    use super::{export_overlay_owner, seed_manifest_from_vm, FromVmAssets};
+    use crate::config::VmRecord;
+    use smolvm_pack::{PackManifest, PackMode};
+
+    fn record(name: &str) -> VmRecord {
+        VmRecord::new(name.to_string(), 1, 512, vec![], vec![], false)
+    }
+
+    fn assets() -> FromVmAssets {
+        FromVmAssets {
+            mode: PackMode::Container,
+            image: Some("alpine".to_string()),
+            image_env: vec![],
+            image_user: None,
+            layer_bytes: 0,
+        }
+    }
+
+    fn manifest() -> PackManifest {
+        PackManifest::new(
+            "vm://m".to_string(),
+            "none".to_string(),
+            "linux/amd64".to_string(),
+            "linux/amd64".to_string(),
+        )
+    }
+
+    /// A machine created with trailing args stores them as `cmd` with no
+    /// entrypoint. Export used to invent `/bin/sh` for the missing entrypoint,
+    /// so the pack launched `/bin/sh sh -c ...`: a shell trying to run a script
+    /// named `sh`, exiting at once. The record's split must survive as-is.
+    #[test]
+    fn a_missing_entrypoint_is_not_replaced_with_a_shell() {
+        let mut rec = record("m");
+        rec.image = Some("alpine".to_string());
+        rec.entrypoint = vec![];
+        rec.cmd = vec!["sh".into(), "-c".into(), "run-the-workload".into()];
+
+        let mut m = manifest();
+        seed_manifest_from_vm(&mut m, &rec, &assets());
+
+        assert!(
+            m.entrypoint.is_empty(),
+            "entrypoint was synthesised: {:?}",
+            m.entrypoint
+        );
+        assert_eq!(m.cmd, rec.cmd);
+
+        // What the runtime will actually exec: entrypoint + cmd.
+        let mut launched = m.entrypoint.clone();
+        launched.extend(m.cmd.clone());
+        assert_eq!(launched, vec!["sh", "-c", "run-the-workload"]);
+    }
+
+    /// An image machine with neither entrypoint nor cmd relies on the agent
+    /// using the image's own ENTRYPOINT+CMD; a synthesised shell would have
+    /// replaced a service image's process with a bare shell.
+    #[test]
+    fn an_image_default_entrypoint_is_left_to_the_image() {
+        let mut rec = record("m");
+        rec.image = Some("nginx".to_string());
+
+        let mut m = manifest();
+        seed_manifest_from_vm(&mut m, &rec, &assets());
+
+        assert!(m.entrypoint.is_empty() && m.cmd.is_empty());
+    }
+
+    /// A record that does carry an entrypoint keeps it verbatim.
+    #[test]
+    fn an_explicit_entrypoint_is_preserved() {
+        let mut rec = record("m");
+        rec.entrypoint = vec!["/app/server".into()];
+        rec.cmd = vec!["--port".into(), "8080".into()];
+
+        let mut m = manifest();
+        seed_manifest_from_vm(&mut m, &rec, &assets());
+
+        assert_eq!(m.entrypoint, vec!["/app/server"]);
+        assert_eq!(m.cmd, vec!["--port", "8080"]);
+    }
+
+    /// A branched or checkpoint-restored machine keeps writing to its source's
+    /// overlay. Export used to look up `persistent-<own-name>`, found nothing,
+    /// and flattened an empty overlay, silently dropping every exec-made change.
+    #[test]
+    fn export_reads_the_overlay_the_machine_actually_writes_to() {
+        let plain = record("orig");
+        assert_eq!(export_overlay_owner("orig", &plain), "orig");
+
+        let mut restored = record("restored");
+        restored.golden = Some("orig".to_string());
+        assert_eq!(
+            export_overlay_owner("restored", &restored),
+            "orig",
+            "a restored machine's changes live in its source's overlay"
+        );
+
+        // A fork clone records its overlay owner explicitly; that wins over golden.
+        let mut clone = record("clone");
+        clone.golden = Some("orig".to_string());
+        clone.fork_overlay_owner = Some("shared-owner".to_string());
+        assert_eq!(export_overlay_owner("clone", &clone), "shared-owner");
     }
 }


### PR DESCRIPTION
Exporting a machine synthesised a /bin/sh entrypoint in front of its stored command and looked up its overlay by its own name, so a pack from a machine created with trailing args launched a shell that exited at once and a pack from a branched or restored machine silently lost every rootfs change. Export now carries the record's entrypoint and cmd through unchanged and resolves the overlay through the same lineage-aware owner every other reader uses, and an empty --entrypoint no longer produces an empty executable.