### PR TITLE
Run a machine created from a pack as the user the pack records

### DIFF
--- a/src/cli/machine.rs
+++ b/src/cli/machine.rs
@@ -3764,7 +3764,10 @@ impl CreateCmd {
                 env
             },
             workdir: manifest.workdir,
-            user: None,
+            // The account the packed workload runs as travels in the manifest,
+            // the same way its entrypoint, env, and workdir do; `--user` still
+            // overrides it, as it does for an image.
+            user: self.user.clone().or_else(|| manifest.user.clone()),
             storage_gb: checkpoint
                 .as_ref()
                 .and_then(|checkpoint| checkpoint.storage_gib)


### PR DESCRIPTION
A machine created with `machine create --from <pack>` always started its workload as root, because the pack path set the record's user to `None` even though the manifest carries the user the source machine ran as (and `pack run` already honors it).

The pack path now takes the manifest's user, with `--user` overriding it the same way it does for an image.