### PR TITLE
Run init as root on every path, and keep the image's USER for a packed workload

### DIFF
--- a/src/cli/smolfile.rs
+++ b/src/cli/smolfile.rs
@@ -639,6 +639,7 @@ init = ["echo init"]
             mode: PackMode::Container,
             image: params.image.clone(),
             image_env: vec![],
+            image_user: None,
             layer_bytes: 0,
         };
         seed_manifest_from_vm(&mut manifest, &persisted, &assets);

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -394,6 +394,11 @@ fn apply_env_override(env: &mut Vec<(String, String)>, key: String, value: Strin
     env.push((key, value));
 }
 
+/// The account init commands run as: root, named explicitly. A run request
+/// with no user takes the image's `USER`, which is right for a workload but
+/// not for provisioning, so init cannot simply leave the field empty.
+const INIT_USER: &str = "0";
+
 /// Build the `RunConfig` an image-based init command runs under.
 ///
 /// Init is provisioning, so it runs as root, like a Dockerfile `RUN` line or
@@ -419,6 +424,7 @@ fn build_init_run_config(
     smolvm::agent::RunConfig::new(image, init_argv(cmd))
         .with_env(defaults.env.clone())
         .with_workdir(defaults.workdir.clone())
+        .with_user(Some(INIT_USER.to_string()))
         .with_mounts(mounts)
         .with_persistent_overlay(Some(overlay_id.to_string()))
 }
@@ -3552,7 +3558,9 @@ mod init_runner_tests {
         assert_eq!(config.workdir.as_deref(), Some("/work"));
         // Init provisions the machine, so it runs as root even when the image
         // (or the machine's `user`) names another account for the workload.
-        assert!(config.user.is_none());
+        // Root is requested explicitly: an absent user would take the image's
+        // USER on the agent side.
+        assert_eq!(config.user.as_deref(), Some("0"));
         // Command is sh-wrapped; assert the wrapped form arrives.
         assert_eq!(
             config.command,
@@ -3610,7 +3618,7 @@ mod init_runner_tests {
         assert!(config.mounts.is_empty());
         assert!(config.workdir.is_none());
         assert!(config.env.is_empty());
-        assert!(config.user.is_none());
+        assert_eq!(config.user.as_deref(), Some("0"));
         assert_eq!(config.persistent_overlay_id.as_deref(), Some("vm"));
     }
 
@@ -3647,7 +3655,7 @@ mod init_runner_tests {
 
         assert_eq!(config.workdir.as_deref(), Some("/image-workdir"));
         // The image's USER names the workload account; init still runs as root.
-        assert!(config.user.is_none());
+        assert_eq!(config.user.as_deref(), Some("0"));
         assert_eq!(
             config.env,
             vec![("FOO".to_string(), "from-image".to_string())]

--- a/src/pack_export.rs
+++ b/src/pack_export.rs
@@ -63,6 +63,11 @@ pub struct FromVmAssets {
     /// that path already copied the source manifest's env into the record, so the
     /// machine's own env is the complete set.
     pub image_env: Vec<String>,
+    /// The image's OCI `USER`, for the same reason as `image_env`: a running
+    /// machine takes it from the image config at exec time, and a pack has no
+    /// image config left, so the manifest has to carry who the workload runs
+    /// as when the machine itself named nobody.
+    pub image_user: Option<String>,
     /// Total bytes of the layer tars collected for this pack.
     ///
     /// Recorded as the manifest's `image_size` so the run-time storage
@@ -120,6 +125,7 @@ pub fn collect_from_vm_assets(
     // machine already carries the source manifest's env in its own record, and a
     // bare machine has no image at all.
     let mut image_env: Vec<String> = Vec::new();
+    let mut image_user: Option<String> = None;
 
     if is_artifact_sourced && !opts.rebase_from_image {
         export_flattened_from_artifact_sourced(
@@ -150,7 +156,7 @@ pub fn collect_from_vm_assets(
                 opts.include_workspace,
             )?;
         } else {
-            image_env =
+            (image_env, image_user) =
                 export_flattened_from_registry_image(collector, vm_name, &vm_dir, &image, opts)?;
         }
     } else {
@@ -198,6 +204,7 @@ pub fn collect_from_vm_assets(
         },
         image: vm.image.clone(),
         image_env,
+        image_user,
         layer_bytes: collector.staged_layer_bytes(),
     })
 }
@@ -224,7 +231,9 @@ pub fn seed_manifest_from_vm(manifest: &mut PackManifest, vm: &VmRecord, assets:
     manifest.cmd = vm.cmd.clone();
     manifest.env = merge_env(&assets.image_env, &vm.env);
     manifest.workdir = vm.workdir.clone();
-    manifest.user = vm.user.clone();
+    // The account the workload runs as, resolved the way a running machine
+    // resolves it: the machine's own user wins, else the image's USER.
+    manifest.user = vm.user.clone().or_else(|| assets.image_user.clone());
     manifest.secret_refs = vm.secret_refs.clone();
 }
 
@@ -380,7 +389,7 @@ fn export_flattened_from_registry_image(
     vm_dir: &Path,
     image: &str,
     opts: &FromVmExportOptions,
-) -> crate::Result<Vec<String>> {
+) -> crate::Result<(Vec<String>, Option<String>)> {
     let export_vm = ExportVm::start(vm_name, vm_dir, None, true)?;
     let mut client = export_vm.connect()?;
     export_vm.mount_source_storage(&mut client)?;
@@ -411,7 +420,7 @@ fn export_flattened_from_registry_image(
         &lowers,
         opts.include_workspace,
     )?;
-    Ok(image_info.env)
+    Ok((image_info.env, image_info.user))
 }
 
 /// Artifact-sourced machine: its extracted layer dirs live in the host-side
@@ -932,10 +941,41 @@ fn read_qcow2_virtual_size(path: &Path) -> crate::Result<u64> {
 
 #[cfg(test)]
 mod env_merge_tests {
-    use super::merge_env;
+    use super::{merge_env, seed_manifest_from_vm, FromVmAssets};
+    use crate::config::VmRecord;
+    use smolvm_pack::format::{PackManifest, PackMode};
 
     /// The image's `PATH` is what makes its binaries resolve, so a machine that
     /// set no env of its own must still carry the image's.
+    #[test]
+    fn packed_user_is_the_machine_user_or_else_the_image_user() {
+        let mut vm = VmRecord::new("m".to_string(), 1, 512, vec![], vec![], false);
+        let mut assets = FromVmAssets {
+            mode: PackMode::Container,
+            image: Some("nginx".to_string()),
+            image_env: vec![],
+            image_user: Some("nginx".to_string()),
+            layer_bytes: 0,
+        };
+        let mut manifest = PackManifest::new(
+            "vm://m".to_string(),
+            "none".to_string(),
+            "linux/arm64".to_string(),
+            "darwin/arm64".to_string(),
+        );
+        seed_manifest_from_vm(&mut manifest, &vm, &assets);
+        assert_eq!(manifest.user.as_deref(), Some("nginx"));
+
+        vm.user = Some("501:20".to_string());
+        seed_manifest_from_vm(&mut manifest, &vm, &assets);
+        assert_eq!(manifest.user.as_deref(), Some("501:20"));
+
+        vm.user = None;
+        assets.image_user = None;
+        seed_manifest_from_vm(&mut manifest, &vm, &assets);
+        assert!(manifest.user.is_none());
+    }
+
     #[test]
     fn image_env_survives_when_the_machine_adds_none() {
         let image = vec![

--- a/src/portable_checkpoint.rs
+++ b/src/portable_checkpoint.rs
@@ -427,6 +427,7 @@ pub fn capture_to_path(
         mode: PackMode::Vm,
         image: None,
         image_env: Vec::new(),
+        image_user: None,
         layer_bytes: 0,
     };
     let platform = format!("linux/{}", crate::platform::Arch::current().oci_arch());


### PR DESCRIPTION
Init commands still ran as an image's USER because a run request with no user takes that default on the agent side; init now asks for root explicitly, so `machine run`, the baked init layer, and an explicit `user = "root"` all provision as root while the workload keeps its account. The same test exposed that a pack made from an image machine dropped the image's USER, so the workload of a baked or packed machine ran as root; the manifest now records it the way it already records the image's env.