### PR TITLE
Resolve a Smolfile image the same way as the --image flag so a local archive is not sent to the registry

### DIFF
--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -2406,19 +2406,35 @@ impl AgentManager {
                 smolvm_protocol::guest_env::READY_MARKER,
                 self.ready_marker_name(),
             )
-            .stdin(std::process::Stdio::null())
-            // SMOLVM_BOOT_DEBUG=1 surfaces the boot subprocess's stdout/stderr so
-            // embedded-host launch failures can be diagnosed (normally silenced).
-            .stdout(if std::env::var_os("SMOLVM_BOOT_DEBUG").is_some() {
-                std::process::Stdio::inherit()
+            .stdin(std::process::Stdio::null());
+        // SMOLVM_BOOT_DEBUG=1 surfaces the boot subprocess's stdout/stderr so
+        // embedded-host launch failures can be diagnosed (normally silenced).
+        //
+        // On Windows the child is spawned DETACHED_PROCESS (below), which drops
+        // its console handles, so an inherited stdio pair reaches nothing and the
+        // flag looks like it does nothing at all. Write to `boot-debug.log` beside
+        // the VM's boot config there instead; every other platform still inherits.
+        {
+            let boot_debug = std::env::var_os("SMOLVM_BOOT_DEBUG").is_some();
+            let debug_log = if cfg!(windows) && boot_debug {
+                config_path.parent().map(|dir| dir.join("boot-debug.log"))
             } else {
-                std::process::Stdio::null()
-            })
-            .stderr(if std::env::var_os("SMOLVM_BOOT_DEBUG").is_some() {
-                std::process::Stdio::inherit()
-            } else {
-                std::process::Stdio::null()
-            });
+                None
+            };
+            let sink = |path: &Option<std::path::PathBuf>| -> std::process::Stdio {
+                match path {
+                    Some(path) => std::fs::OpenOptions::new()
+                        .create(true)
+                        .append(true)
+                        .open(path)
+                        .map(std::process::Stdio::from)
+                        .unwrap_or_else(|_| std::process::Stdio::null()),
+                    None if boot_debug => std::process::Stdio::inherit(),
+                    None => std::process::Stdio::null(),
+                }
+            };
+            cmd.stdout(sink(&debug_log)).stderr(sink(&debug_log));
+        }
         // Own process group (pgid = child pid) so the VM is immune to SIGHUP from
         // the parent's terminal closing, without making it a session leader.
         // POSIX-only; Windows process groups have different semantics and the

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -3356,24 +3356,9 @@ impl CreateCmd {
             .name
             .unwrap_or_else(smolvm::util::generate_machine_name);
 
-        // Resolve a local image source (archive/dir) on the host now: stage it
-        // into the content-addressed cache and persist the resulting `local:…`
-        // reference, so `start` re-derives the mount dir without a registry
-        // pull. Registry refs pass through unchanged.
-        let image = match self.image.as_deref() {
-            Some(img) => {
-                use smolvm::data::image_source::{classify, resolve, ResolvedImage};
-                Some(match resolve(classify(img))? {
-                    ResolvedImage::Registry(reference) => reference,
-                    ResolvedImage::Local { reference, .. } => reference,
-                })
-            }
-            None => None,
-        };
-
         let params = crate::cli::smolfile::build_create_params(
             name,
-            image,
+            self.image,
             None,         // entrypoint: from Smolfile only
             self.command, // persistent-workload command (detached container on start)
             self.cpus,
@@ -3395,6 +3380,22 @@ impl CreateCmd {
             smolvm::util::parse_labels(&self.labels)?,
         )?;
         let mut params = params;
+
+        // Resolve the image source on the host now, AFTER the CLI flag and the
+        // Smolfile have been merged, so both take the same path: a registry
+        // reference passes through; a local `docker save` archive or unpacked
+        // rootfs directory is staged into the content-addressed cache and the
+        // resulting `local:…` reference persisted, so `start` re-derives the
+        // mount without a registry pull. Resolving only the flag here left a
+        // Smolfile `image = "./x.tar"` stored verbatim, and `start` then asked
+        // the registry for it.
+        if let Some(img) = params.image.as_deref() {
+            use smolvm::data::image_source::{classify, resolve, ResolvedImage};
+            params.image = Some(match resolve(classify(img))? {
+                ResolvedImage::Registry(reference) => reference,
+                ResolvedImage::Local { reference, .. } => reference,
+            });
+        }
         params.allow_system_mounts = self.allow_system_mounts;
         if self.auto_graph {
             smolvm::util::enable_cuda_auto_graph_env_specs(&mut params.env);

--- a/src/cli/smolfile.rs
+++ b/src/cli/smolfile.rs
@@ -1010,3 +1010,80 @@ mod resource_cap_precedence_tests {
         assert_eq!(dev_or_top(vec![3], vec![1, 2]), vec![3]);
     }
 }
+
+#[cfg(test)]
+mod smolfile_local_image_tests {
+    use super::*;
+    use smolvm::data::image_source::{classify, ImageSource};
+
+    /// A Smolfile `image = "./x.tar"` reached `create` verbatim and was stored
+    /// as a registry reference, so `start` asked the registry for
+    /// `./x.tar:latest`. The merged image a Smolfile produces must classify
+    /// as the local archive it is, exactly as the same value on `--image` does.
+    #[test]
+    fn a_smolfile_archive_image_is_a_local_source_like_the_flag() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let archive = dir.path().join("debian-trixie.tar");
+        std::fs::write(&archive, b"not really a tar").expect("write");
+        let path = dir.path().join("Smolfile");
+        std::fs::write(&path, format!("image = \"{}\"\n", archive.display())).expect("write");
+
+        let params = build_create_params(
+            "m".to_string(),
+            None,
+            None,
+            vec![],
+            None,
+            None,
+            vec![],
+            vec![],
+            false,
+            None,
+            None,
+            None,
+            vec![],
+            vec![],
+            None,
+            None,
+            Some(path),
+            None,
+            None,
+            vec![],
+            Default::default(),
+        )
+        .expect("params");
+
+        let image = params.image.expect("smolfile image is carried");
+        assert!(
+            matches!(classify(&image), ImageSource::Archive(_)),
+            "smolfile image {image} must classify as a local archive"
+        );
+
+        // And the flag, given the same value, agrees — one rule, two routes.
+        let flagged = build_create_params(
+            "m".to_string(),
+            Some(archive.display().to_string()),
+            None,
+            vec![],
+            None,
+            None,
+            vec![],
+            vec![],
+            false,
+            None,
+            None,
+            None,
+            vec![],
+            vec![],
+            None,
+            None,
+            None,
+            None,
+            None,
+            vec![],
+            Default::default(),
+        )
+        .expect("params");
+        assert_eq!(flagged.image, Some(image));
+    }
+}

--- a/src/data/image_source.rs
+++ b/src/data/image_source.rs
@@ -36,7 +36,12 @@ pub enum ImageSource {
     /// A value that is recognisably meant as a local source but in a form
     /// smolvm does not read. Carries the exact syntax to use instead, so the
     /// error names the fix rather than a registry-parser failure.
-    Unsupported { given: String, hint: String },
+    Unsupported {
+        /// The value exactly as the user wrote it.
+        given: String,
+        /// The syntax to use instead.
+        hint: String,
+    },
 }
 
 /// Where an [`ImageSource::Archive`]'s bytes come from.

--- a/src/data/image_source.rs
+++ b/src/data/image_source.rs
@@ -33,6 +33,10 @@ pub enum ImageSource {
     /// An already-unpacked root filesystem directory (apptainer-style). Used
     /// as-is — no extraction.
     Directory(PathBuf),
+    /// A value that is recognisably meant as a local source but in a form
+    /// smolvm does not read. Carries the exact syntax to use instead, so the
+    /// error names the fix rather than a registry-parser failure.
+    Unsupported { given: String, hint: String },
 }
 
 /// Where an [`ImageSource::Archive`]'s bytes come from.
@@ -57,6 +61,18 @@ pub fn classify(image: &str) -> ImageSource {
     if image == "-" {
         return ImageSource::Archive(ArchiveInput::Stdin);
     }
+    // `file://` is not a scheme smolvm reads; left alone it either fell through
+    // to the registry parser or was handed to the filesystem with the prefix
+    // still attached. Name it so the caller can reject it with the real syntax.
+    if let Some(rest) = image.strip_prefix("file://") {
+        return ImageSource::Unsupported {
+            given: image.to_string(),
+            hint: format!(
+                "`file://` is not a supported prefix; give the path directly: `{}`",
+                rest
+            ),
+        };
+    }
     if looks_local(image) {
         let path = Path::new(image);
         // Only an existing directory is treated as a ready-made rootfs; a
@@ -76,9 +92,21 @@ fn looks_local(image: &str) -> bool {
     image.starts_with('/')
         || image.starts_with("./")
         || image.starts_with("../")
+        || has_windows_drive_prefix(image)
         || ARCHIVE_SUFFIXES
             .iter()
             .any(|suffix| image.ends_with(suffix))
+}
+
+/// `C:\…` or `C:/…` — a Windows absolute path. A registry reference can carry
+/// a `:` (`repo:tag`, `host:port/repo`) but never a single letter followed by
+/// `:` and a path separator, so this cannot mistake a reference for a path.
+fn has_windows_drive_prefix(image: &str) -> bool {
+    let bytes = image.as_bytes();
+    bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && (bytes[2] == b'/' || bytes[2] == b'\\')
 }
 
 /// Whether a local path is a Dockerfile rather than an image archive — so we can
@@ -171,6 +199,10 @@ pub fn resolve(source: ImageSource) -> Result<ResolvedImage> {
         ImageSource::Registry(reference) => Ok(ResolvedImage::Registry(reference)),
         ImageSource::Directory(path) => resolve_directory(&path),
         ImageSource::Archive(input) => resolve_archive(input),
+        ImageSource::Unsupported { given, hint } => Err(Error::config(
+            "image source",
+            format!("unsupported image reference '{given}': {hint}"),
+        )),
     }
 }
 
@@ -566,6 +598,68 @@ mod tests {
                 assert_eq!(packed_layers_dir, dir.path().canonicalize().unwrap());
             }
             other => panic!("expected Local, got {other:?}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod classify_tests {
+    use super::*;
+
+    /// `file://` is not a scheme smolvm reads. It used to fall through to the
+    /// registry parser, which appended `:latest` to a `.tar` path and failed
+    /// with an unparseable-reference error that named neither the cause nor
+    /// the fix.
+    #[test]
+    fn a_file_scheme_is_rejected_with_the_real_syntax() {
+        match classify("file://D:/images/debian.tar") {
+            ImageSource::Unsupported { given, hint } => {
+                assert_eq!(given, "file://D:/images/debian.tar");
+                assert!(
+                    hint.contains("D:/images/debian.tar"),
+                    "hint names the bare path: {hint}"
+                );
+            }
+            other => panic!("expected Unsupported, got {other:?}"),
+        }
+
+        let err = resolve(classify("file:///srv/x.tar")).expect_err("must not resolve");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("file://") && msg.contains("/srv/x.tar"),
+            "{msg}"
+        );
+    }
+
+    /// A Windows absolute path is a local source whether or not it carries an
+    /// archive suffix; a registry reference never has a one-letter drive
+    /// prefix, so `repo:tag` and `host:5000/repo` are untouched.
+    #[test]
+    fn windows_drive_paths_are_local_and_references_are_not() {
+        for local in [
+            "D:/images/rootfs",
+            "C:\\Users\\me\\rootfs",
+            "D:/images/debian.tar",
+        ] {
+            assert!(
+                !matches!(classify(local), ImageSource::Registry(_)),
+                "{local} must be local"
+            );
+        }
+
+        // `ab:/x` has a two-letter "drive", `a:x` has no separator: neither is
+        // a Windows path, and both fall through as references as before.
+        for reference in [
+            "alpine",
+            "python:3.12",
+            "localhost:5000/repo:tag",
+            "ab:/x",
+            "a:x",
+        ] {
+            assert!(
+                matches!(classify(reference), ImageSource::Registry(_)),
+                "{reference} must be a registry reference"
+            );
         }
     }
 }


### PR DESCRIPTION
machine create resolved local image sources only for the --image flag, so an archive named in a Smolfile was stored verbatim and start handed it to the registry puller, which appended :latest and failed to parse the path, and SMOLVM_BOOT_DEBUG was separately useless on Windows because the boot subprocess is spawned detached and its inherited stdio reaches nothing. The image is now resolved once after the flag and Smolfile are merged, a file:// prefix is rejected with the working syntax, Windows drive-letter paths are recognised as local, and the boot subprocess's debug output goes to a file beside its config on Windows.