### PR TITLE
Forget externally deleted machines in the API supervisor

### DIFF
--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -691,6 +691,27 @@ impl ApiState {
             .ok_or_else(|| ApiError::NotFound(format!("machine '{}' not found", name)))
     }
 
+    /// Forget an externally deleted machine without deleting data or stopping
+    /// a process. Caller must hold the machine's lifecycle lock.
+    pub(crate) fn forget_deleted_machine(&self, name: &str) -> crate::Result<bool> {
+        if self.db.get_vm(name)?.is_some() {
+            return Ok(false);
+        }
+        let mut machines = self.machines.write();
+        let entry = machines.get(name).cloned();
+        if let Some(entry) = entry {
+            let Some(entry_guard) = entry.try_lock() else {
+                return Ok(false);
+            };
+            // A detached manager must not stop a surviving or replacement VM
+            // when its final reference is dropped.
+            entry_guard.manager.detach();
+            machines.remove(name);
+            tracing::info!(machine = name, "forgot externally deleted machine");
+        }
+        Ok(true)
+    }
+
     /// Update machine state in database (call after start/stop).
     ///
     /// Returns an error if the database write fails. Callers in API handlers
@@ -1888,6 +1909,58 @@ mod tests {
             state.remove_machine("nope"),
             Err(ApiError::NotFound(_))
         ));
+    }
+
+    #[test]
+    fn externally_deleted_machine_is_forgotten_without_deleting_replacements() {
+        let (_dir, state) = temp_api_state();
+        let name = "external-delete-qa";
+        let record = VmRecord::new(name.into(), 1, 512, vec![], vec![], false);
+        state.db.insert_vm(name, &record).unwrap();
+        state.insert_machine(
+            name,
+            MachineEntry {
+                manager: AgentManager::for_vm(name).unwrap(),
+                mounts: vec![],
+                ports: vec![],
+                resources: ResourceSpec {
+                    cpus: None,
+                    memory_mb: None,
+                    network: None,
+                    gpu: None,
+                    cuda: None,
+                    storage_gb: None,
+                    overlay_gb: None,
+                    block_io: None,
+                    allowed_cidrs: None,
+                    allowed_hosts: None,
+                    network_backend: None,
+                },
+                restart: RestartConfig::default(),
+                network: false,
+                secret_refs: Default::default(),
+                source_smolmachine: None,
+                forkable: false,
+                cuda_fork_pool_size: None,
+                cuda_vram_limit_mib: None,
+                forkpoint_held: false,
+            },
+        );
+        assert!(!state.forget_deleted_machine(name).unwrap());
+        state.db.remove_vm(name).unwrap();
+        let entry = state.get_machine(name).unwrap();
+        let busy = entry.lock();
+        assert!(!state.forget_deleted_machine(name).unwrap());
+        drop(busy);
+        // A same-name replacement in the DB must survive reconciliation.
+        state.db.insert_vm(name, &record).unwrap();
+        assert!(!state.forget_deleted_machine(name).unwrap());
+        assert!(state.db.get_vm(name).unwrap().is_some());
+        state.db.remove_vm(name).unwrap();
+        assert!(state.forget_deleted_machine(name).unwrap());
+        assert!(state.get_machine(name).is_err());
+        assert!(entry.lock().manager.is_detached());
+        assert!(state.forget_deleted_machine(name).unwrap());
     }
 
     // remove_machine must clear BOTH the DB row and the in-memory registry entry

--- a/src/api/supervisor.rs
+++ b/src/api/supervisor.rs
@@ -113,6 +113,18 @@ impl Supervisor {
 
     /// Check a single machine and restart if needed.
     async fn check_machine(&mut self, name: &str) -> crate::Result<()> {
+        {
+            let lifecycle = self.state.lifecycle_lock(name);
+            // An API lifecycle operation may be creating or deleting the row.
+            // Let it finish, without blocking other machines' health checks.
+            let Ok(_guard) = lifecycle.try_lock() else {
+                return Ok(());
+            };
+            if self.state.forget_deleted_machine(name)? {
+                self.next_restart_at.remove(name);
+                return Ok(());
+            }
+        }
         // Check if machine is alive
         let is_alive = self.state.is_machine_alive(name);
 
@@ -385,6 +397,37 @@ mod restart_timing_tests {
     use std::collections::HashMap;
     use std::time::Duration;
     use tokio::time::Instant;
+
+    #[tokio::test]
+    async fn external_delete_clears_registry_and_pending_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = crate::db::SmolvmDb::open_at(&dir.path().join("machines.db")).unwrap();
+        let name = "supervisor-external-delete";
+        db.insert_vm(
+            name,
+            &crate::config::VmRecord::new(name.into(), 1, 512, vec![], vec![], false),
+        )
+        .unwrap();
+        let state = std::sync::Arc::new(crate::api::state::ApiState::with_db(db));
+        state.load_persisted_machines();
+        assert!(state.get_machine(name).is_ok());
+        let (_tx, rx) = tokio::sync::watch::channel(false);
+        let mut supervisor = Supervisor::new(state.clone(), rx);
+        supervisor
+            .next_restart_at
+            .insert(name.into(), Instant::now());
+        state.db().remove_vm(name).unwrap();
+        // In-flight lifecycle work must be left alone until it finishes.
+        let lock = state.lifecycle_lock(name);
+        let guard = lock.lock().await;
+        supervisor.check_machine(name).await.unwrap();
+        assert!(state.get_machine(name).is_ok());
+        drop(guard);
+        supervisor.check_machine(name).await.unwrap();
+        assert!(state.get_machine(name).is_err());
+        assert!(!supervisor.next_restart_at.contains_key(name));
+        supervisor.check_machine(name).await.unwrap();
+    }
 
     // A backoff at or below the minimum restarts immediately and schedules nothing.
     #[test]


### PR DESCRIPTION
Removes stale API registry entries and pending restart timers after machines are deleted through the CLI.