### PR TITLE
README: the virglrenderer loader path for Nix and NixOS hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ ANGLE (Intel, Vulkan 1.4 (Virtio-GPU Venus (Intel(R) UHD Graphics ...)), venus)
 |--------|----------|
 | Alpine | `apk add virglrenderer mesa-vulkan-intel` (or `mesa-vulkan-ati` for AMD) |
 | Debian/Ubuntu | `apt install virglrenderer0 mesa-vulkan-drivers` |
+| Nix / NixOS | the flake does not put virglrenderer on the loader path; export `LD_LIBRARY_PATH` with the nixpkgs `virglrenderer` and `libepoxy` lib dirs (and `/run/opengl-driver/lib` on NixOS), see the [GPU page](https://smolmachines.com/docs/introduction/concepts/gpu) |
 
 > virglrenderer depends on libEGL and libdrm from the host GPU driver stack. These are hardware-specific and cannot be bundled. Any GPU-capable Linux host will already have them installed via its GPU driver.
 


### PR DESCRIPTION
One row in the Linux host-requirements table: the flake does not put virglrenderer on the loader path, so a Nix install exports `LD_LIBRARY_PATH` with the nixpkgs virglrenderer and libepoxy directories (and `/run/opengl-driver/lib` on NixOS). The full entry is on the docs GPU page.

Refs #907.
