### PR TITLE
[Agent Experience] Add skill packets: install, teardown, sandbox, plus agent discovery instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,53 @@ smolvm machine create --name myvm --image ./myapp.tar     # persistent, from a l
 - **`machine create --from .smolmachine`** — creates a persistent named machine from a packed artifact. Boots from pre-extracted layers (~250ms, no image pull). Full `machine exec` persistence — package installs, file writes all survive across exec and stop/start.
 - **Memory-backed paths** — `/tmp`, `/run`, and `/dev/shm` are tmpfs regardless of the mode above. They keep their contents while the machine runs, including across `exec` sessions, but are empty again after a stop and start. `/workspace` and the rest of the machine filesystem are on the storage disk, so write anything that must outlive a restart there — including credentials and configuration, which should not sit in `/tmp` or behind a symlink into it.
 
+## Skills
+
+Task-scoped procedures for this CLI, one directory per use case under `skills/`. Each was run end
+to end on a published release; each says which steps were not.
+
+| Task | Packet | Its preflight checks | Not for |
+|------|--------|----------------------|---------|
+| Install smolvm and prove the host boots a VM | `install` | version, platform, KVM or `kern.hv_support`, macOS socket path length, Intel Mac stated unverified | anything after the first boot |
+| Stop everything and remove smolvm's state | `teardown` | every state directory with its size, image caches, `PATH` block, whether state can be relocated | deleting machines another session created |
+| Run untrusted code, no network, repo read-only | `sandbox` | as install, plus mounts plus ports against the device budget, and whether the offline shape works here | a machine you re-enter; anything needing state to survive |
+
+More packets follow with the same shape: a persistent dev environment, the local HTTP API, Docker
+inside a machine, and CUDA against a host GPU.
+
+Each directory holds `SKILL.md` (the procedure), `scripts/` (preflight, the lifecycle, cleanup) and
+`references/` (traps and per-platform arms, read when the situation calls for them). Scripts are
+wrappers over this CLI: they edit no configuration, escalate no privilege, and delete only machines
+they created. They are plain `bash` and assume nothing about which agent, if any, is driving them.
+
+### Finding them
+
+`skills/` is the home. The format is a `SKILL.md` per directory with `name` (matching the directory
+name) and `description` frontmatter, which is what current agents read.
+
+An agent with no skill discovery needs nothing: read `skills/<name>/SKILL.md` when the task matches
+its description.
+
+An agent that scans a fixed path needs `skills/` linked to that path, which is a local choice and
+is deliberately not committed here. The paths known at the time of writing, each from that agent's
+own documentation, read 2026-09-08:
+
+| Agent | Project path | Notes |
+|---|---|---|
+| Claude Code | `.claude/skills/<name>/SKILL.md` | also `~/.claude/skills` for personal skills |
+| OpenCode | `.opencode/skills/<name>/SKILL.md` | also accepts `.claude/skills` and the cross-agent `.agents/skills`, walking up to the git worktree root |
+
+```bash
+# Expose them to an agent that scans .claude/skills, once, locally:
+mkdir -p .claude && ln -s ../skills .claude/skills
+```
+
+Check the agent's own documentation before trusting a path here; discovery conventions are young
+and move.
+
+`AGENTS.md` is how to work in this repository and is always in context. A `SKILL.md` is how to
+accomplish one task with the product, and loads only when that task comes up.
+
 ## CLI Structure
 
 All commands use named flags (no positional args except `machine create --name NAME` and `machine delete --name NAME`).

--- a/README.md
+++ b/README.md
@@ -346,7 +346,6 @@ ANGLE (Intel, Vulkan 1.4 (Virtio-GPU Venus (Intel(R) UHD Graphics ...)), venus)
 |--------|----------|
 | Alpine | `apk add virglrenderer mesa-vulkan-intel` (or `mesa-vulkan-ati` for AMD) |
 | Debian/Ubuntu | `apt install virglrenderer0 mesa-vulkan-drivers` |
-| Nix / NixOS | the flake does not put virglrenderer on the loader path; export `LD_LIBRARY_PATH` with the nixpkgs `virglrenderer` and `libepoxy` lib dirs (and `/run/opengl-driver/lib` on NixOS), see the [GPU page](https://smolmachines.com/docs/introduction/concepts/gpu) |
 
 > virglrenderer depends on libEGL and libdrm from the host GPU driver stack. These are hardware-specific and cannot be bundled. Any GPU-capable Linux host will already have them installed via its GPU driver.
 
@@ -401,6 +400,12 @@ The user documentation at [smolmachines.com/docs](https://smolmachines.com/docs/
 welcome there. It is Markdown only, with no build to run; its
 [CONTRIBUTING.md](https://github.com/smol-machines/docs/blob/main/CONTRIBUTING.md) covers the
 page format and how a change reaches the site.
+
+Task-scoped procedures for agents and scripts live in [`skills/`](skills/), one directory per use
+case: `install`, `teardown` and `sandbox`, with more to follow. Each carries a preflight script,
+the lifecycle commands, a cleanup that reaps what it started, and the traps that cost real time.
+[`AGENTS.md`](AGENTS.md#skills) has the table of which packet answers which task, and how an agent
+finds them.
 
 Bugs and feature requests for the runtime stay here.
 

--- a/skills/install/SKILL.md
+++ b/skills/install/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: install
+description: Installs smolvm from a published release and proves the host can actually boot a microVM before any other work starts. Use when setting smolvm up on a new machine, a CI runner or an agent sandbox; when a first boot fails with krun_start_enter -22, KVM_DENIED or "agent did not become ready"; when checking whether a host meets smolvm's requirements at all; or when an install has to be isolated from an existing one and then removed. Do not use it to remove an existing install (see the teardown packet) or for anything after the first boot has succeeded.
+---
+
+# Installing smolvm and proving it works
+
+Verified on **smolvm v1.14.6** on macOS arm64 and Linux aarch64, 2026-09-10. Done means `smolvm --version` prints the release version **and**
+a throwaway VM has run one command and exited. A version number alone proves nothing: on every
+platform here there is at least one way for the install to succeed and every VM start to fail.
+
+`scripts/preflight.sh` reports the host as `key=value` lines and ends with `result=ready` or
+`result=blocked`. Run it first, and run it again after the install if the first boot fails.
+
+## Procedure
+
+**1. Preflight.** Read-only. It starts no VM and writes no smolvm state.
+
+```bash
+scripts/preflight.sh
+```
+
+Stop on `result=blocked` and read the `note=` lines. The two that block a fresh host are
+`accel_access=denied` on Linux (your user cannot open `/dev/kvm`) and `socket_path_status=too_long`
+on macOS (the install path is too deep for a VM's Unix socket). Both have a fix in
+`references/traps.md`, and neither announces itself later: the installer warns about KVM and
+continues, and the path limit surfaces as an error about disks.
+
+**2. Install from the published release.**
+
+```bash
+curl -sSL https://smolmachines.com/install.sh | bash -s -- --version 1.14.6
+export PATH="$HOME/.local/bin:$PATH"
+smolvm --version
+```
+
+On macOS two `warning:` lines about notarization appear on every install and are not a problem.
+On Linux `info: KVM access verified` appears only when your user can already open `/dev/kvm`.
+
+To install without touching an existing one, point `HOME` at a scratch directory: every path
+smolvm uses moves with it on macOS and Linux. Keep that directory shallow on macOS. This does not
+work on Windows, where state cannot be relocated at all. See `references/layout.md`.
+
+Windows does not use this installer. See `references/windows.md`.
+
+**3. Prove it boots.** This is the step that decides whether smolvm works here.
+
+```bash
+scripts/verify-boot.sh
+```
+
+It runs one ephemeral alpine VM and asserts two values: a marker the guest printed, and that the
+guest kernel is not the host's. On failure it prints the three misreadings that cost the most
+time, before you clean up and lose the evidence.
+
+**4. Clean up.**
+
+```bash
+scripts/cleanup.sh
+```
+
+It waits before asserting an empty machine list, because a successful `machine run` returns
+before its entry retires and an immediate assertion fails on a healthy host. It then reports VM
+processes an interrupt left behind, and kills them only with `--reap`.
+
+## What the preflight reports
+
+| key | meaning |
+|---|---|
+| `smolvm_installed`, `smolvm_version` | whether the binary is on `PATH` and what it says |
+| `verified_version`, `version_status` | `match`, `newer`, `older` or `unknown` against the 1.14.6 this packet was verified on |
+| `platform` | `darwin-aarch64`, `linux-aarch64`, `linux-x86_64` |
+| `accel`, `accel_access` | `hvf` and `kern.hv_support`, or `kvm` and whether `/dev/kvm` is readable and writable |
+| `macos_version`, `hardware_verified` | `hardware_verified=no` on an Intel Mac: the installer accepts it and nothing here was run on one |
+| `socket_path_bytes`, `socket_path_status` | macOS only, and the single most common cause of "macOS is broken" |
+| `unsupported` | features this platform does not have |
+| `result` | `ready` or `blocked` |
+
+`version_status=newer` is a warning, not a failure. smolvm's flags and messages move every
+release, so on a newer binary check each step's output against the binary before trusting the
+text here.
+
+## Security defaults, and why they are the defaults
+
+- **The installer is a user-level install and needs no root.** Everything lands under `$HOME`,
+  which is what lets an agent or a CI job install a private copy and remove it without a
+  privileged step. Nothing in this packet escalates privilege.
+- **`sudo usermod -aG kvm` is the one privileged step, and it is yours to run.** Group membership
+  on `/dev/kvm` is the host's boundary between users who can start VMs and users who cannot, so a
+  script should report `accel_access=denied` and stop rather than widen it for you. `sg kvm -c`
+  then applies the group to a single command instead of your whole session.
+- **The uninstaller leaves `~/.config/smolvm` and your `PATH` line on purpose.** Those hold
+  registry credentials and a change you made to your own shell profile, so removing them is a
+  separate, deliberate act. `references/layout.md` has both commands.
+
+## Platform arms
+
+- **macOS arm64**: verified. The path-length rule in `references/traps.md` applies to every install.
+- **Linux aarch64 and x86_64**: verified. The `kvm` group check applies to every fresh host.
+- **Intel Mac**: **unverified.** The installer accepts macOS 11 or later on Intel and nothing in
+  the material behind this packet was run on one. `preflight.sh` reports `hardware_verified=no`
+  there rather than implying it works.
+- **Windows x86_64**: `references/windows.md`, **re-run on 2026-09-11 against v1.14.6** on
+  Windows 11 Home build 10.0.26200.0 UBR 9445, where it confirmed. The
+  three facts that break a Unix-shaped script are there: the zip unpacks into a nested versioned
+  folder, state lives in `%LOCALAPPDATA%\smolvm` and cannot be moved, and a script must never
+  capture `machine start` output because it never returns.
+
+## Eval prompts, and what they produced
+
+Run against this packet on 2026-09-07 PT, on smolvm v1.14.2 installed from the published release
+into an isolated `HOME`. Output is verbatim.
+
+**1. "Install smolvm on this machine and tell me whether it can actually run a VM."**
+
+macOS 26.6.2 arm64:
+
+```
+smolvm_installed=yes
+smolvm_version=1.14.2
+version_status=match
+platform=darwin-aarch64
+accel=hvf
+accel_access=ok
+socket_path_bytes=62
+socket_path_status=ok
+result=ready
+
+  BOOTED_OK
+  Linux 6.12.95 aarch64
+guest_ran=yes
+guest_kernel=Linux 6.12.95
+host_kernel=Darwin 25.6.0
+is_a_vm=yes
+result=boot_ok
+```
+
+Lima `linux-kvm`, Ubuntu 24.04 aarch64:
+
+```
+platform=linux-aarch64
+accel=kvm
+accel_access=ok
+result=ready
+
+  BOOTED_OK
+  Linux 6.12.95 aarch64
+guest_kernel=Linux 6.12.95
+host_kernel=Linux 6.8.0-139-generic
+is_a_vm=yes
+result=boot_ok
+```
+
+Boot plus image pull took 8.9 s on macOS and 22.4 s on the nested-virt Linux box.
+
+**2. "smolvm is installed but every `machine run` fails with `krun_start_enter returned: -22`.
+What is wrong?"**
+
+Reproduced deliberately on macOS by installing into a 49-character `HOME`. The preflight names
+the cause before any VM is started:
+
+```
+socket_path_bytes=104
+socket_path_status=too_long
+note=HOME is too deep: every VM start will fail with krun_start_enter -22, whose text blames disks and device options. Install under a shorter HOME.
+result=blocked
+```
+
+and the boot then fails exactly as reported, with the misleading text:
+
+```
+Error: agent operation failed: start machine: agent operation failed: monitor agent:
+agent operation failed: start vm: krun_start_enter returned: -22 (EINVAL ... libkrun
+rejected the VM configuration; usually a disk/overlay that could not be opened ... or an
+unsupported device option) (boot process exited (code 1) before the agent was ready)
+guest_ran=no
+is_a_vm=no
+result=boot_failed
+```
+
+**3. "Set up smolvm somewhere throwaway so it does not touch my existing install, then remove
+it."**
+
+Both isolated installs in this session ran under a scratch `HOME` and the uninstaller then
+reported every path removed, with `find "$HOME" -iname '*smolvm*'` empty afterwards:
+
+```
+success: Removed <HOME>/.smolvm
+success: Removed symlink <HOME>/.local/bin/smolvm
+success: Removed data directory <HOME>/Library/Application Support/smolvm
+success: Removed cache directory <HOME>/Library/Caches/smolvm
+warning: You may want to remove the PATH entry from your shell profile.
+success: smolvm has been uninstalled
+```
+
+## Re-verified on v1.14.6
+
+Run 2026-09-10 PT against v1.14.6 from the published release, into a fresh isolated `HOME` on
+macOS 26.6.2 arm64 and Lima `linux-kvm` (Ubuntu 24.04 aarch64). Both hosts: `result=ready`, then
+`guest_ran=yes`, `guest_kernel=Linux 6.12.95`, `is_a_vm=yes`, `result=boot_ok`, and a clean
+cleanup. The guest kernel is unchanged across 1.14.2, 1.14.3 and 1.14.6.
+
+## What was not run
+
+- **Intel Mac.** Nothing.
+- **Windows.** `references/windows.md` records a run on Windows 11 Home build 26200 that was not
+  repeated here. No PowerShell script ships with this packet for that reason.
+- **The unprivileged Windows symlink path.** The Windows preflight check for Developer Mode or
+  `SeCreateSymbolicLinkPrivilege` is written from reading the release's extraction path and from a
+  session that already held the privilege. The failure it guards against has been reported from
+  outside and reproduced by forcing the state, but the unprivileged install itself has not been
+  run by anyone here.
+- **Linux x86_64** was verified for install and boot in the material behind this packet, on a
+  cloud GPU instance that no longer exists. The scripts here were re-run on macOS arm64 and Linux
+  aarch64 only.
+
+## Related packets
+
+- `teardown` for the full removal sequence, and for what a leak check must exclude.
+- `sandbox` for running untrusted work in a throwaway machine, which assumes this boot.

--- a/skills/install/references/layout.md
+++ b/skills/install/references/layout.md
@@ -1,0 +1,78 @@
+# What the install lays down, how to upgrade, and how to remove it
+
+Observed on macOS arm64, Linux aarch64 and Linux x86_64 on v1.14.2.
+
+## Layout
+
+| | macOS | Linux |
+|---|---|---|
+| install prefix (wrapper, `smolvm-bin`, `lib/`, `.version`, disk templates) | `$HOME/.smolvm` | `$HOME/.smolvm` |
+| launcher symlink | `$HOME/.local/bin/smolvm` | `$HOME/.local/bin/smolvm` |
+| agent rootfs | `$HOME/Library/Application Support/smolvm` | `$HOME/.local/share/smolvm` |
+| per-VM state | `$HOME/Library/Caches/smolvm/vms` | `$HOME/.cache/smolvm/vms` |
+| image cache, once `--oci-cache` has run | `.../smolvm/vms/_shared` | `.../smolvm/vms/_shared` |
+| pack cache | `$HOME/Library/Caches/smolvm-pack` | `$HOME/.cache/smolvm-pack` |
+| packed-binary lib cache | `$HOME/Library/Caches/smolvm-libs` | `$HOME/.cache/smolvm-libs` |
+| registry credentials | `$HOME/.config/smolvm` | `$HOME/.config/smolvm` |
+| `PATH` block | your shell profile | your shell profile |
+
+The last three are the ones people miss. `smolvm-libs` appears only once a packed `.smolmachine`
+stub has run, and the last two are deliberately not removed by the uninstaller.
+
+Disk: about 120 MB for the install itself. The first VM then creates sparse disks with 20 GiB
+storage and 10 GiB overlay **apparent** size; actual usage after one run was 18 MB.
+
+## Isolating a test install
+
+On macOS and Linux, running the installer with `HOME` pointed at a scratch directory puts every
+path above inside it, which is how the runs behind this packet avoided touching a real
+installation. Keep that directory shallow on macOS or you will hit the socket path limit in
+`references/traps.md`.
+
+```bash
+curl -sSL https://smolmachines.com/install.sh | HOME=/tmp/sk bash -s -- --version 1.14.2
+HOME=/tmp/sk /tmp/sk/.local/bin/smolvm --version
+```
+
+This does not work on Windows: state there cannot be relocated at all. See
+`references/windows.md`.
+
+## Upgrade
+
+The same installer with a newer `--version`. Upgrading 1.14.1 to 1.14.2 printed
+`info: Upgrading from 1.14.1 to 1.14.2` and correctly removed the stale expanded disk templates
+the older release had left behind.
+
+## Uninstall
+
+```bash
+curl -sSL https://smolmachines.com/install.sh | bash -s -- --uninstall
+```
+
+Verified complete on macOS against an isolated `HOME` that had been used for a full session of
+machines, packs and `--oci-cache` runs: afterwards `find "$HOME" -iname '*smolvm*'` returned
+nothing. It removes the prefix, the symlink, the data directory, the cache directory, the pack
+cache and `smolvm-libs`, and warns about the two things it leaves: the `PATH` block in your shell
+profile, and `~/.config/smolvm`.
+
+The `--uninstall` flag is documented only in `scripts/install.sh --help`, not in the README or on
+the docs site. The full removal sequence, including the Kubernetes runtime and the Windows tree,
+is the `teardown` packet.
+
+## Where the docs and the release disagree, at v1.14.2
+
+Checked while running this procedure. Each of these will send you somewhere the release does not
+go:
+
+- `README.md` Install says to "download from GitHub Releases, and place it into
+  `~/.local/share/`". The installer places the prefix in `$HOME/.smolvm`; only the agent rootfs
+  goes to a data directory.
+- `scripts/install.sh` and `README.md` describe a unified `smol` CLI. No v1.14.2 tarball
+  (darwin-arm64, linux-arm64, linux-x86_64) contains `smol` or `smol-bin`, so that branch never
+  fires and no `smol` command is installed.
+- `scripts/install.sh` calls `init.krun` "(Linux only, required by libkrunfw kernel)". The
+  linux-arm64 tarball contains none, the installer skips it silently, and VMs boot anyway.
+- `smolvm machine --help` describes `images` as "List cached images and storage usage", but
+  `machine images` requires `--name` and reports one machine's images. There is no command that
+  lists what `--oci-cache` has baked.
+- Nothing anywhere mentions the macOS path-length limit.

--- a/skills/install/references/traps.md
+++ b/skills/install/references/traps.md
@@ -1,0 +1,116 @@
+# Install traps, and what each misleading message actually means
+
+## Contents
+
+- `krun_start_enter returned: -22 (EINVAL ...)` on macOS
+- `KVM_DENIED` on a fresh Linux box
+- `agent did not become ready within 30 seconds`
+- `machine list` shows a just-finished VM as `unreachable (eph)`
+- The boot subprocess hides its own errors
+- `DYLD_PRINT_LIBRARIES` prints nothing on macOS
+- Two assertion habits that apply beyond install
+
+Each entry is "if you see X, it means Y". Every one of these was hit on a real host during the
+runs this packet is built from, and each cost time because the message points somewhere else.
+
+## `krun_start_enter returned: -22 (EINVAL ...)` on macOS
+
+**It means your install path is too long.** The error text blames disks and device options and
+is wholly misleading.
+
+A VM's agent socket is `$HOME/Library/Caches/smolvm/vms/<16 hex>/agent.sock`. macOS
+`sockaddr_un.sun_path` holds 104 bytes including the terminator, so once `$HOME` is deep enough
+the socket path no longer fits and **every** VM start fails immediately. Measured by installing
+into `$HOME` directories of increasing length:
+
+| socket path bytes | result |
+|---|---|
+| 100 | boots |
+| 102 | `-22` |
+| 104 | `-22` |
+| 106 | `-22` |
+
+`scripts/preflight.sh` computes that path and reports `socket_path_bytes` and
+`socket_path_status` before you install anything.
+
+This is the single most expensive trap in the material behind this packet: it cost most of a
+session and produced a false "macOS is broken" conclusion. Everything else was ruled out by
+running it. The same release boots from a short `$HOME` on the same machine; v1.14.1, v1.13.0 and
+v1.11.0 all fail identically at a long path, so it is not a regression; the installed binary
+matches the tarball byte for byte; `kern.hv_support` is 1; and an ad-hoc-signed C program linking
+the release's own `libkrun.dylib` runs a VM to completion and accepts smolvm's own `storage.raw`
+and `overlay.raw`.
+
+**A CI job or an agent harness that installs under a deep temporary directory will hit this and
+will not be able to tell why.** Nothing in the README or the installer mentions a path-length
+limit.
+
+## `KVM_DENIED` on a fresh Linux box
+
+**It means your user is not in the `kvm` group, and the install said nothing about it.** The
+installer warns and then continues when `/dev/kvm` is inaccessible, so a successful install says
+nothing about whether a VM will start. This was the out-of-the-box state on a fresh cloud GPU
+instance.
+
+The installer tells you to log out and back in. You do not have to:
+
+```bash
+sudo usermod -aG kvm "$USER"
+sg kvm -c 'smolvm machine run --mem 2048 --net --image alpine -- echo OK'
+```
+
+`sg kvm -c '<command>'` (or `newgrp kvm`) applies the new group to a single command immediately,
+which is what you want over SSH or inside a script.
+
+## `agent did not become ready within 30 seconds`
+
+**Suspect host load before you suspect the install.** This was reproduced on both macOS and a
+nested-virt Linux box purely by running other VMs at the same time, and the identical command
+passed on a quiet host seconds later.
+
+The 30 s limit is a hard-coded constant (`src/agent/manager.rs`, `AGENT_READY_TIMEOUT`) and
+**there is no flag or environment variable that raises it** for `machine run` or `machine start`.
+`SMOLVM_AGENT_READY_TIMEOUT_SECS` exists but is read only by `pack run`.
+
+## `machine list` shows your just-finished VM as `unreachable (eph)`
+
+**Nothing is wrong.** The entry retires asynchronously after the run returns; observed gone by
+20 s. A cleanup assertion that runs immediately after `machine run` fails on a healthy system,
+which is why `scripts/cleanup.sh` waits before asserting.
+
+## The boot subprocess hides its own errors
+
+The child's stdout and stderr go to `/dev/null` unless `SMOLVM_BOOT_DEBUG=1`, and even that
+showed nothing useful. To see the real failure, run the child yourself:
+
+```bash
+smolvm-bin _boot-vm <vm-dir>/boot-config.json
+```
+
+That is how the vCPU panics behind the macOS `-22` were finally read. **The child deletes its own
+`boot-config.json` on exit**, so copy it while a start is in flight if you want to re-run it.
+`RUST_LOG=debug` on the CLI shows the disk-template and boot timeline, which separates a template
+problem from a hypervisor problem.
+
+## `DYLD_PRINT_LIBRARIES` prints nothing on macOS
+
+**Do not conclude anything from it.** `smolvm-bin` carries entitlements, so dyld strips `DYLD_*`
+from its environment. The binary finds its libraries through `@executable_path/lib` regardless,
+so the stripping is harmless and tells you nothing about a library problem.
+
+## Two assertion habits that apply beyond install
+
+- **Assert values, never exit codes.** A pack that lost its rootfs still boots and exits zero; a
+  guest command that fails still returns HTTP 200 from the local API; a CUDA program can link and
+  exit zero without ever reaching a GPU. `scripts/verify-boot.sh` asserts a marker the guest
+  printed and that the guest kernel differs from the host's, for this reason.
+- **Find leftover VMs by argv, not by `pgrep -f _boot-vm` and not by `readlink /proc/<pid>/exe`.**
+  The pattern form matches any shell whose text contains that string, including the cleanup script
+  itself, and it produced a phantom "1 orphan survived" result in the runs behind this packet.
+  **The `/proc/<pid>/exe` route then fails for a different reason**: the VM process is not
+  dumpable, so its `/proc/<pid>/exe` is root-owned and `readlink` returns `Permission denied` to
+  the very user who started it, leaving a reaper that reports "no orphans" while an orphan runs.
+  Both were observed on Ubuntu 24.04 aarch64 on 2026-09-07. `scripts/cleanup.sh` reads
+  `/proc/<pid>/cmdline` and requires `argv[1]` to be exactly `_boot-vm`, which a shell cannot
+  match, then keeps only the processes whose boot config lives under this `HOME`'s smolvm state so
+  another session's VM is left alone. On macOS the same test runs over `ps -axo pid=,command=`.

--- a/skills/install/references/windows.md
+++ b/skills/install/references/windows.md
@@ -1,0 +1,168 @@
+# Installing smolvm on Windows
+
+## Contents
+
+- Preflight, before anything is downloaded
+- Install from the zip
+- Prove the boot
+- State, and what you cannot move
+- The trap that breaks every script: captured output never returns
+- When a boot fails, read the guest console before cleaning up
+- Other Windows behaviour worth knowing at install time
+
+**Re-run on 2026-09-11 against smolvm v1.14.6** on Windows 11 Home build 10.0.26200.0 UBR 9445
+x86_64 (Intel Core Ultra 9 185H, 31.6 GB), in an elevated session with Developer Mode off.
+Everything below confirmed; only the release version and the zip's size and hash changed. The
+outputs are reproduced verbatim. Treat it as a record of a run, not as a promise about your host.
+
+Not covered at all: Windows 10, Windows Server, non-admin users, WSL2 as a host.
+
+`scripts/preflight.sh` reports `result=blocked` on Windows and points here. This packet ships no
+PowerShell script, because a script nobody has executed is worse than a procedure somebody has.
+
+## 1. Preflight, before anything is downloaded
+
+All read-only.
+
+```powershell
+[Environment]::OSVersion
+(Get-CimInstance Win32_OperatingSystem).Caption
+Get-WindowsOptionalFeature -Online -FeatureName HypervisorPlatform | Select-Object State
+```
+
+`State : Enabled` is the gate. The Windows Hypervisor Platform is available on Windows 11
+**Home**, unlike Hyper-V: `Microsoft-Hyper-V-All` returned no state on the tested host while
+`HypervisorPlatform` was `Enabled`. Enabling WHP is a system change and needs a reboot.
+
+**Also check symlink creation before the first run.** The agent rootfs ships as a tarball on
+Windows and its extraction drops symlinks silently without the privilege, after which the guest
+cannot exec `/sbin/init` and the boot ends as `boot process exited (code 127)`. The tolerant
+extraction path that lets a failed extraction be marked complete still exists at v1.14.6
+(`src/agent/manager.rs`), so the check is worth making rather than discovering afterwards. The
+re-run above was an elevated session with Developer Mode off, so it did not exercise the
+unprivileged path either.
+
+```powershell
+# Either of these is enough. Developer Mode is the one a non-admin user can turn on.
+(Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock' `
+  -Name AllowDevelopmentWithoutDevLicense -EA SilentlyContinue).AllowDevelopmentWithoutDevLicense
+whoami /priv | Select-String SeCreateSymbolicLinkPrivilege
+```
+
+`1` from the first, or a line from the second, means extraction will keep its symlinks. Neither
+was verified on an unprivileged shell: the tested host's SSH session was elevated and already
+held `SeCreateSymbolicLinkPrivilege`, so 389 reparse points extracted cleanly there and the
+unprivileged path could not be exercised.
+
+## 2. Install from the zip
+
+Windows does not use `install.sh`.
+
+```powershell
+Invoke-WebRequest -Uri 'https://github.com/smol-machines/smolvm/releases/download/v1.14.6/smolvm-1.14.6-windows-x86_64.zip' -OutFile "$dir\smolvm.zip"
+Invoke-WebRequest -Uri 'https://github.com/smol-machines/smolvm/releases/download/v1.14.6/checksums.sha256' -OutFile "$dir\checksums.sha256"
+(Get-FileHash -Algorithm SHA256 -LiteralPath "$dir\smolvm.zip").Hash
+Expand-Archive -LiteralPath "$dir\smolvm.zip" -DestinationPath "$dir\dist"
+```
+
+Observed: 40104648 bytes, SHA256
+`70105f035cf4b566c1abbb026ac113b7157f5000d26a1466bbdf4966e06b6b10`, matching the release
+checksums exactly.
+
+**The zip contains a nested versioned folder.** The exe is at
+`dist\smolvm-1.14.6-windows-x86_64\smolvm.exe`, not `dist\smolvm.exe`. A script that assumes the
+flat layout fails here, and the failure looks like a bad download.
+
+```powershell
+& "$dir\dist\smolvm-1.14.6-windows-x86_64\smolvm.exe" --version   # smolvm 1.14.6
+```
+
+## 3. Prove the boot
+
+```powershell
+& $exe machine run --net --image alpine -- sh -c "echo HELLO_FROM_WINDOWS; uname -srm"
+```
+
+Observed, including the image pull:
+
+```
+Starting ephemeral machine (vm-f0d4c640)...
+Pulling image alpine... done.
+HELLO_FROM_WINDOWS
+Linux 6.12.95 x86_64
+```
+
+Native Windows runs x86_64 Linux guests. The guest kernel differs from the host, which is the
+assertion that proves it is a VM.
+
+## 4. State, and what you cannot move
+
+smolvm writes to `%LOCALAPPDATA%\smolvm` (`server\`, `rootfs\`, `vms\`). **You cannot relocate
+it.** There is no `SMOLVM_DATA_DIR` in the Windows binary, and pointing `$env:LOCALAPPDATA` at a
+scratch directory changed nothing: smolvm still created `C:\Users\<user>\AppData\Local\smolvm`,
+because it resolves the known folder through the Windows API, which ignores the variable.
+
+Two consequences. There is no isolated-HOME trick for testing on Windows, so a test run writes
+into the real profile. And teardown has to remove that tree by hand: it reached **30756 MB** in
+one session, since each machine's storage and overlay images are sparse files with 20 GiB and
+10 GiB apparent size. See the `teardown` packet.
+
+`machine list` is not read-only either: it creates the state directory and `server\smolvm.db`.
+
+## 5. The trap that breaks every script: captured output never returns
+
+`machine start` leaves the VM running as a background `smolvm.exe _boot-vm` child that inherits
+the parent's stdout handle. Any caller that **captures** that output waits for the handle to
+close, which happens only when the VM dies.
+
+| invocation | result |
+|---|---|
+| `& $exe machine start --name X 2>&1 \| Out-String` | still blocked after 90 s, while `machine list` showed the machine `running` |
+| `cmd /c "smolvm.exe machine start ... > out.txt 2>&1"` | also blocks, though the file already shows `Machine 'X' running (PID ...)` |
+| `Start-Process -RedirectStandardOutput out.txt -PassThru`, poll `HasExited` | returns in 4.9 s |
+
+The command itself is fast and correct. The shell is what hangs, and it cost about an hour on the
+tested host and produced two wrong conclusions before it was found: `machine branch` and
+`machine checkpoint` both looked like indefinite hangs when the `machine start` before them was
+what blocked, and neither had run at all.
+
+The pattern that works:
+
+```powershell
+$p = Start-Process -FilePath $exe -ArgumentList @('machine','start','--name','X') `
+     -RedirectStandardOutput out.txt -RedirectStandardError err.txt -WindowStyle Hidden -PassThru
+while (-not $p.HasExited) { Start-Sleep -Milliseconds 400 }
+Get-Content out.txt
+```
+
+One caveat on that pattern: `-ArgumentList` applies its own quoting and mangles nested shell
+quoting such as `-- sh -c "echo $(id -un)"`. For `exec` commands containing quotes, `cmd /c` with
+file redirection is correct and does not block, because `exec` leaves no new background VM.
+
+## 6. When a boot fails, read the guest console before cleaning up
+
+Since v1.14.0 the guest console is written to
+`%LOCALAPPDATA%\smolvm\vms\<hash>\agent-console.log`, beside `agent-startup-error.log`. It holds
+the real reason (`Couldn't execute '/sbin/init': ENOENT` when the rootfs extraction is broken)
+while the CLI prints only `boot process exited (code 127)`. Nothing surfaces it for you.
+
+**It exists only while the VM directory does**, so read it after the failure and before any
+cleanup step removes the directory.
+
+```powershell
+Get-Content "$env:LOCALAPPDATA\smolvm\vms\<hash>\agent-console.log" -Tail 40
+```
+
+## 7. Other Windows behaviour worth knowing at install time
+
+- **PowerShell turns the exe's stderr into error records.** A fully successful run prints
+  `smolvm.exe : Starting ephemeral machine (...)` followed by `NativeCommandError`. The command
+  succeeded and `$LASTEXITCODE` is 0. Do not set `$ErrorActionPreference = 'Stop'` around a
+  smolvm call, and do not read red text as failure.
+- **Device ceiling on WHP.** Four `-v` mounts boot; five fail with `no more IRQs are available`.
+  Any `-p` costs one of those slots, so four mounts plus two ports fails while two plus two boots.
+- **Path length was not a problem** in the paths this run exercised: a volume mount from a
+  237-character directory worked and nothing broke approaching 260 characters.
+- **The rest of the platform picture.** `--net` gives a real `eth0` with inbound port-forwarding,
+  and `--cuda` reaches a real NVIDIA GPU. Vulkan (`--gpu`) is accepted and silently does nothing.
+  Two of those three contradict the caveats this release ships with.

--- a/skills/install/scripts/cleanup.sh
+++ b/skills/install/scripts/cleanup.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Delete the machines this packet's scripts created, then prove the host is clean.
+#
+# Only machines recorded in the state file are deleted, so a machine you or
+# another session created by hand is never touched. Scripts record a name by
+# calling: cleanup.sh --record <name>
+#
+# usage: cleanup.sh [--record <name>] [--reap] [--purge]
+#   --record <name>  add a machine name to the state file and exit
+#   --reap           kill leftover VM processes (see the warning it prints)
+#   --purge          also remove the state file once the list is empty
+
+set -uo pipefail
+
+PACKET="install"
+PREFIX="smolskill-"
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+STATE_DIR="${SMOLVM_SKILL_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/smolvm-skills}"
+STATE_FILE="$STATE_DIR/$PACKET.machines"
+
+reap=0
+purge=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --record)
+            mkdir -p "$STATE_DIR"
+            printf '%s\n' "$2" >> "$STATE_FILE"
+            exit 0
+            ;;
+        --reap)  reap=1 ;;
+        --purge) purge=1 ;;
+        *) printf 'unknown argument: %s\n' "$1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+if [ -z "$SMOLVM" ]; then
+    printf 'smolvm not found; set SMOLVM to its path\n' >&2
+    exit 2
+fi
+
+case "$(uname -s)" in
+    Darwin) VMS_DIR="$HOME/Library/Caches/smolvm/vms" ;;
+    *)      VMS_DIR="${SMOLVM_DATA_DIR:-$HOME/.cache/smolvm}/vms" ;;
+esac
+VMS_DIR="${SMOLVM_VMS_DIR:-$VMS_DIR}"
+SMOLVM_PREFIX="${SMOLVM_PREFIX:-$HOME/.smolvm}"
+
+# List this HOME's smolvm VM processes, as "pid marker".
+#
+# Two process shapes exist and a reaper has to catch both. The plain
+# `machine run` path EXECS a child whose argv[1] is `_boot-vm` and whose argv[2]
+# is its boot-config path. The pack-run path, which is `--oci-cache` or any
+# `init`, FORKS without execing, so the child inherits the parent's argv and
+# carries no boot-config at all. Matching `_boot-vm` alone is therefore blind to
+# exactly the path whose child survives an interrupt
+# (smol-machines/smolvm#1193): measured on v1.14.6, it reported "none" while two
+# orphaned VMs held 234 MB each.
+#
+# On Linux both shapes rename themselves to `libkrun VM`, the one marker that
+# covers both and that no shell can hold. macOS exposes no rename, so there the
+# executable path scopes the search to this HOME and the parent chain separates
+# a VM from the CLI that started it.
+#
+# `pgrep -f _boot-vm` is not an alternative: it matches any shell whose text
+# contains that string, including this script.
+list_vm_processes() {
+    case "$(uname -s)" in
+        Linux)
+            for p in /proc/[0-9]*; do
+                [ "$(cat "$p/comm" 2>/dev/null)" = "libkrun VM" ] || continue
+                pid="${p#/proc/}"
+                cfg="$(tr '\0' '\n' < "$p/cmdline" 2>/dev/null | sed -n '3p')"
+                case "$cfg" in
+                    "$VMS_DIR"/*) printf '%s %s\n' "$pid" "$cfg"; continue ;;
+                esac
+                # Forked shape: nothing in argv identifies it, so scope by the
+                # binary it is running.
+                case "$(readlink "$p/exe" 2>/dev/null)" in
+                    "$SMOLVM_PREFIX"/*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;;
+                esac
+            done
+            ;;
+        Darwin)
+            # shellcheck disable=SC2009  # pgrep cannot return ppid and the full
+            # command together, and pgrep -f matches this script's own text.
+            own=" $(ps -axo pid=,command= 2>/dev/null | grep -F "$SMOLVM_PREFIX/smolvm-bin" | awk '{print $1}' | tr '\n' ' ') "
+            ps -axo pid=,ppid=,command= 2>/dev/null | while read -r pid ppid rest; do
+                case "$rest" in "$SMOLVM_PREFIX"/smolvm-bin*) ;; *) continue ;; esac
+                case "$rest" in
+                    *" _boot-vm "*) printf '%s %s\n' "$pid" "${rest#* _boot-vm }"; continue ;;
+                esac
+                # Forked shape: its parent is the CLI that started it, or init
+                # once that CLI is gone.
+                if [ "$ppid" = 1 ]; then
+                    printf '%s orphaned-under %s\n' "$pid" "$SMOLVM_PREFIX"
+                else
+                    case "$own" in *" $ppid "*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;; esac
+                fi
+            done
+            ;;
+    esac
+}
+
+# 1. Delete recorded machines. --force is not optional: without it the command
+# prompts, defaults to No, and leaves the machine in place while the script
+# carries on. --cascade removes branch children, which otherwise block the
+# delete.
+if [ -s "$STATE_FILE" ]; then
+    while read -r name; do
+        [ -n "$name" ] || continue
+        case "$name" in "$PREFIX"*) ;; *)
+            printf 'skipping %s: not created by this packet (no %s prefix)\n' "$name" "$PREFIX"
+            continue ;;
+        esac
+        "$SMOLVM" machine stop   --name "$name" >/dev/null 2>&1
+        "$SMOLVM" machine delete --name "$name" --force --cascade 2>&1 | sed 's/^/  /'
+    done < "$STATE_FILE"
+fi
+
+# 2. An ephemeral machine's entry retires after the run returns, not with it.
+# Asserting an empty list immediately fails on a healthy host.
+sleep 20
+
+# 3. Assert the value, not the exit code.
+listing="$("$SMOLVM" machine list 2>&1)"
+if printf '%s' "$listing" | grep -q 'No machines found'; then
+    printf 'machines=clean\n'
+    [ "$purge" -eq 1 ] && rm -f "$STATE_FILE"
+else
+    printf 'machines=remaining\n'
+    printf '%s\n' "$listing" | sed 's/^/  /'
+fi
+
+# 4. Report VM processes an interrupt left behind. Ctrl-C does not stop a
+# machine: the VM outlives the CLI and `machine list` cannot see it, so this is
+# the only route to it. Only processes whose boot config lives under this HOME's
+# smolvm state are listed, so a VM another session started is left alone.
+found=0
+while read -r pid cfg; do
+    [ -n "$pid" ] || continue
+    found=1
+    printf 'vm_process=%s config=%s\n' "$pid" "$cfg"
+    if [ "$reap" -eq 1 ]; then
+        kill -9 "$pid" 2>/dev/null && printf '  killed %s\n' "$pid"
+    fi
+done <<EOF
+$(list_vm_processes)
+EOF
+
+if [ "$found" -eq 0 ]; then
+    printf 'vm_processes=none\n'
+elif [ "$reap" -eq 0 ]; then
+    printf 'rerun with --reap to kill them\n'
+fi

--- a/skills/install/scripts/preflight.sh
+++ b/skills/install/scripts/preflight.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Report whether this host can install and boot smolvm. Read-only: starts no VM,
+# writes no smolvm state, changes no group membership.
+#
+# Output is one key=value per line so a caller can parse it. The last line is
+# always result=ready or result=blocked.
+
+set -uo pipefail
+
+VERIFIED_VERSION="1.14.6"
+
+emit() { printf '%s=%s\n' "$1" "$2"; }
+
+blocked=0
+note() { printf 'note=%s\n' "$1"; }
+
+# --- the binary --------------------------------------------------------------
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+if [ -z "$SMOLVM" ]; then
+    emit smolvm_installed no
+    emit smolvm_version ""
+    blocked=1
+else
+    emit smolvm_installed yes
+    version="$("$SMOLVM" --version 2>/dev/null | awk '{print $NF}')"
+    emit smolvm_version "${version:-unknown}"
+fi
+
+emit verified_version "$VERIFIED_VERSION"
+if [ -n "${version:-}" ] && [ "$version" != "unknown" ]; then
+    if [ "$version" = "$VERIFIED_VERSION" ]; then
+        emit version_status match
+    else
+        newest="$(printf '%s\n%s\n' "$version" "$VERIFIED_VERSION" | sort -V | tail -1)"
+        if [ "$newest" = "$version" ]; then
+            emit version_status newer
+            note "this packet was verified on $VERIFIED_VERSION and the binary is $version; flags and messages move every release, so check the output against the binary before trusting a step here"
+        else
+            emit version_status older
+            note "this packet was verified on $VERIFIED_VERSION and the binary is $version"
+        fi
+    fi
+else
+    emit version_status unknown
+fi
+
+# --- platform ----------------------------------------------------------------
+
+kernel="$(uname -s)"
+arch="$(uname -m)"
+case "$arch" in aarch64|arm64) arch=aarch64 ;; esac
+
+case "$kernel" in
+    Darwin)
+        emit platform "darwin-$arch"
+        emit accel hvf
+        emit macos_version "$(sw_vers -productVersion)"
+        hv="$(sysctl -n kern.hv_support 2>/dev/null)"
+        if [ "$hv" = "1" ]; then emit accel_access ok; else emit accel_access denied; blocked=1; fi
+        if [ "$arch" != "aarch64" ]; then
+            emit hardware_verified no
+            note "Intel Mac is not verified by this packet; the installer accepts it and nothing here was run on one"
+        else
+            emit hardware_verified yes
+        fi
+        # A VM's agent socket lives under the cache directory. macOS sockaddr_un
+        # holds 104 bytes including the terminator.
+        sock="$HOME/Library/Caches/smolvm/vms/0123456789abcdef/agent.sock"
+        len=${#sock}
+        emit socket_path_bytes "$len"
+        if [ "$len" -gt 100 ]; then
+            emit socket_path_status too_long
+            blocked=1
+            note "HOME is too deep: every VM start will fail with krun_start_enter -22, whose text blames disks and device options. Install under a shorter HOME."
+        else
+            emit socket_path_status ok
+        fi
+        emit unsupported "vulkan,cuda"
+        ;;
+    Linux)
+        emit platform "linux-$arch"
+        emit accel kvm
+        emit socket_path_status n_a
+        if [ ! -e /dev/kvm ]; then
+            emit accel_access missing
+            blocked=1
+            note "/dev/kvm does not exist; this host has no KVM"
+        elif [ -r /dev/kvm ] && [ -w /dev/kvm ]; then
+            emit accel_access ok
+        else
+            emit accel_access denied
+            blocked=1
+            note "your user cannot open /dev/kvm. The installer warns and continues, so a successful install says nothing about whether a VM will start. Fix: sudo usermod -aG kvm \$USER, then run the next command through sg kvm -c '...' rather than logging out."
+        fi
+        emit unsupported "vulkan"
+        ;;
+    *)
+        emit platform "unsupported-$kernel"
+        emit accel unknown
+        emit accel_access unknown
+        blocked=1
+        note "this script covers macOS and Linux. On Windows use references/windows.md, which is written from a run and not re-run by this packet."
+        ;;
+esac
+
+if [ "$blocked" -eq 0 ]; then emit result ready; else emit result blocked; fi

--- a/skills/install/scripts/verify-boot.sh
+++ b/skills/install/scripts/verify-boot.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Prove the install can actually boot a VM. This is the step that decides
+# whether smolvm works here; `smolvm --version` printing a number does not.
+#
+# Runs one ephemeral alpine VM, asserts a marker the guest printed and that the
+# guest kernel is not the host's, then hands off to cleanup.sh.
+
+set -uo pipefail
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+if [ -z "$SMOLVM" ]; then
+    printf 'smolvm not found; set SMOLVM to its path\n' >&2
+    exit 2
+fi
+
+host_kernel="$(uname -sr)"
+marker="BOOTED_OK"
+
+out="$("$SMOLVM" machine run --mem 2048 --net --image alpine -- \
+      sh -c "echo $marker && uname -srm" 2>&1)"
+printf '%s\n' "$out" | sed 's/^/  /'
+
+fail=0
+
+# Assert the marker, not the exit code. smolvm exits zero on paths where the
+# guest never ran the command.
+if printf '%s' "$out" | grep -q "^$marker$"; then
+    printf 'guest_ran=yes\n'
+else
+    printf 'guest_ran=no\n'
+    fail=1
+fi
+
+guest_kernel="$(printf '%s' "$out" | grep -m1 '^Linux ' | awk '{print $1" "$2}')"
+printf 'guest_kernel=%s\n' "${guest_kernel:-none}"
+printf 'host_kernel=%s\n' "$host_kernel"
+if [ -n "$guest_kernel" ] && [ "$guest_kernel" != "$host_kernel" ]; then
+    printf 'is_a_vm=yes\n'
+else
+    printf 'is_a_vm=no\n'
+    fail=1
+fi
+
+if [ "$fail" -eq 0 ]; then
+    printf 'result=boot_ok\n'
+else
+    printf 'result=boot_failed\n'
+    printf 'next: read the failure before cleaning up, because the evidence is deleted with the VM directory.\n'
+    printf '  - "agent did not become ready within 30 seconds" is usually host load, not the install. The 30s limit is fixed and no flag raises it for machine run or machine start.\n'
+    printf '  - "krun_start_enter returned: -22" on macOS is almost always the socket path length, not the disks its text names. Run preflight.sh and read socket_path_status.\n'
+    printf '  - the boot child sends its own output to /dev/null. To see the real failure, copy <vm-dir>/boot-config.json while a start is in flight and run: smolvm-bin _boot-vm <copy>\n'
+fi
+
+exit "$fail"

--- a/skills/sandbox/SKILL.md
+++ b/skills/sandbox/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: sandbox
+description: Runs untrusted code in a throwaway smolvm microVM against a repo it must not modify, with no network unless explicitly granted, and collects artifacts from a writable output directory. Use when executing an agent's generated script, a pull request's test suite, or any code that should not be trusted with the host; when a workload needs egress granted one host at a time; or when a sandbox run has to be cancelled, because Ctrl-C leaves the VM running and invisible to the CLI. Do not use it for a development environment that is re-entered across sessions, for running a Docker daemon inside a machine, or for installing smolvm itself, which is the install packet.
+---
+
+# Running untrusted work in a throwaway machine
+
+Verified on **smolvm v1.14.6** on macOS arm64 and Linux aarch64, 2026-09-10. Done means the command's output landed in your writable directory,
+the repo is unchanged, the workload could not reach the network, and nothing is left running.
+
+**Two smolvm defects shape this packet and you will meet both.**
+
+- **[#1193](https://github.com/smol-machines/smolvm/issues/1193): Ctrl-C does not stop a cached
+  run.** The VM outlives the CLI, `machine list` reports `No machines found`, and it exits only
+  when the untrusted workload does. **The cancel is `scripts/cleanup.sh --cancel`, never Ctrl-C.**
+- **[#1192](https://github.com/smol-machines/smolvm/issues/1192): on macOS a cached run with any
+  mount never boots.** The offline shape below is therefore Linux-only today. macOS has its own
+  page with a route that works: read `references/macos.md`.
+
+## Workflow
+
+```
+- [ ] 1. preflight.sh, and read result= and device_budget_ok=
+- [ ] 2. bake.sh          (offline route only; network on, nothing untrusted mounted)
+- [ ] 3. run.sh           (the untrusted command; records the VM pid)
+- [ ] 4. verify.sh        (from inside the guest and from the host)
+- [ ] 5. cleanup.sh       (or cleanup.sh --cancel to stop a run early)
+```
+
+**1. Preflight.** Read-only: starts no VM, bakes nothing.
+
+```bash
+scripts/preflight.sh --mounts 2 --ports 0
+```
+
+`device_budget_ok=no` means the boot will fail with `no more IRQs are available`. The guest has
+eleven IRQs: **four `-v` mounts boot and five do not, and every published port costs one of those
+slots**, so the budget is mounts plus ports. Combine directories under one mount rather than
+discovering this at boot.
+
+`offline_shape=unavailable` means this host cannot run the shape below. On macOS that is #1192; on
+any host it can also mean the bake helper's memory does not fit, which step 2 diagnoses.
+
+**2. Bake the image. This is the only step that talks to a registry.**
+
+```bash
+scripts/bake.sh python:3.12-alpine
+```
+
+Network on, nothing untrusted mounted, done before the untrusted code is anywhere near the machine.
+Afterwards the runs need no network at all, which is a materially stronger sandbox than granting
+egress and hoping.
+
+**3. Run the untrusted command.**
+
+```bash
+scripts/run.sh --repo ./repo --out ./out -- sh -c 'python3 /workspace/calc.py > /out/result.txt'
+```
+
+The repo is mounted read-only at `/workspace`, the output directory writable at `/out`, and the run
+has no network. It prints `used_host_cache=yes`, which is the assertion that the bake worked and
+that this run reached no registry: without it the run pulled, which means it had network, which
+means it was not the sandbox you asked for.
+
+It also prints `vm_pid=` and records it. **That pid is the only route back to the machine** if the
+run has to be stopped.
+
+To grant egress, name hosts one at a time:
+
+```bash
+scripts/run.sh --allow-host example.com --repo ./repo --out ./out -- <command>
+```
+
+**4. Verify. Both halves, because either alone passes on a broken sandbox.**
+
+```bash
+scripts/verify.sh --expect-file result.txt --expect 42
+```
+
+```
+inside_workspace=ok (readonly)
+inside_out=ok (writable)
+inside_network=ok (blocked)
+artifact=ok (42)
+repo_unchanged=ok
+result=sandbox_held
+```
+
+The inside half proves the workload could not write the repo and could not reach the network; the
+host half proves the artifact came out and the repo is unchanged. A run that merely exited zero
+tells you neither.
+
+**5. Clean up, or cancel.**
+
+```bash
+scripts/cleanup.sh --purge            # after a run finished
+scripts/cleanup.sh --cancel --purge   # to stop a run that is still going
+```
+
+`--cancel` kills exactly the VMs `run.sh` recorded and then verifies that nothing is left. It waits
+before asserting an empty machine list, because the ephemeral entry retires after the run returns
+and an immediate assertion fails on a healthy host.
+
+## Cancelling, and why Ctrl-C is not it
+
+On the offline route, interrupting the CLI leaves the VM running with no CLI route to it, and it
+exits only when the untrusted workload finishes. For code that hangs or loops that is unbounded
+exposure, with roughly 230 MB held per survivor.
+
+**The routes differ, and `references/traps.md` has the measurements.** On the plain path a `SIGINT`
+to the CLI does take the VM with it, verified here on Linux. Do not rely on that: interrupting the
+*wrapper* rather than the CLI leaves both running on either route, which was observed on both hosts
+used for this packet. Use `--cancel`.
+
+## Reference pages
+
+Read these when the situation calls for them; they are not needed for a normal run.
+
+- **`references/traps.md`** for every trap with its measurement: the two routes and what Ctrl-C does
+  to each, the bake helper's fixed memory, why `pgrep -f` and `readlink` both fail as reapers, and
+  what counts as cache rather than residue.
+- **`references/macos.md`** if you are on macOS. The offline shape does not work there; that page
+  gives a route that does and says what it costs.
+- **`references/windows.md`** if you are on Windows. The bake never completes there, so the offline
+  shape is unavailable for a different reason, and the reaper has to be broader.
+
+## Security defaults, and why they are the defaults
+
+- **No network is the default because it is the only guarantee that does not depend on the
+  workload's cooperation.** An egress policy is a filter on what untrusted code asks for; no network
+  is a property of the machine. The bake exists so that the offline run is possible at all.
+- **`--allow-host` grants one host, and the run still has a network stack.** Prefer it to `--net`,
+  but treat it as a narrower opening rather than as no opening. A denial under it looks like a DNS
+  failure, so a workload can fail confusingly rather than obviously.
+- **The repo is `:ro` because a read-only mount is enforced by the guest kernel**, not by the
+  workload's good behaviour. `verify.sh` tries to write it and asserts the write failed, then checks
+  from the host that nothing landed.
+- **The output directory is the only writable path out of the sandbox.** Keep it a directory you
+  created for this run, not a source tree, and read what lands in it before trusting it.
+- **Cleanup kills only the VMs this packet recorded.** A shared host can carry another session's
+  machines, and one was live throughout the runs behind this packet; the reaper is scoped by the
+  boot config's path and left it alone. A cleanup that kills every smolvm process is fine on your
+  laptop and destructive on a build agent.
+- **Nothing here escalates privilege**, edits smolvm configuration, or touches `~/.smolvm`. The
+  scripts are wrappers over the public CLI.
+
+## Platform arms
+
+- **Linux aarch64**: **the offline route, the network-on route, the cancel path and the reaper
+  were all run here on v1.14.6.** This is the first host on which the offline route completed.
+- **Linux x86_64**: the offline route is verified in the material behind this packet, not re-run.
+- **macOS arm64**: the offline shape is unavailable (#1192, reproduced here 3 of 3). The
+  network-on route was run end to end. `references/macos.md`.
+- **Windows x86_64**: the offline shape is unavailable for a different reason, the bake never
+  completes. `references/windows.md`, **re-run on 2026-09-11 against v1.14.6** on Windows 11 Home
+  build 10.0.26200.0 UBR 9445: the mount and the network-off refusal confirmed, and the bake still
+  did not complete inside a ten minute cap.
+
+## Eval prompts, and what they produced
+
+Run on 2026-09-08 PT against v1.14.2 from the published release, under an isolated `HOME`, on
+macOS 26.6.2 arm64 and Lima `linux-kvm` (Ubuntu 24.04 aarch64). Output is verbatim.
+
+**1. "Run this untrusted script against my repo without letting it modify the repo or reach the
+network, and get the output back."**
+
+On Linux aarch64 the **offline route** answers this directly on v1.14.6, with the network off for
+the whole run: `used_host_cache=yes`, `inside_network=ok (blocked)`, `artifact=ok (42)`,
+`repo_unchanged=ok`, `result=sandbox_held`. On macOS, where #1192 blocks that route, the
+network-on route:
+
+```
+route=network-on
+vm_pid=74421
+cli_exit=0
+
+inside_workspace=ok (readonly)
+inside_out=ok (writable)
+inside_network=ok (REACHED)
+artifact=ok (42)
+repo_unchanged=ok
+result=sandbox_held
+```
+
+`inside_network=REACHED` is the expected result on that route and the reason it is the second
+choice: the network was open for the whole run.
+
+**2. "The sandboxed job is hung. Stop it."**
+
+On Lima, a run with a `sleep 600` workload, wrapper interrupted:
+
+```
+--- recorded pid file ---
+76773 /home/<user>/skp/.cache/smolvm/vms/77196d36f7bb8555/boot-config.json
+--- VM still alive after the interrupt? ---
+STILL RUNNING 76773 ...
+--- machine list after the interrupt ---
+vm-1b3d157f running (eph)   4  2048 MiB  2  0  20 GiB  10 GiB
+=== cancel with the packet reaper ===
+cancelled=76773 config=/home/<user>/skp/.cache/smolvm/vms/77196d36f7bb8555/boot-config.json
+machines=clean
+vm_processes=none
+result=clean
+```
+
+The same on macOS, cancelling pid 82510 and ending clean.
+
+**3. "Can I sandbox on this machine?"**
+
+macOS 26.6.2 arm64, where the answer is a qualified no:
+
+```
+platform=darwin-aarch64
+accel=hypervisor_framework
+accel_access=ok
+offline_shape=unavailable
+offline_shape_blocker=smol-machines/smolvm#1192
+device_budget_ok=yes
+cancel_route=scripts/cleanup.sh --cancel
+result=blocked
+```
+
+and `bake.sh` refuses rather than baking something unusable:
+
+```
+result=unsupported_on_macos
+A baked image is only useful to a run that also mounts something, and on macOS
+--oci-cache plus any -v mount times out the boot (smol-machines/smolvm#1192).
+```
+
+## Re-verified on v1.14.6
+
+Run 2026-09-10 PT against v1.14.6 from the published release. **Two things changed on this
+release and both matter.**
+
+**The offline route now runs on Linux, for the first time on any host available to this packet.**
+On Lima `linux-kvm` (Ubuntu 24.04 aarch64) the bake completed in 59 s and the run held:
+
+```
+result=baked
+Using cached image f60a20a837dc1a34 (host cache hit; no pull)
+used_host_cache=yes
+inside_workspace=ok (readonly)
+inside_out=ok (writable)
+inside_network=ok (blocked)
+artifact=ok (42)
+repo_unchanged=ok
+result=sandbox_held
+```
+
+`inside_network=ok (blocked)` is the line the whole packet exists for: the workload reached no
+network at all. Earlier releases could not get this far on any host here.
+
+**The reaper was broken on exactly this route, and is fixed.** The pack-run path forks without
+execing, so its VM child inherits the parent's argv and carries no `_boot-vm`. Measured on
+v1.14.6 before the fix: `run.sh` reported `vm_pid=not_observed`, and after the CLI was killed
+`cleanup.sh` reported `vm_processes=none` and `result=clean` while the VM held 234 MB. After the
+fix, the same sequence reports `vm_pid=71676` and
+`vm_process=... forked-under ...` with `result=vms_still_running`, and `--cancel` clears it. See
+`references/traps.md`.
+
+**macOS is unchanged**: `--oci-cache` with any mount still times out, 3 of 3 with both controls
+passing in the same session, so the offline shape is still unavailable there and `bake.sh` still
+refuses with the reason. The network-on route held (`artifact=ok (42)`, `result=sandbox_held`) and
+the cancel path recorded and killed its VM.
+
+## What was not run
+
+- **The offline route on macOS.** Blocked by #1192, reproduced on v1.14.6 3 of 3 with both
+  controls passing. `references/macos.md` gives the route that works there and what it costs.
+  The offline route itself is now verified on Linux aarch64, so it is no longer unrun everywhere.
+- **A GPU sandbox.** Nothing here was run against a GPU on either release.
+- **The macOS first-choice route** in `references/macos.md`, which needs a `docker`, `crane`,
+  `podman` or `nerdctl` binary to produce an image archive. None is installed on that host.
+- **Windows.** One earlier run, recorded in `references/windows.md`.
+- **S3 and `:staged` mounts**, and driving the sandbox from a CI runner.
+
+## Related packets
+
+- `install` for the boot this assumes and the KVM group check.
+- `teardown` for the wider cleanup, and for what a leak check must exclude.
+- A machine whose state should survive between runs is the opposite of this packet, and is a
+  separate procedure.

--- a/skills/sandbox/references/macos.md
+++ b/skills/sandbox/references/macos.md
@@ -1,0 +1,95 @@
+# Sandboxing on macOS
+
+## Contents
+
+- Why the offline shape does not work here
+- First choice: an offline persistent machine from a local image archive
+- Second choice: the network-on route, and what it costs
+- Which of these was run
+
+## Why the offline shape does not work here
+
+The packet's default shape is bake once with `--oci-cache`, then run with the repo mounted and no
+network. **On macOS that combination never boots.** Reproduced on macOS 26.6.2 arm64 on v1.14.2,
+2026-09-08, three attempts with both controls passing in the same session:
+
+| command | result |
+|---|---|
+| `--oci-cache`, no mounts | OK |
+| mounts, no `--oci-cache` | OK |
+| `--oci-cache` + one `:ro` mount | `agent did not become ready within 30 seconds`, 3 of 3 |
+
+The bake itself is fine here: `machine run --net --oci-cache --image alpine -- true` reported
+`baked in 5s`. It is the run with a mount that fails, which is the run you actually need.
+
+This is [smol-machines/smolvm#1192](https://github.com/smol-machines/smolvm/issues/1192). The
+pack-run path forks a session leader that never execs and, when a directory mount is present,
+starts a filesystem watcher in that child; on macOS that watcher calls into CoreFoundation, and
+Apple's Objective-C runtime aborts a forked, non-exec'd child that calls into ObjC. Fork versus
+exec, not architecture, which is why the same combination is fine on Linux.
+
+`scripts/preflight.sh` reports `offline_shape=unavailable` here, and `scripts/bake.sh` refuses with
+the reason rather than baking something you cannot use.
+
+## First choice: an offline persistent machine from a local image archive
+
+This keeps the property that matters, **no network on the run at all**, by supplying the image
+locally instead of caching it. `machine create` refuses a registry image without networking and its
+message names this route itself.
+
+```bash
+# 1. Supply the image from a local archive. No registry, so no network needed.
+docker save python:3.12-alpine | smolvm machine create --name smolskill-box --image - \
+    --volume "$PWD/repo:/workspace:ro" \
+    --volume "$PWD/out:/out"
+
+# 2. Start it. Still no --net anywhere.
+smolvm machine start --name smolskill-box
+
+# 3. Run the untrusted command.
+smolvm machine exec --name smolskill-box -- sh -c 'python3 /workspace/calc.py > /out/result.txt'
+
+# 4. Cancel is `machine stop`, which works, unlike Ctrl-C on an ephemeral run.
+smolvm machine stop --name smolskill-box
+
+# 5. Delete. --force is not optional in a script.
+smolvm machine delete --name smolskill-box --force
+```
+
+The mounts go on `create`, not on `exec`. `crane export` or `podman save` produce the same archive
+if you have those instead of Docker.
+
+**Why this is the first choice:** the workload never has a network, which is the single property
+that makes the offline shape worth the trouble. And cancellation is a supported command rather than
+a reaper, because a persistent machine is visible to `machine list` and `machine stop` acts on it.
+
+**It costs you the throwaway property.** The machine persists until you delete it, so a run that
+writes outside the mounts leaves state behind for the next run to inherit. Delete between runs if
+the workload is untrusted rather than merely unknown.
+
+## Second choice: the network-on route, and what it costs
+
+```bash
+scripts/run.sh --route network-on --repo ./repo --out ./out -- <command>
+scripts/verify.sh --route network-on --expect-file result.txt --expect 42
+scripts/cleanup.sh --purge
+```
+
+Without `--oci-cache` the run pulls its own image, so **it has egress for the whole run**. Narrow
+it with `--allow-host` and the run still needs to reach the registry, so the policy has to include
+the registry hosts.
+
+**State this as the weaker sandbox rather than an equivalent one.** The offline route reaches no
+network at all; this one is open for as long as the untrusted code runs, and a policy denial in it
+looks like a DNS failure rather than a denial. `scripts/verify.sh --route network-on` asserts
+`net=REACHED` for exactly that reason: on this route the workload reaching the network is the
+expected result, and a check that asserted `blocked` would be asserting something untrue.
+
+## Which of these was run
+
+- **The second choice was run**, end to end on macOS 26.6.2 arm64 against v1.14.2 on 2026-09-08:
+  `run.sh`, `verify.sh` (all five checks), the cancel path and `cleanup.sh`.
+- **The first choice was not re-run.** It needs a `docker`, `crane`, `podman` or `nerdctl` binary to
+  produce the image archive and this host has none of them. The commands above are the route the
+  runbook names and the one `machine create`'s own error message recommends; treat them as
+  untested here.

--- a/skills/sandbox/references/traps.md
+++ b/skills/sandbox/references/traps.md
@@ -1,0 +1,150 @@
+# Sandbox traps
+
+## Contents
+
+- Ctrl-C does not stop the machine, and which route that applies to
+- Assert no machines left only after a wait
+- A network-off run that dies on the manifest means the bake was skipped
+- A blocked host looks like a DNS bug, not a policy denial
+- The bake helper ignores `--mem`
+- `machine egress-events` cannot inspect an ephemeral run
+- Counting orphans: why `pgrep -f`, `readlink` and `_boot-vm` alone all fail
+- What is cache and what is residue
+- There is no way to list what has been baked
+
+## Ctrl-C does not stop the machine, and which route that applies to
+
+**On the offline route this is the whole reason the packet has a cancel script.**
+`machine run` with `--oci-cache` or `--init` takes the pack-run boot path, which on Unix forks a
+session leader that never execs, so the VM child is detached with no parent-death arming. Interrupt
+the CLI and the VM keeps running, `machine list` reports `No machines found`, no VM cache directory
+exists, and there is no CLI route to what is still running. It exits only when the untrusted
+workload does, which for code that hangs or loops is unbounded. This is
+[smol-machines/smolvm#1193](https://github.com/smol-machines/smolvm/issues/1193).
+
+**On the plain path it does not happen**, and that is worth knowing rather than assuming the worst
+everywhere. Measured on Ubuntu 24.04 aarch64 on 2026-09-08: a `machine run` with no `--oci-cache`,
+one mount and a `sleep 600` workload, sent `SIGINT` on the CLI itself, left `machine list` empty
+and **no VM process at all**. The plain path spawns an exec'd `_boot-vm` that dies with the CLI.
+
+So:
+
+| route | Ctrl-C on the CLI | cancel with |
+|---|---|---|
+| offline (`--oci-cache`) | VM survives, invisible to `machine list` | `scripts/cleanup.sh --cancel` |
+| network-on (no `--oci-cache`) | VM dies with the CLI (verified on Linux) | either |
+
+**Do not rely on the second row to cancel a sandbox.** `run.sh` records the VM's pid on both
+routes because the difference is a boot-path detail that can change between releases, and because
+interrupting the *wrapper* rather than the CLI leaves the CLI and its VM running on either route,
+which was observed on both hosts here.
+
+## Assert no machines left only after a wait
+
+A successful `machine run` returns **before** its ephemeral entry retires. Asserting an empty
+machine list immediately fails on a healthy host, and it is the single most likely false failure in
+a scripted sandbox. `scripts/cleanup.sh` waits before asserting.
+
+## A network-off run that dies on the manifest means the bake was skipped
+
+```
+Error: fetching manifest docker.io/library/python:3.12-alpine: ... network is unreachable
+Hint: networking is disabled. Add --net to enable image pulls
+```
+
+**An ordinary earlier pull does not make a later run offline-capable**: the runtime still resolves
+the tag through the registry. Bake the image with `scripts/bake.sh` instead.
+
+The CLI's own hint points at re-opening the network, which is the opposite of what a sandbox wants.
+Adding `--net` here is how an offline sandbox quietly becomes a networked one.
+
+## A blocked host looks like a DNS bug, not a policy denial
+
+With `--allow-host example.com`, reaching `pypi.org` fails as `wget: bad address 'pypi.org'`.
+Nothing says "denied by policy". Do not spend time debugging the guest's resolver.
+
+## The bake helper ignores `--mem`
+
+The bake runs in a helper machine named `init-bake-<hash>-<pid>` which takes the **default** memory,
+8192 MiB, whatever `--mem` you passed to the outer command. Confirmed on Ubuntu 24.04 aarch64 on
+2026-09-08 by reading `machine ls --json` while a bake was in flight.
+
+**On a host that cannot boot a VM that large, the bake can never succeed and the error names
+neither the helper nor its memory:**
+
+```
+Error: config operation failed: init-layer bake:
+  `smolvm machine start --name init-bake-f60a20a837dc1a34-68696` failed (exit status: 1):
+  Error: agent operation failed: start machine: agent operation failed: wait for ready:
+  agent did not become ready within 30 seconds
+```
+
+That is exactly the message a loaded host produces, so it invites the wrong diagnosis.
+`scripts/bake.sh` runs a 2048 MiB control boot on failure and tells you which of the two it is.
+
+`SMOLVM_AGENT_READY_TIMEOUT_SECS` does not help: the string is in the binary, but the failure is in
+the inner `machine start`, which uses the hard-coded 30 s limit. Verified by setting it to 180 and
+watching the bake fail at 30 s anyway.
+
+## `machine egress-events` cannot inspect an ephemeral run
+
+It takes `--name` and defaults to a machine called `default`, so it applies to named machines. An
+ephemeral run's machine is gone before you can name it, so egress denials from a `machine run` are
+not retrievable this way.
+
+## Counting orphans: why `pgrep -f`, `readlink` and `_boot-vm` alone all fail
+
+Three reapers that look right. Each misses a different thing, and the third is the one that
+matters here.
+
+`pgrep -f _boot-vm` matches any process whose command line contains that string, including the
+script doing the counting, so it reports orphans that do not exist.
+
+`readlink /proc/<pid>/exe` is unreliable in the other direction. For the **exec'd** VM child it
+returns `Permission denied` to the user who started it, so a reaper built on it reports nothing.
+On v1.14.6 it is readable for the **forked** child, which makes it useful for scoping but not for
+finding.
+
+**Matching `argv[1] == "_boot-vm"` is exact, and still blind to the route this packet uses by
+default.** There are two VM process shapes:
+
+| route | child | argv[1] | carries its boot config |
+|---|---|---|---|
+| plain `machine run` | exec'd | `_boot-vm` | yes, in argv[2] |
+| pack-run (`--oci-cache`, or any `init`) | **forked, never exec'd** | inherited, so `machine` | **no** |
+
+The forked child inherits the parent's whole command line, so nothing in its argv says it is a VM.
+Measured on v1.14.6 on Ubuntu 24.04 aarch64: with two orphaned pack-run VMs alive at 234 MB each,
+`cleanup.sh` reported `vm_processes=none` and `result=clean`, and `run.sh` had recorded
+`vm_pid=not_observed`. **The reaper was blind to exactly the path that survives an interrupt**,
+which is the pack-run path, and sighted only on the path that does not.
+
+**What works.** On Linux both shapes rename themselves to `libkrun VM`, which no shell can hold,
+so `scripts/cleanup.sh` matches `/proc/<pid>/comm` and then scopes by argv[2] when it is there and
+by the executable's path when it is not. macOS exposes no rename, so there the search is scoped by
+the executable path under this `HOME` and the parent chain separates a VM from the CLI that
+started it. Verified against a live orphan on both hosts: the same sequence now reports
+`vm_process=... forked-under ...` and `result=vms_still_running`, and `--cancel` clears it.
+
+## What is cache and what is residue
+
+`ls ~/.cache/smolvm/vms/ | wc -l` is not a leak check. Two separate caches exist and neither is
+residue:
+
+- `vms/_shared`, the image store the runbooks describe.
+- **the pack cache**, `~/Library/Caches/smolvm-pack` on macOS and `~/.cache/smolvm-pack` on Linux.
+  On v1.14.2 on macOS a bake of one alpine image landed **here** and produced no `_shared` at all:
+  114 MB in the pack cache, `vms/_shared` absent. Observed 2026-09-08.
+
+`scripts/cleanup.sh` reports both and keeps both. Deleting them costs you the offline route, and
+the next bake pays for it again.
+
+Leftover VM directories are also not necessarily a leak: `smolvm serve start` prints
+`Reclaimed N dangling VM data dir(es)` on startup and clears them.
+
+## There is no way to list what has been baked
+
+`smolvm machine images` requires `--name` and reports one machine's images, so cache state is not
+observable. If a run unexpectedly pulls, you cannot inspect the cache to find out why. The
+`used_host_cache` line from `scripts/run.sh` is the only signal you get, which is why it is asserted
+rather than printed.

--- a/skills/sandbox/references/windows.md
+++ b/skills/sandbox/references/windows.md
@@ -1,0 +1,92 @@
+# Sandboxing on Windows
+
+## Contents
+
+- What was verified
+- Why the offline shape is unavailable
+- What a Windows sandbox has to do instead
+- The reaper on Windows
+
+**Re-run on 2026-09-11 against smolvm v1.14.6** on Windows 11 Home build 10.0.26200.0 UBR 9445
+x86_64, in an elevated session. The host mount, the artifact-out directory and the network-off
+refusal all behaved as recorded below, and the bake still never completes. The transcripts below
+are from the earlier v1.14.2 run except where a v1.14.6 line is quoted. `scripts/*.sh` are POSIX
+shell and do not run here.
+
+## What was verified
+
+The read-only mount, the artifact-out directory and the network-off refusal all behave as on Unix.
+
+```powershell
+& $exe machine run --net --mem 2048 --image python:3.12-alpine `
+    -v "$W\repo:/workspace:ro" -v "$W\out:/out" `
+    -- sh -c 'python3 /workspace/calc.py > /out/result.txt; touch /workspace/EVIL 2>/dev/null && echo WS_WRITABLE || echo ws_blocked'
+```
+
+```
+ws_blocked
+host result.txt : 42
+EVIL in repo    : False
+```
+
+The run took 5.8 s. Windows host paths work directly in `-v` (`C:\...\repo:/workspace:ro`),
+including from a 237-character directory.
+
+The same shape ran again on v1.14.6, asserting the mount with a marker rather than a timing:
+
+```
+SANDBOX_MOUNT_OK
+elapsed s : 9.7
+```
+
+A network-off run refuses to pull and prints the same hint as Unix, on v1.14.6 as before:
+
+```
+Error: fetching manifest docker.io/library/python:3.12-alpine: ... network is unreachable
+Hint: networking is disabled. Add --net to enable image pulls:
+  smolvm machine run --net --image python:3.12-alpine ...
+```
+
+## Why the offline shape is unavailable
+
+**The `--oci-cache` bake never completes on Windows, still on v1.14.6.** It stalls at the same
+line. Capped at ten minutes on the 2026-09-11 run and killed there:
+
+```
+Caching image 6e96a1a9683d8fb2 (one-time; reused on later runs)
+  pulling image and running init...
+```
+
+Probed while hanging, the bake's helper VM is running and healthy: `PID 1 /run/smolvm/init
+container-init` and nothing else, working egress, and 20.9 MB of pulled layers already on its
+storage disk. So the guest finished the pull and went idle while the host CLI waits for a
+completion signal that never arrives. Host-side `RUST_LOG=debug` shows the manifest resolved and
+then nothing.
+
+This is a host and guest completion-handshake problem, not a pull problem, not a network problem
+and **not the macOS abort in #1192**: the Windows pack-run boot spawns a detached `_boot-vm` rather
+than forking in-process, so the Objective-C fork-safety abort cannot apply here.
+
+**Every killed bake leaves a registered `init-bake-<hash>-<pid>` machine.** They accumulate and
+nothing cleans them up; delete them like any other machine. The v1.14.6 run left
+`init-bake-6e96a1a9683d8fb2-8648` behind exactly this way.
+
+## What a Windows sandbox has to do instead
+
+Use `--net` with an egress policy rather than the offline pattern, and say plainly that it is the
+weaker sandbox: the workload has network for the whole run. That is the same trade as the
+network-on route in `references/macos.md`, for a different underlying reason.
+
+## The reaper on Windows
+
+**Key on every `_boot-vm` process the script started, not only the pack-run path.**
+
+The `pack run` path spawns a detached `_boot-vm` with `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP`,
+and measured on the tested host, that child survives a real Ctrl-C and a kill of the CLI: about
+365 MB, invisible to `machine ls`. Only killing the child ends it.
+
+The plain foreground `machine run` has **not** been measured on Windows, and the source has no
+parent-death arming there at all: the watchdog is Unix-only and the plain `_boot-vm` spawn is also
+detached. Until someone measures it, assume a foreground run can orphan too. That is why a Windows
+port of `scripts/cleanup.sh` should reap every VM process it started rather than only the ones from
+the cached route, which is the opposite of the Linux split in `references/traps.md`.

--- a/skills/sandbox/scripts/bake.sh
+++ b/skills/sandbox/scripts/bake.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Bake an image into the host cache. This is the only step that talks to a
+# registry, and it runs with the network on and nothing untrusted mounted.
+#
+# usage: bake.sh [<image>]      (default python:3.12-alpine)
+#
+# Do this before the untrusted code is anywhere near the machine. Afterwards the
+# sandbox runs need no network at all, which is a materially stronger sandbox
+# than granting egress and hoping the workload behaves.
+
+set -uo pipefail
+
+IMAGE="${1:-python:3.12-alpine}"
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+if [ -z "$SMOLVM" ]; then
+    printf 'smolvm not found; set SMOLVM to its path\n' >&2
+    exit 2
+fi
+
+if [ "$(uname -s)" = "Darwin" ]; then
+    printf 'result=unsupported_on_macos\n'
+    printf 'A baked image is only useful to a run that also mounts something, and on macOS\n'
+    printf '%s\n' '--oci-cache plus any -v mount times out the boot (smol-machines/smolvm#1192).'
+    printf 'Read references/macos.md instead. Baking here would succeed and buy you nothing.\n'
+    exit 2
+fi
+
+start="$(date +%s)"
+out="$("$SMOLVM" machine run --mem 2048 --net --oci-cache --image "$IMAGE" -- true 2>&1)"
+rc=$?
+elapsed=$(( $(date +%s) - start ))
+printf '%s\n' "$out" | sed 's/^/  /'
+
+printf 'image=%s\n' "$IMAGE"
+printf 'elapsed_s=%s\n' "$elapsed"
+
+# Assert the value, not the exit code. A bake that did not cache still exits
+# zero, and the run that depends on it then fails much later with a message
+# about the registry.
+if printf '%s' "$out" | grep -q 'baked in'; then
+    printf 'result=baked\n'
+    exit 0
+fi
+
+# A second bake of an already-cached image reports the cache hit instead.
+if printf '%s' "$out" | grep -q 'host cache hit'; then
+    printf 'result=already_baked\n'
+    exit 0
+fi
+
+printf 'result=FAILED rc=%s\n' "$rc"
+
+# Diagnose rather than hand the error back. A ready timeout here names neither
+# the helper VM nor its memory, and the cause is usually one of two things.
+if printf '%s' "$out" | grep -q 'did not become ready'; then
+    printf 'diagnosis: the bake runs in a helper machine (init-bake-<hash>-<pid>) which takes\n'
+    printf '  the DEFAULT memory, 8192 MiB, ignoring the --mem on your command. If this host\n'
+    printf '  cannot boot a VM that large, the bake can never succeed and the error says so\n'
+    printf '  nowhere. Control boot at 2048 MiB:\n'
+    if "$SMOLVM" machine run --mem 2048 --net --image alpine -- echo CONTROL_OK 2>&1 | grep -q CONTROL_OK; then
+        printf '  control_boot_2048=ok\n'
+        printf '  So small VMs boot here and the helper does not: this host cannot give the bake\n'
+        printf '  the memory it takes. Use the network-on route instead (scripts/run.sh\n'
+        printf '  --route network-on), and read references/macos.md, which explains what that\n'
+        printf '  route costs you. It is the same trade on any host that cannot bake.\n'
+    else
+        printf '  control_boot_2048=failed\n'
+        printf '  Nothing boots here at all. This is not a bake problem: run the install\n'
+        printf '  packet preflight, which checks KVM access and the macOS socket path length.\n'
+    fi
+else
+    printf 'The bake is the only networked step. If it failed on the registry, fix that here\n'
+    printf 'rather than adding --net to the workload run, which is what the CLI hint suggests\n'
+    printf 'and is the opposite of what a sandbox wants.\n'
+fi
+exit 1

--- a/skills/sandbox/scripts/cleanup.sh
+++ b/skills/sandbox/scripts/cleanup.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Cancel or clean up a sandbox run, then prove nothing is left running.
+#
+# usage: cleanup.sh [--cancel] [--purge]
+#   --cancel   kill the VMs run.sh recorded. THIS IS THE SANDBOX'S CANCEL.
+#              Ctrl-C is not: it returns the shell to you and leaves the VM
+#              running, invisible to `machine list`, until the untrusted
+#              workload finishes on its own (smol-machines/smolvm#1193).
+#   --purge    remove the recorded-pid file once nothing is left
+#
+# With no flags it waits, asserts the machine list is empty, and reports any VM
+# process still alive under this HOME's state.
+
+set -uo pipefail
+
+PACKET="sandbox"
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+STATE_DIR="${SMOLVM_SKILL_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/smolvm-skills}"
+PIDFILE="$STATE_DIR/$PACKET.vmpids"
+
+cancel=0
+purge=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --cancel) cancel=1 ;;
+        --purge)  purge=1 ;;
+        *) printf 'unknown argument: %s\n' "$1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+if [ -z "$SMOLVM" ]; then
+    printf 'smolvm not found; set SMOLVM to its path\n' >&2
+    exit 2
+fi
+
+case "$(uname -s)" in
+    Darwin) VMS_DIR="$HOME/Library/Caches/smolvm/vms" ;;
+    *)      VMS_DIR="${SMOLVM_DATA_DIR:-$HOME/.cache/smolvm}/vms" ;;
+esac
+VMS_DIR="${SMOLVM_VMS_DIR:-$VMS_DIR}"
+SMOLVM_PREFIX="${SMOLVM_PREFIX:-$HOME/.smolvm}"
+
+# List this HOME's smolvm VM processes, as "pid marker".
+#
+# Two process shapes exist and a reaper has to catch both. The plain
+# `machine run` path EXECS a child whose argv[1] is `_boot-vm` and whose argv[2]
+# is its boot-config path. The pack-run path, which is `--oci-cache` or any
+# `init`, FORKS without execing, so the child inherits the parent's argv and
+# carries no boot-config at all. Matching `_boot-vm` alone is therefore blind to
+# exactly the path whose child survives an interrupt
+# (smol-machines/smolvm#1193): measured on v1.14.6, it reported "none" while two
+# orphaned VMs held 234 MB each.
+#
+# On Linux both shapes rename themselves to `libkrun VM`, the one marker that
+# covers both and that no shell can hold. macOS exposes no rename, so there the
+# executable path scopes the search to this HOME and the parent chain separates
+# a VM from the CLI that started it.
+#
+# `pgrep -f _boot-vm` is not an alternative: it matches any shell whose text
+# contains that string, including this script.
+list_vm_processes() {
+    case "$(uname -s)" in
+        Linux)
+            for p in /proc/[0-9]*; do
+                [ "$(cat "$p/comm" 2>/dev/null)" = "libkrun VM" ] || continue
+                pid="${p#/proc/}"
+                cfg="$(tr '\0' '\n' < "$p/cmdline" 2>/dev/null | sed -n '3p')"
+                case "$cfg" in
+                    "$VMS_DIR"/*) printf '%s %s\n' "$pid" "$cfg"; continue ;;
+                esac
+                # Forked shape: nothing in argv identifies it, so scope by the
+                # binary it is running.
+                case "$(readlink "$p/exe" 2>/dev/null)" in
+                    "$SMOLVM_PREFIX"/*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;;
+                esac
+            done
+            ;;
+        Darwin)
+            # shellcheck disable=SC2009  # pgrep cannot return ppid and the full
+            # command together, and pgrep -f matches this script's own text.
+            own=" $(ps -axo pid=,command= 2>/dev/null | grep -F "$SMOLVM_PREFIX/smolvm-bin" | awk '{print $1}' | tr '\n' ' ') "
+            ps -axo pid=,ppid=,command= 2>/dev/null | while read -r pid ppid rest; do
+                case "$rest" in "$SMOLVM_PREFIX"/smolvm-bin*) ;; *) continue ;; esac
+                case "$rest" in
+                    *" _boot-vm "*) printf '%s %s\n' "$pid" "${rest#* _boot-vm }"; continue ;;
+                esac
+                # Forked shape: its parent is the CLI that started it, or init
+                # once that CLI is gone.
+                if [ "$ppid" = 1 ]; then
+                    printf '%s orphaned-under %s\n' "$pid" "$SMOLVM_PREFIX"
+                else
+                    case "$own" in *" $ppid "*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;; esac
+                fi
+            done
+            ;;
+    esac
+}
+
+# 1. Cancel: kill exactly the VMs run.sh recorded, and only those.
+if [ "$cancel" -eq 1 ]; then
+    if [ -s "$PIDFILE" ]; then
+        while read -r pid cfg; do
+            [ -n "$pid" ] || continue
+            if kill -0 "$pid" 2>/dev/null; then
+                kill -9 "$pid" 2>/dev/null && printf 'cancelled=%s config=%s\n' "$pid" "$cfg"
+            else
+                printf 'already_gone=%s\n' "$pid"
+            fi
+        done < "$PIDFILE"
+    else
+        printf 'cancelled=none_recorded\n'
+    fi
+fi
+
+# 2. An ephemeral machine's entry retires after the run returns, not with it, so
+# an immediate assertion fails on a healthy host. This is the single most likely
+# false failure in a scripted sandbox.
+sleep 20
+
+# 3. Assert values.
+listing="$("$SMOLVM" machine list 2>&1)"
+if printf '%s' "$listing" | grep -q 'No machines found'; then
+    printf 'machines=clean\n'
+else
+    printf 'machines=remaining\n'
+    printf '%s\n' "$listing" | sed 's/^/  /'
+fi
+
+# `_shared` is the image store bake.sh writes into. It is the cache, not
+# residue, so counting it as a leak gives a false positive on every host that
+# has ever baked.
+if [ -d "$VMS_DIR" ]; then
+    left="$(find "$VMS_DIR" -mindepth 1 -maxdepth 1 -type d ! -name _shared 2>/dev/null | wc -l | tr -d ' ')"
+else
+    left=0
+fi
+printf 'vm_dirs=%s\n' "$left"
+if [ "$left" -gt 0 ]; then
+    printf 'note=leftover VM directories are not necessarily a leak: smolvm serve start prints "Reclaimed N dangling VM data dir(es)" on startup and clears them.\n'
+fi
+
+# What a bake leaves behind is cache, not residue, and deleting it costs you the
+# offline route. Report both places it can live: `_shared` under the VM state,
+# and the pack cache, which is where a v1.14.2 bake actually landed on macOS.
+case "$(uname -s)" in
+    Darwin) PACK_CACHE="$HOME/Library/Caches/smolvm-pack" ;;
+    *)      PACK_CACHE="$HOME/.cache/smolvm-pack" ;;
+esac
+if [ -d "$VMS_DIR/_shared" ]; then
+    printf 'image_cache_shared=%s\n' "$(du -sk "$VMS_DIR/_shared" 2>/dev/null | awk '{printf "%dMB", $1/1024}')"
+else
+    printf 'image_cache_shared=absent\n'
+fi
+if [ -d "$PACK_CACHE" ]; then
+    printf 'image_cache_pack=%s\n' "$(du -sk "$PACK_CACHE" 2>/dev/null | awk '{printf "%dMB", $1/1024}')"
+else
+    printf 'image_cache_pack=absent\n'
+fi
+printf 'note=both caches are kept on purpose. Removing them costs you the offline route and the next bake pays for it again.\n'
+
+# 4. Verify: after a cancel, this is the assertion that the cancel worked.
+found=0
+while read -r pid cfg; do
+    [ -n "$pid" ] || continue
+    found=1
+    printf 'vm_process=%s config=%s\n' "$pid" "$cfg"
+done <<EOF
+$(list_vm_processes)
+EOF
+
+if [ "$found" -eq 0 ]; then
+    printf 'vm_processes=none\n'
+    [ "$purge" -eq 1 ] && rm -f "$PIDFILE"
+    printf 'result=clean\n'
+    exit 0
+fi
+
+printf 'result=vms_still_running\n'
+printf 'rerun with --cancel, after checking none of the above belongs to another session.\n'
+exit 1

--- a/skills/sandbox/scripts/preflight.sh
+++ b/skills/sandbox/scripts/preflight.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Report whether this host can run the offline sandbox shape, and whether the
+# machine you are planning fits the guest's device budget.
+#
+# usage: preflight.sh [--mounts N] [--ports N]
+#   --mounts N  how many -v mounts your run will pass (default 2: repo plus out)
+#   --ports N   how many -p publishes it will pass (default 0)
+#
+# Read-only: starts no VM, bakes nothing, writes no smolvm state.
+# Output is one key=value per line. The last line is result=ready or result=blocked.
+
+set -uo pipefail
+
+VERIFIED_VERSION="1.14.6"
+
+# The guest gets eleven IRQs. Four -v mounts boot and five fail with "no more
+# IRQs are available", and any published port costs one of those slots, so the
+# budget is mounts plus ports. Measured on Windows Hypervisor Platform and the
+# same budget on Linux.
+DEVICE_BUDGET=4
+
+emit() { printf '%s=%s\n' "$1" "$2"; }
+note() { printf 'note=%s\n' "$1"; }
+
+mounts=2
+ports=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --mounts) mounts="$2"; shift ;;
+        --ports)  ports="$2";  shift ;;
+        *) printf 'unknown argument: %s\n' "$1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+blocked=0
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+if [ -z "$SMOLVM" ]; then
+    emit smolvm_installed no
+    blocked=1
+else
+    emit smolvm_installed yes
+    version="$("$SMOLVM" --version 2>/dev/null | awk '{print $NF}')"
+    emit smolvm_version "${version:-unknown}"
+fi
+
+emit verified_version "$VERIFIED_VERSION"
+if [ -n "${version:-}" ] && [ "$version" != "unknown" ]; then
+    if [ "$version" = "$VERIFIED_VERSION" ]; then
+        emit version_status match
+    else
+        newest="$(printf '%s\n%s\n' "$version" "$VERIFIED_VERSION" | sort -V | tail -1)"
+        if [ "$newest" = "$version" ]; then
+            emit version_status newer
+            note "this packet was verified on $VERIFIED_VERSION and the binary is $version; a sandbox is exactly where a silently changed flag matters, so check each step's output against the binary before trusting it"
+        else
+            emit version_status older
+        fi
+    fi
+else
+    emit version_status unknown
+fi
+
+kernel="$(uname -s)"
+arch="$(uname -m)"
+case "$arch" in aarch64|arm64) arch=aarch64 ;; esac
+
+case "$kernel" in
+    Darwin)
+        emit platform "darwin-$arch"
+        emit accel hypervisor_framework
+        if [ "$(sysctl -n kern.hv_support 2>/dev/null)" = "1" ]; then
+            emit accel_access ok
+        else
+            emit accel_access denied
+            blocked=1
+        fi
+        # The offline shape is bake with --oci-cache, then run with mounts and
+        # no network. On macOS that combination never boots.
+        emit offline_shape unavailable
+        emit offline_shape_blocker "smol-machines/smolvm#1192"
+        blocked=1
+        note "on macOS --oci-cache with any -v mount times out the boot, deterministically, so the offline shape this packet is built on cannot run here. Use references/macos.md, which gives a route that works and says what it costs you."
+        for b in docker crane podman nerdctl; do
+            if command -v "$b" >/dev/null 2>&1; then emit image_archive_tool "$b"; break; fi
+        done
+        ;;
+    Linux)
+        emit platform "linux-$arch"
+        emit accel kvm
+        if [ ! -e /dev/kvm ]; then
+            emit accel_access missing
+            blocked=1
+            note "/dev/kvm does not exist; this host has no KVM"
+        elif [ -r /dev/kvm ] && [ -w /dev/kvm ]; then
+            emit accel_access ok
+        else
+            emit accel_access denied
+            blocked=1
+            note "your user cannot open /dev/kvm. Fix without logging out: sudo usermod -aG kvm \$USER, then run the next command through sg kvm -c '...'"
+        fi
+        emit offline_shape available
+        ;;
+    *)
+        emit platform "unsupported-$kernel"
+        emit accel unknown
+        emit accel_access unknown
+        emit offline_shape unavailable
+        blocked=1
+        note "this script covers macOS and Linux. On Windows the --oci-cache bake never completes, so the offline shape is unavailable there too; see references/windows.md, written from a run and not re-run by this packet."
+        ;;
+esac
+
+# The devices your planned run needs, against the budget.
+emit planned_mounts "$mounts"
+emit planned_ports "$ports"
+emit device_budget "$DEVICE_BUDGET"
+emit devices_requested "$((mounts + ports))"
+if [ "$((mounts + ports))" -le "$DEVICE_BUDGET" ]; then
+    emit device_budget_ok yes
+else
+    emit device_budget_ok no
+    blocked=1
+    note "mounts plus published ports exceeds the guest's device budget; the boot fails with 'no more IRQs are available'. Combine directories under one mount, or drop a port."
+fi
+
+# Ctrl-C does not stop a sandbox. Say so before anything is started, not after.
+emit cancel_route "scripts/cleanup.sh --cancel"
+emit interrupt_orphans_vm yes
+emit interrupt_blocker "smol-machines/smolvm#1193"
+
+if [ "$blocked" -eq 0 ]; then emit result ready; else emit result blocked; fi

--- a/skills/sandbox/scripts/run.sh
+++ b/skills/sandbox/scripts/run.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# Run an untrusted command against a repo it must not modify, with no network,
+# and collect its artifacts.
+#
+# usage: run.sh [--repo <dir>] [--out <dir>] [--image <img>] [--allow-host <h>]... -- <command...>
+#   --repo <dir>        mounted read-only at /workspace (default ./repo)
+#   --out  <dir>        mounted writable at /out        (default ./out)
+#   --image <img>       must already be baked; see bake.sh (default python:3.12-alpine)
+#   --allow-host <h>    grant egress to one host. Repeatable. Weakens the sandbox
+#                       and the script says so; --allow-host implies --net.
+#   --route <r>         offline (default) or network-on.
+#                       offline    bake once, then run with no network at all.
+#                       network-on no --oci-cache, the run pulls its own image and
+#                       therefore has egress for the whole run. Use it only where
+#                       offline does not work: macOS, where --oci-cache with any
+#                       mount never boots (smol-machines/smolvm#1192), and any host
+#                       that cannot give the bake helper its 8192 MiB.
+#
+# The VM's pid is recorded before the workload finishes, because Ctrl-C does not
+# stop a smolvm machine: the VM outlives the CLI, `machine list` cannot see it,
+# and it exits only when the untrusted workload does, which for code that hangs
+# or loops is never (smol-machines/smolvm#1193). Cancel with
+# `scripts/cleanup.sh --cancel`, never with Ctrl-C.
+
+set -uo pipefail
+
+REPO="./repo"
+OUT="./out"
+IMAGE="python:3.12-alpine"
+ROUTE="offline"
+allow=()
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --repo)       REPO="$2"; shift ;;
+        --out)        OUT="$2"; shift ;;
+        --image)      IMAGE="$2"; shift ;;
+        --allow-host) allow+=(--allow-host "$2"); shift ;;
+        --route)      ROUTE="$2"; shift ;;
+        --) shift; break ;;
+        *) printf 'unknown argument: %s\n' "$1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+case "$ROUTE" in
+    offline|network-on) ;;
+    *) printf 'unknown route: %s (offline or network-on)\n' "$ROUTE" >&2; exit 2 ;;
+esac
+
+if [ $# -eq 0 ]; then
+    printf 'no command given; everything after -- is run inside the sandbox\n' >&2
+    exit 2
+fi
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+if [ -z "$SMOLVM" ]; then
+    printf 'smolvm not found; set SMOLVM to its path\n' >&2
+    exit 2
+fi
+
+if [ ! -d "$REPO" ]; then
+    printf 'repo directory not found: %s\n' "$REPO" >&2
+    exit 2
+fi
+mkdir -p "$OUT"
+REPO="$(cd "$REPO" && pwd)"
+OUT="$(cd "$OUT" && pwd)"
+
+STATE_DIR="${SMOLVM_SKILL_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/smolvm-skills}"
+mkdir -p "$STATE_DIR"
+PIDFILE="$STATE_DIR/sandbox.vmpids"
+
+case "$(uname -s)" in
+    Darwin) VMS_DIR="$HOME/Library/Caches/smolvm/vms" ;;
+    *)      VMS_DIR="${SMOLVM_DATA_DIR:-$HOME/.cache/smolvm}/vms" ;;
+esac
+VMS_DIR="${SMOLVM_VMS_DIR:-$VMS_DIR}"
+SMOLVM_PREFIX="${SMOLVM_PREFIX:-$HOME/.smolvm}"
+
+# List this HOME's smolvm VM processes, as "pid marker".
+#
+# Two process shapes exist and a reaper has to catch both. The plain
+# `machine run` path EXECS a child whose argv[1] is `_boot-vm` and whose argv[2]
+# is its boot-config path. The pack-run path, which is `--oci-cache` or any
+# `init`, FORKS without execing, so the child inherits the parent's argv and
+# carries no boot-config at all. Matching `_boot-vm` alone is therefore blind to
+# exactly the path whose child survives an interrupt
+# (smol-machines/smolvm#1193): measured on v1.14.6, it reported "none" while two
+# orphaned VMs held 234 MB each.
+#
+# On Linux both shapes rename themselves to `libkrun VM`, the one marker that
+# covers both and that no shell can hold. macOS exposes no rename, so there the
+# executable path scopes the search to this HOME and the parent chain separates
+# a VM from the CLI that started it.
+#
+# `pgrep -f _boot-vm` is not an alternative: it matches any shell whose text
+# contains that string, including this script.
+list_vm_processes() {
+    case "$(uname -s)" in
+        Linux)
+            for p in /proc/[0-9]*; do
+                [ "$(cat "$p/comm" 2>/dev/null)" = "libkrun VM" ] || continue
+                pid="${p#/proc/}"
+                cfg="$(tr '\0' '\n' < "$p/cmdline" 2>/dev/null | sed -n '3p')"
+                case "$cfg" in
+                    "$VMS_DIR"/*) printf '%s %s\n' "$pid" "$cfg"; continue ;;
+                esac
+                # Forked shape: nothing in argv identifies it, so scope by the
+                # binary it is running.
+                case "$(readlink "$p/exe" 2>/dev/null)" in
+                    "$SMOLVM_PREFIX"/*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;;
+                esac
+            done
+            ;;
+        Darwin)
+            # shellcheck disable=SC2009  # pgrep cannot return ppid and the full
+            # command together, and pgrep -f matches this script's own text.
+            own=" $(ps -axo pid=,command= 2>/dev/null | grep -F "$SMOLVM_PREFIX/smolvm-bin" | awk '{print $1}' | tr '\n' ' ') "
+            ps -axo pid=,ppid=,command= 2>/dev/null | while read -r pid ppid rest; do
+                case "$rest" in "$SMOLVM_PREFIX"/smolvm-bin*) ;; *) continue ;; esac
+                case "$rest" in
+                    *" _boot-vm "*) printf '%s %s\n' "$pid" "${rest#* _boot-vm }"; continue ;;
+                esac
+                # Forked shape: its parent is the CLI that started it, or init
+                # once that CLI is gone.
+                if [ "$ppid" = 1 ]; then
+                    printf '%s orphaned-under %s\n' "$pid" "$SMOLVM_PREFIX"
+                else
+                    case "$own" in *" $ppid "*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;; esac
+                fi
+            done
+            ;;
+    esac
+}
+
+before="$(list_vm_processes | awk '{print $1}' | sort)"
+
+printf 'route=%s\n' "$ROUTE"
+cache=(--oci-cache)
+if [ "$ROUTE" = "network-on" ]; then
+    # No host cache, so the run pulls its own image and needs the network for
+    # the whole run. Say what that costs rather than letting it look equivalent.
+    cache=()
+    if [ "${#allow[@]}" -eq 0 ]; then
+        allow=(--net)
+        printf 'egress=all\n'
+        printf 'note=network-on with no --allow-host gives the untrusted workload unrestricted egress for the whole run. Name the hosts it needs with --allow-host to narrow it.\n'
+    else
+        printf 'egress=granted %s\n' "${allow[*]}"
+        printf 'note=the run also needs to reach the registry to pull its image, so the policy must include the registry hosts or the run will not start.\n'
+    fi
+    printf 'note=this is the weaker sandbox. The offline route reaches no network at all; this one is open for as long as the workload runs.\n'
+elif [ "${#allow[@]}" -gt 0 ]; then
+    printf 'egress=granted %s\n' "${allow[*]}"
+    printf 'note=--allow-host implies --net. The workload can now reach the named hosts, and a denial looks like a DNS failure rather than a policy denial.\n'
+else
+    printf 'egress=none\n'
+fi
+
+logfile="$STATE_DIR/sandbox.lastrun.log"
+"$SMOLVM" machine run --mem 2048 ${cache[@]+"${cache[@]}"} --image "$IMAGE" \
+    --volume "$REPO:/workspace:ro" \
+    --volume "$OUT:/out" \
+    ${allow[@]+"${allow[@]}"} \
+    -- "$@" > "$logfile" 2>&1 &
+cli_pid=$!
+
+# Record the VM before waiting on it. If the caller kills this script, the pid
+# in that file is the only route back to the machine.
+# 90 s: long enough to see the VM appear on a host that is pulling an image,
+# and bounded so a workload that finishes instantly does not stall the script.
+recorded=""
+waited=0
+while [ "$waited" -lt 90 ]; do
+    while read -r pid cfg; do
+        [ -n "$pid" ] || continue
+        case "$(printf '%s\n' "$before" | grep -c "^$pid$")" in
+            0) printf '%s %s\n' "$pid" "$cfg" >> "$PIDFILE"; recorded="$pid" ;;
+        esac
+    done <<EOF
+$(list_vm_processes)
+EOF
+    [ -n "$recorded" ] && break
+    kill -0 "$cli_pid" 2>/dev/null || break
+    sleep 1
+    waited=$((waited + 1))
+done
+
+if [ -n "$recorded" ]; then
+    printf 'vm_pid=%s\n' "$recorded"
+    printf 'vm_pid_recorded_in=%s\n' "$PIDFILE"
+else
+    printf 'vm_pid=not_observed\n'
+    printf 'note=the VM was not seen before the run ended, which is normal for a command that finishes in under a second. Nothing to cancel.\n'
+fi
+
+wait "$cli_pid"
+rc=$?
+sed 's/^/  /' "$logfile"
+
+# On the offline route the cache-hit line is the assertion that the bake worked
+# and that this run reached no registry. Without it the run pulled, which means
+# it had network, which means it was not the sandbox you asked for.
+if [ "$ROUTE" = "offline" ]; then
+    if grep -q 'host cache hit' "$logfile"; then
+        printf 'used_host_cache=yes\n'
+    else
+        printf 'used_host_cache=no\n'
+        printf 'note=no host cache hit on the offline route. Run bake.sh first: an ordinary earlier pull does not make a later run offline-capable, because the runtime still resolves the tag through the registry.\n'
+    fi
+else
+    printf 'used_host_cache=n_a_on_this_route\n'
+fi
+
+printf 'cli_exit=%s\n' "$rc"
+printf 'next: scripts/verify.sh, then scripts/cleanup.sh\n'
+exit "$rc"

--- a/skills/sandbox/scripts/verify.sh
+++ b/skills/sandbox/scripts/verify.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Assert the sandbox held: from inside the guest, and from the host afterwards.
+#
+# usage: verify.sh [--repo <dir>] [--out <dir>] [--expect-file <name>]
+#                  [--expect <value>] [--image <img>] [--route offline|network-on]
+#
+# Two halves, and both are needed. The inside half proves the workload could not
+# write the repo and could not reach the network; the host half proves the
+# artifact came out and the repo is unchanged. A run that "succeeded" tells you
+# neither.
+
+set -uo pipefail
+
+REPO="./repo"
+OUT="./out"
+EXPECT_FILE="result.txt"
+EXPECT=""
+IMAGE="python:3.12-alpine"
+ROUTE="offline"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --repo)        REPO="$2"; shift ;;
+        --out)         OUT="$2"; shift ;;
+        --expect-file) EXPECT_FILE="$2"; shift ;;
+        --expect)      EXPECT="$2"; shift ;;
+        --image)       IMAGE="$2"; shift ;;
+        --route)       ROUTE="$2"; shift ;;
+        *) printf 'unknown argument: %s\n' "$1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+if [ -z "$SMOLVM" ]; then
+    printf 'smolvm not found; set SMOLVM to its path\n' >&2
+    exit 2
+fi
+
+printf 'route=%s\n' "$ROUTE"
+REPO="$(cd "$REPO" && pwd)"
+OUT="$(cd "$OUT" && pwd)"
+
+# The probe must run in the same shape as the real run, or it proves nothing
+# about that run. On the network-on route the workload has egress by
+# construction, so the network assertion changes rather than disappearing.
+case "$ROUTE" in
+    offline)    cache=(--oci-cache); net=();       expect_net=blocked ;;
+    network-on) cache=();            net=(--net);  expect_net=REACHED ;;
+    *) printf 'unknown route: %s (offline or network-on)\n' "$ROUTE" >&2; exit 2 ;;
+esac
+
+fail=0
+check() {
+    if [ "$2" = "$3" ]; then
+        printf '%s=ok (%s)\n' "$1" "$2"
+    else
+        printf '%s=FAIL expected=%s actual=%s\n' "$1" "$3" "$2"
+        fail=1
+    fi
+}
+
+# --- from inside the guest, in the same shape a real run uses ----------------
+inside="$("$SMOLVM" machine run --mem 2048 ${cache[@]+"${cache[@]}"} ${net[@]+"${net[@]}"} --image "$IMAGE" \
+    --volume "$REPO:/workspace:ro" \
+    --volume "$OUT:/out" \
+    -- sh -c '
+        touch /workspace/SANDBOX_PROBE 2>/dev/null && echo "workspace=WRITABLE" || echo "workspace=readonly"
+        touch /out/SANDBOX_PROBE      2>/dev/null && echo "out=writable"       || echo "out=READONLY"
+        wget -q -T3 -O- http://example.com >/dev/null 2>&1 && echo "net=REACHED" || echo "net=blocked"
+    ' 2>&1 | tr -d '\r')"
+printf '%s\n' "$inside" | sed 's/^/  /'
+
+check inside_workspace "$(printf '%s' "$inside" | sed -n 's/^workspace=//p')" readonly
+check inside_out       "$(printf '%s' "$inside" | sed -n 's/^out=//p')"       writable
+check inside_network   "$(printf '%s' "$inside" | sed -n 's/^net=//p')"       "$expect_net"
+if [ "$ROUTE" = "network-on" ]; then
+    printf 'note=on this route the workload reaching the network is the expected result, not a failure. It is the price of the route, and the reason offline is the default.\n'
+fi
+
+# --- from the host afterwards ------------------------------------------------
+if [ -n "$EXPECT" ]; then
+    check artifact "$(cat "$OUT/$EXPECT_FILE" 2>/dev/null | tr -d '\r\n')" "$EXPECT"
+elif [ -s "$OUT/$EXPECT_FILE" ]; then
+    printf 'artifact=present (%s)\n' "$OUT/$EXPECT_FILE"
+else
+    printf 'artifact=FAIL missing or empty: %s\n' "$OUT/$EXPECT_FILE"
+    fail=1
+fi
+
+# The probe above tried to write the repo. If the read-only mount leaked, the
+# evidence is sitting in the repo now.
+if [ -e "$REPO/SANDBOX_PROBE" ]; then
+    printf 'repo_unchanged=FAIL the read-only mount leaked: %s/SANDBOX_PROBE exists\n' "$REPO"
+    fail=1
+else
+    printf 'repo_unchanged=ok\n'
+fi
+rm -f "$OUT/SANDBOX_PROBE"
+
+if [ "$fail" -eq 0 ]; then printf 'result=sandbox_held\n'; else printf 'result=FAILED\n'; fi
+exit "$fail"

--- a/skills/teardown/SKILL.md
+++ b/skills/teardown/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: teardown
+description: "Stops every smolvm machine a session started, removes smolvm's state, and proves the host is clean. Use after any smolvm session; when a machine seems to have survived a Ctrl-C or a crash; when disk space has disappeared; when uninstalling smolvm; when tearing down the Kubernetes runtime from a node; or when a borrowed or shared host has to be handed back with nothing left behind. Also use it as the cleanup step for other smolvm work, because the obvious assertions here give false results. Do not use it to delete machines another session created: it removes only what a script recorded under its own name prefix."
+---
+
+# Leaving nothing running and nothing behind
+
+Verified on **smolvm v1.14.6** on macOS arm64 and Linux aarch64, 2026-09-10. This packet exists on its own because **almost every cleanup fact
+in smolvm is counterintuitive**: the obvious assertion gives a false failure, the obvious reaper
+matches the wrong process or nothing at all, and the command a user reaches for when a run
+misbehaves does not stop the machine. Anything that starts machines needs this more than it needs
+any single feature.
+
+Every other packet's cleanup script is this packet's `scripts/cleanup.sh` with one line changed.
+
+## Procedure
+
+**1. See what is there.** Read-only: deletes nothing, starts no VM.
+
+```bash
+scripts/preflight.sh
+```
+
+It reports each state directory with its size, whether a `--oci-cache` image store exists,
+whether the launcher symlink and the `PATH` block are present, and whether state can be relocated
+on this platform.
+
+**2. Delete the machines your scripts created, and report the rest.**
+
+```bash
+scripts/cleanup.sh            # report leftover VM processes
+scripts/cleanup.sh --reap     # and kill them
+```
+
+Only machines recorded in the state file are deleted, so a machine you or another session created
+by hand is never touched. A script records what it creates with
+`scripts/cleanup.sh --record <name>`, and names must carry the `smolskill-` prefix or the delete
+is skipped. `--purge` removes the state file once the list is empty.
+
+The state file lives under `${XDG_STATE_HOME:-$HOME/.local/state}/smolvm-skills/`, outside
+`~/.smolvm` and outside smolvm's own caches. Nothing here edits smolvm configuration.
+
+**3. Prove it.**
+
+```bash
+scripts/verify-clean.sh
+scripts/verify-clean.sh --protected "$HOME/.smolvm"   # after a run under an isolated HOME
+```
+
+Each check prints `ok` or `FAIL expected=... actual=...`, and the script exits non-zero if any
+failed. `--protected <dir>` asserts nothing under a real installation was written today, which is
+how you show a test run under a scratch `HOME` did not reach it. Without it the check reports
+`protected=not_checked` rather than passing silently.
+
+**4. Reclaim space, or remove smolvm entirely.**
+
+```bash
+smolvm machine prune --name <NAME>   # one machine's unreferenced layers; --all drops its cached images
+smolvm pack prune
+curl -sSL https://smolmachines.com/install.sh | bash -s -- --uninstall
+```
+
+`references/locations.md` has the full layout, what the uninstaller removes, and the two things it
+deliberately leaves.
+
+## The four traps that make this a packet
+
+Full detail with the observations behind each is in `references/traps.md`.
+
+- **`Ctrl-C` does not stop the machine, and there is no CLI route to what it leaves.** The VM
+  outlives the CLI, `machine list` says `No machines found`, and no VM cache directory exists. The
+  VM exits only when its own workload finishes, so a run that loops or hangs is unbounded exposure.
+- **The two obvious reapers both fail, in opposite directions.** `pgrep -f _boot-vm` matches any
+  shell whose text contains that string, including the cleanup script, and reports orphans that do
+  not exist. `readlink /proc/<pid>/exe` reports none that do: the VM process is not dumpable, so
+  its `/proc/<pid>/exe` is root-owned and `readlink` returns `Permission denied` to the user who
+  started it. `cleanup.sh` matches `argv[1]` exactly instead, and scopes by the boot config's path.
+- **Asserting "no machines" immediately after `machine run` fails on a healthy host.** The entry
+  retires after the command returns, observed gone by 20 s.
+- **`machine delete` prompts and defaults to No.** Without `--force` a script prints `Cancelled`
+  and carries on believing it cleaned up. A branched machine also needs `--cascade`.
+
+And one false alarm: **`ls ~/.cache/smolvm/vms/ | wc -l` is not a leak check.** Once `--oci-cache`
+has run, `_shared` lives there holding the baked images. Both scripts exclude it.
+
+## Security defaults, and why they are the defaults
+
+- **Cleanup deletes only what it was told it created.** A shared host can carry another session's
+  machines, and during the runs behind this packet it did: a second VM under a different `HOME`
+  was live throughout. `cleanup.sh` listed only the processes whose boot config sits under its own
+  state tree and left the other one running. A cleanup script that kills every smolvm process is
+  fine on your laptop and destructive on a build agent.
+- **`--reap` is opt-in and prints what it is about to kill.** Killing a VM is not recoverable and
+  the VM cannot be identified from `machine list`, so the default is to report.
+- **Nothing here escalates privilege.** The one place teardown needs `sudo` is the Kubernetes
+  runtime, which installs outside your home directory; those commands are in
+  `references/kubernetes.md` for you to run and read, not wrapped in a script.
+- **The uninstaller leaves `~/.config/smolvm` and your `PATH` line on purpose**, because those
+  hold registry credentials and a change you made to your own shell profile.
+
+## Platform arms
+
+- **macOS arm64** and **Linux aarch64**: the scripts were run here.
+- **Linux x86_64**: the procedure was verified in the material behind this packet, on hosts that
+  no longer exist. The scripts themselves were not re-run there.
+- **Windows x86_64**: `references/windows.md`, **not re-run**, including by the 2026-09-11 batch
+  on v1.14.6, so that page stays a v1.14.2 record. The scripts are POSIX shell and do
+  not run there at all. Windows is the platform where this matters most, because state cannot be
+  relocated and one session left 30 GB in `%LOCALAPPDATA%\smolvm`.
+- **Kubernetes nodes**: `references/kubernetes.md`. Verified on Ubuntu 22.04 x86_64 with k3s in
+  the material behind this packet, not re-run here.
+
+## Eval prompts, and what they produced
+
+Run on 2026-09-07 PT against smolvm v1.14.2 from the published release, under an isolated `HOME`
+on macOS 26.6.2 arm64 and on Lima `linux-kvm` (Ubuntu 24.04 aarch64). Output is verbatim.
+
+**1. "I ran some smolvm machines. Clean up after me and show me the host is clean."**
+
+A machine was created, started, recorded, then cleaned up. macOS:
+
+```
+  Cleaning up data directory for vm: smolskill-td
+  Deleted machine: smolskill-td
+machines=clean
+vm_processes=none
+
+machines=ok
+vm_dirs=ok
+vm_processes=ok
+protected_untouched_since_2026-09-07=ok
+result=clean
+```
+
+Linux gave the same, with `protected=not_checked` because no real installation was named.
+
+**2. "Is anything still running that `smolvm machine list` cannot see?"**
+
+Run against a live machine, so this is the answer when the host is not clean. Linux:
+
+```
+vm_process=51706 config=/home/<user>/skp/.cache/smolvm/vms/2ec3433ec42ca6de/boot-config.json
+rerun with --reap to kill them
+```
+
+macOS:
+
+```
+vm_process=76032 config=/tmp/skp/Library/Caches/smolvm/vms/2ec3433ec42ca6de/boot-config.json
+```
+
+A second VM belonging to another session was live on the Linux host under a different `HOME`
+throughout, and was correctly not listed. The same run through `readlink /proc/<pid>/exe`
+returned nothing at all, which is the finding that changed this script.
+
+**3. "Prove my test run did not touch my real smolvm install."**
+
+```
+machines=ok
+vm_dirs=ok
+vm_processes=ok
+protected_untouched_since_2026-09-07=ok
+result=clean
+```
+
+against `--protected $HOME/.smolvm` on the macOS host, where a real v0.5.20 installation sits
+beside the isolated v1.14.2 one used for these runs.
+
+## Re-verified on v1.14.6
+
+Run 2026-09-10 PT against v1.14.6 on macOS 26.6.2 arm64 and Lima `linux-kvm` (Ubuntu 24.04
+aarch64). `verify-clean.sh` returned `result=clean` on both, including
+`protected_untouched_since_2026-09-10=ok` against the real installation on the Mac.
+
+**The reaper changed on this release**, and the change is the reason to read
+`references/traps.md` again: the pack-run path forks without execing, so its VM child carries no
+`_boot-vm` in argv and the previous scanner could not see it. Measured on v1.14.6 before the fix,
+`cleanup.sh` reported `vm_processes=none` and `result=clean` while two orphaned VMs held 234 MB
+each. The scanner now matches both process shapes and was verified against a live orphan on both
+hosts.
+
+## What was not run
+
+- **Windows.** `references/windows.md` records one run that was not repeated.
+- **Kubernetes.** `references/kubernetes.md` records a verified sequence on a node that no longer
+  exists.
+- **Linux x86_64.**
+- **The macOS `hdiutil` mount-point case.** `references/traps.md` records that `rm -rf` on the
+  pack cache can fail with `Resource busy` and what the uninstaller does about it. No pack was
+  created in these runs, so that path was not exercised here.
+- **`--oci-cache`.** No `_shared` store existed on either host, so the exclusion these scripts
+  carry was exercised only against its absence.
+
+## Related packets
+
+- `install` for what the install lays down, which is what you are removing.
+- Every other packet's `scripts/cleanup.sh` is this one.

--- a/skills/teardown/references/kubernetes.md
+++ b/skills/teardown/references/kubernetes.md
@@ -1,0 +1,39 @@
+# Tearing down the Kubernetes runtime
+
+Only relevant if you installed the smolvm containerd shim on a node. Deleting the pod is not the
+whole job: the runtime install is system-wide, the uninstaller does not know about it, and every
+command below reports success while leaving state behind.
+
+Verified on Ubuntu 22.04 x86_64 with k3s.
+
+```bash
+kubectl delete pod <name> --wait=true
+kubectl get pods                                  # No resources found
+
+# then, if you installed the runtime:
+sudo rm -f /usr/local/bin/containerd-shim-smolvm-v2 /usr/local/bin/containerd-shim-smolvm-v2.real
+sudo rm -rf /var/lib/smolvm /etc/systemd/system/k3s.service.d
+sudo /usr/local/bin/k3s-uninstall.sh              # if you installed k3s
+sudo rm -rf /var/lib/rancher                      # k3s-uninstall can leave this behind
+
+# the shim runs as root, so its VM state is in root's home, not yours:
+sudo rm -rf /var/lib/containerd-shim-smolvm /root/.cache/smolvm /root/.local/share/smolvm
+sudo rm -rf /var/log/pods/*smolvm* /var/log/containers/*smolvm*
+```
+
+Then prove it:
+
+```bash
+sudo find / -iname '*smolvm*' -not -path '/proc/*' -not -path '/sys/*'    # expect nothing
+```
+
+**Why the last two removal lines exist.** After `k3s-uninstall.sh` plus removing the shim and
+`/var/lib/smolvm`, which is everything the docs and the obvious reading describe, a filesystem
+sweep still found five more locations: `/var/lib/containerd-shim-smolvm` (4.5 MB),
+`/root/.cache/smolvm` (9.0 MB), `/root/.local/share/smolvm` (312 KB), and pod logs under
+`/var/log/pods` and `/var/log/containers`. **The shim runs as root, so its VM state lands in
+root's home rather than the operator's**, which is why a teardown run as the operator misses it.
+Only after removing those did the sweep come back empty.
+
+A GPU on the node is unaffected throughout: `nvidia-smi` still reported the device after the full
+sequence.

--- a/skills/teardown/references/locations.md
+++ b/skills/teardown/references/locations.md
@@ -1,0 +1,75 @@
+# Where smolvm state lives, and what removes it
+
+Observed on v1.14.2.
+
+| | macOS | Linux |
+|---|---|---|
+| install prefix | `$HOME/.smolvm` | `$HOME/.smolvm` |
+| launcher symlink | `$HOME/.local/bin/smolvm` | `$HOME/.local/bin/smolvm` |
+| agent rootfs | `$HOME/Library/Application Support/smolvm` | `$HOME/.local/share/smolvm` |
+| per-VM state | `$HOME/Library/Caches/smolvm/vms` | `$HOME/.cache/smolvm/vms` |
+| image cache, once `--oci-cache` has run | `.../smolvm/vms/_shared` | `.../smolvm/vms/_shared` |
+| pack cache | `$HOME/Library/Caches/smolvm-pack` | `$HOME/.cache/smolvm-pack` |
+| packed-binary lib cache | `$HOME/Library/Caches/smolvm-libs` | `$HOME/.cache/smolvm-libs` |
+| registry credentials | `$HOME/.config/smolvm` | `$HOME/.config/smolvm` |
+| `PATH` block | your shell profile | your shell profile |
+
+The last three are the ones people miss. `smolvm-libs` appears only once a packed `.smolmachine`
+stub has run, and the last two are deliberately left by the uninstaller.
+
+`scripts/preflight.sh` reports each of these with its size, so you know what a teardown has to
+remove before you remove it.
+
+## Relocating state, for a test run
+
+On macOS and Linux every path above derives from `HOME`, so installing with `HOME` pointed at a
+scratch directory keeps a test run entirely inside it. That is how the runs behind this packet
+avoided touching a real installation, and `scripts/verify-clean.sh --protected <real prefix>` is
+the assertion that proves it.
+
+`SMOLVM_DATA_DIR` moves the data root on **Linux only**: the function that applies it is compiled
+in for Linux and does not exist on macOS or Windows. On macOS `HOME` is still enough. On Windows
+neither works, which is what makes that platform's teardown a manual removal. See
+`references/windows.md`.
+
+## Full removal
+
+```bash
+curl -sSL https://smolmachines.com/install.sh | bash -s -- --uninstall
+```
+
+Verified complete on macOS against an isolated `HOME` used for a full session of machines, packs
+and `--oci-cache` runs:
+
+```
+success: Removed <HOME>/.smolvm
+success: Removed symlink <HOME>/.local/bin/smolvm
+success: Removed data directory <HOME>/Library/Application Support/smolvm
+success: Removed cache directory <HOME>/Library/Caches/smolvm
+success: Removed pack cache directory <HOME>/Library/Caches/smolvm-pack
+warning: You may want to remove the PATH entry from your shell profile.
+success: smolvm has been uninstalled
+```
+
+Afterwards `find "$HOME" -iname '*smolvm*'` returned nothing. It removes `smolvm-libs` too when
+present.
+
+The two things it deliberately leaves, both of which it warns about:
+
+```bash
+# 1. the PATH block it added to your shell profile
+sed -i.bak '/# smolvm/,+1d' ~/.zshrc     # or ~/.bashrc; read the file before running this
+
+# 2. registry credentials, if you ever logged in to a registry
+rm -rf ~/.config/smolvm
+```
+
+`--uninstall` is documented only in `scripts/install.sh --help`, not in the README or on the docs
+site.
+
+## Reclaiming space without uninstalling
+
+```bash
+smolvm machine prune --name <NAME>   # one machine's unreferenced layers; --all drops its cached images
+smolvm pack prune                    # cached pack extractions
+```

--- a/skills/teardown/references/traps.md
+++ b/skills/teardown/references/traps.md
@@ -1,0 +1,96 @@
+# Teardown traps
+
+Almost every cleanup fact in smolvm is counterintuitive: the obvious assertion gives a false
+failure, the obvious reaper matches the wrong process, and the command a user reaches for when a
+run misbehaves does not stop the machine. Each entry below was hit on a real host.
+
+## `Ctrl-C` does not stop the machine
+
+**And there is no CLI route to the machine it leaves behind.** From a clean zero-process
+baseline, the VM's two processes were still alive at t+10 s, t+30 s and t+60 s after `SIGINT` to
+the CLI, and `SIGKILL` to the CLI left one. Throughout, `smolvm machine list` says
+`No machines found` and no VM cache directory exists.
+
+The VM exits only when its own **workload** finishes: a run whose command was `sleep 45` was gone
+30 s after the interrupt; one running `sleep 300` was still alive at 60 s. For a sandbox running
+untrusted code that loops or hangs, the exposure is unbounded.
+
+`scripts/cleanup.sh` is the only way to find it.
+
+## Three reapers that look right, and what each one misses
+
+**`pgrep -f _boot-vm` is too wide.** Any process whose command line contains that string matches,
+including the cleanup script itself. That produced a phantom "1 orphan survived" result and a
+confounded baseline that briefly made `Ctrl-C` look clean.
+
+**`readlink /proc/<pid>/exe` is unreliable in both directions.** For the exec'd VM child the
+process is not dumpable, so `/proc/<pid>/exe` is root-owned and `readlink` returns
+`Permission denied` to the user who started it:
+
+```
+$ ls -l /proc/51706/exe
+ls: cannot read symbolic link '/proc/51706/exe': Permission denied
+```
+
+On v1.14.6 it is readable for the forked child, which makes it useful for scoping and still no
+good for finding.
+
+**Matching `argv[1] == "_boot-vm"` is exact, and blind to half the VMs.** There are two shapes:
+
+| route | child | argv[1] | carries its boot config |
+|---|---|---|---|
+| plain `machine run` | exec'd | `_boot-vm` | yes, in argv[2] |
+| pack-run (`--oci-cache`, or any `init`) | **forked, never exec'd** | inherited, so `machine` | **no** |
+
+The forked child inherits the parent's whole command line, so nothing in its argv marks it as a
+VM. Measured on v1.14.6 on Ubuntu 24.04 aarch64 with two such orphans alive at 234 MB each, the
+argv-only scanner reported `vm_processes=none` and `result=clean`. **That is the worst of the
+outcomes: a false clean.**
+
+**What works.** On Linux both shapes rename themselves to `libkrun VM`, which no shell can hold,
+so `scripts/cleanup.sh` matches `/proc/<pid>/comm`, then scopes by argv[2] where it exists and by
+the executable's path where it does not. macOS exposes no rename, so the search is scoped by the
+executable path under this `HOME` and the parent chain separates a VM from the CLI that started
+it. Verified against a live orphan on both hosts.
+
+## Asserting "no machines" immediately after `machine run` fails on a healthy system
+
+A successful `machine run` returns **before** its entry retires. It was observed still listed as
+`vm-... unreachable (eph)` immediately after the command returned, and gone by 20 s. This is the
+single most likely false failure in a scripted teardown, and it is why `cleanup.sh` waits.
+
+## `machine delete` prompts and defaults to No
+
+Without `--force` a scripted cleanup prints `Delete machine '<name>'? [y/N] Cancelled` and
+**leaves the machine in place**, while the surrounding script carries on believing it cleaned up.
+A machine that has been branched additionally needs `--cascade`, which removes the children first.
+
+## `ls ~/.cache/smolvm/vms/ | wc -l` is not a leak check
+
+Once `--oci-cache` has been used, a `_shared` directory lives there holding the baked images
+(379 MB after one Python image). It is the cache, not residue. `cleanup.sh` and
+`verify-clean.sh` both exclude it.
+
+## Small leftover VM directories are not necessarily a leak either
+
+`smolvm serve start` prints `Reclaimed 2 dangling VM data dir(es)` on startup and clears them, so
+a directory left by a force-killed run is tidied the next time the API server runs.
+
+## On macOS, do not `rm -rf` the pack cache by hand
+
+`smolvm-pack` can contain `layers-cs` directories that are live `hdiutil` mount points, and `rm`
+fails on them with `Resource busy`. The uninstaller detaches them first
+(`find ... -name layers-cs -type d -exec hdiutil detach {} -force \;`); do the same if you are
+cleaning up manually.
+
+## Pre-existing residue is not yours
+
+Check timestamps and paths before reporting a leak. During the runs behind this packet a second
+VM belonging to another session was live on the same host, under a different `HOME`;
+`cleanup.sh` listed only the one under its own state tree and left the other running, which is
+the behaviour you want from anything you let run unattended.
+
+## Nothing in the docs describes cancellation or teardown
+
+`guides/agent-sandboxes-ci.md` is the page a sandbox author would read and it never mentions how
+to stop a run, which matters given the `Ctrl-C` behaviour above.

--- a/skills/teardown/references/windows.md
+++ b/skills/teardown/references/windows.md
@@ -1,0 +1,74 @@
+# Teardown on Windows
+
+**Not re-run.** Every command and output below was executed once on Windows 11 Home build 26200
+x86_64 against smolvm v1.14.2 and is reproduced unchanged. The Windows host was not available when
+this packet was written, and the 2026-09-11 batch on v1.14.6 did not reach this arm either, so
+everything here remains a v1.14.2 record.
+
+`scripts/preflight.sh`, `scripts/cleanup.sh` and `scripts/verify-clean.sh` are POSIX shell and do
+not run here. Follow this page instead.
+
+## Why Windows teardown matters more than elsewhere
+
+**smolvm's state cannot be relocated on Windows.** There is no `SMOLVM_DATA_DIR` in the Windows
+binary, and setting `$env:LOCALAPPDATA` moves nothing: smolvm resolves the known folder through
+the Windows API, which ignores the variable, and writes to the real `%LOCALAPPDATA%\smolvm`
+regardless. There is no isolated-HOME trick, so every test run writes into the real profile and
+teardown is the only way back.
+
+**The sizes are the surprise.** `%LOCALAPPDATA%\smolvm` reached **30756 MB** in one session,
+because each machine's storage and overlay images are sparse files with 20 GiB and 10 GiB
+apparent size. The session's own working directory was 1454 MB. A user who deletes only their
+working directory leaves 30 GB behind with nothing pointing at it.
+`%LOCALAPPDATA%\smolvm-pack` separately reached 92 GB apparent after three `pack run`s of one
+alpine pack.
+
+## The sequence
+
+```powershell
+# 1. delete every machine (--force, and --cascade for branch sources)
+& $exe machine list
+& $exe machine delete --name <each> --force --cascade
+
+# 2. stop anything still running
+Get-Process | Where-Object { $_.Path -like '*smolvm*' } | Stop-Process -Force
+
+# 3. remove the state smolvm created outside your working directory
+Remove-Item -Recurse -Force "$env:LOCALAPPDATA\smolvm"
+Remove-Item -Recurse -Force "$env:LOCALAPPDATA\smolvm-pack"   # exists once packs have run
+
+# 4. remove your own working directory
+Remove-Item -Recurse -Force <your scratch dir>
+```
+
+**A killed `--oci-cache` bake leaves a registered machine** named `init-bake-<hash>-<pid>`. It
+appears in `machine list` and has to be deleted like any other machine; nothing cleans it up, and
+they accumulate. On the tested host the bake never completed at all, so this is not a rare case:
+the helper VM finished its pull and went idle while the host CLI waited forever for a completion
+signal, and every attempt had to be killed.
+
+## Verify, and do not skip this
+
+```powershell
+Get-Process | Where-Object { $_.Path -like '*smolvm*' }                       # expect nothing
+Get-ChildItem $env:USERPROFILE,'C:\ProgramData' -Recurse -Force -Filter '*smolvm*' -EA SilentlyContinue
+Get-NetFirewallApplicationFilter | Where-Object { $_.Program -like '*smolvm*' }
+```
+
+All three returned nothing after the sequence above.
+
+## Proving a borrowed host was left clean
+
+The method used on the tested host, which was borrowed and had to be returned: record
+`path|size|mtime` for `%USERPROFILE%` and `C:\ProgramData` before and after, excluding your own
+working directory, then compare. `%LOCALAPPDATA%`, `%APPDATA%` and `%TEMP%` are all **inside**
+`%USERPROFILE%`, so listing them separately quadruples the work for no extra coverage: the naive
+version of that scan did not finish, and the de-duplicated one took 167 s for 982653 entries.
+The assertion that matters is that no new entry matches `smolvm|krun|libkrunfw`.
+
+## One more Windows process fact
+
+The `pack run` boot path spawns a **detached** `_boot-vm` rather than forking, with
+`DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP`. Measured on the tested host: the child survives a
+real `Ctrl-C` and a kill of the CLI, holds about 365 MB, and is invisible to `machine ls`. Only
+killing the child ends it, so step 2 above is not optional on Windows either.

--- a/skills/teardown/scripts/cleanup.sh
+++ b/skills/teardown/scripts/cleanup.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Delete the machines this packet's scripts created, then prove the host is clean.
+#
+# Only machines recorded in the state file are deleted, so a machine you or
+# another session created by hand is never touched. Scripts record a name by
+# calling: cleanup.sh --record <name>
+#
+# usage: cleanup.sh [--record <name>] [--reap] [--purge]
+#   --record <name>  add a machine name to the state file and exit
+#   --reap           kill leftover VM processes (see the warning it prints)
+#   --purge          also remove the state file once the list is empty
+
+set -uo pipefail
+
+PACKET="teardown"
+PREFIX="smolskill-"
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+STATE_DIR="${SMOLVM_SKILL_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/smolvm-skills}"
+STATE_FILE="$STATE_DIR/$PACKET.machines"
+
+reap=0
+purge=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --record)
+            mkdir -p "$STATE_DIR"
+            printf '%s\n' "$2" >> "$STATE_FILE"
+            exit 0
+            ;;
+        --reap)  reap=1 ;;
+        --purge) purge=1 ;;
+        *) printf 'unknown argument: %s\n' "$1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+if [ -z "$SMOLVM" ]; then
+    printf 'smolvm not found; set SMOLVM to its path\n' >&2
+    exit 2
+fi
+
+case "$(uname -s)" in
+    Darwin) VMS_DIR="$HOME/Library/Caches/smolvm/vms" ;;
+    *)      VMS_DIR="${SMOLVM_DATA_DIR:-$HOME/.cache/smolvm}/vms" ;;
+esac
+VMS_DIR="${SMOLVM_VMS_DIR:-$VMS_DIR}"
+SMOLVM_PREFIX="${SMOLVM_PREFIX:-$HOME/.smolvm}"
+
+# List this HOME's smolvm VM processes, as "pid marker".
+#
+# Two process shapes exist and a reaper has to catch both. The plain
+# `machine run` path EXECS a child whose argv[1] is `_boot-vm` and whose argv[2]
+# is its boot-config path. The pack-run path, which is `--oci-cache` or any
+# `init`, FORKS without execing, so the child inherits the parent's argv and
+# carries no boot-config at all. Matching `_boot-vm` alone is therefore blind to
+# exactly the path whose child survives an interrupt
+# (smol-machines/smolvm#1193): measured on v1.14.6, it reported "none" while two
+# orphaned VMs held 234 MB each.
+#
+# On Linux both shapes rename themselves to `libkrun VM`, the one marker that
+# covers both and that no shell can hold. macOS exposes no rename, so there the
+# executable path scopes the search to this HOME and the parent chain separates
+# a VM from the CLI that started it.
+#
+# `pgrep -f _boot-vm` is not an alternative: it matches any shell whose text
+# contains that string, including this script.
+list_vm_processes() {
+    case "$(uname -s)" in
+        Linux)
+            for p in /proc/[0-9]*; do
+                [ "$(cat "$p/comm" 2>/dev/null)" = "libkrun VM" ] || continue
+                pid="${p#/proc/}"
+                cfg="$(tr '\0' '\n' < "$p/cmdline" 2>/dev/null | sed -n '3p')"
+                case "$cfg" in
+                    "$VMS_DIR"/*) printf '%s %s\n' "$pid" "$cfg"; continue ;;
+                esac
+                # Forked shape: nothing in argv identifies it, so scope by the
+                # binary it is running.
+                case "$(readlink "$p/exe" 2>/dev/null)" in
+                    "$SMOLVM_PREFIX"/*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;;
+                esac
+            done
+            ;;
+        Darwin)
+            # shellcheck disable=SC2009  # pgrep cannot return ppid and the full
+            # command together, and pgrep -f matches this script's own text.
+            own=" $(ps -axo pid=,command= 2>/dev/null | grep -F "$SMOLVM_PREFIX/smolvm-bin" | awk '{print $1}' | tr '\n' ' ') "
+            ps -axo pid=,ppid=,command= 2>/dev/null | while read -r pid ppid rest; do
+                case "$rest" in "$SMOLVM_PREFIX"/smolvm-bin*) ;; *) continue ;; esac
+                case "$rest" in
+                    *" _boot-vm "*) printf '%s %s\n' "$pid" "${rest#* _boot-vm }"; continue ;;
+                esac
+                # Forked shape: its parent is the CLI that started it, or init
+                # once that CLI is gone.
+                if [ "$ppid" = 1 ]; then
+                    printf '%s orphaned-under %s\n' "$pid" "$SMOLVM_PREFIX"
+                else
+                    case "$own" in *" $ppid "*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;; esac
+                fi
+            done
+            ;;
+    esac
+}
+
+# 1. Delete recorded machines. --force is not optional: without it the command
+# prompts, defaults to No, and leaves the machine in place while the script
+# carries on. --cascade removes branch children, which otherwise block the
+# delete.
+if [ -s "$STATE_FILE" ]; then
+    while read -r name; do
+        [ -n "$name" ] || continue
+        case "$name" in "$PREFIX"*) ;; *)
+            printf 'skipping %s: not created by this packet (no %s prefix)\n' "$name" "$PREFIX"
+            continue ;;
+        esac
+        "$SMOLVM" machine stop   --name "$name" >/dev/null 2>&1
+        "$SMOLVM" machine delete --name "$name" --force --cascade 2>&1 | sed 's/^/  /'
+    done < "$STATE_FILE"
+fi
+
+# 2. An ephemeral machine's entry retires after the run returns, not with it.
+# Asserting an empty list immediately fails on a healthy host.
+sleep 20
+
+# 3. Assert the value, not the exit code.
+listing="$("$SMOLVM" machine list 2>&1)"
+if printf '%s' "$listing" | grep -q 'No machines found'; then
+    printf 'machines=clean\n'
+    [ "$purge" -eq 1 ] && rm -f "$STATE_FILE"
+else
+    printf 'machines=remaining\n'
+    printf '%s\n' "$listing" | sed 's/^/  /'
+fi
+
+# 4. Report VM processes an interrupt left behind. Ctrl-C does not stop a
+# machine: the VM outlives the CLI and `machine list` cannot see it, so this is
+# the only route to it. Only processes whose boot config lives under this HOME's
+# smolvm state are listed, so a VM another session started is left alone.
+found=0
+while read -r pid cfg; do
+    [ -n "$pid" ] || continue
+    found=1
+    printf 'vm_process=%s config=%s\n' "$pid" "$cfg"
+    if [ "$reap" -eq 1 ]; then
+        kill -9 "$pid" 2>/dev/null && printf '  killed %s\n' "$pid"
+    fi
+done <<EOF
+$(list_vm_processes)
+EOF
+
+if [ "$found" -eq 0 ]; then
+    printf 'vm_processes=none\n'
+elif [ "$reap" -eq 0 ]; then
+    printf 'rerun with --reap to kill them\n'
+fi

--- a/skills/teardown/scripts/preflight.sh
+++ b/skills/teardown/scripts/preflight.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Report what smolvm state exists on this host, so you know what teardown has to
+# remove before you remove it. Read-only: deletes nothing, starts no VM.
+#
+# Output is one key=value per line. The last line is always result=ready or
+# result=blocked.
+
+set -uo pipefail
+
+VERIFIED_VERSION="1.14.6"
+
+emit() { printf '%s=%s\n' "$1" "$2"; }
+note() { printf 'note=%s\n' "$1"; }
+
+blocked=0
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+if [ -z "$SMOLVM" ]; then
+    emit smolvm_installed no
+    blocked=1
+else
+    emit smolvm_installed yes
+    version="$("$SMOLVM" --version 2>/dev/null | awk '{print $NF}')"
+    emit smolvm_version "${version:-unknown}"
+fi
+
+emit verified_version "$VERIFIED_VERSION"
+if [ -n "${version:-}" ] && [ "$version" != "unknown" ]; then
+    if [ "$version" = "$VERIFIED_VERSION" ]; then
+        emit version_status match
+    else
+        newest="$(printf '%s\n%s\n' "$version" "$VERIFIED_VERSION" | sort -V | tail -1)"
+        if [ "$newest" = "$version" ]; then
+            emit version_status newer
+            note "this packet was verified on $VERIFIED_VERSION and the binary is $version; check each path below still exists before trusting a removal step"
+        else
+            emit version_status older
+        fi
+    fi
+else
+    emit version_status unknown
+fi
+
+kernel="$(uname -s)"
+arch="$(uname -m)"
+case "$arch" in aarch64|arm64) arch=aarch64 ;; esac
+
+case "$kernel" in
+    Darwin)
+        emit platform "darwin-$arch"
+        emit accel hvf
+        if [ "$(sysctl -n kern.hv_support 2>/dev/null)" = "1" ]; then emit accel_access ok; else emit accel_access denied; fi
+        data_dir="$HOME/Library/Application Support/smolvm"
+        cache_dir="$HOME/Library/Caches/smolvm"
+        pack_dir="$HOME/Library/Caches/smolvm-pack"
+        libs_dir="$HOME/Library/Caches/smolvm-libs"
+        emit unsupported "vulkan,cuda"
+        # There is no SMOLVM_DATA_DIR on macOS (it is Linux-only), but every path
+        # below is derived from HOME, so an install under a scratch HOME is
+        # self-contained. Windows is the platform where neither route works.
+        emit state_relocatable via_home
+        ;;
+    Linux)
+        emit platform "linux-$arch"
+        emit accel kvm
+        if [ -r /dev/kvm ] && [ -w /dev/kvm ]; then emit accel_access ok; else emit accel_access denied; fi
+        data_dir="$HOME/.local/share/smolvm"
+        cache_dir="$HOME/.cache/smolvm"
+        pack_dir="$HOME/.cache/smolvm-pack"
+        libs_dir="$HOME/.cache/smolvm-libs"
+        emit unsupported "vulkan"
+        emit state_relocatable via_home_or_data_dir
+        ;;
+    *)
+        emit platform "unsupported-$kernel"
+        emit accel unknown
+        emit accel_access unknown
+        blocked=1
+        note "this script covers macOS and Linux. The Windows removal sequence is references/windows.md and was not re-run by this packet."
+        exit_now=1
+        ;;
+esac
+
+if [ "${exit_now:-0}" = "1" ]; then
+    emit result blocked
+    exit 0
+fi
+
+report_dir() {
+    if [ -d "$2" ]; then
+        emit "$1" "$(du -sk "$2" 2>/dev/null | awk '{printf "%d", $1/1024}')MB"
+    else
+        emit "$1" absent
+    fi
+}
+
+report_dir install_prefix "$HOME/.smolvm"
+report_dir agent_rootfs   "$data_dir"
+report_dir vm_state       "$cache_dir"
+report_dir pack_cache     "$pack_dir"
+report_dir packed_libs    "$libs_dir"
+report_dir credentials    "$HOME/.config/smolvm"
+
+if [ -L "$HOME/.local/bin/smolvm" ]; then emit launcher_symlink present; else emit launcher_symlink absent; fi
+
+# `_shared` is the image store --oci-cache bakes into. It is the cache, not
+# residue, so counting it as a leak gives a false positive.
+if [ -d "$cache_dir/vms" ]; then
+    total="$(find "$cache_dir/vms" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')"
+    shared=0
+    [ -d "$cache_dir/vms/_shared" ] && shared=1
+    emit vm_dirs "$((total - shared))"
+    if [ "$shared" = 1 ]; then emit oci_cache_present yes; else emit oci_cache_present no; fi
+else
+    emit vm_dirs 0
+    emit oci_cache_present no
+fi
+
+if grep -rqs 'smolvm' "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.profile" 2>/dev/null; then
+    emit path_block present
+    note "the uninstaller deliberately leaves the PATH block and \$HOME/.config/smolvm; remove them by hand if you want them gone"
+else
+    emit path_block absent
+fi
+
+if [ "$blocked" -eq 0 ]; then emit result ready; else emit result blocked; fi

--- a/skills/teardown/scripts/verify-clean.sh
+++ b/skills/teardown/scripts/verify-clean.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Prove the host is clean after a teardown. Every check asserts a value rather
+# than an exit code, because the commands teardown runs report success while
+# leaving state behind.
+#
+# usage: verify-clean.sh [--protected <dir>] [--since <date>]
+#   --protected <dir>  assert nothing under <dir> was written on or after --since.
+#                      Point it at a real installation you ran beside: that is how
+#                      you show a test under an isolated HOME did not reach it.
+#                      Omitted, the check is reported as not run rather than passed.
+#   --since <date>     the cutoff for --protected (default: today)
+
+set -uo pipefail
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+since="$(date +%F)"
+protected=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --protected) protected="$2"; shift ;;
+        --since)     since="$2"; shift ;;
+        *) printf 'unknown argument: %s\n' "$1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+fail=0
+check() {
+    if [ "$2" = "$3" ]; then
+        printf '%s=ok\n' "$1"
+    else
+        printf '%s=FAIL expected=%s actual=%s\n' "$1" "$3" "$2"
+        fail=1
+    fi
+}
+
+if [ -n "$SMOLVM" ]; then
+    if "$SMOLVM" machine list 2>&1 | grep -q 'No machines found'; then
+        check machines clean clean
+    else
+        check machines dirty clean
+    fi
+else
+    printf 'machines=skipped (smolvm not on PATH; it may already be uninstalled)\n'
+fi
+
+case "$(uname -s)" in
+    Darwin) cache_dir="$HOME/Library/Caches/smolvm" ;;
+    *)      cache_dir="${SMOLVM_DATA_DIR:-$HOME/.cache/smolvm}" ;;
+esac
+VMS_DIR="${SMOLVM_VMS_DIR:-$cache_dir/vms}"
+SMOLVM_PREFIX="${SMOLVM_PREFIX:-$HOME/.smolvm}"
+
+# List this HOME's smolvm VM processes, as "pid marker".
+#
+# Two process shapes exist and a reaper has to catch both. The plain
+# `machine run` path EXECS a child whose argv[1] is `_boot-vm` and whose argv[2]
+# is its boot-config path. The pack-run path, which is `--oci-cache` or any
+# `init`, FORKS without execing, so the child inherits the parent's argv and
+# carries no boot-config at all. Matching `_boot-vm` alone is therefore blind to
+# exactly the path whose child survives an interrupt
+# (smol-machines/smolvm#1193): measured on v1.14.6, it reported "none" while two
+# orphaned VMs held 234 MB each.
+#
+# On Linux both shapes rename themselves to `libkrun VM`, the one marker that
+# covers both and that no shell can hold. macOS exposes no rename, so there the
+# executable path scopes the search to this HOME and the parent chain separates
+# a VM from the CLI that started it.
+#
+# `pgrep -f _boot-vm` is not an alternative: it matches any shell whose text
+# contains that string, including this script.
+list_vm_processes() {
+    case "$(uname -s)" in
+        Linux)
+            for p in /proc/[0-9]*; do
+                [ "$(cat "$p/comm" 2>/dev/null)" = "libkrun VM" ] || continue
+                pid="${p#/proc/}"
+                cfg="$(tr '\0' '\n' < "$p/cmdline" 2>/dev/null | sed -n '3p')"
+                case "$cfg" in
+                    "$VMS_DIR"/*) printf '%s %s\n' "$pid" "$cfg"; continue ;;
+                esac
+                # Forked shape: nothing in argv identifies it, so scope by the
+                # binary it is running.
+                case "$(readlink "$p/exe" 2>/dev/null)" in
+                    "$SMOLVM_PREFIX"/*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;;
+                esac
+            done
+            ;;
+        Darwin)
+            # shellcheck disable=SC2009  # pgrep cannot return ppid and the full
+            # command together, and pgrep -f matches this script's own text.
+            own=" $(ps -axo pid=,command= 2>/dev/null | grep -F "$SMOLVM_PREFIX/smolvm-bin" | awk '{print $1}' | tr '\n' ' ') "
+            ps -axo pid=,ppid=,command= 2>/dev/null | while read -r pid ppid rest; do
+                case "$rest" in "$SMOLVM_PREFIX"/smolvm-bin*) ;; *) continue ;; esac
+                case "$rest" in
+                    *" _boot-vm "*) printf '%s %s\n' "$pid" "${rest#* _boot-vm }"; continue ;;
+                esac
+                # Forked shape: its parent is the CLI that started it, or init
+                # once that CLI is gone.
+                if [ "$ppid" = 1 ]; then
+                    printf '%s orphaned-under %s\n' "$pid" "$SMOLVM_PREFIX"
+                else
+                    case "$own" in *" $ppid "*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;; esac
+                fi
+            done
+            ;;
+    esac
+}
+
+# _shared is the --oci-cache image store, not residue. Excluding it is what
+# makes this a leak check rather than a false alarm.
+if [ -d "$cache_dir/vms" ]; then
+    left="$(find "$cache_dir/vms" -mindepth 1 -maxdepth 1 -type d ! -name _shared 2>/dev/null | wc -l | tr -d ' ')"
+else
+    left=0
+fi
+check vm_dirs "$left" 0
+
+procs="$(list_vm_processes | grep -c . )"
+check vm_processes "$procs" 0
+
+# Proof that a run under an isolated HOME left a real installation alone. Silence
+# here would read as a pass, so an unchecked run says so.
+if [ -n "$protected" ]; then
+    touched="$(find "$protected" -newermt "$since" 2>/dev/null | wc -l | tr -d ' ')"
+    check "protected_untouched_since_$since" "$touched" 0
+else
+    printf 'protected=not_checked (pass --protected <dir> to assert a real install was untouched)\n'
+fi
+
+if [ "$fail" -eq 0 ]; then printf 'result=clean\n'; else printf 'result=dirty\n'; fi
+exit "$fail"


### PR DESCRIPTION
First set (1/2) of battle tested runbooks to improve agent experience in smolvm.

A coding agent that wants to use smolvm as its sandbox has to design the machine lifecycle by hand every time, and the first attempt walks into traps (a long socket path that hangs the boot, a mount count over the device budget, a cached run that survives Ctrl-C), so agents improvise unsafe shell commands instead. 

**#1175 asks for an official, maintained skill that removes that work.**
_This PR adds three task-scoped packets under skills/: install, teardown and sandbox._

Each is a SKILL.md with the procedure, scripts/ for the deterministic steps, and references/ for traps and per-platform arms. AGENTS.md gains a Skills section and the README a paragraph saying which packet answers which task and how an agent finds them.

Against the acceptance criteria in #1175: 
- the sandbox builds or tests a repository with the repo mounted read-only at /workspace and artifacts collected from a writable output directory
- the network is off by default and egress is granted one host at a time, with no SSH agent, system directories or host environment passed through
- failed and interrupted runs leave no machine behind, because the scripts assert values rather than exit codes and cancellation is a script that reaps by pid, since Ctrl-C leaves a cached run's VM running (#1193)
- mount permissions, resource limits, platform requirements and the security model are stated in each packet
- every packet carries the release it was verified on and warns when the installed binary is newer.

---

Every step was run end to end on the published v1.14.6, on macOS 26.6.2 arm64 and Ubuntu 24.04 aarch64. The Windows arms are reference pages recording earlier runs and say so.

Two things changed on this release and both are in the packets:
- The offline sandbox route now completes on Linux: the run reaches no registry and the workload reaches no network at all.
- The reaper was rewritten. The pack-run VM child is forked, not exec'd, so it carries no _boot-vm in argv, and the old scanner reported a clean host over two abandoned VMs of 234 MB each. It now matches the process name both shapes carry, verified against a live orphan on both hosts.

Two limitations, both named in the packets:
- the offline shape is Linux-only today, because on macOS a cached run with a mount never boots (#1192)
- there is no per-command timeout flag on these paths, so the agent-ready limit stays the fixed 30 seconds.

Discovery: skills/ is the home, the SKILL.md frontmatter is what current agents read, and the paths Claude Code and OpenCode scan are listed from their own documentation with the date read. No symlink is committed and nothing is added to the release tarball.

Not in this PR: four more packets with the same shape (a persistent dev environment, the local HTTP API, Docker inside a machine, CUDA against a host GPU), which follow in #1234.

Closes #1175
