### PR TITLE
Keep a released clone alive when the branch helper is its main process, and hand the child its identity through the helper itself

### DIFF
--- a/crates/smolvm-agent/src/branchpoint.rs
+++ b/crates/smolvm-agent/src/branchpoint.rs
@@ -1,13 +1,9 @@
-//! Native execution of the host-driven side of the branchpoint handshake.
+//! The agent's side of the branchpoint handshake: wait, arm, park, release,
+//! activate, and the worker-ready wait, each a typed request from the host
+//! executed here against the marker files the helper watches. The rules of
+//! the protocol live once, in this module and the helper.
 //!
-//! The host used to drive every step — wait, arm, park, release, activate —
-//! by building a shell script and running it through `VmExec`, with the marker
-//! formats mirrored as `sed` patterns. These functions execute the same steps
-//! against the same marker files, so a helper of either vintage sees an
-//! identical protocol; what changes is that the rules live once, here, typed.
-//!
-//! Every function takes its paths, so each is tested against a temp dir the
-//! way the scripts were.
+//! Every function takes its paths, so each is tested against a temp dir.
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -97,10 +93,9 @@ impl Markers {
     }
 }
 
-/// How long the helper has to acknowledge an arm or park (the scripts allowed
-/// 400 polls of 5 ms).
+/// How long the helper has to acknowledge an arm or park.
 const ACK_WINDOW: Duration = Duration::from_secs(2);
-/// How long a restored clone has to acknowledge its release (500 polls of 20 ms).
+/// How long a restored clone has to acknowledge its release.
 const RELEASE_WINDOW: Duration = Duration::from_secs(10);
 
 /// Re-check `condition` after every change to the state directory until it

--- a/crates/smolvm-agent/src/branchpoint.rs
+++ b/crates/smolvm-agent/src/branchpoint.rs
@@ -1,0 +1,602 @@
+//! Native execution of the host-driven side of the branchpoint handshake.
+//!
+//! The host used to drive every step — wait, arm, park, release, activate —
+//! by building a shell script and running it through `VmExec`, with the marker
+//! formats mirrored as `sed` patterns. These functions execute the same steps
+//! against the same marker files, so a helper of either vintage sees an
+//! identical protocol; what changes is that the rules live once, here, typed.
+//!
+//! Every function takes its paths, so each is tested against a temp dir the
+//! way the scripts were.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use smolvm_protocol::forkpoint::{
+    typed_error, ARMED_PREFIX, ARM_PREFIX, GENERATION_PREFIX, LEGACY_RELEASE_TOKEN, RELEASE_PREFIX,
+};
+
+/// A failed step, carrying the protocol error code the host handles on.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypedError {
+    /// One of [`typed_error`].
+    pub code: &'static str,
+    /// What went wrong, for the operator.
+    pub message: String,
+}
+
+impl TypedError {
+    fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+
+    fn io(step: &str, error: std::io::Error) -> Self {
+        Self::new(typed_error::IO, format!("{step}: {error}"))
+    }
+}
+
+/// Outcome of an activation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Activation {
+    /// This call performed the activation.
+    Done,
+    /// A previous attempt with the same token had already completed it.
+    AlreadyDone,
+}
+
+/// Marker files of one clone, all under the forkpoint state directory except
+/// the two env files, which live on the workload's filesystem.
+#[derive(Debug, Clone)]
+pub struct Markers {
+    /// The state directory itself.
+    pub state_dir: PathBuf,
+    /// Written by the helper when the workload reaches its branchpoint.
+    pub ready: PathBuf,
+    /// Written by the host to enter the restore-safe loop.
+    pub arm: PathBuf,
+    /// Written by the helper to acknowledge arming.
+    pub armed: PathBuf,
+    /// Written by the host to let a restored clone continue.
+    pub release: PathBuf,
+    /// Written by the workload once it is serving (held forks).
+    pub worker_ready: PathBuf,
+    /// The activation token that claimed this clone.
+    pub receipt: PathBuf,
+}
+
+impl Markers {
+    /// The markers at their protocol locations.
+    pub fn standard() -> Self {
+        use smolvm_protocol::forkpoint as f;
+        Self {
+            state_dir: PathBuf::from(f::STATE_DIR),
+            ready: PathBuf::from(f::READY_PATH),
+            arm: PathBuf::from(f::ARM_PATH),
+            armed: PathBuf::from(f::ARMED_PATH),
+            release: PathBuf::from(f::RELEASE_PATH),
+            worker_ready: PathBuf::from(f::WORKER_READY_PATH),
+            receipt: Path::new(f::STATE_DIR).join("activation"),
+        }
+    }
+
+    /// The same layout rooted at `state_dir`, for tests.
+    #[cfg(test)]
+    pub fn under(state_dir: &Path) -> Self {
+        Self {
+            state_dir: state_dir.to_path_buf(),
+            ready: state_dir.join("ready"),
+            arm: state_dir.join("arm"),
+            armed: state_dir.join("armed"),
+            release: state_dir.join("release"),
+            worker_ready: state_dir.join("worker-ready"),
+            receipt: state_dir.join("activation"),
+        }
+    }
+}
+
+/// The scripts' acknowledgement window: 400 polls of 5 ms.
+const ACK_POLLS: u32 = 400;
+const ACK_INTERVAL: Duration = Duration::from_millis(5);
+/// The release script's window: 500 polls of 20 ms.
+const RELEASE_POLLS: u32 = 500;
+const RELEASE_INTERVAL: Duration = Duration::from_millis(20);
+
+/// Poll `condition` up to `polls` times, `interval` apart; true if it held.
+fn poll(polls: u32, interval: Duration, mut condition: impl FnMut() -> bool) -> bool {
+    for _ in 0..polls {
+        if condition() {
+            return true;
+        }
+        std::thread::sleep(interval);
+    }
+    condition()
+}
+
+/// The generation recorded in a ready marker: the first `generation=` line.
+/// `Ok(None)` when the marker carries none or it is not 32 hex digits, which
+/// is the legacy helper's marker and is handled by each caller as the script
+/// did.
+fn generation_of(ready: &Path) -> Result<Option<String>, TypedError> {
+    let contents = match std::fs::read_to_string(ready) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(TypedError::new(
+                typed_error::NOT_READY,
+                "the workload has not declared a branchpoint (no ready marker); it does so by \
+                 running `smolvm-branch-ready` once its setup is done",
+            ));
+        }
+        Err(error) => return Err(TypedError::io("read ready marker", error)),
+    };
+    let generation = contents
+        .lines()
+        .find_map(|line| line.strip_prefix(GENERATION_PREFIX))
+        .unwrap_or("");
+    let valid = generation.len() == 32 && generation.bytes().all(|b| b.is_ascii_hexdigit());
+    Ok(valid.then(|| generation.to_string()))
+}
+
+/// Write `contents` to `path` atomically via a sibling temp file.
+fn write_atomic(path: &Path, contents: &str, mode: u32) -> Result<(), TypedError> {
+    let tmp = path.with_extension("tmp");
+    write_private(&tmp, contents, mode)?;
+    std::fs::rename(&tmp, path).map_err(|error| {
+        let _ = std::fs::remove_file(&tmp);
+        TypedError::io(&format!("move {} into place", path.display()), error)
+    })
+}
+
+fn write_private(path: &Path, contents: &str, mode: u32) -> Result<(), TypedError> {
+    use std::io::Write as _;
+    #[cfg(unix)]
+    let file = {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(mode)
+            .open(path)
+    };
+    #[cfg(not(unix))]
+    let file = {
+        let _ = mode;
+        std::fs::File::create(path)
+    };
+    let mut file =
+        file.map_err(|error| TypedError::io(&format!("create {}", path.display()), error))?;
+    file.write_all(contents.as_bytes())
+        .map_err(|error| TypedError::io(&format!("write {}", path.display()), error))
+}
+
+/// Wait until the workload declares its branchpoint; returns the ready
+/// marker's contents (its profile lines).
+pub fn wait_ready(markers: &Markers, timeout: Duration) -> Result<String, TypedError> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match std::fs::read_to_string(&markers.ready) {
+            Ok(contents) => return Ok(contents),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(TypedError::io("read ready marker", error)),
+        }
+        if Instant::now() >= deadline {
+            return Err(TypedError::new(
+                typed_error::NOT_READY,
+                format!(
+                    "the workload did not reach a branchpoint within {:.1}s; it declares one by \
+                     running `smolvm-branch-ready` once its setup is done",
+                    timeout.as_secs_f64()
+                ),
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Put a negotiated helper into its restore-safe loop before capture.
+pub fn arm(markers: &Markers) -> Result<(), TypedError> {
+    let generation = generation_of(&markers.ready)?.ok_or_else(|| {
+        TypedError::new(
+            typed_error::BAD_GENERATION,
+            "the ready marker carries no usable generation; the helper predates arming",
+        )
+    })?;
+    let _ = std::fs::remove_file(&markers.arm);
+    if !poll(ACK_POLLS, ACK_INTERVAL, || !markers.armed.exists()) {
+        return Err(TypedError::new(
+            typed_error::NO_ACK,
+            "a previous arming was never cleared by the helper",
+        ));
+    }
+    write_atomic(&markers.arm, &format!("{ARM_PREFIX}{generation}\n"), 0o644)?;
+    let expected = format!("{ARMED_PREFIX}{generation}");
+    let acknowledged = poll(ACK_POLLS, ACK_INTERVAL, || {
+        std::fs::read_to_string(&markers.armed)
+            .map(|c| c.lines().any(|line| line == expected))
+            .unwrap_or(false)
+    });
+    if !acknowledged {
+        return Err(TypedError::new(
+            typed_error::NO_ACK,
+            "the helper did not acknowledge arming within the window",
+        ));
+    }
+    Ok(())
+}
+
+/// Return a parked source to its ordinary wait after capture.
+pub fn park(markers: &Markers) -> Result<(), TypedError> {
+    let _ = std::fs::remove_file(&markers.arm);
+    if !poll(ACK_POLLS, ACK_INTERVAL, || !markers.armed.exists()) {
+        return Err(TypedError::new(
+            typed_error::NO_ACK,
+            "the helper did not leave its armed loop within the window",
+        ));
+    }
+    Ok(())
+}
+
+/// Release a restored clone and wait for the helper to acknowledge.
+///
+/// The state directory is private guest RAM, so this wakes only this clone
+/// even though every clone inherited the same blocked helper.
+pub fn release(markers: &Markers) -> Result<(), TypedError> {
+    std::fs::create_dir_all(&markers.state_dir)
+        .map_err(|error| TypedError::io("create state dir", error))?;
+    let generation = match std::fs::metadata(&markers.ready) {
+        Ok(_) => generation_of(&markers.ready)?,
+        Err(_) => None,
+    };
+    let marker = match &generation {
+        Some(generation) => format!("{RELEASE_PREFIX}{generation}\n"),
+        None => format!("{LEGACY_RELEASE_TOKEN}\n"),
+    };
+    write_atomic(&markers.release, &marker, 0o600)?;
+    // The helper acknowledges by dropping its generation line (or the whole
+    // marker, for a legacy helper).
+    let acknowledged = poll(RELEASE_POLLS, RELEASE_INTERVAL, || match &generation {
+        Some(generation) => {
+            let line = format!("{GENERATION_PREFIX}{generation}");
+            !std::fs::read_to_string(&markers.ready)
+                .map(|c| c.lines().any(|l| l == line))
+                .unwrap_or(false)
+        }
+        None => !markers.ready.exists(),
+    });
+    if !acknowledged {
+        return Err(TypedError::new(
+            typed_error::NO_ACK,
+            "the clone did not acknowledge its release marker",
+        ));
+    }
+    Ok(())
+}
+
+/// Assign and release a held clone, idempotently.
+///
+/// A retry with the same `activation_token` finishes a partial commit; a
+/// different token is refused, because a held slot is assigned exactly once.
+#[allow(clippy::too_many_arguments)]
+pub fn activate(
+    markers: &Markers,
+    env_dotenv: &str,
+    env_sourceable: &str,
+    env_path: &Path,
+    branch_env_path: &Path,
+    require_dir: Option<&Path>,
+    env_dir: &Path,
+    activation_token: &str,
+) -> Result<Activation, TypedError> {
+    let receipt_matches = || {
+        std::fs::read_to_string(&markers.receipt)
+            .map(|c| c.trim_end_matches('\n') == activation_token)
+            .unwrap_or(false)
+    };
+    if markers.release.exists() {
+        return if receipt_matches() {
+            Ok(Activation::AlreadyDone)
+        } else {
+            Err(TypedError::new(
+                typed_error::TOKEN_MISMATCH,
+                "this clone was already activated with a different token",
+            ))
+        };
+    }
+    if !markers.ready.exists() {
+        return Err(TypedError::new(
+            typed_error::NOT_READY,
+            "the clone has no ready marker; it was not restored at a branchpoint",
+        ));
+    }
+    let generation = generation_of(&markers.ready)?;
+    let _ = std::fs::remove_file(&markers.worker_ready);
+
+    // Claim: a hard link is atomic and fails if the receipt already exists.
+    let receipt_tmp = markers.receipt.with_file_name(format!(
+        "activation.{activation_token}.{}",
+        std::process::id()
+    ));
+    write_private(&receipt_tmp, &format!("{activation_token}\n"), 0o600)?;
+    let claimed = std::fs::hard_link(&receipt_tmp, &markers.receipt).is_ok();
+    let _ = std::fs::remove_file(&receipt_tmp);
+    if !claimed && !receipt_matches() {
+        return Err(TypedError::new(
+            typed_error::TOKEN_MISMATCH,
+            "another activation claimed this clone first",
+        ));
+    }
+
+    if let Some(dir) = require_dir {
+        if !dir.is_dir() {
+            return Err(TypedError::new(
+                typed_error::IO,
+                format!("missing {}", dir.display()),
+            ));
+        }
+    }
+    std::fs::create_dir_all(env_dir)
+        .map_err(|error| TypedError::io("create env directory", error))?;
+    write_atomic(env_path, env_dotenv, 0o600)?;
+    write_atomic(branch_env_path, env_sourceable, 0o600)?;
+    let marker = match generation {
+        Some(generation) => format!("{RELEASE_PREFIX}{generation}\n"),
+        None => format!("{LEGACY_RELEASE_TOKEN}\n"),
+    };
+    write_atomic(&markers.release, &marker, 0o600)?;
+    Ok(Activation::Done)
+}
+
+/// Wait until the released workload publishes `token` as worker-ready.
+pub fn wait_worker_ready(
+    markers: &Markers,
+    token: &str,
+    timeout: Duration,
+) -> Result<(), TypedError> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Ok(contents) = std::fs::read_to_string(&markers.worker_ready) {
+            return if contents.trim_end_matches('\n') == token {
+                Ok(())
+            } else {
+                Err(TypedError::new(
+                    typed_error::TOKEN_MISMATCH,
+                    "the workload published a different worker-ready token",
+                ))
+            };
+        }
+        if Instant::now() >= deadline {
+            return Err(TypedError::new(
+                typed_error::NO_ACK,
+                format!(
+                    "the workload did not publish worker-ready within {:.1}s",
+                    timeout.as_secs_f64()
+                ),
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ready_with(markers: &Markers, generation: &str) {
+        std::fs::create_dir_all(&markers.state_dir).unwrap();
+        std::fs::write(
+            &markers.ready,
+            format!("smolvm-forkpoint-v1\n{GENERATION_PREFIX}{generation}\n"),
+        )
+        .unwrap();
+    }
+
+    const GEN: &str = "0123456789abcdef0123456789abcdef";
+
+    #[test]
+    fn wait_ready_returns_the_marker_or_times_out_with_guidance() {
+        let temp = tempfile::tempdir().unwrap();
+        let markers = Markers::under(&temp.path().join("state"));
+        let err = wait_ready(&markers, Duration::from_millis(120)).unwrap_err();
+        assert_eq!(err.code, typed_error::NOT_READY);
+        assert!(err.message.contains("smolvm-branch-ready"));
+        ready_with(&markers, GEN);
+        assert!(wait_ready(&markers, Duration::from_secs(1))
+            .unwrap()
+            .contains(GEN));
+    }
+
+    #[test]
+    fn arm_requires_a_generation_and_waits_for_the_ack() {
+        let temp = tempfile::tempdir().unwrap();
+        let markers = Markers::under(&temp.path().join("state"));
+        std::fs::create_dir_all(&markers.state_dir).unwrap();
+        std::fs::write(&markers.ready, "smolvm-forkpoint-v1\n").unwrap();
+        assert_eq!(arm(&markers).unwrap_err().code, typed_error::BAD_GENERATION);
+        ready_with(&markers, GEN);
+        // A helper answers arming by publishing the armed marker.
+        let armed = markers.armed.clone();
+        let arm_path = markers.arm.clone();
+        let helper = std::thread::spawn(move || {
+            for _ in 0..400 {
+                if let Ok(c) = std::fs::read_to_string(&arm_path) {
+                    let gen = c.trim_start_matches(ARM_PREFIX).trim();
+                    std::fs::write(&armed, format!("{ARMED_PREFIX}{gen}\n")).unwrap();
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(5));
+            }
+        });
+        arm(&markers).unwrap();
+        helper.join().unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&markers.arm).unwrap(),
+            format!("{ARM_PREFIX}{GEN}\n")
+        );
+        // park clears arm and waits for armed to go.
+        let armed = markers.armed.clone();
+        let helper = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(30));
+            std::fs::remove_file(&armed).unwrap();
+        });
+        park(&markers).unwrap();
+        helper.join().unwrap();
+        assert!(!markers.arm.exists());
+    }
+
+    #[test]
+    fn arm_reports_a_silent_helper() {
+        let temp = tempfile::tempdir().unwrap();
+        let markers = Markers::under(&temp.path().join("state"));
+        ready_with(&markers, GEN);
+        assert_eq!(arm(&markers).unwrap_err().code, typed_error::NO_ACK);
+    }
+
+    #[test]
+    fn release_writes_the_generation_marker_and_waits_for_the_ack() {
+        let temp = tempfile::tempdir().unwrap();
+        let markers = Markers::under(&temp.path().join("state"));
+        ready_with(&markers, GEN);
+        let ready = markers.ready.clone();
+        let release_path = markers.release.clone();
+        let helper = std::thread::spawn(move || {
+            for _ in 0..500 {
+                if let Ok(c) = std::fs::read_to_string(&release_path) {
+                    assert_eq!(c, format!("{RELEASE_PREFIX}{GEN}\n"));
+                    std::fs::write(&ready, "smolvm-forkpoint-v1\n").unwrap(); // ack: drop the line
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(5));
+            }
+        });
+        release(&markers).unwrap();
+        helper.join().unwrap();
+        // A legacy helper (no generation) gets the legacy token and acks by removing ready.
+        std::fs::write(&markers.ready, "ready\n").unwrap();
+        let ready = markers.ready.clone();
+        let helper = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(30));
+            std::fs::remove_file(&ready).unwrap();
+        });
+        release(&markers).unwrap();
+        helper.join().unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&markers.release).unwrap(),
+            format!("{LEGACY_RELEASE_TOKEN}\n")
+        );
+    }
+
+    #[test]
+    fn activate_is_idempotent_per_token_and_refuses_another() {
+        let temp = tempfile::tempdir().unwrap();
+        let markers = Markers::under(&temp.path().join("state"));
+        ready_with(&markers, GEN);
+        std::fs::write(&markers.worker_ready, "stale\n").unwrap();
+        let ws = temp.path().join("workspace");
+        let env = ws.join("fork-env");
+        let benv = ws.join("branch-env");
+        let first = activate(
+            &markers,
+            "LR=3e-4\n",
+            "export LR='3e-4'\n",
+            &env,
+            &benv,
+            None,
+            &ws,
+            "tok-a",
+        )
+        .unwrap();
+        assert_eq!(first, Activation::Done);
+        assert_eq!(std::fs::read_to_string(&env).unwrap(), "LR=3e-4\n");
+        assert_eq!(
+            std::fs::read_to_string(&benv).unwrap(),
+            "export LR='3e-4'\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&markers.release).unwrap(),
+            format!("{RELEASE_PREFIX}{GEN}\n")
+        );
+        assert!(!markers.worker_ready.exists());
+        // Retry with the same token: already done, nothing rewritten.
+        let again = activate(
+            &markers,
+            "LR=changed\n",
+            "export LR='changed'\n",
+            &env,
+            &benv,
+            None,
+            &ws,
+            "tok-a",
+        )
+        .unwrap();
+        assert_eq!(again, Activation::AlreadyDone);
+        assert_eq!(std::fs::read_to_string(&env).unwrap(), "LR=3e-4\n");
+        // A different token is refused.
+        let other = activate(&markers, "LR=x\n", "", &env, &benv, None, &ws, "tok-b").unwrap_err();
+        assert_eq!(other.code, typed_error::TOKEN_MISMATCH);
+    }
+
+    #[test]
+    fn activate_refuses_a_clone_that_is_not_at_a_branchpoint() {
+        let temp = tempfile::tempdir().unwrap();
+        let markers = Markers::under(&temp.path().join("state"));
+        std::fs::create_dir_all(&markers.state_dir).unwrap();
+        let ws = temp.path().join("ws");
+        let err = activate(
+            &markers,
+            "",
+            "",
+            &ws.join("e"),
+            &ws.join("b"),
+            None,
+            &ws,
+            "t",
+        )
+        .unwrap_err();
+        assert_eq!(err.code, typed_error::NOT_READY);
+    }
+
+    #[test]
+    fn activate_refuses_to_fabricate_a_missing_overlay_root() {
+        let temp = tempfile::tempdir().unwrap();
+        let markers = Markers::under(&temp.path().join("state"));
+        std::fs::create_dir_all(&markers.state_dir).unwrap();
+        std::fs::write(&markers.ready, format!("ready\ngeneration={GEN}\n")).unwrap();
+        let merged = temp.path().join("merged");
+        let env_dir = merged.join("etc/smolvm");
+        let err = activate(
+            &markers,
+            "",
+            "",
+            &env_dir.join("fork-env"),
+            &env_dir.join("branch-env"),
+            Some(&merged),
+            &env_dir,
+            "tok",
+        )
+        .unwrap_err();
+        assert_eq!(err.code, typed_error::IO);
+        assert!(!merged.exists());
+        assert!(!markers.release.exists());
+    }
+
+    #[test]
+    fn worker_ready_matches_the_token_or_reports_why() {
+        let temp = tempfile::tempdir().unwrap();
+        let markers = Markers::under(&temp.path().join("state"));
+        std::fs::create_dir_all(&markers.state_dir).unwrap();
+        let err = wait_worker_ready(&markers, "t", Duration::from_millis(150)).unwrap_err();
+        assert_eq!(err.code, typed_error::NO_ACK);
+        std::fs::write(&markers.worker_ready, "other\n").unwrap();
+        assert_eq!(
+            wait_worker_ready(&markers, "t", Duration::from_secs(1))
+                .unwrap_err()
+                .code,
+            typed_error::TOKEN_MISMATCH
+        );
+        std::fs::write(&markers.worker_ready, "t\n").unwrap();
+        wait_worker_ready(&markers, "t", Duration::from_secs(1)).unwrap();
+    }
+}

--- a/crates/smolvm-agent/src/branchpoint.rs
+++ b/crates/smolvm-agent/src/branchpoint.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use smolvm_protocol::forkpoint::{
-    typed_error, ARMED_PREFIX, ARM_PREFIX, GENERATION_PREFIX, LEGACY_RELEASE_TOKEN, RELEASE_PREFIX,
+    typed_error, ARMED_PREFIX, ARM_PREFIX, GENERATION_PREFIX, RELEASE_PREFIX,
 };
 
 /// A failed step, carrying the protocol error code the host handles on.
@@ -109,11 +109,9 @@ fn settled(markers: &Markers, window: Duration, condition: impl FnMut() -> bool)
     crate::dirwatch::wait_until(&markers.state_dir, window, condition)
 }
 
-/// The generation recorded in a ready marker: the first `generation=` line.
-/// `Ok(None)` when the marker carries none or it is not 32 hex digits, which
-/// is the legacy helper's marker and is handled by each caller as the script
-/// did.
-fn generation_of(ready: &Path) -> Result<Option<String>, TypedError> {
+/// The generation recorded in a ready marker: its `generation=` line, 32 hex
+/// digits. A marker without one is not a branchpoint this protocol can drive.
+fn generation_of(ready: &Path) -> Result<String, TypedError> {
     let contents = match std::fs::read_to_string(ready) {
         Ok(contents) => contents,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
@@ -130,10 +128,15 @@ fn generation_of(ready: &Path) -> Result<Option<String>, TypedError> {
         .find_map(|line| line.strip_prefix(GENERATION_PREFIX))
         .unwrap_or("");
     let valid = generation.len() == 32 && generation.bytes().all(|b| b.is_ascii_hexdigit());
-    Ok(valid.then(|| generation.to_string()))
+    if !valid {
+        return Err(TypedError::new(
+            typed_error::BAD_GENERATION,
+            "the ready marker carries no usable generation; the helper and agent disagree",
+        ));
+    }
+    Ok(generation.to_string())
 }
 
-/// Write `contents` to `path` atomically via a sibling temp file.
 fn write_atomic(path: &Path, contents: &str, mode: u32) -> Result<(), TypedError> {
     let tmp = path.with_extension("tmp");
     write_private(&tmp, contents, mode)?;
@@ -197,12 +200,7 @@ pub fn wait_ready(markers: &Markers, timeout: Duration) -> Result<String, TypedE
 
 /// Put a negotiated helper into its restore-safe loop before capture.
 pub fn arm(markers: &Markers) -> Result<(), TypedError> {
-    let generation = generation_of(&markers.ready)?.ok_or_else(|| {
-        TypedError::new(
-            typed_error::BAD_GENERATION,
-            "the ready marker carries no usable generation; the helper predates arming",
-        )
-    })?;
+    let generation = generation_of(&markers.ready)?;
     let _ = std::fs::remove_file(&markers.arm);
     if !settled(markers, ACK_WINDOW, || !markers.armed.exists()) {
         return Err(TypedError::new(
@@ -245,22 +243,20 @@ pub fn park(markers: &Markers) -> Result<(), TypedError> {
 pub fn release(markers: &Markers, env_dotenv: Option<&str>) -> Result<(), TypedError> {
     std::fs::create_dir_all(&markers.state_dir)
         .map_err(|error| TypedError::io("create state dir", error))?;
-    let generation = match std::fs::metadata(&markers.ready) {
-        Ok(_) => generation_of(&markers.ready)?,
-        Err(_) => None,
-    };
-    let marker = release_marker(generation.as_deref(), env_dotenv.unwrap_or(""));
+    // No ready marker means no parked helper: a checkpoint taken away from
+    // any branchpoint has nothing to release, and that is not an error.
+    if !markers.ready.exists() {
+        return Ok(());
+    }
+    let generation = generation_of(&markers.ready)?;
+    let marker = release_marker(&generation, env_dotenv.unwrap_or(""));
     write_atomic(&markers.release, &marker, 0o600)?;
-    // The helper acknowledges by dropping its generation line (or the whole
-    // marker, for a legacy helper).
-    let acknowledged = settled(markers, RELEASE_WINDOW, || match &generation {
-        Some(generation) => {
-            let line = format!("{GENERATION_PREFIX}{generation}");
-            !std::fs::read_to_string(&markers.ready)
-                .map(|c| c.lines().any(|l| l == line))
-                .unwrap_or(false)
-        }
-        None => !markers.ready.exists(),
+    // The helper acknowledges by dropping its generation line.
+    let line = format!("{GENERATION_PREFIX}{generation}");
+    let acknowledged = settled(markers, RELEASE_WINDOW, || {
+        !std::fs::read_to_string(&markers.ready)
+            .map(|c| c.lines().any(|l| l == line))
+            .unwrap_or(false)
     });
     if !acknowledged {
         return Err(TypedError::new(
@@ -339,7 +335,7 @@ pub fn activate(
     write_atomic(branch_env_path, env_sourceable, 0o600)?;
     write_atomic(
         &markers.release,
-        &release_marker(generation.as_deref(), env_dotenv),
+        &release_marker(&generation, env_dotenv),
         0o600,
     )?;
     Ok(Activation::Done)
@@ -348,12 +344,8 @@ pub fn activate(
 /// The release marker: the token line, then the identity as dotenv lines.
 /// One atomic rename hands the helper both, so it never has to order this
 /// file against the env files in the clone's root.
-fn release_marker(generation: Option<&str>, env_dotenv: &str) -> String {
-    let token = match generation {
-        Some(generation) => format!("{RELEASE_PREFIX}{generation}"),
-        None => LEGACY_RELEASE_TOKEN.to_string(),
-    };
-    let mut marker = format!("{token}\n");
+fn release_marker(generation: &str, env_dotenv: &str) -> String {
+    let mut marker = format!("{RELEASE_PREFIX}{generation}\n");
     for line in env_dotenv.lines().filter(|line| line.contains('=')) {
         marker.push_str(line);
         marker.push('\n');
@@ -488,19 +480,18 @@ mod tests {
         )
         .unwrap();
         helper.join().unwrap();
-        // A legacy helper (no generation) gets the legacy token and acks by removing ready.
+        // A ready marker without a generation is a protocol mismatch, not a
+        // case to accommodate.
         std::fs::write(&markers.ready, "ready\n").unwrap();
-        let ready = markers.ready.clone();
-        let helper = std::thread::spawn(move || {
-            std::thread::sleep(Duration::from_millis(30));
-            std::fs::remove_file(&ready).unwrap();
-        });
-        release(&markers, None).unwrap();
-        helper.join().unwrap();
         assert_eq!(
-            std::fs::read_to_string(&markers.release).unwrap(),
-            format!("{LEGACY_RELEASE_TOKEN}\n")
+            release(&markers, None).unwrap_err().code,
+            typed_error::BAD_GENERATION
         );
+        // No ready marker at all: nothing is parked, so there is nothing to do.
+        std::fs::remove_file(&markers.ready).unwrap();
+        let _ = std::fs::remove_file(&markers.release);
+        release(&markers, None).unwrap();
+        assert!(!markers.release.exists());
     }
 
     #[test]

--- a/crates/smolvm-agent/src/branchpoint.rs
+++ b/crates/smolvm-agent/src/branchpoint.rs
@@ -10,7 +10,7 @@
 //! way the scripts were.
 
 use std::path::{Path, PathBuf};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use smolvm_protocol::forkpoint::{
     typed_error, ARMED_PREFIX, ARM_PREFIX, GENERATION_PREFIX, LEGACY_RELEASE_TOKEN, RELEASE_PREFIX,
@@ -97,22 +97,16 @@ impl Markers {
     }
 }
 
-/// The scripts' acknowledgement window: 400 polls of 5 ms.
-const ACK_POLLS: u32 = 400;
-const ACK_INTERVAL: Duration = Duration::from_millis(5);
-/// The release script's window: 500 polls of 20 ms.
-const RELEASE_POLLS: u32 = 500;
-const RELEASE_INTERVAL: Duration = Duration::from_millis(20);
+/// How long the helper has to acknowledge an arm or park (the scripts allowed
+/// 400 polls of 5 ms).
+const ACK_WINDOW: Duration = Duration::from_secs(2);
+/// How long a restored clone has to acknowledge its release (500 polls of 20 ms).
+const RELEASE_WINDOW: Duration = Duration::from_secs(10);
 
-/// Poll `condition` up to `polls` times, `interval` apart; true if it held.
-fn poll(polls: u32, interval: Duration, mut condition: impl FnMut() -> bool) -> bool {
-    for _ in 0..polls {
-        if condition() {
-            return true;
-        }
-        std::thread::sleep(interval);
-    }
-    condition()
+/// Re-check `condition` after every change to the state directory until it
+/// holds or `window` elapses; true if it held.
+fn settled(markers: &Markers, window: Duration, condition: impl FnMut() -> bool) -> bool {
+    crate::dirwatch::wait_until(&markers.state_dir, window, condition)
 }
 
 /// The generation recorded in a ready marker: the first `generation=` line.
@@ -175,25 +169,30 @@ fn write_private(path: &Path, contents: &str, mode: u32) -> Result<(), TypedErro
 /// Wait until the workload declares its branchpoint; returns the ready
 /// marker's contents (its profile lines).
 pub fn wait_ready(markers: &Markers, timeout: Duration) -> Result<String, TypedError> {
-    let deadline = Instant::now() + timeout;
-    loop {
+    let mut outcome = None;
+    settled(markers, timeout, || {
         match std::fs::read_to_string(&markers.ready) {
-            Ok(contents) => return Ok(contents),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => return Err(TypedError::io("read ready marker", error)),
+            Ok(contents) => {
+                outcome = Some(Ok(contents));
+                true
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+            Err(error) => {
+                outcome = Some(Err(TypedError::io("read ready marker", error)));
+                true
+            }
         }
-        if Instant::now() >= deadline {
-            return Err(TypedError::new(
-                typed_error::NOT_READY,
-                format!(
-                    "the workload did not reach a branchpoint within {:.1}s; it declares one by \
-                     running `smolvm-branch-ready` once its setup is done",
-                    timeout.as_secs_f64()
-                ),
-            ));
-        }
-        std::thread::sleep(Duration::from_millis(50));
-    }
+    });
+    outcome.unwrap_or_else(|| {
+        Err(TypedError::new(
+            typed_error::NOT_READY,
+            format!(
+                "the workload did not reach a branchpoint within {:.1}s; it declares one by \
+                 running `smolvm-branch-ready` once its setup is done",
+                timeout.as_secs_f64()
+            ),
+        ))
+    })
 }
 
 /// Put a negotiated helper into its restore-safe loop before capture.
@@ -205,7 +204,7 @@ pub fn arm(markers: &Markers) -> Result<(), TypedError> {
         )
     })?;
     let _ = std::fs::remove_file(&markers.arm);
-    if !poll(ACK_POLLS, ACK_INTERVAL, || !markers.armed.exists()) {
+    if !settled(markers, ACK_WINDOW, || !markers.armed.exists()) {
         return Err(TypedError::new(
             typed_error::NO_ACK,
             "a previous arming was never cleared by the helper",
@@ -213,7 +212,7 @@ pub fn arm(markers: &Markers) -> Result<(), TypedError> {
     }
     write_atomic(&markers.arm, &format!("{ARM_PREFIX}{generation}\n"), 0o644)?;
     let expected = format!("{ARMED_PREFIX}{generation}");
-    let acknowledged = poll(ACK_POLLS, ACK_INTERVAL, || {
+    let acknowledged = settled(markers, ACK_WINDOW, || {
         std::fs::read_to_string(&markers.armed)
             .map(|c| c.lines().any(|line| line == expected))
             .unwrap_or(false)
@@ -230,7 +229,7 @@ pub fn arm(markers: &Markers) -> Result<(), TypedError> {
 /// Return a parked source to its ordinary wait after capture.
 pub fn park(markers: &Markers) -> Result<(), TypedError> {
     let _ = std::fs::remove_file(&markers.arm);
-    if !poll(ACK_POLLS, ACK_INTERVAL, || !markers.armed.exists()) {
+    if !settled(markers, ACK_WINDOW, || !markers.armed.exists()) {
         return Err(TypedError::new(
             typed_error::NO_ACK,
             "the helper did not leave its armed loop within the window",
@@ -243,21 +242,18 @@ pub fn park(markers: &Markers) -> Result<(), TypedError> {
 ///
 /// The state directory is private guest RAM, so this wakes only this clone
 /// even though every clone inherited the same blocked helper.
-pub fn release(markers: &Markers) -> Result<(), TypedError> {
+pub fn release(markers: &Markers, env_dotenv: Option<&str>) -> Result<(), TypedError> {
     std::fs::create_dir_all(&markers.state_dir)
         .map_err(|error| TypedError::io("create state dir", error))?;
     let generation = match std::fs::metadata(&markers.ready) {
         Ok(_) => generation_of(&markers.ready)?,
         Err(_) => None,
     };
-    let marker = match &generation {
-        Some(generation) => format!("{RELEASE_PREFIX}{generation}\n"),
-        None => format!("{LEGACY_RELEASE_TOKEN}\n"),
-    };
+    let marker = release_marker(generation.as_deref(), env_dotenv.unwrap_or(""));
     write_atomic(&markers.release, &marker, 0o600)?;
     // The helper acknowledges by dropping its generation line (or the whole
     // marker, for a legacy helper).
-    let acknowledged = poll(RELEASE_POLLS, RELEASE_INTERVAL, || match &generation {
+    let acknowledged = settled(markers, RELEASE_WINDOW, || match &generation {
         Some(generation) => {
             let line = format!("{GENERATION_PREFIX}{generation}");
             !std::fs::read_to_string(&markers.ready)
@@ -341,12 +337,28 @@ pub fn activate(
         .map_err(|error| TypedError::io("create env directory", error))?;
     write_atomic(env_path, env_dotenv, 0o600)?;
     write_atomic(branch_env_path, env_sourceable, 0o600)?;
-    let marker = match generation {
-        Some(generation) => format!("{RELEASE_PREFIX}{generation}\n"),
-        None => format!("{LEGACY_RELEASE_TOKEN}\n"),
-    };
-    write_atomic(&markers.release, &marker, 0o600)?;
+    write_atomic(
+        &markers.release,
+        &release_marker(generation.as_deref(), env_dotenv),
+        0o600,
+    )?;
     Ok(Activation::Done)
+}
+
+/// The release marker: the token line, then the identity as dotenv lines.
+/// One atomic rename hands the helper both, so it never has to order this
+/// file against the env files in the clone's root.
+fn release_marker(generation: Option<&str>, env_dotenv: &str) -> String {
+    let token = match generation {
+        Some(generation) => format!("{RELEASE_PREFIX}{generation}"),
+        None => LEGACY_RELEASE_TOKEN.to_string(),
+    };
+    let mut marker = format!("{token}\n");
+    for line in env_dotenv.lines().filter(|line| line.contains('=')) {
+        marker.push_str(line);
+        marker.push('\n');
+    }
+    marker
 }
 
 /// Wait until the released workload publishes `token` as worker-ready.
@@ -355,28 +367,24 @@ pub fn wait_worker_ready(
     token: &str,
     timeout: Duration,
 ) -> Result<(), TypedError> {
-    let deadline = Instant::now() + timeout;
-    loop {
-        if let Ok(contents) = std::fs::read_to_string(&markers.worker_ready) {
-            return if contents.trim_end_matches('\n') == token {
-                Ok(())
-            } else {
-                Err(TypedError::new(
-                    typed_error::TOKEN_MISMATCH,
-                    "the workload published a different worker-ready token",
-                ))
-            };
-        }
-        if Instant::now() >= deadline {
-            return Err(TypedError::new(
-                typed_error::NO_ACK,
-                format!(
-                    "the workload did not publish worker-ready within {:.1}s",
-                    timeout.as_secs_f64()
-                ),
-            ));
-        }
-        std::thread::sleep(Duration::from_millis(100));
+    let mut published = None;
+    settled(markers, timeout, || {
+        published = std::fs::read_to_string(&markers.worker_ready).ok();
+        published.is_some()
+    });
+    match published {
+        Some(contents) if contents.trim_end_matches('\n') == token => Ok(()),
+        Some(_) => Err(TypedError::new(
+            typed_error::TOKEN_MISMATCH,
+            "the workload published a different worker-ready token",
+        )),
+        None => Err(TypedError::new(
+            typed_error::NO_ACK,
+            format!(
+                "the workload did not publish worker-ready within {:.1}s",
+                timeout.as_secs_f64()
+            ),
+        )),
     }
 }
 
@@ -464,14 +472,21 @@ mod tests {
         let helper = std::thread::spawn(move || {
             for _ in 0..500 {
                 if let Ok(c) = std::fs::read_to_string(&release_path) {
-                    assert_eq!(c, format!("{RELEASE_PREFIX}{GEN}\n"));
+                    assert_eq!(
+                        c,
+                        format!("{RELEASE_PREFIX}{GEN}\nLR=3e-4\nSMOLVM_BRANCH_NAME=w-0\n")
+                    );
                     std::fs::write(&ready, "smolvm-forkpoint-v1\n").unwrap(); // ack: drop the line
                     return;
                 }
                 std::thread::sleep(Duration::from_millis(5));
             }
         });
-        release(&markers).unwrap();
+        release(
+            &markers,
+            Some("LR=3e-4\nnot a pair\nSMOLVM_BRANCH_NAME=w-0\n"),
+        )
+        .unwrap();
         helper.join().unwrap();
         // A legacy helper (no generation) gets the legacy token and acks by removing ready.
         std::fs::write(&markers.ready, "ready\n").unwrap();
@@ -480,7 +495,7 @@ mod tests {
             std::thread::sleep(Duration::from_millis(30));
             std::fs::remove_file(&ready).unwrap();
         });
-        release(&markers).unwrap();
+        release(&markers, None).unwrap();
         helper.join().unwrap();
         assert_eq!(
             std::fs::read_to_string(&markers.release).unwrap(),
@@ -516,7 +531,7 @@ mod tests {
         );
         assert_eq!(
             std::fs::read_to_string(&markers.release).unwrap(),
-            format!("{RELEASE_PREFIX}{GEN}\n")
+            format!("{RELEASE_PREFIX}{GEN}\nLR=3e-4\n")
         );
         assert!(!markers.worker_ready.exists());
         // Retry with the same token: already done, nothing rewritten.

--- a/crates/smolvm-agent/src/dirwatch.rs
+++ b/crates/smolvm-agent/src/dirwatch.rs
@@ -1,0 +1,173 @@
+//! Event-driven waits on the branchpoint state directory.
+//!
+//! Both sides of the branchpoint handshake communicate through marker files in
+//! one directory. A wait here blocks in the kernel until that directory
+//! changes, so neither side polls or spins; the caller always re-checks its
+//! markers after a wake, which closes the check/sleep race. Where inotify is
+//! unavailable the wait degrades to a short sleep and the same re-check loop
+//! turns into ordinary polling.
+
+use std::path::Path;
+use std::time::Duration;
+
+#[cfg(target_os = "linux")]
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+
+/// A watch on one directory.
+pub struct DirWatcher {
+    #[cfg(target_os = "linux")]
+    fd: OwnedFd,
+}
+
+/// The sleep a non-inotify wait uses between re-checks.
+#[cfg(not(target_os = "linux"))]
+const FALLBACK_INTERVAL: Duration = Duration::from_millis(5);
+
+impl DirWatcher {
+    /// Watch `dir` for files appearing, disappearing, or finishing a write.
+    #[cfg(target_os = "linux")]
+    pub fn new(dir: &Path) -> std::io::Result<Self> {
+        use std::os::unix::ffi::OsStrExt;
+        let path = std::ffi::CString::new(dir.as_os_str().as_bytes()).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "watched directory path contains NUL",
+            )
+        })?;
+        let raw_fd = unsafe { libc::inotify_init1(libc::IN_CLOEXEC | libc::IN_NONBLOCK) };
+        if raw_fd < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        let fd = unsafe { OwnedFd::from_raw_fd(raw_fd) };
+        let mask = libc::IN_CREATE
+            | libc::IN_DELETE
+            | libc::IN_MOVED_FROM
+            | libc::IN_MOVED_TO
+            | libc::IN_CLOSE_WRITE;
+        if unsafe { libc::inotify_add_watch(fd.as_raw_fd(), path.as_ptr(), mask) } < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(Self { fd })
+    }
+
+    /// Watch `dir`; without inotify every wait is a short sleep.
+    #[cfg(not(target_os = "linux"))]
+    pub fn new(dir: &Path) -> std::io::Result<Self> {
+        if !dir.is_dir() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("{} is not a directory", dir.display()),
+            ));
+        }
+        Ok(Self {})
+    }
+
+    /// Block until the directory changes or `timeout` elapses; `None` waits
+    /// without a time limit. Either way the caller re-checks its markers
+    /// next, so the two are not distinguished. An untimed wait holds no
+    /// kernel timer, which is what lets a waiter sit inside a snapshot and
+    /// wake correctly in every restored copy.
+    #[cfg(target_os = "linux")]
+    pub fn wait(&self, timeout: Option<Duration>) -> std::io::Result<()> {
+        let millis = match timeout {
+            None => -1,
+            Some(timeout) => timeout.as_millis().min(i32::MAX as u128) as i32,
+        };
+        let mut descriptor = libc::pollfd {
+            fd: self.fd.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        loop {
+            let ready = unsafe { libc::poll(&mut descriptor, 1, millis) };
+            if ready > 0 {
+                self.drain();
+                return Ok(());
+            }
+            if ready == 0 {
+                return Ok(());
+            }
+            let error = std::io::Error::last_os_error();
+            if error.kind() != std::io::ErrorKind::Interrupted {
+                return Err(error);
+            }
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub fn wait(&self, timeout: Option<Duration>) -> std::io::Result<()> {
+        std::thread::sleep(timeout.map_or(FALLBACK_INTERVAL, |t| t.min(FALLBACK_INTERVAL)));
+        Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    fn drain(&self) {
+        let mut events = [0_u8; 4096];
+        loop {
+            let read = unsafe {
+                libc::read(
+                    self.fd.as_raw_fd(),
+                    events.as_mut_ptr().cast(),
+                    events.len(),
+                )
+            };
+            if read <= 0 {
+                return;
+            }
+        }
+    }
+}
+
+/// Re-check `done` after every change to `dir` until it holds or `timeout`
+/// elapses. Returns whether it held. Without a watch this polls at a short
+/// interval so the outcome is the same, only later.
+pub fn wait_until(dir: &Path, timeout: Duration, mut done: impl FnMut() -> bool) -> bool {
+    let deadline = std::time::Instant::now() + timeout;
+    let watcher = DirWatcher::new(dir).ok();
+    loop {
+        if done() {
+            return true;
+        }
+        let now = std::time::Instant::now();
+        if now >= deadline {
+            return false;
+        }
+        let remaining = deadline - now;
+        match watcher.as_ref().map(|w| w.wait(Some(remaining))) {
+            Some(Ok(_)) => {}
+            Some(Err(_)) | None => std::thread::sleep(remaining.min(Duration::from_millis(5))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wait_until_returns_when_the_condition_holds() {
+        let temp = tempfile::tempdir().unwrap();
+        let marker = temp.path().join("marker");
+        let writer = {
+            let marker = marker.clone();
+            std::thread::spawn(move || {
+                std::thread::sleep(Duration::from_millis(40));
+                std::fs::write(&marker, "x").unwrap();
+            })
+        };
+        let started = std::time::Instant::now();
+        assert!(wait_until(temp.path(), Duration::from_secs(5), || marker.exists()));
+        assert!(started.elapsed() < Duration::from_secs(2));
+        writer.join().unwrap();
+    }
+
+    #[test]
+    fn wait_until_reports_a_timeout() {
+        let temp = tempfile::tempdir().unwrap();
+        let started = std::time::Instant::now();
+        assert!(!wait_until(temp.path(), Duration::from_millis(60), || {
+            false
+        }));
+        assert!(started.elapsed() >= Duration::from_millis(60));
+    }
+}

--- a/crates/smolvm-agent/src/forkpoint.rs
+++ b/crates/smolvm-agent/src/forkpoint.rs
@@ -14,22 +14,13 @@ const AGENT_BINARY: &str = "/usr/local/bin/smolvm-agent";
 use smolvm_protocol::forkpoint::{
     ARMED_PATH, ARMED_PREFIX, ARM_PATH, ARM_PREFIX, BRANCH_ENV_PATH, BRANCH_HELPER_PATH,
     CONTAINER_INIT_ARG, CONTAINER_INIT_NAME, CUDA_PRELOAD_MODULES_HINT, FORK_ENV_PATH,
-    GENERATION_PREFIX, HELPER_PATH, LEGACY_RELEASE_TOKEN, READY_PATH, READY_VERSION, RELEASE_PATH,
-    RELEASE_PREFIX, RESTORED_CONTAINER_PATH, RESTORED_PATH, STATE_DIR, WORKER_READY_HELPER_PATH,
-    WORKER_READY_PATH, WORKER_READY_TOKEN_ENV,
+    GENERATION_PREFIX, HELPER_PATH, READY_PATH, READY_VERSION, RELEASE_PATH, RELEASE_PREFIX,
+    RESTORED_CONTAINER_PATH, RESTORED_PATH, STATE_DIR, WORKER_READY_HELPER_PATH, WORKER_READY_PATH,
+    WORKER_READY_TOKEN_ENV,
 };
 
 fn enabled() -> bool {
     std::env::var(smolvm_protocol::guest_env::FORKABLE).as_deref()
-        == Ok(smolvm_protocol::guest_env::VALUE_ON)
-}
-
-/// Whether the paired host supports parking and arming an idle branchpoint.
-///
-/// This is negotiated by the host at boot. A new guest launched by an older
-/// host leaves it unset and retains the legacy always-spinning behavior.
-pub fn arming_enabled() -> bool {
-    std::env::var(smolvm_protocol::guest_env::BRANCHPOINT_ARMING).as_deref()
         == Ok(smolvm_protocol::guest_env::VALUE_ON)
 }
 
@@ -92,25 +83,24 @@ pub fn setup() {
 /// Expose the forkpoint helper and its VM-private state directory inside a
 /// workload container. No-op for ordinary machines.
 pub fn inject_into_container(spec: &mut crate::oci::OciSpec) {
-    inject_into_container_if(spec, enabled(), arming_enabled(), AGENT_BINARY, STATE_DIR);
+    inject_into_container_if(spec, enabled(), AGENT_BINARY, STATE_DIR);
 }
 
-/// Keep a `crun exec` process on the same negotiated arming protocol as the
-/// container it joins.
+/// Keep a `crun exec` process on the same footing as the container it joins.
 ///
 /// `crun exec --env` builds a fresh process environment instead of inheriting
 /// the container spec. Without restoring this internal variable, a
-/// `smolvm-branch-ready` helper launched through `machine exec` falls back to
-/// the legacy spin loop while the host waits for an arming acknowledgement.
+/// `smolvm-branch-ready` helper launched through `machine exec` could not tell
+/// that the machine is branchable.
 pub fn augment_exec_env(mut env: Vec<(String, String)>) -> Vec<(String, String)> {
-    augment_exec_env_if(&mut env, arming_enabled());
+    augment_exec_env_if(&mut env, enabled());
     env
 }
 
-fn augment_exec_env_if(env: &mut Vec<(String, String)>, armable: bool) {
-    let key = smolvm_protocol::guest_env::BRANCHPOINT_ARMING;
+fn augment_exec_env_if(env: &mut Vec<(String, String)>, branchable: bool) {
+    let key = smolvm_protocol::guest_env::FORKABLE;
     env.retain(|(existing, _)| existing != key);
-    if armable {
+    if branchable {
         env.push((
             key.to_string(),
             smolvm_protocol::guest_env::VALUE_ON.to_string(),
@@ -121,7 +111,6 @@ fn augment_exec_env_if(env: &mut Vec<(String, String)>, armable: bool) {
 fn inject_into_container_if(
     spec: &mut crate::oci::OciSpec,
     enabled: bool,
-    armable: bool,
     agent_binary: &str,
     state_dir: &str,
 ) {
@@ -132,12 +121,10 @@ fn inject_into_container_if(
     spec.add_bind_mount(agent_binary, BRANCH_HELPER_PATH, true);
     spec.add_bind_mount(agent_binary, WORKER_READY_HELPER_PATH, true);
     spec.add_bind_mount(state_dir, STATE_DIR, false);
-    if armable {
-        spec.add_env(
-            smolvm_protocol::guest_env::BRANCHPOINT_ARMING,
-            smolvm_protocol::guest_env::VALUE_ON,
-        );
-    }
+    spec.add_env(
+        smolvm_protocol::guest_env::FORKABLE,
+        smolvm_protocol::guest_env::VALUE_ON,
+    );
 }
 
 /// Reap exited children while parked, when the helper is the container's
@@ -172,7 +159,7 @@ pub fn run_helper() -> i32 {
     // Released. The helper is the one mechanism in both directions: the
     // workload declared the branchpoint by running it, and it hands the
     // child's identity back the same way — as this command's result.
-    let identity = load_identity(Path::new(RELEASE_PATH), Path::new(FORK_ENV_PATH));
+    let identity = load_identity(Path::new(RELEASE_PATH));
     if let Some(command) = command {
         // `smolvm-branch-ready -- prog args…`: become the child's program, with
         // its identity in the environment. If the helper was `exec`'d as PID 1,
@@ -247,18 +234,11 @@ fn parse_helper_args<I: Iterator<Item = std::ffi::OsString>>(
 /// (`KEY=VALUE`, one per line, values never contain newlines). Absent for a
 /// source or a single branch, which carry no per-child parameters.
 /// The child's identity: the `KEY=VALUE` lines the release marker carries,
-/// delivered in the same atomic rename as the go-ahead. A marker with none
-/// (an older host's script) points at the dotenv file instead; no file is
-/// simply no identity.
-fn load_identity(release_path: &Path, env_path: &Path) -> Vec<(String, String)> {
-    let from_marker = std::fs::read_to_string(release_path)
+/// delivered in the same atomic rename as the go-ahead. A clone released with
+/// no parameters (a plain single branch) has none.
+fn load_identity(release_path: &Path) -> Vec<(String, String)> {
+    std::fs::read_to_string(release_path)
         .map(|marker| parse_dotenv(marker.lines().skip(1)))
-        .unwrap_or_default();
-    if !from_marker.is_empty() {
-        return from_marker;
-    }
-    std::fs::read_to_string(env_path)
-        .map(|contents| parse_dotenv(contents.lines()))
         .unwrap_or_default()
 }
 
@@ -284,6 +264,12 @@ fn render_identity_exports(identity: &[(String, String)]) -> String {
 }
 
 fn run_helper_inner(preload_modules: bool) -> Result<(), String> {
+    if !enabled() {
+        return Err(
+            "this machine is not branchable; start it with `smolvm machine start --branchable`"
+                .to_string(),
+        );
+    }
     run_helper_at(
         ForkpointPaths {
             state_dir: Path::new(STATE_DIR),
@@ -295,7 +281,6 @@ fn run_helper_inner(preload_modules: bool) -> Result<(), String> {
         },
         Duration::from_millis(20),
         preload_modules,
-        arming_enabled(),
     )
 }
 
@@ -312,7 +297,6 @@ fn run_helper_at(
     paths: ForkpointPaths<'_>,
     poll_interval: Duration,
     preload_modules: bool,
-    use_arming: bool,
 ) -> Result<(), String> {
     let ForkpointPaths {
         state_dir,
@@ -348,57 +332,42 @@ fn run_helper_at(
     eprintln!("smolvm branch point ready; waiting for child release");
     let _ = std::io::stdout().flush();
 
-    let mut watcher = use_arming
-        .then(|| crate::dirwatch::DirWatcher::new(state_dir).ok())
-        .flatten();
+    let mut watcher = crate::dirwatch::DirWatcher::new(state_dir).ok();
 
-    // A timed kernel wait captured in the snapshot is not reliably re-armed by
-    // every VMM restore path, so a host without the arming protocol gets the
-    // legacy userspace loop below. A paired host arms the source immediately
-    // before capture and parks it again afterwards. While parked the helper
-    // sleeps on directory events (bounded, so a PID-1 helper still reaps);
-    // while armed it sleeps on the same events with no time limit, which holds
-    // no kernel timer and so wakes correctly in the source and in every
-    // restored clone once its own state directory changes.
-    if use_arming {
-        while !restored_path.is_file() {
-            // Every wake reaps first — including the wake for the arm marker,
-            // so a job that exited while parked is collected before capture and
-            // never baked into a clone as a zombie.
-            reap_children_if_init();
-            if release_matches(release_path, &generation) {
-                acknowledge_generation(ready_path, &generation);
-                return Ok(());
-            }
-            if arm_matches(arm_path, &generation) {
-                publish_generation_marker(armed_path, ARMED_PREFIX, &generation)?;
-                while !restored_path.is_file() && arm_matches(arm_path, &generation) {
-                    if release_matches(release_path, &generation) {
-                        let _ = std::fs::remove_file(armed_path);
-                        acknowledge_generation(ready_path, &generation);
-                        return Ok(());
-                    }
-                    match watcher.as_ref().map(|w| w.wait(None)) {
-                        Some(Ok(_)) => {}
-                        Some(Err(_)) | None => {
-                            watcher = None;
-                            std::thread::yield_now();
-                        }
+    // The host arms the source immediately before capture and parks it again
+    // afterwards. While parked the helper sleeps on directory events
+    // (bounded, so a PID-1 helper still reaps); while armed it sleeps on the
+    // same events with no time limit, which holds no kernel timer and so wakes
+    // correctly in the source and in every restored clone once its own state
+    // directory changes.
+    while !restored_path.is_file() {
+        // Every wake reaps first — including the wake for the arm marker,
+        // so a job that exited while parked is collected before capture and
+        // never baked into a clone as a zombie.
+        reap_children_if_init();
+        if release_matches(release_path, &generation) {
+            acknowledge_generation(ready_path, &generation);
+            return Ok(());
+        }
+        if arm_matches(arm_path, &generation) {
+            publish_generation_marker(armed_path, ARMED_PREFIX, &generation)?;
+            while !restored_path.is_file() && arm_matches(arm_path, &generation) {
+                if release_matches(release_path, &generation) {
+                    let _ = std::fs::remove_file(armed_path);
+                    acknowledge_generation(ready_path, &generation);
+                    return Ok(());
+                }
+                match watcher.as_ref().map(|w| w.wait(None)) {
+                    Some(Ok(_)) => {}
+                    Some(Err(_)) | None => {
+                        watcher = None;
+                        std::thread::yield_now();
                     }
                 }
-                let _ = std::fs::remove_file(armed_path);
-            } else if !wait_for_change(&mut watcher, poll_interval) {
-                std::thread::sleep(poll_interval);
             }
-        }
-    } else {
-        while !restored_path.is_file() {
-            reap_children_if_init();
-            if release_matches(release_path, &generation) {
-                acknowledge_generation(ready_path, &generation);
-                return Ok(());
-            }
-            std::thread::yield_now();
+            let _ = std::fs::remove_file(armed_path);
+        } else if !wait_for_change(&mut watcher, poll_interval) {
+            std::thread::sleep(poll_interval);
         }
     }
 
@@ -531,7 +500,7 @@ fn ready_content(preload_modules: bool, generation: &str) -> String {
 fn release_matches(release_path: &Path, generation: &str) -> bool {
     std::fs::read_to_string(release_path).is_ok_and(|release| {
         let token = release.lines().next().unwrap_or("").trim();
-        token == format!("{RELEASE_PREFIX}{generation}") || token == LEGACY_RELEASE_TOKEN
+        token == format!("{RELEASE_PREFIX}{generation}")
     })
 }
 
@@ -615,7 +584,7 @@ mod tests {
     #[test]
     fn ordinary_container_does_not_receive_helper() {
         let mut spec = spec();
-        inject_into_container_if(&mut spec, false, false, "/missing-agent", "/missing-state");
+        inject_into_container_if(&mut spec, false, "/missing-agent", "/missing-state");
         assert!(spec
             .mounts
             .iter()
@@ -635,7 +604,6 @@ mod tests {
         let mut spec = spec();
         inject_into_container_if(
             &mut spec,
-            true,
             true,
             agent.to_str().unwrap(),
             state.to_str().unwrap(),
@@ -666,7 +634,7 @@ mod tests {
             .any(|option| option == "ro"));
         assert!(spec.process.env.contains(&format!(
             "{}={}",
-            smolvm_protocol::guest_env::BRANCHPOINT_ARMING,
+            smolvm_protocol::guest_env::FORKABLE,
             smolvm_protocol::guest_env::VALUE_ON
         )));
         let state_mount = spec
@@ -679,34 +647,8 @@ mod tests {
     }
 
     #[test]
-    fn older_host_does_not_enable_arming_in_a_new_container() {
-        let temp = tempfile::tempdir().unwrap();
-        let agent = temp.path().join("smolvm-agent");
-        let state = temp.path().join("forkpoint");
-        std::fs::write(&agent, b"agent").unwrap();
-        std::fs::set_permissions(&agent, std::fs::Permissions::from_mode(0o755)).unwrap();
-        std::fs::create_dir(&state).unwrap();
-        let mut spec = spec();
-
-        inject_into_container_if(
-            &mut spec,
-            true,
-            false,
-            agent.to_str().unwrap(),
-            state.to_str().unwrap(),
-        );
-
-        let prefix = format!("{}=", smolvm_protocol::guest_env::BRANCHPOINT_ARMING);
-        assert!(spec
-            .process
-            .env
-            .iter()
-            .all(|entry| !entry.starts_with(&prefix)));
-    }
-
-    #[test]
-    fn exec_env_matches_the_negotiated_arming_protocol() {
-        let key = smolvm_protocol::guest_env::BRANCHPOINT_ARMING;
+    fn exec_env_carries_the_branchable_flag_exactly_once() {
+        let key = smolvm_protocol::guest_env::FORKABLE;
         let mut env = vec![
             ("USER_VALUE".to_string(), "kept".to_string()),
             (key.to_string(), "stale".to_string()),
@@ -753,7 +695,6 @@ mod tests {
                 },
                 Duration::from_millis(1),
                 false,
-                false,
             )
         });
         wait_for_marker(&ready);
@@ -796,7 +737,6 @@ mod tests {
                 },
                 Duration::from_secs(60),
                 false,
-                false,
             )
         });
         wait_for_marker(&ready);
@@ -836,7 +776,6 @@ mod tests {
                 },
                 Duration::from_millis(1),
                 false,
-                true,
             )
         });
         wait_for_marker(&ready);
@@ -913,14 +852,12 @@ mod tests {
     fn identity_loads_from_dotenv_and_renders_for_eval() {
         let temp = tempfile::tempdir().unwrap();
         let release = temp.path().join("release");
-        let env = temp.path().join("fork-env");
         std::fs::write(
             &release,
             format!("{RELEASE_PREFIX}abc\nSMOLVM_BRANCH_NAME=agent-3\nNOTE=a=b c\nQ=it's\n"),
         )
         .unwrap();
-        std::fs::write(&env, "SMOLVM_BRANCH_NAME=stale\n").unwrap();
-        let identity = load_identity(&release, &env);
+        let identity = load_identity(&release);
         assert_eq!(
             identity,
             vec![
@@ -933,14 +870,10 @@ mod tests {
             render_identity_exports(&identity),
             "export SMOLVM_BRANCH_NAME='agent-3'\nexport NOTE='a=b c'\nexport Q='it'\\''s'\n"
         );
-        // An older host's single-line marker: the file is the source.
-        std::fs::write(&release, format!("{LEGACY_RELEASE_TOKEN}\n")).unwrap();
-        assert_eq!(
-            load_identity(&release, &env),
-            vec![("SMOLVM_BRANCH_NAME".to_string(), "stale".to_string())]
-        );
-        let absent = temp.path().join("absent");
-        assert!(load_identity(&absent, &absent).is_empty());
+        // A marker with only its token line is a clone with no parameters.
+        std::fs::write(&release, format!("{RELEASE_PREFIX}abc\n")).unwrap();
+        assert!(load_identity(&release).is_empty());
+        assert!(load_identity(&temp.path().join("absent")).is_empty());
         assert_eq!(render_identity_exports(&[]), "");
     }
 
@@ -1004,15 +937,12 @@ mod tests {
     }
 
     #[test]
-    fn release_requires_its_generation_or_the_legacy_token() {
+    fn release_requires_its_generation() {
         let temp = tempfile::tempdir().unwrap();
         let release = temp.path().join("release");
         std::fs::write(&release, format!("{RELEASE_PREFIX}old\n")).unwrap();
         assert!(!release_matches(&release, "new"));
         assert!(release_matches(&release, "old"));
-
-        std::fs::write(&release, format!("{LEGACY_RELEASE_TOKEN}\n")).unwrap();
-        assert!(release_matches(&release, "new"));
 
         // Identity lines after the token do not disturb the match.
         std::fs::write(&release, format!("{RELEASE_PREFIX}new\nLR=3e-4\n")).unwrap();

--- a/crates/smolvm-agent/src/forkpoint.rs
+++ b/crates/smolvm-agent/src/forkpoint.rs
@@ -18,9 +18,10 @@ use std::os::unix::ffi::OsStrExt as _;
 const AGENT_BINARY: &str = "/usr/local/bin/smolvm-agent";
 use smolvm_protocol::forkpoint::{
     ARMED_PATH, ARMED_PREFIX, ARM_PATH, ARM_PREFIX, BRANCH_ENV_PATH, BRANCH_HELPER_PATH,
-    CUDA_PRELOAD_MODULES_HINT, FORK_ENV_PATH, GENERATION_PREFIX, HELPER_PATH, LEGACY_RELEASE_TOKEN,
-    READY_PATH, READY_VERSION, RELEASE_PATH, RELEASE_PREFIX, RESTORED_CONTAINER_PATH,
-    RESTORED_PATH, STATE_DIR, WORKER_READY_HELPER_PATH, WORKER_READY_PATH, WORKER_READY_TOKEN_ENV,
+    CONTAINER_INIT_ARG, CONTAINER_INIT_NAME, CUDA_PRELOAD_MODULES_HINT, FORK_ENV_PATH,
+    GENERATION_PREFIX, HELPER_PATH, LEGACY_RELEASE_TOKEN, READY_PATH, READY_VERSION, RELEASE_PATH,
+    RELEASE_PREFIX, RESTORED_CONTAINER_PATH, RESTORED_PATH, STATE_DIR, WORKER_READY_HELPER_PATH,
+    WORKER_READY_PATH, WORKER_READY_TOKEN_ENV,
 };
 
 fn enabled() -> bool {
@@ -144,14 +145,135 @@ fn inject_into_container_if(
     }
 }
 
+/// Reap exited children while parked, when the helper is the container's
+/// PID 1.
+///
+/// A parked source can sit at its branchpoint for a long time; if the
+/// workload `exec`'d the helper, every background job is its child, and a job
+/// that exits would otherwise stay a zombie — then be captured into every
+/// clone. Non-blocking, so it never delays the branch protocol; a no-op when
+/// some other process is PID 1.
+fn reap_children_if_init() {
+    if std::process::id() != 1 {
+        return;
+    }
+    // SAFETY: WNOHANG waitpid on any child only collects already-exited
+    // children; it blocks nothing and touches no memory of ours.
+    while unsafe { libc::waitpid(-1, std::ptr::null_mut(), libc::WNOHANG) } > 0 {}
+}
+
 /// Mark the workload ready and block until this VM is a released clone.
+///
+/// Returns 0 once released so the workload can continue — unless the helper
+/// is the container's PID 1 (the workload `exec`'d it), in which case it never
+/// returns: it becomes the container's init instead, so the clone keeps the
+/// processes the branch preserved.
 pub fn run_helper() -> i32 {
-    let preload_modules = std::env::args_os().any(|argument| argument == "--cuda-preload-modules");
+    let (preload_modules, command) = parse_helper_args(std::env::args_os().skip(1));
     if let Err(error) = run_helper_inner(preload_modules) {
         eprintln!("smolvm-branch-ready: {error}");
         return 1;
     }
+    // Released. The helper is the one mechanism in both directions: the
+    // workload declared the branchpoint by running it, and it hands the
+    // child's identity back the same way — as this command's result.
+    let identity = load_identity(Path::new(FORK_ENV_PATH));
+    if let Some(command) = command {
+        // `smolvm-branch-ready -- prog args…`: become the child's program, with
+        // its identity in the environment. If the helper was `exec`'d as PID 1,
+        // the program takes over PID 1 and every background job started before
+        // the branchpoint stays its child.
+        use std::os::unix::process::CommandExt;
+        let error = std::process::Command::new(&command[0])
+            .args(&command[1..])
+            .envs(identity.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+            .exec();
+        eprintln!(
+            "smolvm-branch-ready: exec {}: {error}",
+            command[0].to_string_lossy()
+        );
+        return if error.kind() == std::io::ErrorKind::NotFound {
+            127
+        } else {
+            126
+        };
+    }
+    if std::process::id() == 1 {
+        // The workload `exec`'d the helper with nothing to run after the
+        // branchpoint, so it is now the container's PID 1. Returning would end
+        // PID 1 and the runtime would tear the container down with the very
+        // processes the branch preserved. Become the container's init instead
+        // — the same reaper every workload container runs — by `exec`ing into
+        // it: exec keeps this PID and its children but replaces the process
+        // image, so the init starts single-threaded whatever this helper had
+        // running, which its per-thread signal mask depends on.
+        // This helper is the agent binary invoked by name, and the same binary
+        // in `container-init` mode is the reaper; `/proc/self/exe` is always
+        // it, whatever is or is not mounted into this container.
+        use std::os::unix::process::CommandExt;
+        let error = std::process::Command::new("/proc/self/exe")
+            .arg0(CONTAINER_INIT_NAME)
+            .arg(CONTAINER_INIT_ARG)
+            .exec();
+        // Only reachable if exec itself failed; fall back to the in-process
+        // reaper rather than end PID 1.
+        eprintln!("smolvm-branch-ready: exec container-init: {error}; reaping in-process");
+        return crate::process::run_container_init();
+    }
+    // Inline use from a shell: `eval "$(smolvm-branch-ready)"` exports the
+    // identity into the calling script. Same rendering the host installs, so
+    // every value is quoted correctly.
+    print!("{}", render_identity_exports(&identity));
+    let _ = std::io::Write::flush(&mut std::io::stdout());
     0
+}
+
+/// Split the helper's arguments: the optional `--cuda-preload-modules` flag,
+/// and everything after `--` as the program to exec once released.
+fn parse_helper_args<I: Iterator<Item = std::ffi::OsString>>(
+    args: I,
+) -> (bool, Option<Vec<std::ffi::OsString>>) {
+    let mut preload = false;
+    let mut command: Option<Vec<std::ffi::OsString>> = None;
+    for argument in args {
+        if let Some(rest) = &mut command {
+            rest.push(argument);
+        } else if argument == "--" {
+            command = Some(Vec::new());
+        } else if argument == "--cuda-preload-modules" {
+            preload = true;
+        }
+    }
+    let command = command.filter(|c| !c.is_empty());
+    (preload, command)
+}
+
+/// The child's identity as installed by the host, read from the dotenv form
+/// (`KEY=VALUE`, one per line, values never contain newlines). Absent for a
+/// source or a single branch, which carry no per-child parameters.
+fn load_identity(path: &Path) -> Vec<(String, String)> {
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    contents
+        .lines()
+        .filter_map(|line| line.split_once('='))
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect()
+}
+
+/// Render the identity as `export KEY='VALUE'` lines, quoted so a shell can
+/// `eval` them for any value the host admits.
+fn render_identity_exports(identity: &[(String, String)]) -> String {
+    let mut out = String::new();
+    for (k, v) in identity {
+        out.push_str("export ");
+        out.push_str(k);
+        out.push_str("='");
+        out.push_str(&v.replace('\'', "'\\''"));
+        out.push_str("'\n");
+    }
+    out
 }
 
 fn run_helper_inner(preload_modules: bool) -> Result<(), String> {
@@ -211,7 +333,10 @@ impl StateChangeWaiter {
             revents: 0,
         };
         loop {
-            let ready = unsafe { libc::poll(&mut descriptor, 1, -1) };
+            // Bounded so a parked PID-1 helper wakes at least once a second to
+            // reap; a timeout is reported as a wake and the caller re-checks
+            // its markers, which is cheap and changes nothing else.
+            let ready = unsafe { libc::poll(&mut descriptor, 1, 1000) };
             if ready > 0 {
                 let mut events = [0_u8; 1024];
                 let _ = unsafe {
@@ -224,7 +349,7 @@ impl StateChangeWaiter {
                 return true;
             }
             if ready == 0 {
-                continue;
+                return true;
             }
             let error = std::io::Error::last_os_error();
             if error.kind() == std::io::ErrorKind::Interrupted {
@@ -281,7 +406,7 @@ fn run_helper_at(
             ready_path.display()
         )
     })?;
-    println!("smolvm branch point ready; waiting for child release");
+    eprintln!("smolvm branch point ready; waiting for child release");
     let _ = std::io::stdout().flush();
 
     #[cfg(target_os = "linux")]
@@ -298,6 +423,10 @@ fn run_helper_at(
     // arm marker parks it again instead of consuming one host core forever.
     if use_arming {
         while !restored_path.is_file() {
+            // Every wake reaps first — including the wake for the arm marker,
+            // so a job that exited while parked is collected before capture and
+            // never baked into a clone as a zombie.
+            reap_children_if_init();
             if release_matches(release_path, &generation) {
                 acknowledge_generation(ready_path, &generation);
                 return Ok(());
@@ -326,6 +455,7 @@ fn run_helper_at(
         }
     } else {
         while !restored_path.is_file() {
+            reap_children_if_init();
             if release_matches(release_path, &generation) {
                 acknowledge_generation(ready_path, &generation);
                 return Ok(());
@@ -339,6 +469,7 @@ fn run_helper_at(
             acknowledge_generation(ready_path, &generation);
             return Ok(());
         }
+        reap_children_if_init();
         std::thread::sleep(poll_interval);
     }
 }
@@ -361,14 +492,27 @@ pub fn run_worker_ready_helper() -> i32 {
     0
 }
 
+/// The value of `key` on a fork/branch env line, in either form the host
+/// writes: dotenv `KEY=VALUE` (the `fork-env` file) or the sourceable
+/// `export KEY='VALUE'` (the `branch-env` file, single-quoted with `'\''`
+/// escapes so a shell can `.`-source it).
+fn env_line_value(line: &str, key: &str) -> Option<String> {
+    let line = line.strip_prefix("export ").unwrap_or(line);
+    let rest = line.strip_prefix(key)?.strip_prefix('=')?;
+    let value = match rest.strip_prefix('\'').and_then(|r| r.strip_suffix('\'')) {
+        Some(quoted) => quoted.replace("'\\''", "'"),
+        None => rest.to_string(),
+    };
+    Some(value)
+}
+
 fn worker_ready_token(env_path: &Path) -> Result<String, String> {
     let contents = std::fs::read_to_string(env_path)
         .map_err(|error| format!("read {}: {error}", env_path.display()))?;
-    let prefix = format!("{WORKER_READY_TOKEN_ENV}=");
     let mut matches = contents
         .lines()
-        .filter_map(|line| line.strip_prefix(&prefix));
-    let token = matches
+        .filter_map(|line| env_line_value(line, WORKER_READY_TOKEN_ENV));
+    let token: String = matches
         .next()
         .ok_or_else(|| format!("{WORKER_READY_TOKEN_ENV} is not configured for this lease"))?;
     if matches.next().is_some() {
@@ -759,6 +903,73 @@ mod tests {
         helper.join().unwrap().unwrap();
         assert!(!ready.exists());
         assert!(!armed.exists());
+    }
+
+    /// Both files the host writes must yield the same value: the dotenv
+    /// `fork-env` and the sourceable `branch-env`, quotes and escapes included.
+    #[test]
+    fn env_line_value_reads_dotenv_and_sourceable_forms() {
+        assert_eq!(env_line_value("K=abc", "K").as_deref(), Some("abc"));
+        assert_eq!(
+            env_line_value("export K='abc'", "K").as_deref(),
+            Some("abc")
+        );
+        assert_eq!(
+            env_line_value("export K='a=b c'", "K").as_deref(),
+            Some("a=b c")
+        );
+        assert_eq!(
+            env_line_value("export Q='it'\\''s'", "Q").as_deref(),
+            Some("it's")
+        );
+        assert_eq!(env_line_value("KX=abc", "K"), None);
+        assert_eq!(env_line_value("export OTHER='1'", "K"), None);
+    }
+
+    /// `--` starts the program to exec on release; flags before it are the
+    /// helper's own; a bare `--` means no program.
+    #[test]
+    fn helper_args_split_flags_from_the_program() {
+        let os = |v: &[&str]| v.iter().map(std::ffi::OsString::from).collect::<Vec<_>>();
+        assert_eq!(parse_helper_args(os(&[]).into_iter()), (false, None));
+        assert_eq!(
+            parse_helper_args(os(&["--cuda-preload-modules"]).into_iter()),
+            (true, None)
+        );
+        assert_eq!(
+            parse_helper_args(os(&["--", "python3", "run.py", "--flag"]).into_iter()),
+            (false, Some(os(&["python3", "run.py", "--flag"])))
+        );
+        // a flag after `--` belongs to the program, not to us
+        assert_eq!(
+            parse_helper_args(os(&["--", "prog", "--cuda-preload-modules"]).into_iter()),
+            (false, Some(os(&["prog", "--cuda-preload-modules"])))
+        );
+        assert_eq!(parse_helper_args(os(&["--"]).into_iter()), (false, None));
+    }
+
+    /// Identity round-trips from the host's dotenv file to `export` lines a
+    /// shell can eval, quoting intact; a missing file is simply no identity.
+    #[test]
+    fn identity_loads_from_dotenv_and_renders_for_eval() {
+        let temp = tempfile::tempdir().unwrap();
+        let env = temp.path().join("fork-env");
+        std::fs::write(&env, "SMOLVM_BRANCH_NAME=agent-3\nNOTE=a=b c\nQ=it's\n").unwrap();
+        let identity = load_identity(&env);
+        assert_eq!(
+            identity,
+            vec![
+                ("SMOLVM_BRANCH_NAME".to_string(), "agent-3".to_string()),
+                ("NOTE".to_string(), "a=b c".to_string()),
+                ("Q".to_string(), "it's".to_string()),
+            ]
+        );
+        assert_eq!(
+            render_identity_exports(&identity),
+            "export SMOLVM_BRANCH_NAME='agent-3'\nexport NOTE='a=b c'\nexport Q='it'\\''s'\n"
+        );
+        assert!(load_identity(&temp.path().join("absent")).is_empty());
+        assert_eq!(render_identity_exports(&[]), "");
     }
 
     #[test]

--- a/crates/smolvm-agent/src/forkpoint.rs
+++ b/crates/smolvm-agent/src/forkpoint.rs
@@ -10,11 +10,6 @@ use std::os::unix::fs::PermissionsExt as _;
 use std::path::Path;
 use std::time::Duration;
 
-#[cfg(target_os = "linux")]
-use std::os::fd::{AsRawFd as _, FromRawFd as _, OwnedFd};
-#[cfg(target_os = "linux")]
-use std::os::unix::ffi::OsStrExt as _;
-
 const AGENT_BINARY: &str = "/usr/local/bin/smolvm-agent";
 use smolvm_protocol::forkpoint::{
     ARMED_PATH, ARMED_PREFIX, ARM_PATH, ARM_PREFIX, BRANCH_ENV_PATH, BRANCH_HELPER_PATH,
@@ -177,7 +172,7 @@ pub fn run_helper() -> i32 {
     // Released. The helper is the one mechanism in both directions: the
     // workload declared the branchpoint by running it, and it hands the
     // child's identity back the same way — as this command's result.
-    let identity = load_identity(Path::new(FORK_ENV_PATH));
+    let identity = load_identity(Path::new(RELEASE_PATH), Path::new(FORK_ENV_PATH));
     if let Some(command) = command {
         // `smolvm-branch-ready -- prog args…`: become the child's program, with
         // its identity in the environment. If the helper was `exec`'d as PID 1,
@@ -251,12 +246,24 @@ fn parse_helper_args<I: Iterator<Item = std::ffi::OsString>>(
 /// The child's identity as installed by the host, read from the dotenv form
 /// (`KEY=VALUE`, one per line, values never contain newlines). Absent for a
 /// source or a single branch, which carry no per-child parameters.
-fn load_identity(path: &Path) -> Vec<(String, String)> {
-    let Ok(contents) = std::fs::read_to_string(path) else {
-        return Vec::new();
-    };
-    contents
-        .lines()
+/// The child's identity: the `KEY=VALUE` lines the release marker carries,
+/// delivered in the same atomic rename as the go-ahead. A marker with none
+/// (an older host's script) points at the dotenv file instead; no file is
+/// simply no identity.
+fn load_identity(release_path: &Path, env_path: &Path) -> Vec<(String, String)> {
+    let from_marker = std::fs::read_to_string(release_path)
+        .map(|marker| parse_dotenv(marker.lines().skip(1)))
+        .unwrap_or_default();
+    if !from_marker.is_empty() {
+        return from_marker;
+    }
+    std::fs::read_to_string(env_path)
+        .map(|contents| parse_dotenv(contents.lines()))
+        .unwrap_or_default()
+}
+
+fn parse_dotenv<'a>(lines: impl Iterator<Item = &'a str>) -> Vec<(String, String)> {
+    lines
         .filter_map(|line| line.split_once('='))
         .map(|(k, v)| (k.to_string(), v.to_string()))
         .collect()
@@ -290,74 +297,6 @@ fn run_helper_inner(preload_modules: bool) -> Result<(), String> {
         preload_modules,
         arming_enabled(),
     )
-}
-
-/// Block in the guest kernel until the host changes branchpoint state. The
-/// helper always checks the marker files before waiting, so the inotify queue
-/// closes the check/sleep race without periodic vCPU wakeups. If inotify is
-/// unavailable, the caller retains the bounded polling fallback.
-#[cfg(target_os = "linux")]
-struct StateChangeWaiter {
-    fd: OwnedFd,
-}
-
-#[cfg(target_os = "linux")]
-impl StateChangeWaiter {
-    fn new(state_dir: &Path) -> std::io::Result<Self> {
-        let path = std::ffi::CString::new(state_dir.as_os_str().as_bytes()).map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                "branchpoint state path contains NUL",
-            )
-        })?;
-        let raw_fd = unsafe { libc::inotify_init1(libc::IN_CLOEXEC | libc::IN_NONBLOCK) };
-        if raw_fd < 0 {
-            return Err(std::io::Error::last_os_error());
-        }
-        let fd = unsafe { OwnedFd::from_raw_fd(raw_fd) };
-        let mask = libc::IN_CREATE
-            | libc::IN_DELETE
-            | libc::IN_MOVED_FROM
-            | libc::IN_MOVED_TO
-            | libc::IN_CLOSE_WRITE;
-        if unsafe { libc::inotify_add_watch(fd.as_raw_fd(), path.as_ptr(), mask) } < 0 {
-            return Err(std::io::Error::last_os_error());
-        }
-        Ok(Self { fd })
-    }
-
-    fn wait(&self) -> bool {
-        let mut descriptor = libc::pollfd {
-            fd: self.fd.as_raw_fd(),
-            events: libc::POLLIN,
-            revents: 0,
-        };
-        loop {
-            // Bounded so a parked PID-1 helper wakes at least once a second to
-            // reap; a timeout is reported as a wake and the caller re-checks
-            // its markers, which is cheap and changes nothing else.
-            let ready = unsafe { libc::poll(&mut descriptor, 1, 1000) };
-            if ready > 0 {
-                let mut events = [0_u8; 1024];
-                let _ = unsafe {
-                    libc::read(
-                        self.fd.as_raw_fd(),
-                        events.as_mut_ptr().cast(),
-                        events.len(),
-                    )
-                };
-                return true;
-            }
-            if ready == 0 {
-                return true;
-            }
-            let error = std::io::Error::last_os_error();
-            if error.kind() == std::io::ErrorKind::Interrupted {
-                continue;
-            }
-            return false;
-        }
-    }
 }
 
 struct ForkpointPaths<'a> {
@@ -409,18 +348,18 @@ fn run_helper_at(
     eprintln!("smolvm branch point ready; waiting for child release");
     let _ = std::io::stdout().flush();
 
-    #[cfg(target_os = "linux")]
-    let mut change_waiter = use_arming
-        .then(|| StateChangeWaiter::new(state_dir).ok())
+    let mut watcher = use_arming
+        .then(|| crate::dirwatch::DirWatcher::new(state_dir).ok())
         .flatten();
 
     // A timed kernel wait captured in the snapshot is not reliably re-armed by
-    // every VMM restore path. Older hosts therefore require the legacy
-    // userspace loop below. A paired host advertises the arming protocol: the
-    // source sleeps while idle, the host writes ARM_PATH immediately before
-    // capture and waits for ARMED_PATH, and only that short capture window uses
-    // the restore-safe userspace loop. Once the source continues, removing the
-    // arm marker parks it again instead of consuming one host core forever.
+    // every VMM restore path, so a host without the arming protocol gets the
+    // legacy userspace loop below. A paired host arms the source immediately
+    // before capture and parks it again afterwards. While parked the helper
+    // sleeps on directory events (bounded, so a PID-1 helper still reaps);
+    // while armed it sleeps on the same events with no time limit, which holds
+    // no kernel timer and so wakes correctly in the source and in every
+    // restored clone once its own state directory changes.
     if use_arming {
         while !restored_path.is_file() {
             // Every wake reaps first — including the wake for the arm marker,
@@ -439,17 +378,16 @@ fn run_helper_at(
                         acknowledge_generation(ready_path, &generation);
                         return Ok(());
                     }
-                    std::thread::yield_now();
+                    match watcher.as_ref().map(|w| w.wait(None)) {
+                        Some(Ok(_)) => {}
+                        Some(Err(_)) | None => {
+                            watcher = None;
+                            std::thread::yield_now();
+                        }
+                    }
                 }
                 let _ = std::fs::remove_file(armed_path);
-            } else {
-                #[cfg(target_os = "linux")]
-                if let Some(waiter) = &change_waiter {
-                    if waiter.wait() {
-                        continue;
-                    }
-                    change_waiter = None;
-                }
+            } else if !wait_for_change(&mut watcher, poll_interval) {
                 std::thread::sleep(poll_interval);
             }
         }
@@ -464,13 +402,32 @@ fn run_helper_at(
         }
     }
 
+    // A restored clone waits here for its release; a held slot may wait a
+    // long time, so this is the bounded event wait again, not a poll.
     loop {
         if release_matches(release_path, &generation) {
             acknowledge_generation(ready_path, &generation);
             return Ok(());
         }
         reap_children_if_init();
-        std::thread::sleep(poll_interval);
+        if !wait_for_change(&mut watcher, poll_interval) {
+            std::thread::sleep(poll_interval);
+        }
+    }
+}
+
+/// The bounded parked wait: sleep on directory events for at most a second so
+/// a PID-1 helper reaps promptly; a timeout counts as a wake. Returns false
+/// when no watch is available (and drops a failed one), so the caller polls.
+fn wait_for_change(watcher: &mut Option<crate::dirwatch::DirWatcher>, floor: Duration) -> bool {
+    let bound = Duration::from_secs(1).max(floor);
+    match watcher.as_ref().map(|w| w.wait(Some(bound))) {
+        Some(Ok(_)) => true,
+        Some(Err(_)) => {
+            *watcher = None;
+            false
+        }
+        None => false,
     }
 }
 
@@ -570,10 +527,11 @@ fn ready_content(preload_modules: bool, generation: &str) -> String {
     }
 }
 
+/// The marker's first line is the token; identity lines may follow it.
 fn release_matches(release_path: &Path, generation: &str) -> bool {
     std::fs::read_to_string(release_path).is_ok_and(|release| {
-        let release = release.trim();
-        release == format!("{RELEASE_PREFIX}{generation}") || release == LEGACY_RELEASE_TOKEN
+        let token = release.lines().next().unwrap_or("").trim();
+        token == format!("{RELEASE_PREFIX}{generation}") || token == LEGACY_RELEASE_TOKEN
     })
 }
 
@@ -948,14 +906,21 @@ mod tests {
         assert_eq!(parse_helper_args(os(&["--"]).into_iter()), (false, None));
     }
 
-    /// Identity round-trips from the host's dotenv file to `export` lines a
-    /// shell can eval, quoting intact; a missing file is simply no identity.
+    /// Identity comes from the release marker's own lines, rendered as
+    /// `export` lines a shell can eval with quoting intact; a marker without
+    /// them falls back to the dotenv file, and no file is simply no identity.
     #[test]
     fn identity_loads_from_dotenv_and_renders_for_eval() {
         let temp = tempfile::tempdir().unwrap();
+        let release = temp.path().join("release");
         let env = temp.path().join("fork-env");
-        std::fs::write(&env, "SMOLVM_BRANCH_NAME=agent-3\nNOTE=a=b c\nQ=it's\n").unwrap();
-        let identity = load_identity(&env);
+        std::fs::write(
+            &release,
+            format!("{RELEASE_PREFIX}abc\nSMOLVM_BRANCH_NAME=agent-3\nNOTE=a=b c\nQ=it's\n"),
+        )
+        .unwrap();
+        std::fs::write(&env, "SMOLVM_BRANCH_NAME=stale\n").unwrap();
+        let identity = load_identity(&release, &env);
         assert_eq!(
             identity,
             vec![
@@ -968,7 +933,14 @@ mod tests {
             render_identity_exports(&identity),
             "export SMOLVM_BRANCH_NAME='agent-3'\nexport NOTE='a=b c'\nexport Q='it'\\''s'\n"
         );
-        assert!(load_identity(&temp.path().join("absent")).is_empty());
+        // An older host's single-line marker: the file is the source.
+        std::fs::write(&release, format!("{LEGACY_RELEASE_TOKEN}\n")).unwrap();
+        assert_eq!(
+            load_identity(&release, &env),
+            vec![("SMOLVM_BRANCH_NAME".to_string(), "stale".to_string())]
+        );
+        let absent = temp.path().join("absent");
+        assert!(load_identity(&absent, &absent).is_empty());
         assert_eq!(render_identity_exports(&[]), "");
     }
 
@@ -1041,5 +1013,10 @@ mod tests {
 
         std::fs::write(&release, format!("{LEGACY_RELEASE_TOKEN}\n")).unwrap();
         assert!(release_matches(&release, "new"));
+
+        // Identity lines after the token do not disturb the match.
+        std::fs::write(&release, format!("{RELEASE_PREFIX}new\nLR=3e-4\n")).unwrap();
+        assert!(release_matches(&release, "new"));
+        assert!(!release_matches(&release, "old"));
     }
 }

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -84,6 +84,7 @@ fn boot_log(level: &str, msg: &str) {
 }
 mod branchpoint;
 mod cuda;
+mod dirwatch;
 mod disk_trim;
 mod dns_proxy;
 mod docker_bridge;
@@ -2366,9 +2367,9 @@ fn handle_request(
         AgentRequest::BranchpointPark => {
             branchpoint_outcome(branchpoint::park(&branchpoint::Markers::standard()))
         }
-        AgentRequest::BranchpointRelease => {
-            branchpoint_outcome(branchpoint::release(&branchpoint::Markers::standard()))
-        }
+        AgentRequest::BranchpointRelease { env_dotenv } => branchpoint_outcome(
+            branchpoint::release(&branchpoint::Markers::standard(), env_dotenv.as_deref()),
+        ),
         AgentRequest::BranchpointActivate {
             env_dotenv,
             env_sourceable,

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -82,6 +82,7 @@ fn boot_log(level: &str, msg: &str) {
         }
     }
 }
+mod branchpoint;
 mod cuda;
 mod disk_trim;
 mod dns_proxy;
@@ -2322,6 +2323,7 @@ fn handle_request(
             if forkpoint::arming_enabled() {
                 capabilities.push(smolvm_protocol::forkpoint::ARMING_CAPABILITY.to_string());
             }
+            capabilities.push(smolvm_protocol::forkpoint::TYPED_BRANCHPOINT_CAPABILITY.to_string());
             AgentResponse::Pong {
                 version: PROTOCOL_VERSION,
                 capabilities,
@@ -2349,6 +2351,56 @@ fn handle_request(
 
         AgentRequest::StorageStatus => handle_storage_status(),
 
+        AgentRequest::BranchpointWait { timeout_ms } => {
+            let markers = branchpoint::Markers::standard();
+            match branchpoint::wait_ready(&markers, std::time::Duration::from_millis(timeout_ms)) {
+                Ok(contents) => AgentResponse::Ok {
+                    data: Some(serde_json::json!({ "contents": contents })),
+                },
+                Err(e) => branchpoint_error(e),
+            }
+        }
+        AgentRequest::BranchpointArm => {
+            branchpoint_outcome(branchpoint::arm(&branchpoint::Markers::standard()))
+        }
+        AgentRequest::BranchpointPark => {
+            branchpoint_outcome(branchpoint::park(&branchpoint::Markers::standard()))
+        }
+        AgentRequest::BranchpointRelease => {
+            branchpoint_outcome(branchpoint::release(&branchpoint::Markers::standard()))
+        }
+        AgentRequest::BranchpointActivate {
+            env_dotenv,
+            env_sourceable,
+            env_path,
+            branch_env_path,
+            require_dir,
+            env_dir,
+            activation_token,
+        } => match branchpoint::activate(
+            &branchpoint::Markers::standard(),
+            &env_dotenv,
+            &env_sourceable,
+            std::path::Path::new(&env_path),
+            std::path::Path::new(&branch_env_path),
+            require_dir.as_deref().map(std::path::Path::new),
+            std::path::Path::new(&env_dir),
+            &activation_token,
+        ) {
+            Ok(outcome) => AgentResponse::Ok {
+                data: Some(serde_json::json!({
+                    "already_done": matches!(outcome, branchpoint::Activation::AlreadyDone)
+                })),
+            },
+            Err(e) => branchpoint_error(e),
+        },
+        AgentRequest::BranchpointWaitWorkerReady { token, timeout_ms } => {
+            branchpoint_outcome(branchpoint::wait_worker_ready(
+                &branchpoint::Markers::standard(),
+                &token,
+                std::time::Duration::from_millis(timeout_ms),
+            ))
+        }
         AgentRequest::FlattenLayers { lowerdirs, output } => {
             handle_flatten_layers(&lowerdirs, &output)
         }
@@ -7834,5 +7886,20 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&line)
             .unwrap_or_else(|e| panic!("Invalid JSON: {}\nLine: {}", e, line));
         assert!(parsed["message"].as_str().unwrap().contains("\"device\""));
+    }
+}
+
+/// Map a typed branchpoint step's result onto the wire.
+fn branchpoint_outcome(result: Result<(), branchpoint::TypedError>) -> AgentResponse {
+    match result {
+        Ok(()) => AgentResponse::Ok { data: None },
+        Err(e) => branchpoint_error(e),
+    }
+}
+
+fn branchpoint_error(e: branchpoint::TypedError) -> AgentResponse {
+    AgentResponse::Error {
+        message: e.message,
+        code: Some(e.code.to_string()),
     }
 }

--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -2319,12 +2319,8 @@ fn handle_request(
 
     match request {
         AgentRequest::Ping => {
-            let mut capabilities =
-                vec![smolvm_protocol::forkpoint::WORKER_READY_CAPABILITY.to_string()];
-            if forkpoint::arming_enabled() {
-                capabilities.push(smolvm_protocol::forkpoint::ARMING_CAPABILITY.to_string());
-            }
-            capabilities.push(smolvm_protocol::forkpoint::TYPED_BRANCHPOINT_CAPABILITY.to_string());
+            let capabilities =
+                vec![smolvm_protocol::forkpoint::TYPED_BRANCHPOINT_CAPABILITY.to_string()];
             AgentResponse::Pong {
                 version: PROTOCOL_VERSION,
                 capabilities,

--- a/crates/smolvm-protocol/src/forkpoint.rs
+++ b/crates/smolvm-protocol/src/forkpoint.rs
@@ -68,6 +68,12 @@ pub const RESTORED_PATH: &str = "/run/smolvm/forkpoint/restored";
 pub const RESTORED_CONTAINER_PATH: &str = "/run/smolvm/forkpoint/restored-container";
 
 /// Marker written by the host after a clone is ready to resume.
+///
+/// Its first line is the release token (see [`RELEASE_PREFIX`]). A typed
+/// agent appends the clone's identity as `KEY=VALUE` lines, so the helper
+/// receives the go-ahead and the identity in one atomic rename and never has
+/// to order this file against [`FORK_ENV_PATH`]; a marker with no such lines
+/// (written by an older host's script) sends the helper to that file instead.
 pub const RELEASE_PATH: &str = "/run/smolvm/forkpoint/release";
 
 /// Release token used before generation-addressed forkpoints. Accepting it in

--- a/crates/smolvm-protocol/src/forkpoint.rs
+++ b/crates/smolvm-protocol/src/forkpoint.rs
@@ -22,6 +22,29 @@ pub const WORKER_READY_CAPABILITY: &str = "fork-worker-ready-v1";
 /// Agent capability for parking an idle branchpoint until the host arms it.
 pub const ARMING_CAPABILITY: &str = "branchpoint-arming-v1";
 
+/// Agent capability: the branchpoint handshake is driven by typed requests
+/// (`AgentRequest::Branchpoint*`) the agent executes natively, instead of shell
+/// scripts the host builds and runs through `VmExec`. Same marker files and
+/// generation rules on the guest, so a helper of either vintage keeps working;
+/// what changes is that the protocol lives in one typed schema rather than in
+/// `sed` patterns mirrored across three languages.
+pub const TYPED_BRANCHPOINT_CAPABILITY: &str = "branchpoint-typed-v1";
+
+/// Error codes the agent returns for typed branchpoint requests, mirroring the
+/// exit statuses the shell scripts used so host-side handling stays uniform.
+pub mod typed_error {
+    /// No `ready` marker: the workload has not declared a branchpoint.
+    pub const NOT_READY: &str = "branchpoint.not_ready";
+    /// The `ready` marker carries no usable generation.
+    pub const BAD_GENERATION: &str = "branchpoint.bad_generation";
+    /// The helper did not acknowledge within the protocol's window.
+    pub const NO_ACK: &str = "branchpoint.no_ack";
+    /// Another activation token already claimed this clone.
+    pub const TOKEN_MISMATCH: &str = "branchpoint.token_mismatch";
+    /// A filesystem step failed; the message names it.
+    pub const IO: &str = "branchpoint.io";
+}
+
 /// Host marker that asks the branchpoint helper to enter its capture-safe loop.
 pub const ARM_PATH: &str = "/run/smolvm/forkpoint/arm";
 

--- a/crates/smolvm-protocol/src/forkpoint.rs
+++ b/crates/smolvm-protocol/src/forkpoint.rs
@@ -57,10 +57,13 @@ pub const RELEASE_PREFIX: &str = "smolvm-forkpoint-release-v2:";
 /// Marker written after a released worker finishes clone-local preparation.
 pub const WORKER_READY_PATH: &str = "/run/smolvm/forkpoint/worker-ready";
 
-/// Per-clone environment installed by the host before workload release.
+/// Per-clone environment installed by the host before workload release, as
+/// plain dotenv (`KEY=VALUE` per line) for machine readers.
 pub const FORK_ENV_PATH: &str = "/etc/smolvm/fork-env";
 
-/// Preferred branch-lifecycle alias for [`FORK_ENV_PATH`].
+/// The same parameters as a shell-sourceable file (`export KEY='VALUE'`,
+/// single-quoted). A workload that continues past `smolvm-branch-ready` runs
+/// `. /etc/smolvm/branch-env` to take its identity into its environment.
 pub const BRANCH_ENV_PATH: &str = "/etc/smolvm/branch-env";
 
 /// Host-generated readiness token delivered through [`FORK_ENV_PATH`].
@@ -71,6 +74,16 @@ pub const HELPER_PATH: &str = "/usr/local/bin/smolvm-fork-ready";
 
 /// Preferred branch-lifecycle alias for [`HELPER_PATH`].
 pub const BRANCH_HELPER_PATH: &str = "/usr/local/bin/smolvm-branch-ready";
+
+/// Argument that puts the agent binary into container-init mode: the reaper
+/// every workload container runs as PID 1. A branch helper that finds itself
+/// as PID 1 `exec`s its own binary with this argument on release, so it
+/// becomes that init by construction — a fresh, single-threaded image — rather
+/// than calling the reaper in-process and relying on no thread having been
+/// spawned.
+pub const CONTAINER_INIT_ARG: &str = "container-init";
+/// `argv[0]` the helper gives that init, so it reads clearly in `ps`.
+pub const CONTAINER_INIT_NAME: &str = "smolvm-container-init";
 
 /// Helper used by a released workload after clone-local preparation finishes.
 pub const WORKER_READY_HELPER_PATH: &str = "/usr/local/bin/smolvm-worker-ready";

--- a/crates/smolvm-protocol/src/forkpoint.rs
+++ b/crates/smolvm-protocol/src/forkpoint.rs
@@ -22,8 +22,8 @@ pub const CUDA_PRELOAD_MODULES_HINT: &str = "cuda-preload-modules";
 /// does not advertise it, rather than degrading to an older mechanism.
 pub const TYPED_BRANCHPOINT_CAPABILITY: &str = "branchpoint-typed-v1";
 
-/// Error codes the agent returns for typed branchpoint requests, mirroring the
-/// exit statuses the shell scripts used so host-side handling stays uniform.
+/// Error codes the agent returns for branchpoint requests, so the host can
+/// act on the cause rather than parse a message.
 pub mod typed_error {
     /// No `ready` marker: the workload has not declared a branchpoint.
     pub const NOT_READY: &str = "branchpoint.not_ready";

--- a/crates/smolvm-protocol/src/forkpoint.rs
+++ b/crates/smolvm-protocol/src/forkpoint.rs
@@ -16,18 +16,10 @@ pub const GENERATION_PREFIX: &str = "generation=";
 /// Optional readiness-marker capability requesting eager clone module loading.
 pub const CUDA_PRELOAD_MODULES_HINT: &str = "cuda-preload-modules";
 
-/// Agent capability required by readiness-gated fork-pool leases.
-pub const WORKER_READY_CAPABILITY: &str = "fork-worker-ready-v1";
-
-/// Agent capability for parking an idle branchpoint until the host arms it.
-pub const ARMING_CAPABILITY: &str = "branchpoint-arming-v1";
-
-/// Agent capability: the branchpoint handshake is driven by typed requests
-/// (`AgentRequest::Branchpoint*`) the agent executes natively, instead of shell
-/// scripts the host builds and runs through `VmExec`. Same marker files and
-/// generation rules on the guest, so a helper of either vintage keeps working;
-/// what changes is that the protocol lives in one typed schema rather than in
-/// `sed` patterns mirrored across three languages.
+/// The agent capability the branch protocol requires: the branchpoint
+/// handshake is driven by typed requests (`AgentRequest::Branchpoint*`) the
+/// agent executes natively. A host refuses to branch a machine whose agent
+/// does not advertise it, rather than degrading to an older mechanism.
 pub const TYPED_BRANCHPOINT_CAPABILITY: &str = "branchpoint-typed-v1";
 
 /// Error codes the agent returns for typed branchpoint requests, mirroring the
@@ -73,12 +65,8 @@ pub const RESTORED_CONTAINER_PATH: &str = "/run/smolvm/forkpoint/restored-contai
 /// agent appends the clone's identity as `KEY=VALUE` lines, so the helper
 /// receives the go-ahead and the identity in one atomic rename and never has
 /// to order this file against [`FORK_ENV_PATH`]; a marker with no such lines
-/// (written by an older host's script) sends the helper to that file instead.
+/// is a clone with no parameters, such as a plain single branch.
 pub const RELEASE_PATH: &str = "/run/smolvm/forkpoint/release";
-
-/// Release token used before generation-addressed forkpoints. Accepting it in
-/// newer guests keeps independently-updated host and agent packages compatible.
-pub const LEGACY_RELEASE_TOKEN: &str = "smolvm-forkpoint-release-v1";
 
 /// Prefix of a generation-addressed release marker.
 pub const RELEASE_PREFIX: &str = "smolvm-forkpoint-release-v2:";

--- a/crates/smolvm-protocol/src/guest_env.rs
+++ b/crates/smolvm-protocol/src/guest_env.rs
@@ -35,14 +35,6 @@ pub const CUDA_ZEROCOPY: &str = "SMOLVM_CUDA_ZEROCOPY";
 /// Fork clones inherit the already-running helper from the golden snapshot.
 pub const FORKABLE: &str = "SMOLVM_FORKABLE";
 
-/// The host can arm a branchpoint immediately before capture.
-///
-/// New agents use this handshake to sleep while a branchable source is idle,
-/// then enter the restore-safe userspace loop only for the brief capture
-/// window. An older host does not set the sentinel, so a newer agent preserves
-/// the legacy always-spinning behavior and remains compatible.
-pub const BRANCHPOINT_ARMING: &str = "SMOLVM_BRANCHPOINT_ARMING";
-
 /// Planned CUDA fork-pool size passed to the guest agent.
 ///
 /// The agent uses this to select fork-friendly workload defaults only when a

--- a/crates/smolvm-protocol/src/lib.rs
+++ b/crates/smolvm-protocol/src/lib.rs
@@ -1466,11 +1466,11 @@ mod tests {
     fn test_agent_response_serialization() {
         let resp = AgentResponse::Pong {
             version: PROTOCOL_VERSION,
-            capabilities: vec![forkpoint::WORKER_READY_CAPABILITY.to_string()],
+            capabilities: vec![forkpoint::TYPED_BRANCHPOINT_CAPABILITY.to_string()],
         };
         let json = serde_json::to_string(&resp).unwrap();
         assert!(json.contains("pong"));
-        assert!(json.contains(forkpoint::WORKER_READY_CAPABILITY));
+        assert!(json.contains(forkpoint::TYPED_BRANCHPOINT_CAPABILITY));
 
         let legacy: AgentResponse =
             serde_json::from_str(r#"{"status":"pong","version":1}"#).unwrap();

--- a/crates/smolvm-protocol/src/lib.rs
+++ b/crates/smolvm-protocol/src/lib.rs
@@ -374,6 +374,48 @@ pub enum AgentRequest {
         output: String,
     },
 
+    /// Wait until the workload has declared a branchpoint, returning the ready
+    /// marker's contents (its profile lines) in `data.contents`.
+    BranchpointWait {
+        /// Give up after this many milliseconds.
+        timeout_ms: u64,
+    },
+    /// Put a negotiated helper into its restore-safe loop before capture.
+    BranchpointArm,
+    /// Return a parked source to its ordinary wait after capture.
+    BranchpointPark,
+    /// Release a restored clone: write the release marker for the generation
+    /// recorded in its ready marker and wait for the helper to acknowledge.
+    BranchpointRelease,
+    /// Assign and release a held clone in one idempotent step: claim it with
+    /// `activation_token` (a retry with the same token completes a partial
+    /// commit; a different token is refused), install the per-clone
+    /// parameters, then write the release marker.
+    BranchpointActivate {
+        /// Per-clone parameters, dotenv form, written to `env_path`.
+        env_dotenv: String,
+        /// The same parameters in shell-sourceable form, written to `branch_env_path`.
+        env_sourceable: String,
+        /// Guest path of the dotenv file (under the clone's overlay for image machines).
+        env_path: String,
+        /// Guest path of the sourceable file.
+        branch_env_path: String,
+        /// Directory that must already exist, typically the clone's merged
+        /// overlay root; activation refuses rather than fabricating it.
+        require_dir: Option<String>,
+        /// Directory to create before writing the env files.
+        env_dir: String,
+        /// Token identifying this activation attempt.
+        activation_token: String,
+    },
+    /// Wait until a released clone's workload publishes its worker-ready token.
+    BranchpointWaitWorkerReady {
+        /// The token the workload must publish; any other is a mismatch.
+        token: String,
+        /// Give up after this many milliseconds.
+        timeout_ms: u64,
+    },
+
     /// Execute a command directly in the VM (not in a container).
     ///
     /// This runs the command in the agent's Alpine rootfs without any
@@ -688,6 +730,12 @@ impl AgentRequest {
                 format!("FlattenLayers {{ count: {} }}", lowerdirs.len())
             }
             AgentRequest::VmExec { .. } => "VmExec".into(),
+            AgentRequest::BranchpointWait { .. } => "BranchpointWait".into(),
+            AgentRequest::BranchpointArm => "BranchpointArm".into(),
+            AgentRequest::BranchpointPark => "BranchpointPark".into(),
+            AgentRequest::BranchpointRelease => "BranchpointRelease".into(),
+            AgentRequest::BranchpointActivate { .. } => "BranchpointActivate".into(),
+            AgentRequest::BranchpointWaitWorkerReady { .. } => "BranchpointWaitWorkerReady".into(),
             AgentRequest::Run { image, .. } => format!("Run {{ image: {image} }}"),
             AgentRequest::Stdin { .. } => "Stdin".into(),
             AgentRequest::Resize { .. } => "Resize".into(),

--- a/crates/smolvm-protocol/src/lib.rs
+++ b/crates/smolvm-protocol/src/lib.rs
@@ -385,8 +385,13 @@ pub enum AgentRequest {
     /// Return a parked source to its ordinary wait after capture.
     BranchpointPark,
     /// Release a restored clone: write the release marker for the generation
-    /// recorded in its ready marker and wait for the helper to acknowledge.
-    BranchpointRelease,
+    /// recorded in its ready marker, carrying the clone's identity, and wait
+    /// for the helper to acknowledge.
+    BranchpointRelease {
+        /// The clone's parameters in dotenv form, appended to the marker.
+        #[serde(default)]
+        env_dotenv: Option<String>,
+    },
     /// Assign and release a held clone in one idempotent step: claim it with
     /// `activation_token` (a retry with the same token completes a partial
     /// commit; a different token is refused), install the per-clone
@@ -733,7 +738,7 @@ impl AgentRequest {
             AgentRequest::BranchpointWait { .. } => "BranchpointWait".into(),
             AgentRequest::BranchpointArm => "BranchpointArm".into(),
             AgentRequest::BranchpointPark => "BranchpointPark".into(),
-            AgentRequest::BranchpointRelease => "BranchpointRelease".into(),
+            AgentRequest::BranchpointRelease { .. } => "BranchpointRelease".into(),
             AgentRequest::BranchpointActivate { .. } => "BranchpointActivate".into(),
             AgentRequest::BranchpointWaitWorkerReady { .. } => "BranchpointWaitWorkerReady".into(),
             AgentRequest::Run { image, .. } => format!("Run {{ image: {image} }}"),

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -1518,10 +1518,13 @@ impl AgentClient {
         branchpoint_outcome(resp, |_| ())
     }
 
-    /// Release a restored clone and wait for its helper to acknowledge.
-    pub fn branchpoint_release(&mut self) -> Result<BranchpointOutcome<()>> {
+    /// Release a restored clone, handing it `env_dotenv` as its identity, and
+    /// wait for its helper to acknowledge.
+    pub fn branchpoint_release(&mut self, env_dotenv: &str) -> Result<BranchpointOutcome<()>> {
         let _timeout_guard = self.set_exec_timeout(Some(Duration::from_secs(20)))?;
-        let resp = self.request(&AgentRequest::BranchpointRelease)?;
+        let resp = self.request(&AgentRequest::BranchpointRelease {
+            env_dotenv: Some(env_dotenv.to_string()),
+        })?;
         branchpoint_outcome(resp, |_| ())
     }
 

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -1480,11 +1480,7 @@ impl AgentClient {
         expect_ok(resp, "format storage")
     }
 
-    /// Merge `lowerdirs` (bottom -> top) into a single tar at `output` in the guest.
-    ///
-    /// Missing or empty entries are dropped guest-side, so callers can append a
-    /// Whether this agent executes the branchpoint handshake from typed
-    /// requests, rather than from shell scripts the host builds.
+    /// Whether this agent speaks the branch protocol.
     pub fn supports_typed_branchpoint(&mut self) -> Result<bool> {
         self.supports_capability(smolvm_protocol::forkpoint::TYPED_BRANCHPOINT_CAPABILITY)
     }
@@ -1564,6 +1560,9 @@ impl AgentClient {
         branchpoint_outcome(resp, |_| ())
     }
 
+    /// Merge `lowerdirs` (bottom -> top) into a single tar at `output` in the guest.
+    ///
+    /// Missing or empty entries are dropped guest-side, so callers can append a
     /// container overlay's upper dir without probing it first.
     pub fn flatten_layers(&mut self, lowerdirs: &[String], output: &str) -> Result<()> {
         // Merging the lower dirs and tarring the result runs for minutes on a

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -937,6 +937,54 @@ fn with_term_default(mut env: Vec<(String, String)>, tty: bool) -> Vec<(String, 
 }
 
 /// Expect an `Ok` response, ignoring any data.
+/// A typed branchpoint step's protocol outcome: `Err` carries the agent's
+/// error code (one of `smolvm_protocol::forkpoint::typed_error`) so the host
+/// can tell "no branchpoint declared" from "the helper went silent".
+pub type BranchpointOutcome<T> = std::result::Result<T, BranchpointFailure>;
+
+/// Everything a held clone needs to become a working branch: its per-clone
+/// parameters in both file forms, where to put them, and the idempotency token.
+#[derive(Debug, Clone)]
+pub struct BranchpointActivation {
+    pub env_dotenv: String,
+    pub env_sourceable: String,
+    pub env_path: String,
+    pub branch_env_path: String,
+    /// Must already exist (the clone's merged overlay root for image machines).
+    pub require_dir: Option<String>,
+    pub env_dir: String,
+    pub activation_token: String,
+}
+
+/// Why a typed branchpoint step did not succeed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BranchpointFailure {
+    /// The protocol error code, when the agent supplied one.
+    pub code: Option<String>,
+    /// The agent's explanation.
+    pub message: String,
+}
+
+impl std::fmt::Display for BranchpointFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+fn branchpoint_outcome<T>(
+    resp: AgentResponse,
+    from_data: impl FnOnce(Option<serde_json::Value>) -> T,
+) -> Result<BranchpointOutcome<T>> {
+    match resp {
+        AgentResponse::Ok { data } => Ok(Ok(from_data(data))),
+        AgentResponse::Error { message, code } => Ok(Err(BranchpointFailure { code, message })),
+        other => Err(Error::agent(
+            "branchpoint",
+            format!("unexpected response: {other:?}"),
+        )),
+    }
+}
+
 fn expect_ok(resp: AgentResponse, op: &str) -> Result<()> {
     match resp {
         AgentResponse::Ok { .. } => Ok(()),
@@ -1435,6 +1483,84 @@ impl AgentClient {
     /// Merge `lowerdirs` (bottom -> top) into a single tar at `output` in the guest.
     ///
     /// Missing or empty entries are dropped guest-side, so callers can append a
+    /// Whether this agent executes the branchpoint handshake from typed
+    /// requests, rather than from shell scripts the host builds.
+    pub fn supports_typed_branchpoint(&mut self) -> Result<bool> {
+        self.supports_capability(smolvm_protocol::forkpoint::TYPED_BRANCHPOINT_CAPABILITY)
+    }
+
+    /// Wait for the workload's branchpoint; `Ok(Ok(contents))` is the ready
+    /// marker's contents.
+    pub fn branchpoint_wait(&mut self, timeout: Duration) -> Result<BranchpointOutcome<String>> {
+        let _timeout_guard = self.set_exec_timeout(Some(timeout + Duration::from_secs(5)))?;
+        let resp = self.request(&AgentRequest::BranchpointWait {
+            timeout_ms: timeout.as_millis() as u64,
+        })?;
+        branchpoint_outcome(resp, |data| {
+            data.and_then(|d| {
+                d.get("contents")
+                    .and_then(|c| c.as_str())
+                    .map(str::to_string)
+            })
+            .unwrap_or_default()
+        })
+    }
+
+    /// Put the helper into its restore-safe loop before capture.
+    pub fn branchpoint_arm(&mut self) -> Result<BranchpointOutcome<()>> {
+        let resp = self.request(&AgentRequest::BranchpointArm)?;
+        branchpoint_outcome(resp, |_| ())
+    }
+
+    /// Return a parked source to its ordinary wait after capture.
+    pub fn branchpoint_park(&mut self) -> Result<BranchpointOutcome<()>> {
+        let resp = self.request(&AgentRequest::BranchpointPark)?;
+        branchpoint_outcome(resp, |_| ())
+    }
+
+    /// Release a restored clone and wait for its helper to acknowledge.
+    pub fn branchpoint_release(&mut self) -> Result<BranchpointOutcome<()>> {
+        let _timeout_guard = self.set_exec_timeout(Some(Duration::from_secs(20)))?;
+        let resp = self.request(&AgentRequest::BranchpointRelease)?;
+        branchpoint_outcome(resp, |_| ())
+    }
+
+    /// Assign and release a held clone; `Ok(Ok(true))` when an earlier attempt
+    /// with the same token had already done it.
+    pub fn branchpoint_activate(
+        &mut self,
+        activation: BranchpointActivation,
+    ) -> Result<BranchpointOutcome<bool>> {
+        let resp = self.request(&AgentRequest::BranchpointActivate {
+            env_dotenv: activation.env_dotenv,
+            env_sourceable: activation.env_sourceable,
+            env_path: activation.env_path,
+            branch_env_path: activation.branch_env_path,
+            require_dir: activation.require_dir,
+            env_dir: activation.env_dir,
+            activation_token: activation.activation_token,
+        })?;
+        branchpoint_outcome(resp, |data| {
+            data.and_then(|d| d.get("already_done").and_then(|v| v.as_bool()))
+                .unwrap_or(false)
+        })
+    }
+
+    /// Block until the released workload publishes `token` as worker-ready,
+    /// or until `timeout`; `NO_ACK` on timeout, `TOKEN_MISMATCH` on a stale token.
+    pub fn branchpoint_wait_worker_ready(
+        &mut self,
+        token: &str,
+        timeout: Duration,
+    ) -> Result<BranchpointOutcome<()>> {
+        let _timeout_guard = self.set_exec_timeout(Some(timeout + Duration::from_secs(5)))?;
+        let resp = self.request(&AgentRequest::BranchpointWaitWorkerReady {
+            token: token.to_string(),
+            timeout_ms: timeout.as_millis() as u64,
+        })?;
+        branchpoint_outcome(resp, |_| ())
+    }
+
     /// container overlay's upper dir without probing it first.
     pub fn flatten_layers(&mut self, lowerdirs: &[String], output: &str) -> Result<()> {
         // Merging the lower dirs and tarring the result runs for minutes on a

--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -1511,7 +1511,10 @@ fn build_release_forkpoint_script() -> String {
 /// release marker wakes only this clone even though every clone inherited the
 /// same blocked helper process. Success means the helper also acknowledged the
 /// marker and left the fork boundary; callers may safely vend the clone.
-pub fn release_forkpoint(clone: &str) -> Result<()> {
+/// Release a restored clone's parked helper. `env` is the clone's identity,
+/// the same parameters [`write_fork_env`] installed; a typed agent carries it
+/// inside the release marker so the helper receives both in one atomic step.
+pub fn release_forkpoint(clone: &str, env: &[(String, String)]) -> Result<()> {
     let socket = vm_data_dir(clone).join("agent.sock");
     let mut client = AgentClient::connect_with_retry(&socket)
         .map_err(|e| Error::agent("release forkpoint", format!("agent connect: {e}")))?;
@@ -1520,7 +1523,7 @@ pub fn release_forkpoint(clone: &str) -> Result<()> {
         .map_err(|e| Error::agent("release forkpoint", e.to_string()))?
     {
         return match client
-            .branchpoint_release()
+            .branchpoint_release(&render_fork_env(env))
             .map_err(|e| Error::agent("release forkpoint", e.to_string()))?
         {
             Ok(()) => Ok(()),

--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -2705,7 +2705,11 @@ fn rejuvenate_once(
 /// if the restored container is recycled — the overlay is the only surface
 /// shared by every instance and the running workload alike.
 pub const FORK_ENV_GUEST_PATH: &str = smolvm_protocol::forkpoint::FORK_ENV_PATH;
-/// Preferred branch-lifecycle alias for [`FORK_ENV_GUEST_PATH`].
+/// Guest path of the same per-fork parameters in a form a POSIX shell can
+/// `.`-source: every pair exported and single-quoted (see [`render_branch_env`]).
+/// Not an alias of [`FORK_ENV_GUEST_PATH`]: that file stays plain dotenv for
+/// machine readers; this one is for a workload that continues after
+/// `smolvm-branch-ready` and needs its identity in its own environment.
 pub const BRANCH_ENV_GUEST_PATH: &str = smolvm_protocol::forkpoint::BRANCH_ENV_PATH;
 
 /// Validate per-fork parameters: keys must be non-empty `[A-Za-z_][A-Za-z0-9_]*`
@@ -2743,6 +2747,46 @@ pub fn render_fork_env(env: &[(String, String)]) -> String {
         out.push('\n');
     }
     out
+}
+
+/// Render per-fork parameters as a file a POSIX shell can `.`-source directly.
+///
+/// The dotenv form is not safely sourceable: a bare `KEY=VALUE` line neither
+/// exports the variable (so an `exec`'d workload never sees it) nor survives a
+/// value with spaces (`NOTE=a=b c` runs `c` as a command). This form exports
+/// every pair and single-quotes every value, escaping embedded quotes, so
+/// `. /etc/smolvm/branch-env` is correct for any value the validator admits.
+pub fn render_branch_env(env: &[(String, String)]) -> String {
+    let mut out = String::new();
+    for (k, v) in env {
+        out.push_str("export ");
+        out.push_str(k);
+        out.push_str("='");
+        out.push_str(&v.replace('\'', "'\\''"));
+        out.push_str("'\n");
+    }
+    out
+}
+
+/// Shell fragment that writes the sourceable branch env to `path`.
+///
+/// Delivered inside the same install script as the dotenv file. A quoted
+/// heredoc performs no expansion, and no rendered line can equal the
+/// delimiter (every line starts with `export`), so the embedded content is
+/// injection-safe for any value the validator admits.
+///
+/// The `&& mv` sits on the heredoc's own command line: the body follows that
+/// line, so this keeps the caller's `&&` chain intact — `write_fork_env` has
+/// no `set -e`, and that chain is its only error handling. A rename into
+/// place makes the swap atomic for any reader. The fragment ends with the
+/// delimiter on a line of its own, newline-terminated: a heredoc terminator
+/// must be the whole line, so a caller continues on the next line and must
+/// not append `;` or `&&` to the fragment.
+fn branch_env_install_fragment(path: &str, env: &[(String, String)]) -> String {
+    format!(
+        "cat > '{path}.tmp' <<'SMOLVM_BRANCH_ENV_EOF' && mv '{path}.tmp' '{path}'\n{content}SMOLVM_BRANCH_ENV_EOF\n",
+        content = render_branch_env(env)
+    )
 }
 
 /// Merge assignment-time parameters into a held slot's initial fork
@@ -2812,13 +2856,14 @@ pub fn write_fork_env(clone: &str, record: &VmRecord, env: &[(String, String)]) 
             "if [ ! -d {merged} ]; then echo \"missing {merged}; overlays:\" >&2; \
              ls /storage/overlays >&2; exit 41; fi; \
              mkdir -p {merged}/etc/smolvm && umask 077 && \
-             cat > {merged}{FORK_ENV_GUEST_PATH} && \
-             ln -sfn fork-env {merged}{BRANCH_ENV_GUEST_PATH}"
+             cat > {merged}{FORK_ENV_GUEST_PATH} && {branch_env}",
+            branch_env =
+                branch_env_install_fragment(&format!("{merged}{BRANCH_ENV_GUEST_PATH}"), env)
         )
     } else {
         format!(
-            "mkdir -p /etc/smolvm && umask 077 && cat > {FORK_ENV_GUEST_PATH} && \
-             ln -sfn fork-env {BRANCH_ENV_GUEST_PATH}"
+            "mkdir -p /etc/smolvm && umask 077 && cat > {FORK_ENV_GUEST_PATH} && {branch_env}",
+            branch_env = branch_env_install_fragment(BRANCH_ENV_GUEST_PATH, env)
         )
     };
     let sock = vm_data_dir(clone).join("agent.sock");
@@ -2907,6 +2952,7 @@ pub fn activate_held_fork(
         },
         &ensure_env_parent,
         &activation_token,
+        &merged,
     );
     let socket = vm_data_dir(clone).join("agent.sock");
     for attempt in 1..=2 {
@@ -3090,6 +3136,7 @@ fn build_activation_script(
     paths: ActivationScriptPaths<'_>,
     ensure_env_parent: &str,
     activation_token: &str,
+    env: &[(String, String)],
 ) -> String {
     let ActivationScriptPaths {
         ready,
@@ -3120,11 +3167,11 @@ fn build_activation_script(
          release_tmp='{release}.{activation_token}.'$$; \
          trap 'rm -f \"$env_tmp\" \"$release_tmp\"' EXIT; \
          cat > \"$env_tmp\"; mv \"$env_tmp\" '{env_path}'; \
-         ln -sfn fork-env '{branch_env_path}'; \
-         if [ \"${{#generation}}\" -eq 32 ]; then \
+         {branch_env_install}if [ \"${{#generation}}\" -eq 32 ]; then \
            printf '%s%s\\n' '{release_prefix}' \"$generation\" > \"$release_tmp\"; \
          else printf '%s\\n' '{legacy_release}' > \"$release_tmp\"; fi; \
          mv \"$release_tmp\" '{release}'",
+        branch_env_install = branch_env_install_fragment(branch_env_path, env),
         generation_prefix = smolvm_protocol::forkpoint::GENERATION_PREFIX,
         legacy_release = smolvm_protocol::forkpoint::LEGACY_RELEASE_TOKEN,
         release_prefix = smolvm_protocol::forkpoint::RELEASE_PREFIX,
@@ -3824,6 +3871,50 @@ mod tests {
         assert_eq!(render_fork_env(&[]), "");
     }
 
+    /// The sourceable form must survive the values the dotenv form cannot:
+    /// spaces, `=`, and single quotes — and export everything, so an `exec`'d
+    /// workload sees it after a plain `. /etc/smolvm/branch-env`.
+    #[test]
+    fn branch_env_is_exported_and_quoted_for_any_admissible_value() {
+        let env = vec![
+            ("SMOLVM_BRANCH_NAME".to_string(), "agent-3".to_string()),
+            ("NOTE".to_string(), "a=b c".to_string()),
+            ("Q".to_string(), "it's".to_string()),
+        ];
+        assert_eq!(
+            render_branch_env(&env),
+            "export SMOLVM_BRANCH_NAME='agent-3'\nexport NOTE='a=b c'\nexport Q='it'\\''s'\n"
+        );
+        assert_eq!(render_branch_env(&[]), "");
+        // The install fragment embeds it in a quoted heredoc and moves it into place atomically.
+        let frag = branch_env_install_fragment("/etc/smolvm/branch-env", &env);
+        // `&& mv` on the heredoc line, body after it, delimiter last: the
+        // rename is conditional on the write, and a caller's `&&` chain holds.
+        assert!(frag.starts_with(
+            "cat > '/etc/smolvm/branch-env.tmp' <<'SMOLVM_BRANCH_ENV_EOF' && mv '/etc/smolvm/branch-env.tmp' '/etc/smolvm/branch-env'\n"
+        ));
+        assert!(frag.contains("export NOTE='a=b c'\n"));
+        assert!(frag.ends_with("SMOLVM_BRANCH_ENV_EOF\n"));
+        // And it really runs: a failed write must not leave the target behind.
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("branch-env");
+        let ok = std::process::Command::new("/bin/sh")
+            .args([
+                "-c",
+                &branch_env_install_fragment(target.to_str().unwrap(), &env),
+            ])
+            .status()
+            .unwrap();
+        assert!(ok.success());
+        assert_eq!(
+            std::fs::read_to_string(&target).unwrap(),
+            render_branch_env(&env)
+        );
+        assert!(
+            !target.with_extension("tmp").exists() && !dir.path().join("branch-env.tmp").exists()
+        );
+    }
+
     #[test]
     fn assignment_env_overrides_only_matching_pool_values() {
         let initial = vec![
@@ -3904,6 +3995,7 @@ mod tests {
             },
             &ensure_parent,
             token,
+            &[("LR".to_string(), "1e-4".to_string())],
         );
 
         let first = run_activation_script(&script, "LR=1e-4\n");
@@ -3915,7 +4007,7 @@ mod tests {
         assert_eq!(std::fs::read_to_string(&env_path).unwrap(), "LR=1e-4\n");
         assert_eq!(
             std::fs::read_to_string(&branch_env_path).unwrap(),
-            "LR=1e-4\n"
+            "export LR='1e-4'\n"
         );
         #[cfg(unix)]
         {
@@ -3955,6 +4047,7 @@ mod tests {
             },
             &ensure_parent,
             "fedcba9876543210",
+            &[],
         );
         assert_eq!(
             run_activation_script(&other, "LR=other\n").status.code(),
@@ -3990,6 +4083,7 @@ mod tests {
             },
             &ensure_parent,
             token,
+            &[("LR".to_string(), "3e-4".to_string())],
         );
 
         let retry = run_activation_script(&script, "LR=3e-4\n");
@@ -3999,9 +4093,11 @@ mod tests {
             String::from_utf8_lossy(&retry.stderr)
         );
         assert_eq!(std::fs::read_to_string(&env_path).unwrap(), "LR=3e-4\n");
+        // branch-env is no longer an alias of the dotenv file: it is the same
+        // parameters in a form a shell can `.`-source, exported and quoted.
         assert_eq!(
             std::fs::read_to_string(&branch_env_path).unwrap(),
-            "LR=3e-4\n"
+            "export LR='3e-4'\n"
         );
         assert!(release.is_file());
     }

--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -3191,6 +3191,58 @@ fn worker_ready_command_timeout(timeout: Duration) -> Result<Duration> {
         .ok_or_else(|| Error::config("worker readiness", "timeout is too large"))
 }
 
+/// Guest env key telling a workload how long it has to publish readiness.
+pub const WORKER_READY_TIMEOUT_ENV: &str = "SMOLVM_WORKER_READY_TIMEOUT_SECS";
+
+/// A fresh 64-hex readiness token for a child that has no external
+/// idempotency key to derive one from.
+pub fn random_worker_ready_token() -> Result<String> {
+    use std::io::Read as _;
+    let mut bytes = [0_u8; 32];
+    std::fs::File::open("/dev/urandom")
+        .and_then(|mut random| random.read_exact(&mut bytes))
+        .map_err(|error| Error::agent("worker readiness", format!("generate token: {error}")))?;
+    Ok(bytes.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
+/// Put the readiness contract into a child's parameters: the token its
+/// `smolvm-worker-ready` call must echo and the window it has to do so.
+/// Refuses parameters that already use those keys, since a caller-supplied
+/// token could never be verified.
+pub fn add_worker_ready_assignment(
+    env: &mut Vec<(String, String)>,
+    token: &str,
+    timeout: Duration,
+) -> Result<()> {
+    for reserved in [
+        smolvm_protocol::forkpoint::WORKER_READY_TOKEN_ENV,
+        WORKER_READY_TIMEOUT_ENV,
+    ] {
+        if env.iter().any(|(key, _)| key == reserved) {
+            return Err(Error::config(
+                "worker readiness",
+                format!("{reserved} is reserved for smolvm worker readiness"),
+            ));
+        }
+    }
+    env.push((
+        smolvm_protocol::forkpoint::WORKER_READY_TOKEN_ENV.to_string(),
+        token.to_string(),
+    ));
+    env.push((
+        WORKER_READY_TIMEOUT_ENV.to_string(),
+        timeout.as_secs().to_string(),
+    ));
+    Ok(())
+}
+
+/// The readiness token a child's parameters carry, if any.
+pub fn worker_ready_token_of(env: &[(String, String)]) -> Option<&str> {
+    env.iter()
+        .find(|(key, _)| key == smolvm_protocol::forkpoint::WORKER_READY_TOKEN_ENV)
+        .map(|(_, token)| token.as_str())
+}
+
 /// Wait until a released workload proves that clone-local preparation finished.
 pub fn wait_for_worker_ready(clone: &str, token: &str, timeout: Duration) -> Result<()> {
     if token.len() != 64 || !token.bytes().all(|byte| byte.is_ascii_hexdigit()) {
@@ -3422,6 +3474,29 @@ fn host_random_hex(hex_len: usize) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn worker_ready_assignment_carries_a_fresh_token_and_refuses_a_forged_one() {
+        let token = random_worker_ready_token().unwrap();
+        assert_eq!(token.len(), 64);
+        assert!(token.bytes().all(|b| b.is_ascii_hexdigit()));
+        assert_ne!(token, random_worker_ready_token().unwrap());
+
+        let mut env = vec![("LR".to_string(), "3e-4".to_string())];
+        add_worker_ready_assignment(&mut env, &token, Duration::from_secs(90)).unwrap();
+        assert_eq!(worker_ready_token_of(&env), Some(token.as_str()));
+        assert!(env.contains(&(WORKER_READY_TIMEOUT_ENV.to_string(), "90".to_string())));
+
+        let mut forged = vec![(
+            smolvm_protocol::forkpoint::WORKER_READY_TOKEN_ENV.to_string(),
+            "0".repeat(64),
+        )];
+        let error = add_worker_ready_assignment(&mut forged, &token, Duration::from_secs(1))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("reserved"), "{error}");
+        assert!(worker_ready_token_of(&[]).is_none());
+    }
     use std::cell::Cell;
 
     #[cfg(target_os = "linux")]

--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -295,234 +295,96 @@ fn persist_forkpoint_profile(golden: &str, profile: ForkpointProfile) -> Result<
     Ok(())
 }
 
+/// Connect to a machine's agent and insist on the branch protocol. There is
+/// one protocol; a machine whose agent does not speak it is refused with a
+/// message that says what to update, never driven through an older mechanism.
+fn branch_client(machine: &str, what: &str) -> Result<AgentClient> {
+    let socket = vm_data_dir(machine).join("agent.sock");
+    let mut client = AgentClient::connect_with_retry(&socket)
+        .map_err(|e| Error::agent(what, format!("agent connect: {e}")))?;
+    if !client
+        .supports_typed_branchpoint()
+        .map_err(|e| Error::agent(what, e.to_string()))?
+    {
+        return Err(Error::agent(
+            what,
+            format!(
+                "machine '{machine}' runs a guest agent without the branch protocol \
+                 ({}); update its agent rootfs to this smolvm version",
+                smolvm_protocol::forkpoint::TYPED_BRANCHPOINT_CAPABILITY
+            ),
+        ));
+    }
+    Ok(client)
+}
+
 /// Wait until the golden workload reaches the standard live-fork boundary.
 ///
 /// The workload signals this by calling `smolvm-fork-ready`, which writes the
 /// marker and blocks. Keeping the wait in the VM namespace avoids coupling the
 /// host to container logs, PIDs, or workload-specific files.
 pub fn wait_for_forkpoint(golden: &str, timeout: Duration) -> Result<()> {
-    // On hosts without fork-and-continue, a successful first fork leaves the
-    // golden paused as the CoW base. Pool replenishment must not try to run a
-    // new agent exec inside that paused VM: its vCPUs cannot answer, even
-    // though the already-proven forkpoint remains the exact snapshot source.
-    // The VMM control plane remains live, so recognize it before touching the
-    // guest. A continuing source reports `OK running` and takes the
-    // ordinary agent readiness path below.
-    let control = control_socket_path(golden);
-    if control.exists() {
-        if let Ok(status) = control_socket_cmd(&control, "STATUS") {
-            if fork_base_already_paused(&status) {
-                tracing::debug!(golden, %status, "fork base is already paused; reusing its forkpoint");
-                return Ok(());
-            }
-        }
-    }
-
-    let socket = vm_data_dir(golden).join("agent.sock");
-    let mut client = AgentClient::connect_with_retry(&socket)
-        .map_err(|e| Error::agent("wait for forkpoint", format!("agent connect: {e}")))?;
-    if client
-        .supports_typed_branchpoint()
+    let mut client = branch_client(golden, "wait for forkpoint")?;
+    match client
+        .branchpoint_wait(timeout)
         .map_err(|e| Error::agent("wait for forkpoint", e.to_string()))?
     {
-        return match client
-            .branchpoint_wait(timeout)
-            .map_err(|e| Error::agent("wait for forkpoint", e.to_string()))?
-        {
-            Ok(contents) => {
-                let profile = parse_forkpoint_profile(contents.as_bytes());
-                persist_forkpoint_profile(golden, profile)?;
-                Ok(())
-            }
-            Err(f) => Err(Error::agent(
-                "wait for forkpoint",
-                format!(
-                    "source '{golden}' did not reach a branchpoint within {}s: {f}\n\
-                     A batch branch snapshots the source at a point its workload declares by running \
-                     `smolvm-branch-ready` after setup (see README, \"Branch a running machine\"). \
-                     If the workload never calls it, either add the call, raise --ready-timeout, or \
-                     take single `--name` branches, which snapshot the source wherever it is.",
-                    timeout.as_secs_f64()
-                ),
-            )),
-        };
-    }
-    let script = format!(
-        "while [ ! -f '{ready}' ]; do sleep 0.05; done; cat '{ready}'",
-        ready = smolvm_protocol::forkpoint::READY_PATH,
-    );
-    match client.vm_exec(
-        vec!["/bin/sh".into(), "-c".into(), script],
-        vec![],
-        None,
-        Some(timeout),
-        None,
-    ) {
-        Ok((0, stdout, _)) => {
-            let profile = parse_forkpoint_profile(&stdout);
-            persist_forkpoint_profile(golden, profile)?;
-            Ok(())
+        Ok(contents) => {
+            let profile = parse_forkpoint_profile(contents.as_bytes());
+            persist_forkpoint_profile(golden, profile)
         }
-        Ok((code, _, stderr)) => Err(Error::agent(
+        Err(f) => Err(Error::agent(
             "wait for forkpoint",
             format!(
-                "golden '{golden}' did not become ready within {}s (exit {code}): {}",
-                timeout.as_secs_f64(),
-                String::from_utf8_lossy(&stderr).trim()
-            ),
-        )),
-        Err(e) => Err(Error::agent(
-            "wait for forkpoint",
-            format!(
-                "golden '{golden}' did not become ready within {}s: {e}",
+                "source '{golden}' did not reach a branchpoint within {}s: {f}\n\
+                 A batch branch snapshots the source at a point its workload declares by running \
+                 `smolvm-branch-ready` after setup (see README, \"Branch a running machine\"). \
+                 If the workload never calls it, either add the call, raise --ready-timeout, or \
+                 take single `--name` branches, which snapshot the source wherever it is.",
                 timeout.as_secs_f64()
             ),
         )),
     }
 }
 
-fn build_arm_forkpoint_script() -> String {
-    format!(
-        "if [ ! -f '{ready}' ]; then exit 3; fi; \
-         generation=$(sed -n 's/^{generation_prefix}//p' '{ready}' | head -n 1); \
-         case \"$generation\" in ''|*[!0-9a-fA-F]*) exit 4 ;; esac; \
-         [ \"${{#generation}}\" -eq 32 ] || exit 4; \
-         rm -f '{arm}'; \
-         i=0; while [ -e '{armed}' ]; do \
-           i=$((i + 1)); [ \"$i\" -lt 400 ] || exit 47; sleep 0.005; \
-         done; \
-         printf '%s%s\\n' '{arm_prefix}' \"$generation\" > '{arm}.tmp'; \
-         mv '{arm}.tmp' '{arm}'; \
-         i=0; until grep -q -x '{armed_prefix}'\"$generation\" '{armed}' 2>/dev/null; do \
-           i=$((i + 1)); [ \"$i\" -lt 400 ] || exit 47; sleep 0.005; \
-         done",
-        arm = smolvm_protocol::forkpoint::ARM_PATH,
-        armed = smolvm_protocol::forkpoint::ARMED_PATH,
-        arm_prefix = smolvm_protocol::forkpoint::ARM_PREFIX,
-        armed_prefix = smolvm_protocol::forkpoint::ARMED_PREFIX,
-        generation_prefix = smolvm_protocol::forkpoint::GENERATION_PREFIX,
-        ready = smolvm_protocol::forkpoint::READY_PATH,
-    )
-}
-
 /// Put a negotiated workload helper into its restore-safe userspace loop just
 /// before capture. A branchable machine without a helper remains a valid
 /// immediate snapshot source, and an older guest keeps its legacy loop.
 fn arm_forkpoint_for_capture(golden: &str) -> Result<bool> {
-    let socket = vm_data_dir(golden).join("agent.sock");
-    let mut client = AgentClient::connect_with_retry(&socket)
-        .map_err(|e| Error::agent("arm branchpoint", format!("agent connect: {e}")))?;
-    if !client
-        .supports_capability(smolvm_protocol::forkpoint::ARMING_CAPABILITY)
+    use smolvm_protocol::forkpoint::typed_error;
+    let mut client = branch_client(golden, "arm branchpoint")?;
+    match client
+        .branchpoint_arm()
         .map_err(|e| Error::agent("arm branchpoint", e.to_string()))?
     {
-        return Ok(false);
-    }
-    if client
-        .supports_typed_branchpoint()
-        .map_err(|e| Error::agent("arm branchpoint", e.to_string()))?
-    {
-        use smolvm_protocol::forkpoint::typed_error;
-        return match client
-            .branchpoint_arm()
-            .map_err(|e| Error::agent("arm branchpoint", e.to_string()))?
-        {
-            Ok(()) => Ok(true),
-            // No branchpoint declared: a branchable machine without a helper is
-            // a valid immediate snapshot source.
-            Err(f) if f.code.as_deref() == Some(typed_error::NOT_READY) => Ok(false),
-            Err(f) if f.code.as_deref() == Some(typed_error::NO_ACK) => Err(Error::agent(
-                "arm branchpoint",
-                format!("source '{golden}' did not acknowledge the capture arm marker: {f}"),
-            )),
-            Err(f) => Err(Error::agent(
-                "arm branchpoint",
-                format!("source '{golden}': {f}"),
-            )),
-        };
-    }
-    match client.vm_exec(
-        vec!["/bin/sh".into(), "-c".into(), build_arm_forkpoint_script()],
-        vec![],
-        None,
-        Some(Duration::from_secs(3)),
-        None,
-    ) {
-        Ok((0, _, _)) => Ok(true),
-        Ok((3, _, _)) => Ok(false),
-        Ok((47, _, _)) => Err(Error::agent(
+        Ok(()) => Ok(true),
+        // No branchpoint declared: a branchable machine without a helper is
+        // a valid immediate snapshot source.
+        Err(f) if f.code.as_deref() == Some(typed_error::NOT_READY) => Ok(false),
+        Err(f) if f.code.as_deref() == Some(typed_error::NO_ACK) => Err(Error::agent(
             "arm branchpoint",
-            format!("source '{golden}' did not acknowledge the capture arm marker"),
+            format!("source '{golden}' did not acknowledge the capture arm marker: {f}"),
         )),
-        Ok((code, _, stderr)) => Err(Error::agent(
+        Err(f) => Err(Error::agent(
             "arm branchpoint",
-            format!(
-                "source '{golden}' arm exited {code}: {}",
-                String::from_utf8_lossy(&stderr).trim()
-            ),
-        )),
-        Err(error) => Err(Error::agent(
-            "arm branchpoint",
-            format!("source '{golden}': {error}"),
+            format!("source '{golden}': {f}"),
         )),
     }
-}
-
-fn build_park_forkpoint_script() -> String {
-    format!(
-        "rm -f '{arm}'; \
-         i=0; while [ -e '{armed}' ]; do \
-           i=$((i + 1)); [ \"$i\" -lt 400 ] || exit 47; sleep 0.005; \
-         done",
-        arm = smolvm_protocol::forkpoint::ARM_PATH,
-        armed = smolvm_protocol::forkpoint::ARMED_PATH,
-    )
 }
 
 /// Park the continued source after capture. Failure is reported to the caller,
 /// which can retain the valid snapshot while making the performance fault
 /// visible instead of corrupting a completed branch generation.
 fn park_forkpoint_after_capture(golden: &str) -> Result<()> {
-    let socket = vm_data_dir(golden).join("agent.sock");
-    let mut client = AgentClient::connect_with_retry(&socket)
-        .map_err(|e| Error::agent("park branchpoint", format!("agent connect: {e}")))?;
-    if client
-        .supports_typed_branchpoint()
+    let mut client = branch_client(golden, "park branchpoint")?;
+    match client
+        .branchpoint_park()
         .map_err(|e| Error::agent("park branchpoint", e.to_string()))?
     {
-        return match client
-            .branchpoint_park()
-            .map_err(|e| Error::agent("park branchpoint", e.to_string()))?
-        {
-            Ok(()) => Ok(()),
-            Err(f) => Err(Error::agent(
-                "park branchpoint",
-                format!("source '{golden}': {f}"),
-            )),
-        };
-    }
-    match client.vm_exec(
-        vec!["/bin/sh".into(), "-c".into(), build_park_forkpoint_script()],
-        vec![],
-        None,
-        Some(Duration::from_secs(3)),
-        None,
-    ) {
-        Ok((0, _, _)) => Ok(()),
-        Ok((47, _, _)) => Err(Error::agent(
+        Ok(()) => Ok(()),
+        Err(f) => Err(Error::agent(
             "park branchpoint",
-            format!("source '{golden}' did not leave its capture loop"),
-        )),
-        Ok((code, _, stderr)) => Err(Error::agent(
-            "park branchpoint",
-            format!(
-                "source '{golden}' park exited {code}: {}",
-                String::from_utf8_lossy(&stderr).trim()
-            ),
-        )),
-        Err(error) => Err(Error::agent(
-            "park branchpoint",
-            format!("source '{golden}': {error}"),
+            format!("source '{golden}': {f}"),
         )),
     }
 }
@@ -1482,30 +1344,6 @@ pub fn sync_fork_source(name: &str) -> Result<()> {
     }
 }
 
-/// Build the clone-local release and acknowledgement script.
-fn build_release_forkpoint_script() -> String {
-    format!(
-        "set -e; mkdir -p '{dir}'; umask 077; \
-         if [ -f '{ready}' ]; then generation=$(sed -n 's/^{generation_prefix}//p' '{ready}' | head -n 1); else generation=''; fi; \
-         case \"$generation\" in ''|*[!0-9a-fA-F]*) generation='' ;; esac; \
-         if [ \"${{#generation}}\" -eq 32 ]; then \
-           printf '%s%s\\n' '{release_prefix}' \"$generation\" > '{release}.tmp'; \
-         else \
-           generation=''; printf '%s\\n' '{legacy_release}' > '{release}.tmp'; \
-         fi; \
-         mv '{release}.tmp' '{release}'; i=0; \
-         while if [ -n \"$generation\" ]; then grep -q -x \"{generation_prefix}$generation\" '{ready}' 2>/dev/null; else [ -f '{ready}' ]; fi; do \
-           i=$((i + 1)); [ \"$i\" -lt 500 ] || exit 46; sleep 0.02; \
-         done",
-        dir = smolvm_protocol::forkpoint::STATE_DIR,
-        generation_prefix = smolvm_protocol::forkpoint::GENERATION_PREFIX,
-        legacy_release = smolvm_protocol::forkpoint::LEGACY_RELEASE_TOKEN,
-        release = smolvm_protocol::forkpoint::RELEASE_PATH,
-        release_prefix = smolvm_protocol::forkpoint::RELEASE_PREFIX,
-        ready = smolvm_protocol::forkpoint::READY_PATH,
-    )
-}
-
 /// Release the workload restored in `clone` after its identity and per-fork
 /// environment are installed. The state directory is private guest RAM, so a
 /// release marker wakes only this clone even though every clone inherited the
@@ -1515,47 +1353,15 @@ fn build_release_forkpoint_script() -> String {
 /// the same parameters [`write_fork_env`] installed; a typed agent carries it
 /// inside the release marker so the helper receives both in one atomic step.
 pub fn release_forkpoint(clone: &str, env: &[(String, String)]) -> Result<()> {
-    let socket = vm_data_dir(clone).join("agent.sock");
-    let mut client = AgentClient::connect_with_retry(&socket)
-        .map_err(|e| Error::agent("release forkpoint", format!("agent connect: {e}")))?;
-    if client
-        .supports_typed_branchpoint()
+    let mut client = branch_client(clone, "release forkpoint")?;
+    match client
+        .branchpoint_release(&render_fork_env(env))
         .map_err(|e| Error::agent("release forkpoint", e.to_string()))?
     {
-        return match client
-            .branchpoint_release(&render_fork_env(env))
-            .map_err(|e| Error::agent("release forkpoint", e.to_string()))?
-        {
-            Ok(()) => Ok(()),
-            Err(f) => Err(Error::agent(
-                "release forkpoint",
-                format!("clone '{clone}': {f}"),
-            )),
-        };
-    }
-    let script = build_release_forkpoint_script();
-    match client.vm_exec(
-        vec!["/bin/sh".into(), "-c".into(), script],
-        vec![],
-        None,
-        Some(Duration::from_secs(15)),
-        None,
-    ) {
-        Ok((0, _, _)) => Ok(()),
-        Ok((46, _, _)) => Err(Error::agent(
+        Ok(()) => Ok(()),
+        Err(f) => Err(Error::agent(
             "release forkpoint",
-            format!("clone '{clone}' did not acknowledge its release marker"),
-        )),
-        Ok((code, _, stderr)) => Err(Error::agent(
-            "release forkpoint",
-            format!(
-                "clone '{clone}' release exited {code}: {}",
-                String::from_utf8_lossy(&stderr).trim()
-            ),
-        )),
-        Err(e) => Err(Error::agent(
-            "release forkpoint",
-            format!("clone '{clone}': {e}"),
+            format!("clone '{clone}': {f}"),
         )),
     }
 }
@@ -2864,39 +2670,11 @@ pub fn render_branch_env(env: &[(String, String)]) -> String {
 /// delimiter on a line of its own, newline-terminated: a heredoc terminator
 /// must be the whole line, so a caller continues on the next line and must
 /// not append `;` or `&&` to the fragment.
-fn branch_env_install_fragment(
-    path: &str,
-    env: &[(String, String)],
-    form: BranchEnvForm,
-) -> String {
-    let content = match form {
-        BranchEnvForm::Sourceable => render_branch_env(env),
-        BranchEnvForm::Dotenv => render_fork_env(env),
-    };
+fn branch_env_install_fragment(path: &str, env: &[(String, String)]) -> String {
     format!(
-        "cat > '{path}.tmp' <<'SMOLVM_BRANCH_ENV_EOF' && mv '{path}.tmp' '{path}'\n{content}SMOLVM_BRANCH_ENV_EOF\n"
+        "cat > '{path}.tmp' <<'SMOLVM_BRANCH_ENV_EOF' && mv '{path}.tmp' '{path}'\n{content}SMOLVM_BRANCH_ENV_EOF\n",
+        content = render_branch_env(env)
     )
-}
-
-/// The shape of `branch-env`, chosen by the agent that will read it. An agent
-/// with the typed branchpoint protocol reads either form, so it gets the
-/// sourceable one; an older agent's `smolvm-worker-ready` parses only plain
-/// `KEY=VALUE` lines from this file, so it must keep receiving those or a
-/// pool lease that awaits readiness would never see its token.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum BranchEnvForm {
-    Sourceable,
-    Dotenv,
-}
-
-impl BranchEnvForm {
-    fn for_agent(client: &mut AgentClient) -> Result<Self> {
-        Ok(if client.supports_typed_branchpoint()? {
-            Self::Sourceable
-        } else {
-            Self::Dotenv
-        })
-    }
 }
 
 /// Merge assignment-time parameters into a held slot's initial fork
@@ -2960,8 +2738,6 @@ pub fn write_fork_env(clone: &str, record: &VmRecord, env: &[(String, String)]) 
     let sock = vm_data_dir(clone).join("agent.sock");
     let mut client = AgentClient::connect_with_retry(&sock)
         .map_err(|e| Error::agent("fork env: agent connect", e.to_string()))?;
-    let form = BranchEnvForm::for_agent(&mut client)
-        .map_err(|e| Error::agent("fork env", e.to_string()))?;
     // Image machines MUST land the file in the workload container's rootfs
     // (the overlay merged dir): falling through silently would strand it in
     // the agent rootfs where no workload will ever look. Fail with the actual
@@ -2973,12 +2749,12 @@ pub fn write_fork_env(clone: &str, record: &VmRecord, env: &[(String, String)]) 
              mkdir -p {merged}/etc/smolvm && umask 077 && \
              cat > {merged}{FORK_ENV_GUEST_PATH} && {branch_env}",
             branch_env =
-                branch_env_install_fragment(&format!("{merged}{BRANCH_ENV_GUEST_PATH}"), env, form)
+                branch_env_install_fragment(&format!("{merged}{BRANCH_ENV_GUEST_PATH}"), env)
         )
     } else {
         format!(
             "mkdir -p /etc/smolvm && umask 077 && cat > {FORK_ENV_GUEST_PATH} && {branch_env}",
-            branch_env = branch_env_install_fragment(BRANCH_ENV_GUEST_PATH, env, form)
+            branch_env = branch_env_install_fragment(BRANCH_ENV_GUEST_PATH, env)
         )
     };
     match client.vm_exec(
@@ -3034,14 +2810,6 @@ pub fn activate_held_fork(
     } else {
         BRANCH_ENV_GUEST_PATH.to_string()
     };
-    let ensure_env_parent = if record.image.is_some() {
-        format!(
-            "if [ ! -d '{merged_root}' ]; then echo 'missing {merged_root}' >&2; exit 41; fi; \
-             mkdir -p '{merged_root}/etc/smolvm'"
-        )
-    } else {
-        "mkdir -p /etc/smolvm".to_string()
-    };
     // The token makes this operation safe to repeat after an ambiguous socket
     // timeout. A release can wake a CUDA-heavy workload before the guest agent's
     // reply reaches the host; without an idempotency receipt, retrying could vend
@@ -3052,20 +2820,6 @@ pub fn activate_held_fork(
         crate::util::generate_short_id(),
         crate::util::generate_short_id()
     );
-    let receipt = format!("{}/activation", smolvm_protocol::forkpoint::STATE_DIR);
-    let script = build_activation_script(
-        ActivationScriptPaths {
-            ready: smolvm_protocol::forkpoint::READY_PATH,
-            release: smolvm_protocol::forkpoint::RELEASE_PATH,
-            worker_ready: smolvm_protocol::forkpoint::WORKER_READY_PATH,
-            receipt: &receipt,
-            env: &env_path,
-            branch_env: &branch_env_path,
-        },
-        &ensure_env_parent,
-        &activation_token,
-        &merged,
-    );
     let (require_dir, env_dir) = if record.image.is_some() {
         (
             Some(merged_root.clone()),
@@ -3074,10 +2828,18 @@ pub fn activate_held_fork(
     } else {
         (None, "/etc/smolvm".to_string())
     };
-    let sourceable = render_branch_env(&merged);
-    let socket = vm_data_dir(clone).join("agent.sock");
+    let activation = crate::agent::client::BranchpointActivation {
+        env_dotenv: content,
+        env_sourceable: render_branch_env(&merged),
+        env_path,
+        branch_env_path,
+        require_dir,
+        env_dir,
+        activation_token,
+    };
+    use smolvm_protocol::forkpoint::typed_error;
     for attempt in 1..=2 {
-        let mut client = match AgentClient::connect_with_retry(&socket) {
+        let mut client = match branch_client(clone, "activate held fork") {
             Ok(client) => client,
             Err(error) if attempt == 1 => {
                 tracing::warn!(
@@ -3088,110 +2850,36 @@ pub fn activate_held_fork(
                 std::thread::sleep(Duration::from_millis(100));
                 continue;
             }
-            Err(error) => {
-                return Err(Error::agent(
-                    "activate held fork",
-                    format!("agent connect: {error}"),
-                ));
-            }
+            Err(error) => return Err(error),
         };
-        if client
-            .supports_typed_branchpoint()
-            .map_err(|e| Error::agent("activate held fork", e.to_string()))?
-        {
-            use smolvm_protocol::forkpoint::typed_error;
-            match client.branchpoint_activate(crate::agent::client::BranchpointActivation {
-                env_dotenv: content.clone(),
-                env_sourceable: sourceable.clone(),
-                env_path: env_path.clone(),
-                branch_env_path: branch_env_path.clone(),
-                require_dir: require_dir.clone(),
-                env_dir: env_dir.clone(),
-                activation_token: activation_token.clone(),
-            }) {
-                // A repeat with the same token after an ambiguous reply is the
-                // partial commit completing, not a second activation.
-                Ok(Ok(_already_done)) => return Ok(merged),
-                Ok(Err(f)) if f.code.as_deref() == Some(typed_error::TOKEN_MISMATCH) => {
-                    return Err(Error::agent(
-                        "activate held fork",
-                        format!("clone '{clone}' was already released"),
-                    ));
-                }
-                Ok(Err(f)) if f.code.as_deref() == Some(typed_error::NOT_READY) => {
-                    return Err(Error::agent(
-                        "activate held fork",
-                        format!("clone '{clone}' is not parked at a forkpoint"),
-                    ));
-                }
-                Ok(Err(f)) if attempt == 1 => {
-                    tracing::warn!(
-                        clone,
-                        error = %f,
-                        "held-fork activation attempt failed; retrying idempotently"
-                    );
-                    std::thread::sleep(Duration::from_millis(100));
-                    continue;
-                }
-                Ok(Err(f)) => {
-                    return Err(Error::agent(
-                        "activate held fork",
-                        format!("clone '{clone}': {f}"),
-                    ));
-                }
-                Err(error) if attempt == 1 => {
-                    tracing::warn!(
-                        clone,
-                        %error,
-                        "held-fork activation reply was ambiguous; retrying idempotently"
-                    );
-                    std::thread::sleep(Duration::from_millis(100));
-                    continue;
-                }
-                Err(error) => {
-                    return Err(Error::agent(
-                        "activate held fork",
-                        format!("clone '{clone}': {error}"),
-                    ));
-                }
-            }
-        }
-        match client.vm_exec(
-            vec!["/bin/sh".into(), "-c".into(), script.clone()],
-            vec![],
-            None,
-            Some(Duration::from_secs(10)),
-            Some(content.clone()),
-        ) {
-            Ok((0, _, _)) => return Ok(merged),
-            Ok((42, _, _)) => {
+        match client.branchpoint_activate(activation.clone()) {
+            // A repeat with the same token after an ambiguous reply is the
+            // partial commit completing, not a second activation.
+            Ok(Ok(_already_done)) => return Ok(merged),
+            Ok(Err(f)) if f.code.as_deref() == Some(typed_error::TOKEN_MISMATCH) => {
                 return Err(Error::agent(
                     "activate held fork",
                     format!("clone '{clone}' was already released"),
                 ));
             }
-            Ok((43, _, _)) => {
+            Ok(Err(f)) if f.code.as_deref() == Some(typed_error::NOT_READY) => {
                 return Err(Error::agent(
                     "activate held fork",
                     format!("clone '{clone}' is not parked at a forkpoint"),
                 ));
             }
-            Ok((code, _, stderr)) if attempt == 1 => {
+            Ok(Err(f)) if attempt == 1 => {
                 tracing::warn!(
                     clone,
-                    code,
-                    stderr = %String::from_utf8_lossy(&stderr).trim(),
+                    error = %f,
                     "held-fork activation attempt failed; retrying idempotently"
                 );
                 std::thread::sleep(Duration::from_millis(100));
             }
-            Ok((code, _, stderr)) => {
+            Ok(Err(f)) => {
                 return Err(Error::agent(
                     "activate held fork",
-                    format!(
-                        "clone '{clone}' activation exited {code}: {}",
-                        String::from_utf8_lossy(&stderr).trim()
-                    ),
+                    format!("clone '{clone}': {f}"),
                 ));
             }
             Err(error) if attempt == 1 => {
@@ -3210,15 +2898,10 @@ pub fn activate_held_fork(
             }
         }
     }
-    unreachable!("held-fork activation loop always returns")
-}
-
-const WORKER_READY_TRANSPORT_MARGIN: Duration = Duration::from_secs(30);
-
-fn worker_ready_command_timeout(timeout: Duration) -> Result<Duration> {
-    timeout
-        .checked_add(WORKER_READY_TRANSPORT_MARGIN)
-        .ok_or_else(|| Error::config("worker readiness", "timeout is too large"))
+    Err(Error::agent(
+        "activate held fork",
+        format!("clone '{clone}' activation did not complete"),
+    ))
 }
 
 /// Guest env key telling a workload how long it has to publish readiness.
@@ -3275,6 +2958,7 @@ pub fn worker_ready_token_of(env: &[(String, String)]) -> Option<&str> {
 
 /// Wait until a released workload proves that clone-local preparation finished.
 pub fn wait_for_worker_ready(clone: &str, token: &str, timeout: Duration) -> Result<()> {
+    use smolvm_protocol::forkpoint::typed_error;
     if token.len() != 64 || !token.bytes().all(|byte| byte.is_ascii_hexdigit()) {
         return Err(Error::config(
             "worker readiness",
@@ -3287,163 +2971,32 @@ pub fn wait_for_worker_ready(clone: &str, token: &str, timeout: Duration) -> Res
             "timeout must be positive",
         ));
     }
-    let polls = timeout
-        .as_secs()
-        .checked_mul(10)
-        .ok_or_else(|| Error::config("worker readiness", "timeout is too large"))?;
-    let script = build_worker_ready_wait_script(smolvm_protocol::forkpoint::WORKER_READY_PATH);
-    let socket = vm_data_dir(clone).join("agent.sock");
-    let mut client = AgentClient::connect_with_retry(&socket)
-        .map_err(|error| Error::agent("wait for worker readiness", error.to_string()))?;
-    if !client
-        .supports_capability(smolvm_protocol::forkpoint::WORKER_READY_CAPABILITY)
-        .map_err(|error| Error::agent("check worker readiness capability", error.to_string()))?
-    {
-        return Err(Error::agent(
-            "wait for worker readiness",
-            format!(
-                "clone '{clone}' uses an incompatible guest agent without the worker-readiness capability; rebuild the agent rootfs or remove the stale SMOLVM_AGENT_ROOTFS override"
-            ),
-        ));
-    }
-    let command = vec![
-        "/bin/sh".into(),
-        "-c".into(),
-        script,
-        "smolvm-worker-ready-wait".into(),
-        token.to_ascii_lowercase(),
-        polls.to_string(),
-    ];
-    // The guest poll loop launches `sleep` on every iteration, so its elapsed
-    // wall time can exceed the nominal polling window under CPU contention.
-    // Keep this transport deadline within the controller's reserved activation
-    // grace while allowing the script to report its specific timeout code.
-    let command_timeout = worker_ready_command_timeout(timeout)?;
-    if client
-        .supports_typed_branchpoint()
-        .map_err(|error| Error::agent("wait for worker readiness", error.to_string()))?
-    {
-        use smolvm_protocol::forkpoint::typed_error;
-        return match client
-            .branchpoint_wait_worker_ready(&token.to_ascii_lowercase(), timeout)
-            .map_err(|error| {
-                Error::agent(
-                    "wait for worker readiness",
-                    format!("clone '{clone}': {error}"),
-                )
-            })? {
-            Ok(()) => Ok(()),
-            Err(f) if f.code.as_deref() == Some(typed_error::NO_ACK) => Err(Error::agent(
+    let mut client = branch_client(clone, "wait for worker readiness")?;
+    match client
+        .branchpoint_wait_worker_ready(&token.to_ascii_lowercase(), timeout)
+        .map_err(|error| {
+            Error::agent(
                 "wait for worker readiness",
-                format!(
-                    "clone '{clone}' did not signal readiness within {} seconds",
-                    timeout.as_secs()
-                ),
-            )),
-            Err(f) if f.code.as_deref() == Some(typed_error::TOKEN_MISMATCH) => Err(Error::agent(
-                "wait for worker readiness",
-                format!("clone '{clone}' published a stale or invalid readiness token"),
-            )),
-            Err(f) => Err(Error::agent(
-                "wait for worker readiness",
-                format!("clone '{clone}': {f}"),
-            )),
-        };
-    }
-    match client.vm_exec(command, vec![], None, Some(command_timeout), None) {
-        Ok((0, _, _)) => Ok(()),
-        Ok((44, _, _)) => Err(Error::agent(
+                format!("clone '{clone}': {error}"),
+            )
+        })? {
+        Ok(()) => Ok(()),
+        Err(f) if f.code.as_deref() == Some(typed_error::NO_ACK) => Err(Error::agent(
             "wait for worker readiness",
             format!(
                 "clone '{clone}' did not signal readiness within {} seconds",
                 timeout.as_secs()
             ),
         )),
-        Ok((45, _, _)) => Err(Error::agent(
+        Err(f) if f.code.as_deref() == Some(typed_error::TOKEN_MISMATCH) => Err(Error::agent(
             "wait for worker readiness",
             format!("clone '{clone}' published a stale or invalid readiness token"),
         )),
-        Ok((code, _, stderr)) => Err(Error::agent(
+        Err(f) => Err(Error::agent(
             "wait for worker readiness",
-            format!(
-                "clone '{clone}' readiness wait exited {code}: {}",
-                String::from_utf8_lossy(&stderr).trim()
-            ),
-        )),
-        Err(error) => Err(Error::agent(
-            "wait for worker readiness",
-            format!("clone '{clone}': {error}"),
+            format!("clone '{clone}': {f}"),
         )),
     }
-}
-
-fn build_worker_ready_wait_script(worker_ready: &str) -> String {
-    format!(
-        "set -e; i=0; while [ \"$i\" -lt \"$2\" ]; do \
-         if [ -f '{worker_ready}' ]; then \
-           [ \"$(cat '{worker_ready}')\" = \"$1\" ] && exit 0; exit 45; \
-         fi; \
-         i=$((i + 1)); sleep 0.1; \
-         done; exit 44"
-    )
-}
-
-struct ActivationScriptPaths<'a> {
-    ready: &'a str,
-    release: &'a str,
-    worker_ready: &'a str,
-    receipt: &'a str,
-    env: &'a str,
-    branch_env: &'a str,
-}
-
-fn build_activation_script(
-    paths: ActivationScriptPaths<'_>,
-    ensure_env_parent: &str,
-    activation_token: &str,
-    env: &[(String, String)],
-) -> String {
-    let ActivationScriptPaths {
-        ready,
-        release,
-        worker_ready,
-        receipt,
-        env: env_path,
-        branch_env: branch_env_path,
-    } = paths;
-    format!(
-        "set -e; \
-         if [ -f '{release}' ]; then \
-           [ \"$(cat '{receipt}' 2>/dev/null)\" = '{activation_token}' ] && exit 0; \
-           exit 42; \
-         fi; \
-         if [ ! -f '{ready}' ]; then exit 43; fi; \
-         generation=$(sed -n 's/^{generation_prefix}//p' '{ready}' | head -n 1); \
-         case \"$generation\" in ''|*[!0-9a-fA-F]*) generation='' ;; esac; \
-         rm -f '{worker_ready}'; \
-         receipt_tmp='{receipt}.{activation_token}.'$$; \
-         printf '%s\\n' '{activation_token}' > \"$receipt_tmp\"; \
-         if ! ln \"$receipt_tmp\" '{receipt}' 2>/dev/null; then \
-           rm -f \"$receipt_tmp\"; \
-           [ \"$(cat '{receipt}' 2>/dev/null)\" = '{activation_token}' ] || exit 42; \
-         else rm -f \"$receipt_tmp\"; fi; \
-         {ensure_env_parent}; umask 077; \
-         env_tmp='{env_path}.{activation_token}.'$$; \
-         release_tmp='{release}.{activation_token}.'$$; \
-         trap 'rm -f \"$env_tmp\" \"$release_tmp\"' EXIT; \
-         cat > \"$env_tmp\"; mv \"$env_tmp\" '{env_path}'; \
-         {branch_env_install}if [ \"${{#generation}}\" -eq 32 ]; then \
-           printf '%s%s\\n' '{release_prefix}' \"$generation\" > \"$release_tmp\"; \
-         else printf '%s\\n' '{legacy_release}' > \"$release_tmp\"; fi; \
-         mv \"$release_tmp\" '{release}'",
-        // Only an agent without the typed protocol runs this script, and its
-        // worker-ready helper parses plain lines from this file.
-        branch_env_install =
-            branch_env_install_fragment(branch_env_path, env, BranchEnvForm::Dotenv),
-        generation_prefix = smolvm_protocol::forkpoint::GENERATION_PREFIX,
-        legacy_release = smolvm_protocol::forkpoint::LEGACY_RELEASE_TOKEN,
-        release_prefix = smolvm_protocol::forkpoint::RELEASE_PREFIX,
-    )
 }
 
 /// Fail-closed fork finalizer. A clone whose identity could not be rejuvenated
@@ -3829,54 +3382,6 @@ mod tests {
     }
 
     #[test]
-    fn forkpoint_release_waits_for_clone_acknowledgement() {
-        let script = build_release_forkpoint_script();
-        let publish = script
-            .find(smolvm_protocol::forkpoint::RELEASE_PATH)
-            .expect("release marker must be published");
-        let acknowledge = script
-            .rfind(smolvm_protocol::forkpoint::READY_PATH)
-            .expect("ready marker must be observed");
-        assert!(publish < acknowledge);
-        assert!(script.contains("exit 46"));
-    }
-
-    #[test]
-    fn forkpoint_arm_is_generation_scoped_and_waits_for_acknowledgement() {
-        let script = build_arm_forkpoint_script();
-        let ready = script
-            .find(smolvm_protocol::forkpoint::READY_PATH)
-            .expect("ready marker must be read");
-        let publish = script
-            .find(smolvm_protocol::forkpoint::ARM_PATH)
-            .expect("arm marker must be published");
-        let acknowledge = script
-            .rfind(smolvm_protocol::forkpoint::ARMED_PATH)
-            .expect("armed marker must be observed");
-
-        assert!(ready < publish);
-        assert!(publish < acknowledge);
-        assert!(script.contains(smolvm_protocol::forkpoint::GENERATION_PREFIX));
-        assert!(script.contains(smolvm_protocol::forkpoint::ARM_PREFIX));
-        assert!(script.contains(smolvm_protocol::forkpoint::ARMED_PREFIX));
-        assert!(script.contains("exit 47"));
-    }
-
-    #[test]
-    fn forkpoint_park_disarms_before_waiting_for_idle_acknowledgement() {
-        let script = build_park_forkpoint_script();
-        let disarm = script
-            .find(smolvm_protocol::forkpoint::ARM_PATH)
-            .expect("arm marker must be removed");
-        let idle_ack = script
-            .rfind(smolvm_protocol::forkpoint::ARMED_PATH)
-            .expect("armed marker removal must be observed");
-
-        assert!(disarm < idle_ack);
-        assert!(script.contains("exit 47"));
-    }
-
-    #[test]
     fn golden_rollback_reapplies_a_completed_checkpoint_only() {
         let temp = tempfile::tempdir().unwrap();
         assert_eq!(golden_resume_command(temp.path()).unwrap(), "RESUME");
@@ -4178,13 +3683,7 @@ mod tests {
         );
         assert_eq!(render_branch_env(&[]), "");
         // The install fragment embeds it in a quoted heredoc and moves it into place atomically.
-        let frag =
-            branch_env_install_fragment("/etc/smolvm/branch-env", &env, BranchEnvForm::Sourceable);
-        // An older agent's readiness helper reads plain lines, so it gets them.
-        assert!(
-            branch_env_install_fragment("/etc/smolvm/branch-env", &env, BranchEnvForm::Dotenv)
-                .contains("\nNOTE=a=b c\n")
-        );
+        let frag = branch_env_install_fragment("/etc/smolvm/branch-env", &env);
         // `&& mv` on the heredoc line, body after it, delimiter last: the
         // rename is conditional on the write, and a caller's `&&` chain holds.
         assert!(frag.starts_with(
@@ -4198,11 +3697,7 @@ mod tests {
         let ok = std::process::Command::new("/bin/sh")
             .args([
                 "-c",
-                &branch_env_install_fragment(
-                    target.to_str().unwrap(),
-                    &env,
-                    BranchEnvForm::Sourceable,
-                ),
+                &branch_env_install_fragment(target.to_str().unwrap(), &env),
             ])
             .status()
             .unwrap();
@@ -4237,211 +3732,8 @@ mod tests {
     }
 
     #[cfg(unix)]
-    fn run_activation_script(script: &str, stdin: &str) -> std::process::Output {
-        use std::io::Write;
-        use std::process::{Command, Stdio};
-
-        let mut child = Command::new("/bin/sh")
-            .args(["-c", script])
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .expect("spawn activation script");
-        child
-            .stdin
-            .take()
-            .expect("activation stdin")
-            .write_all(stdin.as_bytes())
-            .expect("write activation input");
-        child
-            .wait_with_output()
-            .expect("wait for activation script")
-    }
-
     #[cfg(unix)]
-    #[test]
-    fn held_fork_activation_is_idempotent_after_an_ambiguous_reply() {
-        let temp = tempfile::tempdir().unwrap();
-        let state = temp.path().join("state");
-        let workspace = temp.path().join("workspace");
-        std::fs::create_dir_all(&state).unwrap();
-        let generation = "0123456789abcdef0123456789abcdef";
-        std::fs::write(
-            state.join("ready"),
-            format!(
-                "{}\n{}{generation}\n",
-                smolvm_protocol::forkpoint::READY_VERSION,
-                smolvm_protocol::forkpoint::GENERATION_PREFIX
-            ),
-        )
-        .unwrap();
-        let ready = state.join("ready");
-        let release = state.join("release");
-        let worker_ready = state.join("worker-ready");
-        let receipt = state.join("activation");
-        let env_path = workspace.join("fork-env");
-        let branch_env_path = workspace.join("branch-env");
-        let ensure_parent = format!("mkdir -p '{}'", workspace.display());
-        let token = "0123456789abcdef";
-        std::fs::write(&worker_ready, b"stale\n").unwrap();
-        let script = build_activation_script(
-            ActivationScriptPaths {
-                ready: ready.to_str().unwrap(),
-                release: release.to_str().unwrap(),
-                worker_ready: worker_ready.to_str().unwrap(),
-                receipt: receipt.to_str().unwrap(),
-                env: env_path.to_str().unwrap(),
-                branch_env: branch_env_path.to_str().unwrap(),
-            },
-            &ensure_parent,
-            token,
-            &[("LR".to_string(), "1e-4".to_string())],
-        );
-
-        let first = run_activation_script(&script, "LR=1e-4\n");
-        assert!(
-            first.status.success(),
-            "{}",
-            String::from_utf8_lossy(&first.stderr)
-        );
-        assert_eq!(std::fs::read_to_string(&env_path).unwrap(), "LR=1e-4\n");
-        // The script path serves older agents, whose readiness helper reads
-        // plain lines from branch-env.
-        assert_eq!(
-            std::fs::read_to_string(&branch_env_path).unwrap(),
-            "LR=1e-4\n"
-        );
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            assert_eq!(
-                std::fs::metadata(&env_path).unwrap().permissions().mode() & 0o777,
-                0o600
-            );
-        }
-        assert_eq!(
-            std::fs::read_to_string(&receipt).unwrap(),
-            format!("{token}\n")
-        );
-        assert_eq!(
-            std::fs::read_to_string(&release).unwrap(),
-            format!(
-                "{}{generation}\n",
-                smolvm_protocol::forkpoint::RELEASE_PREFIX
-            )
-        );
-        assert!(!worker_ready.exists());
-
-        // A lost reply may cause the host to send the same activation again.
-        // The receipt proves ownership and makes that retry a successful no-op.
-        let retry = run_activation_script(&script, "LR=changed\n");
-        assert!(retry.status.success());
-        assert_eq!(std::fs::read_to_string(&env_path).unwrap(), "LR=1e-4\n");
-
-        let other = build_activation_script(
-            ActivationScriptPaths {
-                ready: ready.to_str().unwrap(),
-                release: release.to_str().unwrap(),
-                worker_ready: worker_ready.to_str().unwrap(),
-                receipt: receipt.to_str().unwrap(),
-                env: env_path.to_str().unwrap(),
-                branch_env: branch_env_path.to_str().unwrap(),
-            },
-            &ensure_parent,
-            "fedcba9876543210",
-            &[],
-        );
-        assert_eq!(
-            run_activation_script(&other, "LR=other\n").status.code(),
-            Some(42)
-        );
-    }
-
     #[cfg(unix)]
-    #[test]
-    fn held_fork_activation_retry_finishes_a_partial_commit() {
-        let temp = tempfile::tempdir().unwrap();
-        let state = temp.path().join("state");
-        let workspace = temp.path().join("workspace");
-        std::fs::create_dir_all(&state).unwrap();
-        std::fs::write(state.join("ready"), b"ready\n").unwrap();
-        let ready = state.join("ready");
-        let release = state.join("release");
-        let worker_ready = state.join("worker-ready");
-        let receipt = state.join("activation");
-        let env_path = workspace.join("fork-env");
-        let branch_env_path = workspace.join("branch-env");
-        let ensure_parent = format!("mkdir -p '{}'", workspace.display());
-        let token = "0123456789abcdef";
-        std::fs::write(&receipt, format!("{token}\n")).unwrap();
-        let script = build_activation_script(
-            ActivationScriptPaths {
-                ready: ready.to_str().unwrap(),
-                release: release.to_str().unwrap(),
-                worker_ready: worker_ready.to_str().unwrap(),
-                receipt: receipt.to_str().unwrap(),
-                env: env_path.to_str().unwrap(),
-                branch_env: branch_env_path.to_str().unwrap(),
-            },
-            &ensure_parent,
-            token,
-            &[("LR".to_string(), "3e-4".to_string())],
-        );
-
-        let retry = run_activation_script(&script, "LR=3e-4\n");
-        assert!(
-            retry.status.success(),
-            "{}",
-            String::from_utf8_lossy(&retry.stderr)
-        );
-        assert_eq!(std::fs::read_to_string(&env_path).unwrap(), "LR=3e-4\n");
-        assert_eq!(
-            std::fs::read_to_string(&branch_env_path).unwrap(),
-            "LR=3e-4\n"
-        );
-        assert!(release.is_file());
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn worker_ready_wait_requires_the_exact_token_and_has_a_bounded_timeout() {
-        let temp = tempfile::tempdir().unwrap();
-        let marker = temp.path().join("worker-ready");
-        let script = build_worker_ready_wait_script(marker.to_str().unwrap());
-        let expected = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-
-        std::fs::write(&marker, format!("{expected}\n")).unwrap();
-        let success = std::process::Command::new("/bin/sh")
-            .args(["-c", &script, "wait", expected, "1"])
-            .output()
-            .unwrap();
-        assert!(success.status.success());
-
-        std::fs::write(&marker, format!("{}\n", "f".repeat(64))).unwrap();
-        let stale = std::process::Command::new("/bin/sh")
-            .args(["-c", &script, "wait", expected, "1"])
-            .output()
-            .unwrap();
-        assert_eq!(stale.status.code(), Some(45));
-
-        std::fs::remove_file(marker).unwrap();
-        let timeout = std::process::Command::new("/bin/sh")
-            .args(["-c", &script, "wait", expected, "1"])
-            .output()
-            .unwrap();
-        assert_eq!(timeout.status.code(), Some(44));
-        assert!(!script.contains(expected));
-    }
-
-    #[test]
-    fn worker_ready_transport_deadline_allows_poll_loop_overhead() {
-        assert_eq!(
-            worker_ready_command_timeout(Duration::from_secs(120)).unwrap(),
-            Duration::from_secs(150)
-        );
-    }
-
     #[test]
     fn successful_activation_is_persisted_as_one_shot() {
         let mut record = VmRecord::new("slot-0".to_string(), 2, 1024, vec![], vec![], false);

--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -321,6 +321,32 @@ pub fn wait_for_forkpoint(golden: &str, timeout: Duration) -> Result<()> {
     let socket = vm_data_dir(golden).join("agent.sock");
     let mut client = AgentClient::connect_with_retry(&socket)
         .map_err(|e| Error::agent("wait for forkpoint", format!("agent connect: {e}")))?;
+    if client
+        .supports_typed_branchpoint()
+        .map_err(|e| Error::agent("wait for forkpoint", e.to_string()))?
+    {
+        return match client
+            .branchpoint_wait(timeout)
+            .map_err(|e| Error::agent("wait for forkpoint", e.to_string()))?
+        {
+            Ok(contents) => {
+                let profile = parse_forkpoint_profile(contents.as_bytes());
+                persist_forkpoint_profile(golden, profile)?;
+                Ok(())
+            }
+            Err(f) => Err(Error::agent(
+                "wait for forkpoint",
+                format!(
+                    "source '{golden}' did not reach a branchpoint within {}s: {f}\n\
+                     A batch branch snapshots the source at a point its workload declares by running \
+                     `smolvm-branch-ready` after setup (see README, \"Branch a running machine\"). \
+                     If the workload never calls it, either add the call, raise --ready-timeout, or \
+                     take single `--name` branches, which snapshot the source wherever it is.",
+                    timeout.as_secs_f64()
+                ),
+            )),
+        };
+    }
     let script = format!(
         "while [ ! -f '{ready}' ]; do sleep 0.05; done; cat '{ready}'",
         ready = smolvm_protocol::forkpoint::READY_PATH,
@@ -392,6 +418,29 @@ fn arm_forkpoint_for_capture(golden: &str) -> Result<bool> {
     {
         return Ok(false);
     }
+    if client
+        .supports_typed_branchpoint()
+        .map_err(|e| Error::agent("arm branchpoint", e.to_string()))?
+    {
+        use smolvm_protocol::forkpoint::typed_error;
+        return match client
+            .branchpoint_arm()
+            .map_err(|e| Error::agent("arm branchpoint", e.to_string()))?
+        {
+            Ok(()) => Ok(true),
+            // No branchpoint declared: a branchable machine without a helper is
+            // a valid immediate snapshot source.
+            Err(f) if f.code.as_deref() == Some(typed_error::NOT_READY) => Ok(false),
+            Err(f) if f.code.as_deref() == Some(typed_error::NO_ACK) => Err(Error::agent(
+                "arm branchpoint",
+                format!("source '{golden}' did not acknowledge the capture arm marker: {f}"),
+            )),
+            Err(f) => Err(Error::agent(
+                "arm branchpoint",
+                format!("source '{golden}': {f}"),
+            )),
+        };
+    }
     match client.vm_exec(
         vec!["/bin/sh".into(), "-c".into(), build_arm_forkpoint_script()],
         vec![],
@@ -437,6 +486,21 @@ fn park_forkpoint_after_capture(golden: &str) -> Result<()> {
     let socket = vm_data_dir(golden).join("agent.sock");
     let mut client = AgentClient::connect_with_retry(&socket)
         .map_err(|e| Error::agent("park branchpoint", format!("agent connect: {e}")))?;
+    if client
+        .supports_typed_branchpoint()
+        .map_err(|e| Error::agent("park branchpoint", e.to_string()))?
+    {
+        return match client
+            .branchpoint_park()
+            .map_err(|e| Error::agent("park branchpoint", e.to_string()))?
+        {
+            Ok(()) => Ok(()),
+            Err(f) => Err(Error::agent(
+                "park branchpoint",
+                format!("source '{golden}': {f}"),
+            )),
+        };
+    }
     match client.vm_exec(
         vec!["/bin/sh".into(), "-c".into(), build_park_forkpoint_script()],
         vec![],
@@ -1451,6 +1515,21 @@ pub fn release_forkpoint(clone: &str) -> Result<()> {
     let socket = vm_data_dir(clone).join("agent.sock");
     let mut client = AgentClient::connect_with_retry(&socket)
         .map_err(|e| Error::agent("release forkpoint", format!("agent connect: {e}")))?;
+    if client
+        .supports_typed_branchpoint()
+        .map_err(|e| Error::agent("release forkpoint", e.to_string()))?
+    {
+        return match client
+            .branchpoint_release()
+            .map_err(|e| Error::agent("release forkpoint", e.to_string()))?
+        {
+            Ok(()) => Ok(()),
+            Err(f) => Err(Error::agent(
+                "release forkpoint",
+                format!("clone '{clone}': {f}"),
+            )),
+        };
+    }
     let script = build_release_forkpoint_script();
     match client.vm_exec(
         vec!["/bin/sh".into(), "-c".into(), script],
@@ -2954,6 +3033,15 @@ pub fn activate_held_fork(
         &activation_token,
         &merged,
     );
+    let (require_dir, env_dir) = if record.image.is_some() {
+        (
+            Some(merged_root.clone()),
+            format!("{merged_root}/etc/smolvm"),
+        )
+    } else {
+        (None, "/etc/smolvm".to_string())
+    };
+    let sourceable = render_branch_env(&merged);
     let socket = vm_data_dir(clone).join("agent.sock");
     for attempt in 1..=2 {
         let mut client = match AgentClient::connect_with_retry(&socket) {
@@ -2974,6 +3062,67 @@ pub fn activate_held_fork(
                 ));
             }
         };
+        if client
+            .supports_typed_branchpoint()
+            .map_err(|e| Error::agent("activate held fork", e.to_string()))?
+        {
+            use smolvm_protocol::forkpoint::typed_error;
+            match client.branchpoint_activate(crate::agent::client::BranchpointActivation {
+                env_dotenv: content.clone(),
+                env_sourceable: sourceable.clone(),
+                env_path: env_path.clone(),
+                branch_env_path: branch_env_path.clone(),
+                require_dir: require_dir.clone(),
+                env_dir: env_dir.clone(),
+                activation_token: activation_token.clone(),
+            }) {
+                // A repeat with the same token after an ambiguous reply is the
+                // partial commit completing, not a second activation.
+                Ok(Ok(_already_done)) => return Ok(merged),
+                Ok(Err(f)) if f.code.as_deref() == Some(typed_error::TOKEN_MISMATCH) => {
+                    return Err(Error::agent(
+                        "activate held fork",
+                        format!("clone '{clone}' was already released"),
+                    ));
+                }
+                Ok(Err(f)) if f.code.as_deref() == Some(typed_error::NOT_READY) => {
+                    return Err(Error::agent(
+                        "activate held fork",
+                        format!("clone '{clone}' is not parked at a forkpoint"),
+                    ));
+                }
+                Ok(Err(f)) if attempt == 1 => {
+                    tracing::warn!(
+                        clone,
+                        error = %f,
+                        "held-fork activation attempt failed; retrying idempotently"
+                    );
+                    std::thread::sleep(Duration::from_millis(100));
+                    continue;
+                }
+                Ok(Err(f)) => {
+                    return Err(Error::agent(
+                        "activate held fork",
+                        format!("clone '{clone}': {f}"),
+                    ));
+                }
+                Err(error) if attempt == 1 => {
+                    tracing::warn!(
+                        clone,
+                        %error,
+                        "held-fork activation reply was ambiguous; retrying idempotently"
+                    );
+                    std::thread::sleep(Duration::from_millis(100));
+                    continue;
+                }
+                Err(error) => {
+                    return Err(Error::agent(
+                        "activate held fork",
+                        format!("clone '{clone}': {error}"),
+                    ));
+                }
+            }
+        }
         match client.vm_exec(
             vec!["/bin/sh".into(), "-c".into(), script.clone()],
             vec![],
@@ -3085,6 +3234,37 @@ pub fn wait_for_worker_ready(clone: &str, token: &str, timeout: Duration) -> Res
     // Keep this transport deadline within the controller's reserved activation
     // grace while allowing the script to report its specific timeout code.
     let command_timeout = worker_ready_command_timeout(timeout)?;
+    if client
+        .supports_typed_branchpoint()
+        .map_err(|error| Error::agent("wait for worker readiness", error.to_string()))?
+    {
+        use smolvm_protocol::forkpoint::typed_error;
+        return match client
+            .branchpoint_wait_worker_ready(&token.to_ascii_lowercase(), timeout)
+            .map_err(|error| {
+                Error::agent(
+                    "wait for worker readiness",
+                    format!("clone '{clone}': {error}"),
+                )
+            })? {
+            Ok(()) => Ok(()),
+            Err(f) if f.code.as_deref() == Some(typed_error::NO_ACK) => Err(Error::agent(
+                "wait for worker readiness",
+                format!(
+                    "clone '{clone}' did not signal readiness within {} seconds",
+                    timeout.as_secs()
+                ),
+            )),
+            Err(f) if f.code.as_deref() == Some(typed_error::TOKEN_MISMATCH) => Err(Error::agent(
+                "wait for worker readiness",
+                format!("clone '{clone}' published a stale or invalid readiness token"),
+            )),
+            Err(f) => Err(Error::agent(
+                "wait for worker readiness",
+                format!("clone '{clone}': {f}"),
+            )),
+        };
+    }
     match client.vm_exec(command, vec![], None, Some(command_timeout), None) {
         Ok((0, _, _)) => Ok(()),
         Ok((44, _, _)) => Err(Error::agent(

--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -2864,11 +2864,39 @@ pub fn render_branch_env(env: &[(String, String)]) -> String {
 /// delimiter on a line of its own, newline-terminated: a heredoc terminator
 /// must be the whole line, so a caller continues on the next line and must
 /// not append `;` or `&&` to the fragment.
-fn branch_env_install_fragment(path: &str, env: &[(String, String)]) -> String {
+fn branch_env_install_fragment(
+    path: &str,
+    env: &[(String, String)],
+    form: BranchEnvForm,
+) -> String {
+    let content = match form {
+        BranchEnvForm::Sourceable => render_branch_env(env),
+        BranchEnvForm::Dotenv => render_fork_env(env),
+    };
     format!(
-        "cat > '{path}.tmp' <<'SMOLVM_BRANCH_ENV_EOF' && mv '{path}.tmp' '{path}'\n{content}SMOLVM_BRANCH_ENV_EOF\n",
-        content = render_branch_env(env)
+        "cat > '{path}.tmp' <<'SMOLVM_BRANCH_ENV_EOF' && mv '{path}.tmp' '{path}'\n{content}SMOLVM_BRANCH_ENV_EOF\n"
     )
+}
+
+/// The shape of `branch-env`, chosen by the agent that will read it. An agent
+/// with the typed branchpoint protocol reads either form, so it gets the
+/// sourceable one; an older agent's `smolvm-worker-ready` parses only plain
+/// `KEY=VALUE` lines from this file, so it must keep receiving those or a
+/// pool lease that awaits readiness would never see its token.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BranchEnvForm {
+    Sourceable,
+    Dotenv,
+}
+
+impl BranchEnvForm {
+    fn for_agent(client: &mut AgentClient) -> Result<Self> {
+        Ok(if client.supports_typed_branchpoint()? {
+            Self::Sourceable
+        } else {
+            Self::Dotenv
+        })
+    }
 }
 
 /// Merge assignment-time parameters into a held slot's initial fork
@@ -2929,6 +2957,11 @@ pub fn write_fork_env(clone: &str, record: &VmRecord, env: &[(String, String)]) 
         record.fork_overlay_owner.as_deref(),
     );
     let merged = format!("/storage/overlays/persistent-{owner}/merged");
+    let sock = vm_data_dir(clone).join("agent.sock");
+    let mut client = AgentClient::connect_with_retry(&sock)
+        .map_err(|e| Error::agent("fork env: agent connect", e.to_string()))?;
+    let form = BranchEnvForm::for_agent(&mut client)
+        .map_err(|e| Error::agent("fork env", e.to_string()))?;
     // Image machines MUST land the file in the workload container's rootfs
     // (the overlay merged dir): falling through silently would strand it in
     // the agent rootfs where no workload will ever look. Fail with the actual
@@ -2940,17 +2973,14 @@ pub fn write_fork_env(clone: &str, record: &VmRecord, env: &[(String, String)]) 
              mkdir -p {merged}/etc/smolvm && umask 077 && \
              cat > {merged}{FORK_ENV_GUEST_PATH} && {branch_env}",
             branch_env =
-                branch_env_install_fragment(&format!("{merged}{BRANCH_ENV_GUEST_PATH}"), env)
+                branch_env_install_fragment(&format!("{merged}{BRANCH_ENV_GUEST_PATH}"), env, form)
         )
     } else {
         format!(
             "mkdir -p /etc/smolvm && umask 077 && cat > {FORK_ENV_GUEST_PATH} && {branch_env}",
-            branch_env = branch_env_install_fragment(BRANCH_ENV_GUEST_PATH, env)
+            branch_env = branch_env_install_fragment(BRANCH_ENV_GUEST_PATH, env, form)
         )
     };
-    let sock = vm_data_dir(clone).join("agent.sock");
-    let mut client = AgentClient::connect_with_retry(&sock)
-        .map_err(|e| Error::agent("fork env: agent connect", e.to_string()))?;
     match client.vm_exec(
         vec!["/bin/sh".into(), "-c".into(), script],
         vec![],
@@ -3406,7 +3436,10 @@ fn build_activation_script(
            printf '%s%s\\n' '{release_prefix}' \"$generation\" > \"$release_tmp\"; \
          else printf '%s\\n' '{legacy_release}' > \"$release_tmp\"; fi; \
          mv \"$release_tmp\" '{release}'",
-        branch_env_install = branch_env_install_fragment(branch_env_path, env),
+        // Only an agent without the typed protocol runs this script, and its
+        // worker-ready helper parses plain lines from this file.
+        branch_env_install =
+            branch_env_install_fragment(branch_env_path, env, BranchEnvForm::Dotenv),
         generation_prefix = smolvm_protocol::forkpoint::GENERATION_PREFIX,
         legacy_release = smolvm_protocol::forkpoint::LEGACY_RELEASE_TOKEN,
         release_prefix = smolvm_protocol::forkpoint::RELEASE_PREFIX,
@@ -4145,7 +4178,13 @@ mod tests {
         );
         assert_eq!(render_branch_env(&[]), "");
         // The install fragment embeds it in a quoted heredoc and moves it into place atomically.
-        let frag = branch_env_install_fragment("/etc/smolvm/branch-env", &env);
+        let frag =
+            branch_env_install_fragment("/etc/smolvm/branch-env", &env, BranchEnvForm::Sourceable);
+        // An older agent's readiness helper reads plain lines, so it gets them.
+        assert!(
+            branch_env_install_fragment("/etc/smolvm/branch-env", &env, BranchEnvForm::Dotenv)
+                .contains("\nNOTE=a=b c\n")
+        );
         // `&& mv` on the heredoc line, body after it, delimiter last: the
         // rename is conditional on the write, and a caller's `&&` chain holds.
         assert!(frag.starts_with(
@@ -4159,7 +4198,11 @@ mod tests {
         let ok = std::process::Command::new("/bin/sh")
             .args([
                 "-c",
-                &branch_env_install_fragment(target.to_str().unwrap(), &env),
+                &branch_env_install_fragment(
+                    target.to_str().unwrap(),
+                    &env,
+                    BranchEnvForm::Sourceable,
+                ),
             ])
             .status()
             .unwrap();
@@ -4263,9 +4306,11 @@ mod tests {
             String::from_utf8_lossy(&first.stderr)
         );
         assert_eq!(std::fs::read_to_string(&env_path).unwrap(), "LR=1e-4\n");
+        // The script path serves older agents, whose readiness helper reads
+        // plain lines from branch-env.
         assert_eq!(
             std::fs::read_to_string(&branch_env_path).unwrap(),
-            "export LR='1e-4'\n"
+            "LR=1e-4\n"
         );
         #[cfg(unix)]
         {
@@ -4351,11 +4396,9 @@ mod tests {
             String::from_utf8_lossy(&retry.stderr)
         );
         assert_eq!(std::fs::read_to_string(&env_path).unwrap(), "LR=3e-4\n");
-        // branch-env is no longer an alias of the dotenv file: it is the same
-        // parameters in a form a shell can `.`-source, exported and quoted.
         assert_eq!(
             std::fs::read_to_string(&branch_env_path).unwrap(),
-            "export LR='3e-4'\n"
+            "LR=3e-4\n"
         );
         assert!(release.is_file());
     }

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -1989,14 +1989,6 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
             )));
         }
 
-        if std::env::var(guest_env::BRANCHPOINT_ARMING).as_deref() == Ok(guest_env::VALUE_ON) {
-            env_strings.push(cstr(&format!(
-                "{}={}",
-                guest_env::BRANCHPOINT_ARMING,
-                guest_env::VALUE_ON
-            )));
-        }
-
         if let Ok(pool_size) = std::env::var(guest_env::CUDA_FORK_POOL_SIZE) {
             env_strings.push(cstr(&format!(
                 "{}={pool_size}",

--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -763,14 +763,6 @@ pub fn launch_agent_vm_dynamic(
         )));
     }
 
-    if std::env::var(guest_env::BRANCHPOINT_ARMING).as_deref() == Ok(guest_env::VALUE_ON) {
-        env_strings.push(cstr(&format!(
-            "{}={}",
-            guest_env::BRANCHPOINT_ARMING,
-            guest_env::VALUE_ON
-        )));
-    }
-
     // Enable Rosetta only when requested AND actually available on this host, so
     // a stray `--rosetta` on a non-Rosetta host degrades to a no-op rather than a
     // dangling virtiofs tag the guest would fail to mount. The guest agent reads

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -2036,10 +2036,6 @@ impl AgentManager {
             let mut v = Vec::new();
             if features.forkable {
                 v.push((smolvm_protocol::guest_env::FORKABLE, "1".to_string()));
-                v.push((
-                    smolvm_protocol::guest_env::BRANCHPOINT_ARMING,
-                    smolvm_protocol::guest_env::VALUE_ON.to_string(),
-                ));
             }
             // Embedder override for the control socket path; without it the
             // launcher defaults to control.sock in the per-VM dir.

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -2278,7 +2278,7 @@ async fn boot_prepared_fork_inner(
         let _ = cuda_worker_ready_timeout;
         if wait_ready && !hold {
             crate::agent::fork::fail_closed_on_rejuvenation(
-                crate::agent::fork::release_forkpoint(&clone_b),
+                crate::agent::fork::release_forkpoint(&clone_b, &fork_env),
                 teardown,
             )
             .map_err(|e| format!("forkpoint release failed: {e}"))?;

--- a/src/api/handlers/pools.rs
+++ b/src/api/handlers/pools.rs
@@ -41,7 +41,7 @@ const LEASE_PAYLOAD_STAGE_ATTEMPTS: usize = 2;
 // before the controller's five-minute activating-lease grace period expires.
 const MAX_WORKER_READY_TIMEOUT_SECS: u64 = crate::pool::FORK_LEASE_ACTIVATION_GRACE_SECS - 60;
 const DEFAULT_WORKER_READY_TIMEOUT_SECS: u64 = MAX_WORKER_READY_TIMEOUT_SECS;
-const WORKER_READY_TIMEOUT_ENV: &str = "SMOLVM_WORKER_READY_TIMEOUT_SECS";
+use crate::agent::fork::WORKER_READY_TIMEOUT_ENV;
 
 const RESERVED_LEASE_ENV: &[&str] = &[
     smolvm_protocol::forkpoint::WORKER_READY_TOKEN_ENV,
@@ -96,22 +96,13 @@ fn add_worker_ready_assignment(
     idempotency_key: &str,
     timeout_secs: u64,
 ) -> Result<String, ApiError> {
-    for reserved in [
-        smolvm_protocol::forkpoint::WORKER_READY_TOKEN_ENV,
-        WORKER_READY_TIMEOUT_ENV,
-    ] {
-        if assignment.iter().any(|(key, _)| key == reserved) {
-            return Err(ApiError::BadRequest(format!(
-                "{reserved} is reserved for smolvm worker readiness"
-            )));
-        }
-    }
     let token = worker_ready_token(pool, idempotency_key);
-    assignment.push((
-        smolvm_protocol::forkpoint::WORKER_READY_TOKEN_ENV.into(),
-        token.clone(),
-    ));
-    assignment.push((WORKER_READY_TIMEOUT_ENV.into(), timeout_secs.to_string()));
+    crate::agent::fork::add_worker_ready_assignment(
+        assignment,
+        &token,
+        Duration::from_secs(timeout_secs),
+    )
+    .map_err(|error| ApiError::BadRequest(error.to_string()))?;
     Ok(token)
 }
 

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -4051,11 +4051,11 @@ pub struct ForkCmd {
     #[arg(long)]
     pub share_weights: bool,
 
-    /// Per-branch parameter (repeatable, KEY=VALUE). Delivered to the child as
-    /// `/etc/smolvm/branch-env` (dotenv format) for the already-running workload
-    /// to read, and merged into the child's env for later `machine exec`
-    /// sessions. This is how sweep/rollout children learn which variant they
-    /// are — no shared-mount claim files needed.
+    /// Per-branch parameter (repeatable, KEY=VALUE). Reaches the child through
+    /// `smolvm-branch-ready`: the program it runs (`-- prog`) gets it in its
+    /// environment, a shell gets it from `eval "$(smolvm-branch-ready)"`, and
+    /// later `machine exec` sessions see it too. This is how sweep/rollout
+    /// children learn which variant they are — no shared-mount claim files needed.
     #[arg(short = 'e', long = "env", value_name = "KEY=VALUE")]
     pub env: Vec<String>,
 

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -4041,6 +4041,22 @@ pub struct ForkCmd {
     )]
     pub ready_timeout: Duration,
 
+    /// Count a batch child as branched only once its workload has run
+    /// `smolvm-worker-ready`; a child that does not within the window is torn
+    /// down with the rest of the batch. Held slots take this at release.
+    #[arg(long, conflicts_with = "hold")]
+    pub wait_worker_ready: bool,
+
+    /// Window for `--wait-worker-ready`.
+    #[arg(
+        long,
+        default_value = "5m",
+        value_parser = parse_duration,
+        value_name = "DURATION",
+        requires = "wait_worker_ready",
+    )]
+    pub worker_ready_timeout: Duration,
+
     /// Make the child itself branchable (memfd RAM + control socket), so it can
     /// in turn be branched.
     #[arg(
@@ -4192,23 +4208,32 @@ impl ForkCmd {
             id: fork_batch_id(&self.golden, &prefix),
             size: count,
         });
-        let clones: Vec<_> = names
+        let worker_ready = self.wait_worker_ready.then_some(self.worker_ready_timeout);
+        let clones = names
             .into_iter()
             .enumerate()
             .map(|(index, name)| {
                 let index = index as u32;
-                let env = render_indexed_fork_env(&self.env, index, &name, true, batch.as_ref());
-                (name, env)
+                let mut env =
+                    render_indexed_fork_env(&self.env, index, &name, true, batch.as_ref());
+                if let Some(timeout) = worker_ready {
+                    let token = smolvm::agent::fork::random_worker_ready_token()?;
+                    smolvm::agent::fork::add_worker_ready_assignment(&mut env, &token, timeout)?;
+                }
+                Ok((name, env))
             })
-            .collect();
+            .collect::<smolvm::Result<Vec<_>>>()?;
         vm_common::fork_vm_batch(
             &self.golden,
             &clones,
-            self.share_weights,
-            &fork_secrets,
-            wait_ready,
-            self.parallel.get() as usize,
-            self.hold,
+            vm_common::ForkBatchOptions {
+                share_weights: self.share_weights,
+                fork_secrets: &fork_secrets,
+                wait_ready,
+                parallel: self.parallel.get() as usize,
+                hold: self.hold,
+                worker_ready,
+            },
         )
     }
 }
@@ -4224,12 +4249,33 @@ pub struct ForkReleaseCmd {
     /// parameters installed when the slot was provisioned.
     #[arg(short = 'e', long = "env", value_name = "KEY=VALUE")]
     pub env: Vec<String>,
+
+    /// Report the slot as released only once its workload has run
+    /// `smolvm-worker-ready`; a slot that does not within the window is torn
+    /// down, since a consumed slot cannot be returned to the pool anyway.
+    #[arg(long)]
+    pub wait_worker_ready: bool,
+
+    /// Window for `--wait-worker-ready`.
+    #[arg(
+        long,
+        default_value = "5m",
+        value_parser = parse_duration,
+        value_name = "DURATION",
+        requires = "wait_worker_ready",
+    )]
+    pub worker_ready_timeout: Duration,
 }
 
 impl ForkReleaseCmd {
     pub fn run(self) -> smolvm::Result<()> {
-        let env = smolvm::util::parse_env_list(&self.env);
-        vm_common::release_held_fork(&self.name, &env)
+        let mut env = smolvm::util::parse_env_list(&self.env);
+        let worker_ready = self.wait_worker_ready.then_some(self.worker_ready_timeout);
+        if let Some(timeout) = worker_ready {
+            let token = smolvm::agent::fork::random_worker_ready_token()?;
+            smolvm::agent::fork::add_worker_ready_assignment(&mut env, &token, timeout)?;
+        }
+        vm_common::release_held_fork(&self.name, &env, worker_ready)
     }
 }
 

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -2518,6 +2518,14 @@ mod tests {
     }
 
     #[test]
+    fn only_a_named_single_child_skips_the_batch_path() {
+        assert!(is_plain_branch(1, false, false));
+        assert!(!is_plain_branch(1, true, false));
+        assert!(!is_plain_branch(1, false, true));
+        assert!(!is_plain_branch(2, true, false));
+    }
+
+    #[test]
     fn indexed_fork_env_renders_each_clone() {
         let specs = vec![
             "TRIAL={index}".to_string(),
@@ -4001,7 +4009,9 @@ pub struct ForkCmd {
     #[arg(long, default_value = "1", value_name = "COUNT")]
     pub count: std::num::NonZeroU32,
 
-    /// Name batch children PREFIX-0 through PREFIX-(COUNT-1).
+    /// Name batch children PREFIX-0 through PREFIX-(COUNT-1). With a prefix (or
+    /// --hold) even a count of one is a batch: it waits for the boundary and
+    /// releases the child with its identity, unlike a plain --name branch.
     #[arg(long, value_name = "PREFIX")]
     pub name_prefix: Option<String>,
 
@@ -4107,7 +4117,7 @@ impl ForkCmd {
             ));
         }
 
-        if count == 1 {
+        if is_plain_branch(count, self.name_prefix.is_some(), self.hold) {
             let clone = match (self.clone, self.name_prefix) {
                 (Some(clone), None) => clone,
                 (None, Some(prefix)) => format!("{prefix}-0"),
@@ -4140,18 +4150,31 @@ impl ForkCmd {
             );
         }
 
-        if self.clone.is_some() {
+        if self.clone.is_some() && count > 1 {
             return Err(smolvm::Error::config(
                 "branch",
                 "--name cannot be used with --count greater than 1; use --name-prefix",
             ));
         }
-        let prefix = self.name_prefix.ok_or_else(|| {
-            smolvm::Error::config(
+        if self.clone.is_some() && self.name_prefix.is_some() {
+            return Err(smolvm::Error::config(
                 "branch",
-                "--name-prefix is required with --count greater than 1",
-            )
-        })?;
+                "use either --name or --name-prefix, not both",
+            ));
+        }
+        let (prefix, names): (String, Vec<String>) = match (self.clone, self.name_prefix) {
+            (Some(name), None) => (name.clone(), vec![name]),
+            (None, Some(prefix)) => {
+                let names = (0..count).map(|i| format!("{prefix}-{i}")).collect();
+                (prefix, names)
+            }
+            _ => {
+                return Err(smolvm::Error::config(
+                    "branch",
+                    "--name-prefix is required with --count greater than 1",
+                ));
+            }
+        };
         if self.forkable {
             return Err(smolvm::Error::config(
                 "branch",
@@ -4169,9 +4192,11 @@ impl ForkCmd {
             id: fork_batch_id(&self.golden, &prefix),
             size: count,
         });
-        let clones: Vec<_> = (0..count)
-            .map(|index| {
-                let name = format!("{prefix}-{index}");
+        let clones: Vec<_> = names
+            .into_iter()
+            .enumerate()
+            .map(|(index, name)| {
+                let index = index as u32;
                 let env = render_indexed_fork_env(&self.env, index, &name, true, batch.as_ref());
                 (name, env)
             })
@@ -4206,6 +4231,14 @@ impl ForkReleaseCmd {
         let env = smolvm::util::parse_env_list(&self.env);
         vm_common::release_held_fork(&self.name, &env)
     }
+}
+
+/// One child by `--name` is a plain branch: the source is snapshotted wherever
+/// it is and the child keeps the parked helper. Anything with `--name-prefix`
+/// or `--hold` is a batch of that size, even one, so a pool of one slot gets
+/// the same boundary, identity and release as a pool of eight.
+fn is_plain_branch(count: u32, has_prefix: bool, hold: bool) -> bool {
+    count == 1 && !has_prefix && !hold
 }
 
 fn render_indexed_fork_env(

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -2469,21 +2469,35 @@ mod tests {
         assert_eq!(batch.parallel.get(), 3);
         assert!(!batch.wait_ready);
         assert_eq!(batch.ready_timeout, Duration::from_secs(120));
+        let plain = is_plain_branch(batch.count.get(), batch.name_prefix.is_some(), batch.hold);
+        assert_eq!(
+            forkpoint_timeout(plain, batch.wait_ready, batch.ready_timeout),
+            Some(Duration::from_secs(120))
+        );
+        // A plain branch waits only when asked; every batch shape waits, so a
+        // one-child batch is released at the boundary like any other.
+        assert_eq!(
+            forkpoint_timeout(true, false, Duration::from_secs(120)),
+            None
+        );
+        assert_eq!(
+            forkpoint_timeout(true, true, Duration::from_secs(120)),
+            Some(Duration::from_secs(120))
+        );
         assert_eq!(
             forkpoint_timeout(
-                batch.count.get(),
-                batch.wait_ready,
-                batch.hold,
-                batch.ready_timeout,
+                is_plain_branch(1, true, false),
+                false,
+                Duration::from_secs(120)
             ),
             Some(Duration::from_secs(120))
         );
         assert_eq!(
-            forkpoint_timeout(1, false, false, Duration::from_secs(120)),
-            None
-        );
-        assert_eq!(
-            forkpoint_timeout(1, false, true, Duration::from_secs(120)),
+            forkpoint_timeout(
+                is_plain_branch(1, false, true),
+                false,
+                Duration::from_secs(120)
+            ),
             Some(Duration::from_secs(120))
         );
 
@@ -4119,7 +4133,11 @@ impl ForkCmd {
         // they merge into the clone's secret_refs and resolve fresh per exec.
         let fork_secrets = parse_cli_secret_refs(&self.secret_env, &self.secret_file)?;
         let count = self.count.get();
-        let wait_ready = forkpoint_timeout(count, self.wait_ready, self.hold, self.ready_timeout);
+        let wait_ready = forkpoint_timeout(
+            is_plain_branch(count, self.name_prefix.is_some(), self.hold),
+            self.wait_ready,
+            self.ready_timeout,
+        );
         if count > 1024 {
             return Err(smolvm::Error::config(
                 "branch",
@@ -4352,13 +4370,14 @@ fn fork_batch_id(golden: &str, prefix: &str) -> String {
     hex::encode(digest.finalize())[..32].to_string()
 }
 
+/// A batch always waits for the source's branchpoint and releases each child
+/// there; a plain branch waits only when asked.
 fn forkpoint_timeout(
-    count: u32,
+    plain: bool,
     explicitly_requested: bool,
-    hold: bool,
     timeout: Duration,
 ) -> Option<Duration> {
-    (count > 1 || explicitly_requested || hold).then_some(timeout)
+    (!plain || explicitly_requested).then_some(timeout)
 }
 
 // ============================================================================

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -906,7 +906,7 @@ pub fn fork_vm(golden: &str, clone: &str, options: ForkVmOptions<'_>) -> smolvm:
     }
     if options.wait_ready.is_some() && !options.hold {
         if let Err(error) = smolvm::agent::fork::fail_closed_on_rejuvenation(
-            smolvm::agent::fork::release_forkpoint(clone),
+            smolvm::agent::fork::release_forkpoint(clone, options.fork_env),
             || teardown_fork_clone(&db, clone),
         ) {
             return retain_failed_fork(golden, &snapshot_dir, error);
@@ -1073,7 +1073,12 @@ pub fn fork_vm_batch(
 
     if first_error.is_none() && wait_ready.is_some() && !hold {
         if let Err(error) = run_bounded_clone_jobs(&all_names, width, |name| {
-            smolvm::agent::fork::release_forkpoint(name)
+            let env = clones
+                .iter()
+                .find(|(clone, _)| clone == name)
+                .map(|(_, env)| env.as_slice())
+                .unwrap_or(&[]);
+            smolvm::agent::fork::release_forkpoint(name, env)
         }) {
             first_error = Some(error);
         }
@@ -1088,13 +1093,23 @@ pub fn fork_vm_batch(
 
     if hold {
         eprintln!(
-            "Provisioned {} held branch slots from '{golden}' with one snapshot.",
-            all_names.len()
+            "Provisioned {} held branch {} from '{golden}' with one snapshot.",
+            all_names.len(),
+            if all_names.len() == 1 {
+                "slot"
+            } else {
+                "slots"
+            }
         );
     } else {
         eprintln!(
-            "Branched {} children from '{golden}' with one snapshot.",
-            all_names.len()
+            "Branched {} {} from '{golden}' with one snapshot.",
+            all_names.len(),
+            if all_names.len() == 1 {
+                "child"
+            } else {
+                "children"
+            }
         );
     }
     Ok(())

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -931,15 +931,31 @@ pub fn fork_vm(golden: &str, clone: &str, options: ForkVmOptions<'_>) -> smolvm:
 /// Fork several indexed clones from one snapshot and boot them with bounded
 /// concurrency. All clone workloads remain at the forkpoint until every clone
 /// has booted, received a fresh identity, and received its per-clone env.
+/// How a batch of children is created from one snapshot.
+pub struct ForkBatchOptions<'a> {
+    pub share_weights: bool,
+    pub fork_secrets: &'a BTreeMap<String, SecretRef>,
+    pub wait_ready: Option<std::time::Duration>,
+    pub parallel: usize,
+    pub hold: bool,
+    /// Wait this long for each released child to run `smolvm-worker-ready`,
+    /// tearing the batch down if one never does.
+    pub worker_ready: Option<std::time::Duration>,
+}
+
 pub fn fork_vm_batch(
     golden: &str,
     clones: &[(String, Vec<(String, String)>)],
-    share_weights: bool,
-    fork_secrets: &BTreeMap<String, SecretRef>,
-    wait_ready: Option<std::time::Duration>,
-    parallel: usize,
-    hold: bool,
+    options: ForkBatchOptions<'_>,
 ) -> smolvm::Result<()> {
+    let ForkBatchOptions {
+        share_weights,
+        fork_secrets,
+        wait_ready,
+        parallel,
+        hold,
+        worker_ready,
+    } = options;
     let db = SmolvmDb::open()?;
     let _source_lock = smolvm::agent::fork::lock_fork_source(golden)?;
 
@@ -1084,6 +1100,29 @@ pub fn fork_vm_batch(
         }
     }
 
+    // Fail closed: a batch is only as ready as its slowest child, so one that
+    // never publishes readiness takes the whole batch down rather than leaving
+    // the caller with a set of children it cannot tell apart.
+    if first_error.is_none() && !hold {
+        if let Some(timeout) = worker_ready {
+            if let Err(error) = run_bounded_clone_jobs(&all_names, width, |name| {
+                let token = clones
+                    .iter()
+                    .find(|(clone, _)| clone == name)
+                    .and_then(|(_, env)| smolvm::agent::fork::worker_ready_token_of(env))
+                    .ok_or_else(|| {
+                        smolvm::Error::agent(
+                            "worker readiness",
+                            format!("child '{name}' carries no readiness token"),
+                        )
+                    })?;
+                smolvm::agent::fork::wait_for_worker_ready(name, token, timeout)
+            }) {
+                first_error = Some(error);
+            }
+        }
+    }
+
     if let Some(error) = first_error {
         for name in &all_names {
             teardown_fork_clone(&db, name);
@@ -1118,7 +1157,11 @@ pub fn fork_vm_batch(
 /// Assign and release one held clone. This is intentionally one-way: after the
 /// workload begins, the clone is dirty and must be replaced from its golden
 /// before it can serve another independent job.
-pub fn release_held_fork(clone: &str, assignment: &[(String, String)]) -> smolvm::Result<()> {
+pub fn release_held_fork(
+    clone: &str,
+    assignment: &[(String, String)],
+    worker_ready: Option<std::time::Duration>,
+) -> smolvm::Result<()> {
     let db = SmolvmDb::open()?;
     let record = db
         .get_vm(clone)?
@@ -1163,6 +1206,23 @@ pub fn release_held_fork(clone: &str, assignment: &[(String, String)]) -> smolvm
         },
     )?;
     debug_assert_eq!(activated, merged);
+    if let Some(timeout) = worker_ready {
+        let token = smolvm::agent::fork::worker_ready_token_of(assignment).ok_or_else(|| {
+            smolvm::Error::agent(
+                "worker readiness",
+                format!("slot '{clone}' carries no readiness token"),
+            )
+        })?;
+        // Fail closed: the slot is consumed either way, so a worker that never
+        // reports ready is torn down instead of left running unverified.
+        if let Err(error) = smolvm::agent::fork::wait_for_worker_ready(clone, token, timeout) {
+            teardown_fork_clone(&db, clone);
+            return Err(smolvm::Error::agent(
+                "release held fork",
+                format!("slot '{clone}' was torn down because {error}"),
+            ));
+        }
+    }
     eprintln!(
         "Released held branch slot '{clone}'. Replace it from '{}' after the workload completes.",
         record.golden.as_deref().unwrap_or("its source")
@@ -1368,7 +1428,7 @@ where
     {
         return Err(smolvm::Error::agent(
             "batch fork",
-            format!("clone '{clone}' release failed: {error}"),
+            format!("clone '{clone}': {error}"),
         ));
     }
     Ok(())
@@ -3212,7 +3272,7 @@ mod init_runner_tests {
         .expect_err("the batch must fail closed");
 
         assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 1);
-        assert!(error.to_string().contains("clone 'bad' release failed"));
+        assert!(error.to_string().contains("clone 'bad': "));
     }
 
     #[test]

--- a/src/embedded/control.rs
+++ b/src/embedded/control.rs
@@ -361,7 +361,9 @@ fn boot_prepared_fork(
             // clone-local barrier only after identity reset succeeds, matching
             // the CLI and serve fork paths. Publishing a release marker is
             // harmless for an arbitrary checkpoint with no waiting helper.
-            if let Err(error) = crate::agent::fork::release_forkpoint(clone) {
+            if let Err(error) =
+                crate::agent::fork::release_forkpoint(clone, &prep.clone_record.fork_env)
+            {
                 let _ = handle.stop();
                 return Err(error);
             }

--- a/src/portable_checkpoint.rs
+++ b/src/portable_checkpoint.rs
@@ -1714,7 +1714,7 @@ pub fn discard_transport_pack(vm_data_dir: &Path) -> Result<()> {
 /// workload instead of silently creating a second container.
 pub fn finalize_live_restore(name: &str, record: &VmRecord) -> Result<()> {
     crate::agent::fork::rejuvenate_clone(name, record)?;
-    crate::agent::fork::release_forkpoint(name)
+    crate::agent::fork::release_forkpoint(name, &record.fork_env)
 }
 
 /// Return the pending one-shot checkpoint directory for a machine, if any.


### PR DESCRIPTION
The one command that declares a branchpoint now also delivers the child's identity: `smolvm-branch-ready -- prog` execs prog with it in the environment, a bare call prints it for a shell to eval, and an exec'd helper stays as the container's init instead of ending it; the host drives the wait, arm, park, release, activate and worker-ready steps through typed agent requests that are now the only branch protocol, both sides wake on directory events instead of polling, the release marker carries the child's identity, a one-child batch is released like any other, and `--wait-worker-ready` tears down a child that never reports ready.