### PR TITLE
fix(network): prevent named-fabric receive busy loop

### DIFF
--- a/crates/smolvm-network/src/fabric.rs
+++ b/crates/smolvm-network/src/fabric.rs
@@ -232,6 +232,16 @@ pub fn start_fabric(
 }
 
 #[cfg(unix)]
+fn accept_blocking_peer(listener: &UnixListener) -> io::Result<UnixStream> {
+    let (stream, _) = listener.accept()?;
+    // The listener is nonblocking so the accept loop can poll for shutdown.
+    // Normalize accepted peers explicitly: on platforms where they inherit
+    // O_NONBLOCK, read_full would otherwise spin while retrying WouldBlock.
+    stream.set_nonblocking(false)?;
+    Ok(stream)
+}
+
+#[cfg(unix)]
 fn run_accept_loop(
     lease: FabricLease,
     queues: Arc<NetworkFrameQueues>,
@@ -242,8 +252,8 @@ fn run_accept_loop(
         if queues.is_shutting_down() {
             return; // dropping `lease` unlinks the registry socket
         }
-        match lease.listener.accept() {
-            Ok((stream, _)) => {
+        match accept_blocking_peer(&lease.listener) {
+            Ok(stream) => {
                 let reader_queues = queues.clone();
                 let _ = std::thread::Builder::new()
                     .name("smolvm-fabric-recv".into())
@@ -447,6 +457,7 @@ pub fn start_fabric(
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
+    use std::os::fd::AsRawFd;
 
     #[test]
     fn leases_are_distinct_and_release_on_drop() {
@@ -531,6 +542,20 @@ mod tests {
         }
         queues_a.begin_shutdown();
         queues_b.begin_shutdown();
+    }
+
+    #[test]
+    fn accepted_fabric_peer_is_blocking() {
+        let tmp = tempfile::tempdir().unwrap();
+        let listener = UnixListener::bind(tmp.path().join("fabric.sock")).unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let _client = UnixStream::connect(tmp.path().join("fabric.sock")).unwrap();
+
+        let peer = accept_blocking_peer(&listener).unwrap();
+        let flags = unsafe { libc::fcntl(peer.as_raw_fd(), libc::F_GETFL) };
+
+        assert!(flags >= 0, "F_GETFL failed: {}", io::Error::last_os_error());
+        assert_eq!(flags & libc::O_NONBLOCK, 0);
     }
 
     #[test]


### PR DESCRIPTION

## Summary

- restore blocking mode on Unix streams accepted by the nonblocking named network fabric listener;
- prevent `read_full` from continuously retrying `WouldBlock` on an idle peer;
- add a regression test for the accepted stream's blocking-mode invariant.

## Problem

The fabric listener is intentionally nonblocking so `run_accept_loop` can poll for shutdown. On macOS, an accepted peer may retain nonblocking behavior.

`run_peer_reader` expects a blocking stream with a short read timeout, but its `read_full` helper immediately retries `WouldBlock` and `TimedOut`. If an idle accepted stream is nonblocking, the retry path becomes a tight loop.

In a two-VM named-network topology this consumed approximately one host CPU core in each direction after the first request established the bidirectional fabric streams. Spindumps attributed 9.980-9.992 seconds of each ten-second sample to `smolvm-fabric-recv`, while the guest vCPU threads were effectively idle.

The behavior was connection-triggered: both VM processes remained idle after startup until the first cross-fabric request established the peer streams. Stopping one peer reduced the surviving process from approximately 100% CPU to 0.0-0.2% and removed one thread. Guest `/proc/stat` remained approximately 99.9% idle, while host spindumps repeatedly sampled `smolvm-fabric-recv` in `recvfrom`.

## Change

Introduce `accept_blocking_peer`, which:

1. accepts the peer from the nonblocking listener;
2. explicitly calls `stream.set_nonblocking(false)`;
3. returns the normalized stream to `run_accept_loop`.

If restoring blocking mode fails, the accept loop follows its existing error path instead of starting a reader with incompatible socket behavior.

The reader's timeout and partial-frame handling remain unchanged.

## Testing

### Automated

- `cargo make lint`
  - formatting and strict Clippy checks passed
- `cargo make test-lib`
  - 723 passed
- `cargo test -p smolvm-network fabric::tests`
  - 8 passed
- `cargo build --release`
  - completed successfully on Apple Silicon macOS
- local release binary codesigned with `smolvm.entitlements`
  - signature verification passed

The new test creates a nonblocking Unix listener, accepts a peer through the production helper, and verifies with `F_GETFL` that `O_NONBLOCK` is cleared on the returned stream.

### Runtime validation

The unpatched behavior was observed with smolvm 1.14.1 on Apple Silicon macOS 26.6.2 (25G83). The patched validation used a local 1.14.2 build.

Two existing persistent VMs were restarted using the patched local build, then an HTTPS request was sent through the proxy VM to establish both directional fabric streams.

| State | Proxy VM host CPU | Client VM host CPU |
| --- | ---: | ---: |
| Unpatched, streams established | approximately 100% | approximately 100% |
| Patched, before traffic | approximately 0.0% | approximately 0.4% |
| Patched, streams established | approximately 0.1-0.2% | approximately 0.4-0.7% |

Socket inspection confirmed that the bidirectional fabric streams and receive threads were present in the patched run. The processes remained sleeping when idle rather than spinning.

Four proxied HTTPS requests completed successfully in 0.446 s, 0.728 s, 0.130 s, and 0.134 s. The VM processes remained idle after the connections stayed cached.

## Scope

This change only normalizes accepted named-fabric Unix streams to the blocking mode already assumed by the timeout-driven reader. It does not change fabric framing, queue behavior, routing, shutdown cadence, or partial-read handling.
