### PR TITLE
Make a smaller storage disk work for a Nix install on macOS

### DIFF
--- a/nix/smolvm.nix
+++ b/nix/smolvm.nix
@@ -44,10 +44,16 @@
     bzip2
   ];
 
-  # crun/e2fsprogs/util-linux are Linux-only; the container runtime and mkfs.ext4
-  # only matter there. On darwin smolvm uses the host's own facilities.
+  # e2fsprogs is needed on EVERY host, not just Linux: `resize2fs` shrinks a
+  # machine's disk whenever one is asked for below the template size
+  # (src/disk_utils.rs:112 and :135 at 8dd8b18d), and the macOS branch of that
+  # error tells the user to `brew install e2fsprogs`. Without it on PATH the
+  # shrink is skipped with a warning and the machine silently gets the full
+  # template instead of the size that was requested. crun and util-linux stay
+  # Linux-only: the container runtime and mkfs.ext4 only matter there.
   runtimeDeps =
     [
+      e2fsprogs
       jq
       gzip
       gnutar
@@ -55,7 +61,6 @@
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
       crun
-      e2fsprogs
       util-linux
     ];
 in


### PR DESCRIPTION
For a macOS Nix install, a machine asked for a disk smaller than the template comes up on the full 20 GiB template (no error reported).

`nix/smolvm.nix` adds `e2fsprogs` to `runtimeDeps` only on Linux. A disk requested below the template is shrunk on the host with resize2fs before its first boot, on every platform.
This PR moves `e2fsprogs` into the unconditional list for Nix.

---

Verified on aarch64-darwin from an isolated HOME, with `nix build .#smolvm` on main and on this branch.

**Before fix**, after running --storage 1: `machine start` logs `resize2fs not found ... brew install e2fsprogs`, the machine runs, `storage.raw` is 21474836480 bytes and the guest sees 19.7G.

**After fix**, after running --storage 1: no warning, `storage.raw` is 1073741824 bytes, the guest sees 990.7M, and the machine boots. A default-size machine is 20 GiB in both.

`nix flake check` passes and `tests/test_nix_release_hashes.sh` is 4 of 4, unchanged.

Closes #587