### PR TITLE
Fix scoped memory, UID-isolated checkpoints, and VM restart safety

### DIFF
--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -280,6 +280,40 @@ const TIMEOUT_BUFFER_SECS: u64 = 5;
 /// likely already torn down — safe to proceed with SIGTERM.
 const SHUTDOWN_ACK_TIMEOUT_SECS: u64 = 5;
 
+fn shutdown_io_until(
+    deadline: Instant,
+    mut operation: impl FnMut() -> std::io::Result<usize>,
+) -> std::io::Result<usize> {
+    loop {
+        if Instant::now() >= deadline {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "shutdown deadline exceeded",
+            ));
+        }
+        match operation() {
+            Ok(0) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "connection closed",
+                ))
+            }
+            Ok(count) => return Ok(count),
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::WouldBlock
+                        | std::io::ErrorKind::Interrupted
+                        | std::io::ErrorKind::TimedOut
+                ) =>
+            {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
 /// Default read window for a guest-side flatten (overlay merge + tar of tens
 /// of GiB to the guest disk). The guest stays quiet while tar runs, so the
 /// window must cover the whole tar, not just the mount. Pack size is
@@ -1128,7 +1162,7 @@ impl AgentClient {
 
     /// Connect to the agent socket and configure read/write timeouts (in milliseconds).
     fn connect_with_timeouts_ms(socket_path: &Path, read_ms: u64, write_ms: u64) -> Result<Self> {
-        let stream = UdsStream::connect(socket_path)
+        let stream = UdsStream::connect_timeout(socket_path, Duration::from_millis(read_ms.max(1)))
             .map_err(|e| Error::agent("connect to agent", e.to_string()))?;
 
         stream
@@ -1617,39 +1651,63 @@ impl AgentClient {
     /// may be killed before ext4 journal commits are flushed, causing layer
     /// corruption on next boot.
     pub fn shutdown(&mut self) -> Result<()> {
-        // Set a timeout for shutdown acknowledgment.
-        // The agent calls sync() then sends the ack — typically <100ms,
-        // but heavy writes or large journals may take longer.
-        // If no ack within 5s, the VM has likely already torn down.
-        let _ = self
-            .stream
-            .set_read_timeout(Some(Duration::from_secs(SHUTDOWN_ACK_TIMEOUT_SECS)));
+        self.shutdown_with_deadline(Duration::from_secs(SHUTDOWN_ACK_TIMEOUT_SECS))
+    }
 
-        let data = self.encode_traced(&AgentRequest::Shutdown)?;
-        self.stream
-            .write_all(&data)
-            .map_err(|e| Error::agent("send shutdown", e.to_string()))?;
-
-        // Wait for acknowledgment - this confirms sync() completed.
-        // Returns Ok only when the ack is actually received, so callers
-        // can distinguish "sync confirmed" from "sync unknown".
-        match self.receive() {
-            Ok(_) => {
-                tracing::debug!("agent acknowledged shutdown (sync complete)");
-                Ok(())
+    fn shutdown_with_deadline(&mut self, timeout: Duration) -> Result<()> {
+        let started = Instant::now();
+        let deadline = started + timeout;
+        self.stream.as_socket().set_nonblocking(true)?;
+        let result = (|| -> Result<()> {
+            let data = self.encode_traced(&AgentRequest::Shutdown)?;
+            let mut sent = 0;
+            while sent < data.len() {
+                sent += shutdown_io_until(deadline, || self.stream.write(&data[sent..]))?;
             }
-            Err(e) => {
-                let error_str = e.to_string();
-                if is_benign_shutdown_error(&error_str) {
-                    tracing::debug!(
-                        "shutdown ack not received (connection closed) - sync may have completed"
-                    );
-                } else {
-                    tracing::warn!(error = %e, "shutdown acknowledgment failed");
-                }
-                Err(Error::agent("shutdown ack", error_str))
+            tracing::debug!(
+                send_ms = started.elapsed().as_millis(),
+                "shutdown request sent; waiting for acknowledgment"
+            );
+            let mut header = [0; 4];
+            self.shutdown_read_until(&mut header, deadline)?;
+            let len = u32::from_be_bytes(header) as usize;
+            if len > MAX_FRAME_SIZE as usize {
+                return Err(Error::agent("shutdown ack", "response frame too large"));
+            }
+            let mut body = vec![0; len];
+            self.shutdown_read_until(&mut body, deadline)?;
+            match serde_json::from_slice::<AgentResponse>(&body)
+                .map_err(|error| Error::agent("shutdown ack", error.to_string()))?
+            {
+                AgentResponse::Ok { .. } => Ok(()),
+                _ => Err(Error::agent("shutdown ack", "unexpected acknowledgment")),
+            }
+        })();
+        let reset = self.stream.as_socket().set_nonblocking(false);
+        tracing::debug!(
+            elapsed_ms = started.elapsed().as_millis(),
+            acknowledged = result.is_ok(),
+            "shutdown acknowledgment finished"
+        );
+        if let Err(error) = &result {
+            let _ = self.stream.shutdown(std::net::Shutdown::Both);
+            if is_benign_shutdown_error(&error.to_string()) {
+                tracing::debug!(%error, "shutdown connection closed without acknowledgment");
+            } else {
+                tracing::warn!(%error, "shutdown acknowledgment failed");
             }
         }
+        result?;
+        reset?;
+        Ok(())
+    }
+
+    fn shutdown_read_until(&mut self, buf: &mut [u8], deadline: Instant) -> Result<()> {
+        let mut read = 0;
+        while read < buf.len() {
+            read += shutdown_io_until(deadline, || self.stream.read(&mut buf[read..]))?;
+        }
+        Ok(())
     }
 
     // ========================================================================
@@ -3829,6 +3887,39 @@ mod stalled_body_tests {
     use super::*;
     use std::io::Write;
     use std::time::{Duration, Instant};
+
+    #[test]
+    fn shutdown_deadline_is_not_extended_by_partial_frames() {
+        for slow_header in [true, false] {
+            let (client_stream, mut peer) = UdsStream::pair().unwrap();
+            let server = std::thread::spawn(move || {
+                let mut request = [0; 1024];
+                assert!(peer.read(&mut request).unwrap() > 0);
+                let body = serde_json::to_vec(&AgentResponse::Ok { data: None }).unwrap();
+                let header = (body.len() as u32).to_be_bytes();
+                let bytes = if slow_header {
+                    [header.as_slice(), body.as_slice()].concat()
+                } else {
+                    peer.write_all(&header).unwrap();
+                    body
+                };
+                for byte in bytes {
+                    if peer.write_all(&[byte]).is_err() {
+                        break;
+                    }
+                    std::thread::sleep(Duration::from_millis(30));
+                }
+            });
+            let mut client = AgentClient::from_stream(client_stream);
+            let start = Instant::now();
+            let error = client
+                .shutdown_with_deadline(Duration::from_millis(100))
+                .unwrap_err();
+            assert!(error.to_string().contains("deadline exceeded"), "{error}");
+            assert!(start.elapsed() < Duration::from_millis(500));
+            server.join().unwrap();
+        }
+    }
 
     #[test]
     fn receive_times_out_when_peer_never_starts_a_frame() {

--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -1420,6 +1420,19 @@ fn fork_lineage_memory_limit_bytes(record: &VmRecord, additional_ram_units: u64)
 }
 
 #[cfg(target_os = "linux")]
+fn fork_lineage_memory_budget(
+    record: &VmRecord,
+    additional_ram_units: u64,
+) -> Result<crate::process::VmmMemoryBudget> {
+    let base = crate::process::vmm_memory_budget(record.mem, record.cuda, true);
+    let max_bytes = fork_lineage_memory_limit_bytes(record, additional_ram_units)?;
+    Ok(crate::process::VmmMemoryBudget {
+        high_bytes: max_bytes - (base.max_bytes - base.high_bytes),
+        max_bytes,
+    })
+}
+
+#[cfg(target_os = "linux")]
 fn source_has_private_ram_backing(record: &VmRecord) -> bool {
     record.pid_start_time.is_some() && record.fork_lineage_pid_start_time == record.pid_start_time
 }
@@ -1436,8 +1449,10 @@ fn set_fork_lineage_memory_limit(
     if !crate::process::is_our_process_strict(pid, record.pid_start_time) {
         return Ok(false);
     }
-    let limit = fork_lineage_memory_limit_bytes(record, generations)?;
-    let updated = crate::process::set_managed_vmm_memory_limit(golden, pid, limit)?;
+    let budget = fork_lineage_memory_budget(record, generations)?;
+    let limit = budget.max_bytes;
+    let updated =
+        crate::process::set_managed_vmm_memory_limit(golden, pid, limit, budget.high_bytes)?;
     if updated {
         tracing::debug!(%golden, generations, memory_max_bytes = limit, "sized live-branch lineage cgroup");
     }
@@ -4129,7 +4144,7 @@ mod tests {
         let mut record = VmRecord::new("golden".into(), 2, 1024, vec![], vec![], false);
         assert_eq!(
             fork_lineage_memory_limit_bytes(&record, 2).unwrap(),
-            3840 * 1024 * 1024
+            4864 * 1024 * 1024
         );
 
         record.cuda = true;
@@ -4137,6 +4152,19 @@ mod tests {
             fork_lineage_memory_limit_bytes(&record, 2).unwrap(),
             4864 * 1024 * 1024
         );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn lineage_reclaim_threshold_tracks_growth_and_collection() {
+        let record = VmRecord::new("golden".into(), 2, 1024, vec![], vec![], false);
+        let base = fork_lineage_memory_budget(&record, 0).unwrap();
+        for generations in [1, 2, 8, 32, 8, 2, 0] {
+            let budget = fork_lineage_memory_budget(&record, generations).unwrap();
+            let retained = generations * 1024 * 1024 * 1024;
+            assert_eq!(budget.high_bytes, base.high_bytes + retained);
+            assert_eq!(budget.max_bytes, base.max_bytes + retained);
+        }
     }
 
     #[cfg(target_os = "linux")]

--- a/src/agent/fork.rs
+++ b/src/agent/fork.rs
@@ -1408,7 +1408,7 @@ fn fork_lineage_memory_limit_bytes(record: &VmRecord, additional_ram_units: u64)
     let guest_bytes = u64::from(record.mem)
         .checked_mul(1024 * 1024)
         .ok_or_else(|| Error::agent("fork memory accounting", "guest memory size overflow"))?;
-    crate::process::vmm_memory_limit_bytes(record.mem, record.cuda)
+    crate::process::vmm_memory_limit_bytes(record.mem, record.cuda, true)
         .checked_add(
             additional_ram_units
                 .checked_mul(guest_bytes)

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -2571,11 +2571,14 @@ impl AgentManager {
         #[cfg(target_os = "linux")]
         if std::env::var_os("SMOLVM_VM_USE_SCOPE").is_some() {
             if let Some(name) = self.name() {
+                let budget = crate::process::vmm_memory_budget(
+                    resources_for_config.memory_mib,
+                    config.cuda,
+                    config.forkable,
+                );
                 let caps = crate::systemd_scope::ScopeCaps {
-                    memory_max_bytes: Some(crate::process::vmm_memory_limit_bytes(
-                        resources_for_config.memory_mib,
-                        config.cuda,
-                    )),
+                    memory_max_bytes: Some(budget.max_bytes),
+                    memory_high_bytes: Some(budget.high_bytes),
                     cpu_quota_usec_per_sec: Some(
                         u64::from(resources_for_config.cpus.max(1)) * 1_000_000,
                     ),

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -1807,6 +1807,11 @@ impl AgentManager {
             lock_file
         };
 
+        // The launcher, not the VMM, owns vm.lock. A service restart releases
+        // that lock while its VMM survives. Failed agent reconnect must not
+        // authorize opening the surviving process's disks a second time.
+        self.verify_no_persisted_process()?;
+
         // Check and update state
         {
             let mut inner = self.inner.lock();
@@ -1902,6 +1907,40 @@ impl AgentManager {
         Ok(())
     }
 
+    fn verify_no_persisted_process(&self) -> Result<()> {
+        if let Some((pid, _)) = self.read_pid_file_with_start_time() {
+            refuse_live_launch_pid(pid)?;
+        }
+        // The database can retain identity when a PID file is missing.
+        if let Some(name) = self.name() {
+            if let Some(record) = crate::db::SmolvmDb::open()?.get_vm(name)? {
+                if let Some(pid) = record.pid {
+                    refuse_live_launch_pid(pid)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Preserve process identity and the launch lock unless teardown succeeds.
+    fn abort_failed_launch(&self, pid: i32) -> Result<()> {
+        self.inner.lock().child = Some(ChildProcess::new(pid));
+        let identity = match process::process_start_time(pid) {
+            Some(start) => format!("{pid}\n{start}"),
+            None => pid.to_string(),
+        };
+        if let Err(error) = std::fs::write(&self.pid_file, identity) {
+            tracing::warn!(pid, %error, "could not persist failed launch identity; retaining child handle");
+        }
+        process::stop_vm_process(pid, Duration::ZERO, process::VM_SIGKILL_TIMEOUT)?;
+        if process::is_alive(pid) {
+            return Err(Error::agent("abort launch", "VMM is still alive"));
+        }
+        let _ = std::fs::remove_file(&self.pid_file);
+        self.mark_stopped();
+        Ok(())
+    }
+
     /// Common post-launch bookkeeping: store child PID, write config/PID files,
     /// wait for agent ready.
     ///
@@ -1949,33 +1988,16 @@ impl AgentManager {
                 Ok(())
             }
             Err(e) => {
-                // The _boot-vm child may be stuck inside krun_start_enter()
-                // where SIGTERM alone may not kill it (the VM run loop can
-                // mask signals). Use the full SIGTERM -> wait -> SIGKILL
-                // sequence so the child is reliably dead before we return,
-                // preventing an orphaned process from holding ports/sockets
-                // and making every subsequent start attempt fail permanently.
-                if let Err(kill_err) = process::stop_vm_process(
-                    child_pid,
-                    AGENT_STOP_TIMEOUT,
-                    process::VM_SIGKILL_TIMEOUT,
-                ) {
+                // The _boot-vm child may be stuck inside krun_start_enter().
+                // Terminate it and retain its identity if it cannot be reaped,
+                // so another launch cannot reopen disks it still owns.
+                if let Err(kill_err) = self.abort_failed_launch(child_pid) {
                     tracing::warn!(
                         pid = child_pid,
                         error = %kill_err,
                         "failed to kill _boot-vm child after start failure; \
                          process may be orphaned"
                     );
-                }
-                // Remove the PID file written earlier in this function so a
-                // stale PID doesn't confuse future reconnect attempts.
-                let _ = std::fs::remove_file(&self.pid_file);
-                let mut inner = self.inner.lock();
-                inner.state = AgentState::Stopped;
-                inner.child = None;
-                #[cfg(unix)]
-                {
-                    inner.vm_lock_handle = None;
                 }
                 Err(e)
             }
@@ -2569,8 +2591,7 @@ impl AgentManager {
         // boot subprocess skipped self-placement and the VM is still in serve's
         // cgroup for this microsecond window — the adopt moves it out. Caps mirror
         // process::place_in_cgroup (VMM_MEM_OVERHEAD_MIB=768, CGROUP_PIDS_MAX
-        // =1024) as scope properties. Best-effort: on failure the VM keeps running
-        // (just not restart-safe), same as an uncapped cgroup join.
+        // =1024) as scope properties. Required placement fails closed.
         #[cfg(target_os = "linux")]
         if std::env::var_os("SMOLVM_VM_USE_SCOPE").is_some() {
             if let Some(name) = self.name() {
@@ -2588,14 +2609,10 @@ impl AgentManager {
                     tasks_max: Some(1024),
                 };
                 if let Err(e) = crate::systemd_scope::adopt_into_scope(name, child_pid, &caps) {
-                    // Only reachable when is_available() said yes (root + systemd +
-                    // busctl) but the bus call still failed — effectively a broken
-                    // D-Bus. The VM keeps running but stays in serve's cgroup,
-                    // uncapped and not restart-safe. Loud so the operator notices.
-                    tracing::warn!(
-                        error = %e, pid = child_pid,
-                        "failed to adopt VM into systemd scope; VM left in service cgroup — uncapped and NOT restart-safe"
-                    );
+                    // Terminate only this newly spawned child, never the existing
+                    // same-name scope: it may still own another live process.
+                    self.abort_failed_launch(child_pid)?;
+                    return Err(Error::agent("adopt VM scope", e.to_string()));
                 }
             }
         }
@@ -2688,9 +2705,15 @@ impl AgentManager {
     fn stop_vm_process(&self, pid: crate::process::Pid, start_time: Option<u64>) -> Result<()> {
         // Use short timeout — the agent may already be gone (ephemeral run exited).
         // A 100ms connect timeout avoids blocking the exit path.
-        let shutdown_acked = if let Ok(mut client) =
-            super::AgentClient::connect_with_short_timeout(&self.vsock_socket)
-        {
+        let connect_started = Instant::now();
+        let connection = super::AgentClient::connect_with_short_timeout(&self.vsock_socket);
+        tracing::debug!(
+            pid,
+            connect_ms = connect_started.elapsed().as_millis(),
+            connected = connection.is_ok(),
+            "shutdown agent connect finished"
+        );
+        let shutdown_acked = if let Ok(mut client) = connection {
             client.shutdown().is_ok()
         } else {
             false
@@ -3260,6 +3283,16 @@ impl AgentManager {
     }
 }
 
+fn refuse_live_launch_pid(pid: crate::process::Pid) -> Result<()> {
+    if process::is_alive(pid) {
+        return Err(Error::agent(
+            "start agent",
+            format!("recorded VMM process {pid} is still alive; refusing a second launch on its disks; use machine start to recover an unreachable machine or stop it first"),
+        ));
+    }
+    Ok(())
+}
+
 impl Drop for AgentManager {
     fn drop(&mut self) {
         let inner = self.inner.lock();
@@ -3432,6 +3465,33 @@ mod tests {
     }
 
     use super::*;
+
+    #[test]
+    fn launch_refuses_live_persisted_pid_without_agent_reachability() {
+        let temp = tempfile::tempdir().unwrap();
+        let storage = StorageDisk::open_or_create_at(&temp.path().join("storage.raw"), 1).unwrap();
+        let overlay = OverlayDisk::open_or_create_at(&temp.path().join("overlay.raw"), 1).unwrap();
+        let mut manager = AgentManager::new(temp.path().join("rootfs"), storage, overlay).unwrap();
+        manager.pid_file = temp.path().join("agent.pid");
+        manager.vsock_socket = temp.path().join("missing-agent.sock");
+        #[cfg(unix)]
+        {
+            manager.vm_lock = temp.path().join("vm.lock");
+        }
+        let identity = std::process::id().to_string();
+        std::fs::write(&manager.pid_file, &identity).unwrap();
+        // Fresh manager (Stopped), no responding agent, but a live recorded PID.
+        // This must fail before rootfs validation or disk formatting.
+        let error = manager
+            .prepare_for_launch(&[], &[], VmResources::default())
+            .unwrap_err();
+        assert!(error.to_string().contains("refusing a second launch"));
+        assert_eq!(
+            std::fs::read_to_string(&manager.pid_file).unwrap(),
+            identity
+        );
+        assert_eq!(manager.inner.lock().state, AgentState::Stopped);
+    }
 
     #[test]
     fn reconnecting_to_custom_raw_disks_never_resizes_them() {

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -2115,6 +2115,10 @@ impl AgentManager {
         // multithreaded `serve` process, where concurrent forks would clobber
         // each other (and `set_var` is `unsafe` in edition 2024 for that reason).
         let fork_clone = features.snapshot_dir.is_some();
+        // Either shape backs guest RAM with a memfd — a golden creates one, a
+        // clone maps the golden's copy-on-write — and the kernel charges those
+        // pages to this VM's cgroup as shmem it cannot reclaim without swap.
+        let fork_memfd = features.forkable || fork_clone;
         let cuda_clone = fork_clone && (features.cuda || resources_for_config.cuda);
         let fork_env: Vec<(&str, String)> = {
             let mut v = Vec::new();
@@ -2574,7 +2578,7 @@ impl AgentManager {
                 let budget = crate::process::vmm_memory_budget(
                     resources_for_config.memory_mib,
                     config.cuda,
-                    config.forkable,
+                    fork_memfd,
                 );
                 let caps = crate::systemd_scope::ScopeCaps {
                     memory_max_bytes: Some(budget.max_bytes),

--- a/src/agent/manager.rs
+++ b/src/agent/manager.rs
@@ -2115,9 +2115,8 @@ impl AgentManager {
         // multithreaded `serve` process, where concurrent forks would clobber
         // each other (and `set_var` is `unsafe` in edition 2024 for that reason).
         let fork_clone = features.snapshot_dir.is_some();
-        // Either shape backs guest RAM with a memfd — a golden creates one, a
-        // clone maps the golden's copy-on-write — and the kernel charges those
-        // pages to this VM's cgroup as shmem it cannot reclaim without swap.
+        // Account conservatively for shared backing plus private COW pages.
+        #[cfg(target_os = "linux")]
         let fork_memfd = features.forkable || fork_clone;
         let cuda_clone = fork_clone && (features.cuda || resources_for_config.cuda);
         let fork_env: Vec<(&str, String)> = {

--- a/src/api/handlers/machines.rs
+++ b/src/api/handlers/machines.rs
@@ -2214,6 +2214,13 @@ async fn boot_prepared_fork_inner(
         // Boot from the golden's snapshot instead of cold-booting.
         features.forkable = record.forkable;
         features.snapshot_dir = Some(prep.snapshot_dir);
+        // A nested branch must keep the original lineage's UID, not allocate
+        // a new UID from the immediate parent's snapshot directory.
+        features.uid_share_dir = record
+            .fork_overlay_owner
+            .as_deref()
+            .or(record.golden.as_deref())
+            .map(crate::agent::vm_data_dir);
         features.cuda_share_weights = share_weights;
         features.cuda_preload_modules = record.cuda_preload_modules;
         features.cuda_fork_pool_size = record.cuda_fork_pool_size;

--- a/src/api/supervisor.rs
+++ b/src/api/supervisor.rs
@@ -126,6 +126,13 @@ impl Supervisor {
         // Machine is dead — try to retrieve its exit code via waitpid
         // and persist it so the restart policy can use it.
         if let Ok(Some(record)) = self.state.db().get_vm(name) {
+            // A recovered manager can lack a child handle and its PID file
+            // can be missing while the database still identifies a live VMM.
+            // Do not erase that identity or schedule another launch.
+            if record.is_process_alive() {
+                self.next_restart_at.remove(name);
+                return Ok(());
+            }
             if let Some(pid) = record.pid {
                 let exit_code = crate::process::try_wait(pid);
                 self.state.set_last_exit_code(name, exit_code);
@@ -385,6 +392,43 @@ mod restart_timing_tests {
     use std::collections::HashMap;
     use std::time::Duration;
     use tokio::time::Instant;
+
+    #[tokio::test]
+    async fn live_database_pid_survives_missing_manager_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = crate::db::SmolvmDb::open_at(&dir.path().join("test.db")).unwrap();
+        let state = std::sync::Arc::new(crate::api::state::ApiState::with_db(db));
+        let mut record = crate::config::VmRecord::new(
+            "supervisor-live-pid".into(),
+            1,
+            512,
+            vec![],
+            vec![],
+            false,
+        );
+        record.pid = Some(std::process::id() as i32);
+        record.state = crate::config::RecordState::Running;
+        state
+            .db()
+            .insert_vm("supervisor-live-pid", &record)
+            .unwrap();
+        let (_tx, rx) = tokio::sync::watch::channel(false);
+        let mut supervisor = Supervisor::new(state.clone(), rx);
+        supervisor
+            .next_restart_at
+            .insert("supervisor-live-pid".into(), Instant::now());
+        assert!(!state.is_machine_alive("supervisor-live-pid"));
+        supervisor
+            .check_machine("supervisor-live-pid")
+            .await
+            .unwrap();
+        let kept = state.db().get_vm("supervisor-live-pid").unwrap().unwrap();
+        assert_eq!(kept.pid, record.pid);
+        assert_eq!(kept.state, record.state);
+        assert!(!supervisor
+            .next_restart_at
+            .contains_key("supervisor-live-pid"));
+    }
 
     // A backoff at or below the minimum restarts immediately and schedules nothing.
     #[test]

--- a/src/embedded/control.rs
+++ b/src/embedded/control.rs
@@ -207,7 +207,11 @@ fn launch_from_record(record: &VmRecord, features: LaunchFeatures) -> Result<Sta
     // (re)start — where no snapshot path exists to infer it — can still open
     // the golden's copy-on-write disk backing behind its 0700 data dir.
     if features.uid_share_dir.is_none() {
-        if let Some(ref g) = record.golden {
+        if let Some(g) = record
+            .fork_overlay_owner
+            .as_deref()
+            .or(record.golden.as_deref())
+        {
             features.uid_share_dir = Some(crate::agent::vm_data_dir(g));
         }
     }

--- a/src/internal_boot.rs
+++ b/src/internal_boot.rs
@@ -199,9 +199,9 @@ pub fn run(config_path: PathBuf) -> crate::Result<()> {
             config.resources.cpus,
             config.resources.memory_mib,
             config.cuda,
-            // Forkable VMs back guest RAM with a memfd, charged to this cgroup
-            // as unreclaimable shmem — it needs room beyond the guest size.
-            std::env::var_os("SMOLVM_FORKABLE").is_some(),
+            // Match scope-mode accounting for both sources and restored clones.
+            std::env::var_os("SMOLVM_FORKABLE").is_some()
+                || std::env::var_os("SMOLVM_SNAPSHOT_DIR").is_some(),
         );
     }
 

--- a/src/internal_boot.rs
+++ b/src/internal_boot.rs
@@ -199,6 +199,9 @@ pub fn run(config_path: PathBuf) -> crate::Result<()> {
             config.resources.cpus,
             config.resources.memory_mib,
             config.cuda,
+            // Forkable VMs back guest RAM with a memfd, charged to this cgroup
+            // as unreclaimable shmem — it needs room beyond the guest size.
+            std::env::var_os("SMOLVM_FORKABLE").is_some(),
         );
     }
 

--- a/src/platform/uds.rs
+++ b/src/platform/uds.rs
@@ -33,6 +33,14 @@ impl UdsStream {
         Ok(Self { inner: sock })
     }
 
+    /// Connect with a deadline, including a full listener backlog.
+    pub fn connect_timeout(path: impl AsRef<Path>, timeout: Duration) -> io::Result<Self> {
+        let addr = SockAddr::unix(path.as_ref())?;
+        let sock = Socket::new(Domain::UNIX, Type::STREAM, None)?;
+        sock.connect_timeout(&addr, timeout)?;
+        Ok(Self { inner: sock })
+    }
+
     /// Wrap an already-connected `socket2::Socket` (e.g. one returned by
     /// [`UdsListener::accept`]).
     pub fn from_socket(inner: Socket) -> Self {

--- a/src/portable_checkpoint.rs
+++ b/src/portable_checkpoint.rs
@@ -286,6 +286,46 @@ fn staging_root(options: &CaptureOptions) -> Result<PathBuf> {
     Ok(root)
 }
 
+// SAVE runs in the already-confined VMM, not in the privileged API service.
+// Its output must be inside the machine's writable directory and owned by the
+// same lineage UID. Never grant the VMM access to service-owned pack libraries.
+fn runtime_capture_dir(name: &str, vm: &VmRecord) -> Result<tempfile::TempDir> {
+    let data = crate::agent::vm_data_dir(name);
+    let owner = vm
+        .fork_overlay_owner
+        .as_deref()
+        .or(vm.golden.as_deref())
+        .unwrap_or(name);
+    let owner_data = crate::agent::vm_data_dir(owner);
+    let ids = crate::process::vm_drop_ids(
+        &crate::agent::vm_uid_registry_dir(),
+        &data,
+        None,
+        Some(&owner_data),
+    )
+    .transpose()
+    .map_err(|error| Error::agent("resolve checkpoint uid", error.to_string()))?;
+    runtime_capture_dir_at(&data, ids)
+}
+
+fn runtime_capture_dir_at(data: &Path, ids: Option<(u32, u32)>) -> Result<tempfile::TempDir> {
+    let mut builder = tempfile::Builder::new();
+    builder.prefix("checkpoint-capture-");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        builder.permissions(std::fs::Permissions::from_mode(0o700));
+    }
+    let temporary = builder
+        .tempdir_in(data)
+        .map_err(|error| Error::agent("create runtime checkpoint directory", error.to_string()))?;
+    if let Some((uid, gid)) = ids {
+        crate::process::chown_tree(temporary.path(), uid, gid)
+            .map_err(|error| Error::agent("own runtime checkpoint directory", error.to_string()))?;
+    }
+    Ok(temporary)
+}
+
 fn checkpoint_lib_dir(options: &CaptureOptions) -> Result<PathBuf> {
     options
         .lib_dir
@@ -400,12 +440,14 @@ pub fn capture_to_path(
         .get(name)
         .expect("validated checkpoint source must remain in its loaded config");
     let control = crate::agent::fork::control_socket_path(name);
+    let runtime_capture = runtime_capture_dir(name, vm)?;
+    let runtime_snapshot = runtime_capture.path().join(ASSET_DIR);
     crate::agent::fork::sync_fork_source(name)?;
     let snapshot_dir = staging_dir.join(ASSET_DIR);
     let pause_started = std::time::Instant::now();
     let reply = crate::agent::fork::control_socket_cmd_with_timeout(
         &control,
-        &format!("SAVE {}", snapshot_dir.display()),
+        &format!("SAVE {}", runtime_snapshot.display()),
         std::time::Duration::from_secs(30 * 60),
     )?;
     if !reply.starts_with("OK") {
@@ -422,6 +464,15 @@ pub fn capture_to_path(
     pause.resume()?;
     let source_pause = pause_started.elapsed();
     drop(source_lock);
+
+    // Export after resuming the source. Preserve sparse RAM holes/reflinks;
+    // copying into service staging must not extend the guest's pause.
+    for file in ["checkpoint.bin", "memory.bin", "manifest.bin"] {
+        crate::disk_utils::clone_or_copy_file(
+            &runtime_snapshot.join(file),
+            &snapshot_dir.join(file),
+        )?;
+    }
 
     let assets = crate::pack_export::FromVmAssets {
         mode: PackMode::Vm,
@@ -1782,6 +1833,26 @@ fn consume_with_retained_backing(vm_data_dir: &Path, retain_memory: bool) -> Res
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn runtime_capture_is_private_machine_local_and_removed_on_drop() {
+        let data = tempfile::tempdir().unwrap();
+        let capture = runtime_capture_dir_at(data.path(), None).unwrap();
+        let path = capture.path().to_path_buf();
+        assert_eq!(path.parent(), Some(data.path()));
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+                0o700
+            );
+        }
+        std::fs::create_dir(path.join(ASSET_DIR)).unwrap();
+        std::fs::write(path.join(ASSET_DIR).join("memory.bin"), b"private state").unwrap();
+        drop(capture);
+        assert!(!path.exists());
+    }
 
     #[test]
     fn install_verifies_and_consumes_checkpoint() {

--- a/src/process.rs
+++ b/src/process.rs
@@ -1186,6 +1186,7 @@ pub fn allocate_vm_uid(
     vm_key: &str,
 ) -> std::io::Result<u32> {
     std::fs::create_dir_all(registry_dir)?;
+    let _registry_lock = lock_uid_registry(registry_dir)?;
     let cache = key_dir.join(".vm-uid");
     // Fast path: a cached uid whose marker still belongs to us.
     if let Some(uid) = std::fs::read_to_string(&cache)
@@ -1244,11 +1245,40 @@ pub fn allocate_vm_uid(
 /// shares its golden's uid and never claims its own). Linux-only.
 #[cfg(target_os = "linux")]
 pub fn free_vm_uid(registry_dir: &std::path::Path, key_dir: &std::path::Path) {
+    let Ok(_registry_lock) = lock_uid_registry(registry_dir) else {
+        tracing::warn!("unable to lock UID registry; retaining assignment");
+        return;
+    };
     if let Some(uid) = std::fs::read_to_string(key_dir.join(".vm-uid"))
         .ok()
         .and_then(|s| s.trim().parse::<u32>().ok())
     {
-        let _ = std::fs::remove_file(registry_dir.join(uid.to_string()));
+        if uid_marker_key(registry_dir, uid).as_deref()
+            == key_dir.file_name().and_then(|name| name.to_str())
+        {
+            let _ = std::fs::remove_file(registry_dir.join(uid.to_string()));
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn lock_uid_registry(registry_dir: &std::path::Path) -> std::io::Result<std::fs::File> {
+    use std::os::fd::AsRawFd;
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(registry_dir.join(".allocation.lock"))?;
+    loop {
+        // Hold one transaction across lookup, claim, cache update and release.
+        // O_EXCL alone only makes UIDs unique, not assignments per machine.
+        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) } == 0 {
+            return Ok(file);
+        }
+        let error = std::io::Error::last_os_error();
+        if error.kind() != std::io::ErrorKind::Interrupted {
+            return Err(error);
+        }
     }
 }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -469,14 +469,21 @@ pub fn setup_cgroup_delegation_root() -> Option<std::path::PathBuf> {
 /// Caps applied (best-effort, each independently):
 /// - `cpu.max` = `vcpus * 100ms / 100ms` → bounds CPU to ~`vcpus` cores.
 /// - `pids.max` = [`CGROUP_PIDS_MAX`] → caps host tasks (fork-bomb containment).
-/// - `memory.max` = guest RAM, CUDA mapping allowance, and fixed overhead.
+/// - `memory.high`/`memory.max` = guest RAM, unreclaimable-mapping allowance,
+///   and proportional overhead, with a reclaim stage below the ceiling.
 ///
 /// `root` must be a delegated root with `cpu`/`memory`/`pids` enabled in its
 /// `subtree_control` (see [`setup_cgroup_delegation_root`]); otherwise the limit
 /// files won't exist and the caps silently degrade while the process still runs.
 /// Never blocks boot.
 #[cfg(target_os = "linux")]
-pub fn place_in_cgroup(root: &std::path::Path, vcpus: u8, memory_mib: u32, cuda: bool) {
+pub fn place_in_cgroup(
+    root: &std::path::Path,
+    vcpus: u8,
+    memory_mib: u32,
+    cuda: bool,
+    memfd_backed: bool,
+) {
     let pid = unsafe { libc::getpid() };
     let vm = root.join(format!("vm-{pid}"));
     if let Err(e) = std::fs::create_dir(&vm) {
@@ -495,7 +502,11 @@ pub fn place_in_cgroup(root: &std::path::Path, vcpus: u8, memory_mib: u32, cuda:
         &format!("{quota_us} {CGROUP_CPU_PERIOD_US}"),
     );
     let _ = write_cgroup(&vm, "pids.max", &CGROUP_PIDS_MAX.to_string());
-    let memory_limit_bytes = vmm_memory_limit_bytes(memory_mib, cuda);
+    let budget = vmm_memory_budget(memory_mib, cuda, memfd_backed);
+    let memory_limit_bytes = budget.max_bytes;
+    // high BEFORE max: a reclaim threshold without a ceiling is safe, a ceiling
+    // without a reclaim threshold is what kills VMs.
+    let _ = write_cgroup(&vm, "memory.high", &budget.high_bytes.to_string());
     let _ = write_cgroup(&vm, "memory.max", &memory_limit_bytes.to_string());
 
     // Join the leaf last; from here the caps above govern this process tree.
@@ -510,19 +521,54 @@ pub fn place_in_cgroup(root: &std::path::Path, vcpus: u8, memory_mib: u32, cuda:
     );
 }
 
+/// Host-memory budget for one VMM's cgroup: a reclaim threshold and a hard
+/// ceiling.
+///
+/// cgroup v2 charges anon + page cache + shmem to one counter, so the page
+/// cache the host faults in for a VM's own disks competes with the guest RAM
+/// the customer bought. `memory.max` on its own is a KILL threshold — without a
+/// `memory.high` there is no throttle-and-reclaim stage, so a VM using the RAM
+/// it was sold plus its own page cache walks into the ceiling and is SIGKILLed.
+///
+/// Measured on a 2 GiB machine before this existed: 2.01 GiB shmem (the guest)
+/// plus 701 MiB of reclaimable page cache against a 2.75 GiB cap, having hit
+/// the hard limit 3,849 times — on a host with 657 GiB free.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VmmMemoryBudget {
+    /// `memory.high` — throttle and reclaim here, before anything is killed.
+    pub high_bytes: u64,
+    /// `memory.max` — the hard backstop for a genuine runaway.
+    pub max_bytes: u64,
+}
+
 /// Bound host memory for a VMM while leaving room beyond its configured guest
-/// RAM. CUDA device mappings and forkable memfd-backed guest pages can both be
-/// charged to the VMM cgroup, so CUDA needs room for one additional guest-sized
-/// mapping plus the fixed process overhead. CPU-only VMs retain the tighter
-/// historical guest-plus-overhead cap.
-pub fn vmm_memory_limit_bytes(guest_memory_mib: u32, cuda: bool) -> u64 {
+/// RAM, and leave a reclaim stage below the ceiling.
+///
+/// Overhead scales with the guest rather than being flat: page tables, virtio
+/// rings, virtiofs/virtio-net buffers and the disk page cache all grow with it,
+/// so a fixed allowance is generous at 2 GiB and negligible at 40 GiB.
+///
+/// CUDA device mappings and memfd-backed (forkable) guest RAM are charged to
+/// this cgroup as shmem, which cannot be reclaimed at all without swap — they
+/// need room BEYOND the guest allocation, not inside it. Omitting that for
+/// forkable VMs is why a branchable machine was killed the moment it booted.
+pub fn vmm_memory_budget(guest_memory_mib: u32, cuda: bool, memfd_backed: bool) -> VmmMemoryBudget {
     let guest = u64::from(guest_memory_mib);
-    let limit_mib = if cuda {
-        guest.saturating_mul(2).saturating_add(VMM_MEM_OVERHEAD_MIB)
-    } else {
-        guest.saturating_add(VMM_MEM_OVERHEAD_MIB)
-    };
-    limit_mib.saturating_mul(1024 * 1024)
+    let overhead = VMM_MEM_OVERHEAD_MIB.max(guest / 4);
+    let unreclaimable = if cuda || memfd_backed { guest } else { 0 };
+    let max_mib = guest.saturating_add(unreclaimable).saturating_add(overhead);
+    // Start reclaiming once three quarters of the overhead is in use, keeping
+    // the last quarter as the hard backstop.
+    let high_mib = max_mib.saturating_sub(overhead / 4);
+    VmmMemoryBudget {
+        high_bytes: high_mib.saturating_mul(1024 * 1024),
+        max_bytes: max_mib.saturating_mul(1024 * 1024),
+    }
+}
+
+/// The hard ceiling alone, for callers doing their own arithmetic on it.
+pub fn vmm_memory_limit_bytes(guest_memory_mib: u32, cuda: bool, memfd_backed: bool) -> u64 {
+    vmm_memory_budget(guest_memory_mib, cuda, memfd_backed).max_bytes
 }
 
 #[cfg(target_os = "linux")]
@@ -2952,11 +2998,17 @@ mod tests {
         let pid = unsafe { libc::getpid() };
         let vm = root.path().join(format!("vm-{pid}"));
         std::fs::create_dir(&vm).expect("create fake VM cgroup");
-        for file in ["cpu.max", "pids.max", "memory.max", "cgroup.procs"] {
+        for file in [
+            "cpu.max",
+            "pids.max",
+            "memory.high",
+            "memory.max",
+            "cgroup.procs",
+        ] {
             std::fs::write(vm.join(file), []).expect("create fake cgroup control");
         }
 
-        place_in_cgroup(root.path(), 2, 1024, true);
+        place_in_cgroup(root.path(), 2, 1024, true, false);
 
         assert_eq!(
             std::fs::read_to_string(vm.join("cpu.max")).expect("read boot CPU quota"),
@@ -2968,20 +3020,78 @@ mod tests {
         );
         assert_eq!(
             std::fs::read_to_string(vm.join("memory.max")).expect("read memory limit"),
-            ((2 * 1024_u64 + VMM_MEM_OVERHEAD_MIB) * 1024 * 1024).to_string()
+            vmm_memory_budget(1024, true, false).max_bytes.to_string()
+        );
+        // The reclaim threshold must exist, or page cache growth goes straight
+        // to an OOM kill instead of an eviction.
+        assert_eq!(
+            std::fs::read_to_string(vm.join("memory.high")).expect("read reclaim threshold"),
+            vmm_memory_budget(1024, true, false).high_bytes.to_string()
         );
     }
 
     #[test]
+    fn a_reclaim_threshold_always_sits_below_the_ceiling_and_above_the_guest() {
+        // The bug this encodes: with no memory.high there is no reclaim stage,
+        // so a VM using the RAM it was sold plus its own disk page cache walks
+        // into memory.max and is SIGKILLed. The threshold must also sit ABOVE
+        // the guest allocation, or the guest alone would hold the cgroup in
+        // permanent reclaim.
+        for &mib in &[512_u32, 1024, 2048, 8192, 40960] {
+            for &(cuda, memfd) in &[(false, false), (false, true), (true, false)] {
+                let b = vmm_memory_budget(mib, cuda, memfd);
+                let guest = u64::from(mib) * 1024 * 1024;
+                assert!(
+                    b.high_bytes < b.max_bytes,
+                    "{mib} {cuda} {memfd}: high >= max"
+                );
+                assert!(
+                    b.high_bytes > guest,
+                    "{mib} {cuda} {memfd}: reclaim starts inside guest RAM"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_forkable_vm_gets_room_for_its_unreclaimable_memfd() {
+        // A branchable machine's guest RAM is a memfd, charged as shmem, which
+        // cannot be reclaimed without swap — so it needs room BEYOND the guest
+        // size. Without this a 2 GiB branchable machine was OOM-killed on boot.
+        let plain = vmm_memory_budget(2048, false, false);
+        let forkable = vmm_memory_budget(2048, false, true);
+        assert!(
+            forkable.max_bytes > plain.max_bytes + 1024 * 1024 * 1024,
+            "a forkable VM needs a guest-sized allowance beyond the plain cap"
+        );
+        // and the elastic room above the unreclaimable floor must be real
+        let floor = 2048_u64 * 1024 * 1024 * 2; // guest + its memfd charge
+        assert!(
+            forkable.high_bytes > floor,
+            "no headroom above the shmem floor"
+        );
+    }
+
+    #[test]
+    fn overhead_scales_with_the_guest_instead_of_staying_flat() {
+        // A flat 768 MiB is 37% headroom at 2 GiB and 1.9% at 40 GiB; page
+        // tables, virtio rings and disk page cache all grow with the guest.
+        let small = vmm_memory_budget(2048, false, false).max_bytes - 2048 * 1024 * 1024;
+        let large = vmm_memory_budget(40960, false, false).max_bytes - 40960 * 1024 * 1024;
+        assert!(large > small * 4, "overhead did not scale with guest size");
+    }
+
+    #[test]
     fn cuda_vmm_memory_limit_allows_device_and_memfd_mappings() {
-        assert_eq!(
-            vmm_memory_limit_bytes(8192, true),
-            (2 * 8192_u64 + VMM_MEM_OVERHEAD_MIB) * 1024 * 1024
-        );
-        assert_eq!(
-            vmm_memory_limit_bytes(8192, false),
-            (8192_u64 + VMM_MEM_OVERHEAD_MIB) * 1024 * 1024
-        );
+        // CUDA device mappings are charged to this cgroup, so a CUDA VM needs
+        // room for a second guest-sized mapping. Asserted as a property rather
+        // than a literal: the overhead term is proportional now, so pinning the
+        // exact byte count would just re-encode the formula.
+        let guest = 8192_u64 * 1024 * 1024;
+        let with_cuda = vmm_memory_limit_bytes(8192, true, false);
+        let plain = vmm_memory_limit_bytes(8192, false, false);
+        assert!(with_cuda >= plain + guest, "no room for the device mapping");
+        assert!(plain > guest, "no overhead above the guest allocation");
     }
 
     #[test]

--- a/src/process.rs
+++ b/src/process.rs
@@ -504,8 +504,7 @@ pub fn place_in_cgroup(
     let _ = write_cgroup(&vm, "pids.max", &CGROUP_PIDS_MAX.to_string());
     let budget = vmm_memory_budget(memory_mib, cuda, memfd_backed);
     let memory_limit_bytes = budget.max_bytes;
-    // high BEFORE max: a reclaim threshold without a ceiling is safe, a ceiling
-    // without a reclaim threshold is what kills VMs.
+    // Establish the early throttle/reclaim threshold before the hard ceiling.
     let _ = write_cgroup(&vm, "memory.high", &budget.high_bytes.to_string());
     let _ = write_cgroup(&vm, "memory.max", &memory_limit_bytes.to_string());
 
@@ -526,13 +525,10 @@ pub fn place_in_cgroup(
 ///
 /// cgroup v2 charges anon + page cache + shmem to one counter, so the page
 /// cache the host faults in for a VM's own disks competes with the guest RAM
-/// the customer bought. `memory.max` on its own is a KILL threshold — without a
-/// `memory.high` there is no throttle-and-reclaim stage, so a VM using the RAM
-/// it was sold plus its own page cache walks into the ceiling and is SIGKILLed.
-///
-/// Measured on a 2 GiB machine before this existed: 2.01 GiB shmem (the guest)
-/// plus 701 MiB of reclaimable page cache against a 2.75 GiB cap, having hit
-/// the hard limit 3,849 times — on a host with 657 GiB free.
+/// the customer bought. `memory.max` also attempts reclaim before invoking
+/// OOM; `memory.high` starts throttling and reclaim earlier. Neither threshold
+/// makes resident unswappable shmem reclaimable. A `memory.events` max event
+/// records limit pressure, not an OOM kill.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct VmmMemoryBudget {
     /// `memory.high` — throttle and reclaim here, before anything is killed.
@@ -548,10 +544,10 @@ pub struct VmmMemoryBudget {
 /// rings, virtiofs/virtio-net buffers and the disk page cache all grow with it,
 /// so a fixed allowance is generous at 2 GiB and negligible at 40 GiB.
 ///
-/// CUDA device mappings and memfd-backed (forkable) guest RAM are charged to
-/// this cgroup as shmem, which cannot be reclaimed at all without swap — they
-/// need room BEYOND the guest allocation, not inside it. Omitting that for
-/// forkable VMs is why a branchable machine was killed the moment it booted.
+/// Reserve a conservative extra guest-sized allowance for CUDA or forkable
+/// workloads. A memfd mapping does not itself double physical memory: private
+/// COW pages and retained generations can add charges. The branch lifecycle
+/// accounts for additional retained generations separately.
 pub fn vmm_memory_budget(guest_memory_mib: u32, cuda: bool, memfd_backed: bool) -> VmmMemoryBudget {
     let guest = u64::from(guest_memory_mib);
     let overhead = VMM_MEM_OVERHEAD_MIB.max(guest / 4);
@@ -588,7 +584,7 @@ fn cgroup_v2_process_dir(pid: Pid) -> Option<std::path::PathBuf> {
     Some(std::path::Path::new("/sys/fs/cgroup").join(rel))
 }
 
-/// Update `memory.max` only when `pid` is already inside a cgroup owned by
+/// Update both memory thresholds only when `pid` is already inside a cgroup owned by
 /// SmolVM. Returns `false` for ordinary CLI-launched/externally-capped
 /// processes, whose enclosing cgroup must never be modified by a guest action.
 ///
@@ -601,6 +597,7 @@ pub fn set_managed_vmm_memory_limit(
     machine: &str,
     pid: Pid,
     memory_max_bytes: u64,
+    memory_high_bytes: u64,
 ) -> Result<bool> {
     let Some(dir) = cgroup_v2_process_dir(pid) else {
         return Ok(false);
@@ -610,10 +607,16 @@ pub fn set_managed_vmm_memory_limit(
     };
     let scope = crate::systemd_scope::scope_name(machine);
     if leaf == scope {
-        crate::systemd_scope::set_scope_memory_max(machine, memory_max_bytes)?;
+        crate::systemd_scope::set_scope_memory_max(machine, memory_max_bytes, memory_high_bytes)?;
         return Ok(true);
     }
     if leaf == format!("vm-{pid}") {
+        write_cgroup(&dir, "memory.high", &memory_high_bytes.to_string()).map_err(|error| {
+            Error::agent(
+                "VM cgroup",
+                format!("update {} memory.high: {error}", dir.display()),
+            )
+        })?;
         write_cgroup(&dir, "memory.max", &memory_max_bytes.to_string()).map_err(|error| {
             Error::agent(
                 "VM cgroup",
@@ -634,6 +637,7 @@ pub fn set_managed_vmm_memory_limit(
     _machine: &str,
     _pid: Pid,
     _memory_max_bytes: u64,
+    _memory_high_bytes: u64,
 ) -> Result<bool> {
     Ok(false)
 }
@@ -3022,8 +3026,7 @@ mod tests {
             std::fs::read_to_string(vm.join("memory.max")).expect("read memory limit"),
             vmm_memory_budget(1024, true, false).max_bytes.to_string()
         );
-        // The reclaim threshold must exist, or page cache growth goes straight
-        // to an OOM kill instead of an eviction.
+        // The early reclaim threshold must be installed alongside the hard cap.
         assert_eq!(
             std::fs::read_to_string(vm.join("memory.high")).expect("read reclaim threshold"),
             vmm_memory_budget(1024, true, false).high_bytes.to_string()
@@ -3032,11 +3035,8 @@ mod tests {
 
     #[test]
     fn a_reclaim_threshold_always_sits_below_the_ceiling_and_above_the_guest() {
-        // The bug this encodes: with no memory.high there is no reclaim stage,
-        // so a VM using the RAM it was sold plus its own disk page cache walks
-        // into memory.max and is SIGKILLed. The threshold must also sit ABOVE
-        // the guest allocation, or the guest alone would hold the cgroup in
-        // permanent reclaim.
+        // The early threshold must sit above guest RAM, so the configured
+        // guest allocation alone cannot hold the cgroup in permanent reclaim.
         for &mib in &[512_u32, 1024, 2048, 8192, 40960] {
             for &(cuda, memfd) in &[(false, false), (false, true), (true, false)] {
                 let b = vmm_memory_budget(mib, cuda, memfd);
@@ -3055,17 +3055,16 @@ mod tests {
 
     #[test]
     fn a_forkable_vm_gets_room_for_its_unreclaimable_memfd() {
-        // A branchable machine's guest RAM is a memfd, charged as shmem, which
-        // cannot be reclaimed without swap — so it needs room BEYOND the guest
-        // size. Without this a 2 GiB branchable machine was OOM-killed on boot.
+        // Preserve the conservative allowance for private COW pages in
+        // addition to the original shared backing.
         let plain = vmm_memory_budget(2048, false, false);
         let forkable = vmm_memory_budget(2048, false, true);
         assert!(
             forkable.max_bytes > plain.max_bytes + 1024 * 1024 * 1024,
             "a forkable VM needs a guest-sized allowance beyond the plain cap"
         );
-        // and the elastic room above the unreclaimable floor must be real
-        let floor = 2048_u64 * 1024 * 1024 * 2; // guest + its memfd charge
+        // Keep reclaim headroom above the two-backing allowance.
+        let floor = 2048_u64 * 1024 * 1024 * 2;
         assert!(
             forkable.high_bytes > floor,
             "no headroom above the shmem floor"

--- a/src/systemd_scope.rs
+++ b/src/systemd_scope.rs
@@ -88,6 +88,11 @@ fn busctl_bounded(mut cmd: Command, timeout: Duration) -> Result<Output> {
 pub struct ScopeCaps {
     /// Hard memory ceiling in bytes (`MemoryMax`). `None` = uncapped.
     pub memory_max_bytes: Option<u64>,
+    /// Reclaim threshold in bytes (`MemoryHigh`), set below `MemoryMax` so the
+    /// kernel evicts page cache under pressure instead of jumping straight to
+    /// an OOM kill. `None` = no reclaim stage, which is what made a VM using
+    /// the RAM it was sold die against the ceiling.
+    pub memory_high_bytes: Option<u64>,
     /// CPU quota in microseconds-of-CPU-time per real second
     /// (`CPUQuotaPerSecUSec`). For N vCPUs uncapped-overcommit, pass
     /// `N * 1_000_000`. `None` = uncapped.
@@ -183,6 +188,9 @@ pub fn adopt_into_scope(machine_id: &str, pid: i32, caps: &ScopeCaps) -> Result<
         format!("smolvm VM {machine_id}"),
     ]);
     nprops += 1;
+    if let Some(m) = caps.memory_high_bytes {
+        props.extend(["MemoryHigh".into(), "t".into(), m.to_string()]);
+    }
     if let Some(m) = caps.memory_max_bytes {
         props.extend(["MemoryMax".into(), "t".into(), m.to_string()]);
         nprops += 1;

--- a/src/systemd_scope.rs
+++ b/src/systemd_scope.rs
@@ -89,9 +89,8 @@ pub struct ScopeCaps {
     /// Hard memory ceiling in bytes (`MemoryMax`). `None` = uncapped.
     pub memory_max_bytes: Option<u64>,
     /// Reclaim threshold in bytes (`MemoryHigh`), set below `MemoryMax` so the
-    /// kernel evicts page cache under pressure instead of jumping straight to
-    /// an OOM kill. `None` = no reclaim stage, which is what made a VM using
-    /// the RAM it was sold die against the ceiling.
+    /// kernel starts throttling and reclaim before the hard limit is reached.
+    /// `None` disables this early threshold; `MemoryMax` still attempts reclaim.
     pub memory_high_bytes: Option<u64>,
     /// CPU quota in microseconds-of-CPU-time per real second
     /// (`CPUQuotaPerSecUSec`). For N vCPUs uncapped-overcommit, pass
@@ -173,6 +172,25 @@ pub fn adopt_into_scope(machine_id: &str, pid: i32, caps: &ScopeCaps) -> Result<
     let busctl = busctl_path()
         .ok_or_else(|| Error::agent("vm scope", "busctl not found; cannot create scope"))?;
     let name = scope_name(machine_id);
+    let args = scope_start_args(machine_id, pid, caps);
+    let mut cmd = Command::new(&busctl);
+    cmd.args(&args);
+    let out = busctl_bounded(cmd, BUSCTL_TIMEOUT)?;
+    if !out.status.success() {
+        return Err(Error::agent(
+            "vm scope",
+            format!(
+                "StartTransientUnit {name} failed: {}",
+                String::from_utf8_lossy(&out.stderr).trim()
+            ),
+        ));
+    }
+    tracing::info!(scope = %name, pid, "adopted VM into systemd transient scope");
+    Ok(())
+}
+
+fn scope_start_args(machine_id: &str, pid: i32, caps: &ScopeCaps) -> Vec<String> {
+    let name = scope_name(machine_id);
 
     // Build the a(sv) property list in busctl's positional encoding:
     //   <prop-name> <variant-type> <variant-value...>
@@ -190,6 +208,7 @@ pub fn adopt_into_scope(machine_id: &str, pid: i32, caps: &ScopeCaps) -> Result<
     nprops += 1;
     if let Some(m) = caps.memory_high_bytes {
         props.extend(["MemoryHigh".into(), "t".into(), m.to_string()]);
+        nprops += 1;
     }
     if let Some(m) = caps.memory_max_bytes {
         props.extend(["MemoryMax".into(), "t".into(), m.to_string()]);
@@ -221,29 +240,21 @@ pub fn adopt_into_scope(machine_id: &str, pid: i32, caps: &ScopeCaps) -> Result<
     args.extend(props);
     args.push("0".into()); // empty aux array
 
-    let mut cmd = Command::new(&busctl);
-    cmd.args(&args);
-    let out = busctl_bounded(cmd, BUSCTL_TIMEOUT)?;
-
-    if !out.status.success() {
-        let stderr = String::from_utf8_lossy(&out.stderr);
-        return Err(Error::agent(
-            "vm scope",
-            format!("StartTransientUnit {name} failed: {}", stderr.trim()),
-        ));
-    }
-    tracing::info!(scope = %name, pid, "adopted VM into systemd transient scope");
-    Ok(())
+    args
 }
 
-/// Change the hard memory ceiling of an existing VM scope.
+/// Change the reclaim threshold and hard memory ceiling of an existing VM scope.
 ///
 /// A live branch source retains immutable RAM generations in the same memory
 /// cgroup that originally faulted those pages.  Linux does not migrate those
 /// page charges when a raw-forked guardian moves between cgroups, so the scope
 /// ceiling must grow with the number of retained generations and shrink again
 /// when they are collected.
-pub fn set_scope_memory_max(machine_id: &str, memory_max_bytes: u64) -> Result<()> {
+pub fn set_scope_memory_max(
+    machine_id: &str,
+    memory_max_bytes: u64,
+    memory_high_bytes: u64,
+) -> Result<()> {
     let busctl = busctl_path()
         .ok_or_else(|| Error::agent("vm scope", "busctl not found; cannot update scope"))?;
     let name = scope_name(machine_id);
@@ -260,7 +271,10 @@ pub fn set_scope_memory_max(machine_id: &str, memory_max_bytes: u64) -> Result<(
         "sba(sv)".to_string(),
         name.clone(),
         "true".to_string(),
-        "1".to_string(),
+        "2".to_string(),
+        "MemoryHigh".to_string(),
+        "t".to_string(),
+        memory_high_bytes.to_string(),
         "MemoryMax".to_string(),
         "t".to_string(),
         memory_max_bytes.to_string(),
@@ -340,6 +354,33 @@ pub fn kill_scope(machine_id: &str) -> Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn scope_property_count_matches_every_optional_cap_combination() {
+        for mask in 0..16 {
+            let caps = ScopeCaps {
+                memory_high_bytes: (mask & 1 != 0).then_some(100),
+                memory_max_bytes: (mask & 2 != 0).then_some(200),
+                cpu_quota_usec_per_sec: (mask & 4 != 0).then_some(300),
+                tasks_max: (mask & 8 != 0).then_some(400),
+            };
+            let args = scope_start_args("test", 123, &caps);
+            let declared: usize = args[8].parse().unwrap();
+            let mut cursor = 9;
+            for _ in 0..declared {
+                cursor += match args[cursor + 1].as_str() {
+                    "au" => 3 + args[cursor + 2].parse::<usize>().unwrap(),
+                    "s" | "t" => 3,
+                    other => panic!("unexpected variant {other}"),
+                };
+            }
+            assert_eq!(
+                &args[cursor..],
+                &["0"],
+                "mask {mask}: malformed auxiliary array"
+            );
+        }
+    }
 
     // A wedged busctl (systemd stuck on a dying cgroup) must not pin the thread:
     // the call is bounded and returns promptly, well under the hang it replaces.

--- a/tests/test_api_uid_checkpoint.py
+++ b/tests/test_api_uid_checkpoint.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Run as root against a dedicated local serve with default isolation enabled.
+
+Usage: sudo python3 tests/test_api_uid_checkpoint.py http://127.0.0.1:8080
+Creates uniquely named Ubuntu machines; deletes only those machines afterward.
+The server must run on this host so its VMM credentials and artifact paths can
+be inspected. No host policy or existing service configuration is changed.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import urllib.request
+import uuid
+from pathlib import Path
+
+
+def main():
+    if os.geteuid() != 0:
+        raise SystemExit("run as root to validate the privileged service path")
+    base = sys.argv[1].rstrip("/") + "/api/v1/machines"
+    names = ["uid-qa-" + uuid.uuid4().hex[:12] + suffix
+             for suffix in ("-source", "-child", "-grandchild", "-restore")]
+
+    def call(method, path, payload=None):
+        data = json.dumps(payload or {}).encode() if method == "POST" else None
+        request = urllib.request.Request(base + path, data=data, method=method,
+                                         headers={"Content-Type": "application/json"})
+        with urllib.request.urlopen(request, timeout=300) as response:
+            result = json.load(response)
+        if "exitCode" in result:
+            assert result["exitCode"] == 0, result
+        return result
+
+    def host_uid(name):
+        info = call("GET", "/" + name)
+        status = Path(f'/proc/{info["pid"]}/status').read_text()
+        uid_line = next(line for line in status.splitlines() if line.startswith("Uid:"))
+        ids = list(map(int, uid_line.split()[1:]))
+        assert len(set(ids)) == 1 and ids[0] >= 2_000_000, ids
+        assert "Seccomp:\t2" in status, "seccomp must be enabled"
+        cgroup = Path(f'/proc/{info["pid"]}/cgroup').read_text()
+        assert "smolvm-vm-" in cgroup and ".scope" in cgroup, cgroup
+        return ids[0]
+
+    def marker(name):
+        return call("POST", f"/{name}/exec", {
+            "command": ["sh", "-c", "cat /root/uid-qa /dev/shm/uid-qa"]})["stdout"]
+
+    source, child, grandchild, restored = names
+    try:
+        call("POST", "", {"name": source, "image": "ubuntu:24.04",
+             "network": True, "cpus": 2, "memoryMb": 1024,
+             "storageGb": 4, "overlayGb": 2})
+        call("POST", f"/{source}/start?branchable=true")
+        uid = host_uid(source)
+        call("POST", f"/{source}/exec", {"command": ["sh", "-c",
+             "echo disk >/root/uid-qa; echo ram >/dev/shm/uid-qa"]})
+        expected = marker(source)
+        for parent, target in [(source, child), (child, grandchild)]:
+            call("POST", f"/{parent}/branches", {"name": target, "branchable": True})
+            assert host_uid(target) == uid, "nested branch changed lineage UID"
+            assert marker(target) == expected
+
+        with tempfile.TemporaryDirectory(prefix="smolvm-uid-qa-") as directory:
+            artifact = Path(directory, "state.smolcheckpoint")
+            request = urllib.request.Request(base + f"/{source}/checkpoint", method="POST")
+            with urllib.request.urlopen(request, timeout=300) as response, artifact.open("wb") as output:
+                while block := response.read(1024 * 1024):
+                    output.write(block)
+            assert marker(source) == expected, "source failed to continue after SAVE"
+            call("POST", "", {"name": restored, "from": str(artifact)})
+            call("POST", f"/{restored}/start")
+            assert marker(restored) == expected, "disk or RAM was not restored"
+            call("POST", f"/{restored}/exec", {"command": ["sh", "-c",
+                 "echo changed >/root/uid-qa; echo changed >/dev/shm/uid-qa"]})
+            assert marker(source) == expected, "restore mutated the source"
+        print("PASS: isolated nested branches, checkpoint, restore, and source continuation")
+    finally:
+        for name in reversed(names):
+            try:
+                call("DELETE", f"/{name}?force=true")
+            except urllib.error.HTTPError as error:
+                if error.code != 404:
+                    print(f"cleanup failed for {name}: {error}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/uid_allocation.rs
+++ b/tests/uid_allocation.rs
@@ -1,0 +1,58 @@
+//! UID allocation and shutdown regressions without VMs or root privileges.
+#![cfg(target_os = "linux")]
+
+#[test]
+fn silent_peer_shutdown_is_bounded() {
+    use std::io::Read;
+    use std::time::{Duration, Instant};
+    let temp = tempfile::tempdir().unwrap();
+    let socket = temp.path().join("agent.sock");
+    let listener = std::os::unix::net::UnixListener::bind(&socket).unwrap();
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut data = [0; 1024];
+        assert!(stream.read(&mut data).unwrap() > 0);
+        std::thread::sleep(Duration::from_secs(6));
+    });
+    let start = Instant::now();
+    let mut client = smolvm::agent::AgentClient::connect_with_short_timeout(&socket).unwrap();
+    let result = client.shutdown();
+    let elapsed = start.elapsed();
+    eprintln!("silent-peer connect+shutdown: {elapsed:?}, result={result:?}");
+    server.join().unwrap();
+    assert!(result.is_err());
+    assert!(elapsed < Duration::from_secs(6));
+}
+
+#[test]
+fn concurrent_same_machine_uid_is_stable() {
+    let mut unstable = 0;
+    let rounds = 100;
+    for _ in 0..rounds {
+        let temp = tempfile::tempdir().unwrap();
+        let registry = temp.path().join("uids");
+        let machine = temp.path().join("vms/same-machine");
+        std::fs::create_dir_all(&registry).unwrap();
+        std::fs::create_dir_all(&machine).unwrap();
+        let barrier = std::sync::Barrier::new(16);
+        let assignments = std::thread::scope(|scope| {
+            let jobs: Vec<_> = (0..16)
+                .map(|_| {
+                    scope.spawn(|| {
+                        barrier.wait();
+                        smolvm::process::allocate_vm_uid(&registry, &machine, "same-machine")
+                            .unwrap()
+                    })
+                })
+                .collect();
+            jobs.into_iter()
+                .map(|job| job.join().unwrap())
+                .collect::<std::collections::BTreeSet<_>>()
+        });
+        if assignments.len() != 1 {
+            unstable += 1;
+        }
+    }
+    eprintln!("same-machine UID allocation: {unstable}/{rounds} waves returned multiple UIDs (16 callers/wave)");
+    assert_eq!(unstable, 0, "one machine must receive exactly one UID");
+}


### PR DESCRIPTION
Keep branch memory limits and lineage UIDs consistent, capture confined checkpoints safely, and prevent duplicate VMM launches with stable UID allocation and bounded shutdown.