### PR TITLE
Share active branch memory and guard host capacity

### DIFF
--- a/crates/smolvm-agent/src/branchpoint.rs
+++ b/crates/smolvm-agent/src/branchpoint.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use smolvm_protocol::forkpoint::{
-    typed_error, ARMED_PREFIX, ARM_PREFIX, GENERATION_PREFIX, RELEASE_PREFIX,
+    typed_error, ARMED_PREFIX, ARM_PREFIX, GENERATION_PREFIX, READY_LEASE_HINT, RELEASE_PREFIX,
 };
 
 /// A failed step, carrying the protocol error code the host handles on.
@@ -107,8 +107,14 @@ fn settled(markers: &Markers, window: Duration, condition: impl FnMut() -> bool)
 /// The generation recorded in a ready marker: its `generation=` line, 32 hex
 /// digits. A marker without one is not a branchpoint this protocol can drive.
 fn generation_of(ready: &Path) -> Result<String, TypedError> {
-    let contents = match std::fs::read_to_string(ready) {
-        Ok(contents) => contents,
+    let contents = match live_ready_contents(ready) {
+        Ok(Some(contents)) => contents,
+        Ok(None) => {
+            return Err(TypedError::new(
+                typed_error::NOT_READY,
+                "the branchpoint marker has no live helper; run `smolvm-branch-ready` again",
+            ));
+        }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             return Err(TypedError::new(
                 typed_error::NOT_READY,
@@ -130,6 +136,35 @@ fn generation_of(ready: &Path) -> Result<String, TypedError> {
         ));
     }
     Ok(generation.to_string())
+}
+
+/// Read a readiness marker and, when it advertises the lease protocol, prove
+/// that its helper still owns the file lock. Older markers remain accepted so
+/// live branches made by the previous agent continue to work.
+fn live_ready_contents(ready: &Path) -> std::io::Result<Option<String>> {
+    use std::io::Read as _;
+    use std::os::fd::AsRawFd as _;
+
+    let mut file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(ready)?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;
+    if !contents.lines().any(|line| line == READY_LEASE_HINT) {
+        return Ok(Some(contents));
+    }
+
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0 {
+        let _ = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
+        return Ok(None);
+    }
+    let error = std::io::Error::last_os_error();
+    if error.kind() == std::io::ErrorKind::WouldBlock {
+        Ok(Some(contents))
+    } else {
+        Err(error)
+    }
 }
 
 fn write_atomic(path: &Path, contents: &str, mode: u32) -> Result<(), TypedError> {
@@ -169,11 +204,15 @@ fn write_private(path: &Path, contents: &str, mode: u32) -> Result<(), TypedErro
 pub fn wait_ready(markers: &Markers, timeout: Duration) -> Result<String, TypedError> {
     let mut outcome = None;
     settled(markers, timeout, || {
-        match std::fs::read_to_string(&markers.ready) {
-            Ok(contents) => {
+        match live_ready_contents(&markers.ready) {
+            Ok(Some(contents)) => {
                 outcome = Some(Ok(contents));
                 true
             }
+            // An unlocked lease is stale. Leave the pathname in place so a
+            // concurrently published replacement can never be unlinked; its
+            // atomic rename wakes this wait through the directory watcher.
+            Ok(None) => false,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
             Err(error) => {
                 outcome = Some(Err(TypedError::io("read ready marker", error)));
@@ -239,8 +278,17 @@ pub fn release(markers: &Markers, env_dotenv: Option<&str>) -> Result<(), TypedE
     std::fs::create_dir_all(&markers.state_dir)
         .map_err(|error| TypedError::io("create state dir", error))?;
     // No ready marker means no parked helper: a checkpoint taken away from
-    // any branchpoint has nothing to release, and that is not an error.
+    // any branchpoint has nothing to release. Clear the restore marker that
+    // rejuvenation installs unconditionally; otherwise a helper started later
+    // mistakes itself for an inherited clone helper and never acknowledges a
+    // future capture arm.
     if !markers.ready.exists() {
+        let restored = markers.state_dir.join("restored");
+        match std::fs::remove_file(&restored) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(TypedError::io("remove stale restored marker", error)),
+        }
         return Ok(());
     }
     let generation = generation_of(&markers.ready)?;
@@ -404,6 +452,29 @@ mod tests {
     }
 
     #[test]
+    fn leased_ready_marker_requires_a_live_lock_holder() {
+        use std::os::fd::AsRawFd as _;
+
+        let temp = tempfile::tempdir().unwrap();
+        let ready = temp.path().join("ready");
+        std::fs::write(
+            &ready,
+            format!("smolvm-forkpoint-v1\n{GENERATION_PREFIX}{GEN}\n{READY_LEASE_HINT}\n"),
+        )
+        .unwrap();
+        let lease = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&ready)
+            .unwrap();
+        assert_eq!(unsafe { libc::flock(lease.as_raw_fd(), libc::LOCK_EX) }, 0);
+        assert!(live_ready_contents(&ready).unwrap().is_some());
+
+        drop(lease);
+        assert_eq!(live_ready_contents(&ready).unwrap(), None);
+    }
+
+    #[test]
     fn arm_requires_a_generation_and_waits_for_the_ack() {
         let temp = tempfile::tempdir().unwrap();
         let markers = Markers::under(&temp.path().join("state"));
@@ -485,8 +556,11 @@ mod tests {
         // No ready marker at all: nothing is parked, so there is nothing to do.
         std::fs::remove_file(&markers.ready).unwrap();
         let _ = std::fs::remove_file(&markers.release);
+        let restored = markers.state_dir.join("restored");
+        std::fs::write(&restored, "smolvm-forkpoint-restored-v1\n").unwrap();
         release(&markers, None).unwrap();
         assert!(!markers.release.exists());
+        assert!(!restored.exists());
     }
 
     #[test]

--- a/crates/smolvm-agent/src/forkpoint.rs
+++ b/crates/smolvm-agent/src/forkpoint.rs
@@ -14,9 +14,9 @@ const AGENT_BINARY: &str = "/usr/local/bin/smolvm-agent";
 use smolvm_protocol::forkpoint::{
     ARMED_PATH, ARMED_PREFIX, ARM_PATH, ARM_PREFIX, BRANCH_ENV_PATH, BRANCH_HELPER_PATH,
     CONTAINER_INIT_ARG, CONTAINER_INIT_NAME, CUDA_PRELOAD_MODULES_HINT, FORK_ENV_PATH,
-    GENERATION_PREFIX, HELPER_PATH, READY_PATH, READY_VERSION, RELEASE_PATH, RELEASE_PREFIX,
-    RESTORED_CONTAINER_PATH, RESTORED_PATH, STATE_DIR, WORKER_READY_HELPER_PATH, WORKER_READY_PATH,
-    WORKER_READY_TOKEN_ENV,
+    GENERATION_PREFIX, HELPER_PATH, READY_LEASE_HINT, READY_PATH, READY_VERSION, RELEASE_PATH,
+    RELEASE_PREFIX, RESTORED_CONTAINER_PATH, RESTORED_PATH, STATE_DIR, WORKER_READY_HELPER_PATH,
+    WORKER_READY_PATH, WORKER_READY_TOKEN_ENV,
 };
 
 fn enabled() -> bool {
@@ -321,6 +321,14 @@ fn run_helper_at(
     ready
         .sync_all()
         .map_err(|error| format!("sync {}: {error}", ready_temp.display()))?;
+    // The ready marker is a lease, not merely a file. Keeping this lock for
+    // the entire parked lifetime lets the agent reject a stale marker after a
+    // helper is killed, including after restoring a portable checkpoint.
+    if unsafe { libc::flock(std::os::fd::AsRawFd::as_raw_fd(&ready), libc::LOCK_EX) } != 0 {
+        let error = std::io::Error::last_os_error();
+        let _ = std::fs::remove_file(&ready_temp);
+        return Err(format!("lock {}: {error}", ready_temp.display()));
+    }
     std::fs::rename(&ready_temp, ready_path).map_err(|error| {
         let _ = std::fs::remove_file(&ready_temp);
         format!(
@@ -346,7 +354,7 @@ fn run_helper_at(
         // never baked into a clone as a zombie.
         reap_children_if_init();
         if release_matches(release_path, &generation) {
-            acknowledge_generation(ready_path, &generation);
+            acknowledge_release(ready_path, restored_path, &generation);
             return Ok(());
         }
         if arm_matches(arm_path, &generation) {
@@ -354,7 +362,7 @@ fn run_helper_at(
             while !restored_path.is_file() && arm_matches(arm_path, &generation) {
                 if release_matches(release_path, &generation) {
                     let _ = std::fs::remove_file(armed_path);
-                    acknowledge_generation(ready_path, &generation);
+                    acknowledge_release(ready_path, restored_path, &generation);
                     return Ok(());
                 }
                 match watcher.as_ref().map(|w| w.wait(None)) {
@@ -375,7 +383,7 @@ fn run_helper_at(
     // long time, so this is the bounded event wait again, not a poll.
     loop {
         if release_matches(release_path, &generation) {
-            acknowledge_generation(ready_path, &generation);
+            acknowledge_release(ready_path, restored_path, &generation);
             return Ok(());
         }
         reap_children_if_init();
@@ -490,9 +498,12 @@ fn forkpoint_generation() -> Result<String, String> {
 
 fn ready_content(preload_modules: bool, generation: &str) -> String {
     if preload_modules {
-        format!("{READY_VERSION}\n{GENERATION_PREFIX}{generation}\n{CUDA_PRELOAD_MODULES_HINT}\n")
+        format!(
+            "{READY_VERSION}\n{GENERATION_PREFIX}{generation}\n{READY_LEASE_HINT}\n\
+             {CUDA_PRELOAD_MODULES_HINT}\n"
+        )
     } else {
-        format!("{READY_VERSION}\n{GENERATION_PREFIX}{generation}\n")
+        format!("{READY_VERSION}\n{GENERATION_PREFIX}{generation}\n{READY_LEASE_HINT}\n")
     }
 }
 
@@ -542,6 +553,15 @@ fn acknowledge_generation(ready_path: &Path, generation: &str) {
     if is_current {
         let _ = std::fs::remove_file(ready_path);
     }
+}
+
+fn acknowledge_release(ready_path: &Path, restored_path: &Path, generation: &str) {
+    acknowledge_generation(ready_path, generation);
+    // `restored` describes only the inherited helper's first wait. Once that
+    // helper is released, leaving the marker behind would make every future
+    // branchpoint helper ignore capture-arm requests, preventing a restored
+    // machine from becoming a branch source itself.
+    let _ = std::fs::remove_file(restored_path);
 }
 
 #[cfg(test)]
@@ -708,6 +728,7 @@ mod tests {
         std::fs::write(&release, format!("{RELEASE_PREFIX}{generation}\n")).unwrap();
         helper.join().unwrap().unwrap();
         assert!(!ready.exists());
+        assert!(!restored.exists());
         assert!(!arm.exists());
         assert!(!armed.exists());
     }
@@ -799,6 +820,7 @@ mod tests {
         std::fs::write(&release, format!("{RELEASE_PREFIX}{generation}\n")).unwrap();
         helper.join().unwrap().unwrap();
         assert!(!ready.exists());
+        assert!(!restored.exists());
         assert!(!armed.exists());
     }
 
@@ -928,11 +950,12 @@ mod tests {
     fn helper_records_cuda_module_preload_hint() {
         assert_eq!(
             ready_content(true, "0123"),
-            "smolvm-forkpoint-v1\ngeneration=0123\ncuda-preload-modules\n"
+            "smolvm-forkpoint-v1\ngeneration=0123\nready-lease=flock-v1\n\
+             cuda-preload-modules\n"
         );
         assert_eq!(
             ready_content(false, "0123"),
-            "smolvm-forkpoint-v1\ngeneration=0123\n"
+            "smolvm-forkpoint-v1\ngeneration=0123\nready-lease=flock-v1\n"
         );
     }
 

--- a/crates/smolvm-protocol/src/forkpoint.rs
+++ b/crates/smolvm-protocol/src/forkpoint.rs
@@ -13,6 +13,11 @@ pub const READY_VERSION: &str = "smolvm-forkpoint-v1";
 /// releaser distinguish a new forkpoint from the previous helper's marker.
 pub const GENERATION_PREFIX: &str = "generation=";
 
+/// Readiness-marker capability indicating that the helper holds an advisory
+/// lock on the marker for its entire parked lifetime. The agent uses the lock
+/// to distinguish a live helper from a marker left behind by a killed process.
+pub const READY_LEASE_HINT: &str = "ready-lease=flock-v1";
+
 /// Optional readiness-marker capability requesting eager clone module loading.
 pub const CUDA_PRELOAD_MODULES_HINT: &str = "cuda-preload-modules";
 

--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -430,19 +430,134 @@ pub fn fork_continue_enabled() -> bool {
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 fn kernel_fault_userfaultfd_available() -> bool {
-    let fd = unsafe {
-        libc::syscall(libc::SYS_userfaultfd, libc::O_CLOEXEC | libc::O_NONBLOCK) as libc::c_int
-    };
-    if fd < 0 {
-        return false;
-    }
-    unsafe { libc::close(fd) };
-    true
+    crate::process::open_kernel_userfaultfd().is_ok()
 }
 
 #[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
 fn kernel_fault_userfaultfd_available() -> bool {
     false
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LiveBranchRamMode {
+    /// Map every clone from one materialized memfd generation. Clean pages stay
+    /// physically shared across active siblings and only writes allocate RAM.
+    Shared,
+    /// Leave clone RAM empty and fetch pages from the generation guardian as
+    /// they are first touched. Best for one sparse/idle child, but every child
+    /// that reads a page materializes its own copy.
+    Paged,
+}
+
+fn select_live_branch_ram_mode(
+    clone_count: usize,
+    userfaultfd_available: bool,
+    requested: Option<&str>,
+) -> Result<LiveBranchRamMode> {
+    match requested.unwrap_or("auto") {
+        "auto" if clone_count > 1 => Ok(LiveBranchRamMode::Shared),
+        "auto" if userfaultfd_available => Ok(LiveBranchRamMode::Paged),
+        "auto" => Ok(LiveBranchRamMode::Shared),
+        "shared" => Ok(LiveBranchRamMode::Shared),
+        "paged" if userfaultfd_available => Ok(LiveBranchRamMode::Paged),
+        "paged" => Err(Error::agent(
+            "fork",
+            "SMOLVM_BRANCH_RAM_MODE=paged requires kernel-fault userfaultfd; run a privileged SmolVM service or grant it read/write access to /dev/userfaultfd",
+        )),
+        value => Err(Error::config(
+            "fork",
+            format!("SMOLVM_BRANCH_RAM_MODE must be auto, shared, or paged (got '{value}')"),
+        )),
+    }
+}
+
+fn branch_admission_value(name: &str, default: u64) -> Result<u64> {
+    match std::env::var(name) {
+        Ok(value) => value.parse::<u64>().map_err(|_| {
+            Error::config(
+                "fork memory admission",
+                format!("{name} must be a non-negative integer MiB value"),
+            )
+        }),
+        Err(std::env::VarError::NotPresent) => Ok(default),
+        Err(error) => Err(Error::config(
+            "fork memory admission",
+            format!("read {name}: {error}"),
+        )),
+    }
+}
+
+fn branch_admission_required_mib(
+    children: usize,
+    child_overhead_mib: u64,
+    reserve_mib: u64,
+    materialized_generation_mib: u64,
+) -> Option<u64> {
+    u64::try_from(children)
+        .ok()?
+        .checked_mul(child_overhead_mib)?
+        .checked_add(reserve_mib)?
+        .checked_add(materialized_generation_mib)
+}
+
+/// Refuse a fan-out before capture if it would consume the host/cgroup's safe
+/// boot headroom. This intentionally reserves only measured VMM boot overhead
+/// plus a fresh shared generation—not every child's configured guest ceiling,
+/// which would erase COW density. Managed per-VM cgroups remain the hard bound
+/// for later workload writes where the service enables them.
+fn admit_branch_memory(
+    record: &VmRecord,
+    children: usize,
+    materializes_shared_generation: bool,
+) -> Result<()> {
+    if std::env::var("SMOLVM_BRANCH_MEMORY_ADMISSION").as_deref() == Ok("0") {
+        return Ok(());
+    }
+    let Some(memory) = crate::process::host_memory_stats() else {
+        return Ok(());
+    };
+    const MIB: u64 = 1024 * 1024;
+    let total_mib = memory.total_bytes / MIB;
+    let available_mib = memory.available_bytes / MIB;
+    let default_reserve_mib = (total_mib / 20).clamp(512, 4096).min(total_mib / 2);
+    let reserve_mib =
+        branch_admission_value("SMOLVM_HOST_MEMORY_RESERVE_MIB", default_reserve_mib)?;
+    // H100 and ordinary Linux QA put a booted, idle VMM at roughly 39–42 MiB.
+    // Reserve 64 MiB to include thread stacks and transient launch state.
+    let child_overhead_mib = branch_admission_value("SMOLVM_BRANCH_ADMISSION_MIB_PER_CHILD", 64)?;
+    let materialized_generation_mib = if materializes_shared_generation {
+        record
+            .pid
+            .and_then(crate::process::process_memory_stats)
+            .and_then(|stats| stats.pss_bytes)
+            .map(|bytes| (bytes.saturating_add(MIB - 1)) / MIB)
+            .unwrap_or(u64::from(record.mem))
+            .min(u64::from(record.mem))
+    } else {
+        0
+    };
+    let required_mib = branch_admission_required_mib(
+        children,
+        child_overhead_mib,
+        reserve_mib,
+        materialized_generation_mib,
+    )
+    .ok_or_else(|| Error::agent("fork memory admission", "memory estimate overflow"))?;
+    if available_mib < required_mib {
+        return Err(Error::vm_creation(format!(
+            "branch needs at least {required_mib} MiB of effective host headroom for {children} children, but only {available_mib} MiB is available; reduce the batch, free memory, or tune SMOLVM_HOST_MEMORY_RESERVE_MIB/SMOLVM_BRANCH_ADMISSION_MIB_PER_CHILD"
+        )));
+    }
+    tracing::debug!(
+        children,
+        available_mib,
+        required_mib,
+        reserve_mib,
+        child_overhead_mib,
+        materialized_generation_mib,
+        "branch memory admission passed"
+    );
+    Ok(())
 }
 
 pub(crate) fn retained_snapshot_source_continues(snapshot: &RetainedForkSnapshot) -> bool {
@@ -1898,6 +2013,18 @@ pub(crate) fn prepare_forks_reusing(
         ));
     }
     let golden_was_paused = fork_base_already_paused(&status);
+    let fork_continue = fork_continue_enabled();
+    let userfaultfd_available = kernel_fault_userfaultfd_available();
+    let requested_ram_mode = std::env::var("SMOLVM_BRANCH_RAM_MODE").ok();
+    let live_ram_mode = fork_continue
+        .then(|| {
+            select_live_branch_ram_mode(
+                specs.len(),
+                userfaultfd_available,
+                requested_ram_mode.as_deref(),
+            )
+        })
+        .transpose()?;
 
     let gdir = vm_data_dir(golden);
     // Keep this path short and independent of clone names. libkrun and its
@@ -1909,7 +2036,7 @@ pub(crate) fn prepare_forks_reusing(
     // be using an older snapshot.
     let snapshot_root = gdir.join("s");
     #[cfg(any(target_os = "linux", target_os = "macos"))]
-    if fork_continue_enabled() && !golden_was_paused {
+    if fork_continue && !golden_was_paused {
         recover_uncommitted_generations(db, golden, &gdir, &snapshot_root)?;
     }
     let reusable = retained.filter(|snapshot| {
@@ -1921,12 +2048,38 @@ pub(crate) fn prepare_forks_reusing(
                 snapshot,
             )
     });
+    #[cfg(target_os = "linux")]
+    let reusable = match (reusable, live_ram_mode) {
+        (Some(snapshot), Some(wanted)) if !golden_was_paused => {
+            let retained_mode = if snapshot_guardian_identity(&snapshot.path)?.is_some() {
+                LiveBranchRamMode::Paged
+            } else {
+                LiveBranchRamMode::Shared
+            };
+            if retained_mode == wanted {
+                Some(snapshot)
+            } else {
+                tracing::debug!(
+                    ?wanted,
+                    ?retained_mode,
+                    "fork: refreshing retained RAM generation for requested sharing policy"
+                );
+                None
+            }
+        }
+        (snapshot, _) => snapshot,
+    };
     if golden_was_paused && reusable.is_none() {
         return Err(Error::agent(
             "fork",
             format!("golden '{golden}' is already paused; a valid retained checkpoint is required"),
         ));
     }
+    admit_branch_memory(
+        &golden_rec,
+        specs.len(),
+        reusable.is_none() && live_ram_mode == Some(LiveBranchRamMode::Shared),
+    )?;
     let (snapshot_dir, snapshot_reused) = if let Some(snapshot) = reusable {
         tracing::info!(
             golden,
@@ -1990,7 +2143,6 @@ pub(crate) fn prepare_forks_reusing(
             }
         };
 
-        let fork_continue = fork_continue_enabled();
         if fork_continue {
             #[cfg(any(target_os = "linux", target_os = "macos"))]
             if let Err(error) = prepare_running_disk_generation(&gdir, &snapshot_dir, vm_ids) {
@@ -2032,16 +2184,24 @@ pub(crate) fn prepare_forks_reusing(
         };
 
         let t_snap = std::time::Instant::now();
-        // Prefer demand paging when host policy allows kernel-originated
-        // userfaultfd events; otherwise preserve the same semantics with an
-        // eagerly materialized RAM generation.
-        let fork_verb = if fork_continue && kernel_fault_userfaultfd_available() {
-            "FORK_CONTINUE_PAGED"
-        } else if fork_continue {
-            tracing::debug!(
-                "fork: kernel-fault userfaultfd unavailable; using materialized RAM generation"
-            );
-            "FORK_CONTINUE"
+        // A batch maps one materialized memfd generation so siblings share
+        // every clean physical page. For a single sparse child, demand paging
+        // avoids materializing untouched source RAM when userfaultfd is usable.
+        // The environment override is an operator/debugging escape hatch; auto
+        // is the user-facing behavior.
+        let fork_verb = if fork_continue {
+            match live_ram_mode.expect("fork-continue mode selected before capture") {
+                LiveBranchRamMode::Shared => {
+                    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+                    if specs.len() == 1 && !userfaultfd_available {
+                        tracing::warn!(
+                            "kernel-fault userfaultfd unavailable; using a shared materialized RAM generation (grant the service read/write access to /dev/userfaultfd to make sparse single-child branches lazy)"
+                        );
+                    }
+                    "FORK_CONTINUE"
+                }
+                LiveBranchRamMode::Paged => "FORK_CONTINUE_PAGED",
+            }
         } else {
             "FORK"
         };
@@ -3360,6 +3520,50 @@ fn host_random_hex(hex_len: usize) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn live_branch_ram_auto_shares_active_sibling_pages() {
+        assert_eq!(
+            select_live_branch_ram_mode(2, true, None).unwrap(),
+            LiveBranchRamMode::Shared
+        );
+        assert_eq!(
+            select_live_branch_ram_mode(100, false, Some("auto")).unwrap(),
+            LiveBranchRamMode::Shared
+        );
+    }
+
+    #[test]
+    fn live_branch_ram_auto_pages_only_one_sparse_child() {
+        assert_eq!(
+            select_live_branch_ram_mode(1, true, None).unwrap(),
+            LiveBranchRamMode::Paged
+        );
+        assert_eq!(
+            select_live_branch_ram_mode(1, false, None).unwrap(),
+            LiveBranchRamMode::Shared
+        );
+    }
+
+    #[test]
+    fn live_branch_ram_override_is_validated() {
+        assert_eq!(
+            select_live_branch_ram_mode(8, true, Some("paged")).unwrap(),
+            LiveBranchRamMode::Paged
+        );
+        assert!(select_live_branch_ram_mode(8, false, Some("paged")).is_err());
+        assert!(select_live_branch_ram_mode(8, true, Some("copy-everything")).is_err());
+    }
+
+    #[test]
+    fn branch_memory_admission_scales_with_children_and_new_generation() {
+        assert_eq!(branch_admission_required_mib(8, 64, 1024, 512), Some(2048));
+        assert_eq!(branch_admission_required_mib(8, 64, 1024, 0), Some(1536));
+        assert_eq!(
+            branch_admission_required_mib(usize::MAX, u64::MAX, 1, 1),
+            None
+        );
+    }
 
     #[test]
     fn worker_ready_assignment_carries_a_fresh_token_and_refuses_a_forged_one() {

--- a/src/agent/launcher.rs
+++ b/src/agent/launcher.rs
@@ -1818,7 +1818,7 @@ pub fn launch_agent_vm(config: &LaunchConfig<'_>) -> Result<()> {
                     ctx,
                     tag.as_ptr(),
                     host_path.as_ptr(),
-                    super::virtiofs::DATA_DAX_WINDOW,
+                    super::virtiofs::packed_layers_dax_window(),
                     false,
                 ) < 0
                 {

--- a/src/agent/launcher_dynamic.rs
+++ b/src/agent/launcher_dynamic.rs
@@ -807,8 +807,8 @@ pub fn launch_agent_vm_dynamic(
         free_ctx_on_err!("krun_set_exec failed");
     }
 
-    // Packed image layers always use the shared data DAX window. User mounts
-    // follow the same explicit policy as every other launch path below.
+    // Packed image layers use DAX where the guest architecture supports it.
+    // User mounts follow the same explicit policy as every other launch path.
     // Add virtiofs mount for packed layers (AFTER set_exec)
     if config.layers_dir.exists() {
         let layers_tag = cstr("smolvm_layers");
@@ -822,7 +822,7 @@ pub fn launch_agent_vm_dynamic(
                 ctx,
                 layers_tag.as_ptr(),
                 layers_path.as_ptr(),
-                super::virtiofs::DATA_DAX_WINDOW,
+                super::virtiofs::packed_layers_dax_window(),
                 false,
             )
         } < 0

--- a/src/agent/virtiofs.rs
+++ b/src/agent/virtiofs.rs
@@ -28,6 +28,17 @@ pub(crate) fn rootfs_dax_window() -> u64 {
     }
 }
 
+/// DAX window for immutable packed image layers. These layers are the main
+/// cross-VM filesystem-sharing surface, but must follow the same architecture
+/// gate as the root filesystem because the arm64 guest kernel has no FUSE DAX.
+pub(crate) fn packed_layers_dax_window() -> u64 {
+    if VIRTIOFS_DAX_SUPPORTED {
+        DATA_DAX_WINDOW
+    } else {
+        0
+    }
+}
+
 /// DAX window for one user mount. Normal mounts are explicit opt-in; on a
 /// supported architecture the CUDA ring is always DAX because it cannot
 /// function as a plain virtiofs mount.
@@ -61,12 +72,14 @@ mod tests {
     #[test]
     fn dax_windows_follow_architecture_support() {
         if cfg!(target_arch = "x86_64") {
+            assert_eq!(packed_layers_dax_window(), DATA_DAX_WINDOW);
             assert_eq!(
                 user_mount_dax_window(Path::new("/opt/smolvm-ring")),
                 CUDA_RING_DAX_WINDOW
             );
         } else {
             assert_eq!(rootfs_dax_window(), 0);
+            assert_eq!(packed_layers_dax_window(), 0);
             assert_eq!(user_mount_dax_window(Path::new("/opt/smolvm-ring")), 0);
         }
     }

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -75,6 +75,8 @@ fn record_to_info(name: &str, record: &VmRecord) -> MachineInfo {
     } else {
         record.pid
     };
+    let stats = pid.and_then(crate::process::process_stats);
+    let memory_stats = pid.and_then(crate::process::process_memory_stats);
     MachineInfo {
         name: name.to_string(),
         state: actual_state.to_string(),
@@ -132,19 +134,22 @@ fn record_to_info(name: &str, record: &VmRecord) -> MachineInfo {
         // (user+system CPU time). Resets on restart — the control plane treats it
         // as a monotonic-with-resets counter and accumulates the durable total.
         // `None` when stopped (pid cleared) or the process vanished mid-sample.
-        cpu_seconds: pid
-            .and_then(crate::process::process_stats)
-            .map(|s| s.cpu_time_ns / 1_000_000_000),
+        cpu_seconds: stats.map(|s| s.cpu_time_ns / 1_000_000_000),
         // Same consumed CPU in milliseconds — sub-second precision so consumers
         // don't quantize a barely-busy process up to a whole second.
-        cpu_millis: pid
-            .and_then(crate::process::process_stats)
-            .map(|s| s.cpu_time_ns / 1_000_000),
+        cpu_millis: stats.map(|s| s.cpu_time_ns / 1_000_000),
         // Current RSS (MiB) of the VMM process — an instantaneous gauge the
         // control plane integrates over time for active-memory billing.
-        rss_mb: pid
-            .and_then(crate::process::process_stats)
-            .map(|s| s.rss_bytes / (1024 * 1024)),
+        rss_mb: stats.map(|s| s.rss_bytes / (1024 * 1024)),
+        pss_mb: memory_stats
+            .and_then(|s| s.pss_bytes)
+            .map(|v| v / (1024 * 1024)),
+        private_memory_mb: memory_stats
+            .and_then(|s| s.private_bytes)
+            .map(|v| v / (1024 * 1024)),
+        shared_memory_mapped_mb: memory_stats
+            .and_then(|s| s.shared_mapped_bytes)
+            .map(|v| v / (1024 * 1024)),
         // Actual used disk (sparse-image blocks) — a gauge for active-disk billing,
         // measured from the data dir regardless of whether the VMM is running.
         disk_used_mb: crate::agent::disk_used_mb(name),
@@ -1758,7 +1763,9 @@ pub async fn start_machine(
 fn classify_fork_error(e: SmolvmError) -> ApiError {
     let msg = e.to_string();
     let lc = msg.to_ascii_lowercase();
-    if lc.contains("cuda fork descendants") || lc.contains("fork lineage would exceed") {
+    if lc.contains("branch needs at least") && lc.contains("effective host headroom") {
+        ApiError::Unavailable(msg)
+    } else if lc.contains("cuda fork descendants") || lc.contains("fork lineage would exceed") {
         ApiError::BadRequest(msg)
     } else if lc.contains("already exists")
         || lc.contains("not running forkable")
@@ -3674,6 +3681,10 @@ mod tests {
         // An unrelated fork failure stays a 500.
         let e = SmolvmError::agent("fork", "disk write failed");
         assert!(matches!(classify_fork_error(e), ApiError::Internal(_)));
+        let e = SmolvmError::vm_creation(
+            "branch needs at least 2048 MiB of effective host headroom for 8 children, but only 1024 MiB is available",
+        );
+        assert!(matches!(classify_fork_error(e), ApiError::Unavailable(_)));
     }
 
     #[test]

--- a/src/api/handlers/node.rs
+++ b/src/api/handlers/node.rs
@@ -53,7 +53,8 @@ pub async fn capacity(State(state): State<Arc<ApiState>>) -> Response {
     }
 
     let (allocated_cpus, allocated_memory_mb) = state.allocated_resources();
-    let (used_cpus, used_memory_mb, used_disk_gb) = state.real_utilization();
+    let utilization = state.real_utilization();
+    let host_memory = crate::process::host_memory_stats();
     let cuda_devices = state.cuda_devices().map(|devices| {
         devices
             .into_iter()
@@ -72,9 +73,14 @@ pub async fn capacity(State(state): State<Arc<ApiState>>) -> Response {
     Json(CapacityResponse {
         allocated_cpus,
         allocated_memory_mb,
-        used_cpus,
-        used_memory_mb,
-        used_disk_gb,
+        used_cpus: utilization.used_cpus,
+        used_memory_mb: utilization.rss_mb,
+        used_memory_pss_mb: utilization.pss_mb,
+        used_memory_private_mb: utilization.private_memory_mb,
+        used_memory_shared_mapped_mb: utilization.shared_memory_mapped_mb,
+        host_memory_total_mb: host_memory.map(|memory| memory.total_bytes / (1024 * 1024)),
+        host_memory_available_mb: host_memory.map(|memory| memory.available_bytes / (1024 * 1024)),
+        used_disk_gb: utilization.disk_gb,
         boot_id: boot_id().to_string(),
         cuda_devices,
     })

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -20,6 +20,23 @@ struct CpuSample {
     cpu_time_ns: u64,
 }
 
+/// Aggregate live host utilization for SmolVM processes.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NodeUtilization {
+    /// Fractional CPUs consumed across running VMMs.
+    pub used_cpus: f64,
+    /// Summed resident memory in MiB.
+    pub rss_mb: u64,
+    /// Summed proportional resident memory in MiB.
+    pub pss_mb: Option<u64>,
+    /// Summed private resident memory in MiB.
+    pub private_memory_mb: Option<u64>,
+    /// Summed shared mappings in MiB (not unique physical memory).
+    pub shared_memory_mapped_mb: Option<u64>,
+    /// Physical disk blocks consumed by machine disks in GiB.
+    pub disk_gb: u64,
+}
+
 /// Records whose disk state must survive startup reconciliation. A stopped or
 /// live clone keeps every ancestor in its qcow2 lineage alive even when an
 /// ancestor VMM process died; deleting that ancestor's data directory would
@@ -773,16 +790,22 @@ impl ApiState {
 
     /// Sample real CPU + memory + disk utilization across all running VM processes.
     ///
-    /// Returns `(used_cpus, used_memory_mb, used_disk_gb)`:
+    /// Returns CPU, RSS/PSS/private/shared memory, and used disk:
     /// - CPU is fractional CPUs (e.g., 2.5 = 2.5 CPUs of load), computed as
     ///   `Δcpu_time / Δwall_time` since the previous sample per PID. First sample
     ///   for a new PID returns 0 CPU; subsequent samples return the real rate.
     /// - Memory is the sum of resident set sizes across VM processes.
     /// - Disk is the sum of VM storage + overlay disk file sizes on disk.
-    pub fn real_utilization(&self) -> (f64, u64, u64) {
+    pub fn real_utilization(&self) -> NodeUtilization {
         let now = std::time::Instant::now();
         let mut total_cpus: f64 = 0.0;
         let mut total_rss_bytes: u64 = 0;
+        let mut total_pss_bytes: u64 = 0;
+        let mut total_private_bytes: u64 = 0;
+        let mut total_shared_mapped_bytes: u64 = 0;
+        let mut complete_pss = true;
+        let mut complete_private = true;
+        let mut complete_shared = true;
         let mut total_disk_bytes: u64 = 0;
 
         let pid_and_paths: Vec<(Option<i32>, std::path::PathBuf, std::path::PathBuf)> = {
@@ -823,6 +846,30 @@ impl ApiState {
                 continue;
             };
             total_rss_bytes = total_rss_bytes.saturating_add(stats.rss_bytes);
+            match crate::process::process_memory_stats(pid) {
+                Some(memory) => {
+                    if let Some(value) = memory.pss_bytes {
+                        total_pss_bytes = total_pss_bytes.saturating_add(value);
+                    } else {
+                        complete_pss = false;
+                    }
+                    if let Some(value) = memory.private_bytes {
+                        total_private_bytes = total_private_bytes.saturating_add(value);
+                    } else {
+                        complete_private = false;
+                    }
+                    if let Some(value) = memory.shared_mapped_bytes {
+                        total_shared_mapped_bytes = total_shared_mapped_bytes.saturating_add(value);
+                    } else {
+                        complete_shared = false;
+                    }
+                }
+                None => {
+                    complete_pss = false;
+                    complete_private = false;
+                    complete_shared = false;
+                }
+            }
 
             if let Some(prev) = samples.get(&pid).copied() {
                 let dt_ns = now.duration_since(prev.at).as_nanos() as u64;
@@ -844,11 +891,15 @@ impl ApiState {
         // as VMs come and go over the lifetime of the smolvm serve process).
         samples.retain(|pid, _| still_alive.contains(pid));
 
-        (
-            total_cpus,
-            total_rss_bytes / (1024 * 1024),
-            total_disk_bytes / (1024 * 1024 * 1024),
-        )
+        NodeUtilization {
+            used_cpus: total_cpus,
+            rss_mb: total_rss_bytes / (1024 * 1024),
+            pss_mb: complete_pss.then_some(total_pss_bytes / (1024 * 1024)),
+            private_memory_mb: complete_private.then_some(total_private_bytes / (1024 * 1024)),
+            shared_memory_mapped_mb: complete_shared
+                .then_some(total_shared_mapped_bytes / (1024 * 1024)),
+            disk_gb: total_disk_bytes / (1024 * 1024 * 1024),
+        }
     }
 
     // ========================================================================
@@ -1650,6 +1701,10 @@ pub fn machine_entry_to_info(name: String, entry: &MachineEntry) -> MachineInfo 
     let cpu_seconds = stats.map(|s| s.cpu_time_ns / 1_000_000_000);
     let cpu_millis = stats.map(|s| s.cpu_time_ns / 1_000_000);
     let rss_mb = stats.map(|s| s.rss_bytes / (1024 * 1024));
+    let memory_stats = entry
+        .manager
+        .child_pid()
+        .and_then(crate::process::process_memory_stats);
     // Actual used disk (sparse-image blocks) — a gauge the control integrates for
     // active-disk billing. Independent of whether there's a live VMM process.
     let disk_used_mb = crate::agent::disk_used_mb(&name);
@@ -1696,6 +1751,15 @@ pub fn machine_entry_to_info(name: String, entry: &MachineEntry) -> MachineInfo 
         cpu_seconds,
         cpu_millis,
         rss_mb,
+        pss_mb: memory_stats
+            .and_then(|s| s.pss_bytes)
+            .map(|v| v / (1024 * 1024)),
+        private_memory_mb: memory_stats
+            .and_then(|s| s.private_bytes)
+            .map(|v| v / (1024 * 1024)),
+        shared_memory_mapped_mb: memory_stats
+            .and_then(|s| s.shared_mapped_bytes)
+            .map(|v| v / (1024 * 1024)),
         disk_used_mb,
         created_at: 0,
     }

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -479,6 +479,25 @@ pub struct CapacityResponse {
     pub used_cpus: f64,
     /// Real resident memory (MB) across VM processes.
     pub used_memory_mb: u64,
+    /// Proportional resident memory (MB) across VM processes. Unlike summed
+    /// RSS, this counts clean pages shared by branch siblings only once in the
+    /// aggregate. Omitted where the host cannot provide process PSS.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub used_memory_pss_mb: Option<u64>,
+    /// Private resident memory (MB) across VM processes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub used_memory_private_mb: Option<u64>,
+    /// Sum of shared bytes mapped by VM processes (MB). This is a mapping gauge,
+    /// not a unique physical-memory total; use `used_memory_pss_mb` for that.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub used_memory_shared_mapped_mb: Option<u64>,
+    /// Effective memory ceiling (MB) available to this runtime, constrained by
+    /// finite cgroup-v2 ancestors where applicable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub host_memory_total_mb: Option<u64>,
+    /// Effective memory currently available (MB) to this runtime.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub host_memory_available_mb: Option<u64>,
     /// Real disk (GB) consumed by VM storage + overlay files.
     pub used_disk_gb: u64,
     /// Opaque id minted once per serve process. It changes iff the serve restarts
@@ -759,6 +778,20 @@ pub struct MachineInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(example = 128)]
     pub rss_mb: Option<u64>,
+    /// Proportional resident memory (PSS) in MiB. Summing this across branch
+    /// siblings accounts shared clean pages once instead of once per sibling.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = 72)]
+    pub pss_mb: Option<u64>,
+    /// Private resident memory in MiB.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = 48)]
+    pub private_memory_mb: Option<u64>,
+    /// Shared memory mapped by this VMM in MiB. This is not a unique physical
+    /// total when summed; use PSS for physical accounting.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = 384)]
+    pub shared_memory_mapped_mb: Option<u64>,
     /// Actual host disk consumed by this machine's data dir, in MiB (real blocks of
     /// the sparse disk images, not provisioned capacity). An instantaneous gauge the
     /// control integrates over time for active-disk billing. Omitted when the data

--- a/src/internal_boot.rs
+++ b/src/internal_boot.rs
@@ -33,28 +33,28 @@ fn preopen_guardian_userfaultfd() -> crate::Result<()> {
         return Ok(());
     }
 
-    let fd = unsafe {
-        libc::syscall(libc::SYS_userfaultfd, libc::O_CLOEXEC | libc::O_NONBLOCK) as libc::c_int
-    };
-    if fd < 0 {
-        return Err(crate::Error::agent(
+    use std::os::fd::{AsRawFd, IntoRawFd};
+
+    let fd = crate::process::open_kernel_userfaultfd().map_err(|error| {
+        crate::Error::agent(
             "prepare demand-paged clone RAM",
             format!(
-                "kernel-fault-capable userfaultfd is unavailable: {}; run the privileged SmolVM service so it can open userfaultfd before the per-VM uid drop",
-                std::io::Error::last_os_error()
+                "kernel-fault-capable userfaultfd is unavailable: {error}; run a privileged SmolVM service or grant it read/write access to /dev/userfaultfd"
             ),
-        ));
-    }
-    if fd != PREOPENED_USERFAULTFD_FD {
-        if unsafe { libc::dup3(fd, PREOPENED_USERFAULTFD_FD, libc::O_CLOEXEC) } < 0 {
+        )
+    })?;
+    if fd.as_raw_fd() != PREOPENED_USERFAULTFD_FD {
+        if unsafe { libc::dup3(fd.as_raw_fd(), PREOPENED_USERFAULTFD_FD, libc::O_CLOEXEC) } < 0 {
             let error = std::io::Error::last_os_error();
-            unsafe { libc::close(fd) };
             return Err(crate::Error::agent(
                 "prepare demand-paged clone RAM",
                 format!("reserve userfaultfd descriptor: {error}"),
             ));
         }
-        unsafe { libc::close(fd) };
+    } else {
+        // Inherited descriptors were closed immediately before this call, so
+        // this is unlikely; transfer ownership if the kernel reused slot 198.
+        let _ = fd.into_raw_fd();
     }
     Ok(())
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -5,6 +5,8 @@
 
 #[cfg(unix)]
 use std::os::fd::IntoRawFd;
+#[cfg(target_os = "linux")]
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
@@ -1861,6 +1863,54 @@ pub fn process_start_time(pid: Pid) -> Option<u64> {
     fields.get(19)?.parse::<u64>().ok()
 }
 
+/// Open a kernel-fault-capable userfaultfd without requiring the global
+/// `vm.unprivileged_userfaultfd=1` switch when Linux exposes its
+/// permission-governed `/dev/userfaultfd` device.
+///
+/// The syscall remains the first choice for privileged services and hosts that
+/// intentionally enable it. An unprivileged service then falls back to the
+/// device, whose ownership and mode can grant this capability only to SmolVM.
+#[cfg(target_os = "linux")]
+pub fn open_kernel_userfaultfd() -> std::io::Result<OwnedFd> {
+    const FLAGS: libc::c_int = libc::O_CLOEXEC | libc::O_NONBLOCK;
+    // `_IO(USERFAULTFD_IOC, 0x00)` from linux/userfaultfd.h. `_IO` carries no
+    // size or direction bits, so its stable value is type << 8 | number.
+    const USERFAULTFD_IOC_NEW: libc::c_ulong = 0xaa00;
+
+    let syscall_fd = unsafe { libc::syscall(libc::SYS_userfaultfd, FLAGS) as libc::c_int };
+    if syscall_fd >= 0 {
+        return Ok(unsafe { OwnedFd::from_raw_fd(syscall_fd) });
+    }
+    let syscall_error = std::io::Error::last_os_error();
+
+    let control = match std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("/dev/userfaultfd")
+    {
+        Ok(control) => control,
+        Err(device_error) => {
+            return Err(std::io::Error::new(
+                device_error.kind(),
+                format!(
+                    "userfaultfd syscall failed ({syscall_error}) and /dev/userfaultfd could not be opened ({device_error}); grant the SmolVM service read/write access to /dev/userfaultfd"
+                ),
+            ));
+        }
+    };
+    let device_fd = unsafe { libc::ioctl(control.as_raw_fd(), USERFAULTFD_IOC_NEW, FLAGS) };
+    if device_fd < 0 {
+        let device_error = std::io::Error::last_os_error();
+        return Err(std::io::Error::new(
+            device_error.kind(),
+            format!(
+                "userfaultfd syscall failed ({syscall_error}) and USERFAULTFD_IOC_NEW failed ({device_error})"
+            ),
+        ));
+    }
+    Ok(unsafe { OwnedFd::from_raw_fd(device_fd as libc::c_int) })
+}
+
 /// Get the start time of a process (Windows process creation FILETIME).
 #[cfg(windows)]
 pub fn process_start_time(pid: Pid) -> Option<u64> {
@@ -1880,6 +1930,160 @@ pub struct ProcessStats {
     pub cpu_time_ns: u64,
     /// Resident set size in bytes (physical memory currently held by the process).
     pub rss_bytes: u64,
+}
+
+/// Host-visible memory attributed to one VMM process.
+///
+/// RSS counts a shared page once in every process mapping it. PSS divides that
+/// page across its mappings, so summing PSS is the meaningful physical-memory
+/// gauge for a branch lineage. The remaining fields make the sharing visible
+/// without pretending that the mapped-shared sum is unique physical memory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProcessMemoryStats {
+    /// Resident bytes mapped by this process.
+    pub rss_bytes: u64,
+    /// Proportional resident bytes, when the host exposes `smaps_rollup`.
+    pub pss_bytes: Option<u64>,
+    /// Private clean + dirty resident bytes.
+    pub private_bytes: Option<u64>,
+    /// Shared clean + dirty bytes mapped by this process.
+    pub shared_mapped_bytes: Option<u64>,
+    /// Proportional swapped bytes.
+    pub swap_pss_bytes: Option<u64>,
+}
+
+/// Physical-memory capacity currently available to this SmolVM process.
+/// On Linux this is the tighter of host `MemAvailable` and any finite cgroup-v2
+/// ancestor headroom, preventing a service-scoped deployment from admitting
+/// against RAM it cannot actually consume.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HostMemoryStats {
+    /// Effective host or cgroup memory ceiling.
+    pub total_bytes: u64,
+    /// Effective currently available host or cgroup memory.
+    pub available_bytes: u64,
+}
+
+#[cfg(target_os = "linux")]
+fn parse_kib_field(contents: &str, field: &str) -> Option<u64> {
+    let value = contents.lines().find_map(|line| {
+        let (name, rest) = line.split_once(':')?;
+        (name == field).then_some(rest)
+    })?;
+    let kib = value.split_whitespace().next()?.parse::<u64>().ok()?;
+    kib.checked_mul(1024)
+}
+
+#[cfg(target_os = "linux")]
+fn parse_smaps_rollup(contents: &str) -> Option<ProcessMemoryStats> {
+    let rss_bytes = parse_kib_field(contents, "Rss")?;
+    let private_bytes = parse_kib_field(contents, "Private_Clean")?
+        .checked_add(parse_kib_field(contents, "Private_Dirty")?)?;
+    let shared_mapped_bytes = parse_kib_field(contents, "Shared_Clean")?
+        .checked_add(parse_kib_field(contents, "Shared_Dirty")?)?;
+    Some(ProcessMemoryStats {
+        rss_bytes,
+        pss_bytes: parse_kib_field(contents, "Pss"),
+        private_bytes: Some(private_bytes),
+        shared_mapped_bytes: Some(shared_mapped_bytes),
+        swap_pss_bytes: parse_kib_field(contents, "SwapPss"),
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn parse_statm_memory(contents: &str, page_size: u64) -> Option<(u64, u64)> {
+    let mut fields = contents.split_whitespace();
+    let _virtual_pages = fields.next()?;
+    let resident_pages = fields.next()?.parse::<u64>().ok()?;
+    let shared_pages = fields.next()?.parse::<u64>().ok()?;
+    Some((
+        resident_pages.checked_mul(page_size)?,
+        shared_pages.checked_mul(page_size)?,
+    ))
+}
+
+/// Read PSS/private/shared memory for a VMM. Linux uses the kernel's rollup
+/// view and falls back to `statm`'s cheaper resident/shared split when smaps is
+/// restricted; other hosts retain an RSS-only result.
+pub fn process_memory_stats(pid: Pid) -> Option<ProcessMemoryStats> {
+    #[cfg(target_os = "linux")]
+    if let Ok(contents) = std::fs::read_to_string(format!("/proc/{pid}/smaps_rollup")) {
+        if let Some(stats) = parse_smaps_rollup(&contents) {
+            return Some(stats);
+        }
+    }
+    let stats = process_stats(pid)?;
+    #[cfg(target_os = "linux")]
+    let statm = std::fs::read_to_string(format!("/proc/{pid}/statm"))
+        .ok()
+        .and_then(|contents| {
+            let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+            (page_size > 0)
+                .then_some(page_size as u64)
+                .and_then(|page_size| parse_statm_memory(&contents, page_size))
+        });
+    #[cfg(not(target_os = "linux"))]
+    let statm: Option<(u64, u64)> = None;
+    let shared_mapped_bytes = statm.map(|(_, shared)| shared);
+    Some(ProcessMemoryStats {
+        rss_bytes: stats.rss_bytes,
+        pss_bytes: None,
+        private_bytes: shared_mapped_bytes.map(|shared| stats.rss_bytes.saturating_sub(shared)),
+        shared_mapped_bytes,
+        swap_pss_bytes: None,
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn parse_host_meminfo(contents: &str) -> Option<HostMemoryStats> {
+    Some(HostMemoryStats {
+        total_bytes: parse_kib_field(contents, "MemTotal")?,
+        available_bytes: parse_kib_field(contents, "MemAvailable")?,
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn finite_cgroup_memory_headroom(mut dir: std::path::PathBuf) -> Option<(u64, u64)> {
+    let cgroup_root = std::path::Path::new("/sys/fs/cgroup");
+    let mut tightest_limit: Option<u64> = None;
+    let mut tightest_headroom: Option<u64> = None;
+    loop {
+        let max = std::fs::read_to_string(dir.join("memory.max")).ok();
+        let current = std::fs::read_to_string(dir.join("memory.current")).ok();
+        if let (Some(max), Some(current)) = (max, current) {
+            if let (Ok(max), Ok(current)) =
+                (max.trim().parse::<u64>(), current.trim().parse::<u64>())
+            {
+                tightest_limit = Some(tightest_limit.map_or(max, |limit| limit.min(max)));
+                let headroom = max.saturating_sub(current);
+                tightest_headroom =
+                    Some(tightest_headroom.map_or(headroom, |available| available.min(headroom)));
+            }
+        }
+        if dir == cgroup_root || !dir.pop() || !dir.starts_with(cgroup_root) {
+            break;
+        }
+    }
+    tightest_limit.zip(tightest_headroom)
+}
+
+/// Report effective host memory available to SmolVM.
+pub fn host_memory_stats() -> Option<HostMemoryStats> {
+    #[cfg(target_os = "linux")]
+    {
+        let mut stats = parse_host_meminfo(&std::fs::read_to_string("/proc/meminfo").ok()?)?;
+        if let Some(dir) = cgroup_v2_self_dir() {
+            if let Some((limit, headroom)) = finite_cgroup_memory_headroom(dir) {
+                stats.total_bytes = stats.total_bytes.min(limit);
+                stats.available_bytes = stats.available_bytes.min(headroom);
+            }
+        }
+        Some(stats)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
+    }
 }
 
 /// Sample CPU time and RSS for a single process. Returns None if the PID is
@@ -3167,6 +3371,56 @@ mod tests {
             "a live process must have non-zero RSS, got {}",
             stats.rss_bytes
         );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn smaps_rollup_distinguishes_proportional_private_and_shared_memory() {
+        let sample = "00400000-00452000 r--p 00000000 00:00 0 [rollup]\n\
+                      Rss:                1024 kB\n\
+                      Pss:                 640 kB\n\
+                      Shared_Clean:        256 kB\n\
+                      Shared_Dirty:         64 kB\n\
+                      Private_Clean:       128 kB\n\
+                      Private_Dirty:       576 kB\n\
+                      SwapPss:              16 kB\n";
+        let stats = parse_smaps_rollup(sample).expect("parse rollup");
+        assert_eq!(stats.rss_bytes, 1024 * 1024);
+        assert_eq!(stats.pss_bytes, Some(640 * 1024));
+        assert_eq!(stats.private_bytes, Some(704 * 1024));
+        assert_eq!(stats.shared_mapped_bytes, Some(320 * 1024));
+        assert_eq!(stats.swap_pss_bytes, Some(16 * 1024));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn statm_fallback_distinguishes_resident_private_and_shared_pages() {
+        let (resident, shared) = parse_statm_memory("1000 300 220 8 0 400 0\n", 4096).unwrap();
+        assert_eq!(resident, 300 * 4096);
+        assert_eq!(shared, 220 * 4096);
+        assert_eq!(resident - shared, 80 * 4096);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn host_meminfo_uses_available_not_free_memory() {
+        let sample = "MemTotal:       16384000 kB\n\
+                      MemFree:          100000 kB\n\
+                      MemAvailable:    4096000 kB\n";
+        let stats = parse_host_meminfo(sample).expect("parse meminfo");
+        assert_eq!(stats.total_bytes, 16_384_000 * 1024);
+        assert_eq!(stats.available_bytes, 4_096_000 * 1024);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn process_memory_stats_samples_self() {
+        let stats = process_memory_stats(std::process::id() as Pid)
+            .expect("memory stats must sample the current process");
+        assert!(stats.rss_bytes > 0);
+        if let Some(pss) = stats.pss_bytes {
+            assert!(pss <= stats.rss_bytes);
+        }
     }
 
     /// A PID that does not exist must yield None, not a bogus sample.


### PR DESCRIPTION
Keeps active fan-out pages shared, enables permission-scoped demand paging, reports proportional memory, and rejects unsafe branch admission before capture.