### PR TITLE
Fix the flake's release hashes and stop the cut from half-bumping nix/smolvm.nix

### DIFF
--- a/docs/install-nix.md
+++ b/docs/install-nix.md
@@ -45,7 +45,11 @@ loaded and your user is in the `kvm` group.
   release tarball served on the GitHub Releases page, patchelf'd for Nix. The
   bundled libkrun/libkrunfw fork lives under the package's `libexec`, so it does
   not collide with a system `libkrun`.
-- The pinned version and hashes in `nix/smolvm.nix` are bumped automatically on
-  every release by `.github/workflows/update-nix-flake.yml` (which opens a PR).
+- The pinned version and hashes in `nix/smolvm.nix` are bumped after every
+  release by `.github/workflows/update-nix-flake.yml`, which pushes a
+  `nix-bump-<version>` branch and tries to open a PR. **The bump only reaches
+  users once that PR is merged**, so check for an unmerged `nix-bump-*` branch
+  if the flake lags the latest release. `./scripts/update-nix-hashes.sh VERSION`
+  refreshes the hashes by hand from a release's `checksums.sha256`.
 - A submission to the upstream **nixpkgs** collection is planned so
   `nix profile install nixpkgs#smolvm` works without referencing this flake.

--- a/nix/smolvm.nix
+++ b/nix/smolvm.nix
@@ -23,17 +23,17 @@
     x86_64-linux = {
       asset = "smolvm-${version}-linux-x86_64.tar.gz";
       root = "smolvm-${version}-linux-x86_64";
-      hash = "sha256-rcgpaUhgqWcw3qsgfNGyJJp4NqoUDvpnHhmNSJ3YZPg=";
+      hash = "sha256-lKHtsMQrIKxWLDdZ7SFrqyyrnifDgvZWCWkUT3vR3OM=";
     };
     aarch64-linux = {
       asset = "smolvm-${version}-linux-arm64.tar.gz";
       root = "smolvm-${version}-linux-arm64";
-      hash = "sha256-1MARiKXs3q50qMf2MiakpX4Q5bwVONvzer+o44aRNQc=";
+      hash = "sha256-ZZszEXNPLiznMWB+OP9mfLG11BPwYm4SrGSUOoBDbf8=";
     };
     aarch64-darwin = {
       asset = "smolvm-${version}-darwin-arm64.tar.gz";
       root = "smolvm-${version}-darwin-arm64";
-      hash = "sha256-fFnoBtQHP5mtiyBggMeE8u7qhrEnD5/5KPbzx1ovu1Q=";
+      hash = "sha256-SEtjxqfHTE0F3OLmP8zj0TXg+6VqHXcSgCTlc20zhKg=";
     };
   };
 

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -40,7 +40,15 @@ echo ">>> bumping workspace $BASE -> $VERSION"
 for f in Cargo.toml crates/*/Cargo.toml; do
   perl -i -pe "s/^version = \"\Q$BASE\E\"/version = \"$VERSION\"/" "$f"
 done
-perl -i -pe "s/version = \"\Q$BASE\E\"/version = \"$VERSION\"/g" Cargo.toml nix/smolvm.nix
+perl -i -pe "s/version = \"\Q$BASE\E\"/version = \"$VERSION\"/g" Cargo.toml
+
+# nix/smolvm.nix is deliberately NOT bumped here. It pins each platform tarball
+# by hash, and the tarballs do not exist yet: the tag pushed below is what
+# triggers the workflow that builds them. Bumping only the version would leave
+# the flake claiming a release its hashes do not describe, which is a hash
+# mismatch on `nix build` (#1222). The whole file is rewritten after the release
+# exists, by the "Update Nix flake" workflow (packaging/nix/bump.py), or by hand
+# with ./scripts/update-nix-hashes.sh VERSION if that bump has not landed.
 
 if grep -rn "^version = \"$BASE\"" Cargo.toml crates/*/Cargo.toml >/dev/null 2>&1; then
   echo "error: some manifests still at $BASE after bump:" >&2

--- a/scripts/update-nix-hashes.sh
+++ b/scripts/update-nix-hashes.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Refresh the per-arch SRI hashes in nix/smolvm.nix from a published release.
+#
+# The flake pins each platform tarball by hash, so the hashes are only knowable
+# once the release assets exist. cut-release.sh cannot do it: it pushes the tag,
+# and the tag is what triggers the workflow that builds the tarballs.
+#
+# The release path normally runs packaging/nix/bump.py from the "Update Nix
+# flake" workflow, which downloads all three tarballs. This is the hand-run
+# equivalent for when that bump has not landed: it reads the release's
+# checksums.sha256 instead, so it costs one small download rather than three
+# large ones, and it rewrites only the hashes (the version is left alone).
+#
+# Usage: ./scripts/update-nix-hashes.sh 1.14.6
+#
+# SMOLVM_CHECKSUMS_FILE=<path> reads a local checksums file instead of
+# downloading one, which is how the test drives it offline.
+set -euo pipefail
+
+VERSION="${1:?usage: update-nix-hashes.sh X.Y.Z}"
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "error: '$VERSION' is not X.Y.Z" >&2; exit 1; }
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+NIX_FILE="${SMOLVM_NIX_FILE:-$REPO_ROOT/nix/smolvm.nix}"
+[[ -f "$NIX_FILE" ]] || { echo "error: no such file: $NIX_FILE" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+CHECKSUMS="$WORK/checksums.sha256"
+if [[ -n "${SMOLVM_CHECKSUMS_FILE:-}" ]]; then
+  cp "$SMOLVM_CHECKSUMS_FILE" "$CHECKSUMS"
+else
+  gh release download "v$VERSION" -R smol-machines/smolvm \
+    --pattern checksums.sha256 --output "$CHECKSUMS" --clobber
+fi
+
+# The nix file is the source of truth for which assets are pinned: read the
+# asset names out of it rather than hardcoding a list that can drift from it.
+ASSETS="$(sed -n 's/.*asset = "smolvm-\${version}-\([^"]*\)";.*/\1/p' "$NIX_FILE")"
+[[ -n "$ASSETS" ]] || { echo "error: no asset lines found in $NIX_FILE" >&2; exit 1; }
+
+while read -r suffix; do
+  [[ -n "$suffix" ]] || continue
+  asset="smolvm-$VERSION-$suffix"
+  digest="$(awk -v a="$asset" '$2 == a { print $1 }' "$CHECKSUMS")"
+  # A pinned asset with no checksum line means the release is incomplete or the
+  # asset was renamed; either way the resulting flake would not build.
+  if [[ -z "$digest" ]]; then
+    echo "error: $asset has no line in the checksums for v$VERSION" >&2
+    exit 1
+  fi
+  sri="sha256-$(printf '%s' "$digest" | xxd -r -p | base64)"
+
+  # Rewrite the hash inside this asset's attribute block only. The block runs
+  # from its asset line to its hash line, so a range address pins it without
+  # needing to name the nix system attribute.
+  perl -i -pe "
+    if (/asset = \"smolvm-\\\${version}-\Q$suffix\E\";/) { \$in = 1 }
+    if (\$in && s/hash = \"[^\"]*\";/hash = \"$sri\";/) { \$in = 0 }
+  " "$NIX_FILE"
+  echo "$asset: $sri"
+done <<EOF
+$ASSETS
+EOF
+
+echo "rewrote the release hashes in $NIX_FILE for v$VERSION"

--- a/tests/test_nix_release_hashes.sh
+++ b/tests/test_nix_release_hashes.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# Tests for the flake's release-hash refresh (scripts/update-nix-hashes.sh).
+#
+# These use a fake nix file and a fake checksums file, so they need no network,
+# no release, and no nix.
+#
+# The incident: cut-release.sh used to bump `version` in nix/smolvm.nix while
+# leaving the three hashes at the previous release's digests. Six releases
+# shipped that way, and `nix build` failed the fixed-output check on every one
+# of them because the flake claimed a version its hashes did not describe.
+
+source "$(dirname "$0")/common.sh"
+
+echo ""
+echo "=========================================="
+echo "  smolvm Nix Release Hash Tests"
+echo "=========================================="
+echo ""
+
+UPDATE_HASHES="$PROJECT_ROOT/scripts/update-nix-hashes.sh"
+
+# A nix file shaped like nix/smolvm.nix: three pinned assets, stale hashes.
+make_nix_fixture() {
+    cat > "$1" <<'EOF'
+{lib}: let
+  version = "9.9.9";
+
+  releases = {
+    x86_64-linux = {
+      asset = "smolvm-${version}-linux-x86_64.tar.gz";
+      root = "smolvm-${version}-linux-x86_64";
+      hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    };
+    aarch64-linux = {
+      asset = "smolvm-${version}-linux-arm64.tar.gz";
+      root = "smolvm-${version}-linux-arm64";
+      hash = "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=";
+    };
+    aarch64-darwin = {
+      asset = "smolvm-${version}-darwin-arm64.tar.gz";
+      root = "smolvm-${version}-darwin-arm64";
+      hash = "sha256-CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC=";
+    };
+  };
+in
+  releases
+EOF
+}
+
+# Digests chosen so each SRI is distinct and independently checkable: the
+# base64 of the raw bytes of each hex digest below.
+make_checksums_fixture() {
+    cat > "$1" <<'EOF'
+1111111111111111111111111111111111111111111111111111111111111111  smolvm-9.9.9-darwin-arm64.tar.gz
+2222222222222222222222222222222222222222222222222222222222222222  smolvm-9.9.9-linux-arm64.tar.gz
+3333333333333333333333333333333333333333333333333333333333333333  smolvm-9.9.9-linux-x86_64.tar.gz
+EOF
+}
+
+hash_for() {
+    sed -n "/asset = \"smolvm-\${version}-$2\";/,/hash = /p" "$1" | sed -n 's/.*hash = "\(.*\)";.*/\1/p'
+}
+
+test_rewrites_every_pinned_hash() {
+    local tmp nixf sums rc
+    tmp=$(mktemp -d)
+    nixf="$tmp/smolvm.nix"; sums="$tmp/checksums.sha256"
+    make_nix_fixture "$nixf"; make_checksums_fixture "$sums"
+
+    SMOLVM_NIX_FILE="$nixf" SMOLVM_CHECKSUMS_FILE="$sums" \
+        "$UPDATE_HASHES" 9.9.9 >/dev/null 2>&1
+    rc=$?
+
+    # base64 of the raw bytes of 0x33.. / 0x22.. / 0x11.. respectively.
+    local want_x86 want_arm want_darwin
+    want_x86="sha256-MzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzM="
+    want_arm="sha256-IiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiI="
+    want_darwin="sha256-ERERERERERERERERERERERERERERERERERERERERERE="
+
+    local got_x86 got_arm got_darwin
+    got_x86=$(hash_for "$nixf" "linux-x86_64.tar.gz")
+    got_arm=$(hash_for "$nixf" "linux-arm64.tar.gz")
+    got_darwin=$(hash_for "$nixf" "darwin-arm64.tar.gz")
+    rm -rf "$tmp"
+
+    [[ $rc -eq 0 ]] || return 1
+    [[ "$got_x86" == "$want_x86" ]] || { echo "x86_64: got $got_x86 want $want_x86"; return 1; }
+    [[ "$got_arm" == "$want_arm" ]] || { echo "arm64: got $got_arm want $want_arm"; return 1; }
+    [[ "$got_darwin" == "$want_darwin" ]] || { echo "darwin: got $got_darwin want $want_darwin"; return 1; }
+}
+
+test_leaves_the_version_alone() {
+    local tmp nixf sums before after
+    tmp=$(mktemp -d)
+    nixf="$tmp/smolvm.nix"; sums="$tmp/checksums.sha256"
+    make_nix_fixture "$nixf"; make_checksums_fixture "$sums"
+    before=$(sed -n 's/.*version = "\(.*\)";.*/\1/p' "$nixf")
+
+    SMOLVM_NIX_FILE="$nixf" SMOLVM_CHECKSUMS_FILE="$sums" \
+        "$UPDATE_HASHES" 9.9.9 >/dev/null 2>&1
+
+    after=$(sed -n 's/.*version = "\(.*\)";.*/\1/p' "$nixf")
+    rm -rf "$tmp"
+    [[ "$before" == "$after" ]]
+}
+
+test_missing_asset_fails_loudly() {
+    local tmp nixf sums rc output
+    tmp=$(mktemp -d)
+    nixf="$tmp/smolvm.nix"; sums="$tmp/checksums.sha256"
+    make_nix_fixture "$nixf"
+    # A release that shipped no darwin tarball: the flake still pins it.
+    cat > "$sums" <<'EOF'
+2222222222222222222222222222222222222222222222222222222222222222  smolvm-9.9.9-linux-arm64.tar.gz
+3333333333333333333333333333333333333333333333333333333333333333  smolvm-9.9.9-linux-x86_64.tar.gz
+EOF
+
+    output=$(SMOLVM_NIX_FILE="$nixf" SMOLVM_CHECKSUMS_FILE="$sums" \
+        "$UPDATE_HASHES" 9.9.9 2>&1)
+    rc=$?
+    rm -rf "$tmp"
+
+    [[ $rc -ne 0 ]] || { echo "expected a non-zero exit for a missing asset"; return 1; }
+    printf '%s\n' "$output" | grep -q "has no line in the checksums"
+}
+
+test_cut_release_does_not_bump_the_flake() {
+    # The regression itself: cutting a release must not rewrite the flake's
+    # version, because the hashes it would then contradict cannot be computed
+    # until the tag has built the tarballs.
+    ! grep -qE '^perl .*nix/smolvm\.nix' "$PROJECT_ROOT/scripts/cut-release.sh"
+}
+
+run_test "Rewrites every pinned hash" test_rewrites_every_pinned_hash || true
+run_test "Leaves the version alone" test_leaves_the_version_alone || true
+run_test "Missing asset fails loudly" test_missing_asset_fails_loudly || true
+run_test "Cutting a release does not bump the flake" test_cut_release_does_not_bump_the_flake || true
+
+print_summary "Nix Release Hash Tests"


### PR DESCRIPTION
`nix build` has failed with a hash mismatch on every release since 1.14.0

The first commit sets the three hashes to the v1.14.6 assets, confirmed by downloading each tarball and hashing it. The bot's `nix-bump-1.14.6` branch carries the same file; its pull request never opens because "Allow GitHub Actions to create and approve pull requests" is off. Turning that setting on will make the next release bump the flake by itself.

The second commit stops the cut from touching `nix/smolvm.nix` at all. Today `scripts/cut-release.sh` bumps the version while the hashes stay at the previous release, so main is broken for Nix from the tag until the bump lands. The "Update Nix flake" workflow rewrites version and hashes together once the tarballs exist.

`scripts/update-nix-hashes.sh` is the hand-run equivalent for a release whose bump has not landed: it reads the release's `checksums.sha256` and rewrites only the hashes.

---

Verified on Linux aarch64 with nix 2.35.2: `nix build .#smolvm` fails on main with `hash mismatch in fixed-output derivation` and succeeds on this branch, producing a binary whose `smolvm --version` prints 1.14.6; `nix run .#` prints the same.

Closes #1222
