### PR TITLE
Say checkpoint, not snapshot, in the branch command's messages and help

### DIFF
--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -347,9 +347,9 @@ pub fn wait_for_forkpoint(golden: &str, timeout: Duration) -> Result<()> {
     }
 }
 
-/// Put a negotiated workload helper into its restore-safe userspace loop just
-/// before capture. A branchable machine without a helper remains a valid
-/// immediate snapshot source, and an older guest keeps its legacy loop.
+/// Put the workload's helper into its restore-safe wait just before capture.
+/// A branchable machine without a helper remains a valid immediate checkpoint
+/// source, reported as `Ok(false)`.
 fn arm_forkpoint_for_capture(golden: &str) -> Result<bool> {
     use smolvm_protocol::forkpoint::typed_error;
     let mut client = branch_client(golden, "arm branchpoint")?;

--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -337,10 +337,10 @@ pub fn wait_for_forkpoint(golden: &str, timeout: Duration) -> Result<()> {
             "wait for forkpoint",
             format!(
                 "source '{golden}' did not reach a branchpoint within {}s: {f}\n\
-                 A batch branch snapshots the source at a point its workload declares by running \
+                 A batch branch checkpoints the source at a point its workload declares by running \
                  `smolvm-branch-ready` after setup (see README, \"Branch a running machine\"). \
                  If the workload never calls it, either add the call, raise --ready-timeout, or \
-                 take single `--name` branches, which snapshot the source wherever it is.",
+                 take single `--name` branches, which checkpoint the source wherever it is.",
                 timeout.as_secs_f64()
             ),
         )),

--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -3997,7 +3997,7 @@ impl StartCmd {
 ///
 /// Captures the source through its control socket, copy-on-write
 /// branches its disks, and boots the new machine from the source's in-memory
-/// snapshot instead of cold-booting. Linux/x86_64 resumes the source after the
+/// checkpoint instead of cold-booting. Linux/x86_64 resumes the source after the
 /// boundary; other hosts retain it as the frozen copy-on-write base.
 ///
 /// The source must have been started with `--branchable`.
@@ -4011,7 +4011,7 @@ pub struct ForkCmd {
     #[arg(short = 'n', long = "name", value_name = "NAME")]
     pub clone: Option<String>,
 
-    /// Number of children to create from one snapshot. Batch branches wait for the
+    /// Number of children to create from one checkpoint. Batch branches wait for the
     /// standard `smolvm-branch-ready` boundary automatically. Direct batches
     /// receive one shared `SMOLVM_BRANCH_BATCH_ID` and `SMOLVM_BRANCH_BATCH_SIZE`;
     /// held slots remain independent until assigned by their controller.
@@ -4292,7 +4292,7 @@ impl ForkReleaseCmd {
     }
 }
 
-/// One child by `--name` is a plain branch: the source is snapshotted wherever
+/// One child by `--name` is a plain branch: the source is checkpointed wherever
 /// it is and the child keeps the parked helper. Anything with `--name-prefix`
 /// or `--hold` is a batch of that size, even one, so a pool of one slot gets
 /// the same boundary, identity and release as a pool of eight.

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -783,7 +783,7 @@ pub(crate) fn print_create_success(params: &CreateVmParams) {
 pub struct ForkLaunch {
     /// Start as a fork base: memfd-back guest RAM and expose `control_socket`.
     pub forkable: bool,
-    /// Boot as a fork clone, restoring from the golden's snapshot at this dir.
+    /// Boot as a fork clone, restoring from the golden's checkpoint at this dir.
     pub snapshot_dir: Option<std::path::PathBuf>,
     /// Clone boot only: share the golden's loaded CUDA weights instead of
     /// copying them (`machine fork --share-weights`).
@@ -820,7 +820,7 @@ pub fn forkable_launch() -> ForkLaunch {
 /// Freezes the golden (it stays paused as the shared copy-on-write base — its
 /// guest RAM is mapped `MAP_PRIVATE` by clones, so it must not run again while
 /// clones exist), copy-on-write clones its disks, and boots the clone from the
-/// golden's in-memory snapshot.
+/// golden's in-memory checkpoint.
 pub struct ForkVmOptions<'a> {
     pub clone_forkable: bool,
     pub pinned_ports: &'a [(u16, u16)],
@@ -928,10 +928,10 @@ pub fn fork_vm(golden: &str, clone: &str, options: ForkVmOptions<'_>) -> smolvm:
     Ok(())
 }
 
-/// Fork several indexed clones from one snapshot and boot them with bounded
+/// Fork several indexed clones from one checkpoint and boot them with bounded
 /// concurrency. All clone workloads remain at the forkpoint until every clone
 /// has booted, received a fresh identity, and received its per-clone env.
-/// How a batch of children is created from one snapshot.
+/// How a batch of children is created from one checkpoint.
 pub struct ForkBatchOptions<'a> {
     pub share_weights: bool,
     pub fork_secrets: &'a BTreeMap<String, SecretRef>,
@@ -1132,7 +1132,7 @@ pub fn fork_vm_batch(
 
     if hold {
         eprintln!(
-            "Provisioned {} held branch {} from '{golden}' with one snapshot.",
+            "Provisioned {} held branch {} from '{golden}' with one checkpoint.",
             all_names.len(),
             if all_names.len() == 1 {
                 "slot"
@@ -1142,7 +1142,7 @@ pub fn fork_vm_batch(
         );
     } else {
         eprintln!(
-            "Branched {} {} from '{golden}' with one snapshot.",
+            "Branched {} {} from '{golden}' with one checkpoint.",
             all_names.len(),
             if all_names.len() == 1 {
                 "child"
@@ -1240,7 +1240,7 @@ fn boot_prepared_fork(
 ) -> smolvm::Result<()> {
     let preload_modules = prep.clone_record.cuda_preload_modules;
     let clone_forkable = prep.clone_record.forkable;
-    eprintln!("Booting child '{clone}' from snapshot...");
+    eprintln!("Booting child '{clone}' from the checkpoint...");
     let mut start = || {
         start_vm_named_with_db(
             db,
@@ -1821,7 +1821,7 @@ fn start_vm_named_with_db(
             }
         } else {
             tracing::info!(
-                "clone booted from snapshot: workload container inherited from fork, skipping relaunch"
+                "clone booted from checkpoint: workload container inherited from fork, skipping relaunch"
             );
         }
         println!("Machine '{}' running (PID: {})", name, pid.unwrap_or(0));


### PR DESCRIPTION
The branch command printed "Checkpointing 'source'…" and then "Branched 3 children … with one snapshot"; its messages, help text and docs now use checkpoint for the state a branch is taken from, matching the README in #1183.