### PR TITLE
[Agent Experience] Add skill packets: dev-env, local-api, docker-in-machine, gpu-cuda, pack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,9 +98,10 @@ to end on a published release; each says which steps were not.
 | Install smolvm and prove the host boots a VM | `install` | version, platform, KVM or `kern.hv_support`, macOS socket path length, Intel Mac stated unverified | anything after the first boot |
 | Stop everything and remove smolvm's state | `teardown` | every state directory with its size, image caches, `PATH` block, whether state can be relocated | deleting machines another session created |
 | Run untrusted code, no network, repo read-only | `sandbox` | as install, plus mounts plus ports against the device budget, and whether the offline shape works here | a machine you re-enter; anything needing state to survive |
-
-More packets follow with the same shape: a persistent dev environment, the local HTTP API, Docker
-inside a machine, and CUDA against a host GPU.
+| Keep a machine with its dependencies, re-enter it later | `dev-env` | as install, plus `restart_after_stop` | untrusted code; a machine that must leave nothing behind |
+| Drive smolvm over its local HTTP API | `local-api` | as install, plus `auth=none`, transport availability, `curl` and `python3` | a substitute for the CLI in a shell script |
+| Run a Docker daemon inside a machine | `docker-in-machine` | as install, plus whether this platform can do it at all | Windows, where the guest kernel cannot; running OCI images, which smolvm does natively |
+| Run CUDA compute against a host GPU | `gpu-cuda` | GPU and driver, KVM access, host `libcuda` count, glibc image requirement | Vulkan (`--gpu`), which works on no tested host |
 
 Each directory holds `SKILL.md` (the procedure), `scripts/` (preflight, the lifecycle, cleanup) and
 `references/` (traps and per-platform arms, read when the situation calls for them). Scripts are

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,7 @@ to end on a published release; each says which steps were not.
 | Drive smolvm over its local HTTP API | `local-api` | as install, plus `auth=none`, transport availability, `curl` and `python3` | a substitute for the CLI in a shell script |
 | Run a Docker daemon inside a machine | `docker-in-machine` | as install, plus whether this platform can do it at all | Windows, where the guest kernel cannot; running OCI images, which smolvm does natively |
 | Run CUDA compute against a host GPU | `gpu-cuda` | GPU and driver, KVM access, host `libcuda` count, glibc image requirement | Vulkan (`--gpu`), which works on no tested host |
+| Ship a machine or an image as one portable file | `pack` | as install, plus free memory against the exporter's fixed 8192 MiB | a machine you keep and re-enter; carrying an artifact to another architecture |
 
 Each directory holds `SKILL.md` (the procedure), `scripts/` (preflight, the lifecycle, cleanup) and
 `references/` (traps and per-platform arms, read when the situation calls for them). Scripts are

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,53 @@ smolvm machine create --name myvm --image ./myapp.tar     # persistent, from a l
 - **`machine create --from .smolmachine`** — creates a persistent named machine from a packed artifact. Boots from pre-extracted layers (~250ms, no image pull). Full `machine exec` persistence — package installs, file writes all survive across exec and stop/start.
 - **Memory-backed paths** — `/tmp`, `/run`, and `/dev/shm` are tmpfs regardless of the mode above. They keep their contents while the machine runs, including across `exec` sessions, but are empty again after a stop and start. `/workspace` and the rest of the machine filesystem are on the storage disk, so write anything that must outlive a restart there — including credentials and configuration, which should not sit in `/tmp` or behind a symlink into it.
 
+## Skills
+
+Task-scoped procedures for this CLI, one directory per use case under `skills/`. Each was run end
+to end on a published release; each says which steps were not.
+
+| Task | Packet | Its preflight checks | Not for |
+|------|--------|----------------------|---------|
+| Install smolvm and prove the host boots a VM | `install` | version, platform, KVM or `kern.hv_support`, macOS socket path length, Intel Mac stated unverified | anything after the first boot |
+| Stop everything and remove smolvm's state | `teardown` | every state directory with its size, image caches, `PATH` block, whether state can be relocated | deleting machines another session created |
+| Run untrusted code, no network, repo read-only | `sandbox` | as install, plus mounts plus ports against the device budget, and whether the offline shape works here | a machine you re-enter; anything needing state to survive |
+
+More packets follow with the same shape: a persistent dev environment, the local HTTP API, Docker
+inside a machine, and CUDA against a host GPU.
+
+Each directory holds `SKILL.md` (the procedure), `scripts/` (preflight, the lifecycle, cleanup) and
+`references/` (traps and per-platform arms, read when the situation calls for them). Scripts are
+wrappers over this CLI: they edit no configuration, escalate no privilege, and delete only machines
+they created. They are plain `bash` and assume nothing about which agent, if any, is driving them.
+
+### Finding them
+
+`skills/` is the home. The format is a `SKILL.md` per directory with `name` (matching the directory
+name) and `description` frontmatter, which is what current agents read.
+
+An agent with no skill discovery needs nothing: read `skills/<name>/SKILL.md` when the task matches
+its description.
+
+An agent that scans a fixed path needs `skills/` linked to that path, which is a local choice and
+is deliberately not committed here. The paths known at the time of writing, each from that agent's
+own documentation, read 2026-09-08:
+
+| Agent | Project path | Notes |
+|---|---|---|
+| Claude Code | `.claude/skills/<name>/SKILL.md` | also `~/.claude/skills` for personal skills |
+| OpenCode | `.opencode/skills/<name>/SKILL.md` | also accepts `.claude/skills` and the cross-agent `.agents/skills`, walking up to the git worktree root |
+
+```bash
+# Expose them to an agent that scans .claude/skills, once, locally:
+mkdir -p .claude && ln -s ../skills .claude/skills
+```
+
+Check the agent's own documentation before trusting a path here; discovery conventions are young
+and move.
+
+`AGENTS.md` is how to work in this repository and is always in context. A `SKILL.md` is how to
+accomplish one task with the product, and loads only when that task comes up.
+
 ## CLI Structure
 
 All commands use named flags (no positional args except `machine create --name NAME` and `machine delete --name NAME`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ A tool to build and run portable, self-contained virtual machines locally. <200m
 | Linux x86_64 / aarch64 | matching Linux | KVM | `/dev/kvm` |
 | Windows x86_64 | x86_64 Linux | Windows Hypervisor Platform (WHP) | WHP feature enabled |
 
-Windows caveats (run, persistent machines, volumes, port-forwarding, pack create/run, and interactive TTY all work): networking is TSI-only (TCP/UDP + inbound `-p`, no virtio-net); no GPU acceleration; no branch/snapshot. `pack create` needs `storage-template.ext4` / `overlay-template.ext4` beside `smolvm.exe` (Windows has no host `mkfs.ext4`). Set `SMOLVM_LIB_DIR` (folder holding `krun.dll` + `libkrunfw.dll`) and `SMOLVM_AGENT_ROOTFS` when running from a non-standard layout.
+Windows caveats (run, persistent machines, volumes, port-forwarding, pack create/run, and interactive TTY all work): `--net` works as on other platforms (virtio-net with inbound `-p`; TSI for outbound-only VMs); CUDA (`--cuda`) works, Vulkan (`--gpu`) does not; no branch/snapshot. `pack create` needs `storage-template.ext4` / `overlay-template.ext4` beside `smolvm.exe` (Windows has no host `mkfs.ext4`). Set `SMOLVM_LIB_DIR` (folder holding `krun.dll` + `libkrunfw.dll`) and `SMOLVM_AGENT_ROOTFS` when running from a non-standard layout.
 
 ## Quick Reference
 

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Known Limitations
 * macOS: binary must be signed with Hypervisor.framework entitlements (`com.apple.security.hypervisor`). The shipped release is; a re-signed or freshly built binary silently loses it and every VM start then fails with `krun_start_enter returned: -22 (EINVAL)`. Re-sign it (ad-hoc is fine): `codesign --force --sign - --entitlements hv.entitlements <smolvm-bin>` where `hv.entitlements` is a plist containing `<key>com.apple.security.hypervisor</key><true/>`.
 * `--ssh-agent` requires an SSH agent running on the host (`SSH_AUTH_SOCK` must be set).
 * GPU acceleration requires libkrun built with `GPU=1` and virglrenderer + a Vulkan driver on the host (see [GPU Acceleration](#gpu-acceleration) below).
-* Windows: `--net` works the same as on other platforms (virtio-net with inbound port-forwarding; TSI for outbound-only VMs), as do `machine exec` / interactive sessions and `machine stats`. Not yet available on Windows: GPU acceleration and `machine branch` / `machine checkpoint`. Pack *create* needs `storage-template.ext4` / `overlay-template.ext4` next to `smolvm.exe` (Windows has no host `mkfs.ext4`).
+* Windows: `--net` works the same as on other platforms (virtio-net with inbound port-forwarding; TSI for outbound-only VMs), as do `machine exec` / interactive sessions and `machine stats`. CUDA (`--cuda`) works on Windows against an NVIDIA GPU. Not yet available on Windows: Vulkan (`--gpu`) and `machine branch` / `machine checkpoint`. Pack *create* needs `storage-template.ext4` / `overlay-template.ext4` next to `smolvm.exe` (Windows has no host `mkfs.ext4`).
 
 Kubernetes
 ----------

--- a/README.md
+++ b/README.md
@@ -346,7 +346,6 @@ ANGLE (Intel, Vulkan 1.4 (Virtio-GPU Venus (Intel(R) UHD Graphics ...)), venus)
 |--------|----------|
 | Alpine | `apk add virglrenderer mesa-vulkan-intel` (or `mesa-vulkan-ati` for AMD) |
 | Debian/Ubuntu | `apt install virglrenderer0 mesa-vulkan-drivers` |
-| Nix / NixOS | the flake does not put virglrenderer on the loader path; export `LD_LIBRARY_PATH` with the nixpkgs `virglrenderer` and `libepoxy` lib dirs (and `/run/opengl-driver/lib` on NixOS), see the [GPU page](https://smolmachines.com/docs/introduction/concepts/gpu) |
 
 > virglrenderer depends on libEGL and libdrm from the host GPU driver stack. These are hardware-specific and cannot be bundled. Any GPU-capable Linux host will already have them installed via its GPU driver.
 
@@ -401,6 +400,12 @@ The user documentation at [smolmachines.com/docs](https://smolmachines.com/docs/
 welcome there. It is Markdown only, with no build to run; its
 [CONTRIBUTING.md](https://github.com/smol-machines/docs/blob/main/CONTRIBUTING.md) covers the
 page format and how a change reaches the site.
+
+Task-scoped procedures for agents and scripts live in [`skills/`](skills/), one directory per use
+case: `install`, `teardown` and `sandbox`, with more to follow. Each carries a preflight script,
+the lifecycle commands, a cleanup that reaps what it started, and the traps that cost real time.
+[`AGENTS.md`](AGENTS.md#skills) has the table of which packet answers which task, and how an agent
+finds them.
 
 Bugs and feature requests for the runtime stay here.
 

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ page format and how a change reaches the site.
 
 Task-scoped procedures for agents and scripts live in [`skills/`](skills/), one directory per use
 case: `install`, `teardown`, `sandbox`, `dev-env`, `local-api`, `docker-in-machine` and
-`gpu-cuda`. Each carries a preflight script,
+`gpu-cuda` and `pack`. Each carries a preflight script,
 the lifecycle commands, a cleanup that reaps what it started, and the traps that cost real time.
 [`AGENTS.md`](AGENTS.md#skills) has the table of which packet answers which task, and how an agent
 finds them.

--- a/README.md
+++ b/README.md
@@ -402,7 +402,8 @@ welcome there. It is Markdown only, with no build to run; its
 page format and how a change reaches the site.
 
 Task-scoped procedures for agents and scripts live in [`skills/`](skills/), one directory per use
-case: `install`, `teardown` and `sandbox`, with more to follow. Each carries a preflight script,
+case: `install`, `teardown`, `sandbox`, `dev-env`, `local-api`, `docker-in-machine` and
+`gpu-cuda`. Each carries a preflight script,
 the lifecycle commands, a cleanup that reaps what it started, and the traps that cost real time.
 [`AGENTS.md`](AGENTS.md#skills) has the table of which packet answers which task, and how an agent
 finds them.

--- a/scripts/build-dist-windows.sh
+++ b/scripts/build-dist-windows.sh
@@ -138,8 +138,11 @@ USAGE (run smolvm.exe directly)
   smolvm.exe machine stats --name myvm
   smolvm.exe machine stop --name myvm
 
+GPU
+  CUDA compute works: run with --cuda against an NVIDIA GPU.
+
 NOT YET SUPPORTED ON WINDOWS
-  GPU acceleration; machine fork / snapshot.
+  Vulkan graphics (--gpu); machine fork / snapshot.
 
 More: https://github.com/smol-machines/smolvm
 EOF

--- a/skills/dev-env/SKILL.md
+++ b/skills/dev-env/SKILL.md
@@ -1,0 +1,265 @@
+---
+name: dev-env
+description: Keeps a persistent smolvm machine with its dependencies already installed and re-enters it cheaply across sessions. Use when a project needs an isolated development environment that survives stop and start; when deciding what belongs in a Smolfile's init versus what has to run on every boot; when a package installed in a machine has vanished after a restart; or when exec answers "the container smolvm-<hash> is not running". Do not use it for untrusted code, which needs a machine that leaves nothing behind (see the sandbox packet), or for running a Docker daemon inside the machine (see docker-in-machine).
+---
+
+# A persistent dev machine
+
+Verified on **smolvm v1.14.6** on Linux aarch64 and macOS arm64, 2026-09-10. Done means a second `start` is
+fast, skips provisioning, and the packages installed in the first session are still there.
+
+The whole use case turns on one fact: **`init` runs once, not on every start.** The docs now say
+so, under their own "When init runs" heading, but `smolvm machine create --help` still reads
+"Run command on every VM start" at v1.14.6. The CLI is where the wrong promise survives, and
+provisioning designed around it comes up missing on the second boot.
+
+## Procedure
+
+**1. Preflight.**
+
+```bash
+scripts/preflight.sh
+```
+
+Read-only. `restart_after_stop=verified` on macOS and Linux, and on Windows too as of v1.14.6.
+The script covers macOS and Linux only, so its Windows note points at `references/windows.md`.
+
+**2. Declare the machine.** `assets/dev.smolfile` is a working starting point.
+
+```toml
+image = "python:3.12-alpine"
+net = true
+cpus = 2
+memory = 2048
+volumes = ["./src:/app"]
+init = ["sh -c \"id -un > /init-ran-as.txt\"", "adduser -D app"]
+user = "app"
+workdir = "/app"
+```
+
+**3. Create and bring it up.**
+
+```bash
+scripts/create-dev-machine.sh              # name defaults to smolskill-dev
+scripts/create-dev-machine.sh smolskill-myproj ./my.smolfile
+```
+
+It creates the machine **with an explicit long-lived workload command**, records the name for
+cleanup, starts it, waits for the workload container to answer with a value, and then reports what
+actually happened rather than that nothing errored:
+
+```
+init_ran=yes
+machine_running=yes
+workload_ready_after_s=0
+workload_ready=yes
+init_ran_as=root
+exec_user=app
+workdir=/app
+result=up
+```
+
+`init_ran_as=root` with `exec_user=app` is the correct outcome, not a bug: `init` provisions the
+machine and runs as root regardless of `user`, while `exec` and `shell` run as `user`.
+
+**4. Work in it.**
+
+```bash
+smolvm machine exec  --name smolskill-dev -- pip install --user requests
+smolvm machine exec  --name smolskill-dev --user root -- sh -c 'mkdir -p /storage/keep'
+smolvm machine shell --name smolskill-dev            # interactive, lands in workdir as `user`
+```
+
+**5. Prove it is worth keeping.**
+
+```bash
+scripts/verify-persistence.sh
+```
+
+It installs a package and records its **version**, seeds one file per filesystem, stops, starts,
+and then asserts each value against what it recorded. A version comparison is the point: an import
+that does not crash can be satisfied by a system copy and says nothing about your install.
+
+**6. Clean up.**
+
+```bash
+scripts/cleanup.sh --purge
+```
+
+## What `init` and `user` actually do at v1.14.2
+
+Observed, not inferred:
+
+| question | observed |
+|---|---|
+| when does `init` run? | on the **first `start`**, not on `create`, and not again |
+| second start | prints `Init already completed, skipping N command(s)` |
+| which user runs `init`? | **root**, even with `user = "app"` set |
+| which user runs `exec` and `shell`? | the Smolfile `user` |
+| override per command | `machine exec --user root` works |
+| is there `machine start --init`? | **no** |
+
+## What survives a stop and start
+
+| location | survives | why |
+|---|---|---|
+| pip `--user` packages | yes | under `$HOME`, on the overlay |
+| `$HOME/...` files | yes | overlay |
+| files written at `/` | yes | overlay |
+| `/tmp` | **no** | `tmpfs` |
+| `/storage/...` | yes | the ext4 disk itself |
+
+The root filesystem is an overlay whose upper layer lives on the machine's ext4 disk, which is why
+writes to `/` persist while `tmpfs` mounts do not.
+
+## Traps
+
+Full detail in `references/traps.md`. The three that cost the most:
+
+- **`init` runs once.** `smolvm machine create --help` still says "Run command on every VM start"
+  at v1.14.6 while `machine run --help` says the right thing, so the CLI contradicts itself in its
+  own help output. The docs have been corrected and now say once. Anything that must be true on
+  every boot, a bind mount above all, has to run in the command that needs it.
+- **`exec` right after `start` can answer with a message rather than running.** If you see
+  ``the container `smolvm-<hash>` is not running``, the workload container is being relaunched.
+  Without a command, `create` uses the image's own CMD as the persistent workload, and for an
+  interpreter image that exits at once. Measured on a nested-virt aarch64 host: 1 exec in 20 failed
+  that way with no command, 0 in 20 with an explicit long-lived one.
+- **`machine shell` does not start a stopped machine**, despite its own help text saying it does.
+
+Two smaller ones: `create` is instant and proves nothing, because every failure lands on the first
+`start`; and a host `volumes` mount is not writable by a non-root `user`, so build output has to go
+somewhere else.
+
+## Security defaults, and why they are the defaults
+
+- **`user` in the Smolfile is what your workload runs as, and it is not root.** `init` running as
+  root is the provisioning step, deliberately separated from the workload's identity. Keep them
+  separate rather than setting `user = "root"` to make a mount writable: the mount carries host
+  ownership, and running the workload as root to reach it hands root in the guest everything the
+  mount exposes on the host.
+- **A `volumes` mount is host authority handed to the guest**, so mount the narrowest directory
+  that works and prefer `:ro` for anything the machine only reads. Treat root in the guest as
+  untrusted: the VM boundary limits its direct access to the host, while every forwarded mount,
+  port and network permission becomes part of the workload's authority.
+- **`net = true` is outbound access for the whole machine.** A dev machine that only needs a
+  package index does not need general egress; `--allow-host` scopes it.
+- **These scripts wrap the public CLI only.** They edit no smolvm configuration and nothing under
+  `~/.smolvm`, and cleanup deletes only names it recorded under the `smolskill-` prefix.
+
+## Platform arms
+
+- **Linux aarch64**: the scripts were run here on v1.14.2, which is the verified platform for
+  this use case. **Not confirmed on v1.14.3**, for a host reason rather than a product one:
+  see the re-verification section below.
+- **macOS arm64**: the scripts were run here too, and every check passed. The material behind this
+  packet had not exercised this use case on macOS.
+- **Linux x86_64**: verified in the material behind this packet, not re-run here.
+- **Windows x86_64**: `references/windows.md`, **re-run on 2026-09-11 against v1.14.6** on
+  Windows 11 Home build 10.0.26200.0 UBR 9445. Create, two stops and two starts, with a marker
+  read back after each start: **a stopped machine starts again and its state survives**, where on
+  v1.14.2 it did not. That page also carries the WHP device ceiling a Windows preflight needs:
+  four `-v` mounts, three when a port is published.
+- **`init` after a checkpoint restore**: not verified anywhere.
+
+## Eval prompts, and what they produced
+
+Run on 2026-09-07 PT against v1.14.2 from the published release, under an isolated `HOME`. Output
+is verbatim.
+
+**1. "Set me up a Python dev machine I can come back to, and prove the packages survive a
+restart."**
+
+macOS 26.6.2 arm64 and Lima `linux-kvm` (Ubuntu 24.04 aarch64) gave identical results:
+
+```
+init_ran=yes
+machine_running=yes
+workload_ready_after_s=0
+workload_ready=yes
+init_ran_as=root
+exec_user=app
+workdir=/app
+result=up
+
+workload_ready_after_s=0
+installed_version=2.34.2
+  Starting machine 'smolskill-dev' with 1 mount(s)...
+  Init already completed, skipping 3 command(s)
+  Machine 'smolskill-dev' running (PID: 58513)
+init_ran_once=ok (yes)
+package_version=ok (2.34.2)
+home_file=ok (SURVIVES)
+storage_file=ok (SURVIVES)
+tmp_file=ok (WIPED)
+exec_user=ok (app)
+workdir=ok (/app)
+result=persistent
+```
+
+**2. "My bind mount is gone after I restarted the machine. It is right there in `init`."**
+
+`init` ran once. The Linux run shows the machine's own report of it:
+
+```
+Init already completed, skipping 3 command(s)
+```
+
+There is no `machine start --init`, so the mount has to be re-applied by the command that needs
+it. `docker-in-machine` is the packet built entirely around this.
+
+**3. "`smolvm machine exec` just told me the container is not running, but the machine is
+running."**
+
+Reproduced deliberately by creating the same machine without a workload command, then running 20
+execs, on Lima:
+
+```
+ 3: the container `smolvm-e51bb94127b751bf` is not running
+failures=1/20
+ 4: the container `smolvm-32edffb50eaf0d20` is not running
+failures_after_restart=1/20
+```
+
+and with the explicit long-lived workload `scripts/create-dev-machine.sh` passes:
+
+```
+failures=0/20
+failures_after_restart=0/20
+```
+
+The changing hash is the tell: the workload container is being relaunched between execs.
+
+## Re-verified on v1.14.6
+
+Run 2026-09-10 PT against v1.14.6 on macOS 26.6.2 arm64 and Lima `linux-kvm` (Ubuntu 24.04
+aarch64). **Full pass on both**, restart included:
+
+```
+init_ran=yes / machine_running=yes / workload_ready=yes
+init_ran_as=root / exec_user=app / workdir=/app / result=up
+init_ran_once=ok (yes)
+package_version=ok (2.34.2)
+home_file=ok (SURVIVES) / storage_file=ok (SURVIVES) / tmp_file=ok (WIPED)
+result=persistent
+```
+
+The Linux arm was unconfirmed on v1.14.3 because that host was failing one plain boot in ten. It
+is confirmed here.
+
+## What was not run
+
+- **Windows beyond the restart.** The 2026-09-11 v1.14.6 run covered create, stop and start and
+  the marker. The WHP device ceiling and the scripted-driving pattern on that page are still from
+  the earlier run.
+- **Linux x86_64.**
+- **`init` after a checkpoint restore.** Nowhere, on any platform.
+- **The `USER` interaction still settling.** `init` runs as root at v1.14.2, and whether the
+  image's own `USER` still governs it in some paths is open as
+  [smolvm#1189](https://github.com/smol-machines/smolvm/issues/1189). Nothing here tested an image
+  with a `USER` line.
+
+## Related packets
+
+- `install` for the boot this assumes, and `teardown` for the cleanup script.
+- `docker-in-machine` for the clearest case of the `init`-runs-once trap.

--- a/skills/dev-env/SKILL.md
+++ b/skills/dev-env/SKILL.md
@@ -263,3 +263,4 @@ is confirmed here.
 
 - `install` for the boot this assumes, and `teardown` for the cleanup script.
 - `docker-in-machine` for the clearest case of the `init`-runs-once trap.
+- `pack` for turning the machine this packet builds into a portable artifact.

--- a/skills/dev-env/assets/dev.smolfile
+++ b/skills/dev-env/assets/dev.smolfile
@@ -1,0 +1,30 @@
+# A persistent development machine. `smolvm machine create -s dev.smolfile`.
+#
+# The two keys worth understanding before you edit this:
+#
+#   init  runs ONCE, on the first start, and as root. It does not run again on
+#         later starts, whatever the docs say, so anything that has to be true
+#         on every boot does not belong here.
+#   user  governs `exec` and `shell`, not `init`.
+#
+# There is no workload-command key here. Pass one after `--` on `machine create`,
+# as scripts/create-dev-machine.sh does: without it the image's own CMD becomes
+# the persistent workload, and for an interpreter image that command exits at
+# once and `exec` starts racing the relaunch.
+image = "python:3.12-alpine"
+net = true
+cpus = 2
+memory = 2048
+
+# A host mount carries host ownership, so `user` below cannot write to it.
+# Read source in, write build output somewhere else.
+volumes = ["./src:/app"]
+
+init = [
+  "sh -c \"id -un > /init-ran-as.txt\"",
+  "sh -c \"date +%s >> /init-count.txt\"",
+  "adduser -D app",
+]
+
+user = "app"
+workdir = "/app"

--- a/skills/dev-env/references/traps.md
+++ b/skills/dev-env/references/traps.md
@@ -1,0 +1,163 @@
+# Persistent dev machine traps
+
+## Contents
+
+- `init` runs once, not on every start
+- `create` is not where the time goes, and not where failures appear
+- `exec` right after `start` can answer with a message instead of running
+- A missing host mount source lets a machine start once and never restart
+- `machine shell` does not start a stopped machine
+- A host `volumes` mount is not writable by a non-root `user`
+- `/tmp` is tmpfs and is wiped by a stop
+- `machine delete` prompts and defaults to No
+- Do not run two lifecycle commands against the same machine at once
+- Assert the package version, not that the import worked
+
+## `init` runs once, not on every start
+
+Observed on v1.14.2 on macOS arm64 and Linux aarch64: `init` runs on the **first `start`**, not
+on `create`, and never again. The second start prints
+`Init already completed, skipping N command(s)`.
+
+**Anything that must be true on every boot does not belong in `init`.** The most common victim is
+a bind mount: put `mount --bind ...` in `init` and the second boot comes up without it. Re-apply
+it in the same command that needs it. The `docker-in-machine` packet is built around this.
+
+**The CLI still says otherwise, and the docs no longer do.** `smolvm machine create --help` at
+v1.14.6 describes `--init` as "Run command on every VM start", while `smolvm machine run --help`
+has the corrected wording, so the two subcommands contradict each other in their own help output.
+`introduction/concepts/smolfile.md` has since been corrected and carries a "When init runs"
+heading stating that init runs once, on the first start, and that later starts skip it. Believe
+the observed behaviour, which the docs now match and `machine create --help` does not.
+
+`init` also runs **as root**, even with `user` set: `/init-ran-as.txt` contained `root` while
+`exec` and `shell` ran as `app`. There is no `machine start --init` to force a re-run.
+
+## `create` is not where the time goes, and not where failures appear
+
+It is pure configuration and returns in milliseconds without touching the registry. The pull, the
+init commands and any of their failures all land on the first `start`. Do not read a fast
+`create` as evidence that anything works.
+
+Two docs claims to ignore: `introduction/concepts/isolation-networking-credentials.md` says "a
+persistent machine pulls once, when it is created". Observed: `create` pulls nothing.
+
+## `exec` right after `start` can answer with a message instead of running
+
+**If you see ``the container `smolvm-<hash>` is not running``**, the workload container is not up
+and the exec did nothing. The hash differs between occurrences, because the container is being
+relaunched.
+
+**Why it happens.** Without a command, `machine create` launches the image's own ENTRYPOINT or CMD
+as the persistent workload (`machine create --help`, `[COMMAND]`). For an interpreter image such
+as `python:3.12-alpine` that command reads EOF from a stdin nobody is holding and exits at once,
+so the container dies and is relaunched, and an `exec` can land in the gap.
+
+Measured on a nested-virt aarch64 host on 2026-09-07, 20 execs each on a fresh machine and again
+immediately after a restart:
+
+| workload command | failures, fresh | failures, after restart |
+|---|---|---|
+| none (image CMD) | 1 in 20 | 1 in 20 |
+| `sh -c 'while true; do sleep 3600; done'` | 0 in 20 | 0 in 20 |
+
+**The fix is to give the machine a workload that stays up**, which is what
+`scripts/create-dev-machine.sh` does. There is no Smolfile key for it: pass it after `--` on
+`machine create`.
+
+**And this is why the readiness probe has to assert a value.** The message goes to stdout, so a
+probe that waits for empty output or a zero exit code reports ready while the container is still
+flapping, and the next three checks silently read that message as their answer. Both scripts here
+wait for the exact string `WORKLOAD_READY`.
+
+## A missing host mount source lets a machine start once and never restart
+
+**If a machine created from a Smolfile starts fine and then never starts again**, check that every
+host path in `volumes` exists. A Smolfile with `volumes = ["./src:/app"]` in a directory that has
+no `./src` creates and starts once, and every later `start` fails with:
+
+```
+Error: agent operation failed: start machine: agent operation failed: wait for ready:
+agent did not become ready within 30 seconds
+```
+
+which names neither the mount nor the missing directory, and reads exactly like host load.
+
+Measured on macOS 26.6.2 arm64 on v1.14.3, 2026-09-08, three create-start-stop-start cycles each
+with the workload confirmed ready before the stop:
+
+| host mount source | restarts |
+|---|---|
+| `./src` exists | **3 of 3** |
+| `./src` absent | **0 of 3** |
+
+`scripts/create-dev-machine.sh` runs `mkdir -p ./src` before creating, which is why the packet's
+own flow does not hit this. **Anything that writes its own Smolfile has to do the same.** A
+relative path in `volumes` resolves against the working directory, so the same Smolfile run from
+two directories can behave differently.
+
+This one cost real time while writing this packet: an ad-hoc restart loop that omitted the
+`mkdir -p` produced 0 of 5 and looked like a release regression until the two were compared
+side by side.
+
+## `machine shell` does not start a stopped machine, despite its own help
+
+`smolvm machine --help` describes `shell` as "Open an interactive shell in a machine (starts it if
+stopped)". It does not:
+
+```
+$ smolvm machine stop --name dev
+$ smolvm machine shell --name dev
+Error: agent operation failed: connect: machine 'dev' is not running.
+       Use 'smolvm machine start --name dev' first.
+```
+
+Verified both through a pipe and under a real pty, so it is not a TTY-detection effect. Start it
+explicitly first.
+
+## A host `volumes` mount is not writable by a non-root `user`
+
+With `volumes = ["./src:/app"]` and `user = "app"`, writing to `/app` fails with
+`Operation not permitted`. The mount carries host ownership and the guest user does not match.
+Read source in through the mount, write build output somewhere else, or run that step as root.
+
+## `/tmp` is tmpfs and is wiped by a stop
+
+Anything a provisioning step leaves in `/tmp` is gone on the next start, while the same step's
+writes to `$HOME` or `/` persist. What survives, verified by writing one file per filesystem and
+restarting:
+
+| location | survives | why |
+|---|---|---|
+| pip `--user` packages | yes | under `$HOME`, on the overlay |
+| `$HOME/...` files | yes | overlay |
+| files written at `/` | yes | overlay |
+| `/tmp` | **no** | `tmpfs` |
+| `/storage/...` | yes | the ext4 disk itself |
+
+Read from inside the guest, the mechanism is an overlay whose upper layer lives on the machine's
+ext4 disk:
+
+```
+none on / type overlay (... upperdir=/storage/overlays/persistent-<name>/upper ...)
+/dev/vda on /workspace type ext4 (rw,noatime)
+/dev/vda on /storage   type ext4 (rw,noatime)
+```
+
+## `machine delete` prompts and defaults to No
+
+Without `--force` a scripted cleanup prints `Delete machine 'dev'? [y/N] Cancelled` and leaves the
+machine in place while the script carries on. Always pass `--force` in a script.
+
+## Do not run two lifecycle commands against the same machine at once
+
+Two overlapping `stop` and `shell` invocations left a `machine stop` unfinished for over two
+minutes, against 0.14 s for a single `stop` on the same machine. That was self-inflicted rather
+than a reproduced defect, but anything that fans out lifecycle calls should serialize them per
+machine.
+
+## Assert the package version, not that the import worked
+
+An import can be satisfied by a system copy and tells you nothing about whether your install
+survived the restart. `scripts/verify-persistence.sh` records the version before the stop and
+compares it after.

--- a/skills/dev-env/references/windows.md
+++ b/skills/dev-env/references/windows.md
@@ -1,0 +1,71 @@
+# A dev machine on Windows
+
+**Re-run on 2026-09-11 against smolvm v1.14.6** on Windows 11 Home build 10.0.26200.0 UBR 9445
+x86_64 (Intel Core Ultra 9 185H, 31.6 GB), in an elevated session. **A dev machine on Windows
+survives a stop and a start**, so the use case holds there as it does on Unix.
+
+The timings in the next section and the device ceiling further down are from the earlier run on
+the same host, on v1.14.2, and were not measured again.
+
+## What works, and matches Unix exactly
+
+```
+create                  in 0.5s   Created machine: wd   Init commands: 2
+first start             in 4.9s   Running 2 init command(s)...
+init user / exec user   initran=root   execuser=app   workdir=/tmp
+install requests        in 9.1s   2.34.2
+stop                    in 0.4s   Stopped machine: wd
+```
+
+So `init` runs as root while the workload runs as the Smolfile `user`, identical to Linux and
+macOS, and `init` runs once: the second start printed
+`Init already completed, skipping 2 command(s)`.
+
+## Stop and start, which is what this use case rests on
+
+Run on v1.14.6 through create, start, stop, start, stop, start, with a marker written inside the
+machine and read back after each start:
+
+```
+Created machine: wd
+  --- first start
+    out: Machine 'wd' running (PID: 2028)
+    MARKER_V1146
+  --- stop 1
+    Stopped machine: wd
+  --- start 2 (this is what failed on v1.14.2 with Bad message os error 74)
+    out: Machine 'wd' running (PID: 14784)
+  --- marker after start 2
+    MARKER_V1146
+  --- stop 2
+    Stopped machine: wd
+  --- start 3
+    out: Machine 'wd' running (PID: 13820)
+  --- marker after start 3
+    MARKER_V1146
+```
+
+**Both restarts succeed and the marker survives both.** State written inside the machine is still
+there after a stop, which is the promise this packet makes everywhere else.
+
+The history, because the earlier version of this page was built around it: on v1.14.2 the second
+start failed with `pull image: Bad message (os error 74)` and left the machine stopped, which is
+[smolvm#1196](https://github.com/smol-machines/smolvm/issues/1196) and is fixed in v1.14.6.
+
+## The device ceiling belongs in a Windows preflight
+
+WHP gives the guest an eleven-IRQ budget, the same as Linux. Measured on the tested host:
+**four `-v` mounts boot and five fail** with `no more IRQs are available`, and **any published
+port costs one of those slots**, so four mounts plus two ports fails while two plus two boots.
+
+A dev machine that mounts a source tree, a cache, a build output directory and a config directory
+is already at the limit before it publishes a dev server's port.
+
+## Driving it from a script
+
+`machine start` never returns to a caller that captures its output: the background VM inherits
+the parent's stdout handle. Use `Start-Process -RedirectStandardOutput` and poll `HasExited`. The
+full measurement and the working pattern are in the `install` packet's `references/windows.md`.
+
+State cannot be relocated on Windows, so a dev machine's disks land in `%LOCALAPPDATA%\smolvm`
+and have to be removed by hand. See the `teardown` packet.

--- a/skills/dev-env/scripts/cleanup.sh
+++ b/skills/dev-env/scripts/cleanup.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Delete the machines this packet's scripts created, then prove the host is clean.
+#
+# Only machines recorded in the state file are deleted, so a machine you or
+# another session created by hand is never touched. Scripts record a name by
+# calling: cleanup.sh --record <name>
+#
+# usage: cleanup.sh [--record <name>] [--reap] [--purge]
+#   --record <name>  add a machine name to the state file and exit
+#   --reap           kill leftover VM processes (see the warning it prints)
+#   --purge          also remove the state file once the list is empty
+
+set -uo pipefail
+
+PACKET="dev-env"
+PREFIX="smolskill-"
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+STATE_DIR="${SMOLVM_SKILL_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/smolvm-skills}"
+STATE_FILE="$STATE_DIR/$PACKET.machines"
+
+reap=0
+purge=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --record)
+            mkdir -p "$STATE_DIR"
+            printf '%s\n' "$2" >> "$STATE_FILE"
+            exit 0
+            ;;
+        --reap)  reap=1 ;;
+        --purge) purge=1 ;;
+        *) printf 'unknown argument: %s\n' "$1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+if [ -z "$SMOLVM" ]; then
+    printf 'smolvm not found; set SMOLVM to its path\n' >&2
+    exit 2
+fi
+
+case "$(uname -s)" in
+    Darwin) VMS_DIR="$HOME/Library/Caches/smolvm/vms" ;;
+    *)      VMS_DIR="${SMOLVM_DATA_DIR:-$HOME/.cache/smolvm}/vms" ;;
+esac
+VMS_DIR="${SMOLVM_VMS_DIR:-$VMS_DIR}"
+SMOLVM_PREFIX="${SMOLVM_PREFIX:-$HOME/.smolvm}"
+
+# List this HOME's smolvm VM processes, as "pid marker".
+#
+# Two process shapes exist and a reaper has to catch both. The plain
+# `machine run` path EXECS a child whose argv[1] is `_boot-vm` and whose argv[2]
+# is its boot-config path. The pack-run path, which is `--oci-cache` or any
+# `init`, FORKS without execing, so the child inherits the parent's argv and
+# carries no boot-config at all. Matching `_boot-vm` alone is therefore blind to
+# exactly the path whose child survives an interrupt
+# (smol-machines/smolvm#1193): measured on v1.14.6, it reported "none" while two
+# orphaned VMs held 234 MB each.
+#
+# On Linux both shapes rename themselves to `libkrun VM`, the one marker that
+# covers both and that no shell can hold. macOS exposes no rename, so there the
+# executable path scopes the search to this HOME and the parent chain separates
+# a VM from the CLI that started it.
+#
+# `pgrep -f _boot-vm` is not an alternative: it matches any shell whose text
+# contains that string, including this script.
+list_vm_processes() {
+    case "$(uname -s)" in
+        Linux)
+            for p in /proc/[0-9]*; do
+                [ "$(cat "$p/comm" 2>/dev/null)" = "libkrun VM" ] || continue
+                pid="${p#/proc/}"
+                cfg="$(tr '\0' '\n' < "$p/cmdline" 2>/dev/null | sed -n '3p')"
+                case "$cfg" in
+                    "$VMS_DIR"/*) printf '%s %s\n' "$pid" "$cfg"; continue ;;
+                esac
+                # Forked shape: nothing in argv identifies it, so scope by the
+                # binary it is running.
+                case "$(readlink "$p/exe" 2>/dev/null)" in
+                    "$SMOLVM_PREFIX"/*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;;
+                esac
+            done
+            ;;
+        Darwin)
+            # shellcheck disable=SC2009  # pgrep cannot return ppid and the full
+            # command together, and pgrep -f matches this script's own text.
+            own=" $(ps -axo pid=,command= 2>/dev/null | grep -F "$SMOLVM_PREFIX/smolvm-bin" | awk '{print $1}' | tr '\n' ' ') "
+            ps -axo pid=,ppid=,command= 2>/dev/null | while read -r pid ppid rest; do
+                case "$rest" in "$SMOLVM_PREFIX"/smolvm-bin*) ;; *) continue ;; esac
+                case "$rest" in
+                    *" _boot-vm "*) printf '%s %s\n' "$pid" "${rest#* _boot-vm }"; continue ;;
+                esac
+                # Forked shape: its parent is the CLI that started it, or init
+                # once that CLI is gone.
+                if [ "$ppid" = 1 ]; then
+                    printf '%s orphaned-under %s\n' "$pid" "$SMOLVM_PREFIX"
+                else
+                    case "$own" in *" $ppid "*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;; esac
+                fi
+            done
+            ;;
+    esac
+}
+
+# 1. Delete recorded machines. --force is not optional: without it the command
+# prompts, defaults to No, and leaves the machine in place while the script
+# carries on. --cascade removes branch children, which otherwise block the
+# delete.
+if [ -s "$STATE_FILE" ]; then
+    while read -r name; do
+        [ -n "$name" ] || continue
+        case "$name" in "$PREFIX"*) ;; *)
+            printf 'skipping %s: not created by this packet (no %s prefix)\n' "$name" "$PREFIX"
+            continue ;;
+        esac
+        "$SMOLVM" machine stop   --name "$name" >/dev/null 2>&1
+        "$SMOLVM" machine delete --name "$name" --force --cascade 2>&1 | sed 's/^/  /'
+    done < "$STATE_FILE"
+fi
+
+# 2. An ephemeral machine's entry retires after the run returns, not with it.
+# Asserting an empty list immediately fails on a healthy host.
+sleep 20
+
+# 3. Assert the value, not the exit code.
+listing="$("$SMOLVM" machine list 2>&1)"
+if printf '%s' "$listing" | grep -q 'No machines found'; then
+    printf 'machines=clean\n'
+    [ "$purge" -eq 1 ] && rm -f "$STATE_FILE"
+else
+    printf 'machines=remaining\n'
+    printf '%s\n' "$listing" | sed 's/^/  /'
+fi
+
+# 4. Report VM processes an interrupt left behind. Ctrl-C does not stop a
+# machine: the VM outlives the CLI and `machine list` cannot see it, so this is
+# the only route to it. Only processes whose boot config lives under this HOME's
+# smolvm state are listed, so a VM another session started is left alone.
+found=0
+while read -r pid cfg; do
+    [ -n "$pid" ] || continue
+    found=1
+    printf 'vm_process=%s config=%s\n' "$pid" "$cfg"
+    if [ "$reap" -eq 1 ]; then
+        kill -9 "$pid" 2>/dev/null && printf '  killed %s\n' "$pid"
+    fi
+done <<EOF
+$(list_vm_processes)
+EOF
+
+if [ "$found" -eq 0 ]; then
+    printf 'vm_processes=none\n'
+elif [ "$reap" -eq 0 ]; then
+    printf 'rerun with --reap to kill them\n'
+fi

--- a/skills/dev-env/scripts/create-dev-machine.sh
+++ b/skills/dev-env/scripts/create-dev-machine.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Create a persistent dev machine and bring it up for the first time.
+#
+# usage: create-dev-machine.sh [<name>] [<smolfile>]
+#   name      default smolskill-dev (the prefix cleanup.sh will delete)
+#   smolfile  default ../assets/dev.smolfile
+#
+# `create` is configuration only: it returns in milliseconds, pulls nothing and
+# reports no failure. The pull, the init commands and any of their failures all
+# land on the first `start`, so a fast create is not evidence that anything works.
+
+set -uo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+NAME="${1:-smolskill-dev}"
+SMOLFILE="${2:-$here/../assets/dev.smolfile}"
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+if [ -z "$SMOLVM" ]; then
+    printf 'smolvm not found; set SMOLVM to its path\n' >&2
+    exit 2
+fi
+
+case "$NAME" in
+    smolskill-*) ;;
+    *) printf 'name must start with smolskill- so cleanup.sh will delete it\n' >&2; exit 2 ;;
+esac
+
+# The Smolfile mounts ./src, which is relative to the working directory.
+mkdir -p ./src
+
+# Give the machine a workload that stays up. Without a command, `create` launches
+# the image's own ENTRYPOINT/CMD as the persistent workload; for an interpreter
+# image such as python:3.12-alpine that command reads EOF and exits at once, the
+# container is relaunched, and `exec` then intermittently answers "the container
+# `smolvm-<hash>` is not running" instead of running your command. Measured on a
+# nested-virt aarch64 host: 1 exec in 20 failed that way with no command, 0 in 20
+# with this one, both on a fresh machine and immediately after a restart.
+"$SMOLVM" machine create --name "$NAME" -s "$SMOLFILE" \
+    -- sh -c 'while true; do sleep 3600; done' 2>&1 | sed 's/^/  /'
+"$here/cleanup.sh" --record "$NAME"
+
+start_out="$("$SMOLVM" machine start --name "$NAME" 2>&1)"
+printf '%s\n' "$start_out" | sed 's/^/  /'
+
+fail=0
+if printf '%s' "$start_out" | grep -q 'Running .* init command'; then
+    printf 'init_ran=yes\n'
+else
+    printf 'init_ran=no\n'
+    fail=1
+fi
+if printf '%s' "$start_out" | grep -q "Machine '$NAME' running"; then
+    printf 'machine_running=yes\n'
+else
+    printf 'machine_running=no\n'
+    fail=1
+fi
+
+# `start` returns before the workload container is up. Wait for a VALUE: an empty
+# result and a zero exit code both pass while the container is still coming up,
+# so a probe that asserts either of those reports ready too early and the next
+# three checks read a message as their answer.
+wait_for_workload() {
+    # 120 s: the slowest first start observed while building this packet was
+    # under 20 s on a nested-virt aarch64 host, so this is six times the worst
+    # case and still short enough that a real hang is reported, not waited on.
+    waited=0
+    while [ "$waited" -lt 120 ]; do
+        out="$("$SMOLVM" machine exec --name "$1" -- sh -c 'echo WORKLOAD_READY' 2>&1 | tr -d '\r')"
+        if [ "$out" = "WORKLOAD_READY" ]; then
+            printf 'workload_ready_after_s=%s\n' "$waited"
+            return 0
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+    printf 'workload_ready_after_s=timeout last_probe=%s\n' "$out"
+    return 1
+}
+
+if wait_for_workload "$NAME"; then
+    printf 'workload_ready=yes\n'
+else
+    printf 'workload_ready=no\n'
+    fail=1
+fi
+
+# init runs as root even with `user` set. Asserting the value rather than the
+# absence of an error is the point: an exec that fails still leaves you guessing.
+printf 'init_ran_as=%s\n' "$("$SMOLVM" machine exec --name "$NAME" --user root -- cat /init-ran-as.txt 2>&1 | tr -d '\r')"
+printf 'exec_user=%s\n'   "$("$SMOLVM" machine exec --name "$NAME" -- id -un 2>&1 | tr -d '\r')"
+printf 'workdir=%s\n'     "$("$SMOLVM" machine exec --name "$NAME" -- pwd 2>&1 | tr -d '\r')"
+
+if [ "$fail" -eq 0 ]; then printf 'result=up\n'; else printf 'result=failed\n'; fi
+exit "$fail"

--- a/skills/dev-env/scripts/preflight.sh
+++ b/skills/dev-env/scripts/preflight.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Report whether this host can keep a persistent smolvm dev machine. Read-only:
+# starts no VM, writes no smolvm state, changes no group membership.
+#
+# Output is one key=value per line so a caller can parse it. The last line is
+# always result=ready or result=blocked.
+
+set -uo pipefail
+
+VERIFIED_VERSION="1.14.6"
+
+emit() { printf '%s=%s\n' "$1" "$2"; }
+
+blocked=0
+note() { printf 'note=%s\n' "$1"; }
+
+# --- the binary --------------------------------------------------------------
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+if [ -z "$SMOLVM" ]; then
+    emit smolvm_installed no
+    emit smolvm_version ""
+    blocked=1
+else
+    emit smolvm_installed yes
+    version="$("$SMOLVM" --version 2>/dev/null | awk '{print $NF}')"
+    emit smolvm_version "${version:-unknown}"
+fi
+
+emit verified_version "$VERIFIED_VERSION"
+if [ -n "${version:-}" ] && [ "$version" != "unknown" ]; then
+    if [ "$version" = "$VERIFIED_VERSION" ]; then
+        emit version_status match
+    else
+        newest="$(printf '%s\n%s\n' "$version" "$VERIFIED_VERSION" | sort -V | tail -1)"
+        if [ "$newest" = "$version" ]; then
+            emit version_status newer
+            note "this packet was verified on $VERIFIED_VERSION and the binary is $version; flags and messages move every release, so check the output against the binary before trusting a step here"
+        else
+            emit version_status older
+            note "this packet was verified on $VERIFIED_VERSION and the binary is $version"
+        fi
+    fi
+else
+    emit version_status unknown
+fi
+
+# --- platform ----------------------------------------------------------------
+
+kernel="$(uname -s)"
+arch="$(uname -m)"
+case "$arch" in aarch64|arm64) arch=aarch64 ;; esac
+
+case "$kernel" in
+    Darwin)
+        emit platform "darwin-$arch"
+        emit accel hvf
+        emit macos_version "$(sw_vers -productVersion)"
+        hv="$(sysctl -n kern.hv_support 2>/dev/null)"
+        if [ "$hv" = "1" ]; then emit accel_access ok; else emit accel_access denied; blocked=1; fi
+        if [ "$arch" != "aarch64" ]; then
+            emit hardware_verified no
+            note "Intel Mac is not verified by this packet; the installer accepts it and nothing here was run on one"
+        else
+            emit hardware_verified yes
+        fi
+        # A VM's agent socket lives under the cache directory. macOS sockaddr_un
+        # holds 104 bytes including the terminator.
+        sock="$HOME/Library/Caches/smolvm/vms/0123456789abcdef/agent.sock"
+        len=${#sock}
+        emit socket_path_bytes "$len"
+        if [ "$len" -gt 100 ]; then
+            emit socket_path_status too_long
+            blocked=1
+            note "HOME is too deep: every VM start will fail with krun_start_enter -22, whose text blames disks and device options. Install under a shorter HOME."
+        else
+            emit socket_path_status ok
+        fi
+        emit unsupported "vulkan,cuda"
+        emit restart_after_stop verified
+        ;;
+    Linux)
+        emit platform "linux-$arch"
+        emit accel kvm
+        emit socket_path_status n_a
+        if [ ! -e /dev/kvm ]; then
+            emit accel_access missing
+            blocked=1
+            note "/dev/kvm does not exist; this host has no KVM"
+        elif [ -r /dev/kvm ] && [ -w /dev/kvm ]; then
+            emit accel_access ok
+        else
+            emit accel_access denied
+            blocked=1
+            note "your user cannot open /dev/kvm. The installer warns and continues, so a successful install says nothing about whether a VM will start. Fix: sudo usermod -aG kvm \$USER, then run the next command through sg kvm -c '...' rather than logging out."
+        fi
+        emit unsupported "vulkan"
+        emit restart_after_stop verified
+        ;;
+    *)
+        emit platform "unsupported-$kernel"
+        emit accel unknown
+        emit accel_access unknown
+        blocked=1
+        emit restart_after_stop broken
+        note "this script covers macOS and Linux. On Windows a stopped machine starts again as of v1.14.6, and the WHP device budget caps you at four -v mounts, three when a port is published. See references/windows.md."
+        ;;
+esac
+
+if [ "$blocked" -eq 0 ]; then emit result ready; else emit result blocked; fi

--- a/skills/dev-env/scripts/verify-persistence.sh
+++ b/skills/dev-env/scripts/verify-persistence.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Prove the machine is worth keeping: that a package installed in one session is
+# still there in the next, that init does not run again, and that the parts of
+# the filesystem people assume persist actually do.
+#
+# usage: verify-persistence.sh [<name>]     (default smolskill-dev)
+#
+# Every check asserts a value. Asserting that an import did not crash proves
+# nothing here: a system copy of the package satisfies it and tells you nothing
+# about whether your install survived.
+
+set -uo pipefail
+
+NAME="${1:-smolskill-dev}"
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+if [ -z "$SMOLVM" ]; then
+    printf 'smolvm not found; set SMOLVM to its path\n' >&2
+    exit 2
+fi
+
+fail=0
+check() {
+    if [ "$2" = "$3" ]; then
+        printf '%s=ok (%s)\n' "$1" "$2"
+    else
+        printf '%s=FAIL expected=%s actual=%s\n' "$1" "$3" "$2"
+        fail=1
+    fi
+}
+
+exec_in() { "$SMOLVM" machine exec --name "$NAME" -- "$@" 2>&1 | tr -d '\r'; }
+
+# `start` returns before the workload container is up, and an `exec` in that
+# window answers "the container `smolvm-<hash>` is not running" on stdout while
+# still exiting zero. Wait for a VALUE: an empty result or a zero exit code both
+# pass while the container is still coming up, which is how this window gets
+# missed. Observed on a nested-virt aarch64 host, where a probe that asserted
+# only an empty result let three later checks read that message as their answer.
+wait_for_workload() {
+    # 120 s: six times the slowest start observed while building this packet.
+    # Long enough to absorb a loaded host, short enough to report a real hang.
+    waited=0
+    while [ "$waited" -lt 120 ]; do
+        probe="$(exec_in sh -c 'echo WORKLOAD_READY')"
+        if [ "$probe" = "WORKLOAD_READY" ]; then
+            printf 'workload_ready_after_s=%s\n' "$waited"
+            return 0
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+    printf 'workload_ready_after_s=timeout last_probe=%s\n' "$probe"
+    return 1
+}
+
+if ! wait_for_workload; then
+    printf 'result=FAILED (workload container never came up)\n'
+    exit 1
+fi
+
+# 1. Install something and record its version, not its presence.
+"$SMOLVM" machine exec --name "$NAME" -- pip install --quiet --user requests >/dev/null 2>&1
+before="$(exec_in python3 -c 'import requests; print(requests.__version__)')"
+printf 'installed_version=%s\n' "$before"
+
+# 2. Seed one file per filesystem so the stop tells them apart.
+# shellcheck disable=SC2016  # $HOME must expand inside the guest, not here
+"$SMOLVM" machine exec --name "$NAME" -- sh -c 'echo SURVIVES > "$HOME/keep.txt"; echo GONE > /tmp/scratch.txt' >/dev/null 2>&1
+"$SMOLVM" machine exec --name "$NAME" --user root -- sh -c 'mkdir -p /storage/keep && echo SURVIVES > /storage/keep/disk.txt' >/dev/null 2>&1
+
+# 3. Stop and come back.
+"$SMOLVM" machine stop --name "$NAME" >/dev/null 2>&1
+restart_out="$("$SMOLVM" machine start --name "$NAME" 2>&1)"
+printf '%s\n' "$restart_out" | sed 's/^/  /'
+
+if ! wait_for_workload; then
+    fail=1
+fi
+
+if printf '%s' "$restart_out" | grep -q 'Init already completed'; then
+    check init_ran_once yes yes
+else
+    check init_ran_once no yes
+fi
+
+after="$(exec_in python3 -c 'import requests; print(requests.__version__)')"
+check package_version "$after" "$before"
+
+# shellcheck disable=SC2016  # same: the guest resolves $HOME
+check home_file    "$(exec_in sh -c 'cat "$HOME/keep.txt" 2>/dev/null')" SURVIVES
+check storage_file "$(exec_in cat /storage/keep/disk.txt)" SURVIVES
+
+# /tmp is tmpfs and is wiped by a stop. Anything a provisioning step leaves
+# there is gone on the next start, while the same step's writes to $HOME or /
+# persist. This is the asymmetry that surprises people.
+check tmp_file "$(exec_in sh -c 'cat /tmp/scratch.txt 2>/dev/null || echo WIPED')" WIPED
+
+check exec_user "$(exec_in id -un)" app
+check workdir   "$(exec_in pwd)" /app
+
+if [ "$fail" -eq 0 ]; then printf 'result=persistent\n'; else printf 'result=FAILED\n'; fi
+exit "$fail"

--- a/skills/docker-in-machine/SKILL.md
+++ b/skills/docker-in-machine/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: docker-in-machine
+description: Runs a Docker daemon inside a smolvm machine, for workloads that must call Docker themselves such as Testcontainers, Compose, image builds, or a coding agent that launches containers. Use when dockerd will not start inside a machine; when Docker worked on the first boot and broke after a stop and start; when deciding where Docker's data directory has to live; or when checking whether this is possible on a given platform at all. Do not use it to run OCI images, which smolvm boots natively without Docker, and do not attempt it on Windows, where the bundled guest kernel cannot support it.
+---
+
+# A Docker daemon inside a machine
+
+Verified on **smolvm v1.14.6** on Linux aarch64 and macOS arm64, 2026-09-10. Done means `docker info` succeeds
+inside the guest, a nested container runs, and Docker's data sits on the ext4 storage disk rather
+than the rootfs overlay.
+
+smolvm boots OCI images without Docker. This is only for software **inside** the machine that must
+call Docker itself.
+
+**This use case does not exist on Windows, up to and including v1.14.6.** The bundled guest kernel
+there has neither bridge networking nor POSIX message queues, so `dockerd` will not start and,
+forced past that, containers still cannot be created. `references/windows.md` has the evidence, and
+the direct kernel probe to re-check it on a newer build.
+
+## Procedure
+
+**1. Preflight.**
+
+```bash
+scripts/preflight.sh
+```
+
+`docker_in_machine=verified` on macOS and Linux, `unavailable` on Windows with the reason.
+
+**2. Create and install.** `assets/docker.smolfile` is the upstream example's configuration,
+shipped here because **the release tarball does not contain `examples/`**, so the guide's
+`git clone` step is not something a released install can follow.
+
+```bash
+scripts/create-docker-machine.sh              # name defaults to smolskill-docker
+```
+
+The `apk add docker` happens on the **first start**, not on create, and dominates the time.
+
+**3. Start the daemon. Run this on every start, not only the first.**
+
+```bash
+scripts/start-dockerd.sh
+```
+
+It re-applies both bind mounts, clears a stale pid file, starts `dockerd` with the `overlay2`
+driver and waits for `docker info` to answer:
+
+```
+ Server Version: 25.0.5
+ Storage Driver: overlay2
+ Docker Root Dir: /var/lib/docker
+server_version=25.0.5
+result=dockerd_up
+```
+
+**4. Prove it, on the right filesystem.**
+
+```bash
+scripts/verify-docker.sh
+```
+
+```
+storage_driver=ok (overlay2)
+docker_root_device=ok (/dev/vda)
+pull=docker.io/library/alpine:latest
+nested_container=ok (NESTED_OK)
+host_network=ok (HOSTNET_OK)
+host_socket=present (.../vms/<hash>/docker.sock)
+result=docker_ok
+```
+
+`docker_root_device` is the check that matters. `docker info` succeeds while `/var/lib/docker`
+sits on the rootfs overlay, and the failure that follows is confusing and much later.
+
+**5. Clean up.**
+
+```bash
+scripts/cleanup.sh --purge
+```
+
+## Why Docker's data has to live on `/storage`
+
+A hard requirement, not a preference. The smolvm rootfs overlay uses the initramfs (ramfs) as its
+lower layer, ramfs has no file-handle support, and overlayfs then rejects it as an upper dir for
+Docker's nested overlay. Both mounts are needed: `/var/lib/containerd` holds the snapshotter's
+overlay state and fails the same way.
+
+That is why the Smolfile declares `storage = 20`, and why every check here is against `/dev/vda`.
+
+## The trap this packet exists for
+
+**`init` runs once, so the bind mounts are gone on the second boot.** The upstream example puts
+them in `init` alone, which is correct for exactly one boot. Reproduced on both hosts:
+
+```
+Init already completed, skipping 5 command(s)
+NO_BIND_MOUNTS_AFTER_RESTART
+DOCKERD_DOWN
+```
+
+Running `scripts/start-dockerd.sh` afterwards restored everything, and `docker images` still
+listed `alpine:latest`, because the images are on `/storage`. **The failure mode is a daemon that
+will not start, or one running on the wrong filesystem, not lost data.**
+
+`smolvm machine create --help` still describes `--init` as running "on every VM start" at
+v1.14.6, which is what makes the upstream example look correct. The docs have been corrected and
+now say init runs once. More in `references/traps.md`.
+
+## The host-side socket
+
+`docker_socket = true` bridges the guest's `/var/run/docker.sock` to a host path under the
+machine's data directory:
+
+```bash
+D=$(smolvm machine data-dir --name smolskill-docker)
+DOCKER_HOST=unix://$D/docker.sock docker ps      # needs a docker client on the host
+```
+
+The socket is created and `verify-docker.sh` asserts it exists. **Driving it from the host was not
+verified**: neither host used here has a `docker` client.
+
+## Security defaults, and why they are the defaults
+
+- **`docker_socket = true` is the one line here that gives something outside the VM real
+  authority.** A process on the host that can open that socket can start containers inside the
+  machine, mount paths the machine can see and read anything they hold. Leave it off unless a host
+  tool actually needs it, which is why nothing in this packet's own checks depends on it.
+- **A Docker daemon inside the machine is root inside the machine, and that is the point.** The VM
+  boundary is what makes it acceptable: treat root in the guest as untrusted, and remember that
+  every forwarded mount, port and network permission becomes part of what the nested containers
+  can reach.
+- **`--network=host` inside the guest is the guest's network, not yours.** It is verified here
+  because Testcontainers and Compose commonly need it, and it is contained by the VM rather than
+  by Docker.
+- **`net = true` is outbound access for the whole machine**, and it is required for this use case
+  because `apk add docker` and every `docker pull` need it. Scope it with `--allow-host` where the
+  set of registries is known.
+- **The scripts wrap the public CLI only.** They edit no smolvm configuration and nothing under
+  `~/.smolvm`, and cleanup deletes only names it recorded under the `smolskill-` prefix.
+
+## Platform arms
+
+- **Linux aarch64**: the scripts were run here, which is the verified platform for this use case.
+- **macOS arm64**: the scripts were run here too and every check passed, including the restart
+  trap and its recovery. The material behind this packet had not exercised this use case on macOS.
+- **Linux x86_64**: not run anywhere for this use case.
+- **Windows x86_64**: **not possible**, on the evidence of one v1.14.2 run. A re-run on
+  2026-09-11 against v1.14.6 **did not reach the question**: both attempts died pulling the image,
+  so nothing was confirmed or refuted there. `references/windows.md` has both, and the direct
+  kernel probe that answers it without a large pull.
+
+## Eval prompts, and what they produced
+
+Run on 2026-09-07 PT against v1.14.2 from the published release, under an isolated `HOME`, on
+macOS 26.6.2 arm64 and Lima `linux-kvm` (Ubuntu 24.04 aarch64). Output is verbatim.
+
+**1. "Give me a machine where I can run Testcontainers, and show me Docker actually works in
+it."**
+
+Both hosts, identical:
+
+```
+docker_version=Docker version 25.0.5, build d260a54c81efcc3f00fe67dee78c94b16c2f8692
+result=installed
+ Server Version: 25.0.5
+ Storage Driver: overlay2
+ Docker Root Dir: /var/lib/docker
+result=dockerd_up
+storage_driver=ok (overlay2)
+docker_root_device=ok (/dev/vda)
+nested_container=ok (NESTED_OK)
+host_network=ok (HOSTNET_OK)
+result=docker_ok
+```
+
+**2. "Docker worked yesterday and today `dockerd` will not start. Nothing changed."**
+
+Reproduced on both hosts by stopping and starting the machine, then checking before running
+anything:
+
+```
+Init already completed, skipping 5 command(s)
+NO_BIND_MOUNTS_AFTER_RESTART
+DOCKERD_DOWN
+```
+
+`scripts/start-dockerd.sh` then brought it back to `result=docker_ok` on both, and the images
+were still there:
+
+```
+$ smolvm machine exec --name smolskill-docker -- docker images --format '{{.Repository}}:{{.Tag}}'
+alpine:latest
+```
+
+**3. "Can I do this on Windows?"**
+
+**No**, and the answer is short enough to give without running anything: the bundled guest kernel
+has `CONFIG_BRIDGE` and `CONFIG_POSIX_MQUEUE` both off, so `dockerd` fails on
+`error creating default "bridge" network: operation not supported`, and with `--bridge=none` the
+daemon comes up healthy while every container fails on `/dev/mqueue`. That result is from an
+earlier run on Windows 11 against v1.14.2. The 2026-09-11 attempt on v1.14.6 died pulling the
+image and confirmed nothing either way, so that answer still rests on the one run.
+
+## Re-verified on v1.14.6
+
+Run 2026-09-10 PT against v1.14.6 on macOS 26.6.2 arm64 **and Lima `linux-kvm` (Ubuntu 24.04
+aarch64)**: `Docker version 25.0.5`, `Server Version: 25.0.5`, `storage_driver=ok (overlay2)`,
+`docker_root_device=ok (/dev/vda)`, `nested_container=ok (NESTED_OK)`,
+`host_network=ok (HOSTNET_OK)`, `result=docker_ok` on both. The Linux arm was not re-run on
+v1.14.3; it is re-run here.
+
+## What was not run
+
+- **Windows on v1.14.6.** The 2026-09-11 attempt never got past the image pull, so the conclusion
+  in `references/windows.md` is still the v1.14.2 one. That page carries a direct kernel probe that
+  answers it from a plain `alpine` guest without the large pull.
+- **Linux x86_64.** Not run for this use case on any host, then or now.
+- **Driving the host-side `docker.sock` from a host `docker` client.** The socket is created and
+  asserted; neither host here has a docker client to drive it with.
+- **Compose and Testcontainers themselves.** The packet verifies `docker info`, a nested container
+  and host networking, which is what those depend on, not the tools.
+
+## Related packets
+
+- `dev-env` for the `init`-runs-once semantics this is built on.
+- `install` for the boot this assumes, `teardown` for the cleanup script.

--- a/skills/docker-in-machine/assets/docker.smolfile
+++ b/skills/docker-in-machine/assets/docker.smolfile
@@ -1,0 +1,28 @@
+# A machine that runs a Docker daemon inside itself, for workloads that must
+# call Docker themselves: Testcontainers, Compose, image builds, agents that
+# launch containers. smolvm boots OCI images without Docker, so this is only for
+# software inside the machine that needs the daemon.
+#
+# The bind mounts below are in `init`, which is where the upstream example puts
+# them, and `init` runs ONCE. They are correct for the first boot and gone on
+# every boot after it, so scripts/start-dockerd.sh re-applies them before
+# starting dockerd. Do not rely on this block alone.
+cpus = 2
+memory = 2048
+net = true
+
+# Docker's data directory must live on /storage, not on the rootfs overlay.
+# This is a hard requirement: the rootfs overlay uses the initramfs (ramfs) as
+# its lower layer, ramfs has no file-handle support, and overlayfs then rejects
+# it as an upper dir for Docker's nested overlay.
+storage = 20
+
+docker_socket = true
+
+init = [
+    "apk update -q",
+    "apk add docker -q",
+    "mkdir -p /storage/docker /var/lib/docker /storage/containerd /var/lib/containerd",
+    "mount --bind /storage/docker /var/lib/docker",
+    "mount --bind /storage/containerd /var/lib/containerd",
+]

--- a/skills/docker-in-machine/references/traps.md
+++ b/skills/docker-in-machine/references/traps.md
@@ -1,0 +1,80 @@
+# Docker in a machine traps
+
+## The bind mounts do not survive a stop, and `init` will not re-apply them
+
+**This is the trap that breaks the second session**, and it is the reason this packet has a
+separate `start-dockerd.sh` rather than a Smolfile alone.
+
+`init` runs **once**. On every start after the first the guest comes up with `/var/lib/docker`
+back on the rootfs overlay. Observed on macOS arm64 and Linux aarch64, immediately after one stop
+and start:
+
+```
+Init already completed, skipping 5 command(s)
+NO_BIND_MOUNTS_AFTER_RESTART
+DOCKERD_DOWN
+```
+
+**Putting the mounts in `init`, as the upstream example does, is correct for exactly one boot.**
+Re-apply them in the same command that starts `dockerd`, which is what `scripts/start-dockerd.sh`
+does. After it ran, the same host reported `dockerd_up` and every check passed again.
+
+**Your images do survive**, because they are on `/storage`. After the restart and the re-mount,
+`docker images` still listed `alpine:latest`. So the failure mode is "dockerd will not start" or
+"dockerd starts on the wrong filesystem", not data loss.
+
+## `/var/lib/docker` must be on `/storage`, and `docker info` will not tell you it is not
+
+A hard requirement, not a preference. The smolvm rootfs overlay uses the initramfs (ramfs) as its
+lower layer, ramfs has no file-handle support, and overlayfs then rejects it as an upper dir for
+Docker's nested overlay.
+
+**`docker info` succeeds while `/var/lib/docker` sits on the overlay**, and the failure that
+follows is confusing and much later. Assert the backing device:
+
+```bash
+smolvm machine exec --name <n> -- sh -c 'df /var/lib/docker | tail -1'
+# /dev/vda 20623316 412 20606520 0% /storage
+```
+
+Both readings print `/var/lib/docker` as the mount point, so the path tells you nothing. The
+device is the value that matters.
+
+## Both bind mounts are needed, not just Docker's
+
+`/var/lib/containerd` holds the snapshotter's overlay state and fails the same way if it is left
+on the rootfs overlay. The upstream Smolfile mounts both and its own comments say container start
+fails without the second one, with containerd's overlay mount rejected as `invalid argument`.
+
+`guides/docker-in-a-machine.md` gives a `dockerd` start command that bind-mounts only
+`/storage/docker`. That command is incomplete.
+
+## A `docker run` that pulls interleaves two streams
+
+The first run of an image prints the pull's progress alongside the container's own output, and the
+two arrive in a different order on different hosts: on Linux aarch64 the marker was the last line,
+on macOS arm64 it was not. A check that takes the last line passes on one host and fails on the
+other. `scripts/verify-docker.sh` pulls first, separately, so the run's output stands alone
+without discarding the stderr that would explain a real failure.
+
+## `machine delete` prompts and defaults to No
+
+Pass `--force` in a script, or the cleanup reports success and leaves a 20 GiB machine behind.
+
+## What the guide and the CLI still get wrong for this use case, at v1.14.6
+
+- `guides/docker-in-a-machine.md` bind-mounts only one path in its `dockerd` command, while the
+  upstream Smolfile mounts two.
+- The same guide shows `machine create ... -s examples/docker-in-vm/docker.smolfile` after a
+  `git clone` of the smolvm repo. **The release tarball does not contain `examples/`**, so a user
+  who installed from the release has to clone the repo to follow the guide at all. This packet
+  ships its own `assets/docker.smolfile` for that reason.
+- The same guide says bind mounts "do not survive a stop and start, so reapply that mount before
+  starting `dockerd`", which is correct and verified. But the page's own example puts them in
+  `init`, where they run once, and never connects the two facts.
+- `smolvm machine create --help` describes `--init` as "Run command on every VM start" at
+  v1.14.6. If that were true the example would be correct, and **it is the surviving copy of the
+  wrong promise**: `introduction/concepts/smolfile.md` has been corrected and now documents under
+  "When init runs" that init runs once, on the first start.
+- The guide carries no platform note at all, and on Windows the procedure cannot succeed. See
+  `references/windows.md`.

--- a/skills/docker-in-machine/references/windows.md
+++ b/skills/docker-in-machine/references/windows.md
@@ -1,0 +1,105 @@
+# Docker in a machine on Windows: it cannot work
+
+**Not a Windows use case, and this is where the page stops.** The cause is in the bundled guest
+kernel, not in the procedure, so there is no configuration a user can reach for.
+
+Established on Windows 11 Home build 26200 x86_64 against smolvm v1.14.2. **A re-run was attempted
+on 2026-09-11 against v1.14.6** on Windows 11 Home build 10.0.26200.0 UBR 9445 and **never reached
+the question**: both attempts died pulling the image.
+
+```
+Error: agent operation failed: pull image: crane blob failed for layer sha256:23be5e15...:
+  copying blob docker.io/library/docker@sha256:23be5e15...: unexpected EOF
+
+Error: io operation failed: A connection attempt failed because the connected party did not
+  properly respond after a period of time, or established connection failed because connected
+  host has failed to respond. (os error 10060)
+```
+
+Neither is a kernel result. This is the same large-image pull failure the `gpu-cuda` packet's
+Windows page records for `nvidia/cuda`, and it stops before any kernel feature is exercised, so
+**nothing below was confirmed or refuted on v1.14.6.** Everything on this page remains the v1.14.2
+record.
+
+## How far it gets
+
+```
+create (Smolfile + --net-backend virtio-net)   in 0.6s   Init commands: 5
+start  (init runs apk add docker)              in 10.7s
+docker --version                               Docker version 25.0.5
+df /var/lib/docker                             /dev/vda ... /storage
+```
+
+So the storage requirement this use case is built around is satisfied: the bind mounts land on the
+ext4 disk exactly as on Linux and macOS.
+
+## Where it stops
+
+With the default configuration `dockerd` will not start at all:
+
+```
+failed to start daemon: Error initializing network controller:
+error creating default "bridge" network: operation not supported
+```
+
+The guest kernel has no bridge support, confirmed directly:
+
+```
+ip link add name testbr0 type bridge
+ip: RTNETLINK answers: Not supported
+```
+
+`dockerd --bridge=none` **does** start and reports a healthy daemon:
+
+```
+Server Version: 25.0.5
+Storage Driver: overlay2
+Docker Root Dir: /var/lib/docker
+```
+
+but creating any container then fails on a second missing kernel feature:
+
+```
+docker run --rm --network=host alpine echo hi
+docker: Error response from daemon: failed to create task for container:
+  ... error mounting "mqueue" to rootfs at "/dev/mqueue":
+  mount mqueue:/dev/mqueue ... : no such device: unknown.
+```
+
+**Two kernel options are missing from the Windows libkrunfw build**: bridge networking and POSIX
+message queues. Confirmed against the config itself: `config-libkrunfw-windows_x86_64` carries
+`# CONFIG_POSIX_MQUEUE is not set` and `# CONFIG_BRIDGE is not set`, while the Linux
+`config-libkrunfw_x86_64` has both set to `y`.
+
+The upstream example's own "Kernel requirements" comment lists `CONFIG_BRIDGE` and the netfilter
+options as required; `CONFIG_POSIX_MQUEUE` is not in that list and is also needed.
+
+**A healthy daemon is not the finish line.** `--bridge=none` gets `dockerd` up, which is exactly
+the shape of a workaround that looks like it worked, and containers still cannot be created.
+
+## Answering this without pulling a dind image
+
+The two missing options can be probed directly from a plain `alpine` guest, which is small enough
+to pull on a network that cannot carry the `docker` image. Report each by exit code rather than by
+reading the message:
+
+```
+ip link add name testbr0 type bridge   ; echo bridge=$?
+mount -t mqueue none /dev/mqueue       ; echo mqueue=$?
+```
+
+Two non-zero exits mean the kernel is still missing both and this page stands. Two zeroes mean the
+guest kernel has changed and everything above needs re-running. This is the check to run first on
+any new build: it costs one small pull and answers in seconds.
+
+**A build newer than v1.14.6 ships a rebuilt Windows guest kernel**, so treat the two missing
+options as a statement about v1.14.6 and earlier until that probe has been run on the newer build.
+
+## What would change this
+
+A libkrunfw Windows config change turning on `CONFIG_BRIDGE` and `CONFIG_POSIX_MQUEUE`. Nothing in
+smolvm. Until then, use the `dev-env` or `local-api` packets on Windows and run containers
+somewhere else.
+
+`guides/docker-in-a-machine.md` carries no platform note and reads as applying to every host
+smolvm supports.

--- a/skills/docker-in-machine/scripts/cleanup.sh
+++ b/skills/docker-in-machine/scripts/cleanup.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Delete the machines this packet's scripts created, then prove the host is clean.
+#
+# Only machines recorded in the state file are deleted, so a machine you or
+# another session created by hand is never touched. Scripts record a name by
+# calling: cleanup.sh --record <name>
+#
+# usage: cleanup.sh [--record <name>] [--reap] [--purge]
+#   --record <name>  add a machine name to the state file and exit
+#   --reap           kill leftover VM processes (see the warning it prints)
+#   --purge          also remove the state file once the list is empty
+
+set -uo pipefail
+
+PACKET="docker-in-machine"
+PREFIX="smolskill-"
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+STATE_DIR="${SMOLVM_SKILL_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/smolvm-skills}"
+STATE_FILE="$STATE_DIR/$PACKET.machines"
+
+reap=0
+purge=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --record)
+            mkdir -p "$STATE_DIR"
+            printf '%s\n' "$2" >> "$STATE_FILE"
+            exit 0
+            ;;
+        --reap)  reap=1 ;;
+        --purge) purge=1 ;;
+        *) printf 'unknown argument: %s\n' "$1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+if [ -z "$SMOLVM" ]; then
+    printf 'smolvm not found; set SMOLVM to its path\n' >&2
+    exit 2
+fi
+
+case "$(uname -s)" in
+    Darwin) VMS_DIR="$HOME/Library/Caches/smolvm/vms" ;;
+    *)      VMS_DIR="${SMOLVM_DATA_DIR:-$HOME/.cache/smolvm}/vms" ;;
+esac
+VMS_DIR="${SMOLVM_VMS_DIR:-$VMS_DIR}"
+SMOLVM_PREFIX="${SMOLVM_PREFIX:-$HOME/.smolvm}"
+
+# List this HOME's smolvm VM processes, as "pid marker".
+#
+# Two process shapes exist and a reaper has to catch both. The plain
+# `machine run` path EXECS a child whose argv[1] is `_boot-vm` and whose argv[2]
+# is its boot-config path. The pack-run path, which is `--oci-cache` or any
+# `init`, FORKS without execing, so the child inherits the parent's argv and
+# carries no boot-config at all. Matching `_boot-vm` alone is therefore blind to
+# exactly the path whose child survives an interrupt
+# (smol-machines/smolvm#1193): measured on v1.14.6, it reported "none" while two
+# orphaned VMs held 234 MB each.
+#
+# On Linux both shapes rename themselves to `libkrun VM`, the one marker that
+# covers both and that no shell can hold. macOS exposes no rename, so there the
+# executable path scopes the search to this HOME and the parent chain separates
+# a VM from the CLI that started it.
+#
+# `pgrep -f _boot-vm` is not an alternative: it matches any shell whose text
+# contains that string, including this script.
+list_vm_processes() {
+    case "$(uname -s)" in
+        Linux)
+            for p in /proc/[0-9]*; do
+                [ "$(cat "$p/comm" 2>/dev/null)" = "libkrun VM" ] || continue
+                pid="${p#/proc/}"
+                cfg="$(tr '\0' '\n' < "$p/cmdline" 2>/dev/null | sed -n '3p')"
+                case "$cfg" in
+                    "$VMS_DIR"/*) printf '%s %s\n' "$pid" "$cfg"; continue ;;
+                esac
+                # Forked shape: nothing in argv identifies it, so scope by the
+                # binary it is running.
+                case "$(readlink "$p/exe" 2>/dev/null)" in
+                    "$SMOLVM_PREFIX"/*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;;
+                esac
+            done
+            ;;
+        Darwin)
+            # shellcheck disable=SC2009  # pgrep cannot return ppid and the full
+            # command together, and pgrep -f matches this script's own text.
+            own=" $(ps -axo pid=,command= 2>/dev/null | grep -F "$SMOLVM_PREFIX/smolvm-bin" | awk '{print $1}' | tr '\n' ' ') "
+            ps -axo pid=,ppid=,command= 2>/dev/null | while read -r pid ppid rest; do
+                case "$rest" in "$SMOLVM_PREFIX"/smolvm-bin*) ;; *) continue ;; esac
+                case "$rest" in
+                    *" _boot-vm "*) printf '%s %s\n' "$pid" "${rest#* _boot-vm }"; continue ;;
+                esac
+                # Forked shape: its parent is the CLI that started it, or init
+                # once that CLI is gone.
+                if [ "$ppid" = 1 ]; then
+                    printf '%s orphaned-under %s\n' "$pid" "$SMOLVM_PREFIX"
+                else
+                    case "$own" in *" $ppid "*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;; esac
+                fi
+            done
+            ;;
+    esac
+}
+
+# 1. Delete recorded machines. --force is not optional: without it the command
+# prompts, defaults to No, and leaves the machine in place while the script
+# carries on. --cascade removes branch children, which otherwise block the
+# delete.
+if [ -s "$STATE_FILE" ]; then
+    while read -r name; do
+        [ -n "$name" ] || continue
+        case "$name" in "$PREFIX"*) ;; *)
+            printf 'skipping %s: not created by this packet (no %s prefix)\n' "$name" "$PREFIX"
+            continue ;;
+        esac
+        "$SMOLVM" machine stop   --name "$name" >/dev/null 2>&1
+        "$SMOLVM" machine delete --name "$name" --force --cascade 2>&1 | sed 's/^/  /'
+    done < "$STATE_FILE"
+fi
+
+# 2. An ephemeral machine's entry retires after the run returns, not with it.
+# Asserting an empty list immediately fails on a healthy host.
+sleep 20
+
+# 3. Assert the value, not the exit code.
+listing="$("$SMOLVM" machine list 2>&1)"
+if printf '%s' "$listing" | grep -q 'No machines found'; then
+    printf 'machines=clean\n'
+    [ "$purge" -eq 1 ] && rm -f "$STATE_FILE"
+else
+    printf 'machines=remaining\n'
+    printf '%s\n' "$listing" | sed 's/^/  /'
+fi
+
+# 4. Report VM processes an interrupt left behind. Ctrl-C does not stop a
+# machine: the VM outlives the CLI and `machine list` cannot see it, so this is
+# the only route to it. Only processes whose boot config lives under this HOME's
+# smolvm state are listed, so a VM another session started is left alone.
+found=0
+while read -r pid cfg; do
+    [ -n "$pid" ] || continue
+    found=1
+    printf 'vm_process=%s config=%s\n' "$pid" "$cfg"
+    if [ "$reap" -eq 1 ]; then
+        kill -9 "$pid" 2>/dev/null && printf '  killed %s\n' "$pid"
+    fi
+done <<EOF
+$(list_vm_processes)
+EOF
+
+if [ "$found" -eq 0 ]; then
+    printf 'vm_processes=none\n'
+elif [ "$reap" -eq 0 ]; then
+    printf 'rerun with --reap to kill them\n'
+fi

--- a/skills/docker-in-machine/scripts/create-docker-machine.sh
+++ b/skills/docker-in-machine/scripts/create-docker-machine.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Create the machine and install Docker into it. The install happens on the
+# first start, not on create.
+#
+# usage: create-docker-machine.sh [<name>] [<smolfile>]
+
+set -uo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+NAME="${1:-smolskill-docker}"
+SMOLFILE="${2:-$here/../assets/docker.smolfile}"
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+if [ -z "$SMOLVM" ]; then
+    printf 'smolvm not found; set SMOLVM to its path\n' >&2
+    exit 2
+fi
+
+case "$NAME" in
+    smolskill-*) ;;
+    *) printf 'name must start with smolskill- so cleanup.sh will delete it\n' >&2; exit 2 ;;
+esac
+
+"$SMOLVM" machine create --name "$NAME" -s "$SMOLFILE" --net-backend virtio-net 2>&1 | sed 's/^/  /'
+"$here/cleanup.sh" --record "$NAME"
+
+start_out="$("$SMOLVM" machine start --name "$NAME" 2>&1)"
+printf '%s\n' "$start_out" | sed 's/^/  /'
+
+fail=0
+if printf '%s' "$start_out" | grep -q "Machine '$NAME' running"; then
+    printf 'machine_running=yes\n'
+else
+    printf 'machine_running=no\n'
+    fail=1
+fi
+
+docker_version="$("$SMOLVM" machine exec --name "$NAME" -- docker --version 2>&1 | tr -d '\r')"
+printf 'docker_version=%s\n' "$docker_version"
+case "$docker_version" in
+    "Docker version"*) ;;
+    *) fail=1 ;;
+esac
+
+if [ "$fail" -eq 0 ]; then printf 'result=installed\n'; else printf 'result=failed\n'; fi
+exit "$fail"

--- a/skills/docker-in-machine/scripts/preflight.sh
+++ b/skills/docker-in-machine/scripts/preflight.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Report whether this host can run a Docker daemon inside a smolvm machine.
+# Read-only: starts no VM, writes no smolvm state.
+#
+# Output is one key=value per line so a caller can parse it. The last line is
+# always result=ready or result=blocked.
+
+set -uo pipefail
+
+VERIFIED_VERSION="1.14.6"
+
+emit() { printf '%s=%s\n' "$1" "$2"; }
+
+blocked=0
+note() { printf 'note=%s\n' "$1"; }
+
+# --- the binary --------------------------------------------------------------
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+if [ -z "$SMOLVM" ]; then
+    emit smolvm_installed no
+    emit smolvm_version ""
+    blocked=1
+else
+    emit smolvm_installed yes
+    version="$("$SMOLVM" --version 2>/dev/null | awk '{print $NF}')"
+    emit smolvm_version "${version:-unknown}"
+fi
+
+emit verified_version "$VERIFIED_VERSION"
+if [ -n "${version:-}" ] && [ "$version" != "unknown" ]; then
+    if [ "$version" = "$VERIFIED_VERSION" ]; then
+        emit version_status match
+    else
+        newest="$(printf '%s\n%s\n' "$version" "$VERIFIED_VERSION" | sort -V | tail -1)"
+        if [ "$newest" = "$version" ]; then
+            emit version_status newer
+            note "this packet was verified on $VERIFIED_VERSION and the binary is $version; flags and messages move every release, so check the output against the binary before trusting a step here"
+        else
+            emit version_status older
+            note "this packet was verified on $VERIFIED_VERSION and the binary is $version"
+        fi
+    fi
+else
+    emit version_status unknown
+fi
+
+# --- platform ----------------------------------------------------------------
+
+kernel="$(uname -s)"
+arch="$(uname -m)"
+case "$arch" in aarch64|arm64) arch=aarch64 ;; esac
+
+case "$kernel" in
+    Darwin)
+        emit platform "darwin-$arch"
+        emit accel hvf
+        emit macos_version "$(sw_vers -productVersion)"
+        hv="$(sysctl -n kern.hv_support 2>/dev/null)"
+        if [ "$hv" = "1" ]; then emit accel_access ok; else emit accel_access denied; blocked=1; fi
+        if [ "$arch" != "aarch64" ]; then
+            emit hardware_verified no
+            note "Intel Mac is not verified by this packet; the installer accepts it and nothing here was run on one"
+        else
+            emit hardware_verified yes
+        fi
+        # A VM's agent socket lives under the cache directory. macOS sockaddr_un
+        # holds 104 bytes including the terminator.
+        sock="$HOME/Library/Caches/smolvm/vms/0123456789abcdef/agent.sock"
+        len=${#sock}
+        emit socket_path_bytes "$len"
+        if [ "$len" -gt 100 ]; then
+            emit socket_path_status too_long
+            blocked=1
+            note "HOME is too deep: every VM start will fail with krun_start_enter -22, whose text blames disks and device options. Install under a shorter HOME."
+        else
+            emit socket_path_status ok
+        fi
+        emit unsupported "vulkan,cuda"
+        emit docker_in_machine verified
+        ;;
+    Linux)
+        emit platform "linux-$arch"
+        emit accel kvm
+        emit socket_path_status n_a
+        if [ ! -e /dev/kvm ]; then
+            emit accel_access missing
+            blocked=1
+            note "/dev/kvm does not exist; this host has no KVM"
+        elif [ -r /dev/kvm ] && [ -w /dev/kvm ]; then
+            emit accel_access ok
+        else
+            emit accel_access denied
+            blocked=1
+            note "your user cannot open /dev/kvm. The installer warns and continues, so a successful install says nothing about whether a VM will start. Fix: sudo usermod -aG kvm \$USER, then run the next command through sg kvm -c '...' rather than logging out."
+        fi
+        emit unsupported "vulkan"
+        emit docker_in_machine verified
+        ;;
+    *)
+        emit platform "unsupported-$kernel"
+        emit accel unknown
+        emit accel_access unknown
+        blocked=1
+        emit docker_in_machine unavailable
+        note "Docker in a machine cannot work on Windows: the bundled guest kernel has neither bridge networking nor POSIX message queues, so dockerd will not start and, forced past that, containers still fail. See references/windows.md."
+        ;;
+esac
+
+if [ "$blocked" -eq 0 ]; then emit result ready; else emit result blocked; fi

--- a/skills/docker-in-machine/scripts/start-dockerd.sh
+++ b/skills/docker-in-machine/scripts/start-dockerd.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Start dockerd inside the machine, re-applying the bind mounts first.
+#
+# usage: start-dockerd.sh [<name>]
+#
+# Run this on EVERY start, not only the first. `init` runs once, so on any start
+# after the first the guest comes up with /var/lib/docker back on the rootfs
+# overlay, and dockerd either refuses to start or starts on the wrong
+# filesystem. The upstream example puts these mounts in `init` alone, which is
+# correct for exactly one boot.
+
+set -uo pipefail
+
+NAME="${1:-smolskill-docker}"
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+if [ -z "$SMOLVM" ]; then
+    printf 'smolvm not found; set SMOLVM to its path\n' >&2
+    exit 2
+fi
+
+# shellcheck disable=SC2016  # $(seq ...) runs in the guest shell, not here
+"$SMOLVM" machine exec --name "$NAME" -- sh -c '
+  mkdir -p /storage/docker /var/lib/docker /storage/containerd /var/lib/containerd
+  mountpoint -q /var/lib/docker     || mount --bind /storage/docker /var/lib/docker
+  mountpoint -q /var/lib/containerd || mount --bind /storage/containerd /var/lib/containerd
+  rm -f /var/run/docker.pid
+  dockerd --storage-driver=overlay2 >/tmp/dockerd.log 2>&1 &
+  # 60 s: dockerd answered docker info within a few seconds on both hosts here;
+  # the margin covers a first start that has to create its storage layout.
+  for i in $(seq 1 60); do docker info >/dev/null 2>&1 && break; sleep 1; done
+  docker info 2>/dev/null | grep -E "Server Version|Storage Driver|Docker Root Dir"
+' 2>&1 | sed 's/^/  /'
+
+# `docker info` succeeding is not the check that matters; see verify-docker.sh.
+server="$("$SMOLVM" machine exec --name "$NAME" -- docker info --format '{{.ServerVersion}}' 2>&1 | tr -d '\r')"
+printf 'server_version=%s\n' "$server"
+case "$server" in
+    [0-9]*) printf 'result=dockerd_up\n' ;;
+    *)
+        printf 'result=dockerd_down\n'
+        printf 'daemon log:\n'
+        "$SMOLVM" machine exec --name "$NAME" -- tail -20 /tmp/dockerd.log 2>&1 | sed 's/^/  /'
+        exit 1
+        ;;
+esac

--- a/skills/docker-in-machine/scripts/verify-docker.sh
+++ b/skills/docker-in-machine/scripts/verify-docker.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Prove Docker is usable AND on the right filesystem.
+#
+# usage: verify-docker.sh [<name>]
+#
+# The df assertion is the one that matters. `docker info` succeeds while
+# /var/lib/docker sits on the rootfs overlay, and the failure that follows is
+# confusing and much later: overlayfs rejects the ramfs-backed rootfs as an
+# upper dir for Docker's nested overlay.
+
+set -uo pipefail
+
+NAME="${1:-smolskill-docker}"
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+if [ -z "$SMOLVM" ]; then
+    printf 'smolvm not found; set SMOLVM to its path\n' >&2
+    exit 2
+fi
+
+fail=0
+check() {
+    if [ "$2" = "$3" ]; then
+        printf '%s=ok (%s)\n' "$1" "$2"
+    else
+        printf '%s=FAIL expected=%s actual=%s\n' "$1" "$3" "$2"
+        fail=1
+    fi
+}
+exec_in() { "$SMOLVM" machine exec --name "$NAME" -- "$@" 2>&1 | tr -d '\r'; }
+
+check storage_driver "$(exec_in docker info --format '{{.Driver}}')" overlay2
+
+# The backing device, not the path. Both readings print /var/lib/docker.
+# shellcheck disable=SC2016  # the awk field reference belongs to the guest shell
+check docker_root_device "$(exec_in sh -c 'df /var/lib/docker | tail -1 | awk "{print \$1}"')" /dev/vda
+
+# Pull first, and separately. A `docker run` that pulls interleaves the pull's
+# progress with the container's output, and the two streams arrive in a
+# different order on different hosts, so the marker is not reliably the last
+# line. Pulling first leaves the run's output alone without discarding the
+# stderr that would explain a real failure.
+printf 'pull=%s\n' "$(exec_in docker pull -q alpine | tail -1)"
+check nested_container "$(exec_in docker run --rm alpine echo NESTED_OK)" NESTED_OK
+check host_network     "$(exec_in docker run --rm --network=host alpine echo HOSTNET_OK)" HOSTNET_OK
+
+# docker_socket = true bridges the guest's /var/run/docker.sock to a host path.
+sock="$("$SMOLVM" machine data-dir --name "$NAME" 2>/dev/null)/docker.sock"
+if [ -S "$sock" ]; then
+    printf 'host_socket=present (%s)\n' "$sock"
+else
+    printf 'host_socket=absent (%s)\n' "$sock"
+fi
+
+if [ "$fail" -eq 0 ]; then printf 'result=docker_ok\n'; else printf 'result=FAILED\n'; fi
+exit "$fail"

--- a/skills/gpu-cuda/SKILL.md
+++ b/skills/gpu-cuda/SKILL.md
@@ -5,15 +5,16 @@ description: Runs CUDA compute workloads inside a smolvm microVM against a real 
 
 # CUDA inside a machine
 
-Built on a verified run of **smolvm v1.14.2** against an **NVIDIA A10** (Linux x86_64) and an
-**NVIDIA GeForce RTX 4050** (Windows x86_64). Done means a program in the VM opens the device,
-creates a context, and moves data to and from it.
+Verified on **smolvm v1.14.6** against an **NVIDIA A10** (driver 580.105.08, Linux x86_64,
+kernel 6.8.0-1046-nvidia), and on the same version against an **NVIDIA GeForce RTX 4050**
+(driver 32.0.15.6626, Windows x86_64). Done means a program in the VM opens the device, creates a context, and moves
+data to and from it.
 
-> **Read this before trusting a step here.** **No GPU host was available when this packet was
-> written**, so every step that needs one is written from those earlier runs and **was not
-> re-run**. What was re-run, on macOS arm64 and Ubuntu 24.04 aarch64, is `scripts/preflight.sh`
-> and the failure path of `scripts/run-cuda-probe.sh` on a host with no NVIDIA hardware. The
-> section "What was not run" lists every step individually.
+> **Read this before trusting a step here.** **The Linux GPU path was re-run end to end on
+> v1.14.6**, on a rented A10 instance: the preflight, the probe against the real device with two
+> different glibc images, all three eval prompts, and the cleanup. **Windows was re-run on
+> v1.14.6 too**, on 2026-09-11 against an RTX 4050: the probe, the two absences and the shim in a
+> plain `alpine` guest. The section "What was not run" lists every remaining step individually.
 
 ## How this works, and why the checks are shaped this way
 
@@ -55,9 +56,10 @@ data_roundtrip=ok
 result=cuda_ok
 ```
 
-On the A10, `cuda-probe.py`'s own output was:
+On the A10 on v1.14.6, `cuda-probe.py`'s own output was:
 
 ```
+load_shim -> ok /opt/smolvm-cuda/libcuda.so.1
 cuInit -> 0
 cuDeviceGetCount -> 0 count = 1
 cuDeviceGetName -> 0 name = NVIDIA A10
@@ -77,8 +79,11 @@ device.
 
 ```bash
 scripts/cleanup.sh --purge
-smolvm machine prune
+smolvm machine prune --name <NAME> --all   # any persistent --cuda machine you kept
 ```
+
+The probe runs are ephemeral and leave nothing to prune; `machine prune` takes a machine name and
+is rejected without one.
 
 `--cuda` changes nothing on the host: the shim is injected inside the guest only. Verified after a
 full session of CUDA runs plus a Kubernetes install and teardown on the same box, where
@@ -117,11 +122,13 @@ Full detail in `references/traps.md`.
 
 ## Platform arms
 
-- **Linux x86_64 with an NVIDIA GPU**: **verified on an A10**, in the run this packet is built
-  from. Not re-run.
-- **Windows x86_64 with an NVIDIA GPU**: **verified on an RTX 4050**, including a 1 MiB device
-  round trip. Not re-run. `references/windows.md`. **This contradicts three documentation pages**,
-  which this branch corrects.
+- **Linux x86_64 with an NVIDIA GPU**: **verified on an A10 on v1.14.6** (driver 580.105.08,
+  kernel 6.8.0-1046-nvidia), preflight through cleanup, with the probe run against two glibc
+  images.
+- **Windows x86_64 with an NVIDIA GPU**: **verified on an RTX 4050 on v1.14.6**, on 2026-09-11
+  (driver 32.0.15.6626), including the device name and a 1 MiB device round trip.
+  `references/windows.md`. **This contradicts three documentation pages**, which this branch
+  corrects.
 - **macOS arm64 and Intel**: **not applicable.** No Mac has an NVIDIA GPU, so `--cuda` has nothing
   to reach. The preflight says so rather than letting a run time out.
 - **Linux aarch64**: no NVIDIA hardware on the hosts available here. Only the preflight and the
@@ -133,10 +140,11 @@ Full detail in `references/traps.md`.
 The first two need a GPU host and are recorded from the earlier runs; the third was run in this
 session. Which is which is stated per prompt.
 
-**1. "Run a CUDA workload in a smolvm machine and prove it reached the GPU." (not re-run; from the
-A10 run, v1.14.2)**
+**1. "Run a CUDA workload in a smolvm machine and prove it reached the GPU." (re-run on v1.14.6
+on the A10)**
 
 ```
+load_shim -> ok /opt/smolvm-cuda/libcuda.so.1
 cuInit -> 0
 cuDeviceGetCount -> 0 count = 1
 cuDeviceGetName -> 0 name = NVIDIA A10
@@ -150,15 +158,48 @@ cuMemFree    -> 0
 ```
 
 **2. "`nvidia-smi` is not in my `--cuda` guest and there is no `/dev/nvidia0`. Is the GPU
-working?" (not re-run; from the A10 run)**
+working?" (re-run on v1.14.6 on the A10)**
 
-Both absences are correct. The guest showed `/opt/smolvm-cuda/libcuda.so`,
-`/opt/smolvm-cuda/libcuda.so.1` and `SMOLVM_CUDA_ZEROCOPY=1` in the environment, while
-`ls /dev/nvidia*` returned `No such file or directory` and `nvidia-smi` was not present in the base
-image. The driver API is the check.
+Both absences are correct. Inside a `--cuda` guest on `python:3.12-slim`:
 
-**3. "Can this machine run CUDA?" (run in this session, 2026-09-07 PT, on two hosts with no NVIDIA
-hardware)**
+```
+--- /opt/smolvm-cuda ---
+libcublas.so.11
+libcublas.so.12
+libcublas.so.13
+libcublasLt.so.11
+libcublasLt.so.12
+libcublasLt.so.13
+libcuda.so
+libcuda.so.1
+--- /dev/nvidia* ---
+ls: cannot access '/dev/nvidia*': No such file or directory
+--- nvidia-smi ---
+nvidia-smi: not present in the image
+--- SMOLVM_CUDA env ---
+SMOLVM_CUDA_ZEROCOPY=1
+```
+
+The driver API is the check, and the probe above is what runs it.
+
+**3. "Can this machine run CUDA?" (re-run on v1.14.6; the A10 answer is new, the two negative
+answers are from hosts with no NVIDIA hardware)**
+
+On the A10, where the answer is yes:
+
+```
+platform=linux-x86_64
+accel=kvm
+accel_access=ok
+gpu_present=yes
+gpu=NVIDIA A10, 580.105.08
+host_libcuda=1
+guest_needs_glibc_image=yes
+guest_shim_path=/opt/smolvm-cuda/libcuda.so.1
+result=ready
+```
+
+And where it is no:
 
 macOS 26.6.2 arm64:
 
@@ -196,22 +237,56 @@ The error names neither CUDA nor the missing device.
 
 ## Re-verified on v1.14.6
 
-Run 2026-09-10 PT against v1.14.6 on macOS 26.6.2 arm64 and Lima `linux-kvm` (Ubuntu 24.04
-aarch64). Only `preflight.sh` could run, and on both hosts it correctly reports `gpu_present=no`
-and `result=blocked`. **No GPU host was available for this release either**, so every step in the
-list below is still unrun.
+Run 2026-09-11 PT against v1.14.6 from the published release, installed into an isolated data root
+on a rented **NVIDIA A10** instance: 30 vCPU Intel Xeon Platinum 8358, 222 GiB memory, kernel
+6.8.0-1046-nvidia, driver 580.105.08, 23028 MiB of device memory.
+
+**The GPU path is no longer written from an earlier run.** preflight, probe, all three eval
+prompts and cleanup were executed in the packet's own order:
+
+```
+preflight            result=ready, gpu_present=yes, gpu=NVIDIA A10, 580.105.08, host_libcuda=1
+probe, default image device_named=ok, data_roundtrip=ok, result=cuda_ok
+probe, second image  device_named=ok, data_roundtrip=ok, result=cuda_ok
+cleanup --purge      machines=clean, vm_processes=none
+```
+
+The probe was run against **two** glibc images, `python:3.12-slim` and `python:3.12-bookworm`, and
+both reported `name = NVIDIA A10` and `total MiB = 22587` with the 1 MiB round trip returning the
+same bytes.
+
+**The host is untouched by `--cuda`, and that is now measured rather than quoted.** After the
+session `nvidia-smi` reported `NVIDIA A10, 580.105.08, 23028 MiB, 0 MiB` used, a whole-filesystem
+sweep for `*smolvm*` outside the install prefix and the data root returned nothing, and the eight
+NVIDIA kernel modules were still loaded.
+
+**The KVM precondition in the traps reproduced on this instance.** A fresh box has `/dev/kvm` as
+`root:kvm` with the login user outside the group, so the preflight reported `KVM_DENIED` until the
+group was granted. The single-command `sg kvm -c` form the traps recommend was not the route used
+here; a group change plus a new login session was.
+
+**One step failed as written on v1.14.6 and is now fixed.** The cleanup section said `smolvm
+machine prune` bare, which the CLI rejects:
+
+```
+$ smolvm machine prune
+Usage: smolvm machine prune --name <NAME>
+```
+
+Its help reads as host-wide ("Remove unused images and layers to free disk space") while the
+command prunes one machine's unreferenced layers, `--all` its cached images. The section now names
+the machine and says the ephemeral probe runs leave nothing to prune.
 
 ## What was not run
 
-**No GPU host was available for this packet.** Every step below is written from the earlier
-verified runs and was not repeated:
+The Linux GPU path was re-run on v1.14.6, and the Windows one on 2026-09-11. What remains unrun:
 
-- The probe against a real device, on Linux x86_64 and on Windows.
-- `--cuda` with a CUDA base image (`nvidia/cuda:...`), and the `apt-get install -y python3` those
-  images need.
-- The observation that `--cuda` leaves no host NVIDIA state behind.
-- The `sg kvm -c` remedy on a fresh GPU cloud instance.
-- Everything in `references/windows.md`.
+- **The preflight and the cleanup on Windows.** `scripts/*.sh` are POSIX shell and do not run
+  there, so the 2026-09-11 v1.14.6 run issued the probe and the eval prompts by hand.
+- **`--cuda` with a CUDA base image** (`nvidia/cuda:...`), and the `apt-get install -y python3`
+  those images need. Both probe runs used a Python image, which is what the packet recommends.
+- **The `sg kvm -c` single-command remedy.** The `KVM_DENIED` state it addresses did reproduce on
+  a fresh instance; the fix applied was a group change and a new session.
 
 Never run anywhere, then or now:
 

--- a/skills/gpu-cuda/SKILL.md
+++ b/skills/gpu-cuda/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: gpu-cuda
+description: Runs CUDA compute workloads inside a smolvm microVM against a real host NVIDIA GPU, using smolvm's --cuda API remoting. Use when a workload in a machine needs a GPU; when nvidia-smi or /dev/nvidia* is missing inside a --cuda guest; when a CUDA program in a machine exits zero but seems not to touch the device; when the shim will not load in an Alpine image; or when checking whether CUDA is available on a given platform, including Windows. Do not use it for Vulkan graphics (--gpu), which is a separate feature that works on no tested host, and do not expect it on a Mac, which has no NVIDIA hardware.
+---
+
+# CUDA inside a machine
+
+Built on a verified run of **smolvm v1.14.2** against an **NVIDIA A10** (Linux x86_64) and an
+**NVIDIA GeForce RTX 4050** (Windows x86_64). Done means a program in the VM opens the device,
+creates a context, and moves data to and from it.
+
+> **Read this before trusting a step here.** **No GPU host was available when this packet was
+> written**, so every step that needs one is written from those earlier runs and **was not
+> re-run**. What was re-run, on macOS arm64 and Ubuntu 24.04 aarch64, is `scripts/preflight.sh`
+> and the failure path of `scripts/run-cuda-probe.sh` on a host with no NVIDIA hardware. The
+> section "What was not run" lists every step individually.
+
+## How this works, and why the checks are shaped this way
+
+The guest gets **no NVIDIA driver and no `/dev/nvidia*`**. A compatibility `libcuda.so.1` is
+injected at `/opt/smolvm-cuda` inside the guest and forwards CUDA driver calls over vsock to a host
+daemon that owns the device. Nothing is needed on the host beyond a working NVIDIA driver: no extra
+packages, no container toolkit, no device plugin.
+
+Because the API is **remoted rather than passed through**, a program can start, link against
+`libcuda.so.1` and exit zero without a GPU ever being reached. **Assert a device name and a
+transferred result, never an exit code.**
+
+## Procedure
+
+**1. Preflight.**
+
+```bash
+scripts/preflight.sh
+```
+
+Read-only: it starts no VM and touches no NVIDIA state. It reports the GPU and driver version,
+whether your user can open `/dev/kvm`, and the host's own `libcuda` count. `result=blocked` with
+`gpu_present=no` is the answer that saves the most time, because the failure without it names
+neither CUDA nor the GPU.
+
+**2. Run the probe.**
+
+```bash
+scripts/run-cuda-probe.sh                     # python:3.12-slim
+scripts/run-cuda-probe.sh <other glibc image>
+```
+
+It mounts `scripts/` into the guest and runs `cuda-probe.py` under `--cuda`, then asserts two
+values from the output:
+
+```
+device_named=ok
+data_roundtrip=ok
+result=cuda_ok
+```
+
+On the A10, `cuda-probe.py`'s own output was:
+
+```
+cuInit -> 0
+cuDeviceGetCount -> 0 count = 1
+cuDeviceGetName -> 0 name = NVIDIA A10
+cuCtxCreate -> 0
+cuMemGetInfo -> 0 total MiB = 22587
+cuMemAlloc   -> 0
+cuMemcpyHtoD -> 0
+cuMemcpyDtoH -> 0
+roundtrip first 16 bytes match: True
+cuMemFree    -> 0
+```
+
+`roundtrip ... True` is the one that matters. It is the only line that proves bytes reached the
+device.
+
+**3. Clean up.** CUDA images are large.
+
+```bash
+scripts/cleanup.sh --purge
+smolvm machine prune
+```
+
+`--cuda` changes nothing on the host: the shim is injected inside the guest only. Verified after a
+full session of CUDA runs plus a Kubernetes install and teardown on the same box, where
+`nvidia-smi` still reported the device and a whole-filesystem sweep for `*smolvm*` came back empty.
+
+## Traps
+
+Full detail in `references/traps.md`.
+
+- **A zero exit code proves nothing.** The remoted API is why.
+- **`nvidia-smi` is absent inside the guest and that is correct.** So is `/dev/nvidia*`. Neither is
+  a useful check.
+- **Use a glibc image and load the shim by absolute path.** The shim is glibc, so an Alpine guest
+  cannot load it, and relying on the loader path picks up whatever the image carries.
+- **A fresh GPU cloud instance does not have KVM access for your user**, and the installer says the
+  install succeeded anyway. `sg kvm -c` applies the group without a logout.
+- **On a host with no NVIDIA GPU the error names neither CUDA nor the GPU.** Observed on Ubuntu
+  24.04 aarch64: `agent did not become ready within 30 seconds`, which reads exactly like host
+  load. The preflight is the only thing that tells the two apart.
+- **`--cuda` and `--gpu` are different features.** `--cuda` is compute over vsock and works;
+  `--gpu` is Vulkan over virtio-gpu and works on no host tested. On Windows `--gpu` is accepted and
+  silently does nothing.
+
+## Security defaults, and why they are the defaults
+
+- **The guest never gets the device, and that is the isolation.** No `/dev/nvidia*` is passed
+  through, so a workload in the machine cannot reach the driver directly, reprogram it, or see
+  another VM's device state through it. What it gets is a forwarded API surface.
+- **What that surface exposes is still real.** A remoted CUDA call runs against the host's driver
+  and the host's memory allocator, so treat a `--cuda` machine as having a channel to a privileged
+  host component. The VM boundary is what makes that acceptable; it is not zero authority.
+- **Nothing here needs root or a container toolkit on the host.** If a procedure asks you to
+  install a device plugin or run the CLI as root to get CUDA working, it is not this procedure.
+- **The scripts wrap the public CLI only**, mount only this packet's own `scripts/` directory into
+  the guest, and cleanup deletes only names it recorded under the `smolskill-` prefix.
+
+## Platform arms
+
+- **Linux x86_64 with an NVIDIA GPU**: **verified on an A10**, in the run this packet is built
+  from. Not re-run.
+- **Windows x86_64 with an NVIDIA GPU**: **verified on an RTX 4050**, including a 1 MiB device
+  round trip. Not re-run. `references/windows.md`. **This contradicts three documentation pages**,
+  which this branch corrects.
+- **macOS arm64 and Intel**: **not applicable.** No Mac has an NVIDIA GPU, so `--cuda` has nothing
+  to reach. The preflight says so rather than letting a run time out.
+- **Linux aarch64**: no NVIDIA hardware on the hosts available here. Only the preflight and the
+  failure path were run.
+- **Multi-GPU, GPU forks and clones, and a real training or inference workload**: not run anywhere.
+
+## Eval prompts, and what they produced
+
+The first two need a GPU host and are recorded from the earlier runs; the third was run in this
+session. Which is which is stated per prompt.
+
+**1. "Run a CUDA workload in a smolvm machine and prove it reached the GPU." (not re-run; from the
+A10 run, v1.14.2)**
+
+```
+cuInit -> 0
+cuDeviceGetCount -> 0 count = 1
+cuDeviceGetName -> 0 name = NVIDIA A10
+cuCtxCreate -> 0
+cuMemGetInfo -> 0 total MiB = 22587
+cuMemAlloc   -> 0
+cuMemcpyHtoD -> 0
+cuMemcpyDtoH -> 0
+roundtrip first 16 bytes match: True
+cuMemFree    -> 0
+```
+
+**2. "`nvidia-smi` is not in my `--cuda` guest and there is no `/dev/nvidia0`. Is the GPU
+working?" (not re-run; from the A10 run)**
+
+Both absences are correct. The guest showed `/opt/smolvm-cuda/libcuda.so`,
+`/opt/smolvm-cuda/libcuda.so.1` and `SMOLVM_CUDA_ZEROCOPY=1` in the environment, while
+`ls /dev/nvidia*` returned `No such file or directory` and `nvidia-smi` was not present in the base
+image. The driver API is the check.
+
+**3. "Can this machine run CUDA?" (run in this session, 2026-09-07 PT, on two hosts with no NVIDIA
+hardware)**
+
+macOS 26.6.2 arm64:
+
+```
+platform=darwin-aarch64
+gpu_present=no
+unsupported=cuda,vulkan
+note=no Apple Silicon or Intel Mac has an NVIDIA GPU, so --cuda has nothing to reach here. This is a hardware fact, not a smolvm limitation.
+result=blocked
+```
+
+Lima `linux-kvm`, Ubuntu 24.04 aarch64:
+
+```
+platform=linux-aarch64
+accel_access=ok
+gpu_present=no
+note=no nvidia-smi on this host, so there is no GPU for the remoting daemon to own
+host_libcuda=0
+result=blocked
+```
+
+and running the probe anyway, to record what a user sees when they skip the preflight:
+
+```
+Starting ephemeral machine (vm-5d98e4be)...
+Error: agent operation failed: start machine: agent operation failed: wait for ready:
+agent did not become ready within 30 seconds
+device_named=FAIL
+data_roundtrip=FAIL
+result=FAILED
+```
+
+The error names neither CUDA nor the missing device.
+
+## Re-verified on v1.14.6
+
+Run 2026-09-10 PT against v1.14.6 on macOS 26.6.2 arm64 and Lima `linux-kvm` (Ubuntu 24.04
+aarch64). Only `preflight.sh` could run, and on both hosts it correctly reports `gpu_present=no`
+and `result=blocked`. **No GPU host was available for this release either**, so every step in the
+list below is still unrun.
+
+## What was not run
+
+**No GPU host was available for this packet.** Every step below is written from the earlier
+verified runs and was not repeated:
+
+- The probe against a real device, on Linux x86_64 and on Windows.
+- `--cuda` with a CUDA base image (`nvidia/cuda:...`), and the `apt-get install -y python3` those
+  images need.
+- The observation that `--cuda` leaves no host NVIDIA state behind.
+- The `sg kvm -c` remedy on a fresh GPU cloud instance.
+- Everything in `references/windows.md`.
+
+Never run anywhere, then or now:
+
+- **GPU forks and clones.** `introduction/concepts/gpu.md` sells this as a reason for the remoting
+  design, and a CUDA clone has its own shorter 10 s ready timeout.
+- **Multi-GPU**, and contention between two machines sharing one device.
+- **A real workload.** These are driver-API assertions, not a training or inference run, and say
+  nothing about throughput or how much of the CUDA API surface is implemented.
+
+## Related packets
+
+- `install` for the KVM group precondition, which a fresh GPU instance fails.
+- `teardown` for the cleanup script. CUDA images are large enough that `machine prune` is worth it.

--- a/skills/gpu-cuda/references/traps.md
+++ b/skills/gpu-cuda/references/traps.md
@@ -1,0 +1,87 @@
+# CUDA traps
+
+## A zero exit code proves nothing on a remoted API
+
+**This is the trap the whole packet is shaped around.** CUDA in smolvm is remoted, not passed
+through: the guest gets no NVIDIA driver and no `/dev/nvidia*`, and a compatibility `libcuda.so.1`
+forwards driver calls over vsock to a host daemon that owns the device. A program can therefore
+start, link against `libcuda.so.1`, and exit zero without a GPU ever being reached.
+
+Assert a **device name** and a **computed or copied result**. `scripts/cuda-probe.py` asserts both:
+`cuDeviceGetName` returning a real name, and a 1 MiB host to device to host round trip returning
+the same bytes.
+
+## `nvidia-smi` is absent inside a `--cuda` guest, and that is correct
+
+So is `/dev/nvidia*`. Both are the documented remoting design, not a fault, and neither is a useful
+check. Use the driver API.
+
+## Use a glibc image, and load the shim by absolute path
+
+The injected shim is glibc, so an Alpine (musl) guest cannot load it. `python:3.12-slim` is small
+and already has Python.
+
+Load it as `/opt/smolvm-cuda/libcuda.so.1` rather than by soname: relying on the loader path picks
+up whatever the image happens to carry, and the shim is at a fixed location.
+
+**CUDA base images do not ship `python3`**, so `nvidia/cuda:...-base-...` needs
+`apt-get install -y python3` in the guest first, or a `-devel` image. That is a reason to prefer a
+small glibc image over a CUDA one for a probe.
+
+## A fresh GPU cloud instance does not have KVM access for your user
+
+`/dev/kvm` is `crw-rw---- root:kvm` and your account is not in the `kvm` group. The installer warns
+and continues, so the install succeeds and the first VM fails. Apply the group without logging out:
+
+```bash
+sudo usermod -aG kvm "$USER"
+sg kvm -c 'smolvm machine run --mem 2048 --net --image alpine -- echo OK'
+```
+
+## On a host with no NVIDIA GPU, the failure names neither CUDA nor the GPU
+
+Observed on Ubuntu 24.04 aarch64 on 2026-09-07, running `machine run --cuda` on a host with no
+NVIDIA hardware:
+
+```
+Starting ephemeral machine (vm-5d98e4be)...
+Error: agent operation failed: start machine: agent operation failed: wait for ready:
+agent did not become ready within 30 seconds
+```
+
+**That message reads exactly like host load**, which is its usual cause, and there is no mention of
+CUDA, the shim or a missing device. `scripts/preflight.sh` reports `gpu_present=no` before you run
+anything, which is the only thing that tells you the difference.
+
+## Large CUDA images may not pull
+
+`nvidia/cuda:12.4.1-base-ubuntu22.04` failed after 582 s with `crane blob failed ... unexpected
+EOF` on the Windows host's network. That is a transfer failure, not a CUDA one, but it is another
+reason to prefer a small image.
+
+## Memory: give the machine real headroom
+
+The verified runs used `--mem 8192`. On a small host, see the ready-timeout trap in the `install`
+packet: the 30 s limit is a hard-coded constant and no flag raises it for `machine run` or
+`machine start`.
+
+## `--cuda` changes nothing on the host
+
+The remoting shim is injected at `/opt/smolvm-cuda` **inside the guest only**, and no host NVIDIA
+state is touched. Verified after a full session of CUDA runs plus a Kubernetes install and teardown
+on the same box: `nvidia-smi` still reported the device, and a whole-filesystem sweep for
+`*smolvm*` came back empty.
+
+## `--cuda` and `--gpu` are different features
+
+`--cuda` is compute over vsock and works. `--gpu` is Vulkan graphics over virtio-gpu and does not
+work on any host tested, because the host renderer reports the Venus capset at version 0. They
+share nothing but the word GPU. On Windows `--gpu` is accepted and silently does nothing.
+
+## Docs drift for the CUDA path
+
+None found for `--cuda` itself: `introduction/concepts/gpu.md` describes the remoting design, the
+absence of `/dev/nvidia*` and the `libcuda.so.1` shim accurately.
+
+The drift is about **Windows**, where three pages say GPU acceleration is unavailable and CUDA
+works. See `references/windows.md`.

--- a/skills/gpu-cuda/references/windows.md
+++ b/skills/gpu-cuda/references/windows.md
@@ -1,0 +1,59 @@
+# CUDA on Windows: it works, and the documentation says it does not
+
+**Not re-run by this packet.** Executed once on Windows 11 Home build 26200 x86_64 with an
+**NVIDIA GeForce RTX 4050 Laptop GPU** (driver 566.26, 6141 MiB) against smolvm v1.14.2.
+
+`--cuda` injects the same remoting shim as on Linux and the guest reaches the real device:
+
+```powershell
+& $exe machine run --cuda --net --mem 6144 -v "$probe:/probe" --image python:3.12-slim -- python3 /probe/probe.py
+```
+
+Observed, 13.4 s:
+
+```
+cuInit -> 0
+cuDeviceGetCount -> 0 count = 1
+cuDeviceGetName -> 0 name = NVIDIA GeForce RTX 4050 Laptop GPU
+cuCtxCreate -> 0
+cuMemGetInfo -> 0 total MiB = 6140
+cuMemAlloc -> 0
+cuMemcpyHtoD -> 0
+cuMemcpyDtoH -> 0
+roundtrip 16 bytes match: True
+```
+
+**The 1 MiB round trip is the assertion that matters**: bytes went to the device and came back
+unchanged, so this is not a stub.
+
+The shim is present even in a non-CUDA image: `machine run --cuda --image alpine` shows
+`/opt/smolvm-cuda` containing `libcuda.so.1`, `libcudart`, `libcublas*` and `libcudnn*`. As on
+Linux, the guest gets no `/dev/nvidia*` and `nvidia-smi` is absent, which is the documented
+remoting design.
+
+## Windows-specific notes
+
+- **Use a glibc image.** The shim is glibc and an Alpine guest cannot load it. `python:3.12-slim`
+  is small and already has Python.
+- **Load the shim by absolute path**, `/opt/smolvm-cuda/libcuda.so.1`, rather than by soname.
+- **Large CUDA images may not pull.** `nvidia/cuda:12.4.1-base-ubuntu22.04` failed after 582 s
+  with `crane blob failed ... unexpected EOF` on this host's network. A transfer failure, not a
+  CUDA one, but another reason to prefer a small image.
+- **Do not capture `machine run` output in PowerShell.** See the `install` packet's Windows page.
+- **Vulkan is a different story.** `machine run --gpu` boots and exits 0, and in the guest
+  `/dev/dri` does not exist and `dmesg` has zero `virtio_gpu` lines. No error, no warning, no
+  mention that the flag was dropped.
+
+## What the docs say, and which one is right
+
+At v1.14.2 three places state that Windows has no GPU acceleration, and **all three are wrong for
+CUDA**:
+
+- `AGENTS.md:13`, "no GPU acceleration"
+- `README.md:300`, "Not yet available on Windows: GPU acceleration"
+- the shipped `README.txt`, "NOT YET SUPPORTED ON WINDOWS: GPU acceleration"
+
+The accurate page is `introduction/concepts/supported-platforms.md:29`, which says Windows "lacks
+**Vulkan** GPU acceleration, VM fork, and snapshots". Saying Vulkan specifically is exactly right.
+
+This branch corrects the first three to say Vulkan rather than GPU.

--- a/skills/gpu-cuda/references/windows.md
+++ b/skills/gpu-cuda/references/windows.md
@@ -1,7 +1,9 @@
 # CUDA on Windows: it works, and the documentation says it does not
 
-**Not re-run by this packet.** Executed once on Windows 11 Home build 26200 x86_64 with an
-**NVIDIA GeForce RTX 4050 Laptop GPU** (driver 566.26, 6141 MiB) against smolvm v1.14.2.
+**Re-run on 2026-09-11 against smolvm v1.14.6** on Windows 11 Home build 10.0.26200.0 UBR 9445
+x86_64 with an **NVIDIA GeForce RTX 4050 Laptop GPU** (driver 32.0.15.6626), in an elevated
+session. The probe, the two absences and the shim in a plain `alpine` guest all reproduced. The
+Vulkan note and the documentation section further down are from the earlier run on v1.14.2.
 
 `--cuda` injects the same remoting shim as on Linux and the guest reaches the real device:
 
@@ -9,27 +11,42 @@
 & $exe machine run --cuda --net --mem 6144 -v "$probe:/probe" --image python:3.12-slim -- python3 /probe/probe.py
 ```
 
-Observed, 13.4 s:
+Observed on v1.14.6, from the packet's own `scripts/cuda-probe.py`:
 
 ```
+load_shim -> ok /opt/smolvm-cuda/libcuda.so.1
 cuInit -> 0
 cuDeviceGetCount -> 0 count = 1
 cuDeviceGetName -> 0 name = NVIDIA GeForce RTX 4050 Laptop GPU
 cuCtxCreate -> 0
 cuMemGetInfo -> 0 total MiB = 6140
-cuMemAlloc -> 0
+cuMemAlloc   -> 0
 cuMemcpyHtoD -> 0
 cuMemcpyDtoH -> 0
-roundtrip 16 bytes match: True
+roundtrip first 16 bytes match: True
+cuMemFree    -> 0
+exit : 0
 ```
 
 **The 1 MiB round trip is the assertion that matters**: bytes went to the device and came back
-unchanged, so this is not a stub.
+unchanged, so this is not a stub. The device name is the other one.
 
-The shim is present even in a non-CUDA image: `machine run --cuda --image alpine` shows
-`/opt/smolvm-cuda` containing `libcuda.so.1`, `libcudart`, `libcublas*` and `libcudnn*`. As on
-Linux, the guest gets no `/dev/nvidia*` and `nvidia-smi` is absent, which is the documented
-remoting design.
+## The two absences are correct
+
+In a `--cuda` guest on v1.14.6, `/opt/smolvm-cuda` holds sixteen entries including `libcuda.so.1`,
+`libcudart*`, `libcublas*`, `libcudnn*` and `proto-hash`, while:
+
+```
+ls: cannot access '/dev/nvidia*': No such file or directory
+nvidia-smi absent
+```
+
+Both absences are the documented remoting design, not a broken setup. The driver API is the check,
+and the probe above is what runs it.
+
+The shim is injected even in a non-CUDA image: on v1.14.6 `machine run --cuda --image alpine` still
+shows `/opt/smolvm-cuda` populated in a plain `alpine` guest. It cannot be loaded there, because
+the shim is glibc, which is the next note.
 
 ## Windows-specific notes
 

--- a/skills/gpu-cuda/scripts/cleanup.sh
+++ b/skills/gpu-cuda/scripts/cleanup.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Delete the machines this packet's scripts created, then prove the host is clean.
+#
+# Only machines recorded in the state file are deleted, so a machine you or
+# another session created by hand is never touched. Scripts record a name by
+# calling: cleanup.sh --record <name>
+#
+# usage: cleanup.sh [--record <name>] [--reap] [--purge]
+#   --record <name>  add a machine name to the state file and exit
+#   --reap           kill leftover VM processes (see the warning it prints)
+#   --purge          also remove the state file once the list is empty
+
+set -uo pipefail
+
+PACKET="gpu-cuda"
+PREFIX="smolskill-"
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+STATE_DIR="${SMOLVM_SKILL_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/smolvm-skills}"
+STATE_FILE="$STATE_DIR/$PACKET.machines"
+
+reap=0
+purge=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --record)
+            mkdir -p "$STATE_DIR"
+            printf '%s\n' "$2" >> "$STATE_FILE"
+            exit 0
+            ;;
+        --reap)  reap=1 ;;
+        --purge) purge=1 ;;
+        *) printf 'unknown argument: %s\n' "$1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+if [ -z "$SMOLVM" ]; then
+    printf 'smolvm not found; set SMOLVM to its path\n' >&2
+    exit 2
+fi
+
+case "$(uname -s)" in
+    Darwin) VMS_DIR="$HOME/Library/Caches/smolvm/vms" ;;
+    *)      VMS_DIR="${SMOLVM_DATA_DIR:-$HOME/.cache/smolvm}/vms" ;;
+esac
+VMS_DIR="${SMOLVM_VMS_DIR:-$VMS_DIR}"
+SMOLVM_PREFIX="${SMOLVM_PREFIX:-$HOME/.smolvm}"
+
+# List this HOME's smolvm VM processes, as "pid marker".
+#
+# Two process shapes exist and a reaper has to catch both. The plain
+# `machine run` path EXECS a child whose argv[1] is `_boot-vm` and whose argv[2]
+# is its boot-config path. The pack-run path, which is `--oci-cache` or any
+# `init`, FORKS without execing, so the child inherits the parent's argv and
+# carries no boot-config at all. Matching `_boot-vm` alone is therefore blind to
+# exactly the path whose child survives an interrupt
+# (smol-machines/smolvm#1193): measured on v1.14.6, it reported "none" while two
+# orphaned VMs held 234 MB each.
+#
+# On Linux both shapes rename themselves to `libkrun VM`, the one marker that
+# covers both and that no shell can hold. macOS exposes no rename, so there the
+# executable path scopes the search to this HOME and the parent chain separates
+# a VM from the CLI that started it.
+#
+# `pgrep -f _boot-vm` is not an alternative: it matches any shell whose text
+# contains that string, including this script.
+list_vm_processes() {
+    case "$(uname -s)" in
+        Linux)
+            for p in /proc/[0-9]*; do
+                [ "$(cat "$p/comm" 2>/dev/null)" = "libkrun VM" ] || continue
+                pid="${p#/proc/}"
+                cfg="$(tr '\0' '\n' < "$p/cmdline" 2>/dev/null | sed -n '3p')"
+                case "$cfg" in
+                    "$VMS_DIR"/*) printf '%s %s\n' "$pid" "$cfg"; continue ;;
+                esac
+                # Forked shape: nothing in argv identifies it, so scope by the
+                # binary it is running.
+                case "$(readlink "$p/exe" 2>/dev/null)" in
+                    "$SMOLVM_PREFIX"/*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;;
+                esac
+            done
+            ;;
+        Darwin)
+            # shellcheck disable=SC2009  # pgrep cannot return ppid and the full
+            # command together, and pgrep -f matches this script's own text.
+            own=" $(ps -axo pid=,command= 2>/dev/null | grep -F "$SMOLVM_PREFIX/smolvm-bin" | awk '{print $1}' | tr '\n' ' ') "
+            ps -axo pid=,ppid=,command= 2>/dev/null | while read -r pid ppid rest; do
+                case "$rest" in "$SMOLVM_PREFIX"/smolvm-bin*) ;; *) continue ;; esac
+                case "$rest" in
+                    *" _boot-vm "*) printf '%s %s\n' "$pid" "${rest#* _boot-vm }"; continue ;;
+                esac
+                # Forked shape: its parent is the CLI that started it, or init
+                # once that CLI is gone.
+                if [ "$ppid" = 1 ]; then
+                    printf '%s orphaned-under %s\n' "$pid" "$SMOLVM_PREFIX"
+                else
+                    case "$own" in *" $ppid "*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;; esac
+                fi
+            done
+            ;;
+    esac
+}
+
+# 1. Delete recorded machines. --force is not optional: without it the command
+# prompts, defaults to No, and leaves the machine in place while the script
+# carries on. --cascade removes branch children, which otherwise block the
+# delete.
+if [ -s "$STATE_FILE" ]; then
+    while read -r name; do
+        [ -n "$name" ] || continue
+        case "$name" in "$PREFIX"*) ;; *)
+            printf 'skipping %s: not created by this packet (no %s prefix)\n' "$name" "$PREFIX"
+            continue ;;
+        esac
+        "$SMOLVM" machine stop   --name "$name" >/dev/null 2>&1
+        "$SMOLVM" machine delete --name "$name" --force --cascade 2>&1 | sed 's/^/  /'
+    done < "$STATE_FILE"
+fi
+
+# 2. An ephemeral machine's entry retires after the run returns, not with it.
+# Asserting an empty list immediately fails on a healthy host.
+sleep 20
+
+# 3. Assert the value, not the exit code.
+listing="$("$SMOLVM" machine list 2>&1)"
+if printf '%s' "$listing" | grep -q 'No machines found'; then
+    printf 'machines=clean\n'
+    [ "$purge" -eq 1 ] && rm -f "$STATE_FILE"
+else
+    printf 'machines=remaining\n'
+    printf '%s\n' "$listing" | sed 's/^/  /'
+fi
+
+# 4. Report VM processes an interrupt left behind. Ctrl-C does not stop a
+# machine: the VM outlives the CLI and `machine list` cannot see it, so this is
+# the only route to it. Only processes whose boot config lives under this HOME's
+# smolvm state are listed, so a VM another session started is left alone.
+found=0
+while read -r pid cfg; do
+    [ -n "$pid" ] || continue
+    found=1
+    printf 'vm_process=%s config=%s\n' "$pid" "$cfg"
+    if [ "$reap" -eq 1 ]; then
+        kill -9 "$pid" 2>/dev/null && printf '  killed %s\n' "$pid"
+    fi
+done <<EOF
+$(list_vm_processes)
+EOF
+
+if [ "$found" -eq 0 ]; then
+    printf 'vm_processes=none\n'
+elif [ "$reap" -eq 0 ]; then
+    printf 'rerun with --reap to kill them\n'
+fi

--- a/skills/gpu-cuda/scripts/cuda-probe.py
+++ b/skills/gpu-cuda/scripts/cuda-probe.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Prove a smolvm --cuda guest reaches a real GPU, and that data moves.
+
+Run this inside the guest. It uses the CUDA driver API through ctypes, so it
+needs no CUDA toolkit, no torch and no nvidia-smi.
+
+Why it is shaped this way. CUDA in smolvm is REMOTED, not passed through: the
+guest gets no NVIDIA driver and no /dev/nvidia*, and a compatibility
+libcuda.so.1 forwards driver calls over vsock to a host daemon that owns the
+device. A program can therefore start, link against libcuda.so.1 and exit zero
+without a GPU ever being reached, so an exit code proves nothing. The two
+assertions that mean something are a device NAME and a byte-for-byte round trip
+through device memory.
+"""
+import ctypes
+import sys
+
+# Load by absolute path rather than by soname. The shim is injected at a fixed
+# location in the guest, and relying on the loader path picks up whatever the
+# image happens to carry.
+SHIM = "/opt/smolvm-cuda/libcuda.so.1"
+
+try:
+    lib = ctypes.CDLL(SHIM)
+except OSError as exc:
+    print(f"load_shim -> FAILED {exc}")
+    print("If this says 'not found', the machine was started without --cuda.")
+    print("If it names a musl or ld-linux problem, use a glibc image: the shim is glibc,")
+    print("so an Alpine guest cannot load it. python:3.12-slim works and has Python already.")
+    sys.exit(1)
+
+print(f"load_shim -> ok {SHIM}")
+
+rc = lib.cuInit(0)
+print("cuInit ->", rc)
+
+count = ctypes.c_int(-1)
+print("cuDeviceGetCount ->", lib.cuDeviceGetCount(ctypes.byref(count)), "count =", count.value)
+
+buf = ctypes.create_string_buffer(128)
+print("cuDeviceGetName ->", lib.cuDeviceGetName(buf, 128, 0), "name =", buf.value.decode())
+
+ctx = ctypes.c_void_p()
+print("cuCtxCreate ->", lib.cuCtxCreate_v2(ctypes.byref(ctx), 0, 0))
+
+free, total = ctypes.c_size_t(), ctypes.c_size_t()
+print("cuMemGetInfo ->", lib.cuMemGetInfo_v2(ctypes.byref(free), ctypes.byref(total)),
+      "total MiB =", total.value // (1024 * 1024))
+
+# The assertion that matters: 1 MiB to the device and back, unchanged.
+N = 1024 * 1024
+src = (ctypes.c_ubyte * N)(*([7] * 16 + [0] * (N - 16)))
+dptr = ctypes.c_void_p()
+print("cuMemAlloc   ->", lib.cuMemAlloc_v2(ctypes.byref(dptr), ctypes.c_size_t(N)))
+print("cuMemcpyHtoD ->", lib.cuMemcpyHtoD_v2(dptr, src, ctypes.c_size_t(N)))
+dst = (ctypes.c_ubyte * N)()
+print("cuMemcpyDtoH ->", lib.cuMemcpyDtoH_v2(dst, dptr, ctypes.c_size_t(N)))
+print("roundtrip first 16 bytes match:", list(dst[:16]) == [7] * 16)
+print("cuMemFree    ->", lib.cuMemFree_v2(dptr))

--- a/skills/gpu-cuda/scripts/preflight.sh
+++ b/skills/gpu-cuda/scripts/preflight.sh
@@ -32,7 +32,7 @@ if [ -n "${version:-}" ] && [ "$version" != "unknown" ]; then
         newest="$(printf '%s\n%s\n' "$version" "$VERIFIED_VERSION" | sort -V | tail -1)"
         if [ "$newest" = "$version" ]; then
             emit version_status newer
-            note "this packet was verified on $VERIFIED_VERSION and the binary is $version; nothing here has been re-run on a GPU host since, so check each step's output against the binary"
+            note "this packet was verified on $VERIFIED_VERSION and the binary is $version; the GPU path was last exercised on an A10 on $VERIFIED_VERSION, so check each step's output against the binary"
         else
             emit version_status older
         fi

--- a/skills/gpu-cuda/scripts/preflight.sh
+++ b/skills/gpu-cuda/scripts/preflight.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Report whether this host can run CUDA workloads inside a smolvm machine.
+# Read-only: starts no VM, touches no NVIDIA state, changes no group membership.
+#
+# Output is one key=value per line. The last line is always result=ready or
+# result=blocked.
+
+set -uo pipefail
+
+VERIFIED_VERSION="1.14.6"
+
+emit() { printf '%s=%s\n' "$1" "$2"; }
+note() { printf 'note=%s\n' "$1"; }
+
+blocked=0
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+if [ -z "$SMOLVM" ]; then
+    emit smolvm_installed no
+    blocked=1
+else
+    emit smolvm_installed yes
+    version="$("$SMOLVM" --version 2>/dev/null | awk '{print $NF}')"
+    emit smolvm_version "${version:-unknown}"
+fi
+
+emit verified_version "$VERIFIED_VERSION"
+if [ -n "${version:-}" ] && [ "$version" != "unknown" ]; then
+    if [ "$version" = "$VERIFIED_VERSION" ]; then
+        emit version_status match
+    else
+        newest="$(printf '%s\n%s\n' "$version" "$VERIFIED_VERSION" | sort -V | tail -1)"
+        if [ "$newest" = "$version" ]; then
+            emit version_status newer
+            note "this packet was verified on $VERIFIED_VERSION and the binary is $version; nothing here has been re-run on a GPU host since, so check each step's output against the binary"
+        else
+            emit version_status older
+        fi
+    fi
+else
+    emit version_status unknown
+fi
+
+kernel="$(uname -s)"
+arch="$(uname -m)"
+case "$arch" in aarch64|arm64) arch=aarch64 ;; esac
+emit platform "$(printf '%s' "$kernel" | tr '[:upper:]' '[:lower:]')-$arch"
+
+case "$kernel" in
+    Darwin)
+        emit accel hvf
+        if [ "$(sysctl -n kern.hv_support 2>/dev/null)" = "1" ]; then emit accel_access ok; else emit accel_access denied; fi
+        emit gpu_present no
+        emit unsupported "cuda,vulkan"
+        blocked=1
+        note "no Apple Silicon or Intel Mac has an NVIDIA GPU, so --cuda has nothing to reach here. This is a hardware fact, not a smolvm limitation."
+        ;;
+    Linux)
+        emit accel kvm
+        # A fresh cloud GPU instance fails this, and the installer warns and
+        # continues, so the install succeeds and the first VM fails.
+        if [ -r /dev/kvm ] && [ -w /dev/kvm ]; then
+            emit accel_access ok
+        else
+            emit accel_access denied
+            blocked=1
+            note "your user cannot open /dev/kvm. Fix without logging out: sudo usermod -aG kvm \$USER, then run the next command through sg kvm -c '...'"
+        fi
+        emit unsupported "vulkan"
+        ;;
+    *)
+        emit accel unknown
+        emit accel_access unknown
+        note "this script covers macOS and Linux. CUDA does work on Windows, against the documentation; see references/windows.md, written from a run and not re-run by this packet."
+        blocked=1
+        ;;
+esac
+
+if command -v nvidia-smi >/dev/null 2>&1; then
+    gpu="$(nvidia-smi --query-gpu=name,driver_version --format=csv,noheader 2>/dev/null | head -1)"
+    if [ -n "$gpu" ]; then
+        emit gpu_present yes
+        emit gpu "$gpu"
+    else
+        emit gpu_present no
+        blocked=1
+        note "nvidia-smi is installed but reported no device"
+    fi
+elif [ "$kernel" = "Linux" ]; then
+    emit gpu_present no
+    blocked=1
+    note "no nvidia-smi on this host, so there is no GPU for the remoting daemon to own"
+fi
+
+# The host's own libcuda is what the remoting daemon forwards to. The guest gets
+# none, and that is the design.
+if command -v ldconfig >/dev/null 2>&1; then
+    emit host_libcuda "$(ldconfig -p 2>/dev/null | grep -c 'libcuda\.so\.1')"
+fi
+
+emit guest_needs_glibc_image yes
+emit guest_shim_path /opt/smolvm-cuda/libcuda.so.1
+
+if [ "$blocked" -eq 0 ]; then emit result ready; else emit result blocked; fi

--- a/skills/gpu-cuda/scripts/run-cuda-probe.sh
+++ b/skills/gpu-cuda/scripts/run-cuda-probe.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Run the CUDA driver-API probe inside a --cuda machine and assert its values.
+#
+# usage: run-cuda-probe.sh [<image>]      (default python:3.12-slim)
+#
+# The image must be glibc. The injected shim is glibc, so an Alpine (musl) guest
+# cannot load it. python:3.12-slim is small and already has Python, which CUDA
+# base images do not.
+
+set -uo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+IMAGE="${1:-python:3.12-slim}"
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+if [ -z "$SMOLVM" ]; then
+    printf 'smolvm not found; set SMOLVM to its path\n' >&2
+    exit 2
+fi
+
+out="$("$SMOLVM" machine run --cuda --net --mem 8192 \
+    -v "$here:/probe" --image "$IMAGE" -- python3 /probe/cuda-probe.py 2>&1)"
+printf '%s\n' "$out" | sed 's/^/  /'
+
+fail=0
+check() {
+    if printf '%s' "$out" | grep -q "$2"; then
+        printf '%s=ok\n' "$1"
+    else
+        printf '%s=FAIL\n' "$1"
+        fail=1
+    fi
+}
+
+# A device NAME, not a zero return code: on a remoted API a program links and
+# exits zero without a GPU ever being reached.
+check device_named 'name = '
+# And the round trip, which is the only proof that bytes reached the device.
+check data_roundtrip 'roundtrip first 16 bytes match: True'
+
+if [ "$fail" -eq 0 ]; then
+    printf 'result=cuda_ok\n'
+else
+    printf 'result=FAILED\n'
+    printf 'Run scripts/preflight.sh. The three causes, and none of them says so in the error:\n'
+    printf '  - No NVIDIA GPU on the host. Observed on Ubuntu 24.04 aarch64: the run fails with\n'
+    printf '    "agent did not become ready within 30 seconds", which names neither CUDA nor the\n'
+    printf '    missing device and reads exactly like host load.\n'
+    printf '  - A musl image. The injected shim is glibc, so an Alpine guest cannot load it.\n'
+    printf '  - A machine started without --cuda, in which case /opt/smolvm-cuda does not exist.\n'
+fi
+exit "$fail"

--- a/skills/install/SKILL.md
+++ b/skills/install/SKILL.md
@@ -218,4 +218,4 @@ cleanup. The guest kernel is unchanged across 1.14.2, 1.14.3 and 1.14.6.
 
 - `teardown` for the full removal sequence, and for what a leak check must exclude.
 - `sandbox` for running untrusted work in a throwaway machine, which assumes this boot.
-- `dev-env`, `local-api`, `docker-in-machine` and `gpu-cuda` all assume it too.
+- `dev-env`, `local-api`, `docker-in-machine`, `gpu-cuda` and `pack` all assume it too.

--- a/skills/install/SKILL.md
+++ b/skills/install/SKILL.md
@@ -218,3 +218,4 @@ cleanup. The guest kernel is unchanged across 1.14.2, 1.14.3 and 1.14.6.
 
 - `teardown` for the full removal sequence, and for what a leak check must exclude.
 - `sandbox` for running untrusted work in a throwaway machine, which assumes this boot.
+- `dev-env`, `local-api`, `docker-in-machine` and `gpu-cuda` all assume it too.

--- a/skills/install/SKILL.md
+++ b/skills/install/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: install
+description: Installs smolvm from a published release and proves the host can actually boot a microVM before any other work starts. Use when setting smolvm up on a new machine, a CI runner or an agent sandbox; when a first boot fails with krun_start_enter -22, KVM_DENIED or "agent did not become ready"; when checking whether a host meets smolvm's requirements at all; or when an install has to be isolated from an existing one and then removed. Do not use it to remove an existing install (see the teardown packet) or for anything after the first boot has succeeded.
+---
+
+# Installing smolvm and proving it works
+
+Verified on **smolvm v1.14.6** on macOS arm64 and Linux aarch64, 2026-09-10. Done means `smolvm --version` prints the release version **and**
+a throwaway VM has run one command and exited. A version number alone proves nothing: on every
+platform here there is at least one way for the install to succeed and every VM start to fail.
+
+`scripts/preflight.sh` reports the host as `key=value` lines and ends with `result=ready` or
+`result=blocked`. Run it first, and run it again after the install if the first boot fails.
+
+## Procedure
+
+**1. Preflight.** Read-only. It starts no VM and writes no smolvm state.
+
+```bash
+scripts/preflight.sh
+```
+
+Stop on `result=blocked` and read the `note=` lines. The two that block a fresh host are
+`accel_access=denied` on Linux (your user cannot open `/dev/kvm`) and `socket_path_status=too_long`
+on macOS (the install path is too deep for a VM's Unix socket). Both have a fix in
+`references/traps.md`, and neither announces itself later: the installer warns about KVM and
+continues, and the path limit surfaces as an error about disks.
+
+**2. Install from the published release.**
+
+```bash
+curl -sSL https://smolmachines.com/install.sh | bash -s -- --version 1.14.6
+export PATH="$HOME/.local/bin:$PATH"
+smolvm --version
+```
+
+On macOS two `warning:` lines about notarization appear on every install and are not a problem.
+On Linux `info: KVM access verified` appears only when your user can already open `/dev/kvm`.
+
+To install without touching an existing one, point `HOME` at a scratch directory: every path
+smolvm uses moves with it on macOS and Linux. Keep that directory shallow on macOS. This does not
+work on Windows, where state cannot be relocated at all. See `references/layout.md`.
+
+Windows does not use this installer. See `references/windows.md`.
+
+**3. Prove it boots.** This is the step that decides whether smolvm works here.
+
+```bash
+scripts/verify-boot.sh
+```
+
+It runs one ephemeral alpine VM and asserts two values: a marker the guest printed, and that the
+guest kernel is not the host's. On failure it prints the three misreadings that cost the most
+time, before you clean up and lose the evidence.
+
+**4. Clean up.**
+
+```bash
+scripts/cleanup.sh
+```
+
+It waits before asserting an empty machine list, because a successful `machine run` returns
+before its entry retires and an immediate assertion fails on a healthy host. It then reports VM
+processes an interrupt left behind, and kills them only with `--reap`.
+
+## What the preflight reports
+
+| key | meaning |
+|---|---|
+| `smolvm_installed`, `smolvm_version` | whether the binary is on `PATH` and what it says |
+| `verified_version`, `version_status` | `match`, `newer`, `older` or `unknown` against the 1.14.6 this packet was verified on |
+| `platform` | `darwin-aarch64`, `linux-aarch64`, `linux-x86_64` |
+| `accel`, `accel_access` | `hvf` and `kern.hv_support`, or `kvm` and whether `/dev/kvm` is readable and writable |
+| `macos_version`, `hardware_verified` | `hardware_verified=no` on an Intel Mac: the installer accepts it and nothing here was run on one |
+| `socket_path_bytes`, `socket_path_status` | macOS only, and the single most common cause of "macOS is broken" |
+| `unsupported` | features this platform does not have |
+| `result` | `ready` or `blocked` |
+
+`version_status=newer` is a warning, not a failure. smolvm's flags and messages move every
+release, so on a newer binary check each step's output against the binary before trusting the
+text here.
+
+## Security defaults, and why they are the defaults
+
+- **The installer is a user-level install and needs no root.** Everything lands under `$HOME`,
+  which is what lets an agent or a CI job install a private copy and remove it without a
+  privileged step. Nothing in this packet escalates privilege.
+- **`sudo usermod -aG kvm` is the one privileged step, and it is yours to run.** Group membership
+  on `/dev/kvm` is the host's boundary between users who can start VMs and users who cannot, so a
+  script should report `accel_access=denied` and stop rather than widen it for you. `sg kvm -c`
+  then applies the group to a single command instead of your whole session.
+- **The uninstaller leaves `~/.config/smolvm` and your `PATH` line on purpose.** Those hold
+  registry credentials and a change you made to your own shell profile, so removing them is a
+  separate, deliberate act. `references/layout.md` has both commands.
+
+## Platform arms
+
+- **macOS arm64**: verified. The path-length rule in `references/traps.md` applies to every install.
+- **Linux aarch64 and x86_64**: verified. The `kvm` group check applies to every fresh host.
+- **Intel Mac**: **unverified.** The installer accepts macOS 11 or later on Intel and nothing in
+  the material behind this packet was run on one. `preflight.sh` reports `hardware_verified=no`
+  there rather than implying it works.
+- **Windows x86_64**: `references/windows.md`, **re-run on 2026-09-11 against v1.14.6** on
+  Windows 11 Home build 10.0.26200.0 UBR 9445, where it confirmed. The
+  three facts that break a Unix-shaped script are there: the zip unpacks into a nested versioned
+  folder, state lives in `%LOCALAPPDATA%\smolvm` and cannot be moved, and a script must never
+  capture `machine start` output because it never returns.
+
+## Eval prompts, and what they produced
+
+Run against this packet on 2026-09-07 PT, on smolvm v1.14.2 installed from the published release
+into an isolated `HOME`. Output is verbatim.
+
+**1. "Install smolvm on this machine and tell me whether it can actually run a VM."**
+
+macOS 26.6.2 arm64:
+
+```
+smolvm_installed=yes
+smolvm_version=1.14.2
+version_status=match
+platform=darwin-aarch64
+accel=hvf
+accel_access=ok
+socket_path_bytes=62
+socket_path_status=ok
+result=ready
+
+  BOOTED_OK
+  Linux 6.12.95 aarch64
+guest_ran=yes
+guest_kernel=Linux 6.12.95
+host_kernel=Darwin 25.6.0
+is_a_vm=yes
+result=boot_ok
+```
+
+Lima `linux-kvm`, Ubuntu 24.04 aarch64:
+
+```
+platform=linux-aarch64
+accel=kvm
+accel_access=ok
+result=ready
+
+  BOOTED_OK
+  Linux 6.12.95 aarch64
+guest_kernel=Linux 6.12.95
+host_kernel=Linux 6.8.0-139-generic
+is_a_vm=yes
+result=boot_ok
+```
+
+Boot plus image pull took 8.9 s on macOS and 22.4 s on the nested-virt Linux box.
+
+**2. "smolvm is installed but every `machine run` fails with `krun_start_enter returned: -22`.
+What is wrong?"**
+
+Reproduced deliberately on macOS by installing into a 49-character `HOME`. The preflight names
+the cause before any VM is started:
+
+```
+socket_path_bytes=104
+socket_path_status=too_long
+note=HOME is too deep: every VM start will fail with krun_start_enter -22, whose text blames disks and device options. Install under a shorter HOME.
+result=blocked
+```
+
+and the boot then fails exactly as reported, with the misleading text:
+
+```
+Error: agent operation failed: start machine: agent operation failed: monitor agent:
+agent operation failed: start vm: krun_start_enter returned: -22 (EINVAL ... libkrun
+rejected the VM configuration; usually a disk/overlay that could not be opened ... or an
+unsupported device option) (boot process exited (code 1) before the agent was ready)
+guest_ran=no
+is_a_vm=no
+result=boot_failed
+```
+
+**3. "Set up smolvm somewhere throwaway so it does not touch my existing install, then remove
+it."**
+
+Both isolated installs in this session ran under a scratch `HOME` and the uninstaller then
+reported every path removed, with `find "$HOME" -iname '*smolvm*'` empty afterwards:
+
+```
+success: Removed <HOME>/.smolvm
+success: Removed symlink <HOME>/.local/bin/smolvm
+success: Removed data directory <HOME>/Library/Application Support/smolvm
+success: Removed cache directory <HOME>/Library/Caches/smolvm
+warning: You may want to remove the PATH entry from your shell profile.
+success: smolvm has been uninstalled
+```
+
+## Re-verified on v1.14.6
+
+Run 2026-09-10 PT against v1.14.6 from the published release, into a fresh isolated `HOME` on
+macOS 26.6.2 arm64 and Lima `linux-kvm` (Ubuntu 24.04 aarch64). Both hosts: `result=ready`, then
+`guest_ran=yes`, `guest_kernel=Linux 6.12.95`, `is_a_vm=yes`, `result=boot_ok`, and a clean
+cleanup. The guest kernel is unchanged across 1.14.2, 1.14.3 and 1.14.6.
+
+## What was not run
+
+- **Intel Mac.** Nothing.
+- **Windows.** `references/windows.md` records a run on Windows 11 Home build 26200 that was not
+  repeated here. No PowerShell script ships with this packet for that reason.
+- **The unprivileged Windows symlink path.** The Windows preflight check for Developer Mode or
+  `SeCreateSymbolicLinkPrivilege` is written from reading the release's extraction path and from a
+  session that already held the privilege. The failure it guards against has been reported from
+  outside and reproduced by forcing the state, but the unprivileged install itself has not been
+  run by anyone here.
+- **Linux x86_64** was verified for install and boot in the material behind this packet, on a
+  cloud GPU instance that no longer exists. The scripts here were re-run on macOS arm64 and Linux
+  aarch64 only.
+
+## Related packets
+
+- `teardown` for the full removal sequence, and for what a leak check must exclude.
+- `sandbox` for running untrusted work in a throwaway machine, which assumes this boot.

--- a/skills/install/references/layout.md
+++ b/skills/install/references/layout.md
@@ -1,0 +1,78 @@
+# What the install lays down, how to upgrade, and how to remove it
+
+Observed on macOS arm64, Linux aarch64 and Linux x86_64 on v1.14.2.
+
+## Layout
+
+| | macOS | Linux |
+|---|---|---|
+| install prefix (wrapper, `smolvm-bin`, `lib/`, `.version`, disk templates) | `$HOME/.smolvm` | `$HOME/.smolvm` |
+| launcher symlink | `$HOME/.local/bin/smolvm` | `$HOME/.local/bin/smolvm` |
+| agent rootfs | `$HOME/Library/Application Support/smolvm` | `$HOME/.local/share/smolvm` |
+| per-VM state | `$HOME/Library/Caches/smolvm/vms` | `$HOME/.cache/smolvm/vms` |
+| image cache, once `--oci-cache` has run | `.../smolvm/vms/_shared` | `.../smolvm/vms/_shared` |
+| pack cache | `$HOME/Library/Caches/smolvm-pack` | `$HOME/.cache/smolvm-pack` |
+| packed-binary lib cache | `$HOME/Library/Caches/smolvm-libs` | `$HOME/.cache/smolvm-libs` |
+| registry credentials | `$HOME/.config/smolvm` | `$HOME/.config/smolvm` |
+| `PATH` block | your shell profile | your shell profile |
+
+The last three are the ones people miss. `smolvm-libs` appears only once a packed `.smolmachine`
+stub has run, and the last two are deliberately not removed by the uninstaller.
+
+Disk: about 120 MB for the install itself. The first VM then creates sparse disks with 20 GiB
+storage and 10 GiB overlay **apparent** size; actual usage after one run was 18 MB.
+
+## Isolating a test install
+
+On macOS and Linux, running the installer with `HOME` pointed at a scratch directory puts every
+path above inside it, which is how the runs behind this packet avoided touching a real
+installation. Keep that directory shallow on macOS or you will hit the socket path limit in
+`references/traps.md`.
+
+```bash
+curl -sSL https://smolmachines.com/install.sh | HOME=/tmp/sk bash -s -- --version 1.14.2
+HOME=/tmp/sk /tmp/sk/.local/bin/smolvm --version
+```
+
+This does not work on Windows: state there cannot be relocated at all. See
+`references/windows.md`.
+
+## Upgrade
+
+The same installer with a newer `--version`. Upgrading 1.14.1 to 1.14.2 printed
+`info: Upgrading from 1.14.1 to 1.14.2` and correctly removed the stale expanded disk templates
+the older release had left behind.
+
+## Uninstall
+
+```bash
+curl -sSL https://smolmachines.com/install.sh | bash -s -- --uninstall
+```
+
+Verified complete on macOS against an isolated `HOME` that had been used for a full session of
+machines, packs and `--oci-cache` runs: afterwards `find "$HOME" -iname '*smolvm*'` returned
+nothing. It removes the prefix, the symlink, the data directory, the cache directory, the pack
+cache and `smolvm-libs`, and warns about the two things it leaves: the `PATH` block in your shell
+profile, and `~/.config/smolvm`.
+
+The `--uninstall` flag is documented only in `scripts/install.sh --help`, not in the README or on
+the docs site. The full removal sequence, including the Kubernetes runtime and the Windows tree,
+is the `teardown` packet.
+
+## Where the docs and the release disagree, at v1.14.2
+
+Checked while running this procedure. Each of these will send you somewhere the release does not
+go:
+
+- `README.md` Install says to "download from GitHub Releases, and place it into
+  `~/.local/share/`". The installer places the prefix in `$HOME/.smolvm`; only the agent rootfs
+  goes to a data directory.
+- `scripts/install.sh` and `README.md` describe a unified `smol` CLI. No v1.14.2 tarball
+  (darwin-arm64, linux-arm64, linux-x86_64) contains `smol` or `smol-bin`, so that branch never
+  fires and no `smol` command is installed.
+- `scripts/install.sh` calls `init.krun` "(Linux only, required by libkrunfw kernel)". The
+  linux-arm64 tarball contains none, the installer skips it silently, and VMs boot anyway.
+- `smolvm machine --help` describes `images` as "List cached images and storage usage", but
+  `machine images` requires `--name` and reports one machine's images. There is no command that
+  lists what `--oci-cache` has baked.
+- Nothing anywhere mentions the macOS path-length limit.

--- a/skills/install/references/traps.md
+++ b/skills/install/references/traps.md
@@ -1,0 +1,116 @@
+# Install traps, and what each misleading message actually means
+
+## Contents
+
+- `krun_start_enter returned: -22 (EINVAL ...)` on macOS
+- `KVM_DENIED` on a fresh Linux box
+- `agent did not become ready within 30 seconds`
+- `machine list` shows a just-finished VM as `unreachable (eph)`
+- The boot subprocess hides its own errors
+- `DYLD_PRINT_LIBRARIES` prints nothing on macOS
+- Two assertion habits that apply beyond install
+
+Each entry is "if you see X, it means Y". Every one of these was hit on a real host during the
+runs this packet is built from, and each cost time because the message points somewhere else.
+
+## `krun_start_enter returned: -22 (EINVAL ...)` on macOS
+
+**It means your install path is too long.** The error text blames disks and device options and
+is wholly misleading.
+
+A VM's agent socket is `$HOME/Library/Caches/smolvm/vms/<16 hex>/agent.sock`. macOS
+`sockaddr_un.sun_path` holds 104 bytes including the terminator, so once `$HOME` is deep enough
+the socket path no longer fits and **every** VM start fails immediately. Measured by installing
+into `$HOME` directories of increasing length:
+
+| socket path bytes | result |
+|---|---|
+| 100 | boots |
+| 102 | `-22` |
+| 104 | `-22` |
+| 106 | `-22` |
+
+`scripts/preflight.sh` computes that path and reports `socket_path_bytes` and
+`socket_path_status` before you install anything.
+
+This is the single most expensive trap in the material behind this packet: it cost most of a
+session and produced a false "macOS is broken" conclusion. Everything else was ruled out by
+running it. The same release boots from a short `$HOME` on the same machine; v1.14.1, v1.13.0 and
+v1.11.0 all fail identically at a long path, so it is not a regression; the installed binary
+matches the tarball byte for byte; `kern.hv_support` is 1; and an ad-hoc-signed C program linking
+the release's own `libkrun.dylib` runs a VM to completion and accepts smolvm's own `storage.raw`
+and `overlay.raw`.
+
+**A CI job or an agent harness that installs under a deep temporary directory will hit this and
+will not be able to tell why.** Nothing in the README or the installer mentions a path-length
+limit.
+
+## `KVM_DENIED` on a fresh Linux box
+
+**It means your user is not in the `kvm` group, and the install said nothing about it.** The
+installer warns and then continues when `/dev/kvm` is inaccessible, so a successful install says
+nothing about whether a VM will start. This was the out-of-the-box state on a fresh cloud GPU
+instance.
+
+The installer tells you to log out and back in. You do not have to:
+
+```bash
+sudo usermod -aG kvm "$USER"
+sg kvm -c 'smolvm machine run --mem 2048 --net --image alpine -- echo OK'
+```
+
+`sg kvm -c '<command>'` (or `newgrp kvm`) applies the new group to a single command immediately,
+which is what you want over SSH or inside a script.
+
+## `agent did not become ready within 30 seconds`
+
+**Suspect host load before you suspect the install.** This was reproduced on both macOS and a
+nested-virt Linux box purely by running other VMs at the same time, and the identical command
+passed on a quiet host seconds later.
+
+The 30 s limit is a hard-coded constant (`src/agent/manager.rs`, `AGENT_READY_TIMEOUT`) and
+**there is no flag or environment variable that raises it** for `machine run` or `machine start`.
+`SMOLVM_AGENT_READY_TIMEOUT_SECS` exists but is read only by `pack run`.
+
+## `machine list` shows your just-finished VM as `unreachable (eph)`
+
+**Nothing is wrong.** The entry retires asynchronously after the run returns; observed gone by
+20 s. A cleanup assertion that runs immediately after `machine run` fails on a healthy system,
+which is why `scripts/cleanup.sh` waits before asserting.
+
+## The boot subprocess hides its own errors
+
+The child's stdout and stderr go to `/dev/null` unless `SMOLVM_BOOT_DEBUG=1`, and even that
+showed nothing useful. To see the real failure, run the child yourself:
+
+```bash
+smolvm-bin _boot-vm <vm-dir>/boot-config.json
+```
+
+That is how the vCPU panics behind the macOS `-22` were finally read. **The child deletes its own
+`boot-config.json` on exit**, so copy it while a start is in flight if you want to re-run it.
+`RUST_LOG=debug` on the CLI shows the disk-template and boot timeline, which separates a template
+problem from a hypervisor problem.
+
+## `DYLD_PRINT_LIBRARIES` prints nothing on macOS
+
+**Do not conclude anything from it.** `smolvm-bin` carries entitlements, so dyld strips `DYLD_*`
+from its environment. The binary finds its libraries through `@executable_path/lib` regardless,
+so the stripping is harmless and tells you nothing about a library problem.
+
+## Two assertion habits that apply beyond install
+
+- **Assert values, never exit codes.** A pack that lost its rootfs still boots and exits zero; a
+  guest command that fails still returns HTTP 200 from the local API; a CUDA program can link and
+  exit zero without ever reaching a GPU. `scripts/verify-boot.sh` asserts a marker the guest
+  printed and that the guest kernel differs from the host's, for this reason.
+- **Find leftover VMs by argv, not by `pgrep -f _boot-vm` and not by `readlink /proc/<pid>/exe`.**
+  The pattern form matches any shell whose text contains that string, including the cleanup script
+  itself, and it produced a phantom "1 orphan survived" result in the runs behind this packet.
+  **The `/proc/<pid>/exe` route then fails for a different reason**: the VM process is not
+  dumpable, so its `/proc/<pid>/exe` is root-owned and `readlink` returns `Permission denied` to
+  the very user who started it, leaving a reaper that reports "no orphans" while an orphan runs.
+  Both were observed on Ubuntu 24.04 aarch64 on 2026-09-07. `scripts/cleanup.sh` reads
+  `/proc/<pid>/cmdline` and requires `argv[1]` to be exactly `_boot-vm`, which a shell cannot
+  match, then keeps only the processes whose boot config lives under this `HOME`'s smolvm state so
+  another session's VM is left alone. On macOS the same test runs over `ps -axo pid=,command=`.

--- a/skills/install/references/windows.md
+++ b/skills/install/references/windows.md
@@ -1,0 +1,168 @@
+# Installing smolvm on Windows
+
+## Contents
+
+- Preflight, before anything is downloaded
+- Install from the zip
+- Prove the boot
+- State, and what you cannot move
+- The trap that breaks every script: captured output never returns
+- When a boot fails, read the guest console before cleaning up
+- Other Windows behaviour worth knowing at install time
+
+**Re-run on 2026-09-11 against smolvm v1.14.6** on Windows 11 Home build 10.0.26200.0 UBR 9445
+x86_64 (Intel Core Ultra 9 185H, 31.6 GB), in an elevated session with Developer Mode off.
+Everything below confirmed; only the release version and the zip's size and hash changed. The
+outputs are reproduced verbatim. Treat it as a record of a run, not as a promise about your host.
+
+Not covered at all: Windows 10, Windows Server, non-admin users, WSL2 as a host.
+
+`scripts/preflight.sh` reports `result=blocked` on Windows and points here. This packet ships no
+PowerShell script, because a script nobody has executed is worse than a procedure somebody has.
+
+## 1. Preflight, before anything is downloaded
+
+All read-only.
+
+```powershell
+[Environment]::OSVersion
+(Get-CimInstance Win32_OperatingSystem).Caption
+Get-WindowsOptionalFeature -Online -FeatureName HypervisorPlatform | Select-Object State
+```
+
+`State : Enabled` is the gate. The Windows Hypervisor Platform is available on Windows 11
+**Home**, unlike Hyper-V: `Microsoft-Hyper-V-All` returned no state on the tested host while
+`HypervisorPlatform` was `Enabled`. Enabling WHP is a system change and needs a reboot.
+
+**Also check symlink creation before the first run.** The agent rootfs ships as a tarball on
+Windows and its extraction drops symlinks silently without the privilege, after which the guest
+cannot exec `/sbin/init` and the boot ends as `boot process exited (code 127)`. The tolerant
+extraction path that lets a failed extraction be marked complete still exists at v1.14.6
+(`src/agent/manager.rs`), so the check is worth making rather than discovering afterwards. The
+re-run above was an elevated session with Developer Mode off, so it did not exercise the
+unprivileged path either.
+
+```powershell
+# Either of these is enough. Developer Mode is the one a non-admin user can turn on.
+(Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock' `
+  -Name AllowDevelopmentWithoutDevLicense -EA SilentlyContinue).AllowDevelopmentWithoutDevLicense
+whoami /priv | Select-String SeCreateSymbolicLinkPrivilege
+```
+
+`1` from the first, or a line from the second, means extraction will keep its symlinks. Neither
+was verified on an unprivileged shell: the tested host's SSH session was elevated and already
+held `SeCreateSymbolicLinkPrivilege`, so 389 reparse points extracted cleanly there and the
+unprivileged path could not be exercised.
+
+## 2. Install from the zip
+
+Windows does not use `install.sh`.
+
+```powershell
+Invoke-WebRequest -Uri 'https://github.com/smol-machines/smolvm/releases/download/v1.14.6/smolvm-1.14.6-windows-x86_64.zip' -OutFile "$dir\smolvm.zip"
+Invoke-WebRequest -Uri 'https://github.com/smol-machines/smolvm/releases/download/v1.14.6/checksums.sha256' -OutFile "$dir\checksums.sha256"
+(Get-FileHash -Algorithm SHA256 -LiteralPath "$dir\smolvm.zip").Hash
+Expand-Archive -LiteralPath "$dir\smolvm.zip" -DestinationPath "$dir\dist"
+```
+
+Observed: 40104648 bytes, SHA256
+`70105f035cf4b566c1abbb026ac113b7157f5000d26a1466bbdf4966e06b6b10`, matching the release
+checksums exactly.
+
+**The zip contains a nested versioned folder.** The exe is at
+`dist\smolvm-1.14.6-windows-x86_64\smolvm.exe`, not `dist\smolvm.exe`. A script that assumes the
+flat layout fails here, and the failure looks like a bad download.
+
+```powershell
+& "$dir\dist\smolvm-1.14.6-windows-x86_64\smolvm.exe" --version   # smolvm 1.14.6
+```
+
+## 3. Prove the boot
+
+```powershell
+& $exe machine run --net --image alpine -- sh -c "echo HELLO_FROM_WINDOWS; uname -srm"
+```
+
+Observed, including the image pull:
+
+```
+Starting ephemeral machine (vm-f0d4c640)...
+Pulling image alpine... done.
+HELLO_FROM_WINDOWS
+Linux 6.12.95 x86_64
+```
+
+Native Windows runs x86_64 Linux guests. The guest kernel differs from the host, which is the
+assertion that proves it is a VM.
+
+## 4. State, and what you cannot move
+
+smolvm writes to `%LOCALAPPDATA%\smolvm` (`server\`, `rootfs\`, `vms\`). **You cannot relocate
+it.** There is no `SMOLVM_DATA_DIR` in the Windows binary, and pointing `$env:LOCALAPPDATA` at a
+scratch directory changed nothing: smolvm still created `C:\Users\<user>\AppData\Local\smolvm`,
+because it resolves the known folder through the Windows API, which ignores the variable.
+
+Two consequences. There is no isolated-HOME trick for testing on Windows, so a test run writes
+into the real profile. And teardown has to remove that tree by hand: it reached **30756 MB** in
+one session, since each machine's storage and overlay images are sparse files with 20 GiB and
+10 GiB apparent size. See the `teardown` packet.
+
+`machine list` is not read-only either: it creates the state directory and `server\smolvm.db`.
+
+## 5. The trap that breaks every script: captured output never returns
+
+`machine start` leaves the VM running as a background `smolvm.exe _boot-vm` child that inherits
+the parent's stdout handle. Any caller that **captures** that output waits for the handle to
+close, which happens only when the VM dies.
+
+| invocation | result |
+|---|---|
+| `& $exe machine start --name X 2>&1 \| Out-String` | still blocked after 90 s, while `machine list` showed the machine `running` |
+| `cmd /c "smolvm.exe machine start ... > out.txt 2>&1"` | also blocks, though the file already shows `Machine 'X' running (PID ...)` |
+| `Start-Process -RedirectStandardOutput out.txt -PassThru`, poll `HasExited` | returns in 4.9 s |
+
+The command itself is fast and correct. The shell is what hangs, and it cost about an hour on the
+tested host and produced two wrong conclusions before it was found: `machine branch` and
+`machine checkpoint` both looked like indefinite hangs when the `machine start` before them was
+what blocked, and neither had run at all.
+
+The pattern that works:
+
+```powershell
+$p = Start-Process -FilePath $exe -ArgumentList @('machine','start','--name','X') `
+     -RedirectStandardOutput out.txt -RedirectStandardError err.txt -WindowStyle Hidden -PassThru
+while (-not $p.HasExited) { Start-Sleep -Milliseconds 400 }
+Get-Content out.txt
+```
+
+One caveat on that pattern: `-ArgumentList` applies its own quoting and mangles nested shell
+quoting such as `-- sh -c "echo $(id -un)"`. For `exec` commands containing quotes, `cmd /c` with
+file redirection is correct and does not block, because `exec` leaves no new background VM.
+
+## 6. When a boot fails, read the guest console before cleaning up
+
+Since v1.14.0 the guest console is written to
+`%LOCALAPPDATA%\smolvm\vms\<hash>\agent-console.log`, beside `agent-startup-error.log`. It holds
+the real reason (`Couldn't execute '/sbin/init': ENOENT` when the rootfs extraction is broken)
+while the CLI prints only `boot process exited (code 127)`. Nothing surfaces it for you.
+
+**It exists only while the VM directory does**, so read it after the failure and before any
+cleanup step removes the directory.
+
+```powershell
+Get-Content "$env:LOCALAPPDATA\smolvm\vms\<hash>\agent-console.log" -Tail 40
+```
+
+## 7. Other Windows behaviour worth knowing at install time
+
+- **PowerShell turns the exe's stderr into error records.** A fully successful run prints
+  `smolvm.exe : Starting ephemeral machine (...)` followed by `NativeCommandError`. The command
+  succeeded and `$LASTEXITCODE` is 0. Do not set `$ErrorActionPreference = 'Stop'` around a
+  smolvm call, and do not read red text as failure.
+- **Device ceiling on WHP.** Four `-v` mounts boot; five fail with `no more IRQs are available`.
+  Any `-p` costs one of those slots, so four mounts plus two ports fails while two plus two boots.
+- **Path length was not a problem** in the paths this run exercised: a volume mount from a
+  237-character directory worked and nothing broke approaching 260 characters.
+- **The rest of the platform picture.** `--net` gives a real `eth0` with inbound port-forwarding,
+  and `--cuda` reaches a real NVIDIA GPU. Vulkan (`--gpu`) is accepted and silently does nothing.
+  Two of those three contradict the caveats this release ships with.

--- a/skills/install/references/windows.md
+++ b/skills/install/references/windows.md
@@ -163,6 +163,6 @@ Get-Content "$env:LOCALAPPDATA\smolvm\vms\<hash>\agent-console.log" -Tail 40
   Any `-p` costs one of those slots, so four mounts plus two ports fails while two plus two boots.
 - **Path length was not a problem** in the paths this run exercised: a volume mount from a
   237-character directory worked and nothing broke approaching 260 characters.
-- **The rest of the platform picture.** `--net` gives a real `eth0` with inbound port-forwarding,
-  and `--cuda` reaches a real NVIDIA GPU. Vulkan (`--gpu`) is accepted and silently does nothing.
-  Two of those three contradict the caveats this release ships with.
+- **The rest of the platform picture**, in the `dev-env`, `local-api` and `gpu-cuda` packets.
+  `--net` gives a real `eth0` with inbound port-forwarding, and `--cuda` reaches a real NVIDIA
+  GPU. Vulkan (`--gpu`) is accepted and silently does nothing.

--- a/skills/install/scripts/cleanup.sh
+++ b/skills/install/scripts/cleanup.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Delete the machines this packet's scripts created, then prove the host is clean.
+#
+# Only machines recorded in the state file are deleted, so a machine you or
+# another session created by hand is never touched. Scripts record a name by
+# calling: cleanup.sh --record <name>
+#
+# usage: cleanup.sh [--record <name>] [--reap] [--purge]
+#   --record <name>  add a machine name to the state file and exit
+#   --reap           kill leftover VM processes (see the warning it prints)
+#   --purge          also remove the state file once the list is empty
+
+set -uo pipefail
+
+PACKET="install"
+PREFIX="smolskill-"
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+STATE_DIR="${SMOLVM_SKILL_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/smolvm-skills}"
+STATE_FILE="$STATE_DIR/$PACKET.machines"
+
+reap=0
+purge=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --record)
+            mkdir -p "$STATE_DIR"
+            printf '%s\n' "$2" >> "$STATE_FILE"
+            exit 0
+            ;;
+        --reap)  reap=1 ;;
+        --purge) purge=1 ;;
+        *) printf 'unknown argument: %s\n' "$1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+if [ -z "$SMOLVM" ]; then
+    printf 'smolvm not found; set SMOLVM to its path\n' >&2
+    exit 2
+fi
+
+case "$(uname -s)" in
+    Darwin) VMS_DIR="$HOME/Library/Caches/smolvm/vms" ;;
+    *)      VMS_DIR="${SMOLVM_DATA_DIR:-$HOME/.cache/smolvm}/vms" ;;
+esac
+VMS_DIR="${SMOLVM_VMS_DIR:-$VMS_DIR}"
+SMOLVM_PREFIX="${SMOLVM_PREFIX:-$HOME/.smolvm}"
+
+# List this HOME's smolvm VM processes, as "pid marker".
+#
+# Two process shapes exist and a reaper has to catch both. The plain
+# `machine run` path EXECS a child whose argv[1] is `_boot-vm` and whose argv[2]
+# is its boot-config path. The pack-run path, which is `--oci-cache` or any
+# `init`, FORKS without execing, so the child inherits the parent's argv and
+# carries no boot-config at all. Matching `_boot-vm` alone is therefore blind to
+# exactly the path whose child survives an interrupt
+# (smol-machines/smolvm#1193): measured on v1.14.6, it reported "none" while two
+# orphaned VMs held 234 MB each.
+#
+# On Linux both shapes rename themselves to `libkrun VM`, the one marker that
+# covers both and that no shell can hold. macOS exposes no rename, so there the
+# executable path scopes the search to this HOME and the parent chain separates
+# a VM from the CLI that started it.
+#
+# `pgrep -f _boot-vm` is not an alternative: it matches any shell whose text
+# contains that string, including this script.
+list_vm_processes() {
+    case "$(uname -s)" in
+        Linux)
+            for p in /proc/[0-9]*; do
+                [ "$(cat "$p/comm" 2>/dev/null)" = "libkrun VM" ] || continue
+                pid="${p#/proc/}"
+                cfg="$(tr '\0' '\n' < "$p/cmdline" 2>/dev/null | sed -n '3p')"
+                case "$cfg" in
+                    "$VMS_DIR"/*) printf '%s %s\n' "$pid" "$cfg"; continue ;;
+                esac
+                # Forked shape: nothing in argv identifies it, so scope by the
+                # binary it is running.
+                case "$(readlink "$p/exe" 2>/dev/null)" in
+                    "$SMOLVM_PREFIX"/*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;;
+                esac
+            done
+            ;;
+        Darwin)
+            # shellcheck disable=SC2009  # pgrep cannot return ppid and the full
+            # command together, and pgrep -f matches this script's own text.
+            own=" $(ps -axo pid=,command= 2>/dev/null | grep -F "$SMOLVM_PREFIX/smolvm-bin" | awk '{print $1}' | tr '\n' ' ') "
+            ps -axo pid=,ppid=,command= 2>/dev/null | while read -r pid ppid rest; do
+                case "$rest" in "$SMOLVM_PREFIX"/smolvm-bin*) ;; *) continue ;; esac
+                case "$rest" in
+                    *" _boot-vm "*) printf '%s %s\n' "$pid" "${rest#* _boot-vm }"; continue ;;
+                esac
+                # Forked shape: its parent is the CLI that started it, or init
+                # once that CLI is gone.
+                if [ "$ppid" = 1 ]; then
+                    printf '%s orphaned-under %s\n' "$pid" "$SMOLVM_PREFIX"
+                else
+                    case "$own" in *" $ppid "*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;; esac
+                fi
+            done
+            ;;
+    esac
+}
+
+# 1. Delete recorded machines. --force is not optional: without it the command
+# prompts, defaults to No, and leaves the machine in place while the script
+# carries on. --cascade removes branch children, which otherwise block the
+# delete.
+if [ -s "$STATE_FILE" ]; then
+    while read -r name; do
+        [ -n "$name" ] || continue
+        case "$name" in "$PREFIX"*) ;; *)
+            printf 'skipping %s: not created by this packet (no %s prefix)\n' "$name" "$PREFIX"
+            continue ;;
+        esac
+        "$SMOLVM" machine stop   --name "$name" >/dev/null 2>&1
+        "$SMOLVM" machine delete --name "$name" --force --cascade 2>&1 | sed 's/^/  /'
+    done < "$STATE_FILE"
+fi
+
+# 2. An ephemeral machine's entry retires after the run returns, not with it.
+# Asserting an empty list immediately fails on a healthy host.
+sleep 20
+
+# 3. Assert the value, not the exit code.
+listing="$("$SMOLVM" machine list 2>&1)"
+if printf '%s' "$listing" | grep -q 'No machines found'; then
+    printf 'machines=clean\n'
+    [ "$purge" -eq 1 ] && rm -f "$STATE_FILE"
+else
+    printf 'machines=remaining\n'
+    printf '%s\n' "$listing" | sed 's/^/  /'
+fi
+
+# 4. Report VM processes an interrupt left behind. Ctrl-C does not stop a
+# machine: the VM outlives the CLI and `machine list` cannot see it, so this is
+# the only route to it. Only processes whose boot config lives under this HOME's
+# smolvm state are listed, so a VM another session started is left alone.
+found=0
+while read -r pid cfg; do
+    [ -n "$pid" ] || continue
+    found=1
+    printf 'vm_process=%s config=%s\n' "$pid" "$cfg"
+    if [ "$reap" -eq 1 ]; then
+        kill -9 "$pid" 2>/dev/null && printf '  killed %s\n' "$pid"
+    fi
+done <<EOF
+$(list_vm_processes)
+EOF
+
+if [ "$found" -eq 0 ]; then
+    printf 'vm_processes=none\n'
+elif [ "$reap" -eq 0 ]; then
+    printf 'rerun with --reap to kill them\n'
+fi

--- a/skills/install/scripts/preflight.sh
+++ b/skills/install/scripts/preflight.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Report whether this host can install and boot smolvm. Read-only: starts no VM,
+# writes no smolvm state, changes no group membership.
+#
+# Output is one key=value per line so a caller can parse it. The last line is
+# always result=ready or result=blocked.
+
+set -uo pipefail
+
+VERIFIED_VERSION="1.14.6"
+
+emit() { printf '%s=%s\n' "$1" "$2"; }
+
+blocked=0
+note() { printf 'note=%s\n' "$1"; }
+
+# --- the binary --------------------------------------------------------------
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+if [ -z "$SMOLVM" ]; then
+    emit smolvm_installed no
+    emit smolvm_version ""
+    blocked=1
+else
+    emit smolvm_installed yes
+    version="$("$SMOLVM" --version 2>/dev/null | awk '{print $NF}')"
+    emit smolvm_version "${version:-unknown}"
+fi
+
+emit verified_version "$VERIFIED_VERSION"
+if [ -n "${version:-}" ] && [ "$version" != "unknown" ]; then
+    if [ "$version" = "$VERIFIED_VERSION" ]; then
+        emit version_status match
+    else
+        newest="$(printf '%s\n%s\n' "$version" "$VERIFIED_VERSION" | sort -V | tail -1)"
+        if [ "$newest" = "$version" ]; then
+            emit version_status newer
+            note "this packet was verified on $VERIFIED_VERSION and the binary is $version; flags and messages move every release, so check the output against the binary before trusting a step here"
+        else
+            emit version_status older
+            note "this packet was verified on $VERIFIED_VERSION and the binary is $version"
+        fi
+    fi
+else
+    emit version_status unknown
+fi
+
+# --- platform ----------------------------------------------------------------
+
+kernel="$(uname -s)"
+arch="$(uname -m)"
+case "$arch" in aarch64|arm64) arch=aarch64 ;; esac
+
+case "$kernel" in
+    Darwin)
+        emit platform "darwin-$arch"
+        emit accel hvf
+        emit macos_version "$(sw_vers -productVersion)"
+        hv="$(sysctl -n kern.hv_support 2>/dev/null)"
+        if [ "$hv" = "1" ]; then emit accel_access ok; else emit accel_access denied; blocked=1; fi
+        if [ "$arch" != "aarch64" ]; then
+            emit hardware_verified no
+            note "Intel Mac is not verified by this packet; the installer accepts it and nothing here was run on one"
+        else
+            emit hardware_verified yes
+        fi
+        # A VM's agent socket lives under the cache directory. macOS sockaddr_un
+        # holds 104 bytes including the terminator.
+        sock="$HOME/Library/Caches/smolvm/vms/0123456789abcdef/agent.sock"
+        len=${#sock}
+        emit socket_path_bytes "$len"
+        if [ "$len" -gt 100 ]; then
+            emit socket_path_status too_long
+            blocked=1
+            note "HOME is too deep: every VM start will fail with krun_start_enter -22, whose text blames disks and device options. Install under a shorter HOME."
+        else
+            emit socket_path_status ok
+        fi
+        emit unsupported "vulkan,cuda"
+        ;;
+    Linux)
+        emit platform "linux-$arch"
+        emit accel kvm
+        emit socket_path_status n_a
+        if [ ! -e /dev/kvm ]; then
+            emit accel_access missing
+            blocked=1
+            note "/dev/kvm does not exist; this host has no KVM"
+        elif [ -r /dev/kvm ] && [ -w /dev/kvm ]; then
+            emit accel_access ok
+        else
+            emit accel_access denied
+            blocked=1
+            note "your user cannot open /dev/kvm. The installer warns and continues, so a successful install says nothing about whether a VM will start. Fix: sudo usermod -aG kvm \$USER, then run the next command through sg kvm -c '...' rather than logging out."
+        fi
+        emit unsupported "vulkan"
+        ;;
+    *)
+        emit platform "unsupported-$kernel"
+        emit accel unknown
+        emit accel_access unknown
+        blocked=1
+        note "this script covers macOS and Linux. On Windows use references/windows.md, which is written from a run and not re-run by this packet."
+        ;;
+esac
+
+if [ "$blocked" -eq 0 ]; then emit result ready; else emit result blocked; fi

--- a/skills/install/scripts/verify-boot.sh
+++ b/skills/install/scripts/verify-boot.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Prove the install can actually boot a VM. This is the step that decides
+# whether smolvm works here; `smolvm --version` printing a number does not.
+#
+# Runs one ephemeral alpine VM, asserts a marker the guest printed and that the
+# guest kernel is not the host's, then hands off to cleanup.sh.
+
+set -uo pipefail
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+if [ -z "$SMOLVM" ]; then
+    printf 'smolvm not found; set SMOLVM to its path\n' >&2
+    exit 2
+fi
+
+host_kernel="$(uname -sr)"
+marker="BOOTED_OK"
+
+out="$("$SMOLVM" machine run --mem 2048 --net --image alpine -- \
+      sh -c "echo $marker && uname -srm" 2>&1)"
+printf '%s\n' "$out" | sed 's/^/  /'
+
+fail=0
+
+# Assert the marker, not the exit code. smolvm exits zero on paths where the
+# guest never ran the command.
+if printf '%s' "$out" | grep -q "^$marker$"; then
+    printf 'guest_ran=yes\n'
+else
+    printf 'guest_ran=no\n'
+    fail=1
+fi
+
+guest_kernel="$(printf '%s' "$out" | grep -m1 '^Linux ' | awk '{print $1" "$2}')"
+printf 'guest_kernel=%s\n' "${guest_kernel:-none}"
+printf 'host_kernel=%s\n' "$host_kernel"
+if [ -n "$guest_kernel" ] && [ "$guest_kernel" != "$host_kernel" ]; then
+    printf 'is_a_vm=yes\n'
+else
+    printf 'is_a_vm=no\n'
+    fail=1
+fi
+
+if [ "$fail" -eq 0 ]; then
+    printf 'result=boot_ok\n'
+else
+    printf 'result=boot_failed\n'
+    printf 'next: read the failure before cleaning up, because the evidence is deleted with the VM directory.\n'
+    printf '  - "agent did not become ready within 30 seconds" is usually host load, not the install. The 30s limit is fixed and no flag raises it for machine run or machine start.\n'
+    printf '  - "krun_start_enter returned: -22" on macOS is almost always the socket path length, not the disks its text names. Run preflight.sh and read socket_path_status.\n'
+    printf '  - the boot child sends its own output to /dev/null. To see the real failure, copy <vm-dir>/boot-config.json while a start is in flight and run: smolvm-bin _boot-vm <copy>\n'
+fi
+
+exit "$fail"

--- a/skills/local-api/SKILL.md
+++ b/skills/local-api/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: local-api
+description: "Drives smolvm programmatically over its local HTTP API (smolvm serve) instead of the CLI: create machines, exec and stream commands, move files in and out, and tear them down. Use when building a client, harness, agent tool or MCP backend over smolvm; when a create call is accepted but the machine behaves as if a field was ignored; when a file uploaded over the API has disappeared; when an exec that failed still returned HTTP 200; or when choosing between the Unix socket and loopback TCP. Do not use it as a substitute for the CLI in a shell script, and do not bind the listener beyond loopback: the API has no authentication of any kind."
+---
+
+# Driving smolvm over HTTP
+
+Verified on **smolvm v1.14.6** on macOS arm64 and Linux aarch64, 2026-09-10. Done means a machine went through
+its whole lifecycle over HTTP and `GET /api/v1/machines` is empty again at the end.
+
+Two rules run through everything here, and both are the same shape: **a 200 is not a result.**
+
+1. **A failing guest command still returns HTTP 200.** Assert `exitCode` from the body.
+2. **Upload files only after the workload container is running.** An upload before that returns
+   200 with the resolved path and byte count for a file that is then unreadable.
+
+## Procedure
+
+**1. Preflight.**
+
+```bash
+scripts/preflight.sh
+```
+
+It reports `auth=none`, which is not a warning about your setup: the API has no TLS, token or auth
+flag of any kind, so **the transport you pick is the access control**.
+
+**2. Start the server.** A Unix socket is the default here, as it is smolvm's.
+
+```bash
+scripts/serve-start.sh
+scripts/serve-start.sh --listen 127.0.0.1:8899
+```
+
+It waits for `"status":"ok"` from `/health` rather than for the process to exist, records the
+listen address and pid for cleanup, and reports any `Reclaimed N dangling VM data dir(es)` line so
+you do not later read those directories as a leak.
+
+**3. Export the spec before writing a request body.** This is the step that saves the most time.
+
+```bash
+smolvm serve openapi -o ./openapi.json
+```
+
+The field names are the schema's, not the CLI's flags. `network` not `net`, `memoryMb` not
+`memory`, and `cmd` for the workload you would pass after `--`. Unknown fields are accepted with
+200 and ignored. `references/api-fields.md` has the full list and what each wrong name costs.
+
+**4. Run the lifecycle.**
+
+```bash
+scripts/lifecycle-check.sh
+```
+
+Create, start, wait for the workload container to answer with a value, exec, exec a deliberately
+failing command and assert its non-zero `exitCode` came back on a 200, stream, round-trip a file,
+stop, delete, and assert the machine list is empty:
+
+```
+created_state=ok (created)
+started_state=ok (running)
+workload_ready_after_s=0
+workload_ready=ok (yes)
+exec_exit_code=ok (0)
+exec_stdout=ok
+failing_exec_exit_code=ok (3)
+stream_lines=ok (3)
+stream_exit_event=ok
+file_roundtrip=ok (PAYLOAD123)
+machines_empty=ok ({"machines":[]})
+result=lifecycle_ok
+```
+
+**5. Clean up, machines first.**
+
+```bash
+scripts/cleanup.sh --purge
+```
+
+Order matters: **stopping the server does not stop machines**, it orphans them. The script deletes
+recorded machines, then stops the server, then removes the socket.
+
+## The calls, in short
+
+```bash
+B=http://127.0.0.1:8899   # or: curl --unix-socket "$SOCK" http://localhost/...
+
+curl $B/health
+curl -X POST $B/api/v1/machines -H 'content-type: application/json' \
+  -d '{"name":"m","image":"python:3.12-alpine","network":true,"memoryMb":2048,
+       "cmd":["sh","-c","while true; do sleep 3600; done"]}'
+curl -X POST $B/api/v1/machines/m/start -H 'content-type: application/json' -d '{}'
+curl -X POST $B/api/v1/machines/m/exec  -H 'content-type: application/json' \
+  -d '{"command":["sh","-c","echo hi"]}'
+curl -N -X POST $B/api/v1/machines/m/exec/stream -H 'content-type: application/json' \
+  -d '{"command":["sh","-c","for i in 1 2 3; do echo line$i; sleep 1; done"]}'
+curl -X PUT "$B/api/v1/machines/m/files/%2Ftmp%2Fabs.txt" --data-binary 'PAYLOAD'
+curl        "$B/api/v1/machines/m/files/%2Ftmp%2Fabs.txt"
+curl -X POST   $B/api/v1/machines/m/stop -H 'content-type: application/json' -d '{}'
+curl -X DELETE $B/api/v1/machines/m
+```
+
+Paths in the `files` route are **absolute and URL-encoded**. `exec` returns stdout as text and as
+base64; `exec/stream` emits one `event: stdout` per line then a terminal `event: exit`.
+
+## Traps
+
+Full detail in `references/traps.md` and `references/api-fields.md`.
+
+- **Upload after the container is up, never before.** Reproduced on Linux aarch64: the PUT
+  returned `200 {"path":"/tmp/r1.txt","size":6}` and the file was never readable, first with
+  `failed to canonicalize target`, then with `failed to read /tmp/r1.txt in the workload
+  container`. Both directions pick a namespace per request, and `/tmp` is a path the container
+  mounts over. The same sequence on macOS returned the payload, which makes this timing dependent
+  rather than safe.
+- **A failing guest command is HTTP 200.**
+- **Unknown create fields are accepted and ignored**, while a Smolfile rejects them. A `net` for
+  `network` was caught at create here with a clear 400 about the missing network, but a `memory`
+  for `memoryMb` gets no diagnostic at all: you silently get the default.
+- **Killing the server orphans machines.**
+- **The spec's `info.version` is not the binary's.** It says `0.5.2` on v1.14.2 while `/health`
+  says `1.14.2`. Take the version from `/health`.
+
+## Security defaults, and why they are the defaults
+
+- **The Unix socket is the default because it is the only access control there is.** `serve start`
+  has no TLS, certificate, token or auth flag, and the routes it exposes create machines, exec
+  arbitrary commands and read and write files. The socket's file permissions are a real boundary;
+  a loopback port is a boundary only in the sense that every process on the host is inside it.
+- **Loopback TCP is for when you need a URL**, in a container network namespace or for a client
+  that cannot do Unix sockets. Treat the port as equivalent to a shell on the host, and do not
+  bind anything but `127.0.0.1`.
+- **`scripts/serve-start.sh` puts its socket under the packet's own state directory**, not in a
+  world-traversable temporary directory, and removes it at cleanup.
+- **Machines are deleted before the server is stopped**, because a server shutdown leaves running
+  VMs with nothing managing them and no route back to them from the CLI.
+
+## Platform arms
+
+- **macOS arm64** and **Linux aarch64**: the scripts were run here, over the Unix socket.
+- **Linux x86_64**: verified in the material behind this packet, over both transports, not re-run
+  here.
+- **Windows x86_64**: `references/windows.md`, **re-run on 2026-09-11 against v1.14.6** on
+  Windows 11 Home build 10.0.26200.0 UBR 9445, where the whole lifecycle passed over loopback TCP.
+  No Unix socket form has ever been attempted there, **400 and 404 still return empty bodies**, and
+  two shapes fail before reaching a machine: routes live under `/api/v1/`, and a bodiless POST to
+  `start` or `stop` needs `application/json` with an empty JSON body.
+
+## Eval prompts, and what they produced
+
+Run on 2026-09-07 PT against v1.14.2 from the published release, under an isolated `HOME`. Output
+is verbatim.
+
+**1. "Write me something that drives a smolvm machine over HTTP end to end and proves it worked."**
+
+`scripts/lifecycle-check.sh`, over a Unix socket. All eleven checks passed on macOS 26.6.2 arm64
+and on Lima `linux-kvm` (Ubuntu 24.04 aarch64), the Linux one twice in a row. Output as shown in
+step 4 above, including `failing_exec_exit_code=ok (3)`, which is the assertion that catches a
+guest failure hiding behind a 200.
+
+**2. "I uploaded a file right after starting the machine and now the API says it does not
+exist."**
+
+Reproduced on Linux aarch64 by doing exactly that:
+
+```
+PUT: {"path":"/tmp/r1.txt","size":6}
+GET now: {"error":"agent operation failed: read file: failed to canonicalize target
+          /tmp/r1.txt: No such file or directory (os error 2)","code":"INTERNAL_ERROR"}
+GET after 30s: {"error":"agent operation failed: read file: failed to read /tmp/r1.txt in
+          the workload container: open /tmp/r1.txt: No such file or directory (os error 2)",
+          "code":"INTERNAL_ERROR"}
+```
+
+The upload reported success for a file that was never readable. The same sequence on macOS arm64
+returned `ROUND1` both immediately and after 30 s, so a run that works proves nothing.
+
+**3. "My create call returned 200 but the machine has the wrong settings."**
+
+Verified on both hosts: a body carrying an unknown field is accepted and the field is dropped.
+
+```
+POST {"name":"...","image":"alpine","network":true,"memoryMb":2048,"bogusField":1}
+-> 200 {"name":"...","state":"created","network":true,"memoryMb":2048,...}
+```
+
+and the runbook's `net`/`memory` shape was caught at create on both hosts, with a message that
+names the remedy:
+
+```
+400 {"error":"config operation failed: create machine: image 'alpine' must be pulled from a
+registry, but this machine has no network, so the pull can never succeed. Add --net ...",
+"code":"BAD_REQUEST"}
+```
+
+A 404 on either host returns `{"error":"machine 'nope-does-not-exist' not found",
+"code":"NOT_FOUND"}`, which is the diagnostic Windows does not give you.
+
+## Re-verified on v1.14.6
+
+Run 2026-09-10 PT against v1.14.6 on macOS 26.6.2 arm64 and Lima `linux-kvm` (Ubuntu 24.04
+aarch64), over the Unix socket. **All eleven checks green on both**, including
+`failing_exec_exit_code=ok (3)`, the case that proves a guest failure arrives on an HTTP 200.
+
+## What was not run
+
+- **The Unix socket form on Windows.** The 2026-09-11 v1.14.6 re-run there used loopback TCP, as
+  every Windows run has.
+- **Linux x86_64.**
+- **Loopback TCP.** `serve-start.sh` accepts `--listen 127.0.0.1:8899` and the code path is the
+  same, but every run here used the Unix socket.
+- **Authenticated or TLS deployment.** There is no such thing to test: `serve start` has no flags
+  for it.
+- **The pool and rollout-executor routes** in the spec. They belong to the branch-pool feature.
+
+## Related packets
+
+- `install` for the boot this assumes, `teardown` for the cleanup script.
+- `dev-env` for the same lifecycle through the CLI, and for the workload-container behaviour that
+  the `cmd` field addresses here.

--- a/skills/local-api/references/api-fields.md
+++ b/skills/local-api/references/api-fields.md
@@ -1,0 +1,126 @@
+# Reading the API's own schema, and the field names that bite
+
+## Contents
+
+- Export the spec first
+- The create body's field names are not the CLI's flags
+- Unknown fields are accepted and silently ignored
+- Error bodies carry a reason on macOS and Linux, and were empty on Windows
+- Route parameters are inconsistent in the spec
+- Assert `exitCode` from the body, never the HTTP status
+- The routes this packet does not cover
+
+## Export the spec first. This is the step that saves the most time.
+
+```bash
+smolvm serve openapi -o ./openapi.json
+```
+
+`serve openapi` writes to **stdout** by default, so without `-o` you paste a 150 KB spec into your
+terminal. Read `components.schemas.CreateMachineRequest` before writing a create body.
+
+**The version in the spec is not the binary's.** The exported spec says `info.version = "0.5.2"`
+while `GET /health` on the same server reports the real one: `"1.14.2"` observed on macOS arm64 on
+2026-09-07, and `"1.14.3"` on 2026-09-08. The gap widens with every release, because the spec's
+number is hardcoded. Take the version from `/health`, never from the spec.
+
+## The create body's field names are not the CLI's flags
+
+`CreateMachineRequest` at v1.14.2 accepts:
+
+```
+allowedCidrs  allowedHosts  autoGraph  blobPeers  cmd  cpus  cuda  dockerSocket
+entrypoint  env  from  gpu  image  memoryMb  mounts  name  network  networkBackend
+overlayGb  ports  registryIdentityToken  registryRef  restart  secrets  storageGb  workdir
+```
+
+**v1.14.3 adds `blockIo`**, selecting the block I/O engine, and adds host and guest memory fields
+to the responses (`hostMemoryAvailableMb`, `usedMemoryPssMb` and neighbours). `blockIo` defaults to
+unset, so leaving it out keeps the behaviour this packet describes. Asking for the async engine on
+a host without `io_uring` fails the boot with a message naming the way out
+(`use --block-io sync`), which is a boot failure mode none of the other packets mention. **Export
+the spec against your own binary rather than trusting this list**, which is a snapshot of two
+releases.
+
+The three worth memorising, because the CLI trains you to write the other thing:
+
+| you will write | the schema wants |
+|---|---|
+| `net` | `network` |
+| `memory` | `memoryMb` |
+| a workload after `--` | `cmd` (and `entrypoint`) |
+
+**`cmd` matters more than it looks.** Without it the image's own ENTRYPOINT or CMD becomes the
+machine's persistent workload, and for an interpreter image such as `python:3.12-alpine` that
+command reads EOF and exits at once. The container is then relaunched, and an `exec` that lands in
+the gap comes back as `exitCode: 1` with **empty stdout and empty stderr**, which is quieter than
+the CLI's equivalent failure. That happened once in this packet's own run on a nested-virt aarch64
+host, and `scripts/lifecycle-check.sh` now passes a long-lived `cmd`.
+
+## Unknown fields are accepted and silently ignored
+
+Verified on macOS arm64 and Linux aarch64 at v1.14.2: a create body carrying `bogusField` returns
+**200** and a machine built from the fields it did recognise.
+
+```
+POST /api/v1/machines {"name":"...","image":"alpine","network":true,"memoryMb":2048,"bogusField":1}
+-> 200 {"name":"...","state":"created","network":true,"memoryMb":2048,...}
+```
+
+Note the contrast: a **Smolfile rejects unknown keys**, and the README says so. The API does not.
+
+**What the wrong name costs depends on which one you got wrong.** Writing `net` instead of
+`network` produces a machine with no networking, and on both hosts here that was caught at create
+with a 400 and a good message:
+
+```
+{"error":"config operation failed: create machine: image 'alpine' must be pulled from a
+registry, but this machine has no network, so the pull can never succeed. Add --net (or
+publish a port with -p, or set an egress policy with --allow-cidr/--allow-host). ...",
+ "code":"BAD_REQUEST"}
+```
+
+A wrong name that does not change network reachability, such as `memory` for `memoryMb`, gets no
+diagnostic at all: you simply get the default. So do not rely on the 400 above to catch a typo.
+
+## Error bodies carry a reason on macOS and Linux, and were empty on Windows
+
+Observed here at v1.14.2:
+
+```
+GET /api/v1/machines/nope-does-not-exist
+-> 404 {"error":"machine 'nope-does-not-exist' not found","code":"NOT_FOUND"}
+```
+
+On the Windows host, **400 and 404 returned empty bodies**, which is what turns a wrong field name
+into a silent failure there. See `references/windows.md`.
+
+## Route parameters are inconsistent in the spec
+
+Some paths take `{id}` and some take `{name}`, for the same thing:
+
+- `{id}`: `exec`, `exec/stream`, `files/{path}`, `images`, `images/pull`, `logs`, `run`
+- `{name}`: the machine itself, `start`, `stop`, `branches`, `fork`, `export`, `resize`, `sync`
+
+Both accept the machine name in practice, but a generated client will expose two different
+parameter names for one concept.
+
+## Assert `exitCode` from the body, never the HTTP status
+
+A command that fails inside the guest is still **HTTP 200**:
+
+```
+POST .../exec {"command":["sh","-c","exit 3"]}  ->  200 {"exitCode":3,...}
+```
+
+`scripts/lifecycle-check.sh` runs exactly that case, so the assertion that catches it is itself
+tested rather than assumed.
+
+`exec` returns stdout both as text and base64 (`stdout` and `stdoutB64`), and `exec/stream` emits
+one `event: stdout` per line followed by a terminal `event: exit`.
+
+## The routes this packet does not cover
+
+`serve start` has **no TLS, certificate, auth or token flag at all**, so there is no authenticated
+deployment to describe. The pool and rollout-executor routes in the spec belong to the branch-pool
+feature, not to this use case, and nothing here exercises them.

--- a/skills/local-api/references/traps.md
+++ b/skills/local-api/references/traps.md
@@ -1,0 +1,79 @@
+# Local API traps
+
+## Upload files only after the workload container is running
+
+**This is the one ordering rule in this packet, and it applies on every platform.**
+
+A file uploaded before the workload container is up is written into the agent's own namespace.
+Once the container starts, reads resolve **inside the container**, and for a path the container
+mounts over, the earlier file is no longer in the view being read. `/tmp` is exactly such a path:
+it is a tmpfs inside the guest, so the container's own `/tmp` masks whatever was seeded underneath.
+
+Both directions pick a namespace per request. `handle_file_write` and
+`handle_streaming_file_read` each switch on `nsfile::GuestNs::for_workload()`
+(`crates/smolvm-agent/src/main.rs` at v1.14.2), writing and reading inside the workload container
+when one is running and in the agent's namespace otherwise. The source's own comment claims the
+pre-container write is safe, "seeding it before the container starts is exactly how the file
+becomes visible once it does". **That holds for overlay paths and not for paths the container
+mounts over.**
+
+Reproduced on Ubuntu 24.04 aarch64 on 2026-09-07, PUT immediately after `POST /start`:
+
+```
+PUT  files/tmp%2Fr1.txt   ->  200 {"path":"/tmp/r1.txt","size":6}
+GET  files/tmp%2Fr1.txt   ->  500 failed to canonicalize target /tmp/r1.txt: No such file or directory
+GET  again after 30 s     ->  500 failed to read /tmp/r1.txt in the workload container: ...
+```
+
+The upload reported success, with the resolved path and the byte count, for a file that was never
+readable. The two different error texts are the two namespaces: before the container it cannot
+canonicalize the path at all, after it the read happens inside the container and misses.
+
+**It is timing dependent, which makes it worse rather than better.** The same sequence on macOS
+arm64, and on Linux with a long-lived `cmd` in the create body, returned `ROUND1` both immediately
+and after 30 s. A run that happens to work proves nothing about the next one.
+
+**So:** wait for a successful `exec` before uploading anything, which is what
+`scripts/lifecycle-check.sh` does, or upload to a path on the overlay such as `/root` rather than
+one the container mounts over.
+
+## A failing guest command is still HTTP 200
+
+Check `exitCode` in the body. `scripts/lifecycle-check.sh` deliberately runs `sh -c 'exit 3'` and
+asserts `exitCode == 3`, so the assertion that catches this is itself tested.
+
+## Killing the server orphans running machines
+
+On shutdown it prints `Shutting down server (VMs continue running)...`, and that is the only
+notice you get, in a line you will miss if stderr is redirected. **Delete machines before killing
+the server**, or they survive it with nothing managing them. `scripts/cleanup.sh` does them in
+that order.
+
+## `serve start` also reclaims stale VM directories
+
+On startup it printed `Reclaimed 2 dangling VM data dir(es)`, which is what clears the small
+leftover directories a crashed or force-killed run leaves in the cache. Worth knowing before
+reporting those as a leak.
+
+## The default listen address is derived, not hard-coded
+
+It is a Unix socket under `XDG_RUNTIME_DIR` (`unix:///run/user/<uid>/smolvm.sock`), not a fixed
+uid, despite how the help text reads when your uid happens to be 501.
+
+## `serve openapi` writes to stdout by default
+
+Pass `-o`, or you will paste a 150 KB spec into your terminal. On Windows it writes its
+confirmation to stderr, which PowerShell renders as an error record even though the file is
+written and the exit code is 0.
+
+## There is no authentication of any kind
+
+`serve start` exposes create, exec and file routes with no TLS, token or auth flag. On loopback
+that is a single-user boundary; the Unix socket, whose file permissions are the boundary, is the
+safer default and is why it is smolvm's default and this packet's.
+
+## Field names, versions and error bodies
+
+Those have their own page: `references/api-fields.md`. The short version is that unknown fields
+are accepted with 200 and ignored, `network` and `memoryMb` are not `net` and `memory`, and the
+version in the exported spec is not the binary's.

--- a/skills/local-api/references/windows.md
+++ b/skills/local-api/references/windows.md
@@ -1,0 +1,86 @@
+# The local API on Windows
+
+**Re-run on 2026-09-11 against smolvm v1.14.6** on Windows 11 Home build 10.0.26200.0 UBR 9445
+x86_64 (Intel Core Ultra 9 185H, 31.6 GB), in an elevated session.
+
+The whole lifecycle works, over **loopback TCP only**. The re-run also corrected two things this
+page had wrong, both of which stop a request before it reaches a machine.
+
+## Starting the server
+
+`machine start` on the CLI never returns to a caller that captures its output. The HTTP API is a
+clean way to drive smolvm from PowerShell precisely because it avoids that, but the server itself
+still has to be launched without capturing:
+
+```powershell
+Start-Process -FilePath $exe -ArgumentList @('serve','start','--listen','127.0.0.1:18899') `
+  -RedirectStandardOutput serve.out -RedirectStandardError serve.err -WindowStyle Hidden -PassThru
+```
+
+## What was observed
+
+On v1.14.6, against routes under `/api/v1/`:
+
+```
+openapi info.version : 0.5.2
+health         : {"status":"ok","version":"1.14.6","machines":{"total":1,"running":0},"uptime_seconds":6}
+POST machines  : {"name":"wapi","state":"created","cpus":2,"memoryMb":2048,...,"network":true,...}
+POST start     : {"name":"wapi","state":"running","pid":21368,...,"rssMb":167,...}
+POST exec      : {"exitCode":0,"stdout":"WIN_API_OK\nLinux x86_64\n","stderr":"",...}
+PUT  files     : {"path":"/root/w.txt","size":10}
+GET  files     : WINPAYLOAD
+POST stop      : {"name":"wapi","state":"stopped",...}
+DELETE machine : ok
+GET  machines  : {"machines":[{"name":"wd",...}]}
+http://127.0.0.1:18899/api/v1/machines/nope -> 404 body ''
+```
+
+`serve openapi -o spec.json` wrote 157345 bytes on v1.14.6, and 153291 on v1.14.2.
+
+## Two ways a request fails before it reaches a machine
+
+Both were found by getting them wrong. Neither produces a body you can read.
+
+- **The routes are under `/api/v1/`.** A bare `POST /machines` returns **404** with an empty body,
+  which reads exactly like a missing machine rather than a missing prefix. `serve openapi` is
+  where the full route list comes from.
+- **A bodiless POST needs an explicit content type.** `POST /api/v1/machines/{name}/start` with no
+  body returns **415 Unsupported Media Type**. It succeeds with an empty JSON body and the header
+  set:
+
+  ```powershell
+  Invoke-RestMethod -Method Post -Uri "$base/api/v1/machines/wapi/start" `
+    -Body '{}' -ContentType 'application/json'
+  ```
+
+  The same applies to `stop`.
+
+## Four Windows differences that change how you write a client
+
+- **The Unix socket transport is not applicable.** The default listen address on Unix is
+  `unix://$XDG_RUNTIME_DIR/smolvm.sock`; this run used loopback TCP only and no `--listen unix://`
+  form was attempted. Loopback is therefore the only boundary you have, and there is no
+  authentication, so treat the port as equivalent to a shell on the host.
+- **The create field is `network`, not `net`.** The same as everywhere, but it matters more here
+  because of the next point.
+- **400 and 404 return empty bodies**, still true on v1.14.6. A wrong field name gets no
+  diagnostic at all. On macOS and Linux the same requests come back with
+  `{"error":"...","code":"..."}`, so a client that reads the error text works there and goes
+  silent here. Export the spec and read `components.schemas.CreateMachineRequest` before writing a
+  body.
+- **`serve openapi` reports `info.version "0.5.2"`** while `/health` on the same server reports
+  `1.14.6`. The mismatch survived the version bump. Also true on macOS, so it is not a Windows
+  quirk, but it was found here.
+
+## One result that differs from Linux, and does not clear it
+
+**A file PUT before `start` survived the start on this host**, on the v1.14.2 run; the v1.14.6
+run uploaded after `exec` and did not test the ordering again. On Linux the same sequence lost the
+file. That does not lift the ordering rule in `references/traps.md`: the rule costs nothing, the
+loss is real on Linux, and the Windows result is one run. Upload after a successful `exec`.
+
+## Everything else about Windows
+
+State cannot be relocated and reached 30 GB in one session, `machine list` is not read-only, and
+PowerShell renders the exe's stderr as error records on a fully successful run. Those are in the
+`install` and `teardown` packets.

--- a/skills/local-api/scripts/cleanup.sh
+++ b/skills/local-api/scripts/cleanup.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Delete the machines this packet's scripts created, then prove the host is clean.
+#
+# Only machines recorded in the state file are deleted, so a machine you or
+# another session created by hand is never touched. Scripts record a name by
+# calling: cleanup.sh --record <name>
+#
+# usage: cleanup.sh [--record <name>] [--reap] [--purge]
+#   --record <name>  add a machine name to the state file and exit
+#   --reap           kill leftover VM processes (see the warning it prints)
+#   --purge          also remove the state file once the list is empty
+
+set -uo pipefail
+
+PACKET="local-api"
+PREFIX="smolskill-"
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+STATE_DIR="${SMOLVM_SKILL_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/smolvm-skills}"
+STATE_FILE="$STATE_DIR/$PACKET.machines"
+
+reap=0
+purge=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --record)
+            mkdir -p "$STATE_DIR"
+            printf '%s\n' "$2" >> "$STATE_FILE"
+            exit 0
+            ;;
+        --reap)  reap=1 ;;
+        --purge) purge=1 ;;
+        *) printf 'unknown argument: %s\n' "$1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+if [ -z "$SMOLVM" ]; then
+    printf 'smolvm not found; set SMOLVM to its path\n' >&2
+    exit 2
+fi
+
+case "$(uname -s)" in
+    Darwin) VMS_DIR="$HOME/Library/Caches/smolvm/vms" ;;
+    *)      VMS_DIR="${SMOLVM_DATA_DIR:-$HOME/.cache/smolvm}/vms" ;;
+esac
+VMS_DIR="${SMOLVM_VMS_DIR:-$VMS_DIR}"
+SMOLVM_PREFIX="${SMOLVM_PREFIX:-$HOME/.smolvm}"
+
+# List this HOME's smolvm VM processes, as "pid marker".
+#
+# Two process shapes exist and a reaper has to catch both. The plain
+# `machine run` path EXECS a child whose argv[1] is `_boot-vm` and whose argv[2]
+# is its boot-config path. The pack-run path, which is `--oci-cache` or any
+# `init`, FORKS without execing, so the child inherits the parent's argv and
+# carries no boot-config at all. Matching `_boot-vm` alone is therefore blind to
+# exactly the path whose child survives an interrupt
+# (smol-machines/smolvm#1193): measured on v1.14.6, it reported "none" while two
+# orphaned VMs held 234 MB each.
+#
+# On Linux both shapes rename themselves to `libkrun VM`, the one marker that
+# covers both and that no shell can hold. macOS exposes no rename, so there the
+# executable path scopes the search to this HOME and the parent chain separates
+# a VM from the CLI that started it.
+#
+# `pgrep -f _boot-vm` is not an alternative: it matches any shell whose text
+# contains that string, including this script.
+list_vm_processes() {
+    case "$(uname -s)" in
+        Linux)
+            for p in /proc/[0-9]*; do
+                [ "$(cat "$p/comm" 2>/dev/null)" = "libkrun VM" ] || continue
+                pid="${p#/proc/}"
+                cfg="$(tr '\0' '\n' < "$p/cmdline" 2>/dev/null | sed -n '3p')"
+                case "$cfg" in
+                    "$VMS_DIR"/*) printf '%s %s\n' "$pid" "$cfg"; continue ;;
+                esac
+                # Forked shape: nothing in argv identifies it, so scope by the
+                # binary it is running.
+                case "$(readlink "$p/exe" 2>/dev/null)" in
+                    "$SMOLVM_PREFIX"/*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;;
+                esac
+            done
+            ;;
+        Darwin)
+            # shellcheck disable=SC2009  # pgrep cannot return ppid and the full
+            # command together, and pgrep -f matches this script's own text.
+            own=" $(ps -axo pid=,command= 2>/dev/null | grep -F "$SMOLVM_PREFIX/smolvm-bin" | awk '{print $1}' | tr '\n' ' ') "
+            ps -axo pid=,ppid=,command= 2>/dev/null | while read -r pid ppid rest; do
+                case "$rest" in "$SMOLVM_PREFIX"/smolvm-bin*) ;; *) continue ;; esac
+                case "$rest" in
+                    *" _boot-vm "*) printf '%s %s\n' "$pid" "${rest#* _boot-vm }"; continue ;;
+                esac
+                # Forked shape: its parent is the CLI that started it, or init
+                # once that CLI is gone.
+                if [ "$ppid" = 1 ]; then
+                    printf '%s orphaned-under %s\n' "$pid" "$SMOLVM_PREFIX"
+                else
+                    case "$own" in *" $ppid "*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;; esac
+                fi
+            done
+            ;;
+    esac
+}
+
+# 1. Delete recorded machines. --force is not optional: without it the command
+# prompts, defaults to No, and leaves the machine in place while the script
+# carries on. --cascade removes branch children, which otherwise block the
+# delete.
+if [ -s "$STATE_FILE" ]; then
+    while read -r name; do
+        [ -n "$name" ] || continue
+        case "$name" in "$PREFIX"*) ;; *)
+            printf 'skipping %s: not created by this packet (no %s prefix)\n' "$name" "$PREFIX"
+            continue ;;
+        esac
+        "$SMOLVM" machine stop   --name "$name" >/dev/null 2>&1
+        "$SMOLVM" machine delete --name "$name" --force --cascade 2>&1 | sed 's/^/  /'
+    done < "$STATE_FILE"
+fi
+
+# 1b. Stop the API server, AFTER the machines are gone. Shutting it down does
+# not stop machines: it prints "Shutting down server (VMs continue running)..."
+# and leaves them with nothing managing them.
+if [ -s "$STATE_DIR/local-api.pid" ]; then
+    apipid="$(cat "$STATE_DIR/local-api.pid")"
+    if kill "$apipid" 2>/dev/null; then
+        printf 'api_server=stopped pid=%s\n' "$apipid"
+    else
+        printf 'api_server=not_running pid=%s\n' "$apipid"
+    fi
+    rm -f "$STATE_DIR/local-api.pid"
+    listen="$(cat "$STATE_DIR/local-api.listen" 2>/dev/null)"
+    case "$listen" in unix://*) rm -f "${listen#unix://}" ;; esac
+    rm -f "$STATE_DIR/local-api.listen"
+fi
+
+# 2. An ephemeral machine's entry retires after the run returns, not with it.
+# Asserting an empty list immediately fails on a healthy host.
+sleep 20
+
+# 3. Assert the value, not the exit code.
+listing="$("$SMOLVM" machine list 2>&1)"
+if printf '%s' "$listing" | grep -q 'No machines found'; then
+    printf 'machines=clean\n'
+    [ "$purge" -eq 1 ] && rm -f "$STATE_FILE"
+else
+    printf 'machines=remaining\n'
+    printf '%s\n' "$listing" | sed 's/^/  /'
+fi
+
+# 4. Report VM processes an interrupt left behind. Ctrl-C does not stop a
+# machine: the VM outlives the CLI and `machine list` cannot see it, so this is
+# the only route to it. Only processes whose boot config lives under this HOME's
+# smolvm state are listed, so a VM another session started is left alone.
+found=0
+while read -r pid cfg; do
+    [ -n "$pid" ] || continue
+    found=1
+    printf 'vm_process=%s config=%s\n' "$pid" "$cfg"
+    if [ "$reap" -eq 1 ]; then
+        kill -9 "$pid" 2>/dev/null && printf '  killed %s\n' "$pid"
+    fi
+done <<EOF
+$(list_vm_processes)
+EOF
+
+if [ "$found" -eq 0 ]; then
+    printf 'vm_processes=none\n'
+elif [ "$reap" -eq 0 ]; then
+    printf 'rerun with --reap to kill them\n'
+fi

--- a/skills/local-api/scripts/lifecycle-check.sh
+++ b/skills/local-api/scripts/lifecycle-check.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Drive one machine through its whole lifecycle over HTTP and assert every
+# result from the response body.
+#
+# usage: lifecycle-check.sh [<name>]      (default smolskill-api)
+#
+# Reads the listen address serve-start.sh recorded. Two rules run through the
+# whole script:
+#
+#   1. A failing guest command still returns HTTP 200. Assert exitCode from the
+#      body, never the status line.
+#   2. Upload files only AFTER the workload container is running. An upload
+#      before that returns 200 with the path and byte count, is readable for a
+#      moment, and is then gone for good.
+
+set -uo pipefail
+
+NAME="${1:-smolskill-api}"
+here="$(cd "$(dirname "$0")" && pwd)"
+STATE_DIR="${SMOLVM_SKILL_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/smolvm-skills}"
+
+LISTEN="$(cat "$STATE_DIR/local-api.listen" 2>/dev/null)"
+if [ -z "$LISTEN" ]; then
+    printf 'no server recorded; run serve-start.sh first\n' >&2
+    exit 2
+fi
+
+case "$LISTEN" in
+    unix://*) CURLOPTS=(-s --unix-socket "${LISTEN#unix://}"); BASE="http://localhost" ;;
+    *)        CURLOPTS=(-s); BASE="http://$LISTEN" ;;
+esac
+api() { curl "${CURLOPTS[@]}" "$@"; }
+
+fail=0
+check() {
+    if [ "$2" = "$3" ]; then
+        printf '%s=ok (%s)\n' "$1" "$2"
+    else
+        printf '%s=FAIL expected=%s actual=%s\n' "$1" "$3" "$2"
+        fail=1
+    fi
+}
+jget() { python3 -c 'import json,sys;d=json.load(sys.stdin);print(d.get(sys.argv[1],""))' "$1"; }
+
+# 1. Create. The field names are the schema's, not the CLI's flags: `network`,
+# not `net`; `memoryMb`, not `memory`. Unknown fields are accepted with 200 and
+# silently ignored, and the machine then fails two calls later with a message
+# about the image. Export the spec rather than guessing:
+#   smolvm serve openapi -o ./openapi.json
+# `cmd` gives the machine a workload that stays up. Without it the image's own
+# CMD becomes the persistent workload, and for an interpreter image that exits
+# at once: the container is relaunched and an exec can land in the gap, coming
+# back as exitCode 1 with an empty stdout AND an empty stderr, which is quieter
+# than the CLI's equivalent failure. Seen once in this packet's own run.
+created="$(api -X POST "$BASE/api/v1/machines" -H 'content-type: application/json' \
+    -d "{\"name\":\"$NAME\",\"image\":\"python:3.12-alpine\",\"network\":true,\"memoryMb\":2048,\"cmd\":[\"sh\",\"-c\",\"while true; do sleep 3600; done\"]}")"
+check created_state "$(printf '%s' "$created" | jget state)" created
+"$here/cleanup.sh" --record "$NAME"
+
+# 2. Start.
+started="$(api -X POST "$BASE/api/v1/machines/$NAME/start" -H 'content-type: application/json' -d '{}')"
+check started_state "$(printf '%s' "$started" | jget state)" running
+
+# 3. Wait for the workload container by asserting a value it produced. This is
+# the gate the upload below depends on.
+# 120 s: six times the slowest workload-container start observed while building
+# this packet, on the slower of the two hosts.
+ready=no
+waited=0
+while [ "$waited" -lt 120 ]; do
+    out="$(api -X POST "$BASE/api/v1/machines/$NAME/exec" -H 'content-type: application/json' \
+        -d '{"command":["sh","-c","echo WORKLOAD_READY"]}' | jget stdout)"
+    case "$out" in WORKLOAD_READY*) ready=yes; break ;; esac
+    sleep 1
+    waited=$((waited + 1))
+done
+printf 'workload_ready_after_s=%s\n' "$waited"
+check workload_ready "$ready" yes
+
+# 4. Exec, asserting exitCode from the body.
+execd="$(api -X POST "$BASE/api/v1/machines/$NAME/exec" -H 'content-type: application/json' \
+    -d '{"command":["sh","-c","echo API_EXEC_OK; uname -s"]}')"
+check exec_exit_code "$(printf '%s' "$execd" | jget exitCode)" 0
+case "$(printf '%s' "$execd" | jget stdout)" in
+    API_EXEC_OK*) printf 'exec_stdout=ok\n' ;;
+    *) printf 'exec_stdout=FAIL actual=%s\n' "$(printf '%s' "$execd" | jget stdout)"; fail=1 ;;
+esac
+
+# A command that fails inside the guest is still HTTP 200. Prove the assertion
+# that catches it actually catches it.
+failing="$(api -X POST "$BASE/api/v1/machines/$NAME/exec" -H 'content-type: application/json' \
+    -d '{"command":["sh","-c","exit 3"]}')"
+check failing_exec_exit_code "$(printf '%s' "$failing" | jget exitCode)" 3
+
+# 5. Stream. One event per line, then a terminal exit event.
+# shellcheck disable=SC2016  # $i is the guest shell's loop variable
+stream="$(api -N -X POST "$BASE/api/v1/machines/$NAME/exec/stream" -H 'content-type: application/json' \
+    -d '{"command":["sh","-c","for i in 1 2 3; do echo line$i; sleep 1; done"]}')"
+check stream_lines "$(printf '%s' "$stream" | grep -c '^data: line')" 3
+case "$stream" in *'event: exit'*) printf 'stream_exit_event=ok\n' ;; *) printf 'stream_exit_event=FAIL\n'; fail=1 ;; esac
+
+# 6. Files, now that the container is up. Absolute path, URL-encoded.
+api -X PUT "$BASE/api/v1/machines/$NAME/files/%2Ftmp%2Fabs.txt" --data-binary 'PAYLOAD123' >/dev/null
+check file_roundtrip "$(api "$BASE/api/v1/machines/$NAME/files/%2Ftmp%2Fabs.txt")" PAYLOAD123
+
+# 7. Stop and delete. Delete machines BEFORE the server goes away: shutting the
+# server down does not stop them, it orphans them.
+api -X POST "$BASE/api/v1/machines/$NAME/stop" -H 'content-type: application/json' -d '{}' >/dev/null
+api -X DELETE "$BASE/api/v1/machines/$NAME" >/dev/null
+check machines_empty "$(api "$BASE/api/v1/machines")" '{"machines":[]}'
+
+if [ "$fail" -eq 0 ]; then printf 'result=lifecycle_ok\n'; else printf 'result=FAILED\n'; fi
+exit "$fail"

--- a/skills/local-api/scripts/preflight.sh
+++ b/skills/local-api/scripts/preflight.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Report whether this host can run the local HTTP API. Read-only: starts no VM,
+# starts no server, writes no smolvm state.
+#
+# Output is one key=value per line so a caller can parse it. The last line is
+# always result=ready or result=blocked.
+
+set -uo pipefail
+
+VERIFIED_VERSION="1.14.6"
+
+emit() { printf '%s=%s\n' "$1" "$2"; }
+
+blocked=0
+note() { printf 'note=%s\n' "$1"; }
+
+# --- the binary --------------------------------------------------------------
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+if [ -z "$SMOLVM" ]; then
+    emit smolvm_installed no
+    emit smolvm_version ""
+    blocked=1
+else
+    emit smolvm_installed yes
+    version="$("$SMOLVM" --version 2>/dev/null | awk '{print $NF}')"
+    emit smolvm_version "${version:-unknown}"
+fi
+
+emit verified_version "$VERIFIED_VERSION"
+if [ -n "${version:-}" ] && [ "$version" != "unknown" ]; then
+    if [ "$version" = "$VERIFIED_VERSION" ]; then
+        emit version_status match
+    else
+        newest="$(printf '%s\n%s\n' "$version" "$VERIFIED_VERSION" | sort -V | tail -1)"
+        if [ "$newest" = "$version" ]; then
+            emit version_status newer
+            note "this packet was verified on $VERIFIED_VERSION and the binary is $version; flags and messages move every release, so check the output against the binary before trusting a step here"
+        else
+            emit version_status older
+            note "this packet was verified on $VERIFIED_VERSION and the binary is $version"
+        fi
+    fi
+else
+    emit version_status unknown
+fi
+
+# --- platform ----------------------------------------------------------------
+
+kernel="$(uname -s)"
+arch="$(uname -m)"
+case "$arch" in aarch64|arm64) arch=aarch64 ;; esac
+
+case "$kernel" in
+    Darwin)
+        emit platform "darwin-$arch"
+        emit accel hvf
+        emit macos_version "$(sw_vers -productVersion)"
+        hv="$(sysctl -n kern.hv_support 2>/dev/null)"
+        if [ "$hv" = "1" ]; then emit accel_access ok; else emit accel_access denied; blocked=1; fi
+        if [ "$arch" != "aarch64" ]; then
+            emit hardware_verified no
+            note "Intel Mac is not verified by this packet; the installer accepts it and nothing here was run on one"
+        else
+            emit hardware_verified yes
+        fi
+        # A VM's agent socket lives under the cache directory. macOS sockaddr_un
+        # holds 104 bytes including the terminator.
+        sock="$HOME/Library/Caches/smolvm/vms/0123456789abcdef/agent.sock"
+        len=${#sock}
+        emit socket_path_bytes "$len"
+        if [ "$len" -gt 100 ]; then
+            emit socket_path_status too_long
+            blocked=1
+            note "HOME is too deep: every VM start will fail with krun_start_enter -22, whose text blames disks and device options. Install under a shorter HOME."
+        else
+            emit socket_path_status ok
+        fi
+        emit unsupported "vulkan,cuda"
+        emit unix_socket_transport yes
+        ;;
+    Linux)
+        emit platform "linux-$arch"
+        emit accel kvm
+        emit socket_path_status n_a
+        if [ ! -e /dev/kvm ]; then
+            emit accel_access missing
+            blocked=1
+            note "/dev/kvm does not exist; this host has no KVM"
+        elif [ -r /dev/kvm ] && [ -w /dev/kvm ]; then
+            emit accel_access ok
+        else
+            emit accel_access denied
+            blocked=1
+            note "your user cannot open /dev/kvm. The installer warns and continues, so a successful install says nothing about whether a VM will start. Fix: sudo usermod -aG kvm \$USER, then run the next command through sg kvm -c '...' rather than logging out."
+        fi
+        emit unsupported "vulkan"
+        emit unix_socket_transport yes
+        ;;
+    *)
+        emit platform "unsupported-$kernel"
+        emit accel unknown
+        emit accel_access unknown
+        blocked=1
+        emit unix_socket_transport no
+        note "this script covers macOS and Linux. On Windows the API works over loopback TCP only, and no unix:// listen form was ever attempted. See references/windows.md, written from a run and not re-run by this packet."
+        ;;
+esac
+
+# The API has no TLS, token or auth flag of any kind. Anyone who can reach the
+# listener can create machines, exec in them and read their files, so which
+# transport you choose IS the access control.
+emit auth none
+if command -v curl >/dev/null 2>&1; then emit curl present; else emit curl absent; blocked=1; fi
+if command -v python3 >/dev/null 2>&1; then emit python3 present; else emit python3 absent; blocked=1; fi
+
+if [ "$blocked" -eq 0 ]; then emit result ready; else emit result blocked; fi

--- a/skills/local-api/scripts/serve-start.sh
+++ b/skills/local-api/scripts/serve-start.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Start the local HTTP API and wait until it answers, then print how to reach it.
+#
+# usage: serve-start.sh [--listen <addr>]
+#   default: a Unix socket under this packet's state directory.
+#
+# A Unix socket is the default here for the same reason it is smolvm's: the API
+# has no authentication of any kind, so the socket's file permissions are the
+# only boundary there is. Over loopback TCP the boundary is the whole machine.
+
+set -uo pipefail
+
+STATE_DIR="${SMOLVM_SKILL_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/smolvm-skills}"
+mkdir -p "$STATE_DIR"
+
+LISTEN="unix://$STATE_DIR/local-api.sock"
+if [ "${1:-}" = "--listen" ]; then LISTEN="$2"; fi
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+if [ -z "$SMOLVM" ]; then
+    printf 'smolvm not found; set SMOLVM to its path\n' >&2
+    exit 2
+fi
+
+case "$LISTEN" in
+    unix://*)
+        SOCK="${LISTEN#unix://}"
+        rm -f "$SOCK"
+        CURLOPTS=(-s --unix-socket "$SOCK")
+        BASE="http://localhost"
+        ;;
+    *)
+        CURLOPTS=(-s)
+        BASE="http://$LISTEN"
+        ;;
+esac
+
+"$SMOLVM" serve start --listen "$LISTEN" > "$STATE_DIR/local-api.log" 2>&1 &
+pid=$!
+printf '%s\n' "$pid" > "$STATE_DIR/local-api.pid"
+printf '%s\n' "$LISTEN" > "$STATE_DIR/local-api.listen"
+
+# Assert a value from /health, not that the process is alive: the server writes
+# its listening line before it can answer, and a dead server leaves a stale pid.
+# 60 s: the server answered /health in 1 s on both hosts here. This is the
+# margin for a loaded host, not an expected wait.
+health=""
+waited=0
+while [ "$waited" -lt 60 ]; do
+    health="$(curl "${CURLOPTS[@]}" "$BASE/health" 2>/dev/null)"
+    case "$health" in *'"status":"ok"'*) break ;; esac
+    sleep 1
+    waited=$((waited + 1))
+done
+
+case "$health" in
+    *'"status":"ok"'*)
+        printf 'listen=%s\n' "$LISTEN"
+        printf 'pid=%s\n' "$pid"
+        printf 'health=%s\n' "$health"
+        printf 'ready_after_s=%s\n' "$waited"
+        printf 'result=serving\n'
+        ;;
+    *)
+        printf 'result=failed\n'
+        printf 'log:\n'
+        sed 's/^/  /' "$STATE_DIR/local-api.log"
+        exit 1
+        ;;
+esac
+
+# `serve start` also clears VM directories a crashed or force-killed run left
+# behind, which is worth knowing before reporting those as a leak.
+if grep -q 'Reclaimed' "$STATE_DIR/local-api.log" 2>/dev/null; then
+    grep 'Reclaimed' "$STATE_DIR/local-api.log" | sed 's/^/note: /'
+fi

--- a/skills/pack/SKILL.md
+++ b/skills/pack/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: pack
+description: Turns an image, or a machine already provisioned, into a single self-contained artifact that runs on another compatible host. Use when shipping a prepared environment as one file, when a packed artifact runs but the state installed into it is missing, when pack create --from-vm fails with a ready timeout that names nothing, when an export is refused because the machine is a fork clone, or when deciding whether to pack from an image or from a machine. Do not use it to keep a machine you re-enter, which is the dev-env packet, or to run untrusted code, which is the sandbox packet.
+---
+
+# Packing a machine into a portable artifact
+
+Verified on **smolvm v1.14.6** on macOS arm64 and Linux aarch64, 2026-09-11. Done means the
+artifact runs a command in a real VM and, for a machine pack, **the state you installed is still
+inside it**.
+
+**The assertion that matters is a value, not a boot.** A pack that lost its rootfs still boots,
+still prints a guest kernel and still exits zero. The only thing that separates a good artifact
+from an empty one is a marker written into the source machine before packing and read back out of
+the artifact afterwards, which is what `pack-machine.sh` and `verify-pack.sh` do between them.
+
+## Procedure
+
+**1. Preflight.** Read-only: starts no VM, packs nothing.
+
+```bash
+scripts/preflight.sh
+```
+
+The line to read is `exporter_memory_ok`. `pack create --from-vm` starts an exporter VM whose
+memory is **hardcoded to 8192 MiB** with no flag and no environment variable, and on a host that
+cannot give it that the export fails as `agent did not become ready within 30 seconds`, which
+mentions neither memory nor the exporter. **This preflight is the only place that failure has a
+name.** It is a warning and not a gate, because the figure is a cap rather than a reservation: see
+"What the memory line does and does not promise".
+
+**2. Pack from an image**, when you want a runnable artifact of a stock image.
+
+```bash
+scripts/pack-image.sh                       # alpine, ./from-image
+scripts/pack-image.sh python:3.12-alpine ./mypack
+```
+
+This path starts no exporter, so the memory line does not apply to it. **If you pass a custom
+output, pass it to the verify step too** (`verify-pack.sh --image ./mypack`), or that step finds
+nothing at its defaults and tells you so rather than passing.
+
+**3. Pack from a machine you provisioned**, when the point is the state in it.
+
+```bash
+scripts/pack-machine.sh                     # smolskill-golden, ./from-vm
+```
+
+It creates the machine with a workload that stays up, waits for a value from it, writes a marker,
+**asserts the marker on the source**, stops the machine and exports it. The source assertion is
+not ceremony: packing a machine whose provisioning silently failed produces an artifact that runs
+perfectly and contains nothing, and nothing downstream will tell you.
+
+**4. Verify.** Both halves.
+
+```bash
+scripts/verify-pack.sh
+```
+
+```
+image_pack_is_a_vm=ok (Linux)
+image_pack_second_run=ok (SECOND_RUN_OK)
+pack_cache_entries=2
+image_pack_reused_cache=ok (2)
+machine_pack_carried_rootfs=ok (PACKED_STATE_PRESENT)
+machine_pack_is_a_vm=ok (Linux)
+result=artifacts_good (2 of 2 artifacts)
+```
+
+`machine_pack_carried_rootfs` is the load-bearing line. The rest is context.
+
+**Verifying nothing is not a pass.** Point it at artifacts that are not there and it says
+`result=nothing_verified` and exits non-zero, because a green line over zero artifacts is the same
+false clean the marker exists to prevent.
+
+**5. Clean up.**
+
+```bash
+scripts/cleanup.sh --purge --artifacts ./from-image ./from-vm
+```
+
+It prunes each recorded machine while it still exists, deletes it, removes both stubs and their
+sidecars, and runs `pack prune`. **`smolvm machine prune` with no argument does not run on this
+release**; the form is `--name <NAME>`.
+
+## What an artifact is, and what it carries
+
+A pack is **two files**: a stub binary and a `<stub>.smolmachine` sidecar. `--output` names the
+**stub**; the sidecar is created for you. Keep them together.
+
+```
+Mode:       container
+Image:      python:3.12-alpine
+Platform:   linux/arm64
+CPUs:       4
+Memory:     8192 MiB
+Checksum:   94baf297
+```
+
+That `Memory` is the **packed artifact's** runtime memory, which `pack create --mem` can set. It
+is not the exporter's, which nothing can set.
+
+## What the memory line does and does not promise
+
+The exporter's 8192 MiB is a **cap, not a reservation**, so a host reporting less available memory
+can still export. Measured on this release: the export succeeded on a Mac whose preflight reported
+`free_memory_mib=4990`, well under the figure, and it is the binding constraint on a small Linux
+box where it fails with the unnamed ready timeout. So the preflight **warns and does not block**,
+and `result=ready` with `exporter_memory_ok=no` means "this may work, and if it does not, here is
+why".
+
+## Traps
+
+Full detail with the evidence in `references/traps.md`. The ones that cost the most:
+
+- **`--output` names the stub, not the sidecar.** Passing `--output foo.smolmachine` fails; the
+  scripts refuse it before the CLI does.
+- **The stub takes a subcommand, and a bare `--` is rejected** with a tip that does not mention
+  `run`. The working form is `./from-vm run -- sh -c '...'`.
+- **`pack run` takes `--sidecar <PATH>`, not a positional path**, and getting it wrong reports
+  that your sidecar is not an executable in `$PATH`.
+- **Reported sizes understate the stub on disk**, by about 8.4 MB on Linux aarch64 and about
+  10 MB on macOS arm64, where an extra signing step runs. The sidecar figure is accurate.
+- **A fork clone is refused at export**, by design, with a message naming both remedies: pack the
+  golden it came from, or recreate the state in a machine that was never branched.
+- **A checkpoint restore packs and carries its rootfs**, and the restore path is
+  `machine create --from`. There is no `machine restore` subcommand.
+- **On Linux, `SMOLVM_DATA_DIR` moves where the agent rootfs is looked up and the installer does
+  not write it there**, so an isolated data root needs the rootfs copied in before the first boot.
+
+## Security defaults, and why they are the defaults
+
+- **An artifact is a filesystem you are handing to someone else.** Whatever was in the source
+  machine's rootfs is in the sidecar, including anything a provisioning step left in a shell
+  history, a cache, or a file under `/root`. The marker this packet writes is deliberately inert;
+  treat anything else you put in the source as published.
+- **Packing does not narrow what the artifact may do.** The recorded entrypoint, network setting
+  and memory come from the source, so a machine created with `--net` produces an artifact that
+  expects a network. Decide that on the source, not afterwards.
+- **The scripts pack only a machine they created**, named under the `smolskill-` prefix and
+  recorded in a state file, and cleanup deletes only those. A machine you or another session made
+  by hand is never exported and never deleted.
+- **`pack run` takes the forked boot path**, so a cancelled run leaves a VM the CLI cannot see.
+  `cleanup.sh` is the way to stop one, and its process scan catches both VM shapes. Ctrl-C is not.
+- **Nothing here escalates privilege**, edits smolvm configuration or touches `~/.smolvm`.
+
+## Platform arms
+
+- **macOS arm64**: verified on v1.14.6. An extra `Signing binary with hypervisor entitlements`
+  step runs here that does not on Linux.
+- **Linux aarch64**: verified on v1.14.6.
+- **Linux x86_64**: verified in the material behind this packet on v1.14.6, including the branched
+  and restored cases. Not re-run here.
+
+**Both hosts run here produce `linux/arm64` artifacts**, so two hosts is two hosts and not two
+artifact architectures. The `linux/amd64` side rests on the x86_64 run above.
+- **Windows x86_64**: `references/windows.md`, **re-run on 2026-09-11 against v1.14.6** on
+  Windows 11 Home build 10.0.26200.0 UBR 9445. Both paths work: the image pack, and `--from-vm`
+  for the first time there, with the marker read back out of the artifact. The stub is written
+  without `.exe` and will not run until it and its sidecar are renamed.
+
+## Eval prompts, and what they produced
+
+Run 2026-09-11 PT against v1.14.6 from the published release, on macOS 26.6.2 arm64 and Lima
+`linux-kvm` (Ubuntu 24.04 aarch64). Output is verbatim.
+
+**1. "Ship this provisioned machine to another host as one file."**
+
+Both hosts, through `pack-machine.sh` then `verify-pack.sh`:
+
+```
+source_marker=PACKED_STATE_PRESENT
+result=packed
+
+machine_pack_carried_rootfs=ok (PACKED_STATE_PRESENT)
+machine_pack_is_a_vm=ok (Linux)
+result=artifacts_good
+```
+
+macOS produced a 31572 KB sidecar in 3 s, Linux aarch64 a 31491 KB sidecar in 32 s.
+
+**2. "The artifact runs fine but the thing I installed is not in it."**
+
+That is the failure this packet is shaped against, and the answer is that running proves nothing.
+`verify-pack.sh` asserts the marker rather than the boot, and `pack-machine.sh` refuses to export
+at all if the marker is not on the source first:
+
+```
+result=FAILED the source does not carry the marker, so packing it would produce an empty artifact
+```
+
+The image pack is the control: it runs and does not carry the machine's state.
+
+**3. "`pack create --from-vm` fails with `agent did not become ready within 30 seconds` and says
+nothing else."**
+
+Run the preflight, which is the only place that failure is named:
+
+```
+exporter_memory_mib=8192
+free_memory_mib=4990
+exporter_memory_ok=no
+note=free memory is below the exporter's fixed 8192 MiB. If pack create --from-vm fails with
+'agent did not become ready within 30 seconds', that is this, and the message will not mention
+memory. Packing from an image starts no exporter and is unaffected.
+```
+
+On the hosts here the export then **succeeded anyway**, on the Mac reporting 4990 MiB, which is
+why that line warns rather than blocks.
+
+## What was not run
+
+- **Cross-platform rehydration**, except for one pair. An arm64 stub built on macOS was carried to
+  x86_64 Windows on 2026-09-11 and **the OS loader refuses it before any smolvm code runs**, so an
+  artifact has to be built on the platform it will run on. Nothing tests the reverse direction, or
+  two hosts of the same architecture on different operating systems.
+- **`pack push`, `pack pull` and `pack inspect` against a registry.** Nothing here touched a
+  registry.
+- **Windows through these scripts.** `scripts/*.sh` are POSIX shell and do not run there; the
+  2026-09-11 v1.14.6 run on Windows issued the CLI by hand. `references/windows.md` has it.
+- **The branched and restored sources on these two hosts.** Both are answered on Linux x86_64 in
+  the material behind this packet and are written up in `references/traps.md` as behaviour; they
+  were not re-run on macOS or aarch64.
+
+## Related packets
+
+- `dev-env` for producing the machine that gets packed, and for the `init`-runs-once semantics
+  its provisioning depends on.
+- `install` for the boot this assumes, and `teardown` for the wider cleanup.

--- a/skills/pack/references/traps.md
+++ b/skills/pack/references/traps.md
@@ -1,0 +1,173 @@
+# Pack traps
+
+## Contents
+
+- `--output` names the stub, not the sidecar
+- The stub takes a subcommand, and a bare `--` is rejected
+- `pack run` takes `--sidecar`, not a positional path
+- The exporter's 8192 MiB, and what the failure looks like
+- Verify the state, not the boot
+- Reported sizes understate the stub on disk
+- A fork clone is refused at export
+- A checkpoint restore packs, and the restore path is not `machine restore`
+- An isolated data root on Linux does not carry the agent rootfs
+- `smolvm machine prune` needs a machine, and it starts one
+- On Windows the stub is written without `.exe`
+
+## `--output` names the stub, not the sidecar
+
+Passing `--output foo.smolmachine` fails immediately, and the error is good: it says the sidecar
+is created automatically as `<output>.smolmachine` and to pass `--output ./foo`. Read it rather
+than guessing. `scripts/pack-image.sh` and `scripts/pack-machine.sh` refuse the `.smolmachine`
+form before the CLI sees it.
+
+## On Windows the stub is written without `.exe`
+
+`pack create -o pimg` on Windows writes `pimg` and `pimg.smolmachine`, and PowerShell refuses to
+execute the extensionless stub:
+
+```
+ERROR: Cannot run a document in the middle of a pipeline: C:\...\pimg.
+```
+
+Rename it to `p.exe` with `p.exe.smolmachine` beside it and it runs, printing `PACK_IMG_OK` from
+the packaged entrypoint. The sidecar has to be renamed too, because the stub looks for its own
+name plus `.smolmachine`. Observed on v1.14.6; `references/windows.md` has the run.
+
+## The stub takes a subcommand, and a bare `--` is rejected
+
+```
+$ ./from-vm -- sh -c 'echo hi'
+tip: subcommand 'sh' exists; to use it, remove the '--' before it
+```
+
+The working forms are `./from-vm run -- sh -c '...'` and `./from-vm` alone, which executes the
+packaged entrypoint. The tip does not mention `run`, which is the part that costs the time.
+
+## `pack run` takes `--sidecar`, not a positional path
+
+```
+$ smolvm pack run ./x.smolmachine -- cmd
+executable file `./x.smolmachine` not found in $PATH
+```
+
+The path was consumed as the command to run. Nothing in the message points at `--sidecar`.
+
+## The exporter's 8192 MiB, and what the failure looks like
+
+`pack create --from-vm` starts an exporter VM whose memory is **hardcoded to 8192 MiB**:
+`src/pack_export.rs:345` at `3412bd26`, `memory_mib: 8192`. A second exporter VM at `:914` is
+hardcoded to `cpus: 2, memory_mib: 2048`. A grep of that file for `env::var`, any `SMOLVM_*MEM`
+and `--mem` returns nothing, so **neither is overridable**.
+
+`pack create --mem` sets the **packed artifact's** runtime memory, not the exporter's. The two are
+easy to confuse because `--info` reports the artifact's figure and it is also 8192 by default.
+
+On a host that cannot give the exporter that much, the export fails as:
+
+```
+agent did not become ready within 30 seconds
+```
+
+which names neither memory nor the exporter. `scripts/preflight.sh` is the only place it gets a
+name.
+
+**It is a cap and not a reservation, so the figure does not decide the outcome.** Measured on
+v1.14.6: the export **succeeded** on a Mac whose preflight reported `free_memory_mib=4990`, and
+the same trap was the binding constraint on a 10.9 GiB Linux box in the material behind this
+packet. That is why the preflight warns rather than blocks. The citation has drifted twice, from
+`:299` to `:311` at v1.14.2 to `:345` now, so check the line before quoting it.
+
+## Verify the state, not the boot
+
+**A pack that lost its rootfs still boots, still prints a guest kernel and still exits zero.**
+Packing a machine whose provisioning silently failed produces an artifact that runs perfectly and
+contains nothing. That happened in the runbook session behind this packet: a provisioning `exec`
+had failed unnoticed and the resulting pack reported `MISSING` for both markers.
+
+The shape that makes it impossible is the one these scripts use: write a marker into the source,
+**assert it on the source before packing**, and read it back out of the artifact afterwards.
+`pack-machine.sh` exits non-zero rather than exporting a machine that does not carry its marker.
+
+## Reported sizes understate the stub on disk
+
+`pack create` reports a stub smaller than the file it wrote, so its `total:` understates by the
+same amount. Measured on v1.14.6:
+
+| host | reported | on disk | understated by |
+|---|---|---|---|
+| Linux aarch64 | 30737 KB | 39195 KB | 8458 KB |
+| macOS arm64 | 29643 KB | 39883 KB | 10240 KB |
+
+The macOS gap is larger because an extra `Signing binary with hypervisor entitlements` step runs
+there. The sidecar figures are accurate on both. **Do not size a disk budget or an upload from the
+reported total.**
+
+## A fork clone is refused at export
+
+Packing a branched machine is refused, by design, and the message names both remedies:
+
+```
+machine 'child' is a fork clone of 'src'; its copy-on-write disks cannot be exported
+directly. Export the golden instead, or recreate the state in a non-clone machine and
+export that.
+```
+
+The child itself carries the source's state and runs normally; it is only the export that
+refuses. **So a branched machine is packed through its golden.** No artifact is produced, so there
+is nothing to verify afterwards.
+
+## A checkpoint restore packs, and the restore path is not `machine restore`
+
+A machine restored from a checkpoint packs, runs, and carries its rootfs. This is the case
+[#1174](https://github.com/smol-machines/smolvm/pull/1174) changed, shipped in v1.14.3.
+
+There is **no `machine restore` subcommand**, which is the obvious guess and gives
+`unrecognized subcommand`. The restore path is `machine create --from <PATH>`, the same flag that
+takes a `.smolmachine`, documented as "Create from a `.smolmachine` pack or restore a
+`.smolcheckpoint`".
+
+## An isolated data root on Linux does not carry the agent rootfs
+
+`SMOLVM_DATA_DIR` relocates the whole data root **including where the agent rootfs is looked up**,
+and the installer does not write it there. The first boot under an isolated root fails with:
+
+```
+agent rootfs not found: <data root>/.local/share/smolvm/agent-rootfs
+```
+
+which points at a missing file rather than at the variable that moved it. Copy the installer's
+`agent-rootfs` in first:
+
+```bash
+mkdir -p "$SMOLVM_DATA_DIR/.local/share/smolvm"
+cp -r "$HOME/.local/share/smolvm/agent-rootfs" "$SMOLVM_DATA_DIR/.local/share/smolvm/"
+```
+
+`scripts/preflight.sh` reports `data_root_rootfs=missing` when the variable is set and the rootfs
+is not there.
+
+## `smolvm machine prune` needs a machine, and it starts one
+
+The bare form does not run on v1.14.6:
+
+```
+$ smolvm machine prune
+Usage: smolvm machine prune --name <NAME>
+```
+
+Its own help describes "Remove unused images and layers to free disk space", which reads host
+wide, while `--name` is documented as "Machine to prune". `smolvm pack prune`, which clears cached
+pack extractions, does take no required argument. Any cleanup line that says `smolvm machine
+prune` bare is wrong on this release.
+
+**And the machine form starts the machine to do its work**, observed on Linux aarch64:
+
+```
+Starting machine...
+Removing unreferenced layers...
+No unreferenced layers to remove.
+```
+
+So it is worth running while the machine still exists and before deleting it, which is the order
+`scripts/cleanup.sh` uses. Run after the delete it is a silent no-op.

--- a/skills/pack/references/windows.md
+++ b/skills/pack/references/windows.md
@@ -1,0 +1,120 @@
+# Packing on Windows
+
+## Contents
+
+- What was verified
+- `--from-vm` works here, and the marker proves it
+- The stub is written without `.exe`
+- An artifact built for another architecture is refused by Windows, not by smolvm
+- The template requirement the caveats describe is already satisfied
+- The trap that makes `pack run` look broken
+- What was never run here
+
+**Re-run on 2026-09-11 against smolvm v1.14.6** on Windows 11 Home build 10.0.26200.0 UBR 9445
+x86_64 (Intel Core Ultra 9 185H, 31.6 GB), in an elevated session. `scripts/*.sh` are POSIX shell
+and do not run there, so every command below was issued by hand from PowerShell.
+
+The image path and the sizes in the next section are from the earlier v1.14.2 run on the same host
+and were not measured again. The three sections after it are the v1.14.6 run.
+
+## What was verified
+
+The image path works.
+
+```powershell
+& $exe pack create --image alpine --output "$dir\wpack"
+& $exe pack run --sidecar "$dir\wpack.smolmachine" -- sh -c "echo PACK_RAN_OK"
+& $exe pack run --sidecar "$dir\wpack.smolmachine" --info
+```
+
+Observed:
+
+```
+pack create  in 12.9s
+Creating storage template...
+Packed: ...\wpack (stub: 31615KB, total: 49851KB)
+Assets: ...\wpack.smolmachine (18234KB compressed)
+
+pack run     exitcode 0   PACK_RAN_OK
+pack run --info            Platform: linux/amd64   Memory: 8192 MiB   Checksum: 1f7ced2a
+```
+
+## `--from-vm` works here, and the marker proves it
+
+**First time `pack create --from-vm` has been run on Windows.** A marker was written inside the
+source machine, the machine was packed, and the marker was read back out of the artifact:
+
+```
+----- B. pack create --from-vm (never run on Windows before)
+  Created machine: psrc
+    out: Machine 'psrc' running (PID: 12908)
+    FROMVM_MARKER_0911
+    Stopped machine: psrc
+  Assets: C:\...\pvm.smolmachine (18239KB compressed)
+  artifacts: pvm, pvm.smolmachine
+----- read the marker back out of the artifact
+  FROMVM_MARKER_0911
+```
+
+Reading the marker back out is the assertion, not the boot. The exporter VM and its fixed memory
+behave as `references/traps.md` describes; nothing on this host hit that ceiling.
+
+## The stub is written without `.exe`
+
+`pack create -o <name>` writes the stub with no extension, and PowerShell will not execute it:
+
+```
+  pimg   44354243
+  pimg.smolmachine   18678054
+```
+
+```
+ERROR: Cannot run a document in the middle of a pipeline: C:\...\pimg.
+```
+
+Rename the stub to `p.exe`, keeping `p.exe.smolmachine` beside it, and the same artifact runs:
+
+```
+PACK_IMG_OK
+```
+
+The sidecar has to be renamed with it: the stub looks for `<stub name>.smolmachine`. Still present
+on v1.14.6.
+
+## An artifact built for another architecture is refused by Windows, not by smolvm
+
+An arm64 stub built on macOS with the v1.14.6 darwin release, carried to this x86_64 Windows host:
+
+```
+Program 'parm.exe' failed to run: The specified executable is not a valid application for this OS platform.
+```
+
+The stub is a macOS arm64 binary, so Windows refuses to load it before any smolvm code runs. **This
+is a platform answer rather than a pack-format one**, and it is the cross-architecture answer for
+this pair: an artifact has to be built on the platform it will run on.
+
+## The template requirement the caveats describe is already satisfied
+
+`AGENTS.md` says `pack create` on Windows "needs `storage-template.ext4` /
+`overlay-template.ext4` beside `smolvm.exe` (Windows has no host `mkfs.ext4`)". **The release
+ships both**, uncompressed at 536870912 bytes each, in the same folder as the exe, so the
+requirement is met out of the box and needs no user action.
+
+This is a real platform difference rather than a mistake in the caveat: the Unix releases ship
+those templates as `.zst`, and Windows ships them expanded.
+
+## The trap that makes `pack run` look broken
+
+`pack run` returned **no output at all** under `Start-Process -RedirectStandardOutput`, which
+reads as a silent failure. The same command through `cmd /c "... > out.txt 2>&1"` exits 0 and
+prints `PACK_RAN_OK`.
+
+**Do not conclude `pack run` is broken on Windows from an empty capture.** Check the invocation
+first. This is the same captured-output shape that affects `machine start` there, which the
+`install` packet's Windows page describes in full.
+
+## What was never run here
+
+- **An x86_64 Windows artifact carried to another host.** The pair that was tried is the reverse,
+  above, and it is refused by the OS loader.
+- **`pack push`, `pack pull` and `pack inspect`** against a registry.

--- a/skills/pack/scripts/cleanup.sh
+++ b/skills/pack/scripts/cleanup.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# Delete the machines this packet's scripts created, then prove the host is clean.
+#
+# Only machines recorded in the state file are deleted, so a machine you or
+# another session created by hand is never touched. Scripts record a name by
+# calling: cleanup.sh --record <name>
+#
+# usage: cleanup.sh [--record <name>] [--reap] [--purge] [--artifacts <stub>...]
+#   --record <name>     add a machine name to the state file and exit
+#   --reap              kill leftover VM processes (see the warning it prints)
+#   --purge             also remove the state file once the list is empty
+#   --artifacts <stub>  also remove that stub and its .smolmachine sidecar
+#
+# `pack run` takes the forked boot path, so a cancelled run leaves a VM the CLI
+# cannot see. The process scan below catches both shapes, which is why this
+# script and not Ctrl-C is the way to stop one.
+
+set -uo pipefail
+
+PACKET="pack"
+PREFIX="smolskill-"
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+STATE_DIR="${SMOLVM_SKILL_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/smolvm-skills}"
+STATE_FILE="$STATE_DIR/$PACKET.machines"
+
+reap=0
+purge=0
+ARTIFACTS=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --record)
+            mkdir -p "$STATE_DIR"
+            printf '%s\n' "$2" >> "$STATE_FILE"
+            exit 0
+            ;;
+        --reap)  reap=1 ;;
+        --purge) purge=1 ;;
+        --artifacts) shift; ARTIFACTS="$*"; break ;;
+        *) printf 'unknown argument: %s\n' "$1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+if [ -z "$SMOLVM" ]; then
+    printf 'smolvm not found; set SMOLVM to its path\n' >&2
+    exit 2
+fi
+
+case "$(uname -s)" in
+    Darwin) VMS_DIR="$HOME/Library/Caches/smolvm/vms" ;;
+    *)      VMS_DIR="${SMOLVM_DATA_DIR:-$HOME/.cache/smolvm}/vms" ;;
+esac
+VMS_DIR="${SMOLVM_VMS_DIR:-$VMS_DIR}"
+SMOLVM_PREFIX="${SMOLVM_PREFIX:-$HOME/.smolvm}"
+
+# List this HOME's smolvm VM processes, as "pid marker".
+#
+# Two process shapes exist and a reaper has to catch both. The plain
+# `machine run` path EXECS a child whose argv[1] is `_boot-vm` and whose argv[2]
+# is its boot-config path. The pack-run path, which is `--oci-cache` or any
+# `init`, FORKS without execing, so the child inherits the parent's argv and
+# carries no boot-config at all. Matching `_boot-vm` alone is therefore blind to
+# exactly the path whose child survives an interrupt
+# (smol-machines/smolvm#1193): measured on v1.14.6, it reported "none" while two
+# orphaned VMs held 234 MB each.
+#
+# On Linux both shapes rename themselves to `libkrun VM`, the one marker that
+# covers both and that no shell can hold. macOS exposes no rename, so there the
+# executable path scopes the search to this HOME and the parent chain separates
+# a VM from the CLI that started it.
+#
+# `pgrep -f _boot-vm` is not an alternative: it matches any shell whose text
+# contains that string, including this script.
+list_vm_processes() {
+    case "$(uname -s)" in
+        Linux)
+            for p in /proc/[0-9]*; do
+                [ "$(cat "$p/comm" 2>/dev/null)" = "libkrun VM" ] || continue
+                pid="${p#/proc/}"
+                cfg="$(tr '\0' '\n' < "$p/cmdline" 2>/dev/null | sed -n '3p')"
+                case "$cfg" in
+                    "$VMS_DIR"/*) printf '%s %s\n' "$pid" "$cfg"; continue ;;
+                esac
+                # Forked shape: nothing in argv identifies it, so scope by the
+                # binary it is running.
+                case "$(readlink "$p/exe" 2>/dev/null)" in
+                    "$SMOLVM_PREFIX"/*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;;
+                esac
+            done
+            ;;
+        Darwin)
+            # shellcheck disable=SC2009  # pgrep cannot return ppid and the full
+            # command together, and pgrep -f matches this script's own text.
+            own=" $(ps -axo pid=,command= 2>/dev/null | grep -F "$SMOLVM_PREFIX/smolvm-bin" | awk '{print $1}' | tr '\n' ' ') "
+            ps -axo pid=,ppid=,command= 2>/dev/null | while read -r pid ppid rest; do
+                case "$rest" in "$SMOLVM_PREFIX"/smolvm-bin*) ;; *) continue ;; esac
+                case "$rest" in
+                    *" _boot-vm "*) printf '%s %s\n' "$pid" "${rest#* _boot-vm }"; continue ;;
+                esac
+                # Forked shape: its parent is the CLI that started it, or init
+                # once that CLI is gone.
+                if [ "$ppid" = 1 ]; then
+                    printf '%s orphaned-under %s\n' "$pid" "$SMOLVM_PREFIX"
+                else
+                    case "$own" in *" $ppid "*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;; esac
+                fi
+            done
+            ;;
+    esac
+}
+
+# 1. Delete recorded machines. --force is not optional: without it the command
+# prompts, defaults to No, and leaves the machine in place while the script
+# carries on. --cascade removes branch children, which otherwise block the
+# delete.
+if [ -s "$STATE_FILE" ]; then
+    while read -r name; do
+        [ -n "$name" ] || continue
+        case "$name" in "$PREFIX"*) ;; *)
+            printf 'skipping %s: not created by this packet (no %s prefix)\n' "$name" "$PREFIX"
+            continue ;;
+        esac
+        # Reclaim this machine's cached layers while it still exists. The bare
+        # `smolvm machine prune` the runbooks used is rejected on this release:
+        #     Usage: smolvm machine prune --name <NAME>
+        "$SMOLVM" machine prune --name "$name" 2>&1 | sed 's/^/  /'
+        "$SMOLVM" machine stop   --name "$name" >/dev/null 2>&1
+        "$SMOLVM" machine delete --name "$name" --force --cascade 2>&1 | sed 's/^/  /'
+    done < "$STATE_FILE"
+fi
+
+# 1b. Remove the artifacts named on the command line. A stub and its sidecar are
+# two files and the sidecar is the large one.
+for a in ${ARTIFACTS:-}; do
+    for f in "$a" "$a.smolmachine"; do
+        [ -f "$f" ] && rm -f "$f" && printf 'removed=%s\n' "$f"
+    done
+done
+
+# 1c. Reclaim the pack caches. `pack prune` takes no required argument; the
+# machine form does, and the bare `smolvm machine prune` the runbooks used is
+# rejected outright on this release:
+#     Usage: smolvm machine prune --name <NAME>
+if [ -n "$SMOLVM" ]; then
+    "$SMOLVM" pack prune 2>&1 | sed 's/^/  /'
+fi
+
+# 2. An ephemeral machine's entry retires after the run returns, not with it.
+# Asserting an empty list immediately fails on a healthy host.
+sleep 20
+
+# 3. Assert the value, not the exit code.
+listing="$("$SMOLVM" machine list 2>&1)"
+if printf '%s' "$listing" | grep -q 'No machines found'; then
+    printf 'machines=clean\n'
+    [ "$purge" -eq 1 ] && rm -f "$STATE_FILE"
+else
+    printf 'machines=remaining\n'
+    printf '%s\n' "$listing" | sed 's/^/  /'
+fi
+
+# 4. Report VM processes an interrupt left behind. Ctrl-C does not stop a
+# machine: the VM outlives the CLI and `machine list` cannot see it, so this is
+# the only route to it. Only processes whose boot config lives under this HOME's
+# smolvm state are listed, so a VM another session started is left alone.
+found=0
+while read -r pid cfg; do
+    [ -n "$pid" ] || continue
+    found=1
+    printf 'vm_process=%s config=%s\n' "$pid" "$cfg"
+    if [ "$reap" -eq 1 ]; then
+        kill -9 "$pid" 2>/dev/null && printf '  killed %s\n' "$pid"
+    fi
+done <<EOF
+$(list_vm_processes)
+EOF
+
+if [ "$found" -eq 0 ]; then
+    printf 'vm_processes=none\n'
+elif [ "$reap" -eq 0 ]; then
+    printf 'rerun with --reap to kill them\n'
+fi

--- a/skills/pack/scripts/pack-image.sh
+++ b/skills/pack/scripts/pack-image.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Pack an image into a portable artifact.
+#
+# usage: pack-image.sh [<image>] [<output>]
+#   image   default alpine
+#   output  default ./from-image, and it names the STUB, not the sidecar
+#
+# This path starts no exporter VM, so the free-memory precondition in
+# preflight.sh does not apply to it. Only `--from-vm` does.
+
+set -uo pipefail
+
+IMAGE="${1:-alpine}"
+OUT="${2:-./from-image}"
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+if [ -z "$SMOLVM" ]; then
+    printf 'smolvm not found; set SMOLVM to its path\n' >&2
+    exit 2
+fi
+
+# `--output` names the stub. Passing a .smolmachine here fails immediately, and
+# the error is good, but there is no reason to meet it.
+case "$OUT" in
+    *.smolmachine)
+        printf 'output=%s\n' "$OUT"
+        printf 'result=FAILED --output names the stub, not the sidecar. The sidecar is created for you as <output>.smolmachine, so pass --output %s instead.\n' "${OUT%.smolmachine}"
+        exit 2
+        ;;
+esac
+
+start="$(date +%s)"
+out="$("$SMOLVM" pack create --image "$IMAGE" --output "$OUT" 2>&1)"
+rc=$?
+elapsed=$(( $(date +%s) - start ))
+printf '%s\n' "$out" | sed 's/^/  /'
+
+printf 'image=%s\n' "$IMAGE"
+printf 'elapsed_s=%s\n' "$elapsed"
+
+# Assert the artifact, not the exit code.
+if [ ! -f "$OUT" ] || [ ! -f "$OUT.smolmachine" ]; then
+    printf 'result=FAILED rc=%s (stub or sidecar missing)\n' "$rc"
+    exit 1
+fi
+
+reported_kb="$(printf '%s' "$out" | sed -n 's/.*stub: \([0-9]*\)KB.*/\1/p' | head -1)"
+actual_kb=$(( $(wc -c < "$OUT") / 1024 ))
+printf 'stub_reported_kb=%s\n' "${reported_kb:-unknown}"
+printf 'stub_actual_kb=%s\n' "$actual_kb"
+if [ -n "${reported_kb:-}" ] && [ "$actual_kb" -gt "$reported_kb" ]; then
+    printf 'stub_understated_kb=%s\n' "$(( actual_kb - reported_kb ))"
+    printf 'note=pack create reports a stub smaller than the file on disk, so its total: understates by the same amount. Size a disk budget or an upload from the file, not from the report. The sidecar figure is accurate.\n'
+fi
+printf 'sidecar_kb=%s\n' "$(( $(wc -c < "$OUT.smolmachine") / 1024 ))"
+printf 'result=packed\n'

--- a/skills/pack/scripts/pack-machine.sh
+++ b/skills/pack/scripts/pack-machine.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Provision a machine, prove the state is in it, then pack it.
+#
+# usage: pack-machine.sh [<name>] [<output>] [<image>]
+#   name    default smolskill-golden (the prefix cleanup.sh will delete)
+#   output  default ./from-vm, naming the STUB
+#   image   default python:3.12-alpine
+#
+# The marker written here is the whole point of the packet. A pack that lost its
+# rootfs still boots, still prints a guest kernel and still exits zero, so the
+# only assertion that separates a good artifact from an empty one is a value put
+# into the source and read back out of the artifact. This script writes it and
+# asserts it ON THE SOURCE before packing; verify-pack.sh reads it back.
+#
+# This path starts an exporter VM whose memory is hardcoded to 8192 MiB. If it
+# fails with a ready timeout, run preflight.sh: that is the only place the
+# failure gets a name.
+
+set -uo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+NAME="${1:-smolskill-golden}"
+OUT="${2:-./from-vm}"
+IMAGE="${3:-python:3.12-alpine}"
+MARKER="PACKED_STATE_PRESENT"
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+if [ -z "$SMOLVM" ]; then
+    printf 'smolvm not found; set SMOLVM to its path\n' >&2
+    exit 2
+fi
+
+case "$NAME" in
+    smolskill-*) ;;
+    *) printf 'name must start with smolskill- so cleanup.sh will delete it\n' >&2; exit 2 ;;
+esac
+case "$OUT" in
+    *.smolmachine) printf 'result=FAILED --output names the stub; pass %s\n' "${OUT%.smolmachine}"; exit 2 ;;
+esac
+
+# A workload that stays up, so exec does not race a relaunching container.
+"$SMOLVM" machine create --name "$NAME" --net --image "$IMAGE" \
+    -- sh -c 'while true; do sleep 3600; done' 2>&1 | sed 's/^/  /'
+"$here/cleanup.sh" --record "$NAME"
+"$SMOLVM" machine start --name "$NAME" 2>&1 | sed 's/^/  /'
+
+# Wait for a value, not for an empty result or a zero exit code: an exec in the
+# startup window answers with a message and still exits zero.
+waited=0
+while [ "$waited" -lt 120 ]; do
+    probe="$("$SMOLVM" machine exec --name "$NAME" -- sh -c 'echo READY' 2>&1 | tr -d '\r')"
+    [ "$probe" = "READY" ] && break
+    sleep 1
+    waited=$((waited + 1))
+done
+printf 'workload_ready_after_s=%s\n' "$waited"
+if [ "$probe" != "READY" ]; then
+    printf 'result=FAILED the machine never became usable, so there is nothing to pack\n'
+    exit 1
+fi
+
+"$SMOLVM" machine exec --name "$NAME" -- sh -c "echo $MARKER > /marker.txt" >/dev/null 2>&1
+
+# Assert on the SOURCE. Packing a machine that was never provisioned produces an
+# artifact that runs fine and contains nothing, and that mistake is invisible
+# until the artifact is read.
+src_marker="$("$SMOLVM" machine exec --name "$NAME" -- cat /marker.txt 2>&1 | tr -d '\r')"
+printf 'source_marker=%s\n' "$src_marker"
+if [ "$src_marker" != "$MARKER" ]; then
+    printf 'result=FAILED the source does not carry the marker, so packing it would produce an empty artifact\n'
+    exit 1
+fi
+
+"$SMOLVM" machine stop --name "$NAME" 2>&1 | sed 's/^/  /'
+
+start="$(date +%s)"
+out="$("$SMOLVM" pack create --from-vm "$NAME" --output "$OUT" 2>&1)"
+rc=$?
+elapsed=$(( $(date +%s) - start ))
+printf '%s\n' "$out" | sed 's/^/  /'
+printf 'elapsed_s=%s\n' "$elapsed"
+
+if [ ! -f "$OUT" ] || [ ! -f "$OUT.smolmachine" ]; then
+    printf 'result=FAILED rc=%s\n' "$rc"
+    case "$out" in
+        *"did not become ready"*)
+            printf 'diagnosis: the exporter VM did not come up. Its memory is hardcoded to 8192 MiB and the message never says so. Run scripts/preflight.sh and read free_memory_mib against exporter_memory_mib.\n' ;;
+        *"fork clone"*)
+            printf 'diagnosis: this machine is a branch child and its copy-on-write disks cannot be exported. Pack the golden it came from, or recreate the state in a machine that was never branched.\n' ;;
+    esac
+    exit 1
+fi
+
+printf 'sidecar_kb=%s\n' "$(( $(wc -c < "$OUT.smolmachine") / 1024 ))"
+printf 'marker=%s\n' "$MARKER"
+printf 'result=packed\n'
+printf 'next: scripts/verify-pack.sh, which reads that marker back out of the artifact\n'

--- a/skills/pack/scripts/preflight.sh
+++ b/skills/pack/scripts/preflight.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Report whether this host can pack a machine into a portable artifact.
+# Read-only: starts no VM, packs nothing, writes no smolvm state.
+#
+# The memory line is the reason this script exists. `pack create --from-vm`
+# starts an exporter VM whose memory is hardcoded to 8192 MiB
+# (`src/pack_export.rs:345` at 3412bd26, and a second exporter at `:914` fixed
+# at 2048), with no flag and no environment variable. On a host with less free
+# memory the export fails as "agent did not become ready within 30 seconds",
+# which names neither memory nor the exporter. This is the only place that
+# failure gets a name before you hit it.
+#
+# Output is one key=value per line so a caller can parse it. The last line is
+# always result=ready or result=blocked.
+
+set -uo pipefail
+
+VERIFIED_VERSION="1.14.6"
+
+emit() { printf '%s=%s\n' "$1" "$2"; }
+
+blocked=0
+note() { printf 'note=%s\n' "$1"; }
+
+# --- the binary --------------------------------------------------------------
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+if [ -z "$SMOLVM" ]; then
+    emit smolvm_installed no
+    emit smolvm_version ""
+    blocked=1
+else
+    emit smolvm_installed yes
+    version="$("$SMOLVM" --version 2>/dev/null | awk '{print $NF}')"
+    emit smolvm_version "${version:-unknown}"
+fi
+
+emit verified_version "$VERIFIED_VERSION"
+if [ -n "${version:-}" ] && [ "$version" != "unknown" ]; then
+    if [ "$version" = "$VERIFIED_VERSION" ]; then
+        emit version_status match
+    else
+        newest="$(printf '%s\n%s\n' "$version" "$VERIFIED_VERSION" | sort -V | tail -1)"
+        if [ "$newest" = "$version" ]; then
+            emit version_status newer
+            note "this packet was verified on $VERIFIED_VERSION and the binary is $version; flags and messages move every release, so check the output against the binary before trusting a step here"
+        else
+            emit version_status older
+            note "this packet was verified on $VERIFIED_VERSION and the binary is $version"
+        fi
+    fi
+else
+    emit version_status unknown
+fi
+
+# --- platform ----------------------------------------------------------------
+
+kernel="$(uname -s)"
+arch="$(uname -m)"
+case "$arch" in aarch64|arm64) arch=aarch64 ;; esac
+
+case "$kernel" in
+    Darwin)
+        emit platform "darwin-$arch"
+        emit accel hvf
+        emit macos_version "$(sw_vers -productVersion)"
+        hv="$(sysctl -n kern.hv_support 2>/dev/null)"
+        if [ "$hv" = "1" ]; then emit accel_access ok; else emit accel_access denied; blocked=1; fi
+        if [ "$arch" != "aarch64" ]; then
+            emit hardware_verified no
+            note "Intel Mac is not verified by this packet; the installer accepts it and nothing here was run on one"
+        else
+            emit hardware_verified yes
+        fi
+        # A VM's agent socket lives under the cache directory. macOS sockaddr_un
+        # holds 104 bytes including the terminator.
+        sock="$HOME/Library/Caches/smolvm/vms/0123456789abcdef/agent.sock"
+        len=${#sock}
+        emit socket_path_bytes "$len"
+        if [ "$len" -gt 100 ]; then
+            emit socket_path_status too_long
+            blocked=1
+            note "HOME is too deep: every VM start will fail with krun_start_enter -22, whose text blames disks and device options. Install under a shorter HOME."
+        else
+            emit socket_path_status ok
+        fi
+        emit unsupported "vulkan,cuda"
+        ;;
+    Linux)
+        emit platform "linux-$arch"
+        emit accel kvm
+        emit socket_path_status n_a
+        if [ ! -e /dev/kvm ]; then
+            emit accel_access missing
+            blocked=1
+            note "/dev/kvm does not exist; this host has no KVM"
+        elif [ -r /dev/kvm ] && [ -w /dev/kvm ]; then
+            emit accel_access ok
+        else
+            emit accel_access denied
+            blocked=1
+            note "your user cannot open /dev/kvm. The installer warns and continues, so a successful install says nothing about whether a VM will start. Fix: sudo usermod -aG kvm \$USER, then run the next command through sg kvm -c '...' rather than logging out."
+        fi
+        emit unsupported "vulkan"
+        ;;
+    *)
+        emit platform "unsupported-$kernel"
+        emit accel unknown
+        emit accel_access unknown
+        blocked=1
+        note "this script covers macOS and Linux. Windows packs an image and packs --from-vm fine as of v1.14.6, but writes the stub without .exe; see references/windows.md."
+        ;;
+esac
+
+# --- the exporter's fixed memory, the precondition that names nothing ---------
+#
+# Read free memory the way the kernel reports it. MemAvailable is the honest
+# number for "could a new process get this", and it is what a large host makes
+# irrelevant and a small host makes decisive.
+EXPORTER_MIB=8192
+emit exporter_memory_mib "$EXPORTER_MIB"
+case "$kernel" in
+    Darwin)
+        # Free alone is meaningless on macOS, which keeps almost nothing free.
+        # Inactive and purgeable pages are reclaimable, which is what Activity
+        # Monitor calls available.
+        avail_mib="$(vm_stat 2>/dev/null | awk -v page="$(sysctl -n hw.pagesize 2>/dev/null || echo 16384)" '
+            /Pages free/        {gsub(/\./,"",$3); f=$3}
+            /Pages inactive/    {gsub(/\./,"",$3); i=$3}
+            /Pages speculative/ {gsub(/\./,"",$3); s=$3}
+            /Pages purgeable/   {gsub(/\./,"",$3); p=$3}
+            END {printf "%d", (f+i+s+p)*page/1048576}')"
+        ;;
+    Linux)
+        avail_mib="$(awk '/^MemAvailable:/ {print int($2/1024)}' /proc/meminfo 2>/dev/null)"
+        ;;
+    *) avail_mib="" ;;
+esac
+
+if [ -n "${avail_mib:-}" ] && [ "${avail_mib:-0}" -gt 0 ]; then
+    emit free_memory_mib "$avail_mib"
+    if [ "$avail_mib" -ge "$EXPORTER_MIB" ]; then
+        emit exporter_memory_ok yes
+    else
+        # A warning, not a block. smolvm memory is a cap and not a reservation,
+        # so an exporter can still come up under the figure; what this line buys
+        # you is the name of the failure if it does not.
+        emit exporter_memory_ok no
+        note "free memory is below the exporter's fixed $EXPORTER_MIB MiB. If pack create --from-vm fails with 'agent did not become ready within 30 seconds', that is this, and the message will not mention memory. Packing from an image starts no exporter and is unaffected."
+    fi
+else
+    emit free_memory_mib unknown
+    emit exporter_memory_ok unknown
+    note "could not read free memory; the exporter needs $EXPORTER_MIB MiB and fails with a ready timeout that names nothing"
+fi
+
+# An isolated data root on Linux does not carry the agent rootfs: the variable
+# moves where it is looked up and the installer does not write it there.
+if [ "$kernel" = "Linux" ] && [ -n "${SMOLVM_DATA_DIR:-}" ]; then
+    if [ -d "$SMOLVM_DATA_DIR/.local/share/smolvm/agent-rootfs" ]; then
+        emit data_root_rootfs present
+    else
+        emit data_root_rootfs missing
+        blocked=1
+        note "SMOLVM_DATA_DIR is set and holds no agent-rootfs, so the first boot fails with 'agent rootfs not found'. Copy the installer's agent-rootfs into \$SMOLVM_DATA_DIR/.local/share/smolvm/ first."
+    fi
+fi
+
+if [ "$blocked" -eq 0 ]; then emit result ready; else emit result blocked; fi

--- a/skills/pack/scripts/verify-pack.sh
+++ b/skills/pack/scripts/verify-pack.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Prove an artifact is worth shipping: that it runs a real VM, and for a machine
+# pack that the state is inside it.
+#
+# usage: verify-pack.sh [--image <stub>] [--machine <stub>] [--marker <value>]
+#   --image   <stub>  an artifact packed from an image   (default ./from-image)
+#   --machine <stub>  an artifact packed from a machine  (default ./from-vm)
+#   --marker  <value> what pack-machine.sh wrote         (default PACKED_STATE_PRESENT)
+#
+# Every check asserts a value. A pack that lost its rootfs still boots, still
+# prints a guest kernel and still exits zero, so "it ran" proves nothing about
+# what is inside it.
+
+set -uo pipefail
+
+IMAGE_STUB="./from-image"
+MACHINE_STUB="./from-vm"
+MARKER="PACKED_STATE_PRESENT"
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --image)   IMAGE_STUB="$2"; shift ;;
+        --machine) MACHINE_STUB="$2"; shift ;;
+        --marker)  MARKER="$2"; shift ;;
+        *) printf 'unknown argument: %s\n' "$1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+fail=0
+checked=0
+check() {
+    if [ "$2" = "$3" ]; then
+        printf '%s=ok (%s)\n' "$1" "$2"
+    else
+        printf '%s=FAIL expected=%s actual=%s\n' "$1" "$3" "$2"
+        fail=1
+    fi
+}
+
+# Where `pack run` keeps its extractions, one directory per artifact checksum.
+case "$(uname -s)" in
+    Darwin) PACK_CACHE="$HOME/Library/Caches/smolvm-pack" ;;
+    *)      PACK_CACHE="${SMOLVM_DATA_DIR:-$HOME/.cache}/smolvm-pack" ;;
+esac
+cache_entries() { find "$PACK_CACHE" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | wc -l | tr -d ' '; }
+
+# --- the image pack: a real VM, and a cached second run ----------------------
+if [ -f "$IMAGE_STUB" ]; then
+    # The stub takes a subcommand. A bare `--` is rejected with a tip that does
+    # not mention `run`.
+    checked=$((checked + 1))
+    kernel="$("$IMAGE_STUB" run -- uname -sr 2>&1 | tr -d '\r' | grep -m1 '^Linux ' | awk '{print $1}')"
+    check image_pack_is_a_vm "${kernel:-none}" Linux
+
+    # Count the cache after the first run, then again after the second. A reused
+    # extraction adds nothing. Timing is not the test: wall clock on a loaded or
+    # nested-virt host varies by more than the saving, so it reports a healthy
+    # host as suspect.
+    after_first="$(cache_entries)"
+    marker2="$("$IMAGE_STUB" run -- sh -c 'echo SECOND_RUN_OK' 2>&1 | tr -d '\r' | tail -1)"
+    check image_pack_second_run "$marker2" SECOND_RUN_OK
+    after_second="$(cache_entries)"
+    printf 'pack_cache_entries=%s\n' "$after_second"
+    if [ "$after_first" -gt 0 ]; then
+        check image_pack_reused_cache "$after_second" "$after_first"
+    else
+        printf 'image_pack_reused_cache=skipped (no pack cache at %s)\n' "$PACK_CACHE"
+    fi
+else
+    printf 'image_pack=skipped (%s not present)\n' "$IMAGE_STUB"
+fi
+
+# --- the machine pack: the load-bearing assertion ----------------------------
+if [ -f "$MACHINE_STUB" ]; then
+    checked=$((checked + 1))
+    got="$("$MACHINE_STUB" run -- cat /marker.txt 2>&1 | tr -d '\r' | tail -1)"
+    check machine_pack_carried_rootfs "$got" "$MARKER"
+
+    mkernel="$("$MACHINE_STUB" run -- uname -sr 2>&1 | tr -d '\r' | grep -m1 '^Linux ' | awk '{print $1}')"
+    check machine_pack_is_a_vm "${mkernel:-none}" Linux
+
+    if [ -n "$SMOLVM" ] && [ -f "$MACHINE_STUB.smolmachine" ]; then
+        printf '%s\n' "--- what the artifact says it is ---"
+        "$SMOLVM" pack run --sidecar "$MACHINE_STUB.smolmachine" --info 2>&1 \
+            | grep -E '^(Mode|Image|Platform|CPUs|Memory|Checksum):' | sed 's/^/  /'
+    fi
+else
+    printf 'machine_pack=skipped (%s not present)\n' "$MACHINE_STUB"
+fi
+
+# Verifying nothing is not a pass. Both stubs absent means the artifacts were
+# written somewhere else, and a green line there would be the same false clean
+# this packet exists to prevent.
+if [ "$checked" -eq 0 ]; then
+    printf 'result=nothing_verified\n'
+    printf 'note=no artifact was found at %s or %s. If you packed to another path, pass --image and --machine, or this says nothing at all.\n' "$IMAGE_STUB" "$MACHINE_STUB"
+    exit 2
+fi
+
+if [ "$fail" -eq 0 ]; then printf 'result=artifacts_good (%s of 2 artifacts)\n' "$checked"; else printf 'result=FAILED\n'; fi
+exit "$fail"

--- a/skills/sandbox/SKILL.md
+++ b/skills/sandbox/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: sandbox
+description: Runs untrusted code in a throwaway smolvm microVM against a repo it must not modify, with no network unless explicitly granted, and collects artifacts from a writable output directory. Use when executing an agent's generated script, a pull request's test suite, or any code that should not be trusted with the host; when a workload needs egress granted one host at a time; or when a sandbox run has to be cancelled, because Ctrl-C leaves the VM running and invisible to the CLI. Do not use it for a development environment that is re-entered across sessions, for running a Docker daemon inside a machine, or for installing smolvm itself, which is the install packet.
+---
+
+# Running untrusted work in a throwaway machine
+
+Verified on **smolvm v1.14.6** on macOS arm64 and Linux aarch64, 2026-09-10. Done means the command's output landed in your writable directory,
+the repo is unchanged, the workload could not reach the network, and nothing is left running.
+
+**Two smolvm defects shape this packet and you will meet both.**
+
+- **[#1193](https://github.com/smol-machines/smolvm/issues/1193): Ctrl-C does not stop a cached
+  run.** The VM outlives the CLI, `machine list` reports `No machines found`, and it exits only
+  when the untrusted workload does. **The cancel is `scripts/cleanup.sh --cancel`, never Ctrl-C.**
+- **[#1192](https://github.com/smol-machines/smolvm/issues/1192): on macOS a cached run with any
+  mount never boots.** The offline shape below is therefore Linux-only today. macOS has its own
+  page with a route that works: read `references/macos.md`.
+
+## Workflow
+
+```
+- [ ] 1. preflight.sh, and read result= and device_budget_ok=
+- [ ] 2. bake.sh          (offline route only; network on, nothing untrusted mounted)
+- [ ] 3. run.sh           (the untrusted command; records the VM pid)
+- [ ] 4. verify.sh        (from inside the guest and from the host)
+- [ ] 5. cleanup.sh       (or cleanup.sh --cancel to stop a run early)
+```
+
+**1. Preflight.** Read-only: starts no VM, bakes nothing.
+
+```bash
+scripts/preflight.sh --mounts 2 --ports 0
+```
+
+`device_budget_ok=no` means the boot will fail with `no more IRQs are available`. The guest has
+eleven IRQs: **four `-v` mounts boot and five do not, and every published port costs one of those
+slots**, so the budget is mounts plus ports. Combine directories under one mount rather than
+discovering this at boot.
+
+`offline_shape=unavailable` means this host cannot run the shape below. On macOS that is #1192; on
+any host it can also mean the bake helper's memory does not fit, which step 2 diagnoses.
+
+**2. Bake the image. This is the only step that talks to a registry.**
+
+```bash
+scripts/bake.sh python:3.12-alpine
+```
+
+Network on, nothing untrusted mounted, done before the untrusted code is anywhere near the machine.
+Afterwards the runs need no network at all, which is a materially stronger sandbox than granting
+egress and hoping.
+
+**3. Run the untrusted command.**
+
+```bash
+scripts/run.sh --repo ./repo --out ./out -- sh -c 'python3 /workspace/calc.py > /out/result.txt'
+```
+
+The repo is mounted read-only at `/workspace`, the output directory writable at `/out`, and the run
+has no network. It prints `used_host_cache=yes`, which is the assertion that the bake worked and
+that this run reached no registry: without it the run pulled, which means it had network, which
+means it was not the sandbox you asked for.
+
+It also prints `vm_pid=` and records it. **That pid is the only route back to the machine** if the
+run has to be stopped.
+
+To grant egress, name hosts one at a time:
+
+```bash
+scripts/run.sh --allow-host example.com --repo ./repo --out ./out -- <command>
+```
+
+**4. Verify. Both halves, because either alone passes on a broken sandbox.**
+
+```bash
+scripts/verify.sh --expect-file result.txt --expect 42
+```
+
+```
+inside_workspace=ok (readonly)
+inside_out=ok (writable)
+inside_network=ok (blocked)
+artifact=ok (42)
+repo_unchanged=ok
+result=sandbox_held
+```
+
+The inside half proves the workload could not write the repo and could not reach the network; the
+host half proves the artifact came out and the repo is unchanged. A run that merely exited zero
+tells you neither.
+
+**5. Clean up, or cancel.**
+
+```bash
+scripts/cleanup.sh --purge            # after a run finished
+scripts/cleanup.sh --cancel --purge   # to stop a run that is still going
+```
+
+`--cancel` kills exactly the VMs `run.sh` recorded and then verifies that nothing is left. It waits
+before asserting an empty machine list, because the ephemeral entry retires after the run returns
+and an immediate assertion fails on a healthy host.
+
+## Cancelling, and why Ctrl-C is not it
+
+On the offline route, interrupting the CLI leaves the VM running with no CLI route to it, and it
+exits only when the untrusted workload finishes. For code that hangs or loops that is unbounded
+exposure, with roughly 230 MB held per survivor.
+
+**The routes differ, and `references/traps.md` has the measurements.** On the plain path a `SIGINT`
+to the CLI does take the VM with it, verified here on Linux. Do not rely on that: interrupting the
+*wrapper* rather than the CLI leaves both running on either route, which was observed on both hosts
+used for this packet. Use `--cancel`.
+
+## Reference pages
+
+Read these when the situation calls for them; they are not needed for a normal run.
+
+- **`references/traps.md`** for every trap with its measurement: the two routes and what Ctrl-C does
+  to each, the bake helper's fixed memory, why `pgrep -f` and `readlink` both fail as reapers, and
+  what counts as cache rather than residue.
+- **`references/macos.md`** if you are on macOS. The offline shape does not work there; that page
+  gives a route that does and says what it costs.
+- **`references/windows.md`** if you are on Windows. The bake never completes there, so the offline
+  shape is unavailable for a different reason, and the reaper has to be broader.
+
+## Security defaults, and why they are the defaults
+
+- **No network is the default because it is the only guarantee that does not depend on the
+  workload's cooperation.** An egress policy is a filter on what untrusted code asks for; no network
+  is a property of the machine. The bake exists so that the offline run is possible at all.
+- **`--allow-host` grants one host, and the run still has a network stack.** Prefer it to `--net`,
+  but treat it as a narrower opening rather than as no opening. A denial under it looks like a DNS
+  failure, so a workload can fail confusingly rather than obviously.
+- **The repo is `:ro` because a read-only mount is enforced by the guest kernel**, not by the
+  workload's good behaviour. `verify.sh` tries to write it and asserts the write failed, then checks
+  from the host that nothing landed.
+- **The output directory is the only writable path out of the sandbox.** Keep it a directory you
+  created for this run, not a source tree, and read what lands in it before trusting it.
+- **Cleanup kills only the VMs this packet recorded.** A shared host can carry another session's
+  machines, and one was live throughout the runs behind this packet; the reaper is scoped by the
+  boot config's path and left it alone. A cleanup that kills every smolvm process is fine on your
+  laptop and destructive on a build agent.
+- **Nothing here escalates privilege**, edits smolvm configuration, or touches `~/.smolvm`. The
+  scripts are wrappers over the public CLI.
+
+## Platform arms
+
+- **Linux aarch64**: **the offline route, the network-on route, the cancel path and the reaper
+  were all run here on v1.14.6.** This is the first host on which the offline route completed.
+- **Linux x86_64**: the offline route is verified in the material behind this packet, not re-run.
+- **macOS arm64**: the offline shape is unavailable (#1192, reproduced here 3 of 3). The
+  network-on route was run end to end. `references/macos.md`.
+- **Windows x86_64**: the offline shape is unavailable for a different reason, the bake never
+  completes. `references/windows.md`, **re-run on 2026-09-11 against v1.14.6** on Windows 11 Home
+  build 10.0.26200.0 UBR 9445: the mount and the network-off refusal confirmed, and the bake still
+  did not complete inside a ten minute cap.
+
+## Eval prompts, and what they produced
+
+Run on 2026-09-08 PT against v1.14.2 from the published release, under an isolated `HOME`, on
+macOS 26.6.2 arm64 and Lima `linux-kvm` (Ubuntu 24.04 aarch64). Output is verbatim.
+
+**1. "Run this untrusted script against my repo without letting it modify the repo or reach the
+network, and get the output back."**
+
+On Linux aarch64 the **offline route** answers this directly on v1.14.6, with the network off for
+the whole run: `used_host_cache=yes`, `inside_network=ok (blocked)`, `artifact=ok (42)`,
+`repo_unchanged=ok`, `result=sandbox_held`. On macOS, where #1192 blocks that route, the
+network-on route:
+
+```
+route=network-on
+vm_pid=74421
+cli_exit=0
+
+inside_workspace=ok (readonly)
+inside_out=ok (writable)
+inside_network=ok (REACHED)
+artifact=ok (42)
+repo_unchanged=ok
+result=sandbox_held
+```
+
+`inside_network=REACHED` is the expected result on that route and the reason it is the second
+choice: the network was open for the whole run.
+
+**2. "The sandboxed job is hung. Stop it."**
+
+On Lima, a run with a `sleep 600` workload, wrapper interrupted:
+
+```
+--- recorded pid file ---
+76773 /home/<user>/skp/.cache/smolvm/vms/77196d36f7bb8555/boot-config.json
+--- VM still alive after the interrupt? ---
+STILL RUNNING 76773 ...
+--- machine list after the interrupt ---
+vm-1b3d157f running (eph)   4  2048 MiB  2  0  20 GiB  10 GiB
+=== cancel with the packet reaper ===
+cancelled=76773 config=/home/<user>/skp/.cache/smolvm/vms/77196d36f7bb8555/boot-config.json
+machines=clean
+vm_processes=none
+result=clean
+```
+
+The same on macOS, cancelling pid 82510 and ending clean.
+
+**3. "Can I sandbox on this machine?"**
+
+macOS 26.6.2 arm64, where the answer is a qualified no:
+
+```
+platform=darwin-aarch64
+accel=hypervisor_framework
+accel_access=ok
+offline_shape=unavailable
+offline_shape_blocker=smol-machines/smolvm#1192
+device_budget_ok=yes
+cancel_route=scripts/cleanup.sh --cancel
+result=blocked
+```
+
+and `bake.sh` refuses rather than baking something unusable:
+
+```
+result=unsupported_on_macos
+A baked image is only useful to a run that also mounts something, and on macOS
+--oci-cache plus any -v mount times out the boot (smol-machines/smolvm#1192).
+```
+
+## Re-verified on v1.14.6
+
+Run 2026-09-10 PT against v1.14.6 from the published release. **Two things changed on this
+release and both matter.**
+
+**The offline route now runs on Linux, for the first time on any host available to this packet.**
+On Lima `linux-kvm` (Ubuntu 24.04 aarch64) the bake completed in 59 s and the run held:
+
+```
+result=baked
+Using cached image f60a20a837dc1a34 (host cache hit; no pull)
+used_host_cache=yes
+inside_workspace=ok (readonly)
+inside_out=ok (writable)
+inside_network=ok (blocked)
+artifact=ok (42)
+repo_unchanged=ok
+result=sandbox_held
+```
+
+`inside_network=ok (blocked)` is the line the whole packet exists for: the workload reached no
+network at all. Earlier releases could not get this far on any host here.
+
+**The reaper was broken on exactly this route, and is fixed.** The pack-run path forks without
+execing, so its VM child inherits the parent's argv and carries no `_boot-vm`. Measured on
+v1.14.6 before the fix: `run.sh` reported `vm_pid=not_observed`, and after the CLI was killed
+`cleanup.sh` reported `vm_processes=none` and `result=clean` while the VM held 234 MB. After the
+fix, the same sequence reports `vm_pid=71676` and
+`vm_process=... forked-under ...` with `result=vms_still_running`, and `--cancel` clears it. See
+`references/traps.md`.
+
+**macOS is unchanged**: `--oci-cache` with any mount still times out, 3 of 3 with both controls
+passing in the same session, so the offline shape is still unavailable there and `bake.sh` still
+refuses with the reason. The network-on route held (`artifact=ok (42)`, `result=sandbox_held`) and
+the cancel path recorded and killed its VM.
+
+## What was not run
+
+- **The offline route on macOS.** Blocked by #1192, reproduced on v1.14.6 3 of 3 with both
+  controls passing. `references/macos.md` gives the route that works there and what it costs.
+  The offline route itself is now verified on Linux aarch64, so it is no longer unrun everywhere.
+- **A GPU sandbox.** Nothing here was run against a GPU on either release.
+- **The macOS first-choice route** in `references/macos.md`, which needs a `docker`, `crane`,
+  `podman` or `nerdctl` binary to produce an image archive. None is installed on that host.
+- **Windows.** One earlier run, recorded in `references/windows.md`.
+- **S3 and `:staged` mounts**, and driving the sandbox from a CI runner.
+
+## Related packets
+
+- `install` for the boot this assumes and the KVM group check.
+- `teardown` for the wider cleanup, and for what a leak check must exclude.
+- A machine whose state should survive between runs is the opposite of this packet, and is a
+  separate procedure.

--- a/skills/sandbox/SKILL.md
+++ b/skills/sandbox/SKILL.md
@@ -279,5 +279,4 @@ the cancel path recorded and killed its VM.
 
 - `install` for the boot this assumes and the KVM group check.
 - `teardown` for the wider cleanup, and for what a leak check must exclude.
-- A machine whose state should survive between runs is the opposite of this packet, and is a
-  separate procedure.
+- `dev-env` when state should survive between runs, which is the opposite of this packet.

--- a/skills/sandbox/references/macos.md
+++ b/skills/sandbox/references/macos.md
@@ -1,0 +1,95 @@
+# Sandboxing on macOS
+
+## Contents
+
+- Why the offline shape does not work here
+- First choice: an offline persistent machine from a local image archive
+- Second choice: the network-on route, and what it costs
+- Which of these was run
+
+## Why the offline shape does not work here
+
+The packet's default shape is bake once with `--oci-cache`, then run with the repo mounted and no
+network. **On macOS that combination never boots.** Reproduced on macOS 26.6.2 arm64 on v1.14.2,
+2026-09-08, three attempts with both controls passing in the same session:
+
+| command | result |
+|---|---|
+| `--oci-cache`, no mounts | OK |
+| mounts, no `--oci-cache` | OK |
+| `--oci-cache` + one `:ro` mount | `agent did not become ready within 30 seconds`, 3 of 3 |
+
+The bake itself is fine here: `machine run --net --oci-cache --image alpine -- true` reported
+`baked in 5s`. It is the run with a mount that fails, which is the run you actually need.
+
+This is [smol-machines/smolvm#1192](https://github.com/smol-machines/smolvm/issues/1192). The
+pack-run path forks a session leader that never execs and, when a directory mount is present,
+starts a filesystem watcher in that child; on macOS that watcher calls into CoreFoundation, and
+Apple's Objective-C runtime aborts a forked, non-exec'd child that calls into ObjC. Fork versus
+exec, not architecture, which is why the same combination is fine on Linux.
+
+`scripts/preflight.sh` reports `offline_shape=unavailable` here, and `scripts/bake.sh` refuses with
+the reason rather than baking something you cannot use.
+
+## First choice: an offline persistent machine from a local image archive
+
+This keeps the property that matters, **no network on the run at all**, by supplying the image
+locally instead of caching it. `machine create` refuses a registry image without networking and its
+message names this route itself.
+
+```bash
+# 1. Supply the image from a local archive. No registry, so no network needed.
+docker save python:3.12-alpine | smolvm machine create --name smolskill-box --image - \
+    --volume "$PWD/repo:/workspace:ro" \
+    --volume "$PWD/out:/out"
+
+# 2. Start it. Still no --net anywhere.
+smolvm machine start --name smolskill-box
+
+# 3. Run the untrusted command.
+smolvm machine exec --name smolskill-box -- sh -c 'python3 /workspace/calc.py > /out/result.txt'
+
+# 4. Cancel is `machine stop`, which works, unlike Ctrl-C on an ephemeral run.
+smolvm machine stop --name smolskill-box
+
+# 5. Delete. --force is not optional in a script.
+smolvm machine delete --name smolskill-box --force
+```
+
+The mounts go on `create`, not on `exec`. `crane export` or `podman save` produce the same archive
+if you have those instead of Docker.
+
+**Why this is the first choice:** the workload never has a network, which is the single property
+that makes the offline shape worth the trouble. And cancellation is a supported command rather than
+a reaper, because a persistent machine is visible to `machine list` and `machine stop` acts on it.
+
+**It costs you the throwaway property.** The machine persists until you delete it, so a run that
+writes outside the mounts leaves state behind for the next run to inherit. Delete between runs if
+the workload is untrusted rather than merely unknown.
+
+## Second choice: the network-on route, and what it costs
+
+```bash
+scripts/run.sh --route network-on --repo ./repo --out ./out -- <command>
+scripts/verify.sh --route network-on --expect-file result.txt --expect 42
+scripts/cleanup.sh --purge
+```
+
+Without `--oci-cache` the run pulls its own image, so **it has egress for the whole run**. Narrow
+it with `--allow-host` and the run still needs to reach the registry, so the policy has to include
+the registry hosts.
+
+**State this as the weaker sandbox rather than an equivalent one.** The offline route reaches no
+network at all; this one is open for as long as the untrusted code runs, and a policy denial in it
+looks like a DNS failure rather than a denial. `scripts/verify.sh --route network-on` asserts
+`net=REACHED` for exactly that reason: on this route the workload reaching the network is the
+expected result, and a check that asserted `blocked` would be asserting something untrue.
+
+## Which of these was run
+
+- **The second choice was run**, end to end on macOS 26.6.2 arm64 against v1.14.2 on 2026-09-08:
+  `run.sh`, `verify.sh` (all five checks), the cancel path and `cleanup.sh`.
+- **The first choice was not re-run.** It needs a `docker`, `crane`, `podman` or `nerdctl` binary to
+  produce the image archive and this host has none of them. The commands above are the route the
+  runbook names and the one `machine create`'s own error message recommends; treat them as
+  untested here.

--- a/skills/sandbox/references/traps.md
+++ b/skills/sandbox/references/traps.md
@@ -1,0 +1,150 @@
+# Sandbox traps
+
+## Contents
+
+- Ctrl-C does not stop the machine, and which route that applies to
+- Assert no machines left only after a wait
+- A network-off run that dies on the manifest means the bake was skipped
+- A blocked host looks like a DNS bug, not a policy denial
+- The bake helper ignores `--mem`
+- `machine egress-events` cannot inspect an ephemeral run
+- Counting orphans: why `pgrep -f`, `readlink` and `_boot-vm` alone all fail
+- What is cache and what is residue
+- There is no way to list what has been baked
+
+## Ctrl-C does not stop the machine, and which route that applies to
+
+**On the offline route this is the whole reason the packet has a cancel script.**
+`machine run` with `--oci-cache` or `--init` takes the pack-run boot path, which on Unix forks a
+session leader that never execs, so the VM child is detached with no parent-death arming. Interrupt
+the CLI and the VM keeps running, `machine list` reports `No machines found`, no VM cache directory
+exists, and there is no CLI route to what is still running. It exits only when the untrusted
+workload does, which for code that hangs or loops is unbounded. This is
+[smol-machines/smolvm#1193](https://github.com/smol-machines/smolvm/issues/1193).
+
+**On the plain path it does not happen**, and that is worth knowing rather than assuming the worst
+everywhere. Measured on Ubuntu 24.04 aarch64 on 2026-09-08: a `machine run` with no `--oci-cache`,
+one mount and a `sleep 600` workload, sent `SIGINT` on the CLI itself, left `machine list` empty
+and **no VM process at all**. The plain path spawns an exec'd `_boot-vm` that dies with the CLI.
+
+So:
+
+| route | Ctrl-C on the CLI | cancel with |
+|---|---|---|
+| offline (`--oci-cache`) | VM survives, invisible to `machine list` | `scripts/cleanup.sh --cancel` |
+| network-on (no `--oci-cache`) | VM dies with the CLI (verified on Linux) | either |
+
+**Do not rely on the second row to cancel a sandbox.** `run.sh` records the VM's pid on both
+routes because the difference is a boot-path detail that can change between releases, and because
+interrupting the *wrapper* rather than the CLI leaves the CLI and its VM running on either route,
+which was observed on both hosts here.
+
+## Assert no machines left only after a wait
+
+A successful `machine run` returns **before** its ephemeral entry retires. Asserting an empty
+machine list immediately fails on a healthy host, and it is the single most likely false failure in
+a scripted sandbox. `scripts/cleanup.sh` waits before asserting.
+
+## A network-off run that dies on the manifest means the bake was skipped
+
+```
+Error: fetching manifest docker.io/library/python:3.12-alpine: ... network is unreachable
+Hint: networking is disabled. Add --net to enable image pulls
+```
+
+**An ordinary earlier pull does not make a later run offline-capable**: the runtime still resolves
+the tag through the registry. Bake the image with `scripts/bake.sh` instead.
+
+The CLI's own hint points at re-opening the network, which is the opposite of what a sandbox wants.
+Adding `--net` here is how an offline sandbox quietly becomes a networked one.
+
+## A blocked host looks like a DNS bug, not a policy denial
+
+With `--allow-host example.com`, reaching `pypi.org` fails as `wget: bad address 'pypi.org'`.
+Nothing says "denied by policy". Do not spend time debugging the guest's resolver.
+
+## The bake helper ignores `--mem`
+
+The bake runs in a helper machine named `init-bake-<hash>-<pid>` which takes the **default** memory,
+8192 MiB, whatever `--mem` you passed to the outer command. Confirmed on Ubuntu 24.04 aarch64 on
+2026-09-08 by reading `machine ls --json` while a bake was in flight.
+
+**On a host that cannot boot a VM that large, the bake can never succeed and the error names
+neither the helper nor its memory:**
+
+```
+Error: config operation failed: init-layer bake:
+  `smolvm machine start --name init-bake-f60a20a837dc1a34-68696` failed (exit status: 1):
+  Error: agent operation failed: start machine: agent operation failed: wait for ready:
+  agent did not become ready within 30 seconds
+```
+
+That is exactly the message a loaded host produces, so it invites the wrong diagnosis.
+`scripts/bake.sh` runs a 2048 MiB control boot on failure and tells you which of the two it is.
+
+`SMOLVM_AGENT_READY_TIMEOUT_SECS` does not help: the string is in the binary, but the failure is in
+the inner `machine start`, which uses the hard-coded 30 s limit. Verified by setting it to 180 and
+watching the bake fail at 30 s anyway.
+
+## `machine egress-events` cannot inspect an ephemeral run
+
+It takes `--name` and defaults to a machine called `default`, so it applies to named machines. An
+ephemeral run's machine is gone before you can name it, so egress denials from a `machine run` are
+not retrievable this way.
+
+## Counting orphans: why `pgrep -f`, `readlink` and `_boot-vm` alone all fail
+
+Three reapers that look right. Each misses a different thing, and the third is the one that
+matters here.
+
+`pgrep -f _boot-vm` matches any process whose command line contains that string, including the
+script doing the counting, so it reports orphans that do not exist.
+
+`readlink /proc/<pid>/exe` is unreliable in the other direction. For the **exec'd** VM child it
+returns `Permission denied` to the user who started it, so a reaper built on it reports nothing.
+On v1.14.6 it is readable for the **forked** child, which makes it useful for scoping but not for
+finding.
+
+**Matching `argv[1] == "_boot-vm"` is exact, and still blind to the route this packet uses by
+default.** There are two VM process shapes:
+
+| route | child | argv[1] | carries its boot config |
+|---|---|---|---|
+| plain `machine run` | exec'd | `_boot-vm` | yes, in argv[2] |
+| pack-run (`--oci-cache`, or any `init`) | **forked, never exec'd** | inherited, so `machine` | **no** |
+
+The forked child inherits the parent's whole command line, so nothing in its argv says it is a VM.
+Measured on v1.14.6 on Ubuntu 24.04 aarch64: with two orphaned pack-run VMs alive at 234 MB each,
+`cleanup.sh` reported `vm_processes=none` and `result=clean`, and `run.sh` had recorded
+`vm_pid=not_observed`. **The reaper was blind to exactly the path that survives an interrupt**,
+which is the pack-run path, and sighted only on the path that does not.
+
+**What works.** On Linux both shapes rename themselves to `libkrun VM`, which no shell can hold,
+so `scripts/cleanup.sh` matches `/proc/<pid>/comm` and then scopes by argv[2] when it is there and
+by the executable's path when it is not. macOS exposes no rename, so there the search is scoped by
+the executable path under this `HOME` and the parent chain separates a VM from the CLI that
+started it. Verified against a live orphan on both hosts: the same sequence now reports
+`vm_process=... forked-under ...` and `result=vms_still_running`, and `--cancel` clears it.
+
+## What is cache and what is residue
+
+`ls ~/.cache/smolvm/vms/ | wc -l` is not a leak check. Two separate caches exist and neither is
+residue:
+
+- `vms/_shared`, the image store the runbooks describe.
+- **the pack cache**, `~/Library/Caches/smolvm-pack` on macOS and `~/.cache/smolvm-pack` on Linux.
+  On v1.14.2 on macOS a bake of one alpine image landed **here** and produced no `_shared` at all:
+  114 MB in the pack cache, `vms/_shared` absent. Observed 2026-09-08.
+
+`scripts/cleanup.sh` reports both and keeps both. Deleting them costs you the offline route, and
+the next bake pays for it again.
+
+Leftover VM directories are also not necessarily a leak: `smolvm serve start` prints
+`Reclaimed N dangling VM data dir(es)` on startup and clears them.
+
+## There is no way to list what has been baked
+
+`smolvm machine images` requires `--name` and reports one machine's images, so cache state is not
+observable. If a run unexpectedly pulls, you cannot inspect the cache to find out why. The
+`used_host_cache` line from `scripts/run.sh` is the only signal you get, which is why it is asserted
+rather than printed.

--- a/skills/sandbox/references/windows.md
+++ b/skills/sandbox/references/windows.md
@@ -1,0 +1,92 @@
+# Sandboxing on Windows
+
+## Contents
+
+- What was verified
+- Why the offline shape is unavailable
+- What a Windows sandbox has to do instead
+- The reaper on Windows
+
+**Re-run on 2026-09-11 against smolvm v1.14.6** on Windows 11 Home build 10.0.26200.0 UBR 9445
+x86_64, in an elevated session. The host mount, the artifact-out directory and the network-off
+refusal all behaved as recorded below, and the bake still never completes. The transcripts below
+are from the earlier v1.14.2 run except where a v1.14.6 line is quoted. `scripts/*.sh` are POSIX
+shell and do not run here.
+
+## What was verified
+
+The read-only mount, the artifact-out directory and the network-off refusal all behave as on Unix.
+
+```powershell
+& $exe machine run --net --mem 2048 --image python:3.12-alpine `
+    -v "$W\repo:/workspace:ro" -v "$W\out:/out" `
+    -- sh -c 'python3 /workspace/calc.py > /out/result.txt; touch /workspace/EVIL 2>/dev/null && echo WS_WRITABLE || echo ws_blocked'
+```
+
+```
+ws_blocked
+host result.txt : 42
+EVIL in repo    : False
+```
+
+The run took 5.8 s. Windows host paths work directly in `-v` (`C:\...\repo:/workspace:ro`),
+including from a 237-character directory.
+
+The same shape ran again on v1.14.6, asserting the mount with a marker rather than a timing:
+
+```
+SANDBOX_MOUNT_OK
+elapsed s : 9.7
+```
+
+A network-off run refuses to pull and prints the same hint as Unix, on v1.14.6 as before:
+
+```
+Error: fetching manifest docker.io/library/python:3.12-alpine: ... network is unreachable
+Hint: networking is disabled. Add --net to enable image pulls:
+  smolvm machine run --net --image python:3.12-alpine ...
+```
+
+## Why the offline shape is unavailable
+
+**The `--oci-cache` bake never completes on Windows, still on v1.14.6.** It stalls at the same
+line. Capped at ten minutes on the 2026-09-11 run and killed there:
+
+```
+Caching image 6e96a1a9683d8fb2 (one-time; reused on later runs)
+  pulling image and running init...
+```
+
+Probed while hanging, the bake's helper VM is running and healthy: `PID 1 /run/smolvm/init
+container-init` and nothing else, working egress, and 20.9 MB of pulled layers already on its
+storage disk. So the guest finished the pull and went idle while the host CLI waits for a
+completion signal that never arrives. Host-side `RUST_LOG=debug` shows the manifest resolved and
+then nothing.
+
+This is a host and guest completion-handshake problem, not a pull problem, not a network problem
+and **not the macOS abort in #1192**: the Windows pack-run boot spawns a detached `_boot-vm` rather
+than forking in-process, so the Objective-C fork-safety abort cannot apply here.
+
+**Every killed bake leaves a registered `init-bake-<hash>-<pid>` machine.** They accumulate and
+nothing cleans them up; delete them like any other machine. The v1.14.6 run left
+`init-bake-6e96a1a9683d8fb2-8648` behind exactly this way.
+
+## What a Windows sandbox has to do instead
+
+Use `--net` with an egress policy rather than the offline pattern, and say plainly that it is the
+weaker sandbox: the workload has network for the whole run. That is the same trade as the
+network-on route in `references/macos.md`, for a different underlying reason.
+
+## The reaper on Windows
+
+**Key on every `_boot-vm` process the script started, not only the pack-run path.**
+
+The `pack run` path spawns a detached `_boot-vm` with `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP`,
+and measured on the tested host, that child survives a real Ctrl-C and a kill of the CLI: about
+365 MB, invisible to `machine ls`. Only killing the child ends it.
+
+The plain foreground `machine run` has **not** been measured on Windows, and the source has no
+parent-death arming there at all: the watchdog is Unix-only and the plain `_boot-vm` spawn is also
+detached. Until someone measures it, assume a foreground run can orphan too. That is why a Windows
+port of `scripts/cleanup.sh` should reap every VM process it started rather than only the ones from
+the cached route, which is the opposite of the Linux split in `references/traps.md`.

--- a/skills/sandbox/scripts/bake.sh
+++ b/skills/sandbox/scripts/bake.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Bake an image into the host cache. This is the only step that talks to a
+# registry, and it runs with the network on and nothing untrusted mounted.
+#
+# usage: bake.sh [<image>]      (default python:3.12-alpine)
+#
+# Do this before the untrusted code is anywhere near the machine. Afterwards the
+# sandbox runs need no network at all, which is a materially stronger sandbox
+# than granting egress and hoping the workload behaves.
+
+set -uo pipefail
+
+IMAGE="${1:-python:3.12-alpine}"
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+if [ -z "$SMOLVM" ]; then
+    printf 'smolvm not found; set SMOLVM to its path\n' >&2
+    exit 2
+fi
+
+if [ "$(uname -s)" = "Darwin" ]; then
+    printf 'result=unsupported_on_macos\n'
+    printf 'A baked image is only useful to a run that also mounts something, and on macOS\n'
+    printf '%s\n' '--oci-cache plus any -v mount times out the boot (smol-machines/smolvm#1192).'
+    printf 'Read references/macos.md instead. Baking here would succeed and buy you nothing.\n'
+    exit 2
+fi
+
+start="$(date +%s)"
+out="$("$SMOLVM" machine run --mem 2048 --net --oci-cache --image "$IMAGE" -- true 2>&1)"
+rc=$?
+elapsed=$(( $(date +%s) - start ))
+printf '%s\n' "$out" | sed 's/^/  /'
+
+printf 'image=%s\n' "$IMAGE"
+printf 'elapsed_s=%s\n' "$elapsed"
+
+# Assert the value, not the exit code. A bake that did not cache still exits
+# zero, and the run that depends on it then fails much later with a message
+# about the registry.
+if printf '%s' "$out" | grep -q 'baked in'; then
+    printf 'result=baked\n'
+    exit 0
+fi
+
+# A second bake of an already-cached image reports the cache hit instead.
+if printf '%s' "$out" | grep -q 'host cache hit'; then
+    printf 'result=already_baked\n'
+    exit 0
+fi
+
+printf 'result=FAILED rc=%s\n' "$rc"
+
+# Diagnose rather than hand the error back. A ready timeout here names neither
+# the helper VM nor its memory, and the cause is usually one of two things.
+if printf '%s' "$out" | grep -q 'did not become ready'; then
+    printf 'diagnosis: the bake runs in a helper machine (init-bake-<hash>-<pid>) which takes\n'
+    printf '  the DEFAULT memory, 8192 MiB, ignoring the --mem on your command. If this host\n'
+    printf '  cannot boot a VM that large, the bake can never succeed and the error says so\n'
+    printf '  nowhere. Control boot at 2048 MiB:\n'
+    if "$SMOLVM" machine run --mem 2048 --net --image alpine -- echo CONTROL_OK 2>&1 | grep -q CONTROL_OK; then
+        printf '  control_boot_2048=ok\n'
+        printf '  So small VMs boot here and the helper does not: this host cannot give the bake\n'
+        printf '  the memory it takes. Use the network-on route instead (scripts/run.sh\n'
+        printf '  --route network-on), and read references/macos.md, which explains what that\n'
+        printf '  route costs you. It is the same trade on any host that cannot bake.\n'
+    else
+        printf '  control_boot_2048=failed\n'
+        printf '  Nothing boots here at all. This is not a bake problem: run the install\n'
+        printf '  packet preflight, which checks KVM access and the macOS socket path length.\n'
+    fi
+else
+    printf 'The bake is the only networked step. If it failed on the registry, fix that here\n'
+    printf 'rather than adding --net to the workload run, which is what the CLI hint suggests\n'
+    printf 'and is the opposite of what a sandbox wants.\n'
+fi
+exit 1

--- a/skills/sandbox/scripts/cleanup.sh
+++ b/skills/sandbox/scripts/cleanup.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Cancel or clean up a sandbox run, then prove nothing is left running.
+#
+# usage: cleanup.sh [--cancel] [--purge]
+#   --cancel   kill the VMs run.sh recorded. THIS IS THE SANDBOX'S CANCEL.
+#              Ctrl-C is not: it returns the shell to you and leaves the VM
+#              running, invisible to `machine list`, until the untrusted
+#              workload finishes on its own (smol-machines/smolvm#1193).
+#   --purge    remove the recorded-pid file once nothing is left
+#
+# With no flags it waits, asserts the machine list is empty, and reports any VM
+# process still alive under this HOME's state.
+
+set -uo pipefail
+
+PACKET="sandbox"
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+STATE_DIR="${SMOLVM_SKILL_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/smolvm-skills}"
+PIDFILE="$STATE_DIR/$PACKET.vmpids"
+
+cancel=0
+purge=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --cancel) cancel=1 ;;
+        --purge)  purge=1 ;;
+        *) printf 'unknown argument: %s\n' "$1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+if [ -z "$SMOLVM" ]; then
+    printf 'smolvm not found; set SMOLVM to its path\n' >&2
+    exit 2
+fi
+
+case "$(uname -s)" in
+    Darwin) VMS_DIR="$HOME/Library/Caches/smolvm/vms" ;;
+    *)      VMS_DIR="${SMOLVM_DATA_DIR:-$HOME/.cache/smolvm}/vms" ;;
+esac
+VMS_DIR="${SMOLVM_VMS_DIR:-$VMS_DIR}"
+SMOLVM_PREFIX="${SMOLVM_PREFIX:-$HOME/.smolvm}"
+
+# List this HOME's smolvm VM processes, as "pid marker".
+#
+# Two process shapes exist and a reaper has to catch both. The plain
+# `machine run` path EXECS a child whose argv[1] is `_boot-vm` and whose argv[2]
+# is its boot-config path. The pack-run path, which is `--oci-cache` or any
+# `init`, FORKS without execing, so the child inherits the parent's argv and
+# carries no boot-config at all. Matching `_boot-vm` alone is therefore blind to
+# exactly the path whose child survives an interrupt
+# (smol-machines/smolvm#1193): measured on v1.14.6, it reported "none" while two
+# orphaned VMs held 234 MB each.
+#
+# On Linux both shapes rename themselves to `libkrun VM`, the one marker that
+# covers both and that no shell can hold. macOS exposes no rename, so there the
+# executable path scopes the search to this HOME and the parent chain separates
+# a VM from the CLI that started it.
+#
+# `pgrep -f _boot-vm` is not an alternative: it matches any shell whose text
+# contains that string, including this script.
+list_vm_processes() {
+    case "$(uname -s)" in
+        Linux)
+            for p in /proc/[0-9]*; do
+                [ "$(cat "$p/comm" 2>/dev/null)" = "libkrun VM" ] || continue
+                pid="${p#/proc/}"
+                cfg="$(tr '\0' '\n' < "$p/cmdline" 2>/dev/null | sed -n '3p')"
+                case "$cfg" in
+                    "$VMS_DIR"/*) printf '%s %s\n' "$pid" "$cfg"; continue ;;
+                esac
+                # Forked shape: nothing in argv identifies it, so scope by the
+                # binary it is running.
+                case "$(readlink "$p/exe" 2>/dev/null)" in
+                    "$SMOLVM_PREFIX"/*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;;
+                esac
+            done
+            ;;
+        Darwin)
+            # shellcheck disable=SC2009  # pgrep cannot return ppid and the full
+            # command together, and pgrep -f matches this script's own text.
+            own=" $(ps -axo pid=,command= 2>/dev/null | grep -F "$SMOLVM_PREFIX/smolvm-bin" | awk '{print $1}' | tr '\n' ' ') "
+            ps -axo pid=,ppid=,command= 2>/dev/null | while read -r pid ppid rest; do
+                case "$rest" in "$SMOLVM_PREFIX"/smolvm-bin*) ;; *) continue ;; esac
+                case "$rest" in
+                    *" _boot-vm "*) printf '%s %s\n' "$pid" "${rest#* _boot-vm }"; continue ;;
+                esac
+                # Forked shape: its parent is the CLI that started it, or init
+                # once that CLI is gone.
+                if [ "$ppid" = 1 ]; then
+                    printf '%s orphaned-under %s\n' "$pid" "$SMOLVM_PREFIX"
+                else
+                    case "$own" in *" $ppid "*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;; esac
+                fi
+            done
+            ;;
+    esac
+}
+
+# 1. Cancel: kill exactly the VMs run.sh recorded, and only those.
+if [ "$cancel" -eq 1 ]; then
+    if [ -s "$PIDFILE" ]; then
+        while read -r pid cfg; do
+            [ -n "$pid" ] || continue
+            if kill -0 "$pid" 2>/dev/null; then
+                kill -9 "$pid" 2>/dev/null && printf 'cancelled=%s config=%s\n' "$pid" "$cfg"
+            else
+                printf 'already_gone=%s\n' "$pid"
+            fi
+        done < "$PIDFILE"
+    else
+        printf 'cancelled=none_recorded\n'
+    fi
+fi
+
+# 2. An ephemeral machine's entry retires after the run returns, not with it, so
+# an immediate assertion fails on a healthy host. This is the single most likely
+# false failure in a scripted sandbox.
+sleep 20
+
+# 3. Assert values.
+listing="$("$SMOLVM" machine list 2>&1)"
+if printf '%s' "$listing" | grep -q 'No machines found'; then
+    printf 'machines=clean\n'
+else
+    printf 'machines=remaining\n'
+    printf '%s\n' "$listing" | sed 's/^/  /'
+fi
+
+# `_shared` is the image store bake.sh writes into. It is the cache, not
+# residue, so counting it as a leak gives a false positive on every host that
+# has ever baked.
+if [ -d "$VMS_DIR" ]; then
+    left="$(find "$VMS_DIR" -mindepth 1 -maxdepth 1 -type d ! -name _shared 2>/dev/null | wc -l | tr -d ' ')"
+else
+    left=0
+fi
+printf 'vm_dirs=%s\n' "$left"
+if [ "$left" -gt 0 ]; then
+    printf 'note=leftover VM directories are not necessarily a leak: smolvm serve start prints "Reclaimed N dangling VM data dir(es)" on startup and clears them.\n'
+fi
+
+# What a bake leaves behind is cache, not residue, and deleting it costs you the
+# offline route. Report both places it can live: `_shared` under the VM state,
+# and the pack cache, which is where a v1.14.2 bake actually landed on macOS.
+case "$(uname -s)" in
+    Darwin) PACK_CACHE="$HOME/Library/Caches/smolvm-pack" ;;
+    *)      PACK_CACHE="$HOME/.cache/smolvm-pack" ;;
+esac
+if [ -d "$VMS_DIR/_shared" ]; then
+    printf 'image_cache_shared=%s\n' "$(du -sk "$VMS_DIR/_shared" 2>/dev/null | awk '{printf "%dMB", $1/1024}')"
+else
+    printf 'image_cache_shared=absent\n'
+fi
+if [ -d "$PACK_CACHE" ]; then
+    printf 'image_cache_pack=%s\n' "$(du -sk "$PACK_CACHE" 2>/dev/null | awk '{printf "%dMB", $1/1024}')"
+else
+    printf 'image_cache_pack=absent\n'
+fi
+printf 'note=both caches are kept on purpose. Removing them costs you the offline route and the next bake pays for it again.\n'
+
+# 4. Verify: after a cancel, this is the assertion that the cancel worked.
+found=0
+while read -r pid cfg; do
+    [ -n "$pid" ] || continue
+    found=1
+    printf 'vm_process=%s config=%s\n' "$pid" "$cfg"
+done <<EOF
+$(list_vm_processes)
+EOF
+
+if [ "$found" -eq 0 ]; then
+    printf 'vm_processes=none\n'
+    [ "$purge" -eq 1 ] && rm -f "$PIDFILE"
+    printf 'result=clean\n'
+    exit 0
+fi
+
+printf 'result=vms_still_running\n'
+printf 'rerun with --cancel, after checking none of the above belongs to another session.\n'
+exit 1

--- a/skills/sandbox/scripts/preflight.sh
+++ b/skills/sandbox/scripts/preflight.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Report whether this host can run the offline sandbox shape, and whether the
+# machine you are planning fits the guest's device budget.
+#
+# usage: preflight.sh [--mounts N] [--ports N]
+#   --mounts N  how many -v mounts your run will pass (default 2: repo plus out)
+#   --ports N   how many -p publishes it will pass (default 0)
+#
+# Read-only: starts no VM, bakes nothing, writes no smolvm state.
+# Output is one key=value per line. The last line is result=ready or result=blocked.
+
+set -uo pipefail
+
+VERIFIED_VERSION="1.14.6"
+
+# The guest gets eleven IRQs. Four -v mounts boot and five fail with "no more
+# IRQs are available", and any published port costs one of those slots, so the
+# budget is mounts plus ports. Measured on Windows Hypervisor Platform and the
+# same budget on Linux.
+DEVICE_BUDGET=4
+
+emit() { printf '%s=%s\n' "$1" "$2"; }
+note() { printf 'note=%s\n' "$1"; }
+
+mounts=2
+ports=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --mounts) mounts="$2"; shift ;;
+        --ports)  ports="$2";  shift ;;
+        *) printf 'unknown argument: %s\n' "$1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+blocked=0
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+if [ -z "$SMOLVM" ]; then
+    emit smolvm_installed no
+    blocked=1
+else
+    emit smolvm_installed yes
+    version="$("$SMOLVM" --version 2>/dev/null | awk '{print $NF}')"
+    emit smolvm_version "${version:-unknown}"
+fi
+
+emit verified_version "$VERIFIED_VERSION"
+if [ -n "${version:-}" ] && [ "$version" != "unknown" ]; then
+    if [ "$version" = "$VERIFIED_VERSION" ]; then
+        emit version_status match
+    else
+        newest="$(printf '%s\n%s\n' "$version" "$VERIFIED_VERSION" | sort -V | tail -1)"
+        if [ "$newest" = "$version" ]; then
+            emit version_status newer
+            note "this packet was verified on $VERIFIED_VERSION and the binary is $version; a sandbox is exactly where a silently changed flag matters, so check each step's output against the binary before trusting it"
+        else
+            emit version_status older
+        fi
+    fi
+else
+    emit version_status unknown
+fi
+
+kernel="$(uname -s)"
+arch="$(uname -m)"
+case "$arch" in aarch64|arm64) arch=aarch64 ;; esac
+
+case "$kernel" in
+    Darwin)
+        emit platform "darwin-$arch"
+        emit accel hypervisor_framework
+        if [ "$(sysctl -n kern.hv_support 2>/dev/null)" = "1" ]; then
+            emit accel_access ok
+        else
+            emit accel_access denied
+            blocked=1
+        fi
+        # The offline shape is bake with --oci-cache, then run with mounts and
+        # no network. On macOS that combination never boots.
+        emit offline_shape unavailable
+        emit offline_shape_blocker "smol-machines/smolvm#1192"
+        blocked=1
+        note "on macOS --oci-cache with any -v mount times out the boot, deterministically, so the offline shape this packet is built on cannot run here. Use references/macos.md, which gives a route that works and says what it costs you."
+        for b in docker crane podman nerdctl; do
+            if command -v "$b" >/dev/null 2>&1; then emit image_archive_tool "$b"; break; fi
+        done
+        ;;
+    Linux)
+        emit platform "linux-$arch"
+        emit accel kvm
+        if [ ! -e /dev/kvm ]; then
+            emit accel_access missing
+            blocked=1
+            note "/dev/kvm does not exist; this host has no KVM"
+        elif [ -r /dev/kvm ] && [ -w /dev/kvm ]; then
+            emit accel_access ok
+        else
+            emit accel_access denied
+            blocked=1
+            note "your user cannot open /dev/kvm. Fix without logging out: sudo usermod -aG kvm \$USER, then run the next command through sg kvm -c '...'"
+        fi
+        emit offline_shape available
+        ;;
+    *)
+        emit platform "unsupported-$kernel"
+        emit accel unknown
+        emit accel_access unknown
+        emit offline_shape unavailable
+        blocked=1
+        note "this script covers macOS and Linux. On Windows the --oci-cache bake never completes, so the offline shape is unavailable there too; see references/windows.md, written from a run and not re-run by this packet."
+        ;;
+esac
+
+# The devices your planned run needs, against the budget.
+emit planned_mounts "$mounts"
+emit planned_ports "$ports"
+emit device_budget "$DEVICE_BUDGET"
+emit devices_requested "$((mounts + ports))"
+if [ "$((mounts + ports))" -le "$DEVICE_BUDGET" ]; then
+    emit device_budget_ok yes
+else
+    emit device_budget_ok no
+    blocked=1
+    note "mounts plus published ports exceeds the guest's device budget; the boot fails with 'no more IRQs are available'. Combine directories under one mount, or drop a port."
+fi
+
+# Ctrl-C does not stop a sandbox. Say so before anything is started, not after.
+emit cancel_route "scripts/cleanup.sh --cancel"
+emit interrupt_orphans_vm yes
+emit interrupt_blocker "smol-machines/smolvm#1193"
+
+if [ "$blocked" -eq 0 ]; then emit result ready; else emit result blocked; fi

--- a/skills/sandbox/scripts/run.sh
+++ b/skills/sandbox/scripts/run.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# Run an untrusted command against a repo it must not modify, with no network,
+# and collect its artifacts.
+#
+# usage: run.sh [--repo <dir>] [--out <dir>] [--image <img>] [--allow-host <h>]... -- <command...>
+#   --repo <dir>        mounted read-only at /workspace (default ./repo)
+#   --out  <dir>        mounted writable at /out        (default ./out)
+#   --image <img>       must already be baked; see bake.sh (default python:3.12-alpine)
+#   --allow-host <h>    grant egress to one host. Repeatable. Weakens the sandbox
+#                       and the script says so; --allow-host implies --net.
+#   --route <r>         offline (default) or network-on.
+#                       offline    bake once, then run with no network at all.
+#                       network-on no --oci-cache, the run pulls its own image and
+#                       therefore has egress for the whole run. Use it only where
+#                       offline does not work: macOS, where --oci-cache with any
+#                       mount never boots (smol-machines/smolvm#1192), and any host
+#                       that cannot give the bake helper its 8192 MiB.
+#
+# The VM's pid is recorded before the workload finishes, because Ctrl-C does not
+# stop a smolvm machine: the VM outlives the CLI, `machine list` cannot see it,
+# and it exits only when the untrusted workload does, which for code that hangs
+# or loops is never (smol-machines/smolvm#1193). Cancel with
+# `scripts/cleanup.sh --cancel`, never with Ctrl-C.
+
+set -uo pipefail
+
+REPO="./repo"
+OUT="./out"
+IMAGE="python:3.12-alpine"
+ROUTE="offline"
+allow=()
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --repo)       REPO="$2"; shift ;;
+        --out)        OUT="$2"; shift ;;
+        --image)      IMAGE="$2"; shift ;;
+        --allow-host) allow+=(--allow-host "$2"); shift ;;
+        --route)      ROUTE="$2"; shift ;;
+        --) shift; break ;;
+        *) printf 'unknown argument: %s\n' "$1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+case "$ROUTE" in
+    offline|network-on) ;;
+    *) printf 'unknown route: %s (offline or network-on)\n' "$ROUTE" >&2; exit 2 ;;
+esac
+
+if [ $# -eq 0 ]; then
+    printf 'no command given; everything after -- is run inside the sandbox\n' >&2
+    exit 2
+fi
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+if [ -z "$SMOLVM" ]; then
+    printf 'smolvm not found; set SMOLVM to its path\n' >&2
+    exit 2
+fi
+
+if [ ! -d "$REPO" ]; then
+    printf 'repo directory not found: %s\n' "$REPO" >&2
+    exit 2
+fi
+mkdir -p "$OUT"
+REPO="$(cd "$REPO" && pwd)"
+OUT="$(cd "$OUT" && pwd)"
+
+STATE_DIR="${SMOLVM_SKILL_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/smolvm-skills}"
+mkdir -p "$STATE_DIR"
+PIDFILE="$STATE_DIR/sandbox.vmpids"
+
+case "$(uname -s)" in
+    Darwin) VMS_DIR="$HOME/Library/Caches/smolvm/vms" ;;
+    *)      VMS_DIR="${SMOLVM_DATA_DIR:-$HOME/.cache/smolvm}/vms" ;;
+esac
+VMS_DIR="${SMOLVM_VMS_DIR:-$VMS_DIR}"
+SMOLVM_PREFIX="${SMOLVM_PREFIX:-$HOME/.smolvm}"
+
+# List this HOME's smolvm VM processes, as "pid marker".
+#
+# Two process shapes exist and a reaper has to catch both. The plain
+# `machine run` path EXECS a child whose argv[1] is `_boot-vm` and whose argv[2]
+# is its boot-config path. The pack-run path, which is `--oci-cache` or any
+# `init`, FORKS without execing, so the child inherits the parent's argv and
+# carries no boot-config at all. Matching `_boot-vm` alone is therefore blind to
+# exactly the path whose child survives an interrupt
+# (smol-machines/smolvm#1193): measured on v1.14.6, it reported "none" while two
+# orphaned VMs held 234 MB each.
+#
+# On Linux both shapes rename themselves to `libkrun VM`, the one marker that
+# covers both and that no shell can hold. macOS exposes no rename, so there the
+# executable path scopes the search to this HOME and the parent chain separates
+# a VM from the CLI that started it.
+#
+# `pgrep -f _boot-vm` is not an alternative: it matches any shell whose text
+# contains that string, including this script.
+list_vm_processes() {
+    case "$(uname -s)" in
+        Linux)
+            for p in /proc/[0-9]*; do
+                [ "$(cat "$p/comm" 2>/dev/null)" = "libkrun VM" ] || continue
+                pid="${p#/proc/}"
+                cfg="$(tr '\0' '\n' < "$p/cmdline" 2>/dev/null | sed -n '3p')"
+                case "$cfg" in
+                    "$VMS_DIR"/*) printf '%s %s\n' "$pid" "$cfg"; continue ;;
+                esac
+                # Forked shape: nothing in argv identifies it, so scope by the
+                # binary it is running.
+                case "$(readlink "$p/exe" 2>/dev/null)" in
+                    "$SMOLVM_PREFIX"/*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;;
+                esac
+            done
+            ;;
+        Darwin)
+            # shellcheck disable=SC2009  # pgrep cannot return ppid and the full
+            # command together, and pgrep -f matches this script's own text.
+            own=" $(ps -axo pid=,command= 2>/dev/null | grep -F "$SMOLVM_PREFIX/smolvm-bin" | awk '{print $1}' | tr '\n' ' ') "
+            ps -axo pid=,ppid=,command= 2>/dev/null | while read -r pid ppid rest; do
+                case "$rest" in "$SMOLVM_PREFIX"/smolvm-bin*) ;; *) continue ;; esac
+                case "$rest" in
+                    *" _boot-vm "*) printf '%s %s\n' "$pid" "${rest#* _boot-vm }"; continue ;;
+                esac
+                # Forked shape: its parent is the CLI that started it, or init
+                # once that CLI is gone.
+                if [ "$ppid" = 1 ]; then
+                    printf '%s orphaned-under %s\n' "$pid" "$SMOLVM_PREFIX"
+                else
+                    case "$own" in *" $ppid "*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;; esac
+                fi
+            done
+            ;;
+    esac
+}
+
+before="$(list_vm_processes | awk '{print $1}' | sort)"
+
+printf 'route=%s\n' "$ROUTE"
+cache=(--oci-cache)
+if [ "$ROUTE" = "network-on" ]; then
+    # No host cache, so the run pulls its own image and needs the network for
+    # the whole run. Say what that costs rather than letting it look equivalent.
+    cache=()
+    if [ "${#allow[@]}" -eq 0 ]; then
+        allow=(--net)
+        printf 'egress=all\n'
+        printf 'note=network-on with no --allow-host gives the untrusted workload unrestricted egress for the whole run. Name the hosts it needs with --allow-host to narrow it.\n'
+    else
+        printf 'egress=granted %s\n' "${allow[*]}"
+        printf 'note=the run also needs to reach the registry to pull its image, so the policy must include the registry hosts or the run will not start.\n'
+    fi
+    printf 'note=this is the weaker sandbox. The offline route reaches no network at all; this one is open for as long as the workload runs.\n'
+elif [ "${#allow[@]}" -gt 0 ]; then
+    printf 'egress=granted %s\n' "${allow[*]}"
+    printf 'note=--allow-host implies --net. The workload can now reach the named hosts, and a denial looks like a DNS failure rather than a policy denial.\n'
+else
+    printf 'egress=none\n'
+fi
+
+logfile="$STATE_DIR/sandbox.lastrun.log"
+"$SMOLVM" machine run --mem 2048 ${cache[@]+"${cache[@]}"} --image "$IMAGE" \
+    --volume "$REPO:/workspace:ro" \
+    --volume "$OUT:/out" \
+    ${allow[@]+"${allow[@]}"} \
+    -- "$@" > "$logfile" 2>&1 &
+cli_pid=$!
+
+# Record the VM before waiting on it. If the caller kills this script, the pid
+# in that file is the only route back to the machine.
+# 90 s: long enough to see the VM appear on a host that is pulling an image,
+# and bounded so a workload that finishes instantly does not stall the script.
+recorded=""
+waited=0
+while [ "$waited" -lt 90 ]; do
+    while read -r pid cfg; do
+        [ -n "$pid" ] || continue
+        case "$(printf '%s\n' "$before" | grep -c "^$pid$")" in
+            0) printf '%s %s\n' "$pid" "$cfg" >> "$PIDFILE"; recorded="$pid" ;;
+        esac
+    done <<EOF
+$(list_vm_processes)
+EOF
+    [ -n "$recorded" ] && break
+    kill -0 "$cli_pid" 2>/dev/null || break
+    sleep 1
+    waited=$((waited + 1))
+done
+
+if [ -n "$recorded" ]; then
+    printf 'vm_pid=%s\n' "$recorded"
+    printf 'vm_pid_recorded_in=%s\n' "$PIDFILE"
+else
+    printf 'vm_pid=not_observed\n'
+    printf 'note=the VM was not seen before the run ended, which is normal for a command that finishes in under a second. Nothing to cancel.\n'
+fi
+
+wait "$cli_pid"
+rc=$?
+sed 's/^/  /' "$logfile"
+
+# On the offline route the cache-hit line is the assertion that the bake worked
+# and that this run reached no registry. Without it the run pulled, which means
+# it had network, which means it was not the sandbox you asked for.
+if [ "$ROUTE" = "offline" ]; then
+    if grep -q 'host cache hit' "$logfile"; then
+        printf 'used_host_cache=yes\n'
+    else
+        printf 'used_host_cache=no\n'
+        printf 'note=no host cache hit on the offline route. Run bake.sh first: an ordinary earlier pull does not make a later run offline-capable, because the runtime still resolves the tag through the registry.\n'
+    fi
+else
+    printf 'used_host_cache=n_a_on_this_route\n'
+fi
+
+printf 'cli_exit=%s\n' "$rc"
+printf 'next: scripts/verify.sh, then scripts/cleanup.sh\n'
+exit "$rc"

--- a/skills/sandbox/scripts/verify.sh
+++ b/skills/sandbox/scripts/verify.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Assert the sandbox held: from inside the guest, and from the host afterwards.
+#
+# usage: verify.sh [--repo <dir>] [--out <dir>] [--expect-file <name>]
+#                  [--expect <value>] [--image <img>] [--route offline|network-on]
+#
+# Two halves, and both are needed. The inside half proves the workload could not
+# write the repo and could not reach the network; the host half proves the
+# artifact came out and the repo is unchanged. A run that "succeeded" tells you
+# neither.
+
+set -uo pipefail
+
+REPO="./repo"
+OUT="./out"
+EXPECT_FILE="result.txt"
+EXPECT=""
+IMAGE="python:3.12-alpine"
+ROUTE="offline"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --repo)        REPO="$2"; shift ;;
+        --out)         OUT="$2"; shift ;;
+        --expect-file) EXPECT_FILE="$2"; shift ;;
+        --expect)      EXPECT="$2"; shift ;;
+        --image)       IMAGE="$2"; shift ;;
+        --route)       ROUTE="$2"; shift ;;
+        *) printf 'unknown argument: %s\n' "$1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+if [ -z "$SMOLVM" ]; then
+    printf 'smolvm not found; set SMOLVM to its path\n' >&2
+    exit 2
+fi
+
+printf 'route=%s\n' "$ROUTE"
+REPO="$(cd "$REPO" && pwd)"
+OUT="$(cd "$OUT" && pwd)"
+
+# The probe must run in the same shape as the real run, or it proves nothing
+# about that run. On the network-on route the workload has egress by
+# construction, so the network assertion changes rather than disappearing.
+case "$ROUTE" in
+    offline)    cache=(--oci-cache); net=();       expect_net=blocked ;;
+    network-on) cache=();            net=(--net);  expect_net=REACHED ;;
+    *) printf 'unknown route: %s (offline or network-on)\n' "$ROUTE" >&2; exit 2 ;;
+esac
+
+fail=0
+check() {
+    if [ "$2" = "$3" ]; then
+        printf '%s=ok (%s)\n' "$1" "$2"
+    else
+        printf '%s=FAIL expected=%s actual=%s\n' "$1" "$3" "$2"
+        fail=1
+    fi
+}
+
+# --- from inside the guest, in the same shape a real run uses ----------------
+inside="$("$SMOLVM" machine run --mem 2048 ${cache[@]+"${cache[@]}"} ${net[@]+"${net[@]}"} --image "$IMAGE" \
+    --volume "$REPO:/workspace:ro" \
+    --volume "$OUT:/out" \
+    -- sh -c '
+        touch /workspace/SANDBOX_PROBE 2>/dev/null && echo "workspace=WRITABLE" || echo "workspace=readonly"
+        touch /out/SANDBOX_PROBE      2>/dev/null && echo "out=writable"       || echo "out=READONLY"
+        wget -q -T3 -O- http://example.com >/dev/null 2>&1 && echo "net=REACHED" || echo "net=blocked"
+    ' 2>&1 | tr -d '\r')"
+printf '%s\n' "$inside" | sed 's/^/  /'
+
+check inside_workspace "$(printf '%s' "$inside" | sed -n 's/^workspace=//p')" readonly
+check inside_out       "$(printf '%s' "$inside" | sed -n 's/^out=//p')"       writable
+check inside_network   "$(printf '%s' "$inside" | sed -n 's/^net=//p')"       "$expect_net"
+if [ "$ROUTE" = "network-on" ]; then
+    printf 'note=on this route the workload reaching the network is the expected result, not a failure. It is the price of the route, and the reason offline is the default.\n'
+fi
+
+# --- from the host afterwards ------------------------------------------------
+if [ -n "$EXPECT" ]; then
+    check artifact "$(cat "$OUT/$EXPECT_FILE" 2>/dev/null | tr -d '\r\n')" "$EXPECT"
+elif [ -s "$OUT/$EXPECT_FILE" ]; then
+    printf 'artifact=present (%s)\n' "$OUT/$EXPECT_FILE"
+else
+    printf 'artifact=FAIL missing or empty: %s\n' "$OUT/$EXPECT_FILE"
+    fail=1
+fi
+
+# The probe above tried to write the repo. If the read-only mount leaked, the
+# evidence is sitting in the repo now.
+if [ -e "$REPO/SANDBOX_PROBE" ]; then
+    printf 'repo_unchanged=FAIL the read-only mount leaked: %s/SANDBOX_PROBE exists\n' "$REPO"
+    fail=1
+else
+    printf 'repo_unchanged=ok\n'
+fi
+rm -f "$OUT/SANDBOX_PROBE"
+
+if [ "$fail" -eq 0 ]; then printf 'result=sandbox_held\n'; else printf 'result=FAILED\n'; fi
+exit "$fail"

--- a/skills/teardown/SKILL.md
+++ b/skills/teardown/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: teardown
+description: "Stops every smolvm machine a session started, removes smolvm's state, and proves the host is clean. Use after any smolvm session; when a machine seems to have survived a Ctrl-C or a crash; when disk space has disappeared; when uninstalling smolvm; when tearing down the Kubernetes runtime from a node; or when a borrowed or shared host has to be handed back with nothing left behind. Also use it as the cleanup step for other smolvm work, because the obvious assertions here give false results. Do not use it to delete machines another session created: it removes only what a script recorded under its own name prefix."
+---
+
+# Leaving nothing running and nothing behind
+
+Verified on **smolvm v1.14.6** on macOS arm64 and Linux aarch64, 2026-09-10. This packet exists on its own because **almost every cleanup fact
+in smolvm is counterintuitive**: the obvious assertion gives a false failure, the obvious reaper
+matches the wrong process or nothing at all, and the command a user reaches for when a run
+misbehaves does not stop the machine. Anything that starts machines needs this more than it needs
+any single feature.
+
+Every other packet's cleanup script is this packet's `scripts/cleanup.sh` with one line changed.
+
+## Procedure
+
+**1. See what is there.** Read-only: deletes nothing, starts no VM.
+
+```bash
+scripts/preflight.sh
+```
+
+It reports each state directory with its size, whether a `--oci-cache` image store exists,
+whether the launcher symlink and the `PATH` block are present, and whether state can be relocated
+on this platform.
+
+**2. Delete the machines your scripts created, and report the rest.**
+
+```bash
+scripts/cleanup.sh            # report leftover VM processes
+scripts/cleanup.sh --reap     # and kill them
+```
+
+Only machines recorded in the state file are deleted, so a machine you or another session created
+by hand is never touched. A script records what it creates with
+`scripts/cleanup.sh --record <name>`, and names must carry the `smolskill-` prefix or the delete
+is skipped. `--purge` removes the state file once the list is empty.
+
+The state file lives under `${XDG_STATE_HOME:-$HOME/.local/state}/smolvm-skills/`, outside
+`~/.smolvm` and outside smolvm's own caches. Nothing here edits smolvm configuration.
+
+**3. Prove it.**
+
+```bash
+scripts/verify-clean.sh
+scripts/verify-clean.sh --protected "$HOME/.smolvm"   # after a run under an isolated HOME
+```
+
+Each check prints `ok` or `FAIL expected=... actual=...`, and the script exits non-zero if any
+failed. `--protected <dir>` asserts nothing under a real installation was written today, which is
+how you show a test run under a scratch `HOME` did not reach it. Without it the check reports
+`protected=not_checked` rather than passing silently.
+
+**4. Reclaim space, or remove smolvm entirely.**
+
+```bash
+smolvm machine prune --name <NAME>   # one machine's unreferenced layers; --all drops its cached images
+smolvm pack prune
+curl -sSL https://smolmachines.com/install.sh | bash -s -- --uninstall
+```
+
+`references/locations.md` has the full layout, what the uninstaller removes, and the two things it
+deliberately leaves.
+
+## The four traps that make this a packet
+
+Full detail with the observations behind each is in `references/traps.md`.
+
+- **`Ctrl-C` does not stop the machine, and there is no CLI route to what it leaves.** The VM
+  outlives the CLI, `machine list` says `No machines found`, and no VM cache directory exists. The
+  VM exits only when its own workload finishes, so a run that loops or hangs is unbounded exposure.
+- **The two obvious reapers both fail, in opposite directions.** `pgrep -f _boot-vm` matches any
+  shell whose text contains that string, including the cleanup script, and reports orphans that do
+  not exist. `readlink /proc/<pid>/exe` reports none that do: the VM process is not dumpable, so
+  its `/proc/<pid>/exe` is root-owned and `readlink` returns `Permission denied` to the user who
+  started it. `cleanup.sh` matches `argv[1]` exactly instead, and scopes by the boot config's path.
+- **Asserting "no machines" immediately after `machine run` fails on a healthy host.** The entry
+  retires after the command returns, observed gone by 20 s.
+- **`machine delete` prompts and defaults to No.** Without `--force` a script prints `Cancelled`
+  and carries on believing it cleaned up. A branched machine also needs `--cascade`.
+
+And one false alarm: **`ls ~/.cache/smolvm/vms/ | wc -l` is not a leak check.** Once `--oci-cache`
+has run, `_shared` lives there holding the baked images. Both scripts exclude it.
+
+## Security defaults, and why they are the defaults
+
+- **Cleanup deletes only what it was told it created.** A shared host can carry another session's
+  machines, and during the runs behind this packet it did: a second VM under a different `HOME`
+  was live throughout. `cleanup.sh` listed only the processes whose boot config sits under its own
+  state tree and left the other one running. A cleanup script that kills every smolvm process is
+  fine on your laptop and destructive on a build agent.
+- **`--reap` is opt-in and prints what it is about to kill.** Killing a VM is not recoverable and
+  the VM cannot be identified from `machine list`, so the default is to report.
+- **Nothing here escalates privilege.** The one place teardown needs `sudo` is the Kubernetes
+  runtime, which installs outside your home directory; those commands are in
+  `references/kubernetes.md` for you to run and read, not wrapped in a script.
+- **The uninstaller leaves `~/.config/smolvm` and your `PATH` line on purpose**, because those
+  hold registry credentials and a change you made to your own shell profile.
+
+## Platform arms
+
+- **macOS arm64** and **Linux aarch64**: the scripts were run here.
+- **Linux x86_64**: the procedure was verified in the material behind this packet, on hosts that
+  no longer exist. The scripts themselves were not re-run there.
+- **Windows x86_64**: `references/windows.md`, **not re-run**, including by the 2026-09-11 batch
+  on v1.14.6, so that page stays a v1.14.2 record. The scripts are POSIX shell and do
+  not run there at all. Windows is the platform where this matters most, because state cannot be
+  relocated and one session left 30 GB in `%LOCALAPPDATA%\smolvm`.
+- **Kubernetes nodes**: `references/kubernetes.md`. Verified on Ubuntu 22.04 x86_64 with k3s in
+  the material behind this packet, not re-run here.
+
+## Eval prompts, and what they produced
+
+Run on 2026-09-07 PT against smolvm v1.14.2 from the published release, under an isolated `HOME`
+on macOS 26.6.2 arm64 and on Lima `linux-kvm` (Ubuntu 24.04 aarch64). Output is verbatim.
+
+**1. "I ran some smolvm machines. Clean up after me and show me the host is clean."**
+
+A machine was created, started, recorded, then cleaned up. macOS:
+
+```
+  Cleaning up data directory for vm: smolskill-td
+  Deleted machine: smolskill-td
+machines=clean
+vm_processes=none
+
+machines=ok
+vm_dirs=ok
+vm_processes=ok
+protected_untouched_since_2026-09-07=ok
+result=clean
+```
+
+Linux gave the same, with `protected=not_checked` because no real installation was named.
+
+**2. "Is anything still running that `smolvm machine list` cannot see?"**
+
+Run against a live machine, so this is the answer when the host is not clean. Linux:
+
+```
+vm_process=51706 config=/home/<user>/skp/.cache/smolvm/vms/2ec3433ec42ca6de/boot-config.json
+rerun with --reap to kill them
+```
+
+macOS:
+
+```
+vm_process=76032 config=/tmp/skp/Library/Caches/smolvm/vms/2ec3433ec42ca6de/boot-config.json
+```
+
+A second VM belonging to another session was live on the Linux host under a different `HOME`
+throughout, and was correctly not listed. The same run through `readlink /proc/<pid>/exe`
+returned nothing at all, which is the finding that changed this script.
+
+**3. "Prove my test run did not touch my real smolvm install."**
+
+```
+machines=ok
+vm_dirs=ok
+vm_processes=ok
+protected_untouched_since_2026-09-07=ok
+result=clean
+```
+
+against `--protected $HOME/.smolvm` on the macOS host, where a real v0.5.20 installation sits
+beside the isolated v1.14.2 one used for these runs.
+
+## Re-verified on v1.14.6
+
+Run 2026-09-10 PT against v1.14.6 on macOS 26.6.2 arm64 and Lima `linux-kvm` (Ubuntu 24.04
+aarch64). `verify-clean.sh` returned `result=clean` on both, including
+`protected_untouched_since_2026-09-10=ok` against the real installation on the Mac.
+
+**The reaper changed on this release**, and the change is the reason to read
+`references/traps.md` again: the pack-run path forks without execing, so its VM child carries no
+`_boot-vm` in argv and the previous scanner could not see it. Measured on v1.14.6 before the fix,
+`cleanup.sh` reported `vm_processes=none` and `result=clean` while two orphaned VMs held 234 MB
+each. The scanner now matches both process shapes and was verified against a live orphan on both
+hosts.
+
+## What was not run
+
+- **Windows.** `references/windows.md` records one run that was not repeated.
+- **Kubernetes.** `references/kubernetes.md` records a verified sequence on a node that no longer
+  exists.
+- **Linux x86_64.**
+- **The macOS `hdiutil` mount-point case.** `references/traps.md` records that `rm -rf` on the
+  pack cache can fail with `Resource busy` and what the uninstaller does about it. No pack was
+  created in these runs, so that path was not exercised here.
+- **`--oci-cache`.** No `_shared` store existed on either host, so the exclusion these scripts
+  carry was exercised only against its absence.
+
+## Related packets
+
+- `install` for what the install lays down, which is what you are removing.
+- Every other packet's `scripts/cleanup.sh` is this one.

--- a/skills/teardown/references/kubernetes.md
+++ b/skills/teardown/references/kubernetes.md
@@ -1,0 +1,39 @@
+# Tearing down the Kubernetes runtime
+
+Only relevant if you installed the smolvm containerd shim on a node. Deleting the pod is not the
+whole job: the runtime install is system-wide, the uninstaller does not know about it, and every
+command below reports success while leaving state behind.
+
+Verified on Ubuntu 22.04 x86_64 with k3s.
+
+```bash
+kubectl delete pod <name> --wait=true
+kubectl get pods                                  # No resources found
+
+# then, if you installed the runtime:
+sudo rm -f /usr/local/bin/containerd-shim-smolvm-v2 /usr/local/bin/containerd-shim-smolvm-v2.real
+sudo rm -rf /var/lib/smolvm /etc/systemd/system/k3s.service.d
+sudo /usr/local/bin/k3s-uninstall.sh              # if you installed k3s
+sudo rm -rf /var/lib/rancher                      # k3s-uninstall can leave this behind
+
+# the shim runs as root, so its VM state is in root's home, not yours:
+sudo rm -rf /var/lib/containerd-shim-smolvm /root/.cache/smolvm /root/.local/share/smolvm
+sudo rm -rf /var/log/pods/*smolvm* /var/log/containers/*smolvm*
+```
+
+Then prove it:
+
+```bash
+sudo find / -iname '*smolvm*' -not -path '/proc/*' -not -path '/sys/*'    # expect nothing
+```
+
+**Why the last two removal lines exist.** After `k3s-uninstall.sh` plus removing the shim and
+`/var/lib/smolvm`, which is everything the docs and the obvious reading describe, a filesystem
+sweep still found five more locations: `/var/lib/containerd-shim-smolvm` (4.5 MB),
+`/root/.cache/smolvm` (9.0 MB), `/root/.local/share/smolvm` (312 KB), and pod logs under
+`/var/log/pods` and `/var/log/containers`. **The shim runs as root, so its VM state lands in
+root's home rather than the operator's**, which is why a teardown run as the operator misses it.
+Only after removing those did the sweep come back empty.
+
+A GPU on the node is unaffected throughout: `nvidia-smi` still reported the device after the full
+sequence.

--- a/skills/teardown/references/locations.md
+++ b/skills/teardown/references/locations.md
@@ -1,0 +1,75 @@
+# Where smolvm state lives, and what removes it
+
+Observed on v1.14.2.
+
+| | macOS | Linux |
+|---|---|---|
+| install prefix | `$HOME/.smolvm` | `$HOME/.smolvm` |
+| launcher symlink | `$HOME/.local/bin/smolvm` | `$HOME/.local/bin/smolvm` |
+| agent rootfs | `$HOME/Library/Application Support/smolvm` | `$HOME/.local/share/smolvm` |
+| per-VM state | `$HOME/Library/Caches/smolvm/vms` | `$HOME/.cache/smolvm/vms` |
+| image cache, once `--oci-cache` has run | `.../smolvm/vms/_shared` | `.../smolvm/vms/_shared` |
+| pack cache | `$HOME/Library/Caches/smolvm-pack` | `$HOME/.cache/smolvm-pack` |
+| packed-binary lib cache | `$HOME/Library/Caches/smolvm-libs` | `$HOME/.cache/smolvm-libs` |
+| registry credentials | `$HOME/.config/smolvm` | `$HOME/.config/smolvm` |
+| `PATH` block | your shell profile | your shell profile |
+
+The last three are the ones people miss. `smolvm-libs` appears only once a packed `.smolmachine`
+stub has run, and the last two are deliberately left by the uninstaller.
+
+`scripts/preflight.sh` reports each of these with its size, so you know what a teardown has to
+remove before you remove it.
+
+## Relocating state, for a test run
+
+On macOS and Linux every path above derives from `HOME`, so installing with `HOME` pointed at a
+scratch directory keeps a test run entirely inside it. That is how the runs behind this packet
+avoided touching a real installation, and `scripts/verify-clean.sh --protected <real prefix>` is
+the assertion that proves it.
+
+`SMOLVM_DATA_DIR` moves the data root on **Linux only**: the function that applies it is compiled
+in for Linux and does not exist on macOS or Windows. On macOS `HOME` is still enough. On Windows
+neither works, which is what makes that platform's teardown a manual removal. See
+`references/windows.md`.
+
+## Full removal
+
+```bash
+curl -sSL https://smolmachines.com/install.sh | bash -s -- --uninstall
+```
+
+Verified complete on macOS against an isolated `HOME` used for a full session of machines, packs
+and `--oci-cache` runs:
+
+```
+success: Removed <HOME>/.smolvm
+success: Removed symlink <HOME>/.local/bin/smolvm
+success: Removed data directory <HOME>/Library/Application Support/smolvm
+success: Removed cache directory <HOME>/Library/Caches/smolvm
+success: Removed pack cache directory <HOME>/Library/Caches/smolvm-pack
+warning: You may want to remove the PATH entry from your shell profile.
+success: smolvm has been uninstalled
+```
+
+Afterwards `find "$HOME" -iname '*smolvm*'` returned nothing. It removes `smolvm-libs` too when
+present.
+
+The two things it deliberately leaves, both of which it warns about:
+
+```bash
+# 1. the PATH block it added to your shell profile
+sed -i.bak '/# smolvm/,+1d' ~/.zshrc     # or ~/.bashrc; read the file before running this
+
+# 2. registry credentials, if you ever logged in to a registry
+rm -rf ~/.config/smolvm
+```
+
+`--uninstall` is documented only in `scripts/install.sh --help`, not in the README or on the docs
+site.
+
+## Reclaiming space without uninstalling
+
+```bash
+smolvm machine prune --name <NAME>   # one machine's unreferenced layers; --all drops its cached images
+smolvm pack prune                    # cached pack extractions
+```

--- a/skills/teardown/references/traps.md
+++ b/skills/teardown/references/traps.md
@@ -1,0 +1,96 @@
+# Teardown traps
+
+Almost every cleanup fact in smolvm is counterintuitive: the obvious assertion gives a false
+failure, the obvious reaper matches the wrong process, and the command a user reaches for when a
+run misbehaves does not stop the machine. Each entry below was hit on a real host.
+
+## `Ctrl-C` does not stop the machine
+
+**And there is no CLI route to the machine it leaves behind.** From a clean zero-process
+baseline, the VM's two processes were still alive at t+10 s, t+30 s and t+60 s after `SIGINT` to
+the CLI, and `SIGKILL` to the CLI left one. Throughout, `smolvm machine list` says
+`No machines found` and no VM cache directory exists.
+
+The VM exits only when its own **workload** finishes: a run whose command was `sleep 45` was gone
+30 s after the interrupt; one running `sleep 300` was still alive at 60 s. For a sandbox running
+untrusted code that loops or hangs, the exposure is unbounded.
+
+`scripts/cleanup.sh` is the only way to find it.
+
+## Three reapers that look right, and what each one misses
+
+**`pgrep -f _boot-vm` is too wide.** Any process whose command line contains that string matches,
+including the cleanup script itself. That produced a phantom "1 orphan survived" result and a
+confounded baseline that briefly made `Ctrl-C` look clean.
+
+**`readlink /proc/<pid>/exe` is unreliable in both directions.** For the exec'd VM child the
+process is not dumpable, so `/proc/<pid>/exe` is root-owned and `readlink` returns
+`Permission denied` to the user who started it:
+
+```
+$ ls -l /proc/51706/exe
+ls: cannot read symbolic link '/proc/51706/exe': Permission denied
+```
+
+On v1.14.6 it is readable for the forked child, which makes it useful for scoping and still no
+good for finding.
+
+**Matching `argv[1] == "_boot-vm"` is exact, and blind to half the VMs.** There are two shapes:
+
+| route | child | argv[1] | carries its boot config |
+|---|---|---|---|
+| plain `machine run` | exec'd | `_boot-vm` | yes, in argv[2] |
+| pack-run (`--oci-cache`, or any `init`) | **forked, never exec'd** | inherited, so `machine` | **no** |
+
+The forked child inherits the parent's whole command line, so nothing in its argv marks it as a
+VM. Measured on v1.14.6 on Ubuntu 24.04 aarch64 with two such orphans alive at 234 MB each, the
+argv-only scanner reported `vm_processes=none` and `result=clean`. **That is the worst of the
+outcomes: a false clean.**
+
+**What works.** On Linux both shapes rename themselves to `libkrun VM`, which no shell can hold,
+so `scripts/cleanup.sh` matches `/proc/<pid>/comm`, then scopes by argv[2] where it exists and by
+the executable's path where it does not. macOS exposes no rename, so the search is scoped by the
+executable path under this `HOME` and the parent chain separates a VM from the CLI that started
+it. Verified against a live orphan on both hosts.
+
+## Asserting "no machines" immediately after `machine run` fails on a healthy system
+
+A successful `machine run` returns **before** its entry retires. It was observed still listed as
+`vm-... unreachable (eph)` immediately after the command returned, and gone by 20 s. This is the
+single most likely false failure in a scripted teardown, and it is why `cleanup.sh` waits.
+
+## `machine delete` prompts and defaults to No
+
+Without `--force` a scripted cleanup prints `Delete machine '<name>'? [y/N] Cancelled` and
+**leaves the machine in place**, while the surrounding script carries on believing it cleaned up.
+A machine that has been branched additionally needs `--cascade`, which removes the children first.
+
+## `ls ~/.cache/smolvm/vms/ | wc -l` is not a leak check
+
+Once `--oci-cache` has been used, a `_shared` directory lives there holding the baked images
+(379 MB after one Python image). It is the cache, not residue. `cleanup.sh` and
+`verify-clean.sh` both exclude it.
+
+## Small leftover VM directories are not necessarily a leak either
+
+`smolvm serve start` prints `Reclaimed 2 dangling VM data dir(es)` on startup and clears them, so
+a directory left by a force-killed run is tidied the next time the API server runs.
+
+## On macOS, do not `rm -rf` the pack cache by hand
+
+`smolvm-pack` can contain `layers-cs` directories that are live `hdiutil` mount points, and `rm`
+fails on them with `Resource busy`. The uninstaller detaches them first
+(`find ... -name layers-cs -type d -exec hdiutil detach {} -force \;`); do the same if you are
+cleaning up manually.
+
+## Pre-existing residue is not yours
+
+Check timestamps and paths before reporting a leak. During the runs behind this packet a second
+VM belonging to another session was live on the same host, under a different `HOME`;
+`cleanup.sh` listed only the one under its own state tree and left the other running, which is
+the behaviour you want from anything you let run unattended.
+
+## Nothing in the docs describes cancellation or teardown
+
+`guides/agent-sandboxes-ci.md` is the page a sandbox author would read and it never mentions how
+to stop a run, which matters given the `Ctrl-C` behaviour above.

--- a/skills/teardown/references/windows.md
+++ b/skills/teardown/references/windows.md
@@ -1,0 +1,74 @@
+# Teardown on Windows
+
+**Not re-run.** Every command and output below was executed once on Windows 11 Home build 26200
+x86_64 against smolvm v1.14.2 and is reproduced unchanged. The Windows host was not available when
+this packet was written, and the 2026-09-11 batch on v1.14.6 did not reach this arm either, so
+everything here remains a v1.14.2 record.
+
+`scripts/preflight.sh`, `scripts/cleanup.sh` and `scripts/verify-clean.sh` are POSIX shell and do
+not run here. Follow this page instead.
+
+## Why Windows teardown matters more than elsewhere
+
+**smolvm's state cannot be relocated on Windows.** There is no `SMOLVM_DATA_DIR` in the Windows
+binary, and setting `$env:LOCALAPPDATA` moves nothing: smolvm resolves the known folder through
+the Windows API, which ignores the variable, and writes to the real `%LOCALAPPDATA%\smolvm`
+regardless. There is no isolated-HOME trick, so every test run writes into the real profile and
+teardown is the only way back.
+
+**The sizes are the surprise.** `%LOCALAPPDATA%\smolvm` reached **30756 MB** in one session,
+because each machine's storage and overlay images are sparse files with 20 GiB and 10 GiB
+apparent size. The session's own working directory was 1454 MB. A user who deletes only their
+working directory leaves 30 GB behind with nothing pointing at it.
+`%LOCALAPPDATA%\smolvm-pack` separately reached 92 GB apparent after three `pack run`s of one
+alpine pack.
+
+## The sequence
+
+```powershell
+# 1. delete every machine (--force, and --cascade for branch sources)
+& $exe machine list
+& $exe machine delete --name <each> --force --cascade
+
+# 2. stop anything still running
+Get-Process | Where-Object { $_.Path -like '*smolvm*' } | Stop-Process -Force
+
+# 3. remove the state smolvm created outside your working directory
+Remove-Item -Recurse -Force "$env:LOCALAPPDATA\smolvm"
+Remove-Item -Recurse -Force "$env:LOCALAPPDATA\smolvm-pack"   # exists once packs have run
+
+# 4. remove your own working directory
+Remove-Item -Recurse -Force <your scratch dir>
+```
+
+**A killed `--oci-cache` bake leaves a registered machine** named `init-bake-<hash>-<pid>`. It
+appears in `machine list` and has to be deleted like any other machine; nothing cleans it up, and
+they accumulate. On the tested host the bake never completed at all, so this is not a rare case:
+the helper VM finished its pull and went idle while the host CLI waited forever for a completion
+signal, and every attempt had to be killed.
+
+## Verify, and do not skip this
+
+```powershell
+Get-Process | Where-Object { $_.Path -like '*smolvm*' }                       # expect nothing
+Get-ChildItem $env:USERPROFILE,'C:\ProgramData' -Recurse -Force -Filter '*smolvm*' -EA SilentlyContinue
+Get-NetFirewallApplicationFilter | Where-Object { $_.Program -like '*smolvm*' }
+```
+
+All three returned nothing after the sequence above.
+
+## Proving a borrowed host was left clean
+
+The method used on the tested host, which was borrowed and had to be returned: record
+`path|size|mtime` for `%USERPROFILE%` and `C:\ProgramData` before and after, excluding your own
+working directory, then compare. `%LOCALAPPDATA%`, `%APPDATA%` and `%TEMP%` are all **inside**
+`%USERPROFILE%`, so listing them separately quadruples the work for no extra coverage: the naive
+version of that scan did not finish, and the de-duplicated one took 167 s for 982653 entries.
+The assertion that matters is that no new entry matches `smolvm|krun|libkrunfw`.
+
+## One more Windows process fact
+
+The `pack run` boot path spawns a **detached** `_boot-vm` rather than forking, with
+`DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP`. Measured on the tested host: the child survives a
+real `Ctrl-C` and a kill of the CLI, holds about 365 MB, and is invisible to `machine ls`. Only
+killing the child ends it, so step 2 above is not optional on Windows either.

--- a/skills/teardown/scripts/cleanup.sh
+++ b/skills/teardown/scripts/cleanup.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Delete the machines this packet's scripts created, then prove the host is clean.
+#
+# Only machines recorded in the state file are deleted, so a machine you or
+# another session created by hand is never touched. Scripts record a name by
+# calling: cleanup.sh --record <name>
+#
+# usage: cleanup.sh [--record <name>] [--reap] [--purge]
+#   --record <name>  add a machine name to the state file and exit
+#   --reap           kill leftover VM processes (see the warning it prints)
+#   --purge          also remove the state file once the list is empty
+
+set -uo pipefail
+
+PACKET="teardown"
+PREFIX="smolskill-"
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+STATE_DIR="${SMOLVM_SKILL_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/smolvm-skills}"
+STATE_FILE="$STATE_DIR/$PACKET.machines"
+
+reap=0
+purge=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --record)
+            mkdir -p "$STATE_DIR"
+            printf '%s\n' "$2" >> "$STATE_FILE"
+            exit 0
+            ;;
+        --reap)  reap=1 ;;
+        --purge) purge=1 ;;
+        *) printf 'unknown argument: %s\n' "$1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+if [ -z "$SMOLVM" ]; then
+    printf 'smolvm not found; set SMOLVM to its path\n' >&2
+    exit 2
+fi
+
+case "$(uname -s)" in
+    Darwin) VMS_DIR="$HOME/Library/Caches/smolvm/vms" ;;
+    *)      VMS_DIR="${SMOLVM_DATA_DIR:-$HOME/.cache/smolvm}/vms" ;;
+esac
+VMS_DIR="${SMOLVM_VMS_DIR:-$VMS_DIR}"
+SMOLVM_PREFIX="${SMOLVM_PREFIX:-$HOME/.smolvm}"
+
+# List this HOME's smolvm VM processes, as "pid marker".
+#
+# Two process shapes exist and a reaper has to catch both. The plain
+# `machine run` path EXECS a child whose argv[1] is `_boot-vm` and whose argv[2]
+# is its boot-config path. The pack-run path, which is `--oci-cache` or any
+# `init`, FORKS without execing, so the child inherits the parent's argv and
+# carries no boot-config at all. Matching `_boot-vm` alone is therefore blind to
+# exactly the path whose child survives an interrupt
+# (smol-machines/smolvm#1193): measured on v1.14.6, it reported "none" while two
+# orphaned VMs held 234 MB each.
+#
+# On Linux both shapes rename themselves to `libkrun VM`, the one marker that
+# covers both and that no shell can hold. macOS exposes no rename, so there the
+# executable path scopes the search to this HOME and the parent chain separates
+# a VM from the CLI that started it.
+#
+# `pgrep -f _boot-vm` is not an alternative: it matches any shell whose text
+# contains that string, including this script.
+list_vm_processes() {
+    case "$(uname -s)" in
+        Linux)
+            for p in /proc/[0-9]*; do
+                [ "$(cat "$p/comm" 2>/dev/null)" = "libkrun VM" ] || continue
+                pid="${p#/proc/}"
+                cfg="$(tr '\0' '\n' < "$p/cmdline" 2>/dev/null | sed -n '3p')"
+                case "$cfg" in
+                    "$VMS_DIR"/*) printf '%s %s\n' "$pid" "$cfg"; continue ;;
+                esac
+                # Forked shape: nothing in argv identifies it, so scope by the
+                # binary it is running.
+                case "$(readlink "$p/exe" 2>/dev/null)" in
+                    "$SMOLVM_PREFIX"/*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;;
+                esac
+            done
+            ;;
+        Darwin)
+            # shellcheck disable=SC2009  # pgrep cannot return ppid and the full
+            # command together, and pgrep -f matches this script's own text.
+            own=" $(ps -axo pid=,command= 2>/dev/null | grep -F "$SMOLVM_PREFIX/smolvm-bin" | awk '{print $1}' | tr '\n' ' ') "
+            ps -axo pid=,ppid=,command= 2>/dev/null | while read -r pid ppid rest; do
+                case "$rest" in "$SMOLVM_PREFIX"/smolvm-bin*) ;; *) continue ;; esac
+                case "$rest" in
+                    *" _boot-vm "*) printf '%s %s\n' "$pid" "${rest#* _boot-vm }"; continue ;;
+                esac
+                # Forked shape: its parent is the CLI that started it, or init
+                # once that CLI is gone.
+                if [ "$ppid" = 1 ]; then
+                    printf '%s orphaned-under %s\n' "$pid" "$SMOLVM_PREFIX"
+                else
+                    case "$own" in *" $ppid "*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;; esac
+                fi
+            done
+            ;;
+    esac
+}
+
+# 1. Delete recorded machines. --force is not optional: without it the command
+# prompts, defaults to No, and leaves the machine in place while the script
+# carries on. --cascade removes branch children, which otherwise block the
+# delete.
+if [ -s "$STATE_FILE" ]; then
+    while read -r name; do
+        [ -n "$name" ] || continue
+        case "$name" in "$PREFIX"*) ;; *)
+            printf 'skipping %s: not created by this packet (no %s prefix)\n' "$name" "$PREFIX"
+            continue ;;
+        esac
+        "$SMOLVM" machine stop   --name "$name" >/dev/null 2>&1
+        "$SMOLVM" machine delete --name "$name" --force --cascade 2>&1 | sed 's/^/  /'
+    done < "$STATE_FILE"
+fi
+
+# 2. An ephemeral machine's entry retires after the run returns, not with it.
+# Asserting an empty list immediately fails on a healthy host.
+sleep 20
+
+# 3. Assert the value, not the exit code.
+listing="$("$SMOLVM" machine list 2>&1)"
+if printf '%s' "$listing" | grep -q 'No machines found'; then
+    printf 'machines=clean\n'
+    [ "$purge" -eq 1 ] && rm -f "$STATE_FILE"
+else
+    printf 'machines=remaining\n'
+    printf '%s\n' "$listing" | sed 's/^/  /'
+fi
+
+# 4. Report VM processes an interrupt left behind. Ctrl-C does not stop a
+# machine: the VM outlives the CLI and `machine list` cannot see it, so this is
+# the only route to it. Only processes whose boot config lives under this HOME's
+# smolvm state are listed, so a VM another session started is left alone.
+found=0
+while read -r pid cfg; do
+    [ -n "$pid" ] || continue
+    found=1
+    printf 'vm_process=%s config=%s\n' "$pid" "$cfg"
+    if [ "$reap" -eq 1 ]; then
+        kill -9 "$pid" 2>/dev/null && printf '  killed %s\n' "$pid"
+    fi
+done <<EOF
+$(list_vm_processes)
+EOF
+
+if [ "$found" -eq 0 ]; then
+    printf 'vm_processes=none\n'
+elif [ "$reap" -eq 0 ]; then
+    printf 'rerun with --reap to kill them\n'
+fi

--- a/skills/teardown/scripts/preflight.sh
+++ b/skills/teardown/scripts/preflight.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Report what smolvm state exists on this host, so you know what teardown has to
+# remove before you remove it. Read-only: deletes nothing, starts no VM.
+#
+# Output is one key=value per line. The last line is always result=ready or
+# result=blocked.
+
+set -uo pipefail
+
+VERIFIED_VERSION="1.14.6"
+
+emit() { printf '%s=%s\n' "$1" "$2"; }
+note() { printf 'note=%s\n' "$1"; }
+
+blocked=0
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+if [ -z "$SMOLVM" ]; then
+    emit smolvm_installed no
+    blocked=1
+else
+    emit smolvm_installed yes
+    version="$("$SMOLVM" --version 2>/dev/null | awk '{print $NF}')"
+    emit smolvm_version "${version:-unknown}"
+fi
+
+emit verified_version "$VERIFIED_VERSION"
+if [ -n "${version:-}" ] && [ "$version" != "unknown" ]; then
+    if [ "$version" = "$VERIFIED_VERSION" ]; then
+        emit version_status match
+    else
+        newest="$(printf '%s\n%s\n' "$version" "$VERIFIED_VERSION" | sort -V | tail -1)"
+        if [ "$newest" = "$version" ]; then
+            emit version_status newer
+            note "this packet was verified on $VERIFIED_VERSION and the binary is $version; check each path below still exists before trusting a removal step"
+        else
+            emit version_status older
+        fi
+    fi
+else
+    emit version_status unknown
+fi
+
+kernel="$(uname -s)"
+arch="$(uname -m)"
+case "$arch" in aarch64|arm64) arch=aarch64 ;; esac
+
+case "$kernel" in
+    Darwin)
+        emit platform "darwin-$arch"
+        emit accel hvf
+        if [ "$(sysctl -n kern.hv_support 2>/dev/null)" = "1" ]; then emit accel_access ok; else emit accel_access denied; fi
+        data_dir="$HOME/Library/Application Support/smolvm"
+        cache_dir="$HOME/Library/Caches/smolvm"
+        pack_dir="$HOME/Library/Caches/smolvm-pack"
+        libs_dir="$HOME/Library/Caches/smolvm-libs"
+        emit unsupported "vulkan,cuda"
+        # There is no SMOLVM_DATA_DIR on macOS (it is Linux-only), but every path
+        # below is derived from HOME, so an install under a scratch HOME is
+        # self-contained. Windows is the platform where neither route works.
+        emit state_relocatable via_home
+        ;;
+    Linux)
+        emit platform "linux-$arch"
+        emit accel kvm
+        if [ -r /dev/kvm ] && [ -w /dev/kvm ]; then emit accel_access ok; else emit accel_access denied; fi
+        data_dir="$HOME/.local/share/smolvm"
+        cache_dir="$HOME/.cache/smolvm"
+        pack_dir="$HOME/.cache/smolvm-pack"
+        libs_dir="$HOME/.cache/smolvm-libs"
+        emit unsupported "vulkan"
+        emit state_relocatable via_home_or_data_dir
+        ;;
+    *)
+        emit platform "unsupported-$kernel"
+        emit accel unknown
+        emit accel_access unknown
+        blocked=1
+        note "this script covers macOS and Linux. The Windows removal sequence is references/windows.md and was not re-run by this packet."
+        exit_now=1
+        ;;
+esac
+
+if [ "${exit_now:-0}" = "1" ]; then
+    emit result blocked
+    exit 0
+fi
+
+report_dir() {
+    if [ -d "$2" ]; then
+        emit "$1" "$(du -sk "$2" 2>/dev/null | awk '{printf "%d", $1/1024}')MB"
+    else
+        emit "$1" absent
+    fi
+}
+
+report_dir install_prefix "$HOME/.smolvm"
+report_dir agent_rootfs   "$data_dir"
+report_dir vm_state       "$cache_dir"
+report_dir pack_cache     "$pack_dir"
+report_dir packed_libs    "$libs_dir"
+report_dir credentials    "$HOME/.config/smolvm"
+
+if [ -L "$HOME/.local/bin/smolvm" ]; then emit launcher_symlink present; else emit launcher_symlink absent; fi
+
+# `_shared` is the image store --oci-cache bakes into. It is the cache, not
+# residue, so counting it as a leak gives a false positive.
+if [ -d "$cache_dir/vms" ]; then
+    total="$(find "$cache_dir/vms" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')"
+    shared=0
+    [ -d "$cache_dir/vms/_shared" ] && shared=1
+    emit vm_dirs "$((total - shared))"
+    if [ "$shared" = 1 ]; then emit oci_cache_present yes; else emit oci_cache_present no; fi
+else
+    emit vm_dirs 0
+    emit oci_cache_present no
+fi
+
+if grep -rqs 'smolvm' "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.profile" 2>/dev/null; then
+    emit path_block present
+    note "the uninstaller deliberately leaves the PATH block and \$HOME/.config/smolvm; remove them by hand if you want them gone"
+else
+    emit path_block absent
+fi
+
+if [ "$blocked" -eq 0 ]; then emit result ready; else emit result blocked; fi

--- a/skills/teardown/scripts/verify-clean.sh
+++ b/skills/teardown/scripts/verify-clean.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Prove the host is clean after a teardown. Every check asserts a value rather
+# than an exit code, because the commands teardown runs report success while
+# leaving state behind.
+#
+# usage: verify-clean.sh [--protected <dir>] [--since <date>]
+#   --protected <dir>  assert nothing under <dir> was written on or after --since.
+#                      Point it at a real installation you ran beside: that is how
+#                      you show a test under an isolated HOME did not reach it.
+#                      Omitted, the check is reported as not run rather than passed.
+#   --since <date>     the cutoff for --protected (default: today)
+
+set -uo pipefail
+
+SMOLVM="${SMOLVM:-$(command -v smolvm 2>/dev/null)}"
+since="$(date +%F)"
+protected=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --protected) protected="$2"; shift ;;
+        --since)     since="$2"; shift ;;
+        *) printf 'unknown argument: %s\n' "$1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+fail=0
+check() {
+    if [ "$2" = "$3" ]; then
+        printf '%s=ok\n' "$1"
+    else
+        printf '%s=FAIL expected=%s actual=%s\n' "$1" "$3" "$2"
+        fail=1
+    fi
+}
+
+if [ -n "$SMOLVM" ]; then
+    if "$SMOLVM" machine list 2>&1 | grep -q 'No machines found'; then
+        check machines clean clean
+    else
+        check machines dirty clean
+    fi
+else
+    printf 'machines=skipped (smolvm not on PATH; it may already be uninstalled)\n'
+fi
+
+case "$(uname -s)" in
+    Darwin) cache_dir="$HOME/Library/Caches/smolvm" ;;
+    *)      cache_dir="${SMOLVM_DATA_DIR:-$HOME/.cache/smolvm}" ;;
+esac
+VMS_DIR="${SMOLVM_VMS_DIR:-$cache_dir/vms}"
+SMOLVM_PREFIX="${SMOLVM_PREFIX:-$HOME/.smolvm}"
+
+# List this HOME's smolvm VM processes, as "pid marker".
+#
+# Two process shapes exist and a reaper has to catch both. The plain
+# `machine run` path EXECS a child whose argv[1] is `_boot-vm` and whose argv[2]
+# is its boot-config path. The pack-run path, which is `--oci-cache` or any
+# `init`, FORKS without execing, so the child inherits the parent's argv and
+# carries no boot-config at all. Matching `_boot-vm` alone is therefore blind to
+# exactly the path whose child survives an interrupt
+# (smol-machines/smolvm#1193): measured on v1.14.6, it reported "none" while two
+# orphaned VMs held 234 MB each.
+#
+# On Linux both shapes rename themselves to `libkrun VM`, the one marker that
+# covers both and that no shell can hold. macOS exposes no rename, so there the
+# executable path scopes the search to this HOME and the parent chain separates
+# a VM from the CLI that started it.
+#
+# `pgrep -f _boot-vm` is not an alternative: it matches any shell whose text
+# contains that string, including this script.
+list_vm_processes() {
+    case "$(uname -s)" in
+        Linux)
+            for p in /proc/[0-9]*; do
+                [ "$(cat "$p/comm" 2>/dev/null)" = "libkrun VM" ] || continue
+                pid="${p#/proc/}"
+                cfg="$(tr '\0' '\n' < "$p/cmdline" 2>/dev/null | sed -n '3p')"
+                case "$cfg" in
+                    "$VMS_DIR"/*) printf '%s %s\n' "$pid" "$cfg"; continue ;;
+                esac
+                # Forked shape: nothing in argv identifies it, so scope by the
+                # binary it is running.
+                case "$(readlink "$p/exe" 2>/dev/null)" in
+                    "$SMOLVM_PREFIX"/*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;;
+                esac
+            done
+            ;;
+        Darwin)
+            # shellcheck disable=SC2009  # pgrep cannot return ppid and the full
+            # command together, and pgrep -f matches this script's own text.
+            own=" $(ps -axo pid=,command= 2>/dev/null | grep -F "$SMOLVM_PREFIX/smolvm-bin" | awk '{print $1}' | tr '\n' ' ') "
+            ps -axo pid=,ppid=,command= 2>/dev/null | while read -r pid ppid rest; do
+                case "$rest" in "$SMOLVM_PREFIX"/smolvm-bin*) ;; *) continue ;; esac
+                case "$rest" in
+                    *" _boot-vm "*) printf '%s %s\n' "$pid" "${rest#* _boot-vm }"; continue ;;
+                esac
+                # Forked shape: its parent is the CLI that started it, or init
+                # once that CLI is gone.
+                if [ "$ppid" = 1 ]; then
+                    printf '%s orphaned-under %s\n' "$pid" "$SMOLVM_PREFIX"
+                else
+                    case "$own" in *" $ppid "*) printf '%s forked-under %s\n' "$pid" "$SMOLVM_PREFIX" ;; esac
+                fi
+            done
+            ;;
+    esac
+}
+
+# _shared is the --oci-cache image store, not residue. Excluding it is what
+# makes this a leak check rather than a false alarm.
+if [ -d "$cache_dir/vms" ]; then
+    left="$(find "$cache_dir/vms" -mindepth 1 -maxdepth 1 -type d ! -name _shared 2>/dev/null | wc -l | tr -d ' ')"
+else
+    left=0
+fi
+check vm_dirs "$left" 0
+
+procs="$(list_vm_processes | grep -c . )"
+check vm_processes "$procs" 0
+
+# Proof that a run under an isolated HOME left a real installation alone. Silence
+# here would read as a pass, so an unchecked run says so.
+if [ -n "$protected" ]; then
+    touched="$(find "$protected" -newermt "$since" 2>/dev/null | wc -l | tr -d ' ')"
+    check "protected_untouched_since_$since" "$touched" 0
+else
+    printf 'protected=not_checked (pass --protected <dir> to assert a real install was untouched)\n'
+fi
+
+if [ "$fail" -eq 0 ]; then printf 'result=clean\n'; else printf 'result=dirty\n'; fi
+exit "$fail"


### PR DESCRIPTION
Second set (2/2) of runbooks to improve agent experience.

A coding agent that wants to use smolvm for its features runs into traps we already stepped into during development, and needs to spend extra time and tokens to debug and figure out the process.

**#1175 asks for an official, maintained skill that removes this type of work.**
_This PR adds five more task-scoped packets under skills/: dev-env, local-api, docker-in-machine, gpu-cuda and pack._

It also corrects the Windows caveat in AGENTS.md, README.md and the shipped README.txt: three places said no GPU on Windows, but CUDA works there and Vulkan does not. The sibling pointers and the AGENTS.md table are completed for all eight.

pack, the eighth packet, turns an image or a provisioned machine into one portable artifact. Its load bearing assertion is a marker written into the source and read back out of the artifact, because a pack that lost its rootfs still boots and exits zero. Its preflight names the failure that names nothing, the exporter's fixed 8192 MiB.

---

Every step was run end to end on the published v1.14.6, on macOS 26.6.2 arm64 and Ubuntu 24.04 aarch64 (pack on both, 09-11). gpu-cuda was also run on an NVIDIA A10 (Ubuntu 22.04 x86_64): the probe reached the device on two glibc images and the packet records that run. The Windows arms were re-run on v1.14.6 on 2026-09-11: dev-env, local-api, pack and gpu-cuda confirm there, and docker-in-machine never got past the image pull, so its page is unchanged.

Two limitations, both named in the packets:
- docker-in-machine is blocked on Windows, because the guest kernel there has no bridge and no POSIX mqueue
- local-api has no Unix socket on Windows, loopback TCP only

Not yet written: checkpoint-and-branch (currently moving), kubernetes-runtime (waits on #1179 and an answer on #889), and gpu-vulkan (no tested host offers a Venus capset).

This PR completes the initial skill packets set with #1208.




