### PR TITLE
Honor operation-specific API timeouts

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -191,10 +191,11 @@ use state::ApiState;
 )]
 pub struct ApiDoc;
 
-/// Default timeout for API requests (5 minutes).
-/// Most operations (start, stop, exec) complete within this time.
-/// Long-running operations like image pulls may need longer, but this
-/// provides a reasonable upper bound for most requests.
+/// Default timeout for bounded API requests (5 minutes).
+///
+/// Operations whose duration is controlled by the caller (exec/run), or by an
+/// explicit longer transfer deadline (image pulls), are deliberately not
+/// wrapped in this timeout.
 const API_REQUEST_TIMEOUT_SECS: u64 = 300;
 
 /// Body cap for the file-upload route. axum's 2 MiB default silently 413s larger
@@ -262,16 +263,17 @@ pub fn create_router(state: Arc<ApiState>, cors_origins: Vec<String>) -> Router 
             get(handlers::exec::exec_interactive),
         );
 
-    // Machine routes with timeout
-    let machine_routes_with_timeout = Router::new()
-        .route("/", post(handlers::machines::create_machine))
+    // Bounded metadata and lifecycle routes. These have no caller-selected
+    // runtime and transfer no unbounded payload, so a stuck request should not
+    // occupy a server task forever.
+    let bounded_machine_routes = Router::new()
         .route("/", get(handlers::machines::list_machines))
         .route("/{id}", get(handlers::machines::get_machine))
         .route(
             "/{id}/egress-events",
             get(handlers::machines::get_machine_egress_events),
         )
-        .route("/{id}/start", post(handlers::machines::start_machine))
+        .route("/", post(handlers::machines::create_machine))
         .route("/{id}/branches", post(handlers::machines::branch_machine))
         .route("/{id}/fork", post(handlers::machines::fork_machine))
         .route(
@@ -287,10 +289,6 @@ pub fn create_router(state: Arc<ApiState>, cors_origins: Vec<String>) -> Router 
         .route("/{id}/resize", post(handlers::machines::resize_machine))
         .route("/{id}/export", post(handlers::machines::export_machine))
         .route("/{id}", delete(handlers::machines::delete_machine))
-        // Exec routes
-        .route("/{id}/exec", post(handlers::exec::exec_command))
-        .route("/{id}/exec/stream", post(handlers::exec::exec_stream))
-        .route("/{id}/run", post(handlers::exec::run_command))
         // File I/O routes. The upload handler buffers the whole body (`body:
         // Bytes`), so without a raised limit axum's 2 MiB default rejects any
         // larger upload with a bare 413 "Failed to buffer the request body" —
@@ -303,19 +301,28 @@ pub fn create_router(state: Arc<ApiState>, cors_origins: Vec<String>) -> Router 
             put(handlers::files::upload_file).layer(DefaultBodyLimit::max(MAX_FILE_UPLOAD_BYTES)),
         )
         .route("/{id}/files/{*path}", get(handlers::files::download_file))
-        // Image routes
         .route("/{id}/images", get(handlers::images::list_images))
-        .route("/{id}/images/pull", post(handlers::images::pull_image))
-        // Apply timeout only to these routes
         .layer(TimeoutLayer::with_status_code(
             StatusCode::REQUEST_TIMEOUT,
             Duration::from_secs(API_REQUEST_TIMEOUT_SECS),
         ));
 
+    // Long operations own their deadline. In particular, exec and run pass
+    // `timeout_secs` through to the guest agent; wrapping them in the generic
+    // five-minute timeout used to turn a valid 30-minute exec into an HTTP 408
+    // at 300 seconds. Image pulls already carry a ten-minute agent deadline.
+    let long_machine_routes = Router::new()
+        .route("/{id}/start", post(handlers::machines::start_machine))
+        .route("/{id}/exec", post(handlers::exec::exec_command))
+        .route("/{id}/exec/stream", post(handlers::exec::exec_stream))
+        .route("/{id}/run", post(handlers::exec::run_command))
+        .route("/{id}/images/pull", post(handlers::images::pull_image));
+
     // Machine routes
     let machine_routes = Router::new()
         .merge(logs_route)
-        .merge(machine_routes_with_timeout);
+        .merge(bounded_machine_routes)
+        .merge(long_machine_routes);
 
     // Automatic pool operations are bounded by the same request timeout as
     // machine lifecycle calls. Pool fill and worker replacement happen in the


### PR DESCRIPTION
Lets exec, run, start, and image-pull requests use their operation-specific deadlines instead of the generic five-minute API limit.