### PR TITLE
Say the guest agent is outdated when it rejects a request it does not know

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -2084,6 +2084,11 @@ fn handle_connection(stream: &mut impl ReadWrite) -> Result<(), Box<dyn std::err
                     Ok(req) => (req, None),
                     Err(e) => {
                         warn!(error = %e, "invalid request");
+                        // Keep the "invalid request: " prefix stable: the host
+                        // recognizes "invalid request: unknown variant `…`" as
+                        // a protocol-version skew and rewrites it into an
+                        // update-the-agent message (client.rs
+                        // `describe_agent_error`).
                         send_response(
                             stream,
                             &AgentResponse::error(

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -903,6 +903,31 @@ fn stalled_read_error(bytes_read: usize, propagate_initial_wouldblock: bool) -> 
 // Response match helpers
 // ============================================================================
 
+/// Translate an agent error that is really a protocol-version skew.
+///
+/// An agent replying `invalid request: unknown variant `X` …` is older than
+/// this CLI: its deserializer has no such request tag, which is what a stock
+/// older agent-rootfs under a newer binary produces (a 1.7.7 agent receiving
+/// `flatten_layers` from a 1.8+ `pack create --from-vm`, say — see #951). Old
+/// agents in the field already emit exactly this text, so matching the string
+/// is the only translation possible for them; the prefix comes from the
+/// agent's own request loop (`invalid request: {serde error}` in
+/// smolvm-agent's `main.rs`), which must keep it stable. Anything else passes
+/// through untouched.
+fn describe_agent_error(message: String) -> String {
+    let Some(rest) = message.strip_prefix("invalid request: unknown variant `") else {
+        return message;
+    };
+    let Some((variant, _)) = rest.split_once('`') else {
+        return message;
+    };
+    format!(
+        "the machine's guest agent is older than this CLI and does not support the \
+         '{variant}' request. Update the agent rootfs to this release's (reinstall \
+         smolvm, or point SMOLVM_AGENT_ROOTFS at the new one), then restart the machine"
+    )
+}
+
 /// Extract typed data from an `Ok` response.
 fn expect_data<T: serde::de::DeserializeOwned>(resp: AgentResponse, op: &str) -> Result<T> {
     match resp {
@@ -911,7 +936,9 @@ fn expect_data<T: serde::de::DeserializeOwned>(resp: AgentResponse, op: &str) ->
         } => {
             serde_json::from_value(data).map_err(|e| Error::agent("parse response", e.to_string()))
         }
-        AgentResponse::Error { message, .. } => Err(Error::agent(op, message)),
+        AgentResponse::Error { message, .. } => {
+            Err(Error::agent(op, describe_agent_error(message)))
+        }
         _ => Err(Error::agent(op, "unexpected response type")),
     }
 }
@@ -988,7 +1015,9 @@ fn branchpoint_outcome<T>(
 fn expect_ok(resp: AgentResponse, op: &str) -> Result<()> {
     match resp {
         AgentResponse::Ok { .. } => Ok(()),
-        AgentResponse::Error { message, .. } => Err(Error::agent(op, message)),
+        AgentResponse::Error { message, .. } => {
+            Err(Error::agent(op, describe_agent_error(message)))
+        }
         _ => Err(Error::agent(op, "unexpected response type")),
     }
 }
@@ -1001,7 +1030,9 @@ fn expect_completed(resp: AgentResponse, op: &str) -> Result<(i32, Vec<u8>, Vec<
             stdout,
             stderr,
         } => Ok((exit_code, stdout, stderr)),
-        AgentResponse::Error { message, .. } => Err(Error::agent(op, message)),
+        AgentResponse::Error { message, .. } => {
+            Err(Error::agent(op, describe_agent_error(message)))
+        }
         _ => Err(Error::agent(op, "unexpected response type")),
     }
 }
@@ -3972,6 +4003,36 @@ mod term_default_tests {
         let env = with_term_default(vec![("A".to_string(), "b".to_string())], false);
         assert_eq!(term_of(&env), None);
         assert_eq!(env.len(), 1);
+    }
+}
+
+#[cfg(test)]
+mod agent_error_skew_tests {
+    use super::describe_agent_error;
+
+    #[test]
+    fn unknown_variant_becomes_a_version_mismatch_message() {
+        // The verbatim reply a 1.7.7 agent sends for a newer CLI's
+        // flatten_layers request (#951). The raw serde text told the user
+        // nothing about the actual problem or the fix.
+        let raw = "invalid request: unknown variant `flatten_layers`, expected one of \
+                   `ping`, `fs_notify`, `pull` at line 1 column 26";
+        let described = describe_agent_error(raw.to_string());
+        assert!(described.contains("older than this CLI"), "{described}");
+        assert!(described.contains("flatten_layers"), "{described}");
+        assert!(described.contains("agent rootfs"), "{described}");
+        assert!(!described.contains("expected one of"), "{described}");
+    }
+
+    #[test]
+    fn ordinary_agent_errors_pass_through_unchanged() {
+        for msg in [
+            "flatten failed: no space left on device",
+            "invalid request: missing field `path` at line 1 column 40",
+            "invalid request: unknown variant with no backtick",
+        ] {
+            assert_eq!(describe_agent_error(msg.to_string()), msg);
+        }
     }
 }
 


### PR DESCRIPTION
```text
# before (1.7.7 agent-rootfs under a 1.8+ CLI, per #951)
Error: agent operation failed: flatten layers: invalid request: unknown variant
`flatten_layers`, expected one of `ping`, `fs_notify`, `pull`, ...

# after
Error: agent operation failed: flatten layers: the machine's guest agent is older
than this CLI and does not support the 'flatten_layers' request. Update the agent
rootfs to this release's (reinstall smolvm, or point SMOLVM_AGENT_ROOTFS at the
new one), then restart the machine
```

An older agent rejecting an unknown request tag is a protocol-version skew, and the raw serde text named neither the problem nor the fix. The client now recognizes the agent's `invalid request: unknown variant` reply and reports the skew, naming the unsupported request.

The translation lives in the shared response helpers (`expect_data`, `expect_ok`, `expect_completed`), so every RPC added after an agent shipped gets the same message, not just `flatten_layers`. String matching is the only translation possible for agents already in the field, so the agent side gains a comment pinning its error prefix stable. Anything that is not the unknown-variant shape passes through unchanged.

Closes #951
