### PR TITLE
Report a machine's real memory in status by asking the guest instead of the host

### DIFF
--- a/crates/smolvm-agent/src/main.rs
+++ b/crates/smolvm-agent/src/main.rs
@@ -2347,6 +2347,7 @@ fn handle_request(
         AgentRequest::FormatStorage => handle_format_storage(),
 
         AgentRequest::StorageStatus => handle_storage_status(),
+        AgentRequest::MemoryStatus => handle_memory_status(),
 
         AgentRequest::BranchpointWait { timeout_ms } => {
             let markers = branchpoint::Markers::standard();
@@ -6570,6 +6571,57 @@ fn handle_storage_status() -> AgentResponse {
     AgentResponse::from_result(storage::status(), error_codes::STATUS_FAILED)
 }
 
+/// Report machine memory as the guest's own allocator sees it.
+///
+/// `/proc/meminfo` reports kB (always kibibytes, whatever the unit column
+/// says), so every value is scaled to bytes here and the protocol carries only
+/// bytes. A field the running kernel does not publish stays zero rather than
+/// failing the request: `SwapTotal` is absent on a guest with no swap, and
+/// `MemAvailable` predates some very old kernels.
+fn handle_memory_status() -> AgentResponse {
+    AgentResponse::from_result(read_meminfo("/proc/meminfo"), error_codes::STATUS_FAILED)
+}
+
+/// Parse the `Key:  value kB` lines of a meminfo file into bytes.
+fn read_meminfo(path: &str) -> std::io::Result<smolvm_protocol::MemoryStatus> {
+    let text = std::fs::read_to_string(path)?;
+    let mut status = smolvm_protocol::MemoryStatus::default();
+    let mut swap_free = 0u64;
+
+    for line in text.lines() {
+        let Some((key, rest)) = line.split_once(':') else {
+            continue;
+        };
+        // The value is the first token of the remainder; the unit, when present,
+        // is always kB.
+        let Some(value) = rest
+            .split_whitespace()
+            .next()
+            .and_then(|v| v.parse::<u64>().ok())
+        else {
+            continue;
+        };
+        let bytes = value.saturating_mul(1024);
+        match key {
+            "MemTotal" => status.total_bytes = bytes,
+            "MemAvailable" => status.available_bytes = bytes,
+            "MemFree" => status.free_bytes = bytes,
+            "Cached" => status.cached_bytes = bytes,
+            "SwapTotal" => status.swap_total_bytes = bytes,
+            "SwapFree" => swap_free = bytes,
+            _ => {}
+        }
+    }
+
+    status.swap_used_bytes = status.swap_total_bytes.saturating_sub(swap_free);
+    // A kernel too old for MemAvailable would otherwise report everything as
+    // used; free plus reclaimable cache is the estimate it replaced.
+    if status.available_bytes == 0 {
+        status.available_bytes = status.free_bytes.saturating_add(status.cached_bytes);
+    }
+    Ok(status)
+}
+
 // ============================================================================
 // VM-Level Exec Handlers (Direct Execution in VM)
 // ============================================================================
@@ -7942,5 +7994,89 @@ fn branchpoint_error(e: branchpoint::TypedError) -> AgentResponse {
     AgentResponse::Error {
         message: e.message,
         code: Some(e.code.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod meminfo_tests {
+    use super::read_meminfo;
+
+    fn write(contents: &str) -> tempfile::NamedTempFile {
+        use std::io::Write as _;
+        let mut f = tempfile::NamedTempFile::new().expect("temp file");
+        f.write_all(contents.as_bytes()).expect("write");
+        f.flush().expect("flush");
+        f
+    }
+
+    /// meminfo reports kibibytes, so every field has to be scaled. Reading the
+    /// numbers as bytes would understate a machine's memory 1024-fold.
+    #[test]
+    fn values_are_scaled_from_kibibytes_to_bytes() {
+        let f = write(
+            "MemTotal:        4035968 kB\n\
+             MemFree:         4001728 kB\n\
+             MemAvailable:    3982212 kB\n\
+             Cached:             9512 kB\n",
+        );
+        let m = read_meminfo(f.path().to_str().unwrap()).expect("parses");
+
+        assert_eq!(m.total_bytes, 4_035_968 * 1024);
+        assert_eq!(m.free_bytes, 4_001_728 * 1024);
+        assert_eq!(m.available_bytes, 3_982_212 * 1024);
+        assert_eq!(m.cached_bytes, 9_512 * 1024);
+        // Total minus available is what the guest cannot hand back.
+        assert_eq!(m.used_bytes(), (4_035_968 - 3_982_212) * 1024);
+    }
+
+    /// Swap is reported as total and free; used is the difference. A guest with
+    /// no swap publishes neither line and must report zero, not garbage.
+    #[test]
+    fn swap_used_is_total_minus_free_and_absent_swap_is_zero() {
+        let with_swap = write(
+            "MemTotal:        1024 kB\n\
+             MemAvailable:     512 kB\n\
+             SwapTotal:       2048 kB\n\
+             SwapFree:         512 kB\n",
+        );
+        let m = read_meminfo(with_swap.path().to_str().unwrap()).expect("parses");
+        assert_eq!(m.swap_total_bytes, 2048 * 1024);
+        assert_eq!(m.swap_used_bytes, (2048 - 512) * 1024);
+
+        let no_swap = write("MemTotal:        1024 kB\nMemAvailable:     512 kB\n");
+        let m = read_meminfo(no_swap.path().to_str().unwrap()).expect("parses");
+        assert_eq!(m.swap_total_bytes, 0);
+        assert_eq!(m.swap_used_bytes, 0);
+    }
+
+    /// Kernels predating MemAvailable would otherwise report the whole machine
+    /// as used, since used is derived from it.
+    #[test]
+    fn a_kernel_without_mem_available_falls_back_to_free_plus_cache() {
+        let f = write(
+            "MemTotal:        1000 kB\n\
+             MemFree:          200 kB\n\
+             Cached:           300 kB\n",
+        );
+        let m = read_meminfo(f.path().to_str().unwrap()).expect("parses");
+        assert_eq!(m.available_bytes, 500 * 1024);
+        assert_eq!(m.used_bytes(), 500 * 1024);
+    }
+
+    /// Lines this build does not care about, and malformed ones, must not
+    /// derail the fields it does read.
+    #[test]
+    fn unknown_and_malformed_lines_are_skipped() {
+        let f = write(
+            "Committed_AS:   123456 kB\n\
+             not a meminfo line\n\
+             HugePages_Total:     0\n\
+             MemTotal:         2048 kB\n\
+             Bogus:          notanumber kB\n\
+             MemAvailable:     1024 kB\n",
+        );
+        let m = read_meminfo(f.path().to_str().unwrap()).expect("parses");
+        assert_eq!(m.total_bytes, 2048 * 1024);
+        assert_eq!(m.available_bytes, 1024 * 1024);
     }
 }

--- a/crates/smolvm-protocol/src/lib.rs
+++ b/crates/smolvm-protocol/src/lib.rs
@@ -333,6 +333,16 @@ pub enum AgentRequest {
     /// Get storage disk status.
     StorageStatus,
 
+    /// Report the guest's own view of machine memory, read from
+    /// `/proc/meminfo`.
+    ///
+    /// The host cannot answer this. macOS charges the VMM's `phys_footprint`
+    /// as `internal + compressed`, and the compressed part is counted at the
+    /// pages' *uncompressed* size, so an idle guest whose memory has been
+    /// compressed reports a footprint several times the bytes it actually
+    /// occupies. Only the guest's allocator knows what the machine is using.
+    MemoryStatus,
+
     /// Test network connectivity directly from the agent (not via chroot).
     /// Used to debug TSI networking.
     NetworkTest {
@@ -728,6 +738,7 @@ impl AgentRequest {
             AgentRequest::CleanupOverlay { .. } => "CleanupOverlay".into(),
             AgentRequest::FormatStorage => "FormatStorage".into(),
             AgentRequest::StorageStatus => "StorageStatus".into(),
+            AgentRequest::MemoryStatus => "MemoryStatus".into(),
             AgentRequest::NetworkTest { .. } => "NetworkTest".into(),
             AgentRequest::Shutdown => "Shutdown".into(),
             AgentRequest::ExportLayer { .. } => "ExportLayer".into(),
@@ -1071,6 +1082,38 @@ pub struct OverlayInfo {
     pub upper_path: String,
     /// Path to the work directory.
     pub work_path: String,
+}
+
+/// The guest's own account of machine memory, from `/proc/meminfo`.
+///
+/// This is what a machine is actually using. The host-side `phys_footprint`
+/// answers a different question — it counts compressed pages at their
+/// uncompressed size and keeps counting memory the guest has stopped needing —
+/// so it runs well above these figures and should not be read as consumption.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MemoryStatus {
+    /// Total usable RAM the guest sees, in bytes. Slightly below the machine's
+    /// configured size: the kernel reserves some before the allocator sees it.
+    pub total_bytes: u64,
+    /// Memory available for new allocations without swapping, in bytes. The
+    /// figure to report, since `free_bytes` excludes reclaimable page cache.
+    pub available_bytes: u64,
+    /// Free memory in bytes: never allocated, or released and not reused.
+    pub free_bytes: u64,
+    /// Page cache in bytes. Counted inside `available_bytes`.
+    pub cached_bytes: u64,
+    /// Swap configured in the guest, in bytes. Zero when the guest has none.
+    pub swap_total_bytes: u64,
+    /// Swap in use, in bytes.
+    pub swap_used_bytes: u64,
+}
+
+impl MemoryStatus {
+    /// Memory the guest cannot hand back on demand.
+    pub fn used_bytes(&self) -> u64 {
+        self.total_bytes.saturating_sub(self.available_bytes)
+    }
 }
 
 /// Storage status information.

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -9,9 +9,9 @@ use crate::registry::{extract_registry, rewrite_image_registry, RegistryAuth};
 use crate::settings::SmolSettings;
 use smolvm_protocol::normalize_image_ref;
 use smolvm_protocol::{
-    encode_message, AgentRequest, AgentResponse, Envelope, FsNotifyEvent, ImageInfo, OverlayInfo,
-    StorageStatus, FILE_TRANSFER_MAX_TOTAL, FILE_WRITE_CHUNK_SIZE, FILE_WRITE_SINGLE_SHOT_MAX,
-    MAX_FRAME_SIZE, PROTOCOL_VERSION,
+    encode_message, AgentRequest, AgentResponse, Envelope, FsNotifyEvent, ImageInfo, MemoryStatus,
+    OverlayInfo, StorageStatus, FILE_TRANSFER_MAX_TOTAL, FILE_WRITE_CHUNK_SIZE,
+    FILE_WRITE_SINGLE_SHOT_MAX, MAX_FRAME_SIZE, PROTOCOL_VERSION,
 };
 use std::io::{Read, Write};
 use std::path::Path;
@@ -1582,6 +1582,15 @@ impl AgentClient {
     pub fn storage_status(&mut self) -> Result<StorageStatus> {
         let resp = self.request(&AgentRequest::StorageStatus)?;
         expect_data(resp, "storage status")
+    }
+
+    /// The guest's own view of machine memory.
+    ///
+    /// Agents older than this request reject it as an unknown variant, so
+    /// callers should treat an error as "not available" rather than a failure.
+    pub fn memory_status(&mut self) -> Result<MemoryStatus> {
+        let resp = self.request(&AgentRequest::MemoryStatus)?;
+        expect_data(resp, "memory status")
     }
 
     /// Test network connectivity directly from the agent (not via chroot).

--- a/src/cli/vm_common.rs
+++ b/src/cli/vm_common.rs
@@ -2746,6 +2746,7 @@ where
     if manager.try_connect_existing().is_some() {
         let pid_suffix = crate::cli::format_pid_suffix(manager.child_pid());
         println!("Machine '{}': running{}", label, pid_suffix);
+        print_memory_usage(&manager);
         extra(&manager);
         manager.detach();
     } else if let Some(ref n) = name {
@@ -2769,6 +2770,38 @@ where
     }
 
     Ok(())
+}
+
+/// Print what the machine is actually using, asked of the guest.
+///
+/// Deliberately not taken from the host: macOS charges the VMM's
+/// `phys_footprint` as `internal + compressed` with the compressed part counted
+/// at the pages' uncompressed size, so an idle machine whose memory has been
+/// compressed appears to be using several times what it occupies. The guest's
+/// allocator is the only thing that knows.
+///
+/// Silent when the machine's agent predates the request: a `status` that still
+/// reports state is more useful than one that fails over a detail.
+fn print_memory_usage(manager: &AgentManager) {
+    let Ok(mut client) = smolvm::agent::AgentClient::connect_with_retry(manager.vsock_socket())
+    else {
+        return;
+    };
+    let Ok(status) = client.memory_status() else {
+        return;
+    };
+    if status.total_bytes == 0 {
+        return;
+    }
+    let gib = |bytes: u64| bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+    let percent = status.used_bytes() as f64 * 100.0 / status.total_bytes as f64;
+    println!(
+        "  memory: {:.2} GiB of {:.2} GiB used ({:.0}%), {:.2} GiB available",
+        gib(status.used_bytes()),
+        gib(status.total_bytes),
+        percent,
+        gib(status.available_bytes),
+    );
 }
 
 /// Build the per-machine JSON object shared by `machine list --json` and


### PR DESCRIPTION
`machine status` reported only state and a PID, and `machine ls` shows the *configured* size. It should now show the real memory usage as reported by the agent