### PR TITLE
Lay the release out as bin/, conf/, and lib/

### DIFF
--- a/.github/workflows/pacman-repo.yml
+++ b/.github/workflows/pacman-repo.yml
@@ -136,6 +136,10 @@ jobs:
             rm -rf pkgroot
             mkdir pkgroot
             tar -xzf tarball.tgz --strip-components=1 -C pkgroot
+            # 1.15+ tarballs keep executables in bin/ and templates in conf/;
+            # flatten so the nfpm file map works for both layouts.
+            if [ -d pkgroot/bin ]; then mv pkgroot/bin/* pkgroot/ && rmdir pkgroot/bin; fi
+            if [ -d pkgroot/conf ]; then mv pkgroot/conf/* pkgroot/ && rmdir pkgroot/conf; fi
             cp packaging/deb/copyright pkgroot/copyright
             sed -i \
               -e 's|^SMOLVM_BIN=.*|SMOLVM_BIN=/usr/lib/smolvm/smolvm-bin|' \

--- a/crates/smolvm-pack/src/assets.rs
+++ b/crates/smolvm-pack/src/assets.rs
@@ -260,7 +260,16 @@ pub fn find_existing_template(filename: &str) -> Option<PathBuf> {
     }
     if let Ok(exe) = std::env::current_exe() {
         if let Some(dir) = exe.parent() {
+            // Beside the executable: the Windows release and pre-bin/ Unix
+            // dists ship templates flat next to the binary.
             roots.push(dir.to_path_buf());
+            // The bin/ dist layout keeps executables in bin/ with the
+            // templates in a conf/ sibling (and installs migrated from the
+            // flat layout may still hold them at the install root).
+            if let Some(root) = dir.parent() {
+                roots.push(root.join("conf"));
+                roots.push(root.to_path_buf());
+            }
         }
     }
 

--- a/nix/smolvm.nix
+++ b/nix/smolvm.nix
@@ -88,13 +88,18 @@ in
 
         mkdir -p $out/libexec/smolvm $out/bin
         cp -R . $out/libexec/smolvm/
-        chmod +x $out/libexec/smolvm/smolvm $out/libexec/smolvm/smolvm-bin
-        patchShebangs $out/libexec/smolvm/smolvm
+        # 1.15+ tarballs keep executables in bin/; older ones are flat.
+        bindir=$out/libexec/smolvm
+        if [ -d $out/libexec/smolvm/bin ]; then
+          bindir=$out/libexec/smolvm/bin
+        fi
+        chmod +x $bindir/smolvm $bindir/smolvm-bin
+        patchShebangs $bindir/smolvm
       ''
       + lib.optionalString stdenv.hostPlatform.isLinux ''
         patchelf --set-interpreter ${stdenv.cc.bintools.dynamicLinker} \
-          --set-rpath '$ORIGIN/lib:${linuxRpath}' \
-          $out/libexec/smolvm/smolvm-bin
+          --set-rpath '$ORIGIN/lib:$ORIGIN/../lib:${linuxRpath}' \
+          $bindir/smolvm-bin
 
         for library in $out/libexec/smolvm/lib/*.so*; do
           if patchelf --print-needed "$library" >/dev/null 2>&1; then
@@ -103,7 +108,7 @@ in
         done
       ''
       + ''
-        makeWrapper $out/libexec/smolvm/smolvm $out/bin/smolvm \
+        makeWrapper $bindir/smolvm $out/bin/smolvm \
           --set-default SMOLVM_AGENT_ROOTFS $out/libexec/smolvm/agent-rootfs \
           --prefix PATH : ${lib.makeBinPath runtimeDeps}
 

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -65,21 +65,27 @@ package() {
     esac
     cd "$_dir"
 
+    # 1.15+ tarballs keep executables in bin/ and disk templates in conf/;
+    # older ones are flat. Resolve once so this PKGBUILD builds either.
+    local _bindir=. _confdir=.
+    [[ -d bin ]] && _bindir=bin
+    [[ -d conf ]] && _confdir=conf
+
     # Point the wrapper at the packaged locations instead of script-relative ones
     sed -i \
         -e 's|^SMOLVM_BIN=.*|SMOLVM_BIN=/usr/lib/smolvm/smolvm-bin|' \
         -e 's|^SMOLVM_LIB=.*|SMOLVM_LIB=/usr/lib/smolvm/lib|' \
         -e 's|^SMOLVM_BUNDLED_ROOTFS=.*|SMOLVM_BUNDLED_ROOTFS=/usr/lib/smolvm/agent-rootfs|' \
-        smolvm
+        "$_bindir/smolvm"
 
-    install -Dm0755 smolvm "$pkgdir/usr/bin/smolvm"
-    install -Dm0755 smolvm-bin "$pkgdir/usr/lib/smolvm/smolvm-bin"
+    install -Dm0755 "$_bindir/smolvm" "$pkgdir/usr/bin/smolvm"
+    install -Dm0755 "$_bindir/smolvm-bin" "$pkgdir/usr/lib/smolvm/smolvm-bin"
     cp -a lib "$pkgdir/usr/lib/smolvm/lib"
     cp -r agent-rootfs "$pkgdir/usr/lib/smolvm/agent-rootfs"
     # pre-formatted disk templates, zstd-compressed (optional at runtime; the
     # engine expands them to sparse files on first use, saving a mkfs)
-    install -Dm644 storage-template.ext4.zst "$pkgdir/usr/lib/smolvm/storage-template.ext4.zst"
-    install -Dm644 overlay-template.ext4.zst "$pkgdir/usr/lib/smolvm/overlay-template.ext4.zst"
+    install -Dm644 "$_confdir/storage-template.ext4.zst" "$pkgdir/usr/lib/smolvm/storage-template.ext4.zst"
+    install -Dm644 "$_confdir/overlay-template.ext4.zst" "$pkgdir/usr/lib/smolvm/overlay-template.ext4.zst"
     install -Dm644 "../LICENSE-$pkgver" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
     install -Dm644 README.txt "$pkgdir/usr/share/doc/$pkgname/README.txt"
 }

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -327,17 +327,19 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
     fi
 fi
 
-# Create distribution directory
+# Create distribution directory. Executables live in bin/, disk templates in
+# conf/, libraries in lib/, so the tarball root holds only directories and the
+# informational files (README.txt, checksums.txt). See issue #1069.
 echo "Creating distribution package..."
 rm -rf "$DIST_DIR"
-mkdir -p "$DIST_DIR/lib"
+mkdir -p "$DIST_DIR/bin" "$DIST_DIR/conf" "$DIST_DIR/lib"
 
 # Copy binary (renamed to smolvm-bin)
-cp ./target/release/smolvm "$DIST_DIR/smolvm-bin"
+cp ./target/release/smolvm "$DIST_DIR/bin/smolvm-bin"
 
 # Copy wrapper script
-cp ./scripts/smolvm-wrapper.sh "$DIST_DIR/smolvm"
-chmod +x "$DIST_DIR/smolvm"
+cp ./scripts/smolvm-wrapper.sh "$DIST_DIR/bin/smolvm"
+chmod +x "$DIST_DIR/bin/smolvm"
 
 # Kubernetes runtime: the containerd shim plus everything needed to register
 # it. Shipping these means `runtimeClassName: smolvm` is reachable from a
@@ -345,8 +347,8 @@ chmod +x "$DIST_DIR/smolvm"
 # the feature was invisible to anyone who installed the normal way.
 if [[ "$(uname -s)" == "Linux" ]]; then
     mkdir -p "$DIST_DIR/kubernetes"
-    cp ./target/release/containerd-shim-smolvm-v2 "$DIST_DIR/containerd-shim-smolvm-v2"
-    chmod +x "$DIST_DIR/containerd-shim-smolvm-v2"
+    cp ./target/release/containerd-shim-smolvm-v2 "$DIST_DIR/bin/containerd-shim-smolvm-v2"
+    chmod +x "$DIST_DIR/bin/containerd-shim-smolvm-v2"
     cp ./scripts/install-k8s-runtime.sh "$DIST_DIR/kubernetes/"
     chmod +x "$DIST_DIR/kubernetes/install-k8s-runtime.sh"
     cp ./deploy/kubernetes/runtimeclass.yaml ./deploy/kubernetes/example-pod.yaml "$DIST_DIR/kubernetes/"
@@ -357,9 +359,9 @@ fi
 # The wrapper points at the same lib/ and agent-rootfs, so one tarball serves
 # both `smol` (the user-facing CLI) and `smolvm` (the lower-level engine).
 if [[ "$BUILD_SMOL" == "1" ]]; then
-    cp ./smol/target/release/smol "$DIST_DIR/smol-bin"
-    cp ./scripts/smol-wrapper.sh "$DIST_DIR/smol"
-    chmod +x "$DIST_DIR/smol"
+    cp ./smol/target/release/smol "$DIST_DIR/bin/smol-bin"
+    cp ./scripts/smol-wrapper.sh "$DIST_DIR/bin/smol"
+    chmod +x "$DIST_DIR/bin/smol"
 fi
 
 # Copy libraries
@@ -493,8 +495,8 @@ if [[ "$(uname -s)" == "Linux" ]]; then
 
     if [[ -n "$INIT_KRUN" ]]; then
         echo "Copying init.krun from $INIT_KRUN..."
-        cp "$INIT_KRUN" "$DIST_DIR/init.krun"
-        chmod +x "$DIST_DIR/init.krun"
+        cp "$INIT_KRUN" "$DIST_DIR/lib/init.krun"
+        chmod +x "$DIST_DIR/lib/init.krun"
 
         # init.krun runs as the guest PID 1, so it must match the target arch.
         # libkrun/init/init is a committed binary that does NOT track the build
@@ -507,7 +509,7 @@ if [[ "$(uname -s)" == "Linux" ]]; then
             aarch64|arm64) want="aarch64" ;;
             *)       want="" ;;
         esac
-        init_desc="$(file -b "$DIST_DIR/init.krun")"
+        init_desc="$(file -b "$DIST_DIR/lib/init.krun")"
         if [[ -n "$want" ]] && [[ "$init_desc" != *"$want"* ]]; then
             echo "ERROR: init.krun is the wrong architecture for a $host_arch build." >&2
             echo "       expected '$want', got: $init_desc" >&2
@@ -550,7 +552,7 @@ echo "Agent rootfs size: $(du -sh "$DIST_DIR/agent-rootfs" | cut -f1)"
 # This eliminates the e2fsprogs dependency for end users
 echo "Creating storage template..."
 TEMPLATE_SIZE=$((512 * 1024 * 1024))  # 512MB
-TEMPLATE_PATH="$DIST_DIR/storage-template.ext4"
+TEMPLATE_PATH="$DIST_DIR/conf/storage-template.ext4"
 
 # Find mkfs.ext4
 MKFS_PATHS=(
@@ -600,7 +602,7 @@ else
     echo "Storage template created: $(du -h "$TEMPLATE_PATH" | cut -f1) physical (20 GiB virtual)"
 
     # Create overlay template (same format, different label)
-    OVERLAY_TEMPLATE_PATH="$DIST_DIR/overlay-template.ext4"
+    OVERLAY_TEMPLATE_PATH="$DIST_DIR/conf/overlay-template.ext4"
     dd if=/dev/zero of="$OVERLAY_TEMPLATE_PATH" bs=1 count=0 seek=$TEMPLATE_SIZE 2>/dev/null
     "$MKFS_BIN" -F -q -m 0 -L smolvm-overlay "$OVERLAY_TEMPLATE_PATH"
     # Size to the default overlay virtual size (DEFAULT_OVERLAY_SIZE_GIB=10).
@@ -639,15 +641,23 @@ INSTALLATION
    tar -xzf smolvm-*.tar.gz
    cd smolvm-*
 
-2. Run the smolvm wrapper script. It automatically uses the bundled
-   agent-rootfs/ directory when present.
+2. Run bin/smolvm. The wrapper automatically uses the bundled lib/ and
+   agent-rootfs/ directories.
 
 3. (Optional) Add to PATH:
    # Add to ~/.bashrc or ~/.zshrc:
-   export PATH="/path/to/smolvm-directory:$PATH"
+   export PATH="/path/to/smolvm-directory/bin:$PATH"
 
 4. (Optional) Create a symlink:
-   sudo ln -s /path/to/smolvm-directory/smolvm /usr/local/bin/smolvm
+   sudo ln -s /path/to/smolvm-directory/bin/smolvm /usr/local/bin/smolvm
+
+LAYOUT
+======
+
+  bin/           smolvm (wrapper), smolvm-bin, and any bundled CLIs
+  conf/          pre-formatted disk templates (storage/overlay, zstd)
+  lib/           libkrun, libkrunfw, and the other bundled libraries
+  agent-rootfs/  the guest agent's root filesystem
 
 PREREQUISITES
 =============
@@ -663,15 +673,15 @@ Linux:
 USAGE
 =====
 
-Run the 'smolvm' script (not smolvm-bin directly):
+Run the 'bin/smolvm' script (not smolvm-bin directly):
 
-  ./smolvm machine run --net --image alpine -- echo "Hello World"
-  ./smolvm machine create --net --name myvm
-  ./smolvm machine start --name myvm
-  ./smolvm machine exec --name myvm -- /bin/sh
-  ./smolvm machine ls
-  ./smolvm machine stop --name myvm
-  ./smolvm machine delete --name myvm
+  ./bin/smolvm machine run --net --image alpine -- echo "Hello World"
+  ./bin/smolvm machine create --net --name myvm
+  ./bin/smolvm machine start --name myvm
+  ./bin/smolvm machine exec --name myvm -- /bin/sh
+  ./bin/smolvm machine ls
+  ./bin/smolvm machine stop --name myvm
+  ./bin/smolvm machine delete --name myvm
 
 TROUBLESHOOTING
 ===============
@@ -702,7 +712,7 @@ else
     echo "Error: neither sha256sum nor shasum found; cannot generate checksums" >&2
     exit 1
 fi
-(cd "$DIST_DIR" && "${SHA256_CMD[@]}" smolvm smolvm-bin lib/* > checksums.txt)
+(cd "$DIST_DIR" && "${SHA256_CMD[@]}" bin/smolvm bin/smolvm-bin lib/* > checksums.txt)
 
 # Delete existing tarball. This is because when a new release is created, there could be 
 # tarball of the old release left in dist/, and ./install-local.sh may pick up the wrong tarball

--- a/scripts/install-k8s-runtime.sh
+++ b/scripts/install-k8s-runtime.sh
@@ -27,7 +27,10 @@ set -euo pipefail
 # unpacked release, where it sits beside the runtime artifacts one level up
 # from this script, and a source checkout, where cargo leaves it in target/.
 _HERE="$(cd "$(dirname "$0")" && pwd)"
-if [ -x "$_HERE/../containerd-shim-smolvm-v2" ]; then
+if [ -x "$_HERE/../bin/containerd-shim-smolvm-v2" ]; then
+    # 1.15+ releases keep executables in bin/ at the dist root.
+    SHIM_SRC="$_HERE/../bin/containerd-shim-smolvm-v2"
+elif [ -x "$_HERE/../containerd-shim-smolvm-v2" ]; then
     SHIM_SRC="$_HERE/../containerd-shim-smolvm-v2"
 else
     SHIM_SRC="target/release/containerd-shim-smolvm-v2"
@@ -63,6 +66,11 @@ if [ -n "$RUNTIME_SRC" ]; then
             echo "    warning: $a not found in $RUNTIME_SRC — leaving existing" >&2
         fi
     done
+    # 1.15+ dists carry init.krun inside lib/ (it arrives with the lib copy
+    # above); keep the root-of-DATA_DIR location older artifacts used.
+    if [ ! -e "$DATA_DIR/init.krun" ] && [ -e "$DATA_DIR/lib/init.krun" ]; then
+        cp -a "$DATA_DIR/lib/init.krun" "$DATA_DIR/init.krun"
+    fi
 else
     echo "    (no --runtime-dir; keeping existing artifacts)"
 fi

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -74,8 +74,18 @@ find_tarball() {
 install_from_dir() {
     local src_dir="$1"
 
+    # Tarball layout: newer dists keep executables in bin/ and disk templates
+    # in conf/; older ones are flat. The install mirrors the dist's own layout
+    # into the prefix — the wrapper resolves lib/ relative to itself, so the
+    # two must move together.
+    local src_bin_dir="$src_dir" dst_bin_dir="$INSTALL_PREFIX"
+    if [[ -d "$src_dir/bin" ]]; then
+        src_bin_dir="$src_dir/bin"
+        dst_bin_dir="$INSTALL_PREFIX/bin"
+    fi
+
     # Verify required files exist
-    if [[ ! -f "$src_dir/smolvm" ]] || [[ ! -f "$src_dir/smolvm-bin" ]]; then
+    if [[ ! -f "$src_bin_dir/smolvm" ]] || [[ ! -f "$src_bin_dir/smolvm-bin" ]]; then
         error "Invalid smolvm distribution: missing smolvm or smolvm-bin"
         exit 1
     fi
@@ -96,15 +106,19 @@ install_from_dir() {
     # Create installation directory
     mkdir -p "$INSTALL_PREFIX"
 
-    # Remove old installation
-    rm -rf "$INSTALL_PREFIX/lib"
+    # Remove old installation (both layouts, so upgrades never mix them)
+    rm -rf "$INSTALL_PREFIX/lib" "$INSTALL_PREFIX/bin" "$INSTALL_PREFIX/conf"
     rm -f "$INSTALL_PREFIX/smolvm" "$INSTALL_PREFIX/smolvm-bin"
 
     # Copy files
+    mkdir -p "$dst_bin_dir"
     cp -r "$src_dir/lib" "$INSTALL_PREFIX/"
-    cp "$src_dir/smolvm" "$INSTALL_PREFIX/"
-    cp "$src_dir/smolvm-bin" "$INSTALL_PREFIX/"
-    chmod +x "$INSTALL_PREFIX/smolvm" "$INSTALL_PREFIX/smolvm-bin"
+    if [[ -d "$src_dir/conf" ]]; then
+        cp -r "$src_dir/conf" "$INSTALL_PREFIX/"
+    fi
+    cp "$src_bin_dir/smolvm" "$dst_bin_dir/"
+    cp "$src_bin_dir/smolvm-bin" "$dst_bin_dir/"
+    chmod +x "$dst_bin_dir/smolvm" "$dst_bin_dir/smolvm-bin"
 
     # Install agent-rootfs to data directory
     local data_dir
@@ -125,20 +139,25 @@ install_from_dir() {
         warn "agent-rootfs not found in distribution"
     fi
 
-    # Copy init.krun if present (Linux only, required by libkrunfw kernel)
-    if [[ -f "$src_dir/init.krun" ]]; then
-        info "Installing init.krun to $data_dir..."
-        cp "$src_dir/init.krun" "$data_dir/init.krun"
-        chmod +x "$data_dir/init.krun"
-        success "init.krun installed"
-    fi
+    # Copy init.krun if present (Linux only, required by libkrunfw kernel).
+    # Newer dists carry it in lib/, older ones at the root.
+    local init_krun
+    for init_krun in "$src_dir/lib/init.krun" "$src_dir/init.krun"; do
+        if [[ -f "$init_krun" ]]; then
+            info "Installing init.krun to $data_dir..."
+            cp "$init_krun" "$data_dir/init.krun"
+            chmod +x "$data_dir/init.krun"
+            success "init.krun installed"
+            break
+        fi
+    done
 
     # Store version
     echo "$version" > "$INSTALL_PREFIX/.version"
 
     # Create symlink
     mkdir -p "$BIN_DIR"
-    ln -sf "$INSTALL_PREFIX/smolvm" "$BIN_DIR/smolvm"
+    ln -sf "$dst_bin_dir/smolvm" "$BIN_DIR/smolvm"
 
     success "Installed smolvm to $INSTALL_PREFIX"
     success "Symlink created at $BIN_DIR/smolvm"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -309,12 +309,12 @@ zstd_declared_size() {
 # Fail the install unless the templates the runtime will look for are present
 # and will present their full virtual size.
 #
-# The runtime resolves `<name>` before `<name>.zst`, under ~/.smolvm and beside
-# the binary, and takes the instant copy-on-write boot path only when the
-# resolved template is at least the disk type's default size. `$prefix` is both
-# of those roots for an install: it is the default prefix, and it is the
-# directory the installed binary runs from. A compressed template is measured by
-# the size its frame declares, which is what expanding it produces.
+# The runtime resolves `<name>` before `<name>.zst`, under ~/.smolvm, beside
+# the binary, and in the conf/ sibling of a bin/-layout install, and takes the
+# instant copy-on-write boot path only when the resolved template is at least
+# the disk type's default size. `$prefix` here is the directory this install
+# wrote the templates to, which is one of those roots. A compressed template is
+# measured by the size its frame declares, which is what expanding it produces.
 verify_disk_templates() {
     local prefix="$1"
     local spec name min_bytes resolved size
@@ -408,6 +408,22 @@ install_smolvm() {
         exit 1
     fi
 
+    # Tarball layout: newer releases keep executables in bin/ and disk
+    # templates in conf/; older releases (still installable via --version) are
+    # flat. The install mirrors the tarball's own layout into the prefix — the
+    # bundled wrapper resolves lib/ and agent-rootfs/ relative to itself, so
+    # the two must move together.
+    local src_bin_dir="$extracted_dir" src_conf_dir="$extracted_dir"
+    local dst_bin_dir="$prefix" dst_conf_dir="$prefix"
+    if [[ -d "$extracted_dir/bin" ]]; then
+        src_bin_dir="$extracted_dir/bin"
+        dst_bin_dir="$prefix/bin"
+    fi
+    if [[ -d "$extracted_dir/conf" ]]; then
+        src_conf_dir="$extracted_dir/conf"
+        dst_conf_dir="$prefix/conf"
+    fi
+
     # Safety: refuse to install to system directories
     case "$prefix" in
         /|/usr|/usr/*|/bin|/sbin|/lib|/lib64|/etc|/var|/opt|/tmp|/System|/System/*|/Library|/Library/*)
@@ -450,6 +466,16 @@ install_smolvm() {
         warn "$prefix/lib exists but no .version file found — skipping lib/ removal"
         warn "If this is a previous smolvm install, remove it manually first"
     fi
+    # Same guard for the bin/ and conf/ directories the newer layout writes.
+    local sub
+    for sub in bin conf; do
+        if [[ -d "$prefix/$sub" ]] && [[ -f "$prefix/.version" ]]; then
+            rm -rf "$prefix/${sub:?}"
+        elif [[ -d "$prefix/$sub" ]]; then
+            warn "$prefix/$sub exists but no .version file found — skipping removal"
+            warn "If this is a previous smolvm install, remove it manually first"
+        fi
+    done
     # An older layout bundled agent-rootfs next to the binary, and the wrapper
     # prefers that copy over the one in the data directory. Upgrades refresh the
     # data-dir copy but left this one in place, so a new binary kept booting a
@@ -477,6 +503,9 @@ install_smolvm() {
     if [[ -f "$prefix/smolvm-stub" ]]; then
         rm -f "$prefix/smolvm-stub"
     fi
+    if [[ -f "$prefix/containerd-shim-smolvm-v2" ]]; then
+        rm -f "$prefix/containerd-shim-smolvm-v2"
+    fi
     if [[ -f "$prefix/storage-template.ext4" ]]; then
         rm -f "$prefix/storage-template.ext4"
     fi
@@ -491,20 +520,21 @@ install_smolvm() {
     fi
 
     # Copy files
+    mkdir -p "$dst_bin_dir" "$dst_conf_dir"
     cp -r "$extracted_dir/lib" "$prefix/"
-    cp "$extracted_dir/smolvm" "$prefix/"
-    cp "$extracted_dir/smolvm-bin" "$prefix/"
-    chmod +x "$prefix/smolvm"
-    chmod +x "$prefix/smolvm-bin"
+    cp "$src_bin_dir/smolvm" "$dst_bin_dir/"
+    cp "$src_bin_dir/smolvm-bin" "$dst_bin_dir/"
+    chmod +x "$dst_bin_dir/smolvm"
+    chmod +x "$dst_bin_dir/smolvm-bin"
 
     # Copy the unified `smol` CLI if the distribution includes it. Older
     # engine-only tarballs won't have it; newer ones ship both.
     local has_smol=false
-    if [[ -f "$extracted_dir/smol" ]] && [[ -f "$extracted_dir/smol-bin" ]]; then
-        cp "$extracted_dir/smol" "$prefix/"
-        cp "$extracted_dir/smol-bin" "$prefix/"
-        chmod +x "$prefix/smol"
-        chmod +x "$prefix/smol-bin"
+    if [[ -f "$src_bin_dir/smol" ]] && [[ -f "$src_bin_dir/smol-bin" ]]; then
+        cp "$src_bin_dir/smol" "$dst_bin_dir/"
+        cp "$src_bin_dir/smol-bin" "$dst_bin_dir/"
+        chmod +x "$dst_bin_dir/smol"
+        chmod +x "$dst_bin_dir/smol-bin"
         has_smol=true
     fi
 
@@ -512,9 +542,9 @@ install_smolvm() {
     # tarballs only; older ones won't have it). Without this the shim ships in
     # the release but never reaches disk, so `runtimeClassName: smolvm` stays
     # out of reach for anyone who installed with this script.
-    if [[ -f "$extracted_dir/containerd-shim-smolvm-v2" ]]; then
-        cp "$extracted_dir/containerd-shim-smolvm-v2" "$prefix/"
-        chmod +x "$prefix/containerd-shim-smolvm-v2"
+    if [[ -f "$src_bin_dir/containerd-shim-smolvm-v2" ]]; then
+        cp "$src_bin_dir/containerd-shim-smolvm-v2" "$dst_bin_dir/"
+        chmod +x "$dst_bin_dir/containerd-shim-smolvm-v2"
         if [[ -d "$extracted_dir/kubernetes" ]]; then
             rm -rf "$prefix/kubernetes"
             cp -r "$extracted_dir/kubernetes" "$prefix/"
@@ -525,15 +555,15 @@ install_smolvm() {
     # Copy disk templates if present. Releases ship them zstd-compressed, and
     # the runtime expands a `.zst` next to itself on first use, so either form
     # is usable; prefer the compressed one the tarball actually carries.
-    if [[ -f "$extracted_dir/storage-template.ext4.zst" ]]; then
-        cp "$extracted_dir/storage-template.ext4.zst" "$prefix/"
-    elif [[ -f "$extracted_dir/storage-template.ext4" ]]; then
-        cp "$extracted_dir/storage-template.ext4" "$prefix/"
+    if [[ -f "$src_conf_dir/storage-template.ext4.zst" ]]; then
+        cp "$src_conf_dir/storage-template.ext4.zst" "$dst_conf_dir/"
+    elif [[ -f "$src_conf_dir/storage-template.ext4" ]]; then
+        cp "$src_conf_dir/storage-template.ext4" "$dst_conf_dir/"
     fi
-    if [[ -f "$extracted_dir/overlay-template.ext4.zst" ]]; then
-        cp "$extracted_dir/overlay-template.ext4.zst" "$prefix/"
-    elif [[ -f "$extracted_dir/overlay-template.ext4" ]]; then
-        cp "$extracted_dir/overlay-template.ext4" "$prefix/"
+    if [[ -f "$src_conf_dir/overlay-template.ext4.zst" ]]; then
+        cp "$src_conf_dir/overlay-template.ext4.zst" "$dst_conf_dir/"
+    elif [[ -f "$src_conf_dir/overlay-template.ext4" ]]; then
+        cp "$src_conf_dir/overlay-template.ext4" "$dst_conf_dir/"
     fi
 
     # Size the disk templates to their default virtual size at install time, so
@@ -545,12 +575,12 @@ install_smolvm() {
     # case the runtime safely falls back to the copy path. The sizes mirror
     # DEFAULT_STORAGE_SIZE_GIB (20) and DEFAULT_OVERLAY_SIZE_GIB (10).
     if [[ "$(uname -s)" == "Linux" ]] && command -v truncate >/dev/null 2>&1; then
-        [[ -f "$prefix/storage-template.ext4" ]] && truncate -s 20G "$prefix/storage-template.ext4"
-        [[ -f "$prefix/overlay-template.ext4" ]] && truncate -s 10G "$prefix/overlay-template.ext4"
+        [[ -f "$dst_conf_dir/storage-template.ext4" ]] && truncate -s 20G "$dst_conf_dir/storage-template.ext4"
+        [[ -f "$dst_conf_dir/overlay-template.ext4" ]] && truncate -s 10G "$dst_conf_dir/overlay-template.ext4"
     fi
 
     # Templates are final here; nothing installed later touches them.
-    if ! verify_disk_templates "$prefix"; then
+    if ! verify_disk_templates "$dst_conf_dir"; then
         rm -rf "$tmp_dir"
         exit 1
     fi
@@ -573,12 +603,17 @@ install_smolvm() {
         warn "agent-rootfs not found in distribution - some features may not work"
     fi
 
-    # Copy init.krun if present (Linux only, required by libkrunfw kernel)
-    if [[ -f "$extracted_dir/init.krun" ]]; then
-        info "Installing init.krun to $data_dir..."
-        cp "$extracted_dir/init.krun" "$data_dir/init.krun"
-        chmod +x "$data_dir/init.krun"
-    fi
+    # Copy init.krun if present (Linux only, required by libkrunfw kernel).
+    # Newer tarballs carry it in lib/, older ones at the root.
+    local init_krun
+    for init_krun in "$extracted_dir/lib/init.krun" "$extracted_dir/init.krun"; do
+        if [[ -f "$init_krun" ]]; then
+            info "Installing init.krun to $data_dir..."
+            cp "$init_krun" "$data_dir/init.krun"
+            chmod +x "$data_dir/init.krun"
+            break
+        fi
+    done
 
     # Store version info
     echo "$version" > "$prefix/.version"
@@ -595,8 +630,8 @@ install_smolvm() {
             xattr -dr com.apple.quarantine "$prefix" 2>/dev/null || true
         fi
         if command -v codesign &> /dev/null; then
-            local _sig_bin="$prefix/smolvm-bin"
-            [[ "$has_smol" == true ]] && _sig_bin="$prefix/smol-bin"
+            local _sig_bin="$dst_bin_dir/smolvm-bin"
+            [[ "$has_smol" == true ]] && _sig_bin="$dst_bin_dir/smol-bin"
             if ! codesign --verify --deep "$_sig_bin" 2>/dev/null; then
                 warn "The installed binary is not validly code-signed."
                 warn "It needs the com.apple.security.hypervisor entitlement to start VMs."
@@ -610,9 +645,9 @@ install_smolvm() {
     # Create symlinks in bin directory. `smol` is the primary, user-facing CLI;
     # `smolvm` remains available as the lower-level engine command.
     mkdir -p "$BIN_DIR"
-    ln -sf "$prefix/smolvm" "$BIN_DIR/smolvm"
+    ln -sf "$dst_bin_dir/smolvm" "$BIN_DIR/smolvm"
     if [[ "$has_smol" == true ]]; then
-        ln -sf "$prefix/smol" "$BIN_DIR/smol"
+        ln -sf "$dst_bin_dir/smol" "$BIN_DIR/smol"
         success "smol $version installed to $prefix (also installed: smolvm)"
     else
         success "smolvm $version installed to $prefix"

--- a/scripts/smol-wrapper.sh
+++ b/scripts/smol-wrapper.sh
@@ -42,10 +42,16 @@ resolve_symlink() {
 SCRIPT_PATH="$(resolve_symlink "${BASH_SOURCE[0]}")"
 SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
 
-# The actual binary and libraries are in the same directory
+# The binary sits beside this script. Libraries and the agent rootfs are one
+# level up in the bin/ dist layout, or beside the script in the older flat
+# layout — probe for lib/ to tell the two apart, mirroring smolvm-wrapper.sh.
+SMOL_ROOT="$SCRIPT_DIR"
+if [[ ! -d "$SMOL_ROOT/lib" && -d "$SCRIPT_DIR/../lib" ]]; then
+    SMOL_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+fi
 SMOL_BIN="$SCRIPT_DIR/smol-bin"
-SMOL_LIB="$SCRIPT_DIR/lib"
-SMOL_BUNDLED_ROOTFS="$SCRIPT_DIR/agent-rootfs"
+SMOL_LIB="$SMOL_ROOT/lib"
+SMOL_BUNDLED_ROOTFS="$SMOL_ROOT/agent-rootfs"
 
 if [[ -d "$SMOL_BUNDLED_ROOTFS" ]]; then
     export SMOLVM_AGENT_ROOTFS="${SMOLVM_AGENT_ROOTFS:-$SMOL_BUNDLED_ROOTFS}"

--- a/scripts/smolvm-wrapper.sh
+++ b/scripts/smolvm-wrapper.sh
@@ -38,10 +38,18 @@ resolve_symlink() {
 SCRIPT_PATH="$(resolve_symlink "${BASH_SOURCE[0]}")"
 SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
 
-# The actual binary and libraries are in the same directory
+# The binary sits beside this script. Libraries and the agent rootfs are one
+# level up in the bin/ dist layout, or beside the script in the older flat
+# layout — probe for lib/ to tell the two apart. Packaging (the PKGBUILD and
+# the deb/rpm pipeline) rewrites the three SMOLVM_* assignments below to
+# absolute paths with sed, so each must stay a single VAR=... line.
+SMOLVM_ROOT="$SCRIPT_DIR"
+if [[ ! -d "$SMOLVM_ROOT/lib" && -d "$SCRIPT_DIR/../lib" ]]; then
+    SMOLVM_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+fi
 SMOLVM_BIN="$SCRIPT_DIR/smolvm-bin"
-SMOLVM_LIB="$SCRIPT_DIR/lib"
-SMOLVM_BUNDLED_ROOTFS="$SCRIPT_DIR/agent-rootfs"
+SMOLVM_LIB="$SMOLVM_ROOT/lib"
+SMOLVM_BUNDLED_ROOTFS="$SMOLVM_ROOT/agent-rootfs"
 
 if [[ -d "$SMOLVM_BUNDLED_ROOTFS" ]]; then
     export SMOLVM_AGENT_ROOTFS="${SMOLVM_AGENT_ROOTFS:-$SMOLVM_BUNDLED_ROOTFS}"

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -1034,14 +1034,23 @@ impl AgentManager {
             .ok()
             .and_then(|p| p.parent().map(Path::to_path_buf))
         {
-            let dir = exe_dir.join("agent-rootfs");
-            if dir.is_dir() {
-                return Ok(dir);
+            // Beside the executable (Windows and pre-bin/ Unix dists), then one
+            // level up (the bin/ dist layout keeps agent-rootfs/ at the root,
+            // beside bin/).
+            let mut candidates = vec![exe_dir.clone()];
+            if let Some(root) = exe_dir.parent() {
+                candidates.push(root.to_path_buf());
             }
-            for name in ["agent-rootfs.tar.gz", "agent-rootfs.tar"] {
-                let tar = exe_dir.join(name);
-                if tar.is_file() {
-                    return Self::ensure_extracted_rootfs(&tar);
+            for base in &candidates {
+                let dir = base.join("agent-rootfs");
+                if dir.is_dir() {
+                    return Ok(dir);
+                }
+                for name in ["agent-rootfs.tar.gz", "agent-rootfs.tar"] {
+                    let tar = base.join(name);
+                    if tar.is_file() {
+                        return Self::ensure_extracted_rootfs(&tar);
+                    }
                 }
             }
         }
@@ -2441,6 +2450,10 @@ impl AgentManager {
             if let Some(parent) = boot_exe.parent() {
                 search.push(parent.to_path_buf());
                 search.push(parent.join("lib"));
+                // The bin/ dist layout keeps lib/ beside bin/, not inside it.
+                if let Some(root) = parent.parent() {
+                    search.push(root.join("lib"));
+                }
             }
             let var = if cfg!(target_os = "macos") {
                 "DYLD_LIBRARY_PATH"


### PR DESCRIPTION
```text
smolvm-1.15.0-darwin-arm64/
├── bin/            smolvm (wrapper), smolvm-bin, smol, smol-bin
├── conf/           storage-template.ext4.zst, overlay-template.ext4.zst
├── lib/            libkrun, libkrunfw, bundled libraries, init.krun
├── agent-rootfs/
├── README.txt
└── checksums.txt
```

The tarball root previously mixed executables, wrapper scripts, and disk templates with README.txt (#1069). Now the root holds directories and informational files only.

Both layouts keep working everywhere. The wrappers probe for `lib/` beside the script and fall back one level up. The template, agent-rootfs, and boot-library lookups gain parent-directory candidates. The installers mirror whichever layout the given tarball uses, so `--version` installs of older releases still work. The PKGBUILD, the deb/rpm pipeline, and the Nix package handle both. The packaging sed contract on the wrapper's `SMOLVM_*=` lines is preserved.

The Windows zip stays flat on purpose. DLLs resolve from the executable's own directory there, and `pack create` looks for its templates beside `smolvm.exe`.

One side effect: a source-tree build at `target/debug/smolvm` now finds `target/agent-rootfs` without `SMOLVM_AGENT_ROOTFS` set, because the rootfs lookup gained the parent candidate.

Verified: full test suite passes; a dist tree assembled in each layout runs through the wrapper, including via a PATH symlink; the PKGBUILD sed still rewrites all three wrapper variables.

Closes #1069